### PR TITLE
cli: pglite host dep + graceful LLM-step degradation in init

### DIFF
--- a/packages/vendo-cli/src/cli.ts
+++ b/packages/vendo-cli/src/cli.ts
@@ -81,7 +81,7 @@ export async function main(argv: string[]): Promise<number> {
     case "telemetry":
       return runTelemetryCmd(rest.find((a) => !a.startsWith("--")), { log: (m) => console.log(m) });
     case "--version":
-      console.log("0.0.0");
+      console.log("0.1.0");
       return 0;
     default:
       console.log(HELP);

--- a/packages/vendo-cli/src/init.test.ts
+++ b/packages/vendo-cli/src/init.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir, writeFile, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { runInit } from "./init.js";
-import { textModel } from "./test-helpers.js";
+import { textModel, throwingModel } from "./test-helpers.js";
 
 const ROUTE_REPLY = JSON.stringify([{
   name: "list_things", description: "List things.", method: "get", path: "/api/things",
@@ -74,6 +74,45 @@ describe("runInit e2e (mock model)", () => {
         if (v === undefined) delete process.env[k];
         else process.env[k] = v;
       }
+    }
+  });
+
+  it("falls back to non-LLM init and still wires Next when route scan generation fails", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "init-"));
+    await writeFile(path.join(dir, "package.json"), JSON.stringify({ name: "host-app", dependencies: { next: "16.0.0" } }));
+    await writeFile(path.join(dir, "tsconfig.json"), "{}");
+    await mkdir(path.join(dir, "app/api/things"), { recursive: true });
+    await writeFile(
+      path.join(dir, "app/layout.tsx"),
+      "export default function RootLayout({ children }: { children: React.ReactNode }) { return <html><body>{children}</body></html>; }\n",
+    );
+    await writeFile(path.join(dir, "app/api/things/route.ts"), "export async function GET() { return Response.json([]); }\n");
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const code = await runInit({
+        targetDir: dir,
+        skipLlm: false,
+        force: false,
+        model: throwingModel("temperature is deprecated for this model"),
+      });
+      expect(code).toBe(0);
+      expect(err.mock.calls.flat().join("\n")).toContain("LLM-assisted route scan failed");
+      expect(err.mock.calls.flat().join("\n")).toContain("temperature is deprecated");
+      const out = log.mock.calls.flat().join("\n");
+      expect(out).toContain("next wiring:");
+      expect(out).toContain("LLM steps skipped");
+      const route = await readFile(path.join(dir, "app/api/vendo/[...path]/route.ts"), "utf8");
+      expect(route).toContain("createVendoHandler()");
+      const pkg = JSON.parse(await readFile(path.join(dir, "package.json"), "utf8")) as {
+        dependencies: Record<string, string>;
+      };
+      expect(pkg.dependencies["@vendoai/next"]).toBe("latest");
+      expect(pkg.dependencies["@electric-sql/pglite"]).toBe("^0.2.0");
+    } finally {
+      log.mockRestore();
+      err.mockRestore();
     }
   });
 

