### PR TITLE
feat(store,mcp): atomic token claim for multi-instance redemption

### DIFF
--- a/.changeset/atomic-token-claims.md
+++ b/.changeset/atomic-token-claims.md
@@ -1,0 +1,7 @@
+---
+"@vendoai/core": minor
+"@vendoai/store": minor
+"@vendoai/mcp": minor
+---
+
+Add database-level atomic claims for multi-instance OAuth code redemption and refresh-token rotation.

--- a/docs/contracts/01-core.md
+++ b/docs/contracts/01-core.md
@@ -345,6 +345,10 @@ export interface RecordQuery { refs?: Record<string, string>; ids?: string[]; li
 export interface RecordStore {
   get(id: string): Promise<VendoRecord | null>;
   put(record: Pick<VendoRecord, "id" | "data" | "refs">): Promise<VendoRecord>;
+  // Optional additive capability: one compare-and-claim statement. Exact data
+  // + refs match; replacement omitted means delete. Exactly one caller gets true.
+  claim?(expected: Pick<VendoRecord, "id" | "data" | "refs">,
+         replacement?: Pick<VendoRecord, "data" | "refs">): Promise<boolean>;
   delete(id: string): Promise<void>;
   list(q?: RecordQuery): Promise<{ records: VendoRecord[]; cursor?: string }>;
 }
@@ -453,4 +457,10 @@ export interface VendoApprovalPart { type: "data-vendo-approval"; toolCallId: st
 - **Changed:** Documented the shipped `@vendoai/core/conformance` test-infrastructure subpath and the stable root utilities already consumed by sibling blocks, including the exact-grant input hash algorithm.
 - **Changed:** Recorded that `Tree.data` and `TreeNode.props` size limits are delegated to host request-body enforcement.
 - **Why:** Post-freeze MCP work and sibling usage had expanded the real surface without updating this contract, and the host-side tree size responsibility was only pinned in a test.
+- **Approved by:** Yousef, 2026-07-14.
+
+### 2026-07-14 — Atomic record claims
+
+- **Changed:** Added optional `RecordStore.claim(expected, replacement?)` as the core seam for one-statement compare-and-replace or compare-and-delete adapters.
+- **Why:** Store consumers that require single-use state need an additive capability they can require without importing the concrete store block.
 - **Approved by:** Yousef, 2026-07-14.

--- a/docs/contracts/02-store.md
+++ b/docs/contracts/02-store.md
@@ -80,6 +80,7 @@ For non-reserved names, `records()` remains app data and collection names are ot
 
 - **PGlite default**: no `url` → embedded Postgres at `.vendo/data`; kill-the-server durability applies (fsync on write).
 - **Same schema everywhere**: one DDL, no dialect switches. `ensureSchema()` is the only migration entry point, keyed by `vendo_meta.schema_version`, forward-only within the version train.
+- **Atomic claims**: generic and door-owned record tables implement core's optional `RecordStore.claim` as one `UPDATE ... WHERE data/refs match RETURNING` or `DELETE ... RETURNING` statement. Consumers that require single-use state fail closed when an alternate adapter omits the capability.
 - **Encryption at rest**: `encryption.key` encrypts `vendo_secrets.ciphertext` only (AES-256-GCM). App data stays plaintext by design — encrypting it would defeat the page's host-can-query/join promise; at-rest encryption of the database is the host's disk/DB layer. Default-on composition is contracted here and ships in Wave 3: `vendo init` provisions `VENDO_STORE_ENCRYPTION_KEY` in `.env`, `createVendo` reads it from the environment, and AES-GCM binds ciphertext to the secret name as AAD with envelope versioning. Key rotation: out of v0 scope.
 - **No tenant axis**: `subject` is the one partition key — the host's stable user id. Multi-tenant hosts scope the same way they scope their own tables: by joining through `subject` and refs.
 - **Ephemeral principals** (`ephemeral: true`) never touch disk: their rows live in an adapter-level, per-process in-memory overlay that is dropped by `close()`. Multi-instance deployments therefore split anonymous-session state between processes. A real session lifecycle is Wave 4 scope and will amend this section again when designed.
@@ -99,4 +100,10 @@ A store-level erase API is contracted here and ships in Wave 3. It erases by sub
 - **Changed:** Contracted default-on encryption composition, secret-name AAD, and envelope versioning for Wave 3.
 - **Changed:** Corrected ephemeral-overlay lifetime to `close()` and recorded the per-process multi-instance constraint; full session lifecycle design remains Wave 4 work.
 - **Why:** The shipped routing and secret surfaces had overtaken the frozen typed-helper text, while retention, audit deletion, encryption defaults, and anonymous-session lifetime needed the approved foundations contracts before later implementation waves.
+- **Approved by:** Yousef, 2026-07-14.
+
+### 2026-07-14 — Atomic record claims
+
+- **Changed:** Added the optional `RecordStore.claim` capability and required the concrete Postgres store to implement compare-and-replace or compare-and-delete in one statement for generic and door-owned record tables.
+- **Why:** Authorization codes and refresh-token rotation need database-level single-use guarantees across non-sticky multi-instance MCP deployments.
 - **Approved by:** Yousef, 2026-07-14.

--- a/docs/contracts/10-mcp.md
+++ b/docs/contracts/10-mcp.md
@@ -70,7 +70,7 @@ Normative:
 - **Audience binding (RFC 8707)**: the `resource` parameter is accepted and enforced on both authorization and token requests; access tokens are bound to `(subject, clientId, scopes, resource)` and rejected when the resource is not the door's canonical URI — token-passthrough is structurally impossible.
 - **Challenge**: every `401` carries `WWW-Authenticate` naming the protected-resource metadata URL (RFC 9728 §5.1) — this is the discovery entry point compliant clients start from.
 - **Clients**: HTTPS-URL client ids (Client ID Metadata Documents) are accepted and advertised; RFC 7591 dynamic registration stays as the fallback (registered clients live in door state).
-- **Tokens**: opaque (never host-verifiable JWTs), checked on every request, refresh rotates, PKCE required, redirect URIs exact-match. Lifetimes: access 1h, refresh 30d (per-request `principal()` resolution is the real kill switch).
+- **Tokens**: opaque (never host-verifiable JWTs), checked on every request, refresh rotates, PKCE required, redirect URIs exact-match. Authorization-code consumption and refresh rotation use the store's database-level atomic claim; an adapter without that additive capability fails closed at the token endpoint. Lifetimes: access 1h, refresh 30d (per-request `principal()` resolution is the real kill switch).
 - **Audit**: token issuance and revocation are `AuditEvent`s (`kind: "door-auth"`, additive variant per 01 §15) — the SIEM export (05 §1) sees the door's auth lifecycle, same as everything else.
 - Door state lands in `vendo_mcp_clients` / `vendo_mcp_grants` (additive to the 02 §2 table map; typed helpers are block-internal, same status as guard's).
 

--- a/fixtures/mcp-e2e/package.json
+++ b/fixtures/mcp-e2e/package.json
@@ -23,6 +23,8 @@
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/node": "^22.0.0",
+    "@types/pg": "^8.11.10",
+    "pg": "^8.22.0",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"
   }

--- a/fixtures/mcp-e2e/src/token-claim-race.e2e.test.ts
+++ b/fixtures/mcp-e2e/src/token-claim-race.e2e.test.ts
@@ -1,0 +1,247 @@
+import { randomUUID } from "node:crypto";
+import type { AuditEvent, Guard, Principal, StoreAdapter, ToolRegistry } from "@vendoai/core";
+import { createMcpDoor, type HostOAuthAdapter, type McpDoor } from "@vendoai/mcp";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const BASE = "https://product.example/api/vendo/mcp";
+const REDIRECT = "https://client.example/callback";
+const VERIFIER = "a-very-long-pkce-verifier-that-is-valid-for-the-race-test-1234567890";
+const RACE_ITERATIONS = 25;
+const POSTGRES_URL = process.env.POSTGRES_URL;
+
+const describePostgres = POSTGRES_URL ? describe : describe.skip;
+
+describePostgres("multi-instance OAuth token claims (Postgres)", () => {
+  let admin: Client;
+  let schema: string;
+  let firstStore: VendoStore;
+  let secondStore: VendoStore;
+  let firstDoor: McpDoor;
+  let secondDoor: McpDoor;
+  let claimBarrier: ClaimBarrier;
+  const audits: AuditEvent[] = [];
+
+  beforeAll(async () => {
+    if (!POSTGRES_URL) return;
+    admin = new Client({ connectionString: POSTGRES_URL });
+    await admin.connect();
+    schema = `vendo_eng270_${randomUUID().replaceAll("-", "")}`;
+    await admin.query(`CREATE SCHEMA ${schema}`);
+
+    const isolatedUrl = new URL(POSTGRES_URL);
+    const priorOptions = isolatedUrl.searchParams.get("options");
+    isolatedUrl.searchParams.set(
+      "options",
+      [priorOptions, `-c search_path=${schema}`].filter(Boolean).join(" "),
+    );
+
+    firstStore = createStore({ url: isolatedUrl.toString() });
+    secondStore = createStore({ url: isolatedUrl.toString() });
+    await firstStore.ensureSchema();
+    await secondStore.ensureSchema();
+
+    claimBarrier = new ClaimBarrier();
+    firstDoor = makeDoor(gateTokenClaims(firstStore, claimBarrier), audits);
+    secondDoor = makeDoor(gateTokenClaims(secondStore, claimBarrier), audits);
+  }, 60_000);
+
+  afterAll(async () => {
+    await secondStore?.close();
+    await firstStore?.close();
+    if (admin && schema) await admin.query(`DROP SCHEMA ${schema} CASCADE`);
+    await admin?.end();
+  });
+
+  it(`lets exactly one of two server instances redeem an authorization code across ${RACE_ITERATIONS} races`, async () => {
+    const clientId = await register(firstDoor);
+
+    for (let iteration = 0; iteration < RACE_ITERATIONS; iteration += 1) {
+      const code = await authorize(firstDoor, clientId);
+      claimBarrier.arm();
+      const responses = await Promise.all([
+        exchange(firstDoor, code, clientId),
+        exchange(secondDoor, code, clientId),
+      ]);
+
+      expect(responses.map((response) => response.status).sort()).toEqual([200, 400]);
+      const loser = responses.find((response) => response.status === 400)!;
+      expect(await loser.json()).toMatchObject({
+        error: "invalid_grant",
+        error_description: "Authorization code is invalid or expired",
+      });
+    }
+  });
+
+  it(`lets exactly one refresh rotation win and revokes its successor across ${RACE_ITERATIONS} races`, async () => {
+    const clientId = await register(firstDoor);
+
+    for (let iteration = 0; iteration < RACE_ITERATIONS; iteration += 1) {
+      const code = await authorize(firstDoor, clientId);
+      const issued = await exchange(firstDoor, code, clientId);
+      expect(issued.status).toBe(200);
+      const first = await issued.json() as TokenResponse;
+
+      claimBarrier.arm();
+      const responses = await Promise.all([
+        refresh(firstDoor, first.refresh_token, clientId),
+        refresh(secondDoor, first.refresh_token, clientId),
+      ]);
+
+      expect(responses.map((response) => response.status).sort()).toEqual([200, 400]);
+      const winner = responses.find((response) => response.status === 200)!;
+      const loser = responses.find((response) => response.status === 400)!;
+      const rotated = await winner.json() as TokenResponse;
+      expect(await loser.json()).toMatchObject({
+        error: "invalid_grant",
+        error_description: "Refresh token reuse detected",
+      });
+
+      // The losing reuse attempt revokes the whole subject/client chain,
+      // including the winner's freshly rotated access and refresh tokens.
+      const bearer = await firstDoor.handler(new Request(BASE, {
+        method: "POST",
+        headers: { authorization: `Bearer ${rotated.access_token}` },
+      }));
+      expect(bearer.status).toBe(401);
+      const successor = await refresh(secondDoor, rotated.refresh_token, clientId);
+      expect(successor.status).toBe(400);
+      expect(await successor.json()).toMatchObject({ error: "invalid_grant" });
+    }
+
+    expect(audits.filter(
+      (event) => (event.detail as { event?: unknown } | undefined)?.event === "revoke",
+    )).toHaveLength(RACE_ITERATIONS);
+  });
+});
+
+function makeDoor(store: StoreAdapter, audits: AuditEvent[]): McpDoor {
+  const guard: Guard = {
+    async check() { return { action: "run", decidedBy: "default" }; },
+    async report(event) { audits.push(event); },
+    async directions() { return []; },
+    onApprovalDecision() { return () => undefined; },
+  };
+  const tools: ToolRegistry = {
+    async descriptors() { return []; },
+    async execute() { throw new Error("token race test never executes tools"); },
+  };
+  const oauth: HostOAuthAdapter = {
+    async authorize() { return { subject: "user_race" }; },
+    async principal() { return { kind: "user", subject: "user_race" } satisfies Principal; },
+  };
+  return createMcpDoor({ tools, guard, oauth, store });
+}
+
+/**
+ * Hold both instances immediately before their real database claim. This makes
+ * every iteration exercise two stale readers contending on the same SQL row,
+ * rather than merely hoping request scheduling overlaps.
+ */
+class ClaimBarrier {
+  #remaining = 0;
+  #release: (() => void) | undefined;
+  #ready: Promise<void> = Promise.resolve();
+
+  arm(): void {
+    if (this.#remaining !== 0) throw new Error("claim barrier is already armed");
+    this.#remaining = 2;
+    this.#ready = new Promise<void>((resolve) => {
+      this.#release = resolve;
+    });
+  }
+
+  async arrive(): Promise<void> {
+    if (this.#remaining === 0) return;
+    this.#remaining -= 1;
+    if (this.#remaining === 0) this.#release?.();
+    await this.#ready;
+  }
+}
+
+function gateTokenClaims(store: StoreAdapter, barrier: ClaimBarrier): StoreAdapter {
+  return {
+    records(collection) {
+      const records = store.records(collection);
+      const claim = records.claim;
+      if (collection !== "vendo_mcp_grants" || !claim) return records;
+      return {
+        ...records,
+        async claim(expected, replacement) {
+          await barrier.arrive();
+          return claim(expected, replacement);
+        },
+      };
+    },
+    blobs(namespace) {
+      return store.blobs(namespace);
+    },
+    async ensureSchema() {
+      await store.ensureSchema();
+    },
+  };
+}
+
+async function register(door: McpDoor): Promise<string> {
+  const response = await door.handler(new Request(`${BASE}/register`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ client_name: "Race client", redirect_uris: [REDIRECT] }),
+  }));
+  expect(response.status).toBe(201);
+  return ((await response.json()) as { client_id: string }).client_id;
+}
+
+async function authorize(door: McpDoor, clientId: string): Promise<string> {
+  const challenge = await pkceChallenge(VERIFIER);
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: clientId,
+    redirect_uri: REDIRECT,
+    code_challenge: challenge,
+    code_challenge_method: "S256",
+    resource: BASE,
+  });
+  const response = await door.handler(new Request(`${BASE}/authorize?${params}`));
+  expect(response.status).toBe(302);
+  return new URL(response.headers.get("location")!).searchParams.get("code")!;
+}
+
+function exchange(door: McpDoor, code: string, clientId: string): Promise<Response> {
+  return tokenRequest(door, {
+    grant_type: "authorization_code",
+    code,
+    client_id: clientId,
+    redirect_uri: REDIRECT,
+    code_verifier: VERIFIER,
+    resource: BASE,
+  });
+}
+
+function refresh(door: McpDoor, refreshToken: string, clientId: string): Promise<Response> {
+  return tokenRequest(door, {
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    client_id: clientId,
+    resource: BASE,
+  });
+}
+
+function tokenRequest(door: McpDoor, values: Record<string, string>): Promise<Response> {
+  return door.handler(new Request(`${BASE}/token`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(values),
+  }));
+}
+
+async function pkceChallenge(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+  return Buffer.from(digest).toString("base64url");
+}
+
+interface TokenResponse {
+  access_token: string;
+  refresh_token: string;
+}

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -44,6 +44,15 @@ export const recordQuerySchema = z.object({
 export interface RecordStore {
   get(id: string): Promise<VendoRecord | null>;
   put(record: Pick<VendoRecord, "id" | "data" | "refs">): Promise<VendoRecord>;
+  /**
+   * Atomically replace or delete a record only when its current data and refs
+   * still equal `expected`. Returns true for the single successful claimant.
+   * Omitted by adapters that cannot provide a database-level compare-and-claim.
+   */
+  claim?(
+    expected: Pick<VendoRecord, "id" | "data" | "refs">,
+    replacement?: Pick<VendoRecord, "data" | "refs">,
+  ): Promise<boolean>;
   delete(id: string): Promise<void>;
   list(query?: RecordQuery): Promise<{ records: VendoRecord[]; cursor?: string }>;
 }

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -57,11 +57,10 @@ package-root API remains the frozen `createMcpDoor(config)` surface.
   straight to your adapter. **Escape it** before rendering it on a consent screen;
   a client can register a name like `"Google Drive (official)"` for phishing or
   inject markup for XSS on your page. The door deliberately does no rendering.
-- **Single-secret redemption is serialized in-process.** Concurrent redemptions of
-  the same authorization code or refresh token are locked within one process, so a
-  refresh cannot fork. A **multi-instance** deployment (several door processes
-  behind a load balancer) needs sticky routing by token, or a shared-store atomic
-  claim, to keep that guarantee — the store exposes no atomic claim today.
+- **Single-secret redemption is claimed in the database.** Authorization codes and
+  refresh tokens use the store's atomic compare-and-claim capability, so one
+  redeemer wins across multiple door processes sharing Postgres. A custom
+  `StoreAdapter` that omits atomic claims fails closed at the token endpoint.
 - **CIMD fetch egress.** The door resolves a Client ID Metadata Document URL server-side
   and rejects private/loopback/link-local resolutions (best-effort, via `node:dns`
   when present). On runtimes without a resolver, or for defense in depth, enforce

--- a/packages/mcp/src/door.test.ts
+++ b/packages/mcp/src/door.test.ts
@@ -1,15 +1,16 @@
-import type {
-  AppDocument,
-  AuditEvent,
-  BlobStore,
-  Guard,
-  Principal,
-  RecordQuery,
-  RecordStore,
-  StoreAdapter,
-  ToolOutcome,
-  ToolRegistry,
-  VendoRecord,
+import {
+  canonicalJson,
+  type AppDocument,
+  type AuditEvent,
+  type BlobStore,
+  type Guard,
+  type Principal,
+  type RecordQuery,
+  type RecordStore,
+  type StoreAdapter,
+  type ToolOutcome,
+  type ToolRegistry,
+  type VendoRecord,
 } from "@vendoai/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
@@ -309,13 +310,13 @@ describe("createMcpDoor routing and OAuth", () => {
     expect(revoked.status).toBe(401);
   });
 
-  it("does not fork on concurrent refresh of the same token (in-process lock)", async () => {
+  it("does not fork on concurrent refresh of the same token (atomic claim)", async () => {
     const harness = makeHarness();
     const client = await register(harness.door);
     const first = await issue(harness.door, client.body.client_id);
 
-    // Two simultaneous rotations of the same refresh token: the lock serializes
-    // them, so exactly one succeeds and the other sees it already rotated.
+    // Two simultaneous rotations of the same refresh token: the store claim
+    // admits exactly one and the other sees reuse of the already-rotated grant.
     const [a, b] = await Promise.all([
       refresh(harness.door, first.refresh_token, client.body.client_id),
       refresh(harness.door, first.refresh_token, client.body.client_id),
@@ -1054,6 +1055,27 @@ class MemoryStore implements StoreAdapter {
         };
         rows.set(stored.id, stored);
         return stored;
+      },
+      async claim(expected, replacement) {
+        const current = rows.get(expected.id);
+        if (
+          !current
+          || canonicalJson(current.data) !== canonicalJson(expected.data)
+          || canonicalJson(current.refs ?? null) !== canonicalJson(expected.refs ?? null)
+        ) return false;
+        if (replacement === undefined) {
+          rows.delete(expected.id);
+        } else {
+          const now = new Date().toISOString();
+          rows.set(expected.id, {
+            id: expected.id,
+            data: structuredClone(replacement.data),
+            ...(replacement.refs === undefined ? {} : { refs: { ...replacement.refs } }),
+            createdAt: current.createdAt,
+            updatedAt: now,
+          });
+        }
+        return true;
       },
       async delete(id) { rows.delete(id); },
       async list(query?: RecordQuery) {

--- a/packages/mcp/src/oauth/server.ts
+++ b/packages/mcp/src/oauth/server.ts
@@ -90,32 +90,11 @@ export class OAuthServer {
   readonly #oauth: HostOAuthAdapter;
   readonly #store: StoreAdapter;
   readonly #guard: Guard;
-  /** Serializes read-check-write on a single code/refresh token so two
-   * concurrent redemptions of the SAME secret cannot both pass the "unused"
-   * check and both mint tokens (the store exposes no atomic claim). In-process
-   * only — a multi-instance deployment still needs a shared store lock or
-   * sticky routing; documented in the README. */
-  readonly #tokenLocks = new Map<string, Promise<void>>();
 
   constructor(config: OAuthServerConfig) {
     this.#oauth = config.oauth;
     this.#store = config.store;
     this.#guard = config.guard;
-  }
-
-  async #withTokenLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
-    const prior = this.#tokenLocks.get(key) ?? Promise.resolve();
-    let release!: () => void;
-    const mine = new Promise<void>((resolve) => (release = resolve));
-    const chained = prior.then(() => mine);
-    this.#tokenLocks.set(key, chained);
-    await prior;
-    try {
-      return await fn();
-    } finally {
-      release();
-      if (this.#tokenLocks.get(key) === chained) this.#tokenLocks.delete(key);
-    }
   }
 
   async register(req: Request): Promise<Response> {
@@ -208,12 +187,12 @@ export class OAuthServer {
     if (grantType === "authorization_code") {
       const code = form.get("code");
       if (!code) return oauthJsonError("invalid_request", "code is required");
-      return this.#withTokenLock(`code:${await sha256Hex(code)}`, () => this.#exchangeCode(form));
+      return this.#exchangeCode(form);
     }
     if (grantType === "refresh_token") {
       const refreshToken = form.get("refresh_token");
       if (!refreshToken) return oauthJsonError("invalid_request", "refresh_token is required");
-      return this.#withTokenLock(`refresh:${await sha256Hex(refreshToken)}`, () => this.#rotateRefresh(form));
+      return this.#rotateRefresh(form);
     }
     return oauthJsonError("unsupported_grant_type", "Unsupported grant_type");
   }
@@ -261,7 +240,12 @@ export class OAuthServer {
     // The code is single-use the moment it is PRESENTED, not only when it is
     // redeemed: a stolen code must not survive a failed PKCE/binding attempt
     // and stay guessable-against for the rest of its TTL.
-    await store.delete(record.id);
+    if (!store.claim) {
+      return oauthJsonError("server_error", "The configured store does not support atomic token claims");
+    }
+    if (!(await store.claim(record))) {
+      return oauthJsonError("invalid_grant", "Authorization code is invalid or expired");
+    }
 
     const grant = parsed.data;
     if (grant.clientId !== clientId || grant.redirectUri !== redirectUri) {
@@ -311,12 +295,23 @@ export class OAuthServer {
       return oauthJsonError("invalid_target", "resource does not match the refresh token");
     }
 
+    if (!store.claim) {
+      return oauthJsonError("server_error", "The configured store does not support atomic token claims");
+    }
+    // Persist candidate grants BEFORE claiming the parent. If another instance
+    // loses the claim, reuse revocation can see and remove every candidate in
+    // the successor chain. Candidate secrets are not exposed unless their
+    // parent claim succeeds.
     const tokens = await this.#issueTokens(grant);
-    await store.put({
-      id: record.id,
+    const claimed = await store.claim(record, {
       data: { ...grant, rotatedTo: tokens.refreshGrantId },
-      refs: record.refs,
+      ...(record.refs === undefined ? {} : { refs: record.refs }),
     });
+    if (!claimed) {
+      await this.#revokeSubjectClient(grant.subject, grant.clientId);
+      await this.#audit({ kind: "user", subject: grant.subject }, grant.clientId, "revoke");
+      return oauthJsonError("invalid_grant", "Refresh token reuse detected");
+    }
     await this.#audit({ kind: "user", subject: grant.subject }, grant.clientId, "refresh");
     return json(publicTokenResponse(tokens), 200, tokenHeaders());
   }

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -31,6 +31,11 @@ For production, pass a Postgres connection string explicitly, for example `creat
 
 App storage uses `app:<appId>:<name>` by convention. When the owning app is ephemeral, generic record collections and blob namespaces following that convention stay entirely in the session's in-memory overlay. Except for the reserved names below, collection names remain opaque and use `vendo_records`; non-`app:`-prefixed collections and namespaces have no principal linkage and therefore keep their normal persistence behavior.
 
+Generic record collections and the two door-owned tables expose the optional
+`RecordStore.claim` capability: one database statement compares the current
+`data` and `refs`, then replaces or deletes the row. Exactly one concurrent
+claimant receives `true`.
+
 ## Reserved collections (block seam)
 
 Blocks receive core's plain `StoreAdapter`, so these exact `records()` collection names route to their typed tables:

--- a/packages/store/src/adapter.records.test.ts
+++ b/packages/store/src/adapter.records.test.ts
@@ -73,6 +73,44 @@ for (const backend of backends()) {
       expect((await b.get("shared_note"))?.data).toEqual({ app: "b" });
     });
 
+    it("atomically compares and claims a record exactly once", async () => {
+      const firstHandle = made.store.records("atomic_claims");
+      const secondHandle = made.store.records("atomic_claims");
+      const expected = await firstHandle.put({
+        id: "claim_1",
+        data: { status: "unclaimed" },
+        refs: { owner: "user_1" },
+      });
+
+      expect(firstHandle.claim).toBeTypeOf("function");
+      expect(secondHandle.claim).toBeTypeOf("function");
+      if (!firstHandle.claim || !secondHandle.claim) throw new Error("store does not support atomic claims");
+
+      const [first, second] = await Promise.all([
+        firstHandle.claim(expected, {
+          data: { status: "claimed", winner: "first" },
+          refs: expected.refs,
+        }),
+        secondHandle.claim(expected, {
+          data: { status: "claimed", winner: "second" },
+          refs: expected.refs,
+        }),
+      ]);
+
+      expect([first, second].filter(Boolean)).toHaveLength(1);
+      expect((await firstHandle.get(expected.id))?.data).toEqual({
+        status: "claimed",
+        winner: first ? "first" : "second",
+      });
+
+      // A stale compare cannot consume the winner's row. The current value can.
+      expect(await firstHandle.claim(expected)).toBe(false);
+      const current = await firstHandle.get(expected.id);
+      expect(current).not.toBeNull();
+      expect(await firstHandle.claim(current!)).toBe(true);
+      expect(await firstHandle.get(expected.id)).toBeNull();
+    });
+
     it("rejects malformed cursors as validation errors", async () => {
       const records = made.store.records("cursor_errors");
       const encode = (value: unknown): string => Buffer.from(JSON.stringify(value), "utf8").toString("base64url");

--- a/packages/store/src/records.ts
+++ b/packages/store/src/records.ts
@@ -1,4 +1,4 @@
-import type { RecordQuery, RecordStore, VendoRecord } from "@vendoai/core";
+import { canonicalJson, type RecordQuery, type RecordStore, type VendoRecord } from "@vendoai/core";
 import type { Db } from "./db.js";
 import { isEphemeralApp, overlayFor, snapshot } from "./ephemeral.js";
 import { decodeCursor, encodeCursor, iso, jsonParam, pageLimit, text } from "./helpers/utils.js";
@@ -15,6 +15,14 @@ function recordFromRow(row: Record<string, unknown>): VendoRecord {
     createdAt: iso(row["created_at"]),
     updatedAt: iso(row["updated_at"]),
   };
+}
+
+function sameRecordValue(
+  current: VendoRecord,
+  expected: Pick<VendoRecord, "data" | "refs">,
+): boolean {
+  return canonicalJson(current.data) === canonicalJson(expected.data)
+    && canonicalJson(current.refs ?? null) === canonicalJson(expected.refs ?? null);
 }
 
 /** 01-core §12 */
@@ -88,6 +96,50 @@ export function createRecordStore(
           [record.id, jsonParam(record.data), record.refs === undefined ? null : jsonParam(record.refs), now],
         );
       return recordFromRow(result.rows[0] as Record<string, unknown>);
+    },
+    async claim(expected, replacement) {
+      if (await isEphemeral()) {
+        const records = ephemeralRecords();
+        const current = records.get(expected.id);
+        if (!current || !sameRecordValue(current, expected)) return false;
+        if (replacement === undefined) {
+          records.delete(expected.id);
+        } else {
+          records.set(expected.id, snapshot({
+            id: expected.id,
+            data: replacement.data,
+            ...(replacement.refs === undefined ? {} : { refs: replacement.refs }),
+            createdAt: current.createdAt,
+            updatedAt: new Date().toISOString(),
+          }));
+        }
+        return true;
+      }
+
+      const expectedRefs = expected.refs === undefined ? null : jsonParam(expected.refs);
+      const clauses = usesCollection
+        ? "collection = $1 AND id = $2 AND data = $3::jsonb AND refs IS NOT DISTINCT FROM $4::jsonb"
+        : "id = $1 AND data = $2::jsonb AND refs IS NOT DISTINCT FROM $3::jsonb";
+      const params: unknown[] = usesCollection
+        ? [collection, expected.id, jsonParam(expected.data), expectedRefs]
+        : [expected.id, jsonParam(expected.data), expectedRefs];
+
+      if (replacement === undefined) {
+        const result = await db.query(`DELETE FROM ${table} WHERE ${clauses} RETURNING id`, params);
+        return result.rows.length === 1;
+      }
+
+      const dataParam = params.push(jsonParam(replacement.data));
+      const refsParam = params.push(replacement.refs === undefined ? null : jsonParam(replacement.refs));
+      const updatedAtParam = params.push(new Date().toISOString());
+      const result = await db.query(
+        `UPDATE ${table}
+         SET data = $${dataParam}::jsonb, refs = $${refsParam}::jsonb, updated_at = $${updatedAtParam}
+         WHERE ${clauses}
+         RETURNING id`,
+        params,
+      );
+      return result.rows.length === 1;
     },
     async delete(id) {
       if (await isEphemeral()) {

--- a/packages/store/src/routing.test.ts
+++ b/packages/store/src/routing.test.ts
@@ -154,6 +154,28 @@ for (const backend of backends()) {
           .toEqual([`${prefix}_a`]);
       });
 
+      it(`atomically claims ${collection} rows`, async () => {
+        const firstHandle = made.store.records(collection);
+        const secondHandle = made.store.records(collection);
+        const expected = await firstHandle.put({
+          id: `${collection}_claim`,
+          data: { status: "unclaimed" },
+          refs: { kind: "claim" },
+        });
+        if (!firstHandle.claim || !secondHandle.claim) throw new Error("store does not support atomic claims");
+
+        const results = await Promise.all([
+          firstHandle.claim(expected, { data: { status: "claimed", by: "first" }, refs: expected.refs }),
+          secondHandle.claim(expected, { data: { status: "claimed", by: "second" }, refs: expected.refs }),
+        ]);
+
+        expect(results.filter(Boolean)).toHaveLength(1);
+        expect((await firstHandle.get(expected.id))?.data).toEqual({
+          status: "claimed",
+          by: results[0] ? "first" : "second",
+        });
+      });
+
       it(`walks cursor pages in ${collection} without duplicates or misses`, async () => {
         const records = made.store.records(collection);
         const pageSet = `${collection}_pages`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -546,6 +546,12 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.0
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
+      pg:
+        specifier: ^8.22.0
+        version: 8.22.0
       typescript:
         specifier: ^5.6.0
         version: 5.9.3


### PR DESCRIPTION
Fixes ENG-270

## What changed

- Adds an optional `RecordStore.claim(expected, replacement?)` capability and implements it for generic records plus the door-owned MCP tables.
- Replaces the OAuth server's in-process token locks with database claims for authorization-code consumption and refresh-token rotation.
- Preserves refresh reuse revocation: a losing redeemer revokes the subject/client chain, including the winning successor tokens.
- Adds a release changeset and minimal additive, dated contract amendments for the new store seam.

## Primitive design

The concrete store performs one conditional SQL statement per claim:

- replacement: `UPDATE ... WHERE id/data/refs still match ... RETURNING id`
- consumption: `DELETE ... WHERE id/data/refs still match ... RETURNING id`

Exactly one concurrent caller receives `true`. MCP token endpoints fail closed if a custom adapter omits the optional capability. Refresh candidates are persisted before the parent claim so a losing reuse attempt can see and revoke every successor candidate.

## Race evidence

Ran against a disposable Postgres 16 database with two independent `createStore` instances and two independent `createMcpDoor` instances sharing the same schema. A barrier forces both servers to reach the real SQL claim with stale reads on every iteration.

`POSTGRES_URL=postgres://... pnpm --dir fixtures/mcp-e2e exec vitest run src/token-claim-race.e2e.test.ts`

- authorization code: 25/25 races produced exactly one 200 and one `invalid_grant`
- refresh rotation: 25/25 races produced exactly one 200 and one reuse error; the losing request revoked the winner's access and refresh successors

## Validation

- GitHub Actions root CI: `pnpm install --frozen-lockfile`, `pnpm build`, `pnpm test`, `pnpm typecheck`, and `pnpm lint` — all green
- GitHub Actions integration, perf, audit, and changeset checks — all green
- `pnpm --filter @vendoai/mcp test` (25/25 on the final rebased base)
- focused store claim/routing tests (23/23)
- Postgres multi-instance race test (2/2; 50 forced-overlap races on the final rebased commit)