### PR TITLE
spike(install-dx): CLI-session riders as dev-mode providers — decision record (ENG-337)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,7 +112,7 @@ importers:
         version: 9.39.5(jiti@2.7.0)
       eslint-config-next:
         specifier: 16.2.9
-        version: 16.2.9(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+        version: 16.2.9(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)
@@ -233,7 +233,7 @@ importers:
         version: 9.39.5(jiti@2.7.0)
       eslint-config-next:
         specifier: 16.2.9
-        version: 16.2.9(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+        version: 16.2.9(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)
@@ -276,7 +276,7 @@ importers:
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: 3.0.12
-        version: 3.0.12(zod@4.4.3)
+        version: 3.0.12(zod@3.25.76)
       '@playwright/test':
         specifier: ^1.48.0
         version: 1.61.1
@@ -291,7 +291,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       ai:
         specifier: 6.0.28
-        version: 6.0.28(zod@4.4.3)
+        version: 6.0.28(zod@3.25.76)
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)
@@ -340,7 +340,7 @@ importers:
     dependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.12
-        version: 3.0.12(zod@4.4.3)
+        version: 3.0.12(zod@3.25.76)
       '@vendoai/ui':
         specifier: workspace:*
         version: link:../../../packages/ui
@@ -349,7 +349,7 @@ importers:
         version: link:../../../packages/vendo
       ai:
         specifier: ^6.0.28
-        version: 6.0.28(zod@4.4.3)
+        version: 6.0.28(zod@3.25.76)
       express:
         specifier: ^5.0.0
         version: 5.2.1
@@ -417,13 +417,13 @@ importers:
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.12
-        version: 3.0.12(zod@4.4.3)
+        version: 3.0.12(zod@3.25.76)
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.0
       ai:
         specifier: ^6.0.0
-        version: 6.0.28(zod@4.4.3)
+        version: 6.0.28(zod@3.25.76)
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -451,7 +451,7 @@ importers:
         version: 22.20.0
       ai:
         specifier: ^6.0.0
-        version: 6.0.28(zod@4.4.3)
+        version: 6.0.28(zod@3.25.76)
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -504,13 +504,13 @@ importers:
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@4.4.3)
+        version: 1.29.0(zod@3.25.76)
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.0
       ai:
         specifier: ^6.0.0
-        version: 6.0.28(zod@4.4.3)
+        version: 6.0.28(zod@3.25.76)
       fflate:
         specifier: ^0.8.2
         version: 0.8.3
@@ -525,10 +525,10 @@ importers:
     dependencies:
       '@modelcontextprotocol/ext-apps':
         specifier: ^1.7.4
-        version: 1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@3.25.76)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@4.4.3)
+        version: 1.29.0(zod@3.25.76)
       '@vendoai/actions':
         specifier: workspace:*
         version: link:../../packages/actions
@@ -565,7 +565,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       ai:
         specifier: ^6.0.0
-        version: 6.0.28(zod@4.4.3)
+        version: 6.0.28(zod@3.25.76)
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -599,7 +599,7 @@ importers:
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@4.4.3)
+        version: 1.29.0(zod@3.25.76)
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.0
@@ -620,7 +620,7 @@ importers:
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.12
-        version: 3.0.12(zod@4.4.3)
+        version: 3.0.12(zod@3.25.76)
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.0
@@ -653,7 +653,7 @@ importers:
         version: link:../../packages/vendo
       ai:
         specifier: ^6.0.0
-        version: 6.0.28(zod@4.4.3)
+        version: 6.0.28(zod@3.25.76)
       fflate:
         specifier: ^0.8.2
         version: 0.8.3
@@ -709,19 +709,19 @@ importers:
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: 3.0.12
-        version: 3.0.12(zod@4.4.3)
+        version: 3.0.12(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: 3.0.9
-        version: 3.0.9(zod@4.4.3)
+        version: 3.0.9(zod@3.25.76)
       '@ai-sdk/openai-compatible':
         specifier: 2.0.9
-        version: 2.0.9(zod@4.4.3)
+        version: 2.0.9(zod@3.25.76)
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.0
       ai:
         specifier: 6.0.28
-        version: 6.0.28(zod@4.4.3)
+        version: 6.0.28(zod@3.25.76)
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -892,7 +892,7 @@ importers:
     dependencies:
       '@ai-sdk/react':
         specifier: ^3.0.30
-        version: 3.0.226(react@19.2.7)(zod@4.4.3)
+        version: 3.0.226(react@19.2.7)(zod@3.25.76)
       '@vendoai/core':
         specifier: workspace:*
         version: link:../core
@@ -917,7 +917,7 @@ importers:
         version: 4.12.1(playwright-core@1.61.1)
       '@modelcontextprotocol/ext-apps':
         specifier: ^1.7.4
-        version: 1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@3.25.76)
       '@playwright/test':
         specifier: ^1.49.0
         version: 1.61.1
@@ -935,7 +935,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       ai:
         specifier: ^6.0.28
-        version: 6.0.224(zod@4.4.3)
+        version: 6.0.224(zod@3.25.76)
       jsdom:
         specifier: ^25.0.0
         version: 25.0.1
@@ -1072,25 +1072,6 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)
 
