### PR TITLE
fix(corpus,bench,apps): clear the three ENG-243 measurement blockers + restore the silently-broken Layer-3 lane

### DIFF
--- a/bench/demo-capture/README.md
+++ b/bench/demo-capture/README.md
@@ -26,6 +26,12 @@ documented `.env.local` pattern, but the capture tool intentionally writes
 nothing under `apps/`. Maple is `demo-bank` at `/vendo`; Cadence is
 `demo-accounting` at `/assistant`.
 
+Both demos sit behind a real login wall (ENG-260). The capture signs in by
+itself with the primary seeded demo user (the login form prefills the email)
+and the shared demo password: `MAPLE_DEMO_PASSWORD` / `CADENCE_DEMO_PASSWORD`
+when set, otherwise each demo's seeded dev fallback (`maple-demo` /
+`cadence-demo`). No flags are needed for a local capture.
+
 ## The four one-command beats
 
 Use a distinct `--run-id` for each measurement wave so its raw recording and

--- a/bench/src/demo-capture/capture.ts
+++ b/bench/src/demo-capture/capture.ts
@@ -57,6 +57,21 @@ function hostList(host: BrowserCaptureArgs["host"]): ConcreteDemoHost[] {
   return host === "both" ? ["maple", "cadence"] : [host];
 }
 
