### PR TITLE
feat(apps): functional OSS secret egress via allowlisted proxy + SSRF guard (ENG-259)

### DIFF
--- a/docs/contracts/06-apps.md
+++ b/docs/contracts/06-apps.md
@@ -122,9 +122,13 @@ The machine IS the server part. No declared entry point; by convention the app l
 | `VENDO_RUN_TOKEN` | bearer token scoping this run: `{ appId, principal, runId, presence }` — minted per run, short-lived |
 | declared secret names | **handles**, not values (§4.3) |
 
-### 4.3 Secrets ⚑ — handles, substituted at egress
+### 4.3 Secrets ⚑ — handles, substituted at the egress proxy
 
-Per the page, secret values are never readable by app code. Each declared secret name is injected as an opaque handle (`vendo-secret:<name>:<nonce>`). The machine's egress proxy (which also enforces the `egress` allowlist) substitutes the real value when a handle transits toward an allowlisted domain (headers or body). App code uses `process.env.STRIPE_KEY` normally and never learns the value; a handle leaving toward a non-allowlisted domain never resolves. Values come from the composition's `SecretsProvider`.
+Per the page, secret values are never readable by app code. Each declared secret name is injected as an opaque handle (`vendo-secret:<name>:<nonce>`). App code uses `process.env.STRIPE_KEY` normally and never learns the value. Real values come from the composition's `SecretsProvider` and resolve **only inside the proxy process, only for egress the app is permitted** — never in the sandbox env, never at boot.
+
+The functional path (ENG-259): the sandbox reaches an external host by sending the outbound request through the runtime proxy's **egress route** (§4.5). The proxy (a) matches the target host against the app's declared `egress` allowlist — the same list that drives the sandbox provider's outbound network allow rule (§3), reused, not a second allowlist; (b) applies a Vendo-side SSRF guard that refuses loopback, link-local (incl. `169.254.169.254`), RFC1918, IPv6 ULA/link-local, and `0.0.0.0`, validating the **resolved IP** (rebind-resistant) on the initial hop and every redirect; (c) only then resolves the request's declared-secret handles to real values via `SecretsProvider.get()` and substitutes them into headers or body (`substituteSecretHandles`); (d) forwards, without ever sending the run token to the target; (e) strips any reflected secret from the response before it returns to app code. A handle leaving toward a non-allowlisted or SSRF-blocked host never resolves and never forwards. An app that declares no `egress` allowlist gets no substitution and no egress through the proxy (fail closed), even though the sandbox provider treats undefined `egress` as unrestricted raw network.
+
+> **Amendment (2026-07-14, ENG-259):** this section previously implied the substitution was a latent helper "safe by construction because nothing calls it." It is now WIRED and functional: an OSS app declaring `secrets` can authenticate to its allowlisted hosts. Substitution and the SSRF guard are the enforced boundary — secrets resolve at the proxy for allowlisted egress and nowhere else. The in-sandbox `fetch` shim that routes app outbound calls into §4.5 ships in the served-app scaffold; the security boundary is the proxy route described here.
 
 ### 4.4 Host tools from inside the machine (the capability axis)
 
@@ -137,6 +141,20 @@ body: { "args": {...} }        →  ToolOutcome (core §4)
 ```
 
 The proxy resolves the token to its `RunContext` and calls the guard-bound registry — identical treatment to a chat tool call. Away + ungranted → `{ "status": "pending-approval" }`; the app must tolerate it (fail soft).
+
+### 4.5 Allowlisted secret egress (the external-service axis) ⚑ — ENG-259
+
+App code never holds real secret values and never opens raw sockets to the outside world with them; it sends an outbound request through the proxy, which is the one point where a declared-secret handle becomes a real value.
+
+```
+POST {VENDO_PROXY_URL}/egress
+Authorization: Bearer {VENDO_RUN_TOKEN}
+body: { "url": "...", "method"?: "...", "headers"?: {...}, "body"?: "..." }
+  → 200 { "status": <int>, "headers": {...}, "body": "..." }   (secrets redacted from the response)
+  → 403 { "error": { "code": "egress-blocked", ... } }         (host not allowlisted, or SSRF-refused)
+```
+
+The envelope describes the request the app wants forwarded; the run token authenticates the app→proxy hop and is never forwarded to the target (which is why the target's own `authorization` travels inside the envelope, not the outer header). The proxy performs, in order: declared-`egress` allowlist match → SSRF/private-address guard on the resolved IP (re-checked on every redirect) → declared-secret handle substitution → forward → response secret-stripping. Non-allowlisted or SSRF-blocked hosts are refused before any secret is read. Request and response bodies are size-capped (fail-safe); the URL is never rewritten, so a handle placed in a query string is never substituted. The SSRF guard is a reusable primitive (`checkEgressUrl`, `isBlockedAddress`); actions' `resolveUrl` (04) is a follow-up adopter once the primitive relocates to core (actions may import core only).
 
 ## 5. Generation engine
 

--- a/packages/apps/src/e2b/egress.live.test.ts
+++ b/packages/apps/src/e2b/egress.live.test.ts
@@ -1,0 +1,120 @@
+import type { AppDocument, SecretsProvider } from "@vendoai/core";
+import type { AppDataAccess } from "../app-data.js";
+import { describe, expect, it } from "vitest";
+import { createAppsProxy } from "../proxy.js";
+import { mintRunToken } from "../run-token.js";
+import { e2bSandbox } from "./index.js";
+
+// ============================================================================
+// ENG-259 LIVE verification — gated on E2B_API_KEY (skipped when absent, exactly
+// like e2b.live.test.ts). Proves the FUNCTIONAL egress path end-to-end against a
+// real E2B machine and the real public network, using the DEFAULT node:dns SSRF
+// resolver and DEFAULT global fetch (no injected fakes):
+//
+//   1. A real E2B sandbox created with an egress allowlist + a declared secret
+//      HANDLE in env boots and carries the opaque handle (never the value).
+//   2. The host-side proxy /egress route substitutes the real secret toward an
+//      allowlisted host (proven via a reflect-then-redact echo), forwards, and
+//      redacts the reflected secret from the response.
+//   3. A non-allowlisted host is refused with no forward.
+//   4. The real node:dns SSRF guard blocks the cloud metadata address.
+//
+// NOTE: with no E2B_API_KEY in this environment, this suite is SKIPPED and was
+// NOT executed here; it is written real + runnable for a keyed environment.
+// ============================================================================
+
+const ALLOWED_HOST = "postman-echo.com"; // reflects request headers in its JSON response
+const REAL_SECRET = `sk_live_${Math.random().toString(36).slice(2)}`;
+const HANDLE = "vendo-secret:ECHO_KEY:live0nonce";
+const tokenSecret = new TextEncoder().encode("eng-259-live-egress-secret-key-01");
+
+const app = {
+  format: "vendo/app@1",
+  id: "app_live_egress",
+  name: "Live egress app",
+  egress: [ALLOWED_HOST],
+  secrets: ["ECHO_KEY"],
+} as AppDocument;
+
+const secrets: SecretsProvider = { async get(name) { return name === "ECHO_KEY" ? REAL_SECRET : undefined; } };
+
+const proxy = createAppsProxy({
+  tokenSecret,
+  tools: { async descriptors() { return []; }, async execute() { return { status: "blocked", reason: "n/a" }; } },
+  data: {} as AppDataAccess,
+  owns: async () => true,
+  loadApp: async () => app,
+  secrets,
+  // default fetch + default node:dns resolver — the real thing.
+});
+
+const runToken = async (): Promise<string> => mintRunToken(tokenSecret, {
+  appId: app.id, subject: "user_live", runId: "run_live", presence: "present", expiresAt: Date.now() + 120_000,
+});
+
+const egress = async (envelope: unknown): Promise<Response> => proxy.handler(new Request("https://proxy.test/egress", {
+  method: "POST",
+  headers: { authorization: `Bearer ${await runToken()}`, "content-type": "application/json" },
+  body: JSON.stringify(envelope),
+}));
+
+describe.skipIf(!process.env.E2B_API_KEY)("ENG-259 functional secret egress (live)", () => {
+  it("boots a real E2B machine that carries the secret HANDLE, not the value", async () => {
+    const adapter = e2bSandbox({ apiKey: process.env.E2B_API_KEY, timeoutMs: 90_000 });
+    const machine = await adapter.create({
+      env: { PORT: "8080", ECHO_KEY: HANDLE },
+      egress: [ALLOWED_HOST],
+    });
+    try {
+      const printed = await machine.exec("printenv ECHO_KEY", { timeoutMs: 10_000 });
+      expect(printed.stdout.trim()).toBe(HANDLE);
+      expect(printed.stdout).not.toContain(REAL_SECRET);
+    } finally {
+      await machine.stop().catch(() => undefined);
+    }
+  }, 90_000);
+
+  it("substitutes and forwards a real secret to an allowlisted host, redacting the reflection", async () => {
+    const response = await egress({
+      url: `https://${ALLOWED_HOST}/post`,
+      method: "POST",
+      headers: { authorization: `Bearer ${HANDLE}` },
+      body: "hello",
+    });
+    expect(response.status).toBe(200);
+    const envelope = await response.json() as { status: number; body: string };
+    expect(envelope.status).toBe(200);
+    // Reflect-then-redact: the echo saw the REAL value (so substitution happened), and the
+    // proxy redacted it before returning — the handle is gone AND the real value is gone.
+    expect(envelope.body).toContain("[vendo-secret-redacted]");
+    expect(envelope.body).not.toContain(HANDLE);
+    expect(envelope.body).not.toContain(REAL_SECRET);
+  }, 30_000);
+
+  it("refuses a non-allowlisted host with no substitution", async () => {
+    const response = await egress({
+      url: "https://example.com/collect",
+      headers: { authorization: `Bearer ${HANDLE}` },
+    });
+    expect(response.status).toBe(403);
+  }, 30_000);
+
+  it("blocks the cloud metadata address via the real node:dns SSRF guard", async () => {
+    // 169.254.169.254 is an IP literal, so this is refused pre-DNS; still exercises the guard live.
+    const metadataApp = { ...app, egress: ["169.254.169.254"] } as AppDocument;
+    const metadataProxy = createAppsProxy({
+      tokenSecret,
+      tools: { async descriptors() { return []; }, async execute() { return { status: "blocked", reason: "n/a" }; } },
+      data: {} as AppDataAccess,
+      owns: async () => true,
+      loadApp: async () => metadataApp,
+      secrets,
+    });
+    const response = await metadataProxy.handler(new Request("https://proxy.test/egress", {
+      method: "POST",
+      headers: { authorization: `Bearer ${await runToken()}`, "content-type": "application/json" },
+      body: JSON.stringify({ url: "http://169.254.169.254/latest/meta-data/" }),
+    }));
+    expect(response.status).toBe(403);
+  }, 30_000);
+});

