### PR TITLE
fix: post-#68 follow-ups — truthful keyless capabilities, shell CI flake headroom, asset-restore docs

### DIFF
--- a/apps/demo-bank/src/vendo/handler-options.test.ts
+++ b/apps/demo-bank/src/vendo/handler-options.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { detectCapabilities } from "vendoai/server";
+
+const savedKey = process.env.ANTHROPIC_API_KEY;
+
+afterEach(() => {
+  if (savedKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+  else process.env.ANTHROPIC_API_KEY = savedKey;
+  vi.resetModules();
+});
+
+// `vendoOptions.model` is assembled once at module-load time (see
+// handler-options.ts's own comment on why it's a shared singleton), so
+// exercising both env states means resetting the module registry and
+// re-importing between assertions.
+describe("vendoOptions keyless boot", () => {
+  it("does not inject a model when ANTHROPIC_API_KEY is unset, so chat reports false", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    vi.resetModules();
+    const { vendoOptions } = await import("./handler-options");
+    expect(vendoOptions.model).toBeUndefined();
+    expect(
+      detectCapabilities(process.env, { hasInjectedModel: vendoOptions.model !== undefined }).chat,
+    ).toBe(false);
+  });
+
+  it("injects a model when ANTHROPIC_API_KEY is set, so chat reports true", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test-key";
+    vi.resetModules();
+    const { vendoOptions } = await import("./handler-options");
+    expect(vendoOptions.model).toBeDefined();
+    expect(
+      detectCapabilities(process.env, { hasInjectedModel: vendoOptions.model !== undefined }).chat,
+    ).toBe(true);
+  });
+});

--- a/apps/demo-bank/src/vendo/handler-options.ts
+++ b/apps/demo-bank/src/vendo/handler-options.ts
@@ -102,7 +102,14 @@ export const vendoOptions: VendoHandlerOptions = {
   // identical shape — bootKey gives the boot registry a stable identity that
   // survives that split (see fetch-handler.ts's BootRegistry comment).
   bootKey: "demo-bank",
-  model: anthropic(process.env.VENDO_DEMO_MODEL ?? "claude-sonnet-4-6"),
+  // Only inject a model when a real credential exists — `detectCapabilities`
+  // treats ANY injected model as chat-capable (`hasInjectedModel`), so an
+  // unconditional inject would make a keyless boot report chat:true and then
+  // 500 on the first turn. This exists purely to pin the demo's model id;
+  // it must never be the thing that turns chat on.
+  ...(process.env.ANTHROPIC_API_KEY
+    ? { model: anthropic(process.env.VENDO_DEMO_MODEL ?? "claude-sonnet-4-6") }
+    : {}),
   // Per-run function (spec §7): grounds capability talk in the live toolset.
   instructions: (ctx) => buildInstructions({ toolSummary: ctx.toolSummary }),
   policy: demoPolicy,

--- a/docs-site/deploy/troubleshooting.mdx
+++ b/docs-site/deploy/troubleshooting.mdx
@@ -9,13 +9,13 @@ Use the headings and error snippets to find the matching cause.
 
 Cause: `public/vendo/react-runtime.js` is missing.
 
-Fix: run `npx vendo init . --force`, or copy the Vendo sandbox assets into `public/vendo/` as part of your own setup.
+Fix: run `npx vendo init .` — init copies any missing sandbox asset even without `--force` (add `--force` only to overwrite files that already exist but are stale). `vendo sync` does not restore these assets.
 
 ## Sandbox unavailable: components bundle missing
 
 Cause: `public/vendo/components-sandbox.js` is missing.
 
-Fix: run `npx vendo init . --force`, or copy the Vendo sandbox assets into `public/vendo/`.
+Fix: run `npx vendo init .` — init copies any missing sandbox asset even without `--force` (add `--force` only to overwrite files that already exist but are stale). `vendo sync` does not restore these assets.
 
 ## Chat is unavailable
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -321,8 +321,10 @@ scheduler and Composio webhook setup you'll want on a real deployment.
 ## Troubleshooting
 
 - **"Sandbox unavailable / react shim missing"** — `public/vendo/` is
-  missing its two assets; re-run `npx vendo init . --force` or copy them
-  from the CLI's `dist/assets/`.
+  missing its two assets; re-run `npx vendo init .` to restore them (init
+  copies any missing sandbox asset even without `--force`; add `--force` only
+  if the files exist but are stale). `vendo sync` does NOT copy these — it
+  only captures wrapped-component source, so it won't fix this.
 - **Chat answers 403 on a deployment** — that's the local-only default; see
   Deploying above.
 - **Chat errors immediately** — check that one of `ANTHROPIC_API_KEY`,

--- a/packages/vendo-shell/vitest.config.ts
+++ b/packages/vendo-shell/vitest.config.ts
@@ -1,2 +1,13 @@
 import { defineConfig } from "vitest/config";
-export default defineConfig({ test: { environment: "jsdom", globals: true, css: false } });
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    css: false,
+    setupFiles: ["./vitest.setup.ts"],
+    // Full-thread renders (VendoThread/approval-resume/slot) under parallel
+    // monorepo load can outrun vitest's 5s default even with async-util
+    // headroom bumped above — give the whole test body more room too.
+    testTimeout: 30_000,
+  },
+});

