### PR TITLE
Restore Mintlify docs site into the repo

### DIFF
--- a/docs-site/capabilities/automations.mdx
+++ b/docs-site/capabilities/automations.mdx
@@ -1,0 +1,74 @@
+---
+title: "Automations"
+description: "Schedules and triggers your customers set up in chat"
+---
+
+Automations let customers describe standing behavior in chat, then approve an inspectable spec before it starts running.
+
+The packaged handler enables automation authoring by default. Pass `automations: false` to remove the authoring tools and make automation routes such as `POST /api/vendo/tick` return `404`.
+
+## What Customers Can Create
+
+Vendo's automation DSL supports these trigger types:
+
+- `schedule` with either a cron expression plus an IANA `timezone`, or a one-shot `at` timestamp.
+- `composio` with a Composio trigger slug and optional trigger config.
+- `host_event` with an event name.
+
+With `createVendoHandler` today, schedules are wired through the in-process scheduler or `POST /api/vendo/tick`, and Composio triggers are wired through `POST /api/vendo/webhooks/composio`. Host-event ingestion is implemented in `@vendoai/runtime` through `createHostEventIngest`, but the packaged handler does not expose a host-event declaration option yet.
+
+Automation steps can be:
+
+- Fixed tool calls.
+- Agent steps with a tool allowlist and an optional output JSON Schema.
+- Branches.
+- Bounded `for_each` loops.
+
+The spec is capped at 25 total steps, `for_each` is capped at 100 items, and `maxFiringsPerHour` is capped at 60.
+
+## Tool Registration
+
+Unattended automations can only call server-registered tools. Host API tools from `.vendo/tools.json` execute in the customer's browser session, so Vendo rejects them for unattended runs.
+
+Register server-executed tools through:
+
+```ts
+createVendoHandler({
+  automations: {
+    tools: {
+      // Record<string, RegisteredTool>
+    },
+  },
+});
+```
+
+That closed world is what `create_automation` and `update_automation` validate against. If the agent references a tool that is not registered for automations, the tool call returns a correction error instead of saving a broken automation.
+
+## Versions and Grants
+
+Every edit creates a new immutable version. Runs point at the exact version they executed, so history remains readable after later edits.
+
+Pre-approval is per tool and per version. The agent passes `grantedTools` only when the customer explicitly authorizes a gated tool for unattended runs. Grants are stored as version metadata, not inside the DSL, and they are hashed against the tool descriptor and the relevant trigger, guard, and step scope. If the spec or tool descriptor changes, the grant no longer matches and Vendo asks again.
+
+Critical tools are never pre-authorized. They pause or park for customer approval when the automation fires.
+
+## Run History and Management
+
+The chat agent gets these automation management tools:
+
+- `create_automation`
+- `list_automations`
+- `get_automation_runs`
+- `pause_automation`
+- `resume_automation`
+- `update_automation`
+- `delete_automation`
+- `run_automation_now`
+
+`get_automation_runs` returns recent run status, timing, test-run flag, errors, and per-step status. `run_automation_now` is a dry run by default: read-only tools execute, mutating tools are simulated and recorded. Passing `live: true` runs through the same policy and grant path as a real firing.
+
+Pausing, editing, or deleting an automation cancels pending approval waits for that automation. One-shot `at` schedules are paused after they finish so they do not rehydrate as enabled forever.
+
+## Persistence
+
+With durable storage, Vendo persists automations, versions, grants, run history, and parked approvals in the handler's storage backend. With `storage: false`, automation state is in memory and disappears on restart.

--- a/docs-site/capabilities/integrations.mdx
+++ b/docs-site/capabilities/integrations.mdx
@@ -1,0 +1,55 @@
+---
+title: "Integrations"
+description: "Connect external tools through Composio-backed OAuth"
+---
+
+Vendo uses Composio for external integrations. When a customer connects a toolkit, Vendo can ingest that toolkit's tools for that customer and run them through the same approval policy as your own tools.
+
+Set the key on the server that hosts `createVendoHandler`.
+
+```bash
+COMPOSIO_API_KEY=...
+```
+
+With the key present, `GET /api/vendo/capabilities` reports `integrations: true` and the integrations tray uses `GET|POST /api/vendo/integrations`.
+
+Without the key, integrations stay inert. The capabilities response reports `integrations: false`, the tray has an empty catalog, and `POST /api/vendo/integrations` returns `503` with a message to set `COMPOSIO_API_KEY`.
+
+## Catalog
+
+Vendo ships a default catalog for Gmail, Slack, Notion, GitHub, Google Calendar, Linear, Google Drive, Discord, Google Sheets, Stripe, Jira, Asana, HubSpot, and Airtable.
+
+You can replace the visible catalog with the `integrations` handler option. Each `id` must be the Composio toolkit slug that Vendo should connect.
+
+```ts
+import { createVendoHandler } from "@vendoai/next";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const { GET, POST } = createVendoHandler({
+  integrations: [
+    { id: "gmail", name: "Gmail" },
+    { id: "slack", name: "Slack" },
+  ],
+});
+```
+
+## Connect Flow
+
+Customers can connect tools in two places:
+
+- The integrations tray lists the catalog, shows connected status, and lets customers connect or disconnect a toolkit.
+- The agent can call `request_connect` when a request needs a toolkit that is not connected yet. That emits a host-rendered `Connect` card with the toolkit and an optional reason.
+
+The default Next client opens the Composio OAuth URL in a popup, polls the status endpoint, and marks the toolkit connected once Composio reports the connected account as active. The next agent turn is built from the connected toolkit list.
+
+## Webhook Triggers
+
+Integration connections also back Composio-triggered automations. For webhook delivery, configure `COMPOSIO_WEBHOOK_SECRET` and point Composio at:
+
+```text
+POST https://your-host.example.com/api/vendo/webhooks/composio
+```
+
+If `COMPOSIO_WEBHOOK_SECRET` is not set, that route returns `404` so unsigned webhook calls cannot fire automations.

--- a/docs-site/capabilities/mcp.mdx
+++ b/docs-site/capabilities/mcp.mdx
@@ -1,0 +1,78 @@
+---
+title: "MCP servers"
+description: "Point Vendo at any remote MCP server, governed by the same approvals"
+---
+
+MCP support is host-configured. You declare remote HTTP MCP servers, and Vendo ingests their tools as agent tools. Customers do not add arbitrary servers at runtime.
+
+Each MCP tool is registered as `<serverName>_<toolName>`, so a server named `weather` with a tool named `get_forecast` appears to the model as `weather_get_forecast`.
+
+## Configure in Code
+
+Pass `mcpServers` to `createVendoHandler`.
+
+```ts
+import { createVendoHandler } from "@vendoai/next";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const { GET, POST } = createVendoHandler({
+  mcpServers: [
+    {
+      name: "weather",
+      url: "https://mcp.example.com/mcp",
+      headers: {
+        Authorization: `Bearer ${process.env.WEATHER_TOKEN}`,
+      },
+      tools: ["get_forecast"],
+    },
+  ],
+});
+```
+
+`tools` is optional. Omit it to ingest every tool the server returns.
+
+## Configure in `.vendo/mcp.json`
+
+You can also check MCP server declarations into `.vendo/mcp.json`.
+
+```json
+{
+  "version": 1,
+  "servers": [
+    {
+      "name": "weather",
+      "url": "https://mcp.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${WEATHER_TOKEN}"
+      },
+      "tools": ["get_forecast"]
+    }
+  ]
+}
+```
+
+Header values in `.vendo/mcp.json` support `${VAR_NAME}` interpolation from the server environment. If a referenced variable is missing or empty, Vendo drops that server and logs a warning. Interpolation only applies to file-based config. In code, read `process.env` yourself.
+
+If both `mcpServers` and `.vendo/mcp.json` are present, the `mcpServers` option wins entirely.
+
+## Limits
+
+Vendo's MCP client supports:
+
+- Streamable HTTP endpoints over `http://` or `https://`.
+- Static headers supplied by the host.
+- Tools.
+
+It does not support stdio servers, per-customer OAuth for MCP servers, resources, prompts, elicitation, sampling, or MCP apps.
+
+MCP has no connect UI in Vendo. The integrations tray is for Composio-backed OAuth integrations only.
+
+## Approvals
+
+MCP tools use the same policy engine as every other tool.
+
+Vendo reads server-sent MCP annotations when available. `readOnlyHint: true` lets a tool run without pausing. `destructiveHint: true` or `openWorldHint: true` pauses for approval. Missing or unknown annotations fail closed and also pause for approval.
+
+If a server cannot be reached, Vendo skips that server for the turn and keeps the rest of the toolset available.

--- a/docs-site/capabilities/saved-views.mdx
+++ b/docs-site/capabilities/saved-views.mdx
@@ -1,0 +1,57 @@
+---
+title: "Saved views"
+description: "Generated views your customers keep, refresh, and reuse"
+---
+
+Saved views are generated UI records that can be reopened later. A saved record stores the view name, generated UI node, originating prompt, optional pin state, host-component version stamp, and timestamps.
+
+The shell exposes the store as `VendoStore`:
+
+```ts
+interface VendoStore {
+  list(): Promise<Vendo[]>;
+  load(id: string): Promise<Vendo | null>;
+  save(draft: VendoDraft): Promise<Vendo>;
+  remove(id: string): Promise<void>;
+}
+```
+
+`VendoRoot` chooses a store from the server capability response. When durable storage is on, it uses the server-backed `/api/vendo/vendos` endpoints. Otherwise it uses `localStorage` with keys under `vendo:saved:<namespace>:`.
+
+There is no automatic `localStorage` to server migration in v1. If you turn durable storage on after customers have local saved views, the server-side library starts empty for those customers.
+
+## Library UI
+
+The shell exports `FlowGallery` for the saved-view library. It sorts pinned views first, then recent views. Each card can open the view, rename it inline, pin or unpin it, or delete it when you provide the corresponding callbacks.
+
+`VendoThread` accepts `flows`, `onOpenFlow`, `onRenameFlow`, `onPinFlow`, and `onDeleteFlow` props for wiring that library into a thread or landing surface.
+
+## Live Refresh
+
+Generated views can declare where their data came from. The `render_view` tool accepts a `queries` array:
+
+```ts
+type DataQuery = {
+  path: string;
+  tool: string;
+  input?: Record<string, unknown>;
+};
+```
+
+`path` is an RFC 6901 JSON Pointer into the generated view's `data` object. On reopen, Vendo renders the saved snapshot immediately. If the view has `queries` and the shell has a `runQuery` seam, Vendo re-runs those queries and patches fresh results into the same view tree.
+
+Reopen refresh is read-only. The default Next client only replays manifest tools whose `.vendo/tools.json` annotation has `mutating: false`. Route-scanned tools are fail-closed as mutating until you review and relax the annotation by hand.
+
+Refresh results have three states:
+
+- `live`: every query refreshed successfully.
+- `partial`: at least one query refreshed and at least one fell back to the snapshot.
+- `snapshot`: no query refreshed, or the view had no queries.
+
+Open saved views refresh every 60 seconds by default, only while the tab is visible. Set `refreshIntervalMs={0}` on `VendoShellProvider` to disable the interval. After repeated full-refresh failures, the open view stops polling and keeps the latest snapshot or partial result.
+
+When a refresh succeeds, Vendo writes the fresh data back to the current saved record. Rename and pin changes made during a refresh are preserved, and a deleted record is not recreated by a late refresh.
+
+## Undo
+
+`FlowGallery` calls your `onDeleteFlow` callback directly. The shell also exports `VendoToast`, a small undo toast with an action button. Use it to implement delete as an undoable action: remove the record, show the toast, and re-save the captured draft if the customer clicks Undo.

--- a/docs-site/capabilities/voice.mdx
+++ b/docs-site/capabilities/voice.mdx
@@ -1,0 +1,18 @@
+---
+title: "Voice"
+description: "Realtime voice sessions over the same tools and views"
+---
+
+Voice is implemented in `@vendoai/shell` as a `VoiceDriver` seam plus the `VoiceStage` UI. A voice session can call the same kind of tools as chat, render views into the stage, and land its transcript and generated views back into the thread when the session closes.
+
+Set `OPENAI_API_KEY` on your server to make the handler report `voice: true` from `GET /api/vendo/capabilities`.
+
+<Warning>
+  The default `VendoRoot` does not auto-wire a realtime voice driver yet. The stage package, `@vendoai/stage`, is the generated-UI sandbox and action bridge, not the voice runtime. To ship voice today, wire a `VoiceDriver` into `VendoThread` or `VendoSlot`.
+</Warning>
+
+`@vendoai/shell` exports `createRealtimeVoiceDriver`. It expects a `getSession()` function that returns an ephemeral Realtime client secret. Keep your raw `OPENAI_API_KEY` on the server. The browser receives only the ephemeral secret.
+
+Voice approvals follow the same tier model as chat. Read tools run directly. Act tools show a consent bar and can be approved by voice or by tapping. Critical tools require on-screen confirmation.
+
+Voice sessions can receive a compact thread brief, visible views, recent tool results, and saved views. If you pass saved views into `VendoThread`, the session also gets an `open_saved_vendo` tool so a customer can ask for a saved view by name.

--- a/docs-site/capability-keys.mdx
+++ b/docs-site/capability-keys.mdx
@@ -1,0 +1,76 @@
+---
+title: "Capability keys"
+description: "Each key you add turns on another Vendo capability"
+---
+
+Vendo treats keys as additive. A missing key turns a capability off and the client hides that surface.
+
+| What you set | Capability | What changes |
+| --- | --- | --- |
+| Any one of `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY` | `chat: true` | Chat and generated UI work. |
+| A handler option `model` | `chat: true` | Chat works even without provider env keys, because your code supplied the model. |
+| `OPENAI_API_KEY` | `voice: true` | The server reports the voice capability flag. |
+| `COMPOSIO_API_KEY` | `integrations: true` | The integrations endpoints and connect UI become active. |
+| At least one resolved MCP server in `mcpServers` or `.vendo/mcp.json` | `mcp: true` | MCP tools can be ingested by the agent. |
+
+## Provider selection
+
+When more than one provider key is present and `VENDO_MODEL` does not choose a provider, Vendo picks the first provider in this order:
+
+1. `ANTHROPIC_API_KEY`
+2. `OPENAI_API_KEY`
+3. `GOOGLE_GENERATIVE_AI_API_KEY`
+
+The default model ids are:
+
+| Provider | Default model id |
+| --- | --- |
+| Anthropic | `claude-sonnet-5` |
+| OpenAI | `gpt-5.5` |
+| Google | `gemini-3.5-flash` |
+
+OpenAI and Google model resolution loads optional peer packages only when those providers are selected. Install `@ai-sdk/openai` for OpenAI models and `@ai-sdk/google` for Google models.
+
+## `VENDO_MODEL`
+
+`VENDO_MODEL` names the model. It is not a credential.
+
+Use `provider/model` to choose both provider and model:
+
+```bash
+VENDO_MODEL=openai/gpt-5.5-mini
+```
+
+Supported provider prefixes are `anthropic`, `openai`, and `google`. Set the credential for the provider you choose.
+
+Use a bare model id to keep provider selection based on your provider keys:
+
+```bash
+VENDO_MODEL=claude-sonnet-4-6
+```
+
+With a bare model id and no provider key, model resolution falls back to Anthropic, but `chat` still stays `false` until you set a provider key or pass a `model` option to the handler.
+
+## Capabilities endpoint
+
+The client reads the capabilities endpoint and gates its UI from the response:
+
+```txt
+GET /api/vendo/capabilities
+```
+
+The response shape is:
+
+```json
+{
+  "chat": true,
+  "integrations": false,
+  "voice": false,
+  "mcp": false,
+  "storage": true
+}
+```
+
+`storage` is `true` when the assembled handler built durable storage. Passing `storage: false` to the handler makes it `false`.
+
+Without `COMPOSIO_API_KEY`, `GET /api/vendo/integrations` returns an empty disabled catalog and connect attempts return 503. Without a chat key or injected model, `POST /api/vendo/chat` returns 503 instead of streaming a provider error.

