### PR TITLE
Hardening wave 7: integrations + telemetry honesty

### DIFF
--- a/packages/vendo-next/src/client/integrations.test.ts
+++ b/packages/vendo-next/src/client/integrations.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createServerIntegrations } from "./integrations.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("createServerIntegrations.disconnect", () => {
+  it("throws and does not mark the row disconnected when the server rejects", async () => {
+    const fetchMock = vi.fn(async () => new Response("nope", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const integrations = createServerIntegrations("/api/vendo");
+    await expect(integrations.disconnect("gmail")).rejects.toThrow();
+  });
+
+  it("updates the cache and returns disconnected on an ok response", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ integrations: [{ id: "gmail", name: "Gmail", connected: false }] }), {
+          status: 200,
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const integrations = createServerIntegrations("/api/vendo");
+    const result = await integrations.disconnect("gmail");
+    expect(result).toEqual({ id: "gmail", name: "Gmail", connected: false });
+  });
+});

--- a/packages/vendo-next/src/client/integrations.ts
+++ b/packages/vendo-next/src/client/integrations.ts
@@ -51,10 +51,11 @@ export function createServerIntegrations(basePath: string): VendoIntegrations {
         body: JSON.stringify({ id, action: "disconnect" }),
         cache: "no-store",
       });
-      if (res.ok) {
-        const json = (await res.json()) as { integrations?: Integration[] };
-        if (json.integrations) cache = json.integrations;
-      }
+      // Mirror connect(): surface a server reject instead of silently claiming
+      // success. Leave the cache untouched so the row keeps its real state.
+      if (!res.ok) throw new Error(`disconnect failed: ${res.status}`);
+      const json = (await res.json()) as { integrations?: Integration[] };
+      if (json.integrations) cache = json.integrations;
       return { ...find(id), connected: false };
     },
   };

--- a/packages/vendo-server/src/integrations.test.ts
+++ b/packages/vendo-server/src/integrations.test.ts
@@ -103,6 +103,24 @@ describe("integrations endpoints", () => {
     expect(await d.store.connectedToolkits()).toEqual([]);
   });
 
