### PR TITLE
follow-up: prove chart brand palettes actually reach charts (corrects earlier conclusion)

### DIFF
--- a/packages/vendo-components/src/theme/chart-palette.test.tsx
+++ b/packages/vendo-components/src/theme/chart-palette.test.tsx
@@ -1,56 +1,129 @@
 /**
- * Chart palettes must reach OpenUI's charts WITHOUT tripping ThemeProvider's
- * dev validation. OpenUI's `Theme` TYPE includes the `*ChartPalette` keys
- * (ChartColorPalette in ThemeProvider/types.d.ts), but its runtime validator
- * derives "known keys" from the default theme object — which carries none of
- * them — so passing palettes through `lightTheme`/`darkTheme` spammed
- * "[OpenUI] lightTheme contains unknown key 'barChartPalette'…" ten times per
- * page (browser-observed in both demo apps). The fix routes palettes around
- * the validated prop and re-provides them on OpenUI's ThemeContext, so
- * `useChartPalette` still finds them and the console stays clean.
+ * Chart palettes must actually COLOR OpenUI's charts with the host brand — not
+ * merely land on a theme object. OpenUI 0.12.1's charts resolve their series
+ * colors through `useChartPalette` (dist components/Charts/utils/PalletUtils.js),
+ * which reads `useTheme().theme[themePaletteName] || .defaultChartPalette` — and
+ * `useTheme` is `useContext(ThemeContext)` (dist ThemeProvider/ThemeProvider.js),
+ * a plain React context, NOT a separate store. But the `*ChartPalette` keys are
+ * absent from OpenUI's default theme, so its ThemeProvider's dev validator both
+ * warns "unknown key '…ChartPalette'" AND drops them when they ride the
+ * `lightTheme`/`darkTheme` props. `ChartPaletteBridge` therefore peels the
+ * palette keys off the validated prop and re-provides them on that same
+ * ThemeContext, where `useChartPalette` still finds them.
  *
- * NOTE: OpenUI's warnOnce dedupes per module load, so the no-warning
- * assertion must run FIRST in this file (vitest isolates per test file).
+ * These tests render a REAL OpenUI `BarChart` and assert the brand palette
+ * reaches the rendered DOM (recharts emits the series colors as CSS-var hexes
+ * in a ChartStyle <style> block + legend swatches, so the colors are present
+ * even though jsdom gives recharts no layout). A negative control renders the
+ * same chart with no provider and asserts it falls back to OpenUI's "ocean"
+ * defaults — proving the assertion discriminates brand colors from defaults.
+ * Both mount paths are covered: host chrome (VendoThemeProvider) and the
+ * sandbox theme wrap (installVendoHost's __VENDO_THEME_WRAP__).
  */
 import { describe, expect, it, vi } from "vitest";
+import React from "react";
 import { render } from "@testing-library/react";
-import { useTheme } from "../openui.js";
+import { BarChart, useTheme } from "../openui.js";
+import { installVendoHost } from "../sandbox-install.js";
 import { VendoThemeProvider } from "./VendoThemeProvider.js";
 import { defaultBrand } from "./brand.js";
 import { brandToChartPalette } from "./brand-to-chart-palette.js";
 import { mapBrandToTheme } from "./map-brand-to-theme.js";
 import { splitChartPalettes } from "./chart-palette-bridge.js";
 
