### PR TITLE
feat(sync): blast-radius impact endpoint, strict exit codes, --report, init hooks (ENG-261)

### DIFF
--- a/fixtures/integration/src/harness.ts
+++ b/fixtures/integration/src/harness.ts
@@ -136,11 +136,23 @@ const cookieCache = new Map<string, string>();
 export async function loginCookie(subject: string): Promise<string> {
   const cached = cookieCache.get(subject);
   if (cached !== undefined) return cached;
-  const response = await fetch(`${fixtureBaseUrl()}/api/login`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ user: subject }),
-  });
+  let response: Response | undefined;
+  let lastError: unknown;
+  // The shared Next dev fixture can reset its first login socket while sibling
+  // Turbo tasks finish compiling; retry only this idempotent session mint.
+  for (let attempt = 0; attempt < 3 && response === undefined; attempt += 1) {
+    try {
+      response = await fetch(`${fixtureBaseUrl()}/api/login`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ user: subject }),
+      });
+    } catch (error) {
+      lastError = error;
+      if (attempt < 2) await new Promise((resolve) => setTimeout(resolve, 250 * (attempt + 1)));
+    }
+  }
+  if (response === undefined) throw lastError;
   if (!response.ok) throw new Error(`Fixture login failed (${response.status})`);
   const cookie = response.headers.get("set-cookie")?.split(";")[0];
   if (!cookie) throw new Error("Fixture login did not return a cookie");

