### PR TITLE
fix(corpus): gallery builds only dev servers that serve prebuilt output (ENG-243)

### DIFF
--- a/corpus/README.md
+++ b/corpus/README.md
@@ -97,7 +97,10 @@ Each deep-tier gallery config contains one or two `nativeScreens` (`id`,
 UI-generating `prompts` (`id`, `label`, `prompt`, and optional `timeoutMs`). The
 gallery command reuses the normal checkout, bootstrap, local-package injection,
 `vendo init`, per-repo e2e preparation, and boot recipes before opening the
-Layer-3 Playwright surface.
+Layer-3 Playwright surface. The manifest `buildCommand` runs first only when
+the recipe's `devServer.requiresBuild` is true (express-host, whose start
+script serves prebuilt `dist/` output); self-compiling dev servers boot
+directly, exactly like `pnpm corpus boot`.
 
 Artifacts are written under
 `corpus/.repos/.gallery/<runId>/<repo>/`. Every prompt gets

--- a/corpus/harness/src/cli.test.ts
+++ b/corpus/harness/src/cli.test.ts
@@ -786,6 +786,9 @@ describe("runCli gallery", () => {
     const corpusRoot = await makeTempRoot();
     const context = createRunContext({ corpusRoot });
     const repo = deepManifestEntry("repo-gallery");
+    // The build step runs only for recipes whose dev server serves prebuilt
+    // output (express-host's `node dist/...`); flag it like the manifest does.
+    repo.bootstrap.devServer = { ...repo.bootstrap.devServer!, requiresBuild: true };
     const events: string[] = [];
     const stdout: string[] = [];
     const captureOptions: CaptureGalleryRepoOptions[] = [];
@@ -888,5 +891,66 @@ describe("runCli gallery", () => {
     });
     expect(reportOptions[0]?.repos).toEqual([galleryResult]);
     expect(stdout.join("\n")).toContain("gallery.html");
+  });
+
+  it("boots self-compiling dev servers without running the production build", async () => {
+    const corpusRoot = await makeTempRoot();
+    const context = createRunContext({ corpusRoot });
+    // deepManifestEntry leaves devServer.requiresBuild unset — `next dev`
+    // style recipes (umami, skateshop, papermark) compile themselves, and
+    // papermark's upstream baseline production build is broken at the pin.
+    const repo = deepManifestEntry("repo-gallery-dev");
+    const events: string[] = [];
+
+    const exitCode = await runCli(["gallery"], {
+      now: () => new Date("2026-07-14T12:00:00.000Z"),
+      stdout: () => {},
+      stderr: () => {},
+      loadManifest: async () => [repo],
+      discoverConfiguredGalleryRepoNames: async () => [repo.name],
+      createContext: () => context,
+      ensureRepoCheckout: async (entry) => {
+        await writeHostPackage(context.repoDir(entry.name));
+        return context.repoDir(entry.name);
+      },
+      bootstrapRepo: async (entry) => ({
+        repoDir: context.repoDir(entry.name),
+        envPath: path.join(context.repoDir(entry.name), ".env"),
+        logs: { stdout: "bootstrap.stdout.log", stderr: "bootstrap.stderr.log" },
+      }),
+      createInjector: () => ({
+        async inject(entry) {
+          return {
+            repoDir: context.repoDir(entry.name),
+            packageManager: "pnpm",
+            packages: [],
+            vendorDir: path.join(context.repoDir(entry.name), "vendor"),
+            installCommand: "pnpm install",
+          };
+        },
+      }),
+      runInit: async (entry) =>
+        makeInitResult(context.repoDir(entry.name), "gallery.init.log", "gallery.init.diff"),
+      prepareE2eRepo: async () => [],
+      commandRunner: async (command) => {
+        events.push(`build:${command}`);
+        return { code: 0, stdout: "", stderr: "" };
+      },
+      bootRepo: async (entry) => ({
+        repoDir: context.repoDir(entry.name),
+        readinessUrl: "http://127.0.0.1:3333",
+        logPaths: { server: path.join(context.logsDir(entry.name), "boot.server.log") },
+        teardown: async () => {},
+      }),
+      captureGalleryRepo: async (options) => ({
+        repoName: options.repoName,
+        nativeScreens: [],
+        prompts: [],
+      }),
+      writeGalleryHtml: async (options) => path.join(options.runRoot, "gallery.html"),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(events).toEqual([]);
   });
 });

