### PR TITLE
Cadence demo-day hardening: send timeout + content idempotency + runbook (fix-forward on #27)

### DIFF
--- a/apps/demo-accounting/src/flowlet/automations.test.ts
+++ b/apps/demo-accounting/src/flowlet/automations.test.ts
@@ -152,6 +152,27 @@ describe("cadence automations world — the morning document chase", () => {
     expect(events.every((e) => /^\d{4}-\d{2}-\d{2}T14:00:00$/.test(e.start_datetime))).toBe(true);
   });
 
+  it("content idempotency: a second same-day live fire does NOT double-send or double-book", async () => {
+    __reseed(new Date());
+    const gmail = vi.fn(async () => OK);
+    const calendar = vi.fn(async () => OK);
+    // Pin the clock so both fires land on the same send-day.
+    const now = () => "2026-07-02T09:00:00.000Z";
+    const world = createAutomationsWorld({ gmail, calendar, now });
+    const id = await createChase(world);
+
+    const first = await forceFire(world, id, true);
+    expect(first.run!.status).toBe("succeeded");
+    expect(gmail).toHaveBeenCalledTimes(8);
+    expect(calendar).toHaveBeenCalledTimes(2);
+
+    // Rehearsal re-fire: run still succeeds, but no NEW real sends happen.
+    const second = await forceFire(world, id, true);
+    expect(second.run!.status).toBe("succeeded");
+    expect(gmail).toHaveBeenCalledTimes(8);
+    expect(calendar).toHaveBeenCalledTimes(2);
+  });
+
   it("dry run (default): simulates the gated sends without calling Composio", async () => {
     __reseed(new Date());
     const gmail = vi.fn(async () => OK);

--- a/apps/demo-accounting/src/flowlet/automations.ts
+++ b/apps/demo-accounting/src/flowlet/automations.ts
@@ -94,6 +94,14 @@ export function createAutomationsWorld(opts: CreateWorldOptions = {}): CadenceAu
   const calendar = opts.calendar ?? realCreateCalendarEvent;
   const store = new InMemoryAutomationStore(opts.now ? { now: opts.now } : {});
 
+  // Content idempotency: a rehearsal re-fire on demo day must not double-send
+  // or double-book. Key each REAL side effect by (recipient/attendee, day) and
+  // skip a repeat. World-scoped, so a demo reset (which recreates the world)
+  // intentionally clears it and lets the next run send fresh. Keys are added
+  // only AFTER a successful send, so a failed send stays retryable.
+  const doneKeys = new Set<string>();
+  const sendDay = (): string => (opts.now ? opts.now() : new Date().toISOString()).slice(0, 10);
+
   const getDeadlines: RegisteredTool = {
     descriptor: {
       name: "get_deadlines",
@@ -143,12 +151,20 @@ export function createAutomationsWorld(opts: CreateWorldOptions = {}): CadenceAu
       body: z.string(),
     }),
     execute: async (input) => {
+      const recipient = String(input["recipient_email"]);
+      const key = `gmail:${recipient}:${sendDay()}`;
+      if (doneKeys.has(key)) {
+        return { ok: true, result: { skipped: true, reason: "already emailed today", recipient } };
+      }
       const result = await gmail({
-        recipient_email: String(input["recipient_email"]),
+        recipient_email: recipient,
         subject: String(input["subject"]),
         body: String(input["body"]),
       });
-      if (result.ok) return { ok: true, result };
+      if (result.ok) {
+        doneKeys.add(key);
+        return { ok: true, result };
+      }
       return {
         ok: false,
         error: { code: "gmail_error", message: result.error ?? "Gmail send failed" },
@@ -195,6 +211,15 @@ export function createAutomationsWorld(opts: CreateWorldOptions = {}): CadenceAu
       timezone: z.string().optional(),
     }),
     execute: async (input) => {
+      // Dedup by (attendee-or-summary, event day) so a re-fire the same day
+      // does not book a second identical event.
+      const attendees = Array.isArray(input["attendees"]) ? (input["attendees"] as string[]) : [];
+      const who = attendees.length > 0 ? attendees.join(",") : String(input["summary"]);
+      const day = String(input["start_datetime"]).slice(0, 10);
+      const key = `cal:${who}:${day}`;
+      if (doneKeys.has(key)) {
+        return { ok: true, result: { skipped: true, reason: "already booked", who, day } };
+      }
       const result = await calendar({
         summary: String(input["summary"]),
         ...(input["description"] !== undefined ? { description: String(input["description"]) } : {}),
@@ -208,7 +233,10 @@ export function createAutomationsWorld(opts: CreateWorldOptions = {}): CadenceAu
         ...(Array.isArray(input["attendees"]) ? { attendees: input["attendees"] as string[] } : {}),
         ...(input["timezone"] !== undefined ? { timezone: String(input["timezone"]) } : {}),
       });
-      if (result.ok) return { ok: true, result };
+      if (result.ok) {
+        doneKeys.add(key);
+        return { ok: true, result };
+      }
       return {
         ok: false,
         error: { code: "calendar_error", message: result.error ?? "Calendar booking failed" },

--- a/apps/demo-accounting/src/flowlet/composio-fire.timeout.test.ts
+++ b/apps/demo-accounting/src/flowlet/composio-fire.timeout.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sendGmail, createCalendarEvent } from "./composio-fire";
+
+const priorKey = process.env.COMPOSIO_API_KEY;
+
+beforeEach(() => {
+  process.env.COMPOSIO_API_KEY = "test-key";
+});
+afterEach(() => {
+  if (priorKey === undefined) delete process.env.COMPOSIO_API_KEY;
+  else process.env.COMPOSIO_API_KEY = priorKey;
+});
+
+/** A fetch that never responds until the request's AbortSignal fires — the
+ *  real "Gmail stalled mid-send" shape. Real fetch rejects with an AbortError
+ *  when its signal aborts, so we mirror that. */
+const stallFetch: typeof fetch = ((_url: unknown, init?: { signal?: AbortSignal }) =>
+  new Promise((_resolve, reject) => {
+    const signal = init?.signal;
+    if (!signal) return; // would hang — but the executor always passes one
+    signal.addEventListener("abort", () =>
+      reject(new DOMException("The operation was aborted", "AbortError")),
+    );
+  })) as unknown as typeof fetch;
+
+describe("composio executor stall protection", () => {
+  it("a stalled Gmail send FAILS LOUD as a timeout, not a hang", async () => {
+    const result = await sendGmail(
+      { recipient_email: "yousef+rivera@vendo.run", subject: "s", body: "b" },
+      { fetchImpl: stallFetch, timeoutMs: 25 },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/timed out/i);
+  });
+
+  it("a stalled Calendar create also times out", async () => {
+    const result = await createCalendarEvent(
+      { summary: "s", start_datetime: "2026-07-02T14:00:00" },
+      { fetchImpl: stallFetch, timeoutMs: 25 },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/timed out/i);
+  });
+
+  it("a fast success still returns ok (timeout does not fire)", async () => {
+    const okFetch: typeof fetch = (async () =>
+      new Response(JSON.stringify({ successful: true, data: { id: "x" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch;
+    const result = await sendGmail(
+      { recipient_email: "yousef+rivera@vendo.run", subject: "s", body: "b" },
+      { fetchImpl: okFetch, timeoutMs: 25 },
+    );
+    expect(result.ok).toBe(true);
+  });
+});

--- a/apps/demo-accounting/src/flowlet/composio-fire.ts
+++ b/apps/demo-accounting/src/flowlet/composio-fire.ts
@@ -11,11 +11,22 @@ import { DEMO_USER_ID } from "./principal";
 
 const COMPOSIO_API = "https://backend.composio.dev/api/v3";
 
+/** Hard ceiling on a single real send. If Gmail/Calendar stalls mid-send on
+ *  demo day, this makes the run FAIL LOUD into run history instead of leaving
+ *  the stage spinning forever (post-merge Opus review, PR #27). */
+const SEND_TIMEOUT_MS = 15_000;
+
 export interface ComposioFireResult {
   ok: boolean;
   /** The Composio response payload (or error detail) for run-history display. */
   detail: unknown;
   error?: string;
+}
+
+/** Injectable knobs for tests (a stalling fetch, a short timeout). */
+export interface ExecuteOptions {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
 }
 
 /** The wire-format args the executor sends, exposed for tests. */
@@ -42,14 +53,22 @@ export function calendarArgs(input: CalendarCreateInput): Record<string, unknown
 async function executeComposio(
   slug: string,
   args: Record<string, unknown>,
+  opts: ExecuteOptions = {},
 ): Promise<ComposioFireResult> {
   const apiKey = process.env.COMPOSIO_API_KEY;
   if (!apiKey) return { ok: false, detail: null, error: "COMPOSIO_API_KEY not set" };
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const timeoutMs = opts.timeoutMs ?? SEND_TIMEOUT_MS;
+  // Abort the send if it stalls past the ceiling — a hung fetch would spin the
+  // stage forever with no error otherwise.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const res = await fetch(`${COMPOSIO_API}/tools/execute/${slug}`, {
+    const res = await fetchImpl(`${COMPOSIO_API}/tools/execute/${slug}`, {
       method: "POST",
       headers: { "x-api-key": apiKey, "content-type": "application/json" },
       body: JSON.stringify({ user_id: DEMO_USER_ID, arguments: args }),
+      signal: controller.signal,
     });
     const json = (await res.json().catch(() => ({}))) as {
       successful?: boolean;
@@ -59,7 +78,15 @@ async function executeComposio(
     if (json.successful) return { ok: true, detail: json.data ?? null };
     return { ok: false, detail: json.data ?? null, error: json.error ?? `HTTP ${res.status}` };
   } catch (e) {
+    // The timeout aborts the signal, so fetch rejects with an AbortError —
+    // surface it as an explicit timeout so run history reads "timed out",
+    // never a bare AbortError or a silent hang.
+    if (controller.signal.aborted) {
+      return { ok: false, detail: null, error: `Composio ${slug} timed out after ${timeoutMs}ms` };
+    }
     return { ok: false, detail: null, error: String(e) };
+  } finally {
+    clearTimeout(timer);
   }
 }
 
@@ -69,12 +96,19 @@ export interface GmailSendInput {
   body: string;
 }
 
-export function sendGmail(input: GmailSendInput): Promise<ComposioFireResult> {
-  return executeComposio("GMAIL_SEND_EMAIL", {
-    recipient_email: input.recipient_email,
-    subject: input.subject,
-    body: input.body,
-  });
+export function sendGmail(
+  input: GmailSendInput,
+  opts?: ExecuteOptions,
+): Promise<ComposioFireResult> {
+  return executeComposio(
+    "GMAIL_SEND_EMAIL",
+    {
+      recipient_email: input.recipient_email,
+      subject: input.subject,
+      body: input.body,
+    },
+    opts,
+  );
 }
 
 export interface CalendarCreateInput {
@@ -89,8 +123,11 @@ export interface CalendarCreateInput {
   timezone?: string;
 }
 
-export function createCalendarEvent(input: CalendarCreateInput): Promise<ComposioFireResult> {
-  return executeComposio("GOOGLECALENDAR_CREATE_EVENT", calendarArgs(input));
+export function createCalendarEvent(
+  input: CalendarCreateInput,
+  opts?: ExecuteOptions,
+): Promise<ComposioFireResult> {
+  return executeComposio("GOOGLECALENDAR_CREATE_EVENT", calendarArgs(input), opts);
 }
 
 /** Injectable seams so the automations world is testable offline. */

--- a/docs/superpowers/CADENCE-DEMO-RUNBOOK.md
+++ b/docs/superpowers/CADENCE-DEMO-RUNBOOK.md
@@ -1,0 +1,135 @@
+# Morning Document Chase — Cadence Demo Runbook
+
+Everything to run the Flowlet × Cadence beat on stage, reset it, and recover if
+it misbehaves. The beat: the user asks Vendo (the embedded Flowlet agent) to
+set up a standing automation in plain English; it compiles an inspectable
+AutomationCard; one approval, one force-fire, and **real** emails go out and
+**real** calendar events get booked.
+
+## Start
+
+```bash
+pnpm demo:accounting
+```
+
+(= `infisical run --projectId=b366cac7-1716-47a0-9617-f335500f6dee --env=dev -- pnpm --filter demo-accounting dev`)
+
+Open **http://localhost:3000**. Secrets come from Infisical (`dev`):
+`ANTHROPIC_API_KEY`, `COMPOSIO_API_KEY`. No keys are committed. Model:
+`claude-sonnet-4-6` (override with `FLOWLET_DEMO_MODEL`).
+
+Three Flowlet surfaces are live:
+- **Vendo page** — "Vendo" in the left sidebar (`/assistant`): the full agent page.
+- **Cmd/Ctrl+K overlay** — summon the same agent over any page.
+- **Dashboard slot** — the "Design a view" card at the bottom of the dashboard.
+
+Gmail + Google Calendar show connected in the composer's connect tray (2
+connected). There is no on-screen connect flow — they are the firm's standing
+integrations, pre-authorized for the Composio subject `flowlet-demo`.
+
+## Before you walk on stage — reset + reseed
+
+Press **Cmd/Ctrl+Shift+.** (period) anywhere. This restores the seeded firm and
+reloads to a clean thread. **Reseeding is what keeps the deadlines in-window:**
+the seed anchors deadlines to *today*, so Rivera lands 2 days out and Chen 3
+days out — both inside the automation's 3-day window, both still missing
+documents. If you demo without reseeding after the app has been up a while,
+those two deadlines are still relative to the boot date, which is fine same-day
+but drifts across days. **Reseed right before you demo.**
+
+Reset also recreates the automations world (any automation you built is gone)
+and clears the same-day send-dedup (see Idempotency below), so the next run
+sends fresh.
+
+## The beat, on stage
+
+1. Open the **Vendo** page (or Cmd/Ctrl+K). Type verbatim — it is also a
+   suggestion chip:
+
+   > every morning, email any clients missing docs. If anyone is within 3 days of a deadline, book a call with them on my calendar
+
+2. Vendo compiles it into an **AutomationCard**: trigger `0 8 * * *`
+   (America/Los_Angeles), a `get_deadlines` read, a `for_each` that emails every
+   `missing_docs` client, a `for_each` that books a call for anyone
+   `daysUntilDeadline <= 3`, and grants for the two sends. Read it aloud — the
+   whole point is that it is inspectable — then **Approve automation**.
+
+3. To fire it now instead of waiting for 8 AM, type:
+
+   > run it now for real
+
+   Approve the run-now card (it is itself approval-gated). You get **8 real
+   chase emails** (to `yousef+<client>@vendo.run`, so they land in your own
+   inbox) and **2 real calendar events** (Rivera, Chen), plus a rendered run
+   history.
+
+### Dry-run gotcha — the #1 thing to know
+
+`run_automation_now` **defaults to a dry run** (mutating tools are simulated,
+nothing real is sent). The agent only fires live when the user is explicit.
+**If a run shows no real sends, that's the dry run** — just re-ask:
+
+> run it live, actually send them
+
+Have that phrase ready. Saying "for real" / "actually send" in the prompt is
+what flips `live: true`.
+
+## Timing gotcha — the 8 AM cron
+
+The automation's real trigger is `0 8 * * *` America/Los_Angeles. The scheduler
+is driven by a client heartbeat (`POST /api/flowlet/tick` every ~30s). **If the
+wall clock crosses 8:00 AM PT while the app is running with an approved
+automation, it can fire on its own** — sending the real emails/events
+unprompted. For a controlled stage demo, either demo away from ~8 AM PT, or
+reset (which drops the automation) between takes so nothing is armed when you
+are not looking.
+
+## Idempotency — safe to rehearse
+
+Each real send is deduped by `(recipient, day)` for email and
+`(attendee/summary, event-day)` for calendar, world-scoped. So **a second
+force-fire the same day does not double-send or double-book** — the repeat run
+still succeeds but the sends are skipped. A reset (new world) clears the dedup
+and lets the next run send fresh. Rehearse freely; reset before the real take
+if you want the emails to actually go out again.
+
+## Stall protection
+
+Every real Composio call has a 15-second timeout (AbortController). If Gmail or
+Calendar stalls mid-send, the step **fails loud into run history** ("... timed
+out after 15000ms") instead of leaving the stage spinning. If you see a
+timeout, reset and retry — it is almost always transient.
+
+## Recover if a beat misbehaves
+
+- **No real sends** → dry run; re-ask "run it live, actually send them".
+- **"items expression did not produce an array"** → the agent mis-compiled the
+  `for_each`; it usually self-corrects if you say "keep the deterministic spec,
+  the items filter needs the `{{ }}` braces and `output.clients`". Or reset and
+  re-ask from scratch.
+- **Calendar booked but emails didn't (or vice-versa)** → check the rendered run
+  history for the failed step's error; reset and retry.
+- **403 on chat/tick** → you are not on `localhost` (or `NODE_ENV=production`
+  without the opt-in). Real Composio identity is attached only for local runs;
+  set `FLOWLET_DEMO_PUBLIC=1` to intentionally enable a deployment.
+- **Nuclear option** → Cmd/Ctrl+Shift+. to reset, reload, start clean.
+
+## What is real vs staged
+
+Real: the agent (Claude), the compiled automation, the generated UI, the run
+history, **the Gmail sends and the Calendar events** (verify in the
+`yousef@vendo.run` inbox / calendar). Staged: the firm and its clients are
+seeded fiction; client emails are plus-addressed to the demo inbox on purpose so
+live sends never reach a stranger.
+
+## Pre-flight (once, before the session)
+
+Confirm the Composio connections are live for `flowlet-demo`:
+
+```bash
+infisical run --projectId=b366cac7-1716-47a0-9617-f335500f6dee --env=dev -- \
+  node -e "const k=process.env.COMPOSIO_API_KEY;const A='https://backend.composio.dev/api/v3';(async()=>{for(const s of ['GMAIL_GET_PROFILE','GOOGLECALENDAR_LIST_CALENDARS']){const r=await(await fetch(A+'/tools/execute/'+s,{method:'POST',headers:{'x-api-key':k,'content-type':'application/json'},body:JSON.stringify({user_id:'flowlet-demo',arguments:{}})})).json();console.log(s, r.successful?'OK':'FAIL')}})()"
+```
+
+Both should print `OK`. If not, the Gmail/Calendar connection for `flowlet-demo`
+has expired — reconnect it in the Composio dashboard for that subject.


### PR DESCRIPTION
# Cadence demo-day hardening (fix-forward on #27)

Post-merge independent Opus review of #27 found **no P0** (consent, scoping, and all three surfaces verified clean) but flagged demo-day risks. This closes them.

## Changes

**P1 — send timeout (composio-fire.ts).** `executeComposio` did a bare `fetch` with no timeout: if Gmail/Calendar stalled mid-send on demo day the stage would spin forever with no error. Now wrapped in a 15s `AbortController` timeout — a stall **fails loud** into run history (`Composio <tool> timed out after 15000ms`) instead of hanging. `fetchImpl`/`timeoutMs` are injectable for tests.

**P2 — content idempotency (automations.ts).** A rehearsal re-fire the same day used to double-send / double-book. Each real side effect is now keyed by `(recipient, day)` (email) or `(attendee|summary, event-day)` (calendar), world-scoped, checked before the call and recorded only after success (so a failed send stays retryable). A second same-day force-fire **skips** the repeat — the run still succeeds. A demo reset recreates the world and clears the dedup, so the next take sends fresh.

**Runbook — `docs/superpowers/CADENCE-DEMO-RUNBOOK.md`.** Start / reset+reseed (the reseed is what keeps Rivera/Chen in the 3-day window), the beat, the **dry-run gotcha** (`run_automation_now` defaults to dry-run — re-ask "run it live" if a run shows no real sends; this is the #1 recovery), the **8 AM PT cron self-fire** warning (an armed automation can fire on its own if wall-clock crosses 8am mid-session — reset between takes), idempotency, stall protection, recovery paths, and a one-liner pre-flight Composio check.

## Verification

- 106 app tests green (new: stall→timeout, fast-success-unaffected, same-day double-fire dedup). Typecheck clean.
- **Live-exercised against real Composio** (not mocks): a real Gmail send landed (message id `19f230f8...` in SENT+INBOX), and a 1ms timeout aborted a real network call returning `Composio GMAIL_SEND_EMAIL timed out after 1ms`. The full compile→approve→force-fire→8 emails+2 events beat was verified live end-to-end in #27 on functionally identical send code; the only new paths (timeout wrapper, same-day dedup) are covered by the above and don't affect a first live fire.

No shared-package edits. Scoped entirely to `apps/demo-accounting` + docs.

https://claude.ai/code/session_0155AqKLee8x4ReR83sbgvQx
