### PR TITLE
feat(cli): fill all VendoTheme slots in theme extraction (ENG-242)

### DIFF
--- a/corpus/harness/src/clone.ts
+++ b/corpus/harness/src/clone.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { realpathSync } from "node:fs";
 import { cp, mkdir, realpath, rm } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -29,7 +30,18 @@ const defaultWorkspaceRoot = path.resolve(fileURLToPath(new URL("../../../", imp
 
 function runGit(gitBin: string, args: readonly string[], cwd: string): Promise<CommandResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn(gitBin, args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+    const targetDir = args[0] === "-C" && args[1] ? args[1] : cwd;
+    const child = spawn(gitBin, args, {
+      cwd,
+      env: {
+        ...process.env,
+        // All corpus clones are direct children of .repos. Even if a caller
+        // forgets the toplevel identity check, Git must not discover beyond
+        // that cache boundary.
+        GIT_CEILING_DIRECTORIES: realpathSync(path.dirname(targetDir)),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
     let stdout = "";
     let stderr = "";
     child.stdout.setEncoding("utf8");

--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -336,16 +336,24 @@ describe("vendo init", () => {
     // resolve to concrete hex/px (the jail knows no host custom properties).
     await writeFile(join(root, "app", "globals.css"),
       ":root { --background: #fafafa; --brand-hue: 262 83% 58%; --primary: hsl(var(--brand-hue)); " +
-      "--foreground: oklch(0.205 0 0); --card: 0 0% 100%; --radius: 0.625rem; }\n");
+      "--primary-foreground: #ffffff; --foreground: oklch(0.205 0 0); --card: 0 0% 100%; " +
+      "--border: #dedede; --destructive: #b91c1c; --font-heading: Newsreader, serif; " +
+      "--density: compact; --motion: reduced; --radius: 0.625rem; }\n");
     await runInit({ targetDir: root, yes: true, output: output().output });
     expect(JSON.parse(await readFile(join(root, ".vendo", "theme.json"), "utf8"))).toMatchObject({
       colors: {
         background: "#fafafa",
         accent: "#7c3bed",
+        accentText: "#ffffff",
+        border: "#dedede",
+        danger: "#b91c1c",
         text: "#171717",
         surface: "#ffffff",
       },
+      typography: { headingFamily: "Newsreader, serif" },
       radius: { medium: "10px" },
+      density: "compact",
+      motion: "reduced",
     });
   });
 

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -17,22 +17,7 @@ import {
   writeText,
 } from "./shared.js";
 
-const DEFAULT_THEME = {
-  colors: {
-    background: "#ffffff",
-    surface: "#f8fafc",
-    text: "#0f172a",
-    muted: "#64748b",
-    accent: "#2563eb",
-    accentText: "#ffffff",
-    danger: "#dc2626",
-    border: "#e2e8f0",
-  },
-  typography: { fontFamily: "system-ui, sans-serif", baseSize: "16px" },
-  radius: { small: "4px", medium: "8px", large: "12px" },
-  density: "comfortable",
-  motion: "full",
-} as const;
+const DEFAULT_RADIUS = { small: "4px", large: "12px" } as const;
 
 async function extractTheme(root: string): Promise<VendoTheme> {
   const { slots } = await extractThemeSlots(root);
@@ -47,21 +32,22 @@ async function extractTheme(root: string): Promise<VendoTheme> {
       text: slots.text,
       muted: slots.mutedText,
       accent: slots.accent,
-      accentText: DEFAULT_THEME.colors.accentText,
-      danger: DEFAULT_THEME.colors.danger,
-      border: DEFAULT_THEME.colors.border,
+      accentText: slots.accentText,
+      danger: slots.danger,
+      border: slots.border,
     },
     typography: {
       fontFamily: slots.fontFamily,
+      headingFamily: slots.headingFamily,
       baseSize: slots.baseSize,
     },
     radius: {
-      small: deriveRadius(0.5, DEFAULT_THEME.radius.small),
+      small: deriveRadius(0.5, DEFAULT_RADIUS.small),
       medium: slots.radius,
-      large: deriveRadius(1.5, DEFAULT_THEME.radius.large),
+      large: deriveRadius(1.5, DEFAULT_RADIUS.large),
     },
-    density: DEFAULT_THEME.density,
-    motion: DEFAULT_THEME.motion,
+    density: slots.density,
+    motion: slots.motion,
   };
 }
 

--- a/packages/vendo/src/cli/theme/extract-theme.test.ts
+++ b/packages/vendo/src/cli/theme/extract-theme.test.ts
@@ -1,0 +1,155 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { extractTheme } from "./extract-theme.js";
+
+const cleanup: string[] = [];
+const appsDir = fileURLToPath(new URL("../../../../../apps/", import.meta.url));
+
+afterEach(async () => {
+  await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe("extractTheme host evidence", () => {
+  it("recovers Maple-style next/font, monochrome accent, generic radius, density, and motion", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-theme-maple-"));
+    cleanup.push(root);
+    await mkdir(join(root, "app"), { recursive: true });
+    await writeFile(join(root, "package.json"), "{}\n");
+    await writeFile(join(root, "app", "layout.tsx"), `
+      import { Inter } from "next/font/google";
+      import "./globals.css";
+      const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
+      export default function Layout({ children }) {
+        return <html className={inter.variable}><body className="bg-bg text-ink">{children}</body></html>;
+      }
+    `);
+    await writeFile(join(root, "app", "globals.css"), `
+      :root {
+        --color-bg: #fbfbfa;
+        --color-surface: #ffffff;
+        --color-ink: #111111;
+        --color-muted: #908c85;
+        --color-border: #ecebe8;
+        --color-neg: #b0473a;
+        --radius-card: 14px;
+        --font-sans: var(--font-inter);
+      }
+    `);
+    await writeFile(join(root, "app", "page.tsx"), `
+      export default function Page() { return <>
+        <button className="bg-ink text-white rounded-lg h-8 text-[13px] transition-colors" />
+        <button className="bg-ink text-white rounded-lg h-8 text-[13px] transition-colors" />
+        <button className="bg-ink text-white rounded-lg h-8 text-[13px] transition-colors" />
+        <button className="bg-ink text-white rounded-lg h-8 text-[13px] transition-colors" />
+        <button className="bg-ink text-white rounded-lg h-8 text-[13px] transition-colors" />
+        <button className="bg-ink text-white rounded-lg h-8 text-[13px] transition-colors" />
+      </>; }
+    `);
+
+    const result = await extractTheme(root);
+    expect(result.slots).toMatchObject({
+      accent: "#111111",
+      border: "#ecebe8",
+      danger: "#b0473a",
+      accentText: "#ffffff",
+      radius: "8px",
+      fontFamily: "Inter, sans-serif",
+      headingFamily: "Inter, sans-serif",
+      density: "compact",
+      motion: "full",
+    });
+  });
+
+  it("fails closed when source utility evidence is tied or too weak", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-theme-ambiguous-"));
+    cleanup.push(root);
+    await mkdir(join(root, "app"), { recursive: true });
+    await writeFile(join(root, "package.json"), "{}\n");
+    await writeFile(join(root, "app", "layout.tsx"), `
+      import "./globals.css";
+      export default function Layout({ children }) {
+        return <html><body>{children}</body></html>;
+      }
+    `);
+    await writeFile(join(root, "app", "globals.css"), `
+      :root { --color-cedar: #266755; --color-ocean: #1d4ed8; }
+    `);
+    await writeFile(join(root, "app", "page.tsx"), `
+      export default function Page() { return <>
+        ${Array.from({ length: 6 }, () => '<button className="bg-cedar rounded-md h-8 text-sm" />').join("\n")}
+        ${Array.from({ length: 6 }, () => '<button className="bg-ocean rounded-lg h-10 text-base" />').join("\n")}
+      </>; }
+    `);
+
+    const result = await extractTheme(root);
+    expect(result.defaulted).toEqual(expect.arrayContaining(["accent", "radius", "density", "motion"]));
+    expect(result.slots).toMatchObject({
+      accent: "#2563eb",
+      radius: "8px",
+      density: "comfortable",
+      motion: "full",
+    });
+  });
+
+  it("infers reduced motion from a disabling prefers-reduced-motion rule", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-theme-reduced-motion-"));
+    cleanup.push(root);
+    await mkdir(join(root, "app"), { recursive: true });
+    await writeFile(join(root, "package.json"), "{}\n");
+    await writeFile(join(root, "app", "layout.tsx"), `
+      import "./globals.css";
+      export default function Layout({ children }) { return <html><body>{children}</body></html>; }
+    `);
+    await writeFile(join(root, "app", "globals.css"), `
+      @media (prefers-reduced-motion: reduce) {
+        *, *::before, *::after { animation-duration: 0.01ms !important; transition: none; }
+      }
+    `);
+
+    const result = await extractTheme(root);
+    expect(result.slots.motion).toBe("reduced");
+    expect(result.matched.motion).toContain("prefers-reduced-motion");
+    expect(result.defaulted).not.toContain("motion");
+  });
+
+  it.each([
+    ["Maple", "demo-bank", {
+      accent: "#111111",
+      accentText: "#ffffff",
+      background: "#fbfbfa",
+      border: "#ecebe8",
+      danger: "#b0473a",
+      surface: "#ffffff",
+      text: "#111111",
+      mutedText: "#908c85",
+      radius: "8px",
+      fontFamily: "Inter, sans-serif",
+      headingFamily: "Inter, sans-serif",
+      baseSize: "16px",
+      density: "compact",
+      motion: "reduced",
+    }],
+    ["Cadence", "demo-accounting", {
+      accent: "#266755",
+      accentText: "#ffffff",
+      background: "#f7f5f1",
+      border: "#e9e4db",
+      danger: "#b91c1c",
+      surface: "#ffffff",
+      text: "#221e19",
+      mutedText: "#5c554b",
+      radius: "8px",
+      fontFamily: "Hanken Grotesk, ui-sans-serif, system-ui, sans-serif",
+      headingFamily: "Hanken Grotesk, ui-sans-serif, system-ui, sans-serif",
+      baseSize: "16px",
+      density: "compact",
+      motion: "full",
+    }],
+  ] as const)("matches measured %s host slots", async (_name, app, expected) => {
+    const result = await extractTheme(join(appsDir, app));
+    expect(result.slots).toEqual(expected);
+  });
+});

--- a/packages/vendo/src/cli/theme/extract-theme.ts
+++ b/packages/vendo/src/cli/theme/extract-theme.ts
@@ -3,7 +3,13 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { parseCssVars, type CssVarDecl } from "./css-vars.js";
 import { collectNextFontVars, collectNextLayoutVars, TAILWIND_NEUTRAL_COLORS } from "./next-fonts.js";
-import { mapVarsToBrand, type BrandMappingResult, type InferredSlotValue } from "./map-to-brand.js";
+import {
+  mapVarsToBrand,
+  normalizeColorVar,
+  type BrandMappingResult,
+  type InferredSlotValue,
+  type ThemeSlotValues,
+} from "./map-to-brand.js";
 import { resolveWorkspacePackageSpecifier } from "./workspace-resolve.js";
 import { walk } from "./walk.js";
 
@@ -156,22 +162,140 @@ async function collectCssFiles(targetDir: string): Promise<{ selected: string[];
  */
 const MUTED_UTILITY = /(?<![\w:-])text-(slate|gray|zinc|neutral|stone)-(400|500|600)\b/g;
 
-async function inferMutedTextFromUtilities(targetDir: string): Promise<InferredSlotValue | undefined> {
-  const files = await walk(targetDir, (rel) => /\.(tsx|jsx)$/.test(rel), 2_000);
-  const counts = new Map<string, number>();
-  for (const file of files) {
-    const source = await fs.readFile(file, "utf8").catch(() => "");
-    for (const match of source.matchAll(MUTED_UTILITY)) {
-      counts.set(`${match[1]}-${match[2]}`, (counts.get(`${match[1]}-${match[2]}`) ?? 0) + 1);
+const ACCENT_BG_UTILITY = /(?<![\w:-])bg-([a-z][a-z0-9-]*)\b/g;
+const RADIUS_UTILITY = /(?<![\w:-])rounded-(sm|md|lg|xl|2xl|3xl)(?![\w-])/g;
+const SMALL_TEXT_UTILITY = /(?<![\w:-])text-(xs|sm)\b|(?<![\w:-])text-\[((?:\d+|\d*\.\d+))px\]/g;
+const LARGE_TEXT_UTILITY = /(?<![\w:-])text-(base|lg)\b|(?<![\w:-])text-\[((?:\d+|\d*\.\d+))px\]/g;
+const COMPACT_HEIGHT_UTILITY = /(?<![\w:-])h-(6|7|8)\b/g;
+const COMFORTABLE_HEIGHT_UTILITY = /(?<![\w:-])h-(10|11|12)\b/g;
+const MOTION_UTILITY = /(?<![\w:-])(?:transition(?:-[\w-]+)?|animate-[\w-]+)\b/g;
+const NON_ACCENT_BG = /^(?:bg|background|surface|card|panel|popover|hover|muted|border|line|transparent|current|inherit|white|gray|grey|slate|stone|zinc|neutral|status|success|warning|error|danger|destructive|positive|negative|pos|neg)(?:-|$)/;
+const RADIUS_VALUES: Record<string, string> = {
+  sm: "2px",
+  md: "6px",
+  lg: "8px",
+  xl: "12px",
+  "2xl": "16px",
+  "3xl": "24px",
+};
+
+interface SourceInferences {
+  accent?: InferredSlotValue;
+  mutedText?: InferredSlotValue;
+  radius?: InferredSlotValue;
+  density?: InferredSlotValue;
+  motion?: InferredSlotValue;
+}
+
+function hasDisablingReducedMotionRule(source: string): boolean {
+  const media = /@media\s*\([^)]*prefers-reduced-motion\s*:\s*reduce[^)]*\)\s*\{/gi;
+  for (const match of source.matchAll(media)) {
+    const start = match.index! + match[0].length;
+    let depth = 1;
+    let end = start;
+    for (; end < source.length && depth > 0; end += 1) {
+      if (source[end] === "{") depth += 1;
+      else if (source[end] === "}") depth -= 1;
+    }
+    const block = source.slice(start, end - 1);
+    if (/(?:animation|transition)(?:-duration)?\s*:\s*none(?:\s*!important)?\s*[;}]/i.test(block)) return true;
+    if (/scroll-behavior\s*:\s*auto(?:\s*!important)?\s*[;}]/i.test(block)) return true;
+    for (const duration of block.matchAll(/(?:animation|transition)-duration\s*:\s*(\d*\.?\d+)(ms|s)(?:\s*!important)?\s*[;}]/gi)) {
+      const milliseconds = Number(duration[1]) * (duration[2]!.toLowerCase() === "s" ? 1_000 : 1);
+      if (milliseconds <= 1) return true;
     }
   }
+  return false;
+}
+
+function dominant(
+  counts: Map<string, number>,
+  minimum: number,
+  lead = 1.5,
+): [string, number] | undefined {
   const ranked = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
   const [winner, runnerUp] = ranked;
-  // Require real adoption and a clear winner, not a coin flip between scales.
-  if (!winner || winner[1] < 5 || (runnerUp && winner[1] < runnerUp[1] * 1.5)) return undefined;
-  const [family, step] = winner[0].split("-") as [string, string];
-  const value = TAILWIND_NEUTRAL_COLORS[family]?.[step];
-  return value ? { value, source: `text-${winner[0]} ×${winner[1]}` } : undefined;
+  if (!winner || winner[1] < minimum || (runnerUp && winner[1] < runnerUp[1] * lead)) return undefined;
+  return winner;
+}
+
+/**
+ * Source-level fallbacks are deliberately high-signal: a utility must be used
+ * repeatedly and dominate alternatives. A one-off class never becomes a host
+ * theme token, which keeps extraction fail-closed on mixed design systems.
+ */
+async function inferSlotsFromUtilities(targetDir: string, vars: CssVarDecl[]): Promise<SourceInferences> {
+  const files = await walk(targetDir, (rel) => /\.(tsx|jsx)$/.test(rel), 2_000);
+  const cssFiles = await walk(targetDir, (rel) => rel.endsWith(".css"), 2_000);
+  const accentCounts = new Map<string, number>();
+  const mutedCounts = new Map<string, number>();
+  const radiusCounts = new Map<string, number>();
+  let compact = 0;
+  let comfortable = 0;
+  let motion = 0;
+
+  for (const file of files) {
+    const source = await fs.readFile(file, "utf8").catch(() => "");
+    for (const match of source.matchAll(ACCENT_BG_UTILITY)) {
+      const token = match[1]!;
+      if (!NON_ACCENT_BG.test(token)) accentCounts.set(token, (accentCounts.get(token) ?? 0) + 1);
+    }
+    for (const match of source.matchAll(MUTED_UTILITY)) {
+      const token = `${match[1]}-${match[2]}`;
+      mutedCounts.set(token, (mutedCounts.get(token) ?? 0) + 1);
+    }
+    for (const match of source.matchAll(RADIUS_UTILITY)) {
+      const token = match[1]!;
+      radiusCounts.set(token, (radiusCounts.get(token) ?? 0) + 1);
+    }
+    for (const match of source.matchAll(SMALL_TEXT_UTILITY)) {
+      const arbitrary = match[2] ? Number(match[2]) : null;
+      if (arbitrary === null || arbitrary <= 13.5) compact += 1;
+    }
+    for (const match of source.matchAll(LARGE_TEXT_UTILITY)) {
+      const arbitrary = match[2] ? Number(match[2]) : null;
+      if (arbitrary === null || arbitrary >= 16) comfortable += 1;
+    }
+    compact += [...source.matchAll(COMPACT_HEIGHT_UTILITY)].length;
+    comfortable += [...source.matchAll(COMFORTABLE_HEIGHT_UTILITY)].length;
+    motion += [...source.matchAll(MOTION_UTILITY)].length;
+  }
+
+  const inferred: SourceInferences = {};
+  const accent = dominant(accentCounts, 5);
+  if (accent) {
+    const decl = [...vars].reverse().find((value) => !value.darkScope && value.name === `--color-${accent[0]}`);
+    const color = decl ? normalizeColorVar(decl.value, vars) : null;
+    if (color) inferred.accent = { value: color, source: `bg-${accent[0]} ×${accent[1]}` };
+  }
+  const muted = dominant(mutedCounts, 5);
+  if (muted) {
+    const [family, step] = muted[0].split("-") as [string, string];
+    const value = TAILWIND_NEUTRAL_COLORS[family]?.[step];
+    if (value) inferred.mutedText = { value, source: `text-${muted[0]} ×${muted[1]}` };
+  }
+  const radius = dominant(radiusCounts, 5);
+  if (radius) inferred.radius = { value: RADIUS_VALUES[radius[0]]!, source: `rounded-${radius[0]} ×${radius[1]}` };
+
+  if (compact >= 12 && compact >= comfortable * 1.5) {
+    inferred.density = { value: "compact", source: `compact type/spacing utilities ×${compact}` };
+  } else if (comfortable >= 12 && comfortable >= compact * 1.5) {
+    inferred.density = { value: "comfortable", source: `comfortable type/spacing utilities ×${comfortable}` };
+  }
+  let reducedMotionFile: string | undefined;
+  for (const file of cssFiles) {
+    const source = await fs.readFile(file, "utf8").catch(() => "");
+    if (hasDisablingReducedMotionRule(source)) {
+      reducedMotionFile = path.relative(targetDir, file) || path.basename(file);
+      break;
+    }
+  }
+  if (reducedMotionFile) {
+    inferred.motion = { value: "reduced", source: `prefers-reduced-motion in ${reducedMotionFile}` };
+  } else if (motion >= 5) {
+    inferred.motion = { value: "full", source: `transition/animation utilities ×${motion}` };
+  }
+  return inferred;
 }
 
 export async function extractTheme(
@@ -199,9 +323,12 @@ export async function extractTheme(
   // Inference fallbacks fill only slots no declared variable claims — map
   // first, and pay the source scan only when the slot actually defaulted.
   let result = mapVarsToBrand(vars);
-  if (result.defaulted.includes("mutedText")) {
-    const mutedText = await inferMutedTextFromUtilities(targetDir);
-    if (mutedText) result = mapVarsToBrand(vars, { mutedText });
+  const utilitySlots = ["accent", "radius", "density", "motion"] satisfies Array<keyof ThemeSlotValues>;
+  const needsUtilityInference = utilitySlots.some((slot) => result.defaulted.includes(slot))
+    || /(?:card|popover|modal|dialog)/.test(result.matched.radius ?? "");
+  if (needsUtilityInference || result.defaulted.includes("mutedText")) {
+    const inferred = await inferSlotsFromUtilities(targetDir, vars);
+    result = mapVarsToBrand(vars, inferred);
   }
   return { ...result, errors, varCount: vars.length };
 }

--- a/packages/vendo/src/cli/theme/map-to-brand.test.ts
+++ b/packages/vendo/src/cli/theme/map-to-brand.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import type { CssVarDecl } from "./css-vars.js";
+import { mapVarsToBrand } from "./map-to-brand.js";
+
+function vars(values: Record<string, string>): CssVarDecl[] {
+  return Object.entries(values).map(([name, value]) => ({
+    name,
+    value,
+    file: "tokens.css",
+    darkScope: false,
+  }));
+}
+
+describe("mapVarsToBrand full VendoTheme slots", () => {
+  it("fills every new slot with fail-closed defaults when host evidence is absent", () => {
+    const result = mapVarsToBrand([]);
+    expect(result.slots).toMatchObject({
+      border: "#e2e8f0",
+      danger: "#dc2626",
+      accentText: "#ffffff",
+      headingFamily: "system-ui, sans-serif",
+      density: "comfortable",
+      motion: "full",
+    });
+    expect(result.defaulted).toEqual(expect.arrayContaining([
+      "border", "danger", "headingFamily", "density", "motion",
+    ]));
+  });
+
+  it("uses an explicit muted token before falling back to an ink-soft convention", () => {
+    expect(mapVarsToBrand(vars({
+      "--color-muted": "#908c85",
+      "--color-ink-soft": "#46443f",
+    })).slots.mutedText).toBe("#908c85");
+    expect(mapVarsToBrand(vars({ "--color-ink-soft": "#5c554b" })).slots.mutedText).toBe("#5c554b");
+  });
+
+  it("uses the conventional 600 step for a single declared brand scale", () => {
+    expect(mapVarsToBrand(vars({
+      "--color-evergreen-100": "#d8ebe2",
+      "--color-evergreen-500": "#34816a",
+      "--color-evergreen-600": "#266755",
+      "--color-evergreen-900": "#16362e",
+    })).slots.accent).toBe("#266755");
+  });
+
+  it("maps explicit border and danger tokens without confusing status backgrounds", () => {
+    const result = mapVarsToBrand(vars({
+      "--color-border": "#e7e5e4",
+      "--color-border-strong": "#d6d3d1",
+      "--color-danger": "#b91c1c",
+      "--color-danger-bg": "#fee2e2",
+    }));
+
+    expect(result.slots.border).toBe("#e7e5e4");
+    expect(result.slots.danger).toBe("#b91c1c");
+    expect(result.matched).toMatchObject({ border: "--color-border", danger: "--color-danger" });
+
+    const ambiguous = mapVarsToBrand(vars({
+      "--color-danger-bg": "#fee2e2",
+      "--color-danger-foreground": "#7f1d1d",
+    }));
+    expect(ambiguous.slots.danger).toBe("#dc2626");
+    expect(ambiguous.defaulted).toContain("danger");
+  });
+
+  it("uses an explicit accent text token, otherwise chooses the higher WCAG contrast", () => {
+    const explicit = mapVarsToBrand(vars({
+      "--primary": "#facc15",
+      "--primary-foreground": "#422006",
+    }));
+    expect(explicit.slots.accentText).toBe("#422006");
+    expect(explicit.matched.accentText).toBe("--primary-foreground");
+
+    expect(mapVarsToBrand(vars({ "--primary": "#facc15" })).slots.accentText).toBe("#000000");
+    expect(mapVarsToBrand(vars({ "--primary": "#1d4ed8" })).slots.accentText).toBe("#ffffff");
+  });
+
+  it("maps a declared heading family and otherwise inherits the resolved body stack", () => {
+    const explicit = mapVarsToBrand(vars({
+      "--font-sans": "Inter, sans-serif",
+      "--font-heading": "Newsreader, serif",
+    }));
+    expect(explicit.slots.headingFamily).toBe("Newsreader, serif");
+    expect(explicit.matched.headingFamily).toBe("--font-heading");
+
+    const inherited = mapVarsToBrand(vars({ "--font-sans": "Inter, sans-serif" }));
+    expect(inherited.slots.headingFamily).toBe("Inter, sans-serif");
+    expect(inherited.matched.headingFamily).toBe("(inherit) fontFamily");
+
+    const headingOnly = mapVarsToBrand(vars({ "--font-heading": "Newsreader, serif" }));
+    expect(headingOnly.slots.fontFamily).toBe("system-ui, sans-serif");
+    expect(headingOnly.slots.headingFamily).toBe("Newsreader, serif");
+  });
+
+  it("infers compact density only from strong base-size or explicit density signals", () => {
+    expect(mapVarsToBrand(vars({ "--font-size": "14px" })).slots.density).toBe("compact");
+    expect(mapVarsToBrand(vars({ "--density": "compact" })).slots.density).toBe("compact");
+    expect(mapVarsToBrand(vars({ "--font-size": "16px" })).slots.density).toBe("comfortable");
+    expect(mapVarsToBrand([]).defaulted).toContain("density");
+  });
+
+  it("maps explicit reduced motion and non-zero transition duration signals", () => {
+    expect(mapVarsToBrand(vars({ "--motion": "reduced" })).slots.motion).toBe("reduced");
+    expect(mapVarsToBrand(vars({ "--transition-duration": "0ms" })).slots.motion).toBe("reduced");
+    const full = mapVarsToBrand(vars({ "--transition-duration": "150ms" }));
+    expect(full.slots.motion).toBe("full");
+    expect(full.matched.motion).toBe("--transition-duration");
+    expect(mapVarsToBrand([]).defaulted).toContain("motion");
+  });
+});

--- a/packages/vendo/src/cli/theme/map-to-brand.ts
+++ b/packages/vendo/src/cli/theme/map-to-brand.ts
@@ -2,13 +2,19 @@ import type { CssVarDecl } from "./css-vars.js";
 
 export interface ThemeSlotValues {
   accent: string;
+  accentText: string;
   background: string;
+  border: string;
+  danger: string;
   surface: string;
   text: string;
   mutedText: string;
   radius: string;
   fontFamily: string;
+  headingFamily: string;
   baseSize: string;
+  density: "compact" | "comfortable";
+  motion: "full" | "reduced";
 }
 
 export interface BrandMappingResult {
@@ -25,13 +31,19 @@ export interface BrandMappingResult {
 
 const DEFAULT_THEME_SLOTS: ThemeSlotValues = {
   accent: "#2563eb",
+  accentText: "#ffffff",
   background: "#ffffff",
+  border: "#e2e8f0",
+  danger: "#dc2626",
   surface: "#f8fafc",
   text: "#0f172a",
   mutedText: "#64748b",
   radius: "8px",
   fontFamily: "system-ui, sans-serif",
+  headingFamily: "system-ui, sans-serif",
   baseSize: "16px",
+  density: "comfortable",
+  motion: "full",
 };
 
 const HEX = /^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
@@ -48,7 +60,7 @@ const COLOR_SLOTS: Array<{ slot: ColorSlot; fragments: string[] }> = [
   { slot: "accent", fragments: ["brand", "primary", "content-emphasis", "bg-inverted", "cta", "accent"] },
   { slot: "background", fragments: ["background", "bg-default", "surface-raised", "-bg", "bg"] },
   { slot: "surface", fragments: ["surface-base", "surface", "card", "popover", "cal-bg", "color-default", "bg-muted", "color-secondary", "panel", "secondary", "bg-default"] },
-  { slot: "mutedText", fragments: ["muted-foreground", "content-muted", "text-color-muted", "fg-muted", "text-muted", "muted-text", "secondary-text", "muted"] },
+  { slot: "mutedText", fragments: ["muted-foreground", "content-muted", "text-color-muted", "fg-muted", "text-muted", "muted-text", "secondary-text", "muted", "-ink-soft", "-ink-faint"] },
   { slot: "text", fragments: ["content-default", "text-color-default", "text-primary", "foreground", "-ink", "text-default", "primary", "-fg", "text"] },
 ];
 
@@ -57,6 +69,7 @@ const SCALE_STEPS = new Set([50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 95
 /** Scale families that are never the brand accent. */
 const NON_ACCENT_FAMILY = /(gray|grey|neutral|slate|stone|zinc|status|success|warning|error|danger|info)/;
 const STATUS_TOKEN = /--(?:color-)?(?:destructive|danger|error|info|success|warning)(?:-|$)/;
+const ACCENT_TEXT_TOKEN = /(?:foreground|contrast|accent-text|on-(?:accent|brand|primary)|text-on-)/;
 
 /** Spread between the widest RGB channels — near zero for neutral ramps whose
  * family name isn't on the keyword list (sand, ash, ivory, ...). */
@@ -68,8 +81,9 @@ function hexChroma(hex: string): number {
 
 /**
  * Accent fallback for scale-named token sets (e.g. --color-evergreen-50..950):
- * when exactly one non-neutral, non-status hex scale exists, its mid step is
- * the brand accent. Zero or several candidate families, or a mid step too
+ * when exactly one non-neutral, non-status hex scale exists, its conventional
+ * interactive step (600, then nearest) is the brand accent. Zero or several
+ * candidate families, or a selected step too
  * gray to be a brand color, is genuinely ambiguous — return nothing and let
  * the slot default (fail-closed).
  */
@@ -89,7 +103,7 @@ function pickScaleAccent(vars: CssVarDecl[]): CssVarDecl | undefined {
   );
   if (candidates.length !== 1) return undefined;
   const steps = candidates[0]![1];
-  const mid = [...steps.keys()].sort((a, b) => Math.abs(a - 500) - Math.abs(b - 500) || a - b)[0]!;
+  const mid = [...steps.keys()].sort((a, b) => Math.abs(a - 600) - Math.abs(b - 600) || a - b)[0]!;
   const hit = steps.get(mid);
   const color = hit ? normalizeColor(hit.value) : null;
   return hit && color && hexChroma(color) >= 32 ? hit : undefined;
@@ -223,9 +237,27 @@ function normalizeColor(value: string): string | null {
   return normalizeHex(value) ?? parseRgbTriplet(value) ?? parseHsl(value) ?? parseOklch(value);
 }
 
-function normalizeColorVar(value: string, all: CssVarDecl[]): string | null {
+export function normalizeColorVar(value: string, all: CssVarDecl[]): string | null {
   const resolved = resolveCssVarRefs(value, all, 6);
   return resolved ? normalizeColor(resolved) : null;
+}
+
+function relativeLuminance(hex: string): number {
+  const normalized = normalizeHex(hex);
+  if (!normalized) return 0;
+  const channels = [1, 3, 5].map((index) => parseInt(normalized.slice(index, index + 2), 16) / 255);
+  const [r, g, b] = channels.map((channel) => channel <= 0.04045
+    ? channel / 12.92
+    : ((channel + 0.055) / 1.055) ** 2.4) as [number, number, number];
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/** Pick black or white by the larger WCAG contrast ratio against the accent. */
+function contrastingText(accent: string): "#000000" | "#ffffff" {
+  const luminance = relativeLuminance(accent);
+  const blackContrast = (luminance + 0.05) / 0.05;
+  const whiteContrast = 1.05 / (luminance + 0.05);
+  return blackContrast >= whiteContrast ? "#000000" : "#ffffff";
 }
 
 function normalizeRadius(value: string, all: CssVarDecl[]): string | null {
@@ -236,6 +268,15 @@ function normalizeRadius(value: string, all: CssVarDecl[]): string | null {
   const rem = resolved.match(/^((?:\d+|\d*\.\d+))rem$/);
   if (rem) return `${Number(rem[1]) * 16}px`;
   return null;
+}
+
+function normalizeTime(value: string, all: CssVarDecl[]): number | null {
+  const resolved = resolveCssVarRefs(value, all, 6)?.trim();
+  if (!resolved) return null;
+  const match = resolved.match(/^((?:\d+|\d*\.\d+))(ms|s)$/);
+  if (!match) return null;
+  const amount = Number(match[1]);
+  return match[2] === "s" ? amount * 1_000 : amount;
 }
 
 function normalizeFontStack(value: string): string {
@@ -315,7 +356,7 @@ function isSafeFontStack(value: string): boolean {
 
 export function mapVarsToBrand(
   all: CssVarDecl[],
-  fallbacks?: Partial<Record<ColorSlot, InferredSlotValue>>,
+  fallbacks?: Partial<Record<keyof ThemeSlotValues, InferredSlotValue>>,
 ): BrandMappingResult {
   // Synthetic decls (next/font recovery) resolve var() chains only — slots
   // pick from CSS-declared vars.
@@ -336,9 +377,36 @@ export function mapVarsToBrand(
     return names.has(base) || names.has(`${base}-fg`);
   };
 
+  const mapDeclaredColor = (slot: "accentText" | "border" | "danger", fragments: string[]): CssVarDecl | undefined => {
+    const candidates = light.filter((v) => !used.has(v)
+      && !isCompanionTint(v)
+      && (slot !== "danger" || !/(?:foreground|text|contrast|-bg|-background|-subtle)/.test(v.name)));
+    const hit = pick(candidates, fragments, (value) => normalizeColorVar(value, all) !== null);
+    if (!hit) return undefined;
+    used.add(hit);
+    matched[slot] = hit.name;
+    draft[slot] = normalizeColorVar(hit.value, all)!;
+    return hit;
+  };
+
+  // Reserve semantic foreground/status/border tokens before the looser core
+  // color pass. In particular, --primary-foreground must never become the
+  // accent merely because it contains "primary".
+  const accentText = mapDeclaredColor("accentText", [
+    "primary-foreground", "accent-foreground", "brand-foreground",
+    "on-primary", "on-accent", "on-brand", "accent-text", "text-on-primary",
+  ]);
+  const border = mapDeclaredColor("border", ["border-default", "divider", "separator", "-line", "border"]);
+  const danger = mapDeclaredColor("danger", [
+    "danger", "destructive", "error", "negative", "-neg", "status-overdue", "critical",
+  ]);
+
   const hits: Partial<Record<ColorSlot, CssVarDecl>> = {};
   for (const { slot, fragments } of COLOR_SLOTS) {
-    const candidates = light.filter((v) => !used.has(v) && !isCompanionTint(v) && (slot === "accent" || !STATUS_TOKEN.test(v.name)));
+    const candidates = light.filter((v) => !used.has(v)
+      && !isCompanionTint(v)
+      && !STATUS_TOKEN.test(v.name)
+      && (slot !== "accent" || !ACCENT_TEXT_TOKEN.test(v.name)));
     let hit = pick(candidates, fragments, (value) => normalizeColorVar(value, all) !== null);
     if (!hit && slot === "accent") hit = pickScaleAccent(candidates);
     if (!hit && slot === "background") {
@@ -356,6 +424,13 @@ export function mapVarsToBrand(
       draft[slot] = fallbacks[slot]!.value;
     }
     else { defaulted.push(slot); draft[slot] = DEFAULT_THEME_SLOTS[slot]; }
+  }
+
+  if (!border) { defaulted.push("border"); draft.border = DEFAULT_THEME_SLOTS.border; }
+  if (!danger) { defaulted.push("danger"); draft.danger = DEFAULT_THEME_SLOTS.danger; }
+  if (!accentText) {
+    draft.accentText = contrastingText(draft.accent!);
+    matched.accentText = `(contrast) accent`;
   }
 
   // The two rules below apply ONLY when the source slot was inferred from a
@@ -390,11 +465,24 @@ export function mapVarsToBrand(
   }
 
   const radius = pick(light, ["radius-cal", "radius-default", "radius-card", "radius"], (val) => normalizeRadius(val, all) !== null);
-  if (radius) { used.add(radius); matched["radius"] = radius.name; draft["radius"] = normalizeRadius(radius.value, all)!; }
-  else { defaulted.push("radius"); draft["radius"] = DEFAULT_THEME_SLOTS.radius; }
+  // A component-specific card/popover token is weaker evidence for the global
+  // radius than a strongly dominant generic utility scale measured in source.
+  const inferredRadius = fallbacks?.radius;
+  const specializedRadius = radius && /(?:card|popover|modal|dialog)/.test(radius.name);
+  if (inferredRadius && (!radius || specializedRadius)) {
+    matched.radius = `(inferred) ${inferredRadius.source}`;
+    draft.radius = inferredRadius.value;
+  } else if (radius) {
+    used.add(radius);
+    matched.radius = radius.name;
+    draft.radius = normalizeRadius(radius.value, all)!;
+  } else {
+    defaulted.push("radius");
+    draft.radius = DEFAULT_THEME_SLOTS.radius;
+  }
 
   const font = pick(
-    light,
+    light.filter((v) => !/(?:heading|display|mono|code)/.test(v.name)),
     ["font-default", "font-sans", "font-family", "font"],
     (val) => resolveCssVarRefs(val, all) !== null && isSafeFontStack(resolveCssVarRefs(val, all)!),
   );
@@ -407,8 +495,65 @@ export function mapVarsToBrand(
     draft["fontFamily"] = DEFAULT_THEME_SLOTS.fontFamily;
   }
 
+  const heading = pick(
+    light.filter((v) => v !== font && !/(?:mono|code)/.test(v.name)),
+    ["font-heading", "heading-font", "font-display", "display-font"],
+    (val) => resolveCssVarRefs(val, all) !== null && isSafeFontStack(resolveCssVarRefs(val, all)!),
+  );
+  if (heading) {
+    used.add(heading);
+    matched.headingFamily = heading.name;
+    draft.headingFamily = ensureFontFallback(normalizeFontStack(resolveCssVarRefs(heading.value, all)!));
+  } else {
+    draft.headingFamily = draft.fontFamily;
+    if (font) matched.headingFamily = "(inherit) fontFamily";
+    else defaulted.push("headingFamily");
+  }
+
   const baseSize = pick(light, ["font-size", "text-base"], (val) => normalizeRadius(val, all) !== null);
-  draft["baseSize"] = baseSize ? normalizeRadius(baseSize.value, all)! : DEFAULT_THEME_SLOTS.baseSize;
+  if (baseSize) {
+    used.add(baseSize);
+    matched.baseSize = baseSize.name;
+    draft.baseSize = normalizeRadius(baseSize.value, all)!;
+  } else {
+    defaulted.push("baseSize");
+    draft.baseSize = DEFAULT_THEME_SLOTS.baseSize;
+  }
+
+  const density = pick(light, ["density"], (value) => /^(?:compact|comfortable)$/.test(value.trim()));
+  if (density) {
+    used.add(density);
+    matched.density = density.name;
+    draft.density = density.value.trim() as ThemeSlotValues["density"];
+  } else if (fallbacks?.density) {
+    matched.density = `(inferred) ${fallbacks.density.source}`;
+    draft.density = fallbacks.density.value as ThemeSlotValues["density"];
+  } else if (Number.parseFloat(draft.baseSize) <= 14) {
+    matched.density = `(inferred) baseSize ${draft.baseSize}`;
+    draft.density = "compact";
+  } else {
+    defaulted.push("density");
+    draft.density = DEFAULT_THEME_SLOTS.density;
+  }
+
+  const motion = pick(light, ["motion", "animation-mode"], (value) => /^(?:full|reduced)$/.test(value.trim()));
+  const duration = light.find((v) => /(?:transition|animation|motion).*(?:duration|speed)|(?:duration|speed).*(?:transition|animation|motion)/.test(v.name)
+    && normalizeTime(v.value, all) !== null);
+  if (motion) {
+    used.add(motion);
+    matched.motion = motion.name;
+    draft.motion = motion.value.trim() as ThemeSlotValues["motion"];
+  } else if (duration) {
+    used.add(duration);
+    matched.motion = duration.name;
+    draft.motion = normalizeTime(duration.value, all)! === 0 ? "reduced" : "full";
+  } else if (fallbacks?.motion) {
+    matched.motion = `(inferred) ${fallbacks.motion.source}`;
+    draft.motion = fallbacks.motion.value as ThemeSlotValues["motion"];
+  } else {
+    defaulted.push("motion");
+    draft.motion = DEFAULT_THEME_SLOTS.motion;
+  }
 
   return {
     slots: draft as ThemeSlotValues,


### PR DESCRIPTION
## Summary

- Fill every frozen `VendoTheme` slot during CLI extraction: border, danger, accent text, heading family, density, and motion now join the existing eight slots.
- Add fail-closed token and source heuristics: WCAG contrast for accent text; divider/border and destructive/error token matching; heading-family inheritance; dominant spacing/type density signals; reduced-motion and transition signals; conservative defaults on ambiguity.
- Fix the measured Maple misses (Inter, 8px radius, black accent) and lock both Maple and Cadence to their measured 14-slot host values.

## Measured host accuracy

| Slot | Maple actual | Maple extracted | Cadence actual | Cadence extracted |
|---|---|---|---|---|
| `colors.border` | `#ecebe8` | `#ecebe8` | `#e9e4db` | `#e9e4db` |
| `colors.danger` | `#b0473a` | `#b0473a` | `#b91c1c` | `#b91c1c` |
| `colors.accent` | `#111111` | `#111111` | `#266755` | `#266755` |
| `colors.background` | `#fbfbfa` | `#fbfbfa` | `#f7f5f1` | `#f7f5f1` |
| `colors.surface` | `#ffffff` | `#ffffff` | `#ffffff` | `#ffffff` |
| `colors.muted` | `#908c85` | `#908c85` | `#5c554b` | `#5c554b` |
| `colors.text` | `#111111` | `#111111` | `#221e19` | `#221e19` |
| `colors.accentText` | `#ffffff` | `#ffffff` | `#ffffff` | `#ffffff` |
| `radius.medium` | `8px` | `8px` | `8px` | `8px` |
| `typography.fontFamily` | `Inter, sans-serif` | `Inter, sans-serif` | `Hanken Grotesk, ui-sans-serif, system-ui, sans-serif` | `Hanken Grotesk, ui-sans-serif, system-ui, sans-serif` |
| `typography.headingFamily` | `Inter, sans-serif` | `Inter, sans-serif` | `Hanken Grotesk, ui-sans-serif, system-ui, sans-serif` | `Hanken Grotesk, ui-sans-serif, system-ui, sans-serif` |
| `typography.baseSize` | `16px` | `16px` | `16px` | `16px` |
| `density` | `compact` | `compact` | `compact` | `compact` |
| `motion` | `reduced` | `reduced` | `full` | `full` |

Result: Maple 14/14; Cadence 14/14.

## Corpus

- Before reference: the frozen corpus baselines expect 26/26 passing layers.
- After (`pnpm corpus run --layer 2 --strict`, fixed harness, foreground): 16/26 layers passed and 10 hard failures were reported; theme scoring was 89/91, with all seven scored theme slots exact in 11/13 hosts.
- The two theme misses were Dub and Formbricks `fontFamily`; running the `origin/main` extractor against the same pinned checkouts produced the identical values (`system-ui, sans-serif` for both), so this branch introduces no theme regression. Formbricks declares no font token and therefore correctly takes the frozen fail-closed default; Dub's expected Inter bridge spans source and executable Tailwind config beyond the existing collector.
- The other strict failures are pre-existing/non-theme host build/typecheck or tool inventory differences (including Papermark, Cal.com, and Teable tool counts); no T2 extraction slot regressed against `origin/main`.

### Harness checkout incident

An ENOSPC-interrupted cache left `corpus/.repos/dub` without its own `.git`. The old harness accepted the enclosing Vendo worktree and moved its HEAD while trying to force-checkout the pinned Dub SHA. The canonical top-level guard from commit `2fa54e37` was initially cherry-picked as requested; after PR #195 merged during this work, the final rebase correctly skipped that duplicate. This PR retains one additive, separate defense: every production harness Git spawn sets `GIT_CEILING_DIRECTORIES` to the real `.repos` path. A cache audit removed the invalid checkout before the fixed strict run, and the final run left the Vendo branch/HEAD unchanged.

## Verification

- `pnpm build`
- `pnpm test` (41/41 Turbo tasks; one newly landed timing-sensitive automation fixture passed focused 6/6 and on the full cached retry)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @vendoai/corpus-harness test` (15 files, 96 tests on latest main)
- Live `extractTheme` against `apps/demo-bank` and `apps/demo-accounting`

ENG-242

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the CLI to extract and fill every `VendoTheme` slot with conservative, fail-closed heuristics, fixing Maple/Cadence misses and improving host fidelity. Addresses ENG-242 by delivering full theme coverage and persisting the new slots in `init`.

- **New Features**
  - Fills new slots: `border`, `danger`, `accentText`, `headingFamily`, `density`, `motion`.
  - Heuristics: explicit `border`/`danger` token mapping; `accentText` from explicit token or higher WCAG contrast; `accent` from a single non-neutral scale (prefers 600) or dominant `bg-` utilities; `headingFamily` inherits body stack when missing; `radius` prefers strong generic utility evidence over component-specific tokens; `density` from dominant spacing/type utilities or base size; `motion` from `prefers-reduced-motion` disabling rules or transition/animation utilities; conservative defaults on ties.
  - `init` now persists extracted `accentText`, `border`, `danger`, `headingFamily`, `density`, and `motion`; only small/large radius are derived.
  - Tests: added mapping and extraction tests; Maple and Cadence match measured hosts end-to-end (14/14).

- **Bug Fixes**
  - Corpus harness: set `GIT_CEILING_DIRECTORIES` for all Git spawns to the real `.repos` parent to prevent discovery outside the repo cache.

<sup>Written for commit 093ed0cb8eeef237f364db9a6233627087c09672. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

