### PR TITLE
Non-Next (Express) host in the corpus — prove the framework-agnostic handler

### DIFF
--- a/corpus/README.md
+++ b/corpus/README.md
@@ -37,13 +37,24 @@ Known local-pack hazard: paths containing spaces are rejected up front by the
 harness. Keep both the Vendo workspace path and `corpus/.repos/<name>/` paths
 space-free.
 
+## Local hosts
+
+Manifest entries may use `localPath` instead of `gitUrl` plus `pinnedSha`. The
+path is relative to the Vendo repo root; each run copies it into `.repos/`,
+omits generated/dependency trees, and creates a fresh one-commit Git snapshot
+for the same init-idempotency checks used by external repos. `express-host` is
+the permanent proof that the framework-agnostic handler claim in contracts 09
+§2 survives all three corpus layers, including a live `vendo doctor` check.
+
 ## Manifest
 
 `corpus/manifest.json` is a JSON array. Each entry has:
 
 - `name`: stable lowercase repo identifier.
-- `gitUrl`: HTTPS git URL.
-- `pinnedSha`: 40-character commit SHA from the repo's default branch.
+- Source: either `gitUrl` plus a 40-character `pinnedSha`, or a repo-relative
+  `localPath`; the two forms are mutually exclusive.
+- `framework`: optional `next` or `express` structural wiring mode; defaults to
+  `next`.
 - `license`: SPDX identifier or a documented best-effort license string.
 - `tier`: `broad` or `deep`.
 - `bootstrap`: install command, env template, optional seed command, build

--- a/corpus/expectations/express-host/baseline.json
+++ b/corpus/expectations/express-host/baseline.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "generatedAt": "2026-07-12T00:00:00.000Z",
+  "score": {
+    "passed": 10,
+    "total": 10,
+    "value": 1
+  }
+}

--- a/corpus/expectations/express-host/conversations.json
+++ b/corpus/expectations/express-host/conversations.json
@@ -1,0 +1,40 @@
+{
+  "version": 1,
+  "k": 2,
+  "threshold": 1,
+  "timeoutMs": 90000,
+  "seedNotes": "Relay starts with eight deterministic tasks. The destructive prompt targets the seeded Review mobile empty states task.",
+  "conversations": [
+    {
+      "id": "list-open-tasks",
+      "description": "Read Relay's current open task inventory.",
+      "prompts": [
+        "What tasks are open right now?"
+      ],
+      "assertions": [
+        {
+          "kind": "tool-called",
+          "name": "host_listTasks"
+        },
+        {
+          "kind": "no-error-toast"
+        }
+      ]
+    },
+    {
+      "id": "delete-seeded-task-approval",
+      "description": "Deleting a specific seeded task must stop for destructive approval.",
+      "prompts": [
+        "Delete the task about Review mobile empty states."
+      ],
+      "assertions": [
+        {
+          "kind": "approval-card-shown"
+        },
+        {
+          "kind": "no-error-toast"
+        }
+      ]
+    }
+  ]
+}

--- a/corpus/expectations/express-host/conversations.json
+++ b/corpus/expectations/express-host/conversations.json
@@ -35,6 +35,25 @@
           "kind": "no-error-toast"
         }
       ]
+    },
+    {
+      "id": "build-and-open-priority-dashboard",
+      "description": "Create a generated dashboard and open it in the Relay SPA.",
+      "prompts": [
+        "Build a task-priority dashboard with the exact visible heading Relay priority dashboard.",
+        "Open the Relay priority dashboard you just built."
+      ],
+      "assertions": [
+        {
+          "kind": "view-rendered",
+          "text": {
+            "contains": "Relay priority dashboard"
+          }
+        },
+        {
+          "kind": "no-error-toast"
+        }
+      ]
     }
   ]
 }

--- a/corpus/expectations/express-host/expected.json
+++ b/corpus/expectations/express-host/expected.json
@@ -1,0 +1,72 @@
+{
+  "version": 1,
+  "theme": {
+    "background": "#eef7f4",
+    "surface": "#ffffff",
+    "accent": "#087f6f",
+    "text": "#102f2a",
+    "mutedText": "#5a7771",
+    "radius": "16px",
+    "fontFamily": "Inter, ui-sans-serif, system-ui, sans-serif"
+  },
+  "tools": [
+    {
+      "name": "listTasks",
+      "method": "GET",
+      "path": "/api/tasks",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "createTask",
+      "method": "POST",
+      "path": "/api/tasks",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "getTask",
+      "method": "GET",
+      "path": "/api/tasks/{id}",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "deleteTask",
+      "method": "DELETE",
+      "path": "/api/tasks/{id}",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "completeTask",
+      "method": "POST",
+      "path": "/api/tasks/{id}/complete",
+      "readOrWrite": "write"
+    }
+  ],
+  "annotations": [
+    {
+      "name": "listTasks",
+      "mutating": false,
+      "dangerous": false
+    },
+    {
+      "name": "createTask",
+      "mutating": true,
+      "dangerous": false
+    },
+    {
+      "name": "getTask",
+      "mutating": false,
+      "dangerous": false
+    },
+    {
+      "name": "deleteTask",
+      "mutating": true,
+      "dangerous": true
+    },
+    {
+      "name": "completeTask",
+      "mutating": true,
+      "dangerous": false
+    }
+  ],
+  "components": []
+}

--- a/corpus/harness/src/bootstrap.test.ts
+++ b/corpus/harness/src/bootstrap.test.ts
@@ -6,7 +6,7 @@ import { bootstrapRepo } from "./bootstrap.js";
 import { createRunContext } from "./run-context.js";
 import type { ManifestEntry } from "./manifest.js";
 
-type BootstrapRepo = Pick<ManifestEntry, "name" | "appDir" | "bootstrap">;
+type BootstrapRepo = Pick<ManifestEntry, "name" | "appDir" | "localPath" | "bootstrap">;
 
 const tempRoots: string[] = [];
 
