### PR TITLE
feat(cli): entitlement contract v2 client — parse, cache, resilience, human validate (ENG-305/306/307)

### DIFF
--- a/packages/vendo/src/cli/cloud/E2E.md
+++ b/packages/vendo/src/cli/cloud/E2E.md
@@ -55,3 +55,30 @@ All shapes match the frozen flowlet wave-2 contracts; the 402 `cloud-required`
 envelope is surfaced as a friendly message. The auth/share/publish flows were
 verified live on 2026-07-13; hosted deploy has deterministic local-store and
 mocked-wire coverage pending the console-side production endpoint.
+
+## Entitlement contract v2 (ENG-305/306/307)
+
+`vendo cloud validate` on a `contract_version: 2` response renders plan
+(informational only — never gated on), the nine capabilities, and per-meter
+quota bars; `--json` prints the raw contract. Entitlements are cached in
+`~/.vendo/entitlements.json` (0600, keyed by sha256(apiUrl+key)):
+
+- fresh within `cache.ttl_seconds` (600) for programmatic consumers;
+  `validate` itself always revalidates live
+- 503/network failure → cached contract served with a
+  `stale since <ISO> (console unreachable)` banner (exit 0) within
+  `stale_if_error_seconds` (24h)
+- past 24h unreachable → degrades to free entitlements, renders
+  `Vendo Cloud key: unverified (offline)` (exit 1, fail-closed meters)
+- 401 → cache entry dropped immediately; envelope-less 401 surfaces as
+  `Invalid or revoked API key (401)`
+- free-tier `storage_gb` arrives `exhausted: true` from day one — rendered
+  as no-headroom, not an error (exit stays 0)
+- malformed keys (`^vnd_[0-9a-f]{40}$` mismatch) fail before any request;
+  every cloud request sends `User-Agent: vendo-cli/<version>`
+
+Verified 2026-07-14 live against the console contract-v2 spine
+(vendo-web@5cb58dc run locally: supabase local + `next dev`): signup → OTP
+login (Mailpit) → `keys create` → validate free + pro, `--json`, stale,
+degrade-to-free, and 401 eviction, all through the real HTTP seam. Production
+console re-verification pending the ENG-318 migration deploy.

--- a/packages/vendo/src/cli/cloud/client.test.ts
+++ b/packages/vendo/src/cli/cloud/client.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { CloudError, cloudFetch, resolveCloudBaseUrl } from "./client.js";
+import { CLI_VERSION } from "../shared.js";
 
 describe("cloud client", () => {
   it("resolves the explicit URL before the environment and default", () => {
@@ -26,6 +27,9 @@ describe("cloud client", () => {
       message: "Upgrade required",
       status: 402,
     });
+    expect(fetchImpl).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
+      headers: expect.objectContaining({ "user-agent": `vendo-cli/${CLI_VERSION}` }),
+    }));
   });
 
   it("refreshes a user session once after a 401 and retries the request", async () => {
@@ -44,6 +48,9 @@ describe("cloud client", () => {
       },
     })).resolves.toEqual([{ id: "org_1" }]);
     expect(fetchImpl).toHaveBeenCalledTimes(3);
+    for (const call of fetchImpl.mock.calls) {
+      expect(call[1]).toMatchObject({ headers: expect.objectContaining({ "user-agent": `vendo-cli/${CLI_VERSION}` }) });
+    }
     expect(fetchImpl.mock.calls[2]?.[1]).toMatchObject({ headers: expect.objectContaining({ authorization: "Bearer fresh" }) });
     expect(writeSession).toHaveBeenCalledWith({ access_token: "fresh", refresh_token: "next", expires_at: 2_000_000_000 });
   });

--- a/packages/vendo/src/cli/cloud/client.ts
+++ b/packages/vendo/src/cli/cloud/client.ts
@@ -4,6 +4,7 @@ import {
   writeCloudSession,
   type CloudSession,
 } from "./session.js";
+import { CLI_VERSION } from "../shared.js";
 
 const DEFAULT_CLOUD_URL = "https://console.vendo.run";
 
@@ -100,7 +101,11 @@ async function refreshUserSession(
   }
   const response = await (options.fetchImpl ?? fetch)(requestUrl("/api/v1/auth/refresh", options), {
     method: "POST",
-    headers: { accept: "application/json", "content-type": "application/json" },
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+      "user-agent": `vendo-cli/${CLI_VERSION}`,
+    },
     body: JSON.stringify({ refresh_token: session.refresh_token }),
   });
   const body = await responseBody(response);
