### PR TITLE
feat(apps): custom-fields data plane — records/files access, proxy data routes, agent data tools (ENG-289 M1)

### DIFF
--- a/docs/superpowers/plans/2026-07-14-eng-289-custom-fields-plan.md
+++ b/docs/superpowers/plans/2026-07-14-eng-289-custom-fields-plan.md
@@ -1,0 +1,42 @@
+# ENG-289 Child B: Custom fields substrate — milestone plan
+
+Date: 2026-07-14. Owner: child-B orchestrator (this session). Spec: `docs/superpowers/specs/2026-07-14-apps-block-design.md` (locked). Issue: ENG-289.
+
+## Audit baseline (verified in code)
+
+- `packages/apps/src/proxy.ts` serves only `POST /tools/<name>` and `GET|PUT /state`.
+- `packages/apps/src/app-data.ts` has `getState`/`setState`/`clear` only; `resolveAppStorage` already maps declarations to `app:<appId>:<name>` collections but nothing calls it outside `clear`.
+- `packages/apps/src/agent-tools.ts` exposes create/edit/open only.
+- Core `RecordStore.list({ refs })` filtering exists and is conformance-tested; `StorageDecl.refs` values are validated against `^host\.` and then never consumed.
+- Rung-1 tree queries (`{ tool, input, path }`) resolve **sequentially, server-side** in `open.ts` — this is the join seam. UI actions route through `AppsRuntime.call(appId, ref, ...)` — same interception point.
+
+## Join query encoding (deferred design item — needs parent sign-off before M2)
+
+**Recommendation: reserved `vendo.data.*` refs resolved inside the apps runtime. No core/tree wire-format change.**
+
+- Tree queries and actions may name `vendo.data.list | get | put | delete | join`. Core tree validation already accepts these (any non-empty tool string); the apps runtime intercepts the `vendo.data.` prefix in `open()`/`call()`/`callQuery()` before the guard-bound host registry — exactly how `fn:` is special-cased today. Scoped to the calling user's own app instance (appId + subject from ctx), like `/state`; no guard prompt, matching the one-security-rule (app data belongs to the user's copy).
+- `vendo.data.list` input: `{ collection, refs?, limit?, cursor? }` — collection must be declared in `storage`.
+- `vendo.data.join` input: `{ source: <JSON pointer into tree.data>, collection, on?: { host?: string = "id", ref: string }, into?: string = "vendo" }`. Queries resolve in document order, so a join query placed after a host-tool query reads its rows at `source`, fetches app records via `RecordStore.list({ refs: { [on.ref]: String(row[on.host]) } })`, and merges each matched record's `data` under `row[into]`. Result written at the join query's own `path`.
+- **Host-entity key convention**: the declaration's ref key IS the join key. `storage.fields.refs = { invoice_id: "host.invoice" }` ⇒ records carry `refs.invoice_id = <host invoice id, stringified>`; SQL hosts join via `refs @> jsonb_build_object('invoice_id', ...)` per 02 §2; tree joins name the same key in `on.ref`. Host rows are keyed by `id` by default, overridable via `on.host`.
+- Rejected alternative: an optional `join` clause on `TreeQuery` in core — touches the frozen `vendo-genui/v1` wire format and the renderer for zero added power.
+
+## Milestones (each a PR, gates green before each)
+
+1. **M1 — Data plane** (no dependency on join sign-off; starts immediately)
+   - Extend `AppDataAccess`: records + files access, gated on the app's `storage` declarations, reserved-name and size caps mirroring `/state` (256 KB records; pick a blob cap and note it).
+   - Proxy routes for machines: `/data/<collection>` + `/data/<collection>/<id>` (list/get/put/delete, refs filters), `/files/<collection>[/<key>]`.
+   - Agent data tools in `agent-tools.ts`: `vendo_apps_data_list` (read), `vendo_apps_data_put`, `vendo_apps_data_delete` (write) — ownership-checked, declaration-gated.
+   - Enforce that written `refs` keys match the collection's declaration and values are non-empty strings.
+2. **M2 — Refs join + rung-1 tree binding** (gated on parent sign-off of the encoding above)
+   - Intercept `vendo.data.*` in open/call/callQuery; implement list/get/put/delete/join semantics; batch the join's record lookups.
+   - Tests: rung-1 tree with a host-tool query + join query renders joined rows; reload (fresh `open()`) reproduces them.
+3. **M3 — Org-install shapes + cloud-required + shared-write policy shape**
+   - `OrgInstall` + shared-instance types and zod schemas, runtime entry throwing `cloud-required` exactly like `cloud.ts` share/publish; `SharedWritePolicy` host-policy shape for writes to shared fields; additive contract-doc note. Records the interface Cloud implements (standing Cloud-alignment agenda).
+4. **M4 — Cadence demo + mandatory GIF**
+   - Real browser: Cadence user adds a "priority" field to invoices via the agent, tags invoices, generated UI shows fields joined onto the real invoice list, survives reload. GIF captured and attached to the PR. Docs synced.
+
+## Coordination
+
+- All coding delegated to codex sol in this worktree; Opus 4.8 only if sol is usage-blocked.
+- packages/apps merge conflicts with children A (remix/in-client) and C (venues) brokered by the parent; my files of concern: proxy.ts, app-data.ts, agent-tools.ts, call.ts, open.ts, runtime.ts, cloud.ts.
+- Anything cut is filed as a Linear issue, never silently dropped.

