### PR TITLE
Hardening wave 4: client/state reliability (thread restore, capability gating, chart palettes)

### DIFF
--- a/apps/demo-accounting/src/vendo/tools.test.ts
+++ b/apps/demo-accounting/src/vendo/tools.test.ts
@@ -1,0 +1,45 @@
+/**
+ * The in-process read tools must CARRY their read-only annotation, not just
+ * be name-allowlisted by the policy (policy.ts's ALWAYS_ALLOW). The audit
+ * trail classifies every execution from the DESCRIPTOR
+ * (`mutating: readOnlyHint !== true` in @vendoai/runtime's auditPolicy), so
+ * an unannotated read tool lands in the Trust screen's diary as a mutating
+ * "action you approved" — the browser-observed "0 reads, 4 actions you
+ * approved" miscount after nothing but read-only runs.
+ */
+import { describe, expect, it } from "vitest";
+import { buildDescriptor, auditPolicy, type VendoPrincipal } from "@vendoai/runtime";
+import type { AuditEvent, AuditLog, Principal } from "@vendoai/core";
+import { demoTools, READ_ONLY_TOOLS } from "./tools";
+
+const PRINCIPAL: VendoPrincipal = { userId: "test" };
+const SCOPE: Principal = { tenantId: "t", subject: "test" };
+
+describe("in-process read tools", () => {
+  it("every READ_ONLY_TOOLS tool object carries readOnlyHint (the audit classifier's input)", () => {
+    const tools = demoTools();
+    for (const name of READ_ONLY_TOOLS) {
+      const descriptor = buildDescriptor(name, tools[name], "engine");
+      expect(descriptor.annotations.readOnlyHint, `${name} must be read-annotated`).toBe(true);
+      expect(descriptor.annotations.destructiveHint ?? false, name).toBe(false);
+    }
+  });
+
+  it("an executed read tool audits as a READ (mutating:false), so the diary counts it as one", async () => {
+    const events: AuditEvent[] = [];
+    const audit: AuditLog = {
+      append: async (e) => {
+        events.push(e);
+      },
+      query: async () => events,
+    };
+    const policy = auditPolicy(audit, { principalScope: () => SCOPE });
+    const descriptor = buildDescriptor("get_clients", demoTools()["get_clients"], "engine");
+    await policy.onExecuted?.(
+      { toolName: "get_clients", input: {}, descriptor, principal: PRINCIPAL, toolCallId: "c1" },
+      "allow",
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ kind: "tool_execution", mutating: false, dangerous: false });
+  });
+});

--- a/apps/demo-accounting/src/vendo/tools.ts
+++ b/apps/demo-accounting/src/vendo/tools.ts
@@ -7,11 +7,29 @@
  * browser session. Writes have no in-process form: they go through the
  * client-executed host tools and their approval cards.
  */
-import { tool, type ToolSet } from "ai";
+import { tool, type Tool, type ToolSet } from "ai";
 import { z } from "zod";
 import { getStore } from "@/server/store";
 import { listClientSummaries, listDeadlineEntries } from "@/server/clients";
 import { dashboardMetrics } from "@/server/documents";
