### PR TITLE
test(automations): cover claim/cancellation paths from #176 (fixes coverage gate)

### DIFF
--- a/packages/automations/src/engine.test.ts
+++ b/packages/automations/src/engine.test.ts
@@ -608,6 +608,51 @@ describe("schedule, webhook, and host triggers", () => {
     await expect(engine.tick()).resolves.toHaveLength(1);
   });
 
+  it.each([
+    ["atomic", memoryStoreAdapter],
+    ["non-atomic", memoryStoreWithoutAtomic],
+  ])("initializes a future schedule cursor without firing via the %s store path", async (_path, createStore) => {
+    const store = createStore();
+    const doc = app("app_schedule_future", {
+      on: { kind: "schedule", at: "2026-07-12T13:00:00.000Z" },
+      run: { kind: "steps", steps: [] },
+    });
+    await seedApp(store, doc, "user_a", true);
+    const engine = createAutomations({
+      apps: appsDouble(), tools: registry(), guard: new GuardDouble(), store, now: () => NOW,
+    });
+
+    await expect(engine.tick()).resolves.toEqual([]);
+    expect((await store.records("automations:schedule").get(doc.id))?.data).toEqual({
+      lastFiredAt: NOW.toISOString(),
+    });
+  });
+
+  it("atomically claims an uninitialized due schedule across engine instances", async () => {
+    const store = memoryStoreAdapter();
+    let calls = 0;
+    const apps = appsDouble(async () => {
+      calls += 1;
+      return { status: "ok", output: {} };
+    });
+    const doc = app("app_schedule_first_claim", {
+      on: { kind: "schedule", at: "2026-07-12T11:00:00.000Z" },
+      run: { kind: "steps", steps: [{ id: "run", tool: "fn:main" }] },
+    });
+    await seedApp(store, doc, "user_a", true);
+    const engine = createAutomations({ apps, tools: registry(), guard: new GuardDouble(), store, now: () => NOW });
+    const peer = createAutomations({ apps, tools: registry(), guard: new GuardDouble(), store, now: () => NOW });
+
+    const ticks = await Promise.all([engine.tick(), peer.tick()]);
+
+    expect(ticks.flat()).toHaveLength(1);
+    expect(calls).toBe(1);
+    expect((await store.records("automations:schedule").get(doc.id))?.data).toEqual({
+      lastFiredAt: NOW.toISOString(),
+      firedAt: NOW.toISOString(),
+    });
+  });
+
   it("verifies HMAC vectors, dedupes deliveries, rejects bad/stale signatures once, and emits matching host events", async () => {
     const store = memoryStoreAdapter();
     const guard = new GuardDouble();
@@ -689,6 +734,45 @@ describe("schedule, webhook, and host triggers", () => {
     expect(await engine.emit("invoice.paid", {}, ctx("other").principal)).toEqual([]);
     expect(observed).toContainEqual({ payload: { answer: 42 } });
     expect(observed).toContainEqual({ payload: { invoice: "inv_1" } });
+  });
+
+  it("dedupes webhook deliveries when the store lacks atomic claims", async () => {
+    const store = memoryStoreWithoutAtomic();
+    const external = app("app_webhook_fallback", {
+      on: { kind: "external", connector: "github", event: "push" },
+      run: { kind: "steps", steps: [] },
+    });
+    await seedApp(store, external);
+    const engine = createAutomations({
+      apps: appsDouble(), tools: registry(), guard: new GuardDouble(), store, now: () => NOW,
+    });
+    await engine.enable(external.id, ctx());
+    const secret = ((await store.records("automations:webhook").get(external.id))?.data as { secret: string }).secret;
+    const body = JSON.stringify({ answer: 42 });
+    const timestamp = String(NOW.getTime() / 1_000);
+    const deliveryId = "delivery_fallback";
+    const signature = await sign(secret, deliveryId, timestamp, body);
+    const request = () => new Request("https://example.test/api/webhooks/github", {
+      method: "POST",
+      headers: {
+        "webhook-id": deliveryId,
+        "webhook-timestamp": timestamp,
+        "webhook-signature": `v1,${signature}`,
+      },
+      body,
+    });
+
+    const first = await engine.webhook(request());
+    const duplicate = await engine.webhook(request());
+
+    expect(await first.json()).toMatchObject({ runIds: [expect.stringMatching(/^run_/)] });
+    expect(await duplicate.json()).toEqual({ deduped: true });
+    expect((await store.records("vendo_runs").list()).records).toHaveLength(1);
+    expect((await store.records("automations:deliveries").get(`${external.id}:${deliveryId}`))?.data).toEqual({
+      appId: external.id,
+      deliveryId,
+      receivedAt: NOW.toISOString(),
+    });
   });
 });
 

