### PR TITLE
Hardening wave 8: sandbox-shims completeness

### DIFF
--- a/packages/vendo-sandbox-shims/src/dispatch.ts
+++ b/packages/vendo-sandbox-shims/src/dispatch.ts
@@ -22,20 +22,16 @@ export function dispatch(action: string, payload?: unknown): Promise<unknown> {
     return Promise.resolve(undefined);
   }
   // The runtime bridge returns a Promise that REJECTS on a blocked action
-  // (policy deny, capability mismatch). Dropping it left an unhandled rejection
-  // and a dead click; own the Promise and swallow-with-log so a blocked action
-  // fails quietly instead of crashing.
-  return Promise.resolve(fn({ action, payload })).catch((err: unknown) => {
-    if (typeof console !== "undefined") {
-      console.warn(`[vendo] shim dispatch "${action}" was blocked:`, err);
-    }
-    return undefined;
-  });
+  // (policy deny, capability mismatch, pending-then-denied). Return it RAW so a
+  // caller that awaits dispatch()/navigate() sees the failure — swallowing it
+  // here would hide policy/nav errors from component code. Fire-and-forget call
+  // sites (e.g. Link.onClick) are responsible for catching.
+  return Promise.resolve(fn({ action, payload }));
 }
 
 /** Navigate the host app. Only same-app paths are meaningful; the host
- *  receiver validates before touching the router. Returns the (already
- *  rejection-handled) dispatch Promise so callers never drop it. */
+ *  receiver validates before touching the router. Returns the RAW bridge
+ *  Promise — awaiters see a rejection; fire-and-forget callers must catch. */
 export function navigate(href: string): Promise<unknown> {
   return dispatch(NAVIGATE_ACTION, { href });
 }

--- a/packages/vendo-sandbox-shims/src/dispatch.ts
+++ b/packages/vendo-sandbox-shims/src/dispatch.ts
@@ -13,17 +13,29 @@ interface ShimWindow {
   __vendoDispatch?: Dispatch;
 }
 
