### PR TITLE
docs(specs): app format v0 design

### DIFF
--- a/docs/superpowers/specs/2026-07-11-app-format-design.md
+++ b/docs/superpowers/specs/2026-07-11-app-format-design.md
@@ -29,7 +29,7 @@ Not in the folder, by construction:
 
 ## 2. Storage of the artifact
 
-The folder is a logical shape. Its canonical home is the store (host Postgres, `vendo_` tables), content-addressed so versions and forks share unchanged files. This content-addressed layer is new work, not the current flat saved-record store. The folder materializes to a real filesystem in three places: inside the sandbox at rungs 2 to 4, on `.vendoapp` export, and optionally as a dev checkout. Apps are addressed by id; files within an app by folder path. Tar ingestion safety and canonical hashing rules live in an implementation appendix, not this spec.
+The folder is a logical shape with one storage rule: file contents live in the app file store (S3-compatible object storage, content-addressed so versions and forks share unchanged files; a local-disk default keeps zero-config installs working). Everything queryable lives in Postgres (`vendo_` tables): manifests, version graph, head pointers, installs, and all app records. This content-addressed layer is new work, not the current flat saved-record store. The folder materializes to a real filesystem in three places: inside the sandbox at rungs 2 to 4, on `.vendoapp` export, and optionally as a dev checkout. Apps are addressed by id; files within an app by folder path. Tar ingestion safety and canonical hashing rules live in an implementation appendix, not this spec.
 
 ## 3. Installs
 

--- a/docs/superpowers/specs/2026-07-11-app-format-design.md
+++ b/docs/superpowers/specs/2026-07-11-app-format-design.md
@@ -1,141 +1,90 @@
 # Vendo App Format v0 (design)
 
 Date: 2026-07-11
-Status: approved in brainstorm with Yousef; revised after triple review (Opus review, Codex review, Codex clean-room design). Feeds wave 2 (contracts) of the v0 campaign.
-Ground truth: the "Open-Source Full Stack Agentic Interface" Notion page. This spec fills what the page defers to the app-format brainstorm; it changes no page decision.
-Scope: the artifact format only. Runtime internals and the generation engine are out of scope. Trigger details belong to the automations wave.
+Status: approved with Yousef after triple review (Opus review, Codex review, Codex clean-room design) and successive simplification. Feeds wave 2 (contracts) of the v0 campaign.
+Ground truth: the "Open-Source Full Stack Agentic Interface" Notion page. This spec changes no page decision.
+Scope: the artifact format only. How a runtime stores apps (tables, caches, history) is the runtime's business, not this spec's. Trigger details belong to the automations wave.
 
-## 1. Core model
+## 1. The format
 
