### PR TITLE
Install DX wave 1: publish-prep 0.3.0 + npm hygiene

### DIFF
--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -1,0 +1,166 @@
+# Vendo 0.3.0 publish runbook
+
+This runbook is for Yousef's TTY because npm publishing and deprecation require
+passkey/WebAuthn 2FA. The repository is publish-ready; this document does not
+authorize an automated or sandboxed publish.
+
+## What will publish
+
+`pnpm -r publish` skips private workspaces and publishes these twelve packages
+at `0.3.0`:
+
+- `@vendoai/actions`
+- `@vendoai/agent`
+- `@vendoai/apps`
+- `@vendoai/automations`
+- `@vendoai/core`
+- `@vendoai/guard`
+- `@vendoai/mcp`
+- `@vendoai/store`
+- `@vendoai/telemetry`
+- `@vendoai/ui`
+- `@vendoai/vendo`
+- `vendoai`
+
+Demos, fixtures, corpus tooling/hosts, the benchmark, and spikes remain
+`private: true`. There is no separate sandbox-shims package to publish; the
+runtime artifacts needed by consumers are already inside the owning packages'
+`dist` directories.
+
+## Publish from a TTY
+
+From the repository root on the reviewed commit, with a clean worktree:
+
+```bash
+NPM_CONFIG_MIN_RELEASE_AGE=0 pnpm -r publish --access public --no-git-checks
+```
+
+The override is required: `~/.npmrc` has `min-release-age=7`, which otherwise
+causes false `ENOVERSIONS` failures while fresh workspace dependencies are
+being published.
+
+## Deprecate the pre-v0 package line
+
+Run these after 0.3.0 is visible. The unscoped `vendoai` package is superseded
+by `vendoai@0.3.0` and must **not** be deprecated.
+
+```bash
+NPM_CONFIG_MIN_RELEASE_AGE=0 npm deprecate "@vendoai/cli@0.1.0" "Pre-v0 package; use vendoai instead. See https://docs.vendo.run/quickstart."
+NPM_CONFIG_MIN_RELEASE_AGE=0 npm deprecate "@vendoai/client@0.1.0" "Pre-v0 package; use vendoai instead. See https://docs.vendo.run/quickstart."
+NPM_CONFIG_MIN_RELEASE_AGE=0 npm deprecate "@vendoai/components@0.1.0" "Pre-v0 package; use vendoai instead. See https://docs.vendo.run/quickstart."
+NPM_CONFIG_MIN_RELEASE_AGE=0 npm deprecate "@vendoai/core@0.1.0" "Pre-v0 package; use vendoai instead. See https://docs.vendo.run/quickstart."
+NPM_CONFIG_MIN_RELEASE_AGE=0 npm deprecate "@vendoai/react@0.1.0" "Pre-v0 package; use vendoai instead. See https://docs.vendo.run/quickstart."
+NPM_CONFIG_MIN_RELEASE_AGE=0 npm deprecate "@vendoai/runtime@0.1.0" "Pre-v0 package; use vendoai instead. See https://docs.vendo.run/quickstart."
+NPM_CONFIG_MIN_RELEASE_AGE=0 npm deprecate "@vendoai/server@0.1.0" "Pre-v0 package; use vendoai instead. See https://docs.vendo.run/quickstart."
+NPM_CONFIG_MIN_RELEASE_AGE=0 npm deprecate "@vendoai/shell@0.1.0" "Pre-v0 package; use vendoai instead. See https://docs.vendo.run/quickstart."
+NPM_CONFIG_MIN_RELEASE_AGE=0 npm deprecate "@vendoai/stage@0.1.0" "Pre-v0 package; use vendoai instead. See https://docs.vendo.run/quickstart."
+NPM_CONFIG_MIN_RELEASE_AGE=0 npm deprecate "@vendoai/store@0.1.0" "Pre-v0 package; use vendoai instead. See https://docs.vendo.run/quickstart."
+NPM_CONFIG_MIN_RELEASE_AGE=0 npm deprecate "@vendoai/telemetry@0.1.0" "Pre-v0 package; use vendoai instead. See https://docs.vendo.run/quickstart."
+```
+
+## Registry propagation check
+
+Brand-new scoped packages can return anonymous `404` responses for several
+minutes after a successful publish. Wait and retry before treating that as a
+failure. Keep the release-age override on every view/install check:
+
+```bash
+for package in \
+  @vendoai/actions @vendoai/agent @vendoai/apps @vendoai/automations \
+  @vendoai/core @vendoai/guard @vendoai/mcp @vendoai/store \
+  @vendoai/telemetry @vendoai/ui @vendoai/vendo vendoai
+do
+  NPM_CONFIG_MIN_RELEASE_AGE=0 npm view "$package@0.3.0" version
+done
+
+NPM_CONFIG_MIN_RELEASE_AGE=0 npm view "@vendoai/vendo@0.3.0" readme | sed -n '1,20p'
+NPM_CONFIG_MIN_RELEASE_AGE=0 npm view "vendoai@0.3.0" readme | sed -n '1,20p'
+```
+
+## Post-publish clean-room verification
+
+Verify each public install name in its own fresh Next.js app. The starter model
+module written by init uses the AI SDK v6 Anthropic provider, so install the two
+provider packages before building. Use `npx --no-install vendo` only after the
+local package install; a global deployment CLI also named `vendo` exists on this
+machine and can shadow `npx vendo` when neither Vendo npm package is local.
+
+### Unscoped alias
+
+```bash
+alias_root=$(mktemp -d /private/tmp/vendo-registry-alias.XXXXXX)
+cd "$alias_root"
+NPM_CONFIG_MIN_RELEASE_AGE=0 npx create-next-app@16.2.9 app --ts --tailwind --eslint --app --src-dir --use-npm --yes
+cd app
+NPM_CONFIG_MIN_RELEASE_AGE=0 npm install vendoai 'ai@^6' '@ai-sdk/anthropic@^3'
+npx --no-install vendo --version
+npx --no-install vendo init --yes --brief 'Vendo 0.3.0 registry verification.'
+npm run build
+npm run dev -- --hostname 127.0.0.1 --port 3137 >"$alias_root/dev.log" 2>&1 &
+server_pid=$!
+trap 'kill "$server_pid" 2>/dev/null || true' EXIT
+until curl --fail --silent http://127.0.0.1:3137/api/vendo/status >/dev/null; do sleep 1; done
+npx --no-install vendo doctor --url http://127.0.0.1:3137/api/vendo
+kill "$server_pid"
+wait "$server_pid" || true
+trap - EXIT
+```
+
+### Scoped umbrella
+
+```bash
+scoped_root=$(mktemp -d /private/tmp/vendo-registry-scoped.XXXXXX)
+cd "$scoped_root"
+NPM_CONFIG_MIN_RELEASE_AGE=0 npx create-next-app@16.2.9 app --ts --tailwind --eslint --app --src-dir --use-npm --yes
+cd app
+NPM_CONFIG_MIN_RELEASE_AGE=0 npm install @vendoai/vendo 'ai@^6' '@ai-sdk/anthropic@^3'
+npx --no-install vendo --version
+npx --no-install vendo init --yes --brief 'Vendo 0.3.0 registry verification.'
+npm run build
+npm run dev -- --hostname 127.0.0.1 --port 3138 >"$scoped_root/dev.log" 2>&1 &
+server_pid=$!
+trap 'kill "$server_pid" 2>/dev/null || true' EXIT
+until curl --fail --silent http://127.0.0.1:3138/api/vendo/status >/dev/null; do sleep 1; done
+npx --no-install vendo doctor --url http://127.0.0.1:3138/api/vendo
+kill "$server_pid"
+wait "$server_pid" || true
+trap - EXIT
+```
+
+Success means both installs report CLI version `0.3.0`, init writes the complete
+`.vendo` contract and Next wiring, the app builds, and doctor reports a live
+`/status` round trip with version `0.3.0`.
+
+## Local rehearsal evidence
+
+Rehearsed on 2026-07-14 in
+`/private/tmp/vendo-install-dx-wave1.hedhyg`:
+
+- Packed all 12 public workspaces; every tarball was version `0.3.0`, contained
+  `README.md`, and had zero remaining `workspace:` references.
+- Confirmed `vendoai` packed `@vendoai/vendo` as concrete version `0.3.0`.
+- Created a fresh Next.js 16.2.9 app and installed all 12 local tarballs plus
+  the documented AI SDK v6 provider pair.
+- `npx vendo --version` printed `0.3.0`; `npx vendo init --yes` completed; the
+  generated app passed `next build`.
+- Both the alias and canonical bin entry points printed `0.3.0`, and all three
+  exports (`.`, `./server`, and `./react`) imported through both package names.
+- Booted the app on `127.0.0.1:3137`; `npx vendo doctor` exited 0 after a live
+  `/status` response reporting `0.3.0` and posture `unconfigured`.
+
+### Friction log
+
+- The local-tarball injector omitted `@vendoai/mcp`, allowing the umbrella's
+  dependency to fall through to the unpublished registry package. The injector
+  and its pack-once regression test now include MCP.
+- `@vendoai/telemetry` was still versioned `0.2.0`; it is now aligned with the
+  locked 0.3.0 block set.
+- Init intentionally writes a starter model module but does not install its
+  provider. Installing the exact pair printed by init (`ai@^6` and
+  `@ai-sdk/anthropic@^3`) made the clean app build; credential/model ladder work
+  remains Wave 2.
+- npm reported two moderate transitive audit findings and allow-scripts notices
+  for `sharp` and `unrs-resolver`; neither affected install, build, init, or
+  doctor.
+- The first dev compilation of `/api/vendo/status` took about 12 seconds;
+  doctor waited and passed.

