### PR TITLE
Hardening on top of launch prep: reliability + error hygiene + publish gates

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -84,8 +84,10 @@ VENDO_MODEL=claude-sonnet-4-6     # bare id: applied to whichever provider key i
 `VENDO_MODEL` alone names a model, not a credential: without a real
 provider key (or a code-injected `model`), chat stays off. OpenAI and Google
 are optional peers (`@ai-sdk/openai`, `@ai-sdk/google`): resolving to one
-without its package installed fails fast with an actionable `npm i` hint, not
-a silent fallback.
+without its package installed degrades like the keyless state — every route
+stays healthy, `/capabilities` reports `chat: false`, and the server log and
+the chat 503 both carry an actionable `npm i` hint. A misconfigured
+`VENDO_MODEL` (unknown provider) still fails loudly.
 
 ## MCP servers
 

--- a/packages/vendo-cli/package.json
+++ b/packages/vendo-cli/package.json
@@ -2,7 +2,13 @@
   "name": "@vendoai/cli",
   "version": "0.1.0",
   "description": "One-command Vendo install: extracts theme, tools, and components from a host app and wires in the embedded agent.",
-  "keywords": ["ai", "agent", "generative-ui", "cli", "devtool"],
+  "keywords": [
+    "ai",
+    "agent",
+    "generative-ui",
+    "cli",
+    "devtool"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -21,7 +27,9 @@
   "bin": {
     "vendo": "./dist/cli.js"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "vite build && node scripts/bundle-assets.mjs",
     "test": "vitest run",
@@ -48,7 +56,6 @@
     "@vendoai/server": "workspace:*",
     "@vendoai/telemetry": "workspace:*",
     "ajv": "^8.17.0",
-    "typescript": "^5.6.0",
     "vite": "^5.4.0",
     "vitest": "^2.1.0"
   },

--- a/packages/vendo-cli/src/cli.test.ts
+++ b/packages/vendo-cli/src/cli.test.ts
@@ -1,5 +1,9 @@
+import { mkdirSync, mkdtempSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
-import { main } from "./cli.js";
+import { isCliEntrypoint, main } from "./cli.js";
 
 describe("cli dispatch", () => {
   it("prints help and exits 0 with no command", async () => {
@@ -30,5 +34,52 @@ describe("cli dispatch", () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
     expect(await main(["sync", dir])).toBe(0);
     log.mockRestore();
+  });
+});
+
+describe("isCliEntrypoint", () => {
+  // Simulates the layout npm creates: node_modules/@vendoai/cli/dist/cli.js
+  // plus a node_modules/.bin/vendo symlink pointing at it.
+  const setup = () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "vendo cli entry-")); // space on purpose
+    const entry = path.join(dir, "dist", "cli.js");
+    mkdirSync(path.dirname(entry), { recursive: true });
+    writeFileSync(entry, "// stub\n");
+    // Node reports import.meta.url as the module's realpath (e.g. /var -> /private/var
+    // on macOS), so build the fixture URL from the realpath too.
+    return { dir, entry, metaUrl: pathToFileURL(realpathSync(entry)).href };
+  };
+
+  it("true when argv[1] is the module path itself", () => {
+    const { entry, metaUrl } = setup();
+    expect(isCliEntrypoint(metaUrl, entry)).toBe(true);
+  });
+
+  it("true when argv[1] is a symlink to the module (npm .bin shim)", () => {
+    const { dir, entry, metaUrl } = setup();
+    const bin = path.join(dir, ".bin");
+    mkdirSync(bin);
+    const shim = path.join(bin, "vendo");
+    symlinkSync(entry, shim);
+    expect(isCliEntrypoint(metaUrl, shim)).toBe(true);
+  });
+
+  it("true when the install path contains spaces", () => {
+    const { entry, metaUrl } = setup(); // tmpdir already contains a space
+    expect(entry).toContain(" ");
+    expect(isCliEntrypoint(metaUrl, entry)).toBe(true);
+  });
+
+  it("false for an unrelated script path", () => {
+    const { dir, metaUrl } = setup();
+    const other = path.join(dir, "dist", "other.js");
+    writeFileSync(other, "// other\n");
+    expect(isCliEntrypoint(metaUrl, other)).toBe(false);
+  });
+
+  it("false when argv[1] is missing or nonexistent", () => {
+    const { dir, metaUrl } = setup();
+    expect(isCliEntrypoint(metaUrl, undefined)).toBe(false);
+    expect(isCliEntrypoint(metaUrl, path.join(dir, "nope.js"))).toBe(false);
   });
 });

--- a/packages/vendo-cli/src/cli.ts
+++ b/packages/vendo-cli/src/cli.ts
@@ -54,15 +54,15 @@ export async function main(argv: string[]): Promise<number> {
 // Node resolves the main module through symlinks (npm's .bin/vendo is one) and
 // pathToFileURL percent-encodes special characters, so compare against the
 // realpath's file URL rather than a hand-built `file://` string.
-const invokedAsBin = (() => {
-  const entry = process.argv[1];
-  if (!entry) return false;
+export function isCliEntrypoint(metaUrl: string, argv1: string | undefined): boolean {
+  if (!argv1) return false;
   try {
-    return import.meta.url === pathToFileURL(realpathSync(entry)).href;
+    return metaUrl === pathToFileURL(realpathSync(argv1)).href;
   } catch {
     return false;
   }
-})();
-if (invokedAsBin) {
+}
+
+if (isCliEntrypoint(import.meta.url, process.argv[1])) {
   main(process.argv.slice(2)).then((code) => process.exit(code));
 }

--- a/packages/vendo-next/src/handler.test.ts
+++ b/packages/vendo-next/src/handler.test.ts
@@ -487,6 +487,68 @@ describe("createVendoHandler", () => {
     expect(anon.status).toBe(403);
   });
 
+  it("REGRESSION: a remote caller's boot failure gets the generic message, not the raw one", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-x");
+    vi.stubEnv("VENDO_MODEL", "grok/whatever");
+    const { GET } = createVendoHandler({ vendoDir: emptyDir() });
+    // Boot runs before any principal guard, so this is reachable remotely and
+    // unauthenticated — the adapter must serve the server package's sanitized
+    // body, never echo the assembly error.
+    const res = await GET(
+      new Request("http://prod.example.com/api/vendo/capabilities", {
+        headers: { host: "prod.example.com" },
+      }),
+    );
+    expect(res.status).toBe(500);
+    expect(((await res.json()) as { error: string }).error).toBe(
+      "vendo failed to start — see server logs",
+    );
+    error.mockRestore();
+  });
+
+  it("REGRESSION: a host tool execute() throw answers as JSON 500, not an escaped rejection (framework HTML 500)", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { POST } = createVendoHandler({
+      vendoDir: emptyDir(),
+      storage: false,
+      tools: {
+        explode: tool({
+          description: "always throws",
+          inputSchema: z.object({}).passthrough(),
+          execute: async () => {
+            throw new Error("ECONNREFUSED 10.0.0.7:5432 at /srv/app/internal/db.ts:42");
+          },
+        }),
+      },
+    });
+    // Two-step /action: approve first (unannotated tool → approval gate),
+    // then execute with the token so the throwing execute() actually runs.
+    const gate = await POST(
+      req("/api/vendo/action", {
+        method: "POST",
+        body: JSON.stringify({ action: "explode", payload: {} }),
+      }),
+    );
+    const { approvalToken } = (await gate.json()) as { approvalToken: string };
+    const res = await POST(
+      req("/api/vendo/action", {
+        method: "POST",
+        body: JSON.stringify({ action: "explode", payload: {}, approvalToken }),
+      }),
+    );
+    expect(res.status).toBe(500);
+    expect(res.headers.get("content-type")).toMatch(/application\/json/);
+    expect(await res.json()).toEqual({ error: "internal error" });
+    // The path/host detail lands in the server log, not the response.
+    expect(
+      error.mock.calls.some((call) =>
+        call.some((arg) => arg instanceof Error && arg.message.includes("ECONNREFUSED")),
+      ),
+    ).toBe(true);
+    error.mockRestore();
+  });
+
   it("guards every mutating endpoint against remote requests by default", async () => {
     // A key so chat reaches the guard rather than short-circuiting on 503.
     vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-x");

--- a/packages/vendo-runtime/src/automations/host-events.ts
+++ b/packages/vendo-runtime/src/automations/host-events.ts
@@ -42,7 +42,14 @@ export function createHostEventIngest(deps: {
       key: eventType,
     });
     for (const automation of matches) {
-      await deps.runner.fire(scope, automation.id, envelope);
+      try {
+        await deps.runner.fire(scope, automation.id, envelope);
+      } catch (error) {
+        // Same isolation rule as InProcessScheduler.tick(): one automation's
+        // failure (e.g. a transient store error) must not starve the other
+        // matches of this event.
+        console.error(`[vendo] host-event firing failed for automation ${automation.id}`, error);
+      }
     }
   };
 }

