### PR TITLE
Update fluidkit repo URLs after transfer to runvendo org

### DIFF
--- a/docs/superpowers/specs/2026-07-02-eng205-fluid-motion-findings.md
+++ b/docs/superpowers/specs/2026-07-02-eng205-fluid-motion-findings.md
@@ -5,7 +5,7 @@ perf numbers. Updated per increment.
 
 ## Consumption mechanics (decided increment 1)
 
-- **Source of truth:** fluidkit `main` (repo github.com/yousefh409/fluidkit). Consumed at
+- **Source of truth:** fluidkit `main` (repo github.com/runvendo/fluidkit). Consumed at
   `d5e0fd6` (the tab-bar merge). The touch-up worktree carries uncommitted aurora/mesh WIP,
   so main is the stable line.
 - **Linkage:** committed tarball `vendor/fluidkit-0.3.0-d5e0fd6.tgz`, packed from a clean

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -8,7 +8,7 @@ Flowlet pins an exact built artifact instead of a live path link (works on any
 machine/CI, no dependency on a sibling checkout).
 
 - **Provenance:** packed from fluidkit `main` at the SHA in the filename
-  (repo: github.com/yousefh409/fluidkit), after a clean `npm ci && npm run build && npm test && npm pack`.
+  (repo: github.com/runvendo/fluidkit), after a clean `npm ci && npm run build && npm test && npm pack`.
 - **Consumed by:** `@flowlet/shell` via `"fluidkit": "file:../../vendor/fluidkit-<version>-<sha>.tgz"`.
 - **Refresh procedure:** clone fluidkit main into a scratch dir → `npm ci && npm run build
   && npm test && npm pack` → copy the tarball here named `fluidkit-<version>-<shortsha>.tgz` →


### PR DESCRIPTION
Updates the two living references to the fluidkit source repo (vendor/README.md and the ENG-205 findings doc) to github.com/runvendo/fluidkit after the ownership transfer. Historical branch names in point-in-time specs are left as-is.

https://claude.ai/code/session_01V3VKpddsC3CKHk5KVS2J7t
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/flowlet/pull/39" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update fluidkit repo references to `github.com/runvendo/fluidkit` after the transfer. Updates `vendor/README.md` and the ENG-205 findings doc to point to the new source of truth; historical branch names in point-in-time specs stay as-is (ENG-205).

<sup>Written for commit 0b0387b08df8cec62edf3754bbb2b36e6f00ab77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/flowlet/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