-export function dispatch(action: string, payload?: unknown): void {
+export function dispatch(action: string, payload?: unknown): Promise<unknown> {
   const fn = (globalThis as unknown as ShimWindow).__vendoDispatch;
-  if (typeof fn === "function") {
-    fn({ action, payload });
-  } else if (typeof console !== "undefined") {
-    console.warn(`[vendo] shim dispatch "${action}" with no bridge — ignored`);
+  if (typeof fn !== "function") {
+    if (typeof console !== "undefined") {
+      console.warn(`[vendo] shim dispatch "${action}" with no bridge — ignored`);
+    }
+    return Promise.resolve(undefined);
   }
+  // The runtime bridge returns a Promise that REJECTS on a blocked action
+  // (policy deny, capability mismatch). Dropping it left an unhandled rejection
+  // and a dead click; own the Promise and swallow-with-log so a blocked action
+  // fails quietly instead of crashing.
+  return Promise.resolve(fn({ action, payload })).catch((err: unknown) => {
+    if (typeof console !== "undefined") {
+      console.warn(`[vendo] shim dispatch "${action}" was blocked:`, err);
+    }
+    return undefined;
+  });
 }
 
 /** Navigate the host app. Only same-app paths are meaningful; the host
- *  receiver validates before touching the router. */
-export function navigate(href: string): void {
-  dispatch(NAVIGATE_ACTION, { href });
+ *  receiver validates before touching the router. Returns the (already
+ *  rejection-handled) dispatch Promise so callers never drop it. */
+export function navigate(href: string): Promise<unknown> {
+  return dispatch(NAVIGATE_ACTION, { href });
 }

--- a/packages/vendo-sandbox-shims/src/index.ts
+++ b/packages/vendo-sandbox-shims/src/index.ts
@@ -4,7 +4,7 @@
  * the framework import specifiers onto these in the sandbox import map.
  */
 export { NAVIGATE_ACTION, navigate, dispatch } from "./dispatch.js";
-export { default as Link, type LinkProps } from "./next-link.js";
+export { default as Link, useLinkStatus, type LinkProps, type UrlObject } from "./next-link.js";
 export { default as Image, type ImageProps } from "./next-image.js";
 export {
   useRouter,

--- a/packages/vendo-sandbox-shims/src/index.ts
+++ b/packages/vendo-sandbox-shims/src/index.ts
@@ -6,5 +6,14 @@
 export { NAVIGATE_ACTION, navigate, dispatch } from "./dispatch.js";
 export { default as Link, type LinkProps } from "./next-link.js";
 export { default as Image, type ImageProps } from "./next-image.js";
-export { useRouter, usePathname, useSearchParams } from "./next-navigation.js";
+export {
+  useRouter,
+  usePathname,
+  useSearchParams,
+  useParams,
+  redirect,
+  notFound,
+  useSelectedLayoutSegment,
+  useSelectedLayoutSegments,
+} from "./next-navigation.js";
 export { default as useSWR, type SWRResponse } from "./swr.js";

--- a/packages/vendo-sandbox-shims/src/index.ts
+++ b/packages/vendo-sandbox-shims/src/index.ts
@@ -16,4 +16,12 @@ export {
   useSelectedLayoutSegment,
   useSelectedLayoutSegments,
 } from "./next-navigation.js";
-export { default as useSWR, type SWRResponse } from "./swr.js";
+export {
+  default as useSWR,
+  useSWRConfig,
+  mutate,
+  SWRConfig,
+  preload,
+  type SWRResponse,
+  type SWRConfiguration,
+} from "./swr.js";

--- a/packages/vendo-sandbox-shims/src/next-link.tsx
+++ b/packages/vendo-sandbox-shims/src/next-link.tsx
@@ -95,3 +95,10 @@ export default function Link({ href, children, onClick, prefetch: _p, replace: _
     children,
   );
 }
+
+/** Next 16's `next/link` also exports `useLinkStatus`; a component importing it
+ *  would fail module instantiation without this. In-sandbox navigation is
+ *  synchronous (no prefetch/pending transition), so it's always not-pending. */
+export function useLinkStatus(): { pending: boolean } {
+  return { pending: false };
+}

--- a/packages/vendo-sandbox-shims/src/next-link.tsx
+++ b/packages/vendo-sandbox-shims/src/next-link.tsx
@@ -7,9 +7,18 @@
 import { createElement, type AnchorHTMLAttributes, type MouseEvent, type ReactNode } from "react";
 import { navigate } from "./dispatch.js";
 
+type QueryValue = string | number | boolean | ReadonlyArray<string | number | boolean> | null | undefined;
+
+/** The subset of Next's UrlObject we can honor in the sandbox. */
+export interface UrlObject {
+  pathname?: string;
+  query?: Record<string, QueryValue>;
+  hash?: string;
+}
+
 export interface LinkProps
   extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> {
-  href: string | { pathname?: string };
+  href: string | UrlObject;
   children?: ReactNode;
   // Accepted for API-compat; ignored in the sandbox.
   prefetch?: boolean;
@@ -18,7 +27,24 @@ export interface LinkProps
 }
 
 function hrefString(href: LinkProps["href"]): string {
-  return typeof href === "string" ? href : (href.pathname ?? "");
+  if (typeof href === "string") return href;
+  const pathname = href.pathname ?? "";
+  let search = "";
+  if (href.query) {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(href.query)) {
+      if (value == null) continue;
+      if (Array.isArray(value)) {
+        for (const item of value) params.append(key, String(item));
+      } else {
+        params.append(key, String(value));
+      }
+    }
+    const qs = params.toString();
+    if (qs) search = `?${qs}`;
+  }
+  const hash = href.hash ? (href.hash.startsWith("#") ? href.hash : `#${href.hash}`) : "";
+  return `${pathname}${search}${hash}`;
 }
 
 export default function Link({ href, children, onClick, prefetch: _p, replace: _r, scroll: _s, ...rest }: LinkProps): import("react").ReactElement {

--- a/packages/vendo-sandbox-shims/src/next-link.tsx
+++ b/packages/vendo-sandbox-shims/src/next-link.tsx
@@ -47,6 +47,20 @@ function hrefString(href: LinkProps["href"]): string {
   return `${pathname}${search}${hash}`;
 }
 
+/** Only same-app local paths should be hijacked into an in-host navigate; the
+ *  host router rejects everything else, which would make those links dead.
+ *  Falls through to the browser for: hash-only anchors, any scheme
+ *  (https:/http:/mailto:/tel:/…), protocol-relative `//host` externals, and
+ *  `download` links. Relative and `/absolute` app paths are intercepted. */
+function isLocalAppPath(url: string, download: unknown): boolean {
+  if (download != null && download !== false) return false; // let the browser download
+  if (!url) return false;
+  if (url.startsWith("#")) return false; // in-page anchor
+  if (url.startsWith("//")) return false; // protocol-relative → external origin
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(url)) return false; // has a URL scheme → external
+  return true;
+}
+
 export default function Link({ href, children, onClick, prefetch: _p, replace: _r, scroll: _s, ...rest }: LinkProps): import("react").ReactElement {
   const url = hrefString(href);
   return createElement(
@@ -64,6 +78,9 @@ export default function Link({ href, children, onClick, prefetch: _p, replace: _
         if (event.button !== 0) return;
         if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
         if (rest.target && rest.target !== "_self") return;
+        // Only hijack local app paths; external/mailto/tel/hash/download links
+        // must reach the browser (the host router would reject them → dead link).
+        if (!isLocalAppPath(url, rest.download)) return;
         event.preventDefault();
         // Fire-and-forget: navigate() returns the raw bridge Promise, which
         // rejects on a blocked navigation. Catch here so a denied click logs

--- a/packages/vendo-sandbox-shims/src/next-link.tsx
+++ b/packages/vendo-sandbox-shims/src/next-link.tsx
@@ -65,7 +65,14 @@ export default function Link({ href, children, onClick, prefetch: _p, replace: _
         if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
         if (rest.target && rest.target !== "_self") return;
         event.preventDefault();
-        navigate(url);
+        // Fire-and-forget: navigate() returns the raw bridge Promise, which
+        // rejects on a blocked navigation. Catch here so a denied click logs
+        // instead of surfacing as an unhandled rejection.
+        void navigate(url).catch((err: unknown) => {
+          if (typeof console !== "undefined") {
+            console.warn(`[vendo] Link navigation to "${url}" was blocked:`, err);
+          }
+        });
       },
     },
     children,

--- a/packages/vendo-sandbox-shims/src/next-link.tsx
+++ b/packages/vendo-sandbox-shims/src/next-link.tsx
@@ -48,16 +48,24 @@ function hrefString(href: LinkProps["href"]): string {
 }
 
 export default function Link({ href, children, onClick, prefetch: _p, replace: _r, scroll: _s, ...rest }: LinkProps): import("react").ReactElement {
-  const target = hrefString(href);
+  const url = hrefString(href);
   return createElement(
     "a",
     {
       ...rest,
-      href: target,
+      href: url,
       onClick: (event: MouseEvent<HTMLAnchorElement>) => {
-        event.preventDefault();
+        // Let the user's handler run first; it may cancel navigation.
         onClick?.(event);
-        navigate(target);
+        if (event.defaultPrevented) return;
+        // Let the browser handle open-in-new-tab / open-in-window and any
+        // non-primary (middle/right) button — only a plain primary click
+        // becomes an in-host navigate.
+        if (event.button !== 0) return;
+        if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+        if (rest.target && rest.target !== "_self") return;
+        event.preventDefault();
+        navigate(url);
       },
     },
     children,

--- a/packages/vendo-sandbox-shims/src/next-navigation.ts
+++ b/packages/vendo-sandbox-shims/src/next-navigation.ts
@@ -1,7 +1,8 @@
 /**
- * Minimal `next/navigation` shim. `useRouter().push/replace` route the host
- * app via vendo.navigate; the rest throw descriptive contained errors rather
- * than silently misbehaving.
+ * Minimal `next/navigation` shim. `useRouter().push/replace` (and `redirect`)
+ * route the host app via vendo.navigate; everything else that can't be honored
+ * in the sandbox is a safe no-op or returns Next's empty value rather than
+ * throwing into a React render/handler.
  */
 import { navigate } from "./dispatch.js";
 
@@ -9,11 +10,15 @@ export function useRouter() {
   return {
     push: (href: string) => navigate(href),
     replace: (href: string) => navigate(href),
+    // No history channel exists between the sandbox and the host router, so
+    // back/forward can't do anything real. They are safe no-ops rather than
+    // throwing, because these are wired to onClick handlers and an exception
+    // there would crash the component instead of just being inert.
     back: () => {
-      throw new Error("[vendo] router.back() is not available in a remixed component");
+      /* no-op: no host history bridge */
     },
     forward: () => {
-      throw new Error("[vendo] router.forward() is not available in a remixed component");
+      /* no-op: no host history bridge */
     },
     refresh: () => {
       /* no-op: the host owns refresh */

--- a/packages/vendo-sandbox-shims/src/next-navigation.ts
+++ b/packages/vendo-sandbox-shims/src/next-navigation.ts
@@ -1,8 +1,9 @@
 /**
  * Minimal `next/navigation` shim. `useRouter().push/replace` (and `redirect`)
- * route the host app via vendo.navigate; everything else that can't be honored
- * in the sandbox is a safe no-op or returns Next's empty value rather than
- * throwing into a React render/handler.
+ * route the host app via vendo.navigate. `redirect`/`notFound` throw to unwind
+ * the render (Next semantics, caught by the sandbox error boundary); the
+ * router history methods and the read hooks that have no route channel are safe
+ * no-ops / empty values so they never crash a render or event handler.
  */
 import { navigate } from "./dispatch.js";
 
@@ -44,19 +45,28 @@ export function useParams<T extends Record<string, string | string[]> = Record<s
   return {} as T;
 }
 
-/** `redirect(url)` in Next throws to unwind rendering; that is impossible here,
- *  so route through the same navigate bridge `useRouter().push` uses and return.
- *  A blocked redirect surfaces via the bridge (see dispatch), not an exception
- *  thrown into React render. */
-export function redirect(url: string): void {
-  navigate(url);
+/** Recognizable codes so a host/error-boundary can tell these apart from real
+ *  errors (mirrors Next's NEXT_REDIRECT / NEXT_NOT_FOUND digests). */
+export const REDIRECT_ERROR_CODE = "VENDO_REDIRECT";
+export const NOT_FOUND_ERROR_CODE = "VENDO_NOT_FOUND";
+
+/** `redirect(url)` in Next THROWS to unwind rendering so the protected content
+ *  below it never renders. We must do the same: kick off the navigation, then
+ *  throw. A no-op-return would let the guarded component render its protected
+ *  branch before/if navigation resolves. In the sandbox this throw hits the
+ *  error boundary — exactly the "stop rendering protected content" behavior. */
+export function redirect(url: string): never {
+  // Fire-and-forget (we throw immediately and cannot await); catch so a blocked
+  // navigation doesn't become an unhandled rejection.
+  void navigate(url).catch(() => {});
+  throw Object.assign(new Error(`[vendo] redirect(${url})`), { code: REDIRECT_ERROR_CODE });
 }
 
-/** `notFound()` in Next throws NEXT_NOT_FOUND to render the not-found segment.
- *  The sandbox has no not-found boundary, and throwing would crash the render,
- *  so treat it as a safe no-op — the component keeps rendering. */
-export function notFound(): void {
-  /* no-op: no not-found boundary in the sandbox */
+/** `notFound()` in Next THROWS NEXT_NOT_FOUND to stop rendering and show the
+ *  not-found segment. Throw likewise so the invalid content below never renders;
+ *  in the sandbox the error boundary catches it. */
+export function notFound(): never {
+  throw Object.assign(new Error("[vendo] notFound()"), { code: NOT_FOUND_ERROR_CODE });
 }
 
 /** No layout-segment routing in the sandbox — mirror Next's "no segment" values. */

--- a/packages/vendo-sandbox-shims/src/next-navigation.ts
+++ b/packages/vendo-sandbox-shims/src/next-navigation.ts
@@ -31,3 +31,34 @@ export function usePathname(): string {
 export function useSearchParams(): URLSearchParams {
   return new URLSearchParams();
 }
+
+/** No route channel exists in the sandbox yet, so there are no dynamic route
+ *  params to surface — return an empty object rather than crash a component
+ *  that reads `params.id`. */
+export function useParams<T extends Record<string, string | string[]> = Record<string, string | string[]>>(): T {
+  return {} as T;
+}
+
+/** `redirect(url)` in Next throws to unwind rendering; that is impossible here,
+ *  so route through the same navigate bridge `useRouter().push` uses and return.
+ *  A blocked redirect surfaces via the bridge (see dispatch), not an exception
+ *  thrown into React render. */
+export function redirect(url: string): void {
+  navigate(url);
+}
+
+/** `notFound()` in Next throws NEXT_NOT_FOUND to render the not-found segment.
+ *  The sandbox has no not-found boundary, and throwing would crash the render,
+ *  so treat it as a safe no-op — the component keeps rendering. */
+export function notFound(): void {
+  /* no-op: no not-found boundary in the sandbox */
+}
+
+/** No layout-segment routing in the sandbox — mirror Next's "no segment" values. */
+export function useSelectedLayoutSegment(): string | null {
+  return null;
+}
+
+export function useSelectedLayoutSegments(): string[] {
+  return [];
+}

--- a/packages/vendo-sandbox-shims/src/shims.test.tsx
+++ b/packages/vendo-sandbox-shims/src/shims.test.tsx
@@ -93,6 +93,41 @@ describe("Link shim", () => {
     fireEvent.click(screen.getByText("x"));
     expect(calls).toEqual([]);
   });
+
+  it.each([
+    ["https://example.com/x"],
+    ["http://example.com/x"],
+    ["mailto:a@b.com"],
+    ["tel:+15551234"],
+    ["//cdn.example.com/x"],
+    ["#section"],
+  ])("lets non-local href %s fall through to the browser (no navigate, no preventDefault)", (href) => {
+    const calls = captureDispatch();
+    render(<Link href={href}>l</Link>);
+    const notCanceled = fireEvent.click(screen.getByText("l"));
+    expect(calls).toEqual([]);
+    expect(notCanceled).toBe(true); // preventDefault NOT called
+  });
+
+  it("lets a download link fall through to the browser", () => {
+    const calls = captureDispatch();
+    render(
+      <Link href="/file.pdf" download>
+        d
+      </Link>,
+    );
+    const notCanceled = fireEvent.click(screen.getByText("d"));
+    expect(calls).toEqual([]);
+    expect(notCanceled).toBe(true);
+  });
+
+  it("still intercepts a plain local app path", () => {
+    const calls = captureDispatch();
+    render(<Link href="/clients/x">c</Link>);
+    const notCanceled = fireEvent.click(screen.getByText("c"));
+    expect(calls).toEqual([{ action: NAVIGATE_ACTION, payload: { href: "/clients/x" } }]);
+    expect(notCanceled).toBe(false); // preventDefault called
+  });
 });
 
 describe("Image shim", () => {

--- a/packages/vendo-sandbox-shims/src/shims.test.tsx
+++ b/packages/vendo-sandbox-shims/src/shims.test.tsx
@@ -297,6 +297,56 @@ describe("swr extra exports", () => {
     expect(screen.getByText("swr-child")).toBeTruthy();
   });
 
+  it("useSWR reads fallback data from an enclosing SWRConfig provider", () => {
+    function Probe() {
+      const { data } = useSWR("/api/x");
+      return <span>{JSON.stringify(data)}</span>;
+    }
+    render(
+      <SWRConfig value={{ fallback: { "/api/x": [7] } }}>
+        <Probe />
+      </SWRConfig>,
+    );
+    expect(screen.getByText("[7]")).toBeTruthy();
+  });
+
+  it("useSWRConfig returns the provider's shared cache and mutate", () => {
+    const sharedCache = new Map<string, unknown>();
+    let captured: ReturnType<typeof useSWRConfig> | undefined;
+    function Probe() {
+      captured = useSWRConfig();
+      return null;
+    }
+    render(
+      <SWRConfig value={{ provider: () => sharedCache }}>
+        <Probe />
+      </SWRConfig>,
+    );
+    expect(captured?.cache).toBe(sharedCache);
+    expect(typeof captured?.mutate).toBe("function");
+  });
+
+  it("nested SWRConfig merges fallback over the parent provider", () => {
+    function Probe({ k }: { k: string }) {
+      const { data } = useSWR(k);
+      return (
+        <span>
+          {k}:{JSON.stringify(data)}
+        </span>
+      );
+    }
+    render(
+      <SWRConfig value={{ fallback: { "/a": 1, "/b": 2 } }}>
+        <SWRConfig value={{ fallback: { "/b": 99 } }}>
+          <Probe k="/a" />
+          <Probe k="/b" />
+        </SWRConfig>
+      </SWRConfig>,
+    );
+    expect(screen.getByText("/a:1")).toBeTruthy();
+    expect(screen.getByText("/b:99")).toBeTruthy();
+  });
+
   it("preload is a safe no-op returning a resolved promise (fetcher never runs)", async () => {
     const fetcher = vi.fn();
     await expect(preload("/api/x", fetcher)).resolves.toBeUndefined();

--- a/packages/vendo-sandbox-shims/src/shims.test.tsx
+++ b/packages/vendo-sandbox-shims/src/shims.test.tsx
@@ -57,6 +57,42 @@ describe("Link shim", () => {
     fireEvent.click(screen.getByText("x"));
     expect(onClick).toHaveBeenCalledTimes(1);
   });
+
+  it("does nothing when the user's onClick calls preventDefault (user-cancel)", () => {
+    const calls = captureDispatch();
+    render(
+      <Link href="/x" onClick={(e) => e.preventDefault()}>
+        x
+      </Link>,
+    );
+    fireEvent.click(screen.getByText("x"));
+    expect(calls).toEqual([]);
+  });
+
+  it("ignores modified clicks (open-in-new-tab) and does not navigate", () => {
+    const calls = captureDispatch();
+    render(<Link href="/x">x</Link>);
+    fireEvent.click(screen.getByText("x"), { metaKey: true });
+    expect(calls).toEqual([]);
+  });
+
+  it("ignores non-primary (middle/right) button clicks", () => {
+    const calls = captureDispatch();
+    render(<Link href="/x">x</Link>);
+    fireEvent.click(screen.getByText("x"), { button: 1 });
+    expect(calls).toEqual([]);
+  });
+
+  it("ignores clicks on a link with target other than _self", () => {
+    const calls = captureDispatch();
+    render(
+      <Link href="/x" target="_blank">
+        x
+      </Link>,
+    );
+    fireEvent.click(screen.getByText("x"));
+    expect(calls).toEqual([]);
+  });
 });
 
 describe("Image shim", () => {

--- a/packages/vendo-sandbox-shims/src/shims.test.tsx
+++ b/packages/vendo-sandbox-shims/src/shims.test.tsx
@@ -163,6 +163,12 @@ describe("useSWR shim", () => {
     expect(result.isLoading).toBe(false);
   });
 
+  it("a false key (ready && '/api/x' idiom) means skip — not a permanent spinner", () => {
+    const result = useSWR(false, vi.fn());
+    expect(result.data).toBeUndefined();
+    expect(result.isLoading).toBe(false);
+  });
+
   it("a function key is called to derive the key and resolves its data", () => {
     (globalThis as Record<string, unknown>)["__vendoAnchorData"] = { "/api/live": [1, 2] };
     const result = useSWR(() => "/api/live", vi.fn());

--- a/packages/vendo-sandbox-shims/src/shims.test.tsx
+++ b/packages/vendo-sandbox-shims/src/shims.test.tsx
@@ -37,6 +37,19 @@ describe("Link shim", () => {
     expect(calls).toEqual([{ action: NAVIGATE_ACTION, payload: { href: "/clients/cl_rivera" } }]);
   });
 
+  it("builds the full URL from a UrlObject href (pathname + query + hash)", () => {
+    const calls = captureDispatch();
+    render(
+      <Link href={{ pathname: "/search", query: { q: "acme", page: 2 }, hash: "results" }}>go</Link>,
+    );
+    const anchor = screen.getByText("go") as HTMLAnchorElement;
+    expect(anchor.getAttribute("href")).toBe("/search?q=acme&page=2#results");
+    fireEvent.click(anchor);
+    expect(calls).toEqual([
+      { action: NAVIGATE_ACTION, payload: { href: "/search?q=acme&page=2#results" } },
+    ]);
+  });
+
   it("still fires a user onClick before navigating", () => {
     captureDispatch();
     const onClick = vi.fn();

--- a/packages/vendo-sandbox-shims/src/shims.test.tsx
+++ b/packages/vendo-sandbox-shims/src/shims.test.tsx
@@ -122,14 +122,15 @@ describe("next/navigation extra exports", () => {
     expect(useParams()).toEqual({});
   });
 
-  it("redirect routes through the same navigate bridge (does not throw)", () => {
+  it("redirect initiates navigation then THROWS to unwind the current render", () => {
     const calls = captureDispatch();
-    expect(() => redirect("/login")).not.toThrow();
+    expect(() => redirect("/login")).toThrow(/redirect/i);
+    // navigation was still kicked off before the throw
     expect(calls).toEqual([{ action: NAVIGATE_ACTION, payload: { href: "/login" } }]);
   });
 
-  it("notFound is a safe no-op (does not throw)", () => {
-    expect(() => notFound()).not.toThrow();
+  it("notFound THROWS to stop rendering the protected/invalid content", () => {
+    expect(() => notFound()).toThrow(/not.?found/i);
   });
 
   it("useSelectedLayoutSegment(s) return null / []", () => {

--- a/packages/vendo-sandbox-shims/src/shims.test.tsx
+++ b/packages/vendo-sandbox-shims/src/shims.test.tsx
@@ -193,11 +193,22 @@ describe("dispatch bridge-promise handling", () => {
     await expect(dispatch("vendo.something")).resolves.toBe("ok");
   });
 
-  it("swallows a bridge rejection (policy deny) with a warning — no unhandled rejection or dead click", async () => {
+  it("propagates a bridge rejection to awaiters (does NOT swallow policy/capability failures)", async () => {
+    (globalThis as Record<string, unknown>)["__vendoDispatch"] = () =>
+      Promise.reject(Object.assign(new Error("policy deny"), { code: "policy" }));
+    await expect(dispatch("vendo.blocked")).rejects.toThrow(/policy deny/);
+    await expect(navigate("/blocked")).rejects.toThrow(/policy deny/);
+  });
+
+  it("a blocked navigation from a Link click is caught (no unhandled rejection, no dead crash)", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     (globalThis as Record<string, unknown>)["__vendoDispatch"] = () =>
       Promise.reject(Object.assign(new Error("policy deny"), { code: "policy" }));
-    await expect(navigate("/blocked")).resolves.toBeUndefined();
+    render(<Link href="/blocked">go</Link>);
+    expect(() => fireEvent.click(screen.getByText("go"))).not.toThrow();
+    // flush the navigate() promise's rejection handler
+    await Promise.resolve();
+    await Promise.resolve();
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
   });

--- a/packages/vendo-sandbox-shims/src/shims.test.tsx
+++ b/packages/vendo-sandbox-shims/src/shims.test.tsx
@@ -105,12 +105,15 @@ describe("Image shim", () => {
 });
 
 describe("useRouter shim", () => {
-  it("push routes the host app; back throws a contained error", () => {
+  it("push routes the host app; back/forward are safe no-ops (never throw into a handler)", () => {
     const calls = captureDispatch();
     const router = useRouter();
     router.push("/settings");
     expect(calls).toEqual([{ action: NAVIGATE_ACTION, payload: { href: "/settings" } }]);
-    expect(() => router.back()).toThrow(/not available/);
+    expect(() => router.back()).not.toThrow();
+    expect(() => router.forward()).not.toThrow();
+    // no history channel exists, so back/forward must not emit a navigate
+    expect(calls).toEqual([{ action: NAVIGATE_ACTION, payload: { href: "/settings" } }]);
   });
 });
 

--- a/packages/vendo-sandbox-shims/src/shims.test.tsx
+++ b/packages/vendo-sandbox-shims/src/shims.test.tsx
@@ -273,6 +273,25 @@ describe("swr extra exports", () => {
     await expect(mutate("/api/x")).resolves.toBeUndefined();
   });
 
+  it("global mutate with a key only (revalidate form) resolves the current cached value", async () => {
+    (globalThis as Record<string, unknown>)["__vendoAnchorData"] = { "/api/x": [1] };
+    await expect(mutate("/api/x")).resolves.toEqual([1]);
+  });
+
+  it("global mutate with a predicate matches cache entries and resolves their values", async () => {
+    (globalThis as Record<string, unknown>)["__vendoAnchorData"] = { "/api/a": 1, "/api/b": 2, "/other": 3 };
+    const res = (await mutate((key: string) => key.startsWith("/api/"))) as unknown[];
+    expect(res).toEqual(expect.arrayContaining([1, 2]));
+    expect(res).not.toContain(3);
+  });
+
+  it("global mutate with a predicate + data writes matching entries only", async () => {
+    (globalThis as Record<string, unknown>)["__vendoAnchorData"] = { "/api/a": 1, "/api/b": 2 };
+    await mutate((key: string) => key === "/api/a", 99);
+    expect(useSWR("/api/a").data).toBe(99);
+    expect(useSWR("/api/b").data).toBe(2);
+  });
+
   it("SWRConfig renders its children (passthrough provider)", () => {
     render(<SWRConfig value={{}}>{<span>swr-child</span>}</SWRConfig>);
     expect(screen.getByText("swr-child")).toBeTruthy();

--- a/packages/vendo-sandbox-shims/src/shims.test.tsx
+++ b/packages/vendo-sandbox-shims/src/shims.test.tsx
@@ -11,7 +11,7 @@ import {
   useSelectedLayoutSegments,
 } from "./next-navigation";
 import useSWR, { useSWRConfig, mutate, SWRConfig, preload } from "./swr";
-import { NAVIGATE_ACTION } from "./dispatch";
+import { NAVIGATE_ACTION, dispatch, navigate } from "./dispatch";
 
 afterEach(() => {
   cleanup();
@@ -102,6 +102,22 @@ describe("useSWR shim", () => {
     expect(result.data).toBeUndefined();
     expect(result.isLoading).toBe(true);
     expect(fetcher).not.toHaveBeenCalled();
+  });
+});
+
+describe("dispatch bridge-promise handling", () => {
+  it("dispatch returns the bridge promise, resolving with its result on success", async () => {
+    (globalThis as Record<string, unknown>)["__vendoDispatch"] = () => Promise.resolve("ok");
+    await expect(dispatch("vendo.something")).resolves.toBe("ok");
+  });
+
+  it("swallows a bridge rejection (policy deny) with a warning — no unhandled rejection or dead click", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    (globalThis as Record<string, unknown>)["__vendoDispatch"] = () =>
+      Promise.reject(Object.assign(new Error("policy deny"), { code: "policy" }));
+    await expect(navigate("/blocked")).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 });
 

--- a/packages/vendo-sandbox-shims/src/shims.test.tsx
+++ b/packages/vendo-sandbox-shims/src/shims.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
-import Link from "./next-link";
+import Link, { useLinkStatus } from "./next-link";
 import Image from "./next-image";
 import {
   useRouter,
@@ -127,6 +127,10 @@ describe("Link shim", () => {
     const notCanceled = fireEvent.click(screen.getByText("c"));
     expect(calls).toEqual([{ action: NAVIGATE_ACTION, payload: { href: "/clients/x" } }]);
     expect(notCanceled).toBe(false); // preventDefault called
+  });
+
+  it("exports useLinkStatus (Next 16) returning { pending: false }", () => {
+    expect(useLinkStatus()).toEqual({ pending: false });
   });
 });
 

--- a/packages/vendo-sandbox-shims/src/shims.test.tsx
+++ b/packages/vendo-sandbox-shims/src/shims.test.tsx
@@ -2,7 +2,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import Link from "./next-link";
 import Image from "./next-image";
-import { useRouter } from "./next-navigation";
+import {
+  useRouter,
+  useParams,
+  redirect,
+  notFound,
+  useSelectedLayoutSegment,
+  useSelectedLayoutSegments,
+} from "./next-navigation";
 import useSWR from "./swr";
 import { NAVIGATE_ACTION } from "./dispatch";
 
@@ -55,6 +62,27 @@ describe("useRouter shim", () => {
     router.push("/settings");
     expect(calls).toEqual([{ action: NAVIGATE_ACTION, payload: { href: "/settings" } }]);
     expect(() => router.back()).toThrow(/not available/);
+  });
+});
+
+describe("next/navigation extra exports", () => {
+  it("useParams returns an empty object (no route channel in the sandbox)", () => {
+    expect(useParams()).toEqual({});
+  });
+
+  it("redirect routes through the same navigate bridge (does not throw)", () => {
+    const calls = captureDispatch();
+    expect(() => redirect("/login")).not.toThrow();
+    expect(calls).toEqual([{ action: NAVIGATE_ACTION, payload: { href: "/login" } }]);
+  });
+
+  it("notFound is a safe no-op (does not throw)", () => {
+    expect(() => notFound()).not.toThrow();
+  });
+
+  it("useSelectedLayoutSegment(s) return null / []", () => {
+    expect(useSelectedLayoutSegment()).toBeNull();
+    expect(useSelectedLayoutSegments()).toEqual([]);
   });
 });
 

--- a/packages/vendo-sandbox-shims/src/shims.test.tsx
+++ b/packages/vendo-sandbox-shims/src/shims.test.tsx
@@ -103,6 +103,36 @@ describe("useSWR shim", () => {
     expect(result.isLoading).toBe(true);
     expect(fetcher).not.toHaveBeenCalled();
   });
+
+  it("a null key (conditional fetch) means skip — not a permanent spinner", () => {
+    const result = useSWR(null, vi.fn());
+    expect(result.data).toBeUndefined();
+    expect(result.isLoading).toBe(false);
+  });
+
+  it("a function key is called to derive the key and resolves its data", () => {
+    (globalThis as Record<string, unknown>)["__vendoAnchorData"] = { "/api/live": [1, 2] };
+    const result = useSWR(() => "/api/live", vi.fn());
+    expect(result.data).toEqual([1, 2]);
+    expect(result.isLoading).toBe(false);
+  });
+
+  it("a function key that returns null is skipped (not loading)", () => {
+    const result = useSWR(() => null, vi.fn());
+    expect(result.data).toBeUndefined();
+    expect(result.isLoading).toBe(false);
+  });
+
+  it("a function key that throws (dependency not ready) is skipped (not loading)", () => {
+    const result = useSWR(
+      () => {
+        throw new Error("dep not ready");
+      },
+      vi.fn(),
+    );
+    expect(result.data).toBeUndefined();
+    expect(result.isLoading).toBe(false);
+  });
 });
 
 describe("dispatch bridge-promise handling", () => {

--- a/packages/vendo-sandbox-shims/src/shims.test.tsx
+++ b/packages/vendo-sandbox-shims/src/shims.test.tsx
@@ -10,7 +10,7 @@ import {
   useSelectedLayoutSegment,
   useSelectedLayoutSegments,
 } from "./next-navigation";
-import useSWR from "./swr";
+import useSWR, { useSWRConfig, mutate, SWRConfig, preload } from "./swr";
 import { NAVIGATE_ACTION } from "./dispatch";
 
 afterEach(() => {
@@ -101,6 +101,35 @@ describe("useSWR shim", () => {
     const result = useSWR("/api/missing", fetcher);
     expect(result.data).toBeUndefined();
     expect(result.isLoading).toBe(true);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+});
+
+describe("swr extra exports", () => {
+  it("useSWRConfig returns a config object with a working mutate", async () => {
+    const config = useSWRConfig();
+    expect(typeof config.mutate).toBe("function");
+    await expect(config.mutate("/api/x")).resolves.toBeUndefined();
+  });
+
+  it("global mutate writes into the anchor-data cache and resolves", async () => {
+    (globalThis as Record<string, unknown>)["__vendoAnchorData"] = {};
+    await expect(mutate("/api/deadlines", [{ id: "z" }])).resolves.toEqual([{ id: "z" }]);
+    expect(useSWR("/api/deadlines").data).toEqual([{ id: "z" }]);
+  });
+
+  it("global mutate with no data is a safe resolved no-op", async () => {
+    await expect(mutate("/api/x")).resolves.toBeUndefined();
+  });
+
+  it("SWRConfig renders its children (passthrough provider)", () => {
+    render(<SWRConfig value={{}}>{<span>swr-child</span>}</SWRConfig>);
+    expect(screen.getByText("swr-child")).toBeTruthy();
+  });
+
+  it("preload is a safe no-op returning a resolved promise (fetcher never runs)", async () => {
+    const fetcher = vi.fn();
+    await expect(preload("/api/x", fetcher)).resolves.toBeUndefined();
     expect(fetcher).not.toHaveBeenCalled();
   });
 });

--- a/packages/vendo-sandbox-shims/src/swr.ts
+++ b/packages/vendo-sandbox-shims/src/swr.ts
@@ -24,17 +24,33 @@ export interface SWRResponse<T> {
   mutate: () => Promise<T | undefined>;
 }
 
-function resolveKey(key: unknown): string | undefined {
-  if (typeof key === "string") return key;
-  if (Array.isArray(key) && typeof key[0] === "string") return key[0];
-  return undefined;
+/** SWR conditional-fetching: a null/undefined key, or a function key that
+ *  throws/returns null (a dependency isn't ready), means "don't fetch". Returns
+ *  `{ skip: true }` for those; otherwise the cache key (or undefined if the key
+ *  shape carries no lookup string). */
+function resolveKey(key: unknown): { skip: true } | { skip: false; key: string | undefined } {
+  if (typeof key === "function") {
+    try {
+      key = (key as () => unknown)();
+    } catch {
+      return { skip: true }; // dependency not ready → don't fetch
+    }
+  }
+  if (key == null) return { skip: true }; // conditional-fetch idiom → don't fetch
+  if (typeof key === "string") return { skip: false, key };
+  if (Array.isArray(key) && typeof key[0] === "string") return { skip: false, key: key[0] };
+  return { skip: false, key: undefined };
 }
 
 export default function useSWR<T = unknown>(key: unknown, _fetcher?: unknown): SWRResponse<T> {
   // _fetcher is intentionally ignored — calling it would breach the egress jail.
-  const store = (globalThis as unknown as AnchorDataWindow).__vendoAnchorData ?? {};
   const resolved = resolveKey(key);
-  const data = resolved !== undefined ? (store[resolved] as T | undefined) : undefined;
+  if (resolved.skip) {
+    // Not fetching: no spinner. Without this a null/conditional key spun forever.
+    return { data: undefined, error: undefined, isLoading: false, isValidating: false, mutate: async () => undefined };
+  }
+  const store = (globalThis as unknown as AnchorDataWindow).__vendoAnchorData ?? {};
+  const data = resolved.key !== undefined ? (store[resolved.key] as T | undefined) : undefined;
   return {
     data,
     error: undefined,

--- a/packages/vendo-sandbox-shims/src/swr.ts
+++ b/packages/vendo-sandbox-shims/src/swr.ts
@@ -24,10 +24,10 @@ export interface SWRResponse<T> {
   mutate: () => Promise<T | undefined>;
 }
 
-/** SWR conditional-fetching: a null/undefined key, or a function key that
- *  throws/returns null (a dependency isn't ready), means "don't fetch". Returns
- *  `{ skip: true }` for those; otherwise the cache key (or undefined if the key
- *  shape carries no lookup string). */
+/** SWR conditional-fetching: a null/undefined/false key, or a function key that
+ *  throws/returns a falsy key (a dependency isn't ready), means "don't fetch".
+ *  Returns `{ skip: true }` for those; otherwise the cache key (or undefined if
+ *  the key shape carries no lookup string). */
 function resolveKey(key: unknown): { skip: true } | { skip: false; key: string | undefined } {
   if (typeof key === "function") {
     try {
@@ -36,7 +36,8 @@ function resolveKey(key: unknown): { skip: true } | { skip: false; key: string |
       return { skip: true }; // dependency not ready → don't fetch
     }
   }
-  if (key == null) return { skip: true }; // conditional-fetch idiom → don't fetch
+  // null/undefined/false are all "disabled key" idioms: useSWR(ready && "/x").
+  if (key == null || key === false) return { skip: true };
   if (typeof key === "string") return { skip: false, key };
   if (Array.isArray(key) && typeof key[0] === "string") return { skip: false, key: key[0] };
   return { skip: false, key: undefined };

--- a/packages/vendo-sandbox-shims/src/swr.ts
+++ b/packages/vendo-sandbox-shims/src/swr.ts
@@ -5,7 +5,7 @@
  * INVOKED — network egress stays jailed. `mutate` is a no-op unless a declared
  * query backs the key (not in v1). Default export mirrors `swr`.
  */
-import { createElement, Fragment, type ReactElement, type ReactNode } from "react";
+import { createContext, createElement, useContext, type ReactElement, type ReactNode } from "react";
 
 interface AnchorDataWindow {
   __vendoAnchorData?: Record<string, unknown>;
@@ -46,12 +46,20 @@ function resolveKey(key: unknown): { skip: true } | { skip: false; key: string |
 export default function useSWR<T = unknown>(key: unknown, _fetcher?: unknown): SWRResponse<T> {
   // _fetcher is intentionally ignored — calling it would breach the egress jail.
   const resolved = resolveKey(key);
+  const config = useConfig();
   if (resolved.skip) {
     // Not fetching: no spinner. Without this a null/conditional key spun forever.
     return { data: undefined, error: undefined, isLoading: false, isValidating: false, mutate: async () => undefined };
   }
   const store = (globalThis as unknown as AnchorDataWindow).__vendoAnchorData ?? {};
-  const data = resolved.key !== undefined ? (store[resolved.key] as T | undefined) : undefined;
+  // Precedence: live anchor data > provider per-key fallback > provider
+  // fallbackData default. Fallback keeps a component out of a permanent spinner
+  // when the host hasn't injected that key yet.
+  let data = resolved.key !== undefined ? (store[resolved.key] as T | undefined) : undefined;
+  if (data === undefined && resolved.key !== undefined && resolved.key in config.fallback) {
+    data = config.fallback[resolved.key] as T | undefined;
+  }
+  if (data === undefined) data = config.fallbackData as T | undefined;
   return {
     data,
     error: undefined,
@@ -113,15 +121,62 @@ export interface SWRConfiguration {
   cache: Map<string, unknown>;
 }
 
-/** `useSWRConfig()` — a config object with a working `mutate` and sane defaults. */
-export function useSWRConfig(): SWRConfiguration {
-  return { mutate, cache: new Map() };
+/** The provider config threaded through `SWRConfig`. `fallback`/`fallbackData`
+ *  seed `useSWR` and `cache`/`mutate` are shared so `useSWRConfig` sees them. */
+export interface SWRProviderValue extends SWRConfiguration {
+  fallback: Record<string, unknown>;
+  fallbackData: unknown;
 }
 
-/** `SWRConfig` — a passthrough provider. There is no live config in the sandbox,
- *  so it simply renders its children. */
-export function SWRConfig({ children }: { value?: unknown; children?: ReactNode }): ReactElement {
-  return createElement(Fragment, null, children);
+const DEFAULT_CONFIG: SWRProviderValue = {
+  fallback: {},
+  fallbackData: undefined,
+  cache: new Map(),
+  mutate,
+};
+
+const SWRConfigContext = createContext<SWRProviderValue>(DEFAULT_CONFIG);
+
+/** Read the active `SWRConfig`. Tolerates being called outside a React render —
+ *  the shim's hooks are also invoked directly (e.g. in tests / non-render code)
+ *  — by returning the defaults rather than throwing. */
+function useConfig(): SWRProviderValue {
+  try {
+    return useContext(SWRConfigContext);
+  } catch {
+    return DEFAULT_CONFIG;
+  }
+}
+
+export interface SWRConfigValue {
+  fallback?: Record<string, unknown>;
+  fallbackData?: unknown;
+  provider?: () => Map<string, unknown>;
+}
+
+/** `useSWRConfig()` — the active provider config (shared `cache` + `mutate`), so
+ *  callers no longer get a throwaway fresh Map each call. */
+export function useSWRConfig(): SWRConfiguration {
+  return useConfig();
+}
+
+/** `SWRConfig` — provides its `value` (merged over any parent) through context
+ *  so `useSWR`/`useSWRConfig` see the fallback data, shared cache, and mutate. */
+export function SWRConfig({
+  value,
+  children,
+}: {
+  value?: SWRConfigValue;
+  children?: ReactNode;
+}): ReactElement {
+  const parent = useConfig();
+  const merged: SWRProviderValue = {
+    fallback: { ...parent.fallback, ...(value?.fallback ?? {}) },
+    fallbackData: value?.fallbackData !== undefined ? value.fallbackData : parent.fallbackData,
+    cache: typeof value?.provider === "function" ? value.provider() : parent.cache,
+    mutate,
+  };
+  return createElement(SWRConfigContext.Provider, { value: merged }, children);
 }
 
 /** `preload(key, fetcher)` — a safe no-op returning a resolved promise. The

--- a/packages/vendo-sandbox-shims/src/swr.ts
+++ b/packages/vendo-sandbox-shims/src/swr.ts
@@ -63,15 +63,49 @@ export default function useSWR<T = unknown>(key: unknown, _fetcher?: unknown): S
 
 export { useSWR };
 
-/** Global `mutate`. Wired to the same anchor-data cache `useSWR` reads: when
- *  `data` is supplied it writes it under the key so a subsequent `useSWR(key)`
- *  sees the new value, then resolves with it. With no data it is a safe resolved
- *  no-op (there is no revalidation — the fetcher is never run). */
-export function mutate<T = unknown>(key: unknown, data?: T): Promise<T | undefined> {
-  if (typeof key === "string" && data !== undefined) {
-    anchorStore()[key] = data;
+function keyString(key: unknown): string | undefined {
+  if (typeof key === "string") return key;
+  if (Array.isArray(key) && typeof key[0] === "string") return key[0];
+  return undefined;
+}
+
+/** Global `mutate`, wired to the same anchor-data cache `useSWR` reads. Supports:
+ *   - `mutate(key, data)` — write `data` under the key, resolve with it;
+ *   - `mutate(key)` — the revalidate form: no fetcher to run, so resolve with
+ *     the CURRENT cached value rather than silently dropping;
+ *   - `mutate(matcherFn[, data])` — predicate/broadcast form: apply the matcher
+ *     to every cache key, optionally write `data` to matches, resolve with the
+ *     array of matched values.
+ *  (No reactive re-render here — `useSWR` reads synchronously each render.) */
+export function mutate<T = unknown>(
+  keyOrMatcher: unknown,
+  data?: T,
+  _opts?: unknown,
+): Promise<T | undefined | Array<T | undefined>> {
+  const store = anchorStore();
+  const hasData = data !== undefined;
+
+  if (typeof keyOrMatcher === "function") {
+    const matcher = keyOrMatcher as (key: string) => unknown;
+    const results: Array<T | undefined> = [];
+    for (const k of Object.keys(store)) {
+      let matches = false;
+      try {
+        matches = Boolean(matcher(k));
+      } catch {
+        matches = false;
+      }
+      if (!matches) continue;
+      if (hasData) store[k] = data;
+      results.push(store[k] as T | undefined);
+    }
+    return Promise.resolve(results);
   }
-  return Promise.resolve(data);
+
+  const key = keyString(keyOrMatcher);
+  if (key === undefined) return Promise.resolve(undefined);
+  if (hasData) store[key] = data;
+  return Promise.resolve(store[key] as T | undefined);
 }
 
 export interface SWRConfiguration {

--- a/packages/vendo-sandbox-shims/src/swr.ts
+++ b/packages/vendo-sandbox-shims/src/swr.ts
@@ -5,8 +5,15 @@
  * INVOKED — network egress stays jailed. `mutate` is a no-op unless a declared
  * query backs the key (not in v1). Default export mirrors `swr`.
  */
+import { createElement, Fragment, type ReactElement, type ReactNode } from "react";
+
 interface AnchorDataWindow {
   __vendoAnchorData?: Record<string, unknown>;
+}
+
+function anchorStore(): Record<string, unknown> {
+  const win = globalThis as unknown as AnchorDataWindow;
+  return (win.__vendoAnchorData ??= {});
 }
 
 export interface SWRResponse<T> {
@@ -38,3 +45,36 @@ export default function useSWR<T = unknown>(key: unknown, _fetcher?: unknown): S
 }
 
 export { useSWR };
+
+/** Global `mutate`. Wired to the same anchor-data cache `useSWR` reads: when
+ *  `data` is supplied it writes it under the key so a subsequent `useSWR(key)`
+ *  sees the new value, then resolves with it. With no data it is a safe resolved
+ *  no-op (there is no revalidation — the fetcher is never run). */
+export function mutate<T = unknown>(key: unknown, data?: T): Promise<T | undefined> {
+  if (typeof key === "string" && data !== undefined) {
+    anchorStore()[key] = data;
+  }
+  return Promise.resolve(data);
+}
+
+export interface SWRConfiguration {
+  mutate: typeof mutate;
+  cache: Map<string, unknown>;
+}
+
+/** `useSWRConfig()` — a config object with a working `mutate` and sane defaults. */
+export function useSWRConfig(): SWRConfiguration {
+  return { mutate, cache: new Map() };
+}
+
+/** `SWRConfig` — a passthrough provider. There is no live config in the sandbox,
+ *  so it simply renders its children. */
+export function SWRConfig({ children }: { value?: unknown; children?: ReactNode }): ReactElement {
+  return createElement(Fragment, null, children);
+}
+
+/** `preload(key, fetcher)` — a safe no-op returning a resolved promise. The
+ *  fetcher is never invoked (egress stays jailed); data arrives via anchorData. */
+export function preload(_key: unknown, _fetcher?: unknown): Promise<undefined> {
+  return Promise.resolve(undefined);
+}


### PR DESCRIPTION
## What

Stacked on the shell-UI wave (#69). Eight confirmed gaps in the shims that let generated sandbox components import `next/navigation`, `next/link`, and `swr` — plus 7 Codex-review refinements. 14 commits, TDD'd; shim suite 6 → 43 tests.

### Fixes
- **next/navigation**: added `useParams`, `redirect` (navigates then **throws** to unwind render, like real Next — hits the sandbox error boundary so a guarded component can't render protected content), `notFound` (throws), `useSelectedLayoutSegment(s)`. `back()`/`forward()` are safe no-ops instead of throwing into a React handler.
- **swr**: added `useSWRConfig`, global `mutate` (revalidate + predicate forms), `SWRConfig` (threads `fallback`/`fallbackData`/shared cache through context), `preload`. `useSWR` now treats `null`/`undefined`/`false`/skip-function keys as disabled (`isLoading:false`) instead of a permanent spinner.
- **next/link**: builds the full URL from a `UrlObject` (`pathname?query#hash`); the click handler runs the user's `onClick` first and respects `defaultPrevented`, modified clicks (meta/ctrl/shift/alt), non-primary buttons, and `target`; it only intercepts **local app paths** (relative or `/absolute`), letting `https://`/`mailto:`/`tel:`/`#hash`/`download` fall through to the browser. Added `useLinkStatus` (Next 16 export).
- **dispatch**: `dispatch()`/`navigate()` now return the raw bridge promise so a blocked/denied action's rejection reaches awaiting component code; the one fire-and-forget site (Link) catches. (Fixes the previous unhandled-rejection + dead-click.)

### Codex review
Ran once; its 7 findings (redirect/notFound must throw, dispatch must propagate rejections, SWR `false` key, Link hijacking non-local hrefs, mutate predicate form, SWRConfig value threading, `useLinkStatus`) are all fixed in-branch — two of them reversed my own initial instructions.

### Flagged follow-up (needs your call — NOT built)
`usePathname()`/`useSearchParams()`/`useParams()` still return safe **empty** values (they don't crash, but don't reflect the anchor's real route). Surfacing real route values needs a **new route channel** parallel to the existing `__vendoAnchorData` data channel, spanning `vendo-stage/runtime.ts` + `stage-host.ts` and `vendo-react/stage-adapter.tsx` — a cross-package feature, larger and higher-risk than a shim fix. Deferred deliberately.

`pnpm typecheck` 27/27 · `pnpm test` 25/25 · lint clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the sandbox shims for `next/navigation`, `next/link`, and `swr` so generated components import them safely, with safer link handling and proper promise propagation to prevent dead clicks and spinners.

- **New Features**
  - `next/navigation`: adds `useParams`, `redirect`/`notFound` (they throw to unwind render), `useSelectedLayoutSegment(s)`; `push`/`replace` navigate; `back`/`forward` are safe no-ops.
  - `next/link`: builds full URLs from a `UrlObject` (pathname + query + hash); exports `useLinkStatus`.
  - `swr`: adds `useSWRConfig`, `SWRConfig` (fallback/fallbackData + shared cache), global `mutate` (key, revalidate, predicate), and `preload`; `useSWR` reads provider fallback.

- **Bug Fixes**
  - `dispatch`/`navigate` now return the raw bridge Promise so rejections reach awaiters; `Link` catches a blocked navigation to avoid unhandled rejections.
  - `useSWR` treats `null`/`false`/skip-function keys as disabled (no permanent spinner).
  - `Link` respects `onClick` cancel, modified/non-primary clicks, and `target`, and only intercepts local app paths; external/hash/download links fall through.

<sup>Written for commit 7c53388f6f0625e512041fe94b039ee9765d3a3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

