### PR TITLE
fix(runtime,shell): self-review fixes for #30 — engine-level history repair, overlay focus order, keyboard focus ring

### DIFF
--- a/packages/flowlet-runtime/src/engine.test.ts
+++ b/packages/flowlet-runtime/src/engine.test.ts
@@ -316,4 +316,70 @@ describe("createFlowletAgent", () => {
 
     expect(parts.map((p) => (p as { type: string }).type)).toContain("finish");
   });
+
+  it("repairs history a stale turn would wedge: unanswered approvals become denials, aborted input-* calls are dropped", async () => {
+    // Capture the prompt the model actually receives.
+    let seenPrompt: { role: string; content: unknown }[] = [];
+    const model = new MockLanguageModelV3({
+      doStream: async ({ prompt }) => {
+        seenPrompt = prompt as typeof seenPrompt;
+        return {
+          stream: simulateReadableStream({
+            chunks: [
+              ...textChunks("t-ok", "Continuing."),
+              { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
+            ] satisfies LanguageModelV3StreamPart[],
+          }),
+        };
+      },
+    });
+    const agent = createFlowletAgent({ model, policy: allowPolicy });
+
+    const history = [
+      { id: "m1", role: "user", parts: [{ type: "text", text: "set it up" }] },
+      {
+        id: "m2",
+        role: "assistant",
+        parts: [
+          // The user typed past this approval card — no response ever recorded.
+          {
+            type: "tool-mutate_thing",
+            toolCallId: "call-stale",
+            state: "approval-requested",
+            input: { a: 1 },
+            approval: { id: "appr-1" },
+          },
+          // An aborted stream left this call with no output.
+          {
+            type: "tool-render_view",
+            toolCallId: "call-aborted",
+            state: "input-available",
+            input: { name: "Card" },
+          },
+        ],
+      },
+      { id: "m3", role: "user", parts: [{ type: "text", text: "actually just tell me a joke" }] },
+    ] as unknown as FlowletUIMessage[];
+
+    const parts = await collect(
+      agent.run({ messages: history, tools: {}, signal: new AbortController().signal }),
+    );
+
+    // The run completed rather than erroring on a dangling tool_use…
+    expect(parts.map((p) => (p as { type: string }).type)).toContain("finish");
+    // …the stale approval reached the model as a completed (denied) call…
+    const toolMessages = seenPrompt.filter((m) => m.role === "tool");
+    const results = toolMessages.flatMap((m) => m.content as { type: string; toolCallId: string }[]);
+    expect(results.some((r) => r.type === "tool-result" && r.toolCallId === "call-stale")).toBe(true);
+    // …and the aborted input-available call was dropped entirely (every
+    // tool-call in the prompt has a matching tool-result).
+    const calls = seenPrompt
+      .filter((m) => m.role === "assistant")
+      .flatMap((m) => (Array.isArray(m.content) ? m.content : []))
+      .filter((c): c is { type: string; toolCallId: string } => (c as { type?: string }).type === "tool-call");
+    for (const call of calls) {
+      expect(results.some((r) => r.type === "tool-result" && r.toolCallId === call.toolCallId)).toBe(true);
+    }
+    expect(calls.some((c) => c.toolCallId === "call-aborted")).toBe(false);
+  });
 });

