### PR TITLE
follow-up: sandbox route channel (optional-supplier, Next-free generic client)

### DIFF
--- a/apps/demo-bank/src/components/vendo/SandboxStage.tsx
+++ b/apps/demo-bank/src/components/vendo/SandboxStage.tsx
@@ -84,11 +84,14 @@ function useHostRoute(): StageRoute {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const params = useParams();
-  const search = searchParams.toString();
+  // useSearchParams() can be null in hybrid/pages-dir apps — guard it. params
+  // can likewise be null; normalize to {} so catch-all segments (string[]) still
+  // survive when present.
+  const search = searchParams?.toString() ?? "";
   return {
     pathname: pathname ?? "",
     search: search ? `?${search}` : "",
-    params: params as Record<string, string | string[]>, // catch-all segments stay string[]
+    params: (params ?? {}) as Record<string, string | string[]>,
   };
 }
 

--- a/apps/demo-bank/src/components/vendo/SandboxStage.tsx
+++ b/apps/demo-bank/src/components/vendo/SandboxStage.tsx
@@ -6,9 +6,11 @@
  * onAction to the policy-governed action route, and renders an inline approval
  * prompt when the policy answers "approve".
  */
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { Suspense, useEffect, useRef, useState, type ReactNode } from "react";
+import { usePathname, useSearchParams, useParams } from "next/navigation";
 import type { UINode, ActionRequest, ActionResult } from "@vendoai/core";
 import { VendoStage } from "@vendoai/react";
+import type { StageRoute } from "@vendoai/stage";
 import { ApprovalCard } from "@vendoai/shell";
 import { prewiredComponents, brandToCssVars, mapBrandToTheme } from "@vendoai/components";
 import { mapleHostComponents } from "@/vendo/host-components/descriptors";
@@ -73,6 +75,21 @@ function StageApproval({ req, settle }: { req: ActionRequest; settle: (approved:
       />
     </div>
   );
+}
+
+/** Live route supplier: feeds the host's REAL location into the sandbox so the
+ *  next/navigation shims resolve it. `useSearchParams` subscribes to query-only
+ *  navigation (so the sandbox re-renders) but forces a Suspense boundary. */
+function useHostRoute(): StageRoute {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const params = useParams();
+  const search = searchParams.toString();
+  return {
+    pathname: pathname ?? "",
+    search: search ? `?${search}` : "",
+    params: params as Record<string, string | string[]>, // catch-all segments stay string[]
+  };
 }
 
 export function SandboxStage({ node }: { node: UINode }): ReactNode {
@@ -142,15 +159,11 @@ export function SandboxStage({ node }: { node: UINode }): ReactNode {
 
   return (
     <div>
-      <VendoStage
-        node={node}
-        components={[...prewiredComponents, ...mapleHostComponents]}
-        reactSource={sources.react}
-        bundleSource={sources.bundle}
-        onAction={onAction}
-        theme={theme}
-        componentTheme={componentTheme}
-      />
+      {/* Suspense satisfies useSearchParams()'s boundary requirement; on the
+          client the route resolves synchronously so the stage mounts once. */}
+      <Suspense fallback={<div data-testid="stage-loading" aria-busy="true" />}>
+        <RoutedStage node={node} sources={sources} onAction={onAction} />
+      </Suspense>
       {[...pending.entries()].map(([requestId, entry]) => (
         <StageApproval
           key={requestId}
@@ -159,5 +172,31 @@ export function SandboxStage({ node }: { node: UINode }): ReactNode {
         />
       ))}
     </div>
+  );
+}
+
+/** The stage with the host's live route fed in. Isolated so the
+ *  `useSearchParams()` subscription lives under the Suspense boundary above. */
+function RoutedStage({
+  node,
+  sources,
+  onAction,
+}: {
+  node: UINode;
+  sources: Sources;
+  onAction: (req: ActionRequest) => Promise<ActionResult>;
+}): ReactNode {
+  const route = useHostRoute();
+  return (
+    <VendoStage
+      node={node}
+      components={[...prewiredComponents, ...mapleHostComponents]}
+      reactSource={sources.react}
+      bundleSource={sources.bundle}
+      onAction={onAction}
+      theme={theme}
+      componentTheme={componentTheme}
+      route={route}
+    />
   );
 }

--- a/packages/vendo-client/package.json
+++ b/packages/vendo-client/package.json
@@ -33,7 +33,6 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "peerDependencies": {
-    "next": ">=13.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },

--- a/packages/vendo-client/package.json
+++ b/packages/vendo-client/package.json
@@ -33,6 +33,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "peerDependencies": {
+    "next": ">=13.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },
@@ -42,6 +43,7 @@
     "@vendoai/react": "workspace:*",
     "@vendoai/server": "workspace:*",
     "@vendoai/shell": "workspace:*",
+    "@vendoai/stage": "workspace:*",
     "ai": "6.0.28"
   },
   "devDependencies": {
@@ -50,6 +52,7 @@
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "jsdom": "^25.0.0",
+    "next": "16.2.9",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "typescript": "^5.6.0",

--- a/packages/vendo-client/src/sandbox-stage.test.tsx
+++ b/packages/vendo-client/src/sandbox-stage.test.tsx
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type { UINode } from "@vendoai/core";
+import { defaultBrand } from "@vendoai/components/theme";
+
+// Capture the props the packaged sandbox hands to VendoStage.
+let captured: Record<string, any> | null = null;
+vi.mock("@vendoai/react", () => ({
+  VendoStage: (props: any) => {
+    captured = props;
+    return null;
+  },
+}));
+
+// The host's real route, exactly as next/navigation would report it (including a
+// catch-all array param, which must survive to the sandbox unchanged).
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/clients/cl_rivera",
+  useSearchParams: () => new URLSearchParams("tab=invoices&page=2"),
+  useParams: () => ({ id: "cl_rivera", slug: ["a", "b"] }),
+}));
+
+import { SandboxStage } from "./sandbox-stage.js";
+
+afterEach(() => {
+  cleanup();
+  captured = null;
+  vi.unstubAllGlobals();
+});
+
+function stubSources() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("react-runtime.js")) return new Response("/* react */", { status: 200 });
+      if (url.includes("components-sandbox.js")) return new Response("/* bundle */", { status: 200 });
+      return new Response("", { status: 404 }); // env assets absent → bare sandbox
+    }),
+  );
+}
+
+describe("packaged SandboxStage route channel", () => {
+  it("feeds VendoStage the host's REAL route from next/navigation (non-empty)", async () => {
+    stubSources();
+    const node: UINode = { id: "gen", kind: "component", source: "prewired", name: "Text", props: { text: "hi" } };
+    render(<SandboxStage node={node} brand={defaultBrand} components={[]} basePath="/api/vendo" />);
+
+    // Sources load in an effect, then RoutedStage mounts VendoStage with the route.
+    await waitFor(() => expect(captured).not.toBeNull());
+    expect(captured!.route).toBeDefined();
+    expect(captured!.route.pathname).toBe("/clients/cl_rivera");
+    expect(captured!.route.search).toBe("?tab=invoices&page=2");
+    // Catch-all array param survives unchanged (segment shape preserved).
+    expect(captured!.route.params).toEqual({ id: "cl_rivera", slug: ["a", "b"] });
+    // The whole point of the feature: packaged installs get a NON-empty route.
+    expect(captured!.route.pathname).not.toBe("");
+    expect(captured!.route.search).not.toBe("");
+  });
+});