+  it("status poll reports 'active' only when the store write happened; a foreign active account is not connected (review)", async () => {
+    // Composio says the polled account is ACTIVE, but it is not THIS user's
+    // connection for THIS toolkit → the store was never written, so the
+    // client-facing status must NOT read as connected.
+    const d = deps({
+      client: stubClient({
+        connectionStatus: async () => "active" as const,
+        hasActiveConnection: async () => false,
+      }),
+    });
+    const res = await handleIntegrationsGet(
+      get("/api/vendo/integrations?status&id=gmail&account=foreign-acct"),
+      d,
+    );
+    expect(await res.json()).toEqual({ status: "pending" });
+    expect(await d.store.connectedToolkits()).toEqual([]);
+  });
+
   it("rejects an unknown toolkit id before spending the Composio key (review P1)", async () => {
     let authorizeCalls = 0;
     const d = deps({

--- a/packages/vendo-server/src/integrations.test.ts
+++ b/packages/vendo-server/src/integrations.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ComposioClient } from "@vendoai/runtime";
 import { WORLD_SCOPE } from "./guard.js";
 import {
@@ -119,6 +119,28 @@ describe("integrations endpoints", () => {
     );
     expect(await res.json()).toEqual({ status: "pending" });
     expect(await d.store.connectedToolkits()).toEqual([]);
+  });
+
+  it("status poll logs server-side and reports transient 'pending' when Composio throws (review)", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const d = deps({
+        client: stubClient({
+          connectionStatus: async () => {
+            throw new Error("composio blip");
+          },
+        }),
+      });
+      const res = await handleIntegrationsGet(
+        get("/api/vendo/integrations?status&id=gmail&account=acc-1"),
+        d,
+      );
+      // A poll error is transient, not terminal — client keeps polling.
+      expect(await res.json()).toEqual({ status: "pending" });
+      expect(errSpy).toHaveBeenCalled();
+    } finally {
+      errSpy.mockRestore();
+    }
   });
 
   it("rejects an unknown toolkit id before spending the Composio key (review P1)", async () => {

--- a/packages/vendo-server/src/integrations.ts
+++ b/packages/vendo-server/src/integrations.ts
@@ -82,8 +82,12 @@ export async function handleIntegrationsGet(req: Request, deps: IntegrationsDeps
       // account) must not read as connected — downgrade it to "pending" so the
       // client keeps polling instead of showing connected with no toolkit.
       return Response.json({ status: status === "active" ? ("pending" as const) : status });
-    } catch {
-      return Response.json({ status: "failed" as const });
+    } catch (err) {
+      // A poll error is usually a transient Composio hiccup, not a terminal
+      // failure. Log it server-side like the connect handler does, and report
+      // "pending" so the client keeps polling rather than latching "failed".
+      console.error("[vendo] integrations status poll failed:", err);
+      return Response.json({ status: "pending" as const });
     }
   }
   return Response.json({ enabled: true, integrations: await deps.store.list() });

--- a/packages/vendo-server/src/integrations.ts
+++ b/packages/vendo-server/src/integrations.ts
@@ -75,8 +75,13 @@ export async function handleIntegrationsGet(req: Request, deps: IntegrationsDeps
         // a toolkit for webhook routing (findByConnectedAccount). Subsumes
         // connect(id)'s effect (marks the toolkit connected too).
         await deps.store.setConnectedAccount(id, account);
+        return Response.json({ status: "active" as const });
       }
-      return Response.json({ status });
+      // The client-facing status must reflect what actually happened. A raw
+      // "active" we did NOT record (anti-spoof case: foreign/other-toolkit
+      // account) must not read as connected — downgrade it to "pending" so the
+      // client keeps polling instead of showing connected with no toolkit.
+      return Response.json({ status: status === "active" ? ("pending" as const) : status });
     } catch {
       return Response.json({ status: "failed" as const });
     }

--- a/packages/vendo-server/src/telemetry-dev.test.ts
+++ b/packages/vendo-server/src/telemetry-dev.test.ts
@@ -1,7 +1,22 @@
 import { describe, it, expect, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { devTelemetry } from "./telemetry-dev.js";
 
 describe("devTelemetry", () => {
+  it("shows the first-run notice instead of burning it into a no-op sink (review)", () => {
+    const home = mkdtempSync(join(tmpdir(), "vendo-dev-notice-"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      devTelemetry({ env: { NODE_ENV: "development" }, posthogKey: "phc", fetchImpl: vi.fn(), home });
+      expect(errSpy.mock.calls.some((c) => String(c[0]).includes("TELEMETRY.md"))).toBe(true);
+    } finally {
+      errSpy.mockRestore();
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it("emits agent_run in development", async () => {
     const fetchImpl = vi.fn().mockResolvedValue({ ok: true });
     const t = devTelemetry({ env: { NODE_ENV: "development" }, posthogKey: "phc", fetchImpl, home: undefined });

--- a/packages/vendo-server/src/telemetry-dev.ts
+++ b/packages/vendo-server/src/telemetry-dev.ts
@@ -17,7 +17,9 @@ export function devTelemetry(opts: DevTelemetryOptions = {}): Telemetry {
     home: opts.home,
     posthogKey: opts.posthogKey ?? env.VENDO_POSTHOG_KEY,
     fetchImpl: opts.fetchImpl,
-    log: () => {},
+    // No log override: let initTelemetry emit the one-time disclosure to a real
+    // sink (console.error). A no-op sink here marked the notice "shown" while
+    // showing nothing, so collection proceeded without ever disclosing it.
   });
 }
 

--- a/packages/vendo-telemetry/src/client.test.ts
+++ b/packages/vendo-telemetry/src/client.test.ts
@@ -53,6 +53,22 @@ describe("createTelemetry.track", () => {
     expect(body.properties.framework).toBe("next");
   });
 
+  it("caps oversized string values on an allowed key (review)", async () => {
+    const deps = makeDeps();
+    const t = createTelemetry(deps);
+    await t.track("init_started", { framework: "a".repeat(5000) });
+    const body = JSON.parse((deps.fetchImpl.mock.calls[0][1] as { body: string }).body);
+    expect(body.properties.framework.length).toBeLessThanOrEqual(512);
+  });
+
+  it("drops object/array values even on an allowed key (review)", async () => {
+    const deps = makeDeps();
+    const t = createTelemetry(deps);
+    await t.track("init_started", { framework: { nested: "secret" } } as never);
+    const body = JSON.parse((deps.fetchImpl.mock.calls[0][1] as { body: string }).body);
+    expect(body.properties.framework).toBeUndefined();
+  });
+
   it("never throws when fetch rejects", async () => {
     const deps = makeDeps({ fetchImpl: vi.fn().mockRejectedValue(new Error("network")) });
     const t = createTelemetry(deps);

--- a/packages/vendo-telemetry/src/client.ts
+++ b/packages/vendo-telemetry/src/client.ts
@@ -27,10 +27,27 @@ export interface Telemetry {
   track(event: EventName, props: Record<string, unknown>): Promise<void>;
 }
 
+const MAX_STRING_LEN = 512;
+
+/**
+ * Bound an allowed value to a primitive: cap oversized strings and drop
+ * anything non-primitive (objects, arrays, null) so an allowed key can't smuggle
+ * an arbitrary or oversized payload through the allowlist.
+ */
+function boundValue(v: unknown): string | number | boolean | undefined {
+  if (typeof v === "string") return v.length > MAX_STRING_LEN ? v.slice(0, MAX_STRING_LEN) : v;
+  if (typeof v === "number" || typeof v === "boolean") return v;
+  return undefined;
+}
+
 function filterToAllowlist(event: EventName, props: Record<string, unknown>): Record<string, unknown> {
   const allowed = EVENT_ALLOWLIST[event];
   const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(props)) if (allowed.has(k)) out[k] = v;
+  for (const [k, v] of Object.entries(props)) {
+    if (!allowed.has(k)) continue;
+    const bounded = boundValue(v);
+    if (bounded !== undefined) out[k] = bounded;
+  }
   return out;
 }
 

--- a/packages/vendo-telemetry/src/config.test.ts
+++ b/packages/vendo-telemetry/src/config.test.ts
@@ -41,4 +41,16 @@ describe("config store", () => {
     const c = loadConfig(home);
     expect(c.optedOut).toBe(true);
   });
+
+  it("does not mint or persist a tracking id when an env opt-out is set (review)", () => {
+    const c = loadConfig(home, { DO_NOT_TRACK: "1" });
+    expect(c.optedOut).toBe(true);
+    expect(existsSync(configPath(home))).toBe(false);
+  });
+
+  it("still writes a normal opted-in config on first run without env opt-out (review)", () => {
+    const c = loadConfig(home, {});
+    expect(c.optedOut).toBe(false);
+    expect(existsSync(configPath(home))).toBe(true);
+  });
 });

--- a/packages/vendo-telemetry/src/config.test.ts
+++ b/packages/vendo-telemetry/src/config.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadConfig, saveConfig, configPath } from "./config.js";
+import { loadConfig, saveConfig, configPath, configDir } from "./config.js";
 
 let home: string;
 beforeEach(() => {
@@ -33,5 +33,12 @@ describe("config store", () => {
     const reread = loadConfig(home);
     expect(reread.optedOut).toBe(true);
     expect(reread.noticeShown).toBe(true);
+  });
+
+  it("honors a hand-written opt-out even without an anonymous id (review)", () => {
+    mkdirSync(configDir(home), { recursive: true });
+    writeFileSync(configPath(home), JSON.stringify({ optedOut: true }), "utf8");
+    const c = loadConfig(home);
+    expect(c.optedOut).toBe(true);
   });
 });

--- a/packages/vendo-telemetry/src/config.test.ts
+++ b/packages/vendo-telemetry/src/config.test.ts
@@ -53,4 +53,13 @@ describe("config store", () => {
     expect(c.optedOut).toBe(false);
     expect(existsSync(configPath(home))).toBe(true);
   });
+
+  it("degrades to an in-memory config when the config dir can't be written (review)", () => {
+    // Make configDir un-creatable: a file where the .vendo parent must be a dir.
+    const badHome = join(home, "as-file");
+    writeFileSync(badHome, "x", "utf8"); // badHome/.vendo/... → ENOTDIR on mkdir
+    const c = loadConfig(badHome, {});
+    expect(c.anonymousId).toMatch(/[0-9a-f-]{36}/);
+    expect(existsSync(configPath(badHome))).toBe(false);
+  });
 });

--- a/packages/vendo-telemetry/src/config.ts
+++ b/packages/vendo-telemetry/src/config.ts
@@ -22,10 +22,15 @@ export function loadConfig(home = homedir()): TelemetryConfig {
   if (existsSync(path)) {
     try {
       const raw = JSON.parse(readFileSync(path, "utf8")) as Partial<TelemetryConfig>;
-      if (typeof raw.anonymousId === "string" && raw.anonymousId.length > 0) {
+      const hasId = typeof raw.anonymousId === "string" && raw.anonymousId.length > 0;
+      const optedOut = raw.optedOut === true;
+      // Honor the file when it carries EITHER an id or an explicit decision. A
+      // hand-written {optedOut:true} with no id must never be silently
+      // overwritten back to opted-in; synthesize an (unsent) id and keep it.
+      if (hasId || optedOut) {
         return {
-          anonymousId: raw.anonymousId,
-          optedOut: raw.optedOut === true,
+          anonymousId: hasId ? (raw.anonymousId as string) : randomUUID(),
+          optedOut,
           noticeShown: raw.noticeShown === true,
         };
       }

--- a/packages/vendo-telemetry/src/config.ts
+++ b/packages/vendo-telemetry/src/config.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { envOptOut } from "./consent.js";
 
 export interface TelemetryConfig {
   anonymousId: string;
@@ -17,7 +18,10 @@ export function configPath(home = homedir()): string {
   return join(configDir(home), "telemetry.json");
 }
 
-export function loadConfig(home = homedir()): TelemetryConfig {
+export function loadConfig(
+  home = homedir(),
+  env: Record<string, string | undefined> = process.env,
+): TelemetryConfig {
   const path = configPath(home);
   if (existsSync(path)) {
     try {
@@ -39,6 +43,10 @@ export function loadConfig(home = homedir()): TelemetryConfig {
     }
   }
   const fresh: TelemetryConfig = { anonymousId: randomUUID(), optedOut: false, noticeShown: false };
+  // No usable config on disk. If an env opt-out is in effect, return an
+  // ephemeral opted-out config — never persist a tracking id the user asked us
+  // not to keep. Only a genuine opted-in first run gets written.
+  if (envOptOut(env)) return { ...fresh, optedOut: true };
   saveConfig(home, fresh);
   return fresh;
 }

--- a/packages/vendo-telemetry/src/config.ts
+++ b/packages/vendo-telemetry/src/config.ts
@@ -47,7 +47,12 @@ export function loadConfig(
   // ephemeral opted-out config — never persist a tracking id the user asked us
   // not to keep. Only a genuine opted-in first run gets written.
   if (envOptOut(env)) return { ...fresh, optedOut: true };
-  saveConfig(home, fresh);
+  try {
+    saveConfig(home, fresh);
+  } catch {
+    // Read-only home / ENOSPC etc.: degrade to an in-memory config rather than
+    // crashing callers like `vendo telemetry`. The id just won't persist.
+  }
   return fresh;
 }
 

--- a/packages/vendo-telemetry/src/consent.test.ts
+++ b/packages/vendo-telemetry/src/consent.test.ts
@@ -31,4 +31,12 @@ describe("resolveConsent", () => {
   it("allows runtime callers in development", () => {
     expect(resolveConsent({ ...base, runtime: true, env: { NODE_ENV: "development" } }).allowed).toBe(true);
   });
+
+  it("blocks runtime callers when NODE_ENV is unset (fail closed, review)", () => {
+    expect(resolveConsent({ ...base, runtime: true, env: {} }).allowed).toBe(false);
+  });
+
+  it("blocks runtime callers on an unknown NODE_ENV (fail closed, review)", () => {
+    expect(resolveConsent({ ...base, runtime: true, env: { NODE_ENV: "staging" } }).allowed).toBe(false);
+  });
 });

--- a/packages/vendo-telemetry/src/consent.ts
+++ b/packages/vendo-telemetry/src/consent.ts
@@ -15,6 +15,17 @@ function truthy(v: string | undefined): boolean {
   return v === "1" || v === "true";
 }
 
+/**
+ * True when an environment opt-out is in effect (VENDO_TELEMETRY_DISABLED,
+ * DO_NOT_TRACK, or CI). Used both by resolveConsent (to gate track()) and by
+ * loadConfig (to avoid minting/persisting a tracking id the user opted out of).
+ */
+export function envOptOut(env: Record<string, string | undefined>): boolean {
+  if (truthy(env.VENDO_TELEMETRY_DISABLED)) return true;
+  if (truthy(env.DO_NOT_TRACK)) return true;
+  return env.CI !== undefined && env.CI !== "" && env.CI !== "0" && env.CI !== "false";
+}
+
 export function resolveConsent({ env, optedOut, runtime }: ConsentInputs): ConsentResult {
   if (truthy(env.VENDO_TELEMETRY_DISABLED)) return { allowed: false, reason: "env-disabled" };
   if (truthy(env.DO_NOT_TRACK)) return { allowed: false, reason: "do-not-track" };

--- a/packages/vendo-telemetry/src/consent.ts
+++ b/packages/vendo-telemetry/src/consent.ts
@@ -21,6 +21,11 @@ export function resolveConsent({ env, optedOut, runtime }: ConsentInputs): Conse
   if (env.CI !== undefined && env.CI !== "" && env.CI !== "0" && env.CI !== "false")
     return { allowed: false, reason: "ci" };
   if (optedOut) return { allowed: false, reason: "config-opt-out" };
-  if (runtime && env.NODE_ENV === "production") return { allowed: false, reason: "production" };
+  // Runtime (dev-server) collection is allowed ONLY when NODE_ENV explicitly
+  // names a dev environment. An unset/unknown NODE_ENV is treated as production
+  // (fail closed) so a prod deploy that forgot to set it is never collected
+  // from. Build-side callers (runtime:false) are unaffected.
+  if (runtime && env.NODE_ENV !== "development" && env.NODE_ENV !== "test")
+    return { allowed: false, reason: "production" };
   return { allowed: true, reason: "allowed" };
 }

--- a/packages/vendo-telemetry/src/index.ts
+++ b/packages/vendo-telemetry/src/index.ts
@@ -26,7 +26,9 @@ export interface InitTelemetryOptions {
 export function initTelemetry(opts: InitTelemetryOptions): Telemetry {
   const env = opts.env ?? process.env;
   const home = opts.home;
-  const config = loadConfig(home);
+  // Pass the same env used for consent so an env opt-out also suppresses the
+  // fresh-config write (no tracking id minted for an opted-out user).
+  const config = loadConfig(home, env);
   const afterNotice = maybeShowNotice(config, {
     log: opts.log ?? ((m) => console.error(m)),
     save: (c) => saveConfig(home ?? homedir(), c),


### PR DESCRIPTION
## What

Stacked on the shell-UI wave (#69). Nine confirmed audit findings — integrations UI telling the truth about the server, and telemetry consent/privacy being honest. 9 commits, each TDD'd; Codex review returned **no findings**.

### Integrations truthfulness (vendo-server, vendo-next)
1. **Status no longer reports "active" without the store write** — a foreign active account returned `active` while the toolkit was never registered; now `active` only inside the store-write branch, anti-spoof case reports `pending` (bounded 120s poll, never latches).
2. **Disconnect no longer silently succeeds on a server reject** — now throws on non-ok and leaves the row untouched (mirrors `connect()`).
3. **Status poll no longer swallows errors** — logs server-side and reports transient `pending`, reserving `failed` for real failures.

### Telemetry consent (vendo-telemetry — anonymous, opt-out, posture unchanged)
4. The one-time notice is actually shown (was routed to a no-op logger then marked seen).
5. Prod guard fails **closed** on unset NODE_ENV (runtime collection only in explicit dev/test).
6. An explicit `{"optedOut":true}` without an anonymousId is honored, not overwritten to opted-in.
7. No tracking UUID minted/persisted under an env opt-out (`DO_NOT_TRACK`/`VENDO_TELEMETRY_DISABLED`/`CI`).
8. `vendo telemetry` can't crash — `loadConfig` degrades to in-memory on a write failure.
9. Allowlisted event values are bounded (coerced to primitives, strings capped, objects dropped).

### Flags (deliberate, non-blocking)
- Findings 1 & 3 use `pending` for not-connected/transient — correct per the client contract, but the spoof case polls to the 120s timeout rather than fast-failing. Your call if you'd prefer fast-fail.
- Fix 5 treats `development` AND `test` as dev envs (so vitest/CI runtime callers aren't surprised); one word to make it strictly `development`.

`pnpm typecheck` 27/27 · `pnpm test` 25/25. No UI changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens integrations and telemetry so the UI shows real connection state and telemetry consent is enforced. Prevents false “connected” states and avoids minting or persisting tracking IDs when opted out.

- **Bug Fixes**
  - `vendo-server`/`vendo-next`: Status only returns active after the store write; foreign/other-toolkit “active” polls return pending so the client keeps polling instead of latching a false connected state.
  - `vendo-server`: Status poll errors are logged and reported as pending (transient), reserving failed for real failures.
  - `vendo-next`: `disconnect()` throws on non-ok responses and leaves the cache unchanged, mirroring `connect()`.
  - `vendo-server`/`vendo-telemetry`: The one-time telemetry notice is actually shown in dev; runtime collection fails closed unless `NODE_ENV` is explicitly `development` or `test`; a file with `{ optedOut: true }` is honored even without an `anonymousId`; env opt-outs (`DO_NOT_TRACK`, `VENDO_TELEMETRY_DISABLED`, `CI`) avoid minting/persisting an ID; config save failures degrade to in-memory to prevent crashes.
  - `vendo-telemetry`: Allowlisted event values are bounded to primitives; strings are capped at 512 chars and objects/arrays are dropped.

<sup>Written for commit d993e8ad499bcc9b828efb3cd98297e9056bd76a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

