### PR TITLE
feat(cli): vendo cloud subcommands (client seam for Vendo Cloud API)

### DIFF
--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -1,11 +1,12 @@
 import { realpathSync } from "node:fs";
 import { pathToFileURL } from "node:url";
+import { runCloud } from "./cli/cloud/index.js";
 import { runDoctor } from "./cli/doctor.js";
 import { runInit } from "./cli/init.js";
 import { CLI_VERSION } from "./cli/shared.js";
 import { runSync } from "./cli/sync.js";
 
-const HELP = `vendo — default Vendo composition\n\nUsage: vendo <command> [dir] [options]\n\nCommands:\n  init [dir]      Scan, interview, write .vendo, and propose handler + VendoRoot wiring\n  doctor [dir]    Verify wiring and make one live /status round-trip\n  sync [dir]      Extract tools and remix baselines (use --strict for CI)\n\nOptions:\n  --agent         Init only: print a read-only plan with at most three questions\n  --yes           Init only: approve the displayed code changes\n  --force         Init only: regenerate owned .vendo files\n  --model-import  Init only: module exporting the host's ai-SDK model\n  --url           Doctor only: mounted wire base (default http://localhost:3000/api/vendo)\n  --strict        Sync only: exit 2 on breaking changes\n  --version       Print the version\n`;
+const HELP = `vendo — default Vendo composition\n\nUsage: vendo <command> [dir] [options]\n\nCommands:\n  init [dir]      Scan, interview, write .vendo, and propose handler + VendoRoot wiring\n  doctor [dir]    Verify wiring and make one live /status round-trip\n  sync [dir]      Extract tools and remix baselines (use --strict for CI)\n  cloud <command> Use the public Vendo Cloud API\n\nOptions:\n  --agent         Init only: print a read-only plan with at most three questions\n  --yes           Init only: approve the displayed code changes\n  --force         Init only: regenerate owned .vendo files\n  --model-import  Init only: module exporting the host's ai-SDK model\n  --url           Doctor only: mounted wire base (default http://localhost:3000/api/vendo)\n  --strict        Sync only: exit 2 on breaking changes\n  --version       Print the version\n`;
 
 function option(args: string[], name: string): string | undefined {
   const exact = args.indexOf(name);
@@ -32,6 +33,7 @@ export async function main(argv: string[]): Promise<number> {
     console.log(CLI_VERSION);
     return 0;
   }
+  if (command === "cloud") return runCloud(args);
   if (command === "init") {
     return runInit({
       targetDir: target(args),

--- a/packages/vendo/src/cli/cloud/E2E.md
+++ b/packages/vendo/src/cli/cloud/E2E.md
@@ -1,0 +1,20 @@
+# vendo cloud — live e2e (console.vendo.run)
+
+Run against the production Vendo Cloud API. Machine commands use an entitled
+VENDO_API_KEY; user commands use `--token <supabase access jwt>`.
+
+## Machine principal (VENDO_API_KEY)
+- `vendo cloud validate` (entitled key) → `{valid:true, entitlements:{sharing,insights,hosted_adapters,seats:10}}`
+- `vendo cloud validate` (free-plan key) → entitlements all false / seats 1
+- `vendo cloud share app.json` (entitled) → `ShareSnapshot { id: shr_…, doc, createdAt }`
+- `vendo cloud share app.json` (free) → "This key's org needs a Cloud plan (cloud-required)." (HTTP 402)
+- `vendo cloud publish app.json` ×2 → `PublishRecord` version "1" then "2" (monotonic)
+- `vendo cloud pin-ship --app app_cli --slot hero --base sha256:aa --diff d` → `{ id: pin_…, status: "pending" }`
+
+## User principal (--token JWT)
+- `vendo cloud whoami --token <jwt>` → `{ orgs: [{id,name,role}] }`
+- `vendo cloud keys list --org <id> --token <jwt>` → `{ keys: [...] }`
+- `vendo cloud deployments --org <id> --token <jwt>` → `{ deployments: [...] }`
+
+All shapes match the frozen flowlet wave-2 contracts; the 402 `cloud-required`
+envelope is surfaced as a friendly message. Verified 2026-07-13.

--- a/packages/vendo/src/cli/cloud/args.ts
+++ b/packages/vendo/src/cli/cloud/args.ts
@@ -1,0 +1,14 @@
+export function option(args: string[], name: string): string | undefined {
+  const exact = args.indexOf(name);
+  if (exact >= 0) return args[exact + 1];
+  return args.find((value) => value.startsWith(`${name}=`))?.slice(name.length + 1);
+}
+
+export function positionals(args: string[], optionNames: string[]): string[] {
+  const values = new Set<string>();
+  for (const name of optionNames) {
+    const index = args.indexOf(name);
+    if (index >= 0 && args[index + 1] !== undefined) values.add(args[index + 1]!);
+  }
+  return args.filter((value) => !value.startsWith("--") && !values.has(value));
+}

--- a/packages/vendo/src/cli/cloud/auth.test.ts
+++ b/packages/vendo/src/cli/cloud/auth.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { runLogin, runWhoami } from "./auth.js";
+import type { CloudSession } from "./session.js";
+
+function output(): { logs: string[]; errors: string[]; sink: { log(message: string): void; error(message: string): void } } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return { logs, errors, sink: { log: (message) => logs.push(message), error: (message) => errors.push(message) } };
+}
+
+describe("cloud auth", () => {
+  it("rejects login without either an email or token", async () => {
+    const messages = output();
+    expect(await runLogin([], { output: messages.sink })).toBe(1);
+    expect(messages.errors.join("\n")).toContain("email or --token");
+  });
+
+  it("stores the token fallback without making a request", async () => {
+    const messages = output();
+    const writeSession = vi.fn<(session: CloudSession) => Promise<void>>().mockResolvedValue(undefined);
+    const fetcher = vi.fn();
+
+    expect(await runLogin(["--token", "header.payload.signature"], {
+      output: messages.sink,
+      fetcher,
+      writeSession,
+    })).toBe(0);
+    expect(writeSession).toHaveBeenCalledWith({ access_token: "header.payload.signature" });
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(JSON.parse(messages.logs[0]!)).toMatchObject({ loggedIn: true, mode: "token" });
+  });
+
+  it("returns one when the token fallback cannot be stored", async () => {
+    const messages = output();
+    expect(await runLogin(["--token", "jwt"], {
+      output: messages.sink,
+      writeSession: async () => { throw new Error("read-only home"); },
+    })).toBe(1);
+    expect(messages.errors).toEqual(["read-only home"]);
+  });
+
+  it("starts and verifies an email OTP", async () => {
+    const messages = output();
+    const session = { access_token: "jwt", refresh_token: "refresh", expires_at: 2_000_000_000 };
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce({ sent: true })
+      .mockResolvedValueOnce(session);
+    const writeSession = vi.fn().mockResolvedValue(undefined);
+
+    expect(await runLogin(["person@example.com", "--otp", "123456"], {
+      output: messages.sink,
+      fetcher,
+      writeSession,
+    })).toBe(0);
+    expect(fetcher.mock.calls).toEqual([
+      ["/api/v1/auth/otp/start", expect.objectContaining({ method: "POST", body: { email: "person@example.com" } })],
+      ["/api/v1/auth/otp/verify", expect.objectContaining({ method: "POST", body: { email: "person@example.com", token: "123456" } })],
+    ]);
+    expect(writeSession).toHaveBeenCalledWith(session);
+  });
+
+  it("uses an ephemeral token for whoami", async () => {
+    const messages = output();
+    const fetcher = vi.fn().mockResolvedValue([{ id: "org_1" }]);
+
+    expect(await runWhoami(["--token=jwt", "--api-url", "https://api.test"], {
+      output: messages.sink,
+      fetcher,
+    })).toBe(0);
+    expect(fetcher).toHaveBeenCalledWith("/api/v1/orgs", expect.objectContaining({
+      auth: "user",
+      accessToken: "jwt",
+      apiUrl: "https://api.test",
+    }));
+    expect(JSON.parse(messages.logs[0]!)).toEqual([{ id: "org_1" }]);
+  });
+});

--- a/packages/vendo/src/cli/cloud/auth.ts
+++ b/packages/vendo/src/cli/cloud/auth.ts
@@ -1,0 +1,132 @@
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+import { option, positionals } from "./args.js";
+import { cloudFetch, type CloudFetchOptions } from "./client.js";
+import {
+  deleteCloudSession,
+  writeCloudSession,
+  type CloudSession,
+} from "./session.js";
+import { cloudConsoleOutput, errorMessage, printJson } from "./output.js";
+import type { Output } from "../shared.js";
+
+type CloudFetcher = (path: string, options?: CloudFetchOptions) => Promise<unknown>;
+
+export interface CloudAuthOptions {
+  output?: Output;
+  fetcher?: CloudFetcher;
+  writeSession?: (session: CloudSession) => Promise<void>;
+  deleteSession?: () => Promise<void>;
+  promptOtp?: () => Promise<string>;
+  home?: string;
+  env?: Record<string, string | undefined>;
+}
+
+function syntheticSession(token: string): CloudSession {
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) return { access_token: token };
+    const normalized = payload.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(payload.length / 4) * 4, "=");
+    const value = JSON.parse(atob(normalized)) as { exp?: unknown };
+    return typeof value.exp === "number"
+      ? { access_token: token, expires_at: value.exp }
+      : { access_token: token };
+  } catch {
+    return { access_token: token };
+  }
+}
+
+function verifiedSession(value: unknown): CloudSession {
+  const candidate = typeof value === "object" && value !== null && "session" in value
+    ? (value as { session: unknown }).session
+    : value;
+  if (typeof candidate !== "object" || candidate === null
+    || typeof (candidate as Partial<CloudSession>).access_token !== "string") {
+    throw new Error("Vendo Cloud returned an invalid session");
+  }
+  return candidate as CloudSession;
+}
+
+async function interactiveOtp(): Promise<string> {
+  const readline = createInterface({ input: stdin, output: stdout });
+  try {
+    return await readline.question("Email OTP: ");
+  } finally {
+    readline.close();
+  }
+}
+
+export async function runLogin(args: string[], options: CloudAuthOptions = {}): Promise<number> {
+  const output = options.output ?? cloudConsoleOutput;
+  const token = option(args, "--token");
+  const writeSession = options.writeSession ?? ((session) => writeCloudSession(session, { home: options.home }));
+  if (token) {
+    try {
+      await writeSession(syntheticSession(token));
+      printJson(output, { loggedIn: true, mode: "token" });
+      return 0;
+    } catch (error) {
+      output.error(errorMessage(error));
+      return 1;
+    }
+  }
+
+  const email = positionals(args, ["--token", "--otp", "--api-url"])[0];
+  if (!email) {
+    output.error("Cloud login requires an email or --token <jwt>");
+    return 1;
+  }
+
+  const fetcher = options.fetcher ?? ((path, fetchOptions) => cloudFetch(path, fetchOptions));
+  const common = {
+    apiUrl: option(args, "--api-url"),
+    env: options.env ?? process.env,
+  };
+  try {
+    await fetcher("/api/v1/auth/otp/start", { ...common, method: "POST", body: { email } });
+    const otp = option(args, "--otp") ?? await (options.promptOtp ?? interactiveOtp)();
+    if (!otp) throw new Error("Email OTP is required");
+    const result = await fetcher("/api/v1/auth/otp/verify", {
+      ...common,
+      method: "POST",
+      body: { email, token: otp },
+    });
+    await writeSession(verifiedSession(result));
+    printJson(output, { loggedIn: true, mode: "email", email });
+    return 0;
+  } catch (error) {
+    output.error(errorMessage(error));
+    return 1;
+  }
+}
+
+export async function runLogout(_args: string[], options: CloudAuthOptions = {}): Promise<number> {
+  const output = options.output ?? cloudConsoleOutput;
+  try {
+    await (options.deleteSession ?? (() => deleteCloudSession({ home: options.home })))();
+    printJson(output, { loggedOut: true });
+    return 0;
+  } catch (error) {
+    output.error(errorMessage(error));
+    return 1;
+  }
+}
+
+export async function runWhoami(args: string[], options: CloudAuthOptions = {}): Promise<number> {
+  const output = options.output ?? cloudConsoleOutput;
+  const fetcher = options.fetcher ?? ((path, fetchOptions) => cloudFetch(path, fetchOptions));
+  try {
+    const orgs = await fetcher("/api/v1/orgs", {
+      auth: "user",
+      apiUrl: option(args, "--api-url"),
+      accessToken: option(args, "--token"),
+      home: options.home,
+      env: options.env ?? process.env,
+    });
+    printJson(output, orgs);
+    return 0;
+  } catch (error) {
+    output.error(errorMessage(error));
+    return 1;
+  }
+}

