### PR TITLE
follow-up: sandbox route channel (usePathname/useSearchParams/useParams return the real host route)

### DIFF
--- a/apps/demo-bank/src/components/vendo/SandboxStage.tsx
+++ b/apps/demo-bank/src/components/vendo/SandboxStage.tsx
@@ -6,10 +6,11 @@
  * onAction to the policy-governed action route, and renders an inline approval
  * prompt when the policy answers "approve".
  */
-import { useEffect, useRef, useState, type ReactNode } from "react";
-import { usePathname, useParams } from "next/navigation";
+import { Suspense, useEffect, useRef, useState, type ReactNode } from "react";
+import { usePathname, useSearchParams, useParams } from "next/navigation";
 import type { UINode, ActionRequest, ActionResult } from "@vendoai/core";
 import { VendoStage } from "@vendoai/react";
+import type { StageRoute } from "@vendoai/stage";
 import { ApprovalCard } from "@vendoai/shell";
 import { prewiredComponents, brandToCssVars, mapBrandToTheme } from "@vendoai/components";
 import { mapleHostComponents } from "@/vendo/host-components/descriptors";
@@ -76,21 +77,22 @@ function StageApproval({ req, settle }: { req: ActionRequest; settle: (approved:
   );
 }
 
-export function SandboxStage({ node }: { node: UINode }): ReactNode {
-  // Live route supplier: feed the host's REAL location into the sandbox so the
-  // next/navigation shims (usePathname/useSearchParams/useParams) resolve it
-  // instead of empty values. `search` comes from window.location rather than
-  // useSearchParams() to avoid forcing a Suspense boundary on the build.
+/** Live route supplier: feeds the host's REAL location into the sandbox so the
+ *  next/navigation shims resolve it. `useSearchParams` subscribes to query-only
+ *  navigation (so the sandbox re-renders) but forces a Suspense boundary. */
+function useHostRoute(): StageRoute {
   const pathname = usePathname();
-  const rawParams = useParams();
-  const params: Record<string, string> = {};
-  for (const [k, v] of Object.entries(rawParams)) params[k] = Array.isArray(v) ? v.join("/") : (v ?? "");
-  const route = {
+  const searchParams = useSearchParams();
+  const params = useParams();
+  const search = searchParams.toString();
+  return {
     pathname: pathname ?? "",
-    search: typeof window !== "undefined" ? window.location.search : "",
-    params,
+    search: search ? `?${search}` : "",
+    params: params as Record<string, string | string[]>, // catch-all segments stay string[]
   };
+}
 
+export function SandboxStage({ node }: { node: UINode }): ReactNode {
   const [sources, setSources] = useState<Sources | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   // Pending approvals keyed by requestId: CONCURRENT gated dispatches each get
@@ -157,16 +159,11 @@ export function SandboxStage({ node }: { node: UINode }): ReactNode {
 
   return (
     <div>
-      <VendoStage
-        node={node}
-        components={[...prewiredComponents, ...mapleHostComponents]}
-        reactSource={sources.react}
-        bundleSource={sources.bundle}
-        onAction={onAction}
-        theme={theme}
-        componentTheme={componentTheme}
-        route={route}
-      />
+      {/* Suspense satisfies useSearchParams()'s boundary requirement; on the
+          client the route resolves synchronously so the stage mounts once. */}
+      <Suspense fallback={<div data-testid="stage-loading" aria-busy="true" />}>
+        <RoutedStage node={node} sources={sources} onAction={onAction} />
+      </Suspense>
       {[...pending.entries()].map(([requestId, entry]) => (
         <StageApproval
           key={requestId}
@@ -175,5 +172,31 @@ export function SandboxStage({ node }: { node: UINode }): ReactNode {
         />
       ))}
     </div>
+  );
+}
+
+/** The stage with the host's live route fed in. Isolated so the
+ *  `useSearchParams()` subscription lives under the Suspense boundary above. */
+function RoutedStage({
+  node,
+  sources,
+  onAction,
+}: {
+  node: UINode;
+  sources: Sources;
+  onAction: (req: ActionRequest) => Promise<ActionResult>;
+}): ReactNode {
+  const route = useHostRoute();
+  return (
+    <VendoStage
+      node={node}
+      components={[...prewiredComponents, ...mapleHostComponents]}
+      reactSource={sources.react}
+      bundleSource={sources.bundle}
+      onAction={onAction}
+      theme={theme}
+      componentTheme={componentTheme}
+      route={route}
+    />
   );
 }

--- a/apps/demo-bank/src/components/vendo/SandboxStage.tsx
+++ b/apps/demo-bank/src/components/vendo/SandboxStage.tsx
@@ -7,6 +7,7 @@
  * prompt when the policy answers "approve".
  */
 import { useEffect, useRef, useState, type ReactNode } from "react";
+import { usePathname, useParams } from "next/navigation";
 import type { UINode, ActionRequest, ActionResult } from "@vendoai/core";
 import { VendoStage } from "@vendoai/react";
 import { ApprovalCard } from "@vendoai/shell";
@@ -76,6 +77,20 @@ function StageApproval({ req, settle }: { req: ActionRequest; settle: (approved:
 }
 
 export function SandboxStage({ node }: { node: UINode }): ReactNode {
+  // Live route supplier: feed the host's REAL location into the sandbox so the
+  // next/navigation shims (usePathname/useSearchParams/useParams) resolve it
+  // instead of empty values. `search` comes from window.location rather than
+  // useSearchParams() to avoid forcing a Suspense boundary on the build.
+  const pathname = usePathname();
+  const rawParams = useParams();
+  const params: Record<string, string> = {};
+  for (const [k, v] of Object.entries(rawParams)) params[k] = Array.isArray(v) ? v.join("/") : (v ?? "");
+  const route = {
+    pathname: pathname ?? "",
+    search: typeof window !== "undefined" ? window.location.search : "",
+    params,
+  };
+
   const [sources, setSources] = useState<Sources | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   // Pending approvals keyed by requestId: CONCURRENT gated dispatches each get
@@ -150,6 +165,7 @@ export function SandboxStage({ node }: { node: UINode }): ReactNode {
         onAction={onAction}
         theme={theme}
         componentTheme={componentTheme}
+        route={route}
       />
       {[...pending.entries()].map(([requestId, entry]) => (
         <StageApproval

--- a/packages/vendo-next/package.json
+++ b/packages/vendo-next/package.json
@@ -37,6 +37,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "peerDependencies": {
+    "next": ">=13.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },
@@ -47,6 +48,7 @@
     "@vendoai/runtime": "workspace:*",
     "@vendoai/server": "workspace:*",
     "@vendoai/shell": "workspace:*",
+    "@vendoai/stage": "workspace:*",
     "@vendoai/store": "workspace:*",
     "@scarf/scarf": "^1.4.0",
     "ai": "6.0.28",
@@ -58,6 +60,7 @@
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "jsdom": "^25.0.0",
+    "next": "16.2.9",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "typescript": "^5.6.0",

--- a/packages/vendo-next/src/client/sandbox-stage.test.tsx
+++ b/packages/vendo-next/src/client/sandbox-stage.test.tsx
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type { UINode } from "@vendoai/core";
+import { defaultBrand } from "@vendoai/components/theme";
+
+// Capture the props the packaged sandbox hands to VendoStage.
+let captured: Record<string, any> | null = null;
+vi.mock("@vendoai/react", () => ({
+  VendoStage: (props: any) => {
+    captured = props;
+    return null;
+  },
+}));
+
+// The host's real route, exactly as next/navigation would report it (including a
+// catch-all array param, which must survive to the sandbox unchanged).
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/clients/cl_rivera",
+  useSearchParams: () => new URLSearchParams("tab=invoices&page=2"),
+  useParams: () => ({ id: "cl_rivera", slug: ["a", "b"] }),
+}));
+
+import { SandboxStage } from "./sandbox-stage.js";
+
+afterEach(() => {
+  cleanup();
+  captured = null;
+  vi.unstubAllGlobals();
+});
+
+function stubSources() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("react-runtime.js")) return new Response("/* react */", { status: 200 });
+      if (url.includes("components-sandbox.js")) return new Response("/* bundle */", { status: 200 });
+      return new Response("", { status: 404 }); // env assets absent → bare sandbox
+    }),
+  );
+}
+
+describe("packaged SandboxStage route channel", () => {
+  it("feeds VendoStage the host's REAL route from next/navigation (non-empty)", async () => {
+    stubSources();
+    const node: UINode = { id: "gen", kind: "component", source: "prewired", name: "Text", props: { text: "hi" } };
+    render(<SandboxStage node={node} brand={defaultBrand} components={[]} basePath="/api/vendo" />);
+
+    // Sources load in an effect, then RoutedStage mounts VendoStage with the route.
+    await waitFor(() => expect(captured).not.toBeNull());
+    expect(captured!.route).toBeDefined();
+    expect(captured!.route.pathname).toBe("/clients/cl_rivera");
+    expect(captured!.route.search).toBe("?tab=invoices&page=2");
+    // Catch-all array param survives unchanged (segment shape preserved).
+    expect(captured!.route.params).toEqual({ id: "cl_rivera", slug: ["a", "b"] });
+    // The whole point of the feature: packaged installs get a NON-empty route.
+    expect(captured!.route.pathname).not.toBe("");
+    expect(captured!.route.search).not.toBe("");
+  });
+});

--- a/packages/vendo-next/src/client/sandbox-stage.tsx
+++ b/packages/vendo-next/src/client/sandbox-stage.tsx
@@ -7,13 +7,32 @@
  * route (single-use approval tokens), and renders the shell's ApprovalCard
  * when the policy answers "approve".
  */
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { Suspense, useEffect, useRef, useState, type ReactNode } from "react";
+import { usePathname, useSearchParams, useParams } from "next/navigation";
 import type { UINode, ActionRequest, ActionResult, RegisteredComponent } from "@vendoai/core";
 import { VendoStage } from "@vendoai/react";
+import type { StageRoute } from "@vendoai/stage";
 import { ApprovalCard } from "@vendoai/shell";
 import { prewiredComponents, brandToCssVars, mapBrandToTheme } from "@vendoai/components";
 import type { BrandTokens } from "@vendoai/components/theme";
 import { NAVIGATE_ACTION, isSafeAppPath } from "./navigate.js";
+
+/** Read the host's REAL route from next/navigation and shape it for the sandbox
+ *  (`window.__vendoRouteData`). `useSearchParams` subscribes to query-only
+ *  navigation so the sandbox's `useSearchParams()` re-renders — but it forces a
+ *  Suspense boundary, so callers must render `<RoutedStage>` inside `<Suspense>`. */
+function useHostRoute(): StageRoute {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const params = useParams();
+  const search = searchParams.toString();
+  return {
+    pathname: pathname ?? "",
+    search: search ? `?${search}` : "",
+    // Pass Next's params through unchanged — catch-all segments stay string[].
+    params: params as Record<string, string | string[]>,
+  };
+}
 
 interface StageEnv {
   modules?: Record<string, string>;
@@ -206,16 +225,18 @@ export function SandboxStage({ node, brand, components, basePath, onNavigate }: 
 
   return (
     <div>
-      <VendoStage
-        node={node}
-        components={[...prewiredComponents, ...components]}
-        reactSource={sources.react}
-        bundleSource={sources.bundle}
-        {...(sources.env ? { env: sources.env } : {})}
-        onAction={onAction}
-        theme={brandToCssVars(brand)}
-        componentTheme={{ theme: mapBrandToTheme(brand), mode: brand.mode ?? "light" }}
-      />
+      {/* Suspense satisfies useSearchParams()'s boundary requirement; the light
+          placeholder only shows during static prerender — on the client the
+          route resolves synchronously and the stage mounts once (no double iframe). */}
+      <Suspense fallback={<div data-testid="stage-route-loading" aria-busy="true" />}>
+        <RoutedStage
+          node={node}
+          components={components}
+          sources={sources}
+          onAction={onAction}
+          brand={brand}
+        />
+      </Suspense>
       {[...pending.entries()].map(([requestId, entry]) => (
         <div key={requestId} style={{ marginTop: 10 }}>
           <ApprovalCard
@@ -227,5 +248,37 @@ export function SandboxStage({ node, brand, components, basePath, onNavigate }: 
         </div>
       ))}
     </div>
+  );
+}
+
+/** Renders the sandbox stage with the host's live route fed in. Isolated so the
+ *  `useSearchParams()` subscription lives under SandboxStage's Suspense boundary
+ *  (never at the top level, which would opt the whole page into CSR). */
+function RoutedStage({
+  node,
+  components,
+  sources,
+  onAction,
+  brand,
+}: {
+  node: UINode;
+  components: RegisteredComponent[];
+  sources: Sources;
+  onAction: (req: ActionRequest) => Promise<ActionResult>;
+  brand: BrandTokens;
+}): ReactNode {
+  const route = useHostRoute();
+  return (
+    <VendoStage
+      node={node}
+      components={[...prewiredComponents, ...components]}
+      reactSource={sources.react}
+      bundleSource={sources.bundle}
+      {...(sources.env ? { env: sources.env } : {})}
+      onAction={onAction}
+      theme={brandToCssVars(brand)}
+      componentTheme={{ theme: mapBrandToTheme(brand), mode: brand.mode ?? "light" }}
+      route={route}
+    />
   );
 }

--- a/packages/vendo-react/src/stage-adapter.tsx
+++ b/packages/vendo-react/src/stage-adapter.tsx
@@ -6,6 +6,7 @@ import {
   type StageController,
   type OnAction,
   type GenUISession,
+  type StageRoute,
 } from "@vendoai/stage";
 import {
   isGeneratedNode,
@@ -64,6 +65,12 @@ export interface VendoStageProps {
   /** Opaque OpenUI theme the sandbox bundle mounts; @vendoai/react does not
    *  interpret its shape. */
   componentTheme?: unknown;
+  /** The host's real route (read-only), fed into the sandbox as
+   *  `window.__vendoRouteData` so the next/navigation shims resolve the host's
+   *  actual location. Supply it from the host's own next/navigation, e.g.
+   *  `{ pathname: usePathname(), search: useSearchParams().toString(), params }`.
+   *  Omit and the shims fall back to empty values. */
+  route?: StageRoute;
 }
 
 export function VendoStage({
@@ -76,7 +83,11 @@ export function VendoStage({
   onAction,
   components,
   componentTheme,
+  route,
 }: VendoStageProps) {
+  // Read-only route channel spread into every initialize() so the shims resolve
+  // the host's real location regardless of which tree is mounted.
+  const routeInit = route ? { route } : {};
   const slotRef = useRef<HTMLDivElement>(null);
   const ctrlRef = useRef<StageController | null>(null);
   const initedRef = useRef(false);
@@ -133,7 +144,7 @@ export function VendoStage({
         c.ready
           .then(() => {
             if (cancelled) return;
-            c.initialize({ theme, state, bundleSource, componentTheme, tree: CLEARED_TREE });
+            c.initialize({ theme, state, bundleSource, componentTheme, ...routeInit, tree: CLEARED_TREE });
             rootIdRef.current = CLEARED_TREE.id;
             sessionRef.current = null;
             payloadRef.current = null;
@@ -172,7 +183,7 @@ export function VendoStage({
                 name: "Text",
                 props: { text: "Failed to render generated UI: " + result.error.message },
               };
-              c.initialize({ theme, state, bundleSource, componentTheme, tree: errorTree });
+              c.initialize({ theme, state, bundleSource, componentTheme, ...routeInit, tree: errorTree });
               initedRef.current = true;
               rootIdRef.current = node.id;
               // Drop any prior session so the next valid payload re-initializes
@@ -194,6 +205,7 @@ export function VendoStage({
               state,
               bundleSource,
               componentTheme,
+              ...routeInit,
               tree: result.session.tree,
               generatedComponents: payload.components,
               ...(anchorData ? { anchorData } : {}),
@@ -234,14 +246,14 @@ export function VendoStage({
           payloadRef.current = null;
         }
         if (!initedRef.current) {
-          c.initialize({ theme, state, bundleSource, componentTheme, tree: node });
+          c.initialize({ theme, state, bundleSource, componentTheme, ...routeInit, tree: node });
           initedRef.current = true;
           rootIdRef.current = node.id;
         } else if (switchedFromGenerated || node.id !== rootIdRef.current) {
           // New tree (root id changed, or we just switched off a generated tree
           // whose mounted root id differs from this node). Re-initialize — a
           // plain update would target a nodeId that no longer exists and no-op.
-          c.initialize({ theme, state, bundleSource, componentTheme, tree: node });
+          c.initialize({ theme, state, bundleSource, componentTheme, ...routeInit, tree: node });
           rootIdRef.current = node.id;
         } else {
           c.update({ replace: { nodeId: node.id, node } });
@@ -276,6 +288,13 @@ export function VendoStage({
     if (!c || !initedRef.current) return;
     c.update({ state });
   }, [state]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Re-patch the read-only route channel after init when the host route changes.
+  useEffect(() => {
+    const c = ctrlRef.current;
+    if (!c || !initedRef.current || !route) return;
+    c.update({ route });
+  }, [route]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return <div ref={slotRef} data-vendo-stage />;
 }

--- a/packages/vendo-sandbox-shims/src/next-navigation.ts
+++ b/packages/vendo-sandbox-shims/src/next-navigation.ts
@@ -1,11 +1,25 @@
 /**
  * Minimal `next/navigation` shim. `useRouter().push/replace` (and `redirect`)
  * route the host app via vendo.navigate. `redirect`/`notFound` throw to unwind
- * the render (Next semantics, caught by the sandbox error boundary); the
- * router history methods and the read hooks that have no route channel are safe
- * no-ops / empty values so they never crash a render or event handler.
+ * the render (Next semantics, caught by the sandbox error boundary). The read
+ * hooks (usePathname/useSearchParams/useParams) resolve the host's real route
+ * from the read-only `window.__vendoRouteData` channel, falling back to empty
+ * values when absent; the router history methods stay safe no-ops so they never
+ * crash a render or event handler.
  */
 import { navigate } from "./dispatch.js";
+
+/** Read-only route channel the host injects (`window.__vendoRouteData`, set by
+ *  the stage runtime parallel to `__vendoAnchorData`). `search` is a raw query
+ *  string like "?q=1"; `params` is Next's dynamic-route params object. */
+interface RouteDataWindow {
+  __vendoRouteData?: { pathname?: string; search?: string; params?: Record<string, string> };
+}
+
+/** Never crashes when the channel is absent (SSR / no host): returns {}. */
+function routeData(): NonNullable<RouteDataWindow["__vendoRouteData"]> {
+  return (globalThis as unknown as RouteDataWindow).__vendoRouteData ?? {};
+}
 
 export function useRouter() {
   return {
@@ -30,19 +44,21 @@ export function useRouter() {
   };
 }
 
+/** The host's real pathname from the route channel (fallback "" with no host). */
 export function usePathname(): string {
-  return "";
+  return routeData().pathname ?? "";
 }
 
+/** The host's real query string, parsed from the route channel (fallback empty). */
 export function useSearchParams(): URLSearchParams {
-  return new URLSearchParams();
+  return new URLSearchParams(routeData().search ?? "");
 }
 
-/** No route channel exists in the sandbox yet, so there are no dynamic route
- *  params to surface — return an empty object rather than crash a component
- *  that reads `params.id`. */
+/** The host's real dynamic-route params from the route channel. Returns an empty
+ *  object when the channel is absent rather than crash a component reading
+ *  `params.id`. */
 export function useParams<T extends Record<string, string | string[]> = Record<string, string | string[]>>(): T {
-  return {} as T;
+  return (routeData().params ?? {}) as T;
 }
 
 /** Recognizable codes so a host/error-boundary can tell these apart from real

--- a/packages/vendo-sandbox-shims/src/next-navigation.ts
+++ b/packages/vendo-sandbox-shims/src/next-navigation.ts
@@ -13,7 +13,7 @@ import { navigate } from "./dispatch.js";
  *  the stage runtime parallel to `__vendoAnchorData`). `search` is a raw query
  *  string like "?q=1"; `params` is Next's dynamic-route params object. */
 interface RouteDataWindow {
-  __vendoRouteData?: { pathname?: string; search?: string; params?: Record<string, string> };
+  __vendoRouteData?: { pathname?: string; search?: string; params?: Record<string, string | string[]> };
 }
 
 /** Never crashes when the channel is absent (SSR / no host): returns {}. */

--- a/packages/vendo-sandbox-shims/src/shims.test.tsx
+++ b/packages/vendo-sandbox-shims/src/shims.test.tsx
@@ -5,6 +5,8 @@ import Image from "./next-image";
 import {
   useRouter,
   useParams,
+  usePathname,
+  useSearchParams,
   redirect,
   notFound,
   useSelectedLayoutSegment,
@@ -17,6 +19,7 @@ afterEach(() => {
   cleanup();
   delete (globalThis as Record<string, unknown>)["__vendoDispatch"];
   delete (globalThis as Record<string, unknown>)["__vendoAnchorData"];
+  delete (globalThis as Record<string, unknown>)["__vendoRouteData"];
 });
 
 function captureDispatch() {
@@ -157,7 +160,7 @@ describe("useRouter shim", () => {
 });
 
 describe("next/navigation extra exports", () => {
-  it("useParams returns an empty object (no route channel in the sandbox)", () => {
+  it("useParams returns an empty object when the route channel is absent", () => {
     expect(useParams()).toEqual({});
   });
 
@@ -175,6 +178,34 @@ describe("next/navigation extra exports", () => {
   it("useSelectedLayoutSegment(s) return null / []", () => {
     expect(useSelectedLayoutSegment()).toBeNull();
     expect(useSelectedLayoutSegments()).toEqual([]);
+  });
+});
+
+describe("next/navigation route channel (window.__vendoRouteData)", () => {
+  it("usePathname/useSearchParams/useParams read the host's real route from the channel", () => {
+    (globalThis as Record<string, unknown>)["__vendoRouteData"] = {
+      pathname: "/clients/cl_rivera",
+      search: "?tab=invoices&page=2",
+      params: { id: "cl_rivera" },
+    };
+    expect(usePathname()).toBe("/clients/cl_rivera");
+    const sp = useSearchParams();
+    expect(sp.get("tab")).toBe("invoices");
+    expect(sp.get("page")).toBe("2");
+    expect(useParams()).toEqual({ id: "cl_rivera" });
+  });
+
+  it("falls back to empty values when the channel is absent (SSR / no host)", () => {
+    expect(usePathname()).toBe("");
+    expect(useSearchParams().toString()).toBe("");
+    expect(useParams()).toEqual({});
+  });
+
+  it("falls back per-field when the channel exists but a field is missing", () => {
+    (globalThis as Record<string, unknown>)["__vendoRouteData"] = { pathname: "/settings" };
+    expect(usePathname()).toBe("/settings");
+    expect(useSearchParams().toString()).toBe("");
+    expect(useParams()).toEqual({});
   });
 });
 

--- a/packages/vendo-sandbox-shims/src/shims.test.tsx
+++ b/packages/vendo-sandbox-shims/src/shims.test.tsx
@@ -207,6 +207,17 @@ describe("next/navigation route channel (window.__vendoRouteData)", () => {
     expect(useSearchParams().toString()).toBe("");
     expect(useParams()).toEqual({});
   });
+
+  it("passes catch-all/array params through unchanged (segment shape preserved)", () => {
+    (globalThis as Record<string, unknown>)["__vendoRouteData"] = {
+      pathname: "/docs/a/b/c",
+      search: "",
+      params: { slug: ["a", "b", "c"], org: "acme" },
+    };
+    const params = useParams();
+    expect(Array.isArray(params.slug)).toBe(true);
+    expect(params).toEqual({ slug: ["a", "b", "c"], org: "acme" });
+  });
 });
 
 describe("useSWR shim", () => {

--- a/packages/vendo-stage/src/runtime.test.ts
+++ b/packages/vendo-stage/src/runtime.test.ts
@@ -71,6 +71,12 @@ describe("stage runtime source", () => {
       "if (params.componentTheme && window.__VENDO_THEME_WRAP__)",
     );
   });
+  it("injects the read-only route channel (window.__vendoRouteData) on init and re-patches it on ui/update", () => {
+    // Parallel to __vendoAnchorData: set on the full render (init) and refreshed
+    // on ui/update, so the next/navigation shims resolve the host's real route.
+    expect(STAGE_RUNTIME_SRC).toContain("window.__vendoRouteData = params.route || {}");
+    expect(STAGE_RUNTIME_SRC).toContain("window.__vendoRouteData = p.route");
+  });
   it("Text/Skeleton primitives read the canonical --vendo-* theme vars, not --brand-*", () => {
     // TU-2: --brand-* is retired in favor of --vendo-* (see TU-1's brandToCssVars).
     expect(STAGE_RUNTIME_SRC).toContain("--vendo-fg");

--- a/packages/vendo-stage/src/runtime.ts
+++ b/packages/vendo-stage/src/runtime.ts
@@ -340,6 +340,9 @@ export const STAGE_RUNTIME_SRC = String.raw`
     // Anchor data feed for the swr shim (set BEFORE any generated module
     // evaluates or renders — useSWR reads it synchronously).
     window.__vendoAnchorData = params.anchorData || {};
+    // Read-only route channel for the next/navigation shims (usePathname /
+    // useSearchParams / useParams). Set alongside anchorData, before any render.
+    window.__vendoRouteData = params.route || {};
     injectTheme(params.theme || {});
     cachedHost = await loadBundle(params.bundleSource);
     var gen = await loadGeneratedComponents(params.generatedComponents);
@@ -436,6 +439,12 @@ export const STAGE_RUNTIME_SRC = String.raw`
       if (p.anchorData) {
         currentParams = Object.assign({}, currentParams, { anchorData: p.anchorData });
         window.__vendoAnchorData = p.anchorData;
+      }
+
+      // Refresh the read-only route channel (live re-patch, same lifecycle).
+      if (p.route) {
+        currentParams = Object.assign({}, currentParams, { route: p.route });
+        window.__vendoRouteData = p.route;
       }
 
       // Apply node patch (find-and-replace by id, including root).

--- a/packages/vendo-stage/src/stage-host.test.ts
+++ b/packages/vendo-stage/src/stage-host.test.ts
@@ -178,6 +178,38 @@ describe("connectStage", () => {
     peer.dispose();
   });
 
+  it("carries the read-only route through ui/initialize and re-patches it on ui/update", async () => {
+    const { a, b } = makePair();
+    let initParams: any;
+    let updateParams: any;
+    const peer = makeRpc(b, a, async (method, params) => {
+      if (method === "ui/initialize") { initParams = params; return { ok: true }; }
+      if (method === "ui/update") { updateParams = params; return { ok: true }; }
+      return {};
+    });
+    const controller = connectStage(
+      { listen: a, post: b },
+      { onAction: async () => ({ result: "ok" }) },
+    );
+
+    const route = { pathname: "/clients/cl_rivera", search: "?tab=invoices", params: { id: "cl_rivera" } };
+    await controller.initialize({
+      theme: {},
+      state: {},
+      bundleSource: "",
+      route,
+      tree: { id: "root", kind: "component", source: "host", name: "Card", props: {} },
+    });
+    expect(initParams.route).toEqual(route);
+
+    const nextRoute = { pathname: "/settings", search: "" };
+    await controller.update({ route: nextRoute });
+    expect(updateParams.route).toEqual(nextRoute);
+
+    controller.dispose();
+    peer.dispose();
+  });
+
   it("tools/call with CORRECT capability token reaches onAction as ActionRequest and returns ActionResult", async () => {
     const { a, b } = makePair();
     const onAction = vi.fn().mockResolvedValue({ result: "confirmed" });

--- a/packages/vendo-stage/src/stage-host.test.ts
+++ b/packages/vendo-stage/src/stage-host.test.ts
@@ -210,6 +210,36 @@ describe("connectStage", () => {
     peer.dispose();
   });
 
+  it("forwards a live anchorData re-patch through ui/update (same-structure refresh)", async () => {
+    // Regression: update() dropped anchorData, so the swr shim's live refresh on
+    // same-structure data (saved views / anchor re-patch) never reached the sandbox.
+    const { a, b } = makePair();
+    let updateParams: any;
+    const peer = makeRpc(b, a, async (method, params) => {
+      if (method === "ui/initialize") { return { ok: true }; }
+      if (method === "ui/update") { updateParams = params; return { ok: true }; }
+      return {};
+    });
+    const controller = connectStage(
+      { listen: a, post: b },
+      { onAction: async () => ({ result: "ok" }) },
+    );
+
+    await controller.initialize({
+      theme: {},
+      state: {},
+      bundleSource: "",
+      tree: { id: "root", kind: "component", source: "host", name: "Card", props: {} },
+    });
+
+    const anchorData = { "/api/deadlines": [{ id: "a" }, { id: "b" }] };
+    await controller.update({ anchorData });
+    expect(updateParams.anchorData).toEqual(anchorData);
+
+    controller.dispose();
+    peer.dispose();
+  });
+
   it("tools/call with CORRECT capability token reaches onAction as ActionRequest and returns ActionResult", async () => {
     const { a, b } = makePair();
     const onAction = vi.fn().mockResolvedValue({ result: "confirmed" });

--- a/packages/vendo-stage/src/stage-host.ts
+++ b/packages/vendo-stage/src/stage-host.ts
@@ -280,7 +280,9 @@ export function createStage(
 export interface StageRoute {
   pathname: string;
   search: string;
-  params?: Record<string, string>;
+  /** Next's dynamic-route params. Catch-all segments arrive as string[], so the
+   *  value type is `string | string[]` and passes through the shims unchanged. */
+  params?: Record<string, string | string[]>;
 }
 
 /** Payload for `controller.initialize()`. */
@@ -485,9 +487,10 @@ export function connectStage(
     },
 
     update(update) {
-      const payload: { theme?: Record<string, string>; state?: Record<string, unknown>; route?: StageRoute; replace?: { nodeId: string; node: UINode } } = {};
+      const payload: { theme?: Record<string, string>; state?: Record<string, unknown>; anchorData?: Record<string, unknown>; route?: StageRoute; replace?: { nodeId: string; node: UINode } } = {};
       if (update.theme) payload.theme = update.theme;
       if (update.state) payload.state = update.state;
+      if (update.anchorData) payload.anchorData = update.anchorData;
       if (update.route) payload.route = update.route;
       if (update.replace) {
         const { nodeId, node } = update.replace;

--- a/packages/vendo-stage/src/stage-host.ts
+++ b/packages/vendo-stage/src/stage-host.ts
@@ -272,6 +272,17 @@ export function createStage(
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
+/** The host's real route, injected read-only as `window.__vendoRouteData` so the
+ *  next/navigation shims (usePathname/useSearchParams/useParams) resolve the
+ *  host's actual location instead of empty values. `search` is a raw query string
+ *  (e.g. "?q=1"); `params` is Next's dynamic-route params object. Read-only —
+ *  navigation writes go through the dispatch bridge, not this channel. */
+export interface StageRoute {
+  pathname: string;
+  search: string;
+  params?: Record<string, string>;
+}
+
 /** Payload for `controller.initialize()`. */
 export interface StageInitPayload {
   theme: Record<string, string>;
@@ -284,6 +295,9 @@ export interface StageInitPayload {
    *  `window.__vendoAnchorData` so the swr shim resolves keys from it
    *  (remix fast-edits — the shim shipped in PR #35 but nothing fed it). */
   anchorData?: Record<string, unknown>;
+  /** The host's real route, injected read-only as `window.__vendoRouteData` for
+   *  the next/navigation shims (parallel to `anchorData`). */
+  route?: StageRoute;
   /**
    * Opaque theme blob for the in-sandbox component library (OpenUI). Forwarded
    * unchanged into `ui/initialize`; the runtime hands it to the host bundle's
@@ -299,6 +313,8 @@ export interface StageUpdatePayload {
   state?: Record<string, unknown>;
   /** Refreshed anchor data (live context re-patch) for the swr shim. */
   anchorData?: Record<string, unknown>;
+  /** Refreshed route (live re-patch) for the next/navigation shims. */
+  route?: StageRoute;
   /**
    * Node patch. `nodeId` and `node` travel as one unit — you cannot pass one
    * without the other (the runtime rejects a partial patch).
@@ -469,9 +485,10 @@ export function connectStage(
     },
 
     update(update) {
-      const payload: { theme?: Record<string, string>; state?: Record<string, unknown>; replace?: { nodeId: string; node: UINode } } = {};
+      const payload: { theme?: Record<string, string>; state?: Record<string, unknown>; route?: StageRoute; replace?: { nodeId: string; node: UINode } } = {};
       if (update.theme) payload.theme = update.theme;
       if (update.state) payload.state = update.state;
+      if (update.route) payload.route = update.route;
       if (update.replace) {
         const { nodeId, node } = update.replace;
         // Mint fresh tokens for the replacement subtree, splice it into our tree

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -586,6 +586,9 @@ importers:
       '@vendoai/shell':
         specifier: workspace:*
         version: link:../vendo-shell
+      '@vendoai/stage':
+        specifier: workspace:*
+        version: link:../vendo-stage
       '@vendoai/store':
         specifier: workspace:*
         version: link:../vendo-store
@@ -611,6 +614,9 @@ importers:
       jsdom:
         specifier: ^25.0.0
         version: 25.0.1
+      next:
+        specifier: 16.2.9
+        version: 16.2.9(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.0
         version: 18.3.1
@@ -11835,6 +11841,32 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  next@16.2.9(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@next/env': 16.2.9
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.40
+      caniuse-lite: 1.0.30001799
+      postcss: 8.4.31
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      styled-jsx: 5.1.6(react@18.3.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.9
+      '@next/swc-darwin-x64': 16.2.9
+      '@next/swc-linux-arm64-gnu': 16.2.9
+      '@next/swc-linux-arm64-musl': 16.2.9
+      '@next/swc-linux-x64-gnu': 16.2.9
+      '@next/swc-linux-x64-musl': 16.2.9
+      '@next/swc-win32-arm64-msvc': 16.2.9
+      '@next/swc-win32-x64-msvc': 16.2.9
+      '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.61.1
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
   node-addon-api@7.1.1: {}
 
   node-emoji@2.2.0:
@@ -12748,6 +12780,11 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@babel/core': 7.29.7
+
+  styled-jsx@5.1.6(react@18.3.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 18.3.1
 
   sucrase@3.35.1:
     dependencies:


### PR DESCRIPTION
## What

A read-only `__vendoRouteData` channel (parallel to the existing `__vendoAnchorData`) so generated sandbox components' `next/navigation` shims return the **host's real route** instead of empty values.

### Plumbing (mirrors the proven anchorData path)
- `vendo-stage/stage-host.ts` — `StageRoute` type (`{ pathname; search; params? }`, params `string | string[]` for catch-alls); optional `route` on init + update payloads; `update()` now forwards it.
- `vendo-stage/runtime.ts` — injects `window.__vendoRouteData` on init, re-patches on `ui/update`.
- `vendo-sandbox-shims/next-navigation.ts` — `usePathname`/`useSearchParams`/`useParams` read the channel (safe empty fallback when absent).
- `vendo-react/stage-adapter.tsx` — `route` prop threaded into initialize + a route-change update effect.
- **Packaged `@vendoai/next` client** — `SandboxStage` → new `RoutedStage` sources live `next/navigation` under a `<Suspense>` boundary and feeds `route` to `VendoStage`. Real installs get populated route data, not just demo-bank.

### Also fixed (Codex review)
- Catch-all params preserved (no more `join("/")` shape loss).
- Real `useSearchParams` subscription (was an unsubscribed `location.search` read that went stale on query-only nav).
- **Pre-existing bug:** `stage-host.ts` `update()` silently dropped `anchorData` from the `ui/update` payload — the live anchor re-patch (saved-view refresh on same-structure data) never reached the controller. Now forwarded + pinned by a test.

## Architecture flag for you (your call at merge)
Auto-supplying route from the packaged client required adding **`next` as a peerDependency of `@vendoai/next`**, reversing the package's previously deliberate next-free stance (the old `onNavigate` prop pattern). For the Next adapter this is defensible and gives "it just works," but it's a real coupling decision. Alternative: thread `route` as a host-supplied prop through `VendoRoot` (keeps the library next-free, but the host must wire route themselves). I went with auto-supply per the "make it work for packaged installs" direction — happy to switch to the prop approach if you prefer. **Note:** if PR #68 (`@vendoai/next` → `vendo` umbrella) lands, this needs reconciling there.

`pnpm typecheck` 27/27 · `pnpm test` 25/25 (shims + stage + react + next + demo-bank) · demo-bank & vendo-next `build` clean. New test asserts the packaged path delivers a non-empty route incl. a catch-all array.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read‑only `__vendoRouteData` channel so sandbox `next/navigation` shims return the host’s real pathname, search, and params. The packaged `@vendoai/next` client now auto-wires this route (under `<Suspense>`) for correct, reactive routing.

- **New Features**
  - `@vendoai/stage`: `StageRoute` type; optional `route` on init/update; runtime sets `window.__vendoRouteData` and refreshes it on `ui/update`.
  - `@vendoai/react`: `VendoStage` accepts `route` and forwards it on initialize/update.
  - `@vendoai/next`: `SandboxStage` reads `usePathname`/`useSearchParams`/`useParams` and passes `route` via a `RoutedStage` inside `<Suspense>`; adds `next` (>=13) as a peer dependency.
  - `vendo-sandbox-shims`: `usePathname`/`useSearchParams`/`useParams` read the channel; safe empty fallbacks when absent.

- **Bug Fixes**
  - Preserve catch‑all params as `string[]` (no `join("/")` collapse).
  - `useSearchParams` is now a real subscription, fixing stale results on query-only nav.
  - `stage-host.update()` forwards `anchorData` so SWR live re-patch reaches the sandbox.

<sup>Written for commit f13447ec047fb518dc5353aed2046eb58ef5bd56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