--- a/fixtures/integration/src/sync-impact.e2e.test.ts
+++ b/fixtures/integration/src/sync-impact.e2e.test.ts
@@ -1,0 +1,90 @@
+/** ENG-261 — sync blast radius over the real composed wire and store. */
+import { VENDO_APP_FORMAT, VENDO_TREE_FORMAT, type AppDocument } from "@vendoai/core";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ADA,
+  createStack,
+  decideApprovals,
+  importAutomation,
+  resetFixture,
+  type Stack,
+  type WireApproval,
+} from "./harness.js";
+
+const TOOL = "host_invoices_list";
+
+let stack: Stack;
+afterEach(async () => {
+  await stack?.close();
+});
+
+function plainApp(): AppDocument {
+  return {
+    format: VENDO_APP_FORMAT,
+    id: "app_import_placeholder",
+    name: "Invoice viewer",
+    ui: "tree",
+    tree: {
+      formatVersion: VENDO_TREE_FORMAT,
+      root: "root",
+      nodes: [{ id: "root", component: "Text", props: { text: "Invoices" } }],
+      queries: [{ path: "/invoices", tool: TOOL }],
+    },
+  };
+}
+
+function automation(): AppDocument {
+  return {
+    format: VENDO_APP_FORMAT,
+    id: "app_import_placeholder",
+    name: "Invoice refresh",
+    trigger: {
+      on: { kind: "host-event", event: "sync-impact.refresh" },
+      run: { kind: "steps", steps: [{ id: "list", tool: TOOL }] },
+    },
+  };
+}
+
+describe("ENG-261: sync impact through the composed wire", () => {
+  it("maps a tool to its saved app, automation, and active standing grant", async () => {
+    await resetFixture();
+    stack = await createStack();
+
+    const app = await importAutomation(stack, plainApp(), ADA);
+    // Imported documents are intentionally disabled at rest and the public wire
+    // has no enable route for plain apps; flip only that persisted operator bit.
+    await stack.sql("UPDATE vendo_apps SET enabled = true WHERE id = $1", [app.id]);
+    const automated = await importAutomation(stack, automation(), ADA);
+    const enabled = (await (await stack.wireFetch(
+      `/automations/${automated.id}/enable`,
+      { method: "POST" },
+      ADA,
+    )).json()) as { enabled: boolean; missing: WireApproval[] };
+    expect(enabled).toMatchObject({ enabled: true });
+    expect(enabled.missing.map((request) => request.call.tool)).toEqual([TOOL]);
+    expect((await decideApprovals(
+      stack,
+      enabled.missing.map((request) => request.id),
+      { approve: true },
+      ADA,
+    )).status).toBe(200);
+
+    const response = await stack.wireFetch("/sync/impact", {
+      method: "POST",
+      body: JSON.stringify({ tools: [TOOL, "host_absent"] }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      impact: [
+        {
+          tool: TOOL,
+          apps: [{ id: app.id, title: "Invoice viewer" }],
+          automations: [{ id: automated.id, title: "Invoice refresh" }],
+          grants: 1,
+        },
+        { tool: "host_absent", apps: [], automations: [], grants: 0 },
+      ],
+    });
+  });
+});

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -25,7 +25,7 @@ Options:
   --model-import <specifier> Init only: module exporting the host's ai-SDK model
   --brief <text>             Init only: product brief used for non-interactive setup
   --url <url>                Doctor/server-json: mounted wire base or public MCP URL
-  --strict                   Sync only: exit 2 on breaking changes
+  --strict                   Sync only: exit 2 on breaking changes, 3 when saved references are impacted
   --version                  Print the version
 `;
 
@@ -70,7 +70,11 @@ export async function main(argv: string[]): Promise<number> {
     return runDoctor({ targetDir: target(args), url: option(args, "--url") });
   }
   if (command === "sync") {
-    return runSync({ targetDir: target(args), strict: args.includes("--strict") });
+    return runSync({
+      targetDir: target(args),
+      strict: args.includes("--strict"),
+      url: option(args, "--url"),
+    });
   }
   console.error(`Unknown command: ${command}\n\n${HELP}`);
   return 1;

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -26,6 +26,9 @@ Options:
   --brief <text>             Init only: product brief used for non-interactive setup
   --url <url>                Doctor/server-json: mounted wire base or public MCP URL
   --strict                   Sync only: exit 2 on breaking changes, 3 when saved references are impacted
+  --report                   Sync only: push the report to Vendo Cloud
+  --key <key>                Sync/cloud: override VENDO_API_KEY
+  --api-url <url>            Sync/cloud: override VENDO_CLOUD_URL
   --version                  Print the version
 `;
 
@@ -37,7 +40,7 @@ function option(args: string[], name: string): string | undefined {
 
 function target(args: string[]): string {
   const optionValues = new Set<string>();
-  for (const name of ["--model-import", "--url", "--brief"]) {
+  for (const name of ["--model-import", "--url", "--brief", "--key", "--api-url"]) {
     const index = args.indexOf(name);
     if (index >= 0 && args[index + 1] !== undefined) optionValues.add(args[index + 1]!);
   }
@@ -74,6 +77,9 @@ export async function main(argv: string[]): Promise<number> {
       targetDir: target(args),
       strict: args.includes("--strict"),
       url: option(args, "--url"),
+      report: args.includes("--report"),
+      apiKey: option(args, "--key"),
+      apiUrl: option(args, "--api-url"),
     });
   }
   console.error(`Unknown command: ${command}\n\n${HELP}`);

--- a/packages/vendo/src/cli/cloud/services.ts
+++ b/packages/vendo/src/cli/cloud/services.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { option, positionals } from "./args.js";
-import { CloudError, resolveCloudBaseUrl, type CloudFetchOptions } from "./client.js";
+import { CloudError, cloudFetch, resolveCloudBaseUrl, type CloudFetchOptions } from "./client.js";
 import {
   commandContext,
   type CloudCommandContext,
@@ -13,6 +13,18 @@ import {
   type EntitlementResolution,
 } from "./entitlements-cache.js";
 import { isVendoKey, parseContractV2, type ContractV2 } from "./entitlements.js";
+
+export function pushSyncReport(
+  payload: unknown,
+  options: Pick<CloudFetchOptions, "apiKey" | "apiUrl" | "env" | "fetchImpl"> = {},
+): Promise<unknown> {
+  return cloudFetch("/api/v1/sync/report", {
+    ...options,
+    auth: "key",
+    method: "POST",
+    body: payload,
+  });
+}
 
 function machineOptions(args: string[], context: CloudCommandContext): CloudFetchOptions {
   const apiKey = option(args, "--key") ?? context.env.VENDO_API_KEY;

--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -95,7 +95,10 @@ describe("vendo init", () => {
     const root = await expressFixture(true);
     const sink = output();
     expect(await runInit({ targetDir: root, agent: true, output: sink.output })).toBe(0);
-    expect(JSON.parse(sink.logs.join("\n"))).toMatchObject({ framework: "express", codeChanges: [] });
+    expect(JSON.parse(sink.logs.join("\n"))).toMatchObject({
+      framework: "express",
+      codeChanges: [{ path: "package.json" }],
+    });
 
     const initialized = output();
     expect(await runInit({ targetDir: root, yes: true, output: initialized.output })).toBe(0);
@@ -124,16 +127,17 @@ describe("vendo init", () => {
       codeChanges: Array<{ path: string; diff: string }>;
     };
     expect(plan.framework).toBe("express");
-    expect(plan.codeChanges).toHaveLength(2);
+    expect(plan.codeChanges).toHaveLength(3);
     expect(plan.codeChanges[0]?.path).toBe("vendo/server.ts");
     expect(plan.codeChanges[0]?.diff).toContain("createVendo");
     expect(plan.codeChanges[0]?.diff).toContain("new Request");
     expect(plan.codeChanges[1]?.path).toBe("vendo/ai.ts");
+    expect(plan.codeChanges[2]?.path).toBe("package.json");
 
     const declined = output();
     const confirm = vi.fn().mockResolvedValue(false);
     expect(await runInit({ targetDir: root, confirm, output: declined.output })).toBe(0);
-    expect(confirm).toHaveBeenCalledTimes(2);
+    expect(confirm).toHaveBeenCalledTimes(3);
     expect(declined.logs.join("\n")).toContain("Proposed code change");
     await expect(readFile(join(root, "vendo", "server.ts")))
       .rejects.toMatchObject({ code: "ENOENT" });
@@ -179,6 +183,7 @@ describe("vendo init", () => {
     expect(codeChanges).toMatchObject([
       { path: "vendo/server.mjs" },
       { path: "vendo/ai.mjs" },
+      { path: "package.json" },
     ]);
     // The JS wiring hint must be pasteable JavaScript — no type-only syntax.
     const scaffold = codeChanges[0]?.diff ?? "";
@@ -195,10 +200,73 @@ describe("vendo init", () => {
     const sink = output();
     expect(await runInit({ targetDir: root, agent: true, output: sink.output })).toBe(0);
     expect(await tree(root)).toEqual(before);
-    const plan = JSON.parse(sink.logs.join("\n")) as { questions: unknown[]; codeChanges: Array<{ diff: string }> };
+    const plan = JSON.parse(sink.logs.join("\n")) as {
+      questions: unknown[];
+      codeChanges: Array<{ path: string; diff: string }>;
+    };
     expect(plan.questions).toHaveLength(4);
-    expect(plan.codeChanges).toHaveLength(3); // route + layout + starter model module
+    expect(plan.codeChanges).toHaveLength(4); // route + layout + starter model module + package hooks
     expect(plan.codeChanges[0]?.diff).toContain("@vendoai/vendo/server");
+    expect(plan.codeChanges.find((change) => change.path === "package.json")?.diff)
+      .toContain('"predev": "vendo sync"');
+  });
+
+  it("adds predev and prebuild sync hooks only when the package change is approved", async () => {
+    const root = await fixture();
+    const before = await readFile(join(root, "package.json"), "utf8");
+    const confirm = vi.fn(async (change: { path: string }) => change.path === "package.json");
+
+    expect(await runInit({ targetDir: root, confirm, output: output().output })).toBe(0);
+
+    expect(confirm).toHaveBeenCalledTimes(4);
+    expect(JSON.parse(await readFile(join(root, "package.json"), "utf8"))).toMatchObject({
+      scripts: { predev: "vendo sync", prebuild: "vendo sync --strict" },
+    });
+    expect(await readFile(join(root, "package.json"), "utf8")).not.toBe(before);
+  });
+
+  it("prepends sync to existing lifecycle hooks and preserves package formatting", async () => {
+    const root = await fixture();
+    const manifest = {
+      name: "host",
+      scripts: { predev: "echo warmup", prebuild: "npm run check" },
+      dependencies: { next: "16.0.0", "@vendoai/vendo": "0.3.0" },
+    };
+    await writeFile(join(root, "package.json"), `${JSON.stringify(manifest, null, 4)}\n`);
+
+    expect(await runInit({ targetDir: root, yes: true, output: output().output })).toBe(0);
+
+    const raw = await readFile(join(root, "package.json"), "utf8");
+    expect(raw.endsWith("\n")).toBe(true);
+    expect(raw).toContain('    "scripts"');
+    expect(JSON.parse(raw)).toMatchObject({
+      scripts: {
+        predev: "vendo sync && echo warmup",
+        prebuild: "vendo sync --strict && npm run check",
+      },
+    });
+  });
+
+  it("offers no package change on an idempotent rerun", async () => {
+    const root = await fixture();
+    expect(await runInit({ targetDir: root, yes: true, output: output().output })).toBe(0);
+    const first = await readFile(join(root, "package.json"), "utf8");
+    const confirm = vi.fn().mockResolvedValue(false);
+
+    expect(await runInit({ targetDir: root, confirm, output: output().output })).toBe(0);
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(await readFile(join(root, "package.json"), "utf8")).toBe(first);
+  });
+
+  it("leaves package.json untouched when its prompt is declined", async () => {
+    const root = await fixture();
+    const before = await readFile(join(root, "package.json"), "utf8");
+    const confirm = vi.fn(async (change: { path: string }) => change.path !== "package.json");
+
+    expect(await runInit({ targetDir: root, confirm, output: output().output })).toBe(0);
+
+    expect(await readFile(join(root, "package.json"), "utf8")).toBe(before);
   });
 
   it("writes the complete .vendo contract and permission-gated Next wiring idempotently", async () => {
@@ -284,7 +352,7 @@ describe("vendo init", () => {
     const sink = output();
     const confirm = vi.fn().mockResolvedValue(false);
     expect(await runInit({ targetDir: root, confirm, output: sink.output })).toBe(0);
-    expect(confirm).toHaveBeenCalledTimes(3); // route + layout + starter model module
+    expect(confirm).toHaveBeenCalledTimes(4); // route + layout + starter model module + package hooks
     expect(sink.logs.join("\n")).toContain("Proposed code change");
     expect(await readFile(join(root, "app", "layout.tsx"), "utf8")).not.toContain("VendoRoot");
     await expect(readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8"))

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -372,6 +372,33 @@ function diff(path: string, before: string | null, after: string): string {
   ].join("\n");
 }
 
+function packageWithSyncHooks(raw: string): string | null {
+  const manifest = JSON.parse(raw) as Record<string, unknown>;
+  const priorScripts = manifest["scripts"];
+  const scripts = typeof priorScripts === "object" && priorScripts !== null && !Array.isArray(priorScripts)
+    ? priorScripts as Record<string, unknown>
+    : {};
+  let changed = false;
+  const hook = (name: "predev" | "prebuild", command: string): void => {
+    const prior = scripts[name];
+    if (typeof prior !== "string") {
+      scripts[name] = command;
+      changed = true;
+    } else if (!prior.includes(command)) {
+      scripts[name] = `${command} && ${prior}`;
+      changed = true;
+    }
+  };
+  hook("predev", "vendo sync");
+  hook("prebuild", "vendo sync --strict");
+  if (!changed) return null;
+  manifest["scripts"] = scripts;
+
+  const detectedIndent = raw.match(/^[\t ]+(?=")/m)?.[0] ?? "  ";
+  const trailingNewline = raw.endsWith("\r\n") ? "\r\n" : raw.endsWith("\n") ? "\n" : "";
+  return `${JSON.stringify(manifest, null, detectedIndent)}${trailingNewline}`;
+}
+
 async function buildPlan(options: InitOptions, mcpEnabled = false): Promise<{ plan: InitPlan; changes: Array<{ absolute: string; path: string; before: string | null; after: string; diff: string }> }> {
   const root = resolve(options.targetDir);
   const framework = await detectFramework(root);
@@ -431,6 +458,21 @@ async function buildPlan(options: InitOptions, mcpEnabled = false): Promise<{ pl
     if (layoutAfter !== null && layoutAfter !== layoutBefore) {
       const path = relative(root, layout);
       changes.push({ absolute: layout, path, before: layoutBefore, after: layoutAfter, diff: diff(path, layoutBefore, layoutAfter) });
+    }
+  }
+  const packageJson = join(root, "package.json");
+  const packageBefore = await readOptional(packageJson);
+  if (packageBefore !== null) {
+    const packageAfter = packageWithSyncHooks(packageBefore);
+    if (packageAfter !== null) {
+      const path = relative(root, packageJson);
+      changes.push({
+        absolute: packageJson,
+        path,
+        before: packageBefore,
+        after: packageAfter,
+        diff: diff(path, packageBefore, packageAfter),
+      });
     }
   }
   const writes = [

--- a/packages/vendo/src/cli/sync.test.ts
+++ b/packages/vendo/src/cli/sync.test.ts
@@ -140,15 +140,15 @@ describe("vendo sync", () => {
     })).resolves.toBe(0);
 
     expect(fetchImpl).toHaveBeenCalledOnce();
-    expect(fetchImpl).toHaveBeenCalledWith("https://cloud.test/api/v1/sync/report", {
+    expect(fetchImpl).toHaveBeenCalledWith("https://cloud.test/api/v1/sync/report", expect.objectContaining({
       method: "POST",
-      headers: {
+      headers: expect.objectContaining({
         accept: "application/json",
         authorization: "Bearer vnd_test",
         "content-type": "application/json",
-      },
+      }),
       body: expect.any(String),
-    });
+    }));
     const body = JSON.parse((fetchImpl.mock.calls[0]?.[1] as RequestInit).body as string) as Record<string, unknown>;
     expect(body).toEqual({ report: report(), at: expect.any(String) });
   });

--- a/packages/vendo/src/cli/sync.test.ts
+++ b/packages/vendo/src/cli/sync.test.ts
@@ -1,18 +1,124 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { runSync } from "./sync.js";
 
-const report = (breaking: Array<{ tool: string; change: "removed" }> = []) => ({
-  tools: { added: [], removed: [], changed: [] },
+const report = (
+  breaking: Array<{ tool: string; change: "removed" }> = [],
+  changed: string[] = [],
+) => ({
+  tools: { added: [], removed: [], changed },
   breaking,
   pins: { captured: [], drifted: [] },
   warnings: [],
 });
 
+function captureOutput(): { output: { log(message: string): void; error(message: string): void }; logs: string[]; errors: string[] } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return {
+    output: { log: (message) => logs.push(message), error: (message) => errors.push(message) },
+    logs,
+    errors,
+  };
+}
+
 describe("vendo sync", () => {
   it("fails soft by default and exits two for strict breaking changes", async () => {
     const output = { log() {}, error() {} };
+    const fetchImpl = async () => new Response(JSON.stringify({
+      impact: [{ tool: "host_x", apps: [], automations: [], grants: 0 }],
+    }), { status: 200 });
     expect(await runSync({ targetDir: ".", output, sync: async () => { throw new Error("scan"); } })).toBe(0);
-    expect(await runSync({ targetDir: ".", strict: true, output, sync: async () => report([{ tool: "host_x", change: "removed" }]) })).toBe(2);
-    expect(await runSync({ targetDir: ".", output, sync: async () => report([{ tool: "host_x", change: "removed" }]) })).toBe(0);
+    expect(await runSync({ targetDir: ".", strict: true, output, fetchImpl, sync: async () => report([{ tool: "host_x", change: "removed" }]) })).toBe(2);
+    expect(await runSync({ targetDir: ".", output, fetchImpl, sync: async () => report([{ tool: "host_x", change: "removed" }]) })).toBe(0);
+  });
+
+  it("queries changed and breaking tools and prints per-tool impact", async () => {
+    const messages = captureOutput();
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      impact: [
+        {
+          tool: "host_x",
+          apps: [{ id: "app_x", title: "X" }],
+          automations: [{ id: "app_a", title: "A" }, { id: "app_b", title: "B" }],
+          grants: 3,
+        },
+        { tool: "host_y", apps: [], automations: [], grants: 0 },
+      ],
+    }), { status: 200, headers: { "content-type": "application/json" } })) as typeof fetch;
+
+    await runSync({
+      targetDir: ".",
+      output: messages.output,
+      url: "http://dev.test/api/vendo/",
+      fetchImpl,
+      sync: async () => report([{ tool: "host_x", change: "removed" }], ["host_x", "host_y"]),
+    });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(fetchImpl).toHaveBeenCalledWith("http://dev.test/api/vendo/sync/impact", {
+      method: "POST",
+      headers: { accept: "application/json", "content-type": "application/json" },
+      body: JSON.stringify({ tools: ["host_x", "host_y"] }),
+    });
+    expect(messages.logs).toContain("impact: host_x breaks 2 automations, 1 app, 3 grants");
+    expect(messages.logs).toContain("impact: host_y no saved references");
+  });
+
+  it("falls back when impact is unreachable and keeps strict exit two", async () => {
+    const messages = captureOutput();
+    const fetchImpl = vi.fn(async () => { throw new Error("offline"); }) as typeof fetch;
+
+    const exit = await runSync({
+      targetDir: ".",
+      strict: true,
+      output: messages.output,
+      url: "http://offline.test/api/vendo",
+      fetchImpl,
+      sync: async () => report([{ tool: "host_x", change: "removed" }]),
+    });
+
+    expect(exit).toBe(2);
+    expect(messages.logs).toContain("impact unknown — dev server not reachable at http://offline.test/api/vendo");
+  });
+
+  it("returns strict exit three when a breaking tool has nonzero impact", async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      impact: [{ tool: "host_x", apps: [], automations: [{ id: "app_a", title: "A" }], grants: 0 }],
+    }), { status: 200 })) as typeof fetch;
+
+    await expect(runSync({
+      targetDir: ".",
+      strict: true,
+      output: captureOutput().output,
+      fetchImpl,
+      sync: async () => report([{ tool: "host_x", change: "removed" }]),
+    })).resolves.toBe(3);
+  });
+
+  it("keeps strict exit two when breaking tools have zero impact", async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      impact: [{ tool: "host_x", apps: [], automations: [], grants: 0 }],
+    }), { status: 200 })) as typeof fetch;
+
+    await expect(runSync({
+      targetDir: ".",
+      strict: true,
+      output: captureOutput().output,
+      fetchImpl,
+      sync: async () => report([{ tool: "host_x", change: "removed" }]),
+    })).resolves.toBe(2);
+  });
+
+  it("does not query impact when there are no changed or breaking tools", async () => {
+    const fetchImpl = vi.fn() as typeof fetch;
+
+    await expect(runSync({
+      targetDir: ".",
+      strict: true,
+      output: captureOutput().output,
+      fetchImpl,
+      sync: async () => report(),
+    })).resolves.toBe(0);
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 });

--- a/packages/vendo/src/cli/sync.test.ts
+++ b/packages/vendo/src/cli/sync.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { runSync } from "./sync.js";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 const report = (
   breaking: Array<{ tool: string; change: "removed" }> = [],
@@ -120,5 +124,77 @@ describe("vendo sync", () => {
       sync: async () => report(),
     })).resolves.toBe(0);
     expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("pushes --report to the Cloud API with key auth", async () => {
+    const fetchImpl = vi.fn(async () => new Response("{}", { status: 200 })) as typeof fetch;
+
+    await expect(runSync({
+      targetDir: ".",
+      report: true,
+      apiKey: "vnd_test",
+      apiUrl: "https://cloud.test",
+      fetchImpl,
+      output: captureOutput().output,
+      sync: async () => report(),
+    })).resolves.toBe(0);
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(fetchImpl).toHaveBeenCalledWith("https://cloud.test/api/v1/sync/report", {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        authorization: "Bearer vnd_test",
+        "content-type": "application/json",
+      },
+      body: expect.any(String),
+    });
+    const body = JSON.parse((fetchImpl.mock.calls[0]?.[1] as RequestInit).body as string) as Record<string, unknown>;
+    expect(body).toEqual({ report: report(), at: expect.any(String) });
+  });
+
+  it("warns for --report without a key and preserves the strict exit code", async () => {
+    vi.stubEnv("VENDO_API_KEY", "");
+    const messages = captureOutput();
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      impact: [{ tool: "host_x", apps: [], automations: [], grants: 0 }],
+    }), { status: 200 })) as typeof fetch;
+
+    const exit = await runSync({
+      targetDir: ".",
+      strict: true,
+      report: true,
+      output: messages.output,
+      fetchImpl,
+      sync: async () => report([{ tool: "host_x", change: "removed" }]),
+    });
+
+    expect(exit).toBe(2);
+    expect(messages.errors).toContain("--report requires VENDO_API_KEY or --key");
+  });
+
+  it("warns when report push rejects and preserves blast-radius exit three", async () => {
+    const messages = captureOutput();
+    const push = vi.fn(async () => { throw new Error("cloud offline"); });
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      impact: [{ tool: "host_x", apps: [{ id: "app_x", title: "X" }], automations: [], grants: 0 }],
+    }), { status: 200 })) as typeof fetch;
+
+    const exit = await runSync({
+      targetDir: ".",
+      strict: true,
+      report: true,
+      apiKey: "vnd_test",
+      output: messages.output,
+      fetchImpl,
+      push,
+      sync: async () => report([{ tool: "host_x", change: "removed" }]),
+    });
+
+    expect(exit).toBe(3);
+    expect(push).toHaveBeenCalledWith({ report: report([{ tool: "host_x", change: "removed" }]), impact: [
+      { tool: "host_x", apps: [{ id: "app_x", title: "X" }], automations: [], grants: 0 },
+    ], at: expect.any(String) });
+    expect(messages.errors).toContain("warning: failed to push sync report: cloud offline");
   });
 });

