### PR TITLE
feat(actions): actAs provider presets + impersonation guard (ENG-260)

### DIFF
--- a/docs/act-as-presets.md
+++ b/docs/act-as-presets.md
@@ -166,7 +166,9 @@ pass through for the host's existing verifier.
 ### Express verifier
 
 Mount the middleware before protected API routes. Verified claims are attached
-to `req.vendoAwayToken`; a malformed or expired away-token returns 401.
+to `req.vendoAwayToken`; a malformed or expired away-token returns 401. Like
+the Next.js flavor, it removes caller-supplied `x-vendo-away-*` headers from
+every request, so only `req.vendoAwayToken` carries away identity.
 
 ```ts
 import { awayAuth } from "./vendo-away.js";

--- a/docs/act-as-presets.md
+++ b/docs/act-as-presets.md
@@ -1,0 +1,246 @@
+# actAs presets
+
+`@vendoai/actions/presets` turns a Vendo principal and captured grant into the
+host credentials used for away automations and MCP calls. Pass the resulting
+`actAs` function to `createVendo`:
+
+```ts
+import { createVendo } from "@vendoai/vendo";
+import { authJsPreset } from "@vendoai/actions/presets";
+
+const actAs = authJsPreset();
+export const vendo = createVendo({ model, principal, actAs });
+```
+
+Every preset keeps minted tokens in its own closure and refreshes them before
+expiry. Create one preset instance during host boot and reuse it. A missing
+secret, unknown user, or revoked user should return `null`; Vendo then fails the
+run closed.
+
+Keep all signing secrets server-only. The preset secret must be the same secret
+the host API verifier uses, never a public or publishable key.
+
+## Auth.js and NextAuth v5
+
+Install Auth.js alongside the preset. It is an optional peer so hosts that do
+not use Auth.js do not install it.
+
+```sh
+pnpm add @auth/core
+```
+
+The preset calls the real Auth.js v5 encoder lazily. It creates the encrypted
+session JWE that `getToken` accepts; a conventional signed JWT is not enough.
+
+```ts
+import { authJsPreset } from "@vendoai/actions/presets";
+
+export const actAs = authJsPreset({
+  // Defaults to process.env.AUTH_SECRET.
+  secret: () => process.env.AUTH_SECRET,
+
+  // Match the host's real cookie. Use secureCookie for Auth.js's production
+  // default, or set cookieName explicitly when the host customizes it.
+  secureCookie: process.env.NODE_ENV === "production",
+
+  claims: async (principal) => {
+    const user = await db.user.findUnique({ where: { id: principal.subject } });
+    if (!user || user.disabled) return null;
+    return { name: user.name, email: user.email };
+  },
+});
+```
+
+`cookieName` is also the JWE key-derivation salt, so it must match exactly. The
+defaults are `authjs.session-token` and, with `secureCookie: true`,
+`__Secure-authjs.session-token`.
+
+## Supabase Auth
+
+Use the project's server-only legacy JWT secret. The preset mints an HS256
+access token offline with `sub`, `role: "authenticated"`, `aud`, `iat`, and
+`exp`, then sends it as `Authorization: Bearer ...`.
+
+```ts
+import { supabasePreset } from "@vendoai/actions/presets";
+
+export const actAs = supabasePreset({
+  // Defaults to process.env.SUPABASE_JWT_SECRET.
+  secret: () => process.env.SUPABASE_JWT_SECRET,
+  audience: "authenticated",
+  role: "authenticated",
+  expiresInSeconds: 300,
+  claims: async (principal) => {
+    const profile = await loadProfile(principal.subject);
+    if (!profile || profile.disabled) return null;
+    return { email: profile.email };
+  },
+});
+```
+
+Do not pass the Supabase anon key or service-role token. Those are complete
+tokens, not the project JWT signing secret.
+
+## Clerk and Auth0
+
+Clerk and Auth0 hold the private keys for their RS256 user sessions, so a host
+cannot honestly mint a provider session offline. Their presets instead issue a
+short-lived, host-owned HS256 `VendoAway` token. The host API accepts that token
+only through the shipped verifier; ordinary browser requests continue through
+the existing Clerk or Auth0 verifier.
+
+Create a separate random server secret and deploy the same value to the Vendo
+runtime and host API:
+
+```sh
+openssl rand -base64 32
+```
+
+```ts
+// lib/vendo-away.ts
+import { clerkPreset } from "@vendoai/actions/presets";
+// Use auth0Preset with identical options in an Auth0 host.
+
+export const awayAuth = clerkPreset({
+  // Defaults to process.env.VENDO_AWAY_TOKEN_SECRET.
+  secret: () => process.env.VENDO_AWAY_TOKEN_SECRET,
+  issuer: "my-product",
+  audience: "my-product-api",
+  expiresInSeconds: 120,
+  claims: async (principal) => {
+    const user = await loadUser(principal.subject);
+    if (!user || user.disabled) return null;
+    return { tenantId: user.tenantId };
+  },
+});
+
+export const actAs = awayAuth.actAs;
+```
+
+The token binds `sub`, provider, grant id, and tool in addition to issuer,
+audience, issued-at, and expiry. `awayAuth.verify(value)` accepts either the
+compact token or the complete `VendoAway ...` authorization value, which also
+makes a mint-and-verify doctor probe straightforward.
+
+### Next.js verifier
+
+Install `next` only in a Next.js host; it is an optional peer and is imported
+only when `nextMiddleware` runs.
+
+```ts
+// middleware.ts
+import { clerkPreset } from "@vendoai/actions/presets";
+
+// A verifier-only instance keeps database-backed producer claims out of an
+// Edge middleware bundle. Keep these values identical to lib/vendo-away.ts.
+const awayVerifier = clerkPreset({
+  secret: () => process.env.VENDO_AWAY_TOKEN_SECRET,
+  issuer: "my-product",
+  audience: "my-product-api",
+});
+
+export const middleware = awayVerifier.nextMiddleware;
+export const config = { matcher: ["/api/:path*"] };
+```
+
+For a valid away-token the middleware adds these request headers:
+`x-vendo-away-subject`, `x-vendo-away-provider`, `x-vendo-away-grant`, and
+`x-vendo-away-tool`. It removes caller-supplied versions first, including on
+ordinary requests. Trust these headers only on routes covered by this
+middleware, then branch to the provider's normal verifier for present traffic:
+
+```ts
+import { headers } from "next/headers";
+
+export async function GET() {
+  const requestHeaders = await headers();
+  const awaySubject = requestHeaders.get("x-vendo-away-subject");
+  const subject = awaySubject ?? (await requireProviderSession()).userId;
+  return Response.json(await loadAccount(subject));
+}
+```
+
+Invalid `VendoAway` tokens return 401. `Bearer` and cookie-based provider auth
+pass through for the host's existing verifier.
+
+### Express verifier
+
+Mount the middleware before protected API routes. Verified claims are attached
+to `req.vendoAwayToken`; a malformed or expired away-token returns 401.
+
+```ts
+import { awayAuth } from "./vendo-away.js";
+
+app.use("/api", awayAuth.expressMiddleware);
+app.get("/api/account", async (req, res) => {
+  const subject = req.vendoAwayToken?.sub ?? (await requireProviderSession(req)).userId;
+  res.json(await loadAccount(subject));
+});
+```
+
+If TypeScript owns the Express request type, merge the field once:
+
+```ts
+import type { AwayTokenClaims } from "@vendoai/actions/presets";
+
+declare global {
+  namespace Express {
+    interface Request {
+      vendoAwayToken?: AwayTokenClaims;
+    }
+  }
+}
+```
+
+## Generic JWT recipes
+
+`genericJwtPreset` covers host-owned HS256 schemes and long-tail providers that
+accept a shared-secret JWT. It always forces `alg: "HS256"`, `iat`, and `exp`.
+
+### Bearer token
+
+```ts
+import { genericJwtPreset } from "@vendoai/actions/presets";
+
+export const actAs = genericJwtPreset({
+  secret: () => process.env.HOST_API_JWT_SECRET,
+  jwtHeader: { typ: "at+jwt", kid: "current" },
+  claims: async (principal, grant) => {
+    const account = await loadAccount(principal.subject);
+    if (!account?.active) return null;
+    return {
+      sub: account.providerUserId,
+      aud: "host-api",
+      tenant: account.tenantId,
+      permission: grant.tool,
+    };
+  },
+});
+```
+
+### Custom header or cookie
+
+```ts
+export const actAs = genericJwtPreset({
+  secret: process.env.HOST_API_JWT_SECRET,
+  claims: (principal) => ({ sub: principal.subject, aud: "internal-api" }),
+  headers: (token) => ({
+    "x-internal-session": token,
+    cookie: `internal_session=${token}`,
+  }),
+});
+```
+
+For managed asymmetric providers that do not expose a signing key, do not put a
+provider public key into `genericJwtPreset`: a public key cannot sign. Use the
+Clerk/Auth0 away-token pattern above, or implement the same two-sided pattern
+in the host with a dedicated server secret and a distinct authorization
+scheme.
+
+## Cache and rotation controls
+
+All presets default to a five-minute token and a 30-second cache safety margin.
+Use `expiresInSeconds` and `cacheSafetySeconds` to tune them. Secret resolvers
+run on every call, so rotating the returned secret immediately changes the
+cache key and minted token. Claims resolvers also run on every call so a
+disabled or deleted user can decline even while an older token remains cached.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -107,6 +107,10 @@ A sandbox adapter unlocks server-backed app rungs. `actAs` unlocks host API
 calls while the user is away. Connectors add external tools. `VENDO_API_KEY`
 activates cloud-gated sharing, publishing, org overlays, and pinning.
 
+Use the [actAs preset recipes](./act-as-presets.md) to wire Auth.js, Supabase
+Auth, Clerk, Auth0, or a host-owned generic JWT without changing the
+`AuthMaterial` contract.
+
 ## Serve your product to MCP clients (the door)
 
 The door makes your host tools installable in Claude, ChatGPT, Cursor, and any

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -31,6 +31,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./presets": {
+      "types": "./dist/presets/index.d.ts",
+      "default": "./dist/presets/index.js"
     }
   },
   "files": [
@@ -48,8 +52,23 @@
     "yaml": "^2.6.0",
     "zod": "^3.24.0"
   },
+  "peerDependencies": {
+    "@auth/core": "^0.34.3",
+    "next": ">=14"
+  },
+  "peerDependenciesMeta": {
+    "@auth/core": {
+      "optional": true
+    },
+    "next": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@auth/core": "^0.34.3",
     "@types/node": "^22.0.0",
+    "jose": "^6.2.3",
+    "next": "16.2.9",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"
   }

--- a/packages/actions/src/presets/adversarial.test.ts
+++ b/packages/actions/src/presets/adversarial.test.ts
@@ -150,6 +150,42 @@ describe("trusted header spoofing", () => {
       .toBe("Bearer ordinary-provider-session");
   });
 
+  it("strips caller-supplied x-vendo-away-* headers in the Express flavor too", async () => {
+    const created = clerkPreset({ secret });
+    const material = await created.actAs(principal, grant);
+    const next = vi.fn();
+    const response = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    const awayRequest = {
+      headers: {
+        authorization: material?.headers.authorization,
+        "X-Vendo-Away-Subject": "attacker-user",
+        "x-vendo-away-grant": "grt_forged",
+      },
+      vendoAwayToken: undefined,
+    };
+    await created.expressMiddleware(awayRequest, response, next);
+    expect(awayRequest.headers["X-Vendo-Away-Subject"]).toBeUndefined();
+    expect(awayRequest.headers["x-vendo-away-grant"]).toBeUndefined();
+    expect(awayRequest.vendoAwayToken).toMatchObject({ sub: principal.subject });
+
+    const ordinaryRequest = {
+      headers: {
+        authorization: "Bearer ordinary-provider-session",
+        "x-vendo-away-subject": "attacker-user",
+      },
+      vendoAwayToken: undefined,
+    };
+    await created.expressMiddleware(ordinaryRequest, response, next);
+    expect(ordinaryRequest.headers["x-vendo-away-subject"]).toBeUndefined();
+    expect(ordinaryRequest.headers.authorization).toBe("Bearer ordinary-provider-session");
+    expect(ordinaryRequest.vendoAwayToken).toBeUndefined();
+    expect(next).toHaveBeenCalledTimes(2);
+  });
+
   it("overwrites spoofed identity headers with the verified claims on away requests", async () => {
     const created = clerkPreset({ secret });
     const material = await created.actAs(principal, grant);

--- a/packages/actions/src/presets/adversarial.test.ts
+++ b/packages/actions/src/presets/adversarial.test.ts
@@ -1,0 +1,203 @@
+import type { PermissionGrant, Principal } from "@vendoai/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  auth0Preset,
+  authJsPreset,
+  clerkPreset,
+  genericJwtPreset,
+  supabasePreset,
+} from "./index.js";
+import { signHs256 } from "./shared.js";
+
+// Red-team suite for @vendoai/actions/presets. actAs material is host
+// authority: a forged, replayed, or tampered away-token must never verify, and
+// the signing secret must never surface in AuthMaterial or logs.
+
+const principal: Principal = { kind: "user", subject: "victim-user" };
+const grant: PermissionGrant = {
+  id: "grt_victim",
+  subject: principal.subject,
+  tool: "host_transfer_create",
+  descriptorHash: "sha256:victim",
+  scope: { kind: "tool" },
+  duration: "standing",
+  source: "automation",
+  grantedAt: "2026-07-14T00:00:00.000Z",
+};
+const secret = "away-token-secret-belonging-to-the-host-32b";
+const attackerSecret = "attacker-chosen-secret-also-32-bytes-long";
+
+function base64Url(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+describe("away-token forgery and replay", () => {
+  beforeEach(() => vi.useFakeTimers().setSystemTime(new Date("2026-07-14T12:00:00.000Z")));
+  afterEach(() => vi.useRealTimers());
+
+  it("rejects a token signed with a secret the host never issued", async () => {
+    const forged = await signHs256(
+      {
+        iss: "vendo",
+        aud: "vendo-away",
+        sub: principal.subject,
+        provider: "clerk",
+        grantId: grant.id,
+        tool: grant.tool,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 300,
+      },
+      attackerSecret,
+      { typ: "vendo-away+jwt" },
+    );
+    const verifier = clerkPreset({ secret });
+
+    await expect(verifier.verify(forged)).rejects.toThrow("invalid JWT signature");
+    const response = await verifier.nextMiddleware(new Request("https://host.test/api/probe", {
+      headers: { authorization: `VendoAway ${forged}` },
+    }));
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects a legitimate token whose subject was swapped after signing", async () => {
+    const created = clerkPreset({ secret });
+    const material = await created.actAs(principal, grant);
+    const token = (material?.headers.authorization ?? "").replace(/^VendoAway /, "");
+    const [header = "", payload = "", signature = ""] = token.split(".");
+    const claims = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as Record<string, unknown>;
+    const tampered = `${header}.${base64Url(JSON.stringify({ ...claims, sub: "attacker-user" }))}.${signature}`;
+
+    await expect(created.verify(tampered)).rejects.toThrow("invalid JWT signature");
+  });
+
+  it("rejects an unsigned alg:none token even when its claims are perfect", async () => {
+    const header = base64Url(JSON.stringify({ alg: "none", typ: "vendo-away+jwt" }));
+    const payload = base64Url(JSON.stringify({
+      iss: "vendo",
+      aud: "vendo-away",
+      sub: principal.subject,
+      provider: "clerk",
+      grantId: grant.id,
+      tool: grant.tool,
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 300,
+    }));
+    const verifier = clerkPreset({ secret });
+
+    await expect(verifier.verify(`${header}.${payload}.`)).rejects.toThrow();
+    await expect(verifier.verify(`${header}.${payload}`)).rejects.toThrow();
+  });
+
+  it("rejects a Clerk-minted token replayed against the Auth0 verifier", async () => {
+    const clerk = clerkPreset({ secret });
+    const auth0 = auth0Preset({ secret });
+    const material = await clerk.actAs(principal, grant);
+
+    await expect(auth0.verify(material?.headers.authorization ?? ""))
+      .rejects.toThrow("invalid Vendo away-token claims");
+  });
+
+  it("rejects a token minted for a different issuer or audience", async () => {
+    const otherHost = clerkPreset({ secret, issuer: "other-product", audience: "other-api" });
+    const verifier = clerkPreset({ secret });
+    const material = await otherHost.actAs(principal, grant);
+
+    await expect(verifier.verify(material?.headers.authorization ?? ""))
+      .rejects.toThrow(/invalid JWT (issuer|audience)/);
+  });
+
+  it("rejects a plain HS256 JWT that lacks the vendo-away token type", async () => {
+    const lookalike = genericJwtPreset({
+      secret,
+      claims: () => ({
+        iss: "vendo",
+        aud: "vendo-away",
+        provider: "clerk",
+        grantId: grant.id,
+        tool: grant.tool,
+      }),
+    });
+    const verifier = clerkPreset({ secret });
+    const material = await lookalike(principal, grant);
+    const token = (material?.headers.authorization ?? "").replace(/^Bearer /, "");
+
+    await expect(verifier.verify(token)).rejects.toThrow("invalid JWT type");
+  });
+});
+
+describe("trusted header spoofing", () => {
+  beforeEach(() => vi.useFakeTimers().setSystemTime(new Date("2026-07-14T12:00:00.000Z")));
+  afterEach(() => vi.useRealTimers());
+
+  it("strips caller-supplied x-vendo-away-* headers from ordinary requests", async () => {
+    const created = clerkPreset({ secret });
+    const response = await created.nextMiddleware(new Request("https://host.test/api/probe", {
+      headers: {
+        authorization: "Bearer ordinary-provider-session",
+        "x-vendo-away-subject": "attacker-user",
+        "x-vendo-away-provider": "clerk",
+        "x-vendo-away-grant": "grt_forged",
+        "x-vendo-away-tool": "host_transfer_create",
+      },
+    }));
+
+    expect(response.status).toBe(200);
+    for (const name of ["subject", "provider", "grant", "tool"]) {
+      expect(response.headers.get(`x-middleware-request-x-vendo-away-${name}`)).toBeNull();
+    }
+    // The provider session continues to the host verifier untouched.
+    expect(response.headers.get("x-middleware-request-authorization"))
+      .toBe("Bearer ordinary-provider-session");
+  });
+
+  it("overwrites spoofed identity headers with the verified claims on away requests", async () => {
+    const created = clerkPreset({ secret });
+    const material = await created.actAs(principal, grant);
+    const response = await created.nextMiddleware(new Request("https://host.test/api/probe", {
+      headers: {
+        authorization: material?.headers.authorization ?? "",
+        "x-vendo-away-subject": "attacker-user",
+      },
+    }));
+
+    expect(response.headers.get("x-middleware-request-x-vendo-away-subject")).toBe(principal.subject);
+  });
+});
+
+describe("secret containment", () => {
+  const presets = [
+    ["Generic JWT", genericJwtPreset({ secret })],
+    ["Auth.js", authJsPreset({ secret })],
+    ["Supabase Auth", supabasePreset({ secret })],
+    ["Clerk away-token", clerkPreset({ secret }).actAs],
+    ["Auth0 away-token", auth0Preset({ secret }).actAs],
+  ] as const;
+
+  it.each(presets)("%s never leaks the signing secret into AuthMaterial or console output", async (_name, actAs) => {
+    const spies = (["log", "info", "warn", "error", "debug"] as const)
+      .map((level) => vi.spyOn(console, level));
+    try {
+      const material = await actAs(principal, grant);
+
+      expect(material).not.toBeNull();
+      const serialized = JSON.stringify(material);
+      expect(serialized).not.toContain(secret);
+      expect(serialized).not.toContain(Buffer.from(secret, "utf8").toString("base64url"));
+      for (const spy of spies) expect(spy).not.toHaveBeenCalled();
+    } finally {
+      for (const spy of spies) spy.mockRestore();
+    }
+  });
+
+  it("declines with a bare null (no secret-bearing error) when the secret resolver throws-adjacent returns nothing", async () => {
+    const spies = (["log", "info", "warn", "error", "debug"] as const)
+      .map((level) => vi.spyOn(console, level));
+    try {
+      const actAs = genericJwtPreset({ secret: async () => undefined });
+      await expect(actAs(principal, grant)).resolves.toBeNull();
+      for (const spy of spies) expect(spy).not.toHaveBeenCalled();
+    } finally {
+      for (const spy of spies) spy.mockRestore();
+    }
+  });
+});

--- a/packages/actions/src/presets/auth-js.test.ts
+++ b/packages/actions/src/presets/auth-js.test.ts
@@ -1,0 +1,105 @@
+import { getToken } from "@auth/core/jwt";
+import type { PermissionGrant, Principal } from "@vendoai/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { authJsPreset } from "./index.js";
+
+const principal: Principal = { kind: "user", subject: "user_authjs" };
+const grant: PermissionGrant = {
+  id: "grt_authjs",
+  subject: principal.subject,
+  tool: "host_profile",
+  descriptorHash: "sha256:authjs",
+  scope: { kind: "tool" },
+  duration: "standing",
+  source: "automation",
+  grantedAt: "2026-07-14T00:00:00.000Z",
+};
+const secret = "authjs-secret-for-real-jwe-verification";
+const cookieName = "authjs.session-token";
+
+describe("authJsPreset", () => {
+  beforeEach(() => vi.useFakeTimers().setSystemTime(new Date("2026-07-14T12:00:00.000Z")));
+  afterEach(() => vi.useRealTimers());
+
+  it("mints an Auth.js v5 JWE accepted by the real getToken implementation", async () => {
+    const actAs = authJsPreset({
+      secret,
+      cookieName,
+      expiresInSeconds: 120,
+      claims: () => ({ name: "Ada", email: "ada@example.com" }),
+    });
+
+    const material = await actAs(principal, grant);
+
+    expect(material?.headers.cookie).toMatch(/^authjs\.session-token=/);
+    const token = await getToken({
+      req: { headers: material?.headers ?? {} },
+      secret,
+      cookieName,
+    });
+    expect(token).toMatchObject({
+      sub: principal.subject,
+      name: "Ada",
+      email: "ada@example.com",
+    });
+  });
+
+  it("caches until the safety margin and then refreshes", async () => {
+    const actAs = authJsPreset({
+      secret,
+      cookieName,
+      expiresInSeconds: 120,
+      cacheSafetySeconds: 10,
+    });
+
+    const first = await actAs(principal, grant);
+    vi.advanceTimersByTime(109_000);
+    const cached = await actAs(principal, grant);
+    vi.advanceTimersByTime(2_000);
+    const refreshed = await actAs(principal, grant);
+
+    expect(cached).toEqual(first);
+    expect(refreshed?.headers.cookie).not.toBe(first?.headers.cookie);
+  });
+
+  it("never reuses a cached JWE once its whole-second Auth.js expiry is reached", async () => {
+    vi.setSystemTime(new Date("2026-07-14T12:00:00.900Z"));
+    const actAs = authJsPreset({
+      secret,
+      cookieName,
+      expiresInSeconds: 60,
+      cacheSafetySeconds: 0,
+    });
+
+    const first = await actAs(principal, grant);
+    vi.advanceTimersByTime(59_100);
+    const refreshed = await actAs(principal, grant);
+
+    expect(refreshed?.headers.cookie).not.toBe(first?.headers.cookie);
+    await expect(getToken({
+      req: { headers: refreshed?.headers ?? {} },
+      secret,
+      cookieName,
+    })).resolves.toMatchObject({ sub: principal.subject });
+  });
+
+  it("uses Auth.js's secure default cookie name when requested", async () => {
+    const actAs = authJsPreset({ secret, secureCookie: true });
+    const material = await actAs(principal, grant);
+
+    expect(material?.headers.cookie).toMatch(/^__Secure-authjs\.session-token=/);
+    await expect(getToken({
+      req: { headers: material?.headers ?? {} },
+      secret,
+      secureCookie: true,
+    })).resolves.toMatchObject({ sub: principal.subject });
+  });
+
+  it("declines when the host cannot resolve claims or the secret", async () => {
+    const denied = authJsPreset({ secret, claims: () => null });
+    const missingSecret = authJsPreset({ secret: async () => undefined });
+
+    await expect(denied(principal, grant)).resolves.toBeNull();
+    await expect(missingSecret(principal, grant)).resolves.toBeNull();
+  });
+});

--- a/packages/actions/src/presets/auth-js.ts
+++ b/packages/actions/src/presets/auth-js.ts
@@ -61,7 +61,7 @@ export function authJsPreset(options: AuthJsPresetOptions = {}): ActAs {
     if (!token) {
       const encode = await loadEncode();
       token = await encode({ token: claims, secret, salt: cookieName, maxAge: expiresInSeconds });
-      cache.set(key, token, (Math.floor(nowMs / 1000) + expiresInSeconds) * 1000);
+      cache.set(key, token, (Math.floor(nowMs / 1000) + expiresInSeconds) * 1000, nowMs);
     }
     return { headers: { cookie: `${cookieName}=${token}` } };
   };

--- a/packages/actions/src/presets/auth-js.ts
+++ b/packages/actions/src/presets/auth-js.ts
@@ -1,0 +1,68 @@
+import type { ActAs, AuthMaterial } from "@vendoai/core";
+import {
+  TokenCache,
+  assertLifetime,
+  resolveClaims,
+  resolveSecret,
+  secretFingerprint,
+  stableJson,
+  type ClaimsOption,
+  type JwtClaims,
+  type SecretSource,
+} from "./shared.js";
+
+type AuthJsEncode = (options: {
+  token: JwtClaims;
+  secret: string;
+  salt: string;
+  maxAge: number;
+}) => Promise<string>;
+
+export interface AuthJsPresetOptions {
+  /** The host's Auth.js secret. Defaults to AUTH_SECRET. */
+  secret?: SecretSource;
+  /** Must match the host's session cookie name because Auth.js uses it as the JWE salt. */
+  cookieName?: string;
+  /** Use Auth.js's `__Secure-` production cookie default when cookieName is omitted. */
+  secureCookie?: boolean;
+  claims?: ClaimsOption;
+  expiresInSeconds?: number;
+  cacheSafetySeconds?: number;
+}
+
+/** Mint an Auth.js v5 encrypted session JWE using @auth/core's own encoder. */
+export function authJsPreset(options: AuthJsPresetOptions = {}): ActAs {
+  const expiresInSeconds = options.expiresInSeconds ?? 300;
+  const cacheSafetySeconds = options.cacheSafetySeconds ?? 30;
+  const cookieName = options.cookieName
+    ?? (options.secureCookie ? "__Secure-authjs.session-token" : "authjs.session-token");
+  assertLifetime(expiresInSeconds, cacheSafetySeconds);
+  const cache = new TokenCache();
+  let encodePromise: Promise<AuthJsEncode> | undefined;
+  const loadEncode = (): Promise<AuthJsEncode> => {
+    encodePromise ??= import("@auth/core/jwt")
+      .then((module) => module.encode as unknown as AuthJsEncode);
+    return encodePromise;
+  };
+
+  return async (principal, grant): Promise<AuthMaterial | null> => {
+    const secret = await resolveSecret(options.secret, "AUTH_SECRET");
+    if (!secret) return null;
+    const additionalClaims = await resolveClaims(options.claims, principal, grant);
+    if (additionalClaims === null) return null;
+    const claims: JwtClaims = { ...additionalClaims, sub: principal.subject };
+    const nowMs = Date.now();
+    const key = stableJson({
+      secret: await secretFingerprint(secret),
+      cookieName,
+      claims,
+    });
+    let token = cache.get(key, nowMs, cacheSafetySeconds * 1000);
+    if (!token) {
+      const encode = await loadEncode();
+      token = await encode({ token: claims, secret, salt: cookieName, maxAge: expiresInSeconds });
+      cache.set(key, token, (Math.floor(nowMs / 1000) + expiresInSeconds) * 1000);
+    }
+    return { headers: { cookie: `${cookieName}=${token}` } };
+  };
+}

--- a/packages/actions/src/presets/away-token.test.ts
+++ b/packages/actions/src/presets/away-token.test.ts
@@ -1,0 +1,119 @@
+import type { PermissionGrant, Principal } from "@vendoai/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { auth0Preset, clerkPreset, type AwayTokenPreset } from "./index.js";
+
+const principal: Principal = { kind: "user", subject: "provider-user" };
+const grant: PermissionGrant = {
+  id: "grt_provider",
+  subject: principal.subject,
+  tool: "host_transfer_create",
+  descriptorHash: "sha256:provider",
+  scope: { kind: "tool" },
+  duration: "standing",
+  source: "automation",
+  grantedAt: "2026-07-14T00:00:00.000Z",
+};
+const secret = "vendo-away-token-secret-at-least-32-bytes";
+
+type ExpressRequest = { headers: Record<string, string | undefined>; vendoAwayToken?: unknown };
+
+describe.each([
+  ["Clerk", "clerk", clerkPreset],
+  ["Auth0", "auth0", auth0Preset],
+] as const)("%s away-token preset", (_label, provider, makePreset) => {
+  beforeEach(() => vi.useFakeTimers().setSystemTime(new Date("2026-07-14T12:00:00.000Z")));
+  afterEach(() => vi.useRealTimers());
+
+  function preset(): AwayTokenPreset {
+    return makePreset({ secret, expiresInSeconds: 60, cacheSafetySeconds: 5 });
+  }
+
+  it("mints a short-lived VendoAway token and verifies a doctor-probeable round trip", async () => {
+    const created = preset();
+    const material = await created.actAs(principal, grant);
+    const authorization = material?.headers.authorization ?? "";
+    const claims = await created.verify(authorization);
+
+    expect(authorization).toMatch(/^VendoAway /);
+    expect(claims).toMatchObject({
+      iss: "vendo",
+      aud: "vendo-away",
+      sub: principal.subject,
+      provider,
+      grantId: grant.id,
+      tool: grant.tool,
+    });
+    expect(claims.exp).toBe(claims.iat + 60);
+  });
+
+  it("caches through the safety window, refreshes, and supports host decline", async () => {
+    const created = preset();
+    const first = await created.actAs(principal, grant);
+    vi.advanceTimersByTime(54_000);
+    expect(await created.actAs(principal, grant)).toEqual(first);
+    vi.advanceTimersByTime(2_000);
+    expect((await created.actAs(principal, grant))?.headers.authorization).not.toBe(first?.headers.authorization);
+
+    const denied = makePreset({ secret, claims: () => null });
+    await expect(denied.actAs(principal, grant)).resolves.toBeNull();
+    const missingSecret = makePreset({ secret: async () => undefined });
+    await expect(missingSecret.actAs(principal, grant)).resolves.toBeNull();
+  });
+
+  it("rejects an expired away-token", async () => {
+    const created = preset();
+    const material = await created.actAs(principal, grant);
+    vi.advanceTimersByTime(61_000);
+
+    await expect(created.verify(material?.headers.authorization ?? "")).rejects.toThrow("expired JWT");
+  });
+
+  it("ships Express middleware that verifies away auth without swallowing provider auth", async () => {
+    const created = preset();
+    const material = await created.actAs(principal, grant);
+    const request: ExpressRequest = { headers: { authorization: material?.headers.authorization } };
+    const response = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+    const next = vi.fn();
+
+    await created.expressMiddleware(request, response, next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(request.vendoAwayToken).toMatchObject({ sub: principal.subject, provider });
+
+    const providerRequest: ExpressRequest = { headers: { authorization: "Bearer provider-token" } };
+    await created.expressMiddleware(providerRequest, response, next);
+    expect(next).toHaveBeenCalledTimes(2);
+    expect(providerRequest.vendoAwayToken).toBeUndefined();
+  });
+
+  it("fails invalid away tokens closed in both Express and Next.js middleware", async () => {
+    const created = preset();
+    const request: ExpressRequest = { headers: { authorization: "VendoAway invalid" } };
+    const response = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+    const next = vi.fn();
+
+    await created.expressMiddleware(request, response, next);
+    const nextResponse = await created.nextMiddleware(new Request("https://host.test/api/probe", {
+      headers: { authorization: "VendoAway invalid" },
+    }));
+
+    expect(next).not.toHaveBeenCalled();
+    expect(response.status).toHaveBeenCalledWith(401);
+    expect(response.json).toHaveBeenCalledWith({ error: "invalid-vendo-away-token" });
+    expect(nextResponse.status).toBe(401);
+    await expect(nextResponse.json()).resolves.toEqual({ error: "invalid-vendo-away-token" });
+  });
+
+  it("injects verified identity headers through real Next.js middleware semantics", async () => {
+    const created = preset();
+    const material = await created.actAs(principal, grant);
+    const response = await created.nextMiddleware(new Request("https://host.test/api/probe", {
+      headers: { authorization: material?.headers.authorization ?? "" },
+    }));
+
+    expect(response.headers.get("x-middleware-request-x-vendo-away-subject")).toBe(principal.subject);
+    expect(response.headers.get("x-middleware-request-x-vendo-away-provider")).toBe(provider);
+    expect(response.headers.get("x-middleware-request-x-vendo-away-grant")).toBe(grant.id);
+    expect(response.headers.get("x-middleware-request-x-vendo-away-tool")).toBe(grant.tool);
+  });
+});

--- a/packages/actions/src/presets/away-token.ts
+++ b/packages/actions/src/presets/away-token.ts
@@ -137,6 +137,12 @@ function makeAwayTokenPreset(
 
   const expressMiddleware: ExpressAwayTokenMiddleware = async (request, response, next) => {
     delete request.vendoAwayToken;
+    // Same anti-spoofing rule as the Next.js flavor: caller-supplied trusted
+    // identity headers never survive this middleware, on any request.
+    const trusted = new Set<string>(Object.values(TRUSTED_HEADERS));
+    for (const name of Object.keys(request.headers)) {
+      if (trusted.has(name.toLowerCase())) delete request.headers[name];
+    }
     const authorization = authorizationValue(request.headers);
     if (!isAwayAuthorization(authorization)) {
       next();

--- a/packages/actions/src/presets/away-token.ts
+++ b/packages/actions/src/presets/away-token.ts
@@ -1,0 +1,183 @@
+import type { ActAs } from "@vendoai/core";
+import { genericJwtPreset } from "./generic-jwt.js";
+import {
+  resolveClaims,
+  resolveSecret,
+  verifyHs256,
+  type ClaimsOption,
+  type SecretSource,
+} from "./shared.js";
+
+export type AwayTokenProvider = "clerk" | "auth0";
+
+export interface AwayTokenClaims extends Record<string, unknown> {
+  iss: string;
+  aud: string;
+  sub: string;
+  provider: AwayTokenProvider;
+  grantId: string;
+  tool: string;
+  iat: number;
+  exp: number;
+}
+
+export interface AwayTokenPresetOptions {
+  /** A host-owned secret shared by the producer and verifier. Defaults to VENDO_AWAY_TOKEN_SECRET. */
+  secret?: SecretSource;
+  issuer?: string;
+  audience?: string;
+  claims?: ClaimsOption;
+  expiresInSeconds?: number;
+  cacheSafetySeconds?: number;
+}
+
+export interface ExpressAwayTokenRequest {
+  headers: Record<string, string | string[] | undefined>;
+  vendoAwayToken?: AwayTokenClaims;
+}
+
+export interface ExpressAwayTokenResponse {
+  status(code: number): ExpressAwayTokenResponse;
+  json(body: unknown): unknown;
+}
+
+export type ExpressAwayTokenMiddleware = (
+  request: ExpressAwayTokenRequest,
+  response: ExpressAwayTokenResponse,
+  next: () => void,
+) => Promise<void>;
+
+export interface AwayTokenPreset {
+  actAs: ActAs;
+  /** Verify either the compact token or its complete `VendoAway ...` header value. */
+  verify(tokenOrAuthorization: string): Promise<AwayTokenClaims>;
+  /** Next.js middleware.ts-compatible verifier; mount it on the host API matcher. */
+  nextMiddleware(request: Request): Promise<Response>;
+  /** Express middleware that attaches verified claims to req.vendoAwayToken. */
+  expressMiddleware: ExpressAwayTokenMiddleware;
+}
+
+const TRUSTED_HEADERS = {
+  subject: "x-vendo-away-subject",
+  provider: "x-vendo-away-provider",
+  grant: "x-vendo-away-grant",
+  tool: "x-vendo-away-tool",
+} as const;
+
+function authorizationValue(headers: ExpressAwayTokenRequest["headers"]): string | undefined {
+  const match = Object.entries(headers)
+    .find(([name]) => name.toLowerCase() === "authorization")?.[1];
+  return Array.isArray(match) ? match[0] : match;
+}
+
+function extractToken(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed.includes(" ") && trimmed.split(".").length === 3) return trimmed;
+  const match = /^VendoAway\s+(\S+)$/i.exec(trimmed);
+  if (!match?.[1]) throw new Error("invalid VendoAway authorization");
+  return match[1];
+}
+
+function isAwayAuthorization(value: string | undefined): value is string {
+  return value !== undefined && /^VendoAway(?:\s|$)/i.test(value);
+}
+
+function invalidResponse(): Response {
+  return Response.json({ error: "invalid-vendo-away-token" }, { status: 401 });
+}
+
+function makeAwayTokenPreset(
+  provider: AwayTokenProvider,
+  options: AwayTokenPresetOptions,
+): AwayTokenPreset {
+  const issuer = options.issuer ?? "vendo";
+  const audience = options.audience ?? "vendo-away";
+  const secretSource = options.secret ?? (() => process.env.VENDO_AWAY_TOKEN_SECRET);
+  const actAs = genericJwtPreset({
+    secret: secretSource,
+    expiresInSeconds: options.expiresInSeconds ?? 300,
+    cacheSafetySeconds: options.cacheSafetySeconds,
+    jwtHeader: { typ: "vendo-away+jwt" },
+    headers: (token) => ({ authorization: `VendoAway ${token}` }),
+    claims: async (principal, grant) => {
+      const additional = await resolveClaims(options.claims, principal, grant);
+      if (additional === null) return null;
+      return {
+        ...additional,
+        iss: issuer,
+        aud: audience,
+        sub: principal.subject,
+        provider,
+        grantId: grant.id,
+        tool: grant.tool,
+      };
+    },
+  });
+
+  const verify = async (tokenOrAuthorization: string): Promise<AwayTokenClaims> => {
+    const secret = await resolveSecret(secretSource);
+    if (!secret) throw new Error("VENDO_AWAY_TOKEN_SECRET is unavailable");
+    const { payload } = await verifyHs256(extractToken(tokenOrAuthorization), secret, {
+      issuer,
+      audience,
+      type: "vendo-away+jwt",
+    });
+    if (
+      payload.provider !== provider
+      || typeof payload.sub !== "string"
+      || typeof payload.grantId !== "string"
+      || typeof payload.tool !== "string"
+      || typeof payload.iat !== "number"
+      || typeof payload.exp !== "number"
+    ) {
+      throw new Error("invalid Vendo away-token claims");
+    }
+    return payload as AwayTokenClaims;
+  };
+
+  const expressMiddleware: ExpressAwayTokenMiddleware = async (request, response, next) => {
+    delete request.vendoAwayToken;
+    const authorization = authorizationValue(request.headers);
+    if (!isAwayAuthorization(authorization)) {
+      next();
+      return;
+    }
+    try {
+      request.vendoAwayToken = await verify(authorization);
+      next();
+    } catch {
+      response.status(401).json({ error: "invalid-vendo-away-token" });
+    }
+  };
+
+  const nextMiddleware = async (request: Request): Promise<Response> => {
+    const { NextResponse } = await import("next/server.js");
+    const headers = new Headers(request.headers);
+    for (const name of Object.values(TRUSTED_HEADERS)) headers.delete(name);
+    const authorization = headers.get("authorization") ?? undefined;
+    if (!isAwayAuthorization(authorization)) return NextResponse.next({ request: { headers } });
+    let claims: AwayTokenClaims;
+    try {
+      claims = await verify(authorization);
+    } catch {
+      return invalidResponse();
+    }
+    headers.set(TRUSTED_HEADERS.subject, claims.sub);
+    headers.set(TRUSTED_HEADERS.provider, claims.provider);
+    headers.set(TRUSTED_HEADERS.grant, claims.grantId);
+    headers.set(TRUSTED_HEADERS.tool, claims.tool);
+    return NextResponse.next({ request: { headers } });
+  };
+
+  return { actAs, verify, expressMiddleware, nextMiddleware };
+}
+
+/** Clerk cannot mint provider RS256 sessions offline, so this uses a host-owned away-token. */
+export function clerkPreset(options: AwayTokenPresetOptions = {}): AwayTokenPreset {
+  return makeAwayTokenPreset("clerk", options);
+}
+
+/** Auth0 cannot mint provider RS256 sessions offline, so this uses a host-owned away-token. */
+export function auth0Preset(options: AwayTokenPresetOptions = {}): AwayTokenPreset {
+  return makeAwayTokenPreset("auth0", options);
+}

--- a/packages/actions/src/presets/conformance.test.ts
+++ b/packages/actions/src/presets/conformance.test.ts
@@ -1,0 +1,40 @@
+import type { PermissionGrant, Principal } from "@vendoai/core";
+import { actAsConformance, runConformance } from "@vendoai/core/conformance";
+import { describe, expect, it } from "vitest";
+import {
+  auth0Preset,
+  authJsPreset,
+  clerkPreset,
+  genericJwtPreset,
+  supabasePreset,
+} from "./index.js";
+
+const principal: Principal = { kind: "user", subject: "preset-conformance-user" };
+const grant: PermissionGrant = {
+  id: "grt_preset_conformance",
+  subject: principal.subject,
+  tool: "host_conformance",
+  descriptorHash: "sha256:preset-conformance",
+  scope: { kind: "tool" },
+  duration: "standing",
+  source: "automation",
+  grantedAt: "2026-07-14T00:00:00.000Z",
+};
+const secret = "preset-conformance-secret-at-least-32-bytes";
+
+describe.each([
+  ["Generic JWT", genericJwtPreset({ secret })],
+  ["Auth.js", authJsPreset({ secret })],
+  ["Supabase Auth", supabasePreset({ secret })],
+  ["Clerk away-token", clerkPreset({ secret }).actAs],
+  ["Auth0 away-token", auth0Preset({ secret }).actAs],
+] as const)("%s preset", (_name, actAs) => {
+  it("passes the core ActAs conformance suite", async () => {
+    const suite = actAsConformance({ actAs, principal, grant });
+    const report = await runConformance(suite);
+
+    expect(report.ok).toBe(true);
+    expect(report.failures).toEqual([]);
+    expect(report.passed).toBe(suite.cases.length);
+  });
+});

--- a/packages/actions/src/presets/generic-jwt.test.ts
+++ b/packages/actions/src/presets/generic-jwt.test.ts
@@ -1,0 +1,60 @@
+import { decodeProtectedHeader, jwtVerify } from "jose";
+import type { PermissionGrant, Principal } from "@vendoai/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { genericJwtPreset } from "./index.js";
+
+const principal: Principal = { kind: "user", subject: "generic-user" };
+const grant: PermissionGrant = {
+  id: "grt_generic",
+  subject: principal.subject,
+  tool: "host_generic",
+  descriptorHash: "sha256:generic",
+  scope: { kind: "tool" },
+  duration: "standing",
+  source: "automation",
+  grantedAt: "2026-07-14T00:00:00.000Z",
+};
+const secret = "generic-jwt-secret-at-least-32-bytes-long";
+
+describe("genericJwtPreset", () => {
+  beforeEach(() => vi.useFakeTimers().setSystemTime(new Date("2026-07-14T12:00:00.000Z")));
+  afterEach(() => vi.useRealTimers());
+
+  it("supports custom claims, protected headers, and AuthMaterial header shape", async () => {
+    const actAs = genericJwtPreset({
+      secret,
+      expiresInSeconds: 90,
+      claims: (_principal, receivedGrant) => ({
+        sub: "host-user-42",
+        tenant: "tenant-a",
+        permission: receivedGrant.tool,
+      }),
+      jwtHeader: { kid: "current-key", typ: "at+jwt" },
+      headers: (token) => ({ "x-host-token": token, "x-token-kind": "vendo-act-as" }),
+    });
+
+    const material = await actAs(principal, grant);
+    const token = material?.headers["x-host-token"] ?? "";
+    const verified = await jwtVerify(token, new TextEncoder().encode(secret), { algorithms: ["HS256"] });
+
+    expect(material?.headers["x-token-kind"]).toBe("vendo-act-as");
+    expect(decodeProtectedHeader(token)).toMatchObject({ alg: "HS256", kid: "current-key", typ: "at+jwt" });
+    expect(verified.payload).toMatchObject({
+      sub: "host-user-42",
+      tenant: "tenant-a",
+      permission: grant.tool,
+    });
+  });
+
+  it("caches matching material, refreshes near expiry, and declines explicitly", async () => {
+    const actAs = genericJwtPreset({ secret, expiresInSeconds: 60, cacheSafetySeconds: 5 });
+    const first = await actAs(principal, grant);
+    vi.advanceTimersByTime(54_000);
+    expect(await actAs(principal, grant)).toEqual(first);
+    vi.advanceTimersByTime(2_000);
+    expect((await actAs(principal, grant))?.headers.authorization).not.toBe(first?.headers.authorization);
+
+    await expect(genericJwtPreset({ secret, claims: () => null })(principal, grant)).resolves.toBeNull();
+    await expect(genericJwtPreset({ secret: async () => undefined })(principal, grant)).resolves.toBeNull();
+  });
+});

--- a/packages/actions/src/presets/generic-jwt.ts
+++ b/packages/actions/src/presets/generic-jwt.ts
@@ -1,0 +1,63 @@
+import type { ActAs, AuthMaterial } from "@vendoai/core";
+import {
+  TokenCache,
+  assertLifetime,
+  resolveClaims,
+  resolveSecret,
+  secretFingerprint,
+  signHs256,
+  stableJson,
+  type ClaimsOption,
+  type JwtClaims,
+  type SecretSource,
+} from "./shared.js";
+
+export interface GenericJwtPresetOptions {
+  /** An HS256 secret or lazy secret resolver. An unavailable secret declines actAs. */
+  secret?: SecretSource;
+  /** Static claims or a resolver. Returning null declines actAs for that principal/grant. */
+  claims?: ClaimsOption;
+  /** Extra protected-header fields. `alg` is always forced to HS256. */
+  jwtHeader?: JwtClaims;
+  /** Convert the compact JWT to AuthMaterial headers. Defaults to Authorization: Bearer. */
+  headers?: (token: string) => Record<string, string>;
+  expiresInSeconds?: number;
+  cacheSafetySeconds?: number;
+}
+
+/** Configurable HS256 actAs for hosts with a conventional shared-secret JWT verifier. */
+export function genericJwtPreset(options: GenericJwtPresetOptions): ActAs {
+  const expiresInSeconds = options.expiresInSeconds ?? 300;
+  const cacheSafetySeconds = options.cacheSafetySeconds ?? 30;
+  assertLifetime(expiresInSeconds, cacheSafetySeconds);
+  const cache = new TokenCache();
+  const toHeaders = options.headers ?? ((token: string) => ({ authorization: `Bearer ${token}` }));
+
+  return async (principal, grant): Promise<AuthMaterial | null> => {
+    const secret = await resolveSecret(options.secret);
+    if (!secret) return null;
+    const additionalClaims = await resolveClaims(options.claims, principal, grant);
+    if (additionalClaims === null) return null;
+    const nowMs = Date.now();
+    const nowSeconds = Math.floor(nowMs / 1000);
+    const payload: JwtClaims = {
+      sub: principal.subject,
+      ...additionalClaims,
+      iat: nowSeconds,
+      exp: nowSeconds + expiresInSeconds,
+    };
+    const key = stableJson({
+      secret: await secretFingerprint(secret),
+      payload: { ...payload, iat: undefined, exp: undefined },
+      header: options.jwtHeader ?? {},
+    });
+    let token = cache.get(key, nowMs, cacheSafetySeconds * 1000);
+    if (!token) {
+      token = await signHs256(payload, secret, options.jwtHeader);
+      cache.set(key, token, (nowSeconds + expiresInSeconds) * 1000);
+    }
+    return { headers: { ...toHeaders(token) } };
+  };
+}
+
+export type { ClaimsOption, ClaimsResolver, JwtClaims, SecretSource } from "./shared.js";

--- a/packages/actions/src/presets/generic-jwt.ts
+++ b/packages/actions/src/presets/generic-jwt.ts
@@ -54,7 +54,7 @@ export function genericJwtPreset(options: GenericJwtPresetOptions): ActAs {
     let token = cache.get(key, nowMs, cacheSafetySeconds * 1000);
     if (!token) {
       token = await signHs256(payload, secret, options.jwtHeader);
-      cache.set(key, token, (nowSeconds + expiresInSeconds) * 1000);
+      cache.set(key, token, (nowSeconds + expiresInSeconds) * 1000, nowMs);
     }
     return { headers: { ...toHeaders(token) } };
   };

--- a/packages/actions/src/presets/index.ts
+++ b/packages/actions/src/presets/index.ts
@@ -1,0 +1,21 @@
+export { authJsPreset, type AuthJsPresetOptions } from "./auth-js.js";
+export { supabasePreset, type SupabasePresetOptions } from "./supabase.js";
+export {
+  genericJwtPreset,
+  type ClaimsOption,
+  type ClaimsResolver,
+  type GenericJwtPresetOptions,
+  type JwtClaims,
+  type SecretSource,
+} from "./generic-jwt.js";
+export {
+  auth0Preset,
+  clerkPreset,
+  type AwayTokenClaims,
+  type AwayTokenPreset,
+  type AwayTokenPresetOptions,
+  type AwayTokenProvider,
+  type ExpressAwayTokenMiddleware,
+  type ExpressAwayTokenRequest,
+  type ExpressAwayTokenResponse,
+} from "./away-token.js";

--- a/packages/actions/src/presets/shared.test.ts
+++ b/packages/actions/src/presets/shared.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { TokenCache } from "./shared.js";
+
+describe("TokenCache", () => {
+  it("returns cached tokens inside the safety margin and drops them past it", () => {
+    const cache = new TokenCache();
+    cache.set("a", "token-a", 10_000, 0);
+
+    expect(cache.get("a", 4_999, 5_000)).toBe("token-a");
+    expect(cache.get("a", 5_000, 5_000)).toBeUndefined();
+  });
+
+  it("evicts expired entries on set so abandoned subjects cannot grow the cache unbounded", () => {
+    const cache = new TokenCache();
+    cache.set("stale-1", "t1", 1_000, 0);
+    cache.set("stale-2", "t2", 2_000, 0);
+    cache.set("live", "t3", 60_000, 0);
+
+    // Both stale entries have expired; nobody ever calls get() for them again.
+    cache.set("new", "t4", 120_000, 3_000);
+
+    expect(cache.size).toBe(2);
+    expect(cache.get("live", 3_000, 0)).toBe("t3");
+    expect(cache.get("new", 3_000, 0)).toBe("t4");
+    expect(cache.get("stale-1", 3_000, 0)).toBeUndefined();
+    expect(cache.get("stale-2", 3_000, 0)).toBeUndefined();
+  });
+});

--- a/packages/actions/src/presets/shared.ts
+++ b/packages/actions/src/presets/shared.ts
@@ -17,6 +17,10 @@ interface CachedToken {
 export class TokenCache {
   readonly #tokens = new Map<string, CachedToken>();
 
+  get size(): number {
+    return this.#tokens.size;
+  }
+
   get(key: string, nowMs: number, safetyMs: number): string | undefined {
     const cached = this.#tokens.get(key);
     if (!cached) return undefined;
@@ -27,7 +31,12 @@ export class TokenCache {
     return cached.token;
   }
 
-  set(key: string, token: string, expiresAtMs: number): void {
+  set(key: string, token: string, expiresAtMs: number, nowMs: number): void {
+    // Evict every expired entry so keys that are never read again (users who
+    // stop triggering runs, rotated secrets) cannot grow the cache unbounded.
+    for (const [cachedKey, cached] of this.#tokens) {
+      if (nowMs >= cached.expiresAtMs) this.#tokens.delete(cachedKey);
+    }
     this.#tokens.set(key, { token, expiresAtMs });
   }
 }

--- a/packages/actions/src/presets/shared.ts
+++ b/packages/actions/src/presets/shared.ts
@@ -1,0 +1,201 @@
+import type { PermissionGrant, Principal } from "@vendoai/core";
+
+export type Awaitable<T> = T | Promise<T>;
+export type SecretSource = string | (() => Awaitable<string | undefined>);
+export type JwtClaims = Record<string, unknown>;
+export type ClaimsResolver = (
+  principal: Principal,
+  grant: PermissionGrant,
+) => Awaitable<JwtClaims | null>;
+export type ClaimsOption = JwtClaims | ClaimsResolver;
+
+interface CachedToken {
+  token: string;
+  expiresAtMs: number;
+}
+
+export class TokenCache {
+  readonly #tokens = new Map<string, CachedToken>();
+
+  get(key: string, nowMs: number, safetyMs: number): string | undefined {
+    const cached = this.#tokens.get(key);
+    if (!cached) return undefined;
+    if (nowMs >= cached.expiresAtMs - safetyMs) {
+      this.#tokens.delete(key);
+      return undefined;
+    }
+    return cached.token;
+  }
+
+  set(key: string, token: string, expiresAtMs: number): void {
+    this.#tokens.set(key, { token, expiresAtMs });
+  }
+}
+
+export function assertLifetime(expiresInSeconds: number, cacheSafetySeconds: number): void {
+  if (!Number.isFinite(expiresInSeconds) || expiresInSeconds <= 0) {
+    throw new TypeError("expiresInSeconds must be greater than zero");
+  }
+  if (!Number.isFinite(cacheSafetySeconds) || cacheSafetySeconds < 0) {
+    throw new TypeError("cacheSafetySeconds must be zero or greater");
+  }
+}
+
+export async function resolveSecret(
+  source: SecretSource | undefined,
+  fallbackEnvironmentName?: string,
+): Promise<string | undefined> {
+  const value = source === undefined
+    ? (fallbackEnvironmentName ? process.env[fallbackEnvironmentName] : undefined)
+    : typeof source === "function"
+      ? await source()
+      : source;
+  return value && value.length > 0 ? value : undefined;
+}
+
+export async function resolveClaims(
+  option: ClaimsOption | undefined,
+  principal: Principal,
+  grant: PermissionGrant,
+): Promise<JwtClaims | null> {
+  if (option === undefined) return {};
+  const claims = typeof option === "function" ? await option(principal, grant) : option;
+  return claims === null ? null : { ...claims };
+}
+
+function canonical(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, canonical(entry)]),
+    );
+  }
+  return value;
+}
+
+export function stableJson(value: unknown): string {
+  return JSON.stringify(canonical(value));
+}
+
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function fromBase64Url(value: string): Uint8Array {
+  if (!/^[A-Za-z0-9_-]+$/.test(value) || value.length % 4 === 1) {
+    throw new Error("invalid base64url encoding");
+  }
+  const padding = "=".repeat((4 - (value.length % 4)) % 4);
+  const binary = atob(value.replace(/-/g, "+").replace(/_/g, "/") + padding);
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}
+
+export async function secretFingerprint(secret: string): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", new TextEncoder().encode(secret));
+  return toBase64Url(new Uint8Array(digest));
+}
+
+function encodeJson(value: unknown): string {
+  return toBase64Url(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+function decodeJson(value: string): unknown {
+  return JSON.parse(new TextDecoder().decode(fromBase64Url(value))) as unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function hmacKey(secret: string, usage: "sign" | "verify"): Promise<CryptoKey> {
+  return globalThis.crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    [usage],
+  );
+}
+
+export async function signHs256(
+  payload: JwtClaims,
+  secret: string,
+  header: JwtClaims = {},
+): Promise<string> {
+  const protectedHeader = encodeJson({ typ: "JWT", ...header, alg: "HS256" });
+  const encodedPayload = encodeJson(payload);
+  const signingInput = `${protectedHeader}.${encodedPayload}`;
+  const key = await hmacKey(secret, "sign");
+  const signature = await globalThis.crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(signingInput),
+  );
+  return `${signingInput}.${toBase64Url(new Uint8Array(signature))}`;
+}
+
+export interface VerifyHs256Options {
+  nowSeconds?: number;
+  issuer?: string;
+  audience?: string;
+  type?: string;
+}
+
+export async function verifyHs256(
+  token: string,
+  secret: string,
+  options: VerifyHs256Options = {},
+): Promise<{ header: JwtClaims; payload: JwtClaims }> {
+  const parts = token.split(".");
+  if (parts.length !== 3 || parts.some((part) => part.length === 0)) {
+    throw new Error("invalid JWT shape");
+  }
+  const [encodedHeader, encodedPayload, encodedSignature] = parts as [string, string, string];
+  let received: Uint8Array;
+  try {
+    received = fromBase64Url(encodedSignature);
+  } catch {
+    throw new Error("invalid JWT signature encoding");
+  }
+  const key = await hmacKey(secret, "verify");
+  const validSignature = await globalThis.crypto.subtle.verify(
+    "HMAC",
+    key,
+    Uint8Array.from(received),
+    new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`),
+  );
+  if (!validSignature) {
+    throw new Error("invalid JWT signature");
+  }
+
+  let header: unknown;
+  let payload: unknown;
+  try {
+    header = decodeJson(encodedHeader);
+    payload = decodeJson(encodedPayload);
+  } catch {
+    throw new Error("invalid JWT JSON");
+  }
+  if (!isRecord(header) || header.alg !== "HS256") throw new Error("invalid JWT algorithm");
+  if (!isRecord(payload)) throw new Error("invalid JWT payload");
+  if (options.type !== undefined && header.typ !== options.type) throw new Error("invalid JWT type");
+  if (options.issuer !== undefined && payload.iss !== options.issuer) throw new Error("invalid JWT issuer");
+  if (options.audience !== undefined) {
+    const audience = payload.aud;
+    if (audience !== options.audience && !(Array.isArray(audience) && audience.includes(options.audience))) {
+      throw new Error("invalid JWT audience");
+    }
+  }
+  const now = options.nowSeconds ?? Math.floor(Date.now() / 1000);
+  if (typeof payload.exp !== "number" || !Number.isFinite(payload.exp) || payload.exp <= now) {
+    throw new Error("expired JWT");
+  }
+  if (payload.nbf !== undefined && (typeof payload.nbf !== "number" || payload.nbf > now)) {
+    throw new Error("JWT is not active");
+  }
+  return { header, payload };
+}

