### PR TITLE
Zero-config gaps: host events in authoring, VendoRoot voice driver, scoped pin

### DIFF
--- a/REVIEW-PR53.md
+++ b/REVIEW-PR53.md
@@ -1,0 +1,46 @@
+# PR #53 Review
+
+## Findings
+
+1. **major** - `packages/vendo-next/src/client/vendo-root.tsx:125`
+
+   `ScopedPinOverlay` persists only `{ anchorId, node, components }` when the new scoped pin affordance is used. The existing chat "Apply to page" path persists the paired sealed remix `envelope` (`packages/vendo-shell/src/VendoThread.tsx:195`), and `VendoRemix` later sends that envelope back on scoped opens so the server can edit `base: "pin"` instead of starting from the original anchor. Because `onPin` only receives a `UINode`, and the envelope lives beside the node on the thread item rather than inside `UINode`, pins created through this new path silently lose fast-edit state.
+
+   Suggested fix: extend the pin path to carry the envelope, for example by changing the shell `onPin` callback shape to include `envelope?: string`, tracking the latest UI item rather than only `latestNode`, and passing `{ envelope }` into `remixes.pin` when present. Add a scoped-pin regression test that pins an enveloped remix and verifies the next `VendoRemix` scoped open carries that envelope.
+
+2. **minor** - `apps/demo-accounting/src/components/vendo/VendoLayer.tsx:70`
+
+   The scoped pin wrapper is private to `@vendoai/next`'s `VendoRoot`, but Cadence mounts `VendoOverlay` directly inside its custom root while also using `VendoRemix` anchors. That call site bypasses `ScopedPinOverlay`, so the new scoped pin affordance is absent in the demo path most likely to exercise anchor-scoped overlays. The existing "Apply to page" flow still works, but the PR's new `onPin` behavior is not applied there.
+
+   Suggested fix: move the scoped pin behavior into `VendoOverlay`/`VendoThread` in `@vendoai/shell`, or export a reusable wrapper and update direct overlay call sites such as Cadence's `VendoLayer`. Cover at least one direct-`VendoOverlay` + `VendoRemix` integration test.
+
+3. **minor** - `packages/vendo-server/src/fetch-handler.ts:261`
+
+   The host-events runtime behavior is covered only below the server boundary. Runtime tests validate `createAutomationTools({ hostEvents })`, and instruction tests validate `buildAutomationInstructions`, but there is no server-level regression test proving `.vendo/tools.json` `events` flow through `loadVendoDir` into both `createAutomationsWorld(... hostEvents ...)` and the default prompt's `automationEvents`.
+
+   Suggested fix: add a `fetch-handler` or `world` test with a temp `.vendo/tools.json` declaring a host event, then assert a `host_event` automation for that event is accepted while an undeclared event is rejected. Add an `agent.test` assertion that `automationEvents` fields appear in the default automation instructions.
+
+## Verification
+
+Original review verification:
+- `pnpm install` passed; lockfile was already up to date.
+- `packages/vendo-server`: `pnpm test` passed (247 tests), `pnpm build` passed.
+- `packages/vendo-next`: `pnpm test` passed (71 tests), `pnpm build` passed.
+- `packages/vendo-runtime`: `pnpm test` passed (747 passed, 4 skipped).
+- Extra demo check: `apps/demo-bank pnpm test` passed (86 tests); `apps/demo-accounting pnpm test` passed (144 tests).
+
+## FIXED
+
+- Moved scoped pinning into `@vendoai/shell` in `packages/vendo-shell/src/VendoThread.tsx`: scoped chat "Pin to card" and `VoiceStage` pins now use the existing remix pin path, stamp host components, dispatch `REMIX_CHANGED_EVENT`, and preserve the paired sealed envelope when present.
+- Kept explicit `onPin` as the slot-host override; when provided, it receives the latest `UINode` exactly as before and bypasses scoped remix persistence.
+- Removed the private `ScopedPinOverlay` wrapper from `packages/vendo-next/src/client/vendo-root.tsx`; `VendoRoot` now renders `VendoOverlay` directly while keeping the gated `voice` prop pass-through intact.
+- Added shell regressions for scoped envelope preservation and `onPin` override behavior in `packages/vendo-shell/src/VendoThread.test.tsx`.
+- Added server regressions proving `.vendo/tools.json` events flow into automation closed-world validation, plus prompt coverage for `automationEvents`, in `packages/vendo-server/src/fetch-handler.test.ts` and `packages/vendo-server/src/agent.test.ts`.
+
+Post-fix verification:
+- `packages/vendo-shell`: `pnpm test` passed (332 tests).
+- `packages/vendo-next`: `pnpm test` passed (71 tests).
+- `packages/vendo-server`: `pnpm test` passed (249 tests).
+- Root: `pnpm build` passed (19 tasks), including `demo-bank` and `demo-accounting`; only existing bundle/tracing warnings were reported.
+
+Verdict: MERGE

