### PR TITLE
feat(cli): vendo cloud deploy - push local project to hosted instance (ENG-297)

### DIFF
--- a/packages/vendo/src/cli/cloud/E2E.md
+++ b/packages/vendo/src/cli/cloud/E2E.md
@@ -12,6 +12,31 @@ VENDO_API_KEY; user commands use a stored email-OTP session or the `--token
 - `vendo cloud publish app.json` ×2 → `PublishRecord` version "1" then "2" (monotonic)
 - `vendo cloud pin-ship --app app_cli --slot hero --base sha256:aa --diff d` → `{ id: pin_…, status: "pending" }`
 
+## Hosted runtime deploy
+
+`vendo cloud deploy` opens the local project's default PGlite store at
+`.vendo/data` and deploys every enabled automation for its sole subject. If the
+store contains more than one subject, pass `--subject <subject>`; the command
+never combines apps or grants from different subjects.
+
+- `vendo cloud deploy --key vnd_…` → concise applied-count and hosted-webhook table
+- `vendo cloud deploy --key vnd_… --json` → raw hosted deploy response
+- `vendo cloud deploy --app app_daily --app app_webhook` → restrict the deploy;
+  an explicitly selected disabled automation is sent with `enabled: false`
+- `vendo cloud deploy --secret STRIPE_KEY=sk_… --secret RESEND_KEY=re_…` → send
+  only values whose names are referenced by the selected app documents
+
+The request is `POST /api/v1/hosted/deploy` with machine-key bearer auth and
+the exact body `{ apps: [{ doc, enabled }], grants, secrets: [{ name, value }] }`.
+Only active grants with `source: "automation"`, the selected subject, and an
+`appId` in the deployed set are included.
+
+Stored secret values are encrypted and the local encryption key is deliberately
+not discoverable through the CLI contract. The v1 deploy vehicle is therefore
+the repeatable `--secret NAME=VALUE` flag; values cross only the authenticated
+TLS request and are never printed. A referenced name without a matching flag
+produces a warning and does not fail the app/grant deploy.
+
 ## User authentication
 - `vendo cloud login EMAIL` → sends a 6-digit email OTP, prompts for the code,
   and stores the returned session in `~/.vendo/cloud-session.json`
@@ -23,4 +48,6 @@ VENDO_API_KEY; user commands use a stored email-OTP session or the `--token
 - `vendo cloud deployments --org <id> --token <jwt>` → `{ deployments: [...] }`
 
 All shapes match the frozen flowlet wave-2 contracts; the 402 `cloud-required`
-envelope is surfaced as a friendly message. Verified 2026-07-13.
+envelope is surfaced as a friendly message. The auth/share/publish flows were
+verified live on 2026-07-13; hosted deploy has deterministic local-store and
+mocked-wire coverage pending the console-side production endpoint.

--- a/packages/vendo/src/cli/cloud/E2E.md
+++ b/packages/vendo/src/cli/cloud/E2E.md
@@ -36,6 +36,9 @@ not discoverable through the CLI contract. The v1 deploy vehicle is therefore
 the repeatable `--secret NAME=VALUE` flag; values cross only the authenticated
 TLS request and are never printed. A referenced name without a matching flag
 produces a warning and does not fail the app/grant deploy.
+Automations with `steps[].tool` beginning `fn:` also warn per app: those steps
+target the app's machine, which hosted sandboxes cannot reach in v1, so they
+will fail/park when fired hosted without blocking the deploy itself.
 
 ## User authentication
 - `vendo cloud login EMAIL` → sends a 6-digit email OTP, prompts for the code,

--- a/packages/vendo/src/cli/cloud/args.ts
+++ b/packages/vendo/src/cli/cloud/args.ts
@@ -4,6 +4,22 @@ export function option(args: string[], name: string): string | undefined {
   return args.find((value) => value.startsWith(`${name}=`))?.slice(name.length + 1);
 }
 
