### PR TITLE
fix(e2e): rehydrate grant-invalidation spec via the server-bound thread id

### DIFF
--- a/fixtures/integration-browser/e2e/grant-invalidation.spec.ts
+++ b/fixtures/integration-browser/e2e/grant-invalidation.spec.ts
@@ -78,8 +78,12 @@ test("descriptor drift explains the replacement approval and Activity event", as
       headers: { "x-vendo-test-user": "user_bob" },
     });
     expect(listed.ok()).toBeTruthy();
-    const summaries = await listed.json() as { id: string; title: string }[];
-    committedThreadId = summaries.find((summary) => summary.title.includes(FIRST))?.id;
+    const summaries = await listed.json() as { id: string; title: string; updatedAt: string }[];
+    // Newest first: repeat runs against a shared store each mint a fresh thread
+    // with this same title, and only the latest one belongs to this run.
+    committedThreadId = summaries
+      .filter((summary) => summary.title.includes(FIRST))
+      .sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1))[0]?.id;
     expect(committedThreadId).toBeTruthy();
   }).toPass({ timeout: 10_000 });
   await page.goto(`/?thread=${committedThreadId}&user=user_bob`);

--- a/fixtures/integration-browser/e2e/grant-invalidation.spec.ts
+++ b/fixtures/integration-browser/e2e/grant-invalidation.spec.ts
@@ -68,7 +68,21 @@ test("descriptor drift explains the replacement approval and Activity event", as
 
   // Reload proves both surfaces are backed by committed wire/store state: the
   // thread rehydrates its approval payload and Activity fetches persisted audit.
-  await page.reload();
+  // ENG-211 (08-ui amendment 2026-07-14): a supplied thread id unknown to the
+  // server is discarded by the hook and the server mints the effective id — so
+  // recover the id the server actually bound from the summaries listing (the
+  // documented way hosts persist thread identity) and rehydrate THAT thread.
+  let committedThreadId: string | undefined;
+  await expect(async () => {
+    const listed = await request.get("/api/vendo/threads", {
+      headers: { "x-vendo-test-user": "user_bob" },
+    });
+    expect(listed.ok()).toBeTruthy();
+    const summaries = await listed.json() as { id: string; title: string }[];
+    committedThreadId = summaries.find((summary) => summary.title.includes(FIRST))?.id;
+    expect(committedThreadId).toBeTruthy();
+  }).toPass({ timeout: 10_000 });
+  await page.goto(`/?thread=${committedThreadId}&user=user_bob`);
   const committedApproval = page.getByRole("article", { name: `Approval for ${TOOL}` });
   await expect(committedApproval.getByRole("note", { name: "Previous permission invalidated" })).toBeVisible();
   await retain(committedApproval, "approval-card-invalidated-grant.png");


### PR DESCRIPTION
## Problem

The required `integration` check is red on main: `fixtures/integration-browser/e2e/grant-invalidation.spec.ts:73` — after descriptor drift + `page.reload()`, the "Previous permission invalidated" note is not visible. Fails on 60bde355 and 70c8b357, 3+ consecutive CI runs, reproduces locally.

## Root cause (not #158, #196, or #199)

PR **#198** (ENG-211, b7041112) changed `useVendoThread` semantics per the approved 08-ui amendment: a supplied thread id the server does not know is treated as stale — the hook validates it against `GET /threads` summaries, discards it, and lets the server mint the effective id (returned via `x-vendo-thread-id`).

The ENG-261 spec (merged later via #192) pins `?thread=thr_eng_261_browser` and reloads that URL to prove the invalidation note survives from committed store state. Under #198 semantics it only ever passed by a **race**: if the first send beat the hook's async `threads.list()` validation, the pinned id rode the POST and the server bound it (`resolve`: free id → create). When validation wins — consistently in CI, and locally (trace evidence: first POST body has no `threadId`; post-reload `GET /threads` returns only a minted `thr_023c...`) — the conversation persists under the minted id, the reload's pinned id resolves to an empty thread, and the note assertion fails.

**The ENG-261 product behavior is intact.** With the correct (server-bound) id, the committed approval payload rehydrates and the note renders. No product code was touched.

## Fix

Spec-only: before the reload, recover the effective thread id from `GET /threads` (exactly the host pattern the 08-ui 2026-07-14 amendment documents for persisting thread identity) and navigate to it. All ENG-261 assertions — including the user-visible invalidation note after rehydration and the Activity audit row — are kept verbatim.

## Verification

- `grant-invalidation.spec.ts` green locally (was red on pristine HEAD)
- Full `integration-browser` suite: 4/4 passed
- `pnpm build` / `pnpm typecheck` / `pnpm lint` green
- `pnpm test` green except two pre-existing local-env artifacts, both reproduced on clean HEAD with no diff: `@vendoai/store` durability drill fails only because this worktree path contains a space (`Cool%20Code` MODULE_NOT_FOUND in the spawned writer), and one `redteam-e2e` flake under parallel turbo load that passes in isolation.

## Note for follow-up (not this PR)

`useVendoThread` still has the send-vs-validation race: a message sent before `threads.list()` resolves carries the supplied id and the server binds it; after, it is dropped. Worth an ENG ticket to make sends await validation so thread identity is deterministic.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the grant-invalidation e2e spec by rehydrating via the server-bound thread ID instead of a pinned query ID, matching `useVendoThread` behavior from ENG-211. We now read the effective ID from GET /threads, pick the newest matching summary to avoid stale threads on reused stores, and navigate to it before reload so the ENG-261 note renders after rehydration.

<sup>Written for commit 22e71ea219acfd78ff1b9de75b01286a266853d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

