### PR TITLE
docs: secrets egress gateway design options (ENG-290 M4, decision pending)

### DIFF
--- a/docs/superpowers/specs/2026-07-15-secrets-gateway-design.md
+++ b/docs/superpowers/specs/2026-07-15-secrets-gateway-design.md
@@ -1,0 +1,107 @@
+# Secrets Egress Gateway — Design Options
+
+Date: 2026-07-15. Parent: apps-block design (2026-07-14), locked decision 5.
+Status: **DECISION PENDING — Yousef picks before implementation.** This
+document compares; it does not build.
+
+## Problem
+
+Secret values must never enter the sandbox (06-apps §4.3, FROZEN): app code
+holds opaque handles (`vendo-secret:<name>:<nonce>`), and substitution happens
+at an egress gateway **outside** the sandbox, only for hosts on the app's
+declared `egress` allowlist. What ships today (ENG-259) is the explicit egress
+endpoint: `POST {VENDO_PROXY_URL}/egress` (§4.5) with allowlist match → SSRF
+guard on the resolved IP (re-checked per redirect) → handle substitution →
+forward → response secret-stripping. The open question is the *shape of the
+path from app code to that boundary*: transparent TLS interception, or an
+explicit endpoint reached by a fetch shim.
+
+## Option A — TLS-terminating egress gateway
+
+A forward proxy the sandbox is forced through: `HTTPS_PROXY`/`HTTP_PROXY` env
+plus a gateway CA injected into the machine's trust store at create/resume.
+The gateway terminates TLS, applies the §4.5 pipeline (allowlist, SSRF,
+substitute, redact), re-encrypts upstream.
+
+- App code unchanged: any HTTP client in any language works, including
+  third-party SDKs that never heard of Vendo (`stripe.charges.create(...)`
+  with the handle in env just works).
+- Requires real new infrastructure: a TLS-MITM proxy daemon reachable from
+  inside every provider's sandbox, per-run client auth (the run token must
+  bind CONNECT tunnels to an app/run or one app's gateway serves another's
+  secrets), CA minting/rotation, and per-host leaf-cert forging.
+- Weaker containment story: tools that pin certificates or read the system
+  store lazily bypass or break; anything that ignores `HTTPS_PROXY` (raw
+  sockets) silently skips the gateway, so the provider-level network
+  allowlist must *still* be the deny wall — the gateway can only be the
+  substitution point, never the enforcement point.
+- Response redaction requires streaming rewrite inside the TLS splice.
+
+### How each provider would host it
+
+- **E2B**: no sidecar concept. The gateway must run as a Vendo-operated
+  public endpoint (Cloud-ish) or as a process *inside* the sandbox — which
+  defeats the boundary. OSS zero-config cannot self-host a public MITM proxy;
+  a host-machine proxy is unreachable from E2B's network unless tunneled.
+- **Modal**: `modal.Proxy` exists but is an egress-IP feature, not a
+  programmable TLS terminator; same hosting problem as E2B — the gateway
+  would be a separately deployed Modal app the OSS install must own and pay
+  for.
+- **Cloud (future)**: natural fit — Cloud runs a managed gateway fleet next
+  to its sandboxes and mints per-run proxy credentials. But OSS would then
+  have a venue Cloud secures and OSS does not, or OSS carries the fleet.
+
+## Option B — explicit egress endpoint + in-sandbox fetch shim
+
+Keep §4.5 as the single wired boundary. Ship a `fetch` shim in the served-app
+scaffold (and the rung-2/3 boot convention) that rewrites outbound
+`fetch(externalUrl)` into `POST {VENDO_PROXY_URL}/egress` with the run token,
+so ordinary app code stays unchanged *within the Node fetch path*.
+
+- Already 80% built and contract-frozen: the endpoint, allowlist reuse, SSRF
+  guard, substitution, redaction, and size caps shipped in ENG-259 and are
+  red-team tested; the shim is the only missing piece and is explicitly
+  anticipated by the §4.3 amendment.
+- Hosting is free on every venue: the "gateway" is the umbrella's proxy
+  route, which already runs in the host app (Next/Express) outside the
+  sandbox; `VENDO_PROXY_URL` is already injected (§4.2). Nothing new to
+  deploy for OSS zero-config.
+- Enforcement composes with the provider network wall: sandbox-level egress
+  allowlists (E2B allow/deny rules; Modal domain+CIDR allowlists, fail-closed
+  since ENG-322) keep blocking raw-socket escapes; handles that bypass the
+  shim reach targets as useless opaque strings, never as secrets.
+- Limitation: non-fetch clients (raw `net` sockets, non-Node runtimes,
+  binaries the app spawns) do not get substitution. They *also* do not leak
+  secrets — they never had values — so the failure mode is "integration does
+  not authenticate," not "secret exposed."
+- Deterministic and cheap to test: the live lanes and egress suites already
+  exercise the full path against real E2B.
+
+## Decision matrix
+
+| Criterion | A: TLS-terminating gateway | B: endpoint + fetch shim |
+| --- | --- | --- |
+| App-code transparency | Full (any client, any language) | Node fetch path only |
+| New infra for OSS zero-config | High (public MITM proxy + CA + per-run auth) | None (proxy route already mounted) |
+| Provider fit today (E2B/Modal) | Poor — no per-sandbox hosting point | Native on both |
+| Security surface added | TLS splice, CA key custody, CONNECT auth | None beyond §4.5 (shipped, red-teamed) |
+| Failure mode when bypassed | Silent unproxied egress (if net not walled) | No auth, no leak (handle is opaque) |
+| Response secret-stripping | Streaming TLS rewrite (hard) | Already implemented |
+| Contract impact | New §4 surface, frozen-doc amendment | §4.3 amendment already names the shim |
+| Cloud fit | Good (managed fleet) | Good (same envelope, hosted at scale) |
+
+## Cloud alignment (standing agenda)
+
+Whichever wins, the interface Cloud implements is the **§4.5 egress
+envelope**: `POST /egress` `{ url, method?, headers?, body? }` authenticated
+by the run token, returning `{ status, headers, body }` with secrets redacted
+— plus the `SecretsProvider` seam for value storage. Under option A, Cloud
+additionally exposes per-run proxy credentials + CA distribution to its own
+sandboxes; the OSS contract surface does not change. Cloud should not build
+gateway hosting until the pick lands.
+
+## DECISION PENDING
+
+**Yousef picks (a) or (b) before any implementation.** The venues child
+builds nothing gateway-shaped until then; this doc is the deliverable for
+locked decision 5's design half.