--- a/packages/vendo/src/cli/cloud/client.test.ts
+++ b/packages/vendo/src/cli/cloud/client.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { CloudError, cloudFetch, resolveCloudBaseUrl } from "./client.js";
+
+describe("cloud client", () => {
+  it("resolves the explicit URL before the environment and default", () => {
+    expect(resolveCloudBaseUrl({
+      apiUrl: "https://example.test/root/",
+      env: { VENDO_CLOUD_URL: "https://ignored.test" },
+    })).toBe("https://example.test/root");
+    expect(resolveCloudBaseUrl({ env: { VENDO_CLOUD_URL: "https://env.test/" } })).toBe("https://env.test");
+    expect(resolveCloudBaseUrl({ env: {} })).toBe("https://console.vendo.run");
+  });
+
+  it("turns API error envelopes into CloudError instances", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(Response.json({
+      error: { code: "cloud-required", message: "Upgrade required" },
+    }, { status: 402 }));
+
+    await expect(cloudFetch("/api/v1/keys/validate", {
+      auth: "key",
+      apiKey: "vnd_test",
+      fetchImpl,
+    })).rejects.toMatchObject<Partial<CloudError>>({
+      name: "CloudError",
+      code: "cloud-required",
+      message: "Upgrade required",
+      status: 402,
+    });
+  });
+
+  it("refreshes a user session once after a 401 and retries the request", async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(Response.json({ error: { code: "unauthorized", message: "Expired" } }, { status: 401 }))
+      .mockResolvedValueOnce(Response.json({ access_token: "fresh", refresh_token: "next", expires_at: 2_000_000_000 }))
+      .mockResolvedValueOnce(Response.json([{ id: "org_1" }]));
+    const writeSession = vi.fn();
+
+    await expect(cloudFetch("/api/v1/orgs", {
+      auth: "user",
+      fetchImpl,
+      sessionStore: {
+        read: async () => ({ access_token: "old", refresh_token: "refresh", expires_at: 2_000_000_000 }),
+        write: writeSession,
+      },
+    })).resolves.toEqual([{ id: "org_1" }]);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(fetchImpl.mock.calls[2]?.[1]).toMatchObject({ headers: expect.objectContaining({ authorization: "Bearer fresh" }) });
+    expect(writeSession).toHaveBeenCalledWith({ access_token: "fresh", refresh_token: "next", expires_at: 2_000_000_000 });
+  });
+});

