### PR TITLE
cli: next.config codemod, vendo init --local, events scaffold docs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -50,3 +50,11 @@ Verification:
 - `pnpm build` passed.
 - `pnpm --dir packages/vendo-cli test` passed: 28 files, 136 tests.
 - `pnpm --dir packages/vendo-cli typecheck` passed.
+
+## FIXED
+
+- Replaced `pnpm --filter <pkg> pack` with `pnpm -C <pkg.dir> pack --pack-destination <vendorDir>`.
+- Added a real-pnpm test that packs from a synthetic local repo path containing spaces.
+- Preserved existing npm and pnpm override objects while merging only Vendo tarball keys; unsupported override shapes now skip with manual instructions instead of dropping data.
+- Preflighted `fluidkit` and package.json rewrites before target writes, then staged tarballs before replacing `vendor/`.
+- Updated the generated Events README example to show the full `tools.json` shape and name `ingestVendoEvent()` plus `POST /api/vendo/events/ingest`.

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,5 +1,7 @@
 # Summary
 
+## Shell Polish
+
 Branch: `yousefh409/shell-polish`
 
 Rebased onto current `origin/main` after PR #53.
@@ -28,3 +30,23 @@ Verification:
 Notes:
 - The shell test suite still emits existing React `act(...)` and in-memory store warnings.
 - The root build still emits existing bundle-size, Turbopack NFT trace, and turbo output warnings, with no failures.
+
+## Init Host Friction
+
+Implemented `vendo init` host-app friction fixes in `packages/vendo-cli`:
+
+- Added conservative `next.config.(ts|mjs|js)` wiring in `wireNextApp`.
+  - Creates a minimal config when absent.
+  - Merges literal `transpilePackages` and `serverExternalPackages` arrays.
+  - Skips ambiguous configs and reports manual instructions without editing.
+- Added `vendo init --local <vendo-monorepo>`.
+  - Packs the local Vendo runtime package closure into `<app>/vendor/`.
+  - Copies the monorepo `vendor/fluidkit-*.tgz`.
+  - Rewrites host `package.json` with direct `file:vendor/*` deps for `@vendoai/next` and `@vendoai/shell`.
+  - Adds pnpm overrides for every packed `@vendoai/*` package plus `fluidkit`, with npm `overrides` fallback when npm is detected.
+- Extended generated `.vendo/README.md` with an Events section, including a `charge.posted` payload schema example and producer guidance.
+
+Verification:
+- `pnpm build` passed.
+- `pnpm --dir packages/vendo-cli test` passed: 28 files, 136 tests.
+- `pnpm --dir packages/vendo-cli typecheck` passed.

--- a/packages/vendo-cli/src/cli.ts
+++ b/packages/vendo-cli/src/cli.ts
@@ -12,9 +12,10 @@ import { runTelemetryCmd } from "./telemetry-cmd.js";
 const HELP = `vendo — Vendo one-click dev tool
 
 Usage:
-  vendo init [dir] [--skip-llm] [--force]   Extract theme/tools/components into .vendo/ AND
-                                              wire a Next.js App Router app (route handler,
-                                              provider, .env.example, sandbox assets, prebuild sync)
+  vendo init [dir] [--skip-llm] [--force] [--local <vendo-monorepo>]
+                                            Extract theme/tools/components into .vendo/ AND
+                                            wire a Next.js App Router app (route handler,
+                                            provider, .env.example, sandbox assets, prebuild sync)
   vendo sync [dir]                          Capture wrapped-component source + build the sandbox
                                               environment (deps, host CSS, manifest). Runs every
                                               build via the prebuild script init wires.
@@ -24,15 +25,53 @@ Usage:
 Options:
   --skip-llm   Skip LLM-assisted steps (route scan, component discovery)
   --force      Overwrite existing .vendo/ files
+  --local      Pack local @vendoai packages from a Vendo monorepo into ./vendor
 `;