+/** Both demo hosts sit behind a real login wall (ENG-260): unauthenticated
+ * visits land on a plain, scriptable /login form with the primary demo user's
+ * email prefilled and a single password field. Signs in when the wall is
+ * present and waits to land back on the capture route; no-op when a session
+ * cookie already exists. */
+async function signInIfNeeded(page: Page, host: DemoHostDefinition, timeoutMs: number): Promise<void> {
+  const loginForm = page.locator('form[action="/login"]');
+  if (await loginForm.count() === 0) return;
+  const password = process.env[host.demoPasswordEnv] ?? host.demoPasswordFallback;
+  await loginForm.locator('input[name="password"]').fill(password);
+  await loginForm.locator('button[type="submit"]').click();
+  await page.waitForURL((url) => !url.pathname.startsWith("/login"), { timeout: timeoutMs });
+  await page.waitForLoadState("domcontentloaded");
+}
+
 async function clearThread(page: Page, threadId: string): Promise<void> {
   const status = await page.evaluate(async (id) => {
     const response = await fetch(`/api/vendo/threads/${encodeURIComponent(id)}`, {
@@ -153,6 +168,7 @@ async function captureHost(options: {
     });
     const page = await context.newPage();
     await page.goto(new URL(options.host.route, running.baseUrl).toString(), { waitUntil: "domcontentloaded", timeout: options.args.timeoutMs });
+    await signInIfNeeded(page, options.host, options.args.timeoutMs);
     await clearThread(page, options.host.threadId);
     await page.reload({ waitUntil: "domcontentloaded", timeout: options.args.timeoutMs });
     await page.getByRole("textbox", { name: "Message" }).waitFor({ state: "visible", timeout: options.args.timeoutMs });

--- a/bench/src/demo-capture/hosts.ts
+++ b/bench/src/demo-capture/hosts.ts
@@ -13,6 +13,12 @@ export interface DemoHostDefinition {
   packageName: "demo-bank" | "demo-accounting";
   route: string;
   threadId: string;
+  /** ENG-260 put both demos behind a real login wall. The /login form
+   * prefills the primary seeded demo user's email, so the capture only needs
+   * the shared demo password: the deploy-time env knob when set, otherwise
+   * the seeded dev fallback. */
+  demoPasswordEnv: string;
+  demoPasswordFallback: string;
 }
 
 export const demoHosts: Record<ConcreteDemoHost, DemoHostDefinition> = {
@@ -22,6 +28,8 @@ export const demoHosts: Record<ConcreteDemoHost, DemoHostDefinition> = {
     packageName: "demo-bank",
     route: "/vendo",
     threadId: "thr_maple_demo",
+    demoPasswordEnv: "MAPLE_DEMO_PASSWORD",
+    demoPasswordFallback: "maple-demo",
   },
   cadence: {
     id: "cadence",
@@ -29,6 +37,8 @@ export const demoHosts: Record<ConcreteDemoHost, DemoHostDefinition> = {
     packageName: "demo-accounting",
     route: "/assistant",
     threadId: "thr_cadence_demo",
+    demoPasswordEnv: "CADENCE_DEMO_PASSWORD",
+    demoPasswordFallback: "cadence-demo",
   },
 };
 

--- a/corpus/harness/src/e2e-prep.test.ts
+++ b/corpus/harness/src/e2e-prep.test.ts
@@ -120,18 +120,21 @@ async function createUmamiFixture(): Promise<{ appRoot: string; logsDir: string 
   return { appRoot, logsDir };
 }
 
+// Mirrors real route-scan output: host_* names and its OWN param names
+// ({id} where the curated manifest says {documentId}/{linkId}), so the
+// endpoint matching must normalize params the way sync's dedupKey does.
 const papermarkExtractionTools = [
-  { name: "getTeams", method: "GET", path: "/api/teams" },
-  { name: "getTeamsTeamIdDocuments", method: "GET", path: "/api/teams/{teamId}/documents" },
-  { name: "getTeamsTeamIdDocumentsDocumentIdViewsCount", method: "GET", path: "/api/teams/{teamId}/documents/{documentId}/views-count" },
-  { name: "getTeamsTeamIdViewers", method: "GET", path: "/api/teams/{teamId}/viewers" },
-  { name: "getTeamsTeamIdDocumentsDocumentIdLinks", method: "GET", path: "/api/teams/{teamId}/documents/{documentId}/links" },
-  { name: "getTeamsTeamIdDatarooms", method: "GET", path: "/api/teams/{teamId}/datarooms" },
-  { name: "postLinks", method: "POST", path: "/api/links" },
-  { name: "postTeamsTeamIdDocumentsDocumentIdAddToDataroom", method: "POST", path: "/api/teams/{teamId}/documents/{documentId}/add-to-dataroom" },
-  { name: "putLinksLinkId", method: "PUT", path: "/api/links/{linkId}" },
+  { name: "host_teams_list", method: "GET", path: "/api/teams" },
+  { name: "host_teams_documents_list", method: "GET", path: "/api/teams/{teamId}/documents" },
+  { name: "host_teams_documents_views_count_list", method: "GET", path: "/api/teams/{teamId}/documents/{id}/views-count" },
+  { name: "host_teams_viewers_list", method: "GET", path: "/api/teams/{teamId}/viewers" },
+  { name: "host_teams_documents_links_list", method: "GET", path: "/api/teams/{teamId}/documents/{id}/links" },
+  { name: "host_teams_datarooms_list", method: "GET", path: "/api/teams/{teamId}/datarooms" },
+  { name: "host_links_create", method: "POST", path: "/api/links" },
+  { name: "host_teams_documents_add_to_dataroom", method: "POST", path: "/api/teams/{teamId}/documents/{id}/add-to-dataroom" },
+  { name: "host_links_update", method: "PUT", path: "/api/links/{id}" },
   // Extraction noise the curated surface must disable.
-  { name: "getAccount", method: "GET", path: "/api/account" },
+  { name: "host_account_get", method: "GET", path: "/api/account" },
 ] as const;
 
 function papermarkExtractionToolsJson(): string {
@@ -409,15 +412,16 @@ describe("prepareE2eRepo", () => {
     expect(overrides.format).toBe("vendo/overrides@1");
     // Curated endpoints keep their extraction names and gain descriptions +
     // corrected risk; every other extracted tool is disabled.
-    expect(overrides.tools["getTeams"]).toMatchObject({ risk: "read" });
-    expect(overrides.tools["getTeams"]!.description).toContain("Corpus E2E Team");
-    expect(overrides.tools["getTeamsTeamIdDocuments"]).toMatchObject({ risk: "read" });
-    expect(overrides.tools["getTeamsTeamIdDocuments"]!.description).toContain("seeded document names");
-    expect(overrides.tools["postLinks"]).toMatchObject({ risk: "write" });
-    expect(overrides.tools["putLinksLinkId"]).toMatchObject({ risk: "write" });
-    expect(overrides.tools["postTeamsTeamIdDocumentsDocumentIdAddToDataroom"]).toMatchObject({ risk: "write" });
-    expect(overrides.tools["getTeams"]!.disabled).toBeUndefined();
-    expect(overrides.tools["getAccount"]).toEqual({ disabled: true });
+    expect(overrides.tools["host_teams_list"]).toMatchObject({ risk: "read" });
+    expect(overrides.tools["host_teams_list"]!.description).toContain("Corpus E2E Team");
+    expect(overrides.tools["host_teams_documents_list"]).toMatchObject({ risk: "read" });
+    expect(overrides.tools["host_teams_documents_list"]!.description).toContain("seeded document names");
+    expect(overrides.tools["host_teams_documents_views_count_list"]).toMatchObject({ risk: "read" });
+    expect(overrides.tools["host_links_create"]).toMatchObject({ risk: "write" });
+    expect(overrides.tools["host_links_update"]).toMatchObject({ risk: "write" });
+    expect(overrides.tools["host_teams_documents_add_to_dataroom"]).toMatchObject({ risk: "write" });
+    expect(overrides.tools["host_teams_list"]!.disabled).toBeUndefined();
+    expect(overrides.tools["host_account_get"]).toEqual({ disabled: true });
     // The init-scaffolded handler is already correct; prep must not rewrite it.
     expect(route).toContain("nextVendoHandler(vendo)");
     expect(overlay).toContain("VendoOverlay");

--- a/corpus/harness/src/e2e-prep.test.ts
+++ b/corpus/harness/src/e2e-prep.test.ts
@@ -10,11 +10,11 @@ async function createSkateshopFixture(): Promise<{ appRoot: string; logsDir: str
   const appRoot = path.join(root, "skateshop");
   const logsDir = path.join(root, "logs");
   await mkdir(path.join(appRoot, ".vendo"), { recursive: true });
-  await mkdir(path.join(appRoot, "src/app/api/vendo/[...path]"), { recursive: true });
+  await mkdir(path.join(appRoot, "src/app/api/vendo/[...vendo]"), { recursive: true });
   await mkdir(path.join(appRoot, "src/app"), { recursive: true });
   await writeFile(path.join(appRoot, ".vendo/tools.json"), JSON.stringify({ format: "vendo/tools@1", tools: [] }));
   await writeFile(
-    path.join(appRoot, "src/app/api/vendo/[...path]/route.ts"),
+    path.join(appRoot, "src/app/api/vendo/[...vendo]/route.ts"),
     `import { createVendoHandler } from "vendoai/server";
 export const { GET, POST } = createVendoHandler();
 `,
@@ -97,16 +97,18 @@ export const config = {
   return { appRoot, logsDir };
 }
 
-async function createUmamiFixture(): Promise<{ appRoot: string; logsDir: string }> {
+async function createUmamiFixture(
+  routeSegment = "[...vendo]",
+): Promise<{ appRoot: string; logsDir: string; routeSegment: string }> {
   const root = await mkdtemp(path.join(os.tmpdir(), "vendo-e2e-prep-"));
   const appRoot = path.join(root, "umami");
   const logsDir = path.join(root, "logs");
   await mkdir(path.join(appRoot, ".vendo"), { recursive: true });
-  await mkdir(path.join(appRoot, "src/app/api/vendo/[...path]"), { recursive: true });
+  await mkdir(path.join(appRoot, `src/app/api/vendo/${routeSegment}`), { recursive: true });
   await mkdir(path.join(appRoot, "src/app"), { recursive: true });
   await writeFile(path.join(appRoot, ".vendo/tools.json"), JSON.stringify({ format: "vendo/tools@1", tools: [] }));
   await writeFile(
-    path.join(appRoot, "src/app/api/vendo/[...path]/route.ts"),
+    path.join(appRoot, `src/app/api/vendo/${routeSegment}/route.ts`),
     `import { createVendoHandler } from "vendoai/server";
 export const { GET, POST } = createVendoHandler();
 `,
@@ -128,7 +130,7 @@ export function AppVendoRoot({ children }: { children: ReactNode }) {
 }
 `,
   );
-  return { appRoot, logsDir };
+  return { appRoot, logsDir, routeSegment };
 }
 
 async function createPapermarkFixture(): Promise<{ appRoot: string; logsDir: string }> {
@@ -136,12 +138,12 @@ async function createPapermarkFixture(): Promise<{ appRoot: string; logsDir: str
   const appRoot = path.join(root, "papermark");
   const logsDir = path.join(root, "logs");
   await mkdir(path.join(appRoot, ".vendo"), { recursive: true });
-  await mkdir(path.join(appRoot, "app/api/vendo/[...path]"), { recursive: true });
+  await mkdir(path.join(appRoot, "app/api/vendo/[...vendo]"), { recursive: true });
   await mkdir(path.join(appRoot, "app"), { recursive: true });
   await mkdir(path.join(appRoot, "pages/api"), { recursive: true });
   await writeFile(path.join(appRoot, ".vendo/tools.json"), JSON.stringify({ format: "vendo/tools@1", tools: [] }));
   await writeFile(
-    path.join(appRoot, "app/api/vendo/[...path]/route.ts"),
+    path.join(appRoot, "app/api/vendo/[...vendo]/route.ts"),
     `import { createVendoHandler } from "vendoai/server";
 export const { GET, POST } = createVendoHandler();
 `,
@@ -198,7 +200,7 @@ describe("prepareE2eRepo", () => {
         binding: { method: string; path: string };
       }>;
     };
-    const route = await readFile(path.join(appRoot, "src/app/api/vendo/[...path]/route.ts"), "utf8");
+    const route = await readFile(path.join(appRoot, "src/app/api/vendo/[...vendo]/route.ts"), "utf8");
     const root = await readFile(path.join(appRoot, "src/app/vendo-root.tsx"), "utf8");
     const layout = await readFile(path.join(appRoot, "src/app/layout.tsx"), "utf8");
     const corpusLib = await readFile(path.join(appRoot, "src/app/api/corpus/_lib.ts"), "utf8");
@@ -270,7 +272,7 @@ describe("prepareE2eRepo", () => {
     const tools = JSON.parse(await readFile(path.join(appRoot, ".vendo/tools.json"), "utf8")) as {
       tools: Array<{ name: string }>;
     };
-    const route = await readFile(path.join(appRoot, "src/app/api/vendo/[...path]/route.ts"), "utf8");
+    const route = await readFile(path.join(appRoot, "src/app/api/vendo/[...vendo]/route.ts"), "utf8");
     const root = await readFile(path.join(appRoot, "src/app/vendo-root.tsx"), "utf8");
     const log = await readFile(logs[0]!, "utf8");
 
@@ -292,6 +294,17 @@ describe("prepareE2eRepo", () => {
     expect(root).toContain('headers.set("authorization"');
     expect(log).toContain("read-only tools manifest");
     expect(log).toContain("Umami auth headers");
+  });
+
+  it("derives the Vendo route segment from the repo instead of hardcoding init's name", async () => {
+    // A repo init'd before 1e577988 (or by a future rename) keeps working:
+    // the harness patches whatever catch-all segment exists under api/vendo.
+    const { appRoot, logsDir } = await createUmamiFixture("[...path]");
+    await prepareE2eRepo({ name: "umami" }, appRoot, logsDir);
+
+    const route = await readFile(path.join(appRoot, "src/app/api/vendo/[...path]/route.ts"), "utf8");
+    expect(route).toContain("storage: false");
+    expect(route).toContain("instructionsExtra");
   });
 
   it("does nothing for repos without a Layer 3 prep fixture", async () => {
@@ -356,10 +369,16 @@ describe("prepareE2eRepo", () => {
     const { appRoot, logsDir } = await createPapermarkFixture();
     const logs = await prepareE2eRepo({ name: "papermark" }, appRoot, logsDir);
 
-    const tools = JSON.parse(await readFile(path.join(appRoot, ".vendo/tools.json"), "utf8")) as {
+    const tools = JSON.parse(await readFile(path.join(appRoot, ".vendo/tools.corpus.json"), "utf8")) as {
       tools: Array<{ name: string; risk: "read" | "write" | "destructive"; binding: { method: string; path: string } }>;
     };
-    const route = await readFile(path.join(appRoot, "app/api/vendo/[...path]/route.ts"), "utf8");
+    // The sync-managed extraction pin must stay untouched: papermark's npm
+    // build runs `vendo sync --strict`, and a curated manifest in tools.json
+    // reads as breaking tool renames (exit 2).
+    const extractionPin = JSON.parse(await readFile(path.join(appRoot, ".vendo/tools.json"), "utf8")) as {
+      tools: unknown[];
+    };
+    const route = await readFile(path.join(appRoot, "app/api/vendo/[...vendo]/route.ts"), "utf8");
     const root = await readFile(path.join(appRoot, "app/vendo-root.tsx"), "utf8");
     const layout = await readFile(path.join(appRoot, "app/layout.tsx"), "utf8");
     const corpusPage = await readFile(path.join(appRoot, "app/corpus-e2e/page.tsx"), "utf8");
@@ -396,11 +415,14 @@ describe("prepareE2eRepo", () => {
       path: "/api/teams/{teamId}/documents",
       argsIn: "query",
     });
+    expect(extractionPin.tools).toEqual([]);
     expect(route).toContain("storage: false");
     expect(route).toContain("instructionsExtra");
     expect(route).toContain("Corpus Q3 Board Packet.pdf");
     expect(root).toContain("threadId={threadId}");
     expect(root).toContain("vendoThread");
+    expect(root).toContain('from "../.vendo/tools.corpus.json"');
+    expect(root).not.toContain('from "../.vendo/tools.json"');
     expect(layout).toContain("<AppVendoRoot>{children}</AppVendoRoot>");
     expect(corpusPage).toContain("Corpus Papermark E2E");
     expect(loginRoute).toContain("next-auth.session-token");

--- a/corpus/harness/src/e2e-prep.test.ts
+++ b/corpus/harness/src/e2e-prep.test.ts
@@ -4,6 +4,31 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { prepareE2eRepo } from "./e2e-prep.js";
 
+/** The handler `vendo init` currently scaffolds under api/vendo/[...vendo]. */
+const initRouteSource = `import { model } from "@/lib/ai";
+import { createVendo, nextVendoHandler } from "@vendoai/vendo/server";
+
+const vendo = createVendo({
+  model,
+  principal: async () => null,
+});
+
+export const { GET, POST, DELETE } = nextVendoHandler(vendo);
+`;
+
+/** An App Router layout after init wired VendoRoot around {children}. */
+function initLayoutSource(themeImportPath: string, wrap: (inner: string) => string): string {
+  return `import { VendoRoot } from "@vendoai/vendo/react";
+import theme from "${themeImportPath}";
+import type { VendoTheme } from "@vendoai/vendo";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    ${wrap("<VendoRoot theme={theme as VendoTheme}>{children}</VendoRoot>")}
+  )
+}
+`;
+}
 
 async function createSkateshopFixture(): Promise<{ appRoot: string; logsDir: string }> {
   const root = await mkdtemp(path.join(os.tmpdir(), "vendo-e2e-prep-"));
@@ -11,40 +36,20 @@ async function createSkateshopFixture(): Promise<{ appRoot: string; logsDir: str
   const logsDir = path.join(root, "logs");
   await mkdir(path.join(appRoot, ".vendo"), { recursive: true });
   await mkdir(path.join(appRoot, "src/app/api/vendo/[...vendo]"), { recursive: true });
-  await mkdir(path.join(appRoot, "src/app"), { recursive: true });
   await writeFile(path.join(appRoot, ".vendo/tools.json"), JSON.stringify({ format: "vendo/tools@1", tools: [] }));
-  await writeFile(
-    path.join(appRoot, "src/app/api/vendo/[...vendo]/route.ts"),
-    `import { createVendoHandler } from "vendoai/server";
-export const { GET, POST } = createVendoHandler();
-`,
-  );
-  await writeFile(
-    path.join(appRoot, "src/app/vendo-root.tsx"),
-    `"use client";
-import { VendoRoot } from "vendoai/react";
-import type { ReactNode } from "react";
-import theme from "../../.vendo/theme.json";
-import tools from "../../.vendo/tools.json";
-
-export function AppVendoRoot({ children }: { children: ReactNode }) {
-  return (
-    <VendoRoot theme={theme} tools={tools} productName="Skateshop">
-      {children}
-    </VendoRoot>
-  );
-}
-`,
-  );
+  await writeFile(path.join(appRoot, "src/app/api/vendo/[...vendo]/route.ts"), initRouteSource);
   await writeFile(
     path.join(appRoot, "src/app/layout.tsx"),
     `import { ClerkProvider } from "@clerk/nextjs"
+import { VendoRoot } from "@vendoai/vendo/react";
+import theme from "../../.vendo/theme.json";
+import type { VendoTheme } from "@vendoai/vendo";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <ClerkProvider>
       <html lang="en">
-        <body>{children}</body>
+        <body><VendoRoot theme={theme as VendoTheme}>{children}</VendoRoot></body>
       </html>
     </ClerkProvider>
   )
@@ -97,80 +102,73 @@ export const config = {
   return { appRoot, logsDir };
 }
 
-async function createUmamiFixture(
-  routeSegment = "[...vendo]",
-): Promise<{ appRoot: string; logsDir: string; routeSegment: string }> {
+async function createUmamiFixture(): Promise<{ appRoot: string; logsDir: string }> {
   const root = await mkdtemp(path.join(os.tmpdir(), "vendo-e2e-prep-"));
   const appRoot = path.join(root, "umami");
   const logsDir = path.join(root, "logs");
   await mkdir(path.join(appRoot, ".vendo"), { recursive: true });
-  await mkdir(path.join(appRoot, `src/app/api/vendo/${routeSegment}`), { recursive: true });
-  await mkdir(path.join(appRoot, "src/app"), { recursive: true });
+  await mkdir(path.join(appRoot, "src/app/api/vendo/[...vendo]"), { recursive: true });
   await writeFile(path.join(appRoot, ".vendo/tools.json"), JSON.stringify({ format: "vendo/tools@1", tools: [] }));
+  await writeFile(path.join(appRoot, "src/app/api/vendo/[...vendo]/route.ts"), initRouteSource);
   await writeFile(
-    path.join(appRoot, `src/app/api/vendo/${routeSegment}/route.ts`),
-    `import { createVendoHandler } from "vendoai/server";
-export const { GET, POST } = createVendoHandler();
-`,
+    path.join(appRoot, "src/app/layout.tsx"),
+    initLayoutSource(
+      "../../.vendo/theme.json",
+      (inner) => `<html lang="en"><body><Providers>${inner}</Providers></body></html>`,
+    ),
   );
-  await writeFile(
-    path.join(appRoot, "src/app/vendo-root.tsx"),
-    `"use client";
-import { VendoRoot } from "vendoai/react";
-import type { ReactNode } from "react";
-import theme from "../../.vendo/theme.json";
-import tools from "../../.vendo/tools.json";
-
-export function AppVendoRoot({ children }: { children: ReactNode }) {
-  return (
-    <VendoRoot theme={theme} tools={tools} productName="Umami">
-      {children}
-    </VendoRoot>
-  );
-}
-`,
-  );
-  return { appRoot, logsDir, routeSegment };
+  return { appRoot, logsDir };
 }
 
-async function createPapermarkFixture(): Promise<{ appRoot: string; logsDir: string }> {
+const papermarkExtractionTools = [
+  { name: "getTeams", method: "GET", path: "/api/teams" },
+  { name: "getTeamsTeamIdDocuments", method: "GET", path: "/api/teams/{teamId}/documents" },
+  { name: "getTeamsTeamIdDocumentsDocumentIdViewsCount", method: "GET", path: "/api/teams/{teamId}/documents/{documentId}/views-count" },
+  { name: "getTeamsTeamIdViewers", method: "GET", path: "/api/teams/{teamId}/viewers" },
+  { name: "getTeamsTeamIdDocumentsDocumentIdLinks", method: "GET", path: "/api/teams/{teamId}/documents/{documentId}/links" },
+  { name: "getTeamsTeamIdDatarooms", method: "GET", path: "/api/teams/{teamId}/datarooms" },
+  { name: "postLinks", method: "POST", path: "/api/links" },
+  { name: "postTeamsTeamIdDocumentsDocumentIdAddToDataroom", method: "POST", path: "/api/teams/{teamId}/documents/{documentId}/add-to-dataroom" },
+  { name: "putLinksLinkId", method: "PUT", path: "/api/links/{linkId}" },
+  // Extraction noise the curated surface must disable.
+  { name: "getAccount", method: "GET", path: "/api/account" },
+] as const;
+
+function papermarkExtractionToolsJson(): string {
+  return `${JSON.stringify({
+    format: "vendo/tools@1",
+    tools: papermarkExtractionTools.map((tool) => ({
+      name: tool.name,
+      description: "",
+      inputSchema: { type: "object" },
+      risk: "write",
+      binding: { kind: "route", method: tool.method, path: tool.path, argsIn: tool.method === "GET" ? "query" : "body" },
+    })),
+  }, null, 2)}\n`;
+}
+
+async function createPapermarkFixture(options: {
+  routeSegment?: string | null;
+  toolsJson?: string;
+} = {}): Promise<{ appRoot: string; logsDir: string }> {
   const root = await mkdtemp(path.join(os.tmpdir(), "vendo-e2e-prep-"));
   const appRoot = path.join(root, "papermark");
   const logsDir = path.join(root, "logs");
   await mkdir(path.join(appRoot, ".vendo"), { recursive: true });
-  await mkdir(path.join(appRoot, "app/api/vendo/[...vendo]"), { recursive: true });
   await mkdir(path.join(appRoot, "app"), { recursive: true });
   await mkdir(path.join(appRoot, "pages/api"), { recursive: true });
-  await writeFile(path.join(appRoot, ".vendo/tools.json"), JSON.stringify({ format: "vendo/tools@1", tools: [] }));
-  await writeFile(
-    path.join(appRoot, "app/api/vendo/[...vendo]/route.ts"),
-    `import { createVendoHandler } from "vendoai/server";
-export const { GET, POST } = createVendoHandler();
-`,
-  );
-  await writeFile(
-    path.join(appRoot, "app/vendo-root.tsx"),
-    `"use client";
-import { VendoRoot } from "vendoai/react";
-import type { ReactNode } from "react";
-import theme from "../.vendo/theme.json";
-import tools from "../.vendo/tools.json";
-
-export function AppVendoRoot({ children }: { children: ReactNode }) {
-  return (
-    <VendoRoot theme={theme} tools={tools} productName="Papermark">
-      {children}
-    </VendoRoot>
-  );
-}
-`,
-  );
+  await writeFile(path.join(appRoot, ".vendo/tools.json"), options.toolsJson ?? papermarkExtractionToolsJson());
+  const routeSegment = options.routeSegment === undefined ? "[...vendo]" : options.routeSegment;
+  if (routeSegment !== null) {
+    await mkdir(path.join(appRoot, `app/api/vendo/${routeSegment}`), { recursive: true });
+    await writeFile(path.join(appRoot, `app/api/vendo/${routeSegment}/route.ts`), initRouteSource);
+  }
   await writeFile(
     path.join(appRoot, "app/layout.tsx"),
-    `export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return <html lang="en"><body>{children}</body></html>;
-}
-`,
+    initLayoutSource(
+      "../.vendo/theme.json",
+      (inner) => `<html lang="en"><body>${inner}</body></html>`,
+    ),
   );
   await writeFile(
     path.join(appRoot, "package.json"),
@@ -189,19 +187,20 @@ describe("prepareE2eRepo", () => {
     await expect(readFile(path.join(logsDir, "e2e.prepare.log"), "utf8")).rejects.toThrow();
   });
 
-  it("adds Skateshop corpus routes, reviewed tools, handler guidance, and per-attempt thread ids", async () => {
+  it("adds Skateshop corpus routes, curated tools, overlay chrome, and Clerk bypasses", async () => {
     const { appRoot, logsDir } = await createSkateshopFixture();
     const logs = await prepareE2eRepo({ name: "skateshop" }, appRoot, logsDir);
 
     const tools = JSON.parse(await readFile(path.join(appRoot, ".vendo/tools.json"), "utf8")) as {
       tools: Array<{
         name: string;
+        description: string;
         risk: "read" | "write" | "destructive";
         binding: { method: string; path: string };
       }>;
     };
     const route = await readFile(path.join(appRoot, "src/app/api/vendo/[...vendo]/route.ts"), "utf8");
-    const root = await readFile(path.join(appRoot, "src/app/vendo-root.tsx"), "utf8");
+    const overlay = await readFile(path.join(appRoot, "src/app/vendo-corpus-e2e.tsx"), "utf8");
     const layout = await readFile(path.join(appRoot, "src/app/layout.tsx"), "utf8");
     const corpusLib = await readFile(path.join(appRoot, "src/app/api/corpus/_lib.ts"), "utf8");
     const productsRoute = await readFile(path.join(appRoot, "src/app/api/corpus/products/route.ts"), "utf8");
@@ -233,12 +232,15 @@ describe("prepareE2eRepo", () => {
       ["POST", "/api/corpus/orders"],
       ["GET", "/api/corpus/checkout-defaults"],
     ]);
-    expect(route).toContain("storage: false");
-    expect(route).toContain("instructionsExtra");
-    expect(route).toContain("Youness gradient cuts impact 8.375 skateboard deck");
-    expect(route).toContain("render a Table view");
-    expect(root).toContain("threadId={threadId}");
-    expect(root).toContain("vendoThread");
+    // Fixture guidance now rides in the tool descriptions (the old handler
+    // instructionsExtra knob no longer exists in the composed umbrella).
+    expect(tools.tools[0]!.description).toContain("Youness gradient cuts impact 8.375 skateboard deck");
+    expect(tools.tools[0]!.description).toContain("Table view");
+    // The init-scaffolded handler is already correct; prep must not touch it.
+    expect(route).toContain("nextVendoHandler(vendo)");
+    expect(overlay).toContain('"use client"');
+    expect(overlay).toContain("VendoOverlay");
+    expect(layout).toContain("<VendoCorpusE2e />");
     expect(layout).not.toContain("ClerkProvider");
     expect(layout).toContain("<html");
     expect(corpusLib).toContain('from "@/assets/data/products.json"');
@@ -264,16 +266,19 @@ describe("prepareE2eRepo", () => {
     expect(log).toContain("Skateshop Clerk middleware corpus bypass");
     expect(log).toContain("Skateshop Clerk provider corpus bypass");
     expect(log).toContain("Skateshop cached user query corpus bypass");
+    expect(log).toContain("corpus Vendo overlay");
   });
-  it("adds Umami Layer 3 tools, handler guidance, auth fetch, and per-attempt thread ids", async () => {
+
+  it("adds Umami Layer 3 tools, overlay chrome with the auth shim, and a trusted base URL", async () => {
     const { appRoot, logsDir } = await createUmamiFixture();
     const logs = await prepareE2eRepo({ name: "umami" }, appRoot, logsDir);
 
     const tools = JSON.parse(await readFile(path.join(appRoot, ".vendo/tools.json"), "utf8")) as {
-      tools: Array<{ name: string }>;
+      tools: Array<{ name: string; description: string }>;
     };
-    const route = await readFile(path.join(appRoot, "src/app/api/vendo/[...vendo]/route.ts"), "utf8");
-    const root = await readFile(path.join(appRoot, "src/app/vendo-root.tsx"), "utf8");
+    const overlay = await readFile(path.join(appRoot, "src/app/vendo-corpus-e2e.tsx"), "utf8");
+    const layout = await readFile(path.join(appRoot, "src/app/layout.tsx"), "utf8");
+    const env = await readFile(path.join(appRoot, ".env"), "utf8");
     const log = await readFile(logs[0]!, "utf8");
 
     expect(tools.tools.map((tool) => tool.name)).toEqual([
@@ -283,28 +288,35 @@ describe("prepareE2eRepo", () => {
       "get_umami_revenue_report",
       "get_umami_funnel_report",
     ]);
-    expect(route).toContain("storage: false");
-    expect(route).toContain("instructionsExtra");
-    expect(route).toContain("visible answer must include labels and numeric values");
-    expect(route).toContain("If you render a view");
-    expect(root).toContain("threadId={threadId}");
-    expect(root).toContain("vendoThread");
-    expect(root).toContain("installUmamiAuthFetch");
-    expect(root).toContain("umami.auth");
-    expect(root).toContain('headers.set("authorization"');
+    // Seeded date windows moved from instructionsExtra into the descriptions.
+    expect(tools.tools[1]!.description).toContain("startAt=1782691200000");
+    expect(tools.tools[3]!.description).toContain("2026-07-01T00:00:00.000Z");
+    expect(overlay).toContain('"use client"');
+    expect(overlay).toContain("VendoOverlay");
+    expect(overlay).toContain("installUmamiAuthFetch");
+    expect(overlay).toContain("umami.auth");
+    expect(overlay).toContain('headers.set("authorization"');
+    // The Bearer shim must cover the Vendo wire so server-side route bindings
+    // receive the forwarded authorization header — the old shim excluded it.
+    expect(overlay).not.toContain('!url.pathname.startsWith("/api/vendo")');
+    expect(layout).toContain("<VendoCorpusE2e />");
+    expect(env).toContain("VENDO_BASE_URL=http://127.0.0.1:3000");
     expect(log).toContain("read-only tools manifest");
-    expect(log).toContain("Umami auth headers");
+    expect(log).toContain("Umami auth fetch shim");
+    expect(log).toContain("VENDO_BASE_URL");
   });
 
-  it("derives the Vendo route segment from the repo instead of hardcoding init's name", async () => {
-    // A repo init'd before 1e577988 (or by a future rename) keeps working:
-    // the harness patches whatever catch-all segment exists under api/vendo.
-    const { appRoot, logsDir } = await createUmamiFixture("[...path]");
-    await prepareE2eRepo({ name: "umami" }, appRoot, logsDir);
+  it("fails loudly when init's layout no longer carries the VendoRoot wrapper", async () => {
+    const { appRoot, logsDir } = await createUmamiFixture();
+    await writeFile(
+      path.join(appRoot, "src/app/layout.tsx"),
+      `export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return <html lang="en"><body>{children}</body></html>;
+}
+`,
+    );
 
-    const route = await readFile(path.join(appRoot, "src/app/api/vendo/[...path]/route.ts"), "utf8");
-    expect(route).toContain("storage: false");
-    expect(route).toContain("instructionsExtra");
+    await expect(prepareE2eRepo({ name: "umami" }, appRoot, logsDir)).rejects.toThrow(/VendoRoot/);
   });
 
   it("does nothing for repos without a Layer 3 prep fixture", async () => {
@@ -365,21 +377,22 @@ describe("prepareE2eRepo", () => {
     await expect(prepareE2eRepo({ name: "teable" }, appRoot, logsDir)).rejects.toThrow(/next-i18next\.config\.js/);
   });
 
-  it("adds Papermark fixtures, JWT login, curated tools, handler guidance, and per-attempt thread ids", async () => {
+  it("adds Papermark fixtures, JWT login, curated overrides, and overlay chrome", async () => {
     const { appRoot, logsDir } = await createPapermarkFixture();
+    const toolsBefore = await readFile(path.join(appRoot, ".vendo/tools.json"), "utf8");
     const logs = await prepareE2eRepo({ name: "papermark" }, appRoot, logsDir);
 
-    const tools = JSON.parse(await readFile(path.join(appRoot, ".vendo/tools.corpus.json"), "utf8")) as {
-      tools: Array<{ name: string; risk: "read" | "write" | "destructive"; binding: { method: string; path: string } }>;
-    };
-    // The sync-managed extraction pin must stay untouched: papermark's npm
-    // build runs `vendo sync --strict`, and a curated manifest in tools.json
-    // reads as breaking tool renames (exit 2).
-    const extractionPin = JSON.parse(await readFile(path.join(appRoot, ".vendo/tools.json"), "utf8")) as {
-      tools: unknown[];
+    // The sync-managed extraction pin must stay byte-identical: papermark's
+    // npm build runs `vendo sync --strict`, and replacing the pin with a
+    // curated manifest reads as breaking tool renames (exit 2).
+    await expect(readFile(path.join(appRoot, ".vendo/tools.json"), "utf8")).resolves.toBe(toolsBefore);
+
+    const overrides = JSON.parse(await readFile(path.join(appRoot, ".vendo/overrides.json"), "utf8")) as {
+      format: string;
+      tools: Record<string, { risk?: string; description?: string; disabled?: boolean }>;
     };
     const route = await readFile(path.join(appRoot, "app/api/vendo/[...vendo]/route.ts"), "utf8");
-    const root = await readFile(path.join(appRoot, "app/vendo-root.tsx"), "utf8");
+    const overlay = await readFile(path.join(appRoot, "app/vendo-corpus-e2e.tsx"), "utf8");
     const layout = await readFile(path.join(appRoot, "app/layout.tsx"), "utf8");
     const corpusPage = await readFile(path.join(appRoot, "app/corpus-e2e/page.tsx"), "utf8");
     const loginRoute = await readFile(path.join(appRoot, "pages/api/corpus-login.ts"), "utf8");
@@ -393,43 +406,29 @@ describe("prepareE2eRepo", () => {
     };
     const log = await readFile(logs[0]!, "utf8");
 
-    expect(tools.tools.map((tool) => tool.name)).toEqual([
-      "getTeams",
-      "listTeamDocuments",
-      "getDocumentStats",
-      "getDocumentViews",
-      "listDocumentLinks",
-      "listDatarooms",
-      "createShareLink",
-      "addDocumentToDataroom",
-      "updateLinkSettings",
-    ]);
-    expect(tools.tools.filter((tool) => tool.risk === "write").map((tool) => tool.name)).toEqual([
-      "createShareLink",
-      "addDocumentToDataroom",
-      "updateLinkSettings",
-    ]);
-    expect(tools.tools.find((tool) => tool.name === "listTeamDocuments")?.binding).toEqual({
-      kind: "route",
-      method: "GET",
-      path: "/api/teams/{teamId}/documents",
-      argsIn: "query",
-    });
-    expect(extractionPin.tools).toEqual([]);
-    expect(route).toContain("storage: false");
-    expect(route).toContain("instructionsExtra");
-    expect(route).toContain("Corpus Q3 Board Packet.pdf");
-    expect(root).toContain("threadId={threadId}");
-    expect(root).toContain("vendoThread");
-    expect(root).toContain('from "../.vendo/tools.corpus.json"');
-    expect(root).not.toContain('from "../.vendo/tools.json"');
-    expect(layout).toContain("<AppVendoRoot>{children}</AppVendoRoot>");
+    expect(overrides.format).toBe("vendo/overrides@1");
+    // Curated endpoints keep their extraction names and gain descriptions +
+    // corrected risk; every other extracted tool is disabled.
+    expect(overrides.tools["getTeams"]).toMatchObject({ risk: "read" });
+    expect(overrides.tools["getTeams"]!.description).toContain("Corpus E2E Team");
+    expect(overrides.tools["getTeamsTeamIdDocuments"]).toMatchObject({ risk: "read" });
+    expect(overrides.tools["getTeamsTeamIdDocuments"]!.description).toContain("seeded document names");
+    expect(overrides.tools["postLinks"]).toMatchObject({ risk: "write" });
+    expect(overrides.tools["putLinksLinkId"]).toMatchObject({ risk: "write" });
+    expect(overrides.tools["postTeamsTeamIdDocumentsDocumentIdAddToDataroom"]).toMatchObject({ risk: "write" });
+    expect(overrides.tools["getTeams"]!.disabled).toBeUndefined();
+    expect(overrides.tools["getAccount"]).toEqual({ disabled: true });
+    // The init-scaffolded handler is already correct; prep must not rewrite it.
+    expect(route).toContain("nextVendoHandler(vendo)");
+    expect(overlay).toContain("VendoOverlay");
+    expect(layout).toContain("<VendoCorpusE2e />");
     expect(corpusPage).toContain("Corpus Papermark E2E");
     expect(loginRoute).toContain("next-auth.session-token");
     expect(loginRoute).toContain("encode({");
     expect(loginRoute).toContain("e2e@corpus.test");
     expect(env).toContain("STRIPE_SECRET_KEY=sk_test_corpus_e2e");
     expect(env).toContain("STRIPE_SECRET_KEY_OLD=sk_test_corpus_e2e_old");
+    expect(env).toContain("VENDO_BASE_URL=http://127.0.0.1:3000");
     expect(premiumLimitShim).toContain("getPremiumTeamEligibility");
     expect(unlimitedLimitShim).toContain("canCreateUnlimitedTeam");
     expect(apiErrorShim).toContain("PapermarkApiError");
@@ -438,5 +437,36 @@ describe("prepareE2eRepo", () => {
     expect(packageJson.scripts["dev:prisma"]).toContain("node scripts/corpus-seed.mjs");
     expect(log).toContain("Papermark fixture seed");
     expect(log).toContain("Papermark e2e login route");
+    expect(log).toContain("overrides.json");
+  });
+
+  it("derives the Vendo route segment instead of hardcoding init's name", async () => {
+    // A repo whose route still uses another catch-all name must not gain a
+    // second, conflicting [...vendo] route (Next rejects sibling catch-alls
+    // with different slugs).
+    const { appRoot, logsDir } = await createPapermarkFixture({ routeSegment: "[...path]" });
+    await prepareE2eRepo({ name: "papermark" }, appRoot, logsDir);
+
+    await expect(readFile(path.join(appRoot, "app/api/vendo/[...path]/route.ts"), "utf8"))
+      .resolves.toContain("nextVendoHandler(vendo)");
+    await expect(readFile(path.join(appRoot, "app/api/vendo/[...vendo]/route.ts"), "utf8")).rejects.toThrow();
+  });
+
+  it("creates the current init handler when the fixture has none", async () => {
+    const { appRoot, logsDir } = await createPapermarkFixture({ routeSegment: null });
+    await prepareE2eRepo({ name: "papermark" }, appRoot, logsDir);
+
+    const route = await readFile(path.join(appRoot, "app/api/vendo/[...vendo]/route.ts"), "utf8");
+    expect(route).toContain("createVendo({");
+    expect(route).toContain("nextVendoHandler(vendo)");
+  });
+
+  it("fails Papermark prep loudly when extraction stops covering a curated endpoint", async () => {
+    const { appRoot, logsDir } = await createPapermarkFixture({
+      toolsJson: `${JSON.stringify({ format: "vendo/tools@1", tools: [] }, null, 2)}\n`,
+    });
+
+    await expect(prepareE2eRepo({ name: "papermark" }, appRoot, logsDir))
+      .rejects.toThrow(/no tool for curated endpoint GET \/api\/teams/);
   });
 });

--- a/corpus/harness/src/e2e-prep.ts
+++ b/corpus/harness/src/e2e-prep.ts
@@ -919,13 +919,18 @@ async function writePapermarkOverrides(appRoot: string): Promise<void> {
     throw new Error("Papermark e2e prep expected vendo init to write .vendo/tools.json before prep runs");
   }
   const extracted = isRecord(parsed) && Array.isArray(parsed.tools) ? parsed.tools : [];
+  // Param NAMES differ between the curated bindings ({documentId}) and
+  // route-scan output ({id}); match endpoints the way sync itself does
+  // (dedupKey): method + path with every {param} normalized to {}.
+  const endpointKey = (method: string, bindingPath: string): string =>
+    `${method} ${bindingPath.replace(/\{[^}]+\}/g, "{}")}`;
   const nameByBinding = new Map<string, string>();
   const extractedNames: string[] = [];
   for (const tool of extracted) {
     if (!isRecord(tool) || typeof tool.name !== "string" || !isRecord(tool.binding)) continue;
     extractedNames.push(tool.name);
     if (typeof tool.binding.method === "string" && typeof tool.binding.path === "string") {
-      nameByBinding.set(`${tool.binding.method} ${tool.binding.path}`, tool.name);
+      nameByBinding.set(endpointKey(tool.binding.method, tool.binding.path), tool.name);
     }
   }
 
@@ -933,7 +938,7 @@ async function writePapermarkOverrides(appRoot: string): Promise<void> {
   const curatedNames = new Set<string>();
   for (const curated of papermarkTools.tools) {
     const endpoint = `${curated.binding.method} ${curated.binding.path}`;
-    const extractedName = nameByBinding.get(endpoint);
+    const extractedName = nameByBinding.get(endpointKey(curated.binding.method, curated.binding.path));
     if (extractedName === undefined) {
       throw new Error(`Papermark e2e prep: extraction has no tool for curated endpoint ${endpoint}; re-pin the curated manifest against current extraction output`);
     }

--- a/corpus/harness/src/e2e-prep.ts
+++ b/corpus/harness/src/e2e-prep.ts
@@ -1,6 +1,7 @@
 import { access, copyFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { ManifestEntry } from "./manifest.js";
+import { vendoRouteFilePath } from "./e2e-prep/route-path.js";
 import { prepareSkateshopE2eRepo } from "./e2e-prep/skateshop.js";
 
 const umamiInstructions = [
@@ -739,7 +740,7 @@ export async function prepareE2eRepo(
   );
   actions.push("wrote Umami Layer 3 read-only tools manifest");
 
-  const routePath = path.join(appRoot, "src/app/api/vendo/[...path]/route.ts");
+  const routePath = await vendoRouteFilePath(appRoot, "src/app");
   await patchFile(routePath, (source) => {
     if (source.includes("storage: false") && source.includes("instructionsExtra")) return source;
     return source.replace(
@@ -853,14 +854,21 @@ async function prepareTeableE2eRepo(appRoot: string, logPath: string): Promise<s
 async function preparePapermarkE2eRepo(appRoot: string, logPath: string): Promise<string[]> {
   const actions: string[] = [];
 
+  // Papermark is the one npm-driven deep fixture, so `npm run build` runs the
+  // init-installed `prebuild: vendo sync --strict` gate. sync re-extracts and
+  // diffs against `.vendo/tools.json`; overwriting that pin with the curated
+  // manifest reads as breaking tool renames (exit 2) now that extraction
+  // covers these endpoints (ENG-242 widen). Keep `.vendo/tools.json` pinned to
+  // init's current extraction output and ship the curated Layer 3 manifest as
+  // a separate, sync-ignored file that the Vendo root imports instead.
   await mkdir(path.join(appRoot, ".vendo"), { recursive: true });
   await writeFile(
-    path.join(appRoot, ".vendo/tools.json"),
+    path.join(appRoot, ".vendo/tools.corpus.json"),
     `${JSON.stringify(papermarkTools, null, 2)}\n`,
   );
-  actions.push("wrote Papermark Layer 3 curated tools manifest");
+  actions.push("wrote Papermark Layer 3 curated tools manifest (sync-ignored tools.corpus.json; .vendo/tools.json stays pinned to extraction)");
 
-  const routePath = path.join(appRoot, "app/api/vendo/[...path]/route.ts");
+  const routePath = await vendoRouteFilePath(appRoot, "app");
   await mkdir(path.dirname(routePath), { recursive: true });
   await ensureFile(routePath, `import { createVendoHandler } from "vendoai/server";
 
@@ -887,7 +895,7 @@ export const { GET, POST } = createVendoHandler();
 import { VendoRoot } from "vendoai/react";
 import type { ReactNode } from "react";
 import theme from "../.vendo/theme.json";
-import tools from "../.vendo/tools.json";
+import tools from "../.vendo/tools.corpus.json";
 
 export function AppVendoRoot({ children }: { children: ReactNode }) {
   return (
@@ -897,8 +905,10 @@ export function AppVendoRoot({ children }: { children: ReactNode }) {
   );
 }
 `);
+  await patchFile(rootPath, (source) =>
+    source.replace('.vendo/tools.json"', '.vendo/tools.corpus.json"'));
   await patchVendoRoot(rootPath, "Papermark");
-  actions.push("patched Vendo root to accept per-attempt thread ids");
+  actions.push("patched Vendo root to accept per-attempt thread ids and import the curated corpus manifest");
 
   const corpusPagePath = path.join(appRoot, "app/corpus-e2e/page.tsx");
   await mkdir(path.dirname(corpusPagePath), { recursive: true });

--- a/corpus/harness/src/e2e-prep.ts
+++ b/corpus/harness/src/e2e-prep.ts
@@ -1,20 +1,17 @@
 import { access, copyFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { ManifestEntry } from "./manifest.js";
+import { mountCorpusOverlay } from "./e2e-prep/overlay-mount.js";
 import { vendoRouteFilePath } from "./e2e-prep/route-path.js";
 import { prepareSkateshopE2eRepo } from "./e2e-prep/skateshop.js";
 
-const umamiInstructions = [
-  "This corpus run uses Umami seed data for Demo Blog (blog.example.com) and Demo SaaS (app.example.com).",
-  "Always call list_umami_websites first to map a requested site name or domain to its websiteId.",
-  "For top pages, blog article comparisons, signup events, and referrers, call get_umami_website_metrics.",
-  "For revenue questions, call get_umami_revenue_report.",
-  "Use UTC. Seeded date windows: last 7 days startAt=1782691200000 endAt=1783382399000; this month startDate=2026-07-01T00:00:00.000Z endDate=2026-07-06T23:59:59.000Z; last 30 days startAt=1780704000000 endAt=1783382399000.",
-  "For every corpus prompt, answer only after gathering data. The visible answer must include labels and numeric values from the Umami tool result.",
-  "If you render a view, keep it compact and still summarize the key values in visible text.",
-].join("\n");
-
-const umamiRootAuthShim = `
+// Umami authenticates its API with a Bearer token the app keeps in
+// localStorage. Chat tool calls now execute SERVER-side (route bindings,
+// 04 §4), and the registry forwards the WIRE request's cookie/authorization
+// headers to same-origin bindings when VENDO_BASE_URL is operator-set — so
+// the shim attaches the Bearer to every same-origin /api/ request INCLUDING
+// /api/vendo, and prep pins VENDO_BASE_URL in the fixture .env.
+const umamiAuthShim = `
 const UMAMI_AUTH_KEY = "umami.auth";
 
 function readUmamiAuthToken(): string | undefined {
@@ -38,9 +35,11 @@ function isUmamiApiRequest(input: Parameters<typeof fetch>[0]): boolean {
       : input.url;
   try {
     const url = new URL(rawUrl, window.location.href);
+    // Includes /api/vendo on purpose: the Vendo wire forwards
+    // cookie/authorization to same-origin route bindings, which is how the
+    // server-side Umami tool calls authenticate.
     return url.origin === window.location.origin
-      && url.pathname.startsWith("/api/")
-      && !url.pathname.startsWith("/api/vendo");
+      && url.pathname.startsWith("/api/");
   } catch {
     return false;
   }
@@ -73,7 +72,7 @@ const umamiTools = {
   tools: [
     {
       name: "list_umami_websites",
-      description: "List Umami websites visible to the logged-in user, including seeded Demo Blog and Demo SaaS IDs/domains.",
+      description: "List Umami websites visible to the logged-in user, including seeded Demo Blog (blog.example.com) and Demo SaaS (app.example.com) IDs/domains. Always call this first to map a requested site name or domain to its websiteId, and answer corpus prompts only after gathering data — the visible answer must quote labels and numeric values from the tool results.",
       inputSchema: {
         type: "object",
         properties: {},
@@ -84,7 +83,7 @@ const umamiTools = {
     },
     {
       name: "get_umami_website_metrics",
-      description: "Get ranked Umami metrics for one website. Use type=path for top pages, type=event for custom events such as signup_started/signup_completed, and type=referrer for acquisition sources.",
+      description: "Get ranked Umami metrics for one website. Use type=path for top pages, type=event for custom events such as signup_started/signup_completed, and type=referrer for acquisition sources. Use UTC with the seeded windows: last 7 days startAt=1782691200000 endAt=1783382399000; last 30 days startAt=1780704000000 endAt=1783382399000.",
       inputSchema: {
         type: "object",
         properties: {
@@ -108,7 +107,7 @@ const umamiTools = {
     },
     {
       name: "get_umami_pageviews",
-      description: "Get Umami pageview and session time series for one website over a date range.",
+      description: "Get Umami pageview and session time series for one website over a date range. Use UTC with the seeded windows: last 7 days startAt=1782691200000 endAt=1783382399000; last 30 days startAt=1780704000000 endAt=1783382399000.",
       inputSchema: {
         type: "object",
         properties: {
@@ -126,7 +125,7 @@ const umamiTools = {
     },
     {
       name: "get_umami_revenue_report",
-      description: "Get seeded Umami revenue totals and breakdowns for one website. Use this for Demo SaaS purchase revenue questions.",
+      description: "Get seeded Umami revenue totals and breakdowns for one website. Use this for Demo SaaS purchase revenue questions. Seeded this-month window (UTC): startDate=2026-07-01T00:00:00.000Z endDate=2026-07-06T23:59:59.000Z.",
       inputSchema: {
         type: "object",
         properties: {
@@ -163,7 +162,7 @@ const umamiTools = {
     },
     {
       name: "get_umami_funnel_report",
-      description: "Get an Umami funnel report for path or event steps. Use for signup_started to signup_completed conversion questions.",
+      description: "Get an Umami funnel report for path or event steps. Use for signup_started to signup_completed conversion questions. Seeded this-month window (UTC): startDate=2026-07-01T00:00:00.000Z endDate=2026-07-06T23:59:59.000Z.",
       inputSchema: {
         type: "object",
         properties: {
@@ -211,19 +210,14 @@ const umamiTools = {
   ],
 };
 
-const papermarkInstructions = [
-  "This corpus run uses a deterministic Papermark fixture.",
-  "Fixture user: e2e@corpus.test. Fixture team: Corpus E2E Team.",
-  "Fixture documents: Corpus Q3 Board Packet.pdf, Pricing Memo.pdf, and Security Overview.pdf.",
-  "Fixture dataroom: Investor Room. Fixture test recipient/viewer: analyst@example.test.",
-  "Always call getTeams first and use the returned Corpus E2E Team id as teamId.",
-  "For document lists, call listTeamDocuments and render a compact table with document names, status, views, links, and dataroom counts.",
-  "For viewer activity, call listTeamDocuments to find the document id, then call getDocumentStats and getDocumentViews before answering.",
-  "For link updates, call listDocumentLinks after finding the document id so you can identify the seeded link.",
-  "For dataroom actions, call listDatarooms after getTeams so you can identify Investor Room.",
-  "For every corpus prompt, fetch data before answering. Include the exact fixture names and analyst@example.test when relevant.",
-  "Render a table for list asks, and render visible text that mentions viewer, visit, document, or activity for analytics asks.",
-].join("\n");
+// Shared fixture framing prepended to every curated Papermark description so
+// the guidance survives without the old handler-level instructionsExtra knob
+// (the descriptions are what the agent sees).
+const papermarkFixtureNote =
+  "Deterministic Papermark corpus fixture: user e2e@corpus.test, team Corpus E2E Team, "
+  + "documents Corpus Q3 Board Packet.pdf / Pricing Memo.pdf / Security Overview.pdf, "
+  + "dataroom Investor Room, test recipient analyst@example.test. "
+  + "Fetch data before answering and quote the exact fixture names.";
 
 const papermarkTools = {
   format: "vendo/tools@1",
@@ -734,66 +728,26 @@ export async function prepareE2eRepo(
 
   const actions: string[] = [];
 
+  // The curated manifest is the server-side tool source: the composed umbrella
+  // loads .vendo/tools.json through createActions (04 §1). Fixture guidance
+  // (seeded windows, call-first ordering) lives in the tool descriptions — the
+  // old handler-level instructionsExtra knob no longer exists.
   await writeFile(
     path.join(appRoot, ".vendo/tools.json"),
     `${JSON.stringify(umamiTools, null, 2)}\n`,
   );
   actions.push("wrote Umami Layer 3 read-only tools manifest");
 
-  const routePath = await vendoRouteFilePath(appRoot, "src/app");
-  await patchFile(routePath, (source) => {
-    if (source.includes("storage: false") && source.includes("instructionsExtra")) return source;
-    return source.replace(
-      "export const { GET, POST } = createVendoHandler();",
-      `export const { GET, POST } = createVendoHandler({
-  storage: false,
-  maxSteps: 8,
-  instructionsExtra: ${JSON.stringify(umamiInstructions)},
-});`,
-    );
-  });
-  actions.push("patched Vendo handler for e2e-only in-memory storage and Umami tool guidance");
+  // Credential forwarding to route bindings requires a TRUSTED operator-set
+  // base URL (04 §4); a learned origin never receives the caller's headers.
+  await ensureEnvValue(path.join(appRoot, ".env"), "VENDO_BASE_URL", "http://127.0.0.1:3000");
+  actions.push("pinned VENDO_BASE_URL so the wire forwards Umami Bearer auth to route bindings");
 
-  const rootPath = path.join(appRoot, "src/app/vendo-root.tsx");
-  await patchFile(rootPath, (source) => {
-    let next = source;
-    if (!next.includes('installUmamiAuthFetch')) {
-      next = next
-        .replace(
-          'import type { ReactNode } from "react";',
-          'import { useEffect, type ReactNode } from "react";',
-        )
-        .replace(
-          'import tools from "../../.vendo/tools.json";',
-          `import tools from "../../.vendo/tools.json";\n${umamiRootAuthShim}`,
-        );
-    }
-    if (!next.includes("threadId={threadId}")) {
-      next = next
-      .replace(
-        "export function AppVendoRoot({ children }: { children: ReactNode }) {\n  return (",
-        `export function AppVendoRoot({ children }: { children: ReactNode }) {
-  const threadId = typeof window === "undefined"
-    ? "vendo"
-    : new URLSearchParams(window.location.search).get("vendoThread") ?? "vendo";
-
-  return (`,
-      )
-      .replace(
-        '<VendoRoot theme={theme} tools={tools} productName="Umami">',
-        '<VendoRoot theme={theme} tools={tools} productName="Umami" threadId={threadId}>',
-      );
-    }
-    if (!next.includes("installUmamiAuthFetch();")) {
-      next = next.replace(
-        "export function AppVendoRoot({ children }: { children: ReactNode }) {",
-        `export function AppVendoRoot({ children }: { children: ReactNode }) {
-  useEffect(() => installUmamiAuthFetch(), []);`,
-      );
-    }
-    return next;
+  await mountCorpusOverlay(appRoot, "src/app", {
+    moduleSource: umamiAuthShim,
+    effect: "installUmamiAuthFetch()",
   });
-  actions.push("patched Vendo root to accept per-attempt thread ids and Umami auth headers");
+  actions.push("mounted the corpus Vendo overlay with the Umami auth fetch shim");
 
   await writeFile(logPath, `${actions.join("\n")}\n`);
   return [logPath];
@@ -854,61 +808,41 @@ async function prepareTeableE2eRepo(appRoot: string, logPath: string): Promise<s
 async function preparePapermarkE2eRepo(appRoot: string, logPath: string): Promise<string[]> {
   const actions: string[] = [];
 
-  // Papermark is the one npm-driven deep fixture, so `npm run build` runs the
-  // init-installed `prebuild: vendo sync --strict` gate. sync re-extracts and
-  // diffs against `.vendo/tools.json`; overwriting that pin with the curated
-  // manifest reads as breaking tool renames (exit 2) now that extraction
-  // covers these endpoints (ENG-242 widen). Keep `.vendo/tools.json` pinned to
-  // init's current extraction output and ship the curated Layer 3 manifest as
-  // a separate, sync-ignored file that the Vendo root imports instead.
-  await mkdir(path.join(appRoot, ".vendo"), { recursive: true });
-  await writeFile(
-    path.join(appRoot, ".vendo/tools.corpus.json"),
-    `${JSON.stringify(papermarkTools, null, 2)}\n`,
-  );
-  actions.push("wrote Papermark Layer 3 curated tools manifest (sync-ignored tools.corpus.json; .vendo/tools.json stays pinned to extraction)");
+  // Papermark is the one npm-driven deep fixture, so `npm run build` / `npm
+  // run dev` execute the init-installed `vendo sync` hooks (`--strict` on
+  // build). sync re-extracts and diffs against the .vendo/tools.json pin,
+  // which means the curated Layer 3 manifest can never live IN tools.json
+  // here: replacing the pin read as 9 breaking tool renames (exit 2) once
+  // ENG-242's widened extraction covered these endpoints. The pin therefore
+  // stays exactly what init extracted, and the curation ships as
+  // .vendo/overrides.json — the human-written channel that both sync
+  // (symmetric merge, no diff) and the runtime registry (description/risk/
+  // disabled) respect.
+  await writePapermarkOverrides(appRoot);
+  actions.push("kept .vendo/tools.json pinned to init's extraction; wrote curated overrides.json (descriptions/risk for the 9 fixture endpoints, everything else disabled)");
 
   const routePath = await vendoRouteFilePath(appRoot, "app");
   await mkdir(path.dirname(routePath), { recursive: true });
-  await ensureFile(routePath, `import { createVendoHandler } from "vendoai/server";
+  await ensureFile(routePath, `import { model } from "@/lib/ai";
+import { createVendo, nextVendoHandler } from "@vendoai/vendo/server";
 
-export const runtime = "nodejs";
-export const dynamic = "force-dynamic";
+const vendo = createVendo({
+  model,
+  principal: async () => null,
+});
 
-export const { GET, POST } = createVendoHandler();
+export const { GET, POST, DELETE } = nextVendoHandler(vendo);
 `);
-  await patchFile(routePath, (source) => {
-    if (source.includes("storage: false") && source.includes("instructionsExtra")) return source;
-    return source.replace(
-      "export const { GET, POST } = createVendoHandler();",
-      `export const { GET, POST } = createVendoHandler({
-  storage: false,
-  maxSteps: 8,
-  instructionsExtra: ${JSON.stringify(papermarkInstructions)},
-});`,
-    );
-  });
-  actions.push("patched Vendo handler for e2e-only in-memory storage and Papermark fixture guidance");
+  actions.push("ensured the Vendo App Router handler exists (current init scaffold)");
 
-  const rootPath = path.join(appRoot, "app/vendo-root.tsx");
-  await ensureFile(rootPath, `"use client";
-import { VendoRoot } from "vendoai/react";
-import type { ReactNode } from "react";
-import theme from "../.vendo/theme.json";
-import tools from "../.vendo/tools.corpus.json";
+  // Credential forwarding to route bindings requires a TRUSTED operator-set
+  // base URL (04 §4); the fixture session cookie set by /api/corpus-login
+  // only reaches the real Papermark API through it.
+  await ensureEnvValue(path.join(appRoot, ".env"), "VENDO_BASE_URL", "http://127.0.0.1:3000");
+  actions.push("pinned VENDO_BASE_URL so the wire forwards the fixture session cookie to route bindings");
 
-export function AppVendoRoot({ children }: { children: ReactNode }) {
-  return (
-    <VendoRoot theme={theme} tools={tools} productName="Papermark">
-      {children}
-    </VendoRoot>
-  );
-}
-`);
-  await patchFile(rootPath, (source) =>
-    source.replace('.vendo/tools.json"', '.vendo/tools.corpus.json"'));
-  await patchVendoRoot(rootPath, "Papermark");
-  actions.push("patched Vendo root to accept per-attempt thread ids and import the curated corpus manifest");
+  await mountCorpusOverlay(appRoot, "app");
+  actions.push("mounted the corpus Vendo overlay");
 
   const corpusPagePath = path.join(appRoot, "app/corpus-e2e/page.tsx");
   await mkdir(path.dirname(corpusPagePath), { recursive: true });
@@ -922,16 +856,6 @@ export function AppVendoRoot({ children }: { children: ReactNode }) {
 }
 `);
   actions.push("wrote Papermark App Router e2e host page");
-
-  const layoutPath = path.join(appRoot, "app/layout.tsx");
-  await patchFile(layoutPath, (source) => {
-    if (source.includes("<AppVendoRoot")) return source;
-    const withImport = source.includes('import { AppVendoRoot } from "./vendo-root";')
-      ? source
-      : `import { AppVendoRoot } from "./vendo-root";\n${source}`;
-    return withImport.replace("{children}", "<AppVendoRoot>{children}</AppVendoRoot>");
-  });
-  actions.push("patched root layout to wrap children with AppVendoRoot");
 
   const loginRoutePath = path.join(appRoot, "pages/api/corpus-login.ts");
   await mkdir(path.dirname(loginRoutePath), { recursive: true });
@@ -977,26 +901,56 @@ async function writePapermarkApiSupportShims(appRoot: string): Promise<void> {
   await ensureFile(path.join(appRoot, "lib/api/errors.ts"), papermarkApiErrorShim);
 }
 
-async function patchVendoRoot(rootPath: string, productName: string): Promise<void> {
-  await patchFile(rootPath, (source) => {
-    let next = source;
-    if (!next.includes("threadId={threadId}")) {
-      next = next.replace(
-        "export function AppVendoRoot({ children }: { children: ReactNode }) {\n  return (",
-        `export function AppVendoRoot({ children }: { children: ReactNode }) {
-  const threadId = typeof window === "undefined"
-    ? "vendo"
-    : new URLSearchParams(window.location.search).get("vendoThread") ?? "vendo";
-
-  return (`,
-      );
-      next = next.replace(
-        `<VendoRoot theme={theme} tools={tools} productName="${productName}">`,
-        `<VendoRoot theme={theme} tools={tools} productName="${productName}" threadId={threadId}>`,
-      );
+/**
+ * The curated Papermark manifest expressed through the overrides channel:
+ * `.vendo/tools.json` stays pinned to init's extraction (so the fixture's
+ * `vendo sync --strict` prebuild is a no-op diff), and each curated endpoint's
+ * description + risk are keyed to the EXTRACTION name for that binding. Every
+ * other extracted tool is disabled so the agent works the same 9-tool surface
+ * the conversations were written against. Fails loudly when extraction stops
+ * covering a curated endpoint — that is a real re-pin moment, not a skip.
+ */
+async function writePapermarkOverrides(appRoot: string): Promise<void> {
+  const toolsPath = path.join(appRoot, ".vendo/tools.json");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(toolsPath, "utf8"));
+  } catch {
+    throw new Error("Papermark e2e prep expected vendo init to write .vendo/tools.json before prep runs");
+  }
+  const extracted = isRecord(parsed) && Array.isArray(parsed.tools) ? parsed.tools : [];
+  const nameByBinding = new Map<string, string>();
+  const extractedNames: string[] = [];
+  for (const tool of extracted) {
+    if (!isRecord(tool) || typeof tool.name !== "string" || !isRecord(tool.binding)) continue;
+    extractedNames.push(tool.name);
+    if (typeof tool.binding.method === "string" && typeof tool.binding.path === "string") {
+      nameByBinding.set(`${tool.binding.method} ${tool.binding.path}`, tool.name);
     }
-    return next;
-  });
+  }
+
+  const overrides: Record<string, { risk?: string; description?: string; disabled?: boolean }> = {};
+  const curatedNames = new Set<string>();
+  for (const curated of papermarkTools.tools) {
+    const endpoint = `${curated.binding.method} ${curated.binding.path}`;
+    const extractedName = nameByBinding.get(endpoint);
+    if (extractedName === undefined) {
+      throw new Error(`Papermark e2e prep: extraction has no tool for curated endpoint ${endpoint}; re-pin the curated manifest against current extraction output`);
+    }
+    curatedNames.add(extractedName);
+    overrides[extractedName] = {
+      risk: curated.risk,
+      description: `${papermarkFixtureNote} ${curated.description}`,
+    };
+  }
+  for (const name of extractedNames) {
+    if (!curatedNames.has(name)) overrides[name] = { disabled: true };
+  }
+
+  await writeFile(
+    path.join(appRoot, ".vendo/overrides.json"),
+    `${JSON.stringify({ format: "vendo/overrides@1", tools: overrides }, null, 2)}\n`,
+  );
 }
 
 async function patchPapermarkSeedCommand(packageJsonPath: string): Promise<void> {

--- a/corpus/harness/src/e2e-prep/overlay-mount.ts
+++ b/corpus/harness/src/e2e-prep/overlay-mount.ts
@@ -1,0 +1,56 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+/** Client-side extras a fixture bakes into the corpus overlay component.
+ * `moduleSource` is inserted at module scope (e.g. umami's Bearer-token fetch
+ * shim); `effect` is a call expression run once on mount inside useEffect. */
+export interface CorpusOverlayExtras {
+  moduleSource?: string;
+  effect?: string;
+}
+
+const componentName = "VendoCorpusE2e";
+
+/** The client component file e2e prep writes beside the App Router layout. */
+export const corpusOverlayBasename = "vendo-corpus-e2e.tsx";
+
+export function corpusOverlaySource(extras: CorpusOverlayExtras = {}): string {
+  const useEffectImport = extras.effect === undefined ? "" : 'import { useEffect } from "react";\n';
+  const effect = extras.effect === undefined ? "" : `  useEffect(() => ${extras.effect}, []);\n`;
+  return `"use client";
+${useEffectImport}import { VendoOverlay } from "@vendoai/ui/chrome";
+${extras.moduleSource ?? ""}
+export function ${componentName}() {
+${effect}  return <VendoOverlay />;
+}
+`;
+}
+
+/**
+ * `vendo init` wires `<VendoRoot theme={...}>` into the App Router layout but
+ * ships no chat chrome — hosts mount `VendoOverlay` themselves (the demo apps
+ * do exactly this). The corpus fixtures are hosts too, so e2e prep mounts the
+ * overlay via a small client component beside the layout. Fails loudly when
+ * the layout does not carry init's VendoRoot wrapper, so the harness surfaces
+ * the next init-scaffold drift instead of silently producing a chat-less page.
+ */
+export async function mountCorpusOverlay(
+  appRoot: string,
+  appDirRel: string,
+  extras: CorpusOverlayExtras = {},
+): Promise<void> {
+  const appDir = path.join(appRoot, appDirRel);
+  await writeFile(path.join(appDir, corpusOverlayBasename), corpusOverlaySource(extras));
+
+  const layoutPath = path.join(appDir, "layout.tsx");
+  const source = await readFile(layoutPath, "utf8");
+  if (source.includes(componentName)) return;
+  if (!source.includes("{children}</VendoRoot>")) {
+    throw new Error(
+      `Corpus e2e prep expected ${layoutPath} to wrap {children} in VendoRoot (vendo init layout output drifted?)`,
+    );
+  }
+  const next = `import { ${componentName} } from "./vendo-corpus-e2e";\n${source}`
+    .replace("{children}</VendoRoot>", `{children}<${componentName} /></VendoRoot>`);
+  await writeFile(layoutPath, next);
+}

--- a/corpus/harness/src/e2e-prep/route-path.ts
+++ b/corpus/harness/src/e2e-prep/route-path.ts
@@ -1,0 +1,27 @@
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+/** The catch-all segment `vendo init` currently scaffolds (renamed from
+ * `[...path]` in 1e577988). Used when the route does not exist yet and the
+ * harness has to create it. */
+export const initVendoRouteSegment = "[...vendo]";
+
+const catchAllSegment = /^\[\.\.\..+\]$/;
+
+/**
+ * Resolve the Vendo handler route file inside an init-run corpus repo by
+ * reading the segment `vendo init` actually created under `api/vendo/`,
+ * instead of hardcoding the segment name. This keeps the e2e prep seam from
+ * drifting when init renames its scaffold (as it did in 1e577988,
+ * `[...path]` -> `[...vendo]`). Falls back to the current init segment when
+ * no route exists yet, so callers that create the file get the init shape.
+ */
+export async function vendoRouteFilePath(appRoot: string, appDirRel: string): Promise<string> {
+  const vendoApiDir = path.join(appRoot, appDirRel, "api", "vendo");
+  const entries = await readdir(vendoApiDir, { withFileTypes: true }).catch(() => []);
+  const segments = entries
+    .filter((entry) => entry.isDirectory() && catchAllSegment.test(entry.name))
+    .map((entry) => entry.name)
+    .sort();
+  return path.join(vendoApiDir, segments[0] ?? initVendoRouteSegment, "route.ts");
+}

--- a/corpus/harness/src/e2e-prep/skateshop.ts
+++ b/corpus/harness/src/e2e-prep/skateshop.ts
@@ -1,24 +1,13 @@
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { vendoRouteFilePath } from "./route-path.js";
-
-const skateshopInstructions = [
-  "This corpus run uses Skateshop seed data from src/assets/data/products.json, stored in the app database by the corpus-only API route on first use.",
-  "Seeded products include Youness gradient cuts impact 8.375 skateboard deck, Max mean pets paintings impact light 8.25 skateboard deck, Nike Streakfly, Nike InfinityRN 4, Nike Air Max 2013, and Nike Pegasus 40 BTC.",
-  "Always call list_skateshop_catalog_products or search_skateshop_products before answering product, catalog, item, inventory, compare, cart, checkout, or order prompts. Do not answer from memory.",
-  "For list, browse, show, or compare prompts, render a Table view with columns Product, Price, Inventory, Rating, and Category, then give a one-sentence summary.",
-  "For a single-product find prompt, render a compact view that visibly includes the exact product name, price, inventory, rating, category, and subcategory.",
-  "For cart prompts, search the product first if needed, then call exactly one mutating cart tool.",
-  "For order prompts that mention default checkout details, call get_skateshop_checkout_defaults after finding the product, then call exactly one mutating order tool.",
-  "Mutating cart/order tools are approval-gated, so the approval card is the expected visible outcome.",
-].join("\n");
+import { mountCorpusOverlay } from "./overlay-mount.js";
 
 const skateshopTools = {
   format: "vendo/tools@1",
   tools: [
     {
       name: "list_skateshop_catalog_products",
-      description: "List Skateshop catalog products/items with price, inventory, rating, category, and subcategory. Use for browse, show, deck, store, inventory, and table requests.",
+      description: "List Skateshop catalog products/items with price, inventory, rating, category, and subcategory. Use for browse, show, deck, store, inventory, and table requests. Always call this (or search_skateshop_products) before answering any product/catalog/cart/order prompt — never answer from memory. Seeded products include Youness gradient cuts impact 8.375 skateboard deck, Max mean pets paintings impact light 8.25 skateboard deck, Nike Streakfly, Nike InfinityRN 4, Nike Air Max 2013, and Nike Pegasus 40 BTC. For list/browse/compare prompts render a Table view with columns Product, Price, Inventory, Rating, and Category, then give a one-sentence summary.",
       inputSchema: {
         type: "object",
         properties: {
@@ -34,7 +23,7 @@ const skateshopTools = {
     },
     {
       name: "search_skateshop_products",
-      description: "Search Skateshop products/items by exact or partial product name before comparing, adding to cart, or placing an order. Returns product ids, price, inventory, rating, category, and store id.",
+      description: "Search Skateshop products/items by exact or partial product name before comparing, adding to cart, or placing an order. Returns product ids, price, inventory, rating, category, and store id. For a single-product find prompt, render a compact view that visibly includes the exact product name, price, inventory, rating, category, and subcategory.",
       inputSchema: {
         type: "object",
         properties: {
@@ -50,7 +39,7 @@ const skateshopTools = {
     },
     {
       name: "add_skateshop_item_to_cart",
-      description: "Add one Skateshop product item to the current browser cart. Use after resolving the product with search_skateshop_products. Accepts productName when the exact seeded name is known.",
+      description: "Add one Skateshop product item to the current browser cart. Use after resolving the product with search_skateshop_products; call exactly one mutating cart tool per prompt. Approval-gated, so the approval card is the expected visible outcome. Accepts productName when the exact seeded name is known.",
       inputSchema: {
         type: "object",
         properties: {
@@ -72,7 +61,7 @@ const skateshopTools = {
     },
     {
       name: "place_skateshop_order",
-      description: "Place a minimal Skateshop checkout order for one product using default corpus checkout details. Use after resolving the product with search_skateshop_products. This is approval-gated.",
+      description: "Place a minimal Skateshop checkout order for one product using default corpus checkout details. Use after resolving the product with search_skateshop_products, calling get_skateshop_checkout_defaults first when the prompt mentions default checkout details; call exactly one mutating order tool per prompt. This is approval-gated, so the approval card is the expected visible outcome.",
       inputSchema: {
         type: "object",
         properties: {
@@ -589,23 +578,13 @@ export async function prepareSkateshopE2eRepo(appRoot: string, logsDir: string):
   await patchSkateshopUserQuery(appRoot);
   actions.push("patched Skateshop cached user query corpus bypass");
 
-  const routePath = await vendoRouteFilePath(appRoot, "src/app");
-  await patchFile(routePath, (source) => {
-    if (source.includes("storage: false") && source.includes("instructionsExtra")) return source;
-    return source.replace(
-      "export const { GET, POST } = createVendoHandler();",
-      `export const { GET, POST } = createVendoHandler({
-  storage: false,
-  maxSteps: 8,
-  instructionsExtra: ${JSON.stringify(skateshopInstructions)},
-});`,
-    );
-  });
-  actions.push("patched Vendo handler for e2e-only in-memory storage and Skateshop tool guidance");
-
-  const rootPath = path.join(appRoot, "src/app/vendo-root.tsx");
-  await patchFile(rootPath, patchSkateshopRoot);
-  actions.push("patched Vendo root to accept per-attempt thread ids");
+  // The curated manifest is the server-side tool source (createActions reads
+  // .vendo/tools.json); guidance lives in the tool descriptions since the old
+  // handler-level instructionsExtra knob no longer exists, and the chat
+  // surface ships as the corpus-mounted VendoOverlay (init wires the VendoRoot
+  // provider only).
+  await mountCorpusOverlay(appRoot, "src/app");
+  actions.push("mounted the corpus Vendo overlay");
 
   await writeFile(logPath, `${actions.join("\n")}\n`);
   return [logPath];
@@ -706,26 +685,6 @@ async function patchSkateshopUserQuery(appRoot: string): Promise<void> {
       .replace('import { currentUser } from "@clerk/nextjs/server"\n', "")
       .replace("export const getCachedUser = cache(currentUser)", "export const getCachedUser = cache(async () => null)");
   });
-}
-
-function patchSkateshopRoot(source: string): string {
-  let next = source;
-  if (!next.includes("threadId={threadId}")) {
-    next = next.replace(
-      "export function AppVendoRoot({ children }: { children: ReactNode }) {\n  return (",
-      `export function AppVendoRoot({ children }: { children: ReactNode }) {
-  const threadId = typeof window === "undefined"
-    ? "vendo"
-    : new URLSearchParams(window.location.search).get("vendoThread") ?? "vendo";
-
-  return (`,
-    );
-    next = next.replace(
-      /<VendoRoot\b([^>]*)>/,
-      (match, attrs: string) => match.includes("threadId=") ? match : `<VendoRoot${attrs} threadId={threadId}>`,
-    );
-  }
-  return next;
 }
 
 async function firstExisting(filePaths: string[]): Promise<string | null> {

--- a/corpus/harness/src/e2e-prep/skateshop.ts
+++ b/corpus/harness/src/e2e-prep/skateshop.ts
@@ -1,5 +1,6 @@
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { vendoRouteFilePath } from "./route-path.js";
 
 const skateshopInstructions = [
   "This corpus run uses Skateshop seed data from src/assets/data/products.json, stored in the app database by the corpus-only API route on first use.",
@@ -588,7 +589,7 @@ export async function prepareSkateshopE2eRepo(appRoot: string, logsDir: string):
   await patchSkateshopUserQuery(appRoot);
   actions.push("patched Skateshop cached user query corpus bypass");
 
-  const routePath = path.join(appRoot, "src/app/api/vendo/[...path]/route.ts");
+  const routePath = await vendoRouteFilePath(appRoot, "src/app");
   await patchFile(routePath, (source) => {
     if (source.includes("storage: false") && source.includes("instructionsExtra")) return source;
     return source.replace(

--- a/corpus/harness/src/layers/e2e.ts
+++ b/corpus/harness/src/layers/e2e.ts
@@ -312,11 +312,10 @@ export async function evaluateAssertion(
     // Chat tool calls execute server-side in the composed umbrella (04 §4),
     // so many never surface as page-originated network requests. The thread
     // chrome renders every call as an "fl-tool-label" chip ("Tool: <name>");
-    // count those too.
-    const domMatches = matches.length > 0 || page === undefined
-      ? 0
-      : await countToolCallDomMatches(page, assertion.name);
-    const observed = matches.length + domMatches;
+    // count those too. The two sources can describe the SAME call, so take
+    // the larger count rather than the sum.
+    const domMatches = page === undefined ? 0 : await countToolCallDomMatches(page, assertion.name);
+    const observed = Math.max(matches.length, domMatches);
     const minimum = assertion.minimum ?? 1;
     return {
       id,

--- a/corpus/harness/src/layers/e2e.ts
+++ b/corpus/harness/src/layers/e2e.ts
@@ -687,11 +687,18 @@ async function attachNetworkSignals(
 }
 
 async function loadManifestToolBindings(repoDir: string): Promise<ManifestToolBinding[]> {
+  // Fixtures whose curated Layer 3 manifest must not clobber the sync-managed
+  // extraction pin (papermark) ship it as .vendo/tools.corpus.json instead of
+  // .vendo/tools.json; prefer the curated manifest when it exists.
   let raw: string;
   try {
-    raw = await readFile(path.join(repoDir, ".vendo/tools.json"), "utf8");
+    raw = await readFile(path.join(repoDir, ".vendo/tools.corpus.json"), "utf8");
   } catch {
-    return [];
+    try {
+      raw = await readFile(path.join(repoDir, ".vendo/tools.json"), "utf8");
+    } catch {
+      return [];
+    }
   }
   const value = JSON.parse(raw) as unknown;
   const tools = isRecord(value) && Array.isArray(value.tools) ? value.tools : Array.isArray(value) ? value : [];

--- a/corpus/harness/src/layers/e2e.ts
+++ b/corpus/harness/src/layers/e2e.ts
@@ -9,6 +9,7 @@ export interface E2eLocator {
   fill?(value: string): Promise<void>;
   press?(key: string): Promise<void>;
   textContent?(): Promise<string | null>;
+  allTextContents?(): Promise<string[]>;
   first?(): E2eLocator;
 }
 
@@ -308,13 +309,21 @@ export async function evaluateAssertion(
   const id = assertion.id ?? assertion.kind;
   if (assertion.kind === "tool-called") {
     const matches = signals.toolCalls.filter((call) => textMatches(assertion.name, call.name));
+    // Chat tool calls execute server-side in the composed umbrella (04 §4),
+    // so many never surface as page-originated network requests. The thread
+    // chrome renders every call as an "fl-tool-label" chip ("Tool: <name>");
+    // count those too.
+    const domMatches = matches.length > 0 || page === undefined
+      ? 0
+      : await countToolCallDomMatches(page, assertion.name);
+    const observed = matches.length + domMatches;
     const minimum = assertion.minimum ?? 1;
     return {
       id,
       kind: assertion.kind,
-      pass: matches.length >= minimum,
-      detail: matches.length >= minimum
-        ? `${matches.length} matching tool call(s) observed`
+      pass: observed >= minimum,
+      detail: observed >= minimum
+        ? `${observed} matching tool call(s) observed`
         : `expected at least ${minimum} tool call(s); observed ${signals.toolCalls.map((call) => call.name).join(", ") || "none"}`,
     };
   }
@@ -687,18 +696,11 @@ async function attachNetworkSignals(
 }
 
 async function loadManifestToolBindings(repoDir: string): Promise<ManifestToolBinding[]> {
-  // Fixtures whose curated Layer 3 manifest must not clobber the sync-managed
-  // extraction pin (papermark) ship it as .vendo/tools.corpus.json instead of
-  // .vendo/tools.json; prefer the curated manifest when it exists.
   let raw: string;
   try {
-    raw = await readFile(path.join(repoDir, ".vendo/tools.corpus.json"), "utf8");
+    raw = await readFile(path.join(repoDir, ".vendo/tools.json"), "utf8");
   } catch {
-    try {
-      raw = await readFile(path.join(repoDir, ".vendo/tools.json"), "utf8");
-    } catch {
-      return [];
-    }
+    return [];
   }
   const value = JSON.parse(raw) as unknown;
   const tools = isRecord(value) && Array.isArray(value.tools) ? value.tools : Array.isArray(value) ? value : [];
@@ -787,6 +789,12 @@ async function waitFor(predicate: () => Promise<boolean>, timeoutMs: number): Pr
   }
   const suffix = lastError instanceof Error ? ` Last error: ${lastError.message}` : "";
   throw new Error(`Timed out after ${timeoutMs}ms.${suffix}`);
+}
+
+async function countToolCallDomMatches(page: E2ePage, name: TextMatcher): Promise<number> {
+  const labels = page.locator(".fl-tool-label");
+  const texts = await labels.allTextContents?.().catch(() => [] as string[]) ?? [];
+  return texts.filter((text) => textMatches(name, text.replace(/^Tool:\s*/i, ""))).length;
 }
 
 async function countViewDomMatches(page: E2ePage, assertion: Extract<ConversationAssertion, { kind: "view-rendered" }>): Promise<number> {

--- a/corpus/harness/src/local-pack.ts
+++ b/corpus/harness/src/local-pack.ts
@@ -2,7 +2,12 @@ import { spawn } from "node:child_process";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 
-export const LOCAL_DIRECT_DEPENDENCIES = ["@vendoai/vendo"] as const;
+// Direct dependencies every injected fixture gets. @vendoai/ui rides along
+// because the corpus e2e prep mounts the shipped chat chrome
+// (@vendoai/ui/chrome VendoOverlay) exactly like a real host would — init
+// wires the provider only, and pnpm's strict node_modules make transitive
+// packages unimportable.
+export const LOCAL_DIRECT_DEPENDENCIES = ["@vendoai/vendo", "@vendoai/ui"] as const;
 
 export const LOCAL_VENDO_PACKAGE_NAMES = [
   "@vendoai/core",

--- a/corpus/manifest.json
+++ b/corpus/manifest.json
@@ -11,7 +11,7 @@
         "DATABASE_URL": "postgresql://corpus:corpus@127.0.0.1:55432/umami",
         "HASH_SALT": "corpus-layer1-hash-salt"
       },
-      "seedCommand": "pnpm --ignore-workspace update-db && pnpm --ignore-workspace seed-data -- --clear",
+      "seedCommand": "pnpm --ignore-workspace build-db && pnpm --ignore-workspace update-db && pnpm --ignore-workspace seed-data -- --clear",
       "database": {
         "kind": "docker-postgres",
         "containerName": "vendo-corpus-umami-postgres",

--- a/packages/apps/src/e2b/index.ts
+++ b/packages/apps/src/e2b/index.ts
@@ -166,7 +166,9 @@ export const e2bSandbox = (options: E2BSandboxOptions = {}): SandboxAdapter => {
 
   return {
     async create(spec) {
-      const { ALL_TRAFFIC, Sandbox } = await import("e2b");
+      // Optional SDK: keep it a runtime import so hosts without e2b installed
+      // don't fail Next's (webpack/Turbopack) bundling of the vendo route.
+      const { ALL_TRAFFIC, Sandbox } = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ "e2b");
       const sandbox = await Sandbox.create({
         ...(options.apiKey === undefined ? {} : { apiKey: options.apiKey }),
         envs: spec.env,
@@ -182,7 +184,7 @@ export const e2bSandbox = (options: E2BSandboxOptions = {}): SandboxAdapter => {
     },
     async resume(snapshotRef) {
       const state = decodeSnapshotRef(snapshotRef);
-      const { ALL_TRAFFIC, Sandbox } = await import("e2b");
+      const { ALL_TRAFFIC, Sandbox } = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ "e2b");
       return wrap(await Sandbox.create(state.snapshotId, {
         ...(options.apiKey === undefined ? {} : { apiKey: options.apiKey }),
         timeoutMs,

--- a/packages/apps/src/modal/index.ts
+++ b/packages/apps/src/modal/index.ts
@@ -160,7 +160,11 @@ export const modalSandbox = (options: ModalSandboxOptions = {}): SandboxAdapter 
   });
 
   const newClient = async (): Promise<ModalClient> => {
-    const sdk = await import("modal");
+    // The optional SDK must stay a RUNTIME import: without the ignore hints,
+    // Next (webpack and Turbopack) resolves the literal specifier while
+    // bundling a host's route handler and fails the whole /api/vendo route
+    // when the SDK isn't installed.
+    const sdk = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ "modal");
     return new sdk.ModalClient(clientOptions());
   };
 


### PR DESCRIPTION
The gen-verify measurement wave (ENG-243, wave-2026-07-15) hit three verification-harness blockers. This PR clears all three — and the first turned out to be the visible edge of a wider drift that has ALSO silently broken the Layer-3 live corpus lane since **2026-07-12**.

## The Layer-3 breakage window (why nothing alarmed)

1e577988 (the umbrella rework, merged 2026-07-12) changed `vendo init`'s *entire* output, not just the `[...path]` → `[...vendo]` segment rename the wave saw:

| pre-umbrella scaffold (what e2e prep patched) | current scaffold |
|---|---|
| `createVendoHandler({ storage, maxSteps, instructionsExtra })` | `nextVendoHandler(createVendo({ model, principal }))` — those knobs no longer exist |
| `vendo-root.tsx` client wrapper passing `tools` / `threadId` props | `VendoRoot` (provider only) wired into `layout.tsx`; no tools prop — the server loads `.vendo/tools.json` via `createActions` |
| tools executed client-side (browser fetch + shims) | tools execute server-side; the wire's `cookie`/`authorization` forward to route bindings only under a **trusted** `VENDO_BASE_URL` (04 §4) |

Layer-3 prep still patched the pre-umbrella scaffold, so every Next deep fixture has been broken since 2026-07-12. The nightly corpus job only runs layers 1–2, so it never alarmed; the first thing to exercise Layer-3 since the rework was this measurement wave.

## Fix 1 — Layer-3 e2e prep re-derived against the current init scaffold (umami / skateshop / papermark)

- **Route file derived, not hardcoded**: `vendoRouteFilePath()` reads the catch-all segment init actually created under `api/vendo/` (fallback `[...vendo]` when creating), so a future rename can't drift the seam again and an older-segment repo can't gain a second conflicting catch-all.
- **Chat chrome mounted by prep**: init ships the provider only; hosts mount `VendoOverlay` themselves (the demo apps do). Prep now writes a `vendo-corpus-e2e.tsx` client component and renders it inside init's `VendoRoot` wrapper — failing loudly if the layout stops carrying that wrapper.
- **Guidance moved into curated tool descriptions** (the handler-level `instructionsExtra` knob is gone from the composed umbrella).
- **Umami auth**: the Bearer shim now covers the Vendo wire (it used to *exclude* `/api/vendo`), and prep pins `VENDO_BASE_URL` in the fixture `.env` so the registry forwards the header to route bindings.
- **Per-attempt isolation comes free**: each attempt loads a fresh page, the overlay starts a fresh conversation, the server mints the thread id (`VendoProvider` has no `threadId` prop anymore).
- **`tool-called` assertions gained a DOM fallback** (`.fl-tool-label` chips) — server-side execution means calls no longer appear as page-originated network requests.

Three adjacent potholes surfaced while proving this end-to-end and are fixed here because the lane cannot run without them:

- `corpus/manifest.json`: umami's deep-boot seed now runs `build-db` first — the boot lane `git clean -ffdx`s the fixture every run and umami has no postinstall to generate its Prisma client, so the seed structurally cannot succeed without it.
- `local-pack.ts`: injected fixtures get `@vendoai/ui` as a **direct** dependency (pnpm's strict `node_modules` make the transitive copy unimportable, and the prep-mounted chrome imports `@vendoai/ui/chrome` exactly like a real host).
- `packages/apps`: the optional sandbox SDK imports (`modal`, `e2b`) now carry `webpackIgnore` + `turbopackIgnore` hints. Without them, Next resolves the literal specifiers while bundling **any fresh host's** `/api/vendo` route and 500s every wire request when the optional SDK isn't installed (reproduced on umami; the only product-code change in this PR, and it's inert at runtime — Node still resolves the SDK natively when installed).

## Fix 2 — `bench/demo-capture` signs into the demo hosts (ENG-260 login walls)

`signInIfNeeded()` runs after navigation: the `/login` form arrives with the primary demo user's email prefilled, so the capture fills only the shared demo password (`MAPLE_DEMO_PASSWORD` / `CADENCE_DEMO_PASSWORD`, seeded dev fallbacks otherwise) and waits to land back on the capture route; a no-op when a session cookie already exists. Documented in `bench/demo-capture/README.md`.

## Fix 3 — Papermark `vendo sync --strict` exit 2 → curation moved to the overrides channel

Papermark is the one npm-driven deep fixture, so `npm run build` executes the init-installed `prebuild: vendo sync --strict`. The prep used to overwrite `.vendo/tools.json` (the sync-managed extraction pin) with 9 curated tools; once ENG-242's widened extraction covered those endpoints, sync read that as **9 breaking tool renames** and exited 2. Now:

- `.vendo/tools.json` stays exactly init's extraction (the strict prebuild is a no-op diff);
- the curation ships as `.vendo/overrides.json` — the channel both sync (symmetric merge) and the runtime registry (description/risk/disabled) respect: the 9 fixture endpoints keep their extraction names (`host_teams_list`, …) and gain curated descriptions + corrected risk, everything else (379 tools) is `disabled`;
- endpoints match via dedupKey-style param normalization (`{documentId}` vs route-scan's `{id}`);
- prep fails loudly if extraction ever stops covering a curated endpoint.

## Verification (all from a space-free checkout, /tmp/eng243-fix)

- **Fix 1 end-to-end**: `pnpm corpus boot umami` → full pipeline (pinned checkout → bootstrap + seed → inject → init → new prep → dev server) ends in `Booted umami at http://localhost:3000`; `GET /` 200, login page SSR carries the mounted overlay (`fl-launcher` + `vendo-corpus-e2e`), and `GET /api/vendo/status` → **200** `{"posture":"unconfigured","version":"0.3.0","blocks":{...}}` (was 500 on `modal` module-not-found before the apps fix).
- **Fix 2 live**: `demo:capture streaming-first-paint --host maple --port 3105` → exit 0, GIF produced. Maple server log shows the wall + sign-in: `GET /login?returnTo=%2Fvendo 200` → `POST /login 303` → authed `GET /api/profile 200` → full generation turn (`POST /api/vendo/threads 200 in 2.6min`). Beat numbers: first paint 41.9s, usable 157.9s, blankSamples 0.
- **Fix 3**: in the freshly prepared papermark fixture, `vendo sync --strict` → `tools: +1 -0 ~0`, **exit 0** (twice; previously exit 2 with 9 renames). overrides.json: 9 curated + 379 disabled, format `vendo/overrides@1`.
- **Unit suites**: corpus-harness 104/104; @vendoai/apps 290 passed / 19 skipped; bench demo-capture 14/14. e2e-prep tests rewritten to simulate the *current* init output (segment derivation, layout-drift fail-loud, overrides generation, missing-endpoint fail-loud).
- **Full gate** on the rebased branch: `pnpm build && pnpm test && pnpm typecheck && pnpm lint` — green.

## Known follow-ups (flagged for the ui-generation orchestrator, not blocking)

- The composed umbrella has **no system-instructions seam** (`createVendo` exposes no `system.instructions` even though `createAgent` supports it); guidance-in-descriptions is a workable stand-in, but Layer-3 pass-rate tuning may want the real seam back (product decision).
- Curated papermark tools now carry extraction inputSchemas (generic) instead of the old hand-written ones — fine for the loose conversation assertions, may need tuning for pass@2.
- Teable prep untouched (ENG-291 owns its boot recipe).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks ENG-243 measurement by updating the e2e prep to today’s `vendo init`, adding demo login, making Papermark `sync --strict` pass, and fixing tool-called assertion counting. Restores the Layer‑3 corpus lane and stabilizes the gallery runs.

- **Bug Fixes**
  - Re-derived Layer‑3 prep to match current init: derive the `api/vendo` catch‑all segment, mount chat chrome via a client `VendoOverlay`, and move guidance into tool descriptions. Fail loudly if the layout drops the `VendoRoot` wrapper.
  - Umami: Bearer fetch shim now covers `/api/vendo`, and `VENDO_BASE_URL` is pinned so server-side tools receive auth headers. Deep boot runs `build-db` before seeding.
  - Papermark: keep `.vendo/tools.json` pinned; ship curation in `.vendo/overrides.json` (descriptions/risk for 9 endpoints; others disabled) with dedupKey-style param normalization. Create the current App Router handler when missing.
  - Demo capture: auto sign-in for Maple and Cadence via `/login` using `MAPLE_DEMO_PASSWORD` / `CADENCE_DEMO_PASSWORD`.
  - Harness assertions: “tool-called” now counts the max of network-observed calls and DOM chips to support minimum>1 without double-counting.

- **Dependencies**
  - Injected fixtures declare `@vendoai/ui` to load `@vendoai/ui/chrome`.
  - Keep optional SDKs `e2b` and `modal` as true runtime imports using `webpackIgnore` and `turbopackIgnore` to avoid bundling errors in fresh hosts.

<sup>Written for commit ebdc228a12b880f6502c5b99d63650489d88b081. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

