### PR TITLE
feat(mcp): RFC 7009 token revocation (ENG-269)

### DIFF
--- a/.changeset/mcp-rfc7009-revocation.md
+++ b/.changeset/mcp-rfc7009-revocation.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/mcp": minor
+---
+
+Add RFC 7009 token revocation, grant-family invalidation, per-client host disconnects, and revocation/scope discovery metadata.

--- a/docs/contracts/10-mcp.md
+++ b/docs/contracts/10-mcp.md
@@ -160,3 +160,22 @@ Hosted broker (Cloud), registry submission automation, MCP Apps write-back beyon
 ## 8. Review round (recorded)
 
 Dual review applied before any build: **standards** (verified against MCP 2025-11-25, MCP Apps 2026-01-26, RFC 8707/9728/8414/7591, CIMD draft) — all 6 findings applied, the big two being resource/audience binding and the MCP Apps shim delivery model. **Simplification** — 5 of 7 applied (`HostOAuthAdapter` shrunk to two functions, door owns its own state via `StoreAdapter`, `isRevoked`/`ttl`/`serverInfo` deleted, `AppsPort` = structural subset of `AppsRuntime`); 2 declined with rationale: the server card stays (the page mandates discovery — "agent-reachability becomes distribution" — path corrected + marked provisional instead), and `guard` stays in config (the page mandates "same audit"; auth events belong in the SIEM export, not only in SQL).
+
+## 9. Additive amendments
+
+### 2026-07-14 — RFC 7009 token revocation
+
+- **Changed:** Added local `{mount}/revoke` handling for access and refresh
+  tokens, advertised `revocation_endpoint` and `scopes_supported` in RFC 8414
+  metadata, and added `McpDoor.revokeClient(subject, clientId)` as the
+  host-authorized per-client disconnect surface.
+- **Semantics:** Access-token revocation invalidates that token. Refresh-token
+  revocation atomically kills the token's authorization-grant family, including
+  its access tokens and rotated successors. The host API revokes every existing
+  family for the subject/client and closes matching live MCP sessions. Unknown
+  tokens return an empty `200` as required by RFC 7009.
+- **Compatibility:** Grant-family fields and the `McpDoor` method are additive.
+  Pre-family grants remain readable during rolling deployment and are revoked
+  through guarded token updates. External authorization-server mode continues
+  to delegate the complete OAuth surface, including revocation, to `remoteAs`.
+- **Approved by:** Yousef, 2026-07-14 (ENG-269).

--- a/fixtures/mcp-e2e/src/revocation.e2e.test.ts
+++ b/fixtures/mcp-e2e/src/revocation.e2e.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { createStack, resetFixture, SUBJECT } from "./harness.js";
-import { connectWithSdk, issueTokens, registerClient } from "./support.js";
+import { connectWithSdk, issueTokens, refreshToken, registerClient } from "./support.js";
+
+interface TokenResponse {
+  access_token: string;
+  refresh_token: string;
+}
 
 describe("host revocation kills an MCP session", () => {
   beforeEach(resetFixture);
@@ -57,4 +62,95 @@ describe("host revocation kills an MCP session", () => {
       await stack.close();
     }
   });
+
+  it("revokes tokens through RFC 7009 with PGlite-backed family semantics", async () => {
+    const stack = await createStack();
+    try {
+      const client = await registerClient(stack);
+      const first = await issueTokens(stack, client.body.client_id);
+      const rotatedResponse = await refreshToken(stack, first.body.refresh_token, client.body.client_id);
+      expect(rotatedResponse.status).toBe(200);
+      const rotated = await rotatedResponse.json() as TokenResponse;
+      const independent = await issueTokens(stack, client.body.client_id);
+
+      const revoked = await fetch(`${stack.endpoint}/revoke`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          token: first.body.refresh_token,
+          token_type_hint: "access_token",
+          client_id: client.body.client_id,
+        }),
+      });
+      expect(revoked.status).toBe(200);
+      expect(await revoked.text()).toBe("");
+      expect(await bearerStatus(stack.endpoint, first.body.access_token)).toBe(401);
+      expect(await bearerStatus(stack.endpoint, rotated.access_token)).toBe(401);
+      expect((await refreshToken(stack, rotated.refresh_token, client.body.client_id)).status).toBe(400);
+      expect((await refreshToken(stack, independent.body.refresh_token, client.body.client_id)).status).toBe(200);
+
+      const families = await stack.sql<{ status: string; count: number }>(
+        `SELECT data->>'status' AS status, count(*)::int AS count
+         FROM vendo_mcp_grants
+         WHERE data->>'kind' = 'family'
+         GROUP BY data->>'status'
+         ORDER BY status`,
+      );
+      expect(families).toEqual([
+        { status: "active", count: 1 },
+        { status: "revoked", count: 1 },
+      ]);
+
+      const accessOnly = await issueTokens(stack, client.body.client_id);
+      const accessRevoked = await fetch(`${stack.endpoint}/revoke`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          token: accessOnly.body.access_token,
+          token_type_hint: "access_token",
+          client_id: client.body.client_id,
+        }),
+      });
+      expect(accessRevoked.status).toBe(200);
+      expect(await bearerStatus(stack.endpoint, accessOnly.body.access_token)).toBe(401);
+      expect((await refreshToken(stack, accessOnly.body.refresh_token, client.body.client_id)).status).toBe(200);
+
+      const unknown = await fetch(`${stack.endpoint}/revoke`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          token: "vmrt_unknown",
+          token_type_hint: "future_token_type",
+          client_id: client.body.client_id,
+        }),
+      });
+      expect(unknown.status).toBe(200);
+      expect(await unknown.text()).toBe("");
+    } finally {
+      await stack.close();
+    }
+  });
 });
+
+async function bearerStatus(endpoint: string, token: string): Promise<number> {
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+      "mcp-protocol-version": "2025-11-25",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 99,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "revocation-e2e", version: "1.0.0" },
+      },
+    }),
+  });
+  return response.status;
+}

--- a/fixtures/mcp-e2e/src/token-claim-race.e2e.test.ts
+++ b/fixtures/mcp-e2e/src/token-claim-race.e2e.test.ts
@@ -114,6 +114,39 @@ describePostgres("multi-instance OAuth token claims (Postgres)", () => {
       (event) => (event.detail as { event?: unknown } | undefined)?.event === "revoke",
     )).toHaveLength(RACE_ITERATIONS);
   });
