### PR TITLE
fix(agent): guarded versioned persist — concurrent turns no longer clobber messages (ENG-310)

### DIFF
--- a/docs/verification/eng-310/01-red-unfixed.txt
+++ b/docs/verification/eng-310/01-red-unfixed.txt
@@ -1,0 +1,56 @@
+
+ RUN  v2.1.9 /Users/yousefh/Desktop/Cool Code/flowlet/.claude/worktrees/agent-a43f9e48364eb09ae/packages/agent
+
+ ❯ src/threads.test.ts (10 tests | 2 failed) 1685ms
+   ✓ agent threads > persist failure after a completed stream (ENG-309 / AGENT-8) > retries a transient store write failure so the completed turn is not silently lost 686ms
+   ✓ agent threads > persist failure after a completed stream (ENG-309 / AGENT-8) > surfaces a permanent store write failure loudly instead of swallowing it 619ms
+   × agent threads > concurrent turns on one thread (ENG-310 / AGENT-9) > two overlapping stream() calls on one threadId keep BOTH turns' messages 21ms
+     → expected false to be true // Object.is equality
+   × agent threads > concurrent turns on one thread (ENG-310 / AGENT-9) > overlapping turns on an EXISTING thread preserve prior history and both new turns 118ms
+     → expected false to be true // Object.is equality
+
+⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
+
+ FAIL  src/threads.test.ts > agent threads > concurrent turns on one thread (ENG-310 / AGENT-9) > two overlapping stream() calls on one threadId keep BOTH turns' messages
+AssertionError: expected false to be true // Object.is equality
+
+- Expected
++ Received
+
+- true
++ false
+
+ ❯ src/threads.test.ts:401:80
+    399|       const thread = await agent.threads.get(threadId, runCtx);
+    400|       expect(thread).not.toBeNull();
+    401|       expect(thread!.messages.some((message) => message.id === "user_r…
+       |                                                                                ^
+    402|       expect(thread!.messages.some((message) => message.id === "user_r…
+    403|       const replies = assistantText(thread!.messages);
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯
+
+ FAIL  src/threads.test.ts > agent threads > concurrent turns on one thread (ENG-310 / AGENT-9) > overlapping turns on an EXISTING thread preserve prior history and both new turns
+AssertionError: expected false to be true // Object.is equality
+
+- Expected
++ Received
+
+- true
++ false
+
+ ❯ src/threads.test.ts:442:71
+    440|       expect(thread).not.toBeNull();
+    441|       for (const id of ["user_seed", "user_branch_a", "user_branch_b"]…
+    442|         expect(thread!.messages.some((message) => message.id === id)).…
+       |                                                                       ^
+    443|       }
+    444|       const replies = assistantText(thread!.messages);
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯
+
+ Test Files  1 failed (1)
+      Tests  2 failed | 8 passed (10)
+   Start at  12:13:15
+   Duration  5.89s (transform 1.03s, setup 0ms, collect 2.33s, tests 1.69s, environment 0ms, prepare 513ms)
+

--- a/docs/verification/eng-310/02-green-agent.txt
+++ b/docs/verification/eng-310/02-green-agent.txt
@@ -1,0 +1,12 @@
+
+ RUN  v2.1.9 /Users/yousefh/Desktop/Cool Code/flowlet/.claude/worktrees/agent-a43f9e48364eb09ae/packages/agent
+
+ ✓ src/threads.test.ts (10 tests) 1401ms
+   ✓ agent threads > persist failure after a completed stream (ENG-309 / AGENT-8) > retries a transient store write failure so the completed turn is not silently lost 629ms
+   ✓ agent threads > persist failure after a completed stream (ENG-309 / AGENT-8) > surfaces a permanent store write failure loudly instead of swallowing it 612ms
+
+ Test Files  1 passed (1)
+      Tests  10 passed (10)
+   Start at  12:14:30
+   Duration  2.58s (transform 428ms, setup 0ms, collect 689ms, tests 1.40s, environment 0ms, prepare 124ms)
+

--- a/docs/verification/eng-310/03-green-store-cas.txt
+++ b/docs/verification/eng-310/03-green-store-cas.txt
@@ -1,0 +1,13 @@
+
+ RUN  v2.1.9 /Users/yousefh/Desktop/Cool Code/flowlet/.claude/worktrees/agent-a43f9e48364eb09ae/packages/store
+
+stdout | src/thread-scoping.test.ts
+POSTGRES_URL not set — postgres leg skipped
+
+ ✓ src/thread-scoping.test.ts (6 tests) 13516ms
+
+ Test Files  1 passed (1)
+      Tests  6 passed (6)
+   Start at  12:18:30
+   Duration  15.17s (transform 578ms, setup 0ms, collect 1.13s, tests 13.52s, environment 0ms, prepare 195ms)
+

--- a/docs/verification/eng-310/README.md
+++ b/docs/verification/eng-310/README.md
@@ -1,0 +1,50 @@
+# ENG-310 verification — lost-update race on concurrent turns (AGENT-9)
+
+Bug: `packages/agent/src/threads.ts` `persist()` was a bare
+`put({ id, data, refs })`. Two overlapping `stream()` calls on one threadId
+each finish holding their OWN copy of the history, so last-write-wins
+clobbered the other turn's messages. The guarded upsert in `resolve()` covers
+cross-subject takeover only, not same-subject races.
+
+Evidence:
+
+- `01-red-unfixed.txt` — the two new concurrency tests
+  (`packages/agent/src/threads.test.ts`, describe "concurrent turns on one
+  thread (ENG-310 / AGENT-9)": two overlapping `stream()` calls via
+  `Promise.all` on one threadId, fresh and existing thread) run against the
+  UNFIXED `persist()`: both fail — one turn's user message and reply are
+  gone after the race.
+- `02-green-agent.txt` — same tests with the fix: 10/10 pass (including all
+  pre-existing thread tests and the ENG-309 tests).
+- `03-green-store-cas.txt` — the store-level guarded-write tests
+  (`packages/store/src/thread-scoping.test.ts`, describe "vendo_threads
+  guarded writes (ENG-310)"): routed `atomic.insertIfAbsent` admits exactly
+  one concurrent first-persist, `compareAndSwap` admits exactly one
+  concurrent swap per revision, foreign subjects can never land a guarded
+  write, and the ephemeral overlay path behaves identically.
+
+Mechanism (checked @vendoai/store's primitives first, as directed):
+
+- The FROZEN contract (01 §12) already reserves the optional
+  `RecordStore.atomic` capability (`insertIfAbsent` + `compareAndSwap` over an
+  opaque `revision` token). The generic record path and the conformance
+  memory adapter implement it; the routed reserved `vendo_threads` door did
+  not — so this change ADDITIVELY implements it there, backed by a new
+  `revision bigint NOT NULL DEFAULT 1` column (same `ADD COLUMN IF NOT
+  EXISTS` migration pattern as the thread `title` column).
+- `persist()` is now read-merge-guarded-write with bounded retry (5
+  attempts): re-read the current row, merge this turn's messages into the
+  CURRENT history (upsert by message id — same identity rule as the
+  in-stream upsert), then `insertIfAbsent` (first turn) or `compareAndSwap`
+  on the freshly-read revision. A loser re-reads and re-merges; exhaustion
+  throws a structured conflict which ENG-309's retry/loud-error path
+  surfaces.
+- Adapters without `atomic` fall back to the merged put — still a huge
+  improvement (the race window shrinks from a whole streaming turn to one
+  read-write), and the door's subject guard keeps refusing takeovers.
+- Memory mode merges synchronously against the current map entry (atomic in
+  JS), so it needs no further guard.
+
+Note: queue-send (ENG-215, separate lane) reduces but does not eliminate
+concurrency — two tabs on one thread remain possible, which is exactly the
+overlapping-turns case these tests pin.

--- a/packages/agent/src/threads.test.ts
+++ b/packages/agent/src/threads.test.ts
@@ -396,11 +396,15 @@ describe("agent threads", () => {
       ]);
       await Promise.all([readSse(first), readSse(second)]);
 
-      const thread = await agent.threads.get(threadId, runCtx);
-      expect(thread).not.toBeNull();
-      expect(thread!.messages.some((message) => message.id === "user_race_1")).toBe(true);
-      expect(thread!.messages.some((message) => message.id === "user_race_2")).toBe(true);
-      const replies = assistantText(thread!.messages);
+      // waitFor: robust against a store whose writes settle after stream close.
+      const thread = await vi.waitFor(async () => {
+        const persisted = await agent.threads.get(threadId, runCtx);
+        expect(persisted).not.toBeNull();
+        expect(persisted!.messages.some((message) => message.id === "user_race_1")).toBe(true);
+        expect(persisted!.messages.some((message) => message.id === "user_race_2")).toBe(true);
+        return persisted!;
+      });
+      const replies = assistantText(thread.messages);
       expect(replies).toContain("Reply one.");
       expect(replies).toContain("Reply two.");
       // One thread row, not a fork.
@@ -436,12 +440,16 @@ describe("agent threads", () => {
       ]);
       await Promise.all([readSse(first), readSse(second)]);
 
-      const thread = await agent.threads.get(threadId, runCtx);
-      expect(thread).not.toBeNull();
-      for (const id of ["user_seed", "user_branch_a", "user_branch_b"]) {
-        expect(thread!.messages.some((message) => message.id === id)).toBe(true);
-      }
-      const replies = assistantText(thread!.messages);
+      // waitFor: robust against a store whose writes settle after stream close.
+      const thread = await vi.waitFor(async () => {
+        const persisted = await agent.threads.get(threadId, runCtx);
+        expect(persisted).not.toBeNull();
+        for (const id of ["user_seed", "user_branch_a", "user_branch_b"]) {
+          expect(persisted!.messages.some((message) => message.id === id)).toBe(true);
+        }
+        return persisted!;
+      });
+      const replies = assistantText(thread.messages);
       expect(replies).toContain("Seed reply.");
       expect(replies).toContain("Branch A.");
       expect(replies).toContain("Branch B.");

--- a/packages/agent/src/threads.test.ts
+++ b/packages/agent/src/threads.test.ts
@@ -371,6 +371,83 @@ describe("agent threads", () => {
     });
   });
 
+  describe("concurrent turns on one thread (ENG-310 / AGENT-9)", () => {
+    it("two overlapping stream() calls on one threadId keep BOTH turns' messages", async () => {
+      const store = memoryStore();
+      const guard = testGuard({});
+      const agent = createAgent({
+        model: scriptedModel([
+          textTurn("Reply one.", "text_race_1"),
+          textTurn("Reply two.", "text_race_2"),
+        ]),
+        tools: boundRegistry({}, guard),
+        guard,
+        store,
+      });
+      const runCtx = ctx();
+      const threadId = "thr_race";
+
+      // Two tabs on one thread: both turns resolve the thread BEFORE either
+      // persists, so each holds its own copy — the last-write-wins put used to
+      // clobber whichever turn finished first.
+      const [first, second] = await Promise.all([
+        agent.stream({ threadId, message: userMessage("user_race_1", "Question one"), ctx: runCtx }),
+        agent.stream({ threadId, message: userMessage("user_race_2", "Question two"), ctx: runCtx }),
+      ]);
+      await Promise.all([readSse(first), readSse(second)]);
+
+      const thread = await agent.threads.get(threadId, runCtx);
+      expect(thread).not.toBeNull();
+      expect(thread!.messages.some((message) => message.id === "user_race_1")).toBe(true);
+      expect(thread!.messages.some((message) => message.id === "user_race_2")).toBe(true);
+      const replies = assistantText(thread!.messages);
+      expect(replies).toContain("Reply one.");
+      expect(replies).toContain("Reply two.");
+      // One thread row, not a fork.
+      const rows = await store.records("vendo_threads").list({ refs: { subject: "u1" } });
+      expect(rows.records).toHaveLength(1);
+    });
+
+    it("overlapping turns on an EXISTING thread preserve prior history and both new turns", async () => {
+      const store = memoryStore();
+      const guard = testGuard({});
+      const agent = createAgent({
+        model: scriptedModel([
+          textTurn("Seed reply.", "text_seed"),
+          textTurn("Branch A.", "text_branch_a"),
+          textTurn("Branch B.", "text_branch_b"),
+        ]),
+        tools: boundRegistry({}, guard),
+        guard,
+        store,
+      });
+      const runCtx = ctx();
+      const threadId = "thr_race_existing";
+
+      await readSse(await agent.stream({
+        threadId,
+        message: userMessage("user_seed", "Seed question"),
+        ctx: runCtx,
+      }));
+
+      const [first, second] = await Promise.all([
+        agent.stream({ threadId, message: userMessage("user_branch_a", "Branch question A"), ctx: runCtx }),
+        agent.stream({ threadId, message: userMessage("user_branch_b", "Branch question B"), ctx: runCtx }),
+      ]);
+      await Promise.all([readSse(first), readSse(second)]);
+
+      const thread = await agent.threads.get(threadId, runCtx);
+      expect(thread).not.toBeNull();
+      for (const id of ["user_seed", "user_branch_a", "user_branch_b"]) {
+        expect(thread!.messages.some((message) => message.id === id)).toBe(true);
+      }
+      const replies = assistantText(thread!.messages);
+      expect(replies).toContain("Seed reply.");
+      expect(replies).toContain("Branch A.");
+      expect(replies).toContain("Branch B.");
+    });
+  });
+
   it("lets two subjects privately use the same thread id in MEMORY mode (no store)", async () => {
     // With no store, threads live in per-subject maps: the same id is two distinct
     // private threads — no conflict, no leak. This pins the intentional divergence

--- a/packages/agent/src/threads.ts
+++ b/packages/agent/src/threads.ts
@@ -87,6 +87,25 @@ function toPlainJson(messages: UIMessage[]): UIMessage[] {
   return JSON.parse(JSON.stringify(messages)) as UIMessage[];
 }
 
+// ENG-310: how many times persist re-reads and re-merges after losing a write
+// race. Each retry starts from the freshly-read row, so a loss only recurs
+// while OTHER writers keep landing between our read and our guarded write.
+const MAX_PERSIST_ATTEMPTS = 5;
+
+/** ENG-310: fold this turn's messages into the CURRENT persisted history —
+ *  upsert by message id (same identity rule as the in-stream upsertMessage),
+ *  so two concurrent turns on one thread both survive: shared history is
+ *  updated in place, each turn's new messages are appended. */
+function mergeMessages(current: UIMessage[], turn: UIMessage[]): UIMessage[] {
+  const merged = [...current];
+  for (const message of turn) {
+    const index = merged.findIndex((candidate) => candidate.id === message.id);
+    if (index === -1) merged.push(message);
+    else merged[index] = message;
+  }
+  return merged;
+}
+
 /** 03-agent §5 */
 export class ThreadRepository {
   readonly #memory = new Map<string, Map<ThreadId, Thread>>();
@@ -172,27 +191,70 @@ export class ThreadRepository {
   }
 
   async persist(thread: Thread, messages: UIMessage[], ctx: RunContext): Promise<void> {
-    const updated: Thread = {
+    // ai-SDK UIMessages carry explicit `undefined`-valued optional props on
+    // tool parts (e.g. an approval-requested part with no output yet). The
+    // store seam is typed `Json` and rejects `undefined` values, so serialize
+    // to plain JSON — dropping absent-anyway keys — before it crosses.
+    const turnMessages = toPlainJson(messages);
+    // ENG-310 (AGENT-9): persist is read-modify-write, never a blind overwrite.
+    // Two overlapping turns on one thread each finish with their OWN copy of the
+    // history; a bare put made the last writer clobber the other turn's messages.
+    // Every write below first merges this turn into the CURRENT stored history.
+    if (this.usesMemory(ctx)) {
+      // The read+merge+set below is synchronous — atomic in JS — so the memory
+      // path needs no further guard.
+      const threads = this.subjectMemory(ctx.principal.subject);
+      const current = threads.get(thread.id);
+      threads.set(thread.id, this.updatedThread(
+        thread,
+        current === undefined ? turnMessages : mergeMessages(current.messages, turnMessages),
+      ));
+      return;
+    }
+    const records = this.store!.records(THREAD_COLLECTION);
+    for (let attempt = 0; attempt < MAX_PERSIST_ATTEMPTS; attempt += 1) {
+      const record = await records.get(thread.id);
+      const current = record === null ? null : threadFromRecord(record);
+      if (current !== null && current.subject !== thread.subject) {
+        // Mirror the door's guarded upsert (03 §5): never take over a foreign row.
+        throw new VendoError("conflict", "threadId is already in use");
+      }
+      const updated = this.updatedThread(
+        thread,
+        current === null ? turnMessages : mergeMessages(current.messages, turnMessages),
+      );
+      const input = { id: updated.id, data: updated, refs: { subject: updated.subject } };
+      // Guarded write when the adapter has the optional atomic capability (01
+      // §12): insert-if-absent for a first turn, revision CAS for an existing
+      // row — exactly one concurrent writer lands; the loser re-reads and
+      // re-merges. Without atomic (or on a legacy pre-revision row) the merged
+      // put still shrinks the race window from a whole streaming turn to one
+      // read-write, and the door's subject guard keeps refusing takeovers.
+      if (records.atomic === undefined || (record !== null && record.revision === undefined)) {
+        await records.put(input);
+        return;
+      }
+      const written = record === null
+        ? await records.atomic.insertIfAbsent(input)
+        : await records.atomic.compareAndSwap(input, record.revision!);
+      if (written !== null) return;
+    }
+    throw new VendoError(
+      "conflict",
+      `thread ${thread.id} persist lost the update race ${MAX_PERSIST_ATTEMPTS} times`,
+    );
+  }
+
+  /** The Thread as it should be written for this turn: merged messages, a
+   *  freshly-derived listing title (never a stale prior title — `list` reads it
+   *  back without loading messages), and a new updatedAt. */
+  private updatedThread(thread: Thread, messages: UIMessage[]): Thread {
+    return {
       ...thread,
-      // ai-SDK UIMessages carry explicit `undefined`-valued optional props on
-      // tool parts (e.g. an approval-requested part with no output yet). The
-      // store seam is typed `Json` and rejects `undefined` values, so serialize
-      // to plain JSON — dropping absent-anyway keys — before it crosses.
-      messages: toPlainJson(messages),
-      // Precompute the listing title from the derivation (never a stale prior title),
-      // so `list` can read it back without loading the messages array.
+      messages,
       title: deriveTitle(messages),
       updatedAt: new Date().toISOString(),
     };
-    if (this.usesMemory(ctx)) {
-      this.subjectMemory(ctx.principal.subject).set(updated.id, updated);
-      return;
-    }
-    await this.store!.records(THREAD_COLLECTION).put({
-      id: updated.id,
-      data: updated,
-      refs: { subject: updated.subject },
-    });
   }
 
   private create(ctx: RunContext, requestedId?: ThreadId): Thread {

--- a/packages/store/src/helpers/rows.ts
+++ b/packages/store/src/helpers/rows.ts
@@ -48,6 +48,7 @@ export async function putAppRow(
 
 export function threadFromRow(row: Record<string, unknown>): ThreadRow {
   const title = row["title"];
+  const revision = row["revision"];
   return {
     id: text(row["id"]),
     subject: text(row["subject"]),
@@ -55,6 +56,9 @@ export function threadFromRow(row: Record<string, unknown>): ThreadRow {
     ...(typeof title === "string" ? { title } : {}),
     createdAt: iso(row["created_at"]),
     updatedAt: iso(row["updated_at"]),
+    ...(typeof revision === "string" || typeof revision === "number" || typeof revision === "bigint"
+      ? { revision: String(revision) }
+      : {}),
   };
 }
 
@@ -70,12 +74,13 @@ export async function putThreadRow(
   // This closes the TOCTOU window that a resolve()-time pre-check alone cannot
   // (a foreign row can appear during a long streaming turn, before persist runs).
   const result = await db.query(
-    `INSERT INTO vendo_threads (id, subject, messages, title, created_at, updated_at)
-     VALUES ($1, $2, $3::jsonb, $4, $5, $5)
+    `INSERT INTO vendo_threads (id, subject, messages, title, created_at, updated_at, revision)
+     VALUES ($1, $2, $3::jsonb, $4, $5, $5, 1)
      ON CONFLICT (id) DO UPDATE
-       SET messages = EXCLUDED.messages, title = EXCLUDED.title, updated_at = EXCLUDED.updated_at
+       SET messages = EXCLUDED.messages, title = EXCLUDED.title, updated_at = EXCLUDED.updated_at,
+           revision = vendo_threads.revision + 1
        WHERE vendo_threads.subject = EXCLUDED.subject
-     RETURNING id, subject, messages, title, created_at, updated_at`,
+     RETURNING id, subject, messages, title, created_at, updated_at, revision`,
     [input.id, input.subject, JSON.stringify(input.messages), input.title ?? null, now],
   );
   const row = result.rows[0];

--- a/packages/store/src/helpers/threads.ts
+++ b/packages/store/src/helpers/threads.ts
@@ -33,6 +33,7 @@ export function threadStore(store: VendoStore): {
           messages: parsed.messages,
           createdAt: prior?.createdAt ?? now,
           updatedAt: now,
+          revision: String(BigInt(prior?.revision ?? "0") + 1n),
         };
         overlay.threads.set(thread.id, snapshot(row));
         return snapshot(row);
@@ -49,7 +50,7 @@ export function threadStore(store: VendoStore): {
         return row?.subject === principal.subject ? snapshot(row) : null;
       }
       const result = await db.query(
-        `SELECT id, subject, messages, created_at, updated_at FROM vendo_threads
+        `SELECT id, subject, messages, title, created_at, updated_at, revision FROM vendo_threads
          WHERE id = $1 AND subject = $2`,
         [id, principal.subject],
       );

--- a/packages/store/src/helpers/types.ts
+++ b/packages/store/src/helpers/types.ts
@@ -29,6 +29,9 @@ export interface ThreadRow {
   title?: string;
   createdAt: IsoDateTime;
   updatedAt: IsoDateTime;
+  /** Opaque write counter backing the routed atomic capability (01 §12); bumped
+   *  on every write. Absent only on projections that never carry it (listSelect). */
+  revision?: string;
 }
 
 /** 02-store §3 */

--- a/packages/store/src/records.ts
+++ b/packages/store/src/records.ts
@@ -38,7 +38,7 @@ function sameRecordValue(
     && canonicalJson(current.refs ?? null) === canonicalJson(expected.refs ?? null);
 }
 
-function requireRevision(value: string): void {
+export function requireRevision(value: string): void {
   if (!/^[1-9]\d*$/.test(value)) throw new VendoError("validation", "malformed record revision");
 }
 

--- a/packages/store/src/routing.ts
+++ b/packages/store/src/routing.ts
@@ -2,6 +2,7 @@ import {
   VendoError,
   type AppDocument,
   type ApprovalRequest,
+  type AtomicRecordStore,
   type AuditEvent,
   type Json,
   type PermissionGrant,
@@ -10,7 +11,7 @@ import {
   type VendoRecord,
 } from "@vendoai/core";
 import type { Db } from "./db.js";
-import { createRecordStore, type DedicatedRecordTable } from "./records.js";
+import { createRecordStore, requireRevision, type DedicatedRecordTable } from "./records.js";
 import { isEphemeralApp, isEphemeralSubject, overlayFor, registerEphemeralSubject, snapshot, stateKey } from "./ephemeral.js";
 import {
   appFromRow,
@@ -76,6 +77,9 @@ interface RoutedConfig {
   overlayRecords(): VendoRecord[];
   put(record: { id: string; data: Json; refs?: Record<string, string> }): Promise<VendoRecord>;
   deleteOverlay(id: string): boolean;
+  /** Optional additive capability (01 §12): guarded writes for collections whose
+   *  table carries a revision counter. vendo_threads provides it (ENG-310). */
+  atomic?: AtomicRecordStore;
 }
 
 function refs(values: Record<string, string | undefined>): Record<string, string> {
@@ -138,6 +142,9 @@ function threadRecord(row: ThreadRow): VendoRecord {
     refs: { subject: row.subject },
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
+    // Present when the row carries the write counter (01 §12: opaque token when
+    // atomic is present); the messages-less listSelect projection omits it.
+    ...(row.revision === undefined ? {} : { revision: row.revision }),
   };
 }
 
@@ -282,6 +289,7 @@ function createTableRecordStore(db: Db, config: RoutedConfig): RecordStore {
         ...(hasMore && last ? { cursor: encodeCursor(last.createdAt, last.id) } : {}),
       };
     },
+    ...(config.atomic === undefined ? {} : { atomic: config.atomic }),
   };
 }
 
@@ -406,6 +414,7 @@ function configFor(store: VendoStore, db: Db, collection: ReservedCollection): R
               ...(data.title === undefined ? {} : { title: data.title }),
               createdAt: prior?.createdAt ?? now,
               updatedAt: now,
+              revision: String(BigInt(prior?.revision ?? "0") + 1n),
             };
             overlay.threads.set(record.id, snapshot(row));
           } else {
@@ -414,6 +423,77 @@ function configFor(store: VendoStore, db: Db, collection: ReservedCollection): R
           return threadRecord(row);
         },
         deleteOverlay: (id) => overlay.threads.delete(id),
+        // ENG-310: guarded writes (01 §12) backed by the vendo_threads revision
+        // counter, so a concurrent-turn persist can read-merge-write without
+        // last-write-wins clobbering. Both verbs keep the same cross-subject
+        // refusal as put: a foreign-subject write NEVER lands (it just loses —
+        // insertIfAbsent finds the id taken, compareAndSwap's guarded WHERE /
+        // overlay subject check fails — and returns null).
+        atomic: {
+          async insertIfAbsent(record) {
+            requireRecordId(record.id);
+            const data = parseThreadData(record.data, record.id);
+            const now = new Date().toISOString();
+            if (isEphemeralSubject(store, data.subject)) {
+              if (overlay.threads.has(record.id)) return null;
+              const row: ThreadRow = {
+                id: record.id,
+                subject: data.subject,
+                messages: data.messages,
+                ...(data.title === undefined ? {} : { title: data.title }),
+                createdAt: now,
+                updatedAt: now,
+                revision: "1",
+              };
+              overlay.threads.set(record.id, snapshot(row));
+              return threadRecord(row);
+            }
+            const result = await db.query(
+              `INSERT INTO vendo_threads (id, subject, messages, title, created_at, updated_at, revision)
+               VALUES ($1, $2, $3::jsonb, $4, $5, $5, 1)
+               ON CONFLICT (id) DO NOTHING
+               RETURNING id, subject, messages, title, created_at, updated_at, revision`,
+              [record.id, data.subject, JSON.stringify(data.messages), data.title ?? null, now],
+            );
+            return result.rows[0]
+              ? threadRecord(threadFromRow(result.rows[0] as Record<string, unknown>))
+              : null;
+          },
+          async compareAndSwap(record, expectedRevision) {
+            requireRecordId(record.id);
+            requireRevision(expectedRevision);
+            const data = parseThreadData(record.data, record.id);
+            const now = new Date().toISOString();
+            if (isEphemeralSubject(store, data.subject)) {
+              const prior = overlay.threads.get(record.id);
+              if (prior === undefined || prior.subject !== data.subject
+                || prior.revision !== expectedRevision) {
+                return null;
+              }
+              const row: ThreadRow = {
+                id: record.id,
+                subject: data.subject,
+                messages: data.messages,
+                ...(data.title === undefined ? {} : { title: data.title }),
+                createdAt: prior.createdAt,
+                updatedAt: now,
+                revision: String(BigInt(expectedRevision) + 1n),
+              };
+              overlay.threads.set(record.id, snapshot(row));
+              return threadRecord(row);
+            }
+            const result = await db.query(
+              `UPDATE vendo_threads
+               SET messages = $3::jsonb, title = $4, updated_at = $5, revision = revision + 1
+               WHERE id = $1 AND subject = $2 AND revision = $6::bigint
+               RETURNING id, subject, messages, title, created_at, updated_at, revision`,
+              [record.id, data.subject, JSON.stringify(data.messages), data.title ?? null, now, expectedRevision],
+            );
+            return result.rows[0]
+              ? threadRecord(threadFromRow(result.rows[0] as Record<string, unknown>))
+              : null;
+          },
+        },
       };
     case "vendo_runs":
       return {

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -108,6 +108,11 @@ const ADDITIVE_DDL = [
   // Thread listing derives a title without loading the full messages array (routing.ts uses a
   // messages-less listSelect once a row has a stored title). NULLable; populated on next write.
   "ALTER TABLE vendo_threads ADD COLUMN IF NOT EXISTS title text",
+  // ENG-310: revision counter backing the routed vendo_threads atomic capability
+  // (01 §12 — insertIfAbsent / compareAndSwap), so concurrent turns on one thread
+  // can do guarded read-merge-write instead of last-write-wins. DEFAULT backfills
+  // existing rows on ALTER; every write path bumps it.
+  "ALTER TABLE vendo_threads ADD COLUMN IF NOT EXISTS revision bigint NOT NULL DEFAULT 1",
   // Secret rewrites (rotation) must count as activity for the erase-by-age axis
   // (02 §5): set() stamps it; NULL on legacy rows means created_at IS the last
   // write, so byAge reads COALESCE(updated_at, created_at).

--- a/packages/store/src/thread-scoping.test.ts
+++ b/packages/store/src/thread-scoping.test.ts
@@ -68,4 +68,108 @@ for (const backend of backends()) {
       expect(await threads.get(e2, "thr_overlay")).toBeNull();
     });
   });
+
+  describe(`${backend.name} vendo_threads guarded writes (ENG-310)`, () => {
+    let made: MadeBackend;
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    const threadData = (subject: string, text: string): { subject: string; messages: unknown[] } => ({
+      subject,
+      messages: [{ role: "user", text }],
+    });
+
+    it("exposes atomic on the routed seam: one insert winner, revision-guarded swaps", async () => {
+      const seam = made.store.records("vendo_threads");
+      expect(seam.atomic).toBeDefined();
+
+      // Exactly one concurrent first-persist lands; the loser gets null.
+      const [first, second] = await Promise.all([
+        seam.atomic!.insertIfAbsent({ id: "thr_cas", data: threadData(u1.subject, "one") }),
+        seam.atomic!.insertIfAbsent({ id: "thr_cas", data: threadData(u1.subject, "two") }),
+      ]);
+      const winners = [first, second].filter((record) => record !== null);
+      expect(winners).toHaveLength(1);
+      expect(winners[0]!.revision).toBe("1");
+
+      // Only the CURRENT revision swaps — and exactly one concurrent swapper wins.
+      const revision = winners[0]!.revision!;
+      const swaps = await Promise.all([
+        seam.atomic!.compareAndSwap({ id: "thr_cas", data: threadData(u1.subject, "swap a") }, revision),
+        seam.atomic!.compareAndSwap({ id: "thr_cas", data: threadData(u1.subject, "swap b") }, revision),
+      ]);
+      expect(swaps.filter((record) => record !== null)).toHaveLength(1);
+      const surviving = swaps[0] !== null ? "swap a" : "swap b";
+      expect((await seam.get("thr_cas"))?.data).toMatchObject({
+        messages: [{ role: "user", text: surviving }],
+      });
+      // The stale token keeps losing.
+      expect(await seam.atomic!.compareAndSwap(
+        { id: "thr_cas", data: threadData(u1.subject, "stale") },
+        revision,
+      )).toBeNull();
+      // A malformed token is refused outright, not treated as a miss.
+      await expect(seam.atomic!.compareAndSwap(
+        { id: "thr_cas", data: threadData(u1.subject, "junk token") },
+        "not-a-revision",
+      )).rejects.toMatchObject<VendoError>({ code: "validation" });
+      // Plain put still bumps the counter, so a pre-put token can no longer swap.
+      const bumped = await seam.put({ id: "thr_cas", data: threadData(u1.subject, "via put") });
+      expect(BigInt(bumped.revision!)).toBeGreaterThan(BigInt(revision));
+    });
+
+    it("a foreign subject can never land a guarded write, even with the current revision", async () => {
+      const seam = made.store.records("vendo_threads");
+      const mine = await seam.put({ id: "thr_cas_foreign", data: threadData(u1.subject, "mine") });
+
+      // insertIfAbsent: the id is taken → null, no takeover.
+      expect(await seam.atomic!.insertIfAbsent({
+        id: "thr_cas_foreign",
+        data: threadData(u2.subject, "steal by insert"),
+      })).toBeNull();
+      // compareAndSwap with the RIGHT revision but the WRONG subject → null, row intact.
+      expect(await seam.atomic!.compareAndSwap(
+        { id: "thr_cas_foreign", data: threadData(u2.subject, "steal by swap") },
+        mine.revision!,
+      )).toBeNull();
+      expect(await made.sql("SELECT subject, messages FROM vendo_threads WHERE id = 'thr_cas_foreign'"))
+        .toEqual([{ subject: u1.subject, messages: [{ role: "user", text: "mine" }] }]);
+    });
+
+    it("guards the ephemeral overlay path the same way", async () => {
+      const eSubject = "sess_cas";
+      registerEphemeralSubject(made.store, eSubject);
+      const seam = made.store.records("vendo_threads");
+
+      const inserted = await seam.atomic!.insertIfAbsent({
+        id: "thr_cas_overlay",
+        data: threadData(eSubject, "overlay one"),
+      });
+      expect(inserted).not.toBeNull();
+      expect(inserted!.revision).toBe("1");
+      expect(await seam.atomic!.insertIfAbsent({
+        id: "thr_cas_overlay",
+        data: threadData(eSubject, "overlay dupe"),
+      })).toBeNull();
+
+      const swapped = await seam.atomic!.compareAndSwap(
+        { id: "thr_cas_overlay", data: threadData(eSubject, "overlay two") },
+        "1",
+      );
+      expect(swapped).not.toBeNull();
+      expect(swapped!.revision).toBe("2");
+      expect(await seam.atomic!.compareAndSwap(
+        { id: "thr_cas_overlay", data: threadData(eSubject, "overlay stale") },
+        "1",
+      )).toBeNull();
+
+      // Nothing hit disk: the overlay owns the row.
+      expect(Number((await made.sql(
+        "SELECT COUNT(*)::int AS count FROM vendo_threads WHERE id = 'thr_cas_overlay'",
+      ))[0]?.["count"])).toBe(0);
+    });
+  });
 }


### PR DESCRIPTION
> **STACKED on #263 (ENG-309).** Base branch is `yousef/eng-309-silent-thread-loss-persist-failure-after-completed-stream-is`; ENG-309 head SHA is `bc8cda762646b1e51075d35bddac378bb599e428`. After #263 squash-merges, `git rebase --onto main bc8cda762646b1e51075d35bddac378bb599e428` this branch and retarget to `main`.

## What

Fixes AGENT-9 (handed off from block-foundations as a verified finding): `ThreadRepository.persist()` was a bare `put({id, data, refs})` with no version/CAS. Two simultaneous `stream()` calls on one threadId each mutate their own copy of the history and last-write-wins clobbers the other turn's messages. The guarded upsert in `resolve()` covers cross-subject takeover only, not same-subject races. Two tabs on one thread remain possible even after queue-send (ENG-215, separate lane), so this closes the race at the persist seam.

## Mechanism (store primitives checked first, as directed)

- **What the store layer allows today:** the FROZEN contract (01 §12) already reserves the optional `RecordStore.atomic` capability — `insertIfAbsent` + `compareAndSwap` over an opaque `revision` token ("revision?: opaque token when RecordStore.atomic is present"). The generic `vendo_records` path and the core conformance memory adapter both implement it; the routed reserved `vendo_threads` door did **not** (get/put/delete/list only, no revision).
- **Store (additive, no contract change):** the routed `vendo_threads` door now implements `atomic`, backed by a new `revision bigint NOT NULL DEFAULT 1` column (`ADD COLUMN IF NOT EXISTS` — same additive migration pattern as the thread `title` column; DEFAULT backfills existing rows). Implemented on both the SQL and the ephemeral overlay paths, preserving put's cross-subject refusal: a foreign-subject guarded write never lands (CAS's `WHERE subject = …` / overlay subject check → `null`). `putThreadRow`, the routed put's overlay branch, and the typed `threadStore` door all bump and carry the revision so every thread door agrees.
- **Agent:** `persist()` is now **read-merge-guarded-write with bounded retry** (5 attempts): re-read the current row, merge this turn's messages into the CURRENT history (upsert by message id — the same identity rule as the in-stream `upsertMessage`), then `insertIfAbsent` (first turn) or `compareAndSwap` on the freshly-read revision. A losing writer re-reads and re-merges, so **both turns' messages survive**; exhaustion throws a structured conflict which ENG-309's retry + loud-error path surfaces. Memory mode merges synchronously against the current map entry (atomic in JS). Adapters without `atomic` fall back to the merged put — the race window shrinks from a whole streaming turn to a single read-write, and the door's subject guard still refuses takeovers.

## Tests

- `packages/agent/src/threads.test.ts` — new describe "concurrent turns on one thread (ENG-310 / AGENT-9)": two overlapping `stream()` calls (`Promise.all`) on one threadId, for a fresh thread and for an existing thread with prior history; both turns' user messages and replies must survive, one row, no fork. **Red on unfixed code** (evidence: `docs/verification/eng-310/01-red-unfixed.txt`, green: `02-green-agent.txt`).
- `packages/store/src/thread-scoping.test.ts` — new describe "vendo_threads guarded writes (ENG-310)": exactly one concurrent `insertIfAbsent` winner, exactly one concurrent `compareAndSwap` winner per revision, stale/malformed tokens refused, plain put bumps the counter, foreign subject can never land a guarded write even with the current revision, and the ephemeral overlay path behaves identically (`03-green-store-cas.txt`).

## Gate

`pnpm build` ✓ · `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm test`: agent 43 passed/4 skipped, store 179 passed/1 skipped; only failures are pre-existing paths-with-spaces environmental ones in this worktree ("Cool Code" contains a space): `@vendoai/core` `packaging.e2e.test.ts` (sanctioned ignore) and `@vendoai/store` `durability.drill.test.ts` (same class — `MODULE_NOT_FOUND` on a `%20`-encoded fixture URL before any store code loads; file untouched by this diff, passes in CI where paths have no spaces).

No visual surface and no user-visible wire behavior change (the added `revision` on vendo_threads records is the contract's own optional additive capability) — per UI law, committed test evidence instead of screenshots.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the lost-update race so two concurrent stream turns on the same thread no longer clobber each other’s messages. Adds a guarded, versioned persist path with merge-by-id and CAS on `vendo_threads`, aligning with Linear ENG-310.

- **Bug Fixes**
  - Agent (`packages/agent/src/threads.ts`): `persist()` now does read-merge-guarded-write with up to 5 retries. Merges messages by id, then uses `insertIfAbsent` or `compareAndSwap` when available; memory mode merges atomically; non-atomic adapters fall back to a merged `put`. Title is freshly derived and `updatedAt` is bumped on write.
  - Store (`packages/store`): Routed `vendo_threads` now exposes optional `atomic` backed by a `revision` counter. Implements `insertIfAbsent`/`compareAndSwap` for SQL and the ephemeral overlay, preserving cross-subject write refusal. `get`/`put` carry and bump `revision`; projections include `revision` when present. Adds tests for concurrent turns and guarded writes; agent assertions poll with `vi.waitFor`. Verification logs added under `docs/verification/eng-310`.

- **Migration**
  - Schema adds `revision bigint NOT NULL DEFAULT 1` to `vendo_threads` (additive). Applied via `ensureSchema()`.

<sup>Written for commit c56801806a0251e239a75dcdd488ca30fcf8cc31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

