### PR TITLE
feat: capability-miss capture — jsonl sink + cloud upload (ENG-253)

### DIFF
--- a/.changeset/calm-wolves-report.md
+++ b/.changeset/calm-wolves-report.md
@@ -1,0 +1,9 @@
+---
+"@vendoai/core": patch
+"@vendoai/agent": patch
+"@vendoai/vendo": patch
+---
+
+Capture capability misses from embedded agent runs in a local JSONL sink and,
+when a Cloud API key and telemetry consent are present, upload them in bounded
+best-effort batches with the canonical enabled-tool surface.

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -22,6 +22,11 @@ import { assembleSystemPrompt } from "./prompt.js";
 import { createRunner } from "./runner.js";
 import { ThreadRepository, type Thread, type ThreadSummary } from "./threads.js";
 import { buildAgentTools } from "./tools.js";
+import {
+  createCapabilityMissDetector,
+  latestUserIntent,
+  type CapabilityMissConfig,
+} from "./capability-miss.js";
 
 const THREAD_ID_HEADER = "x-vendo-thread-id";
 
@@ -42,6 +47,7 @@ interface AgentConfig {
      *  full thread (current behavior). Persistence and the streamed thread are unaffected. */
     historyWindow?: number;
   };
+  capabilityMiss?: CapabilityMissConfig;
 }
 
 // Anthropic prompt-caching breakpoint. providerOptions.anthropic is ignored by every
@@ -140,18 +146,33 @@ export function createAgent(config: AgentConfig): VendoAgent {
         abandonPendingApprovals(thread.messages);
       }
       upsertMessage(thread.messages, input.message);
