### PR TITLE
fix(corpus): detect allowBuilds + pnpm-field build curation before forcing dangerouslyAllowAllBuilds (ENG-334)

### DIFF
--- a/corpus/harness/src/inject.test.ts
+++ b/corpus/harness/src/inject.test.ts
@@ -279,6 +279,72 @@ describe("createLocalVendoInjector", () => {
     await expect(readFile(path.join(repoDir, "pnpm-lock.yaml"), "utf8")).resolves.toContain("file:vendor/vendoai-vendo-0.3.0.tgz");
   });
 
+  for (const curation of [
+    {
+      name: "onlyBuiltDependencies in pnpm-workspace.yaml",
+      async write(repoDir: string) {
+        await writeFile(
+          path.join(repoDir, "pnpm-workspace.yaml"),
+          "packages:\n  - '.'\nonlyBuiltDependencies:\n  - prisma\n",
+        );
+      },
+    },
+    {
+      name: "allowBuilds in pnpm-workspace.yaml",
+      async write(repoDir: string) {
+        await writeFile(
+          path.join(repoDir, "pnpm-workspace.yaml"),
+          "packages:\n  - '.'\nallowBuilds:\n  '@prisma/engines': true\n  esbuild: false\n",
+        );
+      },
+    },
+    {
+      name: "pnpm.onlyBuiltDependencies in package.json",
+      async write(repoDir: string) {
+        const pkg = await readAnyPackageJson(repoDir);
+        await writeJson(path.join(repoDir, "package.json"), {
+          ...pkg,
+          pnpm: { ...(pkg.pnpm as Record<string, unknown> | undefined), onlyBuiltDependencies: ["prisma"] },
+        });
+      },
+    },
+  ]) {
+    it(`skips dangerouslyAllowAllBuilds when the repo curates builds via ${curation.name}`, async () => {
+      const workspaceRoot = await createWorkspace();
+      const corpusRoot = await makeTempRoot();
+      const repoDir = await createTargetRepo(corpusRoot, "repo-curated-builds");
+      await curation.write(repoDir);
+      const pack: PackWorkspacePackage = async (pkg, opts) => {
+        await mkdir(opts.vendorDir, { recursive: true });
+        await writeFile(path.join(opts.vendorDir, opts.fileName), `packed ${pkg.name}`);
+      };
+      const installCalls: string[] = [];
+      const injector = createLocalVendoInjector({
+        context: createRunContext({ corpusRoot }),
+        workspaceRoot,
+        pack,
+        log() {},
+        async buildWorkspace() {},
+        async runInstallCommand(command, cwd) {
+          installCalls.push(`${command} @ ${cwd}`);
+          await writeFile(path.join(cwd, "pnpm-lock.yaml"), [
+            "dependencies:",
+            "  '@vendoai/vendo':",
+            "    specifier: file:vendor/vendoai-vendo-0.3.0.tgz",
+            "    version: file:vendor/vendoai-vendo-0.3.0.tgz",
+            "",
+          ].join("\n"));
+        },
+      });
+
+      await injector.inject({ name: "repo-curated-builds" });
+
+      expect(installCalls).toEqual([
+        `pnpm --config.minimumReleaseAge=0 install --no-frozen-lockfile @ ${repoDir}`,
+      ]);
+    });
+  }
+
   it("targets appDir package.json when injecting into monorepo apps", async () => {
     const workspaceRoot = await createWorkspace();
     const corpusRoot = await makeTempRoot();

--- a/corpus/harness/src/inject.ts
+++ b/corpus/harness/src/inject.ts
@@ -163,11 +163,23 @@ async function findPnpmWorkspaceRoot(checkoutDir: string, targetDir: string): Pr
 }
 
 /** pnpm ≥10 errors on dangerouslyAllowAllBuilds when the workspace already
- * declares a curated build allowlist — detect that curation. */
+ * declares a curated build allowlist — detect that curation, whether it lives
+ * in pnpm-workspace.yaml (onlyBuiltDependencies/neverBuiltDependencies, or the
+ * newer allowBuilds map umami uses) or in the package.json `pnpm` field
+ * (ENG-334). */
 async function pnpmDeclaresBuiltDependencies(installDir: string): Promise<boolean> {
+  const curationKeys = ["onlyBuiltDependencies", "neverBuiltDependencies", "allowBuilds"];
   try {
     const source = await readFile(path.join(installDir, "pnpm-workspace.yaml"), "utf8");
-    return /^\s*(onlyBuiltDependencies|neverBuiltDependencies)\s*:/m.test(source);
+    if (new RegExp(`^\\s*(${curationKeys.join("|")})\\s*:`, "m").test(source)) return true;
+  } catch {
+    // No workspace manifest — fall through to package.json.
+  }
+  try {
+    const pkg = JSON.parse(await readFile(path.join(installDir, "package.json"), "utf8")) as {
+      pnpm?: Record<string, unknown>;
+    };
+    return curationKeys.some((key) => pkg.pnpm?.[key] !== undefined);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
- pnpm >=10 hard-errors (`ERR_PNPM_CONFIG_CONFLICT_BUILT_DEPENDENCIES`) when the corpus injector's `--config.dangerouslyAllowAllBuilds=true` meets a target repo that curates its own build allowlist (Linear ENG-334, found injecting into the umami fork in ENG-268).
- The skip that landed with #229 only matched `onlyBuiltDependencies`/`neverBuiltDependencies` in `pnpm-workspace.yaml`. Current umami declares its curation via the newer `allowBuilds:` map, which the regex missed; curation can also live in the `package.json` `pnpm` field.
- `pnpmDeclaresBuiltDependencies` now detects all three shapes and the injector respects the repo's own policy instead of forcing the global flag.

## Verification
- Empirical repro with pnpm 10.33.4: a repo with `allowBuilds:` in pnpm-workspace.yaml fails `pnpm --config.dangerouslyAllowAllBuilds=true install` with `ERR_PNPM_CONFIG_CONFLICT_BUILT_DEPENDENCIES` and succeeds without the flag.
- New unit tests cover all three curation shapes (the skip path previously had zero test coverage); the two new shapes fail against the old detection and pass with this change.
- Full gate green locally: `pnpm build && pnpm test && pnpm typecheck && pnpm lint` (exit 0).

Corpus-harness-only change; no publishable package touched, so no changeset (precedent #226).

Linear: ENG-334
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect when a repo already curates build scripts and skip `--config.dangerouslyAllowAllBuilds` to avoid `pnpm >=10` conflicts (ENG-334). Adds support for `allowBuilds` and `package.json` `pnpm`-field curation in addition to `onlyBuiltDependencies`/`neverBuiltDependencies`.

- **Bug Fixes**
  - Detect `allowBuilds`, `onlyBuiltDependencies`, and `neverBuiltDependencies` in `pnpm-workspace.yaml`, and the same keys under the `package.json` `pnpm` field.
  - Omit the global flag when curation exists to prevent `ERR_PNPM_CONFIG_CONFLICT_BUILT_DEPENDENCIES`; unit tests cover all cases.

<sup>Written for commit 3f70272e63c7c2f604953cf953e9504efe302c62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

