### PR TITLE
Contracts freeze: manifest schema + five runtime seams

### DIFF
--- a/docs/contracts/manifest.md
+++ b/docs/contracts/manifest.md
@@ -4,6 +4,12 @@ The dev tool (`npx flowlet init`, ENG-197) emits three artifacts into `.flowlet/
 
 Source of truth: zod schemas in `packages/flowlet-core/src/manifest/`. Language-neutral JSON Schema artifacts are generated into `packages/flowlet-core/schemas/` (`pnpm --filter @flowlet/core generate:schemas`; a test fails CI if they drift).
 
+Validation semantics (zod and AJV agree, parity-tested):
+
+- All manifest objects are **strict**: unknown keys are rejected on both sides, never silently stripped.
+- `events` is optional in the `tools.json` file; zod parse normalizes it to `[]`. JSON Schema `default` is annotation-only, so raw-JSON consumers must treat a missing `events` as empty.
+- Nested JSON Schema documents (`inputSchema`, `payloadSchema`, `propsSchema`) are opaque to the contract; the registry validates them against the JSON Schema meta-schema at publish time (ENG-197/198).
+
 ## theme.json
 
 Extracted host design tokens, fully resolved primitives only (the sandbox has no host CSS vars or fonts). Identical in shape to `BrandTokens` v1 in `@flowlet/components`; a conformance test keeps them in sync.
@@ -64,7 +70,7 @@ Required on every tool — a tool with unknown safety cannot be published.
 
 ### Bindings
 
-`binding` says how a call physically reaches the host API. Only `http` is frozen now (method + `{param}` path template, filled from the tool input by name). The discriminated union on `type` is the extension point for trpc/graphql extractors.
+`binding` says how a call physically reaches the host API. Only `http` is frozen now (method + `{param}` path template, filled from the tool input by name). Paths must be host-relative — a single leading `/`, no scheme, no `//authority`, no whitespace — so a manifest can never point a client executor at a foreign origin. The discriminated union on `type` is the extension point for trpc/graphql extractors.
 
 ### Host events
 

--- a/docs/contracts/manifest.md
+++ b/docs/contracts/manifest.md
@@ -1,0 +1,75 @@
+# Manifest contract
+
+The dev tool (`npx flowlet init`, ENG-197) emits three artifacts into `.flowlet/` in the host repo (architecture Decision 3). `flowlet publish` assembles and uploads them as one immutable manifest to the cloud registry; sessions bind to a published manifest at init. Embedded mode reads `.flowlet/` from disk; publish is a no-op.
+
+Source of truth: zod schemas in `packages/flowlet-core/src/manifest/`. Language-neutral JSON Schema artifacts are generated into `packages/flowlet-core/schemas/` (`pnpm --filter @flowlet/core generate:schemas`; a test fails CI if they drift).
+
+## theme.json
+
+Extracted host design tokens, fully resolved primitives only (the sandbox has no host CSS vars or fonts). Identical in shape to `BrandTokens` v1 in `@flowlet/components`; a conformance test keeps them in sync.
+
+```json
+{
+  "version": 1,
+  "accent": "#0A7CFF",
+  "background": "#FFFFFF",
+  "surface": "#F5F7FA",
+  "text": "#111418",
+  "mutedText": "#5B6470",
+  "fontFamily": "system-ui, sans-serif",
+  "radius": 8,
+  "mode": "light"
+}
+```
+
+## components/
+
+Descriptor + wrapper pairs around the host's own components, compiled into the sandbox bundle. The published manifest carries only the serialized descriptors (`ManifestComponent`): `name`, `description` (drives LLM selection), `propsSchema` as JSON Schema. The compiled bundle travels alongside the manifest, referenced by the registry row, not embedded in it.
+
+## tools.json
+
+The host API surface as tool descriptors, plus host event types available as automation triggers. Developer-editable after extraction; validated on publish.
+
+```json
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "cancelInvoice",
+      "description": "Cancel an open invoice.",
+      "inputSchema": { "type": "object", "properties": { "id": { "type": "string" } } },
+      "annotations": { "mutating": true, "dangerous": true, "idempotent": true },
+      "binding": { "type": "http", "method": "POST", "path": "/api/invoices/{id}/cancel" }
+    }
+  ],
+  "events": [
+    {
+      "name": "invoice.paid",
+      "description": "An invoice was paid in full.",
+      "payloadSchema": { "type": "object", "properties": { "invoiceId": { "type": "string" } } }
+    }
+  ]
+}
+```
+
+### Annotations
+
+Required on every tool — a tool with unknown safety cannot be published.
+
+| Field | Meaning | MCP hint mapping |
+|---|---|---|
+| `mutating` | writes host state | `readOnlyHint = !mutating` |
+| `dangerous` | danger-gated: approval card interactively; pre-authorized scopes or async approval in automations | `destructiveHint = dangerous` |
+| `idempotent` (optional) | repeat calls with same input are safe | `idempotentHint = idempotent` |
+
+### Bindings
+
+`binding` says how a call physically reaches the host API. Only `http` is frozen now (method + `{param}` path template, filled from the tool input by name). The discriminated union on `type` is the extension point for trpc/graphql extractors.
+
+### Host events
+
+Dot-namespaced names (`invoice.paid`). Delivered at runtime as signed webhooks from the host backend to the cloud worker (in-process for embedded). Consumed by the automations compiler as trigger choices.
+
+## Published manifest and binding
+
+`FlowletManifest` = `{ schemaVersion, theme, tools, events, components }`. Registry rows are immutable — a re-publish is a new row, keyed by tenant + version + content hash (`ManifestRef`), with an active pointer per environment. Sessions carry a `ManifestRef`, never a mutable manifest. Enterprise approval/diff (ENG-194) is a review queue over these rows.

--- a/docs/contracts/seams.md
+++ b/docs/contracts/seams.md
@@ -1,0 +1,35 @@
+# Runtime seam contracts
+
+The portable runtime (architecture Decision 1) never imports a database, queue, or HTTP server — it depends on five injected seams. Interfaces live in `packages/flowlet-core/src/seams/`; demo-bank's in-process implementations keep the embedded guarantee honest in CI.
+
+| Seam | Purpose | Embedded impl | Cloud impl |
+|---|---|---|---|
+| `Store` | threads, saved flowlets, automations, audit | host's choice (in-memory/SQLite in CI) | Postgres in apps/cloud |
+| `CredentialBroker` | how a tool call gets user identity | host session, in-process | vouch JWT + RFC 8693 token exchange |
+| `Executor` | where a tool call physically runs | in-process | client executor (browser) / server executor (worker) |
+| `Scheduler` | firing automations when the user is away | none or host cron | pg-boss worker |
+| `Channels` | reaching the user off-thread | in-app only | in-app now; SMS/voice later |
+
+Everything is scoped by `Principal` (`tenantId` + `subject` + vouch claims). Timestamps are ISO 8601 strings.
+
+## Store
+
+Aggregates one sub-store per concern: `threads` (persisted `FlowletUIMessage` streams), `flowlets` (saved UI tree + bound tool query + originating prompt), `automations` (records + run history), `audit` (append-only `AuditEvent` union: tool execution, approval, grant exchange, firing — written from day 1, ENG-194 is UI over it).
+
+Deferred on purpose: the automation `spec` field is `unknown` until ENG-188 freezes the DSL; memory (ENG-189) has no member yet — adding one later is additive.
+
+## CredentialBroker
+
+Two operations for the two credential lifetimes it owns: `authenticate(credential)` turns the SDK-presented credential into a verified `Principal` at session init; `acquireGrant(request)` exchanges a signed assertion for a short-lived scoped token for one automation run. Interactive host-API calls need nothing from this seam — the browser executes them on the user's existing session (Decision 2).
+
+## Executor
+
+`execute(call, context) → { result } | { error }` — one outcome per call, non-streaming. Policy has already evaluated the call before any executor sees it. `context.grant` is present only on server-executed automation runs.
+
+## Scheduler
+
+Time-based triggers only (`cron` / `at`); the runtime registers one firing handler. Host webhooks and Composio triggers are ingest paths that invoke the same handler directly — they don't pass through the Scheduler.
+
+## Channels
+
+Message-shaped `deliver` for `in-app` and `sms`. Realtime voice is a session, not a message — it gets its own contract at ENG-185 time.

--- a/docs/contracts/seams.md
+++ b/docs/contracts/seams.md
@@ -14,7 +14,7 @@ Everything is scoped by `Principal` (`tenantId` + `subject` + vouch claims). Tim
 
 ## Store
 
-Aggregates one sub-store per concern: `threads` (persisted `FlowletUIMessage` streams), `flowlets` (saved UI tree + bound tool query + originating prompt), `automations` (records + run history), `audit` (append-only `AuditEvent` union: tool execution, approval, grant exchange, firing — written from day 1, ENG-194 is UI over it).
+Aggregates one sub-store per concern: `threads` (persisted `FlowletUIMessage` streams), `flowlets` (saved UI tree + bound tool query + originating prompt), `automations` (records + run history), `audit` (append-only `AuditEvent` union: tool execution, approval, grant exchange, firing — written from day 1, ENG-194 is UI over it). The store owns identity and timestamps: `create`/`save` callers never supply `id`, `createdAt`, or `updatedAt`.
 
 Deferred on purpose: the automation `spec` field is `unknown` until ENG-188 freezes the DSL; memory (ENG-189) has no member yet — adding one later is additive.
 