--- a/packages/vendo-client/src/sandbox-stage.test.tsx
+++ b/packages/vendo-client/src/sandbox-stage.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, waitFor } from "@testing-library/react";
 import type { UINode } from "@vendoai/core";
+import type { StageRoute } from "@vendoai/stage";
 import { defaultBrand } from "@vendoai/components/theme";
 
 // Capture the props the packaged sandbox hands to VendoStage.
@@ -12,13 +13,11 @@ vi.mock("@vendoai/react", () => ({
   },
 }));
 
-// The host's real route, exactly as next/navigation would report it (including a
-// catch-all array param, which must survive to the sandbox unchanged).
-vi.mock("next/navigation", () => ({
-  usePathname: () => "/clients/cl_rivera",
-  useSearchParams: () => new URLSearchParams("tab=invoices&page=2"),
-  useParams: () => ({ id: "cl_rivera", slug: ["a", "b"] }),
-}));
+// NOTE: this file deliberately does NOT import or mock `next/navigation`.
+// The generic @vendoai/client must stay Next-free (a Next dependency here
+// would break plain-React/Vite consumers like examples/node). Route is now an
+// OPTIONAL host-supplied input; a Next host passes it from its own
+// next/navigation. These tests exercise both the supplied and absent paths.
 
 import { SandboxStage } from "./sandbox-stage.js";
 
@@ -40,11 +39,20 @@ function stubSources() {
   );
 }
 