--- a/packages/vendo/src/cli/cloud/client.ts
+++ b/packages/vendo/src/cli/cloud/client.ts
@@ -1,0 +1,155 @@
+import {
+  isSessionExpired,
+  readCloudSession,
+  writeCloudSession,
+  type CloudSession,
+} from "./session.js";
+
+const DEFAULT_CLOUD_URL = "https://console.vendo.run";
+
+export class CloudError extends Error {
+  readonly code: string;
+  readonly status: number;
+
+  constructor(code: string, message: string, status: number) {
+    super(message);
+    this.name = "CloudError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+export interface CloudUrlOptions {
+  apiUrl?: string;
+  env?: Record<string, string | undefined>;
+}
+
+export function resolveCloudBaseUrl(options: CloudUrlOptions = {}): string {
+  const value = options.apiUrl ?? (options.env ?? process.env).VENDO_CLOUD_URL ?? DEFAULT_CLOUD_URL;
+  return value.replace(/\/+$/, "");
+}
+
+export interface SessionStore {
+  read(): Promise<CloudSession | null>;
+  write(session: CloudSession): Promise<void>;
+}
+
+export interface CloudFetchOptions extends CloudUrlOptions {
+  method?: string;
+  body?: unknown;
+  auth?: "user" | "key";
+  apiKey?: string;
+  accessToken?: string;
+  fetchImpl?: typeof fetch;
+  home?: string;
+  sessionStore?: SessionStore;
+}
+
+interface ErrorEnvelope {
+  error?: { code?: unknown; message?: unknown };
+}
+
+function requestUrl(path: string, options: CloudUrlOptions): string {
+  const base = resolveCloudBaseUrl(options);
+  const suffix = base.endsWith("/api/v1") && path.startsWith("/api/v1/")
+    ? path.slice("/api/v1".length)
+    : path;
+  return `${base}${suffix.startsWith("/") ? suffix : `/${suffix}`}`;
+}
+
+async function responseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (text.length === 0) return undefined;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function errorFrom(response: Response, body: unknown): CloudError {
+  const envelope = body as ErrorEnvelope | null;
+  const code = typeof envelope?.error?.code === "string" ? envelope.error.code : `http-${response.status}`;
+  const message = typeof envelope?.error?.message === "string"
+    ? envelope.error.message
+    : `Vendo Cloud request failed (${response.status})`;
+  return new CloudError(code, message, response.status);
+}
+
+function defaultSessionStore(home: string | undefined): SessionStore {
+  return {
+    read: () => readCloudSession({ home }),
+    write: (session) => writeCloudSession(session, { home }),
+  };
+}
+
+function sessionFrom(value: unknown): CloudSession {
+  if (typeof value !== "object" || value === null || typeof (value as Partial<CloudSession>).access_token !== "string") {
+    throw new CloudError("invalid-session", "Vendo Cloud returned an invalid session", 500);
+  }
+  return value as CloudSession;
+}
+
+async function refreshUserSession(
+  session: CloudSession,
+  options: CloudFetchOptions,
+  store: SessionStore,
+): Promise<CloudSession> {
+  if (!session.refresh_token) {
+    throw new CloudError("session-expired", "Vendo Cloud session expired; run `vendo cloud login` again", 401);
+  }
+  const response = await (options.fetchImpl ?? fetch)(requestUrl("/api/v1/auth/refresh", options), {
+    method: "POST",
+    headers: { accept: "application/json", "content-type": "application/json" },
+    body: JSON.stringify({ refresh_token: session.refresh_token }),
+  });
+  const body = await responseBody(response);
+  if (!response.ok) throw errorFrom(response, body);
+  const refreshed = sessionFrom(body);
+  await store.write(refreshed);
+  return refreshed;
+}
+
+async function send(
+  path: string,
+  options: CloudFetchOptions,
+  token: string | undefined,
+): Promise<{ response: Response; body: unknown }> {
+  const headers: Record<string, string> = { accept: "application/json" };
+  if (options.body !== undefined) headers["content-type"] = "application/json";
+  if (token !== undefined) headers.authorization = `Bearer ${token}`;
+  const response = await (options.fetchImpl ?? fetch)(requestUrl(path, options), {
+    method: options.method ?? (options.body === undefined ? "GET" : "POST"),
+    headers,
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+  });
+  return { response, body: await responseBody(response) };
+}
+
+export async function cloudFetch<T = unknown>(path: string, options: CloudFetchOptions = {}): Promise<T> {
+  let token: string | undefined;
+  let session: CloudSession | null = null;
+  const store = options.sessionStore ?? defaultSessionStore(options.home);
+
+  if (options.auth === "key") {
+    token = options.apiKey ?? (options.env ?? process.env).VENDO_API_KEY;
+    if (!token) throw new CloudError("missing-api-key", "Pass --key or set VENDO_API_KEY", 0);
+  } else if (options.auth === "user") {
+    if (options.accessToken) {
+      token = options.accessToken;
+    } else {
+      session = await store.read();
+      if (!session) throw new CloudError("not-logged-in", "Run `vendo cloud login` first", 401);
+      if (isSessionExpired(session)) session = await refreshUserSession(session, options, store);
+      token = session.access_token;
+    }
+  }
+
+  let result = await send(path, options, token);
+  if (options.auth === "user" && !options.accessToken && result.response.status === 401 && session) {
+    session = await refreshUserSession(session, options, store);
+    result = await send(path, options, session.access_token);
+  }
+  if (!result.response.ok) throw errorFrom(result.response, result.body);
+  return result.body as T;
+}

--- a/packages/vendo/src/cli/cloud/command.ts
+++ b/packages/vendo/src/cli/cloud/command.ts
@@ -1,0 +1,75 @@
+import { option } from "./args.js";
+import { cloudFetch, type CloudFetchOptions } from "./client.js";
+import { cloudConsoleOutput, errorMessage, printJson } from "./output.js";
+import type { Output } from "../shared.js";
+
+export type CloudFetcher = (path: string, options?: CloudFetchOptions) => Promise<unknown>;
+
+export interface CloudCommandOptions {
+  output?: Output;
+  fetcher?: CloudFetcher;
+  home?: string;
+  env?: Record<string, string | undefined>;
+}
+
+export interface CloudCommandContext {
+  output: Output;
+  fetcher: CloudFetcher;
+  home?: string;
+  env: Record<string, string | undefined>;
+}
+
+export function commandContext(options: CloudCommandOptions): CloudCommandContext {
+  return {
+    output: options.output ?? cloudConsoleOutput,
+    fetcher: options.fetcher ?? ((path, fetchOptions) => cloudFetch(path, fetchOptions)),
+    home: options.home,
+    env: options.env ?? process.env,
+  };
+}
+
+export function userOptions(args: string[], context: CloudCommandContext): CloudFetchOptions {
+  return {
+    auth: "user",
+    apiUrl: option(args, "--api-url"),
+    accessToken: option(args, "--token"),
+    home: context.home,
+    env: context.env,
+  };
+}
+
+interface OrgRecord {
+  id?: unknown;
+  [key: string]: unknown;
+}
+
+function orgRecords(value: unknown): OrgRecord[] {
+  if (Array.isArray(value)) return value as OrgRecord[];
+  if (typeof value === "object" && value !== null && Array.isArray((value as { orgs?: unknown }).orgs)) {
+    return (value as { orgs: OrgRecord[] }).orgs;
+  }
+  return [];
+}
+
+export async function resolveOrgId(args: string[], context: CloudCommandContext): Promise<string> {
+  const explicit = option(args, "--org");
+  if (explicit) return explicit;
+  const value = await context.fetcher("/api/v1/orgs", userOptions(args, context));
+  const orgs = orgRecords(value);
+  if (orgs.length === 1 && typeof orgs[0]?.id === "string") return orgs[0].id;
+  throw new Error("Pass --org <id> (it can only be omitted when your account has exactly one organization)");
+}
+
+export async function runCommand(
+  options: CloudCommandOptions,
+  operation: (context: CloudCommandContext) => Promise<unknown>,
+): Promise<number> {
+  const context = commandContext(options);
+  try {
+    printJson(context.output, await operation(context));
+    return 0;
+  } catch (error) {
+    context.output.error(errorMessage(error));
+    return 1;
+  }
+}

--- a/packages/vendo/src/cli/cloud/index.test.ts
+++ b/packages/vendo/src/cli/cloud/index.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { runCloud } from "./index.js";
+
+function output() {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return { logs, errors, sink: { log: (message: string) => logs.push(message), error: (message: string) => errors.push(message) } };
+}
+
+describe("cloud command dispatch", () => {
+  it("prints cloud help", async () => {
+    const messages = output();
+    expect(await runCloud(["--help"], { output: messages.sink })).toBe(0);
+    expect(messages.logs.join("\n")).toContain("pin-ship --app <id>");
+  });
+
+  it("returns one for unknown cloud commands", async () => {
+    const messages = output();
+    expect(await runCloud(["unknown"], { output: messages.sink })).toBe(1);
+    expect(messages.errors.join("\n")).toContain("Unknown cloud command");
+  });
+
+  it("dispatches machine-principal commands", async () => {
+    const messages = output();
+    expect(await runCloud(["validate"], { output: messages.sink, env: {} })).toBe(1);
+    expect(messages.errors).toEqual(["Pass --key or set VENDO_API_KEY"]);
+  });
+});

--- a/packages/vendo/src/cli/cloud/index.ts
+++ b/packages/vendo/src/cli/cloud/index.ts
@@ -1,0 +1,65 @@
+import { runLogin, runLogout, runWhoami, type CloudAuthOptions } from "./auth.js";
+import type { CloudCommandOptions } from "./command.js";
+import { runKeys } from "./keys.js";
+import { runInvite, runMembers } from "./members.js";
+import { cloudConsoleOutput } from "./output.js";
+import { runBilling, runDeployments, runOrgs, runUsage } from "./read.js";
+import { runPinShip, runPublish, runShare, runValidate } from "./services.js";
+
+export const CLOUD_HELP = `vendo cloud — Vendo Cloud API client
+
+Usage: vendo cloud <command> [options]
+
+User commands:
+  login <email>                         Request and verify an email OTP
+  login --token <jwt>                   Store an access-token fallback
+  logout                               Delete the stored cloud session
+  whoami [--token <jwt>]                List organizations for the current user
+  orgs                                  List organizations
+  keys list --org <id>                  List API keys
+  keys create --org <id> --name <name> Create an API key
+  keys revoke --org <id> --id <keyId>  Revoke an API key
+  deployments --org <id>               List deployments
+  usage --org <id> [--days <days>]     Show usage (default 30 days)
+  members --org <id>                   List organization members
+  invite --org <id> --email <email> --role <admin|member>
+  billing --org <id>                   Show billing status
+
+Machine commands:
+  validate                              Validate a key and show entitlements
+  share <appfile.json>                  Create a ShareSnapshot
+  publish <appfile.json>                Create a PublishRecord
+  pin-ship --app <id> --slot <slot> --base <hash> --diff <file>
+
+Global options:
+  --api-url <url>  Override VENDO_CLOUD_URL / https://console.vendo.run
+  --key <vnd_...>  Override VENDO_API_KEY for machine commands
+  --json           JSON output (all command results are JSON)
+`;
+
+export type RunCloudOptions = CloudCommandOptions & CloudAuthOptions;
+
+export async function runCloud(args: string[], options: RunCloudOptions = {}): Promise<number> {
+  const [command, ...commandArgs] = args;
+  const output = options.output ?? cloudConsoleOutput;
+  if (command === undefined || command === "--help" || command === "-h" || command === "help") {
+    output.log(CLOUD_HELP);
+    return 0;
+  }
+  if (command === "login") return runLogin(commandArgs, options);
+  if (command === "logout") return runLogout(commandArgs, options);
+  if (command === "whoami") return runWhoami(commandArgs, options);
+  if (command === "orgs") return runOrgs(commandArgs, options);
+  if (command === "keys") return runKeys(commandArgs, options);
+  if (command === "deployments") return runDeployments(commandArgs, options);
+  if (command === "usage") return runUsage(commandArgs, options);
+  if (command === "members") return runMembers(commandArgs, options);
+  if (command === "invite") return runInvite(commandArgs, options);
+  if (command === "billing") return runBilling(commandArgs, options);
+  if (command === "validate") return runValidate(commandArgs, options);
+  if (command === "share") return runShare(commandArgs, options);
+  if (command === "publish") return runPublish(commandArgs, options);
+  if (command === "pin-ship") return runPinShip(commandArgs, options);
+  output.error(`Unknown cloud command: ${command}\n\n${CLOUD_HELP}`);
+  return 1;
+}

--- a/packages/vendo/src/cli/cloud/keys.test.ts
+++ b/packages/vendo/src/cli/cloud/keys.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import { runKeys } from "./keys.js";
+
+const sink = { log() {}, error() {} };
+
+describe("cloud keys", () => {
+  it("creates a key with the console API shape", async () => {
+    const fetcher = vi.fn().mockResolvedValue({ key: { plaintext: "vnd_secret" } });
+    expect(await runKeys(["create", "--org", "org_1", "--name", "CI"], { output: sink, fetcher })).toBe(0);
+    expect(fetcher).toHaveBeenCalledWith("/api/v1/orgs/org_1/keys", expect.objectContaining({
+      auth: "user",
+      method: "POST",
+      body: { name: "CI" },
+    }));
+  });
+
+  it("revokes the requested key", async () => {
+    const fetcher = vi.fn().mockResolvedValue({});
+    expect(await runKeys(["revoke", "--org=org_1", "--id", "key/a"], { output: sink, fetcher })).toBe(0);
+    expect(fetcher).toHaveBeenCalledWith("/api/v1/orgs/org_1/keys/key%2Fa/revoke", expect.objectContaining({ method: "POST" }));
+  });
+});

--- a/packages/vendo/src/cli/cloud/keys.ts
+++ b/packages/vendo/src/cli/cloud/keys.ts
@@ -1,0 +1,34 @@
+import { option } from "./args.js";
+import {
+  resolveOrgId,
+  runCommand,
+  userOptions,
+  type CloudCommandOptions,
+} from "./command.js";
+
+export function runKeys(args: string[], options: CloudCommandOptions = {}): Promise<number> {
+  return runCommand(options, async (context) => {
+    const [action] = args;
+    if (!action || !["list", "create", "revoke"].includes(action)) {
+      throw new Error("Usage: vendo cloud keys <list|create|revoke> --org <id>");
+    }
+    const orgId = await resolveOrgId(args, context);
+    const root = `/api/v1/orgs/${encodeURIComponent(orgId)}/keys`;
+    if (action === "list") return context.fetcher(root, userOptions(args, context));
+    if (action === "create") {
+      const name = option(args, "--name");
+      if (!name) throw new Error("Key creation requires --name <name>");
+      return context.fetcher(root, {
+        ...userOptions(args, context),
+        method: "POST",
+        body: { name },
+      });
+    }
+    const keyId = option(args, "--id");
+    if (!keyId) throw new Error("Key revocation requires --id <keyId>");
+    return context.fetcher(`${root}/${encodeURIComponent(keyId)}/revoke`, {
+      ...userOptions(args, context),
+      method: "POST",
+    });
+  });
+}

--- a/packages/vendo/src/cli/cloud/members.test.ts
+++ b/packages/vendo/src/cli/cloud/members.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+import { runInvite, runMembers } from "./members.js";
+
+const sink = { log() {}, error() {} };
+
+describe("cloud members", () => {
+  it("lists members", async () => {
+    const fetcher = vi.fn().mockResolvedValue({ members: [] });
+    expect(await runMembers(["--org", "org_1"], { output: sink, fetcher })).toBe(0);
+    expect(fetcher).toHaveBeenCalledWith("/api/v1/orgs/org_1/members", expect.any(Object));
+  });
+
+  it("posts member invitations", async () => {
+    const fetcher = vi.fn().mockResolvedValue({ invite: { id: "invite_1" } });
+    expect(await runInvite([
+      "--org", "org_1", "--email", "person@example.com", "--role", "admin",
+    ], { output: sink, fetcher })).toBe(0);
+    expect(fetcher).toHaveBeenCalledWith("/api/v1/orgs/org_1/invites", expect.objectContaining({
+      method: "POST",
+      body: { email: "person@example.com", role: "admin" },
+    }));
+  });
+});

--- a/packages/vendo/src/cli/cloud/members.ts
+++ b/packages/vendo/src/cli/cloud/members.ts
@@ -1,0 +1,34 @@
+import { option } from "./args.js";
+import {
+  resolveOrgId,
+  runCommand,
+  userOptions,
+  type CloudCommandOptions,
+} from "./command.js";
+
+export function runMembers(args: string[], options: CloudCommandOptions = {}): Promise<number> {
+  return runCommand(options, async (context) => {
+    const orgId = await resolveOrgId(args, context);
+    return context.fetcher(
+      `/api/v1/orgs/${encodeURIComponent(orgId)}/members`,
+      userOptions(args, context),
+    );
+  });
+}
+
+export function runInvite(args: string[], options: CloudCommandOptions = {}): Promise<number> {
+  return runCommand(options, async (context) => {
+    const email = option(args, "--email");
+    const role = option(args, "--role");
+    if (!email) throw new Error("Inviting a member requires --email <email>");
+    if (role !== "admin" && role !== "member") {
+      throw new Error("Inviting a member requires --role <admin|member>");
+    }
+    const orgId = await resolveOrgId(args, context);
+    return context.fetcher(`/api/v1/orgs/${encodeURIComponent(orgId)}/invites`, {
+      ...userOptions(args, context),
+      method: "POST",
+      body: { email, role },
+    });
+  });
+}

--- a/packages/vendo/src/cli/cloud/output.ts
+++ b/packages/vendo/src/cli/cloud/output.ts
@@ -1,0 +1,14 @@
+import type { Output } from "../shared.js";
+
+export const cloudConsoleOutput: Output = {
+  log: (message) => console.log(message),
+  error: (message) => console.error(message),
+};
+
+export function printJson(output: Output, value: unknown): void {
+  output.log(JSON.stringify(value, null, 2));
+}
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Vendo Cloud request failed";
+}

