### PR TITLE
fix(mcp): honor configured VENDO_BASE_URL for door metadata + audience (ENG-333)

### DIFF
--- a/docs-site/capabilities/mcp.mdx
+++ b/docs-site/capabilities/mcp.mdx
@@ -174,14 +174,29 @@ well-known routes before that second mount.
 
 ## Set VENDO_BASE_URL
 
-Host tools that bind to routes need a base origin. The wire normally learns its
-own origin from the first in-product request, but door requests never teach it
-(only wire routes do). Set `VENDO_BASE_URL` explicitly so door-first traffic can
-still resolve host routes.
+Set `VENDO_BASE_URL` to your product's public origin in every real deployment.
+It does two jobs for the door:
+
+- **Discovery and audience binding.** Behind a reverse proxy (Railway, Fly, any
+  TLS terminator), the request reaching your process carries the proxy-internal
+  origin. The door derives its OAuth discovery documents (issuer, endpoint
+  URLs, the protected-resource `resource`) and its token audience binding from
+  `VENDO_BASE_URL` when set, so clients see your public origin instead of an
+  unreachable internal one. Forwarded headers such as `X-Forwarded-Host` are
+  never trusted. Without it, the door falls back to the request URL, which is
+  fine for local development and wrong behind a proxy.
+- **Route-binding base.** Host tools that bind to routes need a base origin.
+  The wire normally learns its own origin from the first in-product request,
+  but door requests never teach it (only wire routes do); `VENDO_BASE_URL`
+  gives door-first traffic a base to resolve host routes against.
 
 ```bash
 VENDO_BASE_URL=https://app.example.com
 ```
+
+If your composition serves the door on a different origin than the one host
+routes resolve against, pass the door's public base explicitly:
+`createVendo({ mcp: { baseUrl: "https://app.example.com" }, oauth })`.
 
 ## How door calls reach host tools
 

--- a/docs-site/reference/environment-variables.mdx
+++ b/docs-site/reference/environment-variables.mdx
@@ -11,7 +11,7 @@ description: "Every environment variable Vendo reads across host process, sandbo
 | `VENDO_CLOUD_URL` | overrides the Vendo Cloud base URL for the runtime and CLI; defaults to `https://console.vendo.run` |
 | `VENDO_TELEMETRY_DISABLED=1` | disables build and development telemetry |
 | `VENDO_TICK_SECRET` | bearer secret required by `POST /tick` |
-| `VENDO_BASE_URL` | trusted host origin used for server-side execution of extracted route tools and for marking the anonymous-session cookie `Secure` behind a TLS-terminating proxy; set it explicitly when the MCP door is open so door-first traffic still has a base to bind against |
+| `VENDO_BASE_URL` | trusted host origin used for server-side execution of extracted route tools, for marking the anonymous-session cookie `Secure` behind a TLS-terminating proxy, and as the MCP door's canonical public base: discovery metadata (issuer, endpoints, `resource`) and token audience binding derive from it instead of the proxy-internal request origin; set it in every proxied deployment with the door open |
 | `VENDO_URL` | base URL `vendo doctor` probes for the live `/status` check; defaults to `http://localhost:3000/api/vendo`, overridden per run by `--url` |
 | `VENDO_PROXY_URL` | tool-proxy URL injected into app machines by the default composition |
 | `VENDO_POSTHOG_KEY` | overrides the telemetry project key |

--- a/docs/contracts/10-mcp-umbrella-hookup.md
+++ b/docs/contracts/10-mcp-umbrella-hookup.md
@@ -43,6 +43,14 @@ base when a door tool call resolves its route binding; such hosts should set
 `VENDO_BASE_URL` explicitly (it is also the trusted origin credentials forward
 to, so setting it is the right move regardless).
 
+`VENDO_BASE_URL` is also the door's canonical public base (ENG-333): the
+umbrella passes it to `createMcpDoor` as `baseUrl`, so behind a reverse proxy
+the discovery documents, issuer/endpoint URLs, `resource`, and RFC 8707
+audience binding advertise the PUBLIC origin instead of the proxy-internal
+request origin. The additive `mcp: { baseUrl }` form of the flag overrides the
+env default for compositions whose door origin differs from the route-binding
+origin (`mcp: true` is unchanged). Forwarded headers are never trusted.
+
 ## Next.js note
 
 The `/api/vendo/[...]` catch-all cannot see origin-root paths, so

