### PR TITLE
fix(agent): surface + retry thread persist failure after completed stream (ENG-309)

### DIFF
--- a/docs/verification/eng-309/01-red-unfixed.txt
+++ b/docs/verification/eng-309/01-red-unfixed.txt
@@ -1,0 +1,34 @@
+
+ RUN  v2.1.9 /Users/yousefh/Desktop/Cool Code/flowlet/.claude/worktrees/agent-a43f9e48364eb09ae/packages/agent
+
+ ❯ src/threads.test.ts (8 tests | 2 failed) 103ms
+   × agent threads > persist failure after a completed stream (ENG-309 / AGENT-8) > retries a transient store write failure so the completed turn is not silently lost 9ms
+     → injected store write failure
+   × agent threads > persist failure after a completed stream (ENG-309 / AGENT-8) > surfaces a permanent store write failure loudly instead of swallowing it 7ms
+     → injected store write failure
+
+⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
+
+ FAIL  src/threads.test.ts > agent threads > persist failure after a completed stream (ENG-309 / AGENT-8) > retries a transient store write failure so the completed turn is not silently lost
+ FAIL  src/threads.test.ts > agent threads > persist failure after a completed stream (ENG-309 / AGENT-8) > surfaces a permanent store write failure loudly instead of swallowing it
+Error: injected store write failure
+ ❯ failNext src/threads.test.ts:273:41
+    271|       const failNext = (): void => {
+    272|         attempts += 1;
+    273|         if (attempts <= failures) throw new Error("injected store writ…
+       |                                         ^
+    274|       };
+    275|       const store: StoreAdapter = {
+ ❯ Object.put src/threads.test.ts:284:15
+ ❯ ThreadRepository.persist src/threads.ts:191:50
+ ❯ onFinish src/agent.ts:210:25
+ ❯ callOnFinish ../../../../../../../Cool%20Code/flowlet/.claude/worktrees/agent-a43f9e48364eb09ae/node_modules/.pnpm/ai@6.0.28_zod@3.25.76/node_modules/ai/dist/index.mjs:5214:11
+ ❯ Object.flush ../../../../../../../Cool%20Code/flowlet/.claude/worktrees/agent-a43f9e48364eb09ae/node_modules/.pnpm/ai@6.0.28_zod@3.25.76/node_modules/ai/dist/index.mjs:5239:15
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯
+
+ Test Files  1 failed (1)
+      Tests  2 failed | 6 passed (8)
+   Start at  12:06:38
+   Duration  588ms (transform 100ms, setup 0ms, collect 201ms, tests 103ms, environment 0ms, prepare 50ms)
+

--- a/docs/verification/eng-309/02-green-fixed.txt
+++ b/docs/verification/eng-309/02-green-fixed.txt
@@ -1,0 +1,12 @@
+
+ RUN  v2.1.9 /Users/yousefh/Desktop/Cool Code/flowlet/.claude/worktrees/agent-a43f9e48364eb09ae/packages/agent
+
+ ✓ src/threads.test.ts (8 tests) 1303ms
+   ✓ agent threads > persist failure after a completed stream (ENG-309 / AGENT-8) > retries a transient store write failure so the completed turn is not silently lost 610ms
+   ✓ agent threads > persist failure after a completed stream (ENG-309 / AGENT-8) > surfaces a permanent store write failure loudly instead of swallowing it 607ms
+
+ Test Files  1 passed (1)
+      Tests  8 passed (8)
+   Start at  12:07:26
+   Duration  1.87s (transform 108ms, setup 0ms, collect 225ms, tests 1.30s, environment 0ms, prepare 65ms)
+

--- a/docs/verification/eng-309/README.md
+++ b/docs/verification/eng-309/README.md
@@ -1,0 +1,25 @@
+# ENG-309 verification — persist failure after completed stream (AGENT-8)
+
+Bug: `packages/agent/src/agent.ts` persisted the finished turn in `onFinish`
+with no try/catch and no retry. A store write failure after the SSE `[DONE]`
+lost the thread while the user saw a successful response — and the raw
+injected error escaped through the stream transport.
+
+Evidence (agent test suite `packages/agent/src/threads.test.ts`, describe
+"persist failure after a completed stream (ENG-309 / AGENT-8)"):
+
+- `01-red-unfixed.txt` — the two new tests run against the UNFIXED
+  `agent.ts` (persist call restored to the bare
+  `await threads.persist(...)`): both fail. The stack shows the injected
+  store error escaping from `onFinish` via `ThreadRepository.persist`,
+  i.e. the exact silent-loss / stream-corruption path.
+- `02-green-fixed.txt` — same tests with the fix (`persistFinishedTurn`:
+  bounded retry 3 attempts with 100ms/500ms backoff, then a loud structured
+  `console.error` naming the thread): 8/8 pass, including the six
+  pre-existing thread tests.
+
+Wire-signal decision: by the time `onFinish` runs, the response headers and
+the SSE `[DONE]` are already delivered, so no additive wire signal can reach
+this turn's client. Per the locked direction, the fix is bounded retry plus a
+loud structured error path (never throwing — a throw corrupts the
+already-delivered stream, which is what the red run demonstrates).

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -30,6 +30,49 @@ import {
 
 const THREAD_ID_HEADER = "x-vendo-thread-id";
 
+// ENG-309: backoff between persist attempts after a completed stream. Short and
+// bounded — long waits would hold the response open for nothing (the user
+// already has the reply); a store blip that outlives ~600ms is a real outage.
+const PERSIST_RETRY_DELAYS_MS = [100, 500] as const;
+
+const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** ENG-309: persist the finished turn with bounded retry, and surface a final
+ *  failure LOUDLY instead of swallowing it. By the time onFinish runs, the
+ *  response headers and the SSE `[DONE]` are already on the wire, so no
+ *  additive wire signal can reach this turn's client — never throw here (that
+ *  would corrupt the already-delivered stream / crash the transport), but a
+ *  thread silently vanishing after a successful reply is data loss, so the
+ *  structured error names the thread. */
+async function persistFinishedTurn(
+  threads: ThreadRepository,
+  thread: Thread,
+  messages: UIMessage[],
+  ctx: RunContext,
+): Promise<void> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await threads.persist(thread, messages, ctx);
+      return;
+    } catch (error) {
+      const delay = PERSIST_RETRY_DELAYS_MS[attempt];
+      if (delay === undefined) {
+        console.error(
+          "[vendo] agent: thread persist failed after completed stream — this turn was NOT saved",
+          {
+            threadId: thread.id,
+            subject: ctx.principal.subject,
+            attempts: attempt + 1,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+        return;
+      }
+      await wait(delay);
+    }
+  }
+}
+
 interface AgentConfig {
   model: LanguageModel;
   tools: ToolRegistry;
@@ -207,7 +250,7 @@ export function createAgent(config: AgentConfig): VendoAgent {
           }));
         },
         onFinish: async ({ messages }) => {
-          await threads.persist(thread, messages, input.ctx);
+          await persistFinishedTurn(threads, thread, messages, input.ctx);
         },
         onError: () => "An error occurred while generating the response.",
       });

