### PR TITLE
feat(mcp): remote-AS trust mode + login-federation endpoint (ENG-284)

### DIFF
--- a/docs/contracts/10-mcp.md
+++ b/docs/contracts/10-mcp.md
@@ -15,6 +15,12 @@ export function createMcpDoor(config: {
   oauth: HostOAuthAdapter;              // §3 — two functions; the host owns identity + consent, the door owns the protocol
   store: StoreAdapter;                  // door-owned protocol state (clients, codes, refresh grants) — wired like every other block
   apps?: AppsPort;                      // §4 — saved apps ride along as MCP Apps; absent → tools-only door
+  remoteAs?: {                          // §3.1 — trust an external authorization server instead of serving the local AS
+    issuer: string;
+    jwksUri?: string;                   // absent → discover jwks_uri from the issuer's RFC 8414 metadata
+    audience: string;
+  };
+  federation?: { secret: string };      // §3.2 — generic signed login handshake for an external AS
 }): McpDoor;
 
 export interface McpDoor {
@@ -74,6 +80,41 @@ Normative:
 - **Audit**: token issuance and revocation are `AuditEvent`s (`kind: "door-auth"`, additive variant per 01 §15) — the SIEM export (05 §1) sees the door's auth lifecycle, same as everything else.
 - Door state lands in `vendo_mcp_clients` / `vendo_mcp_grants` (additive to the 02 §2 table map; typed helpers are block-internal, same status as guard's).
 
+### 3.1 External authorization-server trust mode
+
+`remoteAs` switches bearer authentication from the door's local grant store to
+external JWT validation. The door accepts ES256 only, resolves keys from the
+configured `jwksUri` or the issuer's
+`{issuer}/.well-known/oauth-authorization-server` `jwks_uri`, caches keys, and
+refreshes the JWKS when a new `kid` appears. A bearer is valid only when its
+signature and `iss`, `aud`, `exp`, and `iat` claims validate against the
+configured issuer and audience. The JWT `sub` is then resolved through
+`HostOAuthAdapter.principal` on every door request exactly like a local grant;
+the host kill switch, session ownership, replay, guard, and audit behavior do
+not change.
+
+In this mode the local `/authorize`, `/token`, and `/register` endpoints return
+`404`, the door returns `404` for its RFC 8414 authorization-server metadata,
+and RFC 9728 protected-resource metadata advertises
+`authorization_servers: [remoteAs.issuer]`. The external server owns its OAuth
+protocol surface.
+
+### 3.2 Login federation
+
+`federation: { secret }` adds `GET {mount}/federate?request=<compact JWS>` as a
+generic handshake for an external authorization server. The request is HS256
+verified with `secret` and must contain `{ iss, aud, exp, jti, redirect_uri,
+scopes, client_name }`, where `aud` is the canonical door resource, `exp` is in
+the future but no more than five minutes away, `scopes` is a string array, and
+the redirect URI origin equals the `iss` origin.
+
+After validation the door calls `HostOAuthAdapter.authorize(req, { clientName:
+claims.client_name, scopes: claims.scopes })`. An adapter `Response` is returned
+unchanged so host login can bounce and the browser can retry the same request.
+For `{ subject }`, the door redirects to `redirect_uri` with an HS256
+`assertion` carrying `{ iss: resource, aud: request.iss, sub: subject, jti:
+request.jti, iat, exp: iat + 60s }`. The endpoint renders no HTML.
+
 ## 4. Apps ride along — MCP Apps
 
 The user's saved layer, not just raw tools — delivered the way the MCP Apps spec (2026-01-26) actually works:
@@ -96,12 +137,20 @@ export interface AppsPort {
 ## 5. Discovery — agents find the host's server
 
 - Protected-resource metadata at the **path-inserted** well-known URL (RFC 9728 §3): a door mounted at `/api/vendo/mcp` serves `/.well-known/oauth-protected-resource/api/vendo/mcp`. Authorization-server metadata (RFC 8414) likewise.
+- With `remoteAs`, protected-resource metadata names the external issuer and the door does not serve RFC 8414 authorization-server metadata; the external server owns it (§3.1).
 - Server card at `/.well-known/mcp-server-card` — ⚑ **provisional**, tracking SEP-2127 (Draft); the path moves with the SEP if it changes before ratification. Registry listings are a publishing step, not code. The door accepts an optional `mount` (e.g. `/api/vendo/mcp`): when set it is authoritative for the card's advertised transport URL, so a **cold** composed umbrella advertises the right mount before any request arrives, and learned request paths never override it (the umbrella passes its fixed `MCP_MOUNT`). Unset, the card falls back to `/mcp` until an authenticated request teaches it a mount.
 - `vendo doctor` validates both metadata documents resolve and the card parses.
 
 ## 6. Testing doctrine (binding, e2e-first)
 
 The harness is a REAL MCP client: e2e drives the door with an actual MCP SDK client — `401` → `WWW-Authenticate` → metadata discovery at the path-inserted URL → OAuth round-trip against the fixture host app's auth (with `resource` sent and a wrong-resource token request rejected) → initialize → `tools/list` → `tools/call` — asserting: descriptors match the bound registry verbatim; a `destructive` call parks and the client sees the in-band `isError` result naming the approval; audit rows land with `venue='mcp'` and `kind='door-auth'` (SQL asserts); `principal() → null` kills an existing session. Apps-ride-along e2e: `vendo_apps_open` returns the fixture app's payload with `_meta.ui.resourceUri` set, and the shim resource serves with the MCP Apps mimeType. Live leg (env-gated): connect Claude Code itself via `claude mcp add` against a local door and run one tool call.
+
+External-AS coverage uses an in-test authorization server with a jose-generated
+ES256 keypair: valid JWTs cross the real MCP transport, claim/signature failures
+are rejected, unknown keys fail closed, and a rotated `kid` refreshes cached
+JWKS. Federation coverage signs requests and verifies returned assertions
+against a fake `HostOAuthAdapter`, including signature, expiry, audience, and
+redirect-origin failures.
 
 ## 7. Deferred
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -12,6 +12,48 @@ pnpm --filter @vendoai/ui build:mcp-shim
 
 The server-card response tracks the provisional SEP-2127 draft and may move with that specification before ratification.
 
+## External authorization servers
+
+By default the door owns the OAuth authorization-server flow. A host that runs
+its authorization server separately can instead configure:
+
+```ts
+createMcpDoor({
+  // tools, guard, oauth, store, ...
+  remoteAs: {
+    issuer: "https://auth.example.com",
+    audience: "https://product.example.com/api/mcp",
+    // Optional. Otherwise the door discovers jwks_uri from RFC 8414 metadata.
+    jwksUri: "https://auth.example.com/.well-known/jwks.json",
+  },
+});
+```
+
+In this mode the door accepts only ES256 bearer JWTs whose signature, `iss`,
+`aud`, `exp`, and `iat` validate against the external server's JWKS. Keys are
+cached and a new `kid` triggers a refresh for key rotation. The host's
+`oauth.principal(sub)` still runs on every request, so returning `null` remains
+the immediate account-level kill switch. The door's local `/authorize`,
+`/token`, and `/register` endpoints and RFC 8414 metadata return `404`; RFC 9728
+protected-resource metadata advertises the configured external issuer.
+
+## Login federation
+
+`federation: { secret }` enables `GET {mount}/federate?request=<compact JWS>` as
+a generic login handshake for an external authorization server. Requests are
+HS256-signed with the shared secret and carry `iss`, the door resource as `aud`,
+an expiration no more than five minutes away, `jti`, `redirect_uri`, `scopes`,
+and `client_name`. The redirect URI must have the same origin as `iss`.
+
+The door passes the client name and scopes to `HostOAuthAdapter.authorize`. A
+`Response` from the adapter is returned unchanged for the host's login bounce;
+after authentication the browser can retry the same signed request. A resolved
+host subject is returned to the external server as `assertion=<compact JWS>` on
+the redirect URI. That HS256 assertion is audience-bound to the request issuer,
+issuer-bound to the canonical door resource, echoes the request `jti`, and
+expires after 60 seconds. The endpoint emits redirects or JSON errors only; it
+does not render request values into HTML.
+
 ## Transport state seam
 
 The door's protocol-lifetime state is isolated behind the package-internal

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@vendoai/core": "workspace:*",
+    "jose": "^6.2.3",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/packages/mcp/src/door.test.ts
+++ b/packages/mcp/src/door.test.ts
@@ -14,6 +14,7 @@ import {
 } from "@vendoai/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { exportJWK, generateKeyPair, jwtVerify, SignJWT, type KeyLike } from "jose";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createMcpDoorWithState } from "./door.js";
 import { createMcpDoor, type AppsPort, type McpDoor } from "./index.js";
@@ -401,6 +402,151 @@ describe("createMcpDoor routing and OAuth", () => {
   });
 });
 
+describe("createMcpDoor remote authorization server trust", () => {
+  it("discovers and caches ES256 JWKS, accepts a valid JWT, and keeps principal() as the host kill switch", async () => {
+    const as = await remoteAsFixture();
+    vi.stubGlobal("fetch", as.fetch);
+    const harness = makeHarness({
+      remoteAs: { issuer: as.issuer, audience: BASE },
+      principal: (subject) => ({ kind: "user", subject }),
+    });
+
+    const token = await as.mint({ sub: "external_user" });
+    const connected = await connect(harness.door, token);
+    expect((await connected.client.listTools()).tools).toHaveLength(1);
+    expect(harness.principalSubjects.length).toBeGreaterThan(0);
+    expect(new Set(harness.principalSubjects)).toEqual(new Set(["external_user"]));
+    expect(as.fetch).toHaveBeenCalledTimes(2); // one RFC 8414 discovery + one JWKS fetch
+
+    await connected.client.listTools();
+    expect(as.fetch).toHaveBeenCalledTimes(2); // cached discovery and keys
+    await connected.client.close();
+  });
+
+  it.each([
+    ["issuer", { issuer: "https://attacker.example" }],
+    ["audience", { audience: "https://other.example/mcp" }],
+    ["expiry", { expiresAt: Math.floor(Date.now() / 1_000) - 1 }],
+  ])("rejects a JWT with a bad %s", async (_case, overrides) => {
+    const as = await remoteAsFixture();
+    vi.stubGlobal("fetch", as.fetch);
+    const harness = makeHarness({ remoteAs: { issuer: as.issuer, audience: BASE } });
+    const token = await as.mint(overrides);
+
+    const response = await harness.door.handler(mcpRequest(token));
+    expect(response.status).toBe(401);
+    expect(harness.principalSubjects).toEqual([]);
+  });
+
+  it("rejects an unknown kid and refreshes cached JWKS when a new kid appears", async () => {
+    const as = await remoteAsFixture();
+    vi.stubGlobal("fetch", as.fetch);
+    const harness = makeHarness({
+      remoteAs: { issuer: as.issuer, jwksUri: as.jwksUri, audience: BASE },
+      principal: (subject) => ({ kind: "user", subject }),
+    });
+
+    expect((await harness.door.handler(mcpRequest(await as.mint({ sub: "before_rotation" })))).status).toBe(200);
+
+    const unknown = await generateSigningKey("unknown");
+    const unknownToken = await mintRemoteToken(unknown.privateKey, unknown.kid, {
+      issuer: as.issuer,
+      audience: BASE,
+      sub: "unknown_key",
+    });
+    expect((await harness.door.handler(mcpRequest(unknownToken))).status).toBe(401);
+    expect(harness.principalSubjects).not.toContain("unknown_key");
+
+    await as.rotate("rotated");
+    expect((await harness.door.handler(mcpRequest(await as.mint({ sub: "after_rotation" })))).status).toBe(200);
+    expect(harness.principalSubjects).toEqual(["before_rotation", "after_rotation"]);
+    expect(as.fetch).toHaveBeenCalledTimes(3); // initial, unknown-kid refresh, rotation refresh
+  });
+
+  it("disables the local AS surface and advertises only the configured remote issuer", async () => {
+    const as = await remoteAsFixture();
+    const harness = makeHarness({ remoteAs: { issuer: as.issuer, jwksUri: as.jwksUri, audience: BASE } });
+
+    const prm = await harness.door.handler(new Request(
+      "https://product.example/.well-known/oauth-protected-resource/api/vendo/mcp",
+    ));
+    expect(await prm.json()).toEqual({
+      resource: BASE,
+      authorization_servers: [as.issuer],
+      bearer_methods_supported: ["header"],
+    });
+
+    for (const request of [
+      new Request(`${BASE}/authorize`),
+      new Request(`${BASE}/token`, { method: "POST" }),
+      new Request(`${BASE}/register`, { method: "POST" }),
+      new Request("https://product.example/.well-known/oauth-authorization-server/api/vendo/mcp"),
+    ]) {
+      const response = await harness.door.handler(request);
+      expect(response.status).toBe(404);
+    }
+  });
+});
+
+describe("createMcpDoor login federation", () => {
+  const secret = "test-federation-secret-with-enough-entropy";
+  const issuer = "https://as.example/oauth";
+  const redirectUri = "https://as.example/login/callback?state=kept";
+
+  it("round-trips a signed login request through the host adapter and returns a one-minute assertion", async () => {
+    const harness = makeHarness({
+      federation: { secret },
+      authorizeSubject: () => "host_user_7",
+    });
+    const request = await mintFederationRequest(secret, { issuer, redirectUri });
+
+    const response = await harness.door.handler(new Request(`${BASE}/federate?request=${encodeURIComponent(request)}`));
+    expect(response.status).toBe(302);
+    const location = new URL(response.headers.get("location")!);
+    expect(location.origin + location.pathname).toBe("https://as.example/login/callback");
+    expect(location.searchParams.get("state")).toBe("kept");
+    expect(harness.authorizeContexts).toEqual([{ clientName: "Generic MCP client", scopes: ["tools", "apps"] }]);
+
+    const assertion = location.searchParams.get("assertion")!;
+    const verified = await jwtVerify(assertion, new TextEncoder().encode(secret), {
+      algorithms: ["HS256"],
+      issuer: BASE,
+      audience: issuer,
+    });
+    expect(verified.payload).toMatchObject({
+      iss: BASE,
+      aud: issuer,
+      sub: "host_user_7",
+      jti: "federation-request-1",
+    });
+    expect(verified.payload.exp! - verified.payload.iat!).toBe(60);
+  });
+
+  it("returns a host login bounce unchanged so the browser can retry the same signed request", async () => {
+    const bounce = new Response(null, { status: 302, headers: { location: "/login?return_to=federate" } });
+    const harness = makeHarness({ federation: { secret }, authorizeResponse: bounce });
+    const request = await mintFederationRequest(secret, { issuer, redirectUri });
+
+    const response = await harness.door.handler(new Request(`${BASE}/federate?request=${encodeURIComponent(request)}`));
+    expect(response).toBe(bounce);
+  });
+
+  it.each([
+    ["bad signature", "different-secret", {}],
+    ["expired request", secret, { expiresAt: Math.floor(Date.now() / 1_000) - 1 }],
+    ["wrong audience", secret, { audience: "https://other.example/mcp" }],
+    ["redirect origin mismatch", secret, { redirectUri: "https://evil.example/callback" }],
+  ])("rejects %s before calling the host adapter", async (_case, signingSecret, overrides) => {
+    const harness = makeHarness({ federation: { secret } });
+    const request = await mintFederationRequest(signingSecret, { issuer, redirectUri, ...overrides });
+
+    const response = await harness.door.handler(new Request(`${BASE}/federate?request=${encodeURIComponent(request)}`));
+    expect(response.status).toBe(400);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(harness.authorizeContexts).toEqual([]);
+  });
+});
+
 describe("createMcpDoor MCP protocol", () => {
   it("uses the real SDK for descriptors and all in-band outcome mappings", async () => {
     let outcome: ToolOutcome = { status: "ok", output: { answer: 42 } };
@@ -764,11 +910,14 @@ interface HarnessOptions {
   store?: MemoryStore;
   state?: McpDoorState;
   getOutcome?: () => ToolOutcome;
-  principal?: () => Principal | null;
+  principal?: (subject: string) => Principal | null;
   apps?: AppsPort;
   extraDescriptors?: Awaited<ReturnType<ToolRegistry["descriptors"]>>;
   check?: Guard["check"];
   mount?: string;
+  remoteAs?: { issuer: string; jwksUri?: string; audience: string };
+  federation?: { secret: string };
+  authorizeResponse?: Response;
   /** The subject the OAuth authorize step returns (defaults "user_1"); a fn lets
    * a test mint tokens for two different subjects against one door (FIX G). */
   authorizeSubject?: () => string;
@@ -778,6 +927,7 @@ function makeHarness(options: HarnessOptions = {}) {
   const store = options.store ?? new MemoryStore();
   const audits: AuditEvent[] = [];
   const authorizeContexts: Array<{ clientName: string; scopes: string[] }> = [];
+  const principalSubjects: string[] = [];
   const executions: Array<{ id: string; ctx: Parameters<ToolRegistry["execute"]>[1] }> = [];
   const guard: Guard = {
     check: options.check ?? (async () => ({ action: "run", decidedBy: "default" })),
@@ -805,20 +955,24 @@ function makeHarness(options: HarnessOptions = {}) {
     store,
     apps: options.apps,
     ...(options.mount === undefined ? {} : { mount: options.mount }),
+    ...(options.remoteAs === undefined ? {} : { remoteAs: options.remoteAs }),
+    ...(options.federation === undefined ? {} : { federation: options.federation }),
     oauth: {
       async authorize(_req, ctx) {
         authorizeContexts.push(ctx);
+        if (options.authorizeResponse) return options.authorizeResponse;
         return { subject: options.authorizeSubject ? options.authorizeSubject() : "user_1" };
       },
-      async principal() {
-        return options.principal ? options.principal() : { kind: "user", subject: "user_1" };
+      async principal(subject) {
+        principalSubjects.push(subject);
+        return options.principal ? options.principal(subject) : { kind: "user", subject: "user_1" };
       },
     },
   };
   const door = options.state === undefined
     ? createMcpDoor(config)
     : createMcpDoorWithState(config, options.state);
-  return { door, store, audits, authorizeContexts, executions };
+  return { door, store, audits, authorizeContexts, principalSubjects, executions };
 }
 
 async function register(door: McpDoor) {
@@ -897,6 +1051,7 @@ function mcpRequest(accessToken: string, sessionId?: string) {
     method: "POST",
     headers: {
       authorization: `Bearer ${accessToken}`,
+      accept: "application/json, text/event-stream",
       "content-type": "application/json",
       ...(sessionId === undefined ? {} : { "mcp-session-id": sessionId }),
       "mcp-protocol-version": "2025-11-25",
@@ -914,6 +1069,89 @@ function mcpRequest(accessToken: string, sessionId?: string) {
 async function pkceChallenge(verifier: string): Promise<string> {
   const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier)));
   return Buffer.from(digest).toString("base64url");
+}
+
+interface RemoteTokenOverrides {
+  issuer?: string;
+  audience?: string;
+  sub?: string;
+  issuedAt?: number;
+  expiresAt?: number;
+}
+
+async function generateSigningKey(kid: string) {
+  const pair = await generateKeyPair("ES256");
+  return { ...pair, kid };
+}
+
+async function mintRemoteToken(
+  privateKey: KeyLike,
+  kid: string,
+  options: { issuer: string; audience: string } & RemoteTokenOverrides,
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1_000);
+  return new SignJWT({})
+    .setProtectedHeader({ alg: "ES256", kid })
+    .setIssuer(options.issuer)
+    .setAudience(options.audience)
+    .setSubject(options.sub ?? "external_user")
+    .setIssuedAt(options.issuedAt ?? now)
+    .setExpirationTime(options.expiresAt ?? now + 300)
+    .sign(privateKey);
+}
+
+async function remoteAsFixture() {
+  const issuer = "https://as.example";
+  const jwksUri = `${issuer}/jwks`;
+  let key = await generateSigningKey("initial");
+  let jwks = { keys: [{ ...(await exportJWK(key.publicKey)), alg: "ES256", use: "sig", kid: key.kid }] };
+  const fetch = vi.fn(async (input: string | URL | Request) => {
+    const url = input instanceof Request ? input.url : input.toString();
+    if (url === `${issuer}/.well-known/oauth-authorization-server`) {
+      return Response.json({ issuer, jwks_uri: jwksUri });
+    }
+    if (url === jwksUri) return Response.json(jwks);
+    return new Response(null, { status: 404 });
+  });
+  return {
+    issuer,
+    jwksUri,
+    fetch,
+    async mint(overrides: RemoteTokenOverrides = {}) {
+      return mintRemoteToken(key.privateKey, key.kid, {
+        issuer: overrides.issuer ?? issuer,
+        audience: overrides.audience ?? BASE,
+        ...overrides,
+      });
+    },
+    async rotate(kid: string) {
+      key = await generateSigningKey(kid);
+      jwks = { keys: [{ ...(await exportJWK(key.publicKey)), alg: "ES256", use: "sig", kid: key.kid }] };
+    },
+  };
+}
+
+async function mintFederationRequest(
+  secret: string,
+  options: {
+    issuer: string;
+    redirectUri: string;
+    audience?: string;
+    expiresAt?: number;
+  },
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1_000);
+  return new SignJWT({
+    redirect_uri: options.redirectUri,
+    scopes: ["tools", "apps"],
+    client_name: "Generic MCP client",
+  })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuer(options.issuer)
+    .setAudience(options.audience ?? BASE)
+    .setJti("federation-request-1")
+    .setExpirationTime(options.expiresAt ?? now + 300)
+    .sign(new TextEncoder().encode(secret));
 }
 
 function textOf(result: unknown): string {

--- a/packages/mcp/src/door.test.ts
+++ b/packages/mcp/src/door.test.ts
@@ -438,6 +438,21 @@ describe("createMcpDoor remote authorization server trust", () => {
     expect(harness.principalSubjects).toEqual([]);
   });
 
+  it("rejects a JWT whose signature does not match the trusted key", async () => {
+    const as = await remoteAsFixture();
+    vi.stubGlobal("fetch", as.fetch);
+    const harness = makeHarness({ remoteAs: { issuer: as.issuer, audience: BASE } });
+    const untrusted = await generateSigningKey("initial");
+    const token = await mintRemoteToken(untrusted.privateKey, untrusted.kid, {
+      issuer: as.issuer,
+      audience: BASE,
+      sub: "forged_user",
+    });
+
+    expect((await harness.door.handler(mcpRequest(token))).status).toBe(401);
+    expect(harness.principalSubjects).toEqual([]);
+  });
+
   it("rejects an unknown kid and refreshes cached JWKS when a new kid appears", async () => {
     const as = await remoteAsFixture();
     vi.stubGlobal("fetch", as.fetch);

--- a/packages/mcp/src/door.ts
+++ b/packages/mcp/src/door.ts
@@ -20,6 +20,8 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import type { HostOAuthAdapter } from "./oauth/adapter.js";
 import type { AppsPort } from "./apps-port.js";
+import { handleFederation } from "./oauth/federation.js";
+import { RemoteAsVerifier } from "./oauth/remote-as.js";
 import { canonicalUri, OAuthServer, sameCanonicalUri } from "./oauth/server.js";
 import { SHIM_HTML } from "./shim/shim-html.gen.js";
 import {
@@ -78,6 +80,11 @@ export interface McpDoorConfig {
    * authenticated request teaches it a mount. The umbrella passes its fixed
    * mount so a composed door's card is correct before any traffic arrives. */
   mount?: string;
+  /** Trust access tokens from an external OAuth authorization server instead
+   * of serving the door's local authorization-server endpoints. */
+  remoteAs?: { issuer: string; jwksUri?: string; audience: string };
+  /** Enable the generic signed login-federation handshake at `{mount}/federate`. */
+  federation?: { secret: string };
 }
 
 export interface McpDoor {
@@ -100,6 +107,7 @@ export function createMcpDoorWithState(config: McpDoorConfig, state: McpDoorStat
 class Door {
   readonly #config: McpDoorConfig;
   readonly #oauth: OAuthServer;
+  readonly #remoteAs: RemoteAsVerifier | undefined;
   readonly #state: McpDoorState;
   /** Last mount an MCP request actually arrived at — a server-card hint only.
    * Authority never derives from remembered paths: every flow re-derives its
@@ -113,6 +121,7 @@ class Door {
     this.#config = config;
     this.#state = state;
     this.#oauth = new OAuthServer(config);
+    this.#remoteAs = config.remoteAs === undefined ? undefined : new RemoteAsVerifier(config.remoteAs);
   }
 
   async handler(req: Request): Promise<Response> {
@@ -121,10 +130,14 @@ class Door {
 
     if (path.startsWith(PRM_PREFIX)) {
       if (req.method !== "GET") return notFound();
-      return json(protectedResourceMetadata(url.origin, path.slice(PRM_PREFIX.length)));
+      return json(protectedResourceMetadata(
+        url.origin,
+        path.slice(PRM_PREFIX.length),
+        this.#config.remoteAs?.issuer,
+      ));
     }
     if (path.startsWith(AS_PREFIX)) {
-      if (req.method !== "GET") return notFound();
+      if (req.method !== "GET" || this.#config.remoteAs !== undefined) return notFound();
       return json(authorizationServerMetadata(url.origin, path.slice(AS_PREFIX.length)));
     }
     if (path === SERVER_CARD_PATH || path === SERVER_CARD_ALIAS_PATH) {
@@ -151,13 +164,20 @@ class Door {
     const endpoint = endpointFor(path);
     const mount = endpoint.mount;
     if (endpoint.kind === "authorize") {
-      return req.method === "GET" ? this.#oauth.authorize(req, resourceUri(url.origin, mount)) : notFound();
+      return req.method === "GET" && this.#config.remoteAs === undefined
+        ? this.#oauth.authorize(req, resourceUri(url.origin, mount))
+        : notFound();
     }
     if (endpoint.kind === "token") {
-      return req.method === "POST" ? this.#oauth.token(req) : notFound();
+      return req.method === "POST" && this.#config.remoteAs === undefined ? this.#oauth.token(req) : notFound();
     }
     if (endpoint.kind === "register") {
-      return req.method === "POST" ? this.#oauth.register(req) : notFound();
+      return req.method === "POST" && this.#config.remoteAs === undefined ? this.#oauth.register(req) : notFound();
+    }
+    if (endpoint.kind === "federate") {
+      return req.method === "GET" && this.#config.federation !== undefined
+        ? handleFederation(req, resourceUri(url.origin, mount), this.#config.federation.secret, this.#config.oauth)
+        : notFound();
     }
     if (!["GET", "POST", "DELETE"].includes(req.method)) return notFound();
     return this.#handleMcp(req, mount);
@@ -167,7 +187,9 @@ class Door {
     const url = new URL(req.url);
     const resource = resourceUri(url.origin, mount);
     await this.#sweepIdleSessions();
-    const auth = await this.#oauth.authenticate(req);
+    const auth = this.#remoteAs === undefined
+      ? await this.#oauth.authenticate(req)
+      : await this.#remoteAs.authenticate(req);
     if (!auth || !sameCanonicalUri(auth.grant.resource, resource)) {
       return unauthorized(url.origin, mount, req.headers.has("authorization"));
     }
@@ -477,11 +499,12 @@ class Door {
   }
 }
 
-function endpointFor(path: string): { kind: "mcp" | "authorize" | "token" | "register"; mount: string } {
+function endpointFor(path: string): { kind: "mcp" | "authorize" | "token" | "register" | "federate"; mount: string } {
   for (const [suffix, kind] of [
     ["/authorize", "authorize"],
     ["/token", "token"],
     ["/register", "register"],
+    ["/federate", "federate"],
   ] as const) {
     if (path.endsWith(suffix)) return { kind, mount: path.slice(0, -suffix.length) };
   }
@@ -501,11 +524,11 @@ function protectedResourceMetadataUrl(origin: string, mount: string): string {
   return canonicalUri(origin) + PRM_PREFIX + normalizeMount(mount);
 }
 
-function protectedResourceMetadata(origin: string, mount: string) {
+function protectedResourceMetadata(origin: string, mount: string, remoteIssuer?: string) {
   const resource = resourceUri(origin, mount);
   return {
     resource,
-    authorization_servers: [resource],
+    authorization_servers: [remoteIssuer ?? resource],
     bearer_methods_supported: ["header"],
   };
 }

--- a/packages/mcp/src/oauth/federation.ts
+++ b/packages/mcp/src/oauth/federation.ts
@@ -1,0 +1,75 @@
+import { jwtVerify, SignJWT } from "jose";
+import { z } from "zod";
+import type { HostOAuthAdapter } from "./adapter.js";
+
+const requestClaimsSchema = z.object({
+  iss: z.string().url(),
+  aud: z.string(),
+  exp: z.number().int(),
+  jti: z.string().min(1),
+  redirect_uri: z.string().url(),
+  scopes: z.array(z.string()),
+  client_name: z.string().min(1),
+});
+
+export async function handleFederation(
+  req: Request,
+  resource: string,
+  secret: string,
+  oauth: HostOAuthAdapter,
+): Promise<Response> {
+  const compact = new URL(req.url).searchParams.get("request");
+  if (!compact) return invalidRequest();
+
+  let claims: z.infer<typeof requestClaimsSchema>;
+  try {
+    const { payload } = await jwtVerify(compact, secretKey(secret), {
+      algorithms: ["HS256"],
+      audience: resource,
+      requiredClaims: ["iss", "aud", "exp", "jti"],
+    });
+    const parsed = requestClaimsSchema.safeParse(payload);
+    if (!parsed.success) return invalidRequest();
+    claims = parsed.data;
+  } catch {
+    return invalidRequest();
+  }
+
+  const now = Math.floor(Date.now() / 1_000);
+  if (claims.exp <= now || claims.exp > now + 5 * 60) return invalidRequest();
+  try {
+    if (new URL(claims.redirect_uri).origin !== new URL(claims.iss).origin) return invalidRequest();
+  } catch {
+    return invalidRequest();
+  }
+
+  const authorized = await oauth.authorize(req, {
+    clientName: claims.client_name,
+    scopes: claims.scopes,
+  });
+  if (authorized instanceof Response) return authorized;
+
+  const assertion = await new SignJWT({})
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuer(resource)
+    .setAudience(claims.iss)
+    .setSubject(authorized.subject)
+    .setJti(claims.jti)
+    .setIssuedAt(now)
+    .setExpirationTime(now + 60)
+    .sign(secretKey(secret));
+  const redirect = new URL(claims.redirect_uri);
+  redirect.searchParams.set("assertion", assertion);
+  return new Response(null, { status: 302, headers: { location: redirect.toString() } });
+}
+
+function secretKey(secret: string): Uint8Array {
+  return new TextEncoder().encode(secret);
+}
+
+function invalidRequest(): Response {
+  return new Response(JSON.stringify({ error: "invalid_request" }), {
+    status: 400,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/packages/mcp/src/oauth/remote-as.ts
+++ b/packages/mcp/src/oauth/remote-as.ts
@@ -1,0 +1,117 @@
+import { createRemoteJWKSet, jwtVerify } from "jose";
+
+export interface RemoteAsConfig {
+  issuer: string;
+  jwksUri?: string;
+  audience: string;
+}
+
+export interface RemoteAccessGrant {
+  kind: "access";
+  subject: string;
+  clientId: string;
+  resource: string;
+  scopes: string[];
+  expiresAt: string;
+}
+
+/** Validates bearer JWTs issued by an external authorization server. The
+ * RemoteJWKSet keeps verified keys in memory and re-fetches the JWKS when an
+ * unfamiliar `kid` appears, which covers ordinary zero-downtime key rotation. */
+export class RemoteAsVerifier {
+  readonly #config: RemoteAsConfig;
+  #jwksUri: Promise<string> | undefined;
+  #keys: ReturnType<typeof createRemoteJWKSet> | undefined;
+
+  constructor(config: RemoteAsConfig) {
+    this.#config = config;
+  }
+
+  async authenticate(req: Request): Promise<{ grant: RemoteAccessGrant; tokenWasPresented: true } | null> {
+    const header = req.headers.get("authorization");
+    const match = header?.match(/^Bearer\s+([^\s]+)$/i);
+    if (!match?.[1]) return null;
+    try {
+      const { payload } = await jwtVerify(match[1], await this.#keySet(), {
+        algorithms: ["ES256"],
+        issuer: this.#config.issuer,
+        audience: this.#config.audience,
+        requiredClaims: ["sub", "iat", "exp"],
+      });
+      const now = Math.floor(Date.now() / 1_000);
+      if (
+        typeof payload.sub !== "string" || payload.sub.length === 0 ||
+        typeof payload.iat !== "number" || !Number.isInteger(payload.iat) || payload.iat > now ||
+        typeof payload.exp !== "number" || !Number.isInteger(payload.exp) || payload.exp <= now ||
+        payload.exp <= payload.iat
+      ) {
+        return null;
+      }
+      return {
+        grant: {
+          kind: "access",
+          subject: payload.sub,
+          clientId: remoteClientId(payload, this.#config.issuer),
+          resource: this.#config.audience,
+          scopes: remoteScopes(payload),
+          expiresAt: new Date(payload.exp * 1_000).toISOString(),
+        },
+        tokenWasPresented: true,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async #keySet(): Promise<ReturnType<typeof createRemoteJWKSet>> {
+    if (this.#keys) return this.#keys;
+    const uri = await this.#resolveJwksUri();
+    // A zero cooldown lets the first JWT carrying a newly-rotated `kid` trigger
+    // an immediate refresh. Known keys remain cached by jose until cacheMaxAge.
+    this.#keys = createRemoteJWKSet(new URL(uri), { cooldownDuration: 0 });
+    return this.#keys;
+  }
+
+  async #resolveJwksUri(): Promise<string> {
+    if (this.#config.jwksUri !== undefined) return this.#config.jwksUri;
+    const pending = this.#jwksUri ?? this.#discoverJwksUri();
+    this.#jwksUri = pending;
+    try {
+      return await pending;
+    } catch (error) {
+      if (this.#jwksUri === pending) this.#jwksUri = undefined;
+      throw error;
+    }
+  }
+
+  async #discoverJwksUri(): Promise<string> {
+    const issuer = this.#config.issuer.replace(/\/+$/, "");
+    const response = await fetch(`${issuer}/.well-known/oauth-authorization-server`, {
+      headers: { accept: "application/json" },
+      redirect: "error",
+    });
+    if (!response.ok) throw new Error("Authorization server metadata was unavailable");
+    const metadata = await response.json() as { issuer?: unknown; jwks_uri?: unknown };
+    if (metadata.issuer !== this.#config.issuer || typeof metadata.jwks_uri !== "string") {
+      throw new Error("Authorization server metadata is invalid");
+    }
+    return metadata.jwks_uri;
+  }
+}
+
+function remoteClientId(payload: Record<string, unknown>, issuer: string): string {
+  if (typeof payload.client_id === "string" && payload.client_id.length > 0) return payload.client_id;
+  if (typeof payload.azp === "string" && payload.azp.length > 0) return payload.azp;
+  return issuer;
+}
+
+function remoteScopes(payload: Record<string, unknown>): string[] {
+  if (typeof payload.scope === "string") return uniqueScopes(payload.scope.split(/\s+/));
+  if (Array.isArray(payload.scope)) return uniqueScopes(payload.scope);
+  if (Array.isArray(payload.scp)) return uniqueScopes(payload.scp);
+  return [];
+}
+
+function uniqueScopes(values: unknown[]): string[] {
+  return [...new Set(values.filter((value): value is string => typeof value === "string" && value.length > 0))];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -765,6 +765,9 @@ importers:
       '@vendoai/core':
         specifier: workspace:*
         version: link:../core
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
       zod:
         specifier: ^3.24.0
         version: 3.25.76


### PR DESCRIPTION
## Summary

- add ES256/JWKS remote authorization-server trust mode with discovery, key caching, and rotation handling
- add a generic HS256 login-federation handshake endpoint
- disable local authorization-server routes and adjust discovery metadata in remote-AS mode
- document both seams and add JWT, SDK fixture, and federation coverage

## Verification

- pnpm build: pass
- pnpm typecheck: pass
- pnpm lint: pass
- @vendoai/mcp tests: 38/38 pass
- pnpm test: MCP passes; the root run remains red only on unrelated corpus-harness 5-second timeouts on the shared host, including when isolated to one worker

Linear: ENG-284
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds remote authorization-server trust mode and a generic login-federation endpoint to the MCP door, letting hosts use an external AS and federate user login. In remote-AS mode, local AS routes are disabled and discovery advertises the external issuer (ENG-284).

- New Features
  - Remote-AS trust: accepts ES256 bearer JWTs; discovers or uses `jwks_uri`, caches keys, and refreshes on new `kid`; validates `iss`, `aud`, `iat`, and `exp`; still resolves the user via `oauth.principal`.
  - Discovery and routes: `/authorize`, `/token`, `/register`, and RFC 8414 metadata return 404 when `remoteAs` is set; RFC 9728 protected-resource metadata lists the external issuer.
  - Login federation: `GET {mount}/federate?request=<compact JWS>` (HS256) validates `{ iss, aud, exp<=5m, jti, redirect_uri (same origin as iss), scopes, client_name }`; calls `oauth.authorize`; on success redirects to `redirect_uri` with an HS256 `assertion` `{ iss: resource, aud: iss, sub, jti }` expiring in 60s.

- Dependencies
  - Added `jose` for JWT/JWKS handling.

<sup>Written for commit 0574a878e8d71b1d5498bbd5f2becb6f4bc9b099. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

