### PR TITLE
refactor(mcp): stateless-ready session/replay state seam

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -12,6 +12,44 @@ pnpm --filter @vendoai/ui build:mcp-shim
 
 The server-card response tracks the provisional SEP-2127 draft and may move with that specification before ratification.
 
+## Transport state seam
+
+The door's protocol-lifetime state is isolated behind the package-internal
+`McpDoorState` interface. `createMcpDoor` still composes the 2025-11-25
+Streamable HTTP transport with `InMemoryMcpDoorState`, so initialization,
+`Mcp-Session-Id`, response bytes, and error behavior are unchanged.
+
+The current adapter owns three related lifetimes:
+
+- a TTL-indexed session record keyed by `Mcp-Session-Id`, containing the
+  authenticated subject and opaque SDK runtime;
+- the subject-to-session index used to close every live runtime on revocation;
+- a bounded approval-replay map keyed by an opaque replay scope plus the
+  canonical tool/arguments fingerprint. A pending approval retains its exact
+  `ToolCall.id`; any resolved outcome deletes it. Session deletion, revocation,
+  and idle expiry also delete the scope's replay records.
+
+A 2026-07-28 adapter would leave OAuth and guard behavior alone and replace the
+transport/state composition as follows:
+
+1. Do not mint, accept, or look up `Mcp-Session-Id`, and do not persist an SDK
+   transport runtime across requests. Construct the runtime and `McpRunContext`
+   for the authenticated request only.
+2. Supply a stable opaque replay scope for the logical approval/retry context,
+   derived from authenticated request context and never from caller-controlled
+   protocol input. Use that value for both the `RunContext.sessionId` context
+   key and `McpStateSession.replayScope`.
+3. Back `getReplay`, `setReplay`, and `deleteReplay` with the durable store,
+   preserving absolute expiry, the per-scope capacity bound, and eviction. The
+   stored value includes the authenticated subject and parked `ToolCall.id`, so
+   an identical approved retry reuses it, a resolved retry removes it, and
+   subject revocation purges it even when there is no live transport runtime.
+4. Make the session registry operations request-scoped/no-op for the stateless
+   transport, while preserving subject revocation before any tool execution.
+
+The seam is intentionally internal until that protocol adapter exists; the
+package-root API remains the frozen `createMcpDoor(config)` surface.
+
 ## Operating notes for host integrators
 
 - **`HostOAuthAdapter.authorize` renders consent.** The door passes the client's

--- a/packages/mcp/src/door.test.ts
+++ b/packages/mcp/src/door.test.ts
@@ -14,7 +14,14 @@ import type {
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMcpDoorWithState } from "./door.js";
 import { createMcpDoor, type AppsPort, type McpDoor } from "./index.js";
+import type {
+  McpDoorState,
+  McpStateSession,
+  ReplayStateOptions,
+  SessionStateRecord,
+} from "./state.js";
 
 const BASE = "https://product.example/api/vendo/mcp";
 const REDIRECT = "https://client.example/callback";
@@ -695,6 +702,38 @@ describe("createMcpDoor MCP protocol", () => {
     await connected.client.close();
   });
 
