### PR TITLE
Permanent cross-block integration suite: real composed umbrella, whole-product journeys, required CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,30 @@ jobs:
       - run: pnpm test
       - run: pnpm typecheck
       - run: pnpm lint
+
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # Build only the workspace deps the two integration suites need (the `...`
+      # suffix pulls each fixture package's transitive workspace deps).
+      - run: pnpm turbo run build --filter=@vendoai-fixtures/integration... --filter=@vendoai-fixtures/integration-browser...
+      # The node suite boots the real composed umbrella over HTTP against the host app.
+      - run: pnpm --filter @vendoai-fixtures/integration test
+      # The browser leg drives the shipped hooks/chrome in Chromium against the same wire.
+      - run: pnpm --filter @vendoai-fixtures/integration-browser exec playwright install --with-deps chromium
+      - run: pnpm --filter @vendoai-fixtures/integration-browser test:browser
+      - if: failure()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: integration-browser-playwright-trace
+          path: fixtures/integration-browser/e2e/test-results
+          if-no-files-found: ignore
+          retention-days: 7

--- a/docs/superpowers/plans/2026-07-12-cross-block-integration-suite.md
+++ b/docs/superpowers/plans/2026-07-12-cross-block-integration-suite.md
@@ -1,0 +1,123 @@
+# Cross-Block Integration Suite (fixtures/integration) — Wave Plan
+
+**Goal:** A permanent, CI-required integration suite that boots the REAL composed
+umbrella (`createVendo` from `@vendoai/vendo`) against the fixture host app and
+drives whole-product user journeys end-to-end through the public wire and hooks,
+asserting real side effects. Wave-4 and composition each found latent bugs that
+block-local tests missed (5 and 8 respectively); this suite makes that class of
+bug a standing CI catch instead of a per-wave discovery.
+
+**Why this is different from every existing fixture suite:** chat-e2e,
+automations-e2e, mcp-e2e, and redteam all compose blocks BY HAND ("the way the
+umbrella will compose them"). Nothing on main tests the actual composition —
+`createVendo` + its wire — with the blocks unstubbed. `packages/vendo/server.test.ts`
+stubs block methods (routing coverage) and runs exactly one real chat turn.
+
+**Scope discipline:** additive only — `fixtures/integration` + a CI job. Frozen
+contracts (docs/contracts) are law and are NOT modified. Real cross-block bugs
+found by the suite are fixed in the owning block, each with a permanent
+regression test here.
+
+---
+
+## Design decisions (locked)
+
+1. **The composition under test is `createVendo` itself.** No hand-wiring of
+   store/guard/actions/apps/automations in the harness. The harness passes only
+   what a real host passes: model, principal resolver, store (temp-dir PGlite for
+   isolation), actAs, policy.
+2. **Host tools load through the real `.vendo/` contract.** The fixture package
+   commits `.vendo/tools.json` (`vendo/tools@1`, route bindings against the
+   fixture host app) and a `.vendo/policy.json`. `createVendo` reads them from
+   cwd via `createActions({dir: "."})` — a load path no composed test exercises
+   today. `VENDO_BASE_URL` points route bindings at the booted host app
+   (trusted-origin branch).
+3. **Journeys drive real HTTP.** The umbrella handler is served on a loopback
+   `node:http` server (adapter pattern already proven in fixtures/mcp-e2e);
+   tests hit it with `fetch`/SSE — the public wire, not `handler()` in-process
+   shortcuts. Side-effect asserts: raw SQL on the public `vendo_*` tables
+   (02 §table-map is contract), host-app HTTP state, and wire GETs.
+4. **Deterministic model, zero live keys in CI.** The chat-e2e `scriptedModel`
+   pattern (`MockLanguageModelV3` from `ai/test`) drives both agent turns and the
+   apps generation engine (which consumes the same `LanguageModel` via
+   `generateText`). Generation turns return the CREATE/EDIT dialect JSON shapes
+   from `packages/apps/src/engine.ts`.
+5. **MCP door composes around the umbrella the way a host must today.** The
+   `createVendo({mcp:true})` hookup (docs/contracts/10-mcp-umbrella-hookup.md) is
+   an unlanded handoff gated on a Yousef naming decision, so the suite mounts
+   `createMcpDoor` beside `vendo.handler` on the same loopback origin, fed from
+   the umbrella's own composed parts (guard-bound registry, guard, store,
+   AppsPort over `vendo.apps`). When the hookup lands, the harness collapses to
+   the one flag and the journeys stay valid.
+6. **UI journey = real browser.** A minimal Vite harness page mounts
+   `VendoRoot`/hooks (`useVendoThread`, `useApprovals`, `useApps`) proxying
+   `/api/vendo` to the loopback wire server; Playwright Chromium drives it
+   (pattern proven in packages/ui/playwright.config.ts: ephemeral port,
+   workers 1, retries 0). Chat send → approval card → decide → side effect.
+7. **Flake discipline is a merge gate.** `fileParallelism: false`, generous
+   suite timeouts per the CI-hardened fixture patterns, no test retries. The
+   full suite must pass ≥5 consecutive full runs locally before the PR merges.
+8. **CI job.** A dedicated `integration` job in `.github/workflows/ci.yml`
+   (install → turbo-scoped build of deps → run the suite; Playwright Chromium
+   installed for the browser leg). The suite also runs inside the existing
+   `ci` job via root `pnpm test` (fixtures are workspace members); the dedicated
+   job gives it a required named check. Branch-protection required-check added
+   if API permissions allow, else flagged to Yousef.
+
+## The journeys (each = one permanent regression test file)
+
+- **J1 chat-generates-app:** POST /threads turn → scripted agent calls the
+  `vendo_apps_create` capability tool → generation returns a valid
+  `vendo-genui/v1` tree → SSE completes → `vendo_apps` row (SQL), GET /apps,
+  GET /apps/:id/open returns the tree payload.
+- **J2 destructive approval round-trip:** chat turn calls a destructive host
+  tool → decision pipeline parks it → GET /approvals shows `inputPreview` →
+  POST /approvals/decide (approve + remember) → resumption executes the real
+  HTTP call against the host app → host state changed, audit rows, grant row
+  minted; a second turn runs grant-authorized without asking.
+- **J3 app edit + history:** POST /apps/:id/edit with scripted EDIT-dialect
+  response → EditResult; history lists two versions; POST history undo restores.
+- **J4 automation lifecycle:** automation app enters through the public wire
+  (POST /apps/import of a built .vendoapp with a trigger — fresh id minted) →
+  POST /automations/:id/enable → `{enabled, missing}` → decide approvals →
+  standing app-bound `source:"automation"` grants (SQL) → fire the trigger both
+  ways that are public (POST /tick with bearer for schedule; `vendo.emit` for
+  host-event) → away run executes steps against the host app via `actAs` →
+  GET /runs shows ok with steps, host side effect real.
+- **J5 away-run grant capture + park + revoke:** away step on an ungranted tool
+  parks the run `pending-approval` (fails soft) → approval queues → decide →
+  run resumes ok. DELETE /grants/:id → next firing parks again (revocation is
+  live). Chat-minted grants must NOT authorize away (05 §6) — asserted through
+  the composed wire, not block-local.
+- **J6 MCP door round-trip:** real MCP SDK client: 401 → WWW-Authenticate →
+  path-inserted metadata discovery → OAuth (fixture HostOAuthAdapter over the
+  host app's login) → initialize → tools/list (descriptors = bound registry
+  verbatim) → tools/call (read runs; destructive returns in-band isError naming
+  the approval) → SQL: `venue='mcp'` audit + door-auth events. Apps ride-along:
+  `vendo_apps_open` returns the J1-style app's payload with the ui `_meta`.
+- **J7 UI hooks in a real browser:** VendoRoot page → useVendoThread send →
+  stream renders → useApprovals surfaces the parked call → decide in-page →
+  host side effect; useApps lists the generated app.
+
+## Execution (per hardening-execution-model.md)
+
+Fable orchestrates; ALL implementation on Claude Opus subagent lanes (or Codex
+lanes) — never Fable. Orchestrator runs installs, stages, commits, gates.
+
+- **Lane A (first):** package scaffold, `.vendo/` files, global-setup (host-app
+  boot with own FIXTURE_DIST_DIR + wire server helper), scripted-model support,
+  J1 + J2 + J3.
+- **Lane B (after A):** J4 + J5 + J6.
+- **Lane C (after A, parallel with B):** J7 browser leg + CI workflow job.
+- **Bug-fix lanes:** any real cross-block bug → fix in the owning block +
+  regression test in this suite. Contracts stay frozen.
+- **Verification:** root gates green; new suite ≥5 consecutive green full runs;
+  Codex review + adversarial self-pass; external reviewers triaged; PR to main
+  (baseRefName=main); autonomous merge on the full done-definition.
+
+## Non-goals
+
+- No `createVendo({mcp:true})` hookup (Yousef-gated naming decision; flagged).
+- No live-model legs (existing env-gated live suites already cover those).
+- No re-proving block-local behavior already pinned by chat-e2e /
+  automations-e2e / mcp-e2e / redteam — this suite owns the *composed* system.

--- a/fixtures/host-app/tsconfig.json
+++ b/fixtures/host-app/tsconfig.json
@@ -45,7 +45,10 @@
     ".next/redteam-e2e/dev/types/**/*.ts",
     ".next/redteam-e2e/dev/dev/types/**/*.ts",
     ".next/integration-e2e/dev/types/**/*.ts",
-    ".next/integration-e2e/dev/dev/types/**/*.ts"
+    ".next/integration-e2e/dev/dev/types/**/*.ts",
+    ".next/integration-browser/dev/types/**/*.ts",
+    ".next/integration-browser/dev/dev/types/**/*.ts",
+    ".next/integration-browser/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/fixtures/host-app/tsconfig.json
+++ b/fixtures/host-app/tsconfig.json
@@ -43,7 +43,9 @@
     ".next/mcp-e2e/dev/types/**/*.ts",
     ".next/mcp-e2e/dev/dev/types/**/*.ts",
     ".next/redteam-e2e/dev/types/**/*.ts",
-    ".next/redteam-e2e/dev/dev/types/**/*.ts"
+    ".next/redteam-e2e/dev/dev/types/**/*.ts",
+    ".next/integration-e2e/dev/types/**/*.ts",
+    ".next/integration-e2e/dev/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/fixtures/integration-browser/.gitignore
+++ b/fixtures/integration-browser/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+e2e/test-results/
+.vendo-data/

--- a/fixtures/integration-browser/.vendo/policy.json
+++ b/fixtures/integration-browser/.vendo/policy.json
@@ -1,0 +1,8 @@
+{
+  "format": "vendo/policy@1",
+  "rules": [
+    { "match": { "risk": "destructive" }, "action": "ask" },
+    { "match": { "risk": "read" }, "action": "run" },
+    { "match": { "risk": "write" }, "action": "run" }
+  ]
+}

--- a/fixtures/integration-browser/.vendo/tools.json
+++ b/fixtures/integration-browser/.vendo/tools.json
@@ -1,0 +1,62 @@
+{
+  "format": "vendo/tools@1",
+  "tools": [
+    {
+      "name": "host_invoices_list",
+      "description": "List invoices",
+      "inputSchema": { "type": "object" },
+      "risk": "read",
+      "binding": { "kind": "route", "method": "GET", "path": "/api/invoices", "argsIn": "query" }
+    },
+    {
+      "name": "host_invoices_get",
+      "description": "Get one invoice by id",
+      "inputSchema": { "type": "object" },
+      "risk": "read",
+      "binding": { "kind": "route", "method": "GET", "path": "/api/invoices/{id}", "argsIn": "query" }
+    },
+    {
+      "name": "host_customers_list",
+      "description": "List customers",
+      "inputSchema": { "type": "object" },
+      "risk": "read",
+      "binding": { "kind": "route", "method": "GET", "path": "/api/customers", "argsIn": "query" }
+    },
+    {
+      "name": "host_invoices_create",
+      "description": "Create an invoice",
+      "inputSchema": { "type": "object" },
+      "risk": "write",
+      "binding": { "kind": "route", "method": "POST", "path": "/api/invoices", "argsIn": "body" }
+    },
+    {
+      "name": "host_invoices_update",
+      "description": "Update an invoice",
+      "inputSchema": { "type": "object" },
+      "risk": "write",
+      "binding": { "kind": "route", "method": "PATCH", "path": "/api/invoices/{id}", "argsIn": "body" }
+    },
+    {
+      "name": "host_invoices_send",
+      "description": "Send an invoice",
+      "inputSchema": { "type": "object" },
+      "risk": "write",
+      "binding": { "kind": "route", "method": "POST", "path": "/api/invoices/{id}/send", "argsIn": "body" }
+    },
+    {
+      "name": "host_invoices_delete",
+      "description": "Delete an invoice (destructive)",
+      "inputSchema": { "type": "object" },
+      "risk": "destructive",
+      "binding": { "kind": "route", "method": "DELETE", "path": "/api/invoices/{id}", "argsIn": "query" }
+    },
+    {
+      "name": "host_invoices_send_critical",
+      "description": "Send an invoice with a critical confirmation",
+      "inputSchema": { "type": "object" },
+      "risk": "write",
+      "critical": true,
+      "binding": { "kind": "route", "method": "POST", "path": "/api/invoices/{id}/send", "argsIn": "body" }
+    }
+  ]
+}

--- a/fixtures/integration-browser/e2e/harness/backends.ts
+++ b/fixtures/integration-browser/e2e/harness/backends.ts
@@ -1,0 +1,240 @@
+/** The REAL backends for the browser leg, booted ONCE inside the Vite config
+ * (Vite executes this TS natively — the packages/ui harness proves the pattern).
+ *
+ *   1. the fixture host app (`next dev`, its OWN FIXTURE_DIST_DIR so it can run
+ *      beside the sibling e2e suites under turbo without a dev-server lock fight),
+ *   2. the REAL composed umbrella — `createVendo` from `@vendoai/vendo/server` —
+ *      backed by a temp-dir PGlite store, reading host tools + policy from the
+ *      package's own committed `.vendo/` files (cwd), with route bindings pointed
+ *      at the booted host app via VENDO_BASE_URL (trusted-origin present forward),
+ *   3. a loopback node:http wire server that serves `vendo.handler` on the FULL
+ *      `/api/vendo/...` path (self-routing — the URL is forwarded verbatim, never
+ *      mount-relative) plus a small, obviously test-only control surface.
+ *
+ * Because Playwright's tests run in a different process from the model, the
+ * control surface (`/__test/*`) lets a spec enqueue scripted model turns, reset,
+ * and read authenticated host state before/while it drives the page. The Vite dev
+ * server proxies `/api/vendo` and `/__test` to this origin so the page's default
+ * same-origin baseUrl just works.
+ *
+ * PRESENT-call auth: the browser can't set a `cookie` header (forbidden) but it
+ * CAN send `x-vendo-test-user`. The wire server reads that principal header,
+ * logs the subject into the host app, and injects the resulting session cookie
+ * onto the forwarded request — so the composed actions layer forwards it to the
+ * host exactly as the node harness's `wireFetch` does (04 §4 present forwarding).
+ */
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer as createHttpServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { createServer as createNetServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Principal } from "@vendoai/core";
+import { createStore } from "@vendoai/store";
+import { createVendo } from "@vendoai/vendo/server";
+import { createControllableModel, expandTurn, type TurnSpec } from "./model.ts";
+
+const WIRE_BASE = "/api/vendo";
+const CONTROL_BASE = "/__test";
+const hostDir = fileURLToPath(new URL("../../../host-app/", import.meta.url));
+const nextBin = join(hostDir, "node_modules", ".bin", "next");
+
+async function freePort(): Promise<number> {
+  const probe = createNetServer();
+  await new Promise<void>((resolve, reject) => {
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      probe.off("error", reject);
+      resolve();
+    });
+  });
+  const address = probe.address();
+  if (!address || typeof address === "string") throw new Error("could not allocate a port");
+  const port = address.port;
+  await new Promise<void>((resolve, reject) => probe.close((error) => (error ? reject(error) : resolve())));
+  return port;
+}
+
+export interface Backends {
+  /** The wire origin the Vite proxy targets. */
+  wireUrl: string;
+  close(): Promise<void>;
+}
+
+export async function startBackends(): Promise<Backends> {
+  // --- 1. the fixture host app --------------------------------------------
+  const hostPort = await freePort();
+  const hostBaseUrl = `http://127.0.0.1:${hostPort}`;
+  let hostOutput = "";
+  const host: ChildProcessWithoutNullStreams = spawn(nextBin, ["dev", "-p", String(hostPort)], {
+    cwd: hostDir,
+    env: { ...process.env, NEXT_TELEMETRY_DISABLED: "1", FIXTURE_DIST_DIR: ".next/integration-browser" },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const record = (chunk: unknown) => {
+    hostOutput = `${hostOutput}${String(chunk)}`.slice(-20_000);
+  };
+  host.stdout.on("data", record);
+  host.stderr.on("data", record);
+
+  const deadline = Date.now() + 180_000;
+  for (;;) {
+    if (host.exitCode !== null) throw new Error(`host app exited early (${host.exitCode})\n${hostOutput}`);
+    try {
+      if ((await fetch(hostBaseUrl)).ok) break;
+    } catch {
+      // Next is still compiling.
+    }
+    if (Date.now() > deadline) throw new Error(`host app did not become ready\n${hostOutput}`);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  // --- 2. the composed umbrella -------------------------------------------
+  // Trusted-origin branch: an explicit VENDO_BASE_URL means present-call
+  // credentials forward to the host app. Set BEFORE createVendo reads it.
+  process.env.VENDO_BASE_URL = hostBaseUrl;
+  process.env.VENDO_TICK_SECRET ??= "integration-browser-tick-secret";
+
+  const cookieCache = new Map<string, string>();
+  const loginCookie = async (subject: string): Promise<string> => {
+    const cached = cookieCache.get(subject);
+    if (cached !== undefined) return cached;
+    const response = await fetch(`${hostBaseUrl}/api/login`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ user: subject }),
+    });
+    if (!response.ok) throw new Error(`host login failed (${response.status})`);
+    const cookie = response.headers.get("set-cookie")?.split(";")[0];
+    if (!cookie) throw new Error("host login did not return a cookie");
+    cookieCache.set(subject, cookie);
+    return cookie;
+  };
+
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-integration-browser-"));
+  const store = createStore({ dataDir });
+  await store.ensureSchema();
+  const scripted = createControllableModel();
+
+  const vendo = createVendo({
+    model: scripted.model,
+    principal: async (req) => {
+      const subject = req.headers.get("x-vendo-test-user");
+      return subject ? { kind: "user", subject } : null;
+    },
+    store,
+    actAs: async (principal: Principal) => ({ headers: { cookie: await loginCookie(principal.subject) } }),
+    policy: { file: ".vendo/policy.json" },
+  });
+
+  // --- 3. the loopback wire + control server ------------------------------
+  const httpServer = createHttpServer((req, res) => {
+    void handle(req, res).catch((error) => {
+      res.statusCode = 500;
+      res.setHeader("content-type", "text/plain");
+      res.end(error instanceof Error ? error.message : "wire bridge failed");
+    });
+  });
+
+  async function readBody(req: IncomingMessage): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    return Buffer.concat(chunks);
+  }
+
+  async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    if (url.pathname.startsWith(CONTROL_BASE)) return control(req, res, url);
+    if (url.pathname === WIRE_BASE || url.pathname.startsWith(`${WIRE_BASE}/`)) return wire(req, res);
+    res.statusCode = 404;
+    res.end("not found");
+  }
+
+  // The control surface is obviously test-only: enqueue scripted turns, reset,
+  // and read authenticated host state. It is NEVER mounted in product.
+  async function control(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
+    const sub = url.pathname.slice(CONTROL_BASE.length);
+    const respond = (body: unknown, status = 200) => {
+      res.statusCode = status;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify(body));
+    };
+
+    if (req.method === "POST" && sub === "/reset") {
+      scripted.reset();
+      await fetch(`${hostBaseUrl}/fixture/reset`, { method: "POST" });
+      return respond({ ok: true });
+    }
+    if (req.method === "POST" && sub === "/script") {
+      const body = JSON.parse((await readBody(req)).toString("utf8") || "{}") as { turns?: TurnSpec[] };
+      const turns = Array.isArray(body.turns) ? body.turns : [];
+      scripted.enqueue(turns.map(expandTurn));
+      return respond({ ok: true, enqueued: turns.length });
+    }
+    const invoice = /^\/host\/invoice\/(.+)$/.exec(sub);
+    if (req.method === "GET" && invoice) {
+      const response = await fetch(`${hostBaseUrl}/api/invoices/${invoice[1]}`, {
+        headers: { cookie: await loginCookie("user_ada") },
+      });
+      return respond({ exists: response.status === 200 });
+    }
+    return respond({ error: "unknown control route" }, 404);
+  }
+
+  // Forward the FULL /api/vendo/... path verbatim to the self-routing handler.
+  async function wire(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const body = ["GET", "HEAD"].includes(req.method ?? "GET") ? undefined : await readBody(req);
+    const headers = new Headers();
+    for (const [name, value] of Object.entries(req.headers)) {
+      if (value === undefined) continue;
+      headers.set(name, Array.isArray(value) ? value.join(", ") : value);
+    }
+    // Present-call auth: inject the host session cookie for the named principal
+    // so the composed actions layer forwards it to the host (04 §4).
+    const subject = headers.get("x-vendo-test-user");
+    if (subject) headers.set("cookie", await loginCookie(subject));
+    const request = new Request(`http://127.0.0.1${req.url ?? "/"}`, {
+      method: req.method,
+      headers,
+      ...(body === undefined || body.length === 0 ? {} : { body: new Uint8Array(body) }),
+    });
+    const response = await vendo.handler(request);
+    res.statusCode = response.status;
+    response.headers.forEach((value, name) => res.setHeader(name, value));
+    res.end(Buffer.from(await response.arrayBuffer()));
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once("error", reject);
+    httpServer.listen(0, "127.0.0.1", () => {
+      httpServer.off("error", reject);
+      resolve();
+    });
+  });
+  const address = httpServer.address();
+  if (!address || typeof address === "string") throw new Error("wire server did not bind a TCP port");
+  const wireUrl = `http://127.0.0.1:${address.port}`;
+
+  let closed = false;
+  const close = async (): Promise<void> => {
+    if (closed) return;
+    closed = true;
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    if (host.exitCode === null) {
+      host.kill("SIGTERM");
+      const exited = new Promise<void>((resolve) => host.once("exit", () => resolve()));
+      await Promise.race([exited, new Promise<void>((resolve) => setTimeout(resolve, 5_000))]);
+      if (host.exitCode === null) host.kill("SIGKILL");
+    }
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  };
+  // Vite kills this process on teardown; make sure the next child dies with it.
+  const onSignal = () => void close().finally(() => process.exit(0));
+  process.once("SIGTERM", onSignal);
+  process.once("SIGINT", onSignal);
+  process.once("exit", () => { if (host.exitCode === null) host.kill("SIGKILL"); });
+
+  return { wireUrl, close };
+}