--- a/packages/apps/src/egress.ts
+++ b/packages/apps/src/egress.ts
@@ -11,7 +11,8 @@ export type SecretHandleMap = Readonly<Record<string, string>> | ReadonlyMap<str
 const entries = (handleMap: SecretHandleMap): Array<[string, string]> =>
   handleMap instanceof Map ? [...handleMap.entries()] : Object.entries(handleMap);
 
-const hostAllowed = (hostname: string, allowlist: readonly string[]): boolean => {
+/** 06-apps §4.3 — exact or `*.`-wildcard host match against a declared egress allowlist. */
+export const hostAllowed = (hostname: string, allowlist: readonly string[]): boolean => {
   const host = hostname.toLowerCase();
   return allowlist.some((entry) => {
     const allowed = entry.toLowerCase();

--- a/packages/apps/src/index.ts
+++ b/packages/apps/src/index.ts
@@ -1,8 +1,10 @@
 /** @vendoai/apps — the app artifact and engine (docs/contracts/06-apps.md).
  *
  * The package root exports exactly the 06 §1 public API plus the block-plan's
- * flagged additions (AppsConfig.proxyUrl/pinBaselines, AppsRuntime.proxy,
- * SandboxMachine.url?, create-spec egress?, substituteSecretHandles).
+ * flagged additions (AppsConfig.proxyUrl/pinBaselines/egressTransport,
+ * AppsRuntime.proxy, SandboxMachine.url?, create-spec egress?,
+ * substituteSecretHandles/hostAllowed) and the ENG-259 SSRF egress guard
+ * (checkEgressUrl, isBlockedAddress) exposed for reuse.
  * Everything else — machine sessions, run tokens, the generation engine,
  * interchange plumbing — is internal and reachable only through AppsRuntime.
  */
@@ -33,7 +35,15 @@ export {
   type PinShipRequest,
 } from "./pins.js";
 export {
+  hostAllowed,
   substituteSecretHandles,
   type SandboxEgressRequest,
   type SecretHandleMap,
 } from "./egress.js";
+export {
+  checkEgressUrl,
+  isBlockedAddress,
+  nodeIpResolver,
+  type EgressUrlCheck,
+  type IpResolver,
+} from "./ssrf.js";

--- a/packages/apps/src/proxy.ts
+++ b/packages/apps/src/proxy.ts
@@ -1,9 +1,18 @@
-import type { AppId, RunContext, ToolRegistry } from "@vendoai/core";
+import type { AppDocument, AppId, RunContext, SecretsProvider, ToolRegistry } from "@vendoai/core";
 import type { AppDataAccess } from "./app-data.js";
+import { hostAllowed, substituteSecretHandles } from "./egress.js";
 import { verifyRunToken, type RunTokenSecret } from "./run-token.js";
+import { checkEgressUrl, type IpResolver } from "./ssrf.js";
 
 const STATE_BODY_MAX_BYTES = 256 * 1024;
+const EGRESS_BODY_MAX_BYTES = 1 * 1024 * 1024; // 1 MiB request envelope ceiling
+const EGRESS_RESPONSE_MAX_BYTES = 4 * 1024 * 1024; // 4 MiB response ceiling
+const EGRESS_MAX_REDIRECTS = 5;
 const decoder = new TextDecoder();
+// Non-fatal so a non-UTF-8 (binary) response is redacted safely rather than throwing.
+const lenientDecoder = new TextDecoder("utf-8", { fatal: false });
+// vendo-secret:<NAME>:<nonce> — NAME is a declared secret name, nonce is per-boot hex.
+const HANDLE_PATTERN = /vendo-secret:([A-Za-z_][A-Za-z0-9_]*):[0-9a-fA-F]+/g;
 
 const jsonResponse = (body: unknown, status = 200): Response => new Response(JSON.stringify(body), {
   status,
@@ -24,74 +33,262 @@ const bearerToken = (request: Request): string | null => {
   return match?.[1] ?? null;
 };
 
-/** 06-apps §4.4 — internal dependencies for the fetch-style proxy. */
+/** 06-apps §4.3 — the outbound request an app hands to the proxy for allowlist-gated egress. */
+interface EgressEnvelope {
+  url: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+const parseEnvelope = (value: unknown): EgressEnvelope | null => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.url !== "string") return null;
+  if (record.method !== undefined && typeof record.method !== "string") return null;
+  if (record.body !== undefined && typeof record.body !== "string") return null;
+  if (record.headers !== undefined) {
+    if (typeof record.headers !== "object" || record.headers === null || Array.isArray(record.headers)) return null;
+    for (const header of Object.values(record.headers as Record<string, unknown>)) {
+      if (typeof header !== "string") return null;
+    }
+  }
+  return {
+    url: record.url,
+    ...(record.method === undefined ? {} : { method: record.method as string }),
+    ...(record.headers === undefined ? {} : { headers: record.headers as Record<string, string> }),
+    ...(record.body === undefined ? {} : { body: record.body as string }),
+  };
+};
+
+/** Replace every occurrence of a real secret value with a redaction marker (response-path defense). */
+const redact = (text: string, values: readonly string[]): string => {
+  let output = text;
+  for (const value of values) {
+    if (value.length === 0) continue;
+    output = output.split(value).join("[vendo-secret-redacted]");
+  }
+  return output;
+};
+
+/** 06-apps §1 plus ENG-259 egress additions — internal dependencies for the fetch-style proxy. */
 export interface AppsProxyDependencies {
   tokenSecret: RunTokenSecret;
   tools: ToolRegistry;
   data: AppDataAccess;
   owns(appId: AppId, subject: string): Promise<boolean>;
+  /** Load the owner's app document — supplies the egress allowlist and declared secret names. */
+  loadApp(appId: AppId, subject: string): Promise<AppDocument | null>;
+  /** Resolves declared secret handles to real values, ONLY inside the proxy, ONLY for allowlisted egress. */
+  secrets?: SecretsProvider;
+  /** Override the outbound transport (tests, instrumentation); defaults to global fetch. */
+  fetch?: typeof globalThis.fetch;
+  /** Override DNS resolution (tests, edge hosts); defaults to node:dns. */
+  resolveIp?: IpResolver;
 }
 
 /** 06-apps §4.4 and plan decision 3 — fetch-style machine capability proxy. */
-export const createAppsProxy = (dependencies: AppsProxyDependencies): { handler(request: Request): Promise<Response> } => ({
-  async handler(request) {
-    const url = new URL(request.url);
-    const toolMatch = /^\/tools\/([a-zA-Z0-9_-]{1,64})$/.exec(url.pathname);
-    const isTool = request.method === "POST" && toolMatch?.[1] !== undefined;
-    const isStateGet = request.method === "GET" && url.pathname === "/state";
-    const isStatePut = request.method === "PUT" && url.pathname === "/state";
-    if (!isTool && !isStateGet && !isStatePut) {
-      return errorResponse(404, "not-found", "unknown proxy route");
-    }
-    if ((isTool || isStatePut) && !isJson(request)) {
-      return errorResponse(400, "validation", "content-type must be application/json");
-    }
-    const token = bearerToken(request);
-    const payload = token === null ? null : await verifyRunToken(dependencies.tokenSecret, token);
-    if (payload === null) return errorResponse(401, "unauthorized", "invalid or expired run token");
-    if (!await dependencies.owns(payload.appId, payload.subject)) {
-      return errorResponse(404, "not-found", "app not found");
-    }
-    const runCtx: RunContext = {
-      principal: { kind: "user", subject: payload.subject },
-      venue: "app",
-      presence: payload.presence,
-      sessionId: payload.runId,
-      appId: payload.appId,
-    };
+export const createAppsProxy = (dependencies: AppsProxyDependencies): { handler(request: Request): Promise<Response> } => {
+  const outboundFetch = dependencies.fetch ?? globalThis.fetch;
 
-    if (isStateGet) {
-      return jsonResponse(await dependencies.data.getState(payload.appId, payload.subject));
-    }
-    let body: unknown;
-    try {
-      if (isStatePut) {
-        const bytes = new Uint8Array(await request.arrayBuffer());
-        if (bytes.byteLength > STATE_BODY_MAX_BYTES) {
-          return errorResponse(400, "validation", "request body exceeds size limit");
-        }
-        body = JSON.parse(decoder.decode(bytes)) as unknown;
-      } else {
-        body = await request.json();
+  // ENG-259 — resolve declared-secret handles present in THIS request to real values.
+  // Nonce-agnostic by design: the nonce is read from the request itself (so it works for
+  // both freshly-created and snapshot-resumed machines), and only names the app DECLARED
+  // are ever resolved. The app is already entitled to its declared secrets toward
+  // allowlisted hosts, so reading the nonce from the request grants nothing new.
+  const buildHandleMap = async (
+    app: AppDocument,
+    envelope: EgressEnvelope,
+  ): Promise<{ handleMap: Record<string, string>; values: string[] }> => {
+    const handleMap: Record<string, string> = {};
+    const values: string[] = [];
+    if (dependencies.secrets === undefined) return { handleMap, values };
+    const declared = new Set(app.secrets ?? []);
+    const scanned = JSON.stringify({ headers: envelope.headers ?? {}, body: envelope.body ?? "" });
+    const seen = new Set<string>();
+    for (const match of scanned.matchAll(HANDLE_PATTERN)) {
+      const handle = match[0];
+      const name = match[1] as string;
+      if (seen.has(handle) || !declared.has(name)) continue;
+      seen.add(handle);
+      const value = await dependencies.secrets.get(name);
+      if (value !== undefined && value.length > 0) {
+        handleMap[handle] = value;
+        values.push(value);
       }
+    }
+    return { handleMap, values };
+  };
+
+  // ENG-259 — forward with manual redirect following; re-validate SSRF + allowlist on EVERY hop.
+  const forward = async (
+    request: { url: string; method: string; headers: Record<string, string>; body?: string },
+    allowlist: readonly string[],
+  ): Promise<{ status: number; headers: Record<string, string>; body: string } | { blocked: string }> => {
+    let target = request.url;
+    for (let hop = 0; hop <= EGRESS_MAX_REDIRECTS; hop += 1) {
+      const host = (() => {
+        try {
+          return new URL(target).hostname;
+        } catch {
+          return null;
+        }
+      })();
+      if (host === null || !hostAllowed(host, allowlist)) return { blocked: "host-not-allowlisted" };
+      const vetted = await checkEgressUrl(target, { ...(dependencies.resolveIp === undefined ? {} : { resolve: dependencies.resolveIp }) });
+      if (!vetted.ok) return { blocked: vetted.reason };
+
+      const response = await outboundFetch(target, {
+        method: request.method,
+        headers: request.headers,
+        ...(request.body === undefined ? {} : { body: request.body }),
+        redirect: "manual",
+      });
+
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get("location");
+        if (location === null) return { blocked: "redirect-without-location" };
+        try {
+          target = new URL(location, target).toString();
+        } catch {
+          return { blocked: "redirect-invalid-location" };
+        }
+        continue; // re-validate the new hop at the top of the loop
+      }
+
+      const buffer = await response.arrayBuffer();
+      const bytes = buffer.byteLength > EGRESS_RESPONSE_MAX_BYTES
+        ? new Uint8Array(buffer, 0, EGRESS_RESPONSE_MAX_BYTES)
+        : new Uint8Array(buffer);
+      const headers: Record<string, string> = {};
+      for (const [name, value] of response.headers.entries()) headers[name] = value;
+      return { status: response.status, headers, body: lenientDecoder.decode(bytes) };
+    }
+    return { blocked: "too-many-redirects" };
+  };
+
+  const handleEgress = async (payload: { appId: AppId; subject: string }, envelope: EgressEnvelope): Promise<Response> => {
+    const app = await dependencies.loadApp(payload.appId, payload.subject);
+    if (app === null) return errorResponse(404, "not-found", "app not found");
+    const allowlist = app.egress ?? [];
+
+    // 1. Allowlist gate FIRST (cheap, no DNS, no secret read) — non-allowlisted host is refused
+    //    with no substitution and no forward. `new URL().hostname` collapses the userinfo trick
+    //    (https://api.stripe.com@evil.com → evil.com), so it is refused here.
+    let hostname: string;
+    try {
+      hostname = new URL(envelope.url).hostname;
     } catch {
-      return errorResponse(400, "validation", "request body must be valid JSON");
+      return errorResponse(400, "validation", "egress url is not a valid absolute URL");
     }
-    if (isStatePut) {
-      await dependencies.data.setState(payload.appId, payload.subject, body);
-      return jsonResponse({ status: "ok" });
+    if (!hostAllowed(hostname, allowlist)) {
+      return errorResponse(403, "egress-blocked", "host is not in the app egress allowlist");
     }
-    if (typeof body !== "object" || body === null || Array.isArray(body)
-      || !Object.prototype.hasOwnProperty.call(body, "args")) {
-      return errorResponse(400, "validation", "tool body must be an object containing args");
-    }
-    const tool = toolMatch?.[1];
-    if (tool === undefined) return errorResponse(404, "not-found", "unknown proxy route");
-    const outcome = await dependencies.tools.execute({
-      id: `call_${globalThis.crypto.randomUUID()}`,
-      tool,
-      args: (body as { args: unknown }).args,
-    }, runCtx);
-    return jsonResponse(outcome);
-  },
-});
+
+    // 2. SSRF / private-address gate on the RESOLVED IPs (rebind-resistant).
+    const vetted = await checkEgressUrl(envelope.url, { ...(dependencies.resolveIp === undefined ? {} : { resolve: dependencies.resolveIp }) });
+    if (!vetted.ok) return errorResponse(403, "egress-blocked", `egress refused: ${vetted.reason}`);
+
+    // 3. Only now — egress is permitted — resolve declared secrets and substitute in headers/body.
+    const { handleMap, values } = await buildHandleMap(app, envelope);
+    const substituted = substituteSecretHandles(
+      { url: envelope.url, ...(envelope.headers === undefined ? {} : { headers: envelope.headers }), ...(envelope.body === undefined ? {} : { body: envelope.body }) },
+      handleMap,
+      allowlist,
+    );
+
+    // 4. Forward (never send our run token to the target), re-validating each redirect hop.
+    const result = await forward({
+      url: substituted.url,
+      method: (envelope.method ?? "GET").toUpperCase(),
+      headers: (substituted.headers as Record<string, string> | undefined) ?? {},
+      ...(typeof substituted.body === "string" ? { body: substituted.body } : {}),
+    }, allowlist);
+    if ("blocked" in result) return errorResponse(403, "egress-blocked", `egress refused: ${result.blocked}`);
+
+    // 5. Strip any reflected secret from the response path before it returns to app code.
+    const responseHeaders: Record<string, string> = {};
+    for (const [name, value] of Object.entries(result.headers)) responseHeaders[name] = redact(value, values);
+    return jsonResponse({ status: result.status, headers: responseHeaders, body: redact(result.body, values) });
+  };
+
+  return {
+    async handler(request) {
+      const url = new URL(request.url);
+      const toolMatch = /^\/tools\/([a-zA-Z0-9_-]{1,64})$/.exec(url.pathname);
+      const isTool = request.method === "POST" && toolMatch?.[1] !== undefined;
+      const isStateGet = request.method === "GET" && url.pathname === "/state";
+      const isStatePut = request.method === "PUT" && url.pathname === "/state";
+      const isEgress = request.method === "POST" && url.pathname === "/egress";
+      if (!isTool && !isStateGet && !isStatePut && !isEgress) {
+        return errorResponse(404, "not-found", "unknown proxy route");
+      }
+      if ((isTool || isStatePut || isEgress) && !isJson(request)) {
+        return errorResponse(400, "validation", "content-type must be application/json");
+      }
+      const token = bearerToken(request);
+      const payload = token === null ? null : await verifyRunToken(dependencies.tokenSecret, token);
+      if (payload === null) return errorResponse(401, "unauthorized", "invalid or expired run token");
+      if (!await dependencies.owns(payload.appId, payload.subject)) {
+        return errorResponse(404, "not-found", "app not found");
+      }
+      const runCtx: RunContext = {
+        principal: { kind: "user", subject: payload.subject },
+        venue: "app",
+        presence: payload.presence,
+        sessionId: payload.runId,
+        appId: payload.appId,
+      };
+
+      if (isStateGet) {
+        return jsonResponse(await dependencies.data.getState(payload.appId, payload.subject));
+      }
+      if (isEgress) {
+        const bytes = new Uint8Array(await request.arrayBuffer());
+        if (bytes.byteLength > EGRESS_BODY_MAX_BYTES) {
+          return errorResponse(400, "validation", "egress request exceeds size limit");
+        }
+        let envelope: EgressEnvelope | null;
+        try {
+          envelope = parseEnvelope(JSON.parse(decoder.decode(bytes)) as unknown);
+        } catch {
+          return errorResponse(400, "validation", "egress request body must be valid JSON");
+        }
+        if (envelope === null) {
+          return errorResponse(400, "validation", "egress request must be { url, method?, headers?, body? }");
+        }
+        return handleEgress(payload, envelope);
+      }
+      let body: unknown;
+      try {
+        if (isStatePut) {
+          const bytes = new Uint8Array(await request.arrayBuffer());
+          if (bytes.byteLength > STATE_BODY_MAX_BYTES) {
+            return errorResponse(400, "validation", "request body exceeds size limit");
+          }
+          body = JSON.parse(decoder.decode(bytes)) as unknown;
+        } else {
+          body = await request.json();
+        }
+      } catch {
+        return errorResponse(400, "validation", "request body must be valid JSON");
+      }
+      if (isStatePut) {
+        await dependencies.data.setState(payload.appId, payload.subject, body);
+        return jsonResponse({ status: "ok" });
+      }
+      if (typeof body !== "object" || body === null || Array.isArray(body)
+        || !Object.prototype.hasOwnProperty.call(body, "args")) {
+        return errorResponse(400, "validation", "tool body must be an object containing args");
+      }
+      const tool = toolMatch?.[1];
+      if (tool === undefined) return errorResponse(404, "not-found", "unknown proxy route");
+      const outcome = await dependencies.tools.execute({
+        id: `call_${globalThis.crypto.randomUUID()}`,
+        tool,
+        args: (body as { args: unknown }).args,
+      }, runCtx);
+      return jsonResponse(outcome);
+    },
+  };
+};

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -41,6 +41,7 @@ import type { PinBaseline } from "./pins.js";
 import { createAppsProxy } from "./proxy.js";
 import type { SandboxAdapter } from "./sandbox.js";
 import type { SandboxMachine } from "./sandbox.js";
+import type { IpResolver } from "./ssrf.js";
 
 /** 06-apps §1 plus block-plan decisions 3–4. */
 export interface AppsConfig {
@@ -55,6 +56,12 @@ export interface AppsConfig {
   designRules?: string;
   proxyUrl?: string;
   pinBaselines?: PinBaseline[];
+  /**
+   * ENG-259 — advanced egress seam for the allowlisted secret-egress proxy (§4.3).
+   * Defaults are zero-config on Node: global fetch + node:dns. A non-Node host (edge)
+   * or a test injects its own transport/resolver here.
+   */
+  egressTransport?: { fetch?: typeof globalThis.fetch; resolveIp?: IpResolver };
 }
 
 /** 06-apps §1 */
@@ -176,6 +183,10 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     tools: config.tools,
     data,
     owns: async (appId, subject) => await owned(appId, subject) !== null,
+    loadApp: owned,
+    ...(config.secrets === undefined ? {} : { secrets: config.secrets }),
+    ...(config.egressTransport?.fetch === undefined ? {} : { fetch: config.egressTransport.fetch }),
+    ...(config.egressTransport?.resolveIp === undefined ? {} : { resolveIp: config.egressTransport.resolveIp }),
   });
 
   const failedEdit = (

--- a/packages/apps/src/security/egress-proxy.test.ts
+++ b/packages/apps/src/security/egress-proxy.test.ts
@@ -1,0 +1,241 @@
+import type { AppDataAccess } from "../app-data.js";
+import type { AppDocument, SecretsProvider, ToolRegistry } from "@vendoai/core";
+import { describe, expect, it, vi } from "vitest";
+import { createAppsProxy } from "../proxy.js";
+import { mintRunToken } from "../run-token.js";
+import type { IpResolver } from "../ssrf.js";
+
+// ============================================================================
+// ENG-259 adversarial suite for the FUNCTIONAL secret-egress proxy (06-apps §4.3).
+//
+// The proxy /egress route is the one controlled point where a declared secret
+// handle becomes a real value. Every case here is an attack: get the real secret
+// to a host the adversary controls, or reach an internal address. All must FAIL
+// CLOSED — refuse, with no substitution and no forward. Delete a guard and the
+// matching case here goes red (revert-to-fail).
+// ============================================================================
+
+const SECRET = "sk_live_REAL_SECRET_VALUE";
+const tokenSecret = new TextEncoder().encode("egress-proxy-test-secret-key-0001");
+
+const appDoc = (over: Partial<AppDocument>): AppDocument =>
+  ({ format: "vendo/app@1", id: "app_egress", name: "Egress app", ...over }) as AppDocument;
+
+const noopData = {} as AppDataAccess;
+const noopTools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "blocked", reason: "unused" }; },
+};
+
+interface Harness {
+  handler(request: Request): Promise<Response>;
+  token: string;
+  fetchMock: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
+}
+
+const publicResolver: IpResolver = async () => ["93.184.216.34"];
+
+const makeHarness = async (options: {
+  app: AppDocument;
+  fetchImpl?: (input: string, init?: RequestInit) => Promise<Response>;
+  resolveIp?: IpResolver;
+  secretValue?: string | undefined;
+} ): Promise<Harness> => {
+  const get = vi.fn(async (): Promise<string | undefined> => options.secretValue ?? SECRET);
+  const secrets: SecretsProvider = { get };
+  const fetchMock = vi.fn(options.fetchImpl ?? (async () =>
+    new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } })));
+  const proxy = createAppsProxy({
+    tokenSecret,
+    tools: noopTools,
+    data: noopData,
+    owns: async () => true,
+    loadApp: async () => options.app,
+    secrets,
+    fetch: fetchMock as unknown as typeof globalThis.fetch,
+    resolveIp: options.resolveIp ?? publicResolver,
+  });
+  const token = await mintRunToken(tokenSecret, {
+    appId: options.app.id,
+    subject: "user_ada",
+    runId: "run_egress",
+    presence: "present",
+    expiresAt: Date.now() + 60_000,
+  });
+  return { handler: proxy.handler, token, fetchMock, get };
+};
+
+const egress = (token: string, envelope: unknown): Request =>
+  new Request("https://proxy.test/egress", {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify(envelope),
+  });
+
+const handleFor = (name: string): string => `vendo-secret:${name}:deadbeef`;
+
+describe("egress proxy — allowlisted secret substitution (happy path)", () => {
+  it("substitutes a declared secret toward an allowlisted host and forwards, redacting reflections", async () => {
+    const reflected = async (_input: string, init?: RequestInit): Promise<Response> =>
+      // A reflecting endpoint echoes the Authorization header back — the proxy must strip it.
+      new Response(JSON.stringify({ echoed: (init?.headers as Record<string, string>).authorization }), {
+        status: 200,
+        headers: { "content-type": "application/json", "x-echo": (init?.headers as Record<string, string>).authorization },
+      });
+    const h = await makeHarness({ app: appDoc({ egress: ["api.stripe.com"], secrets: ["STRIPE_KEY"] }), fetchImpl: reflected });
+
+    const response = await h.handler(egress(h.token, {
+      url: "https://api.stripe.com/v1/charges",
+      method: "POST",
+      headers: { authorization: `Bearer ${handleFor("STRIPE_KEY")}` },
+      body: `amount=100`,
+    }));
+    expect(response.status).toBe(200);
+
+    // The forwarded request carried the REAL secret to the allowlisted host.
+    expect(h.fetchMock).toHaveBeenCalledTimes(1);
+    const forwardedHeaders = h.fetchMock.mock.calls[0][1].headers as Record<string, string>;
+    expect(forwardedHeaders.authorization).toBe(`Bearer ${SECRET}`);
+    expect(h.get).toHaveBeenCalledWith("STRIPE_KEY");
+
+    // The reflected secret is stripped on the way back to app code.
+    const envelope = await response.json() as { status: number; headers: Record<string, string>; body: string };
+    expect(JSON.stringify(envelope)).not.toContain(SECRET);
+    expect(envelope.body).toContain("[vendo-secret-redacted]");
+    expect(envelope.headers["x-echo"]).toBe("Bearer [vendo-secret-redacted]");
+  });
+});
+
+describe("egress proxy — exfiltration attempts fail closed", () => {
+  it("refuses a non-allowlisted host with NO substitution and NO forward", async () => {
+    const h = await makeHarness({ app: appDoc({ egress: ["api.stripe.com"], secrets: ["STRIPE_KEY"] }) });
+    const response = await h.handler(egress(h.token, {
+      url: "https://evil.attacker.test/collect",
+      method: "POST",
+      headers: { authorization: `Bearer ${handleFor("STRIPE_KEY")}` },
+    }));
+    expect(response.status).toBe(403);
+    expect(h.fetchMock).not.toHaveBeenCalled();
+    expect(h.get).not.toHaveBeenCalled(); // secret never even read
+  });
+
+  it("blocks the userinfo trick https://api.stripe.com@evil.com → evil.com refused", async () => {
+    const h = await makeHarness({ app: appDoc({ egress: ["api.stripe.com"], secrets: ["STRIPE_KEY"] }) });
+    const response = await h.handler(egress(h.token, {
+      url: "https://api.stripe.com@evil.com/collect",
+      headers: { authorization: `Bearer ${handleFor("STRIPE_KEY")}` },
+    }));
+    expect(response.status).toBe(403);
+    expect(h.fetchMock).not.toHaveBeenCalled();
+    expect(h.get).not.toHaveBeenCalled();
+  });
+
+  it("blocks a redirect from an allowlisted host to an internal IP", async () => {
+    const redirecter: IpResolver = async (host) => (host === "api.stripe.com" ? ["93.184.216.34"] : ["10.0.0.5"]);
+    const fetchImpl = async (input: string): Promise<Response> => {
+      if (input.includes("api.stripe.com")) {
+        return new Response(null, { status: 302, headers: { location: "http://169.254.169.254/latest/meta-data/" } });
+      }
+      return new Response("SHOULD NOT REACH", { status: 200 });
+    };
+    const h = await makeHarness({ app: appDoc({ egress: ["api.stripe.com"], secrets: ["STRIPE_KEY"] }), fetchImpl, resolveIp: redirecter });
+    const response = await h.handler(egress(h.token, {
+      url: "https://api.stripe.com/v1/charges",
+      headers: { authorization: `Bearer ${handleFor("STRIPE_KEY")}` },
+    }));
+    expect(response.status).toBe(403);
+    // The first hop was attempted; the redirect target (metadata IP) was refused before a second fetch.
+    expect(h.fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks DNS rebind: an allowlisted host that resolves to loopback is refused", async () => {
+    const rebind: IpResolver = async () => ["127.0.0.1"]; // allowlisted name, private answer
+    const h = await makeHarness({ app: appDoc({ egress: ["api.stripe.com"], secrets: ["STRIPE_KEY"] }), resolveIp: rebind });
+    const response = await h.handler(egress(h.token, {
+      url: "https://api.stripe.com/v1/charges",
+      headers: { authorization: `Bearer ${handleFor("STRIPE_KEY")}` },
+    }));
+    expect(response.status).toBe(403);
+    expect(h.fetchMock).not.toHaveBeenCalled();
+    expect(h.get).not.toHaveBeenCalled();
+  });
+
+  it("does not leak a handle hidden in the query string toward a non-allowlisted host", async () => {
+    const h = await makeHarness({ app: appDoc({ egress: ["api.stripe.com"], secrets: ["STRIPE_KEY"] }) });
+    const response = await h.handler(egress(h.token, {
+      url: `https://evil.attacker.test/x?leak=${handleFor("STRIPE_KEY")}`,
+    }));
+    expect(response.status).toBe(403);
+    expect(h.fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not substitute a handle in the URL query even toward an allowlisted host (URL is never rewritten)", async () => {
+    const h = await makeHarness({ app: appDoc({ egress: ["api.stripe.com"], secrets: ["STRIPE_KEY"] }) });
+    await h.handler(egress(h.token, {
+      url: `https://api.stripe.com/x?leak=${handleFor("STRIPE_KEY")}`,
+    }));
+    expect(h.fetchMock).toHaveBeenCalledTimes(1);
+    const forwardedUrl = h.fetchMock.mock.calls[0][0] as string;
+    expect(forwardedUrl).toContain(handleFor("STRIPE_KEY"));
+    expect(forwardedUrl).not.toContain(SECRET);
+  });
+
+  it("does not resolve a handle for a secret the app did not declare", async () => {
+    const h = await makeHarness({ app: appDoc({ egress: ["api.stripe.com"], secrets: ["STRIPE_KEY"] }) });
+    await h.handler(egress(h.token, {
+      url: "https://api.stripe.com/v1",
+      headers: { authorization: `Bearer ${handleFor("OTHER_SECRET")}` },
+    }));
+    expect(h.get).not.toHaveBeenCalledWith("OTHER_SECRET");
+    const forwardedHeaders = h.fetchMock.mock.calls[0][1].headers as Record<string, string>;
+    expect(forwardedHeaders.authorization).toBe(`Bearer ${handleFor("OTHER_SECRET")}`); // left as an opaque handle
+  });
+});
+
+describe("egress proxy — fail-safe limits and auth", () => {
+  it("rejects an oversized egress request body", async () => {
+    const h = await makeHarness({ app: appDoc({ egress: ["api.stripe.com"], secrets: ["STRIPE_KEY"] }) });
+    const response = await h.handler(egress(h.token, {
+      url: "https://api.stripe.com/v1",
+      body: "x".repeat(1024 * 1024 + 1),
+    }));
+    expect(response.status).toBe(400);
+    expect(h.fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("truncates an oversized response body and never leaks the secret", async () => {
+    const huge = `${SECRET}${"y".repeat(5 * 1024 * 1024)}`;
+    const fetchImpl = async (): Promise<Response> => new Response(huge, { status: 200 });
+    const h = await makeHarness({ app: appDoc({ egress: ["api.stripe.com"], secrets: ["STRIPE_KEY"] }), fetchImpl });
+    const response = await h.handler(egress(h.token, {
+      url: "https://api.stripe.com/v1",
+      headers: { authorization: `Bearer ${handleFor("STRIPE_KEY")}` },
+    }));
+    const envelope = await response.json() as { body: string };
+    expect(envelope.body.length).toBeLessThanOrEqual(4 * 1024 * 1024);
+    expect(envelope.body).not.toContain(SECRET);
+  });
+
+  it("rejects an unauthenticated egress request", async () => {
+    const h = await makeHarness({ app: appDoc({ egress: ["api.stripe.com"], secrets: ["STRIPE_KEY"] }) });
+    const response = await h.handler(new Request("https://proxy.test/egress", {
+      method: "POST",
+      headers: { authorization: "Bearer forged.token", "content-type": "application/json" },
+      body: JSON.stringify({ url: "https://api.stripe.com/v1" }),
+    }));
+    expect(response.status).toBe(401);
+    expect(h.fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses egress when the app declares no allowlist (fail closed)", async () => {
+    const h = await makeHarness({ app: appDoc({ secrets: ["STRIPE_KEY"] }) }); // egress undefined
+    const response = await h.handler(egress(h.token, {
+      url: "https://api.stripe.com/v1",
+      headers: { authorization: `Bearer ${handleFor("STRIPE_KEY")}` },
+    }));
+    expect(response.status).toBe(403);
+    expect(h.fetchMock).not.toHaveBeenCalled();
+    expect(h.get).not.toHaveBeenCalled();
+  });
+});

--- a/packages/apps/src/security/wired-in.test.ts
+++ b/packages/apps/src/security/wired-in.test.ts
@@ -1,6 +1,10 @@
-import type { RunContext, SecretsProvider } from "@vendoai/core";
+import type { AppDocument, RunContext, SecretsProvider } from "@vendoai/core";
 import { describe, expect, it, vi } from "vitest";
 import { createApps } from "../index.js";
+import { createAppsProxy } from "../proxy.js";
+import { mintRunToken } from "../run-token.js";
+import type { AppDataAccess } from "../app-data.js";
+import type { IpResolver } from "../ssrf.js";
 import {
   basicLanguageModel,
   fakeSandbox,
@@ -10,22 +14,20 @@ import {
 } from "../testing/index.js";
 
 // ============================================================================
-// KEY RED-TEAM FINDING FOR SECRETS (documented, then proven):
+// SECRETS INVARIANT (ENG-259, updated from the pre-hardening "dead code" framing):
 //
-// machine.ts `environment()` injects each declared secret into the sandbox as an
-// OPAQUE HANDLE string `vendo-secret:<name>:<nonce>` — NOT the real value. The real
-// secret value is never placed in the machine's env, files, or any request the app
-// can read. The SecretsProvider.get() is not even consulted at boot.
+//   Real secret values resolve ONLY inside the proxy process, ONLY for egress toward
+//   an allowlisted host. They NEVER enter the sandbox: the machine's env carries only
+//   opaque per-boot handles (`vendo-secret:<name>:<nonce>`), and boot never reads the
+//   SecretsProvider.
 //
-// substituteSecretHandles (see egress-exfil.test.ts) is a PURE helper that a sandbox
-// egress adapter *could* call to swap a handle for its value on an allowlisted host.
-// But in the OSS e2b/modal path that helper is NOT wired in: nothing calls it, so the
-// real secret value is never present inside the sandbox at all. Exfiltration is
-// therefore impossible BY CONSTRUCTION — strictly stronger than the contract's
-// allowlist-gated substitution, because there is no value to exfiltrate.
-//
-// This test proves the injected-handle property end-to-end via the real createApps
-// open() path with a fake sandbox.
+// This replaces the earlier claim that substituteSecretHandles was unreachable dead
+// code ("safe by construction because nothing calls it"). It is now WIRED: the apps
+// proxy /egress route builds a handle→value map at request time and calls it — but
+// only after the host has passed the declared egress allowlist and the SSRF guard, so
+// a secret is read only when egress is actually permitted. Two properties, both proven
+// below: (1) the sandbox holds handles, not values, and boot does not read secrets;
+// (2) the proxy resolves a secret only for allowlisted egress, never otherwise.
 // ============================================================================
 
 const ctx: RunContext = {
@@ -34,6 +36,9 @@ const ctx: RunContext = {
   presence: "present",
   sessionId: "session_ada",
 };
+
+const tokenSecret = new TextEncoder().encode("wired-in-secrets-invariant-key-01");
+const publicResolver: IpResolver = async () => ["93.184.216.34"];
 
 describe("secret handles are injected, real values never enter the sandbox", () => {
   it("boots a machine whose env carries handles, not secret values, and never reads the provider", async () => {
@@ -67,5 +72,52 @@ describe("secret handles are injected, real values never enter the sandbox", () 
     expect(Object.values(env)).not.toContain(REAL_VALUE);
     // ...and the boot path never even asked the SecretsProvider for it.
     expect(get).not.toHaveBeenCalled();
+  });
+});
+
+describe("the proxy resolves a secret ONLY for allowlisted egress", () => {
+  const REAL = "sk_live_PROXY_ONLY";
+  const app = { format: "vendo/app@1", id: "app_wired", name: "Wired", egress: ["api.stripe.com"], secrets: ["STRIPE_KEY"] } as AppDocument;
+
+  const proxyWith = (fetchMock: typeof globalThis.fetch, resolveIp: IpResolver, get: SecretsProvider["get"]) =>
+    createAppsProxy({
+      tokenSecret,
+      tools: { async descriptors() { return []; }, async execute() { return { status: "blocked", reason: "no" }; } },
+      data: {} as AppDataAccess,
+      owns: async () => true,
+      loadApp: async () => app,
+      secrets: { get },
+      fetch: fetchMock,
+      resolveIp,
+    });
+
+  const token = async () => mintRunToken(tokenSecret, {
+    appId: app.id, subject: "user_ada", runId: "run_wired", presence: "present", expiresAt: Date.now() + 60_000,
+  });
+
+  const call = (bearer: string, url: string): Request => new Request("https://proxy.test/egress", {
+    method: "POST",
+    headers: { authorization: `Bearer ${bearer}`, "content-type": "application/json" },
+    body: JSON.stringify({ url, method: "POST", headers: { authorization: "Bearer vendo-secret:STRIPE_KEY:abc123" } }),
+  });
+
+  it("reads and substitutes the secret toward an allowlisted host", async () => {
+    const get = vi.fn(async () => REAL);
+    const fetchMock = vi.fn(async () => new Response("{}", { status: 200 })) as unknown as typeof globalThis.fetch;
+    const proxy = proxyWith(fetchMock, publicResolver, get);
+    await proxy.handler(call(await token(), "https://api.stripe.com/v1/charges"));
+    expect(get).toHaveBeenCalledWith("STRIPE_KEY");
+    const headers = (fetchMock as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1].headers as Record<string, string>;
+    expect(headers.authorization).toBe(`Bearer ${REAL}`);
+  });
+
+  it("never reads the secret toward a non-allowlisted host", async () => {
+    const get = vi.fn(async () => REAL);
+    const fetchMock = vi.fn(async () => new Response("{}", { status: 200 })) as unknown as typeof globalThis.fetch;
+    const proxy = proxyWith(fetchMock, publicResolver, get);
+    const response = await proxy.handler(call(await token(), "https://evil.example/collect"));
+    expect(response.status).toBe(403);
+    expect(get).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/apps/src/ssrf.test.ts
+++ b/packages/apps/src/ssrf.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { checkEgressUrl, isBlockedAddress } from "./ssrf.js";
+
+describe("isBlockedAddress", () => {
+  it("blocks IPv4 loopback, private, link-local, CGNAT, and multicast ranges", () => {
+    for (const ip of [
+      "127.0.0.1", "127.1.2.3",
+      "10.0.0.1", "10.255.255.255",
+      "172.16.0.1", "172.31.255.255",
+      "192.168.1.1",
+      "169.254.169.254", // cloud metadata
+      "100.64.0.1", // CGNAT
+      "0.0.0.0",
+      "224.0.0.1", "255.255.255.255",
+    ]) {
+      expect(isBlockedAddress(ip), ip).toBe(true);
+    }
+  });
+
+  it("allows ordinary public IPv4 addresses", () => {
+    for (const ip of ["1.1.1.1", "8.8.8.8", "93.184.216.34", "172.15.0.1", "172.32.0.1", "100.63.255.255"]) {
+      expect(isBlockedAddress(ip), ip).toBe(false);
+    }
+  });
+
+  it("blocks IPv6 loopback, unspecified, link-local, ULA, and multicast", () => {
+    for (const ip of ["::1", "::", "fe80::1", "fc00::1", "fd12:3456::1", "ff02::1"]) {
+      expect(isBlockedAddress(ip), ip).toBe(true);
+    }
+  });
+
+  it("unwraps IPv4-mapped IPv6 and classifies the inner address", () => {
+    expect(isBlockedAddress("::ffff:127.0.0.1")).toBe(true);
+    expect(isBlockedAddress("::ffff:169.254.169.254")).toBe(true);
+    expect(isBlockedAddress("::ffff:8.8.8.8")).toBe(false);
+  });
+
+  it("allows a public IPv6 address", () => {
+    expect(isBlockedAddress("2606:4700:4700::1111")).toBe(false);
+  });
+
+  it("fails closed on anything unparseable", () => {
+    for (const junk of ["not-an-ip", "", "999.999.999.999", "12.34"]) {
+      expect(isBlockedAddress(junk), junk).toBe(true);
+    }
+  });
+});
+
+describe("checkEgressUrl", () => {
+  const resolve = (map: Record<string, string[]>) => async (host: string) => map[host] ?? [];
+
+  it("passes a public host and returns its addresses", async () => {
+    const check = await checkEgressUrl("https://api.stripe.com/v1", { resolve: resolve({ "api.stripe.com": ["8.8.8.8"] }) });
+    expect(check.ok).toBe(true);
+  });
+
+  it("rejects non-http(s) schemes", async () => {
+    const check = await checkEgressUrl("file:///etc/passwd", { resolve: resolve({}) });
+    expect(check).toMatchObject({ ok: false });
+  });
+
+  it("rejects embedded userinfo", async () => {
+    const check = await checkEgressUrl("https://user:pass@api.stripe.com/", { resolve: resolve({ "api.stripe.com": ["8.8.8.8"] }) });
+    expect(check).toMatchObject({ ok: false, reason: "userinfo-forbidden" });
+  });
+
+  it("rejects a host that resolves to a private address (rebind defense)", async () => {
+    const check = await checkEgressUrl("https://api.stripe.com/", { resolve: resolve({ "api.stripe.com": ["127.0.0.1"] }) });
+    expect(check).toMatchObject({ ok: false });
+    if (!check.ok) expect(check.reason).toContain("blocked-address");
+  });
+
+  it("rejects when ANY resolved address is private", async () => {
+    const check = await checkEgressUrl("https://api.stripe.com/", { resolve: resolve({ "api.stripe.com": ["8.8.8.8", "10.0.0.1"] }) });
+    expect(check).toMatchObject({ ok: false });
+  });
+
+  it("validates an IP-literal host without resolving", async () => {
+    expect(await checkEgressUrl("http://169.254.169.254/latest/meta-data/")).toMatchObject({ ok: false });
+    expect(await checkEgressUrl("http://[::1]/")).toMatchObject({ ok: false });
+  });
+
+  it("fails closed when DNS is unavailable", async () => {
+    const check = await checkEgressUrl("https://api.stripe.com/", {
+      resolve: async () => { throw new Error("no dns"); },
+    });
+    expect(check).toMatchObject({ ok: false, reason: "dns-unavailable" });
+  });
+});

--- a/packages/apps/src/ssrf.ts
+++ b/packages/apps/src/ssrf.ts
@@ -1,0 +1,166 @@
+/**
+ * ENG-259 — Vendo-side SSRF / private-address egress guard.
+ *
+ * A reusable, platform-neutral primitive: it classifies IP literals with pure
+ * arithmetic and resolves hostnames through an injectable resolver, so the same
+ * code runs in a unit test (fake resolver) and in production (node:dns). It is
+ * consumed by the apps egress proxy (proxy.ts); actions' registry.ts resolveUrl
+ * can adopt it once this primitive is relocated to core (a core-additive
+ * follow-up — actions may only import core, never apps).
+ *
+ * Fail-closed: an unparseable address, an empty DNS answer, or an unavailable
+ * resolver all deny egress. DNS resolution happens against the RESOLVED IPs, not
+ * the hostname string, which is what makes it resistant to a rebind that points
+ * an allowlisted name at a private address.
+ */
+
+/** Resolve a hostname to its IP addresses. Injected in tests; node:dns by default. */
+export type IpResolver = (hostname: string) => Promise<string[]>;
+
+/** Default resolver: node:dns/promises, imported lazily so edge/Bun bundles stay clean. */
+export const nodeIpResolver: IpResolver = async (hostname) => {
+  const dns = await import("node:dns/promises");
+  const records = await dns.lookup(hostname, { all: true, verbatim: true });
+  return records.map((record) => record.address);
+};
+
+const parseIpv4 = (value: string): number[] | null => {
+  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(value);
+  if (match === null) return null;
+  const octets = [Number(match[1]), Number(match[2]), Number(match[3]), Number(match[4])];
+  return octets.some((octet) => octet > 255) ? null : octets;
+};
+
+const ipv4Blocked = (octets: number[]): boolean => {
+  const [a, b, c] = octets as [number, number, number, number];
+  if (a === 0) return true; // 0.0.0.0/8 "this host"
+  if (a === 10) return true; // RFC1918
+  if (a === 127) return true; // loopback
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64/10 CGNAT
+  if (a === 169 && b === 254) return true; // 169.254/16 link-local (incl. 169.254.169.254 metadata)
+  if (a === 172 && b >= 16 && b <= 31) return true; // RFC1918
+  if (a === 192 && b === 0 && c === 0) return true; // 192.0.0.0/24 IETF protocol assignments
+  if (a === 192 && b === 168) return true; // RFC1918
+  if (a === 198 && (b === 18 || b === 19)) return true; // 198.18/15 benchmarking
+  if (a >= 224) return true; // 224/4 multicast + 240/4 reserved + 255.255.255.255 broadcast
+  return false;
+};
+
+const parseIpv6 = (input: string): Uint8Array | null => {
+  let text = input;
+  if (text.startsWith("[") && text.endsWith("]")) text = text.slice(1, -1);
+  const zone = text.indexOf("%");
+  if (zone !== -1) text = text.slice(0, zone);
+  if (!text.includes(":")) return null;
+
+  // Embedded IPv4 tail, e.g. ::ffff:1.2.3.4 — fold into two 16-bit groups.
+  const embedded = /^(.*:)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/.exec(text);
+  if (embedded !== null) {
+    const v4 = parseIpv4(embedded[2] as string);
+    if (v4 === null) return null;
+    const high = ((v4[0] as number) << 8) | (v4[1] as number);
+    const low = ((v4[2] as number) << 8) | (v4[3] as number);
+    text = `${embedded[1]}${high.toString(16)}:${low.toString(16)}`;
+  }
+
+  const halves = text.split("::");
+  if (halves.length > 2) return null;
+  const head = halves[0] === "" ? [] : (halves[0] as string).split(":");
+  const tail = halves.length === 2 ? (halves[1] === "" ? [] : (halves[1] as string).split(":")) : null;
+
+  let groups: string[];
+  if (tail === null) {
+    if (head.length !== 8) return null;
+    groups = head;
+  } else {
+    const missing = 8 - head.length - tail.length;
+    if (missing < 1) return null;
+    groups = [...head, ...new Array<string>(missing).fill("0"), ...tail];
+  }
+
+  const bytes = new Uint8Array(16);
+  for (let index = 0; index < 8; index += 1) {
+    const group = groups[index] as string;
+    if (!/^[0-9a-fA-F]{1,4}$/.test(group)) return null;
+    const value = Number.parseInt(group, 16);
+    bytes[index * 2] = value >> 8;
+    bytes[index * 2 + 1] = value & 0xff;
+  }
+  return bytes;
+};
+
+const ipv6Blocked = (bytes: Uint8Array): boolean => {
+  const allZeroUpTo = (end: number): boolean => bytes.slice(0, end).every((byte) => byte === 0);
+  if (allZeroUpTo(16)) return true; // :: unspecified
+  if (allZeroUpTo(15) && bytes[15] === 1) return true; // ::1 loopback
+  // IPv4-mapped ::ffff:0:0/96 and deprecated IPv4-compatible ::/96 — classify the inner v4.
+  if (allZeroUpTo(10) && bytes[10] === 0xff && bytes[11] === 0xff) {
+    return ipv4Blocked([bytes[12] as number, bytes[13] as number, bytes[14] as number, bytes[15] as number]);
+  }
+  if (allZeroUpTo(12) && !(bytes[12] === 0 && bytes[13] === 0 && bytes[14] === 0 && bytes[15] === 0)) {
+    return ipv4Blocked([bytes[12] as number, bytes[13] as number, bytes[14] as number, bytes[15] as number]);
+  }
+  const first = bytes[0] as number;
+  const second = bytes[1] as number;
+  if (first === 0xfe && (second & 0xc0) === 0x80) return true; // fe80::/10 link-local
+  if ((first & 0xfe) === 0xfc) return true; // fc00::/7 unique-local
+  if (first === 0xff) return true; // ff00::/8 multicast
+  return false;
+};
+
+/** True when an IP literal is loopback, link-local, private, ULA, multicast, or otherwise non-public. Unparseable → blocked. */
+export const isBlockedAddress = (address: string): boolean => {
+  const v4 = parseIpv4(address);
+  if (v4 !== null) return ipv4Blocked(v4);
+  const v6 = parseIpv6(address);
+  if (v6 !== null) return ipv6Blocked(v6);
+  return true; // fail closed on anything we cannot classify
+};
+
+const isIpLiteral = (host: string): boolean =>
+  parseIpv4(host) !== null || parseIpv6(host) !== null;
+
+/** The outcome of vetting one URL for egress. */
+export type EgressUrlCheck =
+  | { ok: true; url: URL; addresses: string[] }
+  | { ok: false; reason: string };
+
+/**
+ * Vet a URL for outbound egress: http(s) only, no embedded credentials, and every
+ * address it resolves to must be public. Call this on the initial URL AND on every
+ * redirect Location before following it.
+ */
+export const checkEgressUrl = async (
+  rawUrl: string,
+  options: { resolve?: IpResolver } = {},
+): Promise<EgressUrlCheck> => {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return { ok: false, reason: "invalid-url" };
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return { ok: false, reason: `unsupported-scheme:${url.protocol}` };
+  }
+  if (url.username !== "" || url.password !== "") {
+    return { ok: false, reason: "userinfo-forbidden" };
+  }
+  const host = url.hostname.replace(/^\[/, "").replace(/\]$/, "");
+  let addresses: string[];
+  if (isIpLiteral(host)) {
+    addresses = [host];
+  } else {
+    const resolve = options.resolve ?? nodeIpResolver;
+    try {
+      addresses = await resolve(host);
+    } catch {
+      return { ok: false, reason: "dns-unavailable" };
+    }
+    if (addresses.length === 0) return { ok: false, reason: "dns-empty" };
+  }
+  for (const address of addresses) {
+    if (isBlockedAddress(address)) return { ok: false, reason: `blocked-address:${address}` };
+  }
+  return { ok: true, url, addresses };
+};


### PR DESCRIPTION
## ENG-259 — functional OSS secret egress, safely

Makes declared app `secrets` functional in OSS single-player. Before this PR, `substituteSecretHandles` had zero non-test callers, `SecretsProvider.get()` was never called at boot, and the apps proxy served only `/tools/*` and `/state` — so an OSS app declaring `secrets` got opaque handles it could never authenticate with. A functional hole. Separately, no Vendo-side SSRF guard existed. Both are closed here, fail-closed and tested adversarially.

### Design

New proxy route `POST {VENDO_PROXY_URL}/egress`, run-token authenticated (same bearer as `/tools`, `/state`). The app sends an envelope `{ url, method?, headers?, body? }`; the run token authenticates the app→proxy hop and is never forwarded to the target (the target's own `authorization` rides inside the envelope, avoiding a header collision). The route performs, in strict order:

1. **Allowlist gate** — target host must match the app's declared `egress` list (exact or `*.` wildcard). This is the SAME list that drives the sandbox provider's `network.allowOut` (E2B `create(spec).egress`), reused — not a second allowlist. `new URL().hostname` collapses the `https://api.stripe.com@evil.com` userinfo trick to `evil.com`, refused here. No allowlist / empty ⇒ refuse (fail closed).
2. **SSRF guard** on the RESOLVED IP (`ssrf.ts`) — blocks loopback, link-local incl. `169.254.169.254`, RFC1918, CGNAT `100.64/10`, IPv6 ULA/link-local, multicast, `0.0.0.0`, IPv4-mapped IPv6. Re-validated on every redirect hop (manual redirect following). Because it validates the resolved IP (via an injectable resolver; `node:dns` default), a DNS rebind pointing an allowlisted name at `127.0.0.1` is refused.
3. **Handle substitution** — only now (egress permitted) are declared-secret handles resolved via `SecretsProvider.get()` and swapped into headers/body via `substituteSecretHandles`. The handleMap is built in the proxy process only, nonce-agnostic (nonce read from the request, so it survives snapshot/resume) and scoped to declared secret names. The sandbox still holds only opaque handles; boot never reads the provider.
4. **Forward** without the run token, re-validating each redirect hop.
5. **Response stripping** — any reflected real secret is redacted before returning to app code. Request and response bodies are size-capped (fail-safe).

Real values live solely in the proxy process, only for the duration of a permitted call.

### Adversarial coverage (revert-to-fail)

`packages/apps/src/security/egress-proxy.test.ts` + `ssrf.test.ts`:
- exfil to non-allowlisted host → refused, no substitution, secret never read
- `https://api.stripe.com@evil.com` userinfo trick → `evil.com` refused
- redirect allowlisted→internal IP (169.254.169.254) blocked before the 2nd fetch
- DNS-rebind: allowlisted host resolving to 127.0.0.1 blocked, secret never read
- handle in query string toward non-allowlisted host → refused (URL never rewritten even for allowlisted hosts)
- undeclared secret name → left as opaque handle
- oversized request body rejected; oversized response truncated + secret never leaks
- unauthenticated / no-allowlist → refused
- `ssrf.ts`: full IPv4/IPv6 range classification incl. IPv4-mapped IPv6, fail-closed on unparseable/DNS-unavailable

`wired-in.test.ts` rewritten to the new invariant (secrets resolve ONLY in the proxy for allowlisted egress; boot still injects handles and never reads the provider). Removes the old "safe by construction because dead code" framing.

### Live e2b status

`packages/apps/src/e2b/egress.live.test.ts`, `describe.skipIf(!process.env.E2B_API_KEY)`, real + runnable: boots a real E2B machine carrying the secret HANDLE (not value), then drives the real proxy egress path over the public network (default `node:dns` + global fetch) proving substitution-then-redaction toward an allowlisted host, refusal of a non-allowlisted host, and the metadata address blocked. **NOT executed here — no `E2B_API_KEY` in this environment.**

### Contract amendments

`docs/contracts/06-apps.md`: §4.3 rewritten to the functional path with a dated (2026-07-14) amendment note; new §4.5 documents the `/egress` route.

### Flagged assumptions (safest interpretation chosen)

1. **Allowlist source** = `app.egress` (reused from the E2B `allowOut` derivation). Substitution requires an explicit allowlist: undefined `egress` ⇒ no substitution and no proxy egress, EVEN THOUGH the sandbox provider treats undefined `egress` as unrestricted raw network. Apps wanting functional secrets must declare `egress`.
2. **Egress wire shape** = a JSON envelope (chosen over header-smuggling to avoid the run-token vs target-auth collision and to be fully testable at `proxy.handler`). The in-sandbox `fetch` shim that rewrites app `fetch()` into this envelope is the scaffold integration point — noted in the contract, not built here; the proxy route is the security boundary this PR delivers and tests.
3. **actions/registry.ts `resolveUrl` NOT wired** — layering forbids `actions` importing `apps`, and making `resolveUrl` async/DNS-validating is a behavior change with its own live tests. The SSRF primitive is exposed reusable from `apps`; adopting it in actions is a follow-up once the primitive relocates to core.
4. **Socket-level IP pinning residual** — global `fetch` (undici) re-resolves DNS, so a narrow window remains between the guard's resolve and undici's connect. The guard + per-redirect re-validation catches static private IPs, metadata, and the injected-resolver rebind case; full pinning (custom dispatcher / connect-to-validated-IP) is a follow-up. Default `node:dns` resolver is injectable via `AppsConfig.egressTransport` for edge hosts; DNS-unavailable fails closed.

### Gate

`build` ✓, `typecheck` ✓, apps test suite + new suites ✓ (197 apps tests + 25 new pass), dependency-guard (lint) ✓ (12 packages OK). The repo's `pnpm lint` also errors locally due to a pre-existing `new URL().pathname` percent-encoding bug in `scripts/dependency-guard.mjs` triggered only by this worktree's spaced path ("Cool Code" → `%20`) — absent on CI/canonical paths; verified passing with a decoded ROOT. The `@vendoai-corpus/express-host` e2e timeouts are pre-existing/environmental (reproduced identically on the clean base with my changes stashed; the machine is heavily loaded, single test files taking >100s against a 60s timeout) and touch no egress code.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables safe, functional secret egress in OSS by adding an allowlisted `/egress` proxy with an SSRF guard, so apps can authenticate to external services without exposing secrets. Addresses ENG-259 by wiring server-side substitution and blocking private/internal targets.

- **New Features**
  - Added `POST /egress` on the apps proxy (run-token auth). Accepts `{ url, method?, headers?, body? }`, never forwards the run token.
  - Enforces the app’s `egress` allowlist (exact or `*.` wildcard). No allowlist ⇒ refuse.
  - SSRF guard on resolved IPs (per redirect): blocks loopback, link-local incl. `169.254.169.254`, RFC1918, CGNAT, IPv6 ULA/link-local, multicast, `0.0.0.0`; rebind-resistant.
  - Resolves declared-secret handles via `SecretsProvider.get()` only after allowlist+SSRF pass, forwards, then redacts any reflected secret from the response. Request/response size-capped; manual redirect following with re-validation.
  - Sandbox continues to hold only opaque handles; boot never reads secrets. `@vendoai/apps` now exports `hostAllowed`, `checkEgressUrl`, `isBlockedAddress`, and `nodeIpResolver`. Docs updated (§4.3, new §4.5). Adversarial + live tests added.

- **Migration**
  - Declare `egress` on your app to enable proxy egress and secret substitution; undefined `egress` is refused.
  - Outbound calls should use the proxy envelope `POST {VENDO_PROXY_URL}/egress` (the scaffold shim routes `fetch()` accordingly).
  - For non-Node hosts/tests, you can inject transport via `AppsConfig.egressTransport` (`fetch`, DNS `resolveIp`); defaults are global fetch + `node:dns`.

<sup>Written for commit 015fbdfd966bf8b3925225b11d47b2cb967e9c26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

