### PR TITLE
fix(corpus): umami gallery native waitFor uses h2, not main (ENG-243)

### DIFF
--- a/corpus/expectations/umami/gallery.json
+++ b/corpus/expectations/umami/gallery.json
@@ -5,7 +5,7 @@
       "id": "websites",
       "label": "Umami websites overview",
       "path": "/websites",
-      "waitFor": "main"
+      "waitFor": "h2"
     }
   ],
   "prompts": [


### PR DESCRIPTION
## What

Third pothole in the wave-5 measurement rerun (ENG-243), after #271 and #276: the umami gallery leg boots and authenticates cleanly, but its **native-screen** capture always times out at 60s.

Root cause: umami's app shell renders **no `<main>` element**. It composes every page from `@umami/react-zen` `Column`/`Grid`/`Row` primitives, and the `/websites` page title is an `<h2>` `Heading` (via `PageHeader`). The gallery native-screen `waitFor` was `"main"`, which never matches. #271 verified `pnpm corpus boot umami` (boot + `/api/vendo/status` 200) but never exercised the full gallery capture, so this selector was never hit until now.

## Fix

`corpus/expectations/umami/gallery.json`: native `waitFor` `"main"` → `"h2"` (the page-title heading react-zen emits; visible as soon as the authed page mounts). One-line config change; no harness code touched.

## Validation

Re-running `pnpm corpus gallery express-host umami` with live keys after this change (umami boots, logs in as the seeded admin, `/websites` renders, native + 3 generation prompts capture). Results land on ENG-243.

## Note

skateshop and papermark remain blocked by substantive, non-selector issues surfaced in the same run (skateshop: injected `ai@5` closure needs `zod/v4`, host pins `zod@3.23.8`; papermark: upstream `export *` in a client boundary + 23 missing `ee/` modules at the pinned SHA). Those are reported on ENG-243 for the parent/engine team, not fixed here.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the Umami gallery native-screen wait selector from "main" to "h2" so the capture doesn’t time out and the gallery run completes.
Umami pages don’t render a <main> (they use `@umami/react-zen`), so waiting on the page-title <h2> fixes ENG-243’s Umami gallery capture.

<sup>Written for commit bcfd3c9f8ceaafb95a3e56bd1758088394ee177e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