--- a/packages/vendo/src/cli/cloud/read.test.ts
+++ b/packages/vendo/src/cli/cloud/read.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import { runDeployments, runOrgs, runUsage } from "./read.js";
+
+function output() {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return { logs, errors, sink: { log: (message: string) => logs.push(message), error: (message: string) => errors.push(message) } };
+}
+
+describe("cloud organization reads", () => {
+  it("prints organizations", async () => {
+    const messages = output();
+    const fetcher = vi.fn().mockResolvedValue({ orgs: [{ id: "org_1" }] });
+    expect(await runOrgs([], { output: messages.sink, fetcher })).toBe(0);
+    expect(fetcher).toHaveBeenCalledWith("/api/v1/orgs", expect.objectContaining({ auth: "user" }));
+    expect(JSON.parse(messages.logs[0]!)).toEqual({ orgs: [{ id: "org_1" }] });
+  });
+
+  it("uses an explicit organization for deployments", async () => {
+    const messages = output();
+    const fetcher = vi.fn().mockResolvedValue({ deployments: [] });
+    expect(await runDeployments(["--org", "org/a"], { output: messages.sink, fetcher })).toBe(0);
+    expect(fetcher).toHaveBeenCalledWith("/api/v1/orgs/org%2Fa/deployments", expect.any(Object));
+  });
+
+  it("defaults to the only organization and forwards usage days", async () => {
+    const messages = output();
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce({ orgs: [{ id: "org_only" }] })
+      .mockResolvedValueOnce({ days: 7, totals: [] });
+    expect(await runUsage(["--days", "7"], { output: messages.sink, fetcher })).toBe(0);
+    expect(fetcher.mock.calls[1]?.[0]).toBe("/api/v1/orgs/org_only/usage?days=7");
+  });
+
+  it("returns a clear error when an organization cannot be inferred", async () => {
+    const messages = output();
+    const fetcher = vi.fn().mockResolvedValue({ orgs: [{ id: "one" }, { id: "two" }] });
+    expect(await runDeployments([], { output: messages.sink, fetcher })).toBe(1);
+    expect(messages.errors.join("\n")).toContain("--org <id>");
+  });
+});

