### PR TITLE
follow-up: critical transfer tool in demo-bank + integrations spoof logging

### DIFF
--- a/apps/demo-bank/openapi.json
+++ b/apps/demo-bank/openapi.json
@@ -189,7 +189,7 @@
         "x-vendo-dangerous": true,
         "x-vendo-formats": { "amount": "cents" },
         "parameters": [
-          { "name": "amount", "in": "query", "required": true, "schema": { "type": "number" }, "description": "Amount to send in cents, e.g. 50000 = $500.00" },
+          { "name": "amount", "in": "query", "required": true, "schema": { "type": "integer", "minimum": 1 }, "description": "Amount to send in cents (positive whole number), e.g. 50000 = $500.00" },
           { "name": "recipient_name", "in": "query", "required": true, "schema": { "type": "string" }, "description": "Who the money goes to, e.g. Alex Rivera" },
           { "name": "memo", "in": "query", "schema": { "type": "string" }, "description": "Optional note shown on the transfer, e.g. June rent" }
         ],

--- a/apps/demo-bank/openapi.json
+++ b/apps/demo-bank/openapi.json
@@ -181,6 +181,20 @@
         },
         "responses": { "200": { "description": "The appended transaction" } }
       }
+    },
+    "/api/transfers": {
+      "post": {
+        "operationId": "transferMoney",
+        "summary": "Send money to a person from the user's checking account. This IRREVERSIBLY MOVES MONEY: it debits checking and appends a transfer. There is no undo.",
+        "x-vendo-dangerous": true,
+        "x-vendo-formats": { "amount": "cents" },
+        "parameters": [
+          { "name": "amount", "in": "query", "required": true, "schema": { "type": "number" }, "description": "Amount to send in cents, e.g. 50000 = $500.00" },
+          { "name": "recipient_name", "in": "query", "required": true, "schema": { "type": "string" }, "description": "Who the money goes to, e.g. Alex Rivera" },
+          { "name": "memo", "in": "query", "schema": { "type": "string" }, "description": "Optional note shown on the transfer, e.g. June rent" }
+        ],
+        "responses": { "200": { "description": "The appended transfer transaction" } }
+      }
     }
   }
 }

--- a/apps/demo-bank/src/app/api/transfers/route.ts
+++ b/apps/demo-bank/src/app/api/transfers/route.ts
@@ -1,0 +1,22 @@
+/**
+ * POST /api/transfers — Maple's irreversible write. Sends money to a person,
+ * debiting checking and appending a posted transfer. The Vendo agent only
+ * reaches this after the CRITICAL ceremony consent card (Amount, Recipient) is
+ * confirmed; params arrive as query string (the host-tool runner's shape for
+ * declared query parameters). Moves in-memory demo funds only — no real money.
+ */
+import { transferMoney } from "@/server/transfers"
+import { ok } from "@/server/http"
+
+export const dynamic = "force-dynamic"
+
+export async function POST(req: Request) {
+  const url = new URL(req.url)
+  const amountRaw = url.searchParams.get("amount")
+  const txn = transferMoney({
+    amount: amountRaw != null ? Number(amountRaw) : undefined,
+    recipientName: url.searchParams.get("recipient_name") ?? undefined,
+    memo: url.searchParams.get("memo") ?? undefined,
+  })
+  return ok(txn)
+}

--- a/apps/demo-bank/src/app/api/transfers/route.ts
+++ b/apps/demo-bank/src/app/api/transfers/route.ts
@@ -5,18 +5,25 @@
  * confirmed; params arrive as query string (the host-tool runner's shape for
  * declared query parameters). Moves in-memory demo funds only — no real money.
  */
-import { transferMoney } from "@/server/transfers"
-import { ok } from "@/server/http"
+import { transferMoney, TransferError } from "@/server/transfers"
+import { ok, badRequest } from "@/server/http"
 
 export const dynamic = "force-dynamic"
 
 export async function POST(req: Request) {
   const url = new URL(req.url)
   const amountRaw = url.searchParams.get("amount")
-  const txn = transferMoney({
-    amount: amountRaw != null ? Number(amountRaw) : undefined,
-    recipientName: url.searchParams.get("recipient_name") ?? undefined,
-    memo: url.searchParams.get("memo") ?? undefined,
-  })
-  return ok(txn)
+  try {
+    const txn = transferMoney({
+      amount: amountRaw != null ? Number(amountRaw) : undefined,
+      recipientName: url.searchParams.get("recipient_name") ?? undefined,
+      memo: url.searchParams.get("memo") ?? undefined,
+    })
+    return ok(txn)
+  } catch (err) {
+    // Bad amount / overdraft is a clean 400 the agent can relay; a real bug
+    // still surfaces.
+    if (err instanceof TransferError) return badRequest(err.message)
+    throw err
+  }
 }