--- a/fixtures/integration-browser/e2e/harness/index.html
+++ b/fixtures/integration-browser/e2e/harness/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <title>Vendo cross-block integration — browser harness</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.tsx"></script>
+  </body>
+</html>

--- a/fixtures/integration-browser/e2e/harness/main.tsx
+++ b/fixtures/integration-browser/e2e/harness/main.tsx
@@ -1,0 +1,59 @@
+/** The J7 page: the shipped Vendo React surface — `VendoRoot` + the chrome
+ *  `<VendoThread />` — plus a headless `useApps` probe, all driving the REAL
+ *  composed umbrella wire (proxied to the loopback server) same-origin.
+ *
+ *  The principal rides `x-vendo-test-user: user_ada` on the client headers; the
+ *  wire server resolves it to the principal AND injects the matching host session
+ *  cookie so present host-tool calls execute for real (04 §4).
+ */
+import { createVendoClient, useApps, VendoRoot } from "@vendoai/vendo/react";
+import { VendoThread } from "@vendoai/ui/chrome";
+import { createRoot } from "react-dom/client";
+
+const TEST_USER = "user_ada";
+
+const client = createVendoClient({
+  baseUrl: "/api/vendo",
+  headers: { "x-vendo-test-user": TEST_USER },
+});
+
+/** A minimal headless surface over `useApps` — proves the apps hook lists an app
+ *  the composed generation engine produced (the create call rides the same wire
+ *  and consumes a scripted generation turn). */
+function AppsProbe() {
+  const { apps, create } = useApps();
+  return (
+    <section aria-label="Apps probe" data-testid="apps-probe">
+      <h2>Apps</h2>
+      <button
+        type="button"
+        data-testid="apps-create"
+        onClick={() => void create("Build me a greeting card").catch(() => undefined)}
+      >
+        Create app
+      </button>
+      <ul data-testid="apps-list">
+        {apps.map((app) => (
+          <li key={app.id} data-app-id={app.id}>{app.name}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function Page() {
+  return (
+    <VendoRoot client={client}>
+      <main style={{ display: "grid", gap: 24, padding: 24, maxWidth: 900, margin: "0 auto" }}>
+        <section aria-label="Thread" data-testid="thread-surface" style={{ minHeight: 360 }}>
+          <VendoThread threadId="thr_j7" greeting="What can I help you build?" />
+        </section>
+        <AppsProbe />
+      </main>
+    </VendoRoot>
+  );
+}
+
+const root = document.getElementById("root");
+if (!root) throw new Error("browser harness root is missing");
+createRoot(root).render(<Page />);

--- a/fixtures/integration-browser/e2e/harness/model.ts
+++ b/fixtures/integration-browser/e2e/harness/model.ts
@@ -1,0 +1,121 @@
+/** A CONTROLLABLE scripted LanguageModel for the browser leg.
+ *
+ * Same technique as the node harness (fixtures/integration/src/harness.ts) — ONE
+ * model instance drives BOTH the agent loop (doStream) and the apps generation
+ * engine (doGenerate) off a single FIFO queue — but the queue is MUTABLE so the
+ * test (running in a separate process from the model) can enqueue turns over the
+ * wire server's `/__test/script` control endpoint before it drives the page.
+ *
+ * The control endpoint speaks a small high-level TurnSpec dialect (kind:"text" |
+ * "tool" | "generate") rather than raw stream parts, so tests stay legible and
+ * the JSON on the wire stays tiny; this module expands each spec into the exact
+ * LanguageModelV3 stream parts the composed system consumes.
+ */
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+
+type LanguageModelV3StreamPart = Awaited<
+  ReturnType<MockLanguageModelV3["doStream"]>
+>["stream"] extends ReadableStream<infer Part> ? Part : never;
+type LanguageModelV3GenerateResult = Awaited<ReturnType<MockLanguageModelV3["doGenerate"]>>;
+type LanguageModelV3Content = LanguageModelV3GenerateResult["content"][number];
+
+const ZERO_USAGE = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+} as const;
+
+/** A plain assistant text turn (agent doStream). */
+function textTurn(text: string, id = "text_1"): LanguageModelV3StreamPart[] {
+  return [
+    { type: "text-start", id },
+    { type: "text-delta", id, delta: text },
+    { type: "text-end", id },
+    { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
+  ];
+}
+
+/** An agent turn that calls one tool (agent doStream). */
+function toolCallTurn(
+  toolName: string,
+  input: unknown,
+  toolCallId = "call_1",
+): LanguageModelV3StreamPart[] {
+  return [
+    { type: "tool-call", toolCallId, toolName, input: JSON.stringify(input) },
+    { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "tool-calls", raw: undefined } },
+  ];
+}
+
+/** A generation-engine turn: the apps engine reads this through doGenerate and
+ *  parses the emitted text as CREATE/EDIT-dialect JSON (must be VALID). */
+function generationTurn(dialect: unknown, id = "gen_1"): LanguageModelV3StreamPart[] {
+  return [
+    { type: "text-start", id },
+    { type: "text-delta", id, delta: JSON.stringify(dialect) },
+    { type: "text-end", id },
+    { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
+  ];
+}
+
+/** The high-level control dialect the `/__test/script` endpoint accepts. */
+export type TurnSpec =
+  | { kind: "text"; text: string; id?: string }
+  | { kind: "tool"; name: string; input: unknown; toolCallId?: string }
+  | { kind: "generate"; dialect: unknown; id?: string };
+
+export function expandTurn(spec: TurnSpec): LanguageModelV3StreamPart[] {
+  switch (spec.kind) {
+    case "text":
+      return textTurn(spec.text, spec.id);
+    case "tool":
+      return toolCallTurn(spec.name, spec.input, spec.toolCallId);
+    case "generate":
+      return generationTurn(spec.dialect, spec.id);
+  }
+}
+
+export interface ControllableModel {
+  model: MockLanguageModelV3;
+  /** Append expanded turns to the shared FIFO queue. */
+  enqueue(turns: LanguageModelV3StreamPart[][]): void;
+  /** Drop every queued turn (between-journey reset). */
+  reset(): void;
+}
+
+export function createControllableModel(): ControllableModel {
+  const queue: LanguageModelV3StreamPart[][] = [];
+  const shift = (): LanguageModelV3StreamPart[] => {
+    const chunks = queue.shift();
+    if (chunks === undefined) throw new Error("scripted model exhausted");
+    return chunks;
+  };
+  const model = new MockLanguageModelV3({
+    doStream: async () => ({ stream: simulateReadableStream({ chunks: shift() }) }),
+    doGenerate: async (): Promise<LanguageModelV3GenerateResult> => {
+      const chunks = shift();
+      const finish = chunks.find((part) => part.type === "finish");
+      const content: LanguageModelV3Content[] = [];
+      const text = chunks
+        .filter((part): part is Extract<LanguageModelV3StreamPart, { type: "text-delta" }> => part.type === "text-delta")
+        .map((part) => part.delta)
+        .join("");
+      if (text.length > 0) content.push({ type: "text", text });
+      for (const part of chunks) if (part.type === "tool-call") content.push(structuredClone(part));
+      return {
+        content,
+        finishReason: finish?.finishReason ?? { unified: "stop", raw: undefined },
+        usage: finish?.usage ?? ZERO_USAGE,
+        warnings: [],
+      };
+    },
+  });
+  return {
+    model,
+    enqueue(turns) {
+      for (const turn of turns) queue.push([...turn]);
+    },
+    reset() {
+      queue.length = 0;
+    },
+  };
+}

--- a/fixtures/integration-browser/e2e/harness/vite.config.ts
+++ b/fixtures/integration-browser/e2e/harness/vite.config.ts
@@ -1,0 +1,35 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig, type ViteDevServer } from "vite";
+import { startBackends } from "./backends.ts";
+
+const harnessRoot = fileURLToPath(new URL(".", import.meta.url));
+
+/** J7 real-browser harness — the page runs against the REAL composed umbrella
+ *  wire and the booted fixture host app (both started in-process here). */
+export default defineConfig(async () => {
+  const backends = await startBackends();
+
+  return {
+    root: harnessRoot,
+    clearScreen: false,
+    server: {
+      host: "127.0.0.1",
+      // Ephemeral by default so parallel lanes never collide; playwright.config
+      // reserves a free port and passes it via env + the CLI --port flag.
+      port: Number(process.env.VENDO_HARNESS_PORT) || 4_273,
+      strictPort: true,
+      proxy: {
+        // No rewrite: the umbrella handler self-routes on the FULL /api/vendo/…
+        // path, so the mount prefix must survive to the wire.
+        "/api/vendo": { target: backends.wireUrl, changeOrigin: false },
+        "/__test": { target: backends.wireUrl, changeOrigin: false },
+      },
+    },
+    plugins: [{
+      name: "vendo-backends-lifecycle",
+      configureServer(server: ViteDevServer) {
+        server.httpServer?.once("close", () => void backends.close());
+      },
+    }],
+  };
+});

--- a/fixtures/integration-browser/e2e/journey.spec.ts
+++ b/fixtures/integration-browser/e2e/journey.spec.ts
@@ -1,0 +1,93 @@
+/** J7 — UI HOOKS IN A REAL BROWSER, end to end through the composed umbrella.
+ *
+ * The shipped `VendoRoot` + `<VendoThread />` chrome and a `useApps` probe drive
+ * the REAL `createVendo` wire (proxied same-origin) against the booted fixture
+ * host app. One deterministic journey, no live keys:
+ *
+ *   1. send a chat message → the scripted assistant text streams and renders;
+ *   2. send a destructive-tool turn → the composed destructive-ask policy parks
+ *      it → the approval surfaces in-thread → click Approve → the resume executes
+ *      the REAL host DELETE (asserted by polling the host API) and the thread
+ *      shows completion;
+ *   3. the `useApps` surface lists the app a scripted generation turn produced.
+ *
+ * This is the first time the shipped hooks/chrome talk to the actual composed
+ * wire (every other browser suite runs against a hand-built wire fixture) — a
+ * hooks-vs-wire mismatch would surface right here.
+ */
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const INVOICE = "inv_0003"; // ADA's seeded draft invoice
+const CREATE_DIALECT = {
+  name: "Ada's Greeting",
+  description: "A tiny greeting card",
+  tree: {
+    formatVersion: "vendo-genui/v1",
+    root: "root",
+    nodes: [
+      { id: "root", component: "Stack", source: "prewired", children: ["greeting"] },
+      { id: "greeting", component: "Text", source: "prewired", props: { text: "Hello Ada" } },
+    ],
+  },
+};
+
+async function script(request: APIRequestContext): Promise<void> {
+  await expect(async () => {
+    const reset = await request.post("/__test/reset");
+    expect(reset.ok()).toBeTruthy();
+  }).toPass({ timeout: 30_000 });
+  const scripted = await request.post("/__test/script", {
+    data: {
+      turns: [
+        { kind: "text", text: "Hi Ada, I'm ready to help.", id: "t_greet" },
+        { kind: "tool", name: "host_invoices_delete", input: { id: INVOICE }, toolCallId: "call_del" },
+        { kind: "text", text: "Deleted the invoice.", id: "t_done" },
+        { kind: "generate", dialect: CREATE_DIALECT },
+      ],
+    },
+  });
+  expect(scripted.ok()).toBeTruthy();
+}
+
+test("J7: chat streams, destructive approval executes for real, useApps lists the generated app", async ({ page, request }) => {
+  await script(request);
+  await page.goto("/");
+
+  const composer = page.getByRole("textbox", { name: /message/i });
+  await expect(composer).toBeVisible();
+
+  // --- 1. chat send → streamed assistant text renders ----------------------
+  await composer.fill("Hello");
+  await composer.press("Enter");
+  await expect(page.getByText("Hi Ada, I'm ready to help.")).toBeVisible();
+
+  // --- 2. destructive tool turn → in-thread approval parks -----------------
+  await expect(composer).toBeEnabled();
+  await composer.fill(`Delete invoice ${INVOICE}`);
+  await composer.press("Enter");
+
+  const approval = page.getByRole("article", { name: /Approval for host_invoices_delete/i });
+  await expect(approval).toBeVisible();
+  // The parked destructive call must NOT have executed yet.
+  await expect
+    .poll(async () => (await (await request.get(`/__test/host/invoice/${INVOICE}`)).json()).exists)
+    .toBe(true);
+
+  // Approve in-page → the resume executes the REAL host DELETE.
+  await approval.getByRole("button", { name: "Approve" }).click();
+
+  // UI reflects completion...
+  await expect(page.getByText("Deleted the invoice.")).toBeVisible();
+  await expect(page.getByText(/Tool: host_invoices_delete/i)).toBeVisible();
+  // ...and the REAL side effect landed on the host app.
+  await expect
+    .poll(async () => (await (await request.get(`/__test/host/invoice/${INVOICE}`)).json()).exists, {
+      timeout: 15_000,
+    })
+    .toBe(false);
+
+  // --- 3. useApps lists the app the generation turn produced ---------------
+  await page.getByTestId("apps-create").click();
+  const list = page.getByTestId("apps-list");
+  await expect(list.getByText("Ada's Greeting")).toBeVisible();
+});

--- a/fixtures/integration-browser/e2e/smoke.spec.ts
+++ b/fixtures/integration-browser/e2e/smoke.spec.ts
@@ -1,13 +1,22 @@
 /** A minimal smoke: the shipped Vendo React surface mounts against the composed
  *  wire and renders its chrome. Breadth belongs to the node suite — this only
- *  guards that the page boots and the wire is reachable same-origin. */
+ *  guards that the page boots and the wire actually round-trips same-origin. */
 import { expect, test } from "@playwright/test";
 
-test("the Vendo React surface mounts and reaches the composed wire", async ({ page }) => {
+test("the Vendo React surface mounts and reaches the composed wire", async ({ page, request }) => {
   await page.goto("/");
   // The thread chrome rendered its composer (empty-thread landing).
   await expect(page.getByRole("textbox", { name: /message/i })).toBeVisible();
-  // The useApps probe mounted and completed its GET /apps against the wire.
+  // The useApps probe mounted its create control.
   await expect(page.getByTestId("apps-probe")).toBeVisible();
   await expect(page.getByTestId("apps-create")).toBeVisible();
+
+  // Prove the WIRE round-tripped, not just that static JSX rendered: hit the same
+  // GET /apps the useApps hook drives (proxied same-origin to the composed
+  // umbrella, principal via the test-user header) and assert a REAL response —
+  // the composed server answered with the app list array (empty for a fresh
+  // owner). A dead/unreachable wire would 404/500 or fail to parse here.
+  const listed = await request.get("/api/vendo/apps", { headers: { "x-vendo-test-user": "user_ada" } });
+  expect(listed.ok()).toBeTruthy();
+  expect(Array.isArray(await listed.json())).toBe(true);
 });

--- a/fixtures/integration-browser/e2e/smoke.spec.ts
+++ b/fixtures/integration-browser/e2e/smoke.spec.ts
@@ -1,0 +1,13 @@
+/** A minimal smoke: the shipped Vendo React surface mounts against the composed
+ *  wire and renders its chrome. Breadth belongs to the node suite — this only
+ *  guards that the page boots and the wire is reachable same-origin. */
+import { expect, test } from "@playwright/test";
+
+test("the Vendo React surface mounts and reaches the composed wire", async ({ page }) => {
+  await page.goto("/");
+  // The thread chrome rendered its composer (empty-thread landing).
+  await expect(page.getByRole("textbox", { name: /message/i })).toBeVisible();
+  // The useApps probe mounted and completed its GET /apps against the wire.
+  await expect(page.getByTestId("apps-probe")).toBeVisible();
+  await expect(page.getByTestId("apps-create")).toBeVisible();
+});

--- a/fixtures/integration-browser/package.json
+++ b/fixtures/integration-browser/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@vendoai-fixtures/integration-browser",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Real-browser leg of the cross-block integration suite: Playwright Chromium drives @vendoai/vendo/react (VendoRoot + hooks/chrome) in a page against the REAL composed umbrella wire and the fixture host app.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "test:browser": "playwright test",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@vendoai/core": "workspace:*",
+    "@vendoai/store": "workspace:*",
+    "@vendoai/ui": "workspace:*",
+    "@vendoai/vendo": "workspace:*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
+    "ai": "^6.0.0",
+    "typescript": "^5.6.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/fixtures/integration-browser/playwright.config.ts
+++ b/fixtures/integration-browser/playwright.config.ts
@@ -1,0 +1,65 @@
+import { createServer } from "node:net";
+import type { AddressInfo } from "node:net";
+import { fileURLToPath } from "node:url";
+import { defineConfig, devices } from "@playwright/test";
+
+const packageRoot = fileURLToPath(new URL(".", import.meta.url));
+
+/**
+ * Reserve an ephemeral free port so concurrent hardening lanes never collide on
+ * the harness dev server. The OS hands back an unused port; a lane holds it only
+ * for the length of its run.
+ */
+async function freePort(): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const probe = createServer();
+    probe.unref();
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const { port } = probe.address() as AddressInfo;
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+// Reserve once, then pin into the environment so every re-evaluation of this
+// config (Playwright re-imports it per worker) and the vite child all agree on
+// the SAME port — otherwise baseURL and the dev server diverge.
+const port = Number(process.env.VENDO_HARNESS_PORT) || (await freePort());
+process.env.VENDO_HARNESS_PORT = String(port);
+const baseURL = `http://127.0.0.1:${port}`;
+
+/** 08-ui §4–5 — deterministic Chromium journey over the REAL composed umbrella. */
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: "**/*.spec.ts",
+  outputDir: "./e2e/test-results",
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  timeout: 30_000,
+  expect: { timeout: 7_500 },
+  reporter: [["line"]],
+  use: {
+    baseURL,
+    viewport: { width: 1_280, height: 900 },
+    colorScheme: "light",
+    locale: "en-US",
+    timezoneId: "America/Los_Angeles",
+    screenshot: "off",
+    trace: "retain-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"], channel: undefined } }],
+  webServer: [{
+    command: `pnpm exec vite --config e2e/harness/vite.config.ts --host 127.0.0.1 --port ${port}`,
+    cwd: packageRoot,
+    url: baseURL,
+    reuseExistingServer: false,
+    // The vite child boots the fixture host app (next dev, first compile) AND the
+    // composed umbrella before it listens — give it room.
+    timeout: 180_000,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { NO_COLOR: "1", VENDO_HARNESS_PORT: String(port) },
+  }],
+});

--- a/fixtures/integration-browser/tsconfig.json
+++ b/fixtures/integration-browser/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "types": ["node", "@playwright/test"]
+  },
+  "include": ["e2e/**/*.ts", "e2e/**/*.tsx"],
+  "exclude": ["node_modules", "e2e/harness/vite.config.ts", "e2e/test-results"]
+}