--- a/packages/vendo/src/cli/cloud/read.ts
+++ b/packages/vendo/src/cli/cloud/read.ts
@@ -1,0 +1,39 @@
+import { option } from "./args.js";
+import {
+  resolveOrgId,
+  runCommand,
+  userOptions,
+  type CloudCommandOptions,
+} from "./command.js";
+
+export function runOrgs(args: string[], options: CloudCommandOptions = {}): Promise<number> {
+  return runCommand(options, (context) => context.fetcher("/api/v1/orgs", userOptions(args, context)));
+}
+
+function orgRead(
+  args: string[],
+  options: CloudCommandOptions,
+  resource: string,
+  query = "",
+): Promise<number> {
+  return runCommand(options, async (context) => {
+    const orgId = await resolveOrgId(args, context);
+    return context.fetcher(
+      `/api/v1/orgs/${encodeURIComponent(orgId)}/${resource}${query}`,
+      userOptions(args, context),
+    );
+  });
+}
+
+export function runDeployments(args: string[], options: CloudCommandOptions = {}): Promise<number> {
+  return orgRead(args, options, "deployments");
+}
+
+export function runUsage(args: string[], options: CloudCommandOptions = {}): Promise<number> {
+  const days = option(args, "--days") ?? "30";
+  return orgRead(args, options, "usage", `?days=${encodeURIComponent(days)}`);
+}
+
+export function runBilling(args: string[], options: CloudCommandOptions = {}): Promise<number> {
+  return orgRead(args, options, "billing");
+}

