### PR TITLE
feat(vendo,cli): refine engine — vendo refine + end-of-init offer (ENG-250)

### DIFF
--- a/docs-site/reference/cli.mdx
+++ b/docs-site/reference/cli.mdx
@@ -108,6 +108,42 @@ Exit codes:
 - `3`: breaking changes that impact saved apps, automations, or grants when
   `--strict` is set
 
+## `vendo refine [dir]`
+
+Proposes agent-layer improvements as reviewable diffs — nothing is ever
+applied silently, and deterministic `tools.json` is never touched. One
+model pass over the extracted tools, your app's source, the capability-miss
+feed (`.vendo/data/misses.jsonl`), and a short interview proposes:
+
+- compound capabilities and briefs into `.vendo/capabilities.json`
+- risk corrections, enable/disable curation, and clearer descriptions into
+  `.vendo/overrides.json`
+- product-brief improvements to `.vendo/brief.md`
+
+With `--url` pointing at your running dev server, each proposed compound is
+probed before it is offered: the composition's `/status` is checked and
+read-risk steps are verified against the live app. Write-risk steps are never
+executed by the probe. Compounds that fail their probe are dropped with the
+reason printed.
+
+```bash
+npx vendo refine --url http://localhost:3000/api/vendo
+```
+
+The model rides your own key: `--model-import` loads the module that exports
+your AI SDK `model`, and without it the init starter default is used
+(`@ai-sdk/anthropic` installed in your app plus `ANTHROPIC_API_KEY`).
+
+Options:
+
+- `--url <url>` — mounted wire base of the running dev app; enables the probe.
+- `--model-import <specifier>` — module exporting your AI SDK `model`.
+- `--ask <text>` — interview answer for non-interactive runs (repeatable).
+- `--yes` — approve every displayed diff without prompting.
+
+Each run writes a transcript under `.vendo/data/refine/`. `vendo init` offers
+to run refine once at the end of a successful interactive setup.
+
 ## `vendo mcp`
 
 Tooling for publishing your door to the official MCP registry. Both

--- a/packages/vendo/package.json
+++ b/packages/vendo/package.json
@@ -68,7 +68,8 @@
     "@vendoai/telemetry": "workspace:*",
     "@vendoai/ui": "workspace:*",
     "ajv": "^8.20.0",
