### PR TITLE
docs: platform architecture spec + context kit (CLAUDE.md, PRD snapshot)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# Flowlet
+
+Flowlet is a devtool that lets a company's users customize its product: an embedded agent that acts through the host's own API as the user and renders generated UI in a sandboxed, brand-native surface.
+
+## Read first
+
+- [`docs/PRD.md`](docs/PRD.md) — product intent (Notion is the source of truth; this is a synced snapshot)
+- [`docs/superpowers/specs/2026-07-01-flowlet-platform-architecture-design.md`](docs/superpowers/specs/2026-07-01-flowlet-platform-architecture-design.md) — the locked platform architecture. Build against its seams; if your task conflicts with it, stop and surface the conflict.
+- `docs/superpowers/specs/` — per-epic point-in-time designs
+
+## Standing rules
+
+- No product, architecture, or scope decisions on your own — surface the question and stop.
+- All UI/UX work pauses for Yousef's review: before building it, and again before merging it. Nothing visual ships without him.
+- Open PRs; never merge. Yousef merges.
+- If you're in an Orca-managed worktree, keep its comment updated at meaningful checkpoints (`orca worktree set --worktree active --comment "..."`).
+
+## Shipping
+
+- Always a feature branch or worktree; never commit on main.
+
+## Verification
+
+- Any UI-affecting change is verified in a real browser with screenshots in the PR. Tests and typecheck alone don't count.
+
+## Skills
+
+- Superpowers skills are mandatory: invoke `using-superpowers` at conversation start, then any matching skill when its trigger hits (brainstorming, writing-plans, test-driven-development, systematic-debugging, verification-before-completion, etc.).
+
+## Commands
+
+- `pnpm install` · `pnpm build` · `pnpm test` · `pnpm typecheck` · `pnpm lint` (turbo-cached)
+- `pnpm demo` — run the demo-bank host app (secrets via Infisical)

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,68 @@
+# Flowlet PRD
+
+> Synced snapshot of the [Notion PRD](https://app.notion.com/p/PRD-391efc48a641803c94b8d95930e5ebd7) (2026-07-01). **Notion is the source of truth** — if this file and Notion disagree, Notion wins; re-sync this file when the PRD changes.
+
+**One-Liner:** A devtool that lets your users customize your product.
+
+- One-click dev tool + running on the company's existing API and auth.
+- Allows the user to customize your product in your own brand.
+
+## Core Features
+
+- **One-click dev tool**
+  - Run one command on the host codebase → extracts (1) themes/styles, (2) reusable components, (3) the API/CLI/SDK surface the agent can act through
+  - Never changes existing code, can add code
+  - Output feeds everything below: theming, component registry, tool discovery
+- **Agent acts through the company's existing API, as the user**
+  - Authenticated with the user's own credentials → we sit on their existing security layer, not beside it
+  - Per-user auth threading, not a shared service principal
+- **UI generation**
+  - Any arbitrary UI: agent writes real component code, runs in the locked sandbox (egress-jailed, opaque origin, governed actions)
+  - Stays on-brand: meshes generated code with the company's own components + extracted theme
+  - One output path: everything AI-generated renders in the sandbox
+- **Safeguards + permissions**
+  - Danger-gated actions → approval cards. Bank-grade: the agent can be authenticated to do something and still not allowed to.
+- **Fast generation**
+  - Quick first response + live skeletons while the UI streams in
+- **Integrations via Composio**
+- **Automations**
+  - Describe it in plain English → compiles into the right kind of automation, on a schedule or trigger (time, host events, integration/MCP events)
+  - Two execution tiers, one authoring surface:
+    - Deterministic: trigger → fixed steps. Predictable, cheap, auditable, no LLM per firing. Most "when X do Y" rules land here.
+    - Agentic: a full agent run with a goal + tools → judgment, variable inputs; can do anything the agent does in chat (host API, integrations, generate/update UIs, notify)
+  - Hybrid allowed: deterministic backbone with agent steps where judgment is needed; agents can call workflows as tools
+  - Runs server-side with the user's auth, even when they're not in the app
+  - Manageable + inspectable: see what it compiled to, list, edit, pause, run history
+- **AI memory** → user actions + account history, injected by relevance
+- **Company grounding** → agent grounded in company docs, cites, doesn't hallucinate, resists hijacking
+- **Save what you make**
+  - Generated UIs/dashboards persist, reopenable, part of the product
+
+## What runs where?
+
+- **Local → their app / their infra:**
+  - Shell surfaces (page, overlay, droppable slots) + chat UI → SDK in their frontend
+  - Sandbox → runs in the end-user's browser, egress-jailed; generated code never leaves the device at render time
+  - Theme tokens + component registry → build artifacts in their repo
+  - Host-API actions → run against their API with the user's own credentials, inside their existing security perimeter
+  - One-click dev tool → dev-time CLI on their codebase; extracts locally, then a build-time `flowlet publish` uploads a reviewable tool manifest (versioned + hash-keyed) to the Flowlet registry — sessions bind to a published manifest
+- **Flowlet cloud → ours:**
+  - Agent runtime (LLM loop, tool-calling, policy evaluation). Their backend vouches for user identity, we run the loop. **BYOK later** so companies bring their own model key; the runtime stays ours.
+  - Automations engine → fires when the user isn't in the app; their auth brokered server-side
+  - Memory + saved-flowlet store → cross-device, shareable, survives sessions
+  - Concierge SMS channel + realtime voice relay
+  - Enterprise layer (later) → governance, audit, analytics, cost metering
+- **Third-party regardless:** Composio (integration OAuth + tool execution), model provider
+
+## UX
+
+- Agent center page in the dashboard/sidebar: chat + your created/pinned UIs
+- Droppable components the company places anywhere → tap, create UI in place
+- Realtime voice mode: talk to it, it does/shows things live. No dictation stepping stone.
+- Concierge text channel: reach the agent off-product (SMS/chat), same tools + permissions
+
+## Enterprise readiness (later, after core)
+
+- Admin governance console → what the agent may ever do, per tenant (tools, codegen on/off, approval routing)
+- Audit log + compliance → every action recorded, PII posture
+- Observability + cost → adoption analytics, token spend caps, latency SLOs

--- a/docs/superpowers/specs/2026-07-01-flowlet-platform-architecture-design.md
+++ b/docs/superpowers/specs/2026-07-01-flowlet-platform-architecture-design.md
@@ -1,0 +1,126 @@
+# Flowlet Platform Architecture
+
+**Date:** 2026-07-01
+**Status:** Approved (brainstormed with Yousef)
+**Scope:** North-star architecture for the whole PRD. Each Flowlet Platform epic (ENG-197, 198, 200, 202, 184, 188, 189, 183, 185, 191, 194) implements against the seams defined here.
+**Sources:** Notion PRD (rewritten 2026-07-01), Flowlet Platform Linear project, existing monorepo (F1 to F5 demo phase).
+
+## Summary
+
+Flowlet is built as one portable agent runtime with five injected seams, deployed two ways: Flowlet cloud (the product) and embedded in a host backend (an architectural guarantee, kept honest by demo-bank in CI). Interactive host-API tool calls execute in the user's browser on their existing session. Automations execute server-side under a brokered, short-lived grant. The one-click dev tool emits three artifacts into the host repo; the tool manifest is published to a cloud registry at build time.
+
+## Decisions
+
+### 1. Portable runtime, two deployments
+
+`@flowlet/runtime` (evolving `flowlet-agent`) is a library containing the agent loop: LLM engine, tool calling, policy, UI generation. It never imports a database, queue, or HTTP server. It depends only on five seams:
+
+| Seam | Purpose | Embedded impl | Cloud impl |
+|---|---|---|---|
+| Store | threads, saved flowlets, memory, automations, audit | host's choice (in-memory/SQLite in CI) | our Postgres |
+| CredentialBroker | how a tool call gets user identity | host session, in-process | vouch JWT + token exchange |
+| Executor | where a tool call physically runs | in-process | client executor / server executor |
+| Scheduler | firing automations when the user is away | none or host cron | pg-boss worker |
+| Channels | in-app, SMS, voice transports | in-app only | in-app now; SMS/voice later |
+
+- **Cloud** (`apps/cloud`) is the product: multi-tenant, hosts automations, cross-device store, channels, enterprise layer later.
+- **Embedded** (runtime inside the host's own backend) is an architectural guarantee only: not documented or sold yet. demo-bank runs the runtime in-process, so any cloud concern leaking into the runtime breaks CI. Embedded is BYOK by definition, which keeps the PRD's "BYOK later" cheap.
+
+### 2. Topology: client-executed host-API tools
+
+The SDK in the host frontend streams directly to Flowlet cloud (SSE, ai SDK UIMessage protocol, as in F1). The loop runs in cloud. When the agent calls a host-API tool interactively:
+
+- The tool call streams down to the SDK, which executes fetch against the host API from the user's browser with their existing session (ai SDK client-tool mechanism: onToolCall, addToolResult).
+- User credentials never transit Flowlet cloud. We see only tool results.
+- Composio and other integration tools execute cloud-side as today.
+- Automations (user absent) use the server executor with a brokered grant (Decision 4).
+
+A host-backend server executor can be added later as an opt-in for enterprises that want everything in-perimeter.
+
+### 3. Dev-tool artifact contract
+
+`npx flowlet init` scans the host codebase and emits three artifacts into `.flowlet/` in their repo. It never modifies existing code.
+
+1. `theme.json`: extracted design tokens. Consumed by the sandbox theme injection (exists, F3a).
+2. `components/`: descriptor + wrapper pairs around the host's own components, compiled into the sandbox bundle. Consumed by the registry and renderer (exist, F1/F3b).
+3. `tools.json`: the host API surface (OpenAPI, tRPC, GraphQL, route scan) as tool descriptors with mutating/dangerous annotations, developer-editable. Consumed by the runtime for tool discovery (new, ENG-202). Also declares host event types available as automation triggers.
+
+Delivery is **build-time publish**: `flowlet publish` (locally or CI) uploads the manifest to the cloud registry, keyed by tenant, version, and hash. Sessions bind to a published manifest at init. This gives a central, reviewable tool surface from day 1. Consequences accepted:
+
+- The PRD line "extracts, uploads nothing" is revised to "extracts locally; publishes a reviewable manifest."
+- Embedded mode reads `.flowlet/` from disk; publish is a no-op there.
+- Manifest rows are immutable; a re-publish is a new row. Enterprise approval/diff (ENG-194) becomes a review queue over data we already have.
+
+### 4. Identity and auth
+
+Three credentials, three lifetimes:
+
+1. **Vouch JWT (who is this user):** the host backend adds one endpoint that signs a short-lived JWT (tenant, subject, claims) with a key registered at tenant setup (JWKS or pasted key). The SDK presents it at session init; cloud verifies and issues its own session token. The dev tool can generate this endpoint per framework.
+2. **Interactive host-API calls:** no credential shared at all. The browser executes them on the user's existing session (Decision 2).
+3. **Brokered grant (automations):** the host backend exposes a token-exchange endpoint (RFC 8693 shape). The worker presents a signed assertion (tenant, subject, automation id, scopes) and receives a short-lived scoped user token, held only for the run. Revocation lives on the host side. Only required when a tenant enables automations, so day-1 integration is just the vouch endpoint.
+
+The existing policy layer (F2) evaluates every tool call regardless of executor. Danger-gated actions emit approval cards interactively; automations either pre-authorize scopes at creation or pause for async approval.
+
+### 5. Automations (high level; detail deferred)
+
+Locked now:
+
+- **Two execution tiers, one authoring surface.** Plain English in chat; a compiler agent emits an inspectable spec the user can read, edit, and pause. Hybrid allowed: deterministic backbone with agent-step nodes.
+- **Deterministic tier is an interpreted JSON step graph**, not generated code. Inspectable by construction, can only call registered tools, policy applies per step, no LLM per firing. No server-side codegen sandbox.
+- **Three trigger sources:** cloud scheduler (time), signed webhooks from the host backend (event types declared in the manifest), Composio triggers.
+- **Execution** in the cloud worker under the brokered grant, with run history.
+
+Deliberately open, to be brainstormed at ENG-188 time: storage shape, DSL field design and expression language, spec versioning, run retention.
+
+### 6. Data layer
+
+One Postgres in `apps/cloud`, all access behind the Store seam. Jobs via pg-boss (Postgres-backed queue; no Redis, one database to operate). Core concerns:
+
+- `tenants`, `users`: tenant = host app (keys, Composio ref, settings); users are vouched subjects, unique per (tenant, subject). No PII beyond the vouch claims.
+- `manifests`: immutable published rows with an active pointer per environment.
+- `threads`, `messages`: persisted UIMessage streams (replaces the demo's in-memory route state).
+- `saved_flowlets` (ENG-183): declarative UI tree + bound data query + originating prompt + name/pin. Reopening re-renders the tree and re-runs the query through the normal tool path.
+- `automations`, `automation_runs`: shape deferred (Decision 5).
+- `audit_events`: append-only record of every tool execution, approval, grant exchange, and firing. Written from day 1; ENG-194 becomes UI over it.
+- **Memory (ENG-189): deliberately undefined.** The architecture reserves a Store concern and a context-assembly injection point in the runtime, and assumes memories may be ingested from outside the chat loop (host analytics such as PostHog, account history, events). Schema, write/read policy, and sources are decided when that work starts.
+
+### 7. Package layout
+
+```
+packages/
+  flowlet-core        contracts (exists)
+  flowlet-runtime     NEW: portable loop + five seams (evolves flowlet-agent)
+  flowlet-stage       sandbox (exists)
+  flowlet-components  pre-wired library (exists)
+  flowlet-shell       surfaces (exists)
+  flowlet-react       SDK (exists)
+  flowlet-cli         NEW: init, publish, dev
+apps/
+  cloud               NEW: API service (SSE, sessions, manifest registry, approvals)
+                      + worker (scheduler, webhook ingest, automation execution)
+                      Two entrypoints of one deployable; split only when scale forces it.
+  demo-bank           stays: embedded-mode CI guarantee + e2e host
+```
+
+Stack: Node/TS, Postgres, pg-boss, Railway initially. Anthropic-first via the ai SDK, provider-agnostic as today.
+
+## Sequencing
+
+Dependency-ordered:
+
+1. Land in-flight work: ENG-200 (one-box UI gen), then ENG-201 cleanup.
+2. **Contracts freeze** (short): manifest schema + the five seam interfaces. Unlocks the parallel tracks.
+3. Parallel tracks:
+   - **A. Cloud skeleton (ENG-198):** runtime carve-out, session init/vouch, SSE chat, manifest registry, worker skeleton. The linchpin; other tracks merge onto it.
+   - **B. Dev tool (ENG-197):** extractor first (theme, then tools.json, then component wrapping, in order of extraction difficulty). Needs only the schema; longest-tail work, so it starts earliest. `publish` lands when A's registry exists.
+   - **C. Host-API tools (ENG-202):** descriptors + client executor, built and proven in embedded demo-bank (no cloud needed), then ported onto A's cloud session.
+   - **D. Automations front half (ENG-188):** DSL spec, interpreter, compiler agent as pure library code with in-memory scheduler in tests. Back half (webhook ingest, token exchange, pg-boss) waits on A. Preceded by its own brainstorm (Decision 5).
+   - **E. Brand-native quality (ENG-184):** continuous and independent; never blocks, never blocked.
+4. Then: ENG-183 saved flowlets on the Store; ENG-189 memory (own brainstorm first).
+5. Later: ENG-185 voice and ENG-191 SMS on the Channels seam; ENG-194 enterprise (audit log already accumulating).
+
+## Follow-ups
+
+- Revise the PRD's "uploads nothing" line to match Decision 3.
+- Sync these decisions into the Linear epics (ENG-197, 198, 202, 188 descriptions).
+- ENG-188 and ENG-189 each get their own brainstorm before implementation.


### PR DESCRIPTION
## Summary
- North-star platform architecture spec (`docs/superpowers/specs/2026-07-01-flowlet-platform-architecture-design.md`): portable runtime + five seams, two deployments, topology B (client-executed host tools), build-time manifest publish, identity model, data layer, and dependency-ordered parallel sequencing. Memory (ENG-189) and automations detail (ENG-188) deliberately left open.
- Context kit for spawned sessions: root `CLAUDE.md` (links + standing rules, timeless only) and `docs/PRD.md` (synced Notion snapshot).

Docs-only, no code changes.

https://claude.ai/code/session_01ESmeacrjtfTXCsCkZ9rivy