--- a/docs/superpowers/specs/2026-07-15-secrets-gateway-design.md
+++ b/docs/superpowers/specs/2026-07-15-secrets-gateway-design.md
@@ -112,3 +112,14 @@ provider-hosting gaps are avoided. Cloud implements the §4.5 egress
 envelope + `SecretsProvider` seam, nothing gateway-shaped.
 
 The venues child may now build the M4 implementation against this pick.
+
+**Follow-up (decided same session): a guarded per-secret in-sandbox toggle.**
+Yousef additionally wants a user-facing safety toggle — "expose this secret
+inside this app's sandbox" — as a fast-follow, NOT in M4 scope. Constraints
+locked with the pick: B stays the default; the toggle is per-secret × per-app,
+owner-only; flipping it is a high-risk approval through the existing guard
+flow; every run with an exposed secret emits an audit event; the toggle never
+travels with shares or remixes (copies always revert to handles). Requires a
+§4.3 amendment ("never by default; explicit per-secret owner opt-in") and its
+own red-team pass before shipping. Tracked as a follow-up issue in the apps
+project.

--- a/docs/superpowers/specs/2026-07-15-secrets-gateway-design.md
+++ b/docs/superpowers/specs/2026-07-15-secrets-gateway-design.md
@@ -1,7 +1,7 @@
 # Secrets Egress Gateway — Design Options
 
 Date: 2026-07-15. Parent: apps-block design (2026-07-14), locked decision 5.
-Status: **DECISION PENDING — Yousef picks before implementation.** This
+Status: **DECIDED 2026-07-15: Option B (egress endpoint + fetch shim), picked by Yousef.** This
 document compares; it does not build.
 
 ## Problem
