### PR TITLE
fix: live voice-check follow-ups — Table tolerates rich raw rows, scalar-column source gate, no dead air

### DIFF
--- a/apps/demo-bank/src/components/flowlet/voice-realtime.test.ts
+++ b/apps/demo-bank/src/components/flowlet/voice-realtime.test.ts
@@ -113,3 +113,43 @@ describe("review fixes (PR #41 triage)", () => {
     expect(titleNode?.props).toEqual({ text: "March" });
   });
 });
+
+describe("live voice check fixes (real Maple row shapes)", () => {
+  // The REAL listTransactions rows: scalar display fields + nested extras.
+  const REAL_ROWS = [
+    {
+      id: "txn_0135",
+      merchant: "Spotify",
+      amount: -1199,
+      category: "subscriptions",
+      statusTimeline: [{ state: "Posted", at: "2026-07-04T13:00:00.000Z" }],
+    },
+  ];
+  const REAL_RAW = { status: 200, ok: true, data: { data: REAL_ROWS } };
+
+  it("binds when declared columns are scalar, even though rows carry nested fields", () => {
+    replayRegistry.register("listTransactions", async () => REAL_RAW);
+    recordResult("listTransactions", { limit: 40 }, REAL_RAW);
+    const node = tableView({
+      columns: [
+        { key: "merchant", label: "Merchant" },
+        { key: "amount", label: "Amount" },
+      ],
+      rows: REAL_ROWS,
+      source: { tool: "listTransactions", input: { limit: 40 }, rowsPath: "/data/data" },
+    });
+    const payload = (node as { payload: GeneratedPayload }).payload;
+    expect(payload.queries?.[0]?.tool).toBe("listTransactions");
+  });
+
+  it("degrades to snapshot when a DECLARED column is a nested value", () => {
+    recordResult("listTransactions", { limit: 41 }, REAL_RAW);
+    const node = tableView({
+      columns: [{ key: "statusTimeline", label: "Status" }],
+      rows: [{ statusTimeline: "Posted" }],
+      source: { tool: "listTransactions", input: { limit: 41 }, rowsPath: "/data/data" },
+    });
+    const payload = (node as { payload: GeneratedPayload }).payload;
+    expect(payload.queries).toBeUndefined();
+  });
+});

--- a/apps/demo-bank/src/components/flowlet/voice-realtime.test.ts
+++ b/apps/demo-bank/src/components/flowlet/voice-realtime.test.ts
@@ -153,3 +153,29 @@ describe("live voice check fixes (real Maple row shapes)", () => {
     expect(payload.queries).toBeUndefined();
   });
 });
+
+describe("heterogeneous rows (PR #43 review P1)", () => {
+  it("degrades to snapshot when a LATER row has a nested value for a declared column", () => {
+    const mixed = {
+      ok: true,
+      data: {
+        data: [
+          { merchant: "A", status: "posted" },
+          { merchant: "B", status: [{ state: "pending" }] },
+        ],
+      },
+    };
+    replayRegistry.register("listTransactions", async () => mixed);
+    recordResult("listTransactions", { limit: 42 }, mixed);
+    const node = tableView({
+      columns: [
+        { key: "merchant", label: "Merchant" },
+        { key: "status", label: "Status" },
+      ],
+      rows: [{ merchant: "A", status: "posted" }],
+      source: { tool: "listTransactions", input: { limit: 42 }, rowsPath: "/data/data" },
+    });
+    const payload = (node as { payload: GeneratedPayload }).payload;
+    expect(payload.queries).toBeUndefined();
+  });
+});

--- a/apps/demo-bank/src/components/flowlet/voice-realtime.ts
+++ b/apps/demo-bank/src/components/flowlet/voice-realtime.ts
@@ -105,8 +105,13 @@ function matchSource(
   if (rows.length > 0) {
     const first = rows[0];
     if (!first || typeof first !== "object") return undefined;
-    const fields = new Set(Object.keys(first as Record<string, unknown>));
-    if (!columns.every((c) => fields.has(c.key))) return undefined;
+    const record = first as Record<string, unknown>;
+    // Declared columns must exist AND be scalar: bound cells render raw
+    // values, so a nested field (statusTimeline…) would show as an em dash
+    // in every row — worse than the model's own formatted snapshot.
+    const scalar = (v: unknown) =>
+      v === null || ["string", "number", "boolean"].includes(typeof v);
+    if (!columns.every((c) => c.key in record && scalar(record[c.key]))) return undefined;
   }
   return { raw, tool: source.tool, input: source.input ?? {}, rowsPath: source.rowsPath };
 }

