### PR TITLE
feat(init): generate Next.js .well-known route for mcp; reconcile stale mcp docs

### DIFF
--- a/docs-site/capabilities/mcp.mdx
+++ b/docs-site/capabilities/mcp.mdx
@@ -9,8 +9,9 @@ registry, policy, approvals, and audit path as chat, so outside agents get no
 weaker perimeter than your own conversation surface.
 
 Opening the door is a host decision. It is off by default, and `vendo init`
-asks whether you want it, then points you at the wiring rather than turning it
-on itself.
+asks whether you want it. On yes, init generates the Next.js discovery route
+and points you at the host-owned OAuth wiring; it never invents an auth adapter
+or turns the flag on by itself.
 
 ## When to use it
 
@@ -76,11 +77,13 @@ door cannot mint principals otherwise. Import the `HostOAuthAdapter` type from
 
 The door's transport and OAuth endpoints mount under the wire at
 `/api/vendo/mcp`, so your existing catch-all handler already serves them. The
-OAuth discovery documents live at the origin root, outside `/api/vendo`, so on
-Next.js you forward them to the same handler:
+OAuth discovery documents live at the origin root, outside `/api/vendo`. When
+you opt into MCP during `vendo init`, a Next.js host gets
+`app/.well-known/[...vendo]/route.ts` (under `src/app` when present), forwarding
+to the same handler. If you wire Vendo without init, add the equivalent route:
 
 ```ts
-// app/.well-known/[...path]/route.ts
+// app/.well-known/[...vendo]/route.ts
 import { vendo } from "@/lib/vendo";
 
 export const GET = (request: Request) => vendo.handler(request);

--- a/docs-site/connect/vendo-init.mdx
+++ b/docs-site/connect/vendo-init.mdx
@@ -13,19 +13,21 @@ The wizard scans the app with deterministic analysis plus available AI
 assistance. It interviews you with recommendations on four questions: your model
 import, the product brief, risk labels for critical tools, and whether to open
 the MCP door. Theme is extracted automatically, not asked. It then proposes the
-handler route and `<VendoRoot>` wiring. The scaffolded `<VendoRoot>` imports the
-extracted `.vendo/theme.json` and passes it as the `theme` prop, so shipped
-chrome adopts the host brand from the first boot with no hand wiring. Every code
-change is permission-gated and shown as a diff.
+handler route, the MCP discovery route when you opt in, and `<VendoRoot>` wiring.
+The scaffolded `<VendoRoot>` imports the extracted `.vendo/theme.json` and
+passes it as the `theme` prop, so shipped chrome adopts the host brand from the
+first boot with no hand wiring. Every code change is permission-gated and shown
+as a diff.
 
 Critical-tool risk answers land in `.vendo/overrides.json` and remain
 authoritative across future sync runs. Init also writes policy, product brief,
 theme, and the PGlite ignore entry where applicable.
 
 One of those questions is whether to open the [MCP door](/capabilities/mcp).
-Opening it is
-a host decision and needs a `HostOAuthAdapter`, so init never scaffolds it: on
-yes it points you at the wiring. The door stays off unless you opt in.
+Opening it is a host decision and needs a `HostOAuthAdapter`, so init never
+invents auth wiring or flips `mcp: true`: on yes it generates the Next.js
+`/.well-known` sibling route and points you at the remaining wiring. The door
+stays off unless you opt in.
 
 ## Framework detection
 
@@ -34,7 +36,8 @@ frameworks by dependency:
 
 - **Next.js** (a `next` dependency): proposes `app/api/vendo/[...vendo]/route.ts`
   (under `src/app` when that directory exists) and wraps the root layout in
-  `<VendoRoot>`.
+  `<VendoRoot>`. Opting into MCP also proposes
+  `app/.well-known/[...vendo]/route.ts` in the same app-router layout.
 - **Express** (an `express` dependency): proposes a `vendo/server.ts` module
   (`vendo/server.mjs` without a `tsconfig.json`) holding the `createVendo()`
   composition and a Node HTTP-to-fetch adapter, plus a starter `vendo/ai.ts`. Two

--- a/docs-site/reference/cli.mdx
+++ b/docs-site/reference/cli.mdx
@@ -16,10 +16,12 @@ runs.
 
 Init detects the host framework from `package.json` and scaffolds only what
 applies. A `next` dependency gets `app/api/vendo/[...vendo]/route.ts` (under
-`src/app` when that directory exists) and a layout that wraps `<VendoRoot>`. An
-`express` dependency gets a `vendo/server.ts` (`vendo/server.mjs` without a
-`tsconfig.json`) holding the `createVendo()` composition and a Node
-HTTP-to-fetch adapter, plus a starter `vendo/ai.ts`. Mount the adapter with
+`src/app` when that directory exists), a layout that wraps `<VendoRoot>`, and,
+when you opt into MCP in the interview, a sibling
+`.well-known/[...vendo]/route.ts`. An `express` dependency gets a
+`vendo/server.ts` (`vendo/server.mjs` without a `tsconfig.json`) holding the
+`createVendo()` composition and a Node HTTP-to-fetch adapter, plus a starter
+`vendo/ai.ts`. Mount the adapter with
 `app.use("/api/vendo", mountVendo())` and wrap the client entry in `<VendoRoot>`
 to finish. Init detects only `next` and `express`, checking `next` first, so an
 app with both gets the Next scaffold; any other host is treated as Next.

--- a/docs-site/reference/http-routes.mdx
+++ b/docs-site/reference/http-routes.mdx
@@ -53,8 +53,9 @@ Door paths bypass the wire's principal resolver and CSRF JSON gate. The door
 re-resolves `oauth.principal(subject)` on every bearer-authenticated transport
 request, so returning `null` revokes live sessions; the OAuth and discovery
 endpoints are not principal-resolved. The origin-root discovery documents sit
-outside `/api/vendo`, so on Next.js you forward them to `vendo.handler`. See
-[MCP door](/capabilities/mcp).
+outside `/api/vendo`; opting into MCP during `vendo init` generates the sibling
+Next.js route that forwards them to the same handler. See [MCP
+door](/capabilities/mcp) for the generated placement and manual fallback.
 
 ## Webhook verification
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -151,10 +151,12 @@ Policy posture: the shipped policy example blocks `venue: "mcp"`. Opening the
 door is a host decision, never a default. `vendo init` asks before opening it.
 
 The door also serves discovery documents at the origin root, which the
-`/api/vendo/[...]` catch-all cannot see. In a Next.js host, add a sibling
-well-known route forwarding to the same handler. The door owns only four exact
-paths — forward just those and 404 anything else, so the route never shadows a
-host serving its own OAuth/OIDC metadata at the same origin:
+`/api/vendo/[...]` catch-all cannot see. When you opt into MCP during `vendo init`
+in a Next.js host, init generates `app/.well-known/[...vendo]/route.ts` (under
+`src/app` when that layout is present) and forwards through the same handler.
+The generated route allows only the door's four exact paths and 404s everything
+else, so it never shadows host OAuth/OIDC metadata. If you wire Vendo without
+init, add the equivalent route manually:
 
 ```ts
 // app/.well-known/[...vendo]/route.ts

