### PR TITLE
docs(site): document MCP door, Express host support, and Vendo Cloud

### DIFF
--- a/docs-site/capabilities/mcp.mdx
+++ b/docs-site/capabilities/mcp.mdx
@@ -1,0 +1,138 @@
+---
+title: "MCP door"
+description: "Serve your product's tools to Claude, ChatGPT, Cursor, and other MCP clients through one guarded, OAuth-authenticated door that shares your policy."
+---
+
+The MCP door makes your host product installable in MCP clients such as Claude,
+ChatGPT, and Cursor. Every door tool call runs through the same guard-bound
+registry, policy, approvals, and audit path as chat, so outside agents get no
+weaker perimeter than your own conversation surface.
+
+Opening the door is a host decision. It is off by default, and `vendo init`
+asks whether you want it, then points you at the wiring rather than turning it
+on itself.
+
+## When to use it
+
+- You want an installable MCP server that exposes your product's tools to
+  third-party agents.
+- Users of those agents should act as themselves in your product, with the same
+  policy and approvals you enforce in-product.
+- You already own a session and consent flow you can plug in behind an OAuth
+  seam.
+
+Skip it if you only need to pull remote MCP tools into your own agent. That is
+what `mcpConnector` does, and it runs the other direction. See
+[Connectors](/capabilities/integrations).
+
+## Enable the door
+
+Set `mcp: true` and pass a `HostOAuthAdapter`:
+
+```ts
+import { createVendo, nextVendoHandler } from "@vendoai/vendo/server";
+import type { HostOAuthAdapter } from "@vendoai/mcp";
+
+const oauth: HostOAuthAdapter = {
+  async authorize(request, { clientName, scopes }) {
+    // Authenticate the user with your existing session and confirm consent.
+    // Return { subject } on success, or a Response for redirects/renders.
+    const user = await resolveSession(request);
+    if (!user) return renderLogin(request);
+    return { subject: user.id };
+  },
+  async principal(subject) {
+    // Resolve subject to a Principal on every door request. Return null to revoke.
+    const user = await lookupUser(subject);
+    return user ? { kind: "user", subject: user.id, display: user.name } : null;
+  },
+};
+
+const vendo = createVendo({
+  model,
+  principal: resolvePrincipal,
+  mcp: true,
+  oauth,
+});
+
+export const { GET, POST, DELETE } = nextVendoHandler(vendo);
+```
+
+`oauth` is required when `mcp` is true. Without it, `createVendo` throws: the
+door cannot mint principals otherwise.
+
+## Route the discovery paths
+
+The door's transport and OAuth endpoints mount under the wire at
+`/api/vendo/mcp`, so your existing catch-all handler already serves them. The
+OAuth discovery documents live at the origin root, outside `/api/vendo`, so on
+Next.js you forward them to the same handler:
+
+```ts
+// app/.well-known/[...path]/route.ts
+import { vendo } from "@/lib/vendo";
+
+export const GET = (request: Request) => vendo.handler(request);
+```
+
+The door answers only its own discovery paths and returns 404 for anything else
+under `/.well-known`. If your app also serves its own well-known documents,
+branch on the pathname and call `vendo.handler` only for the paths below. The
+door owns:
+
+- `/.well-known/oauth-protected-resource/api/vendo/mcp` (RFC 9728
+  protected-resource metadata)
+- `/.well-known/oauth-authorization-server/api/vendo/mcp` (RFC 8414
+  authorization-server metadata)
+- `/.well-known/mcp/server-card.json` (server card; `/.well-known/mcp-server-card`
+  is an alias)
+
+## Set VENDO_BASE_URL
+
+Host tools that bind to routes need a base origin. The wire normally learns its
+own origin from the first in-product request, but door requests never teach it
+(only wire routes do). Set `VENDO_BASE_URL` explicitly so door-first traffic can
+still resolve host routes.
+
+```bash
+VENDO_BASE_URL=https://app.example.com
+```
+
+## How door calls reach host tools
+
+MCP clients have no host browser session, so the inbound MCP bearer is never
+forwarded to your host routes. Door tool calls reach host APIs through the same
+`actAs` seam away automations use:
+
+- On successful OAuth, the door records the user's consent for that client.
+- When a door tool call resolves to a host route, Vendo calls
+  `actAs(principal, grant)` to source auth material for the OAuth'd user.
+- Without a real grant or a consent record, the call fails closed.
+- Without `actAs` configured, the tool returns a `not-implemented` error, the
+  same clean degradation as an away automation.
+
+The OAuth-authenticated user is the authority. Risky tools still stop at your
+per-call guard decision, whatever the token's scopes.
+
+## Saved apps ride along
+
+The door exposes your saved apps as MCP Apps. `tools/list` includes
+`vendo_apps_list`, `vendo_apps_open`, and `vendo_apps_call`, and opened apps
+render through a static HTML shim. Interactions inside a rendered app route back
+through the same guard-bound path. The door is a viewer and runner: app creation
+and editing stay in-product.
+
+## Verify
+
+```bash
+npx vendo doctor
+```
+
+When the door is open, doctor verifies both OAuth metadata documents resolve and
+the server card parses. `GET /status` returns `blocks.mcp: true`. See
+[HTTP routes](/reference/http-routes) for the door's route table and
+[Handler options](/reference/handler-options) for the `mcp` and `oauth` options.
+
+To connect a client, point it at `https://your-app.example.com/api/vendo/mcp`.
+The client discovers OAuth from the `WWW-Authenticate` challenge on its first
+`401`, walks the user through your `authorize` step, and starts calling tools.

--- a/docs-site/capabilities/mcp.mdx
+++ b/docs-site/capabilities/mcp.mdx
@@ -27,10 +27,11 @@ what `mcpConnector` does, and it runs the other direction. See
 
 ## Enable the door
 