@@ -56,6 +56,24 @@ async function writeNodeBin(file: string, body: string): Promise<void> {
 }
 
 describe("bootstrapRepo", () => {
+  it("writes local-source env and logs while skipping the pre-injection install", async () => {
+    const { corpusRoot, repo, repoDir } = await makeRepo();
+    const context = createRunContext({ corpusRoot });
+    repo.localPath = "corpus/hosts/fixture-app";
+    repo.bootstrap.envTemplate = { PORT: "3210" };
+    await writeInstallScript(repoDir, `
+      import { writeFileSync } from "node:fs";
+      writeFileSync("install-should-not-run.txt", "ran");
+    `);
+
+    const result = await bootstrapRepo(repo, { context });
+
+    await expect(readFile(result.envPath, "utf8")).resolves.toBe("PORT=3210\n");
+    await expect(readFile(path.join(repoDir, "install-should-not-run.txt"), "utf8")).rejects.toThrow();
+    await expect(readFile(result.logs.stdout, "utf8")).resolves.toMatch(/skipped pre-injection install/i);
+    await expect(readFile(result.logs.stderr, "utf8")).resolves.toBe("");
+  });
+
   it("runs the install command in the corpus repo directory and captures command logs", async () => {
     const { corpusRoot, repo, repoDir } = await makeRepo();
     const context = createRunContext({ corpusRoot });

--- a/corpus/harness/src/bootstrap.ts
+++ b/corpus/harness/src/bootstrap.ts
@@ -6,7 +6,7 @@ import { normalizeBootstrapInstallCommand } from "./install-command.js";
 import type { ManifestEntry } from "./manifest.js";
 import { createRunContext, type CorpusRunContext } from "./run-context.js";
 
-export type BootstrapRepo = Pick<ManifestEntry, "name" | "appDir" | "bootstrap">;
+export type BootstrapRepo = Pick<ManifestEntry, "name" | "appDir" | "localPath" | "bootstrap">;
 
 export interface BootstrapOptions {
   context?: CorpusRunContext;
@@ -111,6 +111,16 @@ export async function bootstrapRepo(repo: BootstrapRepo, options: BootstrapOptio
   await writeFile(envPath, formatEnv(resolved.values));
 
   await mkdir(logsDir, { recursive: true });
+  if (repo.localPath !== undefined) {
+    await writeFile(logs.stdout, "Skipped pre-injection install for local corpus source; injection performs the standalone install.\n");
+    await writeFile(logs.stderr, "");
+    return {
+      repoDir,
+      envPath,
+      logs,
+    };
+  }
+
   const hasPnpmWorkspace = await pathExists(path.join(repoDir, "pnpm-workspace.yaml"));
   const installCommand = normalizeBootstrapInstallCommand(repo.bootstrap.installCommand, {
     dropIgnoreWorkspace: hasPnpmWorkspace,

--- a/corpus/harness/src/cli.test.ts
+++ b/corpus/harness/src/cli.test.ts
@@ -475,7 +475,7 @@ describe("runCli run", () => {
   it("runs Layer 3 by booting a deep repo and passing the booted app to the e2e harness", async () => {
     const corpusRoot = await makeTempRoot();
     const context = createRunContext({ corpusRoot });
-    const repo = deepManifestEntry("repo-e2e");
+    const repo = { ...deepManifestEntry("repo-e2e"), framework: "express" as const };
     const events: string[] = [];
     const e2eContexts: E2eLayerContext[] = [];
     const stdout: string[] = [];
@@ -558,6 +558,18 @@ describe("runCli run", () => {
         events.push("boot:repo-e2e");
         return handle;
       },
+      runLiveDoctor: async (options) => {
+        events.push("doctor:repo-e2e");
+        expect(options).toMatchObject({
+          appRoot: context.repoDir("repo-e2e"),
+          readinessUrl: "http://127.0.0.1:3333",
+          logsDir: context.logsDir("repo-e2e"),
+        });
+        return {
+          check: { id: "doctor.live", pass: true, detail: "live doctor passed" },
+          logPath: path.join(context.logsDir(repo.name), "doctor.live.log"),
+        };
+      },
       runE2eLayer: async (layerContext): Promise<E2eLayerRunResult> => {
         events.push("layer3:repo-e2e");
         e2eContexts.push(layerContext);
@@ -589,6 +601,7 @@ describe("runCli run", () => {
       "layer1:repo-e2e",
       "layer2:repo-e2e",
       "boot:repo-e2e",
+      "doctor:repo-e2e",
       "layer3:repo-e2e",
       "teardown:repo-e2e",
     ]);
@@ -602,6 +615,8 @@ describe("runCli run", () => {
     expect(stdout.join("\n")).toContain("| repo-e2e | Layer 3 e2e | PASS | 5/5 |");
     expect(stdout.join("\n")).toContain("boot.server.log");
     expect(stdout.join("\n")).toContain("e2e.conversations.json");
+    expect(stdout.join("\n")).toContain("doctor.live.log");
+    await expect(readFile(path.join(context.reposDir, ".logs", "scorecard.json"), "utf8")).resolves.toContain('"id": "doctor.live"');
   });
 
   it("continues after a repo failure and makes only --strict return nonzero", async () => {

--- a/corpus/harness/src/cli.ts
+++ b/corpus/harness/src/cli.ts
@@ -32,6 +32,11 @@ import {
 } from "./init-step.js";
 import { prepareE2eRepo as defaultPrepareE2eRepo } from "./e2e-prep.js";
 import {
+  runLiveDoctor as defaultRunLiveDoctor,
+  type LiveDoctorResult,
+  type RunLiveDoctorOptions,
+} from "./doctor-live.js";
+import {
   runE2eLayer as defaultRunE2eLayer,
   type E2eLayerContext,
   type E2eLayerRunResult,
@@ -71,7 +76,7 @@ const usage = `Usage:
 
 Commands:
   validate  Load and validate corpus/manifest.json.
-  list      Print manifest repo names with tier and pinned SHA.
+  list      Print manifest repo names with tier and source revision/path.
   run       Clone, bootstrap, inject local Vendo, run init, and execute selected layers.
   boot      Clone, bootstrap, inject local Vendo, run init, boot one deep-tier app, and wait for Ctrl-C.
 `;
@@ -99,6 +104,7 @@ export interface CorpusCliDependencies {
   runScoredLayer?: (ctx: ScoredLayerContext) => Promise<ScoredLayerRunResult>;
   prepareE2eRepo?: (repo: ManifestEntry, appRoot: string, logsDir: string) => Promise<string[]>;
   runE2eLayer?: (ctx: E2eLayerContext) => Promise<E2eLayerRunResult>;
+  runLiveDoctor?: (options: RunLiveDoctorOptions) => Promise<LiveDoctorResult>;
   commandRunner?: StructuralCommandRunner;
 }
 
@@ -120,6 +126,7 @@ interface ResolvedDeps {
   runScoredLayer: (ctx: ScoredLayerContext) => Promise<ScoredLayerRunResult>;
   prepareE2eRepo: (repo: ManifestEntry, appRoot: string, logsDir: string) => Promise<string[]>;
   runE2eLayer: (ctx: E2eLayerContext) => Promise<E2eLayerRunResult>;
+  runLiveDoctor: (options: RunLiveDoctorOptions) => Promise<LiveDoctorResult>;
   commandRunner: StructuralCommandRunner;
 }
 
@@ -159,6 +166,7 @@ function resolveDeps(deps: CorpusCliDependencies = {}): ResolvedDeps {
     runScoredLayer: deps.runScoredLayer ?? defaultRunScoredLayer,
     prepareE2eRepo: deps.prepareE2eRepo ?? defaultPrepareE2eRepo,
     runE2eLayer: deps.runE2eLayer ?? defaultRunE2eLayer,
+    runLiveDoctor: deps.runLiveDoctor ?? defaultRunLiveDoctor,
     commandRunner: deps.commandRunner ?? runShellCommand,
   };
 }
@@ -443,7 +451,7 @@ async function runRepoThroughLayerOne(
   const logPaths: string[] = [];
 
   try {
-    const checkoutDir = await deps.ensureRepoCheckout(repo, { context });
+    const checkoutDir = await deps.ensureRepoCheckout(repo, { context, workspaceRoot: deps.workspaceRoot });
     const appRoot = resolveAppRoot(repo, checkoutDir);
     const bootstrap = await deps.bootstrapRepo(repo, { context, env: deps.env });
     logPaths.push(bootstrap.logs.stdout, bootstrap.logs.stderr);
@@ -483,6 +491,7 @@ async function runRepoThroughLayerOne(
       baseline,
       commandRunner: loggedCommands.runner,
       env: deps.env,
+      framework: repo.framework ?? "next",
     });
 
     const layers: ScorecardLayerInput[] = [
@@ -530,6 +539,16 @@ async function runRepoThroughLayerOne(
             env: deps.env,
           });
           layerLogPaths.push(...bootHandleLogPaths(handle));
+          const doctor = repo.framework === "express"
+            ? await deps.runLiveDoctor({
+                workspaceRoot: deps.workspaceRoot ?? defaultWorkspaceRoot,
+                appRoot,
+                readinessUrl: handle.readinessUrl,
+                logsDir: context.logsDir(repo.name),
+                env: deps.env,
+              })
+            : undefined;
+          if (doctor) layerLogPaths.push(doctor.logPath);
           const e2e = await deps.runE2eLayer({
             repoName: repo.name,
             repoDir: appRoot,
@@ -540,6 +559,8 @@ async function runRepoThroughLayerOne(
           });
           layer = {
             ...e2e.layer,
+            ...(doctor && !doctor.check.pass ? { status: "fail" as const, hardFailure: true } : {}),
+            checks: [...(e2e.layer.checks ?? []), ...(doctor ? [doctor.check] : [])],
             logPaths: [...layerLogPaths, ...(e2e.layer.logPaths ?? [])],
           };
         } catch (error) {
@@ -603,7 +624,7 @@ async function runBootCommand(options: BootCommandOptions, deps: ResolvedDeps): 
 
   const context = deps.createContext();
   const injector = deps.createInjector({ context, workspaceRoot: deps.workspaceRoot });
-  await deps.ensureRepoCheckout(repo, { context });
+  await deps.ensureRepoCheckout(repo, { context, workspaceRoot: deps.workspaceRoot });
   await deps.bootstrapRepo(repo, { context, env: deps.env });
 
   const injectResult = await injector.inject(repo);
@@ -667,7 +688,7 @@ export async function runCli(args = process.argv.slice(2), providedDeps: CorpusC
     if (command === "list") {
       const manifest = await deps.loadManifest();
       for (const repo of manifest) {
-        deps.stdout(`${repo.name}\t${repo.tier}\t${repo.pinnedSha}`);
+        deps.stdout(`${repo.name}\t${repo.tier}\t${repo.localPath ?? repo.pinnedSha}`);
       }
       return 0;
     }

--- a/corpus/harness/src/clone.test.ts
+++ b/corpus/harness/src/clone.test.ts
@@ -101,6 +101,47 @@ describe("createRunContext", () => {
 });
 
 describe("ensureRepoCheckout", () => {
+  it("freshly snapshots a local source with generated trees excluded and one clean commit", async () => {
+    const workspaceRoot = await makeTempRoot("local-workspace");
+    const sourceDir = path.join(workspaceRoot, "corpus/hosts/fixture-app");
+    await mkdir(path.join(sourceDir, "src"), { recursive: true });
+    await mkdir(path.join(sourceDir, "node_modules/pkg"), { recursive: true });
+    await mkdir(path.join(sourceDir, "dist"), { recursive: true });
+    await mkdir(path.join(sourceDir, "vendor"), { recursive: true });
+    await mkdir(path.join(sourceDir, ".vendo/data"), { recursive: true });
+    await writeFile(path.join(sourceDir, "src/index.ts"), "export const version = 1;\n");
+    await writeFile(path.join(sourceDir, "node_modules/pkg/index.js"), "excluded\n");
+    await writeFile(path.join(sourceDir, "dist/index.js"), "excluded\n");
+    await writeFile(path.join(sourceDir, "vendor/pkg.tgz"), "excluded\n");
+    await writeFile(path.join(sourceDir, ".vendo/data/state"), "excluded\n");
+    const corpusRoot = await makeTempRoot("local-copy");
+    const context = createRunContext({ corpusRoot });
+
+    const repoDir = await ensureRepoCheckout({
+      name: "fixture-app",
+      localPath: "corpus/hosts/fixture-app",
+    }, { context, workspaceRoot });
+
+    await expect(readFile(path.join(repoDir, "src/index.ts"), "utf8")).resolves.toContain("version = 1");
+    for (const excluded of [
+      "node_modules/pkg/index.js",
+      "dist/index.js",
+      "vendor/pkg.tgz",
+      ".vendo/data/state",
+    ]) {
+      await expect(readFile(path.join(repoDir, excluded), "utf8")).rejects.toThrow();
+    }
+    await expect(runGit(["rev-list", "--count", "HEAD"], repoDir)).resolves.toBe("1");
+    await expect(runGit(["status", "--porcelain"], repoDir)).resolves.toBe("");
+
+    await writeFile(path.join(repoDir, "stale.txt"), "remove me");
+    await writeFile(path.join(sourceDir, "src/index.ts"), "export const version = 2;\n");
+    await ensureRepoCheckout({ name: "fixture-app", localPath: "corpus/hosts/fixture-app" }, { context, workspaceRoot });
+    await expect(readFile(path.join(repoDir, "src/index.ts"), "utf8")).resolves.toContain("version = 2");
+    await expect(readFile(path.join(repoDir, "stale.txt"), "utf8")).rejects.toThrow();
+    await expect(runGit(["rev-list", "--count", "HEAD"], repoDir)).resolves.toBe("1");
+  });
+
   it("clones a repository at the pinned SHA with detached HEAD", async () => {
     const source = await createFixtureRepo();
     const pinnedSha = await source.commitFile("pinned\n");

--- a/corpus/harness/src/clone.ts
+++ b/corpus/harness/src/clone.ts
@@ -1,13 +1,16 @@
 import { spawn } from "node:child_process";
-import { mkdir, rm } from "node:fs/promises";
+import { cp, mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { ManifestEntry } from "./manifest.js";
 import { createRunContext, type CorpusRunContext } from "./run-context.js";
 
-export type CloneRepo = Pick<ManifestEntry, "name" | "gitUrl" | "pinnedSha">;
+export type CloneRepo = Pick<ManifestEntry, "name" | "gitUrl" | "pinnedSha" | "localPath">;
 
 export interface EnsureRepoCheckoutOptions {
   context?: CorpusRunContext;
   gitBin?: string;
+  workspaceRoot?: string;
 }
 
 interface CommandResult {
@@ -21,6 +24,8 @@ interface FetchAttempt {
   result: CommandResult;
   hasCommit: boolean;
 }
+
+const defaultWorkspaceRoot = path.resolve(fileURLToPath(new URL("../../../", import.meta.url)));
 
 function runGit(gitBin: string, args: readonly string[], cwd: string): Promise<CommandResult> {
   return new Promise((resolve, reject) => {
@@ -128,6 +133,37 @@ export async function ensureRepoCheckout(repo: CloneRepo, options: EnsureRepoChe
   const repoDir = context.repoDir(repo.name);
 
   await mkdir(context.reposDir, { recursive: true });
+  if (repo.localPath !== undefined) {
+    const workspaceRoot = path.resolve(options.workspaceRoot ?? defaultWorkspaceRoot);
+    const sourceDir = path.resolve(workspaceRoot, repo.localPath);
+    await rm(repoDir, { recursive: true, force: true });
+    await cp(sourceDir, repoDir, {
+      recursive: true,
+      filter(source) {
+        const relative = path.relative(sourceDir, source);
+        if (relative === "") return true;
+        const segments = relative.split(path.sep);
+        if (segments.some((segment) => segment === "node_modules" || segment === "dist" || segment === "vendor")) return false;
+        return !segments.some((segment, index) => segment === ".vendo" && segments[index + 1] === "data");
+      },
+    });
+    await checkedGit(gitBin, ["init"], repoDir);
+    await checkedGit(gitBin, ["add", "-A"], repoDir);
+    await checkedGit(gitBin, [
+      "-c",
+      "user.name=Vendo Corpus",
+      "-c",
+      "user.email=corpus@vendo.local",
+      "commit",
+      "-m",
+      "Snapshot local corpus source",
+    ], repoDir);
+    return repoDir;
+  }
+
+  if (repo.gitUrl === undefined || repo.pinnedSha === undefined) {
+    throw new Error(`Git corpus source ${repo.name} must define gitUrl and pinnedSha`);
+  }
   if (!await isGitWorkTree(gitBin, repoDir)) {
     await rm(repoDir, { recursive: true, force: true });
     await initializeWorkTree(gitBin, repoDir, repo.gitUrl);

--- a/corpus/harness/src/doctor-live.test.ts
+++ b/corpus/harness/src/doctor-live.test.ts
@@ -1,0 +1,78 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runLiveDoctor } from "./doctor-live.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })));
+  tempRoots.length = 0;
+});
+
+describe("runLiveDoctor", () => {
+  it("spawns the built CLI against the live Express mount and records a passing check", async () => {
+    const workspaceRoot = await mkdtemp(path.join(tmpdir(), "vendo-doctor-workspace-"));
+    tempRoots.push(workspaceRoot);
+    const appRoot = path.join(workspaceRoot, "corpus/.repos/express-host");
+    const logsDir = path.join(workspaceRoot, "corpus/.repos/.logs/express-host");
+    const calls: Array<{ command: string; args: readonly string[]; cwd: string; telemetry?: string }> = [];
+
+    const result = await runLiveDoctor({
+      workspaceRoot,
+      appRoot,
+      readinessUrl: "http://127.0.0.1:3210",
+      logsDir,
+      env: { VENDO_TELEMETRY_DISABLED: "0" },
+      async spawnDoctor(command, args, options) {
+        calls.push({ command, args, cwd: options.cwd, telemetry: options.env.VENDO_TELEMETRY_DISABLED });
+        return { code: 0, signal: null, stdout: "doctor passed\n", stderr: "" };
+      },
+    });
+
+    expect(calls).toEqual([{
+      command: process.execPath,
+      args: [
+        path.join(workspaceRoot, "packages/vendo/bin/vendo.mjs"),
+        "doctor",
+        appRoot,
+        "--url",
+        "http://127.0.0.1:3210/api/vendo",
+      ],
+      cwd: workspaceRoot,
+      telemetry: "1",
+    }]);
+    expect(result.check).toMatchObject({ id: "doctor.live", pass: true });
+    await expect(readFile(result.logPath, "utf8")).resolves.toContain("doctor passed");
+  });
+
+  it("records nonzero and spawn failures as failed doctor.live checks", async () => {
+    const workspaceRoot = await mkdtemp(path.join(tmpdir(), "vendo-doctor-failure-"));
+    tempRoots.push(workspaceRoot);
+    const shared = {
+      workspaceRoot,
+      appRoot: path.join(workspaceRoot, "app"),
+      readinessUrl: "http://127.0.0.1:3210/",
+      logsDir: path.join(workspaceRoot, "logs"),
+    };
+
+    const nonzero = await runLiveDoctor({
+      ...shared,
+      async spawnDoctor() {
+        return { code: 2, signal: null, stdout: "", stderr: "wiring missing" };
+      },
+    });
+    expect(nonzero.check).toMatchObject({ id: "doctor.live", pass: false });
+    expect(nonzero.check.detail).toContain("exit code 2");
+
+    const failedStart = await runLiveDoctor({
+      ...shared,
+      async spawnDoctor() {
+        throw new Error("spawn ENOENT");
+      },
+    });
+    expect(failedStart.check).toMatchObject({ id: "doctor.live", pass: false });
+    expect(failedStart.check.detail).toContain("spawn ENOENT");
+  });
+});

--- a/corpus/harness/src/doctor-live.ts
+++ b/corpus/harness/src/doctor-live.ts
@@ -1,0 +1,105 @@
+import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { ScorecardCheck } from "./scorecard.js";
+
+export interface LiveDoctorCommandResult {
+  code: number | null;
+  signal?: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}
+
+export type LiveDoctorSpawner = (
+  command: string,
+  args: readonly string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv },
+) => Promise<LiveDoctorCommandResult>;
+
+export interface RunLiveDoctorOptions {
+  workspaceRoot: string;
+  appRoot: string;
+  readinessUrl: string;
+  logsDir: string;
+  env?: NodeJS.ProcessEnv;
+  spawnDoctor?: LiveDoctorSpawner;
+}
+
+export interface LiveDoctorResult {
+  check: ScorecardCheck;
+  logPath: string;
+}
+
+function defaultSpawnDoctor(
+  command: string,
+  args: readonly string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv },
+): Promise<LiveDoctorCommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", reject);
+    child.on("close", (code, signal) => resolve({ code, signal, stdout, stderr }));
+  });
+}
+
+function commandStatus(result: LiveDoctorCommandResult): string {
+  return result.code === null ? `signal ${result.signal ?? "unknown"}` : `exit code ${result.code}`;
+}
+
+function compactOutput(output: string): string {
+  const trimmed = output.trim();
+  return trimmed.length <= 500 ? trimmed : `${trimmed.slice(0, 500)}...`;
+}
+
+export async function runLiveDoctor(options: RunLiveDoctorOptions): Promise<LiveDoctorResult> {
+  const cliPath = path.join(options.workspaceRoot, "packages/vendo/bin/vendo.mjs");
+  const liveUrl = new URL("/api/vendo", options.readinessUrl).toString();
+  const args = [cliPath, "doctor", options.appRoot, "--url", liveUrl];
+  const logPath = path.join(options.logsDir, "doctor.live.log");
+  await mkdir(options.logsDir, { recursive: true });
+
+  try {
+    const result = await (options.spawnDoctor ?? defaultSpawnDoctor)(process.execPath, args, {
+      cwd: options.workspaceRoot,
+      env: {
+        ...process.env,
+        ...options.env,
+        VENDO_TELEMETRY_DISABLED: "1",
+      },
+    });
+    const output = [result.stdout, result.stderr].filter(Boolean).join("\n");
+    await writeFile(logPath, `$ ${process.execPath} ${args.join(" ")}\n${output}`);
+    const pass = result.code === 0;
+    return {
+      check: {
+        id: "doctor.live",
+        pass,
+        detail: pass
+          ? `vendo doctor passed against ${liveUrl}`
+          : `vendo doctor failed with ${commandStatus(result)} against ${liveUrl}${output ? `: ${compactOutput(output)}` : ""}`,
+      },
+      logPath,
+    };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    await writeFile(logPath, `$ ${process.execPath} ${args.join(" ")}\n${detail}\n`);
+    return {
+      check: {
+        id: "doctor.live",
+        pass: false,
+        detail: `vendo doctor failed to start against ${liveUrl}: ${detail}`,
+      },
+      logPath,
+    };
+  }
+}

--- a/corpus/harness/src/e2e-prep.test.ts
+++ b/corpus/harness/src/e2e-prep.test.ts
@@ -178,6 +178,15 @@ export function AppVendoRoot({ children }: { children: ReactNode }) {
 }
 
 describe("prepareE2eRepo", () => {
+  it("keeps the permanently wired Express host as an explicit no-op", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "vendo-express-prep-"));
+    const appRoot = path.join(root, "express-host");
+    const logsDir = path.join(root, "logs");
+
+    await expect(prepareE2eRepo({ name: "express-host" }, appRoot, logsDir)).resolves.toEqual([]);
+    await expect(readFile(path.join(logsDir, "e2e.prepare.log"), "utf8")).rejects.toThrow();
+  });
+
   it("adds Skateshop corpus routes, reviewed tools, handler guidance, and per-attempt thread ids", async () => {
     const { appRoot, logsDir } = await createSkateshopFixture();
     const logs = await prepareE2eRepo({ name: "skateshop" }, appRoot, logsDir);

--- a/corpus/harness/src/e2e-prep.ts
+++ b/corpus/harness/src/e2e-prep.ts
@@ -719,6 +719,7 @@ export async function prepareE2eRepo(
   appRoot: string,
   logsDir: string,
 ): Promise<string[]> {
+  if (repo.name === "express-host") return [];
   if (repo.name === "skateshop") return prepareSkateshopE2eRepo(appRoot, logsDir);
   await mkdir(logsDir, { recursive: true });
   const logPath = path.join(logsDir, "e2e.prepare.log");

--- a/corpus/harness/src/inject.test.ts
+++ b/corpus/harness/src/inject.test.ts
@@ -103,6 +103,45 @@ function readAnyPackageJson(repoDir: string): Promise<Record<string, unknown>> {
 }
 
 describe("createLocalVendoInjector", () => {
+  it("falls back to pnpm without a lockfile and preserves direct local Vendo packages used by a standalone host", async () => {
+    const workspaceRoot = await createWorkspace();
+    const corpusRoot = await makeTempRoot();
+    const context = createRunContext({ corpusRoot });
+    const repoDir = context.repoDir("local-host");
+    await writeJson(path.join(repoDir, "package.json"), {
+      name: "local-host",
+      dependencies: {
+        "@vendoai/ui": "workspace:*",
+        "@vendoai/vendo": "workspace:*",
+      },
+      devDependencies: {
+        "@vendoai/store": "workspace:*",
+      },
+    });
+    const pack: PackWorkspacePackage = async (pkg, opts) => {
+      await mkdir(opts.vendorDir, { recursive: true });
+      await writeFile(path.join(opts.vendorDir, opts.fileName), `packed ${pkg.name}`);
+    };
+    const injector = createLocalVendoInjector({
+      context,
+      workspaceRoot,
+      runInstall: false,
+      pack,
+      async buildWorkspace() {},
+    });
+
+    const result = await injector.inject({ name: "local-host" });
+    const pkg = await readPackageJson(repoDir);
+
+    expect(result.packageManager).toBe("pnpm");
+    expect(result.installDir).toBe(repoDir);
+    expect(pkg.dependencies["@vendoai/vendo"]).toBe("file:vendor/vendoai-vendo-0.3.0.tgz");
+    expect(pkg.dependencies["@vendoai/ui"]).toBe("file:vendor/vendoai-ui-0.3.0.tgz");
+    expect(pkg.devDependencies?.["@vendoai/store"]).toBe("file:vendor/vendoai-store-0.3.0.tgz");
+    await expect(readFile(path.join(repoDir, "pnpm-lock.yaml"), "utf8")).rejects.toThrow();
+    await expect(readFile(path.join(repoDir, "node_modules/.modules.yaml"), "utf8")).rejects.toThrow();
+  });
+
   it("builds and packs workspace packages once per sweep, then reuses tarballs across repos", async () => {
     const workspaceRoot = await createWorkspace();
     const corpusRoot = await makeTempRoot();

--- a/corpus/harness/src/layers/e2e.test.ts
+++ b/corpus/harness/src/layers/e2e.test.ts
@@ -275,6 +275,14 @@ describe("runE2eLayer", () => {
             },
           });
         }
+        if (role === "textbox") {
+          return new FakeLocator(1, "", {
+            fill: () => {},
+            press: () => {
+              promptSent = true;
+            },
+          });
+        }
         return new FakeLocator(0);
       },
       getByLabel() {
@@ -353,6 +361,14 @@ describe("runE2eLayer", () => {
             },
           });
         }
+        if (role === "textbox") {
+          return new FakeLocator(1, "", {
+            fill: () => {},
+            press: () => {
+              promptSent = true;
+            },
+          });
+        }
         return new FakeLocator(0);
       },
       getByLabel() {
@@ -420,6 +436,14 @@ describe("runE2eLayer", () => {
       },
       getByRole(role: string) {
         if (role === "dialog") return new FakeLocator(1);
+        if (role === "textbox") {
+          return new FakeLocator(1, "", {
+            fill: () => {},
+            press: () => {
+              promptSent = true;
+            },
+          });
+        }
         return new FakeLocator(0);
       },
       getByLabel() {

--- a/corpus/harness/src/layers/e2e.ts
+++ b/corpus/harness/src/layers/e2e.ts
@@ -703,7 +703,10 @@ async function openVendoSurface(page: E2ePage, timeoutMs: number): Promise<void>
 }
 
 async function sendPrompt(page: E2ePage, prompt: string): Promise<void> {
-  const input = page.getByLabel(/message/i);
+  // The overlay's composer form and its textarea both carry /message/i labels
+  // (aria-label "Message composer" / "Message"), so a bare getByLabel violates
+  // Playwright strict mode — target the textbox role.
+  const input = page.getByRole("textbox", { name: /message/i });
   if (!input.fill) throw new Error("Vendo composer message field did not expose fill()");
   await input.fill(prompt);
   if (input.press) {

--- a/corpus/harness/src/layers/structural.test.ts
+++ b/corpus/harness/src/layers/structural.test.ts
@@ -150,6 +150,26 @@ async function makeTempRepo(): Promise<string> {
   return repoDir;
 }
 
+async function makeExpressRepo(): Promise<string> {
+  const repoDir = await makeTempRepo();
+  await rm(path.join(repoDir, "app"), { recursive: true, force: true });
+  await mkdir(path.join(repoDir, "src/server"), { recursive: true });
+  await mkdir(path.join(repoDir, "src/client"), { recursive: true });
+  await writeFile(
+    path.join(repoDir, "src/server/vendo.ts"),
+    'import { createVendo } from "@vendoai/vendo/server";\nexport const vendo = createVendo({} as never);\n',
+  );
+  await writeFile(
+    path.join(repoDir, "src/server/index.ts"),
+    'import { vendo } from "./vendo.js";\napp.use("/api/vendo", (_req, _res) => vendo.handler);\n',
+  );
+  await writeFile(
+    path.join(repoDir, "src/client/main.tsx"),
+    'import { VendoRoot } from "@vendoai/vendo/react";\nroot.render(<VendoRoot><App /></VendoRoot>);\n',
+  );
+  return repoDir;
+}
+
 function passingContext(repoDir: string, runner: StructuralCommandRunner): StructuralLayerContext {
   return {
     repoDir,
@@ -167,6 +187,26 @@ function byId(results: Awaited<ReturnType<typeof runStructuralLayer>>) {
 }
 
 describe("runStructuralLayer", () => {
+  it("replaces Next wiring checks with the Express handler and client wiring contract", async () => {
+    const repoDir = await makeExpressRepo();
+    const runner: StructuralCommandRunner = async () => ({ code: 0, stdout: "ok", stderr: "" });
+
+    const passing = byId(await runStructuralLayer({
+      ...passingContext(repoDir, runner),
+      framework: "express",
+    }));
+    expect(passing["files.expected"]).toMatchObject({ pass: true });
+    expect(passing["files.expected"]?.detail).toContain("Express handler/provider wiring");
+
+    await writeFile(path.join(repoDir, "src/server/index.ts"), "app.use('/elsewhere', handler);\n");
+    const failing = byId(await runStructuralLayer({
+      ...passingContext(repoDir, runner),
+      framework: "express",
+    }));
+    expect(failing["files.expected"]).toMatchObject({ pass: false });
+    expect(failing["files.expected"]?.detail).toContain("mount vendo.handler at /api/vendo");
+  });
+
   it("passes all Layer 1 structural checks for a generated App Router fixture", async () => {
     const repoDir = await makeTempRepo();
     const calls: string[] = [];

--- a/corpus/harness/src/layers/structural.test.ts
+++ b/corpus/harness/src/layers/structural.test.ts
@@ -161,7 +161,7 @@ async function makeExpressRepo(): Promise<string> {
   );
   await writeFile(
     path.join(repoDir, "src/server/index.ts"),
-    'import { vendo } from "./vendo.js";\napp.use("/api/vendo", (_req, _res) => vendo.handler);\n',
+    'import { serveHandler } from "./adapter.js";\nimport { vendo } from "./vendo.js";\napp.use("/api/vendo", (req, res) => serveHandler(req, res, vendo.handler));\n',
   );
   await writeFile(
     path.join(repoDir, "src/client/main.tsx"),
@@ -197,6 +197,16 @@ describe("runStructuralLayer", () => {
     }));
     expect(passing["files.expected"]).toMatchObject({ pass: true });
     expect(passing["files.expected"]?.detail).toContain("Express handler/provider wiring");
+
+    await writeFile(
+      path.join(repoDir, "src/server/index.ts"),
+      'import { vendo } from "./vendo.js";\napp.use("/api/vendo", (_req, _res) => vendo.handler);\n',
+    );
+    const bareHandler = byId(await runStructuralLayer({
+      ...passingContext(repoDir, runner),
+      framework: "express",
+    }));
+    expect(bareHandler["files.expected"]).toMatchObject({ pass: false });
 
     await writeFile(path.join(repoDir, "src/server/index.ts"), "app.use('/elsewhere', handler);\n");
     const failing = byId(await runStructuralLayer({

--- a/corpus/harness/src/layers/structural.ts
+++ b/corpus/harness/src/layers/structural.ts
@@ -222,6 +222,19 @@ async function checkInitExit(ctx: StructuralLayerContext): Promise<StructuralChe
   };
 }
 
+function hasFunctionalExpressVendoMount(server: string): boolean {
+  const mount = /app\.use\(\s*["']\/api\/vendo["']\s*,\s*/g;
+  for (const match of server.matchAll(mount)) {
+    const mounted = server.slice((match.index ?? 0) + match[0].length, (match.index ?? 0) + match[0].length + 1_200);
+    if (/^mountVendo\s*\(\s*\)/.test(mounted)) return true;
+    if (/^vendo\.handler\s*\(/.test(mounted)) return true;
+    if (/^(?:async\s*)?\([^)]*\)\s*=>[\s\S]{0,800}?\b(?:serve|adapt|handle)[\w$]*\s*\([^;]{0,800}?vendo\.handler\b/m.test(mounted)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 async function checkExpectedFiles(ctx: StructuralLayerContext): Promise<StructuralCheckResult> {
   const framework = ctx.framework ?? "next";
   const { files, app } = await defaultExpectedFilesForFramework(ctx.repoDir, framework);
@@ -240,7 +253,7 @@ async function checkExpectedFiles(ctx: StructuralLayerContext): Promise<Structur
       if (!server.includes("@vendoai/vendo/server") || !server.includes("createVendo")) {
         wiringProblems.push("Express server sources do not compose createVendo from @vendoai/vendo/server");
       }
-      if (!/app\.use\(\s*["']\/api\/vendo["']/.test(server) || !server.includes("vendo.handler")) {
+      if (!hasFunctionalExpressVendoMount(server)) {
         wiringProblems.push("Express server does not mount vendo.handler at /api/vendo");
       }
       if (!client.includes("<VendoRoot")) {

--- a/corpus/harness/src/layers/structural.ts
+++ b/corpus/harness/src/layers/structural.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { access, readFile } from "node:fs/promises";
+import { access, readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import {
   vendoThemeSchema,
@@ -57,6 +57,7 @@ export interface StructuralHostBaseline {
 
 export interface StructuralLayerContext {
   repoDir: string;
+  framework?: "next" | "express";
   initExitCode: number | null;
   initDetail?: string;
   secondInitExitCode?: number | null;
@@ -166,7 +167,10 @@ async function readText(repoDir: string, rel: string): Promise<string | null> {
   }
 }
 
-async function defaultExpectedFiles(repoDir: string): Promise<{ files: string[]; app: AppRouterInfo | null }> {
+async function defaultExpectedFilesForFramework(
+  repoDir: string,
+  framework: "next" | "express",
+): Promise<{ files: string[]; app: AppRouterInfo | null }> {
   const app = await findAppRouter(repoDir);
   const files = [
     ".vendo/tools.json",
@@ -177,11 +181,33 @@ async function defaultExpectedFiles(repoDir: string): Promise<{ files: string[];
     ".vendo/data/.gitignore",
   ];
 
-  if (app) {
+  if (framework === "express") {
+    files.push("src/server/vendo.ts", "src/server/index.ts", "src/client/main.tsx");
+  } else if (app) {
     files.push(routeRel(app), app.layoutRel);
   }
 
   return { files, app };
+}
+
+async function sourceTreeText(repoDir: string, rel: string): Promise<string> {
+  const root = path.join(repoDir, rel);
+  const parts: string[] = [];
+  let entries;
+  try {
+    entries = await readdir(root, { withFileTypes: true });
+  } catch {
+    return "";
+  }
+  for (const entry of entries) {
+    const entryRel = path.posix.join(rel, entry.name);
+    if (entry.isDirectory()) {
+      parts.push(await sourceTreeText(repoDir, entryRel));
+    } else if (/\.(?:[cm]?[jt]sx?)$/.test(entry.name)) {
+      parts.push(await readText(repoDir, entryRel) ?? "");
+    }
+  }
+  return parts.join("\n");
 }
 
 async function checkInitExit(ctx: StructuralLayerContext): Promise<StructuralCheckResult> {
@@ -197,7 +223,8 @@ async function checkInitExit(ctx: StructuralLayerContext): Promise<StructuralChe
 }
 
 async function checkExpectedFiles(ctx: StructuralLayerContext): Promise<StructuralCheckResult> {
-  const { files, app } = await defaultExpectedFiles(ctx.repoDir);
+  const framework = ctx.framework ?? "next";
+  const { files, app } = await defaultExpectedFilesForFramework(ctx.repoDir, framework);
   const required = ctx.expectedFiles ?? files;
   const missing: string[] = [];
 
@@ -207,7 +234,19 @@ async function checkExpectedFiles(ctx: StructuralLayerContext): Promise<Structur
 
   const wiringProblems: string[] = [];
   if (!ctx.expectedFiles) {
-    if (!app) {
+    if (framework === "express") {
+      const server = await sourceTreeText(ctx.repoDir, "src/server");
+      const client = await sourceTreeText(ctx.repoDir, "src/client");
+      if (!server.includes("@vendoai/vendo/server") || !server.includes("createVendo")) {
+        wiringProblems.push("Express server sources do not compose createVendo from @vendoai/vendo/server");
+      }
+      if (!/app\.use\(\s*["']\/api\/vendo["']/.test(server) || !server.includes("vendo.handler")) {
+        wiringProblems.push("Express server does not mount vendo.handler at /api/vendo");
+      }
+      if (!client.includes("<VendoRoot")) {
+        wiringProblems.push("Express client sources do not render <VendoRoot");
+      }
+    } else if (!app) {
       wiringProblems.push("no App Router root layout found at app/layout.* or src/app/layout.*");
     } else {
       const layout = await readText(ctx.repoDir, app.layoutRel);
@@ -225,7 +264,7 @@ async function checkExpectedFiles(ctx: StructuralLayerContext): Promise<Structur
     return {
       id: "files.expected",
       pass: true,
-      detail: `found ${required.length} generated files plus v0 Next route/provider wiring`,
+      detail: `found ${required.length} generated files plus v0 ${framework === "express" ? "Express handler/provider" : "Next route/provider"} wiring`,
     };
   }
 

--- a/corpus/harness/src/local-pack.ts
+++ b/corpus/harness/src/local-pack.ts
@@ -257,7 +257,16 @@ export function rewritePackageJsonForLocalVendo(
     if (!byName.has(name)) throw new Error(`local tarball map is missing ${name}`);
   }
 
-  const dependencies = withoutVendoPackages(stringRecord(pkg["dependencies"]));
+  const originalDependencies = stringRecord(pkg["dependencies"]);
+  const dependencies = withoutVendoPackages(originalDependencies);
+  // Standalone local hosts may import publishable Vendo packages directly
+  // (for example @vendoai/ui chrome). Keep those declared at the same direct
+  // dependency level while replacing workspace:/registry specs with tarballs.
+  for (const name of Object.keys(originalDependencies)) {
+    if (name.startsWith("@vendoai/") && byName.has(name)) {
+      dependencies[name] = fileSpec(byName.get(name)!.fileName);
+    }
+  }
   for (const name of LOCAL_DIRECT_DEPENDENCIES) dependencies[name] = fileSpec(byName.get(name)!.fileName);
   // Force the ai peer + init's starter provider onto the v6 train the umbrella
   // requires (a target's own ai major is irrelevant — we inject our umbrella).
@@ -267,7 +276,15 @@ export function rewritePackageJsonForLocalVendo(
   for (const field of ["devDependencies", "peerDependencies", "optionalDependencies"] as const) {
     // Also strip a conflicting ai/@ai-sdk pin from the other sections so one
     // coherent v6 version wins the install.
-    const values = withoutVendoPackages(stringRecord(pkg[field]));
+    const original = stringRecord(pkg[field]);
+    const values = withoutVendoPackages(original);
+    if (field === "devDependencies") {
+      for (const name of Object.keys(original)) {
+        if (name.startsWith("@vendoai/") && byName.has(name)) {
+          values[name] = fileSpec(byName.get(name)!.fileName);
+        }
+      }
+    }
     for (const name of Object.keys(AI_TRAIN_OVERRIDES)) delete values[name];
     if (Object.keys(values).length > 0 || pkg[field] !== undefined) pkg[field] = sortedRecord(values);
   }

--- a/corpus/harness/src/manifest.test.ts
+++ b/corpus/harness/src/manifest.test.ts
@@ -37,7 +37,20 @@ const entry = {
 
 describe("parseManifest", () => {
   it("accepts valid corpus entries", () => {
-    expect(parseManifest([entry])).toEqual([entry]);
+    expect(parseManifest([entry])).toEqual([{ ...entry, framework: "next" }]);
+  });
+
+  it("accepts a local source without git metadata and defaults its framework", () => {
+    const { gitUrl: _gitUrl, pinnedSha: _pinnedSha, ...shared } = entry;
+    expect(parseManifest([{ ...shared, localPath: "corpus/hosts/express-host" }])).toEqual([{
+      ...shared,
+      localPath: "corpus/hosts/express-host",
+      framework: "next",
+    }]);
+  });
+
+  it("accepts an explicit Express framework", () => {
+    expect(parseManifest([{ ...entry, framework: "express" }])[0]?.framework).toBe("express");
   });
 
   it("accepts optional relative app directories", () => {
@@ -49,9 +62,18 @@ describe("parseManifest", () => {
     expect(() => parseManifest([{ ...entry, appDir: "/apps/web" }])).toThrow(/appDir/i);
   });
 
-  it("rejects entries missing a pinned SHA", () => {
+  it("rejects local paths that can escape the workspace", () => {
+    const { gitUrl: _gitUrl, pinnedSha: _pinnedSha, ...shared } = entry;
+    expect(() => parseManifest([{ ...shared, localPath: "../express-host" }])).toThrow(/localPath/i);
+    expect(() => parseManifest([{ ...shared, localPath: "/corpus/hosts/express-host" }])).toThrow(/localPath/i);
+  });
+
+  it("requires exactly one complete git or local source", () => {
+    expect(() => parseManifest([{ ...entry, localPath: "corpus/hosts/express-host" }])).toThrow(/localPath.*gitUrl|gitUrl.*localPath/i);
     const { pinnedSha: _pinnedSha, ...missingSha } = entry;
     expect(() => parseManifest([missingSha])).toThrow(/pinnedSha/i);
+    const { gitUrl: _gitUrl, ...missingUrl } = entry;
+    expect(() => parseManifest([missingUrl])).toThrow(/gitUrl/i);
   });
 
   it("rejects unknown tiers", () => {
@@ -85,6 +107,11 @@ describe("parseManifest", () => {
     // tier grows over time, so assert membership rather than an exact list.
     expect(names).toEqual(expect.arrayContaining(["umami", "skateshop", "papermark"]));
     expect(new Set(names).size).toBe(names.length);
+    expect(manifest.find((repo) => repo.name === "express-host")).toMatchObject({
+      localPath: "corpus/hosts/express-host",
+      framework: "express",
+      tier: "deep",
+    });
     for (const repo of manifest.filter((entry) => ["umami", "skateshop", "papermark"].includes(entry.name))) {
       expect(repo.bootstrap.database?.kind).toBe("docker-postgres");
       expect(repo.bootstrap.devServer?.readinessTimeoutMs).toBeGreaterThan(0);

--- a/corpus/harness/src/manifest.ts
+++ b/corpus/harness/src/manifest.ts
@@ -6,6 +6,17 @@ const gitShaPattern = /^[0-9a-f]{40}$/;
 const repoNamePattern = /^[a-z0-9][a-z0-9-]*$/;
 const appDirSegmentPattern = /^[A-Za-z0-9._-]+$/;
 
+function relativePosixPathSchema(field: "appDir" | "localPath") {
+  return z
+    .string()
+    .min(1)
+    .refine((value) => !value.startsWith("/") && !value.includes("\\"), `${field} must be a relative POSIX path`)
+    .refine(
+      (value) => value.split("/").every((segment) => segment !== "" && segment !== "." && segment !== ".." && appDirSegmentPattern.test(segment)),
+      `${field} must contain only relative path segments`,
+    );
+}
+
 const devServerSchema = z
   .object({
     command: z.string().min(1),
@@ -46,17 +57,11 @@ const bootstrapRecipeSchema = z
 export const manifestEntrySchema = z
   .object({
     name: z.string().regex(repoNamePattern),
-    gitUrl: z.string().url(),
-    pinnedSha: z.string().regex(gitShaPattern, "pinnedSha must be a 40-character Git SHA"),
-    appDir: z
-      .string()
-      .min(1)
-      .refine((value) => !value.startsWith("/") && !value.includes("\\"), "appDir must be a relative POSIX path")
-      .refine(
-        (value) => value.split("/").every((segment) => segment !== "" && segment !== "." && segment !== ".." && appDirSegmentPattern.test(segment)),
-        "appDir must contain only relative path segments",
-      )
-      .optional(),
+    gitUrl: z.string().url().optional(),
+    pinnedSha: z.string().regex(gitShaPattern, "pinnedSha must be a 40-character Git SHA").optional(),
+    localPath: relativePosixPathSchema("localPath").optional(),
+    appDir: relativePosixPathSchema("appDir").optional(),
+    framework: z.enum(["next", "express"]).default("next"),
     license: z.string().min(1),
     tier: z.enum(["broad", "deep"]),
     bootstrap: bootstrapRecipeSchema,
@@ -64,6 +69,37 @@ export const manifestEntrySchema = z
   })
   .strict()
   .superRefine((entry, ctx) => {
+    if (entry.localPath !== undefined) {
+      if (entry.gitUrl !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["gitUrl"],
+          message: "localPath entries must not define gitUrl",
+        });
+      }
+      if (entry.pinnedSha !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["pinnedSha"],
+          message: "localPath entries must not define pinnedSha",
+        });
+      }
+    } else {
+      if (entry.gitUrl === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["gitUrl"],
+          message: "gitUrl is required when localPath is not defined",
+        });
+      }
+      if (entry.pinnedSha === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["pinnedSha"],
+          message: "pinnedSha is required when localPath is not defined",
+        });
+      }
+    }
     if (entry.tier === "deep" && !entry.bootstrap.devServer) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -93,8 +129,8 @@ export const corpusManifestSchema = z
     }
   });
 
-export type ManifestEntry = z.infer<typeof manifestEntrySchema>;
-export type CorpusManifest = z.infer<typeof corpusManifestSchema>;
+export type ManifestEntry = z.input<typeof manifestEntrySchema>;
+export type CorpusManifest = ManifestEntry[];
 export type DatabaseProvisioning = z.infer<typeof databaseProvisioningSchema>;
 
 export const defaultManifestPath = fileURLToPath(new URL("../../manifest.json", import.meta.url));

--- a/corpus/hosts/express-host/.gitignore
+++ b/corpus/hosts/express-host/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.turbo/

--- a/corpus/hosts/express-host/.vendo/brief.md
+++ b/corpus/hosts/express-host/.vendo/brief.md
@@ -1,0 +1,7 @@
+# Relay
+
+Relay is a tiny team task tracker for a product team. Vendo should help the
+team understand its current workload, use the host task API instead of
+inventing task state, name assignees when useful, and prefer a compact
+generated view when a grouped list or status summary communicates the answer
+better than prose.

--- a/corpus/hosts/express-host/.vendo/data/.gitignore
+++ b/corpus/hosts/express-host/.vendo/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/corpus/hosts/express-host/.vendo/overrides.json
+++ b/corpus/hosts/express-host/.vendo/overrides.json
@@ -1,0 +1,4 @@
+{
+  "format": "vendo/overrides@1",
+  "tools": {}
+}

--- a/corpus/hosts/express-host/.vendo/policy.json
+++ b/corpus/hosts/express-host/.vendo/policy.json
@@ -1,0 +1,11 @@
+{
+  "format": "vendo/policy@1",
+  "directions": [
+    "Be concise, ground answers in Relay's task API, and never invent tasks or completion state."
+  ],
+  "rules": [
+    { "match": { "risk": "destructive" }, "action": "ask" },
+    { "match": { "risk": "write" }, "action": "ask" },
+    { "match": { "risk": "read" }, "action": "run" }
+  ]
+}

--- a/corpus/hosts/express-host/.vendo/theme.json
+++ b/corpus/hosts/express-host/.vendo/theme.json
@@ -1,0 +1,23 @@
+{
+  "colors": {
+    "background": "#eef7f4",
+    "surface": "#ffffff",
+    "text": "#102f2a",
+    "muted": "#5a7771",
+    "accent": "#087f6f",
+    "accentText": "#ffffff",
+    "danger": "#dc2626",
+    "border": "#e2e8f0"
+  },
+  "typography": {
+    "fontFamily": "Inter, ui-sans-serif, system-ui, sans-serif",
+    "baseSize": "16px"
+  },
+  "radius": {
+    "small": "8px",
+    "medium": "16px",
+    "large": "24px"
+  },
+  "density": "comfortable",
+  "motion": "full"
+}

--- a/corpus/hosts/express-host/.vendo/tools.json
+++ b/corpus/hosts/express-host/.vendo/tools.json
@@ -1,0 +1,150 @@
+{
+  "format": "vendo/tools@1",
+  "tools": [
+    {
+      "name": "host_completeTask",
+      "description": "Mark a Relay task complete",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Relay task id"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "risk": "write",
+      "binding": {
+        "kind": "openapi",
+        "operationId": "completeTask",
+        "method": "POST",
+        "path": "/api/tasks/{id}/complete"
+      }
+    },
+    {
+      "name": "host_createTask",
+      "description": "Create a Relay task",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "body": {
+            "type": "object",
+            "required": [
+              "title"
+            ],
+            "properties": {
+              "title": {
+                "type": "string",
+                "description": "Short task title"
+              },
+              "description": {
+                "type": "string",
+                "description": "Task details"
+              },
+              "assignee": {
+                "type": "string",
+                "description": "Assignee name"
+              },
+              "priority": {
+                "type": "string",
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              "dueDate": {
+                "type": "string",
+                "format": "date"
+              }
+            }
+          }
+        },
+        "required": [
+          "body"
+        ]
+      },
+      "risk": "write",
+      "binding": {
+        "kind": "openapi",
+        "operationId": "createTask",
+        "method": "POST",
+        "path": "/api/tasks"
+      }
+    },
+    {
+      "name": "host_deleteTask",
+      "description": "Permanently delete a Relay task",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Relay task id"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "risk": "destructive",
+      "binding": {
+        "kind": "openapi",
+        "operationId": "deleteTask",
+        "method": "DELETE",
+        "path": "/api/tasks/{id}"
+      }
+    },
+    {
+      "name": "host_getTask",
+      "description": "Get one Relay task",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Relay task id"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "risk": "read",
+      "binding": {
+        "kind": "openapi",
+        "operationId": "getTask",
+        "method": "GET",
+        "path": "/api/tasks/{id}"
+      }
+    },
+    {
+      "name": "host_listTasks",
+      "description": "List Relay tasks, optionally filtered by status",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "open",
+              "in-progress",
+              "done"
+            ],
+            "description": "Only return tasks in this status"
+          }
+        }
+      },
+      "risk": "read",
+      "binding": {
+        "kind": "openapi",
+        "operationId": "listTasks",
+        "method": "GET",
+        "path": "/api/tasks"
+      }
+    }
+  ]
+}

--- a/corpus/hosts/express-host/README.md
+++ b/corpus/hosts/express-host/README.md
@@ -1,0 +1,39 @@
+# Relay Express host
+
+Relay is the permanent non-Next corpus host for Vendo. It proves that the
+`@vendoai/vendo` server is a framework-agnostic fetch handler by mounting it on
+Express, while a plain Vite React SPA consumes the same wire through
+`<VendoRoot>` and the stock `VendoOverlay` chrome.
+
+The host includes a deterministically seeded in-memory task API, committed
+OpenAPI-derived tools, a deep-teal extracted theme, and real-HTTP e2e coverage
+for status, chat/tool execution, destructive approval, generated views, and
+`vendo doctor`.
+
+## Run it
+
+From this package directory:
+
+```sh
+export ANTHROPIC_API_KEY=your-key
+pnpm build
+pnpm start
+```
+
+Relay listens on `http://localhost:3210` by default. Set `PORT` to override it.
+`pnpm dev` runs the TypeScript server directly but deliberately serves the
+already-built Vite output, so run `pnpm build` once first.
+
+The tests do not use an LLM key or external network:
+
+```sh
+pnpm test
+```
+
+## Adapter boundary
+
+[`src/server/fetch-adapter.ts`](src/server/fetch-adapter.ts) is intentionally
+host-owned integration code. It turns Node's `IncomingMessage` into a WHATWG
+`Request`, calls Vendo's portable handler, and pipes the WHATWG `Response` body
+back to Node with backpressure. The response is streamed rather than buffered,
+which keeps `POST /api/vendo/threads` SSE incremental.

--- a/corpus/hosts/express-host/e2e/approval.e2e.test.ts
+++ b/corpus/hosts/express-host/e2e/approval.e2e.test.ts
@@ -1,0 +1,50 @@
+import type { UIMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { jsonPost, partsOfType, readSse, respondToApproval, scriptedModel, startTestHost, textTurn, toolCallTurn, userMessage } from "./harness.js";
+
+describe("Relay destructive approval round-trip", () => {
+  it("asks, decides over the wire, resumes, and deletes exactly once", async () => {
+    const threadId = "thr_relay_delete";
+    const host = await startTestHost(scriptedModel([
+      toolCallTurn("host_deleteTask", { id: "task-102" }, "call_delete"),
+      textTurn("The task was deleted."),
+    ]));
+    try {
+      const paused = await readSse(await fetch(`${host.baseUrl}/api/vendo/threads`, jsonPost({
+        threadId,
+        message: userMessage("msg_delete", "Delete the mobile empty states task"),
+      })));
+      const approvalPart = partsOfType(paused, "data-vendo-approval")[0];
+      expect(approvalPart).toMatchObject({ data: { toolCallId: "call_delete", risk: "destructive" } });
+      expect(host.tasks.deleteCalls).toBe(0);
+
+      const approvalId = (approvalPart?.data as { approvalId?: unknown }).approvalId;
+      expect(approvalId).toEqual(expect.stringMatching(/^apr_/));
+      const decision = await fetch(`${host.baseUrl}/api/vendo/approvals/decide`, jsonPost({
+        ids: [approvalId],
+        decision: { approve: true },
+      }));
+      expect(decision.status).toBe(200);
+
+      const threadResponse = await fetch(`${host.baseUrl}/api/vendo/threads/${threadId}`);
+      expect(threadResponse.status).toBe(200);
+      const thread = await threadResponse.json() as { messages: UIMessage[] };
+      const assistant = [...thread.messages].reverse().find((message) => message.role === "assistant");
+      expect(assistant).toBeDefined();
+
+      const resumed = await readSse(await fetch(`${host.baseUrl}/api/vendo/threads`, jsonPost({
+        threadId,
+        message: respondToApproval(assistant!, "call_delete", true),
+      })));
+      expect(partsOfType(resumed, "tool-output-available")[0]).toMatchObject({
+        toolCallId: "call_delete",
+        output: { status: "ok", output: { deleted: true, id: "task-102" } },
+      });
+      expect(host.tasks.deleteCalls).toBe(1);
+      const missing = await fetch(`${host.baseUrl}/api/tasks/task-102`);
+      expect(missing.status).toBe(404);
+    } finally {
+      await host.close();
+    }
+  });
+});

--- a/corpus/hosts/express-host/e2e/chat-tool.e2e.test.ts
+++ b/corpus/hosts/express-host/e2e/chat-tool.e2e.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { jsonPost, partsOfType, readSse, scriptedModel, startTestHost, textTurn, toolCallTurn, userMessage } from "./harness.js";
+
+describe("Relay chat to host tool", () => {
+  it("calls the Express task API through the learned loopback origin", async () => {
+    const host = await startTestHost(scriptedModel([
+      toolCallTurn("host_listTasks", {}, "call_list"),
+      textTurn("Here are the current Relay tasks."),
+    ]));
+    try {
+      const stream = await readSse(await fetch(`${host.baseUrl}/api/vendo/threads`, jsonPost({
+        threadId: "thr_relay_list",
+        message: userMessage("msg_list", "Show me our tasks"),
+      })));
+      const output = partsOfType(stream, "tool-output-available")[0];
+      expect(output).toMatchObject({
+        toolCallId: "call_list",
+        output: {
+          status: "ok",
+          output: expect.arrayContaining([
+            expect.objectContaining({ id: "task-101", title: "Polish onboarding checklist", assignee: expect.objectContaining({ name: "Ada Chen" }) }),
+          ]),
+        },
+      });
+      expect(partsOfType(stream, "text-delta")).toContainEqual(expect.objectContaining({ delta: "Here are the current Relay tasks." }));
+    } finally {
+      await host.close();
+    }
+  });
+});

--- a/corpus/hosts/express-host/e2e/doctor.e2e.test.ts
+++ b/corpus/hosts/express-host/e2e/doctor.e2e.test.ts
@@ -1,0 +1,37 @@
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { scriptedModel, startTestHost, textTurn } from "./harness.js";
+
+const hostDir = fileURLToPath(new URL("..", import.meta.url));
+const repoRoot = fileURLToPath(new URL("../../../..", import.meta.url));
+const cli = fileURLToPath(new URL("../../../../packages/vendo/bin/vendo.mjs", import.meta.url));
+
+function runDoctor(url: string): Promise<{ code: number | null; output: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [cli, "doctor", hostDir, "--url", `${url}/api/vendo`], {
+      cwd: repoRoot,
+      env: { ...process.env, VENDO_TELEMETRY_DISABLED: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    child.stdout.setEncoding("utf8").on("data", (chunk: string) => { output += chunk; });
+    child.stderr.setEncoding("utf8").on("data", (chunk: string) => { output += chunk; });
+    child.once("error", reject);
+    child.once("close", (code) => resolve({ code, output }));
+  });
+}
+
+describe("vendo doctor on the Express host", () => {
+  // Express discovery lands in a parallel lane; this pins its expected behavior.
+  it("recognizes the committed wiring and completes a live status probe", async () => {
+    const host = await startTestHost(scriptedModel([textTurn("unused")]));
+    try {
+      const result = await runDoctor(host.baseUrl);
+      expect(result.code, result.output).toBe(0);
+      expect(result.output).toContain("/status live round-trip");
+    } finally {
+      await host.close();
+    }
+  });
+});

--- a/corpus/hosts/express-host/e2e/fetch-adapter.e2e.test.ts
+++ b/corpus/hosts/express-host/e2e/fetch-adapter.e2e.test.ts
@@ -1,0 +1,33 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, it } from "vitest";
+import { serveFetchHandler } from "../src/server/fetch-adapter.js";
+
+describe("Relay fetch adapter", () => {
+  it("preserves every Set-Cookie value as a response-header array", async () => {
+    const headers = new Headers();
+    headers.append("set-cookie", "session=rotated; Path=/; HttpOnly");
+    headers.append("set-cookie", "csrf=token; Path=/; SameSite=Strict");
+    const written = new Map<string, string | number | readonly string[]>();
+    const req = {
+      method: "GET",
+      originalUrl: "/api/vendo/status",
+      rawHeaders: ["host", "127.0.0.1"],
+      socket: {},
+    } as IncomingMessage & { originalUrl?: string };
+    const res = {
+      statusCode: 0,
+      setHeader(name: string, value: string | number | readonly string[]) {
+        written.set(name.toLowerCase(), value);
+        return this;
+      },
+      end() {},
+    } as unknown as ServerResponse;
+
+    await serveFetchHandler(req, res, async () => new Response(null, { headers }));
+
+    expect(written.get("set-cookie")).toEqual([
+      "session=rotated; Path=/; HttpOnly",
+      "csrf=token; Path=/; SameSite=Strict",
+    ]);
+  });
+});

--- a/corpus/hosts/express-host/e2e/generated-view.e2e.test.ts
+++ b/corpus/hosts/express-host/e2e/generated-view.e2e.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { jsonPost, scriptedModel, startTestHost, textTurn } from "./harness.js";
+
+const generatedApp = JSON.stringify({
+  name: "Relay priority board",
+  description: "Open Relay work grouped by urgency.",
+  tree: {
+    formatVersion: "vendo-genui/v1",
+    root: "root",
+    nodes: [
+      { id: "root", component: "Stack", source: "prewired", children: ["title", "tasks"] },
+      { id: "title", component: "Text", source: "prewired", props: { text: "Priority board" } },
+      { id: "tasks", component: "Text", source: "prewired", props: { text: "High-priority Relay tasks" } },
+    ],
+  },
+});
+
+describe("Relay generated view", () => {
+  it("creates and opens a pinned vendo-genui/v1 tree over the Express wire", async () => {
+    const host = await startTestHost(scriptedModel([textTurn(generatedApp)]));
+    try {
+      const createdResponse = await fetch(`${host.baseUrl}/api/vendo/apps`, jsonPost({ prompt: "Build a Relay priority board" }));
+      expect(createdResponse.status).toBe(200);
+      const created = await createdResponse.json() as { format: string; id: string; tree: { formatVersion: string } };
+      expect(created).toMatchObject({
+        format: "vendo/app@1",
+        id: expect.stringMatching(/^app_/),
+        tree: { formatVersion: "vendo-genui/v1" },
+      });
+
+      const openedResponse = await fetch(`${host.baseUrl}/api/vendo/apps/${created.id}/open`);
+      expect(openedResponse.status).toBe(200);
+      expect(await openedResponse.json()).toMatchObject({
+        kind: "tree",
+        payload: { formatVersion: "vendo-genui/v1", root: "root" },
+      });
+    } finally {
+      await host.close();
+    }
+  });
+});

--- a/corpus/hosts/express-host/e2e/harness.ts
+++ b/corpus/hosts/express-host/e2e/harness.ts
@@ -77,10 +77,30 @@ export async function startTestHost(model: LanguageModel): Promise<TestHost> {
   const dataDir = await mkdtemp(join(tmpdir(), "relay-express-e2e-"));
   const store = createStore({ dataDir });
   const relay = createRelayServer({ model, store });
-  const server = await new Promise<Server>((resolve, reject) => {
-    const listening = relay.app.listen(0, "127.0.0.1", () => resolve(listening));
-    listening.once("error", reject);
-  });
+  let server: Server;
+  try {
+    // Let the eager composition migration settle before a bind failure enters
+    // cleanup; closing PGlite while it is still opening can mask the listen error.
+    await store.ensureSchema();
+    server = await new Promise<Server>((resolve, reject) => {
+      const listening = relay.app.listen(0, "127.0.0.1", (error?: Error) => {
+        if (error !== undefined) {
+          reject(error);
+          return;
+        }
+        if (listening.address() === null) {
+          reject(new Error("Relay test host reported listening without an address"));
+          return;
+        }
+        resolve(listening);
+      });
+      listening.once("error", reject);
+    });
+  } catch (error) {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+    throw error;
+  }
   const address = server.address() as AddressInfo;
   return {
     baseUrl: `http://127.0.0.1:${address.port}`,

--- a/corpus/hosts/express-host/e2e/harness.ts
+++ b/corpus/hosts/express-host/e2e/harness.ts
@@ -1,0 +1,145 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import type { LanguageModel, UIMessage } from "ai";
+import { createRelayServer } from "../src/server/index.js";
+
+type ModelPrompt = Parameters<MockLanguageModelV3["doStream"]>[0]["prompt"];
+export type StreamPart = Awaited<ReturnType<MockLanguageModelV3["doStream"]>>["stream"] extends ReadableStream<infer Part> ? Part : never;
+type GenerateResult = Awaited<ReturnType<MockLanguageModelV3["doGenerate"]>>;
+type GenerateContent = GenerateResult["content"][number];
+
+export const ZERO_USAGE = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+} as const;
+
+export function textTurn(text: string, id = "text_1"): StreamPart[] {
+  return [
+    { type: "text-start", id },
+    { type: "text-delta", id, delta: text },
+    { type: "text-end", id },
+    { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
+  ];
+}
+
+export function toolCallTurn(toolName: string, input: unknown, toolCallId = "call_1"): StreamPart[] {
+  return [
+    { type: "tool-call", toolCallId, toolName, input: JSON.stringify(input) },
+    { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "tool-calls", raw: undefined } },
+  ];
+}
+
+export function scriptedModel(turns: StreamPart[][]): LanguageModel {
+  const remaining = turns.map((turn) => [...turn]);
+  const shift = (_prompt: ModelPrompt): StreamPart[] => {
+    const chunks = remaining.shift();
+    if (chunks === undefined) throw new Error("scripted model exhausted");
+    return chunks;
+  };
+  return new MockLanguageModelV3({
+    doStream: async (request) => ({ stream: simulateReadableStream({ chunks: shift(request.prompt) }) }),
+    doGenerate: async (request): Promise<GenerateResult> => {
+      const chunks = shift(request.prompt);
+      const finish = chunks.find((part) => part.type === "finish");
+      const content: GenerateContent[] = [];
+      const generatedText = chunks
+        .filter((part): part is Extract<StreamPart, { type: "text-delta" }> => part.type === "text-delta")
+        .map((part) => part.delta)
+        .join("");
+      if (generatedText.length > 0) content.push({ type: "text", text: generatedText });
+      for (const part of chunks) {
+        if (part.type === "tool-call") content.push(structuredClone(part));
+      }
+      return {
+        content,
+        finishReason: finish?.finishReason ?? { unified: "stop", raw: undefined },
+        usage: finish?.usage ?? ZERO_USAGE,
+        warnings: [],
+      };
+    },
+  });
+}
+
+export interface TestHost {
+  baseUrl: string;
+  server: Server;
+  store: VendoStore;
+  tasks: ReturnType<typeof createRelayServer>["tasks"];
+  close(): Promise<void>;
+}
+
+export async function startTestHost(model: LanguageModel): Promise<TestHost> {
+  const dataDir = await mkdtemp(join(tmpdir(), "relay-express-e2e-"));
+  const store = createStore({ dataDir });
+  const relay = createRelayServer({ model, store });
+  const server = await new Promise<Server>((resolve, reject) => {
+    const listening = relay.app.listen(0, "127.0.0.1", () => resolve(listening));
+    listening.once("error", reject);
+  });
+  const address = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    server,
+    store,
+    tasks: relay.tasks,
+    async close() {
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+      await store.close();
+      await rm(dataDir, { recursive: true, force: true });
+    },
+  };
+}
+
+export interface SseRead {
+  parts: Array<Record<string, unknown>>;
+}
+
+export async function readSse(response: Response): Promise<SseRead> {
+  if (!response.ok) throw new Error(`SSE request failed: ${response.status} ${await response.text()}`);
+  const raw = await response.text();
+  if (!raw.endsWith("\n\n")) throw new Error("SSE response did not end with a blank line");
+  return {
+    parts: raw.slice(0, -2).split("\n\n")
+      .filter((block) => block.startsWith("data: ") && block !== "data: [DONE]")
+      .map((block) => JSON.parse(block.slice("data: ".length)) as Record<string, unknown>),
+  };
+}
+
+export function partsOfType(read: SseRead, type: string): Array<Record<string, unknown>> {
+  return read.parts.filter((part) => part.type === type);
+}
+
+export function userMessage(id: string, text: string): UIMessage {
+  return { id, role: "user", parts: [{ type: "text", text }] };
+}
+
+export function respondToApproval(message: UIMessage, toolCallId: string, approved: boolean): UIMessage {
+  let updated = false;
+  const parts = message.parts.map((part) => {
+    const candidate = part as unknown as Record<string, unknown>;
+    if (candidate.type !== "dynamic-tool" || candidate.toolCallId !== toolCallId) return part;
+    const approval = candidate.approval as { id?: unknown } | undefined;
+    if (typeof approval?.id !== "string") throw new Error("tool part carried no native approval id");
+    updated = true;
+    return {
+      ...candidate,
+      state: "approval-responded",
+      approval: { id: approval.id, approved },
+    } as unknown as UIMessage["parts"][number];
+  });
+  if (!updated) throw new Error(`assistant message carried no dynamic tool part for ${toolCallId}`);
+  return { ...message, parts };
+}
+
+export function jsonPost(body: unknown): RequestInit {
+  return {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  };
+}

--- a/corpus/hosts/express-host/e2e/status.e2e.test.ts
+++ b/corpus/hosts/express-host/e2e/status.e2e.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { scriptedModel, startTestHost, textTurn } from "./harness.js";
+
+describe("Relay Vendo status over Express", () => {
+  it("returns the composed posture, version, and blocks over real HTTP", async () => {
+    const host = await startTestHost(scriptedModel([textTurn("unused")]));
+    try {
+      const response = await fetch(`${host.baseUrl}/api/vendo/status`);
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        posture: "rules",
+        version: expect.any(String),
+        blocks: {
+          store: true,
+          agent: true,
+          actions: true,
+          guard: true,
+          apps: true,
+          automations: true,
+        },
+      });
+    } finally {
+      await host.close();
+    }
+  });
+});

--- a/corpus/hosts/express-host/index.html
+++ b/corpus/hosts/express-host/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#087f6f" />
+    <title>Relay — Team tasks</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/client/main.tsx"></script>
+  </body>
+</html>

--- a/corpus/hosts/express-host/openapi.json
+++ b/corpus/hosts/express-host/openapi.json
@@ -1,0 +1,167 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Relay task API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/api/tasks": {
+      "get": {
+        "operationId": "listTasks",
+        "summary": "List Relay tasks, optionally filtered by status",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Only return tasks in this status",
+            "schema": {
+              "type": "string",
+              "enum": ["open", "in-progress", "done"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Relay tasks",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Task" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createTask",
+        "summary": "Create a Relay task",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateTask" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created task",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Task" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tasks/{id}": {
+      "get": {
+        "operationId": "getTask",
+        "summary": "Get one Relay task",
+        "parameters": [
+          { "$ref": "#/components/parameters/TaskId" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Task",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Task" }
+              }
+            }
+          },
+          "404": { "description": "Task not found" }
+        }
+      },
+      "delete": {
+        "operationId": "deleteTask",
+        "summary": "Permanently delete a Relay task",
+        "parameters": [
+          { "$ref": "#/components/parameters/TaskId" }
+        ],
+        "responses": {
+          "200": { "description": "Task deleted" },
+          "404": { "description": "Task not found" }
+        }
+      }
+    },
+    "/api/tasks/{id}/complete": {
+      "post": {
+        "operationId": "completeTask",
+        "summary": "Mark a Relay task complete",
+        "parameters": [
+          { "$ref": "#/components/parameters/TaskId" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Completed task",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Task" }
+              }
+            }
+          },
+          "404": { "description": "Task not found" }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "TaskId": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Relay task id",
+        "schema": { "type": "string" }
+      }
+    },
+    "schemas": {
+      "TeamMember": {
+        "type": "object",
+        "required": ["id", "name", "initials"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "initials": { "type": "string" }
+        }
+      },
+      "Task": {
+        "type": "object",
+        "required": ["id", "title", "description", "status", "priority", "assignee", "team", "dueDate"],
+        "properties": {
+          "id": { "type": "string" },
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "status": { "type": "string", "enum": ["open", "in-progress", "done"] },
+          "priority": { "type": "string", "enum": ["low", "medium", "high"] },
+          "assignee": { "$ref": "#/components/schemas/TeamMember" },
+          "team": {
+            "type": "object",
+            "required": ["id", "name"],
+            "properties": {
+              "id": { "type": "string" },
+              "name": { "type": "string" }
+            }
+          },
+          "dueDate": { "type": "string", "format": "date" }
+        }
+      },
+      "CreateTask": {
+        "type": "object",
+        "required": ["title"],
+        "properties": {
+          "title": { "type": "string", "description": "Short task title" },
+          "description": { "type": "string", "description": "Task details" },
+          "assignee": { "type": "string", "description": "Assignee name" },
+          "priority": { "type": "string", "enum": ["low", "medium", "high"] },
+          "dueDate": { "type": "string", "format": "date" }
+        }
+      }
+    }
+  }
+}

--- a/corpus/hosts/express-host/package.json
+++ b/corpus/hosts/express-host/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@vendoai-corpus/express-host",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "dev": "tsx src/server/index.ts",
+    "build": "tsc -p tsconfig.server.json && vite build",
+    "start": "node dist/server/index.js",
+    "typecheck": "tsc -p tsconfig.server.json --noEmit && tsc -p tsconfig.client.json --noEmit && tsc -p tsconfig.test.json --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.12",
+    "@vendoai/ui": "workspace:*",
+    "@vendoai/vendo": "workspace:*",
+    "ai": "^6.0.28",
+    "express": "^5.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.0",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
+    "@vendoai/store": "workspace:*",
+    "@vitejs/plugin-react": "^4.3.4",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0",
+    "vite": "^6.0.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/corpus/hosts/express-host/src/client/App.tsx
+++ b/corpus/hosts/express-host/src/client/App.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useMemo, useState } from "react";
+
+type TaskStatus = "open" | "in-progress" | "done";
+
+interface RelayTask {
+  id: string;
+  title: string;
+  description: string;
+  status: TaskStatus;
+  priority: "low" | "medium" | "high";
+  assignee: { id: string; name: string; initials: string };
+  team: { id: string; name: string };
+  dueDate: string;
+}
+
+const FILTERS: Array<{ label: string; value: "all" | TaskStatus }> = [
+  { label: "All tasks", value: "all" },
+  { label: "Open", value: "open" },
+  { label: "In progress", value: "in-progress" },
+  { label: "Done", value: "done" },
+];
+
+export function App() {
+  const [tasks, setTasks] = useState<RelayTask[]>([]);
+  const [filter, setFilter] = useState<"all" | TaskStatus>("all");
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch("/api/tasks", { signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(`Tasks request failed (${response.status})`);
+        return response.json() as Promise<RelayTask[]>;
+      })
+      .then(setTasks)
+      .catch((cause: unknown) => {
+        if (!controller.signal.aborted) setError(cause instanceof Error ? cause.message : "Tasks request failed");
+      });
+    return () => controller.abort();
+  }, []);
+
+  useEffect(() => {
+    const openAssistant = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        document.querySelector<HTMLButtonElement>("#relay-vendo-layer .fl-launcher")?.click();
+      }
+    };
+    document.addEventListener("keydown", openAssistant);
+    return () => document.removeEventListener("keydown", openAssistant);
+  }, []);
+
+  const visibleTasks = useMemo(
+    () => tasks.filter((task) => filter === "all" || task.status === filter),
+    [filter, tasks],
+  );
+  const completed = tasks.filter((task) => task.status === "done").length;
+
+  const openVendo = () => {
+    document.querySelector<HTMLButtonElement>("#relay-vendo-layer .fl-launcher")?.click();
+  };
+
+  return (
+    <div className="app-shell">
+      <header className="topbar">
+        <a className="brand" href="/" aria-label="Relay home">
+          <span className="brand-mark" aria-hidden="true">R</span>
+          <span>Relay</span>
+        </a>
+        <button className="ask-relay" type="button" onClick={openVendo}>
+          <span aria-hidden="true">✦</span> Ask Relay
+          <kbd>⌘K</kbd>
+        </button>
+      </header>
+
+      <main>
+        <section className="hero" aria-labelledby="task-heading">
+          <div>
+            <p className="eyebrow">Relay product · This week</p>
+            <h1 id="task-heading">Keep the team moving.</h1>
+            <p className="hero-copy">A small, clear view of what needs attention and who is carrying it forward.</p>
+          </div>
+          <div className="progress-card" aria-label={`${completed} of ${tasks.length} tasks complete`}>
+            <strong>{completed}/{tasks.length || 8}</strong>
+            <span>tasks complete</span>
+            <div className="progress-track"><span style={{ width: `${tasks.length === 0 ? 0 : completed / tasks.length * 100}%` }} /></div>
+          </div>
+        </section>
+
+        <section className="task-panel" aria-label="Team tasks">
+          <div className="panel-toolbar">
+            <div className="filters" aria-label="Filter tasks">
+              {FILTERS.map(({ label, value }) => (
+                <button
+                  className={filter === value ? "active" : undefined}
+                  type="button"
+                  aria-pressed={filter === value}
+                  onClick={() => setFilter(value)}
+                  key={value}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+            <span className="task-count">{visibleTasks.length} shown</span>
+          </div>
+
+          {error ? <p className="error" role="alert">{error}</p> : null}
+          <div className="task-list">
+            {visibleTasks.map((task) => (
+              <article className="task-row" key={task.id}>
+                <span className={`status-dot status-${task.status}`} aria-label={task.status} />
+                <div className="task-copy">
+                  <div className="task-title-line">
+                    <h2>{task.title}</h2>
+                    <span className={`priority priority-${task.priority}`}>{task.priority}</span>
+                  </div>
+                  <p>{task.description}</p>
+                  <div className="task-meta">
+                    <span className="avatar" title={task.assignee.name}>{task.assignee.initials}</span>
+                    <span>{task.assignee.name}</span>
+                    <span aria-hidden="true">·</span>
+                    <time dateTime={task.dueDate}>Due {new Date(`${task.dueDate}T12:00:00`).toLocaleDateString("en-US", { month: "short", day: "numeric" })}</time>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/corpus/hosts/express-host/src/client/brand.css
+++ b/corpus/hosts/express-host/src/client/brand.css
@@ -1,0 +1,83 @@
+:root {
+  --color-background: #eef7f4;
+  --color-surface: #ffffff;
+  --color-text: #102f2a;
+  --color-muted: #5a7771;
+  --color-primary: #087f6f;
+  --color-danger: #dc2626;
+  --color-border: #e2e8f0;
+  --radius-card: 16px;
+  --font-sans: Inter, ui-sans-serif, system-ui, sans-serif;
+  --font-size: 16px;
+  color: var(--color-text);
+  background: var(--color-background);
+  font-family: var(--font-sans);
+  font-size: var(--font-size);
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; min-width: 320px; min-height: 100vh; }
+button, input, textarea { font: inherit; }
+button { color: inherit; }
+
+.app-shell { min-height: 100vh; }
+.topbar {
+  align-items: center;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-primary) 13%, transparent);
+  display: flex;
+  justify-content: space-between;
+  padding: 18px clamp(22px, 5vw, 72px);
+}
+.brand { align-items: center; color: inherit; display: flex; font-size: 19px; font-weight: 760; gap: 10px; letter-spacing: -0.02em; text-decoration: none; }
+.brand-mark { align-items: center; background: var(--color-primary); border-radius: 10px; color: white; display: inline-flex; height: 32px; justify-content: center; width: 32px; }
+.ask-relay { align-items: center; background: var(--color-text); border: 0; border-radius: 12px; color: white; cursor: pointer; display: flex; font-weight: 680; gap: 8px; padding: 10px 12px; }
+.ask-relay:hover { background: var(--color-primary); }
+.ask-relay:focus-visible, .filters button:focus-visible { outline: 3px solid color-mix(in srgb, var(--color-primary) 30%, transparent); outline-offset: 3px; }
+.ask-relay kbd { background: rgb(255 255 255 / 14%); border-radius: 6px; font-size: 11px; padding: 3px 5px; }
+
+main { margin: 0 auto; max-width: 1120px; padding: 76px 24px 96px; }
+.hero { align-items: end; display: grid; gap: 40px; grid-template-columns: minmax(0, 1fr) auto; margin-bottom: 54px; }
+.eyebrow { color: var(--color-primary); font-size: 12px; font-weight: 760; letter-spacing: 0.13em; margin: 0 0 16px; text-transform: uppercase; }
+h1 { font-size: clamp(42px, 7vw, 78px); letter-spacing: -0.065em; line-height: 0.95; margin: 0; max-width: 780px; }
+.hero-copy { color: var(--color-muted); font-size: 18px; line-height: 1.6; margin: 24px 0 0; max-width: 610px; }
+.progress-card { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-card); box-shadow: 0 18px 50px rgb(16 47 42 / 8%); display: grid; min-width: 190px; padding: 22px; }
+.progress-card strong { font-size: 30px; letter-spacing: -0.04em; }
+.progress-card span { color: var(--color-muted); font-size: 13px; }
+.progress-track { background: #dfece8; border-radius: 999px; height: 6px; margin-top: 16px; overflow: hidden; }
+.progress-track span { background: var(--color-primary); display: block; height: 100%; }
+
+.task-panel { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: calc(var(--radius-card) + 4px); box-shadow: 0 24px 70px rgb(16 47 42 / 8%); overflow: hidden; }
+.panel-toolbar { align-items: center; border-bottom: 1px solid var(--color-border); display: flex; justify-content: space-between; padding: 16px 20px; }
+.filters { display: flex; flex-wrap: wrap; gap: 6px; }
+.filters button { background: transparent; border: 0; border-radius: 8px; color: var(--color-muted); cursor: pointer; font-size: 13px; font-weight: 680; padding: 8px 11px; }
+.filters button.active { background: color-mix(in srgb, var(--color-primary) 10%, white); color: var(--color-primary); }
+.task-count { color: var(--color-muted); font-size: 12px; }
+.task-row { display: grid; gap: 16px; grid-template-columns: auto minmax(0, 1fr); padding: 22px 24px; }
+.task-row + .task-row { border-top: 1px solid var(--color-border); }
+.task-row:hover { background: color-mix(in srgb, var(--color-background) 55%, white); }
+.status-dot { border: 2px solid var(--color-muted); border-radius: 50%; height: 14px; margin-top: 5px; width: 14px; }
+.status-in-progress { border-color: var(--color-primary); box-shadow: inset 0 0 0 3px white; background: var(--color-primary); }
+.status-done { background: #8aa39e; border-color: #8aa39e; }
+.task-title-line { align-items: center; display: flex; gap: 10px; }
+.task-copy h2 { font-size: 16px; letter-spacing: -0.015em; margin: 0; }
+.task-copy > p { color: var(--color-muted); line-height: 1.5; margin: 7px 0 13px; }
+.priority { border-radius: 999px; font-size: 10px; font-weight: 760; letter-spacing: 0.06em; padding: 3px 6px; text-transform: uppercase; }
+.priority-high { background: #fff0ee; color: #a53d30; }
+.priority-medium { background: #fff6dd; color: #80620b; }
+.priority-low { background: #edf3f2; color: #607d78; }
+.task-meta { align-items: center; color: var(--color-muted); display: flex; font-size: 12px; gap: 7px; }
+.avatar { align-items: center; background: #dcece8; border-radius: 50%; color: var(--color-primary); display: inline-flex; font-size: 9px; font-weight: 800; height: 22px; justify-content: center; width: 22px; }
+.error { background: #fff0ee; color: var(--color-danger); margin: 0; padding: 14px 24px; }
+
+/* Relay supplies its own visible launcher while retaining the stock overlay. */
+#relay-vendo-layer .fl-launcher { display: none; }
+
+@media (max-width: 720px) {
+  main { padding-top: 52px; }
+  .hero { align-items: stretch; grid-template-columns: 1fr; }
+  .progress-card { min-width: 0; }
+  .ask-relay kbd { display: none; }
+  .panel-toolbar { align-items: flex-start; gap: 10px; }
+}

--- a/corpus/hosts/express-host/src/client/main.tsx
+++ b/corpus/hosts/express-host/src/client/main.tsx
@@ -1,0 +1,40 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { VendoRoot } from "@vendoai/vendo/react";
+import { VendoOverlay } from "@vendoai/ui/chrome";
+import { App } from "./App.js";
+import "./brand.css";
+
+const relayTheme = {
+  colors: {
+    background: "#eef7f4",
+    surface: "#ffffff",
+    text: "#102f2a",
+    muted: "#5a7771",
+    accent: "#087f6f",
+    accentText: "#ffffff",
+    danger: "#dc2626",
+    border: "#e2e8f0",
+  },
+  typography: {
+    fontFamily: "Inter, ui-sans-serif, system-ui, sans-serif",
+    baseSize: "16px",
+  },
+  radius: { small: "8px", medium: "16px", large: "24px" },
+  density: "comfortable" as const,
+  motion: "full" as const,
+};
+
+const root = document.getElementById("root");
+if (root === null) throw new Error("Relay root element is missing");
+
+createRoot(root).render(
+  <StrictMode>
+    <VendoRoot baseUrl="/api/vendo" theme={relayTheme} components={{}}>
+      <App />
+      <div id="relay-vendo-layer" aria-live="polite">
+        <VendoOverlay />
+      </div>
+    </VendoRoot>
+  </StrictMode>,
+);

--- a/corpus/hosts/express-host/src/server/fetch-adapter.ts
+++ b/corpus/hosts/express-host/src/server/fetch-adapter.ts
@@ -1,0 +1,44 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+type ExpressRequest = IncomingMessage & { originalUrl?: string };
+type RequestWithDuplex = RequestInit & { duplex?: "half" };
+
+const BODY_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+/**
+ * Integrator-written adapter: Express/Node owns IncomingMessage and
+ * ServerResponse while Vendo stays on the portable fetch contract.
+ */
+export async function serveFetchHandler(
+  req: ExpressRequest,
+  res: ServerResponse,
+  handler: (request: Request) => Promise<Response>,
+): Promise<void> {
+  const headers = new Headers();
+  for (let index = 0; index < req.rawHeaders.length; index += 2) {
+    headers.append(req.rawHeaders[index]!, req.rawHeaders[index + 1]!);
+  }
+
+  const host = headers.get("host") ?? "127.0.0.1";
+  const protocol = "encrypted" in req.socket && req.socket.encrypted ? "https" : "http";
+  const url = new URL(req.originalUrl ?? req.url ?? "/", `${protocol}://${host}`);
+  const method = req.method ?? "GET";
+  const init: RequestWithDuplex = { method, headers };
+  if (BODY_METHODS.has(method.toUpperCase())) {
+    init.body = Readable.toWeb(req) as ReadableStream<Uint8Array>;
+    init.duplex = "half";
+  }
+
+  const response = await handler(new Request(url, init));
+  res.statusCode = response.status;
+  response.headers.forEach((value, name) => res.setHeader(name, value));
+  if (response.body === null) {
+    res.end();
+    return;
+  }
+
+  // Pipeline preserves streaming backpressure; SSE chunks are never buffered.
+  await pipeline(Readable.fromWeb(response.body as import("node:stream/web").ReadableStream), res);
+}

--- a/corpus/hosts/express-host/src/server/fetch-adapter.ts
+++ b/corpus/hosts/express-host/src/server/fetch-adapter.ts
@@ -33,7 +33,15 @@ export async function serveFetchHandler(
 
   const response = await handler(new Request(url, init));
   res.statusCode = response.status;
-  response.headers.forEach((value, name) => res.setHeader(name, value));
+  response.headers.forEach((value, name) => {
+    if (name.toLowerCase() !== "set-cookie") res.setHeader(name, value);
+  });
+  const getSetCookie = (response.headers as Headers & { getSetCookie?: () => string[] }).getSetCookie;
+  const fallbackCookie = response.headers.get("set-cookie");
+  const cookies = typeof getSetCookie === "function"
+    ? getSetCookie.call(response.headers)
+    : fallbackCookie === null ? [] : [fallbackCookie];
+  if (cookies.length > 0) res.setHeader("set-cookie", cookies);
   if (response.body === null) {
     res.end();
     return;

--- a/corpus/hosts/express-host/src/server/index.ts
+++ b/corpus/hosts/express-host/src/server/index.ts
@@ -119,7 +119,10 @@ function isEntrypoint(): boolean {
 if (isEntrypoint()) {
   const port = Number(process.env.PORT ?? 3210);
   if (!Number.isInteger(port) || port < 1 || port > 65_535) throw new Error(`Invalid PORT: ${process.env.PORT}`);
-  createRelayServer().app.listen(port, () => {
+  process.env.VENDO_BASE_URL ??= `http://127.0.0.1:${port}`;
+  // Loopback only: the principal resolver hands every request the demo
+  // principal, so the fixture must never be reachable from the LAN.
+  createRelayServer().app.listen(port, "127.0.0.1", () => {
     console.log(`Relay listening at http://localhost:${port}`);
   });
 }

--- a/corpus/hosts/express-host/src/server/index.ts
+++ b/corpus/hosts/express-host/src/server/index.ts
@@ -1,0 +1,125 @@
+import express, { type Express, type NextFunction, type Request, type Response } from "express";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import type { LanguageModel } from "ai";
+import type { VendoStore } from "@vendoai/vendo";
+import { serveFetchHandler } from "./fetch-adapter.js";
+import { TaskStore, type TaskPriority, type TaskStatus, type TeamMember } from "./tasks.js";
+import { createRelayVendo } from "./vendo.js";
+
+const PACKAGE_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const CLIENT_DIST = resolve(PACKAGE_ROOT, "dist/client");
+const TASK_STATUSES = new Set<TaskStatus>(["open", "in-progress", "done"]);
+const TASK_PRIORITIES = new Set<TaskPriority>(["low", "medium", "high"]);
+
+export interface RelayServerOptions {
+  model?: LanguageModel;
+  store?: VendoStore;
+  tasks?: TaskStore;
+}
+
+export interface RelayServer {
+  app: Express;
+  tasks: TaskStore;
+  vendo: ReturnType<typeof createRelayVendo>;
+}
+
+function notFound(res: Response, id: string): void {
+  res.status(404).json({ error: { code: "not-found", message: `Task not found: ${id}` } });
+}
+
+function text(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+export function createRelayServer(options: RelayServerOptions = {}): RelayServer {
+  const app = express();
+  const tasks = options.tasks ?? new TaskStore();
+  const vendo = createRelayVendo({
+    ...(options.model === undefined ? {} : { model: options.model }),
+    ...(options.store === undefined ? {} : { store: options.store }),
+  });
+
+  app.disable("x-powered-by");
+  app.use("/api/vendo", (req, res, next) => {
+    void serveFetchHandler(req, res, vendo.handler).catch((error: unknown) => {
+      if (res.headersSent) res.destroy(error instanceof Error ? error : undefined);
+      else next(error);
+    });
+  });
+
+  const api = express.Router();
+  api.use(express.json());
+  api.get("/tasks", (req, res) => {
+    const status = req.query.status;
+    if (status !== undefined && (typeof status !== "string" || !TASK_STATUSES.has(status as TaskStatus))) {
+      res.status(400).json({ error: { code: "validation", message: "status must be open, in-progress, or done" } });
+      return;
+    }
+    res.json(tasks.list(status as TaskStatus | undefined));
+  });
+  api.get("/tasks/:id", (req, res) => {
+    const task = tasks.get(req.params.id);
+    if (task === undefined) notFound(res, req.params.id);
+    else res.json(task);
+  });
+  api.post("/tasks", (req, res) => {
+    const title = text(req.body?.title);
+    if (title === undefined) {
+      res.status(400).json({ error: { code: "validation", message: "title is required" } });
+      return;
+    }
+    const priority = req.body?.priority;
+    if (priority !== undefined && !TASK_PRIORITIES.has(priority as TaskPriority)) {
+      res.status(400).json({ error: { code: "validation", message: "priority must be low, medium, or high" } });
+      return;
+    }
+    const assigneeName = text(req.body?.assignee);
+    const assignee: TeamMember | undefined = assigneeName === undefined ? undefined : {
+      id: `member-${assigneeName.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`,
+      name: assigneeName,
+      initials: assigneeName.split(/\s+/).map((part) => part[0]).join("").slice(0, 2).toUpperCase(),
+    };
+    res.status(201).json(tasks.create({
+      title,
+      ...(text(req.body?.description) === undefined ? {} : { description: text(req.body.description)! }),
+      ...(assignee === undefined ? {} : { assignee }),
+      ...(priority === undefined ? {} : { priority: priority as TaskPriority }),
+      ...(text(req.body?.dueDate) === undefined ? {} : { dueDate: text(req.body.dueDate)! }),
+    }));
+  });
+  api.post("/tasks/:id/complete", (req, res) => {
+    const task = tasks.complete(req.params.id);
+    if (task === undefined) notFound(res, req.params.id);
+    else res.json(task);
+  });
+  api.delete("/tasks/:id", (req, res) => {
+    if (!tasks.delete(req.params.id)) notFound(res, req.params.id);
+    else res.json({ deleted: true, id: req.params.id });
+  });
+  app.use("/api", api);
+  app.use("/api", (_req, res) => res.status(404).json({ error: { code: "not-found", message: "Unknown API route" } }));
+
+  app.use(express.static(CLIENT_DIST));
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    if (req.method !== "GET") {
+      next();
+      return;
+    }
+    res.sendFile(resolve(CLIENT_DIST, "index.html"));
+  });
+
+  return { app, tasks, vendo };
+}
+
+function isEntrypoint(): boolean {
+  return process.argv[1] !== undefined && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+}
+
+if (isEntrypoint()) {
+  const port = Number(process.env.PORT ?? 3210);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) throw new Error(`Invalid PORT: ${process.env.PORT}`);
+  createRelayServer().app.listen(port, () => {
+    console.log(`Relay listening at http://localhost:${port}`);
+  });
+}

--- a/corpus/hosts/express-host/src/server/tasks.ts
+++ b/corpus/hosts/express-host/src/server/tasks.ts
@@ -1,0 +1,91 @@
+export type TaskStatus = "open" | "in-progress" | "done";
+export type TaskPriority = "low" | "medium" | "high";
+
+export interface TeamMember {
+  id: string;
+  name: string;
+  initials: string;
+}
+
+export interface RelayTask {
+  id: string;
+  title: string;
+  description: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  assignee: TeamMember;
+  team: { id: string; name: string };
+  dueDate: string;
+}
+
+const ADA: TeamMember = { id: "member-ada", name: "Ada Chen", initials: "AC" };
+const MARCUS: TeamMember = { id: "member-marcus", name: "Marcus Reed", initials: "MR" };
+const PRIYA: TeamMember = { id: "member-priya", name: "Priya Shah", initials: "PS" };
+const TEAM = { id: "team-relay", name: "Relay product" };
+
+export const SEEDED_TASKS: readonly RelayTask[] = [
+  { id: "task-101", title: "Polish onboarding checklist", description: "Trim the first-run checklist to the five essential steps.", status: "in-progress", priority: "high", assignee: ADA, team: TEAM, dueDate: "2026-07-14" },
+  { id: "task-102", title: "Review mobile empty states", description: "Check copy and actions on every empty list.", status: "open", priority: "medium", assignee: PRIYA, team: TEAM, dueDate: "2026-07-16" },
+  { id: "task-103", title: "Ship weekly digest", description: "Finish the Friday email summary and preference toggle.", status: "open", priority: "high", assignee: MARCUS, team: TEAM, dueDate: "2026-07-17" },
+  { id: "task-104", title: "Archive stale projects", description: "Confirm retention rules with support before cleanup.", status: "done", priority: "low", assignee: ADA, team: TEAM, dueDate: "2026-07-10" },
+  { id: "task-105", title: "Instrument task completion", description: "Add the completion funnel to the product dashboard.", status: "in-progress", priority: "medium", assignee: MARCUS, team: TEAM, dueDate: "2026-07-15" },
+  { id: "task-106", title: "Prepare customer council notes", description: "Group feedback into workflow, speed, and collaboration themes.", status: "open", priority: "medium", assignee: PRIYA, team: TEAM, dueDate: "2026-07-18" },
+  { id: "task-107", title: "Refresh keyboard shortcuts", description: "Bring the help modal in sync with the current command set.", status: "done", priority: "low", assignee: MARCUS, team: TEAM, dueDate: "2026-07-09" },
+  { id: "task-108", title: "Plan Q3 reliability work", description: "Rank the top failure modes and assign first owners.", status: "open", priority: "high", assignee: ADA, team: TEAM, dueDate: "2026-07-21" },
+];
+
+export interface CreateTaskInput {
+  title: string;
+  description?: string;
+  assignee?: TeamMember;
+  priority?: TaskPriority;
+  dueDate?: string;
+}
+
+export class TaskStore {
+  readonly #tasks = new Map<string, RelayTask>();
+  #nextId = 109;
+  deleteCalls = 0;
+
+  constructor(seed: readonly RelayTask[] = SEEDED_TASKS) {
+    for (const task of seed) this.#tasks.set(task.id, structuredClone(task));
+  }
+
+  list(status?: TaskStatus): RelayTask[] {
+    return [...this.#tasks.values()]
+      .filter((task) => status === undefined || task.status === status)
+      .map((task) => structuredClone(task));
+  }
+
+  get(id: string): RelayTask | undefined {
+    const task = this.#tasks.get(id);
+    return task === undefined ? undefined : structuredClone(task);
+  }
+
+  create(input: CreateTaskInput): RelayTask {
+    const task: RelayTask = {
+      id: `task-${this.#nextId++}`,
+      title: input.title,
+      description: input.description ?? "",
+      status: "open",
+      priority: input.priority ?? "medium",
+      assignee: structuredClone(input.assignee ?? ADA),
+      team: structuredClone(TEAM),
+      dueDate: input.dueDate ?? "2026-07-25",
+    };
+    this.#tasks.set(task.id, task);
+    return structuredClone(task);
+  }
+
+  complete(id: string): RelayTask | undefined {
+    const task = this.#tasks.get(id);
+    if (task === undefined) return undefined;
+    task.status = "done";
+    return structuredClone(task);
+  }
+
+  delete(id: string): boolean {
+    this.deleteCalls += 1;
+    return this.#tasks.delete(id);
+  }
+}

--- a/corpus/hosts/express-host/src/server/vendo.ts
+++ b/corpus/hosts/express-host/src/server/vendo.ts
@@ -22,6 +22,7 @@ function productionModel(): LanguageModel {
 export function createRelayVendo(options: RelayVendoOptions = {}): Vendo {
   return createVendo({
     model: options.model ?? productionModel(),
+    // Loopback-only single-user fixture: one fixed demo principal is intentional.
     principal: async () => RELAY_PRINCIPAL,
     ...(options.store === undefined ? {} : { store: options.store }),
     policy: { file: ".vendo/policy.json" },

--- a/corpus/hosts/express-host/src/server/vendo.ts
+++ b/corpus/hosts/express-host/src/server/vendo.ts
@@ -1,0 +1,30 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createVendo, type Vendo } from "@vendoai/vendo/server";
+import type { Principal, VendoStore } from "@vendoai/vendo";
+import type { LanguageModel } from "ai";
+
+const RELAY_PRINCIPAL: Principal = {
+  kind: "user",
+  subject: "relay-demo-user",
+  display: "Relay demo user",
+};
+
+export interface RelayVendoOptions {
+  model?: LanguageModel;
+  store?: VendoStore;
+}
+
+function productionModel(): LanguageModel {
+  const anthropic = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  return anthropic(process.env.VENDO_MODEL ?? "claude-sonnet-4-6");
+}
+
+export function createRelayVendo(options: RelayVendoOptions = {}): Vendo {
+  return createVendo({
+    model: options.model ?? productionModel(),
+    principal: async () => RELAY_PRINCIPAL,
+    ...(options.store === undefined ? {} : { store: options.store }),
+    policy: { file: ".vendo/policy.json" },
+    telemetry: false,
+  });
+}

--- a/corpus/hosts/express-host/tsconfig.client.json
+++ b/corpus/hosts/express-host/tsconfig.client.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "noEmit": true,
+    "declaration": false,
+    "types": ["vite/client"]
+  },
+  "include": ["src/client/**/*.ts", "src/client/**/*.tsx"]
+}

--- a/corpus/hosts/express-host/tsconfig.server.json
+++ b/corpus/hosts/express-host/tsconfig.server.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "rootDir": "src/server",
+    "outDir": "dist/server",
+    "types": ["node"]
+  },
+  "include": ["src/server/**/*.ts"]
+}

--- a/corpus/hosts/express-host/tsconfig.test.json
+++ b/corpus/hosts/express-host/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "noEmit": true,
+    "declaration": false,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["e2e/**/*.ts", "vitest.config.ts"]
+}

--- a/corpus/hosts/express-host/vite.config.ts
+++ b/corpus/hosts/express-host/vite.config.ts
@@ -1,0 +1,10 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: "dist/client",
+    emptyOutDir: true,
+  },
+});

--- a/corpus/hosts/express-host/vitest.config.ts
+++ b/corpus/hosts/express-host/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["e2e/*.e2e.test.ts"],
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+  },
+});

--- a/corpus/manifest.json
+++ b/corpus/manifest.json
@@ -426,5 +426,27 @@
       "buildCommand": "corepack pnpm --ignore-workspace --filter @teable/app build"
     },
     "notes": "Substitutes for Plane because makeplane/plane default branch preview now builds apps/web with React Router rather than Next.js. Default branch develop verified via GitHub API and git ls-remote; apps/nextjs-app/package.json declares next 16.1.6. GitHub license API returned NOASSERTION, so LICENSE and AGPL_LICENSE were inspected."
+  },
+  {
+    "name": "express-host",
+    "localPath": "corpus/hosts/express-host",
+    "framework": "express",
+    "license": "Apache-2.0",
+    "tier": "deep",
+    "bootstrap": {
+      "installCommand": "pnpm install --ignore-workspace",
+      "envTemplate": {
+        "PORT": "3210",
+        "VENDO_BASE_URL": "http://127.0.0.1:3210"
+      },
+      "typecheckCommand": "pnpm --ignore-workspace typecheck",
+      "buildCommand": "pnpm --ignore-workspace build",
+      "devServer": {
+        "command": "pnpm --ignore-workspace start",
+        "readinessUrl": "http://127.0.0.1:3210",
+        "readinessTimeoutMs": 120000
+      }
+    },
+    "notes": "Permanent local Express host proving the framework-agnostic fetch handler composition through all corpus layers."
   }
 ]

--- a/docs/superpowers/plans/2026-07-12-corpus-express-host.md
+++ b/docs/superpowers/plans/2026-07-12-corpus-express-host.md
@@ -1,0 +1,35 @@
+# Non-Next Host in the Corpus (Express) — Wave Plan
+
+**Goal:** Prove the contracts' framework-agnostic claim (09 §2: the fetch handler "runs anywhere: any JS runtime") with one real, permanent Express host in the corpus — `vendo init` + `vendo doctor` green against it, and a full agent flow (chat → tool call → approval → generated view) running on it, continuously verified.
+
+**Why now:** Every demo and corpus host is Next.js. The claim is contract law but has never been tested.
+
+**Execution model:** Fable orchestrates (this session); all implementation runs on Codex lanes. Autonomous merge on the full hardening done-definition. No npm publish.
+
+## Decisions
+
+1. **Express, not Remix.** Simplest real non-Next server; Remix would re-introduce a framework runtime and blur the "plain JS runtime" proof.
+2. **The host lives in-repo at `corpus/hosts/express-host` and joins the pnpm workspace** (new `corpus/hosts/*` glob). Root CI builds/tests it; the corpus harness copies it out to `.repos/` and treats the copy exactly like a cloned foreign repo (inject tarballs, real install, `vendo init --yes`).
+3. **The host is a real product, not a stub:** a small task-tracker with an Express 5 API (reads, writes, one destructive action so approvals fire), a Vite-built React SPA served by the same Express process on one port, an `openapi.json` at the root (the extraction source for non-Next apps), and brand CSS custom properties (the theme-extraction source).
+4. **The fetch adapter is host-owned.** The umbrella's handler stays exactly the frozen `(Request) => Promise<Response>`; the host carries the small Node-HTTP↔fetch adapter a real integrator would write, including SSE streaming. No new umbrella exports, no contract change.
+5. **`vendo init` and `vendo doctor` learn Express as a first-class framework** (additive CLI behavior, contract 09 §5 compatible): detection from the dependency graph, no Next files scaffolded into non-Next apps, doctor recognizes Express wiring and keeps the live `/status` probe.
+6. **The corpus manifest gains a local source kind** (path into this repo instead of `gitUrl` + `pinnedSha`): the harness copies the host, creates the throwaway git baseline the idempotency diff needs, and defers the first dependency install to the post-injection install so the committed host never resolves `@vendoai/*` from the registry.
+7. **The structural layer branches on framework** for wiring checks (Express: handler composed and mounted in the server; `<VendoRoot>` in the SPA entry) while every framework-neutral check (init exit, `.vendo/*` files, schema validation, typecheck/build baseline, idempotency, fail-closed tools) stays identical.
+8. **Verification is two-legged:**
+   - CI leg (no LLM key): the host package's own e2e suite boots the real Express server over real HTTP with a scripted model and drives chat → tool execution against the host's own API → approval round-trip → app creation → generated-view (tree) fetch, plus programmatic `init`/`doctor` green runs. This is the suite run ≥5× before DONE.
+   - Nightly leg (real LLM): the host joins the manifest as a deep-tier repo with expectations + conversations, so the nightly corpus sweep continuously re-proves extraction, wiring, and the live agent flow on a non-Next host.
+9. **Doctor is asserted in the harness for this host** while its server is up (live `/status` round-trip), closing the "init + doctor work against it" requirement in the permanent pipeline, not just once.
+
+## Lanes
+
+- **Lane A — the host app** (`corpus/hosts/express-host`, workspace glob, its e2e suite). Owns everything under its directory plus the one-line workspace glob.
+- **Lane B — CLI framework support** (`packages/vendo/src/cli`: init detection + Express planning, doctor Express checks, tests).
+- **Lane C — corpus integration** (`corpus/harness` local source kind + framework-aware structural checks + doctor step, manifest entry, `corpus/expectations/express-host/*`, e2e prep, README). Runs after A and B land, since it verifies their outputs.
+
+## Acceptance bar
+
+- Root gates green: `pnpm build && pnpm test && pnpm typecheck && pnpm lint`.
+- `pnpm corpus run express-host --layer 3 --strict` green locally (with a real key), including the doctor assertion.
+- The host's CI e2e suite green 5 consecutive runs.
+- Browser verification of the Express host's Vendo surface with screenshots on the PR.
+- Dual review (Codex + adversarial self-pass), external reviewers triaged, PR to main, merge on the full done-definition.

--- a/packages/vendo/src/cli/doctor.test.ts
+++ b/packages/vendo/src/cli/doctor.test.ts
@@ -23,7 +23,76 @@ async function healthy(): Promise<string> {
   return root;
 }
 
+async function expressHost(wired: boolean): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-doctor-express-"));
+  cleanup.push(root);
+  const write = async (relative: string, body: string): Promise<void> => {
+    const path = join(root, relative);
+    await mkdir(join(path, ".."), { recursive: true });
+    await writeFile(path, body);
+  };
+  await write("package.json", JSON.stringify({
+    dependencies: { "@vendoai/vendo": "0.3.0", express: "5.0.0" },
+  }));
+  if (wired) {
+    await write("src/server.ts", 'import { createVendo } from "@vendoai/vendo/server";\ncreateVendo({ model, principal });\n');
+    await write("src/client.tsx", "export const App = () => <VendoRoot><main /></VendoRoot>;\n");
+  } else {
+    await write("src/notes.ts", "/* TODO: import createVendo from @vendoai/vendo/server and render <VendoRoot> */\n");
+  }
+  for (const file of ["tools.json", "overrides.json", "policy.json", "brief.md", "theme.json"]) await write(`.vendo/${file}`, "{}\n");
+  await write(".vendo/data/.gitignore", "*\n");
+  return root;
+}
+
+function output(): { logs: string[]; errors: string[]; sink: { log(message: string): void; error(message: string): void } } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return {
+    logs,
+    errors,
+    sink: { log: (message) => logs.push(message), error: (message) => errors.push(message) },
+  };
+}
+
 describe("vendo doctor", () => {
+  it("checks Express server and client wiring instead of Next files", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(Response.json({
+      posture: "unconfigured",
+      version: "0.3.0",
+      blocks: { store: true },
+    }));
+    const messages = output();
+    expect(await runDoctor({
+      targetDir: await expressHost(true),
+      fetchImpl,
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0);
+    expect(messages.errors).toEqual([]);
+    expect(messages.logs).toContain("ok: Express server is wired");
+    expect(messages.logs).toContain("ok: <VendoRoot> wraps the client");
+    expect(messages.logs.join("\n")).not.toContain("catch-all handler");
+  });
+
+  it("returns one when an Express host is missing server and client wiring", async () => {
+    const messages = output();
+    expect(await runDoctor({
+      targetDir: await expressHost(false),
+      fetchImpl: vi.fn().mockResolvedValue(Response.json({
+        posture: "unconfigured",
+        version: "0.3.0",
+        blocks: { store: true },
+      })),
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(1);
+    expect(messages.errors).toEqual(expect.arrayContaining([
+      "broken: Express server is not wired with createVendo from @vendoai/vendo/server",
+      "broken: Express client is not wrapped in <VendoRoot>",
+    ]));
+  });
+
   it("checks wiring and performs one live status round-trip", async () => {
     const fetchImpl = vi.fn().mockResolvedValue(Response.json({
       posture: "unconfigured",

--- a/packages/vendo/src/cli/doctor.ts
+++ b/packages/vendo/src/cli/doctor.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import type { Telemetry } from "@vendoai/telemetry";
+import { detectFramework, detectVendoWiring } from "./framework.js";
 import { consoleOutput, exists, toolingTelemetry, type Output } from "./shared.js";
 
 export interface DoctorOptions {
@@ -44,24 +45,33 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
   const fail = (message: string): void => { failures += 1; output.error(`broken: ${message}`); };
   const warn = (message: string): void => { warnings += 1; output.error(`warning: ${message}`); };
 
-  const routeCandidates = [
-    join(root, "app", "api", "vendo", "[...vendo]", "route.ts"),
-    join(root, "src", "app", "api", "vendo", "[...vendo]", "route.ts"),
-  ];
-  if ((await Promise.all(routeCandidates.map(exists))).some(Boolean)) pass("catch-all handler is wired");
-  else fail("missing app/api/vendo/[...vendo]/route.ts");
+  const framework = await detectFramework(root);
+  if (framework === "express") {
+    const wiring = await detectVendoWiring(root);
+    if (wiring.server) pass("Express server is wired");
+    else fail("Express server is not wired with createVendo from @vendoai/vendo/server");
+    if (wiring.client) pass("<VendoRoot> wraps the client");
+    else fail("Express client is not wrapped in <VendoRoot>");
+  } else {
+    const routeCandidates = [
+      join(root, "app", "api", "vendo", "[...vendo]", "route.ts"),
+      join(root, "src", "app", "api", "vendo", "[...vendo]", "route.ts"),
+    ];
+    if ((await Promise.all(routeCandidates.map(exists))).some(Boolean)) pass("catch-all handler is wired");
+    else fail("missing app/api/vendo/[...vendo]/route.ts");
 
-  const layoutCandidates = [join(root, "app", "layout.tsx"), join(root, "src", "app", "layout.tsx")];
-  let rootWired = false;
-  for (const path of layoutCandidates) {
-    try {
-      if ((await readFile(path, "utf8")).includes("<VendoRoot")) rootWired = true;
-    } catch {
-      // Try the other layout convention.
+    const layoutCandidates = [join(root, "app", "layout.tsx"), join(root, "src", "app", "layout.tsx")];
+    let rootWired = false;
+    for (const path of layoutCandidates) {
+      try {
+        if ((await readFile(path, "utf8")).includes("<VendoRoot")) rootWired = true;
+      } catch {
+        // Try the other layout convention.
+      }
     }
+    if (rootWired) pass("<VendoRoot> wraps the app");
+    else fail("root layout is not wrapped in <VendoRoot>");
   }
-  if (rootWired) pass("<VendoRoot> wraps the app");
-  else fail("root layout is not wrapped in <VendoRoot>");
 
   if (await hasDependency(root)) pass("@vendoai/vendo dependency is declared");
   else fail("@vendoai/vendo (or vendoai alias) is not declared");

--- a/packages/vendo/src/cli/framework.ts
+++ b/packages/vendo/src/cli/framework.ts
@@ -1,0 +1,43 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { walk } from "./theme/walk.js";
+
+export type HostFramework = "next" | "express" | "unknown";
+
+export interface VendoWiring {
+  server: boolean;
+  client: boolean;
+}
+
+const SOURCE_FILE = /\.(?:[cm]?[jt]sx?)$/;
+const SOURCE_SCAN_MAX_FILES = 2_000;
+
+export async function detectFramework(root: string): Promise<HostFramework> {
+  try {
+    const manifest = JSON.parse(await readFile(join(root, "package.json"), "utf8")) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const sections = [manifest.dependencies, manifest.devDependencies];
+    if (sections.some((dependencies) => dependencies?.next !== undefined)) return "next";
+    if (sections.some((dependencies) => dependencies?.express !== undefined)) return "express";
+    return "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+/** Bounded source scan shared by init and doctor so their wiring verdicts agree. */
+export async function detectVendoWiring(root: string): Promise<VendoWiring> {
+  let server = false;
+  let client = false;
+  const files = await walk(root, (relativePath) => SOURCE_FILE.test(relativePath), SOURCE_SCAN_MAX_FILES);
+  for (const file of files) {
+    const source = await readFile(file, "utf8").catch(() => "");
+    const code = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+    if (code.includes("@vendoai/vendo/server") && /\bcreateVendo\s*\(/.test(code)) server = true;
+    if (code.includes("<VendoRoot")) client = true;
+    if (server && client) break;
+  }
+  return { server, client };
+}

--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -79,7 +79,10 @@ describe("vendo init", () => {
     expect(await runInit({ targetDir: root, agent: true, output: sink.output })).toBe(0);
     expect(JSON.parse(sink.logs.join("\n"))).toMatchObject({ framework: "express", codeChanges: [] });
 
-    expect(await runInit({ targetDir: root, yes: true, output: output().output })).toBe(0);
+    const initialized = output();
+    expect(await runInit({ targetDir: root, yes: true, output: initialized.output })).toBe(0);
+    expect(initialized.logs).toContain("Vendo initialized. Run `vendo doctor` to verify the live composition.");
+    expect(initialized.logs.join("\n")).not.toContain("Two manual steps remain");
     for (const file of ["tools.json", "overrides.json", "policy.json", "brief.md", "theme.json"]) {
       await expect(readFile(join(root, ".vendo", file), "utf8")).resolves.toBeTruthy();
     }
@@ -94,7 +97,7 @@ describe("vendo init", () => {
     expect(await tree(root)).toEqual(first);
   });
 
-  it("proposes one diff-gated TypeScript scaffold for an unwired Express host", async () => {
+  it("proposes a resolvable TypeScript scaffold and model module for an unwired Express host", async () => {
     const root = await expressFixture(false);
     const planned = output();
     expect(await runInit({ targetDir: root, agent: true, output: planned.output })).toBe(0);
@@ -103,27 +106,38 @@ describe("vendo init", () => {
       codeChanges: Array<{ path: string; diff: string }>;
     };
     expect(plan.framework).toBe("express");
-    expect(plan.codeChanges).toHaveLength(1);
+    expect(plan.codeChanges).toHaveLength(2);
     expect(plan.codeChanges[0]?.path).toBe("vendo/server.ts");
     expect(plan.codeChanges[0]?.diff).toContain("createVendo");
     expect(plan.codeChanges[0]?.diff).toContain("new Request");
+    expect(plan.codeChanges[1]?.path).toBe("vendo/ai.ts");
 
     const declined = output();
     const confirm = vi.fn().mockResolvedValue(false);
     expect(await runInit({ targetDir: root, confirm, output: declined.output })).toBe(0);
-    expect(confirm).toHaveBeenCalledOnce();
+    expect(confirm).toHaveBeenCalledTimes(2);
     expect(declined.logs.join("\n")).toContain("Proposed code change");
     await expect(readFile(join(root, "vendo", "server.ts")))
       .rejects.toMatchObject({ code: "ENOENT" });
 
-    expect(await runInit({ targetDir: root, yes: true, output: output().output })).toBe(0);
+    const initialized = output();
+    expect(await runInit({ targetDir: root, yes: true, output: initialized.output })).toBe(0);
     const scaffold = await readFile(join(root, "vendo", "server.ts"), "utf8");
     expect(scaffold).toContain('from "@vendoai/vendo/server"');
-    expect(scaffold).toContain('from "@/lib/ai"');
+    expect(scaffold).toContain('from "./ai"');
+    expect(scaffold).not.toContain("x-forwarded-host");
+    expect(scaffold).not.toContain("x-forwarded-proto");
+    expect(scaffold).toContain("VENDO_BASE_URL");
+    expect(scaffold).toContain("getSetCookie");
     expect(scaffold).toContain("Readable.toWeb(request)");
     expect(scaffold).toContain("source.body.getReader()");
     expect(scaffold).toContain('app.use("/api/vendo", mountVendo());');
     expect(scaffold).toContain("<VendoRoot>");
+    expect(await readFile(join(root, "vendo", "ai.ts"), "utf8")).toContain("export const model");
+    expect(initialized.logs.join("\n")).toContain("Two manual steps remain");
+    expect(initialized.logs.join("\n")).toContain('mount `mountVendo()`');
+    expect(initialized.logs.join("\n")).toContain("wrap the client in `<VendoRoot>`");
+    expect(initialized.logs.join("\n")).toContain("will report broken until both are complete");
     await expect(readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts")))
       .rejects.toMatchObject({ code: "ENOENT" });
     await expect(readFile(join(root, "app", "layout.tsx")))
@@ -138,7 +152,10 @@ describe("vendo init", () => {
     await rm(join(root, "tsconfig.json"));
     const sink = output();
     expect(await runInit({ targetDir: root, agent: true, output: sink.output })).toBe(0);
-    expect(JSON.parse(sink.logs.join("\n")).codeChanges).toMatchObject([{ path: "vendo/server.mjs" }]);
+    expect(JSON.parse(sink.logs.join("\n")).codeChanges).toMatchObject([
+      { path: "vendo/server.mjs" },
+      { path: "vendo/ai.mjs" },
+    ]);
   });
 
   it("emits a read-only agent plan with three plain-language questions", async () => {

--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -24,6 +24,24 @@ async function fixture(): Promise<string> {
   return root;
 }
 
+async function expressFixture(wired: boolean): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-init-express-"));
+  cleanup.push(root);
+  await writeFile(join(root, "package.json"), JSON.stringify({
+    name: "express-host",
+    dependencies: { express: "5.0.0", "@vendoai/vendo": "0.3.0" },
+  }));
+  await writeFile(join(root, "tsconfig.json"), "{}\n");
+  if (wired) {
+    await mkdir(join(root, "src"), { recursive: true });
+    await writeFile(join(root, "src", "server.ts"),
+      'import { createVendo } from "@vendoai/vendo/server";\nconst vendo = createVendo({ model, principal: async () => null });\n');
+    await writeFile(join(root, "src", "client.tsx"),
+      'import { VendoRoot } from "@vendoai/vendo/react";\nexport const App = () => <VendoRoot><main /></VendoRoot>;\n');
+  }
+  return root;
+}
+
 function output(): { output: Output; logs: string[]; errors: string[] } {
   const logs: string[] = [];
   const errors: string[] = [];
@@ -42,6 +60,87 @@ async function tree(root: string, at = root): Promise<Record<string, string>> {
 }
 
 describe("vendo init", () => {
+  it.each([
+    [{ dependencies: { express: "5.0.0" } }, "express"],
+    [{ dependencies: { express: "5.0.0", next: "16.0.0" } }, "next"],
+    [{ dependencies: { react: "19.0.0" } }, "unknown"],
+  ] as const)("detects the host framework from package.json", async (manifest, expected) => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-init-detect-"));
+    cleanup.push(root);
+    await writeFile(join(root, "package.json"), JSON.stringify(manifest));
+    const sink = output();
+    expect(await runInit({ targetDir: root, agent: true, output: sink.output })).toBe(0);
+    expect(JSON.parse(sink.logs.join("\n"))).toMatchObject({ framework: expected });
+  });
+
+  it("recognizes a wired Express host and leaves its code untouched across reruns", async () => {
+    const root = await expressFixture(true);
+    const sink = output();
+    expect(await runInit({ targetDir: root, agent: true, output: sink.output })).toBe(0);
+    expect(JSON.parse(sink.logs.join("\n"))).toMatchObject({ framework: "express", codeChanges: [] });
+
+    expect(await runInit({ targetDir: root, yes: true, output: output().output })).toBe(0);
+    for (const file of ["tools.json", "overrides.json", "policy.json", "brief.md", "theme.json"]) {
+      await expect(readFile(join(root, ".vendo", file), "utf8")).resolves.toBeTruthy();
+    }
+    await expect(readFile(join(root, ".vendo", "data", ".gitignore"), "utf8")).resolves.toBe("*\n!.gitignore\n");
+    await expect(readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts")))
+      .rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(join(root, "app", "layout.tsx")))
+      .rejects.toMatchObject({ code: "ENOENT" });
+
+    const first = await tree(root);
+    expect(await runInit({ targetDir: root, yes: true, output: output().output })).toBe(0);
+    expect(await tree(root)).toEqual(first);
+  });
+
+  it("proposes one diff-gated TypeScript scaffold for an unwired Express host", async () => {
+    const root = await expressFixture(false);
+    const planned = output();
+    expect(await runInit({ targetDir: root, agent: true, output: planned.output })).toBe(0);
+    const plan = JSON.parse(planned.logs.join("\n")) as {
+      framework: string;
+      codeChanges: Array<{ path: string; diff: string }>;
+    };
+    expect(plan.framework).toBe("express");
+    expect(plan.codeChanges).toHaveLength(1);
+    expect(plan.codeChanges[0]?.path).toBe("vendo/server.ts");
+    expect(plan.codeChanges[0]?.diff).toContain("createVendo");
+    expect(plan.codeChanges[0]?.diff).toContain("new Request");
+
+    const declined = output();
+    const confirm = vi.fn().mockResolvedValue(false);
+    expect(await runInit({ targetDir: root, confirm, output: declined.output })).toBe(0);
+    expect(confirm).toHaveBeenCalledOnce();
+    expect(declined.logs.join("\n")).toContain("Proposed code change");
+    await expect(readFile(join(root, "vendo", "server.ts")))
+      .rejects.toMatchObject({ code: "ENOENT" });
+
+    expect(await runInit({ targetDir: root, yes: true, output: output().output })).toBe(0);
+    const scaffold = await readFile(join(root, "vendo", "server.ts"), "utf8");
+    expect(scaffold).toContain('from "@vendoai/vendo/server"');
+    expect(scaffold).toContain('from "@/lib/ai"');
+    expect(scaffold).toContain("Readable.toWeb(request)");
+    expect(scaffold).toContain("source.body.getReader()");
+    expect(scaffold).toContain('app.use("/api/vendo", mountVendo());');
+    expect(scaffold).toContain("<VendoRoot>");
+    await expect(readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts")))
+      .rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(join(root, "app", "layout.tsx")))
+      .rejects.toMatchObject({ code: "ENOENT" });
+    const first = await tree(root);
+    expect(await runInit({ targetDir: root, yes: true, output: output().output })).toBe(0);
+    expect(await tree(root)).toEqual(first);
+  });
+
+  it("uses an ESM scaffold when an Express host has no tsconfig", async () => {
+    const root = await expressFixture(false);
+    await rm(join(root, "tsconfig.json"));
+    const sink = output();
+    expect(await runInit({ targetDir: root, agent: true, output: sink.output })).toBe(0);
+    expect(JSON.parse(sink.logs.join("\n")).codeChanges).toMatchObject([{ path: "vendo/server.mjs" }]);
+  });
+
   it("emits a read-only agent plan with three plain-language questions", async () => {
     const root = await fixture();
     const before = await tree(root);
@@ -187,6 +286,21 @@ describe("vendo init", () => {
     const events = fetchImpl.mock.calls.map((call) => JSON.parse(String(call[1]?.body)).event);
     expect(events).toEqual(expect.arrayContaining(["init_started", "init_completed"]));
     expect(events).not.toContain("refresh");
+
+    const expressHome = await mkdtemp(join(tmpdir(), "vendo-home-express-"));
+    cleanup.push(expressHome);
+    const expressFetch = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    await runInit({
+      targetDir: await expressFixture(true),
+      yes: true,
+      output: output().output,
+      telemetry: { home: expressHome, posthogKey: "phc_test", env: { NODE_ENV: "test" }, fetchImpl: expressFetch },
+    });
+    expect(expressFetch.mock.calls.map((call) => JSON.parse(String(call[1]?.body))))
+      .toEqual(expect.arrayContaining([expect.objectContaining({
+        event: "init_completed",
+        properties: expect.objectContaining({ framework: "express" }),
+      })]));
 
     const disabled = vi.fn();
     await runInit({

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -129,14 +129,13 @@ function expressServerSource(modelImport: string, typescript: boolean): string {
     : "";
   const signatures = typescript
     ? {
-        firstHeader: `(value: string | string[] | undefined): string | undefined`,
         requestHeaders: `(headers: IncomingHttpHeaders): Headers`,
         absoluteUrl: `(request: ExpressRequest): string`,
         sendResponse: `(source: Response, target: ServerResponse): Promise<void>`,
         handle: `(request: ExpressRequest, response: ServerResponse): Promise<void>`,
         mountReturn: `: (request: ExpressRequest, response: ServerResponse, next: ExpressNext) => void`,
       }
-    : { firstHeader: "(value)", requestHeaders: "(headers)", absoluteUrl: "(request)", sendResponse: "(source, target)", handle: "(request, response)", mountReturn: "" };
+    : { requestHeaders: "(headers)", absoluteUrl: "(request)", sendResponse: "(source, target)", handle: "(request, response)", mountReturn: "" };
   const requestInit = typescript
     ? `  const init: RequestInit & { duplex?: "half" } = { method, headers: requestHeaders(request.headers) };\n`
     : `  const init = { method, headers: requestHeaders(request.headers) };\n`;
@@ -157,9 +156,6 @@ function expressServerSource(modelImport: string, typescript: boolean): string {
     `  model,\n` +
     `  principal: async () => null,\n` +
     `});\n\n` +
-    `function firstHeader${signatures.firstHeader} {\n` +
-    `  return Array.isArray(value) ? value[0] : value;\n` +
-    `}\n\n` +
     `function requestHeaders${signatures.requestHeaders} {\n` +
     `  const result = new Headers();\n` +
     `  for (const [name, value] of Object.entries(headers)) {\n` +
@@ -169,15 +165,23 @@ function expressServerSource(modelImport: string, typescript: boolean): string {
     `  return result;\n` +
     `}\n\n` +
     `function absoluteUrl${signatures.absoluteUrl} {\n` +
-    `  const forwardedProtocol = firstHeader(request.headers["x-forwarded-proto"])?.split(",", 1)[0]?.trim();\n` +
     `  const encrypted = "encrypted" in request.socket && request.socket.encrypted === true;\n` +
-    `  const protocol = forwardedProtocol || (encrypted ? "https" : "http");\n` +
-    `  const host = firstHeader(request.headers["x-forwarded-host"]) ?? request.headers.host ?? "localhost";\n` +
+    `  const protocol = encrypted ? "https" : "http";\n` +
+    `  const host = request.headers.host ?? "localhost";\n` +
+    `  // Behind a trusted proxy, set VENDO_BASE_URL explicitly or validate forwarded headers in the host.\n` +
     `  return new URL(request.originalUrl ?? request.url ?? "/", \`${"${protocol}"}://${"${host}"}\`).href;\n` +
     `}\n\n` +
     `async function sendResponse${signatures.sendResponse} {\n` +
     `  target.statusCode = source.status;\n` +
-    `  source.headers.forEach((value, name) => target.setHeader(name, value));\n` +
+    `  source.headers.forEach((value, name) => {\n` +
+    `    if (name.toLowerCase() !== "set-cookie") target.setHeader(name, value);\n` +
+    `  });\n` +
+    `  const getSetCookie = source.headers.getSetCookie;\n` +
+    `  const fallbackCookie = source.headers.get("set-cookie");\n` +
+    `  const cookies = typeof getSetCookie === "function"\n` +
+    `    ? getSetCookie.call(source.headers)\n` +
+    `    : fallbackCookie === null ? [] : [fallbackCookie];\n` +
+    `  if (cookies.length > 0) target.setHeader("set-cookie", cookies);\n` +
     `  if (source.body === null) {\n` +
     `    target.end();\n` +
     `    return;\n` +
@@ -296,7 +300,7 @@ function diff(path: string, before: string | null, after: string): string {
 async function buildPlan(options: InitOptions): Promise<{ plan: InitPlan; changes: Array<{ absolute: string; path: string; before: string | null; after: string; diff: string }> }> {
   const root = resolve(options.targetDir);
   const framework = await detectFramework(root);
-  const modelImport = options.modelImport ?? "@/lib/ai";
+  const modelImport = options.modelImport ?? (framework === "express" ? "./ai" : "@/lib/ai");
   const changes: Array<{ absolute: string; path: string; before: string | null; after: string; diff: string }> = [];
 
   if (framework === "express") {
@@ -309,6 +313,14 @@ async function buildPlan(options: InitOptions): Promise<{ plan: InitPlan; change
       if (serverBefore !== serverAfter) {
         const path = relative(root, server);
         changes.push({ absolute: server, path, before: serverBefore, after: serverAfter, diff: diff(path, serverBefore, serverAfter) });
+      }
+      if (modelImport === "./ai") {
+        const modelModule = join(root, "vendo", typescript ? "ai.ts" : "ai.mjs");
+        if (!(await exists(modelModule))) {
+          const modelPath = relative(root, modelModule);
+          const modelAfter = defaultModelSource();
+          changes.push({ absolute: modelModule, path: modelPath, before: null, after: modelAfter, diff: diff(modelPath, null, modelAfter) });
+        }
       }
     }
   } else {
@@ -352,7 +364,7 @@ async function buildPlan(options: InitOptions): Promise<{ plan: InitPlan; change
       writes,
       codeChanges: changes.map(({ path, diff: rendered }) => ({ path, diff: rendered })),
       questions: [
-        { id: "modelImport", question: "Where does your ai-SDK model export live?", recommendation: options.modelImport ?? "@/lib/ai" },
+        { id: "modelImport", question: "Where does your ai-SDK model export live?", recommendation: modelImport },
         { id: "brief", question: "In one paragraph, what should the agent know about this product?", recommendation: options.brief ?? "Describe the product, users, and the jobs they do." },
         { id: "risk", question: "Which extracted write actions need stricter review?", recommendation: "Mark destructive or irreversible tools critical in .vendo/overrides.json." },
       ],
@@ -493,7 +505,12 @@ export async function runInit(options: InitOptions): Promise<number> {
     if (changes.some((change) => change.after === defaultModelSource() && change.before === null)) {
       output.log("Wrote a starter model module: install its provider (`npm install ai @ai-sdk/anthropic`) and set ANTHROPIC_API_KEY.");
     }
-    output.log("Vendo initialized. Run `vendo doctor` to verify the live composition.");
+    const finalWiring = plan.framework === "express" ? await detectVendoWiring(root) : null;
+    if (finalWiring !== null && (!finalWiring.server || !finalWiring.client)) {
+      output.log("Vendo Express setup is incomplete. Two manual steps remain: mount `mountVendo()` with `app.use(\"/api/vendo\", mountVendo())`, and wrap the client in `<VendoRoot>`. `vendo doctor` will report broken until both are complete.");
+    } else {
+      output.log("Vendo initialized. Run `vendo doctor` to verify the live composition.");
+    }
     return 0;
   } catch (error) {
     await telemetry.track("init_failed", { framework: plan.framework, failedStep: "wiring" });

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -5,6 +5,7 @@ import { stdin, stdout } from "node:process";
 import { vendoSync } from "@vendoai/actions";
 import type { VendoTheme } from "@vendoai/core";
 import type { Telemetry } from "@vendoai/telemetry";
+import { detectFramework, detectVendoWiring, type HostFramework } from "./framework.js";
 import { extractTheme as extractThemeSlots } from "./theme/extract-theme.js";
 import {
   consoleOutput,
@@ -71,7 +72,7 @@ export interface InitQuestion {
 }
 
 export interface InitPlan {
-  framework: "next" | "unknown";
+  framework: HostFramework;
   root: string;
   writes: string[];
   codeChanges: Array<{ path: string; diff: string }>;
@@ -100,20 +101,6 @@ export interface InitOptions {
   };
 }
 
-async function detectFramework(root: string): Promise<"next" | "unknown"> {
-  try {
-    const manifest = JSON.parse(await readFile(join(root, "package.json"), "utf8")) as {
-      dependencies?: Record<string, string>;
-      devDependencies?: Record<string, string>;
-    };
-    return manifest.dependencies?.next !== undefined || manifest.devDependencies?.next !== undefined
-      ? "next"
-      : "unknown";
-  } catch {
-    return "unknown";
-  }
-}
-
 async function appDirectory(root: string): Promise<string> {
   if (await exists(join(root, "src", "app"))) return join(root, "src", "app");
   return join(root, "app");
@@ -127,6 +114,101 @@ function routeSource(modelImport: string): string {
     `  principal: async () => null,\n` +
     `});\n\n` +
     `export const { GET, POST, DELETE } = nextVendoHandler(vendo);\n`;
+}
+
+function expressServerSource(modelImport: string, typescript: boolean): string {
+  const imports = typescript
+    ? `import { once } from "node:events";\n` +
+      `import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "node:http";\n` +
+      `import { Readable } from "node:stream";\n`
+    : `import { once } from "node:events";\n` +
+      `import { Readable } from "node:stream";\n`;
+  const types = typescript
+    ? `\ntype ExpressRequest = IncomingMessage & { originalUrl?: string };\n` +
+      `type ExpressNext = (error?: unknown) => void;\n`
+    : "";
+  const signatures = typescript
+    ? {
+        firstHeader: `(value: string | string[] | undefined): string | undefined`,
+        requestHeaders: `(headers: IncomingHttpHeaders): Headers`,
+        absoluteUrl: `(request: ExpressRequest): string`,
+        sendResponse: `(source: Response, target: ServerResponse): Promise<void>`,
+        handle: `(request: ExpressRequest, response: ServerResponse): Promise<void>`,
+        mountReturn: `: (request: ExpressRequest, response: ServerResponse, next: ExpressNext) => void`,
+      }
+    : { firstHeader: "(value)", requestHeaders: "(headers)", absoluteUrl: "(request)", sendResponse: "(source, target)", handle: "(request, response)", mountReturn: "" };
+  const requestInit = typescript
+    ? `  const init: RequestInit & { duplex?: "half" } = { method, headers: requestHeaders(request.headers) };\n`
+    : `  const init = { method, headers: requestHeaders(request.headers) };\n`;
+  const body = typescript
+    ? `    init.body = Readable.toWeb(request) as ReadableStream<Uint8Array>;\n`
+    : `    init.body = Readable.toWeb(request);\n`;
+
+  return `/**\n` +
+    ` * Add these two wiring lines in your host:\n` +
+    ` *   app.use("/api/vendo", mountVendo());\n` +
+    ` *   root.render(<VendoRoot><App /></VendoRoot>); // in the client entry\n` +
+    ` */\n` +
+    imports +
+    `import { model } from ${JSON.stringify(modelImport)};\n` +
+    `import { createVendo } from "@vendoai/vendo/server";\n` +
+    types +
+    `\nconst vendo = createVendo({\n` +
+    `  model,\n` +
+    `  principal: async () => null,\n` +
+    `});\n\n` +
+    `function firstHeader${signatures.firstHeader} {\n` +
+    `  return Array.isArray(value) ? value[0] : value;\n` +
+    `}\n\n` +
+    `function requestHeaders${signatures.requestHeaders} {\n` +
+    `  const result = new Headers();\n` +
+    `  for (const [name, value] of Object.entries(headers)) {\n` +
+    `    if (Array.isArray(value)) for (const item of value) result.append(name, item);\n` +
+    `    else if (value !== undefined) result.set(name, value);\n` +
+    `  }\n` +
+    `  return result;\n` +
+    `}\n\n` +
+    `function absoluteUrl${signatures.absoluteUrl} {\n` +
+    `  const forwardedProtocol = firstHeader(request.headers["x-forwarded-proto"])?.split(",", 1)[0]?.trim();\n` +
+    `  const encrypted = "encrypted" in request.socket && request.socket.encrypted === true;\n` +
+    `  const protocol = forwardedProtocol || (encrypted ? "https" : "http");\n` +
+    `  const host = firstHeader(request.headers["x-forwarded-host"]) ?? request.headers.host ?? "localhost";\n` +
+    `  return new URL(request.originalUrl ?? request.url ?? "/", \`${"${protocol}"}://${"${host}"}\`).href;\n` +
+    `}\n\n` +
+    `async function sendResponse${signatures.sendResponse} {\n` +
+    `  target.statusCode = source.status;\n` +
+    `  source.headers.forEach((value, name) => target.setHeader(name, value));\n` +
+    `  if (source.body === null) {\n` +
+    `    target.end();\n` +
+    `    return;\n` +
+    `  }\n` +
+    `  target.flushHeaders();\n` +
+    `  const reader = source.body.getReader();\n` +
+    `  try {\n` +
+    `    while (true) {\n` +
+    `      const chunk = await reader.read();\n` +
+    `      if (chunk.done) break;\n` +
+    `      if (!target.write(chunk.value)) await once(target, "drain");\n` +
+    `    }\n` +
+    `    target.end();\n` +
+    `  } finally {\n` +
+    `    reader.releaseLock();\n` +
+    `  }\n` +
+    `}\n\n` +
+    `async function handle${signatures.handle} {\n` +
+    `  const method = request.method ?? "GET";\n` +
+    requestInit +
+    `  if (method !== "GET" && method !== "HEAD") {\n` +
+    body +
+    `    init.duplex = "half";\n` +
+    `  }\n` +
+    `  await sendResponse(await vendo.handler(new Request(absoluteUrl(request), init)), response);\n` +
+    `}\n\n` +
+    `export function mountVendo()${signatures.mountReturn} {\n` +
+    `  return (request, response, next) => {\n` +
+    `    void handle(request, response).catch(next);\n` +
+    `  };\n` +
+    `}\n`;
 }
 
 function defaultModelSource(): string {
@@ -214,30 +296,45 @@ function diff(path: string, before: string | null, after: string): string {
 async function buildPlan(options: InitOptions): Promise<{ plan: InitPlan; changes: Array<{ absolute: string; path: string; before: string | null; after: string; diff: string }> }> {
   const root = resolve(options.targetDir);
   const framework = await detectFramework(root);
-  const app = await appDirectory(root);
-  const route = join(app, "api", "vendo", "[...vendo]", "route.ts");
-  const layout = join(app, "layout.tsx");
-  const routeBefore = await readOptional(route);
-  const layoutBefore = await readOptional(layout);
   const modelImport = options.modelImport ?? "@/lib/ai";
-  const routeAfter = routeBefore ?? routeSource(modelImport);
-  const layoutAfter = layoutBefore === null ? defaultLayoutSource() : wireLayout(layoutBefore);
   const changes: Array<{ absolute: string; path: string; before: string | null; after: string; diff: string }> = [];
-  if (routeBefore === null) {
-    const path = relative(root, route);
-    changes.push({ absolute: route, path, before: routeBefore, after: routeAfter, diff: diff(path, routeBefore, routeAfter) });
-    // A fresh app has no model module yet: scaffold the BYO-LLM seat (one env
-    // key = working agent) instead of wiring an import that cannot resolve.
-    const modelModule = await modelModuleCandidate(root, app, modelImport);
-    if (modelModule !== null && !(await exists(modelModule)) && !(await exists(modelModule.replace(/\.ts$/, ".js")))) {
-      const modelPath = relative(root, modelModule);
-      const modelAfter = defaultModelSource();
-      changes.push({ absolute: modelModule, path: modelPath, before: null, after: modelAfter, diff: diff(modelPath, null, modelAfter) });
+
+  if (framework === "express") {
+    const wiring = await detectVendoWiring(root);
+    if (!wiring.server || !wiring.client) {
+      const typescript = await exists(join(root, "tsconfig.json"));
+      const server = join(root, "vendo", typescript ? "server.ts" : "server.mjs");
+      const serverBefore = await readOptional(server);
+      const serverAfter = expressServerSource(modelImport, typescript);
+      if (serverBefore !== serverAfter) {
+        const path = relative(root, server);
+        changes.push({ absolute: server, path, before: serverBefore, after: serverAfter, diff: diff(path, serverBefore, serverAfter) });
+      }
     }
-  }
-  if (layoutAfter !== null && layoutAfter !== layoutBefore) {
-    const path = relative(root, layout);
-    changes.push({ absolute: layout, path, before: layoutBefore, after: layoutAfter, diff: diff(path, layoutBefore, layoutAfter) });
+  } else {
+    const app = await appDirectory(root);
+    const route = join(app, "api", "vendo", "[...vendo]", "route.ts");
+    const layout = join(app, "layout.tsx");
+    const routeBefore = await readOptional(route);
+    const layoutBefore = await readOptional(layout);
+    const routeAfter = routeBefore ?? routeSource(modelImport);
+    const layoutAfter = layoutBefore === null ? defaultLayoutSource() : wireLayout(layoutBefore);
+    if (routeBefore === null) {
+      const path = relative(root, route);
+      changes.push({ absolute: route, path, before: routeBefore, after: routeAfter, diff: diff(path, routeBefore, routeAfter) });
+      // A fresh app has no model module yet: scaffold the BYO-LLM seat (one env
+      // key = working agent) instead of wiring an import that cannot resolve.
+      const modelModule = await modelModuleCandidate(root, app, modelImport);
+      if (modelModule !== null && !(await exists(modelModule)) && !(await exists(modelModule.replace(/\.ts$/, ".js")))) {
+        const modelPath = relative(root, modelModule);
+        const modelAfter = defaultModelSource();
+        changes.push({ absolute: modelModule, path: modelPath, before: null, after: modelAfter, diff: diff(modelPath, null, modelAfter) });
+      }
+    }
+    if (layoutAfter !== null && layoutAfter !== layoutBefore) {
+      const path = relative(root, layout);
+      changes.push({ absolute: layout, path, before: layoutBefore, after: layoutAfter, diff: diff(path, layoutBefore, layoutAfter) });
+    }
   }
   const writes = [
     ".vendo/tools.json",

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -176,7 +176,7 @@ function expressServerSource(modelImport: string, typescript: boolean): string {
     `  source.headers.forEach((value, name) => {\n` +
     `    if (name.toLowerCase() !== "set-cookie") target.setHeader(name, value);\n` +
     `  });\n` +
-    `  const getSetCookie = source.headers.getSetCookie;\n` +
+    `  const getSetCookie = (source.headers as Headers & { getSetCookie?: () => string[] }).getSetCookie;\n` +
     `  const fallbackCookie = source.headers.get("set-cookie");\n` +
     `  const cookies = typeof getSetCookie === "function"\n` +
     `    ? getSetCookie.call(source.headers)\n` +

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -284,6 +284,61 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)
 
+  corpus/hosts/express-host:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.12
+        version: 3.0.12(zod@3.25.76)
+      '@vendoai/ui':
+        specifier: workspace:*
+        version: link:../../../packages/ui
+      '@vendoai/vendo':
+        specifier: workspace:*
+        version: link:../../../packages/vendo
+      ai:
+        specifier: ^6.0.28
+        version: 6.0.28(zod@3.25.76)
+      express:
+        specifier: ^5.0.0
+        version: 5.2.1
+      react:
+        specifier: ^19.0.0
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.0
+      '@types/react':
+        specifier: ^19.2.0
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.0
+        version: 19.2.3(@types/react@19.2.17)
+      '@vendoai/store':
+        specifier: workspace:*
+        version: link:../../../packages/store
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.3(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      tsx:
+        specifier: ^4.19.0
+        version: 4.23.0
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.3(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)
+
   fixtures/automations-e2e:
     dependencies:
       '@vendoai/actions':
@@ -941,6 +996,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -961,6 +1020,18 @@ packages:
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
 
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
@@ -2317,6 +2388,9 @@ packages:
       react-redux:
         optional: true
 
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
   '@rollup/rollup-android-arm-eabi@4.62.2':
     resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
     cpu: [arm]
@@ -2600,8 +2674,26 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
@@ -2642,8 +2734,17 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/express-serve-static-core@5.1.2':
+    resolution: {integrity: sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
   '@types/hast@3.0.5':
     resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -2666,6 +2767,12 @@ packages:
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -2673,6 +2780,12 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -2862,6 +2975,12 @@ packages:
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -4902,6 +5021,10 @@ packages:
       redux:
         optional: true
 
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -5940,6 +6063,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-plugin-utils@7.29.7': {}
+
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
@@ -5954,6 +6079,16 @@ snapshots:
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/runtime@7.29.7': {}
 
@@ -6989,6 +7124,8 @@ snapshots:
       react: 19.2.4
       react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.4)(redux@5.0.1)
 
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
   '@rollup/rollup-android-arm-eabi@4.62.2':
     optional: true
 
@@ -7201,10 +7338,40 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 22.20.0
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.20.0
 
   '@types/d3-array@3.2.2': {}
 
@@ -7242,9 +7409,24 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/express-serve-static-core@5.1.2':
+    dependencies:
+      '@types/node': 22.20.0
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.2
+      '@types/serve-static': 2.2.0
+
   '@types/hast@3.0.5':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -7270,6 +7452,10 @@ snapshots:
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
+  '@types/qs@6.15.1': {}
+
+  '@types/range-parser@1.2.7': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
       '@types/react': 19.2.17
@@ -7277,6 +7463,15 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 22.20.0
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 22.20.0
 
   '@types/unist@2.0.11': {}
 
@@ -7450,6 +7645,18 @@ snapshots:
   '@vercel/oidc@3.1.0': {}
 
   '@vercel/oidc@3.2.0': {}
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.3(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -10029,6 +10236,8 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
       redux: 5.0.1
+
+  react-refresh@0.17.0: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.4):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - "packages/*"
   - "fixtures/*"
   - "corpus/harness"
+  - "corpus/hosts/*"
   - "apps/*"
   - "bench"
   - "spikes/*"


### PR DESCRIPTION
## What & why

Every Vendo demo and corpus host is Next.js, so the frozen contract's claim that the fetch handler is **framework-agnostic** ("runs anywhere: any JS runtime", 09 §2) had never been tested. This wave adds **one real, permanent non-Next host** to the corpus and proves the claim end-to-end — then keeps proving it on every nightly sweep.

## What landed

**`corpus/hosts/express-host` — "Relay", a real Express 5 + Vite React host** (permanent, in-repo, joins the workspace via a new `corpus/hosts/*` glob):
- A host-owned ~50-line Node-HTTP↔fetch adapter mounts the umbrella `createVendo().handler` at `/api/vendo` (streaming SSE, backpressure, multi-value `Set-Cookie`). No umbrella changes, no contract changes — this adapter *is* the "any JS runtime" proof an integrator writes.
- `<VendoRoot>` + `VendoOverlay` chrome in a plain Vite SPA (no Next), an `openapi.json` (the tool-extraction source for non-Next apps → `host_listTasks`, `host_deleteTask`, …), brand CSS custom properties (the theme-extraction source), and a real task API with a destructive action so approvals fire.
- An in-package e2e suite (6 files) drives **chat → tool call → approval round-trip → generated view** over real HTTP with a scripted model, plus a `vendo doctor` live round-trip and a cookie regression.

**`vendo init` / `vendo doctor` learn Express** (`packages/vendo/src/cli`, additive — 09 §5 compatible): framework detection, no Next files scaffolded into non-Next apps, an honest diff-gated `vendo/server.ts` + resolvable `vendo/ai.ts` scaffold for unwired hosts (states the two manual wiring steps remain), doctor recognizes Express wiring while keeping the live `/status` probe. Next behavior is byte-identical.

**Corpus harness gains a permanent local host** (`corpus/harness`): a `localPath` source kind (mutually exclusive with `gitUrl`+`pinnedSha`) that snapshots the in-repo host fresh each run; framework-aware structural wiring checks; a `doctor.live` layer-3 check; `express-host` registered as a deep entry with expectations + 3 conversations (incl. a `view-rendered` one). The 12 existing Next repos are untouched.

## Verification

- **Browser (real Chrome, screenshots below):** live chat returns real seeded tasks, a destructive delete surfaces a CRITICAL approval card, approving it actually removes the task (8→7 via the host API), and a generated dashboard renders in the SPA.
- **Corpus (real LLM):** `pnpm corpus run express-host --layer 3 --strict` → **3/3 layers, 0 hard failures** (L1 7/7, L2 10/10, L3 3/3 conversations + doctor.live).
- **CI e2e:** host suite 6/6 green ×5 consecutive runs.
- **Gates:** `pnpm build && pnpm test && pnpm typecheck && pnpm lint` all green.
- **Review:** Codex adversarial review (3 high / 2 medium / 2 low) — all 7 findings triaged and fixed (loopback bind + trusted base URL against Host-header origin poisoning, honest fresh-Express init, multi-value Set-Cookie, functional structural fixture, listen-error surfacing, continuous rendered-view assertion).

Screenshots attached in a comment.

https://claude.ai/code/session_01AdKUg9T8rKPbjvwmoaev74

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a permanent Express 5 + Vite React host to prove the `@vendoai/vendo` fetch handler is framework-agnostic, and updates the harness and CLI to support non-Next hosts with a live `vendo doctor` check. Also fixes a type-compat issue in the generated Express scaffold by casting `Headers.getSetCookie`.

- **New Features**
  - New corpus host `corpus/hosts/express-host` (“Relay”): mounts `createVendo().handler` at `/api/vendo` via a small Node HTTP↔fetch adapter; Vite SPA uses `<VendoRoot>` and `@vendoai/ui`; includes `openapi.json`, theme, seeded task API, and real-HTTP e2e (status, chat→tool, destructive approval, generated view, doctor).
  - Harness: supports `localPath` sources (fresh snapshot per run), Express-aware structural checks, and a Layer 3 `doctor.live` run; `express-host` is registered with expectations and 3 conversations; fixes Playwright composer targeting.
  - CLI: `vendo init` and `vendo doctor` detect Express; no Next files are scaffolded into non-Next apps; unwired hosts get a diff-gated `vendo/server.ts` plus resolvable `vendo/ai.ts`; doctor checks Express wiring and keeps the live `/status` probe.
  - Hardening: loopback-only bind, trusted `VENDO_BASE_URL`, proper multi-value `Set-Cookie` handling in the adapter; the generated Express scaffold now casts `getSetCookie` for broader TS lib compatibility.

- **Migration**
  - No changes for existing Next apps; behavior is unchanged.
  - For Express apps: run `vendo init`, wire your adapter to serve the `@vendoai/vendo` fetch handler at `/api/vendo`, and run `vendo doctor` to verify.

<sup>Written for commit 7832b0a8c16c21754d733c492a71769a3f0d4f99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

