### PR TITLE
fix: umbrella HostOAuthAdapter re-export + deterministic ui voice-stage teardown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ apps/*/.vendo/data/
 
 # wave-6 orchestration lane briefs/signals (never committed)
 .lanes/
+
+# type-surface test fixtures (packages/vendo/src/type-surface.test.ts) — cleaned
+# in afterEach; ignored so an interrupted run can never dirty a commit.
+packages/vendo/.type-surface.*.ts

--- a/packages/ui/test/mocks/fluidkit.tsx
+++ b/packages/ui/test/mocks/fluidkit.tsx
@@ -1,0 +1,29 @@
+// Inert package-wide stub for the `fluidkit` animation library. Wired in via
+// `resolve.alias` in ../../vitest.config.ts so NO test worker ever loads the
+// real library (or its `motion` peer). See that config for the full rationale;
+// in short: fluidkit is a decorative enhancement layer that is not under test
+// in this package, and loading it in vitest is a flake hazard —
+//   1. `motion`'s frameloop keeps a `requestAnimationFrame` perpetually
+//      outstanding. Under jsdom that rAF is backed by a Node `setInterval` that
+//      outlives vitest's environment teardown and then dereferences a stripped
+//      `window`, surfacing as unhandled "window is not defined" errors.
+//   2. The first dynamic `import("fluidkit")` triggers vite's in-worker
+//      transform of the fluidkit+motion chunk — multi-second on a loaded CI —
+//      stalling the worker past `findBy*` windows and timing out unrelated
+//      async assertions.
+//
+// The stub renders the same `aria-hidden`-compatible placeholder spans the real
+// components sit inside, so the surfaces under test mount identically without
+// any animation machinery. `VoiceBall` and `Thinking` are the only fluidkit
+// exports that packages/ui/src dynamically imports (voice-blob.tsx,
+// fluid-thinking.tsx). The type-only import of the REAL prop types keeps these
+// stubs honest against fluidkit 0.5's contract.
+import type { VoiceBallProps, ThinkingProps } from "fluidkit";
+
+export function VoiceBall({ size, mode }: VoiceBallProps) {
+  return <span data-fluidkit-stub="voice-ball" data-mode={mode} style={{ width: size, height: size }} />;
+}
+
+export function Thinking({ label, size }: ThinkingProps) {
+  return <span data-fluidkit-stub="thinking" aria-label={label} style={{ width: size, height: size }} />;
+}

--- a/packages/ui/test/setup.ts
+++ b/packages/ui/test/setup.ts
@@ -6,6 +6,18 @@
  * one so cross-realm aborts keep working exactly like a browser.
  */
 import { transferableAbortController } from "node:util";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+/**
+ * This package's vitest config does not enable `globals`, so
+ * @testing-library/react's automatic per-test cleanup (which keys off a global
+ * `afterEach`) never registers. Without it, every rendered component stays
+ * mounted across the whole file — its effects, listeners, and animation frames
+ * outlive the test. Register cleanup explicitly so each test unmounts before the
+ * next, matching standard RTL semantics.
+ */
+afterEach(cleanup);
 
 const nativeFetch = globalThis.fetch;
 

--- a/packages/ui/test/tree/tree-view.test.tsx
+++ b/packages/ui/test/tree/tree-view.test.tsx
@@ -264,14 +264,17 @@ describe("TreeView bindings and outcomes", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Run action" }));
-    await waitFor(() => expect(onAction).toHaveBeenCalledWith({
+    // The outcome attribute and notice only appear once the async onAction
+    // promise resolves and React commits; wait on that observable state rather
+    // than on the mock merely having been called.
+    expect(await screen.findByRole("note", { name: /action pending approval/i })).toBeTruthy();
+    expect(document.querySelector('[data-vendo-node-id="root"]')?.getAttribute("data-vendo-outcome"))
+      .toBe("pending-approval");
+    expect(onAction).toHaveBeenCalledWith({
       nodeId: "root",
       action: "fn:submit",
       payload: { row: 7 },
-    }));
-    expect(document.querySelector('[data-vendo-node-id="root"]')?.getAttribute("data-vendo-outcome"))
-      .toBe("pending-approval");
-    expect(screen.getByRole("note", { name: /action pending approval/i })).toBeTruthy();
+    });
   });
 
   it("ignores an unknown future ToolOutcome status without throwing a notice", async () => {
@@ -294,7 +297,13 @@ describe("TreeView bindings and outcomes", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Run future action" }));
-    await waitFor(() => expect(onAction).toHaveBeenCalledOnce());
+    // Wait for the unknown outcome to actually land (root gains the raw status
+    // attribute) before asserting no notice — otherwise the null check can pass
+    // simply because the async result has not committed yet.
+    await waitFor(() => expect(
+      document.querySelector('[data-vendo-node-id="root"]')?.getAttribute("data-vendo-outcome"),
+    ).toBe("future-thing"));
+    expect(onAction).toHaveBeenCalledOnce();
     expect(screen.queryByRole("note")).toBeNull();
   });
 });