--- a/packages/actions/src/presets/supabase.test.ts
+++ b/packages/actions/src/presets/supabase.test.ts
@@ -1,0 +1,61 @@
+import { jwtVerify } from "jose";
+import type { PermissionGrant, Principal } from "@vendoai/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { supabasePreset } from "./index.js";
+
+const principal: Principal = { kind: "user", subject: "supabase-user-id" };
+const grant: PermissionGrant = {
+  id: "grt_supabase",
+  subject: principal.subject,
+  tool: "host_invoices_list",
+  descriptorHash: "sha256:supabase",
+  scope: { kind: "tool" },
+  duration: "standing",
+  source: "automation",
+  grantedAt: "2026-07-14T00:00:00.000Z",
+};
+const secret = "supabase-project-jwt-secret-at-least-32-bytes";
+
+function bearer(material: Awaited<ReturnType<ReturnType<typeof supabasePreset>>>): string {
+  return material?.headers.authorization?.replace(/^Bearer /, "") ?? "";
+}
+
+describe("supabasePreset", () => {
+  beforeEach(() => vi.useFakeTimers().setSystemTime(new Date("2026-07-14T12:00:00.000Z")));
+  afterEach(() => vi.useRealTimers());
+
+  it("mints an HS256 token with Supabase claims that jose accepts", async () => {
+    const actAs = supabasePreset({ secret, audience: "authenticated", expiresInSeconds: 120 });
+    const material = await actAs(principal, grant);
+    const verified = await jwtVerify(bearer(material), new TextEncoder().encode(secret), {
+      algorithms: ["HS256"],
+      audience: "authenticated",
+    });
+
+    expect(verified.payload).toMatchObject({
+      sub: principal.subject,
+      role: "authenticated",
+      aud: "authenticated",
+    });
+    expect(verified.payload.exp).toBe(verified.payload.iat! + 120);
+  });
+
+  it("caches per subject until the safety margin and then refreshes", async () => {
+    const actAs = supabasePreset({ secret, expiresInSeconds: 60, cacheSafetySeconds: 5 });
+    const first = await actAs(principal, grant);
+    const other = await actAs({ ...principal, subject: "another-user" }, { ...grant, subject: "another-user" });
+    vi.advanceTimersByTime(54_000);
+    const cached = await actAs(principal, grant);
+    vi.advanceTimersByTime(2_000);
+    const refreshed = await actAs(principal, grant);
+
+    expect(cached).toEqual(first);
+    expect(other?.headers.authorization).not.toBe(first?.headers.authorization);
+    expect(refreshed?.headers.authorization).not.toBe(first?.headers.authorization);
+  });
+
+  it("declines when the claims resolver or project secret is unavailable", async () => {
+    await expect(supabasePreset({ secret, claims: () => null })(principal, grant)).resolves.toBeNull();
+    await expect(supabasePreset({ secret: async () => undefined })(principal, grant)).resolves.toBeNull();
+  });
+});