--- a/packages/vendo-runtime/src/automations/in-process-scheduler.test.ts
+++ b/packages/vendo-runtime/src/automations/in-process-scheduler.test.ts
@@ -191,3 +191,66 @@ describe("host-event ingest (non-Scheduler path)", () => {
     expect(send.calls).toHaveLength(1);
   });
 });
+
+describe("tick error isolation", () => {
+  function bareScheduler(startIso: string) {
+    let nowIso = startIso;
+    const clock = { set: (iso: string) => (nowIso = iso), nowMs: () => Date.parse(nowIso) };
+    const errors: Array<{ automationId: string; error: unknown }> = [];
+    const scheduler = new InProcessScheduler({
+      nowMs: clock.nowMs,
+      onFireError: (automationId, error) => errors.push({ automationId, error }),
+    });
+    return { scheduler, clock, errors };
+  }
+
+  it("a failing handler neither rejects tick() nor skips other due schedules", async () => {
+    const { scheduler, clock, errors } = bareScheduler("2026-07-15T15:59:00.000Z");
+    const fired: string[] = [];
+    scheduler.onFire(async (firing) => {
+      if (firing.automationId === "auto-bad") throw new Error("db down");
+      fired.push(firing.automationId);
+    });
+    // bad first so a bail-out would skip good
+    await scheduler.schedule("auto-bad", { kind: "at", at: "2026-07-15T16:00:00.000Z" }, alice);
+    await scheduler.schedule("auto-good", { kind: "at", at: "2026-07-15T16:00:00.000Z" }, alice);
+
+    clock.set("2026-07-15T16:00:30.000Z");
+    await expect(scheduler.tick()).resolves.toBeUndefined();
+    expect(fired).toEqual(["auto-good"]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.automationId).toBe("auto-bad");
+  });
+
+  it("a recurring schedule keeps firing on later ticks after one failure", async () => {
+    const { scheduler, clock } = bareScheduler("2026-07-15T16:00:30.000Z");
+    let attempts = 0;
+    scheduler.onFire(async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("transient");
+    });
+    await scheduler.schedule("auto-cron", { kind: "cron", expression: "* * * * *" }, alice);
+
+    clock.set("2026-07-15T16:01:30.000Z");
+    await scheduler.tick(); // fails
+    clock.set("2026-07-15T16:02:30.000Z");
+    await scheduler.tick(); // must still fire
+    expect(attempts).toBe(2);
+  });
+
+  it("a failed one-shot is consumed, not retried (missed fires are skipped)", async () => {
+    const { scheduler, clock } = bareScheduler("2026-07-15T15:59:00.000Z");
+    let attempts = 0;
+    scheduler.onFire(async () => {
+      attempts += 1;
+      throw new Error("always fails");
+    });
+    await scheduler.schedule("auto-once", { kind: "at", at: "2026-07-15T16:00:00.000Z" }, alice);
+
+    clock.set("2026-07-15T16:00:30.000Z");
+    await scheduler.tick();
+    clock.set("2026-07-15T16:01:30.000Z");
+    await scheduler.tick();
+    expect(attempts).toBe(1);
+  });
+});

--- a/packages/vendo-runtime/src/automations/in-process-scheduler.test.ts
+++ b/packages/vendo-runtime/src/automations/in-process-scheduler.test.ts
@@ -5,7 +5,7 @@
  * Host-event ingest (a non-Scheduler path per the freeze) is tested via
  * host-events.ts.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AutomationFiring, Principal } from "@vendoai/core";
 import { InProcessScheduler } from "./in-process-scheduler.js";
 import { createHostEventIngest, createSchedulerFiringHandler } from "./host-events.js";