--- a/docs-site/concepts/architecture.mdx
+++ b/docs-site/concepts/architecture.mdx
@@ -1,0 +1,99 @@
+---
+title: "Architecture"
+description: "Where Vendo runs: your server, your customer's browser, and a sandboxed iframe"
+---
+
+Vendo is an embedded runtime. In the open-source install path, it runs from your
+app's own server and browser surface. Your server talks to the model provider
+using your keys, your customer's browser talks to your app with its existing
+session, and generated UI renders inside a sandboxed iframe.
+
+<Note>
+  There is no Vendo cloud in the OSS path. The default Next.js install serves
+  the handler, shell, tools, storage, scheduler hooks, and sandbox assets from
+  your app.
+</Note>
+
+## Server Process
+
+The server process owns the agent loop and the security decisions. In a Next.js
+App Router app, `vendo init` wires a catch-all route like this:
+
+```ts
+import { createVendoHandler } from "@vendoai/next";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const { GET, POST } = createVendoHandler();
+```
+
+By default that route is mounted at `/api/vendo/*`. The same core handler is
+available as `createVendoFetchHandler()` from `@vendoai/server` for other Node
+servers.
+
+The server process:
+
+- Reads `.vendo/` artifacts such as `theme.json`, `tools.json`, and MCP config.
+- Resolves model capability from your provider keys or a supplied `model`.
+- Builds the toolset for each run, including host API tools, server tools,
+  integrations, MCP tools, and Vendo control tools such as `render_view`.
+- Applies the approval policy before any governed action can run.
+- Serves routes such as `/chat`, `/action`, `/capabilities`, `/integrations`,
+  `/threads`, `/vendos`, `/tick`, and `/webhooks/composio` under your mount.
+- Uses durable storage by default, with embedded PGlite at `.vendo/data` unless
+  you pass `storage: false` or configure Postgres with `DATABASE_URL`.
+
+## Customer Browser
+
+The browser owns the product surface. `VendoRoot` mounts the overlay, launcher,
+theme provider, saved-view store, integration UI, notification toasts, and the
+browser-side host-tool executor.
+
+Host API tools from `.vendo/tools.json` execute in this browser, not on a Vendo
+service. Vendo registers those tools with the server-side agent so the model can
+choose them, but the actual HTTP request is made by the customer's browser with
+`credentials: "include"`. That means the call uses your app's existing session
+and authorization layer.
+
+The browser also renders approval cards, Connect cards, activity panels, saved
+views, and notification toasts. Trust and Waiting surfaces can be wired through
+the shell seams backed by the handler's trust and parked-action routes.
+
+## Sandboxed Iframe
+
+Generated UI is not mounted directly into your app's DOM. Generated `UINode`
+trees render through `@vendoai/stage` inside an iframe with
+`sandbox="allow-scripts"` and no `allow-same-origin`.
+
+The stage `srcdoc` includes a Content Security Policy that blocks network
+egress with `default-src 'none'` and `connect-src 'none'`. Scripts, fonts,
+host CSS, and sandbox modules are delivered as strings or `blob:` URLs that the
+host page fetched from its own origin. Generated components get data, props,
+theme variables, and a governed `props.vendo.dispatch(...)` action path. They
+do not get direct access to cookies, storage, the host DOM, or arbitrary fetch.
+
+The one host-rendered exception is the Connect card. The agent uses
+`request_connect` when a customer needs to authorize an integration, because
+OAuth popups and host-page events require privileges the sandbox does not have.
+
+## Extension Seams
+
+Most customization happens through handler options and `.vendo/` files:
+
+- Identity and access: pass `principal` to make your app's auth the production
+  gate.
+- Model choice: pass `model`, or configure provider keys and `VENDO_MODEL`.
+- Prompt behavior: use `productName`, `instructionsExtra`, or a full
+  `instructions` override.
+- Tools: edit `.vendo/tools.json`, pass `hostTools`, add server-side `tools`,
+  or declare `mcpServers`.
+- UI: edit `.vendo/theme.json`, register `components`, and serve the sandbox
+  assets under `public/vendo/`.
+- Persistence: use the default storage, pass `storage`, or inject `store` and
+  `connections` implementations.
+
+Internally these map to stable runtime seams: Store, CredentialBroker,
+Executor, Scheduler, and Channels. You do not need to implement those seams for
+the default install, but they explain where Vendo can be replaced or fronted by
+host-owned infrastructure.

--- a/docs-site/concepts/generated-ui.mdx
+++ b/docs-site/concepts/generated-ui.mdx
@@ -1,0 +1,133 @@
+---
+title: "Generated UI and the sandbox"
+description: "How views are composed and why they render in an egress-jailed sandbox"
+---
+
+Vendo renders generated UI through one built-in tool: `render_view`. The tool
+does not stream HTML. It streams a validated Vendo GenUI payload, which the
+host resolves into a `UINode` tree and renders inside the sandboxed stage.
+
+## The `render_view` Payload
+
+`render_view` accepts one `GeneratedPayload` with
+`formatVersion: "vendo-genui/v1"`.
+
+```json
+{
+  "formatVersion": "vendo-genui/v1",
+  "root": "summary",
+  "nodes": [
+    {
+      "id": "summary",
+      "component": "Surface",
+      "children": ["title", "value"]
+    },
+    {
+      "id": "title",
+      "component": "Text",
+      "props": { "variant": "label", "text": "Current balance" }
+    },
+    {
+      "id": "value",
+      "component": "Text",
+      "props": { "variant": "value", "text": { "$path": "/balance" } }
+    }
+  ],
+  "data": {
+    "balance": "$12,480.00"
+  }
+}
+```
+
+The node list is flat. Each node has an `id`, a `component`, optional `props`,
+and optional `children` containing child node ids. The `root` id selects the
+top node. During rendering, Vendo resolves the flat graph into a nested
+`UINode` tree.
+
+A prop value can bind to the payload data model with `{ "$path": "/json/pointer" }`.
+The data stays in the payload. Generated components can transform it while
+rendering, but Vendo does not ask the model to copy large tool results into
+many props.
+
+## Component Sources
+
+Each node can come from one of three sources:
+
+- `prewired`: built-in primitives shipped with the stage, including `Stack`,
+  `Row`, `Grid`, `Surface`, `Divider`, `Text`, and `Skeleton`. If `source` is
+  omitted, Vendo treats the node as `prewired`.
+- `host`: registered host components from your app's component catalog.
+  Vendo validates registered host component props before streaming when it has
+  the component descriptors.
+- `generated`: React component code carried in the payload's `components` map.
+  The generated component name must be PascalCase and must match a node whose
+  `source` is `generated`.
+
+Generated component source is compiled server-side before it is sent to the
+stage. The code runs only inside the sandbox.
+
+```json
+{
+  "formatVersion": "vendo-genui/v1",
+  "root": "chart",
+  "nodes": [
+    {
+      "id": "chart",
+      "source": "generated",
+      "component": "MiniChart",
+      "props": { "points": { "$path": "/points" } }
+    }
+  ],
+  "data": {
+    "points": [4, 8, 6, 12]
+  },
+  "components": {
+    "MiniChart": "export default function MiniChart(props) { return <pre>{JSON.stringify(props.points)}</pre>; }"
+  }
+}
+```
+
+## Refreshable Data
+
+When a view displays data fetched from a tool, `render_view` can declare
+`queries`. Each query names the tool call that produced one subtree of `data`.
+Saved views can re-run those queries later through the same policy-governed
+tool path and patch fresh results back into the view.
+
+```json
+{
+  "path": "/invoices",
+  "tool": "listInvoices",
+  "input": { "limit": 25 }
+}
+```
+
+## The Sandbox Boundary
+
+Generated UI renders in `@vendoai/stage`, an iframe created with
+`sandbox="allow-scripts"` and no `allow-same-origin`. The stage document
+injects a strict CSP:
+
+- `default-src 'none'`
+- `connect-src 'none'`
+- `img-src data:`
+- `font-src data:`
+- scripts only from the generated nonce and `blob:` URLs
+
+That means generated code cannot fetch, open WebSockets, read cookies, touch
+host storage, or inspect your app DOM. Assets and modules that the stage needs
+are fetched by the host page first, then passed into the iframe as text and
+loaded from `blob:` URLs.
+
+Generated components can still ask your app to do something. They call
+`props.vendo.dispatch({ action, payload })`, which crosses the bridge as a
+`tools/call` request. The host validates the node capability, applies policy,
+and either executes the action, asks for approval, or rejects it.
+
+## The Connect Card Exception
+
+Integration authorization is deliberately not rendered with `render_view`.
+When the model needs an integration the customer has not connected, it calls
+`request_connect`. That emits a host-rendered component named `Connect`, so the
+OAuth flow can use host-page privileges such as popups, window events, and the
+integration routes served by your handler.

--- a/docs-site/concepts/prompts.mdx
+++ b/docs-site/concepts/prompts.mdx
@@ -1,0 +1,108 @@
+---
+title: "How prompts are assembled"
+description: "Platform guardrails plus your identity, brand, and instructions"
+---
+
+Vendo builds the system prompt at run time. The default handler prompt combines
+platform behavior, your app identity, your brand, your available tools, and
+your extra instructions.
+
+## Default Assembly
+
+With `createVendoHandler()` and no full prompt override, Vendo assembles the
+prompt from these inputs:
+
+- Product identity from `productName`.
+- Platform behavior: when to answer in text, when to call `render_view`, how
+  approvals work, how to talk about capabilities, and how to use Connect cards.
+- Brand guidance from `.vendo/theme.json`.
+- Prewired and host component catalogs.
+- Host API capability text from `.vendo/tools.json` or `hostTools`.
+- Integration, MCP, and automation guidance when those capabilities are present.
+- A live per-run tool summary from `ctx.toolSummary`.
+- Your `instructionsExtra`, if supplied.
+- Final non-negotiable guardrails.
+
+The guardrail section is appended last in the default prompt. If your extra
+instructions conflict with Vendo safety rules, the safety rules win.
+
+## Add Host Instructions
+
+Use `instructionsExtra` for normal customization. It is appended before the
+final guardrail section, so you can add product-specific behavior without
+replacing the platform prompt.
+
+```ts
+import { createVendoHandler } from "@vendoai/next";
+
+export const { GET, POST } = createVendoHandler({
+  productName: "Acme",
+  instructionsExtra: [
+    "Use the invoice status labels exactly as they appear in Acme.",
+    "When showing money, include the currency code when the account has one."
+  ].join("\n")
+});
+```
+
+Good host instructions are concrete and local to your product. They should
+describe names, field conventions, customer-facing tone, or workflow rules that
+Vendo cannot infer from your API and component catalog.
+
+## Full Prompt Overrides
+
+`instructions` replaces the assembled default prompt. Use it only when you want
+to own the whole system prompt.
+
+`instructions` can be a string or a function. The function form runs per turn
+after the live toolset is assembled, and receives `ctx.toolSummary`.
+
+```ts
+import { createVendoHandler } from "@vendoai/next";
+
+export const { GET, POST } = createVendoHandler({
+  instructions: (ctx) => {
+    const tools = ctx.toolSummary.map((tool) => tool.name).join(", ");
+
+    return [
+      "You are Acme's assistant.",
+      "Use the available tools to answer customer requests.",
+      `Available tools in this run: ${tools || "none"}.`,
+      "Actions that change state require the customer's explicit approval.",
+      "Use render_view when a chart, table, dashboard, or custom interactive view is better than text."
+    ].join("\n");
+  }
+});
+```
+
+When you use a full override, include the safety and rendering guidance you
+still want. Vendo will still enforce policy in code, but a sparse prompt can
+make the model less useful.
+
+## Grounded Capability Talk
+
+The live `ctx.toolSummary` is also how the default prompt answers "what can you
+do?" without inventing capabilities. The summary is built from the merged
+toolset for that run, excluding internal mechanics such as `render_view` and
+`request_connect`.
+
+If an integration is not connected, its tools are not in the live toolset. The
+default prompt tells the model to offer a Connect card instead of claiming the
+integration is already available.
+
+## Tool Output Capping
+
+Tool results are capped before they enter model context. Vendo uses
+`capToolOutput` at ingestion points so large or messy outputs do not dominate
+the prompt.
+
+The cap is deterministic and shape-stable:
+
+- Long strings are shortened with an explicit truncation marker.
+- HTML bodies are reduced to text.
+- Binary data is omitted.
+- Arrays and wide objects are shortened without fabricating replacement rows.
+- Plain object results can receive a `_truncation` note that explains what was
+  cut.
+
+This keeps the model grounded in real tool output while making oversized
+responses explicit instead of silent.

