### PR TITLE
shell: scope-bar/close layout fix + VendoRemix affordance prop

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -2,9 +2,12 @@
 
 Branch: `yousefh409/shell-polish`
 
-Commits:
-- `e2a7e750` Fix scoped overlay clear button layout
-- `ab88f4c7` Add persistent VendoRemix affordance option
+Rebased onto current `origin/main` after PR #53.
+
+Implementation commits:
+- `a644c69a` Fix scoped overlay clear button layout
+- `57bd8ee1` Add persistent VendoRemix affordance option
+- `92703c11` Fix VendoRemix affordance review findings
 
 Changes:
 - Reserved a right-side gutter in the scoped overlay header so `.fl-scope-clear` stays inline with the scope bar and no longer collides with `.fl-overlay-close`.
@@ -12,8 +15,13 @@ Changes:
 - Added CSS for `.fl-remix-btn[data-affordance="always"]` so the remix affordance is persistently visible when opted in.
 - Updated VendoRemix tests for the default and always-visible affordance modes.
 
+FIXED:
+- Review MEDIUM: `VendoRemix` now emits `data-affordance` only for `affordance="always"`; the default mounted button omits the attribute.
+- Review LOW: Added a file-read CSS contract test asserting the `always` selector sets `opacity: 1` and `transform: scale(1)`, while the default hidden and hover/focus reveal rules remain present.
+
 Verification:
-- `pnpm test` in `packages/vendo-shell`: passed, 61 files and 331 tests.
+- `pnpm --filter @vendoai/shell test -- src/remix/VendoRemix.test.tsx`: passed, 10 tests.
+- `pnpm test` in `packages/vendo-shell`: passed, 61 files and 334 tests.
 - `pnpm build` in `packages/vendo-shell`: passed.
 - `pnpm build` at repo root: passed, 19 of 19 turbo tasks.
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,0 +1,22 @@
+# Summary
+
+Branch: `yousefh409/shell-polish`
+
+Commits:
+- `e2a7e750` Fix scoped overlay clear button layout
+- `ab88f4c7` Add persistent VendoRemix affordance option
+
+Changes:
+- Reserved a right-side gutter in the scoped overlay header so `.fl-scope-clear` stays inline with the scope bar and no longer collides with `.fl-overlay-close`.
+- Added `VendoRemix` prop `affordance?: "hover" | "always"` with the default unchanged at `"hover"`.
+- Added CSS for `.fl-remix-btn[data-affordance="always"]` so the remix affordance is persistently visible when opted in.
+- Updated VendoRemix tests for the default and always-visible affordance modes.
+
+Verification:
+- `pnpm test` in `packages/vendo-shell`: passed, 61 files and 331 tests.
+- `pnpm build` in `packages/vendo-shell`: passed.
+- `pnpm build` at repo root: passed, 19 of 19 turbo tasks.
+
+Notes:
+- The shell test suite still emits existing React `act(...)` and in-memory store warnings.
+- The root build still emits existing bundle-size, Turbopack NFT trace, and turbo output warnings, with no failures.

--- a/packages/vendo-shell/src/remix/VendoRemix.test.tsx
+++ b/packages/vendo-shell/src/remix/VendoRemix.test.tsx
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import type { ReactNode } from "react";
@@ -49,7 +50,7 @@ describe("VendoRemix", () => {
     );
     expect(screen.getByTestId("host-widget").textContent).toBe("original");
     const affordance = await screen.findByLabelText("Ask about Widget");
-    expect(affordance.getAttribute("data-affordance")).toBe("hover");
+    expect(affordance.hasAttribute("data-affordance")).toBe(false);
     expect(document.querySelector(".fl-remix-pill")).toBeNull();
   });
 
