### PR TITLE
fix(mcp): remoteAs trusts configured audience, not request-derived resource (unblocks proxied fronting)

### DIFF
--- a/packages/mcp/src/door.test.ts
+++ b/packages/mcp/src/door.test.ts
@@ -26,6 +26,7 @@ import type {
 } from "./state.js";
 
 const BASE = "https://product.example/api/vendo/mcp";
+const PROXIED_BASE = "http://door.internal:8787/api/vendo/mcp";
 const REDIRECT = "https://client.example/callback";
 const VERIFIER = "a-very-long-pkce-verifier-that-is-valid-for-the-test-suite-1234567890";
 
@@ -403,6 +404,44 @@ describe("createMcpDoor routing and OAuth", () => {
 });
 
 describe("createMcpDoor remote authorization server trust", () => {
+  it("trusts the configured audience when a proxy changes the request origin", async () => {
+    const as = await remoteAsFixture();
+    vi.stubGlobal("fetch", as.fetch);
+    const harness = makeHarness({
+      remoteAs: { issuer: as.issuer, audience: BASE },
+      principal: (subject) => ({ kind: "user", subject }),
+    });
+
+    const token = await as.mint({ sub: "proxied_user" });
+    const response = await harness.door.handler(mcpRequest(token, undefined, PROXIED_BASE));
+
+    expect(response.status).toBe(200);
+    expect(harness.principalSubjects).toEqual(["proxied_user"]);
+  });
+
+  it("rejects a wrong-audience JWT even when the request arrives through a proxy", async () => {
+    const as = await remoteAsFixture();
+    vi.stubGlobal("fetch", as.fetch);
+    const harness = makeHarness({ remoteAs: { issuer: as.issuer, audience: BASE } });
+
+    const token = await as.mint({ audience: "https://attacker.example/api/vendo/mcp" });
+    const response = await harness.door.handler(mcpRequest(token, undefined, PROXIED_BASE));
+
+    expect(response.status).toBe(401);
+    expect(harness.principalSubjects).toEqual([]);
+  });
+
+  it("keeps request-derived resource binding in local authorization-server mode", async () => {
+    const harness = makeHarness();
+    const registration = await register(harness.door);
+    const tokens = await issue(harness.door, registration.body.client_id);
+
+    const response = await harness.door.handler(mcpRequest(tokens.access_token, undefined, PROXIED_BASE));
+
+    expect(response.status).toBe(401);
+    expect(harness.principalSubjects).toEqual([]);
+  });
+
   it("discovers and caches ES256 JWKS, accepts a valid JWT, and keeps principal() as the host kill switch", async () => {
     const as = await remoteAsFixture();
     vi.stubGlobal("fetch", as.fetch);
@@ -1061,8 +1100,8 @@ async function connect(door: McpDoor, accessToken: string) {
   return { client, transport };
 }
 
-function mcpRequest(accessToken: string, sessionId?: string) {
-  return new Request(BASE, {
+function mcpRequest(accessToken: string, sessionId?: string, resource = BASE) {
+  return new Request(resource, {
     method: "POST",
     headers: {
       authorization: `Bearer ${accessToken}`,

--- a/packages/mcp/src/door.ts
+++ b/packages/mcp/src/door.ts
@@ -190,7 +190,7 @@ class Door {
     const auth = this.#remoteAs === undefined
       ? await this.#oauth.authenticate(req)
       : await this.#remoteAs.authenticate(req);
-    if (!auth || !sameCanonicalUri(auth.grant.resource, resource)) {
+    if (!auth || (this.#remoteAs === undefined && !sameCanonicalUri(auth.grant.resource, resource))) {
       return unauthorized(url.origin, mount, req.headers.has("authorization"));
     }
 


### PR DESCRIPTION
## Summary

- skip request-derived resource URI comparison for remote authorization-server tokens, whose audience is already verified against `remoteAs.audience`
- preserve request-derived resource binding for the local authorization-server flow
- cover valid proxied remote tokens, wrong-audience rejection, and the unchanged local mismatch rejection

## Why

Behind TLS termination or a fronting reverse proxy, the incoming request origin can differ from the configured remote audience. Comparing the verified remote grant to that request-derived origin therefore rejected valid proxied traffic; `RemoteAsVerifier` already enforces the authoritative configured audience while verifying the JWT.

This intentionally does not address the broader public/base URL behavior owned by ENG-333 (workstream A).

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `remoteAs` trust the configured audience instead of the request-derived resource so proxied/fronted deployments work, while keeping local AS resource binding unchanged. Aligns with Linear ENG-284’s remote-AS trust mode.

- **Bug Fixes**
  - Updated `packages/mcp/src/door.ts` to only enforce request-derived resource matching in local AS mode; `remoteAs` now relies on the configured `audience`.
  - Added tests for proxied valid tokens, wrong-audience rejection behind a proxy, and unchanged local-mode mismatch rejection.

<sup>Written for commit 48c826bc803aed6ef9834c8036d1b7866b188a42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