--- a/fixtures/integration/.vendo/policy.json
+++ b/fixtures/integration/.vendo/policy.json
@@ -1,0 +1,8 @@
+{
+  "format": "vendo/policy@1",
+  "rules": [
+    { "match": { "risk": "destructive" }, "action": "ask" },
+    { "match": { "risk": "read" }, "action": "run" },
+    { "match": { "risk": "write" }, "action": "run" }
+  ]
+}

--- a/fixtures/integration/.vendo/tools.json
+++ b/fixtures/integration/.vendo/tools.json
@@ -1,0 +1,62 @@
+{
+  "format": "vendo/tools@1",
+  "tools": [
+    {
+      "name": "host_invoices_list",
+      "description": "List invoices",
+      "inputSchema": { "type": "object" },
+      "risk": "read",
+      "binding": { "kind": "route", "method": "GET", "path": "/api/invoices", "argsIn": "query" }
+    },
+    {
+      "name": "host_invoices_get",
+      "description": "Get one invoice by id",
+      "inputSchema": { "type": "object" },
+      "risk": "read",
+      "binding": { "kind": "route", "method": "GET", "path": "/api/invoices/{id}", "argsIn": "query" }
+    },
+    {
+      "name": "host_customers_list",
+      "description": "List customers",
+      "inputSchema": { "type": "object" },
+      "risk": "read",
+      "binding": { "kind": "route", "method": "GET", "path": "/api/customers", "argsIn": "query" }
+    },
+    {
+      "name": "host_invoices_create",
+      "description": "Create an invoice",
+      "inputSchema": { "type": "object" },
+      "risk": "write",
+      "binding": { "kind": "route", "method": "POST", "path": "/api/invoices", "argsIn": "body" }
+    },
+    {
+      "name": "host_invoices_update",
+      "description": "Update an invoice",
+      "inputSchema": { "type": "object" },
+      "risk": "write",
+      "binding": { "kind": "route", "method": "PATCH", "path": "/api/invoices/{id}", "argsIn": "body" }
+    },
+    {
+      "name": "host_invoices_send",
+      "description": "Send an invoice",
+      "inputSchema": { "type": "object" },
+      "risk": "write",
+      "binding": { "kind": "route", "method": "POST", "path": "/api/invoices/{id}/send", "argsIn": "body" }
+    },
+    {
+      "name": "host_invoices_delete",
+      "description": "Delete an invoice (destructive)",
+      "inputSchema": { "type": "object" },
+      "risk": "destructive",
+      "binding": { "kind": "route", "method": "DELETE", "path": "/api/invoices/{id}", "argsIn": "query" }
+    },
+    {
+      "name": "host_invoices_send_critical",
+      "description": "Send an invoice with a critical confirmation",
+      "inputSchema": { "type": "object" },
+      "risk": "write",
+      "critical": true,
+      "binding": { "kind": "route", "method": "POST", "path": "/api/invoices/{id}/send", "argsIn": "body" }
+    }
+  ]
+}

--- a/fixtures/integration/package.json
+++ b/fixtures/integration/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@vendoai-fixtures/integration",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Permanent cross-block integration suite: boots the REAL composed umbrella (createVendo) against the fixture host app and drives whole-product user journeys through the public wire over real HTTP, asserting real side effects.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "test": "vitest run --passWithNoTests",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@vendoai/core": "workspace:*",
+    "@vendoai/store": "workspace:*",
+    "@vendoai/vendo": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "ai": "^6.0.0",
+    "fflate": "^0.8.2",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/fixtures/integration/package.json
+++ b/fixtures/integration/package.json
@@ -13,10 +13,12 @@
   },
   "dependencies": {
     "@vendoai/core": "workspace:*",
+    "@vendoai/mcp": "workspace:*",
     "@vendoai/store": "workspace:*",
     "@vendoai/vendo": "workspace:*"
   },
   "devDependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/node": "^22.0.0",
     "ai": "^6.0.0",
     "fflate": "^0.8.2",

--- a/fixtures/integration/src/app-edit.e2e.test.ts
+++ b/fixtures/integration/src/app-edit.e2e.test.ts
@@ -1,0 +1,103 @@
+/** J3 — APP EDIT + HISTORY through the composed wire.
+ *
+ * Create an app (POST /apps drives the generation engine's CREATE dialect), then
+ * edit it (POST /apps/:id/edit drives the EDIT-TREE dialect — a {ops:[...]} patch
+ * the composed engine applies and re-validates). The wire returns an EditResult;
+ * history surfaces the prior version; undo restores it.
+ *
+ * History note: the frozen history surface (06 §1) lists RESTORABLE prior
+ * snapshots (the undo targets), appended only on edit — so one edit yields
+ * exactly one entry (the original), and a single undo restores the original.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ADA,
+  createStack,
+  generationTurn,
+  resetFixture,
+  type Stack,
+} from "./harness.js";
+
+interface TreeNode {
+  id: string;
+  props?: { text?: string };
+}
+interface AppDoc {
+  id: string;
+  tree: { nodes: TreeNode[] };
+}
+
+const CREATE_DIALECT = {
+  name: "Greeting",
+  description: "A greeting card",
+  tree: {
+    formatVersion: "vendo-genui/v1",
+    root: "root",
+    nodes: [
+      { id: "root", component: "Stack", source: "prewired", children: ["greeting"] },
+      { id: "greeting", component: "Text", source: "prewired", props: { text: "Hello" } },
+    ],
+  },
+};
+
+// EDIT-TREE dialect: patch the greeting text. The instruction avoids the
+// engine's server-keyword heuristic so it routes to the tree (not code) dialect.
+const EDIT_DIALECT = {
+  ops: [{ op: "set-prop", nodeId: "greeting", prop: "text", value: "Goodbye" }],
+};
+
+const greetingText = (doc: AppDoc): string | undefined =>
+  doc.tree.nodes.find((node) => node.id === "greeting")?.props?.text;
+
+let stack: Stack;
+afterEach(async () => {
+  await stack?.close();
+});
+
+describe("J3: app edit + history through the composed wire", () => {
+  it("creates, edits via the tree dialect, lists the prior version, and undoes to restore it", async () => {
+    await resetFixture();
+    stack = await createStack({
+      turns: [generationTurn(CREATE_DIALECT), generationTurn(EDIT_DIALECT)],
+    });
+
+    // --- Create -----------------------------------------------------------
+    const created = (await (await stack.wireFetch("/apps", {
+      method: "POST",
+      body: JSON.stringify({ prompt: "Build a greeting card" }),
+    }, ADA)).json()) as AppDoc;
+    const appId = created.id;
+    expect(greetingText(created)).toBe("Hello");
+    expect(await stack.sql("SELECT id FROM vendo_apps WHERE subject = $1", [ADA.subject])).toHaveLength(1);
+
+    // --- Edit (tree dialect) ----------------------------------------------
+    const edited = (await (await stack.wireFetch(`/apps/${appId}/edit`, {
+      method: "POST",
+      body: JSON.stringify({ instruction: "Change the greeting text to Goodbye" }),
+    }, ADA)).json()) as { app: AppDoc; version: { rung: number } };
+    expect(edited.version.rung).toBe(1);
+    expect(greetingText(edited.app)).toBe("Goodbye");
+
+    // Current app now reads the edited text.
+    const current = (await (await stack.wireFetch(`/apps/${appId}`, {}, ADA)).json()) as AppDoc;
+    expect(greetingText(current)).toBe("Goodbye");
+
+    // --- History lists the restorable prior version -----------------------
+    const history = (await (await stack.wireFetch(`/apps/${appId}/history`, {}, ADA)).json()) as Array<{
+      rung: number;
+      intent: string;
+    }>;
+    expect(history).toHaveLength(1);
+
+    // --- Undo restores the original ---------------------------------------
+    const restored = (await (await stack.wireFetch(`/apps/${appId}/history`, {
+      method: "POST",
+      body: JSON.stringify({ op: "undo" }),
+    }, ADA)).json()) as AppDoc;
+    expect(greetingText(restored)).toBe("Hello");
+
+    // The composed store reflects the restore.
+    const afterUndo = (await (await stack.wireFetch(`/apps/${appId}`, {}, ADA)).json()) as AppDoc;
+    expect(greetingText(afterUndo)).toBe("Hello");
+  });
+});

--- a/fixtures/integration/src/approval-roundtrip.e2e.test.ts
+++ b/fixtures/integration/src/approval-roundtrip.e2e.test.ts
@@ -1,0 +1,151 @@
+/** J2 — DESTRUCTIVE APPROVAL ROUND-TRIP through the composed wire.
+ *
+ * A chat turn calls a destructive host tool (host_invoices_delete, DELETE
+ * /api/invoices/{id}). The composed policy (.vendo/policy.json: destructive →
+ * ask) parks it: the SSE turn pauses with an approval part and the request lands
+ * queryable at GET /approvals. Deciding approve+remember over the wire mints a
+ * grant; resuming the thread executes the real HTTP DELETE against the host app.
+ * A second turn runs grant-authorized without asking.
+ *
+ * Also proves the one-security-rule cross-user boundary: BOB cannot decide ADA's
+ * approval (guard → not-found → 404), and nothing runs off it.
+ *
+ * NB the task brief named host_invoices_archive → POST /api/invoices/archive as
+ * the destructive tool; the fixture host app has no such mutating route (its
+ * /api/invoices/archive is a GET read). host_invoices_delete is the real
+ * destructive mutation the host exposes, so the journey asserts a REAL side
+ * effect (the invoice is gone) rather than a 405.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ADA,
+  BOB,
+  createStack,
+  hostFetch,
+  partsOfType,
+  readSse,
+  resetFixture,
+  resumeApproval,
+  textTurn,
+  toolCallTurn,
+  vendoApprovalId,
+  type Stack,
+} from "./harness.js";
+
+const TOOL = "host_invoices_delete";
+const FIRST = "inv_0003"; // ADA's draft invoice
+const SECOND = "inv_0002"; // ADA's open invoice
+
+let stack: Stack;
+afterEach(async () => {
+  await stack?.close();
+});
+
+async function invoiceExists(id: string): Promise<boolean> {
+  return (await hostFetch(`/api/invoices/${id}`, ADA.subject)).status === 200;
+}
+
+describe("J2: destructive approval round-trip through the composed wire", () => {
+  it("parks, blocks a cross-user decide, then approve+remember executes for real and the grant authorizes the next call", async () => {
+    await resetFixture();
+    stack = await createStack({
+      turns: [
+        toolCallTurn(TOOL, { id: FIRST }, "call_1"), // turn 1: parks on the destructive-ask policy
+        textTurn("Deleted the invoice.", "t1"), //       resume: executes the real DELETE, then text
+        toolCallTurn(TOOL, { id: SECOND }, "call_2"), //  turn 2: grant-authorized, no ask
+        textTurn("Deleted again.", "t2"), //              turn 2: continues after the run
+      ],
+    });
+
+    // --- Turn 1: the destructive call parks --------------------------------
+    const paused = await readSse(
+      await stack.wireFetch("/threads", {
+        method: "POST",
+        body: JSON.stringify({
+          threadId: "thr_j2",
+          message: { id: "u1", role: "user", parts: [{ type: "text", text: `Delete invoice ${FIRST}` }] },
+        }),
+      }, ADA),
+    );
+
+    expect(partsOfType(paused, "tool-approval-request")[0]).toMatchObject({ toolCallId: "call_1" });
+    const approvalId = vendoApprovalId(paused);
+
+    // Nothing executed: one pending approval on disk, host invoice untouched.
+    const pendingRows = await stack.sql<{ status: string; subject: string }>(
+      "SELECT status, subject FROM vendo_approvals",
+    );
+    expect(pendingRows).toEqual([{ status: "pending", subject: ADA.subject }]);
+    expect(await invoiceExists(FIRST)).toBe(true);
+
+    // GET /approvals surfaces the real inputs (05 §6 inputPreview).
+    const pending = (await (await stack.wireFetch("/approvals", {}, ADA)).json()) as Array<{
+      id: string;
+      inputPreview: string;
+    }>;
+    expect(pending.map((request) => request.id)).toContain(approvalId);
+    expect(pending.find((request) => request.id === approvalId)?.inputPreview).toContain(FIRST);
+
+    // --- Cross-user boundary: BOB cannot decide ADA's approval -------------
+    const bobDecide = await stack.wireFetch("/approvals/decide", {
+      method: "POST",
+      body: JSON.stringify({ ids: [approvalId], decision: { approve: true } }),
+    }, BOB);
+    expect(bobDecide.status).toBe(404);
+    // Still pending, still nothing deleted.
+    expect((await stack.sql("SELECT status FROM vendo_approvals WHERE status = 'pending'"))).toHaveLength(1);
+    expect(await invoiceExists(FIRST)).toBe(true);
+
+    // --- ADA decides: approve + remember a standing tool-scope grant -------
+    const decide = await stack.wireFetch("/approvals/decide", {
+      method: "POST",
+      body: JSON.stringify({
+        ids: [approvalId],
+        decision: { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+      }),
+    }, ADA);
+    expect(decide.status).toBe(200);
+
+    const grants = await stack.sql<{ subject: string; tool: string; source: string; duration: string }>(
+      "SELECT subject, tool, source, duration FROM vendo_grants",
+    );
+    expect(grants).toEqual([
+      { subject: ADA.subject, tool: TOOL, source: "chat", duration: "standing" },
+    ]);
+
+    // --- Resume the paused turn: the real DELETE runs against the host -----
+    const resumed = await readSse(await resumeApproval(stack, "thr_j2", "call_1", true, ADA));
+    expect(partsOfType(resumed, "tool-output-available")[0]).toMatchObject({
+      toolCallId: "call_1",
+      output: { status: "ok" },
+    });
+    expect(resumed.raw.includes("Deleted the invoice.")).toBe(true);
+
+    // Real host side effect: the invoice is gone.
+    expect(await invoiceExists(FIRST)).toBe(false);
+
+    // Audit: the executed destructive tool-call authorized by the grant.
+    const audit = await stack.sql<{ kind: string; tool: string; event: { outcome?: string; decidedBy?: string } }>(
+      "SELECT kind, tool, event FROM vendo_audit WHERE subject = $1",
+      [ADA.subject],
+    );
+    const toolCall = audit.find((row) => row.kind === "tool-call" && row.tool === TOOL && row.event.outcome === "ok");
+    expect(toolCall?.event.decidedBy).toBe("grant");
+    expect(audit.some((row) => row.kind === "approval")).toBe(true);
+
+    // --- Turn 2: a fresh destructive call runs on the grant, no new ask ----
+    const second = await readSse(
+      await stack.wireFetch("/threads", {
+        method: "POST",
+        body: JSON.stringify({
+          threadId: "thr_j2",
+          message: { id: "u2", role: "user", parts: [{ type: "text", text: `Delete invoice ${SECOND}` }] },
+        }),
+      }, ADA),
+    );
+    expect(partsOfType(second, "tool-approval-request")).toHaveLength(0);
+    expect(await invoiceExists(SECOND)).toBe(false);
+    // No new approval row: the grant answered the second call.
+    expect(await stack.sql("SELECT id FROM vendo_approvals")).toHaveLength(1);
+  });
+});

--- a/fixtures/integration/src/automation-lifecycle.e2e.test.ts
+++ b/fixtures/integration/src/automation-lifecycle.e2e.test.ts
@@ -1,0 +1,207 @@
+/** J4 — AUTOMATION LIFECYCLE through the composed wire.
+ *
+ * The automation ENTERS through the public wire: a `.vendoapp` archive carrying an
+ * AppDocument with a `trigger` is POSTed to /apps/import (import re-mints the id),
+ * then armed with POST /automations/:id/enable — whose grant-capture flow returns
+ * one ApprovalRequest per referenced tool. Deciding them over the wire mints
+ * standing, app-bound, `source:"automation"` grants (SQL).
+ *
+ * Both PUBLIC trigger paths are fired:
+ *   (a) schedule — a due `at` + POST /tick with the bearer secret;
+ *   (b) host-event — `vendo.emit(event, payload, ADA)`.
+ * Each away run executes its steps against the REAL host app through `actAs`, so
+ * the created invoice is observable on the host API, GET /runs shows "ok" with the
+ * step outcomes, and (b) also proves dry-run previews and disable stops firing.
+ *
+ * Schedule-semantics note: `createVendo` takes no `now`, so the schedule leg uses
+ * a PAST `at` (due on the first /tick after enable) rather than an `every`/`cron`
+ * that would need real wall-clock minutes to elapse.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import type { AppDocument } from "@vendoai/core";
+import {
+  ADA,
+  createStack,
+  decideApprovals,
+  hostFetch,
+  importAutomation,
+  pastAtIso,
+  waitForRunStatus,
+  type Stack,
+  type WireApproval,
+} from "./harness.js";
+
+const CREATE = "host_invoices_create";
+
+interface Invoice {
+  id: string;
+  memo: string;
+  amountCents: number;
+  status: string;
+}
+
+async function hostInvoices(): Promise<Invoice[]> {
+  const response = await hostFetch("/api/invoices", ADA.subject);
+  expect(response.status).toBe(200);
+  return ((await response.json()) as { invoices: Invoice[] }).invoices;
+}
+
+type TriggerOn = { kind: "schedule"; at: string } | { kind: "host-event"; event: string };
+
+/** A steps automation that creates one invoice from static JSONata args. */
+function createInvoiceAutomation(on: TriggerOn, memo: string): AppDocument {
+  return {
+    format: "vendo/app@1",
+    id: "app_import_placeholder", // re-minted by import
+    name: "J4 invoice automation",
+    trigger: {
+      on,
+      run: {
+        kind: "steps",
+        steps: [
+          {
+            id: "create",
+            tool: CREATE,
+            args: {
+              customerId: "'cus_j4'",
+              amountCents: "424242",
+              currency: "'USD'",
+              memo: `'${memo}'`,
+            },
+          },
+        ],
+      },
+    },
+  };
+}
+
+let stack: Stack;
+afterEach(async () => {
+  await stack?.close();
+});
+
+describe("J4: automation lifecycle through the composed wire", () => {
+  it("(schedule) imports, enables+captures grants, then a due `at` fires on /tick and creates the invoice for real", async () => {
+    stack = await createStack();
+    const MEMO = "J4 scheduled invoice";
+
+    // --- Import through the wire: import re-mints the id -------------------
+    const imported = await importAutomation(
+      stack,
+      createInvoiceAutomation({ kind: "schedule", at: pastAtIso() }, MEMO),
+      ADA,
+    );
+    expect(imported.id).not.toBe("app_import_placeholder");
+    expect(imported.id.startsWith("app_")).toBe(true);
+    const appId = imported.id;
+
+    // --- Enable: the capture flow surfaces one approval per referenced tool -
+    const enabled = (await (await stack.wireFetch(`/automations/${appId}/enable`, { method: "POST" }, ADA)).json()) as {
+      enabled: boolean;
+      missing: WireApproval[];
+    };
+    expect(enabled.enabled).toBe(true);
+    expect(enabled.missing.map((request) => request.call.tool)).toEqual([CREATE]);
+
+    // --- Decide approve → standing, app-bound, source:"automation" grants --
+    expect((await decideApprovals(stack, enabled.missing.map((request) => request.id), { approve: true }, ADA)).status)
+      .toBe(200);
+    const grants = await stack.sql<{ subject: string; tool: string; app_id: string; source: string; duration: string }>(
+      "SELECT subject, tool, app_id, source, duration FROM vendo_grants WHERE app_id = $1",
+      [appId],
+    );
+    expect(grants).toEqual([
+      { subject: ADA.subject, tool: CREATE, app_id: appId, source: "automation", duration: "standing" },
+    ]);
+
+    // Nothing has run yet: no invoice with our memo.
+    expect((await hostInvoices()).some((invoice) => invoice.memo === MEMO)).toBe(false);
+
+    // --- Fire the schedule: POST /tick with the bearer secret --------------
+    const tick = await stack.wireFetch("/tick", {
+      method: "POST",
+      headers: { authorization: `Bearer ${process.env.VENDO_TICK_SECRET}` },
+    });
+    expect(tick.status).toBe(200);
+    const runIds = ((await tick.json()) as { runIds: string[] }).runIds;
+    expect(runIds.length).toBe(1);
+    const runId = runIds[0]!;
+
+    // --- Observe: run ok, step outcome ok, REAL host side effect ------------
+    const run = await waitForRunStatus(stack, runId, ADA, "ok");
+    expect(run.appId).toBe(appId);
+    expect(run.steps.map(({ id, tool, outcome }) => ({ id, tool, outcome }))).toEqual([
+      { id: "create", tool: CREATE, outcome: "ok" },
+    ]);
+
+    const created = (await hostInvoices()).filter((invoice) => invoice.memo === MEMO);
+    expect(created).toHaveLength(1);
+    expect(created[0]?.amountCents).toBe(424242);
+
+    // The away run also lands the run row as ok + is audited under the app.
+    expect((await stack.sql<{ status: string }>("SELECT status FROM vendo_runs WHERE id = $1", [runId]))[0]?.status)
+      .toBe("ok");
+    expect(Number((await stack.sql<{ count: unknown }>(
+      "SELECT COUNT(*)::int AS count FROM vendo_audit WHERE kind = 'run' AND app_id = $1",
+      [appId],
+    ))[0]?.count)).toBeGreaterThanOrEqual(1);
+
+    // GET /automations lists it enabled.
+    const list = (await (await stack.wireFetch("/automations", {}, ADA)).json()) as Array<{
+      app: { id: string };
+      enabled: boolean;
+    }>;
+    expect(list.find((entry) => entry.app.id === appId)?.enabled).toBe(true);
+  });
+
+  it("(host-event) fires via vendo.emit, previews with dry-run, and disable stops firing", async () => {
+    stack = await createStack();
+    const EVENT = "j4.invoice.ready";
+    const MEMO = "J4 host-event invoice";
+
+    const imported = await importAutomation(
+      stack,
+      createInvoiceAutomation({ kind: "host-event", event: EVENT }, MEMO),
+      ADA,
+    );
+    const appId = imported.id;
+
+    const enabled = (await (await stack.wireFetch(`/automations/${appId}/enable`, { method: "POST" }, ADA)).json()) as {
+      enabled: boolean;
+      missing: WireApproval[];
+    };
+    expect(enabled.enabled).toBe(true);
+    expect((await decideApprovals(stack, enabled.missing.map((request) => request.id), { approve: true }, ADA)).status)
+      .toBe(200);
+
+    // --- dry-run previews the plan WITHOUT executing (07 §1/§5) ------------
+    const plan = (await (await stack.wireFetch(`/automations/${appId}/dry-run`, { method: "POST" }, ADA)).json()) as {
+      steps: Array<{ id: string; tool: string; wouldAsk: boolean }>;
+      grantsMissing: string[];
+    };
+    expect(plan.steps.map(({ id, tool }) => ({ id, tool }))).toEqual([{ id: "create", tool: CREATE }]);
+    // The captured grant covers the step, so nothing is missing / would-ask.
+    expect(plan.grantsMissing).toEqual([]);
+    expect(plan.steps.every((step) => step.wouldAsk === false)).toBe(true);
+    // dry-run executed nothing.
+    expect((await hostInvoices()).some((invoice) => invoice.memo === MEMO)).toBe(false);
+
+    // --- Fire the host-event seam: vendo.emit -----------------------------
+    const runIds = await stack.vendo.emit(EVENT, { requestedBy: "j4" }, ADA);
+    expect(runIds).toHaveLength(1);
+    const run = await waitForRunStatus(stack, runIds[0]!, ADA, "ok");
+    expect(run.steps.map(({ tool, outcome }) => ({ tool, outcome }))).toEqual([{ tool: CREATE, outcome: "ok" }]);
+    expect((await hostInvoices()).filter((invoice) => invoice.memo === MEMO)).toHaveLength(1);
+
+    // --- disable stops firing: a second emit produces no new run ----------
+    expect((await stack.wireFetch(`/automations/${appId}/disable`, { method: "POST" }, ADA)).status).toBe(200);
+    const afterDisable = await stack.vendo.emit(EVENT, { requestedBy: "j4-again" }, ADA);
+    expect(afterDisable).toEqual([]);
+    // Still exactly one invoice from the single pre-disable run.
+    expect((await hostInvoices()).filter((invoice) => invoice.memo === MEMO)).toHaveLength(1);
+    expect(Number((await stack.sql<{ count: unknown }>(
+      "SELECT COUNT(*)::int AS count FROM vendo_runs WHERE app_id = $1",
+      [appId],
+    ))[0]?.count)).toBe(1);
+  });
+});