--- a/packages/ui/test/voice/stage.test.tsx
+++ b/packages/ui/test/voice/stage.test.tsx
@@ -1,10 +1,25 @@
 // @vitest-environment jsdom
 
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { VendoProvider } from "../../src/index.js";
 import { VendoStage } from "../../src/voice/index.js";
 import { ScriptedVoiceDriver } from "./fake-driver.js";
+
+// This suite exercises VendoStage's behavior (controls, announced status,
+// ordered transcript) — not fluidkit's animated presence, which is decorative
+// and `aria-hidden`. The real `VoiceBall` pulls in `motion`, whose frameloop
+// keeps a `requestAnimationFrame` perpetually outstanding. Under jsdom that rAF
+// is backed by a Node `setInterval` that outlives vitest's environment teardown
+// and then dereferences a stripped `window` — surfacing as unhandled
+// "window is not defined" errors after the file passes. Mocking fluidkit with
+// an inert stub keeps that async animation machinery out of the test entirely,
+// which is both faithful (the ball is not under test) and deterministic.
+vi.mock("fluidkit", () => ({
+  VoiceBall: (props: { size?: number }) => (
+    <span data-fluidkit="voice-ball-stub" style={{ width: props.size, height: props.size }} />
+  ),
+}));
 
 describe("VendoStage", () => {
   it("controls the session and renders announced state and ordered transcript", () => {

--- a/packages/ui/test/voice/stage.test.tsx
+++ b/packages/ui/test/voice/stage.test.tsx
@@ -1,25 +1,16 @@
 // @vitest-environment jsdom
 
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { VendoProvider } from "../../src/index.js";
 import { VendoStage } from "../../src/voice/index.js";
 import { ScriptedVoiceDriver } from "./fake-driver.js";
 
 // This suite exercises VendoStage's behavior (controls, announced status,
 // ordered transcript) — not fluidkit's animated presence, which is decorative
-// and `aria-hidden`. The real `VoiceBall` pulls in `motion`, whose frameloop
-// keeps a `requestAnimationFrame` perpetually outstanding. Under jsdom that rAF
-// is backed by a Node `setInterval` that outlives vitest's environment teardown
-// and then dereferences a stripped `window` — surfacing as unhandled
-// "window is not defined" errors after the file passes. Mocking fluidkit with
-// an inert stub keeps that async animation machinery out of the test entirely,
-// which is both faithful (the ball is not under test) and deterministic.
-vi.mock("fluidkit", () => ({
-  VoiceBall: (props: { size?: number }) => (
-    <span data-fluidkit="voice-ball-stub" style={{ width: props.size, height: props.size }} />
-  ),
-}));
+// and `aria-hidden`. fluidkit is stubbed package-wide via the `resolve.alias`
+// in ../../vitest.config.ts, so the real `VoiceBall` (and its `motion`
+// frameloop teardown hazard) never loads in any ui test.
 
 describe("VendoStage", () => {
   it("controls the session and renders announced state and ordered transcript", () => {

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -5,5 +6,22 @@ export default defineConfig({
     environment: "jsdom",
     include: ["test/**/*.test.ts?(x)"],
     setupFiles: ["test/setup.ts"],
+  },
+  resolve: {
+    alias: {
+      // Resolve `fluidkit` to an inert stub in EVERY ui test, so no test worker
+      // ever loads the real decorative animation library (or its `motion`
+      // peer). Two flake hazards this removes package-wide:
+      //   1. motion's frameloop keeps a rAF outstanding; under jsdom that rAF is
+      //      a Node `setInterval` that survives vitest's environment teardown
+      //      and dereferences a stripped `window` -> unhandled "window is not
+      //      defined".
+      //   2. The first dynamic import triggers vite's in-worker transform of the
+      //      fluidkit+motion chunk (multi-second on loaded CI), stalling the
+      //      worker past `findBy*` windows and timing out unrelated assertions.
+      // fluidkit is not under test in this package; the stub is faithful (the
+      // presence is decorative and `aria-hidden`). See test/mocks/fluidkit.tsx.
+      fluidkit: fileURLToPath(new URL("./test/mocks/fluidkit.tsx", import.meta.url)),
+    },
   },
 });

--- a/packages/vendo/src/index.ts
+++ b/packages/vendo/src/index.ts
@@ -32,3 +32,9 @@ export type {
   RunStatus,
 } from "@vendoai/automations";
 export type { VendoClient, VendoClientConfig } from "@vendoai/ui";
+// 10-mcp §3: the one type a host implements to open the MCP door
+// (`createVendo({ mcp: true, oauth })`). The rest of @vendoai/mcp's surface
+// (createMcpDoor, McpDoor, AppsPort, McpDoorConfig, McpRunContext) is
+// umbrella-internal — the Vendo interface exposes no `mcp` handle (09 §2) — so
+// only this host-facing seam belongs on the root.
+export type { HostOAuthAdapter } from "@vendoai/mcp";

--- a/packages/vendo/src/type-surface.test.ts
+++ b/packages/vendo/src/type-surface.test.ts
@@ -15,6 +15,10 @@ import { afterEach, describe, expect, it } from "vitest";
 // missing re-export makes tsc emit TS2305 and exit non-zero, which
 // execFileSync surfaces as a throw. Removing any single re-export from
 // src/index.ts turns this suite red (proven by mutation in the wave report).
+// Deliberately checks the SOURCE entry, not the published `@vendoai/vendo`
+// surface: source is deterministic against the working tree, while dist would
+// silently test stale build output; exports-map/dist breakage is a different
+// failure class, covered by the clean-room publish verification at release.
 
 const require = createRequire(import.meta.url);
 const tsc = require.resolve("typescript/bin/tsc");

--- a/packages/vendo/src/type-surface.test.ts
+++ b/packages/vendo/src/type-surface.test.ts
@@ -1,0 +1,129 @@
+import { execFileSync } from "node:child_process";
+import { rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+// 09-vendo §1: the umbrella root (`@vendoai/vendo`) re-exports "root types
+// re-exported from core (+ each block's primary types)". This is a PURE TYPE
+// surface — every export in src/index.ts is `export type`, and types are erased
+// at runtime. vitest runs under esbuild (no typechecking) and the package
+// tsconfig EXCLUDES *.test.ts, so a plain `import type` here would be silently
+// unchecked and prove nothing. Instead we shell a real `tsc --noEmit` over a
+// generated fixture that `import type`s each name from the source root entry: a
+// missing re-export makes tsc emit TS2305 and exit non-zero, which
+// execFileSync surfaces as a throw. Removing any single re-export from
+// src/index.ts turns this suite red (proven by mutation in the wave report).
+
+const require = createRequire(import.meta.url);
+const tsc = require.resolve("typescript/bin/tsc");
+const packageDir = fileURLToPath(new URL("..", import.meta.url)); // packages/vendo
+
+// Every host-facing type a host names when wiring or reaching into the umbrella.
+// Core types arrive via `export type * from "@vendoai/core"` (verified: ActAs,
+// SecretsProvider, StoreAdapter, VendoTheme are all core exports); the rest are
+// each block's primary/host-facing types re-exported explicitly.
+const HOST_FACING_TYPES = [
+  // core (through `export type *`)
+  "Principal",
+  "ActAs",
+  "SecretsProvider",
+  "StoreAdapter",
+  "VendoTheme",
+  "RunContext",
+  "AppDocument",
+  "AppId",
+  "RunId",
+  "Json",
+  "ToolRegistry",
+  "Guard",
+  "ToolOutcome",
+  "ApprovalRequest",
+  "PermissionGrant",
+  "AuditEvent",
+  // store
+  "VendoStore",
+  // agent
+  "VendoAgent",
+  "Thread",
+  "ThreadSummary",
+  // actions
+  "ActionsRegistry",
+  "Connector",
+  "ExtractedTool",
+  "SyncReport",
+  // guard
+  "Judge",
+  "PolicyConfig",
+  "PolicyFile",
+  "PolicyFn",
+  "PolicyRule",
+  "Scanner",
+  "VendoGuard",
+  // apps
+  "AppsRuntime",
+  "EditResult",
+  "OpenSurface",
+  "SandboxAdapter",
+  "SandboxMachine",
+  "VersionEntry",
+  // automations
+  "AutomationsEngine",
+  "RunPlan",
+  "RunRecord",
+  "RunStatus",
+  // ui
+  "VendoClient",
+  "VendoClientConfig",
+  // mcp — the host implements HostOAuthAdapter to open the door
+  // (createVendo({ mcp: true, oauth }), 10-mcp §3). This is the gap this
+  // wave closes; the rest of @vendoai/mcp's surface (McpDoor, AppsPort,
+  // McpDoorConfig, McpRunContext) is umbrella-internal — no `vendo.mcp`
+  // handle exists on the Vendo interface (09 §2) — so it is deliberately
+  // NOT re-exported.
+  "HostOAuthAdapter",
+];
+
+const fixtures: string[] = [];
+afterEach(() => {
+  for (const path of fixtures.splice(0)) rmSync(path, { force: true });
+});
+
+/** Type-check a fixture that `import type`s `names` from the source root entry.
+ *  Returns tsc's combined output on failure, or null when it exits clean. */
+function typecheckImports(names: string[]): string | null {
+  // Written at the package root so `./src/index.js` and node_modules both
+  // resolve; a unique name keeps parallel runs isolated and out of the build
+  // (tsconfig `include` is `src/**`, so a root-level file is never compiled).
+  const fixturePath = join(packageDir, `.type-surface.${process.pid}.${Math.random().toString(36).slice(2)}.ts`);
+  fixtures.push(fixturePath);
+  writeFileSync(fixturePath, `import type { ${names.join(", ")} } from "./src/index.js";\n`);
+  try {
+    execFileSync(
+      process.execPath,
+      [tsc, fixturePath, "--noEmit", "--strict", "--target", "ES2022", "--module", "ESNext",
+        "--moduleResolution", "Bundler", "--skipLibCheck", "--esModuleInterop"],
+      { cwd: packageDir, stdio: "pipe" },
+    );
+    return null;
+  } catch (error) {
+    const err = error as { stdout?: Buffer; stderr?: Buffer };
+    return `${err.stdout?.toString() ?? ""}${err.stderr?.toString() ?? ""}`;
+  }
+}
+
+describe("09-vendo §1 — umbrella root type surface", () => {
+  it("re-exports every host-facing type from the source root entry", () => {
+    const failure = typecheckImports(HOST_FACING_TYPES);
+    expect(failure, failure ?? "").toBeNull();
+  });
+
+  it("has teeth: a missing re-export fails the tsc gate with TS2305", () => {
+    // Proves the mechanism genuinely catches a dropped re-export, so the
+    // assertion above cannot silently pass if the surface regresses.
+    const failure = typecheckImports(["__DefinitelyNotAVendoRootExport"]);
+    expect(failure).not.toBeNull();
+    expect(failure).toContain("TS2305");
+  });
+});


### PR DESCRIPTION
Two follow-ups surfaced by the docs-sync wave (#143).

## 1. Contract gap: `HostOAuthAdapter` missing from the umbrella root

`docs/contracts/09-vendo.md` §1 says the umbrella root re-exports each block's primary types. `HostOAuthAdapter` is the one type a host implements to open the MCP door (`createVendo({ mcp: true, oauth })` — and `vendo init` points hosts at it), yet `@vendoai/vendo` didn't re-export it, forcing hosts to reach into the transitive `@vendoai/mcp` dep. Flagged by both Devin and Greptile on #143.

- Added `export type { HostOAuthAdapter } from "@vendoai/mcp"` to the root. The rest of `@vendoai/mcp`'s surface (`createMcpDoor`, `McpDoor`, `AppsPort`, `McpDoorConfig`, `McpRunContext`) is umbrella-internal — the `Vendo` interface exposes no `mcp` handle (09 §2), so hosts never name those types; deliberately not re-exported.
- Audited blocks 01–08 for the same class of gap: **no other misses** — core types (`ActAs`, `SecretsProvider`, `StoreAdapter`, `VendoTheme`, …) arrive via `export type * from "@vendoai/core"`, and every other block's primary types were already re-exported. MCP was the only gap.
- New regression test `packages/vendo/src/type-surface.test.ts` locks the host-facing surface (44 names). Types are erased at runtime and the package tsconfig excludes tests from typecheck, so a naive `import type` would be silently useless — the test shells a real `tsc --noEmit` over a generated fixture and includes a permanent negative control (bogus name ⇒ TS2305). **Mutation-proven**: removing `Judge` from `index.ts` turns the suite red; the pre-fix run failed on exactly `HostOAuthAdapter`.

## 2. Flaky teardown in `packages/ui` `test/voice/stage.test.tsx`

CI symptom: suite passes, then "window is not defined" ×3 as unhandled errors. Root cause chain (each link verified with a deterministic repro):

1. `vitest.config.ts` doesn't enable `globals`, so RTL auto-cleanup (which keys off a global `afterEach`) never registered — rendered components outlived their tests.
2. `VendoStage` → `VoiceBlob` dynamically imports `fluidkit` and mounts `VoiceBall`, whose `motion` frameloop keeps a `requestAnimationFrame` perpetually outstanding (jsdom has no `IntersectionObserver`, so `useInView` defaults in-view).
3. jsdom backs rAF with a Node `setInterval` cleared only at zero outstanding callbacks — never, here.
4. The interval survives vitest's environment teardown and dereferences stripped globals: 3 uncaught ReferenceErrors from `jsdom .../Window.js:640`, matching CI's ×3 exactly. Flaky because a tick must land in the teardown gap — common on loaded CI, rare locally.

Fix (deterministic — no retries, skips, or timeouts):
- `vi.mock("fluidkit")` with an inert stub in `stage.test.tsx` — motion is never loaded, so the jsdom rAF interval is never created, independent of any ordering. (Proven necessary: unmount alone still leaked 3 errors — motion's frameloop is a worker-global singleton, so RTL cleanup by itself does NOT close this hole.) The suite tests VendoStage's controls/status/transcript; the ball is decorative and `aria-hidden`.
- `afterEach(cleanup)` registered in `test/setup.ts` — fixes the proven package-wide RTL-cleanup gap.

No product bug: in real browsers native rAF after unmount is harmless; the fault is the jsdom-rAF-as-setInterval × vitest-teardown interaction. Latent same-class note: `FluidThinking` (chrome) also dynamic-imports fluidkit, but no test mounts it today (nothing renders the `working` state); mock fluidkit if one ever does.

## Verification

- `pnpm build && pnpm test && pnpm typecheck && pnpm lint` — all green (exit 0)
- Perf gate `pnpm --filter @vendoai/bench bench -- --check` — exit 0
- Fixed stage test **10×** clean (no "window is not defined"/unhandled errors in full output); full `packages/ui` suite 10× clean in-lane + re-verified by orchestrator
- New type-surface test 5× clean; mutation proof above
- Dual review: Codex adversarial pass (2 findings triaged in e1288213: fixtures gitignored; source-entry choice documented) + orchestrator adversarial pass

No UI-affecting changes (test-only in packages/ui; type-only re-export in packages/vendo), so no browser screenshots.

https://claude.ai/code/session_0164EhU9FaexSbt4YXx3s5gR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `HostOAuthAdapter` from `@vendoai/vendo` and harden the test suite. UI tests are now deterministic by stubbing `fluidkit`, fixing RTL cleanup, and syncing `tree-view` assertions with committed UI state.

- **Bug Fixes**
  - Re-exported `HostOAuthAdapter` from `@vendoai/mcp` at the `@vendoai/vendo` root. Added a `tsc`-backed type-surface test to lock the host-facing API and ignored the generated fixtures.
  - Stabilized `packages/ui` tests: resolved `fluidkit` to an inert typed stub via `vitest` `resolve.alias`, registered `afterEach(cleanup)` in test setup, and updated `tree-view` tests to wait on committed outcome state. Removes jsdom teardown errors and CI timeouts.

<sup>Written for commit 153eb3d4cfe65b2e374468978f343c98778b70a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