-    "ajv-formats": "^3.0.1"
+    "ajv-formats": "^3.0.1",
+    "zod": "^3.24.0"
   },
   "peerDependencies": {
     "ai": ">=6.0.0 <7",

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -4,6 +4,7 @@ import { runCloud } from "./cli/cloud/index.js";
 import { runDoctor } from "./cli/doctor.js";
 import { runInit } from "./cli/init.js";
 import { runMcp } from "./cli/mcp/index.js";
+import { runRefineCommand } from "./cli/refine.js";
 import { CLI_VERSION } from "./cli/shared.js";
 import { runSync } from "./cli/sync.js";
 
@@ -15,16 +16,18 @@ Commands:
   init [dir]      Scan, interview, write .vendo, and propose handler + VendoRoot wiring
   doctor [dir]    Verify wiring, present credentials, and actAs over live HTTP
   sync [dir]      Extract tools and remix baselines (use --strict for CI)
+  refine [dir]    Propose compound capabilities, risk corrections, and brief updates as reviewable diffs
   mcp <command>   Generate MCP registry discovery and domain-verification files
   cloud <command> Use the public Vendo Cloud API
 
 Options:
   --agent                    Init only: print a read-only plan — four questions, code diffs, extracted tools, risk recommendations
-  --yes                      Init only: skip the interview and approve displayed changes
+  --yes                      Init/refine: skip the interview and approve displayed changes
   --force                    Init/server-json: overwrite owned or generated files
-  --model-import <specifier> Init only: module exporting the host's ai-SDK model
+  --model-import <specifier> Init/refine: module exporting the host's ai-SDK model
   --brief <text>             Init only: product brief used for non-interactive setup
-  --url <url>                Doctor/server-json: mounted wire base or public MCP URL
+  --ask <text>               Refine only: interview answer (repeatable) for non-interactive runs
+  --url <url>                Doctor/refine/server-json: mounted wire base or public MCP URL
   --strict                   Sync only: exit 2 on breaking changes, 3 when saved references are impacted
   --json                     Sync only: print one machine-readable report object
   --report                   Sync only: push the report to Vendo Cloud
@@ -39,11 +42,21 @@ function option(args: string[], name: string): string | undefined {
   return args.find((value) => value.startsWith(`${name}=`))?.slice(name.length + 1);
 }
 
+function options(args: string[], name: string): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === name && args[index + 1] !== undefined) values.push(args[index + 1]!);
+    else if (args[index]!.startsWith(`${name}=`)) values.push(args[index]!.slice(name.length + 1));
+  }
+  return values;
+}
+
 function target(args: string[]): string {
   const optionValues = new Set<string>();
-  for (const name of ["--model-import", "--url", "--brief", "--key", "--api-url"]) {
-    const index = args.indexOf(name);
-    if (index >= 0 && args[index + 1] !== undefined) optionValues.add(args[index + 1]!);
+  for (const name of ["--model-import", "--url", "--brief", "--key", "--api-url", "--ask"]) {
+    for (let index = 0; index < args.length; index += 1) {
+      if (args[index] === name && args[index + 1] !== undefined) optionValues.add(args[index + 1]!);
+    }
   }
   return args.find((value) => !value.startsWith("--") && !optionValues.has(value)) ?? process.cwd();
 }
@@ -72,6 +85,15 @@ export async function main(argv: string[]): Promise<number> {
   }
   if (command === "doctor") {
     return runDoctor({ targetDir: target(args), url: option(args, "--url") });
+  }
+  if (command === "refine") {
+    return runRefineCommand({
+      targetDir: target(args),
+      url: option(args, "--url"),
+      modelImport: option(args, "--model-import"),
+      asks: options(args, "--ask"),
+      yes: args.includes("--yes"),
+    });
   }
   if (command === "sync") {
     return runSync({

--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -843,6 +843,20 @@ describe("vendo init", () => {
       expect(runRefine).toHaveBeenCalledWith(expect.objectContaining({ targetDir: root }));
     });
 
+    it("forwards the model the dev configured during init into the refine offer", async () => {
+      const runRefine = vi.fn(async () => 0);
+      expect(await runInit({
+        targetDir: await fixture(),
+        modelImport: "@/lib/ai",
+        interview: async () => ({}),
+        confirm: async () => true,
+        output: output().output,
+        offerRefine: async () => true,
+        runRefine,
+      })).toBe(0);
+      expect(runRefine).toHaveBeenCalledWith(expect.objectContaining({ modelImport: "@/lib/ai" }));
+    });
+
     it("a declined offer runs nothing; a failed refine never fails init", async () => {
       const declinedRefine = vi.fn(async () => 0);
       const declined = output();

--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -826,4 +826,60 @@ describe("vendo init", () => {
     });
     expect(disabled).not.toHaveBeenCalled();
   });
+
+  describe("end-of-init refine offer (one engine, two surfaces)", () => {
+    it("runs `vendo refine` against the initialized root when the offer is accepted", async () => {
+      const root = await fixture();
+      const sink = output();
+      const runRefine = vi.fn(async () => 0);
+      expect(await runInit({
+        targetDir: root,
+        interview: async () => ({}),
+        confirm: async () => true,
+        output: sink.output,
+        offerRefine: async () => true,
+        runRefine,
+      })).toBe(0);
+      expect(runRefine).toHaveBeenCalledWith(expect.objectContaining({ targetDir: root }));
+    });
+
+    it("a declined offer runs nothing; a failed refine never fails init", async () => {
+      const declinedRefine = vi.fn(async () => 0);
+      const declined = output();
+      expect(await runInit({
+        targetDir: await fixture(),
+        interview: async () => ({}),
+        confirm: async () => true,
+        output: declined.output,
+        offerRefine: async () => false,
+        runRefine: declinedRefine,
+      })).toBe(0);
+      expect(declinedRefine).not.toHaveBeenCalled();
+
+      const failed = output();
+      expect(await runInit({
+        targetDir: await fixture(),
+        interview: async () => ({}),
+        confirm: async () => true,
+        output: failed.output,
+        offerRefine: async () => true,
+        runRefine: async () => 1,
+      })).toBe(0);
+      expect(failed.errors.join("\n")).toContain("vendo refine did not complete");
+    });
+
+    it("--yes skips the prompt and points at `vendo refine` instead", async () => {
+      const sink = output();
+      const runRefine = vi.fn(async () => 0);
+      expect(await runInit({
+        targetDir: await fixture(),
+        yes: true,
+        output: sink.output,
+        offerRefine: async () => true,
+        runRefine,
+      })).toBe(0);
+      expect(runRefine).not.toHaveBeenCalled();
+      expect(sink.logs.join("\n")).toContain("`vendo refine` proposes compound capabilities");
+    });
+  });
 });

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -100,7 +100,7 @@ export interface InitOptions {
   };
   /** End-of-init refine offer (spec §3); injectable for tests. */
   offerRefine?: () => Promise<boolean>;
-  runRefine?: (options: { targetDir: string; output?: Output }) => Promise<number>;
+  runRefine?: (options: { targetDir: string; output?: Output; modelImport?: string }) => Promise<number>;
 }
 
 /** Interactive y/N for the end-of-init `vendo refine` offer. */
@@ -913,7 +913,13 @@ export async function runInit(options: InitOptions): Promise<number> {
       output.log("Next: with your dev server running, `vendo refine` proposes compound capabilities from your app's real surface.");
     } else if (await (options.offerRefine ?? defaultOfferRefine)()) {
       const { runRefineCommand } = await import("./refine.js");
-      const refineExit = await (options.runRefine ?? runRefineCommand)({ targetDir: root, output });
+      // Forward the model the dev just configured so the offer can succeed
+      // without a separate ANTHROPIC_API_KEY (Devin review on #275).
+      const refineExit = await (options.runRefine ?? runRefineCommand)({
+        targetDir: root,
+        output,
+        ...(effective.modelImport === undefined ? {} : { modelImport: effective.modelImport }),
+      });
       if (refineExit !== 0) output.error("vendo refine did not complete; run `vendo refine` again once your dev server and model key are ready.");
     }
     return 0;

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -98,6 +98,23 @@ export interface InitOptions {
     posthogKey?: string;
     fetchImpl?: typeof fetch;
   };
+  /** End-of-init refine offer (spec §3); injectable for tests. */
+  offerRefine?: () => Promise<boolean>;
+  runRefine?: (options: { targetDir: string; output?: Output }) => Promise<number>;
+}
+
+/** Interactive y/N for the end-of-init `vendo refine` offer. */
+async function defaultOfferRefine(): Promise<boolean> {
+  if (!stdin.isTTY) return false;
+  const readline = createInterface({ input: stdin, output: stdout });
+  try {
+    const answer = await readline.question(
+      "Run `vendo refine` now to propose compound capabilities from your app's real surface (needs a running dev server + model key)? [y/N] ",
+    );
+    return ["y", "yes"].includes(answer.trim().toLowerCase());
+  } finally {
+    readline.close();
+  }
 }
 
 async function appDirectory(root: string): Promise<string> {
@@ -887,6 +904,17 @@ export async function runInit(options: InitOptions): Promise<number> {
       output.log("Vendo Express setup is incomplete. Two manual steps remain: mount `mountVendo()` with `app.use(\"/api/vendo\", mountVendo())`, and wrap the client in `<VendoRoot>`. `vendo doctor` will report broken until both are complete.");
     } else {
       output.log("Vendo initialized. Run `vendo doctor` to verify the live composition.");
+    }
+
+    // The end-of-init offer (extraction spec §3): one refine engine, two
+    // surfaces. Init already succeeded — a declined or failed refine never
+    // changes init's exit code.
+    if (options.yes === true) {
+      output.log("Next: with your dev server running, `vendo refine` proposes compound capabilities from your app's real surface.");
+    } else if (await (options.offerRefine ?? defaultOfferRefine)()) {
+      const { runRefineCommand } = await import("./refine.js");
+      const refineExit = await (options.runRefine ?? runRefineCommand)({ targetDir: root, output });
+      if (refineExit !== 0) output.error("vendo refine did not complete; run `vendo refine` again once your dev server and model key are ready.");
     }
     return 0;
   } catch (error) {

--- a/packages/vendo/src/cli/refine.test.ts
+++ b/packages/vendo/src/cli/refine.test.ts
@@ -1,0 +1,215 @@
+import { mkdtemp, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { VENDO_TOOLS_FORMAT } from "@vendoai/core";
+import type { LanguageModel } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveRefineModel, runRefineCommand } from "./refine.js";
+import type { Output } from "./shared.js";
+
+// `vendo refine` CLI surface (ENG-250): diffs are presented and applied only
+// on approval; nothing is ever silently applied.
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+function testOutput(): Output & { logs: string[]; errors: string[] } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return { logs, errors, log: (message) => logs.push(message), error: (message) => errors.push(message) };
+}
+
+const TOOLS_FILE = {
+  format: VENDO_TOOLS_FORMAT,
+  tools: [
+    {
+      name: "host_listTasks",
+      description: "List tasks",
+      inputSchema: { type: "object" },
+      risk: "read",
+      binding: { kind: "route", method: "GET", path: "/api/tasks", argsIn: "query" },
+    },
+    {
+      name: "host_completeTask",
+      description: "Complete a task",
+      inputSchema: { type: "object", properties: { id: { type: "string" } }, required: ["id"] },
+      risk: "write",
+      binding: { kind: "openapi", operationId: "completeTask", method: "POST", path: "/api/tasks/{id}/complete" },
+    },
+  ],
+} as const;
+
+async function makeRoot(withTools = true): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-refine-cli-"));
+  cleanups.push(async () => { await rm(root, { recursive: true, force: true }); });
+  await mkdir(join(root, ".vendo"), { recursive: true });
+  if (withTools) await writeFile(join(root, ".vendo", "tools.json"), JSON.stringify(TOOLS_FILE));
+  return root;
+}
+
+const ZERO_USAGE = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+} as const;
+
+function proposalModel(proposals: unknown): LanguageModel {
+  return new MockLanguageModelV3({
+    doGenerate: async () => ({
+      content: [{ type: "text", text: JSON.stringify(proposals) }],
+      finishReason: { unified: "stop", raw: undefined },
+      usage: ZERO_USAGE,
+      warnings: [],
+    }),
+  }) as LanguageModel;
+}
+
+const COMPOUND_PROPOSAL = {
+  compounds: [{
+    name: "host_complete_open_tasks",
+    description: "Complete every open task",
+    inputSchema: { type: "object" },
+    steps: [
+      { id: "list", tool: "host_listTasks" },
+      { id: "complete", tool: "host_completeTask", forEach: "steps.list.id", args: { id: "item" } },
+    ],
+  }],
+};
+
+async function transcriptFiles(root: string): Promise<string[]> {
+  try {
+    return await readdir(join(root, ".vendo", "data", "refine"));
+  } catch {
+    return [];
+  }
+}
+
+describe("runRefineCommand", () => {
+  it("errors before spending model tokens when .vendo/tools.json is missing", async () => {
+    const root = await makeRoot(false);
+    const output = testOutput();
+    expect(await runRefineCommand({ targetDir: root, output, model: proposalModel({}) })).toBe(1);
+    expect(output.errors.join("\n")).toContain("vendo init");
+  });
+
+  it("explains model resolution when no key and no --model-import is available", async () => {
+    const root = await makeRoot();
+    const output = testOutput();
+    expect(await runRefineCommand({ targetDir: root, output, env: {}, yes: true })).toBe(1);
+    expect(output.errors.join("\n")).toContain("--model-import");
+  });
+
+  it("applies an approved diff and records the decision in the transcript", async () => {
+    const root = await makeRoot();
+    const output = testOutput();
+    const confirmed: string[] = [];
+    const code = await runRefineCommand({
+      targetDir: root,
+      output,
+      model: proposalModel(COMPOUND_PROPOSAL),
+      asks: ["bulk complete"],
+      confirm: async (change) => {
+        confirmed.push(change.path);
+        return true;
+      },
+    });
+    expect(code).toBe(0);
+    expect(confirmed).toEqual([".vendo/capabilities.json"]);
+    const written = JSON.parse(await readFile(join(root, ".vendo", "capabilities.json"), "utf8")) as { tools: Array<{ name: string }> };
+    expect(written.tools[0]!.name).toBe("host_complete_open_tasks");
+
+    const transcripts = await transcriptFiles(root);
+    expect(transcripts).toHaveLength(1);
+    const transcript = JSON.parse(await readFile(join(root, ".vendo", "data", "refine", transcripts[0]!), "utf8")) as {
+      decisions: Array<{ path: string; applied: boolean }>;
+      inputs: { interview: string[] };
+    };
+    expect(transcript.decisions).toEqual([{ path: ".vendo/capabilities.json", applied: true }]);
+    expect(transcript.inputs.interview).toEqual(["bulk complete"]);
+  });
+
+  it("writes nothing when the diff is declined", async () => {
+    const root = await makeRoot();
+    const output = testOutput();
+    const code = await runRefineCommand({
+      targetDir: root,
+      output,
+      model: proposalModel(COMPOUND_PROPOSAL),
+      yes: false,
+      asks: ["x"],
+      confirm: async () => false,
+    });
+    expect(code).toBe(0);
+    await expect(readFile(join(root, ".vendo", "capabilities.json"), "utf8")).rejects.toThrow();
+    const transcripts = await transcriptFiles(root);
+    const transcript = JSON.parse(await readFile(join(root, ".vendo", "data", "refine", transcripts[0]!), "utf8")) as {
+      decisions: Array<{ path: string; applied: boolean }>;
+    };
+    expect(transcript.decisions).toEqual([{ path: ".vendo/capabilities.json", applied: false }]);
+  });
+
+  it("--yes approves the displayed diffs without a confirm callback", async () => {
+    const root = await makeRoot();
+    const output = testOutput();
+    const code = await runRefineCommand({
+      targetDir: root,
+      output,
+      model: proposalModel(COMPOUND_PROPOSAL),
+      yes: true,
+    });
+    expect(code).toBe(0);
+    const written = JSON.parse(await readFile(join(root, ".vendo", "capabilities.json"), "utf8")) as { tools: unknown[] };
+    expect(written.tools).toHaveLength(1);
+    expect(output.logs.join("\n")).toContain("Applied 1 of 1");
+  });
+
+  it("prints probe summaries and drop reasons", async () => {
+    const root = await makeRoot();
+    const output = testOutput();
+    await runRefineCommand({
+      targetDir: root,
+      output,
+      model: proposalModel({
+        compounds: [
+          COMPOUND_PROPOSAL.compounds[0],
+          { name: "host_broken", description: "references unknown", steps: [{ id: "one", tool: "host_nope" }] },
+        ],
+      }),
+      yes: true,
+    });
+    const log = output.logs.join("\n");
+    expect(log).toContain("probe host_complete_open_tasks: static-only");
+    expect(output.errors.join("\n")).toContain("dropped compound host_broken");
+  });
+
+  it("reports a clean no-op when the model proposes nothing", async () => {
+    const root = await makeRoot();
+    const output = testOutput();
+    expect(await runRefineCommand({ targetDir: root, output, model: proposalModel({}), yes: true })).toBe(0);
+    expect(output.logs.join("\n")).toContain("No changes proposed.");
+    expect(await transcriptFiles(root)).toHaveLength(1);
+  });
+});
+
+describe("resolveRefineModel", () => {
+  it("loads the host's own ai-SDK model module via --model-import (the provider-agnostic seam)", async () => {
+    const root = await makeRoot();
+    await writeFile(join(root, "model.mjs"), "export const model = { specificationVersion: 'v3', provider: 'test', modelId: 'stub' };\n");
+    const model = await resolveRefineModel({ root, modelImport: "./model.mjs", env: {} });
+    expect((model as { modelId: string }).modelId).toBe("stub");
+  });
+
+  it("rejects a module that exports no model", async () => {
+    const root = await makeRoot();
+    await writeFile(join(root, "empty.mjs"), "export const nothing = 1;\n");
+    await expect(resolveRefineModel({ root, modelImport: "./empty.mjs", env: {} }))
+      .rejects.toThrow(/does not export/);
+  });
+
+  it("fails with guidance when ANTHROPIC_API_KEY is absent", async () => {
+    const root = await makeRoot();
+    await expect(resolveRefineModel({ root, env: {} })).rejects.toThrow(/ANTHROPIC_API_KEY|--model-import/);
+  });
+});

