### PR TITLE
fix(store): self-heal stale PGlite lock on boot (ENG-350)

### DIFF
--- a/packages/store/src/db.stale-lock.test.ts
+++ b/packages/store/src/db.stale-lock.test.ts
@@ -1,0 +1,95 @@
+import { existsSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ENG-350 — a dev server killed uncleanly leaves postmaster.pid in the PGlite
+// data dir, and in the field PGlite.create can then hard-abort with a raw
+// `Aborted()` (electric-sql/pglite#2, #794). The real wasm engine is mocked so
+// the abort is deterministic; the lock-file staleness logic runs against a
+// real temp dir.
+const pgliteCreate = vi.fn();
+vi.mock("@electric-sql/pglite", () => ({
+  PGlite: { create: (...args: unknown[]) => pgliteCreate(...args) },
+}));
+
+const { createDb } = await import("./db.js");
+
+const aborted = () => Object.assign(new Error("Aborted(). Build with -sASSERTIONS for more info."), { name: "RuntimeError" });
+const fakePglite = () => ({
+  query: vi.fn(async () => ({ rows: [{ ok: 1 }] })),
+  close: vi.fn(async () => {}),
+});
+
+// PGlite's wasm postgres always records Emscripten's fake pid (-42) — a
+// non-positive pid can never belong to a live owner.
+const STALE_LOCK = "-42\n/pglite/data\n1784193130\n5432\n\n\n317123000         1\n";
+
+describe("PGlite stale-lock self-heal (ENG-350)", () => {
+  let dir: string;
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "vendo-stale-lock-"));
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    pgliteCreate.mockReset();
+  });
+
+  afterEach(async () => {
+    warn.mockRestore();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("heals a stale postmaster.pid and retries once", async () => {
+    await writeFile(join(dir, "postmaster.pid"), STALE_LOCK);
+    pgliteCreate.mockRejectedValueOnce(aborted()).mockResolvedValueOnce(fakePglite());
+
+    const db = createDb({ dataDir: dir });
+    await expect(db.query("select 1")).resolves.toEqual({ rows: [{ ok: 1 }] });
+
+    expect(pgliteCreate).toHaveBeenCalledTimes(2);
+    expect(existsSync(join(dir, "postmaster.pid"))).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("stale postmaster.pid"));
+    await db.close();
+  });
+
+  it("refuses to delete a lock recording a live process", async () => {
+    // This test process itself is the recorded owner — definitionally alive.
+    await writeFile(join(dir, "postmaster.pid"), `${process.pid}\n/pglite/data\n1784193130\n5432\n`);
+    pgliteCreate.mockRejectedValue(aborted());
+
+    const db = createDb({ dataDir: dir });
+    await expect(db.query("select 1")).rejects.toThrow(new RegExp(`live process \\(pid ${process.pid}\\)`));
+
+    expect(pgliteCreate).toHaveBeenCalledTimes(1);
+    expect(existsSync(join(dir, "postmaster.pid"))).toBe(true);
+    await db.close();
+  });
+
+  it("surfaces an actionable error when the retry also fails", async () => {
+    await writeFile(join(dir, "postmaster.pid"), STALE_LOCK);
+    pgliteCreate.mockRejectedValue(aborted());
+
+    const db = createDb({ dataDir: dir });
+    const error = await db.query("select 1").catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(`[vendo] PGlite data directory "${dir}"`);
+    expect((error as Error).message).toContain("likely corrupt");
+    expect((error as Error).message).toContain("Aborted()");
+    expect(pgliteCreate).toHaveBeenCalledTimes(2);
+    await db.close();
+  });
+
+  it("propagates the original error when there is no lock file to heal", async () => {
+    pgliteCreate.mockRejectedValue(aborted());
+
+    const db = createDb({ dataDir: dir });
+    await expect(db.query("select 1")).rejects.toThrow("Aborted()");
+
+    expect(pgliteCreate).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+    await db.close();
+  });
+});

--- a/packages/store/src/db.ts
+++ b/packages/store/src/db.ts
@@ -1,6 +1,7 @@
 import { PGlite } from "@electric-sql/pglite";
 import { Client, Pool } from "pg";
 import fs from "node:fs";
+import { join } from "node:path";
 
 /** 02-store §1 */
 export interface StoreConfig {
@@ -37,6 +38,64 @@ function preparePgliteDir(dataDir: string): void {
   }
 }
 
