### PR TITLE
fix(telemetry): CI-red config tests pass an explicit env + README rename stragglers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 ```bash
-npx @vendoai/cli init .
+npx vendoai init .
 ```
 
 <p align="center"><sub>One command inside your Next.js app. No account, no hosted dependency.</sub><br>
@@ -144,7 +144,7 @@ through your permission policy. Deeper docs: [docs/](docs/).
 
 <details>
 <summary><b>Which frameworks are supported?</b></summary>
-<br>Next.js App Router today via <code>@vendoai/next</code>. The agent server is a plain fetch handler underneath, so other frameworks can wire it manually.
+<br>Next.js App Router today via the <code>vendoai</code> package's ready-made route pair. The agent server is a plain fetch handler underneath (plus a Node adapter for Express/<code>node:http</code>), so other frameworks can wire it manually.
 </details>
 
 <details>

--- a/packages/vendo-telemetry/src/config.test.ts
+++ b/packages/vendo-telemetry/src/config.test.ts
@@ -13,8 +13,11 @@ afterEach(() => {
 });
 
 describe("config store", () => {
+  // These pass an explicit empty env: loadConfig defaults to process.env, and
+  // under a real CI runner CI=true is an env opt-out (ephemeral config, nothing
+  // persisted), which is exactly the behavior the "(review)" cases below pin.
   it("creates a random anonymous id on first load", () => {
-    const c = loadConfig(home);
+    const c = loadConfig(home, {});
     expect(c.anonymousId).toMatch(/[0-9a-f-]{36}/);
     expect(c.optedOut).toBe(false);
     expect(c.noticeShown).toBe(false);
@@ -22,15 +25,15 @@ describe("config store", () => {
   });
 
   it("returns the same id on subsequent loads", () => {
-    const a = loadConfig(home);
-    const b = loadConfig(home);
+    const a = loadConfig(home, {});
+    const b = loadConfig(home, {});
     expect(b.anonymousId).toBe(a.anonymousId);
   });
 
   it("persists updates", () => {
-    const c = loadConfig(home);
+    const c = loadConfig(home, {});
     saveConfig(home, { ...c, optedOut: true, noticeShown: true });
-    const reread = loadConfig(home);
+    const reread = loadConfig(home, {});
     expect(reread.optedOut).toBe(true);
     expect(reread.noticeShown).toBe(true);
   });


### PR DESCRIPTION
## Telemetry config tests red on every CI run

`loadConfig(home)` defaults its env to `process.env`. On GitHub Actions, `CI=true` is a deliberate env opt-out: the config comes back ephemeral and opted-out, and no tracking id is ever persisted (correct privacy behavior, pinned by this file's own review cases). The first three tests inherited the runner's env while asserting the opted-in path — red on CI since they landed with the hardening wave, green on any dev machine.

Reproduced locally with `CI=true` (2 failed / 5 passed), fixed by passing an explicit empty env to the three opted-in-path tests, verified 31/31 green under `CI=true`. Test-only; no product behavior touched. Swept other packages for the same leakage — the CLI's telemetry-cmd tests read back files their commands just wrote (file contents win over env), so they're env-safe.

## README rename stragglers

The README redesign (#77/#78 wave) merged after the `vendoai` rename and reintroduced two stale bits: the hero install command said `npx @vendoai/cli init .` (now `npx vendoai init .`, matching the Get-started section), and the frameworks FAQ cited the deleted `@vendoai/next`.

## Verification

Telemetry 31/31 under `CI=true` locally; full typecheck 29/29 and lint clean; this PR's own CI run is the end-to-end proof (the failing tests run under real `CI=true` here).

https://claude.ai/code/session_01SqzDUocFaxPaB1BDuQJ4VS
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/81" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI-only failures in `vendo-telemetry` config tests by passing an explicit empty env to `loadConfig`. Also updates the README to use `npx vendoai init .` and removes the stale `@vendoai/next` reference.

- **Bug Fixes**
  - Tests no longer inherit `process.env`; call `loadConfig(home, {})` so `CI=true` on runners doesn’t trigger the opt-out path and break assertions.

<sup>Written for commit 67316c720ea060262553fb48a9bbb3319d15e665. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

