### PR TITLE
Hardening wave 6: install/init correctness (vendo-cli)

### DIFF
--- a/packages/vendo-cli/src/components/extract-components.test.ts
+++ b/packages/vendo-cli/src/components/extract-components.test.ts
@@ -39,6 +39,21 @@ describe("extractComponents", () => {
     expect(viteConfig).toContain('"@": path.resolve(here, "../../src")');
   });
 
+  it("adds the component-bundle build deps to devDependencies when components are written", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "comp-"));
+    await mkdir(path.join(dir, "src/components/ui"), { recursive: true });
+    await writeFile(path.join(dir, "package.json"), JSON.stringify({ name: "app" }, null, 2));
+    await writeFile(path.join(dir, "src/components/ui/badge.tsx"), "export const Badge = () => null");
+    await extractComponents(dir, textModel([INCLUDE]), { force: false });
+    const pkg = JSON.parse(await readFile(path.join(dir, "package.json"), "utf8")) as {
+      devDependencies?: Record<string, string>;
+    };
+    // .vendo/components build imports @vendoai/stage/build + vite + the react plugin.
+    expect(pkg.devDependencies?.["@vendoai/stage"]).toBeDefined();
+    expect(pkg.devDependencies?.["vite"]).toBeDefined();
+    expect(pkg.devDependencies?.["@vitejs/plugin-react"]).toBeDefined();
+  });
+
   it("repairs a broken wrapper once by feeding the codegen error back", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "comp-"));
     await mkdir(path.join(dir, "src/components/ui"), { recursive: true });

--- a/packages/vendo-cli/src/components/extract-components.ts
+++ b/packages/vendo-cli/src/components/extract-components.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import type { LanguageModel } from "ai";
 import { writeGenerated } from "../fsx.js";
+import { addDevDependency } from "../next-wiring.js";
 import { scanComponents } from "./scan.js";
 import { analyzeComponent } from "./analyze.js";
 import { writeComponent, entrySource, viteConfigSource, aliasesFromTsconfigPaths } from "./codegen.js";
@@ -80,6 +81,26 @@ export async function extractComponents(
       viteConfigSource(await hostAliases(targetDir)),
       opts,
     );
+    // The generated bundle build (vite.config.mts → entry.ts) imports
+    // @vendoai/stage/build + vite + the react plugin. Add them so a manual /
+    // deferred `vite build` in .vendo/components/ resolves. Best-effort:
+    // missing/unparsable package.json is left alone.
+    await addComponentBuildDeps(targetDir);
   }
   return { candidates: candidates.length, written, excluded, failed };
+}
+
+const COMPONENT_BUILD_DEPS = ["@vendoai/stage", "vite", "@vitejs/plugin-react"];
+
+async function addComponentBuildDeps(targetDir: string): Promise<void> {
+  const pkgPath = path.join(targetDir, "package.json");
+  let raw: string;
+  try {
+    raw = await fs.readFile(pkgPath, "utf8");
+  } catch {
+    return;
+  }
+  let out = raw;
+  for (const dep of COMPONENT_BUILD_DEPS) out = addDevDependency(out, dep, "latest") ?? out;
+  if (out !== raw) await fs.writeFile(pkgPath, out);
 }

--- a/packages/vendo-cli/src/components/scan.test.ts
+++ b/packages/vendo-cli/src/components/scan.test.ts
@@ -19,6 +19,32 @@ describe("scanComponents", () => {
     expect(candidates[0]!.relFile).toMatch(/^src\/components\/ui\//);
   });
 
+  it("recognizes shadcn `export { Button }` re-exports and `export { X as Y }`, skipping lowercase utils", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "scan-"));
+    await mkdir(path.join(dir, "src/components/ui"), { recursive: true });
+    await writeFile(
+      path.join(dir, "src/components/ui/button.tsx"),
+      `import * as React from "react"
+const Button = React.forwardRef((props, ref) => null)
+const buttonVariants = () => ""
+export { Button, buttonVariants }`,
+    );
+    await writeFile(
+      path.join(dir, "src/components/ui/alert.tsx"),
+      `const AlertImpl = () => null
+export { AlertImpl as Alert }`,
+    );
+    const candidates = await scanComponents(dir);
+    const byFile = Object.fromEntries(candidates.map((c) => [c.relFile, c]));
+    const button = byFile["src/components/ui/button.tsx"]!;
+    expect(button).toBeDefined();
+    expect(button.exportName).toBe("Button");
+    expect(button.exportNames).toContain("Button");
+    expect(button.exportNames).not.toContain("buttonVariants"); // lowercase util skipped
+    const alert = byFile["src/components/ui/alert.tsx"]!;
+    expect(alert.exportName).toBe("Alert"); // the `X as Y` exported name
+  });
+
   it("scans components/ui before other component dirs so the cap keeps primitives", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "scan-"));
     await mkdir(path.join(dir, "src/components/aaa"), { recursive: true });

--- a/packages/vendo-cli/src/components/scan.ts
+++ b/packages/vendo-cli/src/components/scan.ts
@@ -14,10 +14,38 @@ export interface ComponentCandidate {
   source: string;
 }
 
-const EXPORT_RE = /export\s+(?:function|const)\s+([A-Z][A-Za-z0-9]*)/;
-const EXPORT_RE_ALL = /export\s+(?:function|const)\s+([A-Z][A-Za-z0-9]*)/g;
+// export function/const/class Foo — the declaration form.
+const EXPORT_DECL_RE = /export\s+(?:async\s+)?(?:function|const|class)\s+([A-Za-z_$][A-Za-z0-9_$]*)/g;
+// export { A, B as C } — the clause/re-export form (shadcn declares
+// `const Button = React.forwardRef(...)` then `export { Button, buttonVariants }`).
+const EXPORT_CLAUSE_RE = /export\s*\{([^}]*)\}/g;
 const MAX_CANDIDATES = 25;
 const MAX_FILE_BYTES = 40_000;