@@ -179,6 +179,31 @@ describe("host-event ingest (non-Scheduler path)", () => {
 
     expect(send.calls).toEqual([{ m: "DoorDash" }]);
     expect(await store.listRuns(alice, mine.id)).toHaveLength(1);
+  });
+
+  it("one failing automation does not block other matches (per-fire isolation)", async () => {
+    const { store, send, runner, clock } = setup("2026-07-01T08:00:00.000Z");
+    const ingest = createHostEventIngest({ store, runner });
+    await store.create(alice, { spec: eventSpec(), grants: [] });
+    const { automation: second } = await store.create(alice, { spec: eventSpec(), grants: [] });
+    const realFire = runner.fire.bind(runner);
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(runner, "fire")
+      .mockImplementationOnce(() => Promise.reject(new Error("store blip")))
+      .mockImplementation(realFire);
+
+    await expect(
+      ingest(alice, "transaction.created", {
+        eventId: "txn-iso",
+        occurredAt: clock.now(),
+        payload: { merchant: "DoorDash" },
+      }),
+    ).resolves.not.toThrow();
+
+    expect(send.calls).toHaveLength(1); // the second automation still ran
+    expect(await store.listRuns(alice, second.id)).toHaveLength(1);
+    expect(err).toHaveBeenCalled();
+    err.mockRestore();
   });
 
   it("ignores duplicate event ids", async () => {

--- a/packages/vendo-runtime/src/automations/in-process-scheduler.ts
+++ b/packages/vendo-runtime/src/automations/in-process-scheduler.ts
@@ -21,6 +21,8 @@ export interface InProcessSchedulerConfig {
   /** Tick interval for start(); tests call tick() directly. */
   tickMs?: number;
   nowMs?: () => number;
+  /** Called when a firing handler rejects; defaults to console.error. */
+  onFireError?: (automationId: string, error: unknown) => void;
 }
 
 interface RegisteredSchedule {
@@ -81,8 +83,21 @@ export class InProcessScheduler implements Scheduler {
       const due = dueOccurrence(registered.trigger, windowStart, tickMs);
       if (due === undefined) continue;
       const firedAt = new Date(due).toISOString();
-      await this.handler({ automationId, principal: registered.scope, firedAt });
-      if (registered.trigger.kind === "at") this.schedules.delete(automationId); // one-shot
+      // One-shot occurrences are consumed whether or not delivery succeeds,
+      // same as the missed-fires rule: the occurrence, not the delivery, is
+      // what happens exactly once.
+      if (registered.trigger.kind === "at") this.schedules.delete(automationId);
+      try {
+        await this.handler({ automationId, principal: registered.scope, firedAt });
+      } catch (error) {
+        // A failing handler must not reject tick() (start()'s interval has no
+        // catch — an escape here is an unhandled rejection) nor starve the
+        // remaining due schedules in this window.
+        (this.config.onFireError ?? ((id, err) => console.error(`[vendo] scheduled firing failed for automation ${id}`, err)))(
+          automationId,
+          error,
+        );
+      }
     }
   }
 }

--- a/packages/vendo-runtime/src/engine.test.ts
+++ b/packages/vendo-runtime/src/engine.test.ts
@@ -151,6 +151,37 @@ describe("createVendoAgent", () => {
     expect(ui.data.payload).toEqual(payload);
   });
 
+  it("streams a GENERIC error part on a run failure — raw provider detail stays in the server log", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    // A provider auth failure is the canonical leak: its message carries the
+    // key prefix. The stream's error part must never repeat it to the client.
+    const model = new MockLanguageModelV3({
+      doStream: async () => {
+        throw new Error('401 invalid x-api-key "sk-ant-api03-abc123" (request id req_xyz)');
+      },
+    });
+    const agent = createVendoAgent({ model, policy: allowPolicy });
+
+    const parts = await collect(
+      agent.run({ messages: userTurn, tools: {}, signal: new AbortController().signal }),
+    );
+    const errorPart = parts.find((p) => (p as { type: string }).type === "error") as
+      | { errorText: string }
+      | undefined;
+    expect(errorPart).toBeDefined();
+    expect(errorPart!.errorText).toBe(
+      "something went wrong running this step — check the server logs",
+    );
+    expect(errorPart!.errorText).not.toContain("sk-ant-api03");
+    // The original error (classification-intact) reached the server log.
+    expect(
+      error.mock.calls.some((call) =>
+        call.some((arg) => arg instanceof Error && arg.message.includes("sk-ant-api03-abc123")),
+      ),
+    ).toBe(true);
+    error.mockRestore();
+  });
+
   it("registers render_view and request_connect but not render_ui", async () => {
     // Capture the toolset the engine hands to streamText by reading the tools
     // the SDK forwards to the model's doStream (provider-format function tools,

--- a/packages/vendo-runtime/src/engine.ts
+++ b/packages/vendo-runtime/src/engine.ts
@@ -744,6 +744,21 @@ export function createVendoAgent(config: VendoAgentConfig): VendoAgent {
     // tool runs, and the stream can't finish before `execute` has started.
     let settledPrincipal: VendoPrincipal = { userId: "" };
 
+    // Route run/step failures (bad prompt, provider/Composio errors) into the
+    // stream as an error part instead of an unhandled rejection — one crashed
+    // run must never take the host process down with it. Serialization
+    // boundary: the raw message (provider 401s carrying key prefixes,
+    // Composio/network detail) must not reach the client stream — sanitized
+    // HERE, not at throw sites, so error classification (telemetry's
+    // errorClassName, policy retry paths) still sees the original error.
+    // Wired into BOTH `createUIMessageStream` (execute/merge failures) and
+    // `toUIMessageStream` below (streamText failures, whose own onError
+    // defaults to the raw getErrorMessage).
+    const streamError = (error: unknown): string => {
+      console.error(`[vendo] run ${runId} failed:`, error);
+      return "something went wrong running this step — check the server logs";
+    };
+
     return createUIMessageStream<VendoUIMessage>({
       // Verified against ai@6.0.28's handleUIMessageStreamFinish: without this,
       // `originalMessages` defaults to `[]` and onFinish's `messages` would be
@@ -752,13 +767,7 @@ export function createVendoAgent(config: VendoAgentConfig): VendoAgent {
       // ([...originalMessages, state.message]) — what a Store-backed
       // persistence hook (Task 4/5) actually needs to write.
       originalMessages: input.messages,
-      // Route execute failures (bad prompt, provider/Composio errors) into the
-      // stream as an error part instead of an unhandled rejection — one crashed
-      // run must never take the host process down with it.
-      onError: (error) => {
-        console.error(`[vendo] run ${runId} failed:`, error);
-        return error instanceof Error ? error.message : "The agent run failed.";
-      },
+      onError: streamError,
       // ENG-193 §6.2: persistence for the consent endpoint's "load the
       // thread's messages" step. A throwing/rejecting hook is caught here,
       // never surfaced to the model or the client stream. Only registered when
@@ -1032,6 +1041,11 @@ export function createVendoAgent(config: VendoAgentConfig): VendoAgent {
         writer.merge(
           result.toUIMessageStream({
             originalMessages: input.messages,
+            // Without this, toUIMessageStream's own default (getErrorMessage)
+            // serializes the RAW streamText failure into the error chunk —
+            // the outer createUIMessageStream onError never sees it because
+            // the merged stream doesn't reject, it carries an error chunk.
+            onError: streamError,
             messageMetadata: ({ part }) =>
               part.type === "start"
                 ? { runId, threadId, schemaVersion: SCHEMA_VERSION }

--- a/packages/vendo-sandbox-shims/src/index.ts
+++ b/packages/vendo-sandbox-shims/src/index.ts
@@ -3,8 +3,8 @@
  * that cannot run inside the egress-jailed remix sandbox. `vendo sync` maps
  * the framework import specifiers onto these in the sandbox import map.
  */
-export { NAVIGATE_ACTION, navigate, dispatch } from "./dispatch";
-export { default as Link, type LinkProps } from "./next-link";
-export { default as Image, type ImageProps } from "./next-image";
-export { useRouter, usePathname, useSearchParams } from "./next-navigation";
-export { default as useSWR, type SWRResponse } from "./swr";
+export { NAVIGATE_ACTION, navigate, dispatch } from "./dispatch.js";
+export { default as Link, type LinkProps } from "./next-link.js";
+export { default as Image, type ImageProps } from "./next-image.js";
+export { useRouter, usePathname, useSearchParams } from "./next-navigation.js";
+export { default as useSWR, type SWRResponse } from "./swr.js";

--- a/packages/vendo-sandbox-shims/src/next-link.tsx
+++ b/packages/vendo-sandbox-shims/src/next-link.tsx
@@ -5,7 +5,7 @@
  * iframe navigation). `default` export mirrors `next/link`.
  */
 import { createElement, type AnchorHTMLAttributes, type MouseEvent, type ReactNode } from "react";
-import { navigate } from "./dispatch";
+import { navigate } from "./dispatch.js";
 
 export interface LinkProps
   extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> {

--- a/packages/vendo-sandbox-shims/src/next-navigation.ts
+++ b/packages/vendo-sandbox-shims/src/next-navigation.ts
@@ -3,7 +3,7 @@
  * app via vendo.navigate; the rest throw descriptive contained errors rather
  * than silently misbehaving.
  */
-import { navigate } from "./dispatch";
+import { navigate } from "./dispatch.js";
 
 export function useRouter() {
   return {

--- a/packages/vendo-sandbox-shims/tsconfig.json
+++ b/packages/vendo-sandbox-shims/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": { "outDir": "dist", "rootDir": "src", "jsx": "react-jsx" },
+  "compilerOptions": { "module": "NodeNext", "moduleResolution": "NodeNext", "outDir": "dist", "rootDir": "src", "jsx": "react-jsx" },
   "include": ["src/**/*"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/packages/vendo-server/src/chat.ts
+++ b/packages/vendo-server/src/chat.ts
@@ -59,6 +59,9 @@ export interface ChatDeps {
   options: VendoHandlerOptions;
   /** False when no model key is configured → chat answers 503 instead of streaming a provider error. */
   chatEnabled: boolean;
+  /** Replaces the generic set-a-key hint in the disabled 503 (e.g. the
+   *  missing-provider-peer install hint). */
+  chatDisabledReason?: string;
   /** Maps the client's chat id to a store thread id (ENG-193 §6.2). */
   threadIndex: ThreadIndex;
   /** Durable (or in-memory) thread persistence. Optional — deps built before
@@ -102,6 +105,7 @@ export async function handleChat(req: Request, deps: ChatDeps): Promise<Response
     return Response.json(
       {
         error:
+          deps.chatDisabledReason ??
           "chat is unavailable — set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_GENERATIVE_AI_API_KEY",
       },
       { status: 503 },

--- a/packages/vendo-server/src/fetch-handler.test.ts
+++ b/packages/vendo-server/src/fetch-handler.test.ts
@@ -114,19 +114,50 @@ describe("createVendoFetchHandler", () => {
   });
 
   it("500s a boot failure and retries assembly once the config is fixed", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-x");
     vi.stubEnv("VENDO_MODEL", "grok/whatever");
     const handler = createVendoFetchHandler({ vendoDir: emptyDir() });
 
+    // A deliberately-constructed, developer-actionable message ("Vendo: …")
+    // still reaches a LOCAL dev request verbatim — it's static text our own
+    // code wrote, and localhost-in-dev is the developer's own terminal.
     const broken = await handler(req("/api/vendo/capabilities"));
     expect(broken.status).toBe(500);
-    expect(((await broken.json()) as { error: string }).error).toMatch(/Vendo/);
+    expect(((await broken.json()) as { error: string }).error).toMatch(/Vendo.*VENDO_MODEL/);
 
     // Fixing the env must NOT keep serving the cached rejection.
     vi.stubEnv("VENDO_MODEL", "");
     const fixed = await handler(req("/api/vendo/capabilities"));
     expect(fixed.status).toBe(200);
     expect(await fixed.json()).toEqual({ chat: true, integrations: false, voice: false, mcp: false, storage: false });
+    error.mockRestore();
+  });
+
+  it("answers a REMOTE caller's boot failure with a generic message, even a developer-actionable one", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-x");
+    vi.stubEnv("VENDO_MODEL", "grok/whatever");
+    const handler = createVendoFetchHandler({ vendoDir: emptyDir() });
+
+    // Boot failures happen BEFORE any principal guard runs, so this path is
+    // reachable by unauthenticated remote callers — nothing but the generic
+    // message may cross; the detail goes to the server log.
+    const res = await handler(
+      new Request("http://prod.example.com/api/vendo/capabilities", {
+        headers: { host: "prod.example.com" },
+      }),
+    );
+    expect(res.status).toBe(500);
+    expect(((await res.json()) as { error: string }).error).toBe(
+      "vendo failed to start — see server logs",
+    );
+    expect(
+      error.mock.calls.some((call) =>
+        call.some((arg) => arg instanceof Error && arg.message.includes("VENDO_MODEL")),
+      ),
+    ).toBe(true);
+    error.mockRestore();
   });
 
   it("guards every mutating endpoint against remote requests by default", async () => {

--- a/packages/vendo-server/src/fetch-handler.test.ts
+++ b/packages/vendo-server/src/fetch-handler.test.ts
@@ -160,6 +160,32 @@ describe("createVendoFetchHandler", () => {
     error.mockRestore();
   });
 
+  it("answers a throw inside a route handler with a generic JSON 500, never an escaped rejection", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    // A throwing host `principal` resolver is a realistic route-dep failure
+    // (host auth backend down). Before the route-level boundary this escaped
+    // createVendoFetchHandler entirely — the framework rendered an HTML 500,
+    // which the sandbox then parsed as JSON into a raw SyntaxError.
+    const handler = createVendoFetchHandler({
+      vendoDir: emptyDir(),
+      principal: async () => {
+        throw new Error("pg://user:s3cretpw@auth-db.internal:5432 connection refused");
+      },
+    });
+    const res = await handler(req("/api/vendo/grants"));
+    expect(res.status).toBe(500);
+    expect(res.headers.get("content-type")).toMatch(/application\/json/);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("internal error");
+    // The detail (connection string and all) goes to the server log only.
+    expect(
+      error.mock.calls.some((call) =>
+        call.some((arg) => arg instanceof Error && arg.message.includes("s3cretpw")),
+      ),
+    ).toBe(true);
+    error.mockRestore();
+  });
+
   it("guards every mutating endpoint against remote requests by default", async () => {
     // A key so chat reaches the guard rather than short-circuiting on 503.
     vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-x");

--- a/packages/vendo-server/src/fetch-handler.ts
+++ b/packages/vendo-server/src/fetch-handler.ts
@@ -954,13 +954,23 @@ export function createVendoFetchHandler(rawOptions: VendoHandlerOptions = {}): V
       trackErrorClass(err);
       return bootError(req, err);
     }
-    switch (req.method) {
-      case "GET":
-        return GET(req, s);
-      case "POST":
-        return POST(req, s);
-      default:
-        return Response.json({ error: "not found" }, { status: 404 });
+    // Route-level error boundary: a throw inside any route handler must
+    // answer as JSON, never escape to the framework (whose HTML 500 the
+    // sandbox would parse as JSON into a raw SyntaxError). Same hygiene as
+    // bootError: detail to the server log, generic body to the caller.
+    try {
+      switch (req.method) {
+        case "GET":
+          return await GET(req, s);
+        case "POST":
+          return await POST(req, s);
+        default:
+          return Response.json({ error: "not found" }, { status: 404 });
+      }
+    } catch (err) {
+      console.error(`[vendo] ${req.method} ${routeTail(req)} failed:`, err);
+      trackErrorClass(err);
+      return Response.json({ error: "internal error" }, { status: 500 });
     }
   };
 }

--- a/packages/vendo-server/src/fetch-handler.ts
+++ b/packages/vendo-server/src/fetch-handler.ts
@@ -87,7 +87,7 @@ import { ModelPeerMissingError, resolveModel } from "./model.js";
 import { defaultVendoPolicy } from "./default-policy.js";
 import { composeProductionPolicy, EMBEDDED_TENANT } from "./policy-stack.js";
 import { createThreadIndex } from "./threads.js";
-import { resolvePrincipal, threadScope, tickServiceAuth, DEFAULT_PRINCIPAL, WORLD_SCOPE } from "./guard.js";
+import { isLocalDevRequest, resolvePrincipal, threadScope, tickServiceAuth, DEFAULT_PRINCIPAL, WORLD_SCOPE } from "./guard.js";
 import { resolveStorage } from "./storage.js";
 import { parseHandlerOptions, type VendoHandlerOptions } from "./options.js";
 import { devTelemetry, errorClassName } from "./telemetry-dev.js";
@@ -671,10 +671,24 @@ export function createVendoFetchHandler(rawOptions: VendoHandlerOptions = {}): V
     }
   }
 
-  /** A boot (assembly) failure surfaces as a 500, not an unhandled rejection. */
-  function bootError(err: unknown): Response {
+  /** A boot (assembly) failure surfaces as a 500, not an unhandled rejection.
+   *  This path runs BEFORE any principal guard, so a raw message (which can
+   *  carry file paths, DATABASE_URL contents, provider auth detail) must never
+   *  reach a caller: full detail goes to the server log, the response is
+   *  generic. Exception: our own deliberately-constructed developer-actionable
+   *  messages — recognized by their static "[vendo]"/"Vendo:" prefixes — pass
+   *  through to a LOCAL request in development only. When in doubt, generic. */
+  function bootError(req: Request, err: unknown): Response {
+    console.error("[vendo] handler assembly failed:", err);
+    const message = err instanceof Error ? err.message : String(err);
+    const deliberate = message.startsWith("[vendo]") || message.startsWith("Vendo:");
     return Response.json(
-      { error: err instanceof Error ? err.message : String(err) },
+      {
+        error:
+          deliberate && isLocalDevRequest(req)
+            ? message
+            : "vendo failed to start — see server logs",
+      },
       { status: 500 },
     );
   }
@@ -938,7 +952,7 @@ export function createVendoFetchHandler(rawOptions: VendoHandlerOptions = {}): V
       s = await state();
     } catch (err) {
       trackErrorClass(err);
-      return bootError(err);
+      return bootError(req, err);
     }
     switch (req.method) {
       case "GET":

--- a/packages/vendo-server/src/fetch-handler.ts
+++ b/packages/vendo-server/src/fetch-handler.ts
@@ -81,7 +81,9 @@ import { buildInstructions, createAgentCache } from "./agent.js";
 import { createSourceResolver } from "./remix-enrich.js";
 import { resolveRemixSealer } from "./seal.js";
 import { createAutomationsWorld, type VendoAutomationsWorld } from "./world.js";
-import { resolveModel } from "./model.js";
+import { anthropic } from "@ai-sdk/anthropic";
+import { DEFAULT_MODEL_ID } from "./model-choice.js";
+import { ModelPeerMissingError, resolveModel } from "./model.js";
 import { defaultVendoPolicy } from "./default-policy.js";
 import { composeProductionPolicy, EMBEDDED_TENANT } from "./policy-stack.js";
 import { createThreadIndex } from "./threads.js";
@@ -158,12 +160,31 @@ async function assembleVendoState(options: VendoHandlerOptions) {
     // runs in an env-aware context). A server whose var is missing is dropped
     // with a warning. The capability flag reads the RESOLVED list.
     const mcpServers = options.mcpServers ?? resolveMcpServers(loaded.mcpServers ?? []);
+    const hostTools = options.hostTools ?? manifestToolsToHostTools(loaded.manifest.tools);
+    // A configured provider whose optional peer isn't installed (OPENAI_API_KEY
+    // set, @ai-sdk/openai missing) must degrade like the no-key ladder state —
+    // chat gated off, every other route healthy — not fail assembly and 500
+    // the whole handler. The call-time-failing Anthropic default is the same
+    // placeholder resolveModel() uses for the keyless state; chat stays gated
+    // by capabilities.chat below, and the install hint reaches the developer
+    // through the server log and the chat 503.
+    let model: NonNullable<VendoHandlerOptions["model"]>;
+    let modelUnavailable: string | undefined;
+    try {
+      model = options.model ?? (await resolveModel());
+    } catch (err) {
+      // Only the documented ladder state degrades; a misconfigured
+      // VENDO_MODEL keeps failing assembly loudly.
+      if (!(err instanceof ModelPeerMissingError)) throw err;
+      modelUnavailable = err.message;
+      console.error(`[vendo] model unavailable: ${modelUnavailable}`);
+      model = anthropic(DEFAULT_MODEL_ID.anthropic);
+    }
     const capabilities = {
       ...detectCapabilities(undefined, { hasInjectedModel: options.model !== undefined }),
       mcp: mcpServers.length > 0,
     };
-    const hostTools = options.hostTools ?? manifestToolsToHostTools(loaded.manifest.tools);
-    const model = options.model ?? (await resolveModel());
+    if (modelUnavailable) capabilities.chat = false;
     const grants = options.store?.grants ?? createInMemoryGrantStore();
     const rules = options.store?.rules ?? createInMemoryCompiledRuleStore();
     const audit = options.store?.audit ?? new InMemoryAuditLog();
@@ -487,6 +508,9 @@ async function assembleVendoState(options: VendoHandlerOptions) {
       // The shared durable handle (null = in-memory). Reused by later tasks
       // to wire the decision/thread/vendo/connections stores durably too.
       storage,
+      // Set when a configured provider's optional peer failed to load; chat
+      // is gated off and its 503 carries this actionable hint.
+      modelUnavailable,
     };
 }
 
@@ -764,6 +788,7 @@ export function createVendoFetchHandler(rawOptions: VendoHandlerOptions = {}): V
           // folds in an injected model (via hasInjectedModel above) alongside
           // any configured provider key.
           chatEnabled: s.capabilities.chat,
+          ...(s.modelUnavailable ? { chatDisabledReason: s.modelUnavailable } : {}),
           threadIndex: s.threadIndex,
         });
       case "action":

--- a/packages/vendo-server/src/guard.ts
+++ b/packages/vendo-server/src/guard.ts
@@ -91,6 +91,20 @@ function isLocalRequest(req: Request): boolean {
   return LOCAL_HOSTS.has(hostname.toLowerCase());
 }
 
+/**
+ * True only for a development-mode request from a local host — the one
+ * situation where a deliberately-constructed boot error message may be echoed
+ * to the caller (see fetch-handler.ts's bootError). Same Host-header localness
+ * `resolvePrincipal` keys on; NODE_ENV=production disables it entirely because
+ * that header is client-controlled.
+ */
+export function isLocalDevRequest(
+  req: Request,
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return env["NODE_ENV"] !== "production" && isLocalRequest(req);
+}
+
 export type GuardResult =
   | { ok: true; principal: VendoPrincipal }
   | { ok: false; response: Response };

--- a/packages/vendo-server/src/handler-boot.test.ts
+++ b/packages/vendo-server/src/handler-boot.test.ts
@@ -12,17 +12,28 @@ import { createVendoFetchHandler } from "./fetch-handler.js";
 
 describe("assembly failure eviction", () => {
   it("retries assembly after a transient boot failure instead of caching the rejection", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
     resolveStorage.mockRejectedValueOnce(new Error("transient boot blip")).mockResolvedValue(null);
     const handler = createVendoFetchHandler({ automations: false });
     const req = () => new Request("http://localhost/api/vendo/capabilities");
 
-    // Boot failures surface as a 500 JSON error (never an unhandled rejection).
+    // Boot failures surface as a 500 JSON error (never an unhandled rejection)
+    // whose body is GENERIC — a raw assembly error can carry file paths or
+    // DATABASE_URL contents, so the detail goes to the server log only.
     const first = await handler(req());
     expect(first.status).toBe(500);
-    expect(((await first.json()) as { error: string }).error).toMatch(/transient boot blip/);
+    expect(((await first.json()) as { error: string }).error).toBe(
+      "vendo failed to start — see server logs",
+    );
+    expect(
+      error.mock.calls.some((call) =>
+        call.some((arg) => arg instanceof Error && arg.message.includes("transient boot blip")),
+      ),
+    ).toBe(true);
 
     const second = await handler(req());
     expect(second.status).toBe(200);
     expect(resolveStorage).toHaveBeenCalledTimes(2);
+    error.mockRestore();
   });
 });

--- a/packages/vendo-server/src/model-degradation.test.ts
+++ b/packages/vendo-server/src/model-degradation.test.ts
@@ -1,0 +1,54 @@
+/**
+ * A configured provider whose optional peer isn't installed (OPENAI_API_KEY
+ * set but @ai-sdk/openai missing) must degrade like the no-key ladder state —
+ * capabilities chat:false, non-chat routes healthy, chat 503 with the
+ * actionable install hint — not 500 every route at first assembly.
+ * Isolated in its own file because it mocks ./model module-wide.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+const resolveModel = vi.hoisted(() => vi.fn());
+vi.mock("./model", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./model")>()),
+  resolveModel,
+}));
+
+import { createVendoFetchHandler } from "./fetch-handler";
+import { ModelPeerMissingError } from "./model";
+
+const PEER_HINT =
+  "OPENAI_API_KEY selects openai, which requires @ai-sdk/openai — run: npm i @ai-sdk/openai";
+
+function makeHandler() {
+  resolveModel.mockRejectedValue(new ModelPeerMissingError(PEER_HINT));
+  return createVendoFetchHandler({ automations: false });
+}
+
+describe("missing optional provider peer", () => {
+  it("GET /capabilities answers 200 with chat:false instead of a 500", async () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const handler = makeHandler();
+    const res = await handler(new Request("http://localhost/api/vendo/capabilities"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { chat: boolean };
+    expect(body.chat).toBe(false);
+    // The hint must still reach the developer loudly, server-side.
+    expect(err.mock.calls.flat().join("\n")).toMatch(/@ai-sdk\/openai/);
+    err.mockRestore();
+  });
+
+  it("POST /chat answers 503 with the actionable install hint", async () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const handler = makeHandler();
+    const res = await handler(
+      new Request("http://localhost/api/vendo/chat", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "c1", messages: [] }),
+      }),
+    );
+    expect(res.status).toBe(503);
+    expect(((await res.json()) as { error: string }).error).toMatch(/@ai-sdk\/openai/);
+    err.mockRestore();
+  });
+});

--- a/packages/vendo-server/src/model.ts
+++ b/packages/vendo-server/src/model.ts
@@ -49,13 +49,23 @@ export interface ResolveModelDeps {
   import?: (spec: string) => Promise<unknown>;
 }
 
+/**
+ * A configured provider's optional peer (@ai-sdk/openai, @ai-sdk/google)
+ * could not be loaded. Unlike a misconfigured VENDO_MODEL (which must fail
+ * loudly), this state is part of the documented capability ladder and the
+ * handler degrades it to chat:false + an actionable hint.
+ */
+export class ModelPeerMissingError extends Error {
+  override readonly name = "ModelPeerMissingError";
+}
+
 async function loadOptionalProvider(
   importer: (spec: string) => Promise<unknown>,
   provider: Exclude<ModelProvider, "anthropic">,
   modelId: string,
 ): Promise<LanguageModel> {
   const pkg = PROVIDER_PACKAGE[provider];
-  const missingPeerError = new Error(
+  const missingPeerError = new ModelPeerMissingError(
     `Vendo: model "${provider}/${modelId}" requires ${pkg} — run: npm i ${pkg}`,
   );
   let mod: Record<string, unknown>;

--- a/packages/vendo-server/src/vendo-dir.test.ts
+++ b/packages/vendo-server/src/vendo-dir.test.ts
@@ -59,6 +59,16 @@ describe("loadVendoDir", () => {
     expect(() => loadVendoDir(path.join(dir, ".vendo"))).toThrow(/tools\.json/);
   });
 
+  it("fails loud when a file is PRESENT but unreadable (EACCES/EIO class) instead of silently serving defaults", () => {
+    const dir = scratch();
+    // A directory named tools.json makes readFileSync throw EISDIR — the same
+    // not-ENOENT class as EACCES/EIO, reproducible without root/chmod tricks.
+    mkdirSync(path.join(dir, ".vendo/tools.json"), { recursive: true });
+    expect(() => loadVendoDir(path.join(dir, ".vendo"))).toThrow(
+      /tools\.json exists but could not be read/,
+    );
+  });
+
   it("fails loud on invalid JSON in theme.json", () => {
     const dir = scratch();
     mkdirSync(path.join(dir, ".vendo"));

--- a/packages/vendo-server/src/vendo-dir.ts
+++ b/packages/vendo-server/src/vendo-dir.ts
@@ -59,8 +59,15 @@ function readJson(file: string): unknown | undefined {
   let raw: string;
   try {
     raw = readFileSync(file, "utf8");
-  } catch {
-    return undefined; // absent → caller defaults
+  } catch (err) {
+    // Only ENOENT means "absent → caller defaults". Anything else (EACCES,
+    // EIO, EISDIR) is a PRESENT-but-unreadable file — silently serving
+    // defaults would drop the developer's config (empty tool manifest,
+    // default brand) with no signal, so fail boot loudly instead.
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw new Error(
+      `[vendo] ${path.basename(file)} exists but could not be read (${file}): ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
   try {
     return JSON.parse(raw);

--- a/packages/vendo-server/src/webhooks.test.ts
+++ b/packages/vendo-server/src/webhooks.test.ts
@@ -290,6 +290,46 @@ describe("handleComposioWebhook", () => {
     expect(await res.json()).toEqual({ ok: true, fired: 1 });
   });
 
+  it("one failing automation does not block other matches (per-fire isolation)", async () => {
+    const world = await makeWorld();
+    await world.store.create(WORLD_SCOPE, {
+      spec: composioSpec("GMAIL_NEW_GMAIL_MESSAGE"),
+      grants: [],
+    });
+    const { automation: second } = await world.store.create(WORLD_SCOPE, {
+      spec: composioSpec("GMAIL_NEW_GMAIL_MESSAGE"),
+      grants: [],
+    });
+    const connections = createConnectionsStore(CATALOG);
+    await connections.setConnectedAccount("gmail", "acct-123");
+    const realFire = world.runner.fire.bind(world.runner);
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(world.runner, "fire")
+      .mockImplementationOnce(() => Promise.reject(new Error("store blip")))
+      .mockImplementation(realFire);
+
+    const body = JSON.stringify({
+      type: "trigger.fired",
+      timestamp: "2026-07-04T12:00:00.000Z",
+      data: { subject: "hello" },
+      metadata: {
+        id: "ti_iso",
+        trigger_slug: "GMAIL_NEW_GMAIL_MESSAGE",
+        connected_account_id: "acct-123",
+        toolkit_slug: "gmail",
+      },
+    });
+    const res = await handleComposioWebhook(
+      webhookRequest({ id: "msg_iso", body }),
+      { world, connections, env: { COMPOSIO_WEBHOOK_SECRET: SECRET }, nowMs: () => NOW_MS },
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, fired: 1 }); // one succeeded, one failed
+    expect(await world.store.listRuns(WORLD_SCOPE, second.id)).toHaveLength(1);
+    expect(err).toHaveBeenCalled();
+    err.mockRestore();
+  });
+
   it("redelivery (same webhook-id) is a 200 no-op — runner not re-invoked", async () => {
     const world = await makeWorld();
     const { automation } = await world.store.create(WORLD_SCOPE, {

--- a/packages/vendo-server/src/webhooks.ts
+++ b/packages/vendo-server/src/webhooks.ts
@@ -240,19 +240,27 @@ export async function handleComposioWebhook(req: Request, deps: ComposioWebhookD
   });
 
   const occurredAt = new Date(tsSecondsToMs(timestamp)).toISOString();
+  let fired = 0;
   for (const automation of matches) {
     // A redelivery's DuplicateRunError is swallowed INSIDE runner.fire itself
-    // (see runner.ts fireNow) — nothing to catch here.
-    await deps.world.runner.fire(owner.principal, automation.id, {
-      source: "composio",
-      eventId: id,
-      subject: owner.principal.subject,
-      occurredAt,
-      payload,
-    });
+    // (see runner.ts fireNow). Anything else (e.g. a transient store error)
+    // must not starve the remaining matches of this delivery — same isolation
+    // rule as InProcessScheduler.tick().
+    try {
+      await deps.world.runner.fire(owner.principal, automation.id, {
+        source: "composio",
+        eventId: id,
+        subject: owner.principal.subject,
+        occurredAt,
+        payload,
+      });
+      fired += 1;
+    } catch (error) {
+      console.error(`[vendo] composio webhook firing failed for automation ${automation.id}`, error);
+    }
   }
 
-  return Response.json({ ok: true, fired: matches.length });
+  return Response.json({ ok: true, fired });
 }
 
 // `timestamp` was already validated as finite by verifyComposioSignature.

--- a/packages/vendo-store/src/db.test.ts
+++ b/packages/vendo-store/src/db.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { createVendoDatabase, migrateVendoDatabase } from "./db.js";
+import { createPgPool, createVendoDatabase, migrateVendoDatabase } from "./db.js";
+import { vi } from "vitest";
 
 let savedEnv: NodeJS.ProcessEnv;
 let suffix = 0;
@@ -86,5 +87,18 @@ describe("migrateVendoDatabase", () => {
     const handle = await createVendoDatabase({ pglite: { dataDir: uniqueDataDir() } });
     await expect(migrateVendoDatabase(handle)).resolves.toBeUndefined();
     await expect(migrateVendoDatabase(handle)).resolves.toBeUndefined();
+  });
+});
+
+describe("createPgPool", () => {
+  it("survives an idle-connection 'error' event instead of crashing the process", () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const pool = createPgPool("postgres://vendo:vendo@localhost:1/vendo");
+    // pg.Pool re-emits idle client errors on itself; with no listener,
+    // EventEmitter escalates to an uncaught exception and kills the host.
+    expect(() => pool.emit("error", new Error("idle client lost connection"))).not.toThrow();
+    expect(err).toHaveBeenCalled();
+    err.mockRestore();
+    void pool.end();
   });
 });

--- a/packages/vendo-store/src/db.ts
+++ b/packages/vendo-store/src/db.ts
@@ -31,6 +31,18 @@ const registry: Registry = ((globalThis as Record<string, unknown>)["__vendoStor
   migrated: new Map(),
 }) as Registry;
 
+/**
+ * pg.Pool re-emits idle-client errors (backend restart, dropped connection)
+ * on itself; with no 'error' listener Node escalates that to an uncaught
+ * exception and kills the host process. The pool already discards the dead
+ * client — log and keep serving.
+ */
+export function createPgPool(connectionString: string): Pool {
+  const pool = new Pool({ connectionString });
+  pool.on("error", (err) => console.error("[vendo] postgres pool: idle connection error (recovering)", err));
+  return pool;
+}
+
 export function createVendoDatabase(config: VendoDatabaseConfig = {}): Promise<VendoDb> {
   // Precedence: explicit connectionString > explicit pglite > env DATABASE_URL
   // > default PGlite — an explicitly passed `pglite` config must not lose to
@@ -45,7 +57,7 @@ export function createVendoDatabase(config: VendoDatabaseConfig = {}): Promise<V
   if (existing) return existing;
 
   const created: Promise<VendoDb> = (async () => {
-    if (conn) return { kind: "pg" as const, db: drizzlePg(new Pool({ connectionString: conn })), cacheKey };
+    if (conn) return { kind: "pg" as const, db: drizzlePg(createPgPool(conn)), cacheKey };
     const onServerless = SERVERLESS_ENVS.find((e) => process.env[e]);
     if (onServerless) {
       throw new Error(

--- a/scripts/check-node-esm.mjs
+++ b/scripts/check-node-esm.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * Node-ESM loadability smoke test for the publishable library packages.
+ *
+ * For every non-private package under packages/* (plus @vendoai/sandbox-shims,
+ * which is private but ships into the sandbox bundle), dynamically import()s
+ * every runtime entrypoint declared in its package.json "exports" map from the
+ * built dist, in a plain Node subprocess (no bundler, no loader hooks).
+ *
+ * This is the gate for "dists need NodeNext before ENG-198": plain `tsc` under
+ * moduleResolution Bundler emits extensionless relative specifiers that Node
+ * rejects with ERR_MODULE_NOT_FOUND.
+ *
+ * Exit code 0 iff every entrypoint imports cleanly (or is explicitly
+ * allowlisted below as browser-only).
+ */
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const packagesDir = path.join(repoRoot, "packages");
+
+/**
+ * Entrypoints that legitimately cannot load under plain Node because they
+ * touch browser globals at module-evaluation time. Keep this list empty
+ * unless a failure is proven to be a DOM-global access (not a resolution
+ * error) — resolution errors are always bugs.
+ *
+ * Format: "<package-name> <export-subpath>" -> reason string.
+ */
+const BROWSER_ONLY_ALLOWLIST = new Map([
+  // These entrypoints are React UI surfaces meant to be consumed by a bundler
+  // (Next.js, Vite, ...). They side-effect-import stylesheets at module scope
+  // — @vendoai/shell imports its own ./styles.css, and @vendoai/components /
+  // @vendoai/next/client pull in @openuidev/react-ui which imports its CSS —
+  // so plain Node rejects them with ERR_UNKNOWN_FILE_EXTENSION (".css").
+  // That is inherent to CSS-in-ESM, not an extensionless-specifier bug; every
+  // relative JS specifier in these dists carries an explicit extension.
+  ["@vendoai/components .", "CSS side-effect import via @openuidev/react-ui"],
+  ["@vendoai/components ./sandbox", "CSS side-effect import via @openuidev/react-ui"],
+  ["@vendoai/next ./client", "CSS side-effect import via @openuidev/react-ui"],
+  ["@vendoai/shell .", "side-effect import of ./styles.css"],
+]);
+
+function collectRuntimeTargets(exportsField) {
+  // Returns [subpath, relativeTarget][] for runtime JS entrypoints.
+  const targets = [];
+  if (!exportsField || typeof exportsField !== "object") return targets;
+  for (const [subpath, value] of Object.entries(exportsField)) {
+    let target = value;
+    while (target && typeof target === "object") {
+      // Prefer runtime conditions; never "types".
+      target =
+        target.node ?? target.import ?? target.default ?? target.require ?? null;
+    }
+    if (typeof target !== "string") continue;
+    if (!target.endsWith(".js") && !target.endsWith(".mjs") && !target.endsWith(".cjs")) {
+      continue; // e.g. ./styles.css
+    }
+    targets.push([subpath, target]);
+  }
+  return targets;
+}
+
+function tryImport(fileUrl) {
+  const res = spawnSync(
+    process.execPath,
+    ["--input-type=module", "-e", `await import(${JSON.stringify(fileUrl)});`],
+    { encoding: "utf8", timeout: 30_000 }
+  );
+  return {
+    ok: res.status === 0,
+    stderr: (res.stderr ?? "").trim(),
+  };
+}
+
+let checked = 0;
+let failed = 0;
+let skipped = 0;
+
+for (const dir of readdirSync(packagesDir).sort()) {
+  const pkgJsonPath = path.join(packagesDir, dir, "package.json");
+  if (!existsSync(pkgJsonPath)) continue;
+  const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
+  const includeAnyway = pkg.name === "@vendoai/sandbox-shims";
+  if (pkg.private && !includeAnyway) continue;
+
+  const targets = collectRuntimeTargets(pkg.exports);
+  if (targets.length === 0) continue;
+
+  console.log(`\n${pkg.name}`);
+  for (const [subpath, target] of targets) {
+    const allowKey = `${pkg.name} ${subpath}`;
+    const filePath = path.join(packagesDir, dir, target);
+    checked++;
+    if (!existsSync(filePath)) {
+      failed++;
+      console.log(`  FAIL  ${subpath} -> ${target} (dist file missing — run pnpm build)`);
+      continue;
+    }
+    const { ok, stderr } = tryImport(String(new URL(`file://${filePath}`)));
+    if (ok) {
+      console.log(`  PASS  ${subpath} -> ${target}`);
+    } else if (
+      BROWSER_ONLY_ALLOWLIST.has(allowKey) &&
+      stderr.includes("ERR_UNKNOWN_FILE_EXTENSION") &&
+      stderr.includes(".css")
+    ) {
+      // Browser-only entrypoint: the import got past all JS resolution and
+      // died on a stylesheet, which is the documented, expected limit.
+      skipped++;
+      console.log(
+        `  SKIP  ${subpath} -> ${target} (browser-only: ${BROWSER_ONLY_ALLOWLIST.get(allowKey)})`
+      );
+    } else {
+      failed++;
+      const firstError =
+        stderr.split("\n").find((l) => l.includes("Error")) ?? stderr.split("\n")[0] ?? "";
+      console.log(`  FAIL  ${subpath} -> ${target}`);
+      console.log(`        ${firstError.trim()}`);
+    }
+  }
+}
+
+console.log(
+  `\n${checked} entrypoints checked, ${checked - failed - skipped} passed, ${failed} failed, ${skipped} browser-only (allowlisted, JS resolution verified)`
+);
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/check-publish-hygiene.mjs
+++ b/scripts/check-publish-hygiene.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * Publish-hygiene gate for the @vendoai/* packages (pre-ENG-198).
+ * Checks every non-private package in packages/*:
+ *   1. no `dependencies` entry may point at a private workspace package
+ *   2. no `dependencies` entry may use the `file:` protocol
+ *   3. a `files` allowlist must exist (npm pack must not ship src/tests/.turbo)
+ *   4. no package may list the same dep in both dependencies and devDependencies
+ *   5. scoped packages must declare publishConfig.access = "public"
+ * Exits 1 with a per-package report on any violation.
+ */
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const pkgsDir = path.join(root, "packages");
+
+// Known violations awaiting a product decision — keep this list shrinking.
+// (fluidkit was resolved by bundling it into shell's dist — a devDependency
+// file: path is fine; only published `dependencies` are checked.)
+const KNOWN = new Set([]);
+
+const manifests = new Map();
+for (const dir of readdirSync(pkgsDir)) {
+  const p = path.join(pkgsDir, dir, "package.json");
+  if (existsSync(p)) manifests.set(dir, JSON.parse(readFileSync(p, "utf8")));
+}
+const privateNames = new Set(
+  [...manifests.values()].filter((m) => m.private).map((m) => m.name),
+);
+
+const failures = [];
+const known = [];
+for (const [dir, m] of manifests) {
+  if (m.private) continue;
+  const flag = (id, msg) =>
+    (KNOWN.has(id) ? known : failures).push(`${m.name}: ${msg}`);
+
+  for (const [dep, spec] of Object.entries(m.dependencies ?? {})) {
+    if (privateNames.has(dep))
+      flag(`${m.name}:private-dep:${dep}`, `dependency ${dep} is private and would break install`);
+    if (String(spec).startsWith("file:"))
+      flag(`${m.name}:file-dep:${dep.replace(/^@vendoai\//, "")}`, `dependency ${dep} uses a file: path (${spec}) — uninstallable off npm`);
+    if (m.devDependencies?.[dep] !== undefined)
+      flag(`${m.name}:dup-dep:${dep}`, `${dep} in both dependencies and devDependencies`);
+  }
+  if (!Array.isArray(m.files) || m.files.length === 0)
+    flag(`${m.name}:files`, `no "files" allowlist — npm pack would ship src, tests, .turbo logs`);
+  if (m.name.startsWith("@") && m.publishConfig?.access !== "public")
+    flag(`${m.name}:access`, `missing publishConfig.access "public" — first scoped publish fails`);
+}
+
+for (const k of known) console.log(`KNOWN (decision pending): ${k}`);
+if (failures.length) {
+  console.error(`publish hygiene: ${failures.length} violation(s)`);
+  for (const f of failures) console.error(`  FAIL ${f}`);
+  process.exit(1);
+}
+console.log(`publish hygiene: OK (${[...manifests.values()].filter((m) => !m.private).length} publishable packages checked)`);


### PR DESCRIPTION
## What

**Stacked on #60 (merge that first).** The hardening-audit fixes that launch prep doesn't cover — reconciled after #60 landed the overlapping work (CLI bin guard, NodeNext sweep, manifests, Apache-2.0, fluidkit bundling). 10 commits, every behavioral fix TDD'd. Full audit context: bar + 131-finding inventory + decision queue in PR #58.

### Reliability (crash/data-loss blockers)

1. **Scheduler tick per-fire isolation** — one rejecting firing handler was an unhandled rejection (process-fatal on default Node ≥15) and silently starved every other due schedule in the consumed window. Now isolated per firing (`onFireError` hook); one-shot occurrences are consumed regardless of delivery outcome.
2. **Same pattern in the other two fan-outs** (Codex review catch): host-event ingest and the Composio webhook loop; the webhook's `fired` count now reports actual successes.
3. **pg.Pool error listener** — an idle Postgres connection drop crashed the entire host app.

### Provider ladder

4. **Missing optional provider peer degrades instead of 500ing every route** — `OPENAI_API_KEY` without `@ai-sdk/openai` failed state assembly before routing, breaking "missing key hides the surface, nothing errors" on the documented one-key install. Typed `ModelPeerMissingError` now degrades like the keyless state (chat gated, `npm i` hint in server log + chat 503); a misconfigured `VENDO_MODEL` still fails loudly. Quickstart synced.

### Error hygiene (server-side; DOM copy is Yousef-gated, queued separately)

5. **Boot/assembly errors no longer echoed verbatim to callers** (file paths, connection strings) — generic body, full detail in the server log; deliberate `[vendo]`-prefixed developer messages still pass through for local dev requests only.
6. **Route-level error boundary** — a throw inside any route was a framework-level HTML 500 (which the sandbox parsed as JSON → raw SyntaxError); now a generic JSON 500 + logged detail. Next-adapter regression tests pin the contract.
7. **Run failures stream a generic error part** — provider 401s (with key prefixes) and network errors were serialized raw into the UI stream at two points (`createUIMessageStream.onError` and `toUIMessageStream()`'s default serializer); sanitized at the stream boundary so telemetry/policy classification still see real errors.
8. **Unreadable `.vendo` files fail boot loudly** — EACCES/EIO were treated as file-absent, silently serving an empty manifest.

### Gates + residuals

9. `scripts/check-publish-hygiene.mjs` + `scripts/check-node-esm.mjs` — rerunnable release gates. On top of #60 they caught: `vendo-sandbox-shims` missed by the `.js`-extension sweep (only package skipped as private — its dist wasn't Node-loadable), and the CLI's conflicting duplicate typescript pins. Also: the CLI bin guard refactored to an exported `isCliEntrypoint` with regression tests (npm .bin symlink, spaces in paths, missing argv).

## Verification

- `pnpm typecheck` 27/27, `pnpm test` 25/25 on top of #60's tree; both gates green (hygiene: 11 publishable packages OK; ESM: 17/21 + 4 browser-only allowlisted)
- Wave-1 versions of these fixes were verified against real npm-installed tarballs (symlinked `npx vendo --version` prints; `import('@vendoai/server')` resolves 56 exports in plain Node)

No UI changes.