### PR TITLE
fix(cli): vendo init --agent is read-only (ENG-335)

### DIFF
--- a/docs-site/reference/cli.mdx
+++ b/docs-site/reference/cli.mdx
@@ -57,6 +57,11 @@ Options:
   `model` (default `@/lib/ai` for Next.js and `./ai` for Express).
 - `--brief <text>` supplies the product brief written to `.vendo/brief.md`.
 
+Init rejects options it does not recognize and exits 1 before doing anything,
+so a flag the installed CLI does not support (for example `--agent` on an
+older version) can never be silently dropped and turn a read-only request
+into a writing init.
+
 When the host repo has a `.claude/` directory and no
 `.claude/skills/vendo-setup/SKILL.md`, init also offers (through the same
 diff consent as every code change) to install the `vendo-setup` agent skill

--- a/packages/vendo/src/cli.test.ts
+++ b/packages/vendo/src/cli.test.ts
@@ -54,6 +54,12 @@ describe("vendo CLI commands", () => {
     // (Devin review): --dry-run is still reported as unknown.
     expect(await main(["init", root, "--agent", "--brief", "--dry-run"])).toBe(1);
     expect(error.mock.calls.flat().join("\n")).toContain("--dry-run");
+
+    // And a missing value before a KNOWN flag is rejected too (Greptile P1):
+    // otherwise init proceeds — writing — with modelImport "--force".
+    expect(await main(["init", root, "--yes", "--model-import", "--force"])).toBe(1);
+    expect(error.mock.calls.flat().join("\n")).toContain("--model-import requires a value");
+    expect(await readdir(root)).toEqual([]);
     error.mockRestore();
     log.mockRestore();
   });

--- a/packages/vendo/src/cli.test.ts
+++ b/packages/vendo/src/cli.test.ts
@@ -49,6 +49,11 @@ describe("vendo CLI commands", () => {
     expect(error.mock.calls.flat().join("\n")).toContain("--dry-run");
     expect(log.mock.calls.flat().join("\n")).not.toContain('"framework"'); // init never ran
     expect(await readdir(root)).toEqual([]); // and wrote nothing
+
+    // A value option with a missing value must not swallow the next flag
+    // (Devin review): --dry-run is still reported as unknown.
+    expect(await main(["init", root, "--agent", "--brief", "--dry-run"])).toBe(1);
+    expect(error.mock.calls.flat().join("\n")).toContain("--dry-run");
     error.mockRestore();
     log.mockRestore();
   });