--- a/corpus/harness/src/cli.ts
+++ b/corpus/harness/src/cli.ts
@@ -730,7 +730,12 @@ async function runGalleryCommand(options: GalleryCommandOptions, deps: ResolvedD
         throw new Error(`vendo init failed for ${repo.name}; see ${init.artifacts.log}`);
       }
       await deps.prepareE2eRepo(repo, appRoot, context.logsDir(repo.name));
-      if (repo.bootstrap.buildCommand) {
+      // Build only when the dev server serves prebuilt output (manifest
+      // devServer.requiresBuild). Self-compiling dev servers boot without a
+      // production build — same seam `corpus boot` and Layer 3 have always
+      // used — and papermark's upstream baseline build is broken at the pin
+      // (layers 1-2 record it as skipped-baseline-broken).
+      if (repo.bootstrap.buildCommand && repo.bootstrap.devServer?.requiresBuild === true) {
         const build = createLoggedCommandRunner(
           context.logsDir(repo.name),
           "gallery.build",

--- a/corpus/harness/src/manifest.test.ts
+++ b/corpus/harness/src/manifest.test.ts
@@ -84,6 +84,26 @@ describe("parseManifest", () => {
     expect(() => parseManifest([entry, { ...entry }])).toThrow(/duplicate.*umami/i);
   });
 
+  it("accepts a dev server that requires a build and rejects non-boolean flags", () => {
+    const withFlag = {
+      ...entry,
+      bootstrap: {
+        ...entry.bootstrap,
+        devServer: { ...entry.bootstrap.devServer, requiresBuild: true },
+      },
+    };
+    expect(parseManifest([withFlag])[0]?.bootstrap.devServer?.requiresBuild).toBe(true);
+
+    const invalid = {
+      ...entry,
+      bootstrap: {
+        ...entry.bootstrap,
+        devServer: { ...entry.bootstrap.devServer, requiresBuild: "yes" },
+      },
+    };
+    expect(() => parseManifest([invalid])).toThrow(/requiresBuild/i);
+  });
+
   it("rejects invalid deep-tier docker database provisioning", () => {
     const invalid = {
       ...entry,
@@ -111,7 +131,13 @@ describe("parseManifest", () => {
       localPath: "corpus/hosts/express-host",
       framework: "express",
       tier: "deep",
+      // Its dev server is `node dist/...`, the only recipe serving prebuilt
+      // output — boot-oriented commands must run buildCommand first.
+      bootstrap: { devServer: { requiresBuild: true } },
     });
+    for (const repo of manifest.filter((entry) => ["umami", "skateshop", "papermark", "teable"].includes(entry.name))) {
+      expect(repo.bootstrap.devServer?.requiresBuild).toBeUndefined();
+    }
     for (const repo of manifest.filter((entry) => ["umami", "skateshop", "papermark"].includes(entry.name))) {
       expect(repo.bootstrap.database?.kind).toBe("docker-postgres");
       expect(repo.bootstrap.devServer?.readinessTimeoutMs).toBeGreaterThan(0);

--- a/corpus/harness/src/manifest.ts
+++ b/corpus/harness/src/manifest.ts
@@ -20,6 +20,13 @@ function relativePosixPathSchema(field: "appDir" | "localPath") {
 const devServerSchema = z
   .object({
     command: z.string().min(1),
+    /** True when the dev-server command serves prebuilt output (for example
+     * express-host's `node dist/...` start), so boot-oriented commands such as
+     * `corpus gallery` must run `buildCommand` first. Self-compiling dev
+     * servers (`next dev`, `nest start -w`) leave this unset: `corpus boot`
+     * has never built before booting, and repos with a broken upstream
+     * baseline build (papermark) can still boot and be captured. */
+    requiresBuild: z.boolean().optional(),
     readinessUrl: z.string().url(),
     readinessBodyContains: z.string().min(1).optional(),
     readinessTimeoutMs: z.number().int().positive().optional(),

--- a/corpus/manifest.json
+++ b/corpus/manifest.json
@@ -462,6 +462,7 @@
       "buildCommand": "pnpm --ignore-workspace build",
       "devServer": {
         "command": "pnpm --ignore-workspace start",
+        "requiresBuild": true,
         "readinessUrl": "http://127.0.0.1:3210",
         "readinessTimeoutMs": 120000
       }


### PR DESCRIPTION
## What

Wave-5 measurement rerun (ENG-243) hit the next pothole behind #271: the `corpus gallery` command runs the manifest `buildCommand` unconditionally before boot, and that build step blocked three of the four gate-repo legs in one run:

- **umami, skateshop** — the injected `prebuild: vendo sync --strict` exits 2 (5 breaking renames each): their e2e prep still overwrites `.vendo/tools.json` with the curated facade; only papermark moved to the overrides channel in #271.
- **papermark** — `vendo sync --strict` now exits 0 (the #271 fix works), but `next build` itself fails: the pinned upstream SHA is missing 23 `ee/` modules (`ee/features/branding/*`, `ee/features/request-lists/*`, ...). Layers 1-2 already know this and record it as `skipped-baseline-broken` instead of failing; the gallery had no equivalent.

No boot path has ever needed that build: `corpus boot` and the Layer-3 sweep boot dev servers directly, and #271 validated umami exactly that way. The only recipe that genuinely needs a build before boot is express-host, whose `devServer.command` is `pnpm start` → `node dist/server/index.js`.

## Fix

Config-driven, no hardcoding: new optional `devServer.requiresBuild` boolean in the manifest schema. `corpus gallery` runs `buildCommand` only when it is true. Set on express-host alone; umami/skateshop/papermark/teable boot exactly like `pnpm corpus boot`.

## Validation

- `pnpm --filter @vendoai/corpus-harness test` — 106/106 (new: manifest flag round-trip + rejection, gallery build-skip path; existing gallery-flow test now flags its fixture).
- Full gate: `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green locally (`@vendoai/store` durability drill flaked under parallel load — timed out waiting for the writer marker — and passes 177/177 on isolated rerun).
- End-to-end proof is the wave-5 measurement run itself (results land on ENG-243).

## Follow-up (not this PR)

`vendo sync` always rewrites `tools.json` from extraction, and the fixtures' `predev: vendo sync` hook runs at every dev boot — so umami's and skateshop's curated `tools.json` overwrite is clobbered at boot regardless of this change, and their fixture guidance never reaches the runtime. They need the same overrides-channel conversion papermark got in #271 (skateshop additionally injects its `/api/corpus/*` facade routes after init, so its prep would need to run a real re-extraction before pinning overrides).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `corpus gallery` run `buildCommand` only when a dev server serves prebuilt output, unblocking ENG-243 gallery runs and aligning behavior with `corpus boot`.

- **Bug Fixes**
  - Added `bootstrap.devServer.requiresBuild` (optional) to the manifest schema.
  - `corpus gallery` builds only when `requiresBuild` is true; self-compiling dev servers boot directly.
  - Set the flag for express-host; umami, skateshop, papermark, and teable skip the build.
  - Updated tests and docs to cover the flag and build-skip path, preventing failures from `vendo sync --strict` and papermark’s broken upstream build.

<sup>Written for commit 0ef9344c568fd1663730788e0469a0bb00e8501e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