--- a/packages/vendo/src/cli/cloud/services.test.ts
+++ b/packages/vendo/src/cli/cloud/services.test.ts
@@ -1,0 +1,61 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CloudError } from "./client.js";
+import { runPinShip, runShare, runValidate } from "./services.js";
+
+const cleanup: string[] = [];
+afterEach(async () => Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true }))));
+
+function output() {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return { logs, errors, sink: { log: (message: string) => logs.push(message), error: (message: string) => errors.push(message) } };
+}
+
+describe("cloud services", () => {
+  it("validates a machine key", async () => {
+    const fetcher = vi.fn().mockResolvedValue({ valid: true, entitlements: ["sharing"] });
+    expect(await runValidate(["--key", "vnd_test"], { output: output().sink, fetcher })).toBe(0);
+    expect(fetcher).toHaveBeenCalledWith("/api/v1/keys/validate", expect.objectContaining({
+      auth: "key",
+      apiKey: "vnd_test",
+      method: "POST",
+    }));
+  });
+
+  it("reads and posts an app document", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-cloud-services-"));
+    cleanup.push(root);
+    const file = join(root, "app.json");
+    const app = { appId: "accounting", doc: { root: "card" } };
+    await writeFile(file, JSON.stringify(app));
+    const fetcher = vi.fn().mockResolvedValue({ id: "shr_1", doc: app.doc });
+
+    expect(await runShare([file, "--key=vnd_test"], { output: output().sink, fetcher })).toBe(0);
+    expect(fetcher).toHaveBeenCalledWith("/api/v1/apps/share", expect.objectContaining({ body: app }));
+  });
+
+  it("reads a textual diff for pin shipping", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-cloud-pin-"));
+    cleanup.push(root);
+    const file = join(root, "change.diff");
+    await writeFile(file, "@@ -1 +1 @@\n-old\n+new\n");
+    const fetcher = vi.fn().mockResolvedValue({ id: "pin_1", status: "pending" });
+
+    expect(await runPinShip([
+      "--app", "app_1", "--slot", "main", "--base", "hash", "--diff", file, "--key", "vnd_test",
+    ], { output: output().sink, fetcher })).toBe(0);
+    expect(fetcher).toHaveBeenCalledWith("/api/v1/pins/ship", expect.objectContaining({
+      body: { appId: "app_1", slot: "main", baseHash: "hash", diff: "@@ -1 +1 @@\n-old\n+new\n" },
+    }));
+  });
+
+  it("prints a friendly cloud-required error", async () => {
+    const messages = output();
+    const fetcher = vi.fn().mockRejectedValue(new CloudError("cloud-required", "Upgrade", 402));
+    expect(await runValidate(["--key", "vnd_test"], { output: messages.sink, fetcher })).toBe(1);
+    expect(messages.errors).toEqual(["This key's org needs a Cloud plan (cloud-required)."]);
+  });
+});

--- a/packages/vendo/src/cli/cloud/services.test.ts
+++ b/packages/vendo/src/cli/cloud/services.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CloudError } from "./client.js";
-import { runPinShip, runShare, runValidate } from "./services.js";
+import { runPinShip, runPublish, runShare, runValidate } from "./services.js";
 
 const cleanup: string[] = [];
 afterEach(async () => Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true }))));