+
+/**
+ * Stamp the MCP-style read-only annotations onto a tool object. The policy
+ * already allowlists these by NAME (policy.ts's ALWAYS_ALLOW), but the audit
+ * trail classifies executions from the DESCRIPTOR (`buildDescriptor` reads
+ * top-level `annotations`; `auditPolicy` derives `mutating` from
+ * `readOnlyHint`) — without this, every read run lands in the Trust diary
+ * as a mutating "action you approved".
+ */
+const readOnly = <T extends Tool>(t: T): T =>
+  Object.assign(t, {
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  });
 
 const getDashboard = tool({
   description:
@@ -77,11 +95,11 @@ const getActivity = tool({
 
 export function demoTools(): ToolSet {
   return {
-    get_dashboard: getDashboard,
-    get_clients: getClients,
-    get_client_documents: getClientDocuments,
-    get_deadlines: getDeadlines,
-    get_activity: getActivity,
+    get_dashboard: readOnly(getDashboard),
+    get_clients: readOnly(getClients),
+    get_client_documents: readOnly(getClientDocuments),
+    get_deadlines: readOnly(getDeadlines),
+    get_activity: readOnly(getActivity),
   };
 }
 

--- a/apps/demo-bank/src/components/vendo/VendoRoot.tsx
+++ b/apps/demo-bank/src/components/vendo/VendoRoot.tsx
@@ -44,6 +44,21 @@ export function VendoRoot({
     [],
   );
 
+  // Restore the durable thread on mount (createVendoHandler persists it under
+  // this Chat's own id): a reload — including one right after a stream died
+  // mid-turn — brings back every settled message instead of an empty thread.
+  const loadHistory = useMemo(
+    () => async (): Promise<VendoUIMessage[]> => {
+      const res = await fetch(`/api/vendo/threads/${encodeURIComponent(threadId)}`, {
+        cache: "no-store",
+      });
+      if (!res.ok) return [];
+      const body = (await res.json()) as unknown;
+      return Array.isArray(body) ? (body as VendoUIMessage[]) : [];
+    },
+    [threadId],
+  );
+
   // Live Composio connection status (gmail/slack) for the integrations rail.
   const integrations = useMemo(() => createComposioIntegrations(), []);
 
@@ -58,6 +73,7 @@ export function VendoRoot({
       // existing session (ENG-202, topology B) — the same definitions the
       // server registered, so gated calls run only after the approval card.
       hostTools={{ definitions: mapleHostToolDefs }}
+      loadHistory={loadHistory}
     >
       {/* Maple's single brand feeds the host shell. brandToCssVars supplies the
           --vendo-* colors, applied INLINE on every .vendo-root by the shell

--- a/packages/vendo-components/src/sandbox-install.ts
+++ b/packages/vendo-components/src/sandbox-install.ts
@@ -23,9 +23,10 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import type { ComponentType } from "react";
-import { ThemeProvider } from "@openuidev/react-ui";
+import { ThemeProvider, type Theme } from "@openuidev/react-ui";
 import openuiCss from "@openuidev/react-ui/index.css?inline";
 import { prewiredImpls } from "./impls.js";
+import { ChartPaletteBridge, splitChartPalettes } from "./theme/chart-palette-bridge.js";
 
 declare global {
   interface Window {
@@ -73,10 +74,15 @@ export function installVendoHost(
 
   window.__VENDO_THEME_WRAP__ = (blob, children) => {
     const b = blob as { mode?: "light" | "dark"; theme?: Record<string, unknown> } | undefined;
+    // Chart palettes ride OpenUI's theme CONTEXT via the bridge, not the
+    // validated lightTheme/darkTheme props — same split VendoThemeProvider
+    // does host-side (kills the "[OpenUI] … unknown key" spam without
+    // dropping the brand's chart colors).
+    const { theme, palettes } = splitChartPalettes((b?.theme ?? {}) as Theme);
     return React.createElement(
       ThemeProvider,
-      { mode: b?.mode ?? "light", lightTheme: b?.theme, darkTheme: b?.theme },
-      children as React.ReactNode,
+      { mode: b?.mode ?? "light", lightTheme: theme, darkTheme: theme },
+      React.createElement(ChartPaletteBridge, { palettes }, children as React.ReactNode),
     );
   };
 

--- a/packages/vendo-components/src/theme/VendoThemeProvider.tsx
+++ b/packages/vendo-components/src/theme/VendoThemeProvider.tsx
@@ -1,20 +1,23 @@
-import type { ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 import { ThemeProvider } from "@openuidev/react-ui";
 import { type BrandTokens, defaultBrand } from "./brand.js";
 import { mapBrandToTheme } from "./map-brand-to-theme.js";
+import { ChartPaletteBridge, splitChartPalettes } from "./chart-palette-bridge.js";
 
 export interface VendoThemeProviderProps {
   brand?: BrandTokens;
   children: ReactNode;
 }
 
-/** Wraps OpenUI's ThemeProvider, mapping host brand tokens to its Theme. */
+/** Wraps OpenUI's ThemeProvider, mapping host brand tokens to its Theme.
+ *  Chart palettes ride the ChartPaletteBridge instead of the validated
+ *  lightTheme/darkTheme props (see chart-palette-bridge.tsx). */
 export function VendoThemeProvider({ brand = defaultBrand, children }: VendoThemeProviderProps) {
-  const theme = mapBrandToTheme(brand);
+  const { theme, palettes } = useMemo(() => splitChartPalettes(mapBrandToTheme(brand)), [brand]);
   const mode = brand.mode ?? "light";
   return (
     <ThemeProvider mode={mode} lightTheme={theme} darkTheme={theme}>
-      {children}
+      <ChartPaletteBridge palettes={palettes}>{children}</ChartPaletteBridge>
     </ThemeProvider>
   );
 }

--- a/packages/vendo-components/src/theme/chart-palette-bridge.tsx
+++ b/packages/vendo-components/src/theme/chart-palette-bridge.tsx
@@ -1,0 +1,64 @@
+/**
+ * Route brand chart palettes AROUND OpenUI ThemeProvider's dev validation.
+ *
+ * OpenUI's `Theme` type includes the `*ChartPalette` keys and its charts read
+ * them from the theme CONTEXT (`useChartPalette`: `theme[themePaletteName] ||
+ * theme.defaultChartPalette`), but the ThemeProvider's dev-mode validator
+ * derives its known-key set from the default theme object — which carries no
+ * palette keys — so palettes passed via `lightTheme`/`darkTheme` warn
+ * "[OpenUI] lightTheme contains unknown key '…ChartPalette'" on every mount.
+ *
+ * `splitChartPalettes` peels the palette keys off the theme handed to
+ * ThemeProvider; `ChartPaletteBridge` then re-provides OpenUI's ThemeContext
+ * with the palettes merged back into the resolved theme. Charts (and any
+ * consumer of OpenUI's `useTheme`) see exactly the theme they saw before —
+ * minus the console spam. Palette values are color ARRAYS consumed from
+ * context, never CSS custom properties, so skipping `themeToCssVars` for
+ * them loses nothing.
+ */
+import { useMemo, type ReactNode } from "react";
+import { ThemeContext, useTheme, type Theme } from "@openuidev/react-ui";
+
+const PALETTE_KEYS = [
+  "defaultChartPalette",
+  "barChartPalette",
+  "lineChartPalette",
+  "areaChartPalette",
+  "pieChartPalette",
+  "radarChartPalette",
+  "radialChartPalette",
+  "horizontalBarChartPalette",
+] as const;
+
+export type ChartPalettes = Partial<Pick<Theme, (typeof PALETTE_KEYS)[number]>>;
+
+/** Split a Theme into its validator-safe tokens and its chart palettes. */
+export function splitChartPalettes(full: Theme): { theme: Theme; palettes: ChartPalettes } {
+  const theme: Record<string, unknown> = { ...(full as Record<string, unknown>) };
+  const palettes: Record<string, unknown> = {};
+  for (const key of PALETTE_KEYS) {
+    if (key in theme) {
+      if (theme[key] !== undefined) palettes[key] = theme[key];
+      delete theme[key];
+    }
+  }
+  return { theme: theme as Theme, palettes: palettes as ChartPalettes };
+}
+
+/** Mount INSIDE an OpenUI ThemeProvider: re-provides its ThemeContext with
+ *  the chart palettes merged into the resolved theme. */
+export function ChartPaletteBridge({
+  palettes,
+  children,
+}: {
+  palettes: ChartPalettes;
+  /** Optional so `createElement(Bridge, props, children)` type-checks too. */
+  children?: ReactNode;
+}) {
+  const ctx = useTheme();
+  const value = useMemo(
+    () => ({ ...ctx, theme: { ...ctx.theme, ...palettes } }),
+    [ctx, palettes],
+  );
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}

--- a/packages/vendo-components/src/theme/chart-palette.test.tsx
+++ b/packages/vendo-components/src/theme/chart-palette.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Chart palettes must reach OpenUI's charts WITHOUT tripping ThemeProvider's
+ * dev validation. OpenUI's `Theme` TYPE includes the `*ChartPalette` keys
+ * (ChartColorPalette in ThemeProvider/types.d.ts), but its runtime validator
+ * derives "known keys" from the default theme object — which carries none of
+ * them — so passing palettes through `lightTheme`/`darkTheme` spammed
+ * "[OpenUI] lightTheme contains unknown key 'barChartPalette'…" ten times per
+ * page (browser-observed in both demo apps). The fix routes palettes around
+ * the validated prop and re-provides them on OpenUI's ThemeContext, so
+ * `useChartPalette` still finds them and the console stays clean.
+ *
+ * NOTE: OpenUI's warnOnce dedupes per module load, so the no-warning
+ * assertion must run FIRST in this file (vitest isolates per test file).
+ */
+import { describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { useTheme } from "../openui.js";
+import { VendoThemeProvider } from "./VendoThemeProvider.js";
+import { defaultBrand } from "./brand.js";
+import { brandToChartPalette } from "./brand-to-chart-palette.js";
+import { mapBrandToTheme } from "./map-brand-to-theme.js";
+import { splitChartPalettes } from "./chart-palette-bridge.js";
+
+function probeTheme(): Record<string, unknown> {
+  let seen: Record<string, unknown> = {};
+  function Probe() {
+    seen = useTheme().theme as Record<string, unknown>;
+    return null;
+  }
+  render(
+    <VendoThemeProvider brand={defaultBrand}>
+      <Probe />
+    </VendoThemeProvider>,
+  );
+  return seen;
+}
+
+describe("chart palettes through the OpenUI theme", () => {
+  it("mounts without any '[OpenUI] … unknown key' console spam", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      probeTheme();
+      const openuiWarnings = warn.mock.calls
+        .map((c) => String(c[0]))
+        .filter((m) => m.includes("unknown key"));
+      expect(openuiWarnings).toEqual([]);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("still delivers every brand chart palette to OpenUI's theme context (useChartPalette's source)", () => {
+    const theme = probeTheme();
+    const palette = brandToChartPalette(defaultBrand);
+    for (const key of [
+      "defaultChartPalette",
+      "barChartPalette",
+      "lineChartPalette",
+      "areaChartPalette",
+      "pieChartPalette",
+    ]) {
+      expect(theme[key], key).toEqual(palette);
+    }
+  });
+
+  it("splitChartPalettes separates palette keys from the CSS-token theme", () => {
+    const full = mapBrandToTheme(defaultBrand);
+    const { theme, palettes } = splitChartPalettes(full);
+    expect(Object.keys(theme)).not.toContain("barChartPalette");
+    expect(palettes["barChartPalette"]).toEqual(brandToChartPalette(defaultBrand));
+    // Non-palette tokens survive untouched.
+    expect(theme.background).toBe(full.background);
+  });
+});

--- a/packages/vendo-next/src/client/notifications.test.ts
+++ b/packages/vendo-next/src/client/notifications.test.ts
@@ -62,6 +62,17 @@ describe("createServerNotifications", () => {
     expect(JSON.parse(String(calls[0]!.init?.body))).toEqual({ runId: "r9", approved: true });
   });
 
+  it("answers 'disabled' on a 404 (automations off) so the poll loop can stop", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () => new Response(JSON.stringify({ error: "automations are disabled" }), { status: 404 }),
+      ),
+    );
+    const client = createServerNotifications("/api/vendo");
+    expect(await client.listSince(0)).toBe("disabled");
+  });
+
   it("maps a resumed run answer to 'resumed' and rejects on HTTP failure", async () => {
     vi.stubGlobal(
       "fetch",

--- a/packages/vendo-next/src/client/notifications.ts
+++ b/packages/vendo-next/src/client/notifications.ts
@@ -15,6 +15,10 @@ export function createServerNotifications(basePath: string): VendoNotifications 
   return {
     async listSince(since) {
       const res = await fetch(`${basePath}/deliveries?since=${since}`, { cache: "no-store" });
+      // 404 = the handler has no automations world ("automations are
+      // disabled") — tell the poller to stop for good instead of retrying
+      // a route that will 404 on every interval forever.
+      if (res.status === 404) return "disabled";
       if (!res.ok) throw new Error(`[vendo] deliveries request failed (${res.status})`);
       const body = (await res.json()) as DeliveriesBody;
       const notices: AutomationNotice[] = [];

--- a/packages/vendo-next/src/client/vendo-root.test.tsx
+++ b/packages/vendo-next/src/client/vendo-root.test.tsx
@@ -211,6 +211,34 @@ describe("VendoRoot", () => {
     }
   });
 
+  it("stops trusting a previous endpoint's capabilities when basePath changes and the new fetch fails", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/a/capabilities")) {
+        return new Response(
+          JSON.stringify({ chat: true, integrations: false, voice: false, storage: false }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/api/b/capabilities")) throw new TypeError("network down");
+      return new Response("{}", { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const ui = (basePath: string) => (
+      <VendoRoot productName="Acme" basePath={basePath} toasts={false}>
+        <div />
+      </VendoRoot>
+    );
+    const { rerender } = render(ui("/api/a"));
+    // Endpoint A answered chat:true → the launcher is up.
+    await waitFor(() => expect(screen.queryByRole("button", { name: /ask acme/i })).not.toBeNull());
+
+    // Point the SAME root at endpoint B, whose capabilities fetch fails: the
+    // UI must not keep running on A's answer — B never said chat is on.
+    rerender(ui("/api/b"));
+    await waitFor(() => expect(screen.queryByRole("button", { name: /ask acme/i })).toBeNull());
+  });
+
   it("rehydrates the durable thread on mount (GET /threads/:threadId)", async () => {
     const fetchMock = stubFetch({ chat: true, integrations: false, voice: false });
     vi.stubGlobal("fetch", fetchMock);

--- a/packages/vendo-next/src/client/vendo-root.test.tsx
+++ b/packages/vendo-next/src/client/vendo-root.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import * as shell from "@vendoai/shell";
 import * as serverStore from "./server-store.js";
 import { VendoRoot } from "./vendo-root.js";
@@ -115,6 +115,69 @@ describe("VendoRoot", () => {
     await waitFor(() => expect(screen.getByTestId("app5")).toBeDefined());
     expect(serverStoreSpy).not.toHaveBeenCalled();
     serverStoreSpy.mockRestore();
+  });
+
+  it("retries a failed capabilities fetch with backoff until the server answers", async () => {
+    vi.useFakeTimers();
+    try {
+      let capabilityCalls = 0;
+      const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("/capabilities")) {
+          capabilityCalls += 1;
+          if (capabilityCalls < 3) throw new TypeError("network down");
+          return new Response(
+            JSON.stringify({ chat: true, integrations: false, voice: false, storage: false }),
+            { status: 200 },
+          );
+        }
+        return new Response("{}", { status: 200 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      render(
+        <VendoRoot productName="Acme" toasts={false}>
+          <div />
+        </VendoRoot>,
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(capabilityCalls).toBe(1);
+      // First retry after ~1s of backoff, second after ~2s more.
+      await vi.advanceTimersByTimeAsync(1_100);
+      expect(capabilityCalls).toBe(2);
+      await vi.advanceTimersByTimeAsync(2_100);
+      expect(capabilityCalls).toBe(3);
+      // Once the server answered, no further polling.
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(capabilityCalls).toBe(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops pretending everything is on once the capabilities fetch has failed", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input).includes("/capabilities")) throw new TypeError("network down");
+        return new Response("{}", { status: 200 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      render(
+        <VendoRoot productName="Acme" toasts={false}>
+          <div />
+        </VendoRoot>,
+      );
+      // Optimistic while the first fetch is IN FLIGHT (no flicker on healthy
+      // installs)…
+      expect(screen.queryByRole("button", { name: /ask acme/i })).not.toBeNull();
+      // …but a FAILED fetch must not leave the chat surface enabled forever.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(screen.queryByRole("button", { name: /ask acme/i })).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("rehydrates the durable thread on mount (GET /threads/:threadId)", async () => {

--- a/packages/vendo-next/src/client/vendo-root.test.tsx
+++ b/packages/vendo-next/src/client/vendo-root.test.tsx
@@ -64,6 +64,37 @@ describe("VendoRoot", () => {
     expect(offMock.mock.calls.some(([u]) => String(u).includes("/deliveries"))).toBe(false);
   });
 
+  it("never starts the deliveries poll when capabilities report automations:false", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/capabilities")) {
+        return new Response(
+          JSON.stringify({
+            chat: true,
+            integrations: false,
+            voice: false,
+            storage: false,
+            automations: false,
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response("{}", { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(
+      <VendoRoot productName="Acme">
+        <div />
+      </VendoRoot>,
+    );
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([u]) => String(u).includes("/capabilities"))).toBe(true),
+    );
+    // Give any (wrong) poll a beat to fire.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(fetchMock.mock.calls.some(([u]) => String(u).includes("/deliveries"))).toBe(false);
+  });
+
   it("hides the launcher when launcher='none'", () => {
     vi.stubGlobal("fetch", stubFetch({ chat: true, integrations: false, voice: false }));
     render(

--- a/packages/vendo-next/src/client/vendo-root.test.tsx
+++ b/packages/vendo-next/src/client/vendo-root.test.tsx
@@ -117,6 +117,21 @@ describe("VendoRoot", () => {
     serverStoreSpy.mockRestore();
   });
 
+  it("rehydrates the durable thread on mount (GET /threads/:threadId)", async () => {
+    const fetchMock = stubFetch({ chat: true, integrations: false, voice: false });
+    vi.stubGlobal("fetch", fetchMock);
+    render(
+      <VendoRoot productName="Acme" basePath="/api/vendo" threadId="my thread">
+        <div />
+      </VendoRoot>,
+    );
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(([u]) => String(u).includes("/api/vendo/threads/my%20thread")),
+      ).toBe(true),
+    );
+  });
+
   it("tolerates an invalid theme by falling back to the default brand", () => {
     vi.stubGlobal("fetch", stubFetch({ chat: true, integrations: false, voice: false }));
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/packages/vendo-next/src/client/vendo-root.tsx
+++ b/packages/vendo-next/src/client/vendo-root.tsx
@@ -142,6 +142,22 @@ export function VendoRoot({
     [basePath, threadId],
   );
 
+  // The read half of that durable thread: on mount, restore the persisted
+  // messages (GET /threads/:id) so a reload — including one right after a
+  // stream died mid-turn — brings back every settled message instead of an
+  // empty thread. VendoProvider only seeds a still-empty, idle chat.
+  const loadHistory = useMemo(
+    () => async (): Promise<VendoUIMessage[]> => {
+      const res = await fetch(`${basePath}/threads/${encodeURIComponent(threadId)}`, {
+        cache: "no-store",
+      });
+      if (!res.ok) return [];
+      const body = (await res.json()) as unknown;
+      return Array.isArray(body) ? (body as VendoUIMessage[]) : [];
+    },
+    [basePath, threadId],
+  );
+
   // Saved vendos survive reloads. Server-backed (durable across devices,
   // no localStorage quota) when the handler reports the `storage` capability;
   // localStorage otherwise — including the optimistic `capabilities === null`
@@ -208,6 +224,7 @@ export function VendoRoot({
       components={[]}
       threadId={threadId}
       hostTools={{ definitions: hostToolDefs }}
+      loadHistory={loadHistory}
     >
       <VendoThemeProvider brand={brand}>
         <VendoShellProvider

--- a/packages/vendo-next/src/client/vendo-root.tsx
+++ b/packages/vendo-next/src/client/vendo-root.tsx
@@ -117,19 +117,43 @@ export function VendoRoot({
   const hostToolDefs = useMemo(() => manifestToolsToHostTools(manifestTools), [manifestTools]);
   const [open, setOpen] = useState(false);
   const [capabilities, setCapabilities] = useState<VendoCapabilities | null>(null);
+  // True after a capabilities fetch has FAILED (network error or a non-2xx).
+  // Distinct from `capabilities === null` (not answered yet): the brief
+  // in-flight window renders optimistically so healthy installs never
+  // flicker, but a failure must not leave the UI pretending everything is on.
+  const [capsFailed, setCapsFailed] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
-    fetch(`${basePath}/capabilities`, { cache: "no-store" })
-      .then((r) => (r.ok ? (r.json() as Promise<VendoCapabilities>) : null))
-      .then((caps) => {
-        if (!cancelled && caps) setCapabilities(caps);
-      })
-      .catch(() => {
-        /* capabilities stay null → most conservative UI */
-      });
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let delay = 1_000;
+    const attempt = () => {
+      fetch(`${basePath}/capabilities`, { cache: "no-store" })
+        .then((r) =>
+          r.ok
+            ? (r.json() as Promise<VendoCapabilities>)
+            : Promise.reject(new Error(`capabilities request failed (${r.status})`)),
+        )
+        .then((caps) => {
+          if (cancelled) return;
+          setCapabilities(caps);
+          setCapsFailed(false);
+        })
+        .catch(() => {
+          if (cancelled) return;
+          // Flip the UI to its conservative shape and retry with capped
+          // exponential backoff until the server actually answers — the
+          // zero-config "everything on" default is the SERVER's to declare,
+          // never the fallout of a failed fetch.
+          setCapsFailed(true);
+          timer = setTimeout(attempt, delay);
+          delay = Math.min(delay * 2, 30_000);
+        });
+    };
+    attempt();
     return () => {
       cancelled = true;
+      if (timer !== undefined) clearTimeout(timer);
     };
   }, [basePath]);
 
@@ -215,8 +239,10 @@ export function VendoRoot({
   // Capability-additive contract: with no ANTHROPIC_API_KEY the server reports
   // chat:false, and asking would 401 inside the stream. Hide the assistant
   // surface entirely in that case rather than degrading into a runtime error.
-  // `null` (not yet fetched) renders optimistically so there is no flicker.
-  const chatEnabled = capabilities === null || capabilities.chat;
+  // `null` with no failure yet (first fetch in flight) renders optimistically
+  // so there is no flicker; a FAILED fetch renders conservatively until a
+  // backoff retry gets a real answer.
+  const chatEnabled = capabilities ? capabilities.chat : !capsFailed;
 
   return (
     <VendoProvider

--- a/packages/vendo-next/src/client/vendo-root.tsx
+++ b/packages/vendo-next/src/client/vendo-root.tsx
@@ -282,7 +282,11 @@ export function VendoRoot({
               Ask {productName}
             </button>
           )}
-          {toasts && (
+          {/* The deliveries poll waits for capabilities and never starts when
+              the server says automations are off. An old server that omits
+              the flag still polls, and a 404 from /deliveries then stops the
+              loop for good (see createServerNotifications). */}
+          {toasts && capabilities !== null && capabilities.automations !== false && (
             <VendoToasts placement={toastPlacement} namespace={`vendo:${threadId}`} />
           )}
         </VendoShellProvider>

--- a/packages/vendo-next/src/client/vendo-root.tsx
+++ b/packages/vendo-next/src/client/vendo-root.tsx
@@ -124,6 +124,13 @@ export function VendoRoot({
   const [capsFailed, setCapsFailed] = useState(false);
 
   useEffect(() => {
+    // (Re)starting for this basePath: drop whatever a PREVIOUS endpoint
+    // answered. Without this, a basePath change whose new fetch fails would
+    // flip capsFailed while the stale `capabilities` object kept the chat
+    // surface and the toasts gate running on another endpoint's answer.
+    // No-op on first mount (already null/false).
+    setCapabilities(null);
+    setCapsFailed(false);
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
     let delay = 1_000;

--- a/packages/vendo-next/src/handler.test.ts
+++ b/packages/vendo-next/src/handler.test.ts
@@ -88,7 +88,7 @@ describe("createVendoHandler", () => {
     vi.stubEnv("OPENAI_API_KEY", "");
     const { GET } = createVendoHandler({ vendoDir: emptyDir() });
     const res = await GET(req("/api/vendo/capabilities"));
-    expect(await res.json()).toEqual({ chat: true, integrations: false, voice: false, mcp: false, storage: false });
+    expect(await res.json()).toEqual({ chat: true, integrations: false, voice: false, mcp: false, storage: false, automations: true });
   });
 
   it("capabilities.mcp is true when mcpServers option is set", async () => {
@@ -236,7 +236,7 @@ describe("createVendoHandler", () => {
     const { GET, POST } = createVendoHandler({ vendoDir: emptyDir(), model });
 
     const caps = await GET(req("/api/vendo/capabilities"));
-    expect(await caps.json()).toEqual({ chat: true, integrations: false, voice: false, mcp: false, storage: false });
+    expect(await caps.json()).toEqual({ chat: true, integrations: false, voice: false, mcp: false, storage: false, automations: true });
 
     // The chatEnabled gate (503) fires before messages validation (400), so a
     // 400 on an empty messages array proves chat was NOT gated off.
@@ -268,7 +268,7 @@ describe("createVendoHandler", () => {
     vi.stubEnv("VENDO_MODEL", "");
     const fixed = await GET(req("/api/vendo/capabilities"));
     expect(fixed.status).toBe(200);
-    expect(await fixed.json()).toEqual({ chat: true, integrations: false, voice: false, mcp: false, storage: false });
+    expect(await fixed.json()).toEqual({ chat: true, integrations: false, voice: false, mcp: false, storage: false, automations: true });
   });
 
   it("resolves GET /capabilities after async assembly (async ripple smoke test)", async () => {
@@ -276,7 +276,7 @@ describe("createVendoHandler", () => {
     const { GET } = createVendoHandler({ vendoDir: emptyDir(), storage: false });
     const res = await GET(req("/api/vendo/capabilities"));
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ chat: true, integrations: false, voice: false, mcp: false, storage: false });
+    expect(await res.json()).toEqual({ chat: true, integrations: false, voice: false, mcp: false, storage: false, automations: true });
   });
 
   it("reports storage:true once durable storage actually assembles (not just from an env key)", async () => {
@@ -286,7 +286,7 @@ describe("createVendoHandler", () => {
     });
     const res = await GET(req("/api/vendo/capabilities"));
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ chat: false, integrations: false, voice: false, mcp: false, storage: true });
+    expect(await res.json()).toEqual({ chat: false, integrations: false, voice: false, mcp: false, storage: true, automations: true });
   });
 
   it("warns once, no matter how many requests, when running without durable storage in production", async () => {

--- a/packages/vendo-react/src/host-tool-runner.test.tsx
+++ b/packages/vendo-react/src/host-tool-runner.test.tsx
@@ -160,6 +160,65 @@ describe("chat identity stability", () => {
   });
 });
 
+describe("thread rehydration (loadHistory)", () => {
+  const restoredMessages: VendoUIMessage[] = [
+    { id: "m1", role: "user", parts: [{ type: "text", text: "what did I spend?" }] },
+    { id: "m2", role: "assistant", parts: [{ type: "text", text: "You spent $87." }] },
+  ] as VendoUIMessage[];
+
+  function probeSetup(loadHistory: () => Promise<VendoUIMessage[]>) {
+    const transport: ChatTransport<VendoUIMessage> = {
+      sendMessages: async () => chunkStream(textTurn),
+      reconnectToStream: async () => null,
+    };
+    let chat: Chat<VendoUIMessage> | undefined;
+    function Probe() {
+      chat = useVendoContext().chat;
+      return null;
+    }
+    render(
+      <VendoProvider transport={transport} components={[]} loadHistory={loadHistory}>
+        <Probe />
+      </VendoProvider>,
+    );
+    if (!chat) throw new Error("chat not captured");
+    return chat;
+  }
+
+  it("seeds an empty chat with the persisted thread messages", async () => {
+    const chat = probeSetup(async () => restoredMessages);
+    await waitFor(() => expect(chat.messages.length).toBe(2));
+    expect(chat.messages[0]!.id).toBe("m1");
+    expect(chat.messages[1]!.id).toBe("m2");
+  });
+
+  it("never clobbers a conversation that started before the history resolved", async () => {
+    let resolveHistory!: (m: VendoUIMessage[]) => void;
+    const gate = new Promise<VendoUIMessage[]>((resolve) => {
+      resolveHistory = resolve;
+    });
+    const chat = probeSetup(() => gate);
+
+    await chat.sendMessage({ text: "fresh question" });
+    await waitFor(() => expect(chat.status).toBe("ready"));
+    const liveIds = chat.messages.map((m) => m.id);
+    expect(liveIds.length).toBeGreaterThan(0);
+
+    resolveHistory(restoredMessages);
+    // Give the (skipped) seeding a chance to run; the live turn must survive.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(chat.messages.map((m) => m.id)).toEqual(liveIds);
+  });
+
+  it("ignores a failed history load", async () => {
+    const chat = probeSetup(async () => {
+      throw new Error("boom");
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(chat.messages.length).toBe(0);
+  });
+});
+
 describe("host tool runner", () => {
   it("executes an un-gated host tool in the browser and resubmits with the output", async () => {
     const fetchImpl = vi.fn(async () => jsonResponse({ data: [{ id: "acct_1" }] }));

--- a/packages/vendo-react/src/host-tool-runner.test.tsx
+++ b/packages/vendo-react/src/host-tool-runner.test.tsx
@@ -123,6 +123,41 @@ describe("chat identity stability", () => {
     expect(seen.length).toBeGreaterThanOrEqual(3);
     expect(new Set(seen).size).toBe(1);
   });
+
+  it("keeps the same Chat when the definitions ARRAY identity changes but its content does not", () => {
+    const transport: ChatTransport<VendoUIMessage> = {
+      sendMessages: async () => chunkStream(textTurn),
+      reconnectToStream: async () => null,
+    };
+
+    const seen: unknown[] = [];
+    function Probe() {
+      seen.push(useVendoContext().chat);
+      return null;
+    }
+    const ui = (nonce: number) => (
+      <VendoProvider
+        transport={transport}
+        components={[]}
+        // A fresh definitions ARRAY every render — a host that builds it
+        // inline (e.g. `hostTools={{ definitions: toHostTools(tools) }}`
+        // without memoizing) re-renders with a new identity but identical
+        // content. Keying the Chat on array identity wipes the ENTIRE
+        // conversation on such a re-render.
+        hostTools={{ definitions: [{ ...listAccountsDef }, { ...createOrderDef }] }}
+        key="stable"
+        data-nonce={nonce}
+      >
+        <Probe />
+      </VendoProvider>
+    );
+    const { rerender } = render(ui(1));
+    rerender(ui(2));
+    rerender(ui(3));
+
+    expect(seen.length).toBeGreaterThanOrEqual(3);
+    expect(new Set(seen).size).toBe(1);
+  });
 });
 
 describe("host tool runner", () => {

--- a/packages/vendo-react/src/host-tool-runner.test.tsx
+++ b/packages/vendo-react/src/host-tool-runner.test.tsx
@@ -124,6 +124,53 @@ describe("chat identity stability", () => {
     expect(new Set(seen).size).toBe(1);
   });
 
+  it("keeps the same Chat when the same tool set is rebuilt in a different order", () => {
+    const transport: ChatTransport<VendoUIMessage> = {
+      sendMessages: async () => chunkStream(textTurn),
+      reconnectToStream: async () => null,
+    };
+    const seen: unknown[] = [];
+    function Probe() {
+      seen.push(useVendoContext().chat);
+      return null;
+    }
+    const ui = (definitions: HostToolDefinition[]) => (
+      <VendoProvider transport={transport} components={[]} hostTools={{ definitions }} key="stable">
+        <Probe />
+      </VendoProvider>
+    );
+    // Same tool SET, different array order — a host assembling definitions
+    // from an unordered source (object keys, a Map, a fetch) must not mint a
+    // new Chat (wiping the conversation) just because iteration order moved.
+    const { rerender } = render(ui([listAccountsDef, createOrderDef]));
+    rerender(ui([createOrderDef, listAccountsDef]));
+
+    expect(seen.length).toBeGreaterThanOrEqual(2);
+    expect(new Set(seen).size).toBe(1);
+  });
+
+  it("mints a NEW Chat when the tool set genuinely changes", () => {
+    const transport: ChatTransport<VendoUIMessage> = {
+      sendMessages: async () => chunkStream(textTurn),
+      reconnectToStream: async () => null,
+    };
+    const seen: unknown[] = [];
+    function Probe() {
+      seen.push(useVendoContext().chat);
+      return null;
+    }
+    const ui = (definitions: HostToolDefinition[]) => (
+      <VendoProvider transport={transport} components={[]} hostTools={{ definitions }} key="stable">
+        <Probe />
+      </VendoProvider>
+    );
+    const { rerender } = render(ui([listAccountsDef, createOrderDef]));
+    rerender(ui([listAccountsDef]));
+
+    expect(seen.length).toBeGreaterThanOrEqual(2);
+    expect(new Set(seen).size).toBe(2);
+  });
+
   it("keeps the same Chat when the definitions ARRAY identity changes but its content does not", () => {
     const transport: ChatTransport<VendoUIMessage> = {
       sendMessages: async () => chunkStream(textTurn),

--- a/packages/vendo-react/src/provider.tsx
+++ b/packages/vendo-react/src/provider.tsx
@@ -82,14 +82,17 @@ export function VendoProvider({
     if (agent) return createLocalTransport(agent);
     throw new Error("VendoProvider requires either `agent` or `transport`");
   }, [agent, transport]);
-  // Keyed on a stable serialization of the tool NAMES, not on any object
-  // identity: callers pass `hostTools={{ definitions }}` inline (and often
-  // rebuild the definitions array itself each render), so identities change
-  // on every parent render. A new Set here would rebuild the Chat below and
-  // wipe the SDK's message/approval state — the entire conversation — on a
-  // plain re-render.
+  // Keyed on a stable serialization of the tool NAMES — sorted and deduped,
+  // never on object/array identity or ordering: callers pass
+  // `hostTools={{ definitions }}` inline (and often rebuild the definitions
+  // array each render, sometimes from unordered sources), so identities and
+  // iteration order change on plain re-renders. A new Set here would rebuild
+  // the Chat below and wipe the SDK's message/approval state — the entire
+  // conversation.
   const definitions = hostTools?.definitions;
-  const hostToolNamesKey = JSON.stringify((definitions ?? []).map((def) => def.name));
+  const hostToolNamesKey = JSON.stringify(
+    [...new Set((definitions ?? []).map((def) => def.name))].sort(),
+  );
   const hostToolNames = useMemo(
     () => new Set(JSON.parse(hostToolNamesKey) as string[]),
     [hostToolNamesKey],

--- a/packages/vendo-react/src/provider.tsx
+++ b/packages/vendo-react/src/provider.tsx
@@ -66,14 +66,17 @@ export function VendoProvider({ agent, transport, components, threadId, hostTool
     if (agent) return createLocalTransport(agent);
     throw new Error("VendoProvider requires either `agent` or `transport`");
   }, [agent, transport]);
-  // Keyed on the definitions ARRAY, not the config object: callers pass
-  // `hostTools={{ definitions }}` inline, so the config's identity changes on
-  // every parent render. A new Set here would rebuild the Chat below and wipe
-  // the SDK's message/approval state mid-turn.
+  // Keyed on a stable serialization of the tool NAMES, not on any object
+  // identity: callers pass `hostTools={{ definitions }}` inline (and often
+  // rebuild the definitions array itself each render), so identities change
+  // on every parent render. A new Set here would rebuild the Chat below and
+  // wipe the SDK's message/approval state — the entire conversation — on a
+  // plain re-render.
   const definitions = hostTools?.definitions;
+  const hostToolNamesKey = JSON.stringify((definitions ?? []).map((def) => def.name));
   const hostToolNames = useMemo(
-    () => new Set((definitions ?? []).map((def) => def.name)),
-    [definitions],
+    () => new Set(JSON.parse(hostToolNamesKey) as string[]),
+    [hostToolNamesKey],
   );
   // One Chat instance shared by every surface (dock, overlay, page) so they all
   // render the same thread. Surfaces consume it via useChat({ chat }).

--- a/packages/vendo-react/src/provider.tsx
+++ b/packages/vendo-react/src/provider.tsx
@@ -56,10 +56,26 @@ export interface VendoProviderProps {
   threadId?: string;
   /** Enable the browser-side executor for the host's own API tools. */
   hostTools?: HostToolsConfig;
+  /**
+   * Load this thread's persisted messages (e.g. from the handler's
+   * `GET /threads/:id`). Called once per Chat instance; the result seeds the
+   * chat ONLY while it is still empty and idle, so a reload after a
+   * mid-stream failure restores every settled message without ever
+   * clobbering a conversation that already started.
+   */
+  loadHistory?: () => Promise<VendoUIMessage[]>;
   children: ReactNode;
 }
 
-export function VendoProvider({ agent, transport, components, threadId, hostTools, children }: VendoProviderProps) {
+export function VendoProvider({
+  agent,
+  transport,
+  components,
+  threadId,
+  hostTools,
+  loadHistory,
+  children,
+}: VendoProviderProps) {
   const registry = useMemo(() => createRegistry(components), [components]);
   const local = useMemo<LocalTransport>(() => {
     if (transport) return { transport };
@@ -96,6 +112,40 @@ export function VendoProvider({ agent, transport, components, threadId, hostTool
       }),
     [local, threadId, hostToolNames],
   );
+  // Rehydrate the durable thread (ENG-193 §6.2's server persistence finally
+  // has a client read path): a reload — including one right after a stream
+  // died mid-turn — restores every settled message instead of wiping the
+  // thread. Ref'd so an inline `loadHistory` never re-runs the effect; the
+  // load happens once per Chat instance.
+  const loadHistoryRef = useRef(loadHistory);
+  useEffect(() => {
+    loadHistoryRef.current = loadHistory;
+  }, [loadHistory]);
+  useEffect(() => {
+    const load = loadHistoryRef.current;
+    if (!load) return;
+    // A conversation already underway (another surface sent first) wins.
+    if (chat.messages.length > 0) return;
+    let cancelled = false;
+    void Promise.resolve()
+      .then(load)
+      .then((restored) => {
+        if (cancelled || !Array.isArray(restored) || restored.length === 0) return;
+        // Seed ONLY a still-empty, idle chat: a turn that began while the
+        // history was in flight must never be clobbered.
+        if (chat.status !== "ready" || chat.messages.length > 0) return;
+        chat.messages = restored;
+      })
+      .catch((err: unknown) => {
+        // Restore is best-effort: a persistence read failure must never
+        // break a fresh conversation.
+        console.warn("[vendo] failed to restore the thread history:", err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [chat]);
+
   const value = useMemo<VendoContextValue>(() => ({ registry, local, chat }), [registry, local, chat]);
   return (
     <VendoContext.Provider value={value}>

--- a/packages/vendo-react/src/stage-adapter.test.tsx
+++ b/packages/vendo-react/src/stage-adapter.test.tsx
@@ -139,6 +139,48 @@ describe("VendoStage", () => {
     warn.mockRestore();
   });
 
+  it("clears the mounted tree when node becomes null (no stale interactive view)", async () => {
+    const node = { id: "c1", kind: "component", source: "host", name: "Card", props: {} } as const;
+    const theme = {};
+    const state = {};
+    update.mockClear();
+    initialize.mockClear();
+    const { rerender } = render(<VendoStage node={node} theme={theme} state={state} />);
+    await waitFor(() => expect(initialize).toHaveBeenCalledTimes(1));
+
+    rerender(<VendoStage node={null} theme={theme} state={state} />);
+    // The previous tree must be unmounted — an inert empty tree replaces it,
+    // so the stale view can no longer be seen or interacted with.
+    await waitFor(() => expect(initialize).toHaveBeenCalledTimes(2));
+    expect(initialize.mock.calls[1][0].tree).toMatchObject({ props: { text: "" } });
+
+    // And a later node mounts fresh (re-initialize, not a no-op update).
+    rerender(<VendoStage node={node} theme={theme} state={state} />);
+    await waitFor(() => expect(initialize).toHaveBeenCalledTimes(3));
+    expect(initialize.mock.calls[2][0]).toMatchObject({ tree: node });
+  });
+
+  it("clears a generated tree when node becomes null, then re-resolves the next payload", async () => {
+    const theme = {};
+    const state = {};
+    update.mockClear();
+    initialize.mockClear();
+    const { rerender } = render(
+      <VendoStage node={makeGenNode({ title: "Hello" })} theme={theme} state={state} />,
+    );
+    await waitFor(() => expect(initialize).toHaveBeenCalledTimes(1));
+
+    rerender(<VendoStage node={null} theme={theme} state={state} />);
+    await waitFor(() => expect(initialize).toHaveBeenCalledTimes(2));
+
+    // The next generated payload re-initializes (never a stale data-delta
+    // against the cleared tree).
+    rerender(<VendoStage node={makeGenNode({ title: "World" })} theme={theme} state={state} />);
+    await waitFor(() => expect(initialize).toHaveBeenCalledTimes(3));
+    expect(initialize.mock.calls[2][0].tree).toMatchObject({ props: { title: "World" } });
+    expect(update).not.toHaveBeenCalledWith(expect.objectContaining({ replace: expect.anything() }));
+  });
+
   // ---- Generated nodes (ENG-180) ----
 
   it("initializes a generated node with the session's resolved tree", async () => {

--- a/packages/vendo-react/src/stage-adapter.tsx
+++ b/packages/vendo-react/src/stage-adapter.tsx
@@ -38,6 +38,17 @@ const structureKey = (payload: GeneratedPayload): string => {
   return JSON.stringify([payload.nodes, sortedComponents]);
 };
 
+/** Inert tree mounted when `node` becomes null: renders nothing, carries no
+ *  actions — clearing the node must clear the stage (audit: a stale tree
+ *  stayed mounted and actionable). Reserved id so no real node collides. */
+const CLEARED_TREE: UINode = {
+  id: "__vendo-stage-cleared__",
+  kind: "component",
+  source: "prewired",
+  name: "Text",
+  props: { text: "" },
+};
+
 export interface VendoStageProps {
   node: UINode | null;
   bundleSource?: string;
@@ -110,8 +121,27 @@ export function VendoStage({
   // Initialize or update whenever node changes (after ready).
   useEffect(() => {
     const c = ctrlRef.current;
-    if (!c || !node) return;
+    if (!c) return;
     let cancelled = false;
+    if (!node) {
+      // node={null} means "show nothing": an initialized stage must unmount
+      // its tree, not leave the previous view visible and actionable. An
+      // inert empty tree replaces it (the protocol has no dedicated clear
+      // op); the session/payload refs drop too so the next node — generated
+      // or not — re-initializes instead of data-delta'ing a cleared tree.
+      if (initedRef.current) {
+        c.ready
+          .then(() => {
+            if (cancelled) return;
+            c.initialize({ theme, state, bundleSource, componentTheme, tree: CLEARED_TREE });
+            rootIdRef.current = CLEARED_TREE.id;
+            sessionRef.current = null;
+            payloadRef.current = null;
+          })
+          .catch((err) => console.error("[vendo] stage failed to become ready", err));
+      }
+      return () => { cancelled = true; };
+    }
     c.ready
       .then(() => {
         if (cancelled) return;

--- a/packages/vendo-server/src/capabilities.ts
+++ b/packages/vendo-server/src/capabilities.ts
@@ -26,11 +26,15 @@ export interface VendoCapabilities {
    *  the handler from the resolved `storage` option, not env — see
    *  fetch-handler.ts's GET "capabilities" case). */
   storage: boolean;
+  /** True when the automations world is live (set by the handler from the
+   *  resolved `automations` option, not env). `false` tells the client not
+   *  to start the deliveries poll — /deliveries would 404 forever. */
+  automations: boolean;
 }
 
 /** What `detectCapabilities` alone can answer from env keys — everything on
- *  the wire shape except `storage` (the handler merges that in). */
-export type EnvCapabilities = Omit<VendoCapabilities, "storage">;
+ *  the wire shape except `storage`/`automations` (the handler merges those). */
+export type EnvCapabilities = Omit<VendoCapabilities, "storage" | "automations">;
 
 export interface DetectCapabilitiesOptions {
   /** True when the host supplied its own `model` (e.g. via handler options). */

--- a/packages/vendo-server/src/fetch-handler.test.ts
+++ b/packages/vendo-server/src/fetch-handler.test.ts
@@ -40,7 +40,14 @@ describe("createVendoFetchHandler", () => {
     vi.stubEnv("OPENAI_API_KEY", "");
     const handler = createVendoFetchHandler({ vendoDir: emptyDir() });
     const res = await handler(req("/api/vendo/capabilities"));
-    expect(await res.json()).toEqual({ chat: true, integrations: false, voice: false, mcp: false, storage: false });
+    expect(await res.json()).toEqual({ chat: true, integrations: false, voice: false, mcp: false, storage: false, automations: true });
+  });
+
+  it("reports automations:false when the host disables automations", async () => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-x");
+    const handler = createVendoFetchHandler({ vendoDir: emptyDir(), automations: false });
+    const res = await handler(req("/api/vendo/capabilities"));
+    expect(((await res.json()) as { automations: boolean }).automations).toBe(false);
   });
 
   it("keeps integrations inert without a Composio key", async () => {
@@ -121,7 +128,7 @@ describe("createVendoFetchHandler", () => {
     const handler = createVendoFetchHandler({ vendoDir: emptyDir(), model });
 
     const caps = await handler(req("/api/vendo/capabilities"));
-    expect(await caps.json()).toEqual({ chat: true, integrations: false, voice: false, mcp: false, storage: false });
+    expect(await caps.json()).toEqual({ chat: true, integrations: false, voice: false, mcp: false, storage: false, automations: true });
 
     // The chatEnabled gate (503) fires before messages validation (400), so a
     // 400 on an empty messages array proves chat was NOT gated off.
@@ -157,7 +164,7 @@ describe("createVendoFetchHandler", () => {
     vi.stubEnv("VENDO_MODEL", "");
     const fixed = await handler(req("/api/vendo/capabilities"));
     expect(fixed.status).toBe(200);
-    expect(await fixed.json()).toEqual({ chat: true, integrations: false, voice: false, mcp: false, storage: false });
+    expect(await fixed.json()).toEqual({ chat: true, integrations: false, voice: false, mcp: false, storage: false, automations: true });
     error.mockRestore();
   });
 

--- a/packages/vendo-server/src/fetch-handler.ts
+++ b/packages/vendo-server/src/fetch-handler.ts
@@ -738,10 +738,16 @@ export function createVendoFetchHandler(rawOptions: VendoHandlerOptions = {}): V
           const guard = await resolvePrincipal(req, options);
           if (!guard.ok) return guard.response;
         }
-        // `storage` depends on the ASSEMBLED state (whether a durable handle
-        // was actually built), not an env key — detectCapabilities() alone
-        // can't know it, so it's merged in here.
-        return Response.json({ ...s.capabilities, storage: s.storage !== null });
+        // `storage`/`automations` depend on the ASSEMBLED state (whether a
+        // durable handle / an automations world was actually built), not an
+        // env key — detectCapabilities() alone can't know them, so they're
+        // merged in here. `automations: false` is what stops the client's
+        // deliveries poll from 404ing forever.
+        return Response.json({
+          ...s.capabilities,
+          storage: s.storage !== null,
+          automations: s.world !== null,
+        });
       }
       case "integrations":
         return handleIntegrationsGet(req, {

--- a/packages/vendo-shell/src/components/ConnectCard.tsx
+++ b/packages/vendo-shell/src/components/ConnectCard.tsx
@@ -7,6 +7,13 @@ export interface ConnectCardProps {
   onConnect: () => void;
 }
 
+/** The template supplies "So I can …"; the reason field's canonical examples
+ *  are purpose clauses ("to read the receipt"), so a leading to-infinitive
+ *  must fold into the sentence, never concatenate ("So I can To send …"). */
+function composeReason(reason: string): string {
+  return reason.replace(/^\s*to\s+/i, "").trimEnd().replace(/\.$/, "");
+}
+
 export function ConnectCard({ integration, reason, onConnect }: ConnectCardProps) {
   return (
     <div className="fl-connect" role="group" aria-label={`Connect ${integration.name}`}>
@@ -14,7 +21,7 @@ export function ConnectCard({ integration, reason, onConnect }: ConnectCardProps
         <BrandIcon id={integration.id} size={16} />
         Connect {integration.name}
       </div>
-      {reason && <div style={{ fontSize: 12, margin: "6px 0 10px" }}>So I can {reason}.</div>}
+      {reason && <div style={{ fontSize: 12, margin: "6px 0 10px" }}>So I can {composeReason(reason)}.</div>}
       <button type="button" className="fl-btn fl-btn-primary" onClick={onConnect}>Connect {integration.name}</button>
     </div>
   );

--- a/packages/vendo-shell/src/components/integrations.test.tsx
+++ b/packages/vendo-shell/src/components/integrations.test.tsx
@@ -84,8 +84,31 @@ describe("ConnectCard", () => {
   it("renders reason and triggers connect", () => {
     const onConnect = vi.fn();
     render(<ConnectCard integration={list[1]!} reason="read your invoices" onConnect={onConnect} />);
-    expect(screen.getByText(/read your invoices/)).toBeTruthy();
+    expect(screen.getByText("So I can read your invoices.")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: /Connect Gmail/ }));
     expect(onConnect).toHaveBeenCalledOnce();
+  });
+
+  it("strips a leading 'To ' from an LLM reason instead of rendering 'So I can To …'", () => {
+    // The reason field's own canonical examples are purpose clauses ("to
+    // read the receipt"); the template supplies "So I can", so a leading
+    // to-infinitive must be folded in, not concatenated (browser-observed:
+    // "So I can To send you a weekly emailed summary…").
+    render(
+      <ConnectCard
+        integration={list[1]!}
+        reason="To send you a weekly emailed summary"
+        onConnect={() => {}}
+      />,
+    );
+    expect(screen.getByText("So I can send you a weekly emailed summary.")).toBeTruthy();
+
+    render(<ConnectCard integration={list[1]!} reason="to read the receipt" onConnect={() => {}} />);
+    expect(screen.getByText("So I can read the receipt.")).toBeTruthy();
+  });
+
+  it("leaves a reason that merely STARTS with 'to…' letters intact", () => {
+    render(<ConnectCard integration={list[1]!} reason="total up your invoices" onConnect={() => {}} />);
+    expect(screen.getByText("So I can total up your invoices.")).toBeTruthy();
   });
 });

--- a/packages/vendo-shell/src/seams/notifications.ts
+++ b/packages/vendo-shell/src/seams/notifications.ts
@@ -23,8 +23,10 @@ export interface AutomationNotice {
 export type ResumeOutcome = "resumed" | "stale";
 
 export interface VendoNotifications {
-  /** All notices with cursor > `since`, oldest first. */
-  listSince(since: number): Promise<AutomationNotice[]>;
+  /** All notices with cursor > `since`, oldest first. `"disabled"` means the
+   *  feed does not exist on this host (automations off) — the poller must
+   *  stop for good instead of retrying forever. */
+  listSince(since: number): Promise<AutomationNotice[] | "disabled">;
   /** Approve/deny the paused run behind an approval notice. Pass the notice's
    *  `stepId` so a run that has since paused on a DIFFERENT step answers
    *  `stale` instead of approving something the user never saw. `stale` also

--- a/packages/vendo-shell/src/toasts/VendoToasts.test.tsx
+++ b/packages/vendo-shell/src/toasts/VendoToasts.test.tsx
@@ -137,4 +137,22 @@ describe("VendoToasts", () => {
     expect(screen.getByText("Approve")).toBeTruthy();
     expect(document.querySelectorAll(".fl-toasts-card")).toHaveLength(1);
   });
+
+  it("stops polling for good once the feed reports it is disabled", async () => {
+    let calls = 0;
+    const client: VendoNotifications = {
+      listSince: async () => {
+        calls += 1;
+        return "disabled";
+      },
+      resume: async () => "stale",
+    };
+    mount(client, { pollMs: 20 });
+    await waitFor(() => expect(calls).toBe(1));
+    // Several poll intervals later: still exactly one call — a host with
+    // automations disabled must not 404 the feed every 2 seconds forever.
+    await new Promise((r) => setTimeout(r, 120));
+    expect(calls).toBe(1);
+    expect(document.querySelector(".fl-toasts")).toBeNull();
+  });
 });

--- a/packages/vendo-shell/src/toasts/VendoToasts.tsx
+++ b/packages/vendo-shell/src/toasts/VendoToasts.tsx
@@ -70,6 +70,14 @@ export function VendoToasts({
   const inFlight = useRef(false);
   useEffect(() => {
     let disposed = false;
+    // The feed answered "disabled" (automations off on this host): stop the
+    // loop for good — polling a route that will 404 every interval forever
+    // is exactly the bug this guards against.
+    const stop = () => {
+      disposed = true;
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
     const poll = async () => {
       // Serialize: an overlapping poll could double-read the same cursor and
       // toast notices the first pass already handled (or baselined).
@@ -86,6 +94,10 @@ export function VendoToasts({
       try {
         const notices = await notifications.listSince(cursor ?? 0);
         if (disposed) return;
+        if (notices === "disabled") {
+          stop();
+          return;
+        }
         const initial = firstBatch.current;
         firstBatch.current = false;
         if (notices.length === 0) {
@@ -126,11 +138,7 @@ export function VendoToasts({
       if (document.visibilityState === "visible") void poll();
     };
     document.addEventListener("visibilitychange", onVisible);
-    return () => {
-      disposed = true;
-      clearInterval(interval);
-      document.removeEventListener("visibilitychange", onVisible);
-    };
+    return stop;
   }, [notifications, queue, pollMs, namespace]);
 
   // Auto-dismiss: each visible non-persistent toast gets one countdown.

--- a/packages/vendo-shell/src/use-trust-data.test.ts
+++ b/packages/vendo-shell/src/use-trust-data.test.ts
@@ -54,6 +54,28 @@ describe("useTrustData", () => {
     expect(result.current.diary).toMatchObject({ reads: 1, approved: 1, automationRuns: 1, bigActions: 1 });
   });
 
+  it("a declined approval never counts as an approved action (its trail rows are not executions)", async () => {
+    // What a decline actually leaves behind: NO tool_execution (the tool
+    // never ran) — only trail rows like the judge escalation and the consent
+    // decision. None of them may inflate the diary. The read rows alongside
+    // must still count as reads.
+    const rows: TrustAuditRow[] = [
+      { at: "1", kind: "judge_escalation", toolName: "send_email" },
+      { at: "2", kind: "consent" },
+      { at: "3", kind: "approval" },
+      { at: "4", kind: "tool_execution", toolName: "get_clients", mutating: false },
+      { at: "5", kind: "tool_execution", toolName: "get_deadlines", mutating: false },
+    ];
+    const trust: TrustSeam = {
+      listGrants: async () => [], revokeGrant: async () => {}, queryAudit: async () => rows,
+      listCriticalTools: async () => [], resolveFadeProposal: async () => {},
+      listRules: async () => [], revokeRule: async () => {},
+    };
+    const { result } = renderHook(() => useTrustData(), { wrapper: wrap(trust) });
+    await waitFor(() => expect(result.current.diary.total).toBe(2));
+    expect(result.current.diary).toMatchObject({ reads: 2, approved: 0, bigActions: 0 });
+  });
+
   it("a week of ONLY big actions is never counted as 0 (review nit)", async () => {
     const rows: TrustAuditRow[] = [
       { at: "1", kind: "tool_execution", toolName: "transfer_money", mutating: true, dangerous: true },


### PR DESCRIPTION
## What

**Stacked on #64; sibling of #65 (no file overlap — either merges first).** The client/state bugs from the browser bug bash + code audit. 9 commits, TDD'd, Codex-reviewed with both its findings fixed in-branch.

### Fixes

1. **Threads now restore on reload** — the server persisted every settled message but **no client read path existed at all**; any reload started empty (the bug bash saw a whole conversation vanish after a stream error). New `loadHistory` seam on `VendoProvider` (seeds only an empty idle Chat, never clobbers an in-flight turn), wired in `@vendoai/next` and demo-bank.
2. **Conversation survives re-renders** — the shared Chat was keyed on the `hostTools.definitions` array identity (audit-confirmed wipe); now keyed on the deduped, sorted tool-name content.
3. **`VendoStage node={null}` clears the stage** — previously left the old sandbox tree mounted and actionable.
4. **Capabilities failure isn't optimistic forever** — failed fetch now retries with capped backoff, renders conservatively meanwhile, and a basePath change can't leave the UI trusting the previous endpoint's answer (Codex catch).
5. **Deliveries poll gates on capabilities** — new `automations` capability; hosts with automations off no longer take a 404 every 2 seconds forever (old servers: exactly one 404, then silence).
6. **Trust diary counts reads as reads** — Cadence's read tools carried no annotations so every read run was audited `mutating:true` ("0 reads, 4 actions you approved" after zero approvals); annotated via the existing `readOnly()` pattern + a shell pin that declines never inflate the diary.
7. **ConnectCard template fold** — "So I can **To send** you…" now folds a leading to-infinitive into the template.
8. **Chart palette warning spam killed, palette delivery pinned** — OpenUI's validator warnings were false positives (palettes were reaching charts); a `ThemeContext` bridge re-provides the palette keys past the validator, live-verified zero warnings. *Before/after chart screenshot in the final verification pass.*

### Honest non-fix

The "stray 0 text node" from the bug bash is **Recharts' off-screen measurement span** — exhaustive grep found zero numeric `&&` renders, live DOM inspection confirmed. No change.

### Flagged for Yousef (in the decisions doc, not built)

- Cadence has no thread persistence at all (hand-rolled routes) — nothing to restore there.
- Composio-executed reads still audit as "actions you approved" (no annotation source exists).

`pnpm typecheck` 27/27 · `pnpm test` 25/25.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores chat history on reload and hardens client state so conversations survive re-renders and failures. Gates automations polling via server capabilities and removes OpenUI chart palette warnings while keeping brand palettes.

- **New Features**
  - Thread restore on reload via `VendoProvider.loadHistory`; wired in `@vendo-next` `VendoRoot` and the demo bank (reads `GET /threads/:id`).
  - New `automations` capability from the server; `VendoToasts` only polls when enabled, and old hosts get one 404 then stop.

- **Bug Fixes**
  - Conversation stability: shared Chat now keyed on deduped, sorted tool-name content, not `definitions` array identity or order.
  - `VendoStage node={null}` clears the sandbox tree so no stale, actionable view remains.
  - Capabilities fetch in `@vendo-next` retries with capped backoff and, on failure, renders conservatively; changing `basePath` drops stale capabilities.
  - Demo-accounting read tools carry read-only annotations, so the Trust diary counts reads correctly; declined approvals no longer inflate “approved actions”.
  - ConnectCard folds a leading “To …” into “So I can …” for natural copy.
  - Chart palettes routed around OpenUI ThemeProvider validation via `ChartPaletteBridge`; no more “[OpenUI] unknown key …ChartPalette” warnings and palettes still reach charts (wired in `@vendo-components` host and sandbox).

<sup>Written for commit 7663fae4c2e2df2dde5f203aa26b728f615ee7e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