--- a/packages/core/src/conformance/index.test.ts
+++ b/packages/core/src/conformance/index.test.ts
@@ -149,6 +149,47 @@ describe("StoreAdapter conformance", () => {
     expect(listed.records.map((record) => record.id)).toEqual(["third", "second", "first"]);
     expect(listed.records.some((record) => "seq" in record)).toBe(false);
   });
+
+  it("memoryStoreAdapter atomic writes enforce absence and revision guards", async () => {
+    const records = memoryStoreAdapter().records("atomic");
+    const input = {
+      id: "atomic_1",
+      data: { status: "draft", nested: { count: 1 } },
+      refs: { owner: "user_1" },
+    };
+
+    const inserted = await records.atomic.insertIfAbsent(input);
+    expect(inserted).toMatchObject({
+      id: input.id,
+      data: input.data,
+      refs: input.refs,
+      revision: "1",
+    });
+    expect(await records.atomic.insertIfAbsent({ ...input, data: { status: "duplicate" } })).toBeNull();
+    expect(await records.atomic.compareAndSwap({ id: "missing", data: {} }, "1")).toBeNull();
+    expect(await records.atomic.compareAndSwap({ ...input, data: { status: "wrong revision" } }, "0")).toBeNull();
+
+    input.data.nested.count = 2;
+    input.refs.owner = "mutated";
+    expect(await records.get(input.id)).toMatchObject({
+      data: { status: "draft", nested: { count: 1 } },
+      refs: { owner: "user_1" },
+    });
+
+    const swapped = await records.atomic.compareAndSwap({
+      id: input.id,
+      data: { status: "published" },
+      refs: { owner: "user_2" },
+    }, "1");
+    expect(swapped).toMatchObject({
+      id: input.id,
+      data: { status: "published" },
+      refs: { owner: "user_2" },
+      revision: "2",
+      createdAt: inserted?.createdAt,
+    });
+    expect(await records.get(input.id)).toEqual(swapped);
+  });
 });
 
 describe("ToolRegistry conformance", () => {
@@ -254,6 +295,12 @@ describe("host seam conformance", () => {
 
   it("accepts a scripted AgentRunner that executes the supplied echo registry", async () => {
     const runner: AgentRunner = async (task, runContext) => {
+      expect(await task.tools.descriptors()).toEqual([{
+        name: "conformance_echo",
+        description: "Echo conformance input",
+        inputSchema: { type: "object" },
+        risk: "read",
+      }]);
       const call: ToolCall = { id: "call_echo", tool: "conformance_echo", args: { ping: true } };
       const outcome = await task.tools.execute(call, runContext);
       return {


### PR DESCRIPTION
## Summary

- exercise atomic first-write schedule claims across competing engine instances
- cover schedule cursor initialization through both atomic and non-atomic store paths
- cover webhook delivery deduplication when the store lacks atomic claims
- cover core atomic-store conformance for insert-if-absent, compare-and-swap, revision guards, clone isolation, and descriptor exposure
- raise `@vendoai/automations` line coverage from 90.82% to 91.70% and `@vendoai/core` from 95.21% to 97.68%

## Context

This restores the coverage gate broken in [the red main run](https://github.com/runvendo/vendo/actions/runs/29384074108) after [PR #176](https://github.com/runvendo/vendo/pull/176).

The core package's 97% shortfall was initially masked by Turbo's fail-fast behavior on automations. The parent of #176 measures 97.45% core line coverage, confirming the regression came from #176.

## Validation

- `pnpm build`
- `pnpm test`
- `pnpm --filter @vendoai/automations test:coverage`
- `pnpm --filter @vendoai/core test:coverage`
- `pnpm typecheck`
- `pnpm lint`