@@ -24,11 +24,11 @@ Two operations for the two credential lifetimes it owns: `authenticate(credentia
 
 ## Executor
 
-`execute(call, context) → { result } | { error }` — one outcome per call, non-streaming. Policy has already evaluated the call before any executor sees it. `context.grant` is present only on server-executed automation runs.
+`execute(call, context) → { ok: true, result } | { ok: false, error }` — one outcome per call, non-streaming, discriminated on `ok` (so a legitimate `undefined` result never mis-narrows as an error). Policy has already evaluated the call before any executor sees it. `context.grant` is present only on server-executed automation runs.
 
 ## Scheduler
 
-Time-based triggers only (`cron` / `at`); the runtime registers one firing handler. Host webhooks and Composio triggers are ingest paths that invoke the same handler directly — they don't pass through the Scheduler.
+Time-based triggers only (`cron` / `at`); the runtime registers one firing handler. `schedule` takes the `Principal` scope, which the scheduler persists and replays on every `AutomationFiring` — the handler needs it to load the record (Store is Principal-scoped) and acquire the brokered grant. Host webhooks and Composio triggers are ingest paths that invoke the same handler directly — they don't pass through the Scheduler.
 
 ## Channels
 

--- a/docs/superpowers/plans/2026-07-01-contracts-freeze.md
+++ b/docs/superpowers/plans/2026-07-01-contracts-freeze.md
@@ -1,0 +1,1272 @@
+# Contracts Freeze Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Freeze the two contract surfaces the parallel platform tracks build against — the `.flowlet/` manifest schema (theme.json, components, tools.json + host events) and the five runtime seam interfaces (Store, CredentialBroker, Executor, Scheduler, Channels) — as additive TypeScript + JSON Schema + docs in `@flowlet/core`, gated on Yousef's mid-flight review of an open-questions doc.
+
+**Architecture:** Everything lands additively in `packages/flowlet-core` (the contracts package per the platform architecture spec, Decision 7): a new `src/manifest/` module (zod schemas, mirroring the existing `BrandTokens` and descriptor shapes so current artifacts already conform) and a new `src/seams/` module (documented interfaces only, embedded-vs-cloud mapping captured in TSDoc). JSON Schema artifacts are generated from the zod schemas into `packages/flowlet-core/schemas/` and kept in sync by a test. Reconciliation with the existing hand-written artifacts is proven by tests in `flowlet-components` (which already depends on core — no cycle). NO changes to `flowlet-agent` (ENG-202 owns it), no refactors, no runtime carve-out.
+
+**Tech Stack:** TypeScript, zod 3 (already a core dep), `zod-to-json-schema` + `ajv` (new devDeps in core), vitest.
+
+**Process gate (binding):** After Task 10 (open-questions doc), set the worktree comment to "questions ready" and PAUSE. Do NOT finalize contracts or open the PR until answers come back through the orchestrator. Tasks 11+ run only after the review.
+
+---
+
+### Task 0: Branch rename + baseline check
+
+The orchestrator mandated branch `yousef/contracts-freeze`; the worktree is on `yousefh409/contracts-freeze`.
+
+**Files:** none
+
+- [ ] **Step 1: Rename the branch in place**
+
+```bash
+git branch -m yousefh409/contracts-freeze yousef/contracts-freeze
+```
+
+- [ ] **Step 2: Confirm the workspace builds/tests clean before touching anything**
+
+Run: `pnpm typecheck && pnpm test`
+Expected: both pass (turbo-cached). If they fail on main's code, STOP and report — don't fix unrelated breakage.
+
+---
+
+### Task 1: Manifest theme schema (`theme.json`)
+
+Structurally identical to `brandTokensSchema` in `packages/flowlet-components/src/theme/brand.ts` so every existing theme artifact conforms. Duplication (not import) is deliberate: components→core dependency already exists, so core cannot import components; a reconciliation test (Task 6) prevents drift. Folding `brand.ts` onto this schema is a later, non-additive session.
+
+**Files:**
+- Create: `packages/flowlet-core/src/manifest/theme.ts`
+- Test: `packages/flowlet-core/src/manifest/theme.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/flowlet-core/src/manifest/theme.test.ts
+import { describe, expect, it } from "vitest";
+import { manifestThemeSchema } from "./theme";
+
+const valid = {
+  version: 1,
+  accent: "#0A7CFF",
+  background: "#FFFFFF",
+  surface: "#F5F7FA",
+  text: "#111418",
+  mutedText: "#5B6470",
+  fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
+  radius: 8,
+  mode: "light",
+};
+
+describe("manifestThemeSchema", () => {
+  it("accepts a fully resolved v1 theme", () => {
+    expect(manifestThemeSchema.parse(valid)).toEqual(valid);
+  });
+
+  it("accepts px-string radius and omitted mode", () => {
+    const { mode: _mode, ...rest } = valid;
+    expect(() => manifestThemeSchema.parse({ ...rest, radius: "8.5px" })).not.toThrow();
+  });
+
+  it("rejects non-hex colors (no var()/url() references)", () => {
+    expect(() => manifestThemeSchema.parse({ ...valid, accent: "var(--accent)" })).toThrow();
+  });
+
+  it("rejects unknown versions", () => {
+    expect(() => manifestThemeSchema.parse({ ...valid, version: 2 })).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @flowlet/core test -- theme.test`
+Expected: FAIL — cannot resolve `./theme`
+
+- [ ] **Step 3: Write the schema**
+
+```ts
+// packages/flowlet-core/src/manifest/theme.ts
+import { z } from "zod";
+
+/** A literal hex color (#rgb / #rgba / #rrggbb / #rrggbbaa). No var()/url() references. */
+const hexColor = z
+  .string()
+  .regex(/^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/);
+
+/**
+ * `theme.json` — extracted host design tokens (dev-tool artifact 1 of 3,
+ * architecture Decision 3). Fully resolved primitives only: the sandbox has no
+ * host CSS vars or loaded fonts.
+ *
+ * Structurally identical to `BrandTokens` v1 in `@flowlet/components`
+ * (`src/theme/brand.ts`), which is the consuming side of this contract; a
+ * reconciliation test there keeps the two in sync until they are folded together.
+ */
+export const manifestThemeSchema = z.object({
+  version: z.literal(1),
+  accent: hexColor,
+  background: hexColor,
+  surface: hexColor,
+  text: hexColor,
+  mutedText: hexColor,
+  fontFamily: z.string().min(1),
+  radius: z.union([z.number().nonnegative(), z.string().regex(/^\d+(\.\d+)?px$/)]),
+  mode: z.enum(["light", "dark"]).optional(),
+});
+
+export type ManifestTheme = z.infer<typeof manifestThemeSchema>;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @flowlet/core test -- theme.test`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/flowlet-core/src/manifest/theme.ts packages/flowlet-core/src/manifest/theme.test.ts
+git commit -m "feat(core): manifest theme schema (theme.json contract)"
+```
+
+---
+
+### Task 2: Tool descriptors + annotations + bindings (`tools.json` tools)
+
+The spec (Decision 3) requires "mutating/dangerous annotations". Draft position (open question Q3): Flowlet-native **required** booleans `{ mutating, dangerous }` — policy needs definite values, so no optional "hints" — with the MCP mapping (`readOnlyHint = !mutating`, `destructiveHint = dangerous`) documented for ingestion into `flowlet-agent`'s `ToolDescriptor`. Named `ManifestTool*` to avoid colliding with names ENG-202 may export.
+
+**Files:**
+- Create: `packages/flowlet-core/src/manifest/tool.ts`
+- Test: `packages/flowlet-core/src/manifest/tool.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/flowlet-core/src/manifest/tool.test.ts
+import { describe, expect, it } from "vitest";
+import { manifestToolSchema } from "./tool";
+
+const listInvoices = {
+  name: "listInvoices",
+  description: "List the user's invoices, newest first.",
+  inputSchema: { type: "object", properties: { limit: { type: "number" } } },
+  annotations: { mutating: false, dangerous: false },
+  binding: { type: "http", method: "GET", path: "/api/invoices" },
+};
+
+describe("manifestToolSchema", () => {
+  it("accepts a read-only http tool", () => {
+    expect(() => manifestToolSchema.parse(listInvoices)).not.toThrow();
+  });
+
+  it("accepts a mutating+dangerous tool with a templated path", () => {
+    expect(() =>
+      manifestToolSchema.parse({
+        ...listInvoices,
+        name: "cancelInvoice",
+        annotations: { mutating: true, dangerous: true, idempotent: true },
+        binding: { type: "http", method: "POST", path: "/api/invoices/{id}/cancel" },
+      }),
+    ).not.toThrow();
+  });
+
+  it("requires annotations — no unsound defaults", () => {
+    const { annotations: _a, ...rest } = listInvoices;
+    expect(() => manifestToolSchema.parse(rest)).toThrow();
+  });
+
+  it("rejects unknown binding types and bad names", () => {
+    expect(() =>
+      manifestToolSchema.parse({ ...listInvoices, binding: { type: "grpc" } }),
+    ).toThrow();
+    expect(() => manifestToolSchema.parse({ ...listInvoices, name: "1bad name" })).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @flowlet/core test -- tool.test`
+Expected: FAIL — cannot resolve `./tool` (note: `src/tool.test.ts` doesn't exist today, only `src/tool.ts`; the new test is `src/manifest/tool.test.ts`, disambiguated by path)
+
+- [ ] **Step 3: Write the schema**
+
+```ts
+// packages/flowlet-core/src/manifest/tool.ts
+import { z } from "zod";
+
+/**
+ * A JSON Schema document, kept opaque. Tool inputs and event payloads are
+ * declared as JSON Schema in the manifest (the wire format); zod is the
+ * in-process representation and the ai SDK converts at the model boundary.
+ */
+export const jsonSchemaDocument = z.record(z.unknown());
+export type JsonSchemaDocument = Record<string, unknown>;
+
+/**
+ * Safety annotations, REQUIRED on every manifest tool (architecture Decision 3).
+ * Policy reads definite values — a tool with unknown safety cannot be published.
+ *
+ * MCP mapping (for ingestion into runtime tool descriptors):
+ * `readOnlyHint = !mutating`, `destructiveHint = dangerous`,
+ * `idempotentHint = idempotent`.
+ */
+export const manifestToolAnnotationsSchema = z.object({
+  /** Writes host state. `false` = safe to call freely (read-only). */
+  mutating: z.boolean(),
+  /** Danger-gated: policy emits an approval card (interactive) or requires
+   *  pre-authorized scopes / async approval (automations). */
+  dangerous: z.boolean(),
+  /** Optional: repeat calls with the same input are safe. */
+  idempotent: z.boolean().optional(),
+});
+export type ManifestToolAnnotations = z.infer<typeof manifestToolAnnotationsSchema>;
+
+/**
+ * How a tool call physically reaches the host API. `http` is the only binding
+ * frozen now; the discriminated union is the extension point (trpc, graphql —
+ * ENG-197 extractor targets). Path segments in `{braces}` are template
+ * parameters filled from the tool input by name.
+ */
+export const httpBindingSchema = z.object({
+  type: z.literal("http"),
+  method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]),
+  /** Host-relative path template, e.g. `/api/invoices/{id}/cancel`. */
+  path: z.string().min(1),
+});
+export const manifestToolBindingSchema = z.discriminatedUnion("type", [httpBindingSchema]);
+export type ManifestToolBinding = z.infer<typeof manifestToolBindingSchema>;
+
+/**
+ * One entry in `tools.json` (dev-tool artifact 3 of 3, architecture Decision 3):
+ * a host-API surface exposed to the agent as a tool. Developer-editable;
+ * `flowlet publish` validates against this schema before upload.
+ */
+export const manifestToolSchema = z.object({
+  /** Tool-call identifier presented to the model. */
+  name: z.string().regex(/^[a-zA-Z][a-zA-Z0-9_-]*$/),
+  /** Drives LLM tool selection — same role as component descriptions. */
+  description: z.string().min(1),
+  /** JSON Schema for the tool input. */
+  inputSchema: jsonSchemaDocument,
+  annotations: manifestToolAnnotationsSchema,
+  binding: manifestToolBindingSchema,
+});
+export type ManifestTool = z.infer<typeof manifestToolSchema>;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @flowlet/core test -- tool.test`
+Expected: PASS (4 tests). The pre-existing `src/tool.test.ts` may also run — it must still pass untouched.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/flowlet-core/src/manifest/tool.ts packages/flowlet-core/src/manifest/tool.test.ts
+git commit -m "feat(core): manifest tool schema with mutating/dangerous annotations and http binding"
+```
+
+---
+
+### Task 3: Host event declarations (automation triggers)
+
+Decision 3: tools.json "also declares host event types available as automation triggers"; Decision 5: signed webhooks from the host backend carry these events.
+
+**Files:**
+- Create: `packages/flowlet-core/src/manifest/event.ts`
+- Test: `packages/flowlet-core/src/manifest/event.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/flowlet-core/src/manifest/event.test.ts
+import { describe, expect, it } from "vitest";
+import { hostEventSchema } from "./event";
+
+describe("hostEventSchema", () => {
+  it("accepts a namespaced event with a payload schema", () => {
+    expect(() =>
+      hostEventSchema.parse({
+        name: "invoice.paid",
+        description: "An invoice was paid in full.",
+        payloadSchema: { type: "object", properties: { invoiceId: { type: "string" } } },
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts an event without a payload schema", () => {
+    expect(() =>
+      hostEventSchema.parse({ name: "user.deactivated", description: "Account deactivated." }),
+    ).not.toThrow();
+  });
+
+  it("rejects un-namespaced or malformed names", () => {
+    expect(() => hostEventSchema.parse({ name: "paid", description: "x" })).toThrow();
+    expect(() => hostEventSchema.parse({ name: "Invoice.Paid!", description: "x" })).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @flowlet/core test -- event.test`
+Expected: FAIL — cannot resolve `./event`
+
+- [ ] **Step 3: Write the schema**
+
+```ts
+// packages/flowlet-core/src/manifest/event.ts
+import { z } from "zod";
+import { jsonSchemaDocument } from "./tool";
+
+/**
+ * A host event type declared in `tools.json`, available as an automation
+ * trigger (architecture Decisions 3 & 5). At runtime the host backend delivers
+ * instances as signed webhooks to the cloud worker; embedded hosts may invoke
+ * the ingest path in-process. Names are dot-namespaced, lower_snake segments:
+ * `invoice.paid`, `user.plan_changed`.
+ */
+export const hostEventSchema = z.object({
+  name: z.string().regex(/^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$/),
+  /** Drives trigger selection when the compiler agent builds an automation. */
+  description: z.string().min(1),
+  /** JSON Schema for the event payload; omitted = opaque payload. */
+  payloadSchema: jsonSchemaDocument.optional(),
+});
+export type HostEventDeclaration = z.infer<typeof hostEventSchema>;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @flowlet/core test -- event.test`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/flowlet-core/src/manifest/event.ts packages/flowlet-core/src/manifest/event.test.ts
+git commit -m "feat(core): host event declarations for automation triggers"
+```
+
+---
+
+### Task 4: Component entries + file-level and published manifest shapes
+
+`components/` in `.flowlet/` is code (descriptor + wrapper pairs); what the *published manifest* carries is the serialized descriptor: `{name, description, propsSchema-as-JSON-Schema}` — the JSON image of the existing `PrewiredDescriptor`/`RegisteredComponent`. Also freezes: `toolsManifestSchema` (the tools.json *file*: version + tools + events), `flowletManifestSchema` (the published unit), and `ManifestRef` (what a session binds to).
+
+**Files:**
+- Create: `packages/flowlet-core/src/manifest/component.ts`
+- Create: `packages/flowlet-core/src/manifest/manifest.ts`
+- Create: `packages/flowlet-core/src/manifest/index.ts`
+- Test: `packages/flowlet-core/src/manifest/manifest.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/flowlet-core/src/manifest/manifest.test.ts
+import { describe, expect, it } from "vitest";
+import { manifestComponentSchema } from "./component";
+import { flowletManifestSchema, toolsManifestSchema } from "./manifest";
+
+const theme = {
+  version: 1,
+  accent: "#0A7CFF",
+  background: "#FFFFFF",
+  surface: "#F5F7FA",
+  text: "#111418",
+  mutedText: "#5B6470",
+  fontFamily: "system-ui, sans-serif",
+  radius: 8,
+};
+const tool = {
+  name: "listInvoices",
+  description: "List invoices.",
+  inputSchema: { type: "object" },
+  annotations: { mutating: false, dangerous: false },
+  binding: { type: "http", method: "GET", path: "/api/invoices" },
+};
+const component = {
+  name: "InvoiceCard",
+  description: "The host's invoice summary card.",
+  propsSchema: { type: "object", properties: { invoiceId: { type: "string" } } },
+};
+
+describe("manifestComponentSchema", () => {
+  it("accepts a serialized descriptor", () => {
+    expect(() => manifestComponentSchema.parse(component)).not.toThrow();
+  });
+});
+
+describe("toolsManifestSchema (tools.json file)", () => {
+  it("accepts tools + events, defaulting events to []", () => {
+    const parsed = toolsManifestSchema.parse({ version: 1, tools: [tool] });
+    expect(parsed.events).toEqual([]);
+  });
+});
+
+describe("flowletManifestSchema (published unit)", () => {
+  it("accepts a complete manifest", () => {
+    expect(() =>
+      flowletManifestSchema.parse({
+        schemaVersion: 1,
+        theme,
+        tools: [tool],
+        events: [],
+        components: [component],
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects a manifest missing the theme", () => {
+    expect(() =>
+      flowletManifestSchema.parse({ schemaVersion: 1, tools: [], events: [], components: [] }),
+    ).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @flowlet/core test -- manifest.test`
+Expected: FAIL — cannot resolve `./component` / `./manifest`
+
+- [ ] **Step 3: Write the schemas**
+
+```ts
+// packages/flowlet-core/src/manifest/component.ts
+import { z } from "zod";
+import { jsonSchemaDocument } from "./tool";
+
+/**
+ * The published image of one entry in `.flowlet/components/` (dev-tool artifact
+ * 2 of 3). On disk each entry is a descriptor + wrapper pair compiled into the
+ * sandbox bundle; the published manifest carries only the descriptor, with the
+ * props schema serialized to JSON Schema. This is the JSON form of
+ * `RegisteredComponent` / `PrewiredDescriptor` (name, description, propsSchema).
+ */
+export const manifestComponentSchema = z.object({
+  name: z.string().min(1),
+  /** Drives LLM component selection — same field as `RegisteredComponent.description`. */
+  description: z.string().min(1),
+  /** JSON Schema for the component props (zod-serialized at publish time). */
+  propsSchema: jsonSchemaDocument,
+});
+export type ManifestComponent = z.infer<typeof manifestComponentSchema>;
+```
+
+```ts
+// packages/flowlet-core/src/manifest/manifest.ts
+import { z } from "zod";
+import { manifestThemeSchema } from "./theme";
+import { manifestToolSchema } from "./tool";
+import { hostEventSchema } from "./event";
+import { manifestComponentSchema } from "./component";
+
+/**
+ * The `tools.json` FILE as it sits in `.flowlet/` in the host repo:
+ * host-API tool descriptors plus declared host event types (Decision 3).
+ * Developer-editable after extraction.
+ */
+export const toolsManifestSchema = z.object({
+  version: z.literal(1),
+  tools: z.array(manifestToolSchema),
+  events: z.array(hostEventSchema).default([]),
+});
+export type ToolsManifest = z.infer<typeof toolsManifestSchema>;
+
+/**
+ * The published manifest — the immutable unit `flowlet publish` uploads to the
+ * cloud registry and a session binds to at init (Decision 3). Assembled from
+ * the three `.flowlet/` artifacts; the sandbox component bundle travels
+ * alongside, referenced by the registry row, not embedded here.
+ *
+ * Embedded mode reads the same shape directly from `.flowlet/` on disk;
+ * publish is a no-op there.
+ */
+export const flowletManifestSchema = z.object({
+  schemaVersion: z.literal(1),
+  theme: manifestThemeSchema,
+  tools: z.array(manifestToolSchema),
+  events: z.array(hostEventSchema),
+  components: z.array(manifestComponentSchema),
+});
+export type FlowletManifest = z.infer<typeof flowletManifestSchema>;
+
+/**
+ * Registry identity of a published manifest. Rows are immutable — a re-publish
+ * is a new row with an active pointer per environment (Decision 3/6). Sessions
+ * carry a ManifestRef, never a mutable manifest.
+ */
+export interface ManifestRef {
+  tenantId: string;
+  /** Publisher-supplied version label (e.g. git sha or semver). */
+  version: string;
+  /** Content hash of the published manifest, assigned by the registry. */
+  hash: string;
+}
+```
+
+```ts
+// packages/flowlet-core/src/manifest/index.ts
+export * from "./theme";
+export * from "./tool";
+export * from "./event";
+export * from "./component";
+export * from "./manifest";
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @flowlet/core test -- manifest.test`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/flowlet-core/src/manifest/component.ts packages/flowlet-core/src/manifest/manifest.ts packages/flowlet-core/src/manifest/index.ts packages/flowlet-core/src/manifest/manifest.test.ts
+git commit -m "feat(core): component entries, tools.json file shape, published manifest + ManifestRef"
+```
+
+---
+
+### Task 5: JSON Schema artifacts, generated and sync-tested
+
+Committed JSON Schema files are the language-neutral contract the dev tool (ENG-197) and registry (ENG-198) validate against. Generated from zod (single source of truth); a test regenerates and diffs, so drift fails CI. `ajv` proves the emitted schemas actually validate.
+
+**Files:**
+- Create: `packages/flowlet-core/scripts/generate-schemas.ts`
+- Create: `packages/flowlet-core/schemas/theme.schema.json` (generated)
+- Create: `packages/flowlet-core/schemas/tools.schema.json` (generated)
+- Create: `packages/flowlet-core/schemas/manifest.schema.json` (generated)
+- Test: `packages/flowlet-core/src/manifest/schemas.test.ts`
+- Modify: `packages/flowlet-core/package.json` (add devDeps `zod-to-json-schema`, `ajv`, `tsx`; add `generate:schemas` script)
+
+- [ ] **Step 1: Add devDependencies and script**
+
+In `packages/flowlet-core/package.json`, add to `"scripts"`:
+
+```json
+"generate:schemas": "tsx scripts/generate-schemas.ts"
+```
+
+and to `"devDependencies"`:
+
+```json
+"ajv": "^8.17.0",
+"tsx": "^4.19.0",
+"zod-to-json-schema": "^3.24.0"
+```
+
+Run: `pnpm install`
+Expected: lockfile updated, no peer warnings from these three.
+
+- [ ] **Step 2: Write the failing sync test**
+
+```ts
+// packages/flowlet-core/src/manifest/schemas.test.ts
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Ajv } from "ajv";
+import { describe, expect, it } from "vitest";
+import { generatedSchemas } from "../../scripts/generate-schemas";
+
+const schemasDir = join(__dirname, "..", "..", "schemas");
+
+describe("committed JSON Schema artifacts", () => {
+  for (const [file, schema] of Object.entries(generatedSchemas)) {
+    it(`${file} is in sync with the zod source (run pnpm generate:schemas)`, () => {
+      const committed = JSON.parse(readFileSync(join(schemasDir, file), "utf8"));
+      expect(committed).toEqual(schema);
+    });
+
+    it(`${file} compiles under ajv and validates a known artifact`, () => {
+      const ajv = new Ajv({ strict: false });
+      expect(() => ajv.compile(schema)).not.toThrow();
+    });
+  }
+
+  it("theme.schema.json accepts the flowlet-components default brand shape", () => {
+    const ajv = new Ajv({ strict: false });
+    const validate = ajv.compile(
+      JSON.parse(readFileSync(join(schemasDir, "theme.schema.json"), "utf8")),
+    );
+    expect(
+      validate({
+        version: 1,
+        accent: "#0A7CFF",
+        background: "#FFFFFF",
+        surface: "#F5F7FA",
+        text: "#111418",
+        mutedText: "#5B6470",
+        fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
+        radius: 8,
+        mode: "light",
+      }),
+    ).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm --filter @flowlet/core test -- schemas.test`
+Expected: FAIL — cannot resolve `../../scripts/generate-schemas`
+
+- [ ] **Step 4: Write the generator**
+
+```ts
+// packages/flowlet-core/scripts/generate-schemas.ts
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { manifestThemeSchema } from "../src/manifest/theme";
+import { toolsManifestSchema, flowletManifestSchema } from "../src/manifest/manifest";
+
+const opts = { target: "jsonSchema7" as const, $refStrategy: "none" as const };
+
+/** file name -> JSON Schema document. Imported by the sync test; run as a script to write. */
+export const generatedSchemas: Record<string, Record<string, unknown>> = {
+  "theme.schema.json": zodToJsonSchema(manifestThemeSchema, opts) as Record<string, unknown>,
+  "tools.schema.json": zodToJsonSchema(toolsManifestSchema, opts) as Record<string, unknown>,
+  "manifest.schema.json": zodToJsonSchema(flowletManifestSchema, opts) as Record<string, unknown>,
+};
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const outDir = join(dirname(fileURLToPath(import.meta.url)), "..", "schemas");
+  mkdirSync(outDir, { recursive: true });
+  for (const [file, schema] of Object.entries(generatedSchemas)) {
+    writeFileSync(join(outDir, file), JSON.stringify(schema, null, 2) + "\n");
+    console.log(`wrote schemas/${file}`);
+  }
+}
+```
+
+- [ ] **Step 5: Generate the artifacts, then run the test**
+
+Run: `pnpm --filter @flowlet/core generate:schemas && pnpm --filter @flowlet/core test -- schemas.test`
+Expected: three `wrote schemas/...` lines, then PASS (7 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/flowlet-core/scripts/generate-schemas.ts packages/flowlet-core/schemas packages/flowlet-core/src/manifest/schemas.test.ts packages/flowlet-core/package.json pnpm-lock.yaml
+git commit -m "feat(core): committed JSON Schema artifacts generated from zod, sync-tested"
+```
+
+---
+
+### Task 6: Reconciliation tests in flowlet-components (additive test file only)
+
+Proves "current code is already near-conformant": the real `defaultBrand` parses under the core manifest theme schema, and every prewired descriptor serializes into a valid `ManifestComponent`. Lives in flowlet-components because components→core is the existing dependency direction. Touches no production files.
+
+**Files:**
+- Test: `packages/flowlet-components/src/manifest-conformance.test.ts`
+- Modify: `packages/flowlet-components/package.json` (devDep `zod-to-json-schema`)
+
+- [ ] **Step 1: Add devDependency**
+
+In `packages/flowlet-components/package.json` devDependencies add `"zod-to-json-schema": "^3.24.0"`, then run `pnpm install`.
+
+- [ ] **Step 2: Write the test (fails only if contracts diverge — that's the point)**
+
+```ts
+// packages/flowlet-components/src/manifest-conformance.test.ts
+import { describe, expect, it } from "vitest";
+import { manifestThemeSchema, manifestComponentSchema } from "@flowlet/core";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { defaultBrand, brandTokensSchema } from "./theme/brand";
+import { descriptors } from "./descriptors";
+
+describe("existing artifacts conform to the frozen manifest contracts", () => {
+  it("defaultBrand is a valid manifest theme", () => {
+    expect(() => manifestThemeSchema.parse(defaultBrand)).not.toThrow();
+  });
+
+  it("brandTokensSchema and manifestThemeSchema agree on shape", () => {
+    // Same generated JSON Schema = structurally identical contracts.
+    expect(zodToJsonSchema(brandTokensSchema, { $refStrategy: "none" })).toEqual(
+      zodToJsonSchema(manifestThemeSchema, { $refStrategy: "none" }),
+    );
+  });
+
+  it("every prewired descriptor serializes to a valid ManifestComponent", () => {
+    for (const d of descriptors) {
+      const entry = {
+        name: d.name,
+        description: d.description,
+        propsSchema: zodToJsonSchema(d.propsSchema, { $refStrategy: "none" }) as Record<
+          string,
+          unknown
+        >,
+      };
+      expect(() => manifestComponentSchema.parse(entry), d.name).not.toThrow();
+    }
+  });
+});
+```
+
+- [ ] **Step 3: Build core so components resolves the new exports, then run**
+
+Note: this test needs Task 8's core index export to be in place if `@flowlet/core` resolves via `dist`. If it fails on missing exports, do Task 8 Step 1 first, rebuild core, and return here.
+
+Run: `pnpm --filter @flowlet/core build && pnpm --filter @flowlet/components test -- manifest-conformance`
+Expected: PASS (3 tests)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/flowlet-components/src/manifest-conformance.test.ts packages/flowlet-components/package.json pnpm-lock.yaml
+git commit -m "test(components): existing brand + descriptors conform to frozen manifest contracts"
+```
+
+---
+
+### Task 7: The five seam interfaces
+
+Interfaces + TSDoc only; the embedded/cloud mapping from architecture Decision 1's table goes verbatim into each seam's doc comment. A single stub-implementation test proves the shapes are implementable in-memory (the embedded/CI guarantee in miniature). No runtime code, no carve-out.
+
+**Files:**
+- Create: `packages/flowlet-core/src/seams/principal.ts`
+- Create: `packages/flowlet-core/src/seams/store.ts`
+- Create: `packages/flowlet-core/src/seams/credential-broker.ts`
+- Create: `packages/flowlet-core/src/seams/executor.ts`
+- Create: `packages/flowlet-core/src/seams/scheduler.ts`
+- Create: `packages/flowlet-core/src/seams/channels.ts`
+- Create: `packages/flowlet-core/src/seams/index.ts`
+- Test: `packages/flowlet-core/src/seams/seams.test.ts`
+
+- [ ] **Step 1: Write the failing stub test**
+
+```ts
+// packages/flowlet-core/src/seams/seams.test.ts
+import { describe, expect, it } from "vitest";
+import type { CredentialBroker } from "./credential-broker";
+import type { Executor } from "./executor";
+import type { Principal } from "./principal";
+import type { Scheduler } from "./scheduler";
+import type { Channels } from "./channels";
+import type { Store, ThreadStore, SavedFlowletStore, AutomationStore, AuditLog } from "./store";
+
+const principal: Principal = { tenantId: "t1", subject: "u1" };
+
+// Minimal in-memory implementations: the embedded/CI guarantee in miniature.
+// If these can't be written without a database or HTTP server, the seam is wrong.
+function makeStore(): Store {
+  const threads: ThreadStore = {
+    create: async (scope, init) => ({
+      id: "th1",
+      tenantId: scope.tenantId,
+      subject: scope.subject,
+      title: init?.title,
+      createdAt: "2026-07-01T00:00:00Z",
+      updatedAt: "2026-07-01T00:00:00Z",
+    }),
+    get: async () => undefined,
+    list: async () => [],
+    appendMessages: async () => {},
+    getMessages: async () => [],
+  };
+  const flowlets: SavedFlowletStore = {
+    save: async (scope, f) => ({ ...f, id: "f1" }),
+    get: async () => undefined,
+    list: async () => [],
+    delete: async () => {},
+  };
+  const automations: AutomationStore = {
+    save: async (scope, a) => ({ ...a, id: "a1" }),
+    get: async () => undefined,
+    list: async () => [],
+    recordRun: async () => {},
+    listRuns: async () => [],
+  };
+  const audit: AuditLog = { append: async () => {} };
+  return { threads, flowlets, automations, audit };
+}
+
+describe("seam interfaces are implementable in-memory", () => {
+  it("Store", async () => {
+    const store = makeStore();
+    const t = await store.threads.create(principal, { title: "hi" });
+    expect(t.tenantId).toBe("t1");
+  });
+
+  it("CredentialBroker", async () => {
+    const broker: CredentialBroker = {
+      authenticate: async () => principal,
+      acquireGrant: async (req) => ({
+        token: "grant",
+        expiresAt: "2026-07-01T00:05:00Z",
+        scopes: req.scopes,
+      }),
+    };
+    expect((await broker.authenticate("host-session")).subject).toBe("u1");
+    expect(
+      (await broker.acquireGrant({ principal, automationId: "a1", scopes: ["invoices:read"] }))
+        .scopes,
+    ).toEqual(["invoices:read"]);
+  });
+
+  it("Executor", async () => {
+    const executor: Executor = {
+      execute: async (call) => ({ result: { echoed: call.input } }),
+    };
+    const out = await executor.execute(
+      { toolCallId: "c1", toolName: "listInvoices", input: { limit: 1 } },
+      { principal },
+    );
+    expect("result" in out).toBe(true);
+  });
+
+  it("Scheduler", async () => {
+    const fired: string[] = [];
+    let handler: ((f: { automationId: string; firedAt: string }) => Promise<void>) | undefined;
+    const scheduler: Scheduler = {
+      schedule: async (id) => {
+        await handler?.({ automationId: id, firedAt: "2026-07-01T00:00:00Z" });
+      },
+      cancel: async () => {},
+      onFire: (h) => {
+        handler = h;
+      },
+    };
+    scheduler.onFire(async (f) => {
+      fired.push(f.automationId);
+    });
+    await scheduler.schedule("a1", { kind: "cron", expression: "0 9 * * *" });
+    expect(fired).toEqual(["a1"]);
+  });
+
+  it("Channels", async () => {
+    const sent: string[] = [];
+    const channels: Channels = {
+      deliver: async (msg) => {
+        sent.push(msg.channel);
+      },
+    };
+    await channels.deliver({ channel: "in-app", principal, text: "done" });
+    expect(sent).toEqual(["in-app"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @flowlet/core test -- seams.test`
+Expected: FAIL — cannot resolve `./principal` etc.
+
+- [ ] **Step 3: Write the interfaces**
+
+```ts
+// packages/flowlet-core/src/seams/principal.ts
+/**
+ * The verified identity every seam operation is scoped to.
+ * - Embedded: derived in-process from the host session (tenant is implicit;
+ *   embedded hosts may use a fixed tenantId).
+ * - Cloud: derived from the vouch JWT at session init (Decision 4); users are
+ *   unique per (tenant, subject), no PII beyond the vouch claims.
+ */
+export interface Principal {
+  tenantId: string;
+  /** The host's stable user identifier (the vouch `sub`). */
+  subject: string;
+  /** Vouch claims passed through verbatim (roles, plan, etc.). */
+  claims?: Record<string, unknown>;
+}
+```
+
+```ts
+// packages/flowlet-core/src/seams/store.ts
+import type { FlowletUIMessage } from "../protocol";
+import type { UINode } from "../ui";
+import type { Principal } from "./principal";
+
+/**
+ * Store seam — threads, saved flowlets, automations, audit (Decision 1/6).
+ *
+ * | Deployment | Implementation |
+ * |---|---|
+ * | Embedded | host's choice; in-memory or SQLite in CI (demo-bank) |
+ * | Cloud | Postgres in apps/cloud, all access behind this seam |
+ *
+ * All operations are scoped by Principal (tenant + subject); embedded
+ * implementations may ignore tenantId. Timestamps are ISO 8601 strings.
+ *
+ * Memory (ENG-189) is deliberately NOT here yet: the architecture reserves a
+ * Store concern and a context-assembly injection point, defined when that work
+ * starts. Adding a `memory` member later is an additive change to this seam.
+ */
+export interface Store {
+  threads: ThreadStore;
+  flowlets: SavedFlowletStore;
+  automations: AutomationStore;
+  audit: AuditLog;
+}
+
+export interface ThreadRecord {
+  id: string;
+  tenantId: string;
+  subject: string;
+  title?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Persisted UIMessage streams (replaces the demo's in-memory route state). */
+export interface ThreadStore {
+  create(scope: Principal, init?: { title?: string }): Promise<ThreadRecord>;
+  get(scope: Principal, threadId: string): Promise<ThreadRecord | undefined>;
+  list(scope: Principal): Promise<ThreadRecord[]>;
+  appendMessages(scope: Principal, threadId: string, messages: FlowletUIMessage[]): Promise<void>;
+  getMessages(scope: Principal, threadId: string): Promise<FlowletUIMessage[]>;
+}
+
+/**
+ * A saved flowlet (ENG-183, Decision 6): declarative UI tree + bound data
+ * query + originating prompt. Reopening re-renders the tree and re-runs the
+ * query through the normal tool path (policy applies).
+ */
+export interface SavedFlowlet {
+  id: string;
+  name: string;
+  pinned: boolean;
+  uiTree: UINode;
+  /** Re-executed via the Executor on reopen — never a raw DB query. */
+  query: { toolName: string; input: unknown };
+  originatingPrompt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SavedFlowletStore {
+  save(scope: Principal, flowlet: Omit<SavedFlowlet, "id">): Promise<SavedFlowlet>;
+  get(scope: Principal, id: string): Promise<SavedFlowlet | undefined>;
+  list(scope: Principal): Promise<SavedFlowlet[]>;
+  delete(scope: Principal, id: string): Promise<void>;
+}
+
+/**
+ * Automation records. The spec DSL is deliberately opaque here (`spec:
+ * unknown`) — its shape is decided at ENG-188's brainstorm (Decision 5). This
+ * store freezes only what every design needs: identity, lifecycle, run history.
+ */
+export interface AutomationRecord {
+  id: string;
+  name: string;
+  status: "enabled" | "paused";
+  /** The compiled automation spec — interpreted JSON step graph or agent goal.
+   *  Opaque until ENG-188 freezes the DSL. */
+  spec: unknown;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AutomationRun {
+  id: string;
+  automationId: string;
+  startedAt: string;
+  finishedAt?: string;
+  status: "running" | "succeeded" | "failed";
+  error?: string;
+}
+
+export interface AutomationStore {
+  save(scope: Principal, automation: Omit<AutomationRecord, "id">): Promise<AutomationRecord>;
+  get(scope: Principal, id: string): Promise<AutomationRecord | undefined>;
+  list(scope: Principal): Promise<AutomationRecord[]>;
+  recordRun(scope: Principal, run: AutomationRun): Promise<void>;
+  listRuns(scope: Principal, automationId: string): Promise<AutomationRun[]>;
+}
+
+/**
+ * Append-only audit record of every tool execution, approval, grant exchange,
+ * and automation firing (Decision 6). Written from day 1; ENG-194 is UI over it.
+ */
+export type AuditEvent = { at: string; principal: Principal } & (
+  | {
+      kind: "tool_execution";
+      toolName: string;
+      toolCallId: string;
+      mutating: boolean;
+      dangerous: boolean;
+      outcome: "ok" | "error";
+    }
+  | { kind: "approval"; toolCallId: string; decision: "approved" | "denied" }
+  | { kind: "grant_exchange"; automationId: string; scopes: string[] }
+  | { kind: "automation_firing"; automationId: string; runId: string }
+);
+
+export interface AuditLog {
+  append(event: AuditEvent): Promise<void>;
+}
+```
+
+```ts
+// packages/flowlet-core/src/seams/credential-broker.ts
+import type { Principal } from "./principal";
+
+/**
+ * CredentialBroker seam — how a tool call gets user identity (Decisions 1/4).
+ *
+ * | Deployment | Implementation |
+ * |---|---|
+ * | Embedded | host session, in-process; `authenticate` is a pass-through, `acquireGrant` returns the ambient identity |
+ * | Cloud | vouch JWT verification at session init + RFC 8693-shaped token exchange for automations |
+ *
+ * Interactive host-API calls need NO credential from this seam at all — the
+ * browser executes them on the user's existing session (Decision 2). The
+ * broker covers the other two credential lifetimes: session identity and the
+ * short-lived brokered grant automations run under.
+ */
+export interface CredentialBroker {
+  /**
+   * Turn the SDK-presented credential into a verified Principal at session
+   * init. Cloud: the vouch JWT string. Embedded: whatever the host passes
+   * in-process (opaque here).
+   */
+  authenticate(credential: unknown): Promise<Principal>;
+
+  /**
+   * Exchange a signed assertion for a short-lived scoped user token, held only
+   * for one automation run. Revocation lives on the host side. Only required
+   * once a tenant enables automations.
+   */
+  acquireGrant(request: GrantRequest): Promise<BrokeredGrant>;
+}
+
+export interface GrantRequest {
+  principal: Principal;
+  automationId: string;
+  /** Scopes pre-authorized at automation creation (Decision 4). */
+  scopes: string[];
+}
+
+export interface BrokeredGrant {
+  /** Bearer token for host-API calls during this run. Never persisted. */
+  token: string;
+  /** ISO 8601 expiry; the run must not outlive it without re-exchange. */
+  expiresAt: string;
+  scopes: string[];
+}
+```
+
+```ts
+// packages/flowlet-core/src/seams/executor.ts
+import type { BrokeredGrant } from "./credential-broker";
+import type { Principal } from "./principal";
+
+/**
+ * Executor seam — where a tool call physically runs (Decisions 1/2).
+ *
+ * | Deployment | Implementation |
+ * |---|---|
+ * | Embedded | in-process against the host backend |
+ * | Cloud, interactive | client executor: the call streams to the SDK, the browser fetches the host API on the user's session, the result returns via the ai SDK client-tool round trip |
+ * | Cloud, automation | server executor in the worker, authorized by a BrokeredGrant |
+ *
+ * The runtime selects an executor per tool call; the policy layer has already
+ * evaluated the call before it reaches any executor. Non-streaming by design:
+ * a tool call resolves to one outcome (mirrors `ActionResult`).
+ */
+export interface Executor {
+  execute(call: ToolCallRequest, context: ExecutionContext): Promise<ToolCallOutcome>;
+}
+
+export interface ToolCallRequest {
+  /** ai SDK tool-call id — links outcome, approval, and audit entries. */
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+}
+
+export interface ExecutionContext {
+  principal: Principal;
+  /** Present only on server-executed automation runs. */
+  grant?: BrokeredGrant;
+  signal?: AbortSignal;
+}
+
+export type ToolCallOutcome =
+  | { result: unknown }
+  | { error: { code: string; message: string } };
+```
+
+```ts
+// packages/flowlet-core/src/seams/scheduler.ts
+/**
+ * Scheduler seam — firing automations when the user is away (Decisions 1/5).
+ *
+ * | Deployment | Implementation |
+ * |---|---|
+ * | Embedded | none, or host cron invoking the handler |
+ * | Cloud | pg-boss worker in apps/cloud |
+ *
+ * This seam owns TIME-based triggers only. The other two trigger sources
+ * (signed host webhooks, Composio triggers) are ingest paths that invoke the
+ * same firing handler directly — they don't pass through the Scheduler.
+ */
+export interface Scheduler {
+  /** Register (or replace) the durable schedule for an automation. */
+  schedule(automationId: string, trigger: TimeTrigger): Promise<void>;
+  cancel(automationId: string): Promise<void>;
+  /** The runtime registers exactly one firing handler at startup. */
+  onFire(handler: (firing: AutomationFiring) => Promise<void>): void;
+}
+
+export type TimeTrigger =
+  | { kind: "cron"; expression: string; timezone?: string }
+  | { kind: "at"; at: string };
+
+export interface AutomationFiring {
+  automationId: string;
+  firedAt: string;
+}
+```
+
+```ts
+// packages/flowlet-core/src/seams/channels.ts
+import type { Principal } from "./principal";
+
+/**
+ * Channels seam — reaching the user off-thread (Decision 1).
+ *
+ * | Deployment | Implementation |
+ * |---|---|
+ * | Embedded | in-app only |
+ * | Cloud | in-app now; SMS (ENG-191) and voice (ENG-185) later |
+ *
+ * Message-shaped delivery only. Realtime voice is a session, not a message —
+ * it gets its own contract at ENG-185 time and is deliberately NOT squeezed
+ * into `deliver`.
+ */
+export interface Channels {
+  deliver(message: OutboundMessage): Promise<void>;
+}
+
+export type ChannelKind = "in-app" | "sms";
+
+export interface OutboundMessage {
+  channel: ChannelKind;
+  principal: Principal;
+  /** Plain-text body; in-app surfaces may upgrade rendering later. */
+  text: string;
+  /** Thread to attach in-app deliveries to; ignored by SMS. */
+  threadId?: string;
+}
+```
+
+```ts
+// packages/flowlet-core/src/seams/index.ts
+export * from "./principal";
+export * from "./store";
+export * from "./credential-broker";
+export * from "./executor";
+export * from "./scheduler";
+export * from "./channels";
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @flowlet/core test -- seams.test`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/flowlet-core/src/seams
+git commit -m "feat(core): five runtime seam interfaces with embedded/cloud mapping"
+```
+
+---
+
+### Task 8: Export from the core barrel (additive lines only)
+
+**Files:**
+- Modify: `packages/flowlet-core/src/index.ts` (append two lines)
+
+- [ ] **Step 1: Append exports**
+
+```ts
+export * from "./manifest";
+export * from "./seams";
+```
+
+- [ ] **Step 2: Full-workspace verification**
+
+Run: `pnpm build && pnpm typecheck && pnpm test && pnpm lint`
+Expected: all pass. Watch specifically for name collisions from the new `export *` (e.g. anything in flowlet-agent doing `export * from "@flowlet/core"`). If a collision appears, rename the core-side type (never touch flowlet-agent).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/flowlet-core/src/index.ts
+git commit -m "feat(core): export manifest and seam contracts"
+```
+
+---
+
+### Task 9: Short docs
+
+Two focused docs under `docs/contracts/` + a pointer from the core README. Succinct, no filler.
+
+**Files:**
+- Create: `docs/contracts/manifest.md` — the three artifacts, one example each, the annotations table (with MCP mapping), host events, publish/bind lifecycle, pointer to `packages/flowlet-core/schemas/`.
+- Create: `docs/contracts/seams.md` — the five interfaces, the embedded/cloud table from the architecture spec, one paragraph per seam on what is frozen vs deferred (memory, automation DSL, voice).
+- Modify: `packages/flowlet-core/README.md` — append a "Contracts" section linking both docs.
+
+- [ ] **Step 1: Write both docs** (content follows the TSDoc already written; keep each under ~120 lines)
+- [ ] **Step 2: Append the README pointer**
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/contracts packages/flowlet-core/README.md
+git commit -m "docs: manifest schema and runtime seam contracts"
+```
+
+---
+
+### Task 10: Open-questions doc — THE GATE
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-07-01-contracts-freeze-open-questions.md`
+
+- [ ] **Step 1: Write the doc.** Every point where the contract could reasonably go two ways, each with both options, the draft's current position, and a recommendation. Minimum set (add any discovered during implementation):
+
+1. **Annotation vocabulary** — Flowlet-native required `{mutating, dangerous}` vs MCP hints (`readOnlyHint`/`destructiveHint`, optional). Draft/rec: Flowlet-native required, documented MCP mapping.
+2. **Tool binding shape** — freeze a minimal `http` binding now vs leave `binding` opaque for ENG-202/197. Draft/rec: minimal `http` in a discriminated union.
+3. **Theme schema ownership** — core duplicates `brandTokensSchema` (sync-tested) now; later fold components onto core's schema? Rec: yes, separate session.
+4. **Published manifest vs component bundle** — descriptors in the manifest, compiled sandbox bundle referenced by the registry row (not embedded). Confirm.
+5. **Store granularity** — one `Store` aggregating sub-stores vs five separate seam params. Draft/rec: aggregate.
+6. **Automation spec opacity** — `spec: unknown` until ENG-188 vs a minimal envelope now. Draft/rec: opaque.
+7. **Memory reservation** — no `memory` member until ENG-189 (additive later) vs placeholder now. Draft/rec: none.
+8. **Executor result shape** — Promise of one outcome vs streaming. Draft/rec: non-streaming.
+9. **Scheduler scope** — time triggers only (webhooks/Composio are ingest paths) . Confirm.
+10. **Channels + voice** — message-shaped `deliver` for in-app/SMS; voice reserved for its own contract at ENG-185. Confirm.
+11. **Timestamps** — ISO 8601 strings everywhere vs `Date`. Draft/rec: strings.
+12. **`authenticate(credential: unknown)`** — opaque credential vs typed vouch shape. Draft/rec: opaque (embedded passes host sessions).
+
+- [ ] **Step 2: Commit, set the worktree comment, PAUSE**
+
+```bash
+git add docs/superpowers/specs/2026-07-01-contracts-freeze-open-questions.md
+git commit -m "docs: contracts-freeze open questions for mid-flight review"
+orca worktree set --worktree active --comment "questions ready"
+```
+
+**STOP HERE. Do not proceed to Task 11 until answers come back through the orchestrator.**
+
+---
+
+### Task 11 (post-review): Apply answers
+
+- [ ] Apply each answer as targeted edits to the schemas/interfaces/tests/docs; re-run `pnpm generate:schemas` if manifest schemas changed; update the open-questions doc marking each question RESOLVED with the decision.
+- [ ] Run: `pnpm build && pnpm typecheck && pnpm test && pnpm lint` — all pass.
+- [ ] Commit: `git commit -m "feat(core): finalize contracts per mid-flight review"`
+
+### Task 12 (post-review): PR
+
+- [ ] Push: `git push -u origin yousef/contracts-freeze`
+- [ ] Open a PR (never merge) titled "Contracts freeze: manifest schema + five runtime seams" — body: what's frozen, what's deliberately deferred (memory, automation DSL, voice), link to the open-questions doc with resolutions, note ADDITIVE-ONLY (no flowlet-agent changes).
+- [ ] Set worktree comment: `orca worktree set --worktree active --comment "PR open: contracts freeze"`

--- a/docs/superpowers/specs/2026-07-01-contracts-freeze-open-questions.md
+++ b/docs/superpowers/specs/2026-07-01-contracts-freeze-open-questions.md
@@ -1,0 +1,88 @@
+# Contracts Freeze — Open Questions
+
+**Date:** 2026-07-01
+**Status:** AWAITING REVIEW (Yousef, mid-flight)
+**Branch:** `yousef/contracts-freeze` — contracts are drafted, tested, and committed per the recommendations below; every question here can still be changed cheaply before the PR.
+
+How to answer: each question needs one letter. "Confirm" questions can be answered in bulk ("confirm all").
+
+---
+
+## Manifest schema
+
+### Q1. Annotation vocabulary: Flowlet-native or MCP hints?
+
+`tools.json` needs the spec's "mutating/dangerous annotations". MCP already has a vocabulary (`readOnlyHint`, `destructiveHint`, `idempotentHint` — all optional), which `flowlet-agent`'s internal `ToolDescriptor` uses today.
+
+- **A (draft, recommended):** Flowlet-native, REQUIRED `{ mutating, dangerous, idempotent? }`. Policy needs definite values — an optional "hint" forces every consumer to pick a default, and a wrong default on `dangerous` is a safety bug. The MCP mapping (`readOnlyHint = !mutating`, `destructiveHint = dangerous`) is documented in the type and docs, so ingestion into the runtime's descriptor table is mechanical.
+- **B:** Adopt MCP hint names/optionality verbatim for ecosystem familiarity; policy layers pick conservative defaults for missing hints.
+
+### Q2. Tool binding: freeze a minimal `http` shape now, or leave opaque?
+
+The client executor (ENG-202) and extractor (ENG-197) both need to know how a tool call physically reaches the host API.
+
+- **A (draft, recommended):** freeze a minimal `http` binding now — `{ type: "http", method, path }` with `{param}` path templates filled from tool input by name — inside a discriminated union on `type` so trpc/graphql land additively later. Both tracks can build immediately without inventing private shapes.
+- **B:** `binding: unknown` and let ENG-202 define it. Avoids a wrong guess but guarantees a schema rev within weeks and two tracks negotiating a shape mid-flight.
+
+Sub-point if A: query/body parameter mapping is deliberately NOT frozen (only path templates are). Extractors put non-path input into query (GET) or JSON body (others) by convention until a real case demands explicit mapping. OK?
+
+### Q3. Theme schema ownership: duplicate now, fold later?
+
+Core cannot import `brandTokensSchema` from `@flowlet/components` (dependency points the other way), and this session is additive-only.
+
+- **A (draft, recommended):** core carries its own structurally identical schema; a conformance test in flowlet-components fails CI if they ever diverge (it compares generated JSON Schemas, so any drift is caught). A later session folds `brand.ts` onto the core schema and deletes the duplicate.
+- **B:** move `brandTokensSchema` into core now — cleaner, but a refactor of F3/F4 code, which this session is forbidden to do.
+
+### Q4. Published manifest vs component bundle — confirm
+
+Draft: the published manifest embeds component *descriptors* only (name, description, propsSchema as JSON Schema); the compiled sandbox bundle is a separate artifact referenced by the registry row, keyed by the same hash. The manifest stays small, diffable, reviewable (ENG-194's queue reads it); the bundle is a blob. Confirm?
+
+### Q5. tools.json file shape — confirm
+
+Draft: `tools.json` = `{ version: 1, tools: [...], events: [...] }` — host events live in tools.json per architecture Decision 3, not a fourth artifact. Confirm?
+
+## Seams
+
+### Q6. Automation spec opacity — confirm
+
+Draft: `AutomationRecord.spec: unknown` until ENG-188's brainstorm freezes the DSL (proposals are in flight there — JSONata-flavored step graph etc.). The store freezes only identity, lifecycle (`enabled | paused`), and run history, which every DSL design needs. Confirm?
+
+### Q7. Memory reservation — confirm
+
+Draft: NO `memory` member on `Store` yet. The architecture deliberately leaves memory (ENG-189) undefined; adding a member later is purely additive. The alternative — a placeholder `memory?: unknown` — freezes nothing and invites accidental coupling. Confirm?
+
+### Q8. Store granularity: one aggregate or five parameters?
+
+- **A (draft, recommended):** one `Store` aggregating named sub-stores (`threads`, `flowlets`, `automations`, `audit`). One injection point; sub-stores keep concerns separable and independently testable.
+- **B:** each sub-store injected as its own top-level seam. More flexible partial deployments, but the runtime constructor grows and the architecture names "Store" as ONE seam of five.
+
+### Q9. Executor result shape: single outcome or streaming?
+
+- **A (draft, recommended):** `execute() → Promise<{ result } | { error }>` — one outcome per call, mirroring the existing `ActionResult`. The ai SDK client-tool round trip is itself request/response, so a streaming seam would have nothing to carry on the main path.
+- **B:** `ReadableStream` results for long-running host calls. Can be added later as a new method without breaking A.
+
+### Q10. Scheduler scope: time triggers only — confirm
+
+Draft: `Scheduler` owns `cron`/`at` only; host webhooks and Composio triggers are ingest paths that invoke the same registered firing handler directly. Keeps the seam implementable by "none, or host cron" in embedded mode, per the architecture table. Confirm?
+
+### Q11. Channels: message-shaped now, voice reserved — confirm
+
+Draft: `deliver({ channel: "in-app" | "sms", principal, text, threadId? })`. Realtime voice is a session, not a message — it gets its own contract at ENG-185 and is deliberately not squeezed into `deliver`. Confirm?
+
+### Q12. Credential input: opaque or typed?
+
+- **A (draft, recommended):** `authenticate(credential: unknown)` — cloud passes the vouch JWT string, embedded passes whatever in-process handle the host has. Typing it as `string` would force embedded hosts to fake-serialize.
+- **B:** typed `VouchCredential` union now. Prettier, but invents an embedded credential shape nobody has asked for yet.
+
+## Conventions
+
+### Q13. Timestamps: ISO 8601 strings — confirm
+
+Draft: all seam/store timestamps are ISO 8601 strings (portable across the wire and JSON storage; `Date` objects don't survive serialization). Confirm?
+
+---
+
+## Not questions, but flagged
+
+- **Branch name:** worktree branch renamed `yousefh409/contracts-freeze` → `yousef/contracts-freeze` per the session mandate.
+- **Pre-existing, untouched:** (1) `pnpm lint` fails repo-wide after any fresh `pnpm build` — demo-bank's eslint lints the generated, gitignored `public/flowlet/components-sandbox.js` bundle; (2) test files are excluded from every package's `tsc` typecheck, and `flowlet-core/src/genui/resolve.test.ts` has 6 latent type errors under `noUncheckedIndexedAccess`. Both predate this branch; neither was fixed here (out of scope).

--- a/docs/superpowers/specs/2026-07-01-contracts-freeze-open-questions.md
+++ b/docs/superpowers/specs/2026-07-01-contracts-freeze-open-questions.md
@@ -1,10 +1,16 @@
 # Contracts Freeze — Open Questions
 
 **Date:** 2026-07-01
-**Status:** AWAITING REVIEW (Yousef, mid-flight)
-**Branch:** `yousef/contracts-freeze` — contracts are drafted, tested, and committed per the recommendations below; every question here can still be changed cheaply before the PR.
+**Status:** ANSWERED — LOCKED (Yousef, mid-flight review 2026-07-01)
+**Branch:** `yousef/contracts-freeze`
 
-How to answer: each question needs one letter. "Confirm" questions can be answered in bulk ("confirm all").
+**Resolution:** Yousef answered all 13. Every A/B question resolved to **Option A** (the draft position); all seven confirm questions **CONFIRMED**. The committed contracts already implement every decision — no changes resulted from the review. These contracts are now frozen; changing any of them requires a new review.
+
+Q1 **A** · Q2 **A** (incl. the query/body-convention sub-point) · Q3 **A** · Q4 **confirmed** · Q5 **confirmed** · Q6 **confirmed** · Q7 **confirmed** · Q8 **A** · Q9 **A** · Q10 **confirmed** · Q11 **confirmed** · Q12 **A** · Q13 **confirmed**
+
+**Coordination note (from the review):** ENG-188 locked its DSL in its own session (JSONata step graph, versions table). Q6's opaque `spec: unknown` at the Store seam remains correct — the runtime contracts do NOT import ENG-188's schema; their spec shape lives with the automations track.
+
+The original questions follow, unchanged, for the record.
 
 ---
 

--- a/packages/flowlet-components/src/manifest-conformance.test.ts
+++ b/packages/flowlet-components/src/manifest-conformance.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { manifestThemeSchema, manifestComponentSchema } from "@flowlet/core";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { defaultBrand, brandTokensSchema } from "./theme/brand";
+import { descriptors } from "./descriptors";
+
+describe("existing artifacts conform to the frozen manifest contracts", () => {
+  it("defaultBrand is a valid manifest theme", () => {
+    expect(() => manifestThemeSchema.parse(defaultBrand)).not.toThrow();
+  });
+
+  it("brandTokensSchema and manifestThemeSchema agree on shape", () => {
+    // Same generated JSON Schema = structurally identical contracts.
+    expect(zodToJsonSchema(brandTokensSchema, { $refStrategy: "none" })).toEqual(
+      zodToJsonSchema(manifestThemeSchema, { $refStrategy: "none" }),
+    );
+  });
+
+  it("every prewired descriptor serializes to a valid ManifestComponent", () => {
+    for (const d of descriptors) {
+      const entry = {
+        name: d.name,
+        description: d.description,
+        propsSchema: zodToJsonSchema(d.propsSchema, { $refStrategy: "none" }) as Record<
+          string,
+          unknown
+        >,
+      };
+      expect(() => manifestComponentSchema.parse(entry), d.name).not.toThrow();
+    }
+  });
+});

--- a/packages/flowlet-core/README.md
+++ b/packages/flowlet-core/README.md
@@ -33,3 +33,14 @@ flat, id-addressed graph:
 
 Validate with `validateGeneratedPayload(input)` (pure, never throws); `@flowlet/stage`
 resolves the flat graph into the nested `UINode` tree the sandbox renders.
+
+## Contracts
+
+Frozen platform contracts (2026-07-01 architecture):
+
+- `src/manifest/` — the `.flowlet/` manifest schema (theme.json, components, tools.json
+  + host events) as zod schemas; generated JSON Schema artifacts in `schemas/`
+  (`pnpm generate:schemas`, drift fails CI). See [docs/contracts/manifest.md](../../docs/contracts/manifest.md).
+- `src/seams/` — the five runtime seam interfaces (Store, CredentialBroker, Executor,
+  Scheduler, Channels) with the embedded-vs-cloud mapping in TSDoc. See
+  [docs/contracts/seams.md](../../docs/contracts/seams.md).

--- a/packages/flowlet-core/package.json
+++ b/packages/flowlet-core/package.json
@@ -16,6 +16,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "generate:schemas": "tsx scripts/generate-schemas.ts",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
@@ -26,7 +27,10 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
+    "ajv": "^8.17.0",
+    "tsx": "^4.19.0",
     "typescript": "^5.6.0",
-    "vitest": "^2.1.0"
+    "vitest": "^2.1.0",
+    "zod-to-json-schema": "^3.24.0"
   }
 }

--- a/packages/flowlet-core/schemas/manifest.schema.json
+++ b/packages/flowlet-core/schemas/manifest.schema.json
@@ -1,0 +1,212 @@
+{
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "type": "number",
+      "const": 1
+    },
+    "theme": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "number",
+          "const": 1
+        },
+        "accent": {
+          "type": "string",
+          "pattern": "^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$"
+        },
+        "background": {
+          "type": "string",
+          "pattern": "^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$"
+        },
+        "surface": {
+          "type": "string",
+          "pattern": "^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$"
+        },
+        "text": {
+          "type": "string",
+          "pattern": "^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$"
+        },
+        "mutedText": {
+          "type": "string",
+          "pattern": "^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$"
+        },
+        "fontFamily": {
+          "type": "string",
+          "minLength": 1
+        },
+        "radius": {
+          "anyOf": [
+            {
+              "type": "number",
+              "minimum": 0
+            },
+            {
+              "type": "string",
+              "pattern": "^\\d+(\\.\\d+)?px$"
+            }
+          ]
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "light",
+            "dark"
+          ]
+        }
+      },
+      "required": [
+        "version",
+        "accent",
+        "background",
+        "surface",
+        "text",
+        "mutedText",
+        "fontFamily",
+        "radius"
+      ],
+      "additionalProperties": false
+    },
+    "tools": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9_-]*$"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "inputSchema": {
+            "type": "object",
+            "additionalProperties": {}
+          },
+          "annotations": {
+            "type": "object",
+            "properties": {
+              "mutating": {
+                "type": "boolean"
+              },
+              "dangerous": {
+                "type": "boolean"
+              },
+              "idempotent": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "mutating",
+              "dangerous"
+            ],
+            "additionalProperties": false
+          },
+          "binding": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "http"
+                  },
+                  "method": {
+                    "type": "string",
+                    "enum": [
+                      "GET",
+                      "POST",
+                      "PUT",
+                      "PATCH",
+                      "DELETE"
+                    ]
+                  },
+                  "path": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "type",
+                  "method",
+                  "path"
+                ],
+                "additionalProperties": false
+              }
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "inputSchema",
+          "annotations",
+          "binding"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)+$"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "payloadSchema": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        },
+        "required": [
+          "name",
+          "description"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "components": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "propsSchema": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "propsSchema"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "theme",
+    "tools",
+    "events",
+    "components"
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/packages/flowlet-core/schemas/manifest.schema.json
+++ b/packages/flowlet-core/schemas/manifest.schema.json
@@ -125,7 +125,7 @@
                   },
                   "path": {
                     "type": "string",
-                    "minLength": 1
+                    "pattern": "^\\/(?!\\/)\\S*$"
                   }
                 },
                 "required": [

--- a/packages/flowlet-core/schemas/theme.schema.json
+++ b/packages/flowlet-core/schemas/theme.schema.json
@@ -1,0 +1,64 @@
+{
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "number",
+      "const": 1
+    },
+    "accent": {
+      "type": "string",
+      "pattern": "^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$"
+    },
+    "background": {
+      "type": "string",
+      "pattern": "^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$"
+    },
+    "surface": {
+      "type": "string",
+      "pattern": "^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$"
+    },
+    "text": {
+      "type": "string",
+      "pattern": "^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$"
+    },
+    "mutedText": {
+      "type": "string",
+      "pattern": "^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$"
+    },
+    "fontFamily": {
+      "type": "string",
+      "minLength": 1
+    },
+    "radius": {
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0
+        },
+        {
+          "type": "string",
+          "pattern": "^\\d+(\\.\\d+)?px$"
+        }
+      ]
+    },
+    "mode": {
+      "type": "string",
+      "enum": [
+        "light",
+        "dark"
+      ]
+    }
+  },
+  "required": [
+    "version",
+    "accent",
+    "background",
+    "surface",
+    "text",
+    "mutedText",
+    "fontFamily",
+    "radius"
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/packages/flowlet-core/schemas/tools.schema.json
+++ b/packages/flowlet-core/schemas/tools.schema.json
@@ -1,0 +1,121 @@
+{
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "number",
+      "const": 1
+    },
+    "tools": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9_-]*$"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "inputSchema": {
+            "type": "object",
+            "additionalProperties": {}
+          },
+          "annotations": {
+            "type": "object",
+            "properties": {
+              "mutating": {
+                "type": "boolean"
+              },
+              "dangerous": {
+                "type": "boolean"
+              },
+              "idempotent": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "mutating",
+              "dangerous"
+            ],
+            "additionalProperties": false
+          },
+          "binding": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "http"
+                  },
+                  "method": {
+                    "type": "string",
+                    "enum": [
+                      "GET",
+                      "POST",
+                      "PUT",
+                      "PATCH",
+                      "DELETE"
+                    ]
+                  },
+                  "path": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "type",
+                  "method",
+                  "path"
+                ],
+                "additionalProperties": false
+              }
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "inputSchema",
+          "annotations",
+          "binding"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)+$"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "payloadSchema": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        },
+        "required": [
+          "name",
+          "description"
+        ],
+        "additionalProperties": false
+      },
+      "default": []
+    }
+  },
+  "required": [
+    "version",
+    "tools"
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/packages/flowlet-core/schemas/tools.schema.json
+++ b/packages/flowlet-core/schemas/tools.schema.json
@@ -62,7 +62,7 @@
                   },
                   "path": {
                     "type": "string",
-                    "minLength": 1
+                    "pattern": "^\\/(?!\\/)\\S*$"
                   }
                 },
                 "required": [

--- a/packages/flowlet-core/scripts/generate-schemas.ts
+++ b/packages/flowlet-core/scripts/generate-schemas.ts
@@ -5,6 +5,10 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 import { manifestThemeSchema } from "../src/manifest/theme";
 import { toolsManifestSchema, flowletManifestSchema } from "../src/manifest/manifest";
 
+// CONSTRAINT: zodToJsonSchema cannot serialize .refine()/.transform() logic, so
+// the drift test would silently miss them. Manifest schemas must stay
+// refinement-free (regex/enum/literal only); if a refinement ever becomes
+// necessary, add an explicit AJV-side test asserting the same rejection.
 const opts = { target: "jsonSchema7" as const, $refStrategy: "none" as const };
 
 /** file name -> JSON Schema document. Imported by the sync test; run as a script to write. */

--- a/packages/flowlet-core/scripts/generate-schemas.ts
+++ b/packages/flowlet-core/scripts/generate-schemas.ts
@@ -1,0 +1,24 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { manifestThemeSchema } from "../src/manifest/theme";
+import { toolsManifestSchema, flowletManifestSchema } from "../src/manifest/manifest";
+
+const opts = { target: "jsonSchema7" as const, $refStrategy: "none" as const };
+
+/** file name -> JSON Schema document. Imported by the sync test; run as a script to write. */
+export const generatedSchemas: Record<string, Record<string, unknown>> = {
+  "theme.schema.json": zodToJsonSchema(manifestThemeSchema, opts) as Record<string, unknown>,
+  "tools.schema.json": zodToJsonSchema(toolsManifestSchema, opts) as Record<string, unknown>,
+  "manifest.schema.json": zodToJsonSchema(flowletManifestSchema, opts) as Record<string, unknown>,
+};
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const outDir = join(dirname(fileURLToPath(import.meta.url)), "..", "schemas");
+  mkdirSync(outDir, { recursive: true });
+  for (const [file, schema] of Object.entries(generatedSchemas)) {
+    writeFileSync(join(outDir, file), JSON.stringify(schema, null, 2) + "\n");
+    console.log(`wrote schemas/${file}`);
+  }
+}

--- a/packages/flowlet-core/src/index.ts
+++ b/packages/flowlet-core/src/index.ts
@@ -6,3 +6,5 @@ export * from "./agent";
 export * from "./registry";
 export * from "./genui";
 export * from "./text";
+export * from "./manifest";
+export * from "./seams";

--- a/packages/flowlet-core/src/manifest/component.ts
+++ b/packages/flowlet-core/src/manifest/component.ts
@@ -8,11 +8,13 @@ import { jsonSchemaDocument } from "./tool";
  * props schema serialized to JSON Schema. This is the JSON form of
  * `RegisteredComponent` / `PrewiredDescriptor` (name, description, propsSchema).
  */
-export const manifestComponentSchema = z.object({
-  name: z.string().min(1),
-  /** Drives LLM component selection — same field as `RegisteredComponent.description`. */
-  description: z.string().min(1),
-  /** JSON Schema for the component props (zod-serialized at publish time). */
-  propsSchema: jsonSchemaDocument,
-});
+export const manifestComponentSchema = z
+  .object({
+    name: z.string().min(1),
+    /** Drives LLM component selection — same field as `RegisteredComponent.description`. */
+    description: z.string().min(1),
+    /** JSON Schema for the component props (zod-serialized at publish time). */
+    propsSchema: jsonSchemaDocument,
+  })
+  .strict();
 export type ManifestComponent = z.infer<typeof manifestComponentSchema>;

--- a/packages/flowlet-core/src/manifest/component.ts
+++ b/packages/flowlet-core/src/manifest/component.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { jsonSchemaDocument } from "./tool";
+
+/**
+ * The published image of one entry in `.flowlet/components/` (dev-tool artifact
+ * 2 of 3). On disk each entry is a descriptor + wrapper pair compiled into the
+ * sandbox bundle; the published manifest carries only the descriptor, with the
+ * props schema serialized to JSON Schema. This is the JSON form of
+ * `RegisteredComponent` / `PrewiredDescriptor` (name, description, propsSchema).
+ */
+export const manifestComponentSchema = z.object({
+  name: z.string().min(1),
+  /** Drives LLM component selection — same field as `RegisteredComponent.description`. */
+  description: z.string().min(1),
+  /** JSON Schema for the component props (zod-serialized at publish time). */
+  propsSchema: jsonSchemaDocument,
+});
+export type ManifestComponent = z.infer<typeof manifestComponentSchema>;

--- a/packages/flowlet-core/src/manifest/event.test.ts
+++ b/packages/flowlet-core/src/manifest/event.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { hostEventSchema } from "./event";
+
+describe("hostEventSchema", () => {
+  it("accepts a namespaced event with a payload schema", () => {
+    expect(() =>
+      hostEventSchema.parse({
+        name: "invoice.paid",
+        description: "An invoice was paid in full.",
+        payloadSchema: { type: "object", properties: { invoiceId: { type: "string" } } },
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts an event without a payload schema", () => {
+    expect(() =>
+      hostEventSchema.parse({ name: "user.deactivated", description: "Account deactivated." }),
+    ).not.toThrow();
+  });
+
+  it("rejects un-namespaced or malformed names", () => {
+    expect(() => hostEventSchema.parse({ name: "paid", description: "x" })).toThrow();
+    expect(() => hostEventSchema.parse({ name: "Invoice.Paid!", description: "x" })).toThrow();
+  });
+});

--- a/packages/flowlet-core/src/manifest/event.ts
+++ b/packages/flowlet-core/src/manifest/event.ts
@@ -8,11 +8,13 @@ import { jsonSchemaDocument } from "./tool";
  * the ingest path in-process. Names are dot-namespaced, lower_snake segments:
  * `invoice.paid`, `user.plan_changed`.
  */
-export const hostEventSchema = z.object({
-  name: z.string().regex(/^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$/),
-  /** Drives trigger selection when the compiler agent builds an automation. */
-  description: z.string().min(1),
-  /** JSON Schema for the event payload; omitted = opaque payload. */
-  payloadSchema: jsonSchemaDocument.optional(),
-});
+export const hostEventSchema = z
+  .object({
+    name: z.string().regex(/^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$/),
+    /** Drives trigger selection when the compiler agent builds an automation. */
+    description: z.string().min(1),
+    /** JSON Schema for the event payload; omitted = opaque payload. */
+    payloadSchema: jsonSchemaDocument.optional(),
+  })
+  .strict();
 export type HostEventDeclaration = z.infer<typeof hostEventSchema>;

--- a/packages/flowlet-core/src/manifest/event.ts
+++ b/packages/flowlet-core/src/manifest/event.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { jsonSchemaDocument } from "./tool";
+
+/**
+ * A host event type declared in `tools.json`, available as an automation
+ * trigger (architecture Decisions 3 & 5). At runtime the host backend delivers
+ * instances as signed webhooks to the cloud worker; embedded hosts may invoke
+ * the ingest path in-process. Names are dot-namespaced, lower_snake segments:
+ * `invoice.paid`, `user.plan_changed`.
+ */
+export const hostEventSchema = z.object({
+  name: z.string().regex(/^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$/),
+  /** Drives trigger selection when the compiler agent builds an automation. */
+  description: z.string().min(1),
+  /** JSON Schema for the event payload; omitted = opaque payload. */
+  payloadSchema: jsonSchemaDocument.optional(),
+});
+export type HostEventDeclaration = z.infer<typeof hostEventSchema>;

--- a/packages/flowlet-core/src/manifest/index.ts
+++ b/packages/flowlet-core/src/manifest/index.ts
@@ -1,0 +1,5 @@
+export * from "./theme";
+export * from "./tool";
+export * from "./event";
+export * from "./component";
+export * from "./manifest";

--- a/packages/flowlet-core/src/manifest/manifest.test.ts
+++ b/packages/flowlet-core/src/manifest/manifest.test.ts
@@ -56,4 +56,19 @@ describe("flowletManifestSchema (published unit)", () => {
       flowletManifestSchema.parse({ schemaVersion: 1, tools: [], events: [], components: [] }),
     ).toThrow();
   });
+
+  it("rejects unknown keys (parity with additionalProperties: false)", () => {
+    expect(() => manifestComponentSchema.parse({ ...component, wrapperPath: "./x" })).toThrow();
+    expect(() => toolsManifestSchema.parse({ version: 1, tools: [], extra: 1 })).toThrow();
+    expect(() =>
+      flowletManifestSchema.parse({
+        schemaVersion: 1,
+        theme,
+        tools: [],
+        events: [],
+        components: [],
+        extra: 1,
+      }),
+    ).toThrow();
+  });
 });

--- a/packages/flowlet-core/src/manifest/manifest.test.ts
+++ b/packages/flowlet-core/src/manifest/manifest.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { manifestComponentSchema } from "./component";
+import { flowletManifestSchema, toolsManifestSchema } from "./manifest";
+
+const theme = {
+  version: 1,
+  accent: "#0A7CFF",
+  background: "#FFFFFF",
+  surface: "#F5F7FA",
+  text: "#111418",
+  mutedText: "#5B6470",
+  fontFamily: "system-ui, sans-serif",
+  radius: 8,
+};
+const tool = {
+  name: "listInvoices",
+  description: "List invoices.",
+  inputSchema: { type: "object" },
+  annotations: { mutating: false, dangerous: false },
+  binding: { type: "http", method: "GET", path: "/api/invoices" },
+};
+const component = {
+  name: "InvoiceCard",
+  description: "The host's invoice summary card.",
+  propsSchema: { type: "object", properties: { invoiceId: { type: "string" } } },
+};
+
+describe("manifestComponentSchema", () => {
+  it("accepts a serialized descriptor", () => {
+    expect(() => manifestComponentSchema.parse(component)).not.toThrow();
+  });
+});
+
+describe("toolsManifestSchema (tools.json file)", () => {
+  it("accepts tools + events, defaulting events to []", () => {
+    const parsed = toolsManifestSchema.parse({ version: 1, tools: [tool] });
+    expect(parsed.events).toEqual([]);
+  });
+});
+
+describe("flowletManifestSchema (published unit)", () => {
+  it("accepts a complete manifest", () => {
+    expect(() =>
+      flowletManifestSchema.parse({
+        schemaVersion: 1,
+        theme,
+        tools: [tool],
+        events: [],
+        components: [component],
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects a manifest missing the theme", () => {
+    expect(() =>
+      flowletManifestSchema.parse({ schemaVersion: 1, tools: [], events: [], components: [] }),
+    ).toThrow();
+  });
+});

--- a/packages/flowlet-core/src/manifest/manifest.ts
+++ b/packages/flowlet-core/src/manifest/manifest.ts
@@ -9,11 +9,16 @@ import { manifestComponentSchema } from "./component";
  * host-API tool descriptors plus declared host event types (Decision 3).
  * Developer-editable after extraction.
  */
-export const toolsManifestSchema = z.object({
-  version: z.literal(1),
-  tools: z.array(manifestToolSchema),
-  events: z.array(hostEventSchema).default([]),
-});
+export const toolsManifestSchema = z
+  .object({
+    version: z.literal(1),
+    tools: z.array(manifestToolSchema),
+    /** Optional in the file; zod parse normalizes a missing `events` to `[]`.
+     *  JSON Schema `default` is annotation-only, so raw-JSON consumers must
+     *  treat a missing `events` as empty themselves. */
+    events: z.array(hostEventSchema).default([]),
+  })
+  .strict();
 export type ToolsManifest = z.infer<typeof toolsManifestSchema>;
 
 /**
@@ -25,13 +30,15 @@ export type ToolsManifest = z.infer<typeof toolsManifestSchema>;
  * Embedded mode reads the same shape directly from `.flowlet/` on disk;
  * publish is a no-op there.
  */
-export const flowletManifestSchema = z.object({
-  schemaVersion: z.literal(1),
-  theme: manifestThemeSchema,
-  tools: z.array(manifestToolSchema),
-  events: z.array(hostEventSchema),
-  components: z.array(manifestComponentSchema),
-});
+export const flowletManifestSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    theme: manifestThemeSchema,
+    tools: z.array(manifestToolSchema),
+    events: z.array(hostEventSchema),
+    components: z.array(manifestComponentSchema),
+  })
+  .strict();
 export type FlowletManifest = z.infer<typeof flowletManifestSchema>;
 
 /**

--- a/packages/flowlet-core/src/manifest/manifest.ts
+++ b/packages/flowlet-core/src/manifest/manifest.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import { manifestThemeSchema } from "./theme";
+import { manifestToolSchema } from "./tool";
+import { hostEventSchema } from "./event";
+import { manifestComponentSchema } from "./component";
+
+/**
+ * The `tools.json` FILE as it sits in `.flowlet/` in the host repo:
+ * host-API tool descriptors plus declared host event types (Decision 3).
+ * Developer-editable after extraction.
+ */
+export const toolsManifestSchema = z.object({
+  version: z.literal(1),
+  tools: z.array(manifestToolSchema),
+  events: z.array(hostEventSchema).default([]),
+});
+export type ToolsManifest = z.infer<typeof toolsManifestSchema>;
+
+/**
+ * The published manifest — the immutable unit `flowlet publish` uploads to the
+ * cloud registry and a session binds to at init (Decision 3). Assembled from
+ * the three `.flowlet/` artifacts; the sandbox component bundle travels
+ * alongside, referenced by the registry row, not embedded here.
+ *
+ * Embedded mode reads the same shape directly from `.flowlet/` on disk;
+ * publish is a no-op there.
+ */
+export const flowletManifestSchema = z.object({
+  schemaVersion: z.literal(1),
+  theme: manifestThemeSchema,
+  tools: z.array(manifestToolSchema),
+  events: z.array(hostEventSchema),
+  components: z.array(manifestComponentSchema),
+});
+export type FlowletManifest = z.infer<typeof flowletManifestSchema>;
+
+/**
+ * Registry identity of a published manifest. Rows are immutable — a re-publish
+ * is a new row with an active pointer per environment (Decision 3/6). Sessions
+ * carry a ManifestRef, never a mutable manifest.
+ */
+export interface ManifestRef {
+  tenantId: string;
+  /** Publisher-supplied version label (e.g. git sha or semver). */
+  version: string;
+  /** Content hash of the published manifest, assigned by the registry. */
+  hash: string;
+}

--- a/packages/flowlet-core/src/manifest/schemas.test.ts
+++ b/packages/flowlet-core/src/manifest/schemas.test.ts
@@ -4,8 +4,28 @@ import { fileURLToPath } from "node:url";
 import Ajv from "ajv";
 import { describe, expect, it } from "vitest";
 import { generatedSchemas } from "../../scripts/generate-schemas";
+import { manifestThemeSchema } from "./theme";
+import { toolsManifestSchema } from "./manifest";
 
 const schemasDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "schemas");
+
+const validTheme = {
+  version: 1,
+  accent: "#0A7CFF",
+  background: "#FFFFFF",
+  surface: "#F5F7FA",
+  text: "#111418",
+  mutedText: "#5B6470",
+  fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
+  radius: 8,
+  mode: "light",
+};
+
+function compileCommitted(file: string) {
+  return new Ajv({ strict: false }).compile(
+    JSON.parse(readFileSync(join(schemasDir, file), "utf8")),
+  );
+}
 
 describe("committed JSON Schema artifacts", () => {
   for (const [file, schema] of Object.entries(generatedSchemas)) {
@@ -21,22 +41,25 @@ describe("committed JSON Schema artifacts", () => {
   }
 
   it("theme.schema.json accepts the flowlet-components default brand shape", () => {
-    const ajv = new Ajv({ strict: false });
-    const validate = ajv.compile(
-      JSON.parse(readFileSync(join(schemasDir, "theme.schema.json"), "utf8")),
-    );
-    expect(
-      validate({
-        version: 1,
-        accent: "#0A7CFF",
-        background: "#FFFFFF",
-        surface: "#F5F7FA",
-        text: "#111418",
-        mutedText: "#5B6470",
-        fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
-        radius: 8,
-        mode: "light",
-      }),
-    ).toBe(true);
+    expect(compileCommitted("theme.schema.json")(validTheme)).toBe(true);
+  });
+
+  it("zod and AJV agree: unknown keys are rejected on both sides", () => {
+    const themeWithExtra = { ...validTheme, extraToken: "#FFFFFF" };
+    expect(compileCommitted("theme.schema.json")(themeWithExtra)).toBe(false);
+    expect(manifestThemeSchema.safeParse(themeWithExtra).success).toBe(false);
+
+    const toolsWithExtra = { version: 1, tools: [], extra: 1 };
+    expect(compileCommitted("tools.schema.json")(toolsWithExtra)).toBe(false);
+    expect(toolsManifestSchema.safeParse(toolsWithExtra).success).toBe(false);
+  });
+
+  it("zod and AJV agree: missing events is accepted (zod normalizes to [])", () => {
+    // JSON Schema `default` is annotation-only: raw-JSON consumers must treat a
+    // missing `events` as empty; zod parse is the normalization layer.
+    const noEvents = { version: 1, tools: [] };
+    expect(compileCommitted("tools.schema.json")(noEvents)).toBe(true);
+    const parsed = toolsManifestSchema.parse(noEvents);
+    expect(parsed.events).toEqual([]);
   });
 });

--- a/packages/flowlet-core/src/manifest/schemas.test.ts
+++ b/packages/flowlet-core/src/manifest/schemas.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import Ajv from "ajv";
+import { describe, expect, it } from "vitest";
+import { generatedSchemas } from "../../scripts/generate-schemas";
+
+const schemasDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "schemas");
+
+describe("committed JSON Schema artifacts", () => {
+  for (const [file, schema] of Object.entries(generatedSchemas)) {
+    it(`${file} is in sync with the zod source (run pnpm generate:schemas)`, () => {
+      const committed = JSON.parse(readFileSync(join(schemasDir, file), "utf8"));
+      expect(committed).toEqual(schema);
+    });
+
+    it(`${file} compiles under ajv`, () => {
+      const ajv = new Ajv({ strict: false });
+      expect(() => ajv.compile(schema)).not.toThrow();
+    });
+  }
+
+  it("theme.schema.json accepts the flowlet-components default brand shape", () => {
+    const ajv = new Ajv({ strict: false });
+    const validate = ajv.compile(
+      JSON.parse(readFileSync(join(schemasDir, "theme.schema.json"), "utf8")),
+    );
+    expect(
+      validate({
+        version: 1,
+        accent: "#0A7CFF",
+        background: "#FFFFFF",
+        surface: "#F5F7FA",
+        text: "#111418",
+        mutedText: "#5B6470",
+        fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
+        radius: 8,
+        mode: "light",
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/flowlet-core/src/manifest/theme.test.ts
+++ b/packages/flowlet-core/src/manifest/theme.test.ts
@@ -30,4 +30,8 @@ describe("manifestThemeSchema", () => {
   it("rejects unknown versions", () => {
     expect(() => manifestThemeSchema.parse({ ...valid, version: 2 })).toThrow();
   });
+
+  it("rejects unknown keys (parity with additionalProperties: false)", () => {
+    expect(() => manifestThemeSchema.parse({ ...valid, extraToken: "#FFFFFF" })).toThrow();
+  });
 });

--- a/packages/flowlet-core/src/manifest/theme.test.ts
+++ b/packages/flowlet-core/src/manifest/theme.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { manifestThemeSchema } from "./theme";
+
+const valid = {
+  version: 1,
+  accent: "#0A7CFF",
+  background: "#FFFFFF",
+  surface: "#F5F7FA",
+  text: "#111418",
+  mutedText: "#5B6470",
+  fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
+  radius: 8,
+  mode: "light",
+};
+
+describe("manifestThemeSchema", () => {
+  it("accepts a fully resolved v1 theme", () => {
+    expect(manifestThemeSchema.parse(valid)).toEqual(valid);
+  });
+
+  it("accepts px-string radius and omitted mode", () => {
+    const { mode: _mode, ...rest } = valid;
+    expect(() => manifestThemeSchema.parse({ ...rest, radius: "8.5px" })).not.toThrow();
+  });
+
+  it("rejects non-hex colors (no var()/url() references)", () => {
+    expect(() => manifestThemeSchema.parse({ ...valid, accent: "var(--accent)" })).toThrow();
+  });
+
+  it("rejects unknown versions", () => {
+    expect(() => manifestThemeSchema.parse({ ...valid, version: 2 })).toThrow();
+  });
+});

--- a/packages/flowlet-core/src/manifest/theme.ts
+++ b/packages/flowlet-core/src/manifest/theme.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+/** A literal hex color (#rgb / #rgba / #rrggbb / #rrggbbaa). No var()/url() references. */
+const hexColor = z
+  .string()
+  .regex(/^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/);
+
+/**
+ * `theme.json` — extracted host design tokens (dev-tool artifact 1 of 3,
+ * architecture Decision 3). Fully resolved primitives only: the sandbox has no
+ * host CSS vars or loaded fonts.
+ *
+ * Structurally identical to `BrandTokens` v1 in `@flowlet/components`
+ * (`src/theme/brand.ts`), which is the consuming side of this contract; a
+ * reconciliation test there keeps the two in sync until they are folded together.
+ */
+export const manifestThemeSchema = z.object({
+  version: z.literal(1),
+  accent: hexColor,
+  background: hexColor,
+  surface: hexColor,
+  text: hexColor,
+  mutedText: hexColor,
+  fontFamily: z.string().min(1),
+  radius: z.union([z.number().nonnegative(), z.string().regex(/^\d+(\.\d+)?px$/)]),
+  mode: z.enum(["light", "dark"]).optional(),
+});
+
+export type ManifestTheme = z.infer<typeof manifestThemeSchema>;

--- a/packages/flowlet-core/src/manifest/theme.ts
+++ b/packages/flowlet-core/src/manifest/theme.ts
@@ -14,16 +14,18 @@ const hexColor = z
  * (`src/theme/brand.ts`), which is the consuming side of this contract; a
  * reconciliation test there keeps the two in sync until they are folded together.
  */
-export const manifestThemeSchema = z.object({
-  version: z.literal(1),
-  accent: hexColor,
-  background: hexColor,
-  surface: hexColor,
-  text: hexColor,
-  mutedText: hexColor,
-  fontFamily: z.string().min(1),
-  radius: z.union([z.number().nonnegative(), z.string().regex(/^\d+(\.\d+)?px$/)]),
-  mode: z.enum(["light", "dark"]).optional(),
-});
+export const manifestThemeSchema = z
+  .object({
+    version: z.literal(1),
+    accent: hexColor,
+    background: hexColor,
+    surface: hexColor,
+    text: hexColor,
+    mutedText: hexColor,
+    fontFamily: z.string().min(1),
+    radius: z.union([z.number().nonnegative(), z.string().regex(/^\d+(\.\d+)?px$/)]),
+    mode: z.enum(["light", "dark"]).optional(),
+  })
+  .strict();
 
 export type ManifestTheme = z.infer<typeof manifestThemeSchema>;

--- a/packages/flowlet-core/src/manifest/tool.test.ts
+++ b/packages/flowlet-core/src/manifest/tool.test.ts
@@ -36,4 +36,38 @@ describe("manifestToolSchema", () => {
     ).toThrow();
     expect(() => manifestToolSchema.parse({ ...listInvoices, name: "1bad name" })).toThrow();
   });
+
+  it("rejects non-host-relative binding paths", () => {
+    for (const path of [
+      "https://evil.example/api",
+      "//evil.example/api",
+      "api/invoices",
+      "/api /invoices",
+    ]) {
+      expect(
+        () =>
+          manifestToolSchema.parse({
+            ...listInvoices,
+            binding: { type: "http", method: "GET", path },
+          }),
+        path,
+      ).toThrow();
+    }
+  });
+
+  it("rejects unknown keys at every level (parity with additionalProperties: false)", () => {
+    expect(() => manifestToolSchema.parse({ ...listInvoices, extra: 1 })).toThrow();
+    expect(() =>
+      manifestToolSchema.parse({
+        ...listInvoices,
+        annotations: { mutating: false, dangerous: false, sneaky: true },
+      }),
+    ).toThrow();
+    expect(() =>
+      manifestToolSchema.parse({
+        ...listInvoices,
+        binding: { type: "http", method: "GET", path: "/api/invoices", extra: 1 },
+      }),
+    ).toThrow();
+  });
 });

--- a/packages/flowlet-core/src/manifest/tool.test.ts
+++ b/packages/flowlet-core/src/manifest/tool.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { manifestToolSchema } from "./tool";
+
+const listInvoices = {
+  name: "listInvoices",
+  description: "List the user's invoices, newest first.",
+  inputSchema: { type: "object", properties: { limit: { type: "number" } } },
+  annotations: { mutating: false, dangerous: false },
+  binding: { type: "http", method: "GET", path: "/api/invoices" },
+};
+
+describe("manifestToolSchema", () => {
+  it("accepts a read-only http tool", () => {
+    expect(() => manifestToolSchema.parse(listInvoices)).not.toThrow();
+  });
+
+  it("accepts a mutating+dangerous tool with a templated path", () => {
+    expect(() =>
+      manifestToolSchema.parse({
+        ...listInvoices,
+        name: "cancelInvoice",
+        annotations: { mutating: true, dangerous: true, idempotent: true },
+        binding: { type: "http", method: "POST", path: "/api/invoices/{id}/cancel" },
+      }),
+    ).not.toThrow();
+  });
+
+  it("requires annotations — no unsound defaults", () => {
+    const { annotations: _a, ...rest } = listInvoices;
+    expect(() => manifestToolSchema.parse(rest)).toThrow();
+  });
+
+  it("rejects unknown binding types and bad names", () => {
+    expect(() =>
+      manifestToolSchema.parse({ ...listInvoices, binding: { type: "grpc" } }),
+    ).toThrow();
+    expect(() => manifestToolSchema.parse({ ...listInvoices, name: "1bad name" })).toThrow();
+  });
+});

--- a/packages/flowlet-core/src/manifest/tool.ts
+++ b/packages/flowlet-core/src/manifest/tool.ts
@@ -4,6 +4,10 @@ import { z } from "zod";
  * A JSON Schema document, kept opaque. Tool inputs and event payloads are
  * declared as JSON Schema in the manifest (the wire format); zod is the
  * in-process representation and the ai SDK converts at the model boundary.
+ *
+ * Deliberately NOT meta-schema-validated here: the registry validates nested
+ * documents against the JSON Schema meta-schema at publish time (ENG-197/198),
+ * where a real validator is already loaded. The contract keeps them opaque.
  */
 export const jsonSchemaDocument = z.record(z.unknown());
 export type JsonSchemaDocument = Record<string, unknown>;
@@ -16,15 +20,17 @@ export type JsonSchemaDocument = Record<string, unknown>;
  * `readOnlyHint = !mutating`, `destructiveHint = dangerous`,
  * `idempotentHint = idempotent`.
  */
-export const manifestToolAnnotationsSchema = z.object({
-  /** Writes host state. `false` = safe to call freely (read-only). */
-  mutating: z.boolean(),
-  /** Danger-gated: policy emits an approval card (interactive) or requires
-   *  pre-authorized scopes / async approval (automations). */
-  dangerous: z.boolean(),
-  /** Optional: repeat calls with the same input are safe. */
-  idempotent: z.boolean().optional(),
-});
+export const manifestToolAnnotationsSchema = z
+  .object({
+    /** Writes host state. `false` = safe to call freely (read-only). */
+    mutating: z.boolean(),
+    /** Danger-gated: policy emits an approval card (interactive) or requires
+     *  pre-authorized scopes / async approval (automations). */
+    dangerous: z.boolean(),
+    /** Optional: repeat calls with the same input are safe. */
+    idempotent: z.boolean().optional(),
+  })
+  .strict();
 export type ManifestToolAnnotations = z.infer<typeof manifestToolAnnotationsSchema>;
 
 /**
@@ -33,12 +39,16 @@ export type ManifestToolAnnotations = z.infer<typeof manifestToolAnnotationsSche
  * ENG-197 extractor targets). Path segments in `{braces}` are template
  * parameters filled from the tool input by name.
  */
-export const httpBindingSchema = z.object({
-  type: z.literal("http"),
-  method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]),
-  /** Host-relative path template, e.g. `/api/invoices/{id}/cancel`. */
-  path: z.string().min(1),
-});
+export const httpBindingSchema = z
+  .object({
+    type: z.literal("http"),
+    method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]),
+    /** Host-relative path template, e.g. `/api/invoices/{id}/cancel`. Must start
+     *  with a single `/` (no scheme, no `//authority`) and contain no whitespace —
+     *  a manifest path can never point a client executor at a foreign origin. */
+    path: z.string().regex(/^\/(?!\/)\S*$/),
+  })
+  .strict();
 export const manifestToolBindingSchema = z.discriminatedUnion("type", [httpBindingSchema]);
 export type ManifestToolBinding = z.infer<typeof manifestToolBindingSchema>;
 
@@ -47,14 +57,16 @@ export type ManifestToolBinding = z.infer<typeof manifestToolBindingSchema>;
  * a host-API surface exposed to the agent as a tool. Developer-editable;
  * `flowlet publish` validates against this schema before upload.
  */
-export const manifestToolSchema = z.object({
-  /** Tool-call identifier presented to the model. */
-  name: z.string().regex(/^[a-zA-Z][a-zA-Z0-9_-]*$/),
-  /** Drives LLM tool selection — same role as component descriptions. */
-  description: z.string().min(1),
-  /** JSON Schema for the tool input. */
-  inputSchema: jsonSchemaDocument,
-  annotations: manifestToolAnnotationsSchema,
-  binding: manifestToolBindingSchema,
-});
+export const manifestToolSchema = z
+  .object({
+    /** Tool-call identifier presented to the model. */
+    name: z.string().regex(/^[a-zA-Z][a-zA-Z0-9_-]*$/),
+    /** Drives LLM tool selection — same role as component descriptions. */
+    description: z.string().min(1),
+    /** JSON Schema for the tool input. */
+    inputSchema: jsonSchemaDocument,
+    annotations: manifestToolAnnotationsSchema,
+    binding: manifestToolBindingSchema,
+  })
+  .strict();
 export type ManifestTool = z.infer<typeof manifestToolSchema>;

--- a/packages/flowlet-core/src/manifest/tool.ts
+++ b/packages/flowlet-core/src/manifest/tool.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+/**
+ * A JSON Schema document, kept opaque. Tool inputs and event payloads are
+ * declared as JSON Schema in the manifest (the wire format); zod is the
+ * in-process representation and the ai SDK converts at the model boundary.
+ */
+export const jsonSchemaDocument = z.record(z.unknown());
+export type JsonSchemaDocument = Record<string, unknown>;
+
+/**
+ * Safety annotations, REQUIRED on every manifest tool (architecture Decision 3).
+ * Policy reads definite values — a tool with unknown safety cannot be published.
+ *
+ * MCP mapping (for ingestion into runtime tool descriptors):
+ * `readOnlyHint = !mutating`, `destructiveHint = dangerous`,
+ * `idempotentHint = idempotent`.
+ */
+export const manifestToolAnnotationsSchema = z.object({
+  /** Writes host state. `false` = safe to call freely (read-only). */
+  mutating: z.boolean(),
+  /** Danger-gated: policy emits an approval card (interactive) or requires
+   *  pre-authorized scopes / async approval (automations). */
+  dangerous: z.boolean(),
+  /** Optional: repeat calls with the same input are safe. */
+  idempotent: z.boolean().optional(),
+});
+export type ManifestToolAnnotations = z.infer<typeof manifestToolAnnotationsSchema>;
+
+/**
+ * How a tool call physically reaches the host API. `http` is the only binding
+ * frozen now; the discriminated union is the extension point (trpc, graphql —
+ * ENG-197 extractor targets). Path segments in `{braces}` are template
+ * parameters filled from the tool input by name.
+ */
+export const httpBindingSchema = z.object({
+  type: z.literal("http"),
+  method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]),
+  /** Host-relative path template, e.g. `/api/invoices/{id}/cancel`. */
+  path: z.string().min(1),
+});
+export const manifestToolBindingSchema = z.discriminatedUnion("type", [httpBindingSchema]);
+export type ManifestToolBinding = z.infer<typeof manifestToolBindingSchema>;
+
+/**
+ * One entry in `tools.json` (dev-tool artifact 3 of 3, architecture Decision 3):
+ * a host-API surface exposed to the agent as a tool. Developer-editable;
+ * `flowlet publish` validates against this schema before upload.
+ */
+export const manifestToolSchema = z.object({
+  /** Tool-call identifier presented to the model. */
+  name: z.string().regex(/^[a-zA-Z][a-zA-Z0-9_-]*$/),
+  /** Drives LLM tool selection — same role as component descriptions. */
+  description: z.string().min(1),
+  /** JSON Schema for the tool input. */
+  inputSchema: jsonSchemaDocument,
+  annotations: manifestToolAnnotationsSchema,
+  binding: manifestToolBindingSchema,
+});
+export type ManifestTool = z.infer<typeof manifestToolSchema>;

--- a/packages/flowlet-core/src/seams/channels.ts
+++ b/packages/flowlet-core/src/seams/channels.ts
@@ -1,0 +1,28 @@
+import type { Principal } from "./principal";
+
+/**
+ * Channels seam — reaching the user off-thread (Decision 1).
+ *
+ * | Deployment | Implementation |
+ * |---|---|
+ * | Embedded | in-app only |
+ * | Cloud | in-app now; SMS (ENG-191) and voice (ENG-185) later |
+ *
+ * Message-shaped delivery only. Realtime voice is a session, not a message —
+ * it gets its own contract at ENG-185 time and is deliberately NOT squeezed
+ * into `deliver`.
+ */
+export interface Channels {
+  deliver(message: OutboundMessage): Promise<void>;
+}
+
+export type ChannelKind = "in-app" | "sms";
+
+export interface OutboundMessage {
+  channel: ChannelKind;
+  principal: Principal;
+  /** Plain-text body; in-app surfaces may upgrade rendering later. */
+  text: string;
+  /** Thread to attach in-app deliveries to; ignored by SMS. */
+  threadId?: string;
+}

--- a/packages/flowlet-core/src/seams/credential-broker.ts
+++ b/packages/flowlet-core/src/seams/credential-broker.ts
@@ -1,0 +1,45 @@
+import type { Principal } from "./principal";
+
+/**
+ * CredentialBroker seam — how a tool call gets user identity (Decisions 1/4).
+ *
+ * | Deployment | Implementation |
+ * |---|---|
+ * | Embedded | host session, in-process; `authenticate` is a pass-through, `acquireGrant` returns the ambient identity |
+ * | Cloud | vouch JWT verification at session init + RFC 8693-shaped token exchange for automations |
+ *
+ * Interactive host-API calls need NO credential from this seam at all — the
+ * browser executes them on the user's existing session (Decision 2). The
+ * broker covers the other two credential lifetimes: session identity and the
+ * short-lived brokered grant automations run under.
+ */
+export interface CredentialBroker {
+  /**
+   * Turn the SDK-presented credential into a verified Principal at session
+   * init. Cloud: the vouch JWT string. Embedded: whatever the host passes
+   * in-process (opaque here).
+   */
+  authenticate(credential: unknown): Promise<Principal>;
+
+  /**
+   * Exchange a signed assertion for a short-lived scoped user token, held only
+   * for one automation run. Revocation lives on the host side. Only required
+   * once a tenant enables automations.
+   */
+  acquireGrant(request: GrantRequest): Promise<BrokeredGrant>;
+}
+
+export interface GrantRequest {
+  principal: Principal;
+  automationId: string;
+  /** Scopes pre-authorized at automation creation (Decision 4). */
+  scopes: string[];
+}
+
+export interface BrokeredGrant {
+  /** Bearer token for host-API calls during this run. Never persisted. */
+  token: string;
+  /** ISO 8601 expiry; the run must not outlive it without re-exchange. */
+  expiresAt: string;
+  scopes: string[];
+}

--- a/packages/flowlet-core/src/seams/executor.ts
+++ b/packages/flowlet-core/src/seams/executor.ts
@@ -12,7 +12,7 @@ import type { Principal } from "./principal";
  *
  * The runtime selects an executor per tool call; the policy layer has already
  * evaluated the call before it reaches any executor. Non-streaming by design:
- * a tool call resolves to one outcome (mirrors `ActionResult`).
+ * a tool call resolves to one outcome.
  */
 export interface Executor {
   execute(call: ToolCallRequest, context: ExecutionContext): Promise<ToolCallOutcome>;
@@ -32,6 +32,8 @@ export interface ExecutionContext {
   signal?: AbortSignal;
 }
 
+/** Discriminated on `ok` so narrowing never depends on the truthiness of an
+ *  `unknown` result (a legitimate `result: undefined` must not read as error). */
 export type ToolCallOutcome =
-  | { result: unknown }
-  | { error: { code: string; message: string } };
+  | { ok: true; result: unknown }
+  | { ok: false; error: { code: string; message: string } };

--- a/packages/flowlet-core/src/seams/executor.ts
+++ b/packages/flowlet-core/src/seams/executor.ts
@@ -1,0 +1,37 @@
+import type { BrokeredGrant } from "./credential-broker";
+import type { Principal } from "./principal";
+
+/**
+ * Executor seam — where a tool call physically runs (Decisions 1/2).
+ *
+ * | Deployment | Implementation |
+ * |---|---|
+ * | Embedded | in-process against the host backend |
+ * | Cloud, interactive | client executor: the call streams to the SDK, the browser fetches the host API on the user's session, the result returns via the ai SDK client-tool round trip |
+ * | Cloud, automation | server executor in the worker, authorized by a BrokeredGrant |
+ *
+ * The runtime selects an executor per tool call; the policy layer has already
+ * evaluated the call before it reaches any executor. Non-streaming by design:
+ * a tool call resolves to one outcome (mirrors `ActionResult`).
+ */
+export interface Executor {
+  execute(call: ToolCallRequest, context: ExecutionContext): Promise<ToolCallOutcome>;
+}
+
+export interface ToolCallRequest {
+  /** ai SDK tool-call id — links outcome, approval, and audit entries. */
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+}
+
+export interface ExecutionContext {
+  principal: Principal;
+  /** Present only on server-executed automation runs. */
+  grant?: BrokeredGrant;
+  signal?: AbortSignal;
+}
+
+export type ToolCallOutcome =
+  | { result: unknown }
+  | { error: { code: string; message: string } };

--- a/packages/flowlet-core/src/seams/index.ts
+++ b/packages/flowlet-core/src/seams/index.ts
@@ -1,0 +1,6 @@
+export * from "./principal";
+export * from "./store";
+export * from "./credential-broker";
+export * from "./executor";
+export * from "./scheduler";
+export * from "./channels";

--- a/packages/flowlet-core/src/seams/principal.ts
+++ b/packages/flowlet-core/src/seams/principal.ts
@@ -1,0 +1,14 @@
+/**
+ * The verified identity every seam operation is scoped to.
+ * - Embedded: derived in-process from the host session (tenant is implicit;
+ *   embedded hosts may use a fixed tenantId).
+ * - Cloud: derived from the vouch JWT at session init (Decision 4); users are
+ *   unique per (tenant, subject), no PII beyond the vouch claims.
+ */
+export interface Principal {
+  tenantId: string;
+  /** The host's stable user identifier (the vouch `sub`). */
+  subject: string;
+  /** Vouch claims passed through verbatim (roles, plan, etc.). */
+  claims?: Record<string, unknown>;
+}

--- a/packages/flowlet-core/src/seams/scheduler.ts
+++ b/packages/flowlet-core/src/seams/scheduler.ts
@@ -10,9 +10,12 @@
  * (signed host webhooks, Composio triggers) are ingest paths that invoke the
  * same firing handler directly — they don't pass through the Scheduler.
  */
+import type { Principal } from "./principal";
+
 export interface Scheduler {
-  /** Register (or replace) the durable schedule for an automation. */
-  schedule(automationId: string, trigger: TimeTrigger): Promise<void>;
+  /** Register (or replace) the durable schedule for an automation. The scope
+   *  is persisted with the schedule and replayed on every firing. */
+  schedule(automationId: string, trigger: TimeTrigger, scope: Principal): Promise<void>;
   cancel(automationId: string): Promise<void>;
   /** The runtime registers exactly one firing handler at startup. */
   onFire(handler: (firing: AutomationFiring) => Promise<void>): void;
@@ -24,5 +27,9 @@ export type TimeTrigger =
 
 export interface AutomationFiring {
   automationId: string;
+  /** The scope the automation was scheduled under — the handler needs it to
+   *  load the record (Store is Principal-scoped) and to acquire the brokered
+   *  grant for the run. */
+  principal: Principal;
   firedAt: string;
 }

--- a/packages/flowlet-core/src/seams/scheduler.ts
+++ b/packages/flowlet-core/src/seams/scheduler.ts
@@ -1,0 +1,28 @@
+/**
+ * Scheduler seam — firing automations when the user is away (Decisions 1/5).
+ *
+ * | Deployment | Implementation |
+ * |---|---|
+ * | Embedded | none, or host cron invoking the handler |
+ * | Cloud | pg-boss worker in apps/cloud |
+ *
+ * This seam owns TIME-based triggers only. The other two trigger sources
+ * (signed host webhooks, Composio triggers) are ingest paths that invoke the
+ * same firing handler directly — they don't pass through the Scheduler.
+ */
+export interface Scheduler {
+  /** Register (or replace) the durable schedule for an automation. */
+  schedule(automationId: string, trigger: TimeTrigger): Promise<void>;
+  cancel(automationId: string): Promise<void>;
+  /** The runtime registers exactly one firing handler at startup. */
+  onFire(handler: (firing: AutomationFiring) => Promise<void>): void;
+}
+
+export type TimeTrigger =
+  | { kind: "cron"; expression: string; timezone?: string }
+  | { kind: "at"; at: string };
+
+export interface AutomationFiring {
+  automationId: string;
+  firedAt: string;
+}

--- a/packages/flowlet-core/src/seams/seams.test.ts
+++ b/packages/flowlet-core/src/seams/seams.test.ts
@@ -26,13 +26,23 @@ function makeStore(): Store {
     getMessages: async () => [],
   };
   const flowlets: SavedFlowletStore = {
-    save: async (_scope, f) => ({ ...f, id: "f1" }),
+    save: async (_scope, f) => ({
+      ...f,
+      id: "f1",
+      createdAt: "2026-07-01T00:00:00Z",
+      updatedAt: "2026-07-01T00:00:00Z",
+    }),
     get: async () => undefined,
     list: async () => [],
     delete: async () => {},
   };
   const automations: AutomationStore = {
-    save: async (_scope, a) => ({ ...a, id: "a1" }),
+    save: async (_scope, a) => ({
+      ...a,
+      id: "a1",
+      createdAt: "2026-07-01T00:00:00Z",
+      updatedAt: "2026-07-01T00:00:00Z",
+    }),
     get: async () => undefined,
     list: async () => [],
     recordRun: async () => {},
@@ -47,6 +57,16 @@ describe("seam interfaces are implementable in-memory", () => {
     const store = makeStore();
     const t = await store.threads.create(principal, { title: "hi" });
     expect(t.tenantId).toBe("t1");
+    // The store owns identity AND timestamps — callers never supply either.
+    const f = await store.flowlets.save(principal, {
+      name: "My invoices",
+      pinned: false,
+      uiTree: { id: "n1", kind: "generated", payload: {} },
+      query: { toolName: "listInvoices", input: {} },
+      originatingPrompt: "show my invoices",
+    });
+    expect(f.id).toBe("f1");
+    expect(f.createdAt).toBeTruthy();
   });
 
   it("CredentialBroker", async () => {
@@ -67,21 +87,24 @@ describe("seam interfaces are implementable in-memory", () => {
 
   it("Executor", async () => {
     const executor: Executor = {
-      execute: async (call) => ({ result: { echoed: call.input } }),
+      execute: async (call) => ({ ok: true, result: { echoed: call.input } }),
     };
     const out = await executor.execute(
       { toolCallId: "c1", toolName: "listInvoices", input: { limit: 1 } },
       { principal },
     );
-    expect("result" in out).toBe(true);
+    expect(out.ok).toBe(true);
+    if (out.ok) expect(out.result).toEqual({ echoed: { limit: 1 } });
   });
 
   it("Scheduler", async () => {
-    const fired: string[] = [];
-    let handler: ((f: { automationId: string; firedAt: string }) => Promise<void>) | undefined;
+    const fired: Array<{ automationId: string; subject: string }> = [];
+    let handler:
+      | ((f: { automationId: string; principal: Principal; firedAt: string }) => Promise<void>)
+      | undefined;
     const scheduler: Scheduler = {
-      schedule: async (id) => {
-        await handler?.({ automationId: id, firedAt: "2026-07-01T00:00:00Z" });
+      schedule: async (id, _trigger, scope) => {
+        await handler?.({ automationId: id, principal: scope, firedAt: "2026-07-01T00:00:00Z" });
       },
       cancel: async () => {},
       onFire: (h) => {
@@ -89,10 +112,10 @@ describe("seam interfaces are implementable in-memory", () => {
       },
     };
     scheduler.onFire(async (f) => {
-      fired.push(f.automationId);
+      fired.push({ automationId: f.automationId, subject: f.principal.subject });
     });
-    await scheduler.schedule("a1", { kind: "cron", expression: "0 9 * * *" });
-    expect(fired).toEqual(["a1"]);
+    await scheduler.schedule("a1", { kind: "cron", expression: "0 9 * * *" }, principal);
+    expect(fired).toEqual([{ automationId: "a1", subject: "u1" }]);
   });
 
   it("Channels", async () => {

--- a/packages/flowlet-core/src/seams/seams.test.ts
+++ b/packages/flowlet-core/src/seams/seams.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import type { CredentialBroker } from "./credential-broker";
+import type { Executor } from "./executor";
+import type { Principal } from "./principal";
+import type { Scheduler } from "./scheduler";
+import type { Channels } from "./channels";
+import type { Store, ThreadStore, SavedFlowletStore, AutomationStore, AuditLog } from "./store";
+
+const principal: Principal = { tenantId: "t1", subject: "u1" };
+
+// Minimal in-memory implementations: the embedded/CI guarantee in miniature.
+// If these can't be written without a database or HTTP server, the seam is wrong.
+function makeStore(): Store {
+  const threads: ThreadStore = {
+    create: async (scope, init) => ({
+      id: "th1",
+      tenantId: scope.tenantId,
+      subject: scope.subject,
+      title: init?.title,
+      createdAt: "2026-07-01T00:00:00Z",
+      updatedAt: "2026-07-01T00:00:00Z",
+    }),
+    get: async () => undefined,
+    list: async () => [],
+    appendMessages: async () => {},
+    getMessages: async () => [],
+  };
+  const flowlets: SavedFlowletStore = {
+    save: async (_scope, f) => ({ ...f, id: "f1" }),
+    get: async () => undefined,
+    list: async () => [],
+    delete: async () => {},
+  };
+  const automations: AutomationStore = {
+    save: async (_scope, a) => ({ ...a, id: "a1" }),
+    get: async () => undefined,
+    list: async () => [],
+    recordRun: async () => {},
+    listRuns: async () => [],
+  };
+  const audit: AuditLog = { append: async () => {} };
+  return { threads, flowlets, automations, audit };
+}
+
+describe("seam interfaces are implementable in-memory", () => {
+  it("Store", async () => {
+    const store = makeStore();
+    const t = await store.threads.create(principal, { title: "hi" });
+    expect(t.tenantId).toBe("t1");
+  });
+
+  it("CredentialBroker", async () => {
+    const broker: CredentialBroker = {
+      authenticate: async () => principal,
+      acquireGrant: async (req) => ({
+        token: "grant",
+        expiresAt: "2026-07-01T00:05:00Z",
+        scopes: req.scopes,
+      }),
+    };
+    expect((await broker.authenticate("host-session")).subject).toBe("u1");
+    expect(
+      (await broker.acquireGrant({ principal, automationId: "a1", scopes: ["invoices:read"] }))
+        .scopes,
+    ).toEqual(["invoices:read"]);
+  });
+
+  it("Executor", async () => {
+    const executor: Executor = {
+      execute: async (call) => ({ result: { echoed: call.input } }),
+    };
+    const out = await executor.execute(
+      { toolCallId: "c1", toolName: "listInvoices", input: { limit: 1 } },
+      { principal },
+    );
+    expect("result" in out).toBe(true);
+  });
+
+  it("Scheduler", async () => {
+    const fired: string[] = [];
+    let handler: ((f: { automationId: string; firedAt: string }) => Promise<void>) | undefined;
+    const scheduler: Scheduler = {
+      schedule: async (id) => {
+        await handler?.({ automationId: id, firedAt: "2026-07-01T00:00:00Z" });
+      },
+      cancel: async () => {},
+      onFire: (h) => {
+        handler = h;
+      },
+    };
+    scheduler.onFire(async (f) => {
+      fired.push(f.automationId);
+    });
+    await scheduler.schedule("a1", { kind: "cron", expression: "0 9 * * *" });
+    expect(fired).toEqual(["a1"]);
+  });
+
+  it("Channels", async () => {
+    const sent: string[] = [];
+    const channels: Channels = {
+      deliver: async (msg) => {
+        sent.push(msg.channel);
+      },
+    };
+    await channels.deliver({ channel: "in-app", principal, text: "done" });
+    expect(sent).toEqual(["in-app"]);
+  });
+});

--- a/packages/flowlet-core/src/seams/store.ts
+++ b/packages/flowlet-core/src/seams/store.ts
@@ -1,0 +1,122 @@
+import type { FlowletUIMessage } from "../protocol";
+import type { UINode } from "../ui";
+import type { Principal } from "./principal";
+
+/**
+ * Store seam — threads, saved flowlets, automations, audit (Decision 1/6).
+ *
+ * | Deployment | Implementation |
+ * |---|---|
+ * | Embedded | host's choice; in-memory or SQLite in CI (demo-bank) |
+ * | Cloud | Postgres in apps/cloud, all access behind this seam |
+ *
+ * All operations are scoped by Principal (tenant + subject); embedded
+ * implementations may ignore tenantId. Timestamps are ISO 8601 strings.
+ *
+ * Memory (ENG-189) is deliberately NOT here yet: the architecture reserves a
+ * Store concern and a context-assembly injection point, defined when that work
+ * starts. Adding a `memory` member later is an additive change to this seam.
+ */
+export interface Store {
+  threads: ThreadStore;
+  flowlets: SavedFlowletStore;
+  automations: AutomationStore;
+  audit: AuditLog;
+}
+
+export interface ThreadRecord {
+  id: string;
+  tenantId: string;
+  subject: string;
+  title?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Persisted UIMessage streams (replaces the demo's in-memory route state). */
+export interface ThreadStore {
+  create(scope: Principal, init?: { title?: string }): Promise<ThreadRecord>;
+  get(scope: Principal, threadId: string): Promise<ThreadRecord | undefined>;
+  list(scope: Principal): Promise<ThreadRecord[]>;
+  appendMessages(scope: Principal, threadId: string, messages: FlowletUIMessage[]): Promise<void>;
+  getMessages(scope: Principal, threadId: string): Promise<FlowletUIMessage[]>;
+}
+
+/**
+ * A saved flowlet (ENG-183, Decision 6): declarative UI tree + bound data
+ * query + originating prompt. Reopening re-renders the tree and re-runs the
+ * query through the normal tool path (policy applies).
+ */
+export interface SavedFlowlet {
+  id: string;
+  name: string;
+  pinned: boolean;
+  uiTree: UINode;
+  /** Re-executed via the Executor on reopen — never a raw DB query. */
+  query: { toolName: string; input: unknown };
+  originatingPrompt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SavedFlowletStore {
+  save(scope: Principal, flowlet: Omit<SavedFlowlet, "id">): Promise<SavedFlowlet>;
+  get(scope: Principal, id: string): Promise<SavedFlowlet | undefined>;
+  list(scope: Principal): Promise<SavedFlowlet[]>;
+  delete(scope: Principal, id: string): Promise<void>;
+}
+
+/**
+ * Automation records. The spec DSL is deliberately opaque here (`spec:
+ * unknown`) — its shape is decided at ENG-188's brainstorm (Decision 5). This
+ * store freezes only what every design needs: identity, lifecycle, run history.
+ */
+export interface AutomationRecord {
+  id: string;
+  name: string;
+  status: "enabled" | "paused";
+  /** The compiled automation spec — interpreted JSON step graph or agent goal.
+   *  Opaque until ENG-188 freezes the DSL. */
+  spec: unknown;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AutomationRun {
+  id: string;
+  automationId: string;
+  startedAt: string;
+  finishedAt?: string;
+  status: "running" | "succeeded" | "failed";
+  error?: string;
+}
+
+export interface AutomationStore {
+  save(scope: Principal, automation: Omit<AutomationRecord, "id">): Promise<AutomationRecord>;
+  get(scope: Principal, id: string): Promise<AutomationRecord | undefined>;
+  list(scope: Principal): Promise<AutomationRecord[]>;
+  recordRun(scope: Principal, run: AutomationRun): Promise<void>;
+  listRuns(scope: Principal, automationId: string): Promise<AutomationRun[]>;
+}
+
+/**
+ * Append-only audit record of every tool execution, approval, grant exchange,
+ * and automation firing (Decision 6). Written from day 1; ENG-194 is UI over it.
+ */
+export type AuditEvent = { at: string; principal: Principal } & (
+  | {
+      kind: "tool_execution";
+      toolName: string;
+      toolCallId: string;
+      mutating: boolean;
+      dangerous: boolean;
+      outcome: "ok" | "error";
+    }
+  | { kind: "approval"; toolCallId: string; decision: "approved" | "denied" }
+  | { kind: "grant_exchange"; automationId: string; scopes: string[] }
+  | { kind: "automation_firing"; automationId: string; runId: string }
+);
+
+export interface AuditLog {
+  append(event: AuditEvent): Promise<void>;
+}

--- a/packages/flowlet-core/src/seams/store.ts
+++ b/packages/flowlet-core/src/seams/store.ts
@@ -60,7 +60,12 @@ export interface SavedFlowlet {
 }
 
 export interface SavedFlowletStore {
-  save(scope: Principal, flowlet: Omit<SavedFlowlet, "id">): Promise<SavedFlowlet>;
+  /** The store assigns `id` and both timestamps — callers never supply them
+   *  (same authorship rule as `ThreadStore.create`). */
+  save(
+    scope: Principal,
+    flowlet: Omit<SavedFlowlet, "id" | "createdAt" | "updatedAt">,
+  ): Promise<SavedFlowlet>;
   get(scope: Principal, id: string): Promise<SavedFlowlet | undefined>;
   list(scope: Principal): Promise<SavedFlowlet[]>;
   delete(scope: Principal, id: string): Promise<void>;
@@ -92,7 +97,11 @@ export interface AutomationRun {
 }
 
 export interface AutomationStore {
-  save(scope: Principal, automation: Omit<AutomationRecord, "id">): Promise<AutomationRecord>;
+  /** The store assigns `id` and both timestamps — callers never supply them. */
+  save(
+    scope: Principal,
+    automation: Omit<AutomationRecord, "id" | "createdAt" | "updatedAt">,
+  ): Promise<AutomationRecord>;
   get(scope: Principal, id: string): Promise<AutomationRecord | undefined>;
   list(scope: Principal): Promise<AutomationRecord[]>;
   recordRun(scope: Principal, run: AutomationRun): Promise<void>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,12 +382,21 @@ importers:
         specifier: ^3.24.0
         version: 3.25.76
     devDependencies:
+      ajv:
+        specifier: ^8.17.0
+        version: 8.20.0
+      tsx:
+        specifier: ^4.19.0
+        version: 4.22.4
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
       vitest:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@20.19.43)(jsdom@29.1.1)(lightningcss@1.32.0)
+      zod-to-json-schema:
+        specifier: ^3.24.0
+        version: 3.25.2(zod@3.25.76)
 
   packages/flowlet-react:
     dependencies:
@@ -806,9 +815,21 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -818,9 +839,21 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -830,9 +863,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -842,9 +887,21 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -854,9 +911,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -866,9 +935,21 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -878,9 +959,21 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -890,9 +983,21 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -902,11 +1007,35 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
@@ -914,9 +1043,27 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -926,15 +1073,33 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -2446,6 +2611,9 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2900,6 +3068,11 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -3074,6 +3247,9 @@ packages:
 
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3520,6 +3696,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -4590,6 +4769,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   turbo@2.10.1:
     resolution: {integrity: sha512-z9WGX2bAfElLOri8JY6pcwr+GfS18B5iGefLcvv3nwM9MoE/fPQQhpgZKTRlBciqGSDuLnfNyfP+eji8mEapQA==}
     hasBin: true
@@ -5264,70 +5448,148 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
@@ -7079,6 +7341,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
@@ -7618,6 +7887,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -7862,6 +8160,8 @@ snapshots:
   fast-levenshtein@2.0.6: {}
 
   fast-sha256@1.3.0: {}
+
+  fast-uri@3.1.3: {}
 
   fastq@1.20.1:
     dependencies:
@@ -8382,6 +8682,8 @@ snapshots:
       ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-schema@0.4.0: {}
 
@@ -9835,6 +10137,12 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   turbo@2.10.1:
     optionalDependencies:


### PR DESCRIPTION
Implements sequencing step 2 of the [platform architecture](docs/superpowers/specs/2026-07-01-flowlet-platform-architecture-design.md) (Decisions 1, 3, 6): the frozen contracts the parallel tracks (ENG-197/198/202/188) build against. **Additive only** — no refactors, no runtime carve-out, `flowlet-agent` untouched (ENG-202 works there in parallel).

## What's frozen

**Manifest schema** (`packages/flowlet-core/src/manifest/`, docs in [docs/contracts/manifest.md](docs/contracts/manifest.md)):
- `theme.json` — structurally identical to `BrandTokens` v1; a conformance test in flowlet-components fails CI on divergence
- `tools.json` — tool descriptors with **required** `{mutating, dangerous}` annotations (MCP hint mapping documented) and a minimal `http` binding (discriminated union = extension point), plus host event declarations for automation triggers
- component entries (JSON image of `PrewiredDescriptor`), the published-manifest unit, and `ManifestRef` (immutable registry rows; sessions bind to a ref)
- Language-neutral JSON Schema artifacts in `packages/flowlet-core/schemas/`, generated from the zod source (`pnpm generate:schemas`); a sync test fails CI on drift, ajv-validated

**Five seam interfaces** (`packages/flowlet-core/src/seams/`, docs in [docs/contracts/seams.md](docs/contracts/seams.md)): Store, CredentialBroker, Executor, Scheduler, Channels — embedded-vs-cloud mapping from the architecture table captured in TSDoc, plus an in-memory stub test (the embedded/CI guarantee in miniature).

## Deliberately deferred

- Automation `spec` is `unknown` at the Store seam — ENG-188 owns the DSL (its JSONata step-graph decisions are intentionally NOT imported here)
- No `memory` member on Store until ENG-189 (additive later)
- Realtime voice excluded from `Channels.deliver` — its own contract at ENG-185
- Query/body parameter mapping in http bindings — convention until a real case demands it

## Review trail

All 13 open contract points were reviewed mid-flight by Yousef and locked (every recommendation accepted): [docs/superpowers/specs/2026-07-01-contracts-freeze-open-questions.md](docs/superpowers/specs/2026-07-01-contracts-freeze-open-questions.md).

## Verification

`pnpm build` (10/10), `pnpm typecheck` (15/15), `pnpm test` (13/13 tasks; 27 new tests) all pass. Pre-existing, untouched: `pnpm lint` fails after a fresh build because demo-bank's eslint lints the generated gitignored sandbox bundle; test files are excluded from tsc typecheck repo-wide (6 latent errors in `genui/resolve.test.ts`).

No UI-affecting changes (types, schemas, docs only), so no browser screenshots.

https://claude.ai/code/session_01NL4qkwJ4NRCyEponjnAAM1