-Set `mcp: true` and pass a `HostOAuthAdapter`:
+Set `mcp: true` and pass a `HostOAuthAdapter`. Compose once in a shared module:
 
 ```ts
-import { createVendo, nextVendoHandler } from "@vendoai/vendo/server";
+// lib/vendo.ts
+import { createVendo } from "@vendoai/vendo/server";
 import type { HostOAuthAdapter } from "@vendoai/mcp";
 
 const oauth: HostOAuthAdapter = {
@@ -42,24 +43,34 @@ const oauth: HostOAuthAdapter = {
     return { subject: user.id };
   },
   async principal(subject) {
-    // Resolve subject to a Principal on every door request. Return null to revoke.
+    // Re-resolved on every bearer-authenticated MCP request. Return null to revoke.
     const user = await lookupUser(subject);
     return user ? { kind: "user", subject: user.id, display: user.name } : null;
   },
 };
 
-const vendo = createVendo({
+export const vendo = createVendo({
   model,
   principal: resolvePrincipal,
   mcp: true,
   oauth,
 });
+```
+
+Then re-export the handler from your catch-all route:
+
+```ts
+// app/api/vendo/[...vendo]/route.ts
+import { nextVendoHandler } from "@vendoai/vendo/server";
+import { vendo } from "@/lib/vendo";
 
 export const { GET, POST, DELETE } = nextVendoHandler(vendo);
 ```
 
 `oauth` is required when `mcp` is true. Without it, `createVendo` throws: the
-door cannot mint principals otherwise.
+door cannot mint principals otherwise. The `HostOAuthAdapter` type imports from
+`@vendoai/mcp`, which ships as a dependency of the umbrella; strict package
+managers may need it added explicitly until the umbrella re-exports it.
 
 ## Route the discovery paths
 
@@ -86,6 +97,17 @@ door owns:
   authorization-server metadata)
 - `/.well-known/mcp/server-card.json` (server card; `/.well-known/mcp-server-card`
   is an alias)
+
+On Express, the adapter that `vendo init` generates reconstructs the full path
+from `req.originalUrl`, so the same handler serves both bases:
+
+```ts
+app.use("/api/vendo", mountVendo());
+app.use("/.well-known", mountVendo());
+```
+
+Because the door 404s every other well-known path, register your app's own
+well-known routes before that second mount.
 
 ## Set VENDO_BASE_URL
 

--- a/docs-site/connect/vendo-init.mdx
+++ b/docs-site/connect/vendo-init.mdx
@@ -21,6 +21,30 @@ Answers land in `.vendo/overrides.json` and remain authoritative across future
 sync runs. Init also writes policy, product brief, theme, and the PGlite ignore
 entry where applicable.
 
+Init also asks whether to open the [MCP door](/capabilities/mcp). Opening it is
+a host decision and needs a `HostOAuthAdapter`, so init never scaffolds it: on
+yes it points you at the wiring. The door stays off unless you opt in.
+
+## Framework detection
+
+Init reads `package.json` and scaffolds only the files that apply. It detects two
+frameworks by dependency:
+
+- **Next.js** (a `next` dependency): proposes `app/api/vendo/[...vendo]/route.ts`
+  and wraps the root layout in `<VendoRoot>`.
+- **Express** (an `express` dependency): proposes a `vendo/server.ts` module
+  (`vendo/server.mjs` without a `tsconfig.json`) holding the `createVendo()`
+  composition and a Node HTTP-to-fetch adapter, plus a starter `vendo/ai.ts`. Two
+  manual steps remain: mount the adapter with
+  `app.use("/api/vendo", mountVendo())` and wrap the client entry in
+  `<VendoRoot>`. Init prints both, and `vendo doctor` reports broken until they
+  are done.
+
+Init recognizes only `next` and `express`. A host with neither is treated as
+Next. In other runtimes (Fastify, Hono, Bun, Deno, Workers), decline the proposed
+diffs and mount `vendo.handler` yourself. See
+[Quickstart: Express and other JavaScript servers](/quickstart-node).
+
 ## Agent mode
 
 ```bash

--- a/docs-site/connect/vendo-init.mdx
+++ b/docs-site/connect/vendo-init.mdx
@@ -1,6 +1,6 @@
 ---
 title: "vendo init"
-description: "How the vendo init wizard scans your app, interviews you about risk, theme, and remix candidates, and writes reviewable diffs plus .vendo overrides."
+description: "How the vendo init wizard scans your app, asks about your model, brief, critical-tool risk, and the MCP door, and writes reviewable diffs plus .vendo files."
 ---
 
 Run init after installing the umbrella:
@@ -10,18 +10,20 @@ npx vendo init
 ```
 
 The wizard scans the app with deterministic analysis plus available AI
-assistance. It interviews you with recommendations for risk labels, theme, and
-remix candidates. It then proposes the handler route and `<VendoRoot>` wiring.
-The scaffolded `<VendoRoot>` imports the extracted `.vendo/theme.json` and passes
-it as the `theme` prop, so shipped chrome adopts the host brand from the first
-boot with no hand wiring. Every code change is permission-gated and shown as a
-diff.
+assistance. It interviews you with recommendations on four questions: your model
+import, the product brief, risk labels for critical tools, and whether to open
+the MCP door. Theme is extracted automatically, not asked. It then proposes the
+handler route and `<VendoRoot>` wiring. The scaffolded `<VendoRoot>` imports the
+extracted `.vendo/theme.json` and passes it as the `theme` prop, so shipped
+chrome adopts the host brand from the first boot with no hand wiring. Every code
+change is permission-gated and shown as a diff.
 
-Answers land in `.vendo/overrides.json` and remain authoritative across future
-sync runs. Init also writes policy, product brief, theme, and the PGlite ignore
-entry where applicable.
+Critical-tool risk answers land in `.vendo/overrides.json` and remain
+authoritative across future sync runs. Init also writes policy, product brief,
+theme, and the PGlite ignore entry where applicable.
 