--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ tool proxy.
 
 ## Install flow
 
-`vendo init` scans the host app, interviews you about risk labels, theme, and
-remix candidates, then proposes the handler route and `<VendoRoot>` wiring.
+`vendo init` scans the host app, then asks about the model import, product brief,
+critical-tool risk labels, and whether to open the MCP door. It proposes the
+handler route and `<VendoRoot>` wiring while extracting the theme automatically.
 Every code change is permission-gated and shown as a diff. It writes the
 reviewable `.vendo/` directory and leaves the PGlite data directory ignored.
 

--- a/corpus/harness/src/inject.test.ts
+++ b/corpus/harness/src/inject.test.ts
@@ -60,7 +60,7 @@ async function createWorkspace(): Promise<string> {
     { dir: "guard", name: "@vendoai/guard" },
     { dir: "mcp", name: "@vendoai/mcp" },
     { dir: "store", name: "@vendoai/store" },
-    { dir: "vendo-telemetry", name: "@vendoai/telemetry", version: "0.2.0" },
+    { dir: "vendo-telemetry", name: "@vendoai/telemetry" },
     { dir: "ui", name: "@vendoai/ui" },
   ];
 
@@ -196,7 +196,7 @@ describe("createLocalVendoInjector", () => {
       "vendoai-guard-0.3.0.tgz",
       "vendoai-mcp-0.3.0.tgz",
       "vendoai-store-0.3.0.tgz",
-      "vendoai-telemetry-0.2.0.tgz",
+      "vendoai-telemetry-0.3.0.tgz",
       "vendoai-ui-0.3.0.tgz",
       "vendoai-vendo-0.3.0.tgz",
     ]));
@@ -210,7 +210,7 @@ describe("createLocalVendoInjector", () => {
       "vendoai-guard-0.3.0.tgz",
       "vendoai-mcp-0.3.0.tgz",
       "vendoai-store-0.3.0.tgz",
-      "vendoai-telemetry-0.2.0.tgz",
+      "vendoai-telemetry-0.3.0.tgz",
       "vendoai-ui-0.3.0.tgz",
       "vendoai-vendo-0.3.0.tgz",
     ]));