+const node: UINode = { id: "gen", kind: "component", source: "prewired", name: "Text", props: { text: "hi" } };
+
 describe("packaged SandboxStage route channel", () => {
-  it("feeds VendoStage the host's REAL route from next/navigation (non-empty)", async () => {
+  it("forwards a host-SUPPLIED route to VendoStage (non-empty, catch-all array preserved)", async () => {
     stubSources();
-    const node: UINode = { id: "gen", kind: "component", source: "prewired", name: "Text", props: { text: "hi" } };
-    render(<SandboxStage node={node} brand={defaultBrand} components={[]} basePath="/api/vendo" />);
+    // A Next host would build this from its own usePathname/useSearchParams/useParams.
+    const routeSource = (): StageRoute => ({
+      pathname: "/clients/cl_rivera",
+      search: "?tab=invoices&page=2",
+      params: { id: "cl_rivera", slug: ["a", "b"] },
+    });
+    render(
+      <SandboxStage node={node} brand={defaultBrand} components={[]} basePath="/api/vendo" routeSource={routeSource} />,
+    );
 
     // Sources load in an effect, then RoutedStage mounts VendoStage with the route.
     await waitFor(() => expect(captured).not.toBeNull());
@@ -53,8 +61,19 @@ describe("packaged SandboxStage route channel", () => {
     expect(captured!.route.search).toBe("?tab=invoices&page=2");
     // Catch-all array param survives unchanged (segment shape preserved).
     expect(captured!.route.params).toEqual({ id: "cl_rivera", slug: ["a", "b"] });
-    // The whole point of the feature: packaged installs get a NON-empty route.
+    // The whole point of the feature: a supplied route reaches the sandbox non-empty.
     expect(captured!.route.pathname).not.toBe("");
     expect(captured!.route.search).not.toBe("");
+  });
+
+  it("renders the non-Next path (NO route supplied) without crashing and with no route on VendoStage", async () => {
+    stubSources();
+    // No routeSource: the generic client must mount the stage with no route,
+    // leaving the sandbox's route shims to resolve empty — exactly the behavior
+    // before the route feature, and the path a plain-React/Vite host takes.
+    render(<SandboxStage node={node} brand={defaultBrand} components={[]} basePath="/api/vendo" />);
+
+    await waitFor(() => expect(captured).not.toBeNull());
+    expect(captured!.route).toBeUndefined();
   });
 });

--- a/packages/vendo-client/src/sandbox-stage.tsx
+++ b/packages/vendo-client/src/sandbox-stage.tsx
@@ -7,13 +7,32 @@
  * route (single-use approval tokens), and renders the shell's ApprovalCard
  * when the policy answers "approve".
  */
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { Suspense, useEffect, useRef, useState, type ReactNode } from "react";
+import { usePathname, useSearchParams, useParams } from "next/navigation";
 import type { UINode, ActionRequest, ActionResult, RegisteredComponent } from "@vendoai/core";
 import { VendoStage } from "@vendoai/react";
+import type { StageRoute } from "@vendoai/stage";
 import { ApprovalCard } from "@vendoai/shell";
 import { prewiredComponents, brandToCssVars, mapBrandToTheme } from "@vendoai/components";
 import type { BrandTokens } from "@vendoai/components/theme";
 import { NAVIGATE_ACTION, isSafeAppPath } from "./navigate.js";
+
+/** Read the host's REAL route from next/navigation and shape it for the sandbox
+ *  (`window.__vendoRouteData`). `useSearchParams` subscribes to query-only
+ *  navigation so the sandbox's `useSearchParams()` re-renders — but it forces a
+ *  Suspense boundary, so callers must render `<RoutedStage>` inside `<Suspense>`. */
+function useHostRoute(): StageRoute {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const params = useParams();
+  const search = searchParams.toString();
+  return {
+    pathname: pathname ?? "",
+    search: search ? `?${search}` : "",
+    // Pass Next's params through unchanged — catch-all segments stay string[].
+    params: params as Record<string, string | string[]>,
+  };
+}
 
 interface StageEnv {
   modules?: Record<string, string>;
@@ -206,16 +225,18 @@ export function SandboxStage({ node, brand, components, basePath, onNavigate }: 
 
   return (
     <div>
-      <VendoStage
-        node={node}
-        components={[...prewiredComponents, ...components]}
-        reactSource={sources.react}
-        bundleSource={sources.bundle}
-        {...(sources.env ? { env: sources.env } : {})}
-        onAction={onAction}
-        theme={brandToCssVars(brand)}
-        componentTheme={{ theme: mapBrandToTheme(brand), mode: brand.mode ?? "light" }}
-      />
+      {/* Suspense satisfies useSearchParams()'s boundary requirement; the light
+          placeholder only shows during static prerender — on the client the
+          route resolves synchronously and the stage mounts once (no double iframe). */}
+      <Suspense fallback={<div data-testid="stage-route-loading" aria-busy="true" />}>
+        <RoutedStage
+          node={node}
+          components={components}
+          sources={sources}
+          onAction={onAction}
+          brand={brand}
+        />
+      </Suspense>
       {[...pending.entries()].map(([requestId, entry]) => (
         <div key={requestId} style={{ marginTop: 10 }}>
           <ApprovalCard
@@ -227,5 +248,37 @@ export function SandboxStage({ node, brand, components, basePath, onNavigate }: 
         </div>
       ))}
     </div>
+  );
+}
+
+/** Renders the sandbox stage with the host's live route fed in. Isolated so the
+ *  `useSearchParams()` subscription lives under SandboxStage's Suspense boundary
+ *  (never at the top level, which would opt the whole page into CSR). */
+function RoutedStage({
+  node,
+  components,
+  sources,
+  onAction,
+  brand,
+}: {
+  node: UINode;
+  components: RegisteredComponent[];
+  sources: Sources;
+  onAction: (req: ActionRequest) => Promise<ActionResult>;
+  brand: BrandTokens;
+}): ReactNode {
+  const route = useHostRoute();
+  return (
+    <VendoStage
+      node={node}
+      components={[...prewiredComponents, ...components]}
+      reactSource={sources.react}
+      bundleSource={sources.bundle}
+      {...(sources.env ? { env: sources.env } : {})}
+      onAction={onAction}
+      theme={brandToCssVars(brand)}
+      componentTheme={{ theme: mapBrandToTheme(brand), mode: brand.mode ?? "light" }}
+      route={route}
+    />
   );
 }

--- a/packages/vendo-client/src/sandbox-stage.tsx
+++ b/packages/vendo-client/src/sandbox-stage.tsx
@@ -8,7 +8,6 @@
  * when the policy answers "approve".
  */
 import { Suspense, useEffect, useRef, useState, type ReactNode } from "react";
-import { usePathname, useSearchParams, useParams } from "next/navigation";
 import type { UINode, ActionRequest, ActionResult, RegisteredComponent } from "@vendoai/core";
 import { VendoStage } from "@vendoai/react";
 import type { StageRoute } from "@vendoai/stage";
@@ -16,23 +15,6 @@ import { ApprovalCard } from "@vendoai/shell";
 import { prewiredComponents, brandToCssVars, mapBrandToTheme } from "@vendoai/components";
 import type { BrandTokens } from "@vendoai/components/theme";
 import { NAVIGATE_ACTION, isSafeAppPath } from "./navigate.js";
-
-/** Read the host's REAL route from next/navigation and shape it for the sandbox
- *  (`window.__vendoRouteData`). `useSearchParams` subscribes to query-only
- *  navigation so the sandbox's `useSearchParams()` re-renders — but it forces a
- *  Suspense boundary, so callers must render `<RoutedStage>` inside `<Suspense>`. */
-function useHostRoute(): StageRoute {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const params = useParams();
-  const search = searchParams.toString();
-  return {
-    pathname: pathname ?? "",
-    search: search ? `?${search}` : "",
-    // Pass Next's params through unchanged — catch-all segments stay string[].
-    params: params as Record<string, string | string[]>,
-  };
-}
 
 interface StageEnv {
   modules?: Record<string, string>;
@@ -147,9 +129,19 @@ export interface SandboxStageProps {
    *  version-agnostic; VendoRoot wires `useRouter().push`. Default:
    *  `location.assign`, still validated same-app first. */
   onNavigate?: (href: string) => void;
+  /** OPTIONAL live route supplier — the seam that keeps this generic client
+   *  Next-free (plain-React/Vite consumers must not pull `next` through here).
+   *  Called during render inside SandboxStage's Suspense boundary, so a Next
+   *  host implements it by reading its OWN `next/navigation`, e.g.
+   *  `() => ({ pathname: usePathname() ?? "", search: useSearchParams()?.toString() ? ... , params })`
+   *  (see apps/demo-bank's SandboxStage for the reference sourcing). `useSearchParams`
+   *  forces a Suspense boundary — satisfied here — so the sandbox re-renders on
+   *  query-only navigation. Omit it (any non-Next host) and the sandbox's route
+   *  shims resolve empty, exactly as before the route feature. */
+  routeSource?: () => StageRoute;
 }
 
-export function SandboxStage({ node, brand, components, basePath, onNavigate }: SandboxStageProps): ReactNode {
+export function SandboxStage({ node, brand, components, basePath, onNavigate, routeSource }: SandboxStageProps): ReactNode {
   const [sources, setSources] = useState<Sources | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   // Pending approvals keyed by requestId: concurrent gated dispatches each get
@@ -235,6 +227,7 @@ export function SandboxStage({ node, brand, components, basePath, onNavigate }: 
           sources={sources}
           onAction={onAction}
           brand={brand}
+          {...(routeSource ? { routeSource } : {})}
         />
       </Suspense>
       {[...pending.entries()].map(([requestId, entry]) => (
@@ -251,23 +244,28 @@ export function SandboxStage({ node, brand, components, basePath, onNavigate }: 
   );
 }
 
-/** Renders the sandbox stage with the host's live route fed in. Isolated so the
- *  `useSearchParams()` subscription lives under SandboxStage's Suspense boundary
- *  (never at the top level, which would opt the whole page into CSR). */
+/** Renders the sandbox stage, feeding in the host's live route when a
+ *  `routeSource` is supplied. Isolated so any hook subscription inside
+ *  `routeSource` (e.g. a Next host's `useSearchParams()`) lives under
+ *  SandboxStage's Suspense boundary (never at the top level, which would opt the
+ *  whole page into CSR). With no `routeSource` the stage mounts route-less and
+ *  the sandbox shims resolve empty. */
 function RoutedStage({
   node,
   components,
   sources,
   onAction,
   brand,
+  routeSource,
 }: {
   node: UINode;
   components: RegisteredComponent[];
   sources: Sources;
   onAction: (req: ActionRequest) => Promise<ActionResult>;
   brand: BrandTokens;
+  routeSource?: () => StageRoute;
 }): ReactNode {
-  const route = useHostRoute();
+  const route = routeSource?.();
   return (
     <VendoStage
       node={node}
@@ -278,7 +276,7 @@ function RoutedStage({
       onAction={onAction}
       theme={brandToCssVars(brand)}
       componentTheme={{ theme: mapBrandToTheme(brand), mode: brand.mode ?? "light" }}
-      route={route}
+      {...(route ? { route } : {})}
     />
   );
 }

--- a/packages/vendo-client/src/vendo-root.tsx
+++ b/packages/vendo-client/src/vendo-root.tsx
@@ -14,9 +14,10 @@
  * Capability-additive: the integrations tray only appears when the server
  * reports the Composio capability; voice stays behind its flag (ENG-185).
  */
-import { useEffect, useMemo, useState, type CSSProperties, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { DefaultChatTransport } from "ai";
 import type { VendoUIMessage, ManifestTool, UINode } from "@vendoai/core";
+import type { StageRoute } from "@vendoai/stage";
 import { VendoProvider } from "@vendoai/react";
 import {
   VendoOverlay,
@@ -66,6 +67,24 @@ export interface VendoRootProps {
    *  handler reports `voice:true`; pass `false` to opt out, or a custom
    *  driver to override the packaged OpenAI Realtime wiring. */
   voice?: VoiceDriver | false;
+  /** OPTIONAL live route supplier, threaded to the sandbox stage so generated
+   *  views' next/link + next/navigation shims resolve the host's REAL location.
+   *  This package stays framework-agnostic, so a Next host supplies it from its
+   *  OWN `next/navigation` (declare `next` >= 13.3.0 in the host — `useParams`
+   *  landed in 13.3), e.g.:
+   *    routeSource={() => {
+   *      const params = useParams();
+   *      return {
+   *        pathname: usePathname() ?? "",
+   *        search: useSearchParams()?.toString() ? `?${useSearchParams()!.toString()}` : "",
+   *        params: (params ?? {}) as Record<string, string | string[]>,
+   *      };
+   *    }}
+   *  (`useSearchParams()` can be null in hybrid/pages-dir apps — guard it.) It's
+   *  invoked inside the stage's Suspense boundary, so `useSearchParams` re-renders
+   *  the sandbox on query-only navigation without opting the page into CSR. Omit
+   *  it (any non-Next host) and the sandbox route shims resolve empty. */
+  routeSource?: () => StageRoute;
   children: ReactNode;
 }
 
@@ -117,9 +136,15 @@ export function VendoRoot({
   toasts = true,
   toastPlacement = "bottom-left",
   voice,
+  routeSource,
   children,
 }: VendoRootProps) {
   const brand = useMemo(() => parseBrand(theme), [theme]);
+  // Held in a ref so the memoized renderNode below stays stable (a Next host
+  // typically passes a fresh inline `routeSource` each render); renderNode reads
+  // the latest supplier at call time without re-creating on its identity.
+  const routeSourceRef = useRef(routeSource);
+  routeSourceRef.current = routeSource;
   const manifestTools = useMemo(() => parseManifestTools(tools), [tools]);
   const hostToolDefs = useMemo(() => manifestToolsToHostTools(manifestTools), [manifestTools]);
   const [open, setOpen] = useState(false);
@@ -260,7 +285,15 @@ export function VendoRoot({
       }
       // Everything else the agent produces renders untrusted in the sandbox.
       if (node.kind === "generated") {
-        return <SandboxStage node={node} brand={brand} components={[]} basePath={basePath} />;
+        return (
+          <SandboxStage
+            node={node}
+            brand={brand}
+            components={[]}
+            basePath={basePath}
+            {...(routeSourceRef.current ? { routeSource: routeSourceRef.current } : {})}
+          />
+        );
       }
       // Unexpected: only "Connect" is host-rendered. Fail loud but contained.
       return <div data-testid="unexpected-node">{node.name} (not renderable)</div>;

--- a/packages/vendo-react/src/stage-adapter.test.tsx
+++ b/packages/vendo-react/src/stage-adapter.test.tsx
@@ -5,6 +5,16 @@ import type { UINode } from "@vendoai/core";
 const initialize = vi.fn();
 const update = vi.fn();
 const stageDispose = vi.fn();
+// Controllable `ready` gate: tests that need to observe the pre-ready window
+// swap in a deferred before rendering; connectStage reads it at mount time.
+let readyPromise: Promise<void> = Promise.resolve();
+function deferredReady(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
 // Keep the real @vendoai/stage exports (notably `createGenUISession`) and only
 // stub the DOM-bound stage mount/controller so generated-node resolution runs
 // against the real host session.
@@ -22,7 +32,7 @@ vi.mock("@vendoai/stage", async (importActual) => {
       update,
       resolveAction: vi.fn(),
       dispose: vi.fn(),
-      ready: Promise.resolve(),
+      ready: readyPromise,
     }),
   };
 });
@@ -63,6 +73,35 @@ describe("VendoStage", () => {
     const node2 = { ...node, props: { title: "x" } };
     rerender(<VendoStage node={node2} bundleSource="/*bundle*/" />);
     await waitFor(() => expect(update).toHaveBeenCalled());
+  });
+
+  // Race: route A mounts → route B renders BEFORE `c.ready` resolves → the
+  // route re-patch effect skips (not yet inited) and the node effect does not
+  // re-run (node unchanged), so the pending ready callback must initialize with
+  // the CURRENT route (B), never the stale render-time snapshot (A).
+  it("initializes with the latest route when it changes before the stage is ready", async () => {
+    initialize.mockClear();
+    update.mockClear();
+    const gate = deferredReady();
+    readyPromise = gate.promise;
+    try {
+      const node = { id: "c1", kind: "component", source: "host", name: "Card", props: {} } as const;
+      const routeA = { pathname: "/a", search: "", params: {} };
+      const routeB = { pathname: "/b", search: "?x=1", params: { id: "b", slug: ["x", "y"] } };
+      const { rerender } = render(<VendoStage node={node} route={routeA} />);
+      // Ready is still pending: nothing initialized yet.
+      expect(initialize).not.toHaveBeenCalled();
+      // Route changes to B before ready resolves; node is unchanged.
+      rerender(<VendoStage node={node} route={routeB} />);
+      expect(initialize).not.toHaveBeenCalled();
+      // Now the stage becomes ready and the pending callback fires.
+      gate.resolve();
+      await waitFor(() => expect(initialize).toHaveBeenCalledTimes(1));
+      // Must carry route B (current), not route A (render-time snapshot).
+      expect(initialize.mock.calls[0][0].route).toEqual(routeB);
+    } finally {
+      readyPromise = Promise.resolve();
+    }
   });
 
   it("calls the stage's dispose on unmount (deterministic resize-listener teardown)", async () => {

--- a/packages/vendo-react/src/stage-adapter.tsx
+++ b/packages/vendo-react/src/stage-adapter.tsx
@@ -6,6 +6,7 @@ import {
   type StageController,
   type OnAction,
   type GenUISession,
+  type StageRoute,
 } from "@vendoai/stage";
 import {
   isGeneratedNode,
@@ -64,6 +65,12 @@ export interface VendoStageProps {
   /** Opaque OpenUI theme the sandbox bundle mounts; @vendoai/react does not
    *  interpret its shape. */
   componentTheme?: unknown;
+  /** The host's real route (read-only), fed into the sandbox as
+   *  `window.__vendoRouteData` so the next/navigation shims resolve the host's
+   *  actual location. Supply it from the host's own next/navigation, e.g.
+   *  `{ pathname: usePathname(), search: useSearchParams().toString(), params }`.
+   *  Omit and the shims fall back to empty values. */
+  route?: StageRoute;
 }
 
 export function VendoStage({
@@ -76,7 +83,11 @@ export function VendoStage({
   onAction,
   components,
   componentTheme,
+  route,
 }: VendoStageProps) {
+  // Read-only route channel spread into every initialize() so the shims resolve
+  // the host's real location regardless of which tree is mounted.
+  const routeInit = route ? { route } : {};
   const slotRef = useRef<HTMLDivElement>(null);
   const ctrlRef = useRef<StageController | null>(null);
   const initedRef = useRef(false);
@@ -133,7 +144,7 @@ export function VendoStage({
         c.ready
           .then(() => {
             if (cancelled) return;
-            c.initialize({ theme, state, bundleSource, componentTheme, tree: CLEARED_TREE });
+            c.initialize({ theme, state, bundleSource, componentTheme, ...routeInit, tree: CLEARED_TREE });
             rootIdRef.current = CLEARED_TREE.id;
             sessionRef.current = null;
             payloadRef.current = null;
@@ -172,7 +183,7 @@ export function VendoStage({
                 name: "Text",
                 props: { text: "Failed to render generated UI: " + result.error.message },
               };
-              c.initialize({ theme, state, bundleSource, componentTheme, tree: errorTree });
+              c.initialize({ theme, state, bundleSource, componentTheme, ...routeInit, tree: errorTree });
               initedRef.current = true;
               rootIdRef.current = node.id;
               // Drop any prior session so the next valid payload re-initializes
@@ -194,6 +205,7 @@ export function VendoStage({
               state,
               bundleSource,
               componentTheme,
+              ...routeInit,
               tree: result.session.tree,
               generatedComponents: payload.components,
               ...(anchorData ? { anchorData } : {}),
@@ -234,14 +246,14 @@ export function VendoStage({
           payloadRef.current = null;
         }
         if (!initedRef.current) {
-          c.initialize({ theme, state, bundleSource, componentTheme, tree: node });
+          c.initialize({ theme, state, bundleSource, componentTheme, ...routeInit, tree: node });
           initedRef.current = true;
           rootIdRef.current = node.id;
         } else if (switchedFromGenerated || node.id !== rootIdRef.current) {
           // New tree (root id changed, or we just switched off a generated tree
           // whose mounted root id differs from this node). Re-initialize — a
           // plain update would target a nodeId that no longer exists and no-op.
-          c.initialize({ theme, state, bundleSource, componentTheme, tree: node });
+          c.initialize({ theme, state, bundleSource, componentTheme, ...routeInit, tree: node });
           rootIdRef.current = node.id;
         } else {
           c.update({ replace: { nodeId: node.id, node } });
@@ -276,6 +288,13 @@ export function VendoStage({
     if (!c || !initedRef.current) return;
     c.update({ state });
   }, [state]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Re-patch the read-only route channel after init when the host route changes.
+  useEffect(() => {
+    const c = ctrlRef.current;
+    if (!c || !initedRef.current || !route) return;
+    c.update({ route });
+  }, [route]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return <div ref={slotRef} data-vendo-stage />;
 }

--- a/packages/vendo-react/src/stage-adapter.tsx
+++ b/packages/vendo-react/src/stage-adapter.tsx
@@ -86,8 +86,18 @@ export function VendoStage({
   route,
 }: VendoStageProps) {
   // Read-only route channel spread into every initialize() so the shims resolve
-  // the host's real location regardless of which tree is mounted.
-  const routeInit = route ? { route } : {};
+  // the host's real location regardless of which tree is mounted. Read from a
+  // ref (refreshed every render) rather than a render-time snapshot: the node
+  // effect waits on `c.ready` before initializing, so a route that changes
+  // while the stage is still initializing (node unchanged, so the effect never
+  // re-runs; route effect skips because not-yet-inited) would otherwise
+  // initialize with the STALE route and never re-run. `routeInit()` reads the
+  // latest route at the moment initialize is called.
+  // (theme/state are still captured in the effect closure below and share the
+  // same latent pre-ready race — left out of scope; only route is fixed here.)
+  const routeRef = useRef(route);
+  routeRef.current = route;
+  const routeInit = () => (routeRef.current ? { route: routeRef.current } : {});
   const slotRef = useRef<HTMLDivElement>(null);
   const ctrlRef = useRef<StageController | null>(null);
   const initedRef = useRef(false);
@@ -144,7 +154,7 @@ export function VendoStage({
         c.ready
           .then(() => {
             if (cancelled) return;
-            c.initialize({ theme, state, bundleSource, componentTheme, ...routeInit, tree: CLEARED_TREE });
+            c.initialize({ theme, state, bundleSource, componentTheme, ...routeInit(), tree: CLEARED_TREE });
             rootIdRef.current = CLEARED_TREE.id;
             sessionRef.current = null;
             payloadRef.current = null;
@@ -183,7 +193,7 @@ export function VendoStage({
                 name: "Text",
                 props: { text: "Failed to render generated UI: " + result.error.message },
               };
-              c.initialize({ theme, state, bundleSource, componentTheme, ...routeInit, tree: errorTree });
+              c.initialize({ theme, state, bundleSource, componentTheme, ...routeInit(), tree: errorTree });
               initedRef.current = true;
               rootIdRef.current = node.id;
               // Drop any prior session so the next valid payload re-initializes
@@ -205,7 +215,7 @@ export function VendoStage({
               state,
               bundleSource,
               componentTheme,
-              ...routeInit,
+              ...routeInit(),
               tree: result.session.tree,
               generatedComponents: payload.components,
               ...(anchorData ? { anchorData } : {}),
@@ -246,14 +256,14 @@ export function VendoStage({
           payloadRef.current = null;
         }
         if (!initedRef.current) {
-          c.initialize({ theme, state, bundleSource, componentTheme, ...routeInit, tree: node });
+          c.initialize({ theme, state, bundleSource, componentTheme, ...routeInit(), tree: node });
           initedRef.current = true;
           rootIdRef.current = node.id;
         } else if (switchedFromGenerated || node.id !== rootIdRef.current) {
           // New tree (root id changed, or we just switched off a generated tree
           // whose mounted root id differs from this node). Re-initialize — a
           // plain update would target a nodeId that no longer exists and no-op.
-          c.initialize({ theme, state, bundleSource, componentTheme, ...routeInit, tree: node });
+          c.initialize({ theme, state, bundleSource, componentTheme, ...routeInit(), tree: node });
           rootIdRef.current = node.id;
         } else {
           c.update({ replace: { nodeId: node.id, node } });

--- a/packages/vendo-sandbox-shims/src/next-navigation.ts
+++ b/packages/vendo-sandbox-shims/src/next-navigation.ts
@@ -1,11 +1,25 @@
 /**
  * Minimal `next/navigation` shim. `useRouter().push/replace` (and `redirect`)
  * route the host app via vendo.navigate. `redirect`/`notFound` throw to unwind
- * the render (Next semantics, caught by the sandbox error boundary); the
- * router history methods and the read hooks that have no route channel are safe
- * no-ops / empty values so they never crash a render or event handler.
+ * the render (Next semantics, caught by the sandbox error boundary). The read
+ * hooks (usePathname/useSearchParams/useParams) resolve the host's real route
+ * from the read-only `window.__vendoRouteData` channel, falling back to empty
+ * values when absent; the router history methods stay safe no-ops so they never
+ * crash a render or event handler.
  */
 import { navigate } from "./dispatch.js";
+
+/** Read-only route channel the host injects (`window.__vendoRouteData`, set by
+ *  the stage runtime parallel to `__vendoAnchorData`). `search` is a raw query
+ *  string like "?q=1"; `params` is Next's dynamic-route params object. */
+interface RouteDataWindow {
+  __vendoRouteData?: { pathname?: string; search?: string; params?: Record<string, string | string[]> };
+}
+
+/** Never crashes when the channel is absent (SSR / no host): returns {}. */
+function routeData(): NonNullable<RouteDataWindow["__vendoRouteData"]> {
+  return (globalThis as unknown as RouteDataWindow).__vendoRouteData ?? {};
+}
 
 export function useRouter() {
   return {
@@ -30,19 +44,21 @@ export function useRouter() {
   };
 }
 
+/** The host's real pathname from the route channel (fallback "" with no host). */
 export function usePathname(): string {
-  return "";
+  return routeData().pathname ?? "";
 }
 
+/** The host's real query string, parsed from the route channel (fallback empty). */
 export function useSearchParams(): URLSearchParams {
-  return new URLSearchParams();
+  return new URLSearchParams(routeData().search ?? "");
 }
 
-/** No route channel exists in the sandbox yet, so there are no dynamic route
- *  params to surface — return an empty object rather than crash a component
- *  that reads `params.id`. */
+/** The host's real dynamic-route params from the route channel. Returns an empty
+ *  object when the channel is absent rather than crash a component reading
+ *  `params.id`. */
 export function useParams<T extends Record<string, string | string[]> = Record<string, string | string[]>>(): T {
-  return {} as T;
+  return (routeData().params ?? {}) as T;
 }
 
 /** Recognizable codes so a host/error-boundary can tell these apart from real

--- a/packages/vendo-sandbox-shims/src/shims.test.tsx
+++ b/packages/vendo-sandbox-shims/src/shims.test.tsx
@@ -5,6 +5,8 @@ import Image from "./next-image";
 import {
   useRouter,
   useParams,
+  usePathname,
+  useSearchParams,
   redirect,
   notFound,
   useSelectedLayoutSegment,
@@ -17,6 +19,7 @@ afterEach(() => {
   cleanup();
   delete (globalThis as Record<string, unknown>)["__vendoDispatch"];
   delete (globalThis as Record<string, unknown>)["__vendoAnchorData"];
+  delete (globalThis as Record<string, unknown>)["__vendoRouteData"];
 });
 
 function captureDispatch() {
@@ -157,7 +160,7 @@ describe("useRouter shim", () => {
 });
 
 describe("next/navigation extra exports", () => {
-  it("useParams returns an empty object (no route channel in the sandbox)", () => {
+  it("useParams returns an empty object when the route channel is absent", () => {
     expect(useParams()).toEqual({});
   });
 
@@ -175,6 +178,45 @@ describe("next/navigation extra exports", () => {
   it("useSelectedLayoutSegment(s) return null / []", () => {
     expect(useSelectedLayoutSegment()).toBeNull();
     expect(useSelectedLayoutSegments()).toEqual([]);
+  });
+});
+
+describe("next/navigation route channel (window.__vendoRouteData)", () => {
+  it("usePathname/useSearchParams/useParams read the host's real route from the channel", () => {
+    (globalThis as Record<string, unknown>)["__vendoRouteData"] = {
+      pathname: "/clients/cl_rivera",
+      search: "?tab=invoices&page=2",
+      params: { id: "cl_rivera" },
+    };
+    expect(usePathname()).toBe("/clients/cl_rivera");
+    const sp = useSearchParams();
+    expect(sp.get("tab")).toBe("invoices");
+    expect(sp.get("page")).toBe("2");
+    expect(useParams()).toEqual({ id: "cl_rivera" });
+  });
+
+  it("falls back to empty values when the channel is absent (SSR / no host)", () => {
+    expect(usePathname()).toBe("");
+    expect(useSearchParams().toString()).toBe("");
+    expect(useParams()).toEqual({});
+  });
+
+  it("falls back per-field when the channel exists but a field is missing", () => {
+    (globalThis as Record<string, unknown>)["__vendoRouteData"] = { pathname: "/settings" };
+    expect(usePathname()).toBe("/settings");
+    expect(useSearchParams().toString()).toBe("");
+    expect(useParams()).toEqual({});
+  });
+
+  it("passes catch-all/array params through unchanged (segment shape preserved)", () => {
+    (globalThis as Record<string, unknown>)["__vendoRouteData"] = {
+      pathname: "/docs/a/b/c",
+      search: "",
+      params: { slug: ["a", "b", "c"], org: "acme" },
+    };
+    const params = useParams();
+    expect(Array.isArray(params.slug)).toBe(true);
+    expect(params).toEqual({ slug: ["a", "b", "c"], org: "acme" });
   });
 });
 

--- a/packages/vendo-stage/src/runtime.test.ts
+++ b/packages/vendo-stage/src/runtime.test.ts
@@ -71,6 +71,12 @@ describe("stage runtime source", () => {
       "if (params.componentTheme && window.__VENDO_THEME_WRAP__)",
     );
   });
+  it("injects the read-only route channel (window.__vendoRouteData) on init and re-patches it on ui/update", () => {
+    // Parallel to __vendoAnchorData: set on the full render (init) and refreshed
+    // on ui/update, so the next/navigation shims resolve the host's real route.
+    expect(STAGE_RUNTIME_SRC).toContain("window.__vendoRouteData = params.route || {}");
+    expect(STAGE_RUNTIME_SRC).toContain("window.__vendoRouteData = p.route");
+  });
   it("Text/Skeleton primitives read the canonical --vendo-* theme vars, not --brand-*", () => {
     // TU-2: --brand-* is retired in favor of --vendo-* (see TU-1's brandToCssVars).
     expect(STAGE_RUNTIME_SRC).toContain("--vendo-fg");

--- a/packages/vendo-stage/src/runtime.ts
+++ b/packages/vendo-stage/src/runtime.ts
@@ -340,6 +340,9 @@ export const STAGE_RUNTIME_SRC = String.raw`
     // Anchor data feed for the swr shim (set BEFORE any generated module
     // evaluates or renders — useSWR reads it synchronously).
     window.__vendoAnchorData = params.anchorData || {};
+    // Read-only route channel for the next/navigation shims (usePathname /
+    // useSearchParams / useParams). Set alongside anchorData, before any render.
+    window.__vendoRouteData = params.route || {};
     injectTheme(params.theme || {});
     cachedHost = await loadBundle(params.bundleSource);
     var gen = await loadGeneratedComponents(params.generatedComponents);
@@ -436,6 +439,12 @@ export const STAGE_RUNTIME_SRC = String.raw`
       if (p.anchorData) {
         currentParams = Object.assign({}, currentParams, { anchorData: p.anchorData });
         window.__vendoAnchorData = p.anchorData;
+      }
+
+      // Refresh the read-only route channel (live re-patch, same lifecycle).
+      if (p.route) {
+        currentParams = Object.assign({}, currentParams, { route: p.route });
+        window.__vendoRouteData = p.route;
       }
 
       // Apply node patch (find-and-replace by id, including root).

--- a/packages/vendo-stage/src/stage-host.test.ts
+++ b/packages/vendo-stage/src/stage-host.test.ts
@@ -178,6 +178,68 @@ describe("connectStage", () => {
     peer.dispose();
   });
 
+  it("carries the read-only route through ui/initialize and re-patches it on ui/update", async () => {
+    const { a, b } = makePair();
+    let initParams: any;
+    let updateParams: any;
+    const peer = makeRpc(b, a, async (method, params) => {
+      if (method === "ui/initialize") { initParams = params; return { ok: true }; }
+      if (method === "ui/update") { updateParams = params; return { ok: true }; }
+      return {};
+    });
+    const controller = connectStage(
+      { listen: a, post: b },
+      { onAction: async () => ({ result: "ok" }) },
+    );
+
+    const route = { pathname: "/clients/cl_rivera", search: "?tab=invoices", params: { id: "cl_rivera" } };
+    await controller.initialize({
+      theme: {},
+      state: {},
+      bundleSource: "",
+      route,
+      tree: { id: "root", kind: "component", source: "host", name: "Card", props: {} },
+    });
+    expect(initParams.route).toEqual(route);
+
+    const nextRoute = { pathname: "/settings", search: "" };
+    await controller.update({ route: nextRoute });
+    expect(updateParams.route).toEqual(nextRoute);
+
+    controller.dispose();
+    peer.dispose();
+  });
+
+  it("forwards a live anchorData re-patch through ui/update (same-structure refresh)", async () => {
+    // Regression: update() dropped anchorData, so the swr shim's live refresh on
+    // same-structure data (saved views / anchor re-patch) never reached the sandbox.
+    const { a, b } = makePair();
+    let updateParams: any;
+    const peer = makeRpc(b, a, async (method, params) => {
+      if (method === "ui/initialize") { return { ok: true }; }
+      if (method === "ui/update") { updateParams = params; return { ok: true }; }
+      return {};
+    });
+    const controller = connectStage(
+      { listen: a, post: b },
+      { onAction: async () => ({ result: "ok" }) },
+    );
+
+    await controller.initialize({
+      theme: {},
+      state: {},
+      bundleSource: "",
+      tree: { id: "root", kind: "component", source: "host", name: "Card", props: {} },
+    });
+
+    const anchorData = { "/api/deadlines": [{ id: "a" }, { id: "b" }] };
+    await controller.update({ anchorData });
+    expect(updateParams.anchorData).toEqual(anchorData);
+
+    controller.dispose();
+    peer.dispose();
+  });
+
   it("tools/call with CORRECT capability token reaches onAction as ActionRequest and returns ActionResult", async () => {
     const { a, b } = makePair();
     const onAction = vi.fn().mockResolvedValue({ result: "confirmed" });

--- a/packages/vendo-stage/src/stage-host.ts
+++ b/packages/vendo-stage/src/stage-host.ts
@@ -272,6 +272,19 @@ export function createStage(
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
+/** The host's real route, injected read-only as `window.__vendoRouteData` so the
+ *  next/navigation shims (usePathname/useSearchParams/useParams) resolve the
+ *  host's actual location instead of empty values. `search` is a raw query string
+ *  (e.g. "?q=1"); `params` is Next's dynamic-route params object. Read-only —
+ *  navigation writes go through the dispatch bridge, not this channel. */
+export interface StageRoute {
+  pathname: string;
+  search: string;
+  /** Next's dynamic-route params. Catch-all segments arrive as string[], so the
+   *  value type is `string | string[]` and passes through the shims unchanged. */
+  params?: Record<string, string | string[]>;
+}
+
 /** Payload for `controller.initialize()`. */
 export interface StageInitPayload {
   theme: Record<string, string>;
@@ -284,6 +297,9 @@ export interface StageInitPayload {
    *  `window.__vendoAnchorData` so the swr shim resolves keys from it
    *  (remix fast-edits — the shim shipped in PR #35 but nothing fed it). */
   anchorData?: Record<string, unknown>;
+  /** The host's real route, injected read-only as `window.__vendoRouteData` for
+   *  the next/navigation shims (parallel to `anchorData`). */
+  route?: StageRoute;
   /**
    * Opaque theme blob for the in-sandbox component library (OpenUI). Forwarded
    * unchanged into `ui/initialize`; the runtime hands it to the host bundle's
@@ -299,6 +315,8 @@ export interface StageUpdatePayload {
   state?: Record<string, unknown>;
   /** Refreshed anchor data (live context re-patch) for the swr shim. */
   anchorData?: Record<string, unknown>;
+  /** Refreshed route (live re-patch) for the next/navigation shims. */
+  route?: StageRoute;
   /**
    * Node patch. `nodeId` and `node` travel as one unit — you cannot pass one
    * without the other (the runtime rejects a partial patch).
@@ -469,9 +487,11 @@ export function connectStage(
     },
 
     update(update) {
-      const payload: { theme?: Record<string, string>; state?: Record<string, unknown>; replace?: { nodeId: string; node: UINode } } = {};
+      const payload: { theme?: Record<string, string>; state?: Record<string, unknown>; anchorData?: Record<string, unknown>; route?: StageRoute; replace?: { nodeId: string; node: UINode } } = {};
       if (update.theme) payload.theme = update.theme;
       if (update.state) payload.state = update.state;
+      if (update.anchorData) payload.anchorData = update.anchorData;
+      if (update.route) payload.route = update.route;
       if (update.replace) {
         const { nodeId, node } = update.replace;
         // Mint fresh tokens for the replacement subtree, splice it into our tree

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -534,6 +534,9 @@ importers:
       '@vendoai/shell':
         specifier: workspace:*
         version: link:../vendo-shell
+      '@vendoai/stage':
+        specifier: workspace:*
+        version: link:../vendo-stage
       ai:
         specifier: 6.0.28
         version: 6.0.28(zod@3.25.76)
@@ -553,6 +556,9 @@ importers:
       jsdom:
         specifier: ^25.0.0
         version: 25.0.1
+      next:
+        specifier: 16.2.9
+        version: 16.2.9(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.0
         version: 18.3.1
@@ -11869,6 +11875,32 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  next@16.2.9(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@next/env': 16.2.9
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.40
+      caniuse-lite: 1.0.30001799
+      postcss: 8.4.31
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      styled-jsx: 5.1.6(react@18.3.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.9
+      '@next/swc-darwin-x64': 16.2.9
+      '@next/swc-linux-arm64-gnu': 16.2.9
+      '@next/swc-linux-arm64-musl': 16.2.9
+      '@next/swc-linux-x64-gnu': 16.2.9
+      '@next/swc-linux-x64-musl': 16.2.9
+      '@next/swc-win32-arm64-msvc': 16.2.9
+      '@next/swc-win32-x64-msvc': 16.2.9
+      '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.61.1
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
   node-addon-api@7.1.1: {}
 
   node-emoji@2.2.0:
@@ -12782,6 +12814,11 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@babel/core': 7.29.7
+
+  styled-jsx@5.1.6(react@18.3.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 18.3.1
 
   sucrase@3.35.1:
     dependencies:


### PR DESCRIPTION
Sandbox next/navigation shims return the host's real route via a read-only `__vendoRouteData` channel. Reworked from the original #80 after the #68 restructure: the generic `@vendoai/client` stays Next-free (no `next` peerDep), route is supplied via an optional `routeSource` callback (Next hosts read their own next/navigation under Suspense; demo-bank is the reference). Codex-reviewed twice; fixed the next-in-generic-client break (verified examples/node no longer pulls Next) and a stale-route-before-ready race (latest-route ref read in the ready callback). Also fixes a pre-existing anchorData update-drop. pnpm typecheck 29/29, test 27/27, build clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/86" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects the host’s live route into the sandbox via a read‑only `window.__vendoRouteData` channel so `next/navigation` shims resolve the real location. Keeps `@vendoai/client` Next‑free by accepting an optional `routeSource` and threading `route` through `@vendoai/react` and `@vendoai/stage`.

- **New Features**
  - Added `StageRoute` and a read‑only route channel; runtime sets `window.__vendoRouteData` on init and re‑patches it on `ui/update`. Catch‑all/array params are preserved.
  - `@vendoai/client`: `SandboxStage` and `VendoRoot` accept `routeSource?: () => StageRoute`. A Next host supplies it with `usePathname`/`useSearchParams`/`useParams` under Suspense; non‑Next hosts omit it.
  - `@vendoai/react`: `VendoStage` accepts `route?: StageRoute` and includes it in `initialize` and `update`.
  - `@vendoai/sandbox-shims`: `usePathname`/`useSearchParams`/`useParams` now read from the route channel with safe empty fallbacks.
  - Tests cover route threading, array param shape, and runtime injection. Demo bank sources the route via `next/navigation` under Suspense.

- **Bug Fixes**
  - Fixed a pre‑ready race: stage initializes with the latest `route` if it changes before `ready` resolves.
  - Restored forwarding of `anchorData` on `ui/update` so the SWR shim refreshes live data.
  - Removed the hard `next/navigation` import from `@vendoai/client`; plain React/Vite consumers no longer pull Next.

<sup>Written for commit 8d493932ff0ecac96b72efa65666bafbc0f4345b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

