### PR TITLE
docs(contracts): block-actions wave amendments — presets, connected accounts, loud invalidation, blast radius, orgs (ENG-264)

### DIFF
--- a/docs/contracts/00-overview.md
+++ b/docs/contracts/00-overview.md
@@ -120,6 +120,12 @@ Approved with the contracts (Yousef, 2026-07-11): the blocks are built as if fro
 - **Why:** MCP was built and contracted in wave 6 of v0. `02-store.md` was updated at the time, but this overview and `01-core.md` / `03-agent.md` were not.
 - **Approved by:** Yousef, 2026-07-14.
 
+### 2026-07-15 — Block-actions wave (ENG-260/261/262/263, parent ENG-264)
+
+- **Changed:** One coordinated amendment set across 01-core, 02-store, 04-actions, 05-guard, 08-ui, 09-vendo, and 10-mcp — actAs presets + trust model, per-user connected accounts (`connect-required`), loud grant invalidation, blast-radius sync completion, real org principals + org tables (key-gated), the `vendo:` reserved subject namespace, and anonymous→signed-in migration. Each doc's own Amendments section carries the detail.
+- **Why:** The block-actions project ("everything extraction isn't") implemented the actions vision beyond extraction; the spec supersedes the frozen text where they conflicted, and this set re-aligns the contracts. All changes are additive within the version train.
+- **Approved by:** design locked by Yousef 2026-07-14 (block-actions spec); ENG-263-derived entries land with that PR.
+
 ### 2026-07-15 — tRPC binding kind added to vendo/tools@1
 
 - **Changed:** `04-actions.md` §1/§2/§4 — additive `trpc` binding kind (`procedure`/`type`/`mount`/`transformer?`), the extractor seam registration list (OpenAPI → tRPC → route-scan, with mount shadowing), tRPC static-extraction and fail-closed risk rules, the tRPC HTTP envelope execution semantics, and the binding-kind-aware tool-identity note (method+path for HTTP bindings, mount+procedure for tRPC).

--- a/docs/contracts/00-overview.md
+++ b/docs/contracts/00-overview.md
@@ -120,14 +120,14 @@ Approved with the contracts (Yousef, 2026-07-11): the blocks are built as if fro
 - **Why:** MCP was built and contracted in wave 6 of v0. `02-store.md` was updated at the time, but this overview and `01-core.md` / `03-agent.md` were not.
 - **Approved by:** Yousef, 2026-07-14.
 
-### 2026-07-15 — Block-actions wave (ENG-260/261/262/263, parent ENG-264)
-
-- **Changed:** One coordinated amendment set across 01-core, 02-store, 04-actions, 05-guard, 08-ui, 09-vendo, and 10-mcp — actAs presets + trust model, per-user connected accounts (`connect-required`), loud grant invalidation, blast-radius sync completion, real org principals + org tables (key-gated), the `vendo:` reserved subject namespace, and anonymous→signed-in migration. Each doc's own Amendments section carries the detail.
-- **Why:** The block-actions project ("everything extraction isn't") implemented the actions vision beyond extraction; the spec supersedes the frozen text where they conflicted, and this set re-aligns the contracts. All changes are additive within the version train.
-- **Approved by:** design locked by Yousef 2026-07-14 (block-actions spec); ENG-263-derived entries land with that PR.
-
 ### 2026-07-15 — tRPC binding kind added to vendo/tools@1
 
 - **Changed:** `04-actions.md` §1/§2/§4 — additive `trpc` binding kind (`procedure`/`type`/`mount`/`transformer?`), the extractor seam registration list (OpenAPI → tRPC → route-scan, with mount shadowing), tRPC static-extraction and fail-closed risk rules, the tRPC HTTP envelope execution semantics, and the binding-kind-aware tool-identity note (method+path for HTTP bindings, mount+procedure for tRPC).
 - **Why:** ENG-246 (extraction-survives-real-apps M1) ships the tRPC extractor; the binding kind is additive within `vendo/tools@1` per the discriminated-union evolution rule — existing consumers ignore unknown kinds.
 - **Approved by:** awaiting Yousef's personal sign-off (PR stays draft until then).
+
+### 2026-07-15 — Block-actions wave (ENG-260/261/262/263, parent ENG-264)
+
+- **Changed:** One coordinated amendment set across 01-core, 02-store, 04-actions, 05-guard, 08-ui, 09-vendo, and 10-mcp — actAs presets + trust model, per-user connected accounts (`connect-required`), loud grant invalidation, blast-radius sync completion, real org principals + org tables (key-gated), the `vendo:` reserved subject namespace, and anonymous→signed-in migration. Each doc's own Amendments section carries the detail.
+- **Why:** The block-actions project ("everything extraction isn't") implemented the actions vision beyond extraction; the spec supersedes the frozen text where they conflicted, and this set re-aligns the contracts. All changes are additive within the version train.
+- **Approved by:** design locked by Yousef 2026-07-14 (block-actions spec); ENG-263-derived entries land with that PR.

--- a/docs/contracts/01-core.md
+++ b/docs/contracts/01-core.md
@@ -554,6 +554,12 @@ Persistence and transport are normative:
 - **Why:** Post-freeze MCP work and sibling usage had expanded the real surface without updating this contract, and the host-side tree size responsibility was only pinned in a test.
 - **Approved by:** Yousef, 2026-07-14.
 
+### 2026-07-14 — Atomic record claims
+
+- **Changed:** Added optional `RecordStore.claim(expected, replacement?)` as the core seam for one-statement compare-and-replace or compare-and-delete adapters.
+- **Why:** Store consumers that require single-use state need an additive capability they can require without importing the concrete store block.
+- **Approved by:** Yousef, 2026-07-14.
+
 ### 2026-07-15 — Block-actions wave (ENG-260/261/262/263, parent ENG-264)
 
 - **Changed:** `ToolOutcome` gains the additive `connect-required` variant with its `ConnectRequired` shape; `VendoConnectPart` (`data-vendo-connect`) joins the stream parts (ENG-262, landed).
@@ -563,9 +569,3 @@ Persistence and transport are normative:
 - **Changed:** §2 makes `kind: "org"` principals real (key-gated activation, Vendo-minted only) and reserves the `vendo:` subject namespace against host resolvers; the anonymous→signed-in migration note points at 02 §4. **Ships with ENG-263 — merge of this amendment waits for that PR.**
 - **Why:** The block-actions project implements execute-as-the-user beyond extraction: per-user connected accounts, loud invalidation, real principals. All additive within the version train (discriminated unions, optional fields — §15).
 - **Authorized by:** the Yousef-approved block-actions design spec (`docs/superpowers/specs/2026-07-14-block-actions-design.md`).
-
-### 2026-07-14 — Atomic record claims
-
-- **Changed:** Added optional `RecordStore.claim(expected, replacement?)` as the core seam for one-statement compare-and-replace or compare-and-delete adapters.
-- **Why:** Store consumers that require single-use state need an additive capability they can require without importing the concrete store block.
-- **Approved by:** Yousef, 2026-07-14.

--- a/docs/contracts/01-core.md
+++ b/docs/contracts/01-core.md
@@ -28,14 +28,16 @@ export type JsonSchema = Record<string, unknown>; // JSON Schema draft 2020-12
 
 ## 2. Principals
 
-Who the agent is acting as. Host-minted; the host resolves its own session to a principal (09 §2). `kind: "org"` is reserved for Cloud.
+Who the agent is acting as. Host-minted for users; the host resolves its own session to a principal (09 §2). `kind: "org"` principals are real (ENG-263, block-actions spec §C): the full org machinery ships OSS, activation is key-gated per the Cloud line (00 conventions) — without `VENDO_API_KEY` entitlement, org surfaces return `cloud-required`. Org principals are minted only by Vendo's own org machinery over the org tables (02 §2); host principal resolvers mint `kind: "user"` only.
+
+**Reserved subjects (normative, ENG-263):** the `vendo:` subject prefix belongs to Vendo-synthetic principals — webhook firings run as `vendo:webhook:<source>` — and a host principal resolver returning a `vendo:`-prefixed subject is a validation error, never honored. This closes the collision between synthetic subjects and real users.
 
 ```ts
 export interface Principal {
-  kind: "user";              // "org" reserved (Cloud)
+  kind: "user" | "org";      // "org": real since ENG-263 — key-gated activation, Vendo-minted only
   subject: string;           // host's stable user id — or a generated session id when anonymous
   display?: string;          // for approval UIs and audit
-  ephemeral?: boolean;       // anonymous mode: session-scoped, nothing persists past the session
+  ephemeral?: boolean;       // anonymous mode: session-scoped; on sign-in, threads/apps/state migrate to the real subject (02 §4) — grants/approvals never do
 }
 ```
 
@@ -94,11 +96,15 @@ export interface ToolCall {
   args: Json;
 }
 
+/** A connector call needs a per-user connected account (04 §3.1). */
+export interface ConnectRequired { connector: string; toolkit: string; message: string }
+
 export type ToolOutcome =
   | { status: "ok"; output: Json }
   | { status: "error"; error: { code: string; message: string } }
   | { status: "pending-approval"; approvalId: ApprovalId }   // fail-soft: queued for the user
