### PR TITLE
fix(store): recover lost last-owner-race fix (ENG-263 post-merge)

### DIFF
--- a/packages/store/src/db.ts
+++ b/packages/store/src/db.ts
@@ -109,6 +109,38 @@ export function createDb(config: StoreConfig = {}): Db {
 
 /** 02-store §4 */
 export async function withSchemaLock<T>(db: Db, work: (query: Query) => Promise<T>): Promise<T> {
+  return withAdvisoryLock(db, [ADVISORY_LOCK_KEY], work);
+}
+
+/** ENG-263 — the classroom of the org-membership lock. A session-scoped Postgres
+    advisory lock, taken on a dedicated pinned client so the whole `work` runs
+    against the connection that holds it (the shared pool would scatter the
+    lock/work/unlock across connections). PGlite serializes every query on one
+    connection, so the lock is a no-op there. Keyed per resource so unrelated
+    resources never block each other. */
+const ORG_MEMBERSHIP_LOCK_NAMESPACE = 7_461_002;
+
+/** Stable 31-bit hash of a resource id → the second int4 of a two-key advisory
+    lock (the first is a namespace so org locks never collide with other lock
+    users). Same id → same lock; collisions only cost extra serialization. */
+function lockKeyForId(id: string): number {
+  let hash = 0;
+  for (let index = 0; index < id.length; index += 1) {
+    hash = (Math.imul(31, hash) + id.charCodeAt(index)) | 0;
+  }
+  return hash & 0x7fffffff;
+}
+
+/** Serialize owner-set mutations for ONE org (03-store): demote/remove check
+    the owner count then write, which races under READ COMMITTED (two owners
+    each see the other and both commit → zero owners). Under this lock the two
+    paths run one at a time per org, so the count the guard reads is the count
+    the write sees. */
+export async function withOrgMembershipLock<T>(db: Db, orgId: string, work: (query: Query) => Promise<T>): Promise<T> {
+  return withAdvisoryLock(db, [ORG_MEMBERSHIP_LOCK_NAMESPACE, lockKeyForId(orgId)], work);
+}
+
+async function withAdvisoryLock<T>(db: Db, keys: [number] | [number, number], work: (query: Query) => Promise<T>): Promise<T> {
   if (db.kind === "pglite") return work(db.query.bind(db));
 
   const url = pgUrls.get(db);
@@ -119,12 +151,13 @@ export async function withSchemaLock<T>(db: Db, work: (query: Query) => Promise<
     const result = await client.query(text, params);
     return { rows: result.rows as Record<string, unknown>[] };
   };
+  const placeholders = keys.map((_, index) => `$${index + 1}`).join(", ");
   try {
-    await query("SELECT pg_advisory_lock($1)", [ADVISORY_LOCK_KEY]);
+    await query(`SELECT pg_advisory_lock(${placeholders})`, keys);
     try {
       return await work(query);
     } finally {
-      await query("SELECT pg_advisory_unlock($1)", [ADVISORY_LOCK_KEY]);
+      await query(`SELECT pg_advisory_unlock(${placeholders})`, keys);
     }
   } finally {
     await client.end();

--- a/packages/store/src/helpers/orgs.test.ts
+++ b/packages/store/src/helpers/orgs.test.ts
@@ -72,6 +72,27 @@ for (const backend of backends()) {
       await expect(orgs.setRole(org.id, "user_ghost", "admin")).rejects.toMatchObject({ code: "not-found" });
     });
 
+    it("keeps at least one owner under concurrent self-demotions (last-owner race)", async () => {
+      const orgs = orgStore(made.store);
+      const org = await orgs.create("Race Inc", "user_ada");
+      await orgs.addMember(org.id, "user_bob", "owner");
+
+      // Both owners try to demote themselves at the same time. The per-org
+      // membership lock serializes the count-then-write, so exactly one
+      // succeeds and the org keeps an owner (never zero).
+      const results = await Promise.allSettled([
+        orgs.setRole(org.id, "user_ada", "member"),
+        orgs.setRole(org.id, "user_bob", "member"),
+      ]);
+      const fulfilled = results.filter((result) => result.status === "fulfilled");
+      const rejected = results.filter((result) => result.status === "rejected");
+      expect(fulfilled).toHaveLength(1);
+      expect(rejected).toHaveLength(1);
+      expect((rejected[0] as PromiseRejectedResult).reason).toMatchObject({ code: "conflict" });
+      const owners = (await orgs.members(org.id)).filter((member) => member.role === "owner");
+      expect(owners).toHaveLength(1);
+    });
+
     it("surfaces role integrity as VendoError, not raw db failures", async () => {
       const orgs = orgStore(made.store);
       const org = await orgs.create("Errors Org", "user_ada");

--- a/packages/store/src/helpers/orgs.ts
+++ b/packages/store/src/helpers/orgs.ts
@@ -1,5 +1,6 @@
 import { isReservedSubject, VendoError, type IsoDateTime } from "@vendoai/core";
 import { randomUUID } from "node:crypto";
+import { withOrgMembershipLock } from "../db.js";
 import { dbFor, type VendoStore } from "../store.js";
 import { iso, text } from "./utils.js";
 
@@ -159,17 +160,18 @@ export function orgStore(store: VendoStore): {
     async setRole(orgId, subject, role) {
       parseRole(role);
       await requireOrg(orgId);
-      // Demoting the LAST owner would orphan the org — the guard is in the
-      // UPDATE's WHERE so a concurrent demotion cannot slip past it (the
-      // subquery and the update see the same snapshot).
-      const result = await db.query(
+      // Demoting the LAST owner would orphan the org. The count-then-write
+      // guard races under READ COMMITTED (two owners each see the other and
+      // both commit → zero owners), so serialize owner-set writes per org.
+      // The guard also lives in the UPDATE's WHERE as a second line of defense.
+      const result = await withOrgMembershipLock(db, orgId, (query) => query(
         `UPDATE vendo_org_members SET role = $3
          WHERE org_id = $1 AND subject = $2
            AND (role <> 'owner' OR $3 = 'owner'
              OR (SELECT count(*) FROM vendo_org_members WHERE org_id = $1 AND role = 'owner') > 1)
          RETURNING org_id, subject, role, added_at`,
         [orgId, subject, role],
-      );
+      ));
       if (result.rows[0] === undefined) {
         const current = await roleOf(orgId, subject);
         if (current === null) throw new VendoError("not-found", `${subject} is not a member of ${orgId}`);
@@ -180,14 +182,14 @@ export function orgStore(store: VendoStore): {
 
     async removeMember(orgId, subject) {
       await requireOrg(orgId);
-      const result = await db.query(
+      const result = await withOrgMembershipLock(db, orgId, (query) => query(
         `DELETE FROM vendo_org_members
          WHERE org_id = $1 AND subject = $2
            AND (role <> 'owner'
              OR (SELECT count(*) FROM vendo_org_members WHERE org_id = $1 AND role = 'owner') > 1)
          RETURNING subject`,
         [orgId, subject],
-      );
+      ));
       if (result.rows[0] === undefined) {
         const current = await roleOf(orgId, subject);
         if (current === null) throw new VendoError("not-found", `${subject} is not a member of ${orgId}`);


### PR DESCRIPTION
## What

**Recovers a P1 concurrency fix that missed main by merge timing.** #277 (Child C, ENG-263) was merged at head `f0ab2d28`. Child C then pushed one more commit — `fe60c017`, the fix for Greptile's P1 finding — while finishing reviewer triage. Because the merge had already happened, that commit never reached main.

This PR is a clean cherry-pick of that single commit onto current main.

## The fix
`fix(store): serialize org owner-set writes per org to close last-owner race under READ COMMITTED` — without it, two concurrent owner-demotions on the same org can each observe the other as "still an owner" and both proceed, leaving an org with zero owners (the last-owner invariant is violated under READ COMMITTED). Serializes owner-set writes per org.

Touches `packages/store/src/db.ts`, `helpers/orgs.ts`, `helpers/orgs.test.ts` (+ regression test). Cherry-picked verbatim; not authored fresh.

## Gate
Store suite green locally (cherry-pick applied cleanly; the new regression test is included). No contract/doc change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the ENG-263 fix to prevent orgs from losing their last owner by serializing membership writes per org. Implements a per‑org Postgres advisory lock and adds a regression test.

- **Bug Fixes**
  - Added `withOrgMembershipLock` to serialize owner role changes and removals per org (Postgres advisory lock; no-op on PGlite).
  - Wrapped `setRole` and `removeMember` in the lock; kept the SQL WHERE guard as a second line of defense.
  - Added a regression test to ensure concurrent self-demotions leave exactly one owner.
  - Aligns with ENG-263 org semantics that require at least one owner.

<sup>Written for commit f97c961509e6a5446820a549dbeb6225fc331348. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