--- a/docs-site/concepts/tools-and-safety.mdx
+++ b/docs-site/concepts/tools-and-safety.mdx
@@ -1,0 +1,129 @@
+---
+title: "Tools and safety"
+description: "Tools run as the signed-in customer, fail closed, and pause for approval"
+---
+
+Vendo tools are governed before they execute. Reads can run directly when they
+are marked safe. Mutating or unverified actions pause for approval. Critical
+actions always ask.
+
+## Host API Tools Run In The Browser
+
+Your app's API surface lives in `.vendo/tools.json`. The server registers those
+tools with the agent so the model can choose them, but the server does not
+execute them. The browser executes host API tools on the customer's existing
+session.
+
+The execution path is:
+
+1. The model selects a host API tool.
+2. The server evaluates policy through the tool's `needsApproval` gate.
+3. If approval is required, the shell shows an approval card and waits.
+4. After the stream settles, the browser calls your API with `fetch` and
+   `credentials: "include"`.
+5. The browser returns the tool result to the model turn.
+
+Only the tool result enters the agent loop. Customer cookies and bearer tokens
+stay in the browser and your app's own auth layer remains the final authority.
+
+## Manifest Annotations
+
+Every `.vendo/tools.json` entry has required safety annotations:
+
+```json
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "listInvoices",
+      "description": "List invoices",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      },
+      "annotations": {
+        "mutating": false,
+        "dangerous": false
+      },
+      "binding": {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/invoices"
+      }
+    }
+  ],
+  "events": []
+}
+```
+
+Vendo converts these annotations into policy hints:
+
+- `mutating: false` means read-only. The default policy allows it.
+- `mutating: true` means the action can change host state. The default policy
+  asks for approval unless a remembered exact approval or valid grant
+  suppresses that act-tier approval.
+- `dangerous: true` means critical. Grants do not suppress it.
+- `idempotent` is optional metadata for repeat-call safety.
+
+The route scanner is conservative. Tools inferred from route scans are marked
+`mutating: true` by default, because inferred safety should not auto-run. Relax
+a tool to `mutating: false` only after you review the endpoint.
+
+## Approval Decisions
+
+The policy result is one of three decisions:
+
+- `allow`: run without asking.
+- `approve`: pause and ask the customer.
+- `deny`: do not run.
+
+For client-executed host tools, the server enforces that decision at the
+approval gate before the browser executor runs. For generated UI actions, the
+sandbox dispatches to `POST /api/vendo/action`; that route issues a single-use
+`approvalToken` when approval is needed and only executes the exact approved
+action and payload when the token is returned.
+
+## Consent Surfaces
+
+The shell renders the immediate consent surface that matches the risk:
+
+- A normal approval card for act-tier actions.
+- A batch approval card for multiple same-tool act-tier approvals in one turn.
+- A critical ceremony card for `dangerous: true` tools. Critical approvals do
+  not batch.
+- A fade proposal when the customer has repeatedly approved the same
+  suppressible action shape.
+
+Vendo also exposes Waiting and Trust surfaces for parked automation actions,
+standing grants, compiled rules, audit rows, and critical tools.
+
+Consent has two wires. The Vercel AI SDK approval response resumes the paused
+tool call. Vendo's consent channel records richer semantics such as yes, no,
+subset, grants, fade decisions, and audit events.
+
+## Deployment Gate
+
+The handler holds model and integration credentials, so production traffic must
+be gated by your app. Pass a `principal` resolver to `createVendoHandler()` and
+return `null` for unauthorized requests.
+
+```ts
+import { createVendoHandler } from "@vendoai/next";
+
+export const { GET, POST } = createVendoHandler({
+  principal: async (req) => {
+    const session = await yourAuth(req);
+    return session ? { userId: session.user.id } : null;
+  }
+});
+```
+
+Without `principal`, Vendo serves local development requests with a default
+identity. In `NODE_ENV=production`, it fails closed unless you pass
+`principal` or explicitly set `VENDO_ALLOW_REMOTE=1`.
+
+<Warning>
+  `VENDO_ALLOW_REMOTE=1` disables the default remote guard without replacing it
+  with your auth. Use it only for a throwaway environment you already trust.
+</Warning>

--- a/docs-site/connect/api-tools.mdx
+++ b/docs-site/connect/api-tools.mdx
@@ -1,0 +1,114 @@
+---
+title: "Tools from your API"
+description: "Turn your OpenAPI spec or routes into agent tools"
+---
+
+`.vendo/tools.json` is the reviewed API surface Vendo exposes to the agent. The server registers these tools with the model, and the browser executes them against your host API on the signed-in user's session.
+
+The file is versioned and strict:
+
+```json
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "list_invoices",
+      "description": "List invoices visible to the signed-in user.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "status": { "type": "string" }
+        }
+      },
+      "annotations": {
+        "mutating": false,
+        "dangerous": false
+      },
+      "binding": {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/invoices"
+      }
+    }
+  ],
+  "events": []
+}
+```
+
+`binding.path` must be host-relative, start with one `/`, and contain no whitespace. It cannot point at another origin. Vendo converts the manifest to host tool definitions in one way: path template fields become path params, every other top-level property becomes a query param, and the special `body` property becomes the JSON request body.
+
+## OpenAPI extraction
+
+When `vendo init` finds an OpenAPI or Swagger file, it uses that before any route scan.
+
+The OpenAPI extractor reads `GET`, `POST`, `PUT`, `PATCH`, and `DELETE` operations. It does not extract `HEAD`.
+
+For each operation it writes:
+
+- `name` from `operationId`, converted to snake case. If there is no `operationId`, the name comes from method plus path.
+- `description` from `summary` and `description`, or the HTTP method and path.
+- `inputSchema` with path and query params as top-level properties.
+- `inputSchema.properties.body` for an `application/json` request body.
+- `binding.type: "http"`, uppercase `binding.method`, and the route path.
+
+Local `#/...` references are resolved during extraction. Invalid tool entries are dropped and reported instead of producing an invalid manifest.
+
+## Route scan fallback
+
+If there is no OpenAPI file and an LLM model is available, `vendo init` scans `app/api/**/route.ts` and `app/api/**/route.tsx`.
+
+The route scan asks the model to describe exported `GET`, `POST`, `PUT`, `PATCH`, and `DELETE` handlers, then validates the result against the actual route files. A proposed tool is dropped if its path has no matching route file or its method is not actually exported.
+
+If there is no OpenAPI file and no model key, tool extraction is skipped. On a Next.js app, the wiring step still creates an empty fallback `.vendo/tools.json` so the generated root wrapper can import it.
+
+## Safety annotations
+
+Annotations fail closed. They are required on every manifest tool.
+
+| Field | Meaning |
+| --- | --- |
+| `mutating` | `false` means the tool is read-only and can run without approval under the default policy. |
+| `dangerous` | `true` means the tool is approval-gated even if other hints look safe. |
+| `idempotent` | Optional. Used to mark repeatable writes such as `PUT` and `DELETE`. |
+
+OpenAPI tools are conservative. A `GET` is marked read-only only when the tool name is read-shaped, such as `get`, `list`, `fetch`, `search`, `find`, `read`, `show`, `query`, `describe`, or `count`, and is not destructive. Other operations are marked mutating. `DELETE` and destructive names such as `delete`, `remove`, `destroy`, `cancel`, `reset`, `revoke`, `purge`, or `wipe` are marked dangerous.
+
+Route-scanned tools are always marked `mutating: true`. Non-destructive routes look like this:
+
+```json
+{
+  "mutating": true,
+  "dangerous": false
+}
+```
+
+`DELETE` routes and destructive names are also marked `dangerous: true`. The fail-closed default is intentional. The scan is model-read code, so it cannot grant auto-run permission.
+
+## Relax by hand
+
+Edit `.vendo/tools.json` when you have reviewed a tool and know it is safe.
+
+For a read-only endpoint that should run without an approval card:
+
+```json
+{
+  "annotations": {
+    "mutating": false,
+    "dangerous": false
+  }
+}
+```
+
+For a repeatable write that still needs approval:
+
+```json
+{
+  "annotations": {
+    "mutating": true,
+    "dangerous": false,
+    "idempotent": true
+  }
+}
+```
+
+The runtime maps these fields to policy hints. `mutating: false` becomes `readOnlyHint: true`; `dangerous: true` becomes `destructiveHint: true`; unknown or mutating tools pause for user approval under the default policy.

--- a/docs-site/connect/host-components.mdx
+++ b/docs-site/connect/host-components.mdx
@@ -1,0 +1,174 @@
+---
+title: "Host components"
+description: "Let generated views use your real components"
+---
+
+Host components let generated views render your own React components inside the sandbox. The registration has two halves:
+
+- A descriptor that is React-free and safe for server code. It feeds the prompt and validates generated props.
+- An implementation that adapts validated JSON props to your real React component inside the sandbox bundle.
+
+The same split applies whether `vendo init` generated files under `.vendo/components/` or you write a component registration by hand.
+
+## Descriptor
+
+Use `hostComponent` for hand-written registrations. Names must be PascalCase, must not collide with prewired component names, and must have a non-empty description.
+
+```ts
+// src/vendo/host-components/descriptors.ts
+import { z } from "zod";
+import {
+  hostComponent,
+  toHostRegistry,
+} from "@vendoai/components/descriptors";
+
+export const statusPillDescriptor = hostComponent(
+  "StatusPill",
+  "Compact status label. Use inside tables, lists, and account summaries.",
+  z.object({
+    label: z.string().describe("Visible label."),
+    tone: z.enum(["neutral", "success", "warning"]).optional(),
+  }),
+  { version: "1" },
+);
+
+export const hostComponents = toHostRegistry([statusPillDescriptor]);
+```
+
+`toHostRegistry()` returns the `RegisteredComponent[]` shape accepted by `createVendoHandler()` and by the stage renderer. The `version` option is optional. Leave it unset for version `"1"`, and bump it when a breaking prop or behavior change would affect saved views.
+
+## Implementation
+
+Use `bindHostImpl` to bind the descriptor to a React adapter.
+
+```tsx
+// src/vendo/host-components/impls.tsx
+import { bindHostImpl } from "@vendoai/components";
+import { StatusPill } from "@/components/status-pill";
+import { statusPillDescriptor } from "./descriptors";
+
+export const StatusPillImpl = bindHostImpl(
+  statusPillDescriptor,
+  (props, _runtime) => (
+    <StatusPill
+      label={props.label}
+      tone={props.tone ?? "neutral"}
+    />
+  ),
+);
+
+export const hostImpls = {
+  StatusPill: StatusPillImpl,
+};
+```
+
+The adapter receives schema-validated JSON props. It also receives runtime capabilities as a second argument:
+
+- `runtime.nodeId`, when the stage supplies one.
+- `runtime.vendo?.dispatch`, for governed actions from inside the component.
+
+Props cross a JSON boundary. Use strings, numbers, booleans, arrays, enums, and plain objects. Do not put functions, React nodes, refs, or `Date` objects in the descriptor schema.
+
+## Build the host bundle
+
+Install the host implementations into the sandbox bundle with `installVendoHost()`.
+
+```ts
+// src/vendo/host-components/entry.ts
+import { installVendoHost } from "@vendoai/components/sandbox";
+import { hostImpls } from "./impls";
+
+const hostCss = `
+  .status-pill {
+    border-radius: var(--vendo-radius);
+  }
+`;
+
+installVendoHost(hostImpls, { css: hostCss });
+```
+
+Build the bundle with `vendoHostPreset()` from `@vendoai/stage/build`.
+
+```ts
+// src/vendo/host-components/vite.config.mts
+import { vendoHostPreset } from "@vendoai/stage/build";
+
+export default vendoHostPreset({
+  entry: "src/vendo/host-components/entry.ts",
+  version: "1.0.0",
+  outDir: "dist/vendo-host",
+});
+```
+
+If `vendo init` generated `.vendo/components/entry.ts` and `.vendo/components/vite.config.mts`, use that generated config as your starting point:
+
+```bash
+npx vite build -c .vendo/components/vite.config.mts
+```
+
+`installVendoHost()` merges your implementations with Vendo's prewired catalog. If a host component name collides with a catalog component, it throws. Rename the host component, usually with an app-specific prefix.
+
+## Register the descriptors
+
+Pass the descriptor registry to the handler so `render_view` can validate `source: "host"` nodes before anything streams to the user.
+
+```ts
+// app/api/vendo/[...path]/route.ts
+import { createVendoHandler } from "@vendoai/next";
+import { hostComponents } from "@/vendo/host-components/descriptors";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const { GET, POST } = createVendoHandler({
+  components: hostComponents,
+});
+```
+
+When you render a stage yourself, pass the same registry and the built bundle to `VendoStage`.
+
+```tsx
+import type { UINode } from "@vendoai/core";
+import type { BrandTokens } from "@vendoai/components/theme";
+import { VendoStage } from "@vendoai/react";
+import { brandToCssVars } from "@vendoai/components/descriptors";
+import { hostComponents } from "@/vendo/host-components/descriptors";
+
+export function GeneratedViewStage({
+  node,
+  brand,
+  hostBundleSource,
+  reactRuntimeSource,
+}: {
+  node: UINode;
+  brand: BrandTokens;
+  hostBundleSource: string;
+  reactRuntimeSource: string;
+}) {
+  return (
+    <VendoStage
+      node={node}
+      components={hostComponents}
+      bundleSource={hostBundleSource}
+      reactSource={reactRuntimeSource}
+      theme={brandToCssVars(brand)}
+    />
+  );
+}
+```
+
+Generated views reference the component by name:
+
+```json
+{
+  "id": "status",
+  "component": "StatusPill",
+  "source": "host",
+  "props": {
+    "label": "Paid",
+    "tone": "success"
+  }
+}
+```
+
+Unknown host component names and invalid props become correctable `render_view` errors on the server when the registry is registered. The stage also validates props and contains render failures per node, so one bad host component does not blank the whole view.

--- a/docs-site/connect/instructions.mdx
+++ b/docs-site/connect/instructions.mdx
@@ -1,0 +1,91 @@
+---
+title: "Custom instructions"
+description: "Shape the agent's behavior with your own instructions"
+---
+
+Use handler instructions when Vendo needs product-specific behavior, vocabulary, or rules that are not captured by tools, components, and theme.
+
+`createVendoHandler()` accepts two instruction options:
+
+- `instructions`: replaces the default assembled system prompt.
+- `instructionsExtra`: appends text to the default assembled system prompt.
+
+Prefer `instructionsExtra` unless you need to own the full prompt.
+
+```ts
+import { createVendoHandler } from "@vendoai/next";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const { GET, POST } = createVendoHandler({
+  productName: "Acme",
+  instructionsExtra:
+    "Use Acme account terminology. When summarizing balances, include the account name and status.",
+});
+```
+
+## Full replacement
+
+Pass `instructions` as a string to replace the default prompt:
+
+```ts
+export const { GET, POST } = createVendoHandler({
+  instructions:
+    "You are Acme's assistant. Help customers inspect account data and generate useful Vendo views.",
+});
+```
+
+When you replace the prompt, you are responsible for including the product identity, tool guidance, component guidance, and any behavior rules you want the model to follow.
+
+## Per-run function
+
+`instructions` can also be a function. The function is evaluated for each run after tools are assembled, and receives the live tool summary.
+
+```ts
+export const { GET, POST } = createVendoHandler({
+  instructions: (ctx) => {
+    const toolNames = ctx.toolSummary.map((tool) => tool.name).join(", ");
+
+    return [
+      "You are Acme's assistant.",
+      "Answer in product terminology.",
+      toolNames
+        ? `Available tools for this run: ${toolNames}.`
+        : "No host tools are available for this run.",
+    ].join("\n");
+  },
+});
+```
+
+The function signature is:
+
+```ts
+type Instructions = (ctx: {
+  toolSummary: Array<{
+    name: string;
+    description?: string;
+    tier: "read" | "act" | "critical";
+    source: "host" | "integration";
+    toolkit?: string;
+  }>;
+}) => string;
+```
+
+`ctx.toolSummary` is the merged live toolset for the run. It includes host tools and ingested external tools after ingestion. Use it when the assistant should say exactly what it can do right now.
+
+## How defaults are assembled
+
+When you do not pass `instructions`, the handler builds a default prompt from:
+
+- `productName`.
+- `.vendo/theme.json` brand guidance.
+- The prewired component catalog.
+- Registered host components from the `components` option.
+- Host API tool names from `.vendo/tools.json` or `hostTools`.
+- Connected integration catalog entries.
+- Automations guidance when automations are enabled.
+- `instructionsExtra`, when provided.
+- Platform guardrails, appended last.
+
+`instructionsExtra` is appended before the guardrails. If your extra text conflicts with Vendo's platform guardrails, the guardrails win.