+
+  it(`keeps a grant family dead when refresh rotation races revocation across ${RACE_ITERATIONS} races`, async () => {
+    const clientId = await register(firstDoor);
+
+    for (let iteration = 0; iteration < RACE_ITERATIONS; iteration += 1) {
+      const code = await authorize(firstDoor, clientId);
+      const issued = await exchange(firstDoor, code, clientId);
+      expect(issued.status).toBe(200);
+      const first = await issued.json() as TokenResponse;
+
+      claimBarrier.arm();
+      const [rotation, revocation] = await Promise.all([
+        refresh(firstDoor, first.refresh_token, clientId),
+        revoke(secondDoor, first.refresh_token, clientId),
+      ]);
+
+      expect(revocation.status).toBe(200);
+      expect(await revocation.text()).toBe("");
+      expect([200, 400]).toContain(rotation.status);
+      if (rotation.status === 200) {
+        const successor = await rotation.json() as TokenResponse;
+        expect((await firstDoor.handler(new Request(BASE, {
+          method: "POST",
+          headers: { authorization: `Bearer ${successor.access_token}` },
+        }))).status).toBe(401);
+        expect((await refresh(secondDoor, successor.refresh_token, clientId)).status).toBe(400);
+      }
+      expect((await firstDoor.handler(new Request(BASE, {
+        method: "POST",
+        headers: { authorization: `Bearer ${first.access_token}` },
+      }))).status).toBe(401);
+    }
+  });
 });
 
 function makeDoor(store: StoreAdapter, audits: AuditEvent[]): McpDoor {
@@ -226,6 +259,14 @@ function refresh(door: McpDoor, refreshToken: string, clientId: string): Promise
     client_id: clientId,
     resource: BASE,
   });
+}
+
+function revoke(door: McpDoor, token: string, clientId: string): Promise<Response> {
+  return door.handler(new Request(`${BASE}/revoke`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ token, token_type_hint: "refresh_token", client_id: clientId }),
+  }));
 }
 
 function tokenRequest(door: McpDoor, values: Record<string, string>): Promise<Response> {

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -37,6 +37,29 @@ the immediate account-level kill switch. The door's local `/authorize`,
 `/token`, and `/register` endpoints and RFC 8414 metadata return `404`; RFC 9728
 protected-resource metadata advertises the configured external issuer.
 
+## Token revocation
+
+Local authorization-server metadata advertises `{mount}/revoke` and the
+supported `read` / `write` scopes. The RFC 7009 endpoint accepts an
+`application/x-www-form-urlencoded` POST containing `token`, the public
+`client_id`, and an optional `token_type_hint`. Unknown tokens and unknown or
+incorrect hints receive the RFC-required empty `200` response.
+
+Access-token revocation invalidates that opaque token. Refresh-token revocation
+atomically revokes its authorization-grant family, including access tokens and
+rotated successors, without disconnecting a separate authorization for the
+same client. Hosts can disconnect all existing authorizations for one
+subject/client pair and close their live MCP sessions through the returned door:
+
+```ts
+const door = createMcpDoor({ /* ... */ });
+await door.revokeClient(subject, clientId);
+```
+
+Grant-family and token revocation use the store's guarded atomic claim rather
+than a read-then-write update. In `remoteAs` mode, the external authorization
+server owns revocation and the door's local `/revoke` path returns `404`.
+
 ## Login federation
 
 `federation: { secret }` enables `GET {mount}/federate?request=<compact JWS>` as
@@ -65,7 +88,8 @@ The current adapter owns three related lifetimes:
 
 - a TTL-indexed session record keyed by `Mcp-Session-Id`, containing the
   authenticated subject and opaque SDK runtime;
-- the subject-to-session index used to close every live runtime on revocation;
+- the authenticated subject/client/grant-family binding used to close every
+  matching live runtime on account, per-client, or refresh-family revocation;
 - a bounded approval-replay map keyed by an opaque replay scope plus the
   canonical tool/arguments fingerprint. A pending approval retains its exact
   `ToolCall.id`; any resolved outcome deletes it. Session deletion, revocation,

--- a/packages/mcp/src/door.test.ts
+++ b/packages/mcp/src/door.test.ts
@@ -85,7 +85,9 @@ describe("createMcpDoor routing and OAuth", () => {
       issuer: BASE,
       authorization_endpoint: `${BASE}/authorize`,
       token_endpoint: `${BASE}/token`,
+      revocation_endpoint: `${BASE}/revoke`,
       registration_endpoint: `${BASE}/register`,
+      scopes_supported: ["read", "write"],
       code_challenge_methods_supported: ["S256"],
       client_id_metadata_document_supported: true,
     });
@@ -358,6 +360,133 @@ describe("createMcpDoor routing and OAuth", () => {
     expect(reuse.status).toBe(400);
     const successorReuse = await refresh(harness.door, rotated.refresh_token, client.body.client_id);
     expect(successorReuse.status).toBe(400);
+  });
+
+  it("returns an empty 200 for an unknown token and ignores an unknown token type hint", async () => {
+    const harness = makeHarness();
+    const client = await register(harness.door);
+
+    const response = await revoke(harness.door, "vmrt_unknown", client.body.client_id, "future_token_type");
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("");
+    expect(harness.audits.filter((event) => event.detail?.event === "revoke")).toEqual([]);
+  });
+
+  it("refuses a valid public client trying to revoke another client's token", async () => {
+    const harness = makeHarness();
+    const owner = await register(harness.door);
+    const other = await register(harness.door);
+    const tokens = await issue(harness.door, owner.body.client_id);
+
+    const response = await revoke(harness.door, tokens.refresh_token, other.body.client_id, "refresh_token");
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: "invalid_client" });
+    expect((await refresh(harness.door, tokens.refresh_token, owner.body.client_id)).status).toBe(200);
+  });
+
+  it("revokes one access token atomically without revoking its refresh grant", async () => {
+    const harness = makeHarness();
+    const client = await register(harness.door);
+    const tokens = await issue(harness.door, client.body.client_id);
+
+    const response = await revoke(harness.door, tokens.access_token, client.body.client_id, "access_token");
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("");
+    expect((await harness.door.handler(mcpRequest(tokens.access_token))).status).toBe(401);
+    expect((await refresh(harness.door, tokens.refresh_token, client.body.client_id)).status).toBe(200);
+    expect(harness.audits.map((event) => event.detail)).toContainEqual({
+      clientId: client.body.client_id,
+      event: "revoke",
+    });
+  });
+
+  it("revoking a refresh token kills its access tokens and rotated successors, but not another family", async () => {
+    const harness = makeHarness();
+    const client = await register(harness.door);
+    const first = await issue(harness.door, client.body.client_id);
+    const rotatedResponse = await refresh(harness.door, first.refresh_token, client.body.client_id);
+    const rotated = await rotatedResponse.json() as TokenResponse;
+    const independent = await issue(harness.door, client.body.client_id);
+
+    // A wrong recognized hint is only an optimization. RFC 7009 requires the
+    // server to continue across the other supported token type.
+    const response = await revoke(harness.door, first.refresh_token, client.body.client_id, "access_token");
+
+    expect(response.status).toBe(200);
+    expect((await harness.door.handler(mcpRequest(first.access_token))).status).toBe(401);
+    expect((await harness.door.handler(mcpRequest(rotated.access_token))).status).toBe(401);
+    expect((await refresh(harness.door, rotated.refresh_token, client.body.client_id)).status).toBe(400);
+    expect((await harness.door.handler(mcpRequest(independent.access_token))).status).toBe(200);
+
+    const families = harness.store.rows("vendo_mcp_grants")
+      .filter((row) => row.data.kind === "family")
+      .map((row) => row.data.status)
+      .sort();
+    expect(families).toEqual(["active", "revoked"]);
+  });
+
+  it("lets the host revoke all families and live sessions for one subject/client", async () => {
+    const harness = makeHarness();
+    const clientA = await register(harness.door);
+    const clientB = await register(harness.door);
+    const firstA = await issue(harness.door, clientA.body.client_id);
+    const secondA = await issue(harness.door, clientA.body.client_id);
+    const tokensB = await issue(harness.door, clientB.body.client_id);
+    const connectedA = await connect(harness.door, firstA.access_token);
+    const oldSessionId = connectedA.transport.sessionId;
+    expect(oldSessionId).toMatch(/^mcps_/);
+
+    await harness.door.revokeClient("user_1", clientA.body.client_id);
+
+    expect((await harness.door.handler(mcpRequest(firstA.access_token))).status).toBe(401);
+    expect((await harness.door.handler(mcpRequest(secondA.access_token))).status).toBe(401);
+    expect((await refresh(harness.door, firstA.refresh_token, clientA.body.client_id)).status).toBe(400);
+    expect((await harness.door.handler(mcpRequest(tokensB.access_token))).status).toBe(200);
+
+    // Revocation does not prohibit a later explicit re-authorization, but the
+    // old live runtime was removed rather than left reusable.
+    const reauthorizedA = await issue(harness.door, clientA.body.client_id);
+    expect((await harness.door.handler(mcpRequest(reauthorizedA.access_token, oldSessionId))).status).toBe(404);
+    expect(harness.audits.map((event) => event.detail)).toContainEqual({
+      clientId: clientA.body.client_id,
+      event: "revoke",
+    });
+    await connectedA.client.close().catch(() => undefined);
+  });
+
+  it("revokes a pre-family authorization code during a rolling deployment", async () => {
+    const harness = makeHarness();
+    const client = await register(harness.door);
+    const code = "vmcd_pre_family_code";
+    await harness.store.records("vendo_mcp_grants").put({
+      id: "mcpg_pre_family_code",
+      data: {
+        kind: "code",
+        subject: "user_1",
+        clientId: client.body.client_id,
+        resource: BASE,
+        scopes: ["read", "write"],
+        codeChallenge: await pkceChallenge(VERIFIER),
+        redirectUri: REDIRECT,
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      },
+      refs: { kind: "code", token_hash: await sha256Hex(code) },
+    });
+
+    await harness.door.revokeClient("user_1", client.body.client_id);
+
+    const exchangeResponse = await exchange(harness.door, {
+      code,
+      client_id: client.body.client_id,
+      code_verifier: VERIFIER,
+      resource: BASE,
+    });
+    expect(exchangeResponse.status).toBe(400);
+    expect(await exchangeResponse.json()).toMatchObject({ error: "invalid_grant" });
+    expect(harness.store.rows("vendo_mcp_grants")[0]?.data.revokedAt).toEqual(expect.any(String));
   });
 
   it("consumes an authorization code the moment it is presented, even on PKCE failure", async () => {
@@ -652,6 +781,7 @@ describe("createMcpDoor remote authorization server trust", () => {
       new Request(`${BASE}/authorize`),
       new Request(`${BASE}/authorize`, { method: "POST" }),
       new Request(`${BASE}/token`, { method: "POST" }),
+      new Request(`${BASE}/revoke`, { method: "POST" }),
       new Request(`${BASE}/register`, { method: "POST" }),
       new Request("https://product.example/.well-known/oauth-authorization-server/api/vendo/mcp"),
     ]) {
@@ -1300,6 +1430,18 @@ async function refresh(door: McpDoor, refreshToken: string, clientId: string) {
   }));
 }
 
