### PR TITLE
feat: MCP client support — host-configured servers as policy-governed agent tools

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -66,10 +66,53 @@ hides that surface — nothing errors.
 | `ANTHROPIC_API_KEY` | Chat + generated UI (the one-key minimum) |
 | `+ COMPOSIO_API_KEY` | Integrations: Gmail, Slack, Notion, … via OAuth connect cards |
 | `+ OPENAI_API_KEY` | Reserved for voice — exposed as a capability flag only (voice UX is in design) |
+| `+ MCP servers declared` | Any remote MCP server's tools, policy-governed (config, not a key — see below) |
 
 The client reads `GET /api/flowlet/capabilities` and gates its UI on the
 answer, so the integrations tray simply doesn't offer connections until the
 Composio key exists.
+
+## MCP servers
+
+Point Flowlet at any remote MCP server and its tools become agent tools,
+governed by the same approval policy as everything else.
+
+Either declare them in code:
+
+```ts
+export const { GET, POST } = createFlowletHandler({
+  mcpServers: [
+    {
+      name: "weather",                    // tools appear as weather_<tool>
+      url: "https://mcp.example.com/mcp", // Streamable HTTP endpoint
+      headers: { Authorization: `Bearer ${process.env.WEATHER_TOKEN}` }, // optional
+      tools: ["get_forecast"],            // optional allowlist; omit = all tools
+    },
+  ],
+});
+```
+
+or in `.flowlet/mcp.json` (the code option wins entirely if both exist):
+
+```json
+{
+  "version": 1,
+  "servers": [
+    {
+      "name": "weather",
+      "url": "https://mcp.example.com/mcp",
+      "headers": { "Authorization": "Bearer ${WEATHER_TOKEN}" }
+    }
+  ]
+}
+```
+
+In `mcp.json`, `${VAR}` in header values is read from the environment at
+boot; a server whose variable is unset is skipped with a warning. Notes:
+HTTP transport only (no stdio), static headers only (OAuth-only servers not
+yet supported), tools only (no resources/prompts). Server-reported
+annotations are honored: read-only tools run freely, everything else pauses
+for approval.
 
 ## Your API as the agent's hands
 

