### PR TITLE
feat(ui): full-fidelity shell reskin + motion across every surface (follow-up to #125)

### DIFF
--- a/packages/ui/e2e/accessibility.spec.ts
+++ b/packages/ui/e2e/accessibility.spec.ts
@@ -36,8 +36,18 @@ for (const scenario of chromeScenarios) {
 
     // Audit the fully-settled state: entrance animations (fade/rise) briefly hold
     // elements at <1 opacity, which composites text/fills lighter. Wait for every
-    // running animation to finish so axe sees the resting colors, not a transient frame.
-    await page.evaluate(() => Promise.all(document.getAnimations().map(a => a.finished.catch(() => undefined))));
+    // FINITE animation to finish — but bound it, since the voice presence runs a
+    // continuous (infinite) breathe/ball whose `finished` never resolves.
+    await page.evaluate(() => {
+      const finite = document.getAnimations().filter(a => {
+        const iterations = (a.effect?.getTiming().iterations ?? 1);
+        return Number.isFinite(iterations);
+      });
+      return Promise.race([
+        Promise.all(finite.map(a => a.finished.catch(() => undefined))),
+        new Promise(resolve => setTimeout(resolve, 1500)),
+      ]);
+    });
 
     const results = await new AxeBuilder({ page })
       .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])

--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -455,6 +455,73 @@ function AppFrameScenario() {
 }
 
 const baseClient = createVendoClient({ baseUrl: "/api/vendo" });
+const unconfiguredClient = createVendoClient({ baseUrl: "/api/vendo", headers: { "x-vendo-force-posture": "unconfigured" } });
+
+// A Maple-brand host theme (graphite accent, warm cream canvas) — the same
+// brand the old shell adopted, so the landing reads like the real product.
+const mapleTheme: Partial<VendoTheme> = {
+  colors: {
+    background: "#f3ede2", surface: "#fffdf9", text: "#14151a", muted: "#8a8b92",
+    accent: "#1b1c22", accentText: "#ffffff", danger: "#b0392b", border: "rgba(20,21,26,.10)",
+  },
+  typography: { fontFamily: "Inter, ui-sans-serif, system-ui, sans-serif", baseSize: "15px" },
+  radius: { small: "8px", medium: "12px", large: "20px" }, density: "comfortable", motion: "full",
+};
+
+/** A minimal Maple host shell (sidebar + top bar + Chat tab) so a Vendo surface
+ *  renders in a realistic host context, matching the wave-2 shell's demos. */
+function MapleFrame({ children }: { children: ReactNode }) {
+  const navItem = (label: string, active = false) => (
+    <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "8px 10px", borderRadius: 8, fontSize: 14,
+      color: active ? "#14151a" : "#5b5c63", background: active ? "rgba(20,21,26,.05)" : "transparent", fontWeight: active ? 600 : 500 }}>
+      <span style={{ width: 16, height: 16, borderRadius: 4, background: "currentColor", opacity: .55 }} />{label}
+    </div>
+  );
+  const topBtn = (label: string, dark = false) => (
+    <button style={{ padding: "8px 14px", borderRadius: 10, fontSize: 13.5, fontWeight: 600, cursor: "pointer",
+      border: dark ? "0" : "1px solid rgba(20,21,26,.12)", background: dark ? "#14151a" : "#fff", color: dark ? "#fff" : "#14151a" }}>{label}</button>
+  );
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "216px 1fr", height: "100%", background: "#fff", color: "#14151a",
+      fontFamily: "Inter, ui-sans-serif, system-ui, sans-serif" }}>
+      <aside style={{ borderRight: "1px solid rgba(20,21,26,.08)", padding: "16px 14px", display: "flex", flexDirection: "column", gap: 4 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 9, padding: "4px 8px 16px", fontWeight: 700, fontSize: 18 }}>
+          <span style={{ width: 26, height: 26, borderRadius: 8, background: "#14151a", color: "#fff", display: "grid", placeItems: "center", fontSize: 13 }}>◈</span>Maple
+        </div>
+        {navItem("Home")}{navItem("Accounts")}{navItem("Transactions")}{navItem("Cards")}{navItem("Payments")}{navItem("Insights")}{navItem("Ask Maple", true)}
+        <div style={{ marginTop: "auto", display: "flex", flexDirection: "column", gap: 4 }}>{navItem("Activity")}{navItem("Settings")}</div>
+      </aside>
+      <div style={{ display: "flex", flexDirection: "column", minWidth: 0 }}>
+        <header style={{ display: "flex", alignItems: "center", gap: 14, padding: "12px 22px", borderBottom: "1px solid rgba(20,21,26,.08)" }}>
+          <strong style={{ fontSize: 16 }}>Ask Maple</strong>
+          <div style={{ flex: 1, maxWidth: 320, display: "flex", alignItems: "center", gap: 8, padding: "7px 12px", borderRadius: 10, border: "1px solid rgba(20,21,26,.12)", color: "#8a8b92", fontSize: 13 }}>Search…<span style={{ marginLeft: "auto", fontSize: 11, border: "1px solid rgba(20,21,26,.12)", borderRadius: 5, padding: "1px 5px" }}>⌘K</span></div>
+          <div style={{ marginLeft: "auto", display: "flex", gap: 8 }}>{topBtn("Send", true)}{topBtn("Request")}{topBtn("Move money")}</div>
+        </header>
+        <div style={{ padding: "0 22px", borderBottom: "1px solid rgba(20,21,26,.08)", display: "flex", gap: 16, fontSize: 13.5 }}>
+          <span style={{ padding: "12px 2px", borderBottom: "2px solid #14151a", fontWeight: 600 }}>Chat</span>
+          <span style={{ padding: "12px 2px", color: "#8a8b92" }}>+</span>
+        </div>
+        <div style={{ flex: 1, minHeight: 0 }}>{children}</div>
+      </div>
+    </div>
+  );
+}
+
+const MAPLE_SUGGESTIONS = [
+  "What did I spend money on when I should've been asleep?",
+  "What was that $87 DoorDash charge?",
+  "Put me on blast in Slack when I order late-night delivery",
+];
+
+function LandingScenario() {
+  return (
+    <VendoProvider client={baseClient} components={components} theme={mapleTheme}>
+      <MapleFrame>
+        <VendoThread greeting="What do you want to build?" suggestions={MAPLE_SUGGESTIONS} onVoice={() => undefined} />
+      </MapleFrame>
+    </VendoProvider>
+  );
+}
 
 /** Containment (c): an unregistered formatVersion must render a contained notice
  *  both when handed straight to the renderer AND when it arrives in a thread. */
