### PR TITLE
test(server): decouple remote-guard test from flaky PGlite boot

### DIFF
--- a/packages/vendo-server/src/fetch-handler.test.ts
+++ b/packages/vendo-server/src/fetch-handler.test.ts
@@ -134,7 +134,11 @@ describe("createVendoFetchHandler", () => {
     vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-x");
     vi.stubEnv("COMPOSIO_API_KEY", "ck_x");
     vi.stubEnv("NODE_ENV", "production"); // fail-closed in prod even for spoofed Host
-    const handler = createVendoFetchHandler({ vendoDir: emptyDir() });
+    // storage:false keeps this guard test off the durable path: NODE_ENV=production
+    // otherwise trips resolveStorage's real PGlite boot (the test-env safety net is
+    // NODE_ENV==="test"-only), whose WASM first-init is flaky here and would 500 the
+    // first request before it reaches the remote guard. This test is about the guard.
+    const handler = createVendoFetchHandler({ vendoDir: emptyDir(), storage: false });
     for (const p of ["chat", "action", "tick", "integrations"]) {
       const res = await handler(
         new Request(`http://prod.example.com/api/vendo/${p}`, {


### PR DESCRIPTION
Follow-up to the Flowlet→Vendo rename (PR #50). Fixes the one test that was failing on `main`: `@vendoai/server` → `fetch-handler.test.ts` "guards every mutating endpoint".

## Root cause (pre-existing, not the rename)
The test stubs `NODE_ENV=production` to exercise the fail-closed remote guard. But `resolveStorage` only skips durable storage when `NODE_ENV==="test"`, so under `production` it booted a real **PGlite (WASM)** store. PGlite's WASM first-init is flaky in this vitest environment and throws `ExitStatus/exit(1)`, surfacing as a **500 on the first request** — before it reached the remote guard. So `chat` (first loop iteration) asserted `500 != 403`; later endpoints passed because the lazy-state memo resets on failure and the second boot reuses the now-warm WASM.

The rename left this control flow identical (only `createFlowletDatabase`→`createVendoDatabase` symbol renames), so this was latent on main already.

## Fix
Pass `storage: false` in the guard test so it uses the in-memory store. The test is about the **guard**, not durability. No product code changes.

## Verification
- `@vendoai/server` package: 247/247 ✅
- full workspace `pnpm test`: 26/26 tasks ✅

https://claude.ai/code/session_014Ahk7uGQJXNJaMHAz35t4T
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/51" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky remote-guard test in `@vendoai/server` by using in-memory storage during the production-stubbed run, ensuring consistent 403s across mutating endpoints and avoiding PGlite boot.

- **Bug Fixes**
  - In `fetch-handler.test.ts`, pass `storage: false` to `createVendoFetchHandler` so the test skips durable storage and doesn't trigger PGlite’s flaky first-init.

<sup>Written for commit 4bcbd4eba2cc9572b2911df160df2d47e1125099. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