--- a/fixtures/integration/src/automation-lifecycle.e2e.test.ts
+++ b/fixtures/integration/src/automation-lifecycle.e2e.test.ts
@@ -26,6 +26,7 @@ import {
   hostFetch,
   importAutomation,
   pastAtIso,
+  resetFixture,
   waitForRunStatus,
   type Stack,
   type WireApproval,
@@ -82,6 +83,7 @@ afterEach(async () => {
 
 describe("J4: automation lifecycle through the composed wire", () => {
   it("(schedule) imports, enables+captures grants, then a due `at` fires on /tick and creates the invoice for real", async () => {
+    await resetFixture();
     stack = await createStack();
     const MEMO = "J4 scheduled invoice";
 
@@ -155,6 +157,7 @@ describe("J4: automation lifecycle through the composed wire", () => {
   });
 
   it("(host-event) fires via vendo.emit, previews with dry-run, and disable stops firing", async () => {
+    await resetFixture();
     stack = await createStack();
     const EVENT = "j4.invoice.ready";
     const MEMO = "J4 host-event invoice";

--- a/fixtures/integration/src/away-park-revoke.e2e.test.ts
+++ b/fixtures/integration/src/away-park-revoke.e2e.test.ts
@@ -22,6 +22,7 @@ import {
   importAutomation,
   partsOfType,
   readSse,
+  resetFixture,
   resumeApproval,
   textTurn,
   toolCallTurn,
@@ -76,6 +77,7 @@ async function invoiceStatus(id: string): Promise<string | undefined> {
 
 describe("J5: away capture, park, resume, revoke through the composed wire", () => {
   it("parks the ungranted step, resumes on a wire decision, mints an app-bound grant, lands the side effect", async () => {
+    await resetFixture();
     stack = await createStack();
     const imported = await importAutomation(
       stack,
@@ -139,6 +141,7 @@ describe("J5: away capture, park, resume, revoke through the composed wire", () 
   });
 
   it("revocation is live: after DELETE /grants/:id the next run parks and the host is untouched", async () => {
+    await resetFixture();
     stack = await createStack();
     const imported = await importAutomation(
       stack,
@@ -181,6 +184,7 @@ describe("J5: away capture, park, resume, revoke through the composed wire", () 
   it("a chat-source grant (no appId) never authorizes an away run — the automation still parks (05 §6)", async () => {
     // The chat leg needs the scripted model: a destructive delete parks in chat,
     // approve+remember mints a STANDING chat grant with no appId binding.
+    await resetFixture();
     stack = await createStack({
       turns: [
         toolCallTurn(DELETE, { id: "inv_0003" }, "call_1"),

--- a/fixtures/integration/src/away-park-revoke.e2e.test.ts
+++ b/fixtures/integration/src/away-park-revoke.e2e.test.ts
@@ -1,0 +1,241 @@
+/** J5 — AWAY GRANT CAPTURE, PARK, RESUME, and REVOKE through the composed wire.
+ *
+ * The 07 §3 away-authority boundary, proven end-to-end on the composed system:
+ *   1. A run whose steps reference two tools, one granted at capture and one
+ *      DENIED, executes the granted step and PARKS on the ungranted one.
+ *   2. Deciding the parked approval over the wire RESUMES the run
+ *      (guard.onApprovalDecision through the umbrella) to "ok"; the deferred host
+ *      side effect lands and an app-bound `source:"automation"` grant is minted.
+ *   3. Revocation is live: DELETE /grants/:id, fire again, the run parks again and
+ *      the host is untouched.
+ *   4. The 05 §6 boundary at the COMPOSED level: a chat-source grant (minted via a
+ *      present chat approval with `remember`, so NO appId binding) never authorizes
+ *      an away run — the automation still parks.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import type { AppDocument } from "@vendoai/core";
+import {
+  ADA,
+  createStack,
+  decideApprovals,
+  hostFetch,
+  importAutomation,
+  partsOfType,
+  readSse,
+  resumeApproval,
+  textTurn,
+  toolCallTurn,
+  vendoApprovalId,
+  waitForRunStatus,
+  type Stack,
+  type WireApproval,
+} from "./harness.js";
+
+const LIST = "host_invoices_list";
+const SEND = "host_invoices_send";
+const DELETE = "host_invoices_delete";
+
+let stack: Stack;
+afterEach(async () => {
+  await stack?.close();
+});
+
+function stepsAutomation(event: string, steps: Array<{ id: string; tool: string; args?: Record<string, string> }>): AppDocument {
+  return {
+    format: "vendo/app@1",
+    id: "app_import_placeholder",
+    name: "J5 automation",
+    trigger: { on: { kind: "host-event", event }, run: { kind: "steps", steps } },
+  };
+}
+
+async function enableMissing(appId: string): Promise<WireApproval[]> {
+  const enabled = (await (await stack.wireFetch(`/automations/${appId}/enable`, { method: "POST" }, ADA)).json()) as {
+    enabled: boolean;
+    missing: WireApproval[];
+  };
+  expect(enabled.enabled).toBe(true);
+  return enabled.missing;
+}
+
+/** The owner's pending approvals over the wire, narrowed to the away (run) ones. */
+async function pendingAway(tool: string): Promise<{ id: string } | undefined> {
+  const pending = (await (await stack.wireFetch("/approvals", {}, ADA)).json()) as Array<{
+    id: string;
+    call: { tool: string };
+    ctx?: { presence?: string; appId?: string };
+  }>;
+  return pending.find((request) => request.call.tool === tool);
+}
+
+async function invoiceStatus(id: string): Promise<string | undefined> {
+  const response = await hostFetch(`/api/invoices/${id}`, ADA.subject);
+  if (response.status !== 200) return undefined;
+  return ((await response.json()) as { invoice: { status: string } }).invoice.status;
+}
+
+describe("J5: away capture, park, resume, revoke through the composed wire", () => {
+  it("parks the ungranted step, resumes on a wire decision, mints an app-bound grant, lands the side effect", async () => {
+    stack = await createStack();
+    const imported = await importAutomation(
+      stack,
+      stepsAutomation("j5.park", [
+        { id: "list", tool: LIST },
+        { id: "send", tool: SEND, args: { id: "event.id" } },
+      ]),
+      ADA,
+    );
+    const appId = imported.id;
+
+    // Capture: approve list, DENY send — the run will hold a grant for one tool only.
+    const missing = await enableMissing(appId);
+    const listId = missing.find((request) => request.call.tool === LIST)!.id;
+    const sendCaptureId = missing.find((request) => request.call.tool === SEND)!.id;
+    expect((await decideApprovals(stack, [listId], { approve: true }, ADA)).status).toBe(200);
+    expect((await decideApprovals(stack, [sendCaptureId], { approve: false }, ADA)).status).toBe(200);
+
+    expect(await invoiceStatus("inv_0003")).toBe("draft");
+
+    // Fire: the granted list runs, the ungranted send PARKS the run.
+    const [runId] = await stack.vendo.emit("j5.park", { id: "inv_0003" }, ADA);
+    if (runId === undefined) throw new Error("emit did not return a run id");
+    const parked = await waitForRunStatus(stack, runId, ADA, "pending-approval");
+    expect(parked.steps.map(({ id, outcome }) => ({ id, outcome }))).toEqual([
+      { id: "list", outcome: "ok" },
+      { id: "send", outcome: "pending-approval" },
+    ]);
+    // Nothing sent yet.
+    expect(await invoiceStatus("inv_0003")).toBe("draft");
+
+    // The parked approval is an away approval owned by ADA, visible on the wire.
+    const awaySend = await pendingAway(SEND);
+    expect(awaySend).toBeDefined();
+    const awayRows = await stack.sql<{ venue: string; presence: string; app_id: string | null }>(
+      `SELECT request->'ctx'->>'venue' AS venue,
+              request->'ctx'->>'presence' AS presence,
+              request->'ctx'->>'appId' AS app_id
+         FROM vendo_approvals WHERE id = $1`,
+      [awaySend!.id],
+    );
+    expect(awayRows).toEqual([{ venue: "automation", presence: "away", app_id: appId }]);
+
+    // --- Resume: decide approve over the wire → the run finishes for real ---
+    expect((await decideApprovals(stack, [awaySend!.id], { approve: true }, ADA)).status).toBe(200);
+    const resumed = await waitForRunStatus(stack, runId, ADA, "ok");
+    expect(resumed.steps.map(({ id, outcome }) => ({ id, outcome }))).toEqual([
+      { id: "list", outcome: "ok" },
+      { id: "send", outcome: "ok" },
+    ]);
+    // The deferred host side effect landed.
+    expect(await invoiceStatus("inv_0003")).toBe("open");
+
+    // The resumption minted an app-bound automation grant for the send tool.
+    expect(await stack.sql(
+      "SELECT subject, tool, app_id, source, duration FROM vendo_grants WHERE tool = $1 AND app_id = $2",
+      [SEND, appId],
+    )).toEqual([
+      { subject: ADA.subject, tool: SEND, app_id: appId, source: "automation", duration: "standing" },
+    ]);
+  });
+
+  it("revocation is live: after DELETE /grants/:id the next run parks and the host is untouched", async () => {
+    stack = await createStack();
+    const imported = await importAutomation(
+      stack,
+      stepsAutomation("j5.revoke", [{ id: "send", tool: SEND, args: { id: "event.id" } }]),
+      ADA,
+    );
+    const appId = imported.id;
+    const missing = await enableMissing(appId);
+    expect((await decideApprovals(stack, missing.map((request) => request.id), { approve: true }, ADA)).status).toBe(200);
+
+    // First run: the standing grant authorizes the away send.
+    const [firstRun] = await stack.vendo.emit("j5.revoke", { id: "inv_0003" }, ADA);
+    await waitForRunStatus(stack, firstRun!, ADA, "ok");
+    expect(await invoiceStatus("inv_0003")).toBe("open");
+
+    // Revoke the standing automation grant over the wire.
+    const grants = (await (await stack.wireFetch("/grants", {}, ADA)).json()) as Array<{
+      id: string;
+      tool: string;
+      appId?: string;
+    }>;
+    const sendGrant = grants.find((grant) => grant.tool === SEND && grant.appId === appId);
+    expect(sendGrant).toBeDefined();
+    expect((await stack.wireFetch(`/grants/${sendGrant!.id}`, { method: "DELETE" }, ADA)).status).toBe(200);
+    expect((await stack.sql<{ revoked_at: unknown }>(
+      "SELECT revoked_at FROM vendo_grants WHERE id = $1",
+      [sendGrant!.id],
+    ))[0]?.revoked_at).toBeTruthy();
+
+    // Next run parks — revocation disarmed nothing, the run just asks again.
+    const before = await invoiceStatus("inv_0002");
+    const [secondRun] = await stack.vendo.emit("j5.revoke", { id: "inv_0002" }, ADA);
+    const parked = await waitForRunStatus(stack, secondRun!, ADA, "pending-approval");
+    expect(parked.steps.at(-1)).toMatchObject({ tool: SEND, outcome: "pending-approval" });
+    expect(await pendingAway(SEND)).toBeDefined();
+    // The parked run never hit the host: the target invoice is unchanged.
+    expect(await invoiceStatus("inv_0002")).toBe(before);
+  });
+
+  it("a chat-source grant (no appId) never authorizes an away run — the automation still parks (05 §6)", async () => {
+    // The chat leg needs the scripted model: a destructive delete parks in chat,
+    // approve+remember mints a STANDING chat grant with no appId binding.
+    stack = await createStack({
+      turns: [
+        toolCallTurn(DELETE, { id: "inv_0003" }, "call_1"),
+        textTurn("Deleted the invoice.", "t1"),
+      ],
+    });
+
+    // --- Mint a chat-source, un-app-bound grant for DELETE ----------------
+    const paused = await readSse(
+      await stack.wireFetch("/threads", {
+        method: "POST",
+        body: JSON.stringify({
+          threadId: "thr_j5",
+          message: { id: "u1", role: "user", parts: [{ type: "text", text: "Delete invoice inv_0003" }] },
+        }),
+      }, ADA),
+    );
+    expect(partsOfType(paused, "tool-approval-request")[0]).toMatchObject({ toolCallId: "call_1" });
+    const approvalId = vendoApprovalId(paused);
+    expect((await decideApprovals(
+      stack,
+      [approvalId],
+      { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+      ADA,
+    )).status).toBe(200);
+    await readSse(await resumeApproval(stack, "thr_j5", "call_1", true, ADA));
+    // The minted chat grant is standing and carries NO appId (05 §6 preconditions).
+    expect(await stack.sql<{ source: string; app_id: string | null; duration: string }>(
+      "SELECT source, app_id, duration FROM vendo_grants WHERE tool = $1",
+      [DELETE],
+    )).toEqual([{ source: "chat", app_id: null, duration: "standing" }]);
+
+    // --- The automation references the same tool; deny its capture --------
+    const imported = await importAutomation(
+      stack,
+      stepsAutomation("j5.chatgrant", [{ id: "delete", tool: DELETE, args: { id: "event.id" } }]),
+      ADA,
+    );
+    const appId = imported.id;
+    const missing = await enableMissing(appId);
+    expect((await decideApprovals(stack, missing.map((request) => request.id), { approve: false }, ADA)).status).toBe(200);
+
+    // --- Fire: the away run parks; the chat grant does not carry across -----
+    expect(await invoiceStatus("inv_0002")).toBeDefined(); // exists before
+    const [runId] = await stack.vendo.emit("j5.chatgrant", { id: "inv_0002" }, ADA);
+    const parked = await waitForRunStatus(stack, runId!, ADA, "pending-approval");
+    expect(parked.steps.at(-1)).toMatchObject({ tool: DELETE, outcome: "pending-approval" });
+    const away = await pendingAway(DELETE);
+    expect(away).toBeDefined();
+    expect((await stack.sql<{ presence: string; app_id: string | null }>(
+      `SELECT request->'ctx'->>'presence' AS presence, request->'ctx'->>'appId' AS app_id
+         FROM vendo_approvals WHERE id = $1`,
+      [away!.id],
+    ))).toEqual([{ presence: "away", app_id: appId }]);
+    // Host untouched: the chat-granted delete never ran away.
+    expect(await invoiceStatus("inv_0002")).toBeDefined();
+  });
+});

--- a/fixtures/integration/src/chat-generates-app.e2e.test.ts
+++ b/fixtures/integration/src/chat-generates-app.e2e.test.ts
@@ -1,0 +1,100 @@
+/** J1 — CHAT GENERATES AN APP, end to end through the composed umbrella.
+ *
+ * A single POST /threads turn as ADA: the scripted agent calls the composed
+ * `vendo_apps_create` capability tool (added to the registry by the umbrella via
+ * `actions.add(apps.agentTools())`); executing it drives the apps generation
+ * engine — the SAME model instance, via doGenerate — which returns a valid
+ * vendo-genui/v1 CREATE tree; the agent then closes with a text turn.
+ *
+ * Asserts the whole composition worked: the SSE stream completes, a vendo_apps
+ * row owned by ADA lands (raw SQL), the wire lists + opens it as a tree, and —
+ * the one-security-rule ownership boundary — BOB does not see ADA's app.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ADA,
+  BOB,
+  createStack,
+  generationTurn,
+  readSse,
+  resetFixture,
+  textTurn,
+  toolCallTurn,
+  type Stack,
+} from "./harness.js";
+
+const CREATE_DIALECT = {
+  name: "Ada's Greeting",
+  description: "A tiny greeting card",
+  tree: {
+    formatVersion: "vendo-genui/v1",
+    root: "root",
+    nodes: [
+      { id: "root", component: "Stack", source: "prewired", children: ["greeting"] },
+      { id: "greeting", component: "Text", source: "prewired", props: { text: "Hello Ada" } },
+    ],
+  },
+};
+
+let stack: Stack;
+afterEach(async () => {
+  await stack?.close();
+});
+
+describe("J1: chat generates an app through the real composition", () => {
+  it("streams a turn that creates a vendo_apps row owned by ADA, listable + openable, invisible to BOB", async () => {
+    await resetFixture();
+    stack = await createStack({
+      turns: [
+        toolCallTurn("vendo_apps_create", { prompt: "Build me a greeting card" }, "call_1"),
+        generationTurn(CREATE_DIALECT),
+        textTurn("Created your app.", "t1"),
+      ],
+    });
+
+    const turn = await readSse(
+      await stack.wireFetch("/threads", {
+        method: "POST",
+        body: JSON.stringify({
+          threadId: "thr_j1",
+          message: { id: "u1", role: "user", parts: [{ type: "text", text: "Build me a greeting card" }] },
+        }),
+      }, ADA),
+    );
+
+    // The stream ran to completion and the composed tool produced its output.
+    expect(turn.raw.includes("[DONE]")).toBe(true);
+    expect(turn.raw.includes("Created your app.")).toBe(true);
+
+    // Real side effect: exactly one app, owned by ADA, persisted by the composed store.
+    const apps = await stack.sql<{ id: string; subject: string }>("SELECT id, subject FROM vendo_apps");
+    expect(apps).toHaveLength(1);
+    expect(apps[0]?.subject).toBe(ADA.subject);
+    const appId = apps[0]!.id;
+
+    // The composed guard bound the capability tool: the audit trail records it.
+    const audit = await stack.sql<{ tool: string }>(
+      "SELECT tool FROM vendo_audit WHERE subject = $1 AND kind = 'tool-call'",
+      [ADA.subject],
+    );
+    expect(audit.some((row) => row.tool === "vendo_apps_create")).toBe(true);
+
+    // Wire GET /apps lists it for ADA.
+    const adaList = (await (await stack.wireFetch("/apps", {}, ADA)).json()) as Array<{ id: string }>;
+    expect(adaList.map((app) => app.id)).toContain(appId);
+
+    // Wire GET /apps/:id/open returns the generated tree payload.
+    const opened = (await (await stack.wireFetch(`/apps/${appId}/open`, {}, ADA)).json()) as {
+      kind: string;
+      payload: { formatVersion: string; root: string; nodes: Array<{ id: string; props?: { text?: string } }> };
+    };
+    expect(opened.kind).toBe("tree");
+    expect(opened.payload.formatVersion).toBe("vendo-genui/v1");
+    expect(opened.payload.root).toBe("root");
+    expect(opened.payload.nodes.find((node) => node.id === "greeting")?.props?.text).toBe("Hello Ada");
+
+    // One-security-rule ownership: BOB does not see ADA's app.
+    const bobList = (await (await stack.wireFetch("/apps", {}, BOB)).json()) as Array<{ id: string }>;
+    expect(bobList.map((app) => app.id)).not.toContain(appId);
+  });
+});

--- a/fixtures/integration/src/global-setup.ts
+++ b/fixtures/integration/src/global-setup.ts
@@ -1,0 +1,87 @@
+/** Boots ONE fixture host-app server for the whole integration run and provides
+ * its base URL to every suite (vitest globalSetup). Mirrors the wave-4
+ * automations-e2e boot exactly, but with its OWN FIXTURE_DIST_DIR so it can run
+ * concurrently under turbo next to the other host-app-booting suites without
+ * fighting over a dev-server lock.
+ *
+ * Every stack points the composed umbrella's route bindings at this origin via
+ * VENDO_BASE_URL (harness.ts), so host tools execute real HTTP against it.
+ */
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { createServer } from "node:net";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import type { TestProject } from "vitest/node";
+
+const fixtureDir = fileURLToPath(new URL("../../host-app/", import.meta.url));
+const nextBin = join(fixtureDir, "node_modules", ".bin", "next");
+
+let child: ChildProcessWithoutNullStreams | undefined;
+let serverOutput = "";
+
+async function freePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Could not allocate fixture port");
+  const port = address.port;
+  await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  return port;
+}
+
+async function waitForFixture(baseUrl: string): Promise<void> {
+  const deadline = Date.now() + 180_000;
+  while (Date.now() < deadline) {
+    if (child?.exitCode !== null) throw new Error(`Fixture exited early (${child?.exitCode})\n${serverOutput}`);
+    try {
+      const response = await fetch(baseUrl);
+      if (response.ok) return;
+    } catch {
+      // Next is still compiling.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Fixture did not become ready\n${serverOutput}`);
+}
+
+export default async function setup(project: TestProject): Promise<() => Promise<void>> {
+  const port = await freePort();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  child = spawn(nextBin, ["dev", "-p", String(port)], {
+    cwd: fixtureDir,
+    // Own dist dir → own dev-server lock; sibling e2e suites may boot the same
+    // host app concurrently under turbo. Nested under .next so scanner/gitignore
+    // rules that already skip .next cover it.
+    env: { ...process.env, NEXT_TELEMETRY_DISABLED: "1", FIXTURE_DIST_DIR: ".next/integration-e2e" },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  child.stdout.on("data", (chunk) => {
+    serverOutput = `${serverOutput}${String(chunk)}`.slice(-20_000);
+  });
+  child.stderr.on("data", (chunk) => {
+    serverOutput = `${serverOutput}${String(chunk)}`.slice(-20_000);
+  });
+  await waitForFixture(baseUrl);
+  project.provide("fixtureBaseUrl", baseUrl);
+
+  return async () => {
+    if (!child || child.exitCode !== null) return;
+    child.kill("SIGTERM");
+    const exited = new Promise<void>((resolve) => child?.once("exit", () => resolve()));
+    const timeout = new Promise<void>((resolve) => setTimeout(resolve, 5_000));
+    await Promise.race([exited, timeout]);
+    if (child.exitCode === null) child.kill("SIGKILL");
+  };
+}
+
+declare module "vitest" {
+  export interface ProvidedContext {
+    fixtureBaseUrl: string;
+  }
+}

--- a/fixtures/integration/src/harness.ts
+++ b/fixtures/integration/src/harness.ts
@@ -1,0 +1,374 @@
+/** The cross-block INTEGRATION harness. Unlike every other fixture suite (which
+ * hand-composes the blocks "the way the umbrella will"), this one boots the REAL
+ * composed umbrella — `createVendo` from `@vendoai/vendo/server` — and drives
+ * whole-product journeys through the PUBLIC WIRE over real HTTP.
+ *
+ * What a stack is:
+ *   - a per-test PGlite store in a temp dir (isolation),
+ *   - `createVendo({ model, principal, store, actAs, policy })` — nothing else is
+ *     hand-wired; store/guard/actions/apps/automations are composed by the umbrella,
+ *   - host tools loaded through the real `.vendo/tools.json` contract (createVendo
+ *     does `createActions({ dir: "." })` from cwd = this package),
+ *   - the umbrella `handler` served on a loopback node:http server (the wire),
+ *   - `VENDO_BASE_URL` pointed at the booted fixture host app so route bindings
+ *     execute real HTTP there (trusted-origin branch → present credentials forward).
+ *
+ * The only sanctioned NON-wire seams tests may touch: `vendo.emit` (host-event) and
+ * `stack.sql` (raw SQL over the public vendo_* tables for side-effect asserts). The
+ * harness itself also reads `vendo.store`. Journeys otherwise use the wire only.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { inject } from "vitest";
+import type { Principal } from "@vendoai/core";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { createVendo, type Vendo } from "@vendoai/vendo/server";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import type { LanguageModel } from "ai";
+
+export const fixtureBaseUrl = (): string => inject("fixtureBaseUrl");
+
+/** Seeded fixture principals — resolved from the `x-vendo-test-user` header. */
+export const ADA: Principal = { kind: "user", subject: "user_ada" };
+export const BOB: Principal = { kind: "user", subject: "user_bob" };
+
+export const WIRE_BASE = "/api/vendo";
+
+// ---------------------------------------------------------------------------
+// Scripted LanguageModel — the chat-e2e technique. ONE model instance drives
+// BOTH the agent loop (doStream) AND the apps generation engine (doGenerate via
+// generateText); they share one FIFO queue of turns, so a journey scripts turns
+// in the exact order the composed system will consume them.
+// ---------------------------------------------------------------------------
+
+type LanguageModelV3Prompt = Parameters<MockLanguageModelV3["doStream"]>[0]["prompt"];
+type LanguageModelV3StreamPart = Awaited<
+  ReturnType<MockLanguageModelV3["doStream"]>
+>["stream"] extends ReadableStream<infer Part> ? Part : never;
+type LanguageModelV3GenerateResult = Awaited<ReturnType<MockLanguageModelV3["doGenerate"]>>;
+type LanguageModelV3Content = LanguageModelV3GenerateResult["content"][number];
+
+export const ZERO_USAGE = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+} as const;
+
+/** A plain assistant text turn (agent doStream). */
+export function textTurn(text: string, id = "text_1"): LanguageModelV3StreamPart[] {
+  return [
+    { type: "text-start", id },
+    { type: "text-delta", id, delta: text },
+    { type: "text-end", id },
+    { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
+  ];
+}
+
+/** An agent turn that calls one tool (agent doStream). */
+export function toolCallTurn(
+  toolName: string,
+  input: unknown,
+  toolCallId = "call_1",
+): LanguageModelV3StreamPart[] {
+  return [
+    { type: "tool-call", toolCallId, toolName, input: JSON.stringify(input) },
+    { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "tool-calls", raw: undefined } },
+  ];
+}
+
+/** A generation-engine turn: the apps engine reads this through doGenerate and
+ * parses the emitted text as CREATE/EDIT-dialect JSON. Pass the object; it is
+ * serialized verbatim so the dialect must be VALID (an invalid one triggers the
+ * engine's internal repair retry, which would consume the next scripted turn). */
+export function generationTurn(dialect: unknown, id = "gen_1"): LanguageModelV3StreamPart[] {
+  return [
+    { type: "text-start", id },
+    { type: "text-delta", id, delta: JSON.stringify(dialect) },
+    { type: "text-end", id },
+    { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
+  ];
+}
+
+export type ScriptedModel = MockLanguageModelV3 & { prompts: LanguageModelV3Prompt[] };
+
+export function scriptedModel(turns: LanguageModelV3StreamPart[][]): ScriptedModel {
+  const remaining = turns.map((turn) => [...turn]);
+  const prompts: LanguageModelV3Prompt[] = [];
+  const shift = (prompt: LanguageModelV3Prompt): LanguageModelV3StreamPart[] => {
+    prompts.push(structuredClone(prompt));
+    const chunks = remaining.shift();
+    if (chunks === undefined) throw new Error("scripted model exhausted");
+    return chunks;
+  };
+  const model = new MockLanguageModelV3({
+    doStream: async (request) => ({ stream: simulateReadableStream({ chunks: shift(request.prompt) }) }),
+    doGenerate: async (request): Promise<LanguageModelV3GenerateResult> => {
+      const chunks = shift(request.prompt);
+      const finish = chunks.find((part) => part.type === "finish");
+      const content: LanguageModelV3Content[] = [];
+      const text = chunks
+        .filter((part): part is Extract<LanguageModelV3StreamPart, { type: "text-delta" }> => part.type === "text-delta")
+        .map((part) => part.delta)
+        .join("");
+      if (text.length > 0) content.push({ type: "text", text });
+      for (const part of chunks) if (part.type === "tool-call") content.push(structuredClone(part));
+      return {
+        content,
+        finishReason: finish?.finishReason ?? { unified: "stop", raw: undefined },
+        usage: finish?.usage ?? ZERO_USAGE,
+        warnings: [],
+      };
+    },
+  }) as ScriptedModel;
+  model.prompts = prompts;
+  return model;
+}
+
+// ---------------------------------------------------------------------------
+// Host-app helpers (fixture login / reset / away identity).
+// ---------------------------------------------------------------------------
+
+const cookieCache = new Map<string, string>();
+
+export async function loginCookie(subject: string): Promise<string> {
+  const cached = cookieCache.get(subject);
+  if (cached !== undefined) return cached;
+  const response = await fetch(`${fixtureBaseUrl()}/api/login`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ user: subject }),
+  });
+  if (!response.ok) throw new Error(`Fixture login failed (${response.status})`);
+  const cookie = response.headers.get("set-cookie")?.split(";")[0];
+  if (!cookie) throw new Error("Fixture login did not return a cookie");
+  cookieCache.set(subject, cookie);
+  return cookie;
+}
+
+export async function resetFixture(): Promise<void> {
+  const response = await fetch(`${fixtureBaseUrl()}/fixture/reset`, { method: "POST" });
+  if (!response.ok) throw new Error(`Fixture reset failed (${response.status})`);
+}
+
+/** Away identity: host-implemented ActAs — a fixture login for the grant's
+ * subject. Used by the away (automation) journeys in later lanes; present chat
+ * calls authenticate by forwarding the wire request's own cookie instead. */
+const fixtureActAs = async (principal: Principal): Promise<{ headers: Record<string, string> }> => ({
+  headers: { cookie: await loginCookie(principal.subject) },
+});
+
+/** A direct host-app fetch (bypasses the wire) for asserting real host state. */
+export async function hostFetch(path: string, subject: string, init: RequestInit = {}): Promise<Response> {
+  return fetch(`${fixtureBaseUrl()}${path}`, {
+    ...init,
+    headers: { ...(init.headers ?? {}), cookie: await loginCookie(subject) },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// The stack — one real composed umbrella served on a loopback wire server.
+// ---------------------------------------------------------------------------
+
+export interface StackOptions {
+  /** Ordered scripted turns consumed by doStream (agent) + doGenerate (engine). */
+  turns?: LanguageModelV3StreamPart[][];
+  model?: LanguageModel;
+}
+
+export interface Stack {
+  /** The wire origin (loopback). Wire calls go to `${baseUrl}${WIRE_BASE}/...`. */
+  baseUrl: string;
+  vendo: Vendo;
+  model: ScriptedModel;
+  /** A wire request as `user`: sets x-vendo-test-user (principal) + the host
+   * session cookie (so present route bindings authenticate) + JSON content-type. */
+  wireFetch(path: string, init?: RequestInit, user?: Principal): Promise<Response>;
+  /** Raw SQL over the composed store — the public vendo_* side-effect asserts. */
+  sql<Row = Record<string, unknown>>(query: string, params?: unknown[]): Promise<Row[]>;
+  close(): Promise<void>;
+}
+
+export async function createStack(options: StackOptions = {}): Promise<Stack> {
+  // Route bindings resolve against the host app; an explicit VENDO_BASE_URL is the
+  // trusted-origin branch, so present-call credentials forward there. Set BEFORE
+  // createVendo reads it. VENDO_TICK_SECRET is set for the later scheduler lane.
+  process.env.VENDO_BASE_URL = fixtureBaseUrl();
+  process.env.VENDO_TICK_SECRET ??= "integration-tick-secret";
+
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-integration-"));
+  const store = createStore({ dataDir });
+  // Open the DB up front so `store.raw()` (the SQL-assert seam) is usable
+  // immediately; createVendo also calls ensureSchema (idempotent).
+  await store.ensureSchema();
+  const model = (options.model as ScriptedModel | undefined) ?? scriptedModel(options.turns ?? []);
+
+  const vendo = createVendo({
+    model,
+    principal: async (req) => {
+      const subject = req.headers.get("x-vendo-test-user");
+      return subject ? { kind: "user", subject } : null;
+    },
+    store,
+    actAs: fixtureActAs,
+    policy: { file: ".vendo/policy.json" },
+  });
+
+  const httpServer = createServer((req, res) => void forwardToWire(req, res, vendo.handler));
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once("error", reject);
+    httpServer.listen(0, "127.0.0.1", () => {
+      httpServer.off("error", reject);
+      resolve();
+    });
+  });
+  const address = httpServer.address();
+  if (!address || typeof address === "string") throw new Error("wire server did not bind a TCP port");
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  const raw = store.raw() as { query(q: string, p?: unknown[]): Promise<{ rows: unknown[] }> };
+
+  return {
+    baseUrl,
+    vendo,
+    model,
+    async wireFetch(path, init = {}, user) {
+      const headers: Record<string, string> = { ...(init.headers as Record<string, string> | undefined) };
+      const mutation = ["POST", "PUT", "PATCH", "DELETE"].includes((init.method ?? "GET").toUpperCase());
+      if (mutation && headers["content-type"] === undefined && path !== "/apps/import") {
+        headers["content-type"] = "application/json";
+      }
+      if (user !== undefined) {
+        headers["x-vendo-test-user"] = user.subject;
+        // Forward the host session cookie so PRESENT route bindings authenticate
+        // against the host app (04 §4 trusted-origin forwarding).
+        headers.cookie = await loginCookie(user.subject);
+      }
+      return fetch(`${baseUrl}${WIRE_BASE}${path}`, { ...init, headers });
+    },
+    async sql(query, params) {
+      return (await raw.query(query, params)).rows as never;
+    },
+    async close() {
+      await new Promise<void>((resolve, reject) => httpServer.close((error) => (error ? reject(error) : resolve())));
+      await store.close();
+      await rm(dataDir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function forwardToWire(
+  req: IncomingMessage,
+  res: ServerResponse,
+  handler: (request: Request) => Promise<Response>,
+): Promise<void> {
+  try {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    const host = req.headers.host ?? "127.0.0.1";
+    const headers = new Headers();
+    for (const [name, value] of Object.entries(req.headers)) {
+      if (value === undefined) continue;
+      headers.set(name, Array.isArray(value) ? value.join(", ") : value);
+    }
+    const body = chunks.length === 0 ? undefined : Buffer.concat(chunks);
+    const request = new Request(`http://${host}${req.url ?? "/"}`, {
+      method: req.method,
+      headers,
+      ...(body === undefined ? {} : { body }),
+    });
+    const response = await handler(request);
+    res.statusCode = response.status;
+    response.headers.forEach((value, name) => res.setHeader(name, value));
+    res.end(Buffer.from(await response.arrayBuffer()));
+  } catch (error) {
+    res.statusCode = 500;
+    res.setHeader("content-type", "text/plain");
+    res.end(error instanceof Error ? error.message : "wire bridge failed");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SSE draining — the ai-SDK UI message stream the /threads route returns.
+// ---------------------------------------------------------------------------
+
+export interface StreamRead {
+  parts: Array<Record<string, unknown>>;
+  raw: string;
+}
+
+export async function readSse(response: Response): Promise<StreamRead> {
+  const raw = await response.text();
+  const parts = raw
+    .split("\n\n")
+    .map((block) => block.trim())
+    .filter((block) => block.startsWith("data: ") && block !== "data: [DONE]")
+    .map((block) => JSON.parse(block.slice("data: ".length)) as Record<string, unknown>);
+  return { parts, raw };
+}
+
+export function partsOfType(read: StreamRead, type: string): Array<Record<string, unknown>> {
+  return read.parts.filter((part) => part.type === type);
+}
+
+/** The core approvalId (apr_...) surfaced beside the native tool part on the
+ * stream (the ai-SDK data-part envelope carries fields under `data`). */
+export function vendoApprovalId(read: StreamRead): string {
+  const part = partsOfType(read, "data-vendo-approval")[0];
+  if (part === undefined) throw new Error("stream carried no data-vendo-approval part");
+  const id = (part.data as { approvalId?: unknown }).approvalId;
+  if (typeof id !== "string") throw new Error("data-vendo-approval part carried no approvalId");
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// Present-approval resume over the wire. A present chat approval pauses the
+// turn; resuming is client-driven (03 §agent): the client re-posts the thread
+// with the parked tool part flipped to `approval-responded`. This replays that
+// exactly through the public /threads route.
+// ---------------------------------------------------------------------------
+
+interface WireMessage {
+  id: string;
+  role: string;
+  parts: Array<Record<string, unknown>>;
+}
+
+interface WireThread {
+  id: string;
+  messages: WireMessage[];
+}
+
+export async function resumeApproval(
+  stack: Stack,
+  threadId: string,
+  toolCallId: string,
+  approved: boolean,
+  user: Principal,
+): Promise<Response> {
+  const thread = (await (await stack.wireFetch(`/threads/${threadId}`, {}, user)).json()) as WireThread;
+  const assistant = [...thread.messages].reverse().find((message) => message.role === "assistant");
+  if (assistant === undefined) throw new Error("thread has no assistant message to resume");
+  let flipped = false;
+  const parts = assistant.parts.map((part) => {
+    if (part.type !== "dynamic-tool" || part.toolCallId !== toolCallId) return part;
+    const approval = part.approval as { id?: unknown } | undefined;
+    if (approval === undefined || typeof approval.id !== "string") {
+      throw new Error("parked tool part carried no native approval id");
+    }
+    flipped = true;
+    return {
+      type: "dynamic-tool",
+      toolName: part.toolName,
+      toolCallId,
+      state: "approval-responded",
+      input: part.input,
+      approval: { id: approval.id, approved },
+    };
+  });
+  if (!flipped) throw new Error(`no parked tool part for toolCallId ${toolCallId}`);
+  return stack.wireFetch("/threads", {
+    method: "POST",
+    body: JSON.stringify({ threadId, message: { ...assistant, parts } }),
+  }, user);
+}

--- a/fixtures/integration/src/harness.ts
+++ b/fixtures/integration/src/harness.ts
@@ -22,7 +22,9 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { inject } from "vitest";
-import type { Principal } from "@vendoai/core";
+import { zipSync } from "fflate";
+import type { AppDocument, Principal, ToolRegistry } from "@vendoai/core";
+import { createMcpDoor, type AppsPort, type HostOAuthAdapter, type McpDoor } from "@vendoai/mcp";
 import { createStore, type VendoStore } from "@vendoai/store";
 import { createVendo, type Vendo } from "@vendoai/vendo/server";
 import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
@@ -174,6 +176,24 @@ export interface StackOptions {
   /** Ordered scripted turns consumed by doStream (agent) + doGenerate (engine). */
   turns?: LanguageModelV3StreamPart[][];
   model?: LanguageModel;
+  /** Mount the MCP door (J6) beside `vendo.handler` on the same loopback origin,
+   * composed from the umbrella's OWN parts — the way a host must today until the
+   * `createVendo({ mcp: true })` hookup lands (docs/contracts/10-mcp-umbrella-hookup.md). */
+  mcp?: boolean;
+}
+
+/** The door mounted alongside the wire when `createStack({ mcp: true })`. */
+export interface McpDoorHandle {
+  /** The shared loopback origin (identical to `stack.baseUrl`). */
+  origin: string;
+  /** The door mount — `${origin}/api/vendo/mcp` (the MCP Streamable HTTP endpoint). */
+  endpoint: string;
+  /** The SAME guard-bound registry the door serves — `vendo.guard.bind(vendo.actions)`;
+   * used to assert `tools/list` descriptors match the registry verbatim. */
+  bound: ToolRegistry;
+  /** Live door controls: which fixture subject the OAuth adapter authorizes as, and
+   * the revoked-subject set (`principal() → null` kills a session, 10-mcp §3). */
+  control: { autoSubject?: string; revoked: Set<string> };
 }
 
 export interface Stack {
@@ -181,6 +201,8 @@ export interface Stack {
   baseUrl: string;
   vendo: Vendo;
   model: ScriptedModel;
+  /** Present only when created with `{ mcp: true }` — the co-mounted MCP door. */
+  mcp?: McpDoorHandle;
   /** A wire request as `user`: sets x-vendo-test-user (principal) + the host
    * session cookie (so present route bindings authenticate) + JSON content-type. */
   wireFetch(path: string, init?: RequestInit, user?: Principal): Promise<Response>;
@@ -214,7 +236,50 @@ export async function createStack(options: StackOptions = {}): Promise<Stack> {
     policy: { file: ".vendo/policy.json" },
   });
 
-  const httpServer = createServer((req, res) => void forwardToWire(req, res, vendo.handler));
+  // J6 — the MCP door, composed from the umbrella's OWN parts (the hookup note's
+  // exact shape). Same guard, same store, same guard-bound registry chat uses:
+  // one perimeter, one approvals/audit plane. The `oauth` seam is the fixture
+  // host's login (authorize resolves the current fixture subject; principal()
+  // resolution IS revocation, 10-mcp §3).
+  let door: McpDoor | undefined;
+  let mcpControl: McpDoorHandle["control"] | undefined;
+  let mcpBound: ToolRegistry | undefined;
+  if (options.mcp === true) {
+    const control: McpDoorHandle["control"] = { autoSubject: ADA.subject, revoked: new Set<string>() };
+    mcpControl = control;
+    mcpBound = vendo.guard.bind(vendo.actions);
+    const oauth: HostOAuthAdapter = {
+      async authorize() {
+        if (control.autoSubject === undefined) return new Response("missing fixture session", { status: 401 });
+        return { subject: control.autoSubject };
+      },
+      async principal(subject) {
+        return control.revoked.has(subject) ? null : { kind: "user", subject };
+      },
+    };
+    // AppsPort adapter over vendo.apps — AppsRuntime.open has an extra "resuming"
+    // variant AppsPort does not, so map it (the door is a viewer + runner, 10-mcp §4).
+    const appsPort: AppsPort = {
+      list: (ctx) => vendo.apps.list(ctx),
+      async open(appId, ctx) {
+        const opened = await vendo.apps.open(appId, ctx);
+        if (opened.kind === "resuming") throw new Error("app is resuming; unreachable for the door viewer role");
+        return opened.kind === "tree" ? { kind: "tree", payload: opened.payload } : opened;
+      },
+      call: (appId, ref, args, ctx) => vendo.apps.call(appId, ref, args, ctx),
+    };
+    door = createMcpDoor({ tools: mcpBound, guard: vendo.guard, store, oauth, apps: appsPort });
+  }
+
+  // The door serves its own mount (/api/vendo/mcp…) and the origin-root discovery
+  // documents (/.well-known/…); everything else is the umbrella wire. Route by
+  // path so both share one loopback origin (10-mcp-umbrella-hookup §4).
+  const httpServer = createServer((req, res) => {
+    const path = (req.url ?? "/").split("?", 1)[0] ?? "/";
+    const toDoor = door !== undefined
+      && (path === "/api/vendo/mcp" || path.startsWith("/api/vendo/mcp/") || path.startsWith("/.well-known/"));
+    void forwardToWire(req, res, toDoor ? door!.handler : vendo.handler);
+  });
   await new Promise<void>((resolve, reject) => {
     httpServer.once("error", reject);
     httpServer.listen(0, "127.0.0.1", () => {
@@ -228,10 +293,15 @@ export async function createStack(options: StackOptions = {}): Promise<Stack> {
 
   const raw = store.raw() as { query(q: string, p?: unknown[]): Promise<{ rows: unknown[] }> };
 
+  const mcp: McpDoorHandle | undefined = door === undefined || mcpControl === undefined || mcpBound === undefined
+    ? undefined
+    : { origin: baseUrl, endpoint: `${baseUrl}/api/vendo/mcp`, bound: mcpBound, control: mcpControl };
+
   return {
     baseUrl,
     vendo,
     model,
+    ...(mcp === undefined ? {} : { mcp }),
     async wireFetch(path, init = {}, user) {
       const headers: Record<string, string> = { ...(init.headers as Record<string, string> | undefined) };
       const mutation = ["POST", "PUT", "PATCH", "DELETE"].includes((init.method ?? "GET").toUpperCase());
@@ -371,4 +441,88 @@ export async function resumeApproval(
     method: "POST",
     body: JSON.stringify({ threadId, message: { ...assistant, parts } }),
   }, user);
+}
+
+// ---------------------------------------------------------------------------
+// Automation-journey helpers (J4/J5): .vendoapp import over the wire, approval
+// decisions, and run polling with a deadline. createVendo takes no `now`, so the
+// schedule leg is driven with a PAST `at` that is due on the first /tick.
+// ---------------------------------------------------------------------------
+
+/** An ApprovalRequest as it crosses the wire (enable's `missing[]`, GET /approvals). */
+export interface WireApproval {
+  id: string;
+  call: { tool: string };
+}
+
+/** The RunRecord shape the /runs wire returns (07 §5), narrowed to the asserts. */
+export interface WireRun {
+  id: string;
+  appId: string;
+  status: "running" | "ok" | "error" | "stopped" | "pending-approval";
+  steps: Array<{ id: string; tool: string; outcome: string; detail?: string }>;
+  summary?: string;
+  error?: { code: string; message: string };
+}
+
+/** Build a `.vendoapp` archive (app.json only — no machine) from an AppDocument.
+ * The import boundary re-mints the id and re-validates the document (06 §7). */
+export function buildVendoApp(doc: AppDocument): Uint8Array {
+  return zipSync({ "app.json": new TextEncoder().encode(JSON.stringify(doc)) }, { level: 6 });
+}
+
+/** Import an automation through the PUBLIC wire (POST /apps/import,
+ * application/octet-stream). Returns the imported (fresh-id) document. */
+export async function importAutomation(stack: Stack, doc: AppDocument, user: Principal): Promise<AppDocument> {
+  const response = await stack.wireFetch("/apps/import", {
+    method: "POST",
+    headers: { "content-type": "application/octet-stream" },
+    body: buildVendoApp(doc),
+  }, user);
+  if (!response.ok) throw new Error(`import failed (${response.status}): ${await response.text()}`);
+  return (await response.json()) as AppDocument;
+}
+
+/** Decide a batch of approvals over the wire (POST /approvals/decide). */
+export async function decideApprovals(
+  stack: Stack,
+  ids: string[],
+  decision: Record<string, unknown>,
+  user: Principal,
+): Promise<Response> {
+  return stack.wireFetch("/approvals/decide", {
+    method: "POST",
+    body: JSON.stringify({ ids, decision }),
+  }, user);
+}
+
+/** Poll GET /runs/:id until it reaches `status` or the deadline passes. Away runs
+ * resume asynchronously (guard.onApprovalDecision), so callers poll; the deadline
+ * tolerates CI-grade slowness. */
+export async function waitForRunStatus(
+  stack: Stack,
+  runId: string,
+  user: Principal,
+  status: WireRun["status"],
+  timeoutMs = 30_000,
+): Promise<WireRun> {
+  const deadline = Date.now() + timeoutMs;
+  let last: string | undefined;
+  while (Date.now() <= deadline) {
+    const response = await stack.wireFetch(`/runs/${runId}`, {}, user);
+    if (response.ok) {
+      const run = (await response.json()) as WireRun;
+      last = run.status;
+      if (run.status === status) return run;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`run ${runId} did not reach ${status}; last status was ${last ?? "unknown"}`);
+}
+
+/** An ISO timestamp an hour in the past — a due `at` schedule that fires on the
+ * first /tick after enable (the deterministic public-wire way to drive a schedule
+ * trigger without clock injection). */
+export function pastAtIso(): string {
+  return new Date(Date.now() - 3_600_000).toISOString();
 }

--- a/fixtures/integration/src/mcp-door.e2e.test.ts
+++ b/fixtures/integration/src/mcp-door.e2e.test.ts
@@ -20,15 +20,18 @@
  *   - apps ride-along: a wire-created app opens over MCP for real (store read, no
  *     host auth needed).
  *
- * COMPOSITION FIX (see the second case below): route-bound HOST tools authenticate
- * over the composed door through the umbrella's own `actAs` seam. `mcpContext`
- * carries no host session and — per 10-mcp §3 (no token-passthrough) — no
- * requestHeaders, so `@vendoai/actions` route execution now treats a present
- * `venue:"mcp"` call the same session-less way it treats an away call: when
- * `actAs` is configured it mints the host request's AuthMaterial from the seam
- * (keyed on the principal), never from the inbound MCP headers. The host call
- * therefore reaches the host API as the authenticated user — one perimeter, one
- * identity path — without the hand-built injected-`fetch` mcp-e2e uses.
+ * KNOWN GAP (see the second case below): route-bound HOST tools CANNOT authenticate
+ * over the composed door under the frozen contracts today. The door correctly mints
+ * a session-less `venue:"mcp"` context per 10-mcp §3 (no token-passthrough — the
+ * inbound MCP Authorization Bearer is never forwarded, so `mcpContext` carries no
+ * requestHeaders), and `actAs` is contractually the AWAY-only, grant-REQUIRED seam
+ * (04 §4). There is no present-session host-auth seam in the frozen contracts, so a
+ * present MCP host-route call reaches the host API unauthenticated and the host
+ * answers 401. This is the real gap this suite surfaces for the
+ * `createVendo({ mcp: true })` hookup (docs/contracts/10-mcp-umbrella-hookup.md) to
+ * close with a properly designed present-session seam — it is out of scope for this
+ * additive test-suite wave. The host-route legs below assert the desired end-state
+ * with `it.fails` / an explicit gap assertion so the gap is documented, not hidden.
  */
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -100,19 +103,26 @@ describe("J6: MCP door round-trip composed around the umbrella", () => {
       // --- tools/list: descriptors match the bound registry VERBATIM --------
       const listed = await connected.client.listTools();
       const listedByName = new Map(listed.tools.map((tool) => [tool.name, descriptorShape(tool)]));
-      for (const descriptor of await stack.mcp!.bound.descriptors()) {
+      const boundDescriptors = await stack.mcp!.bound.descriptors();
+      for (const descriptor of boundDescriptors) {
         expect(listedByName.get(descriptor.name)).toEqual({
           name: descriptor.name,
           description: descriptor.description,
           inputSchema: descriptor.inputSchema,
         });
       }
-      // The vendo_apps_* capability tools are served too.
-      expect(listed.tools.map((tool) => tool.name)).toEqual(expect.arrayContaining([
-        "vendo_apps_create",
-        "vendo_apps_open",
-        "vendo_apps_list",
-      ]));
+      // EXACT set, not a subset: tools/list serves the bound registry (10-mcp §2
+      // "no second catalog" of HOST tools) PLUS exactly the door's own three
+      // apps ride-along capability tools (10-mcp §4, door = viewer + runner):
+      // vendo_apps_list / vendo_apps_open / vendo_apps_call, served from the
+      // composed AppsPort, not the actions registry. Asserting equality against
+      // this closed union still fails on ANY unguarded extra surface — a tool in
+      // tools/list that is neither a bound descriptor nor a known ride-along tool.
+      const APP_RIDE_ALONG = ["vendo_apps_list", "vendo_apps_open", "vendo_apps_call"];
+      const expectedNames = [
+        ...new Set([...boundDescriptors.map((descriptor) => descriptor.name), ...APP_RIDE_ALONG]),
+      ].sort();
+      expect(listed.tools.map((tool) => tool.name).sort()).toEqual(expectedNames);
 
       // --- Destructive call PARKS in-band (never a JSON-RPC error) ----------
       const parked = await connected.client.callTool({ name: "host_invoices_delete", arguments: { id: "inv_0003" } });
@@ -137,17 +147,26 @@ describe("J6: MCP door round-trip composed around the umbrella", () => {
 
       // ONE approvals plane: the wire decision authorizes the MCP retry — the
       // guard no longer parks it (it proceeds straight to execution, minting no
-      // new approval). Robust to the host-auth gap below: whether execution
-      // succeeds or errors at the host, the guard did NOT re-ask.
+      // new approval). We prove the guard-plane claim WITHOUT asserting host
+      // success, because the host DELETE over MCP genuinely cannot succeed today
+      // (the same present-session host-auth KNOWN GAP as the second case below).
       const retried = await connected.client.callTool({ name: "host_invoices_delete", arguments: { id: "inv_0003" } });
+      // (a) no NEW approval was minted — the guard did not re-ask.
       expect(textOf(retried)).not.toMatch(/apr_/);
       expect(await stack.wireFetch("/approvals", {}, ADA).then((response) => response.json())).toEqual([]);
-      // The retry is authorized by the wire-minted grant (05 §6 decidedBy=grant).
+      // (b) the retry is authorized by the wire-minted grant (05 §6 decidedBy=grant).
       expect(await stack.sql<{ decided_by: string }>(
         `SELECT event->>'decidedBy' AS decided_by FROM vendo_audit
           WHERE kind = 'tool-call' AND tool = 'host_invoices_delete' AND venue = 'mcp'
           ORDER BY at DESC LIMIT 1`,
       )).toEqual([{ decided_by: "grant" }]);
+      // (c) the retry's failure mode is the host-auth GAP, NOT an approval park:
+      // the guard let it through to real host execution, which 401s because there
+      // is no present-session host-auth seam. When the createVendo({ mcp: true })
+      // hookup lands that seam (docs/contracts/10-mcp-umbrella-hookup.md), this
+      // becomes a real-deletion assert (inv_0003 gone from the host).
+      expect(retried.isError).toBe(true);
+      expect(textOf(retried)).toMatch(/http-error:.*→ 401/);
 
       // --- Apps ride-along: open a wire-created app over the door for real ---
       const opened = await connected.client.callTool({ name: "vendo_apps_open", arguments: { appId: app.id } });
@@ -172,14 +191,18 @@ describe("J6: MCP door round-trip composed around the umbrella", () => {
     }
   });
 
-  // COMPOSITION FIX — the CORRECT contract behavior (10-mcp §2: an authenticated
-  // MCP tool call gets "identical treatment to chat"). The composed umbrella now
-  // authenticates present MCP host-route calls through its own `actAs` seam
-  // (mcpContext carries no host session and no requestHeaders, so actions mints
-  // host AuthMaterial from actAs — keyed on the principal — exactly as it does for
-  // an away call). The read below therefore reaches the host API as user_ada and
-  // returns real invoices instead of `http-error: GET /api/invoices → 401`.
-  it("a read host tool over the door executes for real against the host app", async () => {
+  // KNOWN GAP (it.fails documents the DESIRED end-state, which does NOT hold today).
+  // 10-mcp §2 says an authenticated MCP tool call should get "identical treatment to
+  // chat", but a present MCP host-route call cannot authenticate under the composed
+  // umbrella: the door mints a session-less venue:"mcp" context (10-mcp §3, no
+  // token-passthrough — no requestHeaders), and actAs is the away-only, grant-required
+  // seam (04 §4), so there is no frozen-contract seam to mint host AuthMaterial for a
+  // present read. The read below therefore reaches the host API unauthenticated and
+  // gets `http-error: GET /api/invoices → 401` instead of real invoices. The
+  // createVendo({ mcp: true }) hookup (docs/contracts/10-mcp-umbrella-hookup.md) closes
+  // this with a properly designed present-session host-auth seam; when it lands, flip
+  // `it.fails` back to `it` and this passes.
+  it.fails("a read host tool over the door executes for real against the host app", async () => {
     await resetFixture();
     stack = await createStack({ mcp: true });
     const connected = await connectWithSdk(stack.mcp!.endpoint);

--- a/fixtures/integration/src/mcp-door.e2e.test.ts
+++ b/fixtures/integration/src/mcp-door.e2e.test.ts
@@ -1,0 +1,193 @@
+/** J6 — MCP DOOR ROUND-TRIP composed around the umbrella's own parts.
+ *
+ * The `createVendo({ mcp: true })` hookup is an unlanded handoff
+ * (docs/contracts/10-mcp-umbrella-hookup.md), so the harness mounts `createMcpDoor`
+ * beside `vendo.handler` on the SAME loopback origin, fed the umbrella's composed
+ * parts: the guard-bound registry (`vendo.guard.bind(vendo.actions)`), the same
+ * `vendo.guard`, `vendo.store`, a fixture `HostOAuthAdapter`, and an `AppsPort`
+ * over `vendo.apps`.
+ *
+ * This journey does NOT re-prove door-internal OAuth conformance (fixtures/mcp-e2e
+ * owns that). It proves the door COMPOSES correctly around the umbrella and shares
+ * ONE guard / audit / approval plane with chat:
+ *   - unauthenticated → 401 + WWW-Authenticate → path-inserted metadata discovery
+ *     → OAuth (PKCE, resource) → initialize → tools/list (verbatim vs the bound
+ *     registry, incl. the vendo_apps_* capability tools);
+ *   - a destructive call PARKS in-band (never a protocol error) naming the
+ *     approval, which is visible at GET /approvals ON THE WIRE — then DECIDED over
+ *     the wire, and the guard lets the MCP retry through (ONE approvals plane);
+ *   - SQL: vendo_audit venue='mcp', door-auth events, door state rows;
+ *   - apps ride-along: a wire-created app opens over MCP for real (store read, no
+ *     host auth needed).
+ *
+ * ⚠ COMPOSITION FINDING (see the `it.fails` case below): route-bound HOST tools
+ * cannot authenticate over the composed door — `mcpContext` carries no session and
+ * `createVendo` exposes `actAs` only for `presence:"away"`, so present MCP host
+ * calls reach the host API with no credentials (401). mcp-e2e masks this by
+ * injecting an authenticating `fetch` into a hand-built `createActions`; the
+ * umbrella exposes no such seam.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ADA,
+  createStack,
+  generationTurn,
+  resetFixture,
+  type Stack,
+} from "./harness.js";
+import { connectWithSdk, descriptorShape, textOf } from "./mcp-support.js";
+
+const CREATE_DIALECT = {
+  name: "MCP ride-along app",
+  description: "A rung-1 tree opened over the door",
+  tree: {
+    formatVersion: "vendo-genui/v1",
+    root: "root",
+    nodes: [
+      { id: "root", component: "Stack", source: "prewired", children: ["hi"] },
+      { id: "hi", component: "Text", source: "prewired", props: { text: "Hello over MCP" } },
+    ],
+  },
+};
+
+let stack: Stack;
+afterEach(async () => {
+  await stack?.close();
+});
+
+describe("J6: MCP door round-trip composed around the umbrella", () => {
+  it("discovers, authenticates, lists verbatim, parks in-band, shares one approvals plane with the wire, and opens an app", async () => {
+    await resetFixture();
+    stack = await createStack({ mcp: true, turns: [generationTurn(CREATE_DIALECT)] });
+    const { origin, endpoint } = stack.mcp!;
+
+    // A wire-created app to ride along over the door (store-only, no host auth).
+    const app = (await (await stack.wireFetch("/apps", {
+      method: "POST",
+      body: JSON.stringify({ prompt: "greeting" }),
+    }, ADA)).json()) as { id: string };
+
+    // --- 401 + WWW-Authenticate naming the path-inserted metadata URL -------
+    const resourceMetadataUrl = `${origin}/.well-known/oauth-protected-resource/api/vendo/mcp`;
+    const challenge = await fetch(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
+    });
+    expect(challenge.status).toBe(401);
+    expect(challenge.headers.get("www-authenticate")).toBe(`Bearer resource_metadata="${resourceMetadataUrl}"`);
+
+    // Discovery documents resolve at the origin root (RFC 9728 §3 path-inserted).
+    const protectedResource = await fetch(resourceMetadataUrl);
+    expect(protectedResource.status).toBe(200);
+    expect(await protectedResource.json()).toMatchObject({
+      resource: endpoint,
+      authorization_servers: [endpoint],
+    });
+
+    // --- OAuth round trip + initialize via the REAL MCP SDK client ----------
+    const connected = await connectWithSdk(endpoint);
+    try {
+      // The SDK walked discovery → registration → token against the door.
+      expect(connected.requests.map(String)).toEqual(expect.arrayContaining([
+        resourceMetadataUrl,
+        `${endpoint}/token`,
+      ]));
+
+      // --- tools/list: descriptors match the bound registry VERBATIM --------
+      const listed = await connected.client.listTools();
+      const listedByName = new Map(listed.tools.map((tool) => [tool.name, descriptorShape(tool)]));
+      for (const descriptor of await stack.mcp!.bound.descriptors()) {
+        expect(listedByName.get(descriptor.name)).toEqual({
+          name: descriptor.name,
+          description: descriptor.description,
+          inputSchema: descriptor.inputSchema,
+        });
+      }
+      // The vendo_apps_* capability tools are served too.
+      expect(listed.tools.map((tool) => tool.name)).toEqual(expect.arrayContaining([
+        "vendo_apps_create",
+        "vendo_apps_open",
+        "vendo_apps_list",
+      ]));
+
+      // --- Destructive call PARKS in-band (never a JSON-RPC error) ----------
+      const parked = await connected.client.callTool({ name: "host_invoices_delete", arguments: { id: "inv_0003" } });
+      expect(parked.isError).toBe(true);
+      const approvalId = textOf(parked).match(/apr_[0-9a-f-]+/)?.[0];
+      expect(approvalId).toMatch(/^apr_/);
+
+      // The MCP-minted approval is on the SAME plane: visible at GET /approvals
+      // over the WIRE (venue mcp / present), decided over the wire.
+      const pending = (await (await stack.wireFetch("/approvals", {}, ADA)).json()) as Array<{ id: string }>;
+      expect(pending.map((request) => request.id)).toContain(approvalId);
+      expect(await stack.sql("SELECT id FROM vendo_approvals WHERE id = $1 AND status = 'pending'", [approvalId]))
+        .toHaveLength(1);
+
+      expect((await stack.wireFetch("/approvals/decide", {
+        method: "POST",
+        body: JSON.stringify({
+          ids: [approvalId],
+          decision: { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+        }),
+      }, ADA)).status).toBe(200);
+
+      // ONE approvals plane: the wire decision authorizes the MCP retry — the
+      // guard no longer parks it (it proceeds straight to execution, minting no
+      // new approval). Robust to the host-auth gap below: whether execution
+      // succeeds or errors at the host, the guard did NOT re-ask.
+      const retried = await connected.client.callTool({ name: "host_invoices_delete", arguments: { id: "inv_0003" } });
+      expect(textOf(retried)).not.toMatch(/apr_/);
+      expect(await stack.wireFetch("/approvals", {}, ADA).then((response) => response.json())).toEqual([]);
+      // The retry is authorized by the wire-minted grant (05 §6 decidedBy=grant).
+      expect(await stack.sql<{ decided_by: string }>(
+        `SELECT event->>'decidedBy' AS decided_by FROM vendo_audit
+          WHERE kind = 'tool-call' AND tool = 'host_invoices_delete' AND venue = 'mcp'
+          ORDER BY at DESC LIMIT 1`,
+      )).toEqual([{ decided_by: "grant" }]);
+
+      // --- Apps ride-along: open a wire-created app over the door for real ---
+      const opened = await connected.client.callTool({ name: "vendo_apps_open", arguments: { appId: app.id } });
+      expect(opened.isError).not.toBe(true);
+      expect(textOf(opened)).toContain("vendo-genui/v1");
+
+      // --- SQL: door shares the audit plane, keeps its own protocol state ----
+      expect(await stack.sql(
+        "SELECT DISTINCT venue FROM vendo_audit WHERE kind = 'tool-call' AND tool = 'host_invoices_delete'",
+      )).toEqual([{ venue: "mcp" }]);
+      expect(await stack.sql(
+        "SELECT DISTINCT venue FROM vendo_audit WHERE kind = 'door-auth'",
+      )).toEqual([{ venue: "mcp" }]);
+      expect(Number((await stack.sql<{ count: unknown }>(
+        "SELECT COUNT(*)::int AS count FROM vendo_mcp_clients",
+      ))[0]?.count)).toBeGreaterThanOrEqual(1);
+      expect(Number((await stack.sql<{ count: unknown }>(
+        "SELECT COUNT(*)::int AS count FROM vendo_mcp_grants",
+      ))[0]?.count)).toBeGreaterThanOrEqual(1);
+    } finally {
+      await connected.close();
+    }
+  });
+
+  // COMPOSITION FINDING — asserts the CORRECT contract behavior (10-mcp §2: an
+  // authenticated MCP tool call gets "identical treatment to chat"). It currently
+  // FAILS because the composed umbrella has no seam to authenticate present MCP
+  // host-route calls (mcpContext carries no session; actAs is away-only), so the
+  // call reaches the host API unauthenticated (401). Remove `.fails` when the
+  // umbrella grows a host-call identity seam for the door. Evidence: the read call
+  // below returns `http-error: GET /api/invoices → 401`.
+  it.fails("a read host tool over the door executes for real against the host app", async () => {
+    await resetFixture();
+    stack = await createStack({ mcp: true });
+    const connected = await connectWithSdk(stack.mcp!.endpoint);
+    try {
+      const call = await connected.client.callTool({ name: "host_invoices_list", arguments: {} });
+      expect(call.isError).not.toBe(true);
+      expect(JSON.parse(textOf(call))).toMatchObject({
+        invoices: expect.arrayContaining([expect.objectContaining({ id: "inv_0003" })]),
+      });
+    } finally {
+      await connected.close();
+    }
+  });
+});

--- a/fixtures/integration/src/mcp-door.e2e.test.ts
+++ b/fixtures/integration/src/mcp-door.e2e.test.ts
@@ -20,12 +20,15 @@
  *   - apps ride-along: a wire-created app opens over MCP for real (store read, no
  *     host auth needed).
  *
- * ⚠ COMPOSITION FINDING (see the `it.fails` case below): route-bound HOST tools
- * cannot authenticate over the composed door — `mcpContext` carries no session and
- * `createVendo` exposes `actAs` only for `presence:"away"`, so present MCP host
- * calls reach the host API with no credentials (401). mcp-e2e masks this by
- * injecting an authenticating `fetch` into a hand-built `createActions`; the
- * umbrella exposes no such seam.
+ * COMPOSITION FIX (see the second case below): route-bound HOST tools authenticate
+ * over the composed door through the umbrella's own `actAs` seam. `mcpContext`
+ * carries no host session and — per 10-mcp §3 (no token-passthrough) — no
+ * requestHeaders, so `@vendoai/actions` route execution now treats a present
+ * `venue:"mcp"` call the same session-less way it treats an away call: when
+ * `actAs` is configured it mints the host request's AuthMaterial from the seam
+ * (keyed on the principal), never from the inbound MCP headers. The host call
+ * therefore reaches the host API as the authenticated user — one perimeter, one
+ * identity path — without the hand-built injected-`fetch` mcp-e2e uses.
  */
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -169,14 +172,14 @@ describe("J6: MCP door round-trip composed around the umbrella", () => {
     }
   });
 
-  // COMPOSITION FINDING — asserts the CORRECT contract behavior (10-mcp §2: an
-  // authenticated MCP tool call gets "identical treatment to chat"). It currently
-  // FAILS because the composed umbrella has no seam to authenticate present MCP
-  // host-route calls (mcpContext carries no session; actAs is away-only), so the
-  // call reaches the host API unauthenticated (401). Remove `.fails` when the
-  // umbrella grows a host-call identity seam for the door. Evidence: the read call
-  // below returns `http-error: GET /api/invoices → 401`.
-  it.fails("a read host tool over the door executes for real against the host app", async () => {
+  // COMPOSITION FIX — the CORRECT contract behavior (10-mcp §2: an authenticated
+  // MCP tool call gets "identical treatment to chat"). The composed umbrella now
+  // authenticates present MCP host-route calls through its own `actAs` seam
+  // (mcpContext carries no host session and no requestHeaders, so actions mints
+  // host AuthMaterial from actAs — keyed on the principal — exactly as it does for
+  // an away call). The read below therefore reaches the host API as user_ada and
+  // returns real invoices instead of `http-error: GET /api/invoices → 401`.
+  it("a read host tool over the door executes for real against the host app", async () => {
     await resetFixture();
     stack = await createStack({ mcp: true });
     const connected = await connectWithSdk(stack.mcp!.endpoint);

--- a/fixtures/integration/src/mcp-door.e2e.test.ts
+++ b/fixtures/integration/src/mcp-door.e2e.test.ts
@@ -1,5 +1,19 @@
 /** J6 — MCP DOOR ROUND-TRIP composed around the umbrella's own parts.
  *
+ * ┌─ ACCEPTANCE TEST for the v0-mcp-hookup wave ───────────────────────────────┐
+ * │ This journey is the acceptance test for the dedicated MCP-hookup wave       │
+ * │ (`createVendo({ mcp: true })` + actAs-for-venue="mcp" host auth). When that  │
+ * │ wave lands, host-route auth over the door starts working, so it must FLIP    │
+ * │ the two fail-closed legs marked `⚑ HOOKUP FLIP` below to green:              │
+ * │   1. the `it.fails(...)` "a read host tool over the door executes for real"  │
+ * │      → change to `it(...)` and keep the real-invoice assertion; and          │
+ * │   2. the retried-destructive assertion in the main test (currently asserts   │
+ * │      isError + the 401 gap signature) → assert the real host DELETE landed.  │
+ * │ Until then these legs assert the current fail-closed behavior so the gap is  │
+ * │ documented, never hidden. Do NOT delete this journey. See the KNOWN GAP      │
+ * │ note below and docs/contracts/10-mcp-umbrella-hookup.md.                     │
+ * └────────────────────────────────────────────────────────────────────────────┘
+ *
  * The `createVendo({ mcp: true })` hookup is an unlanded handoff
  * (docs/contracts/10-mcp-umbrella-hookup.md), so the harness mounts `createMcpDoor`
  * beside `vendo.handler` on the SAME loopback origin, fed the umbrella's composed
@@ -165,6 +179,7 @@ describe("J6: MCP door round-trip composed around the umbrella", () => {
       // is no present-session host-auth seam. When the createVendo({ mcp: true })
       // hookup lands that seam (docs/contracts/10-mcp-umbrella-hookup.md), this
       // becomes a real-deletion assert (inv_0003 gone from the host).
+      // ⚑ HOOKUP FLIP (2/2): replace these two asserts with a real host-DELETE assert.
       expect(retried.isError).toBe(true);
       expect(textOf(retried)).toMatch(/http-error:.*→ 401/);
 
@@ -202,6 +217,7 @@ describe("J6: MCP door round-trip composed around the umbrella", () => {
   // createVendo({ mcp: true }) hookup (docs/contracts/10-mcp-umbrella-hookup.md) closes
   // this with a properly designed present-session host-auth seam; when it lands, flip
   // `it.fails` back to `it` and this passes.
+  // ⚑ HOOKUP FLIP (1/2): change `it.fails` → `it` once host-route auth works.
   it.fails("a read host tool over the door executes for real against the host app", async () => {
     await resetFixture();
     stack = await createStack({ mcp: true });

--- a/fixtures/integration/src/mcp-support.ts
+++ b/fixtures/integration/src/mcp-support.ts
@@ -1,0 +1,126 @@
+/** MCP SDK client-driving helpers for J6, ported from fixtures/mcp-e2e/src/support.ts
+ * (that suite owns door-internal OAuth conformance; this one reuses its client
+ * plumbing to prove the door composes around the umbrella's parts). Adapted to
+ * take the door endpoint URL directly rather than the mcp-e2e Stack shape. */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { expect } from "vitest";
+
+export const REDIRECT_URI = "http://127.0.0.1/callback";
+
+type ClientInformation = Parameters<NonNullable<OAuthClientProvider["saveClientInformation"]>>[0];
+type Tokens = Parameters<OAuthClientProvider["saveTokens"]>[0];
+
+export class TestOAuthProvider implements OAuthClientProvider {
+  authorizationUrl?: URL;
+  information?: ClientInformation;
+  savedTokens?: Tokens;
+  verifier?: string;
+
+  get redirectUrl(): URL {
+    return new URL(REDIRECT_URI);
+  }
+
+  get clientMetadata() {
+    return {
+      client_name: "Vendo integration MCP",
+      redirect_uris: [REDIRECT_URI],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+      scope: "read write",
+    };
+  }
+
+  clientInformation(): ClientInformation | undefined {
+    return this.information;
+  }
+
+  saveClientInformation(clientInformation: ClientInformation): void {
+    this.information = clientInformation;
+  }
+
+  tokens(): Tokens | undefined {
+    return this.savedTokens;
+  }
+
+  saveTokens(tokens: Tokens): void {
+    this.savedTokens = tokens;
+  }
+
+  redirectToAuthorization(authorizationUrl: URL): void {
+    this.authorizationUrl = authorizationUrl;
+  }
+
+  saveCodeVerifier(codeVerifier: string): void {
+    this.verifier = codeVerifier;
+  }
+
+  codeVerifier(): string {
+    if (!this.verifier) throw new Error("SDK did not save a PKCE verifier");
+    return this.verifier;
+  }
+}
+
+export interface ConnectedClient {
+  client: Client;
+  transport: StreamableHTTPClientTransport;
+  provider: TestOAuthProvider;
+  requests: URL[];
+  close(): Promise<void>;
+}
+
+/** Drive the real MCP SDK through the full 401 → discovery → OAuth → connect
+ * round trip against the door mounted at `endpoint`. */
+export async function connectWithSdk(endpoint: string): Promise<ConnectedClient> {
+  const provider = new TestOAuthProvider();
+  const requests: URL[] = [];
+  const trackedFetch: typeof fetch = async (input, init) => {
+    requests.push(new URL(input instanceof Request ? input.url : input));
+    return fetch(input, init);
+  };
+  const firstTransport = new StreamableHTTPClientTransport(new URL(endpoint), {
+    authProvider: provider,
+    fetch: trackedFetch,
+  });
+  const firstClient = new Client({ name: "vendo-integration-mcp", version: "1.0.0" });
+  await expect(firstClient.connect(firstTransport)).rejects.toBeInstanceOf(UnauthorizedError);
+  const authorizationUrl = provider.authorizationUrl;
+  if (!authorizationUrl) throw new Error("SDK did not request an OAuth redirect");
+  const authorization = await fetch(authorizationUrl, { redirect: "manual" });
+  expect(authorization.status).toBe(302);
+  const location = authorization.headers.get("location");
+  if (!location) throw new Error("Authorization did not return a redirect location");
+  const code = new URL(location).searchParams.get("code");
+  if (!code) throw new Error("Authorization redirect omitted the code");
+  await firstTransport.finishAuth(code);
+  await firstTransport.close();
+
+  const transport = new StreamableHTTPClientTransport(new URL(endpoint), {
+    authProvider: provider,
+    fetch: trackedFetch,
+  });
+  const client = new Client({ name: "vendo-integration-mcp", version: "1.0.0" });
+  await client.connect(transport);
+  return {
+    client,
+    transport,
+    provider,
+    requests,
+    async close() {
+      await client.close();
+    },
+  };
+}
+
+export function descriptorShape(tool: Tool) {
+  return { name: tool.name, description: tool.description, inputSchema: tool.inputSchema };
+}
+
+export function textOf(result: unknown): string {
+  const content = (result as { content?: Array<{ type: string; text?: string }> }).content;
+  return content?.find((part) => part.type === "text")?.text ?? "";
+}

--- a/fixtures/integration/tsconfig.json
+++ b/fixtures/integration/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/fixtures/integration/vitest.config.ts
+++ b/fixtures/integration/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.e2e.test.ts", "src/**/*.test.ts"],
+    globalSetup: ["./src/global-setup.ts"],
+    // One shared fixture host-app server + suites that reset its seed data:
+    // parallel files would race each other's resets. Also: each stack boots the
+    // real composed umbrella and reads `.vendo/` files from cwd — serial keeps
+    // that deterministic.
+    fileParallelism: false,
+    // The suites boot a real Next.js fixture server and a real (PGlite) store,
+    // and drive real generation turns; give slow first-compiles room.
+    testTimeout: 120_000,
+    hookTimeout: 180_000,
+  },
+});

--- a/packages/actions/src/runtime/registry.ts
+++ b/packages/actions/src/runtime/registry.ts
@@ -280,27 +280,6 @@ async function executeHost(config: RegistryConfig, tool: ExtractedTool, call: To
     } catch (cause) {
       return error("act-as-error", cause instanceof Error ? cause.message : "away authentication failed");
     }
-  } else if (ctx.venue === "mcp" && config.actAs) {
-    // An MCP request shares the host's perimeter (10-mcp §2 — identical treatment
-    // to chat) but carries NO host session: the inbound MCP Authorization Bearer
-    // must NEVER be forwarded to the host (10-mcp §3, no token-passthrough — the
-    // door structurally omits requestHeaders). So a present MCP host-route call
-    // authenticates through the SAME session-less seam an away call uses — actAs,
-    // whose host-issued AuthMaterial is keyed on the principal — not through
-    // ctx.requestHeaders. The guard relays a grant only when one authorized the
-    // run (e.g. a standing grant on a parked-then-approved retry); a present read
-    // has none, and we pass it through verbatim rather than fabricate one. When
-    // actAs is NOT configured, execution falls through to the present branch below
-    // (forward ctx.requestHeaders ?? {}), preserving the injected-fetch harness
-    // mcp-e2e depends on.
-    const grant = (ctx as ActionsRunContext).grant;
-    try {
-      const auth = await config.actAs(ctx.principal, grant as PermissionGrant);
-      if (!auth) return error("not-implemented", "the host declined MCP execution for this action");
-      headers = { ...auth.headers };
-    } catch (cause) {
-      return error("act-as-error", cause instanceof Error ? cause.message : "MCP authentication failed");
-    }
   } else {
     headers = mayForwardPresentHeaders(tool.binding, url, config.baseUrl, config.baseUrlTrusted ?? true)
       ? forwardedHeaders(ctx)

--- a/packages/actions/src/runtime/registry.ts
+++ b/packages/actions/src/runtime/registry.ts
@@ -280,6 +280,27 @@ async function executeHost(config: RegistryConfig, tool: ExtractedTool, call: To
     } catch (cause) {
       return error("act-as-error", cause instanceof Error ? cause.message : "away authentication failed");
     }
+  } else if (ctx.venue === "mcp" && config.actAs) {
+    // An MCP request shares the host's perimeter (10-mcp §2 — identical treatment
+    // to chat) but carries NO host session: the inbound MCP Authorization Bearer
+    // must NEVER be forwarded to the host (10-mcp §3, no token-passthrough — the
+    // door structurally omits requestHeaders). So a present MCP host-route call
+    // authenticates through the SAME session-less seam an away call uses — actAs,
+    // whose host-issued AuthMaterial is keyed on the principal — not through
+    // ctx.requestHeaders. The guard relays a grant only when one authorized the
+    // run (e.g. a standing grant on a parked-then-approved retry); a present read
+    // has none, and we pass it through verbatim rather than fabricate one. When
+    // actAs is NOT configured, execution falls through to the present branch below
+    // (forward ctx.requestHeaders ?? {}), preserving the injected-fetch harness
+    // mcp-e2e depends on.
+    const grant = (ctx as ActionsRunContext).grant;
+    try {
+      const auth = await config.actAs(ctx.principal, grant as PermissionGrant);
+      if (!auth) return error("not-implemented", "the host declined MCP execution for this action");
+      headers = { ...auth.headers };
+    } catch (cause) {
+      return error("act-as-error", cause instanceof Error ? cause.message : "MCP authentication failed");
+    }
   } else {
     headers = mayForwardPresentHeaders(tool.binding, url, config.baseUrl, config.baseUrlTrusted ?? true)
       ? forwardedHeaders(ctx)

--- a/packages/actions/src/security/actions-no-selfauth.test.ts
+++ b/packages/actions/src/security/actions-no-selfauth.test.ts
@@ -29,6 +29,13 @@ const present: RunContext = {
 
 const away: RunContext = { ...present, presence: "away" };
 
+const mcpPresent: RunContext = {
+  principal: { kind: "user", subject: "user_1" },
+  venue: "mcp",
+  presence: "present",
+  sessionId: "mcpr_1",
+};
+
 describe("actions never self-authorizes away execution", () => {
   it("returns a clean not-implemented error for an away call when actAs is absent", async () => {
     const fetchSpy = vi.fn();
@@ -119,6 +126,99 @@ describe("actions never self-authorizes away execution", () => {
     const headers = (fetchSpy.mock.calls[0]?.[1] as RequestInit).headers as Record<string, string>;
     expect(headers.cookie).toBe("session=user_1");
     expect(headers.authorization).toBe("Bearer inbound");
+  });
+
+  // An MCP request carries no host session (the door mints venue "mcp",
+  // presence "present", and — per 10-mcp §3's no-token-passthrough rule — NO
+  // requestHeaders). A present MCP host-route call must therefore authenticate
+  // through the session-less actAs seam, exactly as an away call does, never by
+  // forwarding the inbound MCP headers.
+  it("authenticates a present MCP host-route call via actAs, never forwarding the inbound headers", async () => {
+    const actAs = vi.fn(async () => ({ headers: { cookie: "host-session=user_1" } }));
+    const fetchSpy = vi.fn(async () => new Response(JSON.stringify({ ok: true }), {
+      headers: { "content-type": "application/json" },
+    }));
+    const actions = createActions({
+      tools: [routeTool("host_probe")],
+      baseUrl: "http://host.test",
+      actAs,
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+
+    const ctx: RunContext = {
+      ...mcpPresent,
+      // A hostile inbound MCP request may carry its OWN Authorization bearer plus
+      // an attacker-chosen cookie; NEITHER may reach the host (10-mcp §3).
+      requestHeaders: { authorization: "Bearer mcp-client-token", cookie: "mcp=should-not-forward" },
+    };
+    await expect(actions.execute({ id: "1", tool: "host_probe", args: {} }, ctx))
+      .resolves.toMatchObject({ status: "ok" });
+
+    expect(actAs).toHaveBeenCalledTimes(1);
+    // A present read has no captured grant; actAs is invoked with the principal
+    // and NO fabricated grant.
+    expect(actAs.mock.calls[0]?.[0]).toEqual(mcpPresent.principal);
+    expect(actAs.mock.calls[0]?.[1]).toBeUndefined();
+
+    const headers = (fetchSpy.mock.calls[0]?.[1] as RequestInit).headers as Record<string, string>;
+    // Only the host-issued AuthMaterial rides the request.
+    expect(headers.cookie).toBe("host-session=user_1");
+    // Defense-in-depth for the no-passthrough rule: the MCP client's own
+    // Authorization is dropped entirely, even though it was present on ctx.
+    expect(headers.authorization).toBeUndefined();
+  });
+
+  it("passes the guard-relayed grant to actAs when the MCP call was grant-authorized", async () => {
+    const actAs = vi.fn(async () => ({ headers: { cookie: "host-session=user_1" } }));
+    const fetchSpy = vi.fn(async () => new Response(JSON.stringify({ ok: true }), {
+      headers: { "content-type": "application/json" },
+    }));
+    const actions = createActions({
+      tools: [routeTool("host_probe", { risk: "destructive" })],
+      baseUrl: "http://host.test",
+      actAs,
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+
+    // A standing grant that authorized a parked-then-approved destructive retry
+    // is relayed on ctx.grant; it rides to actAs verbatim.
+    const grant = {
+      id: "grt_1",
+      subject: "user_1",
+      tool: "host_probe",
+      descriptorHash: "hash",
+      scope: { kind: "tool" as const },
+      duration: "standing" as const,
+      source: "chat" as const,
+      grantedAt: "2026-07-12T00:00:00.000Z",
+    };
+    const ctx: ActionsRunContext = { ...mcpPresent, grant };
+    await expect(actions.execute({ id: "1", tool: "host_probe", args: {} }, ctx))
+      .resolves.toMatchObject({ status: "ok" });
+
+    expect(actAs).toHaveBeenCalledTimes(1);
+    expect(actAs.mock.calls[0]?.[1]).toEqual(grant);
+  });
+
+  it("without actAs, keeps legacy present-forwarding so the injected-fetch harness (mcp-e2e) is unchanged", async () => {
+    const fetchSpy = vi.fn(async () => new Response(JSON.stringify({ ok: true }), {
+      headers: { "content-type": "application/json" },
+    }));
+    const actions = createActions({
+      tools: [routeTool("host_probe")],
+      baseUrl: "http://host.test",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+
+    const ctx: RunContext = { ...mcpPresent, requestHeaders: { cookie: "session=user_1" } };
+    await expect(actions.execute({ id: "1", tool: "host_probe", args: {} }, ctx))
+      .resolves.toMatchObject({ status: "ok" });
+
+    const headers = (fetchSpy.mock.calls[0]?.[1] as RequestInit).headers as Record<string, string>;
+    // No actAs seam → today's behavior is preserved: the trusted same-origin base
+    // forwards the inbound headers (mcp-e2e supplies auth via an injected fetch,
+    // not requestHeaders, so it keeps working untouched).
+    expect(headers.cookie).toBe("session=user_1");
   });
 
   it("treats an unannotated connector tool as risk=write (conservative default)", async () => {

--- a/packages/actions/src/security/actions-no-selfauth.test.ts
+++ b/packages/actions/src/security/actions-no-selfauth.test.ts
@@ -29,13 +29,6 @@ const present: RunContext = {
 
 const away: RunContext = { ...present, presence: "away" };
 
-const mcpPresent: RunContext = {
-  principal: { kind: "user", subject: "user_1" },
-  venue: "mcp",
-  presence: "present",
-  sessionId: "mcpr_1",
-};
-
 describe("actions never self-authorizes away execution", () => {
   it("returns a clean not-implemented error for an away call when actAs is absent", async () => {
     const fetchSpy = vi.fn();
@@ -126,99 +119,6 @@ describe("actions never self-authorizes away execution", () => {
     const headers = (fetchSpy.mock.calls[0]?.[1] as RequestInit).headers as Record<string, string>;
     expect(headers.cookie).toBe("session=user_1");
     expect(headers.authorization).toBe("Bearer inbound");
-  });
-
-  // An MCP request carries no host session (the door mints venue "mcp",
-  // presence "present", and — per 10-mcp §3's no-token-passthrough rule — NO
-  // requestHeaders). A present MCP host-route call must therefore authenticate
-  // through the session-less actAs seam, exactly as an away call does, never by
-  // forwarding the inbound MCP headers.
-  it("authenticates a present MCP host-route call via actAs, never forwarding the inbound headers", async () => {
-    const actAs = vi.fn(async () => ({ headers: { cookie: "host-session=user_1" } }));
-    const fetchSpy = vi.fn(async () => new Response(JSON.stringify({ ok: true }), {
-      headers: { "content-type": "application/json" },
-    }));
-    const actions = createActions({
-      tools: [routeTool("host_probe")],
-      baseUrl: "http://host.test",
-      actAs,
-      fetch: fetchSpy as unknown as typeof fetch,
-    });
-
-    const ctx: RunContext = {
-      ...mcpPresent,
-      // A hostile inbound MCP request may carry its OWN Authorization bearer plus
-      // an attacker-chosen cookie; NEITHER may reach the host (10-mcp §3).
-      requestHeaders: { authorization: "Bearer mcp-client-token", cookie: "mcp=should-not-forward" },
-    };
-    await expect(actions.execute({ id: "1", tool: "host_probe", args: {} }, ctx))
-      .resolves.toMatchObject({ status: "ok" });
-
-    expect(actAs).toHaveBeenCalledTimes(1);
-    // A present read has no captured grant; actAs is invoked with the principal
-    // and NO fabricated grant.
-    expect(actAs.mock.calls[0]?.[0]).toEqual(mcpPresent.principal);
-    expect(actAs.mock.calls[0]?.[1]).toBeUndefined();
-
-    const headers = (fetchSpy.mock.calls[0]?.[1] as RequestInit).headers as Record<string, string>;
-    // Only the host-issued AuthMaterial rides the request.
-    expect(headers.cookie).toBe("host-session=user_1");
-    // Defense-in-depth for the no-passthrough rule: the MCP client's own
-    // Authorization is dropped entirely, even though it was present on ctx.
-    expect(headers.authorization).toBeUndefined();
-  });
-
-  it("passes the guard-relayed grant to actAs when the MCP call was grant-authorized", async () => {
-    const actAs = vi.fn(async () => ({ headers: { cookie: "host-session=user_1" } }));
-    const fetchSpy = vi.fn(async () => new Response(JSON.stringify({ ok: true }), {
-      headers: { "content-type": "application/json" },
-    }));
-    const actions = createActions({
-      tools: [routeTool("host_probe", { risk: "destructive" })],
-      baseUrl: "http://host.test",
-      actAs,
-      fetch: fetchSpy as unknown as typeof fetch,
-    });
-
-    // A standing grant that authorized a parked-then-approved destructive retry
-    // is relayed on ctx.grant; it rides to actAs verbatim.
-    const grant = {
-      id: "grt_1",
-      subject: "user_1",
-      tool: "host_probe",
-      descriptorHash: "hash",
-      scope: { kind: "tool" as const },
-      duration: "standing" as const,
-      source: "chat" as const,
-      grantedAt: "2026-07-12T00:00:00.000Z",
-    };
-    const ctx: ActionsRunContext = { ...mcpPresent, grant };
-    await expect(actions.execute({ id: "1", tool: "host_probe", args: {} }, ctx))
-      .resolves.toMatchObject({ status: "ok" });
-
-    expect(actAs).toHaveBeenCalledTimes(1);
-    expect(actAs.mock.calls[0]?.[1]).toEqual(grant);
-  });
-
-  it("without actAs, keeps legacy present-forwarding so the injected-fetch harness (mcp-e2e) is unchanged", async () => {
-    const fetchSpy = vi.fn(async () => new Response(JSON.stringify({ ok: true }), {
-      headers: { "content-type": "application/json" },
-    }));
-    const actions = createActions({
-      tools: [routeTool("host_probe")],
-      baseUrl: "http://host.test",
-      fetch: fetchSpy as unknown as typeof fetch,
-    });
-
-    const ctx: RunContext = { ...mcpPresent, requestHeaders: { cookie: "session=user_1" } };
-    await expect(actions.execute({ id: "1", tool: "host_probe", args: {} }, ctx))
-      .resolves.toMatchObject({ status: "ok" });
-
-    const headers = (fetchSpy.mock.calls[0]?.[1] as RequestInit).headers as Record<string, string>;
-    // No actAs seam → today's behavior is preserved: the trusted same-origin base
-    // forwards the inbound headers (mcp-e2e supplies auth via an injected fetch,
-    // not requestHeaders, so it keeps working untouched).
-    expect(headers.cookie).toBe("session=user_1");
   });
 
   it("treats an unannotated connector tool as risk=write (conservative default)", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -374,6 +374,34 @@ importers:
         specifier: ^5.6.0
         version: 5.9.3
 
+  fixtures/integration:
+    dependencies:
+      '@vendoai/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@vendoai/store':
+        specifier: workspace:*
+        version: link:../../packages/store
+      '@vendoai/vendo':
+        specifier: workspace:*
+        version: link:../../packages/vendo
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.0
+      ai:
+        specifier: ^6.0.0
+        version: 6.0.28(zod@3.25.76)
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.3
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)
+
   fixtures/mcp-e2e:
     dependencies:
       '@vendoai/actions':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -379,6 +379,9 @@ importers:
       '@vendoai/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@vendoai/mcp':
+        specifier: workspace:*
+        version: link:../../packages/mcp
       '@vendoai/store':
         specifier: workspace:*
         version: link:../../packages/store
@@ -386,6 +389,9 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vendo
     devDependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.0
@@ -401,6 +407,49 @@ importers:
       vitest:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)
+
+  fixtures/integration-browser:
+    dependencies:
+      '@vendoai/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@vendoai/store':
+        specifier: workspace:*
+        version: link:../../packages/store
+      '@vendoai/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      '@vendoai/vendo':
+        specifier: workspace:*
+        version: link:../../packages/vendo
+      react:
+        specifier: ^19.0.0
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.49.0
+        version: 1.61.1
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.0
+      '@types/react':
+        specifier: ^19.2.0
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.0
+        version: 19.2.3(@types/react@19.2.17)
+      ai:
+        specifier: ^6.0.0
+        version: 6.0.28(zod@3.25.76)
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.3(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
 
   fixtures/mcp-e2e:
     dependencies:


### PR DESCRIPTION
## Why

Wave-4 and the composition wave each proved the same lesson: blocks pass their own tests but break when composed (5 latents in wave-4, 8 in composition). This wave generalizes that into a **standing CI gate**: a fixtures suite that boots the REAL composed umbrella — `createVendo` from `@vendoai/vendo` — and drives whole-product user journeys end-to-end through the public wire, asserting real side effects. Every existing fixture suite composes blocks by hand; nothing on main tested the actual composition unstubbed until now.

## What

**`fixtures/integration`** — the node suite (10 journeys). The harness passes only what a real host passes (model, principal resolver, store, actAs, policy); host tools load through the real `.vendo/tools.json` + `.vendo/policy.json` contract from cwd (a load path no composed test exercised); the wire is served on a loopback `node:http` origin and driven with fetch/SSE; a scripted deterministic `LanguageModel` feeds both the agent loop and the apps generation engine; asserts are raw SQL on the public `vendo_*` tables, host-app HTTP state, and wire GETs.

- **J1** chat turn generates an app (vendo_apps row, list/open, cross-user invisible)
- **J2** destructive approval round-trip (park → decide+remember → real host DELETE → grant authorizes the next call; cross-user decide rejected)
- **J3** app edit + history undo through the wire
- **J4** automation lifecycle: enters via `POST /apps/import` (.vendoapp, id re-minted) → enable captures approvals → standing app-bound automation grants → fires via BOTH public trigger paths (`POST /tick` bearer + `vendo.emit`) → away run hits the host app for real through actAs → runs/dry-run/disable
- **J5** away park/resume/revoke: capture-deny parks the run, wire decide resumes with the deferred side effect, `DELETE /grants/:id` parks the next run, chat-source grants never authorize away runs — all at the composed level
- **J6** MCP door round-trip with a real MCP SDK client, door composed from the umbrella's own parts (the `createVendo({mcp:true})` hookup is unlanded — see Known gap): discovery → OAuth → tools/list exact-set → in-band destructive park → **one approvals plane** (wire decision authorizes the MCP retry) → `venue='mcp'` + door-auth audit + door state tables via SQL

**`fixtures/integration-browser`** — the real-browser leg (J7): Playwright Chromium drives the shipped React surface (`VendoRoot` + `VendoThread` chrome + `useApps`) against the same real umbrella + host app: chat streams, a destructive call parks on policy, the in-thread ApprovalCard approve resumes and executes the real host DELETE, the generated app lists. Deterministic; no live keys.

**CI** — a dedicated `integration` job in ci.yml (scoped turbo build → node suite → chromium install → browser suite → failure-trace artifact). To be added to branch-protection required checks after merge.

## Known gap the suite surfaces (for the MCP hookup wave, not fixed here)

J6 documents a real composition gap as `it.fails` (executable spec): **present MCP host-route tool calls have no way to authenticate to the host API under the composed umbrella.** The door correctly mints a session-less `venue:"mcp"` context (10-mcp §3 forbids forwarding the MCP bearer), but the frozen contracts define no present-session host-auth seam — `actAs` is reserved for grant-authorized away execution (04 §4). An earlier commit in this PR tried to bridge it via `actAs`; **dual + external review (Codex live-probe, adversarial self-pass, Devin) showed that was a net-negative** — it skipped the origin-trust check (credential exfiltration to an untrusted origin) and violated the frozen `ActAs` type — so it was reverted. Designing the seam is a contract change owned by the unlanded `createVendo({mcp:true})` hookup (docs/contracts/10-mcp-umbrella-hookup.md); the J6 `it.fails` cases hand that wave an exact, executable target. Everything else in J6 (discovery, OAuth, tools/list, in-band destructive park, one approvals plane, apps ride-along, SQL) passes.

MCP-Apps `_meta.ui` ride-along is also shadowed in composition (the umbrella already registers `vendo_apps_open` as an agent tool; the door only adds ride-along tools for absent names) — expected per the door's design, worth revisiting with the hookup.

## Verification

- Both suites ≥5 consecutive green full runs locally + a `--sequence.shuffle` run proving no order-dependence (flake gate; no test retries anywhere)
- Root gates green: build / test / typecheck / lint
- Neighbor suites green: mcp, mcp-e2e, chat-e2e, automations-e2e, redteam-e2e
- Frozen contracts untouched (`git diff c7039240..HEAD -- docs/contracts` is empty); `packages/actions` byte-clean vs pre-wave after the revert
- Dual review (Codex + adversarial self-pass) + external (Devin/Greptile) triaged in a comment below

https://claude.ai/code/session_01LvTv8VGGYDaUHvCxvW8RoH