--- a/packages/vendo/src/cli/refine.ts
+++ b/packages/vendo/src/cli/refine.ts
@@ -1,0 +1,218 @@
+import { createRequire } from "node:module";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+import type { LanguageModel } from "ai";
+import { runRefine, type RefineChange, type RefineResult, type RefineTranscript } from "../refine.js";
+import { consoleOutput, exists, writeText, type Output } from "./shared.js";
+
+/**
+ * `vendo refine` — the CLI surface of the refine engine (ENG-250). Extraction
+ * stays a build step (sync); refine is explicitly a COMMAND: it proposes
+ * agent-layer artifacts as reviewable diffs and applies them only on approval.
+ */
+
+export interface RefineCommandOptions {
+  targetDir: string;
+  url?: string;
+  modelImport?: string;
+  /** Non-interactive interview answers (`--ask`, repeatable). */
+  asks?: string[];
+  /** Approve every displayed diff without prompting. */
+  yes?: boolean;
+  output?: Output;
+  fetchImpl?: typeof fetch;
+  /** Test seam: skip model resolution. */
+  model?: LanguageModel;
+  confirm?: (change: { path: string; diff: string }) => Promise<boolean>;
+  interview?: (questions: string[]) => Promise<string[]>;
+  env?: Record<string, string | undefined>;
+}
+
+const INTERVIEW_QUESTIONS = [
+  "What should users be able to ask the agent for that today's tools can't do in one step? (Enter to skip)",
+  "Any tools that look mislabeled, misdescribed, or that should be disabled? (Enter to skip)",
+];
+
+/** Default model in the starter module `vendo init` writes — kept in sync. */
+const DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6";
+
+async function importHostModule(root: string, specifier: string): Promise<Record<string, unknown>> {
+  if (specifier.startsWith(".") || specifier.startsWith("/") || specifier.startsWith("file:")) {
+    const url = specifier.startsWith("file:") ? specifier : pathToFileURL(resolve(root, specifier)).href;
+    return await import(url) as Record<string, unknown>;
+  }
+  const require = createRequire(join(root, "package.json"));
+  return await import(pathToFileURL(require.resolve(specifier)).href) as Record<string, unknown>;
+}
+
+/** BYO key through the existing provider-agnostic seam: `--model-import` loads
+ * the host's own ai-SDK model module; otherwise the init-starter default
+ * (host-installed `@ai-sdk/anthropic` + ANTHROPIC_API_KEY) is composed. */
+export async function resolveRefineModel(options: {
+  root: string;
+  modelImport?: string;
+  env: Record<string, string | undefined>;
+}): Promise<LanguageModel> {
+  if (options.modelImport !== undefined) {
+    let loaded: Record<string, unknown>;
+    try {
+      loaded = await importHostModule(options.root, options.modelImport);
+    } catch (error) {
+      throw new Error(
+        `could not import ${options.modelImport}: ${error instanceof Error ? error.message : "unknown error"}. `
+          + "Pass a runnable JS module (a TypeScript source module needs your runtime to strip types) "
+          + "exporting your ai-SDK model as `model` (or default).",
+      );
+    }
+    const model = (loaded["model"] ?? loaded["default"]) as LanguageModel | undefined;
+    if (model === undefined) {
+      throw new Error(`${options.modelImport} does not export an ai-SDK model as \`model\` (or default)`);
+    }
+    return model;
+  }
+
+  const apiKey = options.env["ANTHROPIC_API_KEY"]?.trim();
+  if (apiKey === undefined || apiKey === "") {
+    throw new Error(
+      "no model configured: set ANTHROPIC_API_KEY (with @ai-sdk/anthropic installed), "
+        + "or pass --model-import <specifier> pointing at a module that exports your ai-SDK `model`.",
+    );
+  }
+  let anthropic: { createAnthropic(config: { apiKey: string }): (model: string) => LanguageModel };
+  try {
+    anthropic = await importHostModule(options.root, "@ai-sdk/anthropic") as never;
+  } catch {
+    throw new Error(
+      "ANTHROPIC_API_KEY is set but @ai-sdk/anthropic is not installed in this app; "
+        + "install it (`npm install @ai-sdk/anthropic@^3`) or pass --model-import.",
+    );
+  }
+  return anthropic.createAnthropic({ apiKey })(DEFAULT_ANTHROPIC_MODEL);
+}
+
+async function defaultInterview(questions: string[]): Promise<string[]> {
+  if (!stdin.isTTY) return [];
+  const readline = createInterface({ input: stdin, output: stdout });
+  const answers: string[] = [];
+  try {
+    for (const question of questions) {
+      const answer = (await readline.question(`${question}\n> `)).trim();
+      if (answer !== "") answers.push(answer);
+    }
+  } finally {
+    readline.close();
+  }
+  return answers;
+}
+
+async function defaultConfirm(change: { path: string; diff: string }, output: Output): Promise<boolean> {
+  if (!stdin.isTTY) {
+    output.error(`skipped ${change.path}; re-run interactively or with --yes to apply it`);
+    return false;
+  }
+  const readline = createInterface({ input: stdin, output: stdout });
+  try {
+    const answer = await readline.question(`Apply ${change.path}? [y/N] `);
+    return ["y", "yes"].includes(answer.trim().toLowerCase());
+  } finally {
+    readline.close();
+  }
+}
+
+async function writeTranscript(root: string, transcript: RefineTranscript): Promise<string> {
+  const stamp = transcript.startedAt.replace(/[:.]/g, "-");
+  const path = join(root, ".vendo", "data", "refine", `${stamp}.json`);
+  await writeText(path, `${JSON.stringify(transcript, null, 2)}\n`);
+  return path;
+}
+
+function printRun(result: RefineResult, output: Output): void {
+  for (const probe of result.probes) {
+    output.log(`probe ${probe.tool}: ${probe.status}`);
+    for (const check of probe.checks) {
+      output.log(`  ${check.ok ? "ok" : "failed"}: ${check.name} — ${check.detail}`);
+    }
+  }
+  for (const drop of result.dropped) {
+    output.error(`dropped ${drop.kind} ${drop.target}: ${drop.reason}`);
+  }
+}
+
+export async function runRefineCommand(options: RefineCommandOptions): Promise<number> {
+  const root = resolve(options.targetDir);
+  const output = options.output ?? consoleOutput;
+  const env = options.env ?? process.env;
+
+  if (!await exists(join(root, ".vendo", "tools.json"))) {
+    output.error("refine needs .vendo/tools.json — run `vendo init` (or `vendo sync`) first");
+    return 1;
+  }
+
+  let model: LanguageModel;
+  try {
+    model = options.model ?? await resolveRefineModel({
+      root,
+      ...(options.modelImport === undefined ? {} : { modelImport: options.modelImport }),
+      env,
+    });
+  } catch (error) {
+    output.error(error instanceof Error ? error.message : "model resolution failed");
+    return 1;
+  }
+
+  let interview = options.asks ?? [];
+  if (interview.length === 0 && options.yes !== true) {
+    interview = await (options.interview ?? defaultInterview)(INTERVIEW_QUESTIONS);
+  }
+
+  let result: RefineResult;
+  try {
+    result = await runRefine({
+      root,
+      model,
+      interview,
+      ...(options.url === undefined ? {} : { url: options.url }),
+      ...(options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl }),
+    });
+  } catch (error) {
+    output.error(error instanceof Error ? error.message : "vendo refine failed");
+    return 1;
+  }
+
+  printRun(result, output);
+
+  if (result.changes.length === 0) {
+    output.log("No changes proposed.");
+    const transcriptPath = await writeTranscript(root, result.transcript);
+    output.log(`Transcript: ${transcriptPath}`);
+    return 0;
+  }
+
+  let applied = 0;
+  for (const change of result.changes) {
+    output.log(`\nProposed change:\n${change.diff}\n`);
+    for (const warning of change.warnings) output.error(`warning: ${warning}`);
+    const approved = options.yes === true
+      || await (options.confirm ?? ((candidate) => defaultConfirm(candidate, output)))(change);
+    if (approved) {
+      await writeText(join(root, ...change.path.split("/")), change.after);
+      applied += 1;
+      output.log(`wrote ${change.path}`);
+    } else {
+      output.error(`skipped ${change.path}; run \`vendo refine\` again to re-propose`);
+    }
+    result.transcript.decisions.push({ path: change.path, applied: approved });
+  }
+
+  const transcriptPath = await writeTranscript(root, result.transcript);
+  output.log(`\nApplied ${applied} of ${result.changes.length} proposed change(s). Transcript: ${transcriptPath}`);
+  if (applied > 0) {
+    output.log("Review the diffs with `git diff .vendo` and commit them; the registry loads capabilities and overrides on the next boot.");
+  }
+  return 0;
+}
+
+/** The end-of-init offer surface (spec §3): one engine, two surfaces. */
+export { INTERVIEW_QUESTIONS };