--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -48,6 +48,24 @@ function output(): { output: Output; logs: string[]; errors: string[] } {
   return { output: { log: (message) => logs.push(message), error: (message) => errors.push(message) }, logs, errors };
 }
 
+const WELL_KNOWN_ROUTE = `import { GET as handleVendo } from "../../api/vendo/[...vendo]/route";
+
+const DOOR_PATHS = new Set([
+  "/.well-known/oauth-protected-resource/api/vendo/mcp",
+  "/.well-known/oauth-authorization-server/api/vendo/mcp",
+  "/.well-known/mcp/server-card.json",
+  "/.well-known/mcp-server-card",
+]);
+
+const forward = (request: Request) =>
+  DOOR_PATHS.has(new URL(request.url).pathname)
+    ? handleVendo(request)
+    : new Response(null, { status: 404 });
+
+export const GET = forward;
+export const POST = forward;
+`;
+
 async function tree(root: string, at = root): Promise<Record<string, string>> {
   const result: Record<string, string> = {};
   for (const name of await readdir(at, { withFileTypes: true })) {
@@ -197,6 +215,8 @@ describe("vendo init", () => {
     expect(await readFile(join(root, ".vendo", "data", ".gitignore"), "utf8")).toBe("*\n!.gitignore\n");
     expect(await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8"))
       .toContain("@vendoai/vendo/server");
+    await expect(readFile(join(root, "app", ".well-known", "[...vendo]", "route.ts"), "utf8"))
+      .rejects.toMatchObject({ code: "ENOENT" });
     const wiredLayout = await readFile(join(root, "app", "layout.tsx"), "utf8");
     expect(wiredLayout).toContain("<VendoRoot theme={theme as VendoTheme}>{children}</VendoRoot>");
     expect(wiredLayout).toContain('import theme from "../.vendo/theme.json";');
@@ -205,6 +225,58 @@ describe("vendo init", () => {
     const first = await tree(root);
     expect(await runInit({ targetDir: root, yes: true, output: sink.output })).toBe(0);
     expect(await tree(root)).toEqual(first);
+  });
+
+  it.each(["app", join("src", "app")])(
+    "generates the MCP sibling route with exact content under %s",
+    async (appDir) => {
+      const root = await mkdtemp(join(tmpdir(), "vendo-init-mcp-"));
+      cleanup.push(root);
+      await mkdir(join(root, appDir), { recursive: true });
+      await writeFile(join(root, "package.json"), JSON.stringify({
+        name: "host",
+        dependencies: { next: "16.0.0", "@vendoai/vendo": "0.3.0" },
+      }));
+      await writeFile(join(root, appDir, "layout.tsx"),
+        "export default function Layout({ children }) { return <html><body>{children}</body></html>; }\n");
+
+      const confirm = vi.fn().mockResolvedValue(true);
+      expect(await runInit({
+        targetDir: root,
+        confirm,
+        interview: async () => ({ openDoor: true }),
+        output: output().output,
+      })).toBe(0);
+
+      const routePath = join(appDir, ".well-known", "[...vendo]", "route.ts");
+      await expect(readFile(join(root, routePath), "utf8"))
+        .resolves.toBe(WELL_KNOWN_ROUTE);
+      expect(confirm).toHaveBeenCalledWith(expect.objectContaining({
+        path: routePath,
+        diff: expect.stringContaining('+import { GET as handleVendo }'),
+      }));
+      const otherAppDir = appDir === "app" ? join("src", "app") : "app";
+      await expect(readFile(join(root, otherAppDir, ".well-known", "[...vendo]", "route.ts"), "utf8"))
+        .rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
+  it("preserves an existing hand-written MCP sibling route", async () => {
+    const root = await fixture();
+    const routeDir = join(root, "app", ".well-known", "[...vendo]");
+    const route = join(routeDir, "route.ts");
+    const existing = "export { GET } from \"../../api/vendo/[...vendo]/route\";\n";
+    await mkdir(routeDir, { recursive: true });
+    await writeFile(route, existing);
+
+    expect(await runInit({
+      targetDir: root,
+      confirm: async () => true,
+      interview: async () => ({ openDoor: true }),
+      output: output().output,
+    })).toBe(0);
+
+    expect(await readFile(route, "utf8")).toBe(existing);
   });
 
   it("shows each code diff and writes no code without approval", async () => {

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -117,6 +117,22 @@ function routeSource(modelImport: string): string {
     `export const { GET, POST, DELETE } = nextVendoHandler(vendo);\n`;
 }
 
+function wellKnownRouteSource(): string {
+  return `import { GET as handleVendo } from "../../api/vendo/[...vendo]/route";\n\n` +
+    `const DOOR_PATHS = new Set([\n` +
+    `  "/.well-known/oauth-protected-resource/api/vendo/mcp",\n` +
+    `  "/.well-known/oauth-authorization-server/api/vendo/mcp",\n` +
+    `  "/.well-known/mcp/server-card.json",\n` +
+    `  "/.well-known/mcp-server-card",\n` +
+    `]);\n\n` +
+    `const forward = (request: Request) =>\n` +
+    `  DOOR_PATHS.has(new URL(request.url).pathname)\n` +
+    `    ? handleVendo(request)\n` +
+    `    : new Response(null, { status: 404 });\n\n` +
+    `export const GET = forward;\n` +
+    `export const POST = forward;\n`;
+}
+
 function expressServerSource(modelImport: string, typescript: boolean): string {
   const imports = typescript
     ? `import { once } from "node:events";\n` +
@@ -370,7 +386,7 @@ function diff(path: string, before: string | null, after: string): string {
   ].join("\n");
 }
 
-async function buildPlan(options: InitOptions): Promise<{ plan: InitPlan; changes: Array<{ absolute: string; path: string; before: string | null; after: string; diff: string }> }> {
+async function buildPlan(options: InitOptions, mcpEnabled = false): Promise<{ plan: InitPlan; changes: Array<{ absolute: string; path: string; before: string | null; after: string; diff: string }> }> {
   const root = resolve(options.targetDir);
   const framework = await detectFramework(root);
   const modelImport = options.modelImport ?? (framework === "express" ? "./ai" : "@/lib/ai");
@@ -399,8 +415,10 @@ async function buildPlan(options: InitOptions): Promise<{ plan: InitPlan; change
   } else {
     const app = await appDirectory(root);
     const route = join(app, "api", "vendo", "[...vendo]", "route.ts");
+    const wellKnownRoute = join(app, ".well-known", "[...vendo]", "route.ts");
     const layout = join(app, "layout.tsx");
     const routeBefore = await readOptional(route);
+    const wellKnownRouteBefore = await readOptional(wellKnownRoute);
     const layoutBefore = await readOptional(layout);
     const routeAfter = routeBefore ?? routeSource(modelImport);
     const themeSpecifier = await themeImportSpecifier(root, app);
@@ -418,6 +436,11 @@ async function buildPlan(options: InitOptions): Promise<{ plan: InitPlan; change
         const modelAfter = defaultModelSource();
         changes.push({ absolute: modelModule, path: modelPath, before: null, after: modelAfter, diff: diff(modelPath, null, modelAfter) });
       }
+    }
+    if (mcpEnabled && wellKnownRouteBefore === null) {
+      const path = relative(root, wellKnownRoute);
+      const after = wellKnownRouteSource();
+      changes.push({ absolute: wellKnownRoute, path, before: null, after, diff: diff(path, null, after) });
     }
     if (layoutAfter !== null && layoutAfter !== layoutBefore) {
       const path = relative(root, layout);
@@ -516,7 +539,7 @@ export async function runInit(options: InitOptions): Promise<number> {
     modelImport: answers.modelImport ?? options.modelImport,
     brief: answers.brief ?? options.brief,
   };
-  const { plan, changes } = await buildPlan(effective);
+  const { plan, changes } = await buildPlan(effective, answers.openDoor === true);
 
   const telemetry = telemetryFor(options, output);
   await telemetry.track("init_started", { framework: plan.framework });


### PR DESCRIPTION
## Summary

- generate `app/.well-known/[...vendo]/route.ts` (or `src/app/.well-known/[...vendo]/route.ts`) when `vendo init` enables MCP
- forward only the four shipped door metadata paths to the generated `/api/vendo/[...vendo]` handler, while preserving an existing host-owned sibling route
- cover both supported App Router layouts with exact content/placement tests and reconcile stale MCP and manual `.well-known` integration guidance

The frozen contract overview is already reconciled on the latest `main` by the approved MCP amendment; this branch makes no additional frozen-contract edits.

## Real init evidence

Ran the built repository CLI against a fresh App Router fixture:

```sh
node packages/vendo/bin/vendo.mjs init /tmp/eng-272-real-init
```

It exited successfully and generated `/tmp/eng-272-real-init/app/.well-known/[...vendo]/route.ts` with:

```ts
import { GET as handleVendo } from "../../api/vendo/[...vendo]/route";

const DOOR_PATHS = new Set([
  "/.well-known/oauth-protected-resource/api/vendo/mcp",
  "/.well-known/oauth-authorization-server/api/vendo/mcp",
  "/.well-known/mcp/server-card.json",
  "/.well-known/mcp-server-card",
]);

const forward = (request: Request) =>
  DOOR_PATHS.has(new URL(request.url).pathname)
    ? handleVendo(request)
    : new Response(null, { status: 404 });

export const GET = forward;
export const POST = forward;
```

## Validation

- `pnpm build`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- real built-CLI init run above

Fixes ENG-272


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
vendo init now generates a Next.js `.well-known/[...vendo]/route.ts` when you opt into MCP, forwarding only the four discovery endpoints to the existing `/api/vendo/[...vendo]` handler without shadowing host metadata. Docs are updated to reflect MCP support and the new init flow, addressing ENG-272.

- **New Features**
  - Next.js App Router: creates `app/.well-known/[...vendo]/route.ts` (or `src/app/...`) that forwards GET/POST for the four exact MCP discovery paths; 404s everything else.
  - Preserves any existing host-owned `.well-known` route.
  - Opt-in only: does not scaffold a `HostOAuthAdapter` or enable MCP; all changes are shown for approval.
  - Tests cover exact file content and placement for both `app` and `src/app`.
  - Docs updated to reconcile MCP guidance and document the generated discovery route.

<sup>Written for commit c2bd4c376a5eefc99349e26f72963d972371c7c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