--- a/docs/contracts/10-mcp.md
+++ b/docs/contracts/10-mcp.md
@@ -15,6 +15,11 @@ export function createMcpDoor(config: {
   oauth: HostOAuthAdapter;              // §3 — two functions; the host owns identity + consent, the door owns the protocol
   store: StoreAdapter;                  // door-owned protocol state (clients, codes, refresh grants) — wired like every other block
   apps?: AppsPort;                      // §4 — saved apps ride along as MCP Apps; absent → tools-only door
+  baseUrl?: string;                     // §5 — canonical PUBLIC base URL (origin only); behind a reverse proxy the
+                                        // request URL carries the proxy-internal origin, so discovery, issuer,
+                                        // resource, and RFC 8707 audience derive from THIS when set (the umbrella
+                                        // defaults it from VENDO_BASE_URL); unset → request-URL derived. Forwarded
+                                        // headers are never trusted.
   remoteAs?: {                          // §3.1 — trust an external authorization server instead of serving the local AS
     issuer: string;
     jwksUri?: string;                   // absent → discover jwks_uri from the issuer's RFC 8414 metadata
@@ -138,6 +143,7 @@ export interface AppsPort {
 ## 5. Discovery — agents find the host's server
 
 - Protected-resource metadata at the **path-inserted** well-known URL (RFC 9728 §3): a door mounted at `/api/vendo/mcp` serves `/.well-known/oauth-protected-resource/api/vendo/mcp`. Authorization-server metadata (RFC 8414) likewise.
+- **Origin derivation (ENG-333)**: every advertised origin — the issuer, endpoint URLs, the protected-resource `resource`, the `401` challenge's metadata URL — and RFC 8707 audience validation derive from the configured `baseUrl` (origin only) when set; unset, they derive from each request's own URL. `X-Forwarded-*`/`Host` headers are never consulted (Host-header injection). The umbrella defaults `baseUrl` from `VENDO_BASE_URL`; the additive `createVendo({ mcp: { baseUrl } })` form overrides it for compositions whose door origin differs from the route-binding origin.
 - With `remoteAs`, protected-resource metadata names the external issuer and the door does not serve RFC 8414 authorization-server metadata; the external server owns it (§3.1).
 - Server card at `/.well-known/mcp-server-card` — ⚑ **provisional**, tracking SEP-2127 (Draft); the path moves with the SEP if it changes before ratification. Registry listings are a publishing step, not code. The door accepts an optional `mount` (e.g. `/api/vendo/mcp`): when set it is authoritative for the card's advertised transport URL, so a **cold** composed umbrella advertises the right mount before any request arrives, and learned request paths never override it (the umbrella passes its fixed `MCP_MOUNT`). Unset, the card falls back to `/mcp` until an authenticated request teaches it a mount.
 - `vendo doctor` validates both metadata documents resolve and the card parses.

--- a/docs/persistence-and-deploy.md
+++ b/docs/persistence-and-deploy.md
@@ -85,6 +85,15 @@ minutes, and deduplicate by delivery id. The secret never appears in a URL.
 Verification failure returns 401, resolves no principal, starts no run, and
 writes one audit event.
 
+## Reverse proxies
+
+Behind a reverse proxy (Railway, Fly, any TLS terminator), set `VENDO_BASE_URL`
+to the product's public origin. Route-binding host tools execute against it as
+the trusted origin, the anonymous-session cookie stays `Secure`, and the MCP
+door derives its OAuth discovery metadata (issuer, endpoints, `resource`) and
+token audience binding from it instead of the proxy-internal request URL.
+Forwarded headers such as `X-Forwarded-Host` are never trusted.
+
 ## Operations
 
 - Back up the `vendo_` tables with the host database.

--- a/fixtures/integration-browser/e2e/harness/backends.ts
+++ b/fixtures/integration-browser/e2e/harness/backends.ts
@@ -135,6 +135,31 @@ export async function startBackends(): Promise<Backends> {
   await store.ensureSchema();
   const scripted = createControllableModel();
 
+  // Listen BEFORE createVendo: the door's canonical public base defaults to
+  // VENDO_BASE_URL (ENG-333), which this harness deliberately points at the
+  // HOST APP (credential forwarding for route bindings). The door itself is
+  // served on this loopback wire, so its origin is passed explicitly via
+  // mcp.baseUrl below — discovery must advertise the URL the real SDK client
+  // can reach. Requests cannot arrive before `vendo` exists: nothing learns
+  // the port until this function returns.
+  const httpServer = createHttpServer((req, res) => {
+    void handle(req, res).catch((error) => {
+      res.statusCode = 500;
+      res.setHeader("content-type", "text/plain");
+      res.end(error instanceof Error ? error.message : "wire bridge failed");
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once("error", reject);
+    httpServer.listen(0, "127.0.0.1", () => {
+      httpServer.off("error", reject);
+      resolve();
+    });
+  });
+  const address = httpServer.address();
+  if (!address || typeof address === "string") throw new Error("wire server did not bind a TCP port");
+  const wireUrl = `http://127.0.0.1:${address.port}`;
+
   const vendo = createVendo({
     model: scripted.model,
     principal: async (req) => {
@@ -144,7 +169,7 @@ export async function startBackends(): Promise<Backends> {
     store,
     actAs: async (principal: Principal) => ({ headers: { cookie: await loginCookie(principal.subject) } }),
     policy: { file: ".vendo/policy.json" },
-    mcp: true,
+    mcp: { baseUrl: wireUrl },
     oauth: {
       async authorize() {
         return { subject: MCP_APPS_SUBJECT };
@@ -164,13 +189,11 @@ export async function startBackends(): Promise<Backends> {
   );
 
   // --- 3. the loopback wire + control server ------------------------------
-  let wireUrl: string | undefined;
   let connectedMcp: ConnectedClient | undefined;
   let connectingMcp: Promise<ConnectedClient> | undefined;
 
   async function mcpConnection(): Promise<ConnectedClient> {
     if (connectedMcp !== undefined) return connectedMcp;
-    if (wireUrl === undefined) throw new Error("wire server is not listening yet");
     connectingMcp ??= connectWithSdk({ endpoint: `${wireUrl}${WIRE_BASE}/mcp` });
     try {
       connectedMcp = await connectingMcp;
@@ -179,14 +202,6 @@ export async function startBackends(): Promise<Backends> {
       connectingMcp = undefined;
     }
   }
-
-  const httpServer = createHttpServer((req, res) => {
-    void handle(req, res).catch((error) => {
-      res.statusCode = 500;
-      res.setHeader("content-type", "text/plain");
-      res.end(error instanceof Error ? error.message : "wire bridge failed");
-    });
-  });
 
   async function readBody(req: IncomingMessage): Promise<Buffer> {
     const chunks: Buffer[] = [];
@@ -314,17 +329,6 @@ export async function startBackends(): Promise<Backends> {
     response.headers.forEach((value, name) => res.setHeader(name, value));
     res.end(Buffer.from(await response.arrayBuffer()));
   }
-
-  await new Promise<void>((resolve, reject) => {
-    httpServer.once("error", reject);
-    httpServer.listen(0, "127.0.0.1", () => {
-      httpServer.off("error", reject);
-      resolve();
-    });
-  });
-  const address = httpServer.address();
-  if (!address || typeof address === "string") throw new Error("wire server did not bind a TCP port");
-  wireUrl = `http://127.0.0.1:${address.port}`;
 
   let closed = false;
   const close = async (): Promise<void> => {

--- a/fixtures/mcp-e2e/src/umbrella-hookup.e2e.test.ts
+++ b/fixtures/mcp-e2e/src/umbrella-hookup.e2e.test.ts
@@ -105,12 +105,17 @@ async function createUmbrella(
         { match: { risk: "write" }, action: "run" },
       ],
     },
-    mcp: true,
     oauth,
     ...(options.withActAs === false ? {} : { actAs }),
   };
-  const vendo = createVendo(config);
-  const httpServer = createServer((req, res) => void bridge(req, res, vendo.handler));
+  // Listen BEFORE createVendo: the door's canonical public base defaults to
+  // VENDO_BASE_URL (ENG-333), but this fixture deliberately splits origins —
+  // VENDO_BASE_URL points at the fixture HOST APP (route bindings + actAs
+  // credential forwarding), while the door is served on this umbrella's own
+  // loopback origin. Pass that door origin explicitly via mcp.baseUrl so
+  // discovery advertises the URL the SDK client can actually reach.
+  let handler: Vendo["handler"] | undefined;
+  const httpServer = createServer((req, res) => void bridge(req, res, (request) => handler!(request)));
   await new Promise<void>((resolve, reject) => {
     httpServer.once("error", reject);
     httpServer.listen(0, "127.0.0.1", () => {
@@ -121,6 +126,8 @@ async function createUmbrella(
   const address = httpServer.address();
   if (!address || typeof address === "string") throw new Error("umbrella server did not bind a port");
   const origin = `http://127.0.0.1:${address.port}`;
+  const vendo = createVendo({ ...config, mcp: { baseUrl: origin } });
+  handler = vendo.handler;
   const umbrella: Umbrella = {
     vendo,
     origin,

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -14,6 +14,26 @@ pnpm --filter @vendoai/ui build:mcp-shim
 
 The server-card response tracks the provisional SEP-2127 draft and may move with that specification before ratification.
 
+## Reverse proxies and the canonical base URL
+
+Behind a reverse proxy (Railway, Fly, any TLS terminator) the request URL
+reaching the process carries the proxy-internal origin. Configure the door's
+canonical public base so discovery metadata (issuer, endpoint URLs, the
+protected-resource `resource`) and RFC 8707 token audience binding advertise
+and enforce the public origin instead:
+
+```ts
+createMcpDoor({
+  // tools, guard, oauth, store, ...
+  baseUrl: "https://product.example.com", // origin only; the mount stays path-derived
+});
+```
+
+The umbrella defaults `baseUrl` from `VENDO_BASE_URL`; pass
+`createVendo({ mcp: { baseUrl } })` to override the env default. Unset, origins
+derive from each request's own URL. Forwarded headers such as
+`X-Forwarded-Host` are never trusted.
+
 ## External authorization servers
 
 By default the door owns the OAuth authorization-server flow. A host that runs

--- a/packages/mcp/src/door.test.ts
+++ b/packages/mcp/src/door.test.ts
@@ -689,6 +689,129 @@ describe("createMcpDoor routing and OAuth", () => {
   });
 });
 
+describe("createMcpDoor configured canonical base URL (ENG-333)", () => {
+  const PUBLIC_ORIGIN = "https://product.example";
+
+  it("serves discovery documents with the configured public origin behind a proxy", async () => {
+    const harness = makeHarness({ baseUrl: PUBLIC_ORIGIN });
+    const prm = await harness.door.handler(new Request(
+      "http://door.internal:8787/.well-known/oauth-protected-resource/api/vendo/mcp",
+    ));
+    expect(await prm.json()).toEqual({
+      resource: BASE,
+      authorization_servers: [BASE],
+      bearer_methods_supported: ["header"],
+    });
+
+    const as = await harness.door.handler(new Request(
+      "http://door.internal:8787/.well-known/oauth-authorization-server/api/vendo/mcp",
+    ));
+    expect(await as.json()).toMatchObject({
+      issuer: BASE,
+      authorization_endpoint: `${BASE}/authorize`,
+      token_endpoint: `${BASE}/token`,
+      revocation_endpoint: `${BASE}/revoke`,
+      registration_endpoint: `${BASE}/register`,
+    });
+  });
+
+  it("advertises the configured public origin on the server card behind a proxy", async () => {
+    const harness = makeHarness({ baseUrl: PUBLIC_ORIGIN, mount: "/api/vendo/mcp" });
+    const card = await harness.door.handler(new Request(
+      "http://door.internal:8787/.well-known/mcp/server-card.json",
+    ));
+    expect(await card.json()).toMatchObject({
+      transports: [{ type: "streamable-http", url: BASE }],
+      authorization: {
+        type: "oauth2",
+        resource_metadata: "https://product.example/.well-known/oauth-protected-resource/api/vendo/mcp",
+      },
+    });
+  });
+
+  it("names the public metadata URL in the 401 challenge on the proxy-internal origin", async () => {
+    const harness = makeHarness({ baseUrl: PUBLIC_ORIGIN });
+    const challenge = await harness.door.handler(new Request(PROXIED_BASE, { method: "POST" }));
+    expect(challenge.status).toBe(401);
+    expect(challenge.headers.get("www-authenticate")).toBe(
+      'Bearer resource_metadata="https://product.example/.well-known/oauth-protected-resource/api/vendo/mcp"',
+    );
+  });
+
+  it("binds the whole proxied OAuth flow and RFC 8707 audience to the public origin", async () => {
+    const harness = makeHarness({ baseUrl: PUBLIC_ORIGIN });
+    // Every request arrives at the proxy-INTERNAL origin, the way Railway/Fly
+    // hand requests to the process. The `resource` the client sends is the
+    // PUBLIC one it discovered.
+    const registration = await register(harness.door, {}, PROXIED_BASE);
+    const tokens = await issue(harness.door, registration.body.client_id, PROXIED_BASE);
+
+    const response = await harness.door.handler(mcpRequest(tokens.access_token, undefined, PROXIED_BASE));
+    expect(response.status).toBe(200);
+    expect(harness.principalSubjects).toEqual(["user_1"]);
+  });
+
+  it("rejects an authorization request whose resource names the proxy-internal origin", async () => {
+    const harness = makeHarness({ baseUrl: PUBLIC_ORIGIN });
+    const registration = await register(harness.door, {}, PROXIED_BASE);
+    const response = await authorize(harness.door, registration.body.client_id, { resource: PROXIED_BASE }, PROXIED_BASE);
+    expect(response.status).toBe(302);
+    expect(new URL(response.headers.get("location")!).searchParams.get("error")).toBe("invalid_target");
+  });
+
+  it("keeps request-derived origins and ignores forwarded headers when unconfigured", async () => {
+    const harness = makeHarness();
+    // X-Forwarded-*/Host are attacker-controllable (Host-header injection) and
+    // are never trusted — without a configured base the request URL stands.
+    const prm = await harness.door.handler(new Request(
+      "http://door.internal:8787/.well-known/oauth-protected-resource/api/vendo/mcp",
+      { headers: { "x-forwarded-host": "attacker.example", "x-forwarded-proto": "https", host: "attacker.example" } },
+    ));
+    expect(await prm.json()).toMatchObject({
+      resource: "http://door.internal:8787/api/vendo/mcp",
+      authorization_servers: ["http://door.internal:8787/api/vendo/mcp"],
+    });
+  });
+
+  it("ignores forwarded headers even when a base URL is configured", async () => {
+    const harness = makeHarness({ baseUrl: PUBLIC_ORIGIN });
+    const prm = await harness.door.handler(new Request(
+      "http://door.internal:8787/.well-known/oauth-protected-resource/api/vendo/mcp",
+      { headers: { "x-forwarded-host": "attacker.example", "x-forwarded-proto": "https" } },
+    ));
+    expect(await prm.json()).toMatchObject({ resource: BASE });
+  });
+
+  it("uses only the origin of a base URL that carries a path", async () => {
+    const harness = makeHarness({ baseUrl: "https://product.example/some/app/path" });
+    const prm = await harness.door.handler(new Request(
+      "http://door.internal:8787/.well-known/oauth-protected-resource/api/vendo/mcp",
+    ));
+    expect(await prm.json()).toMatchObject({ resource: BASE });
+  });
+
+  it("advertises the external issuer alongside the public resource under remoteAs", async () => {
+    const harness = makeHarness({
+      baseUrl: PUBLIC_ORIGIN,
+      remoteAs: { issuer: "https://auth.example", audience: BASE },
+    });
+    const prm = await harness.door.handler(new Request(
+      "http://door.internal:8787/.well-known/oauth-protected-resource/api/vendo/mcp",
+    ));
+    expect(await prm.json()).toEqual({
+      resource: BASE,
+      authorization_servers: ["https://auth.example"],
+      bearer_methods_supported: ["header"],
+    });
+  });
+
+  it("throws at construction for a malformed or credentialed base URL", () => {
+    for (const baseUrl of ["not a url", "ftp://product.example", "https://user:secret@product.example"]) {
+      expect(() => makeHarness({ baseUrl }), baseUrl).toThrow(TypeError);
+    }
+  });
+});
+
 describe("createMcpDoor remote authorization server trust", () => {
   it("trusts the configured audience when a proxy changes the request origin", async () => {
     const as = await remoteAsFixture();
@@ -1300,6 +1423,7 @@ interface HarnessOptions {
   extraDescriptors?: Awaited<ReturnType<ToolRegistry["descriptors"]>>;
   check?: Guard["check"];
   mount?: string;
+  baseUrl?: string;
   remoteAs?: { issuer: string; jwksUri?: string; audience: string };
   federation?: { secret: string };
   authorizeResponse?: Response;
@@ -1342,6 +1466,7 @@ function makeHarness(options: HarnessOptions = {}) {
     store,
     apps: options.apps,
     ...(options.mount === undefined ? {} : { mount: options.mount }),
+    ...(options.baseUrl === undefined ? {} : { baseUrl: options.baseUrl }),
     ...(options.remoteAs === undefined ? {} : { remoteAs: options.remoteAs }),
     ...(options.federation === undefined ? {} : { federation: options.federation }),
     ...(options.theme === undefined ? {} : { theme: options.theme }),
@@ -1363,8 +1488,8 @@ function makeHarness(options: HarnessOptions = {}) {
   return { door, store, audits, authorizeContexts, principalSubjects, executions };
 }
 
-async function register(door: McpDoor, metadata: Record<string, unknown> = {}) {
-  const response = await door.handler(new Request(`${BASE}/register`, {
+async function register(door: McpDoor, metadata: Record<string, unknown> = {}, base = BASE) {
+  const response = await door.handler(new Request(`${base}/register`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ client_name: "Test client", redirect_uris: [REDIRECT], scope: "read write", ...metadata }),
@@ -1372,7 +1497,7 @@ async function register(door: McpDoor, metadata: Record<string, unknown> = {}) {
   return { response, body: await response.clone().json() as { client_id: string } & Record<string, unknown> };
 }
 
-async function authorize(door: McpDoor, clientId: string, overrides: Record<string, string> = {}) {
+async function authorize(door: McpDoor, clientId: string, overrides: Record<string, string> = {}, base = BASE) {
   const challenge = await pkceChallenge(VERIFIER);
   const params = new URLSearchParams({
     response_type: "code",
@@ -1384,7 +1509,7 @@ async function authorize(door: McpDoor, clientId: string, overrides: Record<stri
     resource: BASE,
     ...overrides,
   });
-  return door.handler(new Request(`${BASE}/authorize?${params}`));
+  return door.handler(new Request(`${base}/authorize?${params}`));
 }
 
 function prebuiltOAuth(): HostOAuthAdapter {
@@ -1436,8 +1561,8 @@ function htmlAttribute(html: string, element: string, attribute: string): string
   return match[1];
 }
 
-async function exchange(door: McpDoor, values: Record<string, string>) {
-  return door.handler(new Request(`${BASE}/token`, {
+async function exchange(door: McpDoor, values: Record<string, string>, base = BASE) {
+  return door.handler(new Request(`${base}/token`, {
     method: "POST",
     headers: { "content-type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({
@@ -1448,10 +1573,10 @@ async function exchange(door: McpDoor, values: Record<string, string>) {
   }));
 }
 
-async function issue(door: McpDoor, clientId: string): Promise<TokenResponse> {
-  const auth = await authorize(door, clientId);
+async function issue(door: McpDoor, clientId: string, base = BASE): Promise<TokenResponse> {
+  const auth = await authorize(door, clientId, {}, base);
   const code = new URL(auth.headers.get("location")!).searchParams.get("code")!;
-  const response = await exchange(door, { code, client_id: clientId, code_verifier: VERIFIER, resource: BASE });
+  const response = await exchange(door, { code, client_id: clientId, code_verifier: VERIFIER, resource: BASE }, base);
   expect(response.status).toBe(200);
   return response.json() as Promise<TokenResponse>;
 }

--- a/packages/mcp/src/door.test.ts
+++ b/packages/mcp/src/door.test.ts
@@ -751,6 +751,33 @@ describe("createMcpDoor configured canonical base URL (ENG-333)", () => {
     expect(harness.principalSubjects).toEqual(["user_1"]);
   });
 
+  it("keeps the prebuilt consent flow on the public origin behind a proxy", async () => {
+    const returnTos: string[] = [];
+    const harness = makeHarness({
+      baseUrl: PUBLIC_ORIGIN,
+      oauth: {
+        async session(_req, ctx) {
+          returnTos.push(ctx.returnTo);
+          return { subject: "user_1" };
+        },
+        async principal(subject) { return { kind: "user", subject }; },
+      },
+    });
+    const registration = await register(harness.door, {}, PROXIED_BASE);
+    const page = await authorize(harness.door, registration.body.client_id, {}, PROXIED_BASE);
+    const html = await page.text();
+
+    // The user's BROWSER reached the door through the public origin; a form
+    // action or host-login returnTo naming the proxy-internal origin would be
+    // unreachable from it. Both must speak the configured public base.
+    expect(htmlAttribute(html, "form", "action")).toContain(`${BASE}/authorize?`);
+    expect(returnTos[0]).toContain(`${BASE}/authorize?`);
+
+    const approved = await submitConsent(harness.door, html, "approve");
+    expect(approved.status).toBe(302);
+    expect(new URL(approved.headers.get("location")!).searchParams.get("code")).toMatch(/^vmcd_/);
+  });
+
   it("rejects an authorization request whose resource names the proxy-internal origin", async () => {
     const harness = makeHarness({ baseUrl: PUBLIC_ORIGIN });
     const registration = await register(harness.door, {}, PROXIED_BASE);

--- a/packages/mcp/src/door.ts
+++ b/packages/mcp/src/door.ts
@@ -84,6 +84,18 @@ export interface McpDoorConfig {
    * authenticated request teaches it a mount. The umbrella passes its fixed
    * mount so a composed door's card is correct before any traffic arrives. */
   mount?: string;
+  /** 10-mcp §5 — the canonical PUBLIC base URL of the deployed host (e.g.
+   * `https://app.example.com`). Behind a reverse proxy (Railway, Fly, any TLS
+   * terminator) the request URL carries the proxy-INTERNAL origin, so deriving
+   * discovery metadata from it advertises unreachable endpoints and binds the
+   * RFC 8707 audience to the wrong resource. When set, the issuer, every
+   * advertised endpoint, the protected-resource `resource`, the 401 challenge's
+   * metadata URL, and token audience validation all use THIS origin; only the
+   * path still comes from the request (or `mount`). Only the URL's origin is
+   * used — a path on the base URL is ignored. Forwarded headers (X-Forwarded-*,
+   * Host) are attacker-controllable and are never consulted.
+   * The umbrella defaults this from `VENDO_BASE_URL`. */
+  baseUrl?: string;
   /** Trust access tokens from an external OAuth authorization server instead
    * of serving the door's local authorization-server endpoints. */
   remoteAs?: { issuer: string; jwksUri?: string; audience: string };
@@ -125,6 +137,9 @@ class Door {
    * URI, so a stray probe to an odd path can neither poison discovery nor
    * mint authority for the real mount. */
   #cardMount: string | undefined;
+  /** The canonical public origin every advertised URL and audience check uses
+   * when `baseUrl` is configured; undefined → derive from each request URL. */
+  readonly #publicOrigin: string | undefined;
   #identity: Promise<HostIdentity> | undefined;
 
   constructor(config: McpDoorConfig, state: McpDoorState) {
@@ -132,23 +147,32 @@ class Door {
     this.#state = state;
     this.#oauth = new OAuthServer(config);
     this.#remoteAs = config.remoteAs === undefined ? undefined : new RemoteAsVerifier(config.remoteAs);
+    this.#publicOrigin = config.baseUrl === undefined ? undefined : publicOriginOf(config.baseUrl);
+  }
+
+  /** The origin metadata, endpoints, resource URIs, and audience checks derive
+   * from: the configured public base when set, else the request's own URL —
+   * never a forwarded header. */
+  #origin(url: URL): string {
+    return this.#publicOrigin ?? url.origin;
   }
 
   async handler(req: Request): Promise<Response> {
     const url = new URL(req.url);
+    const origin = this.#origin(url);
     const path = url.pathname;
 
     if (path.startsWith(PRM_PREFIX)) {
       if (req.method !== "GET") return notFound();
       return json(protectedResourceMetadata(
-        url.origin,
+        origin,
         path.slice(PRM_PREFIX.length),
         this.#config.remoteAs?.issuer,
       ));
     }
     if (path.startsWith(AS_PREFIX)) {
       if (req.method !== "GET" || this.#config.remoteAs !== undefined) return notFound();
-      return json(authorizationServerMetadata(url.origin, path.slice(AS_PREFIX.length)));
+      return json(authorizationServerMetadata(origin, path.slice(AS_PREFIX.length)));
     }
     if (path === SERVER_CARD_PATH || path === SERVER_CARD_ALIAS_PATH) {
       if (req.method !== "GET") return notFound();
@@ -163,10 +187,10 @@ class Door {
         version: identity.version,
         description: identity.description,
         protocol_versions: ["2025-11-25"],
-        transports: [{ type: "streamable-http", url: resourceUri(url.origin, mount) }],
+        transports: [{ type: "streamable-http", url: resourceUri(origin, mount) }],
         authorization: {
           type: "oauth2",
-          resource_metadata: protectedResourceMetadataUrl(url.origin, mount),
+          resource_metadata: protectedResourceMetadataUrl(origin, mount),
         },
       });
     }
@@ -176,7 +200,7 @@ class Door {
     if (endpoint.kind === "authorize") {
       return this.#config.remoteAs === undefined
         && (req.method === "GET" || (req.method === "POST" && this.#oauth.hasPrebuiltConsent))
-        ? this.#oauth.authorize(req, resourceUri(url.origin, mount))
+        ? this.#oauth.authorize(req, resourceUri(origin, mount))
         : notFound();
     }
     if (endpoint.kind === "token") {
@@ -201,7 +225,7 @@ class Door {
       return req.method === "GET"
         && this.#config.federation !== undefined
         && this.#config.oauth.authorize !== undefined
-        ? handleFederation(req, resourceUri(url.origin, mount), this.#config.federation.secret, this.#config.oauth)
+        ? handleFederation(req, resourceUri(origin, mount), this.#config.federation.secret, this.#config.oauth)
         : notFound();
     }
     if (!["GET", "POST", "DELETE"].includes(req.method)) return notFound();
@@ -209,14 +233,14 @@ class Door {
   }
 
   async #handleMcp(req: Request, mount: string): Promise<Response> {
-    const url = new URL(req.url);
-    const resource = resourceUri(url.origin, mount);
+    const origin = this.#origin(new URL(req.url));
+    const resource = resourceUri(origin, mount);
     await this.#sweepIdleSessions();
     const auth = this.#remoteAs === undefined
       ? await this.#oauth.authenticate(req)
       : await this.#remoteAs.authenticate(req);
     if (!auth || (this.#remoteAs === undefined && !sameCanonicalUri(auth.grant.resource, resource))) {
-      return unauthorized(url.origin, mount, req.headers.has("authorization"));
+      return unauthorized(origin, mount, req.headers.has("authorization"));
     }
 
     const requestedSessionId = req.headers.get("mcp-session-id") ?? undefined;
@@ -238,13 +262,13 @@ class Door {
     if (principal === null) {
       await this.#killSubject(auth.grant.subject);
       await this.#oauth.auditRevoke(auth.grant.subject, auth.grant.clientId);
-      return unauthorized(url.origin, mount, true);
+      return unauthorized(origin, mount, true);
     }
     // 10-mcp §2: anonymous/ephemeral principals are never served a session —
     // the door persists grants and audit and must have a durable subject.
     if (principal.ephemeral === true) {
       await this.#killSubject(auth.grant.subject);
-      return unauthorized(url.origin, mount, true);
+      return unauthorized(origin, mount, true);
     }
     // Only authenticated traffic teaches the server card its mount — an
     // unauthenticated probe to an arbitrary path must not steer discovery. A
@@ -578,6 +602,25 @@ function endpointFor(path: string): {
 function normalizeMount(mount: string): string {
   if (!mount || mount === "/") return "";
   return `/${mount.replace(/^\/+|\/+$/g, "")}`;
+}
+
+/** Reduce the configured base URL to its canonical origin, failing LOUD at
+ * construction — a malformed base silently falling back to request-derived
+ * origins would ship wrong discovery documents to every client. */
+function publicOriginOf(baseUrl: string): string {
+  let url: URL;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    throw new TypeError(`baseUrl must be an absolute http(s) URL, got ${JSON.stringify(baseUrl)}`);
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new TypeError(`baseUrl must be an absolute http(s) URL, got ${JSON.stringify(baseUrl)}`);
+  }
+  if (url.username || url.password) {
+    throw new TypeError("baseUrl cannot contain credentials");
+  }
+  return url.origin;
 }
 
 function resourceUri(origin: string, mount: string): string {

--- a/packages/mcp/src/door.ts
+++ b/packages/mcp/src/door.ts
@@ -90,7 +90,8 @@ export interface McpDoorConfig {
    * discovery metadata from it advertises unreachable endpoints and binds the
    * RFC 8707 audience to the wrong resource. When set, the issuer, every
    * advertised endpoint, the protected-resource `resource`, the 401 challenge's
-   * metadata URL, and token audience validation all use THIS origin; only the
+   * metadata URL, token audience validation, and the interactive consent URLs
+   * (form action, host-login returnTo) all use THIS origin; only the
    * path still comes from the request (or `mount`). Only the URL's origin is
    * used — a path on the base URL is ignored. Forwarded headers (X-Forwarded-*,
    * Host) are attacker-controllable and are never consulted.
@@ -150,16 +151,22 @@ class Door {
     this.#publicOrigin = config.baseUrl === undefined ? undefined : publicOriginOf(config.baseUrl);
   }
 
-  /** The origin metadata, endpoints, resource URIs, and audience checks derive
-   * from: the configured public base when set, else the request's own URL —
-   * never a forwarded header. */
-  #origin(url: URL): string {
-    return this.#publicOrigin ?? url.origin;
-  }
-
   async handler(req: Request): Promise<Response> {
+    // ENG-333: behind a reverse proxy the request URL carries the proxy-
+    // internal origin. Rebase the request onto the configured canonical base
+    // ONCE, up front, so everything derived from the request URL downstream —
+    // discovery metadata, issuer/endpoint URLs, resource identifiers and
+    // audience checks, consent form actions, host-login returnTo URLs — speaks
+    // the public origin. Only the origin moves; path, query, method, headers,
+    // and body are preserved. Unconfigured doors keep request-derived origins,
+    // and forwarded headers (X-Forwarded-*, Host) are never consulted either
+    // way: the operator-set base is the only trusted origin channel.
+    const incoming = new URL(req.url);
+    if (this.#publicOrigin !== undefined && incoming.origin !== this.#publicOrigin) {
+      req = rebaseRequest(req, this.#publicOrigin, incoming);
+    }
     const url = new URL(req.url);
-    const origin = this.#origin(url);
+    const origin = url.origin;
     const path = url.pathname;
 
     if (path.startsWith(PRM_PREFIX)) {
@@ -233,7 +240,8 @@ class Door {
   }
 
   async #handleMcp(req: Request, mount: string): Promise<Response> {
-    const origin = this.#origin(new URL(req.url));
+    // handler() has already rebased req onto the canonical public base.
+    const origin = new URL(req.url).origin;
     const resource = resourceUri(origin, mount);
     await this.#sweepIdleSessions();
     const auth = this.#remoteAs === undefined
@@ -621,6 +629,20 @@ function publicOriginOf(baseUrl: string): string {
     throw new TypeError("baseUrl cannot contain credentials");
   }
   return url.origin;
+}
+
+/** Move a request onto the canonical public origin, preserving everything
+ * else. The shape production hosts proved as a workaround (runvendo/umami#1),
+ * now owned by the door itself. */
+function rebaseRequest(req: Request, origin: string, incoming: URL): Request {
+  const url = new URL(`${incoming.pathname}${incoming.search}`, origin);
+  const init: RequestInit & { duplex?: "half" } = {
+    method: req.method,
+    headers: req.headers,
+    signal: req.signal,
+    ...(req.method === "GET" || req.method === "HEAD" ? {} : { body: req.body, duplex: "half" }),
+  };
+  return new Request(url, init);
 }
 
 function resourceUri(origin: string, mount: string): string {

--- a/packages/vendo/src/server.test.ts
+++ b/packages/vendo/src/server.test.ts
@@ -742,7 +742,7 @@ describe("09 §2 apps composition", () => {
 });
 
 describe("10-mcp §5 — door claims only its four exact well-known paths (FIX H)", () => {
-  async function mcpVendo(): Promise<Vendo> {
+  async function mcpVendo(mcp: boolean | { baseUrl?: string } = true): Promise<Vendo> {
     const dataDir = await mkdtemp(join(tmpdir(), "vendo-door-"));
     const store = createStore({ dataDir });
     cleanups.push(async () => { await store.close(); await rm(dataDir, { recursive: true, force: true }); });
@@ -750,7 +750,7 @@ describe("10-mcp §5 — door claims only its four exact well-known paths (FIX H
       model: {} as LanguageModel,
       principal: async () => null,
       store,
-      mcp: true,
+      mcp,
       oauth: {
         async authorize() { return { subject: "user_door" }; },
         async principal(subject) { return { kind: "user", subject }; },
@@ -769,6 +769,40 @@ describe("10-mcp §5 — door claims only its four exact well-known paths (FIX H
     const res = await vendo.handler(root("/.well-known/oauth-protected-resource/api/vendo/mcp"));
     expect(res.status).toBe(200);
     expect((await res.json() as { resource?: string }).resource).toBe("https://host.test/api/vendo/mcp");
+  });
+
+  it("derives door metadata from VENDO_BASE_URL, not the proxy-internal request origin (ENG-333)", async () => {
+    // Behind a reverse proxy (Railway, Fly) the request URL reaching the
+    // process carries the proxy-INTERNAL origin; the operator-set
+    // VENDO_BASE_URL — the same trusted origin channel actions already use —
+    // is what discovery must advertise and what tokens must bind to.
+    vi.stubEnv("VENDO_BASE_URL", "https://app.example.com");
+    const vendo = await mcpVendo();
+    const res = await vendo.handler(new Request(
+      "http://10.0.3.7:8080/.well-known/oauth-protected-resource/api/vendo/mcp",
+    ));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      resource: "https://app.example.com/api/vendo/mcp",
+      authorization_servers: ["https://app.example.com/api/vendo/mcp"],
+    });
+
+    const as = await vendo.handler(new Request(
+      "http://10.0.3.7:8080/.well-known/oauth-authorization-server/api/vendo/mcp",
+    ));
+    expect(await as.json()).toMatchObject({
+      issuer: "https://app.example.com/api/vendo/mcp",
+      token_endpoint: "https://app.example.com/api/vendo/mcp/token",
+    });
+  });
+
+  it("lets mcp.baseUrl override the VENDO_BASE_URL default for split-origin compositions", async () => {
+    vi.stubEnv("VENDO_BASE_URL", "https://host-routes.example.com");
+    const vendo = await mcpVendo({ baseUrl: "https://door.example.com" });
+    const res = await vendo.handler(new Request(
+      "http://10.0.3.7:8080/.well-known/oauth-protected-resource/api/vendo/mcp",
+    ));
+    expect((await res.json() as { resource?: string }).resource).toBe("https://door.example.com/api/vendo/mcp");
   });
 
   it("does NOT route boundary-adjacent or foreign well-known paths to the door", async () => {

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -74,8 +74,14 @@ export interface CreateVendoConfig {
   telemetry?: boolean;
   /** 10-mcp §1 — the one flag: open the MCP door so outside agents (Claude,
       ChatGPT, Cursor) reach the host's tools through the SAME guard-bound path.
-      Opening it is a host decision (10-mcp §2), so it is off by default. */
-  mcp?: boolean;
+      Opening it is a host decision (10-mcp §2), so it is off by default.
+      The additive object form opens the door with options: `baseUrl` is the
+      canonical PUBLIC base URL the door's discovery metadata, issuer, resource
+      identifiers, and RFC 8707 audience binding derive from — set it (or
+      `VENDO_BASE_URL`, the default) behind a reverse proxy, where the request
+      URL carries the proxy-internal origin. Forwarded headers are never
+      trusted. */
+  mcp?: boolean | { baseUrl?: string };
   /** 10-mcp §3 plus its additive prebuilt flow — the host's session + identity seam. Threaded top-level like
       `actAs`/`principal` (the door is agnostic; the umbrella owns the shape).
       REQUIRED when `mcp` is true: the door cannot mint principals without it. */
@@ -782,8 +788,15 @@ export function createVendo(config: CreateVendoConfig): Vendo {
   // guard-bound registry chat/apps/automations use, the guard (its core seam is
   // what the door holds for auth audit), the store (a StoreAdapter for the door's
   // own protocol state), the host's oauth seam, and an AppsPort view of `apps`.
+  // `mcp: true` and `mcp: {…}` both open the door; the object form carries
+  // door options (an explicit `baseUrl` overrides the VENDO_BASE_URL default).
+  const mcpOptions = typeof config.mcp === "object" && config.mcp !== null
+    ? config.mcp
+    : config.mcp === true
+      ? {}
+      : undefined;
   let door: McpDoor | undefined;
-  if (config.mcp === true) {
+  if (mcpOptions !== undefined) {
     if (config.oauth === undefined) {
       throw new VendoError(
         "validation",
@@ -809,7 +822,13 @@ export function createVendo(config: CreateVendoConfig): Vendo {
     };
     // 10-mcp §5 — pin the door's canonical mount so a cold umbrella's server
     // card advertises the right transport URL (BASE_PATH/mcp) before any request
-    // teaches it, and learned paths never override it.
+    // teaches it, and learned paths never override it. The door's canonical
+    // public base (discovery origins + RFC 8707 audience) is the operator-set
+    // VENDO_BASE_URL — behind a reverse proxy the request URL carries the
+    // proxy-INTERNAL origin and must not shape what discovery advertises
+    // (ENG-333). An explicit `mcp.baseUrl` overrides the env default for
+    // compositions whose door origin differs from the route-binding origin.
+    const doorBaseUrl = mcpOptions.baseUrl ?? configuredBaseUrl;
     door = createMcpDoor({
       tools: boundTools,
       guard,
@@ -817,6 +836,7 @@ export function createVendo(config: CreateVendoConfig): Vendo {
       oauth: config.oauth,
       apps: appsPort,
       mount: MCP_MOUNT,
+      ...(doorBaseUrl === undefined ? {} : { baseUrl: doorBaseUrl }),
       ...(theme === undefined ? {} : { theme }),
     });
   }
@@ -846,7 +866,7 @@ export function createVendo(config: CreateVendoConfig): Vendo {
     guard,
     apps,
     automations,
-    mcp: config.mcp === true,
+    mcp: mcpOptions !== undefined,
     ...(door === undefined ? {} : { door }),
     onRequestOrigin: (origin) => {
       // Same-origin default for route-binding execution (04): no VENDO_BASE_URL


### PR DESCRIPTION
## The bug

Behind a reverse proxy (Railway, Fly — i.e. every real deploy), the MCP door built its OAuth surface from the incoming request URL, which carries the proxy-INTERNAL origin:

- RFC 9728 protected-resource metadata (`resource`, `authorization_servers`)
- RFC 8414 authorization-server metadata (issuer + authorize/token/revoke/register endpoint URLs)
- the SEP-2127 server card's transport URL and `resource_metadata`
- the 401 challenge's `WWW-Authenticate: Bearer resource_metadata="…"`
- RFC 8707 audience binding (the `resource` consents/codes/tokens bind to and the per-request audience check)

So discovery documents advertised internal, unreachable origins, and both live hosts shipped a host-side workaround that re-wraps the `Request` with the public origin (runvendo/umami#1 `vendo-request.ts`; demo-bank's `publicVendoRequest`). `VENDO_BASE_URL` — already the operator-set trusted origin channel for actions — was ignored by the door.

## The fix

- **`McpDoorConfig.baseUrl`** (new, `@vendoai/mcp`): the canonical PUBLIC base URL. Origin only; validated loudly at construction (absolute http(s), no credentials). When set, ALL advertised origins, the issuer, endpoint URLs, resource identifiers, the 401 challenge, and RFC 8707 audience validation derive from it; the request contributes only its path. Unset → request-derived, exactly as before. `X-Forwarded-*`/`Host` headers are never consulted, configured or not — the configured base is the fix, not proxy-header trust (Host-header injection).
- **`createVendo`**: defaults the door's `baseUrl` from `VENDO_BASE_URL` (matching how actions' trusted base already works), and the additive `mcp: { baseUrl }` form overrides the env default for compositions whose door origin differs from the route-binding origin. `mcp: true` is unchanged.
- Precedent: same configured-over-request-derived direction as #191 (remoteAs audience).

Follow-up once released: both host-side workarounds can be deleted (their comments already point at ENG-333).

Note one deliberate behavior change: a malformed `VENDO_BASE_URL` now throws at `createVendo({ mcp: true })` time instead of silently shipping wrong discovery documents.

## Contracts & docs

- `docs/contracts/10-mcp.md`: `baseUrl` added to the §1 config block; new §5 origin-derivation bullet (minimal, additive — same shape as the remoteAs/revocation amendments).
- `docs/contracts/10-mcp-umbrella-hookup.md`: Base URL note extended with the door leg.
- `docs-site/capabilities/mcp.mdx`, `docs-site/reference/environment-variables.mdx`, `docs/persistence-and-deploy.md`, `packages/mcp/README.md`.
- `vendo doctor` needs no change: its metadata probes are origin-independent and stay green either way.

## Tests

New door unit suite `createMcpDoor configured canonical base URL (ENG-333)`:
- proxied discovery documents / server card / 401 challenge advertise the public origin
- full proxied OAuth round-trip: register → authorize → token → MCP initialize, all over the internal origin, audience bound to the public resource
- `invalid_target` when the client names the proxy-internal origin as `resource`
- forwarded headers ignored (both configured and unconfigured), request-derived behavior preserved when unconfigured
- base URL with a path reduces to its origin; malformed/credentialed base URLs throw at construction
- remoteAs: public `resource` + external issuer

Umbrella (`packages/vendo/src/server.test.ts`): door metadata derives from `VENDO_BASE_URL` behind a proxy; `mcp.baseUrl` overrides the env default.

E2E: `fixtures/mcp-e2e` umbrella-hookup restructured to pass its door origin via `mcp: { baseUrl }` (that harness deliberately splits door origin from `VENDO_BASE_URL`), full real-SDK OAuth round trip green; `fixtures/integration-browser` harness likewise (mcp-apps.spec.ts verified locally in a real browser).

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm build` ✓ · `pnpm test` ✓ (41/41 tasks) · `pnpm typecheck` ✓ · `pnpm lint` ✓
- Red-first: all 9 new door tests fail against the unmodified door.

https://claude.ai/code/session_01TCaFWy9ifuxgbeozkz83Z9
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP door origin handling behind reverse proxies by rebasing incoming requests onto a configured public base. Discovery docs, issuer/endpoints, `resource`, 401 challenge, consent URLs, and RFC 8707 audience checks now use the public origin from `VENDO_BASE_URL` or `mcp.baseUrl` (ENG-333).

- **Bug Fixes**
  - Adds `baseUrl` to `createMcpDoor` in `@vendoai/mcp` (origin-only; validated at construction; forwarded headers ignored).
  - Rebases proxied requests once at handler entry onto the canonical public origin; issuer, endpoints, `resource`, server card, 401 challenge, prebuilt consent form action, and host-login `returnTo` all use it; request URL supplies only path/query.
  - `createVendo` accepts `mcp: true` or `mcp: { baseUrl }`; defaults door base to `VENDO_BASE_URL`; object form overrides for split-origin setups.

- **Migration**
  - Set `VENDO_BASE_URL` in every proxied deploy; if the door uses a different origin than host routes, pass `mcp: { baseUrl }`.
  - Malformed or credentialed base URLs now throw at startup; correct the value.
  - Remove host-side request-rewrite workarounds that normalized the origin.

<sup>Written for commit e900dd6646174b00f2b5d156470e27131dd3669b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

