### PR TITLE
fix(cli): improve deterministic theme extraction accuracy

### DIFF
--- a/packages/vendo-cli/src/theme/css-vars.ts
+++ b/packages/vendo-cli/src/theme/css-vars.ts
@@ -9,6 +9,9 @@ export interface CssVarDecl {
   value: string;
   file: string;
   darkScope: boolean;
+  /** Not declared in CSS (e.g. recovered from next/font source) — usable to
+   * resolve var() chains but never picked directly for a slot. */
+  synthetic?: boolean;
 }
 
 const DARK_SELECTOR = /(\.dark\b|\[data-theme=["']?dark["']?\]|prefers-color-scheme:\s*dark)/;

--- a/packages/vendo-cli/src/theme/extract-theme.test.ts
+++ b/packages/vendo-cli/src/theme/extract-theme.test.ts
@@ -1,9 +1,25 @@
 import { describe, expect, it } from "vitest";
-import { mkdtemp, mkdir, writeFile, readFile } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, readFile, copyFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { extractTheme } from "./extract-theme.js";
 import { detectTarget } from "../detect.js";
+
+const fixtures = path.join(fileURLToPath(new URL(".", import.meta.url)), "../../test/fixtures/theme");
+
+/** Stage a fixture app (globals.css + layout.tsx snapshots of a demo app) in a temp dir. */
+async function stageFixtureApp(name: string): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), `theme-${name}-`));
+  await writeFile(
+    path.join(dir, "package.json"),
+    JSON.stringify({ dependencies: { next: "^15.0.0", tailwindcss: "^4.0.0" } }),
+  );
+  await mkdir(path.join(dir, "src/app"), { recursive: true });
+  await copyFile(path.join(fixtures, name, "globals.css"), path.join(dir, "src/app/globals.css"));
+  await copyFile(path.join(fixtures, name, "layout.tsx"), path.join(dir, "src/app/layout.tsx"));
+  return dir;
+}
 
 describe("extractTheme", () => {
   it("writes a valid theme.json from a v4 css app", async () => {
@@ -21,5 +37,41 @@ describe("extractTheme", () => {
     expect(written.version).toBe(1);
     expect(summary.written).toBe(true);
     expect(summary.defaulted).toContain("accent");
+  });
+
+  it("extracts Cadence (demo-accounting) tokens: surface background, scale accent, next/font family", async () => {
+    const dir = await stageFixtureApp("cadence");
+    const info = await detectTarget(dir);
+    const summary = await extractTheme(dir, info, { force: false });
+    const written = JSON.parse(await readFile(path.join(dir, ".vendo/theme.json"), "utf8"));
+    // Page background is --color-surface, NOT the --color-status-missing-bg badge tint.
+    expect(written.background).toBe("#f7f5f1");
+    expect(written.surface).toBe("#ffffff");
+    expect(written.text).toBe("#221e19");
+    // Single evergreen scale family -> mid step.
+    expect(written.accent).toBe("#34816a");
+    // --font-sans -> var(--font-hanken) resolved through the next/font wiring.
+    expect(written.fontFamily).toContain("Hanken Grotesk");
+    expect(written.fontFamily).not.toContain("var(");
+    // Genuinely absent tokens stay defaulted and flagged (fail-closed).
+    expect(summary.defaulted).toContain("mutedText");
+    expect(summary.defaulted).toContain("radius");
+    expect(summary.written).toBe(true);
+  });
+
+  it("extracts Maple (demo-bank) tokens at least as well as before (regression baseline)", async () => {
+    const dir = await stageFixtureApp("maple");
+    const info = await detectTarget(dir);
+    const summary = await extractTheme(dir, info, { force: false });
+    const written = JSON.parse(await readFile(path.join(dir, ".vendo/theme.json"), "utf8"));
+    expect(written.background).toBe("#FBFBFA");
+    expect(written.surface).toBe("#FFFFFF");
+    expect(written.text).toBe("#111111");
+    expect(written.mutedText).toBe("#908C85");
+    expect(written.radius).toBe("14px");
+    expect(written.fontFamily).toContain("Inter");
+    // No accent-ish token in Maple — stays defaulted and flagged.
+    expect(summary.defaulted).toEqual(["accent"]);
+    expect(summary.written).toBe(true);
   });
 });

--- a/packages/vendo-cli/src/theme/extract-theme.test.ts
+++ b/packages/vendo-cli/src/theme/extract-theme.test.ts
@@ -39,6 +39,32 @@ describe("extractTheme", () => {
     expect(summary.defaulted).toContain("accent");
   });
 
+  it("lets an explicit CSS declaration of a next/font variable win over the synthesized value", async () => {
+    const dir = await stageFixtureApp("maple");
+    await writeFile(
+      path.join(dir, "src/app/globals.css"),
+      '@theme { --color-bg: #FBFBFA; --font-inter: "Custom Corp Sans", sans-serif; --font-sans: var(--font-inter); }',
+    );
+    const info = await detectTarget(dir);
+    await extractTheme(dir, info, { force: false });
+    const written = JSON.parse(await readFile(path.join(dir, ".vendo/theme.json"), "utf8"));
+    expect(written.fontFamily).toBe('"Custom Corp Sans", sans-serif');
+  });
+
+  it("recovers next/font vars declared in a conventional fonts.ts module", async () => {
+    const dir = await stageFixtureApp("maple");
+    await writeFile(path.join(dir, "src/app/layout.tsx"), "export default function RootLayout() { return null }\n");
+    await mkdir(path.join(dir, "src/app/ui"), { recursive: true });
+    await writeFile(
+      path.join(dir, "src/app/ui/fonts.ts"),
+      'import { Inter } from "next/font/google"\nexport const inter = Inter({ subsets: ["latin"], variable: "--font-inter" })\n',
+    );
+    const info = await detectTarget(dir);
+    await extractTheme(dir, info, { force: false });
+    const written = JSON.parse(await readFile(path.join(dir, ".vendo/theme.json"), "utf8"));
+    expect(written.fontFamily).toContain("Inter");
+  });
+
   it("extracts Cadence (demo-accounting) tokens: surface background, scale accent, next/font family", async () => {
     const dir = await stageFixtureApp("cadence");
     const info = await detectTarget(dir);

--- a/packages/vendo-cli/src/theme/extract-theme.ts
+++ b/packages/vendo-cli/src/theme/extract-theme.ts
@@ -31,8 +31,12 @@ export async function extractTheme(
     if (error) errors.push(error);
   }
   // next/font injects --font-* vars at runtime; recover them from source so
-  // font var() chains resolve to the actual family.
-  if (info.framework === "next") vars.push(...(await collectNextFontVars(targetDir)));
+  // font var() chains resolve to the actual family. An explicit CSS
+  // declaration of the same variable stays authoritative.
+  if (info.framework === "next") {
+    const declared = new Set(vars.map((v) => v.name));
+    vars.push(...(await collectNextFontVars(targetDir)).filter((v) => !declared.has(v.name)));
+  }
 
   const result = mapVarsToBrand(vars);
   let written = false;

--- a/packages/vendo-cli/src/theme/extract-theme.ts
+++ b/packages/vendo-cli/src/theme/extract-theme.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import type { FrameworkInfo } from "../detect.js";
 import { parseCssVars, type CssVarDecl } from "./css-vars.js";
+import { collectNextFontVars } from "./next-fonts.js";
 import { extractTailwindVars } from "./tailwind-config.js";
 import { mapVarsToBrand, type BrandMappingResult } from "./map-to-brand.js";
 import { writeGenerated } from "../fsx.js";
@@ -29,6 +30,9 @@ export async function extractTheme(
     vars.push(...twVars);
     if (error) errors.push(error);
   }
+  // next/font injects --font-* vars at runtime; recover them from source so
+  // font var() chains resolve to the actual family.
+  if (info.framework === "next") vars.push(...(await collectNextFontVars(targetDir)));
 
   const result = mapVarsToBrand(vars);
   let written = false;

--- a/packages/vendo-cli/src/theme/map-to-brand.test.ts
+++ b/packages/vendo-cli/src/theme/map-to-brand.test.ts
@@ -53,6 +53,56 @@ describe("mapVarsToBrand", () => {
     expect(result.unmapped.map((u) => u.name)).toContain("--color-primary");
   });
 
+  it("skips companion -bg tokens and falls back to surface for background", () => {
+    // Cadence-shaped: status tokens have paired *-bg tints, the real page
+    // background is --color-surface, and cards are --color-card.
+    const result = mapVarsToBrand([
+      v("--color-surface", "#f7f5f1"), v("--color-card", "#ffffff"), v("--color-ink", "#221e19"),
+      v("--color-status-missing", "#b45309"), v("--color-status-missing-bg", "#fdf0df"),
+      v("--color-status-overdue", "#b91c1c"), v("--color-status-overdue-bg", "#fdeae8"),
+    ]);
+    expect(result.brand?.background).toBe("#f7f5f1");
+    expect(result.matched["background"]).toBe("--color-surface");
+    expect(result.brand?.surface).toBe("#ffffff");
+    expect(result.matched["surface"]).toBe("--color-card");
+  });
+
+  it("picks the mid step of a single scale-named accent family", () => {
+    const result = mapVarsToBrand([
+      v("--color-bg", "#FFFFFF"),
+      v("--color-evergreen-100", "#d8ebe2"), v("--color-evergreen-300", "#85bda8"),
+      v("--color-evergreen-500", "#34816a"), v("--color-evergreen-700", "#205345"),
+      v("--color-evergreen-900", "#16362e"),
+    ]);
+    expect(result.brand?.accent).toBe("#34816a");
+    expect(result.matched["accent"]).toBe("--color-evergreen-500");
+  });
+
+  it("defaults accent when multiple scale families make the pick ambiguous", () => {
+    const result = mapVarsToBrand([
+      v("--color-bg", "#FFFFFF"),
+      v("--color-blue-300", "#93c5fd"), v("--color-blue-500", "#3b82f6"), v("--color-blue-700", "#1d4ed8"),
+      v("--color-rose-300", "#fda4af"), v("--color-rose-500", "#f43f5e"), v("--color-rose-700", "#be123c"),
+    ]);
+    expect(result.defaulted).toContain("accent");
+  });
+
+  it("does not treat neutral or status scales as an accent family", () => {
+    const result = mapVarsToBrand([
+      v("--color-bg", "#FFFFFF"),
+      v("--color-gray-300", "#d1d5db"), v("--color-gray-500", "#6b7280"), v("--color-gray-700", "#374151"),
+    ]);
+    expect(result.defaulted).toContain("accent");
+  });
+
+  it("still prefers literal accent names over a scale family", () => {
+    const result = mapVarsToBrand([
+      v("--color-bg", "#FFFFFF"), v("--color-accent", "#FF0000"),
+      v("--color-teal-300", "#5eead4"), v("--color-teal-500", "#14b8a6"), v("--color-teal-700", "#0f766e"),
+    ]);
+    expect(result.brand?.accent).toBe("#FF0000");
+  });
+
   it("flags a dark variant when dark-scoped vars exist", () => {
     const result = mapVarsToBrand([v("--color-bg", "#FFFFFF"), v("--color-bg", "#000000", true)]);
     expect(result.hasDarkVariant).toBe(true);

--- a/packages/vendo-cli/src/theme/map-to-brand.test.ts
+++ b/packages/vendo-cli/src/theme/map-to-brand.test.ts
@@ -67,6 +67,52 @@ describe("mapVarsToBrand", () => {
     expect(result.matched["surface"]).toBe("--color-card");
   });
 
+  it("treats X-fg/X-bg pairs as companions even without a bare X token", () => {
+    const result = mapVarsToBrand([
+      v("--color-surface", "#f7f5f1"), v("--color-card", "#ffffff"),
+      v("--color-status-missing-fg", "#92400e"), v("--color-status-missing-bg", "#fef3c7"),
+    ]);
+    expect(result.brand?.background).toBe("#f7f5f1");
+  });
+
+  it("excludes companion tints from every slot, not just background", () => {
+    // --color-panel is non-hex, so without the filter the surface slot's loose
+    // "panel" match would claim the tint --color-panel-bg.
+    const result = mapVarsToBrand([
+      v("--color-bg", "#FBFBFA"), v("--color-panel", "oklch(0.98 0 0)"), v("--color-panel-bg", "#ffeedd"),
+    ]);
+    expect(result.defaulted).toContain("surface");
+  });
+
+  it("leaves a lone surface token to the surface slot instead of promoting it to background", () => {
+    // Only one surface-ish token and nothing bg-named: claiming it for
+    // background would leave BOTH slots wrong. Fail closed on background.
+    const result = mapVarsToBrand([v("--color-surface", "#ffffff"), v("--color-ink", "#111111")]);
+    expect(result.defaulted).toContain("background");
+    expect(result.brand?.surface).toBe("#ffffff");
+    expect(result.matched["surface"]).toBe("--color-surface");
+  });
+
+  it("does not pick synthetic (resolve-only) vars directly for a slot", () => {
+    // next/font-derived vars exist to resolve var() chains; with no CSS font
+    // token the font slot must default, not grab e.g. the mono family.
+    const result = mapVarsToBrand([
+      v("--color-bg", "#FFFFFF"),
+      { name: "--font-geist-mono", value: '"Geist Mono"', file: "layout.tsx", darkScope: false, synthetic: true },
+      { name: "--font-geist-sans", value: '"Geist"', file: "layout.tsx", darkScope: false, synthetic: true },
+    ]);
+    expect(result.defaulted).toContain("fontFamily");
+    expect(result.unmapped.map((u) => u.name)).not.toContain("--font-geist-mono");
+  });
+
+  it("rejects a low-chroma scale family as accent (fail-closed for unlisted neutrals)", () => {
+    const result = mapVarsToBrand([
+      v("--color-bg", "#FFFFFF"),
+      v("--color-sand-300", "#d6cfc2"), v("--color-sand-500", "#a49d8f"), v("--color-sand-700", "#6f695e"),
+    ]);
+    expect(result.defaulted).toContain("accent");
+  });
+
   it("picks the mid step of a single scale-named accent family", () => {
     const result = mapVarsToBrand([
       v("--color-bg", "#FFFFFF"),

--- a/packages/vendo-cli/src/theme/map-to-brand.ts
+++ b/packages/vendo-cli/src/theme/map-to-brand.ts
@@ -22,13 +22,11 @@ type ColorSlot = "accent" | "background" | "surface" | "text" | "mutedText";
  * Ordered name fragments per slot. mutedText is matched before text so
  * "--color-muted" is not claimed by the text slot's looser fragments, and
  * exact-suffix matches beat loose-contains so "--color-ink" wins over
- * "--color-ink-soft". background's trailing "surface" fragment is a fallback:
- * token sets with no bg token (Cadence) use their surface color as the page
- * background, and the surface slot then falls through to card/panel.
+ * "--color-ink-soft".
  */
 const COLOR_SLOTS: Array<{ slot: ColorSlot; fragments: string[] }> = [
   { slot: "accent", fragments: ["accent", "primary", "brand", "cta"] },
-  { slot: "background", fragments: ["background", "-bg", "bg", "surface"] },
+  { slot: "background", fragments: ["background", "-bg", "bg"] },
   { slot: "surface", fragments: ["surface", "card", "panel"] },
   { slot: "mutedText", fragments: ["fg-muted", "text-muted", "muted", "secondary-text"] },
   { slot: "text", fragments: ["-ink", "text", "-fg", "foreground"] },
@@ -39,11 +37,21 @@ const SCALE_STEPS = new Set([50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 95
 /** Scale families that are never the brand accent. */
 const NON_ACCENT_FAMILY = /(gray|grey|neutral|slate|stone|zinc|status|success|warning|error|danger|info)/;
 
+/** Spread between the widest RGB channels — near zero for neutral ramps whose
+ * family name isn't on the keyword list (sand, ash, ivory, ...). */
+function hexChroma(hex: string): number {
+  let h = hex.slice(1);
+  if (h.length <= 4) h = [...h].map((c) => c + c).join("");
+  const [r, g, b] = [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16)) as [number, number, number];
+  return Math.max(r, g, b) - Math.min(r, g, b);
+}
+
 /**
  * Accent fallback for scale-named token sets (e.g. --color-evergreen-50..950):
  * when exactly one non-neutral, non-status hex scale exists, its mid step is
- * the brand accent. Zero or several candidate families is genuinely ambiguous
- * — return nothing and let the slot default (fail-closed).
+ * the brand accent. Zero or several candidate families, or a mid step too
+ * gray to be a brand color, is genuinely ambiguous — return nothing and let
+ * the slot default (fail-closed).
  */
 function pickScaleAccent(vars: CssVarDecl[]): CssVarDecl | undefined {
   const families = new Map<string, Map<number, CssVarDecl>>();
@@ -62,7 +70,8 @@ function pickScaleAccent(vars: CssVarDecl[]): CssVarDecl | undefined {
   if (candidates.length !== 1) return undefined;
   const steps = candidates[0]![1];
   const mid = [...steps.keys()].sort((a, b) => Math.abs(a - 500) - Math.abs(b - 500) || a - b)[0]!;
-  return steps.get(mid);
+  const hit = steps.get(mid);
+  return hit && hexChroma(hit.value) >= 32 ? hit : undefined;
 }
 
 function pick(
@@ -105,23 +114,39 @@ function isSafeFontStack(value: string): boolean {
 }
 
 export function mapVarsToBrand(all: CssVarDecl[]): BrandMappingResult {
-  const light = all.filter((v) => !v.darkScope);
+  // Synthetic decls (next/font recovery) resolve var() chains only — slots
+  // pick from CSS-declared vars.
+  const light = all.filter((v) => !v.darkScope && !v.synthetic);
   const hasDarkVariant = all.some((v) => v.darkScope);
   const used = new Set<CssVarDecl>();
   const matched: Record<string, string> = {};
   const defaulted: string[] = [];
   const draft: Record<string, unknown> = { version: 1, mode: "light" };
 
-  // "X-bg" alongside a declared "X" is a tinted companion of X (badge/status
-  // backgrounds like --color-status-missing-bg), never the page background.
+  // "X-bg" alongside a declared "X" (or "X-fg") is a tinted companion of X
+  // (badge/status backgrounds like --color-status-missing-bg), never a slot
+  // color in its own right.
   const names = new Set(light.map((v) => v.name));
-  const isCompanionBg = (v: CssVarDecl) => v.name.endsWith("-bg") && names.has(v.name.slice(0, -"-bg".length));
+  const isCompanionTint = (v: CssVarDecl) => {
+    if (!v.name.endsWith("-bg")) return false;
+    const base = v.name.slice(0, -"-bg".length);
+    return names.has(base) || names.has(`${base}-fg`);
+  };
+  const isHex = (val: string) => HEX.test(val);
 
   for (const { slot, fragments } of COLOR_SLOTS) {
-    let candidates = light.filter((v) => !used.has(v));
-    if (slot === "background") candidates = candidates.filter((v) => !isCompanionBg(v));
-    let hit = pick(candidates, fragments, (val) => HEX.test(val));
+    const candidates = light.filter((v) => !used.has(v) && !isCompanionTint(v));
+    let hit = pick(candidates, fragments, isHex);
     if (!hit && slot === "accent") hit = pickScaleAccent(candidates);
+    if (!hit && slot === "background") {
+      // Token sets with no bg token (Cadence) use their surface color as the
+      // page background — but only promote it when the surface slot keeps a
+      // candidate of its own, else we'd trade one wrong slot for two.
+      const surface = pick(candidates, ["surface"], isHex);
+      if (surface && pick(candidates.filter((v) => v !== surface), ["surface", "card", "panel"], isHex)) {
+        hit = surface;
+      }
+    }
     if (hit) { used.add(hit); matched[slot] = hit.name; draft[slot] = hit.value; }
     else { defaulted.push(slot); draft[slot] = defaultBrand[slot]; }
   }

--- a/packages/vendo-cli/src/theme/map-to-brand.ts
+++ b/packages/vendo-cli/src/theme/map-to-brand.ts
@@ -22,15 +22,48 @@ type ColorSlot = "accent" | "background" | "surface" | "text" | "mutedText";
  * Ordered name fragments per slot. mutedText is matched before text so
  * "--color-muted" is not claimed by the text slot's looser fragments, and
  * exact-suffix matches beat loose-contains so "--color-ink" wins over
- * "--color-ink-soft".
+ * "--color-ink-soft". background's trailing "surface" fragment is a fallback:
+ * token sets with no bg token (Cadence) use their surface color as the page
+ * background, and the surface slot then falls through to card/panel.
  */
 const COLOR_SLOTS: Array<{ slot: ColorSlot; fragments: string[] }> = [
   { slot: "accent", fragments: ["accent", "primary", "brand", "cta"] },
-  { slot: "background", fragments: ["background", "-bg", "bg"] },
+  { slot: "background", fragments: ["background", "-bg", "bg", "surface"] },
   { slot: "surface", fragments: ["surface", "card", "panel"] },
   { slot: "mutedText", fragments: ["fg-muted", "text-muted", "muted", "secondary-text"] },
   { slot: "text", fragments: ["-ink", "text", "-fg", "foreground"] },
 ];
+
+/** Tailwind-style scale steps. */
+const SCALE_STEPS = new Set([50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950]);
+/** Scale families that are never the brand accent. */
+const NON_ACCENT_FAMILY = /(gray|grey|neutral|slate|stone|zinc|status|success|warning|error|danger|info)/;
+
+/**
+ * Accent fallback for scale-named token sets (e.g. --color-evergreen-50..950):
+ * when exactly one non-neutral, non-status hex scale exists, its mid step is
+ * the brand accent. Zero or several candidate families is genuinely ambiguous
+ * — return nothing and let the slot default (fail-closed).
+ */
+function pickScaleAccent(vars: CssVarDecl[]): CssVarDecl | undefined {
+  const families = new Map<string, Map<number, CssVarDecl>>();
+  for (const v of vars) {
+    const m = v.name.match(/^(--[\w-]+?)-(\d{2,3})$/);
+    if (!m || !m[1] || !m[2]) continue;
+    const step = Number(m[2]);
+    if (!SCALE_STEPS.has(step) || !HEX.test(v.value)) continue;
+    const steps = families.get(m[1]) ?? new Map<number, CssVarDecl>();
+    steps.set(step, v);
+    families.set(m[1], steps);
+  }
+  const candidates = [...families.entries()].filter(
+    ([name, steps]) => steps.size >= 3 && !NON_ACCENT_FAMILY.test(name),
+  );
+  if (candidates.length !== 1) return undefined;
+  const steps = candidates[0]![1];
+  const mid = [...steps.keys()].sort((a, b) => Math.abs(a - 500) - Math.abs(b - 500) || a - b)[0]!;
+  return steps.get(mid);
+}
 
 function pick(
   vars: CssVarDecl[],
@@ -79,8 +112,16 @@ export function mapVarsToBrand(all: CssVarDecl[]): BrandMappingResult {
   const defaulted: string[] = [];
   const draft: Record<string, unknown> = { version: 1, mode: "light" };
 
+  // "X-bg" alongside a declared "X" is a tinted companion of X (badge/status
+  // backgrounds like --color-status-missing-bg), never the page background.
+  const names = new Set(light.map((v) => v.name));
+  const isCompanionBg = (v: CssVarDecl) => v.name.endsWith("-bg") && names.has(v.name.slice(0, -"-bg".length));
+
   for (const { slot, fragments } of COLOR_SLOTS) {
-    const hit = pick(light.filter((v) => !used.has(v)), fragments, (val) => HEX.test(val));
+    let candidates = light.filter((v) => !used.has(v));
+    if (slot === "background") candidates = candidates.filter((v) => !isCompanionBg(v));
+    let hit = pick(candidates, fragments, (val) => HEX.test(val));
+    if (!hit && slot === "accent") hit = pickScaleAccent(candidates);
     if (hit) { used.add(hit); matched[slot] = hit.name; draft[slot] = hit.value; }
     else { defaulted.push(slot); draft[slot] = defaultBrand[slot]; }
   }

--- a/packages/vendo-cli/src/theme/next-fonts.test.ts
+++ b/packages/vendo-cli/src/theme/next-fonts.test.ts
@@ -10,8 +10,8 @@ const splineMono = Spline_Sans_Mono({ subsets: ["latin"], variable: "--font-spli
 `;
     const vars = parseNextFontVars(source, "src/app/layout.tsx");
     expect(vars).toEqual([
-      { name: "--font-hanken", value: '"Hanken Grotesk"', file: "src/app/layout.tsx", darkScope: false },
-      { name: "--font-spline-mono", value: '"Spline Sans Mono"', file: "src/app/layout.tsx", darkScope: false },
+      { name: "--font-hanken", value: '"Hanken Grotesk"', file: "src/app/layout.tsx", darkScope: false, synthetic: true },
+      { name: "--font-spline-mono", value: '"Spline Sans Mono"', file: "src/app/layout.tsx", darkScope: false, synthetic: true },
     ]);
   });
 
@@ -21,7 +21,19 @@ import { Inter as BodyFont } from "next/font/google"
 const body = BodyFont({ subsets: ["latin"], variable: "--font-body" })
 `;
     expect(parseNextFontVars(source, "layout.tsx")).toEqual([
-      { name: "--font-body", value: '"Inter"', file: "layout.tsx", darkScope: false },
+      { name: "--font-body", value: '"Inter"', file: "layout.tsx", darkScope: false, synthetic: true },
+    ]);
+  });
+
+  it("ignores commented-out loader calls", () => {
+    const source = `
+import { Inter } from "next/font/google"
+// const inter = Inter({ subsets: ["latin"], variable: "--font-old" })
+/* const inter = Inter({ variable: "--font-older" }) */
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" })
+`;
+    expect(parseNextFontVars(source, "layout.tsx")).toEqual([
+      { name: "--font-inter", value: '"Inter"', file: "layout.tsx", darkScope: false, synthetic: true },
     ]);
   });
 

--- a/packages/vendo-cli/src/theme/next-fonts.test.ts
+++ b/packages/vendo-cli/src/theme/next-fonts.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { parseNextFontVars } from "./next-fonts.js";
+
+describe("parseNextFontVars", () => {
+  it("maps next/font/google variables to their font family", () => {
+    const source = `
+import { Hanken_Grotesk, Spline_Sans_Mono } from "next/font/google"
+const hanken = Hanken_Grotesk({ subsets: ["latin"], variable: "--font-hanken" })
+const splineMono = Spline_Sans_Mono({ subsets: ["latin"], variable: "--font-spline-mono" })
+`;
+    const vars = parseNextFontVars(source, "src/app/layout.tsx");
+    expect(vars).toEqual([
+      { name: "--font-hanken", value: '"Hanken Grotesk"', file: "src/app/layout.tsx", darkScope: false },
+      { name: "--font-spline-mono", value: '"Spline Sans Mono"', file: "src/app/layout.tsx", darkScope: false },
+    ]);
+  });
+
+  it("resolves aliased imports to the exported family name", () => {
+    const source = `
+import { Inter as BodyFont } from "next/font/google"
+const body = BodyFont({ subsets: ["latin"], variable: "--font-body" })
+`;
+    expect(parseNextFontVars(source, "layout.tsx")).toEqual([
+      { name: "--font-body", value: '"Inter"', file: "layout.tsx", darkScope: false },
+    ]);
+  });
+
+  it("ignores fonts without a variable and next/font/local (family unknowable)", () => {
+    const noVariable = `
+import { Inter } from "next/font/google"
+const inter = Inter({ subsets: ["latin"] })
+`;
+    expect(parseNextFontVars(noVariable, "layout.tsx")).toEqual([]);
+    const local = `
+import localFont from "next/font/local"
+const brand = localFont({ src: "./brand.woff2", variable: "--font-brand" })
+`;
+    expect(parseNextFontVars(local, "layout.tsx")).toEqual([]);
+  });
+});

--- a/packages/vendo-cli/src/theme/next-fonts.ts
+++ b/packages/vendo-cli/src/theme/next-fonts.ts
@@ -1,0 +1,41 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { walk } from "../fsx.js";
+import type { CssVarDecl } from "./css-vars.js";
+
+/**
+ * next/font injects `--font-*` variables at runtime (className on <html>), so
+ * they never appear in CSS. Recover them from source: a next/font/google
+ * export name IS the family name (underscores for spaces). next/font/local is
+ * skipped — the family is not derivable from source, and guessing would break
+ * the fail-closed contract.
+ */
+export function parseNextFontVars(source: string, file: string): CssVarDecl[] {
+  const out: CssVarDecl[] = [];
+  const importRe = /import\s*\{([^}]+)\}\s*from\s*["']next\/font\/google["']/g;
+  for (const im of source.matchAll(importRe)) {
+    for (const spec of im[1]!.split(",")) {
+      const [exportName, alias] = spec.split(/\s+as\s+/).map((s) => s.trim());
+      if (!exportName || !/^[A-Za-z_]\w*$/.test(exportName)) continue;
+      const local = alias && /^[A-Za-z_]\w*$/.test(alias) ? alias : exportName;
+      // First call of the loader with an options object; options never nest braces.
+      const call = source.match(new RegExp(`\\b${local}\\s*\\(\\s*\\{([^}]*)\\}`));
+      const variable = call?.[1]?.match(/variable:\s*["'](--[\w-]+)["']/);
+      if (!variable?.[1]) continue;
+      out.push({ name: variable[1], value: `"${exportName.replace(/_/g, " ")}"`, file, darkScope: false });
+    }
+  }
+  return out;
+}
+
+const SOURCE_FILE = /\.(tsx|jsx|ts|js|mjs)$/;
+
+export async function collectNextFontVars(targetDir: string): Promise<CssVarDecl[]> {
+  const files = await walk(targetDir, (p) => SOURCE_FILE.test(p), 500);
+  const out: CssVarDecl[] = [];
+  for (const f of files) {
+    const src = await fs.readFile(f, "utf8").catch(() => null);
+    if (src?.includes("next/font/google")) out.push(...parseNextFontVars(src, path.relative(targetDir, f)));
+  }
+  return out;
+}

--- a/packages/vendo-cli/src/theme/next-fonts.ts
+++ b/packages/vendo-cli/src/theme/next-fonts.ts
@@ -8,30 +8,43 @@ import type { CssVarDecl } from "./css-vars.js";
  * they never appear in CSS. Recover them from source: a next/font/google
  * export name IS the family name (underscores for spaces). next/font/local is
  * skipped — the family is not derivable from source, and guessing would break
- * the fail-closed contract.
+ * the fail-closed contract. Declarations are marked synthetic: they resolve
+ * var() chains but are never picked directly for a slot.
  */
 export function parseNextFontVars(source: string, file: string): CssVarDecl[] {
+  // Strip comments so stale commented-out loader calls can't win.
+  const src = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
   const out: CssVarDecl[] = [];
   const importRe = /import\s*\{([^}]+)\}\s*from\s*["']next\/font\/google["']/g;
-  for (const im of source.matchAll(importRe)) {
+  for (const im of src.matchAll(importRe)) {
     for (const spec of im[1]!.split(",")) {
       const [exportName, alias] = spec.split(/\s+as\s+/).map((s) => s.trim());
       if (!exportName || !/^[A-Za-z_]\w*$/.test(exportName)) continue;
-      const local = alias && /^[A-Za-z_]\w*$/.test(alias) ? alias : exportName;
+      if (alias && !/^[A-Za-z_]\w*$/.test(alias)) continue; // unsafe to embed in a RegExp
+      const local = alias ?? exportName;
       // First call of the loader with an options object; options never nest braces.
-      const call = source.match(new RegExp(`\\b${local}\\s*\\(\\s*\\{([^}]*)\\}`));
+      const call = src.match(new RegExp(`\\b${local}\\s*\\(\\s*\\{([^}]*)\\}`));
       const variable = call?.[1]?.match(/variable:\s*["'](--[\w-]+)["']/);
       if (!variable?.[1]) continue;
-      out.push({ name: variable[1], value: `"${exportName.replace(/_/g, " ")}"`, file, darkScope: false });
+      out.push({
+        name: variable[1],
+        value: `"${exportName.replace(/_/g, " ")}"`,
+        file,
+        darkScope: false,
+        synthetic: true,
+      });
     }
   }
   return out;
 }
 
-const SOURCE_FILE = /\.(tsx|jsx|ts|js|mjs)$/;
+/** Where next/font loaders conventionally live: root layouts and font modules.
+ * A whole-tree scan would hit walk()'s file cap before the layout on large
+ * repos and pay hundreds of reads on the init path. */
+const FONT_SOURCE_FILE = /(^|\/)(layout|_app|_document|fonts?)\.(tsx|jsx|ts|js|mjs)$/;
 
 export async function collectNextFontVars(targetDir: string): Promise<CssVarDecl[]> {
-  const files = await walk(targetDir, (p) => SOURCE_FILE.test(p), 500);
+  const files = await walk(targetDir, (p) => FONT_SOURCE_FILE.test(p), 500);
   const out: CssVarDecl[] = [];
   for (const f of files) {
     const src = await fs.readFile(f, "utf8").catch(() => null);

--- a/packages/vendo-cli/test/fixtures/theme/cadence/globals.css
+++ b/packages/vendo-cli/test/fixtures/theme/cadence/globals.css
@@ -1,0 +1,65 @@
+@import "tailwindcss";
+
+/* Cadence design tokens.
+   Brand: deep evergreen primary on warm paper neutrals; status colors are
+   reserved exclusively for document/deadline state (missing = amber/red,
+   in review = blue, verified/complete = green). Light theme only. */
+
+@theme inline {
+  --font-sans: var(--font-hanken), ui-sans-serif, system-ui, sans-serif;
+  --font-mono: var(--font-spline-mono), ui-monospace, "SF Mono", monospace;
+}
+
+@theme {
+  /* Brand — evergreen */
+  --color-evergreen-50: #eef6f2;
+  --color-evergreen-100: #d8ebe2;
+  --color-evergreen-200: #b3d8c8;
+  --color-evergreen-300: #85bda8;
+  --color-evergreen-400: #559e85;
+  --color-evergreen-500: #34816a;
+  --color-evergreen-600: #266755;
+  --color-evergreen-700: #205345;
+  --color-evergreen-800: #1c4339;
+  --color-evergreen-900: #16362e;
+  --color-evergreen-950: #0b211c;
+
+  /* Warm neutral surfaces & ink */
+  --color-surface: #f7f5f1;
+  --color-card: #ffffff;
+  --color-line: #e9e4db;
+  --color-line-strong: #d9d2c6;
+  --color-ink: #221e19;
+  --color-ink-soft: #5c554b;
+  --color-ink-faint: #7d7468;
+
+  /* Status — document/deadline state only */
+  --color-status-missing: #b45309;
+  --color-status-missing-bg: #fdf0df;
+  --color-status-overdue: #b91c1c;
+  --color-status-overdue-bg: #fdeae8;
+  --color-status-review: #1d4ed8;
+  --color-status-review-bg: #e8eefc;
+  --color-status-verified: #047857;
+  --color-status-verified-bg: #e2f5ec;
+
+  /* Elevation — warm-tinted, never pure black */
+  --shadow-card: 0 1px 2px rgb(34 30 25 / 0.05), 0 1px 3px rgb(34 30 25 / 0.03);
+  --shadow-pop: 0 1px 3px rgb(34 30 25 / 0.05), 0 8px 24px rgb(34 30 25 / 0.08);
+}
+
+body {
+  background-color: var(--color-surface);
+  color: var(--color-ink);
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+}
+
+::selection {
+  background-color: var(--color-evergreen-200);
+}
+
+/* Vendo stage approval: the shell's ApprovalCard materializes in-flow
+   beneath the generated view (same consent surface as the chat path). */
+.cadence-approval-inflow .fl-approval { animation: cadence-approval-in 0.28s cubic-bezier(0.16, 1, 0.3, 1); }
+@keyframes cadence-approval-in { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }

--- a/packages/vendo-cli/test/fixtures/theme/cadence/layout.tsx
+++ b/packages/vendo-cli/test/fixtures/theme/cadence/layout.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from "next"
+import { Hanken_Grotesk, Spline_Sans_Mono } from "next/font/google"
+import { AppShell } from "@/components/shell/app-shell"
+import { VendoLayer } from "@/components/vendo/VendoLayer"
+import "./globals.css"
+
+const hanken = Hanken_Grotesk({ subsets: ["latin"], variable: "--font-hanken" })
+const splineMono = Spline_Sans_Mono({ subsets: ["latin"], variable: "--font-spline-mono" })
+
+export const metadata: Metadata = {
+  title: "Cadence — Practice management for accounting firms",
+  description:
+    "Client onboarding, document collection, deadlines, and client comms for accounting firms.",
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" className={`${hanken.variable} ${splineMono.variable}`}>
+      <body className="min-h-screen antialiased">
+        {/* Vendo's layer WRAPS the app: the Cmd/Ctrl+K overlay, automation
+            toasts, and the shared provider that VendoRemix wrappers inside
+            the page reach for scoping and pinned remixes. */}
+        <VendoLayer>
+          <AppShell>{children}</AppShell>
+        </VendoLayer>
+      </body>
+    </html>
+  )
+}

--- a/packages/vendo-cli/test/fixtures/theme/maple/globals.css
+++ b/packages/vendo-cli/test/fixtures/theme/maple/globals.css
@@ -1,0 +1,64 @@
+@import "tailwindcss";
+
+@theme {
+  --color-bg: #FBFBFA;
+  --color-surface: #FFFFFF;
+  --color-ink: #111111;
+  --color-ink-soft: #46443F;
+  --color-muted: #908C85;
+  --color-border: #ECEBE8;
+  --color-border-strong: #DFDDD8;
+  --color-hover: #F4F3F1;
+  --color-pos: #1E7F53;
+  --color-pos-bg: #E7F4EE;
+  --color-neg: #B0473A;
+  --color-neg-bg: #FBEDE9;
+  --radius-card: 14px;
+}
+
+@theme inline {
+  --font-sans: var(--font-inter);
+}
+
+/* The dock is Vendo's visible surface; the overlay is Cmd/Ctrl+K-only, so its
+   floating launcher button is hidden in the demo. */
+.fl-launcher {
+  display: none !important;
+}
+
+* {
+  border-color: var(--color-border);
+}
+
+body {
+  background: var(--color-bg);
+  color: var(--color-ink);
+  font-family: var(--font-sans), ui-sans-serif, system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+@keyframes maple-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.animate-fade-in {
+  animation: maple-fade-in 0.25s ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in {
+    animation: none;
+  }
+}
+
+/* Vendo stage approval: the shell's approved ApprovalCard materializes
+   in-flow beneath the generated view (brand-tier pick). */
+.maple-approval-inflow .fl-approval { animation: maple-approval-in 0.28s cubic-bezier(0.16, 1, 0.3, 1); }
+@keyframes maple-approval-in { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }

--- a/packages/vendo-cli/test/fixtures/theme/maple/layout.tsx
+++ b/packages/vendo-cli/test/fixtures/theme/maple/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { Inter } from "next/font/google"
+import { AppShell } from "@/components/shell/app-shell"
+import { VendoLayer } from "@/components/vendo/VendoLayer"
+import "./globals.css"
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" })
+
+export const metadata: Metadata = {
+  title: "Maple — Banking that keeps up.",
+  description: "A modern bank account that actually understands your money.",
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" className={inter.variable}>
+      <body className="min-h-screen bg-bg text-ink antialiased">
+        <AppShell>{children}</AppShell>
+        <VendoLayer />
+      </body>
+    </html>
+  )
+}


### PR DESCRIPTION
## Problem

Follow-up from the OSS launch E2E (#60). The deterministic token matcher only recognized literal names (`--color-bg`, `--color-accent`), so on Cadence (apps/demo-accounting) it:

- mis-mapped **background** to `--color-status-missing-bg` (`#fdf0df`, a status-badge cream) instead of the true page background `--color-surface` (`#f7f5f1`)
- DEFAULTED **accent**, **fontFamily** (plus mutedText/radius, which genuinely have no tokens) because Cadence uses scale names (`--color-evergreen-*`) and a Next.js font variable (`--font-hanken`)

## Fix (three targeted heuristics, fail-closed philosophy unchanged)

1. **Background** — `X-bg` tokens whose base `X` is also declared are tinted companions (badge/status backgrounds), excluded from the background slot; when no bg token exists at all, background falls back to the surface token and the surface slot falls through to card/panel.
2. **Accent scale families** — when literal `accent/primary/brand/cta` names fail, detect Tailwind-style scale families (`--color-evergreen-50..950`) and pick the step closest to 500 — but only when exactly one non-neutral, non-status family exists. Zero or several families is genuinely ambiguous → DEFAULT + flag, as before.
3. **next/font indirection** — `next/font` injects `--font-*` vars at runtime, so font `var()` chains never resolved from CSS. For Next.js targets, recover the family from `next/font/google` usage in source (the export name is the family; aliased imports resolve to the export). `next/font/local` stays unresolvable on purpose — the family isn't derivable, and guessing would break fail-closed.

## Results (live extraction against the real app trees)

| Slot | Cadence before | Cadence after | Maple before | Maple after |
|---|---|---|---|---|
| background | ❌ `#fdf0df` (status badge) | ✅ `#f7f5f1` ← `--color-surface` | ✅ | ✅ |
| surface | `--color-surface` | ✅ `#ffffff` ← `--color-card` | ✅ | ✅ |
| accent | ❌ DEFAULT | ✅ `#34816a` ← `--color-evergreen-500` | DEFAULT (no token — correct) | DEFAULT (unchanged) |
| text | ✅ | ✅ | ✅ | ✅ |
| mutedText | DEFAULT (no token) | DEFAULT + flagged (correct) | ✅ | ✅ |
| radius | DEFAULT (no token) | DEFAULT + flagged (correct) | ✅ | ✅ |
| fontFamily | ❌ DEFAULT | ✅ `"Hanken Grotesk", ui-sans-serif, …` | ❌ DEFAULT | ✅ `"Inter"` |

**Cadence: 2/7 → 5/7** (the two remaining defaults have no tokens to find). **Maple: 5/7 → 6/7** — regression baseline held.

## Tests

Both apps' `globals.css` + `layout.tsx` captured verbatim as fixtures under `packages/vendo-cli/test/fixtures/theme/`, driven end-to-end through `detectTarget` + `extractTheme`. Unit tests cover companion-bg exclusion, surface fallback, single/multiple/neutral scale families, literal-accent precedence, next/font parsing (incl. aliases, no-variable, and local-font rejection). TDD: all new tests were watched failing with the exact reported bug signatures before the fix.

## Gates

- `pnpm build` ✅  `pnpm test` ✅ (26 tasks)  `pnpm typecheck` ✅  `pnpm lint` ✅

No UI surface touched (CLI extraction heuristics + tests only).

https://claude.ai/code/session_012dAT34G2q6KLPuqHNXA7uo
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves deterministic theme extraction in `packages/vendo-cli` and hardens heuristics while lowering scan cost. Fixes background/accent mapping and resolves `next/font` families; Cadence 2/7→5/7, Maple 5/7→6/7.

- **Bug Fixes**
  - Background: treat `X-bg` as a tint when `X` or `X-fg` exists and exclude from all slots; only fall back to `--color-surface` if the surface slot keeps its own candidate, else default.
  - Accent: when no literal `accent/primary/brand/cta`, detect a single non‑neutral scale and pick the mid step (reject near‑gray ramps); default when ambiguous; literal names still win.
  - Font family: recover `--font-*` from `next/font/google` by scanning only `layout/_app/_document/font(s).*`; strip comments and ignore unsafe aliases; mark recovered vars as `synthetic` (resolve‑only) so explicit CSS wins; keep `next/font/local` skipped.

<sup>Written for commit f058c37e65c4aa2e39d5d16dfaa8a9b8e98402c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

