### PR TITLE
docs(specs): @vendoai/core re-architecture spec (track 1)

### DIFF
--- a/docs/specs/2026-07-10-vendoai-core-spec.md
+++ b/docs/specs/2026-07-10-vendoai-core-spec.md
@@ -46,7 +46,7 @@ interface ToolDescriptor {
   description: string;                       // drives LLM tool selection
   inputSchema: JsonSchemaDocument;           // plain JSON Schema (wire format)
   outputSchema?: JsonSchemaDocument;
-  risk?: "read" | "write" | "destructive";   // HOST-OWNED, versioned (§3.1); undeclared/unknown-external ⇒ destructive
+  risk?: "read" | "write" | "destructive";   // HOST-OWNED, versioned (§3.1); default depends on source (§3.1)
   idempotent?: boolean;                      // "safe to retry?" — automations read this
   binding?: ToolBinding;                     // how it reaches the host API (http | … extension point)
   formats?: Record<string, FieldFormat>;     // display hints (cents, iso-date, …) — carried over
@@ -89,11 +89,17 @@ One vocabulary replaces both of today's (`{mutating, dangerous}` manifest boolea
 | `read` | auto-runs (the egress jail is what makes this safe — see §6 invariant I1) |
 | `write` | asks until granted; grants can suppress |
 | `destructive` | **always asks — no grant, fade, or rule may ever suppress** ("money always needs you") |
-| *(undeclared)* | treated as `write` **plus an orthogonal `unverified` flag**, surfaced on cards and the Trust screen |
 
-MCP ingestion is lossless: `readOnlyHint → read`, `destructiveHint → destructive`, `idempotentHint → idempotent`. Approval-need is **Vendo metadata enforced by guard server-side** — never delegated to a framework field (Vercel v7 deprecated per-tool `needsApproval`; we deliberately do not couple). The ladder deliberately stays three levels; finer policy dimensions (data sensitivity, external exposure, unattended-run eligibility) are guard-track policy inputs, not core shapes (review ruling).
+**The missing-label default depends on the source — two distinct populations** (round-3 fix; these were conflated):
 
-**Labels are host-owned facts, not model opinions (security review).** A risk label is a security fact the whole ladder rests on, so: it is **host-declared and versioned** (part of `tools.json`, feeds the seal §5.1); the agent can never author or lower it; an **unknown/unlabeled external tool defaults to `destructive`** (fail-safe, not `write`); and the label is a *policy input evaluated server-side at the binding endpoint*, not merely a UI hint — a mislabeled tool must not become the only thing standing between an automation and a destructive call. Descriptor drift in a label lapses grants via the seal.
+| Source of an unlabeled tool | Default |
+|---|---|
+| **Host-owned** (the host's own API, extractor couldn't infer risk) | `write` **+ `unverified` flag** — usable and grantable, flagged on cards/Trust screen. The source is trusted; only the risk is unknown. |
+| **External / untrusted** (ingested MCP tools, a shared/imported module's foreign tools) | `destructive` — fail-safe. No host authority vouches for it, so it gets the non-suppressible tier until a host explicitly labels it. |
+
+MCP ingestion is lossless where hints exist: `readOnlyHint → read`, `destructiveHint → destructive`, `idempotentHint → idempotent`; an MCP tool with *no* informative hint is external-unlabeled → `destructive`. Approval-need is **Vendo metadata enforced by guard server-side** — never delegated to a framework field (Vercel v7 deprecated per-tool `needsApproval`; we deliberately do not couple). The ladder deliberately stays three levels; finer policy dimensions (data sensitivity, external exposure, unattended-run eligibility) are guard-track policy inputs, not core shapes (review ruling).
+
+**Labels are host-owned facts, not model opinions (security review).** A risk label is a security fact the whole ladder rests on, so: it is **host-declared and versioned** (part of `tools.json`, feeds the approvalSeal §5.1); the agent can never author or lower it; missing labels default per the source table above (host-owned → `write`+unverified; external → `destructive`); and the label is a *policy input evaluated server-side at the binding endpoint*, not merely a UI hint — a mislabeled tool must not become the only thing standing between an automation and a destructive call. Descriptor drift in a label lapses grants via the approvalSeal.
 
 ### 3.2 Framework interop (the "user never worries about it" design)
 
@@ -163,8 +169,10 @@ buildKey    = hash( repo commit sha + canonical envelope )          // what to c
 approvalSeal = hash( buildKey + descriptor hashes of every host tool the module was approved to use )
 ```
 
-- **Caches** (compiled bundle, warm snapshot) key on `buildKey` — a host tweaking one tool's *description* must not invalidate every module's compiled artifact.
-- **Grants and audit** bind to `approvalSeal` — so drift in a granted tool's behavior *does* lapse the approval even though no file changed. Any envelope security edit (widened egress, retimed trigger), any repo change, and any granted-tool descriptor drift **lapses the grants and re-prompts** — closing the "edit the trigger to every-minute without touching code" hole.
+- **Caches** (compiled bundle, warm snapshot) key on `buildKey` — a host tweaking one tool's *description* must not invalidate every module's compiled artifact. This is the ONLY use of `buildKey`.
+- **Grants, audit, provenance, `ModuleRef`, share signatures, and the immutability check (I8)** all bind to `approvalSeal` — so drift in a granted tool's behavior *does* lapse the approval even though no file changed. Any envelope security edit (widened egress, retimed trigger), any repo change, and any granted-tool descriptor drift **lapses the grants and re-prompts** — closing the "edit the trigger to every-minute without touching code" hole.
+
+**Terminology (round-3 fix):** where the rest of this doc says **`seal`**, it means **`approvalSeal`** — the security-binding key. `buildKey` is *only* ever the cache key and is always named explicitly. `ModuleRef` carries `approvalSeal`; warm snapshots are content-addressed by `buildKey` but a run additionally verifies the `approvalSeal` it executes under (I8), so a cache hit never bypasses approval.
 
 **No time-of-check/time-of-use gap (security review — invariant I8).** The seal a user approves is immutable; grant minting is compare-and-set against that exact seal, and every run/build/cache read must prove the same seal or **fail closed**. A repo/envelope/descriptor mutation between save-card and mint (or a stale warm snapshot from a superseded seal) can never be executed under the old approval.
 
@@ -402,7 +410,7 @@ await storage.meter.increment(ctx.principal, ctx.provenance.kind, cost(ctx));
 const guard2 = createGuard({ database: { grants: myRedisGrants, audit: myAudit } });
 ```
 
-**Named types used above** (one-line glosses so §8/§15 are self-contained): `ModuleRef` = `{ id; seal }` handle to a stored module; `ModuleView` = `{ element; dispose() }` the mounted iframe/view; `RunResult` = `{ status; outcome?; error? }` from a headless run; `ModuleWorkspace` = the agent's live sandbox dir with `writeFile`/`save()`; `ToolBinding` = the discriminated `http | …` execution binding.
+**Named types used above** (one-line glosses so §8/§15 are self-contained): `ModuleRef` = `{ id; approvalSeal }` handle to a stored module (the seal it was approved under); `ModuleView` = `{ element; dispose() }` the mounted iframe/view; `RunResult` = `{ status; outcome?; error? }` from a headless run; `ModuleWorkspace` = the agent's live sandbox dir with `writeFile`/`save()`; `ToolBinding` = the discriminated `http | …` execution binding.
 
 ## 16. Open questions → owned by other tracks
 

--- a/docs/specs/2026-07-10-vendoai-core-spec.md
+++ b/docs/specs/2026-07-10-vendoai-core-spec.md
@@ -1,0 +1,419 @@
+# @vendoai/core — Specification
+
+**Status:** Draft v3 for review · **Date:** 2026-07-10 · **Track:** 1 of the standalone-blocks re-architecture
+**Sources of authority:** the Open-Source Full-Stack Agentic Interface PRD (Notion), decisions locked in the 2026-07-09/10 design session, `docs/specs/research-2026-07-framework-landscape.md` (version-stamped ecosystem facts).
+**Reviews incorporated:** two rounds. Round 1 — Codex (gpt-5.5) + Fable. Round 2 — Codex architecture lens + Codex adversarial-security lens + Fable fresh review. All accepted findings folded in; speed research (`research-2026-07-module-speed.md`, `research-2026-07-apps-speed-capability.md`) checked for contract impact (none beyond noted footnotes).
+**Altitude note:** this is a high-level contract spec. Deep security *mechanisms* (signing schemes, replay-nonce protocols, transactional-mint internals) are named as invariants here and designed by the owning track — the spec states the requirement and the fail-closed behavior, not the implementation.
+
+---
+
+## 1. Goals & non-goals
+
+`@vendoai/core` is two things and nothing else:
+
+1. **The shapes everything speaks** — tool descriptors + risk labels, principal, the module envelope + seal, permission grants + provenance, storage slice contracts, theme tokens, the module↔host protocol. A shape earns a place in core only if **two or more blocks (or the host) must agree on it**; anything used by exactly one block belongs to that block.
+2. **The module runtime** — sandboxed execution of modules (browser iframe now, server sandboxes later), so `@vendoai/apps` and `@vendoai/automations` are thin engines on top with **no peer dependencies**.
+
+**Non-goals.** Core never talks to an LLM, never renders chrome, never persists anything itself (contracts only), never depends on another `@vendoai/*` package, and carries no framework dependency — `ai` and `@ai-sdk/provider` leave its dependency list. Blocks depend on core; core depends on `zod` and the platform.
+
+**Release model.** One version train: all `@vendoai/*` release together. This re-architecture ships as a big-bang `0.3.0`; old contracts are deleted, no compat shims (no external consumers yet).
+
+## 2. Package layout
+
+One package, subpath exports:
+
+```
+@vendoai/core             # contracts: tools, principal, module envelope, grants,
+                          #   storage slices, theme, protocol types (deps: zod only)
+@vendoai/core/runtime     # module runtime: workspace, bundler, MCP Apps host bridge,
+                          #   sandbox providers seam (vendo-stage + vendo-sandbox-shims fold in)
+@vendoai/core/adapters    # framework interop: Standard Schema helpers, ingestion
+                          #   (fromAiSdkTools, fromMcp), exporters (toOpenAiAgentsTools, …)
+```
+
+`vendo-stage` and `vendo-sandbox-shims` cease to exist as packages. **Dependency budget (review finding), made enforceable:** the root export depends on `zod` only. `/runtime`'s heavier machinery (esbuild, git plumbing, sandbox providers) and `/adapters`' framework converters are **optional peer dependencies with injected providers** — core references them through seams, never a hard import. A **CI test installs the package with only `zod` present and imports the root + `/adapters` type surface**, failing if either drags in framework or sandbox machinery. So importing a contract type can never install or load a bundler, a git library, or an AI SDK.
+
+The umbrella `vendoai` package (separate track) offers `createVendo({ database })` composition sugar. It is **config-holding only**: every call literally delegates to a block's own `create*`. The umbrella must never add behavior of its own.
+
+## 3. Tool contract
+
+The neutral shape every block speaks — no framework imports anywhere:
+
+```ts
+interface ToolDescriptor {
+  name: string;                              // model-facing identifier  ^[a-zA-Z][a-zA-Z0-9_-]*$
+  title?: string;                            // human display name (cards, audit)
+  description: string;                       // drives LLM tool selection
+  inputSchema: JsonSchemaDocument;           // plain JSON Schema (wire format)
+  outputSchema?: JsonSchemaDocument;
+  risk?: "read" | "write" | "destructive";   // HOST-OWNED, versioned (§3.1); undeclared/unknown-external ⇒ destructive
+  idempotent?: boolean;                      // "safe to retry?" — automations read this
+  binding?: ToolBinding;                     // how it reaches the host API (http | … extension point)
+  formats?: Record<string, FieldFormat>;     // display hints (cents, iso-date, …) — carried over
+  meta?: Record<string, unknown>;            // namespaced extension point (like MCP _meta)
+}
+
+// The AUTHORING shape — a tool as a block defines it. NOT itself a framework tool.
+interface UnboundVendoTool {
+  descriptor: ToolDescriptor;
+  execute(input: unknown, ctx: ToolCallContext): Promise<ToolOutcome>;
+}
+
+interface ToolCallContext {
+  principal: Principal;
+  provenance: CallProvenance;                // §7 — who/what initiated this call
+  toolCallId: string;
+  signal?: AbortSignal;
+}
+
+// Three outcomes — the "pending" arm is a core contract (review finding): guard can
+// answer "ask", and unattended runs PARK. Every consumer (framework loop, Python
+// module, automation runner) must be able to represent "not resolved yet".
+type ToolOutcome =
+  | { ok: true;  result: unknown }
+  | { ok: false; error: { code: string; message: string } }
+  | { ok: false; pending: { kind: "approval" | "parked"; ref: string } };
+  //   ↳ the call is held; `ref` correlates the eventual resume (consent response
+  //     or parked-action resolution). The framework/runtime bridge decides how to
+  //     surface it (HITL data part, park notification) — §3.2, §7.
+```
+
+**Binding vs framework shape (review finding).** `UnboundVendoTool` is the shape blocks author; it is deliberately *not* a Vercel/Mastra tool (it nests metadata under `descriptor` and takes our `ToolCallContext`). The framework-shaped object is what **`toToolSet(tools, { principal, provenance })` emits** — a `BoundToolSet` whose per-tool `execute(input, frameworkOpts)` closes over the bound context and the guarded pipeline. The CI assignability test (§3.2) targets the `BoundToolSet` output, not `UnboundVendoTool`.
+
+### 3.1 Risk labels
+
+One vocabulary replaces both of today's (`{mutating, dangerous}` manifest booleans and the runtime's `read/act/critical` tiers):
+
+| Label | Runtime behavior |
+|---|---|
+| `read` | auto-runs (the egress jail is what makes this safe — see §6 invariant I1) |
+| `write` | asks until granted; grants can suppress |
+| `destructive` | **always asks — no grant, fade, or rule may ever suppress** ("money always needs you") |
+| *(undeclared)* | treated as `write` **plus an orthogonal `unverified` flag**, surfaced on cards and the Trust screen |
+
+MCP ingestion is lossless: `readOnlyHint → read`, `destructiveHint → destructive`, `idempotentHint → idempotent`. Approval-need is **Vendo metadata enforced by guard server-side** — never delegated to a framework field (Vercel v7 deprecated per-tool `needsApproval`; we deliberately do not couple). The ladder deliberately stays three levels; finer policy dimensions (data sensitivity, external exposure, unattended-run eligibility) are guard-track policy inputs, not core shapes (review ruling).
+
+**Labels are host-owned facts, not model opinions (security review).** A risk label is a security fact the whole ladder rests on, so: it is **host-declared and versioned** (part of `tools.json`, feeds the seal §5.1); the agent can never author or lower it; an **unknown/unlabeled external tool defaults to `destructive`** (fail-safe, not `write`); and the label is a *policy input evaluated server-side at the binding endpoint*, not merely a UI hint — a mislabeled tool must not become the only thing standing between an automation and a destructive call. Descriptor drift in a label lapses grants via the seal.
+
+### 3.2 Framework interop (the "user never worries about it" design)
+
+**Our tools ARE valid Vercel AI SDK tools, structurally.** Verified against their source: `tool()` is an identity function, `ToolSet` is a plain record, and `inputSchema` accepts any object implementing Standard Schema (validate) + Standard JSON Schema (converter). `createTool()` attaches those fields to every `VendoTool`.
+
+**Per-request principal binding (review finding — contract-level).** Frameworks never pass `principal`/`provenance` to `execute` — their option bags don't know these concepts. So the export step is where identity binds, per request, in the host's route handler:
+
+```ts
+// app/api/chat/route.ts — the flagship path, honestly shown:
+const principal = await identify(req);                          // host session → Principal
+const tools = toToolSet(safe, { principal, provenance: { kind: "chat" } });
+return streamText({ model, tools, messages }).toUIMessageStreamResponse();
+```
+
+`toToolSet` closes each tool's `execute` over the bound context and the guarded pipeline; an `UnboundVendoTool` is never handed to a framework un-bound (calling its raw execute without context is a contract error). The same bound objects flow into Mastra unchanged; OpenAI Agents gets a thin exporter (`toOpenAiAgentsTools` — their SDK parses but does not validate JSON Schema inputs, so the exporter attaches our validation). **A CI test asserts the `BoundToolSet` output stays assignable to Vercel's `Tool`/`ToolSet` types on every SDK release.** If a Vercel major ever breaks duck-typing, the fallback is one converter call for that major; our contracts don't move.
+
+**Where a "please approve" reaches the UI when you use guard ALONE (review finding).** If a dev adopts only `@vendoai/guard` on a stock Vercel app (no `@vendoai/agent`), a guarded tool that returns the `pending` outcome must still surface a card. The bound tool renders `pending` onto the framework's own HITL channel — for the ai SDK, `toToolSet` emits the tool-approval-request the SDK already understands (`useChat().addToolApprovalResponse` answers it); `/adapters` ships the small bridge that maps a Vendo consent request ↔ that native mechanism. So guard-standalone works with stock `useChat` and no bespoke UI; richer consent cards are an `@vendoai/agent`/ui upgrade, not a requirement. Frameworks without a HITL channel get a documented data-part convention instead.
+
+**Ingestion — the other direction (more important for adoption):**
+
+```ts
+const theirs = fromAiSdkTools(existingTools, {
+  risk: { deleteInvoice: "destructive", listInvoices: "read" },   // one-line annotation
+});
+const safe = guard([...theirs, ...actions], { database });        // guard polices THEIR tools too
+```
+
+`fromAiSdkTools` derives descriptors mechanically (zod → JSON Schema via the SDK's own converter); risk can't be derived from code, so undeclared → `write` + `unverified` with the override map as the fix. `fromMcp` maps annotations losslessly. Industry precedent: neutral catalog + per-framework edges (Composio, Arcade); `ToolDescriptor` is deliberately ~an MCP tool.
+
+The **streaming/genui message protocol stays ai-SDK-typed** (UIMessage + data parts) as the one documented framework-coupled surface, contained in `@vendoai/agent` (not in core's contracts), with MCP Apps as the standards-based escape hatch.
+
+## 4. Principal
+
+```ts
+type Principal =
+  | { kind: "user"; tenantId: string; subject: string; claims?: Record<string, unknown> }
+  | { kind: "anonymous"; sessionId: string; tenantId?: string };   // tenantId: multi-tenant hosts scope guest sessions
+```
+
+Every storage operation and policy decision is principal-scoped. Anonymous is a first-class, *visible* state with contract-level rules:
+
+- **Non-persistence is structural, not prose** (review finding) — core ships `withAnonymousGuard(storage)`, applied by every block's `create*`, routing anonymous-principal operations to an ephemeral layer with defined expiry/cleanup, so third-party storage implementations cannot get this wrong (§10).
+- **Session identity is defined, not hand-waved** (review finding). `sessionId` is minted by core's request helper on first contact (an httpOnly cookie by default; hosts may supply their own opaque id). "Session end" = cookie expiry or an explicit `endSession`; on a stateless HTTP host the ephemeral layer is keyed by `sessionId` with a TTL (default 24h, host-configurable), and expiry is what reaps anonymous grants/modules/state. There is no durable identity to leak into.
+- **Anonymous is least-privilege by default** (security review). Anonymous principals get `read` tools only; `write`/`destructive` tools, module sharing/import, and automations are **off unless the host explicitly opts them in per tool**, under strict rate/resource quotas. This bounds the public-facing abuse surface (spam, write-tool farming, resource exhaustion) that session-scoping alone does not.
+
+This is what makes `vendo init` work in the first ten minutes (before identity wiring) and honestly serves guest-user products. Hosts must never mint fake-permanent subjects for anonymous traffic.
+
+## 5. Modules
+
+### 5.1 What a module is
+
+**A module = a git repo of ordinary files + a system-written envelope.** Saved views, remixes, and scheduled micro-apps are the same artifact with more or fewer files. Nobody — human or AI — authors a manifest:
+
+```
+modules record (envelope — ALL system-written):
+  id, name, provenance                            ← storage/system-assigned
+  trigger, anchor                                 ← captured from conversation at save
+  egress, secrets                                 ← derived from files, confirmed on the save card
+  repo                                            ← bare git repo: THE artifact
+  version = SEAL                                  ← see below
+```
+
+**The module seal (review finding — replaces bare commit-sha versioning).** What a user approves is not just code; it's code + the envelope's security posture + what the named tools actually do. Two derived keys, because approval and caching have different sensitivities (review finding — they were conflated in v2):
+
+```
+buildKey    = hash( repo commit sha + canonical envelope )          // what to compile/run — cache key
+approvalSeal = hash( buildKey + descriptor hashes of every host tool the module was approved to use )
+```
+
+- **Caches** (compiled bundle, warm snapshot) key on `buildKey` — a host tweaking one tool's *description* must not invalidate every module's compiled artifact.
+- **Grants and audit** bind to `approvalSeal` — so drift in a granted tool's behavior *does* lapse the approval even though no file changed. Any envelope security edit (widened egress, retimed trigger), any repo change, and any granted-tool descriptor drift **lapses the grants and re-prompts** — closing the "edit the trigger to every-minute without touching code" hole.
+
+**No time-of-check/time-of-use gap (security review — invariant I8).** The seal a user approves is immutable; grant minting is compare-and-set against that exact seal, and every run/build/cache read must prove the same seal or **fail closed**. A repo/envelope/descriptor mutation between save-card and mint (or a stale warm snapshot from a superseded seal) can never be executed under the old approval.
+
+Everything else lives **in the files, in each ecosystem's own standard formats** — `requirements.txt`, `package.json`, `Procfile`, `Dockerfile`. We infer how to run a repo buildpack-style (delegated to an existing OSS builder — Nixpacks or CNB, runtime track picks); we never define our own execution manifest.
+
+### 5.2 Capability tiers (emergent, not declared)
+
+The ladder is a property of what's in the repo; one module can climb it in place (same id, same grant lineage, new seal):
+
+```
+view.json                → declarative UI tree of host components: instant render,
+                           no sandbox, no code risk, cheapest AI generation (default tier)
+index.tsx / index.html   → custom web UI: esbuild-bundled, sandboxed iframe, MCP Apps
+main.py / Procfile / …   → full micro-app: server sandbox, any language Linux runs
+```
+
+`ui` entries are web tech (iframe physics). Service code is anything. The agent defaults to the cheapest tier that satisfies the request and escalates only when asked. Speed-research note for the apps track: the `view.json` schema must be designed **streaming-first** (identity/skeleton keys before heavy children) so views paint while they generate.
+
+### 5.3 The lifecycle (scoop → store → pour)
+
+1. **Workspace.** The agent works in a runtime-owned sandbox directory — every file write goes through the runtime, so capture never trusts model claims.
+2. **Scoop (save).** The runtime captures the working tree into the repo, excluding reproducible artifacts (rule: *capture the recipe, never the reproducible artifact* — the exclusion set and lockfile-freezing behavior are a runtime-track detail); oversized captures surface on the save card instead of silently storing.
+3. **Derive.** Static analysis over the captured files: tool calls used, external hosts → egress candidates, entry detection. **Derivation is UX, not security** — it feeds the save card; enforcement is always runtime (§7). A missed call = friction (parked + ask), never breach.
+4. **The save card — the single human beat.** "Invoice Chaser: runs Mondays 9am · reads invoices · **sends reminder emails** · no internet access — Save & allow?" Minting seal-bound pre-approval grants happens here.
+5. **Pour (run).** Materialize the repo into the right placement; warm snapshots make it instant (§8). Tier-3 builds run async at save time so first fire is warm (speed-research note).
+6. **Export/share.** `git bundle` + envelope = one portable file (`.vendomodule`); import pours it back on any Vendo install. Sharing shows the receiver the same derived card before accepting; their grants, their scoping. Share/import integrity shapes are core contracts (security review): a **signature covers the canonical repo bundle + envelope + seal + signer identity**; import **verifies signature, signer chain, and revocation/advisory status BEFORE presenting any grant card**, and **fails closed** (offline/unverifiable ⇒ import is blocked or explicitly quarantined read-only, never silently trusted). The registry, key model, and advisory feed implementing this at scale are cloud-track; core defines the shapes and the fail-closed rule.
+
+**Deleted from earlier drafts, deliberately:** the authored manifest, the `capabilities` tier enum, the static tools allowlist (→ §7), the bespoke files-map format, the bespoke capture pipeline and export format (git does all four), the `dependencies`/`entries` manifest fields (ecosystem files do it).
+
+### 5.4 Two homes, one format
+
+Dev-shipped modules live as folders in `.vendo/modules/` (ordinary files; optional tiny `vendo.json` for trigger/egress — devs like config files; agents never write one), packed by `vendo sync` into the same envelope+repo shape. **Sync commits must be deterministic** (fixed author/epoch timestamp, or tree-hash-based versioning) so re-syncs and deploys of unchanged modules never mint a new seal and spuriously lapse grants (review finding). User/agent modules are born as database rows. Provenance records which (§7).
+
+### 5.5 Anchored modules (remixes)
+
+`anchor` is an envelope field: which host page spot the module binds to, plus remix bookkeeping (source hash, envelope/seal refs, edit baseline hash) in one labeled corner. Anchored modules receive live host props (`vendo/anchor-data`, §9) **and may still do anything a module can** — no special identity, no capability restrictions in core (hosts restrict via policy if they want). Which module is pinned at which anchor is a separate tiny mapping owned by the apps block, so several saved remixes of one spot can exist with one active.
+
+### 5.6 Storage split (truth / cache / never-ours)
+
+| | What | Where |
+|---|---|---|
+| **Truth** | envelope + repo · big assets · module state · grants · run history · audit | storage slices (§10) |
+| **Cache** (evict freely) | compiled iframe bundle (by `buildKey`) · warm sandbox snapshots with deps installed (by `buildKey`, provider-owned) | runtime/provider |
+| **Never ours** | host business data (reached only via host tools) · host/shared-module secret values (I4 handle-mode: injected only at the egress proxy, never in module code) | host systems / secrets slice |
+
+Invariant (the test the design must keep passing): **delete every sandbox and every cache; every module still works from its repo.**
+
+## 6. Threat model & security invariants (review finding — new section)
+
+The permission model's claims rest on these. Each is a **contract requirement** on the runtime — testable, not aspirational. An implementation that cannot uphold one must not claim conformance.
+
+- **I1 — Network deny-all.** Module environments have no network except envelope-declared egress, enforced at the platform layer (iframe CSP per the MCP Apps standard; VM-level network policy server-side). This is the invariant that makes `read` auto-run safe.
+- **I2 — Unforgeable provenance.** `CallProvenance` is attached at the trust boundary appropriate to the placement: server/module calls are stamped by the runtime *outside* the sandbox (module code cannot set, omit, or alter it) and verified against the per-run credential (I3); interactive chat calls are stamped in the host route handler by `toToolSet` (trusted server code the module never touches). Calls reaching guard without a boundary-attached provenance are rejected.
+- **I3 — Per-run credentials.** Server-placed runs execute under a runtime-minted credential bound to (principal, module id, seal, run id) with expiry. Tool endpoints reject calls not bearing it — a sandbox cannot call on behalf of anyone else, or outlive its run.
+- **I4 — Secrets are provenance-gated** (security review — the v2 "injected but never readable" wording was self-contradictory). The trust boundary is *secret owner vs. code author*, matching industry norm (Zapier/n8n hand a user their own key; CI/secret-managers give untrusted code only references):
+  - **Owner is the acting user AND the module is self-authored** → the raw value may be injected into the module's environment (your key, your automation — like Zapier). Frictionless common case.
+  - **Host-owned secret, OR any `shared`/`imported` module** → the module gets an **opaque handle** only; the real value attaches at the egress proxy *outside* the sandbox, so the code can never read, log, transform, or exfiltrate it. No opt-out.
+  - Which rule applies is decided by (secret owner, module `origin`), enforced by the `secrets` slice (§10) — never a global switch. Secrets never enter the repo, bundle, or logs in either mode.
+- **I5 — Write-tools are egress, and grants must bound them** (security review). The jail (I1) blocks the network, but a granted `send_email` can carry stolen read-data in its payload. Therefore a pre-approval grant on a write tool MUST carry enforceable **argument constraints** (recipients/domains/fields/volume — the grant-constraint machinery already in the contract); a write whose material payload is not knowable at save time is **not pre-approvable** and parks per instance. Consent cards MUST surface material payload fields (never a blind "allow send_email"); guard applies elevated scrutiny to write-calls following broad reads when `origin: "shared"`.
+- **I6 — Resource limits.** Sandboxes run under CPU/memory/time budgets; exhaustion kills the run and audits it. Budgets are host-configurable, never absent.
+- **I7 — Audit completeness.** Every tool call, parked action, grant mint/lapse, share-accept, and secret injection produces an audit row with principal + provenance + seal. No configuration can disable audit.
+- **I8 — Seal is immutable, mint is fail-closed** (security review; see §5.1). No time-of-check/time-of-use gap between what a user approves and what runs; compare-and-set mint, stale-snapshot rejection.
+- **I9 — The module↔host bridge is capability-bound per render** (security review). Each rendered view gets a per-render capability/nonce; the host binds messages to a strict `targetOrigin` + source window + (seal, principal, render id) and rejects spoofed, replayed, or nested-frame-originated messages. (Mechanism owned by the runtime track; the invariant is core's.)
+- **I10 — Host-pushed data is tainted input** (security review). `vendo/anchor-data` and any host data entering a module or the generation context is untrusted: it is audit-logged, may be sensitivity-tagged, and **must never be treated as instructions** to the agent or module. Writes following anchor-data exposure get I5 scrutiny — this is the prompt-injection path.
+
+## 7. Permissions
+
+One permission layer, module-aware. **No parallel static allowlists** — a module may *attempt* any tool its user can reach; enforcement happens on every call, server-side, in guard.
+
+```ts
+interface CallProvenance {
+  kind: "chat" | "module" | "automation";
+  moduleId?: string;
+  seal?: string;                                        // version binding (§5.1)
+  origin?: "dev-shipped" | "self-generated" | "shared"; // trust class
+}
+```
+
+- **Provenance rides every call** (attached per invariant I2). Policy sees who's really asking; audit records "sent by invoice-chaser (shared by Sarah)," never just "sent."
+- **Grants gain an optional context scope.** A chat-minted grant never auto-suppresses prompts inside someone else's shared module; "always allow *for this module*" is a grantable answer. The existing grant record design (structured scope, constraints, durations, descriptor-hash lapsing, store-assigned identity) carries over intact plus the scope dimension.
+- **Automation pre-approvals are the same grants**, minted at save time from the derived summary, **seal-bound** (§5.1), re-prompted on any edit. No second pre-auth system.
+- **Unattended runs never prompt mid-run:** an unexpected call **parks** — the action is held, the rest of the run proceeds where safe, the user is notified ("Chaser wants `delete_invoice` — it never asked for this. Allow?"). **Approving a parked action releases that one instance only**; the card offers a separate explicit "always allow for this module" choice that mints a scoped grant (decision 2026-07-10). **The card is rendered from host-owned canonical tool metadata** (name, risk, exact arguments/diff, origin, seal) — never from strings the module supplies — so a module cannot social-engineer a misleading one-click approval (security review). "Always allow" is **not offered for a `destructive` parked action** (it stays non-suppressible). Denial drops the action; both outcomes are audited.
+- **Risk ladder is the gate** (§3.1); `destructive` is never suppressible by anything.
+- **Dev-shipped modules** (`origin: "dev-shipped"`) still run under the same permission layer — being in the repo is not blanket authority. The host chooses their grant lifecycle: per-user first-use consent (default) or a host-level pre-trust policy for modules it code-reviewed. Either way, `destructive` calls remain non-suppressible.
+- **Anonymous principals:** session-duration grants only; no pre-approvals (nothing outlives the session); read-tools only unless the host opts in per tool (§4).
+- **What stays static in the envelope** (sandbox-construction *physics*, not permission *policy*): `egress` (→ invariant I1; deny-all default) and `secrets` (→ invariant I4).
+
+Core owns the shapes (grant, provenance, verdict, seal); guard owns the pipeline (policy evaluation, consent ceremony, fade, judge).
+
+## 8. Module runtime (`@vendoai/core/runtime`)
+
+```ts
+interface ModuleRuntime {
+  render(module: ModuleRef, opts: RenderOptions): Promise<ModuleView>;   // browser placement
+  execute(module: ModuleRef, opts: ExecuteOptions): Promise<RunResult>;  // server placement
+  workspace(principal: Principal): Promise<ModuleWorkspace>;             // agent's build/scoop surface
+}
+
+interface RenderOptions {
+  tools: VendoTool[];        // all tools the user can reach — guard polices per-call
+  principal: Principal;
+  theme: ThemeTokens;
+  anchorData?: unknown;      // live host props for anchored modules
+}
+```
+
+**Placement boundary (review finding — keep apps out of core).** Core's runtime owns repo materialization, the sandbox/iframe + MCP Apps transport, CSP construction, and the provider seams. It does **not** know host components: `view.json` rendering is an **apps-owned renderer injected into the runtime** (`runtime.render` accepts a view-renderer plugin), so `@vendoai/core/runtime` never imports the component library and the block boundary stays honest.
+
+**Browser placement:** `view.json` present → the injected apps renderer paints host components directly, no sandbox boot. Otherwise: esbuild bundles the web entry into one HTML document (import maps vendor React + the component library — never re-bundled per module) → different-origin double-iframe with host-constructed CSP from `egress` (I1) and per-render capability binding (I9) → MCP Apps handshake. Compiled output cached by `buildKey` (§5.1); reopen is instant.
+
+**Server placement (provider seam):** `SandboxProvider` interface; E2B and smol-machines-style self-hosted microVMs are the candidate first implementations (runtime track decides with a maturity check — the self-hosted option exists so OSS never *requires* a hosted account). Nixpacks/CNB infers the build; warm snapshot/resume is the **provider's** feature, keyed by seal. Injected into every server sandbox: the MCP tool endpoint (language-agnostic tool calls — Python imports a client, bash gets a `vendo call` shim) guarded by the per-run credential (I3), secrets (I4), and the state client. Sandbox filesystem is disposable by contract; durable data goes through `vendo/state`.
+
+Both placements attach provenance to every call (I2). The three flows the runtime wires end-to-end: **save** (workspace → commit → derive → card → grants → envelope+seal), **render** (envelope+repo → bundle → iframe → MCP Apps → guard → host API), **fire** (scheduler → pour → run → MCP → guard → host API → audit + toast).
+
+## 9. Module↔host protocol: MCP Apps, natively, everywhere
+
+Our surfaces are conforming **MCP Apps** hosts (extension `io.modelcontextprotocol/ui`, Stable 2026-01-26; plain MCP JSON-RPC over postMessage). From the standard, verbatim: `ui/initialize` handshake, `tools/call` from the view, streaming tool input/results, display modes, resize, teardown, host context (theme/locale/timezone), CSP assembled by the host from declared domains (deny-all default; host may tighten, never loosen). The bridge is capability-bound per render (I9).
+
+**Portability is a matrix, not "zero translation"** (review finding — the v2 claim was too strong):
+
+| Module surface | ChatGPT/Claude/VS Code/ai-SDK hosts |
+|---|---|
+| HTML-tier module using only standard MCP Apps | Renders as-is, no translation |
+| Module using `vendo/state` or `vendo/anchor-data` | Feature-detected via handshake capabilities; **degrades gracefully** (e.g. renders read-only) |
+| `view.json`-tier module | **Host-only** — needs the host's component library; does not render externally |
+
+Rationale for the bet: one protocol inside and outside the product; the common HTML tier travels for free.
+
+**Two namespaced Vendo extensions** (the standard's designed extension mechanism), owned by core:
+
+- `vendo/state` — get/set persisted module state (the standard defers persistence); backed by the `state` slice; session-scoped for anonymous principals. Migrates to the standard's persistence when it lands.
+- `vendo/anchor-data` — live host-props push for anchored modules (audit-logged per I5).
+
+**Portability is honest, not absolute** (review finding): modules relying on `vendo/*` extensions MUST feature-detect via the handshake's `appCapabilities`/`hostCapabilities` and degrade gracefully in non-Vendo hosts (a stateful module renders read-only in ChatGPT rather than breaking). `view.json`-tier modules render only where the host component library exists — i.e., inside the host product.
+
+Single-HTML-document delivery is a build step, not a capability ceiling (a bundled SPA routes internally; heavy compute lives in service code reached via tools).
+
+## 10. Storage contracts
+
+Per-concern slice interfaces in core; `@vendoai/store` implements all; any block accepts custom implementations. Config key: **`database`** (per-block `createGuard({ database })`; umbrella `createVendo({ database })` passes it down).
+
+```ts
+// The full registry of slices core defines. NOT all required at once — each block
+// requires only its slice subset via Pick (review finding: v2's "all-required
+// VendoStorage" couldn't typecheck the partial examples).
+interface StorageRegistry {
+  threads:  ThreadStorage;      // conversation persistence — records are OPAQUE to core
+  modules:  ModuleStorage;      // envelope rows + bare git repos
+  state:    StateStorage;       // module runtime data (vendo/state backend)
+  grants:   GrantStorage;       // permission grants — context-scoped, seal-bound
+  secrets:  SecretStorage;      // scoped secret store — provenance-gated access (I4)
+  audit:    AuditLogStorage;    // append-only, provenance-carrying (I7)
+  runs:     RunHistoryStorage;  // automation firings + outcomes
+  memory?:  MemoryStorage;      // reserved & OPTIONAL — memory track defines operations
+  meter?:   MeterStorage;       // reserved & OPTIONAL — meter track defines operations
+}
+
+// Each block states its need as a Pick, so partial implementations typecheck:
+type GuardStorage       = Pick<StorageRegistry, "grants" | "audit">;
+type AutomationsStorage = Pick<StorageRegistry, "modules" | "runs" | "audit">;
+// createGuard({ database }: { database: GuardStorage }) — needs exactly these two.
+```
+
+Rules: every operation principal-scoped; stores assign ids/timestamps (callers never author identity); a block requires only its `Pick` subset, so `createGuard({ database: { grants, audit } })` typechecks and a full `createStorage()` object satisfies it too. **No `database` configured → in-memory defaults** — with a stated caveat: on a serverless/stateless host, in-memory means grants and modules are dropped every cold start (perpetual re-prompting), so any real deployment configures a `database`. **Anonymous enforcement is structural** (review finding): core ships `withAnonymousGuard(storage)` — applied by every block's `create*` — routing anonymous-principal operations to an ephemeral session-scoped layer (TTL per §4) regardless of the underlying implementation. `threads` stores opaque message records (review ruling): core defines the record envelope (ids, ordering, principal scoping) and never types message *content* — the ai-SDK message shape is `@vendoai/agent`'s business. `secrets` enforces I4's provenance gate: `putForUser`/`putForHost` on write, `reference(handle)` for module code, and value injection only at the egress proxy for handle-mode.
+
+## 11. Theme
+
+`ThemeTokens` (the `.vendo/theme.json` shape): palette, typography, radii, spacing, dark variants. One mapping onto the MCP Apps ~80-CSS-variable vocabulary serves both worlds: inside our surfaces, tokens resolve as live CSS custom-property *references* where the host has them (zero drift on redesign) and values elsewhere; in external hosts (ChatGPT/Claude), modules take the host's theme context and just work. Theme is presentation-only: nothing in policy, storage, or runtime branches on it.
+
+## 12. `.vendo/` directory
+
+```
+.vendo/
+  theme.json              # extracted brand tokens — dev-editable
+  tools.json              # machine facts (paths, schemas) — REGENERATED by `vendo sync`
+  tools.overrides.json    # dev-authored edits (descriptions, risk corrections) — merged on top, never touched by sync
+  components/             # host components exposed to generated UI — dev-authored
+  modules/                # dev-SHIPPED modules: one ordinary folder each (+ optional vendo.json)
+  generated/              # machine-owned: env manifest, remix captures, caches — no stability promise
+```
+
+Principles: **derive, don't duplicate** — `vendo sync` regenerates, `vendo sync --check` fails CI on drift, sync flags dead overrides; top level dev-owned, `generated/` tool-owned; everything committed (prod builds never require re-extraction); user/agent modules never live here. The machine-facts/overrides split is what makes regeneration always safe.
+
+## 13. Eviction map
+
+| Today in core | Goes to |
+|---|---|
+| consent card wire schemas, fade proposals, judge strings | `@vendoai/guard` |
+| Scheduler seam, Channels seam | `@vendoai/automations` |
+| prompt-assembly layer + the LLM loop (today's vendo-runtime engine + vendo-server) | **`@vendoai/agent`** (its own block — decision 2026-07-10) |
+| component registry, genui resolve/format | `@vendoai/apps` |
+| `CredentialBroker` seam | split: `authenticate` → `@vendoai/agent` (session init); automation grant exchange → invariant I3's per-run credentials in `/runtime`; secret storage → the `secrets` slice (§10) |
+| `ai` re-exports (`tool`, `Tool`, `ToolSet`) + `@ai-sdk/provider` dep | deleted → neutral shapes + `/adapters` |
+| `SavedVendo`, `RemixRecord`, `AutomationRecord`, monolithic `Store` | module envelope + repo + storage slices |
+| `vendo-stage`, `vendo-sandbox-shims` (packages) | folded into `@vendoai/core/runtime` |
+
+Promotion rule for the future: when a second block needs a shape (e.g. memory's proactive proposals want Channels), promote it to core *then* — additive, cheap.
+
+## 14. Migration (big-bang 0.3.0)
+
+Core first (contracts + runtime), then blocks in parallel (each depends only on new core), demos/corpus last as integration proof. The corpus e2e suite (10/10 repos Layer 2, 5/5 Layer 3) is the regression bar the finished wave must re-clear. No deprecation period; delete on replace.
+
+## 15. Usage sketches (contract validation)
+
+Each core contract, consumed by the block code a dev would actually write — ugliness here fails the contract:
+
+```ts
+// ── ONE-TIME setup (module scope): construct blocks once, reuse across requests ──
+const guard = createGuard({ database });                       // process-scoped: pools connections
+const actions = createActions(manifest);                       // UnboundVendoTool[]
+
+// ── PER-REQUEST: bind identity, then hand framework-shaped tools to the loop ─────
+// app/api/chat/route.ts
+const principal = await identify(req);
+const safe = guard.wrap([...fromAiSdkTools(theirTools), ...actions]);   // still unbound
+const tools = toToolSet(safe, { principal, provenance: { kind: "chat" } });  // → BoundToolSet
+return streamText({ model, tools, messages }).toUIMessageStreamResponse();
+// guard's "ask" rides the SDK's native tool-approval channel (§3.2) — stock useChat works.
+
+// ── apps: the entire render path ────────────────────────────────────────
+const view = await runtime.render(ref, { tools: safe, principal, theme, anchorData });
+container.append(view.element);
+
+// ── automations: the entire fire path ───────────────────────────────────
+const result = await runtime.execute(ref, { tools: safe, principal });
+await storage.runs.record(principal, ref.id, result);
+
+// ── meter: counts calls without knowing any framework ───────────────────
+await storage.meter.increment(ctx.principal, ctx.provenance.kind, cost(ctx));
+
+// ── a Python module calling tools (server sandbox, MCP endpoint, I2/I3) ─
+// import vendo; vendo.tools.call("list_invoices", {"overdue_days": 15})
+
+// ── custom persistence: implement only the slices your block needs (§10 Pick) ──
+const guard2 = createGuard({ database: { grants: myRedisGrants, audit: myAudit } });
+```
+
+**Named types used above** (one-line glosses so §8/§15 are self-contained): `ModuleRef` = `{ id; seal }` handle to a stored module; `ModuleView` = `{ element; dispose() }` the mounted iframe/view; `RunResult` = `{ status; outcome?; error? }` from a headless run; `ModuleWorkspace` = the agent's live sandbox dir with `writeFile`/`save()`; `ToolBinding` = the discriminated `http | …` execution binding.
+
+## 16. Open questions → owned by other tracks
+
+- **apps**: `view.json` tree schema (streaming-first key order; today's UINode evolves there); anchor→module pin mapping; workspace UX; component descriptor conventions
+- **agent**: the LLM loop, prompt assembly, ai-SDK message protocol, provider seam (incl. speed levers: prompt caching, small-model fast lane, judge parallelization)
+- **automations**: trigger vocabulary (cron/webhook/event) in the envelope; run-history semantics; parked-action delivery UX
+- **guard**: policy pipeline, consent ceremony, fade, judge; finer policy dimensions (data sensitivity, unattended eligibility); writes-after-broad-reads scrutiny (I5)
+- **actions**: extraction (OpenAPI/route-scan → tools.json), binding execution
+- **mcp**: serving modules outward as MCP Apps; host-side OAuth door
+- **runtime**: SandboxProvider pick (E2B vs self-hosted microVM — maturity check); Nixpacks vs CNB; isolate middle tier (speed doc); persistent-stage hot swap (F3a-gated)
+- **store**: Drizzle/PGlite implementation of the slices incl. `withAnonymousGuard`
+- **cli/umbrella**: entry-point story (`vendo init` → ???), `createVendo` sugar, sync/drift tooling, deterministic sync commits
+- **cloud**: shared-module registry, signing infrastructure, revocation/advisories (shapes are core's, §5.3)
+- **speed**: `research-2026-07-module-speed.md` + `research-2026-07-apps-speed-capability.md` recommendations, mapped per track above

--- a/docs/specs/research-2026-07-apps-speed-capability.md
+++ b/docs/specs/research-2026-07-apps-speed-capability.md
@@ -1,0 +1,695 @@
+# Modules Speed + Capability Roadmap (July 2026)
+
+Synthesis of the 8-dimension apps-speed research sweep (2026-07-10): monogram
+teardown, product teardowns (v0/Bolt/Lovable/Artifacts/Canvas), gen-UI SDK
+survey, inference SOTA, sandbox/runtime latency, edit-loop SOTA, in-repo
+latency audit at HEAD `3c32f2ba`, and capability levers. Companions:
+`research-2026-07-module-speed.md` (solo survey, same day) and
+`research-2026-07-framework-landscape.md` (protocol/SDK facts). Every claim
+below traces to those reports; UNVERIFIED markers are inherited from them.
+
+Goal restated: generation + render + edit-turnaround that feels like
+monogram.ai (founder-claimed ~1.5s average to a full interactive UI, on a
+"parallel processing architecture") while keeping the full module capability
+ladder (view.json / sandboxed index.tsx / micro-apps) that monogram entirely
+lacks. Monogram's speed comes from what maps to our tier 1 only: server-driven
+native UI over a curated component catalog, no sandbox, no codegen in the hot
+path (monogram report §3c, INFERRED from Ashby job stack: SwiftUI/UIKit +
+WebSockets/gRPC, zero web tech). Their moat is speed; ours is capability +
+embeddability. The plan below buys their speed without giving up our ladder.
+
+---
+
+## 1. TL;DR — top 12, ranked by expected impact / cost
+
+| # | Recommendation | Tier | Expected win | Cost | Owner track |
+|---|---|---|---|---|---|
+| 1 | **Fix the `prepared` zod strip** in `vendo-server/src/vendo-dir.ts:36-42` (`prepared: z.string().optional()`), and put benchmark assertions on the 4.4s path so speed wins can't rot silently (methodology in §1.1 — deterministic stages in PR CI, live wall-clock in nightly only) | edit-loop | restores the shipped, measured 32s→4.4s first-remix path, currently OFF for every OSS install (confirmed live bug, flagged 2026-07-05, still unfixed) | S | server |
+| 2 | **Instrument the seven seams** (model TTFT/step, per-step prefill **with per-segment prefix token counts**, judge latency, tool round-trip per call, stream-to-first-`data-ui`, iframe boot→first-paint, failure/retry rates) with `VENDO_BENCH`-style span logs | all | unblocks every other item; today the repo has exactly ONE timing line and every per-stage number is inferred. No TTFT percentage may be claimed for rec #3 until real prefix token counts are measured here | S | runtime |
+| 3 | **Prompt caching on the stable prefix** (system prompt + catalog + tool schemas + captured source). Guaranteed win = **cost** (Anthropic cached reads at 0.1x input); TTFT upside is real but **depends on measured prefix size** (see §2 target table — the cited curve gives only ~4% at 20k tokens). Prerequisite: the §1.2 prefix measurement; provider caching matrix in §1.2 | all | zero caching exists at HEAD; up to 8 steps/turn re-prefill the full prefix. Cost win is unconditional; latency win to be sized by rec #2 data | S | runtime |
+| 4 | **Stream-render view.json progressively**: streaming-friendly key order (identity/anchor/skeleton first, heavy children last), O(n) incremental parser (jsonriver-class, NOT AI SDK's default `parsePartialJson` — see §10 caveat), skeleton mounts the instant the component name resolves. Guard-layer interaction contract in §1.3 | view.json + perceived | first paint moves from full-emission time to ≈ TTFT + first-node parse (the defensible claim). The oft-quoted ~30s→~1s is from the companion solo survey (`research-2026-07-module-speed.md:121`), a single anecdotal source at chatbot payload scale, not module scale — treat as directional only | M | shell/stage |
+| 5 | **Stop making the model retype data**: replace `render_view`'s "place each tool result VERBATIM in `data`" contract with server-side data splicing by reference/path (A2UI-style JSON-Pointer binds are the v2). Derived-data, validation, and staleness contract in §1.4 | view.json, edit-loop | output tokens are the dominant clock (repo-audit #1); data re-typing is pure waste and also enables live `dataModelUpdate` refresh without regeneration | M | runtime |
+| 6 | **Fast-lane the view.json tier**: bind it to a fast small model + strict structured outputs *where the provider supports them*, else validate-and-repair; escalate to frontier on validation failure. Gated on rec #11's quality eval. Key-configuration behavior in §1.5 | view.json | the tier ladder IS the router (no learned classifier needed); RouteLLM-class 40–85% cost cuts; sub-second TTFT is achievable at this tier — but "monogram-feel" is **unproven until rec #11's corpus eval passes** on a Haiku/Flash-class model, and constrained decoding on hosted APIs is a correctness lever, not a throughput lever (§5) | M | runtime |
+| 7 | **Persistent stage: hot-swap instead of fresh iframe per view/edit**; keep the 4.1MB component bundle out of the per-realm structured clone via jail-safe mechanisms only (transferable ArrayBuffer, or one persistent realm per page that evaluates the bundle once) — NOT by URL inside the sandbox (CSP analysis + swap security policy in §1.6); parallelize the 3 serial env RTTs; swap edited modules via new blob URL (later react-refresh) | iframe | removes the ~100–500ms+ (UNVERIFIED) per-view floor that becomes THE bottleneck once model time shrinks; edits keep UI state instead of re-running ready/init handshakes | M | stage |
+| 8 | **Generalize `edit_view` → `edit_module`**: per-file normalized baselines with `baseHash` = git blob OID, coordinate-mode hunks, `addFile`/`deleteFile`/`renameFile` ops; conflict policy in §1.7 | edit-loop | applies the in-repo 32s→4.4s mechanism to every module tier; `hunks.ts`/`baseline.ts` are file-agnostic. **Cost is split**: hunk/baseline transplant + file ops = M; cross-file import/typecheck gates + tier-3 "patched→building→swapped" async-build progression = a separate L-class follow-up (generated view components are deliberately isolated blob modules today — real multi-file imports are new machinery) | M (+L follow-up) | runtime |
+| 9 | **Move the guard + tool path off the serial hot path**: prompt-cache the judge prefix; fire the judge as each call's input completes so judging call N overlaps the model still streaming call N+1 in the same step; judge and execute independent calls in a step in parallel. Keep ONLY the existing per-`toolCallId` needsApproval/execute-pair dedupe — **no cross-call memoization** (§1.8: that pattern was removed as a security fix; memo scope is ENG-193's decision, not a speed knob) | all (act-tier tools) | today one un-streamed `generateText` per act-tier tool call, serial before execute (~0.3–1.5s/call UNVERIFIED, ~1–4s on a 3-call turn), and tool execution is serialized behind it | S–M | runtime |
+| 10 | **Progressive capability ladder**: every tier-2/3 request first paints a tier-1 approximation (budget: p50 ≤1.5s to paint, same lane as rec #6), produced by **the same stream emitting a view.json block first** — no second model call; the approximation is **read-only** ("upgrading…" affordance, interactivity frozen, no state carry-over in v1) and the real build swaps in when ready; tier-3 builds run async at publish/save (Nixpacks ~90s can never be mid-conversation) with warm snapshot per module version; E2B pause/resume is same order as its ~150ms create per third-party benchmarks (exact resume latency unmeasured — verify before committing a re-open budget); speculative resume on hover | server + perceived | perceived TTFR = tier-1 speed on every generation regardless of final tier; no product in the teardown set has this ladder, it is our structural advantage | M–L | runtime + cloud |
+| 11 | **Tier-1 quality eval gate**: pairwise screenshot-MLLM-judge + deterministic gates over the existing nightly corpus jobs (the monogram variation-scoring loop, §3/§9), run BEFORE rec #6's model swap and as its permanent regression gate | view.json | downgrading the model without a quality harness is the silent-regression failure mode this doc warns about for speed; this is the explicit gate. Also the prerequisite for ever fine-tuning (§10) | M | runtime |
+| 12 | **In-stream repair ladder for tail latency**: promote the render_view JSON-repair middleware from app-level to runtime; add deterministic mid-stream fixes (schema-name repair, bracket balance) so validation failures don't 400 the turn or force a full re-generation; measure failure rates via rec #2 (§2.3) | all | today a render_view JSON break 400s the whole turn (repo memory: tool-input JSON repair), a hunk mismatch costs a full extra turn (4.4s → ~9s+), and rec #6's escalation pays fast-model time PLUS frontier time on failure. p95 is unknowable until these rates are measured; repair-in-stream is the v0 AutoFix idea (§4) applied to our stack | M | runtime |
+
+Sequencing: 1+2+3 are days-class and compounding; do them first (2 before
+claiming wins from 3). Then 11 (the eval gate), then 4+5+6 as one "instant
+tier 1" campaign — **6's model swap does not land until 11 is green** — with 7
+in parallel (client-only). 8+9+12 harden the loop. 10 is the product-defining
+move and lands with tier-3 GA. Retrieval-into-remix (accepted modules as
+prepared baselines, §8 below) rides on 8 as a second wave; the tier-3 half of
+8 (cross-file gates, async-build progression) is its own L-class follow-up and
+must not be silently absorbed into the days-class narrative.
+
+Smaller follow-ups (real, but below the top-12 line):
+
+- **First-turn tool ingestion** (§2 today-table): persist tool manifests keyed
+  by server-config hash, refresh in background, circuit-break dead MCP servers
+  instead of re-paying the connect timeout every 30s. Cost S.
+- **Context growth**: prompt caching does not fix the growing suffix — turn 20
+  is structurally slower than turn 2. History compaction policy, tool-output
+  eviction (`capToolOutput` already exists for voice), and a per-turn prefix
+  growth budget. Cost S–M; deferred until rec #2 shows the actual growth rate.
+- **Delivery**: immutable-cache + brotli for the vendor bundle with an
+  explicit size budget (the stage pays 4.3–7MB of first-load fetches today);
+  and verify the host's deployment does not buffer the SSE stream — proxy
+  buffering on Vercel/nginx is a classic silent TTFT killer that no model-side
+  fix recovers. Cost S.
+
+### 1.1 Rec #1 benchmark methodology (what "CI assertion" means)
+
+The 4.4s path includes a live LLM call — nondeterministic, provider-variant,
+and costly, so it cannot be asserted in PR CI:
+
+- **PR CI** asserts only the deterministic server stages: baseline prepare,
+  hunk apply, validate + sucrase compile, on recorded fixtures, in ms with
+  generous thresholds (these are single-digit-ms today; the assertion exists
+  to catch algorithmic regressions, not noise).
+- **Model time** is proxied by **emitted-token count per op** on recorded
+  fixture conversations — a deterministic number that catches "the prompt
+  started making the model retype the file" without any live call.
+- **Live wall-clock** (the actual 4.4s-class number) runs in the existing
+  nightly corpus jobs (skateshop/umami fixtures), p50 over 5 runs, alerting
+  threshold p50 ≤ 8s. Never in PR CI.
+
+### 1.2 Rec #3 prerequisites: measure the prefix, and the provider matrix
+
+Before implementation, measure a real demo-bank conversation and report
+tokens per prefix segment — system prompt, component catalog, captured source
+(≤48KB ≈ ~12k tokens per repo-audit §1.3), DOM snapshot, tool schemas,
+history — and state the stable-per-host vs per-conversation vs per-turn
+fraction. The plausible total sits in the 15–50k range, where the cited TTFT
+curve predicts single-digit-to-modest cuts (§2), so the win size is unknown
+until measured. The cost win (0.1x cached reads) holds at any size.
+
+Caching is provider-specific and the repo is provider-agnostic
+(`@vendoai/server`, BYO-any-provider, PR #42):
+
+| Provider | Mechanism | Notes |
+|---|---|---|
+| Anthropic | explicit `cacheControl` breakpoints | writes 1.25x/2x; 5m/1h TTL |
+| OpenAI | automatic prefix caching | −90% cached input, 24h retention (2026-05-29); byte-level prefix drift invalidates |
+| Gemini | explicit caching, paid + TTL-based | different model entirely: storage billed per MTok-hour; implicit caching exists but is best-effort |
+
+The abstraction lives in the provider seam in `@vendoai/server`: the engine
+declares breakpoint *intents* (static / per-host / conversation) and each
+provider adapter maps them to its native mechanism or no-ops. Do not leak
+`cacheControl` into engine code.
+
+### 1.3 Rec #4: progressive render vs the guard layer
+
+Progressive render must not leak un-approved act-tier data — the approval flow
+is Vendo's core differentiator and outranks paint latency:
+
+- **Pure-read data may paint pre-approval.** Reads are never judged
+  (judge-policy tier "read" flows untouched), so read-tool results streaming
+  into partial props are safe to render immediately.
+- **Act-tier-bound content may NOT paint before its producing call is
+  allowed.** The skeleton may mount on component-name resolution, but any prop
+  fed by an act-tier tool renders a placeholder until the judge allows the
+  call and any mid-turn `ApprovalCard` resolves.
+- **Denial does not roll back paint.** On a mid-stream denial the placeholder
+  resolves to an explicit denied state ("not authorized") in place; read-fed
+  components already painted stay. No component silently disappears.
+
+### 1.4 Rec #5: derived data, validation, staleness
+
+Pure by-reference splicing removes the model's ability to reshape values —
+and the model reshapes constantly (reformatting, filtering, aggregating, unit
+conversion; the donut-cents bug is the standing proof that formatting at the
+bind seam is a live hazard). The contract:
+
+- **v1**: verbatim pass-through goes by reference; the model **may still
+  inline small derived values** (aggregates, formatted strings). Splicing is
+  mandatory only for arrays/objects above a size threshold, where the token
+  win lives.
+- **v2**: declarative server-evaluated transforms — A2UI-style formatters plus
+  a JSONata-class expression option (JSONata is already the automations DSL
+  precedent). Unit conversion is always an explicit formatter, never implicit.
+- **Bind-time shape validation**: every reference is validated against the
+  recorded tool-result shape at splice time; on mismatch, fall back to asking
+  the model to inline (one-turn repair, same shape as hunk-mismatch retry).
+- **Missing/stale reference**: render the component's placeholder and trigger
+  a refresh; never render silently stale data.
+
+### 1.5 Rec #6: fast-lane behavior per key configuration
+
+The locked OSS install model is zero-infra BYO-keys, "one key = core magic".
+The fast lane must be a **model choice within the host's existing key**, not a
+second-vendor requirement:
+
+- **Single Anthropic key (the default OSS install)**: fast lane = Haiku 4.5
+  via the same key. Still a real win: ~0.70s TTFT / ~114 tok/s and $1/$5 per
+  MTok vs Sonnet-class defaults — a 2k-token view.json emits in ~18s vs ~40s+
+  at typical Sonnet OTPS (exact ratio to be measured by rec #2).
+- **Single OpenAI key**: gpt-5-mini-class; **single Gemini key**: Gemini 3
+  Flash (~193 tok/s). Mind the Gemini structured-output gotchas already in
+  repo memory (numeric enums).
+- **Multi-key / speed enthusiasts**: opt-in `models.viewTier` override in
+  `vendo.config` can point at Cerebras/Groq/Fireworks (gpt-oss-120b on
+  Cerebras: ~3,000 tok/s **vendor-self-reported** — the corroboration is a
+  press-release echo site — and Cerebras access is enterprise/waitlist-gated
+  per inference.md, so this lane may simply not be available to a typical OSS
+  host). The host pays for whatever key they configure.
+- **Capability gate + fallback**: the fast lane engages only when the
+  configured provider supports strict structured outputs for the catalog
+  schema; otherwise the tier runs on the default model with validate-and-
+  repair (the existing `jsonRepairMiddleware` path). Unavailable fast model =
+  silent fallback to the default model, never an error.
+
+Caveats carried from the source reports: genui-sdks §6 cites a 2026 study
+showing constrained decoding on SMALL models can cost 3.6–8.2x latency and
+quality loss in the worst configurations; the "~50% faster" number is from
+self-hosted Guidance engines and hosted APIs are only neutral-to-positive
+(§5). So: an early corpus eval of Haiku/Flash-class models on real view.json
+prompts (rec #11) is a **prerequisite** before declaring this tier
+monogram-capable, and Cerebras/Groq constrained-decoding support is unverified.
+
+### 1.6 Rec #7: sandbox-safe mechanism and swap security policy
+
+The original "serve the bundle by cached URL" phrasing is **not jail-safe**:
+the stage iframe CSP is `connect-src 'none'` with `script-src` limited to a
+per-call nonce + `blob:` (`stage-host.ts:10,14,62`), precisely so generated
+code has no GET-request exfiltration channel. Loading the bundle by URL means
+adding an origin to `script-src` inside the sandbox realm — reopening the
+channel the F3a egress jail was locked to close. The per-realm cost is real
+(4,120,791-byte bundle structured-cloned + re-evaluated per iframe, verified
+at `apps/gmail/build/vendo/components-sandbox.js`); the fix must keep the CSP
+shut. Jail-safe options, in preference order:
+
+1. **Transfer the bundle as a transferable ArrayBuffer** over postMessage —
+   zero-copy, no clone, no CSP change; re-eval cost remains but the multi-MB
+   clone disappears.
+2. **One persistent stage realm per page** that evaluates the bundle once and
+   hosts hot-swapped views — the clone AND the re-eval are paid once.
+3. **Same-origin nonce'd `<script src>` pinned by hash** — only with an
+   explicit sandbox threat-model review; any `script-src` loosening requires
+   F3a-owner sign-off, full stop.
+
+Realm-reuse security policy (the F3a gates were validated for
+fresh-iframe-per-view; reuse changes the model and needs its own analysis):
+
+- **Swap scope v1: same module lineage only** (versions/edits of one module).
+  Two *different* modules never share a realm — state/secret bleed between
+  modules is otherwise unauditable.
+- **Teardown on swap**: unmount the React root, revoke prior blob URLs, clear
+  timers/intervals/listeners registered through the bridge, and evaluate the
+  incoming module in a fresh module scope. Globals the old module smuggled
+  onto `window` are the reason cross-lineage swaps are banned in v1.
+- **Re-validate under reuse**: the egress-jail CSP, host-component-as-data,
+  and the ready/init handshake assumptions (which currently assume a
+  fresh realm) must be re-run against the persistent-realm design before it
+  ships.
+
+### 1.7 Rec #8: concurrent-edit semantics
+
+Once the server-held base is repo HEAD and an applied op is a commit, two
+surfaces can race: two conversations, voice + text sessions, a conversation
+plus the zero-LLM direct-manipulation path (§4), or an automation touching a
+module. Policy:
+
+- **Per-module optimistic locking** via `baseHash` (git blob OID). A stale
+  hash **rejects the op and echoes the current lines** — the same one-turn
+  retry shape as a hunk mismatch, so the model (or the direct-manipulation
+  client) rebases itself in one round trip.
+- **Non-overlapping files auto-rebase**: if the racing commits touch disjoint
+  files, apply on top transparently.
+- **v2, only if racing surfaces become real in telemetry**: per-conversation
+  branches with merge-on-save. Not built speculatively.
+
+### 1.8 Rec #9: why there is no cross-call memo
+
+An earlier draft proposed memoizing the judge "across identical calls in a
+turn". Struck: the judge-policy docstring
+(`judge-policy.ts:44-59`) documents that the prior memo key
+(principal+thread+tool+input) was replaced with per-`toolCallId` memoization
+as a security fix, because a cached verdict could silently replay after the
+run's provenance had become tainted. Within-turn taint has the same shape — a
+read between two identical act-tier calls can poison provenance, and a
+cross-call memo would auto-approve the second call, violating the locked
+"guard on every tool call" invariant. Judge memoization scope is a security
+decision owned by ENG-193; speed recovers via the other two levers
+(prompt-cached judge prefix; judging call N while the model streams call N+1 —
+note the ai SDK invokes `needsApproval` at input-complete, which is already
+the earliest moment the final input exists, so the only real concurrency is
+across multiple calls in one step, not within one call's input stream).
+
+---
+
+## 2. The latency budget — where time goes today vs where it could go
+
+From the repo audit (HEAD `3c32f2ba`; the only measured numbers in the repo
+are first remix 32s→4.4s, pin edits ~6s, and the single `VENDO_BENCH` line in
+`edit-view-tool.ts:281`):
+
+### Today: a typical "show me X" render turn
+
+| Stage | Cost today | Why |
+|---|---|---|
+| First-turn tool ingestion (Composio + MCP `tools/list`) | multi-second (unmeasured range), first turn per user/process only | documented in-source (`engine.ts:629`); promise-cached after; a down MCP server re-adds its connect timeout every 30s (fix in §1 follow-ups) |
+| Per-step prefill, ×2–8 steps/turn | seconds of TTFT per step | zero prompt caching anywhere in packages/; prefix = system + up to 48KB source + DOM snapshot + history + all tool schemas |
+| Judge LLM call per act-tier tool call | ~0.3–1.5s/call UNVERIFIED, serial | `judge-policy.ts:249-279`, memoized only within one call's approve/execute pair |
+| Tool execution (host API + Composio/MCP round-trips) | **unmeasured — no timing exists**; serialized behind the judge, and independent calls in a step run sequentially today | in every act-tier turn's critical path; rec #2 seam |
+| Model emission of the full `render_view` payload | **tens of seconds; 90%+ of TTFR** | nothing paints until the last token: tree + tool data re-typed verbatim + up to 16×64KB component source; only a skeleton chip during input-streaming |
+| Server validate + sucrase compile + hunk apply | single-digit ms | NOT a bottleneck; the bench hook exists to prove it |
+| Fresh iframe per view AND per edit | ~100–500ms+ UNVERIFIED | multi-MB srcdoc parse, 4.1MB bundle structured-cloned + re-evaluated per realm, ready/init handshakes; first stage on a page also pays ~4.3–7MB of fetches with 3 serial env RTTs |
+
+### Target: where each millisecond could go
+
+| Stage | Attainable | Mechanism (report) |
+|---|---|---|
+| Prefill/TTFT per step | TTFT cut ~4% at 20k tokens rising to ~52% at 160k (UNVERIFIED single-Medium-source curve); OpenAI measured 67% at 150k+. Our 15–50k-range prefix (§1.2) predicts single-digit-to-modest TTFT cuts until measured. Cost cut (0.1x cached reads) is unconditional; marginal turn cost ≈ output tokens only at large prefixes | prompt caching (inference §5) |
+| view.json first paint | ~1s | fast small model + partial-tree streaming; structured outputs for skeleton-safety (inference §6, genui-sdks §7–8) |
+| view.json full tree (2k tokens) | ~18s at Haiku ~114 tok/s; <1s at ~3,000 tok/s (Cerebras, vendor-self-reported, waitlist-gated) | provider fast lane (inference §2) |
+| Edit turn, any tier | 4.4s-class | hunks; already proven in-repo, currently regressed for OSS (editloop §1) |
+| Tool execution per act-tier call | judge overlapped with streaming (§1.8) + independent calls executed in parallel (AI SDK supports parallel calls; the guard serializes today). Speculative read-tool prefetch for predictable intents = candidate lever, unevaluated — keep on the list even if rejected | rec #9 |
+| Tier-2 bundle | ≤50ms edit / ≤150ms cold | server-side native esbuild, persistent rebuild contexts, shared vendor bundle (runtime §Tier 2); esbuild-wasm is ~10x slower, never in-browser |
+| Iframe render | tens of ms warm (UNVERIFIED estimate; instrument via rec #2) | persistent stage + hot swap (repo-audit §2, runtime §Tier 2) |
+| Tier-3 re-open | 5–150ms snapshot restore; E2B pause/resume same order as its ~150ms create per third-party benchmarks (exact resume latency unmeasured — verify before committing a re-open budget; the ~1.5s resume figure belongs to CodeSandbox) | warm snapshot per version; boot ladder: isolate ~5ms → snapshot restore 3–30ms → microVM boot <125ms → container 1–3s → Nixpacks build ~90s (runtime table) |
+| Tier-3 first generation | ≤1.5s to the tier-1 placeholder (rec #10), ≤120s wall to the live module behind progress UI — async, never blocking the conversation | build async at publish; reasoning TTFT (GPT-5.5 high ~29.8s) + build dominate (inference §8) |
+
+### 2.1 Composite per-tier SLOs — what "done" means
+
+Per-stage numbers don't define success; these composites do. All budgets are
+**user-send → first paint / → interactive**, measured on the demo-bank
+fixture conversation on the nightly corpus runner (same environment as the
+Layer-3 live jobs), default single Anthropic key. p50 and p95 over ≥5 runs.
+Every number elsewhere in this doc is best-case unless marked otherwise; these
+are the binding ones.
+
+| Tier / turn type | p50 first paint | p50 interactive | p95 first paint | p95 interactive |
+|---|---|---|---|---|
+| Tier 1, first render | ≤1.5s | ≤3.5s (full tree) | ≤4s | ≤8s |
+| Tier 1, edit | ≤1.5s (patch applied) | ≤1.5s | ≤5s (includes one hunk retry) | ≤5s |
+| Tier 2, first render | ≤1.5s (tier-1 approximation) | ≤10s (live module) | ≤4s | ≤20s |
+| Tier 2, edit | ≤5s | ≤5s | ≤10s | ≤10s |
+| Tier 3, first generation | ≤1.5s (placeholder) | ≤120s wall, progress UI | ≤4s | ≤180s |
+| Tier 3, re-open | ≤1s | ≤1s | ≤3s | ≤3s |
+
+Sub-budget composition for the headline cell (tier-1 first render, p50 ≤1.5s
+to first paint): prefill/TTFT ≤0.8s + first-node emission ≤0.3s + parse/mount
+≤0.2s + slack 0.2s. Rec #2's instrumentation is judged against this table;
+"monogram-feel" and "instant tier 1" mean these numbers and nothing else.
+
+### 2.2 Cost to the host — rough per-turn/per-module dollars
+
+BYO-keys means the HOST pays every recommendation's inference and infra cost;
+"cost" in the §1 table is engineering cost only. Rough modeling (assumption:
+host-borne inference cost is acceptable up to ~$0.10 p50 per chat-class turn;
+anything projected above that gets flagged in its rec):
+
+- **Prompt caching (rec #3)**: cache writes cost 1.25x/2x on first write;
+  break-even after ~1–2 cached reads, then strictly cheaper. Gemini explicit
+  caching adds storage billed per MTok-hour — size the TTL to conversation
+  length or it costs more than it saves.
+- **Judge (rec #9)**: one small-model call per act-tier tool ≈ $0.001–0.01;
+  a 3-call turn adds ≈ $0.01–0.03.
+- **Fast lane (rec #6)**: Haiku $1/$5 per MTok — a tier-1 turn lands ≈
+  $0.01–0.03 vs $0.05–0.15 on Sonnet-class. The fast lane is a cost cut, not
+  a cost add.
+- **Tier-3 snapshots (rec #10)**: E2B warm-snapshot storage + resume pricing
+  UNVERIFIED — obtain pricing before GA; per-module-version storage grows
+  unbounded without an eviction policy.
+- **Self-test loops (§9)**: Replit's median $0.20/session is the reference
+  ceiling for a tier-3 verify pass.
+
+### 2.3 Tail latency and failure rates — the missing half of the budget
+
+Every number above is a success-path number. Known failure paths, none with a
+measured rate (rec #2 must capture all three):
+
+| Failure | Cost today | Mitigation |
+|---|---|---|
+| render_view JSON breakage | **400s the whole turn** (repo memory: tool-input JSON repair; app-level middleware exists, not in runtime) | rec #12 promotes repair into the runtime, in-stream |
+| Hunk mismatch | one full extra turn: 4.4s becomes ~9s+ (mismatches echo actual lines for a one-turn retry) | rec #1's nightly bench tracks retry rate; §1.7 keeps conflict retries to one round trip |
+| Fast-lane validation failure (rec #6) | user pays fast-model time PLUS full frontier time | escalation rate is the eval-gate metric (rec #11); if >~10% the fast lane is a net loss and stays off |
+
+Until these rates are measured, no p95 in §2.1 can be claimed as met — the
+p95 columns exist precisely to force the failure paths into the measurement.
+
+The unifying rule from the runtime report: move every non-generation cost off
+the conversational path via content-addressed caches (bundle hash,
+snapshot-per-module-version) so the LLM token stream is the only thing the
+user ever waits on. And the unifying rule from the edit-loop report: the
+32s→4.4s win came from moving work, not speeding inference; the model types
+only what changed.
+
+---
+
+## 3. Monogram — the benchmark and the collision course
+
+Source: `apps-speed/monogram.md` (launch blog, Ashby job board, PitchBook/Yahoo
+interview, HN 48835018, Product Hunt; app is 10 days old, iOS-26-only).
+
+- Out of stealth 2026-07-07, $40M seed (DST + Lux); founders Eren Bali
+  (Udemy/Carbon Health), ex-Airbnb VP Product AI, ex-Carbon Health VP Eng.
+- Claim: **~1.5s average to a full interactive UI** via a "parallel processing
+  architecture", on OpenAI models plus experimental open-source versions;
+  admits it costs more compute than chat. Founder claim, no third-party
+  measurement exists yet.
+- Stack (VERIFIED from job postings): server-driven NATIVE UI. Swift/SwiftUI/
+  UIKit + WebSockets + gRPC; designers craft "building blocks"; a dedicated
+  "core UI generation model" plus an eval platform doing "automated UI
+  variation scoring". No web tech, no codegen, no sandbox anywhere: this is a
+  tier-1 view.json analog with zero sandbox tax, and nothing resembling our
+  tier 2/3 appears in the hot path.
+- Follow-ups use a two-path design (Bali on PH): "edit UI components" or
+  "regenerate a whole new interface", independently converging on edit_view.
+- Founder on HN: 9 months, 3-person team as of Nov 2025, "most of the work...
+  was to build the infrastructure... especially to make it fast". Speed came
+  from infra, not a bigger model.
+- They plan to open the architecture to developers, a future direct collision
+  with our embedded-agent market. Today: no module concept, no permission
+  layer, no persistence/git model.
+- Most copyable idea: the **UI-variation eval loop**. Automated scoring over
+  generated variants is their training/selection lever; a measurable quality
+  loop over view.json variants would let us push a smaller/faster model at
+  tier 1 without quality regression (now rec #11, on the existing
+  corpus/nightly jobs).
+- Honest gaps: wire protocol, constrained decoding, fine-tuning, prefetch,
+  edit latency, layout determinism all UNVERIFIED. Beware unrelated
+  monogram.io polluting search.
+
+Read: their 1.5s is what our tier 1 can be. Nothing they've shown threatens
+tiers 2/3; everything argues we should make tier 1 feel instant first.
+
+### 3.1 GigaCatalyst — the actual closest competitor (coverage gap)
+
+GigaCatalyst (YC P26) is recorded elsewhere as Vendo's closest direct
+competitor — the other "agent your product ships with" play — and was NOT in
+this sweep's teardown set; the omission is a coverage gap, not a judgment. No
+public latency data, no published architecture, feature surface UNVERIFIED as
+of 2026-07-10. Nothing observed in their public positioning contradicts the
+tier-ladder plan, but this doc cannot claim the top-12 matches or beats them.
+Action: add a GigaCatalyst teardown to the next competitive sweep; until then
+monogram is the speed benchmark and GigaCatalyst is the positioning benchmark.
+
+## 4. Product teardowns — what makes tools feel fast
+
+Source: `apps-speed/products.md` (v0, Bolt.new, Lovable, Claude Artifacts,
+ChatGPT Canvas).
+
+- **In-stream error repair (v0)** is the strongest actual-speed idea: a custom
+  small AutoFix model (`vercel-autofixer-01`; 8,130 chars/sec and 86%
+  error-free standalone are **Vercel self-reported / Fireworks co-marketing,
+  UNVERIFIED** per capability.md) corrects the frontier stream while it
+  streams, eliminating visible retries. Generalizes directly from our
+  render_view JSON-repair middleware (now rec #12).
+- **Bolt's speed is structural**: WebContainers run Node in-browser (zero
+  sandbox round-trip), a streaming boltAction parser writes files and starts
+  the dev server before generation finishes, CDN-cached pre-compressed npm
+  layers make install <500ms. The preview is live while the model still types.
+  Our analog: boot/warm the runtime on first streamed file, not on completion
+  (expected win UNQUANTIFIED — on the order of the sandbox create/boot time it
+  hides, ~150ms–3s depending on rung; measure via rec #2 before building).
+- **Everyone converged on a surgical edit protocol** because the second-turn
+  edit is where tools feel fast or slow: Claude Artifacts `update`
+  string-replace (Oct 2025, 3–4x), Canvas generated regexes, v0 QuickEdit.
+  This validates edit_view hunks as the industry pattern.
+- **Zero-LLM edit path** for styling/text nits: v0 Design Mode (live style
+  panel, zero credits) and Lovable Visual Edits (in-browser AST via Babel/SWC,
+  Vite-plugin JSX-element IDs, optimistic client-side Tailwind generation).
+  Direct manipulation persisted back to source is the cheapest perceived-speed
+  win available (latency UNQUANTIFIED in the reports; client-side, so
+  plausibly sub-100ms perceived); for us it extends remix machinery to
+  token-level theme edits, and inherits §1.7's conflict policy.
+- **A rigid skeleton is a speed feature** (Lovable): one identical
+  vite_react_shadcn_ts + Supabase stack for every app means no boilerplate
+  tokens and no infra decisions; 60–90s to first working version. Argues for
+  per-tier module templates/scaffolds.
+- **First-meaningful-render reality (2025 head-to-heads)**: v0 ~30s for
+  components; Bolt "seconds" to live preview / ~20min full app; Lovable
+  ~60–90s first version / ~35min polished; Artifacts ≈ single-file stream time
+  into a client-side sandboxed iframe (the same shape as our tier 2).
+- **Perceived-speed hygiene shared by all five**: never a blank screen (code
+  streams from t=0), legible progress (file/step checklists beat spinners),
+  visible diffs beat full re-streams, context compression keeps later turns as
+  fast as the first (our context-growth follow-up, §1).
+
+## 5. Gen-UI SDKs and protocols — how to stream a UI tree
+
+Source: `apps-speed/genui-sdks.md` (Thesys C1, Vercel AI SDK, assistant-ui,
+CopilotKit, Google A2UI, constrained-decoding literature).
+
+- **Constrained decoding: split the claim by where inference runs.** The
+  latency WIN is local-inference-only: JSONSchemaBench (2025) measured
+  Guidance at 6.4–9.5ms/token vs 15–16ms unconstrained (~50% faster) because
+  the grammar engine fast-forwards forced tokens — a mechanism hosted APIs do
+  not expose to callers. On hosted Anthropic/OpenAI structured outputs the
+  effect is **neutral-to-positive at best** (historically hosted structured
+  modes add overhead), so on the BYO-provider seam constrained decoding is a
+  **correctness + skeleton-safety lever** (streamed prefixes can't hallucinate
+  component names, making rec #4's speculative mounts rollback-safe), NOT a
+  throughput lever. The ms/token speedup applies only if/when running open
+  models on controlled infra (the Cerebras/Fireworks lane). Also: a 2026 study
+  (genui-sdks §6) found constrained decoding on SMALL models can cost 3.6–8.2x
+  latency with quality loss in bad configurations — carried into rec #6 as a
+  gate. Quality fears for well-configured setups were rebutted (dottxt "Say
+  What You Mean", 2024-11; 3–4pt task-quality GAINS in JSONSchemaBench). Real
+  hosted cost: first-request schema compile (OpenAI <10s typical, up to 60s;
+  then cached; Anthropic structured outputs GA with modest init overhead).
+  Consequence: ONE stable per-host catalog schema, pre-warmed at publish time,
+  never per-module dynamic schemas on the hot path.
+- **The 2026 protocol consensus is flat, not nested**: Google A2UI
+  (open-sourced Jan 2026, v0.9 Apr 2026) streams a FLAT ID-referenced
+  component list as JSONL: progressive render without any partial-JSON parser,
+  incremental component-level updates (protocol-level analog of edit_view
+  hunks), and LLMs generate adjacency lists more reliably than nested trees.
+  view.json is a nested tree, so flat encoding would be the single biggest
+  protocol change available — **decision made in §10: deferred with an
+  explicit revisit trigger**, because it breaks the view.json contract across
+  renderer, prompt catalog, corpus fixtures, persisted modules, and remix
+  baselines.
+- **AI SDK's default partial-JSON path is O(n²)** over the stream; the O(n)
+  fix (PR #1883, >100x) was rejected in 2024, and third-party benches still
+  show ~6s parse time at 100KB payloads — though it is UNVERIFIED whether AI
+  SDK 5/6 has since fixed this internally (a 10-minute bench of the current
+  version settles it; do that before building rec #4's parser). At
+  module-sized specs use an O(n) incremental parser (jsonriver, fn-stream,
+  vectorjson) + render throttling.
+- **Streaming React components lost; streaming data won**: AI SDK RSC/streamUI
+  is officially experimental, "not recommended for production". Every
+  surviving SDK (Thesys, assistant-ui, CopilotKit, A2UI) renders a declarative
+  spec against a client-owned catalog. Direct validation of the view.json
+  tier.
+- **Skeleton-on-tool-name / speculative hydration** is the perceived-latency
+  killer: mount a placeholder the instant the component/tool name resolves
+  mid-stream, fill props as partial args arrive (assistant-ui ships this;
+  vercel/ai#13469 calls it "zero-latency generative UI"). Structured outputs
+  make it rollback-safe: streamed prefixes can't hallucinate invalid names.
+- **Schema key ORDER is render choreography** (CopilotKit OpenGenerativeUI):
+  LLMs emit keys in schema order, so put identity/anchor/size/skeleton fields
+  first and heavy children last in the module envelope and view.json schema.
+- **Thesys C1** (closest commercial analog) is tier-1-as-an-API: a compact
+  JSX-like DSL rendered progressively via an `isStreaming` prop. Its levers
+  are token-cheap encoding + partial-spec re-render, nothing exotic. Token
+  count is the dominant wall-clock term; encoding compactness beats parser
+  cleverness.
+
+## 6. Inference — providers, caching, routing
+
+Source: `apps-speed/inference.md`.
+
+- **The tier ladder IS the router**: view.json → Haiku 4.5 (~114 tok/s, 0.70s
+  TTFT, $1/$5) / Gemini 3 Flash (~193 tok/s, 0.66s TTFT) / gpt-oss-120b on
+  Cerebras (~3,000 tok/s **vendor-self-reported** from Cerebras' own blog —
+  the "corroboration" is a press-release echo site — with full 128k, and
+  capacity is enterprise/waitlist-gated, so treat as an opt-in enthusiast lane,
+  not the default); index.tsx → fast coding model (gpt-oss-120b / Qwen3-Coder
+  on Cerebras/Groq/Fireworks, or Sonnet for quality); tier 3 → frontier +
+  progress UI. Deterministic escalation on validation failure = a cascade
+  router with a verifier, no learned classifier. RouteLLM-style 40–85% cost
+  cuts come free from the structure.
+- **Prompt caching is the cost lever, and the TTFT lever at large prefixes**:
+  Anthropic reads 0.1x input (write 1.25x/2x), OpenAI −90% cached input with
+  24h default retention since 2026-05-29 and measured 67% faster TTFT at 150k+
+  tokens; the TTFT curve at our prefix sizes is modest (§2 target table).
+  Structure the prefix as [static system + catalog] → [per-host manifest] →
+  [conversation] with breakpoints; watch invalidation triggers (manifest
+  bumps, Anthropic speed-mode switches, byte-level drift on OpenAI). Provider
+  matrix and seam placement in §1.2.
+- **Anthropic fast mode** (Feb 2026 research preview): up to 2.5x OTPS on Opus
+  4.8/4.7 at premium pricing ($10/$50 per MTok on 4.8), OTPS only (NOT TTFT),
+  and fast/standard do NOT share cache prefixes. Niche fit: tier-3 interactive
+  first-generation only, whole-session or not at all.
+- **Reasoning modes are the TTFT killer**: GPT-5.5 high ~29.8s TTFT vs 0.34s
+  for Gemini 2.5 Flash-Lite. Interactive module paths use non-reasoning or
+  minimal-effort settings, always with streaming progressive render.
+- **Speculative decoding / Predicted Outputs** (EAGLE-3/3.1 4–5x on coding;
+  OpenAI Predicted Outputs 3–5x on rewrites) are strictly dominated by our
+  hunk protocol, which doesn't emit unchanged tokens at all. Use them only as
+  the big-rewrite fallback lane.
+- Latency arithmetic to keep in mind: a 4,000-token index.tsx ≈ 67s at 60
+  tok/s, ≈ 8–10s at 400–500 tok/s, ≈ <2s as a 300-token diff at any provider.
+  Output-length reduction is the highest-leverage, provider-independent win.
+
+## 7. Runtime — the sandbox latency ladder
+
+Source: `apps-speed/runtime.md`.
+
+- **The ladder is ~an order of magnitude per rung**: V8 isolate ~5ms →
+  Firecracker snapshot restore 3–30ms (managed: Daytona ~90ms, E2B ~150ms,
+  Modal sub-second) → microVM boot <125–400ms → container platform 1–3s →
+  Nixpacks image build ~90s (Railway's own data: ~1m27s vs 15s Dockerfile vs
+  6s prebuilt; Railway is abandoning Nixpacks for Railpack over unpredictable
+  caching, worth tracking).
+- **Tier 2 bundles server-side with native esbuild** (module-sized inputs are
+  single-digit-to-tens of ms with persistent rebuild contexts); esbuild-wasm
+  is officially ~10x slower, never in-browser. Shared long-cached react/vendor
+  bundle keeps per-module bundles KB-sized. Budget: ≤150ms cold, ≤50ms edit.
+- **Tier 2.5 (proposed) V8 isolates** for JS-only server logic: Cloudflare
+  Dynamic Workers (open beta 2026-04, $0.002/unique-worker-day) instantiate
+  isolates from dynamically supplied code, exactly the mid-conversation shape;
+  self-hosted `workerd` is the OSS-friendly equivalent. Tier 3's
+  Python/bash/anything cannot run there; this is an optional escape hatch.
+- **Tier 3: snapshot-restore, not boot, is the operative number.** Build async
+  at publish/save time, snapshot after first successful boot, key the snapshot
+  on the envelope's `version`. Any module edit invalidates the snapshot (Fly's
+  deploy caveat generalizes), so edit turns hot-swap interpreted files inside
+  the snapshotted environment and only re-run Nixpacks on dependency changes:
+  the tier-3 analog of remix fast-edits.
+- **Warm-pool economics favor buy over build**: pre-boot pool → snapshot →
+  restore-per-request is exactly E2B/Daytona's business; self-hosting
+  Firecracker pools is a predictive-autoscaling + idle-cost problem Vendo OSS
+  shouldn't own. Avoid 25ms nsjail-class providers whose speed comes from a
+  weaker isolation boundary.
+
+## 8. Edit loop — the in-repo precedent and its generalization
+
+Source: `apps-speed/editloop.md`.
+
+- **The 32s→4.4s win moved work, it didn't speed inference**: the model emits
+  only line hunks against a server-held hash-pinned baseline
+  (`edit-view-tool.ts`, `remix/hunks.ts`, `remix/baseline.ts`);
+  coordinate-mode addressing skips quoting old text; single-line JSON strings
+  structurally kill the control-char truncation bug; mismatches echo actual
+  lines for one-turn retries; prepared baselines move the mechanical glue to
+  build time.
+- **The hunk/baseline core generalizes mechanically; the rest does not**:
+  per-file `baseHash` can literally be the git blob OID, the server-held base
+  is repo HEAD, an applied op is a commit (provenance envelope → commit
+  metadata), and prepared baselines become (a) deterministic build-time
+  scaffold prep and (b) retrieval of accepted modules as edit bases so first
+  generation is itself an edit. That transplant plus
+  `addFile`/`deleteFile`/`renameFile` ops is rec #8's M. Explicitly NOT a
+  transplant (the L-class follow-up): cross-file import/typecheck gates
+  (generated view components are deliberately isolated blob modules today —
+  real multi-file imports are new machinery), per-file + per-repo size
+  budgets, and the "patched → building → swapped" progression for tier 3's
+  async build. Concurrent-edit conflict policy in §1.7.
+- **Cursor's objection to diffs (models botch line numbers) does not apply**:
+  the server, not the model, resolves coordinates against a hash-gated base.
+  Our hunks are strictly cheaper than aider search/replace blocks, and aider's
+  evidence says edit format is a per-model tuning knob anyway (keep the
+  coordinate vs exact-match dial).
+- **Fast-apply models are a shrinking window** (June 2025: Morph and Relace
+  founders both conceding "maybe six months" before frontier models master
+  structured edits natively; Morph v3-fast 10,500 tok/s ~96–98% $0.80/M,
+  Relace Apply 3 10k tok/s used by Lovable/Codebuff/Tempo). Slot
+  Morph/Relace/Predicted-Outputs behind ONE optional materializer seam for big
+  rewrites only, never a hard dependency. edit_view already IS the predicted
+  end-state architecture (frontier emits structured edits + deterministic
+  server apply, no silent merges).
+- **Per-file regen vs whole-repo is settled**: specify as hunks, materialize
+  per file, rebuild only touched files/layers; full-file regen is a fallback
+  for small files (<~400 lines per Cursor) after two hunk failures; whole-repo
+  regen only on explicit start-over.
+- **Lesson from the live regression**: speed wins regress silently. Put
+  `VENDO_BENCH`-class timings under benchmark assertions (rec #1, methodology
+  §1.1).
+
+## 9. Capability — what turns "generates UI" into "ships features"
+
+Source: `apps-speed/capability.md`.
+
+- **Self-healing is the leaders' #1 capability lever, and it's tiered**: v0
+  layers mid-stream deterministic fixes (~100–250ms, icon-swap via embedding
+  search in ~100ms) plus a fine-tuned autofix model (93.87% error-free
+  generation — **Vercel self-reported, UNVERIFIED** per capability.md);
+  Lovable's agent loop cut build errors 90% (self-reported); Replit Agent 3
+  runs a browser self-test subagent at a median $0.20/session. Maps directly
+  onto our split: tier-1 schema-repair (rec #12's in-stream ladder; structured
+  outputs are the upstream fix) → tier-2 bundle-error autofix loop in the
+  sandbox → tier-3 sandbox self-test subagent on warm snapshots.
+- **Fail-closed catalog verification separates demos from shipping**: v0
+  Design Systems 2.0's rule is "if a component, prop, or token cannot be
+  verified from the sources, do not use it", every generation starting from a
+  pre-reviewed starter app. Our zod descriptors make the same enforcement
+  cheap at view-tree validation time; per-host starter scaffolds do it for
+  tier 2/3 (correct-by-construction providers/theme/fonts).
+- **Live data = path binding, not snapshots**: A2UI v0.9 binds components to
+  JSON-Pointer paths and patches via `dataModelUpdate` without regenerating
+  UI. Our 60s reads-only refresh is the v1; declarative binds are the
+  standard-shaped v2 and inherit the guard layer for free. (Pairs with rec #5:
+  data-by-reference at generation time and at refresh time are one design —
+  including §1.4's transform/validation/staleness contract.)
+- **Generation memory is a proven 50–80% head start** (Lovable
+  remix/templates, v0 RAG + curated samples): retrieve a prior known-good
+  module and edit it. Our git-repo modules + 4.4s remix fast-edits make
+  retrieval-into-remix nearly free: embed shipped modules per host, retrieve
+  top-k for similar intent, hand the best as the edit base. Retrieved modules
+  already passed the guard layer and bind to real host tools, so it's a
+  quality win too.
+- **Descriptor ergonomics compound**: flat adjacency lists as generation
+  targets, per-component when-to-use/anti-pattern/display-mode guidance
+  (OpenAI Apps SDK enforces inline-card max-2-actions taxonomies and "the tool
+  response contains everything the widget needs"), catalog shipped as a
+  registry-like payload. Cheap upgrades to our one-line prompt-catalog lines.
+- **Google's A2UI-vs-MCP-Apps split independently validates the tier-1/tier-2
+  architecture** (published 2026-06-17): declarative catalog UI for structured
+  data, sandboxed iframes for state-intensive custom modules, official hybrid
+  patterns.
+- **UI eval SOTA**: deterministic gates + screenshot MLLM-judge with per-task
+  checklists scored pairwise (ArtifactsBench: 94.4% ranking consistency with
+  WebDev Arena), but WebDevJudge shows LLM judges cannot verify functional
+  correctness; that still requires execution, i.e. the self-test loop. This is
+  rec #11, wired as a module-quality layer on the existing nightly corpus
+  jobs; it doubles as the monogram-style variation-scoring loop that lets a
+  smaller tier-1 model hold quality — and it gates rec #6's model swap.
+
+---
+
+## 10. What we deliberately do NOT do (or defer, with triggers)
+
+| Rejected / deferred | Why |
+|---|---|
+| **In-browser bundling (esbuild-wasm / WebContainers)** | esbuild-wasm is officially ~10x slower than native; WebContainers are proprietary, heavyweight, and tier 3 exists precisely so server code runs server-side. Server-side native esbuild is ms-class already (runtime §Tier 2). |
+| **A standalone fast-apply model dependency (Morph/Relace) in the core path** | Two-model pipelines fail silently; both vendors' founders concede a ~6-month viability window as frontier models master structured edits. Optional materializer seam only (editloop §2.5). |
+| **Self-hosted Firecracker warm pools** | Predictive autoscaling + idle-cost is E2B/Daytona's whole business; Vendo OSS shouldn't own it. Buy, don't build (runtime §warm pools). |
+| **nsjail-class "25ms" sandbox providers** | The speed comes from a weaker isolation boundary; unacceptable for untrusted AI-generated code (runtime table). |
+| **Streaming React components (AI SDK RSC/streamUI)** | Officially experimental, "not recommended for production"; the industry settled on streaming declarative data against a client catalog, which is what view.json already is (genui-sdks §2). |
+| **Per-module / per-request dynamic JSON schemas** | Every novel schema re-pays the grammar-compile penalty (up to 60s on OpenAI). One stable pre-warmed per-host catalog schema (genui-sdks §6, inference §7). |
+| **Anthropic fast mode as a general speed lever** | Opus-only, premium ($10/$50), improves OTPS not TTFT, and splits the prompt cache between speed modes. Tier-3 interactive first-gen only, if at all (inference §3). |
+| **Reasoning models on interactive paths** | ~29.8s TTFT (GPT-5.5 high) is disqualifying; reserve deep thinking for tier-3 planning behind progress UI (inference §8). |
+| **Nixpacks builds anywhere near the conversational path** | ~90s average vs a ~5s feel budget is fatal; async at publish/save, warm snapshot as the cache (runtime §Tier 3). |
+| **Whole-repo regeneration as an edit path** | No production system does it; hunks → per-file materialization → touched-file rebuild; whole-repo only on explicit start-over (editloop §2.6). |
+| **Building on AI SDK's default partial-JSON parser for module-sized specs** | O(n²) re-parsing, ~6s at 100KB in third-party benches — though UNVERIFIED whether AI SDK 5/6 has since fixed it internally; bench the current version (10 minutes) before choosing a parser. Default plan: an O(n) incremental parser (genui-sdks §2, §7). |
+| **A learned routing classifier** | The tier ladder plus deterministic validation-failure escalation already is the router; RouteLLM-class savings without the ML (inference §6). |
+| **Flat view.json v2 (A2UI-style JSONL encoding) — DEFERRED, with a trigger** | The single biggest protocol change available (§5), but it breaks the view.json contract everywhere at once: shell/stage renderer, prompt-catalog lines, 10+ corpus repos of pass@2 fixtures, persisted modules in `@vendoai/store`, and the remix baseline format. Migration would need a dual-decode window + full corpus regeneration (L-class). Revisit trigger: if rec #4's O(n) parser + schema key-order still misses the §2.1 tier-1 first-paint p50 (≤1.5s), flat encoding is the next lever and gets a costed spec. |
+| **Fine-tuning / distilling a dedicated tier-1 generation model — DEFERRED, with a trigger** | Monogram's "core UI generation model" and v0's RFT-trained autofixer show the ceiling, but training before an eval loop exists is uncheckable. Deferred until rec #11 is live and the prompt-level levers (recs #4–6) are exhausted. Revisit trigger: a Haiku/Flash-class model fails rec #11's quality gate at the §2.1 latency targets — then distillation is the remaining move. |
+| **Copying monogram's native-renderer bet wholesale** | Their zero-sandbox speed applies only to catalog UI; giving up tiers 2/3 would surrender the capability moat that is our actual differentiation vs a $40M-funded speed play (monogram §4). |
+| **LLM judges as functional verifiers** | WebDevJudge: judges can't verify working-app correctness; ranking/regression only. Functional claims require execution (capability §6). |
+
+---
+
+## Appendix: source reports
+
+- `apps-speed/monogram.md` — monogram.ai teardown (scratchpad, 2026-07-10)
+- `apps-speed/products.md` — v0/Bolt/Lovable/Artifacts/Canvas teardown
+- `apps-speed/genui-sdks.md` — gen-UI SDK + protocol survey
+- `apps-speed/inference.md` — inference SOTA
+- `apps-speed/runtime.md` — sandbox/runtime latency spectrum
+- `apps-speed/editloop.md` — edit-turnaround SOTA + in-repo precedent
+- `apps-speed/repo-audit.md` — where time goes at HEAD `3c32f2ba`
+- `apps-speed/capability.md` — capability levers
+- `docs/specs/research-2026-07-module-speed.md` (2026-07-10, solo survey)
+- `docs/specs/research-2026-07-framework-landscape.md` (protocol/SDK facts)
+
+Note: the scratchpad reports are session-local; if this doc is the only
+artifact that survives, every load-bearing claim above carries enough of its
+original source citation to re-verify.

--- a/docs/specs/research-2026-07-framework-landscape.md
+++ b/docs/specs/research-2026-07-framework-landscape.md
@@ -1,0 +1,457 @@
+# Agent-Framework Landscape Research — July 2026
+
+Reference doc for the @vendoai/core re-architecture: framework-neutral tool/module
+contracts that integrate with (or duck-type as) each major framework's types.
+
+Researched 2026-07-09. Version claims were checked against the npm registry, the
+vercel/ai and openai/openai-agents-js sources at exact tags, and official spec repos —
+not training-data memory. Our repo pins `ai@6.0.28` + `@ai-sdk/provider@3.0.2` +
+`@standard-schema/spec@^1.1.0` (`packages/vendo-core/package.json`).
+
+## TL;DR — the facts that change our design
+
+1. **A plain object literal IS a valid Vercel AI SDK tool.** `tool()` is literally
+   `function tool(tool: any): any { return tool; }` in both v6.0.28 and v7.0.19
+   (verified from source). Our neutral tool objects can duck-type with zero imports.
+2. **AI SDK 7 shipped 2026-06-25 and is npm `latest` (7.0.19).** v6 is still actively
+   maintained on the `ai-v6` dist-tag (6.0.222 published 2026-07-09). Major cadence is
+   ~6–7 months: v4 2024-11-18, v5 2025-07-31, v6 2025-12-22, v7 2026-06-25.
+3. **Two zero-import schema paths exist for our neutral contracts:** (a) implement
+   Standard Schema `~standard` (validate + the new `jsonSchema` converter from spec
+   v1.1.0) — accepted by AI SDK, Mastra, and convertible everywhere; (b) the AI SDK's
+   own `Schema` marker uses `Symbol.for('vercel.ai.schema')` — a *global* symbol
+   registry, so third parties can construct a valid Schema without importing
+   `@ai-sdk/provider-utils`.
+4. **Raw JSON Schema works everywhere on our converter path:** AI SDK via
+   `jsonSchema()`/symbol-marked object; OpenAI Agents SDK accepts JSON Schema
+   `parameters` directly (parsed but not validated — we'd own validation); MCP tools
+   are JSON Schema natively; Mastra accepts Standard-JSON-Schema-capable schemas.
+5. **v7 deprecates per-tool `needsApproval`** (moves approval to
+   `generateText`/`streamText`-level `toolApproval`) and renames tool-execute
+   `experimental_context` → typed `context` via `contextSchema`. Our v6-shaped neutral
+   tools remain valid in v7 (deprecated aliases retained), but the approval seam should
+   not hard-couple to `needsApproval`.
+6. **MCP Apps is real, ratified (Stable, 2026-01-26), and exactly the protocol we
+   sketched:** extension id `io.modelcontextprotocol/ui`, predeclared `ui://` resources
+   with `text/html;profile=mcp-app`, tools linked via `_meta.ui.resourceUri`,
+   iframe↔host = MCP JSON-RPC over postMessage (`ui/initialize` handshake,
+   `tools/call` from the UI, `ui/notifications/tool-result`, `ui/message`,
+   `ui/update-model-context`), mandatory sandbox + host-constructed CSP, double-iframe
+   sandbox proxy required for web hosts. Live in Claude (web+desktop), ChatGPT,
+   VS Code Insiders, Goose.
+7. **AI SDK 7 ships first-party MCP Apps client support** (`@ai-sdk/mcp` helpers +
+   `experimental_MCPAppRenderer` in `@ai-sdk/react`) — building our module↔host UI
+   protocol on MCP Apps means AI SDK hosts can render our modules with stock tooling.
+8. **OpenAI Agents SDK JS is still 0.x** (0.13.1, 2026-07-09) with fast, breaking-ish
+   cadence, but its HITL model (`interruptions` + serializable `RunState`) and JSON
+   Schema tool path are stable enough to target via a converter.
+9. **Mastra 1.50.1 straddles AI SDK v5/v6/v7 simultaneously** (bundles all three
+   provider lines via npm aliases) and accepts any Standard-Schema library for
+   `createTool` — our Standard Schema objects should flow in unchanged.
+10. **MCP core spec current revision is 2025-11-25** (confirmed on the official
+    versioning page today); OAuth 2.1 authorization, elicitation (incl. URL mode),
+    experimental tasks, and the extensions mechanism (SEP-1724) that MCP Apps rides on
+    are all in it.
+
+---
+
+## 1. Vercel AI SDK (`ai`)
+
+### Versions and cadence
+
+| Line | Version (2026-07-09) | dist-tag | First release |
+|---|---|---|---|
+| v7 | `ai@7.0.19`, `@ai-sdk/provider@4.0.3`, `provider-utils@5.0.7`, `@ai-sdk/react@4.0.20`, `@ai-sdk/mcp@2.0.10` | `latest` | 2026-06-25 |
+| v6 (ours) | `ai@6.0.222`, `@ai-sdk/provider@3.0.14`, `provider-utils@4.0.38`, `@ai-sdk/mcp@1.0.61` | `ai-v6` | 2025-12-22 |
+| v5 | `ai@5.0.210` | `ai-v5` | 2025-07-31 |
+
+All three lines received publishes on 2026-07-09 — previous majors are actively
+patched on dist-tags (no formal LTS statement found; UNVERIFIED how long that lasts).
+License: Apache-2.0. Source: npm registry `time` fields.
+
+### The `Tool` type at our pin (ai@6.0.28)
+
+Verified from `packages/provider-utils/src/types/tool.ts` at tag `ai@6.0.28`:
+
+```ts
+type Tool<INPUT, OUTPUT> = {
+  description?: string;
+  title?: string;
+  providerOptions?: ProviderOptions;
+  inputSchema: FlexibleSchema<INPUT>;          // REQUIRED — the only required field
+  inputExamples?: Array<{ input: INPUT }>;
+  needsApproval?: boolean | ((input, { toolCallId, messages, experimental_context? }) => boolean | Promise<boolean>);
+  strict?: boolean;                            // provider strict-mode hint
+  onInputStart?; onInputDelta?; onInputAvailable?;
+  toModelOutput?: ({ toolCallId, input, output }) => ToolResultOutput | Promise<...>;
+}
+// & execute XOR outputSchema (both optional when OUTPUT is never):
+//   execute?: (input, { toolCallId, messages, abortSignal?, experimental_context? })
+//     => AsyncIterable<OUTPUT> | PromiseLike<OUTPUT> | OUTPUT
+// & type?: 'function' (default) | 'dynamic' | 'provider' (provider needs id + args)
+```
+
+`ToolSet` (from `packages/ai/src/generate-text/tool-set.ts`) is just
+`Record<string, Tool<...>>` with a `Pick` to keep callback types aligned — a plain
+object map satisfies it.
+
+**Duck-typing verdict: yes.** `tool()` and `dynamicTool()` are identity functions
+(`dynamicTool` only adds `type: 'dynamic'`). There is no brand/symbol on the Tool
+itself. A neutral object `{ description, inputSchema, execute, needsApproval }` is a
+valid AI SDK tool as long as `inputSchema` is a valid `FlexibleSchema`.
+
+### What `inputSchema` accepts (`FlexibleSchema`, verified from schema.ts)
+
+```ts
+type FlexibleSchema<T> =
+  | Schema<T>                      // symbol-marked AI SDK schema
+  | LazySchema<T>                  // () => Schema<T>
+  | ZodSchema<T>                   // zod v3 or v4 types (special-cased)
+  | StandardSchema<T>;             // StandardSchemaV1 & StandardJSONSchemaV1  ← both!
+```
+
+Conversion (`asSchema`): symbol-marked `Schema` passes through; anything with
+`~standard` and `vendor === 'zod'` goes through the zod converters; **any other
+`~standard` object must provide `~standard.jsonSchema.input({ target: 'draft-07' })`**
+(v7 additionally injects `additionalProperties: false`). Raw JSON Schema is NOT
+accepted bare — it must be wrapped, but the wrapper is trivial:
+
+- `jsonSchema(schema, { validate? })` from `ai`/`@ai-sdk/provider-utils`, **or**
+- construct it yourself without any import — the marker is a **registered global
+  symbol**:
+
+```ts
+// Valid AI SDK Schema, zero @ai-sdk imports (verified against isSchema() in v6 & v7):
+const s = {
+  [Symbol.for('vercel.ai.schema')]: true,
+  _type: undefined,            // type-inference carrier only
+  jsonSchema: myJsonSchema7,   // may also be a Promise or handled lazily via getter
+  validate: myValidateFn,      // key MUST exist ('validate' in obj), value may be undefined
+};
+```
+
+`isSchema()` checks: object, `Symbol.for('vercel.ai.schema')] === true`,
+`'jsonSchema' in value`, `'validate' in value`. This is stable across v6→v7.
+Recommendation: prefer the Standard Schema route (portable) and treat the symbol
+route as an AI-SDK-specific fast path; both avoid a hard dependency.
+
+### v6 → v7 Tool changes (verified from source at ai@7.0.19 + migration guide)
+
+- `Tool` becomes a discriminated union `FunctionTool | DynamicTool |
+  ProviderDefinedTool | ProviderExecutedTool` (structurally compatible for the
+  function case).
+- Typed tool context: new `contextSchema?: FlexibleSchema<CONTEXT>`; execute options
+  gain `context` (from per-tool `toolsContext`) replacing `experimental_context`;
+  `experimental_sandbox?: SandboxSession` added.
+- `metadata?: JSONObject` added; `description` may be a function of `{ context }`.
+- `needsApproval` **@deprecated**: "Tool approval is handled on a `generateText` /
+  `streamText` level now." `title` @deprecated in favor of `providerMetadata`.
+- Platform: v7 is ESM-only, Node ≥22. Other renames (`system`→`instructions`,
+  `onFinish`→`onEnd`, telemetry → `@ai-sdk/otel`) don't touch tool shape. Codemod:
+  `npx @ai-sdk/codemod v7`. v6 names retained as deprecated aliases through v7.
+
+### Approval / HITL (v6 semantics — what we pin)
+
+- `needsApproval: true | (input, opts) => boolean` pauses execution; the UI stream
+  emits `tool-approval-request`; tool part state becomes `approval-requested`.
+- `useChat().addToolApprovalResponse({ id, approved, reason? })` answers it;
+  `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses`
+  auto-resumes. Denied executions surface as `output-denied`.
+- Docs: ai-sdk.dev/docs/agents/tool-approvals, /docs/ai-sdk-ui/chatbot-tool-usage.
+
+### Dynamic tools & MCP
+
+- `dynamicTool()` / `type: 'dynamic'` for runtime-defined tools (unknown types) —
+  MCP tools arrive this way.
+- `@ai-sdk/mcp` is the stable MCP client since v6 (v6 launch: "stable MCP support
+  with OAuth"); v6 line at 1.0.61, v7 at 2.0.10.
+- **v7 adds MCP Apps support**: `@ai-sdk/mcp` helpers to advertise the
+  `io.modelcontextprotocol/ui` capability, `splitMCPAppTools()` to separate
+  model-visible from app-only tools, `ui://` resource reading; `@ai-sdk/react`
+  ships `experimental_MCPAppRenderer` (sandboxed iframe + JSON-RPC bridge,
+  explicitly experimental). Docs: ai-sdk.dev/docs/ai-sdk-core/mcp-apps.
+
+### UIMessage stream protocol
+
+SSE with header `x-vercel-ai-ui-message-stream: v1`, terminated by `[DONE]`.
+Chunk types (v7 docs): `start`/`finish`, `start-step`/`finish-step`,
+`text-start/-delta/-end`, `reasoning-start/-delta/-end` (+ `reasoning-file`, new in
+v7), `tool-input-start/-delta/-available`, `tool-output-available`,
+`tool-output-denied`, `tool-approval-request/-response`, `source-url`,
+`source-document`, `file`, `data-*` (custom data parts), `error`, `abort`, `custom`.
+The `v1` header value has survived v5→v6→v7; part-type additions are additive, but
+there is no written stability guarantee beyond the version header (UNVERIFIED policy).
+
+---
+
+## 2. OpenAI Agents SDK (JS/TS, `@openai/agents`)
+
+- **Version/maturity:** 0.13.1 (published 2026-07-09) — still pre-1.0, releases every
+  few days-to-weeks. MIT. `@openai/agents-core` deps: `openai@^6.46.0`; `zod@^4.0.0`
+  is an *optional* peer. Node 20+, TS 5.4+.
+- **Tool definition** (verified from `packages/agents-core/src/tool.ts` @ main):
+  `tool({ name?, description, parameters, strict?, execute, errorFunction?,
+  needsApproval?, isEnabled?, timeoutMs?, timeoutBehavior?, timeoutErrorFunction?,
+  inputGuardrails?, outputGuardrails?, deferLoading?, customDataExtractor? })`.
+  - `parameters`: a Zod **object** (`ZodObjectLike`, strict mode, auto-validated) or a
+    **raw JSON Schema object** (`JsonObjectSchemaStrict` with `strict: true` default /
+    `JsonObjectSchemaNonStrict` with `strict: false`) or `undefined` (arguments passed
+    as raw string). **JSON Schema inputs are parsed as JSON but NOT validated** — our
+    converter must attach its own validation.
+  - Internal `FunctionTool` shape: `{ type: 'function', name, description,
+    parameters: JsonObjectSchema, strict: boolean, invoke(runContext, input: string,
+    details?), needsApproval: ToolApprovalFunction, isEnabled, ... }` — so
+    **programmatic construction from JSON Schema descriptors is a first-class path**.
+  - `execute(input, runContext)` where `RunContext<Context>` carries user context;
+    approval fn signature is `(runContext, input, callId?) => Promise<boolean>`.
+- **HITL:** `needsApproval: boolean | fn` → run pauses, `result.interruptions` holds
+  `RunToolApprovalItem`s; resolve with `result.state.approve(i)` / `.reject(i)`
+  (options `{ alwaysApprove | alwaysReject, message }`); resume by passing the state
+  back to `run()`. `RunState` serializes via `toString()`/`fromString()` for
+  long-lived approvals. Works with streaming (`stream.interruptions`). Same flow
+  covers handoffs and nested `agent.asTool()`.
+- **Handoffs & guardrails:** core primitives (`handoff()`, input/output guardrails at
+  agent and tool level; v0.13 adds tool input/output guardrails + pre-approval input
+  guardrails opt-in).
+- **MCP:** three modes — `hostedMcpTool()` (server-side via OpenAI Responses API, with
+  `requireApproval: 'always'|'never'|per-tool` + `onApproval` callback),
+  `MCPServerStreamableHttp`, `MCPServerStdio` (`MCPServerSSE` deprecated).
+- **Streaming:** `run(agent, input, { stream: true })` returns an AsyncIterable of
+  three event kinds (raw model events, run-item events, agent-updated events) plus
+  `toTextStream()` and `stream.completed` — a proprietary event model, not the AI SDK
+  UI protocol.
+- **Realtime/voice:** `RealtimeAgent`/`RealtimeSession` (WebRTC/WS); default realtime
+  model is now `gpt-realtime-2`.
+
+---
+
+## 3. Mastra
+
+- **Version:** `@mastra/core@1.50.1` (2026-07-06/07; 1.x GA since early 2026, weekly
+  minors). Apache-2.0. `@mastra/mcp@1.13.1` (2026-07-06).
+- **createTool** (docs: mastra.ai/reference/tools/create-tool):
+  `createTool({ id, description, inputSchema, outputSchema?, suspendSchema?,
+  resumeSchema?, execute(inputData, context) })`.
+  - Schemas: "Standard JSON Schema" capable libraries — zod, valibot, arktype accepted
+    (i.e. our Standard Schema objects with the `jsonSchema` converter fit).
+  - `execute` second arg (`ToolExecutionContext`): `requestContext`, `abortSignal`,
+    `agent`, `workflow` (suspend/resume lifecycle), `observe` (tracing/logging).
+  - Tool-level `mcp` property carries MCP annotations (`title`, `readOnlyHint`,
+    `destructiveHint`, `idempotentHint`, `openWorldHint`) + custom metadata — Mastra
+    tools are designed to be served over MCP.
+- **AI SDK relationship (verified from the published package.json):** `@mastra/core`
+  bundles `@ai-sdk/provider` + `provider-utils` for **v5, v6, and v7 lines
+  simultaneously** via npm aliases (`@ai-sdk/provider-v5/-v6/-v7`), plus
+  `@standard-schema/spec@^1.1.0`, `zod ^3.25 || ^4`, `xstate` (workflows). Model I/O
+  runs on AI SDK provider interfaces; any AI SDK provider package works.
+- **Streaming:** native Mastra stream format, with adapters to the AI SDK UI protocol:
+  `toAISdkStream()` / `handleChatStream()` / `format: 'aisdk'`, `version: 'v6'`
+  option for AI SDK v6-typed apps; `@mastra/ai-sdk` package for useChat interop.
+- **MCP:** `MCPClient` (multi-server, tool namespacing) and `MCPServer` (expose agents
+  + tools as MCP) in `@mastra/mcp`.
+- **Memory/storage:** `MastraStorage` + vector-store abstractions with many adapters
+  (libsql default, pg, clickhouse, etc.); working/semantic memory on top. "OM"
+  (observational memory) is an active 2026 workstream (per repo activity).
+- **Third-party tool packages** integrate by exporting `createTool` results (or
+  Vercel-AI-SDK-shaped tools, which Mastra agents also accept) — no registry
+  mechanism beyond npm.
+
+---
+
+## 4. MCP + MCP Apps (critical for our module↔host UI protocol)
+
+### Core spec
+
+- **Current revision: 2025-11-25** (confirmed 2026-07-09 on
+  modelcontextprotocol.io/specification/versioning; no newer ratified revision;
+  drafts live under /specification/draft).
+- 2025-11-25 highlights (official changelog): experimental **tasks** (SEP-1686,
+  durable/polled long-running requests); **elicitation** upgrades — standards-based
+  enums (SEP-1330), defaults (SEP-1034), **URL-mode elicitation** (SEP-1036); sampling
+  gains `tools`/`toolChoice` (SEP-1577); icons metadata (SEP-973); tool-name guidance;
+  JSON Schema 2020-12 as default dialect (SEP-1613); **extensions mechanism**
+  (SEP-1724) — the hook MCP Apps uses.
+- **Tool annotations** (`annotations.readOnlyHint/destructiveHint/idempotentHint/
+  openWorldHint`, untrusted hints) — in the spec since 2025-03-26, unchanged in
+  2025-11-25 (spec: /specification/2025-11-25/server/tools).
+- **Authorization:** OAuth 2.1-based framework (since 2025-06-18). 2025-11-25 adds
+  OIDC Discovery support, incremental scope consent via `WWW-Authenticate` (SEP-835),
+  **Client ID Metadata Documents** as the recommended client-registration mechanism
+  (SEP-991), and RFC 9728 protected-resource-metadata alignment (SEP-985). This is the
+  contract for our "host-side OAuth" MCP door.
+- SDK: `@modelcontextprotocol/sdk@1.29.0` (2026-03-30, MIT).
+
+### MCP Apps (SEP-1865) — the actual spec
+
+Source: `modelcontextprotocol/ext-apps` repo, `specification/2026-01-26/apps.mdx`.
+**Status: Stable (2026-01-26).** Authors span Anthropic, OpenAI, and MCP-UI. Announced
+2026-01-26 on the MCP blog; standardizes patterns from OpenAI Apps SDK + MCP-UI.
+
+- **Extension identifier:** `io.modelcontextprotocol/ui`. Negotiated via the standard
+  extensions capability: client sends
+  `capabilities.extensions["io.modelcontextprotocol/ui"] = { mimeTypes:
+  ["text/html;profile=mcp-app"] }` in `initialize`. `ui://` prefix and the label are
+  reserved in MCP.
+- **UI resources:** predeclared MCP resources with `ui://` URIs and mimeType
+  `text/html;profile=mcp-app`; content served via `resources/read` (`text` or base64
+  `blob`), MUST be a valid HTML5 document. Resource `_meta.ui` carries: `csp`
+  (`connectDomains`, `resourceDomains`, `frameDomains`, `baseUriDomains`),
+  `permissions` (camera/microphone/geolocation/clipboardWrite), `domain` (dedicated
+  sandbox origin, host-defined format — e.g. `{hash}.claudemcpcontent.com`,
+  `www-example-com.oaiusercontent.com`), `prefersBorder`.
+- **Tool↔UI linkage:** tool `_meta.ui = { resourceUri: "ui://…", visibility?:
+  ["model","app"] }`. `visibility: ["app"]` = app-only tool: host MUST hide it from
+  the model's tools/list and MUST reject app `tools/call` for tools lacking `"app"`;
+  cross-server app calls always blocked. (Flat `_meta["ui/resourceUri"]` is deprecated,
+  removal before GA.)
+- **Iframe↔host protocol: MCP JSON-RPC over `postMessage`** — the iframe acts as an
+  MCP client, the host as (proxying) server. No SDK required; raw example from the
+  spec: `window.parent.postMessage({ jsonrpc: "2.0", id, method, params }, '*')`,
+  starting with `ui/initialize` (`protocolVersion: "2026-01-26"`, `appCapabilities`
+  incl. `availableDisplayModes`) → result carries `hostCapabilities` (openLinks,
+  serverTools, serverResources, logging, sandbox) + `hostContext` (theme, `styles.
+  variables` — a standardized ~80-variable CSS custom-property vocabulary —
+  `styles.css.fonts`, displayMode, containerDimensions fixed/max/unbounded, locale,
+  timeZone, platform, deviceCapabilities, safeAreaInsets) → `ui/notifications/
+  initialized`.
+- **Standard MCP methods available to the view:** `tools/call`, `resources/read`,
+  `notifications/message`, `ping`. **UI-specific:** view→host requests `ui/open-link`,
+  `ui/message` (inject a user-role message into chat), `ui/request-display-mode`
+  (inline|fullscreen|pip), `ui/update-model-context` (overwrite-style context for
+  future turns); host→view `ui/notifications/tool-input` (required, once),
+  `tool-input-partial` (streaming args, best-effort JSON repair), `tool-result`
+  (`CallToolResult`), `tool-cancelled`, `ui/resource-teardown` (request/response —
+  host SHOULD await before teardown), `ui/notifications/size-changed` (view→host,
+  ResizeObserver-driven), `ui/notifications/host-context-changed` (partial updates).
+- **Sandboxing:** iframe sandbox mandatory. Web hosts MUST use a **double-iframe
+  sandbox proxy on a different origin** (`allow-scripts allow-same-origin`), with
+  reserved `ui/notifications/sandbox-proxy-ready` / `sandbox-resource-ready`
+  messages carrying the raw HTML + CSP config. Host MUST construct CSP from declared
+  domains; restrictive default if none declared (`default-src 'none'; script-src
+  'self' 'unsafe-inline'; …; connect-src 'none'`); MAY tighten, MUST NOT loosen.
+- **Data conventions:** `content` = model-visible text, `structuredContent` =
+  UI-render data (not model context), `_meta` = neither.
+- **Explicitly deferred (not in MVP):** external URL embedding (`text/uri-list`),
+  **state persistence/restoration**, multiple UI resources per tool, view↔view
+  communication, custom sandbox policies. **No payload size limits are specified** in
+  the spec.
+- **Host support (blog, 2026-01-26):** Claude web + desktop, ChatGPT (same week),
+  VS Code Insiders, Goose; JetBrains, AWS Kiro, Google Antigravity announced as
+  coming. OpenAI commits to the standard; Apps SDK and MCP Apps **coexist** — the
+  spec is the shared wire standard, not a merged SDK.
+- **SDKs:** `@modelcontextprotocol/ext-apps@1.7.4` (2026-06-05, MIT) — `App` class
+  for views, server helpers (`getUiCapability`, `RESOURCE_MIME_TYPE`), React hooks
+  (`useHostStyleVariables`, `applyDocumentTheme`, auto `size-changed` via
+  ResizeObserver). MCP-UI (`@mcp-ui/client@7.1.1`) predates the SEP and now tracks it.
+  Plus AI SDK 7's client-side support (§1).
+
+---
+
+## 5. Standard Schema
+
+- **Spec:** v1. `@standard-schema/spec@1.1.0` (npm, 2025-12-15; 1.0.0 was
+  2025-01-27). Types-only package (also copy-pasteable — the spec encourages
+  vendoring the interface, so implementing it requires **no runtime dependency**).
+- **`~standard` interface** (verified from spec source):
+  - `StandardSchemaV1.Props`: `version: 1`, `vendor: string`, `validate(value,
+    options?) => Result | Promise<Result>`, `types?: { input, output }` (type-level
+    only). `Result` = `{ value }` on success (`issues` falsy) or `{ issues:
+    [{ message, path? }] }` on failure.
+  - **New in 1.1.0:** `StandardTypedV1` (base) and **`StandardJSONSchemaV1`**:
+    `~standard.jsonSchema: { input(options), output(options) }` where `options.target`
+    ∈ `"draft-2020-12" | "draft-07" | "openapi-3.0" | string`; may throw for
+    unsupported targets.
+- **Implementers** (standardschema.dev): StandardSchemaV1 — zod ≥3.24, valibot ≥1.0,
+  arktype ≥2.0, Effect Schema, yup, TypeBox adapters, many others.
+  StandardJSONSchemaV1 — **zod v4.2+**, **ArkType v2.1.28+**, **Valibot v1.2+ (via
+  `@valibot/to-json-schema` v1.5+)**, VineJS 4.3+, GraphQL Standard Schema 0.2+.
+  Effect is NOT listed for the JSON Schema part.
+- **Third-party implementation (our neutral tools):** attach
+  `~standard: { version: 1, vendor: 'vendo', validate, jsonSchema: { input:
+  ({target}) => ourJsonSchema, output: … } }` to a plain object. Because AI SDK's
+  `asSchema` requires the `jsonSchema` converter for non-zod vendors (it calls
+  `input({ target: 'draft-07' })`), we MUST implement StandardJSONSchemaV1, not just
+  V1, for AI SDK compatibility. MCP Apps' own SDK types reference
+  `StandardSchemaWithJSON` too — the ecosystem is converging on exactly this pair.
+- Caveat: minimum AI SDK v6 patch that accepts non-zod Standard Schemas =
+  our pinned 6.0.28 already does (verified in its source); the earliest 6.x with
+  StandardJSONSchemaV1 support was not pinned down (UNVERIFIED, irrelevant at ≥6.0.28).
+
+---
+
+## 6. Cross-cutting comparison
+
+| | Vercel AI SDK v6/v7 | OpenAI Agents JS 0.13 | Mastra 1.50 | MCP 2025-11-25 | LangChain/LangGraph JS |
+|---|---|---|---|---|---|
+| Tool input schema | `FlexibleSchema`: zod v3/v4, Standard Schema (V1+JSON), symbol-marked `Schema`, `jsonSchema()` wrapper | Zod v4 object (validated) OR raw JSON Schema (unvalidated) OR none | Standard-JSON-Schema libs (zod/valibot/arktype) | Raw JSON Schema (2020-12 default dialect) | zod primarily (JSON Schema accepted) |
+| Execute signature | `(input, { toolCallId, messages, abortSignal, experimental_context→context })` | `(input, runContext)`; internal `invoke(runContext, rawJsonString)` | `(inputData, { requestContext, abortSignal, agent, workflow, observe })` | server-side handler per SDK; result = `content[] + structuredContent` | `(input, config)` |
+| Approval / HITL | v6: per-tool `needsApproval` + `tool-approval-request` chunk + `addToolApprovalResponse`; v7: call-level `toolApproval` | `needsApproval` → `interruptions[]` + serializable `RunState.approve/reject` | tool `suspend()/resume()` + workflow suspend | elicitation (form + URL mode); MCP Apps `ui/message`; host-side approval UX | `interrupt()` in LangGraph |
+| MCP client | `@ai-sdk/mcp` (stable, OAuth; v7 adds MCP Apps rendering) | hosted MCP tool + StreamableHTTP + stdio classes | `@mastra/mcp` MCPClient/MCPServer | — (is the protocol) | `@langchain/mcp-adapters` |
+| Streaming protocol | UIMessage SSE, `x-vercel-ai-ui-message-stream: v1` | proprietary 3-kind event stream + `toTextStream()` | Mastra stream + `toAISdkStream()` adapters (v5/v6 targets) | JSON-RPC over Streamable HTTP (+ SSE polling) | LangGraph event/values streams |
+| License | Apache-2.0 | MIT | Apache-2.0 | MIT (SDK); spec open | MIT |
+| Cadence | major ~every 6–7 months; prior majors patched on dist-tags | 0.x, breaking minors, weekly-ish | weekly minors on 1.x | spec revision ~2/year (2025-03-26, -06-18, -11-25) | 1.x stable since late 2025 |
+| 3rd-party tool package | export plain `Tool`-shaped objects / `ToolSet` maps | export `tool()` results or raw `FunctionTool` objects built from JSON Schema | export `createTool` results (or AI-SDK-shaped tools) | ship an MCP server | export `tool()` results |
+
+**Implication for @vendoai/core:** a neutral tool = `{ name/description, JSON Schema,
+execute, approval metadata, MCP annotations }` with a `~standard` (V1+JSON) schema
+object converts losslessly to all five targets; AI SDK needs no conversion at all.
+
+## 7. Other load-bearing findings
+
+- **AI SDK 7 extras relevant to us:** `WorkflowAgent` (durable, resumable runs that
+  survive restarts/approval delays), `HarnessAgent` (wrap external agent frameworks
+  behind the AI SDK `Agent` interface — a potential adapter seam for Vendo modules),
+  first-class `SandboxSession`, TUI for agent dev, `@ai-sdk/otel` telemetry.
+- **v7 approval relocation** (tool-level `needsApproval` → call-level `toolApproval`)
+  means approval policy is trending toward the *host/orchestrator*, not the tool —
+  matches our host-owned-consent architecture; keep approval as tool *metadata* that
+  hosts enforce.
+- **OpenAI Apps SDK vs MCP Apps:** did not merge into one SDK; MCP Apps is the shared
+  wire standard both commit to. Building on MCP Apps covers ChatGPT + Claude + VS Code.
+- **OpenAI Agents Python/JS divergence:** both maintained; JS remains 0.x while Python
+  is the older line; feature sets track each other loosely (JS-only: some voice
+  features first). Not a blocker for a converter targeting the JS tool shape.
+  (Divergence details UNVERIFIED beyond version numbers.)
+- **LangGraph JS (deliberately deprioritized):** `@langchain/core@1.2.2` (MIT).
+  `tool(fn, { name, description, schema })` with zod (`.describe()` for field docs);
+  agents via `createAgent({ model, tools })`, executed through `ToolNode`, results as
+  `ToolMessage`. Nothing here changes our contract design; a thin converter suffices.
+- **A2A:** agent↔agent interop (peer protocol), orthogonal to tool/module contracts;
+  Mastra is experimenting with an A2A agent class (visible in `@mastra/core`
+  dist-tags). No action for core contracts now. (Status beyond that UNVERIFIED.)
+- **Zod in our core:** we pin `zod@^3.24.0`. zod 3.24 implements StandardSchemaV1 but
+  the StandardJSONSchemaV1 converter is **zod v4.2+ only** — if we keep emitting
+  Standard Schema objects ourselves this doesn't matter, but if we ever pass raw zod 3
+  schemas across the seam, AI SDK special-cases them while other consumers may not.
+
+## Sources
+
+- vercel/ai source at tags `ai@6.0.28` and `ai@7.0.19`:
+  `packages/provider-utils/src/types/tool.ts`, `packages/provider-utils/src/schema.ts`,
+  `packages/ai/src/generate-text/tool-set.ts` (raw.githubusercontent.com)
+- npm registry metadata (versions/dates/licenses): registry.npmjs.org for `ai`,
+  `@ai-sdk/*`, `@openai/agents(-core)`, `@mastra/core`, `@mastra/mcp`,
+  `@standard-schema/spec`, `@modelcontextprotocol/sdk`, `@modelcontextprotocol/ext-apps`,
+  `@mcp-ui/client`, `@langchain/core` (queried 2026-07-09)
+- AI SDK 7: https://vercel.com/blog/ai-sdk-7 ·
+  https://ai-sdk.dev/docs/migration-guides/migration-guide-7-0 ·
+  https://ai-sdk.dev/docs/ai-sdk-core/mcp-apps ·
+  https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol ·
+  https://ai-sdk.dev/docs/agents/tool-approvals
+- AI SDK 6: https://vercel.com/blog/ai-sdk-6
+- OpenAI Agents JS: https://github.com/openai/openai-agents-js
+  (`packages/agents-core/src/tool.ts`, docs `guides/human-in-the-loop.mdx`,
+  `guides/mcp.mdx`, `guides/streaming.mdx`) · https://openai.github.io/openai-agents-js/
+- Mastra: https://mastra.ai/reference/tools/create-tool ·
+  https://mastra.ai/reference/ai-sdk/to-ai-sdk-stream · published
+  `@mastra/core@1.50.1` package.json
+- MCP: https://modelcontextprotocol.io/specification/versioning ·
+  https://modelcontextprotocol.io/specification/2025-11-25/changelog ·
+  https://modelcontextprotocol.io/specification/2025-11-25/server/tools
+- MCP Apps: https://github.com/modelcontextprotocol/ext-apps
+  (`specification/2026-01-26/apps.mdx`, SEP-1865) ·
+  https://blog.modelcontextprotocol.io/posts/2026-01-26-mcp-apps/ ·
+  https://apps.extensions.modelcontextprotocol.io/
+- Standard Schema: https://standardschema.dev/ · https://standardschema.dev/json-schema ·
+  spec source `packages/spec/src/index.ts` (github.com/standard-schema/standard-schema)
+- LangChain JS: https://docs.langchain.com/oss/javascript/langchain/tools

--- a/docs/specs/research-2026-07-module-speed.md
+++ b/docs/specs/research-2026-07-module-speed.md
@@ -1,0 +1,373 @@
+# Module Generation Speed — Research & Recommendations (July 2026)
+
+How to make module generation and editing FAST across our three tiers:
+Tier 1 `view.json` (declarative host-component tree, instant render), Tier 2
+`index.tsx` (esbuild-bundled React in the sandboxed MCP-Apps iframe), Tier 3
+micro-apps (Nixpacks-built server code in E2B/microVM sandboxes). Two clocks
+matter: **time-to-first-render** of a new module and **edit-turnaround**.
+
+Researched 2026-07-10 (web sources cited per section; numbers are the sources'
+claims, marked UNVERIFIED where we could not confirm against a primary source).
+Existing in-repo art this builds on, not redoes:
+
+- **Remix fast edits** (spec 2026-07-04, PR #44): `edit_view` line-hunk deltas
+  against a server-held normalized baseline (`packages/vendo-runtime/src/remix/
+  baseline.ts`, `hunks.ts`, `edit-view-tool.ts`), coordinate-mode hunks, prepared
+  sandbox-ready baselines. Result: first remix 32s → 4.4s, pin edits ~6s. The
+  core insight — *the model should only type what changed, the server owns the
+  rest* — generalizes to everything below.
+- **Import-map vendoring** (`packages/vendo-stage/src/stage-host.ts`): react/
+  react-dom/heavy deps served as blob modules via an injected importmap, so
+  generated code never bundles React and compile input stays one small file.
+- **MCP Apps protocol** (docs/specs/research-2026-07-framework-landscape.md §4):
+  the spec already defines `ui/notifications/tool-input-partial` — streaming
+  tool args into the iframe with best-effort JSON repair — i.e. the standard
+  anticipates stream-rendered UI.
+
+## TL;DR — top 10 ranked recommendations
+
+Ranked by (expected win × confidence) / implementation cost.
+
+| # | Recommendation | Tier(s) | Expected win | Cost |
+|---|---|---|---|---|
+| 1 | **Stream-render `view.json` as it generates** — incremental JSON parse, paint the tree top-down during the stream | 1 | first paint ~1s instead of after full generation (10–30s feel → ~1s feel) | S |
+| 2 | **Prompt-cache the generation prompt** (system prompt + component catalog + module examples behind a cache breakpoint) | all | up to 85% TTFT cut on long prompts; 90% input-cost cut on reads | S |
+| 3 | **Fast-provider lane for draft generation** — Cerebras/Groq/Fireworks-class serving (500–2,600 tok/s) for view.json and first-draft code; frontier model only where quality demands | all | 5–20× raw generation wall-clock | M |
+| 4 | **Generalize hunk edits to all tiers + fast-apply merge** — model emits abbreviated edits; Morph-style apply model (10.5k tok/s) or OpenAI Predicted Outputs (3–5×) materializes full files | edit loop, 2–3 | multi-file edits at Tier-1-edit speed; per-file 70s→20s class wins | M |
+| 5 | **Progressive capability: view.json first, upgrade in background** — every module renders a Tier-1 approximation instantly; Tier 2/3 build swaps in when ready | 1→2→3 | perceived TTFR = Tier 1 always (~1–2s), regardless of final tier | M |
+| 6 | **Small-model routing/cascade** — small fast model classifies tier + emits view.json; big model reserved for code tiers | 1, routing | latency win on the (majority) Tier-1 path; 45–85% cost cut precedent | M |
+| 7 | **Compile-as-you-stream + HMR-patch the live iframe** — esbuild transform per file as it closes in the stream; edits hot-swap the module instead of remounting the stage | 2 | compile off the critical path (~ms anyway); edit repaint without iframe reload, state preserved | M |
+| 8 | **Warm pool + pause/resume snapshots for the server tier** — pre-booted Nixpacks base sandboxes; pause built modules, resume in ~1s (E2B) instead of rebuild/reboot | 3 | re-open of an existing module: minutes → ~1s; first-run: build hidden behind pool | M |
+| 9 | **V8-isolate middle tier for JS-only server code** — Dynamic-Workers-style isolate (or self-hosted workerd/Deno) between iframe and microVM | 3 | ~5ms starts vs 150–800ms microVM boots; ~100× memory efficiency | L |
+| 10 | **Module retrieval as prepared baselines** — retrieve similar accepted modules, seed them as the edit base so "new" modules are edits, not generations | all | our own 32s→4.4s precedent, applied to first-generation | M–L |
+
+Cross-cutting finding: **constrained decoding is ~free and helps** (<40–50µs/
+token overhead, kills retry loops) — always constrain `view.json`. And the
+single biggest lever overall is #4+#10 combined: make as much of the pipeline
+as possible an *edit of something that already exists* rather than open-ended
+generation.
+
+---
+
+## 1. Fast LLM inference for generation
+
+**Throughput-optimized providers are now 5–20× faster than frontier-lab
+endpoints.** Artificial Analysis measured Cerebras serving Kimi K2.6 (a leading
+open-weight coding model) at **981 output tok/s** — a 10k-token response in
+5.6s vs 163.7s on the official Moonshot endpoint (29×). Cerebras publishes
+2,600 tok/s on Llama 4 Scout and ~3,000 tok/s on gpt-oss-120B; Groq serves
+Llama 3.3 70B at 250+ tok/s, Llama 4 Maverick at 1,200+ tok/s, small models at
+500–2,800 tok/s. Typical GPU-served frontier models run ~50–200 tok/s.
+([Cerebras](https://www.cerebras.ai/blog/cerebras-kimi-k2-Enterprise),
+[General Input measurement](https://www.generalinput.com/blog/cerebras-kimi-k2-6-inference-speed-generative-ui),
+[Groq](https://groq.com/lpu-architecture))
+
+**Speculative decoding is productized, not exotic.** Vercel's v0 uses
+Fireworks' n-gram-draft "Adaptive Speculation" (deterministic n-gram model
+proposes tokens, the LLM verifies in parallel) plus RFT: their autofixer runs
+at **8,130 char/s vs 238.9 for GPT-4o-mini (~34×)** with 93.87% error-free
+generation, and the end-to-end pipeline claim is 40×.
+([Fireworks/Vercel](https://fireworks.ai/blog/vercel)) OpenAI **Predicted
+Outputs** is the same idea with the *caller* supplying the draft — pass the
+current file as `prediction`, matching spans are accepted in parallel: 3–5×
+on code edits, one reported 70s→20s large-file edit.
+([OpenAI docs](https://platform.openai.com/docs/guides/predicted-outputs),
+[Morph's guide](https://www.morphllm.com/openai/predicted-outputs)) Anthropic
+has no public equivalent (Cursor cites this as why they self-hosted their
+apply model).
+
+**Prompt caching economics** (Anthropic): cache reads cost 0.1× input, writes
+1.25× (5-min TTL) or 2× (1-hour); breakeven after 1–2 hits; **up to 85%
+latency reduction on long prompts**; min cacheable prefix 1,024 tokens.
+Our generation prompt (system prompt + full component catalog + few-shot
+modules) is exactly the long-stable-prefix shape caching rewards.
+([Anthropic](https://www.anthropic.com/news/prompt-caching),
+[platform docs](https://platform.claude.com/docs/en/build-with-claude/prompt-caching))
+
+**Small-model routing**: cascades ("cheap model first, escalate on failure")
+report 45–85% cost cuts at ~95% retained quality; an upfront classifier adds
+only 50–100ms. For us the classifier is nearly free — the conversation model
+already decides which tool to call; the win is *binding the view.json tool to
+a fast small model* rather than routing per-query.
+([TianPan cascades](https://tianpan.co/blog/2025-11-03-llm-routing-model-cascades))
+
+## 2. Constrained/structured generation for the view.json tier
+
+**Constraining does not hurt latency — it usually helps.** Modern grammar
+engines (XGrammar, llguidance) add **<40–50µs per token**, negligible against
+10–50ms/token inference; schema→FSM compilation costs ~50–200ms once and is
+cached thereafter, and can overlap prefill. Constrained output also eliminates
+filler, stops exactly at JSON-complete, and kills the retry/repair loop —
+JSONSchemaBench (arXiv 2501.10868, ~10k real schemas, 6 frameworks) is the
+reference benchmark. Caveat worth respecting: over-tight schemas can degrade
+*content* quality on complex reasoning (declaration-order effects), so
+constrain structure, keep string fields free.
+([JSONSchemaBench](https://arxiv.org/pdf/2501.10868),
+[grammar-constrained generation overview](https://tianpan.co/blog/2026-04-16-grammar-constrained-generation-output-reliability))
+
+**Streaming partial-JSON UI is the established pattern everywhere:**
+
+- **Thesys C1** (the "Generative UI API"): OpenAI-compatible endpoint returns a
+  streamed JSON UI spec; their React SDK **renders components as the spec
+  streams**, handling partial output gracefully.
+  ([Thesys architecture](https://www.thesys.dev/blogs/generative-ui-architecture))
+  Notably our `@vendoai/components` already wraps their OpenUI vocabulary.
+- **Vercel AI SDK**: `streamObject`/`useObject` deliver progressively-parsed
+  partial objects; v0 renders while streaming and runs mid-stream autofixers
+  ("LLM Suspense", <250ms passes).
+  ([v0 agent blog](https://vercel.com/blog/how-we-made-v0-an-effective-coding-agent))
+- **Ecosystem parsers**: incremental JSON parsers that yield the deepest
+  currently-valid prefix (openai-partial-stream, jsonriver, etc.); practitioners
+  report first-paint going **from ~30s to ~1s** by rendering partials.
+  ([openai-partial-stream](https://github.com/st3w4r/openai-partial-stream),
+  [Aha! engineering](https://www.aha.io/engineering/articles/streaming-ai-responses-incomplete-json))
+- **MCP Apps** standardizes host→view streaming args as
+  `ui/notifications/tool-input-partial` with best-effort JSON repair — the
+  protocol we already speak has the streaming slot built in.
+
+Design consequence: emit `view.json` in a **streaming-friendly key order**
+(node type and static props before children; data bindings last per node) so
+the top of the tree is paintable earliest, and use breadth-first or top-down
+document order in the schema.
+
+## 3. Code-tier speed (Tier 2: esbuild iframe path)
+
+**Compilation is not our bottleneck — token generation is.** esbuild bundles
+~0.19s cold on small React projects and rebuilds in tens of ms; our compile
+input is a *single ~≤64KB component file* with all heavy deps externalized to
+the import map, so transform time is single-digit ms. The three real levers:
+
+1. **Start compiling before the stream ends.** Multi-file modules stream file
+   by file; run esbuild `transform` per file as each closes (or incremental
+   `context.rebuild()` for the graph). By the time the last token lands, the
+   bundle is warm. Sandpack does exactly this shape — transpile in web
+   workers, per-file, on-demand loaders.
+   ([Sandpack architecture](https://sandpack.codesandbox.io/docs/architecture/overview),
+   [Building Sandpack](https://danilowoz.com/blog/sandpack))
+2. **Prebundled dependency CDN.** Sandpack's biggest win was a custom CDN of
+   pre-transpiled npm packages; Bolt keeps popular packages "in pre-compressed
+   layers, so npm install often finishes in <500ms or is skipped entirely."
+   Our import-map vendoring is the same idea; extend it from {react, lucide…}
+   to a curated, versioned catalog of allowed deps, pre-vendored at host
+   build time (`vendo sync`) so Tier-2 modules never fetch npm at all.
+   ([Bolt/WebContainers](https://newsletter.posthog.com/p/from-0-to-40m-arr-inside-the-tech))
+3. **HMR-style patching instead of stage remount.** On edit, swap the blob URL
+   in the import map and re-render, or integrate react-refresh so component
+   state survives. Full iframe reloads re-run the MCP Apps `ui/initialize`
+   handshake and lose scroll/form state; a module-level hot swap is
+   ~milliseconds and keeps the surface alive. (No off-the-shelf numbers for
+   this in-iframe pattern — UNVERIFIED win size, but the mechanism is standard
+   Vite/react-refresh fare.)
+
+**Compile-in-worker vs server**: keep compiling server-side (current
+architecture) — it centralizes validation/sealing and avoids shipping
+esbuild-wasm (which is materially slower than native; esbuild's own docs
+recommend native). Browser-side compile only becomes interesting if we ever
+want offline/local edit preview.
+
+**WebContainers as a reference point, not a path**: full Node-in-browser boots
+<2s and gives Bolt its instant full-stack preview, but it's proprietary
+licensing, heavyweight, and our Tier 3 exists precisely so server code runs
+server-side. ([WebContainers](https://blog.stackblitz.com/posts/introducing-webcontainers/))
+
+**Skeleton-first progressive rendering**: stream the JSX top-down is not
+possible for compiled code — but Tier 2 modules can ship a deterministic
+skeleton (we already mint deterministic skeletons for remix baselines) that
+renders instantly while the real bundle compiles/validates.
+
+## 4. Edit-turnaround
+
+State of the art triangulates on: **let the smart model be terse, let a fast
+mechanism materialize.**
+
+- **Cursor fast apply**: full-file rewrite beats diff formats for files <~400
+  lines (diffs force fewer "thinking" tokens, are off-distribution, and models
+  botch line numbers), so they made *rewriting* fast instead: fine-tuned
+  Llama-3-70B + **speculative edits** — a deterministic draft (the original
+  file) verified in parallel — ~1,000 tok/s, 13× vanilla 70B inference.
+  ([Cursor blog](https://cursor.com/blog/instant-apply))
+- **Morph fast-apply-as-a-service**: 7B specialized merge model; agent sends
+  original file + abbreviated edit ("// … existing code …" markers); returns
+  the merged file at **10,500+ tok/s, ~98% accuracy, $0.80/M input** — used by
+  JetBrains, Vercel, Webflow. ([Morph](https://www.morphllm.com/blog/morph-gets-faster))
+- **OpenAI Predicted Outputs**: same speculative-edit trick, hosted — supply
+  the old file as the prediction, 3–5× faster edits, no extra model to run.
+- **aider's evidence**: edit-format choice swings model behavior hugely
+  (unified-diff format cut GPT-4-Turbo "lazy coding" 3×; search/replace blocks
+  work better for some models) — the format is a *per-model* tuning knob, not
+  a universal. ([aider](https://aider.chat/docs/unified-diffs.html))
+
+**Our `edit_view` hunks already beat this game for Tier 1/2 single files**
+(coordinate-mode hunks are cheaper than search/replace and we hold the
+baseline server-side, so line numbers are safe — we sidestep Cursor's
+objection because the server, not the model, resolves coordinates against a
+pinned `baseHash`). The gap is **multi-file Tier 2/3 modules**: per-file hunks
+still apply, but for large rewrites the winning shape is: smart model emits
+abbreviated intent → Morph/Predicted-Outputs materializes per file → only
+changed files rebuild. Regenerate-whole-repo should never be the default;
+reserve it for structural rewrites (Cursor's <400-line finding suggests
+full-file regen is fine for *small* files on a fast lane).
+
+## 5. Server-tier cold starts (Tier 3)
+
+Benchmarks (2026):
+
+| Mechanism | Time | Source |
+|---|---|---|
+| V8 isolate start (Cloudflare) | **<5ms** | [CF](https://blog.cloudflare.com/eliminating-cold-starts-with-cloudflare-workers/) |
+| Firecracker snapshot restore (tuned) | single-digit ms – 28ms | [DIY 28ms](https://dev.to/adwitiya/how-i-built-sandboxes-that-boot-in-28ms-using-firecracker-snapshots-i0k); p50 3–4ms claims UNVERIFIED (secondary) |
+| E2B fresh sandbox boot | 150–800ms | [benchmarks](https://www.superagent.sh/blog/ai-code-sandbox-benchmark-2026), [gist](https://gist.github.com/homanp/b0bb68dad99a9434057e37e730a66039) |
+| E2B resume-from-pause | **~1s** (pause costs ~4s/GiB RAM) | [E2B docs](https://e2b.dev/docs/sandbox/persistence) |
+| Fly Machines suspend→resume | hundreds of ms | [Fly docs](https://fly.io/docs/reference/suspend-resume/) |
+| Modal memory snapshots | ~10× cold-start cut (e.g. 20s→2s; 118s→12s w/ GPU) | [Modal](https://modal.com/blog/mem-snapshots) |
+| Container cold start (Lambda-class) | 200ms–10s | [CF comparison](https://blog.cloudflare.com/cloud-computing-without-containers/) |
+
+Implications:
+
+1. **The build, not the boot, is the Tier-3 long pole.** A Nixpacks build is
+   tens of seconds to minutes; sandbox boot is sub-second. Attack order:
+   (a) **pool of pre-booted base sandboxes** with the runtime layers (python +
+   uv, node + pnpm, common libs) already present — generation only writes
+   files + installs the delta; (b) Nixpacks `cacheDirectories` + stable
+   `--cache-key` per module lineage so rebuilds hit ~/.npm / pip caches;
+   (c) **pause after first successful build** — reopening a module is then an
+   E2B resume (~1s) with processes and memory intact, no rebuild. This is the
+   warm-snapshot caching already in the design; the numbers confirm it's the
+   right bet and say *pause aggressively, resume optimistically* (resume on
+   module-card hover, not click).
+2. **V8 isolates are a credible middle tier** for "light server code" in
+   JS/TS: Cloudflare **Dynamic Workers** (open beta, April 2026) exists for
+   exactly this — runtime-instantiated workers running AI-generated code,
+   isolate starts in ms at ~100× less memory than containers, Cap'n-Web RPC
+   host bridges, egress credential injection so generated code never sees
+   secrets, and `@cloudflare/worker-bundler` for runtime npm bundling.
+   ([CF blog](https://blog.cloudflare.com/dynamic-workers/),
+   [InfoQ](https://www.infoq.com/news/2026/04/cloudflare-dynamic-workers-beta/))
+   Self-hosted equivalents: workerd, Deno isolates. Tradeoff: JS/WASM only
+   (no Python/bash tier-3 workloads), weaker isolation than a kernel boundary
+   — fine for computation + fetch-through-broker, not for arbitrary binaries.
+
+## 6. Reuse & module memory
+
+- **v0's composite model is the proof of concept**: RAG over specialized
+  knowledge feeds the base model; small "Quick Edit" model handles small
+  changes; autofixer handles the tail. Retrieval is load-bearing in the
+  fastest production UI generator. ([Vercel](https://vercel.com/blog/v0-composite-model-family))
+- **Our own precedent generalizes**: prepared baselines turned first-remix
+  from 32s into a 4.4s *edit*. A library of previously-generated, accepted
+  modules (we already persist envelopes + sealed sources) is a corpus of
+  prepared baselines: embed module descriptions, retrieve nearest accepted
+  module for a new request, present it as the anchor base, and let `edit_view`
+  hunks specialize it. "We've built 30 dashboards like this" becomes literal.
+- **Parameterized templates** are the deterministic end of the same spectrum:
+  for high-frequency shapes (table+filter, chart+summary, form+submit), ship
+  first-party templates where generation only fills a params object —
+  Tier-1-speed even for Tier-2 modules. Cache key: (host, component catalog
+  version, request embedding) → template + params → derivation cache so the
+  *same* request twice is a pure cache hit.
+- **Few-shot with accepted modules** in the (prompt-cached) system prompt
+  doubles as quality *and* speed: fewer retries, more predictable output for
+  speculative/predicted decoding (drafts match more often when style is pinned).
+
+## 7. Perceived speed — product patterns
+
+What v0/Lovable/Bolt/Claude artifacts do while real work happens:
+
+- **Always be streaming something**: v0 streams code visibly while a status
+  line narrates; Claude artifacts render partial markdown/code live. Dead air
+  is the enemy; token flow *is* the progress bar.
+- **Skeleton loaders as first-class generated output** (Lovable ships them in
+  generated apps; we should ship them in the *generation experience*): the
+  module card appears instantly with title + inferred shape, fills in as the
+  stream lands.
+- **Optimistic scaffold**: Bolt shows file tree + terminal activity
+  immediately; the preview pane exists before the app runs. Equivalent for us:
+  the stage mounts with themed skeleton at tool-call start, not at
+  tool-result.
+- **Progressive capability (our structural advantage)**: none of these tools
+  have our tier ladder. A request classified Tier 2/3 can still get an
+  *instant Tier-1 approximation* — small model emits `view.json` of host
+  components in ~1s, renders immediately, marked "upgrading…"; the code tier
+  builds in the background and hot-swaps in. Worst case the user keeps a
+  useful Tier-1 module; best case the upgrade lands in seconds. This converts
+  Tier-3 minutes into Tier-1 seconds *perceptually* on every generation.
+- **Background self-upgrade** also inverts failure UX: build errors in Tier
+  2/3 never strand the user staring at a spinner — the Tier-1 surface stays.
+
+## 8. Mapped onto Vendo
+
+### view.json fast path (Tier 1)
+- Constrained decoding against the view.json schema (structure constrained,
+  strings free); schema ordered for top-down paintability. [S]
+- Incremental-JSON parse in the runtime; stream partial trees to the surface
+  over the existing UIMessage data parts (and to iframes later via MCP Apps
+  `tool-input-partial`). Skeleton per node type until props complete. [S]
+- Bind the view.json tool to a fast small model (Haiku-class or an open model
+  on Cerebras/Groq/Fireworks via our BYO-provider seam); target <1.5s full
+  tree. Escalate to the big model only on validation failure (cascade). [M]
+- Prompt-cache breakpoint after {system prompt + component catalog +
+  few-shot accepted modules}. [S]
+
+### esbuild iframe path (Tier 2)
+- Keep server-side esbuild; add per-file transform-as-the-stream-closes and
+  incremental contexts for multi-file modules. [S–M]
+- Extend import-map vendoring into a versioned pre-vendored dep catalog built
+  at `vendo sync` time (Sandpack-CDN pattern, but host-local). [M]
+- Hot-swap edited modules via new blob URL + re-render (later react-refresh)
+  instead of stage remount; keeps MCP Apps session + UI state. [M]
+- Deterministic skeleton (existing remix machinery) renders while the bundle
+  compiles/validates; Tier-1 approximation renders while Tier 2 generates. [M]
+- v0-style mid-stream autofixers: run our existing render_view validation
+  gates *during* the stream and inject deterministic rescues (we already have
+  deterministic rescues in the CLI extractor lineage). [M]
+
+### server sandbox path (Tier 3)
+- Pre-booted base-sandbox pool per runtime flavor; generation writes files
+  into a warm sandbox, never boots cold. [M]
+- Nixpacks `cacheDirectories` + per-module `--cache-key`; only changed layers
+  rebuild on edit. [S]
+- Pause after successful build (4s/GiB is fine post-hoc); resume (~1s) on
+  module open, speculatively on hover. [M]
+- Evaluate an isolate middle tier for JS-only server modules (Dynamic Workers
+  hosted, or workerd/Deno self-hosted to stay BYO-infra): ms-start "light
+  server" tier; keep microVMs for Python/bash/binaries. [L]
+- Tier-1/Tier-2 surface renders immediately while the Tier-3 build runs;
+  module upgrades itself when the sandbox is live. [M]
+
+### edit loop (all tiers)
+- `edit_view`-style hunks extended per-file across module repos (baseline
+  normalization + baseHash per file); server materializes and rebuilds only
+  touched files. [M]
+- For big rewrites: abbreviated-edit → fast-apply materialization (Morph API,
+  or Predicted Outputs when on OpenAI; both slot behind one "materializer"
+  seam). Full-file regen on the fast lane for small files. [M]
+- Edits to Tier 2 → hot-swap (above); edits to Tier 3 → layer-cached rebuild
+  in the still-warm sandbox, never a fresh boot. [S, falls out of the above]
+
+### Suggested sequencing
+1 (stream-render) + 2 (prompt cache) are small and compounding — do first.
+Then 5 (progressive capability) as the product-defining move, with 6 and 3
+underneath it. 4 + 7 next as the edit loop hardens. 8 lands with Tier-3 GA;
+9 and 10 are the second wave.
+
+## Sources
+
+- Cerebras: cerebras.ai/blog/cerebras-kimi-k2-Enterprise · cerebras.ai/press-release/llama4PR · generalinput.com/blog/cerebras-kimi-k2-6-inference-speed-generative-ui
+- Groq: groq.com/lpu-architecture · groq.com/newsroom/groq-lpu-inference-engine-leads-in-first-independent-llm-benchmark
+- Fireworks × Vercel (40×, autofixer, adaptive speculation): fireworks.ai/blog/vercel
+- v0 architecture: vercel.com/blog/v0-composite-model-family · vercel.com/blog/how-we-made-v0-an-effective-coding-agent
+- Predicted Outputs: platform.openai.com/docs/guides/predicted-outputs · morphllm.com/openai/predicted-outputs
+- Prompt caching: anthropic.com/news/prompt-caching · platform.claude.com/docs/en/build-with-claude/prompt-caching
+- Constrained decoding: arxiv.org/pdf/2501.10868 (JSONSchemaBench) · tianpan.co/blog/2026-04-16-grammar-constrained-generation-output-reliability
+- Streaming partial JSON UI: thesys.dev/blogs/generative-ui-architecture · github.com/st3w4r/openai-partial-stream · aha.io/engineering/articles/streaming-ai-responses-incomplete-json
+- Sandpack: sandpack.codesandbox.io/docs/architecture/overview · danilowoz.com/blog/sandpack
+- WebContainers/Bolt: blog.stackblitz.com/posts/introducing-webcontainers · newsletter.posthog.com/p/from-0-to-40m-arr-inside-the-tech
+- Cursor fast apply / speculative edits: cursor.com/blog/instant-apply · fireworks.ai/blog/cursor
+- Morph: morphllm.com/blog/morph-gets-faster · morphllm.com/fast-apply-model
+- aider edit formats: aider.chat/docs/unified-diffs.html · aider.chat/docs/more/edit-formats.html
+- Cloudflare isolates / Dynamic Workers: blog.cloudflare.com/eliminating-cold-starts-with-cloudflare-workers · blog.cloudflare.com/dynamic-workers · infoq.com/news/2026/04/cloudflare-dynamic-workers-beta
+- E2B: e2b.dev/docs/sandbox/persistence · superagent.sh/blog/ai-code-sandbox-benchmark-2026 · gist.github.com/homanp/b0bb68dad99a9434057e37e730a66039
+- Firecracker/Fly: fly.io/docs/reference/suspend-resume · github.com/firecracker-microvm/firecracker (snapshot-support.md) · dev.to/adwitiya (28ms sandboxes)
+- Modal snapshots: modal.com/blog/mem-snapshots · modal.com/blog/gpu-mem-snapshots
+- Nixpacks caching: nixpacks.com/docs/configuration/caching
+- Model routing/cascades: tianpan.co/blog/2025-11-03-llm-routing-model-cascades


### PR DESCRIPTION
Track 1 of the standalone-blocks re-architecture: specs **@vendoai/core** as the shared foundation every block builds on. This is a design spec (no code), the deliverable of a full brainstorming session.

## What's in `docs/specs/2026-07-10-vendoai-core-spec.md`
- **Tool contract** — neutral `ToolDescriptor` + risk labels (read/write/destructive), structurally duck-types as a Vercel AI SDK tool; ingestion (`fromAiSdkTools`/`fromMcp`) so guard/meter cover an existing agent's tools too
- **Principal** — user/anonymous union; anonymous makes `vendo init` work before identity wiring
- **Module** = git repo + system-written envelope; three emergent tiers (view.json / iframe UI / server micro-app); scoop→store→pour lifecycle; the **seal** (approvalSeal vs buildKey)
- **Permissions** — no static allowlists; module-scoped grants + provenance on every call; parked actions
- **Threat model** — invariants I1–I10 as testable contracts (deny-all egress, unforgeable provenance, provenance-gated secrets, argument-bounded write grants, host-owned risk labels, fail-closed seal, capability-bound bridge, tainted host input)
- **Module runtime** + **MCP-Apps-native** module↔host protocol
- **Storage** — per-concern slices, `database` config, structural anonymous enforcement
- **Theme**, **.vendo/** directory, **eviction map**, big-bang 0.3.0 migration
- Contracts validated with block-level usage sketches (§15)

## Supporting research (also included)
- `research-2026-07-framework-landscape.md` — verified ecosystem facts (MCP Apps stable, Vercel duck-typing, Standard Schema)
- `research-2026-07-module-speed.md` + `research-2026-07-apps-speed-capability.md` — generation/render/edit speed roadmap

## Review
Hardened across two review rounds (Codex architecture + adversarial-security lenses, Fable) plus a round-3 consistency pass. Architecture cleared clean; remaining depth is intentionally delegated to owning tracks as invariants.

> Note: AI-reviewed design spec, not yet built or verified against a running system. Human review is the gate before implementation.

https://claude.ai/code/session_01TnbAwUqTbwBAGKyKRGEmao
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `@vendoai/core` re-architecture spec (track 1) as the shared foundation for all blocks. Includes supporting research on framework compatibility and module/app speed; docs only.

- **New Features**
  - Neutral `ToolDescriptor` with risk labels; ingest from `ai` tools and MCP.
  - Principal model (user/anonymous) and module envelope with `approvalSeal` vs build key; runtime and MCP-Apps host protocol.
  - Module-scoped permissions with provenance and parked actions; host-owned risk labels.
  - Threat-model invariants I1–I10 (deny-all egress, unforgeable provenance, provenance-gated secrets, bounded writes, fail-closed seal).
  - Storage slices and `database` config; `.vendo/`, theme, eviction map; 0.3.0 migration plan; usage sketches.

<sup>Written for commit aa92c3d74e07ec7e5c0afdba32ffd37635f21fbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