-One artifact for everything Vendo produces: an app is a folder with a manifest. A quick chat view is an unsaved app with only a UI. An automation is an app with a trigger. Nothing converts between kinds; fields accumulate as the app grows. The format is named `vendo/app@1`. The interchange form (sharing, the open standard, shipping to a sandbox) is the folder as a tarball, extension `.vendoapp`.
-
-Apps have two origins, same format: created from new (born in conversation, no lineage, runs jailed) and remixed from the product (a pin: a fork of a host component's real source, see section 8). The user never chooses between them; both are just conversation.
-
-```
-invoice-notes/
-├─ manifest.json          # identity + structure declarations
-├─ ui/
-│  ├─ view.json           # a Tree document (wire format: vendo-genui/v1)
-│  └─ components/*.tsx    # novel agent-written components, one file each, PascalCase
-├─ pins/*.tsx             # forks of host components, one per slot, named by slot id
-└─ server/                # only if graduated: real code, any shape; manifest names entries
-```
-
-Not in the folder, by construction:
-
-- The app's data. It lives in the store, per install. Sharing an app never shares data.
-- The install record (see section 3): version pointer, per-user state, view cache, screenshot.
-- Grants and approvals. Authority never lives in an artifact (section 7).
-
-## 2. Storage of the artifact
-
-The folder is the interchange shape (export and sandbox), not the storage shape. Storage follows one split:
-
-- Apps without `server/` (rungs 1 to 3, the overwhelming case): one Postgres row per version holding the manifest fields and the UI inline (jsonb tree + component sources). No object storage involved. This is close to the existing saved-record store.
-- Apps with `server/`: the same version row, plus the project files in an S3-compatible object store (content-addressed per file so a 50-file project edited one file at a time is not duplicated per version; local-disk default keeps zero-config installs working), plus a sandbox snapshot id per version.
-
-`manifest.json` and the folder exist only at the edges: export mints them from the row (`.vendoapp`), the sandbox materializes them, import maps them back. Apps are addressed by id; files within an app by folder path. Tar ingestion safety rules live in an implementation appendix, not this spec.
-
-## 3. Installs
-
-An install is the host-minted record binding an app to a user: which version is live for them, their `state`, their view cache and screenshot (the instant-open snapshot, a cache and never truth), and their storage namespace. Grants and data key off the install record, never off anything written inside the artifact. An imported or shared app always gets a fresh install: empty data, no grants, regardless of what its manifest claims.
-
-## 4. Manifest
-
-Keys are present only when the app has the part; absent means the app does not have it. A kept chat view carries only `format`, `id`, `name`, `ui`. Maximal example for key reference:
+An app is one document. Fields are absent until the app grows them. A quick chat view is this document with only `name`, `ui`, and `tree`; an automation is the same document with a `trigger`.
 
 ```json
 {
   "format": "vendo/app@1",
   "id": "app_7f3k",
-  "name": "Invoice Notes",
-  "description": "Pin comments to invoices",
-  "ui": { "kind": "tree", "source": "static" },
+  "name": "Invoice Chaser",
+  "description": "Chases overdue invoices every Monday",
+  "ui": "tree",
+  "tree": { "root": "...", "nodes": ["..."], "data": {}, "queries": ["..."] },
+  "components": { "SpendChart": "export default function SpendChart(props) { ... }" },
   "storage": { "notes": { "about": "comments pinned to invoices",
                           "refs": { "invoice_id": "host.invoice" } } },
-  "server": { "entry": "server/chase.ts" },
+  "server": "e2b:snap_x91",
   "trigger": { "schedule": "mon 9:00" },
-  "pins": [ { "slot": "invoice-card", "base": "sha256:ab12..." } ],
   "egress": ["api.stripe.com"],
-  "secrets": ["STRIPE_KEY"]
+  "secrets": ["STRIPE_KEY"],
+  "pins": [ { "slot": "invoice-card", "base": "sha256:ab12..." } ],
+  "forkedFrom": "app_2c9d"
 }
 ```
 
-- `ui`: always an object. `kind`: `tree` or `http`. `source`: `static` or `server` (tree only).
-- `storage`: named collections with a one-line description. Contents are free-form JSON, no schemas, no migrations, orphan records acceptable. The only typed part is host-entity refs (`host.` namespace, the vocabulary `vendo init` extracts), which the store materializes as indexed columns so hosts can join app records onto their entities (the mechanism is new work in the store adapter). Storage kinds are a small expandable vocabulary: `records` (default) and `files` in v0; later kinds are one new word plus a store adapter. Declaring an unsupported kind fails cleanly at install.
-- `state` is a reserved built-in: one free-form record per install, zero declaration.
-- `egress` and `secrets` are sandbox wiring, not a permission model: the egress allowlist the sandbox enforces, and the names of secrets injected at runtime (app code receives handles, never values).
-- There is no tools or permissions field. See section 7.
-- A fork mints a new `id` and records `forkOf`.
+Export: the document plus the app's directory (pulled from the snapshot, when one exists) zipped as `<name>.vendoapp`. Import: load the document, spin a fresh machine from the directory if present.
 
-## 5. Surfaces and the ladder
+## 2. The fields
 
-The Tree is the spec name for today's payload; the wire string stays `vendo-genui/v1` (renaming it would break stored records and tool contracts for no functional gain). Fields: `root`, `nodes` (prewired | host | generated), `data`, `queries`. A tree is a file type, not a mode. Two planes by contract:
+- `ui`: `tree` (rendered on the instant jailed path) or `http` (served by the app's machine). With `http`, the last `tree` is kept as the fallback and loading cover.
+- `tree`: the UI payload. Spec name Tree; wire format stays `vendo-genui/v1` (renaming would break stored records and tool contracts). Fields: `root`, `nodes` (prewired | host | generated), `data`, `queries`.
+- `components`: novel agent-written JSX, compiled in milliseconds, run in the jail.
+- `storage`: named record collections. One-line description each, free-form JSON contents, no schemas, no migrations, orphans acceptable. Only host-entity refs are typed (`host.` namespace) so hosts can join app records onto their entities. `state` is a reserved built-in: one free-form record per user per app, zero declaration. Kinds: `records` (default) and `files`; new kinds are one word plus a store adapter.
+- `server`: a sandbox snapshot reference. The machine IS the server part: its filesystem holds the code and the app's own files (page rule: code and files persist as part of the app). No entry point is declared; by convention the app listens on `$PORT`, and UI requests, function calls, and trigger firings arrive as requests to it. The agent edits inside the machine, then it is re-snapshotted. Snapshots resume in about a second, so wake is fast.
+- `trigger`: set = the app is an automation. Details owned by the automations wave.
+- `egress` / `secrets`: sandbox wiring, not a permission model. The egress allowlist the machine's network enforces, and the names of secrets injected at runtime (app code gets handles, never values).
+- `pins`: forks of host components (section 5).
+- There is no tools or permissions field (section 4).
 
-- Tree surface: instant and jailed (`connect-src 'none'`), millisecond compile, catalog-validated before shipping.
-- Sandbox: no ceiling, boot-tolerant, snapshot-resumed.
+## 3. The ladder
 
-The ladder (the agent escalates; the user never picks a tier):
+The agent escalates; the user never picks a tier:
 
-1. Static tree. No sandbox.
-2. Tree + server functions. UI unchanged; buttons and queries call sandbox functions.
-3. Server-computed tree. The sandbox returns trees; rendering stays on the instant path.
-4. Served UI. The sandbox serves a real web app; iframe `connect-src` is the sandbox origin plus manifest egress. Last resort, only when the interface outgrows trees. Never a prerequisite.
+1. Tree only. Instant, jailed (`connect-src 'none'`), no machine.
+2. Tree + server. UI unchanged; buttons and queries call the machine.
+3. Server-computed tree. The machine returns trees; rendering stays on the instant path.
+4. `ui: http`. The machine serves a real web app. Last resort, only when the interface outgrows trees. Never a prerequisite.
 
-Invisible graduation is a product requirement on runtimes (non-normative for the format): the tree renderer ships in served-app scaffolds so the first served version renders the identical tree; apps open on their last state (live tree at rungs 1 to 3, dimmed screenshot at rung 4); the old rung serves while the next builds.
+Invisible graduation is a requirement on runtimes: apps open on their last state (live tree, or a dimmed screenshot while the machine resumes at rung 4); the tree renderer ships in served-app scaffolds so the first served version renders the identical tree; the old rung keeps serving while the next builds.
 
-## 6. Versions and editing
+Editing is one loop (patch, validate, apply, undo) with two dialects: tree edits are structured operations validated against the host catalog (a completed tree cannot ship broken); code edits are text hunks, syntax-checked, contained by error boundaries. Undo/history is runtime UX (a capped log), not format.
 
-Git-shaped, not git. A version is an immutable content-addressed snapshot of the folder. `head` points at the live version (in the registry, not the folder); rollback moves the pointer; remix is a fork. Each version records the intent that produced it, so history reads as a changelog. Rollback rewinds code, never data. Real git appears only inside rung-4 sandboxes if the agent chooses.
+## 4. The one security rule
 
-Editing is one loop (patch, validate, version with intent, rehearse before reality) with two dialects:
+An app never has authority. Only the user running it does, and guard (the existing consent, policy, and grant machinery: input previews, exact or constrained scopes, critical tools always ask) asks that user in context at the moment of the call. Approvals never transfer between users.
 
-- Tree edits: structured operations validated against the host catalog before applying. Instant. A completed tree cannot ship broken; partial trees exist only as stream states, never as persisted versions.
-- Code edits: text hunks, syntax-checked at compile (transform only, not typecheck), contained by error boundaries at runtime.
+Consequences: a shared app with hidden or dormant calls can do nothing without the running user being asked with the real inputs; artifacts and exports carry zero authority; grants and data belong to each user's install, never to the artifact; away runs hold only the grants captured while the user was present, and an ungranted call fails soft and queues for approval; org publishing (cloud) controls distribution, never authority.
 
-Hand-editing files is a first-class escape hatch.
-
-## 7. The one security rule
-
-An app never has authority. Only the user running it does, and guard (the umbrella term for the existing consent, policy, and grant-store machinery) asks that user in context at the moment of the call: input previews, exact or constrained scopes, durations, and critical tools always ask. Approvals never transfer between users.
-
-Everything follows from the rule:
-
-- A shared app with hidden or dormant calls can do nothing: when the call fires, the running user is asked, sees the inputs, and decides. There is nothing to predict at review time because nothing runs without in-context consent.
-- Grants key off the install record (section 3), so no artifact can arrive with, claim, or inherit authority. Exports carry zero authority by construction.
-- Away runs (automations) hold only the grants captured while the user was present (page rule). An ungranted call fails soft and queues for approval.
-- Org publishing (cloud) controls distribution, never authority.
-
-Keying grants per install is new work: today's grants are keyed per user and tool only.
-
-## 8. Pins
+## 5. Pins
 
 A pin is an edit of the host's actual component source, running in the product after host approval.
 
-- The host marks a component remixable (opt-in, per file). `vendo sync` captures its real source. Backend code is never captured.
-- A pin is a fork with lineage: the edited source plus `{ slot, base: sourceHash }`. Same editing loop as everything else, rehearsed in the furnished jail (real sub-components and styles, host-state hooks stubbed with recorded data).
-- Approval reviews the net diff against the host baseline and pins the content hash in the host registry. The host page never executes unapproved code.
-- Approved pins mount in the host's real React tree with full host-page authority; the diff review is the control, stated plainly.
-- Host component updates mark the pin drifted; the agent rebases recorded intents onto the new baseline, through approval again. An erroring pin falls back to the original component.
-- Dependency capture depth and closure hashing are implementation notes, not format.
+- Host marks a component remixable (opt-in, per file); its real source is captured at sync. Backend code is never captured.
+- The user edits a fork conversationally, rehearsed in the furnished jail (real sub-components and styles, stubbed data). The product keeps running the original the whole time.
+- Shipping sends the net diff against the host baseline for approval; the approved copy is held by the host registry, pinned to its hash. The host page never executes unapproved code.
+- Approved pins mount natively in the host page with full host-page authority; the diff review is the control.
+- Host updates to the component mark the pin drifted; the agent rebases the recorded intents onto the new source, through approval again. An erroring pin falls back to the original.
 
-## 9. Sharing and export
+## 6. Sharing and export
 
-- Sharing hands over a frozen copy: fresh install, empty data, no grants.
-- A `.vendoapp` export contains only the folder. Data, caches, and grants live outside it by construction and cannot leak.
-- Host-derived files (pins) export only with host permission; export fails rather than silently stripping them (a stripped pin changes behavior).
-- Jail and sandbox rules are unchanged by sharing: no network in the jail, manifest egress in the sandbox, secrets never readable.
+Sharing and publishing hand over a copy (fresh install, empty data, no grants); freezing is by copying, never by pointing into the author's history. `.vendoapp` exports contain only the document and the app directory: no data, no caches, no grants, no snapshots. Host-derived pin source exports only with host permission, and export fails rather than silently stripping the pin.
 
-## 10. Encoding commitments
+## 7. Encoding commitments
 
-Named now, designed later: a token-compact wire profile of the tree (same structure, mechanically convertible with the readable form); valid-while-partial streaming semantics; catalog-aware autofix (hallucinated names corrected without a model round-trip).
+Named now, designed later: a token-compact wire profile of the tree (mechanically convertible with the readable form); valid-while-partial streaming semantics; catalog-aware autofix against the host catalog.
 
-## 11. Deferred
+## 8. Deferred
 
 - Compact encoding design and benchmarks.
 - Trigger declaration details (automations wave).
-- Server block execution contract (runtime id, build and start commands, function-export mapping) and tree references to server functions: wave 2 contracts work.
 - Pin capture-depth rules.
 - Jail dependency set: fixed blessed kit vs per-host vendored extensions.
-- Tar ingestion and canonical hashing appendix.
+- Multi-view tree apps (a few named screens without graduating to http): raised, unanswered.
 - Marketplace and cross-org distribution.

--- a/docs/superpowers/specs/2026-07-11-app-format-design.md
+++ b/docs/superpowers/specs/2026-07-11-app-format-design.md
@@ -1,7 +1,7 @@
 # Vendo App Format v0 (design)
 
 Date: 2026-07-11
-Status: approved in brainstorm with Yousef; feeds wave 2 (contracts) of the v0 campaign.
+Status: approved in brainstorm with Yousef; revised after triple review (Opus review, Codex review, Codex clean-room design). Feeds wave 2 (contracts) of the v0 campaign.
 Ground truth: the "Open-Source Full Stack Agentic Interface" Notion page. This spec fills what the page defers to the app-format brainstorm; it changes no page decision.
 Scope: the artifact format only. Runtime internals and the generation engine are out of scope. Trigger details belong to the automations wave.
 
@@ -9,31 +9,35 @@ Scope: the artifact format only. Runtime internals and the generation engine are
 
 One artifact for everything Vendo produces: an app is a folder with a manifest. A quick chat view is an unsaved app with only a UI. An automation is an app with a trigger. Nothing converts between kinds; fields accumulate as the app grows. The format is named `vendo/app@1`. The interchange form (sharing, the open standard, shipping to a sandbox) is the folder as a tarball, extension `.vapp`.
 
-## 2. Folder layout
+Apps have two origins, same format: created from new (born in conversation, no lineage, runs jailed) and remixed from the product (a pin: a fork of a host component's real source, see section 8). The user never chooses between them; both are just conversation.
 
 ```
 invoice-notes/
-├─ manifest.json          # identity + structure declarations (the full list below)
+├─ manifest.json          # identity + structure declarations
 ├─ ui/
-│  ├─ view.json           # a Tree document (vendo/tree@1)
+│  ├─ view.json           # a Tree document (wire format: vendo-genui/v1)
 │  └─ components/*.tsx    # novel agent-written components, one file each, PascalCase
 ├─ pins/*.tsx             # forks of host components, one per slot, named by slot id
 └─ server/                # only if graduated: real code, any shape; manifest names entries
 ```
 
-Not in the folder:
+Not in the folder, by construction:
 
-- The app's data. It lives in the store, per user. Sharing an app never shares data.
-- The snapshot (last tree + last data, plus a screenshot at rung 4). Per-user cache kept alongside an install. Never truth: deleting it costs only the instant open.
-- Grants and approvals. Trust records live in guard and the host/org registry, never in the artifact. An artifact cannot declare itself trusted, and a `.vapp` ships with zero authority.
+- The app's data. It lives in the store, per install. Sharing an app never shares data.
+- The install record (see section 3): version pointer, per-user state, view cache, screenshot.
+- Grants and approvals. Authority never lives in an artifact (section 7).
 
-## 3. Storage of the artifact itself
+## 2. Storage of the artifact
 
-The folder is a logical shape. Its canonical home is the store (host Postgres, `vendo_` tables), content-addressed like git objects, so versions and forks share unchanged files. It materializes to a real filesystem in exactly three places: inside the sandbox at rungs 2 to 4, on `.vapp` export, and optionally as a dev checkout. Apps are addressed by `id`; files within an app by folder path.
+The folder is a logical shape. Its canonical home is the store (host Postgres, `vendo_` tables), content-addressed so versions and forks share unchanged files. This content-addressed layer is new work, not the current flat saved-record store. The folder materializes to a real filesystem in three places: inside the sandbox at rungs 2 to 4, on `.vapp` export, and optionally as a dev checkout. Apps are addressed by id; files within an app by folder path. Tar ingestion safety and canonical hashing rules live in an implementation appendix, not this spec.
+
+## 3. Installs
+
+An install is the host-minted record binding an app to a user: which version is live for them, their `state`, their view cache and screenshot (the instant-open snapshot, a cache and never truth), and their storage namespace. Grants and data key off the install record, never off anything written inside the artifact. An imported or shared app always gets a fresh install: empty data, no grants, regardless of what its manifest claims.
 
 ## 4. Manifest
 
-Keys present only when used; nothing is ever null, false, or empty. Real manifests are tiny and grow with the app: a kept chat view carries only `format`, `id`, `name`, `ui`. Maximal example for key reference:
+Keys are present only when the app has the part; absent means the app does not have it. A kept chat view carries only `format`, `id`, `name`, `ui`. Maximal example for key reference:
 
 ```json
 {
@@ -41,7 +45,7 @@ Keys present only when used; nothing is ever null, false, or empty. Real manifes
   "id": "app_7f3k",
   "name": "Invoice Notes",
   "description": "Pin comments to invoices",
-  "ui": "tree",
+  "ui": { "kind": "tree", "source": "static" },
   "storage": { "notes": { "about": "comments pinned to invoices",
                           "refs": { "invoice_id": "host.invoice" } } },
   "server": { "entry": "server/chase.ts" },
@@ -52,103 +56,81 @@ Keys present only when used; nothing is ever null, false, or empty. Real manifes
 }
 ```
 
-- `ui`: `"tree"` shorthand for the common case; long form `{ "kind": "tree" | "http", "source": "static" | "server" }` for the upper rungs.
-- `storage`: named collections with a one-line human description. Contents are free-form JSON, no schemas, no migrations, orphan records are acceptable (WordPress postmeta spirit, per the page). The only typed part is host-entity refs (`host.` namespace, same vocabulary `vendo init` extracts), which become indexed columns so hosts can join app records onto their entities. This one declared line is what makes the custom-fields story work. Storage kinds are a small expandable vocabulary: `records` (Postgres) and `files` (file storage) in v0; later kinds (vectors, kv, queues) are one new word plus a store adapter, no format surgery. An app declaring an unsupported kind fails cleanly at install.
-- `state` is a reserved built-in: one singleton free-form record per user per app, zero declaration. The ladder's "state" rung exists experientially but costs no format concept.
-- There is no permissions or tools field. See section 8.
-- Fork lineage: a fork mints a new `id` and records `forkOf`.
+- `ui`: always an object. `kind`: `tree` or `http`. `source`: `static` or `server` (tree only).
+- `storage`: named collections with a one-line description. Contents are free-form JSON, no schemas, no migrations, orphan records acceptable. The only typed part is host-entity refs (`host.` namespace, the vocabulary `vendo init` extracts), which the store materializes as indexed columns so hosts can join app records onto their entities (the mechanism is new work in the store adapter). Storage kinds are a small expandable vocabulary: `records` (default) and `files` in v0; later kinds are one new word plus a store adapter. Declaring an unsupported kind fails cleanly at install.
+- `state` is a reserved built-in: one free-form record per install, zero declaration.
+- `egress` and `secrets` are sandbox wiring, not a permission model: the egress allowlist the sandbox enforces, and the names of secrets injected at runtime (app code receives handles, never values).
+- There is no tools or permissions field. See section 7.
+- A fork mints a new `id` and records `forkOf`.
 
 ## 5. Surfaces and the ladder
 
-The Tree (`vendo/tree@1`) is the formalization of today's `vendo-genui/v1` payload: `root`, `nodes` (prewired | host | generated), `data`, `dataQueries`. A tree is a file type, not a mode; it is the fastest surface a runtime can show. Two planes by contract:
+The Tree is the spec name for today's payload; the wire string stays `vendo-genui/v1` (renaming it would break stored records and tool contracts for no functional gain). Fields: `root`, `nodes` (prewired | host | generated), `data`, `queries`. A tree is a file type, not a mode. Two planes by contract:
 
-- Tree surface: instant and jailed. Renders in the egress-jailed iframe (`connect-src 'none'`), millisecond compile, no build step, host catalog validated server-side before shipping.
-- Sandbox: no ceiling and boot-tolerant. Any code, any language. Snapshot-resumed so wake is seconds, not builds.
+- Tree surface: instant and jailed (`connect-src 'none'`), millisecond compile, catalog-validated before shipping.
+- Sandbox: no ceiling, boot-tolerant, snapshot-resumed.
 
 The ladder (the agent escalates; the user never picks a tier):
 
-1. Static tree. No sandbox exists. Today's shipped path.
-2. Tree + server functions. UI unchanged and instant; buttons and data queries call sandbox functions, which may be stale-while-boot.
-3. Server-computed tree. The sandbox returns trees; rendering stays on the instant path, brand-checked and guard-bound. Server brains, pushed face.
-4. Served UI. The sandbox serves a real web app; the iframe points at it; iframe `connect-src` is the sandbox origin only, plus manifest egress. Last resort, taken only when the interface itself outgrows trees (npm UI libraries, multi-page). Never a prerequisite for anything.
+1. Static tree. No sandbox.
+2. Tree + server functions. UI unchanged; buttons and queries call sandbox functions.
+3. Server-computed tree. The sandbox returns trees; rendering stays on the instant path.
+4. Served UI. The sandbox serves a real web app; iframe `connect-src` is the sandbox origin plus manifest egress. Last resort, only when the interface outgrows trees. Never a prerequisite.
 
-Invisible graduation is a hard requirement: the user never sees the UI change at a rung jump.
+Invisible graduation is a product requirement on runtimes (non-normative for the format): the tree renderer ships in served-app scaffolds so the first served version renders the identical tree; apps open on their last state (live tree at rungs 1 to 3, dimmed screenshot at rung 4); the old rung serves while the next builds.
 
-- The tree renderer ships as a library in served-app scaffolds, so a graduated app's first served version renders the identical tree and diverges only on later requests.
-- Every app opens on its last state: the live tree at rungs 1 to 3, a dimmed non-interactive screenshot at rung 4 (iOS app-switcher pattern) while the sandbox resumes.
-- The old rung keeps serving while the next one builds; the switch is agent-narrated, never silent.
+## 6. Versions and editing
 
-## 6. Versioning
+Git-shaped, not git. A version is an immutable content-addressed snapshot of the folder. `head` points at the live version (in the registry, not the folder); rollback moves the pointer; remix is a fork. Each version records the intent that produced it, so history reads as a changelog. Rollback rewinds code, never data. Real git appears only inside rung-4 sandboxes if the agent chooses.
 
-Git-shaped, not git. A version is an immutable content-addressed snapshot of the folder (`sha256:...`). `head` points at the live version; rollback moves the pointer; remix is a fork. Human-facing versions are `v1, v2, ...` and each records the intent (the user instruction that produced it), so history reads as a changelog and enables pin rebases. Real git appears only inside rung-4 sandboxes if the agent chooses; the format never requires it.
+Editing is one loop (patch, validate, version with intent, rehearse before reality) with two dialects:
 
-## 7. Editing
+- Tree edits: structured operations validated against the host catalog before applying. Instant. A completed tree cannot ship broken; partial trees exist only as stream states, never as persisted versions.
+- Code edits: text hunks, syntax-checked at compile (transform only, not typecheck), contained by error boundaries at runtime.
 
-One loop everywhere: patch, validate, version with intent, rehearse before reality. Two patch dialects, because the material differs:
+Hand-editing files is a first-class escape hatch.
 
-- Tree edits (`view.json`): structured operations (set prop, wrap nodes, rebind query), validated against the host catalog before applying. Instant, no compile. Trees cannot ship broken.
-- Code edits (`components/*.tsx`, `pins/*.tsx`, `server/`): text hunks, compile-checked, contained by error boundaries at runtime. Code fails contained.
+## 7. The one security rule
 
-Each file type declares its edit dialect and validator. One user instruction may compile to a mix of ops and hunks and lands as one version with one intent. Hand-editing files is a first-class escape hatch; the agent is the default editor, not the only one.
+An app never has authority. Only the user running it does, and guard (the umbrella term for the existing consent, policy, and grant-store machinery) asks that user in context at the moment of the call: input previews, exact or constrained scopes, durations, and critical tools always ask. Approvals never transfer between users.
 
-## 8. Permissions: guard owns everything
+Everything follows from the rule:
 
-The manifest carries no permissions. Industry precedent: capability handles plus ask-at-first-use (iOS, OAuth incremental auth, Deno, WASI) over author-declared permission manifests (Android, Chrome extensions), which drift and over-ask. Guard is already the former; the format follows it.
+- A shared app with hidden or dormant calls can do nothing: when the call fires, the running user is asked, sees the inputs, and decides. There is nothing to predict at review time because nothing runs without in-context consent.
+- Grants key off the install record (section 3), so no artifact can arrive with, claim, or inherit authority. Exports carry zero authority by construction.
+- Away runs (automations) hold only the grants captured while the user was present (page rule). An ungranted call fails soft and queues for approval.
+- Org publishing (cloud) controls distribution, never authority.
 
-- Apps act only through handed-in capability doors: `vendo.dispatch` in the jail, the server SDK in the sandbox. There is no other path to a tool.
-- Guard keeps a grant ledger per app. First call to an ungranted tool triggers the ask in context; the grant is sticky until revoked (existing guard model, keyed by app).
-- Publish review shows the ledger: observed truth about what the app actually uses, not author claims. A new version calling a new tool has no grant, so the ask fires by construction (user for personal apps, org admin for published ones). Capability expansion re-approval needs no diffing machinery.
-- Away runs (automations) hold only their ledger. An ungranted call fails soft and queues for approval. Grants captured while the user is present are the only authority (page rule).
-- Blast-radius warnings join changed tools against ledgers.
-- Exports carry zero authority. Optionally a `.vapp` may include an advisory `uses:` list (derived mechanically for trees) as a courtesy label, never enforcement.
+Keying grants per install is new work: today's grants are keyed per user and tool only.
 
-## 9. Pins: remixing the product itself
+## 8. Pins
 
-A pin is an edit of the host's actual component source, running in-client after host approval, indistinguishable from shipped product code.
+A pin is an edit of the host's actual component source, running in the product after host approval.
 
-- Host marks a component remixable (opt-in, per file). `vendo sync` captures its real source and dependency closure. Backend code never enters the system.
-- A pin is a fork with lineage: the edited source plus `{ slot, base: sourceHash }`. Same editing loop as everything else.
-- Rehearsal: before approval, the fork renders only in the furnished jail (captured real sub-components and styles, host-state hooks stubbed with recorded data). Pixel-faithful for look and behavior, simulated at the data seams. The host page never executes unapproved code.
-- Approval reviews the net diff against the host baseline, PR-shaped. Approval pins the content hash in the registry. Later edits repeat the cycle while the approved hash keeps serving.
-- Mounting: the remixable marking wraps the component in a slot. No approved pin: render the original, near-zero cost. Approved pin: mount the fork in the host's real React tree, imports bound to the real modules (the same imports the jail furnished as copies). Same file, two mounting worlds; approval flips the binding.
-- Drift: the host ships a new component version, the pin's base is stale. Keep serving the old approved fork, notify, and the agent rebases recorded intents onto the new baseline, through approval again.
-- Failure: an erroring pin falls back to the original component. Stock, never broken.
-- Capture depth (dependency-closure rules: what is vendorable, what is stubbed) is the engineering meat of pins and gets its own spec section later.
+- The host marks a component remixable (opt-in, per file). `vendo sync` captures its real source. Backend code is never captured.
+- A pin is a fork with lineage: the edited source plus `{ slot, base: sourceHash }`. Same editing loop as everything else, rehearsed in the furnished jail (real sub-components and styles, host-state hooks stubbed with recorded data).
+- Approval reviews the net diff against the host baseline and pins the content hash in the host registry. The host page never executes unapproved code.
+- Approved pins mount in the host's real React tree with full host-page authority; the diff review is the control, stated plainly.
+- Host component updates mark the pin drifted; the agent rebases recorded intents onto the new baseline, through approval again. An erroring pin falls back to the original component.
+- Dependency capture depth and closure hashing are implementation notes, not format.
 
-## 10. Two species, one system
+## 9. Sharing and export
 
-| | App (create from new) | Pin (remix the product) |
-|---|---|---|
-| Born from | conversation | pointing at a host-marked component |
-| Lineage | none | fork of host source, base hash |
-| Runs | jailed by default, sandbox rungs | rehearsal jail, then in-client when approved |
-| Ship gate | grant ledger review | net-diff review |
-| Host updates | irrelevant | drift, rebase, re-approve |
-| Failure | own error boundary | slot falls back to original |
+- Sharing hands over a frozen copy: fresh install, empty data, no grants.
+- A `.vapp` export contains only the folder. Data, caches, and grants live outside it by construction and cannot leak.
+- Host-derived files (pins) export only with host permission; export fails rather than silently stripping them (a stripped pin changes behavior).
+- Jail and sandbox rules are unchanged by sharing: no network in the jail, manifest egress in the sandbox, secrets never readable.
 
-The user never chooses a path; "make me something" and "change this" are both conversation. The format routes the trust question to the right shape automatically.
+## 10. Encoding commitments
 
-## 11. Security and exfiltration rules
+Named now, designed later: a token-compact wire profile of the tree (same structure, mechanically convertible with the readable form); valid-while-partial streaming semantics; catalog-aware autofix (hallucinated names corrected without a model round-trip).
 
-- Remix captures host-marked client components only. Server-side host code is never captured.
-- Lineage is export control: host-derived files never leave the host's boundary. `.vapp` export strips pins unless host policy says otherwise. Same-product sharing is fine (recipients' browsers already run that code).
-- Jail: no network, no secrets, effects only via guard-gated dispatch. Sandbox: manifest egress allowlist, secrets injected by name, never readable.
-- In-client execution replaces the jail with human judgment: small reviewable diffs, hash-pinned approvals, per-version re-review. This trade is explicit.
-- Source goes to the host's own BYO LLM provider during editing; note in host-facing security docs.
-
-## 12. Encoding commitments
-
-Named now, designed later (the design is measurement work, not brainstorm work):
-
-- The tree structure is versioned (`vendo/tree@1`).
-- A token-compact wire profile of the same structure will exist; readable and compact forms are mechanically convertible. The standard stays readable, the wire stays cheap. Rationale: LLM latency is roughly linear in output tokens (compact UI DSLs measure ~65% token reduction vs markup).
-- The payload defines valid-while-partial semantics so renderers stream components as they generate (A2UI precedent: parse and heal partial output).
-- Catalog-aware autofix is sanctioned: hallucinated component or prop names correctable against the host catalog without a model round-trip (v0 precedent).
-
-## 13. Deferred
+## 11. Deferred
 
 - Compact encoding design and benchmarks.
-- Trigger declaration details (automations wave owns them).
-- Pin capture-depth rules (own spec section).
-- Jail dependency set: fixed blessed kit vs per-host vendored extensions (raised, unanswered).
-- Marketplace and cross-org distribution details.
+- Trigger declaration details (automations wave).
+- Server block execution contract (runtime id, build and start commands, function-export mapping) and tree references to server functions: wave 2 contracts work.
+- Pin capture-depth rules.
+- Jail dependency set: fixed blessed kit vs per-host vendored extensions.
+- Tar ingestion and canonical hashing appendix.
+- Marketplace and cross-org distribution.

--- a/docs/superpowers/specs/2026-07-11-app-format-design.md
+++ b/docs/superpowers/specs/2026-07-11-app-format-design.md
@@ -29,7 +29,12 @@ Not in the folder, by construction:
 
 ## 2. Storage of the artifact
 
-The folder is a logical shape with one storage rule: file contents live in the app file store (S3-compatible object storage, content-addressed so versions and forks share unchanged files; a local-disk default keeps zero-config installs working). Everything queryable lives in Postgres (`vendo_` tables): manifests, version graph, head pointers, installs, and all app records. This content-addressed layer is new work, not the current flat saved-record store. The folder materializes to a real filesystem in three places: inside the sandbox at rungs 2 to 4, on `.vendoapp` export, and optionally as a dev checkout. Apps are addressed by id; files within an app by folder path. Tar ingestion safety and canonical hashing rules live in an implementation appendix, not this spec.
+The folder is the interchange shape (export and sandbox), not the storage shape. Storage follows one split:
+
+- Apps without `server/` (rungs 1 to 3, the overwhelming case): one Postgres row per version holding the manifest fields and the UI inline (jsonb tree + component sources). No object storage involved. This is close to the existing saved-record store.
+- Apps with `server/`: the same version row, plus the project files in an S3-compatible object store (content-addressed per file so a 50-file project edited one file at a time is not duplicated per version; local-disk default keeps zero-config installs working), plus a sandbox snapshot id per version.
+
+`manifest.json` and the folder exist only at the edges: export mints them from the row (`.vendoapp`), the sandbox materializes them, import maps them back. Apps are addressed by id; files within an app by folder path. Tar ingestion safety rules live in an implementation appendix, not this spec.
 
 ## 3. Installs
 

--- a/docs/superpowers/specs/2026-07-11-app-format-design.md
+++ b/docs/superpowers/specs/2026-07-11-app-format-design.md
@@ -1,0 +1,154 @@
+# Vendo App Format v0 (design)
+
+Date: 2026-07-11
+Status: approved in brainstorm with Yousef; feeds wave 2 (contracts) of the v0 campaign.
+Ground truth: the "Open-Source Full Stack Agentic Interface" Notion page. This spec fills what the page defers to the app-format brainstorm; it changes no page decision.
+Scope: the artifact format only. Runtime internals and the generation engine are out of scope. Trigger details belong to the automations wave.
+
+## 1. Core model
+
+One artifact for everything Vendo produces: an app is a folder with a manifest. A quick chat view is an unsaved app with only a UI. An automation is an app with a trigger. Nothing converts between kinds; fields accumulate as the app grows. The format is named `vendo/app@1`. The interchange form (sharing, the open standard, shipping to a sandbox) is the folder as a tarball, extension `.vapp`.
+
+## 2. Folder layout
+
+```
+invoice-notes/
+├─ manifest.json          # identity + structure declarations (the full list below)
+├─ ui/
+│  ├─ view.json           # a Tree document (vendo/tree@1)
+│  └─ components/*.tsx    # novel agent-written components, one file each, PascalCase
+├─ pins/*.tsx             # forks of host components, one per slot, named by slot id
+└─ server/                # only if graduated: real code, any shape; manifest names entries
+```
+
+Not in the folder:
+
+- The app's data. It lives in the store, per user. Sharing an app never shares data.
+- The snapshot (last tree + last data, plus a screenshot at rung 4). Per-user cache kept alongside an install. Never truth: deleting it costs only the instant open.
+- Grants and approvals. Trust records live in guard and the host/org registry, never in the artifact. An artifact cannot declare itself trusted, and a `.vapp` ships with zero authority.
+
+## 3. Storage of the artifact itself
+
+The folder is a logical shape. Its canonical home is the store (host Postgres, `vendo_` tables), content-addressed like git objects, so versions and forks share unchanged files. It materializes to a real filesystem in exactly three places: inside the sandbox at rungs 2 to 4, on `.vapp` export, and optionally as a dev checkout. Apps are addressed by `id`; files within an app by folder path.
+
+## 4. Manifest
+
+Keys present only when used; nothing is ever null, false, or empty. Real manifests are tiny and grow with the app: a kept chat view carries only `format`, `id`, `name`, `ui`. Maximal example for key reference:
+
+```json
+{
+  "format": "vendo/app@1",
+  "id": "app_7f3k",
+  "name": "Invoice Notes",
+  "description": "Pin comments to invoices",
+  "ui": "tree",
+  "storage": { "notes": { "about": "comments pinned to invoices",
+                          "refs": { "invoice_id": "host.invoice" } } },
+  "server": { "entry": "server/chase.ts" },
+  "trigger": { "schedule": "mon 9:00" },
+  "pins": [ { "slot": "invoice-card", "base": "sha256:ab12..." } ],
+  "egress": ["api.stripe.com"],
+  "secrets": ["STRIPE_KEY"]
+}
+```
+
+- `ui`: `"tree"` shorthand for the common case; long form `{ "kind": "tree" | "http", "source": "static" | "server" }` for the upper rungs.
+- `storage`: named collections with a one-line human description. Contents are free-form JSON, no schemas, no migrations, orphan records are acceptable (WordPress postmeta spirit, per the page). The only typed part is host-entity refs (`host.` namespace, same vocabulary `vendo init` extracts), which become indexed columns so hosts can join app records onto their entities. This one declared line is what makes the custom-fields story work. Storage kinds are a small expandable vocabulary: `records` (Postgres) and `files` (file storage) in v0; later kinds (vectors, kv, queues) are one new word plus a store adapter, no format surgery. An app declaring an unsupported kind fails cleanly at install.
+- `state` is a reserved built-in: one singleton free-form record per user per app, zero declaration. The ladder's "state" rung exists experientially but costs no format concept.
+- There is no permissions or tools field. See section 8.
+- Fork lineage: a fork mints a new `id` and records `forkOf`.
+
+## 5. Surfaces and the ladder
+
+The Tree (`vendo/tree@1`) is the formalization of today's `vendo-genui/v1` payload: `root`, `nodes` (prewired | host | generated), `data`, `dataQueries`. A tree is a file type, not a mode; it is the fastest surface a runtime can show. Two planes by contract:
+
+- Tree surface: instant and jailed. Renders in the egress-jailed iframe (`connect-src 'none'`), millisecond compile, no build step, host catalog validated server-side before shipping.
+- Sandbox: no ceiling and boot-tolerant. Any code, any language. Snapshot-resumed so wake is seconds, not builds.
+
+The ladder (the agent escalates; the user never picks a tier):
+
+1. Static tree. No sandbox exists. Today's shipped path.
+2. Tree + server functions. UI unchanged and instant; buttons and data queries call sandbox functions, which may be stale-while-boot.
+3. Server-computed tree. The sandbox returns trees; rendering stays on the instant path, brand-checked and guard-bound. Server brains, pushed face.
+4. Served UI. The sandbox serves a real web app; the iframe points at it; iframe `connect-src` is the sandbox origin only, plus manifest egress. Last resort, taken only when the interface itself outgrows trees (npm UI libraries, multi-page). Never a prerequisite for anything.
+
+Invisible graduation is a hard requirement: the user never sees the UI change at a rung jump.
+
+- The tree renderer ships as a library in served-app scaffolds, so a graduated app's first served version renders the identical tree and diverges only on later requests.
+- Every app opens on its last state: the live tree at rungs 1 to 3, a dimmed non-interactive screenshot at rung 4 (iOS app-switcher pattern) while the sandbox resumes.
+- The old rung keeps serving while the next one builds; the switch is agent-narrated, never silent.
+
+## 6. Versioning
+
+Git-shaped, not git. A version is an immutable content-addressed snapshot of the folder (`sha256:...`). `head` points at the live version; rollback moves the pointer; remix is a fork. Human-facing versions are `v1, v2, ...` and each records the intent (the user instruction that produced it), so history reads as a changelog and enables pin rebases. Real git appears only inside rung-4 sandboxes if the agent chooses; the format never requires it.
+
+## 7. Editing
+
+One loop everywhere: patch, validate, version with intent, rehearse before reality. Two patch dialects, because the material differs:
+
+- Tree edits (`view.json`): structured operations (set prop, wrap nodes, rebind query), validated against the host catalog before applying. Instant, no compile. Trees cannot ship broken.
+- Code edits (`components/*.tsx`, `pins/*.tsx`, `server/`): text hunks, compile-checked, contained by error boundaries at runtime. Code fails contained.
+
+Each file type declares its edit dialect and validator. One user instruction may compile to a mix of ops and hunks and lands as one version with one intent. Hand-editing files is a first-class escape hatch; the agent is the default editor, not the only one.
+
+## 8. Permissions: guard owns everything
+
+The manifest carries no permissions. Industry precedent: capability handles plus ask-at-first-use (iOS, OAuth incremental auth, Deno, WASI) over author-declared permission manifests (Android, Chrome extensions), which drift and over-ask. Guard is already the former; the format follows it.
+
+- Apps act only through handed-in capability doors: `vendo.dispatch` in the jail, the server SDK in the sandbox. There is no other path to a tool.
+- Guard keeps a grant ledger per app. First call to an ungranted tool triggers the ask in context; the grant is sticky until revoked (existing guard model, keyed by app).
+- Publish review shows the ledger: observed truth about what the app actually uses, not author claims. A new version calling a new tool has no grant, so the ask fires by construction (user for personal apps, org admin for published ones). Capability expansion re-approval needs no diffing machinery.
+- Away runs (automations) hold only their ledger. An ungranted call fails soft and queues for approval. Grants captured while the user is present are the only authority (page rule).
+- Blast-radius warnings join changed tools against ledgers.
+- Exports carry zero authority. Optionally a `.vapp` may include an advisory `uses:` list (derived mechanically for trees) as a courtesy label, never enforcement.
+
+## 9. Pins: remixing the product itself
+
+A pin is an edit of the host's actual component source, running in-client after host approval, indistinguishable from shipped product code.
+
+- Host marks a component remixable (opt-in, per file). `vendo sync` captures its real source and dependency closure. Backend code never enters the system.
+- A pin is a fork with lineage: the edited source plus `{ slot, base: sourceHash }`. Same editing loop as everything else.
+- Rehearsal: before approval, the fork renders only in the furnished jail (captured real sub-components and styles, host-state hooks stubbed with recorded data). Pixel-faithful for look and behavior, simulated at the data seams. The host page never executes unapproved code.
+- Approval reviews the net diff against the host baseline, PR-shaped. Approval pins the content hash in the registry. Later edits repeat the cycle while the approved hash keeps serving.
+- Mounting: the remixable marking wraps the component in a slot. No approved pin: render the original, near-zero cost. Approved pin: mount the fork in the host's real React tree, imports bound to the real modules (the same imports the jail furnished as copies). Same file, two mounting worlds; approval flips the binding.
+- Drift: the host ships a new component version, the pin's base is stale. Keep serving the old approved fork, notify, and the agent rebases recorded intents onto the new baseline, through approval again.
+- Failure: an erroring pin falls back to the original component. Stock, never broken.
+- Capture depth (dependency-closure rules: what is vendorable, what is stubbed) is the engineering meat of pins and gets its own spec section later.
+
+## 10. Two species, one system
+
+| | App (create from new) | Pin (remix the product) |
+|---|---|---|
+| Born from | conversation | pointing at a host-marked component |
+| Lineage | none | fork of host source, base hash |
+| Runs | jailed by default, sandbox rungs | rehearsal jail, then in-client when approved |
+| Ship gate | grant ledger review | net-diff review |
+| Host updates | irrelevant | drift, rebase, re-approve |
+| Failure | own error boundary | slot falls back to original |
+
+The user never chooses a path; "make me something" and "change this" are both conversation. The format routes the trust question to the right shape automatically.
+
+## 11. Security and exfiltration rules
+
+- Remix captures host-marked client components only. Server-side host code is never captured.
+- Lineage is export control: host-derived files never leave the host's boundary. `.vapp` export strips pins unless host policy says otherwise. Same-product sharing is fine (recipients' browsers already run that code).
+- Jail: no network, no secrets, effects only via guard-gated dispatch. Sandbox: manifest egress allowlist, secrets injected by name, never readable.
+- In-client execution replaces the jail with human judgment: small reviewable diffs, hash-pinned approvals, per-version re-review. This trade is explicit.
+- Source goes to the host's own BYO LLM provider during editing; note in host-facing security docs.
+
+## 12. Encoding commitments
+
+Named now, designed later (the design is measurement work, not brainstorm work):
+
+- The tree structure is versioned (`vendo/tree@1`).
+- A token-compact wire profile of the same structure will exist; readable and compact forms are mechanically convertible. The standard stays readable, the wire stays cheap. Rationale: LLM latency is roughly linear in output tokens (compact UI DSLs measure ~65% token reduction vs markup).
+- The payload defines valid-while-partial semantics so renderers stream components as they generate (A2UI precedent: parse and heal partial output).
+- Catalog-aware autofix is sanctioned: hallucinated component or prop names correctable against the host catalog without a model round-trip (v0 precedent).
+
+## 13. Deferred
+
+- Compact encoding design and benchmarks.
+- Trigger declaration details (automations wave owns them).
+- Pin capture-depth rules (own spec section).
+- Jail dependency set: fixed blessed kit vs per-host vendored extensions (raised, unanswered).
+- Marketplace and cross-org distribution details.

--- a/docs/superpowers/specs/2026-07-11-app-format-design.md
+++ b/docs/superpowers/specs/2026-07-11-app-format-design.md
@@ -7,7 +7,7 @@ Scope: the artifact format only. Runtime internals and the generation engine are
 
 ## 1. Core model
 
-One artifact for everything Vendo produces: an app is a folder with a manifest. A quick chat view is an unsaved app with only a UI. An automation is an app with a trigger. Nothing converts between kinds; fields accumulate as the app grows. The format is named `vendo/app@1`. The interchange form (sharing, the open standard, shipping to a sandbox) is the folder as a tarball, extension `.vapp`.
+One artifact for everything Vendo produces: an app is a folder with a manifest. A quick chat view is an unsaved app with only a UI. An automation is an app with a trigger. Nothing converts between kinds; fields accumulate as the app grows. The format is named `vendo/app@1`. The interchange form (sharing, the open standard, shipping to a sandbox) is the folder as a tarball, extension `.vendoapp`.
 
 Apps have two origins, same format: created from new (born in conversation, no lineage, runs jailed) and remixed from the product (a pin: a fork of a host component's real source, see section 8). The user never chooses between them; both are just conversation.
 
@@ -29,7 +29,7 @@ Not in the folder, by construction:
 
 ## 2. Storage of the artifact
 
-The folder is a logical shape. Its canonical home is the store (host Postgres, `vendo_` tables), content-addressed so versions and forks share unchanged files. This content-addressed layer is new work, not the current flat saved-record store. The folder materializes to a real filesystem in three places: inside the sandbox at rungs 2 to 4, on `.vapp` export, and optionally as a dev checkout. Apps are addressed by id; files within an app by folder path. Tar ingestion safety and canonical hashing rules live in an implementation appendix, not this spec.
+The folder is a logical shape. Its canonical home is the store (host Postgres, `vendo_` tables), content-addressed so versions and forks share unchanged files. This content-addressed layer is new work, not the current flat saved-record store. The folder materializes to a real filesystem in three places: inside the sandbox at rungs 2 to 4, on `.vendoapp` export, and optionally as a dev checkout. Apps are addressed by id; files within an app by folder path. Tar ingestion safety and canonical hashing rules live in an implementation appendix, not this spec.
 
 ## 3. Installs
 
@@ -117,7 +117,7 @@ A pin is an edit of the host's actual component source, running in the product a
 ## 9. Sharing and export
 
 - Sharing hands over a frozen copy: fresh install, empty data, no grants.
-- A `.vapp` export contains only the folder. Data, caches, and grants live outside it by construction and cannot leak.
+- A `.vendoapp` export contains only the folder. Data, caches, and grants live outside it by construction and cannot leak.
 - Host-derived files (pins) export only with host permission; export fails rather than silently stripping them (a stripped pin changes behavior).
 - Jail and sandbox rules are unchanged by sharing: no network in the jail, manifest egress in the sandbox, secrets never readable.
 


### PR DESCRIPTION
## Summary
The app format spec from today's brainstorm with Yousef: an app is one document (fields absent until grown), server = sandbox snapshot reference, .vendoapp export, the one security rule (apps carry no authority; guard asks the running user), sharing = frozen copies, pins = host-approved diffs of real component source.

Triple-reviewed (Opus review, Codex review, Codex clean-room design) and simplified through four rounds. Docs only — no code changes. Feeds wave 2 (contracts) of the v0 campaign.

https://claude.ai/code/session_01CZxowTzSDPrYZS1oSFxAsz
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the App Format v0 design spec. It defines a single-document app model, server snapshots with a graduation ladder, `.vendoapp` export/import, the one security rule, sharing, and pins. Docs only; no code changes.

- **New Features**
  - Single-document format with core fields (`ui`, `tree`, `components`, `storage`, `server`, `trigger`, `egress`, `secrets`, `pins`); tree wire stays `vendo-genui/v1`.
  - Server is a sandbox snapshot; ladder from tree-only to `ui: http`; export/import via `<name>.vendoapp` (doc + app directory only, no data/grants/snapshots).
  - Security: no tools/permissions field; apps hold no authority—guard asks the running user at call time; `egress`/`secrets` are wiring, not permissions.
  - Pins: host-approved diffs of real component source with drift detection, rebase, and safe fallback.

<sup>Written for commit fcd530e5c1283249552c2ec226357e3485475329. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