-  | { status: "blocked"; reason: string };
+  | { status: "blocked"; reason: string }
+  | { status: "connect-required"; connect: ConnectRequired };  // fail-soft: the UI renders an inline connect card, then retries (08 §4)
 
 /** The executable tool surface a block hands around. */
 export interface ToolRegistry {
@@ -144,6 +150,7 @@ export interface ApprovalRequest {
   call: ToolCall;
   descriptor: ToolDescriptor;   // frozen at ask time — what the user actually approved
   inputPreview: string;         // human-readable real inputs (the one-security-rule: ask with the real inputs)
+  invalidatedGrant?: { id: GrantId; grantedAt: IsoDateTime };  // set when descriptor drift lapsed a grant that would have covered this call — loud, never silent (05 §2)
   ctx: { principal: Principal; venue: RunContext["venue"]; presence: RunContext["presence"]; appId?: AppId; trigger?: TriggerRef };
   createdAt: IsoDateTime;
 }
@@ -201,6 +208,8 @@ export interface AuditEvent {
 ```
 
 The additive `door-auth` event originates in 10-mcp §3 and records successful door authorization.
+
+**Enriched `detail` (block-actions wave, normative):** `detail` stays `Json`, but three enrichments are contracted for it — exactly what guard console and insights consume (block-actions spec, cross-cutting). Connector executions carry `detail.connectorAccount: ConnectorAccountIdentity` (04 §3) — the binding lifts it off the outcome and strips it before the outcome reaches the model or UI. Grant invalidation emits a `policy-decision` event with `detail.reason: "grant-invalidated"` plus `grantIds`, `staleHash`, `currentHash` (05 §2). Present execution that forwards no credentials despite inbound auth headers emits `detail.warning: { code: "present-credentials-not-forwarded", reason, action }` once per process (04 §4). Org-context enrichment lands with ENG-263.
 
 ## 8. The instant-path UI payload (format-tagged; v0 format: the tree, `vendo-genui/v1`)
 
@@ -387,6 +396,12 @@ export type ActAs = (principal: Principal, grant: PermissionGrant) => Promise<Au
 
 export interface AuthMaterial { headers: Record<string, string>; }   // one channel — a bearer token is headers.Authorization; caching/expiry is the host's business
 
+// Impersonation guard (normative, block-actions wave): the actions runtime asserts
+// grant.subject === principal.subject BEFORE invoking actAs — a mismatch is the error
+// "act-as-subject-mismatch", never a mint (04 §4). Away re-verification rides this seam:
+// the host returning null declines the principal and the run fails closed — there is no
+// second verification seam (ENG-263). Shipped implementations: @vendoai/actions/presets (04 §2.1).
+
 /** Secret values by name. Default implementation reads env (02 §1). App code never sees values (06 §4.3). */
 export interface SecretsProvider { get(name: string): Promise<string | undefined>; }
 
@@ -461,7 +476,11 @@ Typed `data-*` parts riding the ai-SDK UI message stream (03 §4). Live here —
 
 ```ts
 export interface VendoViewPart { type: "data-vendo-view"; appId: AppId; payload: UIPayload }                    // a rendered app surface in-thread
-export interface VendoApprovalPart { type: "data-vendo-approval"; toolCallId: string; risk: RiskLabel; approvalId?: ApprovalId }  // receipt/approval metadata beside native tool parts
+export interface VendoApprovalPart {
+  type: "data-vendo-approval"; toolCallId: string; risk: RiskLabel; approvalId?: ApprovalId;
+  invalidatedGrant?: { id: GrantId; grantedAt: IsoDateTime };   // surfaces loud grant invalidation on the approval card (05 §2)
+}  // receipt/approval metadata beside native tool parts
+export interface VendoConnectPart { type: "data-vendo-connect"; toolCallId: string; connector: string; toolkit: string; message: string }  // rides beside the tool part when its outcome is connect-required; the UI renders the inline connect card (08 §4)
 ```
 
 ## 17. Capability-miss event (`vendo/capability-miss@1`)
@@ -534,6 +553,16 @@ Persistence and transport are normative:
 - **Changed:** Recorded that `Tree.data` and `TreeNode.props` size limits are delegated to host request-body enforcement.
 - **Why:** Post-freeze MCP work and sibling usage had expanded the real surface without updating this contract, and the host-side tree size responsibility was only pinned in a test.
 - **Approved by:** Yousef, 2026-07-14.
+
+### 2026-07-15 — Block-actions wave (ENG-260/261/262/263, parent ENG-264)
+
+- **Changed:** `ToolOutcome` gains the additive `connect-required` variant with its `ConnectRequired` shape; `VendoConnectPart` (`data-vendo-connect`) joins the stream parts (ENG-262, landed).
+- **Changed:** `ApprovalRequest` and `VendoApprovalPart` gain optional `invalidatedGrant` — descriptor-drift grant lapse is loud, never a bare re-prompt (ENG-261, landed).
+- **Changed:** §7 contracts the enriched audit `detail` fields: `connectorAccount`, `reason: "grant-invalidated"`, and the `present-credentials-not-forwarded` warning (landed); org context follows with ENG-263.
+- **Changed:** §13 records the impersonation guard at the actAs seam (`act-as-subject-mismatch`) and away re-verification failing closed on a null mint (ENG-260 landed; re-verification semantics ENG-263).
+- **Changed:** §2 makes `kind: "org"` principals real (key-gated activation, Vendo-minted only) and reserves the `vendo:` subject namespace against host resolvers; the anonymous→signed-in migration note points at 02 §4. **Ships with ENG-263 — merge of this amendment waits for that PR.**
+- **Why:** The block-actions project implements execute-as-the-user beyond extraction: per-user connected accounts, loud invalidation, real principals. All additive within the version train (discriminated unions, optional fields — §15).
+- **Authorized by:** the Yousef-approved block-actions design spec (`docs/superpowers/specs/2026-07-14-block-actions-design.md`).
 
 ### 2026-07-14 — Atomic record claims
 

--- a/docs/contracts/01-core.md
+++ b/docs/contracts/01-core.md
@@ -30,7 +30,7 @@ export type JsonSchema = Record<string, unknown>; // JSON Schema draft 2020-12
 
 Who the agent is acting as. Host-minted for users; the host resolves its own session to a principal (09 §2). `kind: "org"` principals are real (ENG-263, block-actions spec §C): the full org machinery ships OSS, activation is key-gated per the Cloud line (00 conventions) — without `VENDO_API_KEY` entitlement, org surfaces return `cloud-required`. Org principals are minted only by Vendo's own org machinery over the org tables (02 §2); host principal resolvers mint `kind: "user"` only.
 
-**Reserved subjects (normative, ENG-263):** the `vendo:` subject prefix belongs to Vendo-synthetic principals — webhook firings run as `vendo:webhook:<source>` — and a host principal resolver returning a `vendo:`-prefixed subject is a validation error, never honored. This closes the collision between synthetic subjects and real users.
+**Reserved subjects (normative, ENG-263):** the `vendo:` subject prefix belongs to Vendo-synthetic principals — webhook firings run as `vendo:webhook:<source>`, org principals as `vendo:org:<id>` — and a host principal resolver returning a `vendo:`-prefixed subject is a validation error, never honored. This closes the collision between synthetic subjects and real users.
 
 ```ts
 export interface Principal {
@@ -48,6 +48,7 @@ Attached to every tool call, guard decision, and audit event. The two axes the p
 ```ts
 export interface RunContext {
   principal: Principal;
+  actor?: Principal;             // the human behind an org request (ENG-263): principal is the org (vendo:org:<id>), actor is the member who initiated it — audit records both
   venue: "chat" | "app" | "automation" | "mcp";   // "mcp" is live — the door (10-mcp.md)  <!-- amended 2026-07-14: MCP door landed (PR #139); original froze pre-door and read "mcp reserved for the deferred door". The value is now live in code (run-context.ts:21,32). -->
 
   presence: "present" | "away";
@@ -192,7 +193,7 @@ Every tool call, approval, and policy decision — recorded with principal + app
 export interface AuditEvent {
   id: string;                    // "aud_..."
   at: IsoDateTime;
-  kind: "tool-call" | "approval" | "policy-decision" | "run" | "app-lifecycle" | "share" | "door-auth";  // "door-auth": an MCP-door OAuth/principal-mint event  <!-- amended 2026-07-14: "door-auth" added — MCP door landed (PR #139), code audit.ts:12,29. -->
+  kind: "tool-call" | "approval" | "policy-decision" | "run" | "app-lifecycle" | "share" | "door-auth" | "principal";  // "door-auth": MCP-door OAuth/principal-mint; "principal": principal-lifecycle event — anon→signed-in migration, org membership change (ENG-263)  <!-- amended 2026-07-14: "door-auth" added — MCP door landed (PR #139), code audit.ts:12,29. -->
 
   principal: Principal;
   venue: RunContext["venue"];
@@ -566,6 +567,6 @@ Persistence and transport are normative:
 - **Changed:** `ApprovalRequest` and `VendoApprovalPart` gain optional `invalidatedGrant` — descriptor-drift grant lapse is loud, never a bare re-prompt (ENG-261, landed).
 - **Changed:** §7 contracts the enriched audit `detail` fields: `connectorAccount`, `reason: "grant-invalidated"`, and the `present-credentials-not-forwarded` warning (landed); org context follows with ENG-263.
 - **Changed:** §13 records the impersonation guard at the actAs seam (`act-as-subject-mismatch`) and away re-verification failing closed on a null mint (ENG-260 landed; re-verification semantics ENG-263).
-- **Changed:** §2 makes `kind: "org"` principals real (key-gated activation, Vendo-minted only) and reserves the `vendo:` subject namespace against host resolvers; the anonymous→signed-in migration note points at 02 §4. **Ships with ENG-263 — merge of this amendment waits for that PR.**
+- **Changed:** §2 makes `kind: "org"` principals real (subjects `vendo:org:<id>`, key-gated activation, Vendo-minted only) and reserves the `vendo:` subject namespace against host resolvers; §3 adds optional `RunContext.actor` (the human member behind an org request); §7 adds `AuditEvent.kind: "principal"` (anon-migration + membership-change lifecycle events); the anonymous→signed-in migration note points at 02 §4. **Ships with ENG-263 (PR #277) — merge of this amendment waits for that PR.**
 - **Why:** The block-actions project implements execute-as-the-user beyond extraction: per-user connected accounts, loud invalidation, real principals. All additive within the version train (discriminated unions, optional fields — §15).
 - **Authorized by:** the Yousef-approved block-actions design spec (`docs/superpowers/specs/2026-07-14-block-actions-design.md`).

--- a/docs/contracts/02-store.md
+++ b/docs/contracts/02-store.md
@@ -53,10 +53,7 @@ The page makes this public: "everything lives in the host's own DB under a `vend
 | `vendo_secrets` | `name, ciphertext, created_at` | optional encrypted secret values (`storeSecrets`) |
 | `vendo_mcp_clients` | `id, data, refs, created_at, updated_at` | MCP client state (wave 6, additive — door-owned, shapes block-internal to `@vendoai/mcp`) |
 | `vendo_mcp_grants` | `id, data, refs, created_at, updated_at` | MCP grant state (wave 6, additive — door-owned, shapes block-internal to `@vendoai/mcp`) |
-| `vendo_orgs` | `id, name, created_at` | organizations (ENG-263, additive — real `kind:"org"` principals, 01 §2; key-gated activation) |
-| `vendo_org_members` | `org_id, subject, role, created_at` | org membership, roles `owner`/`admin`/`member` — members run, admins approve and manage (ENG-263, additive) |
-
-The two org tables ship with ENG-263 (block-actions spec §C); key-column names above are confirmed against that implementation before this amendment merges.
+Two org tables are contracted to join this map with ENG-263 (block-actions spec §C): `vendo_orgs` (organizations — real `kind:"org"` principals, 01 §2) and `vendo_org_members` (membership, roles `owner`/`admin`/`member` — members run, admins approve and manage). They are deliberately NOT rows in the map yet: the map is conformance-tested against the shipped erase cascade (§5), so the rows, their key columns, and the erase coverage land together with that implementation.
 
 Host-entity refs are the join surface: `SELECT ... FROM invoices i JOIN vendo_records r ON r.refs @> jsonb_build_object('invoice_id', i.id)` (containment, so the GIN index is actually used).
 
@@ -101,7 +98,7 @@ A store-level erase API is contracted here and ships in Wave 3. It erases by sub
 
 ### 2026-07-15 — Org tables and anonymous migration (ENG-263, parent ENG-264)
 
-- **Changed:** Added `vendo_orgs` + `vendo_org_members` to the public table map (roles owner/admin/member) — the Vendo-owned home of real org principals; activation key-gated (01 §2, 04 §5).
+- **Changed:** Contracted `vendo_orgs` + `vendo_org_members` (roles owner/admin/member) — the Vendo-owned home of real org principals; activation key-gated (01 §2, 04 §5). The table-map rows, key columns, and erase-cascade coverage (§5, conformance-tested) land together with the ENG-263 implementation.
 - **Changed:** Contracted the anonymous→signed-in migration semantics in §4: threads/apps/state migrate on first authenticated request with a valid anon cookie, idempotent, cookie cleared; grants, approvals, and connected accounts never migrate.
 - **Why:** The block-actions spec locks full org semantics in Vendo-owned tables and closes the silent loss of anonymous work on sign-in. **Ships with ENG-263 — merge of this amendment waits for that PR; key columns confirmed against the implementation at land time.**
 - **Authorized by:** the Yousef-approved block-actions design spec (`docs/superpowers/specs/2026-07-14-block-actions-design.md`).

--- a/docs/contracts/02-store.md
+++ b/docs/contracts/02-store.md
@@ -53,6 +53,7 @@ The page makes this public: "everything lives in the host's own DB under a `vend
 | `vendo_secrets` | `name, ciphertext, created_at` | optional encrypted secret values (`storeSecrets`) |
 | `vendo_mcp_clients` | `id, data, refs, created_at, updated_at` | MCP client state (wave 6, additive — door-owned, shapes block-internal to `@vendoai/mcp`) |
 | `vendo_mcp_grants` | `id, data, refs, created_at, updated_at` | MCP grant state (wave 6, additive — door-owned, shapes block-internal to `@vendoai/mcp`) |
+
 Two org tables are contracted to join this map with ENG-263 (block-actions spec §C): `vendo_orgs` (organizations — real `kind:"org"` principals, 01 §2) and `vendo_org_members` (membership, roles `owner`/`admin`/`member` — members run, admins approve and manage). They are deliberately NOT rows in the map yet: the map is conformance-tested against the shipped erase cascade (§5), so the rows, their key columns, and the erase coverage land together with that implementation.
 
 Host-entity refs are the join surface: `SELECT ... FROM invoices i JOIN vendo_records r ON r.refs @> jsonb_build_object('invoice_id', i.id)` (containment, so the GIN index is actually used).
@@ -96,13 +97,6 @@ A store-level erase API is contracted here and ships in Wave 3. It erases by sub
 
 ## Amendments
 
-### 2026-07-15 — Org tables and anonymous migration (ENG-263, parent ENG-264)
-
-- **Changed:** Contracted `vendo_orgs` + `vendo_org_members` (roles owner/admin/member) — the Vendo-owned home of real org principals; activation key-gated (01 §2, 04 §5). The table-map rows, key columns, and erase-cascade coverage (§5, conformance-tested) land together with the ENG-263 implementation.
-- **Changed:** Contracted the anonymous→signed-in migration semantics in §4: threads/apps/state migrate on first authenticated request with a valid anon cookie, idempotent, cookie cleared; grants, approvals, and connected accounts never migrate.
-- **Why:** The block-actions spec locks full org semantics in Vendo-owned tables and closes the silent loss of anonymous work on sign-in. **Ships with ENG-263 — merge of this amendment waits for that PR; key columns confirmed against the implementation at land time.**
-- **Authorized by:** the Yousef-approved block-actions design spec (`docs/superpowers/specs/2026-07-14-block-actions-design.md`).
-
 ### 2026-07-14 — Routed block persistence, erasure, and secure composition
 
 - **Changed:** Retired the typed-helper architecture and made reserved-collection routing through core's `StoreAdapter` the sanctioned cross-block persistence seam, including its trusted-backend boundary.
@@ -130,3 +124,10 @@ A store-level erase API is contracted here and ships in Wave 3. It erases by sub
 
 - **Changed:** Added the optional derived `trigger_kind` ref to `vendo_apps`, matching the ENG-254 routed-store index used by automations tick and emit queries.
 - **Approved by:** Yousef, 2026-07-14.
+
+### 2026-07-15 — Org tables and anonymous migration (ENG-263, parent ENG-264)
+
+- **Changed:** Contracted `vendo_orgs` + `vendo_org_members` (roles owner/admin/member) — the Vendo-owned home of real org principals; activation key-gated (01 §2, 04 §5). The table-map rows, key columns, and erase-cascade coverage (§5, conformance-tested) land together with the ENG-263 implementation.
+- **Changed:** Contracted the anonymous→signed-in migration semantics in §4: threads/apps/state migrate on first authenticated request with a valid anon cookie, idempotent, cookie cleared; grants, approvals, and connected accounts never migrate.
+- **Why:** The block-actions spec locks full org semantics in Vendo-owned tables and closes the silent loss of anonymous work on sign-in. **Ships with ENG-263 — merge of this amendment waits for that PR; key columns confirmed against the implementation at land time.**
+- **Authorized by:** the Yousef-approved block-actions design spec (`docs/superpowers/specs/2026-07-14-block-actions-design.md`).

--- a/docs/contracts/02-store.md
+++ b/docs/contracts/02-store.md
@@ -54,7 +54,7 @@ The page makes this public: "everything lives in the host's own DB under a `vend
 | `vendo_mcp_clients` | `id, data, refs, created_at, updated_at` | MCP client state (wave 6, additive — door-owned, shapes block-internal to `@vendoai/mcp`) |
 | `vendo_mcp_grants` | `id, data, refs, created_at, updated_at` | MCP grant state (wave 6, additive — door-owned, shapes block-internal to `@vendoai/mcp`) |
 
-Two org tables are contracted to join this map with ENG-263 (block-actions spec §C): `vendo_orgs` (organizations — real `kind:"org"` principals, 01 §2) and `vendo_org_members` (membership, roles `owner`/`admin`/`member` — members run, admins approve and manage). They are deliberately NOT rows in the map yet: the map is conformance-tested against the shipped erase cascade (§5), so the rows, their key columns, and the erase coverage land together with that implementation.
+The two org tables — `vendo_orgs` (organizations, real `kind:"org"` principals, 01 §2) and `vendo_org_members` (membership, roles `owner`/`admin`/`member` — members run, admins approve and manage) — are added to the map by the ENG-263 implementation (PR #277) together with their key columns and the erase-cascade coverage the map is conformance-tested against (§5). This PR carries the surrounding prose only; PR #277 owns the map rows and the §5 count so the conformance test and the doc land atomically.
 
 Host-entity refs are the join surface: `SELECT ... FROM invoices i JOIN vendo_records r ON r.refs @> jsonb_build_object('invoice_id', i.id)` (containment, so the GIN index is actually used).
 
@@ -127,7 +127,7 @@ A store-level erase API is contracted here and ships in Wave 3. It erases by sub
 
 ### 2026-07-15 — Org tables and anonymous migration (ENG-263, parent ENG-264)
 
-- **Changed:** Contracted `vendo_orgs` + `vendo_org_members` (roles owner/admin/member) — the Vendo-owned home of real org principals; activation key-gated (01 §2, 04 §5). The table-map rows, key columns, and erase-cascade coverage (§5, conformance-tested) land together with the ENG-263 implementation.
-- **Changed:** Contracted the anonymous→signed-in migration semantics in §4: threads/apps/state migrate on first authenticated request with a valid anon cookie, idempotent, cookie cleared; grants, approvals, and connected accounts never migrate.
-- **Why:** The block-actions spec locks full org semantics in Vendo-owned tables and closes the silent loss of anonymous work on sign-in. **Ships with ENG-263 — merge of this amendment waits for that PR; key columns confirmed against the implementation at land time.**
+- **Changed:** Described `vendo_orgs` + `vendo_org_members` (roles owner/admin/member) — the Vendo-owned home of real org principals; activation key-gated (01 §2, 04 §5). The actual §2 map rows (`vendo_orgs`: id, name, created_at, updated_at; `vendo_org_members`: org_id, subject, role, added_at, PK(org_id,subject), idx subject), the §5 count (13→15), and the erase-cascade coverage are added by PR #277 (ENG-263) so the doc and the conformance test land atomically. Erase rule (PR #277): erase-by-subject drops that subject's memberships; erasing `vendo:org:<id>` drops the org row plus all its members; full subject erasure overrides the last-owner invariant. Schema version advances to 3.
+- **Changed:** Contracted the anonymous→signed-in migration semantics in §4: threads/apps/state migrate on first authenticated request with a valid anon cookie, idempotent, cookie cleared; grants, approvals, and connected accounts never migrate (users reconnect).
+- **Why:** The block-actions spec locks full org semantics in Vendo-owned tables and closes the silent loss of anonymous work on sign-in. **This PR carries prose; the §2 rows + §5 count ship in PR #277. Land the two coherently — whichever merges second rebases.**
 - **Authorized by:** the Yousef-approved block-actions design spec (`docs/superpowers/specs/2026-07-14-block-actions-design.md`).

--- a/docs/contracts/02-store.md
+++ b/docs/contracts/02-store.md
@@ -53,6 +53,10 @@ The page makes this public: "everything lives in the host's own DB under a `vend
 | `vendo_secrets` | `name, ciphertext, created_at` | optional encrypted secret values (`storeSecrets`) |
 | `vendo_mcp_clients` | `id, data, refs, created_at, updated_at` | MCP client state (wave 6, additive — door-owned, shapes block-internal to `@vendoai/mcp`) |
 | `vendo_mcp_grants` | `id, data, refs, created_at, updated_at` | MCP grant state (wave 6, additive — door-owned, shapes block-internal to `@vendoai/mcp`) |
+| `vendo_orgs` | `id, name, created_at` | organizations (ENG-263, additive — real `kind:"org"` principals, 01 §2; key-gated activation) |
+| `vendo_org_members` | `org_id, subject, role, created_at` | org membership, roles `owner`/`admin`/`member` — members run, admins approve and manage (ENG-263, additive) |
+
+The two org tables ship with ENG-263 (block-actions spec §C); key-column names above are confirmed against that implementation before this amendment merges.
 
 Host-entity refs are the join surface: `SELECT ... FROM invoices i JOIN vendo_records r ON r.refs @> jsonb_build_object('invoice_id', i.id)` (containment, so the GIN index is actually used).
 
@@ -87,12 +91,20 @@ For non-reserved names, `records()` remains app data and collection names are ot
 - **Encryption at rest**: `encryption.key` encrypts `vendo_secrets.ciphertext` only (AES-256-GCM). App data stays plaintext by design — encrypting it would defeat the page's host-can-query/join promise; at-rest encryption of the database is the host's disk/DB layer. Default-on composition is contracted here and ships in Wave 3: `vendo init` provisions `VENDO_STORE_ENCRYPTION_KEY` in `.env`, `createVendo` reads it from the environment, and AES-GCM binds ciphertext to the secret name as AAD with envelope versioning. Key rotation: out of v0 scope.
 - **No tenant axis**: `subject` is the one partition key — the host's stable user id. Multi-tenant hosts scope the same way they scope their own tables: by joining through `subject` and refs.
 - **Ephemeral principals** (`ephemeral: true`) never touch disk: their rows live in an adapter-level, per-process in-memory overlay that is dropped by `close()`. Multi-instance deployments therefore split anonymous-session state between processes. A real session lifecycle is Wave 4 scope and will amend this section again when designed.
+- **Anonymous→signed-in migration** (ENG-263, block-actions spec §C — ships with that PR): the first authenticated request carrying a valid anon cookie migrates the anonymous principal's **threads, apps, and state** to the real subject, clears the cookie, and is idempotent. **Grants and approvals deliberately do NOT migrate** — consent doesn't transfer identities; users re-approve. Connected accounts (04 §3.1) are consent-like and do not migrate either — users reconnect. This is the designed session lifecycle the previous bullet reserved.
 
 ## 5. Retention and erasure
 
 A store-level erase API is contracted here and ships in Wave 3. It erases by subject (full erasure), by app, or by age, cascading the matching data across all 13 tables, and is exposed on the umbrella. It is the only sanctioned deletion path for audit rows. Policy engines and schedulers remain out of scope; host SQL remains available for everything else.
 
 ## Amendments
+
+### 2026-07-15 — Org tables and anonymous migration (ENG-263, parent ENG-264)
+
+- **Changed:** Added `vendo_orgs` + `vendo_org_members` to the public table map (roles owner/admin/member) — the Vendo-owned home of real org principals; activation key-gated (01 §2, 04 §5).
+- **Changed:** Contracted the anonymous→signed-in migration semantics in §4: threads/apps/state migrate on first authenticated request with a valid anon cookie, idempotent, cookie cleared; grants, approvals, and connected accounts never migrate.
+- **Why:** The block-actions spec locks full org semantics in Vendo-owned tables and closes the silent loss of anonymous work on sign-in. **Ships with ENG-263 — merge of this amendment waits for that PR; key columns confirmed against the implementation at land time.**
+- **Authorized by:** the Yousef-approved block-actions design spec (`docs/superpowers/specs/2026-07-14-block-actions-design.md`).
 
 ### 2026-07-14 — Routed block persistence, erasure, and secure composition
 

--- a/docs/contracts/03-agent.md
+++ b/docs/contracts/03-agent.md
@@ -62,7 +62,7 @@ export interface Thread { id: ThreadId; subject: string; messages: UIMessage[]; 
 export interface ThreadSummary { id: ThreadId; title: string; updatedAt: IsoDateTime; }
 ```
 
-Threads belong to a principal; `threads.*` never crosses subjects. Ephemeral principals get in-memory threads regardless of store.
+Threads belong to a principal; `threads.*` never crosses subjects. Ephemeral principals' threads live in the store's per-process in-memory overlay (02 §4) — not a separate agent-owned map — so anon→signed-in migration (02 §4) can move them to the real subject through one seam.
 
 ## Amendments
 
@@ -71,3 +71,9 @@ Threads belong to a principal; `threads.*` never crosses subjects. Ephemeral pri
 - **Changed:** Corrected the `ai` peer dependency contract to `>=6.0.0 <7`.
 - **Why:** Package manifests have always shipped on the v6 train; the contract document lagged behind them.
 - **Approved by:** Yousef, 2026-07-14.
+
+### 2026-07-15 — Ephemeral threads own their overlay in store (ENG-263, parent ENG-264)
+
+- **Changed:** §5 no longer says ephemeral principals get an agent-owned in-memory thread map; ephemeral threads live in the store's per-process overlay (02 §4), so anonymous→signed-in migration moves them through one seam.
+- **Why:** ENG-263's anon-merge relocated ephemeral-subject threads out of `packages/agent/src/threads.ts` into the store overlay; the frozen prose described the pre-merge path.
+- **Authorized by:** the Yousef-approved block-actions design spec (`docs/superpowers/specs/2026-07-14-block-actions-design.md`).

--- a/docs/contracts/04-actions.md
+++ b/docs/contracts/04-actions.md
@@ -264,7 +264,7 @@ A connector call failing on a missing per-user connection produces the typed `co
 
 ## 5. Principals
 
-`kind: "user"` everywhere, plus real `kind: "org"` principals (ENG-263): org-wide automations, admin actions, and org-shared surfaces run as an org subject. The machinery ships OSS in full (01 §2, 02 §2); **activation stays paid** — key-gated via the console's `/keys/validate` entitlement; without a key, org APIs return a posture error (`cloud-required`). Host principal resolvers still mint `kind: "user"` only and may never produce `vendo:`-prefixed subjects (01 §2). <!-- amended 2026-07-15: was "OSS: user only; org is Cloud" — the block-actions spec locks full org semantics in Vendo-owned tables with key-gated activation. -->
+`kind: "user"` everywhere, plus real `kind: "org"` principals (ENG-263): org-wide automations, admin actions, and org-shared surfaces run as an org subject (`vendo:org:<id>`), with the initiating member carried as `RunContext.actor` (01 §3). The machinery ships OSS in full (01 §2, 02 §2); **activation stays paid** — key-gated via the console's `/keys/validate` `orgs` capability (the `CAPABILITY_KEYS` set); without an entitled key, org APIs return a posture error (`cloud-required`). Host principal resolvers still mint `kind: "user"` only and may never produce `vendo:`-prefixed subjects (01 §2). <!-- amended 2026-07-15: was "OSS: user only; org is Cloud" — the block-actions spec locks full org semantics in Vendo-owned tables with key-gated activation. -->
 
 ## 6. Compound tools (normative)
 

--- a/docs/contracts/04-actions.md
+++ b/docs/contracts/04-actions.md
@@ -26,7 +26,12 @@ export interface BreakingChange {
   tool: string;
   change: "removed" | "input-narrowed" | "renamed";
 }
-// Blast radius ("which saved apps reference this tool") is a runtime query over vendo_apps, not a build-step concern.
+// Blast radius ("which saved apps reference this tool") stays a runtime concern — now specified:
+// the umbrella serves a dev-gated POST /sync/impact (09 §3) mapping each tool to the saved apps,
+// automations, and standing grants that reference it. `vendo sync` queries it when the dev server
+// is reachable and prints per-tool impact; unreachable → graceful "impact unknown" fallback.
+// --strict exits 2 on breaking extraction, 3 when a breaking tool also has nonzero blast radius;
+// --report pushes the report to the Cloud console with a key (fail-soft warn, never fatal). (ENG-261)
 ```
 
 Extraction tier: **OpenAPI + route-scan + tRPC** (corpus-proven; tRPC added additively within `vendo/tools@1`, 2026-07-15). GraphQL/server actions next — new extractors change no format below. Extractors sit behind one seam: a registration list of `{ detect, extract }` pairs inside `vendoSync`, run in order (OpenAPI, tRPC, route-scan); route tools under a tRPC mount are shadowed by the extracted procedures (the catch-all HTTP route is not a real API surface). Extraction is fail-closed: a route the scanner can't classify is emitted `disabled: true` with a note, never silently auto-allowed.
@@ -184,28 +189,82 @@ export interface ActionsRegistry extends ToolRegistry {
 
 The umbrella wires `invokeTool` to the guard binding (09 §2).
 
+## 2.1 actAs presets — `@vendoai/actions/presets` (ENG-260)
+
+The `ActAs` seam ships implementations, both tiers: preset code for the four first-class providers plus a generic JWT preset, and documented copy-paste recipes for the long tail. Provider SDKs are optional peer deps of the subpath only; dependency-guard layering holds. Token caching lives inside the preset closures until expiry; `AuthMaterial` stays `{ headers }` — no contract change.
+
+```ts
+export function authJsPreset(options?: { secret?: SecretSource; cookieName?: string; secureCookie?: boolean; claims?: ClaimsOption; expiresInSeconds?: number; cacheSafetySeconds?: number }): ActAs;   // mints an Auth.js v5 encrypted-session JWE; returns { headers: { cookie } }
+export function supabasePreset(options?: { secret?: SecretSource; audience?: string; role?: string; claims?: ClaimsOption; expiresInSeconds?: number; cacheSafetySeconds?: number }): ActAs;           // HS256 native access token (project JWT secret)
+export function genericJwtPreset(options: { secret?: SecretSource; claims?: ClaimsOption; jwtHeader?: Record<string, Json>; headers?: (token: string) => Record<string, string>; expiresInSeconds?: number; cacheSafetySeconds?: number }): ActAs;
+
+/** Where offline minting is impossible (Clerk, Auth0 — RS256, provider-held keys), the preset ships BOTH halves:
+ *  an actAs producer signing a short-lived Vendo away-token, plus a small verify-middleware the host mounts on its API. */
+export function clerkPreset(options?: AwayTokenPresetOptions): AwayTokenPreset;
+export function auth0Preset(options?: AwayTokenPresetOptions): AwayTokenPreset;
+
+export interface AwayTokenPreset {
+  actAs: ActAs;                                              // producer half: authorization: VendoAway <token>, JWT typ "vendo-away+jwt"
+  verify(tokenOrAuthorization: string): Promise<AwayTokenClaims>;
+  nextMiddleware(request: Request): Promise<Response>;       // verify half, Next.js flavor
+  expressMiddleware: ExpressAwayTokenMiddleware;             // verify half, Express flavor
+}
+export interface AwayTokenClaims { iss: string; aud: string; sub: string; provider: "clerk" | "auth0"; grantId: string; tool: string; iat: number; exp: number }
+```
+
+The away-token secret defaults to `VENDO_AWAY_TOKEN_SECRET`; the verifier stamps the trusted `x-vendo-away-subject/-provider/-grant/-tool` headers for the host route. A `ClaimsResolver` returning `null` declines the mint — actAs answers `null` and the run fails closed (01 §13).
+
 ## 3. Connectors — lean, we build zero
 
 ```ts
-export interface Connector { name: string; descriptors(): Promise<ToolDescriptor[]>; execute(call: ToolCall, ctx: RunContext): Promise<ToolOutcome>; }
+export interface Connector {
+  name: string;
+  descriptors(): Promise<ToolDescriptor[]>;
+  execute(call: ToolCall, ctx: RunContext): Promise<ToolOutcome>;
+  connections?: ConnectorConnections;    // per-user connected accounts (ENG-262) — subject-scoped, optional
+}
 
-export function composioConnector(config: { apiKey: string; entityId?: (ctx: RunContext) => string; apps?: string[] }): Connector;
-export function mcpConnector(config: { url: string; headers?: Record<string, string>; name?: string }): Connector;
+/** Per-user connected accounts. Every operation is scoped to one subject —
+ *  the umbrella passes only the resolved principal's subject, never caller input (09 §3). */
+export interface ConnectorConnections {
+  list(subject: string): Promise<ConnectorAccount[]>;
+  initiate(subject: string, toolkit: string, options?: { callbackUrl?: string }): Promise<{ id: string; redirectUrl: string }>;
+  status(subject: string, connectionId: string): Promise<ConnectorAccount | null>;   // null → not this subject's account (no oracle)
+  disconnect(subject: string, connectionId: string): Promise<void>;                  // ownership-checked before any delete leaves the process
+}
+export interface ConnectorAccount { id: string; connector: string; toolkit: string; status: "initiated" | "active" | "expired" | "failed"; createdAt?: IsoDateTime }
+
+/** Audit identity a connector execution attaches to its outcome; the guard binding lifts it
+ *  into AuditEvent.detail.connectorAccount and strips it from the outcome (01 §7, 05 §2). */
+export interface ConnectorAccountIdentity { connector: string; toolkit?: string; entityId?: string; accountId?: string; credential?: "per-principal" | "shared" }
+
+export function composioConnector(config: { apiKey: string; entityId?: (ctx: RunContext) => string; apps?: string[] }): Connector;   // entityId default: the principal's subject — Composio connected accounts are per-user; every read is subject-filtered
+export function mcpConnector(config: { url: string; headers?: Record<string, string> | McpHeadersResolver; name?: string }): Connector;
+
+/** Per-principal connector identity (ENG-262): static shared headers stay the simple default;
+ *  a resolver receives presence/grant context and vends per-user credentials. With a resolver,
+ *  MCP sessions are per-subject (LRU-bounded; evicted sessions re-initialize on next call). */
+export type McpHeadersResolver = (auth: { principal?: Principal; presence?: RunContext["presence"]; grant?: PermissionGrant }) => Record<string, string> | Promise<Record<string, string>>;
 ```
 
-Normalization rules: connector tool names are underscore-prefixed inside the provider-safe charset (core §4): `gmail_send`, `mcp_<server>_<tool>` (truncated + suffix-hashed past 64 chars); risk labels come from connector annotations when present, else default **`write`** (conservative), overridable in `overrides.json`; MCP tools are re-described through the same descriptor shape so guard sees no difference.
+Normalization rules: connector tool names are underscore-prefixed inside the provider-safe charset (core §4): `gmail_send`, `mcp_<server>_<tool>` (truncated + suffix-hashed past 64 chars); MCP tools are re-described through the same descriptor shape so guard sees no difference. Risk labels (ENG-262, replacing the hardcoded conservative default that never let destructive ops hit the forced-ask gate): connector annotations win when present — Composio's `destructiveHint` tag or any destructive verb token (delete/remove/destroy/purge/…) anywhere in the slug → `destructive`; `readOnlyHint` or a leading read verb (get/list/search/…) → `read`; everything else defaults **`write`** (conservative). `overrides.json` still wins field-wise.
+
+### 3.1 connect-required — the missing-connection outcome (ENG-262)
+
+A connector call failing on a missing per-user connection produces the typed `connect-required` outcome (01 §4), never a bare error: the UI renders an inline connect card beside the tool part (`data-vendo-connect`, 01 §16; chrome 08 §4), the user completes the broker's OAuth redirect, and the call retries. Composio is the sole broker — no home-grown OAuth flows. Cloud: with `VENDO_API_KEY` and no BYO connector, connections ride the Vendo Cloud broker endpoints (bearer-authed against `VENDO_CLOUD_URL`) using Vendo's Composio credentials — cloud users bring zero keys; BYO always wins; posture is reported as `blocks.connections: "byo" | "cloud" | false` (09 §3). Ephemeral and synthetic (`webhook:`/`vendo:`) subjects are refused at initiate.
 
 ## 4. Execution semantics (normative)
 
-- **Present** (`presence: "present"`): the call rides the user's real session. Server-side route execution forwards the inbound request's auth material (`ctx.requestHeaders` — cookies/authorization captured by the umbrella handler) on a same-origin fetch to `binding.path`. Zero config.
+- **Present** (`presence: "present"`): the call rides the user's real session. Server-side route execution forwards the inbound request's auth material (`ctx.requestHeaders` — cookies/authorization captured by the umbrella handler) on a same-origin fetch to `binding.path`. **Forwarding requires a trusted base URL** (ENG-260, closing the silent trap): the umbrella trusts `VENDO_BASE_URL` (or an explicit `baseUrl`); a learned wire origin is untrusted and forwards nothing. When present execution forwards nothing despite inbound auth headers, the runtime fires `onPresentCredentialsNotForwarded` (reason `untrusted-host-origin` | `cross-origin-binding`) and the umbrella emits one structured audit warning per process (`detail.warning.code: "present-credentials-not-forwarded"`, 01 §7). `vendo init` writes `VENDO_BASE_URL`; `vendo doctor` live-probes that credentials actually arrive (`/doctor/present`) and that actAs mint+verify round-trips (`/doctor/act-as`) (09 §5).
 - **tRPC bindings** execute over the tRPC HTTP envelope against the host mount: queries `GET {mount}/{procedure}?input=<json>`, mutations `POST {mount}/{procedure}` with the input as the JSON body; `{ result: { data } }` is unwrapped on success. Calls are always single-procedure — HTTP batching (`/p1,p2?batch=1`) is a client optimization the runtime never uses. When `transformer: "superjson"` is present (detected per mount) the input/output ride superjson's `{ json: ... }` wrapping. Auth semantics (present-forward, away/actAs, venue=mcp) are identical to route bindings.
-- **Away** (`presence: "away"`): requires a captured grant (the only authority) and the host's `actAs(principal, grant)` → `AuthMaterial` attached to the request. `actAs` not implemented → `ToolOutcome{status:"error", code:"not-implemented"}` with agent-readable messaging ("away execution isn't set up for this product") — features degrade cleanly, no stack detection, no adapter framework.
-- Connector calls use the connector's own auth (Composio entity, MCP session) but identical guard treatment.
+- **Away** (`presence: "away"`): requires a captured grant (the only authority) and the host's `actAs(principal, grant)` → `AuthMaterial` attached to the request. **The away-needs-present-grant rule is normative**: away runs hold only grants captured while the user was present and bound to the running app (05 §6) — there is no other away authority. **Impersonation guard**: the runtime asserts `grant.subject === ctx.principal.subject` before invoking `actAs`; a mismatch is the error `act-as-subject-mismatch`, never a mint. `actAs` not implemented → `ToolOutcome{status:"error", code:"not-implemented"}` with agent-readable messaging ("away execution isn't set up for this product") — features degrade cleanly. `actAs` → `null` → the host declined this principal; the run fails closed (away re-verification rides this seam — no second seam, ENG-263). Shipped presets cover the first-class providers (§2.1); the long tail uses documented recipes. <!-- amended 2026-07-15: "no stack detection, no adapter framework" dropped — presets now exist (ENG-260); the disclaimer described the pre-preset world. -->
+- **MCP as actAs**: `venue: "mcp"` host-call auth rides this same seam — the door never forwards its inbound bearer; it hands `actAs` the guard-attached real grant or a per-call consent projection (10-mcp §2.1). One seam, three consumers: away automations, the doctor probe, the door.
+- Connector calls use the connector's own auth (Composio per-user entity, MCP per-principal or shared session — §3) but identical guard treatment; the account identity used is auditable via `detail.connectorAccount` (01 §7).
 - actions itself never checks policy: it executes what a guard binding lets through (05 §2). It stamps nothing on the audit trail directly; the binding does.
 
 ## 5. Principals
 
-OSS: `kind: "user"` only. Org principals (org-wide automations, admin actions, org-shared connections) are Cloud; the shapes already accommodate them via `Principal.kind` and change nothing here.
+`kind: "user"` everywhere, plus real `kind: "org"` principals (ENG-263): org-wide automations, admin actions, and org-shared surfaces run as an org subject. The machinery ships OSS in full (01 §2, 02 §2); **activation stays paid** — key-gated via the console's `/keys/validate` entitlement; without a key, org APIs return a posture error (`cloud-required`). Host principal resolvers still mint `kind: "user"` only and may never produce `vendo:`-prefixed subjects (01 §2). <!-- amended 2026-07-15: was "OSS: user only; org is Cloud" — the block-actions spec locks full org semantics in Vendo-owned tables with key-gated activation. -->
 
 ## 6. Compound tools (normative)
 
@@ -214,3 +273,15 @@ A `compound` binding contains ordered steps that reuse core §11 `Step`. Its exp
 Steps reference primitive host or connector tools only: no `fn:` references, compounds, or capability tools. Execution routes every step through the guard-bound registry via the umbrella-wired `invokeTool` seam. Grants, approvals, breakers, scanners, and audit see every real call. There is no second execution path. When the seam is absent, execution returns `not-implemented` and performs no work.
 
 Approvals are per-step in v1. A step's parked outcome becomes the compound's outcome; re-executing the same logical call resumes without re-running completed steps. Batch approval is an explicit follow-up.
+
+## Amendments
+
+### 2026-07-15 — Block-actions wave (ENG-260/261/262/263, parent ENG-264)
+
+- **Changed:** §2.1 contracts the shipped `@vendoai/actions/presets` subpath — both tiers, four first-class providers plus generic JWT, away-token producer+verify halves for Clerk/Auth0 (ENG-260, landed).
+- **Changed:** §4 documents the trust model that was previously silent: `VENDO_BASE_URL` gates credential forwarding with a loud structured warning, the away-needs-present-grant rule is normative, the impersonation guard (`act-as-subject-mismatch`) is asserted at the seam, doctor live-probes both paths, and the "no adapter framework" disclaimer is dropped. MCP-as-actAs is cross-referenced (10-mcp §2.1).
+- **Changed:** §3 gains optional `Connector.connections` (subject-scoped connected accounts), `ConnectorAccountIdentity` audit enrichment, `McpHeadersResolver` per-principal identity, and hint-tag + curated-verb risk derivation replacing the hardcoded `write`; §3.1 contracts the `connect-required` flow and the Cloud zero-key broker posture (ENG-262, landed).
+- **Changed:** §1's blast-radius note now points at the shipped dev-gated `/sync/impact` endpoint, `--strict` exit codes 2/3, and `--report` (ENG-261, landed).
+- **Changed:** §5 makes org principals real with key-gated activation. **Ships with ENG-263 — merge of this amendment waits for that PR.**
+- **Why:** The actions block now implements its vision beyond extraction; the frozen text described the pre-wave world. All changes are additive within the version train.
+- **Authorized by:** the Yousef-approved block-actions design spec (`docs/superpowers/specs/2026-07-14-block-actions-design.md`).

--- a/docs/contracts/05-guard.md
+++ b/docs/contracts/05-guard.md
@@ -45,13 +45,13 @@ export interface VendoGuard extends Guard {
 
 ## 2. The choke point: `guard.bind(tools)` ⚑
 
-The one sanctioned path from a `ToolRegistry` to execution. `bind` wraps every `execute` with: decide → (maybe park) → execute → report. Chat (03), app function/tool proxying (06 §4), automation steps (07 §4), and the future MCP door all receive **bound** tool sets from the umbrella; nothing else in the system calls `ToolRegistry.execute`. This is how "binds every path equally" is made structural instead of aspirational.
+The one sanctioned path from a `ToolRegistry` to execution. `bind` wraps every `execute` with: decide → (maybe park) → execute → report. The report step performs audit enrichment (block-actions wave): a connector execution's `ConnectorAccountIdentity` passthrough (04 §3) is lifted into the audit event's `detail.connectorAccount` and **stripped from the outcome** — the model and UI never see it; the SIEM export does. Chat (03), app function/tool proxying (06 §4), automation steps (07 §4), and the future MCP door all receive **bound** tool sets from the umbrella; nothing else in the system calls `ToolRegistry.execute`. This is how "binds every path equally" is made structural instead of aspirational.
 
 Decision pipeline (normative order):
 
 1. **Critical** — `descriptor.critical` → `ask`, unsuppressible by grant, rule, or judge.
 2. **Scanners (input)** — a `block` finding blocks with the finding recorded.
-3. **Grant match** — an unrevoked, unexpired grant with matching `descriptorHash` and scope → `run`. `session`/`task` grants match only when their `contextKey` equals the current `ctx.sessionId` (task grants: the task's id) — that binding is what the durations mean.
+3. **Grant match** — an unrevoked, unexpired grant with matching `descriptorHash` and scope → `run`. `session`/`task` grants match only when their `contextKey` equals the current `ctx.sessionId` (task grants: the task's id) — that binding is what the durations mean. Grants never match across subjects: `grant.subject === ctx.principal.subject` is asserted here and again at the actAs seam (04 §4). **Loud invalidation (ENG-261):** when descriptor drift is the only reason a grant fails to match, the resulting `ask` is never silent — the `ApprovalRequest` (and its stream part) carries `invalidatedGrant` (01 §5), and one `policy-decision` audit event fires with `detail: { reason: "grant-invalidated", grantIds, tool, staleHash, currentHash }`.
 4. **Policy rules** — first matching rule in the data file → its action.
 5. **Code escape hatch** — if configured, may override with a decision or pass.
 6. **Judge** — if configured, decides `run | ask | block` with rationale. Judge errors/timeouts fail closed to `ask`.
@@ -125,3 +125,12 @@ Adapter surface for LLM Guard-style content scanners (prompt injection on inputs
 - Approvals and grants never transfer between users; grants key off `(subject, tool)` plus optional `appId` — never artifact contents (import mints fresh app ids, core §10).
 - Away runs hold only grants captured while the user was present **and bound to the running app** (`appId` match, 07 §3); chat-minted grants never authorize away execution. Everything else parks as `pending-approval`.
 - Artifacts and exports carry zero authority; there is no tools/permissions field anywhere in the app format.
+
+## Amendments
+
+### 2026-07-15 — Block-actions wave (ENG-261/262, parent ENG-264)
+
+- **Changed:** §2 contracts loud grant invalidation — descriptor-drift lapse attaches `invalidatedGrant` to the `ApprovalRequest` and emits a `policy-decision` audit event with `detail.reason: "grant-invalidated"` (ENG-261, landed) — and makes the cross-subject grant assertion explicit.
+- **Changed:** §2 contracts connector-account audit enrichment: `detail.connectorAccount` lifted at report time and stripped from the outcome (ENG-262, landed).
+- **Why:** Silent re-prompts hid policy-relevant drift, and guard console/insights need connector identity on every connector execution.
+- **Authorized by:** the Yousef-approved block-actions design spec (`docs/superpowers/specs/2026-07-14-block-actions-design.md`).

--- a/docs/contracts/08-ui.md
+++ b/docs/contracts/08-ui.md
@@ -36,6 +36,7 @@ useGrants()                 → { grants: PermissionGrant[]; revoke(id) }
 useApps()                   → { apps: AppDocument[]; create(prompt); remove(id); fork(id) }   // remove = AppsRuntime.delete (`delete` is unusable in destructuring)
 useApp(appId)           → { app, surface: OpenSurface, call(ref, args), edit(instruction), history: {list, undo}, refresh /* = re-open */ }
 useAutomations()            → { automations; enable(id); disable(id); runs(filter); dryRun(id); stopRun(runId) }
+useConnections()            → { connections: ConnectorAccount[]; refresh(); disconnect(id, connector?) }   // per-user connected accounts (04 §3); initiate rides the connect card / client.connections
 useActivity()               → { events, loadMore }                       // "what has the agent done as me"
 useVendoStatus()            → { posture, connected }                     // backs the no-policy notice + doctor
 useVoice()                  → { state, start, stop, transcript }         // WebRTC voice stage session
@@ -53,7 +54,9 @@ All hooks are transport-only (no styling, no portal assumptions) and SSR-safe.
 <VendoPage />            // full-page agent workspace (threads + apps + activity)
 <VendoPalette />         // ⌘K command palette — agent reachable from anywhere
 <VendoStage />           // voice
-<ApprovalCard />         // the one consent surface (used in-thread and in queues)
+<ApprovalCard />         // the one consent surface (used in-thread and in queues); renders the invalidated-grant notice when the request carries invalidatedGrant (01 §5, 05 §2)
+<ConnectCard />          // inline connect-required surface (04 §3.1): initiate → OAuth popup → poll active → automatic retry of the original call
+<ConnectedAccountsPanel /> // persistent connected-accounts list + disconnect, in VendoPage chrome settings
 <ActivityPanel />        // user-facing transparency
 <AutomationsPanel />     // list, enable/disable, run history, dry-run, kill switch
 <NoPolicyNotice />       // the loud default-posture banner (renders only when posture === "unconfigured")
@@ -85,6 +88,13 @@ export function TreeView(props: {
 The "no policy" default posture (05 §1) must be loud: chrome surfaces render `NoPolicyNotice` automatically; headless hosts get it via `useVendoStatus().posture` — leaving it out is a host's deliberate act.
 
 ## Amendments
+
+### 2026-07-15 — Connected accounts + loud invalidation surfaces (ENG-261/262, parent ENG-264)
+
+- **Changed:** §3 adds `useConnections()`; the typed client gains `client.connections` bindings for the umbrella's connection routes (09 §3).
+- **Changed:** §4 adds `<ConnectCard />` (in-flow connect-required → OAuth → automatic retry) and `<ConnectedAccountsPanel />`; `<ApprovalCard />` renders the invalidated-grant notice. All brand-native per the existing theme rules. Minimal org management chrome (create/invite/roles) follows with ENG-263.
+- **Why:** Per-user connected accounts and loud grant invalidation need first-class surfaces in both the headless and chrome tiers (ENG-262/261, landed).
+- **Authorized by:** the Yousef-approved block-actions design spec (`docs/superpowers/specs/2026-07-14-block-actions-design.md`).
 
 ### 2026-07-15 — In-client venue mount (06-apps §9) reconciled with §5
 

--- a/docs/contracts/08-ui.md
+++ b/docs/contracts/08-ui.md
@@ -36,7 +36,7 @@ useGrants()                 → { grants: PermissionGrant[]; revoke(id) }
 useApps()                   → { apps: AppDocument[]; create(prompt); remove(id); fork(id) }   // remove = AppsRuntime.delete (`delete` is unusable in destructuring)
 useApp(appId)           → { app, surface: OpenSurface, call(ref, args), edit(instruction), history: {list, undo}, refresh /* = re-open */ }
 useAutomations()            → { automations; enable(id); disable(id); runs(filter); dryRun(id); stopRun(runId) }
-useConnections()            → { connections: ConnectorAccount[]; refresh(); disconnect(id, connector?) }   // per-user connected accounts (04 §3); initiate rides the connect card / client.connections
+useConnections()            → { connections: ConnectionAccount[]; refresh(); disconnect(id, connector?) }  // per-user connected accounts; ConnectionAccount is a ui-owned WIRE type mirroring 04 §3's ConnectorAccount over the umbrella routes (09 §3) — ui still imports core only; initiate rides the connect card / client.connections
 useActivity()               → { events, loadMore }                       // "what has the agent done as me"
 useVendoStatus()            → { posture, connected }                     // backs the no-policy notice + doctor
 useVoice()                  → { state, start, stop, transcript }         // WebRTC voice stage session
@@ -89,12 +89,11 @@ The "no policy" default posture (05 §1) must be loud: chrome surfaces render `N
 
 ## Amendments
 
-### 2026-07-15 — Connected accounts + loud invalidation surfaces (ENG-261/262, parent ENG-264)
+### 2026-07-14 — Effective thread identity surfaced
 
-- **Changed:** §3 adds `useConnections()`; the typed client gains `client.connections` bindings for the umbrella's connection routes (09 §3).
-- **Changed:** §4 adds `<ConnectCard />` (in-flow connect-required → OAuth → automatic retry) and `<ConnectedAccountsPanel />`; `<ApprovalCard />` renders the invalidated-grant notice. All brand-native per the existing theme rules. Minimal org management chrome (create/invite/roles) follows with ENG-263.
-- **Why:** Per-user connected accounts and loud grant invalidation need first-class surfaces in both the headless and chrome tiers (ENG-262/261, landed).
-- **Authorized by:** the Yousef-approved block-actions design spec (`docs/superpowers/specs/2026-07-14-block-actions-design.md`).
+- **Changed:** Added the effective `threadId` to `useVendoThread`'s return value. A supplied id is exposed while it is validated, a stale id transitions to `undefined`, and a subsequent server-confirmed or server-minted id is exposed after a turn.
+- **Why:** Headless hosts need to observe stale-thread recovery and persist the effective server identity without issuing a noisy missing-thread detail request.
+- **Approved by:** Yousef, 2026-07-14.
 
 ### 2026-07-15 — In-client venue mount (06-apps §9) reconciled with §5
 
@@ -102,8 +101,9 @@ The "no policy" default posture (05 §1) must be loud: chrome surfaces render `N
 - **Why:** ENG-288 M4 ships the OSS enforcement half of the locked in-client split (apps-block design spec, 2026-07-14, decisions 1–2): approval record format, hash-pin verification, host-page mount, drop-back-to-iframe. Cloud owns the review console that mints approvals.
 - **Authorized by:** the Yousef-approved apps-block design spec (`docs/superpowers/specs/2026-07-14-apps-block-design.md`, locked decisions 1–2).
 
-### 2026-07-14 — Effective thread identity surfaced
+### 2026-07-15 — Connected accounts + loud invalidation surfaces (ENG-261/262, parent ENG-264)
 
-- **Changed:** Added the effective `threadId` to `useVendoThread`'s return value. A supplied id is exposed while it is validated, a stale id transitions to `undefined`, and a subsequent server-confirmed or server-minted id is exposed after a turn.
-- **Why:** Headless hosts need to observe stale-thread recovery and persist the effective server identity without issuing a noisy missing-thread detail request.
-- **Approved by:** Yousef, 2026-07-14.
+- **Changed:** §3 adds `useConnections()`; the typed client gains `client.connections` bindings for the umbrella's connection routes (09 §3). The hook's `ConnectionAccount` is a ui-owned wire type mirroring 04 §3's `ConnectorAccount` — ui keeps its core-only dependency rule (00 overview); the shape crosses as JSON over the wire, never as an actions import.
+- **Changed:** §4 adds `<ConnectCard />` (in-flow connect-required → OAuth → automatic retry) and `<ConnectedAccountsPanel />`; `<ApprovalCard />` renders the invalidated-grant notice. All brand-native per the existing theme rules. Minimal org management chrome (create/invite/roles) follows with ENG-263.
+- **Why:** Per-user connected accounts and loud grant invalidation need first-class surfaces in both the headless and chrome tiers (ENG-262/261, landed).
+- **Authorized by:** the Yousef-approved block-actions design spec (`docs/superpowers/specs/2026-07-14-block-actions-design.md`).

--- a/docs/contracts/09-vendo.md
+++ b/docs/contracts/09-vendo.md
@@ -80,7 +80,12 @@ Mounted under one base (default `/api/vendo`). Auth: every request passes throug
 | `/tick` | POST | scheduler tick (serverless cron target; requires `Authorization: Bearer <secret>` — what Vercel cron sends natively) |
 | `/webhooks/:source` | POST | trigger ingress (Composio, host, plain) — verified, see below |
 | `/activity` | GET | `AuditEvent[]` — `guard.audit.query({ principal })` self-scoped at this route |
-| `/status` | GET | `{ posture, version, blocks: {...} }` (doctor's live probe) |
+| `/status` | GET | `{ posture, version, blocks: {...} }` (doctor's live probe); `blocks.connections: "byo" \| "cloud" \| false` reports the connected-accounts posture (04 §3.1) |
+| `/connections` | GET | the resolved principal's `ConnectorAccount[]` (04 §3) — subject is never caller-supplied |
+| `/connections/initiate` | POST | `{ toolkit, connector?, callbackUrl? }` → `{ id, redirectUrl }` (the broker's OAuth URL); ephemeral and synthetic (`webhook:`/`vendo:`) subjects refused |
+| `/connections/:id` | GET · DELETE | `?connector=` — poll status (404 = not this subject's account, no oracle) · disconnect |
+| `/sync/impact` | POST | `{ tools: string[] }` (≤200) → `{ impact: ToolImpact[] }` — blast radius per tool (apps, automations, grants); **dev-only**: production → `blocked` (04 §1) |
+| `/doctor/present` · `/doctor/act-as` | POST | doctor's live probes (04 §4): present credentials actually reach the host API · actAs mint+verify round-trips (each with a `GET …/echo` loopback route) |
 | `/mcp` (+ subpaths) | ALL | MCP door mount (only when `createVendo({ mcp: true, oauth })`); the door owns these paths and authenticates every request through `oauth.principal` — NOT a wire route |
 
 <!-- amended 2026-07-14: MCP door landed (PR #139); original froze pre-door. The door mounts at `/api/vendo/mcp` (server.ts:33 `MCP_MOUNT`) and is handed its own paths BEFORE any wire machinery — ahead of the CSRF json-mutation gate — because it mints its own principals via `oauth.principal` and bypasses the wire's principal/CSRF machinery (server.ts:394-405). It also serves four origin-root discovery documents pre-auth (server.ts:158-169): `/.well-known/oauth-protected-resource/api/vendo/mcp`, `/.well-known/oauth-authorization-server/api/vendo/mcp` (RFC 9728/8414 path-inserted metadata for the mount), `/.well-known/mcp/server-card.json`, and `/.well-known/mcp-server-card` (SEP-2127 server card). Only these exact four are matched, not the whole `/.well-known/oauth-*` prefix, so a host serving its own OAuth/OIDC metadata at the same origin is not shadowed. -->
@@ -111,12 +116,21 @@ Rung-4 app UI is **not** proxied through the wire: `OpenSurface.kind === "http"`
 ## 5. The bin (DX, per the locked DX design)
 
 - **`vendo init`** — interactive wizard: scans the app (deterministic + AI riding the dev's existing Claude Code / Codex / API key), interviews with recommendations (risk labels, theme, remix candidates), writes the two wiring snippets (handler route + `<VendoRoot>`) — every code change permission-gated with the diff shown; answers land in `overrides.json`, respected forever. `--agent` mode: emits the plan, writes nothing, asks ≤3 plain-language questions (vibe-coder persona; `install.md` is the canonical staged playbook it follows).
-- **`vendo doctor`** — wiring checks + one live round-trip against `/status`; green = working agent; ends with ladder hints (the one config line that unlocks each remaining block).
-- **`vendo sync`** — the build-step extraction, callable manually (04 §1).
+- **`vendo doctor`** — wiring checks + one live round-trip against `/status`; green = working agent; ends with ladder hints (the one config line that unlocks each remaining block). Live probes (ENG-260): `POST /doctor/present` proves present credentials reach the host API (fail advises `VENDO_BASE_URL`); `POST /doctor/act-as` proves the actAs mint+verify round-trip (not configured → warn, not fail).
+- **`vendo sync`** — the build-step extraction, callable manually (04 §1). Queries `/sync/impact` when the dev server is reachable and prints per-tool blast radius; `--report` pushes the report to the Cloud console (requires `VENDO_API_KEY` or `--key`; push failure warns, never fails the build) (ENG-261).
 - **`vendo cloud <command>`** — talk to the public Vendo Cloud API (auth/session, keys, members, services, reads); the paid line's CLI surface (§6). <!-- amended 2026-07-14: `cloud` command landed post-freeze (cli.ts, cli/cloud/ tree); original froze with only init/doctor/sync. -->
 
-Exit codes: doctor `0` green / `1` broken wiring; sync `0` (fail-soft warns) / `2` with `--strict` on breaking changes.
+Exit codes: doctor `0` green / `1` broken wiring; sync `0` (fail-soft warns) / with `--strict`: `2` on breaking changes, `3` when a breaking tool also has nonzero blast radius (impact-unknown stays `2`). `vendo init` also writes `VENDO_BASE_URL` into `.env`/`.env.example` (04 §4) and scaffolds the `predev` (`vendo sync`) / `prebuild` (`vendo sync --strict`) hooks into the host package.json — permission-prompted, like route wiring (ENG-260/261).
 
 ## 6. Cloud enforcement
 
 `VENDO_API_KEY` present → cloud-gated surfaces (share/publish/org/pinning) verify entitlements against Cloud and light up; absent → those methods throw `VendoError("cloud-required")`. Paid code lives in the private cloud repo; this repo stays pure Apache-2.0.
+
+## Amendments
+
+### 2026-07-15 — Block-actions wave (ENG-260/261/262, parent ENG-264)
+
+- **Changed:** §3 adds the per-principal connection routes (`/connections`, `/connections/initiate`, `/connections/:id`), the dev-only `/sync/impact` blast-radius endpoint, the doctor probe routes, and the `blocks.connections` posture in `/status`.
+- **Changed:** §5 documents doctor's live probes, sync's impact query + `--report`, the 2/3 strict exit codes, and init writing `VENDO_BASE_URL` + predev/prebuild hooks.
+- **Why:** The silent-trap fixes (ENG-260), sync completion (ENG-261), and connected accounts (ENG-262) all landed umbrella surface; the frozen wire table predated them. All additive.
+- **Authorized by:** the Yousef-approved block-actions design spec (`docs/superpowers/specs/2026-07-14-block-actions-design.md`).

--- a/docs/contracts/10-mcp.md
+++ b/docs/contracts/10-mcp.md
@@ -40,7 +40,7 @@ The umbrella exposes it as the page's one flag — literally `createVendo({ mcp:
 
 ## 2. Door semantics (normative)
 
-- **Same perimeter**: every door tool call becomes a `ToolCall` executed through the guard-bound registry with `RunContext{ venue: "mcp", presence: "present", principal }` — risk labels, grants, approvals, audit, breakers all apply identically. A `pending-approval` outcome returns as a **tool result with `isError: true`** whose content names the approval and says to resolve it in-product (MCP tool *execution* errors are in-band, never JSON-RPC protocol errors — the model must see the message); `blocked` likewise with the guard's reason. Nothing is auto-elevated for being "just MCP".
+- **Same perimeter**: every door tool call becomes a `ToolCall` executed through the guard-bound registry with `RunContext{ venue: "mcp", presence: "present", principal }` — risk labels, grants, approvals, audit, breakers all apply identically. A `pending-approval` outcome returns as a **tool result with `isError: true`** whose content names the approval and says to resolve it in-product (MCP tool *execution* errors are in-band, never JSON-RPC protocol errors — the model must see the message); `blocked` likewise with the guard's reason. A `connect-required` outcome (01 §4, ENG-262) maps the same way: the door has no browser surface to run an OAuth redirect through, so the in-band error tells the user to connect the named toolkit account in the product and retry. Nothing is auto-elevated for being "just MCP".
 - **Principal**: minted by the OAuth layer (§3) — the door never trusts client-supplied identity. Anonymous/ephemeral principals are not served: an unauthenticated request gets `401` with the challenge header (§3), never a session.
 - **Tool surface**: `tools/list` = the bound registry's descriptors verbatim (names are already MCP-safe, `inputSchema` is already the MCP field). No door-specific renames, no second catalog.
 - **Default policy posture**: unchanged from guard's — but the shipped policy example (05 §3) blocks `venue: "mcp"`; `vendo init` asks before opening the door. Opening it is a host decision, never a default.
@@ -171,6 +171,12 @@ Hosted broker (Cloud), registry submission automation, MCP Apps write-back beyon
 Dual review applied before any build: **standards** (verified against MCP 2025-11-25, MCP Apps 2026-01-26, RFC 8707/9728/8414/7591, CIMD draft) — all 6 findings applied, the big two being resource/audience binding and the MCP Apps shim delivery model. **Simplification** — 5 of 7 applied (`HostOAuthAdapter` shrunk to two functions, door owns its own state via `StoreAdapter`, `isRevoked`/`ttl`/`serverInfo` deleted, `AppsPort` = structural subset of `AppsRuntime`); 2 declined with rationale: the server card stays (the page mandates discovery — "agent-reachability becomes distribution" — path corrected + marked provisional instead), and `guard` stays in config (the page mandates "same audit"; auth events belong in the SIEM export, not only in SQL).
 
 ## 9. Additive amendments
+
+### 2026-07-15 — connect-required over the door (ENG-262, parent ENG-264)
+
+- **Changed:** §2 maps the additive `connect-required` tool outcome to the door's in-band `isError` result, directing the user to connect the account in-product — same doctrine as `pending-approval`.
+- **Why:** Per-user connected accounts (04 §3.1) landed; an MCP client cannot host the broker's OAuth redirect.
+- **Authorized by:** the Yousef-approved block-actions design spec (`docs/superpowers/specs/2026-07-14-block-actions-design.md`).
 
 ### 2026-07-14 — RFC 7009 token revocation
 

--- a/docs/contracts/10-mcp.md
+++ b/docs/contracts/10-mcp.md
@@ -172,12 +172,6 @@ Dual review applied before any build: **standards** (verified against MCP 2025-1
 
 ## 9. Additive amendments
 
-### 2026-07-15 — connect-required over the door (ENG-262, parent ENG-264)
-
-- **Changed:** §2 maps the additive `connect-required` tool outcome to the door's in-band `isError` result, directing the user to connect the account in-product — same doctrine as `pending-approval`.
-- **Why:** Per-user connected accounts (04 §3.1) landed; an MCP client cannot host the broker's OAuth redirect.
-- **Authorized by:** the Yousef-approved block-actions design spec (`docs/superpowers/specs/2026-07-14-block-actions-design.md`).
-
 ### 2026-07-14 — RFC 7009 token revocation
 
 - **Changed:** Added local `{mount}/revoke` handling for access and refresh
@@ -210,3 +204,9 @@ Dual review applied before any build: **standards** (verified against MCP 2025-1
 - **Compatibility:** both changes are additive; `mcp: true`, `mcp: { baseUrl }`,
   and `authorize`-bearing adapters behave exactly as before.
 - **Approved by:** pending Yousef review (ENG-286 — flagged in the PR).
+
+### 2026-07-15 — connect-required over the door (ENG-262, parent ENG-264)
+
+- **Changed:** §2 maps the additive `connect-required` tool outcome to the door's in-band `isError` result, directing the user to connect the account in-product — same doctrine as `pending-approval`.
+- **Why:** Per-user connected accounts (04 §3.1) landed; an MCP client cannot host the broker's OAuth redirect.
+- **Authorized by:** the Yousef-approved block-actions design spec (`docs/superpowers/specs/2026-07-14-block-actions-design.md`).

--- a/docs/superpowers/specs/2026-07-14-block-actions-design.md
+++ b/docs/superpowers/specs/2026-07-14-block-actions-design.md
@@ -1,0 +1,172 @@
+# Block: @vendoai/actions — everything extraction isn't (design)
+
+Date: 2026-07-14. Approved by Yousef in the block-actions orchestrator brainstorm.
+Linear project: "Block: @vendoai/actions — everything extraction isn't" (ENG).
+
+This spec is the source of truth for the project. It supersedes the frozen
+contracts where they conflict; a contracts-amendment PR is part of the scope.
+Child sessions read this spec and do not re-litigate decisions recorded here.
+
+## Outcome
+
+The actions block fully implements its vision beyond extraction:
+execute-as-the-signed-in-user that actually forwards credentials, a complete
+actAs seam with per-auth-provider presets proven end-to-end (including away
+execution), per-user connected accounts for external connectors, real
+principals (anonymous upgrade, away re-verification, orgs), and sync that
+tells you what a change breaks before it breaks it.
+
+## Grounding (examination findings, 2026-07-14)
+
+Four code-reading agents examined main. Load-bearing facts:
+
+- The `ActAs` seam is defined, consumed by the away and MCP branches, and has
+  **zero implementations anywhere** — no preset, no demo wiring, no quickstart
+  example. Both demo hosts are present-only with fake fixed-user auth.
+- Present-mode credential forwarding is silently disabled unless the operator
+  sets `VENDO_BASE_URL`; away execution hard-requires a grant captured while
+  present. Neither rule is documented.
+- Composio and MCP connectors are **live and contract-named**, with guard
+  parity at the decision layer. But Composio hardcodes every tool to
+  `risk:"write"` (destructive ops never hit the forced-ask gate) and the MCP
+  connector sends one shared static credential for every principal.
+- `vendo sync` + `--strict` + a real breaking-change diff engine **exist**.
+  Missing: blast-radius (contract defers to a "runtime query over vendo_apps"
+  that was never built), any surfacing of silent grant invalidation
+  (descriptor hash changes silently unmatch grants → bare re-prompt), and
+  build-step scaffolding (init does not add predev/prebuild).
+- Principals: no anonymous→signed-in migration (work silently lost on
+  sign-in); away principals are rebuilt from a subject string with no
+  re-verification; `webhook:` synthetic subjects can collide with real ones;
+  no `grant.subject === ctx.principal.subject` check at the actAs seam;
+  `kind:"org"` reserved but unbuilt.
+
+## Framing decisions
+
+- **This brainstorm wins** over docs/contracts and the Notion vision page;
+  contracts get amended to match.
+- All remaining **sync work lives here** (extraction project keeps only
+  extraction quality).
+- Quality bar: real captured demos — both demo hosts, the MCP venue, at least
+  one live external connector, and an away-execution drill. Not just unit
+  tests.
+- Cloud alignment commitments (all four accepted): audit enrichment for guard
+  console/insights, zero-key connect behind VENDO_API_KEY, key-gated orgs,
+  blast-radius report pushable to the console.
+
+## A. actAs complete (wave 1)
+
+- New subpath `@vendoai/actions/presets` with **both tiers**: shipped preset
+  code for the four first-class providers — Auth.js/NextAuth, Clerk, Supabase
+  Auth, Auth0 — plus a generic JWT preset, and documented copy-paste recipes
+  for the long tail.
+- **Away works for all four.** Mechanism per provider: native user-token
+  minting with the host's own secrets where offline minting is possible
+  (Auth.js secret, Supabase project JWT secret); where it isn't (Auth0 RS256,
+  Clerk), the preset ships **both halves** — an actAs producer that signs a
+  short-lived Vendo away-token plus a small verify-middleware (Next and
+  Express flavors) the host mounts on its API.
+- Token caching lives inside preset closures until expiry. `AuthMaterial`
+  stays `{ headers }` — no contract change.
+- Provider SDKs are optional peer deps of the subpath only; dependency-guard
+  layering holds.
+- Demo conversions: Maple (demo-bank) → real Auth.js login (credentials
+  provider, seeded demo users, real session tokens); Cadence
+  (demo-accounting) → Supabase Auth (Supabase local in dev/CI). Clerk and
+  Auth0 get minimal e2e fixture hosts booting real createVendo, with
+  live-keyed tests skipped when credentials are absent.
+- Silent-trap fixes in product: `vendo init` writes `VENDO_BASE_URL`; doctor
+  gains live probes (credentials actually arrive at the host API; actAs
+  mint+verify round-trips); runtime emits one structured warning when present
+  execution forwards nothing despite inbound auth headers; the
+  away-needs-present-grant rule is documented.
+- Impersonation guard lands here: assert `grant.subject ===
+  ctx.principal.subject` at the actAs seam.
+
+## B. Connected accounts + connector identity (wave 2)
+
+- **Composio is the sole broker.** No home-grown OAuth flows; per-user
+  connections ride Composio connected accounts (entityId = subject).
+- Umbrella gains connection endpoints: initiate (returns Composio redirect
+  URL), status, disconnect — all per-principal.
+- In-flow UX: a Composio call failing on a missing connection produces a
+  typed `connect-required` tool outcome the UI renders as an inline connect
+  card (approvals pattern); after connecting, the call retries.
+- Persistent connected-accounts panel (list + disconnect) in VendoRoot chrome
+  settings. Both surfaces brand-native.
+- Composio risk fix: curated slug-pattern risk map (delete/remove/destroy →
+  destructive, etc.) plus Composio metadata where available; conservative
+  `write` default; `overrides.json` still wins.
+- MCP connector: `headers` becomes an optional async per-principal resolver;
+  presence/grant context is passed through to connector execute. Shared
+  static headers remain the simple default.
+- Cloud: with VENDO_API_KEY, connections ride a Vendo Cloud broker endpoint
+  using Vendo's Composio credentials — cloud users bring zero API keys. OSS
+  stays BYO-Composio-key.
+
+## C. Principals + orgs (wave 2)
+
+- **Anonymous→signed-in auto-merge**: first authenticated request carrying a
+  valid anon cookie migrates threads/apps/state to the real subject, clears
+  the cookie, idempotent. Grants and approvals deliberately do NOT migrate —
+  consent doesn't transfer identities; users re-approve.
+- **Away re-verification rides actAs**: the host declining to mint (null)
+  fails the run closed. No second verification seam.
+- Webhook principals get a reserved namespace (`vendo:webhook:…`); host
+  principal resolvers are forbidden from producing reserved subjects.
+- **Full org semantics, Vendo-owned tables**: `vendo_orgs` +
+  `vendo_org_members` (roles owner/admin/member) in @vendoai/store;
+  `kind:"org"` principals become real; apps/automations ownable by an org
+  subject; members run, admins approve and manage; minimal org management UI
+  (create/invite/roles) in chrome.
+- **Org stays paid**: all machinery ships OSS, activation is gated on
+  VENDO_API_KEY entitlement via the console's existing /keys/validate;
+  without a key, org APIs return a posture error. The Cloud
+  collaboration theme shrinks to console UX on top of this.
+
+## D. Sync completion (wave 1)
+
+- **Blast-radius**: a posture-gated runtime endpoint on the umbrella maps
+  each breaking/changed tool to the saved apps, automations, and standing
+  grants that reference it. `vendo sync` queries it when the dev server is
+  reachable and prints per-tool impact ("breaks N automations, M grants");
+  graceful "impact unknown — server not running" fallback.
+- **Loud grant invalidation**: a descriptor-hash mismatch at runtime emits an
+  audit event and a UI notice instead of a silent re-prompt.
+- `vendo init` scaffolds `predev`/`prebuild` sync hooks into the host
+  package.json (permission-prompted, like route wiring).
+- `--strict` gains distinct exit codes for breaking-extraction vs
+  blast-radius-nonzero. `--report` optionally pushes the report to the Cloud
+  console with a key.
+
+## Cross-cutting
+
+- **Audit enrichment** on every action/actAs/connector execution: grant id,
+  actAs outcome, connector account identity, away trigger, org context —
+  exactly what guard console and insights will consume. OSS emits, Cloud
+  reads.
+- **One contracts-amendment PR**: 04-actions (presets exist, trust model
+  documented, MCP-as-actAs cross-referenced), 01-core (org principals),
+  02-store (org tables, migration semantics). The "no adapter framework"
+  disclaimer is removed.
+- Testing bar per child: unit + integration fixtures + browser e2e; live
+  external tests keyed and skipIf-gated; UI-affecting changes verified in a
+  real browser with screenshots in the PR; `pnpm build && pnpm test &&
+  pnpm typecheck && pnpm lint` green before any PR.
+
+## Execution structure
+
+- **Four child Orca sessions** (Fable orchestrators under the parent,
+  executing via codex sol; Opus 4.8 only when sol is usage-blocked):
+  child A (actAs), child B (connected accounts), child C (principals+orgs),
+  child D (sync).
+- **Waves**: wave 1 = A + D in parallel; wave 2 = B + C once real demo auth
+  exists (B's honest demos need signed-in users; C's merge interacts with
+  B's per-subject connections).
+- **Parent owns**: child management and monitoring, sequencing, integration,
+  the contracts-amendment PR, Linear issues (one per chunk + one for the
+  demo/GIF wave), and the final GIF wave.
+- **GIF wave** (parent-run, end of project): Maple real-login execution;
+  Cadence Supabase execution; away drill — an automation firing with no live
+  user session; live Gmail connect + send via Composio; MCP venue (external
+  agent acting through actions).


### PR DESCRIPTION
## What

The parent-owned contracts-amendment PR for the block-actions project (ENG-264), re-aligning the frozen contract set with what the project landed and locked. Docs-only.

Three commits:
1. **Lands the approved design spec** (`docs/superpowers/specs/2026-07-14-block-actions-design.md`, approved by Yousef 2026-07-14) — it only existed on the planning branch; the amendments cite it.
2. **Coordinated amendments** across 00-overview, 01-core, 02-store, 04-actions, 05-guard, 08-ui, 09-vendo, 10-mcp.
3. **Keeps the org tables out of the conformance-tested 02-store table map** until ENG-263 lands (see Merge gate below).

## Per doc

- **01-core**: additive `connect-required` ToolOutcome + `ConnectRequired`; `VendoConnectPart` stream part; optional `invalidatedGrant` on `ApprovalRequest`/`VendoApprovalPart`; enriched audit `detail` contract (`connectorAccount`, `grant-invalidated`, `present-credentials-not-forwarded`); impersonation guard + away re-verification at the ActAs seam; real `kind:"org"` principals + the reserved `vendo:` subject namespace.
- **02-store**: anonymous→signed-in migration semantics (threads/apps/state migrate; grants/approvals/connected accounts never); org tables contracted in prose, table-map rows deferred to ENG-263.
- **04-actions**: new §2.1 presets (`authJsPreset`/`supabasePreset`/`genericJwtPreset`/`clerkPreset`/`auth0Preset`, away-token producer+verify halves); §4 trust model (`VENDO_BASE_URL` gates forwarding, loud structured warning, away-needs-present-grant normative, `act-as-subject-mismatch`, MCP-as-actAs cross-ref, "no adapter framework" dropped); §3 `Connector.connections` + `ConnectorAccountIdentity` + `McpHeadersResolver` + hint-tag/verb risk derivation; §3.1 connect-required + Cloud zero-key broker; §1 blast-radius note now points at the shipped `/sync/impact`; §5 org principals key-gated.
- **05-guard**: loud grant invalidation in the decision pipeline; connectorAccount lifted into audit detail and stripped from the outcome.
- **08-ui**: `useConnections()`; `<ConnectCard />`, `<ConnectedAccountsPanel />`; ApprovalCard invalidation notice.
- **09-vendo**: `/connections*`, `/sync/impact` (dev-only), `/doctor/present|act-as` wire rows; `blocks.connections` posture; doctor probes, sync exit codes 2/3, `--report`, init `VENDO_BASE_URL` + predev/prebuild scaffolds.
- **10-mcp**: `connect-required` maps to the door's in-band `isError` result (verified against `mapOutcome`).

Every landed shape was verified against code on main (exact types, signatures, routes) — not paraphrased from PR descriptions.

## Merge gate

**Do not merge before the ENG-263 (Child C, principals+orgs) PR lands.** The org-principal, org-table, `vendo:` namespace, and anon-migration entries are marked "ships with ENG-263"; its key columns get trued-up here at land time. Everything else describes surfaces already on main.

Worth noting: `packages/store/src/erase.conformance.test.ts` parses the 02-store §2 table map and asserts the erase cascade covers it — adding the org rows prematurely fails the suite (caught by the full local gate; commit 3 is the fix). The contracts are executable; Child C has been instructed to land the rows, key columns, erase-cascade coverage, and §5 count together.

## Gate

`pnpm build && pnpm test && pnpm typecheck && pnpm lint` — all green locally (test 41/41; one stale generated `.next` fixture artifact from an aborted earlier run was cleared for typecheck). Docs-only: no package changes, no changeset needed (changeset-status is non-blocking and only fires on package changes). No UI change; no screenshots applicable.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the contracts with the block-actions design (ENG-264): adds actAs presets, per-user connected accounts with a `connect-required` flow and UI, trusted present/away rules with doctor probes, blast-radius sync, loud grant invalidation, and real org principals with reserved subjects and anon→signed-in migration. Docs-only; tied to Linear ENG-264.

- New Features
  - `actAs` presets (`@vendoai/actions/presets`): Auth.js, Supabase, generic JWT, and Clerk/Auth0 away-token producer+verify halves.
  - Connected accounts: per-user `Connector.connections`, `connect-required` outcome + `VendoConnectPart`, `/connections*` routes, `<ConnectCard />` and `<ConnectedAccountsPanel />`, `useConnections()` (UI-owned `ConnectionAccount` wire type), `blocks.connections` posture; Cloud zero-key broker option.
  - Trust/execution: `VENDO_BASE_URL` gates present credential forwarding with a structured audit warning; away needs a present-captured grant; impersonation guard (`act-as-subject-mismatch`); MCP rides the same seam; doctor probes (`/doctor/present|act-as`).
  - Sync/DX: dev-only `/sync/impact`, `vendo sync --report`, strict exit codes 2/3; `vendo init` writes `VENDO_BASE_URL` and scaffolds predev/prebuild hooks.
  - Principals/store: real `kind:"org"` principals (activation key-gated), reserved `vendo:` subject namespace, `RunContext.actor`, `AuditEvent.kind:"principal"`, anonymous→signed-in migration; org tables documented to land with ENG-263.
  - Guard/audit: loud grant invalidation (`invalidatedGrant` on approvals + `policy-decision` with `reason:"grant-invalidated"`), `connectorAccount` identity lifted into `AuditEvent.detail`.
  - UI: `<ApprovalCard />` shows invalidation.
  - MCP: maps `connect-required` to an in-band `isError` result.
  - Spec: added `docs/superpowers/specs/2026-07-14-block-actions-design.md`.

- Migration
  - Set `VENDO_BASE_URL` and run `vendo doctor`; fix present/actAs warnings before enabling away.
  - Surface `connect-required` with `<ConnectCard />`; wire `/connections*`; choose BYO vs Cloud broker.
  - Org items ship with ENG-263; without a key, org APIs return `cloud-required`.

<sup>Written for commit 2f0edfe17e0d640be5d613d36ccade865988a0f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