--- a/packages/vendo-shell/vitest.setup.ts
+++ b/packages/vendo-shell/vitest.setup.ts
@@ -1,0 +1,9 @@
+import { configure } from "@testing-library/react";
+
+// Full-thread tests (VendoThread/approval-resume/slot) mount the entire
+// provider stack and drive a scripted agent turn through several waitFor/
+// findBy waits. testing-library's default asyncUtilTimeout (1s) is tuned for
+// a quiet machine — under a loaded, parallel monorepo CI runner the same
+// waits can legitimately take longer even though nothing is actually stuck,
+// so give them CI headroom instead of flaking.
+configure({ asyncUtilTimeout: 10_000 });


### PR DESCRIPTION
# Post-#68 follow-ups

Fixes the three follow-ups noted in #68.

## 1. demo-bank: keyless boot now reports `chat:false`

`handler-options.ts` injected `model: anthropic(...)` unconditionally, and an injected model counts as chat-capable in `detectCapabilities` (by design — that contract is unchanged). So a keyless boot claimed `chat:true` and the first turn 500'd with "Anthropic API key is missing". The model is now injected only when `ANTHROPIC_API_KEY` exists; `VENDO_DEMO_MODEL` pinning still works with a key. New `handler-options.test.ts` covers both branches.

**Live-verified keyless** (this worktree has no `.env.local`): `GET /api/vendo/capabilities` → `{"chat":false,"integrations":false,"voice":false,"mcp":false,"storage":true,"automations":false}`.

Note: demo-bank's hand-rolled overlay doesn't consume capabilities (pre-existing; the packaged `VendoRoot` client does) — so the composer still renders keyless, it just no longer gets lied to by the endpoint. Wiring the demo's custom shell to the capabilities answer would be a separate change.

## 2. vendo-shell: CI headroom for the flaky full-thread tests

`VendoThread e2e` / `approval-resume` / `slot` fail only on loaded CI runners (testing-library's 1s default `waitFor` budget) and pass locally in ~2s. New `vitest.setup.ts` sets `asyncUtilTimeout: 10s` and the config sets `testTimeout: 30s`. Config-only — zero test files touched, no assertions weakened; the three tests were audited for real races (none found: all async assertions already use `waitFor`/`findBy`). 5 consecutive local runs green.

## 3. docs: troubleshooting points at the real asset-restore command

The quickstart told readers to copy sandbox assets "from the CLI's `dist/assets/`" — a path hosts no longer have since #68 stopped installing the CLI. Verified against the code: `vendo init` re-copies any *missing* `public/vendo/` asset without `--force` (force is only needed to overwrite stale-but-present files), and `vendo sync` never touches these assets. `docs/quickstart.md` + `docs-site/deploy/troubleshooting.mdx` now say exactly that.

## Verification

- Full gate green: `pnpm build` 19/19 · `pnpm test` 27/27 (demo-bank 93/93, vendo-shell 359/359) · `pnpm typecheck` 29/29 · `pnpm lint` clean.
- Browser check (keyless demo-bank boot): capabilities JSON above; screenshots shared in-session.
- All three commits reviewed (spec + quality, claims verified against source).

https://claude.ai/code/session_01SqzDUocFaxPaB1BDuQJ4VS

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Demo-bank now reports chat:false when booting without an Anthropic key. CI for `vendo-shell` gets more timeout headroom, and docs now point to `npx vendo init .` for restoring sandbox assets.

- **Bug Fixes**
  - Demo-bank: inject the model only when `ANTHROPIC_API_KEY` exists, so keyless boots report chat:false; tests cover both keyless and keyed paths (pinning via `VENDO_DEMO_MODEL` still works with a key).
  - `vendo-shell` tests: raise `@testing-library/react` `asyncUtilTimeout` to 10s via `vitest.setup.ts` and set Vitest `testTimeout` to 30s; no test files or assertions changed.
  - Docs: update Quickstart and Troubleshooting to use `npx vendo init .`; clarify `--force` only overwrites existing files and that `vendo sync` does not restore assets.

<sup>Written for commit c084281189d378b4edd0da05ffe15dc766b2b3f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