--- a/packages/actions/src/presets/supabase.ts
+++ b/packages/actions/src/presets/supabase.ts
@@ -1,0 +1,35 @@
+import type { ActAs } from "@vendoai/core";
+import { genericJwtPreset } from "./generic-jwt.js";
+import { resolveClaims, type ClaimsOption, type SecretSource } from "./shared.js";
+
+export interface SupabasePresetOptions {
+  /** The project's legacy JWT secret. Defaults to SUPABASE_JWT_SECRET. */
+  secret?: SecretSource;
+  audience?: string;
+  role?: string;
+  claims?: ClaimsOption;
+  expiresInSeconds?: number;
+  cacheSafetySeconds?: number;
+}
+
+/** Mint a native Supabase Auth HS256 access token without contacting Supabase. */
+export function supabasePreset(options: SupabasePresetOptions = {}): ActAs {
+  const audience = options.audience ?? "authenticated";
+  const role = options.role ?? "authenticated";
+  return genericJwtPreset({
+    secret: options.secret ?? (() => process.env.SUPABASE_JWT_SECRET),
+    expiresInSeconds: options.expiresInSeconds,
+    cacheSafetySeconds: options.cacheSafetySeconds,
+    jwtHeader: { typ: "JWT" },
+    claims: async (principal, grant) => {
+      const additional = await resolveClaims(options.claims, principal, grant);
+      if (additional === null) return null;
+      return {
+        ...additional,
+        sub: principal.subject,
+        role,
+        aud: audience,
+      };
+    },
+  });
+}