--- a/apps/demo-bank/src/components/flowlet/voice-realtime.ts
+++ b/apps/demo-bank/src/components/flowlet/voice-realtime.ts
@@ -103,15 +103,17 @@ function matchSource(
   // An EMPTY result is still a valid, refreshable declaration (rows may exist
   // on a later refresh) — column validation only applies when rows exist.
   if (rows.length > 0) {
-    const first = rows[0];
-    if (!first || typeof first !== "object") return undefined;
-    const record = first as Record<string, unknown>;
-    // Declared columns must exist AND be scalar: bound cells render raw
-    // values, so a nested field (statusTimeline…) would show as an em dash
-    // in every row — worse than the model's own formatted snapshot.
+    // Declared columns must exist AND be scalar in EVERY row (review P1:
+    // heterogeneous rows can be scalar in row 1 and nested in row 2): bound
+    // cells render raw values, so a nested field would show as an em dash —
+    // worse than the model's own formatted snapshot.
     const scalar = (v: unknown) =>
       v === null || ["string", "number", "boolean"].includes(typeof v);
-    if (!columns.every((c) => c.key in record && scalar(record[c.key]))) return undefined;
+    for (const row of rows) {
+      if (!row || typeof row !== "object") return undefined;
+      const record = row as Record<string, unknown>;
+      if (!columns.every((c) => c.key in record && scalar(record[c.key]))) return undefined;
+    }
   }
   return { raw, tool: source.tool, input: source.input ?? {}, rowsPath: source.rowsPath };
 }