--- a/packages/vendo/src/refine.test.ts
+++ b/packages/vendo/src/refine.test.ts
@@ -1,0 +1,436 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { VENDO_TOOLS_FORMAT, VENDO_CAPABILITIES_FORMAT, VENDO_OVERRIDES_FORMAT } from "@vendoai/core";
+import type { LanguageModel } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runRefine, type RefineProposals } from "./refine.js";
+
+// The refine engine (ENG-250, extraction spec §3): deterministic tests with a
+// mocked BYO model. The engine's own guarantees under test: model-declared
+// risk is never trusted, tools.json is never a change target, invalid
+// proposals are dropped with reasons, and probes gate what is offered.
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  vi.restoreAllMocks();
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const TOOLS_FILE = {
+  format: VENDO_TOOLS_FORMAT,
+  tools: [
+    {
+      name: "host_listTasks",
+      description: "List tasks",
+      inputSchema: { type: "object" },
+      risk: "read",
+      binding: { kind: "route", method: "GET", path: "/api/tasks", argsIn: "query" },
+    },
+    {
+      name: "host_completeTask",
+      description: "Complete a task",
+      inputSchema: { type: "object", properties: { id: { type: "string" } }, required: ["id"] },
+      risk: "write",
+      binding: { kind: "openapi", operationId: "completeTask", method: "POST", path: "/api/tasks/{id}/complete" },
+    },
+    {
+      name: "host_deleteTask",
+      description: "Delete a task",
+      inputSchema: { type: "object", properties: { id: { type: "string" } }, required: ["id"] },
+      risk: "destructive",
+      binding: { kind: "openapi", operationId: "deleteTask", method: "DELETE", path: "/api/tasks/{id}" },
+    },
+    {
+      name: "host_debugDump",
+      description: "Dump internal state",
+      inputSchema: { type: "object" },
+      risk: "read",
+      disabled: true,
+      binding: { kind: "route", method: "GET", path: "/api/debug", argsIn: "query" },
+    },
+  ],
+} as const;
+
+async function makeRoot(extra: Record<string, string> = {}): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-refine-"));
+  cleanups.push(async () => { await rm(root, { recursive: true, force: true }); });
+  await mkdir(join(root, ".vendo"), { recursive: true });
+  await writeFile(join(root, ".vendo", "tools.json"), JSON.stringify(TOOLS_FILE));
+  await writeFile(join(root, ".vendo", "brief.md"), "Relay is a tiny team task tracker.\n");
+  for (const [path, content] of Object.entries(extra)) {
+    await mkdir(join(root, ...path.split("/").slice(0, -1)), { recursive: true });
+    await writeFile(join(root, ...path.split("/")), content);
+  }
+  return root;
+}
+
+const ZERO_USAGE = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+} as const;
+
+/** A mock BYO model whose single generateObject call returns `proposals`. */
+function proposalModel(proposals: RefineProposals): LanguageModel & { prompts: string[] } {
+  const prompts: string[] = [];
+  const model = new MockLanguageModelV3({
+    doGenerate: async (request) => {
+      const last = request.prompt[request.prompt.length - 1];
+      const content = last !== undefined && Array.isArray(last.content) ? last.content : [];
+      const text = content
+        .filter((part): part is { type: "text"; text: string } => (part as { type: string }).type === "text")
+        .map((part) => part.text)
+        .join("");
+      prompts.push(text);
+      return {
+        content: [{ type: "text", text: JSON.stringify(proposals) }],
+        finishReason: { unified: "stop", raw: undefined },
+        usage: ZERO_USAGE,
+        warnings: [],
+      };
+    },
+  }) as LanguageModel & { prompts: string[] };
+  (model as { prompts: string[] }).prompts = prompts;
+  return model;
+}
+
+const completeAllOpen = {
+  name: "host_complete_open_tasks",
+  description: "Complete every open task in one ask",
+  inputSchema: { type: "object" },
+  steps: [
+    { id: "list", tool: "host_listTasks", args: { status: "'open'" } },
+    { id: "complete", tool: "host_completeTask", forEach: "steps.list.id", args: { id: "item" } },
+  ],
+};
+
+describe("runRefine — proposals become reviewable diffs", () => {
+  it("proposes a compound into capabilities.json with risk computed as the max of step risks", async () => {
+    const root = await makeRoot();
+    const result = await runRefine({ root, model: proposalModel({ compounds: [completeAllOpen] }) });
+
+    expect(result.changes).toHaveLength(1);
+    const change = result.changes[0]!;
+    expect(change.path).toBe(".vendo/capabilities.json");
+    expect(change.before).toBeNull();
+    const file = JSON.parse(change.after) as { format: string; tools: Array<Record<string, unknown>> };
+    expect(file.format).toBe(VENDO_CAPABILITIES_FORMAT);
+    expect(file.tools).toHaveLength(1);
+    const compound = file.tools[0]!;
+    expect(compound.name).toBe("host_complete_open_tasks");
+    // read + write steps → write, computed by the engine (04 §6), never model-declared.
+    expect(compound.risk).toBe("write");
+    expect(compound.note).toBe("authored by vendo refine");
+    expect((compound.binding as { kind: string }).kind).toBe("compound");
+    expect(change.diff).toContain("+++ b/.vendo/capabilities.json");
+  });
+
+  it("never offers tools.json as a change target", async () => {
+    const root = await makeRoot();
+    const result = await runRefine({
+      root,
+      model: proposalModel({
+        compounds: [completeAllOpen],
+        riskCorrections: [{ tool: "host_listTasks", risk: "write" }],
+        briefUpdate: "A better brief.",
+      }),
+    });
+    expect(result.changes.map((change) => change.path)).not.toContain(".vendo/tools.json");
+    expect(result.changes.map((change) => change.path).sort()).toEqual([
+      ".vendo/brief.md",
+      ".vendo/capabilities.json",
+      ".vendo/overrides.json",
+    ]);
+  });
+
+  it("drops invalid compounds with reasons: unknown step tools, disabled step tools, name collisions, bad names", async () => {
+    const root = await makeRoot();
+    const result = await runRefine({
+      root,
+      model: proposalModel({
+        compounds: [
+          { ...completeAllOpen, name: "host_listTasks" },
+          { ...completeAllOpen, name: "bad name!" },
+          {
+            name: "host_uses_unknown",
+            description: "references a tool that does not exist",
+            steps: [{ id: "one", tool: "host_nope" }],
+          },
+          {
+            name: "host_uses_disabled",
+            description: "references a disabled tool",
+            steps: [{ id: "one", tool: "host_debugDump" }],
+          },
+          {
+            name: "host_dupe_ids",
+            description: "duplicate step ids",
+            steps: [{ id: "same", tool: "host_listTasks" }, { id: "same", tool: "host_listTasks" }],
+          },
+        ],
+      }),
+    });
+    expect(result.changes).toHaveLength(0);
+    const reasons = Object.fromEntries(result.dropped.map((drop) => [drop.target, drop.reason]));
+    expect(reasons["host_listTasks"]).toContain("collides with an extracted tool");
+    expect(reasons["bad name!"]).toContain("does not match");
+    expect(reasons["host_uses_unknown"]).toContain("unknown tool");
+    expect(reasons["host_uses_disabled"]).toContain("disabled tool");
+    expect(reasons["host_dupe_ids"]).toContain("unique");
+  });
+
+  it("compound steps may not reference other proposed compounds", async () => {
+    const root = await makeRoot();
+    const result = await runRefine({
+      root,
+      model: proposalModel({
+        compounds: [
+          completeAllOpen,
+          {
+            name: "host_nested",
+            description: "a compound of a compound",
+            steps: [{ id: "inner", tool: "host_complete_open_tasks" }],
+          },
+        ],
+      }),
+    });
+    const file = JSON.parse(result.changes[0]!.after) as { tools: Array<{ name: string }> };
+    expect(file.tools.map((tool) => tool.name)).toEqual(["host_complete_open_tasks"]);
+    expect(result.dropped.some((drop) => drop.target === "host_nested")).toBe(true);
+  });
+
+  it("appends to an existing capabilities.json without disturbing prior entries", async () => {
+    const existing = {
+      format: VENDO_CAPABILITIES_FORMAT,
+      tools: [{
+        name: "host_existing_flow",
+        description: "existing",
+        inputSchema: { type: "object" },
+        risk: "read",
+        binding: { kind: "compound", steps: [{ id: "list", tool: "host_listTasks" }] },
+      }],
+      briefs: [{ name: "old-brief", text: "keep me" }],
+    };
+    const root = await makeRoot({ ".vendo/capabilities.json": JSON.stringify(existing) });
+    const result = await runRefine({
+      root,
+      model: proposalModel({
+        compounds: [completeAllOpen, { ...completeAllOpen, name: "host_existing_flow" }],
+        briefs: [{ name: "bulk-complete", text: "Use host_complete_open_tasks for sweeps", tools: ["host_completeTask"] }],
+      }),
+    });
+    const file = JSON.parse(result.changes[0]!.after) as {
+      tools: Array<{ name: string }>;
+      briefs: Array<{ name: string }>;
+    };
+    expect(file.tools.map((tool) => tool.name)).toEqual(["host_existing_flow", "host_complete_open_tasks"]);
+    expect(file.briefs.map((brief) => brief.name)).toEqual(["old-brief", "bulk-complete"]);
+    expect(result.dropped.some((drop) => drop.target === "host_existing_flow" && drop.reason.includes("existing compound"))).toBe(true);
+  });
+
+  it("merges risk corrections, curation, and description improvements into overrides.json field-wise", async () => {
+    const existingOverrides = {
+      format: VENDO_OVERRIDES_FORMAT,
+      tools: { host_deleteTask: { critical: true } },
+      remix: { ignoreSlots: [] },
+    };
+    const root = await makeRoot({ ".vendo/overrides.json": JSON.stringify(existingOverrides) });
+    const result = await runRefine({
+      root,
+      model: proposalModel({
+        riskCorrections: [
+          { tool: "host_listTasks", risk: "write", reason: "list mutates a view counter" },
+          { tool: "host_deleteTask", risk: "write", reason: "soft delete only" },
+          { tool: "host_unknown", risk: "read" },
+        ],
+        curation: [{ tool: "host_debugDump", disabled: false, reason: "useful" }],
+        descriptions: [{ tool: "host_completeTask", description: "Mark a Relay task as done by id" }],
+      }),
+    });
+    expect(result.changes).toHaveLength(1);
+    const change = result.changes[0]!;
+    expect(change.path).toBe(".vendo/overrides.json");
+    const file = JSON.parse(change.after) as {
+      format: string;
+      tools: Record<string, Record<string, unknown>>;
+      remix: unknown;
+    };
+    expect(file.format).toBe(VENDO_OVERRIDES_FORMAT);
+    // Existing hand-written fields survive; refine's fields merge in.
+    expect(file.tools["host_deleteTask"]).toEqual({ critical: true, risk: "write" });
+    expect(file.tools["host_listTasks"]).toEqual({ risk: "write" });
+    expect(file.tools["host_debugDump"]).toEqual({ disabled: false });
+    expect(file.tools["host_completeTask"]).toEqual({ description: "Mark a Relay task as done by id" });
+    expect(file.remix).toEqual({ ignoreSlots: [] });
+    // The destructive → write downgrade and the re-enable both carry warnings.
+    expect(change.warnings.some((warning) => warning.includes("DOWNGRADE") && warning.includes("host_deleteTask"))).toBe(true);
+    expect(change.warnings.some((warning) => warning.includes("re-ENABLE") && warning.includes("host_debugDump"))).toBe(true);
+    expect(result.dropped.some((drop) => drop.target === "host_unknown")).toBe(true);
+  });
+
+  it("offers brief.md updates and drops unchanged ones", async () => {
+    const root = await makeRoot();
+    const updated = await runRefine({
+      root,
+      model: proposalModel({ briefUpdate: "Relay tracks a product team's tasks; the agent sweeps and summarizes them." }),
+    });
+    expect(updated.changes).toHaveLength(1);
+    expect(updated.changes[0]!.path).toBe(".vendo/brief.md");
+    expect(updated.changes[0]!.after.endsWith("\n")).toBe(true);
+
+    const unchanged = await runRefine({
+      root,
+      model: proposalModel({ briefUpdate: "Relay is a tiny team task tracker." }),
+    });
+    expect(unchanged.changes).toHaveLength(0);
+    expect(unchanged.dropped.some((drop) => drop.kind === "brief-update")).toBe(true);
+  });
+
+  it("returns no changes when the model proposes nothing", async () => {
+    const root = await makeRoot();
+    const result = await runRefine({ root, model: proposalModel({}) });
+    expect(result.changes).toHaveLength(0);
+    expect(result.dropped).toHaveLength(0);
+  });
+
+  it("requires .vendo/tools.json", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-refine-empty-"));
+    cleanups.push(async () => { await rm(root, { recursive: true, force: true }); });
+    await expect(runRefine({ root, model: proposalModel({}) })).rejects.toThrow(/vendo init/);
+  });
+});
+
+describe("runRefine — inputs reach the model", () => {
+  it("feeds the miss feed, interview answers, and bounded source context into the proposal prompt", async () => {
+    const miss = {
+      format: "vendo/capability-miss@1",
+      id: "mis_1",
+      at: "2026-07-15T00:00:00.000Z",
+      hostId: "host_1",
+      sessionId: "session_1",
+      intent: "complete every overdue task at once",
+      surface: { format: "vendo/tools@1", hash: `sha256:${"0".repeat(64)}` },
+      trigger: { kind: "no-matching-tool", toolsConsidered: ["host_completeTask"] },
+    };
+    const root = await makeRoot({
+      ".vendo/data/misses.jsonl": `${JSON.stringify(miss)}\nnot json\n`,
+      "src/server/tasks.ts": "export function bulkComplete() { /* UI-only orchestration */ }",
+    });
+    const model = proposalModel({});
+    await runRefine({ root, model, interview: ["users want a weekly sweep"] });
+
+    expect(model.prompts).toHaveLength(1);
+    const prompt = JSON.parse(model.prompts[0]!) as {
+      capabilityMisses: Array<{ intent: string; trigger: string }>;
+      interview: string[];
+      sourceTree: string[];
+      sourceFiles: Array<{ path: string }>;
+      tools: Array<{ name: string; risk: string; disabled: boolean }>;
+    };
+    expect(prompt.capabilityMisses).toEqual([{ intent: "complete every overdue task at once", trigger: "no-matching-tool" }]);
+    expect(prompt.interview).toEqual(["users want a weekly sweep"]);
+    expect(prompt.sourceTree).toContain("src/server/tasks.ts");
+    expect(prompt.sourceFiles.some((file) => file.path === "src/server/tasks.ts")).toBe(true);
+    expect(prompt.tools.find((tool) => tool.name === "host_debugDump")?.disabled).toBe(true);
+  });
+});
+
+describe("runRefine — probe against the running dev app", () => {
+  const fetchFor = (routes: Record<string, number>): typeof fetch =>
+    (async (input: Parameters<typeof fetch>[0]) => {
+      const url = new URL(typeof input === "string" ? input : (input as URL | Request) instanceof URL ? String(input) : (input as Request).url);
+      if (url.pathname.endsWith("/status")) {
+        return new Response(JSON.stringify({ posture: "ok", version: "test", blocks: {} }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      const status = routes[url.pathname];
+      if (status === undefined) return new Response("{}", { status: 404 });
+      return new Response("{}", { status });
+    }) as typeof fetch;
+
+  it("verifies a compound whose read step answers live; write steps are never executed", async () => {
+    const root = await makeRoot();
+    const calls: string[] = [];
+    const fetchImpl: typeof fetch = (async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const url = typeof input === "string" ? input : (input as Request).url ?? String(input);
+      calls.push(`${init?.method ?? "GET"} ${new URL(url).pathname}`);
+      return fetchFor({ "/api/tasks": 200 })(input, init);
+    }) as typeof fetch;
+
+    const result = await runRefine({
+      root,
+      model: proposalModel({ compounds: [completeAllOpen] }),
+      url: "http://127.0.0.1:9999/api/vendo",
+      fetchImpl,
+    });
+
+    expect(result.probes).toHaveLength(1);
+    const probe = result.probes[0]!;
+    expect(probe.status).toBe("verified");
+    expect(probe.checks.some((check) => check.name === "dev-app" && check.ok)).toBe(true);
+    expect(probe.checks.some((check) => check.detail.includes("GET /api/tasks → 200"))).toBe(true);
+    // The write step was validated statically, not executed.
+    expect(probe.checks.some((check) => check.name.includes("host_completeTask") && check.detail.includes("not executed"))).toBe(true);
+    expect(calls).not.toContain("POST /api/tasks/{id}/complete");
+    expect(calls.filter((call) => call.startsWith("POST"))).toHaveLength(0);
+    expect(result.changes).toHaveLength(1);
+  });
+
+  it("drops a compound whose read step 404s against the dev app", async () => {
+    const root = await makeRoot();
+    const result = await runRefine({
+      root,
+      model: proposalModel({ compounds: [completeAllOpen] }),
+      url: "http://127.0.0.1:9999/api/vendo",
+      fetchImpl: fetchFor({ "/api/tasks": 404 }),
+    });
+    expect(result.probes[0]!.status).toBe("failed");
+    expect(result.changes).toHaveLength(0);
+    expect(result.dropped.some((drop) => drop.target === "host_complete_open_tasks" && drop.reason.includes("probe failed"))).toBe(true);
+  });
+
+  it("degrades to static-only when the dev app is unreachable — proposals are still offered", async () => {
+    const root = await makeRoot();
+    const result = await runRefine({
+      root,
+      model: proposalModel({ compounds: [completeAllOpen] }),
+      url: "http://127.0.0.1:1/api/vendo",
+      fetchImpl: (async () => { throw new Error("connection refused"); }) as unknown as typeof fetch,
+    });
+    expect(result.probes[0]!.status).toBe("static-only");
+    expect(result.probes[0]!.checks.some((check) => check.name === "dev-app" && !check.ok)).toBe(true);
+    expect(result.changes).toHaveLength(1);
+  });
+
+  it("auth-gated (401) read steps count as reachable", async () => {
+    const root = await makeRoot();
+    const result = await runRefine({
+      root,
+      model: proposalModel({ compounds: [completeAllOpen] }),
+      url: "http://127.0.0.1:9999/api/vendo",
+      fetchImpl: fetchFor({ "/api/tasks": 401 }),
+    });
+    expect(result.probes[0]!.status).toBe("verified");
+    expect(result.probes[0]!.checks.some((check) => check.detail.includes("auth-gated"))).toBe(true);
+  });
+});
+
+describe("runRefine — the cloud-seam transcript", () => {
+  it("records inputs, raw proposals, probes, and drops", async () => {
+    const root = await makeRoot();
+    const result = await runRefine({
+      root,
+      model: proposalModel({ compounds: [completeAllOpen] }),
+      interview: ["bulk sweeps"],
+    });
+    const transcript = result.transcript;
+    expect(transcript.version).toBe(0);
+    expect(transcript.inputs.tools).toBe(4);
+    expect(transcript.inputs.interview).toEqual(["bulk sweeps"]);
+    expect((transcript.proposals.compounds ?? [])[0]?.name).toBe("host_complete_open_tasks");
+    expect(transcript.probes).toHaveLength(1);
+    expect(transcript.decisions).toEqual([]);
+  });
+});

--- a/packages/vendo/src/refine.test.ts
+++ b/packages/vendo/src/refine.test.ts
@@ -228,6 +228,29 @@ describe("runRefine — proposals become reviewable diffs", () => {
     expect(result.dropped.some((drop) => drop.target === "host_existing_flow" && drop.reason.includes("existing compound"))).toBe(true);
   });
 
+  it("keeps only output tools in brief references — a dropped compound is never referenced", async () => {
+    const root = await makeRoot();
+    const result = await runRefine({
+      root,
+      model: proposalModel({
+        compounds: [
+          completeAllOpen,
+          { name: "host_dropped", description: "dropped: unknown step", steps: [{ id: "one", tool: "host_nope" }] },
+        ],
+        briefs: [{
+          name: "sweep",
+          text: "Use the compound to sweep tasks.",
+          // References a surviving compound, a real primitive, the dropped
+          // compound, and a bogus name — only the first two may survive.
+          tools: ["host_complete_open_tasks", "host_listTasks", "host_dropped", "host_bogus"],
+        }],
+      }),
+    });
+    const file = JSON.parse(result.changes[0]!.after) as { briefs: Array<{ name: string; tools?: string[] }> };
+    expect(file.briefs[0]!.tools).toEqual(["host_complete_open_tasks", "host_listTasks"]);
+    expect(result.dropped.some((drop) => drop.target === "host_dropped")).toBe(true);
+  });
+
   it("merges risk corrections, curation, and description improvements into overrides.json field-wise", async () => {
     const existingOverrides = {
       format: VENDO_OVERRIDES_FORMAT,

--- a/packages/vendo/src/refine.ts
+++ b/packages/vendo/src/refine.ts
@@ -1,0 +1,741 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join, resolve, sep } from "node:path";
+import {
+  validateCapabilities,
+  capabilitiesFileSchema,
+  overridesFileSchema,
+  toolsFileSchema,
+  type CapabilitiesFile,
+  type CapabilityBrief,
+  type CompoundTool,
+  type ExtractedTool,
+  type OverridesFile,
+  type PrimitiveStepTarget,
+  type ToolOverride,
+} from "@vendoai/actions";
+import {
+  TOOL_NAME_PATTERN,
+  VENDO_CAPABILITIES_FORMAT,
+  VENDO_OVERRIDES_FORMAT,
+  capabilityMissEventSchema,
+  type CapabilityMissEvent,
+  type RiskLabel,
+  type Step,
+} from "@vendoai/core";
+import { generateObject } from "ai";
+import type { LanguageModel } from "ai";
+import { z } from "zod";
+
+/**
+ * The refine engine (ENG-250, extraction spec §3). One engine, two surfaces:
+ * the `vendo refine` CLI command and the end-of-init offer — both call
+ * `runRefine`. The engine PROPOSES agent-layer artifacts as reviewable diffs
+ * (never silently applied, never touching deterministic `tools.json`):
+ *
+ *   - compound capabilities + capability briefs → `.vendo/capabilities.json`
+ *   - risk corrections, enable/disable curation, description improvements
+ *     → `.vendo/overrides.json`
+ *   - product-brief updates → `.vendo/brief.md`
+ *
+ * Loop: propose (one BYO-model `generateObject` call over the static
+ * extraction output, bounded source context, the miss feed, and the dev
+ * interview) → probe each proposed capability against the running dev app
+ * (doctor machinery: `/status`, plus read-step reachability — write steps are
+ * NEVER executed by the probe) → present diffs → the caller applies approved
+ * files.
+ *
+ * Cloud seam (designed, not built): every input is injectable
+ * (`misses`, `interview`, `fetchImpl`) and the run emits a `RefineTranscript`
+ * so the identical engine can execute in a hosted sandbox later.
+ */
+
+const RISK_ORDER: Record<RiskLabel, number> = { read: 0, write: 1, destructive: 2 };
+
+const DEFAULT_SOURCE_BUDGET = 48_000;
+const MAX_FILE_CHARS = 4_000;
+const MAX_TREE_ENTRIES = 400;
+const DEFAULT_MAX_MISSES = 50;
+
+export interface RefineOptions {
+  /** Host app root: `.vendo/` artifacts and source are read from here. */
+  root: string;
+  /** BYO ai-SDK model — the same provider-agnostic seam as `createVendo({ model })`. */
+  model: LanguageModel;
+  /** Mounted Vendo wire base of the running dev app (e.g. http://localhost:3000/api/vendo). */
+  url?: string;
+  fetchImpl?: typeof fetch;
+  /** Dev-interview answers (the CLI collects them; a hosted run passes transcripts). */
+  interview?: string[];
+  /** Injected miss feed; default reads `.vendo/data/misses.jsonl`. */
+  misses?: CapabilityMissEvent[];
+  /** Char budget for the source-context leg. */
+  sourceBudget?: number;
+  maxMisses?: number;
+}
+
+export interface RefineProbeCheck {
+  name: string;
+  ok: boolean;
+  detail: string;
+}
+
+export interface RefineProbe {
+  tool: string;
+  /** verified = at least one live check passed and none failed; static-only = no live check possible. */
+  status: "verified" | "static-only" | "failed";
+  checks: RefineProbeCheck[];
+}
+
+export interface RefineChange {
+  /** Path relative to root (e.g. `.vendo/capabilities.json`). */
+  path: string;
+  before: string | null;
+  after: string;
+  diff: string;
+  /** Human-visible cautions (e.g. a proposed risk downgrade) shown beside the diff. */
+  warnings: string[];
+}
+
+export interface RefineDrop {
+  kind: "compound" | "brief" | "override" | "description" | "brief-update";
+  target: string;
+  reason: string;
+}
+
+/** The cloud-seam run record: inputs digest, raw proposals, probe results, and
+ * (once the caller applies) decisions. Plain JSON under `.vendo/data/refine/`
+ * — deliberately NOT a `vendo/*@N` contract format. */
+export interface RefineTranscript {
+  version: 0;
+  startedAt: string;
+  root: string;
+  url?: string;
+  inputs: {
+    tools: number;
+    misses: number;
+    interview: string[];
+    sourceFiles: string[];
+  };
+  proposals: RefineProposals;
+  dropped: RefineDrop[];
+  probes: RefineProbe[];
+  decisions: Array<{ path: string; applied: boolean }>;
+}
+
+export interface RefineResult {
+  changes: RefineChange[];
+  probes: RefineProbe[];
+  dropped: RefineDrop[];
+  transcript: RefineTranscript;
+}
+
+// ---------------------------------------------------------------------------
+// Proposal schema — what the model returns from the single generateObject call.
+// ---------------------------------------------------------------------------
+
+const proposalStepSchema = z.object({
+  id: z.string(),
+  tool: z.string(),
+  args: z.record(z.string()).optional(),
+  if: z.string().optional(),
+  forEach: z.string().optional(),
+});
+
+const proposalsSchema = z.object({
+  compounds: z.array(z.object({
+    name: z.string(),
+    description: z.string(),
+    inputSchema: z.record(z.unknown()).optional(),
+    steps: z.array(proposalStepSchema).min(1).max(50),
+    rationale: z.string().optional(),
+  })).optional(),
+  briefs: z.array(z.object({
+    name: z.string(),
+    text: z.string(),
+    tools: z.array(z.string()).optional(),
+  })).optional(),
+  riskCorrections: z.array(z.object({
+    tool: z.string(),
+    risk: z.enum(["read", "write", "destructive"]),
+    reason: z.string().optional(),
+  })).optional(),
+  curation: z.array(z.object({
+    tool: z.string(),
+    disabled: z.boolean(),
+    reason: z.string().optional(),
+  })).optional(),
+  descriptions: z.array(z.object({
+    tool: z.string(),
+    description: z.string(),
+  })).optional(),
+  briefUpdate: z.string().optional(),
+});
+
+export type RefineProposals = z.infer<typeof proposalsSchema>;
+
+// ---------------------------------------------------------------------------
+// Input loading
+// ---------------------------------------------------------------------------
+
+interface RefineInputs {
+  tools: ExtractedTool[];
+  overrides: OverridesFile | null;
+  capabilities: CapabilitiesFile | null;
+  brief: string | null;
+  misses: CapabilityMissEvent[];
+}
+
+async function readOptionalFile(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+async function loadInputs(root: string, options: RefineOptions): Promise<RefineInputs> {
+  const vendoDir = join(root, ".vendo");
+  const toolsRaw = await readOptionalFile(join(vendoDir, "tools.json"));
+  if (toolsRaw === null) {
+    throw new Error("refine needs .vendo/tools.json — run `vendo init` (or `vendo sync`) first");
+  }
+  const tools = toolsFileSchema.parse(JSON.parse(toolsRaw)).tools;
+
+  const overridesRaw = await readOptionalFile(join(vendoDir, "overrides.json"));
+  const overrides = overridesRaw === null ? null : overridesFileSchema.parse(JSON.parse(overridesRaw));
+
+  const capabilitiesRaw = await readOptionalFile(join(vendoDir, "capabilities.json"));
+  const capabilities = capabilitiesRaw === null ? null : capabilitiesFileSchema.parse(JSON.parse(capabilitiesRaw));
+
+  const brief = await readOptionalFile(join(vendoDir, "brief.md"));
+
+  let misses = options.misses;
+  if (misses === undefined) {
+    misses = [];
+    const missesRaw = await readOptionalFile(join(vendoDir, "data", "misses.jsonl"));
+    if (missesRaw !== null) {
+      for (const line of missesRaw.split("\n")) {
+        if (line.trim() === "") continue;
+        try {
+          misses.push(capabilityMissEventSchema.parse(JSON.parse(line)));
+        } catch {
+          // A malformed feed line never sinks the run.
+        }
+      }
+    }
+  }
+  const maxMisses = options.maxMisses ?? DEFAULT_MAX_MISSES;
+  return { tools, overrides, capabilities, brief, misses: misses.slice(-maxMisses) };
+}
+
+/** Post-override-merge primitive targets — the same view the registry loads,
+ * so write-time validation agrees with load-time quarantine (04 §6). */
+function mergedPrimitives(inputs: RefineInputs): Map<string, PrimitiveStepTarget> {
+  const primitives = new Map<string, PrimitiveStepTarget>();
+  for (const tool of inputs.tools) {
+    const override = inputs.overrides?.tools[tool.name];
+    primitives.set(tool.name, {
+      risk: override?.risk ?? tool.risk,
+      disabled: override?.disabled ?? tool.disabled,
+    });
+  }
+  return primitives;
+}
+
+// ---------------------------------------------------------------------------
+// Source context — bounded, deterministic, prioritized toward API surfaces.
+// ---------------------------------------------------------------------------
+
+const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
+const IGNORED_DIRS = new Set([
+  "node_modules", ".git", ".next", ".turbo", ".vendo", "dist", "build", "out", "coverage",
+]);
+
+interface SourceContext {
+  tree: string[];
+  files: Array<{ path: string; content: string }>;
+}
+
+function sourcePriority(path: string): number {
+  const segments = path.split("/");
+  if (segments.some((part) => part === "api" || part === "routes" || part === "server" || part === "actions")) return 0;
+  if (segments.some((part) => part === "app" || part === "pages")) return 1;
+  if (segments.some((part) => part === "components" || part === "client")) return 2;
+  return 3;
+}
+
+async function collectSourcePaths(root: string): Promise<string[]> {
+  const found: string[] = [];
+  const walk = async (dir: string): Promise<void> => {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+      if (entry.name.startsWith(".") && entry.name !== ".") continue;
+      const absolute = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!IGNORED_DIRS.has(entry.name)) await walk(absolute);
+      } else if (SOURCE_EXTENSIONS.some((extension) => entry.name.endsWith(extension))) {
+        found.push(absolute.slice(root.length + 1).split(sep).join("/"));
+        if (found.length >= MAX_TREE_ENTRIES) return;
+      }
+      if (found.length >= MAX_TREE_ENTRIES) return;
+    }
+  };
+  await walk(root);
+  return found;
+}
+
+async function gatherSource(root: string, budget: number): Promise<SourceContext> {
+  const tree = await collectSourcePaths(root);
+  const ordered = [...tree].sort((left, right) =>
+    sourcePriority(left) - sourcePriority(right) || left.localeCompare(right));
+  const files: SourceContext["files"] = [];
+  let used = 0;
+  for (const path of ordered) {
+    if (used >= budget) break;
+    const raw = await readOptionalFile(join(root, ...path.split("/")));
+    if (raw === null) continue;
+    const content = raw.length > MAX_FILE_CHARS ? `${raw.slice(0, MAX_FILE_CHARS)}\n// … truncated` : raw;
+    if (used + content.length > budget) continue;
+    files.push({ path, content });
+    used += content.length;
+  }
+  return { tree, files };
+}
+
+// ---------------------------------------------------------------------------
+// Proposal generation — one model call.
+// ---------------------------------------------------------------------------
+
+const SYSTEM_PROMPT = [
+  "You are the Vendo refine engine. Vendo turns a host app's API into risk-labeled agent tools;",
+  "deterministic extraction already produced the primitive tools you are given. Your job is to close",
+  "the gap between what the host UI can do and what single tools can do, by proposing:",
+  "",
+  "1. compounds — multi-step capabilities the UI supports but no single tool covers. Each compound has",
+  "   ordered steps; every step references an ENABLED primitive tool name from the provided list (never",
+  "   another compound, never an unknown name). Step `args` values are JSONata expressions evaluated",
+  "   against { args, steps, item }: `args.x` reads the compound's own input, `steps.<id>` reads a prior",
+  "   step's output, and `item` is the current element inside a `forEach` step. `forEach` is a JSONata",
+  "   expression that must produce an array (max 1000 items); `if` is a JSONata condition that skips the",
+  "   step when false. Give each compound a JSON Schema `inputSchema` for its own arguments.",
+  "2. briefs — short prose playbooks that teach the agent how to combine existing tools.",
+  "3. riskCorrections — primitive tools whose extracted risk label (read/write/destructive) is wrong.",
+  "4. curation — primitive tools to disable (internal/debug/dangerous surfaces) or re-enable.",
+  "5. descriptions — clearer one-line descriptions for badly described primitive tools.",
+  "6. briefUpdate — an improved full replacement for the product brief, only when clearly better.",
+  "",
+  `Tool names must match ${String(TOOL_NAME_PATTERN)} and not collide with existing tools.`,
+  "Propose only what the provided source, misses, and interview genuinely support. Fewer, correct",
+  "proposals beat many speculative ones. Return empty arrays when nothing is warranted.",
+].join("\n");
+
+async function propose(
+  model: LanguageModel,
+  inputs: RefineInputs,
+  source: SourceContext,
+  interview: string[],
+): Promise<RefineProposals> {
+  const prompt = JSON.stringify({
+    productBrief: inputs.brief,
+    tools: inputs.tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      risk: inputs.overrides?.tools[tool.name]?.risk ?? tool.risk,
+      disabled: inputs.overrides?.tools[tool.name]?.disabled ?? tool.disabled ?? false,
+      inputSchema: tool.inputSchema,
+    })),
+    existingCompounds: (inputs.capabilities?.tools ?? []).map((tool) => tool.name),
+    existingBriefs: (inputs.capabilities?.briefs ?? []).map((brief) => brief.name),
+    capabilityMisses: inputs.misses.map((miss) => ({ intent: miss.intent, trigger: miss.trigger.kind })),
+    interview,
+    sourceTree: source.tree,
+    sourceFiles: source.files,
+  });
+  const result = await generateObject({ model, schema: proposalsSchema, system: SYSTEM_PROMPT, prompt });
+  return result.object;
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic normalization — the engine never trusts model-declared risk.
+// ---------------------------------------------------------------------------
+
+interface NormalizedProposals {
+  compounds: CompoundTool[];
+  briefs: CapabilityBrief[];
+  overridePatches: Map<string, ToolOverride>;
+  overrideWarnings: string[];
+  briefUpdate: string | undefined;
+  dropped: RefineDrop[];
+}
+
+function normalize(proposals: RefineProposals, inputs: RefineInputs): NormalizedProposals {
+  const dropped: RefineDrop[] = [];
+  const primitives = mergedPrimitives(inputs);
+  const existingCompoundNames = new Set((inputs.capabilities?.tools ?? []).map((tool) => tool.name));
+
+  const compounds: CompoundTool[] = [];
+  const acceptedNames = new Set<string>();
+  for (const candidate of proposals.compounds ?? []) {
+    const drop = (reason: string): void => { dropped.push({ kind: "compound", target: candidate.name, reason }); };
+    if (!TOOL_NAME_PATTERN.test(candidate.name)) { drop(`name does not match ${String(TOOL_NAME_PATTERN)}`); continue; }
+    if (primitives.has(candidate.name)) { drop("name collides with an extracted tool"); continue; }
+    if (existingCompoundNames.has(candidate.name)) { drop("name collides with an existing compound"); continue; }
+    if (acceptedNames.has(candidate.name)) { drop("duplicate proposal name"); continue; }
+    if (new Set(candidate.steps.map((step) => step.id)).size !== candidate.steps.length) {
+      drop("step ids must be unique");
+      continue;
+    }
+    let maxRisk: RiskLabel = "read";
+    let stepsValid = true;
+    for (const step of candidate.steps) {
+      const target = primitives.get(step.tool);
+      if (target === undefined) { drop(`step ${step.id} references unknown tool ${step.tool}`); stepsValid = false; break; }
+      if (target.disabled === true) { drop(`step ${step.id} references disabled tool ${step.tool}`); stepsValid = false; break; }
+      if (RISK_ORDER[target.risk] > RISK_ORDER[maxRisk]) maxRisk = target.risk;
+    }
+    if (!stepsValid) continue;
+    const steps: Step[] = candidate.steps.map((step) => ({
+      id: step.id,
+      tool: step.tool,
+      ...(step.args === undefined ? {} : { args: step.args }),
+      ...(step.if === undefined ? {} : { if: step.if }),
+      ...(step.forEach === undefined ? {} : { forEach: step.forEach }),
+    }));
+    acceptedNames.add(candidate.name);
+    compounds.push({
+      name: candidate.name,
+      description: candidate.description,
+      inputSchema: candidate.inputSchema ?? { type: "object" },
+      // Descriptor risk = max of step risks, computed HERE (validated again below
+      // and at load) — the model's opinion of risk is never trusted.
+      risk: maxRisk,
+      binding: { kind: "compound", steps },
+      note: "authored by vendo refine",
+    });
+  }
+
+  // Final gate: the SAME semantic validation the registry runs at load (04 §6).
+  const candidateFile = { tools: [...(inputs.capabilities?.tools ?? []), ...compounds] };
+  const issues = validateCapabilities(candidateFile, primitives);
+  const invalid = new Map<string, string>();
+  for (const issue of issues) {
+    if (acceptedNames.has(issue.tool)) invalid.set(issue.tool, issue.message);
+  }
+  const validCompounds = compounds.filter((compound) => {
+    const message = invalid.get(compound.name);
+    if (message !== undefined) dropped.push({ kind: "compound", target: compound.name, reason: message });
+    return message === undefined;
+  });
+
+  const existingBriefNames = new Set((inputs.capabilities?.briefs ?? []).map((brief) => brief.name));
+  const briefs: CapabilityBrief[] = [];
+  for (const candidate of proposals.briefs ?? []) {
+    if (candidate.name.trim() === "" || candidate.text.trim() === "") {
+      dropped.push({ kind: "brief", target: candidate.name || "(unnamed)", reason: "empty name or text" });
+      continue;
+    }
+    if (existingBriefNames.has(candidate.name) || briefs.some((brief) => brief.name === candidate.name)) {
+      dropped.push({ kind: "brief", target: candidate.name, reason: "brief already exists" });
+      continue;
+    }
+    const knownTools = candidate.tools?.filter((tool) => primitives.has(tool) || acceptedNames.has(tool));
+    briefs.push({
+      name: candidate.name,
+      text: candidate.text,
+      ...(knownTools === undefined || knownTools.length === 0 ? {} : { tools: knownTools }),
+    });
+  }
+
+  const overridePatches = new Map<string, ToolOverride>();
+  const overrideWarnings: string[] = [];
+  const patch = (tool: string, fields: ToolOverride): void => {
+    overridePatches.set(tool, { ...overridePatches.get(tool), ...fields });
+  };
+  for (const correction of proposals.riskCorrections ?? []) {
+    const current = primitives.get(correction.tool);
+    if (current === undefined) {
+      dropped.push({ kind: "override", target: correction.tool, reason: "unknown tool" });
+      continue;
+    }
+    if (current.risk === correction.risk) {
+      dropped.push({ kind: "override", target: correction.tool, reason: `risk is already ${correction.risk}` });
+      continue;
+    }
+    if (RISK_ORDER[correction.risk] < RISK_ORDER[current.risk]) {
+      overrideWarnings.push(
+        `risk DOWNGRADE proposed: ${correction.tool} ${current.risk} → ${correction.risk}`
+          + `${correction.reason === undefined ? "" : ` (${correction.reason})`} — approve only if certain`,
+      );
+    }
+    patch(correction.tool, { risk: correction.risk });
+  }
+  for (const curation of proposals.curation ?? []) {
+    const current = primitives.get(curation.tool);
+    if (current === undefined) {
+      dropped.push({ kind: "override", target: curation.tool, reason: "unknown tool" });
+      continue;
+    }
+    if ((current.disabled ?? false) === curation.disabled) {
+      dropped.push({ kind: "override", target: curation.tool, reason: `already ${curation.disabled ? "disabled" : "enabled"}` });
+      continue;
+    }
+    if (!curation.disabled) {
+      overrideWarnings.push(`re-ENABLE proposed: ${curation.tool}${curation.reason === undefined ? "" : ` (${curation.reason})`}`);
+    }
+    patch(curation.tool, { disabled: curation.disabled });
+  }
+  for (const description of proposals.descriptions ?? []) {
+    const extracted = inputs.tools.find((tool) => tool.name === description.tool);
+    if (extracted === undefined) {
+      dropped.push({ kind: "description", target: description.tool, reason: "unknown tool" });
+      continue;
+    }
+    const currentDescription = inputs.overrides?.tools[description.tool]?.description ?? extracted.description;
+    if (description.description.trim() === "" || description.description === currentDescription) {
+      dropped.push({ kind: "description", target: description.tool, reason: "empty or unchanged description" });
+      continue;
+    }
+    patch(description.tool, { description: description.description });
+  }
+
+  let briefUpdate = proposals.briefUpdate;
+  if (briefUpdate !== undefined && (briefUpdate.trim() === "" || briefUpdate.trim() === inputs.brief?.trim())) {
+    dropped.push({ kind: "brief-update", target: "brief.md", reason: "empty or unchanged brief" });
+    briefUpdate = undefined;
+  }
+
+  return { compounds: validCompounds, briefs, overridePatches, overrideWarnings, briefUpdate, dropped };
+}
+
+// ---------------------------------------------------------------------------
+// Probe — doctor machinery against the running dev app. Never mutating: only
+// paramless GET read steps are executed; write steps stay static-only.
+// ---------------------------------------------------------------------------
+
+async function probeStatus(url: string, fetchImpl: typeof fetch): Promise<RefineProbeCheck> {
+  try {
+    const response = await fetchImpl(`${url.replace(/\/$/, "")}/status`, { headers: { accept: "application/json" } });
+    const body = await response.json() as { posture?: unknown; version?: unknown };
+    if (response.ok && typeof body.posture === "string" && typeof body.version === "string") {
+      return { name: "dev-app", ok: true, detail: `/status live (${body.version}, ${body.posture})` };
+    }
+    return { name: "dev-app", ok: false, detail: `/status returned an invalid composition response (${response.status})` };
+  } catch {
+    return { name: "dev-app", ok: false, detail: `/status is unreachable at ${url}` };
+  }
+}
+
+interface LiveStepTarget {
+  method: string;
+  path: string;
+}
+
+/** A step is live-probeable only when it is READ risk and binds a paramless
+ * GET — refine must never mutate the dev app. */
+function liveTarget(binding: ExtractedTool["binding"]): LiveStepTarget | null {
+  if (binding.kind === "route" && binding.method.toUpperCase() === "GET") {
+    return { method: "GET", path: binding.path };
+  }
+  if (binding.kind === "openapi") {
+    const method = (binding as { method?: string }).method?.toUpperCase();
+    const path = (binding as { path?: string }).path;
+    if (method === "GET" && typeof path === "string") return { method, path };
+  }
+  return null;
+}
+
+const hasPathParams = (path: string): boolean => /[{[:]/.test(path);
+
+async function probeCompound(
+  compound: CompoundTool,
+  inputs: RefineInputs,
+  statusCheck: RefineProbeCheck | null,
+  origin: string | null,
+  fetchImpl: typeof fetch,
+): Promise<RefineProbe> {
+  const primitives = mergedPrimitives(inputs);
+  const byName = new Map(inputs.tools.map((tool) => [tool.name, tool]));
+  const checks: RefineProbeCheck[] = [];
+  if (statusCheck !== null) checks.push(statusCheck);
+
+  // "verified" requires at least one live STEP check — a live /status alone
+  // only proves the composition is up, not that this compound's surface exists.
+  let live = false;
+  for (const step of compound.binding.steps) {
+    const label = `step ${step.id} (${step.tool})`;
+    const target = primitives.get(step.tool);
+    const extracted = byName.get(step.tool);
+    if (target === undefined || extracted === undefined) {
+      checks.push({ name: label, ok: false, detail: "not an extracted primitive tool" });
+      continue;
+    }
+    if (target.risk !== "read") {
+      checks.push({ name: label, ok: true, detail: `${target.risk} risk — not executed by the probe; validated statically` });
+      continue;
+    }
+    const request = liveTarget(extracted.binding);
+    if (request === null || hasPathParams(request.path) || origin === null || statusCheck?.ok !== true) {
+      checks.push({ name: label, ok: true, detail: "read step not live-probeable here; validated statically" });
+      continue;
+    }
+    try {
+      const response = await fetchImpl(`${origin}${request.path}`, { headers: { accept: "application/json" } });
+      if (response.status === 404 || response.status === 405 || response.status >= 500) {
+        checks.push({ name: label, ok: false, detail: `GET ${request.path} → ${response.status}` });
+      } else {
+        const gated = response.status === 401 || response.status === 403 ? " (auth-gated)" : "";
+        checks.push({ name: label, ok: true, detail: `GET ${request.path} → ${response.status}${gated}` });
+        live = true;
+      }
+    } catch {
+      checks.push({ name: label, ok: false, detail: `GET ${request.path} is unreachable` });
+    }
+  }
+
+  // An unreachable dev app degrades to static-only (the diff is still worth
+  // presenting); only a STEP-level probe failure marks the compound failed.
+  const failed = checks.some((check) => check.name !== "dev-app" && !check.ok);
+  return {
+    tool: compound.name,
+    status: failed ? "failed" : live ? "verified" : "static-only",
+    checks,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Diff building — init's whole-file diff convention.
+// ---------------------------------------------------------------------------
+
+function renderDiff(path: string, before: string | null, after: string): string {
+  const oldLines = before === null ? [] : before.trimEnd().split("\n");
+  const newLines = after.trimEnd().split("\n");
+  return [
+    `--- a/${path}`,
+    `+++ b/${path}`,
+    ...oldLines.map((line) => `-${line}`),
+    ...newLines.map((line) => `+${line}`),
+  ].join("\n");
+}
+
+const stringify = (value: unknown): string => `${JSON.stringify(value, null, 2)}\n`;
+
+// ---------------------------------------------------------------------------
+// The engine.
+// ---------------------------------------------------------------------------
+
+export async function runRefine(options: RefineOptions): Promise<RefineResult> {
+  const root = resolve(options.root);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const interview = options.interview ?? [];
+  const startedAt = new Date().toISOString();
+
+  const inputs = await loadInputs(root, options);
+  const source = await gatherSource(root, options.sourceBudget ?? DEFAULT_SOURCE_BUDGET);
+  const proposals = await propose(options.model, inputs, source, interview);
+  const normalized = normalize(proposals, inputs);
+
+  // Probe: doctor's /status once, then per-compound verification. Compounds
+  // that FAIL their probe are not offered as changes — the loop is
+  // propose → probe → present → apply (spec §3).
+  const statusCheck = options.url === undefined ? null : await probeStatus(options.url, fetchImpl);
+  const origin = options.url === undefined ? null : new URL(options.url).origin;
+  const probes: RefineProbe[] = [];
+  const verified: CompoundTool[] = [];
+  for (const compound of normalized.compounds) {
+    const probe = await probeCompound(compound, inputs, statusCheck, origin, fetchImpl);
+    probes.push(probe);
+    if (probe.status === "failed") {
+      normalized.dropped.push({
+        kind: "compound",
+        target: compound.name,
+        reason: `probe failed: ${probe.checks.filter((check) => !check.ok).map((check) => check.detail).join("; ")}`,
+      });
+    } else {
+      verified.push(compound);
+    }
+  }
+
+  const changes: RefineChange[] = [];
+  const vendoDir = join(root, ".vendo");
+
+  if (verified.length > 0 || normalized.briefs.length > 0) {
+    const beforeFile = inputs.capabilities;
+    const afterFile: CapabilitiesFile = {
+      format: VENDO_CAPABILITIES_FORMAT,
+      ...beforeFile,
+      tools: [...(beforeFile?.tools ?? []), ...verified],
+      ...((beforeFile?.briefs ?? []).length + normalized.briefs.length > 0
+        ? { briefs: [...(beforeFile?.briefs ?? []), ...normalized.briefs] }
+        : {}),
+    };
+    const before = await readOptionalFile(join(vendoDir, "capabilities.json"));
+    const after = stringify(afterFile);
+    if (before !== after) {
+      changes.push({
+        path: ".vendo/capabilities.json",
+        before,
+        after,
+        diff: renderDiff(".vendo/capabilities.json", before, after),
+        warnings: [],
+      });
+    }
+  }
+
+  if (normalized.overridePatches.size > 0) {
+    const beforeFile: OverridesFile = inputs.overrides ?? { format: VENDO_OVERRIDES_FORMAT, tools: {} };
+    const tools: Record<string, ToolOverride> = { ...beforeFile.tools };
+    for (const [tool, fields] of normalized.overridePatches) {
+      tools[tool] = { ...tools[tool], ...fields };
+    }
+    const before = await readOptionalFile(join(vendoDir, "overrides.json"));
+    const after = stringify({ ...beforeFile, tools });
+    if (before !== after) {
+      changes.push({
+        path: ".vendo/overrides.json",
+        before,
+        after,
+        diff: renderDiff(".vendo/overrides.json", before, after),
+        warnings: normalized.overrideWarnings,
+      });
+    }
+  }
+
+  if (normalized.briefUpdate !== undefined) {
+    const before = inputs.brief;
+    const after = normalized.briefUpdate.endsWith("\n") ? normalized.briefUpdate : `${normalized.briefUpdate}\n`;
+    if (before !== after) {
+      changes.push({
+        path: ".vendo/brief.md",
+        before,
+        after,
+        diff: renderDiff(".vendo/brief.md", before, after),
+        warnings: [],
+      });
+    }
+  }
+
+  const transcript: RefineTranscript = {
+    version: 0,
+    startedAt,
+    root,
+    ...(options.url === undefined ? {} : { url: options.url }),
+    inputs: {
+      tools: inputs.tools.length,
+      misses: inputs.misses.length,
+      interview,
+      sourceFiles: source.files.map((file) => file.path),
+    },
+    proposals,
+    dropped: normalized.dropped,
+    probes,
+    decisions: [],
+  };
+
+  return { changes, probes, dropped: normalized.dropped, transcript };
+}

--- a/packages/vendo/src/refine.ts
+++ b/packages/vendo/src/refine.ts
@@ -434,6 +434,10 @@ function normalize(proposals: RefineProposals, inputs: RefineInputs): Normalized
   });
 
   const existingBriefNames = new Set((inputs.capabilities?.briefs ?? []).map((brief) => brief.name));
+  // Only tools that survive to the OUTPUT are legal brief references: primitives
+  // plus compounds that passed the final validateCapabilities gate — never a
+  // compound this run dropped (Devin/Greptile: no dangling brief references).
+  const outputCompoundNames = new Set(validCompounds.map((compound) => compound.name));
   const briefs: CapabilityBrief[] = [];
   for (const candidate of proposals.briefs ?? []) {
     if (candidate.name.trim() === "" || candidate.text.trim() === "") {
@@ -444,7 +448,7 @@ function normalize(proposals: RefineProposals, inputs: RefineInputs): Normalized
       dropped.push({ kind: "brief", target: candidate.name, reason: "brief already exists" });
       continue;
     }
-    const knownTools = candidate.tools?.filter((tool) => primitives.has(tool) || acceptedNames.has(tool));
+    const knownTools = candidate.tools?.filter((tool) => primitives.has(tool) || outputCompoundNames.has(tool));
     briefs.push({
       name: candidate.name,
       text: candidate.text,

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -49,6 +49,17 @@ import { adoptEphemeralSubject, createStore, envSecrets, registerEphemeralSubjec
 // 02-store §5: the erase API ships on the umbrella's runtime surface so hosts
 // reach it without installing @vendoai/store directly.
 export { eraseStore, type EraseReport, type EraseTable } from "@vendoai/store";
+export {
+  runRefine,
+  type RefineChange,
+  type RefineDrop,
+  type RefineOptions,
+  type RefineProbe,
+  type RefineProbeCheck,
+  type RefineProposals,
+  type RefineResult,
+  type RefineTranscript,
+} from "./refine.js";
 import { initTelemetry, type Telemetry } from "@vendoai/telemetry";
 import type { LanguageModel } from "ai";
 import {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -993,6 +993,9 @@ importers:
       ajv-formats:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.20.0)
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -9360,8 +9363,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.9
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5(jiti@2.7.0))
@@ -9403,21 +9406,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.5(jiti@2.7.0)
-      get-tsconfig: 4.14.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.17
-      unrs-resolver: 1.12.2
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -9429,32 +9417,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      eslint: 9.39.5(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9465,7 +9443,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -9494,7 +9472,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3


### PR DESCRIPTION
Implements ENG-250 from the approved extraction design (`docs/superpowers/specs/2026-07-14-extraction-survives-real-apps-design.md` §3). Builds on the merged ENG-249 compound machinery (#267): this engine AUTHORS the `.vendo/capabilities.json` artifact #267 executes, validated at write time through the same `validateCapabilities` the registry runs at load.

## One engine, two surfaces

- **`runRefine`** (`packages/vendo/src/refine.ts`, exported from `@vendoai/vendo/server`) — the programmatic engine.
- **`vendo refine [dir] [--url --model-import --ask --yes]`** (`cli/refine.ts`) — the command surface.
- **End-of-init offer** — a y/N prompt after a successful interactive `vendo init`; `--yes` prints a pointer instead; a declined or failed refine never changes init's exit code.

## The loop (spec-locked)

propose → probe → present diff → apply on approval.

- **Inputs**: `.vendo/tools.json` + `overrides.json` + `capabilities.json` + `brief.md`; bounded, deterministic source context (API surfaces first, 48k char budget); the miss feed (`.vendo/data/misses.jsonl`, malformed lines skipped); an interactive dev interview (`--ask` for non-interactive/cloud runs); the running dev app via `--url`.
- **Model**: ONE `generateObject` call over a BYO ai-SDK `LanguageModel` — the same provider seam as `createVendo({ model })`. CLI resolution: `--model-import` (host module exporting `model`) or the init-starter default (`@ai-sdk/anthropic` resolved from the HOST app + `ANTHROPIC_API_KEY`). No provider deps added to the umbrella.
- **Probe** (doctor machinery): `/status` live check + read-step reachability against the host origin (401/403 = reachable/auth-gated). **Write/destructive steps are never executed by the probe.** Probe-failed compounds are dropped with reasons; an unreachable dev app degrades to static-only (diffs still presented).
- **Outputs — all reviewable diffs, never silently applied**: compounds + briefs → `capabilities.json`; risk corrections (downgrades carry a loud warning), enable/disable curation, description improvements → `overrides.json`; `brief.md` updates. **`tools.json` is never a change target** (tested).
- **Risk**: descriptor risk on authored compounds = max of step risks, computed by the engine — the model's risk opinion is never trusted — then re-validated via the shared `validateCapabilities` (04 §6).
- **Cloud seam designed, not built**: all inputs injectable; every run emits a `RefineTranscript` (inputs digest, raw proposals, probes, apply decisions) written under `.vendo/data/refine/` (gitignored via the existing `.vendo/data/.gitignore`).

## Live proof (Relay corpus host, real Anthropic key)

Booted `corpus/hosts/express-host` (real `createVendo` on one origin) and ran:

```
vendo refine corpus/hosts/express-host --url http://127.0.0.1:3841/api/vendo --yes \
  --ask "Users want to close out all their open tasks in one ask from chat; ..."
```

- Proposed `complete_all_open_tasks`: `host_listTasks(status="open")` → `forEach` `host_completeTask(id: item.id)` — risk `write` (computed), plus three capability briefs and two description overrides.
- Probe: **verified** — `/status` live (0.3.0, rules), `GET /api/tasks → 200`; write step "not executed by the probe; validated statically".
- Applied as a clean diff, then executed end-to-end through `createActions({ dir })` against the live host: registry loaded the compound beside the 5 deterministic tools; **before: 4 open seeded tasks → compound ok (steps list_open, complete_each) → after: 0 open tasks**. Fixture changes reverted after evidence capture (stash).

## Contract amendment (Yousef-gated, separate)

`docs/contracts/` is untouched here. The spec's build-step-vs-command amendment is a separate DRAFT PR #274 (04-actions §1 scoped to sync + 09-vendo bin surface), left unmerged for Yousef's own action. Note: `vendo refine` does not contradict the frozen text — the build-step rule is §1 *Sync*, and §6 already names the refine engine as capabilities.json's author.

## Tests

- `refine.test.ts` (15): risk computation, drop reasons (collisions, unknown/disabled step tools, duplicate ids, nested compounds), overrides field-wise merge preserving human entries, brief updates, probe verified/failed/static-only/auth-gated, prompt inputs (misses/interview/source), transcript, tools.json never offered.
- `cli/refine.test.ts` (10): approval gating (decline writes nothing), `--yes`, transcript decisions, model resolution paths and guidance.
- `init.test.ts` (+3): offer accepted runs refine against the root; declined runs nothing; failed refine never fails init; `--yes` prints the pointer.

Full gate locally: build, typecheck, lint green; tests green except the pre-existing `packaging.e2e.test.ts` path-with-spaces failure (this worktree lives under a spaced path; CI is the arbiter).

## Parked / follow-ups

- No new telemetry event (the allowlist is closed and mirrored in TELEMETRY.md; a `refine_run` event is a small follow-up).
- JSONata expressions in proposed steps are schema-validated but not parse-checked at write (they fail safe at execution through the guard path); a `jsonata`-backed write-time parse check is a follow-up.
- Live model emitted literal `\n` sequences inside the brief.md replacement text once — visible in the presented diff (exactly what review is for); prompt-hardening follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the refine engine to propose compound capabilities and brief updates as reviewable diffs, exposed via `runRefine` and the `vendo refine` CLI, with an end-of-init offer. Implements ENG-250; forwards the init-chosen `--model-import`, filters brief tool refs to primitives and surviving compounds, and documents the command.

- **New Features**
  - Surfaces: `runRefine` (exported from `@vendoai/vendo/server`) and `vendo refine [dir]`.
  - Loop: propose → probe (`/status` + read-step checks; never executes write steps) → present diff → apply on approval; unreachable dev app degrades to static-only; probe-failed compounds are dropped with reasons.
  - Inputs: `.vendo/tools.json`, `overrides.json`, `capabilities.json`, `brief.md`, bounded source context, `.vendo/data/misses.jsonl`, interview (`--ask`), optional `--url`.
  - Model: one `generateObject` over a BYO `LanguageModel`; CLI resolves via `--model-import` or `@ai-sdk/anthropic` with `ANTHROPIC_API_KEY` from the host app.
  - Outputs (reviewable diffs only): compounds + briefs → `capabilities.json`; risk corrections, enable/disable, description fixes → `overrides.json`; `brief.md` updates; `tools.json` is never changed; brief tool refs are filtered to primitives + surviving compounds; risk downgrades and re-enables emit warnings.
  - Risk: descriptor risk = max step risk, then revalidated via `validateCapabilities`.
  - UX: `--yes` auto-approves; per-file confirm; transcripts under `.vendo/data/refine/`; `vendo init` offers to run refine once, forwards the chosen `--model-import`, and never fails init if declined or refine fails.
  - Docs: adds CLI reference for `vendo refine`.

- **Dependencies**
  - Added `zod@^3.24.0`.

<sup>Written for commit f5761a153560d95b84c84a2e24a20be5c34077e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