-Init also asks whether to open the [MCP door](/capabilities/mcp). Opening it is
+One of those questions is whether to open the [MCP door](/capabilities/mcp).
+Opening it is
 a host decision and needs a `HostOAuthAdapter`, so init never scaffolds it: on
 yes it points you at the wiring. The door stays off unless you opt in.
 
@@ -31,7 +33,8 @@ Init reads `package.json` and scaffolds only the files that apply. It detects tw
 frameworks by dependency:
 
 - **Next.js** (a `next` dependency): proposes `app/api/vendo/[...vendo]/route.ts`
-  and wraps the root layout in `<VendoRoot>`.
+  (under `src/app` when that directory exists) and wraps the root layout in
+  `<VendoRoot>`.
 - **Express** (an `express` dependency): proposes a `vendo/server.ts` module
   (`vendo/server.mjs` without a `tsconfig.json`) holding the `createVendo()`
   composition and a Node HTTP-to-fetch adapter, plus a starter `vendo/ai.ts`. Two
@@ -40,9 +43,10 @@ frameworks by dependency:
   `<VendoRoot>`. Init prints both, and `vendo doctor` reports broken until they
   are done.
 
-Init recognizes only `next` and `express`. A host with neither is treated as
-Next. In other runtimes (Fastify, Hono, Bun, Deno, Workers), decline the proposed
-diffs and mount `vendo.handler` yourself. See
+Init recognizes only `next` and `express`, checking `next` first, so an app with
+both dependencies gets the Next scaffold. A host with neither is treated as
+Next. In other runtimes (Fastify, Hono, Bun), decline the proposed diffs and
+mount `vendo.handler` yourself. See
 [Quickstart: Express and other JavaScript servers](/quickstart-node).
 
 ## Agent mode
@@ -51,8 +55,8 @@ diffs and mount `vendo.handler` yourself. See
 npx vendo init --agent
 ```
 
-Agent mode emits a plan, writes nothing, and asks at most three plain-language
-questions. Its staged playbook is `install.md`.
+Agent mode emits the setup plan with its four plain-language questions and
+writes nothing.
 
 Use `vendo doctor` after setup. It checks wiring and makes one live `/status`
 round trip.

--- a/docs-site/deploy/vendo-cloud.mdx
+++ b/docs-site/deploy/vendo-cloud.mdx
@@ -17,7 +17,9 @@ published copies, or a machine key for CI.
 
 `vendo cloud login <email>` sends a six-digit code to your inbox, prompts for it
 on stdin, and stores the returned session at `~/.vendo/cloud-session.json`
-(file mode 0600). Every other `vendo cloud` command reuses that session.
+(file mode 0600). The user commands reuse that session; the machine commands
+(`validate`, `share`, `publish`, `pin-ship`) authenticate with `--key` or
+`VENDO_API_KEY` instead.
 
 ```bash
 vendo cloud login you@example.com