--- a/packages/flowlet-components/src/components/Table/Table.test.tsx
+++ b/packages/flowlet-components/src/components/Table/Table.test.tsx
@@ -37,20 +37,22 @@ describe("Table", () => {
 describe("rich raw rows (data-bound refreshable views)", () => {
   it("renders declared scalar columns and ignores nested undeclared fields", () => {
     render(
-      <Table
-        columns={[
-          { key: "merchant", label: "Merchant" },
-          { key: "amount", label: "Amount" },
-        ]}
-        rows={[
-          {
-            merchant: "Spotify",
-            amount: -1199,
-            statusTimeline: [{ state: "Posted", at: "2026-07-04" }],
-            meta: { deep: true },
-          },
-        ]}
-      />,
+      <FlowletThemeProvider>
+        <Table
+          columns={[
+            { key: "merchant", label: "Merchant" },
+            { key: "amount", label: "Amount" },
+          ]}
+          rows={[
+            {
+              merchant: "Spotify",
+              amount: -1199,
+              statusTimeline: [{ state: "Posted", at: "2026-07-04" }],
+              meta: { deep: true },
+            },
+          ]}
+        />
+      </FlowletThemeProvider>,
     );
     expect(screen.queryByTestId("flowlet-invalid-props")).toBeNull();
     expect(screen.getByText("Spotify")).toBeInTheDocument();
@@ -59,10 +61,12 @@ describe("rich raw rows (data-bound refreshable views)", () => {
 
   it("renders a non-scalar cell for a DECLARED column as an em dash, not JSON", () => {
     render(
-      <Table
-        columns={[{ key: "statusTimeline", label: "Status" }]}
-        rows={[{ statusTimeline: [{ state: "Posted" }] }]}
-      />,
+      <FlowletThemeProvider>
+        <Table
+          columns={[{ key: "statusTimeline", label: "Status" }]}
+          rows={[{ statusTimeline: [{ state: "Posted" }] }]}
+        />
+      </FlowletThemeProvider>,
     );
     expect(screen.queryByTestId("flowlet-invalid-props")).toBeNull();
     expect(screen.getByText("—")).toBeInTheDocument();

--- a/packages/flowlet-components/src/components/Table/Table.test.tsx
+++ b/packages/flowlet-components/src/components/Table/Table.test.tsx
@@ -29,3 +29,42 @@ describe("Table", () => {
     expect(screen.getByText("42")).toBeInTheDocument();
   });
 });
+
+// Regression: data-bound refreshable views feed the Table RAW tool rows, which
+// carry nested fields (statusTimeline arrays, metadata objects). The Table
+// renders the DECLARED columns and ignores everything else — it must not
+// reject the whole row set (context-engineering follow-up, live voice check).
+describe("rich raw rows (data-bound refreshable views)", () => {
+  it("renders declared scalar columns and ignores nested undeclared fields", () => {
+    render(
+      <Table
+        columns={[
+          { key: "merchant", label: "Merchant" },
+          { key: "amount", label: "Amount" },
+        ]}
+        rows={[
+          {
+            merchant: "Spotify",
+            amount: -1199,
+            statusTimeline: [{ state: "Posted", at: "2026-07-04" }],
+            meta: { deep: true },
+          },
+        ]}
+      />,
+    );
+    expect(screen.queryByTestId("flowlet-invalid-props")).toBeNull();
+    expect(screen.getByText("Spotify")).toBeInTheDocument();
+    expect(screen.getByText("-1199")).toBeInTheDocument();
+  });
+
+  it("renders a non-scalar cell for a DECLARED column as an em dash, not JSON", () => {
+    render(
+      <Table
+        columns={[{ key: "statusTimeline", label: "Status" }]}
+        rows={[{ statusTimeline: [{ state: "Posted" }] }]}
+      />,
+    );
+    expect(screen.queryByTestId("flowlet-invalid-props")).toBeNull();
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+});

--- a/packages/flowlet-components/src/components/Table/descriptor.ts
+++ b/packages/flowlet-components/src/components/Table/descriptor.ts
@@ -4,7 +4,12 @@ import { prewired } from "../../descriptor";
 export const tableSchema = z.object({
   caption: z.string().optional(),
   columns: z.array(z.object({ key: z.string(), label: z.string() })).min(1).max(50),
-  rows: z.array(z.record(z.union([z.string(), z.number(), z.boolean(), z.null()]))).max(1000),
+  // Records of UNKNOWN values: data-bound refreshable views feed the Table raw
+  // tool rows, which legitimately carry nested fields (statusTimeline arrays,
+  // metadata objects). The impl renders only the declared columns and shows an
+  // em dash for a non-scalar cell — rejecting the whole row set here breaks
+  // every bound view over rich rows (live voice check, 2026-07-04).
+  rows: z.array(z.record(z.unknown())).max(1000),
 });
 
 export const tableDescriptor = prewired(

--- a/packages/flowlet-components/src/components/Table/impl.tsx
+++ b/packages/flowlet-components/src/components/Table/impl.tsx
@@ -9,6 +9,15 @@ import {
 import { createPrewiredImpl } from "../../impl-helpers/create-impl";
 import { tableSchema } from "./descriptor";
 
+/** A cell renders scalars; nested values (raw tool rows carry them) show as
+ *  an em dash rather than JSON noise or a whole-table validation failure. */
+function cellText(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return "—";
+}
+
 export const Table = createPrewiredImpl(tableSchema, (p) => (
   <UITable>
     {p.caption ? <caption>{p.caption}</caption> : null}
@@ -23,7 +32,7 @@ export const Table = createPrewiredImpl(tableSchema, (p) => (
       {p.rows.map((row, i) => (
         <UITableRow key={i}>
           {p.columns.map((col) => (
-            <UITableCell key={col.key}>{String(row[col.key] ?? "")}</UITableCell>
+            <UITableCell key={col.key}>{cellText(row[col.key])}</UITableCell>
           ))}
         </UITableRow>
       ))}

--- a/packages/flowlet-core/src/prompt/sections.test.ts
+++ b/packages/flowlet-core/src/prompt/sections.test.ts
@@ -89,3 +89,16 @@ describe("prompt sections", () => {
     expect(guardrailSection("chat")).toMatch(/these rules win/i);
   });
 });
+
+describe("integrations completeness (live check feedback)", () => {
+  it("chat: capability talk demands the complete connectable list, no abbreviation", () => {
+    const s = capabilitiesSection("chat");
+    expect(s).toMatch(/COMPLETE connectable list/);
+    expect(s).toMatch(/never an abbreviated/);
+  });
+
+  it("voice: the complete list goes on screen, not recited aloud", () => {
+    const s = capabilitiesSection("voice");
+    expect(s).toMatch(/complete\s+connectable list on screen/);
+  });
+});

--- a/packages/flowlet-core/src/prompt/sections.ts
+++ b/packages/flowlet-core/src/prompt/sections.ts
@@ -185,8 +185,9 @@ export function registerSection(modality: PromptModality): string {
   return [
     "HOW YOU SPEAK: one thought per turn — answer in at most two sentences, then stop.",
     "No trailing offers ('anything else?') at the end of turns.",
-    "Never announce what you are about to do — just do it; while a tool runs, silence or",
-    "three words at most. Never restate the user's question back to them.",
+    "Never announce a plan — act. When a tool takes more than a beat, say a two-or-three",
+    "word status ('pulling that up') so the user never sits in dead air; never more than",
+    "that. Never restate the user's question back to them.",
     "When a view is on screen, one headline sentence — the screen carries the rest.",
     "Warm but plain: no filler openers, no enthusiasm inflation.",
     "Greeting: one sentence. Sign-off: one sentence.",

--- a/packages/flowlet-core/src/prompt/sections.ts
+++ b/packages/flowlet-core/src/prompt/sections.ts
@@ -206,11 +206,16 @@ export function capabilitiesSection(
           "TALKING ABOUT WHAT YOU CAN DO: when asked, name a handful of things you can",
           "actually do, in the user's terms — never dump a tool inventory. Never claim an",
           "integration that is not connected; offer to connect it instead.",
+          "EXCEPTION — integrations: when asked what you can connect to (or about",
+          "integrations at all), name the COMPLETE connectable list from your summary,",
+          "never an abbreviated 'Gmail, Slack, and others'. The list is the answer.",
         ].join("\n")
       : [
           "If asked what you can do: at most two sentences, in the user's terms, and offer",
           "to put the full list on screen. Never claim an integration that is not connected —",
-          "offer to connect it instead.",
+          "offer to connect it instead. When asked what you can CONNECT to, put the complete",
+          "connectable list on screen (a table works) and speak one headline — never recite",
+          "or abbreviate the list aloud.",
         ].join("\n");
   return toolSummary ? `${rules}\n${toolSummary}` : rules;
 }


### PR DESCRIPTION
## Follow-ups from Yousef's real-speech voice check (post-PR #41)

**Bug (screenshot in session): voice table rendered 'Invalid component props'.**
Root cause: data-bound refreshable views feed the Table the RAW tool rows, and real Maple rows carry nested fields (`statusTimeline: [{state, at}]`) that the old `rows` schema — flat records of scalars — rejected wholesale. Chat never hit it because demo `get_transactions` returns flat rows; the voice OpenAPI tools return rich ones.

Fixes:
- **Table** (`@flowlet/components`): `rows` accepts records of unknown; the impl renders only the declared columns and shows an em dash for a non-scalar cell. Regression tests with real row shapes.
- **matchSource** (demo-bank voice): declared columns must be scalar in the cached rows, else the view degrades to the model's own formatted snapshot (better than a column of dashes).
- **Voice register** (`@flowlet/core`): 'silence or three words' became 'say a two-or-three word status when a tool takes more than a beat' — kills the dead-air-while-fetching feel without reopening yap.

**Surfaced, needs Yousef's call (not built):**
1. **Mid-session connect**: the voice session's toolset is fixed at session start, so connecting Gmail during a session doesn't inject GMAIL_* tools — the model asks to connect again. Fix = re-fetch bridge tools + `session.update` on connect completion (real feature, ENG-185-era behavior).
2. **Connect UX in voice**: the Connect card takes the stage (ENG-185 stage design) rather than appearing as a popup-sized card.
3. **Bound cells show raw values** (cents, ISO dates). Follow-up idea: per-column format hints on the Table descriptor.

All 22 turbo test tasks green; typecheck green.

https://claude.ai/code/session_01EhPWVWXY5JW5gJUfqpZBrV
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/flowlet/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes "Invalid component props" in voice tables by letting `Table` accept rich raw tool rows and only render declared columns (em dash for non-scalars). Tightens source binding to require scalar columns across all rows; adds brief status utterances and surfaces the complete integrations list.

- **Bug Fixes**
  - `flowlet-components` `Table`: `rows` now accept records with unknown values; non-scalar declared cells render as an em dash. Only declared columns are shown.
  - `apps/demo-bank` voice `matchSource`: binds only if all declared columns exist and are scalar in every row; otherwise falls back to the model’s formatted snapshot (covers heterogeneous rows).

- **New Features**
  - `flowlet-core` voice guidance: when a tool runs longer than a beat, say a 2–3 word status to avoid dead air.
  - `flowlet-core` capability talk: integrations are the exception — chat names the COMPLETE connectable list; voice puts the complete list on screen and speaks one headline.

<sup>Written for commit 76f0036cf9af8d25cfce6fd6e8f528aadc00c6bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/flowlet/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

