### PR TITLE
feat(mcp): prebuilt themeable consent/login-bounce page

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -122,23 +122,38 @@ const vendo = createVendo({
 });
 ```
 
-`oauth` is a two-function `HostOAuthAdapter`. The door owns all OAuth protocol
-mechanics. The host owns exactly two answers: who is this user, and did they
-consent.
+`oauth` uses the host's existing session and subject resolver. The door owns the
+OAuth protocol and the complete consent UI.
 
 ```ts
 import type { HostOAuthAdapter } from "@vendoai/mcp";
 
 const hostOAuth: HostOAuthAdapter = {
-  // Authenticate with your existing session machinery and confirm scope consent.
-  authorize: async (req, { clientName, scopes }) => {
-    const subject = await confirmConsentWithHostLogin(req, clientName, scopes);
-    return { subject };
+  // Use the exact returnTo: after login the door resumes the OAuth request once,
+  // sees the new session, and shows consent instead of bouncing back to login.
+  session: async (req, { returnTo }) => {
+    const subject = await currentSubject(req);
+    if (subject) return { subject };
+    const login = new URL("/login", req.url);
+    login.searchParams.set("returnTo", returnTo);
+    return Response.redirect(login);
   },
   // Resolve a subject to the principal the door executes as. null revokes.
   principal: async (subject) => resolveUser(subject),
 };
 ```
+
+The prebuilt page uses the same `--vendo-*` CSS token namespace as the UI
+pipeline; `createVendo` automatically passes the resolved `.vendo/theme.json`
+theme into it. The page CSRF-protects approve/deny, rejects decision replay,
+escapes the attacker-controlled DCR `client_name`, and returns the standard
+OAuth code or `access_denied` redirect.
+
+Need a fully custom page? Add `authorize(req, ctx)` alongside `session`. Render
+your page from `ctx.clientName`/`ctx.scopes` (escape both), then submit hidden
+`transaction` and `csrf_token` values from `ctx.consent` plus
+`decision=approve|deny` to `ctx.consent.action`. The door keeps ownership of the
+flow and validation.
 
 MCP clients have no host browser session, so door tool calls cannot forward
 cookies. They authenticate over the **same `actAs` seam** away automations use.

--- a/fixtures/mcp-e2e/src/authorize-interactive.e2e.test.ts
+++ b/fixtures/mcp-e2e/src/authorize-interactive.e2e.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { createStack, resetFixture } from "./harness.js";
 import {
   authorizeCode,
+  connectWithSdk,
   exchangeCode,
   issueTokens,
   refreshToken,
@@ -20,6 +21,21 @@ describe("OAuth consent delegation and protocol sad paths", () => {
       expect(response.status).toBe(302);
       expect(response.headers.get("location")).toBe("https://fixture.example/consent");
       expect(await response.text()).toBe("");
+    } finally {
+      await stack.close();
+    }
+  });
+
+  it("completes the prebuilt consent page through the real MCP SDK OAuth dance", async () => {
+    const stack = await createStack({ oauthMode: "prebuilt" });
+    try {
+      const connected = await connectWithSdk(stack);
+      try {
+        expect(connected.provider.savedTokens?.access_token).toMatch(/^vmat_/);
+        expect((await connected.client.listTools()).tools.length).toBeGreaterThan(0);
+      } finally {
+        await connected.close();
+      }
     } finally {
       await stack.close();
     }

--- a/fixtures/mcp-e2e/src/harness.ts
+++ b/fixtures/mcp-e2e/src/harness.ts
@@ -82,7 +82,7 @@ const fixtureApp: AppDocument = {
   },
 };
 
-export type OAuthMode = "auto" | "interactive";
+export type OAuthMode = "auto" | "interactive" | "prebuilt";
 
 export interface Stack {
   store: VendoStore;
@@ -161,7 +161,18 @@ export async function createStack(options: StackOptions = {}): Promise<Stack> {
     data: { subject: SUBJECT, enabled: false, doc: fixtureApp },
     refs: { subject: SUBJECT },
   });
-  const oauth: HostOAuthAdapter = {
+  const resolvePrincipal: HostOAuthAdapter["principal"] = async (subject) => {
+    return revoked.has(subject)
+      ? null
+      : { kind: "user", subject, display: `Fixture ${subject}` } satisfies Principal;
+  };
+  const oauth: HostOAuthAdapter = control.oauthMode === "prebuilt" ? {
+    async session() {
+      if (!control.autoSubject) return new Response("missing fixture session", { status: 401 });
+      return { subject: control.autoSubject };
+    },
+    principal: resolvePrincipal,
+  } : {
     async authorize() {
       if (control.oauthMode === "interactive") {
         return new Response(null, {
@@ -172,11 +183,7 @@ export async function createStack(options: StackOptions = {}): Promise<Stack> {
       if (!control.autoSubject) return new Response("missing fixture session", { status: 401 });
       return { subject: control.autoSubject };
     },
-    async principal(subject) {
-      return revoked.has(subject)
-        ? null
-        : { kind: "user", subject, display: `Fixture ${subject}` } satisfies Principal;
-    },
+    principal: resolvePrincipal,
   };
   const appsPort: AppsPort = {
     list: (ctx) => apps.list(ctx),

--- a/fixtures/mcp-e2e/src/support.ts
+++ b/fixtures/mcp-e2e/src/support.ts
@@ -86,7 +86,10 @@ export async function connectWithSdk(stack: Stack): Promise<ConnectedClient> {
   await expect(firstClient.connect(firstTransport)).rejects.toBeInstanceOf(UnauthorizedError);
   const authorizationUrl = provider.authorizationUrl;
   if (!authorizationUrl) throw new Error("SDK did not request an OAuth redirect");
-  const authorization = await fetch(authorizationUrl, { redirect: "manual" });
+  let authorization = await fetch(authorizationUrl, { redirect: "manual" });
+  if (authorization.status === 200 && authorization.headers.get("content-type")?.includes("text/html")) {
+    authorization = await submitPrebuiltConsent(authorization);
+  }
   expect(authorization.status).toBe(302);
   const location = authorization.headers.get("location");
   if (!location) throw new Error("Authorization did not return a redirect location");
@@ -110,6 +113,33 @@ export async function connectWithSdk(stack: Stack): Promise<ConnectedClient> {
       await client.close();
     },
   };
+}
+
+async function submitPrebuiltConsent(page: Response): Promise<Response> {
+  const html = await page.text();
+  const action = htmlAttribute(html, "form", "action").replaceAll("&amp;", "&");
+  return fetch(action, {
+    method: "POST",
+    redirect: "manual",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      transaction: inputValue(html, "transaction"),
+      csrf_token: inputValue(html, "csrf_token"),
+      decision: "approve",
+    }),
+  });
+}
+
+function inputValue(html: string, name: string): string {
+  const match = html.match(new RegExp(`<input[^>]+name="${name}"[^>]+value="([^"]+)"`, "i"));
+  if (!match?.[1]) throw new Error(`Consent page omitted ${name}`);
+  return match[1];
+}
+
+function htmlAttribute(html: string, element: string, attribute: string): string {
+  const match = html.match(new RegExp(`<${element}[^>]+${attribute}="([^"]+)"`, "i"));
+  if (!match?.[1]) throw new Error(`Consent page omitted ${element}[${attribute}]`);
+  return match[1];
 }
 
 export async function registerClient(stack: Stack, redirectUris = [REDIRECT_URI]) {

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -94,11 +94,11 @@ package-root API remains the frozen `createMcpDoor(config)` surface.
 
 ## Operating notes for host integrators
 
-- **`HostOAuthAdapter.authorize` renders consent.** The door passes the client's
-  `client_name` (from DCR or a Client ID Metadata Document — attacker-controllable)
-  straight to your adapter. **Escape it** before rendering it on a consent screen;
-  a client can register a name like `"Google Drive (official)"` for phishing or
-  inject markup for XSS on your page. The door deliberately does no rendering.
+- **The prebuilt page escapes `client_name`.** DCR and Client ID Metadata
+  Documents make that value attacker-controlled. If you replace the page with
+  `HostOAuthAdapter.authorize`, your renderer must keep escaping it too.
+- **Return from login through `session`'s `returnTo`.** It preserves the complete
+  OAuth request and prevents the common login → authorize → login loop.
 - **Single-secret redemption is claimed in the database.** Authorization codes and
   refresh tokens use the store's atomic compare-and-claim capability, so one
   redeemer wins across multiple door processes sharing Postgres. A custom
@@ -109,3 +109,37 @@ package-root API remains the frozen `createMcpDoor(config)` surface.
   egress at your network layer — the door cannot portably prevent DNS rebinding.
 - **`vendo init` must ask before opening the door.** The shipped guard policy blocks
   `venue: "mcp"`; opening the door is a host decision, never a default.
+
+## Prebuilt consent flow
+
+Use `session` instead of hand-building consent in `authorize`. Return the current
+host subject, or redirect an unauthenticated browser to login through the exact
+`returnTo` the door supplies:
+
+```ts
+const oauth: HostOAuthAdapter = {
+  async session(req, { returnTo }) {
+    const subject = await currentSubject(req);
+    if (subject) return { subject };
+
+    const login = new URL("/login", req.url);
+    login.searchParams.set("returnTo", returnTo);
+    return Response.redirect(login);
+  },
+  async principal(subject) {
+    return resolveUser(subject); // null revokes existing door tokens
+  },
+};
+```
+
+The door renders the consent page, handles approve/deny, CSRF-protects the POST,
+rejects replay, and performs the standard authorization-code redirect. Its CSS
+uses the UI pipeline's `--vendo-*` tokens, including `--vendo-color-*`,
+`--vendo-font-*`, `--vendo-radius-*`, and `--vendo-space-*`. The umbrella passes
+the resolved `.vendo/theme.json` automatically; direct `createMcpDoor` users can
+pass the same core `VendoTheme` as `theme`.
+
+To replace the whole page without taking ownership of the protocol, also provide
+`authorize`. In session mode `ctx.consent` contains the door-owned form state;
+post `transaction`, `csrf_token`, and `decision=approve|deny` to its `action`.
+The door still handles and validates the decision.

--- a/packages/mcp/src/door.test.ts
+++ b/packages/mcp/src/door.test.ts
@@ -10,6 +10,7 @@ import {
   type StoreAdapter,
   type ToolOutcome,
   type ToolRegistry,
+  type VendoTheme,
   type VendoRecord,
 } from "@vendoai/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -17,7 +18,12 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { exportJWK, generateKeyPair, jwtVerify, SignJWT, type KeyLike } from "jose";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createMcpDoorWithState } from "./door.js";
-import { createMcpDoor, type AppsPort, type McpDoor } from "./index.js";
+import {
+  createMcpDoor,
+  type AppsPort,
+  type HostOAuthAdapter,
+  type McpDoor,
+} from "./index.js";
 import type {
   McpDoorState,
   McpStateSession,
@@ -28,6 +34,26 @@ import type {
 const BASE = "https://product.example/api/vendo/mcp";
 const REDIRECT = "https://client.example/callback";
 const VERIFIER = "a-very-long-pkce-verifier-that-is-valid-for-the-test-suite-1234567890";
+const CONSENT_THEME: VendoTheme = {
+  colors: {
+    background: "#101820",
+    surface: "#18242f",
+    text: "#f4f7fa",
+    muted: "#aebbc7",
+    accent: "#ffb81c",
+    accentText: "#101820",
+    danger: "#f35b66",
+    border: "#405261",
+  },
+  typography: {
+    fontFamily: "Inter, sans-serif",
+    headingFamily: "Newsreader, serif",
+    baseSize: "16px",
+  },
+  radius: { small: "4px", medium: "8px", large: "14px" },
+  density: "compact",
+  motion: "reduced",
+};
 
 // The door resolves CIMD hostnames and rejects private answers (SSRF DNS-rebind
 // defense). `.example` is a reserved non-resolving TLD, so mock the resolver;
@@ -400,6 +426,137 @@ describe("createMcpDoor routing and OAuth", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
     expect(harness.authorizeContexts).toEqual([{ clientName: "Metadata client", scopes: ["read", "write"] }]);
   });
+
+  it("bounces a missing host session to login with an exact return-to, then renders consent", async () => {
+    let subject: string | undefined;
+    const sessionCalls: Array<{ url: string; returnTo: string }> = [];
+    const harness = makeHarness({
+      oauth: {
+        async session(req, { returnTo }) {
+          sessionCalls.push({ url: req.url, returnTo });
+          if (!subject) {
+            const login = new URL("https://product.example/login");
+            login.searchParams.set("returnTo", returnTo);
+            return Response.redirect(login);
+          }
+          return { subject };
+        },
+        async principal(resolvedSubject) {
+          return { kind: "user", subject: resolvedSubject };
+        },
+      },
+    });
+    const registered = await register(harness.door);
+    const initial = await authorize(harness.door, registered.body.client_id, { state: "after-login" });
+
+    expect(initial.status).toBe(302);
+    const login = new URL(initial.headers.get("location")!);
+    expect(login.pathname).toBe("/login");
+    const returnTo = login.searchParams.get("returnTo");
+    expect(returnTo).toContain(`${BASE}/authorize?`);
+    expect(new URL(returnTo!).searchParams.get("state")).toBe("after-login");
+
+    subject = "user_1";
+    const resumed = await harness.door.handler(new Request(returnTo!));
+    expect(resumed.status).toBe(200);
+    expect(resumed.headers.get("content-type")).toContain("text/html");
+    expect(await resumed.text()).toContain("Allow Test client to access this product?");
+    expect(sessionCalls).toHaveLength(2);
+    expect(sessionCalls[0]?.returnTo).toBe(sessionCalls[1]?.returnTo);
+  });
+
+  it("renders a themeable consent page and escapes a hostile DCR client_name", async () => {
+    const hostileName = '<img src=x onerror="globalThis.pwned=1"><script>alert(1)</script>';
+    const harness = makeHarness({ oauth: prebuiltOAuth(), theme: CONSENT_THEME });
+    const registered = await register(harness.door, { client_name: hostileName });
+    const response = await authorize(harness.door, registered.body.client_id);
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("content-security-policy")).toContain("form-action 'self'");
+    expect(html).toContain("--vendo-color-accent");
+    expect(html).toContain("--vendo-radius-medium");
+    expect(html).toContain("--vendo-color-accent:#ffb81c");
+    expect(html).toContain("--vendo-heading-family:Newsreader, serif");
+    expect(html).toContain("--vendo-motion:reduced");
+    expect(html).not.toContain(hostileName);
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;img src=x onerror=&quot;globalThis.pwned=1&quot;&gt;");
+  });
+
+  it("denies through the standard OAuth redirect and rejects a missing CSRF token", async () => {
+    const harness = makeHarness({ oauth: prebuiltOAuth() });
+    const registered = await register(harness.door);
+    const page = await authorize(harness.door, registered.body.client_id, { state: "deny-state" });
+    const html = await page.text();
+
+    const csrfFailure = await submitConsent(harness.door, html, "deny", { csrfToken: "wrong" });
+    expect(csrfFailure.status).toBe(400);
+    expect(await csrfFailure.json()).toMatchObject({ error: "invalid_request" });
+
+    const denied = await submitConsent(harness.door, html, "deny");
+    expect(denied.status).toBe(302);
+    const location = new URL(denied.headers.get("location")!);
+    expect(location.origin + location.pathname).toBe(REDIRECT);
+    expect(location.searchParams.get("error")).toBe("access_denied");
+    expect(location.searchParams.get("state")).toBe("deny-state");
+    expect(harness.store.rows("vendo_mcp_grants").some((row) => row.data.kind === "code")).toBe(false);
+  });
+
+  it("consumes an approved consent interaction once and rejects a replay", async () => {
+    const harness = makeHarness({ oauth: prebuiltOAuth() });
+    const registered = await register(harness.door);
+    const page = await authorize(harness.door, registered.body.client_id, { state: "approve-state" });
+    const html = await page.text();
+
+    const approved = await submitConsent(harness.door, html, "approve");
+    expect(approved.status).toBe(302);
+    const location = new URL(approved.headers.get("location")!);
+    const code = location.searchParams.get("code");
+    expect(code).toMatch(/^vmcd_/);
+    expect(location.searchParams.get("state")).toBe("approve-state");
+
+    const replay = await submitConsent(harness.door, html, "approve");
+    expect(replay.status).toBe(400);
+    expect(await replay.json()).toMatchObject({ error: "invalid_request" });
+
+    const token = await exchange(harness.door, {
+      code: code!,
+      client_id: registered.body.client_id,
+      code_verifier: VERIFIER,
+      resource: BASE,
+    });
+    expect(token.status).toBe(200);
+  });
+
+  it("lets authorize replace the page while the door keeps the consent flow", async () => {
+    let customFlow: { action: string; transaction: string; csrfToken: string } | undefined;
+    const harness = makeHarness({
+      oauth: {
+        async session() { return { subject: "user_1" }; },
+        async authorize(_req, ctx) {
+          customFlow = ctx.consent;
+          return new Response("<!doctype html><p>Host-branded consent</p>", {
+            headers: { "content-type": "text/html; charset=utf-8" },
+          });
+        },
+        async principal(subject) { return { kind: "user", subject }; },
+      },
+    });
+    const registered = await register(harness.door);
+    const page = await authorize(harness.door, registered.body.client_id);
+
+    expect(await page.text()).toContain("Host-branded consent");
+    expect(customFlow).toMatchObject({
+      action: expect.stringContaining(`${BASE}/authorize?`),
+      transaction: expect.stringMatching(/^vmci_/),
+      csrfToken: expect.stringMatching(/^vmcsrf_/),
+    });
+    const approved = await submitConsentFields(harness.door, customFlow!, "approve");
+    expect(approved.status).toBe(302);
+    expect(new URL(approved.headers.get("location")!).searchParams.get("code")).toMatch(/^vmcd_/);
+  });
 });
 
 describe("createMcpDoor remote authorization server trust", () => {
@@ -493,6 +650,7 @@ describe("createMcpDoor remote authorization server trust", () => {
 
     for (const request of [
       new Request(`${BASE}/authorize`),
+      new Request(`${BASE}/authorize`, { method: "POST" }),
       new Request(`${BASE}/token`, { method: "POST" }),
       new Request(`${BASE}/register`, { method: "POST" }),
       new Request("https://product.example/.well-known/oauth-authorization-server/api/vendo/mcp"),
@@ -933,9 +1091,11 @@ interface HarnessOptions {
   remoteAs?: { issuer: string; jwksUri?: string; audience: string };
   federation?: { secret: string };
   authorizeResponse?: Response;
+  theme?: VendoTheme;
   /** The subject the OAuth authorize step returns (defaults "user_1"); a fn lets
    * a test mint tokens for two different subjects against one door (FIX G). */
   authorizeSubject?: () => string;
+  oauth?: HostOAuthAdapter;
 }
 
 function makeHarness(options: HarnessOptions = {}) {
@@ -972,7 +1132,8 @@ function makeHarness(options: HarnessOptions = {}) {
     ...(options.mount === undefined ? {} : { mount: options.mount }),
     ...(options.remoteAs === undefined ? {} : { remoteAs: options.remoteAs }),
     ...(options.federation === undefined ? {} : { federation: options.federation }),
-    oauth: {
+    ...(options.theme === undefined ? {} : { theme: options.theme }),
+    oauth: options.oauth ?? {
       async authorize(_req, ctx) {
         authorizeContexts.push(ctx);
         if (options.authorizeResponse) return options.authorizeResponse;
@@ -990,11 +1151,11 @@ function makeHarness(options: HarnessOptions = {}) {
   return { door, store, audits, authorizeContexts, principalSubjects, executions };
 }
 
-async function register(door: McpDoor) {
+async function register(door: McpDoor, metadata: Record<string, unknown> = {}) {
   const response = await door.handler(new Request(`${BASE}/register`, {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ client_name: "Test client", redirect_uris: [REDIRECT], scope: "read write" }),
+    body: JSON.stringify({ client_name: "Test client", redirect_uris: [REDIRECT], scope: "read write", ...metadata }),
   }));
   return { response, body: await response.clone().json() as { client_id: string } & Record<string, unknown> };
 }
@@ -1012,6 +1173,55 @@ async function authorize(door: McpDoor, clientId: string, overrides: Record<stri
     ...overrides,
   });
   return door.handler(new Request(`${BASE}/authorize?${params}`));
+}
+
+function prebuiltOAuth(): HostOAuthAdapter {
+  return {
+    async session() { return { subject: "user_1" }; },
+    async principal(subject) { return { kind: "user", subject }; },
+  };
+}
+
+async function submitConsent(
+  door: McpDoor,
+  html: string,
+  decision: "approve" | "deny",
+  overrides: { csrfToken?: string } = {},
+): Promise<Response> {
+  const action = htmlAttribute(html, "form", "action").replaceAll("&amp;", "&");
+  return submitConsentFields(door, {
+    action,
+    transaction: inputValue(html, "transaction"),
+    csrfToken: overrides.csrfToken ?? inputValue(html, "csrf_token"),
+  }, decision);
+}
+
+async function submitConsentFields(
+  door: McpDoor,
+  flow: { action: string; transaction: string; csrfToken: string },
+  decision: "approve" | "deny",
+): Promise<Response> {
+  return door.handler(new Request(flow.action, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      transaction: flow.transaction,
+      csrf_token: flow.csrfToken,
+      decision,
+    }),
+  }));
+}
+
+function inputValue(html: string, name: string): string {
+  const match = html.match(new RegExp(`<input[^>]+name="${name}"[^>]+value="([^"]+)"`, "i"));
+  if (!match?.[1]) throw new Error(`Consent page omitted ${name}`);
+  return match[1];
+}
+
+function htmlAttribute(html: string, element: string, attribute: string): string {
+  const match = html.match(new RegExp(`<${element}[^>]+${attribute}="([^"]+)"`, "i"));
+  if (!match?.[1]) throw new Error(`Consent page omitted ${element}[${attribute}]`);
+  return match[1];
 }
 
 async function exchange(door: McpDoor, values: Record<string, string>) {

--- a/packages/mcp/src/door.ts
+++ b/packages/mcp/src/door.ts
@@ -7,6 +7,7 @@ import type {
   ToolDescriptor,
   ToolOutcome,
   ToolRegistry,
+  VendoTheme,
 } from "@vendoai/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
@@ -68,12 +69,15 @@ export interface McpDoorConfig {
   tools: ToolRegistry;
   /** Audit reporting for auth events (§3); tool decisions happen inside the bound registry. */
   guard: Guard;
-  /** §3 — two functions; the host owns identity + consent, the door owns the protocol. */
+  /** §3 — the host owns session/principal lookup; the door can own consent too. */
   oauth: HostOAuthAdapter;
   /** Door-owned protocol state (clients, codes, refresh grants) — wired like every other block. */
   store: StoreAdapter;
   /** §4 — saved apps ride along as MCP Apps; absent → tools-only door. */
   apps?: AppsPort;
+  /** The same resolved theme the UI pipeline consumes. The prebuilt consent
+   * page emits it as `--vendo-*` custom properties. */
+  theme?: VendoTheme;
   /** 10-mcp §5 — the door's canonical mount path (e.g. `/api/vendo/mcp`). When
    * set, the cold server card advertises THIS transport URL and learned request
    * paths never override it; when unset the card falls back to `/mcp` until an
@@ -164,7 +168,8 @@ class Door {
     const endpoint = endpointFor(path);
     const mount = endpoint.mount;
     if (endpoint.kind === "authorize") {
-      return req.method === "GET" && this.#config.remoteAs === undefined
+      return this.#config.remoteAs === undefined
+        && (req.method === "GET" || (req.method === "POST" && this.#oauth.hasPrebuiltConsent))
         ? this.#oauth.authorize(req, resourceUri(url.origin, mount))
         : notFound();
     }
@@ -175,7 +180,9 @@ class Door {
       return req.method === "POST" && this.#config.remoteAs === undefined ? this.#oauth.register(req) : notFound();
     }
     if (endpoint.kind === "federate") {
-      return req.method === "GET" && this.#config.federation !== undefined
+      return req.method === "GET"
+        && this.#config.federation !== undefined
+        && this.#config.oauth.authorize !== undefined
         ? handleFederation(req, resourceUri(url.origin, mount), this.#config.federation.secret, this.#config.oauth)
         : notFound();
     }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -6,5 +6,10 @@
  */
 export { createMcpDoor } from "./door.js";
 export type { McpDoor, McpDoorConfig, McpRunContext } from "./door.js";
-export type { HostOAuthAdapter } from "./oauth/adapter.js";
+export type {
+  HostOAuthAdapter,
+  HostOAuthAuthorizeContext,
+  HostOAuthConsentFlow,
+  HostOAuthSessionContext,
+} from "./oauth/adapter.js";
 export type { AppsPort } from "./apps-port.js";

--- a/packages/mcp/src/oauth/adapter.ts
+++ b/packages/mcp/src/oauth/adapter.ts
@@ -1,16 +1,47 @@
 import type { Principal } from "@vendoai/core";
 
-/** 10-mcp §3 — the two-function seam. The door owns ALL protocol mechanics
+export interface HostOAuthConsentFlow {
+  /** Submit approve/deny here with application/x-www-form-urlencoded. */
+  action: string;
+  /** Hidden `transaction` value. Single-use; an approved replay is rejected. */
+  transaction: string;
+  /** Hidden `csrf_token` value. */
+  csrfToken: string;
+}
+
+export interface HostOAuthAuthorizeContext {
+  clientName: string;
+  scopes: string[];
+  /** Present when `session` selects the door-owned flow. A custom page posts
+   * `transaction`, `csrf_token`, and `decision=approve|deny` to `action`; the
+   * door still owns CSRF, replay protection, and the OAuth redirect. */
+  consent?: HostOAuthConsentFlow;
+}
+
+export interface HostOAuthSessionContext {
+  /** Exact authorization URL the host login must return to. Supplying this
+   * removes the common redirect-to-login/authorize loop from host code. */
+  returnTo: string;
+}
+
+/** 10-mcp §3 plus the additive prebuilt-consent path. The door owns ALL protocol mechanics
  * (PKCE, resource binding, token issuance/rotation, client registration,
- * metadata documents, its own state via `store`); the host owns exactly:
- * who is this user, and did they consent. */
+ * metadata documents, its own state via `store`) and, when `session` is used,
+ * the consent decision UI too. */
 export interface HostOAuthAdapter {
-  /** The interactive consent step: authenticate the user with the HOST's
-   * existing session machinery and confirm scope consent. Returns the host
-   * subject on success. */
-  authorize(
+  /** Legacy/full-page escape hatch. Without `session`, this retains its original
+   * semantics: authenticate + consent and return a subject, or return a Response.
+   * With `session`, returning a Response replaces the consent page while the
+   * door-owned POST flow remains intact through `ctx.consent`. */
+  authorize?(
     req: Request,
-    ctx: { clientName: string; scopes: string[] },
+    ctx: HostOAuthAuthorizeContext,
+  ): Promise<Response | { subject: string }>;
+  /** Select the prebuilt flow. Return the current host subject, or a login
+   * Response that redirects through `ctx.returnTo` when no session exists. */
+  session?(
+    req: Request,
+    ctx: HostOAuthSessionContext,
   ): Promise<Response | { subject: string }>;
   /** Resolve a host subject to the Principal the door executes as (same shape
    * as 09 §2). Resolved on EVERY door request; `null` → 401, token dead —

--- a/packages/mcp/src/oauth/federation.ts
+++ b/packages/mcp/src/oauth/federation.ts
@@ -18,6 +18,7 @@ export async function handleFederation(
   secret: string,
   oauth: HostOAuthAdapter,
 ): Promise<Response> {
+  if (oauth.authorize === undefined) return invalidRequest();
   const compact = new URL(req.url).searchParams.get("request");
   if (!compact) return invalidRequest();
 

--- a/packages/mcp/src/oauth/server.ts
+++ b/packages/mcp/src/oauth/server.ts
@@ -4,6 +4,7 @@ import type {
   Principal,
   RecordStore,
   StoreAdapter,
+  VendoTheme,
 } from "@vendoai/core";
 import { z } from "zod";
 import type { HostOAuthAdapter } from "./adapter.js";
@@ -13,6 +14,7 @@ const GRANTS_COLLECTION = "vendo_mcp_grants";
 const ACCESS_TOKEN_SECONDS = 60 * 60;
 const REFRESH_TOKEN_SECONDS = 30 * 24 * 60 * 60;
 const CODE_SECONDS = 60;
+const CONSENT_SECONDS = 10 * 60;
 
 const clientDataSchema = z.object({
   client_name: z.string(),
@@ -64,10 +66,25 @@ const refreshGrantSchema = z.object({
   rotatedTo: z.string().optional(),
 });
 
+const consentInteractionSchema = z.object({
+  kind: z.literal("consent"),
+  subject: z.string().min(1),
+  clientId: z.string(),
+  resource: z.string(),
+  scopes: z.array(z.string()),
+  codeChallenge: z.string(),
+  redirectUri: z.string(),
+  state: z.string().nullable(),
+  authorizationUrl: z.string(),
+  csrfHash: z.string(),
+  expiresAt: z.string(),
+});
+
 type ClientData = z.infer<typeof clientDataSchema>;
 type CodeGrant = z.infer<typeof codeGrantSchema>;
 type AccessGrant = z.infer<typeof accessGrantSchema>;
 type RefreshGrant = z.infer<typeof refreshGrantSchema>;
+type ConsentInteraction = z.infer<typeof consentInteractionSchema>;
 
 export interface AuthenticatedGrant {
   grant: AccessGrant;
@@ -78,6 +95,7 @@ interface OAuthServerConfig {
   oauth: HostOAuthAdapter;
   store: StoreAdapter;
   guard: Guard;
+  theme?: VendoTheme;
 }
 
 interface ResolvedClient {
@@ -90,11 +108,20 @@ export class OAuthServer {
   readonly #oauth: HostOAuthAdapter;
   readonly #store: StoreAdapter;
   readonly #guard: Guard;
+  readonly #theme: VendoTheme | undefined;
 
   constructor(config: OAuthServerConfig) {
+    if (config.oauth.authorize === undefined && config.oauth.session === undefined) {
+      throw new TypeError("HostOAuthAdapter requires `session` for the prebuilt consent flow or `authorize` for a custom flow");
+    }
     this.#oauth = config.oauth;
     this.#store = config.store;
     this.#guard = config.guard;
+    this.#theme = config.theme;
+  }
+
+  get hasPrebuiltConsent(): boolean {
+    return this.#oauth.session !== undefined;
   }
 
   async register(req: Request): Promise<Response> {
@@ -122,6 +149,8 @@ export class OAuthServer {
   }
 
   async authorize(req: Request, resource: string): Promise<Response> {
+    if (req.method === "POST") return this.#decideConsent(req, resource);
+
     const url = new URL(req.url);
     const clientId = url.searchParams.get("client_id");
     const redirectUri = url.searchParams.get("redirect_uri");
@@ -155,19 +184,127 @@ export class OAuthServer {
     }
 
     const scopes = splitScopes(url.searchParams.get("scope"));
-    const result = await this.#oauth.authorize(req, { clientName: client.name, scopes });
-    if (result instanceof Response) return result;
-
-    const code = `vmcd_${randomBase64Url(32)}`;
-    const tokenHash = await sha256Hex(code);
-    const grant: CodeGrant = {
-      kind: "code",
-      subject: result.subject,
+    const authorization = {
       clientId,
       resource,
       scopes,
       codeChallenge: challenge,
       redirectUri,
+      state,
+    };
+
+    if (this.#oauth.session === undefined) {
+      const result = await this.#oauth.authorize!(req, { clientName: client.name, scopes });
+      if (result instanceof Response) return result;
+      return this.#approve(result.subject, authorization);
+    }
+
+    const session = await this.#oauth.session(req, { returnTo: req.url });
+    if (session instanceof Response) return session;
+    if (!session.subject) return oauthJsonError("invalid_request", "Host session did not resolve a subject");
+
+    await this.#sweepExpiredConsents();
+    const transaction = `vmci_${randomBase64Url(32)}`;
+    const csrfToken = `vmcsrf_${randomBase64Url(32)}`;
+    const interaction: ConsentInteraction = {
+      kind: "consent",
+      subject: session.subject,
+      ...authorization,
+      authorizationUrl: req.url,
+      csrfHash: await sha256Hex(csrfToken),
+      expiresAt: expiresIn(CONSENT_SECONDS),
+    };
+    const interactionRecord = {
+      id: `mcpg_${randomHex(12)}`,
+      data: interaction,
+      refs: { kind: "consent", token_hash: await sha256Hex(transaction) },
+    };
+    await this.#store.records(GRANTS_COLLECTION).put(interactionRecord);
+    const consent = { action: req.url, transaction, csrfToken };
+
+    if (this.#oauth.authorize !== undefined) {
+      const custom = await this.#oauth.authorize(req, { clientName: client.name, scopes, consent });
+      if (custom instanceof Response) return custom;
+      await this.#store.records(GRANTS_COLLECTION).delete(interactionRecord.id);
+      if (custom.subject !== session.subject) {
+        return oauthJsonError("invalid_request", "Consent subject did not match the host session");
+      }
+      return this.#approve(session.subject, authorization);
+    }
+
+    return consentPage(client.name, scopes, consent, this.#theme);
+  }
+
+  async #decideConsent(req: Request, resource: string): Promise<Response> {
+    if (this.#oauth.session === undefined) {
+      return oauthJsonError("invalid_request", "The prebuilt consent flow is not configured");
+    }
+    if (!contentType(req).startsWith("application/x-www-form-urlencoded")) {
+      return oauthJsonError("invalid_request", "Expected application/x-www-form-urlencoded");
+    }
+    const sessionRequest = req.clone();
+    const form = new URLSearchParams(await req.text());
+    const transaction = form.get("transaction");
+    const csrfToken = form.get("csrf_token");
+    const decision = form.get("decision");
+    if (!transaction || !csrfToken || (decision !== "approve" && decision !== "deny")) {
+      return oauthJsonError("invalid_request", "transaction, csrf_token, and decision are required");
+    }
+
+    const transactionHash = await sha256Hex(transaction);
+    const store = this.#store.records(GRANTS_COLLECTION);
+    const record = await findOne(store, { kind: "consent", token_hash: transactionHash });
+    const parsed = consentInteractionSchema.safeParse(record?.data);
+    if (!record || !parsed.success || expired(parsed.data.expiresAt)) {
+      if (record) await store.delete(record.id);
+      return oauthJsonError("invalid_request", "Consent interaction is invalid, expired, or already used");
+    }
+    const interaction = parsed.data;
+    if (!sameCanonicalUri(interaction.resource, resource)) {
+      return oauthJsonError("invalid_request", "Consent interaction belongs to a different MCP resource");
+    }
+    if (await sha256Hex(csrfToken) !== interaction.csrfHash) {
+      return oauthJsonError("invalid_request", "CSRF token is invalid");
+    }
+
+    const session = await this.#oauth.session!(sessionRequest, { returnTo: interaction.authorizationUrl });
+    if (session instanceof Response) return session;
+    if (session.subject !== interaction.subject) {
+      return oauthJsonError("invalid_request", "Host session changed during consent");
+    }
+
+    // Consume atomically before redirect/code minting. A double-click, replay,
+    // or request routed to another door process can produce at most one result.
+    if (!store.claim) {
+      return oauthJsonError("server_error", "The configured store does not support atomic consent claims");
+    }
+    if (!(await store.claim(record))) {
+      return oauthJsonError("invalid_request", "Consent interaction is invalid, expired, or already used");
+    }
+    if (decision === "deny") {
+      return oauthRedirect(interaction.redirectUri, {
+        error: "access_denied",
+        error_description: "The resource owner denied the request",
+        state: interaction.state,
+      });
+    }
+    return this.#approve(interaction.subject, interaction);
+  }
+
+  async #approve(
+    subject: string,
+    authorization: Pick<ConsentInteraction, "clientId" | "resource" | "scopes" | "codeChallenge" | "redirectUri" | "state">,
+  ): Promise<Response> {
+    const code = `vmcd_${randomBase64Url(32)}`;
+    const tokenHash = await sha256Hex(code);
+    const grant: CodeGrant = {
+      kind: "code",
+      subject,
+      clientId: authorization.clientId,
+      resource: authorization.resource,
+      scopes: authorization.scopes,
+      codeChallenge: authorization.codeChallenge,
+      redirectUri: authorization.redirectUri,
       expiresAt: expiresIn(CODE_SECONDS),
     };
     await this.#store.records(GRANTS_COLLECTION).put({
@@ -175,7 +312,16 @@ export class OAuthServer {
       data: grant,
       refs: { kind: "code", token_hash: tokenHash },
     });
-    return oauthRedirect(redirectUri, { code, state });
+    return oauthRedirect(authorization.redirectUri, { code, state: authorization.state });
+  }
+
+  async #sweepExpiredConsents(): Promise<void> {
+    const store = this.#store.records(GRANTS_COLLECTION);
+    const records = await listAll(store, { kind: "consent" });
+    await Promise.all(records.map(async (record) => {
+      const parsed = consentInteractionSchema.safeParse(record.data);
+      if (!parsed.success || expired(parsed.data.expiresAt)) await store.delete(record.id);
+    }));
   }
 
   async token(req: Request): Promise<Response> {
@@ -627,6 +773,171 @@ function oauthRedirect(redirectUri: string, values: Record<string, string | null
 
 function oauthJsonError(error: string, description: string): Response {
   return json({ error, error_description: description }, 400, { "cache-control": "no-store" });
+}
+
+function consentPage(
+  clientName: string,
+  scopes: string[],
+  flow: { action: string; transaction: string; csrfToken: string },
+  theme?: VendoTheme,
+): Response {
+  const safeClientName = escapeHtml(clientName);
+  const themeStyle = theme === undefined ? "" : ` style="${escapeHtml(vendoThemeStyle(theme))}"`;
+  const scopeList = scopes.length === 0
+    ? ""
+    : `<div class="scope"><span>Requested access</span><strong>${escapeHtml(scopes.join(" · "))}</strong></div>`;
+  const html = `<!doctype html>
+<html lang="en"${themeStyle}>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Authorize MCP access</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: var(--vendo-font-family, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+      font-size: var(--vendo-font-size, 15px);
+      color: var(--vendo-color-text, #17181d);
+      background: var(--vendo-color-background, #f3ede2);
+    }
+    * { box-sizing: border-box; }
+    body {
+      min-height: 100vh;
+      margin: 0;
+      display: grid;
+      place-items: center;
+      padding: var(--vendo-space-large, 28px);
+      background:
+        radial-gradient(circle at 20% 0%, color-mix(in srgb, var(--vendo-color-accent, #3157d5) 12%, transparent), transparent 38rem),
+        var(--vendo-color-background, #f3ede2);
+    }
+    main {
+      width: min(100%, 31rem);
+      padding: var(--vendo-space-large, 30px);
+      border: 1px solid var(--vendo-color-border, rgba(23, 24, 29, .12));
+      border-radius: var(--vendo-radius-medium, 16px);
+      background: var(--vendo-color-surface, #fffdf9);
+      box-shadow: 0 22px 70px color-mix(in srgb, var(--vendo-color-text, #17181d) 12%, transparent);
+    }
+    .mark {
+      width: 2.4rem;
+      height: 2.4rem;
+      display: grid;
+      place-items: center;
+      border-radius: var(--vendo-radius-small, 10px);
+      color: var(--vendo-color-accent-text, #fff);
+      background: var(--vendo-color-accent, #3157d5);
+      font-weight: 750;
+      letter-spacing: -.04em;
+    }
+    h1 {
+      margin: var(--vendo-space-large, 24px) 0 var(--vendo-space-small, 10px);
+      font-family: var(--vendo-heading-family, var(--vendo-font-family, inherit));
+      font-size: clamp(1.45rem, 4vw, 1.8rem);
+      line-height: 1.18;
+      letter-spacing: -.025em;
+    }
+    p { margin: 0; color: var(--vendo-color-muted, #686a73); line-height: 1.55; }
+    .scope {
+      display: flex;
+      justify-content: space-between;
+      gap: var(--vendo-space-medium, 14px);
+      margin-top: var(--vendo-space-large, 24px);
+      padding: var(--vendo-space-medium, 14px);
+      border: 1px solid var(--vendo-color-border, rgba(23, 24, 29, .12));
+      border-radius: var(--vendo-radius-small, 10px);
+      background: color-mix(in srgb, var(--vendo-color-surface, #fffdf9) 78%, var(--vendo-color-background, #f3ede2));
+      font-size: .86rem;
+    }
+    .scope span { color: var(--vendo-color-muted, #686a73); }
+    .scope strong { overflow-wrap: anywhere; text-align: right; }
+    form { display: flex; gap: var(--vendo-space-small, 10px); margin-top: var(--vendo-space-large, 26px); }
+    button {
+      min-height: 2.7rem;
+      flex: 1;
+      border: 1px solid var(--vendo-color-border, rgba(23, 24, 29, .14));
+      border-radius: var(--vendo-radius-small, 10px);
+      padding: .7rem 1rem;
+      font: 650 1rem/1 var(--vendo-font-family, inherit);
+      color: var(--vendo-color-text, #17181d);
+      background: var(--vendo-color-surface, #fffdf9);
+      cursor: pointer;
+    }
+    button:hover { border-color: var(--vendo-color-accent, #3157d5); }
+    button:focus-visible { outline: 3px solid color-mix(in srgb, var(--vendo-color-accent, #3157d5) 35%, transparent); outline-offset: 2px; }
+    button[value="approve"] {
+      border-color: transparent;
+      color: var(--vendo-color-accent-text, #fff);
+      background: var(--vendo-color-accent, #3157d5);
+    }
+    .fine { margin-top: var(--vendo-space-medium, 14px); font-size: .78rem; text-align: center; }
+    @media (max-width: 30rem) {
+      main { padding: var(--vendo-space-large, 24px) var(--vendo-space-medium, 18px); }
+      form { flex-direction: column-reverse; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <div class="mark" aria-hidden="true">V</div>
+    <h1>Allow ${safeClientName} to access this product?</h1>
+    <p>This client will be able to use the tools available to your account. Vendo's policy, approval, and audit controls still apply.</p>
+    ${scopeList}
+    <form method="post" action="${escapeHtml(flow.action)}">
+      <input type="hidden" name="transaction" value="${escapeHtml(flow.transaction)}">
+      <input type="hidden" name="csrf_token" value="${escapeHtml(flow.csrfToken)}">
+      <button type="submit" name="decision" value="deny">Deny</button>
+      <button type="submit" name="decision" value="approve">Allow</button>
+    </form>
+    <p class="fine">You can revoke access from this product at any time.</p>
+  </main>
+</body>
+</html>`;
+  return new Response(html, {
+    status: 200,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store",
+      pragma: "no-cache",
+      "content-security-policy": "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'",
+      "referrer-policy": "no-referrer",
+      "x-content-type-options": "nosniff",
+    },
+  });
+}
+
+/** Mirrors `@vendoai/ui`'s public theme-token mapping without importing that
+ * sibling package: the MCP block's contract permits a core dependency only. */
+function vendoThemeStyle(theme: VendoTheme): string {
+  const variables: Record<string, string> = {};
+  for (const [key, value] of Object.entries(theme.colors)) {
+    variables[`--vendo-color-${kebab(key)}`] = value;
+  }
+  variables["--vendo-font-family"] = theme.typography.fontFamily;
+  if (theme.typography.headingFamily !== undefined) {
+    variables["--vendo-heading-family"] = theme.typography.headingFamily;
+  }
+  variables["--vendo-font-size"] = theme.typography.baseSize;
+  for (const [key, value] of Object.entries(theme.radius)) {
+    variables[`--vendo-radius-${kebab(key)}`] = value;
+  }
+  variables["--vendo-density"] = theme.density;
+  variables["--vendo-motion"] = theme.motion;
+  return Object.entries(variables).map(([name, value]) => `${name}:${value}`).join(";");
+}
+
+function kebab(name: string): string {
+  return name.replace(/[A-Z]/g, (character) => `-${character.toLowerCase()}`);
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  })[character]!);
 }
 
 function json(body: unknown, status = 200, extraHeaders: Record<string, string> = {}): Response {

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -614,10 +614,10 @@ export async function runInit(options: InitOptions): Promise<number> {
     }
     // 10-mcp §2: the door never opens by default. When the host asks to open it,
     // point them at the one code change they make deliberately — a HostOAuthAdapter
-    // (identity + consent) plus `mcp: true` on createVendo. init cannot scaffold the
+    // (session + principal resolution) plus `mcp: true` on createVendo. init cannot scaffold the
     // adapter (it is host auth), so it guides rather than writes broken wiring.
     if (answers.openDoor === true) {
-      output.log("MCP door: implement a HostOAuthAdapter (identity + consent) and pass `createVendo({ mcp: true, oauth })`. Then run `vendo mcp server-json`, `vendo mcp verify-domain`, and `vendo doctor` for registry discovery. See docs/contracts/10-mcp.");
+      output.log("MCP door: implement a HostOAuthAdapter (session lookup + principal resolution) and pass `createVendo({ mcp: true, oauth })`; the door serves consent. Then run `vendo mcp server-json`, `vendo mcp verify-domain`, and `vendo doctor` for registry discovery. See docs/quickstart.md.");
     }
     const finalWiring = plan.framework === "express" ? await detectVendoWiring(root) : null;
     if (finalWiring !== null && (!finalWiring.server || !finalWiring.client)) {

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -68,7 +68,7 @@ export interface CreateVendoConfig {
       ChatGPT, Cursor) reach the host's tools through the SAME guard-bound path.
       Opening it is a host decision (10-mcp §2), so it is off by default. */
   mcp?: boolean;
-  /** 10-mcp §3 — the host's identity + consent seam. Threaded top-level like
+  /** 10-mcp §3 plus its additive prebuilt flow — the host's session + identity seam. Threaded top-level like
       `actAs`/`principal` (the door is agnostic; the umbrella owns the shape).
       REQUIRED when `mcp` is true: the door cannot mint principals without it. */
   oauth?: HostOAuthAdapter;
@@ -777,7 +777,15 @@ export function createVendo(config: CreateVendoConfig): Vendo {
     // 10-mcp §5 — pin the door's canonical mount so a cold umbrella's server
     // card advertises the right transport URL (BASE_PATH/mcp) before any request
     // teaches it, and learned paths never override it.
-    door = createMcpDoor({ tools: boundTools, guard, store, oauth: config.oauth, apps: appsPort, mount: MCP_MOUNT });
+    door = createMcpDoor({
+      tools: boundTools,
+      guard,
+      store,
+      oauth: config.oauth,
+      apps: appsPort,
+      mount: MCP_MOUNT,
+      ...(theme === undefined ? {} : { theme }),
+    });
   }
   const sessionId = `session_${globalThis.crypto.randomUUID()}`;
   // Per-process signing key for anonymous-session cookies (WebCrypto only; see


### PR DESCRIPTION
Fixes ENG-266

## What changed

- adds a door-owned login bounce and consent flow, including standard approve/deny redirects, CSRF validation, and atomically single-use consent interactions
- ships a clean consent page themed through the UI pipeline's `--vendo-*` tokens and escapes attacker-controlled DCR `client_name` values
- keeps full-page replacement available through the existing `authorize` adapter method while the door retains protocol and decision validation
- keeps `remoteAs` authentication, local-AS suppression (including the consent POST), metadata, and `/federate` routing intact
- documents the one-flag path and exercises the prebuilt page through the real MCP SDK OAuth flow

## Design note

The additive adapter surface is `HostOAuthAdapter.session(req, { returnTo })`. It returns either the current host subject or the host's login `Response`; the exact `returnTo` structurally resumes the original authorization request and removes the common login/authorize loop. The existing `principal` method remains the identity and revocation seam. If a host also supplies the existing `authorize` method, it receives `ctx.consent` and may replace the entire page without taking ownership of CSRF, atomic replay protection, or OAuth redirects.

## Test evidence

- clean-runner [`ci`](https://github.com/runvendo/vendo/actions/runs/29381337307/job/87245430586) passed the exact gate: `pnpm build && pnpm test && pnpm typecheck && pnpm lint`
- `pnpm --filter @vendoai/mcp test` (43 tests, including remote-AS and federation coverage)
- `pnpm --filter @vendoai-fixtures/mcp-e2e exec vitest run src/authorize-interactive.e2e.test.ts --reporter=verbose` (3 real-SDK scenarios)