--- a/packages/vendo/src/cli.test.ts
+++ b/packages/vendo/src/cli.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it, vi } from "vitest";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { main } from "./cli.js";
+
+const cleanup: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
 
 describe("vendo CLI commands", () => {
   it("keeps help aligned with the four-question init and its non-interactive flags", async () => {
@@ -22,6 +31,41 @@ describe("vendo CLI commands", () => {
     expect(await main(["refresh"])).toBe(1);
     expect(await main(["telemetry", "status"])).toBe(1);
     expect(error.mock.calls.flat().join("\n")).toContain("Unknown command");
+    error.mockRestore();
+  });
+
+  // ENG-335: an init flag the CLI does not recognize must fail loudly before
+  // anything runs. The field incident was exactly this class — a CLI without
+  // --agent silently dropped the flag and ran a full, writing init, breaking
+  // the documented "agent mode writes nothing" promise.
+  it("init rejects unknown options instead of silently proceeding (ENG-335)", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const root = await mkdtemp(join(tmpdir(), "vendo-cli-init-unknown-"));
+    cleanup.push(root);
+
+    expect(await main(["init", root, "--agent", "--dry-run"])).toBe(1);
+
+    expect(error.mock.calls.flat().join("\n")).toContain("--dry-run");
+    expect(log.mock.calls.flat().join("\n")).not.toContain('"framework"'); // init never ran
+    expect(await readdir(root)).toEqual([]); // and wrote nothing
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it("init accepts every documented option, including = forms", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const root = await mkdtemp(join(tmpdir(), "vendo-cli-init-known-"));
+    cleanup.push(root);
+
+    expect(await main([
+      "init", root, "--agent", "--yes", "--force",
+      "--model-import", "@/lib/ai", "--brief=host brief",
+    ])).toBe(0);
+
+    expect(await readdir(root)).toEqual([]); // --agent stayed read-only
+    log.mockRestore();
     error.mockRestore();
   });
 

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -51,6 +51,29 @@ function options(args: string[], name: string): string[] {
   return values;
 }
 
+const INIT_FLAGS = new Set(["--agent", "--yes", "--force"]);
+const INIT_VALUE_OPTIONS = ["--model-import", "--brief"];
+
+/** ENG-335: init options the CLI does not recognize must fail loudly before
+    anything runs. Silently dropping a flag is how the "--agent writes nothing"
+    promise broke in the field — an older CLI ignored --agent and ran a full,
+    writing init. */
+function unknownInitOptions(args: string[]): string[] {
+  const unknown: string[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]!;
+    if (!arg.startsWith("--")) continue;
+    if (INIT_FLAGS.has(arg)) continue;
+    if (INIT_VALUE_OPTIONS.includes(arg)) {
+      index += 1; // skip the option's value
+      continue;
+    }
+    if (INIT_VALUE_OPTIONS.some((name) => arg.startsWith(`${name}=`))) continue;
+    unknown.push(arg);
+  }
+  return unknown;
+}
+
 function target(args: string[]): string {
   const optionValues = new Set<string>();
   for (const name of ["--model-import", "--url", "--brief", "--key", "--api-url", "--ask"]) {
@@ -74,6 +97,11 @@ export async function main(argv: string[]): Promise<number> {
   if (command === "cloud") return runCloud(args);
   if (command === "mcp") return runMcp(args);
   if (command === "init") {
+    const unknown = unknownInitOptions(args);
+    if (unknown.length > 0) {
+      console.error(`vendo init: unknown option${unknown.length > 1 ? "s" : ""}: ${unknown.join(", ")}\n\n${HELP}`);
+      return 1;
+    }
     return runInit({
       targetDir: target(args),
       agent: args.includes("--agent"),

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -54,26 +54,28 @@ function options(args: string[], name: string): string[] {
 const INIT_FLAGS = new Set(["--agent", "--yes", "--force"]);
 const INIT_VALUE_OPTIONS = ["--model-import", "--brief"];
 
-/** ENG-335: init options the CLI does not recognize must fail loudly before
-    anything runs. Silently dropping a flag is how the "--agent writes nothing"
-    promise broke in the field — an older CLI ignored --agent and ran a full,
-    writing init. */
-function unknownInitOptions(args: string[]): string[] {
-  const unknown: string[] = [];
+/** ENG-335: init options the CLI does not recognize — or value options missing
+    their value — must fail loudly before anything runs. Silently dropping a
+    flag is how the "--agent writes nothing" promise broke in the field: an
+    older CLI ignored --agent and ran a full, writing init. */
+function initOptionErrors(args: string[]): string[] {
+  const errors: string[] = [];
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index]!;
     if (!arg.startsWith("--")) continue;
     if (INIT_FLAGS.has(arg)) continue;
     if (INIT_VALUE_OPTIONS.includes(arg)) {
-      // Skip the option's value — unless it looks like another flag (a missing
-      // value), so `--brief --dry-run` still reports --dry-run as unknown.
-      if (args[index + 1] !== undefined && !args[index + 1]!.startsWith("--")) index += 1;
+      // A value that looks like another flag is a missing value, not a value —
+      // otherwise `--model-import --force` proceeds with modelImport "--force".
+      const value = args[index + 1];
+      if (value === undefined || value.startsWith("--")) errors.push(`${arg} requires a value`);
+      else index += 1;
       continue;
     }
     if (INIT_VALUE_OPTIONS.some((name) => arg.startsWith(`${name}=`))) continue;
-    unknown.push(arg);
+    errors.push(`unknown option: ${arg}`);
   }
-  return unknown;
+  return errors;
 }
 
 function target(args: string[]): string {
@@ -99,9 +101,9 @@ export async function main(argv: string[]): Promise<number> {
   if (command === "cloud") return runCloud(args);
   if (command === "mcp") return runMcp(args);
   if (command === "init") {
-    const unknown = unknownInitOptions(args);
-    if (unknown.length > 0) {
-      console.error(`vendo init: unknown option${unknown.length > 1 ? "s" : ""}: ${unknown.join(", ")}\n\n${HELP}`);
+    const problems = initOptionErrors(args);
+    if (problems.length > 0) {
+      console.error(`vendo init: ${problems.join("; ")}\n\n${HELP}`);
       return 1;
     }
     return runInit({

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -65,7 +65,9 @@ function unknownInitOptions(args: string[]): string[] {
     if (!arg.startsWith("--")) continue;
     if (INIT_FLAGS.has(arg)) continue;
     if (INIT_VALUE_OPTIONS.includes(arg)) {
-      index += 1; // skip the option's value
+      // Skip the option's value — unless it looks like another flag (a missing
+      // value), so `--brief --dry-run` still reports --dry-run as unknown.
+      if (args[index + 1] !== undefined && !args[index + 1]!.startsWith("--")) index += 1;
       continue;
     }
     if (INIT_VALUE_OPTIONS.some((name) => arg.startsWith(`${name}=`))) continue;

--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -689,6 +689,48 @@ describe("vendo init", () => {
     });
   });
 
+  // ENG-335: the documented promise is that --agent writes NOTHING into the
+  // target — not `.vendo/`, not scaffolds, not sync hooks. Exercise every
+  // write-adjacent path at once (extraction, pin capture for an already
+  // remixable slot, catalog scan, skill offer, package.json hooks, layout
+  // wiring) and require the tree byte-identical.
+  it("agent mode writes nothing on the richest plan path (ENG-335)", async () => {
+    const root = await fixture();
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      name: "host",
+      scripts: { dev: "next dev", build: "next build" },
+      dependencies: { next: "16.0.0", "@vendoai/vendo": "0.3.0" },
+    }));
+    await writeFile(join(root, "openapi.json"), JSON.stringify({
+      openapi: "3.1.0",
+      info: { title: "Host", version: "1.0.0" },
+      paths: { "/api/invoices/{id}": { delete: { summary: "Delete an invoice" } } },
+    }));
+    await writeFile(join(root, "app", "card.tsx"),
+      "export function HostCard() { return <div>host card</div>; }\n");
+    await writeFile(join(root, "app", "vendo-components.ts"),
+      "import { HostCard } from \"./card\";\n" +
+      "export const components = [\n" +
+      "  { remixable: true, name: \"HostCard\", component: HostCard, description: \"A host card\" },\n" +
+      "  { name: \"HostBadge\", component: HostCard, description: \"A host badge\" },\n" +
+      "];\n");
+    await mkdir(join(root, ".claude"), { recursive: true });
+    const before = await tree(root);
+    const sink = output();
+
+    expect(await runInit({ targetDir: root, agent: true, output: sink.output })).toBe(0);
+
+    expect(await tree(root)).toEqual(before);
+    // tree() cannot see empty directories — assert .vendo was never created.
+    expect(await readdir(root)).not.toContain(".vendo");
+    const plan = JSON.parse(sink.logs.join("\n")) as {
+      extraction: { tools: Array<{ name: string }> };
+      codeChanges: Array<{ path: string }>;
+    };
+    expect(plan.extraction.tools.length).toBeGreaterThan(0); // the plan still reports
+    expect(plan.codeChanges.length).toBeGreaterThan(0);
+  });
+
   it("agent-plan recommendations respect existing overrides", async () => {
     const root = await fixture();
     await writeFile(join(root, "openapi.json"), JSON.stringify({


### PR DESCRIPTION
## Root cause

ENG-268 (customer-style init on the Umami fork) reported that `vendo init --agent` wrote `.vendo` artifacts despite the docs promising agent mode writes nothing.

Investigation shows the **current agent path is already read-only**, and was at every commit the fork ever vendored:

- Ran `vendo init --agent` from current main against the actual `runvendo/umami` fork (pristine, `.vendo` removed) — tree byte-identical before/after.
- Ran the fork's exact vendored `@vendoai/vendo@0.3.0` tarball bits (built from `4bfb7249`) the same way — no writes.
- Traced every write in the agent path: `buildPlan` is pure reads; `extractForPlan` runs `vendoSync({ root, out: mkdtemp(os.tmpdir()) })`, and `vendoSync`/`capturePins`/`writeCatalog` write only under `out`.

The field writes came from the **stale public npm CLI**: `vendoai@0.1.0` (still `latest` on the public registry) delegates via npx to `@vendoai/cli@0.1.0`, whose `parseInitArgs` **silently drops unknown flags** — so `init --agent` there ran a full, writing init (`.vendo/theme.json` etc.). The fork's RUNBOOK confirms the public packages were tried first ("The public npm packages were not usable for this integration"), and the fork worktree's `.vendo/theme.json` birth timestamp (14:46, thirteen minutes before the real vendored init at 14:59) matches that first attempt.

So the docs are right and current behavior is right — the bug is the *incident class*: an init flag the installed CLI doesn't know must never silently turn a read-only request into a writing init.

## Fix

- `vendo init` now rejects unrecognized options and exits 1 **before running anything** (`unknownInitOptions` in `packages/vendo/src/cli.ts`). Documented options (`--agent`, `--yes`, `--force`, `--model-import`, `--brief`, incl. `=` forms) are unaffected; corpus harness and docs use only known flags.
- One line added to `docs-site/reference/cli.mdx` documenting the rejection. No change to the "writes nothing" wording — it is accurate.

## Tests (written first, TDD)

- `cli.test.ts`: `init <dir> --agent --dry-run` exits 1, names the offending flag, never runs init, writes nothing (failed before the fix); every documented option still accepted with `--agent` staying read-only.
- `init.test.ts`: new richest-path no-write regression for `--agent` — extraction (openapi), pin capture (already-remixable slot), catalog scan, `.claude` skill offer, package.json sync hooks, and layout wiring all exercised at once; asserts the tree byte-identical and `.vendo` never created (tree diff can't see empty dirs).

## Verification

- `pnpm build && pnpm test && pnpm typecheck && pnpm lint` all green (335/335 vendo tests, 41/41 turbo test tasks).
- Built CLI re-run against the real Umami fork: `init . --agent` exits 0 with the full plan and zero tree changes; `init . --agent --dry-run` exits 1 without running.

## Follow-up (out of scope, worth filing)

The public registry still serves `vendoai@0.1.0` / `@vendoai/cli@0.1.0` as `latest` — anyone running `npx vendoai init --agent` today gets the old writing CLI. Deprecating those versions (or unblocking the v0.3.1 publish) closes the remaining exposure.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`vendo init` now validates options up front and exits on unknown or malformed flags, so `--agent` stays read‑only and never degrades into a writing init. Resolves ENG-335.

- **Bug Fixes**
  - Reject unrecognized `init` options and value options missing their value; exit 1 before running. Accepts `--agent`, `--yes`, `--force`, `--model-import`, `--brief` (including `=` forms). Missing values no longer swallow the next flag (e.g., `--brief --dry-run` correctly reports `--dry-run`).
  - Added regression tests for unknown/missing-option rejection and that `--agent` stays write-free on the richest path; updated `docs-site/reference/cli.mdx` to document the rejection behavior.

<sup>Written for commit a4afa8279b86303f2df53624bd8dd1d39438b795. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

