### PR TITLE
fix(corpus): convert umami L3 to the overrides channel (ENG-243)

### DIFF
--- a/corpus/expectations/umami/conversations.json
+++ b/corpus/expectations/umami/conversations.json
@@ -12,7 +12,7 @@
         "For Demo SaaS at app.example.com, show the top pages by views for the last 7 days. Include the page labels and view counts in the visible answer."
       ],
       "assertions": [
-        { "kind": "tool-called", "name": "get_umami_website_metrics" },
+        { "kind": "tool-called", "name": "host_websites_metrics_list" },
         { "kind": "view-rendered", "text": { "regex": "(homepage|/pricing|/features)[\\s\\S]*\\b[0-9][0-9,.]*\\b|\\b[0-9][0-9,.]*\\b[\\s\\S]*(homepage|/pricing|/features)" } },
         { "kind": "no-error-toast" }
       ]
@@ -24,7 +24,7 @@
         "On Demo Blog, compare traffic for /blog/privacy-first-tracking and /blog/getting-started-with-analytics this month. Include each article path and its count in the visible answer."
       ],
       "assertions": [
-        { "kind": "tool-called", "name": "get_umami_website_metrics" },
+        { "kind": "tool-called", "name": "host_websites_metrics_list" },
         { "kind": "view-rendered", "text": { "regex": "\\b[0-9][0-9,.]*\\b[\\s\\S]*(privacy-first-tracking|getting-started-with-analytics)|(privacy-first-tracking|getting-started-with-analytics)[\\s\\S]*\\b[0-9][0-9,.]*\\b" } },
         { "kind": "no-error-toast" }
       ]
@@ -36,7 +36,7 @@
         "Summarize purchase revenue for Demo SaaS this month and break it down by pro versus enterprise if the data is available. Include revenue labels and numeric values in the visible answer."
       ],
       "assertions": [
-        { "kind": "tool-called", "name": "get_umami_revenue_report" },
+        { "kind": "tool-called", "name": "host_reports_revenue_create" },
         { "kind": "view-rendered", "text": { "regex": "(\\$|USD|revenue)[\\s\\S]*\\b[0-9][0-9,.]*\\b|\\b[0-9][0-9,.]*\\b[\\s\\S]*(\\$|USD|revenue)" } },
         { "kind": "no-error-toast" }
       ]
@@ -48,7 +48,7 @@
         "For app.example.com, compare signup_started and signup_completed events over the last 30 days and include the conversion rate. Include event labels and numeric values in the visible answer."
       ],
       "assertions": [
-        { "kind": "tool-called", "name": { "regex": "get_umami_(website_metrics|funnel_report)" } },
+        { "kind": "tool-called", "name": { "regex": "host_(websites_metrics_list|reports_funnel_create)" } },
         { "kind": "view-rendered", "text": { "regex": "\\b[0-9][0-9,.]*\\s*%" } },
         { "kind": "no-error-toast" }
       ]
@@ -60,7 +60,7 @@
         "For blog.example.com, show the top referrers or traffic sources for the last 30 days. Include source labels and counts in the visible answer."
       ],
       "assertions": [
-        { "kind": "tool-called", "name": "get_umami_website_metrics" },
+        { "kind": "tool-called", "name": "host_websites_metrics_list" },
         { "kind": "view-rendered", "text": { "regex": "(google\\.com|bing\\.com|duckduckgo\\.com|twitter\\.com|x\\.com|linkedin\\.com|facebook\\.com|reddit\\.com|news\\.ycombinator\\.com|medium\\.com|dev\\.to|hashnode\\.com|techcrunch\\.com|producthunt\\.com|indiehackers\\.com|direct)[\\s\\S]*\\b[0-9][0-9,.]*\\b|\\b[0-9][0-9,.]*\\b[\\s\\S]*(google\\.com|bing\\.com|duckduckgo\\.com|twitter\\.com|x\\.com|linkedin\\.com|facebook\\.com|reddit\\.com|news\\.ycombinator\\.com|medium\\.com|dev\\.to|hashnode\\.com|techcrunch\\.com|producthunt\\.com|indiehackers\\.com|direct)" } },
         { "kind": "no-error-toast" }
       ]