+
+/** Every exported symbol that looks like a component (PascalCase), in source
+ *  order, deduped. Recognizes both `export function/const Name` and the
+ *  `export { Name, X as Y }` re-export shape; lowercase/util exports are skipped. */
+function exportedComponentNames(source: string): string[] {
+  const hits: Array<{ index: number; name: string }> = [];
+  for (const m of source.matchAll(EXPORT_DECL_RE)) hits.push({ index: m.index!, name: m[1]! });
+  for (const m of source.matchAll(EXPORT_CLAUSE_RE)) {
+    for (const part of m[1]!.split(",")) {
+      const seg = part.trim().replace(/^type\s+/, "");
+      if (!seg) continue;
+      const name = (seg.split(/\s+as\s+/).pop() ?? seg).trim(); // `A as B` exports B
+      hits.push({ index: m.index!, name });
+    }
+  }
+  const seen = new Set<string>();
+  const names: string[] = [];
+  for (const { name } of hits.sort((a, b) => a.index - b.index)) {
+    if (/^[A-Z][A-Za-z0-9]*$/.test(name) && !seen.has(name)) {
+      seen.add(name);
+      names.push(name);
+    }
+  }
+  return names;
+}
 
 export async function scanComponents(targetDir: string): Promise<ComponentCandidate[]> {
   const files = await walk(
@@ -40,13 +68,12 @@ export async function scanComponents(targetDir: string): Promise<ComponentCandid
     if (candidates.length >= MAX_CANDIDATES) break;
     const source = await fs.readFile(file, "utf8");
     if (source.length > MAX_FILE_BYTES) continue; // giant files are not reusable primitives
-    const m = source.match(EXPORT_RE);
-    if (!m || !m[1]) continue;
-    const exportNames = [...source.matchAll(EXPORT_RE_ALL)].map((x) => x[1]!);
+    const exportNames = exportedComponentNames(source);
+    if (exportNames.length === 0) continue;
     candidates.push({
       file,
       relFile: path.relative(targetDir, file).replace(/\\/g, "/"),
-      exportName: m[1],
+      exportName: exportNames[0]!,
       exportNames,
       source,
     });

--- a/packages/vendo-cli/src/fsx.test.ts
+++ b/packages/vendo-cli/src/fsx.test.ts
@@ -29,6 +29,19 @@ describe("writeGenerated", () => {
     await expect(writeGenerated(path.join(dir, "out.json"), "2", { force: false })).rejects.toThrow(/--force/);
   });
 
+  it("resumes: an existing file with IDENTICAL content is a no-op success without force", async () => {
+    const dir = await scratch();
+    await writeGenerated(path.join(dir, "out.json"), "same", { force: false });
+    // A re-run after a mid-init failure re-writes the same bytes — should not throw.
+    await expect(
+      writeGenerated(path.join(dir, "out.json"), "same", { force: false }),
+    ).resolves.toBeUndefined();
+    // But DIFFERENT content is still refused (hand-edit protection intact).
+    await expect(
+      writeGenerated(path.join(dir, "out.json"), "edited", { force: false }),
+    ).rejects.toThrow(/--force/);
+  });
+
   it("overwrites with force and creates parent dirs", async () => {
     const dir = await scratch();
     await writeGenerated(path.join(dir, "a/b/out.json"), "1", { force: false });

--- a/packages/vendo-cli/src/fsx.ts
+++ b/packages/vendo-cli/src/fsx.ts
@@ -40,11 +40,18 @@ export async function writeGenerated(
   opts: { force: boolean },
 ): Promise<void> {
   if (!opts.force) {
+    let existing: string | null = null;
     try {
-      await fs.access(file);
-      throw new Error(`${file} already exists — outputs are developer-editable; re-run with --force to overwrite`);
+      existing = await fs.readFile(file, "utf8");
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    }
+    // Resume support: re-running `vendo init` after a mid-run failure re-writes
+    // identical bytes — treat that as a no-op success. DIFFERENT content is
+    // still refused so hand-edits are never silently clobbered.
+    if (existing !== null) {
+      if (existing === content) return;
+      throw new Error(`${file} already exists — outputs are developer-editable; re-run with --force to overwrite`);
     }
   }
   await fs.mkdir(path.dirname(file), { recursive: true });

--- a/packages/vendo-cli/src/next-wiring.test.ts
+++ b/packages/vendo-cli/src/next-wiring.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   addDependency,
+  addDevDependency,
   addPrebuildSync,
   mergeInstrumentation,
   productNameFrom,
@@ -167,6 +168,27 @@ describe("addDependency", () => {
   });
 });
 
+describe("addDevDependency", () => {
+  it("creates the devDependencies block, adds sorted, and is idempotent", () => {
+    const created = addDevDependency(JSON.stringify({ name: "x" }, null, 2), "@vendoai/cli", "latest")!;
+    expect(JSON.parse(created).devDependencies["@vendoai/cli"]).toBe("latest");
+
+    const out = addDevDependency(
+      JSON.stringify({ name: "x", devDependencies: { vitest: "^2" } }, null, 2),
+      "@vendoai/cli",
+      "latest",
+    )!;
+    expect(Object.keys(JSON.parse(out).devDependencies)).toEqual(["@vendoai/cli", "vitest"]);
+
+    // Re-run leaves it alone.
+    expect(addDevDependency(out, "@vendoai/cli", "latest")).toBe(out);
+  });
+
+  it("returns null on unparsable package.json", () => {
+    expect(addDevDependency("{nope", "@vendoai/cli", "latest")).toBeNull();
+  });
+});
+
 describe("addPrebuildSync", () => {
   it("creates a prebuild script, extends an existing one, and is idempotent", () => {
     const created = addPrebuildSync(JSON.stringify({ name: "x" }))!;
@@ -280,6 +302,17 @@ describe("wireNextApp", () => {
 
     // sandbox assets aren't bundled in the source tree — reported, not fatal
     expect(summary.skipped.some((s) => s.step === "sandbox-assets")).toBe(true);
+  });
+
+  it("adds @vendoai/cli to the app's devDependencies so `vendo sync` resolves at build time", async () => {
+    const dir = await scaffoldFreshApp(false);
+    const info = await detectTarget(dir);
+    await wireNextApp(dir, info, { force: false });
+    const pkg = JSON.parse(await fs.readFile(path.join(dir, "package.json"), "utf8")) as {
+      devDependencies?: Record<string, string>;
+    };
+    // prebuild runs `vendo sync`, so the CLI must be installed alongside it.
+    expect(pkg.devDependencies?.["@vendoai/cli"]).toBeDefined();
   });
 
   it("writes instrumentation.ts at the project root for an app/ (non-src) layout", async () => {

--- a/packages/vendo-cli/src/next-wiring.test.ts
+++ b/packages/vendo-cli/src/next-wiring.test.ts
@@ -382,6 +382,58 @@ describe("wireNextApp", () => {
     expect(summary.manual.some((m) => m.includes("AppVendoRoot"))).toBe(true);
   });
 
+  async function scaffoldWithNext(version: string): Promise<string> {
+    const dir = mkdtempSync(path.join(tmpdir(), "vendo-nextcfg-"));
+    const appDir = path.join(dir, "app");
+    await fs.mkdir(appDir, { recursive: true });
+    await fs.writeFile(path.join(appDir, "layout.tsx"), CREATE_NEXT_APP_LAYOUT);
+    await fs.writeFile(path.join(dir, "tsconfig.json"), "{}");
+    await fs.writeFile(
+      path.join(dir, "package.json"),
+      JSON.stringify({ name: "app", dependencies: { next: version } }, null, 2),
+    );
+    return dir;
+  }
+
+  it("creates next.config.mjs with experimental.instrumentationHook on Next 14 (no config present)", async () => {
+    const dir = await scaffoldWithNext("14.2.3");
+    const info = await detectTarget(dir);
+    const summary = (await wireNextApp(dir, info, { force: false }))!;
+    const cfg = await fs.readFile(path.join(dir, "next.config.mjs"), "utf8");
+    expect(cfg).toContain("instrumentationHook: true");
+    expect(summary.written).toContain("next.config.mjs");
+  });
+
+  it("does NOT touch next.config on Next 15+ (the flag is the default there)", async () => {
+    const dir = await scaffoldWithNext("15.0.0");
+    const info = await detectTarget(dir);
+    await wireNextApp(dir, info, { force: false });
+    expect(await exists(path.join(dir, "next.config.mjs"))).toBe(false);
+    expect(await exists(path.join(dir, "next.config.js"))).toBe(false);
+  });
+
+  it("skips + prints a manual step when a next.config already exists on Next 14 (no risky AST edit)", async () => {
+    const dir = await scaffoldWithNext("14.2.3");
+    await fs.writeFile(path.join(dir, "next.config.js"), "module.exports = { reactStrictMode: true };\n");
+    const info = await detectTarget(dir);
+    const summary = (await wireNextApp(dir, info, { force: false }))!;
+    expect(await fs.readFile(path.join(dir, "next.config.js"), "utf8")).toContain("reactStrictMode: true");
+    expect(summary.manual.some((m) => m.includes("instrumentationHook"))).toBe(true);
+    expect(await exists(path.join(dir, "next.config.mjs"))).toBe(false);
+  });
+
+  it("reports already-wired when an existing config sets instrumentationHook", async () => {
+    const dir = await scaffoldWithNext("14.2.3");
+    await fs.writeFile(
+      path.join(dir, "next.config.mjs"),
+      "export default { experimental: { instrumentationHook: true } };\n",
+    );
+    const info = await detectTarget(dir);
+    const summary = (await wireNextApp(dir, info, { force: false }))!;
+    expect(summary.skipped.some((s) => s.step === "next.config" && /already/.test(s.reason))).toBe(true);
+    expect(summary.manual.some((m) => m.includes("instrumentationHook"))).toBe(false);
+  });
+
   it("returns null for non-Next targets and skips gracefully without an app dir", async () => {
     const dir = mkdtempSync(path.join(tmpdir(), "vendo-wire-"));
     await fs.writeFile(path.join(dir, "package.json"), JSON.stringify({ name: "not-next" }));

--- a/packages/vendo-cli/src/next-wiring.ts
+++ b/packages/vendo-cli/src/next-wiring.ts
@@ -168,6 +168,33 @@ export async function register() {
 }
 `;
 
+const NEXT_CONFIG_SOURCE = `/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // Vendo boots its automation scheduler from instrumentation.ts. Next 13/14
+  // load that file only when this flag is set; Next 15+ ignore it (default on).
+  experimental: { instrumentationHook: true },
+};
+
+export default nextConfig;
+`;
+
+/** The Next major version from package.json (dependencies or devDependencies),
+ *  or undefined when absent/unparsable. Used to gate the instrumentationHook
+ *  step — Next 15+ enables it by default and needs no config edit. */
+export function nextMajorVersion(pkgJson: string): number | undefined {
+  try {
+    const pkg = JSON.parse(pkgJson) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const v = pkg.dependencies?.["next"] ?? pkg.devDependencies?.["next"];
+    const m = typeof v === "string" ? v.match(/(\d+)/) : null;
+    return m ? Number(m[1]) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Merge the scheduler-boot `register()` into an existing `instrumentation.ts`
  * non-destructively. Returns the merged source, the input unchanged when
@@ -492,6 +519,42 @@ export async function wireNextApp(
       summary.edited.push(rel(instrumentationFile));
     } else {
       summary.skipped.push({ step: "instrumentation", reason: "already wired" });
+    }
+  }
+
+  // 4b. experimental.instrumentationHook — Next 13/14 load instrumentation.ts
+  // ONLY with this flag; 15+ ignore it (default on). Version-gated so we never
+  // touch a config that doesn't need it. Undetermined version → treat as
+  // needing it (the flag is harmless on 15+). Following the codemod's fail-safe
+  // convention, an EXISTING config is never AST-edited — we skip + print a
+  // manual step; only an absent config is written for us.
+  const nextMajor = pkgRaw ? nextMajorVersion(pkgRaw) : undefined;
+  if (nextMajor === undefined || nextMajor < 15) {
+    const configNames = ["next.config.js", "next.config.mjs", "next.config.ts", "next.config.cjs"];
+    let configFile: string | undefined;
+    for (const name of configNames) {
+      if (await exists(path.join(targetDir, name))) {
+        configFile = path.join(targetDir, name);
+        break;
+      }
+    }
+    if (!configFile) {
+      const dest = path.join(targetDir, "next.config.mjs");
+      await fs.writeFile(dest, NEXT_CONFIG_SOURCE);
+      summary.written.push(rel(dest));
+    } else {
+      const configSrc = (await readIf(configFile)) ?? "";
+      if (maskLiterals(configSrc).includes("instrumentationHook")) {
+        summary.skipped.push({ step: "next.config", reason: `${rel(configFile)} already sets instrumentationHook` });
+      } else {
+        summary.skipped.push({
+          step: "next.config",
+          reason: `${rel(configFile)} exists — left untouched (Next <15 needs experimental.instrumentationHook)`,
+        });
+        summary.manual.push(
+          `add experimental: { instrumentationHook: true } to ${rel(configFile)} (required on Next 13/14 so instrumentation.ts loads)`,
+        );
+      }
     }
   }
 

--- a/packages/vendo-cli/src/next-wiring.ts
+++ b/packages/vendo-cli/src/next-wiring.ts
@@ -307,6 +307,24 @@ export function addDependency(pkgJson: string, name: string, version: string): s
   return JSON.stringify(pkg, null, 2) + "\n";
 }
 
+/** Merge a package into package.json `devDependencies` (same format contract as
+ *  addDependency). Build-time tooling (`@vendoai/cli` for `vendo sync`, the
+ *  component-bundle build deps) belongs in devDependencies, not runtime deps. */
+export function addDevDependency(pkgJson: string, name: string, version: string): string | null {
+  let pkg: Record<string, unknown>;
+  try {
+    pkg = JSON.parse(pkgJson) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  const deps = (pkg["devDependencies"] ?? {}) as Record<string, string>;
+  if (deps[name]) return pkgJson; // already present — leave the file alone
+  pkg["devDependencies"] = Object.fromEntries(
+    Object.entries({ ...deps, [name]: version }).sort(([a], [b]) => a.localeCompare(b)),
+  );
+  return JSON.stringify(pkg, null, 2) + "\n";
+}
+
 /** Add `vendo sync` to the app's `prebuild` script (create or extend),
  *  so every production build refreshes the capture + sandbox environment.
  *  Idempotent: never adds a second copy. */
@@ -532,8 +550,12 @@ export async function wireNextApp(
       summary.skipped.push({ step: "package.json", reason: "unparsable — add @vendoai/next yourself" });
       summary.manual.push('add "@vendoai/next" to package.json dependencies and install');
       summary.manual.push('add "vendo sync" to your package.json "prebuild" script');
+      summary.manual.push('add "@vendoai/cli" to package.json devDependencies (the prebuild `vendo sync` runner)');
     } else {
-      const withSync = addPrebuildSync(withDep) ?? withDep;
+      // @vendoai/cli is a devDependency: `prebuild: vendo sync` needs it to
+      // resolve at build time.
+      const withCli = addDevDependency(withDep, "@vendoai/cli", "latest") ?? withDep;
+      const withSync = addPrebuildSync(withCli) ?? withCli;
       if (withSync !== pkgRaw) {
         await fs.writeFile(path.join(targetDir, "package.json"), withSync);
         summary.edited.push("package.json");

--- a/packages/vendo-cli/src/sync/capture.test.ts
+++ b/packages/vendo-cli/src/sync/capture.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -169,6 +169,24 @@ export default function Page() {
     expect(records["b"]).toBeUndefined();
     expect(report.join("\n")).toContain("server/ directory");
     expect(report.join("\n")).toContain('"use server" directive');
+  });
+
+  it("realpaths before the refusal check so a symlink can't smuggle server-only code out", () => {
+    const dir = app({
+      "src/server/secret.tsx": `export function Secret() { return null }`,
+      "src/app/page.tsx": `import { VendoRemix } from "@vendoai/shell"
+import { Secret } from "../widget"
+export default function Page() {
+  return <VendoRemix id="w"><Secret /></VendoRemix>
+}
+`,
+    });
+    // src/widget.tsx is a symlink to the server-only file. Its unresolved path
+    // ("widget.tsx") passes the guard; only the realpath is under server/.
+    symlinkSync(path.join(dir, "src/server/secret.tsx"), path.join(dir, "src/widget.tsx"));
+    const { records, report } = captureRemixSources(dir, { now: NOW });
+    expect(records["w"]).toBeUndefined();
+    expect(report.join("\n")).toContain("server/ directory");
   });
 
   it("caps oversized sources with a visible marker", () => {

--- a/packages/vendo-cli/src/sync/capture.ts
+++ b/packages/vendo-cli/src/sync/capture.ts
@@ -13,7 +13,7 @@
  * `pages/api/`, or outside the app source root are refused.
  */
 import { createHash } from "node:crypto";
-import { readFileSync, readdirSync, statSync } from "node:fs";
+import { readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
 import ts from "typescript";
 import type { RemixSourceRecord } from "@vendoai/core";
@@ -102,7 +102,16 @@ export function resolveModuleFile(
 
 /** Threat-model refusal — evaluated on the RESOLVED path + content. */
 export function refusalReason(file: string, content: string, sourceRoot: string): string | undefined {
-  const rel = path.relative(sourceRoot, file);
+  // Realpath both sides before the path checks: a symlink under src/ pointing
+  // at out-of-root or server/ code would otherwise pass on its unresolved path.
+  const real = (p: string) => {
+    try {
+      return realpathSync(p);
+    } catch {
+      return p;
+    }
+  };
+  const rel = path.relative(real(sourceRoot), real(file));
   if (rel.startsWith("..")) return "outside the app source root";
   const segments = rel.split(path.sep);
   if (segments.includes("server")) return "under a server/ directory";

--- a/packages/vendo-cli/src/sync/env-local.test.ts
+++ b/packages/vendo-cli/src/sync/env-local.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -89,6 +89,66 @@ describe("buildEnvironment local vendoring (fast-edits follow-up)", () => {
     expect(manifest.anchors["w"]?.["@/lib/data"]?.kind).toBe("absent");
     expect(report.join("\n")).toContain("could not vendor local");
     expect(existsSync(path.join(dir, ".vendo/env/vendor/local--lib-data.js"))).toBe(false);
+  });
+
+  it("gives each anchor the correctly-resolved bundle when a shared specifier resolves to DIFFERENT files", async () => {
+    const dir = app({
+      "src/a/cn.ts": `export const cn = () => "from-a";`,
+      "src/b/cn.ts": `export const cn = () => "from-b";`,
+    });
+    const rec = (file: string): RemixSourceRecord => ({
+      file,
+      source: `import { cn } from "./cn"\nexport default function W(){ return cn() }`,
+      sourceHash: "h",
+      capturedAt: "2026-07-04T00:00:00.000Z",
+    });
+    const { manifest } = await buildEnvironment(
+      dir,
+      { a: rec("src/a/w.tsx"), b: rec("src/b/w.tsx") },
+      { now: () => "2026-07-04T00:00:00.000Z" },
+    );
+    expect(manifest.anchors["a"]?.["./cn"]?.kind).toBe("real");
+    expect(manifest.anchors["b"]?.["./cn"]?.kind).toBe("real");
+
+    const map = JSON.parse(readFileSync(path.join(dir, ".vendo/env/import-map.json"), "utf8")) as {
+      imports: Record<string, string>;
+      scopes?: Record<string, Record<string, string>>;
+    };
+    // Same specifier "./cn", two different files → per-anchor entries, not one
+    // shared (last-write-wins) bundle.
+    const aUrl = map.scopes?.["a"]?.["./cn"] ?? map.imports["./cn"];
+    const bUrl = map.scopes?.["b"]?.["./cn"] ?? map.imports["./cn"];
+    expect(aUrl).toBeDefined();
+    expect(bUrl).toBeDefined();
+    expect(aUrl).not.toBe(bUrl);
+    const read = (u: string) => readFileSync(path.join(dir, ".vendo/env", u.replace(/^\.\//, "")), "utf8");
+    expect(read(aUrl!)).toContain("from-a");
+    expect(read(aUrl!)).not.toContain("from-b");
+    expect(read(bUrl!)).toContain("from-b");
+    expect(read(bUrl!)).not.toContain("from-a");
+  });
+
+  it("dedups to one bundle when two anchors resolve a shared specifier to the SAME file", async () => {
+    const dir = app({ "src/shared/cn.ts": `export const cn = () => "shared";` });
+    const rec = (file: string): RemixSourceRecord => ({
+      file,
+      source: `import { cn } from "@/shared/cn"\nexport default function W(){ return cn() }`,
+      sourceHash: "h",
+      capturedAt: "2026-07-04T00:00:00.000Z",
+    });
+    await buildEnvironment(
+      dir,
+      { a: rec("src/a/w.tsx"), b: rec("src/b/w.tsx") },
+      { now: () => "2026-07-04T00:00:00.000Z" },
+    );
+    const map = JSON.parse(readFileSync(path.join(dir, ".vendo/env/import-map.json"), "utf8")) as {
+      imports: Record<string, string>;
+      scopes?: Record<string, Record<string, string>>;
+    };
+    expect(map.imports["@/shared/cn"]).toBeDefined(); // single flat entry, no scope needed
+    expect(map.scopes?.["a"]?.["@/shared/cn"]).toBeUndefined();
+    const localBundles = readdirSync(path.join(dir, ".vendo/env/vendor")).filter((f) => f.startsWith("local-"));
+    expect(localBundles).toHaveLength(1);
   });
 
   it("refuses a local module that imports @vendoai/shell or unprovided bare packages", async () => {

--- a/packages/vendo-cli/src/sync/env-local.test.ts
+++ b/packages/vendo-cli/src/sync/env-local.test.ts
@@ -91,7 +91,7 @@ describe("buildEnvironment local vendoring (fast-edits follow-up)", () => {
     expect(existsSync(path.join(dir, ".vendo/env/vendor/local--lib-data.js"))).toBe(false);
   });
 
-  it("gives each anchor the correctly-resolved bundle when a shared specifier resolves to DIFFERENT files", async () => {
+  it("gives each anchor a UNIQUE flat import when a shared specifier resolves to DIFFERENT files", async () => {
     const dir = app({
       "src/a/cn.ts": `export const cn = () => "from-a";`,
       "src/b/cn.ts": `export const cn = () => "from-b";`,
@@ -99,36 +99,45 @@ describe("buildEnvironment local vendoring (fast-edits follow-up)", () => {
     const rec = (file: string): RemixSourceRecord => ({
       file,
       source: `import { cn } from "./cn"\nexport default function W(){ return cn() }`,
+      prepared: `import { cn } from "./cn"\nexport default function W(){ return cn() }`,
       sourceHash: "h",
       capturedAt: "2026-07-04T00:00:00.000Z",
     });
-    const { manifest } = await buildEnvironment(
-      dir,
-      { a: rec("src/a/w.tsx"), b: rec("src/b/w.tsx") },
-      { now: () => "2026-07-04T00:00:00.000Z" },
-    );
-    expect(manifest.anchors["a"]?.["./cn"]?.kind).toBe("real");
-    expect(manifest.anchors["b"]?.["./cn"]?.kind).toBe("real");
+    const records = { a: rec("src/a/w.tsx"), b: rec("src/b/w.tsx") };
+    const { manifest } = await buildEnvironment(dir, records, { now: () => "2026-07-04T00:00:00.000Z" });
 
     const map = JSON.parse(readFileSync(path.join(dir, ".vendo/env/import-map.json"), "utf8")) as {
       imports: Record<string, string>;
-      scopes?: Record<string, Record<string, string>>;
+      scopes?: unknown;
     };
-    // Same specifier "./cn", two different files → per-anchor entries, not one
-    // shared (last-write-wins) bundle.
-    const aUrl = map.scopes?.["a"]?.["./cn"] ?? map.imports["./cn"];
-    const bUrl = map.scopes?.["b"]?.["./cn"] ?? map.imports["./cn"];
+    // The runtime reads only flat `imports` (applied globally) — no scopes.
+    expect(map.scopes).toBeUndefined();
+
+    // The colliding "./cn" is rewritten to a UNIQUE specifier per anchor in the
+    // manifest, the baseline source/prepared, AND the flat import map — all
+    // three agree, so BOTH modules resolve end-to-end.
+    const aSpec = Object.keys(manifest.anchors["a"]!).find((s) => s.startsWith("./cn"))!;
+    const bSpec = Object.keys(manifest.anchors["b"]!).find((s) => s.startsWith("./cn"))!;
+    expect(aSpec).not.toBe(bSpec);
+    expect(manifest.anchors["a"]![aSpec]!.kind).toBe("real");
+    expect(manifest.anchors["b"]![bSpec]!.kind).toBe("real");
+    expect(records.a.source).toContain(`from "${aSpec}"`);
+    expect(records.a.prepared).toContain(`from "${aSpec}"`);
+    expect(records.b.source).toContain(`from "${bSpec}"`);
+
+    const aUrl = map.imports[aSpec]!;
+    const bUrl = map.imports[bSpec]!;
     expect(aUrl).toBeDefined();
     expect(bUrl).toBeDefined();
     expect(aUrl).not.toBe(bUrl);
     const read = (u: string) => readFileSync(path.join(dir, ".vendo/env", u.replace(/^\.\//, "")), "utf8");
-    expect(read(aUrl!)).toContain("from-a");
-    expect(read(aUrl!)).not.toContain("from-b");
-    expect(read(bUrl!)).toContain("from-b");
-    expect(read(bUrl!)).not.toContain("from-a");
+    expect(read(aUrl)).toContain("from-a");
+    expect(read(aUrl)).not.toContain("from-b");
+    expect(read(bUrl)).toContain("from-b");
+    expect(read(bUrl)).not.toContain("from-a");
   });
 
-  it("dedups to one bundle when two anchors resolve a shared specifier to the SAME file", async () => {
+  it("dedups to one plain flat entry when two anchors resolve a shared specifier to the SAME file", async () => {
     const dir = app({ "src/shared/cn.ts": `export const cn = () => "shared";` });
     const rec = (file: string): RemixSourceRecord => ({
       file,
@@ -136,17 +145,15 @@ describe("buildEnvironment local vendoring (fast-edits follow-up)", () => {
       sourceHash: "h",
       capturedAt: "2026-07-04T00:00:00.000Z",
     });
-    await buildEnvironment(
-      dir,
-      { a: rec("src/a/w.tsx"), b: rec("src/b/w.tsx") },
-      { now: () => "2026-07-04T00:00:00.000Z" },
-    );
+    const records = { a: rec("src/a/w.tsx"), b: rec("src/b/w.tsx") };
+    const { manifest } = await buildEnvironment(dir, records, { now: () => "2026-07-04T00:00:00.000Z" });
     const map = JSON.parse(readFileSync(path.join(dir, ".vendo/env/import-map.json"), "utf8")) as {
       imports: Record<string, string>;
-      scopes?: Record<string, Record<string, string>>;
     };
-    expect(map.imports["@/shared/cn"]).toBeDefined(); // single flat entry, no scope needed
-    expect(map.scopes?.["a"]?.["@/shared/cn"]).toBeUndefined();
+    // Same specifier, same file → unchanged plain flat entry, source untouched.
+    expect(map.imports["@/shared/cn"]).toBeDefined();
+    expect(manifest.anchors["a"]?.["@/shared/cn"]?.kind).toBe("real");
+    expect(records.a.source).toContain(`from "@/shared/cn"`);
     const localBundles = readdirSync(path.join(dir, ".vendo/env/vendor")).filter((f) => f.startsWith("local-"));
     expect(localBundles).toHaveLength(1);
   });

--- a/packages/vendo-cli/src/sync/env.test.ts
+++ b/packages/vendo-cli/src/sync/env.test.ts
@@ -75,4 +75,14 @@ describe("sanitizeCss", () => {
     expect(dropped).toHaveLength(0);
     expect(hasFetchableUrl(css)).toBe(false);
   });
+
+  it("keeps a QUOTED data: URL whose payload contains ) and // intact", () => {
+    const input = `.a { background: url("data:image/svg+xml,<svg><text>f(x)//g</text></svg>"); }`;
+    const { css, dropped } = sanitizeCss(input);
+    // The quoted payload holds a ')' — a mask that stops at the first ')' would
+    // leave the tail exposed to the external-ref pass and eat the '//'.
+    expect(css).toContain("<text>f(x)//g</text>");
+    expect(dropped).toHaveLength(0);
+    expect(hasFetchableUrl(css)).toBe(false);
+  });
 });

--- a/packages/vendo-cli/src/sync/env.test.ts
+++ b/packages/vendo-cli/src/sync/env.test.ts
@@ -67,4 +67,12 @@ describe("sanitizeCss", () => {
       expect(css).not.toContain("https://x");
     }
   });
+
+  it("keeps a data: URL whose base64 payload contains // intact (external-ref pass must not eat it)", () => {
+    const input = `.a { background: url(data:image/png;base64,iVBOR//w0KGgoAAAANSU//hEUgAA==); }`;
+    const { css, dropped } = sanitizeCss(input);
+    expect(css).toContain("iVBOR//w0KGgoAAAANSU//hEUgAA==");
+    expect(dropped).toHaveLength(0);
+    expect(hasFetchableUrl(css)).toBe(false);
+  });
 });

--- a/packages/vendo-cli/src/sync/env.ts
+++ b/packages/vendo-cli/src/sync/env.ts
@@ -8,6 +8,7 @@
  * reported and the anchor keeps whatever it can. The env NEVER fails the host
  * build for a classification gap.
  */
+import { createHash } from "node:crypto";
 import { createRequire } from "node:module";
 import { cpSync, existsSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
@@ -340,35 +341,49 @@ export async function buildEnvironment(
   }
 
   // 3. Import map (blob-resolved at runtime by the stage; paths are relative).
-  //    A local specifier that resolves to exactly ONE bundle across all anchors
-  //    goes in the flat `imports`; a specifier resolving to DIFFERENT bundles
-  //    per anchor (shared specifier, different files) goes in per-anchor
-  //    `scopes` so each anchor imports the correct one.
-  const specToOuts = new Map<string, Set<string>>();
+  //    The runtime import map is FLAT and applied globally. A local specifier
+  //    string that resolves to DIFFERENT files across anchors ("./cn" from two
+  //    components in different dirs) cannot be a single flat key, so give each
+  //    such anchor a UNIQUE specifier — rewriting its baseline source (which the
+  //    sandbox runs), its manifest key (which the model reads), and the flat
+  //    import entry together so all three agree and BOTH modules resolve.
+  //    Single-resolution specifiers (the common case) stay a plain flat entry.
+  //    NOTE: mutates `records` in place; the caller persists remix-sources.json
+  //    AFTER this so the rewritten baselines are what the runtime loads.
+  const specToFiles = new Map<string, Set<string>>();
+  for (const r of localResolved) {
+    let files = specToFiles.get(r.specifier);
+    if (!files) specToFiles.set(r.specifier, (files = new Set()));
+    files.add(r.file);
+  }
+  const localImports = new Map<string, string>(); // final specifier → ./vendor/<out>
   for (const r of localResolved) {
     const out = fileToOut.get(r.file);
-    if (!out) continue;
-    let outs = specToOuts.get(r.specifier);
-    if (!outs) specToOuts.set(r.specifier, (outs = new Set()));
-    outs.add(out);
-  }
-  const flatLocal: Array<[string, string]> = [];
-  for (const [specifier, outs] of specToOuts) {
-    if (outs.size === 1) flatLocal.push([specifier, `./vendor/${[...outs][0]!}`]);
-  }
-  const scopes: Record<string, Record<string, string>> = {};
-  for (const r of localResolved) {
-    const out = fileToOut.get(r.file);
-    if (!out || (specToOuts.get(r.specifier)?.size ?? 0) <= 1) continue; // flat-covered
-    (scopes[r.anchorId] ??= {})[r.specifier] = `./vendor/${out}`;
+    if (!out) continue; // failed to bundle → already marked absent, no map row
+    let spec = r.specifier;
+    if ((specToFiles.get(r.specifier)?.size ?? 0) > 1) {
+      spec = uniqueLocalSpecifier(r.specifier, r.file, targetDir);
+      const record = records[r.anchorId];
+      if (record) {
+        record.source = rewriteImportSpecifier(record.source, r.specifier, spec);
+        if (record.prepared !== undefined) {
+          record.prepared = rewriteImportSpecifier(record.prepared, r.specifier, spec);
+        }
+      }
+      const perImport = anchors[r.anchorId];
+      if (perImport && r.specifier in perImport && !(spec in perImport)) {
+        perImport[spec] = perImport[r.specifier]!;
+        delete perImport[r.specifier];
+      }
+    }
+    localImports.set(spec, `./vendor/${out}`);
   }
   const importMap = {
     imports: Object.fromEntries([
       ...[...npmToVendor].map(([specifier, outName]) => [specifier, `./vendor/${outName}`]),
       ...[...shimToVendor].map(([specifier, outName]) => [specifier, `./vendor/${outName}`]),
-      ...flatLocal,
+      ...localImports,
     ]),
-    ...(Object.keys(scopes).length > 0 ? { scopes } : {}),
   };
   writeFileSync(path.join(envDir, "import-map.json"), `${JSON.stringify(importMap, null, 2)}\n`);
 
@@ -423,6 +438,24 @@ export async function buildEnvironment(
 
 function slug(specifier: string): string {
   return specifier.replace(/[^a-z0-9]+/gi, "-").replace(/^-|-$/g, "");
+}
+
+/** A unique, still-relative specifier for a colliding local import, keyed by the
+ *  RESOLVED file (so two anchors resolving to the same file dedup to the same
+ *  specifier, different files diverge). The manifest key, the anchor's baseline
+ *  source, and the flat import entry are all rewritten to this together. */
+function uniqueLocalSpecifier(specifier: string, file: string, targetDir: string): string {
+  const h = createHash("sha256").update(path.relative(targetDir, file)).digest("hex").slice(0, 8);
+  return `${specifier}__${h}`;
+}
+
+/** Rewrite an import specifier (static `from "x"` and dynamic `import("x")`) in
+ *  a captured source string. */
+function rewriteImportSpecifier(code: string, from: string, to: string): string {
+  const q = from.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return code
+    .replace(new RegExp(`(from\\s*['"])${q}(['"])`, "g"), `$1${to}$2`)
+    .replace(new RegExp(`(import\\s*\\(\\s*['"])${q}(['"])`, "g"), `$1${to}$2`);
 }
 function kb(n: number): string {
   return `${(n / 1024).toFixed(1)}KB`;

--- a/packages/vendo-cli/src/sync/env.ts
+++ b/packages/vendo-cli/src/sync/env.ts
@@ -65,7 +65,12 @@ export async function buildEnvironment(
   const anchors: EnvManifest["anchors"] = {};
   const npmToVendor = new Map<string, string>(); // specifier → vendor entry file
   const shimsToVendor = new Set<string>(); // shimmed specifiers actually imported
-  const localToVendor = new Map<string, string>(); // specifier → resolved app file
+  // Local specifier resolution recorded PER ANCHOR: two anchors can import the
+  // same specifier string ("./cn") that resolves to DIFFERENT files. Keying the
+  // vendored bundle by the specifier (not the resolved file) would clobber one
+  // with the other, so we vendor per distinct resolved FILE and map each
+  // anchor's specifier at its own file's bundle below.
+  const localResolved: Array<{ anchorId: string; specifier: string; file: string }> = [];
   const aliases = readAliases(targetDir);
   // realpath both sides of the refusal comparison: esbuild hands plugins REAL
   // paths, and e.g. macOS tmpdirs are symlinks — a naive relative() would
@@ -113,7 +118,7 @@ export async function buildEnvironment(
         );
         if (resolved) {
           perImport[specifier] = toManifestStatus(cls); // real — verified by the bundle step
-          localToVendor.set(specifier, resolved);
+          localResolved.push({ anchorId, specifier, file: resolved });
         } else {
           perImport[specifier] = {
             kind: "absent",
@@ -228,18 +233,22 @@ export async function buildEnvironment(
   //     import map resolves separately (react family, vendored npm, shims).
   //     Refusal rules run on every file the bundle touches — one server-only
   //     file anywhere in the closure fails that specifier to absent.
-  const localVendored = new Map<string, string>();
-  if (localToVendor.size > 0) {
-    const markAbsent = (specifier: string, why: string) => {
-      for (const perImport of Object.values(anchors)) {
-        if (perImport[specifier]) {
-          perImport[specifier] = {
+  const fileToOut = new Map<string, string>(); // resolved file → bundle outName (built ok)
+  const distinctFiles = [...new Set(localResolved.map((r) => r.file))];
+  if (distinctFiles.length > 0) {
+    // Mark absent every (anchor, specifier) pair that resolved to `file`.
+    const markAbsentForFile = (file: string, why: string) => {
+      for (const r of localResolved) {
+        if (r.file !== file) continue;
+        const perImport = anchors[r.anchorId];
+        if (perImport?.[r.specifier]) {
+          perImport[r.specifier] = {
             kind: "absent",
             alternative: "app-local module not vendored — inline its logic from the source",
           };
         }
       }
-      report.push(`env: could not vendor local ${specifier} (${why}) — marked absent`);
+      report.push(`env: could not vendor local ${path.relative(targetDir, file)} (${why}) — marked absent`);
     };
     const externals = new Set([
       "react",
@@ -297,8 +306,11 @@ export async function buildEnvironment(
         });
       },
     };
-    for (const [specifier, file] of localToVendor) {
-      const outName = `local-${slug(specifier)}.js`;
+    for (const file of distinctFiles) {
+      // Name the bundle by the resolved file path (not the specifier) so two
+      // anchors sharing a specifier that resolves to different files get two
+      // distinct bundles instead of clobbering one.
+      const outName = `local-${slug(path.relative(targetDir, file))}.js`;
       try {
         const result = await build({
           entryPoints: [file],
@@ -311,10 +323,10 @@ export async function buildEnvironment(
         });
         const code = result.outputFiles[0]!.text;
         writeFileSync(path.join(vendorDir, outName), code);
-        localVendored.set(specifier, outName);
-        vendorSizes[specifier] = code.length;
+        fileToOut.set(file, outName);
+        for (const r of localResolved) if (r.file === file) vendorSizes[r.specifier] = code.length;
         vendorTotal += code.length;
-        report.push(`env: vendored local ${specifier} (${kb(code.length)})`);
+        report.push(`env: vendored local ${path.relative(targetDir, file)} (${kb(code.length)})`);
       } catch (err) {
         const msg =
           err && typeof err === "object" && "errors" in err
@@ -322,18 +334,41 @@ export async function buildEnvironment(
             : err instanceof Error
               ? err.message
               : String(err);
-        markAbsent(specifier, msg);
+        markAbsentForFile(file, msg);
       }
     }
   }
 
   // 3. Import map (blob-resolved at runtime by the stage; paths are relative).
+  //    A local specifier that resolves to exactly ONE bundle across all anchors
+  //    goes in the flat `imports`; a specifier resolving to DIFFERENT bundles
+  //    per anchor (shared specifier, different files) goes in per-anchor
+  //    `scopes` so each anchor imports the correct one.
+  const specToOuts = new Map<string, Set<string>>();
+  for (const r of localResolved) {
+    const out = fileToOut.get(r.file);
+    if (!out) continue;
+    let outs = specToOuts.get(r.specifier);
+    if (!outs) specToOuts.set(r.specifier, (outs = new Set()));
+    outs.add(out);
+  }
+  const flatLocal: Array<[string, string]> = [];
+  for (const [specifier, outs] of specToOuts) {
+    if (outs.size === 1) flatLocal.push([specifier, `./vendor/${[...outs][0]!}`]);
+  }
+  const scopes: Record<string, Record<string, string>> = {};
+  for (const r of localResolved) {
+    const out = fileToOut.get(r.file);
+    if (!out || (specToOuts.get(r.specifier)?.size ?? 0) <= 1) continue; // flat-covered
+    (scopes[r.anchorId] ??= {})[r.specifier] = `./vendor/${out}`;
+  }
   const importMap = {
     imports: Object.fromEntries([
       ...[...npmToVendor].map(([specifier, outName]) => [specifier, `./vendor/${outName}`]),
       ...[...shimToVendor].map(([specifier, outName]) => [specifier, `./vendor/${outName}`]),
-      ...[...localVendored].map(([specifier, outName]) => [specifier, `./vendor/${outName}`]),
+      ...flatLocal,
     ]),
+    ...(Object.keys(scopes).length > 0 ? { scopes } : {}),
   };
   writeFileSync(path.join(envDir, "import-map.json"), `${JSON.stringify(importMap, null, 2)}\n`);
 

--- a/packages/vendo-cli/src/sync/host-css.ts
+++ b/packages/vendo-cli/src/sync/host-css.ts
@@ -23,6 +23,9 @@ const imageSet = () => /(?:-webkit-)?image-set\([^)]*\)/gi;
 // Any external URL literal that survived the structured passes (belt and
 // suspenders): http(s) and protocol-relative refs anywhere in the text.
 const externalRef = () => /(?:https?:|\/\/)[^\s'")]+/gi;
+// Kept `url(data:...)` payloads — masked out before the external-ref pass so a
+// `//` inside a base64 payload is never mistaken for a protocol-relative URL.
+const dataUrl = () => /url\(\s*(['"]?)data:[^)]*\1\s*\)/gi;
 // CSS comments — stripped FIRST so `u/**/rl(...)`-style hiding can't survive.
 const cssComment = () => /\/\*[\s\S]*?\*\//g;
 // CSS hex escapes (`\75` = u, `\5c` = \) — decoded before matching so an
@@ -66,22 +69,30 @@ export function sanitizeCss(css: string): SanitizeResult {
     dropped.push(match.trim());
     return "none";
   });
+  // Mask kept data: URLs so the catch-all below cannot corrupt a `//` inside a
+  // base64 payload; restore them verbatim afterward.
+  const dataUrls: string[] = [];
+  out = out.replace(dataUrl(), (m) => `__vendo-data-${dataUrls.push(m) - 1}__`);
   // Final catch-all: neutralize any external URL literal still present (e.g. a
   // bare string in a property we don't structurally understand).
   out = out.replace(externalRef(), (match) => {
     dropped.push(match.trim());
     return "";
   });
+  out = out.replace(/__vendo-data-(\d+)__/g, (_m, i) => dataUrls[Number(i)]!);
   return { css: out, dropped };
 }
 
 /** True when `css`, after the same normalization, still has any fetchable URL. */
 export function hasFetchableUrl(css: string): boolean {
   const normalized = decodeEscapes(css.replace(cssComment(), ""));
+  // Exclude kept data: URLs from the external-ref check — a `//` in a base64
+  // payload is not a fetchable reference.
+  const withoutData = normalized.replace(dataUrl(), "");
   return (
     fetchableUrl().test(normalized) ||
     atImport().test(normalized) ||
     imageSet().test(normalized) ||
-    externalRef().test(normalized)
+    externalRef().test(withoutData)
   );
 }

--- a/packages/vendo-cli/src/sync/host-css.ts
+++ b/packages/vendo-cli/src/sync/host-css.ts
@@ -23,9 +23,6 @@ const imageSet = () => /(?:-webkit-)?image-set\([^)]*\)/gi;
 // Any external URL literal that survived the structured passes (belt and
 // suspenders): http(s) and protocol-relative refs anywhere in the text.
 const externalRef = () => /(?:https?:|\/\/)[^\s'")]+/gi;
-// Kept `url(data:...)` payloads — masked out before the external-ref pass so a
-// `//` inside a base64 payload is never mistaken for a protocol-relative URL.
-const dataUrl = () => /url\(\s*(['"]?)data:[^)]*\1\s*\)/gi;
 // CSS comments — stripped FIRST so `u/**/rl(...)`-style hiding can't survive.
 const cssComment = () => /\/\*[\s\S]*?\*\//g;
 // CSS hex escapes (`\75` = u, `\5c` = \) — decoded before matching so an
@@ -37,6 +34,48 @@ function decodeEscapes(css: string): string {
     const code = parseInt(hex, 16);
     return code > 0 && code <= 0x10ffff ? String.fromCodePoint(code) : "";
   });
+}
+
+/**
+ * Replace every kept `url(data:...)` token with an opaque placeholder so NO
+ * later pass (fetchable-url, external-ref) can corrupt a payload containing
+ * `)` (quoted SVG) or `//` (base64). A small quote/escape-aware scanner — a
+ * regex stopping at the first `)` truncates quoted data URLs. Returns the
+ * masked string plus the ordered original tokens for restoration.
+ */
+function maskDataUrls(css: string): { masked: string; tokens: string[] } {
+  const tokens: string[] = [];
+  const lower = css.toLowerCase();
+  let out = "";
+  let i = 0;
+  while (i < css.length) {
+    const start = lower.indexOf("url(", i);
+    if (start === -1) {
+      out += css.slice(i);
+      break;
+    }
+    out += css.slice(i, start);
+    // Scan to the matching ')', honoring a quoted argument whose payload may
+    // itself contain ')'.
+    let j = start + 4;
+    while (j < css.length && /\s/.test(css[j]!)) j++;
+    const quote = css[j] === '"' || css[j] === "'" ? css[j]! : "";
+    let k = j + (quote ? 1 : 0);
+    if (quote) {
+      while (k < css.length && css[k] !== quote) k += css[k] === "\\" ? 2 : 1;
+      k++; // past the closing quote
+    }
+    while (k < css.length && css[k] !== ")") k++;
+    if (k >= css.length) {
+      out += css.slice(start); // unterminated url( — leave verbatim
+      break;
+    }
+    const token = css.slice(start, k + 1);
+    const isData = css.slice(j + (quote ? 1 : 0)).replace(/^\s+/, "").toLowerCase().startsWith("data:");
+    out += isData ? `__vendo-data-${tokens.push(token) - 1}__` : token;
+    i = k + 1;
+  }
+  return { masked: out, tokens };
 }
 
 export interface SanitizeResult {
@@ -57,6 +96,10 @@ export function sanitizeCss(css: string): SanitizeResult {
   const dropped: string[] = [];
   // Normalize first: strip comments, decode escapes.
   let out = decodeEscapes(css.replace(cssComment(), ""));
+  // Mask kept data: URLs up front so NO pass below can corrupt a payload
+  // containing `)` (quoted SVG) or `//` (base64); restore verbatim at the end.
+  const { masked, tokens } = maskDataUrls(out);
+  out = masked;
   out = out.replace(atImport(), (match) => {
     dropped.push(match.trim());
     return "/* vendo: import rule dropped */";
@@ -69,30 +112,26 @@ export function sanitizeCss(css: string): SanitizeResult {
     dropped.push(match.trim());
     return "none";
   });
-  // Mask kept data: URLs so the catch-all below cannot corrupt a `//` inside a
-  // base64 payload; restore them verbatim afterward.
-  const dataUrls: string[] = [];
-  out = out.replace(dataUrl(), (m) => `__vendo-data-${dataUrls.push(m) - 1}__`);
   // Final catch-all: neutralize any external URL literal still present (e.g. a
   // bare string in a property we don't structurally understand).
   out = out.replace(externalRef(), (match) => {
     dropped.push(match.trim());
     return "";
   });
-  out = out.replace(/__vendo-data-(\d+)__/g, (_m, i) => dataUrls[Number(i)]!);
+  out = out.replace(/__vendo-data-(\d+)__/g, (_m, i) => tokens[Number(i)]!);
   return { css: out, dropped };
 }
 
 /** True when `css`, after the same normalization, still has any fetchable URL. */
 export function hasFetchableUrl(css: string): boolean {
-  const normalized = decodeEscapes(css.replace(cssComment(), ""));
-  // Exclude kept data: URLs from the external-ref check — a `//` in a base64
-  // payload is not a fetchable reference.
-  const withoutData = normalized.replace(dataUrl(), "");
+  // Same normalization + data:-URL masking as sanitizeCss, so the guard cannot
+  // be fooled by a form the sanitizer normalized away, nor false-positive on a
+  // `//` inside a kept data: payload.
+  const normalized = maskDataUrls(decodeEscapes(css.replace(cssComment(), ""))).masked;
   return (
     fetchableUrl().test(normalized) ||
     atImport().test(normalized) ||
     imageSet().test(normalized) ||
-    externalRef().test(withoutData)
+    externalRef().test(normalized)
   );
 }

--- a/packages/vendo-cli/src/sync/index.ts
+++ b/packages/vendo-cli/src/sync/index.ts
@@ -29,17 +29,20 @@ export async function runSync(options: SyncOptions): Promise<number> {
     ...(options.now ? { now: options.now } : {}),
   });
   mkdirSync(vendoDir, { recursive: true });
-  writeFileSync(
-    path.join(vendoDir, "remix-sources.json"),
-    `${JSON.stringify(capture.records, null, 2)}\n`,
-  );
   for (const line of capture.report) log(`  ${line}`);
 
+  // buildEnvironment may rewrite colliding local import specifiers in the
+  // captured records in place, so persist remix-sources.json AFTER it runs —
+  // the rewritten baselines are what the runtime loads.
   const env = await buildEnvironment(targetDir, capture.records, {
     ...(options.now ? { now: options.now } : {}),
   });
   for (const line of env.report) log(`  ${line}`);
 
+  writeFileSync(
+    path.join(vendoDir, "remix-sources.json"),
+    `${JSON.stringify(capture.records, null, 2)}\n`,
+  );
   log(`  wrote .vendo/remix-sources.json (${Object.keys(capture.records).length} captured)`);
   return 0;
 }


### PR DESCRIPTION
## What

Stacked on the shell-UI wave (#69). Eight confirmed audit findings in the shipping `@vendoai/cli` package — the things that make `vendo init` + `vendo sync` actually work on a fresh app — plus 2 Codex-review refinements. 10 commits, TDD'd.

### Fixes
1. **`vendo init` adds `@vendoai/cli` to the app's devDependencies** — the wired `prebuild: vendo sync` had no resolvable `vendo` binary, so `next build` failed at prebuild. New idempotent `addDevDependency` helper.
2. **`instrumentation.ts` gets its `experimental.instrumentationHook`** on Next <15 (silently ignored before → scheduler never booted). Writes `next.config.mjs` when absent; an existing config gets a printed manual step (no AST edit — safe-minimal, flagged).
3. **Local-module vendoring no longer collides** — two anchors importing the same specifier string that resolved to different files got one clobbered bundle. Now each colliding specifier is rewritten to a unique **file-hashed** specifier across the baseline source, manifest, and flat import map — all three agree, so both modules resolve end-to-end (identical files still dedupe).
4. **Generated `.vendo/components` build gets its deps** (`@vendoai/stage`, `vite`, `@vitejs/plugin-react`) added to devDependencies when components are extracted.
5. **`sanitizeCss` no longer corrupts kept `data:` URLs** — a quote/escape-aware `url()` scanner masks the full token (quoted or unquoted, including payloads with `)` and `//`) before every stripping pass, restoring verbatim after.
6. **`vendo init` resumes after a mid-run failure** — `writeGenerated` treats an identical-content pre-existing file as a no-op success, while still refusing to overwrite different content without `--force` (clobber-protection intact).
7. **Capture guard realpaths before its refusal check** — a symlink inside the app could smuggle out-of-root/server code into `remix-sources.json`; now matches the env-vendoring guard.
8. **Component scan recognizes the shadcn `export { Button }` shape** — `const Button = forwardRef(...)` + `export { Button }` yielded zero candidates on a typical shadcn app; now scans `export { Name, X as Y }` clauses (capitalized only).

### Codex review
Ran once; both findings fixed in-branch: the vendoring fix's runtime-consumer gap (the earlier `scopes` approach the runtime never read → now unique flat specifiers, fully end-to-end) and the data-URL scanner's quoted-`)` edge case.

### Flag (safe-minimal, non-blocking)
Fix 2 writes a fresh `next.config.mjs` but leaves an EXISTING config to a manual instruction rather than AST-editing it.

`pnpm --filter @vendoai/cli test` 148 tests · `pnpm typecheck` 27/27 · `pnpm test` 25/25.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens `@vendoai/cli` init/sync so fresh Next apps work out of the box and local vendoring is correct and stable. Fixes Next <15 instrumentation, data URL handling, resume safety, and component scanning; also adds missing dev deps.

- **Bug Fixes**
  - Add `@vendoai/cli` to app `devDependencies` so `prebuild: vendo sync` resolves.
  - Next <15: create `next.config.mjs` with `experimental.instrumentationHook: true`; skip and print a manual step if a config exists. Next 15+ is untouched.
  - Local-module vendoring: vendor by resolved file, not specifier. When the same specifier resolves to different files per anchor, rewrite each to a unique file-hashed specifier across baseline source, manifest, and the flat import map (identical files still dedupe).
  - Generated `.vendo/components` build adds `@vendoai/stage`, `vite`, and `@vitejs/plugin-react` to `devDependencies`.
  - CSS sanitizer: preserve kept `data:` URLs (quote/escape-aware `url()` masking) and align `hasFetchableUrl`.
  - Resume safety: `writeGenerated` treats identical existing files as a no-op; still refuses different content without `--force`.
  - Capture guard: realpath before checks to block symlinked out-of-root or `server/` code.
  - Component scan: detect `export { Button }` and `export { X as Y }` (PascalCase only); skip lowercase utils.

- **Migration**
  - On Next 13/14 with an existing `next.config.*`, add `experimental: { instrumentationHook: true }` so `instrumentation.ts` loads.

<sup>Written for commit b128159bc0940b75ab33bea3a5674445bde8dec7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