@@ -115,7 +120,10 @@ async function send(
   options: CloudFetchOptions,
   token: string | undefined,
 ): Promise<{ response: Response; body: unknown }> {
-  const headers: Record<string, string> = { accept: "application/json" };
+  const headers: Record<string, string> = {
+    accept: "application/json",
+    "user-agent": `vendo-cli/${CLI_VERSION}`,
+  };
   if (options.body !== undefined) headers["content-type"] = "application/json";
   if (token !== undefined) headers.authorization = `Bearer ${token}`;
   const response = await (options.fetchImpl ?? fetch)(requestUrl(path, options), {

--- a/packages/vendo/src/cli/cloud/command.ts
+++ b/packages/vendo/src/cli/cloud/command.ts
@@ -10,6 +10,7 @@ export interface CloudCommandOptions {
   fetcher?: CloudFetcher;
   home?: string;
   env?: Record<string, string | undefined>;
+  now?: number | (() => number);
 }
 
 export interface CloudCommandContext {
@@ -17,6 +18,7 @@ export interface CloudCommandContext {
   fetcher: CloudFetcher;
   home?: string;
   env: Record<string, string | undefined>;
+  now?: number | (() => number);
 }
 
 export function commandContext(options: CloudCommandOptions): CloudCommandContext {
@@ -25,6 +27,7 @@ export function commandContext(options: CloudCommandOptions): CloudCommandContex
     fetcher: options.fetcher ?? ((path, fetchOptions) => cloudFetch(path, fetchOptions)),
     home: options.home,
     env: options.env ?? process.env,
+    now: options.now,
   };
 }
 

--- a/packages/vendo/src/cli/cloud/deploy.test.ts
+++ b/packages/vendo/src/cli/cloud/deploy.test.ts
@@ -103,6 +103,7 @@ describe("cloud deploy", () => {
       method: "POST",
       headers: {
         accept: "application/json",
+        "user-agent": "vendo-cli/0.3.0",
         "content-type": "application/json",
         authorization: "Bearer vnd_test",
       },

--- a/packages/vendo/src/cli/cloud/entitlements-cache.test.ts
+++ b/packages/vendo/src/cli/cloud/entitlements-cache.test.ts
@@ -1,0 +1,145 @@
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CloudError } from "./client.js";
+import {
+  dropCachedEntitlements,
+  entitlementsCacheKey,
+  readCachedEntitlements,
+  resolveEntitlements,
+  writeCachedEntitlements,
+} from "./entitlements-cache.js";
+import { FREE_CONTRACT, type ContractV2 } from "./entitlements.js";
+
+const cleanup: string[] = [];
+afterEach(async () => Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true }))));
+
+const contract: ContractV2 = {
+  valid: true,
+  contract_version: 2,
+  org: { id: "org_1", name: "Acme", slug: "acme" },
+  plan: { id: "pro", name: "Pro", status: "active" },
+  capabilities: {
+    sharing: true,
+    registry: false,
+    guard_basic: false,
+    pinning: false,
+    guard_full: false,
+    session_replay: false,
+    insights: false,
+    mcp_broker: false,
+    sso_saml: false,
+  },
+  limits: {
+    sandbox_minutes: { included: 100, used: 10, remaining: 90, exhausted: false },
+    runs: { included: 0, used: 0, remaining: 0, exhausted: false },
+    storage_gb: { included: 0, used: 0, remaining: 0, exhausted: false },
+  },
+  cache: { ttl_seconds: 600, stale_if_error_seconds: 86400 },
+};
+
+async function home(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), "vendo-entitlements-"));
+  cleanup.push(path);
+  return path;
+}
+
+describe("entitlements disk cache", () => {
+  it("hashes the URL and key without exposing the raw key", () => {
+    const key = entitlementsCacheKey("https://console.example", "vnd_secret");
+    expect(key).toMatch(/^[0-9a-f]{64}$/);
+    expect(key).not.toContain("vnd_secret");
+    expect(key).toBe(entitlementsCacheKey("https://console.example", "vnd_secret"));
+  });
+
+  it("round-trips and drops an entry with owner-only permissions", async () => {
+    const root = await home();
+    await writeCachedEntitlements("hash", contract, { home: root, now: () => 1_000 });
+
+    expect(await readCachedEntitlements("hash", { home: root })).toEqual({ fetched_at: 1_000, contract });
+    const path = join(root, ".vendo", "entitlements.json");
+    expect((await stat(path)).mode & 0o777).toBe(0o600);
+    expect(await readFile(path, "utf8")).not.toContain("vnd_");
+
+    await dropCachedEntitlements("hash", { home: root });
+    expect(await readCachedEntitlements("hash", { home: root })).toBeNull();
+  });
+
+  it("returns null for a corrupt cache file", async () => {
+    const root = await home();
+    await writeCachedEntitlements("hash", contract, { home: root, now: () => 1_000 });
+    await writeFile(join(root, ".vendo", "entitlements.json"), "not json");
+    await expect(readCachedEntitlements("hash", { home: root })).resolves.toBeNull();
+  });
+});
+
+describe("entitlement resolution", () => {
+  it("writes a successful network contract as fresh", async () => {
+    const root = await home();
+    const fetchContract = vi.fn().mockResolvedValue(contract);
+    await expect(resolveEntitlements(fetchContract, {
+      cacheKey: "hash", home: root, now: () => 1_000,
+    })).resolves.toEqual({ contract, state: "fresh", fetchedAt: 1_000 });
+    expect(await readCachedEntitlements("hash", { home: root })).toEqual({ fetched_at: 1_000, contract });
+  });
+
+  it("uses a young cached contract without a network request", async () => {
+    const root = await home();
+    await writeCachedEntitlements("hash", contract, { home: root, now: () => 1_000 });
+    const fetchContract = vi.fn();
+    await expect(resolveEntitlements(fetchContract, {
+      cacheKey: "hash", home: root, now: () => 1_500,
+    })).resolves.toEqual({ contract, state: "cached", fetchedAt: 1_000 });
+    expect(fetchContract).not.toHaveBeenCalled();
+  });
+
+  it("forces a refresh even when the cache is young", async () => {
+    const root = await home();
+    await writeCachedEntitlements("hash", contract, { home: root, now: () => 1_000 });
+    const refreshed = { ...contract, org: { ...contract.org, name: "Updated" } };
+    const fetchContract = vi.fn().mockResolvedValue(refreshed);
+    await expect(resolveEntitlements(fetchContract, {
+      cacheKey: "hash", home: root, now: () => 1_100, forceRefresh: true,
+    })).resolves.toEqual({ contract: refreshed, state: "fresh", fetchedAt: 1_100 });
+  });
+
+  it.each([
+    new CloudError("unavailable", "offline", 503),
+    new CloudError("network", "offline", 0),
+    new TypeError("fetch failed"),
+  ])("uses stale cache during a retryable failure", async (error) => {
+    const root = await home();
+    await writeCachedEntitlements("hash", contract, { home: root, now: () => 1_000 });
+    await expect(resolveEntitlements(async () => { throw error; }, {
+      cacheKey: "hash", home: root, now: () => 2_000, forceRefresh: true,
+    })).resolves.toEqual({ contract, state: "stale", fetchedAt: 1_000 });
+  });
+
+  it("degrades to fail-closed free entitlements beyond the stale window", async () => {
+    const root = await home();
+    await writeCachedEntitlements("hash", contract, { home: root, now: () => 1_000 });
+    await expect(resolveEntitlements(async () => { throw new TypeError("fetch failed"); }, {
+      cacheKey: "hash", home: root, now: () => 90_000, forceRefresh: true,
+    })).resolves.toEqual({ contract: FREE_CONTRACT, state: "degraded" });
+  });
+
+  it("drops cached entitlements and rethrows a 401", async () => {
+    const root = await home();
+    await writeCachedEntitlements("hash", contract, { home: root, now: () => 1_000 });
+    const error = new CloudError("unauthorized", "Invalid key", 401);
+    await expect(resolveEntitlements(async () => { throw error; }, {
+      cacheKey: "hash", home: root, now: () => 2_000, forceRefresh: true,
+    })).rejects.toBe(error);
+    expect(await readCachedEntitlements("hash", { home: root })).toBeNull();
+  });
+
+  it("rethrows non-retryable cloud errors without grace", async () => {
+    const root = await home();
+    await writeCachedEntitlements("hash", contract, { home: root, now: () => 1_000 });
+    const error = new CloudError("server-error", "Broken", 500);
+    await expect(resolveEntitlements(async () => { throw error; }, {
+      cacheKey: "hash", home: root, now: () => 2_000, forceRefresh: true,
+    })).rejects.toBe(error);
+  });
+});