--- a/packages/agent/src/threads.test.ts
+++ b/packages/agent/src/threads.test.ts
@@ -1,6 +1,6 @@
 import type { StoreAdapter } from "@vendoai/core";
 import type { UIMessage } from "ai";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAgent } from "./index.js";
 import {
   boundRegistry,
@@ -254,6 +254,121 @@ describe("agent threads", () => {
     expect(summaries.map((s) => s.id).sort()).toEqual(["thr_good", "thr_junk_msgs"]);
     expect(summaries.find((s) => s.id === "thr_good")).toMatchObject({ title: "Good question" });
     expect(summaries.find((s) => s.id === "thr_junk_msgs")).toMatchObject({ title: "New thread" });
+  });
+
+  describe("persist failure after a completed stream (ENG-309 / AGENT-8)", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    /** A store whose vendo_threads WRITES fail the first `failures` times (all
+     *  other collections and operations pass through untouched). */
+    function failingThreadWrites(inner: StoreAdapter, failures: number): {
+      store: StoreAdapter;
+      writeAttempts: () => number;
+    } {
+      let attempts = 0;
+      const failNext = (): void => {
+        attempts += 1;
+        if (attempts <= failures) throw new Error("injected store write failure");
+      };
+      const store: StoreAdapter = {
+        ensureSchema: () => inner.ensureSchema(),
+        blobs: (namespace) => inner.blobs(namespace),
+        records: (collection) => {
+          const records = inner.records(collection);
+          if (collection !== "vendo_threads") return records;
+          return {
+            ...records,
+            async put(record) {
+              failNext();
+              return records.put(record);
+            },
+            ...(records.atomic === undefined ? {} : {
+              atomic: {
+                async insertIfAbsent(record) {
+                  failNext();
+                  return records.atomic!.insertIfAbsent(record);
+                },
+                async compareAndSwap(record, expectedRevision) {
+                  failNext();
+                  return records.atomic!.compareAndSwap(record, expectedRevision);
+                },
+              },
+            }),
+          };
+        },
+      };
+      return { store, writeAttempts: () => attempts };
+    }
+
+    it("retries a transient store write failure so the completed turn is not silently lost", async () => {
+      const { store, writeAttempts } = failingThreadWrites(memoryStore(), 2);
+      const guard = testGuard({});
+      const agent = createAgent({
+        model: scriptedModel([textTurn("Saved reply.", "text_retry")]),
+        tools: boundRegistry({}, guard),
+        guard,
+        store,
+      });
+      const runCtx = ctx();
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const response = await agent.stream({
+        threadId: "thr_retry",
+        message: userMessage("user_retry", "Please save this"),
+        ctx: runCtx,
+      });
+      const { rawFrames } = await readSse(response);
+
+      // The user saw a complete, successful stream…
+      expect(rawFrames.at(-1)).toBe("data: [DONE]\n\n");
+      // …and the thread survived the transient write failures.
+      await vi.waitFor(async () => {
+        const thread = await agent.threads.get("thr_retry", runCtx);
+        expect(thread).not.toBeNull();
+        expect(thread!.messages.some((message) => message.id === "user_retry")).toBe(true);
+        expect(assistantText(thread!.messages)).toContain("Saved reply.");
+      });
+      expect(writeAttempts()).toBeGreaterThan(2);
+      // A recovered persist is not a loud failure.
+      expect(errorSpy.mock.calls.filter(([first]) => String(first).includes("thread persist failed"))).toEqual([]);
+    });
+
+    it("surfaces a permanent store write failure loudly instead of swallowing it", async () => {
+      const { store } = failingThreadWrites(memoryStore(), Number.POSITIVE_INFINITY);
+      const guard = testGuard({});
+      const agent = createAgent({
+        model: scriptedModel([textTurn("Doomed reply.", "text_doomed")]),
+        tools: boundRegistry({}, guard),
+        guard,
+        store,
+      });
+      const runCtx = ctx();
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const response = await agent.stream({
+        threadId: "thr_doomed",
+        message: userMessage("user_doomed", "This write always fails"),
+        ctx: runCtx,
+      });
+      // The stream still completes cleanly for the user — persist failure after
+      // [DONE] must never corrupt or error the already-delivered response.
+      const { rawFrames } = await readSse(response);
+      expect(rawFrames.at(-1)).toBe("data: [DONE]\n\n");
+
+      // The failure is surfaced as a loud, structured error naming the thread.
+      await vi.waitFor(() => {
+        const call = errorSpy.mock.calls.find(([first]) => String(first).includes("thread persist failed"));
+        expect(call).toBeDefined();
+        expect(call![0]).toContain("[vendo]");
+        expect(call![1]).toMatchObject({
+          threadId: "thr_doomed",
+          subject: "u1",
+          error: "injected store write failure",
+        });
+      });
+    });
   });
 
   it("lets two subjects privately use the same thread id in MEMORY mode (no store)", async () => {


### PR DESCRIPTION
## What

Fixes AGENT-8 (handed off from block-foundations as a verified finding): `packages/agent/src/agent.ts` persisted the finished turn in `onFinish` with a bare `await threads.persist(...)` — no try/catch, no retry, no test. A store write failure after the SSE `[DONE]` silently lost the thread while the user saw a successful response; worse, the raw store error escaped through the closed stream transport (see the red run in `docs/verification/eng-309/01-red-unfixed.txt` — the injected error surfaces via `onFinish → ThreadRepository.persist` into the response).

## Fix

`persistFinishedTurn` (agent.ts):
- **Bounded retry**: 3 attempts with 100ms/500ms backoff. Short and bounded on purpose — the user already has the reply, so long waits would only hold the response open; a blip that outlives ~600ms is a real outage.
- **Loud structured error path** on final failure: `console.error("[vendo] agent: thread persist failed after completed stream — this turn was NOT saved", { threadId, subject, attempts, error })` — matching the `[vendo]`-prefixed structured convention already used in `packages/store/src/db.ts`. Never throws: a throw would corrupt the already-delivered stream.

## Wire-signal decision (as directed, documented here)

**No wire signal is added.** By the time `onFinish` runs, the response headers (including `x-vendo-thread-id`) and the SSE `[DONE]` frame are already on the wire, so no additive signal can reach this turn's client — there is no channel left. Per the locked direction, post-`[DONE]` infeasibility ⇒ bounded retry + loud structured error path. Contracts in `docs/contracts/` are untouched.

## Tests

New describe in `packages/agent/src/threads.test.ts` ("persist failure after a completed stream (ENG-309 / AGENT-8)") — store write failure injected after a completed stream, exactly the test the finding asked for:
1. transient failure (2 injected write failures) → stream completes with `[DONE]`, thread survives via retry, no loud error;
2. permanent failure → stream still completes cleanly with `[DONE]`, structured error names the thread + subject.

Both are red on unfixed code (evidence committed under `docs/verification/eng-309/`: `01-red-unfixed.txt`, `02-green-fixed.txt`, `README.md`).

## Gate

`pnpm build` ✓ · `pnpm test` ✓ (only failure: `@vendoai/core` `packaging.e2e.test.ts` — pre-existing, sanctioned ignore under paths with spaces; agent 41 passed/4 skipped, mcp 66 passed) · `pnpm typecheck` ✓ · `pnpm lint` ✓

No visual surface (agent-package robustness fix; no user-visible wire behavior change) — per UI law, committed test evidence instead of screenshots.

Part of "Block: @vendoai/ui — excellent and solid"; ENG-310 will be stacked on this branch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retry and surface thread persist failures that occur after `[DONE]`, preventing silent thread loss while keeping the response intact. Addresses `ENG-309`.

- **Bug Fixes**
  - Persist finished turns via `persistFinishedTurn`: 3 attempts with 100ms/500ms backoff; never throws after `[DONE]`.
  - On final failure, emit structured `console.error` with `[vendo]` prefix and `threadId`/`subject`/`attempts`; no wire signal added because headers and `[DONE]` are already sent.
  - Updated `onFinish` in `packages/agent/src/agent.ts` to use `persistFinishedTurn`; stream always completes cleanly.
  - Added tests in `packages/agent/src/threads.test.ts` covering transient and permanent failures, plus red/green logs in `docs/verification/eng-309/`.

<sup>Written for commit bc8cda762646b1e51075d35bddac378bb599e428. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

