### PR TITLE
fix(ui): JailedComponent auto-height ratchet (ENG-244)

### DIFF
--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -217,6 +217,7 @@ export default function SecurityProbe({ label, onRun }) {
   const [navigateStatus, setNavigateStatus] = useState("not run");
   const [beaconStatus, setBeaconStatus] = useState("not run");
   const [imageStatus, setImageStatus] = useState("not run");
+  const [expanded, setExpanded] = useState(false);
 
   async function probeFetch() {
     try {
@@ -301,8 +302,18 @@ export default function SecurityProbe({ label, onRun }) {
     setActionStatus("delivered");
   }
 
-  return <section aria-label="Generated security probe">
+  return <section
+    aria-label="Generated security probe"
+    style={{ minHeight: "100vh", paddingBottom: 40 }}
+  >
     <h2>{label}</h2>
+    <button type="button" onClick={() => setExpanded(value => !value)}>
+      {expanded ? "Collapse content" : "Expand content"}
+    </button>
+    <div
+      aria-label="Resizable generated content"
+      style={{ height: expanded ? 520 : 80, background: "linear-gradient(#dbeafe, #eff6ff)" }}
+    />
     <button type="button" onClick={probeFetch}>Probe fetch</button>
     <output id="fetch-status">fetch: {fetchStatus}</output>
     <button type="button" onClick={probeXhr}>Probe xhr</button>
@@ -331,11 +342,17 @@ export default function ThrowingGeneratedComponent() {
 }
 `;
 
+const emptySource = String.raw`
+export default function EmptyGeneratedComponent() {
+  return null;
+}
+`;
+
 const jailTree: Tree = {
   formatVersion: "vendo-genui/v1",
   root: "root",
   nodes: [
-    { id: "root", component: "Stack", children: ["before", "probe", "thrower", "after"] },
+    { id: "root", component: "Stack", children: ["before", "probe", "thrower", "empty", "after"] },
     { id: "before", component: "Text", props: { text: "Jail siblings before" } },
     {
       id: "probe",
@@ -347,11 +364,13 @@ const jailTree: Tree = {
       },
     },
     { id: "thrower", component: "ThrowingGeneratedComponent", source: "generated" },
+    { id: "empty", component: "EmptyGeneratedComponent", source: "generated" },
     { id: "after", component: "Text", props: { text: "Jail sibling survived" } },
   ],
   components: {
     SecurityProbe: securitySource,
     ThrowingGeneratedComponent: throwingSource,
+    EmptyGeneratedComponent: emptySource,
   },
 };
 

--- a/packages/ui/e2e/jail-and-tree.spec.ts
+++ b/packages/ui/e2e/jail-and-tree.spec.ts
@@ -31,9 +31,36 @@ test("generated components stay in the opaque-origin CSP jail and actions cross 
     payload: { invoiceId: "inv_42" },
   }));
 
-  await expect(page.getByRole("note", { name: "Generated component error" })).toContainText("generated render exploded inside its jail");
+  const generatedNotices = page.getByRole("note", { name: "Generated component error" });
+  await expect(generatedNotices.filter({ hasText: "generated render exploded inside its jail" })).toBeVisible();
+  await expect(generatedNotices.filter({ hasText: "EmptyGeneratedComponent: generated component rendered no content" })).toBeVisible();
   await expect(page.getByText("Jail sibling survived")).toBeVisible();
   expect(pageErrors, "jail failures must be reported in-surface, not as uncaught page errors").toEqual([]);
+});
+
+test("generated component iframe height follows content growth and shrinkage without feedback", async ({ page }) => {
+  await openScenario(page, "tree-jail");
+  const iframe = page.locator('iframe[title="Generated component: SecurityProbe"]');
+  const jail = jailFrame(page, "SecurityProbe");
+  const mount = jail.locator("#vendo-jail-root");
+  await expect(jail.getByRole("heading", { name: "Rendered generated props" })).toBeVisible();
+
+  const frameHeight = () => iframe.evaluate(element => element.getBoundingClientRect().height);
+  const contentHeight = () => mount.evaluate(element => element.getBoundingClientRect().height);
+  const heightDelta = async () => Math.abs(await frameHeight() - await contentHeight());
+
+  await expect.poll(heightDelta).toBeLessThanOrEqual(1);
+  const collapsedHeight = await frameHeight();
+
+  await jail.getByRole("button", { name: "Expand content" }).click();
+  await expect.poll(frameHeight).toBeGreaterThan(collapsedHeight + 400);
+  await expect.poll(heightDelta).toBeLessThanOrEqual(1);
+  const expandedHeight = await frameHeight();
+
+  await jail.getByRole("button", { name: "Collapse content" }).click();
+  await expect.poll(frameHeight).toBeLessThan(expandedHeight - 400);
+  await expect.poll(heightDelta).toBeLessThanOrEqual(1);
+  expect(await frameHeight()).toBeCloseTo(collapsedHeight, 0);
 });
 
 test("tree node failures and dangling children remain contained", async ({ page }) => {

--- a/packages/ui/src/tree/jail/JailedComponent.tsx
+++ b/packages/ui/src/tree/jail/JailedComponent.tsx
@@ -43,7 +43,7 @@ function buildJailSrcdoc(): string {
   const head = [
     `<meta http-equiv="Content-Security-Policy" content="${csp}">`,
     "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">",
-    "<style>html,body{margin:0;padding:0;background:transparent;height:100%}iframe{display:block;width:100%;height:100%;border:0;background:transparent}</style>",
+    "<style>*,*::before,*::after{box-sizing:border-box}html,body{margin:0;padding:0;background:transparent;height:100%}iframe{display:block;width:100%;height:100%;border:0;background:transparent}</style>",
   ].join("");
 
   // The inner document: the runtime plus the generated code it later renders.
@@ -149,6 +149,8 @@ export function JailedComponent({
           });
       } else if (message.kind === "error") {
         setError(typeof message.message === "string" ? message.message : "generated component failed");
+      } else if (message.kind === "empty") {
+        setError("generated component rendered no content");
       } else if (message.kind === "resize" && typeof message.height === "number" && Number.isFinite(message.height)) {
         iframe.style.height = `${Math.min(MAX_JAIL_HEIGHT, Math.max(1, message.height))}px`;
       }

--- a/packages/ui/src/tree/jail/runtime-entry.tsx
+++ b/packages/ui/src/tree/jail/runtime-entry.tsx
@@ -23,6 +23,10 @@ globalThis.__VENDO_JAIL_JSX__ = { jsx, jsxs, Fragment };
 
 const mount = document.createElement("div");
 mount.id = "vendo-jail-root";
+// Contain first/last-child margins inside the measured box. Otherwise those
+// margins can sit outside the mount and be clipped even when its own height is
+// reported exactly.
+mount.style.display = "flow-root";
 document.body.appendChild(mount);
 
 let root: Root | undefined;
@@ -123,7 +127,10 @@ class RuntimeBoundary extends React.Component<React.PropsWithChildren, { error?:
   }
 }
 
-async function renderComponent(source: string, rawProps: Record<string, unknown>): Promise<void> {
+async function renderComponent(
+  source: string,
+  rawProps: Record<string, unknown>,
+): Promise<"ready" | "empty" | "error"> {
   const Component = await load(source);
   const props = hydrate(rawProps) as Record<string, unknown>;
   props.vendo = {
@@ -132,12 +139,20 @@ async function renderComponent(source: string, rawProps: Record<string, unknown>
       post({ kind: "state-set", key, value });
     },
   };
-  root ??= createRoot(mount);
-  root.render(
-    <RuntimeBoundary>
-      <Component {...props} />
-    </RuntimeBoundary>,
-  );
+  const renderRoot = root ??= createRoot(mount);
+  const boundaryRef = React.createRef<RuntimeBoundary>();
+  // Commit before classifying the result. React root.render is concurrent by
+  // default, so inspecting the mount immediately after it would report a
+  // false empty result before the first commit.
+  flushSync(() => {
+    renderRoot.render(
+      <RuntimeBoundary ref={boundaryRef}>
+        <Component {...props} />
+      </RuntimeBoundary>,
+    );
+  });
+  if (boundaryRef.current?.state.error) return "error";
+  return mount.hasChildNodes() ? "ready" : "empty";
 }
 
 /** Host brand tokens: only --vendo-* custom properties may cross into the jail,
@@ -163,7 +178,10 @@ window.addEventListener("message", (event) => {
   if (message.kind === "render" && typeof message.source === "string") {
     applyThemeVars(message.themeVars);
     void renderComponent(message.source, (message.props ?? {}) as Record<string, unknown>)
-      .then(() => post({ kind: "ready" }))
+      .then((result) => {
+        if (result === "ready") post({ kind: "ready" });
+        else if (result === "empty") post({ kind: "empty" });
+      })
       .catch((error: unknown) => post({
         kind: "error",
         message: error instanceof Error ? error.message : String(error),
@@ -180,15 +198,58 @@ window.addEventListener("message", (event) => {
   }
 });
 
+const VIEWPORT_BLOCK_UNIT = /(?:d|s|l)?v(?:h|b)(?![a-z])/iu;
+const VIEWPORT_BLOCK_PROPERTIES = ["height", "min-height", "block-size", "min-block-size"] as const;
+
+let lastReportedHeight: number | undefined;
+let mutationObserver: MutationObserver | undefined;
+
+function contentHeight(): number {
+  const elements = [mount, ...mount.querySelectorAll<HTMLElement>("[style]")];
+
+  // A generated root commonly uses min-height:100vh. Inside an auto-sized
+  // iframe, that makes its "content" depend on the previous host height. An
+  // auto-height surface has no independent block viewport, so normalize only
+  // inline viewport-relative block constraints to their content-sized forms.
+  for (const element of elements) {
+    for (const property of VIEWPORT_BLOCK_PROPERTIES) {
+      const value = element.style.getPropertyValue(property);
+      if (!VIEWPORT_BLOCK_UNIT.test(value)) continue;
+      element.style.setProperty(property, property.startsWith("min-") ? "0" : "auto", "important");
+    }
+  }
+
+  const height = Math.ceil(Math.max(mount.getBoundingClientRect().height, mount.scrollHeight));
+  // Attribute observation catches state-driven constraint changes. Discard
+  // the normalization mutations themselves so they cannot loop.
+  mutationObserver?.takeRecords();
+  return height;
+}
+
+function reportContentHeight(): void {
+  const height = contentHeight();
+  if (height === lastReportedHeight) return;
+  lastReportedHeight = height;
+  post({ kind: "resize", height });
+}
+
 if (typeof ResizeObserver !== "undefined") {
-  const observer = new ResizeObserver(() => {
-    post({ kind: "resize", height: document.documentElement.scrollHeight });
-  });
-  // Observe the growing boxes: html/body are pinned to height:100% of the
-  // frame, so their border boxes never change when content grows — only the
-  // React mount's does.
+  const observer = new ResizeObserver(reportContentHeight);
+  // The mount changes for content growth; observing viewport-owned html/body
+  // would reintroduce the host/frame feedback path.
   observer.observe(mount);
-  observer.observe(document.body);
+}
+
+if (typeof MutationObserver !== "undefined") {
+  mutationObserver = new MutationObserver(reportContentHeight);
+  // React can add a new viewport constraint without changing the current box,
+  // so also react to render mutations and normalize before measuring.
+  mutationObserver.observe(mount, {
+    attributes: true,
+    characterData: true,
+    childList: true,
+    subtree: true,
+  });
 }
 
 post({ kind: "booted" });

--- a/packages/ui/test/tree/frames-and-jail.test.tsx
+++ b/packages/ui/test/tree/frames-and-jail.test.tsx
@@ -137,4 +137,55 @@ describe("generated component jail structure", () => {
     await waitFor(() => expect(screen.getByTitle("Generated component: Editable")).toBeTruthy());
     expect(screen.queryByRole("note", { name: "Generated component error" })).toBeNull();
   });
+
+  it("applies reported content height for both growth and shrinkage", () => {
+    const generatedTree: Tree = {
+      formatVersion: VENDO_TREE_FORMAT,
+      root: "root",
+      nodes: [{ id: "root", component: "Resizable", source: "generated" }],
+      components: { Resizable: "export default function Resizable() { return <p>content</p> }" },
+    };
+
+    render(<TreeView tree={generatedTree} components={{}} onAction={ok} />);
+    const iframe = screen.getByTitle("Generated component: Resizable") as HTMLIFrameElement;
+
+    window.dispatchEvent(new MessageEvent("message", {
+      source: iframe.contentWindow,
+      data: { kind: "resize", height: 1_400 },
+    }));
+    expect(iframe.style.height).toBe("1400px");
+
+    window.dispatchEvent(new MessageEvent("message", {
+      source: iframe.contentWindow,
+      data: { kind: "resize", height: 280 },
+    }));
+    expect(iframe.style.height).toBe("280px");
+
+    window.dispatchEvent(new MessageEvent("message", {
+      source: iframe.contentWindow,
+      data: { kind: "resize", height: 10_000 },
+    }));
+    expect(iframe.style.height).toBe("8192px");
+  });
+
+  it("contains a generated component that renders no content", async () => {
+    const generatedTree: Tree = {
+      formatVersion: VENDO_TREE_FORMAT,
+      root: "root",
+      nodes: [{ id: "root", component: "Empty", source: "generated" }],
+      components: { Empty: "export default function Empty() { return null; }" },
+    };
+
+    render(<TreeView tree={generatedTree} components={{}} onAction={ok} />);
+    const iframe = screen.getByTitle("Generated component: Empty") as HTMLIFrameElement;
+
+    window.dispatchEvent(new MessageEvent("message", {
+      source: iframe.contentWindow,
+      data: { kind: "empty" },
+    }));
+
+    expect((await screen.findByRole("note", { name: "Generated component error" })).textContent)
+      .toBe("Empty: generated component rendered no content");
+    expect(screen.queryByTitle("Generated component: Empty")).toBeNull();
+  });
 });

--- a/packages/ui/test/tree/jail-runtime-empty.test.ts
+++ b/packages/ui/test/tree/jail-runtime-empty.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+  document.body.replaceChildren();
+});
+
+describe("generated component jail empty render runtime", () => {
+  it("reports an explicit empty result instead of ready for a null render", async () => {
+    class FakeResizeObserver implements ResizeObserver {
+      constructor(_callback: ResizeObserverCallback) {}
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+
+    vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+    const postMessage = vi.spyOn(window, "postMessage").mockImplementation(() => undefined);
+    await import("../../src/tree/jail/runtime-entry.js");
+    postMessage.mockClear();
+
+    window.dispatchEvent(new MessageEvent("message", {
+      source: window,
+      data: {
+        vendo: true,
+        kind: "render",
+        source: "export default function Empty() { return null; }",
+        props: {},
+      },
+    }));
+
+    await vi.waitFor(() => {
+      expect(postMessage).toHaveBeenCalledWith({ vendo: true, kind: "empty" }, "*");
+    });
+    expect(postMessage).not.toHaveBeenCalledWith({ vendo: true, kind: "ready" }, "*");
+  }, 15_000);
+});

--- a/packages/ui/test/tree/jail-runtime-resize.test.ts
+++ b/packages/ui/test/tree/jail-runtime-resize.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+  delete (document.documentElement as unknown as { scrollHeight?: number }).scrollHeight;
+  document.body.replaceChildren();
+});
+
+describe("generated component jail resize runtime", () => {
+  it("reports the mount content height as it grows and shrinks, independent of the frame height", async () => {
+    let resizeCallback: ResizeObserverCallback | undefined;
+    let contentHeight = 1_400;
+    let frameHeight = 150;
+    const observed: Element[] = [];
+
+    class FakeResizeObserver implements ResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+      }
+
+      observe(target: Element) {
+        observed.push(target);
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+
+    vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function () {
+      if (this.id !== "vendo-jail-root") return DOMRect.fromRect();
+      const generatedRoot = this.firstElementChild as HTMLElement | null;
+      const viewportConstraintIsNeutralized = generatedRoot !== null
+        && !generatedRoot.style.minHeight.includes("vh");
+      return DOMRect.fromRect({ height: viewportConstraintIsNeutralized ? contentHeight : frameHeight + 40 });
+    });
+    Object.defineProperty(document.documentElement, "scrollHeight", {
+      configurable: true,
+      get: () => 8_192,
+    });
+    const postMessage = vi.spyOn(window, "postMessage").mockImplementation(() => undefined);
+
+    await import("../../src/tree/jail/runtime-entry.js");
+    const generatedRoot = document.createElement("section");
+    generatedRoot.style.minHeight = "100vh";
+    generatedRoot.style.paddingBottom = "40px";
+    document.querySelector("#vendo-jail-root")!.appendChild(generatedRoot);
+    expect(resizeCallback).toBeTypeOf("function");
+    expect(observed.map(element => element.id)).toEqual(["vendo-jail-root"]);
+    postMessage.mockClear();
+
+    resizeCallback!([], {} as ResizeObserver);
+    expect(postMessage).toHaveBeenLastCalledWith({ vendo: true, kind: "resize", height: 1_400 }, "*");
+
+    frameHeight = 1_400;
+    contentHeight = 280;
+    resizeCallback!([], {} as ResizeObserver);
+    expect(postMessage).toHaveBeenLastCalledWith({ vendo: true, kind: "resize", height: 280 }, "*");
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary

- Measure the generated mount content instead of document height, and normalize inline viewport-relative block sizing so the frame cannot feed its previous height back into the next measurement.
- Observe both resize and render mutations so content growth and shrinkage update the host frame.
- Emit a distinct empty signal for components whose render returns null and show the existing contained error notice in the host.

## Root cause

The inner html/body and generated 100vh roots inherited the host frame height. Posting that height and writing it back to the outer iframe created a feedback ratchet that climbed to the 8,192px safety cap.

## Verification

- `pnpm build` — passed, 18/18 tasks.
- Focused jail unit regressions — passed, 13/13 tests.
- Jail browser regressions — passed, 2/2, including 100vh growth and shrink plus null render containment.
- Live Maple prompt `build me a budget tracker` — frame stabilized at 1,588px for the rendered content instead of 8,192px.
- `pnpm --filter @vendoai/ui typecheck` and `pnpm lint` — passed.
- `pnpm test` — repository fan-out remains limited by shared-machine contention: unrelated UI chrome requests hit 5s timeouts and Express probes hit 60s timeouts; all jail tests pass, and the same UI suite passed 80/80 earlier in isolation before the machine became saturated.

## Screenshots

### Before

<img width="2400" height="17062" alt="eng-244-before" src="https://github.com/user-attachments/assets/79dafa7f-c927-480b-8e80-647b99d01d58" />

### After

<img width="2400" height="1514" alt="eng-244-after" src="https://github.com/user-attachments/assets/2536fe6c-d68b-4c25-8278-70813ee03cae" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the auto-height feedback loop in the generated component jail and adds explicit handling for null renders so the host shows an error instead of a blank iframe. Frames now match real content height and no longer ratchet to 8,192px (ENG-244).

- **Bug Fixes**
  - Measure the mount’s content, not the document; neutralize inline viewport-relative block constraints (e.g., 100vh) so the frame height can’t feed into the next measurement; observe resizes and DOM mutations; post height only on change; clamp to the safety cap.
  - Emit a distinct "empty" result when a generated component renders null; the host shows the contained error and hides the iframe.
  - Improve measurement accuracy by containing margins via flow-root on the mount and applying universal box-sizing in the jail document.
  - Add focused unit and e2e coverage for growth/shrink and empty renders, including an expand/collapse scenario to verify stability.

<sup>Written for commit 6b8ba445c2b8cd24f547e39885dbf122893a1759. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




## Cross-links

- The tree-layer half of the blank-iframe failure (empty-tree notice + edit reliability) is https://github.com/runvendo/vendo/pull/173 (ENG-245, gen-streaming). Its "Residual gap: jail null-render" section is exactly what this PR closes; a non-empty tree containing a jailed component that renders null passes their tree check and is caught here.