+export function options(args: string[], name: string): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index]!;
+    if (value === name) {
+      const next = args[index + 1];
+      if (next === undefined || next.startsWith("--")) throw new Error(`${name} requires a value`);
+      values.push(next);
+      index += 1;
+    } else if (value.startsWith(`${name}=`)) {
+      values.push(value.slice(name.length + 1));
+    }
+  }
+  return values;
+}
+
 export function positionals(args: string[], optionNames: string[]): string[] {
   const values = new Set<string>();
   for (const name of optionNames) {

--- a/packages/vendo/src/cli/cloud/deploy.test.ts
+++ b/packages/vendo/src/cli/cloud/deploy.test.ts
@@ -152,6 +152,49 @@ describe("cloud deploy", () => {
     expect(messages.logs).toEqual([JSON.stringify(response, null, 2)]);
   });
 
+  it("warns once per app for fn: steps without blocking the deploy", async () => {
+    const app = automation("app_fn_steps");
+    app.trigger = {
+      ...trigger,
+      run: {
+        kind: "steps",
+        steps: [
+          { id: "first", tool: "fn:first" },
+          { id: "second", tool: "fn:second" },
+        ],
+      },
+    };
+    const secondApp = automation("app_second_fn");
+    secondApp.trigger = {
+      ...trigger,
+      run: { kind: "steps", steps: [{ id: "only", tool: "fn:only" }] },
+    };
+    const messages = output();
+    const fetcher = vi.fn().mockResolvedValue({
+      org: { id: "org_1", slug: "acme" },
+      instance: { status: "active" },
+      applied: { apps: 2, grants: 0, secrets: 0 },
+      webhooks: [],
+    });
+    const localProjectReader = vi.fn().mockResolvedValue({
+      subject: "user_a",
+      apps: [{ doc: app, enabled: true }, { doc: secondApp, enabled: true }],
+      grants: [],
+    });
+
+    expect(await runDeploy(["--key", "vnd_test"], {
+      output: messages.sink,
+      fetcher,
+      env: {},
+      localProjectReader,
+    })).toBe(0);
+    expect(messages.errors).toEqual([
+      "WARNING: Automation app_fn_steps has fn: steps that target the app's machine, which is unreachable from hosted sandboxes in v1; those steps will fail/park when fired hosted.",
+      "WARNING: Automation app_second_fn has fn: steps that target the app's machine, which is unreachable from hosted sandboxes in v1; those steps will fail/park when fired hosted.",
+    ]);
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+
   it("rejects an explicit --app that is not an automation", async () => {
     const messages = output();
     const fetcher = vi.fn();

--- a/packages/vendo/src/cli/cloud/deploy.test.ts
+++ b/packages/vendo/src/cli/cloud/deploy.test.ts
@@ -1,0 +1,239 @@
+import type { AppDocument, PermissionGrant, Principal } from "@vendoai/core";
+import { appStore, createStore, grantStore } from "@vendoai/store";
+import { describe, expect, it, vi } from "vitest";
+import { CloudError, cloudFetch } from "./client.js";
+import { readLocalProject, runDeploy } from "./deploy.js";
+
+const trigger: NonNullable<AppDocument["trigger"]> = {
+  on: { kind: "external", connector: "stripe", event: "invoice.paid" },
+  run: { kind: "steps", steps: [{ id: "notify", tool: "host_notifications_send" }] },
+};
+
+function automation(id: string, secrets?: string[]): AppDocument {
+  return {
+    format: "vendo/app@1",
+    id,
+    name: id,
+    trigger,
+    ...(secrets === undefined ? {} : { secrets }),
+  };
+}
+
+function grant(
+  id: string,
+  appId: string,
+  overrides: Partial<PermissionGrant> = {},
+): PermissionGrant {
+  return {
+    id,
+    subject: "user_a",
+    tool: "host_notifications_send",
+    descriptorHash: "sha256:test",
+    scope: { kind: "tool" },
+    duration: "standing",
+    appId,
+    source: "automation",
+    grantedAt: "2026-07-14T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function output() {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return {
+    logs,
+    errors,
+    sink: {
+      log: (message: string) => logs.push(message),
+      error: (message: string) => errors.push(message),
+    },
+  };
+}
+
+describe("cloud deploy", () => {
+  it("deploys enabled automations with their grants and explicitly provided referenced secrets", async () => {
+    const enabled = automation("app_enabled", ["TOKEN", "MISSING"]);
+    const disabled = automation("app_disabled");
+    const ordinary: AppDocument = { format: "vendo/app@1", id: "app_view", name: "View" };
+    const messages = output();
+    const response = {
+      org: { id: "org_1", slug: "acme" },
+      instance: { status: "active" },
+      applied: { apps: 1, grants: 1, secrets: 1 },
+      webhooks: [{ app_id: "app_enabled", source: "stripe", url: "https://hooks.vendo.run/acme/app_enabled" }],
+    };
+    const fetchImpl = vi.fn().mockResolvedValue(Response.json(response, { status: 201 }));
+    const fetcher = vi.fn((path: string, request = {}) => cloudFetch(path, { ...request, fetchImpl }));
+    const localProjectReader = vi.fn().mockResolvedValue({
+      subject: "user_a",
+      apps: [
+        { doc: enabled, enabled: true },
+        { doc: disabled, enabled: false },
+        { doc: ordinary, enabled: true },
+      ],
+      grants: [
+        grant("grt_enabled", "app_enabled"),
+        grant("grt_disabled", "app_disabled"),
+        grant("grt_chat", "app_enabled", { source: "chat" }),
+        grant("grt_other_subject", "app_enabled", { subject: "user_b" }),
+      ],
+    });
+
+    expect(await runDeploy([
+      "--key", "vnd_test", "--secret", "TOKEN=plain=value", "--secret", "UNUSED=ignored",
+    ], {
+      output: messages.sink,
+      fetcher,
+      env: {},
+      localProjectReader,
+    })).toBe(0);
+
+    expect(fetcher).toHaveBeenCalledWith("/api/v1/hosted/deploy", expect.objectContaining({
+      auth: "key",
+      apiKey: "vnd_test",
+      method: "POST",
+      body: {
+        apps: [{ doc: enabled, enabled: true }],
+        grants: [grant("grt_enabled", "app_enabled")],
+        secrets: [{ name: "TOKEN", value: "plain=value" }],
+      },
+    }));
+    expect(fetchImpl).toHaveBeenCalledWith("https://console.vendo.run/api/v1/hosted/deploy", {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/json",
+        authorization: "Bearer vnd_test",
+      },
+      body: JSON.stringify({
+        apps: [{ doc: enabled, enabled: true }],
+        grants: [grant("grt_enabled", "app_enabled")],
+        secrets: [{ name: "TOKEN", value: "plain=value" }],
+      }),
+    });
+    expect(messages.errors).toEqual([
+      "Automation app_enabled references missing secret MISSING; pass --secret MISSING=VALUE",
+    ]);
+    expect(messages.logs.join("\n")).toContain("Vendo Cloud deploy: acme (active)");
+    expect(messages.logs.join("\n")).toContain("APPLIED");
+    expect(messages.logs.join("\n")).toContain("app_enabled  stripe  https://hooks.vendo.run/acme/app_enabled");
+  });
+
+  it("lets repeatable --app select disabled automations and emits the raw response in --json mode", async () => {
+    const enabled = automation("app_enabled");
+    const disabled = automation("app_disabled");
+    const messages = output();
+    const response = {
+      org: { id: "org_1", slug: "acme" },
+      instance: { status: "active" },
+      applied: { apps: 2, grants: 2, secrets: 0 },
+      webhooks: [],
+    };
+    const fetcher = vi.fn().mockResolvedValue(response);
+    const localProjectReader = vi.fn().mockResolvedValue({
+      subject: "user_a",
+      apps: [{ doc: enabled, enabled: true }, { doc: disabled, enabled: false }],
+      grants: [grant("grt_enabled", "app_enabled"), grant("grt_disabled", "app_disabled")],
+    });
+
+    expect(await runDeploy([
+      "--app", "app_disabled", "--app=app_enabled", "--subject", "user_a", "--json", "--key=vnd_test",
+    ], { output: messages.sink, fetcher, env: {}, localProjectReader })).toBe(0);
+
+    expect(localProjectReader).toHaveBeenCalledWith(expect.objectContaining({ subject: "user_a" }));
+    expect(fetcher).toHaveBeenCalledWith("/api/v1/hosted/deploy", expect.objectContaining({
+      body: {
+        apps: [{ doc: enabled, enabled: true }, { doc: disabled, enabled: false }],
+        grants: [grant("grt_enabled", "app_enabled"), grant("grt_disabled", "app_disabled")],
+        secrets: [],
+      },
+    }));
+    expect(messages.logs).toEqual([JSON.stringify(response, null, 2)]);
+  });
+
+  it("rejects an explicit --app that is not an automation", async () => {
+    const messages = output();
+    const fetcher = vi.fn();
+    const localProjectReader = vi.fn().mockResolvedValue({
+      subject: "user_a",
+      apps: [{ doc: { format: "vendo/app@1", id: "app_view", name: "View" }, enabled: true }],
+      grants: [],
+    });
+
+    expect(await runDeploy(["--app", "app_view", "--key", "vnd_test"], {
+      output: messages.sink,
+      fetcher,
+      env: {},
+      localProjectReader,
+    })).toBe(1);
+    expect(messages.errors).toEqual(["App app_view is not an automation"]);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("refuses to send plaintext secret values to a non-TLS API URL", async () => {
+    const messages = output();
+    const fetcher = vi.fn();
+    const localProjectReader = vi.fn().mockResolvedValue({
+      subject: "user_a",
+      apps: [{ doc: automation("app_enabled", ["TOKEN"]), enabled: true }],
+      grants: [],
+    });
+
+    expect(await runDeploy([
+      "--key", "vnd_test", "--api-url", "http://cloud.test", "--secret", "TOKEN=plain",
+    ], { output: messages.sink, fetcher, env: {}, localProjectReader })).toBe(1);
+    expect(messages.errors).toEqual(["Deploying secret values requires an HTTPS Vendo Cloud URL"]);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("keeps the machine-command cloud-required error", async () => {
+    const messages = output();
+    const fetcher = vi.fn().mockRejectedValue(new CloudError("cloud-required", "Upgrade", 402));
+    const localProjectReader = vi.fn().mockResolvedValue({
+      subject: "user_a",
+      apps: [{ doc: automation("app_enabled"), enabled: true }],
+      grants: [],
+    });
+
+    expect(await runDeploy(["--key", "vnd_test"], {
+      output: messages.sink,
+      fetcher,
+      localProjectReader,
+    })).toBe(1);
+    expect(messages.errors).toEqual(["This key's org needs a Cloud plan (cloud-required)."]);
+  });
+});
+
+describe("local project deploy reader", () => {
+  it("requires --subject when the local store contains multiple subjects", async () => {
+    const store = createStore({ dataDir: "memory://cloud-deploy-multiple-subjects" });
+    await store.ensureSchema();
+    await appStore(store).put({ kind: "user", subject: "user_b" }, automation("app_b"));
+    await appStore(store).put({ kind: "user", subject: "user_a" }, automation("app_a"));
+
+    await expect(readLocalProject({ storeFactory: () => store })).rejects.toThrow(
+      "Multiple local Vendo subjects found: user_a, user_b. Pass --subject <subject>.",
+    );
+  });
+
+  it("reads only the selected subject and its active automation grants", async () => {
+    const store = createStore({ dataDir: "memory://cloud-deploy-subject" });
+    await store.ensureSchema();
+    const principalA: Principal = { kind: "user", subject: "user_a" };
+    const principalB: Principal = { kind: "user", subject: "user_b" };
+    await appStore(store).put(principalA, automation("app_a"), { enabled: false });
+    await appStore(store).put(principalB, automation("app_b"));
+    await grantStore(store).create(principalA, grant("grt_active", "app_a"));
+    await grantStore(store).create(principalA, grant("grt_expired", "app_a", {
+      expiresAt: "2020-01-01T00:00:00.000Z",
+    }));
+    await grantStore(store).create(principalA, grant("grt_chat", "app_a", { source: "chat" }));
+
+    await expect(readLocalProject({ subject: "user_a", storeFactory: () => store })).resolves.toEqual({
+      subject: "user_a",
+      apps: [{ doc: automation("app_a"), enabled: false }],
+      grants: [grant("grt_active", "app_a")],
+    });
+  });
+});

--- a/packages/vendo/src/cli/cloud/deploy.ts
+++ b/packages/vendo/src/cli/cloud/deploy.ts
@@ -149,6 +149,17 @@ function selectedApps(project: LocalDeployProject, args: string[]): LocalDeployA
   return project.apps.filter((app) => requestedIds.has(app.doc.id));
 }
 
+function warnUnsupportedFnSteps(context: CloudCommandContext, apps: LocalDeployApp[]): void {
+  for (const app of apps) {
+    const run = app.doc.trigger?.run;
+    if (run?.kind === "steps" && run.steps.some((step) => step.tool.startsWith("fn:"))) {
+      context.output.error(
+        `WARNING: Automation ${app.doc.id} has fn: steps that target the app's machine, which is unreachable from hosted sandboxes in v1; those steps will fail/park when fired hosted.`,
+      );
+    }
+  }
+}
+
 function deployResponse(value: unknown): HostedDeployResponse {
   if (typeof value !== "object" || value === null) throw new Error("Vendo Cloud returned an invalid deploy response");
   const result = value as Partial<HostedDeployResponse>;
@@ -200,6 +211,7 @@ export async function runDeploy(args: string[], options: CloudDeployOptions = {}
       cwd: options.cwd ?? process.cwd(),
     });
     const apps = selectedApps(project, args);
+    warnUnsupportedFnSteps(context, apps);
     const appIds = new Set(apps.map((app) => app.doc.id));
     const grants = project.grants.filter((grant) => grant.subject === project.subject
       && grant.source === "automation"

--- a/packages/vendo/src/cli/cloud/deploy.ts
+++ b/packages/vendo/src/cli/cloud/deploy.ts
@@ -1,0 +1,247 @@
+import type { AppDocument, PermissionGrant } from "@vendoai/core";
+import {
+  appStore,
+  createStore,
+  grantStore,
+  type VendoStore,
+} from "@vendoai/store";
+import { join } from "node:path";
+import { option, options as repeatedOptions } from "./args.js";
+import { CloudError, resolveCloudBaseUrl, type CloudFetchOptions } from "./client.js";
+import {
+  commandContext,
+  type CloudCommandContext,
+  type CloudCommandOptions,
+} from "./command.js";
+import { errorMessage, formatTable, printJson } from "./output.js";
+
+export interface LocalDeployApp {
+  doc: AppDocument;
+  enabled: boolean;
+}
+
+export interface LocalDeployProject {
+  subject: string;
+  apps: LocalDeployApp[];
+  grants: PermissionGrant[];
+}
+
+export interface LocalProjectReadOptions {
+  subject?: string;
+  cwd?: string;
+}
+
+export interface ReadLocalProjectOptions extends LocalProjectReadOptions {
+  storeFactory?: () => VendoStore;
+}
+
+export type LocalProjectReader = (options: LocalProjectReadOptions) => Promise<LocalDeployProject>;
+
+export interface CloudDeployOptions extends CloudCommandOptions {
+  cwd?: string;
+  localProjectReader?: LocalProjectReader;
+}
+
+interface QueryDriver {
+  query<Row extends Record<string, unknown>>(
+    text: string,
+    params?: unknown[],
+  ): Promise<{ rows: Row[] }>;
+}
+
+interface IdRow extends Record<string, unknown> {
+  id: string;
+}
+
+interface SubjectRow extends Record<string, unknown> {
+  subject: string;
+}
+
+export async function readLocalProject(options: ReadLocalProjectOptions = {}): Promise<LocalDeployProject> {
+  const store = options.storeFactory?.() ?? createStore({
+    dataDir: join(options.cwd ?? process.cwd(), ".vendo/data"),
+  });
+  try {
+    await store.ensureSchema();
+    const driver = store.raw() as QueryDriver;
+    const subjectRows = await driver.query<SubjectRow>(
+      "SELECT DISTINCT subject FROM vendo_apps ORDER BY subject ASC",
+    );
+    const subjects = subjectRows.rows.map((row) => row.subject);
+    if (subjects.length === 0) throw new Error("No local Vendo apps found in .vendo/data");
+
+    let subject = options.subject;
+    if (subject === undefined) {
+      if (subjects.length > 1) {
+        throw new Error(`Multiple local Vendo subjects found: ${subjects.join(", ")}. Pass --subject <subject>.`);
+      }
+      subject = subjects[0]!;
+    } else if (!subjects.includes(subject)) {
+      throw new Error(`Subject ${subject} was not found in the local Vendo store`);
+    }
+
+    const appIds = await driver.query<IdRow>(
+      "SELECT id FROM vendo_apps WHERE subject = $1 ORDER BY created_at ASC, id ASC",
+      [subject],
+    );
+    const apps = (await Promise.all(appIds.rows.map(async ({ id }) => {
+      const row = await appStore(store).get(id);
+      if (row === null || row.subject !== subject) return null;
+      return { doc: row.doc, enabled: row.enabled };
+    }))).filter((row): row is LocalDeployApp => row !== null);
+
+    const grantIds = await driver.query<IdRow>(
+      `SELECT id FROM vendo_grants
+       WHERE subject = $1 AND source = 'automation'
+         AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > now())
+       ORDER BY granted_at ASC, id ASC`,
+      [subject],
+    );
+    const grants = (await Promise.all(grantIds.rows.map(({ id }) => grantStore(store).get(id))))
+      .filter((grant): grant is PermissionGrant => grant !== null);
+
+    return { subject, apps, grants };
+  } finally {
+    await store.close();
+  }
+}
+
+interface HostedDeployResponse {
+  org: { id: string; slug: string };
+  instance: { status: string };
+  applied: { apps: number; grants: number; secrets: number };
+  webhooks: Array<{ app_id: string; source: string; url: string }>;
+}
+
+function machineOptions(args: string[], context: CloudCommandContext): CloudFetchOptions {
+  return {
+    auth: "key",
+    apiKey: option(args, "--key"),
+    apiUrl: option(args, "--api-url"),
+    env: context.env,
+  };
+}
+
+function secretValues(args: string[]): Map<string, string> {
+  const values = new Map<string, string>();
+  for (const pair of repeatedOptions(args, "--secret")) {
+    const separator = pair.indexOf("=");
+    if (separator <= 0) throw new Error("--secret must use NAME=VALUE");
+    values.set(pair.slice(0, separator), pair.slice(separator + 1));
+  }
+  return values;
+}
+
+function selectedApps(project: LocalDeployProject, args: string[]): LocalDeployApp[] {
+  const requested = [...new Set(repeatedOptions(args, "--app"))];
+  if (requested.length === 0) {
+    const selected = project.apps.filter((app) => app.enabled && app.doc.trigger !== undefined);
+    if (selected.length === 0) throw new Error("No enabled local automations found");
+    return selected;
+  }
+
+  const requestedIds = new Set(requested);
+  for (const appId of requested) {
+    const app = project.apps.find((candidate) => candidate.doc.id === appId);
+    if (app === undefined) throw new Error(`App ${appId} was not found for subject ${project.subject}`);
+    if (app.doc.trigger === undefined) throw new Error(`App ${appId} is not an automation`);
+  }
+  return project.apps.filter((app) => requestedIds.has(app.doc.id));
+}
+
+function deployResponse(value: unknown): HostedDeployResponse {
+  if (typeof value !== "object" || value === null) throw new Error("Vendo Cloud returned an invalid deploy response");
+  const result = value as Partial<HostedDeployResponse>;
+  if (
+    typeof result.org?.id !== "string"
+    || typeof result.org.slug !== "string"
+    || typeof result.instance?.status !== "string"
+    || typeof result.applied?.apps !== "number"
+    || typeof result.applied.grants !== "number"
+    || typeof result.applied.secrets !== "number"
+    || !Array.isArray(result.webhooks)
+    || result.webhooks.some((webhook) => typeof webhook.app_id !== "string"
+      || typeof webhook.source !== "string"
+      || typeof webhook.url !== "string")
+  ) {
+    throw new Error("Vendo Cloud returned an invalid deploy response");
+  }
+  return result as HostedDeployResponse;
+}
+
+function printDeploySummary(context: CloudCommandContext, response: HostedDeployResponse): void {
+  const lines = [
+    `Vendo Cloud deploy: ${response.org.slug} (${response.instance.status})`,
+    "",
+    formatTable(["APPLIED", "COUNT"], [
+      ["apps", String(response.applied.apps)],
+      ["grants", String(response.applied.grants)],
+      ["secrets", String(response.applied.secrets)],
+    ]),
+    "",
+  ];
+  if (response.webhooks.length === 0) {
+    lines.push("Webhooks: none");
+  } else {
+    lines.push(formatTable(["AUTOMATION", "SOURCE", "WEBHOOK URL"], response.webhooks.map((webhook) => [
+      webhook.app_id,
+      webhook.source,
+      webhook.url,
+    ])));
+  }
+  context.output.log(lines.join("\n"));
+}
+
+export async function runDeploy(args: string[], options: CloudDeployOptions = {}): Promise<number> {
+  const context = commandContext(options);
+  try {
+    const project = await (options.localProjectReader ?? readLocalProject)({
+      subject: option(args, "--subject"),
+      cwd: options.cwd ?? process.cwd(),
+    });
+    const apps = selectedApps(project, args);
+    const appIds = new Set(apps.map((app) => app.doc.id));
+    const grants = project.grants.filter((grant) => grant.subject === project.subject
+      && grant.source === "automation"
+      && grant.appId !== undefined
+      && appIds.has(grant.appId));
+
+    const provided = secretValues(args);
+    const referenced = new Set<string>();
+    for (const app of apps) {
+      for (const name of app.doc.secrets ?? []) {
+        referenced.add(name);
+        if (!provided.has(name)) {
+          context.output.error(`Automation ${app.doc.id} references missing secret ${name}; pass --secret ${name}=VALUE`);
+        }
+      }
+    }
+    const secrets = [...referenced]
+      .filter((name) => provided.has(name))
+      .map((name) => ({ name, value: provided.get(name)! }));
+
+    const requestOptions = machineOptions(args, context);
+    if (secrets.length > 0 && new URL(resolveCloudBaseUrl(requestOptions)).protocol !== "https:") {
+      throw new Error("Deploying secret values requires an HTTPS Vendo Cloud URL");
+    }
+    const response = deployResponse(await context.fetcher("/api/v1/hosted/deploy", {
+      ...requestOptions,
+      method: "POST",
+      body: {
+        apps: apps.map((app) => ({ doc: app.doc, enabled: app.enabled })),
+        grants,
+        secrets,
+      },
+    }));
+    if (args.includes("--json")) printJson(context.output, response);
+    else printDeploySummary(context, response);
+    return 0;
+  } catch (error) {
+    if (error instanceof CloudError && error.code === "cloud-required") {
+      context.output.error("This key's org needs a Cloud plan (cloud-required).");
+    } else {
+      context.output.error(errorMessage(error));
+    }
+    return 1;
+  }
+}

--- a/packages/vendo/src/cli/cloud/index.test.ts
+++ b/packages/vendo/src/cli/cloud/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { runCloud } from "./index.js";
 
 function output() {
@@ -13,6 +13,7 @@ describe("cloud command dispatch", () => {
     expect(await runCloud(["--help"], { output: messages.sink })).toBe(0);
     expect(messages.logs.join("\n")).toContain("pin-ship --app <id>");
     expect(messages.logs.join("\n")).toContain("login EMAIL");
+    expect(messages.logs.join("\n")).toContain("deploy [--app <id>] [--secret NAME=VALUE]");
   });
 
   it("returns one for unknown cloud commands", async () => {
@@ -25,5 +26,42 @@ describe("cloud command dispatch", () => {
     const messages = output();
     expect(await runCloud(["validate"], { output: messages.sink, env: {} })).toBe(1);
     expect(messages.errors).toEqual(["Pass --key or set VENDO_API_KEY"]);
+  });
+
+  it("dispatches deploy with the machine principal", async () => {
+    const messages = output();
+    const fetcher = vi.fn().mockResolvedValue({
+      org: { id: "org_1", slug: "acme" },
+      instance: { status: "active" },
+      applied: { apps: 1, grants: 0, secrets: 0 },
+      webhooks: [],
+    });
+    const localProjectReader = vi.fn().mockResolvedValue({
+      subject: "user_a",
+      apps: [{
+        enabled: true,
+        doc: {
+          format: "vendo/app@1",
+          id: "app_auto",
+          name: "Automation",
+          trigger: {
+            on: { kind: "schedule", every: "1h" },
+            run: { kind: "steps", steps: [] },
+          },
+        },
+      }],
+      grants: [],
+    });
+
+    expect(await runCloud(["deploy", "--key", "vnd_test", "--json"], {
+      output: messages.sink,
+      env: {},
+      fetcher,
+      localProjectReader,
+    })).toBe(0);
+    expect(fetcher).toHaveBeenCalledWith("/api/v1/hosted/deploy", expect.objectContaining({
+      auth: "key",
+      apiKey: "vnd_test",
+    }));
   });
 });

--- a/packages/vendo/src/cli/cloud/index.ts
+++ b/packages/vendo/src/cli/cloud/index.ts
@@ -5,6 +5,7 @@ import { runInvite, runMembers } from "./members.js";
 import { cloudConsoleOutput } from "./output.js";
 import { runBilling, runDeployments, runOrgs, runUsage } from "./read.js";
 import { runPinShip, runPublish, runShare, runValidate } from "./services.js";
+import { runDeploy, type CloudDeployOptions } from "./deploy.js";
 
 export const CLOUD_HELP = `vendo cloud — Vendo Cloud API client
 
@@ -27,6 +28,8 @@ User commands:
 
 Machine commands:
   validate                              Validate a key and show entitlements
+  deploy [--app <id>] [--secret NAME=VALUE]
+                                        Deploy local enabled automations to the hosted instance
   share <appfile.json>                  Create a ShareSnapshot
   publish <appfile.json>                Create a PublishRecord
   pin-ship --app <id> --slot <slot> --base <hash> --diff <file>
@@ -34,10 +37,14 @@ Machine commands:
 Global options:
   --api-url <url>  Override VENDO_CLOUD_URL / https://console.vendo.run
   --key <vnd_...>  Override VENDO_API_KEY for machine commands
-  --json           JSON output (all command results are JSON)
+  --app <id>       Deploy only this automation (repeatable; includes disabled selections)
+  --subject <id>   Local subject (required when .vendo/data contains more than one)
+  --secret NAME=VALUE
+                   Deploy a referenced secret value (repeatable)
+  --json           JSON output (deploy defaults to a concise summary table)
 `;
 
-export type RunCloudOptions = CloudCommandOptions & CloudAuthOptions;
+export type RunCloudOptions = CloudCommandOptions & CloudAuthOptions & CloudDeployOptions;
 
 export async function runCloud(args: string[], options: RunCloudOptions = {}): Promise<number> {
   const [command, ...commandArgs] = args;
@@ -57,6 +64,7 @@ export async function runCloud(args: string[], options: RunCloudOptions = {}): P
   if (command === "invite") return runInvite(commandArgs, options);
   if (command === "billing") return runBilling(commandArgs, options);
   if (command === "validate") return runValidate(commandArgs, options);
+  if (command === "deploy") return runDeploy(commandArgs, options);
   if (command === "share") return runShare(commandArgs, options);
   if (command === "publish") return runPublish(commandArgs, options);
   if (command === "pin-ship") return runPinShip(commandArgs, options);

--- a/packages/vendo/src/cli/cloud/output.ts
+++ b/packages/vendo/src/cli/cloud/output.ts
@@ -9,6 +9,16 @@ export function printJson(output: Output, value: unknown): void {
   output.log(JSON.stringify(value, null, 2));
 }
 
+export function formatTable(headers: string[], rows: string[][]): string {
+  const widths = headers.map((header, column) => Math.max(
+    header.length,
+    ...rows.map((row) => row[column]?.length ?? 0),
+  ));
+  return [headers, ...rows]
+    .map((row) => row.map((cell, column) => cell.padEnd(widths[column] ?? cell.length)).join("  ").trimEnd())
+    .join("\n");
+}
+
 export function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Vendo Cloud request failed";
 }


### PR DESCRIPTION
## Summary

- add `vendo cloud deploy` as a machine-key command that reads `.vendo/data`, scopes by local subject, and deploys selected automation documents plus their active automation grants
- support repeatable `--app`, `--subject`, and `--secret NAME=VALUE` flags; only referenced secret values are sent, and secret-bearing deploys require HTTPS
- add concise applied-count/webhook output, `--json` output, exact wire-contract coverage, help text, and hosted-runtime E2E guidance

## Secret handling

The local store contract exposes encrypted secret rows but does not expose a CLI-reachable local decryption key. This v1 therefore uses repeatable `--secret NAME=VALUE`; missing referenced values warn without blocking app/grant deployment, and no new store decryption surface was added.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- focused cloud CLI suite: 35/35 passing
- isolated `@vendoai/corpus-harness` suite: 84/84 passing

`pnpm test` at repository scope encountered unrelated fixed-timeout failures under concurrent worktree load: the `@vendoai/corpus-harness` aggregate run timed out despite its isolated 84/84 pass, and a serialized aggregate retry later timed out waiting for the child-writer marker in `packages/store/src/durability.drill.test.ts`. This change does not touch either suite; PR CI is the merge gate.

Do not merge until CI is green.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `vendo cloud deploy`, a machine-key CLI that pushes local automations and their active grants (plus optional secrets) from `.vendo/data` to a hosted instance. Adds per-app warnings for `fn:` steps that can't run in hosted sandboxes. This delivers the deploy piece of ENG-297 (Hosted Runtime).

- **New Features**
  - `vendo cloud deploy`: reads `.vendo/data`, scopes by `--subject`, deploys enabled automations by default; `--app` can restrict selection and include disabled when explicitly chosen.
  - Sends only active grants with `source: "automation"` for selected apps; rejects `--app` that isn’t an automation.
  - Secrets via repeatable `--secret NAME=VALUE`; only referenced names are sent and HTTPS is required.
  - Warns once per selected automation if it has `fn:` steps; deploy continues.
  - Output: concise applied counts and webhook table; `--json` returns the raw response.
  - Updated help and repeatable-flag parsing; tests cover selection, secrets, TLS guardrails, `fn:` warnings, and errors.

- **Migration**
  - Run: `vendo cloud deploy --key vnd_...`.
  - If multiple local subjects, pass `--subject <subject>`. Use `--secret NAME=VALUE` to provide referenced secrets and `--app <id>` to limit which automations deploy.

<sup>Written for commit ea4319696195ac5ac854716af8cc21092b19559e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

