### PR TITLE
docs(contracts): additive trpc binding kind in vendo/tools@1 (ENG-246 amendment — Yousef sign-off gate)

### DIFF
--- a/docs/contracts/00-overview.md
+++ b/docs/contracts/00-overview.md
@@ -119,3 +119,9 @@ Approved with the contracts (Yousef, 2026-07-11): the blocks are built as if fro
 - **Changed:** Removed the door from the entirely-deferred list.
 - **Why:** MCP was built and contracted in wave 6 of v0. `02-store.md` was updated at the time, but this overview and `01-core.md` / `03-agent.md` were not.
 - **Approved by:** Yousef, 2026-07-14.
+
+### 2026-07-15 — tRPC binding kind added to vendo/tools@1
+
+- **Changed:** `04-actions.md` §1/§2/§4 — additive `trpc` binding kind (`procedure`/`type`/`mount`/`transformer?`), the extractor seam registration list (OpenAPI → tRPC → route-scan, with mount shadowing), tRPC static-extraction and fail-closed risk rules, the tRPC HTTP envelope execution semantics, and the binding-kind-aware tool-identity note (method+path for HTTP bindings, mount+procedure for tRPC).
+- **Why:** ENG-246 (extraction-survives-real-apps M1) ships the tRPC extractor; the binding kind is additive within `vendo/tools@1` per the discriminated-union evolution rule — existing consumers ignore unknown kinds.
+- **Approved by:** awaiting Yousef's personal sign-off (PR stays draft until then).