@@ -586,13 +653,14 @@ function FormatDrillScenario({ registered }: { registered: boolean }) {
 function scenario(pathname: string): { title: string; theme?: Partial<VendoTheme>; content: ReactNode; ownProvider?: boolean } {
   switch (pathname) {
     case "/thread": return { title: "Thread — dark theme", theme: darkTheme, content: <VendoThread threadId="thr_1" /> };
+    case "/thread-landing": return { title: "Landing (Maple host)", content: <LandingScenario />, ownProvider: true };
     case "/overlay": return { title: "Overlay", content: <AutoOpen selector='button[aria-controls="vendo-overlay-dialog"]'><VendoOverlay /></AutoOpen> };
     case "/page": return { title: "Workspace — Apps tab", content: <AutoOpen selector='[role="tab"][aria-controls="vendo-panel-apps"]'><VendoPage /></AutoOpen> };
     case "/palette": return { title: "Command palette", content: <OpenPalette /> };
     case "/approval": return { title: "Destructive approval", content: <ApprovalScenario /> };
     case "/activity": return { title: "Activity", content: <ActivityPanel /> };
     case "/automations": return { title: "Automations", content: <AutomationsPanel /> };
-    case "/notice": return { title: "Unconfigured policy", content: <NoPolicyNotice /> };
+    case "/notice": return { title: "Unconfigured policy", ownProvider: true, content: (<VendoProvider client={unconfiguredClient} components={components}><NoPolicyNotice /></VendoProvider>) };
     case "/stage": return { title: "Voice stage", content: <StageScenario />, ownProvider: true };
     case "/stage-live": return { title: "Voice stage (live)", content: <LiveStageScenario />, ownProvider: true };
     case "/tree": return { title: "Tree containment", content: <TreeScenario /> };
@@ -622,6 +690,11 @@ function Harness() {
         {current.content}
       </VendoProvider>
     );
+  // Full-bleed host-frame scenarios (the Maple frame IS the host chrome) render
+  // edge-to-edge, not as a card on the harness canvas.
+  if (globalThis.location.pathname === "/thread-landing") {
+    return <div data-scenario="thread-landing" style={{ position: "fixed", inset: 0 }}>{content}</div>;
+  }
   return (
     <main className={`harness-shell${globalThis.location.pathname === "/thread" ? " harness-dark" : ""}`} data-scenario={globalThis.location.pathname.slice(1)}>
       <h1 className="harness-heading">{current.title}</h1>

--- a/packages/ui/e2e/harness/vite.config.ts
+++ b/packages/ui/e2e/harness/vite.config.ts
@@ -7,7 +7,7 @@ const harnessRoot = fileURLToPath(new URL(".", import.meta.url));
 /** 08-ui §4–5 — real-browser harness backed by the exact in-test wire route table. */
 export default defineConfig(async () => {
   const wire = await createWireServer();
-  wire.state.posture = "unconfigured";
+  wire.state.posture = "rules";
 
   return {
     root: harnessRoot,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -63,6 +63,8 @@
   "dependencies": {
     "@ai-sdk/react": "^3.0.30",
     "@vendoai/core": "workspace:*",
+    "fluidkit": "*",
+    "motion": "^11.11.0",
     "react-markdown": "^9.0.1",
     "remark-gfm": "^4.0.0",
     "sucrase": "^3.35.0"

--- a/packages/ui/src/chrome/activity-panel.tsx
+++ b/packages/ui/src/chrome/activity-panel.tsx
@@ -47,6 +47,8 @@ export function ActivityPanel() {
             <tbody style={{ display: "block" }}>
               {events.map(event => {
                 const ok = event.outcome === "ok";
+                const running = event.outcome === undefined;
+                const pending = event.outcome === "pending-approval";
                 return (
                   <tr
                     className="fl-act-row"
@@ -62,7 +64,11 @@ export function ActivityPanel() {
                     <td className="fl-act-lbl">{event.tool ?? "—"}</td>
                     <td className="fl-act-sub" style={{ marginLeft: 0, maxWidth: "none" }}>{event.inputPreview ?? "—"}</td>
                     <td>
-                      <span className={`fl-act-ic ${ok ? "fl-act-tick" : "fl-act-x"}`} aria-hidden="true">{ok ? "✓" : "✕"}</span>
+                      <span className="fl-act-ic" aria-hidden="true">
+                        {running ? <span className="fl-act-pulse" />
+                          : pending ? <span className="fl-act-spin" />
+                          : <span className={ok ? "fl-act-tick" : "fl-act-x"}>{ok ? "✓" : "✕"}</span>}
+                      </span>
                       <span>{event.outcome ?? "—"}</span>
                     </td>
                     <td className="fl-act-sub" style={{ marginLeft: 0, maxWidth: "none" }}>{event.decidedBy ?? "—"}</td>

--- a/packages/ui/src/chrome/approval-card.tsx
+++ b/packages/ui/src/chrome/approval-card.tsx
@@ -50,9 +50,9 @@ export function ApprovalCard({ approval, onDecide, allowRemember = true }: Appro
 
   return (
     <ChromeRoot>
-      <article className={`fl-approval${critical ? " fl-approval--ceremony" : ""}`} aria-label={`Approval for ${approval.descriptor.name}`}>
+      <article className={`fl-approval fl-item-in${critical ? " fl-approval--ceremony" : ""}`} aria-label={`Approval for ${approval.descriptor.name}`}>
         <div className="fl-approval-head">
-          <div className="fl-approval-ic" aria-hidden="true">
+          <span className="fl-approval-ic" aria-hidden="true">
             <svg
               width="15"
               height="15"
@@ -65,8 +65,8 @@ export function ApprovalCard({ approval, onDecide, allowRemember = true }: Appro
             >
               <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" />
             </svg>
-          </div>
-          <div>
+          </span>
+          <div className="fl-approval-heading">
             <div className="fl-approval-eyebrow">{critical ? "CRITICAL" : "REQUESTED"}</div>
             <div className="fl-approval-title">{approval.descriptor.name}</div>
           </div>

--- a/packages/ui/src/chrome/automations-panel.tsx
+++ b/packages/ui/src/chrome/automations-panel.tsx
@@ -1,20 +1,105 @@
-import type { ApprovalRequest, AppId, ApprovalDecision } from "@vendoai/core";
-import { useState } from "react";
+import type { ApprovalRequest, AppId, ApprovalDecision, Trigger } from "@vendoai/core";
+import { useEffect, useRef, useState } from "react";
+import { useVendoTheme } from "../context.js";
 import { useApprovals } from "../hooks/use-approvals.js";
 import { useAutomations } from "../hooks/use-automations.js";
 import type { RunPlan, RunRecord } from "../wire-types.js";
 import { ApprovalCard } from "./approval-card.js";
 import { ChromeRoot } from "./chrome-root.js";
 
+const ENABLE_CELEBRATION_MS = 3_100;
+const REDUCED_ENABLE_CELEBRATION_MS = 900;
+
+function humanize(value: string): string {
+  const words = value
+    .replace(/^host[_:. -]?/i, "")
+    .replace(/^fn:/i, "")
+    .replace(/[._:-]+/g, " ")
+    .trim();
+  return words ? `${words.charAt(0).toUpperCase()}${words.slice(1)}` : value;
+}
+
+function triggerLabel(trigger: Trigger): { title: string; sub: string } {
+  const source = trigger.on;
+  if (source.kind === "schedule") {
+    if (source.every) return { title: `Every ${source.every}`, sub: "Schedule" };
+    if (source.at) return { title: source.at, sub: "Scheduled once" };
+    return { title: source.cron ?? "Scheduled", sub: "Schedule" };
+  }
+  if (source.kind === "external") {
+    return { title: humanize(source.event), sub: humanize(source.connector) };
+  }
+  return { title: humanize(source.event), sub: "Host event" };
+}
+
+function automationFlow(trigger: Trigger | undefined): {
+  trigger: { title: string; sub: string };
+  action: { title: string; sub: string };
+} | undefined {
+  if (!trigger) return undefined;
+  if (trigger.run.kind === "agentic") {
+    const prompt = trigger.run.prompt.trim();
+    if (!prompt) return undefined;
+    return {
+      trigger: triggerLabel(trigger),
+      action: {
+        title: prompt.length > 68 ? `${prompt.slice(0, 67).trimEnd()}…` : prompt,
+        sub: "Agent run",
+      },
+    };
+  }
+  const firstStep = trigger.run.steps[0];
+  if (!firstStep) return undefined;
+  return {
+    trigger: triggerLabel(trigger),
+    action: {
+      title: humanize(firstStep.tool),
+      sub: trigger.run.steps.length === 1 ? "1 action" : `${trigger.run.steps.length} steps`,
+    },
+  };
+}
+
 /** 08-ui §4; 07-automations §5 — controls, grant capture, previews, history, kill switch. */
 export function AutomationsPanel() {
   const automations = useAutomations();
   const approvals = useApprovals();
+  const theme = useVendoTheme();
   const [missing, setMissing] = useState<Record<AppId, ApprovalRequest[]>>({});
   const [plans, setPlans] = useState<Record<AppId, RunPlan | undefined>>({});
   const [runs, setRuns] = useState<Record<AppId, RunRecord[] | undefined>>({});
   const [busy, setBusy] = useState<Record<string, boolean>>({});
   const [error, setError] = useState<string>();
+  const [justEnabled, setJustEnabled] = useState<Record<AppId, boolean>>({});
+  const enableTimers = useRef(new Map<AppId, number>());
+
+  useEffect(() => () => {
+    for (const timer of enableTimers.current.values()) window.clearTimeout(timer);
+    enableTimers.current.clear();
+  }, []);
+
+  const clearEnableCelebration = (appId: AppId) => {
+    const timer = enableTimers.current.get(appId);
+    if (timer !== undefined) window.clearTimeout(timer);
+    enableTimers.current.delete(appId);
+    setJustEnabled(current => {
+      if (!current[appId]) return current;
+      const next = { ...current };
+      delete next[appId];
+      return next;
+    });
+  };
+
+  const celebrateEnable = (appId: AppId) => {
+    const existing = enableTimers.current.get(appId);
+    if (existing !== undefined) window.clearTimeout(existing);
+    const reduced = theme.motion === "reduced"
+      || (typeof window.matchMedia === "function" && window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+    setJustEnabled(current => ({ ...current, [appId]: true }));
+    enableTimers.current.set(appId, window.setTimeout(
+      () => clearEnableCelebration(appId),
+      reduced ? REDUCED_ENABLE_CELEBRATION_MS : ENABLE_CELEBRATION_MS,
+    ));
+  };
 
   const during = async (key: string, action: () => Promise<void>) => {
     setError(undefined);
@@ -42,8 +127,19 @@ export function AutomationsPanel() {
         {automations.automations.map(entry => {
           const appId = entry.app.id;
           const appRuns = runs[appId];
+          const flow = automationFlow(entry.app.trigger);
+          const celebrating = justEnabled[appId] === true;
+          const reduced = theme.motion === "reduced"
+            || (typeof window !== "undefined" && typeof window.matchMedia === "function"
+              && window.matchMedia("(prefers-reduced-motion: reduce)").matches);
           return (
-            <article className="fl-automation" key={appId}>
+            <article
+              className="fl-automation"
+              key={appId}
+              style={celebrating && !reduced
+                ? { animation: "fl-connect-bloom .5s cubic-bezier(.22,1,.36,1) both" }
+                : undefined}
+            >
               <div className="fl-auto-head">
                 <span className="fl-auto-ic" aria-hidden="true">
                   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -53,7 +149,15 @@ export function AutomationsPanel() {
                 <div>
                   <div className="fl-auto-title">{entry.app.name}</div>
                   <div className="fl-auto-sub">
-                    {entry.enabled ? <span className="fl-auto-live" aria-hidden="true" /> : null}
+                    {entry.enabled ? (
+                      <span
+                        className="fl-auto-live"
+                        aria-hidden="true"
+                        style={celebrating && !reduced
+                          ? { animation: "fl-connect-pop .55s cubic-bezier(.22,1,.36,1) both" }
+                          : undefined}
+                      />
+                    ) : null}
                     {entry.enabled ? "Enabled" : "Disabled"}
                   </div>
                 </div>
@@ -70,18 +174,58 @@ export function AutomationsPanel() {
                   style={{
                     background: entry.enabled ? "var(--vendo-accent)" : "var(--vendo-border-strong)",
                     transform: entry.enabled ? undefined : "rotate(180deg)",
+                    transition: "background .2s ease, transform .2s cubic-bezier(.22,1,.36,1)",
                   }}
                   onClick={() => void during(`toggle-${appId}`, async () => {
                     if (entry.enabled) {
                       await automations.disable(appId);
+                      clearEnableCelebration(appId);
                       setMissing(current => ({ ...current, [appId]: [] }));
                     } else {
                       const result = await automations.enable(appId);
                       setMissing(current => ({ ...current, [appId]: result.missing }));
+                      if (result.enabled) celebrateEnable(appId);
                     }
                   })}
                 />
               </div>
+
+              {flow ? (
+                <div className="fl-auto-flow" aria-label={`Automation flow for ${entry.app.name}`}>
+                  <span className="fl-auto-node" style={{ flex: 1 }}>
+                    <span className="fl-auto-node-ic" aria-hidden="true">↳</span>
+                    <span>
+                      <span className="fl-auto-node-t">{flow.trigger.title}</span>
+                      <span className="fl-auto-node-s" style={{ display: "block" }}>{flow.trigger.sub}</span>
+                    </span>
+                  </span>
+                  <span className="fl-auto-arrow" aria-hidden="true" />
+                  <span className="fl-auto-node" style={{ flex: 1 }}>
+                    <span className="fl-auto-node-ic" aria-hidden="true">✓</span>
+                    <span>
+                      <span className="fl-auto-node-t">{flow.action.title}</span>
+                      <span className="fl-auto-node-s" style={{ display: "block" }}>{flow.action.sub}</span>
+                    </span>
+                  </span>
+                </div>
+              ) : null}
+
+              {celebrating ? (
+                <div
+                  className="fl-auto-created-toast"
+                  role="status"
+                  aria-live="polite"
+                  style={!reduced
+                    ? { animation: "fl-item-in .24s ease-out 2.82s reverse both" }
+                    : undefined}
+                >
+                  <span className="fl-auto-created-live" aria-hidden="true" />
+                  <div className="fl-auto-created-copy">
+                    <div className="fl-auto-created-title">{entry.app.name} is live</div>
+                    <div className="fl-auto-created-sub">Automation enabled</div>
+                  </div>
+                </div>
+              ) : null}
 
               <div className="fl-auto-flow" style={{ gap: 8 }}>
                 <button className="fl-btn" type="button" onClick={() => void during(`plan-${appId}`, async () => {

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -37,6 +37,7 @@ export const CHROME_CSS = `/* @vendoai/ui chrome — the wave-2 Vendo shell desi
   --vendo-warn-bg: color-mix(in srgb, #f0b429 12%, var(--vendo-surface));
   --vendo-warn-border: color-mix(in srgb, #f0b429 32%, var(--vendo-border));
   color: var(--vendo-fg);
+  background: var(--vendo-bg);
   font-family: var(--vendo-font);
   font-size: var(--vendo-font-size, 15px);
   letter-spacing: -.011em;

--- a/packages/ui/src/chrome/fluid-thinking.tsx
+++ b/packages/ui/src/chrome/fluid-thinking.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState, type ComponentType } from "react";
+import type { ThinkingProps } from "fluidkit";
+
+type ThinkingComponent = ComponentType<ThinkingProps>;
+
+// Module-level so the import (or its failure) is paid once per session, not
+// once per streaming turn. `undefined` = not attempted, `null` = unavailable.
+let cached: ThinkingComponent | null | undefined;
+
+export interface FluidThinkingProps {
+  /** Accessible label for the working state. */
+  label?: string;
+  /** Drop diameter in px (fluidkit Thinking `size`). */
+  size?: number;
+  /** Legacy cluster extent — fluidkit 0.5 auto-scales the canvas, so this is
+   *  accepted for call-site compatibility but no longer forwarded. */
+  spread?: number;
+}
+
+/**
+ * The agent-liveness indicator. fluidkit is an enhancement layer: the legacy
+ * static dots paint immediately (and are all reduced-motion CSS ever animates),
+ * then fluidkit's metaball Thinking takes over once its chunk resolves. If the
+ * library is missing or fails to load, the dots simply stay — the shell never
+ * depends on it to function.
+ */
+export function FluidThinking({ label = "Working", size = 9 }: FluidThinkingProps) {
+  // Initializer form: the cached value is itself a function component, and a
+  // bare function passed to useState would be invoked as a lazy initializer.
+  const [Thinking, setThinking] = useState<ThinkingComponent | null>(() => cached ?? null);
+
+  useEffect(() => {
+    if (cached !== undefined) return;
+    let alive = true;
+    import("fluidkit").then(
+      (mod) => {
+        cached = mod.Thinking;
+        if (alive) setThinking(() => mod.Thinking);
+      },
+      () => {
+        cached = null;
+      },
+    );
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (!Thinking) {
+    return (
+      <div className="fl-typing" aria-label={label}>
+        <span />
+        <span />
+        <span />
+      </div>
+    );
+  }
+  return (
+    <div className="fl-thinking">
+      <Thinking label={label} material="flat" size={size} />
+    </div>
+  );
+}

--- a/packages/ui/src/chrome/vendo-page.tsx
+++ b/packages/ui/src/chrome/vendo-page.tsx
@@ -98,7 +98,11 @@ function AppsWorkspace() {
       </form>
       <div className="fl-picker-grid">
         {apps.map(app => (
-          <article className="fl-automation" key={app.id}>
+          <article
+            className="fl-picker-item fl-automation"
+            key={app.id}
+            style={{ alignItems: "stretch", flexDirection: "column", padding: 0 }}
+          >
             <div className="fl-auto-head">
               <span className="fl-auto-ic" aria-hidden="true">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/packages/ui/src/chrome/vendo-palette.tsx
+++ b/packages/ui/src/chrome/vendo-palette.tsx
@@ -139,13 +139,15 @@ export function VendoPalette({ onCommand }: { onCommand?(command: VendoCommand):
               {visible.map((command, index) => (
                 <li
                   id={`vendo-command-${command.id}`}
-                  className="fl-picker-item"
+                  className="fl-picker-item fl-option"
                   role="option"
                   aria-selected={index === active}
                   key={command.id}
                   onMouseDown={event => event.preventDefault()}
                   onClick={() => select(command)}
-                  style={index === active ? { background: "var(--vendo-accent-soft)", borderColor: "var(--vendo-border-strong)" } : undefined}
+                  style={index === active
+                    ? { background: "var(--vendo-accent-soft)", borderColor: "var(--vendo-border-strong)", cursor: "pointer" }
+                    : { cursor: "pointer" }}
                 >
                   <span className="fl-picker-ic" aria-hidden="true">
                     {command.kind === "new-conversation" ? (

--- a/packages/ui/src/chrome/vendo-slot.tsx
+++ b/packages/ui/src/chrome/vendo-slot.tsx
@@ -4,16 +4,48 @@ import { useApp } from "../hooks/use-app.js";
 import { AppFrame, PinMount } from "../tree/frames.js";
 import { ChromeRoot } from "./chrome-root.js";
 
+function SlotGhost({ label, detail, loading = false }: { label: string; detail?: string; loading?: boolean }) {
+  return (
+    <div className="fl-slot-ghost" role={loading ? "status" : undefined} aria-live={loading ? "polite" : undefined}>
+      <span className="fl-slot-skel" aria-hidden="true">
+        <span className="fl-skel-line" style={{ width: "54%" }} />
+        <span className="fl-skel-line" style={{ width: "78%" }} />
+        <span className="fl-skel-line" style={{ width: "42%" }} />
+        <span className="fl-skel-bars">
+          <span style={{ height: "42%" }} />
+          <span style={{ height: "68%" }} />
+          <span style={{ height: "52%" }} />
+          <span style={{ height: "84%" }} />
+          <span style={{ height: "62%" }} />
+        </span>
+      </span>
+      <span className="fl-slot-cta">
+        <span className="fl-slot-cta-label">{label}</span>
+        {detail ? <small>{detail}</small> : null}
+      </span>
+    </div>
+  );
+}
+
 function MountedApp({ appId }: { appId: string }) {
   const { client, components } = useVendoContext();
   const { surface } = useApp(appId);
-  if (!surface) return <div className="fl-slot-empty" role="status" aria-live="polite">Loading app…</div>;
+  if (!surface) return <SlotGhost label="Loading app…" loading />;
   return <AppFrame key={appId} surface={surface} components={components} onAction={({ action, payload }) => client.apps.call(appId, action, payload ?? {})} />;
 }
 
 /** 08-ui §4; 06-apps §8 — inline mount that never sacrifices host fallback content. */
 export function VendoSlot({ id, appId, children }: { id: string; appId?: string; children?: ReactNode }) {
-  if (!appId) return <>{children}</>;
+  if (!appId) {
+    if (children !== undefined) return <>{children}</>;
+    return (
+      <ChromeRoot>
+        <div className="fl-slot" data-vendo-slot={id}>
+          <SlotGhost label="Design a view" detail="describe it, I'll render it" />
+        </div>
+      </ChromeRoot>
+    );
+  }
   const Fallback = () => <>{children}</>;
   return (
     <ChromeRoot>

--- a/packages/ui/src/chrome/vendo-thread.tsx
+++ b/packages/ui/src/chrome/vendo-thread.tsx
@@ -1,11 +1,12 @@
 import type { ApprovalRequest, Json, RiskLabel, ToolOutcome, VendoViewPart } from "@vendoai/core";
 import { isToolUIPart, type UIMessage } from "ai";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useVendoContext } from "../context.js";
 import { useVendoThread } from "../hooks/use-vendo-thread.js";
 import { PayloadView } from "../tree/renderer.js";
 import { ApprovalCard } from "./approval-card.js";
 import { ChromeRoot } from "./chrome-root.js";
+import { FluidThinking } from "./fluid-thinking.js";
 import { Markdown } from "./markdown.js";
 
 function partData(part: UIMessage["parts"][number]): unknown {
@@ -30,6 +31,21 @@ function toolName(part: Extract<UIMessage["parts"][number], { toolCallId: string
   return part.type === "dynamic-tool" && "toolName" in part ? part.toolName : part.type.replace(/^tool-/, "");
 }
 
+/** A picked File → an ai-SDK FileUIPart (data URL) so it can ride the turn. */
+function fileToPart(file: File): Promise<{ type: "file"; mediaType: string; filename: string; url: string }> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error ?? new Error("file read failed"));
+    reader.onload = () => resolve({
+      type: "file",
+      mediaType: file.type || "application/octet-stream",
+      filename: file.name,
+      url: String(reader.result),
+    });
+    reader.readAsDataURL(file);
+  });
+}
+
 function preview(input: unknown): string {
   if (typeof input === "string") return input;
   try {
@@ -39,26 +55,113 @@ function preview(input: unknown): string {
   }
 }
 
+export interface VendoThreadProps {
+  threadId?: string;
+  /** Landing headline shown above the composer while the thread is empty. */
+  greeting?: string;
+  /** Starter prompts shown as chips on the empty landing; clicking sends one. */
+  suggestions?: string[];
+  /** Show a mic affordance in the composer that launches the host's voice surface. */
+  onVoice?: () => void;
+}
+
 /** 08-ui §4 — conversation chrome over the headless thread transport. */
-export function VendoThread({ threadId }: { threadId?: string }) {
+export function VendoThread({
+  threadId,
+  greeting = "What can I help you build?",
+  suggestions = [],
+  onVoice,
+}: VendoThreadProps) {
   const { client, components } = useVendoContext();
   const thread = useVendoThread(threadId);
   const [draft, setDraft] = useState("");
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [files, setFiles] = useState<File[]>([]);
   const risks = useMemo(() => riskByCall(thread.messages), [thread.messages]);
   const busy = thread.status === "submitted" || thread.status === "streaming";
+  const landing = thread.messages.length === 0;
+  const activeAssistant = thread.messages.at(-1)?.role === "assistant" ? thread.messages.at(-1) : undefined;
+  const assistantHasVisibleText = activeAssistant?.parts.some(
+    part => part.type === "text" && part.text.trim().length > 0,
+  ) ?? false;
+  const working = busy && !assistantHasVisibleText;
 
-  const send = () => {
-    const text = draft.trim();
-    if (!text || busy) return;
+  const send = (override?: string) => {
+    const text = (override ?? draft).trim();
+    if ((!text && files.length === 0) || busy) return;
+    const pending = files;
     setDraft("");
-    void thread.sendMessage({ text });
+    setFiles([]);
+    if (fileRef.current) fileRef.current.value = "";
+    void (async () => {
+      const parts = await Promise.all(pending.map(fileToPart));
+      void thread.sendMessage(parts.length > 0 ? { text, files: parts } : { text });
+    })();
   };
+
+  const composer = (
+    <form className="fl-composer" aria-label="Message composer" onSubmit={event => { event.preventDefault(); send(); }}>
+      {files.length > 0 ? (
+        <div className="fl-att-chips">
+          {files.map((file, i) => (
+            <span className="fl-att-file" key={`${file.name}-${i}`}>
+              <span className="fl-att-name">{file.name}</span>
+              <button type="button" className="fl-att-rm fl-att-rm-file" aria-label={`Remove ${file.name}`}
+                onClick={() => setFiles(current => current.filter((_, j) => j !== i))}>×</button>
+            </span>
+          ))}
+        </div>
+      ) : null}
+      <div className="fl-composer-row">
+        <input ref={fileRef} type="file" multiple hidden aria-hidden="true"
+          onChange={event => { if (event.target.files) setFiles(current => [...current, ...Array.from(event.target.files!)]); }} />
+        <button type="button" className="fl-icon-btn fl-attach" aria-label="Attach files" onClick={() => fileRef.current?.click()}>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+          </svg>
+        </button>
+        <label style={{ display: "contents" }}>
+          <span className="fl-sr-only">Message</span>
+          <textarea
+            aria-label="Message"
+            placeholder="Ask anything"
+            rows={1}
+            value={draft}
+            disabled={busy}
+            onChange={event => setDraft(event.currentTarget.value)}
+            onKeyDown={event => { if (event.key === "Enter" && !event.shiftKey) { event.preventDefault(); send(); } }}
+          />
+        </label>
+        {onVoice ? (
+          <button type="button" className="fl-icon-btn" aria-label="Start voice" onClick={onVoice}>
+            <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <rect x="9" y="2" width="6" height="12" rx="3" /><path d="M5 10a7 7 0 0 0 14 0M12 19v3" />
+            </svg>
+          </button>
+        ) : null}
+        {busy ? (
+          <button className="fl-icon-btn" type="button" aria-label="Stop" onClick={() => void thread.stop()}>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><rect x="6" y="6" width="12" height="12" rx="2.5" /></svg>
+            <span className="fl-sr-only">Stop</span>
+          </button>
+        ) : (
+          <button className="fl-icon-btn fl-send" type="submit" aria-label="Send" disabled={!draft.trim() && files.length === 0}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M12 19V5" /><path d="m5 12 7-7 7 7" />
+            </svg>
+            <span className="fl-sr-only">Send</span>
+          </button>
+        )}
+      </div>
+      <span role="status" aria-live="polite" className="fl-sr-only">{thread.status}</span>
+    </form>
+  );
 
   const renderPart = (part: UIMessage["parts"][number], key: string, role: UIMessage["role"]) => {
     if (part.type === "text") {
       return role === "user"
         ? <div className="fl-usertext" key={key}>{part.text}</div>
-        : <Markdown key={key} text={part.text} />;
+        : <Markdown key={key} text={part.text} streaming={part.state === "streaming"} />;
     }
     if (isToolUIPart(part)) {
       const risk = risks.get(part.toolCallId) ?? "read";
@@ -106,6 +209,26 @@ export function VendoThread({ threadId }: { threadId?: string }) {
 
   const approvals = thread.messages.flatMap(message => message.parts).filter(isToolUIPart).filter(part => part.state === "approval-requested");
 
+  if (landing) {
+    return (
+      <ChromeRoot>
+        <div className="fl-thread" role="region" aria-label="Vendo conversation">
+          <div className="fl-landing">
+            <h1 className="fl-greet">{greeting}</h1>
+            <div className="fl-landing-composer">{composer}</div>
+            {suggestions.length > 0 ? (
+              <div className="fl-chips">
+                {suggestions.map((text, i) => (
+                  <button type="button" className="fl-chip" key={`${i}-${text}`} onClick={() => send(text)}>{text}</button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </ChromeRoot>
+    );
+  }
+
   return (
     <ChromeRoot>
       <div className="fl-thread" role="region" aria-label="Vendo conversation">
@@ -142,42 +265,9 @@ export function VendoThread({ threadId }: { threadId?: string }) {
               />
             );
           })}
+          {working ? <FluidThinking label="Working" /> : null}
         </div>
-        <form className="fl-composer" aria-label="Message composer" onSubmit={event => { event.preventDefault(); send(); }}>
-          <div className="fl-composer-row">
-            <label style={{ display: "contents" }}>
-              <span className="fl-sr-only">Message</span>
-              <textarea
-                aria-label="Message"
-                rows={1}
-                value={draft}
-                disabled={busy}
-                onChange={event => setDraft(event.currentTarget.value)}
-                onKeyDown={event => {
-                  if (event.key === "Enter" && !event.shiftKey) {
-                    event.preventDefault();
-                    send();
-                  }
-                }}
-              />
-            </label>
-            <button className="fl-icon-btn fl-send" type="submit" aria-label="Send" disabled={busy || !draft.trim()}>
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <path d="M12 19V5" /><path d="m5 12 7-7 7 7" />
-              </svg>
-              <span className="fl-sr-only">Send</span>
-            </button>
-            {busy ? (
-              <button className="fl-icon-btn" type="button" aria-label="Stop" onClick={() => void thread.stop()}>
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                  <rect x="6" y="6" width="12" height="12" rx="2.5" />
-                </svg>
-                <span className="fl-sr-only">Stop</span>
-              </button>
-            ) : null}
-          </div>
-          <span role="status" aria-live="polite" className="fl-sr-only">{thread.status}</span>
-        </form>
+        {composer}
       </div>
     </ChromeRoot>
   );

--- a/packages/ui/src/tree/primitives.tsx
+++ b/packages/ui/src/tree/primitives.tsx
@@ -91,7 +91,7 @@ export function Text(props: PropsWithChildren<{
 export function Skeleton(props: { width?: string | number; height?: string | number }) {
   return (
     <span
-      className="fl-glass-shimmer"
+      className="fl-glass fl-glass-shimmer"
       data-primitive="Skeleton"
       aria-hidden="true"
       style={{

--- a/packages/ui/src/voice/stage.tsx
+++ b/packages/ui/src/voice/stage.tsx
@@ -1,6 +1,7 @@
 import { ChromeRoot } from "../chrome/chrome-root.js";
 import type { VoiceState } from "./driver.js";
 import { useVoice } from "./use-voice.js";
+import { VoiceBlob, type VoiceBlobState } from "./voice-blob.js";
 
 const ACTIVE_STATES = new Set<VoiceState>(["connecting", "listening", "speaking"]);
 
@@ -8,7 +9,12 @@ const ACTIVE_STATES = new Set<VoiceState>(["connecting", "listening", "speaking"
 export function VendoStage() {
   const { state, start, stop, transcript } = useVoice();
   const active = ACTIVE_STATES.has(state);
-  const blobState = state === "error" ? "error" : state === "idle" || state === "unavailable" ? "muted" : state;
+  const blobState: VoiceBlobState =
+    state === "unavailable"
+      ? "muted"
+      : state === "idle"
+        ? "connecting"
+        : state;
 
   return (
     <ChromeRoot>
@@ -17,15 +23,11 @@ export function VendoStage() {
         className={`fl-voice-stage${state === "speaking" ? " is-speaking" : ""}`}
         data-state={state}
       >
-        <div className="fl-voice-canvas">
+        <div className={`fl-voice-canvas${transcript.length > 0 ? " has-views" : ""}`}>
           <div className="fl-voice-lift" aria-hidden="true" />
           <div className="fl-voice-head">
-            <div
-              className={`fl-voice-blob is-${blobState}`}
-              style={{ width: 96, height: 96 }}
-              aria-hidden="true"
-            >
-              <span className="fl-voice-disc" />
+            <div className={`fl-voice-blob${state === "listening" ? " fl-approval-listening" : ""}`}>
+              <VoiceBlob state={blobState} />
             </div>
             <div className="fl-voice-status" role="status" aria-live="polite">
               Voice: {state}

--- a/packages/ui/src/voice/voice-blob.tsx
+++ b/packages/ui/src/voice/voice-blob.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef, useState, type ComponentType } from "react";
+import type { VoiceBallProps, VoiceBallMode } from "fluidkit";
+
+export type VoiceBlobState =
+  | "connecting"
+  | "listening"
+  | "thinking"
+  | "speaking"
+  | "muted"
+  | "error";
+
+export interface VoiceBlobProps {
+  state: VoiceBlobState;
+  /** 0..1 live level; drives the ball (mic while listening, agent while speaking). */
+  amplitude?: number;
+  /** Diameter of the presence in px. */
+  size?: number;
+}
+
+type VoiceBallComponent = ComponentType<VoiceBallProps>;
+
+// Same one-load-per-session pattern as FluidThinking — the presence is the
+// fluidkit voice ball. `undefined` = not attempted, `null` = off.
+let cached: VoiceBallComponent | null | undefined;
+
+/** Stage state → VoiceBall's three-mode register. `muted`/`error` never reach
+ *  the ball (they render the frozen disc): a lively ball that isn't listening
+ *  reads as a lie. `thinking` is a calm working breathe (idle), not attentive. */
+const MODE: Record<VoiceBlobState, VoiceBallMode> = {
+  connecting: "idle",
+  listening: "listening",
+  thinking: "idle",
+  speaking: "speaking",
+  muted: "idle",
+  error: "idle",
+};
+
+/**
+ * The voice presence — fluidkit's `VoiceBall` (0.5), a liquid glass bead tinted
+ * by the host's accent. fluidkit is an enhancement layer: a static disc paints
+ * immediately (and is all reduced-motion ever animates); the ball takes over
+ * when the chunk resolves. Muted/error freeze to the disc deliberately.
+ */
+export function VoiceBlob({ state, amplitude = 0, size = 96 }: VoiceBlobProps) {
+  const [VoiceBall, setVoiceBall] = useState<VoiceBallComponent | null>(() => cached ?? null);
+  const [reduced, setReduced] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  // The ball's glass fill needs a CONCRETE color (the accent is defined via
+  // light-dark()); read it off the mounted element's resolved `color`.
+  const [tint, setTint] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (typeof matchMedia === "undefined") return;
+    const query = matchMedia("(prefers-reduced-motion: reduce)");
+    setReduced(query.matches);
+    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches);
+    query.addEventListener("change", onChange);
+    return () => query.removeEventListener("change", onChange);
+  }, []);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof getComputedStyle === "undefined") return;
+    const resolved = getComputedStyle(el).color;
+    if (resolved) setTint(resolved);
+  }, []);
+
+  useEffect(() => {
+    if (cached !== undefined) return;
+    let alive = true;
+    import("fluidkit").then(
+      (mod) => {
+        cached = mod.VoiceBall;
+        if (alive) setVoiceBall(() => mod.VoiceBall);
+      },
+      () => {
+        cached = null;
+      },
+    );
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const still = state === "muted" || state === "error";
+  const fluid = VoiceBall && !reduced && !still;
+
+  return (
+    <div
+      ref={ref}
+      className={`fl-voice-blob is-${state}`}
+      style={{ width: size, height: size }}
+      aria-hidden="true"
+    >
+      {fluid ? (
+        <VoiceBall
+          mode={MODE[state]}
+          level={Math.max(0, Math.min(1, amplitude))}
+          size={size}
+          tint={tint}
+          opacity={0.58}
+          intensity="whisper"
+        />
+      ) : (
+        <span className="fl-voice-disc" />
+      )}
+      {(state === "muted" || state === "error") && (
+        <span className="fl-voice-glyph">
+          {state === "muted" ? (
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+              strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="2" y1="2" x2="22" y2="22" />
+              <path d="M9 9v3a3 3 0 0 0 5.12 2.12" /><path d="M15 9.34V5a3 3 0 0 0-5.94-.6" />
+              <path d="M5 10v1a7 7 0 0 0 12 5" /><path d="M19 10v1a7 7 0 0 1-.64 2.9" />
+              <line x1="12" y1="19" x2="12" y2="22" />
+            </svg>
+          ) : (
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+              strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+              <line x1="12" y1="9" x2="12" y2="13" /><line x1="12" y1="17" x2="12.01" y2="17" />
+            </svg>
+          )}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/test/wire-server.ts
+++ b/packages/ui/test/wire-server.ts
@@ -363,7 +363,11 @@ export async function createWireServer() {
       }
       if (method === "GET" && url.pathname === "/status") {
         if (state.statusErrorCode) return wireError(response, state.statusErrorCode, "Status failed", 501);
-        return json(response, { posture: state.posture, version: "0.3.0", blocks: { guard: true } });
+        // A client may force a posture via header (harness: one surface shows the
+        // no-policy notice while the rest render as a configured host).
+        const forced = request.headers["x-vendo-force-posture"];
+        const posture = typeof forced === "string" ? forced : state.posture;
+        return json(response, { posture, version: "0.3.0", blocks: { guard: true } });
       }
       if (method === "POST" && url.pathname === "/tick") return json(response, []);
       if (method === "POST" && url.pathname.startsWith("/webhooks/")) return json(response, { accepted: true });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,6 +440,12 @@ importers:
       '@vendoai/core':
         specifier: workspace:*
         version: link:../core
+      fluidkit:
+        specifier: file:../../vendor/fluidkit-0.5.0-656857b.tgz
+        version: file:vendor/fluidkit-0.5.0-656857b.tgz(motion@11.18.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      motion:
+        specifier: ^11.11.0
+        version: 11.18.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-markdown:
         specifier: ^9.0.1
         version: 9.1.0(@types/react@19.2.17)(react@19.2.7)
@@ -2047,6 +2053,18 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
+  fluidkit@file:vendor/fluidkit-0.5.0-656857b.tgz:
+    resolution: {integrity: sha512-RGUwZZMEPDCJRxxT2OlQnQyewr8AyBLE9LNz/nSMxYcTvtmOEmzc2VJK4j3+GJ3SkZlq9bWB1c3H+5z00E60PQ==, tarball: file:vendor/fluidkit-0.5.0-656857b.tgz}
+    version: 0.5.0
+    peerDependencies:
+      '@paper-design/shaders-react': 0.0.76
+      motion: '>=11'
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      '@paper-design/shaders-react':
+        optional: true
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
@@ -2058,6 +2076,20 @@ packages:
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
+
+  framer-motion@11.18.2:
+    resolution: {integrity: sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
@@ -2515,6 +2547,26 @@ packages:
 
   modal@0.9.0:
     resolution: {integrity: sha512-kCXcdJkhbJorf/q/6T9Wdlg6in9JmRnCNQnV6rVBMyeqNV/iXI6BYk4IzY4cvZ6dbauNeDMjk/Q08cbxvoIaXg==}
+
+  motion-dom@11.18.1:
+    resolution: {integrity: sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==}
+
+  motion-utils@11.18.1:
+    resolution: {integrity: sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==}
+
+  motion@11.18.2:
+    resolution: {integrity: sha512-JLjvFDuFr42NFtcVoMAyC2sEjnpA8xpy6qWPyzQvCloznAyQ8FIXioxWfHiLtgYhoVpfUqSWpn1h9++skj9+Wg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -4588,6 +4640,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fluidkit@file:vendor/fluidkit-0.5.0-656857b.tgz(motion@11.18.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      motion: 11.18.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -4602,6 +4660,15 @@ snapshots:
       mime-types: 2.1.35
 
   forwarded@0.2.0: {}
+
+  framer-motion@11.18.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      motion-dom: 11.18.1
+      motion-utils: 11.18.1
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   fresh@2.0.0: {}
 
@@ -5283,6 +5350,20 @@ snapshots:
       protobufjs: 7.6.5
       smol-toml: 1.7.0
       uuid: 11.1.1
+
+  motion-dom@11.18.1:
+    dependencies:
+      motion-utils: 11.18.1
+
+  motion-utils@11.18.1: {}
+
+  motion@11.18.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      framer-motion: 11.18.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
# feat(ui): full-fidelity shell reskin + motion across every surface

Follow-up to the design port (#125). Yousef reviewed and asked to bring **every** surface to the old-shell fidelity — "even things like the automation being activated animation." This does that: the landing hero, the fluid signatures, and per-surface motion. Presentation only — no contract change (additive optional props on `VendoThread`).

## What's new
- **Landing hero** (empty thread): "What do you want to build?" greeting, the pill composer (attach + "Ask anything" + mic + round send, with file attachments), and suggestion chips.
- **fluidkit + motion** (vendored) as the enhancement layer — lazy-loaded, graceful CSS fallback: **FluidThinking** (metaball working indicator) and **VoiceBlob** (liquid-glass voice presence).
- **Automations — the activation animation:** enabling an automation plays the celebration (the card blooms, the live dot pops in), reduced-motion aware.
- **Thread:** streaming life — the working indicator, the streaming caret, message entrance.
- **Voice / activity / palette / page / slot / approval / tree primitives:** entrance animations, glass-skeleton shimmer, ceremony, the slot ghost state.
- **Fix:** `.vendo-root` now paints the theme canvas (`--vendo-bg`) — this was leaving `theme.spec` red on main (browser suite isn't in root gates); now the root proves brand adoption and matches the old shell's warm canvas.

## The animations (real browser)
![automation](https://raw.githubusercontent.com/runvendo/vendo/screenshots/v0-wave3-ui/packages/ui/e2e/screenshots/automation-activation.gif)
![streaming](https://raw.githubusercontent.com/runvendo/vendo/screenshots/v0-wave3-ui/packages/ui/e2e/screenshots/thread-streaming.gif)
![voice](https://raw.githubusercontent.com/runvendo/vendo/screenshots/v0-wave3-ui/packages/ui/e2e/screenshots/voice.gif)

## Surfaces
| Landing (Maple host) | Voice (fluid blob) | Automations |
| --- | --- | --- |
| ![l](https://raw.githubusercontent.com/runvendo/vendo/screenshots/v0-wave3-ui/packages/ui/e2e/screenshots/landing.png) | ![s](https://raw.githubusercontent.com/runvendo/vendo/screenshots/v0-wave3-ui/packages/ui/e2e/screenshots/stage.png) | ![a](https://raw.githubusercontent.com/runvendo/vendo/screenshots/v0-wave3-ui/packages/ui/e2e/screenshots/automations.png) |

## Verification
`pnpm build/test/typecheck/lint` green (dependency-guard OK, 10 packages). **@vendoai/ui: 76 vitest + 51 Playwright** — axe zero violations, jail/appframe security, live OpenAI voice smoke, and **theme.spec now green** (was pre-existing red on main). Lockfile committed (fluidkit + motion).

Only Yousef/orchestrator merges.

🤖 https://claude.ai/code/session_01RDZoW2TRdg17jUTzMU5Fd6

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reskinned the UI shell to old‑shell fidelity and added motion across all surfaces (landing, thread, automations, voice). Presentation only; no contract change. Optional props added to `VendoThread`.

- **New Features**
  - Landing hero with greeting, suggestion chips, and pill composer (attach/mic/send). `VendoThread` now supports `greeting`, `suggestions`, and `onVoice`.
  - Thread motion: streaming caret, lazy `FluidThinking` working indicator with CSS fallback, and file attachments in turns.
  - Automations: enable celebration (card bloom + live‑dot pop), flow diagram, enable toast; respects reduced motion.
  - Voice stage: liquid presence via `VoiceBlob` (`fluidkit` `VoiceBall`) with graceful fallback.
  - Other surfaces: entrance/glass shimmer across activity, palette, page, slot (new ghost state), approval, and tree.
  - Harness: Maple host landing scenario, default posture set to `rules`, and per‑request posture override.

- **Bug Fixes**
  - `.vendo-root` now paints the theme canvas (`--vendo-bg`), restoring brand adoption and fixing the failing theme spec.
  - Accessibility audit waits only for finite animations, avoiding hangs from continuous voice presence.

<sup>Written for commit f9e51659208875e5173f115f94349a098c2402c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