--- a/packages/vendo/src/cli/sync.ts
+++ b/packages/vendo/src/cli/sync.ts
@@ -1,12 +1,59 @@
 import { join, resolve } from "node:path";
 import { vendoSync, type SyncReportWithWarnings } from "@vendoai/actions";
+import type { ToolImpact } from "../sync-impact.js";
 import { consoleOutput, type Output } from "./shared.js";
+
+export interface SyncReportPayload {
+  report: SyncReportWithWarnings;
+  impact?: ToolImpact[];
+  at: string;
+}
 
 export interface SyncOptions {
   targetDir: string;
   strict?: boolean;
   output?: Output;
   sync?: typeof vendoSync;
+  url?: string;
+  fetchImpl?: typeof fetch;
+  report?: boolean;
+  push?: (report: SyncReportPayload) => Promise<void>;
+}
+
+function impactResponse(value: unknown): ToolImpact[] {
+  if (typeof value !== "object" || value === null || !Array.isArray((value as { impact?: unknown }).impact)) {
+    throw new Error("invalid sync impact response");
+  }
+  const impact = (value as { impact: unknown[] }).impact;
+  for (const entry of impact) {
+    if (typeof entry !== "object" || entry === null) throw new Error("invalid sync impact response");
+    const candidate = entry as Partial<ToolImpact>;
+    if (typeof candidate.tool !== "string" || !Array.isArray(candidate.apps)
+      || !Array.isArray(candidate.automations) || typeof candidate.grants !== "number") {
+      throw new Error("invalid sync impact response");
+    }
+  }
+  return impact as ToolImpact[];
+}
+
+function printImpact(output: Output, impact: ToolImpact[]): void {
+  for (const entry of impact) {
+    const categories = [
+      [entry.automations.length, "automation"],
+      [entry.apps.length, "app"],
+      [entry.grants, "grant"],
+    ] as const;
+    const references = categories
+      .filter(([count]) => count > 0)
+      .map(([count, label]) => `${count} ${label}${count === 1 ? "" : "s"}`);
+    output.log(references.length === 0
+      ? `impact: ${entry.tool} no saved references`
+      : `impact: ${entry.tool} breaks ${references.join(", ")}`);
+  }
+}
+
+function nonzero(entry: ToolImpact): boolean {
+  return entry.apps.length > 0 || entry.automations.length > 0 || entry.grants > 0;
 }
 
 /** 04-actions §1 / 09-vendo §5 — fail-soft extraction, strict CI gate. */