--- a/corpus/harness/src/local-pack.ts
+++ b/corpus/harness/src/local-pack.ts
@@ -10,6 +10,7 @@ export const LOCAL_VENDO_PACKAGE_NAMES = [
   "@vendoai/agent",
   "@vendoai/actions",
   "@vendoai/guard",
+  "@vendoai/mcp",
   "@vendoai/apps",
   "@vendoai/automations",
   "@vendoai/ui",

--- a/docs-site/connect/vendo-init.mdx
+++ b/docs-site/connect/vendo-init.mdx
@@ -63,3 +63,20 @@ writes nothing.
 
 Use `vendo doctor` after setup. It checks wiring and makes one live `/status`
 round trip.
+
+## Non-interactive setup
+
+Pass an app directory as the positional argument; it defaults to the current
+directory. For CI, agents, or a reviewed scripted setup, use:
+
+```bash
+npx vendo init [dir] --yes --model-import '@/lib/ai' --brief 'What the product does and who uses it'
+```
+
+- `--yes` skips the four-question interview, still prints each proposed diff,
+  and approves all code changes.
+- `--model-import <specifier>` chooses the module that exports the host's AI SDK
+  `model` (default `@/lib/ai` for Next.js and `./ai` for Express).
+- `--brief <text>` supplies the contents of `.vendo/brief.md`.
+- `--force` regenerates Vendo-owned `.vendo` files while preserving existing
+  host source files.

--- a/docs-site/reference/cli.mdx
+++ b/docs-site/reference/cli.mdx
@@ -5,7 +5,7 @@ description: "Reference for the vendo bin commands: init for setup, doctor for w
 
 The umbrella owns the `vendo` bin. It has four commands.
 
-## `vendo init`
+## `vendo init [dir]`
 
 Interactive setup. It scans the app, interviews you about your model import, the
 product brief, risk labels for critical tools, and the MCP door (theme is
@@ -26,10 +26,22 @@ when you opt into MCP in the interview, a sibling
 to finish. Init detects only `next` and `express`, checking `next` first, so an
 app with both gets the Next scaffold; any other host is treated as Next.
 
-`--agent` emits the setup plan with its four plain-language questions and
-writes nothing.
+`dir` is the app to initialize and defaults to the current directory.
 
-## `vendo doctor`
+Options:
+
+- `--agent` emits the setup plan with its four plain-language questions and
+  writes nothing.
+- `--yes` skips the interview, shows the proposed diffs, and approves every
+  code change. Combine it with `--model-import` and `--brief` for unattended
+  setup.
+- `--force` regenerates Vendo-owned files under `.vendo/`. It does not replace
+  existing host source files.
+- `--model-import <specifier>` sets the module that exports the host's AI SDK
+  `model` (default `@/lib/ai` for Next.js and `./ai` for Express).
+- `--brief <text>` supplies the product brief written to `.vendo/brief.md`.
+
+## `vendo doctor [dir]`
 
 Checks wiring and makes one live `/status` round trip. It recognizes both Next.js
 (catch-all route plus a layout that mounts `<VendoRoot>`) and Express (the server
@@ -43,10 +55,11 @@ Exit codes:
 - `0`: green
 - `1`: broken wiring
 
-## `vendo sync`
+## `vendo sync [dir]`
 
 Runs the build-step extraction manually. It updates tool extraction and remix
-baselines. The default is fail-soft and warns on breaking changes.
+baselines for `dir`, which defaults to the current directory. The default is
+fail-soft and warns on breaking changes.
 
 Exit codes:
 

--- a/docs/superpowers/plans/2026-07-14-install-dx.md
+++ b/docs/superpowers/plans/2026-07-14-install-dx.md
@@ -1,0 +1,147 @@
+# Install DX Implementation Plan
+
+> Executed wave-by-wave by codex sol under Fable orchestration (Opus 4.8 only when
+> sol is blocked). Spec: `docs/superpowers/specs/2026-07-14-install-dx-design.md` —
+> read it first; it holds every locked decision. This plan is deliberately
+> high-level (team rule): goals, steps, decisions — the executor owns the code.
+
+**Goal:** `npm install vendoai` → `npx vendo init` → a working, on-brand agent
+visible in the dev's own product before the terminal closes, for humans and
+agents alike.
+
+**Architecture:** Extend the existing well-tested CLI backbone (wizard, doctor,
+sync) with a dev-mode model-credential ladder, an init-ends-in-product finale,
+cloud starter-allowance rung, and agent-facing surfaces. Publish the real 0.3.0
+artifact first so every subsequent test runs against what devs actually install.
+
+**Cross-cutting rules (every wave):**
+- Branch + PR per wave; never commit to main. `pnpm build && pnpm test &&
+  pnpm typecheck && pnpm lint` green before any PR.
+- UI-affecting changes verified in a real browser with screenshots in the PR.
+- Each wave ends with a captured real demo of its outcome, not just tests.
+- Contracts in `docs/contracts/` are frozen; layering guard must stay green.
+
+---
+
+## Wave 1 — Publish 0.3.0 + npm hygiene (unblocks everything)
+
+Outcome: the product the repo describes is installable from npm; npm page looks
+intentional; stale 0.1.0 line is deprecated.
+
+1. Publish preflight in-repo: per-package READMEs included in tarballs (root
+   README-derived for the umbrella + alias; short block READMEs elsewhere);
+   `files` arrays complete; verify the `vendoai` alias's workspace dep rewrites
+   to a real version on pack; run a pack-and-install rehearsal into a fresh app
+   from local tarballs (no registry) and drive init + doctor.
+2. Drift fixes that ship with the publish: CLI help "three questions" vs docs
+   "four"; document `--yes/--force/--model-import/--brief` and sync's `[dir]`
+   positional; make sure nothing generated pins floating `latest` or references
+   nonexistent packages (the 0.1.0 ghost-dep class).
+3. Deprecation plan for the eleven 0.1.0-era packages (cli, client, components,
+   core→superseded-by-new-core note, react, runtime, server, shell, stage,
+   store, telemetry): deprecation messages pointing at `vendoai`/docs. Old
+   `vendoai@0.1.0` itself gets superseded by the new version, not deprecated.
+4. **Yousef-run publish step** (passkey 2FA cannot run in a sandbox): hand him
+   the exact command block (pnpm recursive publish, `--access public`,
+   `NPM_CONFIG_MIN_RELEASE_AGE=0` to dodge his `min-release-age=7` npmrc), plus
+   the deprecate commands. Expect several minutes of anonymous-GET propagation
+   lag before verification.
+5. Post-publish clean-room verification from the live registry: fresh Next app,
+   `npm install vendoai` and `npm install @vendoai/vendo` both → init → doctor.
+   Capture terminal recording; this is the wave demo.
+
+Acceptance: both package names install from npm; init + doctor complete on a
+fresh app; npm pages show real READMEs; 0.1.0 packages display deprecation
+notices; drift fixes merged.
+
+## Wave 2 — Model ladder + dev-mode runtime + init ends in the product
+
+Outcome: zero-key first turn in the dev's browser at the end of init.
+
+1. **Spike (timeboxed ~1 day, decision gate with orchestrator before build):**
+   persistent-process ai-SDK providers over Claude Agent SDK and Codex
+   app-server, with Vendo's host tools bridged via in-process MCP and consent
+   routed through the permission callback. Measure interactive latency and
+   verify approval semantics survive. Report recommends: full-tools riding /
+   tools-free riding fallback / key-rungs-only.
+2. Credential resolver: detect env keys, authed Claude session, authed Codex
+   session, VENDO_API_KEY — in that order (env first; explicit beats implicit).
+   Wizard states what it found; consent before any CLI-session use; resolver
+   output shared by runtime dev-mode and extraction `--deep`.
+3. Dev-mode runtime model wiring per rung, prod-vs-dev distinction, and the
+   explicit "production needs a real key" messaging in init next-steps.
+4. Init finale: consent-gated start of the dev server, open browser on the host
+   app, adaptive seeded first turn (tools → tool demo; theme-only → on-brand
+   UI generation; blank → self-aware tour).
+5. E2E: clean-room fresh app + each ladder rung exercised (env key, claude
+   session, codex session, none) with captured outcomes.
+
+Acceptance: on a keyless machine with an authed claude or codex CLI, init ends
+with a real agent reply rendered in the browser; every rung's behavior tested;
+wave demo GIF captured.
+
+## Wave 3 — Doctor v2 + cloud-in-init
+
+Outcome: doctor proves a user would get an answer; cloud is a first-class rung.
+
+1. Doctor: one real model turn through the wired route printed in the terminal
+   (exit 0 = answered); `--json`; consent-gated "start the dev server for the
+   probe?" when nothing is listening; VENDO_API_KEY validation + what it
+   unlocks in the ladder hints.
+2. Cloud in init: detect + validate VENDO_API_KEY; offer `vendo cloud login`
+   inline (browser OAuth).
+3. Starter allowance (built here, in vendo-web console): endpoint + key
+   semantics for minting a metered dev-mode key after login; wizard writes
+   `.env.local` itself. Coordinate schema with the Cloud console project but do
+   not wait on it.
+
+Acceptance: doctor exit 0 ⇔ live answered turn; doctor --json consumed by a
+script in tests; keyless dev completing `vendo cloud login` inside init gets a
+working first turn on the allowance key; wave demo captured.
+
+## Wave 4 — Agent surfaces
+
+Outcome: an agent pointed at a repo (or the paste prompt) completes the install.
+
+1. install.md: single canonical staged playbook (base install → review/remix →
+   block unlocks) as a docs-site page served at a stable URL + raw .md; the
+   3-line paste prompt references it.
+2. llms.txt + per-page .md on the docs site.
+3. Vendo setup skill: authored once, shipped in the npm tarball; init offers
+   (consent) to write it to the host repo's `.claude/skills/`; published to
+   skills.sh.
+4. Machine-readable CLI completion: `sync --json`; `init --agent` enriched to
+   include extracted tools + risk recommendations (run extraction before
+   emitting the plan).
+
+Acceptance: a fresh Claude Code session given only the 3-line paste prompt
+completes install through doctor-green on a clean app, captured end-to-end;
+llms.txt validates; skill installs via both routes.
+
+## Wave 5 — Demos, GIFs, CI guard
+
+Outcome: the marketing-grade and honesty-grade proof set, plus permanent drift
+insurance. All captures against the PUBLISHED package.
+
+1. Fresh Next starter GIF: install → init → doctor → browser first turn.
+2. De-wired Maple clone GIF: copy demo-bank, strip Vendo wiring + .vendo/, run
+   the full journey — extraction + on-brand theming wow.
+3. One corpus repo run (real OSS app) — honest proof, terminal + browser capture.
+4. Agent-driven install GIF (from wave 4 acceptance, re-captured at final
+   quality if needed).
+5. CI clean-room guard: recurring workflow installing the published package
+   into a fresh app, running init + doctor + one real turn; fails loudly on
+   npm-vs-main drift.
+
+Acceptance: four GIFs + corpus capture reviewed by Yousef; CI guard green on
+schedule and proven to fail on a simulated drift.
+
+---
+
+## Sequencing & orchestration
+
+Wave 1 strictly first. Waves 2 and 4 can overlap after 1 (different surfaces);
+wave 3 follows 2's resolver; wave 5 last. Publish and any credential-sensitive
+step is Yousef-run. Each wave: codex sol executes → orchestrator reviews →
+code-review pass → PR → Yousef merge. Spike results and any spec deviation come
+back to Yousef before proceeding.

--- a/docs/superpowers/specs/2026-07-14-install-dx-design.md
+++ b/docs/superpowers/specs/2026-07-14-install-dx-design.md
@@ -1,0 +1,124 @@
+# Install DX: npm install → working agent — Design
+
+**Date:** 2026-07-14 · **Owner:** Yousef · **Linear:** Install DX project (ENG)
+**Status:** Approved by Yousef in brainstorm session (this doc is the record).
+
+## Outcome
+
+"Designed for a human dev doing it himself — so simple any agent succeeds too."
+`npm install vendoai` → `npx vendo init` → a working, on-brand agent visible in the
+dev's own product before the terminal closes. `vendo doctor` proves it independently.
+Best possible DX for both plain devs and agent-enabled devs.
+
+## Grounding (examination findings this design responds to)
+
+- The deterministic backbone already exists and is well-tested: init wizard with
+  per-change diff consent, framework detection (Next/Express), deterministic
+  extraction (OpenAPI + route scan + theme harvest), doctor with static checks +
+  one live /status round-trip, `init --agent` JSON plan, `vendo cloud` sub-CLI.
+- npm is five weeks stale and one architecture behind: `vendoai` on npm is 0.1.0
+  (pre-v0 product); `@vendoai/vendo` and the whole 0.3.0 block set were never
+  published. Docs describe software nobody can install.
+- Nothing in the install path gets a model credential into the app, so a fresh
+  install cannot produce a first working turn.
+- No install.md, no llms.txt, no consumer agent surface beyond `--agent` (whose
+  plan JSON lacks extraction results). npm package pages have no README.
+- Creds research (July 2026): Anthropic bans subscription-OAuth riding in
+  third-party products (partner-approval exception exists); OpenAI explicitly
+  endorses Codex/ChatGPT-plan riding; CLI-wrapped providers cannot execute the
+  host tools bound into Vendo's own agent loop; the compliant industry pattern
+  is a vendor-paid gateway (PostHog).
+
+## Scope
+
+Owns the init→doctor→working-agent **journey** and its UX. Extraction engine
+quality (incl. the `--deep` AI pass being built in the Extraction project) and
+the broader docs site belong to neighbor projects; this project owns what init
+invokes, prints, and hands to agents. Framework bar: **Next.js perfect first**;
+Express keeps its manual-snippet path.
+
+## Decisions
+
+### 1. The journey
+- Install via `vendoai` or `@vendoai/vendo` (both published, same bin).
+- `vendo init`: wizard as today (detection stated, per-change diff consent),
+  extended with the model-source ladder and cloud steps below.
+- **Init ends in the product**: with consent, init starts the dev server, opens
+  the browser on the host app with the Vendo surface active, and seeds a first
+  turn. **Adaptive seeding**: real tools extracted → live tool demo; theme-only →
+  generate an on-brand UI piece; nothing found → self-aware tour of what was
+  found and what unlocks next.
+- `.vendo/` stays **committed** (only `data/` gitignored); the July-11 design
+  text saying "gitignored artifact" is superseded.
+
+### 2. Dev-mode model ladder
+Resolved at init; reused by the runtime in dev mode and by extraction `--deep`
+(one credential story). Order, with the wizard always stating what it picked:
+1. Explicit env key (ANTHROPIC / OPENAI / GOOGLE) — explicit beats implicit.
+2. Authed **Claude Code session** (proceeding as-approved per Yousef; consent asked before use).
+3. Authed **Codex session** (officially sanctioned by OpenAI).
+4. **`vendo cloud login` + free starter allowance** — browser OAuth, console
+   mints a metered dev-mode key, the wizard writes `.env.local` itself. The dev
+   never pastes a key at any rung.
+5. Nothing available → honest 503 with exact instructions (today's behavior).
+
+Production deploys always require a real server-side key; init next-steps and
+doctor both say so explicitly.
+
+**Spike (timeboxed, before wave 2 commits):** Agent SDK / Codex app-server as
+persistent-process ai-SDK providers with Vendo's host tools bridged via
+in-process MCP and consent routed through the permission callback — must
+preserve Vendo's approval semantics and interactive latency. Fallback if the
+spike fails: CLI rungs power a tools-free first turn (on-brand UI generation);
+full tool support lights up on key rungs.
+
+### 3. Agent surfaces
+- **install.md** served at a stable URL (vendo.run/install.md + docs-site page):
+  single canonical staged playbook (base install → review/remix → block
+  unlocks). The 3-line paste prompt points here.
+- **llms.txt + per-page .md** on the docs site.
+- **Vendo setup skill**: shipped inside the npm tarball; init offers (consent)
+  to write it into the host repo's `.claude/skills/`; also published to
+  skills.sh (`npx skills add vendo`).
+- **Machine-readable CLI**: `doctor --json`, `sync --json`, and `init --agent`
+  enriched to include extracted tools + risk recommendations.
+
+### 4. npm artifact (wave 1, before everything)
+Publish the 0.3.0 block set + `@vendoai/vendo` + `vendoai` alias; deprecate the
+eleven stale 0.1.0 packages with pointers; real READMEs in the tarballs;
+eliminate the ghost-dep / floating-`latest`-pin class of generated-file bugs;
+fix doc/CLI drift (question counts, undocumented flags).
+
+### 5. Doctor v2
+Keep static checks + /status probe. Add: **one real model turn** printed in the
+terminal (exit 0 = a user would have gotten an answer), `--json`,
+VENDO_API_KEY validation + display of what cloud unlocks, and a consent-gated
+offer to start the dev server when nothing is listening.
+
+### 6. Cloud in init
+Detect + validate VENDO_API_KEY when present (state what it unlocks; one calm
+line when absent). Offer `vendo cloud login` inline. Starter-allowance minting
+(console-side endpoint + key semantics in vendo-web) is **built by this
+project**; the Cloud console project inherits it.
+
+### 7. Quality bar
+All captured against the **published** package, real screen captures:
+- Fresh Next starter GIF (install → init → doctor → browser first turn).
+- De-wired Maple clone GIF (extraction + on-brand theming wow).
+- One corpus repo run (honest real-app proof).
+- Agent-driven install GIF (Claude Code + paste prompt completing the install).
+- **CI clean-room guard**: recurring job installing the published package into a
+  fresh app, running init + doctor + one real turn; fails loudly on npm-vs-main
+  drift.
+
+### 8. Execution
+Five waves in this session, orchestrated here; codex sol executes (Opus 4.8
+only when sol is blocked):
+1. Publish 0.3.0 + npm hygiene.
+2. Model ladder + runtime dev-mode + init-ends-in-product (spike first).
+3. Doctor v2 + cloud-in-init (incl. console allowance pieces).
+4. Agent surfaces (install.md, llms.txt, skill, --json).
+5. Demos, GIFs, CI guard.
+
+Anthropic partner approval: not pursued now; proceeding as-approved (Yousef's
+call, risk flagged and accepted in session).

--- a/packages/actions/README.md
+++ b/packages/actions/README.md
@@ -1,30 +1,8 @@
 # @vendoai/actions
 
-Every API becomes agent tools, executed as the signed-in user. Contract: `docs/contracts/04-actions.md` (FROZEN). Depends on `@vendoai/core` only.
+Turns host APIs into agent tools that execute as the signed-in user. It owns
+deterministic OpenAPI and route extraction, `.vendo` tool metadata, connectors,
+and the runtime action registry.
 
-Two halves:
-
-- **Sync (build step)** — `vendoSync({ root, out?, strict? })` extracts tools (OpenAPI spec if present, plus a Next.js route scan; the spec wins on overlapping method+path) into `.vendo/tools.json` (`vendo/tools@1`), respects human-written `.vendo/overrides.json` (`vendo/overrides@1`) forever, captures remixable component baselines into `.vendo/remixable/<slot>.json`, and reports added/removed/changed tools, breaking changes, and pins. Extraction is fail-closed: unclassifiable routes are emitted `disabled: true` with a note, route-scanned tools are never labeled `read`, and `critical` is only ever set by overrides.
-- **Runtime** — `createActions({ dir | tools, connectors, actAs, baseUrl, fetch })` returns an `ActionsRegistry` (a core `ToolRegistry` plus `add()`). Present-mode calls forward the inbound session's auth material (`ctx.requestHeaders`) on a same-origin fetch; away-mode calls require the host `actAs` seam and a captured grant. Connectors (`composioConnector`, `mcpConnector`) re-describe external tools through the same descriptor shape.
-
-## Contract judgment calls (flagged for cross-block review)
-
-- **Away-mode grant channel**: `ToolRegistry.execute(call, ctx)` has no grant parameter, but `actAs(principal, grant)` needs the matched grant. Convention: the guard binding (the only sanctioned caller, 05 §2) attaches it as `ctx.grant` — see the exported `ActionsRunContext` type. Away calls without a grant return a `validation` error outcome.
-- **`OpenApiBinding.method`/`path`**: the contract names `operationId` + `baseUrl`; we additionally persist `method` and `path` so the runtime can execute without re-reading the spec. Additive fields; consumers ignore unknown keys (01 §15).
-- **`SyncReport.warnings`**: additive field carrying fail-soft extraction warnings (the contract's "default fail-soft warn" channel).
-- **`vendoSync` strict mode** throws `VendoError("conflict", …, { breaking, report })` *after* writing artifacts; the umbrella bin maps it to exit 2 (09 §5).
-- **`tools.json` stays pure extraction output**; overrides are merged at read time (sync report + runtime), so re-extraction never touches human answers and `descriptorHash` is always computed post-merge.
-- **`createActions.dir`** accepts either the host root (reads `<dir>/.vendo/…`) or a `.vendo` directory itself.
-- **Overrides schema is strict** (unknown fields rejected): it is a hand-written file, and a typo silently ignored would be a policy hole.
-
-## Testing
-
-`pnpm --filter @vendoai/actions test`. The extraction and execution e2e suites run against `fixtures/host-app` (deterministic, seeded); the execution suite boots the fixture's real Next server and signs in for a session cookie. Connector suites use in-process stub servers. The core conformance kit (`@vendoai/core/conformance`) runs against the registry.
-
-## Known v0 limitations
-
-- Route discovery uses comment-stripped regex and structural scanning, not a TypeScript/JavaScript AST.
-- Input narrowing detection is top-level only. It covers required/property/type changes, enum reduction or addition, and tightening `additionalProperties` from absent/`true` to `false`; it is not a recursive JSON-Schema compatibility checker.
-- OpenAPI inputs include path and query parameters only (plus parameters with no `in` value). Header/cookie transport and `style`/`explode` serialization are not supported.
-- Catch-all route parameters are represented as one required argument whose value may be a string or an array; array elements become individually encoded path segments.
-- `composioConnector` accepts an additive `baseUrl` configuration seam for deterministic stub and self-hosted endpoint use.
+Read [Connect API tools](https://docs.vendo.run/connect/api-tools) and
+[Tools and safety](https://docs.vendo.run/concepts/tools-and-safety).

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -34,7 +34,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -1,0 +1,7 @@
+# @vendoai/agent
+
+Runs Vendo's streaming, tool-calling conversation loop against any AI SDK
+`LanguageModel`, with persisted threads and guard-bound tools.
+
+Read [Prompts](https://docs.vendo.run/concepts/prompts) and the
+[architecture overview](https://docs.vendo.run/concepts/architecture).

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -34,7 +34,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/apps/README.md
+++ b/packages/apps/README.md
@@ -1,28 +1,6 @@
 # @vendoai/apps
 
-`@vendoai/apps` owns Vendo app documents, their instant tree surfaces, and sandbox-backed server execution.
+Owns Vendo app documents, instant tree rendering, app generation, sandbox
+adapters, snapshots, and the guarded host-tool proxy used by app machines.
 
-## Machine tool proxy
-
-Pass `proxyUrl` to `createApps()` and mount `runtime.proxy.handler(request)` at that URL. New machines receive the URL as `VENDO_PROXY_URL`; when `proxyUrl` is omitted, machines run without host-tool access.
-
-All proxy routes require `Authorization: Bearer $VENDO_RUN_TOKEN`. Mutation routes also require `content-type: application/json`.
-
-- `POST /tools/<name>` with `{ "args": ... }` calls the guard-bound host tool registry and returns its `ToolOutcome` unchanged, including `pending-approval`.
-- `GET /state` reads the `vendo.state` value scoped to the token's app and user.
-- `PUT /state` replaces that scoped state with the request's JSON body.
-
-Run tokens are short-lived (15-minute TTL) and scoped to one app, user subject, presence mode, and run id.
-
-## Secrets
-
-Declared secrets never enter a machine as values: each is injected as an opaque `vendo-secret:<name>:<nonce>` handle, so app code (`process.env.STRIPE_KEY`) only ever holds the handle. This package ships `substituteSecretHandles()` — the pure, allowlist-gated substitution the egress boundary uses to swap a handle for its real value only toward an app's allowlisted hosts.
-
-**v0 limitation (flagged):** wiring that substitution into the actual outbound path requires an in-sandbox egress proxy — the frozen `SandboxMachine.request()` seam models host→machine (inbound) traffic, not machine→internet (outbound). So in v0 the handle injection (the security property: values never reach app code or exports) is complete, but a handle transiting toward an allowlisted host is not yet auto-resolved. Don't rely on secret handles resolving until the in-sandbox proxy lands.
-
-## Sandbox adapters and snapshots
-
-`@vendoai/apps/e2b` and `@vendoai/apps/modal` implement the `SandboxAdapter` seam. Two v0 limitations, both provider-inherent and flagged in the adapter source:
-
-- **Run-env at resume**: the frozen `resume(ref)` seam takes no environment, so a machine woken from a long-slept snapshot keeps its snapshot-time `VENDO_RUN_TOKEN` (which may have expired) and secret nonces. Refreshing per-run auth on resume needs an additive seam extension. Present-mode and short runs are unaffected.
-- **e2b snapshots are single-instance**: e2b pause/resume is one recoverable state (resume unpauses the same sandbox). A non-destructive read-for-export needs adapter-side clone support e2b doesn't expose in v0, so exporting a server-backed app is a Modal-first path (its image snapshots are non-destructive); the in-process fake adapter proves the export/import contract. **Modal** JS snapshots are disk-only (restore builds a new machine and re-runs the start command; images expire in ~30 days), and restore-options currently live per-adapter-instance — durable cross-process restore is a fast-follow.
+Read [Generated UI](https://docs.vendo.run/concepts/generated-ui).

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -45,7 +45,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/automations/README.md
+++ b/packages/automations/README.md
@@ -1,6 +1,7 @@
 # @vendoai/automations
 
-Apps that run on schedules, host events, or verified external webhooks while the user is away. The package supports deterministic step pipelines, agentic runner reports, enable-time authority capture, approval-backed step resume, and run observability.
+Runs Vendo apps on schedules, host events, and verified webhooks while a user is
+away, with captured authority, approval-aware execution, and run history.
 
 The unit suites cover trigger dispatch, capture, parking and resume, lifecycle controls, resource bounds, and run status behavior. The full-stack e2e suites compose the real store, guard, actions, apps runtime, fixture host, and both scripted and opt-in live agentic legs.
 
@@ -11,3 +12,5 @@ The unit suites cover trigger dispatch, capture, parking and resume, lifecycle c
 - In-process agentic runs are aborted by `runs.stop()` through the optional runner signal. Cross-instance stop remains best-effort through the persisted stopped-row check.
 - Agentic enable-capture proposes the full bound surface until a proposal seat exists; approve selectively.
 - JSONata evaluation is not CPU-timeboxed in v0.
+
+Read [Schedulers and webhooks](https://docs.vendo.run/deploy/scheduler-and-webhooks).

--- a/packages/automations/package.json
+++ b/packages/automations/package.json
@@ -33,7 +33,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,6 @@
+# @vendoai/core
+
+Defines the shared Vendo types, schemas, format constants, validators, hashes,
+and conformance seams used across the block set.
+
+Read the [architecture overview](https://docs.vendo.run/concepts/architecture).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/guard/README.md
+++ b/packages/guard/README.md
@@ -1,0 +1,6 @@
+# @vendoai/guard
+
+Applies policy, approvals, grants, audit, breakers, and safety checks at Vendo's
+single tool-execution choke point.
+
+Read [Tools and safety](https://docs.vendo.run/concepts/tools-and-safety).

--- a/packages/guard/package.json
+++ b/packages/guard/package.json
@@ -34,7 +34,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,6 +4,8 @@
 
 The umbrella package wires it behind the one-flag setup, `createVendo({ mcp: true })`, so the same tool registry, guard policy, approvals, and audit trail apply to MCP calls as to in-product calls.
 
+Read [MCP](https://docs.vendo.run/capabilities/mcp).
+
 The MCP Apps tree renderer is a committed, prebuilt HTML artifact. This keeps `@vendoai/mcp` dependent on core rather than UI at runtime. Regenerate the artifact from its owner with:
 
 ```sh

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -34,7 +34,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -2,6 +2,8 @@
 
 `@vendoai/store` implements the `@vendoai/core` persistence seams with one Postgres schema. It uses PGlite for a zero-config local database and the same schema on a hosted Postgres service.
 
+Read [Persistence](https://docs.vendo.run/deploy/persistence).
+
 ```ts
 import { createStore } from "@vendoai/store";
 

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -35,7 +35,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,7 @@
+# @vendoai/ui
+
+Provides Vendo's headless React hooks, optional chrome, tree renderer, generated
+component jail, theming, and voice surfaces.
+
+Read [Generated UI](https://docs.vendo.run/concepts/generated-ui) and
+[Theming](https://docs.vendo.run/connect/theming).

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -46,7 +46,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build:jail": "node scripts/build-jail-runtime.mjs",

--- a/packages/vendo-telemetry/README.md
+++ b/packages/vendo-telemetry/README.md
@@ -1,0 +1,7 @@
+# @vendoai/telemetry
+
+Provides anonymous, opt-out build and development telemetry for Vendo tooling.
+It is disabled by CI, production runtime, `DO_NOT_TRACK`, or
+`VENDO_TELEMETRY_DISABLED=1`.
+
+Read [Telemetry](https://docs.vendo.run/deploy/telemetry).

--- a/packages/vendo-telemetry/package.json
+++ b/packages/vendo-telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vendoai/telemetry",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Anonymous, opt-out telemetry for Vendo tooling.",
   "keywords": [
     "ai",
@@ -31,7 +31,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/vendo/README.md
+++ b/packages/vendo/README.md
@@ -1,0 +1,21 @@
+# @vendoai/vendo
+
+Vendo puts an agent inside your product. Customers can build views, act through
+your APIs, and automate work inside your brand and guardrails.
+
+```bash
+npm install @vendoai/vendo
+npx vendo init
+```
+
+This is the default composition: the public wire handler, React provider,
+policy-bound agent and app blocks, persistence, MCP door, and the `vendo` CLI.
+Install individual `@vendoai/*` blocks only when you want to compose Vendo
+yourself.
+
+Vendo extracts host APIs as signed-in-user tools, renders theme-driven React
+surfaces, applies approvals and audit at one execution choke point, and uses
+PGlite locally with the same schema on production Postgres.
+
+Read the [quickstart](https://docs.vendo.run/quickstart) and
+[CLI reference](https://docs.vendo.run/reference/cli).

--- a/packages/vendo/package.json
+++ b/packages/vendo/package.json
@@ -46,7 +46,8 @@
   },
   "files": [
     "dist",
-    "bin"
+    "bin",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/vendo/src/cli.test.ts
+++ b/packages/vendo/src/cli.test.ts
@@ -2,6 +2,20 @@ import { describe, expect, it, vi } from "vitest";
 import { main } from "./cli.js";
 
 describe("vendo CLI commands", () => {
+  it("keeps help aligned with the four-question init and its non-interactive flags", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    expect(await main(["--help"])).toBe(0);
+    const help = log.mock.calls.flat().join("\n");
+    expect(help).toContain("four questions");
+    expect(help).toContain("--yes");
+    expect(help).toContain("--force");
+    expect(help).toContain("--model-import <specifier>");
+    expect(help).toContain("--brief <text>");
+
+    log.mockRestore();
+  });
+
   it("exposes init, doctor, and sync only", async () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
     expect(await main(["refresh"])).toBe(1);

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -7,7 +7,27 @@ import { runMcp } from "./cli/mcp/index.js";
 import { CLI_VERSION } from "./cli/shared.js";
 import { runSync } from "./cli/sync.js";
 
-const HELP = `vendo — default Vendo composition\n\nUsage: vendo <command> [dir] [options]\n\nCommands:\n  init [dir]      Scan, interview, write .vendo, and propose handler + VendoRoot wiring\n  doctor [dir]    Verify wiring and make one live /status round-trip\n  sync [dir]      Extract tools and remix baselines (use --strict for CI)\n  mcp <command>   Generate MCP registry discovery and domain-verification files\n  cloud <command> Use the public Vendo Cloud API\n\nOptions:\n  --agent         Init only: print a read-only plan with at most three questions\n  --yes           Init only: approve the displayed code changes\n  --force         Init/server-json: overwrite owned or generated files\n  --model-import  Init only: module exporting the host's ai-SDK model\n  --url           Doctor/server-json: mounted wire base or public MCP URL\n  --strict        Sync only: exit 2 on breaking changes\n  --version       Print the version\n`;
+const HELP = `vendo — default Vendo composition
+
+Usage: vendo <command> [dir] [options]
+
+Commands:
+  init [dir]      Scan, interview, write .vendo, and propose handler + VendoRoot wiring
+  doctor [dir]    Verify wiring and make one live /status round-trip
+  sync [dir]      Extract tools and remix baselines (use --strict for CI)
+  mcp <command>   Generate MCP registry discovery and domain-verification files
+  cloud <command> Use the public Vendo Cloud API
+
+Options:
+  --agent                    Init only: print a read-only plan with four questions
+  --yes                      Init only: skip the interview and approve displayed changes
+  --force                    Init/server-json: overwrite owned or generated files
+  --model-import <specifier> Init only: module exporting the host's ai-SDK model
+  --brief <text>             Init only: product brief used for non-interactive setup
+  --url <url>                Doctor/server-json: mounted wire base or public MCP URL
+  --strict                   Sync only: exit 2 on breaking changes
+  --version                  Print the version
+`;
 
 function option(args: string[], name: string): string | undefined {
   const exact = args.indexOf(name);

--- a/packages/vendoai/README.md
+++ b/packages/vendoai/README.md
@@ -1,0 +1,16 @@
+# vendoai
+
+Vendo puts an agent inside your product. Customers can build views, act through
+your APIs, and automate work inside your brand and guardrails.
+
+```bash
+npm install vendoai
+npx vendo init
+```
+
+`vendoai` is the unscoped compatibility alias for `@vendoai/vendo`. It exports
+the same default composition and installs the same `vendo` CLI; new projects can
+use either package name.
+
+Read the [quickstart](https://docs.vendo.run/quickstart) and
+[CLI reference](https://docs.vendo.run/reference/cli).

--- a/packages/vendoai/package.json
+++ b/packages/vendoai/package.json
@@ -46,7 +46,8 @@
   },
   "files": [
     "dist",
-    "bin"
+    "bin",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
## What changed and why

- Prepares the complete public Vendo package set for a coordinated `0.3.0` release: all 12 publishable packages are version-aligned, ship intentional package READMEs, and keep complete publish artifacts.
- Fixes the local-tarball injector so `@vendoai/mcp` cannot fall through to the unpublished registry package, with regression coverage for the exact 12-package pack set.
- Aligns install and CLI guidance with the shipped command surface, including `init --yes/--force/--model-import/--brief`, `sync [dir]`, and the actual three-question wizard.
- Adds `PUBLISH.md`, the exact publish/deprecation/propagation/clean-room runbook for the npm release owner.

This is Wave 1 of the Install DX plan: make the product described by the repository genuinely publish-ready and remove the npm/docs drift that blocks every later onboarding improvement.

## Local-tarball rehearsal and friction log

Fresh rehearsal on commit `90bbe4c4` used `/private/tmp/vendo-install-dx-wave1.wl55Og` and `/private/tmp/vendo-wave1-rehearsal.log`:

- Packed all 12 public workspaces; every tarball was `0.3.0`, included `README.md`, and contained no `workspace:` references.
- Verified `vendoai` rewrites its `@vendoai/vendo` dependency to concrete `0.3.0`.
- Created a fresh Next.js `16.2.9` npm app, installed the 12 local tarballs plus the AI SDK v6 Anthropic provider pair printed by init, and ran `vendo init --yes`.
- The generated app passed `next build`; both declared bin entry points printed `0.3.0`; `.`, `./server`, and `./react` imported through both `@vendoai/vendo` and `vendoai`.
- A live `/api/vendo/status` request returned version `0.3.0` with posture `unconfigured`, and `vendo doctor` exited 0 after the live round trip.

Friction found and handled in the branch: the injector previously omitted MCP; telemetry was the lone `0.2.0` publishable block; init intentionally requires the printed provider pair for the starter model module. npm also reported two moderate transitive audit findings plus allow-scripts notices for `sharp` and `unrs-resolver`; neither blocked install, init, build, exports, boot, or doctor.

## Verification

- `pnpm build` — pass (`18/18` Turbo tasks)
- `pnpm typecheck` — pass (`34/34` Turbo tasks)
- `pnpm lint` — pass (`dependency-guard: OK`, `2/2` lint tasks)
- `pnpm --filter @vendoai/store test` — package-scoped retry was still overwhelmed by machine saturation: host load averages exceeded 210 with 27+ unrelated Vitest processes from other worktrees; the run completed with 109 passing, 1 skipped, and 16 timeout-only failures (the durability child marker plus PGlite conformance operations). No assertion, skip, or timeout was changed.
- Full root `pnpm test` — not repeated after the coordinator's explicit saturation ruling; prior attempts flaked on the same `@vendoai/store` child-spawn/durability path. GitHub CI is the merge arbiter for the suite on a clean runner.

## Publish ownership

`PUBLISH.md` is Yousef's TTY-only runbook. npm publish and deprecation require passkey/WebAuthn 2FA; nobody else and no sandbox automation can publish this release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the public Vendo package set for the 0.3.0 release and aligns installs with the docs. Adds a TTY-only publish runbook, real per-package READMEs on npm, and synced CLI/docs. Wave 1 of the Install DX project.

- New Features
  - Version-align all 12 publishable packages to `0.3.0`; include `README.md` in published files so npm pages show real READMEs (adds READMEs for `@vendoai/vendo`, `vendoai`, and each `@vendoai/*` block).
  - Add `PUBLISH.md`: exact publish command (with release-age override), 0.1.0 deprecations, registry propagation checks, and clean-room verification steps.
  - Sync CLI and docs: `vendo init [dir]`, `doctor [dir]`, `sync [dir]`; four-question init with `--yes`, `--force`, `--model-import`, `--brief`, and `--agent`; non-interactive example added; root README updated; tests assert the four-question help text. Add Install DX design spec and 5‑wave implementation plan.

- Bug Fixes
  - Local-tarball injector now includes `@vendoai/mcp`; pack-once regression covers all 12 tarballs and asserts `@vendoai/telemetry` at `0.3.0`.
  - Bump `@vendoai/telemetry` to `0.3.0` to keep the block set version-aligned.

<sup>Written for commit c07a464f68153498a666099c919f25bdbda41e53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