--- a/packages/vendo-cli/src/init.ts
+++ b/packages/vendo-cli/src/init.ts
@@ -39,7 +39,7 @@ function noopTelemetry(): Telemetry {
 function initRunTelemetry(opts: InitOptions): Telemetry {
   try {
     return initTelemetry({
-      version: "0.0.0",
+      version: "0.1.0",
       runtime: false,
       home: opts.telemetry?.home,
       posthogKey: opts.telemetry?.posthogKey ?? process.env.VENDO_POSTHOG_KEY,
@@ -114,6 +114,10 @@ registry ships (ENG-198). Embedded hosts read this directory from disk.
 `;
 }
 
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 export async function runInit(opts: InitOptions): Promise<number> {
   const startedAt = Date.now();
   const targetDir = path.resolve(opts.targetDir);
@@ -136,20 +140,55 @@ export async function runInit(opts: InitOptions): Promise<number> {
     return 1;
   }
 
-  const report: InitReport = { info, theme: null, tools: null, components: null, llmSkipped: model === null };
+  const report: InitReport = {
+    info,
+    theme: null,
+    tools: null,
+    components: null,
+    llmSkipped: model === null,
+    llmSkippedReason: model === null
+      ? (opts.skipLlm ? "--skip-llm" : "no ANTHROPIC_API_KEY/OPENAI_API_KEY/GOOGLE_GENERATIVE_AI_API_KEY")
+      : undefined,
+  };
   let failedStep: InitFailedStep = "theme";
   try {
     failedStep = "theme";
     report.theme = await extractTheme(targetDir, info, opts);
     failedStep = "tools";
-    report.tools = await extractTools(targetDir, info, model, opts);
+    try {
+      report.tools = await extractTools(targetDir, info, model, opts);
+    } catch (err) {
+      // LLM route scanning is optional. If the provider rejects, warns via an
+      // exception, or otherwise fails, keep the deterministic init path moving
+      // so Next wiring still happens and the developer gets a reviewable diff.
+      // Deterministic OpenAPI conversion errors still fail init normally.
+      if (!model || info.openapiPath) throw err;
+      const message = errorMessage(err);
+      console.error(`LLM-assisted route scan failed; continuing without LLM: ${message}`);
+      model = null;
+      report.llmSkipped = true;
+      report.llmSkippedReason = "LLM-assisted route scan failed; continuing without LLM";
+      report.tools = await extractTools(targetDir, info, null, opts);
+      report.tools.errors.unshift(`LLM-assisted route scan failed (${message}) — continuing without LLM`);
+    }
     if (model) {
       failedStep = "components";
-      report.components = await extractComponents(targetDir, model, opts);
+      try {
+        report.components = await extractComponents(targetDir, model, opts);
+      } catch (err) {
+        const message = errorMessage(err);
+        console.error(`LLM-assisted component discovery failed; continuing without generated components: ${message}`);
+        report.components = {
+          candidates: 0,
+          written: [],
+          excluded: [],
+          failed: [{ file: "(component discovery)", error: message }],
+        };
+      }
     }
     await writeGenerated(path.join(targetDir, ".vendo/README.md"), readmeSource(report), opts);
   } catch (err) {
-    console.error(err instanceof Error ? err.message : String(err));
+    console.error(errorMessage(err));
     await t.track("init_failed", { framework, failedStep });
     return 1;
   }

--- a/packages/vendo-cli/src/llm.test.ts
+++ b/packages/vendo-cli/src/llm.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import type { LanguageModel } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import type { LanguageModelV3GenerateResult } from "@ai-sdk/provider";
 import { cliModel, generateJson } from "./llm.js";
 import { textModel } from "./test-helpers.js";
 
 const schema = z.object({ ok: z.boolean() });
+const ZERO_USAGE: LanguageModelV3GenerateResult["usage"] = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+};
 
 describe("generateJson", () => {
   it("parses fenced JSON", async () => {
@@ -20,6 +26,23 @@ describe("generateJson", () => {
   it("recovers on the retry", async () => {
     const model = textModel(["nope", '{"ok": false}']);
     expect(await generateJson({ model, schema, prompt: "x" })).toEqual({ ok: false });
+  });
+
+  it("does not force a temperature override", async () => {
+    const calls: unknown[] = [];
+    const model = new MockLanguageModelV3({
+      doGenerate: async (opts): Promise<LanguageModelV3GenerateResult> => {
+        calls.push(opts);
+        return {
+          content: [{ type: "text", text: '{"ok": true}' }],
+          finishReason: { unified: "stop", raw: undefined },
+          usage: ZERO_USAGE,
+          warnings: [],
+        };
+      },
+    });
+    await expect(generateJson({ model, schema, prompt: "x" })).resolves.toEqual({ ok: true });
+    expect(JSON.stringify(calls)).not.toContain("temperature");
   });
 });
 

--- a/packages/vendo-cli/src/local-pack.test.ts
+++ b/packages/vendo-cli/src/local-pack.test.ts
@@ -4,17 +4,23 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { installLocalVendoPackages, rewritePackageJsonForLocalVendo, type LocalTarball } from "./local-pack.js";
 
+const TEST_PACKAGE_VERSION = "0.1.0";
+const vendoTarball = (name: string) => `${name.replace("@", "").replace("/", "-")}-${TEST_PACKAGE_VERSION}.tgz`;
+const nextTarball = vendoTarball("@vendoai/next");
+const shellTarball = vendoTarball("@vendoai/shell");
+const coreTarball = vendoTarball("@vendoai/core");
+
 const LOCAL_TARBALLS: LocalTarball[] = [
-  { name: "@vendoai/components", fileName: "vendoai-components-0.0.0.tgz" },
-  { name: "@vendoai/core", fileName: "vendoai-core-0.0.0.tgz" },
-  { name: "@vendoai/next", fileName: "vendoai-next-0.0.0.tgz" },
-  { name: "@vendoai/react", fileName: "vendoai-react-0.0.0.tgz" },
-  { name: "@vendoai/runtime", fileName: "vendoai-runtime-0.0.0.tgz" },
-  { name: "@vendoai/server", fileName: "vendoai-server-0.0.0.tgz" },
-  { name: "@vendoai/shell", fileName: "vendoai-shell-0.0.0.tgz" },
-  { name: "@vendoai/stage", fileName: "vendoai-stage-0.0.0.tgz" },
-  { name: "@vendoai/store", fileName: "vendoai-store-0.0.0.tgz" },
-  { name: "@vendoai/telemetry", fileName: "vendoai-telemetry-0.0.0.tgz" },
+  { name: "@vendoai/components", fileName: vendoTarball("@vendoai/components") },
+  { name: "@vendoai/core", fileName: coreTarball },
+  { name: "@vendoai/next", fileName: nextTarball },
+  { name: "@vendoai/react", fileName: vendoTarball("@vendoai/react") },
+  { name: "@vendoai/runtime", fileName: vendoTarball("@vendoai/runtime") },
+  { name: "@vendoai/server", fileName: vendoTarball("@vendoai/server") },
+  { name: "@vendoai/shell", fileName: shellTarball },
+  { name: "@vendoai/stage", fileName: vendoTarball("@vendoai/stage") },
+  { name: "@vendoai/store", fileName: vendoTarball("@vendoai/store") },
+  { name: "@vendoai/telemetry", fileName: vendoTarball("@vendoai/telemetry") },
   { name: "fluidkit", fileName: "fluidkit-0.5.0-656857b.tgz" },
 ];
 
@@ -36,8 +42,8 @@ describe("rewritePackageJsonForLocalVendo", () => {
       dependencies: Record<string, string>;
       pnpm: { overrides: Record<string, string> };
     };
-    expect(pkg.dependencies["@vendoai/next"]).toBe("file:vendor/vendoai-next-0.0.0.tgz");
-    expect(pkg.dependencies["@vendoai/shell"]).toBe("file:vendor/vendoai-shell-0.0.0.tgz");
+    expect(pkg.dependencies["@vendoai/next"]).toBe(`file:vendor/${nextTarball}`);
+    expect(pkg.dependencies["@vendoai/shell"]).toBe(`file:vendor/${shellTarball}`);
     expect(pkg.dependencies["next"]).toBe("16.0.0");
     for (const tarball of LOCAL_TARBALLS) {
       expect(pkg.pnpm.overrides[tarball.name]).toBe(`file:vendor/${tarball.fileName}`);
@@ -62,9 +68,9 @@ describe("rewritePackageJsonForLocalVendo", () => {
       overrides: Record<string, unknown>;
       pnpm?: unknown;
     };
-    expect(pkg.dependencies["@vendoai/next"]).toBe("file:vendor/vendoai-next-0.0.0.tgz");
-    expect(pkg.dependencies["@vendoai/shell"]).toBe("file:vendor/vendoai-shell-0.0.0.tgz");
-    expect(pkg.overrides["@vendoai/core"]).toBe("file:vendor/vendoai-core-0.0.0.tgz");
+    expect(pkg.dependencies["@vendoai/next"]).toBe(`file:vendor/${nextTarball}`);
+    expect(pkg.dependencies["@vendoai/shell"]).toBe(`file:vendor/${shellTarball}`);
+    expect(pkg.overrides["@vendoai/core"]).toBe(`file:vendor/${coreTarball}`);
     expect(pkg.overrides["fluidkit"]).toBe("file:vendor/fluidkit-0.5.0-656857b.tgz");
     expect(pkg.overrides["zod"]).toBe("^3.24.0");
     expect(pkg.overrides["eslint"]).toEqual({ chalk: "5.0.0" });
@@ -107,7 +113,7 @@ async function createPackableLocalRepo(withFluidkit = true): Promise<string> {
     const pkgDir = path.join(repoDir, "packages", dirName);
     await writeJson(path.join(pkgDir, "package.json"), {
       name,
-      version: "0.0.0",
+      version: TEST_PACKAGE_VERSION,
       type: "module",
       main: "index.js",
       files: ["index.js"],
@@ -139,18 +145,18 @@ describe("installLocalVendoPackages", () => {
     expect(summary.installCommand).toBe("pnpm install");
 
     const vendorFiles = await readdir(path.join(targetDir, "vendor"));
-    expect(vendorFiles).toContain("vendoai-next-0.0.0.tgz");
-    expect(vendorFiles).toContain("vendoai-shell-0.0.0.tgz");
+    expect(vendorFiles).toContain(nextTarball);
+    expect(vendorFiles).toContain(shellTarball);
     expect(vendorFiles).toContain("fluidkit-0.5.0-test.tgz");
 
     const pkg = JSON.parse(await readFile(path.join(targetDir, "package.json"), "utf8")) as {
       dependencies: Record<string, string>;
       pnpm: { overrides: Record<string, string> };
     };
-    expect(pkg.dependencies["@vendoai/next"]).toBe("file:vendor/vendoai-next-0.0.0.tgz");
-    expect(pkg.dependencies["@vendoai/shell"]).toBe("file:vendor/vendoai-shell-0.0.0.tgz");
-    expect(pkg.pnpm.overrides["@vendoai/next"]).toBe("file:vendor/vendoai-next-0.0.0.tgz");
-    expect(pkg.pnpm.overrides["@vendoai/shell"]).toBe("file:vendor/vendoai-shell-0.0.0.tgz");
+    expect(pkg.dependencies["@vendoai/next"]).toBe(`file:vendor/${nextTarball}`);
+    expect(pkg.dependencies["@vendoai/shell"]).toBe(`file:vendor/${shellTarball}`);
+    expect(pkg.pnpm.overrides["@vendoai/next"]).toBe(`file:vendor/${nextTarball}`);
+    expect(pkg.pnpm.overrides["@vendoai/shell"]).toBe(`file:vendor/${shellTarball}`);
     expect(pkg.pnpm.overrides["fluidkit"]).toBe("file:vendor/fluidkit-0.5.0-test.tgz");
   });
 

--- a/packages/vendo-cli/src/next-wiring.test.ts
+++ b/packages/vendo-cli/src/next-wiring.test.ts
@@ -303,6 +303,7 @@ describe("wireNextApp", () => {
       dependencies: Record<string, string>;
     };
     expect(pkg.dependencies["@vendoai/next"]).toBeDefined();
+    expect(pkg.dependencies["@electric-sql/pglite"]).toBe("^0.2.0");
     const nextConfig = await fs.readFile(path.join(dir, "next.config.ts"), "utf8");
     expect(nextConfig).toContain('transpilePackages: [');
     expect(nextConfig).toContain('"@vendoai/next"');
@@ -335,11 +336,15 @@ describe("wireNextApp", () => {
     const dir = await scaffoldFreshApp(false);
     const info = await detectTarget(dir);
     const summary = (await wireNextApp(dir, info, { force: false }))!;
+    const pkg = JSON.parse(await fs.readFile(path.join(dir, "package.json"), "utf8")) as {
+      dependencies: Record<string, string>;
+    };
     const config = await fs.readFile(path.join(dir, "next.config.ts"), "utf8");
     expect(summary.written).toContain("next.config.ts");
     expect(config).toContain('import type { NextConfig } from "next"');
     expect(config).toContain('"@vendoai/next"');
     expect(config).toContain('"@electric-sql/pglite"');
+    expect(pkg.dependencies["@electric-sql/pglite"]).toBe("^0.2.0");
   });
 
   it("edits a simple next.config object literal without removing existing entries", async () => {
@@ -422,12 +427,14 @@ export default withAnalyzer({});
     const instrumentationAfterFirst = await fs.readFile(path.join(dir, "instrumentation.ts"), "utf8");
     const envAfterFirst = await fs.readFile(path.join(dir, ".env.example"), "utf8");
     const nextConfigAfterFirst = await fs.readFile(path.join(dir, "next.config.ts"), "utf8");
+    const pkgAfterFirst = await fs.readFile(path.join(dir, "package.json"), "utf8");
     const second = (await wireNextApp(dir, info, { force: false }))!;
     expect(second.edited).toEqual([]);
     expect(await fs.readFile(path.join(dir, "app/layout.tsx"), "utf8")).toBe(layoutAfterFirst);
     expect(await fs.readFile(path.join(dir, "instrumentation.ts"), "utf8")).toBe(instrumentationAfterFirst);
     expect(await fs.readFile(path.join(dir, ".env.example"), "utf8")).toBe(envAfterFirst);
     expect(await fs.readFile(path.join(dir, "next.config.ts"), "utf8")).toBe(nextConfigAfterFirst);
+    expect(await fs.readFile(path.join(dir, "package.json"), "utf8")).toBe(pkgAfterFirst);
   });
 
   it("fails open on an unrecognizable layout: files written, layout untouched, manual steps printed", async () => {

--- a/packages/vendo-cli/src/next-wiring.ts
+++ b/packages/vendo-cli/src/next-wiring.ts
@@ -59,6 +59,8 @@ export const VENDO_TRANSPILE_PACKAGES = [
 ] as const;
 
 const NEXT_SERVER_EXTERNAL_PACKAGES = ["@electric-sql/pglite"] as const;
+const PGLITE_DEPENDENCY = "@electric-sql/pglite";
+const PGLITE_VERSION = "^0.2.0";
 
 /** Locate the App Router directory (`app/` or `src/app/`) with a root layout. */
 export async function findAppDir(
@@ -829,23 +831,27 @@ export async function wireNextApp(
     summary.written.push(rel(dest));
   }
 
-  // 8. package.json: @vendoai/next dependency + prebuild sync wiring.
+  // 8. package.json: @vendoai/next + PGlite dependencies + prebuild sync
+  // wiring. PGlite is also server-externalized in next.config, but pnpm's
+  // strict node_modules still requires it to be resolvable from the app root.
   if (pkgRaw) {
     const withDep = addDependency(pkgRaw, "@vendoai/next", "latest");
     if (withDep === null) {
-      summary.skipped.push({ step: "package.json", reason: "unparsable — add @vendoai/next yourself" });
+      summary.skipped.push({ step: "package.json", reason: "unparsable — add @vendoai/next and @electric-sql/pglite yourself" });
       summary.manual.push('add "@vendoai/next" to package.json dependencies and install');
+      summary.manual.push('add "@electric-sql/pglite" to package.json dependencies and install');
       summary.manual.push('add "vendo sync" to your package.json "prebuild" script');
     } else {
-      const withSync = addPrebuildSync(withDep) ?? withDep;
+      const withPglite = addDependency(withDep, PGLITE_DEPENDENCY, PGLITE_VERSION) ?? withDep;
+      const withSync = addPrebuildSync(withPglite) ?? withPglite;
       if (withSync !== pkgRaw) {
         await fs.writeFile(path.join(targetDir, "package.json"), withSync);
         summary.edited.push("package.json");
-        if (withDep !== pkgRaw) {
-          summary.manual.push("run your package manager's install (npm/pnpm/yarn) to pull @vendoai/next");
+        if (withPglite !== pkgRaw) {
+          summary.manual.push("run your package manager's install (npm/pnpm/yarn) to pull @vendoai/next and @electric-sql/pglite");
         }
       } else {
-        summary.skipped.push({ step: "package.json", reason: "@vendoai/next + prebuild sync already present" });
+        summary.skipped.push({ step: "package.json", reason: "@vendoai/next + @electric-sql/pglite + prebuild sync already present" });
       }
     }
   }

--- a/packages/vendo-cli/src/report.ts
+++ b/packages/vendo-cli/src/report.ts
@@ -9,6 +9,7 @@ export interface InitReport {
   tools: ToolsSummary | null;
   components: ComponentsSummary | null;
   llmSkipped: boolean;
+  llmSkippedReason?: string;
 }
 
 export function renderReport(r: InitReport): string {
@@ -30,7 +31,12 @@ export function renderReport(r: InitReport): string {
     for (const x of r.components.excluded) lines.push(`  excluded ${x.file}: ${x.reason}`);
     for (const f of r.components.failed) lines.push(`  FAILED ${f.file}: ${f.error}`);
   }
-  if (r.llmSkipped) lines.push("LLM steps skipped (no ANTHROPIC_API_KEY/OPENAI_API_KEY/GOOGLE_GENERATIVE_AI_API_KEY or --skip-llm): route-scan fallback, component discovery");
+  if (r.llmSkipped) {
+    const reason =
+      r.llmSkippedReason ??
+      "no ANTHROPIC_API_KEY/OPENAI_API_KEY/GOOGLE_GENERATIVE_AI_API_KEY or --skip-llm";
+    lines.push(`LLM steps skipped (${reason}): route-scan fallback, component discovery`);
+  }
   lines.push("Extraction output is in .vendo/ — review and edit it (any wiring changes are listed below).");
   return lines.join("\n");
 }

--- a/packages/vendo-cli/src/test-helpers.ts
+++ b/packages/vendo-cli/src/test-helpers.ts
@@ -24,3 +24,11 @@ export function textModel(responses: string[]): MockLanguageModelV3 {
     }),
   });
 }
+
+export function throwingModel(message: string): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    doGenerate: async (): Promise<LanguageModelV3GenerateResult> => {
+      throw new Error(message);
+    },
+  });
+}


### PR DESCRIPTION
Acceptance-testing follow-ups: wireNextApp adds @electric-sql/pglite to host dependencies (serverExternalPackages alone can't resolve it under pnpm strict layout), and LLM-assisted init steps now degrade to the deterministic path with a printed error instead of silently exiting after theme extraction (also drops the forced temperature that warned on newer models).

https://claude.ai/code/session_01JYCxGPaa3BpBqtu6i3iezb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Next app wiring to install `@electric-sql/pglite` and makes `vendo init` resilient: LLM-assisted steps now fail gracefully and fall back to the deterministic path with clear errors instead of aborting. Also bumps CLI/telemetry to 0.1.0.

- **Bug Fixes**
  - Add `@electric-sql/pglite@^0.2.0` to host `package.json` during Next wiring; needed under pnpm strict layout even with server externals.
  - If LLM route scan fails, continue without LLM: keep Next wiring, run deterministic tools, print the provider error; report now includes `llmSkippedReason`.
  - Component discovery failures no longer abort init; they’re captured in the report.
  - Stop forcing `temperature` in `generateJson` to avoid provider warnings/deprecations.

<sup>Written for commit 701987af569e8aa2d6b3abefc64afa60d4cf472c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

