### PR TITLE
test(guard,fixtures): assert audit enrichment e2e — grant id, away trigger, actAs mismatch (ENG-264)

### DIFF
--- a/fixtures/automations-e2e/src/steps-pipeline.e2e.test.ts
+++ b/fixtures/automations-e2e/src/steps-pipeline.e2e.test.ts
@@ -68,6 +68,18 @@ describe("deterministic steps pipelines", () => {
         "SELECT COUNT(*)::int AS count FROM vendo_audit WHERE kind = 'run' AND app_id = $1",
         [appId],
       ))[0]?.count)).toBeGreaterThanOrEqual(2);
+
+      // Audit enrichment (ENG-264): every guard tool-call event from a
+      // trigger-fired away run carries the trigger ref { runId, kind } into
+      // the persisted audit row's event jsonb.
+      const triggered = await stack.sql<{ trigger: { runId?: string; kind?: string } | null }>(
+        "SELECT event->'trigger' AS trigger FROM vendo_audit WHERE kind = 'tool-call' AND app_id = $1",
+        [appId],
+      );
+      expect(triggered.length).toBeGreaterThanOrEqual(3);
+      for (const row of triggered) {
+        expect(row.trigger).toEqual({ runId, kind: "host-event" });
+      }
     } finally {
       await stack.close();
     }

--- a/fixtures/integration/src/approval-roundtrip.e2e.test.ts
+++ b/fixtures/integration/src/approval-roundtrip.e2e.test.ts
@@ -106,12 +106,13 @@ describe("J2: destructive approval round-trip through the composed wire", () => 
     }, ADA);
     expect(decide.status).toBe(200);
 
-    const grants = await stack.sql<{ subject: string; tool: string; source: string; duration: string }>(
-      "SELECT subject, tool, source, duration FROM vendo_grants",
+    const grants = await stack.sql<{ id: string; subject: string; tool: string; source: string; duration: string }>(
+      "SELECT id, subject, tool, source, duration FROM vendo_grants",
     );
     expect(grants).toEqual([
-      { subject: ADA.subject, tool: TOOL, source: "chat", duration: "standing" },
+      expect.objectContaining({ subject: ADA.subject, tool: TOOL, source: "chat", duration: "standing" }),
     ]);
+    const grantId = grants[0]!.id;
 
     // --- Resume the paused turn: the real DELETE runs against the host -----
     const resumed = await readSse(await resumeApproval(stack, "thr_j2", "call_1", true, ADA));
@@ -147,5 +148,19 @@ describe("J2: destructive approval round-trip through the composed wire", () => 
     expect(await invoiceExists(SECOND)).toBe(false);
     // No new approval row: the grant answered the second call.
     expect(await stack.sql("SELECT id FROM vendo_approvals")).toHaveLength(1);
+
+    // Audit enrichment (ENG-264): the grant-decided call carries the deciding
+    // grant's id in the persisted event detail. Assert on the fresh turn-2
+    // call — the resumed call_1 is a single-use approval REPLAY, which is
+    // decidedBy "grant" with no grantId by design.
+    const enriched = await stack.sql<{
+      event: { inputPreview?: string; decidedBy?: string; detail?: { grantId?: string } };
+    }>(
+      "SELECT event FROM vendo_audit WHERE kind = 'tool-call' AND tool = $1 AND subject = $2",
+      [TOOL, ADA.subject],
+    );
+    const grantRun = enriched.find((row) => row.event.inputPreview?.includes(SECOND));
+    expect(grantRun?.event.decidedBy).toBe("grant");
+    expect(grantRun?.event.detail?.grantId).toBe(grantId);
   });
 });

--- a/packages/guard/test/audit.test.ts
+++ b/packages/guard/test/audit.test.ts
@@ -65,19 +65,60 @@ describe("audit persistence, query, and export", () => {
       tool: string | null;
       outcome: string | null;
       decided_by: string | null;
+      grant_id: string | null;
     }>(`SELECT kind, subject, app_id, tool,
                event->>'outcome' AS outcome,
-               event->>'decidedBy' AS decided_by
+               event->>'decidedBy' AS decided_by,
+               event->'detail'->>'grantId' AS grant_id
         FROM vendo_audit`);
     expect(rows.rows.length).toBeGreaterThanOrEqual(6);
     expect(rows.rows).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ kind: "tool-call", subject: alice.subject, app_id: "app_1", tool: "host_read", outcome: "ok", decided_by: "default" }),
+        expect.objectContaining({ kind: "tool-call", subject: alice.subject, app_id: "app_1", tool: "host_read", outcome: "ok", decided_by: "default", grant_id: null }),
         expect.objectContaining({ kind: "tool-call", tool: "host_write", outcome: "blocked", decided_by: "rule" }),
         expect.objectContaining({ kind: "tool-call", tool: "host_destructive", outcome: "pending-approval", decided_by: "rule" }),
-        expect.objectContaining({ kind: "tool-call", tool: "host_granted", outcome: "ok", decided_by: "grant" }),
+        // Audit enrichment: a grant-decided run records WHICH grant decided it.
+        expect.objectContaining({ kind: "tool-call", tool: "host_granted", outcome: "ok", decided_by: "grant", grant_id: "grt_audit" }),
       ]),
     );
