### PR TITLE
chore(release): normalize package manifests (npm pkg fix)

### DIFF
--- a/packages/vendo-cli/package.json
+++ b/packages/vendo-cli/package.json
@@ -25,7 +25,7 @@
   },
   "type": "module",
   "bin": {
-    "vendo": "./dist/cli.js"
+    "vendo": "dist/cli.js"
   },
   "files": [
     "dist"

--- a/packages/vendo/package.json
+++ b/packages/vendo/package.json
@@ -2,7 +2,14 @@
   "name": "vendoai",
   "version": "0.2.0",
   "description": "Vendo: an embedded agent your users talk to, acting through your own API and rendering brand-native generated UI. One package: `vendoai/server` for the route, `vendoai/react` for the UI. (Interim name — bare `vendo` is pending an npm name-dispute; npm's typosquat checker blocks it as \"too similar to send\".)",
-  "keywords": ["ai", "agent", "generative-ui", "react", "nextjs", "devtool"],
+  "keywords": [
+    "ai",
+    "agent",
+    "generative-ui",
+    "react",
+    "nextjs",
+    "devtool"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -21,7 +28,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "vendo": "./bin/vendo.mjs"
+    "vendo": "bin/vendo.mjs"
   },
   "exports": {
     ".": {
@@ -42,11 +49,18 @@
   },
   "typesVersions": {
     "*": {
-      "server": ["dist/server.d.ts"],
-      "react": ["dist/react.d.ts"]
+      "server": [
+        "dist/server.d.ts"
+      ],
+      "react": [
+        "dist/react.d.ts"
+      ]
     }
   },
-  "files": ["dist", "bin"],
+  "files": [
+    "dist",
+    "bin"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "pretest": "tsc -p tsconfig.json",
@@ -58,8 +72,12 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {
-    "react": { "optional": true },
-    "react-dom": { "optional": true }
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@vendoai/client": "workspace:*",


### PR DESCRIPTION
Mechanical `npm pkg fix` normalizations for `vendoai` and `@vendoai/cli` so `npm publish` emits no auto-correction warnings. Verified: all 12 public packages `npm publish --dry-run` clean at 0.2.0.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalized package manifests for `vendoai` and `@vendoai/cli` using `npm pkg fix` to remove `npm publish` auto-correction warnings. Result: clean `npm publish --dry-run` across all 12 public packages at 0.2.0.

- **Refactors**
  - Fixed `bin` paths by removing leading `./` (now `dist/cli.js` and `bin/vendo.mjs`).
  - Reformatted `package.json` fields per npm conventions (expanded `keywords`, `files`, and `typesVersions`; consistent object style).
  - No runtime changes.

<sup>Written for commit e74c19043d097f2e39da56081c3958239cc0a322. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