--- a/packages/apps/src/agent-tools.test.ts
+++ b/packages/apps/src/agent-tools.test.ts
@@ -51,6 +51,9 @@ describe("apps agent tools", () => {
       "vendo_apps_create",
       "vendo_apps_edit",
       "vendo_apps_open",
+      "vendo_apps_data_list",
+      "vendo_apps_data_put",
+      "vendo_apps_data_delete",
     ]);
     for (const descriptor of descriptors) {
       expect(TOOL_NAME_PATTERN.test(descriptor.name)).toBe(true);
@@ -64,7 +67,9 @@ describe("apps agent tools", () => {
     }
     // Creating a document is a rung-1-only, jailed UI operation: it cannot
     // reach host tools, a server machine, or the network.
-    expect(descriptors.map((descriptor) => descriptor.risk)).toEqual(["read", "write", "read"]);
+    expect(descriptors.map((descriptor) => descriptor.risk)).toEqual([
+      "read", "write", "read", "read", "write", "write",
+    ]);
   });
 
   it("classifies only provable tree edits as read-class", async () => {
@@ -236,6 +241,60 @@ describe("apps agent tools", () => {
     }, ctx)).resolves.toMatchObject({
       status: "error",
       error: { code: "validation" },
+    });
+  });
+
+  it("ownership-checks and round-trips declared data collections", async () => {
+    const store = memoryStore();
+    const runtime = createApps({
+      store,
+      guard: guardFixture(),
+      tools: hostTools,
+      catalog: [],
+      model: scriptedLanguageModel(generated),
+    });
+    const created = await runtime.create({ prompt: "Data tools" }, ctx);
+    await seedAppRow(store, {
+      ...created,
+      storage: { notes: { about: "Invoice notes", refs: { invoice_id: "host.invoice" } } },
+    }, ctx.principal.subject);
+    const registry = runtime.agentTools();
+
+    await expect(registry.execute({
+      id: "call_data_put",
+      tool: "vendo_apps_data_put",
+      args: {
+        appId: created.id,
+        collection: "notes",
+        id: "note_1",
+        data: { body: "hello" },
+        refs: { invoice_id: "inv_1" },
+      },
+    }, ctx)).resolves.toMatchObject({ status: "ok", output: { id: "note_1" } });
+    await expect(registry.execute({
+      id: "call_data_list",
+      tool: "vendo_apps_data_list",
+      args: { appId: created.id, collection: "notes", refs: { invoice_id: "inv_1" } },
+    }, ctx)).resolves.toMatchObject({
+      status: "ok",
+      output: { records: [{ id: "note_1", data: { body: "hello" } }] },
+    });
+    await expect(registry.execute({
+      id: "call_data_delete",
+      tool: "vendo_apps_data_delete",
+      args: { appId: created.id, collection: "notes", id: "note_1" },
+    }, ctx)).resolves.toEqual({ status: "ok", output: { status: "ok" } });
+
+    await expect(registry.execute({
+      id: "call_intruder_data_list",
+      tool: "vendo_apps_data_list",
+      args: { appId: created.id, collection: "notes" },
+    }, {
+      ...ctx,
+      principal: { kind: "user", subject: "user_intruder" },
+    })).resolves.toEqual({
+      status: "error",
+      error: { code: "not-found", message: `app not found: ${created.id}` },
     });
   });
 });

--- a/packages/apps/src/agent-tools.ts
+++ b/packages/apps/src/agent-tools.ts
@@ -1,11 +1,15 @@
 import {
   VendoError,
+  type AppDocument,
+  type AppId,
   type Json,
+  type RecordQuery,
   type RunContext,
   type ToolDescriptor,
   type ToolOutcome,
   type ToolRegistry,
 } from "@vendoai/core";
+import type { AppDataAccess } from "./app-data.js";
 import type { AppsRuntime } from "./runtime.js";
 
 const DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema";
@@ -53,17 +57,70 @@ const descriptors: ToolDescriptor[] = [
     },
     risk: "read",
   },
+  {
+    name: "vendo_apps_data_list",
+    description: "List records from a declared Vendo app data collection.",
+    inputSchema: {
+      $schema: DRAFT_2020_12,
+      type: "object",
+      properties: {
+        appId: { type: "string", minLength: 1 },
+        collection: { type: "string", minLength: 1 },
+        refs: { type: "object", additionalProperties: { type: "string", minLength: 1 } },
+        limit: { type: "integer", minimum: 1 },
+        cursor: { type: "string", minLength: 1 },
+      },
+      required: ["appId", "collection"],
+      additionalProperties: false,
+    },
+    risk: "read",
+  },
+  {
+    name: "vendo_apps_data_put",
+    description: "Create or replace a record in a declared Vendo app data collection.",
+    inputSchema: {
+      $schema: DRAFT_2020_12,
+      type: "object",
+      properties: {
+        appId: { type: "string", minLength: 1 },
+        collection: { type: "string", minLength: 1 },
+        id: { type: "string", minLength: 1 },
+        data: {},
+        refs: { type: "object", additionalProperties: { type: "string", minLength: 1 } },
+      },
+      required: ["appId", "collection", "id", "data"],
+      additionalProperties: false,
+    },
+    risk: "write",
+  },
+  {
+    name: "vendo_apps_data_delete",
+    description: "Delete a record from a declared Vendo app data collection.",
+    inputSchema: {
+      $schema: DRAFT_2020_12,
+      type: "object",
+      properties: {
+        appId: { type: "string", minLength: 1 },
+        collection: { type: "string", minLength: 1 },
+        id: { type: "string", minLength: 1 },
+      },
+      required: ["appId", "collection", "id"],
+      additionalProperties: false,
+    },
+    risk: "write",
+  },
 ];
 
 const input = (
   value: Json,
   required: string[],
+  optional: string[] = [],
 ): Record<string, Json> => {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new VendoError("validation", "tool input must be an object");
   }
   const record = value as Record<string, Json>;
