### PR TITLE
Zero-config voice: mint route, packaged createVendoVoice, VendoRoot auto-wire

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -93,3 +93,12 @@ Built zero-config voice for Vendo on branch `yousefh409/voice-zero-config`.
 - `pnpm build` passed.
 
 Notes: shell tests and root build still emit existing warnings (React `act(...)`, no-store provider warnings, Turbopack NFT tracing, and chunk-size warnings), with no failures.
+
+## Rebased
+
+- Rebased `yousefh409/voice-zero-config` onto `origin/main` after PR #53 merged.
+- Kept main's scoped-pin implementation in `@vendoai/shell`'s `VendoThread`; `@vendoai/next` now uses the plain `VendoOverlay` path from main.
+- Confirmed zero-config voice behavior still survives the rebase:
+  - `capabilities.voice === true` and no `voice` prop creates the packaged `createVendoVoice()` driver.
+  - `voice={false}` opts out entirely.
+  - A custom `VoiceDriver` prop wins over packaged voice.

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -58,3 +58,38 @@ Verification:
 - Preserved existing npm and pnpm override objects while merging only Vendo tarball keys; unsupported override shapes now skip with manual instructions instead of dropping data.
 - Preflighted `fluidkit` and package.json rewrites before target writes, then staged tarballs before replacing `vendor/`.
 - Updated the generated Events README example to show the full `tools.json` shape and name `ingestVendoEvent()` plus `POST /api/vendo/events/ingest`.