--- a/apps/demo-bank/src/server/transfers.test.ts
+++ b/apps/demo-bank/src/server/transfers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from "vitest"
-import { transferMoney } from "./transfers"
+import { transferMoney, TransferError } from "./transfers"
 import { listTransactions } from "./transactions"
 import { getStore, __reseed } from "./store"
 
@@ -23,5 +23,24 @@ describe("transferMoney", () => {
     expect(checking.balance).toBe(before - 50000)
     // It is now the most-recent transaction via the existing read path.
     expect(listTransactions({ limit: 1 }).data[0].id).toBe(txn.id)
+  })
+
+  it("rejects poison amounts without touching the balance", () => {
+    const checking = getStore().accounts.find((a) => a.kind === "checking")!
+    const before = checking.balance
+    for (const amount of [-500, 0, Number.NaN, Number.POSITIVE_INFINITY, 12.5]) {
+      expect(() => transferMoney({ amount, recipientName: "Mallory" })).toThrow(TransferError)
+    }
+    // No debit and no appended row from any rejected call.
+    expect(checking.balance).toBe(before)
+  })
+
+  it("rejects an overdraft (amount greater than the checking balance)", () => {
+    const checking = getStore().accounts.find((a) => a.kind === "checking")!
+    const before = checking.balance
+    expect(() => transferMoney({ amount: before + 1, recipientName: "Mallory" })).toThrow(
+      TransferError,
+    )
+    expect(checking.balance).toBe(before)
   })
 })

--- a/apps/demo-bank/src/server/transfers.test.ts
+++ b/apps/demo-bank/src/server/transfers.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeAll } from "vitest"
+import { transferMoney } from "./transfers"
+import { listTransactions } from "./transactions"
+import { getStore, __reseed } from "./store"
+
+// Freeze the store to a fixed, safely-past anchor (same discipline as
+// orders.test.ts) so the appended transfer is always the newest row.
+beforeAll(() => __reseed(new Date("2026-06-29T12:00:00-07:00")))
+
+describe("transferMoney", () => {
+  it("debits checking and appends a posted transfer the read API returns", () => {
+    const store = getStore()
+    const checking = store.accounts.find((a) => a.kind === "checking")!
+    const before = checking.balance
+
+    const txn = transferMoney({ amount: 50000, recipientName: "Alex Rivera", memo: "June rent" })
+
+    expect(txn.category).toBe("transfer")
+    expect(txn.amount).toBe(-50000)
+    expect(txn.merchant).toBe("Alex Rivera")
+    expect(txn.notes).toBe("June rent")
+    // The money actually left the checking balance (in-memory demo store).
+    expect(checking.balance).toBe(before - 50000)
+    // It is now the most-recent transaction via the existing read path.
+    expect(listTransactions({ limit: 1 }).data[0].id).toBe(txn.id)
+  })
+})

--- a/apps/demo-bank/src/server/transfers.ts
+++ b/apps/demo-bank/src/server/transfers.ts
@@ -18,6 +18,15 @@ export interface TransferMoneyInput {
   memo?: string
 }
 
