### PR TITLE
ENG-186 hardening follow-ups: registry versioning for saved flowlets, server-side host-prop validation, prompt-catalog helper

### DIFF
--- a/apps/demo-accounting/src/app/assistant/page.tsx
+++ b/apps/demo-accounting/src/app/assistant/page.tsx
@@ -172,9 +172,16 @@ function PageSurface() {
  */
 function SavedPane({ flowlet }: { flowlet: Flowlet }) {
   const { renderNode } = useShell()
-  const { node, status, errors } = useReopenFlowlet(flowlet)
+  const { node, status, errors, drift } = useReopenFlowlet(flowlet)
+  const drifted = [...drift.missing, ...drift.changed]
   return (
     <div className="fl-saved-pane">
+      {drifted.length > 0 && (
+        <div className="fl-drift-note">
+          {drifted.join(", ")} {drifted.length === 1 ? "has" : "have"} changed in Cadence since this
+          view was saved — parts may render differently
+        </div>
+      )}
       {errors.length > 0 && status !== "live" && (
         <div className="fl-stale-note">showing saved data — live refresh unavailable</div>
       )}

--- a/apps/demo-accounting/src/components/flowlet/FlowletRoot.tsx
+++ b/apps/demo-accounting/src/components/flowlet/FlowletRoot.tsx
@@ -72,6 +72,9 @@ export function FlowletRoot({
           integrations={integrations}
           store={store}
           runQuery={runQuery}
+          // Same registry as FlowletProvider — reopened saved views diff their
+          // host-component stamp against it and surface drift (ENG-186).
+          components={[...prewiredComponents, ...cadenceHostComponents]}
           theme={{ scheme: "light" }}
           cssVars={{
             ...brandToCssVars(cadenceBrand),

--- a/apps/demo-accounting/src/flowlet/agent.ts
+++ b/apps/demo-accounting/src/flowlet/agent.ts
@@ -18,7 +18,7 @@ import {
   type ComposioClient,
 } from "@flowlet/runtime";
 import type { FlowletAgent, RegisteredComponent } from "@flowlet/core";
-import { prewiredComponents, brandToCssVars } from "@flowlet/components/descriptors";
+import { prewiredComponents, brandToCssVars, componentPromptCatalog } from "@flowlet/components/descriptors";
 import type { LanguageModel, ToolSet } from "ai";
 import { demoPolicy } from "./policy";
 import { cadenceBrand } from "./brand";
@@ -33,21 +33,8 @@ const DEMO_MODEL = process.env.FLOWLET_DEMO_MODEL ?? "claude-sonnet-4-6";
  *  Calendar are the firm's standing integrations. */
 const DEMO_TOOLKITS = ["gmail", "googlecalendar"];
 
-/** Compact "{ field, optional? }" hint from a component's zod props schema, so
- *  the model uses exact prop names (e.g. CadenceStatusBadge's `text`, not `label`). */
-function fieldHint(schema: unknown): string {
-  const shape = (schema as { shape?: Record<string, { isOptional?: () => boolean }> }).shape;
-  if (!shape) return "";
-  const parts = Object.entries(shape).map(([key, def]) =>
-    typeof def?.isOptional === "function" && def.isOptional() ? `${key}?` : key,
-  );
-  return parts.length ? `  props: { ${parts.join(", ")} }` : "";
-}
-
 function catalog(components: readonly RegisteredComponent[]): string {
-  return components
-    .map((c) => `- ${c.name}: ${c.description}${fieldHint(c.propsSchema)}`)
-    .join("\n");
+  return componentPromptCatalog([...components]);
 }
 
 function buildInstructions(): string {
@@ -212,5 +199,6 @@ export function createDemoAgent(opts: CreateDemoAgentOptions = {}): FlowletAgent
     },
     tools: opts.extraTools,
     maxSteps: 10,
+    components: [...prewiredComponents, ...cadenceHostComponents],
   });
 }

--- a/apps/demo-accounting/src/flowlet/saved-flowlets.ts
+++ b/apps/demo-accounting/src/flowlet/saved-flowlets.ts
@@ -4,7 +4,8 @@
  * The assistant page persists these through the FlowletStore seam (ENG-183).
  */
 import type { FlowletDraft, ThreadItem } from "@flowlet/shell";
-import { originatingPrompt } from "@flowlet/shell";
+import { originatingPrompt, stampHostComponents } from "@flowlet/shell";
+import { cadenceComponents } from "./components";
 
 const NAME_MAX = 48;
 
@@ -20,7 +21,15 @@ export function deriveSavedDrafts(items: ThreadItem[], knownIds: ReadonlySet<str
     const { node } = item;
     if (knownIds.has(node.id) || drafts.some((d) => d.id === node.id)) continue;
     const prompt = originatingPrompt(items, item.key);
-    drafts.push({ id: node.id, name: nameFrom(prompt, "Saved view"), node, prompt, pinned: false });
+    drafts.push({
+      id: node.id,
+      name: nameFrom(prompt, "Saved view"),
+      node,
+      prompt,
+      pinned: false,
+      // Registry-version stamp (ENG-186): reopen diffs it to surface drift.
+      components: stampHostComponents(node, cadenceComponents),
+    });
   }
   return drafts;
 }

--- a/apps/demo-bank/src/app/flowlet/page.tsx
+++ b/apps/demo-bank/src/app/flowlet/page.tsx
@@ -179,9 +179,17 @@ function PageSurface() {
  */
 function SavedPane({ flowlet }: { flowlet: Flowlet }) {
   const { renderNode } = useShell()
-  const { node, status, errors } = useReopenFlowlet(flowlet)
+  const { node, status, errors, drift } = useReopenFlowlet(flowlet)
+  const drifted = [...drift.missing, ...drift.changed]
   return (
     <div className="fl-saved-pane">
+      {/* Registry drift (ENG-186): the app's components moved since the save. */}
+      {drifted.length > 0 && (
+        <div className="fl-drift-note">
+          {drifted.join(", ")} {drifted.length === 1 ? "has" : "have"} changed in Maple since this
+          view was saved — parts may render differently
+        </div>
+      )}
       {/* Surfaced stale state (ENG-183 gate): quiet mono note when any query
           could not re-run (reads-only refusal, policy deny, network). */}
       {errors.length > 0 && status !== "live" && (

--- a/apps/demo-bank/src/components/flowlet/FlowletRoot.tsx
+++ b/apps/demo-bank/src/components/flowlet/FlowletRoot.tsx
@@ -71,6 +71,9 @@ export function FlowletRoot({
           integrations={integrations}
           store={store}
           runQuery={runQuery}
+          // Same registry as FlowletProvider — reopened saved views diff their
+          // host-component stamp against it and surface drift (ENG-186).
+          components={[...prewiredComponents, ...mapleHostComponents]}
           theme={{ scheme: "light" }}
           cssVars={{
             ...brandToCssVars(mapleBrand),

--- a/apps/demo-bank/src/flowlet/agent.ts
+++ b/apps/demo-bank/src/flowlet/agent.ts
@@ -18,7 +18,7 @@ import {
   type ComposioClient,
 } from "@flowlet/runtime";
 import type { FlowletAgent } from "@flowlet/core";
-import { prewiredComponents, brandToCssVars } from "@flowlet/components/descriptors";
+import { prewiredComponents, brandToCssVars, componentPromptCatalog } from "@flowlet/components/descriptors";
 import { mapleHostComponents } from "./host-components/descriptors";
 import type { LanguageModel, ToolSet } from "ai";
 import { demoPolicy } from "./policy";
@@ -28,29 +28,14 @@ import { demoAutomationInstructions } from "./automations";
 /** Default model — fast + capable for a live, low-latency demo. Overridable. */
 const DEMO_MODEL = process.env.FLOWLET_DEMO_MODEL ?? "claude-sonnet-4-6";
 
-/** Compact "{ field, optional? }" hint from a component's zod props schema, so
- *  the model uses exact prop names (e.g. Callout's `text`, not `body`). */
-function fieldHint(schema: unknown): string {
-  const shape = (schema as { shape?: Record<string, { isOptional?: () => boolean }> }).shape;
-  if (!shape) return "";
-  const parts = Object.entries(shape).map(([key, def]) =>
-    typeof def?.isOptional === "function" && def.isOptional() ? `${key}?` : key,
-  );
-  return parts.length ? `  props: { ${parts.join(", ")} }` : "";
-}
-
 function componentCatalog(): string {
-  return prewiredComponents
-    .map((c) => `- ${c.name}: ${c.description}${fieldHint(c.propsSchema)}`)
-    .join("\n");
+  return componentPromptCatalog(prewiredComponents);
 }
 
 /** The host app's registered components (source:'host') — data-driven from the
  *  registry, so newly registered components appear here automatically. */
 function hostComponentCatalog(): string {
-  return mapleHostComponents
-    .map((c) => `- ${c.name}: ${c.description}${fieldHint(c.propsSchema)}`)
-    .join("\n");
+  return componentPromptCatalog(mapleHostComponents);
 }
 
 function buildInstructions(): string {
@@ -223,5 +208,6 @@ export function createDemoAgent(opts: CreateDemoAgentOptions = {}): FlowletAgent
     },
     tools: opts.extraTools,
     maxSteps: 10,
+    components: [...prewiredComponents, ...mapleHostComponents],
   });
 }

--- a/apps/demo-bank/src/flowlet/saved-flowlets.ts
+++ b/apps/demo-bank/src/flowlet/saved-flowlets.ts
@@ -5,7 +5,11 @@
  * through the FlowletStore seam (ENG-183).
  */
 import type { FlowletDraft, ThreadItem } from "@flowlet/shell";
-import { originatingPrompt } from "@flowlet/shell";
+import { originatingPrompt, stampHostComponents } from "@flowlet/shell";
+import { prewiredComponents } from "@flowlet/components/descriptors";
+import { mapleHostComponents } from "./host-components/descriptors";
+
+const mapleRegistry = [...prewiredComponents, ...mapleHostComponents];
 
 const NAME_MAX = 48;
 
@@ -22,7 +26,15 @@ export function deriveSavedDrafts(items: ThreadItem[], knownIds: ReadonlySet<str
     if (node.kind === "component" && node.name === "Connect") continue; // auth card, not a view
     if (knownIds.has(node.id) || drafts.some((d) => d.id === node.id)) continue;
     const prompt = originatingPrompt(items, item.key);
-    drafts.push({ id: node.id, name: nameFrom(prompt, "Saved view"), node, prompt, pinned: false });
+    drafts.push({
+      id: node.id,
+      name: nameFrom(prompt, "Saved view"),
+      node,
+      prompt,
+      pinned: false,
+      // Registry-version stamp (ENG-186): reopen diffs it to surface drift.
+      components: stampHostComponents(node, mapleRegistry),
+    });
   }
   return drafts;
 }

--- a/apps/gmail/server/flowlet/agent.ts
+++ b/apps/gmail/server/flowlet/agent.ts
@@ -14,7 +14,7 @@ import { anthropic } from "@ai-sdk/anthropic";
 import { wrapLanguageModel } from "ai";
 import { createFlowletAgent, buildBrandGuidance } from "@flowlet/runtime";
 import type { FlowletAgent } from "@flowlet/core";
-import { prewiredComponents, brandToCssVars } from "@flowlet/components/descriptors";
+import { prewiredComponents, brandToCssVars, componentPromptCatalog } from "@flowlet/components/descriptors";
 import type { LanguageModel, ToolSet } from "ai";
 import { demoPolicy } from "./policy";
 import { jsonRepairMiddleware } from "./json-repair";
@@ -28,18 +28,7 @@ const brand = brandTokensSchema.parse(brandJson);
 
 const DEMO_MODEL = process.env.FLOWLET_DEMO_MODEL ?? "claude-sonnet-4-6";
 
-/** Compact "{ field, optional? }" hint from a component's zod props schema. */
-function fieldHint(schema: unknown): string {
-  const shape = (schema as { shape?: Record<string, { isOptional?: () => boolean }> }).shape;
-  if (!shape) return "";
-  const parts = Object.entries(shape).map(([key, def]) =>
-    typeof def?.isOptional === "function" && def.isOptional() ? `${key}?` : key,
-  );
-  return parts.length ? `  props: { ${parts.join(", ")} }` : "";
-}
-
-const catalogLines = (components: ReadonlyArray<{ name: string; description: string; propsSchema: unknown }>) =>
-  components.map((c) => `- ${c.name}: ${c.description}${fieldHint(c.propsSchema)}`).join("\n");
+const catalogLines = componentPromptCatalog;
 
 function buildInstructions(): string {
   return [
@@ -195,5 +184,6 @@ export function createDemoAgent(opts: CreateDemoAgentOptions = {}): FlowletAgent
     instructions: buildInstructions(),
     tools: opts.extraTools,
     maxSteps: 10,
+    components: [...prewiredComponents, ...gmailHostComponents],
   });
 }

--- a/apps/gmail/src/flowlet/FlowletPage.jsx
+++ b/apps/gmail/src/flowlet/FlowletPage.jsx
@@ -12,8 +12,13 @@ import {
   useShell,
   useReopenFlowlet,
   originatingPrompt,
+  stampHostComponents,
 } from "@flowlet/shell";
+import { prewiredComponents } from "@flowlet/components";
+import { gmailHostComponents } from "./host-components";
 import { FlowletRoot } from "./FlowletRoot";
+
+const registry = [...prewiredComponents, ...gmailHostComponents];
 
 const SUGGESTIONS = [
   "Turn my unread emails into Tinder: swipe left to delete, swipe right to reply for me. Swipe up to send it to my team's Slack with a quick summary.",
@@ -38,7 +43,15 @@ const deriveSavedDrafts = (items, knownIds) => {
     const { node } = item;
     if (knownIds.has(node.id) || drafts.some((d) => d.id === node.id)) continue;
     const prompt = originatingPrompt(items, item.key);
-    drafts.push({ id: node.id, name: nameFrom(prompt, "Saved view"), node, prompt, pinned: false });
+    drafts.push({
+      id: node.id,
+      name: nameFrom(prompt, "Saved view"),
+      node,
+      prompt,
+      pinned: false,
+      // Registry-version stamp (ENG-186): reopen diffs it to surface drift.
+      components: stampHostComponents(node, registry),
+    });
   }
   return drafts;
 };
@@ -177,9 +190,17 @@ function PageSurface() {
  *  read-only queries through the governed action route. */
 function SavedPane({ flowlet }) {
   const { renderNode } = useShell();
-  const { node, status, errors } = useReopenFlowlet(flowlet);
+  const { node, status, errors, drift } = useReopenFlowlet(flowlet);
+  const drifted = [...drift.missing, ...drift.changed];
   return (
     <div className="fl-saved-pane">
+      {/* Registry drift (ENG-186): the app's components moved since the save. */}
+      {drifted.length > 0 && (
+        <div className="fl-drift-note">
+          {drifted.join(", ")} {drifted.length === 1 ? "has" : "have"} changed since this view was
+          saved — parts may render differently
+        </div>
+      )}
       {errors.length > 0 && status !== "live" && (
         <div className="fl-stale-note">showing saved data — live refresh unavailable</div>
       )}

--- a/apps/gmail/src/flowlet/FlowletRoot.jsx
+++ b/apps/gmail/src/flowlet/FlowletRoot.jsx
@@ -47,6 +47,9 @@ export function FlowletRoot({ children, threadId = "gmail-demo" }) {
           renderNode={renderNode}
           store={store}
           runQuery={runQuery}
+          // Same registry as FlowletProvider — reopened saved views diff their
+          // host-component stamp against it and surface drift (ENG-186).
+          components={registry}
           theme={{ scheme: "light" }}
           cssVars={brandToCssVars(brand)}
           productName="Vendo"

--- a/docs/host-components.md
+++ b/docs/host-components.md
@@ -13,6 +13,7 @@ export const sparklineDescriptor = hostComponent(
   "MapleSparkline",                       // PascalCase; primitives' names are rejected
   "Tiny inline trend line. Use next to a stat. `data` is chronological.", // the agent READS this
   z.object({ data: z.array(z.number()).min(2) }),  // JSON-safe props only
+  { version: "1" },                       // optional; bump on BREAKING prop/behavior changes
 );
 
 export const myHostComponents = toHostRegistry([sparklineDescriptor]);
@@ -62,14 +63,24 @@ Serve the artifact as the stage's `bundleSource` (demo-bank copies it to `public
 
 ## 4. Wire the registry
 
-Pass `[...prewiredComponents, ...myHostComponents]` wherever the registry goes: the `FlowletProvider`/`FlowletStage` `components` prop (validates generated host-node props) and your agent's system prompt (list them under a HOST COMPONENTS section so the model prefers them).
+Pass `[...prewiredComponents, ...myHostComponents]` wherever the registry goes:
+
+- the `FlowletProvider`/`FlowletStage` `components` prop (validates generated host-node props);
+- the engine's `components` config (`createFlowletAgent({ components })`) so `render_view` rejects unknown names and schema-invalid host props server-side, where the model can repair them;
+- the `FlowletShellProvider` `components` prop so reopened saved views can detect registry drift (below);
+- your agent's system prompt: list them under a HOST COMPONENTS section with `componentPromptCatalog(myHostComponents)` from `@flowlet/components/descriptors` so the model prefers them and uses exact prop names.
+
+## Versioning & saved flowlets
+
+Saved flowlets (ENG-183) outlive your registry. When a view is saved, the host stamps `name → version` for every host component it uses (`stampHostComponents(node, registry)` from `@flowlet/shell`); the `version` comes from the descriptor's `{ version }` option (unset means `"1"`). On reopen, `useReopenFlowlet` diffs the stamp against the live registry and returns `drift: { missing, changed }` — renamed/removed components land in `missing`, version-bumped ones in `changed` — so the host can show a "components changed since this was saved" note (`.fl-drift-note`) instead of degrading silently. Bump `version` on breaking prop/behavior changes; pre-versioning records never warn retroactively.
 
 ## Error story
 
 - Bad registration (name/description/schema) → throws at module load, breaking the build.
-- Schema-invalid props from the model → validated twice: at genui resolution (contained placeholder) and in the adapter (inline fallback).
-- Unknown component name → a visible "Unknown component" notice in the view, per node.
+- Schema-invalid props from the model → rejected server-side in `render_view` as a correctable tool error (when the engine gets `components`), then re-validated at genui resolution (contained placeholder) and in the adapter (inline fallback).
+- Unknown component name → a correctable `render_view` error server-side; a visible "Unknown component" notice per node if one still reaches the view.
 - Adapter/render throw → per-node error boundary; siblings render.
+- Registry drift on a saved view → quiet per-view note naming the changed components (see Versioning).
 
 ## Constraints
 

--- a/docs/superpowers/specs/2026-07-02-eng186-verification.md
+++ b/docs/superpowers/specs/2026-07-02-eng186-verification.md
@@ -1,0 +1,56 @@
+# ENG-186 verification — host-component reuse hardening
+
+**Date:** 2026-07-02 · **Verifier:** eng-186-verify worktree · **Against:** main @ `0984d190`
+
+## Question
+
+Is ENG-186 ("Harden host-component reuse in generated UI") fully satisfied by the registration path that shipped with ENG-184 (PR #25: `docs/host-components.md`, `@flowlet/components` hostComponent/bindHostImpl/installFlowletHost)?
+
+## Verdict: NOT fully satisfied — 3 of 4 scope items shipped; registry versioning did not
+
+ENG-186 was found already closed as **Duplicate** in Linear (2026-07-02 02:55, no comment, no duplicate link). That closure is fine as triage — the bulk of the scope did land under ENG-184 — but one scope item is real, unshipped follow-up work.
+
+## Requirement-by-requirement
+
+### (a) Clean registration API: props schema + allowed values + agent-read docs — SATISFIED
+
+- `hostComponent(name, description, zodSchema)` + `toHostRegistry` — `packages/flowlet-components/src/host-component.ts`. Fails fast at module load on non-PascalCase, reserved-primitive, or empty-description registrations (tested in `host-component.test.ts`).
+- Allowed prop values are expressed as zod enums and read by validation — real example: `CadenceStatusBadge` `variant: z.enum(["missing","overdue","review","verified","neutral"])` in `apps/demo-accounting/src/flowlet/host-components/descriptors.ts`.
+- Agent-read docs: descriptor `description` + per-prop `.describe()` are rendered into a HOST COMPONENTS system-prompt section — `apps/demo-bank/src/flowlet/agent.ts:50-53,128-133`; same pattern in demo-accounting and gmail. Developer docs: `docs/host-components.md`.
+- Minor: the prompt section is hand-rolled per app (the doc instructs hosts to do this); no packaged helper.
+
+### (b) Validation: agent can only pass schema-conforming props; clear rejection — SATISFIED (one limitation)
+
+Three enforcement layers, all wired end-to-end and tested:
+
+1. **Server, before streaming:** `validateGeneratedPayload` structurally validates the payload and returns a correctable error string to the model — `packages/flowlet-runtime/src/render-view-tool.ts:70-73`, `packages/flowlet-core/src/genui/format.ts`.
+2. **GenUI resolution:** host-node props are validated against the descriptor's `propsSchema`; failures are replaced by a contained `[invalid props: X]` placeholder with siblings intact, and re-validated on data patches — `packages/flowlet-stage/src/genui-host.ts:42-84`, tests in `genui-host.test.ts` ("registry prop validation (B1)" suite).
+3. **Adapter:** `bindHostImpl` re-parses props (inline fallback on failure) and wraps render in a per-node error boundary — `packages/flowlet-components/src/bind-host-impl.tsx`, tested.
+
+Registry wiring verified: `FlowletProvider`/stage adapter pass the registry into `createGenUISession` (`packages/flowlet-react/src/stage-adapter.tsx:121`); demo-accounting passes `[...prewiredComponents, ...cadenceHostComponents]` at both surfaces (`FlowletRoot.tsx:58`, `SandboxStage.tsx:138`).
+
+Exercised, not just read: full `@flowlet/components` (125 tests) and `@flowlet/stage` (69 tests) suites pass on main; a throwaway test ran the **real Cadence descriptors** through the shipped path — conforming props accepted, non-allowed enum value rejected, `source:"host"` stamped, all three registration fail-fast cases throw. 4/4 passed.
+
+- Limitation: host-prop **schema** violations are not fed back to the model as a tool error — only structural payload errors are. Rejection is render-side (contained placeholder), so the "repair" half of "reject/repair" doesn't exist for descriptor-schema violations.
+
+### (c) Registry versioning so host-component changes don't break saved flowlets — MISSING
+
+- `SavedFlowlet` persists `uiTree` with **no registry-version field** — `packages/flowlet-core/src/seams/store.ts:50-60`.
+- `flowletHostPreset({ version })` stamps `__FLOWLET_BUNDLE_VERSION__` into the sandbox bundle for traceability only (`packages/flowlet-stage/src/build/preset.ts`); nothing reads it for compatibility.
+- What exists instead is graceful degradation: a renamed component renders an "Unknown component" notice; a changed schema renders the invalid-props placeholder; siblings survive. Saved flowlets don't *crash*, but they silently degrade — there is no version pin, no compat detection, no migration or "this flowlet references outdated components" surface.
+
+### (d) DX: clear errors for unknown/unavailable components — SATISFIED
+
+- Unknown name → visible per-node dashed notice `Unknown component "X"` in the sandbox — `packages/flowlet-stage/src/runtime.ts:285-298`.
+- Bad registration → throws at module load (build-time). Catalog-name collision → `installFlowletHost` throws with a rename instruction — `packages/flowlet-components/src/sandbox-install.ts:53-61`.
+- Minor: `sandbox-install.ts`'s top docstring stale-claims collisions "shadow deliberately" while the code throws; the unknown-component notice has no unit test pinning it (behavior confirmed by code read + ENG-184 audit).
+
+## Follow-up scope (concrete)
+
+1. **Registry versioning (the real gap):** stamp a registry version (or per-descriptor content hash) into `SavedFlowlet` at save time; on reopen, diff against the live registry and surface renamed/schema-changed components (warn/repair) instead of silent degradation. Additive change to the Store seam.
+2. **Model-visible schema rejection (small):** validate host-node props against the registry server-side in `render_view` (the runtime can receive the registry) so the model gets a correctable error and can repair before render.
+3. **Trivial:** fix the stale `sandbox-install.ts` docstring; add a unit test for the unknown-component notice; consider a packaged prompt-section helper (`hostComponentCatalog`) instead of per-app copies.
+
+## Linear action taken
+
+Left ENG-186 closed as Duplicate (its state when verification started); did **not** mark Done — item (c) is unshipped. Posted a verification comment on ENG-186 linking this report. Follow-up issue creation left to the orchestrator (recommend one issue for item 1, with items 2–3 as checklist lines).

--- a/docs/superpowers/specs/2026-07-02-eng186-verification.md
+++ b/docs/superpowers/specs/2026-07-02-eng186-verification.md
@@ -45,7 +45,7 @@ Exercised, not just read: full `@flowlet/components` (125 tests) and `@flowlet/s
 - Bad registration → throws at module load (build-time). Catalog-name collision → `installFlowletHost` throws with a rename instruction — `packages/flowlet-components/src/sandbox-install.ts:53-61`.
 - Minor: `sandbox-install.ts`'s top docstring stale-claims collisions "shadow deliberately" while the code throws; the unknown-component notice has no unit test pinning it (behavior confirmed by code read + ENG-184 audit).
 
-## Follow-up scope (concrete)
+## Follow-up scope (identified, then BUILT same day — see addendum)
 
 1. **Registry versioning (the real gap):** stamp a registry version (or per-descriptor content hash) into `SavedFlowlet` at save time; on reopen, diff against the live registry and surface renamed/schema-changed components (warn/repair) instead of silent degradation. Additive change to the Store seam.
 2. **Model-visible schema rejection (small):** validate host-node props against the registry server-side in `render_view` (the runtime can receive the registry) so the model gets a correctable error and can repair before render.
@@ -53,4 +53,14 @@ Exercised, not just read: full `@flowlet/components` (125 tests) and `@flowlet/s
 
 ## Linear action taken
 
-Left ENG-186 closed as Duplicate (its state when verification started); did **not** mark Done — item (c) is unshipped. Posted a verification comment on ENG-186 linking this report. Follow-up issue creation left to the orchestrator (recommend one issue for item 1, with items 2–3 as checklist lines).
+Left ENG-186 closed as Duplicate (its state when verification started); did **not** mark Done at verification time — item (c) was unshipped. ENG-186 is archived, so Linear rejects comments; this report is the record.
+
+## Addendum (same day): all three follow-ups implemented
+
+Yousef asked for the follow-ups to be built immediately. What shipped (this branch):
+
+1. **Registry versioning** — `RegisteredComponent.version?` (`flowlet-core/src/registry.ts`) + `hostComponent(..., { version })`; saved flowlets stamp host-component `name → version` at save (`stampHostComponents`, wired in all three apps' draft derivation) into the shell `Flowlet.components` field (+ parity field on core `SavedFlowlet`); `useReopenFlowlet` returns `drift: { missing, changed }` diffed against the `FlowletShellProvider` `components` registry (`flowlet-shell/src/component-drift.ts`); each app's `SavedPane` renders a quiet `.fl-drift-note` naming the drifted components. Versions are host-declared (bump on breaking change; unset = "1"); hashing zod schemas was rejected — zod v3 has no stable serialization, and an explicit version is honest about what "breaking" means. Pre-versioning records diff clean (no retroactive warnings).
+2. **Model-visible schema rejection** — `hostPropIssues(payload, registry)` in `flowlet-core/src/genui/host-props.ts` ($path bindings resolved before validation; $state-bound nodes and async schemas skipped, mirroring the stage); `render_view` returns `render_view error (host): …` per issue when the engine gets `components` (threaded via `FlowletAgentConfig.components`; all three demo agents pass their registries). Unknown host names error server-side too, listing what IS registered.
+3. **Trivia** — `sandbox-install.ts` docstring fixed; unknown-notice marker test added to `runtime.test.ts`; `componentPromptCatalog` added to `@flowlet/components/descriptors` and the three hand-rolled per-app copies deleted.
+
+**Verified:** full workspace suite green (1,125 tests incl. 19 new); typecheck green; lint green on all touched packages (5 pre-existing demo-bank errors reproduced on the clean tree, untouched files — reported, not fixed). Browser-verified in the running Cadence app: a saved view seeded with a drifted stamp shows the note (`verification/eng186-hardening/eng186-drift-note.png`), a matching stamp shows none (`eng186-no-drift.png`); the view itself renders in both cases — drift warns, never blocks.

--- a/packages/flowlet-components/src/descriptors.ts
+++ b/packages/flowlet-components/src/descriptors.ts
@@ -55,4 +55,5 @@ export { brandTokensSchema, defaultBrand, type BrandTokens } from "./theme/brand
 export { brandToCssVars } from "./theme/brand-to-css-vars";
 export { brandToChartPalette } from "./theme/brand-to-chart-palette";
 export { hostComponent, toHostRegistry, type HostComponentDescriptor } from "./host-component";
+export { componentPromptCatalog } from "./prompt-catalog";
 export { jsonValue } from "./descriptor";

--- a/packages/flowlet-components/src/host-component.test.ts
+++ b/packages/flowlet-components/src/host-component.test.ts
@@ -30,3 +30,17 @@ describe("hostComponent", () => {
     expect(() => hostComponent("Sparkline", "", schema)).toThrow(/description/);
   });
 });
+
+describe("hostComponent — registry versioning (ENG-186)", () => {
+  it("threads a declared version into the registry entry", () => {
+    const d = hostComponent("AcmeBadge", "pill", z.object({}), { version: "2" });
+    expect(d.version).toBe("2");
+    expect(d.toRegistered().version).toBe("2");
+  });
+
+  it("leaves version unset when not declared (implied '1')", () => {
+    const d = hostComponent("AcmeBadge", "pill", z.object({}));
+    expect(d.version).toBeUndefined();
+    expect(d.toRegistered().version).toBeUndefined();
+  });
+});

--- a/packages/flowlet-components/src/host-component.ts
+++ b/packages/flowlet-components/src/host-component.ts
@@ -4,8 +4,16 @@ import { RESERVED_COMPONENT_NAMES } from "@flowlet/core";
 import type { PrewiredDescriptor } from "./descriptor";
 
 /** A host component's registration metadata. Same shape as PrewiredDescriptor
- *  (React-free, safe for server code) — only the stamped `source` differs. */
-export type HostComponentDescriptor = PrewiredDescriptor;
+ *  (React-free, safe for server code) — only the stamped `source` differs,
+ *  plus an optional registry compat version (ENG-186). */
+export type HostComponentDescriptor = PrewiredDescriptor & { version?: string };
+
+export interface HostComponentOptions {
+  /** Registry compat version. Bump on a BREAKING change to the component's
+   *  props or behavior — saved flowlets stamp the version they were built
+   *  against and warn on reopen when it moved. Unset means "1". */
+  version?: string;
+}
 
 /**
  * Declare one of the HOST APP's own components for the agent's menu.
@@ -23,6 +31,7 @@ export function hostComponent(
   name: string,
   description: string,
   propsSchema: z.ZodType,
+  options: HostComponentOptions = {},
 ): HostComponentDescriptor {
   if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) {
     throw new Error(
@@ -43,11 +52,13 @@ export function hostComponent(
     name,
     description,
     propsSchema,
+    version: options.version,
     toRegistered: () => ({
       name,
       description,
       propsSchema: propsSchema as FlowletSchema<unknown>,
       source: "host",
+      ...(options.version !== undefined ? { version: options.version } : {}),
     }),
   };
 }

--- a/packages/flowlet-components/src/prompt-catalog.test.ts
+++ b/packages/flowlet-components/src/prompt-catalog.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { componentPromptCatalog } from "./prompt-catalog";
+import { hostComponent, toHostRegistry } from "./host-component";
+import { prewiredComponents } from "./descriptors";
+
+describe("componentPromptCatalog", () => {
+  const registry = toHostRegistry([
+    hostComponent(
+      "AcmeBadge",
+      "The app's own status pill.",
+      z.object({ text: z.string(), variant: z.enum(["ok", "warn"]).optional() }),
+    ),
+  ]);
+
+  it("renders one '- Name: description' line per component with a props hint", () => {
+    const catalog = componentPromptCatalog(registry);
+    expect(catalog).toBe("- AcmeBadge: The app's own status pill.  props: { text, variant? }");
+  });
+
+  it("marks optional props with '?' and required props bare", () => {
+    const catalog = componentPromptCatalog(registry);
+    expect(catalog).toContain("text, variant?");
+    expect(catalog).not.toContain("text?");
+  });
+
+  it("omits the props hint for non-object schemas instead of throwing", () => {
+    const weird = toHostRegistry([hostComponent("AcmeFree", "Anything goes.", z.unknown())]);
+    expect(componentPromptCatalog(weird)).toBe("- AcmeFree: Anything goes.");
+  });
+
+  it("works for the full prewired catalog (every line has name + description)", () => {
+    const lines = componentPromptCatalog(prewiredComponents).split("\n");
+    expect(lines).toHaveLength(prewiredComponents.length);
+    for (const line of lines) expect(line).toMatch(/^- [A-Z][A-Za-z0-9]*: .+/);
+  });
+});

--- a/packages/flowlet-components/src/prompt-catalog.ts
+++ b/packages/flowlet-components/src/prompt-catalog.ts
@@ -1,0 +1,25 @@
+import type { RegisteredComponent } from "@flowlet/core";
+
+/** Compact "{ field, optional? }" hint from a component's zod props schema, so
+ *  the model uses exact prop names (e.g. Callout's `text`, not `body`).
+ *  Duck-typed on ZodObject's `.shape` — non-object schemas yield no hint. */
+function fieldHint(schema: unknown): string {
+  const shape = (schema as { shape?: Record<string, { isOptional?: () => boolean }> }).shape;
+  if (!shape) return "";
+  const parts = Object.entries(shape).map(([key, def]) =>
+    typeof def?.isOptional === "function" && def.isOptional() ? `${key}?` : key,
+  );
+  return parts.length ? `  props: { ${parts.join(", ")} }` : "";
+}
+
+/**
+ * Render registry entries as the system-prompt catalog lines the agent reads:
+ * one `- Name: description  props: { … }` line per component. Use it for both
+ * the prewired catalog and a HOST COMPONENTS section (docs/host-components.md)
+ * instead of hand-rolling the formatting per app.
+ */
+export function componentPromptCatalog(components: RegisteredComponent[]): string {
+  return components
+    .map((c) => `- ${c.name}: ${c.description}${fieldHint(c.propsSchema)}`)
+    .join("\n");
+}

--- a/packages/flowlet-components/src/sandbox-install.ts
+++ b/packages/flowlet-components/src/sandbox-install.ts
@@ -13,8 +13,8 @@
  * What it wires (the stage runtime's loadBundle contract):
  *  - window.__React / window.__createRoot — the shared React instance;
  *  - window.__FLOWLET_HOST__ — the pre-wired catalog merged with the host's
- *    own components (host names win; colliding with the catalog is allowed
- *    and shadows it deliberately);
+ *    own components (a host name colliding with a catalog component THROWS —
+ *    silent shadowing would desync the sandbox from the registry/prompt);
  *  - window.__FLOWLET_THEME_WRAP__ — mounts OpenUI's ThemeProvider around the
  *    tree when the init payload carries a componentTheme;
  *  - OpenUI's base stylesheet, injected inline (the iframe cannot load

--- a/packages/flowlet-core/src/genui/host-props.test.ts
+++ b/packages/flowlet-core/src/genui/host-props.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { hostPropIssues } from "./host-props";
+import type { GeneratedPayload } from "./format";
+import type { RegisteredComponent, FlowletSchema } from "../index";
+
+const badge = (schema: z.ZodType): RegisteredComponent => ({
+  name: "AcmeBadge",
+  description: "status pill",
+  propsSchema: schema as FlowletSchema<unknown>,
+  source: "host",
+});
+
+const stringTitle = z.object({ text: z.string(), variant: z.enum(["ok", "warn"]).optional() });
+
+const payloadWith = (
+  props: Record<string, unknown>,
+  data?: Record<string, unknown>,
+  component = "AcmeBadge",
+): GeneratedPayload => ({
+  formatVersion: "flowlet-genui/v1",
+  root: "r",
+  nodes: [
+    { id: "r", component: "Stack", children: ["b"] },
+    { id: "b", component, source: "host", props },
+  ],
+  ...(data ? { data } : {}),
+});
+
+describe("hostPropIssues", () => {
+  it("returns no issues for schema-conforming literal props", () => {
+    expect(hostPropIssues(payloadWith({ text: "Paid", variant: "ok" }), [badge(stringTitle)])).toEqual([]);
+  });
+
+  it("flags schema-invalid props with the node id and a repair-ready message", () => {
+    const issues = hostPropIssues(payloadWith({ text: 42 }), [badge(stringTitle)]);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ nodeId: "b", component: "AcmeBadge", kind: "invalid-props" });
+    expect(issues[0]!.message).toMatch(/text/);
+  });
+
+  it("flags a non-allowed enum value", () => {
+    const issues = hostPropIssues(payloadWith({ text: "Paid", variant: "on-fire" }), [badge(stringTitle)]);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.kind).toBe("invalid-props");
+  });
+
+  it("flags an unknown host component name, listing what IS registered", () => {
+    const issues = hostPropIssues(payloadWith({ text: "x" }, undefined, "AcmeTypo"), [badge(stringTitle)]);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ nodeId: "b", component: "AcmeTypo", kind: "unknown-component" });
+    expect(issues[0]!.message).toContain("AcmeBadge");
+  });
+
+  it("resolves $path bindings against data before validating", () => {
+    const ok = hostPropIssues(payloadWith({ text: { $path: "/label" } }, { label: "Paid" }), [badge(stringTitle)]);
+    expect(ok).toEqual([]);
+    const bad = hostPropIssues(payloadWith({ text: { $path: "/label" } }, { label: 42 }), [badge(stringTitle)]);
+    expect(bad).toHaveLength(1);
+  });
+
+  it("skips schema validation (but not the unknown check) when a prop is $state-bound", () => {
+    // $state resolves client-side; the server cannot know the value, so a
+    // false rejection here would block legitimate views.
+    const issues = hostPropIssues(payloadWith({ text: { $state: "sel" } }), [badge(stringTitle)]);
+    expect(issues).toEqual([]);
+  });
+
+  it("skips async schemas (v1 mirrors the stage's sync-only rule)", () => {
+    // The refine always rejects, but only asynchronously — a Promise from
+    // validate means skip, so no issue is reported.
+    const asyncSchema = z.object({ text: z.string() }).refine(async () => false);
+    const issues = hostPropIssues(payloadWith({ text: "ok" }), [badge(asyncSchema)]);
+    expect(issues).toEqual([]);
+  });
+
+  it("ignores prewired and generated nodes entirely", () => {
+    const payload: GeneratedPayload = {
+      formatVersion: "flowlet-genui/v1",
+      root: "r",
+      nodes: [
+        { id: "r", component: "Stack", children: ["t"] },
+        { id: "t", component: "Text", props: { value: 42 } },
+      ],
+    };
+    expect(hostPropIssues(payload, [badge(stringTitle)])).toEqual([]);
+  });
+});

--- a/packages/flowlet-core/src/genui/host-props.ts
+++ b/packages/flowlet-core/src/genui/host-props.ts
@@ -1,0 +1,92 @@
+/** Server-side host-component prop validation (ENG-186 follow-up).
+ *
+ *  The stage already validates host-node props at genui resolution (contained
+ *  placeholder) and again in the adapter — but by then the turn is over and the
+ *  user sees a degraded node. Running the same check server-side, BEFORE the
+ *  payload streams, turns a schema violation into a correctable tool error the
+ *  model can repair, exactly like `validateGeneratedPayload`'s structural errors.
+ *
+ *  Semantics mirror the stage's `validateHostProps`: only SYNCHRONOUS schemas
+ *  are validated; `$path` bindings are resolved against `data` first. Two
+ *  server-only differences: an unknown host name is an issue here (the stage
+ *  renders a visible notice instead — it cannot ask the model to retry), and a
+ *  node with any `$state`-bound prop skips schema validation entirely (the
+ *  state value exists only client-side; validating a binding object against
+ *  the prop's schema would be a false rejection).
+ */
+import type { RegisteredComponent } from "../registry";
+import { isPropBinding, type GeneratedPayload } from "./format";
+import { resolvePointer } from "./pointer";
+
+export interface HostPropIssue {
+  nodeId: string;
+  component: string;
+  kind: "unknown-component" | "invalid-props";
+  /** Repair-ready description, safe to hand back to the model verbatim. */
+  message: string;
+}
+
+const isStateBinding = (v: unknown): boolean =>
+  typeof v === "object" && v !== null && typeof (v as { $state?: unknown }).$state === "string";
+
+const formatPath = (path: ReadonlyArray<PropertyKey | { key: PropertyKey }> | undefined): string => {
+  if (!path || path.length === 0) return "";
+  const keys = path.map((seg) =>
+    typeof seg === "object" && seg !== null && "key" in seg ? String(seg.key) : String(seg),
+  );
+  return `${keys.join(".")}: `;
+};
+
+/** Validate every `source:"host"` node of a payload against the registry. */
+export function hostPropIssues(
+  payload: GeneratedPayload,
+  components: readonly RegisteredComponent[],
+): HostPropIssue[] {
+  const byName = new Map(components.map((c) => [c.name, c]));
+  const hostNames = components.filter((c) => c.source === "host").map((c) => c.name);
+  const data = payload.data ?? {};
+  const issues: HostPropIssue[] = [];
+
+  for (const node of payload.nodes) {
+    if (node.source !== "host") continue;
+
+    const descriptor = byName.get(node.component);
+    if (descriptor === undefined) {
+      issues.push({
+        nodeId: node.id,
+        component: node.component,
+        kind: "unknown-component",
+        message:
+          `node "${node.id}": unknown host component "${node.component}" — ` +
+          (hostNames.length > 0 ? `registered host components: ${hostNames.join(", ")}` : "no host components are registered"),
+      });
+      continue;
+    }
+
+    const props = node.props ?? {};
+    const values = Object.values(props);
+    if (values.some(isStateBinding)) continue;
+
+    const resolved: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(props)) {
+      resolved[key] = isPropBinding(value) ? resolvePointer(data, value.$path) : value;
+    }
+
+    const result = descriptor.propsSchema["~standard"].validate(resolved);
+    if (result instanceof Promise) continue; // sync-only, mirroring the stage
+    if (result.issues) {
+      const detail = result.issues
+        .slice(0, 4)
+        .map((issue) => `${formatPath(issue.path)}${issue.message}`)
+        .join("; ");
+      issues.push({
+        nodeId: node.id,
+        component: node.component,
+        kind: "invalid-props",
+        message: `node "${node.id}": props for host component "${node.component}" do not match its schema — ${detail}`,
+      });
+    }
+  }
+
+  return issues;
+}

--- a/packages/flowlet-core/src/genui/index.ts
+++ b/packages/flowlet-core/src/genui/index.ts
@@ -1,3 +1,4 @@
 export * from "./format";
+export * from "./host-props";
 export * from "./pointer";
 export * from "./resolve";

--- a/packages/flowlet-core/src/registry.ts
+++ b/packages/flowlet-core/src/registry.ts
@@ -7,6 +7,10 @@ export interface RegisteredComponent {
   description: string;        // drives LLM selection
   propsSchema: FlowletSchema<unknown>;
   source: UINodeSource;
+  /** Registry compat version (ENG-186). Host teams bump it on a breaking
+   *  change to a component's props/behavior; saved flowlets stamp it at save
+   *  time and diff it on reopen to surface drift. Unset means "1". */
+  version?: string;
 }
 
 export interface ComponentRegistry {

--- a/packages/flowlet-core/src/seams/store.ts
+++ b/packages/flowlet-core/src/seams/store.ts
@@ -55,6 +55,10 @@ export interface SavedFlowlet {
   /** Re-executed via the Executor on reopen — never a raw DB query. */
   query: { toolName: string; input: unknown };
   originatingPrompt: string;
+  /** Host-component name → registry version stamped at save time (ENG-186).
+   *  Reopen diffs it against the live registry to surface component drift.
+   *  Absent on trees with no host nodes and on pre-versioning records. */
+  components?: Record<string, string>;
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/flowlet-runtime/src/engine.ts
+++ b/packages/flowlet-runtime/src/engine.ts
@@ -24,7 +24,7 @@ import {
   type ToolSet,
   type UIMessageChunk,
 } from "ai";
-import type { FlowletAgent, RunInput, FlowletUIMessage } from "@flowlet/core";
+import type { FlowletAgent, RunInput, FlowletUIMessage, RegisteredComponent } from "@flowlet/core";
 import { SCHEMA_VERSION } from "@flowlet/core";
 import { buildToolset, type ToolSourceInput } from "./toolset";
 import { createRenderViewTool } from "./render-view-tool";
@@ -74,6 +74,13 @@ export interface FlowletAgentConfig {
   policyVersion?: string;
   /** Max model->tool steps before the loop stops. Defaults to 8. */
   maxSteps?: number;
+  /**
+   * F1 component registry (prewired + host). When provided, `render_view`
+   * validates `source:"host"` nodes server-side — unknown names and
+   * schema-invalid props return correctable tool errors the model can repair
+   * before anything streams (ENG-186).
+   */
+  components?: RegisteredComponent[];
 }
 
 /**
@@ -174,7 +181,7 @@ export function createFlowletAgent(config: FlowletAgentConfig): FlowletAgent {
             : { userId: "" };
 
         // 2. The render + connect tools, bound to this run's stream writer.
-        const renderViewTool = createRenderViewTool(writer);
+        const renderViewTool = createRenderViewTool(writer, { components: config.components });
         const requestConnectTool = createRequestConnectTool(writer);
 
         // 3. Composio ingestion (fail-closed inside ingestComposioTools).

--- a/packages/flowlet-runtime/src/render-view-tool.test.ts
+++ b/packages/flowlet-runtime/src/render-view-tool.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
+import { z } from "zod";
+import type { RegisteredComponent } from "@flowlet/core";
 import { createRenderViewTool } from "./render-view-tool";
 
 const VALID = {
@@ -114,5 +116,55 @@ describe("createRenderViewTool", () => {
     const idA = (writerA.write as ReturnType<typeof vi.fn>).mock.calls[0][0].data.id;
     const idB = (writerB.write as ReturnType<typeof vi.fn>).mock.calls[0][0].data.id;
     expect(idA).not.toBe(idB);
+  });
+});
+
+describe("createRenderViewTool — server-side host validation (ENG-186)", () => {
+  const registry: RegisteredComponent[] = [
+    {
+      name: "AcmeBadge",
+      description: "status pill",
+      propsSchema: z.object({ text: z.string() }) as unknown as RegisteredComponent["propsSchema"],
+      source: "host",
+    },
+  ];
+  const hostPayload = (props: Record<string, unknown>, component = "AcmeBadge") => ({
+    formatVersion: "flowlet-genui/v1",
+    root: "r",
+    nodes: [
+      { id: "r", component: "Stack", source: "prewired", children: ["b"] },
+      { id: "b", component, source: "host", props },
+    ],
+  });
+
+  it("returns a correctable (host) error for schema-invalid host props, writing nothing", async () => {
+    const writer = writerMock();
+    const tool = createRenderViewTool(writer, { components: registry });
+    const result = await tool.execute!(hostPayload({ text: 42 }) as never, {} as never);
+    expect(String(result)).toMatch(/^render_view error \(host\): node "b"/);
+    expect(String(result)).toContain("AcmeBadge");
+    expect((writer.write as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+  });
+
+  it("returns a correctable (host) error naming the registered components for an unknown host name", async () => {
+    const writer = writerMock();
+    const tool = createRenderViewTool(writer, { components: registry });
+    const result = await tool.execute!(hostPayload({ text: "hi" }, "AcmeTypo") as never, {} as never);
+    expect(String(result)).toContain('unknown host component "AcmeTypo"');
+    expect(String(result)).toContain("AcmeBadge");
+  });
+
+  it("ships valid host props untouched", async () => {
+    const writer = writerMock();
+    const tool = createRenderViewTool(writer, { components: registry });
+    const result = await tool.execute!(hostPayload({ text: "hi" }) as never, {} as never);
+    expect(result).toBe("rendered");
+  });
+
+  it("skips host validation entirely when no registry is provided (back-compat)", async () => {
+    const writer = writerMock();
+    const tool = createRenderViewTool(writer);
+    const result = await tool.execute!(hostPayload({ text: 42 }) as never, {} as never);
+    expect(result).toBe("rendered");
   });
 });

--- a/packages/flowlet-runtime/src/render-view-tool.ts
+++ b/packages/flowlet-runtime/src/render-view-tool.ts
@@ -9,13 +9,23 @@ import { tool } from "ai";
 import type { UIMessageStreamWriter } from "ai";
 import { z } from "zod";
 import {
+  hostPropIssues,
   validateGeneratedPayload,
   type FlowletUIMessage,
+  type RegisteredComponent,
   type UINode,
 } from "@flowlet/core";
 import { compileComponentSource } from "./compile-component";
 
 type FlowletWriter = UIMessageStreamWriter<FlowletUIMessage>;
+
+export interface RenderViewToolOptions {
+  /** F1 component registry. When provided, `source:"host"` nodes are validated
+   *  server-side — unknown names and schema-invalid props come back as
+   *  correctable tool errors the model can repair, instead of only degrading
+   *  to placeholders in the stage (ENG-186). */
+  components?: RegisteredComponent[];
+}
 
 const genNodeSchema = z.object({
   id: z.string().describe("Unique node id within this payload."),
@@ -34,7 +44,7 @@ const dataQuerySchema = z.object({
     .describe("The exact input to replay the tool with on refresh."),
 });
 
-export function createRenderViewTool(writer: FlowletWriter) {
+export function createRenderViewTool(writer: FlowletWriter, options: RenderViewToolOptions = {}) {
   // Node ids key saved flowlets (ENG-183), and a tool instance lives for ONE
   // request — a bare counter would make every session's first view "view-1".
   // The random suffix keeps ids unique across instances.
@@ -71,6 +81,12 @@ export function createRenderViewTool(writer: FlowletWriter) {
       const validation = validateGeneratedPayload(payload);
       if (!validation.ok) {
         return `render_view error (${validation.error.code}): ${validation.error.message}`;
+      }
+      if (options.components) {
+        const issues = hostPropIssues(validation.payload, options.components);
+        if (issues.length > 0) {
+          return `render_view error (host): ${issues.map((i) => i.message).join(" | ")}`;
+        }
       }
       // Validation ran on the ORIGINAL authored payload (name/cap checks apply
       // to what the model emitted). Compile each component's JSX/TS to plain ESM

--- a/packages/flowlet-shell/src/component-drift.test.ts
+++ b/packages/flowlet-shell/src/component-drift.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import type { RegisteredComponent, UINode } from "@flowlet/core";
+import { stampHostComponents, diffHostComponents, NO_DRIFT } from "./component-drift";
+
+const registered = (name: string, version?: string): RegisteredComponent => ({
+  name,
+  description: "x",
+  propsSchema: { "~standard": { version: 1, vendor: "test", validate: (v: unknown) => ({ value: v }) } } as RegisteredComponent["propsSchema"],
+  source: "host",
+  ...(version !== undefined ? { version } : {}),
+});
+
+const generatedNode = (nodes: Array<{ id: string; component: string; source?: string }>): UINode => ({
+  id: "v1",
+  kind: "generated",
+  payload: { formatVersion: "flowlet-genui/v1", root: nodes[0]!.id, nodes },
+} as UINode);
+
+describe("stampHostComponents", () => {
+  it("records name → registry version for every host node in the tree", () => {
+    const node = generatedNode([
+      { id: "r", component: "Stack" },
+      { id: "a", component: "AcmeBadge", source: "host" },
+      { id: "b", component: "AcmeMeter", source: "host" },
+    ]);
+    const stamp = stampHostComponents(node, [registered("AcmeBadge", "2"), registered("AcmeMeter")]);
+    expect(stamp).toEqual({ AcmeBadge: "2", AcmeMeter: "1" });
+  });
+
+  it("returns undefined when the tree has no host nodes (records stay stamp-free)", () => {
+    const node = generatedNode([{ id: "r", component: "Stack" }]);
+    expect(stampHostComponents(node, [registered("AcmeBadge")])).toBeUndefined();
+  });
+
+  it("returns undefined for non-generated nodes", () => {
+    const component: UINode = { id: "c", kind: "component", source: "prewired", name: "Text", props: {} };
+    expect(stampHostComponents(component, [])).toBeUndefined();
+  });
+});
+
+describe("diffHostComponents", () => {
+  it("is clean when every stamped component still exists at the same version", () => {
+    expect(diffHostComponents({ AcmeBadge: "2" }, [registered("AcmeBadge", "2")])).toBe(NO_DRIFT);
+  });
+
+  it("reports a renamed/removed component as missing", () => {
+    const drift = diffHostComponents({ AcmeOld: "1" }, [registered("AcmeNew")]);
+    expect(drift).toEqual({ missing: ["AcmeOld"], changed: [] });
+  });
+
+  it("reports a version bump as changed", () => {
+    const drift = diffHostComponents({ AcmeBadge: "1" }, [registered("AcmeBadge", "2")]);
+    expect(drift).toEqual({ missing: [], changed: ["AcmeBadge"] });
+  });
+
+  it("treats an unset registry version as '1'", () => {
+    expect(diffHostComponents({ AcmeBadge: "1" }, [registered("AcmeBadge")])).toBe(NO_DRIFT);
+  });
+
+  it("diffs a stamp-free (pre-versioning) record as clean — no retroactive warnings", () => {
+    expect(diffHostComponents(undefined, [registered("AcmeBadge", "9")])).toBe(NO_DRIFT);
+  });
+});

--- a/packages/flowlet-shell/src/component-drift.ts
+++ b/packages/flowlet-shell/src/component-drift.ts
@@ -1,0 +1,69 @@
+/** Registry versioning for saved flowlets (ENG-186).
+ *
+ *  A saved flowlet outlives the host-component registry it was built against:
+ *  the host renames a component and the tree degrades to an "Unknown component"
+ *  notice; the host changes a props schema and the node degrades to an
+ *  invalid-props placeholder. Both are contained — but silent. These helpers
+ *  make the drift DETECTABLE: `stampHostComponents` records name → version at
+ *  save time, `diffHostComponents` compares that stamp against the live
+ *  registry at reopen so the shell can say *why* a view degraded.
+ *
+ *  Versions are host-declared (`hostComponent(..., { version })`), bumped on
+ *  breaking changes; unset means "1". No stamp (a pre-versioning record) diffs
+ *  as clean — old saves must not start warning retroactively.
+ */
+import {
+  isGeneratedNode,
+  type GeneratedPayload,
+  type RegisteredComponent,
+  type UINode,
+} from "@flowlet/core";
+
+/** The implied version of a registry entry that declares none. */
+export const DEFAULT_COMPONENT_VERSION = "1";
+
+/**
+ * Record which host components a view uses, at which registry version.
+ * Returns undefined for non-generated nodes or trees with no host nodes —
+ * records stay stamp-free rather than carrying an empty object.
+ */
+export function stampHostComponents(
+  node: UINode,
+  components: readonly RegisteredComponent[],
+): Record<string, string> | undefined {
+  if (!isGeneratedNode(node)) return undefined;
+  const byName = new Map(components.map((c) => [c.name, c]));
+  const stamp: Record<string, string> = {};
+  for (const genNode of (node.payload as GeneratedPayload).nodes) {
+    if (genNode.source !== "host") continue;
+    stamp[genNode.component] =
+      byName.get(genNode.component)?.version ?? DEFAULT_COMPONENT_VERSION;
+  }
+  return Object.keys(stamp).length > 0 ? stamp : undefined;
+}
+
+export interface ComponentDrift {
+  /** Stamped names no longer in the registry (renamed or removed). */
+  missing: string[];
+  /** Stamped names whose registry version moved since the save. */
+  changed: string[];
+}
+
+export const NO_DRIFT: ComponentDrift = { missing: [], changed: [] };
+
+/** Compare a saved stamp against the live registry. */
+export function diffHostComponents(
+  stamp: Record<string, string> | undefined,
+  components: readonly RegisteredComponent[],
+): ComponentDrift {
+  if (stamp === undefined) return NO_DRIFT;
+  const byName = new Map(components.map((c) => [c.name, c]));
+  const missing: string[] = [];
+  const changed: string[] = [];
+  for (const [name, savedVersion] of Object.entries(stamp)) {
+    const current = byName.get(name);
+    if (current === undefined) missing.push(name);
+    else if ((current.version ?? DEFAULT_COMPONENT_VERSION) !== savedVersion) changed.push(name);
+  }
+  return missing.length === 0 && changed.length === 0 ? NO_DRIFT : { missing, changed };
+}

--- a/packages/flowlet-shell/src/context.tsx
+++ b/packages/flowlet-shell/src/context.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useMemo, type ComponentType, type ReactNode } from "react";
-import type { UINode } from "@flowlet/core";
+import type { RegisteredComponent, UINode } from "@flowlet/core";
 import { themeToStyle, type FlowletTheme } from "./theme";
 import { createLocalStore, type FlowletStore } from "./seams/store";
 import { createLocalIntegrations, type FlowletIntegrations } from "./seams/integrations";
@@ -28,6 +28,9 @@ export interface ShellContextValue {
   /** What the host calls its assistant (e.g. "Maple"). Default copy that names
    *  the product reads it — the shell package itself ships ZERO brand strings. */
   productName?: string;
+  /** F1 component registry (prewired + host). When present, reopened saved
+   *  views diff their stamp against it and surface drift (ENG-186). */
+  components?: RegisteredComponent[];
 }
 
 const ShellContext = createContext<ShellContextValue | null>(null);
@@ -78,11 +81,13 @@ export interface FlowletShellProviderProps {
   cssVars?: Record<string, string>;
   /** What the host calls its assistant; read by default copy that names it. */
   productName?: string;
+  /** F1 component registry; enables drift detection on reopened saved views. */
+  components?: RegisteredComponent[];
   children: ReactNode;
 }
 
 export function FlowletShellProvider({
-  store, integrations, runQuery, refreshIntervalMs, renderNode, impls, theme, cssVars, productName, children,
+  store, integrations, runQuery, refreshIntervalMs, renderNode, impls, theme, cssVars, productName, components, children,
 }: FlowletShellProviderProps) {
   if (store === undefined) warnNoStoreOnce();
 
@@ -95,7 +100,8 @@ export function FlowletShellProvider({
     theme,
     cssVars: cssVars ?? {},
     productName,
-  }), [store, integrations, runQuery, refreshIntervalMs, renderNode, impls, theme, cssVars, productName]);
+    components,
+  }), [store, integrations, runQuery, refreshIntervalMs, renderNode, impls, theme, cssVars, productName, components]);
 
   return (
     <ShellContext.Provider value={value}>

--- a/packages/flowlet-shell/src/index.ts
+++ b/packages/flowlet-shell/src/index.ts
@@ -11,6 +11,7 @@ export * from "./seams/store";
 export * from "./seams/web-storage";
 export * from "./seams/query";
 export * from "./reopen";
+export * from "./component-drift";
 export * from "./seams/integrations";
 
 export * from "./components/StreamingText";

--- a/packages/flowlet-shell/src/reopen.test.tsx
+++ b/packages/flowlet-shell/src/reopen.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import type { UINode } from "@flowlet/core";
+import type { RegisteredComponent, UINode } from "@flowlet/core";
 import { FlowletShellProvider } from "./context";
 import { createLocalStore, type FlowletStore } from "./seams/store";
 import type { RunQuery } from "./seams/query";
@@ -259,5 +259,49 @@ describe("useReopenFlowlet", () => {
     await waitFor(() => expect(result.current.refreshing).toBe(true));
     rerender({ f: noQueries });
     await waitFor(() => expect(result.current.refreshing).toBe(false));
+  });
+});
+
+describe("useReopenFlowlet — registry drift (ENG-186)", () => {
+  const registered = (name: string, version?: string): RegisteredComponent => ({
+    name,
+    description: "x",
+    propsSchema: { "~standard": { version: 1, vendor: "test", validate: (v: unknown) => ({ value: v }) } } as RegisteredComponent["propsSchema"],
+    source: "host",
+    ...(version !== undefined ? { version } : {}),
+  });
+  const wrapWith = (store: FlowletStore, components?: RegisteredComponent[]) =>
+    function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <FlowletShellProvider store={store} refreshIntervalMs={0} components={components}>
+          {children}
+        </FlowletShellProvider>
+      );
+    };
+
+  it("surfaces missing and version-bumped components from the saved stamp", async () => {
+    const store = createLocalStore();
+    const flowlet = await store.save({
+      id: "f1", name: "V", node: genNode({}),
+      components: { AcmeOld: "1", AcmeBadge: "1" },
+    });
+    const { result } = renderHook(() => useReopenFlowlet(flowlet), {
+      wrapper: wrapWith(store, [registered("AcmeBadge", "2")]),
+    });
+    expect(result.current.drift).toEqual({ missing: ["AcmeOld"], changed: ["AcmeBadge"] });
+  });
+
+  it("reports no drift for a stamp-free record or when no registry is provided", async () => {
+    const store = createLocalStore();
+    const stampFree = await store.save({ id: "f1", name: "V", node: genNode({}) });
+    const stamped = await store.save({
+      id: "f2", name: "W", node: genNode({}), components: { AcmeOld: "1" },
+    });
+    const a = renderHook(() => useReopenFlowlet(stampFree), {
+      wrapper: wrapWith(store, [registered("AcmeBadge", "9")]),
+    });
+    expect(a.result.current.drift).toEqual({ missing: [], changed: [] });
+    const b = renderHook(() => useReopenFlowlet(stamped), { wrapper: wrapWith(store) });
+    expect(b.result.current.drift).toEqual({ missing: [], changed: [] });
   });
 });

--- a/packages/flowlet-shell/src/reopen.ts
+++ b/packages/flowlet-shell/src/reopen.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   applyPointerPatch,
   isGeneratedNode,
@@ -8,6 +8,7 @@ import {
 } from "@flowlet/core";
 import type { Flowlet } from "./seams/store";
 import type { RunQuery } from "./seams/query";
+import { diffHostComponents, NO_DRIFT, type ComponentDrift } from "./component-drift";
 import { useShell } from "./context";
 
 export type RefreshStatus = "live" | "partial" | "snapshot";
@@ -73,8 +74,17 @@ const MAX_REFRESH_FAILURES = 3;
  * Fresh data is written back onto the CURRENT stored record (a rename/pin
  * during a refresh survives; a deleted record is never resurrected).
  */
-export function useReopenFlowlet(flowlet: Flowlet): RefreshResult & { refreshing: boolean } {
-  const { store, runQuery, refreshIntervalMs } = useShell();
+export function useReopenFlowlet(
+  flowlet: Flowlet,
+): RefreshResult & { refreshing: boolean; drift: ComponentDrift } {
+  const { store, runQuery, refreshIntervalMs, components } = useShell();
+  // Registry drift (ENG-186): which of the view's stamped host components have
+  // been renamed/removed or version-bumped since the save. Empty without a
+  // provider registry or a stamp — old records never warn retroactively.
+  const drift = useMemo(
+    () => (components ? diffHostComponents(flowlet.components, components) : NO_DRIFT),
+    [flowlet.components, components],
+  );
   const [result, setResult] = useState<RefreshResult>({ node: flowlet.node, status: "snapshot", errors: [] });
   const [refreshing, setRefreshing] = useState(false);
 
@@ -172,5 +182,5 @@ export function useReopenFlowlet(flowlet: Flowlet): RefreshResult & { refreshing
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [flowlet.id, runQuery, store, refreshIntervalMs]);
 
-  return { ...result, refreshing };
+  return { ...result, refreshing, drift };
 }

--- a/packages/flowlet-shell/src/seams/store.ts
+++ b/packages/flowlet-shell/src/seams/store.ts
@@ -10,6 +10,10 @@ export interface Flowlet {
   /** The user prompt that originally produced the view. */
   prompt?: string;
   pinned?: boolean;
+  /** Host-component name → registry version the view was saved against
+   *  (ENG-186; see `stampHostComponents`). Absent on trees with no host nodes
+   *  and on pre-versioning records — both diff as clean. */
+  components?: Record<string, string>;
   /** Stamped by the store on first save; preserved on later saves. */
   createdAt?: number;
   updatedAt: number;

--- a/packages/flowlet-shell/src/styles.css
+++ b/packages/flowlet-shell/src/styles.css
@@ -453,6 +453,11 @@
 .fl-stale-note { font-family: var(--flowlet-font); font-size: 11px;
   color: color-mix(in srgb, var(--flowlet-fg) 46%, transparent); padding: 6px 2px; }
 
+/* ---------- registry-drift note (ENG-186): same quiet register as the
+   stale note, slightly stronger — it explains a degraded node, not a delay. */
+.fl-drift-note { font-family: var(--flowlet-font); font-size: 11px;
+  color: color-mix(in srgb, var(--flowlet-fg) 62%, transparent); padding: 6px 2px; }
+
 /* ---------- connection selector (denser, brand-forward) ---------- */
 .fl-picker { border: 1px solid var(--flowlet-border); border-radius: var(--flowlet-radius);
   background: var(--flowlet-glass-strong); -webkit-backdrop-filter: var(--flowlet-blur); backdrop-filter: var(--flowlet-blur);

--- a/packages/flowlet-stage/src/runtime.test.ts
+++ b/packages/flowlet-stage/src/runtime.test.ts
@@ -30,6 +30,12 @@ describe("stage runtime source", () => {
     // Fallback to the host bundle (e.g. __row/__badge) must be preserved.
     expect(STAGE_RUNTIME_SRC).toContain("host[node.name]");
   });
+  it("renders a visible, diagnosable notice for an unregistered component name (ENG-186 DX)", () => {
+    // An unknown name must never render an invisible empty div: the notice
+    // carries a data-error marker AND user-readable text naming the component.
+    expect(STAGE_RUNTIME_SRC).toContain('"data-error": "unknown:" + node.name');
+    expect(STAGE_RUNTIME_SRC).toContain("'Unknown component \"' + node.name + '\"'");
+  });
   it("caches the error-boundary class so ui/update reconciles instead of remounting", () => {
     // The class is built once via getEB() and reused, mirroring cachedHost. A
     // fresh makeEB() per render would be a new React component type and force a


### PR DESCRIPTION
## What

Closes out the three gaps found by the ENG-186 verification pass (report: `docs/superpowers/specs/2026-07-02-eng186-verification.md`, first commit on this branch).

### 1. Registry versioning so host-component changes don't break saved flowlets (the real gap)

- `RegisteredComponent.version?` + `hostComponent(name, desc, schema, { version })` — host teams bump on breaking prop/behavior changes; unset means `"1"`. Explicit versions over schema hashing: zod v3 has no stable serialization, and a declared version is honest about what "breaking" means.
- At save, the apps stamp `name → version` for every host component the view uses (`stampHostComponents`) into the shell `Flowlet.components` field (parity field added to core `SavedFlowlet` for the cloud wave; the in-memory store passes it through).
- On reopen, `useReopenFlowlet` diffs the stamp against the `FlowletShellProvider` `components` registry and returns `drift: { missing, changed }`; each app's SavedPane renders a quiet `.fl-drift-note` naming the drifted components. Drift **warns, never blocks** — the view still renders (and still degrades safely via the existing placeholder paths). Pre-versioning records diff clean; no retroactive warnings.

### 2. Server-side host-prop validation in `render_view` (model can self-repair)

- `hostPropIssues(payload, registry)` in core genui: validates `source:"host"` node props against descriptor schemas **before streaming**, resolving `$path` bindings against `data` first; `$state`-bound nodes and async schemas are skipped (mirrors the stage's rules). Unknown host names are also an issue, listing what IS registered.
- `render_view` returns `render_view error (host): node "b": …` when the engine is given `components` (`createFlowletAgent({ components })`); all three demo agents pass their registries. No registry → old behavior, fully back-compat.

### 3. Trivia from the verification report

- `componentPromptCatalog` in `@flowlet/components/descriptors` replaces the three hand-rolled per-app prompt-catalog helpers (demo-bank, demo-accounting, gmail).
- Stale `sandbox-install.ts` docstring fixed (claimed catalog shadowing is allowed; the code throws).
- Unknown-component notice pinned by a marker test in `runtime.test.ts`.

## Verification

- Full workspace suite green: **1,125 tests** (19 new: drift stamp/diff, reopen drift hook, host-prop issues, render_view host errors, prompt catalog, descriptor version passthrough, unknown-notice marker). Typecheck green.
- Lint green on all touched packages; demo-bank has 5 **pre-existing** errors (reproduced on the clean tree, in files this PR doesn't touch: `transactions/*`, `FlowletPoller`, `SandboxStage`, `filters-bar`) — reported, not fixed here.
- **Browser-verified** in the running Cadence app (seeded a saved view with a drifted stamp via the real web-storage store):

| Drifted stamp (`CadenceGhost` removed, `CadenceStatusBadge` bumped) | Matching stamp |
|---|---|
| ![drift note](https://github.com/yousefh409/flowlet/blob/yousefh409/eng-186-verify/verification/eng186-hardening/eng186-drift-note.png?raw=true) | ![no drift](https://github.com/yousefh409/flowlet/blob/yousefh409/eng-186-verify/verification/eng186-hardening/eng186-no-drift.png?raw=true) |

## For Yousef (UI gate)

The only new visual is the `.fl-drift-note` line above reopened saved views (same quiet register as the existing `.fl-stale-note`, slightly stronger). Copy per app: "*X, Y have changed in Cadence since this view was saved — parts may render differently*". Flagging for your sign-off per the UI gate; happy to reword/restyle.

## Notes

- ENG-186 itself is archived as Duplicate in Linear (rejects comments); the verification report in `docs/superpowers/specs/` is the evidence trail, updated with an addendum for this build.
- `docs/host-components.md` documents all three: `{ version }`, the Versioning & saved flowlets section, engine `components` wiring, and `componentPromptCatalog`.

https://claude.ai/code/session_013u1FvH2Lp1jwiSAUCpntPC