+
+## Zero-Config Voice
+
+Built zero-config voice for Vendo on branch `yousefh409/voice-zero-config`.
+
+## What changed
+
+- Added `POST {basePath}/voice/session` in `@vendoai/server`.
+  - Uses the same `resolvePrincipal` request guard as other spend routes.
+  - Returns `503` when `OPENAI_API_KEY` is absent.
+  - Mints OpenAI Realtime client secrets with `OPENAI_REALTIME_MODEL ?? "gpt-realtime"` and `OPENAI_REALTIME_VOICE ?? "marin"`.
+  - Added route-table tests for mint success, upstream failure, missing key, and guarded production requests.
+
+- Added `createVendoVoice()` in `@vendoai/next/client`.
+  - Fetches `POST {basePath}/voice/session` for Realtime credentials.
+  - Includes `show_table`, `show_key_value`, and `show_money_flow`.
+  - `show_money_flow` renders the prewired `Sankey` generated view.
+  - Ported the demo-bank source-declaration/replay-registry data binding for `show_table`; valid sources produce refreshable `queries`, invalid sources degrade to snapshots.
+  - Includes `list_integrations` and `request_connect` only when the root passes the integrations capability.
+  - Adapts manifest host tools through `annotationsToTier` and `executeHostToolCall`.
+  - Builds voice instructions with product persona, capability summary, English (US) default, show-before-say rule, and host extras.
+
+- Updated `VendoRoot`.
+  - When `capabilities.voice` is true and no `voice` prop is supplied, it creates the packaged voice driver automatically.
+  - `voice={false}` opts out.
+  - A custom `VoiceDriver` overrides packaged voice.
+
+## Validation
+
+- `pnpm --filter @vendoai/server test` passed.
+- `pnpm --filter @vendoai/next test` passed.
+- `pnpm --filter @vendoai/shell test` passed.
+- `pnpm build` passed.
+
+Notes: shell tests and root build still emit existing warnings (React `act(...)`, no-store provider warnings, Turbopack NFT tracing, and chunk-size warnings), with no failures.

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -102,3 +102,23 @@ Notes: shell tests and root build still emit existing warnings (React `act(...)`
   - `capabilities.voice === true` and no `voice` prop creates the packaged `createVendoVoice()` driver.
   - `voice={false}` opts out entirely.
   - A custom `VoiceDriver` prop wins over packaged voice.
+
+## FIXED-ROUND-2
+
+- Added guarded `GET|POST {basePath}/voice/tools` in `@vendoai/server` so packaged voice can list and execute CONNECTED Composio tools server-side, with tier mapping and realtime-sized output capping.
+- Hardened `/voice/session` mint failures: upstream bodies are not logged or returned; responses use `{ error: "mint failed" }`.
+- Bound OpenAI Realtime mints to the guarded principal with a stable privacy-preserving `OpenAI-Safety-Identifier`.
+- Validated `show_money_flow` against the Sankey constraints before emitting a generated view; invalid inputs return a repairable tool error and no view.
+- Added replay-registry unregister handles and packaged-driver cleanup on teardown/unmount/tool replacement.
+- Confirmed zero-config voice behavior after rebasing onto `origin/main` with PR #54/#55:
+  - `capabilities.voice === true` and no `voice` prop creates the packaged driver.
+  - `voice={false}` opts out entirely.
+  - A custom `VoiceDriver` still wins over packaged voice.
+
+Verification after rebase:
+- `pnpm --filter @vendoai/server test`: passed, 29 files / 259 tests.
+- `pnpm --filter @vendoai/next test`: passed, 6 files / 83 tests.
+- `pnpm --filter @vendoai/shell test`: passed, 61 files / 335 tests.
+- `pnpm build`: passed, 19 of 19 turbo tasks.
+
+Notes: the suites/build still emit existing React `act(...)`, no-store provider, bundle-size, Turbopack NFT trace, and turbo output warnings, with no failures.

--- a/packages/vendo-next/src/client/index.ts
+++ b/packages/vendo-next/src/client/index.ts
@@ -12,3 +12,4 @@ export { createServerIntegrations } from "./integrations";
 export { createServerVendoStore } from "./server-store";
 export { createRunQuery, type RunQuery } from "./run-query";
 export { runConnectFlow, type ConnectOutcome } from "./connect-flow";
+export { createVendoVoice, type CreateVendoVoiceOptions } from "./voice";

--- a/packages/vendo-next/src/client/vendo-root.test.tsx
+++ b/packages/vendo-next/src/client/vendo-root.test.tsx
@@ -183,6 +183,24 @@ describe("VendoRoot", () => {
     expect(screen.queryByLabelText("Start voice session")).toBeNull();
   });
 
+  it("disposes the packaged voice driver on unmount", async () => {
+    const dispose = vi.fn();
+    vi.spyOn(voiceModule, "createVendoVoice").mockReturnValue({
+      ...customVoice(),
+      dispose,
+    } as voiceModule.DisposableVoiceDriver);
+    vi.stubGlobal("fetch", stubFetch({ chat: true, integrations: false, voice: true }));
+    const view = render(
+      <VendoRoot productName="Acme">
+        <div />
+      </VendoRoot>,
+    );
+
+    await waitFor(() => expect(voiceModule.createVendoVoice).toHaveBeenCalled());
+    view.unmount();
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
   it("uses a custom VoiceDriver even when packaged voice capability is unavailable", async () => {
     const start = vi.fn();
     vi.stubGlobal("fetch", stubFetch({ chat: true, integrations: false, voice: false }));

--- a/packages/vendo-next/src/client/vendo-root.test.tsx
+++ b/packages/vendo-next/src/client/vendo-root.test.tsx
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import * as shell from "@vendoai/shell";
 import * as serverStore from "./server-store";
+import * as voiceModule from "./voice";
+import type { VoiceDriver } from "@vendoai/shell";
 import { VendoRoot } from "./vendo-root";
 
 function stubFetch(capabilities: { chat: boolean; integrations: boolean; voice: boolean; storage?: boolean }) {
@@ -20,7 +22,35 @@ function stubFetch(capabilities: { chat: boolean; integrations: boolean; voice: 
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
+
+function customVoice(start = vi.fn()): VoiceDriver {
+  return {
+    start(emit, init) {
+      start(emit, init);
+      return {
+        mute() {},
+        end() {},
+        approve() {},
+        decline() {},
+        stop() {},
+      };
+    },
+  };
+}
+
+const manifestTools = {
+  tools: [
+    {
+      name: "list_accounts",
+      description: "List accounts",
+      inputSchema: { type: "object", properties: {}, required: [] },
+      annotations: { mutating: false, dangerous: false, idempotent: true },
+      binding: { type: "http", method: "GET", path: "/api/accounts" },
+    },
+  ],
+};
 
 describe("VendoRoot", () => {
   it("renders children, the launcher pill and fetches capabilities", async () => {
@@ -115,6 +145,56 @@ describe("VendoRoot", () => {
     await waitFor(() => expect(screen.getByTestId("app5")).toBeDefined());
     expect(serverStoreSpy).not.toHaveBeenCalled();
     serverStoreSpy.mockRestore();
+  });
+
+  it("auto-wires packaged voice when capabilities report voice:true and no voice prop is passed", async () => {
+    const createSpy = vi.spyOn(voiceModule, "createVendoVoice");
+    vi.stubGlobal("fetch", stubFetch({ chat: true, integrations: true, voice: true }));
+    render(
+      <VendoRoot productName="Acme" basePath="/custom/vendo" tools={manifestTools}>
+        <div />
+      </VendoRoot>,
+    );
+
+    await waitFor(() =>
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          basePath: "/custom/vendo",
+          productName: "Acme",
+          integrations: true,
+          hostTools: [expect.objectContaining({ name: "list_accounts" })],
+        }),
+      ),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /ask acme/i }));
+    expect(await screen.findByLabelText("Start voice session")).toBeDefined();
+  });
+
+  it("keeps voice disabled when voice={false} even if the server reports voice:true", async () => {
+    vi.stubGlobal("fetch", stubFetch({ chat: true, integrations: true, voice: true }));
+    render(
+      <VendoRoot productName="Acme" voice={false}>
+        <div />
+      </VendoRoot>,
+    );
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /ask acme/i })).toBeDefined());
+    fireEvent.click(screen.getByRole("button", { name: /ask acme/i }));
+    expect(screen.queryByLabelText("Start voice session")).toBeNull();
+  });
+
+  it("uses a custom VoiceDriver even when packaged voice capability is unavailable", async () => {
+    const start = vi.fn();
+    vi.stubGlobal("fetch", stubFetch({ chat: true, integrations: false, voice: false }));
+    render(
+      <VendoRoot productName="Acme" voice={customVoice(start)}>
+        <div />
+      </VendoRoot>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /ask acme/i }));
+    fireEvent.click(await screen.findByLabelText("Start voice session"));
+    expect(start).toHaveBeenCalledOnce();
   });
 
   it("tolerates an invalid theme by falling back to the default brand", () => {

--- a/packages/vendo-next/src/client/vendo-root.tsx
+++ b/packages/vendo-next/src/client/vendo-root.tsx
@@ -39,6 +39,7 @@ import { VendoConnectNode } from "./connect-node";
 import { createServerIntegrations } from "./integrations";
 import { createServerNotifications } from "./notifications";
 import { createRunQuery } from "./run-query";
+import { createVendoVoice } from "./voice";
 import type { VoiceDriver } from "@vendoai/shell";
 
 export interface VendoRootProps {
@@ -61,10 +62,10 @@ export interface VendoRootProps {
   /** Corner for the toast stack. Default "bottom-left" (the launcher pill
    *  owns bottom-right). */
   toastPlacement?: VendoToastsProps["placement"];
-  /** Realtime voice driver (ENG-185). When provided, the overlay's composer
-   *  grows a mic. Build one with createRealtimeVoiceDriver from
-   *  @vendoai/shell against a host session-mint endpoint. */
-  voice?: VoiceDriver;
+  /** Realtime voice driver (ENG-185). Omit for zero-config voice when the
+   *  handler reports `voice:true`; pass `false` to opt out, or a custom
+   *  driver to override the packaged OpenAI Realtime wiring. */
+  voice?: VoiceDriver | false;
   children: ReactNode;
 }
 
@@ -178,6 +179,17 @@ export function VendoRoot({
   );
 
   const runQuery = useMemo(() => createRunQuery(basePath, manifestTools), [basePath, manifestTools]);
+  const effectiveVoice = useMemo<VoiceDriver | undefined>(() => {
+    if (voice === false) return undefined;
+    if (voice) return voice;
+    if (!capabilities?.voice) return undefined;
+    return createVendoVoice({
+      basePath,
+      productName,
+      hostTools: hostToolDefs,
+      integrations: capabilities.integrations,
+    });
+  }, [voice, capabilities?.voice, capabilities?.integrations, basePath, productName, hostToolDefs]);
 
   const renderNode = useMemo(() => {
     const render = (node: UINode): ReactNode => {
@@ -236,7 +248,7 @@ export function VendoRoot({
               onOpenChange={setOpen}
               {...(greeting !== undefined ? { greeting } : {})}
               {...(suggestions !== undefined ? { suggestions } : {})}
-              {...(voice !== undefined && capabilities?.voice ? { voice } : {})}
+              {...(effectiveVoice ? { voice: effectiveVoice } : {})}
             />
           )}
           {chatEnabled && launcher === "pill" && !open && (

--- a/packages/vendo-next/src/client/vendo-root.tsx
+++ b/packages/vendo-next/src/client/vendo-root.tsx
@@ -191,6 +191,13 @@ export function VendoRoot({
     });
   }, [voice, capabilities?.voice, capabilities?.integrations, basePath, productName, hostToolDefs]);
 
+  useEffect(
+    () => () => {
+      (effectiveVoice as (VoiceDriver & { dispose?: () => void }) | undefined)?.dispose?.();
+    },
+    [effectiveVoice],
+  );
+
   const renderNode = useMemo(() => {
     const render = (node: UINode): ReactNode => {
       // The one host-rendered, trusted exception: the Connect OAuth card.

--- a/packages/vendo-next/src/client/voice.test.ts
+++ b/packages/vendo-next/src/client/voice.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { replayRegistry } from "@vendoai/shell";
+import type { GeneratedPayload, HostToolDefinition } from "@vendoai/core";
+import { __voiceTesting } from "./voice";
+
+const { createVoiceInternals } = __voiceTesting;
+
+const readAccounts: HostToolDefinition = {
+  name: "list_accounts",
+  description: "List the user's accounts",
+  inputSchema: { type: "object", properties: {}, required: [] },
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  http: { method: "get", path: "/api/accounts", params: [], hasBody: false },
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("createVendoVoice internals", () => {
+  it("builds a data-bound table payload when source matches the replay cache", () => {
+    const internals = createVoiceInternals();
+    const raw = { ok: true, data: { rows: [{ merchant: "Cafe", amount: 42 }] } };
+    replayRegistry.register("listTransactionsForPackagedVoice", async () => raw);
+    internals.recordResult("listTransactionsForPackagedVoice", { limit: 10 }, raw);
+
+    const node = internals.tableView({
+      title: "Recent spend",
+      columns: [
+        { key: "merchant", label: "Merchant" },
+        { key: "amount", label: "Amount" },
+      ],
+      rows: raw.data.rows,
+      source: {
+        tool: "listTransactionsForPackagedVoice",
+        input: { limit: 10 },
+        rowsPath: "/data/rows",
+      },
+    });
+
+    const payload = (node as { payload: GeneratedPayload }).payload;
+    expect(payload.queries).toEqual([
+      { path: "/source", tool: "listTransactionsForPackagedVoice", input: { limit: 10 } },
+    ]);
+    const table = payload.nodes.find((n) => n.component === "Table");
+    expect(table?.props?.rows).toEqual({ $path: "/source/data/rows" });
+    expect(payload.data).toEqual({ source: raw });
+  });
+
+  it("renders show_money_flow as a prewired Sankey generated view", () => {
+    const internals = createVoiceInternals();
+    const node = internals.moneyFlowView({
+      title: "Where money went",
+      nodes: [
+        { id: "income", label: "Income" },
+        { id: "rent", label: "Rent" },
+      ],
+      links: [{ source: "income", target: "rent", value: 2100 }],
+    });
+
+    const payload = (node as { payload: GeneratedPayload }).payload;
+    expect(payload.root).toBe("sankey");
+    expect(payload.nodes).toEqual([
+      {
+        id: "sankey",
+        component: "Sankey",
+        source: "prewired",
+        props: {
+          title: "Where money went",
+          nodes: [
+            { id: "income", label: "Income" },
+            { id: "rent", label: "Rent" },
+          ],
+          links: [{ source: "income", target: "rent", value: 2100 }],
+        },
+      },
+    ]);
+  });
+
+  it("only includes integration tools when the integrations capability is enabled", async () => {
+    expect(createVoiceInternals({ integrations: false }).tools.map((t) => t.name)).not.toContain(
+      "list_integrations",
+    );
+
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ enabled: true, integrations: [{ id: "gmail", connected: false }] })),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const internals = createVoiceInternals({ basePath: "/custom/vendo", integrations: true });
+
+    const list = internals.tools.find((t) => t.name === "list_integrations");
+    expect(list).toBeDefined();
+    await expect(list?.execute({})).resolves.toEqual({
+      enabled: true,
+      integrations: [{ id: "gmail", connected: false }],
+    });
+    expect(fetchMock).toHaveBeenCalledWith("/custom/vendo/integrations", { cache: "no-store" });
+
+    const connect = internals.tools.find((t) => t.name === "request_connect");
+    const view = connect?.toView?.({ toolkit: "gmail", reason: "Read invoices" }, {});
+    expect(view).toMatchObject({
+      kind: "component",
+      source: "host",
+      name: "Connect",
+      props: { toolkit: "gmail", reason: "Read invoices" },
+    });
+  });
+
+  it("composes voice instructions from product persona, host tools, and fixed extras", () => {
+    const internals = createVoiceInternals({
+      productName: "Ledger",
+      hostTools: [readAccounts],
+      instructionsExtra: ["Always call dollars USD."],
+    });
+
+    expect(internals.instructions).toContain("You are Ledger's voice assistant");
+    expect(internals.instructions).toContain("Read the app's own data: list_accounts.");
+    expect(internals.instructions).toContain("Use English (US) by default");
+    expect(internals.instructions).toContain("Never claim something is on screen");
+    expect(internals.instructions).toContain("Always call dollars USD.");
+    expect(internals.instructions).not.toContain("show_table");
+  });
+});

--- a/packages/vendo-next/src/client/voice.test.ts
+++ b/packages/vendo-next/src/client/voice.test.ts
@@ -4,6 +4,7 @@ import type { GeneratedPayload, HostToolDefinition } from "@vendoai/core";
 import { __voiceTesting } from "./voice";
 
 const { createVoiceInternals } = __voiceTesting;
+const disposers: Array<() => void> = [];
 
 const readAccounts: HostToolDefinition = {
   name: "list_accounts",
@@ -19,14 +20,21 @@ const readAccounts: HostToolDefinition = {
 };
 
 afterEach(() => {
+  for (const dispose of disposers.splice(0)) dispose();
   vi.unstubAllGlobals();
 });
 
+function trackedInternals(options?: Parameters<typeof createVoiceInternals>[0]) {
+  const internals = createVoiceInternals(options);
+  disposers.push(() => internals.dispose());
+  return internals;
+}
+
 describe("createVendoVoice internals", () => {
   it("builds a data-bound table payload when source matches the replay cache", () => {
-    const internals = createVoiceInternals();
+    const internals = trackedInternals();
     const raw = { ok: true, data: { rows: [{ merchant: "Cafe", amount: 42 }] } };
-    replayRegistry.register("listTransactionsForPackagedVoice", async () => raw);
+    disposers.push(replayRegistry.register("listTransactionsForPackagedVoice", async () => raw));
     internals.recordResult("listTransactionsForPackagedVoice", { limit: 10 }, raw);
 
     const node = internals.tableView({
@@ -53,7 +61,7 @@ describe("createVendoVoice internals", () => {
   });
 
   it("renders show_money_flow as a prewired Sankey generated view", () => {
-    const internals = createVoiceInternals();
+    const internals = trackedInternals();
     const node = internals.moneyFlowView({
       title: "Where money went",
       nodes: [
@@ -82,8 +90,24 @@ describe("createVendoVoice internals", () => {
     ]);
   });
 
+  it("returns a repairable tool error and no view for invalid show_money_flow input", async () => {
+    const internals = trackedInternals();
+    const tool = internals.tools.find((t) => t.name === "show_money_flow");
+    const input = {
+      nodes: [{ id: "income", label: "Income" }],
+      links: [{ source: "income", target: "missing", value: -1 }],
+    };
+
+    await expect(tool?.execute(input)).resolves.toMatchObject({
+      shown: false,
+      error: expect.any(String),
+      repair: expect.stringContaining("show_money_flow"),
+    });
+    expect(tool?.toView?.(input, { shown: false })).toBeUndefined();
+  });
+
   it("only includes integration tools when the integrations capability is enabled", async () => {
-    expect(createVoiceInternals({ integrations: false }).tools.map((t) => t.name)).not.toContain(
+    expect(trackedInternals({ integrations: false }).tools.map((t) => t.name)).not.toContain(
       "list_integrations",
     );
 
@@ -91,7 +115,7 @@ describe("createVendoVoice internals", () => {
       new Response(JSON.stringify({ enabled: true, integrations: [{ id: "gmail", connected: false }] })),
     );
     vi.stubGlobal("fetch", fetchMock);
-    const internals = createVoiceInternals({ basePath: "/custom/vendo", integrations: true });
+    const internals = trackedInternals({ basePath: "/custom/vendo", integrations: true });
 
     const list = internals.tools.find((t) => t.name === "list_integrations");
     expect(list).toBeDefined();
@@ -111,8 +135,66 @@ describe("createVendoVoice internals", () => {
     });
   });
 
+  it("fetches connected integration voice tools, registers read replay, and records session results", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/voice/tools") && init?.method !== "POST") {
+        return new Response(
+          JSON.stringify({
+            tools: [
+              {
+                name: "GMAIL_FETCH_EMAILS",
+                description: "Fetch emails",
+                parameters: { type: "object", properties: { query: { type: "string" } } },
+                tier: "read",
+              },
+            ],
+          }),
+        );
+      }
+      if (url.endsWith("/voice/tools") && init?.method === "POST") {
+        return new Response(JSON.stringify({ result: { data: { rows: [{ subject: "Invoice" }] } } }));
+      }
+      return new Response("{}", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const internals = trackedInternals({ basePath: "/custom/vendo", integrations: true });
+
+    const session = await internals.createIntegrationVoiceTools();
+    disposers.push(session.unregister);
+    const gmail = session.tools.find((t) => t.name === "GMAIL_FETCH_EMAILS");
+    expect(gmail?.tier).toBe("read");
+    expect(replayRegistry.has("GMAIL_FETCH_EMAILS")).toBe(true);
+
+    const output = await gmail?.execute({ query: "invoice" });
+    expect(output).toEqual({ data: { rows: [{ subject: "Invoice" }] } });
+    const view = internals.tableView({
+      columns: [{ key: "subject", label: "Subject" }],
+      rows: [{ subject: "Invoice" }],
+      source: { tool: "GMAIL_FETCH_EMAILS", input: { query: "invoice" }, rowsPath: "/data/rows" },
+    }) as { payload: GeneratedPayload };
+    expect(view.payload.queries).toEqual([
+      { path: "/source", tool: "GMAIL_FETCH_EMAILS", input: { query: "invoice" } },
+    ]);
+
+    session.unregister();
+    expect(replayRegistry.has("GMAIL_FETCH_EMAILS")).toBe(false);
+  });
+
+  it("keeps the latest read-tool replay registration when an older driver is disposed", async () => {
+    const first = trackedInternals({ hostTools: [readAccounts] });
+    const second = trackedInternals({ hostTools: [readAccounts] });
+
+    expect(replayRegistry.has("list_accounts")).toBe(true);
+    first.dispose();
+    expect(replayRegistry.has("list_accounts")).toBe(true);
+
+    second.dispose();
+    expect(replayRegistry.has("list_accounts")).toBe(false);
+  });
+
   it("composes voice instructions from product persona, host tools, and fixed extras", () => {
-    const internals = createVoiceInternals({
+    const internals = trackedInternals({
       productName: "Ledger",
       hostTools: [readAccounts],
       instructionsExtra: ["Always call dollars USD."],

--- a/packages/vendo-next/src/client/voice.ts
+++ b/packages/vendo-next/src/client/voice.ts
@@ -1,0 +1,457 @@
+"use client";
+
+/**
+ * Zero-config voice driver for `@vendoai/next/client` (ENG-185).
+ *
+ * Hosts that use `createVendoHandler()` and set OPENAI_API_KEY get the same
+ * topology as chat: the server only mints an ephemeral Realtime secret, while
+ * host API tools execute in this browser on the user's existing session.
+ */
+import {
+  annotationsToTier,
+  createRealtimeVoiceDriver,
+  replayRegistry,
+  type VoiceDriver,
+  type VoiceToolDef,
+} from "@vendoai/shell";
+import {
+  buildVoiceInstructions,
+  capabilitySummary,
+  executeHostToolCall,
+  type GeneratedPayload,
+  type HostToolDefinition,
+  type ToolSummaryInput,
+  type UINode,
+} from "@vendoai/core";
+
+export interface CreateVendoVoiceOptions {
+  basePath?: string;
+  productName?: string;
+  hostTools?: HostToolDefinition[];
+  instructionsExtra?: string[];
+  /** Whether to expose the handler-backed integrations tools in voice. */
+  integrations?: boolean;
+}
+
+interface SourceDecl {
+  tool?: string;
+  input?: unknown;
+  rowsPath?: string;
+}
+
+interface VoiceInternals {
+  tools: VoiceToolDef[];
+  instructions: string;
+  greeting: string;
+  clearResults(): void;
+  recordResult(tool: string, input: unknown, output: unknown): void;
+  tableView(input: unknown): UINode | undefined;
+  keyValueView(input: unknown): UINode | undefined;
+  moneyFlowView(input: unknown): UINode | undefined;
+}
+
+const SESSION_RESULTS_MAX = 32;
+
+const SOURCE_PARAM = {
+  type: "object",
+  description:
+    "Where the shown data came from, when it came from ONE tool call you made: the tool name, the exact input you passed, and the JSON pointer to the row array inside that tool's result (e.g. '/data/transactions'). Use raw field names as column keys when declaring this. Makes the view refreshable when pinned.",
+  properties: {
+    tool: { type: "string" },
+    input: { type: "object" },
+    rowsPath: { type: "string" },
+  },
+  required: ["tool", "rowsPath"],
+} as const;
+
+const MECHANIC_TOOLS = new Set([
+  "show_table",
+  "show_key_value",
+  "show_money_flow",
+  "list_integrations",
+  "request_connect",
+]);
+
+function cleanName(productName: string | undefined): string {
+  const trimmed = productName?.trim();
+  return trimmed ? trimmed : "Assistant";
+}
+
+/** Key-order-stable stringify for matching source declarations to cached calls. */
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`);
+    return `{${entries.join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+const resultKey = (tool: string, input: unknown): string =>
+  `${tool}:${stableStringify(input ?? {})}`;
+
+/** Resolve a JSON pointer ("/data/transactions") into a value, or undefined. */
+function resolvePointer(value: unknown, pointer: string): unknown {
+  if (pointer === "" || pointer === "/") return value;
+  let current: unknown = value;
+  for (const raw of pointer.split("/").slice(1)) {
+    const key = raw.replace(/~1/g, "/").replace(/~0/g, "~");
+    if (Array.isArray(current)) current = current[Number(key)];
+    else if (current && typeof current === "object")
+      current = (current as Record<string, unknown>)[key];
+    else return undefined;
+  }
+  return current;
+}
+
+function genNode(id: string, payload: GeneratedPayload): UINode {
+  return { id, kind: "generated", payload };
+}
+
+function createVoiceInternals(options: CreateVendoVoiceOptions = {}): VoiceInternals {
+  const basePath = options.basePath ?? "/api/vendo";
+  const productName = cleanName(options.productName);
+  const sessionResults = new Map<string, unknown>();
+  let viewSeq = 0;
+  const nextId = (prefix: string) => `voice-${prefix}-${++viewSeq}`;
+
+  function recordResult(tool: string, input: unknown, output: unknown): void {
+    const key = resultKey(tool, input);
+    if (sessionResults.size >= SESSION_RESULTS_MAX && !sessionResults.has(key)) {
+      const oldest = sessionResults.keys().next().value as string | undefined;
+      if (oldest !== undefined) sessionResults.delete(oldest);
+    }
+    sessionResults.set(key, output);
+  }
+
+  function matchSource(
+    source: SourceDecl | undefined,
+    columns: Array<{ key: string }>,
+  ): { raw: unknown; tool: string; input: Record<string, unknown>; rowsPath: string } | undefined {
+    if (!source?.tool || typeof source.rowsPath !== "string") return undefined;
+    if (!replayRegistry.has(source.tool)) return undefined;
+    const key = resultKey(source.tool, source.input);
+    if (!sessionResults.has(key)) return undefined;
+    const raw = sessionResults.get(key);
+    const rows = resolvePointer(raw, source.rowsPath);
+    if (!Array.isArray(rows)) return undefined;
+    if (rows.length > 0) {
+      const scalar = (v: unknown) =>
+        v === null || ["string", "number", "boolean"].includes(typeof v);
+      for (const row of rows) {
+        if (!row || typeof row !== "object") return undefined;
+        const record = row as Record<string, unknown>;
+        if (!columns.every((c) => c.key in record && scalar(record[c.key]))) return undefined;
+      }
+    }
+    const input =
+      source.input && typeof source.input === "object" && !Array.isArray(source.input)
+        ? (source.input as Record<string, unknown>)
+        : {};
+    return { raw, tool: source.tool, input, rowsPath: source.rowsPath };
+  }
+
+  function tableView(input: unknown): UINode | undefined {
+    const { title, columns, rows, source } = (input ?? {}) as {
+      title?: string;
+      columns?: Array<{ key: string; label: string }>;
+      rows?: Array<Record<string, unknown>>;
+      source?: SourceDecl;
+    };
+    if (!columns?.length || !rows) return undefined;
+
+    const matched = matchSource(source, columns);
+    const tableProps = matched
+      ? { columns, rows: { $path: `/source${matched.rowsPath}` } }
+      : { columns, rows };
+    return genNode(nextId("table"), {
+      formatVersion: "vendo-genui/v1",
+      root: "root",
+      nodes: [
+        { id: "root", component: "Stack", children: title ? ["title", "table"] : ["table"] },
+        ...(title ? [{ id: "title", component: "Text", props: { text: title } }] : []),
+        { id: "table", component: "Table", source: "prewired", props: tableProps },
+      ],
+      ...(matched
+        ? {
+            data: { source: matched.raw },
+            queries: [{ path: "/source", tool: matched.tool, input: matched.input }],
+          }
+        : {}),
+    });
+  }
+
+  function keyValueView(input: unknown): UINode | undefined {
+    const { title, rows } = (input ?? {}) as {
+      title?: string;
+      rows?: Array<{ label: string; value: string; emphasis?: boolean }>;
+    };
+    if (!rows?.length) return undefined;
+    return genNode(nextId("kv"), {
+      formatVersion: "vendo-genui/v1",
+      root: "root",
+      nodes: [
+        { id: "root", component: "Stack", children: ["kv"] },
+        { id: "kv", component: "KeyValue", source: "prewired", props: { title, rows } },
+      ],
+    });
+  }
+
+  function moneyFlowView(input: unknown): UINode | undefined {
+    const { title, nodes, links } = (input ?? {}) as {
+      title?: string;
+      nodes?: Array<{ id: string; label: string }>;
+      links?: Array<{ source: string; target: string; value: number }>;
+    };
+    if (!nodes?.length || !links?.length) return undefined;
+    return genNode(nextId("money-flow"), {
+      formatVersion: "vendo-genui/v1",
+      root: "sankey",
+      nodes: [
+        {
+          id: "sankey",
+          component: "Sankey",
+          source: "prewired",
+          props: { title, nodes, links },
+        },
+      ],
+    });
+  }
+
+  const displayTools: VoiceToolDef[] = [
+    {
+      name: "show_table",
+      description:
+        "Display structured rows (transactions, comparisons) as a table on screen. Use this to SHOW data, then speak only the headline. Declare `source` when the rows came from a tool call so the view stays refreshable.",
+      parameters: {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          columns: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: { key: { type: "string" }, label: { type: "string" } },
+              required: ["key", "label"],
+            },
+          },
+          rows: { type: "array", items: { type: "object" } },
+          source: SOURCE_PARAM,
+        },
+        required: ["columns", "rows"],
+      },
+      tier: "read",
+      execute: async () => ({ shown: true }),
+      toView: (input) => tableView(input),
+    },
+    {
+      name: "show_key_value",
+      description:
+        "Display a labelled summary (a receipt, account overview, or status summary) as label/value rows on screen. Use `emphasis: true` on the row that matters.",
+      parameters: {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          rows: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                label: { type: "string" },
+                value: { type: "string" },
+                emphasis: { type: "boolean" },
+              },
+              required: ["label", "value"],
+            },
+          },
+          source: SOURCE_PARAM,
+        },
+        required: ["rows"],
+      },
+      tier: "read",
+      execute: async () => ({ shown: true }),
+      toView: (input) => keyValueView(input),
+    },
+    {
+      name: "show_money_flow",
+      description:
+        "Display a Sankey / money-flow diagram on screen. Use for sankey, money-flow, cash-flow, or where-did-money-go asks where value moves between categories.",
+      parameters: {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          nodes: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: { id: { type: "string" }, label: { type: "string" } },
+              required: ["id", "label"],
+            },
+          },
+          links: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                source: { type: "string" },
+                target: { type: "string" },
+                value: { type: "number" },
+              },
+              required: ["source", "target", "value"],
+            },
+          },
+        },
+        required: ["nodes", "links"],
+      },
+      tier: "read",
+      execute: async () => ({ shown: true }),
+      toView: (input) => moneyFlowView(input),
+    },
+  ];
+
+  const integrationTools: VoiceToolDef[] = options.integrations
+    ? [
+        {
+          name: "list_integrations",
+          description: "List the available integrations and whether each is connected.",
+          parameters: { type: "object", properties: {} },
+          tier: "read",
+          execute: async () => {
+            const res = await fetch(`${basePath}/integrations`, { cache: "no-store" });
+            const json = (await res.json().catch(() => ({}))) as unknown;
+            if (!res.ok) throw new Error(`list integrations failed (${res.status})`);
+            return json;
+          },
+        },
+        {
+          name: "request_connect",
+          description:
+            "Put a Connect card on screen so the user can link an integration. Only use after list_integrations shows it is available and not already connected.",
+          parameters: {
+            type: "object",
+            properties: {
+              toolkit: { type: "string", description: "integration id, e.g. gmail, slack, notion" },
+              reason: { type: "string", description: "one short line on why" },
+            },
+            required: ["toolkit"],
+          },
+          tier: "read",
+          execute: async () => ({ shown: true, note: "Card is on screen; the user taps Connect to finish." }),
+          toView: (input) => {
+            const { toolkit, reason } = (input ?? {}) as { toolkit?: string; reason?: string };
+            if (!toolkit) return undefined;
+            return {
+              id: nextId("connect"),
+              kind: "component",
+              source: "host",
+              name: "Connect",
+              props: { toolkit, reason },
+            };
+          },
+        },
+      ]
+    : [];
+
+  const hostVoiceTools: VoiceToolDef[] = (options.hostTools ?? []).map((def) => {
+    const tier = annotationsToTier(def.annotations);
+    const run = (input: unknown) =>
+      executeHostToolCall(def, (input ?? {}) as Record<string, unknown>);
+    if (tier === "read") replayRegistry.register(def.name, run);
+    return {
+      name: def.name,
+      description: def.description,
+      parameters: def.inputSchema,
+      tier,
+      execute: async (input) => {
+        const output = await run(input);
+        if (tier === "read") recordResult(def.name, input, output);
+        return output;
+      },
+    };
+  });
+
+  const tools = [...displayTools, ...integrationTools, ...hostVoiceTools];
+  const instructions = buildInstructions(productName, tools, options.instructionsExtra ?? []);
+  const greeting = `Hi, I'm ${productName}'s voice assistant; what can I help with?`;
+
+  return {
+    tools,
+    instructions,
+    greeting,
+    clearResults: () => sessionResults.clear(),
+    recordResult,
+    tableView,
+    keyValueView,
+    moneyFlowView,
+  };
+}
+
+function voiceToolSummary(tools: VoiceToolDef[]): ToolSummaryInput[] {
+  return tools
+    .filter((t) => !MECHANIC_TOOLS.has(t.name))
+    .map((t) => ({
+      name: t.name,
+      description: t.description,
+      tier: t.tier === "read" ? "read" : t.tier === "critical" ? "critical" : "act",
+      source: "host",
+    }));
+}
+
+function buildInstructions(productName: string, tools: VoiceToolDef[], extras: string[]): string {
+  return buildVoiceInstructions({
+    persona: [
+      `You are ${productName}'s voice assistant. Warm, brisk, and plain-spoken.`,
+      `Use the available tools to help the user operate ${productName}; tool results are the source of truth.`,
+    ].join(" "),
+    toolSummary: capabilitySummary(voiceToolSummary(tools)),
+    extras: [
+      "Use English (US) by default unless the user explicitly switches languages.",
+      "Never claim something is on screen without calling a show_* tool first.",
+      ...extras,
+    ],
+  });
+}
+
+async function getSession(basePath: string): Promise<{ clientSecret: string; model?: string }> {
+  const res = await fetch(`${basePath}/voice/session`, {
+    method: "POST",
+    cache: "no-store",
+  });
+  const json = (await res.json().catch(() => ({}))) as {
+    clientSecret?: unknown;
+    model?: unknown;
+    error?: unknown;
+  };
+  if (!res.ok) {
+    throw new Error(typeof json.error === "string" ? json.error : `voice session failed (${res.status})`);
+  }
+  if (typeof json.clientSecret !== "string" || json.clientSecret.length === 0) {
+    throw new Error("voice session response did not include clientSecret");
+  }
+  return {
+    clientSecret: json.clientSecret,
+    ...(typeof json.model === "string" ? { model: json.model } : {}),
+  };
+}
+
+export function createVendoVoice(options: CreateVendoVoiceOptions = {}): VoiceDriver {
+  const basePath = options.basePath ?? "/api/vendo";
+  const internals = createVoiceInternals(options);
+  const realtime = createRealtimeVoiceDriver({
+    getSession: () => getSession(basePath),
+    tools: internals.tools,
+    instructions: internals.instructions,
+    greeting: internals.greeting,
+  });
+  return {
+    start(emit, init) {
+      internals.clearResults();
+      return realtime.start(emit, init);
+    },
+  };
+}
+
+/** Internal seams exported for unit tests only. */
+export const __voiceTesting = { createVoiceInternals, resolvePointer, stableStringify };

--- a/packages/vendo-next/src/client/voice.ts
+++ b/packages/vendo-next/src/client/voice.ts
@@ -12,8 +12,10 @@ import {
   createRealtimeVoiceDriver,
   replayRegistry,
   type VoiceDriver,
+  type VoiceDriverHandle,
   type VoiceToolDef,
 } from "@vendoai/shell";
+import { descriptors } from "@vendoai/components/descriptors";
 import {
   buildVoiceInstructions,
   capabilitySummary,
@@ -48,6 +50,9 @@ interface VoiceInternals {
   tableView(input: unknown): UINode | undefined;
   keyValueView(input: unknown): UINode | undefined;
   moneyFlowView(input: unknown): UINode | undefined;
+  createIntegrationVoiceTools(): Promise<{ tools: VoiceToolDef[]; unregister(): void }>;
+  buildInstructions(tools: VoiceToolDef[]): string;
+  dispose(): void;
 }
 
 const SESSION_RESULTS_MAX = 32;
@@ -71,6 +76,8 @@ const MECHANIC_TOOLS = new Set([
   "list_integrations",
   "request_connect",
 ]);
+
+const sankeyPropsSchema = descriptors.find((d) => d.name === "Sankey")?.propsSchema;
 
 function cleanName(productName: string | undefined): string {
   const trimmed = productName?.trim();
@@ -110,10 +117,55 @@ function genNode(id: string, payload: GeneratedPayload): UINode {
   return { id, kind: "generated", payload };
 }
 
+function moneyFlowValidation(input: unknown): { ok: true } | { ok: false; message: string } {
+  const parsed = sankeyPropsSchema?.safeParse(input);
+  if (parsed) {
+    if (parsed.success) return { ok: true };
+    return {
+      ok: false,
+      message:
+        parsed.error.issues[0]?.message ??
+        "Money-flow diagrams need at least two unique nodes and positive links between known node ids.",
+    };
+  }
+
+  const { nodes, links } = (input ?? {}) as {
+    nodes?: Array<{ id?: unknown }>;
+    links?: Array<{ source?: unknown; target?: unknown; value?: unknown }>;
+  };
+  if (!Array.isArray(nodes) || nodes.length < 2) {
+    return { ok: false, message: "Money-flow diagrams need at least two nodes." };
+  }
+  const ids = new Set<string>();
+  for (const node of nodes) {
+    if (typeof node.id !== "string" || node.id.length === 0) {
+      return { ok: false, message: "Every money-flow node needs a non-empty string id." };
+    }
+    if (ids.has(node.id)) return { ok: false, message: "Money-flow node ids must be unique." };
+    ids.add(node.id);
+  }
+  if (!Array.isArray(links) || links.length === 0) {
+    return { ok: false, message: "Money-flow diagrams need at least one link." };
+  }
+  for (const link of links) {
+    if (typeof link.value !== "number" || link.value <= 0) {
+      return { ok: false, message: "Money-flow link values must be positive numbers." };
+    }
+    if (typeof link.source !== "string" || !ids.has(link.source)) {
+      return { ok: false, message: "Money-flow link sources must reference known node ids." };
+    }
+    if (typeof link.target !== "string" || !ids.has(link.target)) {
+      return { ok: false, message: "Money-flow link targets must reference known node ids." };
+    }
+  }
+  return { ok: true };
+}
+
 function createVoiceInternals(options: CreateVendoVoiceOptions = {}): VoiceInternals {
   const basePath = options.basePath ?? "/api/vendo";
   const productName = cleanName(options.productName);
   const sessionResults = new Map<string, unknown>();
+  const unregisterHostTools: Array<() => void> = [];
   let viewSeq = 0;
   const nextId = (prefix: string) => `voice-${prefix}-${++viewSeq}`;
 
@@ -205,7 +257,7 @@ function createVoiceInternals(options: CreateVendoVoiceOptions = {}): VoiceInter
       nodes?: Array<{ id: string; label: string }>;
       links?: Array<{ source: string; target: string; value: number }>;
     };
-    if (!nodes?.length || !links?.length) return undefined;
+    if (moneyFlowValidation(input).ok === false) return undefined;
     return genNode(nextId("money-flow"), {
       formatVersion: "vendo-genui/v1",
       root: "sankey",
@@ -284,6 +336,7 @@ function createVoiceInternals(options: CreateVendoVoiceOptions = {}): VoiceInter
           title: { type: "string" },
           nodes: {
             type: "array",
+            minItems: 2,
             items: {
               type: "object",
               properties: { id: { type: "string" }, label: { type: "string" } },
@@ -292,12 +345,13 @@ function createVoiceInternals(options: CreateVendoVoiceOptions = {}): VoiceInter
           },
           links: {
             type: "array",
+            minItems: 1,
             items: {
               type: "object",
               properties: {
                 source: { type: "string" },
                 target: { type: "string" },
-                value: { type: "number" },
+                value: { type: "number", exclusiveMinimum: 0 },
               },
               required: ["source", "target", "value"],
             },
@@ -306,7 +360,18 @@ function createVoiceInternals(options: CreateVendoVoiceOptions = {}): VoiceInter
         required: ["nodes", "links"],
       },
       tier: "read",
-      execute: async () => ({ shown: true }),
+      execute: async (input) => {
+        const validation = moneyFlowValidation(input);
+        if (!validation.ok) {
+          return {
+            shown: false,
+            error: validation.message,
+            repair:
+              "Call show_money_flow again with at least two unique node ids and positive links whose source and target reference those node ids.",
+          };
+        }
+        return { shown: true };
+      },
       toView: (input) => moneyFlowView(input),
     },
   ];
@@ -358,7 +423,7 @@ function createVoiceInternals(options: CreateVendoVoiceOptions = {}): VoiceInter
     const tier = annotationsToTier(def.annotations);
     const run = (input: unknown) =>
       executeHostToolCall(def, (input ?? {}) as Record<string, unknown>);
-    if (tier === "read") replayRegistry.register(def.name, run);
+    if (tier === "read") unregisterHostTools.push(replayRegistry.register(def.name, run));
     return {
       name: def.name,
       description: def.description,
@@ -371,6 +436,57 @@ function createVoiceInternals(options: CreateVendoVoiceOptions = {}): VoiceInter
       },
     };
   });
+
+  async function createIntegrationVoiceTools(): Promise<{ tools: VoiceToolDef[]; unregister(): void }> {
+    if (!options.integrations) return { tools: [], unregister() {} };
+    try {
+      const res = await fetch(`${basePath}/voice/tools`, { cache: "no-store" });
+      if (!res.ok) return { tools: [], unregister() {} };
+      const body = (await res.json()) as {
+        tools?: Array<{
+          name: string;
+          description: string;
+          parameters: Record<string, unknown>;
+          tier: string;
+        }>;
+      };
+      const unregisters: Array<() => void> = [];
+      const tools = (body.tools ?? []).map((tool) => {
+        const tier: VoiceToolDef["tier"] =
+          tool.tier === "read" ? "read" : tool.tier === "critical" ? "critical" : "act";
+        const run = async (input: unknown) => {
+          const exec = await fetch(`${basePath}/voice/tools`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ tool: tool.name, input }),
+          });
+          const json = (await exec.json().catch(() => ({}))) as { result?: unknown; error?: string };
+          if (!exec.ok) throw new Error(json.error ?? `integration tool failed (${exec.status})`);
+          return json.result;
+        };
+        if (tier === "read") unregisters.push(replayRegistry.register(tool.name, run));
+        return {
+          name: tool.name,
+          description: tool.description,
+          parameters: tool.parameters,
+          tier,
+          execute: async (input: unknown) => {
+            const output = await run(input);
+            if (tier === "read") recordResult(tool.name, input, output);
+            return output;
+          },
+        };
+      });
+      return {
+        tools,
+        unregister() {
+          for (const unregister of unregisters.splice(0)) unregister();
+        },
+      };
+    } catch {
+      return { tools: [], unregister() {} };
+    }
+  }
 
   const tools = [...displayTools, ...integrationTools, ...hostVoiceTools];
   const instructions = buildInstructions(productName, tools, options.instructionsExtra ?? []);
@@ -385,18 +501,27 @@ function createVoiceInternals(options: CreateVendoVoiceOptions = {}): VoiceInter
     tableView,
     keyValueView,
     moneyFlowView,
+    createIntegrationVoiceTools,
+    buildInstructions: (sessionTools) => buildInstructions(productName, sessionTools, options.instructionsExtra ?? []),
+    dispose() {
+      for (const unregister of unregisterHostTools.splice(0)) unregister();
+    },
   };
 }
 
 function voiceToolSummary(tools: VoiceToolDef[]): ToolSummaryInput[] {
   return tools
     .filter((t) => !MECHANIC_TOOLS.has(t.name))
-    .map((t) => ({
-      name: t.name,
-      description: t.description,
-      tier: t.tier === "read" ? "read" : t.tier === "critical" ? "critical" : "act",
-      source: "host",
-    }));
+    .map((t) => {
+      const integration = /^[A-Z0-9]+_/.test(t.name);
+      return {
+        name: t.name,
+        description: t.description,
+        tier: t.tier === "read" ? "read" : t.tier === "critical" ? "critical" : "act",
+        source: integration ? "integration" : "host",
+        ...(integration ? { toolkit: t.name.slice(0, t.name.indexOf("_")).toLowerCase() } : {}),
+      };
+    });
 }
 
 function buildInstructions(productName: string, tools: VoiceToolDef[], extras: string[]): string {
@@ -436,19 +561,97 @@ async function getSession(basePath: string): Promise<{ clientSecret: string; mod
   };
 }
 
-export function createVendoVoice(options: CreateVendoVoiceOptions = {}): VoiceDriver {
+export interface DisposableVoiceDriver extends VoiceDriver {
+  dispose(): void;
+}
+
+function inertHandle(): VoiceDriverHandle {
+  return {
+    mute() {},
+    end() {},
+    approve() {},
+    decline() {},
+    stop() {},
+  };
+}
+
+export function createVendoVoice(options: CreateVendoVoiceOptions = {}): DisposableVoiceDriver {
   const basePath = options.basePath ?? "/api/vendo";
   const internals = createVoiceInternals(options);
-  const realtime = createRealtimeVoiceDriver({
-    getSession: () => getSession(basePath),
-    tools: internals.tools,
-    instructions: internals.instructions,
-    greeting: internals.greeting,
-  });
+  const activeStops = new Set<() => void>();
+  let disposed = false;
   return {
+    dispose() {
+      disposed = true;
+      for (const stop of [...activeStops]) stop();
+      internals.dispose();
+    },
     start(emit, init) {
       internals.clearResults();
-      return realtime.start(emit, init);
+      if (disposed) return inertHandle();
+
+      let inner: VoiceDriverHandle | null = null;
+      let stopped = false;
+      let unregisterSessionTools = () => {};
+      const queued: Array<(handle: VoiceDriverHandle) => void> = [];
+      const withInner = (fn: (handle: VoiceDriverHandle) => void) => {
+        if (inner) fn(inner);
+        else queued.push(fn);
+      };
+      const cleanup = () => {
+        activeStops.delete(stop);
+        unregisterSessionTools();
+        unregisterSessionTools = () => {};
+      };
+      const stop = () => {
+        if (stopped) return;
+        stopped = true;
+        inner?.stop();
+        cleanup();
+      };
+      activeStops.add(stop);
+
+      emit({ type: "status", status: "connecting" });
+      void Promise.allSettled([getSession(basePath), internals.createIntegrationVoiceTools()] as const)
+        .then(([grantResult, integrationResult]) => {
+          const integration =
+            integrationResult.status === "fulfilled"
+              ? integrationResult.value
+              : { tools: [], unregister() {} };
+          unregisterSessionTools = integration.unregister;
+          if (grantResult.status === "rejected") throw grantResult.reason;
+          if (stopped || disposed) {
+            cleanup();
+            return;
+          }
+          const sessionTools = [...internals.tools, ...integration.tools];
+          const realtime = createRealtimeVoiceDriver({
+            getSession: async () => grantResult.value,
+            tools: sessionTools,
+            instructions: internals.buildInstructions(sessionTools),
+            greeting: internals.greeting,
+          });
+          inner = realtime.start(emit, init);
+          for (const fn of queued.splice(0)) fn(inner);
+        })
+        .catch((error) => {
+          cleanup();
+          if (stopped || disposed) return;
+          console.error("[vendo voice] failed to prepare realtime session", error);
+          emit({
+            type: "status",
+            status: "error",
+            message: "Voice couldn't start. Check the microphone permission and try again.",
+          });
+        });
+
+      return {
+        mute: (muted) => withInner((handle) => handle.mute(muted)),
+        end: () => withInner((handle) => handle.end()),
+        approve: (id, via) => withInner((handle) => handle.approve(id, via)),
+        decline: (id) => withInner((handle) => handle.decline(id)),
+        stop,
+      };
     },
   };
 }

--- a/packages/vendo-next/src/handler.test.ts
+++ b/packages/vendo-next/src/handler.test.ts
@@ -65,6 +65,7 @@ describe("routeTail", () => {
     ["/api/vendo/action", "action"],
     ["/api/vendo/integrations", "integrations"],
     ["/api/vendo/capabilities", "capabilities"],
+    ["/api/vendo/voice/session", "voice/session"],
     ["/api/vendo/tick", "tick"],
   ])("resolves %s to %s", (pathname, expected) => {
     expect(routeTail(req(pathname))).toBe(expected);

--- a/packages/vendo-server/src/fetch-handler.test.ts
+++ b/packages/vendo-server/src/fetch-handler.test.ts
@@ -121,8 +121,13 @@ function vendoDirWithEvent(): string {
   return dir;
 }
 
+function modelStub(): import("ai").LanguageModel {
+  return { modelId: "stub" } as unknown as import("ai").LanguageModel;
+}
+
 afterEach(() => {
   vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
   // Handlers claim the process-wide boot slot (first-wins); keep tests
   // order-independent.
   resetVendoBootRegistry();
@@ -243,6 +248,91 @@ describe("createVendoFetchHandler", () => {
       req("/api/vendo/chat", { method: "POST", body: JSON.stringify({ messages: [] }) }),
     );
     expect(res.status).toBe(400);
+  });
+
+  it("mints an OpenAI Realtime client secret for POST /voice/session", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-voice");
+    vi.stubEnv("OPENAI_REALTIME_MODEL", "gpt-realtime-preview");
+    vi.stubEnv("OPENAI_REALTIME_VOICE", "alloy");
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ value: "eph_secret" }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const handler = createVendoFetchHandler({ vendoDir: emptyDir(), model: modelStub() });
+
+    const res = await handler(req("/api/vendo/voice/session", { method: "POST" }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      clientSecret: "eph_secret",
+      model: "gpt-realtime-preview",
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("https://api.openai.com/v1/realtime/client_secrets");
+    expect(init).toMatchObject({
+      method: "POST",
+      headers: { Authorization: "Bearer sk-voice", "Content-Type": "application/json" },
+    });
+    expect(JSON.parse(String((init as RequestInit).body))).toEqual({
+      session: {
+        type: "realtime",
+        model: "gpt-realtime-preview",
+        audio: { output: { voice: "alloy" } },
+      },
+    });
+  });
+
+  it("502s /voice/session when the OpenAI mint fails", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-voice");
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ error: { message: "bad key" } }), { status: 401 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const handler = createVendoFetchHandler({ vendoDir: emptyDir(), model: modelStub() });
+
+    const res = await handler(req("/api/vendo/voice/session", { method: "POST" }));
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: "bad key" });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    err.mockRestore();
+  });
+
+  it("503s /voice/session without OPENAI_API_KEY and does not call upstream", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const handler = createVendoFetchHandler({ vendoDir: emptyDir(), model: modelStub() });
+
+    const res = await handler(req("/api/vendo/voice/session", { method: "POST" }));
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "voice not configured (OPENAI_API_KEY missing)" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("guards /voice/session with the same production default request guard as other spend routes", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-voice");
+    vi.stubEnv("NODE_ENV", "production");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const handler = createVendoFetchHandler({
+      vendoDir: emptyDir(),
+      model: modelStub(),
+      storage: false,
+    });
+
+    const res = await handler(
+      new Request("http://prod.example.com/api/vendo/voice/session", {
+        method: "POST",
+        headers: { host: "prod.example.com" },
+      }),
+    );
+
+    expect(res.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("400s a chat request with no messages once a key is present", async () => {

--- a/packages/vendo-server/src/fetch-handler.test.ts
+++ b/packages/vendo-server/src/fetch-handler.test.ts
@@ -270,10 +270,14 @@ describe("createVendoFetchHandler", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
     const [url, init] = fetchMock.mock.calls[0]!;
     expect(url).toBe("https://api.openai.com/v1/realtime/client_secrets");
-    expect(init).toMatchObject({
-      method: "POST",
-      headers: { Authorization: "Bearer sk-voice", "Content-Type": "application/json" },
+    expect((init as RequestInit).method).toBe("POST");
+    expect((init as RequestInit).headers).toMatchObject({
+      Authorization: "Bearer sk-voice",
+      "Content-Type": "application/json",
     });
+    expect(((init as RequestInit).headers as Record<string, string>)["OpenAI-Safety-Identifier"]).toMatch(
+      /^vendo_[a-f0-9]{64}$/,
+    );
     expect(JSON.parse(String((init as RequestInit).body))).toEqual({
       session: {
         type: "realtime",
@@ -286,7 +290,10 @@ describe("createVendoFetchHandler", () => {
   it("502s /voice/session when the OpenAI mint fails", async () => {
     vi.stubEnv("OPENAI_API_KEY", "sk-voice");
     const fetchMock = vi.fn(async () =>
-      new Response(JSON.stringify({ error: { message: "bad key" } }), { status: 401 }),
+      new Response(JSON.stringify({ error: { message: "bad key with account detail" } }), {
+        status: 401,
+        headers: { "x-request-id": "req_voice_123" },
+      }),
     );
     vi.stubGlobal("fetch", fetchMock);
     const err = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -295,9 +302,44 @@ describe("createVendoFetchHandler", () => {
     const res = await handler(req("/api/vendo/voice/session", { method: "POST" }));
 
     expect(res.status).toBe(502);
-    expect(await res.json()).toEqual({ error: "bad key" });
+    expect(await res.json()).toEqual({ error: "mint failed" });
     expect(fetchMock).toHaveBeenCalledOnce();
+    const logged = err.mock.calls
+      .flat()
+      .map((arg) => (typeof arg === "object" ? JSON.stringify(arg) : String(arg)))
+      .join(" ");
+    expect(logged).toContain("401");
+    expect(logged).toContain("req_voice_123");
+    expect(logged).not.toContain("bad key");
+    expect(logged).not.toContain("account detail");
     err.mockRestore();
+  });
+
+  it("binds /voice/session mints to the guarded principal, not a browser-supplied safety id", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-voice");
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ value: "eph_secret" }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const handler = createVendoFetchHandler({
+      vendoDir: emptyDir(),
+      model: modelStub(),
+      principal: async () => ({ userId: "user-42" }),
+    });
+
+    const res = await handler(
+      req("/api/vendo/voice/session", {
+        method: "POST",
+        headers: { host: "localhost:3000", "OpenAI-Safety-Identifier": "browser-forged" },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const init = fetchMock.mock.calls[0]![1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["OpenAI-Safety-Identifier"]).toMatch(/^vendo_[a-f0-9]{64}$/);
+    expect(headers["OpenAI-Safety-Identifier"]).not.toBe("browser-forged");
+    expect(headers["OpenAI-Safety-Identifier"]).not.toContain("user-42");
   });
 
   it("503s /voice/session without OPENAI_API_KEY and does not call upstream", async () => {
@@ -333,6 +375,32 @@ describe("createVendoFetchHandler", () => {
 
     expect(res.status).toBe(403);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("guards /voice/tools with the same production default request guard as other spend routes", async () => {
+    vi.stubEnv("COMPOSIO_API_KEY", "ck_x");
+    vi.stubEnv("NODE_ENV", "production");
+    const handler = createVendoFetchHandler({
+      vendoDir: emptyDir(),
+      model: modelStub(),
+      storage: false,
+    });
+
+    const get = await handler(
+      new Request("http://prod.example.com/api/vendo/voice/tools", {
+        headers: { host: "prod.example.com" },
+      }),
+    );
+    const post = await handler(
+      new Request("http://prod.example.com/api/vendo/voice/tools", {
+        method: "POST",
+        headers: { host: "prod.example.com", "content-type": "application/json" },
+        body: JSON.stringify({ tool: "GMAIL_FETCH_EMAILS", input: {} }),
+      }),
+    );
+
+    expect(get.status).toBe(403);
+    expect(post.status).toBe(403);
   });
 
   it("400s a chat request with no messages once a key is present", async () => {

--- a/packages/vendo-server/src/fetch-handler.ts
+++ b/packages/vendo-server/src/fetch-handler.ts
@@ -10,6 +10,7 @@
  *   POST /action        — sandbox dispatch through the policy (+ approval tokens)
  *   GET|POST /integrations — Composio connect flow (inert without the key)
  *   GET  /capabilities  — { chat, integrations, voice, mcp } from env-key/config presence
+ *   POST /voice/session — ephemeral OpenAI Realtime client secret mint
  *   GET  /deliveries    — in-app Channels feed for VendoToasts (single-tenant)
  *   POST /tick          — drives the automations scheduler
  *   POST /resume        — resumes a paused automation run (approval toast)
@@ -90,6 +91,7 @@ import { resolveStorage } from "./storage";
 import { parseHandlerOptions, type VendoHandlerOptions } from "./options";
 import { devTelemetry, errorClassName } from "./telemetry-dev";
 import { handleComposioWebhook } from "./webhooks";
+import { handleVoiceSessionPost } from "./voice";
 
 // Exported for vendos.ts's save-path id validation (a saved vendo's id
 // is caller-assigned, unlike threads' store-assigned UUIDs — see the
@@ -102,6 +104,7 @@ export const FIRST_SEGMENTS = new Set([
   "action",
   "integrations",
   "capabilities",
+  "voice",
   "deliveries",
   "tick",
   "resume",
@@ -795,6 +798,11 @@ export function createVendoFetchHandler(rawOptions: VendoHandlerOptions = {}): V
           enabled: s.capabilities.integrations,
           options,
         });
+      case "voice/session": {
+        const guard = await resolvePrincipal(req, options);
+        if (!guard.ok) return guard.response;
+        return handleVoiceSessionPost(req);
+      }
       case "tick": {
         if (!s.world) return Response.json({ error: "automations are disabled" }, { status: 404 });
         // Service auth first: an external cron (vercel.json, Cloudflare Cron

--- a/packages/vendo-server/src/fetch-handler.ts
+++ b/packages/vendo-server/src/fetch-handler.ts
@@ -11,6 +11,7 @@
  *   GET|POST /integrations — Composio connect flow (inert without the key)
  *   GET  /capabilities  — { chat, integrations, voice, mcp } from env-key/config presence
  *   POST /voice/session — ephemeral OpenAI Realtime client secret mint
+ *   GET|POST /voice/tools — connected integration tool bridge for voice
  *   GET  /deliveries    — in-app Channels feed for VendoToasts (single-tenant)
  *   POST /tick          — drives the automations scheduler
  *   POST /resume        — resumes a paused automation run (approval toast)
@@ -92,6 +93,7 @@ import { parseHandlerOptions, type VendoHandlerOptions } from "./options";
 import { devTelemetry, errorClassName } from "./telemetry-dev";
 import { handleComposioWebhook } from "./webhooks";
 import { handleVoiceSessionPost } from "./voice";
+import { handleVoiceToolsGet, handleVoiceToolsPost } from "./voice-tools";
 
 // Exported for vendos.ts's save-path id validation (a saved vendo's id
 // is caller-assigned, unlike threads' store-assigned UUIDs — see the
@@ -691,6 +693,15 @@ export function createVendoFetchHandler(rawOptions: VendoHandlerOptions = {}): V
           enabled: s.capabilities.integrations,
           options,
         });
+      case "voice/tools": {
+        const guard = await resolvePrincipal(req, options);
+        if (!guard.ok) return guard.response;
+        return handleVoiceToolsGet(req, {
+          store: s.connections,
+          enabled: s.capabilities.integrations,
+          principal: guard.principal,
+        });
+      }
       case "deliveries": {
         // VendoToasts polls this: in-app Channels deliveries since a cursor.
         if (!s.world) return Response.json({ error: "automations are disabled" }, { status: 404 });
@@ -801,7 +812,16 @@ export function createVendoFetchHandler(rawOptions: VendoHandlerOptions = {}): V
       case "voice/session": {
         const guard = await resolvePrincipal(req, options);
         if (!guard.ok) return guard.response;
-        return handleVoiceSessionPost(req);
+        return handleVoiceSessionPost(req, { principal: guard.principal });
+      }
+      case "voice/tools": {
+        const guard = await resolvePrincipal(req, options);
+        if (!guard.ok) return guard.response;
+        return handleVoiceToolsPost(req, {
+          store: s.connections,
+          enabled: s.capabilities.integrations,
+          principal: guard.principal,
+        });
       }
       case "tick": {
         if (!s.world) return Response.json({ error: "automations are disabled" }, { status: 404 });

--- a/packages/vendo-server/src/index.ts
+++ b/packages/vendo-server/src/index.ts
@@ -76,6 +76,7 @@ export { composeProductionPolicy, principalScope, EMBEDDED_TENANT } from "./poli
 export { createThreadIndex, type ThreadIndex } from "./threads";
 export { handleConsentRoute, type ConsentRouteDeps } from "./consent";
 export { handleFadeProposalRoute, type FadeProposalRouteDeps } from "./fade-proposal";
+export { handleVoiceSessionPost, type VoiceSessionDeps } from "./voice";
 export { listParkedActionsRoute, resolveParkedActionRoute } from "./parked-actions";
 export {
   listGrantsRoute,

--- a/packages/vendo-server/src/vendos.test.ts
+++ b/packages/vendo-server/src/vendos.test.ts
@@ -140,7 +140,7 @@ describe("vendos endpoints — in-memory registry", () => {
 });
 
 describe("vendos endpoints — reserved-id rejection (review blocker)", () => {
-  it.each(["chat", "action", "integrations", "capabilities", "tick", "webhooks", "threads", "vendos"])(
+  it.each(["chat", "action", "integrations", "capabilities", "voice", "tick", "webhooks", "threads", "vendos"])(
     "rejects a save whose id equals the reserved segment %s",
     async (id) => {
       const registry = createInMemoryVendoRegistry();

--- a/packages/vendo-server/src/vendos.ts
+++ b/packages/vendo-server/src/vendos.ts
@@ -37,6 +37,7 @@ const RESERVED_VENDO_IDS = new Set([
   "action",
   "integrations",
   "capabilities",
+  "voice",
   "deliveries",
   "tick",
   "resume",

--- a/packages/vendo-server/src/voice-tools.test.ts
+++ b/packages/vendo-server/src/voice-tools.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ToolSet } from "ai";
+import type { ComposioClient } from "@vendoai/runtime";
+import { createConnectionsStore } from "./connections";
+import { handleVoiceToolsGet, handleVoiceToolsPost, type VoiceToolsDeps } from "./voice-tools";
+
+const CATALOG = [
+  { id: "gmail", name: "Gmail" },
+  { id: "slack", name: "Slack" },
+];
+
+function tool(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    description: "Fetch Gmail messages",
+    inputSchema: { jsonSchema: { type: "object", properties: { query: { type: "string" } } } },
+    execute: vi.fn(async () => ({ ok: true })),
+    ...overrides,
+  };
+}
+
+function deps(toolset: ToolSet): VoiceToolsDeps {
+  const store = createConnectionsStore(CATALOG);
+  const client: ComposioClient = {
+    fetchTools: vi.fn(async () => toolset),
+    authorize: async () => ({ redirectUrl: "https://oauth.example/x", connectedAccountId: "acc-1" }),
+    connectionStatus: async () => "active",
+    hasActiveConnection: async () => true,
+  };
+  return { store, enabled: true, principal: { userId: "user-1" }, client };
+}
+
+function get(): Request {
+  return new Request("http://localhost:3000/api/vendo/voice/tools", { headers: { host: "localhost:3000" } });
+}
+
+function post(body: unknown): Request {
+  return new Request("http://localhost:3000/api/vendo/voice/tools", {
+    method: "POST",
+    headers: { host: "localhost:3000", "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("voice integration tools bridge", () => {
+  it("lists connected Composio tool definitions with tier mapping", async () => {
+    const d = deps({
+      GMAIL_FETCH_EMAILS: tool(),
+      GMAIL_DELETE_EMAIL: tool({ description: "Delete Gmail message" }),
+    } as unknown as ToolSet);
+    await d.store.connect("gmail");
+
+    const res = await handleVoiceToolsGet(get(), d);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      tools: [
+        {
+          name: "GMAIL_FETCH_EMAILS",
+          description: "Fetch Gmail messages",
+          parameters: { type: "object", properties: { query: { type: "string" } } },
+          tier: "read",
+        },
+        {
+          name: "GMAIL_DELETE_EMAIL",
+          description: "Delete Gmail message",
+          parameters: { type: "object", properties: { query: { type: "string" } } },
+          tier: "critical",
+        },
+      ],
+      truncated: false,
+    });
+    expect(d.client?.fetchTools).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({ toolkits: ["gmail"] }),
+    );
+  });
+
+  it("executes connected tools server-side and caps voice output", async () => {
+    const execute = vi.fn(async () => ({ body: "x".repeat(20_000) }));
+    const d = deps({ GMAIL_FETCH_EMAILS: tool({ execute }) } as unknown as ToolSet);
+    await d.store.connect("gmail");
+
+    const res = await handleVoiceToolsPost(post({ tool: "GMAIL_FETCH_EMAILS", input: { query: "invoice" } }), d);
+    const body = (await res.json()) as { result: { body?: string; _truncation?: string } };
+
+    expect(res.status).toBe(200);
+    expect(execute).toHaveBeenCalled();
+    expect(JSON.stringify(body.result).length).toBeLessThan(8_000);
+    expect(body.result.body).toContain("truncated");
+    expect(body.result._truncation).toContain("Output truncated");
+  });
+
+  it("returns no tools when integrations are disabled", async () => {
+    const d = deps({ GMAIL_FETCH_EMAILS: tool() } as unknown as ToolSet);
+    const res = await handleVoiceToolsGet(get(), { ...d, enabled: false });
+    expect(await res.json()).toEqual({ tools: [], truncated: false });
+    expect(d.client?.fetchTools).not.toHaveBeenCalled();
+  });
+});

--- a/packages/vendo-server/src/voice-tools.ts
+++ b/packages/vendo-server/src/voice-tools.ts
@@ -1,0 +1,150 @@
+/**
+ * GET|POST /voice/tools — server bridge for connected integration tools.
+ *
+ * Voice tools execute in the browser, but Composio tools need the server-side
+ * SDK and API key. This bridge gives the Realtime session schemas for the
+ * currently connected toolkits and executes selected calls on behalf of the
+ * guarded principal, with a voice-sized output cap before results hit the
+ * expensive realtime context (ENG-185).
+ */
+import type { ToolSet } from "ai";
+import { capToolOutput } from "@vendoai/core";
+import {
+  createComposioClient,
+  ingestComposioTools,
+  type ComposioClient,
+  type ToolDescriptor,
+  type VendoPrincipal,
+} from "@vendoai/runtime";
+import type { ConnectionsStore } from "./connections";
+
+const MAX_TOOLS = 40;
+const VOICE_TOOL_OUTPUT_BUDGET = { maxChars: 6_000, attachNote: true } as const;
+
+interface Ingested {
+  toolset: ToolSet;
+  descriptors: ToolDescriptor[];
+}
+
+export interface VoiceToolsDeps {
+  store: ConnectionsStore;
+  enabled: boolean;
+  principal: VendoPrincipal;
+  /** Injectable for tests; defaults to a lazily-built real client. */
+  client?: ComposioClient;
+  maxTools?: number;
+}
+
+let realClient: ComposioClient | undefined;
+function getClient(deps: VoiceToolsDeps): ComposioClient {
+  if (deps.client) return deps.client;
+  if (!realClient) realClient = createComposioClient({ apiKey: process.env["COMPOSIO_API_KEY"] });
+  return realClient;
+}
+
+const cache = new Map<string, Promise<Ingested>>();
+
+async function ingested(deps: VoiceToolsDeps): Promise<Ingested> {
+  const toolkits = [...(await deps.store.connectedToolkits())].sort();
+  if (toolkits.length === 0) return { toolset: {}, descriptors: [] };
+
+  // Test fakes should not share state across cases. Production cache keys on
+  // principal+toolkits because Composio schemas are per connected account.
+  if (deps.client) {
+    return ingestComposioTools({
+      principal: deps.principal,
+      config: { toolkits },
+      client: deps.client,
+    });
+  }
+
+  const key = `${deps.principal.userId}\0${toolkits.join(",")}`;
+  let entry = cache.get(key);
+  if (!entry) {
+    entry = ingestComposioTools({
+      principal: deps.principal,
+      config: { toolkits },
+      client: getClient(deps),
+    }).catch((err) => {
+      cache.delete(key);
+      throw err;
+    });
+    cache.set(key, entry);
+  }
+  return entry;
+}
+
+const READ_NAME = /(FETCH|GET|LIST|SEARCH|READ|FIND|LOOKUP|RETRIEVE|HISTORY)/;
+const DESTRUCTIVE_NAME = /(DELETE|REMOVE|DESTROY|PURGE|TRASH)/;
+
+function tierOf(name: string, annotations: ToolDescriptor["annotations"]): "read" | "act" | "critical" {
+  if (annotations.readOnlyHint) return "read";
+  if (annotations.destructiveHint) return "critical";
+  if (DESTRUCTIVE_NAME.test(name)) return "critical";
+  if (READ_NAME.test(name)) return "read";
+  return "act";
+}
+
+function schemaOf(tool: unknown): Record<string, unknown> {
+  const input = (tool as { inputSchema?: { jsonSchema?: unknown } }).inputSchema;
+  const json = input?.jsonSchema;
+  if (json && typeof json === "object") return json as Record<string, unknown>;
+  return { type: "object", properties: {}, additionalProperties: true };
+}
+
+export async function handleVoiceToolsGet(_req: Request, deps: VoiceToolsDeps): Promise<Response> {
+  if (!deps.enabled) return Response.json({ tools: [], truncated: false });
+  try {
+    const { toolset, descriptors } = await ingested(deps);
+    const maxTools = deps.maxTools ?? MAX_TOOLS;
+    const byName = new Map(descriptors.map((d) => [d.name, d]));
+    const tools = Object.entries(toolset)
+      .slice(0, maxTools)
+      .map(([name, tool]) => ({
+        name,
+        description: String((tool as { description?: string }).description ?? name),
+        parameters: schemaOf(tool),
+        tier: tierOf(name, byName.get(name)?.annotations ?? {}),
+      }));
+    return Response.json({ tools, truncated: Object.keys(toolset).length > maxTools });
+  } catch (error) {
+    console.error("[vendo voice] integration tool listing failed", error);
+    return Response.json({ tools: [], truncated: false });
+  }
+}
+
+export async function handleVoiceToolsPost(req: Request, deps: VoiceToolsDeps): Promise<Response> {
+  if (!deps.enabled) {
+    return Response.json(
+      { error: "integrations are disabled — set COMPOSIO_API_KEY to enable them" },
+      { status: 503 },
+    );
+  }
+
+  const { tool, input } = (await req.json().catch(() => ({}))) as {
+    tool?: unknown;
+    input?: unknown;
+  };
+  if (typeof tool !== "string" || tool.length === 0) {
+    return Response.json({ error: "missing tool" }, { status: 400 });
+  }
+
+  const { toolset } = await ingested(deps);
+  const entry = toolset[tool] as
+    | { execute?: (input: unknown, opts: unknown) => Promise<unknown> }
+    | undefined;
+  if (!entry?.execute) {
+    return Response.json({ error: `unknown or non-executable tool ${tool}` }, { status: 404 });
+  }
+
+  try {
+    const result = await entry.execute(input ?? {}, { toolCallId: `voice-${Date.now()}`, messages: [] });
+    return Response.json({ result: capToolOutput(result, VOICE_TOOL_OUTPUT_BUDGET).result });
+  } catch (error) {
+    console.error("[vendo voice] integration tool failed", tool, error);
+    return Response.json(
+      { error: error instanceof Error ? error.message : "tool execution failed" },
+      { status: 502 },
+    );
+  }
+}

--- a/packages/vendo-server/src/voice.ts
+++ b/packages/vendo-server/src/voice.ts
@@ -5,6 +5,8 @@
  * OPENAI_API_KEY never leaves this server route. The caller guard lives in
  * fetch-handler.ts so voice mints share the same spend boundary as chat/action.
  */
+import { createHmac } from "node:crypto";
+import type { VendoPrincipal } from "@vendoai/runtime";
 
 const DEFAULT_REALTIME_MODEL = "gpt-realtime";
 const DEFAULT_REALTIME_VOICE = "marin";
@@ -13,11 +15,19 @@ const CLIENT_SECRETS_URL = "https://api.openai.com/v1/realtime/client_secrets";
 export interface VoiceSessionDeps {
   env?: Record<string, string | undefined>;
   fetchImpl?: typeof fetch;
+  principal?: VendoPrincipal;
 }
 
 function present(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed ? trimmed : undefined;
+}
+
+function safetyIdentifier(principal: VendoPrincipal | undefined, env: Record<string, string | undefined>, apiKey: string): string | undefined {
+  if (!principal?.userId) return undefined;
+  const key = present(env["VENDO_OPENAI_SAFETY_SALT"]) ?? apiKey;
+  const digest = createHmac("sha256", key).update(principal.userId).digest("hex");
+  return `vendo_${digest}`;
 }
 
 export async function handleVoiceSessionPost(_req: Request, deps: VoiceSessionDeps = {}): Promise<Response> {
@@ -30,12 +40,17 @@ export async function handleVoiceSessionPost(_req: Request, deps: VoiceSessionDe
   const model = present(env["OPENAI_REALTIME_MODEL"]) ?? DEFAULT_REALTIME_MODEL;
   const voice = present(env["OPENAI_REALTIME_VOICE"]) ?? DEFAULT_REALTIME_VOICE;
   const fetchImpl = deps.fetchImpl ?? fetch;
+  const safetyId = safetyIdentifier(deps.principal, env, apiKey);
 
   let upstream: Response;
   try {
     upstream = await fetchImpl(CLIENT_SECRETS_URL, {
       method: "POST",
-      headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        ...(safetyId ? { "OpenAI-Safety-Identifier": safetyId } : {}),
+      },
       body: JSON.stringify({
         session: {
           type: "realtime",
@@ -45,20 +60,25 @@ export async function handleVoiceSessionPost(_req: Request, deps: VoiceSessionDe
       }),
     });
   } catch (err) {
-    console.error("[vendo voice] client_secrets mint failed", err);
+    console.error("[vendo voice] client_secrets mint failed", { error: err instanceof Error ? err.name : "unknown" });
     return Response.json({ error: "mint failed" }, { status: 502 });
   }
 
-  const body = (await upstream.json().catch(() => ({}))) as {
-    value?: string;
-    error?: { message?: string };
-  };
-  if (!upstream.ok || !body.value) {
-    console.error("[vendo voice] client_secrets mint failed", upstream.status, body);
-    return Response.json(
-      { error: body.error?.message ?? `mint failed (${upstream.status})` },
-      { status: 502 },
-    );
+  if (!upstream.ok) {
+    console.error("[vendo voice] client_secrets mint failed", {
+      status: upstream.status,
+      requestId: upstream.headers.get("x-request-id") ?? upstream.headers.get("openai-request-id") ?? undefined,
+    });
+    return Response.json({ error: "mint failed" }, { status: 502 });
+  }
+
+  const body = (await upstream.json().catch(() => ({}))) as { value?: string };
+  if (!body.value) {
+    console.error("[vendo voice] client_secrets mint failed", {
+      status: upstream.status,
+      requestId: upstream.headers.get("x-request-id") ?? upstream.headers.get("openai-request-id") ?? undefined,
+    });
+    return Response.json({ error: "mint failed" }, { status: 502 });
   }
 
   return Response.json({ clientSecret: body.value, model });

--- a/packages/vendo-server/src/voice.ts
+++ b/packages/vendo-server/src/voice.ts
@@ -1,0 +1,65 @@
+/**
+ * POST /voice/session — mint an ephemeral OpenAI Realtime client secret.
+ *
+ * The browser receives only the scoped, short-lived credential; the host's
+ * OPENAI_API_KEY never leaves this server route. The caller guard lives in
+ * fetch-handler.ts so voice mints share the same spend boundary as chat/action.
+ */
+
+const DEFAULT_REALTIME_MODEL = "gpt-realtime";
+const DEFAULT_REALTIME_VOICE = "marin";
+const CLIENT_SECRETS_URL = "https://api.openai.com/v1/realtime/client_secrets";
+
+export interface VoiceSessionDeps {
+  env?: Record<string, string | undefined>;
+  fetchImpl?: typeof fetch;
+}
+
+function present(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export async function handleVoiceSessionPost(_req: Request, deps: VoiceSessionDeps = {}): Promise<Response> {
+  const env = deps.env ?? process.env;
+  const apiKey = present(env["OPENAI_API_KEY"]);
+  if (!apiKey) {
+    return Response.json({ error: "voice not configured (OPENAI_API_KEY missing)" }, { status: 503 });
+  }
+
+  const model = present(env["OPENAI_REALTIME_MODEL"]) ?? DEFAULT_REALTIME_MODEL;
+  const voice = present(env["OPENAI_REALTIME_VOICE"]) ?? DEFAULT_REALTIME_VOICE;
+  const fetchImpl = deps.fetchImpl ?? fetch;
+
+  let upstream: Response;
+  try {
+    upstream = await fetchImpl(CLIENT_SECRETS_URL, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        session: {
+          type: "realtime",
+          model,
+          audio: { output: { voice } },
+        },
+      }),
+    });
+  } catch (err) {
+    console.error("[vendo voice] client_secrets mint failed", err);
+    return Response.json({ error: "mint failed" }, { status: 502 });
+  }
+
+  const body = (await upstream.json().catch(() => ({}))) as {
+    value?: string;
+    error?: { message?: string };
+  };
+  if (!upstream.ok || !body.value) {
+    console.error("[vendo voice] client_secrets mint failed", upstream.status, body);
+    return Response.json(
+      { error: body.error?.message ?? `mint failed (${upstream.status})` },
+      { status: 502 },
+    );
+  }
+
+  return Response.json({ clientSecret: body.value, model });
+}

--- a/packages/vendo-shell/src/voice/replay-registry.test.ts
+++ b/packages/vendo-shell/src/voice/replay-registry.test.ts
@@ -19,4 +19,18 @@ describe("replay registry", () => {
     registry.register("t", async () => 2);
     await expect(registry.replay("t", {})).resolves.toBe(2);
   });
+
+  it("unregisters only the executor that owns the current name", async () => {
+    const registry = createReplayRegistry();
+    const unregisterFirst = registry.register("t", async () => 1);
+    const unregisterSecond = registry.register("t", async () => 2);
+
+    unregisterFirst();
+    expect(registry.has("t")).toBe(true);
+    await expect(registry.replay("t", {})).resolves.toBe(2);
+
+    unregisterSecond();
+    expect(registry.has("t")).toBe(false);
+    await expect(registry.replay("t", {})).rejects.toThrow(/not in the replay registry/);
+  });
 });

--- a/packages/vendo-shell/src/voice/replay-registry.ts
+++ b/packages/vendo-shell/src/voice/replay-registry.ts
@@ -12,7 +12,7 @@
 
 export interface ReplayRegistry {
   /** Register a read-tier executor for `tool`. Latest registration wins. */
-  register(tool: string, execute: (input: unknown) => Promise<unknown>): void;
+  register(tool: string, execute: (input: unknown) => Promise<unknown>): () => void;
   has(tool: string): boolean;
   replay(tool: string, input: unknown): Promise<unknown>;
 }
@@ -22,6 +22,9 @@ export function createReplayRegistry(): ReplayRegistry {
   return {
     register(tool, execute) {
       executors.set(tool, execute);
+      return () => {
+        if (executors.get(tool) === execute) executors.delete(tool);
+      };
     },
     has(tool) {
       return executors.has(tool);


### PR DESCRIPTION
A 'vendo init' host with OPENAI_API_KEY now gets full voice with no custom code: guarded /voice/session mint (principal-bound via OpenAI-Safety-Identifier, sanitized errors), createVendoVoice in @vendoai/next/client (show_table/show_key_value/show_money_flow display tools with source/replay binding and Sankey-schema validation, connected-Composio tools via a guarded /voice/tools bridge, manifest host tools, English-pinned instructions on the shared prompt core), and VendoRoot auto-wiring (voice?: VoiceDriver | false). Codex-reviewed twice (5 findings incl. 2×P1 — all fixed).

https://claude.ai/code/session_01JYCxGPaa3BpBqtu6i3iezb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Zero‑config voice for Vendo: adds a server mint route for OpenAI Realtime and a packaged client voice driver, then auto‑wires it in `VendoRoot` when `voice:true` is enabled.

- **New Features**
  - Server (`@vendoai/server`)
    - `POST {basePath}/voice/session` mints ephemeral OpenAI Realtime client secrets; returns 503 when `OPENAI_API_KEY` is missing; binds mints to the guarded principal via `OpenAI-Safety-Identifier`; sanitizes upstream errors.
    - `GET|POST {basePath}/voice/tools` bridges connected Composio tools for voice with tier mapping and output caps.
  - Client (`@vendoai/next/client`)
    - `createVendoVoice()` fetches voice sessions and exposes on-screen tools: `show_table`, `show_key_value`, and `show_money_flow` (with Sankey schema validation).
    - Auto-loads connected integration tools via the server bridge; read tools register replays and bind generated views to live sources.
    - `VendoRoot` auto-creates the packaged voice driver when `capabilities.voice` is true; `voice={false}` opts out; a custom `VoiceDriver` overrides.
  - Shell (`@vendoai/shell`)
    - Replay registry now returns unregister handles; packaged driver cleans up on teardown.

- **Migration**
  - Set `OPENAI_API_KEY` on the host. Optional: `OPENAI_REALTIME_MODEL` and `OPENAI_REALTIME_VOICE`.
  - No app changes needed if you use `VendoRoot`; voice appears automatically when enabled.
  - To opt out, pass `voice={false}`. To customize, pass your own `VoiceDriver`.

<sup>Written for commit 1870fc846b3fc7de68296aa7460e6e2744cfe647. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

