### PR TITLE
feat: Cloud runtime seam + vendo cloud login via email OTP

### DIFF
--- a/packages/apps/src/cloud.test.ts
+++ b/packages/apps/src/cloud.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from "vitest";
+import type { AppDocument } from "@vendoai/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createApps,
   publishRecordSchema,
   shareSnapshotSchema,
 } from "./index.js";
-import { guardFixture, memoryStore } from "./testing/index.js";
+import { guardFixture, memoryStore, seedAppRow } from "./testing/index.js";
 
 const ctx = {
   principal: { kind: "user" as const, subject: "user_ada" },
@@ -13,19 +14,39 @@ const ctx = {
   sessionId: "session_ada",
 };
 
-const runtime = () => createApps({
-  store: memoryStore(),
-  guard: guardFixture(),
-  tools: {
-    async descriptors() { return []; },
-    async execute() { return { status: "error" as const, error: { code: "not-found", message: "missing" } }; },
-  },
-  catalog: [],
+const doc: AppDocument = {
+  format: "vendo/app@1",
+  id: "app_cloud",
+  name: "Cloud app",
+};
+
+const runtime = async () => {
+  const store = memoryStore();
+  await seedAppRow(store, doc, ctx.principal.subject);
+  return createApps({
+    store,
+    guard: guardFixture(),
+    tools: {
+      async descriptors() { return []; },
+      async execute() { return { status: "error" as const, error: { code: "not-found", message: "missing" } }; },
+    },
+    catalog: [],
+  });
+};
+
+const previousKey = globalThis.process.env.VENDO_API_KEY;
+const previousUrl = globalThis.process.env.VENDO_CLOUD_URL;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  if (previousKey === undefined) delete globalThis.process.env.VENDO_API_KEY;
+  else globalThis.process.env.VENDO_API_KEY = previousKey;
+  if (previousUrl === undefined) delete globalThis.process.env.VENDO_CLOUD_URL;
+  else globalThis.process.env.VENDO_CLOUD_URL = previousUrl;
 });
 
-describe.sequential("cloud interchange stubs", () => {
+describe.sequential("cloud interchange", () => {
   it("exports the share and publish schemas", () => {
-    const doc = { format: "vendo/app@1" as const, id: "app_cloud", name: "Cloud app" };
     expect(shareSnapshotSchema.parse({
       id: "share_1",
       doc,
@@ -40,34 +61,81 @@ describe.sequential("cloud interchange stubs", () => {
   });
 
   it("requires Vendo Cloud when no API key is configured", async () => {
-    const previous = globalThis.process.env.VENDO_API_KEY;
     delete globalThis.process.env.VENDO_API_KEY;
-    try {
-      const apps = runtime();
-      await expect(apps.share("app_cloud", ctx)).rejects.toMatchObject({ code: "cloud-required" });
-      await expect(apps.publish("app_cloud", ctx)).rejects.toMatchObject({ code: "cloud-required" });
-    } finally {
-      if (previous === undefined) delete globalThis.process.env.VENDO_API_KEY;
-      else globalThis.process.env.VENDO_API_KEY = previous;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const apps = await runtime();
+
+    await expect(apps.share("app_cloud", ctx)).rejects.toMatchObject({ code: "cloud-required" });
+    await expect(apps.publish("app_cloud", ctx)).rejects.toMatchObject({ code: "cloud-required" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("posts the owned app document and validates share and publish responses", async () => {
+    globalThis.process.env.VENDO_API_KEY = "test-key";
+    globalThis.process.env.VENDO_CLOUD_URL = "https://cloud.example/";
+    const snapshot = {
+      id: "share_1",
+      doc,
+      createdAt: "2026-07-11T12:00:00.000Z",
+    };
+    const record = {
+      id: "publish_1",
+      appId: doc.id,
+      version: "1",
+      createdAt: "2026-07-11T12:00:00.000Z",
+    };
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(Response.json(snapshot))
+      .mockResolvedValueOnce(Response.json(record));
+    vi.stubGlobal("fetch", fetchMock);
+    const apps = await runtime();
+
+    await expect(apps.share(doc.id, ctx)).resolves.toEqual(snapshot);
+    await expect(apps.publish(doc.id, ctx)).resolves.toEqual(record);
+    for (const [index, path] of ["share", "publish"].entries()) {
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        index + 1,
+        `https://cloud.example/api/v1/apps/${path}`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: "Bearer test-key",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ appId: doc.id, doc }),
+        },
+      );
     }
   });
 
-  it("reports the separately shipped client when an API key is present", async () => {
-    const previous = globalThis.process.env.VENDO_API_KEY;
+  it("maps HTTP 402 envelopes to cloud-required", async () => {
     globalThis.process.env.VENDO_API_KEY = "test-key";
-    try {
-      const apps = runtime();
-      await expect(apps.share("app_cloud", ctx)).rejects.toMatchObject({
-        code: "not-implemented",
-        message: "Vendo Cloud client ships separately in v0",
-      });
-      await expect(apps.publish("app_cloud", ctx)).rejects.toMatchObject({
-        code: "not-implemented",
-        message: "Vendo Cloud client ships separately in v0",
-      });
-    } finally {
-      if (previous === undefined) delete globalThis.process.env.VENDO_API_KEY;
-      else globalThis.process.env.VENDO_API_KEY = previous;
-    }
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json({
+      error: { code: "billing-required", message: "Upgrade your Vendo Cloud plan" },
+    }, { status: 402 })));
+    const apps = await runtime();
+
+    await expect(apps.share(doc.id, ctx)).rejects.toMatchObject({
+      code: "cloud-required",
+      message: "Upgrade your Vendo Cloud plan",
+    });
+    await expect(apps.publish(doc.id, ctx)).rejects.toMatchObject({
+      code: "cloud-required",
+      message: "Upgrade your Vendo Cloud plan",
+    });
+  });
+
+  it("does not call Cloud for an app the principal does not own", async () => {
+    globalThis.process.env.VENDO_API_KEY = "test-key";
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const apps = await runtime();
+
+    await expect(apps.share(doc.id, {
+      ...ctx,
+      principal: { kind: "user", subject: "user_grace" },
+    })).rejects.toMatchObject({ code: "not-found" });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/apps/src/cloud.ts
+++ b/packages/apps/src/cloud.ts
@@ -7,6 +7,7 @@ import {
   type AppId,
   type IsoDateTime,
   type RunContext,
+  type VendoErrorCode,
 } from "@vendoai/core";
 import { z } from "zod";
 
@@ -44,21 +45,86 @@ const cloudKey = (): string | undefined => (
   globalThis.process?.env?.VENDO_API_KEY
 );
 
-const unavailable = (): never => {
-  if (cloudKey() === undefined || cloudKey() === "") {
-    throw new VendoError("cloud-required", "Vendo Cloud requires VENDO_API_KEY");
-  }
-  throw new VendoError("not-implemented", "Vendo Cloud client ships separately in v0");
+const cloudBaseUrl = (): string => {
+  const configured = globalThis.process?.env?.VENDO_CLOUD_URL;
+  return (configured === undefined || configured === ""
+    ? "https://console.vendo.run"
+    : configured).replace(/\/+$/, "");
 };
 
-/** 06-apps §1 and block-plan decision 6 — Cloud share client placeholder. */
-export const share = async (
-  _appId: AppId,
-  _ctx: RunContext,
-): Promise<ShareSnapshot> => unavailable();
+const CLOUD_ERROR_CODES = new Set<VendoErrorCode>([
+  "validation",
+  "not-found",
+  "conflict",
+  "blocked",
+  "cloud-required",
+]);
 
-/** 06-apps §1 and block-plan decision 6 — Cloud publish client placeholder. */
-export const publish = async (
-  _appId: AppId,
+const errorEnvelope = async (
+  response: Response,
+): Promise<{ code: string; message: string }> => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await response.text());
+  } catch {
+    parsed = undefined;
+  }
+  const error = typeof parsed === "object" && parsed !== null && "error" in parsed
+    ? (parsed as { error?: unknown }).error
+    : undefined;
+  return {
+    code: typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
+      ? error.code
+      : "unknown",
+    message: typeof error === "object" && error !== null && "message" in error && typeof error.message === "string"
+      ? error.message
+      : response.statusText || `HTTP ${response.status}`,
+  };
+};
+
+const throwCloudError = async (response: Response): Promise<never> => {
+  const error = await errorEnvelope(response);
+  if (response.status === 402) {
+    throw new VendoError("cloud-required", error.message);
+  }
+  if (CLOUD_ERROR_CODES.has(error.code as VendoErrorCode)) {
+    throw new VendoError(error.code as VendoErrorCode, error.message);
+  }
+  throw Object.assign(new Error(error.message), { code: error.code });
+};
+
+const request = async <T>(
+  path: "/api/v1/apps/share" | "/api/v1/apps/publish",
+  appId: AppId,
+  doc: AppDocument,
+  schema: z.ZodType<T>,
+): Promise<T> => {
+  const key = cloudKey();
+  if (key === undefined || key === "") {
+    throw new VendoError("cloud-required", "Vendo Cloud requires VENDO_API_KEY");
+  }
+  const response = await fetch(`${cloudBaseUrl()}${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ appId, doc }),
+  });
+  if (!response.ok) await throwCloudError(response);
+  return schema.parse(await response.json());
+};
+
+/** 06-apps §1 — create a frozen copy through Vendo Cloud. */
+export const share = async (
+  appId: AppId,
+  doc: AppDocument,
   _ctx: RunContext,
-): Promise<PublishRecord> => unavailable();
+): Promise<ShareSnapshot> => request("/api/v1/apps/share", appId, doc, shareSnapshotSchema);
+
+/** 06-apps §1 — publish an app copy through Vendo Cloud. */
+export const publish = async (
+  appId: AppId,
+  doc: AppDocument,
+  _ctx: RunContext,
+): Promise<PublishRecord> => request("/api/v1/apps/publish", appId, doc, publishRecordSchema);

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -456,11 +456,13 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     },
 
     async share(appId, ctx) {
-      return share(appId, ctx);
+      const app = await requireOwned(appId, ctx.principal.subject);
+      return share(appId, app, ctx);
     },
 
     async publish(appId, ctx) {
-      return publish(appId, ctx);
+      const app = await requireOwned(appId, ctx.principal.subject);
+      return publish(appId, app, ctx);
     },
 
     agentTools() {

--- a/packages/vendo/src/cli/cloud/E2E.md
+++ b/packages/vendo/src/cli/cloud/E2E.md
@@ -1,7 +1,8 @@
 # vendo cloud — live e2e (console.vendo.run)
 
 Run against the production Vendo Cloud API. Machine commands use an entitled
-VENDO_API_KEY; user commands use `--token <supabase access jwt>`.
+VENDO_API_KEY; user commands use a stored email-OTP session or the `--token
+<supabase access jwt>` fallback.
 
 ## Machine principal (VENDO_API_KEY)
 - `vendo cloud validate` (entitled key) → `{valid:true, entitlements:{sharing,insights,hosted_adapters,seats:10}}`
@@ -11,7 +12,12 @@ VENDO_API_KEY; user commands use `--token <supabase access jwt>`.
 - `vendo cloud publish app.json` ×2 → `PublishRecord` version "1" then "2" (monotonic)
 - `vendo cloud pin-ship --app app_cli --slot hero --base sha256:aa --diff d` → `{ id: pin_…, status: "pending" }`
 
-## User principal (--token JWT)
+## User authentication
+- `vendo cloud login EMAIL` → sends a 6-digit email OTP, prompts for the code,
+  and stores the returned session in `~/.vendo/cloud-session.json`
+- `vendo cloud login --token <jwt>` → stores an access-token-only fallback session
+
+## User principal (stored session or --token JWT)
 - `vendo cloud whoami --token <jwt>` → `{ orgs: [{id,name,role}] }`
 - `vendo cloud keys list --org <id> --token <jwt>` → `{ keys: [...] }`
 - `vendo cloud deployments --org <id> --token <jwt>` → `{ deployments: [...] }`

--- a/packages/vendo/src/cli/cloud/auth.test.ts
+++ b/packages/vendo/src/cli/cloud/auth.test.ts
@@ -46,17 +46,49 @@ describe("cloud auth", () => {
       .mockResolvedValueOnce({ sent: true })
       .mockResolvedValueOnce(session);
     const writeSession = vi.fn().mockResolvedValue(undefined);
+    const promptOtp = vi.fn().mockResolvedValue("123456");
 
-    expect(await runLogin(["person@example.com", "--otp", "123456"], {
+    expect(await runLogin(["person@example.com", "--api-url", "https://cloud.example"], {
       output: messages.sink,
       fetcher,
       writeSession,
+      promptOtp,
     })).toBe(0);
     expect(fetcher.mock.calls).toEqual([
-      ["/api/v1/auth/otp/start", expect.objectContaining({ method: "POST", body: { email: "person@example.com" } })],
-      ["/api/v1/auth/otp/verify", expect.objectContaining({ method: "POST", body: { email: "person@example.com", token: "123456" } })],
+      ["/api/v1/auth/otp/start", expect.objectContaining({
+        apiUrl: "https://cloud.example",
+        method: "POST",
+        body: { email: "person@example.com" },
+      })],
+      ["/api/v1/auth/otp/verify", expect.objectContaining({
+        apiUrl: "https://cloud.example",
+        method: "POST",
+        body: { email: "person@example.com", token: "123456" },
+      })],
     ]);
+    expect(promptOtp).toHaveBeenCalledWith("Enter the code sent to person@example.com");
     expect(writeSession).toHaveBeenCalledWith(session);
+    expect(JSON.parse(messages.logs[0]!)).toMatchObject({
+      loggedIn: true,
+      mode: "email",
+      email: "person@example.com",
+    });
+  });
+
+  it("rejects a non-six-digit email code before verification", async () => {
+    const messages = output();
+    const fetcher = vi.fn().mockResolvedValue({ sent: true });
+    const writeSession = vi.fn();
+
+    expect(await runLogin(["person@example.com"], {
+      output: messages.sink,
+      fetcher,
+      writeSession,
+      promptOtp: vi.fn().mockResolvedValue("12345"),
+    })).toBe(1);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(writeSession).not.toHaveBeenCalled();
+    expect(messages.errors).toEqual(["Email OTP must be a 6-digit code"]);
   });
 
   it("uses an ephemeral token for whoami", async () => {

--- a/packages/vendo/src/cli/cloud/auth.ts
+++ b/packages/vendo/src/cli/cloud/auth.ts
@@ -17,7 +17,7 @@ export interface CloudAuthOptions {
   fetcher?: CloudFetcher;
   writeSession?: (session: CloudSession) => Promise<void>;
   deleteSession?: () => Promise<void>;
-  promptOtp?: () => Promise<string>;
+  promptOtp?: (prompt: string) => Promise<string>;
   home?: string;
   env?: Record<string, string | undefined>;
 }
@@ -41,16 +41,23 @@ function verifiedSession(value: unknown): CloudSession {
     ? (value as { session: unknown }).session
     : value;
   if (typeof candidate !== "object" || candidate === null
-    || typeof (candidate as Partial<CloudSession>).access_token !== "string") {
+    || typeof (candidate as Partial<CloudSession>).access_token !== "string"
+    || typeof (candidate as Partial<CloudSession>).refresh_token !== "string"
+    || typeof (candidate as Partial<CloudSession>).expires_at !== "number") {
     throw new Error("Vendo Cloud returned an invalid session");
   }
-  return candidate as CloudSession;
+  const session = candidate as Required<CloudSession>;
+  return {
+    access_token: session.access_token,
+    refresh_token: session.refresh_token,
+    expires_at: session.expires_at,
+  };
 }
 
-async function interactiveOtp(): Promise<string> {
+async function interactiveOtp(prompt: string): Promise<string> {
   const readline = createInterface({ input: stdin, output: stdout });
   try {
-    return await readline.question("Email OTP: ");
+    return await readline.question(`${prompt}: `);
   } finally {
     readline.close();
   }
@@ -71,7 +78,7 @@ export async function runLogin(args: string[], options: CloudAuthOptions = {}): 
     }
   }
 
-  const email = positionals(args, ["--token", "--otp", "--api-url"])[0];
+  const email = positionals(args, ["--token", "--api-url"])[0];
   if (!email) {
     output.error("Cloud login requires an email or --token <jwt>");
     return 1;
@@ -84,8 +91,8 @@ export async function runLogin(args: string[], options: CloudAuthOptions = {}): 
   };
   try {
     await fetcher("/api/v1/auth/otp/start", { ...common, method: "POST", body: { email } });
-    const otp = option(args, "--otp") ?? await (options.promptOtp ?? interactiveOtp)();
-    if (!otp) throw new Error("Email OTP is required");
+    const otp = (await (options.promptOtp ?? interactiveOtp)(`Enter the code sent to ${email}`)).trim();
+    if (!/^\d{6}$/.test(otp)) throw new Error("Email OTP must be a 6-digit code");
     const result = await fetcher("/api/v1/auth/otp/verify", {
       ...common,
       method: "POST",

--- a/packages/vendo/src/cli/cloud/index.test.ts
+++ b/packages/vendo/src/cli/cloud/index.test.ts
@@ -12,6 +12,7 @@ describe("cloud command dispatch", () => {
     const messages = output();
     expect(await runCloud(["--help"], { output: messages.sink })).toBe(0);
     expect(messages.logs.join("\n")).toContain("pin-ship --app <id>");
+    expect(messages.logs.join("\n")).toContain("login EMAIL");
   });
 
   it("returns one for unknown cloud commands", async () => {

--- a/packages/vendo/src/cli/cloud/index.ts
+++ b/packages/vendo/src/cli/cloud/index.ts
@@ -11,7 +11,7 @@ export const CLOUD_HELP = `vendo cloud — Vendo Cloud API client
 Usage: vendo cloud <command> [options]
 
 User commands:
-  login <email>                         Request and verify an email OTP
+  login EMAIL                           Send a 6-digit email OTP and prompt for it
   login --token <jwt>                   Store an access-token fallback
   logout                               Delete the stored cloud session
   whoami [--token <jwt>]                List organizations for the current user


### PR DESCRIPTION
Two related client-seam changes (Apache-clean, no paid logic, thin HTTP only).

## 1. Runtime seam (`@vendoai/apps`)
`apps.share()` / `apps.publish()` were placeholders throwing `not-implemented` when `VENDO_API_KEY` was set. They now make real calls to the Vendo Cloud API: POST `{appId, doc}` to `VENDO_CLOUD_URL` (default `https://console.vendo.run`) `/api/v1/apps/share|publish` with the key as a bearer token, map the `{error:{code,message}}` envelope back into the `VendoError` taxonomy (402 → `cloud-required`), and validate the response against the frozen `shareSnapshotSchema` / `publishRecordSchema`. Without a key they still throw `cloud-required`. The runtime resolves the owned `AppDocument` via `requireOwned` before the call. Frozen shapes unchanged.

**"Drop in `VENDO_API_KEY` and it lights up" is now literally true at the runtime level.** Verified live against console.vendo.run: no key → `cloud-required`; unentitled key → `cloud-required` (from the 402); entitled key → a real `ShareSnapshot` / `PublishRecord`.

## 2. `vendo cloud login <email>` (`@vendoai/vendo`)
Now does email OTP: POST `/api/v1/auth/otp/start`, reads the emailed code from stdin, verifies via `/api/v1/auth/otp/verify`, stores the session. The `login --token <jwt>` fallback is unchanged.

Gate: `@vendoai/apps` 147 tests ✓, `@vendoai/vendo` 56 tests ✓, both build clean.

Depends on the console routes `/api/v1/apps/*` (live) and `/api/v1/auth/otp/*` (deploying).

https://claude.ai/code/session_018wxmhYk5Fy9nCdGkmM7hmZ
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connects `@vendoai/apps` share/publish to Vendo Cloud and adds email OTP login to the `@vendoai/vendo` CLI. This enables real sharing/publishing with VENDO_API_KEY and a simpler user auth flow.

- **New Features**
  - `@vendoai/apps`: Share/publish now POST to `${VENDO_CLOUD_URL || https://console.vendo.run}/api/v1/apps/{share|publish}` with Bearer key; sends `{appId, doc}`; validates with `shareSnapshotSchema`/`publishRecordSchema`; maps HTTP 402 to `cloud-required`; propagates known cloud errors; requires ownership before the call.
  - `@vendoai/vendo`: `vendo cloud login EMAIL` sends a 6‑digit email OTP, prompts, verifies, and stores the session; supports `--api-url`; `login --token <jwt>` fallback unchanged; help text updated.

- **Migration**
  - Set VENDO_API_KEY (and optionally VENDO_CLOUD_URL) to enable cloud share/publish.
  - Run `vendo cloud login EMAIL` to create a user session, or use `login --token <jwt>` as a fallback.

<sup>Written for commit 48a3e86b9eaf99b24021b0b3d898c7e6c2ec4abb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

