### PR TITLE
feat(actions): extractor seam + tRPC extractor + Rallly fixture (ENG-246)

### DIFF
--- a/corpus/expectations/rallly/baseline.json
+++ b/corpus/expectations/rallly/baseline.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "generatedAt": "2026-07-15T08:54:31.508Z",
+  "score": {
+    "passed": 6,
+    "total": 10,
+    "value": 0.6
+  }
+}

--- a/corpus/expectations/rallly/expected.json
+++ b/corpus/expectations/rallly/expected.json
@@ -1,0 +1,591 @@
+{
+  "version": 1,
+  "theme": {
+    "background": "#ffffff",
+    "surface": "#ffffff",
+    "accent": "#4f46e5",
+    "text": "#27272a",
+    "mutedText": "#52525b",
+    "radius": 10,
+    "fontFamily": "Inter, sans-serif"
+  },
+  "tools": [
+    {
+      "name": "authGetLoginMethod",
+      "kind": "trpc",
+      "procedure": "auth.getLoginMethod",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "authGetUserPermission",
+      "kind": "trpc",
+      "procedure": "auth.getUserPermission",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "billingGetSubscription",
+      "kind": "trpc",
+      "procedure": "billing.getSubscription",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "billingGetTier",
+      "kind": "trpc",
+      "procedure": "billing.getTier",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "billingUpdateSeats",
+      "kind": "trpc",
+      "procedure": "billing.updateSeats",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "calendarsDisconnect",
+      "kind": "trpc",
+      "procedure": "calendars.disconnect",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "calendarsGetDefault",
+      "kind": "trpc",
+      "procedure": "calendars.getDefault",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "calendarsList",
+      "kind": "trpc",
+      "procedure": "calendars.list",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "calendarsSetDefault",
+      "kind": "trpc",
+      "procedure": "calendars.setDefault",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "calendarsSetSelection",
+      "kind": "trpc",
+      "procedure": "calendars.setSelection",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "calendarsSync",
+      "kind": "trpc",
+      "procedure": "calendars.sync",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "dashboardStats",
+      "kind": "trpc",
+      "procedure": "dashboard.stats",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "eventtypesCreate",
+      "kind": "trpc",
+      "procedure": "eventTypes.create",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "eventtypesList",
+      "kind": "trpc",
+      "procedure": "eventTypes.list",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "eventtypesSoftDelete",
+      "kind": "trpc",
+      "procedure": "eventTypes.softDelete",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "eventtypesUpdate",
+      "kind": "trpc",
+      "procedure": "eventTypes.update",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "eventsCancel",
+      "kind": "trpc",
+      "procedure": "events.cancel",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "eventsInfiniteList",
+      "kind": "trpc",
+      "procedure": "events.infiniteList",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "pollsBook",
+      "kind": "trpc",
+      "procedure": "polls.book",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "pollsClose",
+      "kind": "trpc",
+      "procedure": "polls.close",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "pollsCommentsAdd",
+      "kind": "trpc",
+      "procedure": "polls.comments.add",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "pollsCommentsDelete",
+      "kind": "trpc",
+      "procedure": "polls.comments.delete",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "pollsCommentsList",
+      "kind": "trpc",
+      "procedure": "polls.comments.list",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "pollsDuplicate",
+      "kind": "trpc",
+      "procedure": "polls.duplicate",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "pollsGet",
+      "kind": "trpc",
+      "procedure": "polls.get",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "pollsGetCountByStatus",
+      "kind": "trpc",
+      "procedure": "polls.getCountByStatus",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "pollsInfiniteChronological",
+      "kind": "trpc",
+      "procedure": "polls.infiniteChronological",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "pollsMake",
+      "kind": "trpc",
+      "procedure": "polls.make",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "pollsMarkAsDeleted",
+      "kind": "trpc",
+      "procedure": "polls.markAsDeleted",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "pollsModify",
+      "kind": "trpc",
+      "procedure": "polls.modify",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "pollsParticipantsAdd",
+      "kind": "trpc",
+      "procedure": "polls.participants.add",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "pollsParticipantsDelete",
+      "kind": "trpc",
+      "procedure": "polls.participants.delete",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "pollsParticipantsList",
+      "kind": "trpc",
+      "procedure": "polls.participants.list",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "pollsParticipantsRename",
+      "kind": "trpc",
+      "procedure": "polls.participants.rename",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "pollsParticipantsUpdate",
+      "kind": "trpc",
+      "procedure": "polls.participants.update",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "pollsReopen",
+      "kind": "trpc",
+      "procedure": "polls.reopen",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "pollsToggleMuted",
+      "kind": "trpc",
+      "procedure": "polls.toggleMuted",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "spacesAcceptInvite",
+      "kind": "trpc",
+      "procedure": "spaces.acceptInvite",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "spacesCancelInvite",
+      "kind": "trpc",
+      "procedure": "spaces.cancelInvite",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "spacesChangeMemberRole",
+      "kind": "trpc",
+      "procedure": "spaces.changeMemberRole",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "spacesCreate",
+      "kind": "trpc",
+      "procedure": "spaces.create",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "spacesDelete",
+      "kind": "trpc",
+      "procedure": "spaces.delete",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "spacesGetCurrent",
+      "kind": "trpc",
+      "procedure": "spaces.getCurrent",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "spacesGetImageUploadUrl",
+      "kind": "trpc",
+      "procedure": "spaces.getImageUploadUrl",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "spacesGetSeats",
+      "kind": "trpc",
+      "procedure": "spaces.getSeats",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "spacesInviteMember",
+      "kind": "trpc",
+      "procedure": "spaces.inviteMember",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "spacesLeave",
+      "kind": "trpc",
+      "procedure": "spaces.leave",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "spacesLeaveFromAccount",
+      "kind": "trpc",
+      "procedure": "spaces.leaveFromAccount",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "spacesList",
+      "kind": "trpc",
+      "procedure": "spaces.list",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "spacesListInvites",
+      "kind": "trpc",
+      "procedure": "spaces.listInvites",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "spacesListMembers",
+      "kind": "trpc",
+      "procedure": "spaces.listMembers",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "spacesRemoveImage",
+      "kind": "trpc",
+      "procedure": "spaces.removeImage",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "spacesRemoveMember",
+      "kind": "trpc",
+      "procedure": "spaces.removeMember",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "spacesUpdate",
+      "kind": "trpc",
+      "procedure": "spaces.update",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "spacesUpdateImage",
+      "kind": "trpc",
+      "procedure": "spaces.updateImage",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "spacesUpdateShowBranding",
+      "kind": "trpc",
+      "procedure": "spaces.updateShowBranding",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "systemGetUpdateStatus",
+      "kind": "trpc",
+      "procedure": "system.getUpdateStatus",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "userDeleteMe",
+      "kind": "trpc",
+      "procedure": "user.deleteMe",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "userGetAuthed",
+      "kind": "trpc",
+      "procedure": "user.getAuthed",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "userGetMe",
+      "kind": "trpc",
+      "procedure": "user.getMe",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "userGetNotificationPreferences",
+      "kind": "trpc",
+      "procedure": "user.getNotificationPreferences",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "userSubmitFeedback",
+      "kind": "trpc",
+      "procedure": "user.submitFeedback",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "userUpdateLocale",
+      "kind": "trpc",
+      "procedure": "user.updateLocale",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "userUpdateNotificationPreference",
+      "kind": "trpc",
+      "procedure": "user.updateNotificationPreference",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "getBetterAuth",
+      "method": "GET",
+      "path": "/api/better-auth/{all}",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "postBetterAuth",
+      "method": "POST",
+      "path": "/api/better-auth/{all}",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "getEvent",
+      "method": "GET",
+      "path": "/api/event/{route}",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "getHouseKeeping",
+      "method": "GET",
+      "path": "/api/house-keeping/{method}",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "getIntegrations",
+      "method": "GET",
+      "path": "/api/integrations/{connection}",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "postIntegrations",
+      "method": "POST",
+      "path": "/api/integrations/{connection}",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "getLegacy",
+      "method": "GET",
+      "path": "/api/legacy/{route}",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "getLicensingV1",
+      "method": "GET",
+      "path": "/api/licensing/v1/{route}",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "postLicensingV1",
+      "method": "POST",
+      "path": "/api/licensing/v1/{route}",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "getOgImagePoll",
+      "method": "GET",
+      "path": "/api/og-image-poll",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deletePrivate",
+      "method": "DELETE",
+      "path": "/api/private/{route}",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "getPrivate",
+      "method": "GET",
+      "path": "/api/private/{route}",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "postPrivate",
+      "method": "POST",
+      "path": "/api/private/{route}",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "getStatus",
+      "method": "GET",
+      "path": "/api/status",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "getStorage",
+      "method": "GET",
+      "path": "/api/storage/{key}",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "putStorage",
+      "method": "PUT",
+      "path": "/api/storage/{key}",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "getStripeBuyLicense",
+      "method": "GET",
+      "path": "/api/stripe/buy-license",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "getStripePortal",
+      "method": "GET",
+      "path": "/api/stripe/portal",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "postStripeWebhook",
+      "method": "POST",
+      "path": "/api/stripe/webhook",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "getUpdates",
+      "method": "GET",
+      "path": "/api/updates",
+      "readOrWrite": "write"
+    }
+  ],
+  "annotations": [
+    {
+      "name": "pollsGet",
+      "mutating": false,
+      "dangerous": false
+    },
+    {
+      "name": "pollsCommentsList",
+      "mutating": false,
+      "dangerous": false
+    },
+    {
+      "name": "spacesList",
+      "mutating": false,
+      "dangerous": false
+    },
+    {
+      "name": "userGetMe",
+      "mutating": false,
+      "dangerous": false
+    },
+    {
+      "name": "pollsMake",
+      "mutating": true,
+      "dangerous": false
+    },
+    {
+      "name": "pollsCommentsAdd",
+      "mutating": true,
+      "dangerous": false
+    },
+    {
+      "name": "spacesUpdate",
+      "mutating": true,
+      "dangerous": false
+    },
+    {
+      "name": "userDeleteMe",
+      "mutating": true,
+      "dangerous": true
+    },
+    {
+      "name": "spacesDelete",
+      "mutating": true,
+      "dangerous": true
+    },
+    {
+      "name": "pollsParticipantsDelete",
+      "mutating": true,
+      "dangerous": true
+    },
+    {
+      "name": "pollsCommentsDelete",
+      "mutating": true,
+      "dangerous": true
+    },
+    {
+      "name": "eventsCancel",
+      "mutating": true,
+      "dangerous": true
+    },
+    {
+      "name": "deletePrivate",
+      "mutating": true,
+      "dangerous": true
+    },
+    {
+      "name": "putStorage",
+      "mutating": true,
+      "dangerous": false
+    }
+  ],
+  "components": []
+}

--- a/corpus/harness/src/expectations.ts
+++ b/corpus/harness/src/expectations.ts
@@ -30,7 +30,8 @@ export const repoExpectedThemeSchema = z
   })
   .strict();
 
-export const expectedToolInventorySchema = z
+/** HTTP-shaped tool identity: method + path (route and openapi bindings). */
+export const expectedHttpToolInventorySchema = z
   .object({
     name: z.string().min(1),
     method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]),
@@ -38,6 +39,22 @@ export const expectedToolInventorySchema = z
     readOrWrite: z.enum(["read", "write"]),
   })
   .strict();
