### PR TITLE
ci: run audit with pnpm 11 (npm retired the legacy audit endpoint)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,16 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm audit --prod --audit-level high
+      # npm permanently retired the legacy audit endpoints on 2026-07-15 (HTTP
+      # 410); `pnpm audit` only queries the replacement bulk-advisory endpoint
+      # from pnpm 11 (pnpm/pnpm#11265). The repo pins pnpm 9 via packageManager
+      # and pnpm 11 auto-delegates to that pin, so strip the field in this
+      # throwaway checkout before auditing. 11.10.0 is the newest release that
+      # clears the .npmrc minimumReleaseAge window. Remove this workaround when
+      # the repo itself moves to pnpm 11 (tracked in Linear).
+      - run: |
+          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));delete p.packageManager;fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
+          npx -y pnpm@11.10.0 audit --prod --audit-level high
 
   # Reminder that a user-facing change should ship a changeset. NON-BLOCKING by
   # design (the fleet auto-merges): this job is not a required check and its one


### PR DESCRIPTION
## Problem

npm permanently retired the legacy `/-/npm/v1/security/audits` endpoint today (2026-07-15); it now returns HTTP 410. The `audit` job therefore fails on **every PR** repo-wide (first seen on #181; the endpoint worked as recently as #166's runs a couple hours earlier).

## Fix

`pnpm audit` only queries the replacement bulk-advisory endpoint from pnpm 11 (pnpm/pnpm#11265, fixed by pnpm/pnpm#11268). The repo pins pnpm 9.12.0 via `packageManager`, and pnpm 11 auto-delegates to that pin (`managePackageManagerVersions`), so the audit step now strips the field in its throwaway checkout and runs `npx -y pnpm@11.10.0 audit --prod --audit-level high`. 11.10.0 is the newest release clearing the `.npmrc` `minimumReleaseAge` (7d) window.

## Verification

Ran locally against the workspace with the field stripped:

```console
$ npx -y pnpm@11.10.0 audit --prod --audit-level high
1 vulnerabilities found
Severity: 1 moderate
```

Bulk endpoint reached, only the known moderate postcss finding reported (the one the `--audit-level high` comment already documents), exit 0 — the gate stays green and meaningful.

## Follow-up

Proper fix is moving the repo itself to pnpm 11 (needs `pnpm.overrides` → `pnpm-workspace.yaml` migration since pnpm 11 ignores the `package.json` `pnpm` field) — filing a Linear issue to track; this PR is the minimal unblock for all four in-flight workstreams.

https://claude.ai/code/session_01NWaxJb7L7fGxgUcPQYB1W9
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing CI audit job by using `pnpm` 11’s bulk advisory audit after npm retired the legacy endpoint (HTTP 410). Unblocks all PRs while keeping the `--audit-level high` gate.

- **Bug Fixes**
  - Strip the `packageManager` pin in CI so `pnpm` 11 doesn’t delegate to v9.
  - Run `npx -y pnpm@11.10.0 audit --prod --audit-level high` (latest allowed by `.npmrc` minimumReleaseAge) to use the new bulk endpoint.

<sup>Written for commit 7e585558f38729b716fcd1bf4e7c62ef62d2b3ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