--- a/docs-site/connect/theming.mdx
+++ b/docs-site/connect/theming.mdx
@@ -1,0 +1,105 @@
+---
+title: "Theming"
+description: "Make generated UI match your brand"
+---
+
+Vendo themes generated UI from `.vendo/theme.json`. The file is extracted by `vendo init`, imported by the generated `VendoRoot`, and consumed by both the host shell and the sandbox stage.
+
+## Theme tokens
+
+The theme file uses the `BrandTokens` v1 shape:
+
+```json
+{
+  "version": 1,
+  "accent": "#0A7CFF",
+  "background": "#FFFFFF",
+  "surface": "#F5F7FA",
+  "text": "#111418",
+  "mutedText": "#5B6470",
+  "fontFamily": "system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
+  "radius": 8,
+  "mode": "light"
+}
+```
+
+All color values must be literal hex colors. `fontFamily` must be a resolved font stack string. `radius` can be a non-negative number or a pixel string such as `"12px"`. `mode` is optional and can be `"light"` or `"dark"`.
+
+If `theme.json` is missing, Vendo uses the default brand. If it exists but does not match the schema, the handler fails loudly so you can fix the reviewed file.
+
+## What the extractor does
+
+`vendo init` scans CSS variables from your CSS files and Tailwind config. It maps matching variables into brand slots:
+
+- `accent` from names like `accent`, `primary`, `brand`, or `cta`.
+- `background` from names like `background` or `bg`.
+- `surface` from names like `surface`, `card`, or `panel`.
+- `mutedText` from names like `fg-muted`, `text-muted`, or `muted`.
+- `text` from names like `ink`, `text`, `fg`, or `foreground`.
+- `radius` from a radius variable.
+- `fontFamily` from a resolved font stack.
+
+Unresolved CSS variables are not emitted. Dark-scoped variables are detected, but the generated `theme.json` carries one mode per file today. Edit the file by hand when the automatic mapping is not the brand you want.
+
+## Sandbox CSS variables
+
+Vendo derives CSS variables from the brand tokens and injects them into the host shell and sandbox:
+
+```ts
+import { brandToCssVars } from "@vendoai/components/descriptors";
+
+const vars = brandToCssVars(brand);
+```
+
+The derived variables include:
+
+```css
+--vendo-accent
+--vendo-bg
+--vendo-surface
+--vendo-fg
+--vendo-fg-muted
+--vendo-font
+--vendo-radius
+--vendo-border
+--vendo-skeleton
+--vendo-shadow
+```
+
+Use these tokens in generated component code and host component adapters. The sandbox does not inherit your app's CSS variables or loaded fonts.
+
+```tsx
+<div
+  style={{
+    background: "var(--vendo-surface)",
+    color: "var(--vendo-fg)",
+    border: "1px solid var(--vendo-border)",
+    borderRadius: "var(--vendo-radius)",
+  }}
+>
+  Branded content
+</div>
+```
+
+## CSS for host components
+
+Host components that rely on app classes need their CSS inside the sandbox. The manual host bundle API supports a `css` option:
+
+```ts
+import { installVendoHost } from "@vendoai/components/sandbox";
+import { hostImpls } from "./impls";
+
+installVendoHost(hostImpls, {
+  css: `
+    .status-pill {
+      display: inline-flex;
+      border-radius: var(--vendo-radius);
+      color: var(--vendo-fg);
+    }
+  `,
+});
+```
+
+`vendo sync` also builds a sandbox environment from source CSS when it can find a globals file such as `src/app/globals.css`, `app/globals.css`, `src/styles/globals.css`, or `styles/globals.css`. It writes sanitized CSS to `.vendo/env/host.css` and mirrors it to `public/vendo/env/host.css` for the stage to fetch.
+
+The sanitizer drops `@import`, non-`data:` `url(...)`, image sets, and external URL references. The sandbox keeps `connect-src 'none'`, so CSS cannot fetch from the network.

--- a/docs-site/connect/vendo-init.mdx
+++ b/docs-site/connect/vendo-init.mdx
@@ -1,0 +1,112 @@
+---
+title: "The vendo init codemod"
+description: "What vendo init writes, what it never touches, and how to re-run it"
+---
+
+`npx vendo init .` is a codemod for connecting Vendo to an existing app. It extracts reviewable config into `.vendo/`, then wires a Next.js App Router app when it can do so without guessing.
+
+Run it from your app root:
+
+```bash
+npx vendo init .
+```
+
+## What it writes
+
+The extraction output lives under `.vendo/`. Treat this directory as the source of truth for what Vendo knows about your app.
+
+| File | Purpose |
+| --- | --- |
+| `.vendo/theme.json` | Brand tokens for generated UI. |
+| `.vendo/tools.json` | Host API tools and host event declarations. Written by extraction when tools are found; Next.js wiring creates an empty fallback if needed. |
+| `.vendo/components/<Name>/descriptor.ts` | Server-safe host component metadata. Written only when component discovery includes that component. |
+| `.vendo/components/<Name>/impl.tsx` | Sandbox wrapper for the matching host component. Written only with the descriptor. |
+| `.vendo/components/entry.ts` | Host component sandbox bundle entry. Written when at least one component wrapper is written. |
+| `.vendo/components/vite.config.mts` | Vite config for the host component sandbox bundle. Written with the component entry. |
+| `.vendo/README.md` | Notes on what was extracted and what you should review. |
+
+On a Next.js App Router app, the codemod also writes or edits:
+
+| File | Purpose |
+| --- | --- |
+| `app/api/vendo/[...path]/route.ts` or `src/app/api/vendo/[...path]/route.ts` | Catch-all route exporting `GET` and `POST` from `createVendoHandler()`. |
+| `app/vendo-root.tsx` or `src/app/vendo-root.tsx` | Client wrapper using `VendoRoot` from `@vendoai/next/client`, imported `.vendo/theme.json`, and imported `.vendo/tools.json`. |
+| `app/layout.*` or `src/app/layout.*` | Wraps the single root `{children}` expression in `<AppVendoRoot>`. |
+| `instrumentation.ts` or `src/instrumentation.ts` | Calls `startVendoScheduler()` in the Node.js runtime. |
+| `.env.example` | Provider keys, integration keys, model override, storage, scheduler, and webhook comments. |
+| `public/vendo/react-runtime.js` | React runtime shim for the sandbox. |
+| `public/vendo/components-sandbox.js` | Prewired component bundle for the sandbox. |
+| `package.json` | Adds `@vendoai/next` and a `prebuild` script that runs `vendo sync`. |
+
+The generated route has this shape:
+
+```ts
+import { createVendoHandler } from "@vendoai/next";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const { GET, POST } = createVendoHandler();
+```
+
+The generated `.env.example` documents these keys:
+
+| Env var | Used for |
+| --- | --- |
+| `ANTHROPIC_API_KEY` | Chat and generated UI when Anthropic is the selected provider. |
+| `OPENAI_API_KEY` | Chat and generated UI when OpenAI is the selected provider. Also enables the voice capability flag. |
+| `GOOGLE_GENERATIVE_AI_API_KEY` | Chat and generated UI when Google is the selected provider. |
+| `COMPOSIO_API_KEY` | Integration connect flows. |
+| `VENDO_MODEL` | Runtime model override. |
+| `DATABASE_URL` | Postgres storage. |
+| `VENDO_DATA_DIR` | PGlite data directory when `DATABASE_URL` is not set. |
+| `VENDO_TICK_SECRET` | Bearer token for external scheduler ticks. |
+| `COMPOSIO_WEBHOOK_SECRET` | Signature verification for Composio webhooks. |
+| `VENDO_SCHEDULER` | Scheduler mode. Set to `external` to disable the in-process timer. |
+
+## What it detects
+
+`vendo init` detects the app framework, Tailwind shape, CSS files, and an OpenAPI or Swagger file when one exists. The OpenAPI search covers common root and app-local paths such as `openapi.json`, `openapi.yaml`, `swagger.json`, `docs/openapi.json`, `public/openapi.json`, and `api/openapi.json`.
+
+The extraction order is:
+
+1. Theme tokens from CSS variables and Tailwind config.
+2. Tools from OpenAPI, or an LLM-assisted route scan when no spec exists and a model key is available.
+3. Component wrappers from exported PascalCase components under `components/`, when a model key is available.
+4. `.vendo/README.md`.
+5. Next.js wiring, if the target is a Next.js App Router app.
+
+If LLM steps are unavailable, or you pass `--skip-llm`, the codemod still extracts deterministic files such as theme tokens and still attempts Next.js wiring.
+
+```bash
+npx vendo init . --skip-llm
+```
+
+For init-time LLM steps, the CLI reads the same provider keys as the runtime. It also honors `VENDO_CLI_MODEL`; when set, that init-only override takes precedence over `VENDO_MODEL`.
+
+## Idempotence and `--force`
+
+Files under `.vendo/` are developer-editable. By default, `vendo init` refuses to overwrite existing generated artifacts there. Re-run with `--force` when you want to replace extracted `.vendo/` files with fresh output:
+
+```bash
+npx vendo init . --force
+```
+
+Next.js wiring is separately idempotent. Existing route and root wrapper files are skipped. An already wrapped layout is left alone. Existing sandbox assets are skipped unless `--force` is set.
+
+Review the result with `git diff` after every run. `.vendo/` is meant to be committed, edited, and reviewed like application code.
+
+## Manual follow-ups
+
+When the codemod cannot make a safe edit, it prints the skipped step and an exact manual instruction instead of guessing.
+
+Common skips are:
+
+- No App Router root layout at `app/layout.*` or `src/app/layout.*`.
+- A Pages Router app, or a route-group-only root layout, which is not auto-wired.
+- A root layout with zero or multiple real `{children}` expressions.
+- An existing `register()` function in `instrumentation.ts`. In this case, the codemod writes `instrumentation.vendo-example.ts` and asks you to merge the scheduler boot.
+- An unparsable `package.json`.
+- Existing route, wrapper, `.env.example`, or sandbox asset files.
+
+If `package.json` is edited, install dependencies with your package manager before starting the app.

--- a/docs-site/deploy/deploying.mdx
+++ b/docs-site/deploy/deploying.mdx
@@ -1,0 +1,71 @@
+---
+title: "Deploying safely"
+description: "Gate the handler with your auth before it faces the internet"
+---
+
+Vendo's zero-config handler is a local development default. It holds your model keys, can call server tools you register, and can auto-run read-only work according to policy. Do not expose it to anonymous internet traffic.
+
+In production, the default identity fails closed. A request is accepted only when you provide a `principal` resolver or set the explicit escape hatch `VENDO_ALLOW_REMOTE=1`.
+
+## Add A Principal Resolver
+
+`principal` is the production gate. It runs for identity-bearing routes such as chat, actions, integrations, threads, saved views, and trust routes. Return a principal to allow the request. Return `null` to reject it with `403`.
+
+```ts
+import { createVendoHandler } from "@vendoai/next";
+import { getUserFromRequest } from "@/auth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const { GET, POST } = createVendoHandler({
+  principal: async (req) => {
+    const user = await getUserFromRequest(req);
+    if (!user) return null;
+
+    return {
+      userId: user.id,
+      roles: user.roles,
+      limits: {
+        dailySpendCents: user.dailySpendCents,
+      },
+    };
+  },
+});
+```
+
+The required field is `userId`. `roles` and `limits` are optional and can be used by your policy.
+
+<Warning>
+  The development local-only check uses the request host. That is a convenience
+  for `next dev`, not a production access control. Use `principal` for
+  anything reachable from the internet.
+</Warning>
+
+## Escape Hatch
+
+`VENDO_ALLOW_REMOTE=1` disables the production remote-request block and uses Vendo's default single identity.
+
+Use it only for a trusted, temporary preview. It is not an auth system, and it does not separate users.
+
+```bash
+VENDO_ALLOW_REMOTE=1
+```
+
+## Single Tenant
+
+The embedded Vendo world is single-tenant today.
+
+A `principal` resolver gates who can reach the handler. It does not partition automations, integration connections, cached agents, or the automation scheduler into separate tenant worlds. The automations world uses one embedded scope, and the built-in connections store is shared by that world.
+
+Chat threads are scoped by the resolved `userId`, but that does not make the rest of the embedded runtime multi-tenant.
+
+If you need hard tenant isolation, run separate handler instances per tenant or provide tenant-aware stores and runtime boundaries outside the built-in embedded setup.
+
+## Single Process
+
+Run the handler as one long-lived Node process for the built-in scheduler and embedded world.
+
+Durable storage persists state across restarts, but the embedded scheduler does not coordinate leases across replicas. Scheduler registrations, approval tokens, and agent caches are process-local.
+
+For serverless or multi-instance deployments, set `VENDO_SCHEDULER=external` and drive `POST /api/vendo/tick` from one external cron path. See [Scheduler and webhooks](/deploy/scheduler-and-webhooks).

--- a/docs-site/deploy/persistence.mdx
+++ b/docs-site/deploy/persistence.mdx
@@ -1,0 +1,80 @@
+---
+title: "Persistence"
+description: "Durable by default with embedded PGlite. Point at Postgres when you deploy"
+---
+
+Vendo is durable by default. With no `storage` option, the handler opens an embedded PGlite database at `.vendo/data` and runs migrations on first boot.
+
+Use this default for local development and one long-lived Node process. Use hosted Postgres when the filesystem is ephemeral or Vendo state must live outside the process.
+
+## Storage modes
+
+| Configuration | Behavior |
+| --- | --- |
+| Unset | Uses PGlite at `.vendo/data`. Override the directory with `VENDO_DATA_DIR`. |
+| `DATABASE_URL` | Uses that Postgres connection string. |
+| `storage: { connectionString }` | Uses the explicit Postgres connection string. This wins over `DATABASE_URL`. |
+| `storage: { pglite: { dataDir } }` | Uses PGlite at a specific directory. |
+| `storage: false` | Uses in-memory stores. Nothing survives a restart. |
+
+```ts
+import { createVendoHandler } from "@vendoai/next";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const { GET, POST } = createVendoHandler({
+  storage: {
+    connectionString: process.env.DATABASE_URL,
+  },
+});
+```
+
+You can also omit the option and set `DATABASE_URL` in the environment:
+
+```bash
+DATABASE_URL=postgres://user:password@host:5432/db
+```
+
+<Warning>
+  If `NODE_ENV=test` and you leave `storage` unset, Vendo behaves as if
+  `storage: false` was passed. Set storage explicitly if you run a real
+  deployment under a test environment.
+</Warning>
+
+## What Persists
+
+With durable storage on, Vendo persists:
+
+- Automations, automation versions, pre-approved grants stored on those versions, and automation run history.
+- Parked automation actions that need a later approval.
+- Approval decisions remembered by the interactive ask-once flow.
+- Chat threads and thread messages.
+- Saved generated views.
+- Integration connection state, including the Composio connected-account mapping used by webhook routing.
+- A small operational `meta` table used for the scheduler heartbeat.
+
+Vendo stores these tables in a dedicated Postgres schema named `vendo`. It does not write to your app's `public` schema.
+
+## Migrations
+
+Migrations run automatically by default. For hosted Postgres, Vendo wraps migrations in a Postgres advisory lock so two cold starts do not run the same migration at the same time.
+
+If your team runs schema changes out of band, disable boot migrations:
+
+```ts
+export const { GET, POST } = createVendoHandler({
+  storage: {
+    connectionString: process.env.DATABASE_URL,
+    autoMigrate: false,
+  },
+});
+```
+
+Then run `migrateVendoDatabase(handle)` from `@vendoai/store` in your own migration step.
+
+## Limits
+
+PGlite is file-backed and single-process. On known serverless runtimes such as Vercel, Cloudflare Pages, and Lambda, the default PGlite path fails at boot and tells you to set `DATABASE_URL`.
+
+Durable storage makes Vendo state survive restarts. It does not make the embedded automation world multi-tenant or multi-replica. Run one long-lived process, or provide your own production architecture around the Vendo handler.