@@ -17,14 +64,38 @@ export async function runSync(options: SyncOptions): Promise<number> {
     const report: SyncReportWithWarnings = await (options.sync ?? vendoSync)({
       root,
       out: join(root, ".vendo"),
-      strict: options.strict === true,
+      // The CLI needs the report to compute exit 2 vs 3; it applies strictness below.
+      strict: false,
     });
     for (const warning of report.warnings) output.error(`warning: ${warning}`);
     output.log(`tools: +${report.tools.added.length} -${report.tools.removed.length} ~${report.tools.changed.length}`);
     output.log(`pins: ${report.pins.captured.length} captured, ${report.pins.drifted.length} drifted`);
+
+    const tools = [...new Set([
+      ...report.breaking.map((breaking) => breaking.tool),
+      ...report.tools.changed,
+    ])];
+    let impact: ToolImpact[] | undefined;
+    if (tools.length > 0) {
+      const impactUrl = (options.url ?? process.env.VENDO_URL ?? "http://localhost:3000/api/vendo").replace(/\/+$/, "");
+      try {
+        const response = await (options.fetchImpl ?? fetch)(`${impactUrl}/sync/impact`, {
+          method: "POST",
+          headers: { accept: "application/json", "content-type": "application/json" },
+          body: JSON.stringify({ tools }),
+        });
+        if (!response.ok) throw new Error(`sync impact returned ${response.status}`);
+        impact = impactResponse(await response.json());
+        printImpact(output, impact);
+      } catch {
+        output.log(`impact unknown — dev server not reachable at ${impactUrl}`);
+      }
+    }
+
     if (options.strict === true && report.breaking.length > 0) {
       for (const breaking of report.breaking) output.error(`breaking: ${breaking.tool} ${breaking.change}`);
-      return 2;
+      const breakingTools = new Set(report.breaking.map((breaking) => breaking.tool));
+      return impact?.some((entry) => breakingTools.has(entry.tool) && nonzero(entry)) === true ? 3 : 2;
     }
     return 0;
   } catch (error) {

--- a/packages/vendo/src/cli/sync.ts
+++ b/packages/vendo/src/cli/sync.ts
@@ -1,6 +1,7 @@
 import { join, resolve } from "node:path";
 import { vendoSync, type SyncReportWithWarnings } from "@vendoai/actions";
 import type { ToolImpact } from "../sync-impact.js";
+import { pushSyncReport } from "./cloud/services.js";
 import { consoleOutput, type Output } from "./shared.js";
 
 export interface SyncReportPayload {
@@ -18,6 +19,8 @@ export interface SyncOptions {
   fetchImpl?: typeof fetch;
   report?: boolean;
   push?: (report: SyncReportPayload) => Promise<void>;
+  apiKey?: string;
+  apiUrl?: string;
 }
 
 function impactResponse(value: unknown): ToolImpact[] {
@@ -89,6 +92,29 @@ export async function runSync(options: SyncOptions): Promise<number> {
         printImpact(output, impact);
       } catch {
         output.log(`impact unknown — dev server not reachable at ${impactUrl}`);
+      }
+    }
+
+    if (options.report === true) {
+      const apiKey = options.apiKey ?? process.env.VENDO_API_KEY;
+      if (!apiKey) {
+        output.error("--report requires VENDO_API_KEY or --key");
+      } else {
+        const payload: SyncReportPayload = {
+          report,
+          ...(impact === undefined ? {} : { impact }),
+          at: new Date().toISOString(),
+        };
+        try {
+          if (options.push !== undefined) await options.push(payload);
+          else await pushSyncReport(payload, {
+            apiKey,
+            ...(options.apiUrl === undefined ? {} : { apiUrl: options.apiUrl }),
+            ...(options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl }),
+          });
+        } catch (error) {
+          output.error(`warning: failed to push sync report: ${error instanceof Error ? error.message : "unknown error"}`);
+        }
       }
     }
 

--- a/packages/vendo/src/server.test.ts
+++ b/packages/vendo/src/server.test.ts
@@ -225,6 +225,37 @@ describe("09 §3 public wire", () => {
     });
   });
 