--- a/docs/contracts/04-actions.md
+++ b/docs/contracts/04-actions.md
@@ -29,7 +29,11 @@ export interface BreakingChange {
 // Blast radius ("which saved apps reference this tool") is a runtime query over vendo_apps, not a build-step concern.
 ```
 
-Launch extraction tier: **OpenAPI + route-scan** (corpus-proven). tRPC/GraphQL/server actions next — new extractors change no format below. Extraction is fail-closed: a route the scanner can't classify is emitted `disabled: true` with a note, never silently auto-allowed.
+Extraction tier: **OpenAPI + route-scan + tRPC** (corpus-proven; tRPC added additively within `vendo/tools@1`, 2026-07-15). GraphQL/server actions next — new extractors change no format below. Extractors sit behind one seam: a registration list of `{ detect, extract }` pairs inside `vendoSync`, run in order (OpenAPI, tRPC, route-scan); route tools under a tRPC mount are shadowed by the extracted procedures (the catch-all HTTP route is not a real API surface). Extraction is fail-closed: a route the scanner can't classify is emitted `disabled: true` with a note, never silently auto-allowed.
+
+tRPC extraction is static — routers are parsed with the TypeScript compiler API, no host code runs. Zod input schemas are statically interpreted into JSON Schema for common patterns; unrecognized validators fail closed to a permissive schema plus a `note`. Risk labeling extends the fail-closed rules: a query earns `read` only with a read-shaped name, mutations default to `write`, the destructive word list applies unchanged, and unclassifiable procedures (subscriptions, dynamic composition) are emitted `disabled: true` with a note.
+
+Tool identity is binding-kind-aware: HTTP-shaped bindings (route, openapi) are identified by method + path; tRPC bindings by their procedure dot-path. `SyncReport` breaking-change detection and corpus expectations key on this identity, never on the renamed tool slug (01-core §15).
 
 ### `.vendo/tools.json` (generated, host-committed)
 
@@ -46,6 +50,7 @@ Launch extraction tier: **OpenAPI + route-scan** (corpus-proven). tRPC/GraphQL/s
       // plus the execution binding:
       "binding": { "kind": "route", "method": "GET", "path": "/api/invoices", "argsIn": "query" }
       // | { "kind": "openapi", "operationId": "listInvoices", "baseUrl": "..." }
+      // | { "kind": "trpc", "procedure": "polls.list", "type": "query", "mount": "/api/trpc", "transformer": "superjson"? }
     }
   ]
 }
@@ -162,7 +167,7 @@ import type { ToolRegistry, ToolCall, ToolDescriptor, RunContext, ActAs, ToolOut
 
 export function createActions(config: {
   dir?: string;                          // read .vendo/{tools,overrides,capabilities}.json; or:
-  tools?: ExtractedTool[];               // inject directly (tests, non-file hosts); ExtractedTool = ToolDescriptor & { binding: RouteBinding | OpenApiBinding }
+  tools?: ExtractedTool[];               // inject directly (tests, non-file hosts); ExtractedTool = ToolDescriptor & { binding: RouteBinding | OpenApiBinding | TrpcBinding }
   capabilities?: CapabilitiesFile;       // inject directly (tests, non-file hosts)
   connectors?: Connector[];
   actAs?: ActAs;                         // host seam; absent → away execution cleanly unavailable
@@ -193,6 +198,7 @@ Normalization rules: connector tool names are underscore-prefixed inside the pro
 ## 4. Execution semantics (normative)
 
 - **Present** (`presence: "present"`): the call rides the user's real session. Server-side route execution forwards the inbound request's auth material (`ctx.requestHeaders` — cookies/authorization captured by the umbrella handler) on a same-origin fetch to `binding.path`. Zero config.
+- **tRPC bindings** execute over the tRPC HTTP envelope against the host mount: queries `GET {mount}/{procedure}?input=<json>`, mutations `POST {mount}/{procedure}` with the input as the JSON body; `{ result: { data } }` is unwrapped on success. When `transformer: "superjson"` is present the input/output ride superjson's `{ json: ... }` wrapping. Auth semantics (present-forward, away/actAs, venue=mcp) are identical to route bindings.
 - **Away** (`presence: "away"`): requires a captured grant (the only authority) and the host's `actAs(principal, grant)` → `AuthMaterial` attached to the request. `actAs` not implemented → `ToolOutcome{status:"error", code:"not-implemented"}` with agent-readable messaging ("away execution isn't set up for this product") — features degrade cleanly, no stack detection, no adapter framework.
 - Connector calls use the connector's own auth (Composio entity, MCP session) but identical guard treatment.
 - actions itself never checks policy: it executes what a guard binding lets through (05 §2). It stamps nothing on the audit trail directly; the binding does.

--- a/docs/contracts/04-actions.md
+++ b/docs/contracts/04-actions.md
@@ -33,7 +33,7 @@ Extraction tier: **OpenAPI + route-scan + tRPC** (corpus-proven; tRPC added addi
 
 tRPC extraction is static — routers are parsed with the TypeScript compiler API, no host code runs. Zod input schemas are statically interpreted into JSON Schema for common patterns; unrecognized validators fail closed to a permissive schema plus a `note`. Risk labeling extends the fail-closed rules: a query earns `read` only with a read-shaped name, mutations default to `write`, the destructive word list applies unchanged, and unclassifiable procedures (subscriptions, dynamic composition) are emitted `disabled: true` with a note.
 
-Tool identity is binding-kind-aware: HTTP-shaped bindings (route, openapi) are identified by method + path; tRPC bindings by their procedure dot-path. `SyncReport` breaking-change detection and corpus expectations key on this identity, never on the renamed tool slug (01-core §15).
+Tool identity is binding-kind-aware: HTTP-shaped bindings (route, openapi) are identified by method + path; tRPC bindings by mount + procedure dot-path (the same procedure name under two mounts is two tools). `SyncReport` breaking-change detection and corpus expectations key on this identity, never on the renamed tool slug (01-core §15).
 
 ### `.vendo/tools.json` (generated, host-committed)
 

--- a/docs/contracts/04-actions.md
+++ b/docs/contracts/04-actions.md
@@ -33,7 +33,7 @@ Extraction tier: **OpenAPI + route-scan + tRPC** (corpus-proven; tRPC added addi
 
 tRPC extraction is static — routers are parsed with the TypeScript compiler API, no host code runs. Zod input schemas are statically interpreted into JSON Schema for common patterns; unrecognized validators fail closed to a permissive schema plus a `note`. Risk labeling extends the fail-closed rules: a query earns `read` only with a read-shaped name, mutations default to `write`, the destructive word list applies unchanged, and unclassifiable procedures (subscriptions, dynamic composition) are emitted `disabled: true` with a note.
 
-Tool identity is binding-kind-aware: HTTP-shaped bindings (route, openapi) are identified by method + path; tRPC bindings by mount + procedure dot-path (the same procedure name under two mounts is two tools). `SyncReport` breaking-change detection and corpus expectations key on this identity, never on the renamed tool slug (01-core §15).
+Tool identity is binding-kind-aware: HTTP-shaped bindings (route, openapi) are identified by method + path; tRPC bindings by mount + procedure dot-path (the same procedure name under two mounts is two tools). `SyncReport` breaking-change detection and corpus expectations key on this identity, never on the renamed tool slug (01-core §4).
 
 ### `.vendo/tools.json` (generated, host-committed)
 
@@ -198,7 +198,7 @@ Normalization rules: connector tool names are underscore-prefixed inside the pro
 ## 4. Execution semantics (normative)
 
 - **Present** (`presence: "present"`): the call rides the user's real session. Server-side route execution forwards the inbound request's auth material (`ctx.requestHeaders` — cookies/authorization captured by the umbrella handler) on a same-origin fetch to `binding.path`. Zero config.
-- **tRPC bindings** execute over the tRPC HTTP envelope against the host mount: queries `GET {mount}/{procedure}?input=<json>`, mutations `POST {mount}/{procedure}` with the input as the JSON body; `{ result: { data } }` is unwrapped on success. When `transformer: "superjson"` is present the input/output ride superjson's `{ json: ... }` wrapping. Auth semantics (present-forward, away/actAs, venue=mcp) are identical to route bindings.
+- **tRPC bindings** execute over the tRPC HTTP envelope against the host mount: queries `GET {mount}/{procedure}?input=<json>`, mutations `POST {mount}/{procedure}` with the input as the JSON body; `{ result: { data } }` is unwrapped on success. Calls are always single-procedure — HTTP batching (`/p1,p2?batch=1`) is a client optimization the runtime never uses. When `transformer: "superjson"` is present (detected per mount) the input/output ride superjson's `{ json: ... }` wrapping. Auth semantics (present-forward, away/actAs, venue=mcp) are identical to route bindings.
 - **Away** (`presence: "away"`): requires a captured grant (the only authority) and the host's `actAs(principal, grant)` → `AuthMaterial` attached to the request. `actAs` not implemented → `ToolOutcome{status:"error", code:"not-implemented"}` with agent-readable messaging ("away execution isn't set up for this product") — features degrade cleanly, no stack detection, no adapter framework.
 - Connector calls use the connector's own auth (Composio entity, MCP session) but identical guard treatment.
 - actions itself never checks policy: it executes what a guard binding lets through (05 §2). It stamps nothing on the audit trail directly; the binding does.


### PR DESCRIPTION
DRAFT — DO NOT MERGE. Awaits Yousef's PERSONAL sign-off (docs/contracts is frozen; precedent PR #201). A relayed approval was countermanded 2026-07-15; this PR stays parked until Yousef himself acts.

Status: CI green, reviewer-triaged (no findings), branch kept current. The implementation (PR #229) landed without touching docs/contracts.

Additive amendment within `vendo/tools@1` accompanying the ENG-246 implementation (PR #229):

- `trpc` binding kind: `{ "kind": "trpc", "procedure", "type": "query"|"mutation", "mount", "transformer"?: "superjson" }`
- extractor seam language: extraction tier now OpenAPI + route-scan + tRPC behind one registration list; route tools under a tRPC mount are shadowed
- tRPC static extraction + fail-closed risk labeling rules (read-shaped queries only earn `read`; mutations default `write`; word list unchanged; unclassifiable → `disabled: true` + note)
- tRPC HTTP envelope execution semantics (query GET `?input=`, mutation POST, superjson `{json}` wrapping, `result.data` unwrap)
- binding-kind-aware tool identity note: method+path for HTTP-shaped bindings, mount + procedure dot-path for tRPC — used by SyncReport breaking-change detection and corpus expectations

Docs-only: touches `docs/contracts/04-actions.md` and nothing else.