-  spikes/install-dx-creds:
-    dependencies:
-      '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.3.0
-        version: 0.3.211(@anthropic-ai/sdk@0.111.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
-      zod:
-        specifier: ^4.0.0
-        version: 4.4.3
-    devDependencies:
-      '@types/node':
-        specifier: ^22.0.0
-        version: 22.20.0
-      typescript:
-        specifier: ^5.6.0
-        version: 5.9.3
-      vitest:
-        specifier: ^2.1.0
-        version: 2.1.9(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)
-
 packages:
 
   '@ai-sdk/anthropic@3.0.12':
@@ -1162,54 +1143,6 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
-
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.211':
-    resolution: {integrity: sha512-Iwhm4kfcs20LdXffZ2RGRjj+BFdUOrT/JjhGtICjlGlBPlrLkkkAiHtGzqO9K36v5B/kSIHwOw9CM836kYYPHQ==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.211':
-    resolution: {integrity: sha512-sMBW1CLe2Hq4PwwvEbz9r8LxF84UErgB45TSf+iEa8M/EjYZCsXSoTRT0vKnN4TvrAN5mWoKgi39dkUxS9ybsA==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.211':
-    resolution: {integrity: sha512-X1eg+lCwNH2VXyqLQR722dsDDtWPfUnz7OtnmPVoNMxcMexDlSLMMuvm5fNNi94kYT0pxmBdhIvudew145JuHg==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.211':
-    resolution: {integrity: sha512-orZm8p+BzVRZ7I8c5yD43hEZ5TvBZ+UbKTZTlvID00Y8HSn3M3rNX3sW4RUvNGF2e0eNMaXKysPyEHPEj3kqpg==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.211':
-    resolution: {integrity: sha512-cR12YFMVGSj38074OYkkjgwhYeblgVRK3Uw7ZXw3ZTOevjQLASPajVruFuDRW07ixxTa1ZWxqI3kSsIl71RXYA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.211':
-    resolution: {integrity: sha512-ohDS5EGKQvKiUUMtDNPjyWUDvaeIa+DlzUVjrZ8Y4hPtoWFpvOBtOFIYChJGpllwZ4YULS4H3gywVnLGB4do6Q==}
-    cpu: [x64]
-    os: [linux]
-
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.211':
-    resolution: {integrity: sha512-AOIQRFO0YMDUCrG8W0NUWitBQQUB6fYdNW3SMcPPq3mXpYC/pCNURFyvRdrFm729xXkxDAP5OMLk9x2/IFrTmA==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.211':
-    resolution: {integrity: sha512-pwzNuJg2xRBsv3kSSVVhgLdGAFxd5DqPkQX5ZLrT4uBZDJ+QM4xWKZyN8ZoFLLzNl+u0/4U83Q1ZQ0NdG/9JsQ==}
-    cpu: [x64]
-    os: [win32]
-
-  '@anthropic-ai/claude-agent-sdk@0.3.211':
-    resolution: {integrity: sha512-JhbLu6o1v2g9fjqkO+LDNPWrE0bgd9UeRQQ41JBGouAgows3KyPPYgU2WU0q7M2onuwQxR5plGDpas01F+oaUA==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      '@anthropic-ai/sdk': '>=0.93.0'
-      '@modelcontextprotocol/sdk': ^1.29.0
-      zod: ^4.0.0
 
   '@anthropic-ai/sdk@0.111.0':
     resolution: {integrity: sha512-1hUqKi+uJQoS5X90+InwHbFAXMvgq0DnsC5hVLEeSRaODiU5WvmqDAcVCmGS2wC0pN9Z8jtWCbWw7JLzeDdm/Q==}
@@ -6575,9 +6508,6 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
-
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -6589,12 +6519,6 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.5(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/anthropic@3.0.12(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.2
-      '@ai-sdk/provider-utils': 4.0.5(zod@4.4.3)
-      zod: 4.4.3
-
   '@ai-sdk/gateway@3.0.11(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.2
@@ -6602,38 +6526,31 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 3.25.76
 
-  '@ai-sdk/gateway@3.0.11(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.2
-      '@ai-sdk/provider-utils': 4.0.4(zod@4.4.3)
-      '@vercel/oidc': 3.1.0
-      zod: 4.4.3
-
-  '@ai-sdk/gateway@3.0.148(zod@4.4.3)':
+  '@ai-sdk/gateway@3.0.148(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 4.0.38(zod@4.4.3)
+      '@ai-sdk/provider-utils': 4.0.38(zod@3.25.76)
       '@vercel/oidc': 3.2.0
-      zod: 4.4.3
+      zod: 3.25.76
 
-  '@ai-sdk/openai-compatible@2.0.9(zod@4.4.3)':
+  '@ai-sdk/openai-compatible@2.0.9(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.2
-      '@ai-sdk/provider-utils': 4.0.5(zod@4.4.3)
-      zod: 4.4.3
+      '@ai-sdk/provider-utils': 4.0.5(zod@3.25.76)
+      zod: 3.25.76
 
-  '@ai-sdk/openai@3.0.9(zod@4.4.3)':
+  '@ai-sdk/openai@3.0.9(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.2
-      '@ai-sdk/provider-utils': 4.0.5(zod@4.4.3)
-      zod: 4.4.3
+      '@ai-sdk/provider-utils': 4.0.5(zod@3.25.76)
+      zod: 3.25.76
 
-  '@ai-sdk/provider-utils@4.0.38(zod@4.4.3)':
+  '@ai-sdk/provider-utils@4.0.38(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.1.0
-      zod: 4.4.3
+      zod: 3.25.76
 
   '@ai-sdk/provider-utils@4.0.4(zod@3.25.76)':
     dependencies:
@@ -6642,26 +6559,12 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 3.25.76
 
-  '@ai-sdk/provider-utils@4.0.4(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.2
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.1.0
-      zod: 4.4.3
-
   '@ai-sdk/provider-utils@4.0.5(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.2
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.1.0
       zod: 3.25.76
-
-  '@ai-sdk/provider-utils@4.0.5(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.2
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.1.0
-      zod: 4.4.3
 
   '@ai-sdk/provider@3.0.14':
     dependencies:
@@ -6671,10 +6574,10 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@3.0.226(react@19.2.7)(zod@4.4.3)':
+  '@ai-sdk/react@3.0.226(react@19.2.7)(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.38(zod@4.4.3)
-      ai: 6.0.224(zod@4.4.3)
+      '@ai-sdk/provider-utils': 4.0.38(zod@3.25.76)
+      ai: 6.0.224(zod@3.25.76)
       react: 19.2.7
       swr: 2.4.2(react@19.2.7)
       throttleit: 2.1.0
@@ -6688,58 +6591,12 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.211':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.211':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.211':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.211':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.211':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.211':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.211':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.211':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk@0.3.211(@anthropic-ai/sdk@0.111.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.111.0(zod@4.4.3)
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-      zod: 4.4.3
-    optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.211
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.211
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.211
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.211
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.211
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.211
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.211
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.211
-
   '@anthropic-ai/sdk@0.111.0(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
     optionalDependencies:
       zod: 3.25.76
-
-  '@anthropic-ai/sdk@0.111.0(zod@4.4.3)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-      standardwebhooks: 1.0.0
-    optionalDependencies:
-      zod: 4.4.3
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -7641,11 +7498,11 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@modelcontextprotocol/ext-apps@1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)':
+  '@modelcontextprotocol/ext-apps@1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@3.25.76)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
       '@standard-schema/spec': 1.1.0
-      zod: 4.4.3
+      zod: 3.25.76
     optionalDependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -7669,28 +7526,6 @@ snapshots:
       raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.29)
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.1.0
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.29
-      jose: 6.2.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -8774,13 +8609,13 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@6.0.224(zod@4.4.3):
+  ai@6.0.224(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 3.0.148(zod@4.4.3)
+      '@ai-sdk/gateway': 3.0.148(zod@3.25.76)
       '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 4.0.38(zod@4.4.3)
+      '@ai-sdk/provider-utils': 4.0.38(zod@3.25.76)
       '@opentelemetry/api': 1.9.1
-      zod: 4.4.3
+      zod: 3.25.76
 
   ai@6.0.28(zod@3.25.76):
     dependencies:
@@ -8789,14 +8624,6 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.4(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
-
-  ai@6.0.28(zod@4.4.3):
-    dependencies:
-      '@ai-sdk/gateway': 3.0.11(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.2
-      '@ai-sdk/provider-utils': 4.0.4(zod@4.4.3)
-      '@opentelemetry/api': 1.9.0
-      zod: 4.4.3
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
@@ -12668,16 +12495,10 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  zod-to-json-schema@3.25.2(zod@4.4.3):
-    dependencies:
-      zod: 4.4.3
-
   zod-validation-error@4.0.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
 
   zod@3.25.76: {}
-
-  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,7 +112,7 @@ importers:
         version: 9.39.5(jiti@2.7.0)
       eslint-config-next:
         specifier: 16.2.9
-        version: 16.2.9(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+        version: 16.2.9(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)
@@ -233,7 +233,7 @@ importers:
         version: 9.39.5(jiti@2.7.0)
       eslint-config-next:
         specifier: 16.2.9
-        version: 16.2.9(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+        version: 16.2.9(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)
@@ -276,7 +276,7 @@ importers:
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: 3.0.12
-        version: 3.0.12(zod@3.25.76)
+        version: 3.0.12(zod@4.4.3)
       '@playwright/test':
         specifier: ^1.48.0
         version: 1.61.1
@@ -291,7 +291,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       ai:
         specifier: 6.0.28
-        version: 6.0.28(zod@3.25.76)
+        version: 6.0.28(zod@4.4.3)
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)
@@ -340,7 +340,7 @@ importers:
     dependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.12
-        version: 3.0.12(zod@3.25.76)
+        version: 3.0.12(zod@4.4.3)
       '@vendoai/ui':
         specifier: workspace:*
         version: link:../../../packages/ui
@@ -349,7 +349,7 @@ importers:
         version: link:../../../packages/vendo
       ai:
         specifier: ^6.0.28
-        version: 6.0.28(zod@3.25.76)
+        version: 6.0.28(zod@4.4.3)
       express:
         specifier: ^5.0.0
         version: 5.2.1
@@ -417,13 +417,13 @@ importers:
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.12
-        version: 3.0.12(zod@3.25.76)
+        version: 3.0.12(zod@4.4.3)
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.0
       ai:
         specifier: ^6.0.0
-        version: 6.0.28(zod@3.25.76)
+        version: 6.0.28(zod@4.4.3)
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -451,7 +451,7 @@ importers:
         version: 22.20.0
       ai:
         specifier: ^6.0.0
-        version: 6.0.28(zod@3.25.76)
+        version: 6.0.28(zod@4.4.3)
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -504,13 +504,13 @@ importers:
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@3.25.76)
+        version: 1.29.0(zod@4.4.3)
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.0
       ai:
         specifier: ^6.0.0
-        version: 6.0.28(zod@3.25.76)
+        version: 6.0.28(zod@4.4.3)
       fflate:
         specifier: ^0.8.2
         version: 0.8.3
@@ -525,10 +525,10 @@ importers:
     dependencies:
       '@modelcontextprotocol/ext-apps':
         specifier: ^1.7.4
-        version: 1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@3.25.76)
+        version: 1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@3.25.76)
+        version: 1.29.0(zod@4.4.3)
       '@vendoai/actions':
         specifier: workspace:*
         version: link:../../packages/actions
@@ -565,7 +565,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       ai:
         specifier: ^6.0.0
-        version: 6.0.28(zod@3.25.76)
+        version: 6.0.28(zod@4.4.3)
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -599,7 +599,7 @@ importers:
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@3.25.76)
+        version: 1.29.0(zod@4.4.3)
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.0
@@ -620,7 +620,7 @@ importers:
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.12
-        version: 3.0.12(zod@3.25.76)
+        version: 3.0.12(zod@4.4.3)
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.0
@@ -653,7 +653,7 @@ importers:
         version: link:../../packages/vendo
       ai:
         specifier: ^6.0.0
-        version: 6.0.28(zod@3.25.76)
+        version: 6.0.28(zod@4.4.3)
       fflate:
         specifier: ^0.8.2
         version: 0.8.3
@@ -709,19 +709,19 @@ importers:
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: 3.0.12
-        version: 3.0.12(zod@3.25.76)
+        version: 3.0.12(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: 3.0.9
-        version: 3.0.9(zod@3.25.76)
+        version: 3.0.9(zod@4.4.3)
       '@ai-sdk/openai-compatible':
         specifier: 2.0.9
-        version: 2.0.9(zod@3.25.76)
+        version: 2.0.9(zod@4.4.3)
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.0
       ai:
         specifier: 6.0.28
-        version: 6.0.28(zod@3.25.76)
+        version: 6.0.28(zod@4.4.3)
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -892,7 +892,7 @@ importers:
     dependencies:
       '@ai-sdk/react':
         specifier: ^3.0.30
-        version: 3.0.226(react@19.2.7)(zod@3.25.76)
+        version: 3.0.226(react@19.2.7)(zod@4.4.3)
       '@vendoai/core':
         specifier: workspace:*
         version: link:../core
@@ -917,7 +917,7 @@ importers:
         version: 4.12.1(playwright-core@1.61.1)
       '@modelcontextprotocol/ext-apps':
         specifier: ^1.7.4
-        version: 1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@3.25.76)
+        version: 1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       '@playwright/test':
         specifier: ^1.49.0
         version: 1.61.1
@@ -935,7 +935,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       ai:
         specifier: ^6.0.28
-        version: 6.0.224(zod@3.25.76)
+        version: 6.0.224(zod@4.4.3)
       jsdom:
         specifier: ^25.0.0
         version: 25.0.1
@@ -1072,6 +1072,25 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)
 
+  spikes/install-dx-creds:
+    dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.3.0
+        version: 0.3.211(@anthropic-ai/sdk@0.111.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.0
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)
+
 packages:
 
   '@ai-sdk/anthropic@3.0.12':
@@ -1143,6 +1162,54 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.211':
+    resolution: {integrity: sha512-Iwhm4kfcs20LdXffZ2RGRjj+BFdUOrT/JjhGtICjlGlBPlrLkkkAiHtGzqO9K36v5B/kSIHwOw9CM836kYYPHQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.211':
+    resolution: {integrity: sha512-sMBW1CLe2Hq4PwwvEbz9r8LxF84UErgB45TSf+iEa8M/EjYZCsXSoTRT0vKnN4TvrAN5mWoKgi39dkUxS9ybsA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.211':
+    resolution: {integrity: sha512-X1eg+lCwNH2VXyqLQR722dsDDtWPfUnz7OtnmPVoNMxcMexDlSLMMuvm5fNNi94kYT0pxmBdhIvudew145JuHg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.211':
+    resolution: {integrity: sha512-orZm8p+BzVRZ7I8c5yD43hEZ5TvBZ+UbKTZTlvID00Y8HSn3M3rNX3sW4RUvNGF2e0eNMaXKysPyEHPEj3kqpg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.211':
+    resolution: {integrity: sha512-cR12YFMVGSj38074OYkkjgwhYeblgVRK3Uw7ZXw3ZTOevjQLASPajVruFuDRW07ixxTa1ZWxqI3kSsIl71RXYA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.211':
+    resolution: {integrity: sha512-ohDS5EGKQvKiUUMtDNPjyWUDvaeIa+DlzUVjrZ8Y4hPtoWFpvOBtOFIYChJGpllwZ4YULS4H3gywVnLGB4do6Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.211':
+    resolution: {integrity: sha512-AOIQRFO0YMDUCrG8W0NUWitBQQUB6fYdNW3SMcPPq3mXpYC/pCNURFyvRdrFm729xXkxDAP5OMLk9x2/IFrTmA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.211':
+    resolution: {integrity: sha512-pwzNuJg2xRBsv3kSSVVhgLdGAFxd5DqPkQX5ZLrT4uBZDJ+QM4xWKZyN8ZoFLLzNl+u0/4U83Q1ZQ0NdG/9JsQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.3.211':
+    resolution: {integrity: sha512-JhbLu6o1v2g9fjqkO+LDNPWrE0bgd9UeRQQ41JBGouAgows3KyPPYgU2WU0q7M2onuwQxR5plGDpas01F+oaUA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
+      zod: ^4.0.0
 
   '@anthropic-ai/sdk@0.111.0':
     resolution: {integrity: sha512-1hUqKi+uJQoS5X90+InwHbFAXMvgq0DnsC5hVLEeSRaODiU5WvmqDAcVCmGS2wC0pN9Z8jtWCbWw7JLzeDdm/Q==}
@@ -6508,6 +6575,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -6519,6 +6589,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.5(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/anthropic@3.0.12(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.5(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/gateway@3.0.11(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.2
@@ -6526,31 +6602,38 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 3.25.76
 
-  '@ai-sdk/gateway@3.0.148(zod@3.25.76)':
+  '@ai-sdk/gateway@3.0.11(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.4(zod@4.4.3)
+      '@vercel/oidc': 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/gateway@3.0.148(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 4.0.38(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.38(zod@4.4.3)
       '@vercel/oidc': 3.2.0
-      zod: 3.25.76
+      zod: 4.4.3
 
-  '@ai-sdk/openai-compatible@2.0.9(zod@3.25.76)':
+  '@ai-sdk/openai-compatible@2.0.9(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.2
-      '@ai-sdk/provider-utils': 4.0.5(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 4.0.5(zod@4.4.3)
+      zod: 4.4.3
 
-  '@ai-sdk/openai@3.0.9(zod@3.25.76)':
+  '@ai-sdk/openai@3.0.9(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.2
-      '@ai-sdk/provider-utils': 4.0.5(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 4.0.5(zod@4.4.3)
+      zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.38(zod@3.25.76)':
+  '@ai-sdk/provider-utils@4.0.38(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.1.0
-      zod: 3.25.76
+      zod: 4.4.3
 
   '@ai-sdk/provider-utils@4.0.4(zod@3.25.76)':
     dependencies:
@@ -6559,12 +6642,26 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 3.25.76
 
+  '@ai-sdk/provider-utils@4.0.4(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.2
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
   '@ai-sdk/provider-utils@4.0.5(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.2
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.1.0
       zod: 3.25.76
+
+  '@ai-sdk/provider-utils@4.0.5(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.2
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
 
   '@ai-sdk/provider@3.0.14':
     dependencies:
@@ -6574,10 +6671,10 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@3.0.226(react@19.2.7)(zod@3.25.76)':
+  '@ai-sdk/react@3.0.226(react@19.2.7)(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.38(zod@3.25.76)
-      ai: 6.0.224(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.38(zod@4.4.3)
+      ai: 6.0.224(zod@4.4.3)
       react: 19.2.7
       swr: 2.4.2(react@19.2.7)
       throttleit: 2.1.0
@@ -6591,12 +6688,58 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.211':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.211':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.211':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.211':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.211':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.211':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.211':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.211':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.3.211(@anthropic-ai/sdk@0.111.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.111.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.211
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.211
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.211
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.211
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.211
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.211
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.211
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.211
+
   '@anthropic-ai/sdk@0.111.0(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
     optionalDependencies:
       zod: 3.25.76
+
+  '@anthropic-ai/sdk@0.111.0(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.4.3
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -7498,11 +7641,11 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@modelcontextprotocol/ext-apps@1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@3.25.76)':
+  '@modelcontextprotocol/ext-apps@1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       '@standard-schema/spec': 1.1.0
-      zod: 3.25.76
+      zod: 4.4.3
     optionalDependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -7526,6 +7669,28 @@ snapshots:
       raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.29)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.29
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -8609,13 +8774,13 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@6.0.224(zod@3.25.76):
+  ai@6.0.224(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.148(zod@3.25.76)
+      '@ai-sdk/gateway': 3.0.148(zod@4.4.3)
       '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 4.0.38(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.38(zod@4.4.3)
       '@opentelemetry/api': 1.9.1
-      zod: 3.25.76
+      zod: 4.4.3
 
   ai@6.0.28(zod@3.25.76):
     dependencies:
@@ -8624,6 +8789,14 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.4(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
+
+  ai@6.0.28(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.11(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.4(zod@4.4.3)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.4.3
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
@@ -12495,10 +12668,16 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
   zod-validation-error@4.0.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,8 @@ packages:
   - "apps/*"
   - "bench"
   - "spikes/*"
+  # install-dx-creds is evidence-only and needs zod ^4 (Claude Agent SDK peer);
+  # keeping it in the workspace flips zod peer resolution to 4.x for every
+  # ai-SDK consumer (packages/agent, packages/ui, fixtures, ...). It installs
+  # standalone with its own lockfile instead — see spikes/install-dx-creds/README.md.
+  - "!spikes/install-dx-creds"

--- a/spikes/install-dx-creds/README.md
+++ b/spikes/install-dx-creds/README.md
@@ -1,0 +1,42 @@
+# @vendoai/spike-install-dx-creds
+
+**SPIKE — not shipped.** Install DX wave 2, step 1 (ENG-337): can the machine's
+authed **Claude Code** and **Codex CLI** sessions power Vendo's dev-mode agent
+loop as persistent-process providers — with Vendo's host tools bridged in and
+Vendo's approval semantics intact — at interactive latency?
+
+Verdict, latency table, transcripts and the wave-2 API sketch live in
+**[REPORT.md](./REPORT.md)**. Raw per-trial records: `results/latency.json`.
+
+## What's inside
+
+- `src/vendo-tools.ts` — stand-ins for Vendo host tools (one read-risk, one
+  write-risk) + `ApprovalBroker`, the park-until-human-approves simulator.
+- `src/claude-rider.ts` — persistent Claude Agent SDK session riding the
+  `claude` login: streaming-input `query()`, in-process MCP server
+  (`createSdkMcpServer`), consent routed through `canUseTool`.
+- `src/codex-rider.ts` — persistent `codex app-server` (JSON-RPC over stdio)
+  riding the ChatGPT-plan login: experimental `dynamicTools` on `thread/start`,
+  tool execution via server→client `item/tool/call`, consent = delayed reply.
+- `src/baseline.ts` — direct Anthropic Messages API with an env key (what
+  dev-mode does today when a key exists).
+- `src/run-*.ts` — key/auth-gated measurement scripts (never part of `pnpm test`).
+
+## Run the gates
+
+`pnpm build && pnpm test && pnpm typecheck` — no network, no credentials.
+
+## Reproduce the measurements
+
+Requires: `claude` CLI logged in, `codex` CLI logged in (ChatGPT plan), and —
+for the baseline only — `ANTHROPIC_API_KEY` in the environment.
+
+```sh
+pnpm build
+node dist/run-codex.js       # rides ~/.codex ChatGPT-plan login
+node dist/run-claude.js      # rides the claude CLI login (unsets ANTHROPIC_API_KEY itself)
+set -a; source ../../../.env-with-keys; set +a   # or however you load the key
+node dist/run-baseline.js    # env-key control
+```
+
+Each run appends to `results/latency.json` and prints a summary table.

--- a/spikes/install-dx-creds/README.md
+++ b/spikes/install-dx-creds/README.md
@@ -22,6 +22,18 @@ Verdict, latency table, transcripts and the wave-2 API sketch live in
   dev-mode does today when a key exists).
 - `src/run-*.ts` — key/auth-gated measurement scripts (never part of `pnpm test`).
 
+## Install (standalone, not part of the workspace)
+
+This spike needs **zod ^4** (Claude Agent SDK peer) while the repo is on zod 3;
+as a workspace member it flipped zod peer resolution to 4.x for every ai-SDK
+consumer (packages/agent, packages/ui, fixtures). It is therefore excluded in
+`pnpm-workspace.yaml` and carries its own lockfile:
+
+```sh
+cd spikes/install-dx-creds
+pnpm install --ignore-workspace
+```
+
 ## Run the gates
 
 `pnpm build && pnpm test && pnpm typecheck` — no network, no credentials.

--- a/spikes/install-dx-creds/REPORT.md
+++ b/spikes/install-dx-creds/REPORT.md
@@ -1,0 +1,226 @@
+# Install DX Wave 2 Spike — riding authed CLI sessions as dev-mode providers
+
+**Linear:** ENG-337 · **Date:** 2026-07-15 · **Machine:** Yousef's mac
+(claude CLI 2.1.210 logged in via claude.ai; codex-cli 0.144.4 logged in via
+ChatGPT plan; node v24.2.0)
+
+## RECOMMENDATION: full-tools riding
+
+Both rungs work end-to-end **with Vendo host tools bridged in and approval
+semantics intact**, at interactive latency (~0.2–0.4 s median TTFT overhead vs
+a direct env key on short turns). The tools-free fallback is not needed.
+Wave 2 should build the credential resolver with all four rungs and wire both
+riders as full-tool providers behind one narrow interface (sketch below).
+
+## Approval-semantics verdict: SURVIVE — on both rungs
+
+The key question was whether a destructive tool call can be **parked for user
+approval and later resumed**. Yes, on both:
+
+- **Claude Agent SDK:** the `canUseTool` permission callback is an async
+  function per tool call. We awaited a broker promise for 3 000 ms (simulated
+  human), then returned `{behavior: "allow"}`; the in-process MCP tool then
+  executed and the turn completed with the real result. Denial
+  (`{behavior: "deny", message}`) feeds a refusal back to the model — same
+  shape as Vendo's `pending-approval` → grant/deny flow.
+- **Codex app-server:** dynamic tool calls arrive as a **server→client JSON-RPC
+  request** (`item/tool/call`). The client simply doesn't answer until the
+  human decides; we replied after the 3 000 ms park and the turn resumed.
+  Parking is unbounded by protocol design (request/response, no timeout seen).
+
+Evidence (broker log, codex run — identical shape on the claude run):
+
+```
+approval-parked  apr_1784138778801 @1784138778801
+approval-granted apr_1784138778801 @1784138781803   ← +3002 ms
+tool-executed    vendo_payments_send @1784138781803
+```
+
+and the model's answer after the park, on both rungs, contained the real
+confirmation id produced by the (fake) host API:
+
+```
+claude: "Payment sent — confirmation id is conf_spike_001."
+codex:  "I'll send 1,250 cents to Acme Water Co. … conf_spike_001"
+```
+
+## Latency
+
+Scenarios: `short` = "Reply with exactly: pong" (no tools); `tool-read` = one
+read-risk host-tool round-trip; `tool-approve` = one write-risk call with a
+3 000 ms approval park (park included in totals). 4 trials (2 for approve),
+same machine, same hour. Raw records: `results/latency.json`.
+
+| rung · scenario | trials | TTFT ms (min/med/max) | total ms (min/med/max) |
+|---|---|---|---|
+| env-key claude-opus-4-8 · short | 4 | 1070 / 1619 / 1992 | 1180 / 1731 / 2131 |
+| claude-agent-sdk (claude-opus-4-8[1m]) · short | 4 | 1681 / 1877 / 2122 | 1767 / 1911 / 2239 |
+| claude-agent-sdk · tool-read | 4 | 3231 / 4127 / 8722 | 3277 / 4313 / 8904 |
+| claude-agent-sdk · tool-approve (+3000 park) | 2 | 7242 / 10767 / — | 7434 / 11004 / — |
+| claude-agent-sdk · warmup (spawn + first turn) | 1 | 11531 | 12014 |
+| codex-app-server (gpt-5.6-sol) · short | 4 | 1135 / 1921 / 3689 | 1267 / 2152 / 3825 |
+| codex-app-server · tool-read | 4 | 1418 / 3346 / 4474 | 3986 / 5493 / 7678 |
+| codex-app-server · tool-approve (+3000 park) | 2 | 1449 / 1894 / — | 7160 / 15506 / — |
+| codex-app-server · spawn + thread/start | 1 | — | 1532 |
+
+Readings:
+
+- **Steady-state interactive latency is fine on both riders.** Median short-turn
+  TTFT: baseline 1.6 s → claude rider 1.9 s → codex rider 1.9 s.
+- **First-turn cost differs a lot.** Codex is ready in ~1.5 s. The Claude rider's
+  first turn (process spawn + session init + turn) took ~12 s — the persistent
+  process must be started eagerly (e.g. when the dev server boots), not on the
+  first user message. Model choice untested; a smaller `options.model` likely
+  shrinks this.
+- Tool turns are 2-model-turn round-trips; 3–5 s medians are consistent with the
+  baseline model doing the same loop.
+
+## What worked / failed per rung
+
+### Rung: Claude Agent SDK (`@anthropic-ai/claude-agent-sdk` 0.3.210)
+
+Worked:
+- Rides the CLI login with zero configuration: we `delete
+  process.env.ANTHROPIC_API_KEY` and the SDK used the `claude.ai` subscription
+  auth (verified: no key in env; `system:init` reported model
+  `claude-opus-4-8[1m]`).
+- One persistent session over `query()` streaming-input mode (an
+  `AsyncIterable<SDKUserMessage>` we push turns into); 10+ sequential turns on
+  one live process.
+- In-process MCP server (`createSdkMcpServer` + `tool()` with zod v4 shapes);
+  tools appear as `mcp__vendo__*`.
+- `canUseTool` sees every tool call (MCP tools included), can allow/deny, and
+  can block arbitrarily long — approval parking works.
+- Built-in tools locked out via `disallowedTools` + a deny-all-non-vendo rule in
+  `canUseTool` (defense in depth). `settingSources: []` keeps the host machine's
+  user/project settings and hooks out of the ridden session.
+- `result` messages carry `usage` + `total_cost_usd` per turn (recorded in
+  `results/latency.json`).
+
+Gotchas (cost real time):
+- **Streaming-input mode emits nothing — not even `system:init` — until the
+  first user message is yielded.** Any "wait for init after start" logic
+  deadlocks. Send a warmup turn.
+- SDK 0.3.210 requires **zod ^4** (peer dep); Vendo packages are on zod 3 —
+  keep the provider package's zod isolated from `@vendoai/core`'s.
+- Without `settingSources: []` the ridden session loaded this machine's global
+  hooks (visible as `system:hook_started` messages) — a real product must never
+  inherit the dev's personal Claude Code config.
+
+### Rung: Codex app-server (codex-cli 0.144.4)
+
+Worked:
+- Rides `~/.codex/auth.json` (ChatGPT plan) automatically; no key, no flags.
+- `codex app-server` = newline-delimited JSON-RPC 2.0 over stdio. Handshake:
+  `initialize` (with `capabilities.experimentalApi: true`) → `initialized`
+  notification. Persistent conversation: `thread/start` → many `turn/start`.
+- **First-class dynamic tools — no MCP server needed.** `thread/start` accepts
+  `dynamicTools: [{type:"function", name, description, inputSchema}]`
+  (experimental, gated on `experimentalApi`). Codex executes them by sending
+  the client an `item/tool/call` request; the client's response
+  (`{contentItems:[{type:"inputText",text}], success}`) is the tool result.
+  Delaying that response is the approval park.
+- Turn lifecycle notifications: `item/agentMessage/delta` (TTFT + text),
+  `turn/completed` (status). `sandbox: "read-only"` + `approvalPolicy:
+  "untrusted"` + deny-all on harness approval requests keeps the agent away
+  from shell/filesystem.
+- Protocol shapes were verified against the installed binary via
+  `codex app-server generate-ts --out <dir>` — regenerate on codex upgrades.
+
+Caveats:
+- The whole surface is marked **[experimental]** by upstream; `dynamicTools`
+  is additionally feature-gated. Pin the codex version in wave 2 and add a
+  doctor check (`codex app-server generate-json-schema` diff) for drift.
+- Model was `gpt-5.6-sol` (the plan's default); per-thread `model` override
+  exists in `thread/start`/`turn/start` but was not exercised.
+- No usage/cost fields observed on `turn/completed` in this run (status only).
+
+### Rung: env key (baseline)
+
+Direct `POST /v1/messages` stream with `ANTHROPIC_API_KEY` from the canonical
+key file. Median short-turn TTFT 1.6 s / total 1.7 s. This stays the top rung
+of the ladder — explicit beats implicit.
+
+## Wave-2 API sketch (credential resolver + provider)
+
+```ts
+// packages/vendo/src/dev-creds/resolve.ts
+export type DevCredential =
+  | { rung: "env-key"; provider: "anthropic" | "openai" | "google"; apiKey: string }
+  | { rung: "claude-session" }                    // consent asked by the wizard before use
+  | { rung: "codex-session" }                     // officially sanctioned by OpenAI
+  | { rung: "vendo-cloud"; apiKey: string }       // starter allowance (wave 3)
+  | { rung: "none" };
+
+export async function resolveDevCredential(): Promise<DevCredential>;
+// detection order (spec §2): env keys → `claude auth status` (JSON, loggedIn)
+// → `codex login status` / ~/.codex/auth.json → VENDO_API_KEY → none.
+// Pure read-only detection; consent for session rungs is the wizard's job.
+```
+
+Two consumer shapes, because Vendo has two call sites:
+
+1. **Tool-less generation** (extraction `--deep`, on-brand UI seeding, doctor's
+   one real turn): a plain ai-SDK `LanguageModelV2` whose `doGenerate/doStream`
+   forwards one prompt into the persistent rider session and streams text back.
+   Trivial on both riders (this spike's `short` scenario is exactly that path).
+
+2. **The dev-mode chat loop** (full tools): invert the loop. Today
+   `createVendo` hands `streamText` a model plus ai-SDK tools built by
+   `buildAgentTools` (packages/agent). For rider rungs, wave 2 should add a
+   narrow seam next to the model:
+
+   ```ts
+   interface VendoTurnRunner {
+     startSession(opts: { tools: ToolDescriptor[]; system: string }): Promise<void>;
+     runTurn(input: UserTurn, sink: TurnSink): Promise<TurnResult>;
+     // sink receives text deltas + tool lifecycle events;
+     // tool execution calls back into the SAME guard/registry path
+     // (guard.check → "ask" → pending-approval part → park → registry.execute)
+     dispose(): Promise<void>;
+   }
+   ```
+
+   The rider owns the model loop; Vendo keeps owning **tool execution and
+   consent** — the bridge handler calls `guard.check` + `registry.execute`
+   exactly like `buildAgentTools.execute` does today, so approval UI parts,
+   grants and the abandoned-approval semantics are unchanged. This is what the
+   spike measured (its `ApprovalBroker` stands in for the guard's ask path).
+   A strict `LanguageModelV2` emulation that re-emits harness tool calls as
+   ai-SDK tool-call parts and resumes parked handlers on the next `doStream`
+   is possible but adds cross-call correlation for no user-visible gain — not
+   recommended for wave 2.
+
+Runtime notes for the resolver's rider providers:
+- Spawn the persistent process at dev-server boot (Claude's 12 s first turn).
+- One session per Vendo thread maps cleanly on both riders (Claude: one
+  streaming `query()` per thread; codex: one `threadId` per thread).
+- Production stays key-only; the resolver refuses session rungs when
+  `NODE_ENV === "production"` (spec §2's "honest 503" unchanged).
+
+## Repro
+
+```sh
+cd spikes/install-dx-creds && pnpm build
+node dist/run-codex.js                          # needs codex CLI logged in
+node dist/run-claude.js                         # needs claude CLI logged in
+ANTHROPIC_API_KEY=… node dist/run-baseline.js   # env-key control
+```
+
+Protocol bindings for the installed codex:
+`codex app-server generate-ts --out /tmp/codex-proto` (method names used here:
+`initialize`, `initialized`, `thread/start`, `turn/start`, `item/tool/call`,
+`item/agentMessage/delta`, `turn/completed`).
+
+## Deviations from the spec's assumptions
+
+- The spec's creds-research line said "CLI-wrapped providers cannot execute the
+  host tools bound into Vendo's own agent loop". **That is now false for both
+  vendors**: the Agent SDK executes in-process MCP tools under `canUseTool`,
+  and codex 0.144.x executes client-registered `dynamicTools` over JSON-RPC.
+  The compliant-gateway argument may still apply commercially, but not
+  technically.
+- Codex needed **no MCP bridge at all** — dynamic tools are cleaner than the
+  planned "in-process MCP" wording (MCP config override stays as fallback).
+- ToS posture per Yousef's standing decision: proceeding as-approved on the
+  Anthropic rung; OpenAI rung is officially sanctioned. Not re-litigated here.

--- a/spikes/install-dx-creds/package.json
+++ b/spikes/install-dx-creds/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@vendoai/spike-install-dx-creds",
+  "version": "0.0.0",
+  "private": true,
+  "description": "SPIKE (not shipped): can authed Claude Code / Codex CLI sessions power Vendo's dev-mode agent loop as persistent-process ai-SDK providers? Prototypes + latency/approval-semantics evidence for Install DX wave 2 (ENG-337). Nothing here ships.",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run --passWithNoTests",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "measure:baseline": "node dist/run-baseline.js",
+    "measure:claude": "node dist/run-claude.js",
+    "measure:codex": "node dist/run-codex.js",
+    "measure:all": "node dist/run-all.js"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/spikes/install-dx-creds/pnpm-lock.yaml
+++ b/spikes/install-dx-creds/pnpm-lock.yaml
@@ -1,0 +1,1796 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.3.0
+        version: 0.3.211(@anthropic-ai/sdk@0.111.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.1
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.20.1)
+
+packages:
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.211':
+    resolution: {integrity: sha512-Iwhm4kfcs20LdXffZ2RGRjj+BFdUOrT/JjhGtICjlGlBPlrLkkkAiHtGzqO9K36v5B/kSIHwOw9CM836kYYPHQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.211':
+    resolution: {integrity: sha512-sMBW1CLe2Hq4PwwvEbz9r8LxF84UErgB45TSf+iEa8M/EjYZCsXSoTRT0vKnN4TvrAN5mWoKgi39dkUxS9ybsA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.211':
+    resolution: {integrity: sha512-X1eg+lCwNH2VXyqLQR722dsDDtWPfUnz7OtnmPVoNMxcMexDlSLMMuvm5fNNi94kYT0pxmBdhIvudew145JuHg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.211':
+    resolution: {integrity: sha512-orZm8p+BzVRZ7I8c5yD43hEZ5TvBZ+UbKTZTlvID00Y8HSn3M3rNX3sW4RUvNGF2e0eNMaXKysPyEHPEj3kqpg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.211':
+    resolution: {integrity: sha512-cR12YFMVGSj38074OYkkjgwhYeblgVRK3Uw7ZXw3ZTOevjQLASPajVruFuDRW07ixxTa1ZWxqI3kSsIl71RXYA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.211':
+    resolution: {integrity: sha512-ohDS5EGKQvKiUUMtDNPjyWUDvaeIa+DlzUVjrZ8Y4hPtoWFpvOBtOFIYChJGpllwZ4YULS4H3gywVnLGB4do6Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.211':
+    resolution: {integrity: sha512-AOIQRFO0YMDUCrG8W0NUWitBQQUB6fYdNW3SMcPPq3mXpYC/pCNURFyvRdrFm729xXkxDAP5OMLk9x2/IFrTmA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.211':
+    resolution: {integrity: sha512-pwzNuJg2xRBsv3kSSVVhgLdGAFxd5DqPkQX5ZLrT4uBZDJ+QM4xWKZyN8ZoFLLzNl+u0/4U83Q1ZQ0NdG/9JsQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.3.211':
+    resolution: {integrity: sha512-JhbLu6o1v2g9fjqkO+LDNPWrE0bgd9UeRQQ41JBGouAgows3KyPPYgU2WU0q7M2onuwQxR5plGDpas01F+oaUA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
+      zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.111.0':
+    resolution: {integrity: sha512-1hUqKi+uJQoS5X90+InwHbFAXMvgq0DnsC5hVLEeSRaODiU5WvmqDAcVCmGS2wC0pN9Z8jtWCbWw7JLzeDdm/Q==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.30:
+    resolution: {integrity: sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
+  postcss@8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+snapshots:
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.211':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.211':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.211':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.211':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.211':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.211':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.211':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.211':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.3.211(@anthropic-ai/sdk@0.111.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.111.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.211
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.211
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.211
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.211
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.211
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.211
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.211
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.211
+
+  '@anthropic-ai/sdk@0.111.0(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.4.3
+
+  '@babel/runtime@7.29.7': {}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@hono/node-server@1.19.14(hono@4.12.30)':
+    dependencies:
+      hono: 4.12.30
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.30)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.30
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
+  '@stablelib/base64@1.0.1': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.20.1))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.20.1)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  assertion-error@2.0.1: {}
+
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  bytes@3.1.2: {}
+
+  cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  depd@2.0.0: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  escape-html@1.0.3: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  etag@1.8.1: {}
+
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
+  expect-type@1.4.0: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-sha256@1.3.0: {}
+
+  fast-uri@3.1.3: {}
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.30: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
+
+  is-promise@4.0.0: {}
+
+  isexe@2.0.0: {}
+
+  jose@6.2.3: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.16: {}
+
+  negotiator@1.0.0: {}
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  pkce-challenge@5.0.1: {}
+
+  postcss@8.5.19:
+    dependencies:
+      nanoid: 3.3.16
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
+
+  require-from-string@2.0.2: {}
+
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  safer-buffer@2.1.2: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
+  statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
+  toidentifier@1.0.1: {}
+
+  ts-algebra@2.0.0: {}
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  unpipe@1.0.0: {}
+
+  vary@1.1.2: {}
+
+  vite-node@2.1.9(@types/node@22.20.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.20.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@22.20.1):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.19
+      rollup: 4.62.2
+    optionalDependencies:
+      '@types/node': 22.20.1
+      fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@22.20.1):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.20.1))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.20.1)
+      vite-node: 2.1.9(@types/node@22.20.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.20.1
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrappy@1.0.2: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}

--- a/spikes/install-dx-creds/results/latency.json
+++ b/spikes/install-dx-creds/results/latency.json
@@ -1,0 +1,758 @@
+[
+  {
+    "rung": "codex-app-server (gpt-5.6-sol)",
+    "scenario": "short",
+    "trial": 1,
+    "ttftMs": 1921.3462499999998,
+    "totalMs": 2152.192959,
+    "model": "gpt-5.6-sol",
+    "usage": {
+      "id": "019f66f4-c2e6-7e93-b58c-d7a232e2fa46",
+      "items": [],
+      "itemsView": "notLoaded",
+      "status": "completed",
+      "error": null,
+      "startedAt": 1784138744,
+      "completedAt": 1784138746,
+      "durationMs": 2143
+    },
+    "answer": "pong",
+    "notes": "tools=[] status=completed"
+  },
+  {
+    "rung": "codex-app-server (gpt-5.6-sol)",
+    "scenario": "short",
+    "trial": 2,
+    "ttftMs": 3688.5267089999998,
+    "totalMs": 3825.0853749999997,
+    "model": "gpt-5.6-sol",
+    "usage": {
+      "id": "019f66f4-cb4d-7b31-9cbf-9452103ded1e",
+      "items": [],
+      "itemsView": "notLoaded",
+      "status": "completed",
+      "error": null,
+      "startedAt": 1784138746,
+      "completedAt": 1784138750,
+      "durationMs": 3821
+    },
+    "answer": "pong",
+    "notes": "tools=[] status=completed"
+  },
+  {
+    "rung": "codex-app-server (gpt-5.6-sol)",
+    "scenario": "short",
+    "trial": 3,
+    "ttftMs": 1157.7793330000004,
+    "totalMs": 1274.715333,
+    "model": "gpt-5.6-sol",
+    "usage": {
+      "id": "019f66f4-da40-7da1-b6be-89a952da2c65",
+      "items": [],
+      "itemsView": "notLoaded",
+      "status": "completed",
+      "error": null,
+      "startedAt": 1784138750,
+      "completedAt": 1784138751,
+      "durationMs": 1259
+    },
+    "answer": "pong",
+    "notes": "tools=[] status=completed"
+  },
+  {
+    "rung": "codex-app-server (gpt-5.6-sol)",
+    "scenario": "short",
+    "trial": 4,
+    "ttftMs": 1135.1343340000003,
+    "totalMs": 1266.7311250000002,
+    "model": "gpt-5.6-sol",
+    "usage": {
+      "id": "019f66f4-df3a-75d1-906d-43929781b074",
+      "items": [],
+      "itemsView": "notLoaded",
+      "status": "completed",
+      "error": null,
+      "startedAt": 1784138751,
+      "completedAt": 1784138753,
+      "durationMs": 1260
+    },
+    "answer": "pong",
+    "notes": "tools=[] status=completed"
+  },
+  {
+    "rung": "codex-app-server (gpt-5.6-sol)",
+    "scenario": "tool-read",
+    "trial": 1,
+    "ttftMs": 1418.4560419999998,
+    "totalMs": 3986.419082999999,
+    "model": "gpt-5.6-sol",
+    "usage": {
+      "id": "019f66f4-e42c-73a1-89f4-ae03f1753d05",
+      "items": [],
+      "itemsView": "notLoaded",
+      "status": "completed",
+      "error": null,
+      "startedAt": 1784138753,
+      "completedAt": 1784138757,
+      "durationMs": 3984
+    },
+    "answer": "I’ll check your recent payments list and count the entries.2",
+    "notes": "tools=[vendo_payments_list] status=completed"
+  },
+  {
+    "rung": "codex-app-server (gpt-5.6-sol)",
+    "scenario": "tool-read",
+    "trial": 2,
+    "ttftMs": 3124.3928749999995,
+    "totalMs": 5477.937875000001,
+    "model": "gpt-5.6-sol",
+    "usage": {
+      "id": "019f66f4-f3bf-79a2-a6c9-4318a25b3e26",
+      "items": [],
+      "itemsView": "notLoaded",
+      "status": "completed",
+      "error": null,
+      "startedAt": 1784138757,
+      "completedAt": 1784138762,
+      "durationMs": 5476
+    },
+    "answer": "I’ll check the recent payments list.2",
+    "notes": "tools=[vendo_payments_list] status=completed"
+  },
+  {
+    "rung": "codex-app-server (gpt-5.6-sol)",
+    "scenario": "tool-read",
+    "trial": 3,
+    "ttftMs": 3345.780208,
+    "totalMs": 5492.995457999998,
+    "model": "gpt-5.6-sol",
+    "usage": {
+      "id": "019f66f5-0925-7b12-8bee-eea0c8beea9c",
+      "items": [],
+      "itemsView": "notLoaded",
+      "status": "completed",
+      "error": null,
+      "startedAt": 1784138762,
+      "completedAt": 1784138768,
+      "durationMs": 5491
+    },
+    "answer": "I’ll check your recent payments.2",
+    "notes": "tools=[vendo_payments_list] status=completed"
+  },
+  {
+    "rung": "codex-app-server (gpt-5.6-sol)",
+    "scenario": "tool-read",
+    "trial": 4,
+    "ttftMs": 4473.974833,
+    "totalMs": 7677.884540999999,
+    "model": "gpt-5.6-sol",
+    "usage": {
+      "id": "019f66f5-1e9a-7592-a45c-c3011af0adbe",
+      "items": [],
+      "itemsView": "notLoaded",
+      "status": "completed",
+      "error": null,
+      "startedAt": 1784138768,
+      "completedAt": 1784138775,
+      "durationMs": 7676
+    },
+    "answer": "I’ll count your recent payments.2",
+    "notes": "tools=[vendo_payments_list] status=completed"
+  },
+  {
+    "rung": "codex-app-server (gpt-5.6-sol)",
+    "scenario": "tool-approve(+3000ms park)",
+    "trial": 1,
+    "ttftMs": 1894.2780420000017,
+    "totalMs": 7159.823958999998,
+    "model": "gpt-5.6-sol",
+    "usage": {
+      "id": "019f66f5-3c98-7ad2-b3a7-567900190f69",
+      "items": [],
+      "itemsView": "notLoaded",
+      "status": "completed",
+      "error": null,
+      "startedAt": 1784138775,
+      "completedAt": 1784138782,
+      "durationMs": 7158
+    },
+    "answer": "I’ll send 1,250 cents to Acme Water Co.conf_spike_001",
+    "notes": "tools=[vendo_payments_send] status=completed"
+  },
+  {
+    "rung": "codex-app-server (gpt-5.6-sol)",
+    "scenario": "tool-approve(+3000ms park)",
+    "trial": 2,
+    "ttftMs": 1449.4749169999996,
+    "totalMs": 15506.411166999998,
+    "model": "gpt-5.6-sol",
+    "usage": {
+      "id": "019f66f5-5890-7c53-b827-ce89ef8e2a41",
+      "items": [],
+      "itemsView": "notLoaded",
+      "status": "completed",
+      "error": null,
+      "startedAt": 1784138782,
+      "completedAt": 1784138798,
+      "durationMs": 15504
+    },
+    "answer": "I’ll send 1,250 cents to Acme Water Co.conf_spike_001",
+    "notes": "tools=[vendo_payments_send] status=completed"
+  },
+  {
+    "rung": "claude-agent-sdk (claude-opus-4-8[1m])",
+    "scenario": "warmup(spawn+turn)",
+    "trial": 1,
+    "ttftMs": 11530.810959,
+    "totalMs": 12013.846667000002,
+    "model": "claude-opus-4-8[1m]",
+    "usage": {
+      "usage": {
+        "input_tokens": 2,
+        "cache_creation_input_tokens": 26091,
+        "cache_read_input_tokens": 0,
+        "output_tokens": 4,
+        "server_tool_use": {
+          "web_search_requests": 0,
+          "web_fetch_requests": 0
+        },
+        "service_tier": "standard",
+        "cache_creation": {
+          "ephemeral_1h_input_tokens": 0,
+          "ephemeral_5m_input_tokens": 26091
+        },
+        "inference_geo": "global",
+        "iterations": [
+          {
+            "input_tokens": 2,
+            "output_tokens": 4,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 26091,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 26091,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "type": "message"
+          }
+        ],
+        "speed": "standard"
+      },
+      "totalCostUsd": 0.16376475,
+      "subtype": "success"
+    },
+    "answer": "ready",
+    "notes": "tools=[]"
+  },
+  {
+    "rung": "claude-agent-sdk (claude-opus-4-8[1m])",
+    "scenario": "short",
+    "trial": 1,
+    "ttftMs": 1680.606208000001,
+    "totalMs": 1766.8631670000013,
+    "model": "claude-opus-4-8[1m]",
+    "usage": {
+      "usage": {
+        "input_tokens": 2,
+        "cache_creation_input_tokens": 16,
+        "cache_read_input_tokens": 26091,
+        "output_tokens": 4,
+        "server_tool_use": {
+          "web_search_requests": 0,
+          "web_fetch_requests": 0
+        },
+        "service_tier": "standard",
+        "cache_creation": {
+          "ephemeral_1h_input_tokens": 0,
+          "ephemeral_5m_input_tokens": 16
+        },
+        "inference_geo": "global",
+        "iterations": [
+          {
+            "input_tokens": 2,
+            "output_tokens": 4,
+            "cache_read_input_tokens": 26091,
+            "cache_creation_input_tokens": 16,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 16,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "type": "message"
+          }
+        ],
+        "speed": "standard"
+      },
+      "totalCostUsd": 0.17702025,
+      "subtype": "success"
+    },
+    "answer": "pong",
+    "notes": "tools=[]"
+  },
+  {
+    "rung": "claude-agent-sdk (claude-opus-4-8[1m])",
+    "scenario": "short",
+    "trial": 2,
+    "ttftMs": 1877.2709999999988,
+    "totalMs": 1910.9999169999992,
+    "model": "claude-opus-4-8[1m]",
+    "usage": {
+      "usage": {
+        "input_tokens": 2,
+        "cache_creation_input_tokens": 16,
+        "cache_read_input_tokens": 26107,
+        "output_tokens": 4,
+        "server_tool_use": {
+          "web_search_requests": 0,
+          "web_fetch_requests": 0
+        },
+        "service_tier": "standard",
+        "cache_creation": {
+          "ephemeral_1h_input_tokens": 0,
+          "ephemeral_5m_input_tokens": 16
+        },
+        "inference_geo": "global",
+        "iterations": [
+          {
+            "input_tokens": 2,
+            "output_tokens": 4,
+            "cache_read_input_tokens": 26107,
+            "cache_creation_input_tokens": 16,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 16,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "type": "message"
+          }
+        ],
+        "speed": "standard"
+      },
+      "totalCostUsd": 0.19028375,
+      "subtype": "success"
+    },
+    "answer": "pong",
+    "notes": "tools=[]"
+  },
+  {
+    "rung": "claude-agent-sdk (claude-opus-4-8[1m])",
+    "scenario": "short",
+    "trial": 3,
+    "ttftMs": 1867.249917000001,
+    "totalMs": 1902.822250000001,
+    "model": "claude-opus-4-8[1m]",
+    "usage": {
+      "usage": {
+        "input_tokens": 2,
+        "cache_creation_input_tokens": 16,
+        "cache_read_input_tokens": 26123,
+        "output_tokens": 4,
+        "server_tool_use": {
+          "web_search_requests": 0,
+          "web_fetch_requests": 0
+        },
+        "service_tier": "standard",
+        "cache_creation": {
+          "ephemeral_1h_input_tokens": 0,
+          "ephemeral_5m_input_tokens": 16
+        },
+        "inference_geo": "global",
+        "iterations": [
+          {
+            "input_tokens": 2,
+            "output_tokens": 4,
+            "cache_read_input_tokens": 26123,
+            "cache_creation_input_tokens": 16,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 16,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "type": "message"
+          }
+        ],
+        "speed": "standard"
+      },
+      "totalCostUsd": 0.20355525,
+      "subtype": "success"
+    },
+    "answer": "pong",
+    "notes": "tools=[]"
+  },
+  {
+    "rung": "claude-agent-sdk (claude-opus-4-8[1m])",
+    "scenario": "short",
+    "trial": 4,
+    "ttftMs": 2122.486541000002,
+    "totalMs": 2239.2229160000024,
+    "model": "claude-opus-4-8[1m]",
+    "usage": {
+      "usage": {
+        "input_tokens": 2,
+        "cache_creation_input_tokens": 16,
+        "cache_read_input_tokens": 26139,
+        "output_tokens": 4,
+        "server_tool_use": {
+          "web_search_requests": 0,
+          "web_fetch_requests": 0
+        },
+        "service_tier": "standard",
+        "cache_creation": {
+          "ephemeral_1h_input_tokens": 0,
+          "ephemeral_5m_input_tokens": 16
+        },
+        "inference_geo": "global",
+        "iterations": [
+          {
+            "input_tokens": 2,
+            "output_tokens": 4,
+            "cache_read_input_tokens": 26139,
+            "cache_creation_input_tokens": 16,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 16,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "type": "message"
+          }
+        ],
+        "speed": "standard"
+      },
+      "totalCostUsd": 0.21683475,
+      "subtype": "success"
+    },
+    "answer": "pong",
+    "notes": "tools=[]"
+  },
+  {
+    "rung": "claude-agent-sdk (claude-opus-4-8[1m])",
+    "scenario": "tool-read",
+    "trial": 1,
+    "ttftMs": 8722.216,
+    "totalMs": 8904.447833000002,
+    "model": "claude-opus-4-8[1m]",
+    "usage": {
+      "usage": {
+        "input_tokens": 6,
+        "cache_creation_input_tokens": 367,
+        "cache_read_input_tokens": 78756,
+        "output_tokens": 151,
+        "server_tool_use": {
+          "web_search_requests": 0,
+          "web_fetch_requests": 0
+        },
+        "service_tier": "standard",
+        "cache_creation": {
+          "ephemeral_1h_input_tokens": 0,
+          "ephemeral_5m_input_tokens": 367
+        },
+        "inference_geo": "global",
+        "iterations": [
+          {
+            "input_tokens": 2,
+            "output_tokens": 12,
+            "cache_read_input_tokens": 26415,
+            "cache_creation_input_tokens": 107,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 107,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "type": "message"
+          }
+        ],
+        "speed": "standard"
+      },
+      "totalCostUsd": 0.2623115,
+      "subtype": "success"
+    },
+    "answer": "You have 2 recent payments.",
+    "notes": "tools=[mcp__vendo__payments_list]"
+  },
+  {
+    "rung": "claude-agent-sdk (claude-opus-4-8[1m])",
+    "scenario": "tool-read",
+    "trial": 2,
+    "ttftMs": 4049.4827090000035,
+    "totalMs": 4313.326375000004,
+    "model": "claude-opus-4-8[1m]",
+    "usage": {
+      "usage": {
+        "input_tokens": 4,
+        "cache_creation_input_tokens": 146,
+        "cache_read_input_tokens": 53083,
+        "output_tokens": 47,
+        "server_tool_use": {
+          "web_search_requests": 0,
+          "web_fetch_requests": 0
+        },
+        "service_tier": "standard",
+        "cache_creation": {
+          "ephemeral_1h_input_tokens": 0,
+          "ephemeral_5m_input_tokens": 146
+        },
+        "inference_geo": "global",
+        "iterations": [
+          {
+            "input_tokens": 2,
+            "output_tokens": 12,
+            "cache_read_input_tokens": 26561,
+            "cache_creation_input_tokens": 107,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 107,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "type": "message"
+          }
+        ],
+        "speed": "standard"
+      },
+      "totalCostUsd": 0.29096049999999996,
+      "subtype": "success"
+    },
+    "answer": "You have 2 recent payments.",
+    "notes": "tools=[mcp__vendo__payments_list]"
+  },
+  {
+    "rung": "claude-agent-sdk (claude-opus-4-8[1m])",
+    "scenario": "tool-read",
+    "trial": 3,
+    "ttftMs": 4126.9355420000065,
+    "totalMs": 4308.148417000004,
+    "model": "claude-opus-4-8[1m]",
+    "usage": {
+      "usage": {
+        "input_tokens": 3,
+        "cache_creation_input_tokens": 275,
+        "cache_read_input_tokens": 53505,
+        "output_tokens": 47,
+        "server_tool_use": {
+          "web_search_requests": 0,
+          "web_fetch_requests": 0
+        },
+        "service_tier": "standard",
+        "cache_creation": {
+          "ephemeral_1h_input_tokens": 0,
+          "ephemeral_5m_input_tokens": 275
+        },
+        "inference_geo": "global",
+        "iterations": [
+          {
+            "input_tokens": 2,
+            "output_tokens": 12,
+            "cache_read_input_tokens": 26837,
+            "cache_creation_input_tokens": 106,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 106,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "type": "message"
+          }
+        ],
+        "speed": "standard"
+      },
+      "totalCostUsd": 0.3206217499999999,
+      "subtype": "success"
+    },
+    "answer": "You have 2 recent payments.",
+    "notes": "tools=[mcp__vendo__payments_list]"
+  },
+  {
+    "rung": "claude-agent-sdk (claude-opus-4-8[1m])",
+    "scenario": "tool-read",
+    "trial": 4,
+    "ttftMs": 3230.791124999996,
+    "totalMs": 3276.929624999997,
+    "model": "claude-opus-4-8[1m]",
+    "usage": {
+      "usage": {
+        "input_tokens": 4,
+        "cache_creation_input_tokens": 146,
+        "cache_read_input_tokens": 53925,
+        "output_tokens": 47,
+        "server_tool_use": {
+          "web_search_requests": 0,
+          "web_fetch_requests": 0
+        },
+        "service_tier": "standard",
+        "cache_creation": {
+          "ephemeral_1h_input_tokens": 0,
+          "ephemeral_5m_input_tokens": 146
+        },
+        "inference_geo": "global",
+        "iterations": [
+          {
+            "input_tokens": 2,
+            "output_tokens": 12,
+            "cache_read_input_tokens": 26982,
+            "cache_creation_input_tokens": 107,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 107,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "type": "message"
+          }
+        ],
+        "speed": "standard"
+      },
+      "totalCostUsd": 0.3496917499999999,
+      "subtype": "success"
+    },
+    "answer": "You have 2 recent payments.",
+    "notes": "tools=[mcp__vendo__payments_list]"
+  },
+  {
+    "rung": "claude-agent-sdk (claude-opus-4-8[1m])",
+    "scenario": "tool-approve(+3000ms park)",
+    "trial": 1,
+    "ttftMs": 10767.145459000007,
+    "totalMs": 11003.607417000007,
+    "model": "claude-opus-4-8[1m]",
+    "usage": {
+      "usage": {
+        "input_tokens": 6,
+        "cache_creation_input_tokens": 531,
+        "cache_read_input_tokens": 81631,
+        "output_tokens": 283,
+        "server_tool_use": {
+          "web_search_requests": 0,
+          "web_fetch_requests": 0
+        },
+        "service_tier": "standard",
+        "cache_creation": {
+          "ephemeral_1h_input_tokens": 0,
+          "ephemeral_5m_input_tokens": 531
+        },
+        "inference_geo": "global",
+        "iterations": [
+          {
+            "input_tokens": 2,
+            "output_tokens": 22,
+            "cache_read_input_tokens": 27398,
+            "cache_creation_input_tokens": 222,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 222,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "type": "message"
+          }
+        ],
+        "speed": "standard"
+      },
+      "totalCostUsd": 0.4009309999999999,
+      "subtype": "success"
+    },
+    "answer": "Payment sent — confirmation id is conf_spike_001.",
+    "notes": "tools=[mcp__vendo__payments_send]"
+  },
+  {
+    "rung": "claude-agent-sdk (claude-opus-4-8[1m])",
+    "scenario": "tool-approve(+3000ms park)",
+    "trial": 2,
+    "ttftMs": 7241.981999999996,
+    "totalMs": 7433.928083999999,
+    "model": "claude-opus-4-8[1m]",
+    "usage": {
+      "usage": {
+        "input_tokens": 4,
+        "cache_creation_input_tokens": 200,
+        "cache_read_input_tokens": 55305,
+        "output_tokens": 110,
+        "server_tool_use": {
+          "web_search_requests": 0,
+          "web_fetch_requests": 0
+        },
+        "service_tier": "standard",
+        "cache_creation": {
+          "ephemeral_1h_input_tokens": 0,
+          "ephemeral_5m_input_tokens": 200
+        },
+        "inference_geo": "global",
+        "iterations": [
+          {
+            "input_tokens": 2,
+            "output_tokens": 22,
+            "cache_read_input_tokens": 27685,
+            "cache_creation_input_tokens": 135,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 135,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "type": "message"
+          }
+        ],
+        "speed": "standard"
+      },
+      "totalCostUsd": 0.4326034999999999,
+      "subtype": "success"
+    },
+    "answer": "Payment sent — confirmation id is conf_spike_001.",
+    "notes": "tools=[mcp__vendo__payments_send]"
+  },
+  {
+    "rung": "env-key claude-opus-4-8",
+    "scenario": "short",
+    "trial": 1,
+    "ttftMs": 1173.39375,
+    "totalMs": 1181.3856250000001,
+    "model": "claude-opus-4-8",
+    "usage": {
+      "input_tokens": 47,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 4,
+      "output_tokens_details": {
+        "thinking_tokens": 0
+      }
+    },
+    "answer": "pong"
+  },
+  {
+    "rung": "env-key claude-opus-4-8",
+    "scenario": "short",
+    "trial": 2,
+    "ttftMs": 1992.265125,
+    "totalMs": 2131.056,
+    "model": "claude-opus-4-8",
+    "usage": {
+      "input_tokens": 47,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 4,
+      "output_tokens_details": {
+        "thinking_tokens": 0
+      }
+    },
+    "answer": "pong"
+  },
+  {
+    "rung": "env-key claude-opus-4-8",
+    "scenario": "short",
+    "trial": 3,
+    "ttftMs": 1069.6219589999996,
+    "totalMs": 1179.7942499999995,
+    "model": "claude-opus-4-8",
+    "usage": {
+      "input_tokens": 47,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 4,
+      "output_tokens_details": {
+        "thinking_tokens": 0
+      }
+    },
+    "answer": "pong"
+  },
+  {
+    "rung": "env-key claude-opus-4-8",
+    "scenario": "short",
+    "trial": 4,
+    "ttftMs": 1619.4640420000005,
+    "totalMs": 1731.133167,
+    "model": "claude-opus-4-8",
+    "usage": {
+      "input_tokens": 47,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 4,
+      "output_tokens_details": {
+        "thinking_tokens": 0
+      }
+    },
+    "answer": "pong"
+  }
+]

--- a/spikes/install-dx-creds/src/baseline.ts
+++ b/spikes/install-dx-creds/src/baseline.ts
@@ -1,0 +1,69 @@
+/**
+ * SPIKE rung 1 baseline — direct Anthropic Messages API with an explicit env
+ * key (ANTHROPIC_API_KEY), streaming, no harness. This is what Vendo dev-mode
+ * does today when a key exists; the riders are measured against it.
+ */
+
+import { now, type TurnMetrics } from "./metrics.js";
+
+export async function baselineTurn(
+  text: string,
+  model: string,
+): Promise<Omit<TurnMetrics, "rung" | "scenario" | "trial">> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error("baseline needs ANTHROPIC_API_KEY (source the key file first)");
+
+  const t0 = now();
+  let ttftMs: number | null = null;
+  let answer = "";
+  let usage: unknown;
+
+  const res = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 256,
+      stream: true,
+      system: "You are Vendo's embedded product agent for a demo bank. Answer in one short sentence.",
+      messages: [{ role: "user", content: text }],
+    }),
+  });
+  if (!res.ok || !res.body) {
+    throw new Error(`baseline HTTP ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    let idx: number;
+    while ((idx = buf.indexOf("\n")) >= 0) {
+      const line = buf.slice(0, idx).trim();
+      buf = buf.slice(idx + 1);
+      if (!line.startsWith("data:")) continue;
+      const payload = line.slice(5).trim();
+      if (payload === "[DONE]") continue;
+      let event: { type?: string; delta?: { type?: string; text?: string }; usage?: unknown };
+      try {
+        event = JSON.parse(payload) as typeof event;
+      } catch {
+        continue;
+      }
+      if (event.type === "content_block_delta" && event.delta?.type === "text_delta") {
+        if (ttftMs === null) ttftMs = now() - t0;
+        answer += event.delta.text ?? "";
+      }
+      if (event.type === "message_delta" && event.usage) usage = event.usage;
+    }
+  }
+
+  return { ttftMs, totalMs: now() - t0, model, usage, answer };
+}

--- a/spikes/install-dx-creds/src/claude-rider.ts
+++ b/spikes/install-dx-creds/src/claude-rider.ts
@@ -1,0 +1,217 @@
+/**
+ * SPIKE rung 2 — persistent-process provider over the Claude Agent SDK,
+ * riding the machine's authed `claude` login (no ANTHROPIC_API_KEY).
+ *
+ * Shape: one long-lived query() in streaming-input mode = one persistent
+ * session. Vendo host tools are bridged via an in-process MCP server
+ * (createSdkMcpServer). Vendo's consent semantics ride the canUseTool
+ * permission callback: read-risk tools resolve immediately, write-risk tools
+ * PARK on the ApprovalBroker until the (simulated) user approves.
+ */
+
+import {
+  createSdkMcpServer,
+  query,
+  tool,
+  type Query,
+  type SDKMessage,
+  type SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import { ApprovalBroker, executeSpikeTool } from "./vendo-tools.js";
+import { now, type TurnMetrics } from "./metrics.js";
+
+const SYSTEM_APPEND = [
+  "You are Vendo's embedded product agent for a demo bank.",
+  "Only use the provided vendo tools. Never use shell, file or web tools.",
+  "Answer in one short sentence.",
+].join(" ");
+
+interface PendingTurn {
+  startedAt: number;
+  ttftMs: number | null;
+  answer: string;
+  toolCalls: string[];
+  resolve: (m: Omit<TurnMetrics, "rung" | "scenario" | "trial">) => void;
+}
+
+export class ClaudeRider {
+  readonly broker = new ApprovalBroker();
+  private q: Query | null = null;
+  private queue: SDKUserMessage[] = [];
+  private wake: (() => void) | null = null;
+  private closed = false;
+  private pending: PendingTurn | null = null;
+  public model: string | undefined;
+  public approvalDelayMs: number;
+
+  constructor(opts: { approvalDelayMs?: number } = {}) {
+    this.approvalDelayMs = opts.approvalDelayMs ?? 0;
+  }
+
+  private async *input(): AsyncGenerator<SDKUserMessage> {
+    while (!this.closed) {
+      while (this.queue.length > 0) yield this.queue.shift()!;
+      await new Promise<void>((r) => (this.wake = r));
+    }
+  }
+
+  /** Spawn the persistent session. Resolves once the SDK reports init. */
+  async start(): Promise<{ spawnMs: number; model: string | undefined }> {
+    const t0 = now();
+    const vendoServer = createSdkMcpServer({
+      name: "vendo",
+      version: "0.0.0",
+      tools: [
+        tool(
+          "payments_list",
+          "List the user's recent payments (read-only).",
+          { limit: z.number().optional() },
+          async (args) => ({
+            content: [
+              { type: "text", text: JSON.stringify(executeSpikeTool("vendo_payments_list", args)) },
+            ],
+          }),
+        ),
+        tool(
+          "payments_send",
+          "Send a payment to a payee. DESTRUCTIVE: moves real money.",
+          { payee: z.string(), amountCents: z.number() },
+          async (args) => {
+            this.broker.mark("tool-executed", "payments_send");
+            return {
+              content: [
+                { type: "text", text: JSON.stringify(executeSpikeTool("vendo_payments_send", args)) },
+              ],
+            };
+          },
+        ),
+      ],
+    });
+
+    this.q = query({
+      prompt: this.input(),
+      options: {
+        mcpServers: { vendo: vendoServer },
+        // Keep the ridden harness tool-less apart from our bridge: no
+        // filesystem/shell/web tools are permitted (defense in depth: the
+        // canUseTool below also denies anything that is not mcp__vendo__*).
+        disallowedTools: [
+          "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch",
+          "WebSearch", "Task", "TodoWrite", "NotebookEdit", "KillShell",
+          "BashOutput", "ExitPlanMode",
+        ],
+        systemPrompt: { type: "preset", preset: "claude_code", append: SYSTEM_APPEND },
+        // Isolation: do not load the machine's user/project settings or hooks.
+        settingSources: [],
+        includePartialMessages: true,
+        maxTurns: 100,
+        stderr: (data: string) => {
+          if (process.env.SPIKE_DEBUG) console.error(`[claude stderr] ${data}`);
+        },
+        // Vendo consent projection lives here. This is the survival test:
+        // a destructive call PARKS on the broker and resumes on approval.
+        canUseTool: async (toolName, input) => {
+          this.pending?.toolCalls.push(toolName);
+          if (!toolName.startsWith("mcp__vendo__")) {
+            this.broker.mark("tool-denied", toolName);
+            return { behavior: "deny", message: "Only vendo tools are permitted." };
+          }
+          if (toolName === "mcp__vendo__payments_send") {
+            const id = `apr_${Date.now()}`;
+            if (this.approvalDelayMs > 0) this.broker.autoApproveAfter(id, this.approvalDelayMs);
+            const approved = await this.broker.waitForDecision(id);
+            if (!approved) {
+              return { behavior: "deny", message: "The user declined this payment." };
+            }
+            return { behavior: "allow", updatedInput: input };
+          }
+          this.broker.mark("tool-auto-allowed", toolName);
+          return { behavior: "allow", updatedInput: input };
+        },
+      },
+    });
+
+    // In streaming-input mode the SDK emits nothing (not even system:init)
+    // until the first user message is yielded — do NOT block on init here.
+    void this.consume(() => {});
+    return { spawnMs: now() - t0, model: this.model };
+  }
+
+  private async consume(onInit: () => void): Promise<void> {
+    if (!this.q) return;
+    try {
+      for await (const message of this.q as AsyncIterable<SDKMessage>) {
+        if (message.type === "system" && message.subtype === "init") {
+          this.model = (message as { model?: string }).model;
+          onInit();
+        } else if (message.type === "stream_event") {
+          const event = (message as { event?: { type?: string; delta?: { type?: string } } }).event;
+          if (
+            this.pending &&
+            this.pending.ttftMs === null &&
+            event?.type === "content_block_delta" &&
+            event.delta?.type === "text_delta"
+          ) {
+            this.pending.ttftMs = now() - this.pending.startedAt;
+          }
+        } else if (message.type === "assistant") {
+          const content = (message as { message: { content: Array<{ type: string; text?: string }> } })
+            .message.content;
+          for (const block of content) {
+            if (block.type === "text" && block.text) this.pending && (this.pending.answer = block.text);
+          }
+        } else if (message.type === "result") {
+          const r = message as {
+            usage?: unknown;
+            total_cost_usd?: number;
+            result?: string;
+            subtype: string;
+          };
+          const p = this.pending;
+          this.pending = null;
+          p?.resolve({
+            ttftMs: p.ttftMs,
+            totalMs: now() - p.startedAt,
+            model: this.model,
+            usage: { usage: r.usage, totalCostUsd: r.total_cost_usd, subtype: r.subtype },
+            answer: r.result ?? p.answer,
+            notes: `tools=[${p.toolCalls.join(",")}]`,
+          });
+        }
+      }
+    } catch (err) {
+      const p = this.pending;
+      this.pending = null;
+      p?.resolve({
+        ttftMs: p.ttftMs,
+        totalMs: now() - p.startedAt,
+        answer: "",
+        notes: `stream error: ${String(err)}`,
+      });
+    }
+  }
+
+  /** Send one user turn into the live session and wait for its result. */
+  sendTurn(text: string): Promise<Omit<TurnMetrics, "rung" | "scenario" | "trial">> {
+    return new Promise((resolve) => {
+      this.pending = { startedAt: now(), ttftMs: null, answer: "", toolCalls: [], resolve };
+      this.queue.push({
+        type: "user",
+        message: { role: "user", content: [{ type: "text", text }] },
+        parent_tool_use_id: null,
+      } as SDKUserMessage);
+      this.wake?.();
+    });
+  }
+
+  async dispose(): Promise<void> {
+    this.closed = true;
+    this.wake?.();
+    try {
+      await this.q?.interrupt();
+    } catch {
+      /* already gone */
+    }
+  }
+}

--- a/spikes/install-dx-creds/src/codex-rider.ts
+++ b/spikes/install-dx-creds/src/codex-rider.ts
@@ -1,0 +1,205 @@
+/**
+ * SPIKE rung 3 — persistent-process provider over `codex app-server`
+ * (codex-cli 0.144.4), riding the machine's ChatGPT-plan login.
+ *
+ * Protocol facts verified against `codex app-server generate-ts` output for
+ * the installed binary (see REPORT.md):
+ * - newline-delimited JSON-RPC 2.0 over stdio
+ * - initialize {clientInfo, capabilities:{experimentalApi:true}} → "initialized" notification
+ * - thread/start {dynamicTools:[...], approvalPolicy, sandbox, ephemeral}
+ *   (dynamicTools is experimental: gated on capabilities.experimentalApi)
+ * - turn/start {threadId, input:[{type:"text",text,text_elements:[]}]}
+ * - server → client REQUEST "item/tool/call" (DynamicToolCallParams) for each
+ *   dynamic tool invocation; the client's delayed response IS the approval park
+ * - notifications: item/agentMessage/delta (TTFT), turn/completed (turn end)
+ */
+
+import { spawn, type ChildProcessByStdio } from "node:child_process";
+import { createInterface } from "node:readline";
+import type { Readable, Writable } from "node:stream";
+import { ApprovalBroker, executeSpikeTool, SPIKE_TOOLS } from "./vendo-tools.js";
+import { now, type TurnMetrics } from "./metrics.js";
+
+type Json = Record<string, unknown>;
+
+interface PendingTurn {
+  startedAt: number;
+  ttftMs: number | null;
+  answer: string;
+  toolCalls: string[];
+  resolve: (m: Omit<TurnMetrics, "rung" | "scenario" | "trial">) => void;
+}
+
+export class CodexRider {
+  readonly broker = new ApprovalBroker();
+  private child: ChildProcessByStdio<Writable, Readable, Readable> | null = null;
+  private nextId = 1;
+  private inflight = new Map<number, { resolve: (v: Json) => void; reject: (e: Error) => void }>();
+  private threadId: string | null = null;
+  private pending: PendingTurn | null = null;
+  private model: string | undefined;
+  public approvalDelayMs: number;
+
+  constructor(opts: { approvalDelayMs?: number } = {}) {
+    this.approvalDelayMs = opts.approvalDelayMs ?? 0;
+  }
+
+  private send(obj: Json): void {
+    this.child?.stdin.write(`${JSON.stringify(obj)}\n`);
+  }
+
+  private request(method: string, params: Json | null): Promise<Json> {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.inflight.set(id, { resolve, reject });
+      this.send({ jsonrpc: "2.0", id, method, ...(params === null ? {} : { params }) });
+    });
+  }
+
+  async start(): Promise<{ spawnMs: number; model: string | undefined }> {
+    const t0 = now();
+    this.child = spawn("codex", ["app-server"], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env },
+    }) as ChildProcessByStdio<Writable, Readable, Readable>;
+
+    const rl = createInterface({ input: this.child.stdout });
+    rl.on("line", (line) => {
+      if (!line.trim()) return;
+      let msg: Json;
+      try {
+        msg = JSON.parse(line) as Json;
+      } catch {
+        return;
+      }
+      void this.onMessage(msg);
+    });
+
+    await this.request("initialize", {
+      clientInfo: { name: "vendo-spike", title: "Vendo install-dx spike", version: "0.0.0" },
+      capabilities: { experimentalApi: true, requestAttestation: false },
+    });
+    this.send({ jsonrpc: "2.0", method: "initialized" });
+
+    const started = await this.request("thread/start", {
+      cwd: process.cwd(),
+      ephemeral: true,
+      // No filesystem/shell surface for the agent; Vendo tools only.
+      sandbox: "read-only",
+      approvalPolicy: "untrusted",
+      developerInstructions:
+        "You are Vendo's embedded product agent for a demo bank. Only use the provided vendo tools. Never run commands or read files. Answer in one short sentence.",
+      dynamicTools: SPIKE_TOOLS.map((t) => ({
+        type: "function",
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema,
+      })),
+    });
+    this.model = (started as { model?: string }).model;
+    this.threadId = (started as { thread?: { id?: string } }).thread?.id ?? null;
+    if (!this.threadId) throw new Error(`thread/start gave no thread id: ${JSON.stringify(started)}`);
+    return { spawnMs: now() - t0, model: this.model };
+  }
+
+  private async onMessage(msg: Json): Promise<void> {
+    // Response to one of our requests
+    if (typeof msg.id === "number" && !("method" in msg)) {
+      const slot = this.inflight.get(msg.id);
+      if (!slot) return;
+      this.inflight.delete(msg.id);
+      if (msg.error) slot.reject(new Error(JSON.stringify(msg.error)));
+      else slot.resolve((msg.result ?? {}) as Json);
+      return;
+    }
+
+    const method = msg.method as string | undefined;
+    const params = (msg.params ?? {}) as Json;
+
+    // Server → client REQUEST: dynamic tool call (this is the bridge).
+    if (method === "item/tool/call" && msg.id !== undefined) {
+      const tool = params.tool as string;
+      const args = params.arguments;
+      this.pending?.toolCalls.push(tool);
+      let success = true;
+      let text: string;
+      if (tool === "vendo_payments_send") {
+        const id = `apr_${Date.now()}`;
+        if (this.approvalDelayMs > 0) this.broker.autoApproveAfter(id, this.approvalDelayMs);
+        const approved = await this.broker.waitForDecision(id);
+        if (approved) {
+          this.broker.mark("tool-executed", tool);
+          text = JSON.stringify(executeSpikeTool(tool, args));
+        } else {
+          success = false;
+          text = "The user declined this payment.";
+        }
+      } else {
+        this.broker.mark("tool-auto-allowed", tool);
+        text = JSON.stringify(executeSpikeTool(tool, args));
+      }
+      this.send({
+        jsonrpc: "2.0",
+        id: msg.id,
+        result: { contentItems: [{ type: "inputText", text }], success },
+      });
+      return;
+    }
+
+    // Any command/patch approval request: always deny (agent must stay tool-less).
+    if (
+      msg.id !== undefined &&
+      (method === "item/commandExecution/requestApproval" ||
+        method === "item/fileChange/requestApproval" ||
+        method === "item/permissions/requestApproval" ||
+        method === "execCommandApproval" ||
+        method === "applyPatchApproval")
+    ) {
+      this.broker.mark("harness-approval-denied", method);
+      this.send({ jsonrpc: "2.0", id: msg.id, result: { decision: "denied" } });
+      return;
+    }
+
+    // Notifications
+    if (method === "item/agentMessage/delta") {
+      if (this.pending && this.pending.ttftMs === null) {
+        this.pending.ttftMs = now() - this.pending.startedAt;
+      }
+      this.pending && (this.pending.answer += String(params.delta ?? ""));
+      return;
+    }
+    if (method === "turn/completed") {
+      const turn = params.turn as { status?: string; error?: unknown } | undefined;
+      const p = this.pending;
+      this.pending = null;
+      p?.resolve({
+        ttftMs: p.ttftMs,
+        totalMs: now() - p.startedAt,
+        model: this.model,
+        usage: (params as { usage?: unknown }).usage ?? turn,
+        answer: p.answer,
+        notes: `tools=[${p.toolCalls.join(",")}] status=${turn?.status ?? "?"}`,
+      });
+      return;
+    }
+  }
+
+  async sendTurn(text: string): Promise<Omit<TurnMetrics, "rung" | "scenario" | "trial">> {
+    if (!this.threadId) throw new Error("not started");
+    return new Promise((resolve, reject) => {
+      this.pending = { startedAt: now(), ttftMs: null, answer: "", toolCalls: [], resolve };
+      this.request("turn/start", {
+        threadId: this.threadId!,
+        input: [{ type: "text", text, text_elements: [] }],
+      }).catch((err: Error) => {
+        this.pending = null;
+        reject(err);
+      });
+    });
+  }
+
+  async dispose(): Promise<void> {
+    this.child?.kill("SIGTERM");
+    this.child = null;
+  }
+}

--- a/spikes/install-dx-creds/src/index.ts
+++ b/spikes/install-dx-creds/src/index.ts
@@ -1,0 +1,6 @@
+/** SPIKE — evidence only; nothing here ships. See REPORT.md. */
+export { ClaudeRider } from "./claude-rider.js";
+export { CodexRider } from "./codex-rider.js";
+export { baselineTurn } from "./baseline.js";
+export { ApprovalBroker, SPIKE_TOOLS, executeSpikeTool } from "./vendo-tools.js";
+export { summarize, appendResults, type TurnMetrics } from "./metrics.js";

--- a/spikes/install-dx-creds/src/metrics.ts
+++ b/spikes/install-dx-creds/src/metrics.ts
@@ -1,0 +1,54 @@
+/** SPIKE — shared latency record + tiny stats/reporting helpers. */
+
+export interface TurnMetrics {
+  rung: string;
+  scenario: string;
+  trial: number;
+  /** ms from turn submission to first assistant text delta */
+  ttftMs: number | null;
+  /** ms from turn submission to turn completion */
+  totalMs: number;
+  model?: string;
+  usage?: unknown;
+  answer?: string;
+  notes?: string;
+}
+
+export function now(): number {
+  return performance.now();
+}
+
+export function summarize(rows: TurnMetrics[]): string {
+  const byKey = new Map<string, TurnMetrics[]>();
+  for (const r of rows) {
+    const k = `${r.rung} · ${r.scenario}`;
+    byKey.set(k, [...(byKey.get(k) ?? []), r]);
+  }
+  const lines: string[] = [
+    "| rung · scenario | trials | TTFT ms (min/med/max) | total ms (min/med/max) |",
+    "|---|---|---|---|",
+  ];
+  for (const [k, rs] of byKey) {
+    const ttfts = rs.map((r) => r.ttftMs).filter((v): v is number => v !== null).sort((a, b) => a - b);
+    const totals = rs.map((r) => r.totalMs).sort((a, b) => a - b);
+    const fmt = (xs: number[]) =>
+      xs.length === 0
+        ? "—"
+        : `${Math.round(xs[0]!)} / ${Math.round(xs[Math.floor(xs.length / 2)]!)} / ${Math.round(xs[xs.length - 1]!)}`;
+    lines.push(`| ${k} | ${rs.length} | ${fmt(ttfts)} | ${fmt(totals)} |`);
+  }
+  return lines.join("\n");
+}
+
+export async function appendResults(file: string, rows: TurnMetrics[]): Promise<void> {
+  const { mkdir, readFile, writeFile } = await import("node:fs/promises");
+  const { dirname } = await import("node:path");
+  await mkdir(dirname(file), { recursive: true });
+  let existing: TurnMetrics[] = [];
+  try {
+    existing = JSON.parse(await readFile(file, "utf8")) as TurnMetrics[];
+  } catch {
+    /* first write */
+  }
+  await writeFile(file, JSON.stringify([...existing, ...rows], null, 2));
+}

--- a/spikes/install-dx-creds/src/run-all.ts
+++ b/spikes/install-dx-creds/src/run-all.ts
@@ -1,0 +1,11 @@
+/** SPIKE runner — all rungs in sequence (baseline needs ANTHROPIC_API_KEY). */
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+for (const script of ["run-baseline.js", "run-claude.js", "run-codex.js"]) {
+  console.log(`\n===== ${script} =====`);
+  const r = spawnSync(process.execPath, [join(here, script)], { stdio: "inherit" });
+  if (r.status !== 0) console.error(`${script} exited ${r.status}`);
+}

--- a/spikes/install-dx-creds/src/run-baseline.ts
+++ b/spikes/install-dx-creds/src/run-baseline.ts
@@ -1,0 +1,15 @@
+/** SPIKE runner — env-key baseline. Requires ANTHROPIC_API_KEY. */
+import { baselineTurn } from "./baseline.js";
+import { appendResults, summarize, type TurnMetrics } from "./metrics.js";
+import { SCENARIOS, TRIALS } from "./scenarios.js";
+
+const MODEL = process.env.BASELINE_MODEL ?? "claude-opus-4-8";
+
+const rows: TurnMetrics[] = [];
+for (let trial = 1; trial <= TRIALS; trial++) {
+  const m = await baselineTurn(SCENARIOS.short, MODEL);
+  rows.push({ rung: `env-key ${MODEL}`, scenario: "short", trial, ...m });
+  console.log(`baseline short #${trial}: ttft=${m.ttftMs?.toFixed(0)}ms total=${m.totalMs.toFixed(0)}ms "${(m.answer ?? "").slice(0, 40)}"`);
+}
+await appendResults(new URL("../results/latency.json", import.meta.url).pathname, rows);
+console.log(`\n${summarize(rows)}`);

--- a/spikes/install-dx-creds/src/run-claude.ts
+++ b/spikes/install-dx-creds/src/run-claude.ts
@@ -1,0 +1,46 @@
+/**
+ * SPIKE runner — Claude Agent SDK rider on the machine's `claude` login.
+ * Deliberately unsets ANTHROPIC_API_KEY so the run proves subscription riding.
+ */
+import { ClaudeRider } from "./claude-rider.js";
+import { appendResults, summarize, type TurnMetrics } from "./metrics.js";
+import { APPROVAL_DELAY_MS, SCENARIOS, TRIALS } from "./scenarios.js";
+
+delete process.env.ANTHROPIC_API_KEY;
+
+const rider = new ClaudeRider();
+await rider.start();
+// Streaming-input mode defers spawn work to the first turn; a warmup turn
+// makes the persistent-session cost visible and keeps later trials clean.
+const warm = await rider.sendTurn("Reply with exactly: ready");
+const model = rider.model;
+console.log(`claude rider warmup (spawn+first turn): ${warm.totalMs.toFixed(0)}ms, model=${model}`);
+
+const rows: TurnMetrics[] = [];
+const rung = `claude-agent-sdk (${model ?? "?"})`;
+rows.push({ rung, scenario: "warmup(spawn+turn)", trial: 1, ...warm });
+
+for (let trial = 1; trial <= TRIALS; trial++) {
+  const m = await rider.sendTurn(SCENARIOS.short);
+  rows.push({ rung, scenario: "short", trial, ...m });
+  console.log(`short #${trial}: ttft=${m.ttftMs?.toFixed(0)}ms total=${m.totalMs.toFixed(0)}ms "${(m.answer ?? "").slice(0, 40)}"`);
+}
+for (let trial = 1; trial <= TRIALS; trial++) {
+  const m = await rider.sendTurn(SCENARIOS.toolRead);
+  rows.push({ rung, scenario: "tool-read", trial, ...m });
+  console.log(`tool-read #${trial}: ttft=${m.ttftMs?.toFixed(0)}ms total=${m.totalMs.toFixed(0)}ms ${m.notes ?? ""}`);
+}
+rider.approvalDelayMs = APPROVAL_DELAY_MS;
+for (let trial = 1; trial <= 2; trial++) {
+  const m = await rider.sendTurn(SCENARIOS.toolApprove);
+  rows.push({ rung, scenario: `tool-approve(+${APPROVAL_DELAY_MS}ms park)`, trial, ...m });
+  console.log(`tool-approve #${trial}: total=${m.totalMs.toFixed(0)}ms ${m.notes ?? ""} "${(m.answer ?? "").slice(0, 80)}"`);
+}
+
+console.log("\napproval broker log:");
+for (const e of rider.broker.log) console.log(`  ${e.event} ${e.detail ?? ""} @${e.at}`);
+
+await rider.dispose();
+await appendResults(new URL("../results/latency.json", import.meta.url).pathname, rows);
+console.log(`\n${summarize(rows)}`);
+process.exit(0);

--- a/spikes/install-dx-creds/src/run-codex.ts
+++ b/spikes/install-dx-creds/src/run-codex.ts
@@ -1,0 +1,41 @@
+/**
+ * SPIKE runner — Codex app-server rider on the machine's ChatGPT-plan login.
+ * No OPENAI_API_KEY is used; auth comes from ~/.codex/auth.json (read-only).
+ */
+import { CodexRider } from "./codex-rider.js";
+import { appendResults, summarize, type TurnMetrics } from "./metrics.js";
+import { APPROVAL_DELAY_MS, SCENARIOS, TRIALS } from "./scenarios.js";
+
+delete process.env.OPENAI_API_KEY;
+
+const rider = new CodexRider();
+const { spawnMs, model } = await rider.start();
+console.log(`codex rider up in ${spawnMs.toFixed(0)}ms, model=${model}`);
+
+const rows: TurnMetrics[] = [];
+const rung = `codex-app-server (${model ?? "?"})`;
+
+for (let trial = 1; trial <= TRIALS; trial++) {
+  const m = await rider.sendTurn(SCENARIOS.short);
+  rows.push({ rung, scenario: "short", trial, ...m });
+  console.log(`short #${trial}: ttft=${m.ttftMs?.toFixed(0)}ms total=${m.totalMs.toFixed(0)}ms "${(m.answer ?? "").slice(0, 40)}"`);
+}
+for (let trial = 1; trial <= TRIALS; trial++) {
+  const m = await rider.sendTurn(SCENARIOS.toolRead);
+  rows.push({ rung, scenario: "tool-read", trial, ...m });
+  console.log(`tool-read #${trial}: ttft=${m.ttftMs?.toFixed(0)}ms total=${m.totalMs.toFixed(0)}ms ${m.notes ?? ""}`);
+}
+rider.approvalDelayMs = APPROVAL_DELAY_MS;
+for (let trial = 1; trial <= 2; trial++) {
+  const m = await rider.sendTurn(SCENARIOS.toolApprove);
+  rows.push({ rung, scenario: `tool-approve(+${APPROVAL_DELAY_MS}ms park)`, trial, ...m });
+  console.log(`tool-approve #${trial}: total=${m.totalMs.toFixed(0)}ms ${m.notes ?? ""} "${(m.answer ?? "").slice(0, 80)}"`);
+}
+
+console.log("\napproval broker log:");
+for (const e of rider.broker.log) console.log(`  ${e.event} ${e.detail ?? ""} @${e.at}`);
+
+await rider.dispose();
+await appendResults(new URL("../results/latency.json", import.meta.url).pathname, rows);
+console.log(`\n${summarize(rows)}`);
+process.exit(0);

--- a/spikes/install-dx-creds/src/scenarios.ts
+++ b/spikes/install-dx-creds/src/scenarios.ts
@@ -1,0 +1,19 @@
+/** SPIKE — the three measured scenarios, shared by every rung. */
+
+export const APPROVAL_DELAY_MS = 3000;
+
+export const SCENARIOS = {
+  /** Pure text turn; the interactive-latency headline number. */
+  short: "Reply with exactly: pong",
+  /** One read-risk host tool round-trip. */
+  toolRead: "How many recent payments do I have? Use your payments list tool and answer with the count.",
+  /**
+   * One write-risk host tool round-trip. The guard parks the call for
+   * APPROVAL_DELAY_MS (simulated human), then approves; the turn must resume
+   * and report the confirmation id. Total latency includes the park.
+   */
+  toolApprove:
+    "Send a payment of 1250 cents to 'Acme Water Co' using your payment tool, then tell me the confirmation id.",
+} as const;
+
+export const TRIALS = 4;

--- a/spikes/install-dx-creds/src/vendo-tools.ts
+++ b/spikes/install-dx-creds/src/vendo-tools.ts
@@ -1,0 +1,106 @@
+/**
+ * SPIKE — stand-ins for Vendo's host tools (mirrors the ToolRegistry shape in
+ * packages/agent: descriptor {name, description, inputSchema, risk} + execute).
+ *
+ * Two tools chosen to exercise both approval branches of Vendo's guard:
+ * - vendo_payments_list: risk "read"  → auto-allow
+ * - vendo_payments_send: risk "write" → guard says "ask"; the call must PARK
+ *   until a (simulated) human approves, then resume with the real result.
+ */
+
+export interface SpikeToolDescriptor {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  risk: "read" | "write";
+}
+
+export const SPIKE_TOOLS: SpikeToolDescriptor[] = [
+  {
+    name: "vendo_payments_list",
+    description:
+      "List the user's recent payments. Read-only. Returns id, payee and amount for each payment.",
+    inputSchema: {
+      type: "object",
+      properties: { limit: { type: "number", description: "max rows" } },
+      additionalProperties: false,
+    },
+    risk: "read",
+  },
+  {
+    name: "vendo_payments_send",
+    description:
+      "Send a payment to a payee. DESTRUCTIVE: moves real money. Requires user approval.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        payee: { type: "string" },
+        amountCents: { type: "number" },
+      },
+      required: ["payee", "amountCents"],
+      additionalProperties: false,
+    },
+    risk: "write",
+  },
+];
+
+/** Deterministic fake host API (what registry.execute would hit). */
+export function executeSpikeTool(name: string, args: unknown): unknown {
+  if (name === "vendo_payments_list") {
+    return {
+      payments: [
+        { id: "pay_1", payee: "Acme Water Co", amountCents: 4200 },
+        { id: "pay_2", payee: "Metro Electric", amountCents: 9150 },
+      ],
+    };
+  }
+  if (name === "vendo_payments_send") {
+    const a = args as { payee?: string; amountCents?: number };
+    return {
+      status: "sent",
+      confirmation: "conf_spike_001",
+      payee: a?.payee ?? "?",
+      amountCents: a?.amountCents ?? 0,
+    };
+  }
+  throw new Error(`unknown spike tool: ${name}`);
+}
+
+/**
+ * Simulated Vendo approval broker. When the guard says "ask" the tool call
+ * parks on a promise; a "user" resolves it later. In the measurements we
+ * resolve after `approvalDelayMs` to prove the ridden session tolerates an
+ * arbitrary-length park and then RESUMES the same tool call.
+ */
+export class ApprovalBroker {
+  private pending = new Map<string, (approved: boolean) => void>();
+  public log: Array<{ event: string; at: number; detail?: string }> = [];
+
+  mark(event: string, detail?: string): void {
+    this.log.push({ event, at: Date.now(), detail });
+  }
+
+  /** Park until decide() is called for this id. */
+  waitForDecision(id: string): Promise<boolean> {
+    this.mark("approval-parked", id);
+    return new Promise((resolve) => {
+      this.pending.set(id, (approved) => {
+        this.mark(approved ? "approval-granted" : "approval-denied", id);
+        resolve(approved);
+      });
+    });
+  }
+
+  decide(id: string, approved: boolean): boolean {
+    const fn = this.pending.get(id);
+    if (!fn) return false;
+    this.pending.delete(id);
+    fn(approved);
+    return true;
+  }
+
+  /** Simulate the human clicking Approve after `ms`. */
+  autoApproveAfter(id: string, ms: number): void {
+    setTimeout(() => this.decide(id, true), ms);
+  }
+}

--- a/spikes/install-dx-creds/tsconfig.json
+++ b/spikes/install-dx-creds/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## What

Lands the timeboxed Install DX wave-2 spike (ENG-337) as its decision record. Evidence only — **nothing here ships**; the package is excluded from the pnpm workspace and CI/turbo graph.

## Verdict: FULL-TOOLS RIDING

Both riders bridge Vendo host tools with approval semantics intact at interactive latency (see `spikes/install-dx-creds/REPORT.md` for the full record, latency table, and the wave-2 API sketch):

- **Claude Agent SDK** (rides the `claude` CLI login): persistent streaming-input `query()` session, in-process MCP tools, consent via `canUseTool` — a 3s parked approval resumed and completed with the real tool result.
- **Codex app-server** (rides the ChatGPT-plan login): first-class experimental `dynamicTools` over JSON-RPC; tool calls arrive as server→client requests, so an unanswered request IS the approval park.
- Overhead vs env-key baseline: ~0.2–0.4s median TTFT on short turns. Claude rider first turn ≈ 12s (must spawn at dev-server boot); codex ready in ~1.5s.
- The tools-free fallback is NOT needed. Wave 2 (ENG-338) builds the 4-rung credential resolver + rider providers per the sketch in the report.

Key gotchas recorded for wave 2: Agent SDK streaming-input emits nothing until the first user turn (deadlock trap); needs zod ^4 vs repo zod 3; `settingSources: []` mandatory or the ridden session inherits the dev's personal hooks; codex `dynamicTools` gated on `capabilities.experimentalApi`.

## Workspace isolation (second commit)

Keeping the spike in the workspace flipped zod peer auto-resolution to 4.x for every ai-SDK consumer (`packages/agent`, `packages/ui`, fixtures, bench) — packages/ui chrome tests fail under zod 4. The spike is now excluded in `pnpm-workspace.yaml` with its own standalone lockfile (`pnpm install --ignore-workspace`); the root `pnpm-lock.yaml` in this PR is **byte-identical to main**, so the shipped dependency graph is untouched.

## Receipts

- Approval-park evidence + per-trial latency: `spikes/install-dx-creds/results/latency.json`, transcript excerpts in REPORT.md.
- Local gates: build/typecheck/lint green; tests green except one `packages/ui` chrome flake (`test/chrome/error-surface.test.tsx`) that passes standalone on rerun — root graph is byte-identical to main, so it cannot be introduced by this diff.
- Spike standalone gates: `pnpm install --ignore-workspace && pnpm build && pnpm test && pnpm typecheck` green.

Linear: ENG-337. Spec §2: `docs/superpowers/specs/2026-07-14-install-dx-design.md`. Plan: `docs/superpowers/plans/2026-07-14-install-dx.md` (Wave 2, step 1).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Install DX wave‑2 spike (ENG‑337) as an evidence-only package to validate riding authed `claude` and `codex` CLI sessions as persistent dev‑mode providers with a Vendo tool bridge and approval parking. The spike is excluded from the workspace so nothing ships and the dependency graph remains unchanged.

- **New Features**
  - Prototype persistent providers over `@anthropic-ai/claude-agent-sdk` and `codex app-server`, bridging Vendo tools in-process and routing consent through the rider APIs.
  - Proves approval park-and-resume for write‑risk tools; read‑risk auto‑allow. Aligns with ENG‑337 requirements.
  - Latency recorded vs env‑key baseline; see `spikes/install-dx-creds/REPORT.md` and `spikes/install-dx-creds/results/latency.json`.
  - Verdict: full‑tools riding for wave 2.

- **Dependencies**
  - Excludes `spikes/install-dx-creds` in `pnpm-workspace.yaml` to prevent `zod` `^4` peer leakage.
  - Spike uses its own `pnpm-lock.yaml`; root `pnpm-lock.yaml` remains byte‑identical to `main`.
  - Package is not part of CI/turbo and does not affect shipped code.

<sup>Written for commit f70dc9978c1bb152b9ac4b88894de7946869b3a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