--- a/packages/vendo-next/src/client/vendo-root.tsx
+++ b/packages/vendo-next/src/client/vendo-root.tsx
@@ -39,6 +39,7 @@ import { VendoConnectNode } from "./connect-node";
 import { createServerIntegrations } from "./integrations";
 import { createServerNotifications } from "./notifications";
 import { createRunQuery } from "./run-query";
+import type { VoiceDriver } from "@vendoai/shell";
 
 export interface VendoRootProps {
   /** `.vendo/theme.json`, imported as JSON. Invalid/absent → default brand. */
@@ -60,6 +61,10 @@ export interface VendoRootProps {
   /** Corner for the toast stack. Default "bottom-left" (the launcher pill
    *  owns bottom-right). */
   toastPlacement?: VendoToastsProps["placement"];
+  /** Realtime voice driver (ENG-185). When provided, the overlay's composer
+   *  grows a mic. Build one with createRealtimeVoiceDriver from
+   *  @vendoai/shell against a host session-mint endpoint. */
+  voice?: VoiceDriver;
   children: ReactNode;
 }
 
@@ -110,6 +115,7 @@ export function VendoRoot({
   launcher = "pill",
   toasts = true,
   toastPlacement = "bottom-left",
+  voice,
   children,
 }: VendoRootProps) {
   const brand = useMemo(() => parseBrand(theme), [theme]);
@@ -230,6 +236,7 @@ export function VendoRoot({
               onOpenChange={setOpen}
               {...(greeting !== undefined ? { greeting } : {})}
               {...(suggestions !== undefined ? { suggestions } : {})}
+              {...(voice !== undefined && capabilities?.voice ? { voice } : {})}
             />
           )}
           {chatEnabled && launcher === "pill" && !open && (

--- a/packages/vendo-next/src/client/vendo-root.tsx
+++ b/packages/vendo-next/src/client/vendo-root.tsx
@@ -14,18 +14,22 @@
  * Capability-additive: the integrations tray only appears when the server
  * reports the Composio capability; voice stays behind its flag (ENG-185).
  */
-import { useEffect, useMemo, useState, type CSSProperties, type ReactNode } from "react";
+import { useEffect, useMemo, useState, useSyncExternalStore, type CSSProperties, type ReactNode } from "react";
 import { DefaultChatTransport } from "ai";
 import type { VendoUIMessage, ManifestTool, UINode } from "@vendoai/core";
 import { VendoProvider } from "@vendoai/react";
 import {
+  REMIX_CHANGED_EVENT,
   VendoOverlay,
   VendoShellProvider,
   VendoToasts,
   createLocalIntegrations,
   createWebRemixes,
   createWebStorage,
+  stampHostComponents,
+  useShell,
   type VendoIntegrations,
+  type VendoOverlayProps,
   type VendoToastsProps,
 } from "@vendoai/shell";
 import { createServerVendoStore } from "./server-store";
@@ -103,6 +107,32 @@ const LAUNCHER_STYLE: CSSProperties = {
   boxShadow: "0 10px 30px rgba(0,0,0,.18)",
   cursor: "pointer",
 };
+
+/**
+ * The overlay plus a scoped pin hook: when the overlay is scoped to a
+ * VendoRemix anchor (a \u2726 affordance click), pinning a view — including a
+ * voice-stage view — applies it to that anchor in place, exactly like the
+ * chat path's "Apply to page". Unscoped, the pin affordance stays hidden.
+ */
+function ScopedPinOverlay(props: VendoOverlayProps) {
+  const { scope, remixes, components } = useShell();
+  const activeScope = useSyncExternalStore(scope.subscribe, scope.current, () => null);
+  const onPin = (node: UINode) => {
+    const anchor = scope.current();
+    if (!anchor || node.kind !== "generated") return;
+    const pinned = { ...node, remixAnchorId: anchor.anchorId };
+    const stamp = stampHostComponents(pinned, components ?? []);
+    void remixes
+      .pin({ anchorId: anchor.anchorId, node: pinned, ...(stamp ? { components: stamp } : {}) })
+      .then(() => {
+        window.dispatchEvent(
+          new CustomEvent(REMIX_CHANGED_EVENT, { detail: { anchorId: anchor.anchorId } }),
+        );
+      })
+      .catch((err) => console.warn("[vendo] failed to pin scoped view", err));
+  };
+  return <VendoOverlay {...props} {...(activeScope ? { onPin } : {})} />;
+}
 
 export function VendoRoot({
   theme,
@@ -230,7 +260,7 @@ export function VendoRoot({
         >
           {children}
           {chatEnabled && (
-            <VendoOverlay
+            <ScopedPinOverlay
               launcherLabel={`Ask ${productName}`}
               open={open}
               onOpenChange={setOpen}

--- a/packages/vendo-next/src/client/vendo-root.tsx
+++ b/packages/vendo-next/src/client/vendo-root.tsx
@@ -14,22 +14,18 @@
  * Capability-additive: the integrations tray only appears when the server
  * reports the Composio capability; voice stays behind its flag (ENG-185).
  */
-import { useEffect, useMemo, useState, useSyncExternalStore, type CSSProperties, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type CSSProperties, type ReactNode } from "react";
 import { DefaultChatTransport } from "ai";
 import type { VendoUIMessage, ManifestTool, UINode } from "@vendoai/core";
 import { VendoProvider } from "@vendoai/react";
 import {
-  REMIX_CHANGED_EVENT,
   VendoOverlay,
   VendoShellProvider,
   VendoToasts,
   createLocalIntegrations,
   createWebRemixes,
   createWebStorage,
-  stampHostComponents,
-  useShell,
   type VendoIntegrations,
-  type VendoOverlayProps,
   type VendoToastsProps,
 } from "@vendoai/shell";
 import { createServerVendoStore } from "./server-store";
@@ -107,32 +103,6 @@ const LAUNCHER_STYLE: CSSProperties = {
   boxShadow: "0 10px 30px rgba(0,0,0,.18)",
   cursor: "pointer",
 };
-
-/**
- * The overlay plus a scoped pin hook: when the overlay is scoped to a
- * VendoRemix anchor (a \u2726 affordance click), pinning a view — including a
- * voice-stage view — applies it to that anchor in place, exactly like the
- * chat path's "Apply to page". Unscoped, the pin affordance stays hidden.
- */
-function ScopedPinOverlay(props: VendoOverlayProps) {
-  const { scope, remixes, components } = useShell();
-  const activeScope = useSyncExternalStore(scope.subscribe, scope.current, () => null);
-  const onPin = (node: UINode) => {
-    const anchor = scope.current();
-    if (!anchor || node.kind !== "generated") return;
-    const pinned = { ...node, remixAnchorId: anchor.anchorId };
-    const stamp = stampHostComponents(pinned, components ?? []);
-    void remixes
-      .pin({ anchorId: anchor.anchorId, node: pinned, ...(stamp ? { components: stamp } : {}) })
-      .then(() => {
-        window.dispatchEvent(
-          new CustomEvent(REMIX_CHANGED_EVENT, { detail: { anchorId: anchor.anchorId } }),
-        );
-      })
-      .catch((err) => console.warn("[vendo] failed to pin scoped view", err));
-  };
-  return <VendoOverlay {...props} {...(activeScope ? { onPin } : {})} />;
-}
 
 export function VendoRoot({
   theme,
@@ -260,7 +230,7 @@ export function VendoRoot({
         >
           {children}
           {chatEnabled && (
-            <ScopedPinOverlay
+            <VendoOverlay
               launcherLabel={`Ask ${productName}`}
               open={open}
               onOpenChange={setOpen}

--- a/packages/vendo-server/src/agent.test.ts
+++ b/packages/vendo-server/src/agent.test.ts
@@ -40,6 +40,23 @@ describe("buildInstructions", () => {
     expect(on).toContain("list_things, create_thing");
   });
 
+  it("lists manifest-declared automation events with payload fields", () => {
+    const text = buildInstructions({
+      ...BASE,
+      automations: true,
+      automationEvents: [
+        {
+          name: "invoice.paid",
+          description: "An invoice was paid.",
+          payloadFields: "invoiceId, amount",
+        },
+      ],
+    });
+
+    expect(text).toContain('"invoice.paid": An invoice was paid.');
+    expect(text).toContain("trigger payload fields: invoiceId, amount");
+  });
+
   it("carries host extra instructions verbatim, with only the platform guardrails after", () => {
     const text = buildInstructions({ ...BASE, extra: "ALWAYS SPEAK PIRATE." });
     expect(text).toContain("ALWAYS SPEAK PIRATE.");

--- a/packages/vendo-server/src/agent.ts
+++ b/packages/vendo-server/src/agent.ts
@@ -51,6 +51,8 @@ export interface BuildInstructionsInput {
   integrations: IntegrationCatalogEntry[];
   /** Whether the automations world is enabled. */
   automations: boolean;
+  /** Host events available as automation triggers (compiler guidance). */
+  automationEvents?: Array<{ name: string; description?: string; payloadFields?: string }>;
   /** Appended verbatim at the end when provided. */
   extra?: string;
   /** Live merged toolset (per-run, spec §7) — feeds the capability summary. */
@@ -111,7 +113,7 @@ export function buildInstructions(input: BuildInstructionsInput): string {
       : undefined;
 
   const extras: string[] = [];
-  if (input.automations) extras.push(buildAutomationInstructions());
+  if (input.automations) extras.push(buildAutomationInstructions({ hostEvents: input.automationEvents ?? [] }));
   if (input.extra) extras.push(input.extra);
 
   return buildChatInstructions({

--- a/packages/vendo-server/src/fetch-handler.test.ts
+++ b/packages/vendo-server/src/fetch-handler.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import { z } from "zod";
+import type { ApprovalPolicy, RegisteredTool } from "@vendoai/runtime";
 import { createVendoFetchHandler, resetVendoBootRegistry } from "./fetch-handler";
 
 function req(pathname: string, init?: RequestInit): Request {
@@ -11,9 +15,110 @@ function req(pathname: string, init?: RequestInit): Request {
   });
 }
 
+const ZERO_USAGE = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+} as const;
+
+const ALLOW_POLICY: ApprovalPolicy = {
+  evaluate: () => "allow",
+};
+
+const NOOP_TOOL: RegisteredTool = {
+  descriptor: {
+    name: "noop",
+    source: "caller",
+    annotations: { readOnlyHint: true },
+    hasExecute: true,
+    kind: "function",
+  },
+  inputSchema: z.object({}),
+  execute: async () => ({ ok: true, result: { ok: true } }),
+};
+
+function textChunks(id: string, text: string): LanguageModelV3StreamPart[] {
+  return [
+    { type: "text-start", id },
+    { type: "text-delta", id, delta: text },
+    { type: "text-end", id },
+  ];
+}
+
+function promptHasToolCall(prompt: { role: string; content: unknown }[]): boolean {
+  return prompt.some(
+    (m) =>
+      m.role === "assistant" &&
+      Array.isArray(m.content) &&
+      m.content.some((c) => (c as { type?: string }).type === "tool-call"),
+  );
+}
+
+function createAutomationModel(event: string): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    doStream: async ({ prompt }) => {
+      const chunks: LanguageModelV3StreamPart[] = promptHasToolCall(prompt)
+        ? [
+            ...textChunks("done", "Done."),
+            { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
+          ]
+        : [
+            ...textChunks("start", "Creating automation."),
+            {
+              type: "tool-call",
+              toolCallId: "call-create",
+              toolName: "create_automation",
+              input: JSON.stringify({
+                spec: {
+                  name: "Invoice automation",
+                  description: "Run when invoice event arrives.",
+                  prompt: "When an invoice is paid, run the no-op step.",
+                  trigger: { type: "host_event", event },
+                  execution: {
+                    mode: "steps",
+                    steps: [{ id: "noop_step", type: "tool", tool: "noop", input: {} }],
+                  },
+                  limits: { maxFiringsPerHour: 10 },
+                },
+                grantedTools: [],
+              }),
+            },
+            { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "tool-calls", raw: undefined } },
+          ];
+      return { stream: simulateReadableStream({ chunks }) };
+    },
+  });
+}
+
+async function readBody(res: Response): Promise<string> {
+  return res.text();
+}
+
 // Point at an empty scratch dir so tests never read the repo's .vendo/.
 function emptyDir(): string {
   return path.join(mkdtempSync(path.join(tmpdir(), "vendo-fetch-handler-")), ".vendo");
+}
+
+function vendoDirWithEvent(): string {
+  const dir = path.join(mkdtempSync(path.join(tmpdir(), "vendo-fetch-handler-")), ".vendo");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    path.join(dir, "tools.json"),
+    JSON.stringify({
+      version: 1,
+      tools: [],
+      events: [
+        {
+          name: "invoice.paid",
+          description: "An invoice was paid.",
+          payloadSchema: {
+            type: "object",
+            properties: { invoiceId: { type: "string" } },
+          },
+        },
+      ],
+    }),
+  );
+  return dir;
 }
 
 afterEach(() => {
@@ -72,6 +177,42 @@ describe("createVendoFetchHandler", () => {
     const handler = createVendoFetchHandler({ vendoDir: emptyDir() });
     const res = await handler(req("/api/vendo/tick", { method: "POST" }));
     expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("flows tools.json events into the automation world closed-world validation", async () => {
+    const createHandler = (event: string) =>
+      createVendoFetchHandler({
+        vendoDir: vendoDirWithEvent(),
+        model: createAutomationModel(event),
+        policy: ALLOW_POLICY,
+        automations: { tools: { noop: NOOP_TOOL } },
+        maxSteps: 3,
+      });
+
+    const declared = await createHandler("invoice.paid")(
+      req("/api/vendo/chat", {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [{ id: "u1", role: "user", parts: [{ type: "text", text: "create it" }] }],
+        }),
+      }),
+    );
+    expect(declared.status).toBe(200);
+    expect(await readBody(declared)).toContain('"ok":true');
+
+    resetVendoBootRegistry();
+    const undeclared = await createHandler("invoice.sent")(
+      req("/api/vendo/chat", {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [{ id: "u1", role: "user", parts: [{ type: "text", text: "create it" }] }],
+        }),
+      }),
+    );
+    expect(undeclared.status).toBe(200);
+    const body = await readBody(undeclared);
+    expect(body).toContain('host event \\"invoice.sent\\" is not declared');
+    expect(body).toContain("available: invoice.paid");
   });
 
   it("503s a chat request when no model key is configured", async () => {

--- a/packages/vendo-server/src/fetch-handler.ts
+++ b/packages/vendo-server/src/fetch-handler.ts
@@ -258,6 +258,7 @@ async function assembleVendoState(options: VendoHandlerOptions) {
             policy: worldPolicy,
             model,
             ...(options.automations?.tools ? { tools: options.automations.tools } : {}),
+            hostEvents: loaded.manifest.events,
             scope: worldScope,
             ...(engineStore ? { store: engineStore } : {}),
             // ENG-193 §4.6/§6.2: parked-action resolutions get the SAME
@@ -344,6 +345,15 @@ async function assembleVendoState(options: VendoHandlerOptions) {
           hostToolNames: hostTools.map((t) => t.name),
           integrations: capabilities.integrations ? catalog : [],
           automations: world !== null,
+          automationEvents: loaded.manifest.events.map((e) => ({
+            name: e.name,
+            description: e.description,
+            ...(e.payloadSchema &&
+            typeof e.payloadSchema["properties"] === "object" &&
+            e.payloadSchema["properties"] !== null
+              ? { payloadFields: Object.keys(e.payloadSchema["properties"] as Record<string, unknown>).join(", ") }
+              : {}),
+          })),
           toolSummary: ctx.toolSummary,
           ...(options.instructionsExtra ? { extra: options.instructionsExtra } : {}),
         }));

--- a/packages/vendo-server/src/world.ts
+++ b/packages/vendo-server/src/world.ts
@@ -39,6 +39,9 @@ export interface CreateWorldConfig {
   model: LanguageModel;
   /** Server-executed tools automation steps may reference. */
   tools?: Record<string, RegisteredTool>;
+  /** Host event types (from `.vendo/tools.json` `events`) available as
+   *  `host_event` automation triggers. */
+  hostEvents?: Array<{ name: string; description?: string }>;
   /** The engine store scope. One embedded tenant; subject = default user. */
   scope: Principal;
   /** ENG-193 §4.6/§6.2 — when present, a parked-action resolution appends the
@@ -139,7 +142,7 @@ export async function createAutomationsWorld(config: CreateWorldConfig): Promise
         scheduler,
         principal: config.scope,
         registeredTools: async () => registered,
-        hostEvents: [],
+        hostEvents: (config.hostEvents ?? []).map((e) => e.name),
         ...(threadId !== undefined ? { createdFromThreadId: threadId } : {}),
       }),
     tick: () => scheduler.tick(),

--- a/packages/vendo-shell/src/VendoThread.test.tsx
+++ b/packages/vendo-shell/src/VendoThread.test.tsx
@@ -1,12 +1,13 @@
 import { afterEach, describe, it, expect, vi } from "vitest";
 import { act, render, screen, fireEvent, waitFor } from "@testing-library/react";
-import type { ConsentResponse } from "@vendoai/core";
+import type { ConsentResponse, UINode } from "@vendoai/core";
 import { createStubAgent } from "@vendoai/core/testing";
 import { z } from "zod";
 import { VendoProvider } from "@vendoai/react";
-import { VendoShellProvider, type SendConsentResult } from "./context";
+import { VendoShellProvider, useShell, type SendConsentResult, type ShellContextValue } from "./context";
 import { VendoThread } from "./VendoThread";
 import type { ThreadItem } from "./use-vendo-thread";
+import { createLocalRemixes } from "./seams/remixes";
 
 function DemoCard({ title }: { title: string }) {
   return <div data-testid="demo-card">{title}</div>;
@@ -40,6 +41,15 @@ vi.mock("./use-vendo-thread", async (importOriginal) => {
     useVendoThread: () => chatRef.current ?? (actual as { useVendoThread: () => unknown }).useVendoThread(),
   };
 });
+
+afterEach(() => {
+  chatRef.current = null;
+});
+
+function ShellProbe({ onRead }: { onRead: (shell: ShellContextValue) => void }) {
+  onRead(useShell());
+  return null;
+}
 
 describe("VendoThread composer placement", () => {
   const mount = (heroComposer: boolean) =>
@@ -83,6 +93,88 @@ describe("VendoThread end-to-end", () => {
     fireEvent.click(screen.getByText("Send it"));
     await waitFor(() => screen.getByTestId("demo-card"));
     expect(screen.getByTestId("demo-card").textContent).toBe("Hello from Vendo");
+  });
+});
+
+describe("VendoThread scoped remix pinning", () => {
+  const node: UINode = {
+    id: "view-1",
+    kind: "generated",
+    payload: {
+      formatVersion: "vendo-genui/v1",
+      root: "root",
+      nodes: [{ id: "root", component: "Text", source: "prewired", props: { text: "Pinned" } }],
+    },
+  };
+
+  it("pins the latest scoped view through remixes, preserving the paired envelope", async () => {
+    const remixes = createLocalRemixes();
+    let shell: ShellContextValue | undefined;
+    chatRef.current = {
+      items: [
+        {
+          kind: "ui",
+          key: "m1:0",
+          messageId: "m1",
+          node,
+          envelope: "sealed-authored-state",
+        },
+      ],
+      status: "ready",
+      addToolApprovalResponse: vi.fn(),
+      sendMessage: vi.fn(),
+      regenerate: vi.fn(),
+      stop: vi.fn(),
+      clearError: vi.fn(),
+    };
+
+    render(
+      <VendoShellProvider remixes={remixes}>
+        <ShellProbe onRead={(next) => { shell = next; }} />
+        <VendoThread />
+      </VendoShellProvider>,
+    );
+
+    act(() => {
+      shell!.scope.open({ anchorId: "deadline-list", label: "Deadlines" });
+    });
+    fireEvent.click(await screen.findByRole("button", { name: /pin to card/i }));
+
+    await waitFor(async () => {
+      const pin = await remixes.get("deadline-list");
+      expect(pin?.node).toMatchObject({ kind: "generated", remixAnchorId: "deadline-list" });
+      expect(pin?.envelope).toBe("sealed-authored-state");
+    });
+  });
+
+  it("keeps an explicit onPin prop as the slot-host override even when scope is active", async () => {
+    const remixes = createLocalRemixes();
+    const onPin = vi.fn();
+    let shell: ShellContextValue | undefined;
+    chatRef.current = {
+      items: [{ kind: "ui", key: "m1:0", messageId: "m1", node }],
+      status: "ready",
+      addToolApprovalResponse: vi.fn(),
+      sendMessage: vi.fn(),
+      regenerate: vi.fn(),
+      stop: vi.fn(),
+      clearError: vi.fn(),
+    };
+
+    render(
+      <VendoShellProvider remixes={remixes}>
+        <ShellProbe onRead={(next) => { shell = next; }} />
+        <VendoThread onPin={onPin} />
+      </VendoShellProvider>,
+    );
+
+    act(() => {
+      shell!.scope.open({ anchorId: "deadline-list" });
+    });
+    fireEvent.click(await screen.findByRole("button", { name: /pin to card/i }));
+
+    expect(onPin).toHaveBeenCalledWith(node);
+    expect(await remixes.get("deadline-list")).toBeNull();
   });
 });
 

--- a/packages/vendo-shell/src/VendoThread.tsx
+++ b/packages/vendo-shell/src/VendoThread.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import type { FileUIPart } from "ai";
 import type { AnchorContextBlock, ConsentResponse, VendoMetadata, UINode } from "@vendoai/core";
-import { useVendoThread } from "./use-vendo-thread";
+import { useVendoThread, type ThreadItem } from "./use-vendo-thread";
 import { REMIX_CHANGED_EVENT } from "./remix/VendoRemix";
 import { stampHostComponents } from "./component-drift";
 import type { Feedback } from "./components/TurnActions";
@@ -142,11 +142,12 @@ export function VendoThread({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [voiceSession.supported, voiceSession.active, chat.items]);
 
-  // The most recent rendered view — what "Pin to card" commits.
-  const latestNode = useMemo<UINode | null>(() => {
+  // The most recent rendered view — what "Pin to card" commits. Keep the
+  // whole item so scoped remix pins preserve the paired sealed envelope.
+  const latestUiItem = useMemo<Extract<ThreadItem, { kind: "ui" }> | null>(() => {
     for (let i = chat.items.length - 1; i >= 0; i--) {
       const item = chat.items[i];
-      if (item?.kind === "ui") return item.node;
+      if (item?.kind === "ui") return item;
     }
     return null;
   }, [chat.items]);
@@ -188,14 +189,16 @@ export function VendoThread({
   };
   // Apply a remix candidate: pin it (stamped for drift detection) and tell the
   // mounted wrapper to swap in place.
-  const applyRemix = (node: UINode, envelope?: string) => {
-    if (node.kind !== "generated" || !node.remixAnchorId) return;
-    const anchorId = node.remixAnchorId;
-    const stamp = stampHostComponents(node, components ?? []);
+  const applyRemix = (node: UINode, envelope?: string, anchorIdOverride?: string) => {
+    if (node.kind !== "generated") return;
+    const anchorId = anchorIdOverride ?? node.remixAnchorId;
+    if (!anchorId) return;
+    const pinned = node.remixAnchorId === anchorId ? node : { ...node, remixAnchorId: anchorId };
+    const stamp = stampHostComponents(pinned, components ?? []);
     void remixes
       .pin({
         anchorId,
-        node,
+        node: pinned,
         ...(stamp ? { components: stamp } : {}),
         // The sealed authored state (remix fast-edits): opaque here; sent back
         // on scoped opens so the server can offer base:"pin" hunk editing.
@@ -205,6 +208,20 @@ export function VendoThread({
         window.dispatchEvent(new CustomEvent(REMIX_CHANGED_EVENT, { detail: { anchorId } }));
       })
       .catch((err) => console.warn(`[vendo] failed to apply remix for "${anchorId}"`, err));
+  };
+  const scopedPin = (node: UINode, envelope?: string) => {
+    const anchor = scope.current();
+    if (!anchor) return;
+    applyRemix(node, envelope, anchor.anchorId);
+  };
+  const pinSink = onPin ?? (activeScope ? scopedPin : undefined);
+  const pinLatest = () => {
+    if (!latestUiItem) return;
+    if (onPin) {
+      onPin(latestUiItem.node);
+      return;
+    }
+    scopedPin(latestUiItem.node, latestUiItem.envelope);
   };
   const regenerate = (messageId: string) => { void chat.regenerate({ messageId }); };
 
@@ -392,7 +409,7 @@ export function VendoThread({
           onEnd={voiceSession.end}
           onApprove={voiceSession.approve}
           onDecline={voiceSession.decline}
-          onPin={onPin}
+          onPin={pinSink}
           onClosed={() => {
             const finalSnapshot = voiceSession.close();
             const landed = voiceSessionMessages(finalSnapshot);
@@ -461,13 +478,13 @@ export function VendoThread({
             )}
           </div>
         )}
-      {onPin && (
+      {pinSink && (
         <div className="fl-pinbar">
           <button
             type="button"
             className="fl-pin-btn"
-            disabled={!latestNode}
-            onClick={() => latestNode && onPin(latestNode)}
+            disabled={!latestUiItem}
+            onClick={pinLatest}
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
               strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -475,7 +492,7 @@ export function VendoThread({
             </svg>
             Pin to card
           </button>
-          <span className="fl-pinbar-hint">{latestNode ? "pins the latest view" : "describe a view first"}</span>
+          <span className="fl-pinbar-hint">{latestUiItem ? "pins the latest view" : "describe a view first"}</span>
         </div>
       )}
       {/* heroComposer surfaces hoist the composer into the Landing hero while


### PR DESCRIPTION
Three gaps hit while integrating an external host app (Cove) with plain `vendo init`:

1. **feat(server): flow manifest host events into automation authoring** — `.vendo/tools.json` events were parsed then dropped (`hostEvents: []` hard-coded), so no `host_event` trigger could ever be authored zero-config.
2. **feat(next): accept a voice driver on VendoRoot** — without it the composer mic can never appear in an init-wired app even when the server reports `voice: true`.
3. **feat(next): scoped pin for overlay views (incl. voice stage)** — pinning a view while the overlay is scoped to a VendoRemix anchor applies it in place, same path as chat's Apply to page.

Verified end-to-end in the Cove demo (transactions→Sankey remix, charge.posted receipts automation, voice with rendered views).

https://claude.ai/code/session_01JYCxGPaa3BpBqtu6i3iezb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables zero‑config hosts to author automations from manifest events, light up the voice mic, and pin overlay views in place when scoped to a remix anchor, now implemented in `@vendoai/shell` to work across overlays and preserve fast‑edit state.

- **New Features**
  - Server: Pass `.vendo/tools.json` events into automations and compiler guidance (incl. payload field names); `hostEvents` now reach the automations world.
  - Next: `VendoRoot` accepts a `voice` driver and forwards it to the overlay when voice is supported, so the composer mic appears.
  - Shell: Scoped pinning for overlay views (incl. voice stage); when scoped to a `VendoRemix` anchor, pins via `remixes.pin`, stamps components, emits `REMIX_CHANGED_EVENT`, and preserves the sealed `envelope`. An explicit `onPin` still overrides.

- **Migration**
  - To enable the mic, provide a `voice` driver to `VendoRoot` (e.g., from `@vendoai/shell`). No other changes required.

<sup>Written for commit e74946bd51525825b4c0eeafd938f694d929221f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/53?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