-      const system = await assembleSystemPrompt(config.guard, input.ctx, config.system);
+      const system = await assembleSystemPrompt(
+        config.guard,
+        input.ctx,
+        config.system,
+        config.capabilityMiss !== undefined,
+      );
 
       const stream = createUIMessageStream<UIMessage>({
         originalMessages: thread.messages,
         execute: async ({ writer }) => {
+          const missDetector = config.capabilityMiss === undefined
+            ? undefined
+            : createCapabilityMissDetector({
+                config: config.capabilityMiss,
+                ctx: input.ctx,
+                threadId: thread.id,
+                intent: latestUserIntent(thread.messages),
+              });
           const tools = await buildAgentTools({
             registry: config.tools,
             guard: config.guard,
             ctx: input.ctx,
             writer,
             toolOutputCap: config.context?.toolOutputCap,
+            ...(missDetector === undefined ? {} : { onCall: missDetector.onCall }),
           });
+          missDetector?.attach(tools);
           // History windowing: bound what is re-sent per turn to the last N whole messages.
           // Slicing whole UIMessages keeps each turn's tool-call/result pairing intact.
           const window = config.context?.historyWindow;

--- a/packages/agent/src/capability-miss.test.ts
+++ b/packages/agent/src/capability-miss.test.ts
@@ -1,0 +1,171 @@
+import type { CapabilityMissEvent, ToolDescriptor } from "@vendoai/core";
+import { describe, expect, it, vi } from "vitest";
+import { CAPABILITY_MISS_TOOL_NAME, createAgent } from "./index.js";
+import {
+  boundRegistry,
+  ctx,
+  readSse,
+  scriptedModel,
+  testGuard,
+  textTurn,
+  toolCallTurn,
+  userMessage,
+} from "./test-helpers.js";
+
+const surface = {
+  format: "vendo/tools@1" as const,
+  hash: `sha256:${"b".repeat(64)}`,
+};
+
+const failingDescriptor: ToolDescriptor = {
+  name: "host_export_transactions",
+  description: "Export transactions.",
+  inputSchema: { type: "object" },
+  risk: "read",
+};
+
+async function waitForOne(misses: CapabilityMissEvent[]): Promise<CapabilityMissEvent> {
+  await vi.waitFor(() => expect(misses).toHaveLength(1));
+  return misses[0]!;
+}
+
+describe("capability-miss detection", () => {
+  it("exposes the internal report tool for a no-matching-tool miss", async () => {
+    const misses: CapabilityMissEvent[] = [];
+    const model = scriptedModel([
+      toolCallTurn(CAPABILITY_MISS_TOOL_NAME, {
+        kind: "no-matching-tool",
+        toolsConsidered: ["host_transactions_list"],
+      }, "call_report_missing"),
+      textTurn("I cannot export CSV with the available tools.", "text_missing"),
+    ]);
+    const guard = testGuard({});
+    const agent = createAgent({
+      model,
+      tools: boundRegistry({}, guard),
+      guard,
+      capabilityMiss: {
+        hostId: "host_maple",
+        surface: Promise.resolve(surface),
+        emit: (event) => misses.push(event),
+      },
+    });
+
+    await readSse(await agent.stream({
+      threadId: "thr_missing",
+      message: userMessage("user_missing", "Export my transactions to CSV"),
+      ctx: ctx({ sessionId: "session_missing" }),
+    }));
+
+    expect(await waitForOne(misses)).toMatchObject({
+      format: "vendo/capability-miss@1",
+      id: expect.stringMatching(/^mis_/),
+      hostId: "host_maple",
+      sessionId: "session_missing",
+      threadId: "thr_missing",
+      intent: "Export my transactions to CSV",
+      surface,
+      trigger: {
+        kind: "no-matching-tool",
+        toolsConsidered: [],
+      },
+    });
+  });
+
+  it("emits once when the same tool fails twice, scrubbing failure text", async () => {
+    const misses: CapabilityMissEvent[] = [];
+    const model = scriptedModel([
+      toolCallTurn(failingDescriptor.name, {}, "call_failure_1"),
+      toolCallTurn(failingDescriptor.name, {}, "call_failure_2"),
+      toolCallTurn(CAPABILITY_MISS_TOOL_NAME, {
+        kind: "agent-give-up",
+        toolsConsidered: [failingDescriptor.name],
+      }, "call_duplicate_report"),
+      textTurn("The export failed twice.", "text_failures"),
+    ]);
+    const guard = testGuard({ [failingDescriptor.name]: "run" });
+    const tools = boundRegistry({
+      [failingDescriptor.name]: {
+        descriptor: failingDescriptor,
+        execute: async () => {
+          throw new Error("Authorization Bearer sk_live_super_secret failed for alice@example.com");
+        },
+      },
+    }, guard);
+    const agent = createAgent({
+      model,
+      tools,
+      guard,
+      capabilityMiss: {
+        hostId: "host_maple",
+        surface: Promise.resolve(surface),
+        emit: (event) => misses.push(event),
+      },
+    });
+
+    await readSse(await agent.stream({
+      message: userMessage("user_failures", "Export transactions for alice@example.com"),
+      ctx: ctx(),
+    }));
+
+    const miss = await waitForOne(misses);
+    expect(miss.intent).toBe("Export transactions for [redacted-email]");
+    expect(miss.trigger).toEqual({
+      kind: "repeated-tool-failure",
+      toolsConsidered: [failingDescriptor.name],
+      attempts: [
+        {
+          tool: failingDescriptor.name,
+          attempt: 1,
+          failure: { code: "execution", message: "Authorization Bearer [redacted-secret] failed for [redacted-email]" },
+        },
+        {
+          tool: failingDescriptor.name,
+          attempt: 2,
+          failure: { code: "execution", message: "Authorization Bearer [redacted-secret] failed for [redacted-email]" },
+        },
+      ],
+    });
+    expect(tools.invocations[failingDescriptor.name]).toBe(2);
+  });
+
+  it("records an explicit give-up with the tools actually attempted", async () => {
+    const misses: CapabilityMissEvent[] = [];
+    const model = scriptedModel([
+      toolCallTurn(failingDescriptor.name, {}, "call_give_up_failure"),
+      toolCallTurn(CAPABILITY_MISS_TOOL_NAME, {
+        kind: "agent-give-up",
+        toolsConsidered: [failingDescriptor.name, "host_transactions_list"],
+      }, "call_give_up_report"),
+      textTurn("I cannot finish this request.", "text_give_up"),
+    ]);
+    const guard = testGuard({ [failingDescriptor.name]: "run" });
+    const tools = boundRegistry({
+      [failingDescriptor.name]: {
+        descriptor: failingDescriptor,
+        execute: async () => { throw new Error("temporary failure"); },
+      },
+    }, guard);
+    const agent = createAgent({
+      model,
+      tools,
+      guard,
+      capabilityMiss: {
+        hostId: "host_maple",
+        surface: Promise.resolve(surface),
+        emit: (event) => misses.push(event),
+      },
+    });
+
+    await readSse(await agent.stream({
+      message: userMessage("user_give_up", "Export my transactions"),
+      ctx: ctx(),
+    }));
+
+    expect((await waitForOne(misses)).trigger).toEqual({
+      kind: "agent-give-up",
+      toolsConsidered: [failingDescriptor.name],
+      toolsAttempted: [failingDescriptor.name],
+    });
+  });
+});

--- a/packages/agent/src/capability-miss.ts
+++ b/packages/agent/src/capability-miss.ts
@@ -1,0 +1,168 @@
+import {
+  TOOL_NAME_PATTERN,
+  VendoError,
+  type CapabilityMissEvent,
+  type CapabilityMissToolFailure,
+  type CapabilityMissTrigger,
+  type RunContext,
+  type ThreadId,
+  type ToolCall,
+  type ToolOutcome,
+} from "@vendoai/core";
+import { dynamicTool, jsonSchema, type ToolSet, type UIMessage } from "ai";
+
+export const CAPABILITY_MISS_TOOL_NAME = "vendo_report_capability_miss";
+
+export interface CapabilityMissConfig {
+  hostId: string;
+  surface: Promise<CapabilityMissEvent["surface"]>;
+  emit(event: CapabilityMissEvent): void | Promise<void>;
+}
+
+interface DetectorOptions {
+  config: CapabilityMissConfig;
+  ctx: RunContext;
+  intent: string;
+  threadId?: ThreadId;
+}
+
+const REPORT_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    kind: { type: "string", enum: ["no-matching-tool", "agent-give-up"] },
+    toolsConsidered: {
+      type: "array",
+      items: { type: "string", pattern: TOOL_NAME_PATTERN.source },
+      maxItems: 100,
+    },
+  },
+  required: ["kind", "toolsConsidered"],
+  additionalProperties: false,
+} as Parameters<typeof jsonSchema>[0];
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function toolNames(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value
+    .filter((name): name is string => typeof name === "string" && TOOL_NAME_PATTERN.test(name))
+    .slice(0, 100))];
+}
+
+/** Deterministic, deliberately conservative removal of common credential/PII forms. */
+export function scrubCapabilityMissText(value: string): string {
+  const scrubbed = value
+    .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, "[redacted-email]")
+    .replace(/(\bBearer\s+)[A-Za-z0-9._~+\/-]{8,}/gi, "$1[redacted-secret]")
+    .replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, "[redacted-secret]")
+    .replace(/\b(?:sk|pk|rk|vnd|ghp|github_pat|xox[baprs])[-_][A-Za-z0-9_-]{8,}\b/gi, "[redacted-secret]")
+    .replace(/\b(api[_-]?key|access[_-]?token|secret|password)\s*[:=]\s*[^\s,;]+/gi, "$1=[redacted-secret]")
+    .replace(/\+?\d[\d\s().-]{8,}\d/g, "[redacted-phone]")
+    .trim()
+    .slice(0, 1_000);
+  return scrubbed || "Unspecified request";
+}
+
+function textFromPart(part: UIMessage["parts"][number]): string | undefined {
+  const candidate = part as { type?: unknown; text?: unknown };
+  return candidate.type === "text" && typeof candidate.text === "string"
+    ? candidate.text
+    : undefined;
+}
+
+export function latestUserIntent(messages: UIMessage[]): string {
+  const message = [...messages].reverse().find((candidate) => candidate.role === "user");
+  if (!message) return "Unspecified request";
+  return scrubCapabilityMissText(message.parts.map(textFromPart).filter(Boolean).join(" "));
+}
+
+export interface CapabilityMissDetector {
+  onCall(call: ToolCall): (outcome: ToolOutcome) => void;
+  attach(tools: ToolSet): void;
+}
+
+export function createCapabilityMissDetector(options: DetectorOptions): CapabilityMissDetector {
+  const attempted: string[] = [];
+  const failures = new Map<string, CapabilityMissToolFailure[]>();
+  let reported = false;
+
+  const report = (trigger: CapabilityMissTrigger): boolean => {
+    if (reported) return false;
+    reported = true;
+    void (async () => {
+      const surface = await options.config.surface;
+      const event: CapabilityMissEvent = {
+        format: "vendo/capability-miss@1",
+        id: `mis_${globalThis.crypto.randomUUID().replaceAll("-", "")}`,
+        at: new Date().toISOString(),
+        hostId: options.config.hostId,
+        ...(options.ctx.appId === undefined ? {} : { appId: options.ctx.appId }),
+        sessionId: options.ctx.sessionId,
+        ...(options.threadId === undefined ? {} : { threadId: options.threadId }),
+        intent: scrubCapabilityMissText(options.intent),
+        surface,
+        trigger,
+      };
+      await options.config.emit(event);
+    })().catch(() => {
+      // Reporting is deliberately fire-and-forget. It cannot alter the agent turn.
+    });
+    return true;
+  };
+
+  return {
+    onCall(call) {
+      if (!attempted.includes(call.tool)) attempted.push(call.tool);
+      return (outcome) => {
+        if (reported || outcome.status !== "error") return;
+        const toolFailures = failures.get(call.tool) ?? [];
+        toolFailures.push({
+          tool: call.tool,
+          attempt: toolFailures.length + 1,
+          failure: {
+            ...(outcome.error.code.length === 0 ? {} : { code: outcome.error.code }),
+            message: scrubCapabilityMissText(outcome.error.message),
+          },
+        });
+        failures.set(call.tool, toolFailures);
+        if (toolFailures.length < 2) return;
+        report({
+          kind: "repeated-tool-failure",
+          toolsConsidered: [...attempted],
+          attempts: [...toolFailures] as [
+            CapabilityMissToolFailure,
+            CapabilityMissToolFailure,
+            ...CapabilityMissToolFailure[],
+          ],
+        });
+      };
+    },
+    attach(tools) {
+      if (tools[CAPABILITY_MISS_TOOL_NAME] !== undefined) {
+        throw new VendoError("conflict", `Reserved internal tool name: ${CAPABILITY_MISS_TOOL_NAME}`);
+      }
+      const availableTools = new Set(Object.keys(tools));
+      tools[CAPABILITY_MISS_TOOL_NAME] = dynamicTool({
+        description: "Report that the current user ask cannot be fulfilled. Use only for no matching tool or an explicit terminal give-up.",
+        inputSchema: jsonSchema(REPORT_INPUT_SCHEMA),
+        execute: async (input): Promise<ToolOutcome> => {
+          const parsed = record(input);
+          const kind = parsed?.kind;
+          if (kind !== "no-matching-tool" && kind !== "agent-give-up") {
+            return { status: "error", error: { code: "validation", message: "Invalid capability-miss trigger" } };
+          }
+          const toolsConsidered = toolNames(parsed?.toolsConsidered)
+            .filter((name) => availableTools.has(name));
+          const emitted = kind === "no-matching-tool"
+            ? report({ kind, toolsConsidered })
+            : report({ kind, toolsConsidered, toolsAttempted: [...attempted] });
+          return { status: "ok", output: { reported: emitted } };
+        },
+      });
+    },
+  };
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,3 +1,5 @@
 export { createAgent } from "./agent.js";
 export type { VendoAgent } from "./agent.js";
+export { CAPABILITY_MISS_TOOL_NAME } from "./capability-miss.js";
+export type { CapabilityMissConfig } from "./capability-miss.js";
 export type { Thread, ThreadSummary } from "./threads.js";

--- a/packages/agent/src/prompt.ts
+++ b/packages/agent/src/prompt.ts
@@ -10,13 +10,21 @@ Never claim a tool ran unless its result confirms that it did.
 Never invent tool outputs, records, or side effects.
 For away runs, clearly state what completed and what was left pending.`;
 
+const CAPABILITY_MISS_PROMPT = `When the user's ask cannot be fulfilled:
+- If no available tool can perform it, call vendo_report_capability_miss with kind "no-matching-tool" before replying.
+- If you explicitly give up after trying available approaches, call vendo_report_capability_miss with kind "agent-give-up" before replying.
+- List only tool names you actually considered. Do not call the reporter for a pending approval or a policy-blocked call.
+Repeated failures are detected automatically; if the reporter says the miss was already recorded, do not call it again.`;
+
 /** 03-agent §3: company directions are mandatory policy context and fail closed. */
 export async function assembleSystemPrompt(
   guard: Guard,
   ctx: RunContext,
   system?: { product?: string; instructions?: string },
+  capabilityMiss = false,
 ): Promise<string> {
   const sections = [OPERATING_PROMPT];
+  if (capabilityMiss) sections.push(CAPABILITY_MISS_PROMPT);
   const product = system?.product?.trim();
   if (product) sections.push(`Product\n${product}`);
 

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -17,6 +17,11 @@ import {
 import { mintAuditId } from "./ids.js";
 import { assembleSystemPrompt } from "./prompt.js";
 import { buildAgentTools } from "./tools.js";
+import {
+  createCapabilityMissDetector,
+  scrubCapabilityMissText,
+  type CapabilityMissConfig,
+} from "./capability-miss.js";
 
 /** 03-agent §2 */
 export interface RunnerConfig {
@@ -24,6 +29,7 @@ export interface RunnerConfig {
   guard: Guard;
   system?: { product?: string; instructions?: string };
   context?: { maxOutputTokens?: number; toolOutputCap?: number };
+  capabilityMiss?: CapabilityMissConfig;
 }
 
 interface RecordedCall {
@@ -54,7 +60,19 @@ export function createRunner(config: RunnerConfig): AgentRunner {
     let report: AgentRunReport;
 
     try {
-      const system = await assembleSystemPrompt(config.guard, awayCtx, config.system);
+      const system = await assembleSystemPrompt(
+        config.guard,
+        awayCtx,
+        config.system,
+        config.capabilityMiss !== undefined,
+      );
+      const missDetector = config.capabilityMiss === undefined
+        ? undefined
+        : createCapabilityMissDetector({
+            config: config.capabilityMiss,
+            ctx: awayCtx,
+            intent: scrubCapabilityMissText(task.prompt),
+          });
       const tools = await buildAgentTools({
         registry: task.tools,
         ctx: awayCtx,
@@ -76,11 +94,14 @@ export function createRunner(config: RunnerConfig): AgentRunner {
         onCall: (call) => {
           const entry: RecordedCall = { call, outcome: "error" };
           recorded.push(entry);
+          const finishMissCall = missDetector?.onCall(call);
           return (outcome) => {
             entry.outcome = outcome.status;
+            finishMissCall?.(outcome);
           };
         },
       });
+      missDetector?.attach(tools);
       const toolCallCap: StopCondition<ToolSet> = ({ steps }) =>
         steps.reduce((count, step) => count + step.toolCalls.length, 0) >= cap;
       const result = await generateText({

--- a/packages/core/src/capability-miss.test.ts
+++ b/packages/core/src/capability-miss.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  VENDO_CAPABILITY_MISS_FORMAT,
+  capabilityMissEventSchema,
+  type CapabilityMissEvent,
+} from "./index.js";
+
+const base = {
+  format: "vendo/capability-miss@1" as const,
+  id: "mis_01",
+  at: "2026-07-14T20:00:00.000Z",
+  hostId: "host_maple",
+  appId: "app_bank",
+  sessionId: "session_01",
+  threadId: "thr_01",
+  intent: "Export my transactions to CSV",
+  surface: {
+    format: "vendo/tools@1" as const,
+    hash: `sha256:${"a".repeat(64)}`,
+  },
+};
+
+describe("vendo/capability-miss@1", () => {
+  it("exports the format constant and parses all three closed trigger variants", () => {
+    expect(VENDO_CAPABILITY_MISS_FORMAT).toBe("vendo/capability-miss@1");
+    const events: CapabilityMissEvent[] = [
+      {
+        ...base,
+        trigger: { kind: "no-matching-tool", toolsConsidered: ["host_transactions_list"] },
+      },
+      {
+        ...base,
+        id: "mis_02",
+        trigger: {
+          kind: "repeated-tool-failure",
+          toolsConsidered: ["host_transactions_export"],
+          attempts: [
+            {
+              tool: "host_transactions_export",
+              attempt: 1,
+              failure: { code: "timeout", message: "Export timed out." },
+            },
+            {
+              tool: "host_transactions_export",
+              attempt: 2,
+              failure: { code: "timeout", message: "Export timed out again." },
+            },
+          ],
+        },
+      },
+      {
+        ...base,
+        id: "mis_03",
+        trigger: {
+          kind: "agent-give-up",
+          toolsConsidered: ["host_transactions_export"],
+          toolsAttempted: ["host_transactions_export"],
+        },
+      },
+    ];
+
+    for (const event of events) expect(capabilityMissEventSchema.parse(event)).toEqual(event);
+  });
+
+  it("rejects malformed ids, surface hashes, trigger kinds, and short repeated-failure histories", () => {
+    expect(capabilityMissEventSchema.safeParse({
+      ...base,
+      id: "event_01",
+      trigger: { kind: "no-matching-tool", toolsConsidered: [] },
+    }).success).toBe(false);
+    expect(capabilityMissEventSchema.safeParse({
+      ...base,
+      surface: { format: "vendo/tools@1", hash: "sha256:not-a-digest" },
+      trigger: { kind: "no-matching-tool", toolsConsidered: [] },
+    }).success).toBe(false);
+    expect(capabilityMissEventSchema.safeParse({
+      ...base,
+      trigger: { kind: "unknown", toolsConsidered: [] },
+    }).success).toBe(false);
+    expect(capabilityMissEventSchema.safeParse({
+      ...base,
+      trigger: {
+        kind: "repeated-tool-failure",
+        toolsConsidered: ["host_transactions_export"],
+        attempts: [{
+          tool: "host_transactions_export",
+          attempt: 1,
+          failure: { message: "Only one failure" },
+        }],
+      },
+    }).success).toBe(false);
+  });
+});

--- a/packages/core/src/capability-miss.ts
+++ b/packages/core/src/capability-miss.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+import {
+  appIdSchema,
+  isoDateTimeSchema,
+  threadIdSchema,
+  type AppId,
+  type IsoDateTime,
+  type ThreadId,
+} from "./ids.js";
+import { TOOL_NAME_PATTERN } from "./tools.js";
+
+export const VENDO_CAPABILITY_MISS_FORMAT = "vendo/capability-miss@1" as const;
+
+export interface CapabilityMissToolFailure {
+  tool: string;
+  attempt: number;
+  failure: { code?: string; message: string };
+}
+
+export type CapabilityMissTrigger =
+  | { kind: "no-matching-tool"; toolsConsidered: string[] }
+  | {
+      kind: "repeated-tool-failure";
+      toolsConsidered: string[];
+      attempts: [CapabilityMissToolFailure, CapabilityMissToolFailure, ...CapabilityMissToolFailure[]];
+    }
+  | { kind: "agent-give-up"; toolsConsidered: string[]; toolsAttempted: string[] };
+
+export interface CapabilityMissEvent {
+  format: typeof VENDO_CAPABILITY_MISS_FORMAT;
+  id: string;
+  at: IsoDateTime;
+  hostId: string;
+  appId?: AppId;
+  sessionId: string;
+  threadId?: ThreadId;
+  intent: string;
+  surface: {
+    format: "vendo/tools@1";
+    hash: string;
+  };
+  trigger: CapabilityMissTrigger;
+}
+
+const toolNameSchema = z.string().regex(TOOL_NAME_PATTERN);
+
+export const capabilityMissToolFailureSchema = z.object({
+  tool: toolNameSchema,
+  attempt: z.number().int().positive(),
+  failure: z.object({
+    code: z.string().optional(),
+    message: z.string().min(1),
+  }).passthrough(),
+}).passthrough() satisfies z.ZodType<CapabilityMissToolFailure>;
+
+export const capabilityMissTriggerSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("no-matching-tool"),
+    toolsConsidered: z.array(toolNameSchema),
+  }).passthrough(),
+  z.object({
+    kind: z.literal("repeated-tool-failure"),
+    toolsConsidered: z.array(toolNameSchema),
+    attempts: z.array(capabilityMissToolFailureSchema).min(2),
+  }).passthrough(),
+  z.object({
+    kind: z.literal("agent-give-up"),
+    toolsConsidered: z.array(toolNameSchema),
+    toolsAttempted: z.array(toolNameSchema),
+  }).passthrough(),
+]) as unknown as z.ZodType<CapabilityMissTrigger>;
+
+export const capabilityMissEventSchema = z.object({
+  format: z.literal(VENDO_CAPABILITY_MISS_FORMAT),
+  id: z.string().regex(/^mis_.+$/),
+  at: isoDateTimeSchema,
+  hostId: z.string().min(1),
+  appId: appIdSchema.optional(),
+  sessionId: z.string().min(1),
+  threadId: threadIdSchema.optional(),
+  intent: z.string().min(1),
+  surface: z.object({
+    format: z.literal("vendo/tools@1"),
+    hash: z.string().regex(/^sha256:[0-9a-f]{64}$/),
+  }).passthrough(),
+  trigger: capabilityMissTriggerSchema,
+}).passthrough() satisfies z.ZodType<CapabilityMissEvent>;

--- a/packages/core/src/contract-coverage.e2e.test.ts
+++ b/packages/core/src/contract-coverage.e2e.test.ts
@@ -526,6 +526,7 @@ describe("public export surface — every contracted camelCaseName schema is pre
       "pinSchema", "triggerSourceSchema", "runModelSchema", "stepSchema", "triggerSchema",
       "vendoRecordSchema", "recordQuerySchema", "authMaterialSchema", "agentRunReportSchema",
       "vendoThemeSchema", "vendoViewPartSchema", "vendoApprovalPartSchema", "vendoErrorCodeSchema",
+      "capabilityMissToolFailureSchema", "capabilityMissTriggerSchema", "capabilityMissEventSchema",
       "appIdSchema", "grantIdSchema", "approvalIdSchema", "runIdSchema", "threadIdSchema",
       "isoDateTimeSchema", "jsonSchemaSchema",
     ];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@
 export * from "./app-document.js";
 export * from "./audit.js";
 export * from "./catalog.js";
+export * from "./capability-miss.js";
 export * from "./descriptor-hash.js";
 export * from "./errors.js";
 export * from "./formats.js";

--- a/packages/core/src/packaging.e2e.test.ts
+++ b/packages/core/src/packaging.e2e.test.ts
@@ -16,7 +16,7 @@ const WORK_DIR = join(PACKAGE_DIR, ".e2e-pack");
 
 const RUNTIME_EXPORTS = [
   "VENDO_APP_FORMAT", "VENDO_TREE_FORMAT", "VENDO_TOOLS_FORMAT", "VENDO_OVERRIDES_FORMAT",
-  "VENDO_POLICY_FORMAT", "descriptorHash", "validateTree", "validateAppDocument", "VendoError",
+  "VENDO_POLICY_FORMAT", "VENDO_CAPABILITY_MISS_FORMAT", "descriptorHash", "validateTree", "validateAppDocument", "VendoError",
   "safeErrorMessage", "canonicalJson", "sha256Hex", "TOOL_NAME_PATTERN",
   "TREE_MAX_NODES", "TREE_MAX_QUERIES", "TREE_MAX_GENERATED_COMPONENTS",
   "TREE_MAX_COMPONENT_SOURCE_CHARS", "TREE_MAX_TOTAL_COMPONENT_CHARS", "RESERVED_COMPONENT_NAMES",
@@ -29,6 +29,7 @@ const RUNTIME_EXPORTS = [
   "pinSchema", "triggerSourceSchema", "runModelSchema", "stepSchema", "triggerSchema",
   "vendoRecordSchema", "recordQuerySchema", "authMaterialSchema", "agentRunReportSchema",
   "vendoThemeSchema", "vendoViewPartSchema", "vendoApprovalPartSchema", "vendoErrorCodeSchema",
+  "capabilityMissToolFailureSchema", "capabilityMissTriggerSchema", "capabilityMissEventSchema",
   "appIdSchema", "grantIdSchema", "approvalIdSchema", "runIdSchema", "threadIdSchema",
   "isoDateTimeSchema", "jsonSchemaSchema",
 ];
@@ -76,7 +77,7 @@ describe("packaging e2e — the artifact blocks will install", () => {
     // dist-only artifact: no sources, no tests, no vectors in the tarball
     expect(existsSync(join(packed.dir, "src"))).toBe(false);
     expect(existsSync(join(packed.dir, "vectors"))).toBe(false);
-  });
+  }, 30_000);
 
   it("root import exposes the full contract surface and behaves", async () => {
     const packed = packOnce();
@@ -94,7 +95,7 @@ describe("packaging e2e — the artifact blocks will install", () => {
     const err = new core.VendoError("not-found", "missing");
     expect(err).toBeInstanceOf(Error);
     expect(err.code).toBe("not-found");
-  });
+  }, 30_000);
 
   it("reproduces the committed descriptor-hash vectors from the packed artifact", async () => {
     const packed = packOnce();

--- a/packages/vendo-telemetry/src/index.ts
+++ b/packages/vendo-telemetry/src/index.ts
@@ -3,7 +3,7 @@ import { loadConfig, saveConfig } from "./config.js";
 import { maybeShowNotice } from "./notice.js";
 import { createTelemetry, DEFAULT_POSTHOG_KEY, type Telemetry } from "./client.js";
 
-export { resolveConsent } from "./consent.js";
+export { envOptOut, resolveConsent } from "./consent.js";
 export { loadConfig, saveConfig, configPath, type TelemetryConfig } from "./config.js";
 export { EVENT_ALLOWLIST, isAllowedProps, type EventName } from "./events.js";
 export { createTelemetry, DEFAULT_POSTHOG_KEY, type Telemetry } from "./client.js";

--- a/packages/vendo/src/capability-misses.test.ts
+++ b/packages/vendo/src/capability-misses.test.ts
@@ -89,7 +89,7 @@ describe("capability-miss Cloud upload", () => {
     expect(capture.hostId).toBe("telemetry-installation-id");
   });
 
-  it("keeps local capture but sends nothing without a key or after telemetry opt-out", async () => {
+  it("keeps local capture but sends nothing without a key", async () => {
     const append = vi.fn(async () => {});
     const fetchImpl = vi.fn<typeof fetch>();
     const noKey = createCapabilityMissCapture({
@@ -99,6 +99,18 @@ describe("capability-miss Cloud upload", () => {
       fetchImpl,
       telemetryConfig: { anonymousId: "host_no_key", optedOut: false },
     });
+
+    noKey.record(event("mis_no_key"));
+    await noKey.flush();
+
+    expect(append).toHaveBeenCalledOnce();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("uploads despite the persisted product-telemetry opt-out (contract: key + envOptOut only)", async () => {
+    const append = vi.fn(async () => {});
+    const fetchImpl = vi.fn(async () =>
+      Response.json({ accepted: 1, duplicates: 0 }, { status: 202 }));
     const optedOut = createCapabilityMissCapture({
       env: { VENDO_API_KEY: "vnd_test", NODE_ENV: "development" },
       surface: Promise.resolve(surface),
@@ -107,12 +119,11 @@ describe("capability-miss Cloud upload", () => {
       telemetryConfig: { anonymousId: "host_opted_out", optedOut: true },
     });
 
-    noKey.record(event("mis_no_key"));
     optedOut.record(event("mis_opted_out"));
-    await Promise.all([noKey.flush(), optedOut.flush()]);
+    await optedOut.flush();
 
-    expect(append).toHaveBeenCalledTimes(2);
-    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(append).toHaveBeenCalledOnce();
+    expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
   it.each([
@@ -137,9 +148,10 @@ describe("capability-miss Cloud upload", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
-  it("fails closed outside development and test runtime environments", async () => {
+  it("uploads in production: NODE_ENV never gates miss upload (contract: key is the opt-in)", async () => {
     const append = vi.fn(async () => {});
-    const fetchImpl = vi.fn<typeof fetch>();
+    const fetchImpl = vi.fn(async () =>
+      Response.json({ accepted: 1, duplicates: 0 }, { status: 202 }));
     const capture = createCapabilityMissCapture({
       env: { VENDO_API_KEY: "vnd_test", NODE_ENV: "production" },
       telemetryConfig: { anonymousId: "host_production", optedOut: false },
@@ -152,7 +164,7 @@ describe("capability-miss Cloud upload", () => {
     await capture.flush();
 
     expect(append).toHaveBeenCalledOnce();
-    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
   it("batches events into the exact console request with the canonical enabled surface", async () => {

--- a/packages/vendo/src/capability-misses.test.ts
+++ b/packages/vendo/src/capability-misses.test.ts
@@ -1,0 +1,258 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { CapabilityMissEvent, ToolDescriptor } from "@vendoai/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  appendCapabilityMiss,
+  createCapabilityMissCapture,
+  capabilitySurfaceSnapshot,
+} from "./capability-misses.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  vi.restoreAllMocks();
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const hash = `sha256:${"c".repeat(64)}`;
+const surface = {
+  hash,
+  tools: [
+    { name: "host_accounts_list", risk: "read" as const },
+    { name: "host_transactions_export", risk: "write" as const },
+  ],
+};
+
+function event(id: string): CapabilityMissEvent {
+  return {
+    format: "vendo/capability-miss@1",
+    id,
+    at: "2026-07-14T20:00:00.000Z",
+    hostId: "host_maple",
+    sessionId: "session_01",
+    intent: "Export transactions",
+    surface: { format: "vendo/tools@1", hash },
+    trigger: { kind: "no-matching-tool", toolsConsidered: ["host_accounts_list"] },
+  };
+}
+
+async function tempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  cleanups.push(() => rm(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+describe("capability-miss local sink", () => {
+  it("appends one JSON object per line safely under concurrent writes", async () => {
+    const dataDir = await tempDir("vendo-misses-");
+    const events = Array.from({ length: 40 }, (_, index) => event(`mis_${index}`));
+
+    await Promise.all(events.map((miss) => appendCapabilityMiss(miss, { dataDir })));
+
+    const lines = (await readFile(join(dataDir, "misses.jsonl"), "utf8")).trim().split("\n");
+    expect(lines).toHaveLength(events.length);
+    expect(new Set(lines.map((line) => (JSON.parse(line) as CapabilityMissEvent).id)))
+      .toEqual(new Set(events.map((miss) => miss.id)));
+  });
+
+  it("never rejects the agent path when the local sink fails", async () => {
+    const capture = createCapabilityMissCapture({
+      env: {},
+      telemetryConfig: { anonymousId: "host_sink_failure", optedOut: false },
+      surface: Promise.resolve(surface),
+      append: async () => { throw new Error("disk full"); },
+    });
+
+    expect(() => capture.record(event("mis_disk_full"))).not.toThrow();
+    await expect(capture.flush()).resolves.toBeUndefined();
+  });
+});
+
+describe("capability-miss Cloud upload", () => {
+  it("uses the persisted telemetry anonymous id as the normative host id", async () => {
+    const home = await tempDir("vendo-miss-home-");
+    await mkdir(join(home, ".vendo"), { recursive: true });
+    await writeFile(join(home, ".vendo", "telemetry.json"), JSON.stringify({
+      anonymousId: "telemetry-installation-id",
+      optedOut: false,
+      noticeShown: true,
+    }));
+
+    const capture = createCapabilityMissCapture({
+      env: {},
+      telemetryHome: home,
+      surface: Promise.resolve(surface),
+      append: async () => {},
+    });
+
+    expect(capture.hostId).toBe("telemetry-installation-id");
+  });
+
+  it("keeps local capture but sends nothing without a key or after telemetry opt-out", async () => {
+    const append = vi.fn(async () => {});
+    const fetchImpl = vi.fn<typeof fetch>();
+    const noKey = createCapabilityMissCapture({
+      env: {},
+      surface: Promise.resolve(surface),
+      append,
+      fetchImpl,
+      telemetryConfig: { anonymousId: "host_no_key", optedOut: false },
+    });
+    const optedOut = createCapabilityMissCapture({
+      env: { VENDO_API_KEY: "vnd_test", NODE_ENV: "development" },
+      surface: Promise.resolve(surface),
+      append,
+      fetchImpl,
+      telemetryConfig: { anonymousId: "host_opted_out", optedOut: true },
+    });
+
+    noKey.record(event("mis_no_key"));
+    optedOut.record(event("mis_opted_out"));
+    await Promise.all([noKey.flush(), optedOut.flush()]);
+
+    expect(append).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["VENDO_TELEMETRY_DISABLED", { VENDO_TELEMETRY_DISABLED: "true" }],
+    ["DO_NOT_TRACK", { DO_NOT_TRACK: "1" }],
+    ["CI", { CI: "true" }],
+  ])("honors the %s environment opt-out for Cloud only", async (_name, optOut) => {
+    const append = vi.fn(async () => {});
+    const fetchImpl = vi.fn<typeof fetch>();
+    const capture = createCapabilityMissCapture({
+      env: { VENDO_API_KEY: "vnd_test", ...optOut },
+      surface: Promise.resolve(surface),
+      append,
+      fetchImpl,
+      telemetryConfig: { anonymousId: "host_env_opt_out", optedOut: false },
+    });
+
+    capture.record(event(`mis_${_name.toLowerCase()}`));
+    await capture.flush();
+
+    expect(append).toHaveBeenCalledOnce();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("fails closed outside development and test runtime environments", async () => {
+    const append = vi.fn(async () => {});
+    const fetchImpl = vi.fn<typeof fetch>();
+    const capture = createCapabilityMissCapture({
+      env: { VENDO_API_KEY: "vnd_test", NODE_ENV: "production" },
+      telemetryConfig: { anonymousId: "host_production", optedOut: false },
+      surface: Promise.resolve(surface),
+      append,
+      fetchImpl,
+    });
+
+    capture.record(event("mis_production"));
+    await capture.flush();
+
+    expect(append).toHaveBeenCalledOnce();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("batches events into the exact console request with the canonical enabled surface", async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(input), init });
+      return Response.json({ accepted: 3, duplicates: 0 }, { status: 202 });
+    });
+    const capture = createCapabilityMissCapture({
+      env: {
+        VENDO_API_KEY: "vnd_test_key",
+        VENDO_CLOUD_URL: "https://cloud.example.test/",
+        NODE_ENV: "development",
+      },
+      surface: Promise.resolve(surface),
+      append: async () => {},
+      fetchImpl,
+      telemetryConfig: { anonymousId: "host_batch", optedOut: false },
+      batchDelayMs: 60_000,
+    });
+    const events = [event("mis_batch_1"), event("mis_batch_2"), event("mis_batch_3")];
+
+    for (const miss of events) capture.record(miss);
+    await capture.flush();
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe("https://cloud.example.test/api/v1/misses");
+    expect(requests[0]?.init).toMatchObject({
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        authorization: "Bearer vnd_test_key",
+        "content-type": "application/json",
+      },
+    });
+    expect(JSON.parse(String(requests[0]?.init?.body))).toEqual({ surface, events });
+  });
+
+  it("retries a failed batch within a bound and then drops only the Cloud copy", async () => {
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockRejectedValueOnce(new Error("still offline"))
+      .mockResolvedValueOnce(Response.json({ accepted: 1, duplicates: 0 }, { status: 202 }));
+    const append = vi.fn(async () => {});
+    const capture = createCapabilityMissCapture({
+      env: { VENDO_API_KEY: "vnd_test_key", NODE_ENV: "development" },
+      surface: Promise.resolve(surface),
+      append,
+      fetchImpl,
+      telemetryConfig: { anonymousId: "host_retry", optedOut: false },
+      retryDelaysMs: [0, 0],
+      batchDelayMs: 60_000,
+    });
+
+    capture.record(event("mis_retry"));
+    await capture.flush();
+
+    expect(append).toHaveBeenCalledOnce();
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("bounds a hung Cloud request without delaying or losing the local copy", async () => {
+    const append = vi.fn(async () => {});
+    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+    }));
+    const capture = createCapabilityMissCapture({
+      env: { VENDO_API_KEY: "vnd_test_key", NODE_ENV: "test" },
+      telemetryConfig: { anonymousId: "host_timeout", optedOut: false },
+      surface: Promise.resolve(surface),
+      append,
+      fetchImpl,
+      requestTimeoutMs: 1,
+      retryDelaysMs: [],
+      batchDelayMs: 60_000,
+    });
+
+    capture.record(event("mis_timeout"));
+    await expect(capture.flush()).resolves.toBeUndefined();
+
+    expect(append).toHaveBeenCalledOnce();
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+});
+
+describe("capability surface identity", () => {
+  it("hashes a sorted compact enabled-tool surface canonically", () => {
+    const descriptors: ToolDescriptor[] = [
+      { name: "z_tool", description: "Z", inputSchema: { type: "object" }, risk: "write" },
+      { name: "a_tool", description: "A", inputSchema: { type: "object" }, risk: "read" },
+    ];
+
+    const first = capabilitySurfaceSnapshot(descriptors);
+    const second = capabilitySurfaceSnapshot([...descriptors].reverse());
+
+    expect(first).toEqual(second);
+    expect(first.tools).toEqual([
+      { name: "a_tool", risk: "read" },
+      { name: "z_tool", risk: "write" },
+    ]);
+    expect(first.hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+});

--- a/packages/vendo/src/capability-misses.ts
+++ b/packages/vendo/src/capability-misses.ts
@@ -1,0 +1,237 @@
+import {
+  canonicalJson,
+  sha256Hex,
+  type CapabilityMissEvent,
+  type RiskLabel,
+  type ToolDescriptor,
+} from "@vendoai/core";
+import { loadConfig, resolveConsent, type TelemetryConfig } from "@vendoai/telemetry";
+import { cloudFetch } from "./cli/cloud/client.js";
+
+const DEFAULT_DATA_DIR = ".vendo/data";
+const DEFAULT_BATCH_SIZE = 100;
+const DEFAULT_QUEUE_LIMIT = 1_000;
+const DEFAULT_BATCH_DELAY_MS = 250;
+const DEFAULT_REQUEST_TIMEOUT_MS = 1_500;
+const DEFAULT_RETRY_DELAYS_MS = [250, 1_000] as const;
+
+export interface CapabilitySurfaceSnapshot {
+  hash: string;
+  tools: Array<{ name: string; risk: RiskLabel; disabled?: boolean }>;
+}
+
+interface AppendOptions {
+  dataDir?: string;
+}
+
+type AppendMiss = (event: CapabilityMissEvent) => Promise<void>;
+
+interface CaptureOptions {
+  dataDir?: string;
+  env?: Record<string, string | undefined>;
+  telemetryHome?: string;
+  telemetryConfig?: Pick<TelemetryConfig, "anonymousId" | "optedOut">;
+  surface: Promise<CapabilitySurfaceSnapshot>;
+  append?: AppendMiss;
+  fetchImpl?: typeof fetch;
+  batchSize?: number;
+  queueLimit?: number;
+  batchDelayMs?: number;
+  requestTimeoutMs?: number;
+  retryDelaysMs?: readonly number[];
+}
+
+interface MissUploader {
+  enqueue(event: CapabilityMissEvent): void;
+  flush(): Promise<void>;
+}
+
+export interface CapabilityMissCapture {
+  /** Stable host-installation identity, shared with telemetry by contract. */
+  hostId: string;
+  record(event: CapabilityMissEvent): void;
+  /** Drain hook for tests and orderly host shutdown; agent turns never await it. */
+  flush(): Promise<void>;
+}
+
+function runtimeEnv(): Record<string, string | undefined> {
+  return typeof process === "undefined" ? {} : process.env;
+}
+
+function nodeFs(): typeof import("node:fs") {
+  const proc = (globalThis as { process?: { getBuiltinModule?: (id: string) => unknown } }).process;
+  const fs = proc?.getBuiltinModule?.("node:fs") as typeof import("node:fs") | undefined;
+  if (!fs) throw new Error("Capability-miss local persistence requires the Node filesystem");
+  return fs;
+}
+
+export async function appendCapabilityMiss(
+  event: CapabilityMissEvent,
+  options: AppendOptions = {},
+): Promise<void> {
+  const dataDir = options.dataDir ?? DEFAULT_DATA_DIR;
+  const fs = nodeFs();
+  await fs.promises.mkdir(dataDir, { recursive: true });
+  // appendFile opens with O_APPEND. Each event is serialized into one write so
+  // concurrent processes cannot race a read/modify/write cycle.
+  await fs.promises.appendFile(
+    `${dataDir.replace(/[\\/]$/, "")}/misses.jsonl`,
+    `${JSON.stringify(event)}\n`,
+    { encoding: "utf8", flag: "a" },
+  );
+}
+
+export function capabilitySurfaceSnapshot(descriptors: ToolDescriptor[]): CapabilitySurfaceSnapshot {
+  const tools = descriptors
+    .map(({ name, risk }) => ({ name, risk }))
+    .sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0);
+  const canonical = canonicalJson({ format: "vendo/tools@1", tools });
+  return { hash: `sha256:${sha256Hex(canonical)}`, tools };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    unrefTimer(timer);
+  });
+}
+
+function unrefTimer(timer: ReturnType<typeof setTimeout>): void {
+  if (typeof timer === "object" && timer !== null && "unref" in timer) {
+    (timer as { unref?: () => void }).unref?.();
+  }
+}
+
+function validUploadResponse(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const response = value as { accepted?: unknown; duplicates?: unknown };
+  return Number.isInteger(response.accepted) && Number.isInteger(response.duplicates);
+}
+
+function createMissUploader(options: {
+  apiKey: string;
+  env: Record<string, string | undefined>;
+  surface: Promise<CapabilitySurfaceSnapshot>;
+  fetchImpl?: typeof fetch;
+  batchSize: number;
+  queueLimit: number;
+  batchDelayMs: number;
+  requestTimeoutMs: number;
+  retryDelaysMs: readonly number[];
+}): MissUploader {
+  const queue: CapabilityMissEvent[] = [];
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let active: Promise<void> | undefined;
+
+  const send = async (events: CapabilityMissEvent[]): Promise<void> => {
+    for (let attempt = 0; attempt <= options.retryDelaysMs.length; attempt += 1) {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), options.requestTimeoutMs);
+      unrefTimer(timeout);
+      try {
+        const surface = await options.surface;
+        const response = await cloudFetch<{ accepted: number; duplicates: number }>("/api/v1/misses", {
+          auth: "key",
+          apiKey: options.apiKey,
+          env: options.env,
+          fetchImpl: options.fetchImpl,
+          signal: controller.signal,
+          body: { surface, events },
+        });
+        if (!validUploadResponse(response)) throw new Error("Invalid capability-miss upload response");
+        return;
+      } catch {
+        const retryDelay = options.retryDelaysMs[attempt];
+        if (retryDelay === undefined) return;
+        await delay(retryDelay);
+      } finally {
+        clearTimeout(timeout);
+      }
+    }
+  };
+
+  const drain = async (): Promise<void> => {
+    while (queue.length > 0) {
+      const batch = queue.splice(0, options.batchSize);
+      await send(batch);
+    }
+  };
+
+  const flush = async (): Promise<void> => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+    if (active) {
+      await active;
+      if (queue.length === 0) return;
+    }
+    active = drain().finally(() => {
+      active = undefined;
+    });
+    await active;
+  };
+
+  const schedule = (): void => {
+    if (timer !== undefined || active !== undefined) return;
+    timer = setTimeout(() => {
+      timer = undefined;
+      void flush().catch(() => undefined);
+    }, options.batchDelayMs);
+    unrefTimer(timer);
+  };
+
+  return {
+    enqueue(event) {
+      if (queue.length >= options.queueLimit) return;
+      queue.push(event);
+      if (queue.length >= options.batchSize) void flush().catch(() => undefined);
+      else schedule();
+    },
+    flush,
+  };
+}
+
+export function createCapabilityMissCapture(options: CaptureOptions): CapabilityMissCapture {
+  const env = options.env ?? runtimeEnv();
+  const telemetryConfig = options.telemetryConfig
+    ?? loadConfig(options.telemetryHome, env);
+  const apiKey = env.VENDO_API_KEY?.trim();
+  let uploader: MissUploader | undefined;
+  if (apiKey) {
+    const consent = resolveConsent({ env, optedOut: telemetryConfig.optedOut, runtime: true });
+    if (consent.allowed) {
+      uploader = createMissUploader({
+        apiKey,
+        env,
+        surface: options.surface,
+        fetchImpl: options.fetchImpl,
+        batchSize: options.batchSize ?? DEFAULT_BATCH_SIZE,
+        queueLimit: options.queueLimit ?? DEFAULT_QUEUE_LIMIT,
+        batchDelayMs: options.batchDelayMs ?? DEFAULT_BATCH_DELAY_MS,
+        requestTimeoutMs: options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+        retryDelaysMs: options.retryDelaysMs ?? DEFAULT_RETRY_DELAYS_MS,
+      });
+    }
+  }
+
+  const append = options.append
+    ?? ((event: CapabilityMissEvent) => appendCapabilityMiss(event, { dataDir: options.dataDir }));
+  const pendingLocal = new Set<Promise<void>>();
+
+  return {
+    hostId: telemetryConfig.anonymousId,
+    record(event) {
+      const local = Promise.resolve()
+        .then(() => append(event))
+        .catch(() => undefined)
+        .finally(() => pendingLocal.delete(local));
+      pendingLocal.add(local);
+      uploader?.enqueue(event);
+    },
+    async flush() {
+      while (pendingLocal.size > 0) await Promise.all([...pendingLocal]);
+      await uploader?.flush();
+    },
+  };
+}

--- a/packages/vendo/src/capability-misses.ts
+++ b/packages/vendo/src/capability-misses.ts
@@ -5,7 +5,7 @@ import {
   type RiskLabel,
   type ToolDescriptor,
 } from "@vendoai/core";
-import { loadConfig, resolveConsent, type TelemetryConfig } from "@vendoai/telemetry";
+import { envOptOut, loadConfig, type TelemetryConfig } from "@vendoai/telemetry";
 import { cloudFetch } from "./cli/cloud/client.js";
 
 const DEFAULT_DATA_DIR = ".vendo/data";
@@ -199,8 +199,10 @@ export function createCapabilityMissCapture(options: CaptureOptions): Capability
   const apiKey = env.VENDO_API_KEY?.trim();
   let uploader: MissUploader | undefined;
   if (apiKey) {
-    const consent = resolveConsent({ env, optedOut: telemetryConfig.optedOut, runtime: true });
-    if (consent.allowed) {
+    // Contract (01-core §17): upload is gated by the key plus envOptOut only.
+    // The persisted telemetry opt-out and the NODE_ENV fail-close are
+    // product-telemetry-only; a non-empty VENDO_API_KEY is the host's opt-in.
+    if (!envOptOut(env)) {
       uploader = createMissUploader({
         apiKey,
         env,

--- a/packages/vendo/src/cli/cloud/client.ts
+++ b/packages/vendo/src/cli/cloud/client.ts
@@ -44,6 +44,7 @@ export interface CloudFetchOptions extends CloudUrlOptions {
   fetchImpl?: typeof fetch;
   home?: string;
   sessionStore?: SessionStore;
+  signal?: AbortSignal;
 }
 
 interface ErrorEnvelope {
@@ -130,6 +131,7 @@ async function send(
     method: options.method ?? (options.body === undefined ? "GET" : "POST"),
     headers,
     body: options.body === undefined ? undefined : JSON.stringify(options.body),
+    signal: options.signal,
   });
   return { response, body: await responseBody(response) };
 }

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -27,6 +27,10 @@ import { createMcpDoor, type AppsPort, type HostOAuthAdapter, type McpDoor } fro
 import { createStore, envSecrets, registerEphemeralSubject, type VendoStore } from "@vendoai/store";
 import { initTelemetry, type Telemetry } from "@vendoai/telemetry";
 import type { LanguageModel } from "ai";
+import {
+  capabilitySurfaceSnapshot,
+  createCapabilityMissCapture,
+} from "./capability-misses.js";
 
 const VERSION = "0.3.0";
 const BASE_PATH = "/api/vendo";
@@ -735,6 +739,10 @@ export function createVendo(config: CreateVendoConfig): Vendo {
   });
   resolveAppToolRisk = apps.agentToolRisk;
   actions.add(apps.agentTools());
+  const missSurface = actions.descriptors()
+    .then(capabilitySurfaceSnapshot)
+    .catch(() => capabilitySurfaceSnapshot([]));
+  const missCapture = createCapabilityMissCapture({ surface: missSurface });
   const agent = createAgent({
     model: config.model,
     tools: boundTools,
@@ -744,6 +752,11 @@ export function createVendo(config: CreateVendoConfig): Vendo {
       toolOutputCap: config.agent?.toolOutputCap ?? DEFAULT_TOOL_OUTPUT_CAP,
       ...(config.agent?.maxOutputTokens === undefined ? {} : { maxOutputTokens: config.agent.maxOutputTokens }),
       ...(config.agent?.historyWindow === undefined ? {} : { historyWindow: config.agent.historyWindow }),
+    },
+    capabilityMiss: {
+      hostId: missCapture.hostId,
+      surface: missSurface.then(({ hash }) => ({ format: "vendo/tools@1" as const, hash })),
+      emit: (event) => missCapture.record(event),
     },
   });
   const automations = createAutomations({


### PR DESCRIPTION
## What this implements

ENG-253 adds capability-miss capture to embedded Vendo agent runs. Every miss is fire-and-forget appended as one contract-shaped JSON object to the host's `.vendo/data/misses.jsonl`; local persistence is never consent-gated and sink failures never alter the agent turn.

The three locked triggers are covered:

- `no-matching-tool`: the always-available internal `vendo_report_capability_miss` tool is described in the agent system prompt and records the enabled tools actually considered.
- `repeated-tool-failure`: the agent loop deterministically records the second failure of the same tool in one run, once per run, with credential/PII scrubbing and no arguments or outputs.
- `agent-give-up`: the internal reporter records an explicit terminal give-up plus the tools actually attempted.

When `VENDO_API_KEY` is present, Cloud upload is gated by `envOptOut` alone (`VENDO_TELEMETRY_DISABLED`, `DO_NOT_TRACK`, and `CI`), per the merged 01-core §17 contract: the persisted product-telemetry opt-out and the `NODE_ENV` fail-close do not gate miss upload, and production upload is allowed because a non-empty key is the host's explicit opt-in. Uploads are best-effort bounded batches to `POST /api/v1/misses`, always include the canonical enabled-tool surface and SHA-256 hash, use bounded retries/request timeout/queue size, and never replace or delay the local append.

## Demo-host capture

I ran `demo-bank`, asked the embedded agent `Book me a seat on the first passenger flight to Mars.`, and exercised the normal agent stream with a local Anthropic-protocol stub because this worktree has no provider credential. The real agent loop invoked the internal reporter, replied that it could not fulfill the ask, and the final compiled implementation appended this schema-validated line:

```json
{"format":"vendo/capability-miss@1","id":"mis_1e8467ef235b4652a1d77f414887e73a","at":"2026-07-15T00:55:13.409Z","hostId":"df4955e5-4622-4b8f-a1e1-b0470be375a4","sessionId":"session_d07ce856-f44e-4bca-87db-44598c898c37","threadId":"thr_maple_demo","intent":"Book me a seat on the first passenger flight to Mars.","surface":{"format":"vendo/tools@1","hash":"sha256:b27e996d9a423d5474468582100cb728ca729b5cf177e34bff71a1218e1a7400"},"trigger":{"kind":"no-matching-tool","toolsConsidered":[]}}
```

## Tests and verification

- Contract/schema and packaging coverage in `@vendoai/core`.
- Agent-loop tests for all three triggers, per-run dedupe, attempted/considered tools, and sensitive-text scrubbing.
- Vendo sink/upload tests for concurrent JSONL append, non-fatal sink failure, normative persisted telemetry host ID, no-key and all opt-out paths, exact batching/auth/surface body, retry/drop behavior, and hung-request timeout.
- Focused ENG-253 suites: 20 tests passed.
- `pnpm build`: passed (18/18 tasks).
- `pnpm typecheck`: passed (34/34 tasks).
- `pnpm lint`: passed, including dependency guard (12 packages).
- GitHub CI passed the full root `pnpm build`, `pnpm test`, `pnpm typecheck`, and `pnpm lint` sequence; audit, changeset, integration-browser, and performance jobs are also green. (A local shared-machine `pnpm test` attempt reproduced a pre-existing automations host-approval polling flake under heavy concurrent worktree load, but the controlled CI root test passed.)

This implements the event shape from the gated contract amendment in [runvendo/vendo#167](https://github.com/runvendo/vendo/pull/167).

Linear: https://linear.app/runvendo/issue/ENG-253