--- a/docs-site/deploy/scheduler-and-webhooks.mdx
+++ b/docs-site/deploy/scheduler-and-webhooks.mdx
@@ -1,0 +1,117 @@
+---
+title: "Scheduler and webhooks"
+description: "Fire schedules and triggers without a browser open"
+---
+
+Automations can fire from two server-side paths:
+
+- The in-process scheduler checks time-based schedules.
+- The Composio webhook route receives external trigger deliveries.
+
+Both paths use the same automation runner and durable store when storage is enabled.
+
+## Boot The Scheduler
+
+`vendo init` writes `instrumentation.ts`, or `src/instrumentation.ts` when your App Router lives under `src/app`. The file starts Vendo's scheduler in the Next.js Node.js runtime:
+
+```ts
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { startVendoScheduler } = await import("@vendoai/next");
+    startVendoScheduler();
+  }
+}
+```
+
+`startVendoScheduler()` is idempotent. It starts an unref'd interval that ticks every 60 seconds, so it does not keep the host process alive by itself.
+
+At boot, Vendo rehydrates enabled schedules from durable storage. Missed fires are skipped. A one-shot schedule whose time passed while the server was down is paused as completed instead of firing late.
+
+## External Scheduler Mode
+
+Set `VENDO_SCHEDULER=external` to disable the in-process timer:
+
+```bash
+VENDO_SCHEDULER=external
+VENDO_TICK_SECRET=replace-me
+```
+
+Then run one cron job that sends:
+
+```bash
+curl -X POST https://your-app.example.com/api/vendo/tick \
+  -H "Authorization: Bearer $VENDO_TICK_SECRET"
+```
+
+The route is `POST <mount>/tick`. With the default Next.js mount, that is `POST /api/vendo/tick`.
+
+When `VENDO_TICK_SECRET` is set, a matching bearer token can tick without a user principal. A wrong bearer token returns `401` with `invalid tick credential`. If no bearer token is presented, the request falls back to the normal `principal` or remote guard.
+
+<Warning>
+  Run only one external cron for a Vendo world. The embedded runtime is
+  single-process and single-tenant.
+</Warning>
+
+## Cron Relay Example
+
+If your cron provider cannot send a custom authorization header, point it at a route in your app and have that route make the authenticated POST.
+
+```ts
+// app/api/cron/vendo-tick/route.ts
+export async function GET(req: Request) {
+  const origin = new URL(req.url).origin;
+
+  const res = await fetch(`${origin}/api/vendo/tick`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.VENDO_TICK_SECRET}`,
+    },
+  });
+
+  return new Response(null, { status: res.ok ? 200 : 502 });
+}
+```
+
+A scheduled Worker can call the tick route directly:
+
+```ts
+export default {
+  async scheduled(
+    _event: ScheduledEvent,
+    env: { APP_ORIGIN: string; VENDO_TICK_SECRET: string },
+  ) {
+    await fetch(`${env.APP_ORIGIN}/api/vendo/tick`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.VENDO_TICK_SECRET}`,
+      },
+    });
+  },
+};
+```
+
+## Composio Webhooks
+
+Vendo serves a Composio trigger ingress route:
+
+```txt
+POST /api/vendo/webhooks/composio
+```
+
+Set the signing secret from Composio in your deployment:
+
+```bash
+COMPOSIO_WEBHOOK_SECRET=whsec_...
+```
+
+Then configure Composio to send webhooks to your deployed route. If you mounted Vendo somewhere other than `/api/vendo`, use `POST <mount>/webhooks/composio`.
+
+Vendo verifies the raw request body with the `webhook-id`, `webhook-timestamp`, and `webhook-signature` headers. The timestamp must be within five minutes. Missing or invalid signatures return `401`.
+
+If `COMPOSIO_WEBHOOK_SECRET` is not set, the route returns `404` with `composio webhooks are not configured`. It fails closed rather than accepting unsigned requests.
+
+Webhook routing depends on the connected-account id captured during the OAuth status poll. If a toolkit shows connected but trigger webhooks do not fire, disconnect and reconnect it once so Vendo records the Composio connected-account mapping.
+
+## Local Development
+
+Composio cannot deliver to `localhost`. Use a tunnel to your local server, or test the automation manually from chat while developing.

--- a/docs-site/deploy/telemetry.mdx
+++ b/docs-site/deploy/telemetry.mdx
@@ -1,0 +1,102 @@
+---
+title: "Telemetry"
+description: "What Vendo collects and how to opt out"
+---
+
+Vendo collects anonymous, opt-out telemetry from setup and development tooling. Product telemetry does not run from a deployed production app.
+
+Telemetry is best effort. Network failures are swallowed and cannot break builds or dev servers.
+
+## When Events Fire
+
+| Event | When it fires |
+| --- | --- |
+| `init_started` | `vendo init` starts. |
+| `init_completed` | `vendo init` finishes successfully. |
+| `init_failed` | `vendo init` fails during theme, tools, components, or wiring. |
+| `agent_run` | A dev server handles a chat run outside production. |
+| `error_class` | A dev server catches a Vendo boot error outside production. |
+
+## What Is Collected
+
+Every event includes:
+
+- `vendoVersion`
+- `osPlatform`
+- `nodeVersion`
+- A random anonymous id stored in `~/.vendo/telemetry.json`
+
+Event-specific properties are allowlisted:
+
+| Event | Extra properties |
+| --- | --- |
+| `init_started` | `framework` |
+| `init_completed` | `framework`, `provider`, `llmSkipped`, `componentCount`, `toolCount`, `durationMs` |
+| `init_failed` | `framework`, `failedStep` |
+| `agent_run` | None |
+| `error_class` | `errorClass` |
+
+Keys outside these allowlists are dropped before sending.
+
+Example payload:
+
+```json
+{
+  "api_key": "phc_...",
+  "event": "init_completed",
+  "distinct_id": "3f2a1c2d-4b5a-4678-9abc-1d2e3f4a5b6c",
+  "properties": {
+    "vendoVersion": "0.0.0",
+    "osPlatform": "darwin",
+    "nodeVersion": "v22.3.0",
+    "framework": "next",
+    "provider": "configured",
+    "llmSkipped": false,
+    "componentCount": 4,
+    "toolCount": 7,
+    "durationMs": 1200
+  }
+}
+```
+
+## What Is Never Collected
+
+Vendo product telemetry does not collect:
+
+- Source code
+- File paths
+- Prompts
+- Generated UI
+- Tool inputs or outputs
+- API keys
+- Host app names
+- Environment values
+- Request bodies
+- Error messages
+- Stack traces
+
+The anonymous id is a random UUID. It is not derived from your machine, account, project, app, or environment. Deleting `~/.vendo/telemetry.json` rotates it.
+
+## Opt Out
+
+Any one of these disables product telemetry:
+
+- Run `vendo telemetry disable`.
+- Set `VENDO_TELEMETRY_DISABLED=1` or `VENDO_TELEMETRY_DISABLED=true`.
+- Set `DO_NOT_TRACK=1` or `DO_NOT_TRACK=true`.
+- Run in CI. `CI=true` and any non-empty value except `0` or `false` disables telemetry.
+- Run the dev-runtime telemetry in production with `NODE_ENV=production`.
+
+Run `vendo telemetry enable` to clear the local config-file opt-out.
+
+Check the current local setting:
+
+```bash
+vendo telemetry status
+```
+
+## Where Data Goes
+
+Product events are sent to PostHog US Cloud with a write-only project key. You can override the destination project with `VENDO_POSTHOG_KEY`.
+
+Published package install attribution is wired through Scarf on the published entrypoint packages. Vendo's product telemetry code does not send those install-attribution payloads itself. Set `DO_NOT_TRACK=1` before installing to opt out of Scarf attribution.

--- a/docs-site/deploy/troubleshooting.mdx
+++ b/docs-site/deploy/troubleshooting.mdx
@@ -1,0 +1,204 @@
+---
+title: "Troubleshooting"
+description: "Common failure modes and their fixes"
+---
+
+Use the headings and error snippets to find the matching cause.
+
+## Sandbox unavailable: react shim missing
+
+Cause: `public/vendo/react-runtime.js` is missing.
+
+Fix: run `npx vendo init . --force`, or copy the Vendo sandbox assets into `public/vendo/` as part of your own setup.
+
+## Sandbox unavailable: components bundle missing
+
+Cause: `public/vendo/components-sandbox.js` is missing.
+
+Fix: run `npx vendo init . --force`, or copy the Vendo sandbox assets into `public/vendo/`.
+
+## Chat is unavailable
+
+Error starts with:
+
+```txt
+chat is unavailable
+```
+
+Cause: the server does not see a model provider key, and you did not inject a `model` option. `VENDO_MODEL` names a model, but it is not a credential.
+
+Fix: set one provider key and restart the server:
+
+```bash
+ANTHROPIC_API_KEY=...
+# or OPENAI_API_KEY=...
+# or GOOGLE_GENERATIVE_AI_API_KEY=...
+```
+
+Check what the server sees:
+
+```bash
+curl http://localhost:3000/api/vendo/capabilities
+```
+
+## Chat or action returns 403 in production
+
+Error starts with:
+
+```txt
+Vendo is not serving this request. In production you MUST pass a `principal` resolver
+```
+
+Cause: the handler is reachable outside local development and no production gate is configured.
+
+Fix: pass `principal` to `createVendoHandler`. For a trusted temporary preview only, set `VENDO_ALLOW_REMOTE=1`.
+
+## Integrations tray is empty
+
+Cause: `COMPOSIO_API_KEY` is not set, so the capabilities route reports integrations as disabled.
+
+Fix: set `COMPOSIO_API_KEY` and restart the server. Missing keys hide the integrations UI instead of throwing.
+
+## Integrations POST returns 503
+
+Error starts with:
+
+```txt
+integrations are disabled
+```
+
+Cause: the client tried to connect or disconnect an integration while `COMPOSIO_API_KEY` was absent.
+
+Fix: set `COMPOSIO_API_KEY` and restart the server.
+
+## PGlite cannot run on serverless
+
+Error starts with:
+
+```txt
+[vendo] PGlite (the zero-config store) cannot run on
+```
+
+Cause: the default `.vendo/data` PGlite store was used on an ephemeral serverless filesystem.
+
+Fix: set `DATABASE_URL` to hosted Postgres, or pass `storage: { connectionString }`.
+
+## PGlite data directory is not writable
+
+Error starts with:
+
+```txt
+[vendo] PGlite data directory
+```
+
+Cause: Vendo cannot create or write to `.vendo/data`, or to the directory from `VENDO_DATA_DIR`.
+
+Fix: change directory permissions, set `VENDO_DATA_DIR` to a writable path, or use Postgres with `DATABASE_URL`.
+
+## Migration failed
+
+Error starts with:
+
+```txt
+[vendo] migration failed
+```
+
+Cause: Vendo could not run its schema migrations. A common cause is a Postgres role without permission to create the `vendo` schema or migration tables.
+
+Fix: grant the database role the needed schema permissions, or set `autoMigrate: false` and run `migrateVendoDatabase(handle)` from `@vendoai/store` in your migration pipeline.
+
+## Unknown VENDO_MODEL provider
+
+Error example:
+
+```txt
+Vendo: VENDO_MODEL="grok/whatever" names an unknown provider "grok"
+```
+
+Cause: `VENDO_MODEL` used `provider/model` syntax with an unsupported provider prefix.
+
+Fix: use `anthropic/...`, `openai/...`, `google/...`, or pass a bare model id that applies to the detected provider key.
+
+## Optional provider package missing
+
+Error starts with:
+
+```txt
+Vendo: model "openai/gpt-5.5" requires @ai-sdk/openai
+```
+
+Cause: the resolved provider is OpenAI or Google, but the optional provider package is not installed.
+
+Fix: install the package named in the error, for example `npm i @ai-sdk/openai`, then restart the server.
+
+## Tick route returns 401
+
+Error:
+
+```txt
+invalid tick credential
+```
+
+Cause: `VENDO_TICK_SECRET` is set and the `Authorization: Bearer ...` value did not match it.
+
+Fix: update the cron secret or deployment env var so they match exactly.
+
+## Tick route returns automations are disabled
+
+Error:
+
+```txt
+automations are disabled
+```
+
+Cause: the handler was configured with `automations: false`.
+
+Fix: remove `automations: false` if you want schedules, triggers, deliveries, resume, and parked automation actions.
+
+## Composio webhook returns 404
+
+Error:
+
+```txt
+composio webhooks are not configured
+```
+
+Cause: `COMPOSIO_WEBHOOK_SECRET` is not set.
+
+Fix: set `COMPOSIO_WEBHOOK_SECRET` to the signing secret from Composio and redeploy.
+
+## Composio webhook returns invalid signature
+
+Error:
+
+```txt
+invalid signature
+```
+
+Cause: the webhook request is missing `webhook-id`, `webhook-timestamp`, or `webhook-signature`, the timestamp is outside the five-minute tolerance, or the signature does not match `COMPOSIO_WEBHOOK_SECRET`.
+
+Fix: verify the webhook secret, route URL, and Composio webhook configuration.
+
+## Composio webhook returns unrecognized payload shape
+
+Error:
+
+```txt
+unrecognized payload shape
+```
+
+Cause: the payload did not include a trigger slug and connected-account id in the supported Composio envelope fields.
+
+Fix: confirm the webhook is a Composio trigger delivery. If the toolkit was connected before webhook routing captured a connected-account id, disconnect and reconnect it.
+
+## Invalid handler options
+
+Error starts with:
+
+```txt
+createVendoHandler: invalid options
+```
+
+Cause: an unknown option key or wrong option shape was passed to `createVendoHandler`.
+
+Fix: check the option name and value against the handler options reference. The options object is strict.

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "maple",
+  "name": "Vendo",
+  "description": "Embed an agent in your product that lets every customer automate their work, build their own views, and connect their tools, inside your brand and your guardrails.",
+  "appearance": {
+    "default": "light"
+  },
+  "colors": {
+    "primary": "#4338CA",
+    "light": "#818CF8",
+    "dark": "#4338CA"
+  },
+  "background": {
+    "color": {
+      "light": "#FAFAF8",
+      "dark": "#17171A"
+    }
+  },
+  "fonts": {
+    "family": "Inter"
+  },
+  "logo": {
+    "light": "/logo/light.svg",
+    "dark": "/logo/dark.svg"
+  },
+  "favicon": "/favicon.svg",
+  "navigation": {
+    "groups": [
+      {
+        "group": "Getting started",
+        "pages": ["index", "quickstart", "quickstart-node", "capability-keys"]
+      },
+      {
+        "group": "Concepts",
+        "pages": ["concepts/architecture", "concepts/generated-ui", "concepts/tools-and-safety", "concepts/prompts"]
+      },
+      {
+        "group": "Connect your app",
+        "pages": ["connect/vendo-init", "connect/api-tools", "connect/host-components", "connect/theming", "connect/instructions"]
+      },
+      {
+        "group": "Capabilities",
+        "pages": ["capabilities/integrations", "capabilities/mcp", "capabilities/automations", "capabilities/saved-views", "capabilities/voice"]
+      },
+      {
+        "group": "Deploy and operate",
+        "pages": ["deploy/persistence", "deploy/deploying", "deploy/scheduler-and-webhooks", "deploy/telemetry", "deploy/troubleshooting"]
+      },
+      {
+        "group": "Reference",
+        "pages": ["reference/handler-options", "reference/server-api", "reference/cli", "reference/dot-vendo", "reference/http-routes", "reference/environment-variables"]
+      }
+    ]
+  },
+  "footer": {
+    "socials": {
+      "github": "https://github.com/runvendo/vendo"
+    }
+  }
+}

--- a/docs-site/favicon.svg
+++ b/docs-site/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="8" fill="#17171A"/>
+  <path d="M10 11 L16 22 L22 11" fill="none" stroke="#FAFAF8" stroke-width="3.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -1,0 +1,32 @@
+---
+title: "Introduction"
+description: "Vendo embeds an agent in your product that lets every customer automate their work, build their own views, and connect their tools, inside your brand and your guardrails."
+---
+
+```bash
+npx vendo init
+```
+
+One command. It reads your app, extracts your theme, tools, and components, and wires the agent into your routes. Add one model key and it works.
+
+{/* TODO: Add a hero screenshot or GIF showing Vendo chat beside a generated view. */}
+
+Vendo gives your app a chat surface and a generated UI surface. The agent can talk with your customers, call tools through your own API as the signed-in user, and render generated charts, tables, forms, and workflows in a sandboxed stage.
+
+Your product stays the system of record. Vendo reads the reviewable `.vendo/` files in your repo, serves a single handler from your app, and uses the model keys you provide. There is no extra infrastructure to run for the embedded path.
+
+With Vendo embedded, your customers can:
+
+- Ask for a custom view and get generated UI inside your product.
+- Let the agent use your existing API through their current session.
+- Connect external tools through the integrations surface when you provide a Composio key.
+- Create automations that use the same tools and approval policy as chat.
+
+<CardGroup cols={2}>
+  <Card title="Quickstart: Next.js" icon="bolt" href="/quickstart">
+    Run `npx vendo init` in a Next.js App Router app, add one provider key, and open your first generated view.
+  </Card>
+  <Card title="Quickstart: any Node server" icon="server" href="/quickstart-node">
+    Mount the `@vendoai/server` fetch handler on `node:http`, Express, Hono, or another Node runtime.
+  </Card>
+</CardGroup>

--- a/docs-site/logo/dark.svg
+++ b/docs-site/logo/dark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 32" width="120" height="32">
+  <text x="0" y="24" font-family="Inter, system-ui, sans-serif" font-size="24" font-weight="600" letter-spacing="-0.02em" fill="#FAFAF8">vendo</text>
+</svg>

--- a/docs-site/logo/light.svg
+++ b/docs-site/logo/light.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 32" width="120" height="32">
+  <text x="0" y="24" font-family="Inter, system-ui, sans-serif" font-size="24" font-weight="600" letter-spacing="-0.02em" fill="#17171A">vendo</text>
+</svg>

--- a/docs-site/quickstart-node.mdx
+++ b/docs-site/quickstart-node.mdx
@@ -1,0 +1,109 @@
+---
+title: "Quickstart: any Node server"
+description: "Mount the framework-agnostic handler on Node, Express, or Hono"
+---
+
+`@vendoai/server` exposes the framework-agnostic handler behind the Next.js adapter. It returns a fetch handler, `(Request) => Promise<Response>`, plus `toNodeHandler()` for Node's `IncomingMessage` and `ServerResponse` shape.
+
+Install the server package:
+
+```bash
+npm install @vendoai/server
+```
+
+If your frontend reuses Vendo's React root outside Next.js, also install `@vendoai/next` and import `VendoRoot` from `@vendoai/next/client`.
+
+## node:http
+
+Mount Vendo under `/api/vendo` and serve the sandbox runtime files from `/vendo`:
+
+```ts
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { createServer } from "node:http";
+import path from "node:path";
+import { createVendoFetchHandler, toNodeHandler } from "@vendoai/server";
+
+const publicDir = path.resolve("public");
+const vendo = toNodeHandler(createVendoFetchHandler());
+
+const server = createServer(async (req, res) => {
+  const { pathname } = new URL(req.url ?? "/", "http://localhost");
+
+  if (pathname === "/api/vendo" || pathname.startsWith("/api/vendo/")) {
+    await vendo(req, res);
+    return;
+  }
+
+  const file = path.normalize(path.join(publicDir, pathname));
+  if (pathname.startsWith("/vendo/") && file.startsWith(publicDir + path.sep)) {
+    try {
+      if ((await stat(file)).isFile()) {
+        res.setHeader("content-type", "text/javascript; charset=utf-8");
+        createReadStream(file).pipe(res);
+        return;
+      }
+    } catch {
+      // fall through to 404
+    }
+  }
+
+  res.statusCode = 404;
+  res.end("not found");
+});
+
+server.listen(3300);
+```
+
+The `public/vendo` directory must contain:
+
+- `react-runtime.js`
+- `components-sandbox.js`
+
+The Next.js codemod copies these automatically. On a custom Node server, copy them as part of your own setup or build step and serve them at `/vendo/...`.
+
+## Express
+
+```ts
+import express from "express";
+import { createVendoFetchHandler, toNodeHandler } from "@vendoai/server";
+
+const app = express();
+
+app.all("/api/vendo/*", toNodeHandler(createVendoFetchHandler()));
+app.use("/vendo", express.static("public/vendo"));
+
+app.listen(3300);
+```
+
+For Express 5, use the route pattern `"/api/vendo/{*path}"`.
+
+## Hono
+
+Fetch-native runtimes can call the handler directly:
+
+```ts
+import { Hono } from "hono";
+import { createVendoFetchHandler } from "@vendoai/server";
+
+const vendo = createVendoFetchHandler();
+const app = new Hono();
+
+app.all("/api/vendo/*", (c) => vendo(c.req.raw));
+
+export default app;
+```
+
+Serve the same `public/vendo` directory at `/vendo` with your Hono runtime's static-file middleware.
+
+## Configure capabilities
+
+Use the same capability keys as the Next.js adapter:
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-...
+# or OPENAI_API_KEY=sk-...
+# or GOOGLE_GENERATIVE_AI_API_KEY=...
+```
+
+`createVendoFetchHandler(options)` accepts the same `VendoHandlerOptions` that `createVendoHandler(options)` accepts in Next.js.

--- a/docs-site/quickstart.mdx
+++ b/docs-site/quickstart.mdx
@@ -1,0 +1,87 @@
+---
+title: "Quickstart: Next.js"
+description: "Install Vendo in a Next.js App Router app with one command and one key"
+---
+
+In the root of your Next.js App Router app:
+
+```bash
+npx vendo init
+```
+
+That is the install. The codemod adds Vendo beside your existing code, the handler reads `.vendo/` from disk at runtime, and nothing it cannot edit with certainty gets touched. The steps below walk the same flow from a fresh app.
+
+<Steps>
+  <Step title="Install the adapter and CLI">
+    In a new app or an existing App Router app:
+
+    ```bash
+    npx create-next-app@latest my-app
+    cd my-app
+    npm install @vendoai/next
+    npm install -D @vendoai/cli
+    npx vendo init .
+    ```
+
+    `vendo init` writes reviewable files and skips anything it cannot edit with certainty. Review the diff before you continue.
+  </Step>
+
+  <Step title="Check what was added">
+    On a standard App Router app, the codemod writes:
+
+    - `.vendo/theme.json`, `.vendo/tools.json`, and component files under `.vendo/components/`.
+    - `app/api/vendo/[...path]/route.ts`, the catch-all Vendo route.
+    - `app/vendo-root.tsx`, then wraps your root layout with it.
+    - `instrumentation.ts` or `src/instrumentation.ts` to start the scheduler in the Node.js runtime.
+    - `.env.example` with provider, integration, storage, scheduler, and webhook variables.
+    - `public/vendo/react-runtime.js` and `public/vendo/components-sandbox.js`.
+    - A `prebuild` script that runs `vendo sync`.
+
+    The generated route is:
+
+    ```ts
+    import { createVendoHandler } from "@vendoai/next";
+
+    export const runtime = "nodejs";
+    export const dynamic = "force-dynamic";
+
+    export const { GET, POST } = createVendoHandler();
+    ```
+  </Step>
+
+  <Step title="Add one provider key">
+    Copy the generated example env file and set one model provider key:
+
+    ```bash
+    cp .env.example .env.local
+    ```
+
+    ```bash
+    ANTHROPIC_API_KEY=sk-ant-...
+    # or OPENAI_API_KEY=sk-...
+    # or GOOGLE_GENERATIVE_AI_API_KEY=...
+    ```
+
+    One of those keys enables chat and generated UI. Additional keys add capabilities, but they are not required for the first view.
+  </Step>
+
+  <Step title="Run the app">
+    Start your app normally:
+
+    ```bash
+    npm run dev
+    ```
+
+    Open the app, click the Vendo launcher or press Cmd/Ctrl+K, then ask for a visual result, for example:
+
+    ```txt
+    Show me a dashboard comparing three savings plans.
+    ```
+
+    Vendo streams the response and renders the generated view in the sandbox.
+  </Step>
+</Steps>
+
+<Note>
+  The default route mount is `/api/vendo`. You can inspect the server-side feature flags at `GET /api/vendo/capabilities`.
+</Note>

--- a/docs-site/reference/cli.mdx
+++ b/docs-site/reference/cli.mdx
@@ -1,0 +1,73 @@
+---
+title: "CLI"
+description: "Reference for the vendo init codemod"
+---
+
+This page covers the public `vendo init` command.
+
+```bash
+npx vendo init [dir] [--skip-llm] [--force]
+```
+
+`[dir]` defaults to the current working directory.
+
+## Flags
+
+| Flag | Behavior |
+| --- | --- |
+| `--skip-llm` | Skips LLM-assisted route scanning and component discovery. Deterministic theme extraction, OpenAPI extraction, `.vendo/README.md`, and Next.js wiring still run. |
+| `--force` | Allows generated `.vendo/` artifacts to be overwritten. It also allows existing sandbox asset files in `public/vendo/` to be replaced. Existing route and wrapper files are still skipped rather than rewritten. |
+
+## What It Does
+
+`vendo init` runs these phases:
+
+1. Detects the target framework from `package.json`: `next`, `vite`, `remix`, or `unknown`.
+2. Finds CSS files, Tailwind config, and an OpenAPI file when one exists.
+3. Resolves an LLM for assisted steps unless `--skip-llm` is passed.
+4. Extracts `.vendo/theme.json` from CSS variables and Tailwind config when possible.
+5. Extracts `.vendo/tools.json` from OpenAPI first, else from Next.js route scanning when an LLM is available.
+6. Extracts host component wrappers under `.vendo/components/` when an LLM is available and suitable components are found.
+7. Writes `.vendo/README.md`.
+8. If the target is a Next.js App Router app, wires the route handler, client root, layout, scheduler instrumentation, `.env.example`, sandbox assets, package dependency, and `prebuild` sync script.
+
+## LLM Resolution
+
+The CLI uses the same provider precedence as the runtime:
+
+1. `ANTHROPIC_API_KEY`
+2. `OPENAI_API_KEY`
+3. `GOOGLE_GENERATIVE_AI_API_KEY`
+
+`VENDO_CLI_MODEL` overrides `VENDO_MODEL` for `vendo init` only. Both accept
+`provider/model` or a bare model id. A model id without a provider key is not a
+credential, so assisted steps are skipped unless one provider key is present.
+
+## Tool Extraction
+
+When an OpenAPI file exists, `init` converts each `GET`, `POST`, `PUT`, `PATCH`,
+and `DELETE` operation into a tool entry. `operationId` becomes the tool name
+when present. Otherwise, the name is derived from the method and path.
+
+When no OpenAPI file exists and an LLM is available, `init` scans
+`app/api/**/route.ts` and `app/api/**/route.tsx`. The route file must actually
+export the method the scan reports. Route-scanned tools are all emitted as
+mutating so they fail closed until you review `.vendo/tools.json` by hand.
+
+## Next.js Wiring
+
+For a Next.js App Router app with `app/layout.*` or `src/app/layout.*`, `init`
+writes or edits:
+
+| File | Behavior |
+| --- | --- |
+| `app/api/vendo/[...path]/route.ts` or `.js` | Creates the catch-all route with `createVendoHandler()`. Existing files are skipped. |
+| `app/vendo-root.tsx` or `src/app/vendo-root.tsx` | Creates the client wrapper that imports `.vendo/theme.json` and `.vendo/tools.json`. Existing files are skipped. |
+| Root layout | Wraps exactly one `{children}` with `AppVendoRoot`. If the edit is ambiguous, the layout is left untouched and a manual step is printed. |
+| `instrumentation.ts` or `src/instrumentation.ts` | Starts `startVendoScheduler()` only when `process.env.NEXT_RUNTIME === "nodejs"`. If an existing `register()` cannot be merged safely, an `instrumentation.vendo-example.*` file is written instead. |
+| `.env.example` | Adds provider, integration, storage, scheduler, and webhook variables if they are not already documented. |
+| `public/vendo/react-runtime.js` and `public/vendo/components-sandbox.js` | Copies the sandbox runtime assets from the CLI bundle. |
+| `package.json` | Adds `@vendoai/next` to dependencies and adds `vendo sync` to `prebuild` when possible. |
+
+If the project is not a supported Next.js App Router target, `init` still writes
+the `.vendo/` extraction output it can produce, then reports the skipped wiring.

--- a/docs-site/reference/dot-vendo.mdx
+++ b/docs-site/reference/dot-vendo.mdx
@@ -1,0 +1,108 @@
+---
+title: "The .vendo directory"
+description: "Every file the codemod writes and which edits are supported"
+---
+
+`.vendo/` is Vendo's reviewable source of truth inside your repo. The server
+loader reads it at runtime. Missing files fall back to safe defaults. Present
+but invalid JSON or schema-invalid files fail loudly at boot.
+
+`vendo init` refuses to overwrite generated `.vendo/` files unless you pass
+`--force`.
+
+## Files Written By `vendo init`
+
+| Path | When written | Hand edits |
+| --- | --- | --- |
+| `.vendo/README.md` | Every successful init extraction. | Supported. It is documentation for your generated artifacts. |
+| `.vendo/theme.json` | Written by theme extraction when possible. If Next.js wiring runs and the file is absent, a default theme is written so the generated wrapper can import it. | Supported. Keep the schema valid: `version`, literal hex colors, `fontFamily`, `radius`, and optional `mode`. |
+| `.vendo/tools.json` | Written from OpenAPI when a spec is found, from route scanning when an LLM finds tools, or as an empty manifest during Next.js wiring if the file is absent. | Supported. This is the reviewed API surface. Edit tool descriptions, schemas, bindings, events, and safety annotations. |
+| `.vendo/components/<Name>/descriptor.ts` | Written only when LLM component discovery includes a component. | Supported. Keep it exporting a valid `RegisteredComponent` descriptor with `source: "host"`. |
+| `.vendo/components/<Name>/impl.tsx` | Written with each component descriptor. | Supported. Review generated JSX like any other code. The wrapper runs inside the sandbox, but it is still code in your repo. |
+| `.vendo/components/entry.ts` | Written only when one or more component wrappers are written. | Supported. Update it if you add, remove, or rename wrappers by hand. |
+| `.vendo/components/vite.config.mts` | Written only when one or more component wrappers are written. | Supported. Adjust aliases or build settings if your host component bundle needs them. |
+
+## `theme.json`
+
+`theme.json` must match the brand token schema:
+
+```json
+{
+  "version": 1,
+  "accent": "#0A7CFF",
+  "background": "#FFFFFF",
+  "surface": "#F5F7FA",
+  "text": "#111418",
+  "mutedText": "#5B6470",
+  "fontFamily": "system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
+  "radius": 8,
+  "mode": "light"
+}
+```
+
+Use literal values. CSS variables, URLs, and unresolved font references are not
+accepted by the schema.
+
+## `tools.json`
+
+`tools.json` has this top-level shape:
+
+```json
+{
+  "version": 1,
+  "tools": [],
+  "events": []
+}
+```
+
+Each tool includes:
+
+| Field | Behavior |
+| --- | --- |
+| `name` | Tool-call identifier. Must start with a letter and may contain letters, numbers, `_`, and `-`. |
+| `description` | Text the model uses to decide when to call the tool. |
+| `inputSchema` | JSON Schema object for tool input. Path and query params are top-level properties. A JSON request body is the `body` property. |
+| `annotations.mutating` | `false` means read-only. `true` means the policy treats it as a write. |
+| `annotations.dangerous` | `true` marks a tool as destructive or otherwise high risk. |
+| `annotations.idempotent` | Optional hint that repeated calls with the same input are safe. |
+| `binding` | Currently only `{ "type": "http", "method": "...", "path": "..." }`. Paths must be host-relative and may use `{param}` templates. |
+
+OpenAPI extraction can mark read-shaped `GET` operations as non-mutating.
+Route scanning marks every tool mutating by default. Relax route-scanned tools
+only after review.
+
+Events are optional automation triggers. Event names must be dot-namespaced
+lower snake case, for example `invoice.paid`.
+
+## Files Read But Not Written By `init`
+
+| Path | Writer | Hand edits |
+| --- | --- | --- |
+| `.vendo/mcp.json` | You create this file by hand. | Supported. It declares MCP servers. Header values may use `${ENV_VAR}` templates. Missing env values drop that server at boot. |
+| `.vendo/remix-sources.json` | `vendo sync`. | Not recommended. It is generated from captured remix anchors and will be replaced by sync. |
+| `.vendo/env/manifest.json` | `vendo sync`. | Not recommended. It describes the sandbox environment built by sync. |
+| `.vendo/env/**` | `vendo sync`. | Not recommended. These are vendored or shimmed sandbox-environment assets. |
+
+## `mcp.json`
+
+`mcp.json` is optional and uses this shape:
+
+```json
+{
+  "version": 1,
+  "servers": [
+    {
+      "name": "internal",
+      "url": "https://mcp.example.com/mcp",
+      "headers": {
+        "authorization": "Bearer ${INTERNAL_MCP_TOKEN}"
+      },
+      "tools": ["search"]
+    }
+  ]
+}
+```
+
+Only `http://` and `https://` server URLs are accepted. Server names must use
+letters, digits, `_`, or `-`. Duplicate or prefix-ambiguous server names are
+rejected because MCP tool names are prefixed with the server name.

--- a/docs-site/reference/environment-variables.mdx
+++ b/docs-site/reference/environment-variables.mdx
@@ -1,0 +1,85 @@
+---
+title: "Environment variables"
+description: "Runtime, CLI, provider, storage, scheduler, and telemetry variables"
+---
+
+These are the environment variables read by the Vendo packages. Handler options
+win over env where an explicit option exists.
+
+## Model Providers
+
+| Variable | Effect | Default |
+| --- | --- | --- |
+| `ANTHROPIC_API_KEY` | Enables chat and generated UI through Anthropic. It has first provider precedence. Also provides fallback key material for remix pin sealing when `VENDO_SEAL_SECRET` is unset and no model is injected. | Unset. |
+| `OPENAI_API_KEY` | Enables chat and generated UI through OpenAI when no Anthropic key is present. Also sets the `voice` capability flag. | Unset. |
+| `GOOGLE_GENERATIVE_AI_API_KEY` | Enables chat and generated UI through Google when Anthropic and OpenAI keys are absent. | Unset. |
+| `VENDO_MODEL` | Overrides the runtime model. Accepts `provider/model` or a bare model id. A bare id applies to the detected provider, or Anthropic if none is detected. | Provider default: `claude-sonnet-5`, `gpt-5.5`, or `gemini-3.5-flash`. |
+| `VENDO_CLI_MODEL` | CLI-only model override for `vendo init`. Takes precedence over `VENDO_MODEL` and uses the same syntax. | Unset. |
+
+`VENDO_MODEL` and `VENDO_CLI_MODEL` do not count as credentials. Chat and
+LLM-assisted init steps still need one provider key or an injected model.
+
+OpenAI and Google model resolution require the optional provider package when
+that provider is selected.
+
+## Integrations And Webhooks
+
+| Variable | Effect | Default |
+| --- | --- | --- |
+| `COMPOSIO_API_KEY` | Enables integration catalog and connect routes. The Composio client also falls back to this key when no explicit key is passed. | Integrations disabled. |
+| `COMPOSIO_WEBHOOK_SECRET` | Verifies `POST /webhooks/composio` signatures. Missing secret makes the webhook route return `404`. | Webhook ingress disabled. |
+
+## Storage And Scheduler
+
+| Variable | Effect | Default |
+| --- | --- | --- |
+| `DATABASE_URL` | Uses hosted Postgres for durable storage. Ignored when the handler is given an explicit `storage.pglite` option. | Unset. |
+| `VENDO_DATA_DIR` | Directory for embedded PGlite storage. Ignored when `DATABASE_URL` or an explicit connection string is used. | `.vendo/data`. |
+| `VENDO_TICK_SECRET` | Optional bearer secret for `POST /tick`. A wrong presented bearer returns `401`. If no bearer is presented, `/tick` falls back to principal auth. | Unset. |
+| `VENDO_SCHEDULER` | Set to `external` to disable the in-process scheduler started by `startVendoScheduler()`. Other values behave like unset. | In-process scheduler can start. |
+| `VERCEL` | Marks the runtime as serverless for the default PGlite guard. If set and no Postgres connection is configured, boot fails instead of using ephemeral local files. | Unset. |
+| `CF_PAGES` | Same serverless guard as `VERCEL`. | Unset. |
+| `AWS_LAMBDA_FUNCTION_NAME` | Same serverless guard as `VERCEL`. | Unset. |
+
+If one of the serverless guard variables is present and storage would otherwise
+use the default PGlite file store, boot fails and asks you to set
+`DATABASE_URL`.
+
+## Request Guard And Runtime Mode
+
+| Variable | Effect | Default |
+| --- | --- | --- |
+| `VENDO_ALLOW_REMOTE` | Set to `1` to allow the default principal for remote or production requests. Prefer a `principal` handler option for production. | Remote default principal disabled. |
+| `NODE_ENV` | `production` disables the default principal unless `principal` or `VENDO_ALLOW_REMOTE=1` is set. `test` makes unset storage behave as `storage: false`. Non-production enables development telemetry events. | Depends on your runtime. |
+| `NEXT_RUNTIME` | The generated Next.js instrumentation starts the scheduler only when this is `nodejs`. | Set by Next.js. |
+
+## Telemetry
+
+| Variable | Effect | Default |
+| --- | --- | --- |
+| `VENDO_POSTHOG_KEY` | Overrides the telemetry project key. | Built-in telemetry key. |
+| `VENDO_TELEMETRY_DISABLED` | `1` or `true` disables telemetry. | Telemetry allowed unless another opt-out applies. |
+| `DO_NOT_TRACK` | `1` or `true` disables telemetry. | Unset. |
+| `CI` | Any non-empty value except `0` or `false` disables telemetry. | Unset. |
+
+## Development Diagnostics
+
+| Variable | Effect | Default |
+| --- | --- | --- |
+| `VENDO_BENCH` | Set to `1` to log `edit_view` apply and materialize timings. | Disabled. |
+
+## MCP Header Templates
+
+`.vendo/mcp.json` can reference arbitrary uppercase env vars in header values:
+
+```json
+{
+  "headers": {
+    "authorization": "Bearer ${INTERNAL_MCP_TOKEN}"
+  }
+}
+```
+
+If a referenced variable is missing or empty, that MCP server is dropped at
+boot with a warning. The env var name is not fixed by Vendo. It comes from your
+template.

--- a/docs-site/reference/handler-options.mdx
+++ b/docs-site/reference/handler-options.mdx
@@ -1,0 +1,51 @@
+---
+title: "Handler options"
+description: "Every option accepted by createVendoHandler and createVendoFetchHandler"
+---
+
+`createVendoHandler(options)` from `@vendoai/next` and
+`createVendoFetchHandler(options)` from `@vendoai/server` accept the same
+`VendoHandlerOptions` object. The options object is validated at boot. Unknown
+keys or wrong shapes throw a readable error instead of being ignored.
+
+```ts
+import { createVendoHandler } from "@vendoai/next";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const { GET, POST } = createVendoHandler({
+  productName: "Acme",
+});
+```
+
+| Option | Type | Default | Behavior |
+| --- | --- | --- | --- |
+| `model` | `LanguageModel` | Resolved from provider env keys and `VENDO_MODEL`. | Supplies the model used by the agent loop. Passing a model also enables chat even when no provider key is present. |
+| `productName` | `string` | `"this app"` | Names your product in the default system prompt. |
+| `instructions` | `string \| ((ctx: InstructionContext) => string)` | Built-in Vendo instructions. | Replaces the full system prompt. The function form receives the live tool summary. |
+| `instructionsExtra` | `string` | No extra text. | Appends host-specific instructions to the built-in prompt. |
+| `policy` | `ApprovalPolicy` | `defaultVendoPolicy`. | Controls allow, approve, and deny decisions for tool calls and sandbox actions. |
+| `tools` | `ToolSet \| (() => ToolSet)` | `{}` | Registers server-executed tools. These are separate from browser-executed host API tools. |
+| `components` | `RegisteredComponent[]` | `[]` | Adds host components to the generated UI registry, alongside the prewired component catalog. |
+| `hostTools` | `HostToolDefinition[]` | Tools loaded from `.vendo/tools.json`. | Overrides the host API tool definitions loaded from disk. |
+| `vendoDir` | `string` | `path.join(process.cwd(), ".vendo")` | Points the handler at a different `.vendo/` directory. |
+| `principal` | `(req: Request) => VendoPrincipal \| null \| Promise<VendoPrincipal \| null>` | Development local-only default identity. | Resolves the signed-in caller. Return `null` to reject with 403. In production, pass this or set `VENDO_ALLOW_REMOTE=1`. |
+| `cacheKey` | `() => string` | No extra key material. | Adds host-controlled key material to the agent cache. |
+| `integrations` | `IntegrationCatalogEntry[]` | The built-in integration catalog. | Controls which Composio toolkits the connect UI can show. |
+| `mcpServers` | `McpServerConfig[]` | Resolved from `.vendo/mcp.json`, or `[]`. | Declares Streamable HTTP MCP servers. The option replaces `.vendo/mcp.json` entirely when provided. |
+| `connections` | `ConnectionsStore` | Handler-owned store. | Overrides integration connection state. The store must implement `list`, `connect`, `disconnect`, `connectedToolkits`, `setConnectedAccount`, and `findByConnectedAccount`. |
+| `automations` | `false \| { tools?: Record<string, RegisteredTool> }` | Enabled with no extra automation tools. | `false` disables automation authoring, `/tick`, deliveries, resume, and parked-action routes. The object form adds tools automation steps can call. |
+| `maxSteps` | `number` | Engine default. | Sets the maximum model-to-tool steps per turn. Must be a positive integer. |
+| `remixSources` | `Record<string, string> \| ((anchorId: string) => string \| undefined)` | Sources from `.vendo/remix-sources.json`. | Provides raw component source for remix-aware generated UI. The option is checked before captured sources on disk. |
+| `sealSecret` | `string` | `VENDO_SEAL_SECRET`, else derived from `ANTHROPIC_API_KEY` on the default-model path. | Enables sealed remix pin envelopes. Without key material, pin editing is unavailable and anchor-based edits still work. |
+| `store` | `{ grants?, audit?, threads?, breakers?, fadeTracker?, rules? }` | Handler-owned stores. | Overrides selected persistence seams. Omitted members use the handler defaults. Threads use durable storage when available, otherwise in-memory storage. |
+| `judgeModel` | `LanguageModel` | `undefined`. | Opts into the policy judge model. When omitted, the judge layer is inactive. |
+| `storage` | `false \| { connectionString?: string; pglite?: { dataDir: string }; autoMigrate?: boolean }` | Durable storage, using `DATABASE_URL` or PGlite at `.vendo/data`. | `false` opts out to in-memory storage. `autoMigrate` defaults to `true`. If `NODE_ENV=test` and this option is unset, storage behaves as `false`. |
+| `bootKey` | `string` | No explicit boot key. | Lets the route handler and scheduler share the same process-wide Vendo world when they pass separate but equivalent option objects. |
+
+<Note>
+  The handler reads `.vendo/` lazily on the first request or scheduler boot.
+  Missing files use safe defaults. Present but invalid JSON or schema-invalid
+  files fail loudly.
+</Note>

--- a/docs-site/reference/http-routes.mdx
+++ b/docs-site/reference/http-routes.mdx
@@ -1,0 +1,65 @@
+---
+title: "HTTP routes"
+description: "Every endpoint the handler serves"
+---
+
+The Next.js adapter mounts these routes at `/api/vendo` by default. The
+framework-agnostic fetch handler does not require that exact mount path. It
+finds the first known Vendo segment in the URL suffix, so the same routes work
+under another prefix.
+
+Only `GET` and `POST` are served. Other methods return `404`.
+
+## Auth Posture
+
+Most identity-bearing routes use the handler principal guard:
+
+- If you pass `principal(req)`, that resolver is the gate. Returning `null`
+  rejects the request with `403`.
+- Without `principal`, local development requests use the default principal.
+- In production, the default principal is disabled unless
+  `VENDO_ALLOW_REMOTE=1` is set.
+
+`POST /tick` can also use a bearer secret. `POST /webhooks/composio` uses a
+Composio webhook signature instead of a user principal.
+
+## GET Routes
+
+| Route | Purpose | Auth posture |
+| --- | --- | --- |
+| `GET /capabilities` | Returns `{ chat, integrations, voice, mcp, storage }`. | No principal guard. Returns booleans derived from env, config, and assembled storage. |
+| `GET /integrations` | Lists integration catalog entries and connection state. | Principal guard. If `COMPOSIO_API_KEY` is missing, returns `enabled: false` and an empty catalog. |
+| `GET /integrations?status&id=<id>&account=<connectedAccountId>` | Polls Composio connection status and marks a toolkit connected when active. | Principal guard and known-toolkit validation. |
+| `GET /deliveries?since=<cursor>` | Lists automation delivery messages for in-app toasts. | Principal guard, automations enabled, and single-tenant subject check. |
+| `GET /parked-actions` | Lists unresolved parked automation actions. | Principal guard and automations enabled. |
+| `GET /grants` | Lists standing grants plus automation-version grants for the Trust surface. | Principal guard. |
+| `GET /rules` | Lists compiled always-ask rules. | Principal guard. |
+| `GET /audit` | Queries audit events. Supports `sinceMs` and `limit` query params. | Principal guard. |
+| `GET /critical-tools` | Lists tools classified as critical by the policy descriptor rules. | Principal guard. |
+| `GET /threads` | Lists stored chat threads for the resolved principal. | Principal guard. |
+| `GET /threads/<threadId>` | Returns stored messages for one thread. | Principal guard. |
+| `GET /vendos` | Lists saved generated views for the resolved principal. | Principal guard. |
+| `GET /vendos/<id>` | Loads one saved generated view. | Principal guard. Returns `404` when missing. |
+
+## POST Routes
+
+| Route | Purpose | Auth posture |
+| --- | --- | --- |
+| `POST /chat` | Streams an agent turn from UI messages. | Requires chat capability from a provider key or injected model, then principal guard. |
+| `POST /action` | Executes a server-side action from generated UI after policy evaluation. | Principal guard and policy. Approval decisions return a single-use approval token before execution. |
+| `POST /integrations` | Connects or disconnects an integration. Body action is `"connect"` or `"disconnect"`. | Principal guard, known-toolkit validation, and `COMPOSIO_API_KEY`. Returns `503` when integrations are disabled. |
+| `POST /tick` | Runs one scheduler tick. | Automations enabled. If a bearer token is present and `VENDO_TICK_SECRET` is set, it must match. Without bearer auth, falls back to principal guard. |
+| `POST /webhooks/composio` | Accepts Composio trigger webhooks and fires matching automations. | No principal guard. Requires `COMPOSIO_WEBHOOK_SECRET` and valid `webhook-id`, `webhook-timestamp`, and `webhook-signature` headers. |
+| `POST /resume` | Resumes a paused automation run from an approval toast. | Principal guard, automations enabled, and single-tenant subject check. |
+| `POST /consent` | Records a consent response and may mint a grant. | Principal guard. Validates the consent body and live tool descriptor. |
+| `POST /fade-proposal` | Resolves a fade proposal. | Principal guard. |
+| `POST /parked-actions/resolve` | Approves or declines a parked automation action. | Principal guard and automations enabled. |
+| `POST /grants/revoke` | Revokes a standing grant. | Principal guard. |
+| `POST /rules/revoke` | Revokes an always-ask rule. | Principal guard. |
+| `POST /vendos` | Saves a generated view draft. | Principal guard. Rejects ids that collide with reserved route segments or contain `/`. |
+| `POST /vendos/<id>/delete` | Deletes a saved generated view. | Principal guard. |
+
+## Not Found
+
+Unknown route tails return JSON `{ "error": "not found" }` with status `404`.
+Boot failures return status `500` with the boot error message.

--- a/docs-site/reference/server-api.mdx
+++ b/docs-site/reference/server-api.mdx
@@ -1,0 +1,149 @@
+---
+title: "@vendoai/server"
+description: "The framework-agnostic server API and Node bridge"
+---
+
+`@vendoai/server` is the framework-agnostic handler core behind
+`@vendoai/next`. Import it only from server code. It reads `.vendo/`, uses
+provider keys, and owns route handlers.
+
+## Handler Core
+
+```ts
+import { createServer } from "node:http";
+import { createVendoFetchHandler, toNodeHandler } from "@vendoai/server";
+
+const handler = createVendoFetchHandler();
+
+createServer(toNodeHandler(handler)).listen(3000);
+```
+
+| Export | Purpose |
+| --- | --- |
+| `VENDO_SERVER_PACKAGE` | Constant string, `"@vendoai/server"`. |
+| `createVendoFetchHandler` | Returns the fetch-native Vendo handler, `(Request) => Promise<Response>`. |
+| `VendoFetchHandler` | Type for the fetch-native handler. |
+| `VendoState` | Type for the assembled handler state. |
+| `routeTail` | Resolves the Vendo route suffix from a request URL, independent of mount prefix. |
+| `ensureVendoState` | Assembles or reuses the process-wide Vendo state used by the scheduler. |
+| `bootRegistry` | Process-wide boot registry used to coordinate route and scheduler state. |
+| `resetVendoBootRegistry` | Test helper that clears the boot registry. |
+| `startVendoScheduler` | Starts the in-process automation scheduler unless `VENDO_SCHEDULER=external`. |
+
+## Node Bridge
+
+`toNodeHandler(handler)` adapts the fetch handler to Node's
+`(IncomingMessage, ServerResponse)` shape. It streams response bodies, converts
+thrown handler errors to HTTP 500 when headers are not sent, and aborts the
+fetch `Request` signal if the client disconnects.
+
+| Export | Purpose |
+| --- | --- |
+| `toNodeHandler` | Bridges a fetch handler to Node, Express, and other Node servers that use the same request/response shape. |
+| `FetchHandler` | `(req: Request) => Promise<Response>`. |
+| `NodeHandler` | `(req: IncomingMessage, res: ServerResponse) => Promise<void>`. |
+
+## Options And Loading
+
+| Export | Purpose |
+| --- | --- |
+| `parseHandlerOptions` | Validates `VendoHandlerOptions` and rejects unknown keys. |
+| `VendoHandlerOptions` | Shared options type for `createVendoFetchHandler` and `createVendoHandler`. |
+| `IntegrationCatalogEntry` | `{ id: string; name: string }` entry used by the integrations catalog option. |
+| `loadVendoDir` | Loads `.vendo/theme.json`, `.vendo/tools.json`, `.vendo/remix-sources.json`, `.vendo/env/manifest.json`, and `.vendo/mcp.json`. |
+| `LoadedVendoDir` | Return type for `loadVendoDir`. |
+| `manifestToolsToHostTools` | Converts `.vendo/tools.json` manifest entries into host tool definitions. |
+| `resolveMcpServers` | Resolves MCP server config and substitutes `${ENV_VAR}` header templates. |
+| `mcpJsonSchema` | Zod schema for `.vendo/mcp.json`. |
+| `mcpServerArraySchema` | Zod schema for an array of MCP server configs. |
+
+## Capabilities And Models
+
+| Export | Purpose |
+| --- | --- |
+| `detectCapabilities` | Detects chat, integrations, voice, and MCP capability flags from env and injected-model presence. |
+| `VendoCapabilities` | Wire shape returned by `GET /capabilities`, including `storage`. |
+| `EnvCapabilities` | Capability shape detectable from env alone, without `storage`. |
+| `DetectCapabilitiesOptions` | Options for `detectCapabilities`. |
+| `resolveModel` | Resolves provider env and `VENDO_MODEL` into an AI SDK `LanguageModel`. |
+| `resolveModelChoice` | Pure provider/model-id resolver. |
+| `ModelChoice` | Result type for `resolveModelChoice`. |
+| `ModelProvider` | `"anthropic" \| "openai" \| "google"`. |
+| `ResolveModelDeps` | Test seam for dynamic provider imports. |
+
+## Policy, Principal, And Prompt Helpers
+
+| Export | Purpose |
+| --- | --- |
+| `defaultVendoPolicy` | Default approval policy based on tool annotations and verb/name heuristics. |
+| `composeProductionPolicy` | Composes grants, rules, audit, judge, and breaker behavior around a base policy. |
+| `principalScope` | Maps a policy context to the stored principal scope. |
+| `EMBEDDED_TENANT` | Fixed embedded tenant id used by the built-in handler world. |
+| `resolvePrincipal` | Applies the handler principal resolver or the default local-only guard. |
+| `tickServiceAuth` | Verifies `Authorization: Bearer <VENDO_TICK_SECRET>` for scheduler ticks. |
+| `threadScope` | Maps a `VendoPrincipal` to the thread store scope. |
+| `DEFAULT_PRINCIPAL` | Default development principal used by zero-config local installs. |
+| `WORLD_SCOPE` | Fixed embedded automation-world scope. |
+| `GuardResult` | Result type returned by `resolvePrincipal`. |
+| `buildInstructions` | Builds the default Vendo system prompt. |
+| `createAgentCache` | Creates the cached agent factory used by the handler. |
+| `BuildInstructionsInput` | Input type for `buildInstructions`. |
+| `AgentFactoryConfig` | Config type for `createAgentCache`. |
+
+## Stores And Worlds
+
+| Export | Purpose |
+| --- | --- |
+| `DEFAULT_INTEGRATION_CATALOG` | Default Composio integration catalog. |
+| `createConnectionsStore` | Creates the in-memory integration connection store. |
+| `ConnectionsStore` | Integration connection store interface. |
+| `createAutomationsWorld` | Creates the embedded automations world. |
+| `VendoAutomationsWorld` | Automations world interface returned by `createAutomationsWorld`. |
+| `CreateWorldConfig` | Config type for `createAutomationsWorld`. |
+| `createThreadIndex` | Maps client thread ids to stored thread ids. |
+| `ThreadIndex` | Thread index interface. |
+| `createDrizzleVendoRegistry` | Creates a durable saved-view registry. |
+| `createInMemoryVendoRegistry` | Creates an in-memory saved-view registry. |
+| `VendoRegistry` | Saved-view registry interface. |
+| `createApprovalStore` | Creates the short-lived action approval-token store. |
+| `ApprovalStore` | Approval-token store interface. |
+
+## Route Handlers
+
+These lower-level exports are what `createVendoFetchHandler` mounts for you.
+Use them only if you are composing your own router.
+
+| Export | Purpose |
+| --- | --- |
+| `handleChat`, `ChatDeps` | Agent chat streaming route. |
+| `handleAction`, `ActionDeps` | Server action dispatch route. |
+| `handleIntegrationsGet`, `handleIntegrationsPost`, `IntegrationsDeps` | Integration catalog, connect, disconnect, and status routes. |
+| `handleVendosGet`, `handleVendosPost` | Saved generated view routes. |
+| `handleConsentRoute`, `ConsentRouteDeps` | Consent response route. |
+| `handleFadeProposalRoute`, `FadeProposalRouteDeps` | Fade proposal resolution route. |
+| `listParkedActionsRoute`, `resolveParkedActionRoute` | Parked automation actions routes. |
+| `listGrantsRoute`, `revokeGrantRoute` | Trust grant routes. |
+| `listRulesRoute`, `revokeRuleRoute` | Trust always-ask rule routes. |
+| `queryAuditRoute` | Trust audit query route. |
+| `listCriticalToolsRoute` | Trust critical-tools route. |
+
+## Remix Helpers
+
+| Export | Purpose |
+| --- | --- |
+| `applyVerifiedPinBase` | Applies a verified remix pin envelope to UI messages. |
+| `enrichAnchorSources` | Adds server-side captured anchor source to remix requests. |
+| `createSourceResolver` | Creates a source resolver from handler options and captured `.vendo` sources. |
+| `capSource` | Caps captured component source text. |
+| `resolveRemixSealer` | Resolves the remix envelope sealer from options and env. |
+
+## Subpath Exports
+
+The package also exposes these server-safe subpaths:
+
+| Subpath | Exports |
+| --- | --- |
+| `@vendoai/server/capabilities` | Capability detection without importing the full server barrel. |
+| `@vendoai/server/model` | Model resolution without importing the full server barrel. |
+| `@vendoai/server/manifest-tools` | Manifest-to-host-tool conversion. |
+| `@vendoai/server/catalog` | Default integration catalog. |

--- a/docs-site/styles.css
+++ b/docs-site/styles.css
@@ -1,0 +1,13 @@
+/* Vendo brand, whisper intensity (Brand.md: docs and dense UI drop to Whisper).
+   Applied by Mintlify on plans with custom CSS; harmless when ignored. */
+
+h1,
+h2 {
+  letter-spacing: -0.035em;
+}
+
+:root {
+  --vendo-ink: #17171a;
+  --vendo-porcelain: #fafaf8;
+  --vendo-ultramarine: #4338ca;
+}


### PR DESCRIPTION
## What
Restores `docs-site/` (deleted in #60's cleanup) from history, unchanged. Decision: docs live in the same repo so agents and humans update them in the same PR as code changes; Mintlify supports pointing a project at a subdirectory.

## Why
Same-repo docs keep the "sync docs with every meaningful change" rule enforceable; a separate docs repo invites drift. This replaces launch-checklist item 7 (no separate runvendo/docs repo) — after the repo flips public, connect Mintlify to `runvendo/vendo` with content dir `docs-site/`.

## Verification
- Content restored byte-identical from pre-cleanup history (a74808a1)
- Zero internal references (flowlet / Infisical / ENG-tickets / npm-status caveats): scanned clean
- Follow-up (non-blocking): consolidate `docs/` markdown vs `docs-site/` into one source of truth post-launch

https://claude.ai/code/session_01C3iN3nkdQq7HC3AuFeTcED
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Mintlify docs site under `docs-site/` (unchanged from pre-cleanup) so docs live with the code and ship in the same PRs. No runtime or product code changes—only docs and assets.

- **Migration**
  - After the repo is public, point your Mintlify project to the `docs-site/` content directory for `runvendo/vendo`.

<sup>Written for commit 7fee5c3cdc26786144c762029e74f9cffa9f12df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

