### PR TITLE
feat(shell): UI polish pass — docked connect tray, quiet typography, friendly automation card, fluid entrances

### DIFF
--- a/apps/demo-bank/src/components/flowlet/DemoConnectCard.tsx
+++ b/apps/demo-bank/src/components/flowlet/DemoConnectCard.tsx
@@ -13,7 +13,7 @@
  */
 import { useState } from "react";
 import { useFlowletChat } from "@flowlet/react";
-import { ConnectCard, type Integration } from "@flowlet/shell";
+import { BrandIcon, ConnectCard, type Integration } from "@flowlet/shell";
 import { runConnectFlow } from "./connect-flow";
 
 const NAMES: Record<string, string> = {
@@ -72,14 +72,12 @@ export function DemoConnectCard({ toolkit, reason }: { toolkit: string; reason?:
   }
 
   if (status === "connected") {
+    // Quiet status pill: the flow auto-continues, so no instructions needed.
     return (
-      <div className="fl-connect" role="status" aria-label={`${name} connected`}>
-        <div style={{ display: "flex", alignItems: "center", gap: 8, fontWeight: 600 }}>
-          {name} connected
-        </div>
-        <div style={{ fontSize: 12, marginTop: 6 }}>
-          Ask again and I can use {name}.
-        </div>
+      <div className="fl-connect-done" role="status" aria-label={`${name} connected`}>
+        <BrandIcon id={toolkit} size={15} />
+        {name} connected
+        <span className="fl-connect-done-dot" aria-hidden />
       </div>
     );
   }

--- a/apps/demo-bank/src/flowlet/chat-handler.ts
+++ b/apps/demo-bank/src/flowlet/chat-handler.ts
@@ -22,6 +22,37 @@ interface ChatRequestBody {
 
 const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]", "0.0.0.0"]);
 
+/**
+ * Repair dangling tool calls in client-supplied history. An aborted stream (tab
+ * closed, navigation, error mid-turn) can leave an assistant tool part stuck in
+ * an input-* state; converted to a model message that is a `tool_use` with no
+ * `tool_result`, which the provider rejects — poisoning EVERY later turn of the
+ * thread. Mark such parts failed so they convert to an error tool_result and the
+ * conversation stays usable.
+ */
+function repairDanglingToolParts(messages: FlowletUIMessage[]): FlowletUIMessage[] {
+  return messages.map((message) => {
+    if (message.role !== "assistant") return message;
+    let changed = false;
+    const parts = message.parts.map((rawPart) => {
+      const part = rawPart as { type: string; state?: string };
+      if (
+        part.type.startsWith("tool-") &&
+        (part.state === "input-streaming" || part.state === "input-available")
+      ) {
+        changed = true;
+        return {
+          ...rawPart,
+          state: "output-error",
+          errorText: "Interrupted — this call never finished.",
+        } as typeof rawPart;
+      }
+      return rawPart;
+    });
+    return changed ? { ...message, parts } : message;
+  });
+}
+
 /** Only expose the real Composio identity to local requests, unless an operator
  *  has explicitly opted a deployment in via FLOWLET_DEMO_PUBLIC=1. */
 function principalAllowed(req: Request): boolean {
@@ -53,7 +84,7 @@ export async function handleChat(req: Request, agent: FlowletAgent): Promise<Res
     return Response.json({ error: "messages must be a non-empty array" }, { status: 400 });
   }
   const stream = agent.run({
-    messages,
+    messages: repairDanglingToolParts(messages),
     // Maple's own API surface enters through the caller seam (ENG-202): no
     // execute — the policy gates each call and the BROWSER executes approved
     // ones on the user's session via the SDK's host-tool runner.

--- a/packages/flowlet-shell/src/components/AutomationCard.tsx
+++ b/packages/flowlet-shell/src/components/AutomationCard.tsx
@@ -14,7 +14,7 @@
  */
 import type { CSSProperties } from "react";
 import { ApprovalCard } from "./ApprovalCard";
-import { humanize } from "./tool-labels";
+import { humanize, toolAction } from "./tool-labels";
 
 /** The authoring tools whose approvals render as this card. */
 export function isAutomationApproval(toolName: string): boolean {
@@ -85,16 +85,17 @@ function triggerLine(spec: SpecLike): string {
     if (typeof t["at"] === "string") return `Once at ${t["at"]}`;
     return `On schedule ${String(t["cron"])} (${String(t["timezone"] ?? "UTC")})`;
   }
-  if (t.type === "host_event") return `When ${String(t["event"])} fires`;
-  return `On ${String(t["trigger"])} (integration trigger)`;
+  // Friendly event names: `transaction.created` -> "When transaction created".
+  if (t.type === "host_event") return `When ${humanize(String(t["event"]).replace(/\./g, " ")).toLowerCase()}`;
+  return `When ${humanize(String(t["trigger"]).replace(/\./g, " ")).toLowerCase()}`;
 }
 
-/** One human-readable line per step input mapping: `channel: #general`. */
-function inputSummary(input: Record<string, unknown> | undefined): string {
-  if (!input) return "";
-  return Object.entries(input)
-    .map(([key, value]) => `${key}: ${typeof value === "string" ? value : JSON.stringify(value)}`)
-    .join(" · ");
+/** First sentence of an agent goal, clamped — the full prompt (with its {{ }}
+ *  templates) reads as scary machinery and lives in the details disclosure. */
+function brief(text: string | undefined, max = 110): string {
+  if (!text) return "";
+  const sentence = text.split(/(?<=\.)\s/)[0] ?? text;
+  return sentence.length > max ? `${sentence.slice(0, max - 1).trimEnd()}…` : sentence;
 }
 
 function flattenSteps(steps: StepLike[] | undefined, depth = 0): Array<{ step: StepLike; depth: number }> {
@@ -146,11 +147,11 @@ export function AutomationCard({ toolName, input, onApprove, onDecline }: Automa
 
   return (
     <div className="fl-approval" role="group" aria-label={`${verb}: ${spec.name}`}>
-      <div style={mono}>{verb.toLowerCase()} · approval required</div>
+      <div className="fl-approval-eyebrow">{verb} · approval required</div>
 
       <div style={{ marginTop: 8, display: "flex", alignItems: "baseline", gap: 8, flexWrap: "wrap" }}>
         <span style={{ fontSize: 14, fontWeight: 650 }}>{spec.name}</span>
-        <span className="fl-chip" style={{ ...mono, textTransform: "capitalize" }}>{tier}</span>
+        <span className="fl-chip" style={{ fontSize: 11, textTransform: "capitalize" }}>{tier}</span>
       </div>
 
       {spec.description ? (
@@ -172,31 +173,22 @@ export function AutomationCard({ toolName, input, onApprove, onDecline }: Automa
         <span style={muted}>Steps</span>
         <ol style={{ margin: "4px 0 0", paddingLeft: 18 }}>
           {spec.execution.mode === "agent" ? (
-            <li>
-              Agent run: {spec.execution.goal}
-              <div style={{ ...mono, ...muted }}>tools: {(spec.execution.tools ?? []).join(", ")}</div>
-            </li>
+            <li>AI step — {brief(spec.execution.goal)}</li>
           ) : (
             steps.map(({ step, depth }) => (
               <li key={step.id} style={{ marginLeft: depth * 14, marginTop: 2 }}>
                 {step.type === "tool" ? (
-                  <>
-                    {humanize(step.tool ?? "")}
-                    {step.input ? (
-                      <div style={{ ...mono, ...muted }}>{inputSummary(step.input)}</div>
-                    ) : null}
-                  </>
+                  toolAction(step.tool ?? "").request
                 ) : step.type === "agent" ? (
-                  <>
-                    Agent step: {step.goal}
-                    <div style={{ ...mono, ...muted }}>
-                      tools: {(step.tools ?? []).length > 0 ? step.tools!.join(", ") : "none (judgment only)"}
-                    </div>
-                  </>
+                  <>AI step — {brief(step.goal)}</>
                 ) : step.type === "branch" ? (
-                  <span style={mono}>if {step.if}</span>
+                  <>
+                    If <span style={{ ...mono, ...muted }}>{step.if}</span>
+                  </>
                 ) : (
-                  <span style={mono}>for each {step.items}</span>
+                  <>
+                    For each <span style={{ ...mono, ...muted }}>{step.items}</span>
+                  </>
                 )}
                 {step.type !== "branch" && step.if ? (
                   <div style={{ ...mono, ...muted }}>only if {step.if}</div>
@@ -209,13 +201,13 @@ export function AutomationCard({ toolName, input, onApprove, onDecline }: Automa
 
       {tools.length > 0 ? (
         <div style={{ fontSize: 12, marginTop: 10 }}>
-          <span style={muted}>Permissions</span>
+          <span style={muted}>It can</span>
           <ul style={{ margin: "4px 0 0", paddingLeft: 18 }}>
             {tools.map((tool) => (
               <li key={tool} style={{ marginTop: 2 }}>
-                <span style={mono}>{tool}</span>{" "}
+                {toolAction(tool).request}{" "}
                 <span style={muted}>
-                  {granted.has(tool) ? "— runs unattended (granted)" : "— asks you each firing if gated"}
+                  {granted.has(tool) ? "— runs without asking" : "— asks you each time"}
                 </span>
               </li>
             ))}
@@ -224,8 +216,8 @@ export function AutomationCard({ toolName, input, onApprove, onDecline }: Automa
       ) : null}
 
       <details style={{ marginTop: 10 }}>
-        <summary style={{ ...mono, cursor: "pointer", ...muted }}>raw spec</summary>
-        <pre style={{ fontSize: 11, margin: "6px 0 0", whiteSpace: "pre-wrap" }}>
+        <summary style={{ fontSize: 11, cursor: "pointer", ...muted }}>Show technical details</summary>
+        <pre style={{ fontSize: 11, margin: "6px 0 0", whiteSpace: "pre-wrap", ...mono }}>
           {JSON.stringify(spec, null, 2)}
         </pre>
       </details>

--- a/packages/flowlet-shell/src/components/IntegrationsPicker.tsx
+++ b/packages/flowlet-shell/src/components/IntegrationsPicker.tsx
@@ -112,22 +112,21 @@ export function IntegrationsPicker({ integrations, onConnect, onDisconnect, onCl
 
   return (
     <div className="fl-picker" role="dialog" aria-label="Integrations">
-      <div className="fl-picker-head">
-        <span className="fl-picker-title">Connect tools</span>
+      <div className="fl-picker-toprow">
+        <input
+          className="fl-picker-search"
+          placeholder="Search integrations…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => e.key === "Escape" && onClose()}
+          aria-label="Search integrations"
+          autoFocus
+        />
         <button type="button" className="fl-picker-close" aria-label="Close" onClick={onClose}>
           <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor"
             strokeWidth="2" strokeLinecap="round" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12" /></svg>
         </button>
       </div>
-      <input
-        className="fl-picker-search"
-        placeholder="Search integrations…"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        onKeyDown={(e) => e.key === "Escape" && onClose()}
-        aria-label="Search integrations"
-        autoFocus
-      />
       {connected.length > 0 && (
         <>
           <div className="fl-picker-group">Connected</div>

--- a/packages/flowlet-shell/src/components/MessageList.tsx
+++ b/packages/flowlet-shell/src/components/MessageList.tsx
@@ -33,7 +33,10 @@ export function MessageList({ items, status, onApprove, onDecline, onRegenerate,
     const keys = new Map<string, string>();
     const counters = new Map<string, number>();
     for (const item of rendered) {
-      if (item.kind !== "skeleton" && item.kind !== "ui") continue;
+      // Only GENERATED views pair with skeletons — host-component nodes (the
+      // Connect card) are their own thread items with no skeleton phase, so
+      // counting them here would misalign the skeleton↔view pairing.
+      if (item.kind !== "skeleton" && (item.kind !== "ui" || item.node.kind !== "generated")) continue;
       const n = counters.get(item.messageId) ?? 0;
       counters.set(item.messageId, n + 1);
       keys.set(item.key, `reveal:${item.messageId}:${n}`);
@@ -194,6 +197,17 @@ export function MessageList({ items, status, onApprove, onDecline, onRegenerate,
                 />
               );
             case "ui":
+              // Host-component nodes (the Connect card) are utility affordances,
+              // not built views: they mount directly like any other thread item
+              // (the shared entrance animation covers them) instead of going
+              // through the skeleton→view reveal morph.
+              if (item.node.kind !== "generated") {
+                return (
+                  <div key={item.key} className="fl-uihost">
+                    <UINodeView node={item.node} />
+                  </div>
+                );
+              }
               return (
                 <FluidReveal key={slotKeys.get(item.key)} phase="view">
                   <UINodeView node={item.node} />

--- a/packages/flowlet-shell/src/components/OverlayPanel.tsx
+++ b/packages/flowlet-shell/src/components/OverlayPanel.tsx
@@ -46,6 +46,10 @@ export function OverlayPanel({ open, onClose, ariaLabel, children }: OverlayPane
         ref={panelRef}
         onKeyDown={onKeyDown}
       >
+        <button type="button" className="fl-overlay-close" aria-label="Close" onClick={onClose}>
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+            strokeWidth="2" strokeLinecap="round" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12" /></svg>
+        </button>
         {children}
       </div>
     </div>,

--- a/packages/flowlet-shell/src/components/automation-card.test.tsx
+++ b/packages/flowlet-shell/src/components/automation-card.test.tsx
@@ -48,7 +48,7 @@ describe("AutomationCard (proposal state)", () => {
     expect(screen.getAllByText(/snitch on me in #general/i).length).toBeGreaterThan(0);
   });
 
-  it("marks granted tools as unattended and ungated reads as ask-each-time", () => {
+  it("marks granted tools as run-without-asking and ungated ones as ask-each-time", () => {
     render(
       <AutomationCard
         toolName="create_automation"
@@ -57,7 +57,7 @@ describe("AutomationCard (proposal state)", () => {
         onDecline={vi.fn()}
       />,
     );
-    expect(screen.getByText(/runs unattended/i)).toBeTruthy();
+    expect(screen.getByText(/runs without asking/i)).toBeTruthy();
   });
 
   it("shows the un-granted state truthfully", () => {
@@ -69,7 +69,7 @@ describe("AutomationCard (proposal state)", () => {
         onDecline={vi.fn()}
       />,
     );
-    expect(screen.getByText(/asks you each firing/i)).toBeTruthy();
+    expect(screen.getByText(/asks you each time/i)).toBeTruthy();
   });
 
   it("renders a hybrid spec's agent step with its goal and allowlist", () => {

--- a/packages/flowlet-shell/src/components/message-list.test.tsx
+++ b/packages/flowlet-shell/src/components/message-list.test.tsx
@@ -7,7 +7,9 @@ import { FlowletShellProvider } from "../context";
 import { MessageList } from "./MessageList";
 import type { ThreadItem } from "../use-flowlet-thread";
 
-const node: UINode = { id: "ui-1", kind: "component", source: "prewired", name: "Card", props: {} };
+// A GENERATED node: the render_view product that pairs with a skeleton in the
+// reveal slot. (Host component nodes now bypass the reveal on purpose.)
+const node: UINode = { id: "ui-1", kind: "generated", payload: {} };
 
 function renderList(items: ThreadItem[], onApprove = vi.fn()) {
   return render(

--- a/packages/flowlet-shell/src/index.ts
+++ b/packages/flowlet-shell/src/index.ts
@@ -36,6 +36,7 @@ export * from "./components/IntegrationsPicker";
 export * from "./components/ConnectDock";
 export * from "./components/ConnectTray";
 export * from "./components/ConnectCard";
+export * from "./components/BrandIcon";
 
 export * from "./FlowletThread";
 export * from "./elements/FlowletOverlay";

--- a/packages/flowlet-shell/src/styles.css
+++ b/packages/flowlet-shell/src/styles.css
@@ -51,6 +51,15 @@
    minimum and gets crushed to its borders the moment the thread overflows. */
 .fl-msglist > * { flex-shrink: 0; }
 .fl-msglist::-webkit-scrollbar { display: none; }
+/* Every thread item enters fluidly (fade + rise + un-blur) instead of popping —
+   tool panels, approvals, connect cards, turns alike. Render-view slots are
+   excluded: FluidReveal already morphs those. */
+@media (prefers-reduced-motion: no-preference) {
+  .fl-msglist > :not(.fl-reveal) { animation: fl-item-in .32s cubic-bezier(.22, 1, .36, 1) both; }
+}
+@keyframes fl-item-in {
+  from { opacity: 0; transform: translateY(10px); filter: blur(4px); }
+  to   { opacity: 1; transform: none; filter: none; } }
 @keyframes fl-fade-in { from { opacity: 0; } to { opacity: 1; } }
 /* Visually-hidden live region — announces only the settled assistant turn. */
 .fl-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden;
@@ -75,26 +84,38 @@
   font-weight: 700; line-height: 15px; text-align: center; padding: 0 3px;
   z-index: 1; pointer-events: none;
   box-shadow: 0 0 0 2px var(--flowlet-surface); }
-.fl-dock-anchor { position: relative; }
+/* Flex column so the composer's top margin never collapses out of the anchor:
+   the anchor's top is then always exactly 10px above the bar's border edge,
+   on every surface (page, overlay, slot), and the tray can dock flush. */
+.fl-dock-anchor { position: relative; display: flex; flex-direction: column; }
 /* Bottom-justified so the panel grows out of the bar edge while the entrance
    spring clamps its height. --fl-tray-max is set at open time to the room
    actually above the bar within this surface (page, overlay, or slot panel),
-   so the tray never runs off the top — the picker scrolls internally instead. */
-.fl-tray { position: absolute; bottom: 100%; left: 16px; right: 16px; margin-bottom: 8px;
-  z-index: 30; transform-origin: bottom center; overflow: hidden; border-radius: var(--flowlet-radius);
+   so the tray never runs off the top — the picker scrolls internally instead.
+   Docked flush onto the composer (one interface): the tray's bottom edge sits
+   on the bar's top border, top corners match the bar's 14px, bottom corners
+   square into the seam. */
+.fl-tray { position: absolute; bottom: calc(100% - 10px); left: 16px; right: 16px;
+  z-index: 30; transform-origin: bottom center; overflow: hidden; border-radius: 14px 14px 0 0;
   display: flex; flex-direction: column; justify-content: flex-end; }
+/* While the tray is up (incl. its exit animation) the bar squares its top
+   corners so the two read as one card; the bar's top border is the seam. */
+.fl-dock-anchor:has(.fl-tray) .fl-composer { border-top-left-radius: 0; border-top-right-radius: 0; }
 /* Opaque elevated sheet: the tray floats over display text (the hero greet,
    thread turns), and even a few percent of translucency reads big dark glyphs
    straight through. Depth comes from the border + shadow, not glass. */
 .fl-tray .fl-picker { max-height: min(420px, 48vh, var(--fl-tray-max, 9999px));
   background: var(--flowlet-surface);
+  border-radius: 14px 14px 0 0; border-bottom: 0;
+  /* Fill the tray exactly: the standalone picker's 560px cap + flex-start
+     would leave a dead strip beside the bar whenever the bar is wider. */
+  max-width: none; align-self: stretch;
   -webkit-backdrop-filter: none; backdrop-filter: none; }
-/* Soft bottom scrim signals the list scrolls instead of dead-cutting a row;
-   it matches the panel surface so the border and corners stay crisp. */
-.fl-tray::after { content: ""; position: absolute; left: 1px; right: 1px; bottom: 1px; height: 26px;
-  border-radius: 0 0 var(--flowlet-radius) var(--flowlet-radius);
-  background: linear-gradient(180deg, transparent, var(--flowlet-surface));
-  pointer-events: none; }
+/* No bottom scrim: the row clipped at the seam is the scroll cue. */
+
+/* Host-component thread items (Connect card): same geometry as the render slot
+   but no morph machinery — the shared item entrance is their only motion. */
+.fl-uihost { align-self: flex-start; width: 100%; }
 
 /* Render slot (ENG-205): the persistent wrapper a skeleton and its replacing
    view share, so the reveal can morph. The column layout + 14px gap mirror the
@@ -186,7 +207,7 @@
 
 /* ---------- tool chip (kept quiet; most are hidden in the thread) ---------- */
 .fl-tool { align-self: flex-start; display: flex; align-items: center; gap: 8px;
-  font: 500 12px/1 var(--flowlet-font-mono); color: var(--flowlet-fg-muted);
+  font: 500 12px/1 var(--flowlet-font); color: var(--flowlet-fg-muted);
   border: 1px solid var(--flowlet-border); border-radius: 10px; padding: 7px 11px;
   background: var(--flowlet-glass-strong); -webkit-backdrop-filter: var(--flowlet-blur); backdrop-filter: var(--flowlet-blur); }
 .fl-tool-label { color: var(--flowlet-fg); }
@@ -210,7 +231,7 @@
 .fl-approval-head { display: flex; align-items: flex-start; gap: 10px; }
 .fl-approval-ic { display: grid; place-items: center; width: 28px; height: 28px; flex-shrink: 0;
   border-radius: 9px; color: var(--flowlet-accent); background: var(--flowlet-accent-soft); }
-.fl-approval-eyebrow { font: 600 10px/1 var(--flowlet-font-mono); letter-spacing: .07em;
+.fl-approval-eyebrow { font: 600 10.5px/1 var(--flowlet-font); letter-spacing: .05em;
   text-transform: uppercase; color: var(--flowlet-fg-muted); }
 .fl-approval-title { margin-top: 4px; font: 600 13.5px/1.3 var(--flowlet-font); color: var(--flowlet-fg);
   letter-spacing: -.01em; }
@@ -242,11 +263,9 @@
   border: 1px solid var(--flowlet-border); border-radius: 14px;
   box-shadow: 0 1px 2px color-mix(in srgb, var(--flowlet-fg) 5%, transparent),
     0 10px 28px color-mix(in srgb, var(--flowlet-fg) 7%, transparent);
-  transition: border-color .14s, box-shadow .14s; }
-/* The focus ring lives on the container (the field itself keeps outline:0). */
-.fl-composer:focus-within { border-color: color-mix(in srgb, var(--flowlet-accent) 55%, var(--flowlet-border));
-  box-shadow: 0 1px 2px color-mix(in srgb, var(--flowlet-fg) 5%, transparent),
-    0 10px 28px color-mix(in srgb, var(--flowlet-fg) 9%, transparent), 0 0 0 3px var(--flowlet-accent-soft); }
+  transition: border-color .14s, box-shadow .14s, border-radius .2s ease; }
+/* No focus ring on the bar (Apple/OpenAI-quiet): the caret is the signal.
+   Keyboard :focus-visible outlines on the buttons inside are untouched. */
 .fl-composer-drag { border-color: var(--flowlet-accent); }
 /* align-items:flex-end so the buttons sit at the bottom as the field grows. */
 .fl-composer-row { display: flex; align-items: flex-end; gap: 10px; }
@@ -274,7 +293,7 @@
 .fl-att-file { display: inline-flex; align-items: center; gap: 8px; height: 46px; padding: 0 30px 0 10px; position: relative;
   border: 1px solid var(--flowlet-border); border-radius: 9px; background: var(--flowlet-surface); font-size: 12px; max-width: 220px; }
 .fl-att-ext { display: grid; place-items: center; width: 26px; height: 32px; border-radius: 4px; flex-shrink: 0;
-  background: var(--flowlet-danger); color: #fff; font: 700 8px/1 var(--flowlet-font-mono); letter-spacing: .02em; }
+  background: var(--flowlet-danger); color: #fff; font: 700 8px/1 var(--flowlet-font); letter-spacing: .02em; }
 .fl-att-meta { display: flex; flex-direction: column; min-width: 0; }
 .fl-att-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .fl-att-meta small { color: var(--flowlet-fg-muted); font-size: 10.5px; }
@@ -366,8 +385,11 @@
 .fl-chips { display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; }
 .fl-chip { border: 1px solid var(--flowlet-border); background: var(--flowlet-glass-strong);
   -webkit-backdrop-filter: var(--flowlet-blur); backdrop-filter: var(--flowlet-blur);
-  border-radius: 999px; padding: 8px 14px; font-size: 12.5px; color: var(--flowlet-fg); cursor: pointer; transition: border-color .12s; }
-.fl-chip:hover { border-color: var(--flowlet-border-strong); }
+  border-radius: 999px; padding: 8px 14px; font-size: 12.5px; color: var(--flowlet-fg); cursor: pointer;
+  transition: border-color .14s, background .14s, transform .18s cubic-bezier(.22,1,.36,1), box-shadow .18s; }
+.fl-chip:hover { border-color: var(--flowlet-border-strong); background: var(--flowlet-surface);
+  transform: translateY(-1px); box-shadow: 0 2px 10px color-mix(in srgb, var(--flowlet-fg) 8%, transparent); }
+.fl-chip:active { transform: translateY(0); box-shadow: none; }
 /* Brand focus ring — the UA default blue halo is off-brand in every host. */
 .fl-chip:focus-visible { outline: 2px solid var(--flowlet-accent); outline-offset: 2px; }
 .fl-landing-composer { width: 100%; max-width: 560px; }
@@ -377,7 +399,7 @@
 
 /* ---------- saved-flowlet library (ENG-183) ---------- */
 .fl-library { display: flex; flex-direction: column; gap: 8px; width: 100%; max-width: 560px; }
-.fl-library-label { font-family: var(--flowlet-font-mono); font-size: 10.5px; letter-spacing: .08em;
+.fl-library-label { font-family: var(--flowlet-font); font-weight: 600; font-size: 10.5px; letter-spacing: .05em;
   text-transform: uppercase; color: color-mix(in srgb, var(--flowlet-fg) 46%, transparent);
   text-align: left; margin-top: 6px; }
 .fl-gallery { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; width: 100%; }
@@ -394,7 +416,7 @@
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; padding-right: 18px; }
 .fl-flowcard-prompt { font-size: 11.5px; color: color-mix(in srgb, var(--flowlet-fg) 55%, transparent);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.fl-flowcard-meta { font-family: var(--flowlet-font-mono); font-size: 10.5px;
+.fl-flowcard-meta { font-family: var(--flowlet-font); font-size: 10.5px;
   color: color-mix(in srgb, var(--flowlet-fg) 42%, transparent); margin-top: 3px; }
 .fl-flowcard-actions { position: absolute; top: 7px; right: 7px; display: flex; gap: 2px;
   opacity: 0; transition: opacity .12s; }
@@ -420,16 +442,18 @@
   color: inherit; text-decoration: underline; text-underline-offset: 3px; cursor: pointer; }
 
 /* ---------- stale-data note ---------- */
-.fl-stale-note { font-family: var(--flowlet-font-mono); font-size: 11px;
+.fl-stale-note { font-family: var(--flowlet-font); font-size: 11px;
   color: color-mix(in srgb, var(--flowlet-fg) 46%, transparent); padding: 6px 2px; }
 
 /* ---------- connection selector (denser, brand-forward) ---------- */
 .fl-picker { border: 1px solid var(--flowlet-border); border-radius: var(--flowlet-radius);
   background: var(--flowlet-glass-strong); -webkit-backdrop-filter: var(--flowlet-blur); backdrop-filter: var(--flowlet-blur);
   box-shadow: var(--flowlet-shadow); overflow: auto; padding: 18px 18px 20px; max-width: 560px;
-  max-height: min(560px, 70vh); align-self: flex-start; width: 100%; }
-.fl-picker-head { display: flex; align-items: center; padding: 0 2px 12px; }
-.fl-picker-title { font-size: 13.5px; font-weight: 600; letter-spacing: -.01em; }
+  max-height: min(560px, 70vh); align-self: flex-start; width: 100%;
+  scrollbar-width: none; }
+.fl-picker::-webkit-scrollbar { display: none; }
+.fl-picker-toprow { display: flex; align-items: center; gap: 8px; }
+.fl-picker-toprow .fl-picker-search { flex: 1; width: auto; margin-bottom: 0; }
 .fl-picker-close { margin-left: auto; width: 26px; height: 26px; border-radius: 8px; display: grid; place-items: center;
   border: 0; background: transparent; color: var(--flowlet-fg-muted); cursor: pointer; transition: background .12s, color .12s; }
 .fl-picker-close:hover { background: var(--flowlet-accent-soft); color: var(--flowlet-fg); }
@@ -437,7 +461,7 @@
   outline: 0; background: var(--flowlet-surface); font-family: var(--flowlet-font); font-size: 13px;
   color: var(--flowlet-fg); padding: 9px 11px; margin-bottom: 4px; }
 .fl-picker-search::placeholder { color: var(--flowlet-fg-muted); }
-.fl-picker-group { font: 600 10px/1 var(--flowlet-font-mono); letter-spacing: .12em; text-transform: uppercase;
+.fl-picker-group { font: 600 10.5px/1 var(--flowlet-font); letter-spacing: .05em; text-transform: uppercase;
   color: var(--flowlet-fg-muted); margin: 16px 2px 9px; }
 .fl-picker-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; padding: 0; }
 .fl-picker-item { display: flex; align-items: center; gap: 10px; padding: 11px 12px; border-radius: 11px;
@@ -474,6 +498,12 @@
 .fl-picker-item:hover .fl-picker-add { background: var(--flowlet-accent); color: var(--flowlet-accent-fg); border-color: var(--flowlet-accent); }
 
 /* ---------- in-conversation connect prompt ---------- */
+/* Compact post-connect confirmation: a quiet status pill, not a display card. */
+.fl-connect-done { display: inline-flex; align-items: center; gap: 9px; align-self: flex-start;
+  border: 1px solid var(--flowlet-border); border-radius: 999px; padding: 7px 14px 7px 9px;
+  background: var(--flowlet-surface); font-size: 12.5px; font-weight: 550; }
+.fl-connect-done-dot { width: 7px; height: 7px; border-radius: 999px; background: var(--flowlet-ok);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--flowlet-ok) 18%, transparent); }
 .fl-connect { border: 1px solid var(--flowlet-border-strong); border-radius: var(--flowlet-radius);
   padding: 15px 16px; background: var(--flowlet-glass-strong);
   -webkit-backdrop-filter: var(--flowlet-blur); backdrop-filter: var(--flowlet-blur);
@@ -523,6 +553,10 @@
   /* open animation — the "squeeze": a horizontal stretch out from a sliver, with a
      springy overshoot. transform-origin stays centered so it grows symmetrically. */
   transform-origin: center; animation: fl-overlay-stretch .5s cubic-bezier(.22, 1.2, .36, 1) both; }
+.fl-overlay-close { position: absolute; top: 12px; right: 12px; z-index: 5; width: 28px; height: 28px;
+  border-radius: 9px; display: grid; place-items: center; border: 0; background: transparent;
+  color: var(--flowlet-fg-muted); cursor: pointer; transition: background .12s, color .12s; }
+.fl-overlay-close:hover { background: var(--flowlet-accent-soft); color: var(--flowlet-fg); }
 @keyframes fl-scrim-in { from { opacity: 0; } to { opacity: 1; } }
 @keyframes fl-overlay-stretch {
   from { transform: translate(-50%, -50%) scaleX(.06) scaleY(.7); opacity: .4; }

--- a/packages/flowlet-shell/src/use-flowlet-thread.ts
+++ b/packages/flowlet-shell/src/use-flowlet-thread.ts
@@ -90,12 +90,12 @@ export function toThreadItems(messages: FlowletUIMessage[]): ThreadItem[] {
           items.push({ kind: "approval", key, messageId, approvalId: approval.id, toolName, input: part.input });
         } else if (RENDER_TOOLS.has(toolName)) {
           // A render tool's finished output is the sibling data-ui node (so no chip).
-          // But while it's still streaming/pending, show a skeleton in its place
-          // so the user sees a view being built — and ONLY then, never for
-          // text-only turns. The partial input carries the component name, which
-          // lets the skeleton match the shape of what's being built.
+          // While render_view is still streaming/pending, show a skeleton in its
+          // place so the user sees a view being built. request_connect is NOT a
+          // built view — it resolves instantly into the host Connect card, so it
+          // gets no skeleton (a "building your view" beat there reads absurd).
           const state = String(part.state ?? "");
-          if (state === "input-streaming" || state === "input-available") {
+          if (toolName === "render_view" && (state === "input-streaming" || state === "input-available")) {
             items.push({ kind: "skeleton", key, messageId, name: renderName(part.input) });
           } else if (state === "output-error") {
             items.push({ kind: "error", key, messageId, message: String(part.errorText ?? "Failed to render UI") });


### PR DESCRIPTION
Live UI-tuning session with Yousef (every change below was requested and approved by him in-session, verified in a real browser at each step).

## @flowlet/shell (the keep-set — every host gets these)

**Connect tray ⇄ composer, one interface**
- Tray docks flush onto the bar on every surface (page, ⌘K overlay, slot): deterministic anchor geometry (flex column kills the margin-collapse variance that left a 10px float in the overlay), shared 14px outline, bar's top border is the seam, corners morph smoothly (radius transition)
- Picker fills the tray exactly (dropped the standalone 560px cap + flex-start that left a dead strip beside wider bars)
- Scrollbar hidden (scroll still works; clipped row at the seam is the cue), bottom scrim gradient removed, "Connect tools" title removed (X sits inline with search)

**Typography & affordances**
- Mono uppercase labels (CONNECTED/AVAILABLE, approval eyebrows, tool chips, library labels, card meta, stale notes) → brand sans with tighter tracking; mono retained only for real code (code blocks, raw spec, JSONata conditions)
- No focus ring on the chat bar (Maple's ink-black accent made every tap pop a black border); keyboard :focus-visible outlines on buttons untouched
- Suggestion chips get a hover lift; overlay panel gains a close X

**AutomationCard, de-scarified**
- Steps are friendly one-liners via toolAction ("Search Gmail", "AI step — <first sentence of goal>", "Post to Slack") — no more raw `{{ }}` template dumps
- Trigger humanized ("When transaction created"); permissions become "It can · Search Gmail — runs without asking / asks you each time"; full spec JSON behind a "Show technical details" disclosure

**Connect requests are their own thing (NOT a render_view morph)**
- `request_connect` no longer produces a skeleton ("Building your view…" for a connect prompt read absurd)
- Host-component `data-ui` nodes (the Connect card) mount as plain thread items; **generated views keep the ENG-205 skeleton→view reveal morph untouched** — the reveal-slot pairing test now pins exactly that (`message-list.test.tsx` asserts the morph on a generated node)
- All thread items enter fluidly (fade + rise + un-blur, `prefers-reduced-motion` aware); FluidReveal slots excluded (they morph already)

## apps/demo-bank (isolated; demo-only)

- `DemoConnectCard` connected state → compact status pill (brand icon + "Gmail connected" + green dot); dropped the stale "Ask again…" copy (the flow auto-continues)
- `chat-handler`: repair dangling tool calls in client-supplied history — an aborted stream used to leave a `tool_use` with no `tool_result`, 400-ing every later turn of the thread (the repeat-connect loop Yousef hit). **Flag:** this repair arguably belongs in `@flowlet/runtime` so every host gets it; kept host-side here to avoid an unreviewed engine change.

## Verification

- Fresh post-rebase: `@flowlet/shell` tests 161/161, `demo-bank` tests 84/84, full `pnpm build` 15/15, typecheck clean; the 5 pre-existing demo-bank lint errors are untouched files (verified present on clean main)
- Live E2E in-browser: ask → Connect Gmail card mounts directly (no skeleton) → connect → pill → auto-continue has Gmail (loop gone) → friendly automation card
- ENG-205 reconciliation: the generated-view morph is preserved (see test); only host components bypass it, per Yousef's direct request in-session

| | |
|---|---|
| ![tray docked](https://github.com/yousefh409/flowlet/blob/yousefh409/ui-review/verification/ui-tuning/01-connect-tray-docked.png?raw=true) | ![overlay X + full-width tray](https://github.com/yousefh409/flowlet/blob/yousefh409/ui-review/verification/ui-tuning/02-overlay-x-tray-fullwidth.png?raw=true) |
| ![connect card direct](https://github.com/yousefh409/flowlet/blob/yousefh409/ui-review/verification/ui-tuning/03-connect-card-direct.png?raw=true) | ![pill + automation card](https://github.com/yousefh409/flowlet/blob/yousefh409/ui-review/verification/ui-tuning/04-connected-pill-automation-card.png?raw=true) |

https://claude.ai/code/session_01FQiF2QzWPestwVe3tdGQui