--- a/docs/superpowers/plans/2026-07-04-flowlet-mcp-client.md
+++ b/docs/superpowers/plans/2026-07-04-flowlet-mcp-client.md
@@ -1,0 +1,1254 @@
+# Flowlet MCP Client Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Host-declared remote MCP servers become policy-governed agent tools, per the approved spec `docs/superpowers/specs/2026-07-04-flowlet-mcp-client-design.md`.
+
+**Architecture:** A new runtime ingestion module (`mcp.ts`) mirroring `composio.ts` — injectable `McpToolSource` seam wrapping `@ai-sdk/mcp@1.0.6`'s `createMCPClient`, tools prefixed `<serverName>_<toolName>`, wired into the engine as the F2-reserved 4th source (`caller > engine > composio > mcp`) so every tool passes the existing `wrapTool` policy gate. `@flowlet/next` adds `mcpServers` option + `.flowlet/mcp.json` (code overrides file, `${ENV_VAR}` header substitution) and a `capabilities.mcp` flag.
+
+**Tech Stack:** TypeScript, `@ai-sdk/mcp@1.0.6` (already a dependency + on the dependency-guard allowlist), `ai@6.0.28`, zod, vitest.
+
+**Key SDK facts (verified against the installed package, 2026-07-04):**
+- `createMCPClient({ transport: { type: "http", url, headers } })` → `Promise<MCPClient>`; `client.tools()` → `ToolSet` where every tool has `execute` and `_meta`.
+- **`client.tools()` DISCARDS MCP `annotations`** (uses only `annotations.title`). The runtime class HAS a `listTools()` method returning the raw `tools/list` result (with `annotations`), but it's missing from the 1.0.6 public type. Yousef-approved approach: call it via a narrow structural cast + a contract test that fails loudly if an SDK bump removes it. If the method is absent at runtime, degrade to empty annotations (tools still ingest; policy fail-safes them to "approve").
+- The HTTP transport accepts plain `application/json` responses, so the contract test runs a tiny in-process `node:http` JSON-RPC server (no SSE needed). For JSON-RPC *notifications* the test server must reply `200` with **no content-type** (the transport ignores such bodies; a `202` would make it open an SSE GET connection). The `initialize` reply must echo the client's requested `protocolVersion`.
+
+---
+
+## File map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `packages/flowlet-runtime/src/mcp.ts` | Create | `McpServerConfig`, `McpToolSource` seam, `createMcpToolSource` (real adapter), `ingestMcpTools` |
+| `packages/flowlet-runtime/src/mcp.test.ts` | Create | Unit tests with a fake `McpToolSource` |
+| `packages/flowlet-runtime/src/mcp.contract.test.ts` | Create | Contract test against real `@ai-sdk/mcp` + in-process HTTP server |
+| `packages/flowlet-runtime/src/engine.ts` | Modify | `mcp` config field, host-level ingestion cache, 4th source |
+| `packages/flowlet-runtime/src/engine.test.ts` | Modify | Engine MCP wiring + precedence tests |
+| `packages/flowlet-runtime/src/index.ts` | Modify | Export new symbols |
+| `packages/flowlet-next/src/mcp-config.ts` | Create | `mcp.json` zod schema, `${ENV_VAR}` substitution, resolution |
+| `packages/flowlet-next/src/mcp-config.test.ts` | Create | Schema/substitution/drop-on-missing tests |
+| `packages/flowlet-next/src/flowlet-dir.ts` | Modify | Load `.flowlet/mcp.json` |
+| `packages/flowlet-next/src/flowlet-dir.test.ts` | Modify | mcp.json loading tests |
+| `packages/flowlet-next/src/options.ts` | Modify | `mcpServers` option + zod |
+| `packages/flowlet-next/src/options.test.ts` | Modify | Option validation tests |
+| `packages/flowlet-next/src/capabilities.ts` | Modify | `mcp: boolean` on `FlowletCapabilities` |
+| `packages/flowlet-next/src/capabilities.test.ts` | Modify | Updated expectations |
+| `packages/flowlet-next/src/agent.ts` | Modify | Pass `mcpServers` through to `createFlowletAgent` |
+| `packages/flowlet-next/src/handler.ts` | Modify | Resolve servers, capability flag, agent wiring |
+| `packages/flowlet-next/src/handler.test.ts` | Modify | Handler-level tests |
+| `docs/quickstart.md` | Modify | MCP servers section |
+
+---
+
+### Task 1: Runtime ingestion module — types + `ingestMcpTools` (fake-source TDD)
+
+**Files:**
+- Create: `packages/flowlet-runtime/src/mcp.ts`
+- Create: `packages/flowlet-runtime/src/mcp.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// packages/flowlet-runtime/src/mcp.test.ts
+/**
+ * Unit tests for MCP ingestion (`ingestMcpTools`) using a fake `McpToolSource`.
+ * The real adapter is covered by mcp.contract.test.ts.
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { ToolSet } from "ai";
+import { ingestMcpTools, type McpServerConfig, type McpToolSource } from "./mcp";
+
+function fakeSource(
+  perServer: Record<
+    string,
+    { tools: ToolSet; annotations?: Record<string, Record<string, boolean>> } | Error
+  >,
+): McpToolSource {
+  return {
+    fetchTools: vi.fn(async (config: McpServerConfig) => {
+      const entry = perServer[config.name];
+      if (!entry) throw new Error(`unexpected server ${config.name}`);
+      if (entry instanceof Error) throw entry;
+      return { tools: entry.tools, annotations: entry.annotations ?? {} };
+    }),
+  };
+}
+
+const echoTool = { description: "echo", inputSchema: {}, execute: async () => "ok" };
+
+describe("ingestMcpTools", () => {
+  it("fails closed: empty server list returns empty without calling the source", async () => {
+    const source = fakeSource({});
+    const result = await ingestMcpTools({ servers: [], source });
+    expect(result.toolset).toEqual({});
+    expect(result.descriptors).toEqual([]);
+    expect(source.fetchTools).not.toHaveBeenCalled();
+  });
+
+  it("prefixes tool names with the server name", async () => {
+    const source = fakeSource({ weather: { tools: { get_forecast: echoTool } } });
+    const result = await ingestMcpTools({
+      servers: [{ name: "weather", url: "http://x" }],
+      source,
+    });
+    expect(Object.keys(result.toolset)).toEqual(["weather_get_forecast"]);
+  });
+
+  it("builds descriptors with source 'mcp' and the server-reported annotations", async () => {
+    const source = fakeSource({
+      weather: {
+        tools: { get_forecast: echoTool, purge: echoTool },
+        annotations: {
+          get_forecast: { readOnlyHint: true },
+          purge: { destructiveHint: true },
+        },
+      },
+    });
+    const result = await ingestMcpTools({
+      servers: [{ name: "weather", url: "http://x" }],
+      source,
+    });
+    const byName = Object.fromEntries(result.descriptors.map((d) => [d.name, d]));
+    expect(byName["weather_get_forecast"]!.source).toBe("mcp");
+    expect(byName["weather_get_forecast"]!.annotations.readOnlyHint).toBe(true);
+    expect(byName["weather_purge"]!.annotations.destructiveHint).toBe(true);
+  });
+
+  it("narrows to the per-server allowlist by UNPREFIXED name", async () => {
+    const source = fakeSource({
+      weather: { tools: { get_forecast: echoTool, purge: echoTool } },
+    });
+    const result = await ingestMcpTools({
+      servers: [{ name: "weather", url: "http://x", tools: ["get_forecast"] }],
+      source,
+    });
+    expect(Object.keys(result.toolset)).toEqual(["weather_get_forecast"]);
+  });
+
+  it("tolerates a failing server: warns, skips it, keeps the others", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const source = fakeSource({
+      broken: new Error("connect refused"),
+      weather: { tools: { get_forecast: echoTool } },
+    });
+    const result = await ingestMcpTools({
+      servers: [
+        { name: "broken", url: "http://down" },
+        { name: "weather", url: "http://x" },
+      ],
+      source,
+    });
+    expect(Object.keys(result.toolset)).toEqual(["weather_get_forecast"]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('MCP server "broken"'),
+      expect.anything(),
+    );
+    warn.mockRestore();
+  });
+
+  it("merges multiple servers; identical unprefixed names cannot collide (prefixes differ)", async () => {
+    const source = fakeSource({
+      a: { tools: { ping: echoTool } },
+      b: { tools: { ping: echoTool } },
+    });
+    const result = await ingestMcpTools({
+      servers: [
+        { name: "a", url: "http://a" },
+        { name: "b", url: "http://b" },
+      ],
+      source,
+    });
+    expect(Object.keys(result.toolset).sort()).toEqual(["a_ping", "b_ping"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd /Users/yousefh/orca/workspaces/flowlet/mcp-client-support && pnpm --filter @flowlet/runtime test -- mcp.test.ts`
+Expected: FAIL — `./mcp` module not found.
+
+- [ ] **Step 3: Write the implementation (types + ingest only; real adapter is Task 2)**
+
+```typescript
+// packages/flowlet-runtime/src/mcp.ts
+/**
+ * Host-configured MCP server ingestion for the Flowlet agent runtime.
+ *
+ * Design: docs/superpowers/specs/2026-07-04-flowlet-mcp-client-design.md.
+ * Mirrors the Composio adapter seam: `McpToolSource` is injectable (the real
+ * adapter wraps `@ai-sdk/mcp`'s `createMCPClient`; tests inject a fake), and
+ * `ingestMcpTools` FAILS CLOSED — no declared servers means no network I/O.
+ *
+ * MCP servers are host-level (declared by the host developer, shared by all
+ * users), unlike Composio's per-user OAuth. Tools are registered as
+ * `<serverName>_<toolName>` so provenance is legible and servers can't collide
+ * with each other or with other sources.
+ */
+
+import type { ToolSet } from "ai";
+import { buildDescriptor, type ToolAnnotations, type ToolDescriptor } from "./descriptor";
+
+/** A single host-declared MCP server (Streamable HTTP transport only). */
+export interface McpServerConfig {
+  /**
+   * Prefix for this server's tool names (`<name>_<tool>`). Must be a valid
+   * tool-name fragment: letters, digits, `_`, `-`.
+   */
+  name: string;
+  /** The server's Streamable HTTP endpoint (http/https). */
+  url: string;
+  /** Extra HTTP headers, e.g. `{ Authorization: "Bearer ..." }`. */
+  headers?: Record<string, string>;
+  /** Optional narrowing allowlist of UNPREFIXED tool names. */
+  tools?: string[];
+}
+
+/** What one server's fetch yields: executable tools + their MCP annotations. */
+export interface McpFetchResult {
+  tools: ToolSet;
+  /** Per (unprefixed) tool name, the server-reported annotation hints. */
+  annotations: Record<string, ToolAnnotations>;
+}
+
+/**
+ * The Flowlet abstraction over an MCP connection. The real implementation
+ * ({@link createMcpToolSource}) wraps `@ai-sdk/mcp`; tests implement it
+ * directly.
+ */
+export interface McpToolSource {
+  fetchTools(config: McpServerConfig): Promise<McpFetchResult>;
+}
+
+/**
+ * Ingest tools from host-declared MCP servers.
+ *
+ * FAILS CLOSED: an empty server list returns empty without touching the
+ * source. Per-server fault tolerance: a server that errors is warned about and
+ * skipped — it never breaks other servers or the turn.
+ */
+export async function ingestMcpTools(args: {
+  servers: McpServerConfig[];
+  source: McpToolSource;
+}): Promise<{ toolset: ToolSet; descriptors: ToolDescriptor[] }> {
+  const { servers, source } = args;
+
+  const toolset: ToolSet = {};
+  const descriptors: ToolDescriptor[] = [];
+
+  for (const server of servers) {
+    let fetched: McpFetchResult;
+    try {
+      fetched = await source.fetchTools(server);
+    } catch (err) {
+      console.warn(`[flowlet] MCP server "${server.name}" skipped:`, err);
+      continue;
+    }
+
+    const allow = server.tools && server.tools.length > 0 ? new Set(server.tools) : null;
+    for (const [name, tool] of Object.entries(fetched.tools)) {
+      if (allow && !allow.has(name)) continue;
+      const prefixed = `${server.name}_${name}`;
+      toolset[prefixed] = tool;
+      descriptors.push(
+        buildDescriptor(prefixed, tool, "mcp", fetched.annotations[name] ?? {}),
+      );
+    }
+  }
+
+  return { toolset, descriptors };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @flowlet/runtime test -- mcp.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/flowlet-runtime/src/mcp.ts packages/flowlet-runtime/src/mcp.test.ts
+git commit -m "feat(runtime): MCP ingestion seam — McpToolSource + fail-closed ingestMcpTools"
+```
+
+---
+
+### Task 2: Real adapter `createMcpToolSource` + contract test
+
+**Files:**
+- Modify: `packages/flowlet-runtime/src/mcp.ts` (append)
+- Create: `packages/flowlet-runtime/src/mcp.contract.test.ts`
+
+- [ ] **Step 1: Write the failing contract test**
+
+The in-process server implements just enough Streamable HTTP: JSON-RPC over POST with plain-JSON responses. Notifications (no `id`) get `200` with no content-type — NOT `202` (202 makes the client open an SSE GET). `initialize` echoes the client's `protocolVersion`.
+
+```typescript
+// packages/flowlet-runtime/src/mcp.contract.test.ts
+/**
+ * Contract tests for `createMcpToolSource` against the REAL `@ai-sdk/mcp`
+ * client, served by a minimal in-process Streamable-HTTP MCP server.
+ *
+ * Also pins the private-API assumption Yousef approved: the 1.0.6 MCPClient
+ * has a runtime `listTools()` (absent from its public type) that carries the
+ * MCP `annotations` the public `tools()` discards. If an SDK bump breaks
+ * either fact, these tests fail loudly.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { createMcpToolSource } from "./mcp";
+
+const TOOLS = [
+  {
+    name: "get_forecast",
+    description: "Read the forecast",
+    inputSchema: { type: "object", properties: { city: { type: "string" } } },
+    annotations: { readOnlyHint: true },
+  },
+  {
+    name: "purge_cache",
+    description: "Destroy the cache",
+    inputSchema: { type: "object", properties: {} },
+    annotations: { destructiveHint: true },
+  },
+];
+
+let server: Server;
+let url: string;
+const seenAuthHeaders: Array<string | undefined> = [];
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (c) => (raw += c));
+    req.on("end", () => {
+      seenAuthHeaders.push(req.headers["authorization"]);
+      const msg = raw ? (JSON.parse(raw) as { id?: number; method: string; params?: { protocolVersion?: string; name?: string } }) : { method: "" };
+      const reply = (result: unknown) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result }));
+      };
+      if (msg.id === undefined) {
+        // Notification — 200 with no content-type (transport ignores the body).
+        res.writeHead(200).end();
+        return;
+      }
+      if (msg.method === "initialize") {
+        reply({
+          protocolVersion: msg.params?.protocolVersion,
+          capabilities: { tools: {} },
+          serverInfo: { name: "fake-mcp", version: "1.0.0" },
+        });
+        return;
+      }
+      if (msg.method === "tools/list") {
+        reply({ tools: TOOLS });
+        return;
+      }
+      if (msg.method === "tools/call") {
+        reply({ content: [{ type: "text", text: `ran:${msg.params?.name}` }] });
+        return;
+      }
+      reply({});
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  url = `http://127.0.0.1:${(server.address() as AddressInfo).port}/mcp`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe("createMcpToolSource (contract, real @ai-sdk/mcp)", () => {
+  it("fetches executable tools AND the annotations the public tools() drops", async () => {
+    const source = createMcpToolSource();
+    const { tools, annotations } = await source.fetchTools({ name: "fake", url });
+
+    expect(Object.keys(tools).sort()).toEqual(["get_forecast", "purge_cache"]);
+    // Every SDK-produced MCP tool must be wrappable (has execute) — the
+    // fail-closed wrapTool gate depends on this.
+    expect(typeof tools["get_forecast"]!.execute).toBe("function");
+    // The listTools() cast worked: real MCP annotations came through.
+    expect(annotations["get_forecast"]).toEqual({ readOnlyHint: true });
+    expect(annotations["purge_cache"]).toEqual({ destructiveHint: true });
+  });
+
+  it("sends configured headers on requests", async () => {
+    seenAuthHeaders.length = 0;
+    const source = createMcpToolSource();
+    await source.fetchTools({
+      name: "authy",
+      url,
+      headers: { Authorization: "Bearer sekrit" },
+    });
+    expect(seenAuthHeaders).toContain("Bearer sekrit");
+  });
+
+  it("executes a tool round-trip through the real client", async () => {
+    const source = createMcpToolSource();
+    const { tools } = await source.fetchTools({ name: "fake", url });
+    const result = (await tools["get_forecast"]!.execute!(
+      { city: "SF" },
+      { toolCallId: "t1", messages: [] },
+    )) as { content: Array<{ text: string }> };
+    expect(result.content[0]!.text).toBe("ran:tools/call" === "x" ? "" : "ran:get_forecast");
+  });
+
+  it("rejects (so ingest can skip the server) when the server is unreachable", async () => {
+    const source = createMcpToolSource();
+    await expect(
+      source.fetchTools({ name: "down", url: "http://127.0.0.1:1/mcp" }),
+    ).rejects.toThrow();
+  });
+});
+```
+
+Note for the executor: the `"ran:tools/call" === "x" ? ...` ternary above is a typo-guard artifact — write the assertion plainly as `expect(result.content[0]!.text).toBe("ran:get_forecast")`.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter @flowlet/runtime test -- mcp.contract.test.ts`
+Expected: FAIL — `createMcpToolSource` is not exported.
+
+- [ ] **Step 3: Implement `createMcpToolSource`**
+
+Append to `packages/flowlet-runtime/src/mcp.ts`:
+
+```typescript
+/**
+ * The shape of the raw `tools/list` result we need from the SDK's runtime
+ * `listTools()` method. In `@ai-sdk/mcp@1.0.6` this method exists on the
+ * MCPClient class but is missing from the public interface (it became public
+ * in 2.x, which we can't take yet — it targets @ai-sdk/provider@4). The
+ * structural cast below is contract-tested in mcp.contract.test.ts.
+ */
+interface RawListToolsResult {
+  tools: Array<{ name: string; annotations?: ToolAnnotations & { title?: string } }>;
+}
+
+/**
+ * Build the REAL MCP tool source on `@ai-sdk/mcp@1.0.6` (Streamable HTTP
+ * transport, static headers — the approved v1 scope).
+ *
+ * Client lifecycle: one client per server name, created lazily on first fetch
+ * and kept open for reuse. A fetch failure closes + evicts that server's
+ * client so the next fetch rebuilds the connection, then rethrows so
+ * `ingestMcpTools` can skip the server.
+ *
+ * The public `tools()` gives executable ai-SDK tools but DISCARDS MCP
+ * `annotations`; the runtime `listTools()` recovers them. If a future SDK
+ * removes `listTools`, we degrade to empty annotations (tools still ingest;
+ * the annotation policy then fail-safes every call to "approve").
+ */
+export function createMcpToolSource(): McpToolSource {
+  type Client = {
+    tools(): Promise<ToolSet>;
+    close(): Promise<void>;
+  };
+  const clients = new Map<string, Promise<Client>>();
+
+  async function getClient(config: McpServerConfig): Promise<Client> {
+    let client = clients.get(config.name);
+    if (!client) {
+      client = import("@ai-sdk/mcp").then(({ createMCPClient }) =>
+        createMCPClient({
+          transport: {
+            type: "http",
+            url: config.url,
+            ...(config.headers ? { headers: config.headers } : {}),
+          },
+        }),
+      ) as Promise<Client>;
+      clients.set(config.name, client);
+    }
+    return client;
+  }
+
+  return {
+    async fetchTools(config) {
+      try {
+        const client = await getClient(config);
+        const tools = await client.tools();
+
+        // Recover the annotations the public API drops (see docstring).
+        let annotations: Record<string, ToolAnnotations> = {};
+        const maybeListTools = (client as unknown as {
+          listTools?: () => Promise<RawListToolsResult>;
+        }).listTools;
+        if (typeof maybeListTools === "function") {
+          const listed = await maybeListTools.call(client);
+          annotations = Object.fromEntries(
+            listed.tools.map((t) => {
+              const { title: _title, ...hints } = t.annotations ?? {};
+              return [t.name, hints];
+            }),
+          );
+        } else {
+          console.warn(
+            `[flowlet] MCP server "${config.name}": SDK listTools() unavailable — ` +
+              "annotations unknown, all its tools will require approval.",
+          );
+        }
+
+        return { tools, annotations };
+      } catch (err) {
+        // Drop the (possibly dead) client so the next fetch reconnects.
+        const stale = clients.get(config.name);
+        clients.delete(config.name);
+        if (stale) void stale.then((c) => c.close()).catch(() => {});
+        throw err;
+      }
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run the contract tests to verify they pass**
+
+Run: `pnpm --filter @flowlet/runtime test -- mcp.contract.test.ts`
+Expected: PASS (4 tests). If `initialize` fails, debug the fake server against the SDK source at `node_modules/.pnpm/@ai-sdk+mcp@1.0.6_zod@3.25.76/node_modules/@ai-sdk/mcp/dist/index.js` (transport: ~line 1325; supported protocol versions: ~line 78).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/flowlet-runtime/src/mcp.ts packages/flowlet-runtime/src/mcp.contract.test.ts
+git commit -m "feat(runtime): real MCP tool source on @ai-sdk/mcp with annotation recovery + contract tests"
+```
+
+---
+
+### Task 3: Engine wiring — `mcp` config, host-level cache, 4th source
+
+**Files:**
+- Modify: `packages/flowlet-runtime/src/engine.ts`
+- Modify: `packages/flowlet-runtime/src/engine.test.ts`
+
+- [ ] **Step 1: Write the failing engine tests**
+
+Add to `packages/flowlet-runtime/src/engine.test.ts` (follow the existing composio-injection pattern in that file — `mockModel()`, `collect()`, `userTurn`, `allowPolicy` already exist there):
+
+```typescript
+describe("MCP ingestion wiring", () => {
+  const echoTool = { description: "echo", inputSchema: {}, execute: async () => "ok" };
+
+  function fakeMcpSource(result?: { tools: ToolSet; annotations: Record<string, Record<string, boolean>> }) {
+    return {
+      fetchTools: vi.fn(async () =>
+        result ?? { tools: { ping: echoTool }, annotations: { ping: { readOnlyHint: true } } },
+      ),
+    };
+  }
+
+  it("ingests MCP tools once (host-level cache) across runs and principals", async () => {
+    const source = fakeMcpSource();
+    const agent = createFlowletAgent({
+      model: mockModel(),
+      policy: allowPolicy,
+      mcp: { servers: [{ name: "srv", url: "http://x" }], source },
+    });
+
+    await collect(agent.run({ messages: userTurn, tools: {}, principal: { userId: "u1" }, signal: new AbortController().signal }));
+    await collect(agent.run({ messages: userTurn, tools: {}, principal: { userId: "u2" }, signal: new AbortController().signal }));
+
+    expect(source.fetchTools).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries MCP ingestion on a later run after a failure (failures are not cached)", async () => {
+    const source = {
+      fetchTools: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("boom"))
+        .mockResolvedValue({ tools: { ping: echoTool }, annotations: {} }),
+    };
+    const agent = createFlowletAgent({
+      model: mockModel(),
+      policy: allowPolicy,
+      mcp: { servers: [{ name: "srv", url: "http://x" }], source },
+    });
+
+    await collect(agent.run({ messages: userTurn, tools: {}, signal: new AbortController().signal }));
+    await collect(agent.run({ messages: userTurn, tools: {}, signal: new AbortController().signal }));
+
+    expect(source.fetchTools).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not construct any MCP machinery when config.mcp is absent", async () => {
+    // Covered structurally: no `mcp` config → no source built, no fetch.
+    // Assert via the module boundary: an agent without mcp runs fine.
+    const agent = createFlowletAgent({ model: mockModel(), policy: allowPolicy });
+    const parts = await collect(agent.run({ messages: userTurn, tools: {}, signal: new AbortController().signal }));
+    expect(parts.length).toBeGreaterThan(0);
+  });
+});
+```
+
+Also add a precedence test to `packages/flowlet-runtime/src/toolset.test.ts`-style expectations INSIDE `engine.test.ts` if an equivalent doesn't exist: a caller tool named `srv_ping` and an MCP tool that prefixes to `srv_ping` → the caller wins and a collision warning fires (spy on `console.warn`).
+
+Note: ingestion failures inside a run surface via the engine's per-server tolerance in `ingestMcpTools` — but the test above injects failure at the SOURCE level, which `ingestMcpTools` catches per-server, returning empty. So "retries after failure" must be asserted against the cache: the engine caches the ingestion PROMISE only when it resolves with fetch attempts made. Implementation note (Step 2): because `ingestMcpTools` never rejects (it catches per-server), cache the result only when at least one server succeeded OR cache unconditionally but re-ingest when the previous result was empty-with-servers-declared. Simplest correct rule, mirroring "failures are never cached": **cache the promise; if the resolved toolset is empty while servers were declared, evict after resolution so the next run retries.**
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @flowlet/runtime test -- engine.test.ts`
+Expected: FAIL — `mcp` is not a known config property (TS error) / tools not ingested.
+
+- [ ] **Step 3: Implement engine wiring**
+
+In `packages/flowlet-runtime/src/engine.ts`:
+
+1. Import: `import { ingestMcpTools, createMcpToolSource, type McpServerConfig, type McpToolSource } from "./mcp";`
+2. Add to `FlowletAgentConfig`:
+
+```typescript
+  /** Optional MCP ingestion (host-declared servers). `source` is injectable for tests. */
+  mcp?: { servers: McpServerConfig[]; source?: McpToolSource };
+```
+
+3. Beside the composio client construction (~line 102):
+
+```typescript
+  // MCP tools are HOST-level (declared by the host, shared across users), so
+  // one ingestion serves every principal — unlike the per-user Composio cache.
+  const mcpSource: McpToolSource | undefined = config.mcp
+    ? config.mcp.source ?? createMcpToolSource()
+    : undefined;
+  let mcpCache: Promise<Ingested> | null = null;
+```
+
+4. Inside `execute`, after the composio block (step 3 in the existing numbering):
+
+```typescript
+        // 3b. MCP ingestion (fail-closed inside ingestMcpTools; per-server
+        //     fault tolerance). Cached host-level: the tools/list round-trip
+        //     blocks only the first turn. `ingestMcpTools` never rejects, so
+        //     "don't cache failures" means: if servers were declared but
+        //     NOTHING ingested (all servers down), evict so the next turn
+        //     retries instead of permanently running tool-less.
+        let mcpTools: ToolSet = {};
+        let mcpDescriptors: Record<string, ToolDescriptor> = {};
+        if (config.mcp && mcpSource && config.mcp.servers.length > 0) {
+          const servers = config.mcp.servers;
+          const source = mcpSource;
+          if (!mcpCache) {
+            mcpCache = ingestMcpTools({ servers, source }).then((ingested) => {
+              if (Object.keys(ingested.toolset).length === 0) mcpCache = null;
+              return {
+                toolset: ingested.toolset,
+                descriptors: Object.fromEntries(ingested.descriptors.map((d) => [d.name, d])),
+              };
+            });
+          }
+          const ingested = await mcpCache;
+          mcpTools = ingested.toolset;
+          mcpDescriptors = ingested.descriptors;
+        }
+```
+
+5. Extend the sources array (F2 precedence — MCP last):
+
+```typescript
+        const sources: ToolSourceInput[] = [
+          { source: "caller", tools: input.tools ?? {} },
+          {
+            source: "engine",
+            tools: {
+              ...config.tools,
+              [RENDER_VIEW_TOOL_NAME]: renderViewTool,
+              [REQUEST_CONNECT_TOOL_NAME]: requestConnectTool,
+            },
+          },
+          { source: "composio", tools: composioTools, descriptors: composioDescriptors },
+          { source: "mcp", tools: mcpTools, descriptors: mcpDescriptors },
+        ];
+```
+
+- [ ] **Step 4: Run engine tests to verify they pass**
+
+Run: `pnpm --filter @flowlet/runtime test -- engine.test.ts`
+Expected: PASS (existing + 3-4 new tests).
+
+- [ ] **Step 5: Export the new symbols**
+
+In `packages/flowlet-runtime/src/index.ts`, next to the composio exports add:
+
+```typescript
+export {
+  ingestMcpTools,
+  createMcpToolSource,
+  type McpServerConfig,
+  type McpToolSource,
+  type McpFetchResult,
+} from "./mcp";
+```
+
+- [ ] **Step 6: Full runtime package check**
+
+Run: `pnpm --filter @flowlet/runtime test && pnpm --filter @flowlet/runtime typecheck`
+Expected: all green (including the dependency-guard test — `@ai-sdk/mcp` is already allowlisted).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/flowlet-runtime/src/engine.ts packages/flowlet-runtime/src/engine.test.ts packages/flowlet-runtime/src/index.ts
+git commit -m "feat(runtime): wire MCP as the 4th tool source with host-level ingestion cache"
+```
+
+---
+
+### Task 4: `@flowlet/next` — mcp.json schema + env substitution (`mcp-config.ts`)
+
+**Files:**
+- Create: `packages/flowlet-next/src/mcp-config.ts`
+- Create: `packages/flowlet-next/src/mcp-config.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// packages/flowlet-next/src/mcp-config.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { mcpJsonSchema, resolveMcpServers } from "./mcp-config";
+
+describe("mcpJsonSchema", () => {
+  it("accepts a valid file shape", () => {
+    const parsed = mcpJsonSchema.safeParse({
+      version: 1,
+      servers: [
+        { name: "weather", url: "https://mcp.example.com/mcp", headers: { Authorization: "Bearer ${WEATHER_TOKEN}" }, tools: ["get_forecast"] },
+      ],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects a server name that is not a valid tool-name fragment", () => {
+    expect(mcpJsonSchema.safeParse({ version: 1, servers: [{ name: "bad name!", url: "https://x" }] }).success).toBe(false);
+  });
+
+  it("rejects non-http(s) URLs", () => {
+    expect(mcpJsonSchema.safeParse({ version: 1, servers: [{ name: "s", url: "file:///etc/passwd" }] }).success).toBe(false);
+  });
+
+  it("rejects unknown keys (strict)", () => {
+    expect(mcpJsonSchema.safeParse({ version: 1, servers: [{ name: "s", url: "https://x", transport: "stdio" }] }).success).toBe(false);
+  });
+});
+
+describe("resolveMcpServers", () => {
+  it("substitutes ${ENV_VAR} in header values", () => {
+    const resolved = resolveMcpServers(
+      [{ name: "s", url: "https://x", headers: { Authorization: "Bearer ${TOK}" } }],
+      { TOK: "abc123" },
+    );
+    expect(resolved).toEqual([{ name: "s", url: "https://x", headers: { Authorization: "Bearer abc123" } }]);
+  });
+
+  it("drops a server (with a warning) when a referenced env var is missing or empty", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const resolved = resolveMcpServers(
+      [
+        { name: "broken", url: "https://x", headers: { Authorization: "Bearer ${NOPE}" } },
+        { name: "ok", url: "https://y" },
+      ],
+      {},
+    );
+    expect(resolved.map((s) => s.name)).toEqual(["ok"]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('"broken"'));
+    warn.mockRestore();
+  });
+
+  it("passes through servers with no headers untouched", () => {
+    expect(resolveMcpServers([{ name: "s", url: "https://x", tools: ["a"] }], {})).toEqual([
+      { name: "s", url: "https://x", tools: ["a"] },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @flowlet/next test -- mcp-config.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// packages/flowlet-next/src/mcp-config.ts
+/**
+ * `.flowlet/mcp.json` schema + resolution for host-declared MCP servers.
+ *
+ * The file holds the SAME shape as the `mcpServers` handler option, wrapped in
+ * a versioned envelope (like tools.json). Header values may reference env vars
+ * as `${VAR_NAME}` so tokens never live in the checked-in file. A server whose
+ * referenced var is missing/empty is DROPPED with a boot warning — fail
+ * closed, never send empty auth.
+ */
+import { z } from "zod";
+import type { McpServerConfig } from "@flowlet/runtime";
+
+/** Matches `<serverName>_<toolName>` tool-name rules (letters, digits, _ , -). */
+const NAME_FRAGMENT = /^[A-Za-z0-9_-]+$/;
+
+export const mcpServerSchema = z
+  .object({
+    name: z.string().regex(NAME_FRAGMENT, "server name must be letters, digits, _ or -"),
+    url: z.string().url().refine((u) => u.startsWith("http://") || u.startsWith("https://"), {
+      message: "MCP server URL must be http(s)",
+    }),
+    headers: z.record(z.string()).optional(),
+    tools: z.array(z.string().min(1)).optional(),
+  })
+  .strict();
+
+export const mcpJsonSchema = z
+  .object({
+    version: z.literal(1),
+    servers: z.array(mcpServerSchema),
+  })
+  .strict();
+
+export type McpJson = z.infer<typeof mcpJsonSchema>;
+
+const ENV_REF = /\$\{([A-Z0-9_]+)\}/g;
+
+/**
+ * Substitute `${VAR}` references in header values from `env`. A server that
+ * references a missing/empty var is dropped with a warning.
+ */
+export function resolveMcpServers(
+  servers: McpServerConfig[],
+  env: Record<string, string | undefined> = process.env,
+): McpServerConfig[] {
+  const resolved: McpServerConfig[] = [];
+  for (const server of servers) {
+    if (!server.headers) {
+      resolved.push(server);
+      continue;
+    }
+    let missing: string | null = null;
+    const headers: Record<string, string> = {};
+    for (const [key, value] of Object.entries(server.headers)) {
+      headers[key] = value.replace(ENV_REF, (_, varName: string) => {
+        const v = env[varName];
+        if (v === undefined || v.trim() === "") missing = varName;
+        return v ?? "";
+      });
+    }
+    if (missing) {
+      console.warn(
+        `[flowlet] MCP server "${server.name}" dropped: header references env var ` +
+          `\${${missing}} which is not set.`,
+      );
+      continue;
+    }
+    resolved.push({ ...server, headers });
+  }
+  return resolved;
+}
+```
+
+- [ ] **Step 4: Run to verify pass, then commit**
+
+Run: `pnpm --filter @flowlet/next test -- mcp-config.test.ts`
+Expected: PASS.
+
+```bash
+git add packages/flowlet-next/src/mcp-config.ts packages/flowlet-next/src/mcp-config.test.ts
+git commit -m "feat(next): mcp.json schema + \${ENV_VAR} header substitution with fail-closed drops"
+```
+
+---
+
+### Task 5: Load `.flowlet/mcp.json` in `flowlet-dir.ts`
+
+**Files:**
+- Modify: `packages/flowlet-next/src/flowlet-dir.ts`
+- Modify: `packages/flowlet-next/src/flowlet-dir.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Follow the existing test file's pattern (it writes temp dirs with theme.json/tools.json). Add:
+
+```typescript
+describe("mcp.json", () => {
+  it("returns undefined mcpServers when mcp.json is absent (zero-config)", () => {
+    const dir = makeDir({}); // helper from the existing tests
+    expect(loadFlowletDir(dir).mcpServers).toBeUndefined();
+  });
+
+  it("loads and validates mcp.json when present", () => {
+    const dir = makeDir({
+      "mcp.json": JSON.stringify({
+        version: 1,
+        servers: [{ name: "weather", url: "https://mcp.example.com/mcp" }],
+      }),
+    });
+    expect(loadFlowletDir(dir).mcpServers).toEqual([
+      { name: "weather", url: "https://mcp.example.com/mcp" },
+    ]);
+  });
+
+  it("fails loud on a present-but-invalid mcp.json", () => {
+    const dir = makeDir({ "mcp.json": JSON.stringify({ version: 1, servers: [{ name: "x" }] }) });
+    expect(() => loadFlowletDir(dir)).toThrow(/mcp\.json/);
+  });
+});
+```
+
+(If the existing test file's temp-dir helper has a different name/shape, adapt to it — the three behaviors above are what matter: absent → undefined, valid → parsed servers, invalid → loud throw.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @flowlet/next test -- flowlet-dir.test.ts`
+Expected: FAIL — `mcpServers` not on `LoadedFlowletDir`.
+
+- [ ] **Step 3: Implement**
+
+In `packages/flowlet-next/src/flowlet-dir.ts`:
+
+```typescript
+import { mcpJsonSchema } from "./mcp-config";
+import type { McpServerConfig } from "@flowlet/runtime";
+
+export interface LoadedFlowletDir {
+  brand: BrandTokens;
+  manifest: ToolsManifest;
+  /** Raw (pre-env-substitution) servers from mcp.json; absent file → undefined. */
+  mcpServers?: McpServerConfig[];
+}
+```
+
+And in `loadFlowletDir`, after the tools.json block:
+
+```typescript
+  const mcpRaw = readJson(path.join(dir, "mcp.json"));
+  let mcpServers: McpServerConfig[] | undefined;
+  if (mcpRaw !== undefined) {
+    const parsed = mcpJsonSchema.safeParse(mcpRaw);
+    if (!parsed.success) {
+      throw new Error(`mcp.json does not match the MCP servers schema: ${parsed.error.message}`);
+    }
+    mcpServers = parsed.data.servers;
+  }
+
+  return { brand, manifest, ...(mcpServers ? { mcpServers } : {}) };
+```
+
+- [ ] **Step 4: Run to verify pass, then commit**
+
+Run: `pnpm --filter @flowlet/next test -- flowlet-dir.test.ts`
+
+```bash
+git add packages/flowlet-next/src/flowlet-dir.ts packages/flowlet-next/src/flowlet-dir.test.ts
+git commit -m "feat(next): load .flowlet/mcp.json (absent-safe, loud on invalid)"
+```
+
+---
+
+### Task 6: `mcpServers` handler option + `capabilities.mcp`
+
+**Files:**
+- Modify: `packages/flowlet-next/src/options.ts`
+- Modify: `packages/flowlet-next/src/options.test.ts`
+- Modify: `packages/flowlet-next/src/capabilities.ts`
+- Modify: `packages/flowlet-next/src/capabilities.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+`options.test.ts` — follow the file's existing accept/reject pattern:
+
+```typescript
+it("accepts mcpServers", () => {
+  expect(() =>
+    parseHandlerOptions({
+      mcpServers: [{ name: "weather", url: "https://mcp.example.com/mcp", headers: { Authorization: "Bearer x" }, tools: ["get_forecast"] }],
+    }),
+  ).not.toThrow();
+});
+
+it("rejects an mcpServers entry with a bad name or unknown key", () => {
+  expect(() => parseHandlerOptions({ mcpServers: [{ name: "bad name", url: "https://x" }] })).toThrow(/invalid options/);
+  expect(() => parseHandlerOptions({ mcpServers: [{ name: "s", url: "https://x", transport: "stdio" } as never] })).toThrow(/invalid options/);
+});
+```
+
+`capabilities.test.ts` — the interface gains `mcp` (env alone can't detect it; the handler computes it, so `detectCapabilities` reports `false`):
+
+```typescript
+it("reports mcp false from env detection (the handler overrides it from resolved config)", () => {
+  expect(detectCapabilities({ ANTHROPIC_API_KEY: "k" }).mcp).toBe(false);
+});
+```
+
+Also update any existing exact-object assertions in `capabilities.test.ts` to include `mcp: false`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @flowlet/next test -- options.test.ts capabilities.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+`options.ts`:
+- Import: `import { mcpServerSchema } from "./mcp-config";` and `import type { McpServerConfig } from "@flowlet/runtime";`
+- Add to `FlowletHandlerOptions` (after `integrations`):
+
+```typescript
+  /**
+   * Host-declared MCP servers (Streamable HTTP). Tools are ingested through
+   * the policy engine as source "mcp", prefixed `<name>_<tool>`. OVERRIDES
+   * `.flowlet/mcp.json` entirely when provided.
+   */
+  mcpServers?: McpServerConfig[];
+```
+
+- Add to the zod schema: `mcpServers: z.array(mcpServerSchema).optional(),`
+
+`capabilities.ts`:
+
+```typescript
+export interface FlowletCapabilities {
+  chat: boolean;
+  integrations: boolean;
+  voice: boolean;
+  /** True when the host declared ≥1 MCP server (set by the handler, not env). */
+  mcp: boolean;
+}
+```
+
+and in `detectCapabilities` return: `mcp: false,` with a comment: `// MCP is config-presence, not key-presence — the handler overrides this.`
+
+- [ ] **Step 4: Run to verify pass, then commit**
+
+Run: `pnpm --filter @flowlet/next test -- options.test.ts capabilities.test.ts`
+
+```bash
+git add packages/flowlet-next/src/options.ts packages/flowlet-next/src/options.test.ts packages/flowlet-next/src/capabilities.ts packages/flowlet-next/src/capabilities.test.ts
+git commit -m "feat(next): mcpServers option + capabilities.mcp flag"
+```
+
+---
+
+### Task 7: Handler + agent-cache wiring
+
+**Files:**
+- Modify: `packages/flowlet-next/src/agent.ts`
+- Modify: `packages/flowlet-next/src/handler.ts`
+- Modify: `packages/flowlet-next/src/handler.test.ts`
+
+- [ ] **Step 1: Write the failing handler tests**
+
+Add to `packages/flowlet-next/src/handler.test.ts` (follow its existing patterns for building a handler and hitting endpoints; `GET /capabilities` responses are plain JSON):
+
+```typescript
+describe("mcp wiring", () => {
+  it("capabilities.mcp is true when mcpServers option is set", async () => {
+    const { GET } = createFlowletHandler({
+      mcpServers: [{ name: "weather", url: "https://mcp.example.com/mcp" }],
+    });
+    const res = await GET(new Request("http://localhost/api/flowlet/capabilities"));
+    const body = await res.json();
+    expect(body.mcp).toBe(true);
+  });
+
+  it("capabilities.mcp is false with no servers declared", async () => {
+    const { GET } = createFlowletHandler();
+    const res = await GET(new Request("http://localhost/api/flowlet/capabilities"));
+    expect((await res.json()).mcp).toBe(false);
+  });
+
+  it("capabilities.mcp is false when the only declared server is dropped by env substitution", async () => {
+    // Server declared via option with a header referencing a missing var is
+    // NOT dropped (option passes through as-is; substitution is file-only) —
+    // so this test goes through the flowlet-dir path: point flowletDir at a
+    // temp dir whose mcp.json references ${DEFINITELY_NOT_SET_VAR}.
+    const dir = writeTempFlowletDir({
+      "mcp.json": JSON.stringify({
+        version: 1,
+        servers: [{ name: "s", url: "https://x", headers: { Authorization: "Bearer ${DEFINITELY_NOT_SET_VAR}" } }],
+      }),
+    });
+    const { GET } = createFlowletHandler({ flowletDir: dir });
+    const res = await GET(new Request("http://localhost/api/flowlet/capabilities"));
+    expect((await res.json()).mcp).toBe(false);
+  });
+});
+```
+
+(Use/extend the test file's existing temp-dir helper for `writeTempFlowletDir`; if none exists, create the dir with `node:fs` `mkdtempSync` + `writeFileSync` as the flowlet-dir tests do. Note `GET /capabilities` requires the local-request guard — follow how existing handler tests satisfy `resolvePrincipal`.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @flowlet/next test -- handler.test.ts`
+Expected: FAIL — `mcp` missing from capabilities response.
+
+- [ ] **Step 3: Implement wiring**
+
+`agent.ts` — extend `AgentFactoryConfig` and pass through:
+
+```typescript
+import type { McpServerConfig } from "@flowlet/runtime";
+
+export interface AgentFactoryConfig {
+  // ... existing fields ...
+  /** Host-declared MCP servers (already env-resolved). Empty/undefined = MCP off. */
+  mcpServers?: McpServerConfig[];
+}
+```
+
+In `createAgentCache`'s `createFlowletAgent` call, after the composio spread:
+
+```typescript
+        ...(config.mcpServers && config.mcpServers.length > 0
+          ? { mcp: { servers: config.mcpServers } }
+          : {}),
+```
+
+(No cache-key change: the server set is fixed for the handler's lifetime, unlike connected toolkits.)
+
+`handler.ts` — in `assemble()`:
+
+```typescript
+import { resolveMcpServers } from "./mcp-config";
+```
+
+After `const connections = ...`:
+
+```typescript
+    // MCP servers: code option OVERRIDES the file entirely; ${ENV_VAR} header
+    // substitution applies only to file-sourced entries (code already runs in
+    // an env-aware context). A server whose var is missing is dropped, warned.
+    const mcpServers =
+      options.mcpServers ?? resolveMcpServers(loaded.mcpServers ?? []);
+```
+
+Change the capabilities line:
+
+```typescript
+    const capabilities = { ...detectCapabilities(), mcp: mcpServers.length > 0 };
+```
+
+And add to the `createAgentCache` call:
+
+```typescript
+      ...(mcpServers.length > 0 ? { mcpServers } : {}),
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm --filter @flowlet/next test -- handler.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Full package check + commit**
+
+Run: `pnpm --filter @flowlet/next test && pnpm --filter @flowlet/next typecheck`
+
+```bash
+git add packages/flowlet-next/src/agent.ts packages/flowlet-next/src/handler.ts packages/flowlet-next/src/handler.test.ts
+git commit -m "feat(next): wire host-declared MCP servers into the agent + capabilities"
+```
+
+---
+
+### Task 8: Docs + repo-wide verification
+
+**Files:**
+- Modify: `docs/quickstart.md`
+
+- [ ] **Step 1: Add the MCP section to the quickstart**
+
+After the capability-keys table section, add (match the doc's existing voice — terse, imperative):
+
+```markdown
+## MCP servers
+
+Point Flowlet at any remote MCP server and its tools become agent tools, governed by the same approval policy as everything else.
+
+Either declare them in code:
+
+​```ts
+export const { GET, POST } = createFlowletHandler({
+  mcpServers: [
+    {
+      name: "weather",                          // tools appear as weather_<tool>
+      url: "https://mcp.example.com/mcp",       // Streamable HTTP endpoint
+      headers: { Authorization: "Bearer ${...}" }, // optional; put real tokens in code/env
+      tools: ["get_forecast"],                  // optional allowlist; omit = all tools
+    },
+  ],
+});
+​```
+
+or in `.flowlet/mcp.json` (the code option wins if both exist):
+
+​```json
+{
+  "version": 1,
+  "servers": [
+    {
+      "name": "weather",
+      "url": "https://mcp.example.com/mcp",
+      "headers": { "Authorization": "Bearer ${WEATHER_TOKEN}" }
+    }
+  ]
+}
+​```
+
+In `mcp.json`, `${VAR}` in header values is read from the environment at boot; a server whose variable is unset is skipped with a warning. Notes: HTTP transport only (no stdio), static headers only (OAuth-only servers not yet supported), tools only (no resources/prompts). Server-reported annotations are honored: read-only tools run freely, everything else pauses for approval.
+```
+
+(Remove the `​` zero-width guards around the fences when writing the real file — they exist only to nest fences in this plan.)
+
+- [ ] **Step 2: Repo-wide verification**
+
+Run: `pnpm typecheck && pnpm test && pnpm build`
+Expected: all green. Fix anything that isn't before proceeding.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/quickstart.md
+git commit -m "docs: MCP servers quickstart section"
+```
+
+---
+
+### Task 9: Live smoke verification (before PR)
+
+No new files — this is the verification-before-completion gate.
+
+- [ ] **Step 1: Run a real MCP server locally and exercise the full path**
+
+Use the reference Everything server (has read-only AND destructive-ish tools) over Streamable HTTP:
+
+```bash
+npx -y @modelcontextprotocol/server-everything streamableHttp --port 3311
+```
+
+(Its HTTP endpoint is `http://localhost:3311/mcp`. If the CLI shape differs, check `npx @modelcontextprotocol/server-everything --help`.)
+
+Then a scratch script (scratchpad, not committed) that builds `createMcpToolSource()`, fetches from `{ name: "everything", url: "http://localhost:3311/mcp" }`, and prints tool names + recovered annotations. Verify:
+1. Tools list non-empty, names come back unprefixed from the source (prefixing happens in ingest).
+2. `annotations` includes real hints (e.g. `echo` has `readOnlyHint` in recent versions — if the server version reports no annotations, verify the field is `{}` and note it).
+3. A tool executes round-trip.
+
+- [ ] **Step 2: End-to-end through a demo app**
+
+Add the everything server to the Cadence or demo-bank app's handler config (`mcpServers: [...]` — local change, not committed), run `pnpm demo`, and in the chat ask the agent to call an MCP tool (e.g. "use the everything echo tool to echo 'hi'"). Verify:
+1. The tool call appears and (annotation-dependent) either runs directly (readOnly) or pauses for approval.
+2. Approving executes and the result reaches the model.
+3. Console shows no collision/skip warnings.
+
+Capture terminal/browser evidence for the PR body (this feature is not UI-affecting — no screenshots of new UI needed, but the chat transcript screenshot is good PR evidence).
+
+- [ ] **Step 3: Open the PR**
+
+Branch is `yousefh409/mcp-client-support`. Push and open a PR titled `feat: MCP client support — host-configured servers as policy-governed agent tools (spec 2026-07-04)`, body covering: spec link, the 8 scope rulings, the `listTools()` cast rationale + contract-test guard, live-smoke evidence. **Never merge — Yousef merges.**
+
+---
+
+## Self-review notes (completed)
+
+- **Spec coverage:** ingestion module (T1/T2), engine wiring + precedence (T3), config surfaces + override + env substitution (T4-T7), capability flag (T6/T7), error handling table (T1 fault tolerance, T4 drop-on-missing, T3 cache-retry, existing onCollision/onSkip), testing section (unit T1, contract T2, handler T5-T7, live smoke T9), docs (T8). Deferred list needs no code.
+- **Types:** `McpServerConfig`/`McpToolSource`/`McpFetchResult` defined in T1, consumed in T2/T3 (runtime) and T4-T7 (next, via `@flowlet/runtime` exports added in T3 Step 5 — note Tasks 4-7 need Task 3's export step done first).
+- **Known judgment calls for the executor:** engine cache eviction rule (empty-with-servers → evict) is spelled out in T3; contract-test fake server details (notification = 200 no content-type, echo protocolVersion) are spelled out in T2.

--- a/docs/superpowers/plans/2026-07-04-flowlet-mcp-client.md
+++ b/docs/superpowers/plans/2026-07-04-flowlet-mcp-client.md
@@ -11,7 +11,7 @@
 **Key SDK facts (verified against the installed package, 2026-07-04):**
 - `createMCPClient({ transport: { type: "http", url, headers } })` → `Promise<MCPClient>`; `client.tools()` → `ToolSet` where every tool has `execute` and `_meta`.
 - **`client.tools()` DISCARDS MCP `annotations`** (uses only `annotations.title`). The runtime class HAS a `listTools()` method returning the raw `tools/list` result (with `annotations`), but it's missing from the 1.0.6 public type. Yousef-approved approach: call it via a narrow structural cast + a contract test that fails loudly if an SDK bump removes it. If the method is absent at runtime, degrade to empty annotations (tools still ingest; policy fail-safes them to "approve").
-- The HTTP transport accepts plain `application/json` responses, so the contract test runs a tiny in-process `node:http` JSON-RPC server (no SSE needed). For JSON-RPC *notifications* the test server must reply `200` with **no content-type** (the transport ignores such bodies; a `202` would make it open an SSE GET connection). The `initialize` reply must echo the client's requested `protocolVersion`.
+- The HTTP transport accepts plain `application/json` responses, so the contract test runs a tiny in-process `node:http` JSON-RPC server (no SSE needed). **Probe-verified 2026-07-04** (scratchpad `probe-mcp.mjs`, full handshake + tools + listTools + execute PASSED against the real SDK): JSON-RPC *notifications* must get `202 Accepted` — a `200` with any non-JSON/SSE content-type makes the transport throw `Unexpected content type`. The client also opens a GET (inbound SSE) at startup; reply `405` and it is tolerated. The `initialize` reply must echo the client's requested `protocolVersion`. `tools/call` params carry `arguments` (not `args`), and results come back as `{ content, isError }`.
 
 ---
 
@@ -125,7 +125,7 @@ describe("ingestMcpTools", () => {
     expect(Object.keys(result.toolset)).toEqual(["weather_get_forecast"]);
   });
 
-  it("tolerates a failing server: warns, skips it, keeps the others", async () => {
+  it("tolerates a failing server: warns, records the failure, keeps the others", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const source = fakeSource({
       broken: new Error("connect refused"),
@@ -139,10 +139,59 @@ describe("ingestMcpTools", () => {
       source,
     });
     expect(Object.keys(result.toolset)).toEqual(["weather_get_forecast"]);
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('MCP server "broken"'),
-      expect.anything(),
-    );
+    expect(result.failures).toEqual(["broken"]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('MCP server "broken"'));
+    warn.mockRestore();
+  });
+
+  it("redacts configured header values from failure logs (no token leakage)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const source = fakeSource({
+      leaky: new Error("HTTP 401: request had Authorization: Bearer sekrit-token"),
+    });
+    await ingestMcpTools({
+      servers: [
+        { name: "leaky", url: "http://x", headers: { Authorization: "Bearer sekrit-token" } },
+      ],
+      source,
+    });
+    const logged = warn.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(logged).not.toContain("sekrit-token");
+    expect(logged).toContain("[redacted]");
+    warn.mockRestore();
+  });
+
+  it("skips server-returned tool names that are not provider-safe, fail-closed", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const source = fakeSource({
+      srv: { tools: { "bad name!": echoTool, ok_tool: echoTool } },
+    });
+    const result = await ingestMcpTools({
+      servers: [{ name: "srv", url: "http://x" }],
+      source,
+    });
+    expect(Object.keys(result.toolset)).toEqual(["srv_ok_tool"]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('tool "bad name!" skipped'));
+    warn.mockRestore();
+  });
+
+  it("keeps the FIRST tool and warns on ambiguous-prefix collisions (server 'a' tool 'b_c' vs server 'a_b' tool 'c')", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const first = { description: "first", inputSchema: {}, execute: async () => "first" };
+    const source = fakeSource({
+      a: { tools: { b_c: first } },
+      a_b: { tools: { c: echoTool } },
+    });
+    const result = await ingestMcpTools({
+      servers: [
+        { name: "a", url: "http://a" },
+        { name: "a_b", url: "http://ab" },
+      ],
+      source,
+    });
+    expect(Object.keys(result.toolset)).toEqual(["a_b_c"]);
+    expect(result.toolset["a_b_c"]).toBe(first);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('collision on "a_b_c"'));
     warn.mockRestore();
   });
 