+
+function parseInitArgs(args: string[]):
+  | { ok: true; targetDir: string; skipLlm: boolean; force: boolean; localVendoDir?: string }
+  | { ok: false; error: string } {
+  const positionals: string[] = [];
+  let localVendoDir: string | undefined;
+  let skipLlm = false;
+  let force = false;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg === "--skip-llm") {
+      skipLlm = true;
+    } else if (arg === "--force") {
+      force = true;
+    } else if (arg === "--local") {
+      const value = args[++i];
+      if (!value || value.startsWith("--")) return { ok: false, error: "--local requires a path to the Vendo monorepo" };
+      localVendoDir = value;
+    } else if (arg.startsWith("--local=")) {
+      localVendoDir = arg.slice("--local=".length);
+      if (!localVendoDir) return { ok: false, error: "--local requires a path to the Vendo monorepo" };
+    } else if (!arg.startsWith("--")) {
+      positionals.push(arg);
+    }
+  }
+  return { ok: true, targetDir: positionals[0] ?? process.cwd(), skipLlm, force, localVendoDir };
+}
 
 export async function main(argv: string[]): Promise<number> {
   const [cmd, ...rest] = argv;
-  const flags = new Set(rest.filter((a) => a.startsWith("--")));
   const dir = rest.find((a) => !a.startsWith("--")) ?? process.cwd();
   switch (cmd) {
-    case "init":
-      return runInit({ targetDir: dir, skipLlm: flags.has("--skip-llm"), force: flags.has("--force") });
+    case "init": {
+      const parsed = parseInitArgs(rest);
+      if (!parsed.ok) {
+        console.error(parsed.error);
+        return 1;
+      }
+      return runInit({
+        targetDir: parsed.targetDir,
+        skipLlm: parsed.skipLlm,
+        force: parsed.force,
+        localVendoDir: parsed.localVendoDir,
+      });
+    }
     case "sync":
       return runSync({ targetDir: dir });
     case "publish":

--- a/packages/vendo-cli/src/init.test.ts
+++ b/packages/vendo-cli/src/init.test.ts
@@ -39,7 +39,10 @@ describe("runInit e2e (mock model)", () => {
     const tools = JSON.parse(await readFile(path.join(dir, ".vendo/tools.json"), "utf8"));
     expect(tools.tools[0].name).toBe("list_things");
     await readFile(path.join(dir, ".vendo/components/Badge/impl.tsx"), "utf8");
-    await readFile(path.join(dir, ".vendo/README.md"), "utf8");
+    const readme = await readFile(path.join(dir, ".vendo/README.md"), "utf8");
+    expect(readme).toContain("## Events");
+    expect(readme).toContain('"name": "charge.posted"');
+    expect(readme).toContain("push at the source, relay webhooks, or poll upstream systems");
   });
 
   it("reports a clean error (not an unhandled rejection) when the model factory throws", async () => {

--- a/packages/vendo-cli/src/init.test.ts
+++ b/packages/vendo-cli/src/init.test.ts
@@ -41,7 +41,11 @@ describe("runInit e2e (mock model)", () => {
     await readFile(path.join(dir, ".vendo/components/Badge/impl.tsx"), "utf8");
     const readme = await readFile(path.join(dir, ".vendo/README.md"), "utf8");
     expect(readme).toContain("## Events");
+    expect(readme).toContain('"version": 1');
+    expect(readme).toContain('"events": [');
     expect(readme).toContain('"name": "charge.posted"');
+    expect(readme).toContain("ingestVendoEvent()");
+    expect(readme).toContain("POST /api/vendo/events/ingest");
     expect(readme).toContain("push at the source, relay webhooks, or poll upstream systems");
   });
 

--- a/packages/vendo-cli/src/init.ts
+++ b/packages/vendo-cli/src/init.ts
@@ -80,25 +80,32 @@ after review — this file is the reviewable source of truth.
 ## Events
 
 Events are named payload contracts that automations can use as triggers. Add
-them to \`tools.json\` beside your tools:
+them to the \`events\` array in \`tools.json\`:
 
 \`\`\`json
 {
-  "name": "charge.posted",
-  "description": "A card charge posted to an account.",
-  "payloadSchema": {
-    "type": "object",
-    "required": ["chargeId", "accountId", "amountCents"],
-    "properties": {
-      "chargeId": { "type": "string" },
-      "accountId": { "type": "string" },
-      "amountCents": { "type": "integer" },
-      "postedAt": { "type": "string", "format": "date-time" }
+  "version": 1,
+  "tools": [],
+  "events": [
+    {
+      "name": "charge.posted",
+      "description": "A card charge posted to an account.",
+      "payloadSchema": {
+        "type": "object",
+        "required": ["chargeId", "accountId", "amountCents"],
+        "properties": {
+          "chargeId": { "type": "string" },
+          "accountId": { "type": "string" },
+          "amountCents": { "type": "integer" },
+          "postedAt": { "type": "string", "format": "date-time" }
+        }
+      }
     }
-  }
+  ]
 }
 \`\`\`
 
+Ingest events with \`ingestVendoEvent()\` or \`POST /api/vendo/events/ingest\`.
 Producers can push at the source, relay webhooks, or poll upstream systems; all
 three feed the same Vendo ingest path.
 

--- a/packages/vendo-cli/src/init.ts
+++ b/packages/vendo-cli/src/init.ts
@@ -77,6 +77,31 @@ is LLM-read code and must not grant auto-allow); GETs with side-effect-shaped
 names are marked mutating even from OpenAPI. Relax annotations here by hand
 after review — this file is the reviewable source of truth.
 
+## Events
+
+Events are named payload contracts that automations can use as triggers. Add
+them to \`tools.json\` beside your tools:
+
+\`\`\`json
+{
+  "name": "charge.posted",
+  "description": "A card charge posted to an account.",
+  "payloadSchema": {
+    "type": "object",
+    "required": ["chargeId", "accountId", "amountCents"],
+    "properties": {
+      "chargeId": { "type": "string" },
+      "accountId": { "type": "string" },
+      "amountCents": { "type": "integer" },
+      "postedAt": { "type": "string", "format": "date-time" }
+    }
+  }
+}
+\`\`\`
+
+Producers can push at the source, relay webhooks, or poll upstream systems; all
+three feed the same Vendo ingest path.
+
 \`vendo publish\` uploads tools.json to the Vendo registry — stubbed until the
 registry ships (ENG-198). Embedded hosts read this directory from disk.
 `;

--- a/packages/vendo-cli/src/init.ts
+++ b/packages/vendo-cli/src/init.ts
@@ -9,11 +9,14 @@ import { cliModel } from "./llm.js";
 import { renderReport, type InitReport } from "./report.js";
 import { writeGenerated } from "./fsx.js";
 import { wireNextApp, renderWiring } from "./next-wiring.js";
+import { installLocalVendoPackages, type LocalVendoInstallSummary } from "./local-pack.js";
 
 export interface InitOptions {
   targetDir: string;
   skipLlm: boolean;
   force: boolean;
+  /** Pack local Vendo workspace packages into the host app's vendor/ dir. */
+  localVendoDir?: string;
   /** test seam — pass null to force LLM-off, a mock to avoid the network */
   model?: LanguageModel | null;
   /** test seam — telemetry wiring overrides; omit in production for real env/key */
@@ -123,26 +126,40 @@ export async function runInit(opts: InitOptions): Promise<number> {
   // The install codemod (Next.js App Router): route handler, provider wrap,
   // .env.example, sandbox assets, dependency. Fail-open by design — anything
   // uncertain is skipped and reported, never guessed.
+  let wiringInstalled = false;
+  let localInstall: LocalVendoInstallSummary | null = null;
   try {
     failedStep = "wiring";
     const wiring = await wireNextApp(targetDir, info, { force: opts.force });
     const rendered = renderWiring(wiring);
     if (rendered) console.log(rendered);
-    if (wiring) {
+    wiringInstalled = wiring !== null;
+    if (opts.localVendoDir) {
+      localInstall = await installLocalVendoPackages(targetDir, opts.localVendoDir);
       console.log(
         [
-          "",
-          "Next steps:",
-          "  1. install deps (npm install / pnpm install)",
-          "  2. cp .env.example .env.local  and paste one provider API key (see comments)",
-          "  3. npm run dev — then hit the launcher (or Cmd/Ctrl+K) and ask for a view",
+          "local packages:",
+          `  wrote  ${localInstall.packages.length} @vendoai tarballs + fluidkit into ${path.relative(targetDir, localInstall.vendorDir)}`,
+          `  edited package.json with file:vendor/* dependencies and ${localInstall.packageManager === "pnpm" ? "pnpm.overrides" : "overrides"}`,
+          `  next  run ${localInstall.installCommand}`,
         ].join("\n"),
       );
     }
   } catch (err) {
-    console.error(`next wiring failed (review \`git diff\` — wiring writes are individually atomic): ${err instanceof Error ? err.message : String(err)}`);
+    console.error(`init wiring failed (review \`git diff\` — writes are individually atomic): ${err instanceof Error ? err.message : String(err)}`);
     await t.track("init_failed", { framework, failedStep });
     return 1;
+  }
+  if (wiringInstalled) {
+    console.log(
+      [
+        "",
+        "Next steps:",
+        `  1. ${localInstall ? `run ${localInstall.installCommand}` : "install deps (npm install / pnpm install)"}`,
+        "  2. cp .env.example .env.local  and paste one provider API key (see comments)",
+        "  3. npm run dev — then hit the launcher (or Cmd/Ctrl+K) and ask for a view",
+      ].join("\n"),
+    );
   }
   await t.track("init_completed", {
     framework,

--- a/packages/vendo-cli/src/local-pack.test.ts
+++ b/packages/vendo-cli/src/local-pack.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { rewritePackageJsonForLocalVendo, type LocalTarball } from "./local-pack.js";
+
+const LOCAL_TARBALLS: LocalTarball[] = [
+  { name: "@vendoai/components", fileName: "vendoai-components-0.0.0.tgz" },
+  { name: "@vendoai/core", fileName: "vendoai-core-0.0.0.tgz" },
+  { name: "@vendoai/next", fileName: "vendoai-next-0.0.0.tgz" },
+  { name: "@vendoai/react", fileName: "vendoai-react-0.0.0.tgz" },
+  { name: "@vendoai/runtime", fileName: "vendoai-runtime-0.0.0.tgz" },
+  { name: "@vendoai/server", fileName: "vendoai-server-0.0.0.tgz" },
+  { name: "@vendoai/shell", fileName: "vendoai-shell-0.0.0.tgz" },
+  { name: "@vendoai/stage", fileName: "vendoai-stage-0.0.0.tgz" },
+  { name: "@vendoai/store", fileName: "vendoai-store-0.0.0.tgz" },
+  { name: "@vendoai/telemetry", fileName: "vendoai-telemetry-0.0.0.tgz" },
+  { name: "fluidkit", fileName: "fluidkit-0.5.0-656857b.tgz" },
+];
+
+describe("rewritePackageJsonForLocalVendo", () => {
+  it("writes direct file dependencies and pnpm overrides for every local tarball", () => {
+    const out = rewritePackageJsonForLocalVendo(
+      JSON.stringify({
+        name: "host",
+        packageManager: "pnpm@9.12.0",
+        dependencies: { next: "16.0.0", "@vendoai/next": "latest" },
+        pnpm: { overrides: { "@types/react": "^19.2.0" } },
+      }),
+      LOCAL_TARBALLS,
+      { packageManager: "pnpm" },
+    );
+    expect(out).not.toBeNull();
+    const pkg = JSON.parse(out!) as {
+      dependencies: Record<string, string>;
+      pnpm: { overrides: Record<string, string> };
+    };
+    expect(pkg.dependencies["@vendoai/next"]).toBe("file:vendor/vendoai-next-0.0.0.tgz");
+    expect(pkg.dependencies["@vendoai/shell"]).toBe("file:vendor/vendoai-shell-0.0.0.tgz");
+    expect(pkg.dependencies["next"]).toBe("16.0.0");
+    for (const tarball of LOCAL_TARBALLS) {
+      expect(pkg.pnpm.overrides[tarball.name]).toBe(`file:vendor/${tarball.fileName}`);
+    }
+    expect(pkg.pnpm.overrides["@types/react"]).toBe("^19.2.0");
+  });
+
+  it("uses npm overrides as the fallback package-manager shape", () => {
+    const out = rewritePackageJsonForLocalVendo(
+      JSON.stringify({
+        name: "host",
+        dependencies: { react: "^19.0.0" },
+        overrides: { zod: "^3.24.0" },
+      }),
+      LOCAL_TARBALLS,
+      { packageManager: "npm" },
+    );
+    expect(out).not.toBeNull();
+    const pkg = JSON.parse(out!) as {
+      dependencies: Record<string, string>;
+      overrides: Record<string, string>;
+      pnpm?: unknown;
+    };
+    expect(pkg.dependencies["@vendoai/next"]).toBe("file:vendor/vendoai-next-0.0.0.tgz");
+    expect(pkg.dependencies["@vendoai/shell"]).toBe("file:vendor/vendoai-shell-0.0.0.tgz");
+    expect(pkg.overrides["@vendoai/core"]).toBe("file:vendor/vendoai-core-0.0.0.tgz");
+    expect(pkg.overrides["fluidkit"]).toBe("file:vendor/fluidkit-0.5.0-656857b.tgz");
+    expect(pkg.overrides["zod"]).toBe("^3.24.0");
+    expect(pkg.pnpm).toBeUndefined();
+  });
+
+  it("returns null for invalid package.json or incomplete tarball maps", () => {
+    expect(rewritePackageJsonForLocalVendo("{nope", LOCAL_TARBALLS, { packageManager: "pnpm" })).toBeNull();
+    expect(
+      rewritePackageJsonForLocalVendo("{}", LOCAL_TARBALLS.filter((tarball) => tarball.name !== "fluidkit"), {
+        packageManager: "pnpm",
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/vendo-cli/src/local-pack.test.ts
+++ b/packages/vendo-cli/src/local-pack.test.ts
@@ -1,5 +1,8 @@
+import { mkdtemp, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { rewritePackageJsonForLocalVendo, type LocalTarball } from "./local-pack.js";
+import { installLocalVendoPackages, rewritePackageJsonForLocalVendo, type LocalTarball } from "./local-pack.js";
 
 const LOCAL_TARBALLS: LocalTarball[] = [
   { name: "@vendoai/components", fileName: "vendoai-components-0.0.0.tgz" },
@@ -27,8 +30,9 @@ describe("rewritePackageJsonForLocalVendo", () => {
       LOCAL_TARBALLS,
       { packageManager: "pnpm" },
     );
-    expect(out).not.toBeNull();
-    const pkg = JSON.parse(out!) as {
+    expect(out.kind).toBe("updated");
+    if (out.kind !== "updated") throw new Error("expected local package rewrite");
+    const pkg = JSON.parse(out.source) as {
       dependencies: Record<string, string>;
       pnpm: { overrides: Record<string, string> };
     };
@@ -46,15 +50,16 @@ describe("rewritePackageJsonForLocalVendo", () => {
       JSON.stringify({
         name: "host",
         dependencies: { react: "^19.0.0" },
-        overrides: { zod: "^3.24.0" },
+        overrides: { eslint: { chalk: "5.0.0" }, zod: "^3.24.0" },
       }),
       LOCAL_TARBALLS,
       { packageManager: "npm" },
     );
-    expect(out).not.toBeNull();
-    const pkg = JSON.parse(out!) as {
+    expect(out.kind).toBe("updated");
+    if (out.kind !== "updated") throw new Error("expected local package rewrite");
+    const pkg = JSON.parse(out.source) as {
       dependencies: Record<string, string>;
-      overrides: Record<string, string>;
+      overrides: Record<string, unknown>;
       pnpm?: unknown;
     };
     expect(pkg.dependencies["@vendoai/next"]).toBe("file:vendor/vendoai-next-0.0.0.tgz");
@@ -62,15 +67,97 @@ describe("rewritePackageJsonForLocalVendo", () => {
     expect(pkg.overrides["@vendoai/core"]).toBe("file:vendor/vendoai-core-0.0.0.tgz");
     expect(pkg.overrides["fluidkit"]).toBe("file:vendor/fluidkit-0.5.0-656857b.tgz");
     expect(pkg.overrides["zod"]).toBe("^3.24.0");
+    expect(pkg.overrides["eslint"]).toEqual({ chalk: "5.0.0" });
     expect(pkg.pnpm).toBeUndefined();
   });
 
-  it("returns null for invalid package.json or incomplete tarball maps", () => {
-    expect(rewritePackageJsonForLocalVendo("{nope", LOCAL_TARBALLS, { packageManager: "pnpm" })).toBeNull();
-    expect(
-      rewritePackageJsonForLocalVendo("{}", LOCAL_TARBALLS.filter((tarball) => tarball.name !== "fluidkit"), {
+  it("skips with manual instructions for invalid or unsupported package.json shapes", () => {
+    const invalid = rewritePackageJsonForLocalVendo("{nope", LOCAL_TARBALLS, { packageManager: "pnpm" });
+    expect(invalid.kind).toBe("skipped");
+    if (invalid.kind !== "skipped") throw new Error("expected local package rewrite skip");
+    expect(invalid.manual).toContain("pnpm.overrides");
+
+    const incomplete = rewritePackageJsonForLocalVendo("{}", LOCAL_TARBALLS.filter((tarball) => tarball.name !== "fluidkit"), {
         packageManager: "pnpm",
-      }),
-    ).toBeNull();
+      });
+    expect(incomplete.kind).toBe("skipped");
+
+    const unsupported = rewritePackageJsonForLocalVendo(JSON.stringify({ overrides: "eslint@8" }), LOCAL_TARBALLS, {
+      packageManager: "npm",
+    });
+    expect(unsupported.kind).toBe("skipped");
+    if (unsupported.kind !== "skipped") throw new Error("expected local package rewrite skip");
+    expect(unsupported.reason).toContain("overrides is not an object");
+    expect(unsupported.manual).toContain("@vendoai/next");
+  });
+});
+
+async function writeJson(file: string, value: unknown): Promise<void> {
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFile(file, JSON.stringify(value, null, 2) + "\n");
+}
+
+async function createPackableLocalRepo(withFluidkit = true): Promise<string> {
+  const repoDir = await mkdtemp(path.join(tmpdir(), "vendo local repo "));
+  expect(repoDir).toContain(" ");
+  for (const [dirName, name] of [
+    ["vendo-next", "@vendoai/next"],
+    ["vendo-shell", "@vendoai/shell"],
+  ] as const) {
+    const pkgDir = path.join(repoDir, "packages", dirName);
+    await writeJson(path.join(pkgDir, "package.json"), {
+      name,
+      version: "0.0.0",
+      type: "module",
+      main: "index.js",
+      files: ["index.js"],
+    });
+    await writeFile(path.join(pkgDir, "index.js"), "export {};\n");
+  }
+  if (withFluidkit) {
+    await mkdir(path.join(repoDir, "vendor"), { recursive: true });
+    await writeFile(path.join(repoDir, "vendor/fluidkit-0.5.0-test.tgz"), "not a real tarball");
+  }
+  return repoDir;
+}
+
+async function createTargetApp(): Promise<string> {
+  const targetDir = await mkdtemp(path.join(tmpdir(), "vendo-local-target-"));
+  await writeJson(path.join(targetDir, "package.json"), {
+    name: "host",
+    packageManager: "pnpm@9.12.0",
+    dependencies: { next: "16.0.0" },
+  });
+  return targetDir;
+}
+
+describe("installLocalVendoPackages", () => {
+  it("packs with real pnpm from a local repo path containing spaces", async () => {
+    const repoDir = await createPackableLocalRepo();
+    const targetDir = await createTargetApp();
+    const summary = await installLocalVendoPackages(targetDir, repoDir);
+    expect(summary.installCommand).toBe("pnpm install");
+
+    const vendorFiles = await readdir(path.join(targetDir, "vendor"));
+    expect(vendorFiles).toContain("vendoai-next-0.0.0.tgz");
+    expect(vendorFiles).toContain("vendoai-shell-0.0.0.tgz");
+    expect(vendorFiles).toContain("fluidkit-0.5.0-test.tgz");
+
+    const pkg = JSON.parse(await readFile(path.join(targetDir, "package.json"), "utf8")) as {
+      dependencies: Record<string, string>;
+      pnpm: { overrides: Record<string, string> };
+    };
+    expect(pkg.dependencies["@vendoai/next"]).toBe("file:vendor/vendoai-next-0.0.0.tgz");
+    expect(pkg.dependencies["@vendoai/shell"]).toBe("file:vendor/vendoai-shell-0.0.0.tgz");
+    expect(pkg.pnpm.overrides["@vendoai/next"]).toBe("file:vendor/vendoai-next-0.0.0.tgz");
+    expect(pkg.pnpm.overrides["@vendoai/shell"]).toBe("file:vendor/vendoai-shell-0.0.0.tgz");
+    expect(pkg.pnpm.overrides["fluidkit"]).toBe("file:vendor/fluidkit-0.5.0-test.tgz");
+  });
+
+  it("preflights fluidkit before creating target vendor artifacts", async () => {
+    const repoDir = await createPackableLocalRepo(false);
+    const targetDir = await createTargetApp();
+    await expect(installLocalVendoPackages(targetDir, repoDir)).rejects.toThrow("fluidkit");
+    await expect(readdir(path.join(targetDir, "vendor"))).rejects.toThrow();
   });
 });

--- a/packages/vendo-cli/src/local-pack.ts
+++ b/packages/vendo-cli/src/local-pack.ts
@@ -1,0 +1,228 @@
+import { spawn } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+export const LOCAL_DIRECT_DEPENDENCIES = ["@vendoai/next", "@vendoai/shell"] as const;
+
+type PackageJson = Record<string, unknown>;
+
+export interface LocalTarball {
+  name: string;
+  fileName: string;
+}
+
+export interface LocalVendoInstallSummary {
+  packageManager: "pnpm" | "npm";
+  installCommand: "pnpm install" | "npm install";
+  packages: string[];
+  vendorDir: string;
+}
+
+export interface WorkspacePackage {
+  name: string;
+  version: string;
+  dir: string;
+  dependencies: Record<string, string>;
+}
+
+export interface LocalPackRunner {
+  (pkg: WorkspacePackage, opts: { repoDir: string; vendorDir: string; fileName: string }): Promise<void>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringRecord(value: unknown): Record<string, string> {
+  if (!isRecord(value)) return {};
+  return Object.fromEntries(Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === "string"));
+}
+
+function sortedRecord<T>(record: Record<string, T>): Record<string, T> {
+  return Object.fromEntries(Object.entries(record).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+function fileSpec(fileName: string): string {
+  return `file:vendor/${fileName.split(path.sep).join("/")}`;
+}
+
+function npmPackFileName(name: string, version: string): string {
+  const base = name.startsWith("@") ? name.slice(1).replace("/", "-") : name;
+  return `${base}-${version}.tgz`;
+}
+
+async function readJsonFile(file: string): Promise<PackageJson> {
+  return JSON.parse(await fs.readFile(file, "utf8")) as PackageJson;
+}
+
+async function discoverWorkspacePackages(repoDir: string): Promise<Map<string, WorkspacePackage>> {
+  const packagesDir = path.join(repoDir, "packages");
+  const entries = await fs.readdir(packagesDir, { withFileTypes: true });
+  const packages = new Map<string, WorkspacePackage>();
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const dir = path.join(packagesDir, entry.name);
+    const pkgPath = path.join(dir, "package.json");
+    let pkg: PackageJson;
+    try {
+      pkg = await readJsonFile(pkgPath);
+    } catch {
+      continue;
+    }
+    if (typeof pkg["name"] !== "string" || !pkg["name"].startsWith("@vendoai/")) continue;
+    if (typeof pkg["version"] !== "string") continue;
+    packages.set(pkg["name"], {
+      name: pkg["name"],
+      version: pkg["version"],
+      dir,
+      dependencies: stringRecord(pkg["dependencies"]),
+    });
+  }
+  return packages;
+}
+
+async function discoverLocalPackageClosure(repoDir: string): Promise<WorkspacePackage[]> {
+  const packages = await discoverWorkspacePackages(repoDir);
+  const seen = new Set<string>();
+  const ordered: WorkspacePackage[] = [];
+  const visit = (name: string) => {
+    if (seen.has(name)) return;
+    const pkg = packages.get(name);
+    if (!pkg) throw new Error(`local Vendo monorepo is missing workspace package ${name}`);
+    seen.add(name);
+    ordered.push(pkg);
+    for (const depName of Object.keys(pkg.dependencies).sort()) {
+      if (depName.startsWith("@vendoai/")) visit(depName);
+    }
+  };
+  for (const name of LOCAL_DIRECT_DEPENDENCIES) visit(name);
+  return ordered.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function findFluidkitTarball(repoDir: string): Promise<string> {
+  const vendorDir = path.join(repoDir, "vendor");
+  const matches = (await fs.readdir(vendorDir))
+    .filter((name) => /^fluidkit-.+\.tgz$/.test(name))
+    .sort();
+  if (matches.length === 0) throw new Error(`no fluidkit tarball found in ${path.relative(process.cwd(), vendorDir)}`);
+  if (matches.length > 1) {
+    throw new Error(`multiple fluidkit tarballs found in ${path.relative(process.cwd(), vendorDir)}: ${matches.join(", ")}`);
+  }
+  return path.join(vendorDir, matches[0]!);
+}
+
+async function defaultPackRunner(
+  pkg: WorkspacePackage,
+  opts: { repoDir: string; vendorDir: string; fileName: string },
+): Promise<void> {
+  const output = await new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve, reject) => {
+    const child = spawn("pnpm", ["--filter", pkg.name, "pack", "--pack-destination", opts.vendorDir], {
+      cwd: opts.repoDir,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  });
+  if (output.code !== 0) {
+    throw new Error(`pnpm pack failed for ${pkg.name}:\n${output.stderr || output.stdout}`);
+  }
+  const packed = path.join(opts.vendorDir, opts.fileName);
+  try {
+    await fs.access(packed);
+  } catch {
+    throw new Error(`pnpm pack for ${pkg.name} did not create expected tarball ${opts.fileName}`);
+  }
+}
+
+async function detectPackageManager(targetDir: string, pkg: PackageJson): Promise<"pnpm" | "npm"> {
+  if (typeof pkg["packageManager"] === "string") {
+    if (pkg["packageManager"].startsWith("pnpm@")) return "pnpm";
+    if (pkg["packageManager"].startsWith("npm@")) return "npm";
+  }
+  try {
+    await fs.access(path.join(targetDir, "package-lock.json"));
+    return "npm";
+  } catch {
+    return "pnpm";
+  }
+}
+
+export function rewritePackageJsonForLocalVendo(
+  pkgJson: string,
+  tarballs: readonly LocalTarball[],
+  opts: { packageManager: "pnpm" | "npm" },
+): string | null {
+  let pkg: PackageJson;
+  try {
+    pkg = JSON.parse(pkgJson) as PackageJson;
+  } catch {
+    return null;
+  }
+  const byName = new Map(tarballs.map((tarball) => [tarball.name, tarball]));
+  for (const name of [...LOCAL_DIRECT_DEPENDENCIES, "fluidkit"]) {
+    if (!byName.has(name)) return null;
+  }
+
+  const deps = stringRecord(pkg["dependencies"]);
+  for (const name of LOCAL_DIRECT_DEPENDENCIES) {
+    deps[name] = fileSpec(byName.get(name)!.fileName);
+  }
+  pkg["dependencies"] = sortedRecord(deps);
+
+  const localOverrides = sortedRecord(
+    Object.fromEntries(tarballs.map((tarball) => [tarball.name, fileSpec(tarball.fileName)])),
+  );
+  if (opts.packageManager === "pnpm") {
+    const pnpm = isRecord(pkg["pnpm"]) ? { ...pkg["pnpm"] } : {};
+    pnpm["overrides"] = sortedRecord({ ...stringRecord(pnpm["overrides"]), ...localOverrides });
+    pkg["pnpm"] = pnpm;
+  } else {
+    pkg["overrides"] = sortedRecord({ ...stringRecord(pkg["overrides"]), ...localOverrides });
+  }
+  return JSON.stringify(pkg, null, 2) + "\n";
+}
+
+export async function installLocalVendoPackages(
+  targetDir: string,
+  repoDir: string,
+  opts: { pack?: LocalPackRunner } = {},
+): Promise<LocalVendoInstallSummary> {
+  const resolvedTarget = path.resolve(targetDir);
+  const resolvedRepo = path.resolve(repoDir);
+  const vendorDir = path.join(resolvedTarget, "vendor");
+  await fs.mkdir(vendorDir, { recursive: true });
+
+  const packages = await discoverLocalPackageClosure(resolvedRepo);
+  const pack = opts.pack ?? defaultPackRunner;
+  const tarballs: LocalTarball[] = [];
+  for (const pkg of packages) {
+    const fileName = npmPackFileName(pkg.name, pkg.version);
+    await pack(pkg, { repoDir: resolvedRepo, vendorDir, fileName });
+    tarballs.push({ name: pkg.name, fileName });
+  }
+
+  const fluidkit = await findFluidkitTarball(resolvedRepo);
+  const fluidkitFileName = path.basename(fluidkit);
+  await fs.copyFile(fluidkit, path.join(vendorDir, fluidkitFileName));
+  tarballs.push({ name: "fluidkit", fileName: fluidkitFileName });
+
+  const pkgPath = path.join(resolvedTarget, "package.json");
+  const pkgJson = await fs.readFile(pkgPath, "utf8");
+  const packageManager = await detectPackageManager(resolvedTarget, JSON.parse(pkgJson) as PackageJson);
+  const rewritten = rewritePackageJsonForLocalVendo(pkgJson, tarballs, { packageManager });
+  if (rewritten === null) throw new Error("could not rewrite package.json for local Vendo tarballs");
+  await fs.writeFile(pkgPath, rewritten);
+
+  return {
+    packageManager,
+    installCommand: packageManager === "pnpm" ? "pnpm install" : "npm install",
+    packages: packages.map((pkg) => pkg.name),
+    vendorDir,
+  };
+}

--- a/packages/vendo-cli/src/local-pack.ts
+++ b/packages/vendo-cli/src/local-pack.ts
@@ -11,6 +11,10 @@ export interface LocalTarball {
   fileName: string;
 }
 
+export type LocalPackageRewriteResult =
+  | { kind: "updated"; source: string }
+  | { kind: "skipped"; reason: string; manual: string };
+
 export interface LocalVendoInstallSummary {
   packageManager: "pnpm" | "npm";
   installCommand: "pnpm install" | "npm install";
@@ -36,6 +40,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function stringRecord(value: unknown): Record<string, string> {
   if (!isRecord(value)) return {};
   return Object.fromEntries(Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === "string"));
+}
+
+function objectRecord(value: unknown, label: string): { ok: true; value: Record<string, unknown> } | { ok: false; reason: string } {
+  if (value === undefined) return { ok: true, value: {} };
+  if (!isRecord(value)) return { ok: false, reason: `${label} is not an object` };
+  return { ok: true, value: { ...value } };
 }
 
 function sortedRecord<T>(record: Record<string, T>): Record<string, T> {
@@ -101,7 +111,13 @@ async function discoverLocalPackageClosure(repoDir: string): Promise<WorkspacePa
 
 async function findFluidkitTarball(repoDir: string): Promise<string> {
   const vendorDir = path.join(repoDir, "vendor");
-  const matches = (await fs.readdir(vendorDir))
+  let entries: string[];
+  try {
+    entries = await fs.readdir(vendorDir);
+  } catch {
+    throw new Error(`no fluidkit tarball found in ${path.relative(process.cwd(), vendorDir)}`);
+  }
+  const matches = entries
     .filter((name) => /^fluidkit-.+\.tgz$/.test(name))
     .sort();
   if (matches.length === 0) throw new Error(`no fluidkit tarball found in ${path.relative(process.cwd(), vendorDir)}`);
@@ -116,7 +132,7 @@ async function defaultPackRunner(
   opts: { repoDir: string; vendorDir: string; fileName: string },
 ): Promise<void> {
   const output = await new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve, reject) => {
-    const child = spawn("pnpm", ["--filter", pkg.name, "pack", "--pack-destination", opts.vendorDir], {
+    const child = spawn("pnpm", ["-C", pkg.dir, "pack", "--pack-destination", opts.vendorDir], {
       cwd: opts.repoDir,
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -157,16 +173,26 @@ export function rewritePackageJsonForLocalVendo(
   pkgJson: string,
   tarballs: readonly LocalTarball[],
   opts: { packageManager: "pnpm" | "npm" },
-): string | null {
+): LocalPackageRewriteResult {
   let pkg: PackageJson;
   try {
     pkg = JSON.parse(pkgJson) as PackageJson;
   } catch {
-    return null;
+    return {
+      kind: "skipped",
+      reason: "package.json is not valid JSON",
+      manual: localPackageManualInstructions(tarballs, opts.packageManager),
+    };
   }
   const byName = new Map(tarballs.map((tarball) => [tarball.name, tarball]));
   for (const name of [...LOCAL_DIRECT_DEPENDENCIES, "fluidkit"]) {
-    if (!byName.has(name)) return null;
+    if (!byName.has(name)) {
+      return {
+        kind: "skipped",
+        reason: `local tarball map is missing ${name}`,
+        manual: localPackageManualInstructions(tarballs, opts.packageManager),
+      };
+    }
   }
 
   const deps = stringRecord(pkg["dependencies"]);
@@ -179,13 +205,70 @@ export function rewritePackageJsonForLocalVendo(
     Object.fromEntries(tarballs.map((tarball) => [tarball.name, fileSpec(tarball.fileName)])),
   );
   if (opts.packageManager === "pnpm") {
-    const pnpm = isRecord(pkg["pnpm"]) ? { ...pkg["pnpm"] } : {};
-    pnpm["overrides"] = sortedRecord({ ...stringRecord(pnpm["overrides"]), ...localOverrides });
+    const pnpmResult = objectRecord(pkg["pnpm"], "pnpm");
+    if (!pnpmResult.ok) {
+      return {
+        kind: "skipped",
+        reason: pnpmResult.reason,
+        manual: localPackageManualInstructions(tarballs, opts.packageManager),
+      };
+    }
+    const pnpm = pnpmResult.value;
+    const overridesResult = objectRecord(pnpm["overrides"], "pnpm.overrides");
+    if (!overridesResult.ok) {
+      return {
+        kind: "skipped",
+        reason: overridesResult.reason,
+        manual: localPackageManualInstructions(tarballs, opts.packageManager),
+      };
+    }
+    pnpm["overrides"] = sortedRecord({ ...overridesResult.value, ...localOverrides });
     pkg["pnpm"] = pnpm;
   } else {
-    pkg["overrides"] = sortedRecord({ ...stringRecord(pkg["overrides"]), ...localOverrides });
+    const overridesResult = objectRecord(pkg["overrides"], "overrides");
+    if (!overridesResult.ok) {
+      return {
+        kind: "skipped",
+        reason: overridesResult.reason,
+        manual: localPackageManualInstructions(tarballs, opts.packageManager),
+      };
+    }
+    pkg["overrides"] = sortedRecord({ ...overridesResult.value, ...localOverrides });
   }
-  return JSON.stringify(pkg, null, 2) + "\n";
+  return { kind: "updated", source: JSON.stringify(pkg, null, 2) + "\n" };
+}
+
+function localPackageManualInstructions(tarballs: readonly LocalTarball[], packageManager: "pnpm" | "npm"): string {
+  const byName = new Map(tarballs.map((tarball) => [tarball.name, tarball.fileName]));
+  const direct = LOCAL_DIRECT_DEPENDENCIES
+    .map((name) => `${JSON.stringify(name)}: ${JSON.stringify(byName.has(name) ? fileSpec(byName.get(name)!) : "file:vendor/<tarball>")}`)
+    .join(", ");
+  const overrides = tarballs
+    .map((tarball) => `${JSON.stringify(tarball.name)}: ${JSON.stringify(fileSpec(tarball.fileName))}`)
+    .join(", ");
+  return `manually add package.json dependencies { ${direct} } and ${packageManager === "pnpm" ? "pnpm.overrides" : "overrides"} { ${overrides} }`;
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  return fs.access(p).then(() => true, () => false);
+}
+
+async function replaceVendorDir(stagingDir: string, vendorDir: string): Promise<void> {
+  if (!(await pathExists(vendorDir))) {
+    await fs.rename(stagingDir, vendorDir);
+    return;
+  }
+  const backupDir = await fs.mkdtemp(path.join(path.dirname(vendorDir), ".vendo-local-pack-backup-"));
+  await fs.rm(backupDir, { recursive: true, force: true });
+  await fs.rename(vendorDir, backupDir);
+  try {
+    await fs.rename(stagingDir, vendorDir);
+    await fs.rm(backupDir, { recursive: true, force: true });
+  } catch (err) {
+    await fs.rm(vendorDir, { recursive: true, force: true }).catch(() => {});
+    await fs.rename(backupDir, vendorDir).catch(() => {});
+    throw err;
+  }
 }
 
 export async function installLocalVendoPackages(
@@ -196,28 +279,46 @@ export async function installLocalVendoPackages(
   const resolvedTarget = path.resolve(targetDir);
   const resolvedRepo = path.resolve(repoDir);
   const vendorDir = path.join(resolvedTarget, "vendor");
-  await fs.mkdir(vendorDir, { recursive: true });
-
   const packages = await discoverLocalPackageClosure(resolvedRepo);
-  const pack = opts.pack ?? defaultPackRunner;
-  const tarballs: LocalTarball[] = [];
-  for (const pkg of packages) {
-    const fileName = npmPackFileName(pkg.name, pkg.version);
-    await pack(pkg, { repoDir: resolvedRepo, vendorDir, fileName });
-    tarballs.push({ name: pkg.name, fileName });
-  }
-
   const fluidkit = await findFluidkitTarball(resolvedRepo);
   const fluidkitFileName = path.basename(fluidkit);
-  await fs.copyFile(fluidkit, path.join(vendorDir, fluidkitFileName));
-  tarballs.push({ name: "fluidkit", fileName: fluidkitFileName });
+  const tarballs: LocalTarball[] = [
+    ...packages.map((pkg) => ({ name: pkg.name, fileName: npmPackFileName(pkg.name, pkg.version) })),
+    { name: "fluidkit", fileName: fluidkitFileName },
+  ];
 
   const pkgPath = path.join(resolvedTarget, "package.json");
   const pkgJson = await fs.readFile(pkgPath, "utf8");
-  const packageManager = await detectPackageManager(resolvedTarget, JSON.parse(pkgJson) as PackageJson);
+  let parsedPkg: PackageJson = {};
+  try {
+    parsedPkg = JSON.parse(pkgJson) as PackageJson;
+  } catch {
+    /* rewritePackageJsonForLocalVendo returns the actionable manual path */
+  }
+  const packageManager = await detectPackageManager(resolvedTarget, parsedPkg);
   const rewritten = rewritePackageJsonForLocalVendo(pkgJson, tarballs, { packageManager });
-  if (rewritten === null) throw new Error("could not rewrite package.json for local Vendo tarballs");
-  await fs.writeFile(pkgPath, rewritten);
+  if (rewritten.kind === "skipped") {
+    throw new Error(`${rewritten.reason}; ${rewritten.manual}`);
+  }
+
+  const pack = opts.pack ?? defaultPackRunner;
+  const stagingDir = await fs.mkdtemp(path.join(resolvedTarget, ".vendo-local-pack-"));
+  try {
+    if (await pathExists(vendorDir)) {
+      await fs.cp(vendorDir, stagingDir, { recursive: true });
+    }
+    for (const pkg of packages) {
+      await pack(pkg, { repoDir: resolvedRepo, vendorDir: stagingDir, fileName: npmPackFileName(pkg.name, pkg.version) });
+    }
+
+    await fs.copyFile(fluidkit, path.join(stagingDir, fluidkitFileName));
+    await replaceVendorDir(stagingDir, vendorDir);
+  } catch (err) {
+    await fs.rm(stagingDir, { recursive: true, force: true }).catch(() => {});
+    throw err;
+  }
+
+  await fs.writeFile(pkgPath, rewritten.source);
 
   return {
     packageManager,

--- a/packages/vendo-cli/src/next-wiring.test.ts
+++ b/packages/vendo-cli/src/next-wiring.test.ts
@@ -7,6 +7,7 @@ import {
   addDependency,
   addPrebuildSync,
   mergeInstrumentation,
+  mergeNextConfig,
   productNameFrom,
   wireNextApp,
   wrapLayoutChildren,
@@ -229,6 +230,39 @@ describe("mergeInstrumentation", () => {
   });
 });
 
+describe("mergeNextConfig", () => {
+  it("merges Vendo settings into a simple object-literal config", () => {
+    const source = `const nextConfig = {
+  reactStrictMode: true,
+  transpilePackages: ["next-mdx-remote"],
+  serverExternalPackages: ["sharp"],
+};
+
+export default nextConfig;
+`;
+    const out = mergeNextConfig(source, "next.config.mjs");
+    expect(out.kind).toBe("updated");
+    if (out.kind !== "updated") throw new Error("expected next.config update");
+    expect(out.source).toContain('"next-mdx-remote"');
+    expect(out.source).toContain('"@vendoai/next"');
+    expect(out.source).toContain('"@vendoai/stage"');
+    expect(out.source).toContain('"sharp"');
+    expect(out.source).toContain('"@electric-sql/pglite"');
+  });
+
+  it("skips ambiguous configs instead of guessing", () => {
+    const source = `import analyzer from "@next/bundle-analyzer";
+const withAnalyzer = analyzer();
+
+export default withAnalyzer({});
+`;
+    const out = mergeNextConfig(source, "next.config.mjs");
+    expect(out.kind).toBe("skipped");
+    if (out.kind !== "skipped") throw new Error("expected next.config skip");
+    expect(out.reason).toContain("plain object literal");
+  });
+});
+
 async function scaffoldFreshApp(withSrcDir: boolean): Promise<string> {
   const dir = mkdtempSync(path.join(tmpdir(), "vendo-wire-"));
   const appDir = path.join(dir, withSrcDir ? "src/app" : "app");
@@ -269,6 +303,12 @@ describe("wireNextApp", () => {
       dependencies: Record<string, string>;
     };
     expect(pkg.dependencies["@vendoai/next"]).toBeDefined();
+    const nextConfig = await fs.readFile(path.join(dir, "next.config.ts"), "utf8");
+    expect(nextConfig).toContain('transpilePackages: [');
+    expect(nextConfig).toContain('"@vendoai/next"');
+    expect(nextConfig).toContain('"@vendoai/stage"');
+    expect(nextConfig).toContain('serverExternalPackages: [');
+    expect(nextConfig).toContain('"@electric-sql/pglite"');
 
     // src/app layout → instrumentation.ts lives under src/, matching Next's convention
     const instrumentation = await fs.readFile(path.join(dir, "src/instrumentation.ts"), "utf8");
@@ -289,6 +329,56 @@ describe("wireNextApp", () => {
     const instrumentation = await fs.readFile(path.join(dir, "instrumentation.ts"), "utf8");
     expect(instrumentation).toContain("startVendoScheduler()");
     expect(await exists(path.join(dir, "src/instrumentation.ts"))).toBe(false);
+  });
+
+  it("creates a minimal next.config.ts when the app has none", async () => {
+    const dir = await scaffoldFreshApp(false);
+    const info = await detectTarget(dir);
+    const summary = (await wireNextApp(dir, info, { force: false }))!;
+    const config = await fs.readFile(path.join(dir, "next.config.ts"), "utf8");
+    expect(summary.written).toContain("next.config.ts");
+    expect(config).toContain('import type { NextConfig } from "next"');
+    expect(config).toContain('"@vendoai/next"');
+    expect(config).toContain('"@electric-sql/pglite"');
+  });
+
+  it("edits a simple next.config object literal without removing existing entries", async () => {
+    const dir = await scaffoldFreshApp(false);
+    const configPath = path.join(dir, "next.config.mjs");
+    await fs.writeFile(
+      configPath,
+      `const nextConfig = {
+  transpilePackages: ["next-mdx-remote"],
+  serverExternalPackages: ["sharp"],
+};
+
+export default nextConfig;
+`,
+    );
+    const info = await detectTarget(dir);
+    const summary = (await wireNextApp(dir, info, { force: false }))!;
+    const config = await fs.readFile(configPath, "utf8");
+    expect(summary.edited).toContain("next.config.mjs");
+    expect(config).toContain('"next-mdx-remote"');
+    expect(config).toContain('"@vendoai/shell"');
+    expect(config).toContain('"sharp"');
+    expect(config).toContain('"@electric-sql/pglite"');
+  });
+
+  it("skips ambiguous next.config files and reports exact manual instructions", async () => {
+    const dir = await scaffoldFreshApp(false);
+    const configPath = path.join(dir, "next.config.mjs");
+    const source = `import analyzer from "@next/bundle-analyzer";
+const withAnalyzer = analyzer();
+
+export default withAnalyzer({});
+`;
+    await fs.writeFile(configPath, source);
+    const info = await detectTarget(dir);
+    const summary = (await wireNextApp(dir, info, { force: false }))!;
+    expect(await fs.readFile(configPath, "utf8")).toBe(source);
+    expect(summary.skipped.some((s) => s.step === "next.config")).toBe(true);
+    expect(summary.manual.some((m) => m.includes("transpilePackages") && m.includes("@electric-sql/pglite"))).toBe(true);
   });
 
   it("merges into an existing instrumentation.ts non-destructively when it has no register()", async () => {
@@ -331,11 +421,13 @@ describe("wireNextApp", () => {
     const layoutAfterFirst = await fs.readFile(path.join(dir, "app/layout.tsx"), "utf8");
     const instrumentationAfterFirst = await fs.readFile(path.join(dir, "instrumentation.ts"), "utf8");
     const envAfterFirst = await fs.readFile(path.join(dir, ".env.example"), "utf8");
+    const nextConfigAfterFirst = await fs.readFile(path.join(dir, "next.config.ts"), "utf8");
     const second = (await wireNextApp(dir, info, { force: false }))!;
     expect(second.edited).toEqual([]);
     expect(await fs.readFile(path.join(dir, "app/layout.tsx"), "utf8")).toBe(layoutAfterFirst);
     expect(await fs.readFile(path.join(dir, "instrumentation.ts"), "utf8")).toBe(instrumentationAfterFirst);
     expect(await fs.readFile(path.join(dir, ".env.example"), "utf8")).toBe(envAfterFirst);
+    expect(await fs.readFile(path.join(dir, "next.config.ts"), "utf8")).toBe(nextConfigAfterFirst);
   });
 
   it("fails open on an unrecognizable layout: files written, layout untouched, manual steps printed", async () => {

--- a/packages/vendo-cli/src/next-wiring.ts
+++ b/packages/vendo-cli/src/next-wiring.ts
@@ -20,6 +20,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import ts from "typescript";
 import type { FrameworkInfo } from "./detect.js";
 
 export interface WiringSummary {
@@ -44,6 +45,20 @@ async function readIf(p: string): Promise<string | null> {
     return null;
   }
 }
+
+export const VENDO_TRANSPILE_PACKAGES = [
+  "@vendoai/next",
+  "@vendoai/shell",
+  "@vendoai/react",
+  "@vendoai/components",
+  "@vendoai/core",
+  "@vendoai/runtime",
+  "@vendoai/server",
+  "@vendoai/store",
+  "@vendoai/stage",
+] as const;
+
+const NEXT_SERVER_EXTERNAL_PACKAGES = ["@electric-sql/pglite"] as const;
 
 /** Locate the App Router directory (`app/` or `src/app/`) with a root layout. */
 export async function findAppDir(
@@ -325,6 +340,250 @@ export function addPrebuildSync(pkgJson: string): string | null {
   return JSON.stringify(pkg, null, 2) + "\n";
 }
 
+export type NextConfigMergeResult =
+  | { kind: "updated"; source: string }
+  | { kind: "unchanged"; source: string }
+  | { kind: "skipped"; reason: string };
+
+function nextConfigScriptKind(fileName: string): ts.ScriptKind {
+  if (fileName.endsWith(".ts")) return ts.ScriptKind.TS;
+  if (fileName.endsWith(".tsx")) return ts.ScriptKind.TSX;
+  if (fileName.endsWith(".jsx")) return ts.ScriptKind.JSX;
+  return ts.ScriptKind.JS;
+}
+
+function unwrapConfigExpression(expr: ts.Expression): ts.Expression {
+  let cur = expr;
+  while (
+    ts.isParenthesizedExpression(cur) ||
+    ts.isAsExpression(cur) ||
+    ts.isSatisfiesExpression(cur) ||
+    ts.isTypeAssertionExpression(cur) ||
+    ts.isNonNullExpression(cur)
+  ) {
+    if (ts.isParenthesizedExpression(cur) || ts.isNonNullExpression(cur)) cur = cur.expression;
+    else cur = cur.expression;
+  }
+  return cur;
+}
+
+function isModuleExports(expr: ts.Expression): boolean {
+  return (
+    ts.isPropertyAccessExpression(expr) &&
+    expr.name.text === "exports" &&
+    ts.isIdentifier(expr.expression) &&
+    expr.expression.text === "module"
+  );
+}
+
+function propertyNameText(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) return name.text;
+  return null;
+}
+
+function lineLeadingIndent(source: string, pos: number): string {
+  const lineStart = source.lastIndexOf("\n", Math.max(0, pos - 1)) + 1;
+  const m = source.slice(lineStart, pos).match(/^[ \t]*/);
+  return m?.[0] ?? "";
+}
+
+function visualIndentAt(sf: ts.SourceFile, pos: number): string {
+  return " ".repeat(sf.getLineAndCharacterOfPosition(pos).character);
+}
+
+function findConfigObject(
+  source: string,
+  fileName: string,
+): { object: ts.ObjectLiteralExpression; sf: ts.SourceFile } | { reason: string } {
+  const sf = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    nextConfigScriptKind(fileName),
+  );
+  const objectVars = new Map<string, ts.ObjectLiteralExpression>();
+  for (const stmt of sf.statements) {
+    if (!ts.isVariableStatement(stmt)) continue;
+    for (const decl of stmt.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name) || !decl.initializer) continue;
+      const init = unwrapConfigExpression(decl.initializer);
+      if (ts.isObjectLiteralExpression(init)) objectVars.set(decl.name.text, init);
+    }
+  }
+
+  const candidates: ts.ObjectLiteralExpression[] = [];
+  let sawConfigExport = false;
+  const resolve = (expr: ts.Expression): ts.ObjectLiteralExpression | null => {
+    const unwrapped = unwrapConfigExpression(expr);
+    if (ts.isObjectLiteralExpression(unwrapped)) return unwrapped;
+    if (ts.isIdentifier(unwrapped)) return objectVars.get(unwrapped.text) ?? null;
+    return null;
+  };
+
+  for (const stmt of sf.statements) {
+    if (ts.isExportAssignment(stmt)) {
+      sawConfigExport = true;
+      const object = resolve(stmt.expression);
+      if (object) candidates.push(object);
+      continue;
+    }
+    if (!ts.isExpressionStatement(stmt) || !ts.isBinaryExpression(stmt.expression)) continue;
+    const expr = stmt.expression;
+    if (expr.operatorToken.kind !== ts.SyntaxKind.EqualsToken || !isModuleExports(expr.left)) continue;
+    sawConfigExport = true;
+    const object = resolve(expr.right);
+    if (object) candidates.push(object);
+  }
+
+  if (candidates.length === 1) return { object: candidates[0]!, sf };
+  if (candidates.length > 1) return { reason: "multiple plain object config exports found" };
+  return {
+    reason: sawConfigExport
+      ? "config export is not a plain object literal"
+      : "no export default or module.exports config object found",
+  };
+}
+
+type StringArrayProperty =
+  | { kind: "present"; property: ts.PropertyAssignment; array: ts.ArrayLiteralExpression; values: string[] }
+  | { kind: "absent" }
+  | { kind: "skipped"; reason: string };
+
+function inspectStringArrayProperty(
+  object: ts.ObjectLiteralExpression,
+  propName: string,
+): StringArrayProperty {
+  let found: ts.ObjectLiteralElementLike | null = null;
+  for (const prop of object.properties) {
+    if (ts.isSpreadAssignment(prop)) {
+      return { kind: "skipped", reason: "config object uses object spread (...)" };
+    }
+    const name = prop.name ? propertyNameText(prop.name) : null;
+    if (prop.name && name === null) {
+      return { kind: "skipped", reason: "config object has computed property names" };
+    }
+    if (name !== propName) continue;
+    if (found) return { kind: "skipped", reason: `${propName} is declared more than once` };
+    found = prop;
+  }
+  if (!found) return { kind: "absent" };
+  if (!ts.isPropertyAssignment(found)) {
+    return { kind: "skipped", reason: `${propName} is not a property assignment` };
+  }
+  const init = unwrapConfigExpression(found.initializer);
+  if (!ts.isArrayLiteralExpression(init)) {
+    return { kind: "skipped", reason: `${propName} is not a string array literal` };
+  }
+  const values: string[] = [];
+  for (const element of init.elements) {
+    const item = unwrapConfigExpression(element as ts.Expression);
+    if (ts.isStringLiteral(item) || ts.isNoSubstitutionTemplateLiteral(item)) {
+      values.push(item.text);
+      continue;
+    }
+    return { kind: "skipped", reason: `${propName} contains non-string entries` };
+  }
+  return { kind: "present", property: found, array: init, values };
+}
+
+function mergeValues(existing: readonly string[], required: readonly string[]): string[] {
+  const present = new Set(existing);
+  return [...existing, ...required.filter((value) => !present.has(value))];
+}
+
+function hasEveryValue(existing: readonly string[], required: readonly string[]): boolean {
+  const present = new Set(existing);
+  return required.every((value) => present.has(value));
+}
+
+function renderStringArray(values: readonly string[], propertyIndent: string): string {
+  return `[\n${values.map((value) => `${propertyIndent}  ${JSON.stringify(value)},`).join("\n")}\n${propertyIndent}]`;
+}
+
+function renderConfigProperty(name: string, values: readonly string[], propertyIndent: string): string {
+  return `${propertyIndent}${name}: ${renderStringArray(values, propertyIndent)},`;
+}
+
+export function mergeNextConfig(source: string, fileName = "next.config.ts"): NextConfigMergeResult {
+  const found = findConfigObject(source, fileName);
+  if ("reason" in found) return { kind: "skipped", reason: found.reason };
+  const { object, sf } = found;
+  const transpile = inspectStringArrayProperty(object, "transpilePackages");
+  if (transpile.kind === "skipped") return { kind: "skipped", reason: transpile.reason };
+  const external = inspectStringArrayProperty(object, "serverExternalPackages");
+  if (external.kind === "skipped") return { kind: "skipped", reason: external.reason };
+
+  const replacements: Array<{ start: number; end: number; text: string }> = [];
+  const addedProps: string[] = [];
+  const propertyIndent =
+    object.properties.length > 0
+      ? visualIndentAt(sf, object.properties[0]!.getStart(sf))
+      : lineLeadingIndent(source, object.getStart(sf)) + "  ";
+  const closeIndent = lineLeadingIndent(source, object.getStart(sf));
+
+  if (transpile.kind === "present") {
+    if (!hasEveryValue(transpile.values, VENDO_TRANSPILE_PACKAGES)) {
+      replacements.push({
+        start: transpile.array.getStart(sf),
+        end: transpile.array.getEnd(),
+        text: renderStringArray(mergeValues(transpile.values, VENDO_TRANSPILE_PACKAGES), propertyIndent),
+      });
+    }
+  } else {
+    addedProps.push(renderConfigProperty("transpilePackages", VENDO_TRANSPILE_PACKAGES, propertyIndent));
+  }
+
+  if (external.kind === "present") {
+    if (!hasEveryValue(external.values, NEXT_SERVER_EXTERNAL_PACKAGES)) {
+      replacements.push({
+        start: external.array.getStart(sf),
+        end: external.array.getEnd(),
+        text: renderStringArray(mergeValues(external.values, NEXT_SERVER_EXTERNAL_PACKAGES), propertyIndent),
+      });
+    }
+  } else {
+    addedProps.push(renderConfigProperty("serverExternalPackages", NEXT_SERVER_EXTERNAL_PACKAGES, propertyIndent));
+  }
+
+  if (addedProps.length > 0) {
+    const closeBrace = object.getEnd() - 1;
+    const lastProp = object.properties[object.properties.length - 1];
+    let prefix = "\n";
+    if (lastProp) {
+      const betweenLastPropAndClose = source.slice(lastProp.getEnd(), closeBrace);
+      prefix = betweenLastPropAndClose.trimStart().startsWith(",") ? "\n" : ",\n";
+    }
+    replacements.push({
+      start: closeBrace,
+      end: closeBrace,
+      text: `${prefix}${addedProps.join("\n")}\n${closeIndent}`,
+    });
+  }
+
+  if (replacements.length === 0) return { kind: "unchanged", source };
+  let next = source;
+  for (const r of replacements.sort((a, b) => b.start - a.start)) {
+    next = next.slice(0, r.start) + r.text + next.slice(r.end);
+  }
+  return { kind: next === source ? "unchanged" : "updated", source: next };
+}
+
+function minimalNextConfigSource(tsConfig: boolean): string {
+  const body = [
+    "  transpilePackages: [",
+    ...VENDO_TRANSPILE_PACKAGES.map((pkg) => `    ${JSON.stringify(pkg)},`),
+    "  ],",
+    "  serverExternalPackages: [",
+    ...NEXT_SERVER_EXTERNAL_PACKAGES.map((pkg) => `    ${JSON.stringify(pkg)},`),
+    "  ],",
+  ].join("\n");
+  if (tsConfig) {
+    return `import type { NextConfig } from "next";\n\nconst nextConfig: NextConfig = {\n${body}\n};\n\nexport default nextConfig;\n`;
+  }
+  return `/** @type {import("next").NextConfig} */\nconst nextConfig = {\n${body}\n};\n\nexport default nextConfig;\n`;
+}
+
 /** Sandbox assets bundled with the CLI at build time (see scripts/bundle-assets.mjs). */
 function bundledAssetsDir(): string {
   return fileURLToPath(new URL("./assets/", import.meta.url));
@@ -337,6 +596,11 @@ const MANUAL_LAYOUT = (layoutFile: string) =>
 
 const MANUAL_INSTRUMENTATION = (exampleFile: string, instrumentationFile: string) =>
   `merge the scheduler boot from ${exampleFile} into your existing ${instrumentationFile}'s register() (see @vendoai/next)`;
+
+const MANUAL_NEXT_CONFIG = (configFile: string) =>
+  `merge Vendo's Next.js settings into ${configFile}: add missing entries to ` +
+  `transpilePackages (${VENDO_TRANSPILE_PACKAGES.join(", ")}) and add ` +
+  `serverExternalPackages: ["${NEXT_SERVER_EXTERNAL_PACKAGES.join('", "')}"]`;
 
 export async function wireNextApp(
   targetDir: string,
@@ -499,7 +763,47 @@ export async function wireNextApp(
     }
   }
 
-  // 6. Sandbox assets into public/vendo/.
+  // 6. next.config.* — Vendo's published packages need transpilation in host
+  // apps, and PGlite must stay external so its import.meta.url wasm loading
+  // survives Next's server bundling.
+  const configFiles = ["next.config.ts", "next.config.mjs", "next.config.js"]
+    .map((name) => path.join(targetDir, name));
+  const existingConfigFiles: string[] = [];
+  for (const configFile of configFiles) {
+    if (await exists(configFile)) existingConfigFiles.push(configFile);
+  }
+  if (existingConfigFiles.length === 0) {
+    const configFile = path.join(targetDir, ts ? "next.config.ts" : "next.config.mjs");
+    await fs.writeFile(configFile, minimalNextConfigSource(ts));
+    summary.written.push(rel(configFile));
+  } else if (existingConfigFiles.length > 1) {
+    const names = existingConfigFiles.map((file) => rel(file)).join(", ");
+    summary.skipped.push({ step: "next.config", reason: `multiple Next config files found (${names})` });
+    summary.manual.push(MANUAL_NEXT_CONFIG(names));
+  } else {
+    const configFile = existingConfigFiles[0]!;
+    const configSource = await readIf(configFile);
+    if (configSource === null) {
+      summary.skipped.push({ step: "next.config", reason: `${rel(configFile)} unreadable` });
+      summary.manual.push(MANUAL_NEXT_CONFIG(rel(configFile)));
+    } else {
+      const merged = mergeNextConfig(configSource, rel(configFile));
+      if (merged.kind === "skipped") {
+        summary.skipped.push({ step: "next.config", reason: `${rel(configFile)}: ${merged.reason}` });
+        summary.manual.push(MANUAL_NEXT_CONFIG(rel(configFile)));
+      } else if (merged.kind === "updated") {
+        await fs.writeFile(configFile, merged.source);
+        summary.edited.push(rel(configFile));
+      } else {
+        summary.skipped.push({
+          step: "next.config",
+          reason: "already includes Vendo package transpilation and PGlite externalization",
+        });
+      }
+    }
+  }
+
+  // 7. Sandbox assets into public/vendo/.
   const assetsDir = bundledAssetsDir();
   const publicDir = path.join(targetDir, "public/vendo");
   const assets: Array<[string, string]> = [
@@ -525,7 +829,7 @@ export async function wireNextApp(
     summary.written.push(rel(dest));
   }
 
-  // 7. package.json: @vendoai/next dependency + prebuild sync wiring.
+  // 8. package.json: @vendoai/next dependency + prebuild sync wiring.
   if (pkgRaw) {
     const withDep = addDependency(pkgRaw, "@vendoai/next", "latest");
     if (withDep === null) {


### PR DESCRIPTION
Closes the host-app friction found integrating an external Next 15 app: init now codemods transpilePackages + serverExternalPackages (pglite), `vendo init --local <monorepo>` packs the workspace closure into vendor/ tarballs with overrides for pre-publish testing, and the generated .vendo README documents events (full tools.json shape + ingest surfaces). Codex-reviewed (blocker: pnpm pack invocation — fixed and re-exercised end-to-end against a /tmp fixture).

https://claude.ai/code/session_01JYCxGPaa3BpBqtu6i3iezb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Next.js host setup smoother by safely wiring `next.config` and adding a local install path. `vendo init` can now merge/create Next config, pack/install local `@vendoai/*` tarballs, and the generated docs include Events with examples and ingest guidance.

- **New Features**
  - Next config codemod: create or merge `next.config.(ts|mjs|js)` to add `transpilePackages` for `@vendoai/*` and `serverExternalPackages` for `@electric-sql/pglite`; handles plain object-literal configs and skips ambiguous ones with clear manual steps.
  - Local init: `vendo init --local <monorepo>` packs the workspace closure into `vendor/`, rewrites `package.json` to `file:vendor/*` for `@vendoai/next` and `@vendoai/shell`, and adds overrides for all packed `@vendoai/*` plus `fluidkit`; detects `pnpm` vs `npm` and uses the right overrides shape.
  - Docs: `.vendo/README.md` now documents Events with a `charge.posted` schema example and how to ingest via `ingestVendoEvent()` or `POST /api/vendo/events/ingest` (push, relay, or poll).

- **Bug Fixes**
  - Fixed packing via `pnpm -C <pkg.dir> pack --pack-destination <vendorDir>`; verified against repo paths with spaces.
  - Preserved existing `pnpm.overrides`/`overrides` when merging; unsupported shapes now skip with precise manual instructions.
  - Preflighted `fluidkit` and staged tarballs before replacing `vendor/` to keep writes atomic; init output now prints the correct install command.

<sup>Written for commit 49fa25f16ddd8928c8b5b07566286269ddb7cedb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

