### PR TITLE
fix(ui): review triage for the fidelity pass (attachment draft-drop, fluidkit specifier, matchMedia)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@ai-sdk/react": "^3.0.30",
     "@vendoai/core": "workspace:*",
-    "fluidkit": "*",
+    "fluidkit": "^0.5.0",
     "motion": "^11.11.0",
     "react-markdown": "^9.0.1",
     "remark-gfm": "^4.0.0",

--- a/packages/ui/src/chrome/automations-panel.tsx
+++ b/packages/ui/src/chrome/automations-panel.tsx
@@ -118,6 +118,12 @@ export function AutomationsPanel() {
     setMissing(current => ({ ...current, [appId]: (current[appId] ?? []).filter(item => item.id !== approval.id) }));
   };
 
+  // Evaluated once per render (not once per automation): matchMedia is cheap but
+  // querying it inside the list map was needless repeated work.
+  const reduced = theme.motion === "reduced"
+    || (typeof window !== "undefined" && typeof window.matchMedia === "function"
+      && window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+
   return (
     <ChromeRoot>
       <section aria-labelledby="vendo-automations-heading" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
@@ -129,9 +135,6 @@ export function AutomationsPanel() {
           const appRuns = runs[appId];
           const flow = automationFlow(entry.app.trigger);
           const celebrating = justEnabled[appId] === true;
-          const reduced = theme.motion === "reduced"
-            || (typeof window !== "undefined" && typeof window.matchMedia === "function"
-              && window.matchMedia("(prefers-reduced-motion: reduce)").matches);
           return (
             <article
               className="fl-automation"

--- a/packages/ui/src/chrome/vendo-thread.tsx
+++ b/packages/ui/src/chrome/vendo-thread.tsx
@@ -86,21 +86,33 @@ export function VendoThread({
   ) ?? false;
   const working = busy && !assistantHasVisibleText;
 
+  const [attachError, setAttachError] = useState<string>();
   const send = (override?: string) => {
     const text = (override ?? draft).trim();
     if ((!text && files.length === 0) || busy) return;
     const pending = files;
-    setDraft("");
-    setFiles([]);
-    if (fileRef.current) fileRef.current.value = "";
     void (async () => {
-      const parts = await Promise.all(pending.map(fileToPart));
+      let parts: Awaited<ReturnType<typeof fileToPart>>[];
+      try {
+        parts = await Promise.all(pending.map(fileToPart));
+      } catch (reason) {
+        // A file read failed — DON'T clear the draft/attachments, or the message
+        // would vanish silently. Surface the error and let the user retry.
+        setAttachError(reason instanceof Error ? reason.message : "Couldn't read an attachment.");
+        return;
+      }
+      // Only clear once the turn is committed.
+      setAttachError(undefined);
+      setDraft("");
+      setFiles([]);
+      if (fileRef.current) fileRef.current.value = "";
       void thread.sendMessage(parts.length > 0 ? { text, files: parts } : { text });
     })();
   };
 
   const composer = (
     <form className="fl-composer" aria-label="Message composer" onSubmit={event => { event.preventDefault(); send(); }}>
+      {attachError ? <div className="fl-att-error" role="alert">{attachError}</div> : null}
       {files.length > 0 ? (
         <div className="fl-att-chips">
           {files.map((file, i) => (


### PR DESCRIPTION
# fix(ui): review triage for the fidelity pass (#129)

#129 merged before triage completed, so these are the real reviewer findings applied as a follow-up. All green after.

## Fixed
- **Greptile — attachment draft-drop (real bug):** the composer cleared the draft + attachments *before* the async `FileReader`, so a failed read silently lost the user's message. Now it reads first, clears only on success, and surfaces a `role="alert"` error on failure (nothing is lost).
- **Greptile — fluidkit specifier:** `"*"` → `"^0.5.0"` (matches the legacy convention; the root vendored override still resolves it). Frozen install verified.
- **Devin — matchMedia per render:** hoisted the reduced-motion check out of the per-automation map (once per render).

## Verification
`pnpm build/test/typecheck/lint` green (dependency-guard OK, 10 packages), `pnpm install --frozen-lockfile` clean; **76 vitest + 51 Playwright** (axe 0 violations, theme.spec green).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents message loss in the composer by reading attachments before clearing state and showing an error on read failure. Also pins `fluidkit` to `^0.5.0` and hoists the reduced-motion check to reduce unnecessary work.

- **Bug Fixes**
  - Composer reads files first; clears draft/attachments only on success; shows role="alert" on read failure.
  - Moved reduced-motion matchMedia check out of the list loop to run once per render.

- **Dependencies**
  - Set `fluidkit` from `*` to `^0.5.0` to align with versioning and stabilize installs.

<sup>Written for commit 0a4c4068691b314ec134c2ba99a6919e1674cddb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