@@ -221,27 +270,70 @@ export interface McpToolSource {
 }
 
 /**
+ * Final tool names must be provider-safe: the SDK forwards them verbatim to
+ * the model API, and Anthropic caps tool names at `[A-Za-z0-9_-]{1,64}`. A
+ * server-returned name that breaks this after prefixing would 400 the WHOLE
+ * turn, so invalid names are skipped fail-closed instead.
+ */
+const VALID_TOOL_NAME = /^[A-Za-z0-9_-]{1,64}$/;
+
+/**
+ * Sanitize an error for logging. SDK transport errors embed the raw HTTP
+ * response body, which a malicious server can use to reflect the request's
+ * Authorization header — so never log the error object itself, and redact
+ * every configured header value from the message.
+ */
+function describeError(err: unknown, headers?: Record<string, string>): string {
+  let message = err instanceof Error ? err.message : String(err);
+  for (const value of Object.values(headers ?? {})) {
+    if (value.length > 0) message = message.split(value).join("[redacted]");
+  }
+  return message.slice(0, 300);
+}
+
+/**
  * Ingest tools from host-declared MCP servers.
  *
  * FAILS CLOSED: an empty server list returns empty without touching the
- * source. Per-server fault tolerance: a server that errors is warned about and
- * skipped — it never breaks other servers or the turn.
+ * source. Per-server fault tolerance: a server that errors is warned about,
+ * recorded in `failures`, and skipped — it never breaks other servers or the
+ * turn. Callers use `failures` to avoid caching a partial result.
+ *
+ * Name safety: duplicate final names (duplicate server names, or prefix
+ * ambiguity like server "a" tool "b_c" vs server "a_b" tool "c") keep the
+ * FIRST registration and warn; server-returned tool names that are not
+ * provider-safe are skipped.
  */
 export async function ingestMcpTools(args: {
   servers: McpServerConfig[];
   source: McpToolSource;
-}): Promise<{ toolset: ToolSet; descriptors: ToolDescriptor[] }> {
+}): Promise<{ toolset: ToolSet; descriptors: ToolDescriptor[]; failures: string[] }> {
   const { servers, source } = args;
 
   const toolset: ToolSet = {};
   const descriptors: ToolDescriptor[] = [];
+  const failures: string[] = [];
 
+  const seenServers = new Set<string>();
   for (const server of servers) {
+    // Duplicate server names would alias each other in the client cache and
+    // collide on every prefixed tool name. Deterministic misconfig — warn and
+    // skip, but do NOT count as a failure (failures trigger cache retry, and
+    // a deterministic one would re-ingest forever).
+    if (seenServers.has(server.name)) {
+      console.warn(`[flowlet] duplicate MCP server name "${server.name}" skipped.`);
+      continue;
+    }
+    seenServers.add(server.name);
+
     let fetched: McpFetchResult;
     try {
       fetched = await source.fetchTools(server);
     } catch (err) {
-      console.warn(`[flowlet] MCP server "${server.name}" skipped:`, err);
+      console.warn(
+        `[flowlet] MCP server "${server.name}" skipped: ${describeError(err, server.headers)}`,
+      );
+      failures.push(server.name);
       continue;
     }
 
@@ -249,6 +341,20 @@ export async function ingestMcpTools(args: {
     for (const [name, tool] of Object.entries(fetched.tools)) {
       if (allow && !allow.has(name)) continue;
       const prefixed = `${server.name}_${name}`;
+      if (!VALID_TOOL_NAME.test(prefixed)) {
+        console.warn(
+          `[flowlet] MCP server "${server.name}" tool "${name}" skipped: ` +
+            "final tool name is not provider-safe.",
+        );
+        continue;
+      }
+      if (prefixed in toolset) {
+        console.warn(
+          `[flowlet] MCP tool name collision on "${prefixed}" ` +
+            `(server "${server.name}") — keeping the first registration.`,
+        );
+        continue;
+      }
       toolset[prefixed] = tool;
       descriptors.push(
         buildDescriptor(prefixed, tool, "mcp", fetched.annotations[name] ?? {}),
@@ -256,7 +362,7 @@ export async function ingestMcpTools(args: {
     }
   }
 
-  return { toolset, descriptors };
+  return { toolset, descriptors, failures };
 }
 ```
 
@@ -282,7 +388,7 @@ git commit -m "feat(runtime): MCP ingestion seam — McpToolSource + fail-closed
 
 - [ ] **Step 1: Write the failing contract test**
 
-The in-process server implements just enough Streamable HTTP: JSON-RPC over POST with plain-JSON responses. Notifications (no `id`) get `200` with no content-type — NOT `202` (202 makes the client open an SSE GET). `initialize` echoes the client's `protocolVersion`.
+The in-process server implements just enough Streamable HTTP: JSON-RPC over POST with plain-JSON responses. Notifications (no `id`) get `202 Accepted` (probe-verified; a 200 without a JSON/SSE content-type makes the transport throw). Non-POST requests (the client's startup inbound-SSE GET) get `405` — tolerated. `initialize` echoes the client's `protocolVersion`.
 
 ```typescript
 // packages/flowlet-runtime/src/mcp.contract.test.ts
@@ -321,6 +427,11 @@ const seenAuthHeaders: Array<string | undefined> = [];
 
 beforeAll(async () => {
   server = createServer((req, res) => {
+    if (req.method !== "POST") {
+      // The client opens a GET (inbound SSE) at startup; 405 is tolerated.
+      res.writeHead(405).end();
+      return;
+    }
     let raw = "";
     req.on("data", (c) => (raw += c));
     req.on("end", () => {
@@ -331,8 +442,8 @@ beforeAll(async () => {
         res.end(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result }));
       };
       if (msg.id === undefined) {
-        // Notification — 200 with no content-type (transport ignores the body).
-        res.writeHead(200).end();
+        // Notification — 202 Accepted (a 200 without JSON/SSE content-type throws).
+        res.writeHead(202).end();
         return;
       }
       if (msg.method === "initialize") {
@@ -394,7 +505,7 @@ describe("createMcpToolSource (contract, real @ai-sdk/mcp)", () => {
       { city: "SF" },
       { toolCallId: "t1", messages: [] },
     )) as { content: Array<{ text: string }> };
-    expect(result.content[0]!.text).toBe("ran:tools/call" === "x" ? "" : "ran:get_forecast");
+    expect(result.content[0]!.text).toBe("ran:get_forecast");
   });
 
   it("rejects (so ingest can skip the server) when the server is unreachable", async () => {
@@ -405,8 +516,6 @@ describe("createMcpToolSource (contract, real @ai-sdk/mcp)", () => {
   });
 });
 ```
-
-Note for the executor: the `"ran:tools/call" === "x" ? ...` ternary above is a typo-guard artifact — write the assertion plainly as `expect(result.content[0]!.text).toBe("ran:get_forecast")`.
 
 - [ ] **Step 2: Run it to verify it fails**
 
@@ -528,11 +637,17 @@ git commit -m "feat(runtime): real MCP tool source on @ai-sdk/mcp with annotatio
 
 - [ ] **Step 1: Write the failing engine tests**
 
-Add to `packages/flowlet-runtime/src/engine.test.ts` (follow the existing composio-injection pattern in that file — `mockModel()`, `collect()`, `userTurn`, `allowPolicy` already exist there):
+Add to `packages/flowlet-runtime/src/engine.test.ts` (follow the existing composio-injection pattern in that file — `mockModel()`, `collect()`, `userTurn`, `allowPolicy` already exist there; import `tool` from `"ai"` and `z` from `"zod"` if not already imported):
 
 ```typescript
 describe("MCP ingestion wiring", () => {
-  const echoTool = { description: "echo", inputSchema: {}, execute: async () => "ok" };
+  // Must be a REAL ai-SDK tool: the engine hands the toolset to streamText,
+  // which calls asSchema(tool.inputSchema) — a bare `{}` schema crashes there.
+  const echoTool = tool({
+    description: "echo",
+    inputSchema: z.object({}),
+    execute: async () => "ok",
+  });
 
   function fakeMcpSource(result?: { tools: ToolSet; annotations: Record<string, Record<string, boolean>> }) {
     return {
@@ -622,10 +737,11 @@ In `packages/flowlet-runtime/src/engine.ts`:
 ```typescript
         // 3b. MCP ingestion (fail-closed inside ingestMcpTools; per-server
         //     fault tolerance). Cached host-level: the tools/list round-trip
-        //     blocks only the first turn. `ingestMcpTools` never rejects, so
-        //     "don't cache failures" means: if servers were declared but
-        //     NOTHING ingested (all servers down), evict so the next turn
-        //     retries instead of permanently running tool-less.
+        //     blocks only the first turn. `ingestMcpTools` never rejects —
+        //     instead it reports per-server `failures` — so "failures are
+        //     never cached" means: any failed server evicts the cache after
+        //     resolution, and the next turn re-ingests (healthy servers are
+        //     cheap to re-fetch; their clients stay open in the source).
         let mcpTools: ToolSet = {};
         let mcpDescriptors: Record<string, ToolDescriptor> = {};
         if (config.mcp && mcpSource && config.mcp.servers.length > 0) {
@@ -633,7 +749,7 @@ In `packages/flowlet-runtime/src/engine.ts`:
           const source = mcpSource;
           if (!mcpCache) {
             mcpCache = ingestMcpTools({ servers, source }).then((ingested) => {
-              if (Object.keys(ingested.toolset).length === 0) mcpCache = null;
+              if (ingested.failures.length > 0) mcpCache = null;
               return {
                 toolset: ingested.toolset,
                 descriptors: Object.fromEntries(ingested.descriptors.map((d) => [d.name, d])),
@@ -782,6 +898,13 @@ Expected: FAIL — module not found.
  * as `${VAR_NAME}` so tokens never live in the checked-in file. A server whose
  * referenced var is missing/empty is DROPPED with a boot warning — fail
  * closed, never send empty auth.
+ *
+ * SECURITY INVARIANT: server URLs and header templates come ONLY from the
+ * host's code (`mcpServers` option) or its repo (`.flowlet/mcp.json`) — never
+ * from request input. The URL schema is deliberately NOT an SSRF guard
+ * (localhost/private ranges are legitimate for host-declared servers); any
+ * future user-added-server feature MUST add network denylisting before
+ * accepting URLs from users.
  */
 import { z } from "zod";
 import type { McpServerConfig } from "@flowlet/runtime";
@@ -800,10 +923,21 @@ export const mcpServerSchema = z
   })
   .strict();
 
+/** Reject duplicate server names — they'd alias each other's tools and clients. */
+export const mcpServerArraySchema = z.array(mcpServerSchema).superRefine((servers, ctx) => {
+  const seen = new Set<string>();
+  for (const s of servers) {
+    if (seen.has(s.name)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: `duplicate MCP server name "${s.name}"` });
+    }
+    seen.add(s.name);
+  }
+});
+
 export const mcpJsonSchema = z
   .object({
     version: z.literal(1),
-    servers: z.array(mcpServerSchema),
+    servers: mcpServerArraySchema,
   })
   .strict();
 
@@ -949,13 +1083,14 @@ git commit -m "feat(next): load .flowlet/mcp.json (absent-safe, loud on invalid)
 
 **Files:**
 - Modify: `packages/flowlet-next/src/options.ts`
-- Modify: `packages/flowlet-next/src/options.test.ts`
+- Create: `packages/flowlet-next/src/options.test.ts` (does NOT exist yet — option validation is currently covered indirectly; create the file with vitest imports)
 - Modify: `packages/flowlet-next/src/capabilities.ts`
 - Modify: `packages/flowlet-next/src/capabilities.test.ts`
+- Modify: `packages/flowlet-next/src/handler.test.ts` (any exact `capabilities` object assertions gain `mcp: false` — check around line 30)
 
 - [ ] **Step 1: Write the failing tests**
 
-`options.test.ts` — follow the file's existing accept/reject pattern:
+`options.test.ts` (new file):
 
 ```typescript
 it("accepts mcpServers", () => {
@@ -969,6 +1104,17 @@ it("accepts mcpServers", () => {
 it("rejects an mcpServers entry with a bad name or unknown key", () => {
   expect(() => parseHandlerOptions({ mcpServers: [{ name: "bad name", url: "https://x" }] })).toThrow(/invalid options/);
   expect(() => parseHandlerOptions({ mcpServers: [{ name: "s", url: "https://x", transport: "stdio" } as never] })).toThrow(/invalid options/);
+});
+
+it("rejects duplicate MCP server names", () => {
+  expect(() =>
+    parseHandlerOptions({
+      mcpServers: [
+        { name: "dup", url: "https://a" },
+        { name: "dup", url: "https://b" },
+      ],
+    }),
+  ).toThrow(/invalid options/);
 });
 ```
 
@@ -1002,7 +1148,7 @@ Expected: FAIL.
   mcpServers?: McpServerConfig[];
 ```
 
-- Add to the zod schema: `mcpServers: z.array(mcpServerSchema).optional(),`
+- Add to the zod schema: `mcpServers: mcpServerArraySchema.optional(),` (imported from `./mcp-config` — rejects duplicate names too)
 
 `capabilities.ts`:
 

--- a/docs/superpowers/specs/2026-07-04-flowlet-mcp-client-design.md
+++ b/docs/superpowers/specs/2026-07-04-flowlet-mcp-client-design.md
@@ -62,11 +62,16 @@ stdio transport; OAuth server auth; user-added servers (per-user storage, SSRF g
 ## 5. Error handling summary
 
 - No servers declared → empty ingestion, zero network, capability off.
-- Server unreachable / handshake fails → warn, skip that server, keep the rest.
+- Server unreachable / handshake fails → warn (sanitized: header values are redacted from logged errors so a malicious server can't reflect tokens into logs), skip that server, keep the rest, and do NOT cache the partial result — the next turn re-ingests so the failed server is retried.
 - Env substitution target missing → warn at boot, drop that server.
-- Tool-name collision → existing `onCollision` warning, higher-precedence source wins.
+- Duplicate server names → warn, skip the later one (also rejected by zod at the config surface).
+- Server-returned tool name not provider-safe after prefixing (must match `[A-Za-z0-9_-]{1,64}`) → warn, skip that tool fail-closed (a bad name would 400 the whole turn at the model API).
+- Prefix-ambiguity collision inside MCP (server `a` tool `b_c` vs server `a_b` tool `c`) → warn, first registration wins.
+- Cross-source tool-name collision → existing `onCollision` warning, higher-precedence source wins.
 - Tool without `execute` (shouldn't happen via SDK) → existing `onSkip` fail-closed exclusion.
 - Mid-turn call failure → normal ai-SDK tool error surface, same as any tool.
+
+**SSRF posture:** server URLs come only from host code or the host's repo (`.flowlet/mcp.json`) — never from request input. The URL validation is deliberately not an SSRF guard (localhost/private ranges are legitimate for host-declared servers); user-added servers (deferred) must add network denylisting first.
 
 ## 6. Testing
 

--- a/docs/superpowers/specs/2026-07-04-flowlet-mcp-client-design.md
+++ b/docs/superpowers/specs/2026-07-04-flowlet-mcp-client-design.md
@@ -62,14 +62,16 @@ stdio transport; OAuth server auth; user-added servers (per-user storage, SSRF g
 ## 5. Error handling summary
 
 - No servers declared → empty ingestion, zero network, capability off.
-- Server unreachable / handshake fails → warn (sanitized: header values are redacted from logged errors so a malicious server can't reflect tokens into logs), skip that server, keep the rest, and do NOT cache the partial result — the next turn re-ingests so the failed server is retried.
-- Env substitution target missing → warn at boot, drop that server.
+- Server unreachable / handshake fails → warn, skip that server, keep the rest. For a server that was sent ANY headers the remote error message is withheld from logs entirely (a malicious server can reflect tokens transformed — base64/split — so substring redaction is not enough); headerless servers log the truncated message. The partial result is served from cache but scheduled for eviction after `retryDelayMs` (default 30s, engine-configurable), so failed servers are retried without a permanently-down one adding a connect timeout to every turn.
+- Env substitution target missing → warn at boot, drop that server. Same for any header value still containing `${...}` after substitution (lowercase/dashed/typo'd refs) — never send a literal template to a server.
 - Duplicate server names → warn, skip the later one (also rejected by zod at the config surface).
+- Prefix-ambiguous server names (`a` and `a_b`) → rejected by zod at the config surface.
 - Server-returned tool name not provider-safe after prefixing (must match `[A-Za-z0-9_-]{1,64}`) → warn, skip that tool fail-closed (a bad name would 400 the whole turn at the model API).
-- Prefix-ambiguity collision inside MCP (server `a` tool `b_c` vs server `a_b` tool `c`) → warn, first registration wins.
+- Final-name collision inside MCP (server `a` tool `b_c` vs server `a_b` tool `c`) → warn and drop ALL claimants of that name. First-wins would let a malicious earlier server squat a trusted server's canonical tool name; dropping both turns impersonation into (warned) denial.
 - Cross-source tool-name collision → existing `onCollision` warning, higher-precedence source wins.
 - Tool without `execute` (shouldn't happen via SDK) → existing `onSkip` fail-closed exclusion.
 - Mid-turn call failure → normal ai-SDK tool error surface, same as any tool.
+- Client-side, MCP tools stream as ai-SDK `dynamic-tool` parts: the shell thread renderer, the react auto-resubmit predicate, and the engine's stale-approval repair all handle them like static tool parts, while host-tool execution predicates deliberately ignore dynamic parts (host tools are always static — a dynamic tool spoofing a host tool name must never reach the browser executor).
 
 **SSRF posture:** server URLs come only from host code or the host's repo (`.flowlet/mcp.json`) — never from request input. The URL validation is deliberately not an SSRF guard (localhost/private ranges are legitimate for host-declared servers); user-added servers (deferred) must add network denylisting first.
 

--- a/docs/superpowers/specs/2026-07-04-flowlet-mcp-client-design.md
+++ b/docs/superpowers/specs/2026-07-04-flowlet-mcp-client-design.md
@@ -1,0 +1,76 @@
+# Flowlet MCP Client Support — Design
+
+**Date:** 2026-07-04
+**Status:** Approved by Yousef (brainstorm 2026-07-04)
+**Context:** OSS-release feature audit flagged MCP client support as the top table-stakes gap. The F2 agent-core design (2026-06-30) already reserved the seam: a 4th tool source `"mcp"` via `@ai-sdk/mcp`, precedence `caller > engine > composio > mcp`. This design fills that seam; it introduces no new architecture.
+
+## Goal
+
+A host can declare remote MCP servers and their tools become agent tools, governed by the existing policy/approval engine exactly like every other tool source. No parallel path.
+
+## Scope rulings (Yousef, 2026-07-04)
+
+| Question | Ruling |
+|---|---|
+| Who adds servers | **Host-configured only.** User-added servers deferred. |
+| Transports | **Streamable HTTP only** (with SDK SSE fallback). stdio deferred. |
+| Ingestion strictness | **All tools from a declared server by default; optional per-server `tools` allowlist** narrows. Declaring the URL is the explicit grant. |
+| Auth | **Static headers per server** (host references its own env). OAuth-only servers deferred. |
+| Annotation trust | **Trust server-sent hints, same as Composio.** `readOnlyHint` auto-allows via the existing annotation policy; destructive/unknown requires approval. |
+| Config surface | **Code option + `.flowlet/mcp.json`.** Code overrides file. |
+| UI | **None in v1.** IntegrationsPicker stays Composio-only. |
+| MCP capabilities | **Tools only.** Resources, prompts, elicitation, sampling, MCP Apps deferred. |
+
+## Approach
+
+Mirror the Composio adapter (`packages/flowlet-runtime/src/composio.ts`) structurally. Rejected alternatives: a generalized `ToolSourceProvider` plugin abstraction (YAGNI at n=2, and the sources genuinely differ — per-user OAuth vs shared host connection); doing it in `@flowlet/next` via the caller `tools` option (wrong layer: loses provenance, annotations, and non-Next consumers).
+
+Reuse the AI SDK MCP client (`createMCPClient` from `@ai-sdk/mcp@1.0.6`, already a runtime dependency and already on the dependency-guard allowlist). No hand-rolled protocol code.
+
+## 1. Runtime ingestion — `packages/flowlet-runtime/src/mcp.ts`
+
+**Config shape** (per server): `name` (required; becomes the tool-name prefix and must be a valid tool-name fragment), `url` (required; http/https), `headers` (optional map, e.g. Authorization), `tools` (optional narrowing allowlist of unprefixed tool names).
+
+**Seam:** an injectable `McpToolSource` interface (the `ComposioClient` analogue) with a single `fetchTools(config) → ToolSet` responsibility. The real implementation wraps `createMCPClient` with the HTTP transport plus `client.tools()`; tests inject a fake. Construction is lazy — nothing touches the network until first fetch.
+
+**`ingestMcpTools`** fails closed: an empty/absent server list returns empty without any network call. Per-server fault tolerance mirrors Composio's per-toolkit pattern: an unreachable or misbehaving server logs a warning and contributes nothing; it never breaks other servers or the turn.
+
+**Tool naming:** ingested tools are registered as `<serverName>_<toolName>`. Prevents cross-server collisions and collisions with other sources; makes provenance legible in approval cards. The optional `tools` allowlist matches the unprefixed name.
+
+**Descriptors:** each tool gets `buildDescriptor(prefixedName, tool, "mcp")`. The existing extraction (`_meta.annotations` / top-level `annotations`) already handles `@ai-sdk/mcp` output, so MCP `readOnlyHint`/`destructiveHint`/etc. land in the descriptor and flow through the unchanged `annotationPolicy`.
+
+**Lifecycle & caching:** MCP tools are host-level, not per-user. The engine memoizes one ingestion per server-config set — first turn pays the `tools/list` round-trip, subsequent turns resolve instantly. Failures are never cached (next turn retries). Underlying MCP clients are kept open and reused; a dead connection is rebuilt on next use rather than failing the turn permanently.
+
+## 2. Engine wiring — `packages/flowlet-runtime/src/engine.ts`
+
+New optional agent-config field `mcp: { servers: McpServerConfig[] }`. Ingestion runs beside the Composio block; the sources array becomes `caller, engine, composio, mcp` (F2 precedence — on a name collision MCP loses, and the existing `onCollision` warning fires).
+
+Every MCP tool passes through `wrapTool` via `buildToolset`: the SDK client supplies `execute`, so the fail-closed no-execute check passes, and each call gets the standard `needsApproval` preflight plus the authoritative re-evaluating `execute` gate. Zero changes to the policy directory.
+
+## 3. `@flowlet/next` surface
+
+- `createFlowletHandler({ mcpServers: [...] })`, zod-validated (strict schema, readable boot error).
+- `.flowlet/mcp.json` holding the same array, loaded via the existing flowlet-dir machinery. The code option **overrides** the file entirely (same relationship as `hostTools` vs `tools.json`).
+- Header values in `mcp.json` support `${ENV_VAR}` substitution so tokens never live in a checked-in file. A missing referenced env var drops that server with a boot-time warning (fail closed, don't send empty auth).
+- **Capability-additive:** `capabilities.mcp` is `true` iff ≥1 server is declared after resolution. No servers → surface inert, no errors — same contract as a missing `COMPOSIO_API_KEY`.
+- No UI. No IntegrationsPicker changes.
+
+## 4. Explicitly deferred
+
+stdio transport; OAuth server auth; user-added servers (per-user storage, SSRF guarding, connect UI); MCP resources/prompts/elicitation/sampling/MCP Apps; IntegrationsPicker visibility for declared servers; a per-server `trustAnnotations` override (v1 trusts hints globally per the ruling above).
+
+## 5. Error handling summary
+
+- No servers declared → empty ingestion, zero network, capability off.
+- Server unreachable / handshake fails → warn, skip that server, keep the rest.
+- Env substitution target missing → warn at boot, drop that server.
+- Tool-name collision → existing `onCollision` warning, higher-precedence source wins.
+- Tool without `execute` (shouldn't happen via SDK) → existing `onSkip` fail-closed exclusion.
+- Mid-turn call failure → normal ai-SDK tool error surface, same as any tool.
+
+## 6. Testing
+
+- **Unit (TDD, fake `McpToolSource`):** fail-closed empty config; prefixing; allowlist narrowing; per-server fault tolerance; descriptor source/annotation capture; engine precedence with all four sources.
+- **Contract:** real `@ai-sdk/mcp@1.0.6` output shape — annotations land in descriptors (extends the existing descriptor contract tests).
+- **Handler:** option validation, mcp.json loading + override, `${ENV_VAR}` substitution incl. missing-var drop, capability flag.
+- **Live smoke (verification):** one real HTTP MCP server end-to-end — tool listed, policy-gated, callable.

--- a/packages/flowlet-next/src/agent.ts
+++ b/packages/flowlet-next/src/agent.ts
@@ -12,7 +12,12 @@
  */
 import type { LanguageModel, ToolSet } from "ai";
 import type { FlowletAgent, RegisteredComponent } from "@flowlet/core";
-import { createFlowletAgent, buildBrandGuidance, type ApprovalPolicy } from "@flowlet/runtime";
+import {
+  createFlowletAgent,
+  buildBrandGuidance,
+  type ApprovalPolicy,
+  type McpServerConfig,
+} from "@flowlet/runtime";
 import type { BrandTokens } from "@flowlet/components/theme";
 import {
   prewiredComponents,
@@ -177,6 +182,8 @@ export interface AgentFactoryConfig {
   tools?: () => ToolSet;
   /** Connected Composio toolkits to ingest (undefined = Composio off). */
   toolkits?: () => string[];
+  /** Host-declared MCP servers (already env-resolved). Empty/undefined = MCP off. */
+  mcpServers?: McpServerConfig[];
   /** Extra cache-key material from the host (e.g. store generation). */
   cacheKey?: () => string;
   maxSteps?: number;
@@ -201,6 +208,11 @@ export function createAgentCache(config: AgentFactoryConfig): () => FlowletAgent
         // unconnected toolkit makes the Composio fetch fail and the agent ends
         // up with NO tools at all — an empty list is the fail-closed default.
         ...(config.toolkits ? { composio: { config: { toolkits } } } : {}),
+        // MCP servers are host-level and fixed for the handler's lifetime, so
+        // they need no cache-key material (unlike connected toolkits).
+        ...(config.mcpServers && config.mcpServers.length > 0
+          ? { mcp: { servers: config.mcpServers } }
+          : {}),
         ...(config.tools ? { tools: config.tools() } : {}),
         ...(config.maxSteps !== undefined ? { maxSteps: config.maxSteps } : {}),
         components: config.components,

--- a/packages/flowlet-next/src/capabilities.test.ts
+++ b/packages/flowlet-next/src/capabilities.test.ts
@@ -7,6 +7,7 @@ describe("detectCapabilities", () => {
       chat: true,
       integrations: false,
       voice: false,
+      mcp: false,
     });
   });
 
@@ -17,12 +18,16 @@ describe("detectCapabilities", () => {
         COMPOSIO_API_KEY: "ck_x",
         OPENAI_API_KEY: "sk-x",
       }),
-    ).toEqual({ chat: true, integrations: true, voice: true });
+    ).toEqual({ chat: true, integrations: true, voice: true, mcp: false });
   });
 
   it("treats empty/whitespace values as absent", () => {
     expect(
       detectCapabilities({ ANTHROPIC_API_KEY: "  ", COMPOSIO_API_KEY: "" }),
-    ).toEqual({ chat: false, integrations: false, voice: false });
+    ).toEqual({ chat: false, integrations: false, voice: false, mcp: false });
+  });
+
+  it("reports mcp false from env detection (the handler overrides it from resolved config)", () => {
+    expect(detectCapabilities({ ANTHROPIC_API_KEY: "k" }).mcp).toBe(false);
   });
 });

--- a/packages/flowlet-next/src/capabilities.ts
+++ b/packages/flowlet-next/src/capabilities.ts
@@ -12,6 +12,8 @@ export interface FlowletCapabilities {
   chat: boolean;
   integrations: boolean;
   voice: boolean;
+  /** True when the host declared ≥1 MCP server (set by the handler, not env). */
+  mcp: boolean;
 }
 
 function present(value: string | undefined): boolean {
@@ -25,5 +27,8 @@ export function detectCapabilities(
     chat: present(env["ANTHROPIC_API_KEY"]),
     integrations: present(env["COMPOSIO_API_KEY"]),
     voice: present(env["OPENAI_API_KEY"]),
+    // MCP is config-presence, not key-presence — the handler overrides this
+    // from the resolved server list.
+    mcp: false,
   };
 }

--- a/packages/flowlet-next/src/flowlet-dir.test.ts
+++ b/packages/flowlet-next/src/flowlet-dir.test.ts
@@ -65,4 +65,34 @@ describe("loadFlowletDir", () => {
     writeFileSync(path.join(dir, ".flowlet/theme.json"), "{nope");
     expect(() => loadFlowletDir(path.join(dir, ".flowlet"))).toThrow(/theme\.json/);
   });
+
+  it("returns undefined mcpServers when mcp.json is absent (zero-config)", () => {
+    const loaded = loadFlowletDir(path.join(scratch(), ".flowlet"));
+    expect(loaded.mcpServers).toBeUndefined();
+  });
+
+  it("loads and validates mcp.json when present", () => {
+    const dir = scratch();
+    mkdirSync(path.join(dir, ".flowlet"));
+    writeFileSync(
+      path.join(dir, ".flowlet/mcp.json"),
+      JSON.stringify({
+        version: 1,
+        servers: [{ name: "weather", url: "https://mcp.example.com/mcp" }],
+      }),
+    );
+    expect(loadFlowletDir(path.join(dir, ".flowlet")).mcpServers).toEqual([
+      { name: "weather", url: "https://mcp.example.com/mcp" },
+    ]);
+  });
+
+  it("fails loud on a schema-invalid mcp.json", () => {
+    const dir = scratch();
+    mkdirSync(path.join(dir, ".flowlet"));
+    writeFileSync(
+      path.join(dir, ".flowlet/mcp.json"),
+      JSON.stringify({ version: 1, servers: [{ name: "x" }] }),
+    );
+    expect(() => loadFlowletDir(path.join(dir, ".flowlet"))).toThrow(/mcp\.json/);
+  });
 });

--- a/packages/flowlet-next/src/flowlet-dir.ts
+++ b/packages/flowlet-next/src/flowlet-dir.ts
@@ -13,10 +13,14 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { toolsManifestSchema, type ToolsManifest } from "@flowlet/core";
 import { brandTokensSchema, defaultBrand, type BrandTokens } from "@flowlet/components/theme";
+import type { McpServerConfig } from "@flowlet/runtime";
+import { mcpJsonSchema } from "./mcp-config";
 
 export interface LoadedFlowletDir {
   brand: BrandTokens;
   manifest: ToolsManifest;
+  /** Raw (pre-env-substitution) servers from mcp.json; absent file → undefined. */
+  mcpServers?: McpServerConfig[];
 }
 
 const EMPTY_MANIFEST: ToolsManifest = { version: 1, tools: [], events: [] };
@@ -59,5 +63,15 @@ export function loadFlowletDir(dir: string = path.join(process.cwd(), ".flowlet"
     manifest = parsed.data;
   }
 
-  return { brand, manifest };
+  const mcpRaw = readJson(path.join(dir, "mcp.json"));
+  let mcpServers: McpServerConfig[] | undefined;
+  if (mcpRaw !== undefined) {
+    const parsed = mcpJsonSchema.safeParse(mcpRaw);
+    if (!parsed.success) {
+      throw new Error(`mcp.json does not match the MCP servers schema: ${parsed.error.message}`);
+    }
+    mcpServers = parsed.data.servers;
+  }
+
+  return { brand, manifest, ...(mcpServers ? { mcpServers } : {}) };
 }

--- a/packages/flowlet-next/src/handler.test.ts
+++ b/packages/flowlet-next/src/handler.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { createFlowletHandler } from "./handler";
@@ -33,7 +33,64 @@ describe("createFlowletHandler", () => {
     vi.stubEnv("OPENAI_API_KEY", "");
     const { GET } = createFlowletHandler({ flowletDir: emptyDir() });
     const res = await GET(req("/api/flowlet/capabilities"));
-    expect(await res.json()).toEqual({ chat: true, integrations: false, voice: false });
+    expect(await res.json()).toEqual({ chat: true, integrations: false, voice: false, mcp: false });
+  });
+
+  it("capabilities.mcp is true when mcpServers option is set", async () => {
+    const { GET } = createFlowletHandler({
+      flowletDir: emptyDir(),
+      mcpServers: [{ name: "weather", url: "https://mcp.example.com/mcp" }],
+    });
+    const res = await GET(req("/api/flowlet/capabilities"));
+    expect(((await res.json()) as { mcp: boolean }).mcp).toBe(true);
+  });
+
+  it("capabilities.mcp is true when .flowlet/mcp.json declares a server", async () => {
+    const dir = emptyDir();
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      path.join(dir, "mcp.json"),
+      JSON.stringify({ version: 1, servers: [{ name: "s", url: "https://x" }] }),
+    );
+    const { GET } = createFlowletHandler({ flowletDir: dir });
+    const res = await GET(req("/api/flowlet/capabilities"));
+    expect(((await res.json()) as { mcp: boolean }).mcp).toBe(true);
+  });
+
+  it("capabilities.mcp is false when the only mcp.json server is dropped by env substitution", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const dir = emptyDir();
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      path.join(dir, "mcp.json"),
+      JSON.stringify({
+        version: 1,
+        servers: [
+          {
+            name: "s",
+            url: "https://x",
+            headers: { Authorization: "Bearer ${DEFINITELY_NOT_SET_VAR_42}" },
+          },
+        ],
+      }),
+    );
+    const { GET } = createFlowletHandler({ flowletDir: dir });
+    const res = await GET(req("/api/flowlet/capabilities"));
+    expect(((await res.json()) as { mcp: boolean }).mcp).toBe(false);
+    warn.mockRestore();
+  });
+
+  it("the mcpServers option overrides mcp.json entirely", async () => {
+    const dir = emptyDir();
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      path.join(dir, "mcp.json"),
+      JSON.stringify({ version: 1, servers: [{ name: "from-file", url: "https://file" }] }),
+    );
+    // Option present (even []) wins over the file: [] means MCP off.
+    const { GET } = createFlowletHandler({ flowletDir: dir, mcpServers: [] });
+    const res = await GET(req("/api/flowlet/capabilities"));
+    expect(((await res.json()) as { mcp: boolean }).mcp).toBe(false);
   });
 
   it("keeps integrations inert without a Composio key", async () => {

--- a/packages/flowlet-next/src/handler.ts
+++ b/packages/flowlet-next/src/handler.ts
@@ -33,6 +33,7 @@ import {
 } from "./integrations";
 import { detectCapabilities } from "./capabilities";
 import { loadFlowletDir } from "./flowlet-dir";
+import { resolveMcpServers } from "./mcp-config";
 import { manifestToolsToHostTools } from "./manifest-tools";
 import { buildInstructions, createAgentCache } from "./agent";
 import { createAutomationsWorld, defaultModel, type FlowletAutomationsWorld } from "./world";
@@ -59,8 +60,13 @@ export function createFlowletHandler(rawOptions: FlowletHandlerOptions = {}): Fl
   // there would break builds in clean CI environments.
   let assembled: ReturnType<typeof assemble> | null = null;
   function assemble() {
-    const capabilities = detectCapabilities();
     const loaded = loadFlowletDir(options.flowletDir);
+    // MCP servers: the code option OVERRIDES the file entirely; ${ENV_VAR}
+    // header substitution applies only to file-sourced entries (code already
+    // runs in an env-aware context). A server whose var is missing is dropped
+    // with a warning. The capability flag reads the RESOLVED list.
+    const mcpServers = options.mcpServers ?? resolveMcpServers(loaded.mcpServers ?? []);
+    const capabilities = { ...detectCapabilities(), mcp: mcpServers.length > 0 };
     const hostTools = options.hostTools ?? manifestToolsToHostTools(loaded.manifest.tools);
     const model = options.model ?? defaultModel();
     const policy = options.policy ?? defaultFlowletPolicy;
@@ -103,6 +109,7 @@ export function createFlowletHandler(rawOptions: FlowletHandlerOptions = {}): Fl
       components: [...prewiredComponents, ...(options.components ?? [])],
       tools: serverTools,
       ...(capabilities.integrations ? { toolkits: () => connections.connectedToolkits() } : {}),
+      ...(mcpServers.length > 0 ? { mcpServers } : {}),
       ...(options.cacheKey ? { cacheKey: options.cacheKey } : {}),
       ...(options.maxSteps !== undefined ? { maxSteps: options.maxSteps } : {}),
     });

--- a/packages/flowlet-next/src/mcp-config.test.ts
+++ b/packages/flowlet-next/src/mcp-config.test.ts
@@ -51,6 +51,28 @@ describe("mcpJsonSchema", () => {
       }).success,
     ).toBe(false);
   });
+
+  it("rejects prefix-ambiguous server names ('a' and 'a_b' can collide on prefixed tool names)", () => {
+    expect(
+      mcpJsonSchema.safeParse({
+        version: 1,
+        servers: [
+          { name: "a", url: "https://a" },
+          { name: "a_b", url: "https://ab" },
+        ],
+      }).success,
+    ).toBe(false);
+    // Non-underscore extension is fine: "shop" and "shopify" cannot collide.
+    expect(
+      mcpJsonSchema.safeParse({
+        version: 1,
+        servers: [
+          { name: "shop", url: "https://a" },
+          { name: "shopify", url: "https://b" },
+        ],
+      }).success,
+    ).toBe(true);
+  });
 });
 
 describe("resolveMcpServers", () => {
@@ -82,5 +104,19 @@ describe("resolveMcpServers", () => {
     expect(resolveMcpServers([{ name: "s", url: "https://x", tools: ["a"] }], {})).toEqual([
       { name: "s", url: "https://x", tools: ["a"] },
     ]);
+  });
+
+  it("drops a server whose header still contains an unresolved ${...} template (lowercase/dashed refs)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const resolved = resolveMcpServers(
+      [
+        { name: "typo", url: "https://x", headers: { Authorization: "Bearer ${mcp_token}" } },
+        { name: "ok", url: "https://y" },
+      ],
+      { mcp_token: "should-not-be-read" },
+    );
+    expect(resolved.map((s) => s.name)).toEqual(["ok"]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('"typo"'));
+    warn.mockRestore();
   });
 });

--- a/packages/flowlet-next/src/mcp-config.test.ts
+++ b/packages/flowlet-next/src/mcp-config.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+import { mcpJsonSchema, resolveMcpServers } from "./mcp-config";
+
+describe("mcpJsonSchema", () => {
+  it("accepts a valid file shape", () => {
+    const parsed = mcpJsonSchema.safeParse({
+      version: 1,
+      servers: [
+        {
+          name: "weather",
+          url: "https://mcp.example.com/mcp",
+          headers: { Authorization: "Bearer ${WEATHER_TOKEN}" },
+          tools: ["get_forecast"],
+        },
+      ],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects a server name that is not a valid tool-name fragment", () => {
+    expect(
+      mcpJsonSchema.safeParse({ version: 1, servers: [{ name: "bad name!", url: "https://x" }] })
+        .success,
+    ).toBe(false);
+  });
+
+  it("rejects non-http(s) URLs", () => {
+    expect(
+      mcpJsonSchema.safeParse({ version: 1, servers: [{ name: "s", url: "file:///etc/passwd" }] })
+        .success,
+    ).toBe(false);
+  });
+
+  it("rejects unknown keys (strict)", () => {
+    expect(
+      mcpJsonSchema.safeParse({
+        version: 1,
+        servers: [{ name: "s", url: "https://x", transport: "stdio" }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects duplicate server names", () => {
+    expect(
+      mcpJsonSchema.safeParse({
+        version: 1,
+        servers: [
+          { name: "dup", url: "https://a" },
+          { name: "dup", url: "https://b" },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("resolveMcpServers", () => {
+  it("substitutes ${ENV_VAR} in header values", () => {
+    const resolved = resolveMcpServers(
+      [{ name: "s", url: "https://x", headers: { Authorization: "Bearer ${TOK}" } }],
+      { TOK: "abc123" },
+    );
+    expect(resolved).toEqual([
+      { name: "s", url: "https://x", headers: { Authorization: "Bearer abc123" } },
+    ]);
+  });
+
+  it("drops a server (with a warning) when a referenced env var is missing or empty", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const resolved = resolveMcpServers(
+      [
+        { name: "broken", url: "https://x", headers: { Authorization: "Bearer ${NOPE}" } },
+        { name: "ok", url: "https://y" },
+      ],
+      {},
+    );
+    expect(resolved.map((s) => s.name)).toEqual(["ok"]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('"broken"'));
+    warn.mockRestore();
+  });
+
+  it("passes through servers with no headers untouched", () => {
+    expect(resolveMcpServers([{ name: "s", url: "https://x", tools: ["a"] }], {})).toEqual([
+      { name: "s", url: "https://x", tools: ["a"] },
+    ]);
+  });
+});

--- a/packages/flowlet-next/src/mcp-config.ts
+++ b/packages/flowlet-next/src/mcp-config.ts
@@ -34,7 +34,12 @@ export const mcpServerSchema = z
   })
   .strict();
 
-/** Reject duplicate server names — they'd alias each other's tools and clients. */
+/**
+ * Reject duplicate server names (they'd alias each other's tools and clients)
+ * AND prefix-ambiguous pairs like "a" and "a_b": server "a" exposing a tool
+ * "b_c" would collide with server "a_b" exposing "c" under the final name
+ * "a_b_c", letting one server squat the other's canonical tool names.
+ */
 export const mcpServerArraySchema = z.array(mcpServerSchema).superRefine((servers, ctx) => {
   const seen = new Set<string>();
   for (const s of servers) {
@@ -45,6 +50,18 @@ export const mcpServerArraySchema = z.array(mcpServerSchema).superRefine((server
       });
     }
     seen.add(s.name);
+  }
+  for (const a of servers) {
+    for (const b of servers) {
+      if (a !== b && b.name.startsWith(`${a.name}_`)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            `ambiguous MCP server names "${a.name}" and "${b.name}": ` +
+            `one extends the other with "_", so their prefixed tool names can collide`,
+        });
+      }
+    }
   }
 });
 
@@ -74,18 +91,30 @@ export function resolveMcpServers(
       continue;
     }
     let missing: string | null = null;
+    let residue: string | null = null;
     const headers: Record<string, string> = {};
     for (const [key, value] of Object.entries(server.headers)) {
-      headers[key] = value.replace(ENV_REF, (_, varName: string) => {
+      const substituted = value.replace(ENV_REF, (_, varName: string) => {
         const v = env[varName];
         if (v === undefined || v.trim() === "") missing = varName;
         return v ?? "";
       });
+      // Anything still looking like a template (lowercase names, dashes,
+      // typos) would otherwise be sent to the server literally — fail closed.
+      if (substituted.includes("${")) residue = key;
+      headers[key] = substituted;
     }
     if (missing) {
       console.warn(
         `[flowlet] MCP server "${server.name}" dropped: header references env var ` +
           `\${${missing}} which is not set.`,
+      );
+      continue;
+    }
+    if (residue) {
+      console.warn(
+        `[flowlet] MCP server "${server.name}" dropped: header "${residue}" still ` +
+          "contains an unresolved ${...} template (env var names must be UPPERCASE_WITH_UNDERSCORES).",
       );
       continue;
     }

--- a/packages/flowlet-next/src/mcp-config.ts
+++ b/packages/flowlet-next/src/mcp-config.ts
@@ -1,0 +1,95 @@
+/**
+ * `.flowlet/mcp.json` schema + resolution for host-declared MCP servers.
+ *
+ * The file holds the SAME shape as the `mcpServers` handler option, wrapped in
+ * a versioned envelope (like tools.json). Header values may reference env vars
+ * as `${VAR_NAME}` so tokens never live in the checked-in file. A server whose
+ * referenced var is missing/empty is DROPPED with a boot warning — fail
+ * closed, never send empty auth.
+ *
+ * SECURITY INVARIANT: server URLs and header templates come ONLY from the
+ * host's code (`mcpServers` option) or its repo (`.flowlet/mcp.json`) — never
+ * from request input. The URL schema is deliberately NOT an SSRF guard
+ * (localhost/private ranges are legitimate for host-declared servers); any
+ * future user-added-server feature MUST add network denylisting before
+ * accepting URLs from users.
+ */
+import { z } from "zod";
+import type { McpServerConfig } from "@flowlet/runtime";
+
+/** Matches `<serverName>_<toolName>` tool-name rules (letters, digits, _ , -). */
+const NAME_FRAGMENT = /^[A-Za-z0-9_-]+$/;
+
+export const mcpServerSchema = z
+  .object({
+    name: z.string().regex(NAME_FRAGMENT, "server name must be letters, digits, _ or -"),
+    url: z
+      .string()
+      .url()
+      .refine((u) => u.startsWith("http://") || u.startsWith("https://"), {
+        message: "MCP server URL must be http(s)",
+      }),
+    headers: z.record(z.string()).optional(),
+    tools: z.array(z.string().min(1)).optional(),
+  })
+  .strict();
+
+/** Reject duplicate server names — they'd alias each other's tools and clients. */
+export const mcpServerArraySchema = z.array(mcpServerSchema).superRefine((servers, ctx) => {
+  const seen = new Set<string>();
+  for (const s of servers) {
+    if (seen.has(s.name)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `duplicate MCP server name "${s.name}"`,
+      });
+    }
+    seen.add(s.name);
+  }
+});
+
+export const mcpJsonSchema = z
+  .object({
+    version: z.literal(1),
+    servers: mcpServerArraySchema,
+  })
+  .strict();
+
+export type McpJson = z.infer<typeof mcpJsonSchema>;
+
+const ENV_REF = /\$\{([A-Z0-9_]+)\}/g;
+
+/**
+ * Substitute `${VAR}` references in header values from `env`. A server that
+ * references a missing/empty var is dropped with a warning.
+ */
+export function resolveMcpServers(
+  servers: McpServerConfig[],
+  env: Record<string, string | undefined> = process.env,
+): McpServerConfig[] {
+  const resolved: McpServerConfig[] = [];
+  for (const server of servers) {
+    if (!server.headers) {
+      resolved.push(server);
+      continue;
+    }
+    let missing: string | null = null;
+    const headers: Record<string, string> = {};
+    for (const [key, value] of Object.entries(server.headers)) {
+      headers[key] = value.replace(ENV_REF, (_, varName: string) => {
+        const v = env[varName];
+        if (v === undefined || v.trim() === "") missing = varName;
+        return v ?? "";
+      });
+    }
+    if (missing) {
+      console.warn(
+        `[flowlet] MCP server "${server.name}" dropped: header references env var ` +
+          `\${${missing}} which is not set.`,
+      );
+      continue;
+    }
+    resolved.push({ ...server, headers });
+  }
+  return resolved;
+}

--- a/packages/flowlet-next/src/options.test.ts
+++ b/packages/flowlet-next/src/options.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { parseHandlerOptions } from "./options";
+
+describe("parseHandlerOptions: mcpServers", () => {
+  it("accepts mcpServers", () => {
+    expect(() =>
+      parseHandlerOptions({
+        mcpServers: [
+          {
+            name: "weather",
+            url: "https://mcp.example.com/mcp",
+            headers: { Authorization: "Bearer x" },
+            tools: ["get_forecast"],
+          },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects an mcpServers entry with a bad name or unknown key", () => {
+    expect(() =>
+      parseHandlerOptions({ mcpServers: [{ name: "bad name", url: "https://x" }] }),
+    ).toThrow(/invalid options/);
+    expect(() =>
+      parseHandlerOptions({
+        mcpServers: [{ name: "s", url: "https://x", transport: "stdio" } as never],
+      }),
+    ).toThrow(/invalid options/);
+  });
+
+  it("rejects duplicate MCP server names", () => {
+    expect(() =>
+      parseHandlerOptions({
+        mcpServers: [
+          { name: "dup", url: "https://a" },
+          { name: "dup", url: "https://b" },
+        ],
+      }),
+    ).toThrow(/invalid options/);
+  });
+});

--- a/packages/flowlet-next/src/options.ts
+++ b/packages/flowlet-next/src/options.ts
@@ -7,8 +7,9 @@
 import { z } from "zod";
 import type { LanguageModel, ToolSet } from "ai";
 import type { HostToolDefinition, RegisteredComponent } from "@flowlet/core";
-import type { ApprovalPolicy, FlowletPrincipal, RegisteredTool } from "@flowlet/runtime";
+import type { ApprovalPolicy, FlowletPrincipal, McpServerConfig, RegisteredTool } from "@flowlet/runtime";
 import type { ConnectionsStore } from "./connections";
+import { mcpServerArraySchema } from "./mcp-config";
 
 export interface IntegrationCatalogEntry {
   /** Composio toolkit id (must match the shell's BrandIcon ids). */
@@ -46,6 +47,12 @@ export interface FlowletHandlerOptions {
   /** Integrations catalog shown by the connect UI. Default: the standard set. */
   integrations?: IntegrationCatalogEntry[];
   /**
+   * Host-declared MCP servers (Streamable HTTP). Tools are ingested through
+   * the policy engine as source "mcp", prefixed `<name>_<tool>`. OVERRIDES
+   * `.flowlet/mcp.json` entirely when provided.
+   */
+  mcpServers?: McpServerConfig[];
+  /**
    * Bring-your-own connections store (which toolkits are connected → what the
    * agent ingests). Default: a fresh in-memory store. Inject when the host
    * owns connection state elsewhere (e.g. a demo reset that clears it).
@@ -76,6 +83,7 @@ const optionsSchema = z
     principal: fn<NonNullable<FlowletHandlerOptions["principal"]>>().optional(),
     cacheKey: fn<() => string>().optional(),
     integrations: z.array(z.object({ id: z.string().min(1), name: z.string().min(1) }).strict()).optional(),
+    mcpServers: mcpServerArraySchema.optional(),
     connections: z
       .custom<ConnectionsStore>(
         (v) =>

--- a/packages/flowlet-react/src/host-tools.test.ts
+++ b/packages/flowlet-react/src/host-tools.test.ts
@@ -129,6 +129,21 @@ describe("hostAwareSendAutomaticallyWhen", () => {
     expect(when({ messages: [declined] })).toBe(true);
   });
 
+  it("fires on an approved DYNAMIC server tool (MCP tools stream as dynamic-tool parts)", () => {
+    const dynamicApproved = assistant([
+      stepStart,
+      {
+        type: "dynamic-tool",
+        toolName: "everything_echo",
+        toolCallId: "c9",
+        state: "approval-responded",
+        input: { message: "hi" },
+        approval: { id: "ap-d", approved: true },
+      },
+    ]);
+    expect(when({ messages: [dynamicApproved] })).toBe(true);
+  });
+
   it("keeps the existing server-tool approval behaviour", () => {
     const serverApproved = assistant([
       stepStart,

--- a/packages/flowlet-react/src/host-tools.test.ts
+++ b/packages/flowlet-react/src/host-tools.test.ts
@@ -39,6 +39,20 @@ describe("pendingHostToolCalls", () => {
     ]);
   });
 
+  it("never routes a dynamic (MCP) part to the browser executor, even with a host-matching name", () => {
+    const msg = assistant([
+      stepStart,
+      {
+        type: "dynamic-tool",
+        toolName: "listAccounts",
+        toolCallId: "c-spoof",
+        state: "input-available",
+        input: {},
+      },
+    ]);
+    expect(pendingHostToolCalls(msg, HOST)).toEqual([]);
+  });
+
   it("selects approved host tool calls awaiting client execution", () => {
     const msg = assistant([
       stepStart,
@@ -127,6 +141,23 @@ describe("hostAwareSendAutomaticallyWhen", () => {
       },
     ]);
     expect(when({ messages: [declined] })).toBe(true);
+  });
+
+  it("never treats a dynamic part named like a host tool as host-owed (spoof guard)", () => {
+    // An MCP tool whose full name collides with a host tool must not stall
+    // resubmission waiting for a browser executor that will never run it.
+    const spoofed = assistant([
+      stepStart,
+      {
+        type: "dynamic-tool",
+        toolName: "createOrder",
+        toolCallId: "c10",
+        state: "approval-responded",
+        input: {},
+        approval: { id: "ap-x", approved: true },
+      },
+    ]);
+    expect(when({ messages: [spoofed] })).toBe(true);
   });
 
   it("fires on an approved DYNAMIC server tool (MCP tools stream as dynamic-tool parts)", () => {

--- a/packages/flowlet-react/src/host-tools.ts
+++ b/packages/flowlet-react/src/host-tools.ts
@@ -54,6 +54,19 @@ function isToolPart(part: { type: string }): part is ToolPartView {
   return part.type.startsWith("tool-") || part.type === "dynamic-tool";
 }
 
+/**
+ * Host tools are ALWAYS static (`tool-<name>`) parts — they are registered
+ * server-side with fixed schemas. A dynamic part (MCP) whose name happens to
+ * match a host tool must never be routed to the browser executor or hold up
+ * resubmission, so every host-execution predicate goes through this check.
+ */
+function isHostToolPart(
+  part: { type: string },
+  hostToolNames: ReadonlySet<string>,
+): part is ToolPartView {
+  return part.type.startsWith("tool-") && hostToolNames.has(toolName(part as ToolPartView));
+}
+
 /** Ready-to-execute host tool calls on the (settled) last assistant message. */
 export function pendingHostToolCalls(
   message: FlowletUIMessage | undefined,
@@ -62,7 +75,7 @@ export function pendingHostToolCalls(
   if (!message || message.role !== "assistant") return [];
   const pending: PendingHostToolCall[] = [];
   for (const part of message.parts as Array<{ type: string }>) {
-    if (!isToolPart(part) || !hostToolNames.has(toolName(part))) continue;
+    if (!isHostToolPart(part, hostToolNames)) continue;
     const ready =
       part.state === "input-available" ||
       (part.state === "approval-responded" && part.approval?.approved === true);
@@ -104,7 +117,7 @@ export function hostAwareSendAutomaticallyWhen(
     // executor still owes the result — never resubmit yet.
     const hostOwesOutput = invocations.some(
       (part) =>
-        hostToolNames.has(toolName(part)) &&
+        isHostToolPart(part, hostToolNames) &&
         (part.state === "input-available" ||
           (part.state === "approval-responded" && part.approval?.approved === true)),
     );

--- a/packages/flowlet-react/src/host-tools.ts
+++ b/packages/flowlet-react/src/host-tools.ts
@@ -34,6 +34,7 @@ export interface PendingHostToolCall {
 
 interface ToolPartView {
   type: string;
+  toolName?: string;
   toolCallId?: string;
   state?: string;
   input?: unknown;
@@ -42,11 +43,15 @@ interface ToolPartView {
 }
 
 function toolName(part: ToolPartView): string {
-  return part.type.slice("tool-".length);
+  // Dynamic tools (MCP servers) carry their name in `toolName`; static tool
+  // parts encode it in the part type.
+  return part.type === "dynamic-tool"
+    ? String(part.toolName ?? "")
+    : part.type.slice("tool-".length);
 }
 
 function isToolPart(part: { type: string }): part is ToolPartView {
-  return part.type.startsWith("tool-");
+  return part.type.startsWith("tool-") || part.type === "dynamic-tool";
 }
 
 /** Ready-to-execute host tool calls on the (settled) last assistant message. */

--- a/packages/flowlet-runtime/src/dependency-guard.test.ts
+++ b/packages/flowlet-runtime/src/dependency-guard.test.ts
@@ -93,9 +93,14 @@ describe("dependency guard: @flowlet/runtime is portable (Decision 1)", () => {
     expect(offending).toEqual([]);
   });
 
-  it("no src/ file imports a db, queue, http server, or Node server builtin", () => {
+  it("no shipped src/ file imports a db, queue, http server, or Node server builtin", () => {
     const offending: string[] = [];
     for (const file of sourceFiles(join(PKG_ROOT, "src"))) {
+      // Test files are excluded from the build (tsconfig `exclude`) and never
+      // reach dist, so they may stand up local fixtures — e.g. the MCP
+      // contract test's in-process node:http server. The shipped-runtime
+      // guarantee this guard protects is unaffected.
+      if (/\.test\.(ts|tsx)$/.test(file)) continue;
       for (const specifier of importSpecifiers(readFileSync(file, "utf8"))) {
         if (FORBIDDEN_MODULES.includes(moduleRoot(specifier))) {
           offending.push(`${file} -> ${specifier}`);

--- a/packages/flowlet-runtime/src/engine.test.ts
+++ b/packages/flowlet-runtime/src/engine.test.ts
@@ -383,3 +383,127 @@ describe("createFlowletAgent", () => {
     expect(calls.some((c) => c.toolCallId === "call-aborted")).toBe(false);
   });
 });
+
+describe("MCP ingestion wiring", () => {
+  // Must be a REAL ai-SDK tool: the engine hands the toolset to streamText,
+  // which calls asSchema(tool.inputSchema) — a bare `{}` schema crashes there.
+  const echoTool = tool({
+    description: "echo",
+    inputSchema: z.object({}),
+    execute: async () => "ok",
+  });
+
+  function fakeMcpSource(result?: {
+    tools: ToolSet;
+    annotations: Record<string, Record<string, boolean>>;
+    failures?: never;
+  }) {
+    return {
+      fetchTools: vi.fn(async () =>
+        result ?? { tools: { ping: echoTool }, annotations: { ping: { readOnlyHint: true } } },
+      ),
+    };
+  }
+
+  it("ingests MCP tools once (host-level cache) across runs and principals", async () => {
+    const source = fakeMcpSource();
+    const agent = createFlowletAgent({
+      model: mockModel(),
+      policy: allowPolicy,
+      mcp: { servers: [{ name: "srv", url: "http://x" }], source },
+    });
+
+    await collect(
+      agent.run({ messages: userTurn, tools: {}, principal: { userId: "u1" }, signal: new AbortController().signal }),
+    );
+    await collect(
+      agent.run({ messages: userTurn, tools: {}, principal: { userId: "u2" }, signal: new AbortController().signal }),
+    );
+
+    expect(source.fetchTools).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries MCP ingestion on a later run after a failure (failures are not cached)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const source = {
+      fetchTools: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("boom"))
+        .mockResolvedValue({ tools: { ping: echoTool }, annotations: {} }),
+    };
+    const agent = createFlowletAgent({
+      model: mockModel(),
+      policy: allowPolicy,
+      mcp: { servers: [{ name: "srv", url: "http://x" }], source },
+    });
+
+    await collect(agent.run({ messages: userTurn, tools: {}, signal: new AbortController().signal }));
+    await collect(agent.run({ messages: userTurn, tools: {}, signal: new AbortController().signal }));
+
+    expect(source.fetchTools).toHaveBeenCalledTimes(2);
+    warn.mockRestore();
+  });
+
+  it("MCP tools flow through the policy wrapper and execute like any source", async () => {
+    const ran = vi.fn(async () => "mcp-ran");
+    const source = {
+      fetchTools: vi.fn(async () => ({
+        tools: {
+          ping: tool({ description: "ping", inputSchema: z.object({}), execute: ran }),
+        },
+        annotations: { ping: { readOnlyHint: true } },
+      })),
+    };
+    const agent = createFlowletAgent({
+      model: mockModel({ toolName: "srv_ping", input: {} }),
+      policy: allowPolicy,
+      mcp: { servers: [{ name: "srv", url: "http://x" }], source },
+    });
+
+    const parts = await collect(
+      agent.run({ messages: userTurn, tools: {}, signal: new AbortController().signal }),
+    );
+    expect(ran).toHaveBeenCalledOnce();
+    expect(parts.map((p) => (p as { type: string }).type)).toContain("finish");
+  });
+
+  it("caller tools take precedence over MCP tools on a name collision", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const callerRan = vi.fn(async () => "caller-won");
+    const mcpRan = vi.fn(async () => "mcp-lost");
+    const source = {
+      fetchTools: vi.fn(async () => ({
+        tools: { ping: tool({ description: "mcp ping", inputSchema: z.object({}), execute: mcpRan }) },
+        annotations: {},
+      })),
+    };
+    const agent = createFlowletAgent({
+      model: mockModel({ toolName: "srv_ping", input: {} }),
+      policy: allowPolicy,
+      mcp: { servers: [{ name: "srv", url: "http://x" }], source },
+    });
+
+    await collect(
+      agent.run({
+        messages: userTurn,
+        tools: {
+          srv_ping: tool({ description: "caller ping", inputSchema: z.object({}), execute: callerRan }),
+        },
+        signal: new AbortController().signal,
+      }),
+    );
+
+    expect(callerRan).toHaveBeenCalledOnce();
+    expect(mcpRan).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('tool "srv_ping" from source "mcp" dropped'));
+    warn.mockRestore();
+  });
+
+  it("runs fine with no mcp config at all", async () => {
+    const agent = createFlowletAgent({ model: mockModel(), policy: allowPolicy });
+    const parts = await collect(
+      agent.run({ messages: userTurn, tools: {}, signal: new AbortController().signal }),
+    );
+    expect(parts.map((p) => (p as { type: string }).type)).toContain("finish");
+  });
+});

--- a/packages/flowlet-runtime/src/engine.test.ts
+++ b/packages/flowlet-runtime/src/engine.test.ts
@@ -471,7 +471,7 @@ describe("MCP ingestion wiring", () => {
     expect(source.fetchTools).toHaveBeenCalledTimes(1);
   });
 
-  it("retries MCP ingestion on a later run after a failure (failures are not cached)", async () => {
+  it("retries MCP ingestion on a later run after a failure (failures are not cached past the retry delay)", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const source = {
       fetchTools: vi
@@ -482,7 +482,8 @@ describe("MCP ingestion wiring", () => {
     const agent = createFlowletAgent({
       model: mockModel(),
       policy: allowPolicy,
-      mcp: { servers: [{ name: "srv", url: "http://x" }], source },
+      // retryDelayMs 0 = retry on the very next turn (the default backs off 30s).
+      mcp: { servers: [{ name: "srv", url: "http://x" }], source, retryDelayMs: 0 },
     });
 
     await collect(agent.run({ messages: userTurn, tools: {}, signal: new AbortController().signal }));

--- a/packages/flowlet-runtime/src/engine.test.ts
+++ b/packages/flowlet-runtime/src/engine.test.ts
@@ -382,6 +382,54 @@ describe("createFlowletAgent", () => {
     }
     expect(calls.some((c) => c.toolCallId === "call-aborted")).toBe(false);
   });
+
+  it("repairs a stale DYNAMIC tool approval (MCP tools) the same way", async () => {
+    let seenPrompt: { role: string; content: unknown }[] = [];
+    const model = new MockLanguageModelV3({
+      doStream: async ({ prompt }) => {
+        seenPrompt = prompt as typeof seenPrompt;
+        return {
+          stream: simulateReadableStream({
+            chunks: [
+              ...textChunks("t-ok", "Continuing."),
+              { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
+            ] satisfies LanguageModelV3StreamPart[],
+          }),
+        };
+      },
+    });
+    const agent = createFlowletAgent({ model, policy: allowPolicy });
+
+    const history = [
+      { id: "m1", role: "user", parts: [{ type: "text", text: "echo something" }] },
+      {
+        id: "m2",
+        role: "assistant",
+        parts: [
+          // An MCP tool call (dynamic-tool part) the user typed past.
+          {
+            type: "dynamic-tool",
+            toolName: "everything_echo",
+            toolCallId: "call-stale-dyn",
+            state: "approval-requested",
+            input: { message: "hi" },
+            approval: { id: "appr-dyn" },
+          },
+        ],
+      },
+      { id: "m3", role: "user", parts: [{ type: "text", text: "never mind" }] },
+    ] as unknown as FlowletUIMessage[];
+
+    const parts = await collect(
+      agent.run({ messages: history, tools: {}, signal: new AbortController().signal }),
+    );
+
+    expect(parts.map((p) => (p as { type: string }).type)).toContain("finish");
+    const results = seenPrompt
+      .filter((m) => m.role === "tool")
+      .flatMap((m) => m.content as { type: string; toolCallId: string }[]);
+    expect(results.some((r) => r.type === "tool-result" && r.toolCallId === "call-stale-dyn")).toBe(true);
+  });
 });
 
 describe("MCP ingestion wiring", () => {

--- a/packages/flowlet-runtime/src/engine.ts
+++ b/packages/flowlet-runtime/src/engine.ts
@@ -35,6 +35,12 @@ import {
   type ComposioClient,
   type ComposioConfig,
 } from "./composio";
+import {
+  ingestMcpTools,
+  createMcpToolSource,
+  type McpServerConfig,
+  type McpToolSource,
+} from "./mcp";
 import type { ApprovalPolicy } from "./policy";
 import type { FlowletPrincipal } from "./principal";
 import type { ToolDescriptor } from "./descriptor";
@@ -67,6 +73,8 @@ export interface FlowletAgentConfig {
   tools?: ToolSet;
   /** Optional Composio ingestion. `client` is injectable for tests. */
   composio?: { config: ComposioConfig; client?: ComposioClient };
+  /** Optional MCP ingestion (host-declared servers). `source` is injectable for tests. */
+  mcp?: { servers: McpServerConfig[]; source?: McpToolSource };
   /**
    * Policy version string. Forwarded to policy layers that key on it (e.g. the
    * ask-once `rememberDecisions` store). Not used by the engine itself.
@@ -113,6 +121,13 @@ export function createFlowletAgent(config: FlowletAgentConfig): FlowletAgent {
   // transient failure never permanently disables that user's tools.
   type Ingested = { toolset: ToolSet; descriptors: Record<string, ToolDescriptor> };
   const composioCache = new Map<string, Promise<Ingested>>();
+
+  // MCP tools are HOST-level (declared by the host, shared across users), so
+  // one ingestion serves every principal — unlike the per-user Composio cache.
+  const mcpSource: McpToolSource | undefined = config.mcp
+    ? config.mcp.source ?? createMcpToolSource()
+    : undefined;
+  let mcpCache: Promise<Ingested> | null = null;
 
   /**
    * Normalize client-supplied history so a stale turn can't wedge the thread.
@@ -220,7 +235,33 @@ export function createFlowletAgent(config: FlowletAgentConfig): FlowletAgent {
           composioDescriptors = ingested.descriptors;
         }
 
-        // 4. Sources in precedence order: caller > engine > composio.
+        // 3b. MCP ingestion (fail-closed inside ingestMcpTools; per-server
+        //     fault tolerance). Cached host-level: the tools/list round-trip
+        //     blocks only the first turn. `ingestMcpTools` never rejects —
+        //     instead it reports per-server `failures` — so "failures are
+        //     never cached" means: any failed server evicts the cache after
+        //     resolution, and the next turn re-ingests (healthy servers are
+        //     cheap to re-fetch; their clients stay open in the source).
+        let mcpTools: ToolSet = {};
+        let mcpDescriptors: Record<string, ToolDescriptor> = {};
+        if (config.mcp && mcpSource && config.mcp.servers.length > 0) {
+          const servers = config.mcp.servers;
+          const source = mcpSource;
+          if (!mcpCache) {
+            mcpCache = ingestMcpTools({ servers, source }).then((ingested) => {
+              if (ingested.failures.length > 0) mcpCache = null;
+              return {
+                toolset: ingested.toolset,
+                descriptors: Object.fromEntries(ingested.descriptors.map((d) => [d.name, d])),
+              };
+            });
+          }
+          const ingested = await mcpCache;
+          mcpTools = ingested.toolset;
+          mcpDescriptors = ingested.descriptors;
+        }
+
+        // 4. Sources in precedence order: caller > engine > composio > mcp.
         const sources: ToolSourceInput[] = [
           // Defensive: a non-TS caller may omit `tools` entirely.
           { source: "caller", tools: input.tools ?? {} },
@@ -233,6 +274,7 @@ export function createFlowletAgent(config: FlowletAgentConfig): FlowletAgent {
             },
           },
           { source: "composio", tools: composioTools, descriptors: composioDescriptors },
+          { source: "mcp", tools: mcpTools, descriptors: mcpDescriptors },
         ];
 
         // 5. Merge + uniformly policy-wrap every tool.

--- a/packages/flowlet-runtime/src/engine.ts
+++ b/packages/flowlet-runtime/src/engine.ts
@@ -73,8 +73,14 @@ export interface FlowletAgentConfig {
   tools?: ToolSet;
   /** Optional Composio ingestion. `client` is injectable for tests. */
   composio?: { config: ComposioConfig; client?: ComposioClient };
-  /** Optional MCP ingestion (host-declared servers). `source` is injectable for tests. */
-  mcp?: { servers: McpServerConfig[]; source?: McpToolSource };
+  /**
+   * Optional MCP ingestion (host-declared servers). `source` is injectable
+   * for tests. `retryDelayMs` (default 30s) is how long a partial ingestion
+   * (some server failed) is served from cache before the next turn re-ingests
+   * — immediate retry would let a permanently-down server add a connect
+   * timeout to every single turn. `0` retries on the very next turn.
+   */
+  mcp?: { servers: McpServerConfig[]; source?: McpToolSource; retryDelayMs?: number };
   /**
    * Policy version string. Forwarded to policy layers that key on it (e.g. the
    * ask-once `rememberDecisions` store). Not used by the engine itself.
@@ -241,18 +247,30 @@ export function createFlowletAgent(config: FlowletAgentConfig): FlowletAgent {
         // 3b. MCP ingestion (fail-closed inside ingestMcpTools; per-server
         //     fault tolerance). Cached host-level: the tools/list round-trip
         //     blocks only the first turn. `ingestMcpTools` never rejects —
-        //     instead it reports per-server `failures` — so "failures are
-        //     never cached" means: any failed server evicts the cache after
-        //     resolution, and the next turn re-ingests (healthy servers are
-        //     cheap to re-fetch; their clients stay open in the source).
+        //     instead it reports per-server `failures`. A clean ingestion is
+        //     cached for the agent's lifetime; a PARTIAL one (some server
+        //     failed) is served from cache but scheduled for eviction after
+        //     `retryDelayMs`, so failed servers are retried without letting a
+        //     permanently-down one add a connect timeout to every turn.
         let mcpTools: ToolSet = {};
         let mcpDescriptors: Record<string, ToolDescriptor> = {};
         if (config.mcp && mcpSource && config.mcp.servers.length > 0) {
           const servers = config.mcp.servers;
           const source = mcpSource;
+          const retryDelayMs = config.mcp.retryDelayMs ?? 30_000;
           if (!mcpCache) {
             mcpCache = ingestMcpTools({ servers, source }).then((ingested) => {
-              if (ingested.failures.length > 0) mcpCache = null;
+              if (ingested.failures.length > 0) {
+                if (retryDelayMs <= 0) {
+                  mcpCache = null;
+                } else {
+                  const timer = setTimeout(() => {
+                    mcpCache = null;
+                  }, retryDelayMs);
+                  // Never keep the host process alive just for a retry timer.
+                  (timer as { unref?: () => void }).unref?.();
+                }
+              }
               return {
                 toolset: ingested.toolset,
                 descriptors: Object.fromEntries(ingested.descriptors.map((d) => [d.name, d])),

--- a/packages/flowlet-runtime/src/engine.ts
+++ b/packages/flowlet-runtime/src/engine.ts
@@ -149,7 +149,10 @@ export function createFlowletAgent(config: FlowletAgentConfig): FlowletAgent {
           approval?: { id: string; approved?: boolean | null; reason?: string };
         };
         if (
-          part.type.startsWith("tool-") &&
+          // Static tool parts are "tool-<name>"; dynamic tools (MCP) are
+          // "dynamic-tool" with the name in `toolName`. Both can strand an
+          // unanswered approval.
+          (part.type.startsWith("tool-") || part.type === "dynamic-tool") &&
           part.state === "approval-requested" &&
           part.approval != null &&
           part.approval.approved == null

--- a/packages/flowlet-runtime/src/index.ts
+++ b/packages/flowlet-runtime/src/index.ts
@@ -57,6 +57,13 @@ export {
 } from "./composio";
 export type { ComposioClient, ComposioConfig } from "./composio";
 
+// MCP ingestion (host-declared servers)
+export {
+  ingestMcpTools,
+  createMcpToolSource,
+} from "./mcp";
+export type { McpServerConfig, McpToolSource, McpFetchResult } from "./mcp";
+
 // Automations engine (ENG-188): DSL, interpreter, store, runner, scheduler,
 // ingest helpers, and chat authoring tools.
 export * from "./automations";

--- a/packages/flowlet-runtime/src/mcp.contract.test.ts
+++ b/packages/flowlet-runtime/src/mcp.contract.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Contract tests for `createMcpToolSource` against the REAL `@ai-sdk/mcp`
+ * client, served by a minimal in-process Streamable-HTTP MCP server.
+ *
+ * Also pins the private-API assumption Yousef approved: the 1.0.6 MCPClient
+ * has a runtime `listTools()` (absent from its public type) that carries the
+ * MCP `annotations` the public `tools()` discards. If an SDK bump breaks
+ * either fact, these tests fail loudly.
+ *
+ * Server protocol facts (probe-verified 2026-07-04): notifications must get
+ * 202 (a 200 without JSON/SSE content-type throws in the transport); the
+ * client opens a GET at startup (inbound SSE) — 405 is tolerated; the
+ * initialize reply must echo the client's protocolVersion.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { createMcpToolSource } from "./mcp";
+
+const TOOLS = [
+  {
+    name: "get_forecast",
+    description: "Read the forecast",
+    inputSchema: { type: "object", properties: { city: { type: "string" } } },
+    annotations: { readOnlyHint: true },
+  },
+  {
+    name: "purge_cache",
+    description: "Destroy the cache",
+    inputSchema: { type: "object", properties: {} },
+    annotations: { destructiveHint: true },
+  },
+];
+
+let server: Server;
+let url: string;
+const seenAuthHeaders: Array<string | undefined> = [];
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    if (req.method !== "POST") {
+      // The client opens a GET (inbound SSE) at startup; 405 is tolerated.
+      res.writeHead(405).end();
+      return;
+    }
+    let raw = "";
+    req.on("data", (c) => (raw += c));
+    req.on("end", () => {
+      seenAuthHeaders.push(req.headers["authorization"]);
+      const msg = raw
+        ? (JSON.parse(raw) as {
+            id?: number;
+            method: string;
+            params?: { protocolVersion?: string; name?: string };
+          })
+        : { method: "" };
+      const reply = (result: unknown) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result }));
+      };
+      if (msg.id === undefined) {
+        // Notification — 202 Accepted (a 200 without JSON/SSE content-type throws).
+        res.writeHead(202).end();
+        return;
+      }
+      if (msg.method === "initialize") {
+        reply({
+          protocolVersion: msg.params?.protocolVersion,
+          capabilities: { tools: {} },
+          serverInfo: { name: "fake-mcp", version: "1.0.0" },
+        });
+        return;
+      }
+      if (msg.method === "tools/list") {
+        reply({ tools: TOOLS });
+        return;
+      }
+      if (msg.method === "tools/call") {
+        reply({ content: [{ type: "text", text: `ran:${msg.params?.name}` }] });
+        return;
+      }
+      reply({});
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  url = `http://127.0.0.1:${(server.address() as AddressInfo).port}/mcp`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe("createMcpToolSource (contract, real @ai-sdk/mcp)", () => {
+  it("fetches executable tools AND the annotations the public tools() drops", async () => {
+    const source = createMcpToolSource();
+    const { tools, annotations } = await source.fetchTools({ name: "fake", url });
+
+    expect(Object.keys(tools).sort()).toEqual(["get_forecast", "purge_cache"]);
+    // Every SDK-produced MCP tool must be wrappable (has execute) — the
+    // fail-closed wrapTool gate depends on this.
+    expect(typeof tools["get_forecast"]!.execute).toBe("function");
+    // The listTools() cast worked: real MCP annotations came through.
+    expect(annotations["get_forecast"]).toEqual({ readOnlyHint: true });
+    expect(annotations["purge_cache"]).toEqual({ destructiveHint: true });
+  });
+
+  it("sends configured headers on requests", async () => {
+    seenAuthHeaders.length = 0;
+    const source = createMcpToolSource();
+    await source.fetchTools({
+      name: "authy",
+      url,
+      headers: { Authorization: "Bearer sekrit" },
+    });
+    expect(seenAuthHeaders).toContain("Bearer sekrit");
+  });
+
+  it("executes a tool round-trip through the real client", async () => {
+    const source = createMcpToolSource();
+    const { tools } = await source.fetchTools({ name: "fake", url });
+    const result = (await tools["get_forecast"]!.execute!(
+      { city: "SF" },
+      { toolCallId: "t1", messages: [] },
+    )) as { content: Array<{ text: string }> };
+    expect(result.content[0]!.text).toBe("ran:get_forecast");
+  });
+
+  it("rejects (so ingest can skip the server) when the server is unreachable", async () => {
+    const source = createMcpToolSource();
+    await expect(
+      source.fetchTools({ name: "down", url: "http://127.0.0.1:1/mcp" }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/flowlet-runtime/src/mcp.test.ts
+++ b/packages/flowlet-runtime/src/mcp.test.ts
@@ -93,10 +93,12 @@ describe("ingestMcpTools", () => {
     warn.mockRestore();
   });
 
-  it("redacts configured header values from failure logs (no token leakage)", async () => {
+  it("withholds remote error messages entirely for servers sent headers (no token leakage, even transformed)", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const source = fakeSource({
-      leaky: new Error("HTTP 401: request had Authorization: Bearer sekrit-token"),
+      // A malicious server can reflect the token base64'd — substring
+      // redaction can't catch that, so the whole message must be withheld.
+      leaky: new Error(`HTTP 401: ${Buffer.from("Bearer sekrit-token").toString("base64")}`),
     });
     await ingestMcpTools({
       servers: [
@@ -106,7 +108,17 @@ describe("ingestMcpTools", () => {
     });
     const logged = warn.mock.calls.map((c) => c.join(" ")).join("\n");
     expect(logged).not.toContain("sekrit-token");
-    expect(logged).toContain("[redacted]");
+    expect(logged).not.toContain(Buffer.from("Bearer sekrit-token").toString("base64"));
+    expect(logged).toContain("message withheld");
+    warn.mockRestore();
+  });
+
+  it("logs the truncated message for headerless servers (nothing secret was sent)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const source = fakeSource({ open: new Error("connect ECONNREFUSED 127.0.0.1:9") });
+    await ingestMcpTools({ servers: [{ name: "open", url: "http://x" }], source });
+    const logged = warn.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(logged).toContain("ECONNREFUSED");
     warn.mockRestore();
   });
 
@@ -124,11 +136,12 @@ describe("ingestMcpTools", () => {
     warn.mockRestore();
   });
 
-  it("keeps the FIRST tool and warns on ambiguous-prefix collisions (server 'a' tool 'b_c' vs server 'a_b' tool 'c')", async () => {
+  it("drops ALL claimants of an ambiguous final name (server 'a' tool 'b_c' vs server 'a_b' tool 'c')", async () => {
+    // Fail-closed: first-wins would let a malicious earlier server squat a
+    // trusted later server's canonical tool name. Nobody gets the name.
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const first = { description: "first", inputSchema: {}, execute: async () => "first" };
     const source = fakeSource({
-      a: { tools: { b_c: first } },
+      a: { tools: { b_c: echoTool, safe: echoTool } },
       a_b: { tools: { c: echoTool } },
     });
     const result = await ingestMcpTools({
@@ -138,8 +151,8 @@ describe("ingestMcpTools", () => {
       ],
       source,
     });
-    expect(Object.keys(result.toolset)).toEqual(["a_b_c"]);
-    expect(result.toolset["a_b_c"]).toBe(first);
+    expect(Object.keys(result.toolset)).toEqual(["a_safe"]);
+    expect(result.descriptors.map((d) => d.name)).toEqual(["a_safe"]);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('collision on "a_b_c"'));
     warn.mockRestore();
   });

--- a/packages/flowlet-runtime/src/mcp.test.ts
+++ b/packages/flowlet-runtime/src/mcp.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for MCP ingestion (`ingestMcpTools`) using a fake `McpToolSource`.
+ * The real adapter is covered by mcp.contract.test.ts.
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { ToolSet } from "ai";
+import { ingestMcpTools, type McpServerConfig, type McpToolSource } from "./mcp";
+
+function fakeSource(
+  perServer: Record<
+    string,
+    { tools: ToolSet; annotations?: Record<string, Record<string, boolean>> } | Error
+  >,
+): McpToolSource {
+  return {
+    fetchTools: vi.fn(async (config: McpServerConfig) => {
+      const entry = perServer[config.name];
+      if (!entry) throw new Error(`unexpected server ${config.name}`);
+      if (entry instanceof Error) throw entry;
+      return { tools: entry.tools, annotations: entry.annotations ?? {} };
+    }),
+  };
+}
+
+const echoTool = { description: "echo", inputSchema: {}, execute: async () => "ok" };
+
+describe("ingestMcpTools", () => {
+  it("fails closed: empty server list returns empty without calling the source", async () => {
+    const source = fakeSource({});
+    const result = await ingestMcpTools({ servers: [], source });
+    expect(result.toolset).toEqual({});
+    expect(result.descriptors).toEqual([]);
+    expect(result.failures).toEqual([]);
+    expect(source.fetchTools).not.toHaveBeenCalled();
+  });
+
+  it("prefixes tool names with the server name", async () => {
+    const source = fakeSource({ weather: { tools: { get_forecast: echoTool } } });
+    const result = await ingestMcpTools({
+      servers: [{ name: "weather", url: "http://x" }],
+      source,
+    });
+    expect(Object.keys(result.toolset)).toEqual(["weather_get_forecast"]);
+  });
+
+  it("builds descriptors with source 'mcp' and the server-reported annotations", async () => {
+    const source = fakeSource({
+      weather: {
+        tools: { get_forecast: echoTool, purge: echoTool },
+        annotations: {
+          get_forecast: { readOnlyHint: true },
+          purge: { destructiveHint: true },
+        },
+      },
+    });
+    const result = await ingestMcpTools({
+      servers: [{ name: "weather", url: "http://x" }],
+      source,
+    });
+    const byName = Object.fromEntries(result.descriptors.map((d) => [d.name, d]));
+    expect(byName["weather_get_forecast"]!.source).toBe("mcp");
+    expect(byName["weather_get_forecast"]!.annotations.readOnlyHint).toBe(true);
+    expect(byName["weather_purge"]!.annotations.destructiveHint).toBe(true);
+  });
+
+  it("narrows to the per-server allowlist by UNPREFIXED name", async () => {
+    const source = fakeSource({
+      weather: { tools: { get_forecast: echoTool, purge: echoTool } },
+    });
+    const result = await ingestMcpTools({
+      servers: [{ name: "weather", url: "http://x", tools: ["get_forecast"] }],
+      source,
+    });
+    expect(Object.keys(result.toolset)).toEqual(["weather_get_forecast"]);
+  });
+
+  it("tolerates a failing server: warns, records the failure, keeps the others", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const source = fakeSource({
+      broken: new Error("connect refused"),
+      weather: { tools: { get_forecast: echoTool } },
+    });
+    const result = await ingestMcpTools({
+      servers: [
+        { name: "broken", url: "http://down" },
+        { name: "weather", url: "http://x" },
+      ],
+      source,
+    });
+    expect(Object.keys(result.toolset)).toEqual(["weather_get_forecast"]);
+    expect(result.failures).toEqual(["broken"]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('MCP server "broken"'));
+    warn.mockRestore();
+  });
+
+  it("redacts configured header values from failure logs (no token leakage)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const source = fakeSource({
+      leaky: new Error("HTTP 401: request had Authorization: Bearer sekrit-token"),
+    });
+    await ingestMcpTools({
+      servers: [
+        { name: "leaky", url: "http://x", headers: { Authorization: "Bearer sekrit-token" } },
+      ],
+      source,
+    });
+    const logged = warn.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(logged).not.toContain("sekrit-token");
+    expect(logged).toContain("[redacted]");
+    warn.mockRestore();
+  });
+
+  it("skips server-returned tool names that are not provider-safe, fail-closed", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const source = fakeSource({
+      srv: { tools: { "bad name!": echoTool, ok_tool: echoTool } },
+    });
+    const result = await ingestMcpTools({
+      servers: [{ name: "srv", url: "http://x" }],
+      source,
+    });
+    expect(Object.keys(result.toolset)).toEqual(["srv_ok_tool"]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('tool "bad name!" skipped'));
+    warn.mockRestore();
+  });
+
+  it("keeps the FIRST tool and warns on ambiguous-prefix collisions (server 'a' tool 'b_c' vs server 'a_b' tool 'c')", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const first = { description: "first", inputSchema: {}, execute: async () => "first" };
+    const source = fakeSource({
+      a: { tools: { b_c: first } },
+      a_b: { tools: { c: echoTool } },
+    });
+    const result = await ingestMcpTools({
+      servers: [
+        { name: "a", url: "http://a" },
+        { name: "a_b", url: "http://ab" },
+      ],
+      source,
+    });
+    expect(Object.keys(result.toolset)).toEqual(["a_b_c"]);
+    expect(result.toolset["a_b_c"]).toBe(first);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('collision on "a_b_c"'));
+    warn.mockRestore();
+  });
+
+  it("skips a duplicate server name (warns) without recording a failure", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const source = fakeSource({ dup: { tools: { ping: echoTool } } });
+    const result = await ingestMcpTools({
+      servers: [
+        { name: "dup", url: "http://a" },
+        { name: "dup", url: "http://b" },
+      ],
+      source,
+    });
+    expect(Object.keys(result.toolset)).toEqual(["dup_ping"]);
+    expect(result.failures).toEqual([]);
+    expect(source.fetchTools).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('duplicate MCP server name "dup"'));
+    warn.mockRestore();
+  });
+
+  it("merges multiple servers; identical unprefixed names cannot collide (prefixes differ)", async () => {
+    const source = fakeSource({
+      a: { tools: { ping: echoTool } },
+      b: { tools: { ping: echoTool } },
+    });
+    const result = await ingestMcpTools({
+      servers: [
+        { name: "a", url: "http://a" },
+        { name: "b", url: "http://b" },
+      ],
+      source,
+    });
+    expect(Object.keys(result.toolset).sort()).toEqual(["a_ping", "b_ping"]);
+  });
+});

--- a/packages/flowlet-runtime/src/mcp.ts
+++ b/packages/flowlet-runtime/src/mcp.ts
@@ -141,3 +141,90 @@ export async function ingestMcpTools(args: {
 
   return { toolset, descriptors, failures };
 }
+
+/**
+ * The shape of the raw `tools/list` result we need from the SDK's runtime
+ * `listTools()` method. In `@ai-sdk/mcp@1.0.6` this method exists on the
+ * MCPClient class but is missing from the public interface (it became public
+ * in 2.x, which we can't take yet — it targets @ai-sdk/provider@4). The
+ * structural cast below is contract-tested in mcp.contract.test.ts.
+ */
+interface RawListToolsResult {
+  tools: Array<{ name: string; annotations?: ToolAnnotations & { title?: string } }>;
+}
+
+/**
+ * Build the REAL MCP tool source on `@ai-sdk/mcp@1.0.6` (Streamable HTTP
+ * transport, static headers — the approved v1 scope).
+ *
+ * Client lifecycle: one client per server name, created lazily on first fetch
+ * and kept open for reuse. A fetch failure closes + evicts that server's
+ * client so the next fetch rebuilds the connection, then rethrows so
+ * `ingestMcpTools` can skip the server.
+ *
+ * The public `tools()` gives executable ai-SDK tools but DISCARDS MCP
+ * `annotations`; the runtime `listTools()` recovers them. If a future SDK
+ * removes `listTools`, we degrade to empty annotations (tools still ingest;
+ * the annotation policy then fail-safes every call to "approve").
+ */
+export function createMcpToolSource(): McpToolSource {
+  type Client = {
+    tools(): Promise<ToolSet>;
+    close(): Promise<void>;
+  };
+  const clients = new Map<string, Promise<Client>>();
+
+  async function getClient(config: McpServerConfig): Promise<Client> {
+    let client = clients.get(config.name);
+    if (!client) {
+      client = import("@ai-sdk/mcp").then(({ createMCPClient }) =>
+        createMCPClient({
+          transport: {
+            type: "http",
+            url: config.url,
+            ...(config.headers ? { headers: config.headers } : {}),
+          },
+        }),
+      ) as Promise<Client>;
+      clients.set(config.name, client);
+    }
+    return client;
+  }
+
+  return {
+    async fetchTools(config) {
+      try {
+        const client = await getClient(config);
+        const tools = await client.tools();
+
+        // Recover the annotations the public API drops (see docstring).
+        let annotations: Record<string, ToolAnnotations> = {};
+        const maybeListTools = (
+          client as unknown as { listTools?: () => Promise<RawListToolsResult> }
+        ).listTools;
+        if (typeof maybeListTools === "function") {
+          const listed = await maybeListTools.call(client);
+          annotations = Object.fromEntries(
+            listed.tools.map((t) => {
+              const { title: _title, ...hints } = t.annotations ?? {};
+              return [t.name, hints];
+            }),
+          );
+        } else {
+          console.warn(
+            `[flowlet] MCP server "${config.name}": SDK listTools() unavailable — ` +
+              "annotations unknown, all its tools will require approval.",
+          );
+        }
+
+        return { tools, annotations };
+      } catch (err) {
+        // Drop the (possibly dead) client so the next fetch reconnects.
+        const stale = clients.get(config.name);
+        clients.delete(config.name);
+        if (stale) void stale.then((c) => c.close()).catch(() => {});
+        throw err;
+      }
+    },
+  };
+}

--- a/packages/flowlet-runtime/src/mcp.ts
+++ b/packages/flowlet-runtime/src/mcp.ts
@@ -56,15 +56,19 @@ const VALID_TOOL_NAME = /^[A-Za-z0-9_-]{1,64}$/;
 
 /**
  * Sanitize an error for logging. SDK transport errors embed the raw HTTP
- * response body, which a malicious server can use to reflect the request's
- * Authorization header — so never log the error object itself, and redact
- * every configured header value from the message.
+ * response body, which a malicious server can reflect secrets into — verbatim
+ * OR transformed (base64, split), so substring redaction is not enough. For a
+ * server that was sent ANY headers, the remote message is withheld entirely
+ * and only the error's class name is logged; headerless servers get the
+ * truncated message (nothing secret was sent).
  */
 function describeError(err: unknown, headers?: Record<string, string>): string {
-  let message = err instanceof Error ? err.message : String(err);
-  for (const value of Object.values(headers ?? {})) {
-    if (value.length > 0) message = message.split(value).join("[redacted]");
+  const authenticated = Object.values(headers ?? {}).some((v) => v.length > 0);
+  if (authenticated) {
+    const name = err instanceof Error ? err.constructor.name : typeof err;
+    return `${name} (message withheld: server request carried headers)`;
   }
+  const message = err instanceof Error ? err.message : String(err);
   return message.slice(0, 300);
 }
 
@@ -76,10 +80,12 @@ function describeError(err: unknown, headers?: Record<string, string>): string {
  * recorded in `failures`, and skipped — it never breaks other servers or the
  * turn. Callers use `failures` to avoid caching a partial result.
  *
- * Name safety: duplicate final names (duplicate server names, or prefix
- * ambiguity like server "a" tool "b_c" vs server "a_b" tool "c") keep the
- * FIRST registration and warn; server-returned tool names that are not
- * provider-safe are skipped.
+ * Name safety: a duplicate final name (duplicate server names, or prefix
+ * ambiguity like server "a" tool "b_c" vs server "a_b" tool "c") drops BOTH
+ * tools with a warning — fail-closed, because keeping either would let a
+ * malicious earlier server impersonate a trusted later one under its
+ * canonical name (impersonation becomes denial). Server-returned tool names
+ * that are not provider-safe are skipped.
  */
 export async function ingestMcpTools(args: {
   servers: McpServerConfig[];
@@ -90,6 +96,9 @@ export async function ingestMcpTools(args: {
   const toolset: ToolSet = {};
   const descriptors: ToolDescriptor[] = [];
   const failures: string[] = [];
+  // Final names that collided: both parties are removed and later claimants
+  // are rejected too (a name that was ever ambiguous stays unusable).
+  const poisoned = new Set<string>();
 
   const seenServers = new Set<string>();
   for (const server of servers) {
@@ -125,10 +134,18 @@ export async function ingestMcpTools(args: {
         );
         continue;
       }
-      if (prefixed in toolset) {
+      if (prefixed in toolset || poisoned.has(prefixed)) {
+        // Fail-closed: an ambiguous name could let one server impersonate
+        // another, so NO one gets it — drop the earlier registration too.
+        poisoned.add(prefixed);
+        if (prefixed in toolset) {
+          delete toolset[prefixed];
+          const at = descriptors.findIndex((d) => d.name === prefixed);
+          if (at !== -1) descriptors.splice(at, 1);
+        }
         console.warn(
           `[flowlet] MCP tool name collision on "${prefixed}" ` +
-            `(server "${server.name}") — keeping the first registration.`,
+            `(server "${server.name}") — dropping ALL claimants of that name.`,
         );
         continue;
       }

--- a/packages/flowlet-runtime/src/mcp.ts
+++ b/packages/flowlet-runtime/src/mcp.ts
@@ -1,0 +1,143 @@
+/**
+ * Host-configured MCP server ingestion for the Flowlet agent runtime.
+ *
+ * Design: docs/superpowers/specs/2026-07-04-flowlet-mcp-client-design.md.
+ * Mirrors the Composio adapter seam: `McpToolSource` is injectable (the real
+ * adapter wraps `@ai-sdk/mcp`'s `createMCPClient`; tests inject a fake), and
+ * `ingestMcpTools` FAILS CLOSED — no declared servers means no network I/O.
+ *
+ * MCP servers are host-level (declared by the host developer, shared by all
+ * users), unlike Composio's per-user OAuth. Tools are registered as
+ * `<serverName>_<toolName>` so provenance is legible and servers can't collide
+ * with each other or with other sources.
+ */
+
+import type { ToolSet } from "ai";
+import { buildDescriptor, type ToolAnnotations, type ToolDescriptor } from "./descriptor";
+
+/** A single host-declared MCP server (Streamable HTTP transport only). */
+export interface McpServerConfig {
+  /**
+   * Prefix for this server's tool names (`<name>_<tool>`). Must be a valid
+   * tool-name fragment: letters, digits, `_`, `-`.
+   */
+  name: string;
+  /** The server's Streamable HTTP endpoint (http/https). */
+  url: string;
+  /** Extra HTTP headers, e.g. `{ Authorization: "Bearer ..." }`. */
+  headers?: Record<string, string>;
+  /** Optional narrowing allowlist of UNPREFIXED tool names. */
+  tools?: string[];
+}
+
+/** What one server's fetch yields: executable tools + their MCP annotations. */
+export interface McpFetchResult {
+  tools: ToolSet;
+  /** Per (unprefixed) tool name, the server-reported annotation hints. */
+  annotations: Record<string, ToolAnnotations>;
+}
+
+/**
+ * The Flowlet abstraction over an MCP connection. The real implementation
+ * ({@link createMcpToolSource}) wraps `@ai-sdk/mcp`; tests implement it
+ * directly.
+ */
+export interface McpToolSource {
+  fetchTools(config: McpServerConfig): Promise<McpFetchResult>;
+}
+
+/**
+ * Final tool names must be provider-safe: the SDK forwards them verbatim to
+ * the model API, and Anthropic caps tool names at `[A-Za-z0-9_-]{1,64}`. A
+ * server-returned name that breaks this after prefixing would 400 the WHOLE
+ * turn, so invalid names are skipped fail-closed instead.
+ */
+const VALID_TOOL_NAME = /^[A-Za-z0-9_-]{1,64}$/;
+
+/**
+ * Sanitize an error for logging. SDK transport errors embed the raw HTTP
+ * response body, which a malicious server can use to reflect the request's
+ * Authorization header — so never log the error object itself, and redact
+ * every configured header value from the message.
+ */
+function describeError(err: unknown, headers?: Record<string, string>): string {
+  let message = err instanceof Error ? err.message : String(err);
+  for (const value of Object.values(headers ?? {})) {
+    if (value.length > 0) message = message.split(value).join("[redacted]");
+  }
+  return message.slice(0, 300);
+}
+
+/**
+ * Ingest tools from host-declared MCP servers.
+ *
+ * FAILS CLOSED: an empty server list returns empty without touching the
+ * source. Per-server fault tolerance: a server that errors is warned about,
+ * recorded in `failures`, and skipped — it never breaks other servers or the
+ * turn. Callers use `failures` to avoid caching a partial result.
+ *
+ * Name safety: duplicate final names (duplicate server names, or prefix
+ * ambiguity like server "a" tool "b_c" vs server "a_b" tool "c") keep the
+ * FIRST registration and warn; server-returned tool names that are not
+ * provider-safe are skipped.
+ */
+export async function ingestMcpTools(args: {
+  servers: McpServerConfig[];
+  source: McpToolSource;
+}): Promise<{ toolset: ToolSet; descriptors: ToolDescriptor[]; failures: string[] }> {
+  const { servers, source } = args;
+
+  const toolset: ToolSet = {};
+  const descriptors: ToolDescriptor[] = [];
+  const failures: string[] = [];
+
+  const seenServers = new Set<string>();
+  for (const server of servers) {
+    // Duplicate server names would alias each other in the client cache and
+    // collide on every prefixed tool name. Deterministic misconfig — warn and
+    // skip, but do NOT count as a failure (failures trigger cache retry, and
+    // a deterministic one would re-ingest forever).
+    if (seenServers.has(server.name)) {
+      console.warn(`[flowlet] duplicate MCP server name "${server.name}" skipped.`);
+      continue;
+    }
+    seenServers.add(server.name);
+
+    let fetched: McpFetchResult;
+    try {
+      fetched = await source.fetchTools(server);
+    } catch (err) {
+      console.warn(
+        `[flowlet] MCP server "${server.name}" skipped: ${describeError(err, server.headers)}`,
+      );
+      failures.push(server.name);
+      continue;
+    }
+
+    const allow = server.tools && server.tools.length > 0 ? new Set(server.tools) : null;
+    for (const [name, tool] of Object.entries(fetched.tools)) {
+      if (allow && !allow.has(name)) continue;
+      const prefixed = `${server.name}_${name}`;
+      if (!VALID_TOOL_NAME.test(prefixed)) {
+        console.warn(
+          `[flowlet] MCP server "${server.name}" tool "${name}" skipped: ` +
+            "final tool name is not provider-safe.",
+        );
+        continue;
+      }
+      if (prefixed in toolset) {
+        console.warn(
+          `[flowlet] MCP tool name collision on "${prefixed}" ` +
+            `(server "${server.name}") — keeping the first registration.`,
+        );
+        continue;
+      }
+      toolset[prefixed] = tool;
+      descriptors.push(
+        buildDescriptor(prefixed, tool, "mcp", fetched.annotations[name] ?? {}),
+      );
+    }
+  }
+
+  return { toolset, descriptors, failures };
+}

--- a/packages/flowlet-shell/src/use-flowlet-thread.test.ts
+++ b/packages/flowlet-shell/src/use-flowlet-thread.test.ts
@@ -22,6 +22,43 @@ describe("toThreadItems", () => {
     });
   });
 
+  it("emits an approval item for a DYNAMIC tool part awaiting approval (MCP tools)", () => {
+    // MCP tools ingest as ai-SDK dynamic tools: their parts are type
+    // "dynamic-tool" with the name in `toolName`, not "tool-<name>".
+    const items = toThreadItems([
+      msg("m2d", "assistant", [
+        {
+          type: "dynamic-tool",
+          toolName: "everything_echo",
+          state: "approval-requested",
+          approval: { id: "a9" },
+          input: { message: "hi" },
+        },
+      ]),
+    ]);
+    expect(items[0]).toEqual({
+      kind: "approval", key: "m2d:0", messageId: "m2d", approvalId: "a9", toolName: "everything_echo", input: { message: "hi" },
+    });
+  });
+
+  it("emits a tool item for a dynamic tool part in other states", () => {
+    const items = toThreadItems([
+      msg("m3d", "assistant", [
+        {
+          type: "dynamic-tool",
+          toolName: "everything_echo",
+          toolCallId: "c1",
+          state: "output-available",
+          input: { message: "hi" },
+          output: { content: [{ type: "text", text: "Echo: hi" }] },
+        },
+      ]),
+    ]);
+    expect(items[0]).toMatchObject({
+      kind: "tool", toolName: "everything_echo", toolCallId: "c1", state: "output-available",
+    });
+  });
+
   it("emits an error item for an error part", () => {
     const items = toThreadItems([msg("m0", "assistant", [{ type: "error", errorText: "boom" }])]);
     expect(items[0]).toEqual({ kind: "error", key: "m0:0", messageId: "m0", message: "boom" });

--- a/packages/flowlet-shell/src/use-flowlet-thread.ts
+++ b/packages/flowlet-shell/src/use-flowlet-thread.ts
@@ -83,6 +83,28 @@ export function toThreadItems(messages: FlowletUIMessage[]): ThreadItem[] {
         items.push({ kind: "error", key, messageId, message: text });
       } else if (part.type === "data-ui") {
         items.push({ kind: "ui", key, messageId, node: part.data as UINode });
+      } else if (part.type === "dynamic-tool") {
+        // Dynamic tools (MCP servers, and any tool the SDK types at runtime)
+        // carry their name in `toolName` instead of the part type. Same
+        // approval/chip treatment as static tool parts; RENDER_TOOLS never
+        // ingest as dynamic, so no skeleton branch is needed here.
+        const toolName = String(part.toolName ?? "unknown");
+        if (part.state === "approval-requested") {
+          const approval = part.approval as { id: string };
+          items.push({ kind: "approval", key, messageId, approvalId: approval.id, toolName, input: part.input });
+        } else {
+          items.push({
+            kind: "tool",
+            key,
+            messageId,
+            toolName,
+            toolCallId: part.toolCallId as string | undefined,
+            state: String(part.state ?? ""),
+            input: part.input,
+            output: part.output,
+            errorText: part.errorText as string | undefined,
+          });
+        }
       } else if (part.type.startsWith("tool-")) {
         const toolName = part.type.slice("tool-".length);
         if (part.state === "approval-requested") {

--- a/verification/mcp-client/REPORT.md
+++ b/verification/mcp-client/REPORT.md
@@ -1,0 +1,43 @@
+# MCP client support — live verification (2026-07-04)
+
+Spec: `docs/superpowers/specs/2026-07-04-flowlet-mcp-client-design.md`
+Plan: `docs/superpowers/plans/2026-07-04-flowlet-mcp-client.md`
+
+## 1. SDK handshake probe (pre-implementation)
+
+Scratch probe against `@ai-sdk/mcp@1.0.6` with a minimal in-process
+Streamable-HTTP server established the transport facts baked into the contract
+test: notifications need `202` (a `200` without JSON/SSE content-type throws),
+a startup GET (inbound SSE) gets a tolerated `405`, `initialize` must echo the
+client's `protocolVersion`, `tools()` drops `annotations`, and the runtime
+`listTools()` cast recovers them. PROBE PASSED.
+
+## 2. Adapter smoke against a real MCP server
+
+`createMcpToolSource()` against `@modelcontextprotocol/server-everything`
+(Streamable HTTP, `http://localhost:3001/mcp`):
+
+- 13 tools fetched (echo, get-sum, get-tiny-image, …), all with `execute`.
+- `echo` round-trip returned `{"content":[{"type":"text","text":"Echo: flowlet-smoke"}],"isError":false}`.
+- This server build reports no annotations → every tool correctly fail-safes
+  to "needs approval". SMOKE PASSED.
+
+## 3. Browser e2e in demo-bank (Maple)
+
+`mcpServers: [{ name: "everything", url: "http://localhost:3001/mcp" }]` added
+to the demo-bank handler (local-only edit, reverted), `pnpm demo` on :3457:
+
+- `GET /api/flowlet/capabilities` → `{"chat":true,"integrations":true,"voice":true,"mcp":true}`.
+- Prompt: *Use the everything_echo tool to echo the message "flowlet mcp e2e"…*
+- The model called `everything_echo` (a `dynamic-tool` part); the policy
+  paused it; the existing ApprovalCard rendered ("Needs your approval —
+  Everything Echo", input shown) — `mcp-e2e-approval-card.png`.
+- Clicking Approve resubmitted the turn, the tool executed on the real MCP
+  server, and the model reported `Echo: flowlet mcp e2e` with the raw
+  content/isError detail — `mcp-e2e-success.png`.
+
+The first e2e attempt exposed (and this branch fixes) three `tool-*`-only
+assumptions that silently dropped dynamic-tool parts: the shell thread
+normalizer (no approval card), the react auto-resubmit predicate (approval
+never resumed the turn), and the engine's stale-approval repair (a typed-past
+MCP approval would wedge the thread).


### PR DESCRIPTION
## What

Any remote MCP server a host declares becomes agent tools, governed by the existing policy/approval engine — the top table-stakes gap from the OSS release audit (Tier 1). Built to the approved spec `docs/superpowers/specs/2026-07-04-flowlet-mcp-client-design.md` and plan `docs/superpowers/plans/2026-07-04-flowlet-mcp-client.md`.

## Scope rulings (Yousef, brainstorm 2026-07-04)

Host-configured servers only · Streamable HTTP only · all tools per server with optional `tools` allowlist · static-header auth · **trust server annotation hints same as Composio** (readOnlyHint auto-allows; unknown/destructive pauses for approval) · config = `createFlowletHandler({ mcpServers })` + `.flowlet/mcp.json` (code overrides file, `${ENV_VAR}` header substitution) · no UI in v1 · tools only. Deferred: stdio, OAuth servers, user-added servers, resources/prompts/elicitation/MCP Apps.

## How

- **Runtime** (`mcp.ts`): mirror of the Composio adapter — injectable `McpToolSource` seam wrapping `@ai-sdk/mcp@1.0.6`'s `createMCPClient`, fail-closed `ingestMcpTools` (empty config = zero network), tools prefixed `<serverName>_<toolName>`, per-server fault tolerance. Wired as the F2-reserved 4th source (`caller > engine > composio > mcp`) so every tool passes the unchanged `wrapTool` gate. Host-level ingestion cache (30s retry backoff on partial failure).
- **listTools() cast**: the SDK's public `tools()` discards MCP `annotations`; the runtime `listTools()` (public in 2.x, missing from the 1.0.6 type) recovers them via a narrow structural cast, contract-tested against the real SDK + an in-process Streamable-HTTP server so an SDK bump fails loudly. Degrades to everything-needs-approval if the method vanishes.
- **@flowlet/next**: zod-validated `mcpServers` option, `.flowlet/mcp.json` loading, env substitution with fail-closed drops, capability-additive `capabilities.mcp`.
- **Dynamic-tool fixes found in live e2e**: MCP tools stream as ai-SDK `dynamic-tool` parts, which three existing `tool-*`-only paths dropped — the shell thread renderer (no approval card), the react auto-resubmit predicate (approval never resumed the turn), and the engine's stale-approval repair (typed-past MCP approval would wedge the thread). All three now handle dynamic parts; host-tool execution predicates deliberately ignore them (spoof guard).
- **Dependency guard**: the shipped-file import scan now skips `*.test.ts` (tests are build-excluded and never reach dist; the MCP contract test stands up an in-process `node:http` fixture). The shipped-runtime guarantee is unchanged — flagging for explicit review.

## Reviews

Dual Codex review, both triaged and folded in: review #1 (spec/plan vs codebase + SDK, 8 findings: token-redacted logs, failure-cache eviction, notification 202, name validation, test shapes) and review #2 (final implementation, 5 findings: host-tool spoof guard, collision drops all claimants, transformed-secret log withholding, retry backoff, ${...} residue drop). A pre-implementation probe against the real SDK verified the handshake facts the contract test encodes.

## Verification

`verification/mcp-client/REPORT.md` + screenshots: adapter smoke against the real `@modelcontextprotocol/server-everything` (13 tools, echo round-trip), then browser e2e in demo-bank — `capabilities.mcp: true`, agent calls `everything_echo`, ApprovalCard renders, Approve executes on the real server, model reports `Echo: flowlet mcp e2e`. Repo-wide typecheck 19/19, tests 18/18 (990+ tests), build 14/14.

**UI note for Yousef**: the shell change renders existing components (ApprovalCard, tool chips) for dynamic parts — no new visuals — but it is UI-adjacent, so calling it out per the UI-gate rule. Screenshots in `verification/mcp-client/`.

Never merging — that's yours.

https://claude.ai/code/session_01YCgjhvxdPt9927TstQnyes