+  it("routes session lifetime and approval replay through a pluggable state seam", async () => {
+    let outcome: ToolOutcome = { status: "pending-approval", approvalId: "apr_pluggable" };
+    const state = new TestMcpDoorState();
+    const harness = makeHarness({ state, getOutcome: () => outcome });
+    const registration = await register(harness.door);
+    const tokens = await issue(harness.door, registration.body.client_id);
+    const connected = await connect(harness.door, tokens.access_token);
+
+    await connected.client.listTools();
+    const sessionId = connected.transport.sessionId!;
+    const args = { query: "through-the-seam" };
+    await connected.client.callTool({ name: "host_lookup", arguments: args });
+    await connected.client.callTool({ name: "host_lookup", arguments: args });
+    expect(harness.executions[1]!.id).toBe(harness.executions[0]!.id);
+    expect(state.operations).toEqual(expect.arrayContaining([
+      `session:set:${sessionId}`,
+      `session:get:${sessionId}`,
+      `session:touch:${sessionId}`,
+      `replay:get:${sessionId}`,
+      `replay:set:${sessionId}`,
+    ]));
+
+    outcome = { status: "ok", output: { answer: 1 } };
+    await connected.client.callTool({ name: "host_lookup", arguments: args });
+    expect(state.operations).toContain(`replay:delete:${sessionId}`);
+
+    await connected.transport.terminateSession();
+    expect(state.operations).toContain(`session:delete:${sessionId}`);
+    expect((await harness.door.handler(mcpRequest(tokens.access_token, sessionId))).status).toBe(404);
+    await connected.client.close();
+  });
+
   it("refuses subject B's bearer presented with subject A's session id (FIX G)", async () => {
     let subject = "user_a";
     const harness = makeHarness({ authorizeSubject: () => subject });
@@ -722,6 +761,7 @@ describe("createMcpDoor MCP protocol", () => {
 
 interface HarnessOptions {
   store?: MemoryStore;
+  state?: McpDoorState;
   getOutcome?: () => ToolOutcome;
   principal?: () => Principal | null;
   apps?: AppsPort;
@@ -758,7 +798,7 @@ function makeHarness(options: HarnessOptions = {}) {
       return options.getOutcome?.() ?? { status: "ok", output: { answer: 42 } };
     },
   };
-  const door = createMcpDoor({
+  const config = {
     tools,
     guard,
     store,
@@ -773,7 +813,10 @@ function makeHarness(options: HarnessOptions = {}) {
         return options.principal ? options.principal() : { kind: "user", subject: "user_1" };
       },
     },
-  });
+  };
+  const door = options.state === undefined
+    ? createMcpDoor(config)
+    : createMcpDoorWithState(config, options.state);
   return { door, store, audits, authorizeContexts, executions };
 }
 
@@ -882,6 +925,109 @@ interface TokenResponse {
   expires_in: number;
   refresh_token: string;
   scope: string;
+}
+
+class TestMcpDoorState implements McpDoorState {
+  readonly operations: string[] = [];
+  readonly #sessions = new Map<string, SessionStateRecord>();
+  readonly #replay = new Map<
+    string,
+    Map<string, { callId: string; subject: string; expiresAt: number }>
+  >();
+
+  async getSession(sessionId: string): Promise<McpStateSession | null> {
+    this.operations.push(`session:get:${sessionId}`);
+    return this.#sessions.get(sessionId)?.session ?? null;
+  }
+
+  async setSession(record: SessionStateRecord): Promise<void> {
+    this.operations.push(`session:set:${record.sessionId}`);
+    this.#sessions.set(record.sessionId, record);
+  }
+
+  async touchSession(sessionId: string, expiresAt: number): Promise<void> {
+    this.operations.push(`session:touch:${sessionId}`);
+    const record = this.#sessions.get(sessionId);
+    if (record) record.expiresAt = expiresAt;
+    for (const replay of this.#replay.get(record?.session.replayScope ?? sessionId)?.values() ?? []) {
+      replay.expiresAt = expiresAt;
+    }
+  }
+
+  async deleteSession(sessionId: string): Promise<McpStateSession | null> {
+    this.operations.push(`session:delete:${sessionId}`);
+    const record = this.#sessions.get(sessionId);
+    this.#sessions.delete(sessionId);
+    if (record) this.#replay.delete(record.session.replayScope);
+    return record?.session ?? null;
+  }
+
+  async deleteSessionsBySubject(subject: string): Promise<McpStateSession[]> {
+    this.operations.push(`session:delete-subject:${subject}`);
+    const sessions: McpStateSession[] = [];
+    for (const [sessionId, record] of this.#sessions) {
+      if (record.subject !== subject) continue;
+      sessions.push(record.session);
+      this.#sessions.delete(sessionId);
+      this.#replay.delete(record.session.replayScope);
+    }
+    for (const [scope, entries] of this.#replay) {
+      for (const [key, replay] of entries) {
+        if (replay.subject === subject) entries.delete(key);
+      }
+      if (entries.size === 0) this.#replay.delete(scope);
+    }
+    return sessions;
+  }
+
+  async sweepExpiredSessions(now: number): Promise<McpStateSession[]> {
+    this.operations.push("session:sweep");
+    const sessions: McpStateSession[] = [];
+    for (const [sessionId, record] of this.#sessions) {
+      if (record.expiresAt > now) continue;
+      sessions.push(record.session);
+      this.#sessions.delete(sessionId);
+      this.#replay.delete(record.session.replayScope);
+    }
+    return sessions;
+  }
+
+  async getReplay(scope: string, key: string, now: number): Promise<string | null> {
+    this.operations.push(`replay:get:${scope}`);
+    const replay = this.#replay.get(scope)?.get(key);
+    if (replay === undefined) return null;
+    if (replay.expiresAt > now) return replay.callId;
+    this.#replay.get(scope)?.delete(key);
+    return null;
+  }
+
+  async setReplay(
+    scope: string,
+    key: string,
+    callId: string,
+    options: ReplayStateOptions,
+  ): Promise<void> {
+    this.operations.push(`replay:set:${scope}`);
+    const entries = this.#replay.get(scope) ?? new Map<
+      string,
+      { callId: string; subject: string; expiresAt: number }
+    >();
+    if (!entries.has(key) && entries.size >= options.capacity) {
+      const oldest = entries.keys().next().value;
+      if (oldest !== undefined) entries.delete(oldest);
+    }
+    entries.set(key, {
+      callId,
+      subject: options.subject,
+      expiresAt: options.expiresAt,
+    });
+    this.#replay.set(scope, entries);
+  }
+
+  async deleteReplay(scope: string, key: string): Promise<void> {
+    this.operations.push(`replay:delete:${scope}`);
+    this.#replay.get(scope)?.delete(key);
+  }
 }
 
 class MemoryStore implements StoreAdapter {

--- a/packages/mcp/src/door.ts
+++ b/packages/mcp/src/door.ts
@@ -22,6 +22,14 @@ import type { HostOAuthAdapter } from "./oauth/adapter.js";
 import type { AppsPort } from "./apps-port.js";
 import { canonicalUri, OAuthServer, sameCanonicalUri } from "./oauth/server.js";
 import { SHIM_HTML } from "./shim/shim-html.gen.js";
+import {
+  InMemoryMcpDoorState,
+  type McpDoorState,
+  type McpRunContext,
+  type McpStateSession,
+} from "./state.js";
+
+export type { McpRunContext } from "./state.js";
 
 const PRM_PREFIX = "/.well-known/oauth-protected-resource";
 const AS_PREFIX = "/.well-known/oauth-authorization-server";
@@ -36,27 +44,14 @@ interface HostIdentity {
   description: string;
 }
 
-interface SessionState {
-  subject: string;
-  context: McpRunContext;
+interface SessionState extends McpStateSession {
   server: Server;
   transport: WebStandardStreamableHTTPServerTransport;
   sessionId?: string;
-  touchedAt: number;
-  /** 10-mcp §2 / 01-core (ids unique per call) — a bounded per-session map from
-   * a call's (tool + canonical-args) fingerprint to the ToolCall id last minted
-   * for it while its outcome was pending-approval. Guard's single-use approval
-   * replay pins the exact call.id it parked (guard.ts #consumeApprovedCall), so
-   * a fresh id per retry could never satisfy a one-off approval (approve without
-   * `remember`) — the retry would silently re-park. Reusing the parked id lets
-   * the in-product approval authorize the retry; any non-pending outcome clears
-   * the entry, so a DISTINCT call still gets a unique id and a later identical
-   * call parks anew once the one-off approval is spent. */
-  replay: Map<string, string>;
 }
 
-/** Caps SessionState.replay so a client hammering distinct parking calls in one
- * session cannot grow it without bound; the whole map dies with the session. */
+/** Caps replay state so a client hammering distinct parking calls in one
+ * context cannot grow it without bound; the whole scope dies with its session. */
 const REPLAY_CAP = 256;
 
 /** A session outlives its access token only for as long as the client keeps
@@ -92,15 +87,20 @@ export interface McpDoor {
 }
 
 export function createMcpDoor(config: McpDoorConfig): McpDoor {
-  const door = new Door(config);
+  return createMcpDoorWithState(config, new InMemoryMcpDoorState());
+}
+
+/** Package-internal composition hook for transport/state adapters and tests.
+ * It is deliberately not re-exported from the package root. */
+export function createMcpDoorWithState(config: McpDoorConfig, state: McpDoorState): McpDoor {
+  const door = new Door(config, state);
   return { handler: (req) => door.handler(req) };
 }
 
 class Door {
   readonly #config: McpDoorConfig;
   readonly #oauth: OAuthServer;
-  readonly #sessions = new Map<string, SessionState>();
-  readonly #subjectSessions = new Map<string, Set<string>>();
+  readonly #state: McpDoorState;
   /** Last mount an MCP request actually arrived at — a server-card hint only.
    * Authority never derives from remembered paths: every flow re-derives its
    * mount from its own request URL, and tokens bind to the canonical resource
@@ -109,8 +109,9 @@ class Door {
   #cardMount: string | undefined;
   #identity: Promise<HostIdentity> | undefined;
 
-  constructor(config: McpDoorConfig) {
+  constructor(config: McpDoorConfig, state: McpDoorState) {
     this.#config = config;
+    this.#state = state;
     this.#oauth = new OAuthServer(config);
   }
 
@@ -172,7 +173,9 @@ class Door {
     }
 
     const requestedSessionId = req.headers.get("mcp-session-id") ?? undefined;
-    const requestedState = requestedSessionId === undefined ? undefined : this.#sessions.get(requestedSessionId);
+    const requestedState = requestedSessionId === undefined
+      ? undefined
+      : await this.#state.getSession(requestedSessionId) ?? undefined;
     if (requestedSessionId !== undefined && (!requestedState || requestedState.subject !== auth.grant.subject)) {
       return unknownSession();
     }
@@ -202,13 +205,13 @@ class Door {
 
     if (requestedSessionId !== undefined) {
       requestedState!.context = mcpContext(principal, requestedSessionId, consent);
-      requestedState!.touchedAt = Date.now();
-      return requestedState!.transport.handleRequest(req);
+      await this.#state.touchSession(requestedSessionId, Date.now() + SESSION_IDLE_MS);
+      return requestedState!.handleRequest(req);
     }
 
     const state = await this.#newSession(auth.grant.subject, principal, consent);
-    const response = await state.transport.handleRequest(req);
-    if (state.sessionId === undefined) await state.transport.close();
+    const response = await state.handleRequest(req);
+    if (state.sessionId === undefined) await state.close();
     return response;
   }
 
@@ -222,15 +225,20 @@ class Door {
     const transport = new WebStandardStreamableHTTPServerTransport({
       sessionIdGenerator: () => `mcps_${randomHex(16)}`,
       enableJsonResponse: true,
-      onsessioninitialized: (sessionId) => {
+      onsessioninitialized: async (sessionId) => {
         state.sessionId = sessionId;
+        state.replayScope = sessionId;
         state.context = mcpContext(state.context.principal, sessionId, consent);
-        this.#sessions.set(sessionId, state);
-        const sessions = this.#subjectSessions.get(subject) ?? new Set<string>();
-        sessions.add(sessionId);
-        this.#subjectSessions.set(subject, sessions);
+        await this.#state.setSession({
+          sessionId,
+          subject,
+          session: state,
+          expiresAt: Date.now() + SESSION_IDLE_MS,
+        });
       },
-      onsessionclosed: (sessionId) => this.#forgetSession(subject, sessionId),
+      onsessionclosed: async (sessionId) => {
+        await this.#state.deleteSession(sessionId);
+      },
     });
     const capabilities = this.#config.apps === undefined
       ? { tools: {} }
@@ -243,13 +251,15 @@ class Door {
       { name: identity.name, version: identity.version },
       { capabilities },
     );
+    const initialContextKey = `mcpr_${randomHex(16)}`;
     state = {
       subject,
-      context: mcpContext(principal, `mcpr_${randomHex(16)}`, consent),
+      replayScope: initialContextKey,
+      context: mcpContext(principal, initialContextKey, consent),
       server,
       transport,
-      touchedAt: Date.now(),
-      replay: new Map<string, string>(),
+      handleRequest: (req) => transport.handleRequest(req),
+      close: () => transport.close(),
     };
     this.#registerHandlers(state, identity);
     await server.connect(transport);
@@ -320,9 +330,9 @@ class Door {
       }
       return inBandError(`not-found: Tool ${name} was not found`);
     }
-    const id = replayId(state, name, args);
+    const id = await this.#replayId(state, name, args);
     const outcome = await this.#config.tools.execute({ id, tool: name, args }, state.context);
-    recordReplay(state, name, args, id, outcome.status);
+    await this.#recordReplay(state, name, args, id, outcome.status);
     // FIX E: a bound registry that owns an app-viewer name (vendo_apps_open via
     // apps.agentTools()) returns an OpenSurface envelope ({kind,payload}); the
     // MCP Apps shim renders a bare format-tagged UIPayload (core §8), so unwrap
@@ -354,7 +364,7 @@ class Door {
     if (this.#config.apps === undefined || descriptor === undefined) {
       return inBandError(`not-found: Tool ${name} was not found`);
     }
-    const id = replayId(state, name, args);
+    const id = await this.#replayId(state, name, args);
     const call = { id, tool: name, args: args as Json };
     const decision = await this.#config.guard.check(call, descriptor, ctx);
     const outcome: ToolOutcome = decision.action === "block"
@@ -362,7 +372,7 @@ class Door {
       : decision.action === "ask"
         ? { status: "pending-approval", approvalId: decision.approval.id }
         : await this.#executeAppsTool(name, args, ctx);
-    recordReplay(state, name, args, id, outcome.status);
+    await this.#recordReplay(state, name, args, id, outcome.status);
     await this.#config.guard.report({
       id: `aud_${randomHex(12)}`,
       at: new Date().toISOString(),
@@ -403,13 +413,48 @@ class Door {
     }
   }
 
+  /** 01-core: ToolCall ids are unique per call. The door mints a fresh id per
+   * tools/call, except for an identical still-parked call in the same context.
+   * Guard's one-off approval is pinned to that exact id, so retry must reuse it. */
+  async #replayId(
+    state: McpStateSession,
+    tool: string,
+    args: Record<string, unknown>,
+  ): Promise<string> {
+    const existing = await this.#state.getReplay(
+      state.replayScope,
+      replayKey(tool, args),
+      Date.now(),
+    );
+    return existing ?? `mctc_${crypto.randomUUID()}`;
+  }
+
+  async #recordReplay(
+    state: McpStateSession,
+    tool: string,
+    args: Record<string, unknown>,
+    id: string,
+    status: ToolOutcome["status"],
+  ): Promise<void> {
+    const scope = state.replayScope;
+    const key = replayKey(tool, args);
+    if (status === "pending-approval") {
+      await this.#state.setReplay(scope, key, id, {
+        subject: state.subject,
+        expiresAt: Date.now() + SESSION_IDLE_MS,
+        capacity: REPLAY_CAP,
+      });
+    } else {
+      // Any resolved outcome spends the one-off approval. A later identical
+      // call must mint a fresh id and park anew.
+      await this.#state.deleteReplay(scope, key);
+    }
+  }
+
   async #sweepIdleSessions(): Promise<void> {