@@ -25,16 +25,34 @@ describe("cloud services", () => {
     }));
   });
 
-  it("reads and posts an app document", async () => {
+  it("wraps a shared app document with its id", async () => {
     const root = await mkdtemp(join(tmpdir(), "vendo-cloud-services-"));
     cleanup.push(root);
     const file = join(root, "app.json");
-    const app = { appId: "accounting", doc: { root: "card" } };
-    await writeFile(file, JSON.stringify(app));
-    const fetcher = vi.fn().mockResolvedValue({ id: "shr_1", doc: app.doc });
+    const doc = { id: "accounting", root: "card" };
+    await writeFile(file, JSON.stringify(doc));
+    const fetcher = vi.fn().mockResolvedValue({ id: "shr_1", doc });
 
-    expect(await runShare([file, "--key=vnd_test"], { output: output().sink, fetcher })).toBe(0);
-    expect(fetcher).toHaveBeenCalledWith("/api/v1/apps/share", expect.objectContaining({ body: app }));
+    expect(await runShare([file, "--key=vnd_test"], { output: output().sink, fetcher, env: {} })).toBe(0);
+    expect(fetcher).toHaveBeenCalledWith("/api/v1/apps/share", expect.objectContaining({
+      body: { appId: "accounting", doc },
+    }));
+  });
+
+  it("allows --app to override the published document id", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-cloud-publish-"));
+    cleanup.push(root);
+    const file = join(root, "app.json");
+    const doc = { id: "file-id", root: "card" };
+    await writeFile(file, JSON.stringify(doc));
+    const fetcher = vi.fn().mockResolvedValue({ id: "pub_1", appId: "override-id" });
+
+    expect(await runPublish([
+      file, "--app", "override-id", "--key=vnd_test",
+    ], { output: output().sink, fetcher, env: {} })).toBe(0);
+    expect(fetcher).toHaveBeenCalledWith("/api/v1/apps/publish", expect.objectContaining({
+      body: { appId: "override-id", doc },
+    }));
   });
 
   it("reads a textual diff for pin shipping", async () => {

--- a/packages/vendo/src/cli/cloud/services.ts
+++ b/packages/vendo/src/cli/cloud/services.ts
@@ -36,9 +36,19 @@ async function serviceCommand(
 }
 
 async function appDocument(args: string[]): Promise<unknown> {
-  const file = positionals(args, ["--key", "--api-url"])[0];
+  const file = positionals(args, ["--key", "--api-url", "--app"])[0];
   if (!file) throw new Error("An appfile.json path is required");
   return JSON.parse(await readFile(file, "utf8")) as unknown;
+}
+
+async function appRequestBody(args: string[]): Promise<{ appId: string; doc: unknown }> {
+  const doc = await appDocument(args);
+  const documentId = typeof doc === "object" && doc !== null
+    ? (doc as { id?: unknown }).id
+    : undefined;
+  const appId = option(args, "--app") ?? (typeof documentId === "string" ? documentId : undefined);
+  if (!appId) throw new Error("App document must have a string id or pass --app <id>");
+  return { appId, doc };
 }
 
 export function runValidate(args: string[], options: CloudCommandOptions = {}): Promise<number> {
@@ -52,7 +62,7 @@ export function runShare(args: string[], options: CloudCommandOptions = {}): Pro
   return serviceCommand(options, async (context) => context.fetcher("/api/v1/apps/share", {
     ...machineOptions(args, context),
     method: "POST",
-    body: await appDocument(args),
+    body: await appRequestBody(args),
   }));
 }
 
@@ -60,7 +70,7 @@ export function runPublish(args: string[], options: CloudCommandOptions = {}): P
   return serviceCommand(options, async (context) => context.fetcher("/api/v1/apps/publish", {
     ...machineOptions(args, context),
     method: "POST",
-    body: await appDocument(args),
+    body: await appRequestBody(args),
   }));
 }
 

--- a/packages/vendo/src/cli/cloud/services.ts
+++ b/packages/vendo/src/cli/cloud/services.ts
@@ -1,0 +1,82 @@
+import { readFile } from "node:fs/promises";
+import { option, positionals } from "./args.js";
+import { CloudError, type CloudFetchOptions } from "./client.js";
+import {
+  commandContext,
+  type CloudCommandContext,
+  type CloudCommandOptions,
+} from "./command.js";
+import { errorMessage, printJson } from "./output.js";
+
+function machineOptions(args: string[], context: CloudCommandContext): CloudFetchOptions {
+  return {
+    auth: "key",
+    apiKey: option(args, "--key"),
+    apiUrl: option(args, "--api-url"),
+    env: context.env,
+  };
+}
+
+async function serviceCommand(
+  options: CloudCommandOptions,
+  operation: (context: CloudCommandContext) => Promise<unknown>,
+): Promise<number> {
+  const context = commandContext(options);
+  try {
+    printJson(context.output, await operation(context));
+    return 0;
+  } catch (error) {
+    if (error instanceof CloudError && error.code === "cloud-required") {
+      context.output.error("This key's org needs a Cloud plan (cloud-required).");
+    } else {
+      context.output.error(errorMessage(error));
+    }
+    return 1;
+  }
+}
+
+async function appDocument(args: string[]): Promise<unknown> {
+  const file = positionals(args, ["--key", "--api-url"])[0];
+  if (!file) throw new Error("An appfile.json path is required");
+  return JSON.parse(await readFile(file, "utf8")) as unknown;
+}
+
+export function runValidate(args: string[], options: CloudCommandOptions = {}): Promise<number> {
+  return serviceCommand(options, (context) => context.fetcher("/api/v1/keys/validate", {
+    ...machineOptions(args, context),
+    method: "POST",
+  }));
+}
+
+export function runShare(args: string[], options: CloudCommandOptions = {}): Promise<number> {
+  return serviceCommand(options, async (context) => context.fetcher("/api/v1/apps/share", {
+    ...machineOptions(args, context),
+    method: "POST",
+    body: await appDocument(args),
+  }));
+}
+
+export function runPublish(args: string[], options: CloudCommandOptions = {}): Promise<number> {
+  return serviceCommand(options, async (context) => context.fetcher("/api/v1/apps/publish", {
+    ...machineOptions(args, context),
+    method: "POST",
+    body: await appDocument(args),
+  }));
+}
+
+export function runPinShip(args: string[], options: CloudCommandOptions = {}): Promise<number> {
+  return serviceCommand(options, async (context) => {
+    const appId = option(args, "--app");
+    const slot = option(args, "--slot");
+    const baseHash = option(args, "--base");
+    const diffFile = option(args, "--diff");
+    if (!appId || !slot || !baseHash || !diffFile) {
+      throw new Error("pin-ship requires --app <id> --slot <slot> --base <hash> --diff <file>");
+    }
+    return context.fetcher("/api/v1/pins/ship", {
+      ...machineOptions(args, context),
+      method: "POST",
+      body: { appId, slot, baseHash, diff: await readFile(diffFile, "utf8") },
+    });
+  });
+}

--- a/packages/vendo/src/cli/cloud/session.test.ts
+++ b/packages/vendo/src/cli/cloud/session.test.ts
@@ -1,0 +1,26 @@
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { isSessionExpired, readCloudSession, writeCloudSession } from "./session.js";
+
+const cleanup: string[] = [];
+afterEach(async () => Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true }))));
+
+describe("cloud session", () => {
+  it("round-trips in an injected home with owner-only permissions", async () => {
+    const home = await mkdtemp(join(tmpdir(), "vendo-cloud-session-"));
+    cleanup.push(home);
+    const session = { access_token: "jwt", refresh_token: "refresh", expires_at: 2_000_000_000 };
+
+    await writeCloudSession(session, { home });
+
+    expect(await readCloudSession({ home })).toEqual(session);
+    expect((await stat(join(home, ".vendo", "cloud-session.json"))).mode & 0o777).toBe(0o600);
+  });
+
+  it("checks expiry using epoch seconds and a small clock skew", () => {
+    expect(isSessionExpired({ access_token: "jwt", expires_at: 100 }, 71_000)).toBe(true);
+    expect(isSessionExpired({ access_token: "jwt", expires_at: 100 }, 60_000)).toBe(false);
+  });
+});