--- a/corpus/harness/src/e2e-prep.test.ts
+++ b/corpus/harness/src/e2e-prep.test.ts
@@ -102,13 +102,38 @@ export const config = {
   return { appRoot, logsDir };
 }
 
+// Mirrors real Umami route-scan output: host_* names carrying the endpoints
+// the curated surface maps onto, plus noise the curation must disable.
+const umamiExtractionTools = [
+  { name: "host_me_websites_list", method: "GET", path: "/api/me/websites" },
+  { name: "host_websites_metrics_list", method: "GET", path: "/api/websites/{websiteId}/metrics" },
+  { name: "host_websites_pageviews_list", method: "GET", path: "/api/websites/{websiteId}/pageviews" },
+  { name: "host_reports_revenue_create", method: "POST", path: "/api/reports/revenue" },
+  { name: "host_reports_funnel_create", method: "POST", path: "/api/reports/funnel" },
+  // Extraction noise the curated surface must disable.
+  { name: "host_admin_users_list", method: "GET", path: "/api/admin/users" },
+] as const;
+
+function umamiExtractionToolsJson(): string {
+  return `${JSON.stringify({
+    format: "vendo/tools@1",
+    tools: umamiExtractionTools.map((tool) => ({
+      name: tool.name,
+      description: "",
+      inputSchema: { type: "object", additionalProperties: true },
+      risk: "write",
+      binding: { kind: "route", method: tool.method, path: tool.path, argsIn: tool.method === "GET" ? "query" : "body" },
+    })),
+  }, null, 2)}\n`;
+}
+
 async function createUmamiFixture(): Promise<{ appRoot: string; logsDir: string }> {
   const root = await mkdtemp(path.join(os.tmpdir(), "vendo-e2e-prep-"));
   const appRoot = path.join(root, "umami");
   const logsDir = path.join(root, "logs");
   await mkdir(path.join(appRoot, ".vendo"), { recursive: true });
   await mkdir(path.join(appRoot, "src/app/api/vendo/[...vendo]"), { recursive: true });
-  await writeFile(path.join(appRoot, ".vendo/tools.json"), JSON.stringify({ format: "vendo/tools@1", tools: [] }));
+  await writeFile(path.join(appRoot, ".vendo/tools.json"), umamiExtractionToolsJson());
   await writeFile(path.join(appRoot, "src/app/api/vendo/[...vendo]/route.ts"), initRouteSource);
   await writeFile(
     path.join(appRoot, "src/app/layout.tsx"),
@@ -272,28 +297,35 @@ describe("prepareE2eRepo", () => {
     expect(log).toContain("corpus Vendo overlay");
   });
 
-  it("adds Umami Layer 3 tools, overlay chrome with the auth shim, and a trusted base URL", async () => {
+  it("curates the Umami Layer 3 surface through overrides, keeping tools.json pinned, plus overlay chrome and a trusted base URL", async () => {
     const { appRoot, logsDir } = await createUmamiFixture();
+    const toolsBefore = await readFile(path.join(appRoot, ".vendo/tools.json"), "utf8");
     const logs = await prepareE2eRepo({ name: "umami" }, appRoot, logsDir);
 
-    const tools = JSON.parse(await readFile(path.join(appRoot, ".vendo/tools.json"), "utf8")) as {
-      tools: Array<{ name: string; description: string }>;
+    // predev/prebuild `vendo sync` would clobber a curated tools.json, so the
+    // pin must be left exactly as init extracted it.
+    await expect(readFile(path.join(appRoot, ".vendo/tools.json"), "utf8")).resolves.toBe(toolsBefore);
+
+    const overrides = JSON.parse(await readFile(path.join(appRoot, ".vendo/overrides.json"), "utf8")) as {
+      format: string;
+      tools: Record<string, { risk?: string; description?: string; disabled?: boolean }>;
     };
     const overlay = await readFile(path.join(appRoot, "src/app/vendo-corpus-e2e.tsx"), "utf8");
     const layout = await readFile(path.join(appRoot, "src/app/layout.tsx"), "utf8");
     const env = await readFile(path.join(appRoot, ".env"), "utf8");
     const log = await readFile(logs[0]!, "utf8");
 
-    expect(tools.tools.map((tool) => tool.name)).toEqual([
-      "list_umami_websites",
-      "get_umami_website_metrics",
-      "get_umami_pageviews",
-      "get_umami_revenue_report",
-      "get_umami_funnel_report",
-    ]);
-    // Seeded date windows moved from instructionsExtra into the descriptions.
-    expect(tools.tools[1]!.description).toContain("startAt=1782691200000");
-    expect(tools.tools[3]!.description).toContain("2026-07-01T00:00:00.000Z");
+    expect(overrides.format).toBe("vendo/overrides@1");
+    // Curated endpoints are keyed to their EXTRACTION name and enabled read.
+    expect(overrides.tools["host_me_websites_list"]).toMatchObject({ risk: "read" });
+    expect(overrides.tools["host_me_websites_list"]!.disabled).toBeUndefined();
+    expect(overrides.tools["host_websites_metrics_list"]).toMatchObject({ risk: "read" });
+    // Seeded date windows and request-body shapes live in the descriptions now.
+    expect(overrides.tools["host_websites_metrics_list"]!.description).toContain("startAt=1782691200000");
+    expect(overrides.tools["host_reports_revenue_create"]!.description).toContain("2026-07-01T00:00:00.000Z");
+    expect(overrides.tools["host_reports_revenue_create"]!.description).toContain("cents");
+    // Extraction noise is disabled so the agent works only the curated surface.
+    expect(overrides.tools["host_admin_users_list"]).toEqual({ disabled: true });
     expect(overlay).toContain('"use client"');
     expect(overlay).toContain("VendoOverlay");
     expect(overlay).toContain("installUmamiAuthFetch");
@@ -304,7 +336,7 @@ describe("prepareE2eRepo", () => {
     expect(overlay).not.toContain('!url.pathname.startsWith("/api/vendo")');
     expect(layout).toContain("<VendoCorpusE2e />");
     expect(env).toContain("VENDO_BASE_URL=http://127.0.0.1:3000");
-    expect(log).toContain("read-only tools manifest");
+    expect(log).toContain("curated overrides.json");
     expect(log).toContain("Umami auth fetch shim");
     expect(log).toContain("VENDO_BASE_URL");
   });

--- a/corpus/harness/src/e2e-prep.ts
+++ b/corpus/harness/src/e2e-prep.ts
@@ -84,7 +84,7 @@ interface CuratedEndpoint {
 // seeded sites/windows guidance survives without a handler-level knob.
 const umamiFixtureNote =
   "Deterministic Umami corpus fixture: seeded sites Demo Blog (blog.example.com) and "
-  + "Demo SaaS (app.example.com). Call list_umami_websites first to map a requested site "
+  + "Demo SaaS (app.example.com). Call the websites-list tool first to map a requested site "
   + "name or domain to its websiteId, fetch data before answering, and quote the exact "
   + "labels and numeric values from the tool results.";
 

--- a/corpus/harness/src/e2e-prep.ts
+++ b/corpus/harness/src/e2e-prep.ts
@@ -67,148 +67,80 @@ function installUmamiAuthFetch(): () => void {
 }
 `;
 
-const umamiTools = {
-  format: "vendo/tools@1",
-  tools: [
-    {
-      name: "list_umami_websites",
-      description: "List Umami websites visible to the logged-in user, including seeded Demo Blog (blog.example.com) and Demo SaaS (app.example.com) IDs/domains. Always call this first to map a requested site name or domain to its websiteId, and answer corpus prompts only after gathering data — the visible answer must quote labels and numeric values from the tool results.",
-      inputSchema: {
-        type: "object",
-        properties: {},
-        additionalProperties: false,
-      },
-      risk: "read",
-      binding: { kind: "route", method: "GET", path: "/api/me/websites", argsIn: "query" },
-    },
-    {
-      name: "get_umami_website_metrics",
-      description: "Get ranked Umami metrics for one website. Use type=path for top pages, type=event for custom events such as signup_started/signup_completed, and type=referrer for acquisition sources. Use UTC with the seeded windows: last 7 days startAt=1782691200000 endAt=1783382399000; last 30 days startAt=1780704000000 endAt=1783382399000.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          websiteId: { type: "string", description: "Umami website UUID from list_umami_websites." },
-          type: {
-            type: "string",
-            enum: ["path", "event", "referrer", "title", "hostname"],
-            description: "Metric dimension to rank.",
-          },
-          startAt: { type: "integer", description: "UTC start time in Unix milliseconds." },
-          endAt: { type: "integer", description: "UTC end time in Unix milliseconds." },
-          unit: { type: "string", enum: ["day", "hour", "month"], default: "day" },
-          timezone: { type: "string", default: "UTC" },
-          limit: { type: "integer", default: 10, minimum: 1, maximum: 50 },
-        },
-        required: ["websiteId", "type", "startAt", "endAt"],
-        additionalProperties: false,
-      },
-      risk: "read",
-      binding: { kind: "route", method: "GET", path: "/api/websites/{websiteId}/metrics", argsIn: "query" },
-    },
-    {
-      name: "get_umami_pageviews",
-      description: "Get Umami pageview and session time series for one website over a date range. Use UTC with the seeded windows: last 7 days startAt=1782691200000 endAt=1783382399000; last 30 days startAt=1780704000000 endAt=1783382399000.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          websiteId: { type: "string", description: "Umami website UUID from list_umami_websites." },
-          startAt: { type: "integer", description: "UTC start time in Unix milliseconds." },
-          endAt: { type: "integer", description: "UTC end time in Unix milliseconds." },
-          unit: { type: "string", enum: ["day", "hour", "month"], default: "day" },
-          timezone: { type: "string", default: "UTC" },
-        },
-        required: ["websiteId", "startAt", "endAt"],
-        additionalProperties: false,
-      },
-      risk: "read",
-      binding: { kind: "route", method: "GET", path: "/api/websites/{websiteId}/pageviews", argsIn: "query" },
-    },
-    {
-      name: "get_umami_revenue_report",
-      description: "Get seeded Umami revenue totals and breakdowns for one website. Use this for Demo SaaS purchase revenue questions. Seeded this-month window (UTC): startDate=2026-07-01T00:00:00.000Z endDate=2026-07-06T23:59:59.000Z.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          body: {
-            type: "object",
-            properties: {
-              websiteId: { type: "string", description: "Umami website UUID from list_umami_websites." },
-              filters: { type: "object", additionalProperties: true, default: {} },
-              type: { type: "string", const: "revenue" },
-              parameters: {
-                type: "object",
-                properties: {
-                  startDate: { type: "string", description: "ISO start date." },
-                  endDate: { type: "string", description: "ISO end date." },
-                  unit: { type: "string", enum: ["day", "hour", "month"], default: "day" },
-                  timezone: { type: "string", default: "UTC" },
-                  currency: { type: "string", default: "USD" },
-                  compare: { type: "string", enum: ["prev", "yoy"], default: "prev" },
-                },
-                required: ["startDate", "endDate", "currency"],
-                additionalProperties: false,
-              },
-            },
-            required: ["websiteId", "filters", "type", "parameters"],
-            additionalProperties: false,
-          },
-        },
-        required: ["body"],
-        additionalProperties: false,
-      },
-      risk: "read",
-      binding: { kind: "openapi", operationId: "getUmamiRevenueReport", method: "POST", path: "/api/reports/revenue" },
-      formats: { value: "cents", total: "cents" },
-    },
-    {
-      name: "get_umami_funnel_report",
-      description: "Get an Umami funnel report for path or event steps. Use for signup_started to signup_completed conversion questions. Seeded this-month window (UTC): startDate=2026-07-01T00:00:00.000Z endDate=2026-07-06T23:59:59.000Z.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          body: {
-            type: "object",
-            properties: {
-              websiteId: { type: "string", description: "Umami website UUID from list_umami_websites." },
-              filters: { type: "object", additionalProperties: true, default: {} },
-              type: { type: "string", const: "funnel" },
-              parameters: {
-                type: "object",
-                properties: {
-                  startDate: { type: "string", description: "ISO start date." },
-                  endDate: { type: "string", description: "ISO end date." },
-                  window: { type: "integer", default: 30 },
-                  steps: {
-                    type: "array",
-                    minItems: 2,
-                    maxItems: 8,
-                    items: {
-                      type: "object",
-                      properties: {
-                        type: { type: "string", enum: ["path", "event"] },
-                        value: { type: "string" },
-                      },
-                      required: ["type", "value"],
-                      additionalProperties: false,
-                    },
-                  },
-                },
-                required: ["startDate", "endDate", "window", "steps"],
-                additionalProperties: false,
-              },
-            },
-            required: ["websiteId", "filters", "type", "parameters"],
-            additionalProperties: false,
-          },
-        },
-        required: ["body"],
-        additionalProperties: false,
-      },
-      risk: "read",
-      binding: { kind: "openapi", operationId: "getUmamiFunnelReport", method: "POST", path: "/api/reports/funnel" },
-    },
-  ],
-};
+// A curated endpoint expressed through the overrides channel: matched to init's
+// extraction by binding (method + path), then given the reviewed description +
+// risk. The overrides file only carries description/risk/disabled (04 §1), so
+// every schema hint the agent needs — required args, seeded windows, request
+// body shape, cents units — lives in the description prose, the same way the
+// Papermark curated surface encodes its write-tool bodies.
+interface CuratedEndpoint {
+  binding: { method: string; path: string };
+  // "read" | "write"; validated against riskLabelSchema when overrides load.
+  risk: string;
+  description: string;
+}
+
+// Shared fixture framing prepended to every curated Umami description so the
+// seeded sites/windows guidance survives without a handler-level knob.
+const umamiFixtureNote =
+  "Deterministic Umami corpus fixture: seeded sites Demo Blog (blog.example.com) and "
+  + "Demo SaaS (app.example.com). Call list_umami_websites first to map a requested site "
+  + "name or domain to its websiteId, fetch data before answering, and quote the exact "
+  + "labels and numeric values from the tool results.";
+
+const umamiCuratedTools: readonly CuratedEndpoint[] = [
+  {
+    binding: { method: "GET", path: "/api/me/websites" },
+    risk: "read",
+    description:
+      "List Umami websites visible to the logged-in user, including the seeded Demo Blog "
+      + "(blog.example.com) and Demo SaaS (app.example.com) ids and domains. Always call this "
+      + "first to resolve a requested site name or domain to its websiteId.",
+  },
+  {
+    binding: { method: "GET", path: "/api/websites/{websiteId}/metrics" },
+    risk: "read",
+    description:
+      "Get ranked Umami metrics for one website. Pass query args websiteId, type, startAt, endAt. "
+      + "Use type=path for top pages, type=event for custom events such as "
+      + "signup_started/signup_completed, type=referrer for acquisition sources, and "
+      + "type=title/hostname where relevant. Use UTC with the seeded windows: last 7 days "
+      + "startAt=1782691200000 endAt=1783382399000; last 30 days startAt=1780704000000 "
+      + "endAt=1783382399000. Optional unit (day/hour/month), timezone (default UTC), and limit "
+      + "(default 10).",
+  },
+  {
+    binding: { method: "GET", path: "/api/websites/{websiteId}/pageviews" },
+    risk: "read",
+    description:
+      "Get the Umami pageview and session time series for one website over a date range. Pass "
+      + "query args websiteId, startAt, endAt. Use UTC with the seeded windows: last 7 days "
+      + "startAt=1782691200000 endAt=1783382399000; last 30 days startAt=1780704000000 "
+      + "endAt=1783382399000. Optional unit (day/hour/month) and timezone (default UTC).",
+  },
+  {
+    binding: { method: "POST", path: "/api/reports/revenue" },
+    risk: "read",
+    description:
+      "Get seeded Umami revenue totals and breakdowns for one website; use it for Demo SaaS "
+      + "purchase-revenue questions. Send the request body "
+      + '{ websiteId, filters: {}, type: "revenue", parameters: { startDate, endDate, '
+      + 'currency: "USD", timezone: "UTC" } } using the seeded this-month window (UTC) '
+      + "startDate=2026-07-01T00:00:00.000Z endDate=2026-07-06T23:59:59.000Z. Revenue amounts are "
+      + "returned in integer cents — divide by 100 for dollar figures.",
+  },
+  {
+    binding: { method: "POST", path: "/api/reports/funnel" },
+    risk: "read",
+    description:
+      "Get an Umami funnel report for path or event steps; use it for signup_started to "
+      + "signup_completed conversion questions. Send the request body "
+      + '{ websiteId, filters: {}, type: "funnel", parameters: { startDate, endDate, window: 30, '
+      + 'steps: [{ type: "event", value: "signup_started" }, { type: "event", value: '
+      + '"signup_completed" }] } } using the seeded this-month window (UTC) '
+      + "startDate=2026-07-01T00:00:00.000Z endDate=2026-07-06T23:59:59.000Z.",
+  },
+];
 
 // Shared fixture framing prepended to every curated Papermark description so
 // the guidance survives without the old handler-level instructionsExtra knob
@@ -728,15 +660,20 @@ export async function prepareE2eRepo(
 
   const actions: string[] = [];
 
-  // The curated manifest is the server-side tool source: the composed umbrella
-  // loads .vendo/tools.json through createActions (04 §1). Fixture guidance
-  // (seeded windows, call-first ordering) lives in the tool descriptions — the
-  // old handler-level instructionsExtra knob no longer exists.
-  await writeFile(
-    path.join(appRoot, ".vendo/tools.json"),
-    `${JSON.stringify(umamiTools, null, 2)}\n`,
-  );
-  actions.push("wrote Umami Layer 3 read-only tools manifest");
+  // Umami's init-installed dev/build hooks run `vendo sync` (`predev`,
+  // `prebuild --strict`), which re-extracts and diffs against .vendo/tools.json.
+  // A curated manifest written INTO tools.json is therefore clobbered on the
+  // next boot back to the ~147 generic host_* route-scan tools. So the pin
+  // stays exactly what init extracted, and the curation ships through
+  // .vendo/overrides.json — the human channel both sync (symmetric merge, no
+  // diff) and the runtime registry (description/risk/disabled) respect.
+  await writeCuratedOverrides({
+    appRoot,
+    curatedTools: umamiCuratedTools,
+    fixtureNote: umamiFixtureNote,
+    repoLabel: "Umami",
+  });
+  actions.push("kept .vendo/tools.json pinned to init's extraction; wrote curated overrides.json (descriptions/risk for the 5 fixture endpoints, everything else disabled)");
 
   // Credential forwarding to route bindings requires a TRUSTED operator-set
   // base URL (04 §4); a learned origin never receives the caller's headers.
@@ -901,22 +838,36 @@ async function writePapermarkApiSupportShims(appRoot: string): Promise<void> {
   await ensureFile(path.join(appRoot, "lib/api/errors.ts"), papermarkApiErrorShim);
 }
 
-/**
- * The curated Papermark manifest expressed through the overrides channel:
- * `.vendo/tools.json` stays pinned to init's extraction (so the fixture's
- * `vendo sync --strict` prebuild is a no-op diff), and each curated endpoint's
- * description + risk are keyed to the EXTRACTION name for that binding. Every
- * other extracted tool is disabled so the agent works the same 9-tool surface
- * the conversations were written against. Fails loudly when extraction stops
- * covering a curated endpoint — that is a real re-pin moment, not a skip.
- */
 async function writePapermarkOverrides(appRoot: string): Promise<void> {
-  const toolsPath = path.join(appRoot, ".vendo/tools.json");
+  await writeCuratedOverrides({
+    appRoot,
+    curatedTools: papermarkTools.tools,
+    fixtureNote: papermarkFixtureNote,
+    repoLabel: "Papermark",
+  });
+}
+
+/**
+ * A curated deep-tier surface expressed through the overrides channel:
+ * `.vendo/tools.json` stays pinned to init's extraction (so the fixture's
+ * `vendo sync`/`--strict` hooks are a no-op diff), and each curated endpoint's
+ * description + risk are keyed to the EXTRACTION name for that binding. Every
+ * other extracted tool is disabled so the agent works only the curated surface
+ * the fixture was written against. Fails loudly when extraction stops covering
+ * a curated endpoint — that is a real re-pin moment, not a skip.
+ */
+async function writeCuratedOverrides(options: {
+  appRoot: string;
+  curatedTools: readonly CuratedEndpoint[];
+  fixtureNote: string;
+  repoLabel: string;
+}): Promise<void> {
+  const toolsPath = path.join(options.appRoot, ".vendo/tools.json");
   let parsed: unknown;
   try {
     parsed = JSON.parse(await readFile(toolsPath, "utf8"));
   } catch {
-    throw new Error("Papermark e2e prep expected vendo init to write .vendo/tools.json before prep runs");
+    throw new Error(`${options.repoLabel} e2e prep expected vendo init to write .vendo/tools.json before prep runs`);
   }
   const extracted = isRecord(parsed) && Array.isArray(parsed.tools) ? parsed.tools : [];
   // Param NAMES differ between the curated bindings ({documentId}) and
@@ -936,16 +887,16 @@ async function writePapermarkOverrides(appRoot: string): Promise<void> {
 
   const overrides: Record<string, { risk?: string; description?: string; disabled?: boolean }> = {};
   const curatedNames = new Set<string>();
-  for (const curated of papermarkTools.tools) {
+  for (const curated of options.curatedTools) {
     const endpoint = `${curated.binding.method} ${curated.binding.path}`;
     const extractedName = nameByBinding.get(endpointKey(curated.binding.method, curated.binding.path));
     if (extractedName === undefined) {
-      throw new Error(`Papermark e2e prep: extraction has no tool for curated endpoint ${endpoint}; re-pin the curated manifest against current extraction output`);
+      throw new Error(`${options.repoLabel} e2e prep: extraction has no tool for curated endpoint ${endpoint}; re-pin the curated manifest against current extraction output`);
     }
     curatedNames.add(extractedName);
     overrides[extractedName] = {
       risk: curated.risk,
-      description: `${papermarkFixtureNote} ${curated.description}`,
+      description: `${options.fixtureNote} ${curated.description}`,
     };
   }
   for (const name of extractedNames) {
@@ -953,7 +904,7 @@ async function writePapermarkOverrides(appRoot: string): Promise<void> {
   }
 
   await writeFile(
-    path.join(appRoot, ".vendo/overrides.json"),
+    path.join(options.appRoot, ".vendo/overrides.json"),
     `${JSON.stringify({ format: "vendo/overrides@1", tools: overrides }, null, 2)}\n`,
   );
 }


### PR DESCRIPTION
## What

Umami's init-installed dev/build hooks run `vendo sync` (`predev`, `prebuild --strict`), which re-extracts route tools and diffs against `.vendo/tools.json`. The umami e2e-prep wrote a curated 5-tool facade *into* tools.json, so the next boot's sync clobbered it back to the ~147 generic `host_*` route-scan tools — with no seeded-window/enum guidance, generation tool calls 400 and the umami gallery never settles.

## Fix

Mirror the Papermark PR #271 overrides pattern:
- Keep `.vendo/tools.json` pinned to init's extraction (sync is a no-op diff).
- Ship the curated 5-endpoint surface through `.vendo/overrides.json` — descriptions + risk keyed to the *extraction* names (matched by method+normalized path), everything else `disabled`.
- Seeded date windows and POST body shapes move into the descriptions, since overrides carry no schema (the registry only honors description/risk/disabled).
- Factor the shared matcher out of papermark into `writeCuratedOverrides`; both fixtures use it.
- Point the L3 umami conversations at the extracted tool names the agent now sees.

## Verify

- `corpus/harness` unit tests + typecheck green; full monorepo build/test/typecheck/lint green locally.
- Live umami gallery capture: see the ENG-243 wave-5 gallery refresh.

ENG-243
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converted Umami Layer 3 curation to the overrides channel so `vendo sync` no longer clobbers the curated surface; updated assertions to extracted `host_*` tool names and generalized the fixture guidance for ENG-243.

- **Bug Fixes**
  - Keep `.vendo/tools.json` pinned to init’s extraction; ship the 5 curated endpoints via `.vendo/overrides.json` with descriptions/risk keyed by method+path, and disable all others.
  - Move seeded date windows and POST body shapes into descriptions; update the fixture note to say “call the websites-list tool first” (no stale tool names).
  - Update `corpus/expectations/umami/conversations.json` to assert on `host_websites_metrics_list`, `host_reports_revenue_create`, etc.
  - Factor a shared `writeCuratedOverrides` helper (reused from Papermark); tests assert pinned tools and curated overrides.

<sup>Written for commit 018714581c82e79d2c249f71e521a18792fd8cc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

