### PR TITLE
docs: reflect three-tier CLI + current default model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,9 @@ generated UI in a sandboxed, brand-native surface.
 - `pnpm install` · `pnpm build` · `pnpm test` · `pnpm typecheck` · `pnpm lint` (turbo-cached)
 - `pnpm demo` — run the demo-bank host app (env setup: `apps/demo-bank/README.md`)
 - `pnpm demo:accounting` — run the Cadence accounting demo
-- `npx @vendoai/cli init <dir>` — install Vendo into a Next.js app
+- `npx vendo init <dir>` — install Vendo into a Next.js app (interactive; safe to re-run).
+  `vendo refresh` catches up an existing install; `vendo doctor` checks it; `vendo sync`
+  runs in the build.
 
 ## Rules
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ through your permission policy. Deeper docs: [docs.vendo.run](https://docs.vendo
 | Package | What it is |
 |---|---|
 | `vendoai` | The public install (interim name; bare `vendo` pending an npm name-dispute): `vendoai/server` (`createVendoHandler`) + `vendoai/react` (`<VendoRoot>`) |
-| `@vendoai/cli` | `vendo init`, a one-command install into a Next.js app |
+| `@vendoai/cli` | `vendo init` installs Vendo into a Next.js app; `refresh` catches up, `doctor` checks the install |
 | `@vendoai/core` | Manifest schemas, GenUI format, the five platform seams |
 | `@vendoai/server` | Provider-agnostic agent server (bring any AI SDK provider) |
 | `@vendoai/runtime` | Embedded runtime: tools, automations, MCP client |

--- a/docs-site/capability-keys.mdx
+++ b/docs-site/capability-keys.mdx
@@ -46,7 +46,7 @@ Supported provider prefixes are `anthropic`, `openai`, and `google`. Set the cre
 Use a bare model id to keep provider selection based on your provider keys:
 
 ```bash
-VENDO_MODEL=claude-sonnet-4-6
+VENDO_MODEL=claude-sonnet-5
 ```
 
 With a bare model id and no provider key, model resolution falls back to Anthropic, but `chat` still stays `false` until you set a provider key or pass a `model` option to the handler.


### PR DESCRIPTION
Small follow-up to #89 (already merged), tidying docs that fell outside that PR's file scope now that the new CLI is on main:

- `docs-site/capability-keys.mdx` — the `VENDO_MODEL` example used the retired `claude-sonnet-4-6`; now `claude-sonnet-5` (the current `DEFAULT_MODEL_ID` for anthropic).
- `CLAUDE.md` — the Commands section listed only `vendo init`; now mentions `refresh` / `doctor` / `sync`.
- `README.md` — the `@vendoai/cli` package row now names `refresh`/`doctor` alongside `init`.

Docs-only; no code changes. The `claude-sonnet-4-6` references remaining in demo apps, `options.ts`, and tests are server-side config, not CLI docs, so they're intentionally left alone.

https://claude.ai/code/session_01972cxScoztJwUdYiSWuFa9
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/91" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update docs to reflect the new three-tier CLI and the current default model, so users see the correct commands and model example. Switched `VENDO_MODEL` to `claude-sonnet-5`, replaced `npx @vendoai/cli init` with `npx vendo init`, and added `refresh`/`doctor`/`sync` mentions in `CLAUDE.md` and the `@vendoai/cli` row in `README.md`.

<sup>Written for commit d14c0a8163aad1d729bb76e939efede18dbe52fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