-  const allowed = new Set(required);
+  const allowed = new Set([...required, ...optional]);
   const unexpected = Object.keys(record).find((key) => !allowed.has(key));
   if (unexpected !== undefined) throw new VendoError("validation", `unexpected input property: ${unexpected}`);
   for (const key of required) {
@@ -74,6 +131,34 @@ const input = (
   return record;
 };
 
+const optionalRefs = (value: Json | undefined): Record<string, string> | undefined => {
+  if (value === undefined) return undefined;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new VendoError("validation", "refs must be an object");
+  }
+  const refs: Record<string, string> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (key === "" || typeof item !== "string" || item.trim() === "") {
+      throw new VendoError("validation", "refs must have non-empty string keys and values");
+    }
+    refs[key] = item;
+  }
+  return refs;
+};
+
+const optionalLimit = (value: Json | undefined): number | undefined => {
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 1) {
+    throw new VendoError("validation", "limit must be a positive integer");
+  }
+  return value;
+};
+
+export interface AgentToolsDataDependencies {
+  data: AppDataAccess;
+  requireOwned(appId: AppId, subject: string): Promise<AppDocument>;
+}
+
 const errorOutcome = (error: unknown): ToolOutcome => ({
   status: "error",
   error: error instanceof VendoError
@@ -82,7 +167,10 @@ const errorOutcome = (error: unknown): ToolOutcome => ({
 });
 
 /** 06-apps §§1,5 — unbound Vendo app capabilities; the umbrella binds this registry. */
-export const createAgentTools = (runtime: AppsRuntime): ToolRegistry => ({
+export const createAgentTools = (
+  runtime: AppsRuntime,
+  dependencies: AgentToolsDataDependencies,
+): ToolRegistry => ({
   async descriptors() {
     return structuredClone(descriptors);
   },
@@ -107,6 +195,44 @@ export const createAgentTools = (runtime: AppsRuntime): ToolRegistry => ({
       if (call.tool === "vendo_apps_open") {
         const args = input(call.args, ["appId"]);
         return { status: "ok", output: await runtime.open(args.appId as string, ctx) as unknown as Json };
+      }
+      if (call.tool === "vendo_apps_data_list") {
+        const args = input(call.args, ["appId", "collection"], ["refs", "limit", "cursor"]);
+        const app = await dependencies.requireOwned(args.appId as string, ctx.principal.subject);
+        const refs = optionalRefs(args.refs);
+        const limit = optionalLimit(args.limit);
+        if (args.cursor !== undefined && (typeof args.cursor !== "string" || args.cursor.trim() === "")) {
+          throw new VendoError("validation", "cursor must be a non-empty string");
+        }
+        const query: RecordQuery = {
+          ...(refs === undefined ? {} : { refs }),
+          ...(limit === undefined ? {} : { limit }),
+          ...(args.cursor === undefined ? {} : { cursor: args.cursor as string }),
+        };
+        return {
+          status: "ok",
+          output: await dependencies.data.records(app, args.collection as string).list(query) as unknown as Json,
+        };
+      }
+      if (call.tool === "vendo_apps_data_put") {
+        const args = input(call.args, ["appId", "collection", "id"], ["data", "refs"]);
+        if (!Object.prototype.hasOwnProperty.call(args, "data") || args.data === undefined) {
+          throw new VendoError("validation", "data is required");
+        }
+        const app = await dependencies.requireOwned(args.appId as string, ctx.principal.subject);
+        const refs = optionalRefs(args.refs);
+        const record = await dependencies.data.records(app, args.collection as string).put({
+          id: args.id as string,
+          data: args.data,
+          ...(refs === undefined ? {} : { refs }),
+        });
+        return { status: "ok", output: record as unknown as Json };
+      }
+      if (call.tool === "vendo_apps_data_delete") {
+        const args = input(call.args, ["appId", "collection", "id"]);
+        const app = await dependencies.requireOwned(args.appId as string, ctx.principal.subject);
+        await dependencies.data.records(app, args.collection as string).delete(args.id as string);
+        return { status: "ok", output: { status: "ok" } };
       }
       return { status: "error", error: { code: "not-found", message: `Unknown tool: ${call.tool}` } };
     } catch (error) {

--- a/packages/apps/src/app-data.test.ts
+++ b/packages/apps/src/app-data.test.ts
@@ -1,6 +1,11 @@
 import type { AppDocument, RunContext, ToolRegistry } from "@vendoai/core";
 import { VENDO_APP_FORMAT, validateAppDocument } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
+import {
+  APP_BLOB_MAX_BYTES,
+  APP_RECORD_MAX_BYTES,
+  createAppData,
+} from "./app-data.js";
 import { createApps } from "./index.js";
 import { basicLanguageModel, guardFixture, memoryStore, seedAppRow } from "./testing/index.js";
 
@@ -23,6 +28,82 @@ const ctx: RunContext = {
 const model = basicLanguageModel();
 
 describe("app data persistence", () => {
+  it("gates record and file collections on declarations and reserves state", async () => {
+    const store = memoryStore();
+    const runtime = createApps({ store, guard: guardFixture(), tools, catalog: [], model });
+    const created = await runtime.create({ prompt: "Declared storage" }, ctx);
+    const app: AppDocument = {
+      ...created,
+      storage: {
+        notes: { about: "Invoice notes" },
+        attachments: { about: "Invoice attachments", kind: "files" },
+      },
+    };
+    const data = createAppData(store);
+
+    expect(() => data.records(app, "missing")).toThrow(expect.objectContaining({ code: "not-found" }));
+    expect(() => data.blobs(app, "missing")).toThrow(expect.objectContaining({ code: "not-found" }));
+    expect(() => data.records(app, "attachments")).toThrow(expect.objectContaining({ code: "not-found" }));
+    expect(() => data.blobs(app, "notes")).toThrow(expect.objectContaining({ code: "not-found" }));
+    expect(() => data.records(app, "state")).toThrow(expect.objectContaining({ code: "validation" }));
+    expect(() => data.blobs(app, "state")).toThrow(expect.objectContaining({ code: "validation" }));
+  });
+
+  it("round-trips records with refs filters and validates declared refs", async () => {
+    const store = memoryStore();
+    const runtime = createApps({ store, guard: guardFixture(), tools, catalog: [], model });
+    const created = await runtime.create({ prompt: "Referenced records" }, ctx);
+    const app: AppDocument = {
+      ...created,
+      storage: {
+        notes: { about: "Invoice notes", refs: { invoice_id: "host.invoice" } },
+      },
+    };
+    const records = createAppData(store).records(app, "notes");
+
+    await records.put({ id: "note_1", data: { body: "first" }, refs: { invoice_id: "inv_1" } });
+    await records.put({ id: "note_2", data: { body: "second" }, refs: { invoice_id: "inv_2" } });
+
+    await expect(records.list({ refs: { invoice_id: "inv_1" } })).resolves.toMatchObject({
+      records: [{ id: "note_1", data: { body: "first" }, refs: { invoice_id: "inv_1" } }],
+    });
+    await expect(records.put({
+      id: "bad_key",
+      data: {},
+      refs: { customer_id: "cus_1" },
+    })).rejects.toMatchObject({ code: "validation" });
+    await expect(records.put({
+      id: "bad_value",
+      data: {},
+      refs: { invoice_id: "" },
+    })).rejects.toMatchObject({ code: "validation" });
+  });
+
+  it("enforces the 256 KB record cap and documented 5 MB blob cap", async () => {
+    const store = memoryStore();
+    const runtime = createApps({ store, guard: guardFixture(), tools, catalog: [], model });
+    const created = await runtime.create({ prompt: "Bounded storage" }, ctx);
+    const app: AppDocument = {
+      ...created,
+      storage: {
+        notes: { about: "Bounded notes" },
+        attachments: { about: "Bounded attachments", kind: "files" },
+      },
+    };
+    const data = createAppData(store);
+
+    await expect(data.records(app, "notes").put({
+      id: "oversized",
+      data: { body: "x".repeat(APP_RECORD_MAX_BYTES) },
+    })).rejects.toMatchObject({ code: "validation" });
+    await expect(data.blobs(app, "attachments").put(
+      "oversized.bin",
+      new Uint8Array(APP_BLOB_MAX_BYTES + 1),
+    )).rejects.toMatchObject({ code: "validation" });
+    await expect(store.records(`app:${app.id}:notes`).get("oversized")).resolves.toBeNull();
+    await expect(store.blobs(`app:${app.id}:attachments`).get("oversized.bin")).resolves.toBeNull();
+  });
+
   it("deletes declared records, state, file collections, and the app blob namespace", async () => {
     const store = memoryStore();
     const runtime = createApps({ store, guard: guardFixture(), tools, catalog: [], model });

--- a/packages/apps/src/app-data.ts
+++ b/packages/apps/src/app-data.ts
@@ -7,6 +7,13 @@ import type {
   StorageDecl,
   StoreAdapter,
 } from "@vendoai/core";
+import { VendoError } from "@vendoai/core";
+
+export const APP_RECORD_MAX_BYTES = 256 * 1024;
+/** ENG-289 M1 — app-declared file collections accept blobs up to 5 MB each. */
+export const APP_BLOB_MAX_BYTES = 5 * 1024 * 1024;
+
+const encoder = new TextEncoder();
 
 export type AppStorage =
   | { kind: "records"; records: RecordStore }
@@ -44,8 +51,56 @@ const clearBlobs = async (blobs: BlobStore): Promise<void> => {
 export interface AppDataAccess {
   getState(appId: AppId, subject: string): Promise<Json | null>;
   setState(appId: AppId, subject: string, data: Json): Promise<void>;
+  records(app: AppDocument, name: string): RecordStore;
+  blobs(app: AppDocument, name: string): BlobStore;
   clear(app: AppDocument, subject: string, historical?: readonly AppDocument[]): Promise<void>;
 }
+
+const declaredStorage = (
+  app: AppDocument,
+  name: string,
+  kind: "records" | "files",
+): StorageDecl => {
+  if (name === "state") throw new VendoError("validation", 'storage collection "state" is reserved');
+  const declaration = app.storage !== undefined
+    && Object.prototype.hasOwnProperty.call(app.storage, name)
+    ? app.storage[name]
+    : undefined;
+  const actualKind = declaration?.kind ?? "records";
+  if (declaration === undefined || actualKind !== kind) {
+    throw new VendoError("not-found", `${kind} collection not found: ${name}`);
+  }
+  return declaration;
+};
+
+const validateRecordRefs = (
+  declaration: StorageDecl,
+  refs: Record<string, string> | undefined,
+): void => {
+  if (refs === undefined) return;
+  if (typeof refs !== "object" || refs === null || Array.isArray(refs)) {
+    throw new VendoError("validation", "record refs must be an object");
+  }
+  const declared = declaration.refs ?? {};
+  for (const [key, value] of Object.entries(refs)) {
+    if (!Object.prototype.hasOwnProperty.call(declared, key)) {
+      throw new VendoError("validation", `undeclared record ref: ${key}`);
+    }
+    if (typeof value !== "string" || value.trim() === "") {
+      throw new VendoError("validation", `record ref ${key} must be a non-empty string`);
+    }
+  }
+};
+
+const recordByteLength = (record: Parameters<RecordStore["put"]>[0]): number => {
+  try {
+    const serialized = JSON.stringify(record);
+    if (serialized === undefined) throw new Error("record is not JSON serializable");
+    return encoder.encode(serialized).byteLength;
+  } catch {
+    throw new VendoError("validation", "record must be valid JSON");
+  }
+};
 
 /** 06-apps §6 — private app-data API consumed by lifecycle and later execution lanes. */
 export const createAppData = (store: StoreAdapter): AppDataAccess => ({
@@ -59,6 +114,43 @@ export const createAppData = (store: StoreAdapter): AppDataAccess => ({
       data: structuredClone(data),
       refs: { subject, app_id: appId },
     });
+  },
+  records(app, name) {
+    const declaration = declaredStorage(app, name, "records");
+    const storage = resolveAppStorage(store, app.id, name, declaration);
+    if (storage.kind !== "records") {
+      throw new VendoError("not-found", `records collection not found: ${name}`);
+    }
+    return {
+      get: (id) => storage.records.get(id),
+      async put(record) {
+        validateRecordRefs(declaration, record.refs);
+        if (recordByteLength(record) > APP_RECORD_MAX_BYTES) {
+          throw new VendoError("validation", "record exceeds 256 KB size limit");
+        }
+        return storage.records.put(record);
+      },
+      delete: (id) => storage.records.delete(id),
+      list: (query) => storage.records.list(query),
+    };
+  },
+  blobs(app, name) {
+    const declaration = declaredStorage(app, name, "files");
+    const storage = resolveAppStorage(store, app.id, name, declaration);
+    if (storage.kind !== "files") {
+      throw new VendoError("not-found", `files collection not found: ${name}`);
+    }
+    return {
+      async put(key, bytes, meta) {
+        if (bytes.byteLength > APP_BLOB_MAX_BYTES) {
+          throw new VendoError("validation", "blob exceeds 5 MB size limit");
+        }
+        await storage.blobs.put(key, bytes, meta);
+      },
+      get: (key) => storage.blobs.get(key),
+      delete: (key) => storage.blobs.delete(key),
+      list: (prefix) => storage.blobs.list(prefix),
+    };
   },
   async clear(app, subject, historical = []) {
     const declarations = new Map<string, StorageDecl>();

--- a/packages/apps/src/proxy.test.ts
+++ b/packages/apps/src/proxy.test.ts
@@ -160,6 +160,109 @@ describe("machine tool proxy", () => {
     expect(await store.records("vendo_state").get(`${app.id}:${ctx.principal.subject}`)).toBeNull();
   });
 
+  it("authenticates and round-trips declared record and file collections", async () => {
+    const sandbox = fakeSandbox();
+    const store = memoryStore();
+    const runtime = createApps({
+      store,
+      guard: guardFixture(),
+      tools: { async descriptors() { return []; }, async execute() { return { status: "blocked", reason: "no" }; } },
+      sandbox,
+      proxyUrl: "https://proxy.test",
+      catalog: [],
+      model,
+    });
+    const created = await runtime.create({ prompt: "Custom fields" }, ctx);
+    const app = {
+      ...created,
+      ui: "http" as const,
+      storage: {
+        notes: { about: "Invoice notes", refs: { invoice_id: "host.invoice" } },
+        attachments: { about: "Invoice attachments", kind: "files" as const },
+      },
+    };
+    await seedAppRow(store, app, ctx.principal.subject);
+    await runtime.open(app.id, ctx);
+    await vi.waitFor(() => expect(sandbox.machines.size).toBe(1));
+    const token = [...sandbox.machines.values()].at(-1)?.env.VENDO_RUN_TOKEN;
+    const headers = { authorization: `Bearer ${token}` };
+
+    for (const [id, invoiceId] of [["note_1", "inv_1"], ["note_2", "inv_2"]]) {
+      const response = await runtime.proxy.handler(new Request(`https://proxy.test/data/notes/${id}`, {
+        method: "PUT",
+        headers: { ...headers, "content-type": "application/json" },
+        body: JSON.stringify({ data: { body: id }, refs: { invoice_id: invoiceId } }),
+      }));
+      expect(response.status).toBe(200);
+    }
+    const listed = await runtime.proxy.handler(new Request(
+      "https://proxy.test/data/notes?refs.invoice_id=inv_1&limit=10",
+      { headers },
+    ));
+    expect(await json(listed)).toMatchObject({
+      records: [{ id: "note_1", data: { body: "note_1" }, refs: { invoice_id: "inv_1" } }],
+    });
+    const fetched = await runtime.proxy.handler(new Request("https://proxy.test/data/notes/note_1", { headers }));
+    expect(await json(fetched)).toMatchObject({ id: "note_1", data: { body: "note_1" } });
+
+    const filePut = await runtime.proxy.handler(new Request("https://proxy.test/files/attachments/report.txt", {
+      method: "PUT",
+      headers: { ...headers, "content-type": "text/plain" },
+      body: "hello file",
+    }));
+    expect(filePut.status).toBe(200);
+    const fileList = await runtime.proxy.handler(new Request("https://proxy.test/files/attachments", { headers }));
+    expect(await json(fileList)).toEqual(["report.txt"]);
+    const fileGet = await runtime.proxy.handler(new Request(
+      "https://proxy.test/files/attachments/report.txt",
+      { headers },
+    ));
+    expect(fileGet.headers.get("content-type")).toBe("text/plain");
+    expect(await fileGet.text()).toBe("hello file");
+
+    expect((await runtime.proxy.handler(new Request("https://proxy.test/data/notes/note_1", {
+      method: "DELETE",
+      headers,
+    }))).status).toBe(200);
+    expect((await runtime.proxy.handler(new Request("https://proxy.test/files/attachments/report.txt", {
+      method: "DELETE",
+      headers,
+    }))).status).toBe(200);
+    expect(await store.records(`app:${app.id}:notes`).get("note_1")).toBeNull();
+    expect(await store.blobs(`app:${app.id}:attachments`).get("report.txt")).toBeNull();
+  });
+
+  it("rejects unauthenticated and non-owned collection routes", async () => {
+    const sandbox = fakeSandbox();
+    const store = memoryStore();
+    const runtime = createApps({
+      store,
+      guard: guardFixture(),
+      tools: { async descriptors() { return []; }, async execute() { return { status: "blocked", reason: "no" }; } },
+      sandbox,
+      proxyUrl: "https://proxy.test",
+      catalog: [],
+      model,
+    });
+    const created = await runtime.create({ prompt: "Private custom fields" }, ctx);
+    const app = { ...created, ui: "http" as const, storage: { notes: { about: "Notes" } } };
+    await seedAppRow(store, app, ctx.principal.subject);
+    await runtime.open(app.id, ctx);
+    await vi.waitFor(() => expect(sandbox.machines.size).toBe(1));
+    const token = [...sandbox.machines.values()].at(-1)?.env.VENDO_RUN_TOKEN;
+
+    const unauthenticated = await runtime.proxy.handler(new Request("https://proxy.test/data/notes"));
+    expect(unauthenticated.status).toBe(401);
+    expect(await json(unauthenticated)).toMatchObject({ error: { code: "unauthorized" } });
+
+    await seedAppRow(store, app, "user_intruder");
+    const nonOwned = await runtime.proxy.handler(new Request("https://proxy.test/files/missing", {
+      headers: { authorization: `Bearer ${token}` },
+    }));
+    expect(nonOwned.status).toBe(404);
+    expect(await json(nonOwned)).toEqual({ error: { code: "not-found", message: "app not found" } });
+  });
+
   it("injects opaque secret handles without ever reading or exposing values", async () => {
     const get = vi.fn(async () => "REAL_SECRET_SENTINEL");
     const sandbox = fakeSandbox();

--- a/packages/apps/src/proxy.ts
+++ b/packages/apps/src/proxy.ts
@@ -1,11 +1,20 @@
-import type { AppDocument, AppId, RunContext, SecretsProvider, ToolRegistry } from "@vendoai/core";
-import type { AppDataAccess } from "./app-data.js";
+import {
+  VendoError,
+  type AppDocument,
+  type AppId,
+  type RecordQuery,
+  type RunContext,
+  type SecretsProvider,
+  type ToolRegistry,
+  type VendoErrorCode,
+} from "@vendoai/core";
+import { APP_BLOB_MAX_BYTES, APP_RECORD_MAX_BYTES, type AppDataAccess } from "./app-data.js";
 import { hostAllowed, substituteSecretHandles } from "./egress.js";
 import type { RunTokenGate } from "./run-token-gate.js";
 import { verifyRunToken, type RunTokenSecret } from "./run-token.js";
 import { checkEgressUrl, type IpResolver } from "./ssrf.js";
 
-const STATE_BODY_MAX_BYTES = 256 * 1024;
+const STATE_BODY_MAX_BYTES = APP_RECORD_MAX_BYTES;
 const EGRESS_BODY_MAX_BYTES = 1 * 1024 * 1024; // 1 MiB request envelope ceiling
 const EGRESS_RESPONSE_MAX_BYTES = 4 * 1024 * 1024; // 4 MiB response ceiling
 const EGRESS_MAX_REDIRECTS = 5;
@@ -14,6 +23,16 @@ const decoder = new TextDecoder();
 const lenientDecoder = new TextDecoder("utf-8", { fatal: false });
 // vendo-secret:<NAME>:<nonce> — NAME is a declared secret name, nonce is per-boot hex.
 const HANDLE_PATTERN = /vendo-secret:([A-Za-z_][A-Za-z0-9_]*):[0-9a-fA-F]+/g;
+
+const STATUS_BY_CODE: Record<VendoErrorCode, number> = {
+  validation: 400,
+  "not-found": 404,
+  blocked: 403,
+  conflict: 409,
+  "cloud-required": 402,
+  "sandbox-unavailable": 501,
+  "not-implemented": 501,
+};
 
 const jsonResponse = (body: unknown, status = 200): Response => new Response(JSON.stringify(body), {
   status,
@@ -70,6 +89,122 @@ const redact = (text: string, values: readonly string[]): string => {
     output = output.split(value).join("[vendo-secret-redacted]");
   }
   return output;
+};
+
+type ProxyRoute =
+  | { kind: "tool"; name: string }
+  | { kind: "state-get" | "state-put" }
+  | { kind: "egress" }
+  | { kind: "data-list"; collection: string }
+  | { kind: "data-item"; collection: string; id: string }
+  | { kind: "file-list"; collection: string }
+  | { kind: "file-item"; collection: string; key: string };
+
+const decoded = (value: string): string | null => {
+  try {
+    const result = decodeURIComponent(value);
+    return result === "" ? null : result;
+  } catch {
+    return null;
+  }
+};
+
+const collectionRoute = (
+  pathname: string,
+  prefix: "data" | "files",
+): { collection: string; item?: string } | null => {
+  const match = new RegExp(`^/${prefix}/([^/]+)(?:/(.+))?$`).exec(pathname);
+  if (match?.[1] === undefined) return null;
+  const collection = decoded(match[1]);
+  const item = match[2] === undefined ? undefined : decoded(match[2]);
+  if (collection === null || item === null) return null;
+  return { collection, ...(item === undefined ? {} : { item }) };
+};
+
+const routeFor = (request: Request, pathname: string): ProxyRoute | null => {
+  const toolMatch = /^\/tools\/([a-zA-Z0-9_-]{1,64})$/.exec(pathname);
+  if (request.method === "POST" && toolMatch?.[1] !== undefined) {
+    return { kind: "tool", name: toolMatch[1] };
+  }
+  if (pathname === "/state" && request.method === "GET") return { kind: "state-get" };
+  if (pathname === "/state" && request.method === "PUT") return { kind: "state-put" };
+  if (pathname === "/egress" && request.method === "POST") return { kind: "egress" };
+
+  const data = collectionRoute(pathname, "data");
+  if (data !== null) {
+    if (data.item === undefined && request.method === "GET") {
+      return { kind: "data-list", collection: data.collection };
+    }
+    if (data.item !== undefined && ["GET", "PUT", "DELETE"].includes(request.method)) {
+      return { kind: "data-item", collection: data.collection, id: data.item };
+    }
+  }
+  const files = collectionRoute(pathname, "files");
+  if (files !== null) {
+    if (files.item === undefined && request.method === "GET") {
+      return { kind: "file-list", collection: files.collection };
+    }
+    if (files.item !== undefined && ["GET", "PUT", "DELETE"].includes(request.method)) {
+      return { kind: "file-item", collection: files.collection, key: files.item };
+    }
+  }
+  return null;
+};
+
+const readJson = async (request: Request, maxBytes?: number): Promise<unknown> => {
+  const bytes = new Uint8Array(await request.arrayBuffer());
+  if (maxBytes !== undefined && bytes.byteLength > maxBytes) {
+    throw new VendoError("validation", "request body exceeds size limit");
+  }
+  try {
+    return JSON.parse(decoder.decode(bytes)) as unknown;
+  } catch {
+    throw new VendoError("validation", "request body must be valid JSON");
+  }
+};
+
+const objectBody = (value: unknown, label: string): Record<string, unknown> => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new VendoError("validation", `${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+};
+
+const recordQuery = (url: URL): RecordQuery => {
+  const refs: Record<string, string> = {};
+  let limit: number | undefined;
+  let cursor: string | undefined;
+  for (const [key, value] of url.searchParams) {
+    if (key.startsWith("refs.")) {
+      const ref = key.slice("refs.".length);
+      if (ref === "" || value === "") {
+        throw new VendoError("validation", "ref filters require non-empty keys and values");
+      }
+      refs[ref] = value;
+      continue;
+    }
+    if (key === "limit") {
+      if (!/^[1-9]\d*$/.test(value)) {
+        throw new VendoError("validation", "limit must be a positive integer");
+      }
+      limit = Number(value);
+      if (!Number.isSafeInteger(limit)) {
+        throw new VendoError("validation", "limit must be a positive integer");
+      }
+      continue;
+    }
+    if (key === "cursor") {
+      if (value === "") throw new VendoError("validation", "cursor must be a non-empty string");
+      cursor = value;
+      continue;
+    }
+    throw new VendoError("validation", `unknown list query parameter: ${key}`);
+  }
+  return {
+    ...(Object.keys(refs).length === 0 ? {} : { refs }),
+    ...(limit === undefined ? {} : { limit }),
+    ...(cursor === undefined ? {} : { cursor }),
+  };
 };
 
 /** 06-apps §1 plus ENG-259 egress additions — internal dependencies for the fetch-style proxy. */
@@ -221,16 +356,19 @@ export const createAppsProxy = (dependencies: AppsProxyDependencies): { handler(
   return {
     async handler(request) {
       const url = new URL(request.url);
-      const toolMatch = /^\/tools\/([a-zA-Z0-9_-]{1,64})$/.exec(url.pathname);
-      const isTool = request.method === "POST" && toolMatch?.[1] !== undefined;
-      const isStateGet = request.method === "GET" && url.pathname === "/state";
-      const isStatePut = request.method === "PUT" && url.pathname === "/state";
-      const isEgress = request.method === "POST" && url.pathname === "/egress";
-      if (!isTool && !isStateGet && !isStatePut && !isEgress) {
-        return errorResponse(404, "not-found", "unknown proxy route");
+      const route = routeFor(request, url.pathname);
+      if (route === null) return errorResponse(404, "not-found", "unknown proxy route");
+      if (["tool", "state-put", "egress"].includes(route.kind)
+        || (route.kind === "data-item" && request.method === "PUT")) {
+        if (!isJson(request)) {
+          return errorResponse(400, "validation", "content-type must be application/json");
+        }
       }
-      if ((isTool || isStatePut || isEgress) && !isJson(request)) {
-        return errorResponse(400, "validation", "content-type must be application/json");
+      if (route.kind === "file-item" && request.method === "PUT") {
+        const contentType = request.headers.get("content-type");
+        if (contentType === null || contentType.trim() === "") {
+          return errorResponse(400, "validation", "content-type is required");
+        }
       }
       const token = bearerToken(request);
       const payload = token === null ? null : await verifyRunToken(dependencies.tokenSecret, token);
@@ -254,55 +392,109 @@ export const createAppsProxy = (dependencies: AppsProxyDependencies): { handler(
         appId: payload.appId,
       };
 
-      if (isStateGet) {
-        return jsonResponse(await dependencies.data.getState(payload.appId, payload.subject));
-      }
-      if (isEgress) {
-        const bytes = new Uint8Array(await request.arrayBuffer());
-        if (bytes.byteLength > EGRESS_BODY_MAX_BYTES) {
-          return errorResponse(400, "validation", "egress request exceeds size limit");
-        }
-        let envelope: EgressEnvelope | null;
-        try {
-          envelope = parseEnvelope(JSON.parse(decoder.decode(bytes)) as unknown);
-        } catch {
-          return errorResponse(400, "validation", "egress request body must be valid JSON");
-        }
-        if (envelope === null) {
-          return errorResponse(400, "validation", "egress request must be { url, method?, headers?, body? }");
-        }
-        return handleEgress(payload, envelope);
-      }
-      let body: unknown;
       try {
-        if (isStatePut) {
-          const bytes = new Uint8Array(await request.arrayBuffer());
-          if (bytes.byteLength > STATE_BODY_MAX_BYTES) {
-            return errorResponse(400, "validation", "request body exceeds size limit");
-          }
-          body = JSON.parse(decoder.decode(bytes)) as unknown;
-        } else {
-          body = await request.json();
+        if (route.kind === "state-get") {
+          return jsonResponse(await dependencies.data.getState(payload.appId, payload.subject));
         }
-      } catch {
-        return errorResponse(400, "validation", "request body must be valid JSON");
+        if (route.kind === "egress") {
+          const bytes = new Uint8Array(await request.arrayBuffer());
+          if (bytes.byteLength > EGRESS_BODY_MAX_BYTES) {
+            return errorResponse(400, "validation", "egress request exceeds size limit");
+          }
+          let envelope: EgressEnvelope | null;
+          try {
+            envelope = parseEnvelope(JSON.parse(decoder.decode(bytes)) as unknown);
+          } catch {
+            return errorResponse(400, "validation", "egress request body must be valid JSON");
+          }
+          if (envelope === null) {
+            return errorResponse(400, "validation", "egress request must be { url, method?, headers?, body? }");
+          }
+          return handleEgress(payload, envelope);
+        }
+        if (route.kind === "state-put") {
+          await dependencies.data.setState(
+            payload.appId,
+            payload.subject,
+            await readJson(request, STATE_BODY_MAX_BYTES) as never,
+          );
+          return jsonResponse({ status: "ok" });
+        }
+
+        let app: AppDocument | undefined;
+        if (["data-list", "data-item", "file-list", "file-item"].includes(route.kind)) {
+          app = await dependencies.loadApp(payload.appId, payload.subject) ?? undefined;
+          if (app === undefined) throw new VendoError("not-found", "app not found");
+        }
+        if (route.kind === "data-list") {
+          return jsonResponse(await dependencies.data.records(app as AppDocument, route.collection).list(recordQuery(url)));
+        }
+        if (route.kind === "data-item") {
+          const records = dependencies.data.records(app as AppDocument, route.collection);
+          if (request.method === "GET") {
+            const record = await records.get(route.id);
+            if (record === null) throw new VendoError("not-found", `record not found: ${route.id}`);
+            return jsonResponse(record);
+          }
+          if (request.method === "DELETE") {
+            await records.delete(route.id);
+            return jsonResponse({ status: "ok" });
+          }
+          const body = objectBody(await readJson(request, APP_RECORD_MAX_BYTES), "record body");
+          const unexpected = Object.keys(body).find((key) => key !== "data" && key !== "refs");
+          if (unexpected !== undefined) {
+            throw new VendoError("validation", `unexpected record property: ${unexpected}`);
+          }
+          if (!Object.prototype.hasOwnProperty.call(body, "data")) {
+            throw new VendoError("validation", "record body must contain data");
+          }
+          return jsonResponse(await records.put({
+            id: route.id,
+            data: body.data as never,
+            ...(body.refs === undefined ? {} : { refs: body.refs as Record<string, string> }),
+          }));
+        }
+        if (route.kind === "file-list") {
+          return jsonResponse(await dependencies.data.blobs(app as AppDocument, route.collection).list());
+        }
+        if (route.kind === "file-item") {
+          const blobs = dependencies.data.blobs(app as AppDocument, route.collection);
+          if (request.method === "GET") {
+            const blob = await blobs.get(route.key);
+            if (blob === null) throw new VendoError("not-found", `file not found: ${route.key}`);
+            return new Response(blob.bytes, {
+              headers: { "content-type": blob.contentType ?? "application/octet-stream" },
+            });
+          }
+          if (request.method === "DELETE") {
+            await blobs.delete(route.key);
+            return jsonResponse({ status: "ok" });
+          }
+          const contentLength = request.headers.get("content-length");
+          if (contentLength !== null && Number(contentLength) > APP_BLOB_MAX_BYTES) {
+            throw new VendoError("validation", "request body exceeds size limit");
+          }
+          const bytes = new Uint8Array(await request.arrayBuffer());
+          await blobs.put(route.key, bytes, { contentType: request.headers.get("content-type") ?? undefined });
+          return jsonResponse({ status: "ok" });
+        }
+
+        if (route.kind !== "tool") return errorResponse(404, "not-found", "unknown proxy route");
+        const body = objectBody(await readJson(request), "tool body");
+        if (!Object.prototype.hasOwnProperty.call(body, "args")) {
+          throw new VendoError("validation", "tool body must be an object containing args");
+        }
+        return jsonResponse(await dependencies.tools.execute({
+          id: `call_${globalThis.crypto.randomUUID()}`,
+          tool: route.name,
+          args: body.args as never,
+        }, runCtx));
+      } catch (error) {
+        if (error instanceof VendoError) {
+          return errorResponse(STATUS_BY_CODE[error.code], error.code, error.message);
+        }
+        return errorResponse(500, "internal", error instanceof Error ? error.message : "unknown proxy error");
       }
-      if (isStatePut) {
-        await dependencies.data.setState(payload.appId, payload.subject, body);
-        return jsonResponse({ status: "ok" });
-      }
-      if (typeof body !== "object" || body === null || Array.isArray(body)
-        || !Object.prototype.hasOwnProperty.call(body, "args")) {
-        return errorResponse(400, "validation", "tool body must be an object containing args");
-      }
-      const tool = toolMatch?.[1];
-      if (tool === undefined) return errorResponse(404, "not-found", "unknown proxy route");
-      const outcome = await dependencies.tools.execute({
-        id: `call_${globalThis.crypto.randomUUID()}`,
-        tool,
-        args: (body as { args: unknown }).args,
-      }, runCtx);
-      return jsonResponse(outcome);
     },
   };
 };

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -512,7 +512,7 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     },
 
     agentTools() {
-      return createAgentTools(runtime);
+      return createAgentTools(runtime, { data, requireOwned });
     },
 
     proxy,


### PR DESCRIPTION
## What

ENG-289 M1 — the app data plane. Apps get declaration-gated custom-field storage beyond `/state`:

- `AppDataAccess.records()/blobs()` — access gated on the app's `storage` declarations; reserved name `state` rejected; written `refs` keys must match the collection's declaration with non-empty string values; 256 KB record cap (mirrors `/state`), 5 MB blob cap.
- Proxy routes for machines: `GET /data/<collection>` (refs./limit/cursor query filters), `GET|PUT|DELETE /data/<collection>/<id>`, `GET /files/<collection>`, `GET|PUT|DELETE /files/<collection>/<key>`. VendoError-code → HTTP status mapping centralized.
- Agent data tools: `vendo_apps_data_list` (read), `vendo_apps_data_put` / `vendo_apps_data_delete` (write) — ownership-checked via `requireOwned`, declaration-gated through the same `AppDataAccess` layer.

## Why

Custom fields substrate (ENG-289, block-apps child B). Users tag host entities (e.g. a "priority" field on invoices) with app-owned records that join back onto host data. M1 is the storage + access lane; M2 adds the `vendo.data.*` refs-join tree binding (encoding signed off by the parent orchestrator).

## Verification

- [x] `@vendoai/apps`: 184 passed | 7 skipped (32 files) on the merged tree
- [x] `pnpm build` green for all `packages/*` on the merged tree
- [x] Root `pnpm build && pnpm test && pnpm typecheck && pnpm lint` — green on CI (run 29383807229: ci 7m33s, integration 1m55s, audit, changeset-status, perf all pass; the fixture-e2e suite that flaked locally passes cleanly off-box). Local context: local repo-wide runs are currently unreliable on the shared fleet box (fixture-e2e `ECONNRESET`/`ECONNREFUSED` under 6 concurrent turbo gate runs at load ≈110, then `ENOSPC` when the host disk hit 100%). Failures are all in `@vendoai-fixtures/*` server boot/connect, none in changed code; same environmental-flake precedent as #171/#188. CI confirmed green.
- [ ] Not UI-affecting (no screenshots needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the app data plane for custom fields (ENG-289 M1): declaration-gated record and file storage with proxy data routes and agent data tools. Adds strict validation, refs checks, and ownership enforcement so apps can store and query data beyond `/state`.

- **New Features**
  - Data access layer: `records()` and `blobs()` gated by app `storage` declarations; reserves `state`; enforces declared `refs` keys with non-empty string values; 256 KB record cap and 5 MB blob cap.
  - Proxy routes for machines:
    - Records: `GET /data/<collection>?refs.<k>=<v>&limit=<n>&cursor=<c>`, `GET|PUT|DELETE /data/<collection>/<id>`.
    - Files: `GET /files/<collection>`, `GET|PUT|DELETE /files/<collection>/<key>`.
    - JSON required for record PUT, tool calls, `POST /egress`, and `PUT /state`; content-type required for file PUT; authenticated via run token with ownership checks; consistent HTTP mapping for `VendoError` codes.
  - Agent tools: `vendo_apps_data_list`, `vendo_apps_data_put`, `vendo_apps_data_delete` — all use `requireOwned`, validate refs/limit/cursor, and share the same declaration/refs validation path.

Linked Linear: ENG-289 — delivers M1 “Data plane” requirements (record+file R/W, refs filtering, proxy endpoints, agent data tools).

<sup>Written for commit d2f96a04324afc20d1b4e790d80018adb068abca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

