### PR TITLE
docs(contracts): build-step rule scoped to sync; refine is a command (ENG-250) — Yousef-gated

### DIFF
--- a/docs/contracts/04-actions.md
+++ b/docs/contracts/04-actions.md
@@ -8,6 +8,9 @@ Two halves: sync (a build step) and runtime.
 
 "Sync is a build step → tools can't go stale." `vendo init` is the visible, interactive first pass (09 §5); after that, sync runs inside build/dev-start. Missing `.vendo/` → full extract; skipping init never breaks.
 
+The build-step rule is scoped to SYNC — the deterministic extraction pipeline. The agent-layer refine engine (`vendo refine`, the author of `.vendo/capabilities.json` in §6) is explicitly a COMMAND: it runs a BYO model, proposes reviewable diffs (capabilities, overrides, brief), and applies them only on approval — it never runs inside build/dev-start, and it never writes `tools.json`. <!-- amended 2026-07-15: build-step-versus-command language scoped to sync per the approved extraction design (spec §3, ENG-250); refine engine landed in packages/vendo (refine.ts, cli/refine.ts). -->
+
+
 ```ts
 export function vendoSync(options: {
   root: string;                          // host app root

--- a/docs/contracts/09-vendo.md
+++ b/docs/contracts/09-vendo.md
@@ -10,7 +10,7 @@ Status: FROZEN (wave-2 gate passed by Yousef, 2026-07-11). Changes now require a
 | `@vendoai/vendo` | root types re-exported from core (+ each block's primary types) |
 | `@vendoai/vendo/server` | `createVendo` — the composition + handler |
 | `@vendoai/vendo/react` | re-exports `@vendoai/ui` (+ `<VendoRoot>` = provider wired to defaults) |
-| bin `vendo` | `init`, `doctor`, `sync`, `cloud` |
+| bin `vendo` | `init`, `doctor`, `sync`, `refine`, `cloud` | <!-- amended 2026-07-15: `refine` added (ENG-250, §5) -->
 
 ## 2. The composition
 
@@ -122,6 +122,7 @@ Rung-4 app UI is **not** proxied through the wire: `OpenSurface.kind === "http"`
 - **`vendo doctor`** — wiring checks + one live round-trip against `/status`; green = working agent; ends with ladder hints (the one config line that unlocks each remaining block). Live probes (ENG-260): `POST /doctor/present` proves present credentials reach the host API (fail advises `VENDO_BASE_URL`); `POST /doctor/act-as` proves the actAs mint+verify round-trip (not configured → warn, not fail).
 - **`vendo sync`** — the build-step extraction, callable manually (04 §1). Queries `/sync/impact` when the dev server is reachable and prints per-tool blast radius; `--report` pushes the report to the Cloud console (requires `VENDO_API_KEY` or `--key`; push failure warns, never fails the build) (ENG-261).
 - **`vendo cloud <command>`** — talk to the public Vendo Cloud API (auth/session, keys, members, services, reads); the paid line's CLI surface (§6). <!-- amended 2026-07-14: `cloud` command landed post-freeze (cli.ts, cli/cloud/ tree); original froze with only init/doctor/sync. -->
+- **`vendo refine`** — the refine engine's CLI surface (04 §1/§6): one BYO-model pass over the extraction output, host source, the miss feed, and a dev interview proposes compound capabilities + briefs (`capabilities.json`), risk/curation/description corrections (`overrides.json`), and `brief.md` updates — probed against the running dev app (doctor's `/status` machinery; write-risk steps never executed), every file presented as a diff and applied only on approval. Also offered once at the end of `vendo init` (one engine, two surfaces). <!-- amended 2026-07-15: `refine` command landed (cli.ts, cli/refine.ts, refine.ts) per the approved extraction design (spec §3, ENG-250); extraction stays a build step — refine is a command by design (04 §1). -->
 
 Exit codes: doctor `0` green / `1` broken wiring; sync `0` (fail-soft warns) / with `--strict`: `2` on breaking changes, `3` when a breaking tool also has nonzero blast radius (impact-unknown stays `2`). `vendo init` also writes `VENDO_BASE_URL` into `.env`/`.env.example` (04 §4) and scaffolds the `predev` (`vendo sync`) / `prebuild` (`vendo sync --strict`) hooks into the host package.json — permission-prompted, like route wiring (ENG-260/261).
 


### PR DESCRIPTION
**DRAFT — held for Yousef.** Contract changes are Yousef-gated; this PR is deliberately left unmerged for his own review and action.

Amends per the approved extraction design (`docs/superpowers/specs/2026-07-14-extraction-survives-real-apps-design.md` §3, locked decision: *"extraction is a build step, never a command" is amended to scope the build-step rule to sync; refine is explicitly a command*):

- **04-actions §1**: build-step rule scoped to SYNC; the refine engine (author of `.vendo/capabilities.json`, §6) is explicitly a COMMAND — reviewable diffs, apply on approval, never inside build/dev-start, never writes `tools.json`.
- **09-vendo §1 + §5**: `vendo refine` added to the bin surface, same dated-amendment convention as the `cloud` amendment.

docs/contracts only — no code. The ENG-250 implementation PR (refine engine) is separate and does not touch docs/contracts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the “extraction is a build step” rule to SYNC and defines `vendo refine` as a command that proposes reviewable diffs (capabilities, overrides, brief) and applies them only on approval. Updates 04-actions and 09-vendo per ENG-250: add `refine` to the CLI (also offered at the end of `vendo init`), never runs in build/dev-start, and never writes `tools.json`.

<sup>Written for commit 3b99986886221bd3081453b3cd9b4e8b94cb1031. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