+/** ENG-350 — a dev server killed uncleanly leaves postmaster.pid in the data
+    dir, and PGlite.create can then hard-abort with a raw `Aborted()`
+    (electric-sql/pglite#2, #794). PGlite's wasm postgres always records
+    Emscripten's fake pid (-42), so a non-positive or unparseable pid can never
+    belong to a live owner — stale by definition. A real positive pid (a native
+    postgres dir, or a custom writer) is only stale once that process is gone. */
+function readPgliteLock(dataDir: string): { path: string; livePid?: number } | undefined {
+  if (dataDir.startsWith("memory://")) return undefined;
+  const lockPath = join(dataDir, "postmaster.pid");
+  let firstLine: string;
+  try {
+    firstLine = fs.readFileSync(lockPath, "utf8").split("\n", 1)[0] ?? "";
+  } catch {
+    return undefined; // no lock file — nothing to heal
+  }
+  const pid = Number.parseInt(firstLine.trim(), 10);
+  if (Number.isFinite(pid) && pid > 0 && isPidAlive(pid)) return { path: lockPath, livePid: pid };
+  return { path: lockPath };
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM = exists but owned by someone else — still alive.
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+const errorMessage = (error: unknown): string => (error instanceof Error ? error.message : String(error));
+
+/** ENG-350 — self-heal a stale lock instead of hard-aborting boot. */
+async function createPgliteHealingStaleLock(dataDir: string): Promise<PGlite> {
+  try {
+    return await PGlite.create(dataDir);
+  } catch (error) {
+    const lock = readPgliteLock(dataDir);
+    if (!lock) throw error;
+    if (lock.livePid !== undefined) {
+      throw new Error(
+        `[vendo] PGlite data directory "${dataDir}" is locked by a live process (pid ${lock.livePid}) — stop that process or point dataDir elsewhere. Cause: ${errorMessage(error)}`,
+      );
+    }
+    console.warn(
+      `[vendo] PGlite data directory "${dataDir}" failed to open with a stale postmaster.pid left by an unclean shutdown — removing the stale lock and retrying.`,
+    );
+    fs.rmSync(lock.path, { force: true });
+    try {
+      return await PGlite.create(dataDir);
+    } catch (retryError) {
+      throw new Error(
+        `[vendo] PGlite data directory "${dataDir}" failed to open even after clearing its stale lock — the store is likely corrupt. Back up and delete the directory to start fresh, or set a Postgres url. Cause: ${errorMessage(retryError)}`,
+      );
+    }
+  }
+}
+
 /** 02-store §4 */
 export function createDb(config: StoreConfig = {}): Db {
   const kind = config.url ? "pg" : "pglite";
@@ -66,7 +125,7 @@ export function createDb(config: StoreConfig = {}): Db {
         );
       }
       preparePgliteDir(dataDir);
-      const pglite = await PGlite.create(dataDir);
+      const pglite = await createPgliteHealingStaleLock(dataDir);
       driver = pglite;
       return pglite;
     })();


### PR DESCRIPTION
## What

Boot no longer hard-aborts when the PGlite store at `.vendo/data` was left with a stale `postmaster.pid` by an uncleanly killed dev server. `createDb`'s open path now wraps `PGlite.create`: on failure it inspects the lock file, and

- **stale lock** (PGlite's wasm postgres always records Emscripten's fake pid `-42`, which can never name a live owner; a real positive pid is probed with `kill(pid, 0)`) → warn, remove only `postmaster.pid`, retry once;
- **live lock** (recorded positive pid is alive) → never deleted; clear error naming the pid;
- **retry also fails** → actionable corrupt-store error (back up + delete the dir, or set a Postgres `url`) instead of the raw `Aborted()`;
- **no lock file** → original error propagates untouched.

## Why

ENG-350: a dev server killed uncleanly can leave the store unrecoverable — subsequent `PGlite.create` throws a bare `Aborted()` (known PGlite failure mode, electric-sql/pglite#2, #794), and the raw abort gives the dev nothing to act on. Investigation notes: on @electric-sql/pglite 0.5.4/NODEFS, SIGKILL mid-write self-recovers via WAL replay in local repros, and PGlite has no cross-process protection at all (concurrent opens of a live dir succeed) — so removing a stale pid file after a failed create never reduces safety, and the pid-liveness guard protects the only case where the file could name a real live owner.

## Verification

- [x] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green (full suite in a space-free /tmp clone; the worktree-local durability-drill failure is the known space-in-path issue)
- [ ] Screenshots attached (if UI-affecting) — N/A, no UI surface

New regression tests in `packages/store/src/db.stale-lock.test.ts`: stale-lock heal + warn, live-lock refusal, actionable second-failure error, no-lock passthrough.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Boot now self-heals a stale PGlite `postmaster.pid` in `.vendo/data` to prevent Aborted() crashes after an unclean dev shutdown. Addresses ENG-350 by recovering automatically, warning on stale locks, and surfacing a clear error when needed.

- **Bug Fixes**
  - Detect stale vs. live lock on boot (non-positive/unparseable pid, or positive pid not alive = stale).
  - Stale: warn, delete only `postmaster.pid`, retry `PGlite.create` once.
  - Live: refuse to delete and error with the owning pid.
  - If retry fails: show actionable guidance to back up and remove the directory or set a Postgres `url` (cause included).
  - Tests added for stale-lock heal, live-lock refusal, second-failure messaging, and no-lock passthrough (`@electric-sql/pglite`).

<sup>Written for commit 82f2d82b32e6cf7ff57ccc0467f1af177aefe940. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