+  it("serves sync impact on dev servers and blocks it in production", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const { vendo } = await setup();
+
+    const response = await vendo.handler(request("POST", "/sync/impact", { tools: ["host_get_widgets"] }));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      impact: [{ tool: "host_get_widgets", apps: [], automations: [], grants: 0 }],
+    });
+
+    vi.stubEnv("NODE_ENV", "production");
+    const blocked = await vendo.handler(request("POST", "/sync/impact", { tools: ["host_get_widgets"] }));
+    expect(blocked.status).toBe(403);
+    expect(await blocked.json()).toEqual({
+      error: { code: "blocked", message: "sync impact is only available on a dev server" },
+    });
+  });
+
+  it("validates sync impact tool arrays", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const { vendo } = await setup();
+
+    const nonStrings = await vendo.handler(request("POST", "/sync/impact", { tools: ["host_ok", 7] }));
+    expect(nonStrings.status).toBe(400);
+
+    const tooMany = await vendo.handler(request("POST", "/sync/impact", {
+      tools: Array.from({ length: 201 }, (_, index) => `host_${index}`),
+    }));
+    expect(tooMany.status).toBe(400);
+  });
+
   it("adapts the same fetch handler to Next route exports", async () => {
     const { vendo } = await setup();
     const next = nextVendoHandler(vendo);

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -31,6 +31,7 @@ import {
   capabilitySurfaceSnapshot,
   createCapabilityMissCapture,
 } from "./capability-misses.js";
+import { computeImpact } from "./sync-impact.js";
 
 const VERSION = "0.3.0";
 const BASE_PATH = "/api/vendo";
@@ -467,6 +468,17 @@ function createWireHandler(deps: {
           return json({ error: { code: "blocked", message: "invalid tick credential" } }, 401);
         }
         return json({ runIds: await deps.automations.tick() });
+      }
+      if (request.method === "POST" && path === "/sync/impact") {
+        if (process.env.NODE_ENV === "production") {
+          throw new VendoError("blocked", "sync impact is only available on a dev server");
+        }
+        const body = await requestJson(request);
+        const tools = body["tools"];
+        if (!Array.isArray(tools) || tools.length > 200 || tools.some((tool) => typeof tool !== "string")) {
+          throw new VendoError("validation", "tools must be an array of at most 200 strings");
+        }
+        return json({ impact: await computeImpact(deps.store, tools) });
       }
       if (path.startsWith("/proxy/")) {
         const proxyPath = path.slice("/proxy".length);

--- a/packages/vendo/src/sync-impact.test.ts
+++ b/packages/vendo/src/sync-impact.test.ts
@@ -1,0 +1,101 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  VENDO_APP_FORMAT,
+  VENDO_TREE_FORMAT,
+  type AppDocument,
+  type PermissionGrant,
+  type Principal,
+} from "@vendoai/core";
+import { appStore, createStore, grantStore, type VendoStore } from "@vendoai/store";
+import { afterEach, describe, expect, it } from "vitest";
+import { computeImpact } from "./sync-impact.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const principal: Principal = { kind: "user", subject: "user_sync_impact" };
+
+function plainApp(id: string, name: string, tool: string): AppDocument {
+  return {
+    format: VENDO_APP_FORMAT,
+    id,
+    name,
+    ui: "tree",
+    tree: {
+      formatVersion: VENDO_TREE_FORMAT,
+      root: "root",
+      nodes: [{ id: "root", component: "Text", props: { text: name } }],
+      queries: [{ path: "/widgets", tool }],
+    },
+  };
+}
+
+function automation(id: string, name: string, tool: string): AppDocument {
+  return {
+    format: VENDO_APP_FORMAT,
+    id,
+    name,
+    trigger: {
+      on: { kind: "schedule", every: "1h" },
+      run: { kind: "steps", steps: [{ id: "load", tool }] },
+    },
+  };
+}
+
+function grant(
+  id: string,
+  overrides: Partial<PermissionGrant> = {},
+): PermissionGrant {
+  return {
+    id,
+    subject: principal.subject,
+    tool: "host_get_widgets",
+    descriptorHash: "sha256:widgets",
+    scope: { kind: "tool" },
+    duration: "standing",
+    source: "chat",
+    grantedAt: "2026-07-14T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+async function setup(): Promise<VendoStore> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-sync-impact-"));
+  const store = createStore({ dataDir });
+  await store.ensureSchema();
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return store;
+}
+
+describe("computeImpact", () => {
+  it("maps tools to enabled apps, automations, and active grants across subjects", async () => {
+    const store = await setup();
+    const apps = appStore(store);
+    const grants = grantStore(store);
+
+    await apps.put(principal, plainApp("app_widgets", "Widget viewer", "host_get_widgets"));
+    await apps.put(principal, automation("app_widget_refresh", "Widget refresh", "host_get_widgets"));
+    await apps.put(principal, plainApp("app_unrelated", "Invoice viewer", "host_get_invoices"));
+    await grants.create(principal, grant("grt_active"));
+    await grants.create(principal, grant("grt_revoked", { revokedAt: "2026-07-14T12:30:00.000Z" }));
+    await grants.create(principal, grant("grt_expired", { expiresAt: "2020-01-01T00:00:00.000Z" }));
+
+    await expect(computeImpact(store, ["host_get_widgets", "host_absent"])).resolves.toEqual([
+      {
+        tool: "host_get_widgets",
+        apps: [{ id: "app_widgets", title: "Widget viewer" }],
+        automations: [{ id: "app_widget_refresh", title: "Widget refresh" }],
+        grants: 1,
+      },
+      { tool: "host_absent", apps: [], automations: [], grants: 0 },
+    ]);
+  });
+});

--- a/packages/vendo/src/sync-impact.ts
+++ b/packages/vendo/src/sync-impact.ts
@@ -1,0 +1,87 @@
+import { VENDO_TREE_FORMAT, type AppDocument, type PermissionGrant, type VendoRecord } from "@vendoai/core";
+import type { VendoStore } from "@vendoai/store";
+
+export interface ToolImpact {
+  tool: string;
+  apps: { id: string; title: string }[];
+  automations: { id: string; title: string }[];
+  grants: number;
+}
+
+interface StoredApp {
+  enabled: boolean;
+  doc: AppDocument;
+}
+
+async function allRecords(store: VendoStore, collection: string): Promise<VendoRecord[]> {
+  const records: VendoRecord[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await store.records(collection).list({ limit: 1_000, cursor });
+    records.push(...page.records);
+    cursor = page.cursor;
+  } while (cursor !== undefined);
+  return records;
+}
+
+function collectActions(value: unknown, tools: Set<string>): void {
+  if (Array.isArray(value)) {
+    for (const item of value) collectActions(item, tools);
+    return;
+  }
+  if (typeof value !== "object" || value === null) return;
+  const record = value as Record<string, unknown>;
+  for (const key of ["action", "$action"] as const) {
+    const reference = record[key];
+    if (typeof reference === "string" && !reference.startsWith("fn:")) tools.add(reference);
+  }
+  for (const nested of Object.values(record)) collectActions(nested, tools);
+}
+
+function referencedTools(doc: AppDocument): Set<string> {
+  const tools = new Set<string>();
+  if (doc.tree?.formatVersion === VENDO_TREE_FORMAT) {
+    const tree = doc.tree as {
+      queries?: Array<{ tool?: unknown }>;
+      nodes?: Array<{ props?: unknown }>;
+    };
+    for (const query of tree.queries ?? []) {
+      if (typeof query.tool === "string" && !query.tool.startsWith("fn:")) tools.add(query.tool);
+    }
+    for (const node of tree.nodes ?? []) collectActions(node.props, tools);
+  }
+  if (doc.trigger?.run.kind === "steps") {
+    for (const step of doc.trigger.run.steps) {
+      if (!step.tool.startsWith("fn:")) tools.add(step.tool);
+    }
+  }
+  return tools;
+}
+
+function activeGrant(grant: PermissionGrant, now: string): boolean {
+  return grant.revokedAt === undefined && (grant.expiresAt === undefined || grant.expiresAt > now);
+}
+
+export async function computeImpact(store: VendoStore, tools: string[]): Promise<ToolImpact[]> {
+  const [appRecords, grantRecords] = await Promise.all([
+    allRecords(store, "vendo_apps"),
+    allRecords(store, "vendo_grants"),
+  ]);
+  const apps = appRecords.map((record) => record.data as unknown as StoredApp).filter((app) => app.enabled);
+  const now = new Date().toISOString();
+  const grants = grantRecords
+    .map((record) => record.data as unknown as PermissionGrant)
+    .filter((grant) => activeGrant(grant, now));
+
+  return tools.map((tool) => {
+    const impact: ToolImpact = { tool, apps: [], automations: [], grants: 0 };
+    for (const app of apps) {
+      if (!referencedTools(app.doc).has(tool)) continue;
+      const reference = { id: app.doc.id, title: app.doc.name };
+      if (app.doc.trigger === undefined) impact.apps.push(reference);
+      else impact.automations.push(reference);
+    }
+    impact.grants = grants.filter((grant) => grant.tool === tool).length;
+    return impact;
+  });
+}


### PR DESCRIPTION
## Summary

- Add the dev-only `POST /sync/impact` wire endpoint, computing impact across enabled apps, enabled automations, and active standing grants.
- Teach `vendo sync` to print per-tool blast radius and make strict mode return exit 2 for unconsumed breaking changes or exit 3 when a breaking tool has live impact.
- Add fail-soft `--report` Cloud delivery plus idempotent `predev` and `prebuild` hooks during `vendo init`.
- Cover the complete impact flow through the composed wire and add a bounded retry for transient fixture login resets during parallel Turbo integration runs.

The `--report` client sends to Console `POST /api/v1/sync/report`; that server endpoint belongs to the separate Console track and is intentionally outside this PR.

## Verification

- `pnpm build && pnpm test && pnpm typecheck && pnpm lint`
- Build: 18/18 tasks green
- Tests: 41/41 tasks green, including 94 `packages/vendo` tests and 12 composed-wire integration tests
- Typecheck: 34/34 tasks green
- Lint: dependency guard plus 2/2 tasks green

## Live demo

Setup: Maple dev server running locally; seeded an enabled automation and approved standing grant through the public wire; temporarily made `accountType` required in the `GET /api/accounts` OpenAPI contract.

```console
$ pnpm vendo sync --strict --url http://127.0.0.1:43261/api/vendo
tools: +0 -0 ~1
pins: 0 captured, 0 drifted
breaking: host_listAccounts input-narrowed
impact: host_listAccounts breaks 1 automation, 1 grant
$ echo $?
3
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dev-only `POST /sync/impact` endpoint and updates `vendo sync` to show per-tool blast radius across saved apps, automations, and standing grants, with strict exit codes and optional Cloud reporting; `vendo init` now scaffolds `predev`/`prebuild` hooks. Connects to ENG-261.

- **New Features**
  - Dev wire: `POST /sync/impact` computes impact; blocked in production; validates up to 200 tool strings.
  - CLI: `vendo sync` queries impact for changed and breaking tools; prints per-tool impact or “no saved references”; strict exits 2 for breaking changes, 3 when any breaking tool has nonzero impact; graceful “impact unknown” when the dev server is unreachable (`--url` or `VENDO_URL`).
  - Reporting: `--report` pushes `{report, impact?, at}` to Cloud (`POST /api/v1/sync/report`) using `VENDO_API_KEY` or `--key` (supports `--api-url`); warns on missing key or push errors.
  - Init: `vendo init` proposes `package.json` hooks (`predev: "vendo sync"`, `prebuild: "vendo sync --strict"`); prepends to existing hooks, preserves formatting, idempotent, and only writes if approved.
  - Tests: adds composed-wire impact E2E, server validation and dev-gating, CLI coverage for impact printing, exit codes, and Cloud reporting; retries transient fixture logins.

- **Migration**
  - In CI, use `vendo sync --strict`. Exit 2 = breaking changes; exit 3 = breaking changes with live impact.
  - For impact, point at a dev server with `--url` or `VENDO_URL`; otherwise you’ll see “impact unknown.”
  - To push results, run `--report` with `VENDO_API_KEY` (or `--key`); optional `--api-url` for non-default Cloud.
  - After `vendo init`, review and approve the `package.json` hook changes if desired.

<sup>Written for commit e3fedf3fcad0ee9d7b3b29383dd79bd685ee2027. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