@@ -61,6 +62,19 @@ describe("VendoRemix", () => {
     );
     const affordance = await screen.findByLabelText("Ask about Widget");
     expect(affordance.getAttribute("data-affordance")).toBe("always");
+  });
+
+  it("keeps CSS rules for persistent and default hover affordances", () => {
+    const css = readFileSync("src/styles.css", "utf8");
+    expect(css).toMatch(
+      /\.fl-remix-btn\[data-affordance="always"\]\s*\{[^}]*opacity:\s*1;[^}]*transform:\s*scale\(1\);[^}]*\}/s,
+    );
+    expect(css).toMatch(
+      /\.fl-remix:hover\s+\.fl-remix-btn,\s*\.fl-remix:focus-within\s+\.fl-remix-btn\s*\{[^}]*opacity:\s*1;[^}]*transform:\s*scale\(1\);[^}]*\}/s,
+    );
+    expect(css).toMatch(
+      /\.fl-remix-btn\s*\{[^}]*opacity:\s*0;[^}]*transform:\s*scale\(\.9\);[^}]*\}/s,
+    );
   });
 
   it("registers with the page registry on mount and deregisters on unmount", async () => {

--- a/packages/vendo-shell/src/remix/VendoRemix.test.tsx
+++ b/packages/vendo-shell/src/remix/VendoRemix.test.tsx
@@ -48,8 +48,19 @@ describe("VendoRemix", () => {
       </VendoRemix>,
     );
     expect(screen.getByTestId("host-widget").textContent).toBe("original");
-    await waitFor(() => expect(screen.getByLabelText("Ask about Widget")).toBeTruthy());
+    const affordance = await screen.findByLabelText("Ask about Widget");
+    expect(affordance.getAttribute("data-affordance")).toBe("hover");
     expect(document.querySelector(".fl-remix-pill")).toBeNull();
+  });
+
+  it("can keep the affordance visible for discoverability", async () => {
+    mount(
+      <VendoRemix id="w1" label="Widget" affordance="always">
+        <div data-testid="host-widget">original</div>
+      </VendoRemix>,
+    );
+    const affordance = await screen.findByLabelText("Ask about Widget");
+    expect(affordance.getAttribute("data-affordance")).toBe("always");
   });
 
   it("registers with the page registry on mount and deregisters on unmount", async () => {

--- a/packages/vendo-shell/src/remix/VendoRemix.tsx
+++ b/packages/vendo-shell/src/remix/VendoRemix.tsx
@@ -188,7 +188,7 @@ export function VendoRemix({
         <button
           type="button"
           className="fl-remix-btn"
-          data-affordance={affordance}
+          data-affordance={affordance === "always" ? "always" : undefined}
           aria-label={`Ask about ${label ?? "this"}`}
           title={`Ask about ${label ?? "this"}`}
           onClick={openScoped}

--- a/packages/vendo-shell/src/remix/VendoRemix.tsx
+++ b/packages/vendo-shell/src/remix/VendoRemix.tsx
@@ -28,6 +28,8 @@ export interface VendoRemixProps {
   /** The wrapper is one real div in the host's layout — layout classes that
    *  used to sit on the wrapped child (grid spans, widths) belong here. */
   className?: string;
+  /** Show the ✦ affordance on hover/focus by default, or keep it visible. */
+  affordance?: "hover" | "always";
   children: ReactNode;
 }
 
@@ -66,7 +68,14 @@ class RemixBoundary extends Component<
  * render in place with a "customized · reset" pill, fail-open to the original
  * children on any error or drift. SSR renders children only.
  */
-export function VendoRemix({ id, label, context, className, children }: VendoRemixProps) {
+export function VendoRemix({
+  id,
+  label,
+  context,
+  className,
+  affordance = "hover",
+  children,
+}: VendoRemixProps) {
   const { registry, remixes, renderNode, scope, components } = useShell();
   const hostRef = useRef<HTMLDivElement | null>(null);
   // Client-only affordance: nothing beyond children exists until after mount.
@@ -179,6 +188,7 @@ export function VendoRemix({ id, label, context, className, children }: VendoRem
         <button
           type="button"
           className="fl-remix-btn"
+          data-affordance={affordance}
           aria-label={`Ask about ${label ?? "this"}`}
           title={`Ask about ${label ?? "this"}`}
           onClick={openScoped}

--- a/packages/vendo-shell/src/styles.css
+++ b/packages/vendo-shell/src/styles.css
@@ -881,12 +881,14 @@
 .fl-remix-pill-act:hover { text-decoration: underline; }
 
 /* ---- scoped-overlay header bar ---- */
-.fl-scope-bar { display: flex; align-items: center; gap: 8px; padding: 9px 16px;
+.fl-scope-bar { display: flex; align-items: center; gap: 8px; padding: 9px 56px 9px 16px;
   border-bottom: 1px solid var(--vendo-border); background: var(--vendo-accent-soft); }
-.fl-scope-label { font: 600 12px/1.3 var(--vendo-font); color: var(--vendo-fg); }
-.fl-scope-clear { margin-left: auto; border: 0; background: none; cursor: pointer;
+.fl-scope-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  font: 600 12px/1.3 var(--vendo-font); color: var(--vendo-fg); }
+.fl-scope-clear { margin-left: auto; flex-shrink: 0; width: 26px; height: 26px; border-radius: 8px;
+  display: grid; place-items: center; border: 0; background: transparent; cursor: pointer;
   color: var(--vendo-fg-muted); font: 600 12px/1 var(--vendo-font); }
-.fl-scope-clear:hover { color: var(--vendo-fg); }
+.fl-scope-clear:hover { background: var(--vendo-surface); color: var(--vendo-fg); }
 
 /* ---- remix-candidate apply bar (under a tagged generated view) ---- */
 .fl-applybar { display: flex; align-items: center; gap: 10px; margin-top: 8px; }

--- a/packages/vendo-shell/src/styles.css
+++ b/packages/vendo-shell/src/styles.css
@@ -868,6 +868,7 @@
   font: 600 13px/1 var(--vendo-font); cursor: pointer;
   opacity: 0; transform: scale(.9); transition: opacity .15s, transform .15s;
   box-shadow: 0 4px 14px rgba(0,0,0,.10); }
+.fl-remix-btn[data-affordance="always"] { opacity: 1; transform: scale(1); }
 .fl-remix:hover .fl-remix-btn, .fl-remix:focus-within .fl-remix-btn { opacity: 1; transform: scale(1); }
 .fl-remix-btn:hover { background: var(--vendo-accent); color: var(--vendo-accent-fg); }
 .fl-remix-pill { position: absolute; bottom: 8px; right: 8px; z-index: 5;


### PR DESCRIPTION
Two polish items from external-host integration feedback: the scoped overlay's clear-✕ no longer collides with the panel Close ✕, and VendoRemix gains affordance="hover"|"always" (default unchanged, byte-identical DOM for existing hosts). Codex-reviewed (FIX-FIRST → fixed: default DOM identity + CSS contract test).

https://claude.ai/code/session_01JYCxGPaa3BpBqtu6i3iezb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the scoped overlay header so the Clear button no longer collides with the Close button. Adds an `affordance` option to `VendoRemix` to keep the remix ✦ visible; default stays hover so existing hosts see identical DOM.

- **New Features**
  - `VendoRemix` adds `affordance?: "hover" | "always"`. When `"always"`, the button sets `data-affordance="always"` and is persistently visible via CSS. Tests updated, including a CSS contract check.

- **Bug Fixes**
  - Reserved a right-side gutter in the scope bar and adjusted label truncation and Clear button sizing/hover styles, preventing overlap with the panel Close button in `@vendoai/shell`.

<sup>Written for commit 05d45b919514d0e13d819fba5f894053b3cd7c32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