--- a/packages/vendo/src/cli/cloud/entitlements-cache.ts
+++ b/packages/vendo/src/cli/cloud/entitlements-cache.ts
@@ -1,0 +1,134 @@
+import { createHash } from "node:crypto";
+import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { CloudError } from "./client.js";
+import { FREE_CONTRACT, parseContractV2, type ContractV2 } from "./entitlements.js";
+
+export interface CachedEntitlements {
+  fetched_at: number;
+  contract: ContractV2;
+}
+
+export type EntitlementState = "fresh" | "cached" | "stale" | "degraded";
+
+export interface EntitlementResolution {
+  contract: ContractV2;
+  state: EntitlementState;
+  fetchedAt?: number;
+}
+
+export interface EntitlementsCacheOptions {
+  home?: string;
+  now?: number | (() => number);
+}
+
+export interface ResolveEntitlementsOptions extends EntitlementsCacheOptions {
+  cacheKey: string;
+  forceRefresh?: boolean;
+}
+
+export function entitlementsCacheKey(apiUrl: string, apiKey: string): string {
+  return createHash("sha256").update(`${apiUrl}\n${apiKey}`, "utf8").digest("hex");
+}
+
+function entitlementsCachePath(options: EntitlementsCacheOptions): string {
+  return join(options.home ?? homedir(), ".vendo", "entitlements.json");
+}
+
+function nowSeconds(options: EntitlementsCacheOptions): number {
+  if (typeof options.now === "number") return Math.floor(options.now);
+  if (options.now) return Math.floor(options.now());
+  return Math.floor(Date.now() / 1_000);
+}
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+async function readCacheFile(options: EntitlementsCacheOptions): Promise<Record<string, unknown> | null> {
+  try {
+    return objectValue(JSON.parse(await readFile(entitlementsCachePath(options), "utf8")) as unknown);
+  } catch {
+    return null;
+  }
+}
+
+export async function readCachedEntitlements(
+  cacheKey: string,
+  options: EntitlementsCacheOptions = {},
+): Promise<CachedEntitlements | null> {
+  const cache = await readCacheFile(options);
+  const entry = objectValue(cache?.[cacheKey]);
+  if (!entry || typeof entry.fetched_at !== "number" || !Number.isFinite(entry.fetched_at)) return null;
+  const contract = parseContractV2(entry.contract);
+  return contract ? { fetched_at: entry.fetched_at, contract } : null;
+}
+
+async function writeCacheFile(
+  cache: Record<string, unknown>,
+  options: EntitlementsCacheOptions,
+): Promise<void> {
+  const path = entitlementsCachePath(options);
+  await mkdir(join(path, ".."), { recursive: true, mode: 0o700 });
+  await writeFile(path, `${JSON.stringify(cache, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  await chmod(path, 0o600);
+}
+
+export async function writeCachedEntitlements(
+  cacheKey: string,
+  contract: ContractV2,
+  options: EntitlementsCacheOptions = {},
+): Promise<void> {
+  const cache = await readCacheFile(options) ?? {};
+  cache[cacheKey] = { fetched_at: nowSeconds(options), contract };
+  await writeCacheFile(cache, options);
+}
+
+export async function dropCachedEntitlements(
+  cacheKey: string,
+  options: EntitlementsCacheOptions = {},
+): Promise<void> {
+  const cache = await readCacheFile(options);
+  if (!cache) {
+    await rm(entitlementsCachePath(options), { force: true });
+    return;
+  }
+  delete cache[cacheKey];
+  await writeCacheFile(cache, options);
+}
+
+function retryable(error: unknown): boolean {
+  return !(error instanceof CloudError) || error.status === 0 || error.status === 503;
+}
+
+export async function resolveEntitlements(
+  fetchContract: () => Promise<ContractV2>,
+  options: ResolveEntitlementsOptions,
+): Promise<EntitlementResolution> {
+  const now = nowSeconds(options);
+  const cached = await readCachedEntitlements(options.cacheKey, options);
+  if (cached && !options.forceRefresh
+    && now - cached.fetched_at < cached.contract.cache.ttl_seconds) {
+    return { contract: cached.contract, state: "cached", fetchedAt: cached.fetched_at };
+  }
+
+  try {
+    const contract = parseContractV2(await fetchContract());
+    if (!contract) throw new CloudError("invalid-contract", "Vendo Cloud returned an invalid contract", 500);
+    await writeCachedEntitlements(options.cacheKey, contract, { ...options, now });
+    return { contract, state: "fresh", fetchedAt: now };
+  } catch (error) {
+    if (error instanceof CloudError && error.status === 401) {
+      await dropCachedEntitlements(options.cacheKey, options);
+      throw error;
+    }
+    if (!retryable(error)) throw error;
+    if (cached && now - cached.fetched_at < cached.contract.cache.stale_if_error_seconds) {
+      return { contract: cached.contract, state: "stale", fetchedAt: cached.fetched_at };
+    }
+    return { contract: FREE_CONTRACT, state: "degraded" };
+  }
+}

--- a/packages/vendo/src/cli/cloud/entitlements.test.ts
+++ b/packages/vendo/src/cli/cloud/entitlements.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+  CAPABILITY_KEYS,
+  FREE_CONTRACT,
+  METER_KEYS,
+  isVendoKey,
+  parseContractV2,
+} from "./entitlements.js";
+
+const response = {
+  valid: true,
+  contract_version: 2,
+  org: { id: "org_1", name: "Acme Inc", slug: "acme" },
+  plan: { id: "pro", name: "Pro", status: "active" },
+  capabilities: {
+    sharing: true,
+    registry: true,
+    guard_basic: true,
+    pinning: false,
+    guard_full: false,
+    session_replay: false,
+    insights: false,
+    mcp_broker: false,
+    sso_saml: false,
+  },
+  limits: {
+    sandbox_minutes: { included: 5000, used: 1234, remaining: 3766, exhausted: false },
+    runs: { included: 25000, used: 0, remaining: 25000, exhausted: false },
+    storage_gb: { included: 10, used: 0.4, remaining: 9.6, exhausted: false },
+  },
+  cache: { ttl_seconds: 600, stale_if_error_seconds: 86400 },
+};
+
+describe("contract v2 entitlements", () => {
+  it("parses a complete contract", () => {
+    expect(parseContractV2(response)).toEqual(response);
+  });
+
+  it("tolerates missing and malformed entitlement fields", () => {
+    expect(parseContractV2({
+      valid: true,
+      contract_version: 2,
+      org: { id: 1, name: "Acme Inc" },
+      plan: null,
+      capabilities: { sharing: "yes", registry: true, future_capability: true },
+      limits: {
+        sandbox_minutes: { included: Number.NaN, used: "12", remaining: Infinity, exhausted: "yes" },
+        storage_gb: { included: 10, used: 0.5 },
+      },
+      cache: { ttl_seconds: "600", stale_if_error_seconds: 12 },
+    })).toEqual({
+      valid: true,
+      contract_version: 2,
+      org: { id: "", name: "Acme Inc", slug: "" },
+      plan: { id: "", name: "", status: "" },
+      capabilities: {
+        sharing: false,
+        registry: true,
+        guard_basic: false,
+        pinning: false,
+        guard_full: false,
+        session_replay: false,
+        insights: false,
+        mcp_broker: false,
+        sso_saml: false,
+      },
+      limits: {
+        sandbox_minutes: { included: 0, used: 0, remaining: 0, exhausted: false },
+        runs: { included: 0, used: 0, remaining: 0, exhausted: false },
+        storage_gb: { included: 10, used: 0.5, remaining: 0, exhausted: false },
+      },
+      cache: { ttl_seconds: 600, stale_if_error_seconds: 12 },
+    });
+  });
+
+  it("rejects older and invalid contracts", () => {
+    expect(parseContractV2({ ...response, contract_version: 1 })).toBeNull();
+    expect(parseContractV2({ ...response, valid: false })).toBeNull();
+    expect(parseContractV2(null)).toBeNull();
+  });
+
+  it("defines a fail-closed free contract", () => {
+    expect(CAPABILITY_KEYS).toHaveLength(9);
+    expect(METER_KEYS).toHaveLength(3);
+    expect(Object.values(FREE_CONTRACT.capabilities)).toEqual(Array(9).fill(false));
+    expect(Object.values(FREE_CONTRACT.limits)).toEqual(Array(3).fill({
+      included: 0,
+      used: 0,
+      remaining: 0,
+      exhausted: true,
+    }));
+    expect(FREE_CONTRACT.plan).toEqual({ id: "free", name: "Free", status: "degraded" });
+  });
+
+  it.each([
+    [`vnd_${"0a".repeat(20)}`, true],
+    [`vnd_${"f".repeat(40)}`, true],
+    ["vnd_test", false],
+    [`vnd_${"A".repeat(40)}`, false],
+    [`vnd_${"a".repeat(39)}`, false],
+    [`xvnd_${"a".repeat(40)}`, false],
+  ])("checks API key format for %s", (key, valid) => {
+    expect(isVendoKey(key)).toBe(valid);
+  });
+});

--- a/packages/vendo/src/cli/cloud/entitlements.ts
+++ b/packages/vendo/src/cli/cloud/entitlements.ts
@@ -1,0 +1,165 @@
+export const CAPABILITY_KEYS = [
+  "sharing",
+  "registry",
+  "guard_basic",
+  "pinning",
+  "guard_full",
+  "session_replay",
+  "insights",
+  "mcp_broker",
+  "sso_saml",
+] as const;
+
+export type CapabilityKey = typeof CAPABILITY_KEYS[number];
+
+export const METER_KEYS = ["sandbox_minutes", "runs", "storage_gb"] as const;
+
+export type MeterKey = typeof METER_KEYS[number];
+
+export interface MeterUsage {
+  included: number;
+  used: number;
+  remaining: number;
+  exhausted: boolean;
+}
+
+export interface Organization {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+/** INFORMATIONAL ONLY. Never branch on plan.id/name/status anywhere. */
+export interface Plan {
+  id: string;
+  name: string;
+  status: string;
+}
+
+export interface ContractCachePolicy {
+  ttl_seconds: number;
+  stale_if_error_seconds: number;
+}
+
+export interface ContractV2 {
+  valid: true;
+  contract_version: 2;
+  org: Organization;
+  plan: Plan;
+  capabilities: Record<CapabilityKey, boolean>;
+  limits: Record<MeterKey, MeterUsage>;
+  cache: ContractCachePolicy;
+}
+
+const DEFAULT_METER: MeterUsage = {
+  included: 0,
+  used: 0,
+  remaining: 0,
+  exhausted: false,
+};
+
+const DEFAULT_CACHE: ContractCachePolicy = {
+  ttl_seconds: 600,
+  stale_if_error_seconds: 86400,
+};
+
+function record(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function finiteNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function meterUsage(value: unknown): MeterUsage {
+  const meter = record(value);
+  return {
+    included: finiteNumber(meter.included),
+    used: finiteNumber(meter.used),
+    remaining: finiteNumber(meter.remaining),
+    exhausted: typeof meter.exhausted === "boolean" ? meter.exhausted : false,
+  };
+}
+
+export function parseContractV2(value: unknown): ContractV2 | null {
+  const source = record(value);
+  if (source.contract_version !== 2 || source.valid !== true) return null;
+
+  const org = record(source.org);
+  const plan = record(source.plan);
+  const capabilities = record(source.capabilities);
+  const limits = record(source.limits);
+  const cache = record(source.cache);
+
+  return {
+    valid: true,
+    contract_version: 2,
+    org: {
+      id: stringValue(org.id),
+      name: stringValue(org.name),
+      slug: stringValue(org.slug),
+    },
+    plan: {
+      id: stringValue(plan.id),
+      name: stringValue(plan.name),
+      status: stringValue(plan.status),
+    },
+    capabilities: {
+      sharing: capabilities.sharing === true,
+      registry: capabilities.registry === true,
+      guard_basic: capabilities.guard_basic === true,
+      pinning: capabilities.pinning === true,
+      guard_full: capabilities.guard_full === true,
+      session_replay: capabilities.session_replay === true,
+      insights: capabilities.insights === true,
+      mcp_broker: capabilities.mcp_broker === true,
+      sso_saml: capabilities.sso_saml === true,
+    },
+    limits: {
+      sandbox_minutes: meterUsage(limits.sandbox_minutes),
+      runs: meterUsage(limits.runs),
+      storage_gb: meterUsage(limits.storage_gb),
+    },
+    cache: {
+      ttl_seconds: finiteNumber(cache.ttl_seconds, DEFAULT_CACHE.ttl_seconds),
+      stale_if_error_seconds: finiteNumber(
+        cache.stale_if_error_seconds,
+        DEFAULT_CACHE.stale_if_error_seconds,
+      ),
+    },
+  };
+}
+
+export const FREE_CONTRACT: ContractV2 = {
+  valid: true,
+  contract_version: 2,
+  org: { id: "", name: "", slug: "" },
+  plan: { id: "free", name: "Free", status: "degraded" },
+  capabilities: {
+    sharing: false,
+    registry: false,
+    guard_basic: false,
+    pinning: false,
+    guard_full: false,
+    session_replay: false,
+    insights: false,
+    mcp_broker: false,
+    sso_saml: false,
+  },
+  limits: {
+    sandbox_minutes: { ...DEFAULT_METER, exhausted: true },
+    runs: { ...DEFAULT_METER, exhausted: true },
+    storage_gb: { ...DEFAULT_METER, exhausted: true },
+  },
+  cache: { ...DEFAULT_CACHE },
+};
+
+export function isVendoKey(key: string): boolean {
+  return /^vnd_[0-9a-f]{40}$/.test(key);
+}

--- a/packages/vendo/src/cli/cloud/index.test.ts
+++ b/packages/vendo/src/cli/cloud/index.test.ts
@@ -14,6 +14,7 @@ describe("cloud command dispatch", () => {
     expect(messages.logs.join("\n")).toContain("pin-ship --app <id>");
     expect(messages.logs.join("\n")).toContain("login EMAIL");
     expect(messages.logs.join("\n")).toContain("deploy [--app <id>] [--secret NAME=VALUE]");
+    expect(messages.logs.join("\n")).toContain("validate [--json]                     Validate a key and show plan, capabilities, and quota");
   });
 
   it("returns one for unknown cloud commands", async () => {

--- a/packages/vendo/src/cli/cloud/index.ts
+++ b/packages/vendo/src/cli/cloud/index.ts
@@ -27,7 +27,7 @@ User commands:
   billing --org <id>                   Show billing status
 
 Machine commands:
-  validate                              Validate a key and show entitlements
+  validate [--json]                     Validate a key and show plan, capabilities, and quota
   deploy [--app <id>] [--secret NAME=VALUE]
                                         Deploy local enabled automations to the hosted instance
   share <appfile.json>                  Create a ShareSnapshot

--- a/packages/vendo/src/cli/cloud/output.test.ts
+++ b/packages/vendo/src/cli/cloud/output.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { type ContractV2 } from "./entitlements.js";
+import { renderContract } from "./output.js";
+
+const contract: ContractV2 = {
+  valid: true,
+  contract_version: 2,
+  org: { id: "org_1", name: "Acme Inc", slug: "acme" },
+  plan: { id: "pro", name: "Pro", status: "active" },
+  capabilities: {
+    sharing: true,
+    registry: true,
+    guard_basic: true,
+    pinning: false,
+    guard_full: false,
+    session_replay: false,
+    insights: false,
+    mcp_broker: false,
+    sso_saml: false,
+  },
+  limits: {
+    sandbox_minutes: { included: 5000, used: 1234, remaining: 3766, exhausted: false },
+    runs: { included: 25000, used: 0, remaining: 25000, exhausted: false },
+    storage_gb: { included: 10, used: 0.4, remaining: 9.6, exhausted: true },
+  },
+  cache: { ttl_seconds: 600, stale_if_error_seconds: 86400 },
+};
+
+describe("contract rendering", () => {
+  it("renders capabilities and quotas as plain aligned text", () => {
+    expect(renderContract(contract)).toBe(`Vendo Cloud key: valid
+Org:  Acme Inc (acme)
+Plan: Pro (active)
+
+Capabilities
+  ✓ sharing        ✓ registry       ✓ guard_basic
+  ✗ pinning        ✗ guard_full     ✗ session_replay
+  ✗ insights       ✗ mcp_broker     ✗ sso_saml
+
+Quota (this billing period)
+  sandbox_minutes  [█████░░░░░░░░░░░░░░░]  1,234 / 5,000  (3,766 left)
+  runs             [░░░░░░░░░░░░░░░░░░░░]      0 / 25,000 (25,000 left)
+  storage_gb       [█░░░░░░░░░░░░░░░░░░░]    0.4 / 10     (9.6 left) EXHAUSTED`);
+  });
+
+  it("omits an empty org and renders zero quota with an em dash", () => {
+    const degraded = {
+      ...contract,
+      org: { id: "", name: "", slug: "" },
+      limits: {
+        ...contract.limits,
+        runs: { included: 0, used: 0, remaining: 0, exhausted: true },
+      },
+    };
+    expect(renderContract(degraded)).not.toContain("Org:");
+    expect(renderContract(degraded)).toContain(`  runs             [${"░".repeat(20)}]      — EXHAUSTED`);
+  });
+
+  it("includes stale and degraded state banners", () => {
+    expect(renderContract(contract, { state: "stale", fetchedAt: 1_000 })).toMatch(
+      /^stale since 1970-01-01T00:16:40.000Z \(console unreachable\)\n/,
+    );
+    expect(renderContract(contract, { state: "degraded" })).toMatch(
+      /^degraded to free entitlements \(console unreachable > 24h\)\n/,
+    );
+  });
+
+  it("does not claim the key is valid when degraded", () => {
+    const rendered = renderContract(contract, { state: "degraded" });
+    expect(rendered).not.toContain("Vendo Cloud key: valid");
+    expect(rendered).toContain("Vendo Cloud key: unverified (offline)");
+  });
+});

--- a/packages/vendo/src/cli/cloud/output.ts
+++ b/packages/vendo/src/cli/cloud/output.ts
@@ -1,4 +1,6 @@
 import type { Output } from "../shared.js";
+import { CAPABILITY_KEYS, METER_KEYS, type ContractV2, type MeterUsage } from "./entitlements.js";
+import type { EntitlementState } from "./entitlements-cache.js";
 
 export const cloudConsoleOutput: Output = {
   log: (message) => console.log(message),
@@ -21,4 +23,50 @@ export function formatTable(headers: string[], rows: string[][]): string {
 
 export function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Vendo Cloud request failed";
+}
+
+function capabilityLine(contract: ContractV2, offset: number): string {
+  const entries = CAPABILITY_KEYS.slice(offset, offset + 3).map((key) => {
+    return `${contract.capabilities[key] ? "✓" : "✗"} ${key}`;
+  });
+  return `  ${entries[0]!.padEnd(17)}${entries[1]!.padEnd(17)}${entries[2]!}`;
+}
+
+function number(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+function meterLine(key: string, meter: MeterUsage): string {
+  const filled = meter.included === 0
+    ? 0
+    : Math.max(0, Math.min(20, Math.round((meter.used / meter.included) * 20)));
+  const bar = `[${"█".repeat(filled)}${"░".repeat(20 - filled)}]`;
+  const usage = meter.included === 0
+    ? "      —"
+    : `  ${number(meter.used).padStart(5)} / ${number(meter.included).padEnd(6)} (${number(meter.remaining)} left)`;
+  return `  ${key.padEnd(17)}${bar}${usage}${meter.exhausted ? " EXHAUSTED" : ""}`;
+}
+
+export function renderContract(
+  contract: ContractV2,
+  meta?: { state: EntitlementState; fetchedAt?: number },
+): string {
+  const lines: string[] = [];
+  if (meta?.state === "stale" && meta.fetchedAt !== undefined) {
+    lines.push(`stale since ${new Date(meta.fetchedAt * 1_000).toISOString()} (console unreachable)`);
+  } else if (meta?.state === "degraded") {
+    lines.push("degraded to free entitlements (console unreachable > 24h)");
+  }
+  lines.push(meta?.state === "degraded"
+    ? "Vendo Cloud key: unverified (offline)"
+    : "Vendo Cloud key: valid");
+  if (contract.org.name && contract.org.slug) lines.push(`Org:  ${contract.org.name} (${contract.org.slug})`);
+  lines.push(`Plan: ${contract.plan.name} (${contract.plan.status})`);
+  lines.push("", "Capabilities");
+  for (let index = 0; index < CAPABILITY_KEYS.length; index += 3) {
+    lines.push(capabilityLine(contract, index));
+  }
+  lines.push("", "Quota (this billing period)");
+  for (const key of METER_KEYS) lines.push(meterLine(key, contract.limits[key]));
+  return lines.join("\n");
 }

--- a/packages/vendo/src/cli/cloud/services.test.ts
+++ b/packages/vendo/src/cli/cloud/services.test.ts
@@ -3,10 +3,48 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CloudError } from "./client.js";
+import {
+  entitlementsCacheKey,
+  readCachedEntitlements,
+  writeCachedEntitlements,
+} from "./entitlements-cache.js";
+import { type ContractV2 } from "./entitlements.js";
 import { runPinShip, runPublish, runShare, runValidate } from "./services.js";
+
+const VALID_KEY = `vnd_${"a".repeat(40)}`;
+const API_URL = "https://console.vendo.run";
+const contract: ContractV2 = {
+  valid: true,
+  contract_version: 2,
+  org: { id: "org_1", name: "Acme Inc", slug: "acme" },
+  plan: { id: "pro", name: "Pro", status: "active" },
+  capabilities: {
+    sharing: true,
+    registry: true,
+    guard_basic: true,
+    pinning: false,
+    guard_full: false,
+    session_replay: false,
+    insights: false,
+    mcp_broker: false,
+    sso_saml: false,
+  },
+  limits: {
+    sandbox_minutes: { included: 5000, used: 1234, remaining: 3766, exhausted: false },
+    runs: { included: 25000, used: 0, remaining: 25000, exhausted: false },
+    storage_gb: { included: 10, used: 0.4, remaining: 9.6, exhausted: false },
+  },
+  cache: { ttl_seconds: 600, stale_if_error_seconds: 86400 },
+};
 
 const cleanup: string[] = [];
 afterEach(async () => Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true }))));
+
+async function home(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), "vendo-cloud-services-"));
+  cleanup.push(path);
+  return path;
+}
 
 function output() {
   const logs: string[] = [];
@@ -15,40 +53,155 @@ function output() {
 }
 
 describe("cloud services", () => {
-  it("validates a machine key", async () => {
-    const fetcher = vi.fn().mockResolvedValue({ valid: true, entitlements: ["sharing"] });
-    expect(await runValidate(["--key", "vnd_test"], { output: output().sink, fetcher })).toBe(0);
+  it("renders a live contract v2 response and caches it", async () => {
+    const root = await home();
+    const messages = output();
+    const fetcher = vi.fn().mockResolvedValue(contract);
+
+    expect(await runValidate(["--key", VALID_KEY], {
+      output: messages.sink, fetcher, home: root, now: () => 1_000,
+    })).toBe(0);
     expect(fetcher).toHaveBeenCalledWith("/api/v1/keys/validate", expect.objectContaining({
       auth: "key",
-      apiKey: "vnd_test",
+      apiKey: VALID_KEY,
       method: "POST",
     }));
+    expect(messages.logs[0]).toContain("Vendo Cloud key: valid");
+    expect(messages.logs[0]).toContain("Capabilities");
+    expect(await readCachedEntitlements(entitlementsCacheKey(API_URL, VALID_KEY), { home: root })).toEqual({
+      fetched_at: 1_000,
+      contract,
+    });
+  });
+
+  it("prints a contract v2 response as JSON with --json", async () => {
+    const root = await home();
+    const messages = output();
+    expect(await runValidate(["--key", VALID_KEY, "--json"], {
+      output: messages.sink, fetcher: vi.fn().mockResolvedValue(contract), home: root,
+    })).toBe(0);
+    expect(JSON.parse(messages.logs[0]!)).toEqual(contract);
+  });
+
+  it("passes a non-v2 response through unchanged", async () => {
+    const messages = output();
+    const legacy = { valid: true, entitlements: ["sharing"] };
+    expect(await runValidate(["--key", VALID_KEY], {
+      output: messages.sink, fetcher: vi.fn().mockResolvedValue(legacy),
+    })).toBe(0);
+    expect(JSON.parse(messages.logs[0]!)).toEqual(legacy);
+  });
+
+  it.each([
+    ["validate", (fetcher: ReturnType<typeof vi.fn>) => runValidate(["--key", "vnd_test"], { output: output().sink, fetcher })],
+    ["share", (fetcher: ReturnType<typeof vi.fn>) => runShare(["missing.json", "--key", "vnd_test"], { output: output().sink, fetcher })],
+    ["publish", (fetcher: ReturnType<typeof vi.fn>) => runPublish(["missing.json", "--key", "vnd_test"], { output: output().sink, fetcher })],
+    ["pin-ship", (fetcher: ReturnType<typeof vi.fn>) => runPinShip([
+      "--app", "app_1", "--slot", "main", "--base", "hash", "--diff", "missing.diff", "--key", "vnd_test",
+    ], { output: output().sink, fetcher })],
+  ])("rejects a malformed key before the %s request", async (_command, run) => {
+    const fetcher = vi.fn();
+    expect(await run(fetcher)).toBe(1);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("prints the exact malformed key error", async () => {
+    const messages = output();
+    expect(await runValidate(["--key", "vnd_test"], { output: messages.sink, fetcher: vi.fn() })).toBe(1);
+    expect(messages.errors).toEqual(["Invalid API key format (expected vnd_ followed by 40 hex characters)"]);
+  });
+
+  it("uses a stale contract when the console is unavailable", async () => {
+    const root = await home();
+    const messages = output();
+    const cacheKey = entitlementsCacheKey(API_URL, VALID_KEY);
+    await writeCachedEntitlements(cacheKey, contract, { home: root, now: () => 1_000 });
+
+    expect(await runValidate(["--key", VALID_KEY], {
+      output: messages.sink,
+      fetcher: vi.fn().mockRejectedValue(new CloudError("unavailable", "offline", 503)),
+      home: root,
+      now: () => 2_000,
+    })).toBe(0);
+    expect(messages.logs[0]).toMatch(/^stale since 1970-01-01T00:16:40.000Z \(console unreachable\)/);
+  });
+
+  it("keeps --json output machine-readable when serving the stale cache", async () => {
+    const root = await home();
+    const messages = output();
+    const cacheKey = entitlementsCacheKey(API_URL, VALID_KEY);
+    await writeCachedEntitlements(cacheKey, contract, { home: root, now: () => 1_000 });
+
+    expect(await runValidate(["--key", VALID_KEY, "--json"], {
+      output: messages.sink,
+      fetcher: vi.fn().mockRejectedValue(new CloudError("unavailable", "offline", 503)),
+      home: root,
+      now: () => 2_000,
+    })).toBe(0);
+    expect(JSON.parse(messages.logs[0]!)).toEqual(contract);
+  });
+
+  it("degrades to free entitlements and exits one beyond the stale window", async () => {
+    const root = await home();
+    const messages = output();
+    expect(await runValidate(["--key", VALID_KEY], {
+      output: messages.sink,
+      fetcher: vi.fn().mockRejectedValue(new TypeError("fetch failed")),
+      home: root,
+      now: () => 100_000,
+    })).toBe(1);
+    expect(messages.logs[0]).toMatch(/^degraded to free entitlements \(console unreachable > 24h\)/);
+    expect(messages.logs[0]).toContain("Plan: Free (degraded)");
+  });
+
+  it("drops cached entitlements and exits one on a 401", async () => {
+    const root = await home();
+    const messages = output();
+    const cacheKey = entitlementsCacheKey(API_URL, VALID_KEY);
+    await writeCachedEntitlements(cacheKey, contract, { home: root, now: () => 1_000 });
+
+    expect(await runValidate(["--key", VALID_KEY], {
+      output: messages.sink,
+      fetcher: vi.fn().mockRejectedValue(new CloudError("unauthorized", "Invalid key", 401)),
+      home: root,
+      now: () => 2_000,
+    })).toBe(1);
+    expect(messages.errors).toEqual(["Invalid key"]);
+    expect(await readCachedEntitlements(cacheKey, { home: root })).toBeNull();
+  });
+
+  it("maps an envelope-less 401 to a friendly invalid-key message", async () => {
+    const messages = output();
+    expect(await runValidate(["--key", VALID_KEY], {
+      output: messages.sink,
+      fetcher: vi.fn().mockRejectedValue(new CloudError("http-401", "Vendo Cloud request failed (401)", 401)),
+      home: await home(),
+    })).toBe(1);
+    expect(messages.errors).toEqual(["Invalid or revoked API key (401)"]);
   });
 
   it("wraps a shared app document with its id", async () => {
-    const root = await mkdtemp(join(tmpdir(), "vendo-cloud-services-"));
-    cleanup.push(root);
+    const root = await home();
     const file = join(root, "app.json");
     const doc = { id: "accounting", root: "card" };
     await writeFile(file, JSON.stringify(doc));
     const fetcher = vi.fn().mockResolvedValue({ id: "shr_1", doc });
 
-    expect(await runShare([file, "--key=vnd_test"], { output: output().sink, fetcher, env: {} })).toBe(0);
+    expect(await runShare([file, `--key=${VALID_KEY}`], { output: output().sink, fetcher, env: {} })).toBe(0);
     expect(fetcher).toHaveBeenCalledWith("/api/v1/apps/share", expect.objectContaining({
       body: { appId: "accounting", doc },
     }));
   });
 
   it("allows --app to override the published document id", async () => {
-    const root = await mkdtemp(join(tmpdir(), "vendo-cloud-publish-"));
-    cleanup.push(root);
+    const root = await home();
     const file = join(root, "app.json");
     const doc = { id: "file-id", root: "card" };
     await writeFile(file, JSON.stringify(doc));
     const fetcher = vi.fn().mockResolvedValue({ id: "pub_1", appId: "override-id" });
 
     expect(await runPublish([
-      file, "--app", "override-id", "--key=vnd_test",
+      file, "--app", "override-id", `--key=${VALID_KEY}`,
     ], { output: output().sink, fetcher, env: {} })).toBe(0);
     expect(fetcher).toHaveBeenCalledWith("/api/v1/apps/publish", expect.objectContaining({
       body: { appId: "override-id", doc },
@@ -56,14 +209,13 @@ describe("cloud services", () => {
   });
 
   it("reads a textual diff for pin shipping", async () => {
-    const root = await mkdtemp(join(tmpdir(), "vendo-cloud-pin-"));
-    cleanup.push(root);
+    const root = await home();
     const file = join(root, "change.diff");
     await writeFile(file, "@@ -1 +1 @@\n-old\n+new\n");
     const fetcher = vi.fn().mockResolvedValue({ id: "pin_1", status: "pending" });
 
     expect(await runPinShip([
-      "--app", "app_1", "--slot", "main", "--base", "hash", "--diff", file, "--key", "vnd_test",
+      "--app", "app_1", "--slot", "main", "--base", "hash", "--diff", file, "--key", VALID_KEY,
     ], { output: output().sink, fetcher })).toBe(0);
     expect(fetcher).toHaveBeenCalledWith("/api/v1/pins/ship", expect.objectContaining({
       body: { appId: "app_1", slot: "main", baseHash: "hash", diff: "@@ -1 +1 @@\n-old\n+new\n" },
@@ -73,7 +225,7 @@ describe("cloud services", () => {
   it("prints a friendly cloud-required error", async () => {
     const messages = output();
     const fetcher = vi.fn().mockRejectedValue(new CloudError("cloud-required", "Upgrade", 402));
-    expect(await runValidate(["--key", "vnd_test"], { output: messages.sink, fetcher })).toBe(1);
+    expect(await runValidate(["--key", VALID_KEY], { output: messages.sink, fetcher })).toBe(1);
     expect(messages.errors).toEqual(["This key's org needs a Cloud plan (cloud-required)."]);
   });
 });

--- a/packages/vendo/src/cli/cloud/services.ts
+++ b/packages/vendo/src/cli/cloud/services.ts
@@ -1,20 +1,41 @@
 import { readFile } from "node:fs/promises";
 import { option, positionals } from "./args.js";
-import { CloudError, type CloudFetchOptions } from "./client.js";
+import { CloudError, resolveCloudBaseUrl, type CloudFetchOptions } from "./client.js";
 import {
   commandContext,
   type CloudCommandContext,
   type CloudCommandOptions,
 } from "./command.js";
-import { errorMessage, printJson } from "./output.js";
+import { errorMessage, printJson, renderContract } from "./output.js";
+import {
+  entitlementsCacheKey,
+  resolveEntitlements,
+  type EntitlementResolution,
+} from "./entitlements-cache.js";
+import { isVendoKey, parseContractV2, type ContractV2 } from "./entitlements.js";
 
 function machineOptions(args: string[], context: CloudCommandContext): CloudFetchOptions {
+  const apiKey = option(args, "--key") ?? context.env.VENDO_API_KEY;
+  if (!apiKey) throw new CloudError("missing-api-key", "Pass --key or set VENDO_API_KEY", 0);
+  if (!isVendoKey(apiKey)) {
+    throw new Error("Invalid API key format (expected vnd_ followed by 40 hex characters)");
+  }
   return {
     auth: "key",
-    apiKey: option(args, "--key"),
+    apiKey,
     apiUrl: option(args, "--api-url"),
     env: context.env,
   };
+}
+
+function printServiceError(context: CloudCommandContext, error: unknown): void {
+  if (error instanceof CloudError && error.code === "cloud-required") {
+    context.output.error("This key's org needs a Cloud plan (cloud-required).");
+  } else if (error instanceof CloudError && error.code === "http-401") {
+    context.output.error("Invalid or revoked API key (401)");
+  } else {
+    context.output.error(errorMessage(error));
+  }
 }
 
 async function serviceCommand(
@@ -26,11 +47,7 @@ async function serviceCommand(
     printJson(context.output, await operation(context));
     return 0;
   } catch (error) {
-    if (error instanceof CloudError && error.code === "cloud-required") {
-      context.output.error("This key's org needs a Cloud plan (cloud-required).");
-    } else {
-      context.output.error(errorMessage(error));
-    }
+    printServiceError(context, error);
     return 1;
   }
 }
@@ -51,11 +68,53 @@ async function appRequestBody(args: string[]): Promise<{ appId: string; doc: unk
   return { appId, doc };
 }
 
-export function runValidate(args: string[], options: CloudCommandOptions = {}): Promise<number> {
-  return serviceCommand(options, (context) => context.fetcher("/api/v1/keys/validate", {
-    ...machineOptions(args, context),
-    method: "POST",
-  }));
+function validateResolution(
+  fetchContract: () => Promise<ContractV2>,
+  cacheKey: string,
+  context: CloudCommandContext,
+): Promise<EntitlementResolution> {
+  return resolveEntitlements(fetchContract, {
+    cacheKey,
+    home: context.home,
+    now: context.now,
+    forceRefresh: true,
+  });
+}
+
+export async function runValidate(args: string[], options: CloudCommandOptions = {}): Promise<number> {
+  const context = commandContext(options);
+  try {
+    const fetchOptions = { ...machineOptions(args, context), method: "POST" };
+    const cacheKey = entitlementsCacheKey(resolveCloudBaseUrl(fetchOptions), fetchOptions.apiKey!);
+    let raw: unknown;
+    try {
+      raw = await context.fetcher("/api/v1/keys/validate", fetchOptions);
+    } catch (error) {
+      const resolution = await validateResolution(async () => { throw error; }, cacheKey, context);
+      if (args.includes("--json")) {
+        printJson(context.output, resolution.contract);
+      } else {
+        context.output.log(renderContract(resolution.contract, resolution));
+      }
+      return resolution.state === "degraded" ? 1 : 0;
+    }
+
+    const contract = parseContractV2(raw);
+    if (!contract) {
+      printJson(context.output, raw);
+      return 0;
+    }
+    const resolution = await validateResolution(async () => contract, cacheKey, context);
+    if (args.includes("--json")) {
+      printJson(context.output, raw);
+    } else {
+      context.output.log(renderContract(resolution.contract, resolution));
+    }
+    return 0;
+  } catch (error) {
+    printServiceError(context, error);
+    return 1;
+  }
 }
 
 export function runShare(args: string[], options: CloudCommandOptions = {}): Promise<number> {


### PR DESCRIPTION
Implements the SDK side of entitlement contract v2 (ENG-305, ENG-306, ENG-307; parent ENG-301, spec §3 of the cloud commerce core design).

## What's in here

- **`entitlements.ts`** — typed v2 contract: nine capability keys, three meters (`{included, used, remaining, exhausted}`), cache policy. `parseContractV2` is tolerant (missing/malformed fields default safely; unknown keys ignored; non-v2 → null). `plan{}` is informational only and never branched on — gating is capabilities/limits, enforced by a comment on the type and by construction. `FREE_CONTRACT` is the fail-closed degraded fallback (all caps false, meters exhausted). `isVendoKey` = `^vnd_[0-9a-f]{40}$` (matches the console's `KEY_RE` exactly).
- **`entitlements-cache.ts`** — `~/.vendo/entitlements.json` (dir 0700, file 0600), entries keyed by sha256(apiUrl + key) so no key material lands on disk. `resolveEntitlements`: TTL-fresh cache for programmatic consumers; on 503/network error serves stale within `stale_if_error_seconds`, then degrades to free; 401 drops the entry immediately and rethrows; other errors get no grace.
- **`services.ts`** — `validate` is live-first (always revalidates; cache is fallback), renders human output by default, `--json` stays machine-readable on every path including stale/degraded fallbacks. Malformed keys fail before any network call for all machine commands. Envelope-less 401 maps to `Invalid or revoked API key (401)`.
- **`output.ts`** — plain-text renderer: org/plan lines, capability grid, 20-cell quota bars with locale-formatted numbers. Degraded state renders `Vendo Cloud key: unverified (offline)` instead of claiming validity. Free-tier day-one `storage_gb exhausted:true` renders as no-headroom, not an error (ratified semantic; exit stays 0).
- **`client.ts`** — `User-Agent: vendo-cli/<version>` on every cloud request including auth refresh.
- v1 responses pass through unchanged (raw JSON), so the CLI keeps working against the deployed console until the v2 migrations ship.

## Verification

- 69 unit tests in `src/cli/cloud/` (11 files), all TDD'd; typecheck + lint green.
- **Live integration** against the real console contract-v2 spine (vendo-web@5cb58dc — the merged #23 — run locally: supabase local + next dev): signup trigger → OTP login through Mailpit → `keys create` → validate free and pro contracts, `--json`, stale-if-error (console killed), degrade-to-free (cache aged past 24h), 401 cache eviction (key revoked). All through the real HTTP seam; demo GIFs attached to ENG-308.
- Production re-verification queued for when the console's ENG-318 migrations deploy.

Linear: ENG-305, ENG-306, ENG-307 (parent ENG-301)

https://claude.ai/code/session_015wSa6n4UeMftMtDgYHCqVy

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CLI support for entitlement contract v2 with a tolerant parser, secure disk caching, offline resilience, and clearer validate output; also sets a consistent `User-Agent` header. Satisfies Linear ENG-305, ENG-306, and ENG-307 requirements tied to contract parsing, caching, and UX.

- **New Features**
  - Contract v2 parsing: 9 capability keys, 3 meters, cache policy; safe defaults for missing/malformed fields; unknown keys ignored; non‑v2 responses pass through unchanged (raw JSON). Includes fail‑closed `FREE_CONTRACT`.
  - Disk cache: `~/.vendo/entitlements.json` (0700 dir/0600 file), entries keyed by sha256(apiUrl+key). Fresh within `ttl_seconds`; 503/network errors serve stale within `stale_if_error_seconds`; beyond that degrades to free; 401 evicts immediately; other errors get no grace.
  - Validate UX: live‑first fetch with cached fallback; `--json` stays machine‑readable on live, stale, and degraded paths. Output shows org/plan, capability grid, and 20‑cell quota bars with stale/degraded banners; degraded prints “unverified (offline)”. Free‑tier storage exhaustion renders as no headroom, not an error.
  - Key checks and errors: `^vnd_[0-9a-f]{40}$` format enforced before any network call for all machine commands; envelope‑less 401 → “Invalid or revoked API key (401)”.
  - Client: sends `User-Agent: vendo-cli/<version>` on all cloud requests, including token refresh.

<sup>Written for commit e5f20e8fcdd213cd55383236679cc54db69f67cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