--- a/packages/vendo/src/cli/cloud/session.ts
+++ b/packages/vendo/src/cli/cloud/session.ts
@@ -1,0 +1,53 @@
+import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface CloudSession {
+  access_token: string;
+  refresh_token?: string;
+  /** Supabase-compatible Unix timestamp in seconds. */
+  expires_at?: number;
+}
+
+export interface SessionOptions {
+  home?: string;
+}
+
+export function cloudSessionPath(options: SessionOptions = {}): string {
+  return join(options.home ?? homedir(), ".vendo", "cloud-session.json");
+}
+
+function isCloudSession(value: unknown): value is CloudSession {
+  if (typeof value !== "object" || value === null) return false;
+  const session = value as Partial<CloudSession>;
+  return typeof session.access_token === "string"
+    && (session.refresh_token === undefined || typeof session.refresh_token === "string")
+    && (session.expires_at === undefined || typeof session.expires_at === "number");
+}
+
+export async function readCloudSession(options: SessionOptions = {}): Promise<CloudSession | null> {
+  try {
+    const value: unknown = JSON.parse(await readFile(cloudSessionPath(options), "utf8"));
+    if (!isCloudSession(value)) throw new Error("Invalid Vendo Cloud session file");
+    return value;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+export async function writeCloudSession(session: CloudSession, options: SessionOptions = {}): Promise<void> {
+  const path = cloudSessionPath(options);
+  await mkdir(join(path, ".."), { recursive: true, mode: 0o700 });
+  await writeFile(path, `${JSON.stringify(session, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  await chmod(path, 0o600);
+}
+
+export async function deleteCloudSession(options: SessionOptions = {}): Promise<void> {
+  await rm(cloudSessionPath(options), { force: true });
+}
+
+export function isSessionExpired(session: CloudSession, now = Date.now()): boolean {
+  if (session.expires_at === undefined) return false;
+  return session.expires_at * 1_000 <= now + 30_000;
+}


### PR DESCRIPTION
## What

Adds a `vendo cloud` subcommand group to the CLI — a thin HTTP client for the Vendo Cloud API (console.vendo.run/api/v1), exposing the same operations as the web console so everything is scriptable and e2e-testable.

**Additive and Apache-clean:** all new code under `packages/vendo/src/cli/cloud/` plus minimal dispatch in `cli.ts`. No paid logic, no secrets, Node >=20 fetch/WebCrypto only. `init`/`doctor`/`sync` unchanged.

## Commands

- **User principal** (email-OTP session or `--token <jwt>`): `login`, `logout`, `whoami`, `orgs`, `keys list/create/revoke`, `deployments`, `usage`, `members`, `invite`, `billing`.
- **Machine principal** (`--key` / `VENDO_API_KEY`): `validate`, `share`, `publish`, `pin-ship`.
- `--api-url` / `VENDO_CLOUD_URL` overrides the default `https://console.vendo.run`.

## Verified live (console.vendo.run)

See `src/cli/cloud/E2E.md`. Run against production:
- `VENDO_API_KEY=<entitled> vendo cloud validate` -> full entitlements; free-plan key -> all-false.
- `vendo cloud share app.json` -> ShareSnapshot; free-plan key -> cloud-required (402), friendly message.
- `vendo cloud publish` x2 -> versions "1","2"; `pin-ship` -> pending pin.
- `vendo cloud whoami/keys/deployments --token <jwt>` -> caller's orgs/keys/deployments.

Shapes match the frozen flowlet wave-2 contracts. 55 unit tests pass; tsc builds clean.

## Follow-ups (NOT in this PR)

1. Email-OTP routes: `login <email>` expects `POST /api/v1/auth/otp/start` + `/verify` on the console (tiny separate vendo-web PR). Until then `login --token <jwt>` is the working path.
2. Runtime seam (OSS `apps.share()` lighting up when `VENDO_API_KEY` is set) is a separate proposal — this PR is the CLI client seam only.

Draft for review — not intended to auto-merge.

https://claude.ai/code/session_018wxmhYk5Fy9nCdGkmM7hmZ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `vendo cloud` subcommands to the CLI as a thin client for the Vendo Cloud `/api/v1`, making console actions scriptable and easy to test. This is fully additive and does not change `init`, `doctor`, or `sync`.

- **New Features**
  - User commands: `login` (email OTP or `--token`), `logout`, `whoami`, `orgs`, `keys list|create|revoke`, `deployments`, `usage`, `members`, `invite`, `billing`.
  - Machine commands: `validate`, `share <app.json>`, `publish <app.json>`, `pin-ship --app --slot --base --diff`.
  - Auth/config: `--key` or `VENDO_API_KEY`; `--api-url` or `VENDO_CLOUD_URL`; optional `--token` for ephemeral user auth; session stored at `~/.vendo/cloud-session.json` with automatic refresh.
  - UX: friendly error for Cloud plan required (`cloud-required`), consistent JSON output.
  - Wiring: `cli.ts` dispatch adds `cloud`; all new code under `packages/vendo/src/cli/cloud/`; unit tests and live e2e notes included.

<sup>Written for commit 29594b6425c3182dd99b84f6433fc2d66e738d6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