@@ -100,8 +100,15 @@ additionally exposes per-run proxy credentials + CA distribution to its own
 sandboxes; the OSS contract surface does not change. Cloud should not build
 gateway hosting until the pick lands.
 
-## DECISION PENDING
+## DECIDED: Option B — explicit egress endpoint + fetch shim
 
-**Yousef picks (a) or (b) before any implementation.** The venues child
-builds nothing gateway-shaped until then; this doc is the deliverable for
-locked decision 5's design half.
+**Picked by Yousef, 2026-07-15** (in-session, relayed by the coordinating
+agent). Rationale: the §4.5 egress path is already shipped and red-teamed
+(ENG-259); the fetch shim gives app code plain-`fetch` DX with plaintext
+never entering the venue; the bypass failure mode is "no auth," never
+"secret leaked"; and it hosts on the umbrella's existing proxy route on
+every venue with zero new OSS infra. Option A's CA/MITM surface and
+provider-hosting gaps are avoided. Cloud implements the §4.5 egress
+envelope + `SecretsProvider` seam, nothing gateway-shaped.
+
+The venues child may now build the M4 implementation against this pick.


### PR DESCRIPTION
## What

ENG-290 M4 — **doc-only**: the secrets egress gateway design comparison required by apps-block design locked decision 5 ("The venues child writes a short design doc comparing (a) TLS-terminating gateway … vs (b) explicit egress endpoint/fetch shim, including how each provider hosts the gateway. **Yousef picks before implementation.**").

`docs/superpowers/specs/2026-07-15-secrets-gateway-design.md`:

- Option A — TLS-terminating egress gateway (injected CA, `HTTPS_PROXY`, app code unchanged): what it buys, the MITM/CA/per-run-auth surface it adds, and why neither E2B nor Modal gives OSS zero-config a place to host it today.
- Option B — explicit egress endpoint (§4.5, shipped + red-teamed in ENG-259) plus the in-sandbox fetch shim the §4.3 amendment already names: hosting is the umbrella's existing proxy route on every venue; the bypass failure mode is "no auth," never "secret leaked."
- Decision matrix across transparency, OSS infra cost, provider fit, added security surface, redaction, contract impact, and Cloud fit.
- Cloud-alignment note (standing agenda): the interface Cloud implements either way is the §4.5 egress envelope + `SecretsProvider`; option A additionally means Cloud-managed proxy credentials/CA distribution. Cloud builds nothing until the pick.
- Ends with an explicit **DECISION PENDING: Yousef picks before implementation** marker.

## Why

Locked decision 5 gates the secrets-gateway BUILD on Yousef's pick; this doc is the design half so the pick can happen. No code, no contract changes.

## Gate

Doc-only, but the full repo gate was run on this branch anyway: `pnpm build && pnpm test && pnpm typecheck && pnpm lint` — all exit 0.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records Yousef’s decision for the secrets egress gateway: Option B — explicit `POST {VENDO_PROXY_URL}/egress` with an in-sandbox fetch shim. Also records a post-M4 follow-up: a guarded per-secret in-sandbox exposure toggle (opt-in, owner-only, audited). No code changes; ENG-290 M4 build is now unblocked.

- **New Features**
  - Added `docs/superpowers/specs/2026-07-15-secrets-gateway-design.md`.
  - Compares Option A (TLS-terminating proxy via `HTTPS_PROXY` + injected CA) vs Option B (explicit `/egress` + fetch shim).
  - Decision recorded 2026-07-15: Option B chosen; hosts on existing proxy route; bypass → no auth; Cloud uses `/egress` envelope + `SecretsProvider`.
  - Follow-up decision (post-M4): guarded per-secret in-sandbox exposure toggle — per-secret × per-app, owner-only, high-risk approval, audited, copies revert to handles; requires a §4.3 amendment and a red-team pass.
  - Satisfies Linear ENG-290 locked decision 5; implementation can proceed.

<sup>Written for commit 039aecf52cd2b7a406e1e7427f45e6ee80111a5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

