### PR TITLE
Shell-UI wave: glass skeletons, mobile takeover, summary-only consent, MCP consent (Yousef-approved)

### DIFF
--- a/apps/demo-accounting/src/app/assistant/page.tsx
+++ b/apps/demo-accounting/src/app/assistant/page.tsx
@@ -10,6 +10,7 @@
  */
 import { useEffect, useState } from "react"
 import {
+  GlassVeil,
   VendoThread,
   VendoToast,
   useVendoThread,
@@ -37,6 +38,7 @@ function PageSurface() {
   const parked = useParkedActions()
   const [active, setActive] = useState<string>(CHAT)
   const [saved, setSaved] = useState<Vendo[]>([])
+  const [savedLoaded, setSavedLoaded] = useState(false)
   const [trustOpen, setTrustOpen] = useState(false)
 
   // Hydrate the tab strip from the store (ENG-183): saved vendos survive
@@ -44,7 +46,9 @@ function PageSurface() {
   useEffect(() => {
     let cancelled = false
     void store.list().then((all) => {
-      if (!cancelled) setSaved(all.sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0)))
+      if (cancelled) return
+      setSaved(all.sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0)))
+      setSavedLoaded(true)
     })
     return () => { cancelled = true }
   }, [store])
@@ -167,6 +171,7 @@ function PageSurface() {
             suggestions={SUGGESTIONS}
             heroComposer
             flows={saved}
+            flowsLoading={!savedLoaded}
             onOpenFlow={(f) => setActive(f.id)}
             onRenameFlow={(f, name) => persistPatch(f, { name })}
             onPinFlow={(f, pinned) => persistPatch(f, { pinned })}
@@ -202,10 +207,11 @@ function PageSurface() {
  */
 function SavedPane({ vendo }: { vendo: Vendo }) {
   const { renderNode } = useShell()
-  const { node, status, errors, drift } = useReopenVendo(vendo)
+  const { node, status, errors, drift, refreshing } = useReopenVendo(vendo)
   const drifted = [...drift.missing, ...drift.changed]
   return (
     <div className="fl-saved-pane">
+      {refreshing && <GlassVeil />}
       {drifted.length > 0 && (
         <div className="fl-drift-note">
           {drifted.join(", ")} {drifted.length === 1 ? "has" : "have"} changed in Cadence since this

--- a/packages/vendo-runtime/src/consent.test.ts
+++ b/packages/vendo-runtime/src/consent.test.ts
@@ -96,6 +96,52 @@ describe("handleConsent", () => {
     expect(await d.audit.query(scope, { kinds: ["consent"] })).toHaveLength(1);
   });
 
+  it("MCP dynamic-tool approvals ride the SAME channel: a dynamic-tool part anchors the consent, audits it, and mints the implicit allow-once grant", async () => {
+    // ai-SDK MCP tools persist as `dynamic-tool` parts (name in `toolName`,
+    // not the part type). The lookup and tool-name cross-check must treat
+    // them exactly like static tool-* parts — this was the remaining
+    // tool-*-only path from the MCP work.
+    const messages = [
+      { id: "m1", role: "assistant", parts: [
+        { type: "dynamic-tool", toolName: "everything_echo", toolCallId: "call-mcp",
+          state: "approval-requested", input: { message: "hi" }, approval: { id: "ap-mcp" } },
+      ] },
+    ] as unknown as VendoUIMessage[];
+    const d = {
+      ...deps(messages),
+      resolveDescriptor: (name: string): ToolDescriptor | undefined =>
+        name === "everything_echo"
+          ? { name, source: "mcp", annotations: { readOnlyHint: false }, hasExecute: false, kind: "dynamic" }
+          : undefined,
+    };
+    const result = await handleConsent(d, scope, {
+      threadId: "th-1", toolCallId: "call-mcp", toolName: "everything_echo",
+      response: { id: "call-mcp", decision: "yes" },
+    });
+    expect(result.ok).toBe(true);
+    // Same rows a host-tool approval writes: one consent audit event + the
+    // implicit session-scoped exact grant (spec §4.3 "allow once").
+    expect(await d.audit.query(scope, { kinds: ["consent"] })).toHaveLength(1);
+    expect(await d.grants.findForTool(scope, "everything_echo")).toHaveLength(1);
+  });
+
+  it("a dynamic-tool part still enforces the tool-name cross-check (400 on mismatch, decision audited)", async () => {
+    const messages = [
+      { id: "m1", role: "assistant", parts: [
+        { type: "dynamic-tool", toolName: "everything_echo", toolCallId: "call-mcp",
+          state: "approval-requested", input: {}, approval: { id: "ap-mcp" } },
+      ] },
+    ] as unknown as VendoUIMessage[];
+    const d = deps(messages);
+    const result = await handleConsent(d, scope, {
+      threadId: "th-1", toolCallId: "call-mcp", toolName: "some_other_tool",
+      response: { id: "call-mcp", decision: "yes" },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(400);
+    expect(await d.audit.query(scope, { kinds: ["consent"] })).toHaveLength(1);
+  });
+
   it("404s when no approval-requested part with that toolCallId exists (and still audits the decision)", async () => {
     const d = deps([]);
     const result = await handleConsent(d, scope, {

--- a/packages/vendo-runtime/src/consent.ts
+++ b/packages/vendo-runtime/src/consent.ts
@@ -125,10 +125,27 @@ export type HandleConsentResult =
  *  or not. That's the exact fact this file's evidence check below relies on. */
 interface ApprovalPart {
   type: string;
+  /** Dynamic (MCP) parts carry the tool name here — the part type is just
+   *  "dynamic-tool", not "tool-<name>". */
+  toolName?: string;
   toolCallId?: string;
   state?: string;
   input?: unknown;
   approval?: { id: string; approved?: boolean; reason?: string };
+}
+
+/** Static host/server tool parts ("tool-<name>") AND ai-SDK dynamic-tool
+ *  parts (MCP servers) — the consent channel treats both identically. This
+ *  was the remaining tool-*-only path from the MCP work (2026-07-05): a
+ *  dynamic part could never anchor a consent POST, so MCP approvals silently
+ *  skipped the audit/grant trail host tools get. */
+function isToolPart(part: ApprovalPart): boolean {
+  return part.type.startsWith("tool-") || part.type === "dynamic-tool";
+}
+
+/** The pending part's own tool name, wherever the shape keeps it. */
+function partToolName(part: ApprovalPart): string {
+  return part.type === "dynamic-tool" ? String(part.toolName ?? "") : part.type.slice("tool-".length);
 }
 
 /**
@@ -164,7 +181,7 @@ function findApprovalPart(
   for (const message of messages) {
     for (const rawPart of message.parts) {
       const part = rawPart as ApprovalPart;
-      if (part.type.startsWith("tool-") && part.toolCallId === toolCallId && hasApprovalEvidence(part)) {
+      if (isToolPart(part) && part.toolCallId === toolCallId && hasApprovalEvidence(part)) {
         return part;
       }
     }
@@ -245,11 +262,11 @@ export async function handleConsent(
       error: `the user declined toolCallId "${req.toolCallId}" — an affirmative consent cannot be recorded over a decline`,
     });
   }
-  const partToolName = part.type.slice("tool-".length);
-  if (partToolName !== req.toolName) {
+  const pendingToolName = partToolName(part);
+  if (pendingToolName !== req.toolName) {
     return audited({
       ok: false, status: 400,
-      error: `toolName "${req.toolName}" does not match the pending part's tool "${partToolName}"`,
+      error: `toolName "${req.toolName}" does not match the pending part's tool "${pendingToolName}"`,
     });
   }
 

--- a/packages/vendo-server/src/consent.test.ts
+++ b/packages/vendo-server/src/consent.test.ts
@@ -57,6 +57,26 @@ describe("handleConsentRoute", () => {
     expect(await deps.audit.query(scope, { kinds: ["consent"] })).toHaveLength(1);
   });
 
+  it("an MCP dynamic-tool approval writes the same consent audit row a host-tool approval does", async () => {
+    // The route's descriptor resolver can't statically enumerate MCP tools
+    // (resolveDescriptor returns undefined) — grant minting stays
+    // conservative, but the consent/audit trail must be identical.
+    const deps = makeDeps();
+    const threadId = await deps.threadIndex.resolve(scope, "chat-mcp");
+    await deps.threads.appendMessages(scope, threadId, [
+      { id: "m1", role: "assistant", parts: [
+        { type: "dynamic-tool", toolName: "everything_echo", toolCallId: "call-mcp",
+          state: "approval-requested", input: { message: "hi" }, approval: { id: "ap-1" } },
+      ] } as never,
+    ]);
+    const res = await handleConsentRoute(req({
+      id: "chat-mcp", toolCallId: "call-mcp", toolName: "everything_echo",
+      response: { id: "call-mcp", decision: "yes" },
+    }), deps);
+    expect(res.status).toBe(200);
+    expect(await deps.audit.query(scope, { kinds: ["consent"] })).toHaveLength(1);
+  });
+
   it("404s when no pending approval part exists for the toolCallId", async () => {
     const deps = makeDeps();
     const res = await handleConsentRoute(req({

--- a/packages/vendo-shell/src/VendoThread.tsx
+++ b/packages/vendo-shell/src/VendoThread.tsx
@@ -53,6 +53,9 @@ export interface VendoThreadProps {
   greeting?: string;
   suggestions?: string[];
   flows?: Vendo[];
+  /** True while the host's first store list is still in flight — the landing
+   *  library holds its space with glass skeleton cards instead of popping in. */
+  flowsLoading?: boolean;
   onOpenFlow?: (flow: Vendo) => void;
   /** Library management on the empty-state gallery (ENG-183). */
   onRenameFlow?: (flow: Vendo, name: string) => void;
@@ -84,12 +87,15 @@ export interface VendoThreadProps {
 }
 
 export function VendoThread({
-  greeting, suggestions = [], flows = [], onOpenFlow, onRenameFlow, onPinFlow, onDeleteFlow,
+  greeting, suggestions = [], flows = [], flowsLoading = false, onOpenFlow, onRenameFlow, onPinFlow, onDeleteFlow,
   heroComposer = false, onPin, onFeedback, voice,
 }: VendoThreadProps) {
   const chat = useVendoThread();
   const { integrations, sendConsent, trust, registry, scope, remixes, components } = useShell();
   const [tools, setTools] = useState<Integration[]>([]);
+  // False until the FIRST integrations list lands — the tray shows glass
+  // shimmer placeholder rows for that window only.
+  const [toolsLoaded, setToolsLoaded] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [fadeProposal, setFadeProposal] = useState<{ messageId: string; toolName: string; proposalId: string; count?: number } | null>(null);
   const activeScope = useSyncExternalStore(scope.subscribe, scope.current, () => null);
@@ -151,7 +157,12 @@ export function VendoThread({
     return null;
   }, [chat.items]);
 
-  const refresh = () => { void integrations.list().then(setTools); };
+  const refresh = () => {
+    void integrations.list().then((list) => {
+      setTools(list);
+      setToolsLoaded(true);
+    });
+  };
   useEffect(refresh, [integrations]);
   // Re-list when a connection changes (e.g. the user connects a tool on screen),
   // so the rail and selector reflect it without a reload.
@@ -369,6 +380,7 @@ export function VendoThread({
       <ConnectTray open={pickerOpen} onClose={() => setPickerOpen(false)}>
         <IntegrationsPicker
           integrations={tools}
+          loading={!toolsLoaded}
           // Resolves only after the refreshed list has landed in state, so the
           // picker's connecting row can observe its flip to connected.
           onConnect={(id) => integrations.connect(id).then(() => integrations.list()).then(setTools)}
@@ -410,6 +422,7 @@ export function VendoThread({
           greeting={greeting}
           suggestions={suggestions}
           flows={flows}
+          flowsLoading={flowsLoading}
           composer={composerInHero ? composerArea : undefined}
           onSuggestion={send}
           onOpenFlow={(f) => onOpenFlow?.(f)}

--- a/packages/vendo-shell/src/components/ApprovalCard.tsx
+++ b/packages/vendo-shell/src/components/ApprovalCard.tsx
@@ -1,10 +1,12 @@
 import { isCatalogTool, toolAction } from "./tool-labels";
+import { approvalRows } from "./field-rows";
 
 export interface ApprovalCardProps {
   toolName: string;
-  /** The tool call's raw input. NOT rendered (summary only — Yousef,
-   *  2026-07-05); kept in the contract so every caller keeps passing it and
-   *  voice/receipt surfaces can keep deriving their own copy from it. */
+  /** The tool call's input. Ordinary cards never render it (summary only —
+   *  Yousef, 2026-07-05); CRITICAL cards show its non-empty fields with
+   *  humanized labels/values, untruncated (the ENG-193 §4.5 safety intent —
+   *  the human must see WHAT they are irreversibly approving). */
   input: unknown;
   /** ENG-193 §4.1 — from the sibling data-consent part. Defaults to "act". */
   tier?: "act" | "critical";
@@ -35,21 +37,24 @@ export interface ApprovalCardProps {
  * register — money/irreversible ceremony doesn't need a reason to already
  * be maximally careful.
  *
- * Summary only (Yousef, 2026-07-05): end users see the human-readable action
- * summary — raw parameter key/values ("Is html: false", "User id: me") are
- * REMOVED from the card entirely, not tucked behind a disclosure. The settled
- * receipt (ActivityStep) still carries the full field detail for anyone who
- * wants to audit what ran. The "Unverified tool" badge shows only for tools
- * whose SOURCE is genuinely unknown — stock catalog Composio tools (flagged
- * unverified merely for shipping no annotations) don't wear it. Display
- * changes only; the approval mechanism is untouched.
+ * Summary only (Yousef, 2026-07-05 + same-day amendment): ORDINARY cards show
+ * only the human-readable action summary — raw parameter key/values ("Is
+ * html: false", "User id: me") are REMOVED entirely, not tucked behind a
+ * disclosure. CRITICAL cards keep their material fields (ENG-193 §4.5): the
+ * tool's declared non-empty input fields with humanized labels and readable
+ * values, never truncated — the human must see the amount/recipient they are
+ * irreversibly approving. The settled receipt (ActivityStep) still carries
+ * full field detail for every tier. The "Unverified tool" badge shows only
+ * for tools whose SOURCE is genuinely unknown — stock catalog Composio tools
+ * (flagged unverified merely for shipping no annotations) don't wear it.
+ * Display changes only; the approval mechanism is untouched.
  *
  * Voice sessions (ENG-185) layer on top: `listening` adds a soft ring while
  * a spoken yes is acceptable, and a `resolution` turns the card into a
  * receipt of how consent was given (buttons collapse into an outcome line).
  */
 export function ApprovalCard({
-  toolName, tier = "act", unverified = false, reason, listening = false, resolution, consequence, onApprove, onDecline,
+  toolName, input, tier = "act", unverified = false, reason, listening = false, resolution, consequence, onApprove, onDecline,
 }: ApprovalCardProps) {
   const action = toolAction(toolName);
   const critical = tier === "critical";
@@ -58,6 +63,10 @@ export function ApprovalCard({
   // Badge only when the SOURCE is genuinely unknown: catalog-known Composio
   // tools are unverified-by-annotation, not unverified-by-provenance.
   const showUnverified = unverified && !isCatalogTool(toolName);
+  // Material fields are a CRITICAL-tier concern only: the tool's declared
+  // non-empty input fields, humanized labels + readable values, untruncated
+  // (maxChars null is the same critical signal field-rows.ts always used).
+  const materialRows = critical ? approvalRows(input, null).rows : [];
   const confirmLabel = critical ? `Confirm ${action.request.replace(/^[A-Z]/, (c) => c.toLowerCase())}` : "Send it";
   const declineLabel = critical ? "Cancel" : "No";
   const approveClass = critical ? "fl-btn-ceremony" : escalated ? "fl-btn" : "fl-btn-primary";
@@ -98,6 +107,16 @@ export function ApprovalCard({
       </div>
       {escalated && (
         <div className="fl-approval-reason">Hold on — I stopped to check: {reason}</div>
+      )}
+      {materialRows.length > 0 && (
+        <dl className="fl-approval-fields">
+          {materialRows.map((row) => (
+            <div key={row.label} className="fl-approval-field">
+              <dt>{row.label}</dt>
+              <dd>{row.value}</dd>
+            </div>
+          ))}
+        </dl>
       )}
       {critical && !settled && (
         <div className="fl-approval-consequence">{consequence ?? "This can't be undone."}</div>

--- a/packages/vendo-shell/src/components/ApprovalCard.tsx
+++ b/packages/vendo-shell/src/components/ApprovalCard.tsx
@@ -1,8 +1,10 @@
-import { toolAction } from "./tool-labels";
-import { approvalRows } from "./field-rows";
+import { isCatalogTool, toolAction } from "./tool-labels";
 
 export interface ApprovalCardProps {
   toolName: string;
+  /** The tool call's raw input. NOT rendered (summary only — Yousef,
+   *  2026-07-05); kept in the contract so every caller keeps passing it and
+   *  voice/receipt surfaces can keep deriving their own copy from it. */
   input: unknown;
   /** ENG-193 §4.1 — from the sibling data-consent part. Defaults to "act". */
   tier?: "act" | "critical";
@@ -23,8 +25,6 @@ export interface ApprovalCardProps {
   onDecline: () => void;
 }
 
-const MAX_VALUE_CHARS = 160;
-
 /**
  * The consent moment (spec §3 Moments 3, 6 & 9): a plain yes/no card for an
  * act-tier action, the ceremony variant for critical (money/irreversible)
@@ -35,18 +35,29 @@ const MAX_VALUE_CHARS = 160;
  * register — money/irreversible ceremony doesn't need a reason to already
  * be maximally careful.
  *
+ * Summary only (Yousef, 2026-07-05): end users see the human-readable action
+ * summary — raw parameter key/values ("Is html: false", "User id: me") are
+ * REMOVED from the card entirely, not tucked behind a disclosure. The settled
+ * receipt (ActivityStep) still carries the full field detail for anyone who
+ * wants to audit what ran. The "Unverified tool" badge shows only for tools
+ * whose SOURCE is genuinely unknown — stock catalog Composio tools (flagged
+ * unverified merely for shipping no annotations) don't wear it. Display
+ * changes only; the approval mechanism is untouched.
+ *
  * Voice sessions (ENG-185) layer on top: `listening` adds a soft ring while
  * a spoken yes is acceptable, and a `resolution` turns the card into a
  * receipt of how consent was given (buttons collapse into an outcome line).
  */
 export function ApprovalCard({
-  toolName, input, tier = "act", unverified = false, reason, listening = false, resolution, consequence, onApprove, onDecline,
+  toolName, tier = "act", unverified = false, reason, listening = false, resolution, consequence, onApprove, onDecline,
 }: ApprovalCardProps) {
   const action = toolAction(toolName);
   const critical = tier === "critical";
   const escalated = Boolean(reason) && !critical;
   const settled = resolution !== undefined;
-  const { rows, more } = approvalRows(input, critical ? null : MAX_VALUE_CHARS);
+  // Badge only when the SOURCE is genuinely unknown: catalog-known Composio
+  // tools are unverified-by-annotation, not unverified-by-provenance.
+  const showUnverified = unverified && !isCatalogTool(toolName);
   const confirmLabel = critical ? `Confirm ${action.request.replace(/^[A-Z]/, (c) => c.toLowerCase())}` : "Send it";
   const declineLabel = critical ? "Cancel" : "No";
   const approveClass = critical ? "fl-btn-ceremony" : escalated ? "fl-btn" : "fl-btn-primary";
@@ -80,24 +91,13 @@ export function ApprovalCard({
                 covers money AND irreversible/permission-changing tools — the
                 spec's Trust-screen phrase, not money-specific copy. */}
             {critical ? "Always needs you" : escalated ? "Hold on — checking with you first" : "Needs your approval"}
-            {unverified && <span className="fl-approval-unverified">Unverified tool</span>}
+            {showUnverified && <span className="fl-approval-unverified">Unverified tool</span>}
           </div>
           <div className="fl-approval-title">{action.question}</div>
         </div>
       </div>
       {escalated && (
         <div className="fl-approval-reason">Hold on — I stopped to check: {reason}</div>
-      )}
-      {rows.length > 0 && (
-        <dl className="fl-approval-fields">
-          {rows.map((row) => (
-            <div key={row.label} className="fl-approval-field">
-              <dt>{row.label}</dt>
-              <dd>{row.value}</dd>
-            </div>
-          ))}
-          {more > 0 && <div className="fl-approval-more">+{more} more</div>}
-        </dl>
       )}
       {critical && !settled && (
         <div className="fl-approval-consequence">{consequence ?? "This can't be undone."}</div>

--- a/packages/vendo-shell/src/components/FlowGallery.tsx
+++ b/packages/vendo-shell/src/components/FlowGallery.tsx
@@ -4,6 +4,9 @@ import { relativeTimeLabel } from "../relative-time";
 
 export interface FlowGalleryProps {
   flows: Vendo[];
+  /** True while the host's first store list is still in flight — the grid
+   *  holds its space with glass shimmer cards. Real flows always win. */
+  loading?: boolean;
   onOpen: (flow: Vendo) => void;
   /** Library management (ENG-183). Omit any to hide that affordance. */
   onRename?: (flow: Vendo, name: string) => void;
@@ -13,12 +16,26 @@ export interface FlowGalleryProps {
 
 const byRecent = (a: Vendo, b: Vendo) => b.updatedAt - a.updatedAt;
 
+/** Skeleton cards while the library loads — matches the 2-col card grid. */
+const LOADING_CARDS = 4;
+
 /**
  * The saved-vendo library: pinned cards first, then recent. Each card opens
  * its view; rename is inline, pin/delete sit in a hover action row. Dumb by
  * design — the host owns the store round-trips.
  */
-export function FlowGallery({ flows, onOpen, onRename, onPin, onDelete }: FlowGalleryProps) {
+export function FlowGallery({ flows, loading = false, onOpen, onRename, onPin, onDelete }: FlowGalleryProps) {
+  if (flows.length === 0 && loading) {
+    return (
+      <div className="fl-library" aria-hidden="true">
+        <div className="fl-gallery">
+          {Array.from({ length: LOADING_CARDS }, (_, i) => (
+            <div key={i} className="fl-glass-shimmer fl-flowcard-skel" />
+          ))}
+        </div>
+      </div>
+    );
+  }
   if (flows.length === 0) return null;
   const pinned = flows.filter((f) => f.pinned === true).sort(byRecent);
   const recent = flows.filter((f) => f.pinned !== true).sort(byRecent);

--- a/packages/vendo-shell/src/components/GlassSkeleton.tsx
+++ b/packages/vendo-shell/src/components/GlassSkeleton.tsx
@@ -1,0 +1,51 @@
+/**
+ * Glass skeleton (2026-07-05, Yousef-approved recipe): the landing page's
+ * "view taking shape" panel transplanted into the shell's loading moments.
+ * A frosted glass surface holds a pulse-dot status line and a grid of
+ * accent-tinted shimmer blocks laid out like the view actually forming —
+ * 3 stat tiles, a wide chart, two rows.
+ *
+ * Tokens are derived from the EXISTING host theme (styles.css): the shimmer
+ * tint is `--vendo-accent`, the radius is `--vendo-radius`, and the glass
+ * ground flips with the host scheme via `light-dark()` — no new theme keys.
+ * Real backdrop blur only works in shell chrome; inside the sandboxed iframe
+ * the translucent fill IS the fallback, which the recipe's background already
+ * provides. Reduced motion freezes the sweep; the blocks stay tinted.
+ *
+ * This is a different moment from FluidThinking (chat "thinking") — the two
+ * complement, never compete.
+ */
+
+export interface GlassSkeletonProps {
+  /** The pulse-dot status line. */
+  label?: string;
+}
+
+export function GlassSkeleton({ label = "Building your view…" }: GlassSkeletonProps) {
+  return (
+    <div className="fl-glass fl-glass-skeleton">
+      <div className="fl-glass-line">
+        <span className="fl-glass-dot" aria-hidden="true" />
+        {label}
+      </div>
+      <div className="fl-glass-grid" aria-hidden="true">
+        <div className="fl-glass-shimmer fl-glass-tile" />
+        <div className="fl-glass-shimmer fl-glass-tile" />
+        <div className="fl-glass-shimmer fl-glass-tile" />
+        <div className="fl-glass-shimmer fl-glass-chart" />
+        <div className="fl-glass-shimmer fl-glass-row" />
+        <div className="fl-glass-shimmer fl-glass-row is-short" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The shimmer OVER a stale view: an absolutely-positioned, pointer-transparent
+ * sweep for repaint moments (saved-vendo live refresh, remix pin edits) — the
+ * stale content stays readable underneath instead of flashing out. The parent
+ * container must be positioned (`position: relative`).
+ */
+export function GlassVeil() {
+  return <div className="fl-glass-veil fl-glass-shimmer" aria-hidden="true" />;
+}

--- a/packages/vendo-shell/src/components/IntegrationsPicker.tsx
+++ b/packages/vendo-shell/src/components/IntegrationsPicker.tsx
@@ -5,6 +5,10 @@ import { FluidThinking } from "./FluidThinking";
 
 export interface IntegrationsPickerProps {
   integrations: Integration[];
+  /** True while the FIRST list is still in flight — the grid holds its space
+   *  with glass shimmer placeholder rows instead of rendering empty. A
+   *  background refresh over an already-listed tray never blanks it. */
+  loading?: boolean;
   /** May return the connect flow's promise — the row shows a live connecting
    *  state until it settles and the refreshed list arrives. */
   onConnect: (id: string) => void | Promise<unknown>;
@@ -12,7 +16,10 @@ export interface IntegrationsPickerProps {
   onClose: () => void;
 }
 
-export function IntegrationsPicker({ integrations, onConnect, onDisconnect, onClose }: IntegrationsPickerProps) {
+/** Placeholder rows while the first list loads — mirrors the 2-col item grid. */
+const LOADING_ROWS = 4;
+
+export function IntegrationsPicker({ integrations, loading = false, onConnect, onDisconnect, onClose }: IntegrationsPickerProps) {
   const [query, setQuery] = useState("");
   // Rows with an OAuth flow in flight, and rows whose flip to connected was
   // OBSERVED here (those get the one-shot green celebration; rows that mount
@@ -127,6 +134,13 @@ export function IntegrationsPicker({ integrations, onConnect, onDisconnect, onCl
             strokeWidth="2" strokeLinecap="round" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12" /></svg>
         </button>
       </div>
+      {loading && integrations.length === 0 && (
+        <div className="fl-picker-grid fl-picker-loading" aria-hidden="true">
+          {Array.from({ length: LOADING_ROWS }, (_, i) => (
+            <div key={i} className="fl-glass-shimmer" />
+          ))}
+        </div>
+      )}
       {connected.length > 0 && (
         <>
           <div className="fl-picker-group">Connected</div>

--- a/packages/vendo-shell/src/components/Landing.tsx
+++ b/packages/vendo-shell/src/components/Landing.tsx
@@ -7,6 +7,8 @@ export interface LandingProps {
   greeting?: string;
   suggestions?: string[];
   flows?: Vendo[];
+  /** True while the host's first store list is in flight (glass skeleton cards). */
+  flowsLoading?: boolean;
   /** Hero composer slot: on the new-tab page the input sits up top (ENG-183
    *  gate, placement A), with the saved-vendo library beneath it. */
   composer?: ReactNode;
@@ -21,6 +23,7 @@ export function Landing({
   greeting = "What can I help you build?",
   suggestions = [],
   flows = [],
+  flowsLoading = false,
   composer,
   onSuggestion,
   onOpenFlow,
@@ -35,6 +38,7 @@ export function Landing({
       <SuggestionChips suggestions={suggestions} onSelect={onSuggestion} />
       <FlowGallery
         flows={flows}
+        loading={flowsLoading}
         onOpen={onOpenFlow}
         onRename={onRenameFlow}
         onPin={onPinFlow}

--- a/packages/vendo-shell/src/components/MessageList.tsx
+++ b/packages/vendo-shell/src/components/MessageList.tsx
@@ -7,7 +7,7 @@ import { ApprovalBatchCard } from "./ApprovalBatchCard";
 import { AutomationCard, isAutomationApproval } from "./AutomationCard";
 import { AutomationCreatedMorph, type AutomationCreatedNotice } from "./AutomationCreatedMorph";
 import { UINodeView } from "./UINodeView";
-import { Skeleton } from "./Skeleton";
+import { GlassSkeleton } from "./GlassSkeleton";
 import { ActivityPanel } from "./ActivityPanel";
 import { FadeProposalCard } from "./FadeProposalCard";
 import { TurnActions, type Feedback } from "./TurnActions";
@@ -228,11 +228,12 @@ export function MessageList({
                 </div>
               );
             case "skeleton":
-              // Shown only while render_view is in flight; never for text-only turns.
+              // Shown only while render_view is in flight; never for text-only
+              // turns. The glass panel (2026-07-05 recipe) carries its own
+              // pulse-dot status line + accent-tinted shimmer grid.
               return (
                 <FluidReveal key={slotKeys.get(item.key)} phase="skeleton">
-                  <div className="fl-generating"><span className="fl-pulse" />Building your view…</div>
-                  <Skeleton name={item.name} />
+                  <GlassSkeleton />
                 </FluidReveal>
               );
             case "approval":

--- a/packages/vendo-shell/src/components/OverlayPanel.tsx
+++ b/packages/vendo-shell/src/components/OverlayPanel.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import { themeToStyle } from "../theme";
 import { useShell } from "../context";
 import { useFocusTrap } from "../use-focus-trap";
+import { useMobileTakeover } from "../use-mobile-takeover";
 
 export interface OverlayPanelProps {
   open: boolean;
@@ -27,6 +28,9 @@ export function OverlayPanel({ open, onClose, ariaLabel, children }: OverlayPane
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
   useFocusTrap(open, panelRef);
+  // Below 768px the panel presents as a full-screen takeover (Intercom
+  // pattern) — same dialog, same focus trap, just the full-bleed face.
+  const takeover = useMobileTakeover();
 
   if (!open || !mounted) return null;
 
@@ -38,7 +42,7 @@ export function OverlayPanel({ open, onClose, ariaLabel, children }: OverlayPane
     <div className="vendo-root fl-overlay-portal" style={{ ...themeToStyle(theme), ...cssVars }}>
       <div className="fl-overlay-scrim" onClick={onClose} />
       <div
-        className="fl-overlay-panel"
+        className={takeover ? "fl-overlay-panel fl-takeover" : "fl-overlay-panel"}
         role="dialog"
         aria-modal="true"
         aria-label={ariaLabel}

--- a/packages/vendo-shell/src/components/approval-uinode.test.tsx
+++ b/packages/vendo-shell/src/components/approval-uinode.test.tsx
@@ -78,15 +78,54 @@ describe("ApprovalCard", () => {
     expect(screen.getByText("Confirm transfer money")).toBeTruthy();
   });
 
-  it("critical cards are summary-only too — the ceremony register carries the weight", () => {
-    const long = "x".repeat(300);
+  it("CRITICAL cards keep their material fields, humanized (Yousef 2026-07-05 amendment; ENG-193 §4.5)", () => {
+    // The summary-only decision holds for ordinary cards; critical (money /
+    // irreversible) must still show the human WHAT they are approving —
+    // proper labels + readable values, never a dev-ish raw param dump.
     const { container } = render(
-      <ApprovalCard toolName="transfer_money" input={{ note: long }} tier="critical" onApprove={() => {}} onDecline={() => {}} />,
+      <ApprovalCard
+        toolName="transfer_money"
+        input={{ amount: 1200, recipient_name: "Alex Rivera", memo_note: "October rent", cc: [] }}
+        tier="critical"
+        onApprove={() => {}}
+        onDecline={() => {}}
+      />,
     );
-    expect(container.querySelector(".fl-approval-fields")).toBeNull();
-    expect(screen.queryByText(long)).toBeNull();
+    expect(container.querySelector(".fl-approval-fields")).toBeTruthy();
+    expect(screen.getByText("Amount")).toBeTruthy();
+    expect(screen.getByText("1200")).toBeTruthy();
+    expect(screen.getByText("Recipient name")).toBeTruthy();
+    expect(screen.getByText("Alex Rivera")).toBeTruthy();
+    expect(screen.getByText("Memo note")).toBeTruthy();
+    expect(screen.getByText("October rent")).toBeTruthy();
+    // No-information fields stay hidden — humanized, never a raw dump.
+    expect(screen.queryByText("Cc")).toBeNull();
+    // The ceremony register is unchanged on top of the fields.
     expect(screen.getByText("This can't be undone.")).toBeTruthy();
     expect(screen.getByText("Confirm transfer money")).toBeTruthy();
+  });
+
+  it("critical cards never truncate a material field, even past 160 chars (ENG-193 §4.5 restored)", () => {
+    const long = "x".repeat(300);
+    render(
+      <ApprovalCard toolName="transfer_money" input={{ note: long }} tier="critical" onApprove={() => {}} onDecline={() => {}} />,
+    );
+    expect(screen.getByText(long)).toBeTruthy();
+  });
+
+  it("ordinary act-tier cards stay summary-only even with the same consequential-looking input", () => {
+    const { container } = render(
+      <ApprovalCard
+        toolName="transfer_money"
+        input={{ amount: 1200, recipient_name: "Alex Rivera" }}
+        tier="act"
+        onApprove={() => {}}
+        onDecline={() => {}}
+      />,
+    );
+    expect(container.querySelector(".fl-approval-fields")).toBeNull();
+    expect(screen.queryByText("Amount")).toBeNull();
+    expect(screen.queryByText("Alex Rivera")).toBeNull();
   });
 
   it("shows the unverified tag ONLY for genuinely unknown sources, never for catalog-known Composio tools", () => {

--- a/packages/vendo-shell/src/components/approval-uinode.test.tsx
+++ b/packages/vendo-shell/src/components/approval-uinode.test.tsx
@@ -33,20 +33,21 @@ describe("ApprovalCard", () => {
     expect(container.textContent).not.toContain("{");
   });
 
-  it("renders parameters as labelled fields and hides empty ones", () => {
-    render(
+  it("shows ONLY the human-readable summary — raw parameter key/values never render (Yousef: summary only)", () => {
+    const { container } = render(
       <ApprovalCard
         toolName="GMAIL_CREATE_EMAIL_DRAFT"
-        input={{ recipient_email: "a@b.com", subject: "Hi", cc: [], bcc: [], extra_recipients: [] }}
+        input={{ recipient_email: "a@b.com", subject: "Hi", user_id: "me", is_html: false }}
         onApprove={() => {}}
         onDecline={() => {}}
       />,
     );
-    expect(screen.getByText("Recipient email")).toBeTruthy();
-    expect(screen.getByText("a@b.com")).toBeTruthy();
-    expect(screen.getByText("Subject")).toBeTruthy();
-    expect(screen.queryByText("Cc")).toBeNull();
-    expect(screen.queryByText("Bcc")).toBeNull();
+    expect(screen.getByText("Create Gmail email draft?")).toBeTruthy();
+    // Removed entirely — not behind a disclosure.
+    expect(container.querySelector(".fl-approval-fields")).toBeNull();
+    expect(screen.queryByText(/is html/i)).toBeNull();
+    expect(screen.queryByText(/user id/i)).toBeNull();
+    expect(screen.queryByText("a@b.com")).toBeNull();
   });
 
   it("renders a bare title card for empty input", () => {
@@ -77,22 +78,33 @@ describe("ApprovalCard", () => {
     expect(screen.getByText("Confirm transfer money")).toBeTruthy();
   });
 
-  it("does not truncate material fields on a critical card even past 160 chars", () => {
+  it("critical cards are summary-only too — the ceremony register carries the weight", () => {
     const long = "x".repeat(300);
-    render(
+    const { container } = render(
       <ApprovalCard toolName="transfer_money" input={{ note: long }} tier="critical" onApprove={() => {}} onDecline={() => {}} />,
     );
-    expect(screen.getByText(long)).toBeTruthy();
+    expect(container.querySelector(".fl-approval-fields")).toBeNull();
+    expect(screen.queryByText(long)).toBeNull();
+    expect(screen.getByText("This can't be undone.")).toBeTruthy();
+    expect(screen.getByText("Confirm transfer money")).toBeTruthy();
   });
 
-  it("shows an unverified tag when the tool carries no annotation hints", () => {
+  it("shows the unverified tag ONLY for genuinely unknown sources, never for catalog-known Composio tools", () => {
+    // A stock Composio tool carries no annotations (so the policy flags it
+    // unverified), but its source is the known connect catalog — badge off.
     render(
       <ApprovalCard toolName="GMAIL_SEND_EMAIL" input={{}} tier="act" unverified onApprove={() => {}} onDecline={() => {}} />,
+    );
+    expect(screen.queryByText(/unverified/i)).toBeNull();
+
+    // An unclassified name (e.g. an MCP dynamic tool) keeps the badge.
+    render(
+      <ApprovalCard toolName="mystery_tool" input={{}} tier="act" unverified onApprove={() => {}} onDecline={() => {}} />,
     );
     expect(screen.getByText(/unverified/i)).toBeTruthy();
   });
 
-  it("act-tier (default) still truncates and keeps the plain 'Send it'/'No' buttons", () => {
+  it("act-tier (default) keeps the plain 'Send it'/'No' buttons", () => {
     const long = "x".repeat(300);
     render(<ApprovalCard toolName="GMAIL_SEND_EMAIL" input={{ note: long }} onApprove={() => {}} onDecline={() => {}} />);
     expect(screen.queryByText(long)).toBeNull();

--- a/packages/vendo-shell/src/components/automation-card.test.tsx
+++ b/packages/vendo-shell/src/components/automation-card.test.tsx
@@ -153,10 +153,10 @@ describe("AutomationCard (proposal state)", () => {
         onDecline={vi.fn()}
       />,
     );
-    // The generic ApprovalCard (post-#20 redesign, question-form title —
-    // ENG-193 §3 Moment 3): the input rendered as labelled fields.
+    // The generic ApprovalCard (summary-only, 2026-07-05): the question-form
+    // title carries the moment; raw input key/values never render.
     expect(screen.getByText("Create an automation?")).toBeTruthy();
-    expect(screen.getByText("Nonsense")).toBeTruthy();
-    expect(screen.getByText("true")).toBeTruthy();
+    expect(screen.queryByText("Nonsense")).toBeNull();
+    expect(screen.queryByText("true")).toBeNull();
   });
 });

--- a/packages/vendo-shell/src/components/flow-gallery.test.tsx
+++ b/packages/vendo-shell/src/components/flow-gallery.test.tsx
@@ -85,3 +85,23 @@ describe("VendoToast", () => {
     }
   });
 });
+
+describe("FlowGallery — loading state", () => {
+  it("holds the grid with glass shimmer cards while the library loads", () => {
+    const { container } = render(<FlowGallery flows={[]} loading onOpen={vi.fn()} />);
+    const cards = container.querySelectorAll(".fl-gallery .fl-flowcard-skel");
+    expect(cards.length).toBeGreaterThan(0);
+    expect(container.querySelector(".fl-library")?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("real cards win over the skeleton once flows exist", () => {
+    const { container } = render(<FlowGallery flows={[flow("a", "Real view")]} loading onOpen={vi.fn()} />);
+    expect(container.querySelector(".fl-flowcard-skel")).toBeNull();
+    expect(screen.getByText("Real view")).toBeTruthy();
+  });
+
+  it("still renders nothing when settled and empty", () => {
+    const { container } = render(<FlowGallery flows={[]} onOpen={vi.fn()} />);
+    expect(container.querySelector(".fl-library")).toBeNull();
+  });
+});

--- a/packages/vendo-shell/src/components/glass-skeleton.test.tsx
+++ b/packages/vendo-shell/src/components/glass-skeleton.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { GlassSkeleton, GlassVeil } from "./GlassSkeleton";
+
+describe("GlassSkeleton", () => {
+  it("renders the glass panel with a pulse-dot status line and the approved grid", () => {
+    const { container } = render(<GlassSkeleton />);
+    expect(container.querySelector(".fl-glass")).toBeTruthy();
+    // The status line is real text (screen readers hear the moment), with the
+    // decorative pulse dot hidden from them.
+    expect(screen.getByText("Building your view…")).toBeTruthy();
+    expect(container.querySelector(".fl-glass-dot")?.getAttribute("aria-hidden")).toBe("true");
+    // The approved layout: 3 stat tiles, one wide chart block, two rows.
+    const grid = container.querySelector(".fl-glass-grid");
+    expect(grid?.getAttribute("aria-hidden")).toBe("true");
+    expect(grid?.querySelectorAll(".fl-glass-tile")).toHaveLength(3);
+    expect(grid?.querySelectorAll(".fl-glass-chart")).toHaveLength(1);
+    expect(grid?.querySelectorAll(".fl-glass-row")).toHaveLength(2);
+    // Every block shimmers with the accent-tinted sweep.
+    expect(grid?.querySelectorAll(".fl-glass-shimmer")).toHaveLength(6);
+  });
+
+  it("takes a custom status label", () => {
+    render(<GlassSkeleton label="Refreshing your view…" />);
+    expect(screen.getByText("Refreshing your view…")).toBeTruthy();
+  });
+});
+
+describe("GlassVeil", () => {
+  it("renders a decorative shimmer overlay that never blocks the view under it", () => {
+    const { container } = render(<GlassVeil />);
+    const veil = container.querySelector(".fl-glass-veil");
+    expect(veil).toBeTruthy();
+    expect(veil?.getAttribute("aria-hidden")).toBe("true");
+  });
+});

--- a/packages/vendo-shell/src/components/integrations.test.tsx
+++ b/packages/vendo-shell/src/components/integrations.test.tsx
@@ -112,3 +112,29 @@ describe("ConnectCard", () => {
     expect(screen.getByText("So I can total up your invoices.")).toBeTruthy();
   });
 });
+
+describe("IntegrationsPicker — loading state", () => {
+  it("shows glass shimmer placeholder rows while the first list is in flight", () => {
+    const { container } = render(
+      <IntegrationsPicker integrations={[]} loading onConnect={() => {}} onDisconnect={() => {}} onClose={() => {}} />,
+    );
+    const placeholders = container.querySelectorAll(".fl-picker-grid .fl-glass-shimmer");
+    expect(placeholders.length).toBeGreaterThan(0);
+    expect(container.querySelector(".fl-picker-loading")?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("never blanks an already-listed tray during a background refresh", () => {
+    const { container } = render(
+      <IntegrationsPicker integrations={list} loading onConnect={() => {}} onDisconnect={() => {}} onClose={() => {}} />,
+    );
+    expect(container.querySelector(".fl-picker-loading")).toBeNull();
+    expect(screen.getByText("Gmail")).toBeTruthy();
+  });
+
+  it("shows no placeholders once loading settles on an empty catalog", () => {
+    const { container } = render(
+      <IntegrationsPicker integrations={[]} onConnect={() => {}} onDisconnect={() => {}} onClose={() => {}} />,
+    );
+    expect(container.querySelector(".fl-picker-loading")).toBeNull();
+  });
+});

--- a/packages/vendo-shell/src/components/message-list.test.tsx
+++ b/packages/vendo-shell/src/components/message-list.test.tsx
@@ -68,6 +68,26 @@ describe("MessageList", () => {
     expect(screen.getByTestId("ui-node")).toBeTruthy();
   });
 
+  it("renders the render_view placeholder as the glass skeleton panel", () => {
+    const { container } = render(
+      <VendoProvider agent={createStubAgent()} components={[]}>
+        <VendoShellProvider renderNode={() => <div data-testid="rendered" />}>
+          <MessageList
+            items={[{ kind: "skeleton", key: "m1:1", messageId: "m1", name: "SpendChart" }]}
+            status="streaming"
+            onApprove={vi.fn()}
+          />
+        </VendoShellProvider>
+      </VendoProvider>,
+    );
+    // The glass panel lives inside the persistent reveal slot, carrying its
+    // own pulse-dot "Building your view…" line and the tinted shimmer grid.
+    const panel = container.querySelector(".fl-reveal .fl-glass");
+    expect(panel).toBeTruthy();
+    expect(screen.getByText("Building your view…")).toBeTruthy();
+    expect(panel?.querySelectorAll(".fl-glass-shimmer").length).toBeGreaterThan(0);
+  });
+
   it("renders an error item with friendly copy — raw detail never reaches the DOM", () => {
     const { container } = renderList([
       { kind: "error", key: "e1", messageId: "m", message: "Something exploded" } as unknown as ThreadItem,

--- a/packages/vendo-shell/src/components/tool-labels.test.ts
+++ b/packages/vendo-shell/src/components/tool-labels.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { toolAction, humanize } from "./tool-labels";
+import { toolAction, humanize, isCatalogTool } from "./tool-labels";
 
 describe("toolAction", () => {
   it("keeps the hand-tuned host tool labels", () => {
@@ -81,5 +81,20 @@ describe("humanize", () => {
     expect(humanize("renderDemoCard")).toBe("Render Demo Card");
     expect(humanize("set_rule")).toBe("Set Rule");
     expect(humanize("GMAIL_FETCH")).toBe("Gmail Fetch");
+  });
+});
+
+describe("isCatalogTool", () => {
+  it("recognizes tools whose toolkit prefix is in the connect catalog", () => {
+    expect(isCatalogTool("GMAIL_SEND_EMAIL")).toBe(true);
+    expect(isCatalogTool("SLACK_API_TEST")).toBe(true);
+    expect(isCatalogTool("GOOGLECALENDAR_CREATE_EVENT")).toBe(true);
+  });
+
+  it("treats everything else as unclassified (MCP/dynamic names keep their badge)", () => {
+    expect(isCatalogTool("mystery_tool")).toBe(false);
+    expect(isCatalogTool("search_docs")).toBe(false);
+    expect(isCatalogTool("ACME_DO_THING")).toBe(false);
+    expect(isCatalogTool("transfer_money")).toBe(false);
   });
 });

--- a/packages/vendo-shell/src/components/tool-labels.ts
+++ b/packages/vendo-shell/src/components/tool-labels.ts
@@ -163,3 +163,17 @@ export function toolAction(toolName: string): ToolAction {
 export function friendlyLabel(toolName: string): string {
   return toolAction(toolName).active;
 }
+
+/**
+ * True when the tool's toolkit prefix is in the known connect catalog
+ * (Composio's TOOLKIT_ACTION naming) — i.e. its SOURCE is classified even
+ * though stock Composio tools ship no annotation hints. The consent card uses
+ * this to suppress the "Unverified tool" badge for catalog-known tools
+ * (Yousef, 2026-07-05) while unknown MCP/unclassified names keep it. Display
+ * classification only — the policy engine's own unverified mechanics
+ * (batching exemptions, fade/grant refusals) are untouched.
+ */
+export function isCatalogTool(toolName: string): boolean {
+  const prefix = toolName.split("_")[0]?.toUpperCase() ?? "";
+  return prefix in TOOLKITS;
+}

--- a/packages/vendo-shell/src/elements/VendoPage.tsx
+++ b/packages/vendo-shell/src/elements/VendoPage.tsx
@@ -5,6 +5,7 @@ import { VendoShellProvider } from "../context";
 import type { VendoStore } from "../seams/store";
 import type { VendoIntegrations } from "../seams/integrations";
 import { themeToStyle, type VendoTheme } from "../theme";
+import { useMobileTakeover } from "../use-mobile-takeover";
 import { VendoThread } from "../VendoThread";
 
 export interface VendoPageProps {
@@ -29,6 +30,9 @@ export function VendoPage(props: VendoPageProps) {
   const { agent, components, store, integrations, impls, theme, cssVars, greeting, suggestions } = props;
   const [tabs, setTabs] = useState<Tab[]>(() => [newTab()]);
   const [activeId, setActiveId] = useState<string>(() => tabs[0]!.id);
+  // Below 768px the page presents full-screen over the host layout (the
+  // Intercom takeover) — the host's mobile layout is covered, not our problem.
+  const takeover = useMobileTakeover();
 
   const addTab = () => {
     const tab = newTab();
@@ -37,7 +41,10 @@ export function VendoPage(props: VendoPageProps) {
   };
 
   return (
-    <div className="vendo-root fl-page" style={{ ...themeToStyle(theme), ...cssVars }}>
+    <div
+      className={takeover ? "vendo-root fl-page fl-takeover" : "vendo-root fl-page"}
+      style={{ ...themeToStyle(theme), ...cssVars }}
+    >
       <div className="fl-tabbar" role="tablist">
         {tabs.map((tab) => (
           <button

--- a/packages/vendo-shell/src/elements/takeover.test.tsx
+++ b/packages/vendo-shell/src/elements/takeover.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { createStubAgent } from "@vendoai/core/testing";
+import { VendoProvider } from "@vendoai/react";
+import { VendoShellProvider } from "../context";
+import { OverlayPanel } from "../components/OverlayPanel";
+import { VendoPage } from "./VendoPage";
+
+/** jsdom has no matchMedia — stub one whose max-width query reports `mobile`.
+ *  Every other query (e.g. prefers-reduced-motion) reports false, matching
+ *  the shell's existing one-off matchMedia reads. */
+function stubViewport(mobile: boolean) {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn((query: string) => ({
+      matches: query.includes("max-width") ? mobile : false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** Real surfaces (VendoOverlay, the slot's design overlay) always TRANSITION
+ *  closed→open — the focus trap arms on that transition, so the test opens
+ *  the same way instead of mounting pre-opened. */
+function mountOverlay() {
+  const ui = (open: boolean) => (
+    <VendoShellProvider>
+      <OverlayPanel open={open} onClose={() => {}} ariaLabel="Ask">
+        <button type="button">inside</button>
+      </OverlayPanel>
+    </VendoShellProvider>
+  );
+  const view = render(ui(false));
+  view.rerender(ui(true));
+  return view;
+}
+
+describe("mobile takeover (<768px)", () => {
+  it("the overlay panel presents full-screen below the breakpoint", () => {
+    stubViewport(true);
+    mountOverlay();
+    const panel = screen.getByRole("dialog");
+    expect(panel.className).toContain("fl-takeover");
+    // The close affordance stays reachable inside the takeover.
+    expect(screen.getByLabelText("Close")).toBeTruthy();
+    // The focus trap still lands focus on the content, not the document body.
+    expect(panel.contains(document.activeElement)).toBe(true);
+  });
+
+  it("the overlay panel keeps its centered-card presentation above the breakpoint", () => {
+    stubViewport(false);
+    mountOverlay();
+    expect(screen.getByRole("dialog").className).not.toContain("fl-takeover");
+  });
+
+  it("the page element presents full-screen below the breakpoint, and not above", () => {
+    stubViewport(true);
+    const { container, unmount } = render(
+      <VendoProvider agent={createStubAgent()} components={[]}>
+        <VendoPage agent={createStubAgent()} components={[]} />
+      </VendoProvider>,
+    );
+    expect(container.querySelector(".fl-page")?.className).toContain("fl-takeover");
+    unmount();
+
+    stubViewport(false);
+    const desktop = render(
+      <VendoProvider agent={createStubAgent()} components={[]}>
+        <VendoPage agent={createStubAgent()} components={[]} />
+      </VendoProvider>,
+    );
+    expect(desktop.container.querySelector(".fl-page")?.className).not.toContain("fl-takeover");
+  });
+});

--- a/packages/vendo-shell/src/index.ts
+++ b/packages/vendo-shell/src/index.ts
@@ -70,3 +70,4 @@ export * from "./elements/VendoOverlay";
 export * from "./elements/VendoSlot";
 export * from "./elements/VendoPage";
 export * from "./use-focus-trap";
+export * from "./use-mobile-takeover";

--- a/packages/vendo-shell/src/index.ts
+++ b/packages/vendo-shell/src/index.ts
@@ -37,6 +37,7 @@ export * from "./components/TurnActions";
 export * from "./components/AttachmentChips";
 export * from "./components/FileAttachment";
 export * from "./components/Skeleton";
+export * from "./components/GlassSkeleton";
 export * from "./components/ApprovalCard";
 export * from "./components/ApprovalBatchCard";
 export * from "./components/FadeProposalCard";

--- a/packages/vendo-shell/src/remix/VendoRemix.test.tsx
+++ b/packages/vendo-shell/src/remix/VendoRemix.test.tsx
@@ -189,3 +189,36 @@ describe("VendoRemix", () => {
     await waitFor(() => expect(screen.getByTestId("pinned-view")).toBeTruthy());
   });
 });
+
+describe("VendoRemix — repaint shimmer", () => {
+  it("veils the stale view while a remix-changed reload is in flight, then clears", async () => {
+    const node = pinnedNode(validPayload());
+    const pin = { anchorId: "w1", node, updatedAt: 1 };
+    let calls = 0;
+    let resolveSecond!: (p: typeof pin | null) => void;
+    const remixes: RemixClient = {
+      get: () => {
+        calls += 1;
+        if (calls === 1) return Promise.resolve(pin);
+        return new Promise((r) => { resolveSecond = r; });
+      },
+      pin: async (d) => ({ ...d, updatedAt: 2 }),
+      unpin: async () => {},
+    };
+    mount(
+      <VendoRemix id="w1" label="Widget">
+        <div>original</div>
+      </VendoRemix>,
+      { remixes },
+    );
+    await screen.findByTestId("pinned-view");
+    // Mount load is NOT a repaint — no veil on every page load.
+    expect(document.querySelector(".fl-glass-veil")).toBeNull();
+    act(() => {
+      window.dispatchEvent(new CustomEvent(REMIX_CHANGED_EVENT, { detail: { anchorId: "w1" } }));
+    });
+    await waitFor(() => expect(document.querySelector(".fl-glass-veil")).toBeTruthy());
+    await act(async () => { resolveSecond(pin); });
+    await waitFor(() => expect(document.querySelector(".fl-glass-veil")).toBeNull());
+  });
+});

--- a/packages/vendo-shell/src/remix/VendoRemix.tsx
+++ b/packages/vendo-shell/src/remix/VendoRemix.tsx
@@ -10,6 +10,7 @@ import {
 import { validateGeneratedPayload, type UINode } from "@vendoai/core";
 import { useShell } from "../context";
 import { diffHostComponents } from "../component-drift";
+import { GlassVeil } from "../components/GlassSkeleton";
 import type { RemixPin } from "../seams/remixes";
 import { snapshotElement } from "./snapshot";
 
@@ -85,9 +86,14 @@ export function VendoRemix({ id, label, context, className, children }: VendoRem
 
   // Guarded against unmount/id changes: a slow store resolving late must not
   // set a stale pin, and a pin for a different anchor never renders here.
+  // A CHANGED-event reload is a repaint (a pin edit landing on a mounted
+  // wrapper) — the glass veil shimmers over the stale view while it loads.
+  // Mount loads are not repaints: no veil on every page load.
   const loadToken = useRef(0);
-  const reload = useCallback(() => {
+  const [repainting, setRepainting] = useState(false);
+  const reload = useCallback((repaint = false) => {
     const token = ++loadToken.current;
+    if (repaint) setRepainting(true);
     remixes
       .get(id)
       .then((loaded) => {
@@ -97,6 +103,9 @@ export function VendoRemix({ id, label, context, className, children }: VendoRem
       .catch((err) => {
         console.warn(`[vendo] failed to load remix pin for "${id}"`, err);
         if (loadToken.current === token) setPin(null);
+      })
+      .finally(() => {
+        if (loadToken.current === token) setRepainting(false);
       });
   }, [remixes, id]);
   useEffect(() => {
@@ -107,7 +116,7 @@ export function VendoRemix({ id, label, context, className, children }: VendoRem
   }, [reload]);
   useEffect(() => {
     const onChange = (e: Event) => {
-      if ((e as CustomEvent<{ anchorId?: string }>).detail?.anchorId === id) reload();
+      if ((e as CustomEvent<{ anchorId?: string }>).detail?.anchorId === id) reload(true);
     };
     window.addEventListener(REMIX_CHANGED_EVENT, onChange);
     return () => window.removeEventListener(REMIX_CHANGED_EVENT, onChange);
@@ -175,6 +184,7 @@ export function VendoRemix({ id, label, context, className, children }: VendoRem
           children
         )}
       </div>
+      {repainting && <GlassVeil />}
       {mounted && (
         <button
           type="button"

--- a/packages/vendo-shell/src/reopen.test.tsx
+++ b/packages/vendo-shell/src/reopen.test.tsx
@@ -155,6 +155,29 @@ describe("useReopenVendo", () => {
     });
   });
 
+  it("reports refreshing while a live-refresh tick is in flight (the shimmer-over-stale seam)", async () => {
+    const store = createLocalStore();
+    const vendo = await store.save({
+      id: "f1", name: "Tx",
+      node: genNode({ tx: [0] }, [{ path: "/tx", tool: "get_transactions" }]),
+    });
+    let first = true;
+    let releaseTick!: (v: unknown) => void;
+    const gate = new Promise((r) => { releaseTick = r; });
+    const runQuery = vi.fn(async () => {
+      if (first) { first = false; return [1]; }
+      await gate;
+      return [2];
+    });
+    const { result } = renderHook(() => useReopenVendo(vendo), { wrapper: wrap(store, runQuery, 40) });
+    await waitFor(() => expect(result.current.status).toBe("live"));
+    // A tick starts and hangs — the consumer can shimmer over the stale view.
+    await waitFor(() => expect(result.current.refreshing).toBe(true), { timeout: 3000 });
+    releaseTick(null);
+    // The hung tick lands: the veil clears again between ticks.
+    await waitFor(() => expect(result.current.refreshing).toBe(false));
+  });
+
   it("pauses live refresh while the document is hidden", async () => {
     const store = createLocalStore();
     const vendo = await store.save({

--- a/packages/vendo-shell/src/reopen.ts
+++ b/packages/vendo-shell/src/reopen.ts
@@ -129,6 +129,10 @@ export function useReopenVendo(
     const runOnce = async (initial: boolean) => {
       if (inFlight) return;
       inFlight = true;
+      // Every in-flight refresh — the initial reopen AND interval ticks —
+      // reports `refreshing`, so consumers can shimmer over the stale view
+      // (the glass veil) instead of flashing when fresh data lands.
+      setRefreshing(true);
       try {
         const fresh = await refreshVendoNode(baseNode, runQuery);
         if (cancelled) return;
@@ -158,13 +162,11 @@ export function useReopenVendo(
         }
       } finally {
         inFlight = false;
+        if (!cancelled) setRefreshing(false);
       }
     };
 
-    setRefreshing(true);
-    void runOnce(true).finally(() => {
-      if (!cancelled) setRefreshing(false);
-    });
+    void runOnce(true);
 
     if (refreshIntervalMs > 0) {
       timer = setInterval(() => {

--- a/packages/vendo-shell/src/styles.css
+++ b/packages/vendo-shell/src/styles.css
@@ -211,6 +211,49 @@
   background-size: 400% 100%; animation: fl-shimmer 1.5s ease infinite; border-radius: 6px; }
 @keyframes fl-shimmer { 0% { background-position: 100% 0; } 100% { background-position: 0 0; } }
 
+/* ---------- glass skeleton (2026-07-05 recipe): a view taking shape ---------- */
+/* The glass ground: translucent fill + hairline white border + inset highlight,
+   frosted for real in shell chrome (inside the sandbox iframe backdrop-filter
+   can't see the host page — the translucent fill IS the fallback there). Both
+   grounds flip with the host scheme; tint and radius come from the existing
+   theme tokens — no new theme keys. */
+.fl-glass { border-radius: var(--vendo-radius); padding: 15px 16px;
+  background: light-dark(rgba(255,255,255,.42), rgba(22,24,30,.55));
+  border: 1px solid light-dark(rgba(255,255,255,.65), rgba(255,255,255,.14));
+  box-shadow: 0 4px 24px light-dark(rgba(23,23,26,.06), rgba(0,0,0,.35)),
+    inset 0 1px 0 light-dark(rgba(255,255,255,.8), rgba(255,255,255,.08));
+  -webkit-backdrop-filter: blur(14px) saturate(160%); backdrop-filter: blur(14px) saturate(160%); }
+.fl-glass-skeleton { align-self: flex-start; width: 100%; }
+.fl-glass-line { display: flex; align-items: center; gap: 9px;
+  font: 500 13.5px/1.4 var(--vendo-font); color: var(--vendo-fg); }
+.fl-glass-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--vendo-accent);
+  flex-shrink: 0; animation: fl-glass-pulse 1.6s ease-in-out infinite; }
+@keyframes fl-glass-pulse { 50% { transform: scale(1.25); opacity: 1; } }
+/* Shimmer blocks: the HOST ACCENT at .10→.22→.10 (light) / .16→.32→.16 (dark),
+   sweeping 1.8s — the recipe's exact tint ramp via color-mix instead of a
+   precomputed rgb triplet. */
+.fl-glass-shimmer { border-radius: 10px;
+  background: linear-gradient(100deg,
+    light-dark(color-mix(in srgb, var(--vendo-accent) 10%, transparent), color-mix(in srgb, var(--vendo-accent) 16%, transparent)) 30%,
+    light-dark(color-mix(in srgb, var(--vendo-accent) 22%, transparent), color-mix(in srgb, var(--vendo-accent) 32%, transparent)) 50%,
+    light-dark(color-mix(in srgb, var(--vendo-accent) 10%, transparent), color-mix(in srgb, var(--vendo-accent) 16%, transparent)) 70%);
+  background-size: 200% 100%; animation: fl-glass-shimmer 1.8s linear infinite; }
+@keyframes fl-glass-shimmer { from { background-position: 120% 0; } to { background-position: -80% 0; } }
+/* The approved grid: a view forming — 3 stat tiles, a wide chart, two rows. */
+.fl-glass-grid { display: grid; gap: 8px; margin-top: 12px; grid-template-columns: repeat(3, 1fr); }
+.fl-glass-tile { height: 44px; }
+.fl-glass-chart { grid-column: span 3; height: 96px; }
+.fl-glass-row { grid-column: span 3; height: 18px; }
+.fl-glass-row.is-short { width: 72%; }
+/* Repaint veil: the shimmer OVER a stale view (saved-vendo refresh, remix pin
+   edits) instead of a flash — pointer-transparent, content stays readable. */
+.fl-glass-veil { position: absolute; inset: 0; z-index: 4; pointer-events: none;
+  border-radius: var(--vendo-radius); }
+/* Library skeleton cards + integrations tray placeholder rows. */
+.fl-flowcard-skel { height: 74px; border: 1px solid var(--vendo-border);
+  border-radius: var(--vendo-radius); }
+.fl-picker-loading .fl-glass-shimmer { height: 46px; border-radius: 11px; }
+
 /* ---------- tool chip (kept quiet; most are hidden in the thread) ---------- */
 .fl-tool { align-self: flex-start; display: flex; align-items: center; gap: 8px;
   font: 500 12px/1 var(--vendo-font); color: var(--vendo-fg-muted);
@@ -730,6 +773,8 @@
   .fl-typing span, .fl-generating .fl-pulse, .fl-skeleton-bar,
   .fl-tool-spin, .fl-tool-spinner, .fl-act-pulse, .fl-act-spin,
   .fl-auto-created-live::after { animation: none; }
+  /* Glass skeleton: the sweep and pulse freeze; the blocks stay tinted. */
+  .fl-glass-shimmer, .fl-glass-dot { animation: none; }
   .fl-picker-item.is-just-connected, .fl-picker-item.is-just-connected .fl-picker-on { animation: none; }
   .fl-msglist-wrap, .fl-jump, .fl-md--streaming > * { animation: none; opacity: 1; }
 }
@@ -757,7 +802,8 @@
 .fl-page-body { flex: 1; min-height: 0; display: flex; flex-direction: column; }
 .fl-page-pane { flex: 1; min-height: 0; display: flex; flex-direction: column; }
 .fl-page-pane[hidden] { display: none; }
-.fl-saved-pane { flex: 1; min-height: 0; overflow: auto; padding: 22px 2px; }
+/* position: relative anchors the glass refresh veil over a reopened view. */
+.fl-saved-pane { position: relative; flex: 1; min-height: 0; overflow: auto; padding: 22px 2px; }
 .fl-slot-empty { border: 1.5px dashed var(--vendo-border-strong); border-radius: var(--vendo-radius);
   display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 9px;
   padding: 24px; cursor: pointer; background: var(--vendo-glass-strong); color: var(--vendo-fg-muted);

--- a/packages/vendo-shell/src/styles.css
+++ b/packages/vendo-shell/src/styles.css
@@ -778,6 +778,31 @@
   .fl-picker-item.is-just-connected, .fl-picker-item.is-just-connected .fl-picker-on { animation: none; }
   .fl-msglist-wrap, .fl-jump, .fl-md--streaming > * { animation: none; opacity: 1; }
 }
+
+/* ---------- full-screen mobile takeover (<768px, Intercom pattern) ---------- */
+/* The `fl-takeover` class is stamped by useMobileTakeover (matchMedia) on the
+   surface containers — the overlay panel (the Cmd+K overlay AND the slot's
+   design overlay share OverlayPanel) and the page element. Full bleed, its own
+   stacking context, internal scrolling (only .fl-msglist scrolls), the
+   composer pinned at the bottom inside the safe area, the close X reachable
+   under the notch. Host layout below the breakpoint is covered, not fixed. */
+.fl-overlay-panel.fl-takeover { left: 0; top: 0; transform: none;
+  width: 100%; height: 100%; max-width: none; max-height: none;
+  border: 0; border-radius: 0; isolation: isolate;
+  padding: env(safe-area-inset-top, 0px) env(safe-area-inset-right, 0px)
+    env(safe-area-inset-bottom, 0px) env(safe-area-inset-left, 0px);
+  /* The centered "squeeze" keyframes carry translate(-50%,-50%) — full bleed
+     fades in instead of flying in from mid-screen. */
+  animation: fl-takeover-fade .18s ease both; }
+@keyframes fl-takeover-fade { from { opacity: 0; } to { opacity: 1; } }
+.fl-overlay-panel.fl-takeover .fl-overlay-close {
+  top: calc(12px + env(safe-area-inset-top, 0px));
+  right: calc(12px + env(safe-area-inset-right, 0px)); }
+.fl-page.fl-takeover { position: fixed; inset: 0; z-index: 2147483001; isolation: isolate;
+  background: var(--vendo-bg);
+  padding: env(safe-area-inset-top, 0px) env(safe-area-inset-right, 0px)
+    env(safe-area-inset-bottom, 0px) env(safe-area-inset-left, 0px); }
+
 .fl-launcher { display: inline-flex; align-items: center; gap: 8px; border: 1px solid var(--vendo-border);
   border-radius: 999px; padding: 10px 15px; font-size: 13px; font-weight: 600; color: var(--vendo-fg);
   background: var(--vendo-glass-strong); -webkit-backdrop-filter: var(--vendo-blur); backdrop-filter: var(--vendo-blur);

--- a/packages/vendo-shell/src/use-mobile-takeover.ts
+++ b/packages/vendo-shell/src/use-mobile-takeover.ts
@@ -1,0 +1,33 @@
+import { useSyncExternalStore } from "react";
+
+/** Below this viewport width every open Vendo surface presents full-screen
+ *  (the Intercom pattern) — host layout below the breakpoint is covered, not
+ *  negotiated with. One breakpoint, no per-host configuration in v1. */
+export const MOBILE_TAKEOVER_QUERY = "(max-width: 767px)";
+
+function subscribe(onChange: () => void): () => void {
+  if (typeof matchMedia === "undefined") return () => {};
+  const mql = matchMedia(MOBILE_TAKEOVER_QUERY);
+  // Modern MediaQueryList is an EventTarget; older Safari only has addListener.
+  if (typeof mql.addEventListener === "function") {
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }
+  mql.addListener(onChange);
+  return () => mql.removeListener(onChange);
+}
+
+function getSnapshot(): boolean {
+  return typeof matchMedia !== "undefined" && matchMedia(MOBILE_TAKEOVER_QUERY).matches;
+}
+
+/**
+ * True when the viewport is below the mobile-takeover breakpoint. Surface
+ * containers (the overlay panel, the page element — the slot's design overlay
+ * rides the shared OverlayPanel) add the `fl-takeover` class on it; styles.css
+ * carries the actual full-screen presentation, so this stays CSS-first with
+ * matchMedia only picking which face is live. SSR renders desktop.
+ */
+export function useMobileTakeover(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}

--- a/packages/vendo-shell/src/use-vendo-thread.test.ts
+++ b/packages/vendo-shell/src/use-vendo-thread.test.ts
@@ -41,6 +41,28 @@ describe("toThreadItems", () => {
     });
   });
 
+  it("a DYNAMIC approval carries its toolCallId + sibling data-consent tier — the consent POST must not be dropped (MCP gap)", () => {
+    // Without toolCallId the shell's approve() silently skipped the consent
+    // POST for MCP tools, bypassing the audit/grant channel host tools use.
+    const items = toThreadItems([
+      msg("m2d", "assistant", [
+        {
+          type: "dynamic-tool",
+          toolName: "everything_echo",
+          toolCallId: "call-mcp-1",
+          state: "approval-requested",
+          approval: { id: "a9" },
+          input: { message: "hi" },
+        },
+        { type: "data-consent", data: { toolCallId: "call-mcp-1", tier: "act", unverified: true } },
+      ]),
+    ]);
+    expect(items[0]).toEqual({
+      kind: "approval", key: "m2d:0", messageId: "m2d", approvalId: "a9", toolCallId: "call-mcp-1",
+      toolName: "everything_echo", input: { message: "hi" }, tier: "act", unverified: true,
+    });
+  });
+
   it("emits a tool item for a dynamic tool part in other states", () => {
     const items = toThreadItems([
       msg("m3d", "assistant", [

--- a/packages/vendo-shell/src/use-vendo-thread.ts
+++ b/packages/vendo-shell/src/use-vendo-thread.ts
@@ -154,21 +154,32 @@ export function toThreadItems(messages: VendoUIMessage[]): ThreadItem[] {
         // carry their name in `toolName` instead of the part type. Same
         // approval/chip treatment as static tool parts; RENDER_TOOLS never
         // ingest as dynamic, so no skeleton branch is needed here.
+        // toolCallId MUST ride along (MCP consent gap, 2026-07-05): without
+        // it the shell's approve()/decline() silently skipped the consent
+        // POST, so MCP approvals bypassed the audit/grant channel host tools
+        // use. The sibling data-consent tier pairs by the same id.
         const toolName = String(part.toolName ?? "unknown");
+        const toolCallId = part.toolCallId as string | undefined;
+        const tierInfo = toolCallId ? tierByToolCallId.get(toolCallId) : undefined;
         if (part.state === "approval-requested") {
           const approval = part.approval as { id: string };
-          items.push({ kind: "approval", key, messageId, approvalId: approval.id, toolName, input: part.input });
+          items.push({
+            kind: "approval", key, messageId, approvalId: approval.id, toolCallId, toolName, input: part.input,
+            tier: tierInfo?.tier, unverified: tierInfo?.unverified,
+            ...(tierInfo?.reason ? { reason: tierInfo.reason } : {}),
+          });
         } else {
           items.push({
             kind: "tool",
             key,
             messageId,
             toolName,
-            toolCallId: part.toolCallId as string | undefined,
+            toolCallId,
             state: String(part.state ?? ""),
             input: part.input,
             output: part.output,
             errorText: part.errorText as string | undefined,
+            tier: tierInfo?.tier, unverified: tierInfo?.unverified,
           });
         }
       } else if (part.type.startsWith("tool-")) {


### PR DESCRIPTION
## What

The four UI changes Yousef approved on 2026-07-05, browser-verified on the integration build. Stacked on #66 (client/state). 5 commits, TDD'd. **Screenshots: `~/Desktop/vendo-ui-bash-2026-07-05/final-verification.html`** (5 of 6 fixes verified working in-browser).

1. **Glass skeleton loading states** — the landing page's glass+shimmer recipe, tinted from each host's theme accent, now fills the render_view placeholder, the saved-vendo refresh veil, and library/tray loading. FluidThinking still owns chat thinking (different moment). *Verified.*
2. **Full-screen mobile takeover** — below 768px any open Vendo surface takes over full-screen (Intercom pattern): fixed, composer pinned and visible, close reachable; reverts to the inset panel above the breakpoint. Fixes the old clipped-composer breakage. *Verified.*
3. **Summary-only consent card** — ordinary cards show only the human summary (no raw `Is html`/`User id` params, no "Unverified tool" badge on catalog Composio tools). Per Yousef's amendment, **critical-tier cards keep their material fields, humanized** (Amount, Recipient — not a raw dump). *Ordinary verified; critical unit-tested (no demo exposes a money tool for a live shot).*
4. **MCP approvals through the consent channel** — MCP dynamic-tool approvals dropped the toolCallId and skipped the consent/audit/grant pipeline; they now go through the same ConsentRequest/audit path as host tools (server test proves the audit-row parity).

### Verified alongside this wave (fixes from stacked PRs, re-confirmed on the integration build)
- Decline semantics: declining no longer re-pitches; re-proposes only on new intent.
- Donut center: the $40.18 (100×) bug is gone — center now $4,017.81 = legend sum (PR #65's deterministic fix + descriptor).

### For your call (in the decisions doc, non-blocking)
- **Chart brand palettes** — root-caused: OpenUI 0.12.1 ignores the `*ChartPalette` keys entirely, so brand chart colors never applied in either demo; this batch silenced the false-positive warnings (net improvement). Real brand-chart theming is a follow-up.
- **Critical-card live screenshot** — needs a demo with a genuine money/irreversible tool.

`pnpm typecheck` 27/27 · `pnpm test` 25/25.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds glass skeleton/veil loading states and a full-screen mobile takeover for smoother load and mobile experiences. Refines consent: ordinary cards are summary-only, critical cards show material fields, and MCP dynamic tools now use the audited consent channel.

- **New Features**
  - Glass skeletons and veils: shown for render_view placeholders, saved-vendo refresh, and remix repaints; library and integrations tray show shimmer placeholders on first load (no new theme tokens; tinted by `--vendo-accent`). Aligns with ENG-183.
  - Mobile takeover (<768px): `OverlayPanel` and `VendoPage` present full-screen with safe-area insets and intact focus trap; composer remains pinned. Fixes prior clipped composer.
  - Consent UI: ordinary approval cards show only the human summary; critical-tier cards restore humanized, non-truncated material fields. Suppress the "Unverified tool" badge for catalog Composio tools. Aligns with ENG-193.

- **Bug Fixes**
  - MCP approvals now use the same consent/audit path as host tools: dynamic-tool parts carry `toolCallId`, `toThreadItems` pairs consent data, and `handleConsent` treats `dynamic-tool` like `tool-*` (name cross-check updated). Server route records the same consent audit row; runtime mints the implicit allow-once grant when resolvable.

<sup>Written for commit 590e0a56127c91ebdb490cec15e0b82fe200d9d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