+  });
+
+  it("audits the actAs subject-mismatch error outcome for a grant-decided away call", async () => {
+    const sqlStore = await store();
+    const probe: ToolDescriptor = descriptor("write", { name: "host_probe" });
+    await seedGrant(sqlStore, {
+      descriptor: probe,
+      appId: "app_1",
+      source: "automation",
+      id: "grt_actas",
+    });
+    const tools = new FixtureTools([probe]);
+    // Actions never self-authorizes (04-actions): a grant/principal subject
+    // mismatch surfaces as an error OUTCOME, not an exception. The guard must
+    // land that outcome in the audit trail so the refusal is visible beyond
+    // the return value — alongside the grant that authorized the attempt.
+    tools.setOutcome("host_probe", {
+      status: "error",
+      error: { code: "act-as-subject-mismatch", message: "Grant subject does not match the acting principal" },
+    });
+    const guard = createGuard({ store: sqlStore });
+    const bound = guard.bind(tools);
+    const ctx = context({ venue: "automation", presence: "away", appId: "app_1" });
+
+    await expect(bound.execute(call("host_probe", {}, "audit_actas"), ctx)).resolves.toMatchObject({
+      status: "error",
+      error: { code: "act-as-subject-mismatch" },
+    });
+
+    const rows = await sqlStore.query<{ outcome: string | null; decided_by: string | null; grant_id: string | null }>(
+      `SELECT event->>'outcome' AS outcome,
+              event->>'decidedBy' AS decided_by,
+              event->'detail'->>'grantId' AS grant_id
+       FROM vendo_audit WHERE kind = 'tool-call' AND tool = 'host_probe'`,
+    );
+    expect(rows.rows).toEqual([
+      expect.objectContaining({ outcome: "error", decided_by: "grant", grant_id: "grt_actas" }),
+    ]);
   });
 
   it("lifts the connector account identity off the outcome into the audit detail", async () => {


### PR DESCRIPTION
## ENG-264 — audit enrichment verified end-to-end

Test-only PR. A coverage audit of the contracted audit-enrichment fields found only connector-account identity asserted end-to-end; this closes the grant-id and away-trigger gaps and adds the actAs-mismatch audit-visibility partial. No production code changed.

### Coverage table

| Enrichment field | Test | Level |
| --- | --- | --- |
| `detail.grantId` | `packages/guard/test/audit.test.ts` — "audits ok, blocked, parked, and grant-run outcomes…" now asserts the grant-run row's `event->'detail'->>'grantId'` equals the deciding grant's id (and the default run carries none) | unit |
| `detail.grantId` | `fixtures/integration/src/approval-roundtrip.e2e.test.ts` (J2) — approve+remember mints a grant; the fresh grant-decided turn-2 call's persisted audit event carries the minted grant's id. (The resumed call is a single-use approval REPLAY: `decidedBy: "grant"` with no grantId by design.) | e2e (real composed umbrella over the wire) |
| `trigger` (`{ runId, kind }`) | `fixtures/automations-e2e/src/steps-pipeline.e2e.test.ts` — every `kind='tool-call'` row of a trigger-fired away run persists `event->'trigger'` equal to `{ runId: <emit run id>, kind: "host-event" }` | e2e (real blocks, PGlite, live fixture host) |
| actAs `act-as-subject-mismatch` outcome | `packages/guard/test/audit.test.ts` — new test: a guard-bound away call whose executor returns the mismatch error lands in audit as `outcome: "error"`, `decidedBy: "grant"`, with `grantId` stamped | unit (guard-bound registry) |
| `detail.connectorAccount` | already covered — `fixtures/integration/src/connections.e2e.test.ts` + `packages/guard/test/audit.test.ts` | e2e + unit (pre-existing) |
| present-credentials-not-forwarded warning | already covered — `packages/vendo/src/server.test.ts` | e2e (pre-existing) |

Org-context enrichment verification is deferred to **ENG-263**.

### Verification

`pnpm build && pnpm typecheck && pnpm lint` green; touched suites green (guard 152, fixtures/integration 26, fixtures/automations-e2e 37). Local full `pnpm test` has one known environmental false-fail unrelated to this diff: `packages/core/src/packaging.e2e.test.ts` fails in this worktree because the checkout path contains a space (`Cool Code` → `Cool%20Code` in vite's dynamic-import URL); it fails identically with the diff stashed. GitHub CI is authoritative for it.

No production bugs found: `detail.grantId` does land on grant-decided runs end-to-end, and `trigger` survives into the persisted `vendo_audit.event` jsonb.

Test-only diff — no changeset.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit and e2e tests to verify audit enrichment per ENG-264: `detail.grantId` is stamped on grant‑decided runs, away runs persist `trigger { runId, kind }`, and act‑as subject mismatch is audited as `outcome: "error"` with `decidedBy: "grant"`. Test-only change; no production code modified.

<sup>Written for commit 2470b92c596753655688f985f1d3d64c6f340c70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