@@ -32,8 +34,8 @@ directly:
 vendo cloud login --token <jwt>
 ```
 
-Sign out with `vendo cloud logout`. Confirm the active identity and list your
-organizations with `vendo cloud whoami`.
+Sign out with `vendo cloud logout`. Check that the session works with
+`vendo cloud whoami`, which prints the organizations it can reach.
 
 ## Provide an API key to the runtime
 

--- a/docs-site/deploy/vendo-cloud.mdx
+++ b/docs-site/deploy/vendo-cloud.mdx
@@ -1,0 +1,109 @@
+---
+title: "Vendo Cloud"
+description: "Sign in with email OTP, provide an API key to the runtime, and use hosted app sharing and publishing from the CLI or a composition."
+---
+
+Vendo Cloud is the hosted backend for cloud-gated surfaces: sharing frozen app
+copies, publishing app versions, and org-scoped keys and members. Local
+development never needs it. Reach for it when you want cross-host sharing,
+published copies, or a machine key for CI.
+
+## Prerequisites
+
+- A Vendo Cloud account at `https://console.vendo.run`.
+- The `vendo` bin on your PATH (`npx vendo` also works).
+
+## Sign in from the CLI
+
+`vendo cloud login <email>` sends a six-digit code to your inbox, prompts for it
+on stdin, and stores the returned session at `~/.vendo/cloud-session.json`
+(file mode 0600). Every other `vendo cloud` command reuses that session.
+
+```bash
+vendo cloud login you@example.com
+# Enter the code sent to you@example.com: 123456
+# { "loggedIn": true, "mode": "email", "email": "you@example.com" }
+```
+
+If you already hold a Vendo Cloud access token, skip the OTP and store it
+directly:
+
+```bash
+vendo cloud login --token <jwt>
+```
+
+Sign out with `vendo cloud logout`. Confirm the active identity and list your
+organizations with `vendo cloud whoami`.
+
+## Provide an API key to the runtime
+
+Cloud-gated runtime calls read `VENDO_API_KEY` from the host process. When it is
+unset or empty, `vendo.apps.share()` and `vendo.apps.publish()` throw
+`cloud-required` and the mapped HTTP status is 402. Set it wherever your handler
+runs:
+
+```bash
+export VENDO_API_KEY=vnd_live_...
+```
+
+Create and rotate keys from the CLI:
+
+```bash
+vendo cloud keys create --org <orgId> --name "ci-publisher"
+vendo cloud keys list --org <orgId>
+vendo cloud keys revoke --org <orgId> --id <keyId>
+```
+
+`--org` is optional only when your account has exactly one organization.
+
+## Point at a different Vendo Cloud URL
+
+By default the runtime and CLI both target `https://console.vendo.run`. Set
+`VENDO_CLOUD_URL` to override, for example against a staging environment:
+
+```bash
+export VENDO_CLOUD_URL=https://console.staging.vendo.run
+```
+
+Individual CLI commands also accept `--api-url <url>` for a one-off override.
+
+## Share and publish
+
+With `VENDO_API_KEY` set, the composition's apps runtime calls the hosted API:
+
+```ts
+import { createVendo } from "@vendoai/vendo/server";
+
+const vendo = createVendo({ /* model, principal, store, ... */ });
+
+const snapshot = await vendo.apps.share(appId, ctx);
+const record = await vendo.apps.publish(appId, ctx);
+```
+
+`share` returns a `ShareSnapshot` (a frozen copy: `id`, `doc`, `createdAt`).
+`publish` returns a `PublishRecord` with the assigned `version` (`id`, `appId`,
+`version`, `createdAt`). Both responses are validated against the frozen wire
+schemas (`shareSnapshotSchema`, `publishRecordSchema`) before they resolve.
+
+To share or publish from CI without loading the composition, upload the app
+document directly. The file needs a string `id`, or pass `--app <id>`:
+
+```bash
+vendo cloud share ./app.json
+vendo cloud publish ./app.json
+```
+
+## Error handling
+
+Cloud calls surface the shared error taxonomy (see
+[Troubleshooting](/deploy/troubleshooting)):
+
+- `cloud-required` (HTTP 402): no `VENDO_API_KEY`, or the key's org lacks the
+  entitlement for the requested surface.
+- `validation`, `not-found`, `conflict`, `blocked`: propagated from the hosted
+  API with the same codes the wire uses.
+
+Handle `cloud-required` by setting `VENDO_API_KEY`, or for interactive tools by
+running `vendo cloud login` and creating a key with `vendo cloud keys create`.
+
+For the full CLI surface, see [CLI](/reference/cli).

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -41,11 +41,11 @@
       },
       {
         "group": "Capabilities",
-        "pages": ["capabilities/integrations", "capabilities/voice"]
+        "pages": ["capabilities/integrations", "capabilities/mcp", "capabilities/voice"]
       },
       {
         "group": "Deploy and operate",
-        "pages": ["deploy/persistence", "deploy/deploying", "deploy/scheduler-and-webhooks", "deploy/telemetry", "deploy/troubleshooting"]
+        "pages": ["deploy/persistence", "deploy/deploying", "deploy/vendo-cloud", "deploy/scheduler-and-webhooks", "deploy/telemetry", "deploy/troubleshooting"]
       },
       {
         "group": "Reference",

--- a/docs-site/quickstart-node.mdx
+++ b/docs-site/quickstart-node.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Quickstart: Express and other JavaScript servers"
-description: "Vendo's handler is a fetch handler you can mount in any runtime. vendo init auto-scaffolds the adapter for Express; elsewhere you mount vendo.handler yourself."
+description: "A fetch handler you can mount in any Node-compatible runtime. vendo init scaffolds the adapter for Express; elsewhere you mount vendo.handler yourself."
 ---
 
 Vendo's handler is framework-agnostic. It takes a standard `Request` and returns
-a standard `Response`, so it runs in Express, Fastify, Hono, Bun, Deno,
-Cloudflare Workers, or any runtime with `fetch` and WebCrypto.
+a standard `Response`, so it runs in Express, Fastify, Hono, Bun, or any
+Node-compatible runtime (the umbrella requires Node 20 or later).
 
 ## Install and scaffold
 
@@ -24,9 +24,10 @@ Init always writes the `.vendo` contract (tools, policy, theme, brief). It reads
   `createVendo()` composition and a Node HTTP-to-fetch adapter, plus a starter
   `vendo/ai.ts` model module. Two manual wiring steps remain, and init prints
   both.
-- **Any other runtime** (Fastify, Hono, Bun, Deno, Workers): init detects only
-  `next` and `express`, so it proposes Next-shaped files. Decline those diffs and
-  mount `vendo.handler` yourself (see below).
+- **Any other runtime** (Fastify, Hono, Bun): init detects only `next` and
+  `express`, so it proposes Next-shaped files. Decline those diffs and mount
+  `vendo.handler` yourself (see below). Detection checks `next` first, so an app
+  with both dependencies gets the Next scaffold.
 
 ## Wire the Express adapter
 
@@ -67,8 +68,15 @@ const vendo = createVendo({
 });
 ```
 
-Replace `principal` with your session resolver: it receives the `Request` and
-returns your user, or `null` for an anonymous session.
+Replace `principal` with your session resolver. It receives the `Request` and
+returns a `Principal`, or `null` for an anonymous session:
+
+```ts
+principal: async (request) => {
+  const user = await resolveSession(request);
+  return user ? { kind: "user", subject: user.id } : null;
+},
+```
 
 ## Mount the handler directly
 

--- a/docs-site/quickstart-node.mdx
+++ b/docs-site/quickstart-node.mdx
@@ -1,35 +1,106 @@
 ---
-title: "Quickstart: any JavaScript server"
-description: "Mount Vendo's fetch-style handler in any JavaScript runtime with fetch and WebCrypto, from Node and Bun to Deno, Cloudflare Workers, and other edges."
+title: "Quickstart: Express and other JavaScript servers"
+description: "Vendo's handler is a fetch handler you can mount in any runtime. vendo init auto-scaffolds the adapter for Express; elsewhere you mount vendo.handler yourself."
 ---
 
-Install the umbrella:
+Vendo's handler is framework-agnostic. It takes a standard `Request` and returns
+a standard `Response`, so it runs in Express, Fastify, Hono, Bun, Deno,
+Cloudflare Workers, or any runtime with `fetch` and WebCrypto.
+
+## Install and scaffold
+
+Install the umbrella and run `vendo init` from your app root:
 
 ```bash
 npm install @vendoai/vendo
+npx vendo init
 ```
 
-Create the composition once during server boot:
+Init always writes the `.vendo` contract (tools, policy, theme, brief). It reads
+`package.json` to decide what code to propose:
+
+- **Express** (an `express` dependency): a diff-gated `vendo/server.ts`
+  (`vendo/server.mjs` when the host has no `tsconfig.json`) holding a
+  `createVendo()` composition and a Node HTTP-to-fetch adapter, plus a starter
+  `vendo/ai.ts` model module. Two manual wiring steps remain, and init prints
+  both.
+- **Any other runtime** (Fastify, Hono, Bun, Deno, Workers): init detects only
+  `next` and `express`, so it proposes Next-shaped files. Decline those diffs and
+  mount `vendo.handler` yourself (see below).
+
+## Wire the Express adapter
+
+Mount the exported adapter under one base path, normally `/api/vendo`:
+
+```ts
+import express from "express";
+import { mountVendo } from "./vendo/server.js";
+
+const app = express();
+app.use("/api/vendo", mountVendo());
+app.listen(3000);
+```
+
+Wrap the client root in `<VendoRoot>`:
+
+```tsx
+import { VendoRoot } from "@vendoai/vendo/react";
+
+root.render(
+  <VendoRoot>
+    <App />
+  </VendoRoot>,
+);
+```
+
+## Composition
+
+The generated `vendo/server.ts` calls `createVendo` once during boot:
 
 ```ts
 import { createVendo } from "@vendoai/vendo/server";
+import { model } from "./ai";
 
 const vendo = createVendo({
   model,
-  principal: async (request) => {
-    const user = await resolveSession(request);
-    return user ? { kind: "user", subject: user.id } : null;
-  },
+  principal: async () => null,
 });
 ```
 
-Mount `vendo.handler` under one base path, normally `/api/vendo`. It accepts a
-standard `Request` and returns a standard `Response`. Preserve streaming for
-`POST /threads`.
+Replace `principal` with your session resolver: it receives the `Request` and
+returns your user, or `null` for an anonymous session.
 
-The adapter must pass GET, POST, and DELETE requests through unchanged. Cookie
-and authorization headers must remain available to `principal(req)` and to
-present-mode same-origin tool calls.
+## Mount the handler directly
 
-Use hosted Postgres by passing `createStore({ url })` for multi-process or
+Outside Express, mount `vendo.handler` under one base path yourself. It takes a
+standard `Request` and returns a standard `Response`. The Node adapter that
+`vendo init` generates for Express is the pattern to copy. An adapter must:
+
+- Pass every method (GET, POST, DELETE) through unchanged.
+- Preserve streaming for `POST /threads`, never buffering the response body.
+- Reconstruct the request URL from `req.originalUrl`, not `req.url`, when mounted
+  with `app.use` on a base path (Express strips the mount path from `req.url`).
+- Keep cookie and authorization headers available to `principal(request)` and to
+  present-mode same-origin tool calls.
+- Return multi-value `Set-Cookie` as a header array, not a joined string.
+
+Behind a TLS-terminating proxy, set `VENDO_BASE_URL` to your public origin. It is
+the trusted origin Vendo uses for same-origin tool calls and for marking the
+anonymous-session cookie `Secure`.
+
+## Verify
+
+Run `vendo doctor` against the running server:
+
+```bash
+npx vendo doctor
+```
+
+For an Express host it checks that the server composes `createVendo` from
+`@vendoai/vendo/server`, that the client mounts `<VendoRoot>`, and makes one live
+`/status` round trip. It reports broken until both wiring steps are done.
+
+## Persistence
+
+Pass `createStore({ url })` to use hosted Postgres for multi-process or
 serverless deployments. The default is PGlite at `.vendo/data`.

--- a/docs-site/reference/cli.mdx
+++ b/docs-site/reference/cli.mdx
@@ -7,22 +7,25 @@ The umbrella owns the `vendo` bin. It has four commands.
 
 ## `vendo init`
 
-Interactive setup. It scans the app, interviews you about risk labels, theme,
-and remix candidates, then proposes the handler and `<VendoRoot>` wiring. Every
-code change is permission-gated and shown as a diff. Answers are written to
-`.vendo/overrides.json` and respected by future sync runs.
+Interactive setup. It scans the app, interviews you about your model import, the
+product brief, risk labels for critical tools, and the MCP door (theme is
+extracted automatically), then proposes the handler and `<VendoRoot>` wiring.
+Every code change is permission-gated and shown as a diff. Critical-tool risk
+answers are written to `.vendo/overrides.json` and respected by future sync
+runs.
 
 Init detects the host framework from `package.json` and scaffolds only what
-applies. A `next` dependency gets `app/api/vendo/[...vendo]/route.ts` and a
-layout that wraps `<VendoRoot>`. An `express` dependency gets a `vendo/server.ts`
-(`vendo/server.mjs` without a `tsconfig.json`) holding the `createVendo()`
-composition and a Node HTTP-to-fetch adapter, plus a starter `vendo/ai.ts`. Mount
-the adapter with `app.use("/api/vendo", mountVendo())` and wrap the client entry
-in `<VendoRoot>` to finish. Init detects only `next` and `express`; any other
-host is treated as Next.
+applies. A `next` dependency gets `app/api/vendo/[...vendo]/route.ts` (under
+`src/app` when that directory exists) and a layout that wraps `<VendoRoot>`. An
+`express` dependency gets a `vendo/server.ts` (`vendo/server.mjs` without a
+`tsconfig.json`) holding the `createVendo()` composition and a Node
+HTTP-to-fetch adapter, plus a starter `vendo/ai.ts`. Mount the adapter with
+`app.use("/api/vendo", mountVendo())` and wrap the client entry in `<VendoRoot>`
+to finish. Init detects only `next` and `express`, checking `next` first, so an
+app with both gets the Next scaffold; any other host is treated as Next.
 
-`--agent` emits the setup plan, writes nothing, and asks at most three
-plain-language questions.
+`--agent` emits the setup plan with its four plain-language questions and
+writes nothing.
 
 ## `vendo doctor`
 
@@ -62,7 +65,6 @@ Global options:
 - `--api-url <url>` overrides `VENDO_CLOUD_URL` (default `https://console.vendo.run`).
 - `--key <vnd_...>` overrides `VENDO_API_KEY` for the machine commands
   (`validate`, `share`, `publish`, `pin-ship`).
-- `--json` requests JSON output (results are JSON regardless).
 
 Org-scoped commands take `--org <id>`; omit it only when your account has one
 organization. Run `vendo cloud help` for the full list. See

--- a/docs-site/reference/cli.mdx
+++ b/docs-site/reference/cli.mdx
@@ -1,9 +1,9 @@
 ---
 title: "CLI"
-description: "Reference for the three vendo bin commands owned by @vendoai/vendo: init for setup, doctor for wiring checks, and sync for the build-time extraction step."
+description: "Reference for the vendo bin commands: init for setup, doctor for wiring checks, sync for build-time extraction, and cloud for the Vendo Cloud API."
 ---
 
-The umbrella owns the `vendo` bin. It has three commands.
+The umbrella owns the `vendo` bin. It has four commands.
 
 ## `vendo init`
 
@@ -12,13 +12,26 @@ and remix candidates, then proposes the handler and `<VendoRoot>` wiring. Every
 code change is permission-gated and shown as a diff. Answers are written to
 `.vendo/overrides.json` and respected by future sync runs.
 
+Init detects the host framework from `package.json` and scaffolds only what
+applies. A `next` dependency gets `app/api/vendo/[...vendo]/route.ts` and a
+layout that wraps `<VendoRoot>`. An `express` dependency gets a `vendo/server.ts`
+(`vendo/server.mjs` without a `tsconfig.json`) holding the `createVendo()`
+composition and a Node HTTP-to-fetch adapter, plus a starter `vendo/ai.ts`. Mount
+the adapter with `app.use("/api/vendo", mountVendo())` and wrap the client entry
+in `<VendoRoot>` to finish. Init detects only `next` and `express`; any other
+host is treated as Next.
+
 `--agent` emits the setup plan, writes nothing, and asks at most three
 plain-language questions.
 
 ## `vendo doctor`
 
-Checks wiring and makes one live `/status` round trip. It ends with the config
-line that unlocks each remaining block.
+Checks wiring and makes one live `/status` round trip. It recognizes both Next.js
+(catch-all route plus a layout that mounts `<VendoRoot>`) and Express (the server
+composes `createVendo` from `@vendoai/vendo/server`; the client mounts
+`<VendoRoot>`), and ends with the config line that unlocks each remaining block.
+When the MCP door is open, doctor also verifies both OAuth metadata documents
+resolve and the server card parses.
 
 Exit codes:
 
@@ -34,6 +47,26 @@ Exit codes:
 
 - `0`: success, including fail-soft warnings
 - `2`: breaking changes when `--strict` is set
+
+## `vendo cloud`
+
+Client for the Vendo Cloud API. `vendo cloud login <email>` sends a six-digit
+email OTP, prompts for it, and stores the session at
+`~/.vendo/cloud-session.json`; `--token <jwt>` stores an access token instead.
+Other subcommands: `logout`, `whoami`, `orgs`, `keys` (`list`, `create`,
+`revoke`), `members`, `invite`, `deployments`, `usage`, `billing`, `validate`,
+`share`, `publish`, and `pin-ship`. Every result prints as JSON.
+
+Global options:
+
+- `--api-url <url>` overrides `VENDO_CLOUD_URL` (default `https://console.vendo.run`).
+- `--key <vnd_...>` overrides `VENDO_API_KEY` for the machine commands
+  (`validate`, `share`, `publish`, `pin-ship`).
+- `--json` requests JSON output (results are JSON regardless).
+
+Org-scoped commands take `--org <id>`; omit it only when your account has one
+organization. Run `vendo cloud help` for the full list. See
+[Vendo Cloud](/deploy/vendo-cloud) for setup, keys, and sharing.
 
 ## Telemetry opt-out
 

--- a/docs-site/reference/environment-variables.mdx
+++ b/docs-site/reference/environment-variables.mdx
@@ -8,9 +8,10 @@ description: "Every environment variable Vendo reads across host process, sandbo
 | Variable | Effect |
 | --- | --- |
 | `VENDO_API_KEY` | activates cloud-gated sharing, publishing, org overlays, and pinning after entitlement verification |
+| `VENDO_CLOUD_URL` | overrides the Vendo Cloud base URL for the runtime and CLI; defaults to `https://console.vendo.run` |
 | `VENDO_TELEMETRY_DISABLED=1` | disables build and development telemetry |
 | `VENDO_TICK_SECRET` | bearer secret required by `POST /tick` |
-| `VENDO_BASE_URL` | host origin used for server-side execution of extracted route tools |
+| `VENDO_BASE_URL` | trusted host origin used for server-side execution of extracted route tools and for marking the anonymous-session cookie `Secure` behind a TLS-terminating proxy; set it explicitly when the MCP door is open so door-first traffic still has a base to bind against |
 | `VENDO_PROXY_URL` | tool-proxy URL injected into app machines by the default composition |
 | `VENDO_POSTHOG_KEY` | overrides the telemetry project key |
 | `DO_NOT_TRACK=1` | disables telemetry and is also honored by Scarf |

--- a/docs-site/reference/environment-variables.mdx
+++ b/docs-site/reference/environment-variables.mdx
@@ -12,6 +12,7 @@ description: "Every environment variable Vendo reads across host process, sandbo
 | `VENDO_TELEMETRY_DISABLED=1` | disables build and development telemetry |
 | `VENDO_TICK_SECRET` | bearer secret required by `POST /tick` |
 | `VENDO_BASE_URL` | trusted host origin used for server-side execution of extracted route tools and for marking the anonymous-session cookie `Secure` behind a TLS-terminating proxy; set it explicitly when the MCP door is open so door-first traffic still has a base to bind against |
+| `VENDO_URL` | base URL `vendo doctor` probes for the live `/status` check; defaults to `http://localhost:3000/api/vendo`, overridden per run by `--url` |
 | `VENDO_PROXY_URL` | tool-proxy URL injected into app machines by the default composition |
 | `VENDO_POSTHOG_KEY` | overrides the telemetry project key |
 | `DO_NOT_TRACK=1` | disables telemetry and is also honored by Scarf |

--- a/docs-site/reference/handler-options.mdx
+++ b/docs-site/reference/handler-options.mdx
@@ -17,6 +17,8 @@ description: "Every createVendo configuration option and fetch-handler setting, 
 | `judge` | no | contextual guard judge |
 | `secrets` | no | defaults to environment-backed secret lookup |
 | `telemetry` | no | wires build and development telemetry |
+| `mcp` | no | opens the [MCP door](/capabilities/mcp) so outside agents reach host tools through the guarded path; off by default |
+| `oauth` | conditional | `HostOAuthAdapter` used by the door for identity and consent; required when `mcp` is `true` |
 
 ## Base path
 

--- a/docs-site/reference/handler-options.mdx
+++ b/docs-site/reference/handler-options.mdx
@@ -48,3 +48,4 @@ Every non-2xx response has this shape:
 
 The fixed map is `validation` 400, `not-found` 404, `blocked` 403, `conflict`
 409, `cloud-required` 402, and `sandbox-unavailable` or `not-implemented` 501.
+MCP door paths are the exception; they speak MCP and OAuth response shapes.

--- a/docs-site/reference/http-routes.mdx
+++ b/docs-site/reference/http-routes.mdx
@@ -41,16 +41,20 @@ Bodies follow the MCP transport spec, not the wire's JSON envelope.
 
 | Path | Method | Purpose |
 | --- | --- | --- |
-| `/api/vendo/mcp` | POST · GET · DELETE | MCP Streamable HTTP transport and OAuth endpoints (`/authorize`, `/token`, `/register`) |
+| `/api/vendo/mcp` | POST · GET · DELETE | MCP Streamable HTTP transport |
+| `/api/vendo/mcp/authorize` | GET | OAuth authorization endpoint |
+| `/api/vendo/mcp/token` | POST | OAuth token endpoint (form-encoded) |
+| `/api/vendo/mcp/register` | POST | OAuth dynamic client registration (JSON body) |
 | `/.well-known/oauth-protected-resource/api/vendo/mcp` | GET | RFC 9728 protected-resource metadata |
 | `/.well-known/oauth-authorization-server/api/vendo/mcp` | GET | RFC 8414 authorization-server metadata |
 | `/.well-known/mcp/server-card.json` · `/.well-known/mcp-server-card` | GET | server card describing the door |
 
 Door paths bypass the wire's principal resolver and CSRF JSON gate. The door
-authenticates every request through `oauth.principal`, and the OAuth `/token`
-and `/register` endpoints are form-encoded POSTs. The origin-root discovery
-documents sit outside `/api/vendo`, so on Next.js you forward them to
-`vendo.handler`. See [MCP door](/capabilities/mcp).
+re-resolves `oauth.principal(subject)` on every bearer-authenticated transport
+request, so returning `null` revokes live sessions; the OAuth and discovery
+endpoints are not principal-resolved. The origin-root discovery documents sit
+outside `/api/vendo`, so on Next.js you forward them to `vendo.handler`. See
+[MCP door](/capabilities/mcp).
 
 ## Webhook verification
 
@@ -71,4 +75,5 @@ and 501 sandbox unavailable or not implemented.
 
 Cookie-authenticated mutations require `Content-Type: application/json`.
 Binary app import, signed webhooks, and bearer-authenticated tick are the only
-exceptions.
+exceptions. MCP door paths sit outside both rules; they speak MCP and OAuth
+response shapes, not the wire envelope.

--- a/docs-site/reference/http-routes.mdx
+++ b/docs-site/reference/http-routes.mdx
@@ -31,7 +31,26 @@ stream over SSE.
 | `/tick` | POST | scheduler tick (serverless cron target; requires `Authorization: Bearer <secret>`) |
 | `/webhooks/:source` | POST | trigger ingress (Composio, host, plain), verified as described below |
 | `/activity` | GET | `AuditEvent[]`, self-scoped with `guard.audit.query({ principal })` |
-| `/status` | GET | `{ posture, version, blocks: {...} }` |
+| `/status` | GET | `{ posture, version, blocks: {...} }`, includes `blocks.mcp: true` when the door is open |
+
+## MCP door
+
+With `createVendo({ mcp: true, oauth })`, the door serves its transport under
+the wire plus four origin-root discovery documents through the same handler.
+Bodies follow the MCP transport spec, not the wire's JSON envelope.
+
+| Path | Method | Purpose |
+| --- | --- | --- |
+| `/api/vendo/mcp` | POST · GET · DELETE | MCP Streamable HTTP transport and OAuth endpoints (`/authorize`, `/token`, `/register`) |
+| `/.well-known/oauth-protected-resource/api/vendo/mcp` | GET | RFC 9728 protected-resource metadata |
+| `/.well-known/oauth-authorization-server/api/vendo/mcp` | GET | RFC 8414 authorization-server metadata |
+| `/.well-known/mcp/server-card.json` · `/.well-known/mcp-server-card` | GET | server card describing the door |
+
+Door paths bypass the wire's principal resolver and CSRF JSON gate. The door
+authenticates every request through `oauth.principal`, and the OAuth `/token`
+and `/register` endpoints are form-encoded POSTs. The origin-root discovery
+documents sit outside `/api/vendo`, so on Next.js you forward them to
+`vendo.handler`. See [MCP door](/capabilities/mcp).
 
 ## Webhook verification
 


### PR DESCRIPTION
Re-derives the docs content of the three stale Mintlify bot PRs (#140 MCP door, #134 Express host, #138 Vendo Cloud) against current main. The bot patches were written before the composition docs rewrite and no longer apply; every claim, code sample, path, and flag here was re-verified against the shipped source (packages/mcp, packages/vendo, packages/apps) and the contracts (docs/contracts/10-mcp.md, 00-overview Cloud line).

## What's in

- **New page `capabilities/mcp.mdx`**: enabling `createVendo({ mcp: true, oauth })`, the `HostOAuthAdapter` seam (`principal() -> null` is revocation), origin-root discovery routing on Next.js, `VENDO_BASE_URL` for door-first traffic, the actAs auth model (inbound MCP bearer never forwarded; missing consent/grant fails closed; missing actAs degrades to `not-implemented`), MCP Apps ride-along, doctor/status verification.
- **New page `deploy/vendo-cloud.mdx`**: `vendo cloud login` (email OTP, `~/.vendo/cloud-session.json`), `VENDO_API_KEY` runtime gating (`cloud-required`, HTTP 402), keys, `VENDO_CLOUD_URL`, `vendo.apps.share/publish`, CI share/publish from a file.
- **`quickstart-node.mdx` rewrite**: the Express init scaffold (`vendo/server.ts` + `vendo/ai.ts`, `mountVendo()`), plus accurate direct-mount adapter requirements (including the `req.originalUrl` gotcha) for other runtimes.
- **Reference updates**: cli.mdx (four commands now, `vendo cloud` section, doctor's Express + MCP checks), environment-variables.mdx (`VENDO_CLOUD_URL`, corrected `VENDO_BASE_URL` row), handler-options.mdx (`mcp`, `oauth` rows), http-routes.mdx (MCP door route table), docs.json nav.

## Bot errors fixed (why this isn't just a rebase)

From #134 (Express):
- Backwards headline: init detects only `next` and `express`; every other framework falls through to the NEXT scaffold (framework.ts, init.ts buildPlan). The bot claimed "non-Next hosts never receive Next-shaped files".
- Wrong `VENDO_BASE_URL` mechanism: it is the trusted origin for same-origin tool calls and Secure-cookie marking (server.ts), not a switch that stops the adapter trusting the Host header.
- Generated composition imports `./ai`, not `./ai.js`; omitted the real `req.originalUrl` adapter requirement.

From #140 (MCP):
- Dropped `vendo_apps_call` from the ride-along tool list (door.ts exposes all three).
- Apps ride-along framed as conditional; through `createVendo` an AppsPort is always wired when `mcp: true`.
- Broken well-known forwarding example: a blanket catch-all forwards ALL well-known paths to a handler that 404s non-door paths; discovery docs are GET-only, so no POST forward.
- Conflated the transport mount (already under the wire catch-all) with the four origin-root discovery paths that actually need forwarding.
- Implied init/demos wire the door; init only prints guidance on opt-in (init.ts:596-598).

From #138 (Cloud):
- `import { apps } from "@vendoai/apps"` does not exist and the 3-arg `share(appId, doc, ctx)` is the internal helper; the host API is `vendo.apps.share(appId, ctx)` / `vendo.apps.publish(appId, ctx)` off the composition.
- "Malformed responses reject as `validation` errors" is false (schema parse throws ZodError; the taxonomy code comes from the hosted envelope).
- `--org` is not a global flag (per-command, org-scoped user commands only); `--json` was omitted; session path pinned to `~/.vendo/cloud-session.json`; CLI share/publish needs a string `id` or `--app <id>`.

## Not folded in

#107 (sentence-case headings) predates the docs rewrite; current docs are already sentence-case throughout, so there is nothing to re-apply.

## Verification

- `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green locally.
- `mint broken-links`: no broken links.
- Every code sample verified against shipped exports (`nextVendoHandler`, `mountVendo`, `HostOAuthAdapter`, `vendo.apps.*`).

Follow-up worth a look (not in this PR): `HostOAuthAdapter` is typed from `@vendoai/mcp`, which is only a transitive dep of the umbrella; strict-pnpm hosts can't import it. Consider re-exporting it from `@vendoai/vendo/server`.

Closes stale bot PRs #140, #134, #138, #107 (closed separately with pointers here).

https://claude.ai/code/session_01FWfCqReYkhHeHDYcCd45r2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds docs for the MCP door and Vendo Cloud, and updates init/quickstart to cover the Express scaffold and other JS servers. Refreshes references for CLI, environment variables (including `VENDO_URL`), handler options, and HTTP routes.

- **New Features**
  - MCP door docs: enable with `createVendo({ mcp: true, oauth })` and `HostOAuthAdapter` (`@vendoai/mcp`), copy-pasteable Next example, Next `/.well-known` forwarding and Express dual-mount, `VENDO_BASE_URL` for door-first traffic, actAs-based auth, saved apps ride-along, and verification via `vendo doctor`. Door routes are documented with transport + OAuth subroutes (including `/register` as JSON), and `/status` now shows `blocks.mcp`.
  - Vendo Cloud docs: CLI email OTP login (session used for user commands), `VENDO_API_KEY` runtime gating (`cloud-required`, HTTP 402), `VENDO_CLOUD_URL` override, sharing/publishing via `vendo.apps.share/publish` or CLI file input, and `whoami` prints orgs.

- **Refactors**
  - Quickstart rewritten for Express and other Node-compatible servers: generated `vendo/server.ts` + `mountVendo()`, `<VendoRoot>`, adapter requirements (including `req.originalUrl`), Node 20+ note, and verification via `vendo doctor`.
  - Init docs synced: four interview questions (model, brief, critical-tool risk, MCP door), door is opt-in (no scaffolding), and framework detection clarified (Next checked before Express; `src/app` variant).
  - Reference updates: CLI adds `vendo cloud` (with `--api-url` and `--key`), doctor checks MCP OAuth docs and server card, env adds `VENDO_CLOUD_URL`, clarifies `VENDO_BASE_URL`, and adds `VENDO_URL`, handler options document `mcp` and `oauth`, and HTTP routes split out MCP transport + OAuth endpoints with Next forwarding guidance.

<sup>Written for commit 4dd30169355c203fa59895800404be4ca20c5efd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