+/** Caller-facing rejection (bad amount / overdraft). The route maps it to a
+ *  clean 400 the agent can relay; anything else is a real bug and rethrows. */
+export class TransferError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "TransferError"
+  }
+}
+
 let transferCounter = 0
 
 export function transferMoney(input: TransferMoneyInput = {}): Transaction {
@@ -27,6 +36,16 @@ export function transferMoney(input: TransferMoneyInput = {}): Transaction {
   const accountId = account?.id ?? "acct_checking"
 
   const amount = input.amount ?? 0
+  // Validate BEFORE any mutation: a finite positive integer number of cents.
+  // Rejects negatives (which would credit), zero, fractional cents, and the
+  // NaN/Infinity a non-numeric or out-of-range query param coerces to.
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new TransferError("Amount must be a positive whole number of cents.")
+  }
+  const balance = account?.balance ?? 0
+  if (amount > balance) {
+    throw new TransferError("Insufficient funds for this transfer.")
+  }
   const recipient = input.recipientName?.trim() || "Payee"
   const ref = 4100 + ((transferCounter * 17) % 900)
   transferCounter++

--- a/apps/demo-bank/src/server/transfers.ts
+++ b/apps/demo-bank/src/server/transfers.ts
@@ -1,0 +1,54 @@
+import { getStore } from "./store"
+import type { Transaction } from "./types"
+
+/**
+ * Maple's irreversible write: send money to a person. Unlike placeOrder (a
+ * card charge), this moves funds OUT of the user's checking account and can't
+ * be undone — the guardrail policy classifies it CRITICAL via
+ * `x-vendo-dangerous: true` in openapi.json, so the agent always shows the
+ * ceremony consent card (Amount, Recipient) before it runs.
+ *
+ * It mutates the in-memory demo store only: debit checking, append a posted
+ * transfer. No real money moves. Vendo's poller discovers the new row through
+ * the existing transactions API, same as every other charge.
+ */
+export interface TransferMoneyInput {
+  amount?: number // cents
+  recipientName?: string
+  memo?: string
+}
+
+let transferCounter = 0
+
+export function transferMoney(input: TransferMoneyInput = {}): Transaction {
+  const store = getStore()
+  const checking = store.accounts.find((a) => a.kind === "checking")
+  const account = checking ?? store.accounts[0]
+  const accountId = account?.id ?? "acct_checking"
+
+  const amount = input.amount ?? 0
+  const recipient = input.recipientName?.trim() || "Payee"
+  const ref = 4100 + ((transferCounter * 17) % 900)
+  transferCounter++
+
+  // Debit the account (the demo's "money actually left" moment).
+  if (account) account.balance -= amount
+
+  const txn: Transaction = {
+    id: `txn_transfer_${Date.now()}`,
+    accountId,
+    merchant: recipient,
+    descriptor: `MAPLE TRANSFER TO ${recipient.toUpperCase()} REF ${ref}`,
+    amount: -amount,
+    timestamp: new Date().toISOString(),
+    category: "transfer",
+    status: "posted",
+    statusTimeline: [{ state: "posted", at: new Date().toISOString() }],
+    method: "Maple Checking ·· 4471",
+    notes: input.memo?.trim() || undefined,
+  }
+
+  store.transactions.unshift(txn)
+  store.transactions.sort((a, b) => +new Date(b.timestamp) - +new Date(a.timestamp))
+  return txn
+}

--- a/apps/demo-bank/src/vendo/openapi-spec.test.ts
+++ b/apps/demo-bank/src/vendo/openapi-spec.test.ts
@@ -57,4 +57,17 @@ describe("mapleHostToolDefs", () => {
     expect(order.annotations.readOnlyHint).toBe(false);
     expect(order.http).toEqual({ method: "post", path: "/api/orders", params: [], hasBody: true });
   });
+
+  it("classifies the money transfer as destructive (critical tier) with a currency-formatted amount", () => {
+    const defs = openApiToHostTools(spec);
+    const transfer = defs.find((d) => d.name === "transferMoney")!;
+    // destructiveHint → dangerTier "critical" → the ceremony consent card.
+    expect(transfer.annotations.readOnlyHint).toBe(false);
+    expect(transfer.annotations.destructiveHint).toBe(true);
+    // Query params surface as top-level material fields on the card.
+    expect(transfer.http.method).toBe("post");
+    expect(transfer.http.path).toBe("/api/transfers");
+    expect(transfer.http.params.map((p) => p.name)).toEqual(["amount", "recipient_name", "memo"]);
+    expect(transfer.formats).toEqual({ amount: "cents" });
+  });
 });

--- a/packages/vendo-server/src/integrations.test.ts
+++ b/packages/vendo-server/src/integrations.test.ts
@@ -103,13 +103,14 @@ describe("integrations endpoints", () => {
     expect(await d.store.connectedToolkits()).toEqual([]);
   });
 