--- a/packages/flowlet-runtime/src/engine.ts
+++ b/packages/flowlet-runtime/src/engine.ts
@@ -107,6 +107,48 @@ export function createFlowletAgent(config: FlowletAgentConfig): FlowletAgent {
   type Ingested = { toolset: ToolSet; descriptors: Record<string, ToolDescriptor> };
   const composioCache = new Map<string, Promise<Ingested>>();
 
+  /**
+   * Normalize client-supplied history so a stale turn can't wedge the thread.
+   * A tool part stuck at `approval-requested` with no response (the user typed
+   * past the approval card) converts to a tool_use with NO tool_result — the
+   * provider rejects that request and EVERY later turn of the thread. Treat it
+   * as declined: `output-denied` emits a valid approval-response + denied
+   * tool-result pair. (Parts stuck at input-* from an aborted stream are
+   * handled by `ignoreIncompleteToolCalls` at conversion time.)
+   */
+  function normalizeHistory(messages: FlowletUIMessage[]): FlowletUIMessage[] {
+    return messages.map((message) => {
+      if (message.role !== "assistant") return message;
+      let changed = false;
+      const parts = message.parts.map((rawPart) => {
+        const part = rawPart as {
+          type: string;
+          state?: string;
+          approval?: { id: string; approved?: boolean | null; reason?: string };
+        };
+        if (
+          part.type.startsWith("tool-") &&
+          part.state === "approval-requested" &&
+          part.approval != null &&
+          part.approval.approved == null
+        ) {
+          changed = true;
+          return {
+            ...rawPart,
+            state: "output-denied",
+            approval: {
+              ...part.approval,
+              approved: false,
+              reason: "Not approved — the user moved on without answering.",
+            },
+          } as typeof rawPart;
+        }
+        return rawPart;
+      });
+      return changed ? { ...message, parts } : message;
+    });
+  }
+
   function run(input: RunInput): ReadableStream<UIMessageChunk> {
     const ordinal = ++runCounter;
     const runId = `run-${ordinal}`;
@@ -208,7 +250,12 @@ export function createFlowletAgent(config: FlowletAgentConfig): FlowletAgent {
           model: config.model,
           system: input.system ?? config.instructions ?? DEFAULT_INSTRUCTIONS,
           tools,
-          messages: await convertToModelMessages(input.messages),
+          // `ignoreIncompleteToolCalls` drops tool parts an aborted stream left
+          // at input-streaming/input-available — without it they convert to a
+          // dangling tool_use the provider rejects on every later turn.
+          messages: await convertToModelMessages(normalizeHistory(input.messages), {
+            ignoreIncompleteToolCalls: true,
+          }),
           abortSignal: input.signal,
           stopWhen: stepCountIs(config.maxSteps ?? 8),
         });

--- a/packages/flowlet-shell/src/components/AutomationCard.tsx
+++ b/packages/flowlet-shell/src/components/AutomationCard.tsx
@@ -217,8 +217,10 @@ export function AutomationCard({ toolName, input, onApprove, onDecline }: Automa
 
       <details style={{ marginTop: 10 }}>
         <summary style={{ fontSize: 11, cursor: "pointer", ...muted }}>Show technical details</summary>
+        {/* grantedTools included: friendly labels above can collapse two tool
+            slugs onto one name, so the consent trail needs the raw grants. */}
         <pre style={{ fontSize: 11, margin: "6px 0 0", whiteSpace: "pre-wrap", ...mono }}>
-          {JSON.stringify(spec, null, 2)}
+          {JSON.stringify({ spec, grantedTools }, null, 2)}
         </pre>
       </details>
 

--- a/packages/flowlet-shell/src/components/OverlayPanel.tsx
+++ b/packages/flowlet-shell/src/components/OverlayPanel.tsx
@@ -46,11 +46,16 @@ export function OverlayPanel({ open, onClose, ariaLabel, children }: OverlayPane
         ref={panelRef}
         onKeyDown={onKeyDown}
       >
+        {children}
+        {/* AFTER the content in DOM order (absolute-positioned, so visually
+            top-right regardless): the focus trap sends initial focus to the
+            first focusable descendant, and that must stay the content — with
+            the X first, opening the overlay focused Close and Enter dismissed
+            the dialog the user just opened. */}
         <button type="button" className="fl-overlay-close" aria-label="Close" onClick={onClose}>
           <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor"
             strokeWidth="2" strokeLinecap="round" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12" /></svg>
         </button>
-        {children}
       </div>
     </div>,
     document.body,

--- a/packages/flowlet-shell/src/styles.css
+++ b/packages/flowlet-shell/src/styles.css
@@ -57,9 +57,11 @@
 @media (prefers-reduced-motion: no-preference) {
   .fl-msglist > :not(.fl-reveal) { animation: fl-item-in .32s cubic-bezier(.22, 1, .36, 1) both; }
 }
+/* Opacity+transform only — blur would force per-element rasterization, and a
+   reopened 200-item thread runs every entrance at once on first paint. */
 @keyframes fl-item-in {
-  from { opacity: 0; transform: translateY(10px); filter: blur(4px); }
-  to   { opacity: 1; transform: none; filter: none; } }
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: none; } }
 @keyframes fl-fade-in { from { opacity: 0; } to { opacity: 1; } }
 /* Visually-hidden live region — announces only the settled assistant turn. */
 .fl-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden;
@@ -264,8 +266,14 @@
   box-shadow: 0 1px 2px color-mix(in srgb, var(--flowlet-fg) 5%, transparent),
     0 10px 28px color-mix(in srgb, var(--flowlet-fg) 7%, transparent);
   transition: border-color .14s, box-shadow .14s, border-radius .2s ease; }
-/* No focus ring on the bar (Apple/OpenAI-quiet): the caret is the signal.
-   Keyboard :focus-visible outlines on the buttons inside are untouched. */
+/* No focus ring on pointer focus (Apple/OpenAI-quiet): the caret is the
+   signal. KEYBOARD focus still gets a visible ring via :focus-visible —
+   the textarea keeps outline:0, so without this rule Tab-focus would be
+   invisible on the product's primary input. */
+.fl-composer:has(:focus-visible) { border-color: var(--flowlet-border-strong);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--flowlet-fg) 5%, transparent),
+    0 10px 28px color-mix(in srgb, var(--flowlet-fg) 7%, transparent),
+    0 0 0 3px var(--flowlet-accent-soft); }
 .fl-composer-drag { border-color: var(--flowlet-accent); }
 /* align-items:flex-end so the buttons sit at the bottom as the field grows. */
 .fl-composer-row { display: flex; align-items: flex-end; gap: 10px; }


### PR DESCRIPTION
PR #30 was merged before its self-review fixes landed, so main currently carries three confirmed bugs this PR fixes (details + verification in the review comment on #30: https://github.com/yousefh409/flowlet/pull/30#issuecomment — 8-angle review, all findings verified against the ai SDK dist):

1. **Wedged-thread repair, done right and at the right altitude.** The demo-bank `repairDanglingToolParts` from #30 is reverted (it would have emitted tool_use with `undefined` input for stream-aborted calls). Replacement in `@flowlet/runtime` engine so every host gets it: `ignoreIncompleteToolCalls: true` at conversion + `normalizeHistory` converting unanswered `approval-requested` parts to `output-denied`. New engine test asserts every tool_use in the model prompt has a matching tool_result.
2. **Overlay close X no longer steals initial focus** (it was the focus trap's first focusable — Enter dismissed the dialog you just opened). Verified live: focus lands on the first suggestion chip.
3. **Composer keyboard focus ring restored** (quiet border-strong + soft halo via `:has(:focus-visible)`) — #30 had left Tab-focus invisible on the primary input.
4. Automation card disclosure includes `grantedTools`; item entrance drops the blur (rasterization jank on long reopened threads).

Verification: runtime 269/269, shell 161/161, demo-bank 84/84, full build green; overlay focus + ring verified live in the browser.

https://claude.ai/code/session_01FQiF2QzWPestwVe3tdGQui