-    const cutoff = Date.now() - SESSION_IDLE_MS;
-    for (const [id, state] of [...this.#sessions]) {
-      if (state.touchedAt > cutoff) continue;
-      this.#forgetSession(state.subject, id);
+    for (const session of await this.#state.sweepExpiredSessions(Date.now())) {
       try {
-        await state.transport.close();
+        await session.close();
       } catch {
         // A transport already closing is exactly the state we want it in.
       }
@@ -417,25 +462,13 @@ class Door {
   }
 
   async #killSubject(subject: string): Promise<void> {
-    const ids = [...(this.#subjectSessions.get(subject) ?? [])];
-    for (const id of ids) {
-      const state = this.#sessions.get(id);
-      this.#forgetSession(subject, id);
-      if (state) {
-        try {
-          await state.transport.close();
-        } catch {
-          // Revocation must remain fail-closed even if a transport is already closing.
-        }
+    for (const session of await this.#state.deleteSessionsBySubject(subject)) {
+      try {
+        await session.close();
+      } catch {
+        // Revocation must remain fail-closed even if a transport is already closing.
       }
     }
-  }
-
-  #forgetSession(subject: string, sessionId: string): void {
-    this.#sessions.delete(sessionId);
-    const sessions = this.#subjectSessions.get(subject);
-    sessions?.delete(sessionId);
-    if (sessions?.size === 0) this.#subjectSessions.delete(subject);
   }
 
   #hostIdentity(): Promise<HostIdentity> {
@@ -584,37 +617,6 @@ function unwrapAppsOpen(output: unknown): unknown {
   return output;
 }
 
-/** 01-core: ToolCall ids are unique per call. The door mints a fresh id per
- * tools/call, EXCEPT when replaying an identical still-parked call in the same
- * session — then it reuses the parked id so guard's single-use approval replay
- * (guard.ts #consumeApprovedCall pins call.id) can authorize the retry. */
-function replayId(state: SessionState, tool: string, args: Record<string, unknown>): string {
-  return state.replay.get(replayKey(tool, args)) ?? `mctc_${crypto.randomUUID()}`;
-}
-
-function recordReplay(
-  state: SessionState,
-  tool: string,
-  args: Record<string, unknown>,
-  id: string,
-  status: ToolOutcome["status"],
-): void {
-  const key = replayKey(tool, args);
-  if (status === "pending-approval") {
-    // Cap the map: evict the oldest fingerprint (insertion order) before adding
-    // a new one, so distinct parking calls can't grow it without bound.
-    if (!state.replay.has(key) && state.replay.size >= REPLAY_CAP) {
-      const oldest = state.replay.keys().next().value;
-      if (oldest !== undefined) state.replay.delete(oldest);
-    }
-    state.replay.set(key, id);
-  } else {
-    // Any resolved outcome (ok / error / blocked) spends the one-off approval; a
-    // later identical call must mint a fresh id and park anew.
-    state.replay.delete(key);
-  }
-}
-
 function replayKey(tool: string, args: Record<string, unknown>): string {
   return `${tool} ${canonicalJson(args)}`;
 }
@@ -666,20 +668,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function stringify(value: unknown): string {
   return JSON.stringify(value) ?? "null";
 }
-
-/** The RunContext the door mints for every MCP tool call. It carries the
- * door's OAuth-consent evidence structurally: `mcpConsent` is the projection of
- * the authenticated AccessGrant (10-mcp §3) — the OAuth'd user's `clientId` and
- * the scopes they consented the client to. actions reads it off the ctx to
- * authenticate host execution through the ActAs seam (04 §4) WITHOUT the door
- * ever forwarding the inbound MCP bearer. actions CANNOT import this type
- * (actions depends on core only, enforced by scripts/dependency-guard.mjs), so
- * — exactly as guard attaches `ctx.grant` for ActionsRunContext — this is a
- * STRUCTURAL contract: ActionsRunContext's optional `mcpConsent?` twin must
- * match this shape. */
-export type McpRunContext = RunContext & {
-  mcpConsent: { clientId: string; scopes: string[] };
-};
 
 function mcpContext(
   principal: Principal,

--- a/packages/mcp/src/state.test.ts
+++ b/packages/mcp/src/state.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  InMemoryMcpDoorState,
+  type McpStateSession,
+} from "./state.js";
+
+describe("InMemoryMcpDoorState", () => {
+  it("shares idle expiry between a session and its approval replay scope", () => {
+    const state = new InMemoryMcpDoorState();
+    const session = testSession("mcps_1", "replay_1", "user_1");
+    state.setSession({
+      sessionId: "mcps_1",
+      subject: "user_1",
+      session,
+      expiresAt: 10,
+    });
+    state.setReplay("replay_1", "fingerprint", "mctc_1", {
+      subject: "user_1",
+      expiresAt: 10,
+      capacity: 256,
+    });
+
+    state.touchSession("mcps_1", 20);
+    expect(state.sweepExpiredSessions(15)).toEqual([]);
+    expect(state.getReplay("replay_1", "fingerprint", 15)).toBe("mctc_1");
+
+    expect(state.sweepExpiredSessions(20)).toEqual([session]);
+    expect(state.getReplay("replay_1", "fingerprint", 20)).toBeNull();
+  });
+
+  it("purges stateless replay records by authenticated subject", () => {
+    const state = new InMemoryMcpDoorState();
+    state.setReplay("durable_1", "fingerprint", "mctc_1", {
+      subject: "user_1",
+      expiresAt: 20,
+      capacity: 256,
+    });
+
+    expect(state.deleteSessionsBySubject("user_1")).toEqual([]);
+    expect(state.getReplay("durable_1", "fingerprint", 10)).toBeNull();
+  });
+
+  it("expires replay records and enforces the per-scope capacity", () => {
+    const state = new InMemoryMcpDoorState();
+    const options = { subject: "user_1", expiresAt: 20, capacity: 2 };
+    state.setReplay("scope", "first", "mctc_1", options);
+    state.setReplay("scope", "second", "mctc_2", options);
+    state.setReplay("scope", "third", "mctc_3", options);
+
+    expect(state.getReplay("scope", "first", 10)).toBeNull();
+    expect(state.getReplay("scope", "second", 10)).toBe("mctc_2");
+    expect(state.getReplay("scope", "third", 20)).toBeNull();
+  });
+});
+
+function testSession(
+  sessionId: string,
+  replayScope: string,
+  subject: string,
+): McpStateSession {
+  return {
+    subject,
+    replayScope,
+    context: {
+      principal: { kind: "user", subject },
+      venue: "mcp",
+      presence: "present",
+      sessionId,
+      mcpConsent: { clientId: "mcpc_1", scopes: ["read", "write"] },
+    },
+    async handleRequest() {
+      return new Response();
+    },
+    async close() {},
+  };
+}

--- a/packages/mcp/src/state.ts
+++ b/packages/mcp/src/state.ts
@@ -1,0 +1,179 @@
+import type { RunContext } from "@vendoai/core";
+
+/** The RunContext the door mints for every MCP tool call. The OAuth consent is
+ * structural because actions cannot import this package (dependency guard). */
+export type McpRunContext = RunContext & {
+  mcpConsent: { clientId: string; scopes: string[] };
+};
+
+/** An opaque transport/runtime handle associated with the current protocol's
+ * session key. A stateless transport can supply this from request scope. */
+export interface McpStateSession {
+  readonly subject: string;
+  /** Opaque approval-replay namespace. The 2025-11-25 adapter uses its MCP
+   * session id; a stateless adapter supplies an authenticated durable scope. */
+  replayScope: string;
+  context: McpRunContext;
+  handleRequest(req: Request): Promise<Response>;
+  close(): Promise<void>;
+}
+
+export interface SessionStateRecord {
+  sessionId: string;
+  subject: string;
+  session: McpStateSession;
+  expiresAt: number;
+}
+
+export interface ReplayStateOptions {
+  /** Authenticated owner used for fail-closed revocation cleanup. */
+  subject: string;
+  /** Absolute wall-clock expiry, shared with the owning context/session. */
+  expiresAt: number;
+  /** Maximum fingerprints retained for one context key. */
+  capacity: number;
+}
+
+type MaybePromise<T> = T | Promise<T>;
+
+/**
+ * Internal state seam for the MCP transport lifetime.
+ *
+ * Keys and absolute expiries make the contract implementable over a durable
+ * store; MaybePromise keeps the default in-memory callbacks synchronous while
+ * allowing a store-backed adapter to perform I/O. Session values are opaque:
+ * the 2025-11-25 adapter supplies its SDK runtime, while a future stateless
+ * adapter can supply a request-scoped runtime and durably store only replay
+ * records and serializable context metadata.
+ */
+export interface McpDoorState {
+  /** Session methods serve the 2025-11-25 transport runtime. Implementations
+   * must remove replay records for the same key whenever a session is removed. */
+  getSession(sessionId: string): MaybePromise<McpStateSession | null>;
+  setSession(record: SessionStateRecord): MaybePromise<void>;
+  /** Extends both the session and every replay entry scoped to its key. */
+  touchSession(sessionId: string, expiresAt: number): MaybePromise<void>;
+  deleteSession(sessionId: string): MaybePromise<McpStateSession | null>;
+  /** Removes every session and replay record owned by the subject. */
+  deleteSessionsBySubject(subject: string): MaybePromise<McpStateSession[]>;
+  /** Atomically removes and returns every session whose expiry is <= now. */
+  sweepExpiredSessions(now: number): MaybePromise<McpStateSession[]>;
+
+  /** Replay methods are transport-neutral: callers supply the opaque context
+   * scope, canonical call fingerprint, and absolute expiry. */
+  getReplay(scope: string, key: string, now: number): MaybePromise<string | null>;
+  setReplay(
+    scope: string,
+    key: string,
+    callId: string,
+    options: ReplayStateOptions,
+  ): MaybePromise<void>;
+  deleteReplay(scope: string, key: string): MaybePromise<void>;
+}
+
+interface ReplayRecord {
+  callId: string;
+  subject: string;
+  expiresAt: number;
+}
+
+/** Today's byte-compatible process-memory implementation. */
+export class InMemoryMcpDoorState implements McpDoorState {
+  readonly #sessions = new Map<string, SessionStateRecord>();
+  readonly #subjectSessions = new Map<string, Set<string>>();
+  readonly #replay = new Map<string, Map<string, ReplayRecord>>();
+
+  getSession(sessionId: string): McpStateSession | null {
+    return this.#sessions.get(sessionId)?.session ?? null;
+  }
+
+  setSession(record: SessionStateRecord): void {
+    const previous = this.#sessions.get(record.sessionId);
+    if (previous?.subject !== undefined && previous.subject !== record.subject) {
+      this.#removeSubjectSession(previous.subject, record.sessionId);
+    }
+    this.#sessions.set(record.sessionId, record);
+    const sessions = this.#subjectSessions.get(record.subject) ?? new Set<string>();
+    sessions.add(record.sessionId);
+    this.#subjectSessions.set(record.subject, sessions);
+  }
+
+  touchSession(sessionId: string, expiresAt: number): void {
+    const record = this.#sessions.get(sessionId);
+    if (record === undefined) return;
+    record.expiresAt = expiresAt;
+    for (const replay of this.#replay.get(record.session.replayScope)?.values() ?? []) {
+      replay.expiresAt = expiresAt;
+    }
+  }
+
+  deleteSession(sessionId: string): McpStateSession | null {
+    const record = this.#sessions.get(sessionId);
+    if (record === undefined) return null;
+    this.#sessions.delete(sessionId);
+    this.#replay.delete(record.session.replayScope);
+    this.#removeSubjectSession(record.subject, sessionId);
+    return record.session;
+  }
+
+  deleteSessionsBySubject(subject: string): McpStateSession[] {
+    const sessions: McpStateSession[] = [];
+    for (const sessionId of [...(this.#subjectSessions.get(subject) ?? [])]) {
+      const session = this.deleteSession(sessionId);
+      if (session !== null) sessions.push(session);
+    }
+    for (const [scope, entries] of this.#replay) {
+      for (const [key, replay] of entries) {
+        if (replay.subject === subject) entries.delete(key);
+      }
+      if (entries.size === 0) this.#replay.delete(scope);
+    }
+    return sessions;
+  }
+
+  sweepExpiredSessions(now: number): McpStateSession[] {
+    const expired: McpStateSession[] = [];
+    for (const [sessionId, record] of [...this.#sessions]) {
+      if (record.expiresAt > now) continue;
+      const session = this.deleteSession(sessionId);
+      if (session !== null) expired.push(session);
+    }
+    return expired;
+  }
+
+  getReplay(scope: string, key: string, now: number): string | null {
+    const entries = this.#replay.get(scope);
+    const record = entries?.get(key);
+    if (record === undefined) return null;
+    if (record.expiresAt > now) return record.callId;
+    entries!.delete(key);
+    if (entries!.size === 0) this.#replay.delete(scope);
+    return null;
+  }
+
+  setReplay(scope: string, key: string, callId: string, options: ReplayStateOptions): void {
+    const entries = this.#replay.get(scope) ?? new Map<string, ReplayRecord>();
+    if (!entries.has(key) && entries.size >= options.capacity) {
+      const oldest = entries.keys().next().value;
+      if (oldest !== undefined) entries.delete(oldest);
+    }
+    entries.set(key, {
+      callId,
+      subject: options.subject,
+      expiresAt: options.expiresAt,
+    });
+    this.#replay.set(scope, entries);
+  }
+
+  deleteReplay(scope: string, key: string): void {
+    const entries = this.#replay.get(scope);
+    entries?.delete(key);
+    if (entries?.size === 0) this.#replay.delete(scope);
+  }
+
+  #removeSubjectSession(subject: string, sessionId: string): void {
+    const sessions = this.#subjectSessions.get(subject);
+    sessions?.delete(sessionId);
+    if (sessions?.size === 0) this.#subjectSessions.delete(subject);
+  }
+}


### PR DESCRIPTION
Fixes ENG-271

## Summary

- Extract the 2025-11-25 session registry, subject revocation index, idle TTL, and approval-replay cache behind the package-internal `McpDoorState` seam.
- Keep `createMcpDoor(config)`, initialize, `Mcp-Session-Id`, response bytes, and approval replay behavior unchanged through the default `InMemoryMcpDoorState` adapter.
- Decouple approval replay from the protocol header with an opaque, TTL-aware replay scope that retains the exact parked `ToolCall.id`, enforces the existing capacity bound, and purges by authenticated subject.
- Document exactly how a 2026-07-28 adapter would use request-scoped runtime/context plus durable replay records without a cross-request SDK transport.

## Validation

- `pnpm build`
- `pnpm --filter @vendoai/mcp test` (25 tests)
- `pnpm typecheck`
- `pnpm lint`
- The PR CI runs the complete `pnpm build && pnpm test && pnpm typecheck && pnpm lint` gate on an isolated runner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare the MCP door for a stateless transport by extracting session and approval-replay state behind an internal seam, keeping all current protocol behavior unchanged. This aligns with ENG-271 by making the 2026-07-28 stateless model “an adapter away” without changing today’s `initialize` or `Mcp-Session-Id` flow.

- **Refactors**
  - Introduced internal `McpDoorState` to own session registry, subject revocation index, idle TTL, and approval-replay storage; default adapter is `InMemoryMcpDoorState`.
  - Preserved current API/behavior: `createMcpDoor(config)` still uses the Streamable HTTP transport; initialize, `Mcp-Session-Id`, and response semantics are unchanged.
  - Decoupled approval replay from protocol headers using an opaque, TTL-aware replay scope that retains the exact `ToolCall.id`, enforces per-scope capacity, and purges on subject revocation, session deletion, or idle expiry.
  - Added `createMcpDoorWithState` for adapter injection and documented how a 2026‑07‑28 adapter would supply request-scoped runtime plus durable replay records.
  - Added `state.ts` and `state.test.ts`, expanded `door.test.ts`, and updated `README` with seam details.

<sup>Written for commit 9e91b2fe583e48b5dafc71e9654a19a79d731961. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