-  it("status poll fails fast (terminal) for a foreign/unrecognized ACTIVE account (anti-spoof)", async () => {
-    // Composio says the polled account is ACTIVE, but it is not THIS user's
-    // connection for THIS toolkit → the store was never written. This is a
-    // PERMANENT condition (the account will never legitimately register), so
-    // the client-facing status must be terminal "failed" (fail fast) rather
-    // than "pending" (which would poll to a 120s timeout). A server-side warn
-    // explains why.
+  it("status poll stays 'pending' (never terminal on a first mismatch) for an ACTIVE-but-unstored account, with a server-side warn", async () => {
+    // Composio says the polled account is ACTIVE, but it is not (yet) THIS
+    // user's stored connection for THIS toolkit → the store was never written.
+    // This is USUALLY the anti-spoof case, but it can also be a legitimate
+    // just-authorized account caught in a hasActiveConnection() eventual-
+    // consistency race. Fast-failing would wrongly kill a real connection, so
+    // the client-facing status must stay non-terminal "pending" (retry is
+    // safe). A server-side warn explains the mismatch for diagnosability.
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
       const d = deps({
@@ -122,7 +123,7 @@ describe("integrations endpoints", () => {
         get("/api/vendo/integrations?status&id=gmail&account=foreign-acct"),
         d,
       );
-      expect(await res.json()).toEqual({ status: "failed" });
+      expect(await res.json()).toEqual({ status: "pending" });
       expect(await d.store.connectedToolkits()).toEqual([]);
       expect(warnSpy).toHaveBeenCalled();
     } finally {

--- a/packages/vendo-server/src/integrations.test.ts
+++ b/packages/vendo-server/src/integrations.test.ts
@@ -103,22 +103,31 @@ describe("integrations endpoints", () => {
     expect(await d.store.connectedToolkits()).toEqual([]);
   });
 
-  it("status poll reports 'active' only when the store write happened; a foreign active account is not connected (review)", async () => {
+  it("status poll fails fast (terminal) for a foreign/unrecognized ACTIVE account (anti-spoof)", async () => {
     // Composio says the polled account is ACTIVE, but it is not THIS user's
-    // connection for THIS toolkit → the store was never written, so the
-    // client-facing status must NOT read as connected.
-    const d = deps({
-      client: stubClient({
-        connectionStatus: async () => "active" as const,
-        hasActiveConnection: async () => false,
-      }),
-    });
-    const res = await handleIntegrationsGet(
-      get("/api/vendo/integrations?status&id=gmail&account=foreign-acct"),
-      d,
-    );
-    expect(await res.json()).toEqual({ status: "pending" });
-    expect(await d.store.connectedToolkits()).toEqual([]);
+    // connection for THIS toolkit → the store was never written. This is a
+    // PERMANENT condition (the account will never legitimately register), so
+    // the client-facing status must be terminal "failed" (fail fast) rather
+    // than "pending" (which would poll to a 120s timeout). A server-side warn
+    // explains why.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const d = deps({
+        client: stubClient({
+          connectionStatus: async () => "active" as const,
+          hasActiveConnection: async () => false,
+        }),
+      });
+      const res = await handleIntegrationsGet(
+        get("/api/vendo/integrations?status&id=gmail&account=foreign-acct"),
+        d,
+      );
+      expect(await res.json()).toEqual({ status: "failed" });
+      expect(await d.store.connectedToolkits()).toEqual([]);
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("status poll logs server-side and reports transient 'pending' when Composio throws (review)", async () => {

--- a/packages/vendo-server/src/integrations.ts
+++ b/packages/vendo-server/src/integrations.ts
@@ -78,10 +78,20 @@ export async function handleIntegrationsGet(req: Request, deps: IntegrationsDeps
         return Response.json({ status: "active" as const });
       }
       // The client-facing status must reflect what actually happened. A raw
-      // "active" we did NOT record (anti-spoof case: foreign/other-toolkit
-      // account) must not read as connected — downgrade it to "pending" so the
-      // client keeps polling instead of showing connected with no toolkit.
-      return Response.json({ status: status === "active" ? ("pending" as const) : status });
+      // "active" we did NOT record is the anti-spoof case: Composio reports the
+      // polled account ACTIVE, but it isn't THIS user's connection for THIS
+      // toolkit. That's a PERMANENT condition (the account will never
+      // legitimately register here), so returning "pending" would only poll to
+      // a 120s timeout. Fail fast with terminal "failed" and warn server-side.
+      if (status === "active") {
+        console.warn(
+          `[vendo] integrations status: account is ACTIVE in Composio but is not this user's connection for '${id}' (foreign/unrecognized active account); failing fast instead of polling to timeout`,
+        );
+        return Response.json({ status: "failed" as const });
+      }
+      // Genuinely-transient states (e.g. "pending") pass through so the client
+      // keeps polling.
+      return Response.json({ status });
     } catch (err) {
       // A poll error is usually a transient Composio hiccup, not a terminal
       // failure. Log it server-side like the connect handler does, and report

--- a/packages/vendo-server/src/integrations.ts
+++ b/packages/vendo-server/src/integrations.ts
@@ -78,19 +78,23 @@ export async function handleIntegrationsGet(req: Request, deps: IntegrationsDeps
         return Response.json({ status: "active" as const });
       }
       // The client-facing status must reflect what actually happened. A raw
-      // "active" we did NOT record is the anti-spoof case: Composio reports the
-      // polled account ACTIVE, but it isn't THIS user's connection for THIS
-      // toolkit. That's a PERMANENT condition (the account will never
-      // legitimately register here), so returning "pending" would only poll to
-      // a 120s timeout. Fail fast with terminal "failed" and warn server-side.
+      // "active" we did NOT record must not read as connected. It is USUALLY
+      // the anti-spoof case (a foreign/other-toolkit active account), but it
+      // can ALSO be a LEGITIMATE just-authorized account caught in an
+      // eventual-consistency race: hasActiveConnection() is a separate list
+      // query that can transiently return false (or have errored) moments
+      // after OAuth lands. Fast-failing here would wrongly kill a real
+      // connection — worse than letting a genuine spoof poll to the client's
+      // timeout. So we keep returning "pending" (retry is safe and the store
+      // write will happen on a later poll once the account shows up) and only
+      // warn server-side for diagnosability.
       if (status === "active") {
         console.warn(
-          `[vendo] integrations status: account is ACTIVE in Composio but is not this user's connection for '${id}' (foreign/unrecognized active account); failing fast instead of polling to timeout`,
+          `[vendo] integrations status: account is ACTIVE in Composio but not yet this user's stored connection for '${id}' — still pending (a foreign account, or an eventual-consistency race on a just-authorized one)`,
         );
-        return Response.json({ status: "failed" as const });
+        return Response.json({ status: "pending" as const });
       }
-      // Genuinely-transient states (e.g. "pending") pass through so the client
-      // keeps polling.
+      // Other non-active states (e.g. "pending") pass through unchanged.
       return Response.json({ status });
     } catch (err) {
       // A poll error is usually a transient Composio hiccup, not a terminal


### PR DESCRIPTION
## What

Two changes, both from the hardening follow-up list.

### 1. Demo-bank gets a critical-tier `transfer_money` tool (makes the critical consent card demonstrable)
The summary-only consent card keeps **humanized material fields on critical-tier approvals**, but no demo exposed a money/irreversible tool to trigger it. Added `POST /api/transfers` (`transfer_money`): `x-vendo-dangerous: true` → `destructiveHint` → **critical tier** → approval-gated; `x-vendo-formats: { amount: cents }`; params `amount`/`recipient_name`/`memo` as top-level query params so they render as clean material rows. Debits the in-memory checking balance and appends a posted transfer — no real money.
- **Validated** (Codex review): amount must be a positive whole number of cents (rejects negative/zero/`NaN`/`Infinity`/fractional) and can't overdraft — before any mutation. OpenAPI param tightened to `integer, minimum 1`. The route returns a clean 400 the agent relays. Ungated like demo-bank's sibling `createOrder` (demo posture); validation is the real guard.
- **Trigger prompt:** "transfer $500 to Alex Rivera for June rent" ($500 is within the seeded $9,412.20 balance).

### 2. Integrations spoof case: pending-with-log (not fast-fail)
The `ACTIVE && !hasActiveConnection` mismatch is usually a foreign/spoofed account but can also be a **legitimate just-authorized** account racing `hasActiveConnection()`'s separate list query. Fast-failing would wrongly kill a real connection — worse than a slow spoof timeout. So it stays non-terminal `pending` (safe; the store write lands on a later poll) with a server-side `console.warn` for diagnosability. (Reverted an earlier fast-fail attempt after review flagged the race.)

### Known display note (flag for you)
The critical card renders `Amount: 50000` (raw cents), not `$500.00` — `field-rows.ts` in `@vendoai/shell` doesn't apply `x-vendo-formats` to approval-card **inputs** (only to result rendering). Making the card show `$500.00` is a small shell change (UI-gated). Flagging so the demo screenshot isn't a surprise; happy to do that shell fix if you want it.

`pnpm typecheck` 27/27 · `pnpm test` 25/25 (transfers 3/3, openapi-spec 22/22, integrations 13/13). Live critical-card verification in the consolidated browser pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a critical-tier money transfer tool in demo-bank and make integrations status polling safer. Transfers now require consent and strict validation; ACTIVE-but-unstored accounts stay pending with a server warn to avoid false failures.

- **New Features**
  - Added POST /api/transfers (transferMoney) marked as critical. Uses amount (cents), recipient_name, and memo query params with currency formatting for amount.
  - Validates amount as a positive integer (cents) and blocks overdrafts. Returns 400 on bad input.
  - Debits the in-memory checking balance and appends a posted transfer.
  - Added tests for the transfer flow and OpenAPI classification.

- **Bug Fixes**
  - Integrations: When Composio says ACTIVE but the store has no connection, keep status as pending and log a server-side console.warn. Prevents killing legitimate just-authorized accounts caught in a race. Updated tests to expect pending and the warn.

<sup>Written for commit 8552a9f0761a610b0dd6e3d7b4c77199f22cddc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

