### PR TITLE
fix(apps): vendo_apps_edit blank-iframe + tree-ops fast-path hardening (ENG-245)

### DIFF
--- a/packages/apps/src/agent-tools.test.ts
+++ b/packages/apps/src/agent-tools.test.ts
@@ -70,6 +70,7 @@ describe("apps agent tools", () => {
     expect(descriptors.map((descriptor) => descriptor.risk)).toEqual([
       "read", "write", "read", "read", "write", "write",
     ]);
+    expect(descriptors.find(({ name }) => name === "vendo_apps_edit")?.description).toMatch(/retry.*same app/i);
   });
 
   it("classifies only provable tree edits as read-class", async () => {
@@ -153,6 +154,39 @@ describe("apps agent tools", () => {
       tool: "vendo_apps_edit",
       args: { appId: "app_foreign", instruction: "Make the heading blue" },
     }, ctx)).resolves.toBe("write");
+  });
+
+  it("surfaces a structured retryable edit failure instead of implying the app changed", async () => {
+    const broken = JSON.stringify({
+      ops: [{ op: "set-prop", nodeId: "missing", prop: "value", value: 1 }],
+    });
+    const runtime = createApps({
+      store: memoryStore(),
+      guard: guardFixture(),
+      tools: hostTools,
+      catalog: [],
+      model: scriptedLanguageModel(generated, broken),
+    });
+    const created = await runtime.create({ prompt: "Build a dashboard" }, ctx);
+
+    const outcome = await runtime.agentTools().execute({
+      id: "call_edit_failure",
+      tool: "vendo_apps_edit",
+      args: { appId: created.id, instruction: "Change a missing card" },
+    }, ctx);
+
+    expect(outcome).toMatchObject({
+      status: "ok",
+      output: {
+        app: created,
+        failure: {
+          code: "edit-rejected",
+          retryable: true,
+          message: expect.stringMatching(/same app/i),
+        },
+        issues: expect.arrayContaining([expect.stringContaining("missing")]),
+      },
+    });
   });
 
   it("creates and opens an app through the guard-bound fixture", async () => {

--- a/packages/apps/src/agent-tools.ts
+++ b/packages/apps/src/agent-tools.ts
@@ -35,7 +35,7 @@ const descriptors: ToolDescriptor[] = [
   },
   {
     name: "vendo_apps_edit",
-    description: "Edit an existing Vendo app with one natural-language instruction.",
+    description: "Edit an existing Vendo app with one natural-language instruction. If the result has failure.retryable=true, retry vendo_apps_edit on the same appId with a narrower instruction; do not rebuild it with vendo_apps_create.",
     inputSchema: {
       $schema: DRAFT_2020_12,
       type: "object",
@@ -198,6 +198,7 @@ export const createAgentTools = (
           output: {
             app: result.app,
             ...(result.issues === undefined ? {} : { issues: result.issues }),
+            ...(result.failure === undefined ? {} : { failure: result.failure }),
           } as unknown as Json,
         };
       }

--- a/packages/apps/src/engine.test.ts
+++ b/packages/apps/src/engine.test.ts
@@ -15,6 +15,7 @@ import {
   memoryStore,
   seedAppRow,
   scriptedLanguageModel,
+  type ScriptedModelCall,
 } from "./testing/index.js";
 import { modelEngine } from "./engine.js";
 
@@ -83,6 +84,29 @@ const putApp = async (
 ): Promise<void> => {
   await seedAppRow(store, app, ctx.principal.subject);
 };
+
+const promptText = (call: ScriptedModelCall): string => call.prompt.map((message) => {
+  if (typeof message.content === "string") return message.content;
+  return message.content.map((part) => part.text ?? "").join("");
+}).join("\n");
+
+const generatedTreeApp = (): AppDocument => ({
+  format: "vendo/app@1",
+  id: "app_generated_edit",
+  name: "Generated dashboard",
+  ui: "tree",
+  tree: {
+    formatVersion: "vendo-genui/v1",
+    root: "root",
+    nodes: [
+      { id: "root", component: "Stack", source: "prewired", children: ["existing"] },
+      { id: "existing", component: "ExistingPanel", source: "generated" },
+    ],
+  },
+  components: {
+    ExistingPanel: "export default function ExistingPanel() { return <section>Existing</section>; }",
+  },
+});
 
 describe("generation engine through createApps", () => {
   it("fails closed when a tree-classified edit unexpectedly yields server code", async () => {
@@ -344,6 +368,238 @@ describe("generation engine through createApps", () => {
     expect(result.issues).toEqual(expect.arrayContaining([expect.stringContaining("missing") ]));
     expect(await runtime.get(original.id, ctx)).toEqual(original);
     expect(await runtime.history(original.id).list()).toEqual([]);
+  });
+
+  it("retries a failed tree-edit plan with cumulative, indexed repair feedback", async () => {
+    const store = memoryStore();
+    const original = generatedTreeApp();
+    await putApp(store, original);
+    const duplicateRoot = JSON.stringify({
+      ops: [{
+        op: "add-node",
+        node: { id: "root", component: "Stack", source: "prewired" },
+      }],
+    });
+    const malformedComponent = JSON.stringify({
+      ops: [{ op: "add-component", component: { name: "PeriodFilter", source: "export default null" } }],
+    });
+    const repaired = JSON.stringify({
+      ops: [
+        {
+          op: "add-component",
+          name: "PeriodFilter",
+          source: "export default function PeriodFilter() { return <select><option>All time</option></select>; }",
+        },
+        {
+          op: "add-node",
+          node: { id: "filter", component: "PeriodFilter", source: "generated" },
+          parentId: "root",
+          index: 1,
+        },
+      ],
+    });
+    const runtime = createApps({
+      store,
+      guard: guardFixture(),
+      tools,
+      catalog: [],
+      model: scriptedLanguageModel(
+        duplicateRoot,
+        malformedComponent,
+        (call) => {
+          const prompt = promptText(call).replaceAll('\\"', '"');
+          expect(prompt).toContain('tree op[0] add-node failed: node "root" already exists');
+          expect(prompt).toContain("tree op[0] add-component failed: requires name and source strings");
+          expect(prompt).toContain('"index"');
+          expect(prompt).toContain('"nodeId"');
+          return repaired;
+        },
+      ),
+    });
+
+    const result = await runtime.edit(original.id, "Add a filter dropdown", ctx);
+
+    expect(result.failure).toBeUndefined();
+    expect(result.issues).toBeUndefined();
+    expect(result.app.tree?.nodes.find(({ id }) => id === "root")?.children).toEqual(["existing", "filter"]);
+    expect(result.app.components).toMatchObject({
+      ExistingPanel: original.components?.ExistingPanel,
+      PeriodFilter: expect.stringContaining("<select>"),
+    });
+  });
+
+  it("rejects an edit that leaves the rooted view empty and returns a retryable failure", async () => {
+    const store = memoryStore();
+    const original = generatedTreeApp();
+    await putApp(store, original);
+    const removeOnlyContent = JSON.stringify({
+      ops: [{ op: "remove-node", nodeId: "existing" }],
+    });
+    const runtime = createApps({
+      store,
+      guard: guardFixture(),
+      tools,
+      catalog: [],
+      model: scriptedLanguageModel(removeOnlyContent),
+    });
+
+    const result = await runtime.edit(original.id, "Remove the only visible panel", ctx);
+
+    expect(result.failure).toMatchObject({ code: "edit-rejected", retryable: true });
+    expect(result.issues).toEqual(expect.arrayContaining([expect.stringContaining("empty")]));
+    expect(result.app).toEqual(original);
+    expect(await runtime.get(original.id, ctx)).toEqual(original);
+  });
+
+  it("rejects unsupported position aliases instead of silently misplacing an added node", async () => {
+    const store = memoryStore();
+    const original = generatedTreeApp();
+    await putApp(store, original);
+    const source = "export default function PeriodFilter() { return <select><option>All</option></select>; }";
+    const runtime = createApps({
+      store,
+      guard: guardFixture(),
+      tools,
+      catalog: [],
+      model: scriptedLanguageModel(
+        JSON.stringify({
+          ops: [
+            { op: "add-component", name: "PeriodFilter", source },
+            {
+              op: "add-node",
+              node: { id: "filter", component: "PeriodFilter", source: "generated" },
+              parentId: "root",
+              position: 0,
+            },
+          ],
+        }),
+        (call) => {
+          expect(promptText(call).replaceAll('\\"', '"')).toContain('tree op[1] add-node failed: unsupported field "position"');
+          return JSON.stringify({
+            ops: [
+              { op: "add-component", name: "PeriodFilter", source },
+              {
+                op: "add-node",
+                node: { id: "filter", component: "PeriodFilter", source: "generated" },
+                parentId: "root",
+                index: 0,
+              },
+            ],
+          });
+        },
+      ),
+    });
+
+    const result = await runtime.edit(original.id, "Put a filter before the dashboard", ctx);
+
+    expect(result.failure).toBeUndefined();
+    expect(result.app.tree?.nodes.find(({ id }) => id === "root")?.children).toEqual(["filter", "existing"]);
+  });
+
+  it("repairs parent placement fields nested inside add-node instead of persisting an orphan", async () => {
+    const store = memoryStore();
+    const original = generatedTreeApp();
+    await putApp(store, original);
+    const source = "export default function PeriodFilter() { return <select><option>All</option></select>; }";
+    const runtime = createApps({
+      store,
+      guard: guardFixture(),
+      tools,
+      catalog: [],
+      model: scriptedLanguageModel(
+        JSON.stringify({
+          ops: [
+            { op: "add-component", name: "PeriodFilter", source },
+            {
+              op: "add-node",
+              node: {
+                id: "filter",
+                component: "PeriodFilter",
+                source: "generated",
+                parentId: "root",
+                position: 0,
+              },
+            },
+          ],
+        }),
+        (call) => {
+          const prompt = promptText(call).replaceAll('\\"', '"');
+          expect(prompt).toContain('tree op[1] add-node failed: node has unsupported fields "parentId", "position"');
+          expect(prompt).toContain("place parentId and index on the add-node operation");
+          return JSON.stringify({
+            ops: [
+              { op: "add-component", name: "PeriodFilter", source },
+              {
+                op: "add-node",
+                node: { id: "filter", component: "PeriodFilter", source: "generated" },
+                parentId: "root",
+                index: 0,
+              },
+            ],
+          });
+        },
+      ),
+    });
+
+    const result = await runtime.edit(original.id, "Put a filter before the dashboard", ctx);
+
+    expect(result.failure).toBeUndefined();
+    expect(result.app.tree?.nodes.find(({ id }) => id === "root")?.children).toEqual(["filter", "existing"]);
+    expect(result.app.tree?.nodes.filter(({ id }) => id === "filter")).toHaveLength(1);
+  });
+
+  it("rejects a move index that leaves a gap instead of silently appending the node", async () => {
+    const store = memoryStore();
+    const original = generatedTreeApp();
+    await putApp(store, original);
+    const runtime = createApps({
+      store,
+      guard: guardFixture(),
+      tools,
+      catalog: [],
+      model: scriptedLanguageModel(
+        JSON.stringify({
+          ops: [{ op: "move-node", nodeId: "existing", parentId: "root", index: 4 }],
+        }),
+        (call) => {
+          expect(promptText(call).replaceAll('\\"', '"')).toContain(
+            'tree op[0] move-node failed: index 4 leaves a gap in parent "root" children (length 0)',
+          );
+          return JSON.stringify({
+            ops: [{ op: "move-node", nodeId: "existing", parentId: "root", index: 0 }],
+          });
+        },
+      ),
+    });
+
+    const result = await runtime.edit(original.id, "Keep the panel first", ctx);
+
+    expect(result.failure).toBeUndefined();
+    expect(result.app.tree?.nodes.find(({ id }) => id === "root")?.children).toEqual(["existing"]);
+  });
+
+  it("preserves existing generated component sources across unrelated tree ops", async () => {
+    const store = memoryStore();
+    const original = generatedTreeApp();
+    await putApp(store, original);
+    const runtime = createApps({
+      store,
+      guard: guardFixture(),
+      tools,
+      catalog: [],
+      model: scriptedLanguageModel(JSON.stringify({
+        ops: [{ op: "set-prop", nodeId: "existing", prop: "tone", value: "green" }],
+      })),
+    });
+
+    const result = await runtime.edit(original.id, "Make the numbers green", ctx);
+
+    expect(result.app.components).toEqual(original.components);
+    await expect(runtime.open(original.id, ctx)).resolves.toMatchObject({
+      kind: "tree",
+      payload: { components: original.components },
+      components: original.components,
+    });
   });
 
   it("rejects moving a node under its own descendant without changing the document", async () => {

--- a/packages/apps/src/engine.ts
+++ b/packages/apps/src/engine.ts
@@ -353,6 +353,10 @@ const createDocument = (shape: GeneratedShape): GeneratedAppDocument => ({
 
 type TreeOp = Record<string, unknown> & { op: string };
 
+const distinctIssues = (current: string[], next: string[]): string[] => [
+  ...new Set([...current, ...next]),
+];
+
 const removeChildReference = (tree: Tree, nodeId: string): void => {
   for (const node of tree.nodes) {
     if (node.children !== undefined) node.children = node.children.filter((child) => child !== nodeId);
@@ -367,6 +371,9 @@ const insertChild = (parent: TreeNode, nodeId: string, index: unknown): void => 
   children.splice(position, 0, nodeId);
   parent.children = children;
 };
+
+const validOptionalIndex = (value: unknown): boolean => value === undefined
+  || (typeof value === "number" && Number.isInteger(value) && value >= 0);
 
 const reachesNode = (tree: Tree, startId: string, targetId: string): boolean => {
   const pending = [startId];
@@ -391,52 +398,110 @@ const applyTreeOps = (
     return { issues: ["tree ops require a vendo-genui/v1 app"] };
   }
   const tree = app.tree as unknown as Tree;
-  const issue = (message: string): { issues: string[] } => ({ issues: [message] });
-  for (const operation of ops) {
+  const issue = (index: number, operation: TreeOp, message: string): { issues: string[] } => ({
+    issues: [`tree op[${index}] ${operation.op} failed: ${message}`],
+  });
+  const unsupportedFields = (
+    index: number,
+    operation: TreeOp,
+    allowed: string[],
+  ): { issues: string[] } | undefined => {
+    const unexpected = Object.keys(operation).filter((key) => !allowed.includes(key));
+    if (unexpected.length === 0) return undefined;
+    return issue(
+      index,
+      operation,
+      `unsupported ${unexpected.length === 1 ? "field" : "fields"} ${unexpected.map((key) => `"${key}"`).join(", ")}; allowed fields are ${allowed.map((key) => `"${key}"`).join(", ")}`,
+    );
+  };
+  for (const [index, operation] of ops.entries()) {
     switch (operation.op) {
       case "set-prop": {
         if (typeof operation.nodeId !== "string" || typeof operation.prop !== "string") {
-          return issue("set-prop requires nodeId and prop strings");
+          return issue(index, operation, `requires nodeId and prop strings; received fields: ${Object.keys(operation).join(", ")}`);
         }
+        const unsupported = unsupportedFields(index, operation, ["op", "nodeId", "prop", "value"]);
+        if (unsupported !== undefined) return unsupported;
         const node = tree.nodes.find(({ id }) => id === operation.nodeId);
-        if (node === undefined) return issue(`set-prop node "${operation.nodeId}" does not exist`);
+        if (node === undefined) return issue(index, operation, `node "${operation.nodeId}" does not exist`);
         node.props = { ...(node.props ?? {}), [operation.prop]: asJson(operation.value) };
         break;
       }
       case "add-node": {
-        if (!isRecord(operation.node)) return issue("add-node requires a node object");
-        const node = structuredClone(operation.node) as unknown as TreeNode;
-        if (typeof node.id !== "string") return issue("add-node node requires a string id");
-        if (tree.nodes.some(({ id }) => id === node.id)) return issue(`node "${node.id}" already exists`);
-        tree.nodes.push(node);
-        if (operation.parentId !== undefined) {
-          const parent = tree.nodes.find(({ id }) => id === operation.parentId);
-          if (parent === undefined) return issue(`add-node parent "${String(operation.parentId)}" does not exist`);
-          insertChild(parent, node.id, operation.index);
+        if (!isRecord(operation.node)) return issue(index, operation, "requires a node object");
+        const unsupported = unsupportedFields(index, operation, ["op", "node", "parentId", "index"]);
+        if (unsupported !== undefined) return unsupported;
+        const nodeFields = ["id", "component", "source", "props", "children"];
+        const unexpectedNodeFields = Object.keys(operation.node).filter((key) => !nodeFields.includes(key));
+        if (unexpectedNodeFields.length > 0) {
+          return issue(
+            index,
+            operation,
+            `node has unsupported ${unexpectedNodeFields.length === 1 ? "field" : "fields"} ${unexpectedNodeFields.map((key) => `"${key}"`).join(", ")}; allowed node fields are ${nodeFields.map((key) => `"${key}"`).join(", ")}; place parentId and index on the add-node operation`,
+          );
         }
+        const node = structuredClone(operation.node) as unknown as TreeNode;
+        if (typeof node.id !== "string" || node.id.trim() === "") {
+          return issue(index, operation, "node requires a non-empty string id");
+        }
+        if (typeof node.component !== "string" || node.component.trim() === "") {
+          return issue(index, operation, "node requires a non-empty string component");
+        }
+        if (node.source !== undefined && !["prewired", "host", "generated"].includes(node.source)) {
+          return issue(index, operation, 'node source must be "prewired", "host", or "generated" when present');
+        }
+        if (node.props !== undefined && !isRecord(node.props)) {
+          return issue(index, operation, "node props must be an object when present");
+        }
+        if (node.children !== undefined
+          && (!Array.isArray(node.children) || !node.children.every((child) => typeof child === "string"))) {
+          return issue(index, operation, "node children must be an array of node-id strings when present");
+        }
+        if (!validOptionalIndex(operation.index)) return issue(index, operation, "index must be a non-negative integer when present");
+        if (tree.nodes.some(({ id }) => id === node.id)) return issue(index, operation, `node "${node.id}" already exists`);
+        if (typeof operation.parentId !== "string" || operation.parentId.trim() === "") {
+          return issue(index, operation, "requires a non-empty parentId string so the added node is attached to the rooted view");
+        }
+        const parent = tree.nodes.find(({ id }) => id === operation.parentId);
+        if (parent === undefined) return issue(index, operation, `parent "${operation.parentId}" does not exist`);
+        const childCount = parent.children?.length ?? 0;
+        if (typeof operation.index === "number" && operation.index > childCount) {
+          return issue(index, operation, `index ${operation.index} leaves a gap in parent "${operation.parentId}" children (length ${childCount})`);
+        }
+        tree.nodes.push(node);
+        insertChild(parent, node.id, operation.index);
         break;
       }
       case "remove-node": {
-        if (typeof operation.nodeId !== "string") return issue("remove-node requires nodeId");
-        if (operation.nodeId === tree.root) return issue("remove-node cannot remove the tree root");
-        const index = tree.nodes.findIndex(({ id }) => id === operation.nodeId);
-        if (index === -1) return issue(`remove-node node "${operation.nodeId}" does not exist`);
-        tree.nodes.splice(index, 1);
+        if (typeof operation.nodeId !== "string") return issue(index, operation, "requires nodeId");
+        const unsupported = unsupportedFields(index, operation, ["op", "nodeId"]);
+        if (unsupported !== undefined) return unsupported;
+        if (operation.nodeId === tree.root) return issue(index, operation, "cannot remove the tree root");
+        const nodeIndex = tree.nodes.findIndex(({ id }) => id === operation.nodeId);
+        if (nodeIndex === -1) return issue(index, operation, `node "${operation.nodeId}" does not exist`);
+        tree.nodes.splice(nodeIndex, 1);
         removeChildReference(tree, operation.nodeId);
         break;
       }
       case "move-node": {
         if (typeof operation.nodeId !== "string" || typeof operation.parentId !== "string") {
-          return issue("move-node requires nodeId and parentId strings");
+          return issue(index, operation, `requires nodeId and parentId strings; use "nodeId" (not "id") and optional integer "index" (not "position" or "beforeId")`);
         }
+        const unsupported = unsupportedFields(index, operation, ["op", "nodeId", "parentId", "index"]);
+        if (unsupported !== undefined) return unsupported;
+        if (!validOptionalIndex(operation.index)) return issue(index, operation, "index must be a non-negative integer when present");
         if (!tree.nodes.some(({ id }) => id === operation.nodeId)) {
-          return issue(`move-node node "${operation.nodeId}" does not exist`);
+          return issue(index, operation, `node "${operation.nodeId}" does not exist`);
         }
         const parent = tree.nodes.find(({ id }) => id === operation.parentId);
-        if (parent === undefined) return issue(`move-node parent "${operation.parentId}" does not exist`);
+        if (parent === undefined) return issue(index, operation, `parent "${operation.parentId}" does not exist`);
         if (operation.parentId === operation.nodeId
           || reachesNode(tree, operation.nodeId, operation.parentId)) {
-          return issue(`move-node cannot move "${operation.nodeId}" under itself or its descendant`);
+          return issue(index, operation, `cannot move "${operation.nodeId}" under itself or its descendant`);
+        }
+        const targetChildren = (parent.children ?? []).filter((child) => child !== operation.nodeId);
+        if (typeof operation.index === "number" && operation.index > targetChildren.length) {
+          return issue(index, operation, `index ${operation.index} leaves a gap in parent "${operation.parentId}" children (length ${targetChildren.length})`);
         }
         removeChildReference(tree, operation.nodeId);
         insertChild(parent, operation.nodeId, operation.index);
@@ -444,57 +509,104 @@ const applyTreeOps = (
       }
       case "set-query": {
         if (typeof operation.index !== "number" || !Number.isInteger(operation.index) || operation.index < 0) {
-          return issue("set-query requires a non-negative integer index");
+          return issue(index, operation, "requires a non-negative integer index");
         }
+        const unsupported = unsupportedFields(index, operation, ["op", "index", "query"]);
+        if (unsupported !== undefined) return unsupported;
         const queries = tree.queries ?? [];
         if (operation.query === null) {
-          if (operation.index >= queries.length) return issue(`query index ${operation.index} does not exist`);
+          if (operation.index >= queries.length) return issue(index, operation, `query index ${operation.index} does not exist`);
           queries.splice(operation.index, 1);
         } else if (isRecord(operation.query)) {
-          if (operation.index > queries.length) return issue(`query index ${operation.index} leaves a gap`);
+          if (operation.index > queries.length) return issue(index, operation, `query index ${operation.index} leaves a gap`);
           queries[operation.index] = structuredClone(operation.query) as unknown as TreeQuery;
         } else {
-          return issue("set-query requires a query object or null");
+          return issue(index, operation, "requires a query object or null");
         }
         tree.queries = queries;
         break;
       }
       case "add-component": {
         if (typeof operation.name !== "string" || typeof operation.source !== "string") {
-          return issue("add-component requires name and source strings");
+          return issue(index, operation, `requires name and source strings; received fields: ${Object.keys(operation).join(", ")}`);
         }
+        const unsupported = unsupportedFields(index, operation, ["op", "name", "source"]);
+        if (unsupported !== undefined) return unsupported;
         app.components = { ...(app.components ?? {}), [operation.name]: operation.source };
         break;
       }
       case "set-name": {
         if (typeof operation.name !== "string" || operation.name.trim() === "") {
-          return issue("set-name requires a non-empty name");
+          return issue(index, operation, "requires a non-empty name");
         }
+        const unsupported = unsupportedFields(index, operation, ["op", "name"]);
+        if (unsupported !== undefined) return unsupported;
         app.name = operation.name.trim();
         break;
       }
       case "set-description": {
-        if (typeof operation.description !== "string") return issue("set-description requires a string");
+        if (typeof operation.description !== "string") return issue(index, operation, "requires a string");
+        const unsupported = unsupportedFields(index, operation, ["op", "description"]);
+        if (unsupported !== undefined) return unsupported;
         app.description = operation.description;
         break;
       }
       default:
-        return issue(`unsupported tree op "${operation.op}"`);
+        return issue(index, operation, "unsupported tree operation");
     }
   }
   return { app, issues: [] };
 };
 
+const rootedRenderIssues = (tree: Tree): string[] => {
+  const nodes = new Map(tree.nodes.map((node) => [node.id, node]));
+  const pending = [tree.root];
+  const visited = new Set<string>();
+  const issues: string[] = [];
+  let hasRenderableContent = false;
+  while (pending.length > 0) {
+    const id = pending.pop();
+    if (id === undefined || visited.has(id)) continue;
+    visited.add(id);
+    const node = nodes.get(id);
+    if (node === undefined) {
+      issues.push(`rooted node "${id}" is missing; persisted edits cannot rely on streaming placeholders`);
+      continue;
+    }
+    if (node.source === "generated" || node.source === "host") {
+      hasRenderableContent = true;
+    } else if (node.component === "Text") {
+      const text = node.props?.text;
+      if (text !== undefined && text !== null && String(text).trim() !== "") hasRenderableContent = true;
+    } else if (!new Set(["Stack", "Row", "Grid"]).has(node.component)) {
+      hasRenderableContent = true;
+    }
+    pending.push(...(node.children ?? []));
+  }
+  if (!hasRenderableContent) {
+    issues.push(`tree root "${tree.root}" renders an empty layout; keep at least one attached, visible node`);
+  }
+  return issues;
+};
+
 const validateEditedApp = async (
   app: AppDocument,
   deps: GenerationDependencies,
+  source: AppDocument,
 ): Promise<string[]> => {
   const validation = validateAppDocument(app);
   if (!validation.ok) return [validation.error.message];
   if (app.tree?.formatVersion !== "vendo-genui/v1") return ["tree edit produced an unsupported format"];
   const treeValidation = validateTree({ ...app.tree, components: app.components });
   if (!treeValidation.ok) return [treeValidation.error.message];
-  return catalogIssues(treeValidation.tree, app.components, deps.catalog);
+  const sourceTreeValidation = validateTree({ ...source.tree, components: source.components });
+  const sourceRenderIssues = sourceTreeValidation.ok
+    ? new Set(rootedRenderIssues(sourceTreeValidation.tree))
+    : new Set<string>();
+  return [
+    ...rootedRenderIssues(treeValidation.tree).filter((issue) => !sourceRenderIssues.has(issue)),
+    ...await catalogIssues(treeValidation.tree, app.components, deps.catalog),
+  ];
 };
 
 const treeOpsFrom = (value: unknown): { ops?: TreeOp[]; issues: string[] } => {
@@ -557,53 +669,54 @@ const editTree = async (
   input: GenerationEditInput,
   deps: GenerationDependencies,
 ): Promise<GenerationEditResult> => {
-  let issues = input.repairIssues ?? [];
+  let issues = [...(input.repairIssues ?? [])];
   for (let attempt = 0; attempt < 2; attempt += 1) {
     const output = await generateJson(
       deps,
-      `${formatContract(deps)}\n\nTREE EDIT DIALECT: emit {"ops":[...]}. Allowed ops: set-prop, add-node, remove-node, move-node, set-query, add-component, set-name, set-description. Patch the supplied app; do not regenerate it.`,
+      `${formatContract(deps)}\n\nTREE EDIT DIALECT: emit {"ops":[...]}. Patch the supplied app; do not regenerate it.\nExact op shapes:\n- {"op":"set-prop","nodeId":"...","prop":"...","value":...}\n- {"op":"add-node","node":{"id":"...","component":"...","source":"prewired|host|generated","props":{},"children":[]},"parentId":"...","index":0}\n- {"op":"remove-node","nodeId":"..."}\n- {"op":"move-node","nodeId":"...","parentId":"...","index":0}\n- {"op":"set-query","index":0,"query":{...}|null}\n- {"op":"add-component","name":"PascalCaseName","source":"complete ESM React source"}\n- {"op":"set-name","name":"..."}\n- {"op":"set-description","description":"..."}\nUse nodeId, never id, for existing nodes. Use index, never position or beforeId. Attach every added visible node with parentId, never add the existing root again, preserve all component sources not intentionally replaced, and never leave the rooted view empty.`,
       `TASK: EDIT_TREE\nINSTRUCTION: ${input.instruction}\nCURRENT_APP: ${JSON.stringify(input.app)}${repairPrompt(issues)}`,
     );
-    issues = output.issues;
+    issues = distinctIssues(issues, output.issues);
     if (output.value !== undefined) {
       const parsed = treeOpsFrom(output.value);
-      issues = parsed.issues;
+      issues = distinctIssues(issues, parsed.issues);
       if (parsed.ops !== undefined) {
         const applied = applyTreeOps(input.app, parsed.ops);
-        issues = applied.issues;
+        issues = distinctIssues(issues, applied.issues);
         if (applied.app !== undefined) {
-          issues = await validateEditedApp(applied.app, deps);
-          if (issues.length === 0) {
+          const validationIssues = await validateEditedApp(applied.app, deps, input.app);
+          if (validationIssues.length === 0) {
             return { kind: "document", document: withoutId(applied.app), rung: 1 };
           }
+          issues = distinctIssues(issues, validationIssues);
         }
       }
     }
   }
-  return { kind: "failure", issues };
+  return { kind: "failure", issues: issues.length === 0 ? ["tree edit failed validation"] : issues };
 };
 
 const editCode = async (
   input: GenerationEditInput,
   deps: GenerationDependencies,
 ): Promise<GenerationEditResult> => {
-  let issues = input.repairIssues ?? [];
+  let issues = [...(input.repairIssues ?? [])];
   for (let attempt = 0; attempt < 2; attempt += 1) {
     const output = await generateJson(
       deps,
       `${formatContract(deps)}\n\nCODE EDIT DIALECT: emit full small files as {"rung":2|3|4,"files":[{"path":"/app/...","content":"..."}]}. Keep every path under /app. Rung 2 is tree plus server, rung 3 is a server-computed tree, and rung 4 is only for an already-http app.`,
       `TASK: EDIT_CODE\nINSTRUCTION: ${input.instruction}\nCURRENT_APP: ${JSON.stringify(input.app)}${repairPrompt(issues)}`,
     );
-    issues = output.issues;
+    issues = distinctIssues(issues, output.issues);
     if (output.value !== undefined) {
       const plan = codePlanFrom(output.value, input.app, input.instruction);
-      issues = plan.issues;
+      issues = distinctIssues(issues, plan.issues);
       if (plan.files !== undefined && plan.rung !== undefined) {
         return { kind: "code", files: plan.files, rung: plan.rung };
       }
     }
   }
-  return { kind: "failure", issues };
+  return { kind: "failure", issues: issues.length === 0 ? ["code edit failed validation"] : issues };
 };
 
 /** 06-apps §§2,5 — model-backed rung-1 generation and two-dialect edit planning. */

--- a/packages/apps/src/index.ts
+++ b/packages/apps/src/index.ts
@@ -13,6 +13,7 @@ export {
   type AppsConfig,
   type AppsProxy,
   type AppsRuntime,
+  type EditFailure,
   type EditResult,
   type OpenSurface,
   type VersionEntry,

--- a/packages/apps/src/ladder.e2e.test.ts
+++ b/packages/apps/src/ladder.e2e.test.ts
@@ -79,6 +79,61 @@ const storedServer = async (
 };
 
 describe("ladder rung transitions (e2e)", () => {
+  it("opens a non-empty generated surface after an in-place tree edit through the real runtime", async () => {
+    const store = memoryStore();
+    const runtime = createApps({
+      store,
+      guard: guardFixture(),
+      tools,
+      catalog: [],
+      model: scriptedLanguageModel(
+        JSON.stringify({
+          name: "Editable dashboard",
+          tree: {
+            formatVersion: "vendo-genui/v1",
+            root: "root",
+            nodes: [
+              { id: "root", component: "Stack", source: "prewired", children: ["title"] },
+              { id: "title", component: "Text", source: "prewired", props: { text: "Spending" } },
+            ],
+          },
+        }),
+        JSON.stringify({
+          ops: [
+            {
+              op: "add-component",
+              name: "SpendingChart",
+              source: "export default function SpendingChart() { return <div role=\"img\">Chart</div>; }",
+            },
+            {
+              op: "add-node",
+              node: { id: "chart", component: "SpendingChart", source: "generated" },
+              parentId: "root",
+            },
+          ],
+        }),
+      ),
+    });
+    const ada = ctx();
+    const app = await runtime.create({ prompt: "Build a spending summary" }, ada);
+
+    const edited = await runtime.edit(app.id, "Add a visual dashboard with a chart", ada);
+    const surface = await runtime.open(app.id, ada);
+
+    expect(edited.app.id).toBe(app.id);
+    expect(edited.failure).toBeUndefined();
+    expect(surface).toMatchObject({
+      kind: "tree",
+      payload: {
+        root: "root",
+        nodes: expect.arrayContaining([
+          expect.objectContaining({ id: "chart", component: "SpendingChart", source: "generated" }),
+        ]),
+        components: { SpendingChart: expect.stringContaining("Chart") },
+      },
+    });
+  });
+
   it("walks rung 1 → 2 → 3 through edit() while open() always answers from last state", async () => {
     const store = memoryStore();
     const sandbox = fakeSandbox();

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -74,6 +74,14 @@ export interface EditResult {
   app: AppDocument;
   version: VersionEntry;
   issues?: string[];
+  /** Additive failure detail: when present, no edit was persisted. */
+  failure?: EditFailure;
+}
+
+export interface EditFailure {
+  code: "edit-rejected";
+  retryable: boolean;
+  message: string;
 }
 
 /** 06-apps §1 */
@@ -212,6 +220,7 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     app: AppDocument,
     instruction: string,
     issues: string[],
+    retryable = true,
   ): EditResult => ({
     app: structuredClone(app),
     version: {
@@ -220,7 +229,18 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       rung: rungFor(app),
     },
     issues: [...issues],
+    failure: {
+      code: "edit-rejected",
+      retryable,
+      message: retryable
+        ? "Edit was not applied. Retry vendo_apps_edit on the same app with a narrower instruction; do not rebuild the app."
+        : "Edit was not applied and cannot be retried until the reported blocker is resolved.",
+    },
   });
+
+  const appendIssues = (current: string[], next: string[]): string[] => [
+    ...new Set([...current, ...next]),
+  ];
 
   const syntaxCheck = async (
     machine: SandboxMachine,
@@ -450,10 +470,11 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       if (requiresServer && !machines.available()) {
         return failedEdit(previous, instruction, [
           "sandbox-unavailable: this edit requires server execution",
-        ]);
+        ], false);
       }
 
       let repairIssues: string[] | undefined;
+      let collectedIssues: string[] = [];
       for (let attempt = 0; attempt < 2; attempt += 1) {
         const generated = await engine.edit(
           {
@@ -463,7 +484,11 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
           },
           generationDependencies(config, config.model),
         );
-        if (generated.kind === "failure") return failedEdit(previous, instruction, generated.issues);
+        if (generated.kind === "failure") {
+          collectedIssues = appendIssues(collectedIssues, generated.issues);
+          repairIssues = collectedIssues;
+          continue;
+        }
 
         if (generated.kind === "document") {
           const app: AppDocument = { ...generated.document, id: appId };
@@ -489,7 +514,8 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
 
         const applied = await applyCodeFiles(previous, generated.files, ctx);
         if (applied.server === undefined) {
-          repairIssues = applied.issues;
+          collectedIssues = appendIssues(collectedIssues, applied.issues);
+          repairIssues = collectedIssues;
           continue;
         }
         const app: AppDocument = { ...structuredClone(previous), server: applied.server };
@@ -502,7 +528,11 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
         await machines.evict(appId);
         return { app: persisted, version: { ...version } };
       }
-      return failedEdit(previous, instruction, repairIssues ?? ["code edit failed validation"]);
+      return failedEdit(
+        previous,
+        instruction,
+        collectedIssues.length === 0 ? ["edit failed validation"] : collectedIssues,
+      );
     },
 
     /**

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -149,6 +149,31 @@ interface NodeRendererProps {
   setViewState(key: string, value: Json): void;
 }
 
+const EMPTY_LAYOUT_COMPONENTS = new Set(["Stack", "Row", "Grid"]);
+
+const hasRenderableTreeContent = (tree: Tree): boolean => {
+  const nodes = new Map(tree.nodes.map((node) => [node.id, node]));
+  const pending = [tree.root];
+  const visited = new Set<string>();
+  while (pending.length > 0) {
+    const id = pending.pop();
+    if (id === undefined || visited.has(id)) continue;
+    visited.add(id);
+    const node = nodes.get(id);
+    // A missing child renders the streaming skeleton, which is intentionally visible.
+    if (node === undefined) return true;
+    if (node.source === "host" || node.source === "generated") return true;
+    if (node.component === "Text") {
+      const text = node.props?.text;
+      if (text !== undefined && text !== null && String(text).trim() !== "") return true;
+    } else if (!EMPTY_LAYOUT_COMPONENTS.has(node.component)) {
+      return true;
+    }
+    pending.push(...(node.children ?? []));
+  }
+  return false;
+};
+
 function NodeRenderer(props: NodeRendererProps) {
   const node = props.nodes.get(props.nodeId);
   if (!node) {
@@ -291,6 +316,14 @@ function StatefulTreeView({
     return (
       <ContainedNotice label="Invalid UI tree" code={validation.error.code}>
         {`${validation.error.code}: ${validation.error.message}`}
+      </ContainedNotice>
+    );
+  }
+
+  if (!hasRenderableTreeContent(validation.tree)) {
+    return (
+      <ContainedNotice label="Empty UI tree">
+        The app view has no renderable content.
       </ContainedNotice>
     );
   }

--- a/packages/ui/test/tree/tree-view.test.tsx
+++ b/packages/ui/test/tree/tree-view.test.tsx
@@ -82,6 +82,18 @@ describe("TreeView public surface", () => {
     expect(screen.queryByRole("note", { name: /invalid ui tree/i })).toBeNull();
   });
 
+  it("contains a validated but empty rooted layout instead of rendering a blank surface", () => {
+    render(
+      <TreeView
+        tree={tree([{ id: "root", component: "Stack", source: "prewired" }])}
+        components={{}}
+        onAction={ok}
+      />,
+    );
+
+    expect(screen.getByRole("note", { name: /empty ui tree/i }).textContent).toMatch(/no renderable content/i);
+  });
+
   it("contains an erroring host node while preserving its sibling", () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     const Boom = () => {


### PR DESCRIPTION
## Summary

- make the tree-ops edit dialect strict and repairable instead of accepting malformed operations that can produce invisible/orphaned content
- let the runtime's outer repair loop actually run after the engine exhausts its inner attempts, while carrying cumulative, actionable repair issues across all attempts
- return an additive structured `edit-rejected` failure that tells the agent to retry `vendo_apps_edit` on the same app rather than rebuild with `vendo_apps_create`
- reject newly empty rooted layouts before persistence and render a contained tree-level notice for an already-empty layout

## Root cause

ENG-245 had two independent causes in the observed edit path.

First, model-generated tree ops were not validated strictly enough. Real malformed classes included a nested `{ component: { name, source } }` payload, duplicate-root `add-node`, unsupported `position` aliases, placement fields nested inside `node`, and out-of-range indexes. In particular, nesting `parentId` inside `node` let `add-node` persist an unattached orphan: the document validated, but the rooted view never displayed the added component.

Second, retries were nested but the outer loop was effectively dead. `engine.editTree` used its two attempts and returned `kind: "failure"`; `runtime.edit` then returned immediately on the first outer attempt instead of using its second attempt with the engine's repair feedback. Both layers also replaced repair issues with only the latest failure, so the model could lose earlier actionable context.

This change validates exact op shapes with indexed errors, requires every added node to attach to the rooted view, rejects gap indexes and newly empty rooted layouts, preserves component sources, accumulates distinct repair issues, and continues through the runtime repair loop. The frozen edit response shape is unchanged; `failure` is additive.

## Browser evidence

Playwright drove the real `demo-bank` UI against the provisioned local environment. It opened existing app `app_4a5dccd2-773d-4114-a11b-ea8e42c4bf67`, sent “Add a filter dropdown above the visual spending dashboard and chart … Edit this existing app in place; do not rebuild it,” approved once, and asserted:

- app count stayed `1 -> 1`
- app id stayed unchanged
- document hash changed `3334052be30c2067 -> 50019afeb5f1cbec`
- the only mutation tool card added was `vendo_apps_edit` (no `vendo_apps_create`)
- added node `filter` rendered at `1023 x 150`; generated `PeriodFilter` iframe rendered at `1023 x 150`
- run passed in 84.6 seconds with one approval

Before edit:

![Before the in-place edit](https://raw.githubusercontent.com/runvendo/vendo/evidence/eng-245-edit-reliability/docs/evidence/eng-245/00-before-edit.png)

After the same app was edited and reopened:

![After the in-place edit](https://raw.githubusercontent.com/runvendo/vendo/evidence/eng-245-edit-reliability/docs/evidence/eng-245/01-after-in-place-edit.png)

The final local evidence manifest is `artifacts/eng-245/evidence/2026-07-14T22-05-00-206Z-summary.json`. The two frames are hosted from the dedicated `evidence/eng-245-edit-reliability` branch so browser artifacts remain outside this PR's code commits.

## Residual gap: jail null-render - handed to gen-fidelity

`packages/ui/src/tree/jail/runtime-entry.tsx:126-140` loads the component and calls `root.render(...)`, but the async function resolves without checking whether React committed any DOM. The message handler at `packages/ui/src/tree/jail/runtime-entry.tsx:163-166` consequently posts `{ kind: "ready" }` from `.then(...)` even when the component rendered nothing.

Minimal repro:

```tsx
export default function Blank() {
  return null;
}
```

Send that source in a jail `render` message. The component throws no error, the mount stays empty, and the jail reports `ready`. This PR does not touch `packages/ui/src/tree/jail/*`; the null-render acceptance remains handed to gen-fidelity.

## Verification

Passed:

- `pnpm build` — 18/18 tasks
- changed apps suites with one Vitest worker — 3 files, 30/30 tests
- `@vendoai/ui` suite in the serialized repo run — 13 files, 77/77 tests
- Express corpus e2e with one Vitest worker — 6/6 tests
- `pnpm run typecheck --concurrency=1` — 34/34 tasks
- `pnpm run lint --concurrency=1` — dependency guard OK; 2/2 lint tasks
- Playwright real-browser edit flow described above
- GitHub CI — exact `pnpm build`, `pnpm test`, `pnpm typecheck`, and `pnpm lint` sequence passed; integration, perf, audit, and changeset-status also passed

Local host note: the unconstrained local `pnpm test` run timed out five Express e2e files and one unrelated UI thread test while many other worktrees were simultaneously running Vitest/Next builds. A serialized local retry cleared the UI failure (77/77) but four unrelated `packages/vendo/src/server.test.ts` cases crossed their 30-second timeout; that file took 606 seconds under load. The Express suite subsequently passed 6/6 in isolation, all changed-package suites passed locally, and the clean GitHub runner then passed the full root gate including `pnpm test`.
