### PR TITLE
fix(apps): de-flake run-token tamper test (unblocks the PR pipeline)

### DIFF
--- a/packages/apps/src/execution.test.ts
+++ b/packages/apps/src/execution.test.ts
@@ -417,7 +417,12 @@ describe("apps execution", () => {
     const valid = await runtime.proxy.handler(stateRequest(token as string));
     expect(valid.status).toBe(200);
 
-    const tampered = `${(token as string).slice(0, -1)}${(token as string).endsWith("x") ? "y" : "x"}`;
+    // Mutate a character in the middle of the token (not the trailing base64url char,
+    // whose low bits can be unused so a swap may decode to the same bytes — a flaky no-op tamper).
+    const mid = Math.floor((token as string).length / 2);
+    const orig = (token as string)[mid];
+    const tampered = `${(token as string).slice(0, mid)}${orig === "A" ? "B" : "A"}${(token as string).slice(mid + 1)}`;
+    expect(tampered).not.toBe(token);
     expect((await runtime.proxy.handler(stateRequest(tampered))).status).toBe(401);
 
     vi.useFakeTimers();


### PR DESCRIPTION
The red-team run-token test (#123, on main) flakes: its tamper mutation flips only the trailing base64url char, whose low bits can be unused, so the swap sometimes decodes to the same token → verification passes (200) and the 401 assertion fails. Confirmed the failing test is byte-identical across main/#122/#124, and main's own CI shows the failure on the #123 merge commit — this test blocks every downstream PR.

Fix mutates a middle character and asserts the token differs. **Security control unchanged** — this is a test-determinism fix. Verified 3/3 deterministic locally.

https://claude.ai/code/session_01LcdWUuvFRnVgTngQF3ybDy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky run-token tamper test by mutating a middle character instead of the trailing base64url char, and asserting the token changes. This makes the test deterministic and unblocks CI; no security behavior changed.

<sup>Written for commit 4a2ac080ce910a224dbac4e1180f266f06150bbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