--- a/packages/actions/src/runtime/registry.test.ts
+++ b/packages/actions/src/runtime/registry.test.ts
@@ -526,6 +526,31 @@ describe("host HTTP execution — venue=mcp (10-mcp §3 / 04 §4 ActAs auth)", (
     expect(passed).toBe(realGrant);
   });
 
+  it("refuses a guard-attached grant for a different subject before actAs", async () => {
+    const host = await hostServer();
+    const mismatchedGrant: PermissionGrant = {
+      id: "grt_other_user",
+      subject: "user_2",
+      tool: "host_write",
+      descriptorHash: "sha256:real",
+      scope: { kind: "tool" },
+      duration: "standing",
+      source: "chat",
+      grantedAt: "2026-07-14T00:00:00.000Z",
+    };
+    const actAs = vi.fn(async () => ({ headers: { authorization: "Bearer act" } }));
+    const actions = createActions({ tools: [writeTool(host.url)], baseUrl: host.url, actAs });
+
+    const outcome = await actions.execute(
+      { id: "1", tool: "host_write", args: {} },
+      mcpCtx({ grant: mismatchedGrant, mcpConsent: { clientId: "mcpc_x", scopes: ["write"] } }),
+    );
+
+    expect(outcome).toMatchObject({ status: "error", error: { code: "act-as-subject-mismatch" } });
+    expect(actAs).not.toHaveBeenCalled();
+    expect(host.seen).toHaveLength(0);
+  });
+
   it("fails closed when the ctx carries neither a grant nor mcpConsent", async () => {
     const host = await hostServer();
     const actAs = vi.fn(async () => ({ headers: {} }));

--- a/packages/actions/src/runtime/registry.ts
+++ b/packages/actions/src/runtime/registry.ts
@@ -262,6 +262,14 @@ async function actAsAuth(
   grant: PermissionGrant,
   messages: { declined: string; failed: string },
 ): Promise<{ headers: Record<string, string> } | { error: ToolOutcome }> {
+  if (grant.subject !== principal.subject) {
+    return {
+      error: error(
+        "act-as-subject-mismatch",
+        "the captured grant does not belong to the current principal",
+      ),
+    };
+  }
   try {
     const auth = await actAs(principal, grant);
     if (!auth) return { error: error("not-implemented", messages.declined) };

--- a/packages/actions/src/security/actions-no-selfauth.test.ts
+++ b/packages/actions/src/security/actions-no-selfauth.test.ts
@@ -63,6 +63,39 @@ describe("actions never self-authorizes away execution", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it("refuses an away grant captured for a different subject before actAs", async () => {
+    const actAs = vi.fn(async () => ({ headers: { authorization: "Bearer host-issued" } }));
+    const fetchSpy = vi.fn();
+    const actions = createActions({
+      tools: [routeTool("host_probe")],
+      baseUrl: "http://host.test",
+      actAs,
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    const mismatched: ActionsRunContext = {
+      ...away,
+      grant: {
+        id: "grt_other_user",
+        subject: "user_2",
+        tool: "host_probe",
+        descriptorHash: "hash",
+        scope: { kind: "tool" },
+        duration: "standing",
+        source: "automation",
+        grantedAt: "2026-07-14T00:00:00.000Z",
+      },
+    };
+
+    const outcome = await actions.execute({ id: "1", tool: "host_probe", args: {} }, mismatched);
+
+    expect(outcome).toMatchObject({
+      status: "error",
+      error: { code: "act-as-subject-mismatch" },
+    });
+    expect(actAs).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it("uses host-issued credentials (not the caller's headers) for a properly-granted away call", async () => {
     const actAs = vi.fn(async () => ({ headers: { authorization: "Bearer host-issued" } }));
     const fetchSpy = vi.fn(async () => new Response(JSON.stringify({ ok: true }), {

--- a/packages/actions/src/security/actions-no-selfauth.test.ts
+++ b/packages/actions/src/security/actions-no-selfauth.test.ts
@@ -96,6 +96,42 @@ describe("actions never self-authorizes away execution", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it("refuses a synthetic webhook-style principal redeeming a real user's grant", async () => {
+    // Webhook triggers run as synthetic subjects (reserved-namespace hardening is
+    // child C scope); the actAs seam must still refuse them a human's grant.
+    const actAs = vi.fn(async () => ({ headers: { authorization: "Bearer host-issued" } }));
+    const fetchSpy = vi.fn();
+    const actions = createActions({
+      tools: [routeTool("host_probe")],
+      baseUrl: "http://host.test",
+      actAs,
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    const synthetic: ActionsRunContext = {
+      ...away,
+      principal: { kind: "user", subject: "webhook:invoice-sync" },
+      grant: {
+        id: "grt_real_user",
+        subject: "user_1",
+        tool: "host_probe",
+        descriptorHash: "hash",
+        scope: { kind: "tool" },
+        duration: "standing",
+        source: "automation",
+        grantedAt: "2026-07-14T00:00:00.000Z",
+      },
+    };
+
+    const outcome = await actions.execute({ id: "1", tool: "host_probe", args: {} }, synthetic);
+
+    expect(outcome).toMatchObject({
+      status: "error",
+      error: { code: "act-as-subject-mismatch" },
+    });
+    expect(actAs).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it("uses host-issued credentials (not the caller's headers) for a properly-granted away call", async () => {
     const actAs = vi.fn(async () => ({ headers: { authorization: "Bearer host-issued" } }));
     const fetchSpy = vi.fn(async () => new Response(JSON.stringify({ ok: true }), {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -649,9 +649,18 @@ importers:
         specifier: ^3.24.0
         version: 3.25.76
     devDependencies:
+      '@auth/core':
+        specifier: ^0.34.3
+        version: 0.34.3
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.0
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
+      next:
+        specifier: 16.2.9
+        version: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -1122,6 +1131,20 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@auth/core@0.34.3':
+    resolution: {integrity: sha512-jMjY/S0doZnWYNV90x0jmU3B+UcrsfGYnukxYrRbj0CVvGI/MX3JbHsxSrx2d4mbnXaUsqJmAcDfoQWA6r0lOw==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^7
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
 
   '@axe-core/playwright@4.12.1':
     resolution: {integrity: sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==}
@@ -2252,6 +2275,9 @@ packages:
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
+  '@panva/hkdf@1.2.1':
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -2946,6 +2972,9 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/cookie@0.6.0':
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -3638,6 +3667,10 @@ packages:
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
+
+  cookie@0.6.0:
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    engines: {node: '>= 0.6'}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -4620,6 +4653,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
@@ -5139,6 +5175,9 @@ packages:
   nwsapi@2.2.24:
     resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
 
+  oauth4webapi@2.17.0:
+    resolution: {integrity: sha512-lbC0Z7uzAFNFyzEYRIC+pkSVvDHJTbEW+dYlSBAlCYDe6RxUkJ26bClhk8ocBZip1wfI9uKTe0fm4Ib4RHn6uQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -5376,6 +5415,14 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  preact-render-to-string@5.2.3:
+    resolution: {integrity: sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==}
+    peerDependencies:
+      preact: '>=10'
+
+  preact@10.11.3:
+    resolution: {integrity: sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -5388,6 +5435,9 @@ packages:
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  pretty-format@3.8.0:
+    resolution: {integrity: sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -6496,6 +6546,16 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
+  '@auth/core@0.34.3':
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      '@types/cookie': 0.6.0
+      cookie: 0.6.0
+      jose: 5.10.0
+      oauth4webapi: 2.17.0
+      preact: 10.11.3
+      preact-render-to-string: 5.2.3(preact@10.11.3)
+
   '@axe-core/playwright@4.12.1(playwright-core@1.61.1)':
     dependencies:
       axe-core: 4.12.1
@@ -7439,6 +7499,8 @@ snapshots:
 
   '@opentelemetry/api@1.9.1': {}
 
+  '@panva/hkdf@1.2.1': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -8054,6 +8116,8 @@ snapshots:
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 22.20.0
+
+  '@types/cookie@0.6.0': {}
 
   '@types/d3-array@3.2.2': {}
 
@@ -8790,6 +8854,8 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie-signature@1.2.2: {}
+
+  cookie@0.6.0: {}
 
   cookie@0.7.2: {}
 
@@ -10090,6 +10156,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jose@5.10.0: {}
+
   jose@6.2.3: {}
 
   js-tokens@4.0.0: {}
@@ -10781,6 +10849,32 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@next/env': 16.2.9
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.43
+      caniuse-lite: 1.0.30001805
+      postcss: 8.5.16
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      styled-jsx: 5.1.6(react@19.2.7)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.9
+      '@next/swc-darwin-x64': 16.2.9
+      '@next/swc-linux-arm64-gnu': 16.2.9
+      '@next/swc-linux-arm64-musl': 16.2.9
+      '@next/swc-linux-x64-gnu': 16.2.9
+      '@next/swc-linux-x64-musl': 16.2.9
+      '@next/swc-win32-arm64-msvc': 16.2.9
+      '@next/swc-win32-x64-msvc': 16.2.9
+      '@opentelemetry/api': 1.9.1
+      '@playwright/test': 1.61.1
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
   nice-grpc-common@2.0.3:
     dependencies:
       ts-error: 1.0.6
@@ -10806,6 +10900,8 @@ snapshots:
   node-releases@2.0.51: {}
 
   nwsapi@2.2.24: {}
+
+  oauth4webapi@2.17.0: {}
 
   object-assign@4.1.1: {}
 
@@ -11035,6 +11131,13 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  preact-render-to-string@5.2.3(preact@10.11.3):
+    dependencies:
+      preact: 10.11.3
+      pretty-format: 3.8.0
+
+  preact@10.11.3: {}
+
   prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
@@ -11044,6 +11147,8 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+
+  pretty-format@3.8.0: {}
 
   prop-types@15.8.1:
     dependencies:
@@ -11617,6 +11722,11 @@ snapshots:
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
+
+  styled-jsx@5.1.6(react@19.2.7):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.7
 
   sucrase@3.35.1:
     dependencies:


### PR DESCRIPTION
## Summary

Chunk A1 of Child A (actAs complete) for ENG-260, per the approved block-actions spec (Section A).

- **New subpath `@vendoai/actions/presets`** with all five presets:
  - **Auth.js / NextAuth**: native offline session-JWE minting via `@auth/core`'s own encoder (cookie name doubles as JWE salt; `secureCookie` supported).
  - **Supabase Auth**: native offline HS256 minting with the project JWT secret (`sub`, `role`, `aud`, `iat`, `exp`).
  - **Clerk** and **Auth0**: offline provider-session minting is impossible (RS256), so each ships both halves — an actAs producer signing a short-lived host-owned `VendoAway` HS256 token, plus verify-middleware in **Next.js** and **Express** flavors. Next middleware strips caller-supplied `x-vendo-away-*` headers and injects verified identity headers; `verify()` is doctor-probeable.
  - **Generic JWT**: configurable secret/claims/header-shape preset for the long tail.
- **Token caching inside preset closures** until expiry with a safety margin (default 300s / 30s). Cache keys include a secret fingerprint so rotation invalidates immediately.
- **`AuthMaterial` stays `{ headers }`** — no contract change.
- **Optional peer deps**: `@auth/core` and `next` are optional peers of `@vendoai/actions` only, imported lazily inside the specific preset. `scripts/dependency-guard.mjs` stays green (actions still depends only on core).
- **Impersonation guard** at the actAs seam (`actAsAuth` in `registry.ts`): `grant.subject !== ctx.principal.subject` fails closed with a structured `act-as-subject-mismatch` outcome before the host actAs is ever invoked — covers both the away and MCP branches.
- **Recipes doc** `docs/act-as-presets.md` (linked from quickstart): per-provider wiring, secret provisioning, middleware mounting, long-tail generic-JWT recipes, cache/rotation guidance.

## Test evidence

103 tests in `@vendoai/actions` (all green), including:

- **Real-verifier integration**: minted Auth.js JWE accepted by the real `@auth/core` `getToken`; Supabase/generic tokens verified by `jose`; away tokens round-trip through the shipped middleware (real `next/server` semantics asserted).
- **Unit per preset**: mint / cache-until-safety-margin / refresh / decline (null secret, null claims) paths; whole-second Auth.js expiry edge.
- **Core conformance**: all five presets pass `actAsConformance` from `@vendoai/core/conformance`.
- **Adversarial suite** (`presets/adversarial.test.ts` + security suite):
  - impersonation: grant/principal subject mismatch fails closed at the seam (unit + registry-level MCP branch + synthetic webhook-style subject redeeming a user's grant); actAs never called, no outbound request
  - forged away-tokens: attacker-secret signature, post-signing subject tampering, `alg:none`, all rejected
  - replay: Clerk token vs Auth0 verifier, wrong issuer/audience, lookalike HS256 JWT without the `vendo-away+jwt` typ, expired token — all rejected
  - spoofing: caller-supplied `x-vendo-away-*` headers stripped on ordinary requests and overwritten with verified claims on away requests
  - secret containment: signing secret (raw + base64url) never appears in `AuthMaterial`; no console output from any preset path

Full gate run locally: `pnpm build` / `pnpm typecheck` / `pnpm lint` green; `pnpm test` green across the repo except the two known local false-fails (core `packaging.e2e.test.ts` under paths with spaces; one redteam fixture ECONNRESET flake that passes on rerun) — CI is authoritative.

Note: main currently has a known repo-wide `integration` regression (grant-invalidation browser spec) owned by a separate fix; if that check is red here, it is that regression, not this diff.

No UI surface in this chunk (per the A1 brief).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@vendoai/actions/presets` to mint host credentials for away execution and adds a subject-mismatch guard that blocks impersonation before any outbound call. Delivers ENG-260 Section A with provider presets, short-lived away-tokens + verifiers, and cache hardening.

- New Features
  - Five presets in `@vendoai/actions/presets`: Auth.js (offline JWE via `@auth/core`), Supabase (HS256 with project JWT secret), Clerk/Auth0 (short-lived host `VendoAway` tokens with `verify()`, Next.js and Express middleware), and a configurable HS256 JWT.
  - Middleware strips caller-supplied `x-vendo-away-*` headers on all requests and injects verified identity on away requests; `verify()` accepts compact tokens or full `VendoAway ...` headers for doctor probes.
  - Token caching until expiry with a safety window; rotation-aware cache keys (secret fingerprint) and eviction of expired entries on set.
  - Impersonation guard: reject `grant.subject !== principal.subject` with `act-as-subject-mismatch` before invoking `actAs`; added docs (`docs/act-as-presets.md`) and tests (real verifiers, adversarial forgery/replay/spoofing, secret containment, conformance).

- Dependencies
  - New subpath export `@vendoai/actions/presets`; optional peers `@auth/core` and `next`. Dev deps include `@auth/core`, `next`, and `jose`.

<sup>Written for commit 67ecaa38471672a0475d13feaf43d557e06200cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