-function probeTheme(): Record<string, unknown> {
-  let seen: Record<string, unknown> = {};
-  function Probe() {
-    seen = useTheme().theme as Record<string, unknown>;
-    return null;
-  }
-  render(
-    <VendoThemeProvider brand={defaultBrand}>
-      <Probe />
-    </VendoThemeProvider>,
+const CHART_DATA = [
+  { month: "Jan", a: 10, b: 20, c: 30, d: 40, e: 50, f: 60 },
+  { month: "Feb", a: 15, b: 25, c: 35, d: 45, e: 55, f: 65 },
+];
+
+/** OpenUI's built-in "ocean" default palette (dist Charts/utils/PalletUtils.js)
+ *  — what a chart falls back to when no brand palette reaches it. */
+const OCEAN_DEFAULTS = ["#0d47a1", "#1565c0", "#1976d2", "#1e88e5", "#2196f3", "#42a5f5"];
+
+function chart(): React.ReactElement {
+  return (
+    <BarChart
+      data={CHART_DATA}
+      categoryKey="month"
+      width={600}
+      height={300}
+      isAnimationActive={false}
+    />
   );
-  return seen;
 }
 
-describe("chart palettes through the OpenUI theme", () => {
+/** Lower-cased #rrggbb hex colors present anywhere in a rendered subtree. */
+function hexesIn(node: HTMLElement): string[] {
+  return node.innerHTML.toLowerCase().match(/#[0-9a-f]{6}/g) ?? [];
+}
+
+describe("brand chart palettes reach OpenUI charts", () => {
+  it("host path: a BarChart under VendoThemeProvider renders in the brand palette, not OpenUI defaults", () => {
+    const { container } = render(<VendoThemeProvider brand={defaultBrand}>{chart()}</VendoThemeProvider>);
+    const hexes = new Set(hexesIn(container));
+    const brand = brandToChartPalette(defaultBrand);
+    // Every brand series color is present; no OpenUI "ocean" default leaks in.
+    for (const c of brand) expect(hexes, c).toContain(c);
+    for (const c of OCEAN_DEFAULTS) expect(hexes, c).not.toContain(c);
+  });
+
+  it("negative control: the same chart with NO provider falls back to OpenUI's ocean defaults", () => {
+    const { container } = render(chart());
+    const hexes = new Set(hexesIn(container));
+    const brand = brandToChartPalette(defaultBrand);
+    // Proves the host-path assertion discriminates: without the bridge the
+    // chart shows ocean defaults and none of the brand colors.
+    expect(OCEAN_DEFAULTS.some((c) => hexes.has(c))).toBe(true);
+    for (const c of brand) expect(hexes, c).not.toContain(c);
+  });
+
+  it("sandbox path: __VENDO_THEME_WRAP__ colors a BarChart with the brand palette", () => {
+    installVendoHost();
+    const wrap = window.__VENDO_THEME_WRAP__;
+    expect(wrap).toBeTypeOf("function");
+    const wrapped = wrap!({ mode: "light", theme: mapBrandToTheme(defaultBrand) }, chart());
+    const { container } = render(wrapped as React.ReactElement);
+    const hexes = new Set(hexesIn(container));
+    const brand = brandToChartPalette(defaultBrand);
+    for (const c of brand) expect(hexes, c).toContain(c);
+    for (const c of OCEAN_DEFAULTS) expect(hexes, c).not.toContain(c);
+  });
+
+  it("dark mode still delivers the brand palette to a chart", () => {
+    const darkBrand = { ...defaultBrand, mode: "dark" as const };
+    const { container } = render(<VendoThemeProvider brand={darkBrand}>{chart()}</VendoThemeProvider>);
+    const hexes = new Set(hexesIn(container));
+    for (const c of brandToChartPalette(darkBrand)) expect(hexes, c).toContain(c);
+  });
+
   it("mounts without any '[OpenUI] … unknown key' console spam", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
-      probeTheme();
-      const openuiWarnings = warn.mock.calls
+      render(
+        <VendoThemeProvider brand={defaultBrand}>
+          <span />
+        </VendoThemeProvider>,
+      );
+      const unknownKeyWarnings = warn.mock.calls
         .map((c) => String(c[0]))
         .filter((m) => m.includes("unknown key"));
-      expect(openuiWarnings).toEqual([]);
+      expect(unknownKeyWarnings).toEqual([]);
     } finally {
       warn.mockRestore();
     }
   });
 
-  it("still delivers every brand chart palette to OpenUI's theme context (useChartPalette's source)", () => {
-    const theme = probeTheme();
+  it("still delivers every brand chart palette on OpenUI's theme context (useChartPalette's source)", () => {
+    let seen: Record<string, unknown> = {};
+    function Probe() {
+      seen = useTheme().theme as Record<string, unknown>;
+      return null;
+    }
+    render(
+      <VendoThemeProvider brand={defaultBrand}>
+        <Probe />
+      </VendoThemeProvider>,
+    );
     const palette = brandToChartPalette(defaultBrand);
     for (const key of [
       "defaultChartPalette",
@@ -59,7 +132,7 @@ describe("chart palettes through the OpenUI theme", () => {
       "areaChartPalette",
       "pieChartPalette",
     ]) {
-      expect(theme[key], key).toEqual(palette);
+      expect(seen[key], key).toEqual(palette);
     }
   });
 


### PR DESCRIPTION
## What

Investigated whether Vendo's generated charts render in host brand colors — and **corrects an earlier wrong conclusion**.

### Finding
OpenUI 0.12.1 charts read their palette from **React `ThemeContext`** (`dist/components/Charts/utils/PalletUtils` → `useChartPalette` → `useTheme`), which the existing `ChartPaletteBridge` **already re-provides**. So brand palettes **do** reach the charts through both the host (`VendoThemeProvider`) and sandbox (`__VENDO_THEME_WRAP__`) mount paths. My earlier "OpenUI ignores the palette keys / charts read a store the bridge doesn't touch" was wrong — that's only true for the raw `lightTheme`/`darkTheme` **prop** path (the validator warns + drops), which the bridge bypasses.

### Proof (controlled jsdom)
Renders a real OpenUI `BarChart` and asserts brand colors reach the DOM while OpenUI's "ocean" defaults do not — for host path, sandbox path, dark mode, plus a no-provider negative control.

| Path | Brand colors | Ocean defaults |
|---|---|---|
| Host `VendoThemeProvider` | all 6 | 0 |
| Sandbox `__VENDO_THEME_WRAP__` | all 6 | 0 |
| Control (no provider) | 0 | yes |

### No implementation change
The wiring was already correct. The gap was the **test**, which asserted "context has keys / no warning" instead of "a chart resolves to a brand color." Rewritten to prove the real outcome.

### On the "brown Cadence bars"
Not a bug. Cadence's `brandToChartPalette` derives stops from its brand neutrals (`text #221e19`, `mutedText #5c554b` — warm brown-grays), so its palette legitimately includes taupe/olive. OpenUI's fallback is blue ("ocean"), not brown — so brown bars were the **brand palette working**, misread as a fallback.

`pnpm typecheck` 27/27 · `pnpm test` 25/25 (vendo-components 154 tests). Browser confirmation of a live Cadence chart in the consolidated pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote the chart palette test to prove brand palettes actually color `OpenUI` charts via React `ThemeContext`, correcting the earlier conclusion. The test renders a real `BarChart` and verifies host `VendoThemeProvider`, sandbox `__VENDO_THEME_WRAP__`, dark mode, and a no-provider control (brand colors present; "ocean" defaults absent), with no implementation changes.

<sup>Written for commit f9639bcad85e8e7128e4490b32046608ed0505ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