+async function revoke(door: McpDoor, token: string, clientId: string, tokenTypeHint?: string) {
+  return door.handler(new Request(`${BASE}/revoke`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      token,
+      client_id: clientId,
+      ...(tokenTypeHint === undefined ? {} : { token_type_hint: tokenTypeHint }),
+    }),
+  }));
+}
+
 async function connect(door: McpDoor, accessToken: string) {
   const transport = new StreamableHTTPClientTransport(new URL(BASE), {
     requestInit: { headers: { authorization: `Bearer ${accessToken}` } },
@@ -1337,6 +1479,11 @@ function mcpRequest(accessToken: string, sessionId?: string) {
 async function pkceChallenge(verifier: string): Promise<string> {
   const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier)));
   return Buffer.from(digest).toString("base64url");
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value)));
+  return [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 interface RemoteTokenOverrides {
@@ -1487,6 +1634,16 @@ class TestMcpDoorState implements McpDoorState {
     return sessions;
   }
 
+  async deleteSessionsBySubjectClient(subject: string, clientId: string): Promise<McpStateSession[]> {
+    this.operations.push(`session:delete-client:${subject}:${clientId}`);
+    return this.#deleteSessionsWhere((record) => record.subject === subject && record.clientId === clientId);
+  }
+
+  async deleteSessionsByGrantFamily(familyId: string): Promise<McpStateSession[]> {
+    this.operations.push(`session:delete-family:${familyId}`);
+    return this.#deleteSessionsWhere((record) => record.grantFamilyId === familyId);
+  }
+
   async sweepExpiredSessions(now: number): Promise<McpStateSession[]> {
     this.operations.push("session:sweep");
     const sessions: McpStateSession[] = [];
@@ -1534,6 +1691,17 @@ class TestMcpDoorState implements McpDoorState {
   async deleteReplay(scope: string, key: string): Promise<void> {
     this.operations.push(`replay:delete:${scope}`);
     this.#replay.get(scope)?.delete(key);
+  }
+
+  #deleteSessionsWhere(predicate: (record: SessionStateRecord) => boolean): McpStateSession[] {
+    const sessions: McpStateSession[] = [];
+    for (const [sessionId, record] of this.#sessions) {
+      if (!predicate(record)) continue;
+      sessions.push(record.session);
+      this.#sessions.delete(sessionId);
+      this.#replay.delete(record.session.replayScope);
+    }
+    return sessions;
   }
 }
 

--- a/packages/mcp/src/door.ts
+++ b/packages/mcp/src/door.ts
@@ -95,6 +95,9 @@ export interface McpDoor {
   /** One fetch-style handler serving: MCP Streamable HTTP transport, the OAuth
    * endpoints (§3), and the discovery documents (§5). The umbrella mounts it. */
   handler: (req: Request) => Promise<Response>;
+  /** Host-authorized disconnect for one subject/client pair. Revokes every
+   * existing local grant family and closes its live MCP sessions. */
+  revokeClient: (subject: string, clientId: string) => Promise<void>;
 }
 
 export function createMcpDoor(config: McpDoorConfig): McpDoor {
@@ -105,7 +108,10 @@ export function createMcpDoor(config: McpDoorConfig): McpDoor {
  * It is deliberately not re-exported from the package root. */
 export function createMcpDoorWithState(config: McpDoorConfig, state: McpDoorState): McpDoor {
   const door = new Door(config, state);
-  return { handler: (req) => door.handler(req) };
+  return {
+    handler: (req) => door.handler(req),
+    revokeClient: (subject, clientId) => door.revokeClient(subject, clientId),
+  };
 }
 
 class Door {
@@ -176,6 +182,18 @@ class Door {
     if (endpoint.kind === "token") {
       return req.method === "POST" && this.#config.remoteAs === undefined ? this.#oauth.token(req) : notFound();
     }
+    if (endpoint.kind === "revoke") {
+      if (req.method !== "POST" || this.#config.remoteAs !== undefined) return notFound();
+      const result = await this.#oauth.revoke(req);
+      if (result.grant?.tokenType === "refresh_token") {
+        if (result.grant.familyId === undefined) {
+          await this.#killSubjectClient(result.grant.subject, result.grant.clientId);
+        } else {
+          await this.#killGrantFamily(result.grant.familyId);
+        }
+      }
+      return result.response;
+    }
     if (endpoint.kind === "register") {
       return req.method === "POST" && this.#config.remoteAs === undefined ? this.#oauth.register(req) : notFound();
     }
@@ -205,7 +223,14 @@ class Door {
     const requestedState = requestedSessionId === undefined
       ? undefined
       : await this.#state.getSession(requestedSessionId) ?? undefined;
-    if (requestedSessionId !== undefined && (!requestedState || requestedState.subject !== auth.grant.subject)) {
+    if (
+      requestedSessionId !== undefined
+      && (
+        !requestedState
+        || requestedState.subject !== auth.grant.subject
+        || requestedState.context.mcpConsent.clientId !== auth.grant.clientId
+      )
+    ) {
       return unknownSession();
     }
 
@@ -238,7 +263,8 @@ class Door {
       return requestedState!.handleRequest(req);
     }
 
-    const state = await this.#newSession(auth.grant.subject, principal, consent);
+    const familyId = "familyId" in auth.grant ? auth.grant.familyId : undefined;
+    const state = await this.#newSession(auth.grant.subject, principal, consent, familyId);
     const response = await state.handleRequest(req);
     if (state.sessionId === undefined) await state.close();
     return response;
@@ -248,6 +274,7 @@ class Door {
     subject: string,
     principal: Principal,
     consent: { clientId: string; scopes: string[] },
+    grantFamilyId?: string,
   ): Promise<SessionState> {
     const identity = await this.#hostIdentity();
     let state: SessionState;
@@ -261,6 +288,8 @@ class Door {
         await this.#state.setSession({
           sessionId,
           subject,
+          clientId: consent.clientId,
+          ...(grantFamilyId === undefined ? {} : { grantFamilyId }),
           session: state,
           expiresAt: Date.now() + SESSION_IDLE_MS,
         });
@@ -500,16 +529,44 @@ class Door {
     }
   }
 
+  async revokeClient(subject: string, clientId: string): Promise<void> {
+    await this.#oauth.revokeClient(subject, clientId);
+    await this.#killSubjectClient(subject, clientId);
+    await this.#oauth.auditRevoke(subject, clientId);
+  }
+
+  async #killSubjectClient(subject: string, clientId: string): Promise<void> {
+    await this.#closeSessions(await this.#state.deleteSessionsBySubjectClient(subject, clientId));
+  }
+
+  async #killGrantFamily(familyId: string): Promise<void> {
+    await this.#closeSessions(await this.#state.deleteSessionsByGrantFamily(familyId));
+  }
+
+  async #closeSessions(sessions: McpStateSession[]): Promise<void> {
+    for (const session of sessions) {
+      try {
+        await session.close();
+      } catch {
+        // Revocation must remain fail-closed even if a transport is already closing.
+      }
+    }
+  }
+
   #hostIdentity(): Promise<HostIdentity> {
     this.#identity ??= readHostIdentity();
     return this.#identity;
   }
 }
 
-function endpointFor(path: string): { kind: "mcp" | "authorize" | "token" | "register" | "federate"; mount: string } {
+function endpointFor(path: string): {
+  kind: "mcp" | "authorize" | "token" | "revoke" | "register" | "federate";
+  mount: string;
+} {
   for (const [suffix, kind] of [
     ["/authorize", "authorize"],
     ["/token", "token"],
+    ["/revoke", "revoke"],
     ["/register", "register"],
     ["/federate", "federate"],
   ] as const) {
@@ -546,7 +603,9 @@ function authorizationServerMetadata(origin: string, mount: string) {
     issuer,
     authorization_endpoint: `${issuer}/authorize`,
     token_endpoint: `${issuer}/token`,
+    revocation_endpoint: `${issuer}/revoke`,
     registration_endpoint: `${issuer}/register`,
+    scopes_supported: ["read", "write"],
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code", "refresh_token"],
     token_endpoint_auth_methods_supported: ["none"],

--- a/packages/mcp/src/oauth/server.ts
+++ b/packages/mcp/src/oauth/server.ts
@@ -4,6 +4,7 @@ import type {
   Principal,
   RecordStore,
   StoreAdapter,
+  VendoRecord,
   VendoTheme,
 } from "@vendoai/core";
 import { z } from "zod";
@@ -15,6 +16,7 @@ const ACCESS_TOKEN_SECONDS = 60 * 60;
 const REFRESH_TOKEN_SECONDS = 30 * 24 * 60 * 60;
 const CODE_SECONDS = 60;
 const CONSENT_SECONDS = 10 * 60;
+const CLAIM_ATTEMPTS = 8;
 
 const clientDataSchema = z.object({
   client_name: z.string(),
@@ -40,30 +42,44 @@ const codeGrantSchema = z.object({
   kind: z.literal("code"),
   subject: z.string(),
   clientId: z.string(),
+  familyId: z.string().optional(),
   resource: z.string(),
   scopes: z.array(z.string()),
   codeChallenge: z.string(),
   redirectUri: z.string(),
   expiresAt: z.string(),
+  revokedAt: z.string().optional(),
 });
 
 const accessGrantSchema = z.object({
   kind: z.literal("access"),
   subject: z.string(),
   clientId: z.string(),
+  familyId: z.string().optional(),
   resource: z.string(),
   scopes: z.array(z.string()),
   expiresAt: z.string(),
+  revokedAt: z.string().optional(),
 });
 
 const refreshGrantSchema = z.object({
   kind: z.literal("refresh"),
   subject: z.string(),
   clientId: z.string(),
+  familyId: z.string().optional(),
   resource: z.string(),
   scopes: z.array(z.string()),
   expiresAt: z.string(),
   rotatedTo: z.string().optional(),
+  revokedAt: z.string().optional(),
+});
+
+const grantFamilySchema = z.object({
+  kind: z.literal("family"),
+  subject: z.string(),
+  clientId: z.string(),
+  status: z.enum(["active", "revoked"]),
+  revokedAt: z.string().optional(),
 });
 
 const consentInteractionSchema = z.object({
@@ -84,7 +100,20 @@ type ClientData = z.infer<typeof clientDataSchema>;
 type CodeGrant = z.infer<typeof codeGrantSchema>;
 type AccessGrant = z.infer<typeof accessGrantSchema>;
 type RefreshGrant = z.infer<typeof refreshGrantSchema>;
+type GrantFamily = z.infer<typeof grantFamilySchema>;
 type ConsentInteraction = z.infer<typeof consentInteractionSchema>;
+
+interface RevokedGrant {
+  subject: string;
+  clientId: string;
+  tokenType: "access_token" | "refresh_token";
+  familyId?: string;
+}
+
+interface RevocationResult {
+  response: Response;
+  grant?: RevokedGrant;
+}
 
 export interface AuthenticatedGrant {
   grant: AccessGrant;
@@ -297,21 +326,48 @@ export class OAuthServer {
   ): Promise<Response> {
     const code = `vmcd_${randomBase64Url(32)}`;
     const tokenHash = await sha256Hex(code);
+    const familyId = `mcgf_${randomHex(12)}`;
     const grant: CodeGrant = {
       kind: "code",
       subject,
       clientId: authorization.clientId,
+      familyId,
       resource: authorization.resource,
       scopes: authorization.scopes,
       codeChallenge: authorization.codeChallenge,
       redirectUri: authorization.redirectUri,
       expiresAt: expiresIn(CODE_SECONDS),
     };
-    await this.#store.records(GRANTS_COLLECTION).put({
-      id: `mcpg_${randomHex(12)}`,
-      data: grant,
-      refs: { kind: "code", token_hash: tokenHash },
-    });
+    const family: GrantFamily = {
+      kind: "family",
+      subject,
+      clientId: authorization.clientId,
+      status: "active",
+    };
+    const store = this.#store.records(GRANTS_COLLECTION);
+    await Promise.all([
+      store.put({
+        id: familyId,
+        data: family,
+        refs: {
+          kind: "family",
+          family_id: familyId,
+          subject,
+          client_id: authorization.clientId,
+        },
+      }),
+      store.put({
+        id: `mcpg_${randomHex(12)}`,
+        data: grant,
+        refs: {
+          kind: "code",
+          token_hash: tokenHash,
+          family_id: familyId,
+          subject,
+          client_id: authorization.clientId,
+        },
+      }),
+    ]);
     return oauthRedirect(authorization.redirectUri, { code, state: authorization.state });
   }
 
@@ -353,8 +409,88 @@ export class OAuthServer {
     });
     if (!record) return null;
     const parsed = accessGrantSchema.safeParse(record.data);
-    if (!parsed.success || expired(parsed.data.expiresAt)) return null;
+    if (
+      !parsed.success
+      || parsed.data.revokedAt !== undefined
+      || expired(parsed.data.expiresAt)
+      || !(await this.#isFamilyActive(parsed.data.familyId))
+    ) return null;
     return { grant: parsed.data, tokenWasPresented: true };
+  }
+
+  async revoke(req: Request): Promise<RevocationResult> {
+    if (!contentType(req).startsWith("application/x-www-form-urlencoded")) {
+      return { response: oauthJsonError("invalid_request", "Expected application/x-www-form-urlencoded") };
+    }
+    const form = new URLSearchParams(await req.text());
+    const token = form.get("token");
+    const clientId = form.get("client_id");
+    if (!token || !clientId) {
+      return { response: oauthJsonError("invalid_request", "token and client_id are required") };
+    }
+    try {
+      await this.#resolveClient(clientId);
+    } catch (error) {
+      return { response: oauthJsonError("invalid_client", errorMessage(error)) };
+    }
+
+    const store = this.#store.records(GRANTS_COLLECTION);
+    if (!store.claim) {
+      return { response: oauthJsonError("server_error", "The configured store does not support atomic token claims") };
+    }
+    const tokenHash = await sha256Hex(token);
+    const hint = form.get("token_type_hint");
+    const kinds = hint === "refresh_token"
+      ? ["refresh", "access"] as const
+      : ["access", "refresh"] as const;
+    for (const kind of kinds) {
+      const record = await findOne(store, { kind, token_hash: tokenHash });
+      if (!record) continue;
+      if (kind === "access") {
+        const parsed = accessGrantSchema.safeParse(record.data);
+        if (!parsed.success) return { response: revocationSuccess() };
+        if (parsed.data.clientId !== clientId) {
+          return { response: oauthJsonError("invalid_client", "Token was not issued to this client") };
+        }
+        const changed = await this.#revokeTokenRecord(record, accessGrantSchema);
+        if (changed) await this.#audit({ kind: "user", subject: parsed.data.subject }, clientId, "revoke");
+        return {
+          response: revocationSuccess(),
+          grant: {
+            subject: parsed.data.subject,
+            clientId,
+            tokenType: "access_token",
+            ...(parsed.data.familyId === undefined ? {} : { familyId: parsed.data.familyId }),
+          },
+        };
+      }
+
+      const parsed = refreshGrantSchema.safeParse(record.data);
+      if (!parsed.success) return { response: revocationSuccess() };
+      if (parsed.data.clientId !== clientId) {
+        return { response: oauthJsonError("invalid_client", "Token was not issued to this client") };
+      }
+      const changed = parsed.data.familyId === undefined
+        ? await this.#revokeSubjectClientGrants(parsed.data.subject, clientId)
+        : await this.#revokeFamily(parsed.data.familyId);
+      if (changed) await this.#audit({ kind: "user", subject: parsed.data.subject }, clientId, "revoke");
+      return {
+        response: revocationSuccess(),
+        grant: {
+          subject: parsed.data.subject,
+          clientId,
+          tokenType: "refresh_token",
+          ...(parsed.data.familyId === undefined ? {} : { familyId: parsed.data.familyId }),
+        },
+      };
+    }
+    return { response: revocationSuccess() };
+  }
+
+  /** Host-side per-client disconnect. The caller owns host authorization for
+   * this API; the door atomically revokes every existing grant family. */
+  async revokeClient(subject: string, clientId: string): Promise<boolean> {
+    return this.#revokeSubjectClientGrants(subject, clientId);
   }
 
   async principal(subject: string): Promise<Principal | null> {
@@ -380,7 +516,7 @@ export class OAuthServer {
     const store = this.#store.records(GRANTS_COLLECTION);
     const record = await findOne(store, { kind: "code", token_hash: await sha256Hex(code) });
     const parsed = codeGrantSchema.safeParse(record?.data);
-    if (!record || !parsed.success || expired(parsed.data.expiresAt)) {
+    if (!record || !parsed.success || parsed.data.revokedAt !== undefined || expired(parsed.data.expiresAt)) {
       return oauthJsonError("invalid_grant", "Authorization code is invalid or expired");
     }
     // The code is single-use the moment it is PRESENTED, not only when it is
@@ -399,6 +535,9 @@ export class OAuthServer {
     }
     if (await sha256Base64Url(verifier) !== grant.codeChallenge) {
       return oauthJsonError("invalid_grant", "PKCE verification failed");
+    }
+    if (!(await this.#isFamilyActive(grant.familyId))) {
+      return oauthJsonError("invalid_grant", "Authorization grant is revoked");
     }
     const requestedResource = form.get("resource");
     if (requestedResource !== null && !sameCanonicalUri(requestedResource, grant.resource)) {
@@ -420,19 +559,28 @@ export class OAuthServer {
     const store = this.#store.records(GRANTS_COLLECTION);
     const record = await findOne(store, { kind: "refresh", token_hash: await sha256Hex(refreshToken) });
     const parsed = refreshGrantSchema.safeParse(record?.data);
-    if (!record || !parsed.success || expired(parsed.data.expiresAt) || parsed.data.clientId !== clientId) {
+    if (
+      !record
+      || !parsed.success
+      || parsed.data.revokedAt !== undefined
+      || expired(parsed.data.expiresAt)
+      || parsed.data.clientId !== clientId
+    ) {
       return oauthJsonError("invalid_grant", "Refresh token is invalid or expired");
     }
     const grant = parsed.data;
     if (grant.rotatedTo !== undefined) {
-      await this.#revokeSubjectClient(grant.subject, grant.clientId);
+      await this.#revokeGrant(grant);
       await this.#audit({ kind: "user", subject: grant.subject }, grant.clientId, "revoke");
       return oauthJsonError("invalid_grant", "Refresh token reuse detected");
+    }
+    if (!(await this.#isFamilyActive(grant.familyId))) {
+      return oauthJsonError("invalid_grant", "Refresh token is invalid or expired");
     }
     // 10-mcp §3: principal() is the kill switch. A refresh 30 days later must
     // not mint a fresh token window for a subject the host has since revoked.
     if ((await this.#oauth.principal(grant.subject)) === null) {
-      await this.#revokeSubjectClient(grant.subject, grant.clientId);
+      await this.#revokeSubjectClientGrants(grant.subject, grant.clientId);
       await this.#audit({ kind: "user", subject: grant.subject }, grant.clientId, "revoke");
       return oauthJsonError("invalid_grant", "Subject is no longer authorized");
     }
@@ -454,15 +602,18 @@ export class OAuthServer {
       ...(record.refs === undefined ? {} : { refs: record.refs }),
     });
     if (!claimed) {
-      await this.#revokeSubjectClient(grant.subject, grant.clientId);
+      await this.#revokeGrant(grant);
       await this.#audit({ kind: "user", subject: grant.subject }, grant.clientId, "revoke");
       return oauthJsonError("invalid_grant", "Refresh token reuse detected");
+    }
+    if (!(await this.#isFamilyActive(grant.familyId))) {
+      return oauthJsonError("invalid_grant", "Refresh token is invalid or expired");
     }
     await this.#audit({ kind: "user", subject: grant.subject }, grant.clientId, "refresh");
     return json(publicTokenResponse(tokens), 200, tokenHeaders());
   }
 
-  async #issueTokens(source: Pick<CodeGrant, "subject" | "clientId" | "resource" | "scopes">): Promise<{
+  async #issueTokens(source: Pick<CodeGrant, "subject" | "clientId" | "familyId" | "resource" | "scopes">): Promise<{
     access_token: string;
     token_type: "Bearer";
     expires_in: number;
@@ -475,6 +626,7 @@ export class OAuthServer {
     const binding = {
       subject: source.subject,
       clientId: source.clientId,
+      ...(source.familyId === undefined ? {} : { familyId: source.familyId }),
       resource: source.resource,
       scopes: source.scopes,
     };
@@ -490,7 +642,11 @@ export class OAuthServer {
     };
     const accessGrantId = `mcpg_${randomHex(12)}`;
     const refreshGrantId = `mcpg_${randomHex(12)}`;
-    const refs = { subject: source.subject, client_id: source.clientId };
+    const refs = {
+      subject: source.subject,
+      client_id: source.clientId,
+      ...(source.familyId === undefined ? {} : { family_id: source.familyId }),
+    };
     await Promise.all([
       this.#store.records(GRANTS_COLLECTION).put({
         id: accessGrantId,
@@ -521,10 +677,99 @@ export class OAuthServer {
     return { id: clientId, name: parsed.data.client_name, redirectUris: parsed.data.redirect_uris };
   }
 
-  async #revokeSubjectClient(subject: string, clientId: string): Promise<void> {
+  async #isFamilyActive(familyId: string | undefined): Promise<boolean> {
+    if (familyId === undefined) return true; // compatibility for pre-family grants
+    const record = await this.#store.records(GRANTS_COLLECTION).get(familyId);
+    const parsed = grantFamilySchema.safeParse(record?.data);
+    return parsed.success && parsed.data.status === "active";
+  }
+
+  async #revokeGrant(grant: RefreshGrant): Promise<boolean> {
+    return grant.familyId === undefined
+      ? this.#revokeSubjectClientGrants(grant.subject, grant.clientId)
+      : this.#revokeFamily(grant.familyId);
+  }
+
+  async #revokeFamily(familyId: string): Promise<boolean> {
     const store = this.#store.records(GRANTS_COLLECTION);
-    const records = await listAll(store, { subject, client_id: clientId });
-    await Promise.all(records.map((record) => store.delete(record.id)));
+    if (!store.claim) throw new Error("The configured store does not support atomic token claims");
+    for (let attempt = 0; attempt < CLAIM_ATTEMPTS; attempt += 1) {
+      const record = await store.get(familyId);
+      const parsed = grantFamilySchema.safeParse(record?.data);
+      if (!record || !parsed.success || parsed.data.status === "revoked") return false;
+      const replacement: GrantFamily = {
+        ...parsed.data,
+        status: "revoked",
+        revokedAt: new Date().toISOString(),
+      };
+      if (await store.claim(record, {
+        data: replacement,
+        ...(record.refs === undefined ? {} : { refs: record.refs }),
+      })) return true;
+    }
+    throw new Error("Grant family changed too many times during revocation");
+  }
+
+  async #revokeSubjectClientGrants(subject: string, clientId: string): Promise<boolean> {
+    const store = this.#store.records(GRANTS_COLLECTION);
+    if (!store.claim) throw new Error("The configured store does not support atomic token claims");
+    let changed = false;
+    const families = await listAll(store, { kind: "family", subject, client_id: clientId });
+    for (const family of families) {
+      changed = await this.#revokeFamily(family.id) || changed;
+    }
+
+    // Outstanding grants minted before family anchors shipped remain valid
+    // across a rolling deployment. Revoke those with the same guarded UPDATE
+    // pattern instead of list-then-delete.
+    const legacy = await listAll(store, { subject, client_id: clientId });
+    for (const record of legacy) {
+      const access = accessGrantSchema.safeParse(record.data);
+      if (access.success && access.data.familyId === undefined) {
+        changed = await this.#revokeTokenRecord(record, accessGrantSchema) || changed;
+        continue;
+      }
+      const refresh = refreshGrantSchema.safeParse(record.data);
+      if (refresh.success && refresh.data.familyId === undefined) {
+        changed = await this.#revokeTokenRecord(record, refreshGrantSchema) || changed;
+      }
+    }
+    // Pre-family authorization codes did not carry subject/client refs. Their
+    // one-minute window still overlaps rolling deploys, so scan the bounded
+    // code set, filter by parsed binding, and guard-update matches as revoked.
+    const legacyCodes = await listAll(store, { kind: "code" });
+    for (const record of legacyCodes) {
+      const code = codeGrantSchema.safeParse(record.data);
+      if (
+        code.success
+        && code.data.familyId === undefined
+        && code.data.subject === subject
+        && code.data.clientId === clientId
+      ) {
+        changed = await this.#revokeTokenRecord(record, codeGrantSchema) || changed;
+      }
+    }
+    return changed;
+  }
+
+  async #revokeTokenRecord<T extends CodeGrant | AccessGrant | RefreshGrant>(
+    initial: VendoRecord,
+    schema: z.ZodType<T>,
+  ): Promise<boolean> {
+    const store = this.#store.records(GRANTS_COLLECTION);
+    if (!store.claim) throw new Error("The configured store does not support atomic token claims");
+    let record: VendoRecord | null = initial;
+    for (let attempt = 0; attempt < CLAIM_ATTEMPTS; attempt += 1) {
+      const parsed = schema.safeParse(record?.data);
+      if (!record || !parsed.success || parsed.data.revokedAt !== undefined) return false;
+      const replacement = { ...parsed.data, revokedAt: new Date().toISOString() };
+      if (await store.claim(record, {
+        data: replacement,
+        ...(record.refs === undefined ? {} : { refs: record.refs }),
+      })) return true;
+      record = await store.get(initial.id);
+    }
+    throw new Error("Token grant changed too many times during revocation");
   }
 
   async #audit(principal: Principal, clientId: string, event: "issue" | "refresh" | "register" | "revoke"): Promise<void> {
@@ -990,4 +1235,8 @@ function publicTokenResponse(tokens: {
 
 function tokenHeaders(): Record<string, string> {
   return { "cache-control": "no-store", pragma: "no-cache" };
+}
+
+function revocationSuccess(): Response {
+  return new Response(null, { status: 200, headers: tokenHeaders() });
 }

--- a/packages/mcp/src/state.test.ts
+++ b/packages/mcp/src/state.test.ts
@@ -11,6 +11,8 @@ describe("InMemoryMcpDoorState", () => {
     state.setSession({
       sessionId: "mcps_1",
       subject: "user_1",
+      clientId: "mcpc_1",
+      grantFamilyId: "mcgf_1",
       session,
       expiresAt: 10,
     });
@@ -40,6 +42,41 @@ describe("InMemoryMcpDoorState", () => {
     expect(state.getReplay("durable_1", "fingerprint", 10)).toBeNull();
   });
 
+  it("selectively removes live sessions by client or grant family", () => {
+    const state = new InMemoryMcpDoorState();
+    const familyA = testSession("mcps_a", "replay_a", "user_1", "mcpc_a");
+    const familyB = testSession("mcps_b", "replay_b", "user_1", "mcpc_a");
+    const otherClient = testSession("mcps_c", "replay_c", "user_1", "mcpc_b");
+    state.setSession({
+      sessionId: "mcps_a",
+      subject: "user_1",
+      clientId: "mcpc_a",
+      grantFamilyId: "mcgf_a",
+      session: familyA,
+      expiresAt: 20,
+    });
+    state.setSession({
+      sessionId: "mcps_b",
+      subject: "user_1",
+      clientId: "mcpc_a",
+      grantFamilyId: "mcgf_b",
+      session: familyB,
+      expiresAt: 20,
+    });
+    state.setSession({
+      sessionId: "mcps_c",
+      subject: "user_1",
+      clientId: "mcpc_b",
+      grantFamilyId: "mcgf_c",
+      session: otherClient,
+      expiresAt: 20,
+    });
+
+    expect(state.deleteSessionsByGrantFamily("mcgf_a")).toEqual([familyA]);
+    expect(state.deleteSessionsBySubjectClient("user_1", "mcpc_a")).toEqual([familyB]);
+    expect(state.getSession("mcps_c")).toBe(otherClient);
+  });
+
   it("expires replay records and enforces the per-scope capacity", () => {
     const state = new InMemoryMcpDoorState();
     const options = { subject: "user_1", expiresAt: 20, capacity: 2 };
@@ -57,6 +94,7 @@ function testSession(
   sessionId: string,
   replayScope: string,
   subject: string,
+  clientId = "mcpc_1",
 ): McpStateSession {
   return {
     subject,
@@ -66,7 +104,7 @@ function testSession(
       venue: "mcp",
       presence: "present",
       sessionId,
-      mcpConsent: { clientId: "mcpc_1", scopes: ["read", "write"] },
+      mcpConsent: { clientId, scopes: ["read", "write"] },
     },
     async handleRequest() {
       return new Response();

--- a/packages/mcp/src/state.ts
+++ b/packages/mcp/src/state.ts
@@ -21,6 +21,8 @@ export interface McpStateSession {
 export interface SessionStateRecord {
   sessionId: string;
   subject: string;
+  clientId: string;
+  grantFamilyId?: string;
   session: McpStateSession;
   expiresAt: number;
 }
@@ -56,6 +58,10 @@ export interface McpDoorState {
   deleteSession(sessionId: string): MaybePromise<McpStateSession | null>;
   /** Removes every session and replay record owned by the subject. */
   deleteSessionsBySubject(subject: string): MaybePromise<McpStateSession[]>;
+  /** Removes live sessions for one host subject/client grant set. */
+  deleteSessionsBySubjectClient(subject: string, clientId: string): MaybePromise<McpStateSession[]>;
+  /** Removes live sessions descended from one local OAuth grant family. */
+  deleteSessionsByGrantFamily(familyId: string): MaybePromise<McpStateSession[]>;
   /** Atomically removes and returns every session whose expiry is <= now. */
   sweepExpiredSessions(now: number): MaybePromise<McpStateSession[]>;
 
@@ -131,6 +137,14 @@ export class InMemoryMcpDoorState implements McpDoorState {
     return sessions;
   }
 
+  deleteSessionsBySubjectClient(subject: string, clientId: string): McpStateSession[] {
+    return this.#deleteSessionsWhere((record) => record.subject === subject && record.clientId === clientId);
+  }
+
+  deleteSessionsByGrantFamily(familyId: string): McpStateSession[] {
+    return this.#deleteSessionsWhere((record) => record.grantFamilyId === familyId);
+  }
+
   sweepExpiredSessions(now: number): McpStateSession[] {
     const expired: McpStateSession[] = [];
     for (const [sessionId, record] of [...this.#sessions]) {
@@ -175,5 +189,15 @@ export class InMemoryMcpDoorState implements McpDoorState {
     const sessions = this.#subjectSessions.get(subject);
     sessions?.delete(sessionId);
     if (sessions?.size === 0) this.#subjectSessions.delete(subject);
+  }
+
+  #deleteSessionsWhere(predicate: (record: SessionStateRecord) => boolean): McpStateSession[] {
+    const sessions: McpStateSession[] = [];
+    for (const [sessionId, record] of [...this.#sessions]) {
+      if (!predicate(record)) continue;
+      const session = this.deleteSession(sessionId);
+      if (session !== null) sessions.push(session);
+    }
+    return sessions;
   }
 }


### PR DESCRIPTION
## Summary

- add the local OAuth door POST /revoke endpoint with RFC 7009 form handling, optional token_type_hint, and empty HTTP 200 responses for unknown tokens
- make refresh-token revocation atomically invalidate its complete grant family, including access tokens and rotated successors, using guarded RecordStore.claim updates
- expose a per-subject/per-client host revokeClient API that also closes matching MCP sessions
- advertise revocation_endpoint and scopes_supported from the same canonical issuer used by the existing authorization and token endpoints
- preserve rolling compatibility for grants created before family anchors and keep docs/contracts changes additive

## Verification

- pnpm build && pnpm test && pnpm typecheck && pnpm lint — passed
- @vendoai/mcp unit and coverage suite — 51 tests passed; 92.16% statement/line coverage
- MCP E2E suite — 17 passed, 4 environment-gated skips; both PGlite-backed revocation tests passed
- added an environment-gated Postgres barrier race covering refresh rotation versus family revocation; it typechecks and skips when POSTGRES_URL is absent
- pnpm changeset status --since=origin/main — passed
- git diff --check origin/main...HEAD — passed

## CI status

PR integration, perf, audit, and changeset-status checks passed. The aggregate CI coverage job inherits the current main failure in unchanged packages/automations (90.82% lines versus a 91% floor): main run https://github.com/runvendo/vendo/actions/runs/29384074108 and PR run https://github.com/runvendo/vendo/actions/runs/29386439612. The MCP package coverage gate passes independently at 92.16%.

## Rebase / proxy evidence

Rebase-checked immediately before publication against origin/main at 0032a6790d6d6ae692d2b9224ccb824e4cd45ec4. PR #191 remains open; the new metadata URL is derived from the existing canonical issuer alongside authorization_endpoint and token_endpoint, with no independent request-host concatenation.

Linear: ENG-269
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds RFC 7009 token revocation to `@vendoai/mcp`, including a `POST /revoke` endpoint, atomic grant-family revocation, and a per-client host disconnect that also closes live sessions. Addresses Linear ENG-269 by enabling per-client session kill, binding sessions to client/grant family, and advertising `revocation_endpoint` and `scopes_supported`.

- **New Features**
  - Added `{mount}/revoke` (x-www-form-urlencoded) with `token`, required `client_id`, and optional `token_type_hint`; unknown tokens/hints return empty 200; cross-client attempts return `invalid_client`.
  - Access-token revocation invalidates that token only.
  - Refresh-token revocation atomically revokes its grant family (access tokens and rotated successors) via `RecordStore.claim`, and closes matching MCP sessions; pre-family codes/tokens are revoked with guarded updates.
  - Added `McpDoor.revokeClient(subject, clientId)` to revoke all families for that subject/client and close live sessions.
  - Discovery advertises `revocation_endpoint` and `scopes_supported`; in `remoteAs` mode, local `/revoke` returns 404 and revocation is delegated to the external AS.

<sup>Written for commit 0989aa57ddaf0c4e2906d01042406f891aa15fa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