+
+/** Binding-kind-aware tool identity: a tRPC tool is identified by its
+ * procedure dot-path, not a method+path pair. */
+export const expectedTrpcToolInventorySchema = z
+  .object({
+    name: z.string().min(1),
+    kind: z.literal("trpc"),
+    procedure: z.string().min(1),
+    readOrWrite: z.enum(["read", "write"]),
+  })
+  .strict();
+
+export const expectedToolInventorySchema = z.union([
+  expectedHttpToolInventorySchema,
+  expectedTrpcToolInventorySchema,
+]);
 
 export const expectedToolAnnotationSchema = z
   .object({
@@ -85,6 +102,13 @@ export type ExpectedToolAnnotation = z.infer<typeof expectedToolAnnotationSchema
 export type ExpectedComponentAnnotation = z.infer<typeof expectedComponentAnnotationSchema>;
 export type RepoExpectations = z.infer<typeof repoExpectationsSchema>;
 export type RepoBaseline = z.infer<typeof repoBaselineSchema>;
+
+/** The binding-kind-aware identity an expectation joins on: procedure for
+ * tRPC entries, method+path for HTTP-shaped entries. Names stay out of the
+ * key (01-core §15 renames them deterministically). */
+export function expectedToolIdentity(item: ExpectedToolInventory): string {
+  return "procedure" in item ? `trpc\t${item.procedure}` : `${item.method}\t${item.path}`;
+}
 
 export function repoExpectationsDir(expectationsRoot: string, repoName: string): string {
   return path.join(expectationsRoot, repoName);

--- a/corpus/harness/src/inject.ts
+++ b/corpus/harness/src/inject.ts
@@ -162,6 +162,17 @@ async function findPnpmWorkspaceRoot(checkoutDir: string, targetDir: string): Pr
   return undefined;
 }
 
+/** pnpm ≥10 errors on dangerouslyAllowAllBuilds when the workspace already
+ * declares a curated build allowlist — detect that curation. */
+async function pnpmDeclaresBuiltDependencies(installDir: string): Promise<boolean> {
+  try {
+    const source = await readFile(path.join(installDir, "pnpm-workspace.yaml"), "utf8");
+    return /^\s*(onlyBuiltDependencies|neverBuiltDependencies)\s*:/m.test(source);
+  } catch {
+    return false;
+  }
+}
+
 function localVendoTarballLockfileSpec(lockfile: string): boolean {
   return /file:[^\s"'#]*vendor\/vendoai(?:-[A-Za-z0-9._-]+)?-[^/\s"']+\.tgz/i.test(lockfile);
 }
@@ -379,13 +390,18 @@ export function createLocalVendoInjector(options: CreateLocalVendoInjectorOption
       await writePnpmWorkspaceRootOverrides(repoDir, installSummary);
       if (runInstall) {
         const sourceCommand = installCommandSource(repo, installSummary);
+        // pnpm ≥10 rejects dangerouslyAllowAllBuilds when the repo curates its
+        // own build allowlist (onlyBuiltDependencies/neverBuiltDependencies in
+        // pnpm-workspace.yaml) — respect the repo's explicit config instead.
+        const repoCuratesBuilds = installSummary.packageManager === "pnpm"
+          && await pnpmDeclaresBuiltDependencies(installDir);
         const installCommand = normalizePostInjectionInstallCommand(sourceCommand, {
           dropIgnoreWorkspace: installSummary.packageManager === "pnpm" && installDir !== repoDir,
           disableYarnImmutableInstalls: installSummary.packageManager === "yarn-berry",
           pnpmConfig: installSummary.packageManager === "pnpm"
             ? [
                 "--config.minimumReleaseAge=0",
-                "--config.dangerouslyAllowAllBuilds=true",
+                ...(repoCuratesBuilds ? [] : ["--config.dangerouslyAllowAllBuilds=true"]),
               ]
             : [],
         });

--- a/corpus/harness/src/layers/scored.test.ts
+++ b/corpus/harness/src/layers/scored.test.ts
@@ -207,6 +207,78 @@ describe("runScoredLayer", () => {
     expect(improvement.baselineUpdate?.source).toContain('"generatedAt": "2026-07-06T12:00:00.000Z"');
   });
 
+  it("keys tRPC tools by procedure identity and applies mutation write-safety", async () => {
+    const { repoDir, expectationsRoot } = await makeFixture();
+    const trpcExpectations: RepoExpectations = {
+      ...baseExpectations,
+      tools: [
+        { name: "pollsList", kind: "trpc", procedure: "polls.list", readOrWrite: "read" },
+        { name: "pollsCreate", kind: "trpc", procedure: "polls.create", readOrWrite: "write" },
+      ],
+      annotations: [
+        { name: "pollsList", mutating: false, dangerous: false },
+        { name: "pollsCreate", mutating: true, dangerous: false },
+      ],
+    };
+    await writeExpected(expectationsRoot, "repo-one", trpcExpectations);
+    await mkdir(path.join(repoDir, ".vendo"), { recursive: true });
+    await writeInitOutput(repoDir); // writes theme.json + route tools.json; overwrite tools below
+    await writeFile(
+      path.join(repoDir, ".vendo/tools.json"),
+      JSON.stringify({
+        format: "vendo/tools@1",
+        tools: [
+          {
+            name: "host_polls_list",
+            description: "tRPC query polls.list",
+            inputSchema: { type: "object", properties: {} },
+            risk: "read",
+            binding: { kind: "trpc", procedure: "polls.list", type: "query", mount: "/api/trpc" },
+          },
+          {
+            name: "host_polls_create",
+            description: "tRPC mutation polls.create",
+            inputSchema: { type: "object", properties: {} },
+            risk: "write",
+            binding: { kind: "trpc", procedure: "polls.create", type: "mutation", mount: "/api/trpc" },
+          },
+        ],
+      }, null, 2) + "\n",
+    );
+
+    const result = await runScoredLayer({
+      repoName: "repo-one",
+      repoDir,
+      expectationsRoot,
+      now: () => new Date("2026-07-06T12:00:00.000Z"),
+    });
+    const checks = checkById(result.layer);
+    expect(checks["tools.precision"]).toMatchObject({ pass: true });
+    expect(checks["tools.recall"]).toMatchObject({ pass: true });
+    expect(checks["annotations.match"]).toMatchObject({ pass: true });
+    expect(checks["annotations.write-safety"]).toMatchObject({ pass: true });
+
+    // A read-labeled mutation is unsafe exactly like a read-labeled POST.
+    await writeFile(
+      path.join(repoDir, ".vendo/tools.json"),
+      JSON.stringify({
+        format: "vendo/tools@1",
+        tools: [
+          {
+            name: "host_polls_create",
+            description: "tRPC mutation polls.create",
+            inputSchema: { type: "object", properties: {} },
+            risk: "read",
+            binding: { kind: "trpc", procedure: "polls.create", type: "mutation", mount: "/api/trpc" },
+          },
+        ],
+      }, null, 2) + "\n",
+    );
+    const unsafe = await runScoredLayer({ repoName: "repo-one", repoDir, expectationsRoot });
+    expect(checkById(unsafe.layer)["annotations.write-safety"]).toMatchObject({ pass: false });
+    expect(unsafe.layer.hardFailure).toBe(true);
+  });
+
   it("skips repos that have not been labeled yet", async () => {
     const { repoDir, expectationsRoot } = await makeFixture();
     await writeInitOutput(repoDir);

--- a/corpus/harness/src/layers/scored.ts
+++ b/corpus/harness/src/layers/scored.ts
@@ -8,12 +8,12 @@ import {
 import { toolsFileSchema, type ExtractedTool } from "@vendoai/actions";
 import {
   THEME_RUBRIC_DIMENSIONS,
+  expectedToolIdentity,
   loadRepoBaseline,
   loadRepoExpectations,
   repoBaselinePath,
   type ExpectedComponentAnnotation,
   type ExpectedToolAnnotation,
-  type ExpectedToolInventory,
   type RepoBaseline,
   type RepoExpectations,
   type ThemeRubricDimension,
@@ -102,40 +102,36 @@ function scoreTheme(expected: RepoExpectations, actual: VendoTheme): WeightedRes
   return { checks, points, total: THEME_RUBRIC_DIMENSIONS.length };
 }
 
-function actualInventory(tool: ExtractedTool): ExpectedToolInventory {
-  return {
-    name: tool.name,
-    method: tool.binding.method,
-    path: tool.binding.path,
-    readOrWrite: tool.risk === "read" ? "read" : "write",
-  };
+// A tool's IDENTITY for scoring is binding-kind-aware — the endpoint
+// (method + path) for HTTP-shaped bindings, the procedure dot-path for tRPC —
+// plus its read/write classification, and NOT its name. Tool names are a
+// deterministic, contract-defined value (01-core §15: provider-safe
+// `host_<path>` slugs), while the checked-in expectations carry the pre-freeze
+// OpenAPI-operationId names (`getAdminTeams`). Keying on the identity is the
+// "adapted names" the v0 corpus requires, and still catches every real
+// extraction defect: a missed surface drops recall, a mis-classified
+// read/write breaks the key.
+function actualToolIdentity(tool: ExtractedTool): string {
+  return tool.binding.kind === "trpc"
+    ? `trpc\t${tool.binding.procedure}`
+    : `${tool.binding.method}\t${tool.binding.path}`;
 }
 
-// A tool's IDENTITY for scoring is its endpoint (method + path) and its
-// read/write classification — NOT its name. Tool names are a deterministic,
-// contract-defined value (01-core §15: provider-safe `host_<path>` slugs),
-// while the checked-in expectations carry the pre-freeze OpenAPI-operationId
-// names (`getAdminTeams`). Keying on the endpoint is the "adapted names" the
-// v0 corpus requires, and still catches every real extraction defect: a missed
-// endpoint drops recall, a mis-classified read/write breaks the key.
-function inventoryKey(item: ExpectedToolInventory): string {
-  return `${item.method}\t${item.path}\t${item.readOrWrite}`;
+function actualInventoryKey(tool: ExtractedTool): string {
+  return `${actualToolIdentity(tool)}\t${tool.risk === "read" ? "read" : "write"}`;
 }
 
-/** The endpoint identity (method + path) used to join an expectation to the
-    actual tool independent of the renamed slug. */
-function endpointKey(method: string, path: string): string {
-  return `${method}\t${path}`;
+function expectedInventoryKey(item: RepoExpectations["tools"][number]): string {
+  return `${expectedToolIdentity(item)}\t${item.readOrWrite}`;
 }
 
 function scoreTools(expected: RepoExpectations, actualTools: readonly ExtractedTool[]): WeightedResult {
   const expectedInventories = expected.tools;
-  const expectedKeys = new Set(expectedInventories.map(inventoryKey));
-  const actualInventories = actualTools.map(actualInventory);
-  const actualKeys = actualInventories.map(inventoryKey);
+  const expectedKeys = new Set(expectedInventories.map(expectedInventoryKey));
+  const actualKeys = actualTools.map(actualInventoryKey);
   const actualMatches = actualKeys.filter((key) => expectedKeys.has(key)).length;
-  const expectedMatches = expectedInventories.filter((tool) => actualKeys.includes(inventoryKey(tool))).length;
-  const precision = actualInventories.length === 0 ? 1 : actualMatches / actualInventories.length;
+  const expectedMatches = expectedInventories.filter((tool) => actualKeys.includes(expectedInventoryKey(tool))).length;
+  const precision = actualTools.length === 0 ? 1 : actualMatches / actualTools.length;
   const recall = expected.tools.length === 0 ? 1 : expectedMatches / expected.tools.length;
 
   return {
@@ -145,7 +141,7 @@ function scoreTools(expected: RepoExpectations, actualTools: readonly ExtractedT
       {
         id: "tools.precision",
         pass: precision === 1,
-        detail: `${actualMatches}/${actualInventories.length} generated tools matched expected inventory; precision ${precision.toFixed(3)}`,
+        detail: `${actualMatches}/${actualTools.length} generated tools matched expected inventory; precision ${precision.toFixed(3)}`,
       },
       {
         id: "tools.recall",
@@ -162,22 +158,28 @@ function expectedAnnotationMatches(expected: ExpectedToolAnnotation, actual: Ext
   return actual.risk === expectedRisk;
 }
 
+/** A tRPC mutation is write-shaped exactly like a POST; a query like a GET. */
+function effectiveWriteMethod(tool: ExtractedTool): string {
+  if (tool.binding.kind === "trpc") return tool.binding.type === "query" ? "GET" : "POST";
+  return tool.binding.method;
+}
+
 function isUnsafeAutoAllowed(tool: ExtractedTool): boolean {
-  const method = tool.binding.method;
+  const method = effectiveWriteMethod(tool);
   if (WRITE_METHODS.has(method) && tool.risk === "read") return true;
   if ((method === "DELETE" || DESTRUCTIVE_NAME.test(tool.name)) && tool.risk !== "destructive") return true;
   return false;
 }
 
 function scoreAnnotations(expected: RepoExpectations, actualTools: readonly ExtractedTool[]): WeightedResult {
-  // Names changed by contract (§15), so join by endpoint: the annotation's name
-  // resolves to an expected tool's (method,path) within the expectations, and
-  // that endpoint finds the actual tool.
+  // Names changed by contract (§15), so join by binding identity: the
+  // annotation's name resolves to an expected tool's identity within the
+  // expectations, and that identity finds the actual tool.
   const expectedByName = new Map(expected.tools.map((tool) => [tool.name, tool]));
-  const actualByEndpoint = new Map(actualTools.map((tool) => [endpointKey(tool.binding.method, tool.binding.path), tool]));
+  const actualByIdentity = new Map(actualTools.map((tool) => [actualToolIdentity(tool), tool]));
   const resolveActual = (annotationName: string): ExtractedTool | undefined => {
-    const endpoint = expectedByName.get(annotationName);
-    return endpoint ? actualByEndpoint.get(endpointKey(endpoint.method, endpoint.path)) : undefined;
+    const item = expectedByName.get(annotationName);
+    return item ? actualByIdentity.get(expectedToolIdentity(item)) : undefined;
   };
   const matched = expected.annotations.filter((annotation) => expectedAnnotationMatches(annotation, resolveActual(annotation.name))).length;
   const annotationScore = expected.annotations.length === 0 ? 1 : matched / expected.annotations.length;

--- a/corpus/harness/src/layers/structural.ts
+++ b/corpus/harness/src/layers/structural.ts
@@ -420,8 +420,14 @@ async function checkIdempotency(ctx: StructuralLayerContext): Promise<Structural
   return { id: "init.idempotent", pass: false, detail: pieces.join("; ") };
 }
 
+/** A tRPC mutation is write-shaped exactly like a POST; a query like a GET. */
+function effectiveWriteMethod(tool: ExtractedTool): string {
+  if (tool.binding.kind === "trpc") return tool.binding.type === "query" ? "GET" : "POST";
+  return tool.binding.method;
+}
+
 function isUnsafeAutoAllowed(tool: ExtractedTool): boolean {
-  const method = tool.binding.method;
+  const method = effectiveWriteMethod(tool);
   if (WRITE_METHODS.has(method) && tool.risk === "read") return true;
   if ((method === "DELETE" || DESTRUCTIVE_NAME.test(tool.name)) && tool.risk !== "destructive") return true;
   return false;

--- a/corpus/manifest.json
+++ b/corpus/manifest.json
@@ -392,6 +392,26 @@
     "notes": "Default branch main verified via GitHub API and git ls-remote; package.json declares next 15.6.0-canary.60."
   },
   {
+    "name": "rallly",
+    "gitUrl": "https://github.com/lukevella/rallly.git",
+    "pinnedSha": "317ceaacc2e4e5753c109cbed370a78a0871cb35",
+    "appDir": "apps/web",
+    "license": "AGPL-3.0",
+    "tier": "broad",
+    "bootstrap": {
+      "installCommand": "corepack pnpm install --frozen-lockfile",
+      "envTemplate": {
+        "DATABASE_URL": "postgresql://corpus:corpus@127.0.0.1:55435/rallly",
+        "SECRET_PASSWORD": "corpus-layer1-secret-password-0123456789",
+        "SUPPORT_EMAIL": "support@corpus.test",
+        "NEXT_PUBLIC_BASE_URL": "http://127.0.0.1:3000"
+      },
+      "typecheckCommand": "corepack pnpm -w db:generate && corepack pnpm exec tsc --pretty --noEmit",
+      "buildCommand": "corepack pnpm -w db:generate && corepack pnpm exec turbo run build --filter=@rallly/web"
+    },
+    "notes": "First tRPC corpus fixture (ENG-246): Next 16 app router + tRPC 11 (superjson) + Prisma/Postgres pnpm monorepo. Default branch main verified via git ls-remote; apps/web/package.json declares next 16.2.6. prisma generate must precede typecheck/build (no postinstall hook). LICENSE contains the GNU Affero GPL v3 text."
+  },
+  {
     "name": "teable",
     "gitUrl": "https://github.com/teableio/teable.git",
     "pinnedSha": "105e0f945dd9e4181ba6f80e44056c176a9800aa",

--- a/packages/actions/src/formats.ts
+++ b/packages/actions/src/formats.ts
@@ -156,6 +156,30 @@ export const openApiBindingSchema = z.object({
 }).passthrough() satisfies z.ZodType<OpenApiBinding>;
 
 /**
+ * 04-actions §1 (additive within vendo/tools@1): execution binding for a tRPC
+ * procedure. Tool identity is mount + `procedure` dot-path, not a method+path
+ * pair. Execution is the tRPC HTTP envelope against the host mount: queries
+ * are GET `{mount}/{procedure}?input=...`, mutations POST `{mount}/{procedure}`.
+ * `transformer: "superjson"` marks mounts whose tRPC root applies the superjson
+ * data transformer, so the runtime wraps/unwraps the `{ json: ... }` envelope.
+ */
+export interface TrpcBinding {
+  kind: "trpc";
+  procedure: string;               // dot-path, e.g. "polls.list"
+  type: "query" | "mutation";
+  mount: string;                   // "/api/trpc" — resolved against createActions baseUrl
+  transformer?: "superjson";
+}
+
+export const trpcBindingSchema = z.object({
+  kind: z.literal("trpc"),
+  procedure: z.string().min(1),
+  type: z.enum(["query", "mutation"]),
+  mount: z.string().startsWith("/"),
+  transformer: z.literal("superjson").optional(),
+}).passthrough() satisfies z.ZodType<TrpcBinding>;
+
+/**
  * 04-actions §6: ordered steps over primitive host/connector tools, reusing the
  * core §11 `Step` shape. Expressions see `{ args, steps, item }`. Compounds are
  * agent-authored: they live in `.vendo/capabilities.json`, never `tools.json`.
@@ -174,13 +198,14 @@ export const compoundBindingSchema = z.object({
 ) satisfies z.ZodType<CompoundBinding>;
 
 /** The bindings deterministic extraction may emit into `.vendo/tools.json`. */
-export type PrimitiveToolBinding = RouteBinding | OpenApiBinding;
+export type PrimitiveToolBinding = RouteBinding | OpenApiBinding | TrpcBinding;
 
-export type ToolBinding = RouteBinding | OpenApiBinding | CompoundBinding;
+export type ToolBinding = RouteBinding | OpenApiBinding | TrpcBinding | CompoundBinding;
 
 export const toolBindingSchema = z.union([
   routeBindingSchema,
   openApiBindingSchema,
+  trpcBindingSchema,
   compoundBindingSchema,
 ]) satisfies z.ZodType<ToolBinding>;
 
@@ -194,6 +219,7 @@ const compoundKindSchema = z.object({ kind: z.literal("compound") }).passthrough
 const extractedBindingSchema = z.discriminatedUnion("kind", [
   routeBindingSchema,
   openApiBindingSchema,
+  trpcBindingSchema,
   compoundKindSchema,
 ]) as unknown as z.ZodType<PrimitiveToolBinding>;
 

--- a/packages/actions/src/runtime/registry.test.ts
+++ b/packages/actions/src/runtime/registry.test.ts
@@ -599,7 +599,6 @@ describe("host HTTP execution — venue=mcp (10-mcp §3 / 04 §4 ActAs auth)", (
   });
 });
 
-<<<<<<< HEAD
 describe("host HTTP execution — away (ENG-263 away re-verification rides actAs)", () => {
   async function hostServer(): Promise<{ url: string; seen: Array<Record<string, string | string[] | undefined>> }> {
     const seen: Array<Record<string, string | string[] | undefined>> = [];

--- a/packages/actions/src/runtime/registry.test.ts
+++ b/packages/actions/src/runtime/registry.test.ts
@@ -599,6 +599,7 @@ describe("host HTTP execution — venue=mcp (10-mcp §3 / 04 §4 ActAs auth)", (
   });
 });
 
+<<<<<<< HEAD
 describe("host HTTP execution — away (ENG-263 away re-verification rides actAs)", () => {
   async function hostServer(): Promise<{ url: string; seen: Array<Record<string, string | string[] | undefined>> }> {
     const seen: Array<Record<string, string | string[] | undefined>> = [];
@@ -695,5 +696,83 @@ describe("host HTTP execution — away (ENG-263 away re-verification rides actAs
     expect((mismatch as { actAs?: string }).actAs).toBe("mismatch");
     expect(actAs).not.toHaveBeenCalled();
     expect(host.seen).toHaveLength(0);
+  });
+});
+
+describe("host HTTP execution — trpc bindings (04 §1 tRPC HTTP envelope)", () => {
+  const trpcTool = (extras: Partial<ExtractedTool["binding"] & Record<string, unknown>> = {}): ExtractedTool => ({
+    name: "host_polls_list",
+    description: "tRPC query polls.list",
+    inputSchema: { type: "object", properties: {} },
+    risk: "read",
+    binding: { kind: "trpc", procedure: "polls.list", type: "query", mount: "/api/trpc", ...extras },
+  });
+
+  function capturingFetch(status: number, payload: unknown): { fetch: typeof fetch; seen: Array<{ url: string; method?: string; body?: unknown }> } {
+    const seen: Array<{ url: string; method?: string; body?: unknown }> = [];
+    const impl = (async (input: URL | RequestInfo, init?: RequestInit) => {
+      seen.push({
+        url: String(input),
+        method: init?.method,
+        body: typeof init?.body === "string" ? JSON.parse(init.body) : undefined,
+      });
+      return new Response(JSON.stringify(payload), { status, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+    return { fetch: impl, seen };
+  }
+
+  it("executes a query as GET {mount}/{procedure} with a plain-JSON input param", async () => {
+    const { fetch, seen } = capturingFetch(200, { result: { data: [{ id: "p1" }] } });
+    const actions = createActions({ tools: [trpcTool()], baseUrl: "http://host.test", fetch });
+
+    const outcome = await actions.execute({ id: "1", tool: "host_polls_list", args: { status: "open" } }, ctx);
+    expect(outcome).toEqual({ status: "ok", output: [{ id: "p1" }] });
+    const url = new URL(seen[0]!.url);
+    expect(url.pathname).toBe("/api/trpc/polls.list");
+    expect(seen[0]!.method).toBe("GET");
+    expect(JSON.parse(url.searchParams.get("input")!)).toEqual({ status: "open" });
+  });
+
+  it("omits the input param when a query has no args", async () => {
+    const { fetch, seen } = capturingFetch(200, { result: { data: "ok" } });
+    const actions = createActions({ tools: [trpcTool()], baseUrl: "http://host.test", fetch });
+
+    await actions.execute({ id: "1", tool: "host_polls_list", args: {} }, ctx);
+    expect(new URL(seen[0]!.url).searchParams.get("input")).toBeNull();
+  });
+
+  it("wraps input and unwraps output through the superjson envelope", async () => {
+    const { fetch, seen } = capturingFetch(200, { result: { data: { json: { created: true } } } });
+    const tool: ExtractedTool = {
+      name: "host_polls_create",
+      description: "tRPC mutation polls.create",
+      inputSchema: { type: "object" },
+      risk: "write",
+      binding: { kind: "trpc", procedure: "polls.create", type: "mutation", mount: "/api/trpc", transformer: "superjson" },
+    };
+    const actions = createActions({ tools: [tool], baseUrl: "http://host.test", fetch });
+
+    const outcome = await actions.execute({ id: "1", tool: "host_polls_create", args: { title: "Standup" } }, ctx);
+    expect(outcome).toEqual({ status: "ok", output: { created: true } });
+    expect(seen[0]!.method).toBe("POST");
+    expect(new URL(seen[0]!.url).pathname).toBe("/api/trpc/polls.create");
+    expect(seen[0]!.body).toEqual({ json: { title: "Standup" } });
+  });
+
+  it("returns a validation outcome when no baseUrl is configured", async () => {
+    const actions = createActions({ tools: [trpcTool()] });
+    await expect(actions.execute({ id: "1", tool: "host_polls_list", args: {} }, ctx)).resolves.toMatchObject({
+      status: "error",
+      error: { code: "validation", message: expect.stringContaining("baseUrl") },
+    });
+  });
+
+  it("maps trpc error statuses to http-error outcomes", async () => {
+    const { fetch } = capturingFetch(400, { error: { message: "BAD_REQUEST" } });
+    const actions = createActions({ tools: [trpcTool()], baseUrl: "http://host.test", fetch });
+    await expect(actions.execute({ id: "1", tool: "host_polls_list", args: {} }, ctx)).resolves.toMatchObject({
+      status: "error",
+      error: { code: "http-error", message: expect.stringContaining("400") },
+    });
   });
 });

--- a/packages/actions/src/runtime/registry.ts
+++ b/packages/actions/src/runtime/registry.ts
@@ -340,7 +340,12 @@ function mcpConsentGrant(ctx: ActionsRunContext, call: ToolCall, tool: Extracted
 
 /** The tRPC HTTP envelope (04 §1): queries GET `{mount}/{procedure}?input=...`,
  * mutations POST the input as the JSON body. Hosts whose tRPC root applies the
- * superjson transformer expect the `{ json: ... }` wrapping. */
+ * superjson transformer expect the `{ json: ... }` wrapping — which is exactly
+ * `superjson.serialize(value)` for every value that can traverse the agent
+ * tool-call wire (plain JSON; no Date/Map/Set instances exist there, so no
+ * `meta` is ever needed). Known limitation: a host validator that demands a
+ * rich type (e.g. `z.date()`) rejects the ISO string visibly as a tRPC 400 —
+ * request-path date coercion via schema-informed `meta` is a follow-up. */
 function trpcRequest(binding: TrpcBinding, args: Record<string, unknown>, configuredBaseUrl?: string): {
   url: URL;
   method: HttpMethod;
@@ -369,7 +374,9 @@ function trpcRequest(binding: TrpcBinding, args: Record<string, unknown>, config
 }
 
 /** Unwrap the tRPC success envelope: `{ result: { data } }`, with superjson's
- * `{ json }` wrapping inside `data` when the host applies the transformer. */
+ * `{ json }` wrapping inside `data` when the host applies the transformer.
+ * `meta` is intentionally ignored: rich types come back as their JSON
+ * projections (ISO strings etc.), the format the agent layer consumes. */
 function trpcOutput(binding: TrpcBinding, parsed: unknown): unknown {
   const result = parsed !== null && typeof parsed === "object" && "result" in parsed
     ? (parsed as { result: unknown }).result

--- a/packages/actions/src/runtime/registry.ts
+++ b/packages/actions/src/runtime/registry.ts
@@ -23,10 +23,13 @@ import {
   type CapabilityBrief,
   type CompoundTool,
   type ExtractedTool,
+  type HttpMethod,
   type OpenApiBinding,
   type OverridesFile,
   type RouteBinding,
+  type ToolBinding,
   type ToolOverride,
+  type TrpcBinding,
 } from "../formats.js";
 import { createCompoundExecutor, validateCapabilities, type PrimitiveStepTarget } from "./compound.js";
 import { error, isArgsObject } from "./outcome.js";
@@ -234,7 +237,7 @@ function absoluteHttpUrl(value: string | undefined): URL | undefined {
 }
 
 function mayForwardPresentHeaders(
-  binding: RouteBinding | OpenApiBinding,
+  binding: ToolBinding,
   requestUrl: URL,
   configuredBaseUrl: string | undefined,
   baseUrlTrusted: boolean,
@@ -335,27 +338,81 @@ function mcpConsentGrant(ctx: ActionsRunContext, call: ToolCall, tool: Extracted
   };
 }
 
+/** The tRPC HTTP envelope (04 §1): queries GET `{mount}/{procedure}?input=...`,
+ * mutations POST the input as the JSON body. Hosts whose tRPC root applies the
+ * superjson transformer expect the `{ json: ... }` wrapping. */
+function trpcRequest(binding: TrpcBinding, args: Record<string, unknown>, configuredBaseUrl?: string): {
+  url: URL;
+  method: HttpMethod;
+  body?: string;
+} {
+  if (!configuredBaseUrl) {
+    throw new VendoError(
+      "validation",
+      `Cannot execute trpc binding ${binding.procedure}; set createActions({ baseUrl }) for server-side trpc execution`,
+    );
+  }
+  let url: URL;
+  try {
+    url = joinedUrl(configuredBaseUrl, `${binding.mount.replace(/\/$/, "")}/${binding.procedure}`);
+  } catch {
+    throw new VendoError("validation", `Invalid baseUrl for trpc procedure ${binding.procedure}; set createActions({ baseUrl }) to a valid origin`);
+  }
+  const payload = Object.keys(args).length > 0
+    ? (binding.transformer === "superjson" ? { json: args } : args)
+    : undefined;
+  if (binding.type === "query") {
+    if (payload !== undefined) url.searchParams.set("input", JSON.stringify(payload));
+    return { url, method: "GET" };
+  }
+  return { url, method: "POST", ...(payload !== undefined ? { body: JSON.stringify(payload) } : {}) };
+}
+
+/** Unwrap the tRPC success envelope: `{ result: { data } }`, with superjson's
+ * `{ json }` wrapping inside `data` when the host applies the transformer. */
+function trpcOutput(binding: TrpcBinding, parsed: unknown): unknown {
+  const result = parsed !== null && typeof parsed === "object" && "result" in parsed
+    ? (parsed as { result: unknown }).result
+    : undefined;
+  const data = result !== null && typeof result === "object" && result !== undefined && "data" in result
+    ? (result as { data: unknown }).data
+    : parsed;
+  if (binding.transformer === "superjson" && data !== null && typeof data === "object" && "json" in (data as Record<string, unknown>)) {
+    return (data as { json: unknown }).json;
+  }
+  return data;
+}
+
 async function executeHost(config: RegistryConfig, tool: ExtractedTool, call: ToolCall, ctx: RunContext): Promise<ToolOutcome> {
   if (!isArgsObject(call.args)) return error("validation", `Arguments for ${call.tool} must be an object`);
 
   let url: URL;
+  let method: HttpMethod;
   let body: string | undefined;
   try {
-    const substituted = withPathArgs(tool.binding.path, call.args);
-    url = resolveUrl({ ...tool.binding, path: substituted.path }, config.baseUrl);
-    if (tool.binding.kind === "route") {
-      if (tool.binding.argsIn === "query") {
-        for (const [key, value] of Object.entries(substituted.remaining)) appendQuery(url, key, value);
-      } else {
-        body = JSON.stringify(substituted.remaining);
-      }
+    if (tool.binding.kind === "trpc") {
+      const request = trpcRequest(tool.binding, call.args, config.baseUrl);
+      url = request.url;
+      method = request.method;
+      body = request.body;
     } else {
-      const remaining = { ...substituted.remaining };
-      if (Object.prototype.hasOwnProperty.call(remaining, "body")) {
-        body = JSON.stringify(remaining.body);
-        delete remaining.body;
+      method = tool.binding.method;
+      const substituted = withPathArgs(tool.binding.path, call.args);
+      url = resolveUrl({ ...tool.binding, path: substituted.path }, config.baseUrl);
+      if (tool.binding.kind === "route") {
+        if (tool.binding.argsIn === "query") {
+          for (const [key, value] of Object.entries(substituted.remaining)) appendQuery(url, key, value);
+        } else {
+          body = JSON.stringify(substituted.remaining);
+        }
+      } else {
+        const remaining = { ...substituted.remaining };
+        if (Object.prototype.hasOwnProperty.call(remaining, "body")) {
+          body = JSON.stringify(remaining.body);
+          delete remaining.body;
+        }
+        for (const [key, value] of Object.entries(remaining)) appendQuery(url, key, value);
       }
-      for (const [key, value] of Object.entries(remaining)) appendQuery(url, key, value);
     }
   } catch (cause) {
     return error("validation", cause instanceof Error ? cause.message : `Invalid arguments for ${call.tool}`);
@@ -432,7 +489,7 @@ async function executeHost(config: RegistryConfig, tool: ExtractedTool, call: To
     try {
       const request = config.fetch ?? globalThis.fetch;
       const response = await request(url, {
-        method: tool.binding.method,
+        method,
         headers,
         ...(body !== undefined ? { body } : {}),
       });
@@ -440,12 +497,16 @@ async function executeHost(config: RegistryConfig, tool: ExtractedTool, call: To
       if (!response.ok) {
         return error(
           "http-error",
-          `${tool.binding.method} ${url.pathname} → ${response.status}: ${text.slice(0, 200)}`,
+          `${method} ${url.pathname} → ${response.status}: ${text.slice(0, 200)}`,
         );
       }
       if (text) {
         try {
-          return { status: "ok", output: JSON.parse(text) };
+          const parsed: unknown = JSON.parse(text);
+          return {
+            status: "ok",
+            output: tool.binding.kind === "trpc" ? trpcOutput(tool.binding, parsed) : parsed,
+          };
         } catch {
           // Successful non-JSON responses retain their HTTP status and text.
         }

--- a/packages/actions/src/sync/common.ts
+++ b/packages/actions/src/sync/common.ts
@@ -2,7 +2,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { sha256Hex } from "@vendoai/core";
 import { init, parse } from "es-module-lexer";
-import type { ExtractedTool, HttpMethod, ToolBinding } from "../formats.js";
+import type { ExtractedTool, HttpMethod, PrimitiveToolBinding } from "../formats.js";
 
 const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx"] as const;
 // Hidden directories are never route sources; alternate Next dist dirs
@@ -566,12 +566,12 @@ export function dedupKey(method: HttpMethod, urlPath: string): string {
 /** The binding-kind-aware identity a tool is deduplicated and diffed by:
  * method+path for HTTP-shaped bindings, mount+procedure for tRPC (a host can
  * expose the same procedure name under two mounts — both tools must survive). */
-export function bindingIdentity(binding: ToolBinding): string {
+export function bindingIdentity(binding: PrimitiveToolBinding): string {
   if (binding.kind === "trpc") return `TRPC ${binding.mount.replace(/\/+$/g, "")} ${binding.procedure}`;
   return dedupKey(binding.method, binding.path);
 }
 
-function uniqueNameFallback(binding: ToolBinding): string {
+function uniqueNameFallback(binding: PrimitiveToolBinding): string {
   return binding.kind === "trpc" ? binding.type : binding.method;
 }
 

--- a/packages/actions/src/sync/common.ts
+++ b/packages/actions/src/sync/common.ts
@@ -564,9 +564,10 @@ export function dedupKey(method: HttpMethod, urlPath: string): string {
 }
 
 /** The binding-kind-aware identity a tool is deduplicated and diffed by:
- * method+path for HTTP-shaped bindings, the procedure dot-path for tRPC. */
+ * method+path for HTTP-shaped bindings, mount+procedure for tRPC (a host can
+ * expose the same procedure name under two mounts — both tools must survive). */
 export function bindingIdentity(binding: ToolBinding): string {
-  if (binding.kind === "trpc") return `TRPC ${binding.procedure}`;
+  if (binding.kind === "trpc") return `TRPC ${binding.mount.replace(/\/+$/g, "")} ${binding.procedure}`;
   return dedupKey(binding.method, binding.path);
 }
 

--- a/packages/actions/src/sync/common.ts
+++ b/packages/actions/src/sync/common.ts
@@ -2,7 +2,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { sha256Hex } from "@vendoai/core";
 import { init, parse } from "es-module-lexer";
-import type { ExtractedTool, HttpMethod } from "../formats.js";
+import type { ExtractedTool, HttpMethod, ToolBinding } from "../formats.js";
 
 const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx"] as const;
 // Hidden directories are never route sources; alternate Next dist dirs
@@ -539,13 +539,13 @@ export function unclassifiedToolFullName(urlPath: string): string {
   return `host_${parts.length > 0 ? parts.join("_") : "route"}_unclassified`;
 }
 
-export function allocateToolName(preferred: string, method: HttpMethod, used: Set<string>): string {
+export function allocateToolName(preferred: string, fallbackSuffix: string, used: Set<string>): string {
   const first = limitToolName(preferred);
   if (!used.has(first)) {
     used.add(first);
     return first;
   }
-  const methodFallback = limitToolName(`${preferred}_${method.toLowerCase()}`);
+  const methodFallback = limitToolName(`${preferred}_${fallbackSuffix.toLowerCase()}`);
   if (!used.has(methodFallback)) {
     used.add(methodFallback);
     return methodFallback;
@@ -563,11 +563,22 @@ export function dedupKey(method: HttpMethod, urlPath: string): string {
   return `${method} ${urlPath.replace(/\{[^}]+\}/g, "{}").replace(/\/+$/g, "") || "/"}`;
 }
 
+/** The binding-kind-aware identity a tool is deduplicated and diffed by:
+ * method+path for HTTP-shaped bindings, the procedure dot-path for tRPC. */
+export function bindingIdentity(binding: ToolBinding): string {
+  if (binding.kind === "trpc") return `TRPC ${binding.procedure}`;
+  return dedupKey(binding.method, binding.path);
+}
+
+function uniqueNameFallback(binding: ToolBinding): string {
+  return binding.kind === "trpc" ? binding.type : binding.method;
+}
+
 export function withUniqueNames(tools: ExtractedTool[]): ExtractedTool[] {
   const used = new Set<string>();
   return tools.map((tool) => ({
     ...tool,
-    name: allocateToolName(tool.name, tool.binding.method, used),
+    name: allocateToolName(tool.name, uniqueNameFallback(tool.binding), used),
   }));
 }
 
@@ -594,4 +605,18 @@ export function extractedRisk(method: HttpMethod, name: string, source: "openapi
   if (method === "DELETE" || containsWord(name, DESTRUCTIVE_WORDS)) return "destructive";
   if (source === "openapi" && method === "GET" && containsWord(name, READ_WORDS)) return "read";
   return "write";
+}
+
+/** tRPC risk labeling (04 §1, fail-closed): the destructive word list applies
+ * unchanged; a query earns `read` only with a read-shaped name; everything
+ * else — mutations and ambiguously-named queries — defaults to `write`. */
+export function trpcRisk(type: "query" | "mutation", procedure: string): ExtractedTool["risk"] {
+  if (containsWord(procedure, DESTRUCTIVE_WORDS)) return "destructive";
+  if (type === "query" && containsWord(procedure, READ_WORDS)) return "read";
+  return "write";
+}
+
+export function trpcToolFullName(procedure: string): string {
+  const parts = words(procedure);
+  return `host_${parts.length > 0 ? parts.join("_") : "procedure"}`;
 }

--- a/packages/actions/src/sync/extractors.test.ts
+++ b/packages/actions/src/sync/extractors.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { ExtractedTool } from "../formats.js";
+import { extractorRegistrations, runExtractors, type Extractor } from "./extractors.js";
+
+function routeTool(name: string, path: string): ExtractedTool {
+  return {
+    name,
+    description: name,
+    inputSchema: { type: "object", properties: {} },
+    risk: "read",
+    binding: { kind: "route", method: "GET", path, argsIn: "query" },
+  };
+}
+
+describe("extractor registrations", () => {
+  it("keeps OpenAPI ahead of route-scan", () => {
+    expect(extractorRegistrations.slice(0, 2).map((extractor) => extractor.name)).toEqual([
+      "openapi",
+      "route-scan",
+    ]);
+  });
+
+  it("detects and extracts sequentially in registration order", async () => {
+    const calls: string[] = [];
+    const registration = (
+      name: string,
+      detected: boolean,
+      tools: ExtractedTool[],
+      warnings: string[],
+    ): Extractor => ({
+      name,
+      async detect(root) {
+        calls.push(`${name}:detect:${root}`);
+        return detected;
+      },
+      async extract(root) {
+        calls.push(`${name}:extract:${root}`);
+        return { tools, warnings };
+      },
+    });
+
+    const result = await runExtractors("/host", [
+      registration("openapi", true, [routeTool("host_openapi", "/api/openapi")], ["openapi warning"]),
+      registration("skipped", false, [routeTool("host_skipped", "/api/skipped")], ["skipped warning"]),
+      registration("route-scan", true, [routeTool("host_route", "/api/route")], ["route warning"]),
+    ]);
+
+    expect(calls).toEqual([
+      "openapi:detect:/host",
+      "openapi:extract:/host",
+      "skipped:detect:/host",
+      "route-scan:detect:/host",
+      "route-scan:extract:/host",
+    ]);
+    expect(result.tools.map((tool) => tool.name)).toEqual(["host_openapi", "host_route"]);
+    expect(result.warnings).toEqual(["openapi warning", "route warning"]);
+  });
+});

--- a/packages/actions/src/sync/extractors.test.ts
+++ b/packages/actions/src/sync/extractors.test.ts
@@ -13,9 +13,10 @@ function routeTool(name: string, path: string): ExtractedTool {
 }
 
 describe("extractor registrations", () => {
-  it("keeps OpenAPI ahead of route-scan", () => {
-    expect(extractorRegistrations.slice(0, 2).map((extractor) => extractor.name)).toEqual([
+  it("keeps OpenAPI ahead of trpc ahead of route-scan", () => {
+    expect(extractorRegistrations.map((extractor) => extractor.name)).toEqual([
       "openapi",
+      "trpc",
       "route-scan",
     ]);
   });
@@ -54,5 +55,30 @@ describe("extractor registrations", () => {
     ]);
     expect(result.tools.map((tool) => tool.name)).toEqual(["host_openapi", "host_route"]);
     expect(result.warnings).toEqual(["openapi warning", "route warning"]);
+  });
+
+  it("drops route tools shadowed by a trpc mount, and only those", async () => {
+    const trpcTool: ExtractedTool = {
+      name: "host_polls_list",
+      description: "tRPC query polls.list",
+      inputSchema: { type: "object", properties: {} },
+      risk: "read",
+      binding: { kind: "trpc", procedure: "polls.list", type: "query", mount: "/api/trpc" },
+    };
+    const fake = (name: string, tools: ExtractedTool[]): Extractor => ({
+      name,
+      detect: async () => true,
+      extract: async () => ({ tools, warnings: [] }),
+    });
+    const result = await runExtractors("/host", [
+      fake("trpc", [trpcTool]),
+      fake("route-scan", [
+        routeTool("host_trpc_catchall", "/api/trpc/{trpc}"),
+        routeTool("host_trpc_root", "/api/trpc"),
+        routeTool("host_trpcish", "/api/trpcish"),
+        routeTool("host_health", "/api/health"),
+      ]),
+    ]);
+    expect(result.tools.map((tool) => tool.name)).toEqual(["host_polls_list", "host_trpcish", "host_health"]);
   });
 });

--- a/packages/actions/src/sync/extractors.test.ts
+++ b/packages/actions/src/sync/extractors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ExtractedTool } from "../formats.js";
+import { bindingIdentity } from "./common.js";
 import { extractorRegistrations, runExtractors, type Extractor } from "./extractors.js";
 
 function routeTool(name: string, path: string): ExtractedTool {
@@ -80,5 +81,15 @@ describe("extractor registrations", () => {
       ]),
     ]);
     expect(result.tools.map((tool) => tool.name)).toEqual(["host_polls_list", "host_trpcish", "host_health"]);
+  });
+
+  it("keeps the same procedure name distinct across two trpc mounts", () => {
+    // unionExtracted dedups by bindingIdentity — mount must be part of a trpc
+    // tool's identity or one of these silently disappears from tools.json.
+    const first = bindingIdentity({ kind: "trpc", procedure: "health", type: "query", mount: "/api/trpc" });
+    const second = bindingIdentity({ kind: "trpc", procedure: "health", type: "query", mount: "/api/admin/trpc" });
+    expect(first).not.toBe(second);
+    // Trailing-slash mounts normalize to the same identity.
+    expect(bindingIdentity({ kind: "trpc", procedure: "health", type: "query", mount: "/api/trpc/" })).toBe(first);
   });
 });

--- a/packages/actions/src/sync/extractors.ts
+++ b/packages/actions/src/sync/extractors.ts
@@ -1,0 +1,76 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { ExtractedTool } from "../formats.js";
+import { extractOpenApi } from "./openapi.js";
+import { scanRoutes } from "./route-scan.js";
+
+export interface ExtractorResult {
+  tools: ExtractedTool[];
+  warnings: string[];
+}
+
+export interface Extractor {
+  readonly name: string;
+  detect(root: string): Promise<boolean>;
+  extract(root: string): Promise<ExtractorResult>;
+}
+
+async function firstOpenApiSpec(root: string): Promise<string | null> {
+  const candidates = [
+    "openapi.json",
+    "openapi.yaml",
+    "openapi.yml",
+    path.join("public", "openapi.json"),
+    path.join("docs", "openapi.json"),
+    path.join("docs", "openapi.yaml"),
+  ];
+  for (const relative of candidates) {
+    const candidate = path.join(root, relative);
+    try {
+      const stat = await fs.stat(candidate);
+      if (stat.isFile()) return candidate;
+    } catch {
+      // First existing file wins; absent candidates are expected.
+    }
+  }
+  return null;
+}
+
+const openApiExtractor: Extractor = {
+  name: "openapi",
+  async detect(root) {
+    return (await firstOpenApiSpec(root)) !== null;
+  },
+  async extract(root) {
+    const specPath = await firstOpenApiSpec(root);
+    return { tools: specPath ? await extractOpenApi(specPath) : [], warnings: [] };
+  },
+};
+
+const routeScanExtractor: Extractor = {
+  name: "route-scan",
+  async detect() {
+    return true;
+  },
+  extract: scanRoutes,
+};
+
+export const extractorRegistrations: readonly Extractor[] = [
+  openApiExtractor,
+  routeScanExtractor,
+];
+
+export async function runExtractors(
+  root: string,
+  registrations: readonly Extractor[] = extractorRegistrations,
+): Promise<ExtractorResult> {
+  const tools: ExtractedTool[] = [];
+  const warnings: string[] = [];
+  for (const extractor of registrations) {
+    if (!await extractor.detect(root)) continue;
+    const result = await extractor.extract(root);
+    tools.push(...result.tools);
+    warnings.push(...result.warnings);
+  }
+  return { tools, warnings };
+}

--- a/packages/actions/src/sync/extractors.ts
+++ b/packages/actions/src/sync/extractors.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { ExtractedTool } from "../formats.js";
 import { extractOpenApi } from "./openapi.js";
 import { scanRoutes } from "./route-scan.js";
+import { detectTrpc, extractTrpc, trpcMounts } from "./trpc.js";
 
 export interface ExtractorResult {
   tools: ExtractedTool[];
@@ -47,6 +48,12 @@ const openApiExtractor: Extractor = {
   },
 };
 
+const trpcExtractor: Extractor = {
+  name: "trpc",
+  detect: detectTrpc,
+  extract: extractTrpc,
+};
+
 const routeScanExtractor: Extractor = {
   name: "route-scan",
   async detect() {
@@ -57,8 +64,23 @@ const routeScanExtractor: Extractor = {
 
 export const extractorRegistrations: readonly Extractor[] = [
   openApiExtractor,
+  trpcExtractor,
   routeScanExtractor,
 ];
+
+/** Route-scan sees a tRPC mount as an opaque catch-all HTTP route; when the
+ * trpc extractor produced real procedure tools for that mount, the shadowing
+ * route tools are dropped. No trpc tools → no filtering (unchanged behavior
+ * for every non-tRPC host). */
+function withoutShadowedRoutes(tools: ExtractedTool[]): ExtractedTool[] {
+  const mounts = trpcMounts(tools);
+  if (mounts.length === 0) return tools;
+  return tools.filter((tool) => {
+    if (tool.binding.kind !== "route") return true;
+    const { path: routePath } = tool.binding;
+    return !mounts.some((mount) => routePath === mount || routePath.startsWith(`${mount}/`));
+  });
+}
 
 export async function runExtractors(
   root: string,
@@ -72,5 +94,5 @@ export async function runExtractors(
     tools.push(...result.tools);
     warnings.push(...result.warnings);
   }
-  return { tools, warnings };
+  return { tools: withoutShadowedRoutes(tools), warnings };
 }

--- a/packages/actions/src/sync/index.ts
+++ b/packages/actions/src/sync/index.ts
@@ -13,7 +13,7 @@ import {
   type ToolsFile,
   type UnresolvedPin,
 } from "../formats.js";
-import { clearAliasCache, dedupKey, routeToolFullName, withUniqueNames } from "./common.js";
+import { bindingIdentity, clearAliasCache, routeToolFullName, withUniqueNames } from "./common.js";
 import { proposeCatalogCopy, type CatalogCopyGenerator } from "./catalog-ai.js";
 import { scanComponentCatalog } from "./catalog-scan.js";
 import { writeCatalog } from "./catalog.js";
@@ -83,7 +83,7 @@ async function readOverrides(file: string): Promise<OverridesFile | null> {
 }
 
 function bindingKey(tool: ExtractedTool): string {
-  return dedupKey(tool.binding.method, tool.binding.path);
+  return bindingIdentity(tool.binding);
 }
 
 function unionExtracted(extracted: ExtractedTool[]): ExtractedTool[] {

--- a/packages/actions/src/sync/index.ts
+++ b/packages/actions/src/sync/index.ts
@@ -17,9 +17,8 @@ import { clearAliasCache, dedupKey, routeToolFullName, withUniqueNames } from ".
 import { proposeCatalogCopy, type CatalogCopyGenerator } from "./catalog-ai.js";
 import { scanComponentCatalog } from "./catalog-scan.js";
 import { writeCatalog } from "./catalog.js";
-import { extractOpenApi } from "./openapi.js";
+import { runExtractors } from "./extractors.js";
 import { capturePins } from "./pins.js";
-import { scanRoutes } from "./route-scan.js";
 
 export type SyncReportWithWarnings = SyncReport & {
   warnings: string[];
@@ -83,35 +82,14 @@ async function readOverrides(file: string): Promise<OverridesFile | null> {
   }
 }
 
-async function firstOpenApiSpec(root: string): Promise<string | null> {
-  const candidates = [
-    "openapi.json",
-    "openapi.yaml",
-    "openapi.yml",
-    path.join("public", "openapi.json"),
-    path.join("docs", "openapi.json"),
-    path.join("docs", "openapi.yaml"),
-  ];
-  for (const relative of candidates) {
-    const candidate = path.join(root, relative);
-    try {
-      const stat = await fs.stat(candidate);
-      if (stat.isFile()) return candidate;
-    } catch {
-      // First existing file wins; absent candidates are expected.
-    }
-  }
-  return null;
-}
-
 function bindingKey(tool: ExtractedTool): string {
   return dedupKey(tool.binding.method, tool.binding.path);
 }
 
-function unionExtracted(openApi: ExtractedTool[], routes: ExtractedTool[]): ExtractedTool[] {
+function unionExtracted(extracted: ExtractedTool[]): ExtractedTool[] {
   const seen = new Set<string>();
   const union: ExtractedTool[] = [];
-  for (const tool of [...openApi, ...routes]) {
+  for (const tool of extracted) {
     const key = bindingKey(tool);
     if (seen.has(key)) continue;
     seen.add(key);
@@ -224,13 +202,11 @@ export async function vendoSync(options: {
   const previousFile = await readPrevious(toolsPath, warnings);
   const overrides = await readOverrides(path.join(out, "overrides.json"));
 
-  const specPath = await firstOpenApiSpec(root);
-  const openApiTools = specPath ? await extractOpenApi(specPath) : [];
-  const routeResult = await scanRoutes(root);
-  warnings.push(...routeResult.warnings);
+  const extraction = await runExtractors(root);
+  warnings.push(...extraction.warnings);
   const extracted = toolsFileSchema.parse({
     format: "vendo/tools@1",
-    tools: unionExtracted(openApiTools, routeResult.tools),
+    tools: unionExtracted(extraction.tools),
   });
   if (overrides) {
     const extractedNames = new Set(extracted.tools.map((tool) => tool.name));

--- a/packages/actions/src/sync/trpc.test.ts
+++ b/packages/actions/src/sync/trpc.test.ts
@@ -264,6 +264,163 @@ export const appRouter = t.router({
   });
 });
 
+describe("extractTrpc — zod breadth and router edge cases", () => {
+  async function writeKitchenSinkHost(root: string): Promise<void> {
+    await writeFile(root, "package.json", JSON.stringify({
+      name: "trpc-sink",
+      devDependencies: { "@trpc/server": "^11.0.0" },
+    }));
+    await writeFile(root, "pages/api/trpc/[trpc].ts", `
+import { createNextApiHandler } from "@trpc/server/adapters/next";
+import { appRouter } from "@/server/index";
+
+export default createNextApiHandler({ router: appRouter });
+`);
+    await writeFile(root, "server/index.ts", `
+export * from "./root";
+`);
+    await writeFile(root, "server/root.ts", `
+import { initTRPC } from "@trpc/server";
+import * as z from "zod";
+import { sub } from "./sub";
+
+const t = initTRPC.create();
+const router = t.router;
+const p = t.procedure;
+
+const inner = router({
+  ping: p.query(() => "pong"),
+});
+
+export const appRouter = t.mergeRouters(
+  (router({
+    sub,
+    inner,
+    ...inner,
+    kitchen: p
+      .input(z.object({
+        lit: z.literal("fixed"),
+        negative: z.literal(-2),
+        flag: z.literal(true),
+        pick: z.union([z.literal("a"), z.literal("b")]),
+        disc: z.discriminatedUnion("kind", [
+          z.object({ kind: z.literal("x"), value: z.number().int().min(0).max(10) }),
+          z.object({ kind: z.literal("y") }),
+        ]),
+        bag: z.record(z.string(), z.number()),
+        tags: z.array(z.string()).min(1).max(5),
+        maybe: z.string().nullable(),
+        soft: z.number().nullish(),
+        email: z.string().email(),
+        link: z.string().url(),
+        id: z.string().uuid(),
+        when: z.string().datetime(),
+        stamp: z.date(),
+        big: z.bigint(),
+        empty: z.null(),
+        anything: z.any(),
+        mystery: z.unknown(),
+        coerced: z.coerce.number(),
+        fallback: z.string().default("dft"),
+        opaque: z.tuple([z.string(), z.number()]),
+        strange: z.string().somethingNew(),
+      }))
+      .mutation(() => ({})),
+    bare: p.input(z.object({ list: z.array() })).query(() => []),
+  }) satisfies unknown),
+  notARouter,
+);
+`);
+    await writeFile(root, "server/sub.ts", `
+import { initTRPC } from "@trpc/server";
+
+const t = initTRPC.create();
+export const sub = t.router({
+  echo: t.procedure.query(() => "ok"),
+});
+`);
+  }
+
+  it("detects trpc through devDependencies and survives a missing package.json", async () => {
+    const root = await temporaryHost();
+    await writeKitchenSinkHost(root);
+    expect(await detectTrpc(root)).toBe(true);
+    expect(await detectTrpc(path.join(root, "does-not-exist"))).toBe(false);
+  });
+
+  it("interprets the zod kitchen sink, failing closed per-property where unknown", async () => {
+    const root = await temporaryHost();
+    await writeKitchenSinkHost(root);
+    const result = await extractTrpc(root);
+    const kitchen = result.tools.find((tool) => (tool.binding as TrpcBinding).procedure === "kitchen")!;
+    const schema = kitchen.inputSchema as { properties: Record<string, Record<string, unknown>>; required?: string[] };
+    expect(schema.properties.lit).toEqual({ const: "fixed" });
+    expect(schema.properties.negative).toEqual({ const: -2 });
+    expect(schema.properties.flag).toEqual({ const: true });
+    expect(schema.properties.pick).toEqual({ anyOf: [{ const: "a" }, { const: "b" }] });
+    expect(schema.properties.disc).toMatchObject({ anyOf: [
+      { type: "object", properties: { kind: { const: "x" }, value: { type: "integer", minimum: 0, maximum: 10 } } },
+      { type: "object" },
+    ] });
+    expect(schema.properties.bag).toEqual({ type: "object", additionalProperties: { type: "number" } });
+    expect(schema.properties.tags).toEqual({ type: "array", items: { type: "string" }, minItems: 1, maxItems: 5 });
+    expect(schema.properties.maybe).toEqual({ anyOf: [{ type: "string" }, { type: "null" }] });
+    expect(schema.properties.email).toEqual({ type: "string", format: "email" });
+    expect(schema.properties.link).toEqual({ type: "string", format: "uri" });
+    expect(schema.properties.id).toEqual({ type: "string", format: "uuid" });
+    expect(schema.properties.when).toEqual({ type: "string", format: "date-time" });
+    expect(schema.properties.stamp).toEqual({ type: "string", format: "date-time" });
+    expect(schema.properties.big).toEqual({ type: "integer" });
+    expect(schema.properties.empty).toEqual({ type: "null" });
+    expect(schema.properties.anything).toEqual({});
+    expect(schema.properties.mystery).toEqual({});
+    expect(schema.properties.coerced).toEqual({ type: "number" });
+    expect(schema.properties.fallback).toEqual({ type: "string", default: "dft" });
+    // Unknown constructs fail closed to permissive per-property with a note.
+    expect(schema.properties.opaque).toEqual({});
+    expect(schema.properties.strange).toEqual({});
+    expect(kitchen.note).toContain("opaque");
+    expect(kitchen.note).toContain("strange");
+    const required = schema.required ?? [];
+    expect(required).not.toContain("soft");
+    expect(required).not.toContain("fallback");
+    expect(required).toContain("lit");
+
+    const bare = result.tools.find((tool) => (tool.binding as TrpcBinding).procedure === "bare")!;
+    expect((bare.inputSchema as { properties: Record<string, unknown> }).properties.list).toEqual({ type: "array" });
+  });
+
+  it("follows export-star re-exports, satisfies wrappers, spreads, and warns on unresolvable merges", async () => {
+    const root = await temporaryHost();
+    await writeKitchenSinkHost(root);
+    const result = await extractTrpc(root);
+    const procedures = result.tools.map((tool) => (tool.binding as TrpcBinding).procedure).sort();
+    expect(procedures).toEqual(["bare", "inner.ping", "kitchen", "ping", "sub.echo"]);
+    // No superjson anywhere in this host.
+    for (const tool of result.tools) {
+      expect((tool.binding as TrpcBinding).transformer).toBeUndefined();
+    }
+    expect(result.warnings.some((warning) => warning.includes("mergeRouters"))).toBe(true);
+  });
+
+  it("warns when the mount router identifier cannot be resolved", async () => {
+    const root = await temporaryHost();
+    await writeFile(root, "package.json", JSON.stringify({
+      name: "trpc-broken",
+      dependencies: { "@trpc/server": "^11.0.0" },
+    }));
+    await writeFile(root, "pages/api/trpc/[trpc].ts", `
+import { createNextApiHandler } from "@trpc/server/adapters/next";
+import { appRouter } from "missing-package-router";
+
+export default createNextApiHandler({ router: appRouter });
+`);
+    const result = await extractTrpc(root);
+    expect(result.tools).toEqual([]);
+    expect(result.warnings.some((warning) => warning.includes("could not be statically resolved"))).toBe(true);
+  });
+});
+
 describe("trpc + route-scan interplay", () => {
   it("shadows the catch-all mount route when trpc tools exist", async () => {
     const root = await temporaryHost();

--- a/packages/actions/src/sync/trpc.test.ts
+++ b/packages/actions/src/sync/trpc.test.ts
@@ -240,7 +240,7 @@ describe("extractTrpc", () => {
     }));
     await writeFile(root, "pages/api/rpc/[trpc].ts", `
 import { createNextApiHandler } from "@trpc/server/adapters/next";
-import { appRouter } from "../../../server/router";
+import { appRouter } from "@/server/router";
 
 export default createNextApiHandler({ router: appRouter });
 `);

--- a/packages/actions/src/sync/trpc.test.ts
+++ b/packages/actions/src/sync/trpc.test.ts
@@ -403,6 +403,31 @@ export const sub = t.router({
     expect(result.warnings.some((warning) => warning.includes("mergeRouters"))).toBe(true);
   });
 
+  it("resolves routers imported through a default export", async () => {
+    const root = await temporaryHost();
+    await writeFile(root, "package.json", JSON.stringify({
+      name: "trpc-default",
+      dependencies: { "@trpc/server": "^11.0.0" },
+    }));
+    await writeFile(root, "pages/api/trpc/[trpc].ts", `
+import { createNextApiHandler } from "@trpc/server/adapters/next";
+import appRouter from "@/server/router";
+
+export default createNextApiHandler({ router: appRouter });
+`);
+    await writeFile(root, "server/router.ts", `
+import { initTRPC } from "@trpc/server";
+
+const t = initTRPC.create();
+const appRouter = t.router({
+  health: t.procedure.query(() => "ok"),
+});
+export default appRouter;
+`);
+    const { tools } = await extractTrpc(root);
+    expect(tools.map((tool) => (tool.binding as TrpcBinding).procedure)).toEqual(["health"]);
+  });
+
   it("warns when the mount router identifier cannot be resolved", async () => {
     const root = await temporaryHost();
     await writeFile(root, "package.json", JSON.stringify({

--- a/packages/actions/src/sync/trpc.test.ts
+++ b/packages/actions/src/sync/trpc.test.ts
@@ -434,6 +434,67 @@ export const plainRouter = t.router({
     expect(byMount.get("/api/plain")).toEqual(new Set([undefined]));
   });
 
+  it("detects superjson for a namespace-factory router (t.router) with an imported instance", async () => {
+    const root = await temporaryHost();
+    await writeFile(root, "package.json", JSON.stringify({
+      name: "trpc-ns-factory",
+      dependencies: { "@trpc/server": "^11.0.0" },
+    }));
+    await writeFile(root, "pages/api/trpc/[trpc].ts", `
+import { createNextApiHandler } from "@trpc/server/adapters/next";
+import { appRouter } from "@/server/root";
+
+export default createNextApiHandler({ router: appRouter });
+`);
+    await writeFile(root, "server/init.ts", `
+import { initTRPC } from "@trpc/server";
+import superjson from "superjson";
+export const t = initTRPC.create({ transformer: superjson });
+`);
+    await writeFile(root, "server/root.ts", `
+import { t } from "@/server/init";
+
+export const appRouter = t.router({
+  ping: t.procedure.query(() => "pong"),
+});
+`);
+    const { tools } = await extractTrpc(root);
+    expect(tools).toHaveLength(1);
+    expect((tools[0]!.binding as TrpcBinding).transformer).toBe("superjson");
+  });
+
+  it("shadows and identifies a trailing-slash endpoint mount", async () => {
+    const root = await temporaryHost();
+    await writeFile(root, "package.json", JSON.stringify({
+      name: "trpc-trailing",
+      dependencies: { "@trpc/server": "^11.0.0" },
+    }));
+    await writeFile(root, "tsconfig.json", JSON.stringify({
+      compilerOptions: { paths: { "@/*": ["./src/*"] } },
+    }));
+    await writeFile(root, "src/app/api/trpc/[trpc]/route.ts", `
+import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+import { appRouter } from "@/server/router";
+
+const handler = (req: Request) =>
+  fetchRequestHandler({ endpoint: "/api/trpc/", req, router: appRouter, createContext: () => ({}) });
+
+export { handler as GET, handler as POST };
+`);
+    await writeFile(root, "src/server/router.ts", `
+import { initTRPC } from "@trpc/server";
+const t = initTRPC.create();
+export const appRouter = t.router({ status: t.procedure.query(() => "ok") });
+`);
+    const trpcOnly = await extractTrpc(root);
+    // Trailing slash normalized off the mount.
+    expect((trpcOnly.tools[0]!.binding as TrpcBinding).mount).toBe("/api/trpc");
+    // And the catch-all route under that mount is shadowed by runExtractors.
+    const all = await runExtractors(root);
+    expect(all.tools.some((tool) => tool.binding.kind === "route" && tool.binding.path.startsWith("/api/trpc"))).toBe(false);
+    expect(all.tools.some((tool) => tool.binding.kind === "trpc")).toBe(true);
+  });
+
   it("resolves routers imported through a default export", async () => {
     const root = await temporaryHost();
     await writeFile(root, "package.json", JSON.stringify({
@@ -457,6 +518,36 @@ export default appRouter;
 `);
     const { tools } = await extractTrpc(root);
     expect(tools.map((tool) => (tool.binding as TrpcBinding).procedure)).toEqual(["health"]);
+  });
+
+  it("warns when the handler declares no router and when the router is not a parsable router", async () => {
+    const noRouter = await temporaryHost();
+    await writeFile(noRouter, "package.json", JSON.stringify({
+      name: "trpc-no-router-opt",
+      dependencies: { "@trpc/server": "^11.0.0" },
+    }));
+    await writeFile(noRouter, "pages/api/trpc/[trpc].ts", `
+import { createNextApiHandler } from "@trpc/server/adapters/next";
+export default createNextApiHandler({ createContext: () => ({}) });
+`);
+    const a = await extractTrpc(noRouter);
+    expect(a.tools).toEqual([]);
+    expect(a.warnings.some((w) => w.includes("does not reference a statically-resolvable router"))).toBe(true);
+
+    const notRouter = await temporaryHost();
+    await writeFile(notRouter, "package.json", JSON.stringify({
+      name: "trpc-not-a-router",
+      dependencies: { "@trpc/server": "^11.0.0" },
+    }));
+    await writeFile(notRouter, "pages/api/trpc/[trpc].ts", `
+import { createNextApiHandler } from "@trpc/server/adapters/next";
+import { notARouter } from "@/server/thing";
+export default createNextApiHandler({ router: notARouter });
+`);
+    await writeFile(notRouter, "server/thing.ts", `export const notARouter = { not: "a router" };`);
+    const b = await extractTrpc(notRouter);
+    expect(b.tools).toEqual([]);
+    expect(b.warnings.some((w) => w.includes("is not a statically-parsable router"))).toBe(true);
   });
 
   it("warns when the mount router identifier cannot be resolved", async () => {

--- a/packages/actions/src/sync/trpc.test.ts
+++ b/packages/actions/src/sync/trpc.test.ts
@@ -403,6 +403,37 @@ export const sub = t.router({
     expect(result.warnings.some((warning) => warning.includes("mergeRouters"))).toBe(true);
   });
 
+  it("scopes the superjson transformer to each mount's own router graph", async () => {
+    const root = await temporaryHost();
+    await writeTrpcHost(root); // superjson mount at /api/trpc
+    await writeFile(root, "src/app/api/plain/[trpc]/route.ts", `
+import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+import { plainRouter } from "@/plain/router";
+
+const handler = (req: Request) =>
+  fetchRequestHandler({ endpoint: "/api/plain", req, router: plainRouter, createContext: () => ({}) });
+
+export { handler as GET, handler as POST };
+`);
+    await writeFile(root, "src/plain/router.ts", `
+import { initTRPC } from "@trpc/server";
+
+const t = initTRPC.create();
+export const plainRouter = t.router({
+  status: t.procedure.query(() => "ok"),
+});
+`);
+    const { tools } = await extractTrpc(root);
+    const byMount = new Map<string, Set<string | undefined>>();
+    for (const tool of tools) {
+      const binding = tool.binding as TrpcBinding;
+      if (!byMount.has(binding.mount)) byMount.set(binding.mount, new Set());
+      byMount.get(binding.mount)!.add(binding.transformer);
+    }
+    expect(byMount.get("/api/trpc")).toEqual(new Set(["superjson"]));
+    expect(byMount.get("/api/plain")).toEqual(new Set([undefined]));
+  });
+
   it("resolves routers imported through a default export", async () => {
     const root = await temporaryHost();
     await writeFile(root, "package.json", JSON.stringify({

--- a/packages/actions/src/sync/trpc.test.ts
+++ b/packages/actions/src/sync/trpc.test.ts
@@ -1,0 +1,276 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { TrpcBinding } from "../formats.js";
+import { runExtractors } from "./extractors.js";
+import { detectTrpc, extractTrpc } from "./trpc.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })));
+});
+
+async function temporaryHost(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "vendo-actions-trpc-"));
+  temporaryDirectories.push(root);
+  return root;
+}
+
+async function writeFile(root: string, relative: string, source: string): Promise<void> {
+  const file = path.join(root, relative);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, source, "utf8");
+}
+
+/** A Rallly-shaped fixture: app-router mount, src/ tsconfig alias, superjson
+ * transformer, mergeRouters root, nested + imported routers, zod inputs. */
+async function writeTrpcHost(root: string): Promise<void> {
+  await writeFile(root, "package.json", JSON.stringify({
+    name: "trpc-host",
+    dependencies: { "@trpc/server": "^11.0.0", next: "16.0.0", zod: "^4.0.0" },
+  }));
+  await writeFile(root, "tsconfig.json", JSON.stringify({
+    compilerOptions: { paths: { "@/*": ["./src/*"] } },
+  }));
+  await writeFile(root, "src/app/api/trpc/[trpc]/route.ts", `
+import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+import { appRouter } from "@/trpc/routers";
+
+const handler = (req: Request) =>
+  fetchRequestHandler({
+    endpoint: "/api/trpc",
+    req,
+    router: appRouter,
+    createContext: () => ({}),
+  });
+
+export { handler as GET, handler as POST };
+`);
+  await writeFile(root, "src/trpc/init.ts", `
+import { initTRPC } from "@trpc/server";
+import superjson from "superjson";
+
+const t = initTRPC.create({ transformer: superjson });
+export const router = t.router;
+export const mergeRouters = t.mergeRouters;
+export const publicProcedure = t.procedure;
+`);
+  await writeFile(root, "src/trpc/routers/index.ts", `
+import { mergeRouters, router } from "../init";
+import { polls } from "./polls";
+import { user } from "./user";
+
+export const appRouter = mergeRouters(router({ polls, user }));
+export type AppRouter = typeof appRouter;
+`);
+  await writeFile(root, "src/trpc/routers/polls.ts", `
+import * as z from "zod";
+import { publicProcedure, router } from "../init";
+import { comments } from "./polls/comments";
+import { pollIdSchema } from "./polls/schema";
+
+export const polls = router({
+  comments,
+  list: publicProcedure
+    .input(z.object({
+      status: z.enum(["open", "closed"]).optional(),
+      search: z.string().trim().optional(),
+      cursor: z.number().optional().default(1),
+      limit: z.number().default(20),
+    }))
+    .query(() => []),
+  create: publicProcedure
+    .input(z.object({ title: z.string().min(1), options: z.array(z.string()) }))
+    .mutation(() => ({})),
+  delete: publicProcedure
+    .input(pollIdSchema)
+    .mutation(() => ({})),
+  reindex: publicProcedure.mutation(() => ({})),
+  watch: publicProcedure.subscription(() => ({})),
+});
+`);
+  await writeFile(root, "src/trpc/routers/polls/comments.ts", `
+import * as z from "zod";
+import { publicProcedure, router } from "../../init";
+
+export const comments = router({
+  add: publicProcedure
+    .input(z.object({ pollId: z.string(), text: z.string().max(280) }))
+    .mutation(() => ({})),
+});
+`);
+  await writeFile(root, "src/trpc/routers/polls/schema.ts", `
+import * as z from "zod";
+export const pollIdSchema = z.object({ pollId: z.string() });
+`);
+  await writeFile(root, "src/trpc/routers/user.ts", `
+import { customValidator } from "@some/validator-lib";
+import { publicProcedure, router } from "../init";
+
+export const user = router({
+  get: publicProcedure.query(() => ({})),
+  update: publicProcedure.input(customValidator).mutation(() => ({})),
+});
+`);
+}
+
+describe("detectTrpc", () => {
+  it("detects the @trpc/server dependency", async () => {
+    const root = await temporaryHost();
+    await writeTrpcHost(root);
+    expect(await detectTrpc(root)).toBe(true);
+  });
+
+  it("stays quiet for hosts without trpc", async () => {
+    const root = await temporaryHost();
+    await writeFile(root, "package.json", JSON.stringify({ name: "plain", dependencies: { next: "16.0.0" } }));
+    expect(await detectTrpc(root)).toBe(false);
+  });
+});
+
+describe("extractTrpc", () => {
+  it("extracts procedures across nested, merged, and imported routers", async () => {
+    const root = await temporaryHost();
+    await writeTrpcHost(root);
+    const result = await extractTrpc(root);
+    const byProcedure = new Map(result.tools.map((tool) => [(tool.binding as TrpcBinding).procedure, tool]));
+    expect([...byProcedure.keys()].sort()).toEqual([
+      "polls.comments.add",
+      "polls.create",
+      "polls.delete",
+      "polls.list",
+      "polls.reindex",
+      "polls.watch",
+      "user.get",
+      "user.update",
+    ]);
+    for (const tool of result.tools) {
+      expect(tool.binding).toMatchObject({ kind: "trpc", mount: "/api/trpc", transformer: "superjson" });
+    }
+  });
+
+  it("labels risk fail-closed: read-shaped queries read, mutations write, destructive words destructive", async () => {
+    const root = await temporaryHost();
+    await writeTrpcHost(root);
+    const { tools } = await extractTrpc(root);
+    const risk = (procedure: string) =>
+      tools.find((tool) => (tool.binding as TrpcBinding).procedure === procedure)?.risk;
+    expect(risk("polls.list")).toBe("read");
+    expect(risk("user.get")).toBe("read");
+    expect(risk("polls.create")).toBe("write");
+    expect(risk("polls.reindex")).toBe("write");
+    expect(risk("polls.delete")).toBe("destructive");
+  });
+
+  it("interprets common zod patterns statically", async () => {
+    const root = await temporaryHost();
+    await writeTrpcHost(root);
+    const { tools } = await extractTrpc(root);
+    const list = tools.find((tool) => (tool.binding as TrpcBinding).procedure === "polls.list")!;
+    expect(list.inputSchema).toMatchObject({
+      type: "object",
+      properties: {
+        status: { type: "string", enum: ["open", "closed"] },
+        search: { type: "string" },
+        cursor: { type: "number", default: 1 },
+        limit: { type: "number", default: 20 },
+      },
+    });
+    expect((list.inputSchema as { required?: string[] }).required).toBeUndefined();
+
+    const create = tools.find((tool) => (tool.binding as TrpcBinding).procedure === "polls.create")!;
+    expect(create.inputSchema).toMatchObject({
+      type: "object",
+      properties: {
+        title: { type: "string", minLength: 1 },
+        options: { type: "array", items: { type: "string" } },
+      },
+      required: ["title", "options"],
+    });
+
+    // Schema imported from another module resolves through the import.
+    const remove = tools.find((tool) => (tool.binding as TrpcBinding).procedure === "polls.delete")!;
+    expect(remove.inputSchema).toMatchObject({
+      type: "object",
+      properties: { pollId: { type: "string" } },
+      required: ["pollId"],
+    });
+  });
+
+  it("fails closed on unrecognized validators with a permissive schema and note", async () => {
+    const root = await temporaryHost();
+    await writeTrpcHost(root);
+    const { tools } = await extractTrpc(root);
+    const update = tools.find((tool) => (tool.binding as TrpcBinding).procedure === "user.update")!;
+    expect(update.inputSchema).toEqual({ type: "object", additionalProperties: true });
+    expect(update.note).toContain("not statically interpreted");
+    expect(update.disabled).toBeUndefined();
+    expect(update.risk).toBe("write");
+  });
+
+  it("emits subscriptions disabled with a note, never silently enabled", async () => {
+    const root = await temporaryHost();
+    await writeTrpcHost(root);
+    const result = await extractTrpc(root);
+    const watch = result.tools.find((tool) => (tool.binding as TrpcBinding).procedure === "polls.watch")!;
+    expect(watch.disabled).toBe(true);
+    expect(watch.risk).toBe("destructive");
+    expect(watch.note).toContain("subscriptions");
+    expect(result.warnings.some((warning) => warning.includes("polls.watch"))).toBe(true);
+  });
+
+  it("warns and extracts nothing when no adapter mount exists", async () => {
+    const root = await temporaryHost();
+    await writeFile(root, "package.json", JSON.stringify({
+      name: "trpc-no-mount",
+      dependencies: { "@trpc/server": "^11.0.0" },
+    }));
+    const result = await extractTrpc(root);
+    expect(result.tools).toEqual([]);
+    expect(result.warnings.some((warning) => warning.includes("no HTTP adapter mount"))).toBe(true);
+  });
+
+  it("derives the mount from a pages-router catch-all without an endpoint option", async () => {
+    const root = await temporaryHost();
+    await writeFile(root, "package.json", JSON.stringify({
+      name: "trpc-pages",
+      dependencies: { "@trpc/server": "^10.0.0" },
+    }));
+    await writeFile(root, "pages/api/rpc/[trpc].ts", `
+import { createNextApiHandler } from "@trpc/server/adapters/next";
+import { appRouter } from "../../../server/router";
+
+export default createNextApiHandler({ router: appRouter });
+`);
+    await writeFile(root, "server/router.ts", `
+import { initTRPC } from "@trpc/server";
+import * as z from "zod";
+
+const t = initTRPC.create();
+export const appRouter = t.router({
+  health: t.procedure.query(() => "ok"),
+  echo: t.procedure.input(z.object({ message: z.string() })).mutation(() => "ok"),
+});
+`);
+    const { tools } = await extractTrpc(root);
+    expect(tools).toHaveLength(2);
+    for (const tool of tools) {
+      const binding = tool.binding as TrpcBinding;
+      expect(binding.mount).toBe("/api/rpc");
+      expect(binding.transformer).toBeUndefined();
+    }
+  });
+});
+
+describe("trpc + route-scan interplay", () => {
+  it("shadows the catch-all mount route when trpc tools exist", async () => {
+    const root = await temporaryHost();
+    await writeTrpcHost(root);
+    const result = await runExtractors(root);
+    const routeTools = result.tools.filter((tool) => tool.binding.kind === "route");
+    expect(routeTools.map((tool) => tool.binding.kind === "route" && tool.binding.path)).not.toContain("/api/trpc/{trpc}");
+    expect(result.tools.some((tool) => tool.binding.kind === "trpc")).toBe(true);
+  });
+});

--- a/packages/actions/src/sync/trpc.ts
+++ b/packages/actions/src/sync/trpc.ts
@@ -94,7 +94,11 @@ interface Extraction {
   root: string;
   modules: Map<string, FileModule>;
   warnings: string[];
-  routerFactorySources: Set<string>; // files the router factory was imported from
+  routerFactorySources: Set<string>; // "importerFile\tspecifier" pairs the router factory was imported through
+  /** Files contributing to the CURRENT mount's router graph — superjson
+   * detection is scoped here so one mount's transformer never leaks onto
+   * another mount's tools. */
+  graphFiles: Set<string>;
 }
 
 function parseModule(extraction: Extraction, file: string, source: string): FileModule {
@@ -269,6 +273,7 @@ async function evaluateRouterExpression(
 ): Promise<RouterDef | ProcedureDef | null> {
   if (depth > MAX_RESOLVE_DEPTH) return null;
   const { ts } = extraction;
+  extraction.graphFiles.add(module.file);
 
   if (ts.isIdentifier(expr)) {
     const resolved = await resolveIdentifier(extraction, module, expr.text, depth + 1);
@@ -671,14 +676,17 @@ async function findMounts(extraction: Extraction): Promise<TrpcMount[]> {
 
 async function detectSuperjson(extraction: Extraction): Promise<boolean> {
   const transformerPattern = /transformer\s*:\s*(superjson|SuperJSON)/;
-  for (const module of extraction.modules.values()) {
-    if (transformerPattern.test(module.source)) return true;
+  // Scoped to the CURRENT mount's router graph — a plain-JSON mount must not
+  // inherit another mount's superjson transformer.
+  for (const file of extraction.graphFiles) {
+    const module = extraction.modules.get(file);
+    if (module && transformerPattern.test(module.source)) return true;
   }
   // The initTRPC module is usually NOT part of the router graph — resolve it
-  // from wherever the router factory was imported.
+  // from wherever THIS graph's files imported the router factory.
   for (const entry of extraction.routerFactorySources) {
     const [importer, specifier] = entry.split("\t");
-    if (!importer || !specifier) continue;
+    if (!importer || !specifier || !extraction.graphFiles.has(importer)) continue;
     const resolved = await resolveImportSource(importer, specifier, extraction.root);
     if (resolved && transformerPattern.test(resolved.source)) return true;
   }
@@ -706,7 +714,14 @@ export async function extractTrpc(root: string): Promise<TrpcExtractResult> {
       warnings: ["trpc extraction skipped: the TypeScript compiler could not be resolved from the host package"],
     };
   }
-  const extraction: Extraction = { ts, root, modules: new Map(), warnings, routerFactorySources: new Set() };
+  const extraction: Extraction = {
+    ts,
+    root,
+    modules: new Map(),
+    warnings,
+    routerFactorySources: new Set(),
+    graphFiles: new Set(),
+  };
 
   const mounts = await findMounts(extraction);
   if (mounts.length === 0) {
@@ -722,6 +737,7 @@ export async function extractTrpc(root: string): Promise<TrpcExtractResult> {
       warnings.push(`trpc mount ${mount.mount} does not reference a statically-resolvable router`);
       continue;
     }
+    extraction.graphFiles = new Set([mount.file]);
     const resolved = await resolveIdentifier(extraction, mount.module, mount.routerName, 0);
     if (!resolved) {
       warnings.push(`trpc router "${mount.routerName}" for mount ${mount.mount} could not be statically resolved`);

--- a/packages/actions/src/sync/trpc.ts
+++ b/packages/actions/src/sync/trpc.ts
@@ -1,0 +1,809 @@
+import { promises as fs } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import type TS from "typescript";
+import type { ExtractedTool, TrpcBinding } from "../formats.js";
+import {
+  allocateToolName,
+  resolveImportSource,
+  trpcRisk,
+  trpcToolFullName,
+  walk,
+} from "./common.js";
+
+/**
+ * Static tRPC extraction (04 §1, additive within vendo/tools@1).
+ *
+ * Routers are parsed with the TypeScript compiler API — no code from the host
+ * is executed. The compiler itself is resolved from the HOST's node_modules
+ * (every tRPC app is a TypeScript app); when it cannot be resolved the
+ * extractor fails closed to zero tools with a warning.
+ *
+ * Zod input schemas are statically interpreted into JSON Schema for common
+ * patterns; unrecognized validators fail closed to a permissive schema with a
+ * note on the tool.
+ */
+
+type Ts = typeof TS;
+
+export interface TrpcExtractResult {
+  tools: ExtractedTool[];
+  warnings: string[];
+}
+
+const SOURCE_FILE_PATTERN = /\.(?:tsx?|jsx?)$/;
+const ROUTER_FACTORY_NAMES = new Set(["router", "createTRPCRouter", "createRouter"]);
+const MERGE_ROUTERS_NAMES = new Set(["mergeRouters"]);
+const PROCEDURE_KINDS = new Set(["query", "mutation", "subscription"]);
+const MAX_RESOLVE_DEPTH = 16;
+const DEFAULT_MOUNT = "/api/trpc";
+
+/** Resolve the TypeScript compiler from the host package (fail-closed). The
+ * fallback require targets our own devDependency so tests and monorepo dev
+ * work without a host install. */
+export function loadTypescript(root: string): Ts | null {
+  const requireFrom = [path.join(root, "package.json"), import.meta.url];
+  for (const base of requireFrom) {
+    try {
+      return createRequire(base)("typescript") as Ts;
+    } catch {
+      // Try the next resolution base.
+    }
+  }
+  return null;
+}
+
+async function readPackageJson(root: string): Promise<Record<string, unknown> | null> {
+  try {
+    return JSON.parse(await fs.readFile(path.join(root, "package.json"), "utf8")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export async function detectTrpc(root: string): Promise<boolean> {
+  const pkg = await readPackageJson(root);
+  if (!pkg) return false;
+  for (const field of ["dependencies", "devDependencies", "peerDependencies"] as const) {
+    const deps = pkg[field];
+    if (deps && typeof deps === "object" && "@trpc/server" in (deps as Record<string, unknown>)) return true;
+  }
+  return false;
+}
+
+interface FileModule {
+  file: string;
+  source: string;
+  sf: TS.SourceFile;
+}
+
+interface ProcedureDef {
+  kind: "procedure";
+  type: "query" | "mutation" | "subscription" | "unknown";
+  inputExpr?: TS.Expression;
+  module: FileModule;
+}
+
+interface RouterDef {
+  kind: "router";
+  entries: Map<string, RouterDef | ProcedureDef>;
+}
+
+interface Extraction {
+  ts: Ts;
+  root: string;
+  modules: Map<string, FileModule>;
+  warnings: string[];
+  routerFactorySources: Set<string>; // files the router factory was imported from
+}
+
+function parseModule(extraction: Extraction, file: string, source: string): FileModule {
+  const cached = extraction.modules.get(file);
+  if (cached) return cached;
+  const { ts } = extraction;
+  const scriptKind = file.endsWith(".tsx") || file.endsWith(".jsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+  const sf = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, scriptKind);
+  const module = { file, source, sf };
+  extraction.modules.set(file, module);
+  return module;
+}
+
+async function loadModule(extraction: Extraction, file: string): Promise<FileModule | null> {
+  const cached = extraction.modules.get(file);
+  if (cached) return cached;
+  try {
+    return parseModule(extraction, file, await fs.readFile(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/** import local name → specifier, for one module. */
+function importMap(extraction: Extraction, module: FileModule): Map<string, { specifier: string; imported: string }> {
+  const { ts } = extraction;
+  const imports = new Map<string, { specifier: string; imported: string }>();
+  for (const statement of module.sf.statements) {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    const specifier = statement.moduleSpecifier.text;
+    const clause = statement.importClause;
+    if (!clause) continue;
+    if (clause.name) imports.set(clause.name.text, { specifier, imported: "default" });
+    const bindings = clause.namedBindings;
+    if (bindings && ts.isNamedImports(bindings)) {
+      for (const element of bindings.elements) {
+        imports.set(element.name.text, {
+          specifier,
+          imported: (element.propertyName ?? element.name).text,
+        });
+      }
+    }
+    if (bindings && ts.isNamespaceImport(bindings)) {
+      imports.set(bindings.name.text, { specifier, imported: "*" });
+    }
+  }
+  return imports;
+}
+
+/** Find a top-level declaration's initializer by name within a module. */
+function localInitializer(extraction: Extraction, module: FileModule, name: string): TS.Expression | null {
+  const { ts } = extraction;
+  for (const statement of module.sf.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (ts.isIdentifier(declaration.name) && declaration.name.text === name && declaration.initializer) {
+        return declaration.initializer;
+      }
+    }
+  }
+  return null;
+}
+
+/** Follow `export { x } from "./y"` and `export * from "./y"` chains. */
+async function resolveExport(
+  extraction: Extraction,
+  module: FileModule,
+  name: string,
+  depth: number,
+): Promise<{ module: FileModule; expr: TS.Expression } | null> {
+  if (depth > MAX_RESOLVE_DEPTH) return null;
+  const { ts } = extraction;
+  const local = localInitializer(extraction, module, name);
+  if (local) return { module, expr: local };
+
+  for (const statement of module.sf.statements) {
+    if (!ts.isExportDeclaration(statement) || !statement.moduleSpecifier || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    const clause = statement.exportClause;
+    let exportedAs: string | null = null;
+    if (clause && ts.isNamedExports(clause)) {
+      for (const element of clause.elements) {
+        if (element.name.text === name) exportedAs = (element.propertyName ?? element.name).text;
+      }
+      if (exportedAs === null) continue;
+    } else if (clause) {
+      continue; // namespace re-export
+    } else {
+      exportedAs = name; // export * — try the same name
+    }
+    const resolved = await resolveImportSource(module.file, statement.moduleSpecifier.text, extraction.root);
+    if (!resolved) continue;
+    const target = parseModule(extraction, resolved.file, resolved.source);
+    const found = await resolveExport(extraction, target, exportedAs, depth + 1);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Resolve an identifier to its defining expression, following local
+ * declarations and one-hop-per-level imports. */
+async function resolveIdentifier(
+  extraction: Extraction,
+  module: FileModule,
+  name: string,
+  depth: number,
+): Promise<{ module: FileModule; expr: TS.Expression } | null> {
+  if (depth > MAX_RESOLVE_DEPTH) return null;
+  const local = localInitializer(extraction, module, name);
+  if (local) return { module, expr: local };
+  const imported = importMap(extraction, module).get(name);
+  if (!imported || imported.imported === "*" || imported.imported === "default") return null;
+  const resolved = await resolveImportSource(module.file, imported.specifier, extraction.root);
+  if (!resolved) return null;
+  const target = parseModule(extraction, resolved.file, resolved.source);
+  return resolveExport(extraction, target, imported.imported, depth + 1);
+}
+
+function calleeName(extraction: Extraction, expr: TS.CallExpression): string | null {
+  const { ts } = extraction;
+  const callee = expr.expression;
+  if (ts.isIdentifier(callee)) return callee.text;
+  if (ts.isPropertyAccessExpression(callee)) return callee.name.text;
+  return null;
+}
+
+function propertyKeyName(extraction: Extraction, name: TS.PropertyName): string | null {
+  const { ts } = extraction;
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name)) return name.text;
+  return null;
+}
+
+/** Record where the router factory identifier was imported from, so the
+ * superjson transformer can be detected in the initTRPC module. */
+function recordRouterFactorySource(extraction: Extraction, module: FileModule, factoryName: string): void {
+  const imported = importMap(extraction, module).get(factoryName);
+  if (imported) extraction.routerFactorySources.add(`${module.file}\t${imported.specifier}`);
+}
+
+/** Is this call expression a procedure chain ending in .query/.mutation/.subscription? */
+function procedureFromChain(extraction: Extraction, expr: TS.CallExpression, module: FileModule): ProcedureDef | null {
+  const { ts } = extraction;
+  const callee = expr.expression;
+  if (!ts.isPropertyAccessExpression(callee) || !PROCEDURE_KINDS.has(callee.name.text)) return null;
+  const type = callee.name.text as "query" | "mutation" | "subscription";
+  let inputExpr: TS.Expression | undefined;
+  // Walk down the chain collecting .input(...)
+  let current: TS.Expression = callee.expression;
+  while (ts.isCallExpression(current)) {
+    const inner = current.expression;
+    if (ts.isPropertyAccessExpression(inner)) {
+      if (inner.name.text === "input" && current.arguments.length > 0 && inputExpr === undefined) {
+        inputExpr = current.arguments[0]!;
+      }
+      current = inner.expression;
+    } else {
+      break;
+    }
+  }
+  return { kind: "procedure", type, inputExpr, module };
+}
+
+async function evaluateRouterExpression(
+  extraction: Extraction,
+  module: FileModule,
+  expr: TS.Expression,
+  depth: number,
+  contextPath: string,
+): Promise<RouterDef | ProcedureDef | null> {
+  if (depth > MAX_RESOLVE_DEPTH) return null;
+  const { ts } = extraction;
+
+  if (ts.isIdentifier(expr)) {
+    const resolved = await resolveIdentifier(extraction, module, expr.text, depth + 1);
+    if (!resolved) return null;
+    return evaluateRouterExpression(extraction, resolved.module, resolved.expr, depth + 1, contextPath);
+  }
+  if (ts.isParenthesizedExpression(expr) || ts.isAsExpression(expr) || ts.isSatisfiesExpression(expr)) {
+    return evaluateRouterExpression(extraction, module, expr.expression, depth + 1, contextPath);
+  }
+  if (!ts.isCallExpression(expr)) return null;
+
+  const name = calleeName(extraction, expr);
+  if (name && MERGE_ROUTERS_NAMES.has(name)) {
+    const entries = new Map<string, RouterDef | ProcedureDef>();
+    for (const argument of expr.arguments) {
+      const merged = await evaluateRouterExpression(extraction, module, argument, depth + 1, contextPath);
+      if (merged?.kind === "router") {
+        for (const [key, value] of merged.entries) entries.set(key, value);
+      } else {
+        extraction.warnings.push(`trpc: could not statically resolve a mergeRouters argument at ${contextPath || "<root>"}`);
+      }
+    }
+    return { kind: "router", entries };
+  }
+
+  if (name && ROUTER_FACTORY_NAMES.has(name) && expr.arguments.length === 1) {
+    const argument = expr.arguments[0]!;
+    if (ts.isObjectLiteralExpression(argument)) {
+      recordRouterFactorySource(extraction, module, ts.isIdentifier(expr.expression) ? expr.expression.text : name);
+      const entries = new Map<string, RouterDef | ProcedureDef>();
+      for (const property of argument.properties) {
+        if (ts.isPropertyAssignment(property)) {
+          const key = propertyKeyName(extraction, property.name);
+          if (!key) continue;
+          const child = await evaluateRouterEntry(extraction, module, property.initializer, depth + 1, `${contextPath}${contextPath ? "." : ""}${key}`);
+          if (child) entries.set(key, child);
+        } else if (ts.isShorthandPropertyAssignment(property)) {
+          const key = property.name.text;
+          const resolved = await resolveIdentifier(extraction, module, key, depth + 1);
+          const child = resolved
+            ? await evaluateRouterEntry(extraction, resolved.module, resolved.expr, depth + 1, `${contextPath}${contextPath ? "." : ""}${key}`)
+            : null;
+          if (child) entries.set(key, child);
+          else extraction.warnings.push(`trpc: could not statically resolve router entry "${key}"`);
+        } else if (ts.isSpreadAssignment(property)) {
+          const spread = await evaluateRouterExpression(extraction, module, property.expression, depth + 1, contextPath);
+          if (spread?.kind === "router") {
+            for (const [key, value] of spread.entries) entries.set(key, value);
+          } else {
+            extraction.warnings.push(`trpc: could not statically resolve a spread router entry at ${contextPath || "<root>"}`);
+          }
+        }
+      }
+      return { kind: "router", entries };
+    }
+  }
+
+  return procedureFromChain(extraction, expr, module);
+}
+
+async function evaluateRouterEntry(
+  extraction: Extraction,
+  module: FileModule,
+  expr: TS.Expression,
+  depth: number,
+  contextPath: string,
+): Promise<RouterDef | ProcedureDef | null> {
+  const result = await evaluateRouterExpression(extraction, module, expr, depth, contextPath);
+  if (result) return result;
+  extraction.warnings.push(`trpc: could not statically classify router entry "${contextPath}"; it was skipped`);
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Zod → JSON Schema (static, fail-closed)
+// ---------------------------------------------------------------------------
+
+interface ZodSchemaResult {
+  schema: Record<string, unknown>;
+  optional: boolean;
+  recognized: boolean;
+  reason?: string;
+}
+
+const PERMISSIVE_INPUT: Record<string, unknown> = { type: "object", additionalProperties: true };
+
+function unrecognized(reason: string): ZodSchemaResult {
+  return { schema: {}, optional: false, recognized: false, reason };
+}
+
+function literalValue(extraction: Extraction, expr: TS.Expression): string | number | boolean | null | undefined {
+  const { ts } = extraction;
+  if (ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr)) return expr.text;
+  if (ts.isNumericLiteral(expr)) return Number(expr.text);
+  if (expr.kind === ts.SyntaxKind.TrueKeyword) return true;
+  if (expr.kind === ts.SyntaxKind.FalseKeyword) return false;
+  if (expr.kind === ts.SyntaxKind.NullKeyword) return null;
+  if (ts.isPrefixUnaryExpression(expr) && expr.operator === ts.SyntaxKind.MinusToken && ts.isNumericLiteral(expr.operand)) {
+    return -Number(expr.operand.text);
+  }
+  return undefined;
+}
+
+const ZOD_PASSTHROUGH_MODIFIERS = new Set([
+  "trim", "refine", "superRefine", "transform", "describe", "brand", "readonly",
+  "regex", "startsWith", "endsWith", "includes", "toLowerCase", "toUpperCase",
+  "catch", "passthrough", "strict", "strip", "positive", "nonnegative", "negative",
+  "nonpositive", "finite", "safe", "step", "multipleOf", "length", "nonempty", "cuid", "cuid2", "ulid", "nanoid",
+]);
+
+async function zodFromExpression(
+  extraction: Extraction,
+  module: FileModule,
+  expr: TS.Expression,
+  depth: number,
+): Promise<ZodSchemaResult> {
+  if (depth > MAX_RESOLVE_DEPTH) return unrecognized("zod schema nesting exceeded the static interpretation depth");
+  const { ts } = extraction;
+
+  if (ts.isIdentifier(expr)) {
+    const resolved = await resolveIdentifier(extraction, module, expr.text, depth + 1);
+    if (!resolved) return unrecognized(`schema reference "${expr.text}" could not be statically resolved`);
+    return zodFromExpression(extraction, resolved.module, resolved.expr, depth + 1);
+  }
+  if (ts.isParenthesizedExpression(expr) || ts.isAsExpression(expr) || ts.isSatisfiesExpression(expr)) {
+    return zodFromExpression(extraction, module, expr.expression, depth + 1);
+  }
+  if (!ts.isCallExpression(expr)) return unrecognized("schema expression is not a zod call");
+
+  const callee = expr.expression;
+  if (!ts.isPropertyAccessExpression(callee)) return unrecognized("schema call has no zod-shaped callee");
+  const method = callee.name.text;
+  const receiver = callee.expression;
+
+  // Chained modifier on an inner zod expression: z.string().min(1).optional()
+  if (ts.isCallExpression(receiver) || (ts.isPropertyAccessExpression(receiver) && !ts.isIdentifier(receiver.expression))) {
+    const inner = await zodFromExpression(extraction, module, receiver, depth + 1);
+    if (!inner.recognized) return inner;
+    return applyZodModifier(extraction, module, inner, method, expr, depth);
+  }
+
+  // Base constructor: z.string(), z.coerce.number(), schemaHelpers.thing()
+  if (ts.isIdentifier(receiver)) {
+    return zodBase(extraction, module, method, expr, depth);
+  }
+  if (ts.isPropertyAccessExpression(receiver) && ts.isIdentifier(receiver.expression)) {
+    // z.coerce.number() — receiver is z.coerce
+    if (receiver.name.text === "coerce") return zodBase(extraction, module, method, expr, depth);
+    return unrecognized(`zod namespace "${receiver.name.text}" is not statically interpreted`);
+  }
+  return unrecognized("schema call shape is not statically interpreted");
+}
+
+async function zodBase(
+  extraction: Extraction,
+  module: FileModule,
+  method: string,
+  call: TS.CallExpression,
+  depth: number,
+): Promise<ZodSchemaResult> {
+  const { ts } = extraction;
+  const ok = (schema: Record<string, unknown>): ZodSchemaResult => ({ schema, optional: false, recognized: true });
+  switch (method) {
+    case "object": {
+      const argument = call.arguments[0];
+      if (!argument || !ts.isObjectLiteralExpression(argument)) return unrecognized("z.object argument is not an object literal");
+      const properties: Record<string, unknown> = {};
+      const required: string[] = [];
+      const reasons: string[] = [];
+      for (const property of argument.properties) {
+        if (!ts.isPropertyAssignment(property)) continue;
+        const key = propertyKeyName(extraction, property.name);
+        if (!key) continue;
+        const value = await zodFromExpression(extraction, module, property.initializer, depth + 1);
+        properties[key] = value.recognized ? value.schema : {};
+        if (!value.recognized && value.reason) reasons.push(`${key}: ${value.reason}`);
+        if (!value.optional && value.recognized) required.push(key);
+      }
+      const schema: Record<string, unknown> = {
+        type: "object",
+        properties,
+        ...(required.length > 0 ? { required } : {}),
+        additionalProperties: false,
+      };
+      if (reasons.length > 0) {
+        // Partially recognized: emit what we know, keep unknown properties permissive.
+        return { schema, optional: false, recognized: true, reason: reasons.join("; ") };
+      }
+      return ok(schema);
+    }
+    case "string": return ok({ type: "string" });
+    case "number": return ok({ type: "number" });
+    case "bigint": return ok({ type: "integer" });
+    case "boolean": return ok({ type: "boolean" });
+    case "date": return ok({ type: "string", format: "date-time" });
+    case "null": return ok({ type: "null" });
+    case "any":
+    case "unknown": return ok({});
+    case "void":
+    case "undefined": return { schema: {}, optional: true, recognized: true };
+    case "literal": {
+      const value = call.arguments[0] ? literalValue(extraction, call.arguments[0]) : undefined;
+      if (value === undefined) return unrecognized("z.literal value is not a static literal");
+      return ok({ const: value });
+    }
+    case "enum": {
+      const argument = call.arguments[0];
+      if (!argument || !ts.isArrayLiteralExpression(argument)) return unrecognized("z.enum argument is not an array literal");
+      const values: string[] = [];
+      for (const element of argument.elements) {
+        const value = literalValue(extraction, element);
+        if (typeof value !== "string") return unrecognized("z.enum contains a non-literal value");
+        values.push(value);
+      }
+      return ok({ type: "string", enum: values });
+    }
+    case "array": {
+      const argument = call.arguments[0];
+      if (!argument) return ok({ type: "array" });
+      const items = await zodFromExpression(extraction, module, argument, depth + 1);
+      return items.recognized
+        ? ok({ type: "array", items: items.schema })
+        : { schema: { type: "array" }, optional: false, recognized: true, reason: items.reason };
+    }
+    case "union":
+    case "discriminatedUnion": {
+      const argument = call.arguments[method === "union" ? 0 : 1];
+      if (!argument || !ts.isArrayLiteralExpression(argument)) return unrecognized(`z.${method} options are not an array literal`);
+      const options: Record<string, unknown>[] = [];
+      for (const element of argument.elements) {
+        const option = await zodFromExpression(extraction, module, element, depth + 1);
+        if (!option.recognized) return unrecognized(option.reason ?? `z.${method} option not statically interpreted`);
+        options.push(option.schema);
+      }
+      return ok({ anyOf: options });
+    }
+    case "record": {
+      const valueArgument = call.arguments[call.arguments.length - 1];
+      if (!valueArgument) return ok({ type: "object", additionalProperties: true });
+      const value = await zodFromExpression(extraction, module, valueArgument, depth + 1);
+      return ok({ type: "object", additionalProperties: value.recognized ? value.schema : true });
+    }
+    default:
+      return unrecognized(`z.${method} is not statically interpreted`);
+  }
+}
+
+async function applyZodModifier(
+  extraction: Extraction,
+  module: FileModule,
+  inner: ZodSchemaResult,
+  method: string,
+  call: TS.CallExpression,
+  depth: number,
+): Promise<ZodSchemaResult> {
+  const { ts } = extraction;
+  void module;
+  void depth;
+  switch (method) {
+    case "optional": return { ...inner, optional: true };
+    case "nullish": return { ...inner, optional: true, schema: nullable(inner.schema) };
+    case "nullable": return { ...inner, schema: nullable(inner.schema) };
+    case "default": {
+      const value = call.arguments[0] ? literalValue(extraction, call.arguments[0]) : undefined;
+      return {
+        ...inner,
+        optional: true,
+        schema: value !== undefined ? { ...inner.schema, default: value } : inner.schema,
+      };
+    }
+    case "min": {
+      const value = call.arguments[0] && ts.isNumericLiteral(call.arguments[0]) ? Number(call.arguments[0].text) : undefined;
+      if (value === undefined) return inner;
+      if (inner.schema.type === "string") return { ...inner, schema: { ...inner.schema, minLength: value } };
+      if (inner.schema.type === "number" || inner.schema.type === "integer") return { ...inner, schema: { ...inner.schema, minimum: value } };
+      if (inner.schema.type === "array") return { ...inner, schema: { ...inner.schema, minItems: value } };
+      return inner;
+    }
+    case "max": {
+      const value = call.arguments[0] && ts.isNumericLiteral(call.arguments[0]) ? Number(call.arguments[0].text) : undefined;
+      if (value === undefined) return inner;
+      if (inner.schema.type === "string") return { ...inner, schema: { ...inner.schema, maxLength: value } };
+      if (inner.schema.type === "number" || inner.schema.type === "integer") return { ...inner, schema: { ...inner.schema, maximum: value } };
+      if (inner.schema.type === "array") return { ...inner, schema: { ...inner.schema, maxItems: value } };
+      return inner;
+    }
+    case "int": return { ...inner, schema: { ...inner.schema, type: "integer" } };
+    case "email": return { ...inner, schema: { ...inner.schema, format: "email" } };
+    case "uuid": return { ...inner, schema: { ...inner.schema, format: "uuid" } };
+    case "url": return { ...inner, schema: { ...inner.schema, format: "uri" } };
+    case "datetime": return { ...inner, schema: { ...inner.schema, format: "date-time" } };
+    default:
+      if (ZOD_PASSTHROUGH_MODIFIERS.has(method)) return inner;
+      // Fail closed on modifiers we do not understand: keep the wire type
+      // unknown rather than risk a wrong constraint.
+      return unrecognized(`zod modifier .${method}() is not statically interpreted`);
+  }
+}
+
+function nullable(schema: Record<string, unknown>): Record<string, unknown> {
+  return Object.keys(schema).length === 0 ? {} : { anyOf: [schema, { type: "null" }] };
+}
+
+// ---------------------------------------------------------------------------
+// Mount discovery
+// ---------------------------------------------------------------------------
+
+interface TrpcMount {
+  file: string;
+  mount: string;
+  routerName: string | null;
+  module: FileModule;
+}
+
+function isRouteFileCandidate(relativePath: string): boolean {
+  const normalized = relativePath.replace(/\\/g, "/");
+  const parts = normalized.split("/");
+  const file = parts.at(-1) ?? "";
+  if (/^route\.(?:tsx?|jsx?)$/.test(file) && parts.includes("app")) return true;
+  const pagesIndex = parts.findIndex((part) => part === "pages");
+  return pagesIndex !== -1 && parts[pagesIndex + 1] === "api" && SOURCE_FILE_PATTERN.test(file) && !/\.d\.ts$/.test(file);
+}
+
+function isDynamicSegment(segment: string): boolean {
+  return /^\[.*\]$/.test(segment);
+}
+
+function mountPathFromFile(relativePath: string): string | null {
+  const parts = relativePath.replace(/\\/g, "/").split("/");
+  const file = parts.at(-1) ?? "";
+  if (/^route\.(?:tsx?|jsx?)$/.test(file)) {
+    const appIndex = parts.findIndex((part) => part === "app");
+    if (appIndex === -1) return null;
+    const segments = parts.slice(appIndex + 1, -1)
+      .filter((segment) => !(segment.startsWith("(") && segment.endsWith(")")) && !segment.startsWith("@"))
+      .filter((segment) => !isDynamicSegment(segment));
+    return `/${segments.join("/")}`.replace(/\/+/g, "/");
+  }
+  const pagesIndex = parts.findIndex((part) => part === "pages");
+  if (pagesIndex === -1) return null;
+  const fileBase = file.replace(/\.(?:tsx?|jsx?)$/, "");
+  const segments = [...parts.slice(pagesIndex + 1, -1), fileBase]
+    .filter((segment) => segment !== "index" && !isDynamicSegment(segment));
+  return `/${segments.join("/")}`.replace(/\/+/g, "/");
+}
+
+function handlerOptions(extraction: Extraction, module: FileModule): { endpoint?: string; routerName: string | null } | null {
+  const { ts } = extraction;
+  let found: { endpoint?: string; routerName: string | null } | null = null;
+  const visit = (node: TS.Node): void => {
+    if (found) return;
+    if (ts.isCallExpression(node)) {
+      const name = calleeName(extraction, node);
+      if ((name === "fetchRequestHandler" || name === "createNextApiHandler") && node.arguments.length > 0) {
+        const argument = node.arguments[0]!;
+        if (ts.isObjectLiteralExpression(argument)) {
+          let endpoint: string | undefined;
+          let routerName: string | null = null;
+          for (const property of argument.properties) {
+            if (!ts.isPropertyAssignment(property)) continue;
+            const key = propertyKeyName(extraction, property.name);
+            if (key === "endpoint" && ts.isStringLiteral(property.initializer)) endpoint = property.initializer.text;
+            if (key === "router" && ts.isIdentifier(property.initializer)) routerName = property.initializer.text;
+          }
+          found = { endpoint, routerName };
+          return;
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(module.sf);
+  return found;
+}
+
+async function findMounts(extraction: Extraction): Promise<TrpcMount[]> {
+  const files = await walk(extraction.root, isRouteFileCandidate);
+  const mounts: TrpcMount[] = [];
+  for (const file of files) {
+    let source: string;
+    try {
+      source = await fs.readFile(file, "utf8");
+    } catch {
+      continue;
+    }
+    if (!source.includes("@trpc/server/adapters")) continue;
+    const module = parseModule(extraction, file, source);
+    const options = handlerOptions(extraction, module);
+    if (!options) continue;
+    const relativePath = path.relative(extraction.root, file);
+    const mount = options.endpoint ?? mountPathFromFile(relativePath) ?? DEFAULT_MOUNT;
+    mounts.push({ file, mount, routerName: options.routerName, module });
+  }
+  return mounts;
+}
+
+// ---------------------------------------------------------------------------
+// Superjson detection
+// ---------------------------------------------------------------------------
+
+async function detectSuperjson(extraction: Extraction): Promise<boolean> {
+  const transformerPattern = /transformer\s*:\s*(superjson|SuperJSON)/;
+  for (const module of extraction.modules.values()) {
+    if (transformerPattern.test(module.source)) return true;
+  }
+  // The initTRPC module is usually NOT part of the router graph — resolve it
+  // from wherever the router factory was imported.
+  for (const entry of extraction.routerFactorySources) {
+    const [importer, specifier] = entry.split("\t");
+    if (!importer || !specifier) continue;
+    const resolved = await resolveImportSource(importer, specifier, extraction.root);
+    if (resolved && transformerPattern.test(resolved.source)) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Extraction entry point
+// ---------------------------------------------------------------------------
+
+function flattenProcedures(router: RouterDef, prefix: string, out: Array<{ procedure: string; def: ProcedureDef }>): void {
+  for (const [key, value] of router.entries) {
+    const procedurePath = prefix ? `${prefix}.${key}` : key;
+    if (value.kind === "router") flattenProcedures(value, procedurePath, out);
+    else out.push({ procedure: procedurePath, def: value });
+  }
+}
+
+export async function extractTrpc(root: string): Promise<TrpcExtractResult> {
+  const warnings: string[] = [];
+  const ts = loadTypescript(root);
+  if (!ts) {
+    return {
+      tools: [],
+      warnings: ["trpc extraction skipped: the TypeScript compiler could not be resolved from the host package"],
+    };
+  }
+  const extraction: Extraction = { ts, root, modules: new Map(), warnings, routerFactorySources: new Set() };
+
+  const mounts = await findMounts(extraction);
+  if (mounts.length === 0) {
+    return { tools: [], warnings: ["trpc detected (@trpc/server dependency) but no HTTP adapter mount was found; no trpc tools extracted"] };
+  }
+
+  const tools: ExtractedTool[] = [];
+  const usedNames = new Set<string>();
+  const seenProcedures = new Set<string>();
+
+  for (const mount of mounts) {
+    if (!mount.routerName) {
+      warnings.push(`trpc mount ${mount.mount} does not reference a statically-resolvable router`);
+      continue;
+    }
+    const resolved = await resolveIdentifier(extraction, mount.module, mount.routerName, 0);
+    if (!resolved) {
+      warnings.push(`trpc router "${mount.routerName}" for mount ${mount.mount} could not be statically resolved`);
+      continue;
+    }
+    const router = await evaluateRouterExpression(extraction, resolved.module, resolved.expr, 0, "");
+    if (!router || router.kind !== "router") {
+      warnings.push(`trpc router "${mount.routerName}" for mount ${mount.mount} is not a statically-parsable router`);
+      continue;
+    }
+    const transformer = (await detectSuperjson(extraction)) ? ("superjson" as const) : undefined;
+
+    const procedures: Array<{ procedure: string; def: ProcedureDef }> = [];
+    flattenProcedures(router, "", procedures);
+    for (const { procedure, def } of procedures) {
+      const dedup = `${mount.mount}\t${procedure}`;
+      if (seenProcedures.has(dedup)) continue;
+      seenProcedures.add(dedup);
+
+      if (def.type === "subscription" || def.type === "unknown") {
+        const name = allocateToolName(trpcToolFullName(procedure), "mutation", usedNames);
+        const reason = def.type === "subscription"
+          ? "tRPC subscriptions are not invokable over the HTTP envelope"
+          : "procedure type could not be statically classified";
+        tools.push({
+          name,
+          description: `tRPC procedure ${procedure} could not be classified`,
+          inputSchema: { type: "object", properties: {} },
+          risk: "destructive",
+          disabled: true,
+          note: `${reason}; enable only after review; overrides.json can flip disabled/risk`,
+          binding: bindingFor(procedure, "mutation", mount.mount, transformer),
+        });
+        warnings.push(`trpc procedure ${procedure} could not be classified: ${reason}`);
+        continue;
+      }
+
+      let inputSchema: Record<string, unknown> = { type: "object", properties: {} };
+      let note: string | undefined;
+      if (def.inputExpr) {
+        const interpreted = await zodFromExpression(extraction, def.module, def.inputExpr, 0);
+        if (interpreted.recognized) {
+          inputSchema = interpreted.schema;
+          if (interpreted.reason) note = `input schema partially interpreted; permissive where unknown (${interpreted.reason})`;
+        } else {
+          inputSchema = { ...PERMISSIVE_INPUT };
+          note = `input schema not statically interpreted (${interpreted.reason ?? "unrecognized validator"}); permissive schema emitted`;
+        }
+      }
+
+      const name = allocateToolName(trpcToolFullName(procedure), def.type, usedNames);
+      tools.push({
+        name,
+        description: `tRPC ${def.type} ${procedure}`,
+        inputSchema,
+        risk: trpcRisk(def.type, procedure),
+        ...(note ? { note } : {}),
+        binding: bindingFor(procedure, def.type, mount.mount, transformer),
+      });
+    }
+  }
+
+  return { tools, warnings };
+}
+
+function bindingFor(
+  procedure: string,
+  type: "query" | "mutation",
+  mount: string,
+  transformer: "superjson" | undefined,
+): TrpcBinding {
+  return {
+    kind: "trpc",
+    procedure,
+    type,
+    mount,
+    ...(transformer ? { transformer } : {}),
+  };
+}
+
+/** The mounts trpc tools were extracted from — route-scan tools under these
+ * paths are shadowed (the catch-all HTTP route is not a real API surface). */
+export function trpcMounts(tools: readonly ExtractedTool[]): string[] {
+  const mounts = new Set<string>();
+  for (const tool of tools) {
+    if (tool.binding.kind === "trpc") mounts.add(tool.binding.mount);
+  }
+  return [...mounts];
+}

--- a/packages/actions/src/sync/trpc.ts
+++ b/packages/actions/src/sync/trpc.ts
@@ -302,7 +302,13 @@ async function evaluateRouterExpression(
   if (name && ROUTER_FACTORY_NAMES.has(name) && expr.arguments.length === 1) {
     const argument = expr.arguments[0]!;
     if (ts.isObjectLiteralExpression(argument)) {
-      recordRouterFactorySource(extraction, module, ts.isIdentifier(expr.expression) ? expr.expression.text : name);
+      // For `t.router({...})` the factory source is the namespace base `t`
+      // (the initTRPC instance), not the "router" method name; for a bare
+      // `router({...})` it is the imported `router` identifier itself.
+      const factoryName = ts.isPropertyAccessExpression(expr.expression) && ts.isIdentifier(expr.expression.expression)
+        ? expr.expression.expression.text
+        : ts.isIdentifier(expr.expression) ? expr.expression.text : name;
+      recordRouterFactorySource(extraction, module, factoryName);
       const entries = new Map<string, RouterDef | ProcedureDef>();
       for (const property of argument.properties) {
         if (ts.isPropertyAssignment(property)) {
@@ -664,7 +670,11 @@ async function findMounts(extraction: Extraction): Promise<TrpcMount[]> {
     const options = handlerOptions(extraction, module);
     if (!options) continue;
     const relativePath = path.relative(extraction.root, file);
-    const mount = options.endpoint ?? mountPathFromFile(relativePath) ?? DEFAULT_MOUNT;
+    const rawMount = options.endpoint ?? mountPathFromFile(relativePath) ?? DEFAULT_MOUNT;
+    // Normalize a trailing slash (an `endpoint: "/api/trpc/"` literal) so the
+    // mount matches route-scan's `/api/trpc/{trpc}` shadowing and stays a
+    // single identity; the root mount "/" is preserved.
+    const mount = rawMount.length > 1 ? rawMount.replace(/\/+$/, "") : rawMount;
     mounts.push({ file, mount, routerName: options.routerName, module });
   }
   return mounts;

--- a/packages/actions/src/sync/trpc.ts
+++ b/packages/actions/src/sync/trpc.ts
@@ -160,6 +160,20 @@ async function resolveExport(
   const local = localInitializer(extraction, module, name);
   if (local) return { module, expr: local };
 
+  if (name === "default") {
+    for (const statement of module.sf.statements) {
+      if (ts.isExportAssignment(statement) && !statement.isExportEquals) {
+        const expr = statement.expression;
+        // `export default appRouter` — chase the local identifier.
+        if (ts.isIdentifier(expr)) {
+          const resolved = await resolveIdentifier(extraction, module, expr.text, depth + 1);
+          if (resolved) return resolved;
+        }
+        return { module, expr };
+      }
+    }
+  }
+
   for (const statement of module.sf.statements) {
     if (!ts.isExportDeclaration(statement) || !statement.moduleSpecifier || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
     const clause = statement.exportClause;
@@ -195,7 +209,7 @@ async function resolveIdentifier(
   const local = localInitializer(extraction, module, name);
   if (local) return { module, expr: local };
   const imported = importMap(extraction, module).get(name);
-  if (!imported || imported.imported === "*" || imported.imported === "default") return null;
+  if (!imported || imported.imported === "*") return null;
   const resolved = await resolveImportSource(module.file, imported.specifier, extraction.root);
   if (!resolved) return null;
   const target = parseModule(extraction, resolved.file, resolved.source);

--- a/packages/actions/src/sync/trpc.ts
+++ b/packages/actions/src/sync/trpc.ts
@@ -108,16 +108,6 @@ function parseModule(extraction: Extraction, file: string, source: string): File
   return module;
 }
 
-async function loadModule(extraction: Extraction, file: string): Promise<FileModule | null> {
-  const cached = extraction.modules.get(file);
-  if (cached) return cached;
-  try {
-    return parseModule(extraction, file, await fs.readFile(file, "utf8"));
-  } catch {
-    return null;
-  }
-}
-
 /** import local name → specifier, for one module. */
 function importMap(extraction: Extraction, module: FileModule): Map<string, { specifier: string; imported: string }> {
   const { ts } = extraction;

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -47,7 +47,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@vendoai/core": "workspace:*",
     "jose": "^6.2.3",
-    "zod": "^3.24.0"
+    "zod": "^3.25.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -850,7 +850,7 @@ importers:
         specifier: ^6.2.3
         version: 6.2.3
       zod:
-        specifier: ^3.24.0
+        specifier: ^3.25.0
         version: 3.25.76
     devDependencies:
       '@types/node':


### PR DESCRIPTION
Implements ENG-246 (M1 of the extraction project, spec: docs/superpowers/specs/2026-07-14-extraction-survives-real-apps-design.md §1/§6/§7).

## What

- **Extractor seam**: `vendoSync` extraction now runs a registration list of `{ detect, extract }` extractors (`packages/actions/src/sync/extractors.ts`); OpenAPI and route-scan are the first two registrations. No behavior change for existing corpus repos.
- **tRPC extractor** (`packages/actions/src/sync/trpc.ts`): static router parse via the TypeScript compiler API (resolved from the *host's* node_modules, fail-closed to zero tools + warning when absent — no 40MB dep shipped). Handles `router({...})`/`createTRPCRouter`/`mergeRouters`, nested + cross-file routers, app-router and pages-router mounts (endpoint literal or path-derived), superjson transformer detection. Zod input schemas statically interpreted to JSON Schema for common patterns; unrecognized validators fail closed to a permissive schema + note. Subscriptions/unclassifiable procedures emit `disabled: true` with a note.
- **Additive `trpc` binding kind** in the `ToolBinding` union (`formats.ts`): `{ procedure, type, mount, transformer? }`. `executeHost` speaks the tRPC HTTP envelope: queries `GET {mount}/{procedure}?input=`, mutations `POST` with JSON body, superjson `{json}` wrap/unwrap, `result.data` unwrapped; auth paths (present-forward/away/mcp) unchanged and shared with route bindings.
- **Risk rules**: queries get `read` only with a read-shaped name; mutations default `write`; destructive word list unchanged; unclassifiable → disabled.
- **Mount shadowing**: route-scan's opaque `/api/trpc/{trpc}` catch-all tools are dropped when trpc tools exist for that mount.
- **Binding-kind-aware corpus expectation keys** (shared with M2/M3): tRPC expectations key on procedure dot-path, HTTP-shaped on method+path; write-safety treats mutations as POST-shaped. (`corpus/harness/src/expectations.ts`, `layers/scored.ts`, `layers/structural.ts`)
- **Rallly onboarded** (`corpus/manifest.json` + `corpus/expectations/rallly/`): Next 16 app router + tRPC 11 (superjson) + Prisma, pnpm monorepo, broad tier, pinned at `317ceaac`.
- Two host-integration fixes surfaced by the Rallly leg:
  - corpus inject: omit `--config.dangerouslyAllowAllBuilds` when the host workspace curates `onlyBuiltDependencies`/`neverBuiltDependencies` (pnpm ≥10 errors on the conflict).
  - `@vendoai/mcp`: zod floor `^3.25.0` — `@modelcontextprotocol/sdk` imports `zod/v3`, a subpath zod only ships from 3.25; a host lockfile pinning 3.24.0 broke the post-init build.
- Enabling fix in `resolveImportSource`: `@/` specifiers now also consult tsconfig path aliases (src/-layout apps map `@/*` to `./src/*`).

## Contract freeze

`docs/contracts/` untouched here. The additive `vendo/tools@1` amendment (trpc binding kind + keying note) is a separate DRAFT PR gated on Yousef's sign-off.

## Evidence

- Rallly Layer 1: all 7 structural checks pass (init exit/files/schema/typecheck/build/idempotent/fail-closed; 84 tools).
- Rallly Layer 2: pass — tools precision 1.000 / recall 1.000 (84/84), 14/14 safety annotations, write-safety hard check pass; theme 3/7 → score 0.600 recorded as baseline. The 64 extracted tRPC procedures were hand-audited against `apps/web/src/trpc/routers` (count, query/mutation kind, and risk label all match source).
- Full 14-repo Layer 1–2 regression sweep running; result posted below before merge.
- `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green at root.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a pluggable extractor seam and a static tRPC extractor with a new `trpc` binding and runtime execution, validated on the Rallly corpus. Delivers ENG‑246 M1 with binding‑kind‑aware tool identity and tRPC write‑safety; adds namespace‑factory superjson detection and trailing‑slash mount normalization with no behavior change for existing repos.

- **New Features**
  - Extractor seam: `vendoSync` runs extractors in order — `openapi` → `trpc` → `route-scan`.
  - tRPC extractor: static TS parse (compiler from host); resolves default‑export routers; supports nested/merged routers, app/pages mounts; per‑mount superjson detection; Zod inputs mapped to JSON Schema with fail‑closed notes; subscriptions emitted disabled.
  - `trpc` binding: `{ procedure, type, mount, transformer? }`; runtime speaks the tRPC HTTP envelope (queries GET ?input=, mutations POST; superjson wrap/unwrap).
  - Safety: queries read only with read‑shaped names; mutations default write; mutations treated as POST‑shaped for write‑safety; route‑scan catch‑alls under a `trpc` mount are shadowed.
  - Corpus/expectations: onboarded Rallly (Next 16 + tRPC 11). Tools keyed by procedure for tRPC; Layer 1–2 pass; 84 tools total (64 tRPC); tRPC precision/recall 1.0; baseline score 0.600 recorded.

- **Bug Fixes**
  - Superjson detection now resolves the namespace base (e.g., `t.router(...)`), so transformers on imported `initTRPC` instances are correctly detected; scoped per mount’s router graph.
  - Mount handling: normalize trailing‑slash mounts at extraction and in identity to keep dedup/shadowing stable.
  - Tool identity: tRPC keys include `mount + procedure` with trailing‑slash normalization to prevent cross‑mount collisions.
  - `pnpm`: omit `--config.dangerouslyAllowAllBuilds` when the workspace sets `onlyBuiltDependencies`/`neverBuiltDependencies` (pnpm ≥10 conflict).
  - `@vendoai/mcp`: bump `zod` to `^3.25.0` to satisfy `@modelcontextprotocol/sdk`’s `zod/v3` import.
  - Import resolution: `@/` specifiers honor tsconfig path aliases (e.g., `@/*` → `./src/*`).
  - Binding plumbing: `trpc` joins `PrimitiveToolBinding`; unique‑name fallback and dedup narrow on primitive bindings.

<sup>Written for commit 44ed3679feac41b361d27898bedac8556254d754. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

