### PR TITLE
fix(apps): stop misrouting UI asks containing server keywords (ENG-349)

### DIFF
--- a/packages/apps/src/agent-tools.test.ts
+++ b/packages/apps/src/agent-tools.test.ts
@@ -101,6 +101,18 @@ describe("apps agent tools", () => {
       tool: "vendo_apps_edit",
       args: { appId: created.id, instruction: "Persist this to the database" },
     }, ctx)).resolves.toBe("write");
+    // ENG-349: a server keyword used as a visible-element label is still a tree edit,
+    // while the same word in an action context stays write-class.
+    await expect(runtime.agentToolRisk({
+      id: "call_labeled_edit",
+      tool: "vendo_apps_edit",
+      args: { appId: created.id, instruction: "Make the API status card blue" },
+    }, ctx)).resolves.toBe("read");
+    await expect(runtime.agentToolRisk({
+      id: "call_api_edit",
+      tool: "vendo_apps_edit",
+      args: { appId: created.id, instruction: "Call the api and store the results" },
+    }, ctx)).resolves.toBe("write");
 
     await expect(runtime.agentToolRisk({
       id: "call_missing_edit",

--- a/packages/apps/src/engine.test.ts
+++ b/packages/apps/src/engine.test.ts
@@ -18,7 +18,7 @@ import {
   scriptedLanguageModel,
   type ScriptedModelCall,
 } from "./testing/index.js";
-import { modelEngine } from "./engine.js";
+import { instructionRequiresServer, modelEngine } from "./engine.js";
 
 const ctx: RunContext = {
   principal: { kind: "user", subject: "user_engine" },
@@ -855,6 +855,30 @@ describe("generation engine through createApps", () => {
     expect(result.app.tree).toEqual(original.tree);
   });
 
+  it("routes a UI ask that mentions the API to the tree dialect (ENG-349)", async () => {
+    // "API" and "function" are SERVER_INSTRUCTION words, but here they label
+    // visible elements; before the routing fix this edit took the code dialect
+    // and failed slowly (here: sandbox-unavailable, since no sandbox is wired).
+    const store = memoryStore();
+    const runtime = createApps({
+      store,
+      guard: guardFixture(),
+      tools,
+      catalog,
+      model: scriptedLanguageModel(
+        validCreate(),
+        JSON.stringify({ ops: [{ op: "set-prop", nodeId: "metric", prop: "label", value: "API status" }] }),
+      ),
+    });
+    const original = await runtime.create({ prompt: "Dashboard" }, ctx);
+
+    const result = await runtime.edit(original.id, "Make the API status card blue", ctx);
+
+    expect(result.issues).toBeUndefined();
+    expect(result.version.rung).toBe(1);
+    expect(result.app.tree).toMatchObject({ nodes: [{ props: { label: "API status" } }] });
+  });
+
   it("keeps the first graduated version on the scaffold and repairs reserved-file edits", async () => {
     const sandbox = fakeSandbox();
     const store = memoryStore();
@@ -1094,5 +1118,41 @@ describe("generation engine through createApps", () => {
     expect(result.app).toEqual(original);
     expect(result.issues).toContain("sandbox-unavailable: this edit requires server execution");
     expect(await runtime.history(original.id).list()).toEqual([]);
+  });
+});
+
+describe("instructionRequiresServer (ENG-349)", () => {
+  const app = (ui?: "tree" | "http"): AppDocument => ({
+    format: "vendo/app@1",
+    id: "app_router",
+    name: "Router fixture",
+    ...(ui === undefined ? {} : { ui }),
+  });
+
+  it.each([
+    "Make the API status card blue",
+    "Rename the function list header",
+    "Move the HTTP status badge next to the title",
+    "Update the External vendors table caption",
+    "Make the secret santa list festive",
+  ])("routes the UI ask %j to the tree dialect", (instruction) => {
+    expect(instructionRequiresServer(app(), instruction)).toBe(false);
+  });
+
+  it.each([
+    "Add a server function that calls the api and stores results",
+    "Call the external api and cache the results",
+    "Add a function that fetches live prices",
+    "Use my secret key to authenticate the request",
+    "Persist mutations in server state",
+    "Make the api card blue and call the api for fresh data",
+    "Make this a custom client over the data",
+    "Turn this into a full web app",
+  ])("routes the server ask %j to the code dialect", (instruction) => {
+    expect(instructionRequiresServer(app(), instruction)).toBe(true);
+  });
+
+  it("always routes an http app to the code dialect", () => {
+    expect(instructionRequiresServer(app("http"), "Make the heading blue")).toBe(true);
   });
 });

--- a/packages/apps/src/engine.ts
+++ b/packages/apps/src/engine.ts
@@ -67,7 +67,11 @@ export interface GenerationEngine {
 
 const PASCAL_CASE = /^[A-Z][A-Za-z0-9]*$/;
 const SAFE_MACHINE_PATH = /^\/app\/[A-Za-z0-9._/-]+$/;
-const SERVER_INSTRUCTION = /\b(server|server-side|backend|api|database|persist|mutation|mutate|external|http|web app|function|secret|egress)\b/i;
+const SERVER_INSTRUCTION = /\b(server|server-side|backend|database|persist|mutation|mutate|egress)\b/i;
+// Words that signal server work only outside a visible-element label: "call the
+// api" needs code, "the API status card" is a tree edit (ENG-349).
+const AMBIGUOUS_SERVER_TERM = /\b(api|http|web app|function|external|secret)\b/gi;
+const VISIBLE_ELEMENT_LABEL = /^(?:\w+\s+)?(card|button|badge|chip|header|heading|title|label|caption|text|list|table|column|row|cell|section|panel|chart|graph|icon|field|tab|menu|toolbar|sidebar|footer|banner|tile|widget)s?\b/i;
 const SERVER_COMPUTED_INSTRUCTION = /\b(server-computed|computed (?:view|tree)|render(?:ed)? on the server)\b/i;
 const FULL_WEB_APP_INSTRUCTION = /\b(full web app|served web app|custom client|ui:? ?http)\b/i;
 const reserved = new Set<string>(RESERVED_COMPONENT_NAMES);
@@ -803,11 +807,16 @@ export const modelEngine: GenerationEngine = {
  * Every rung-4 phrase `codePlanFrom` recognizes must route here too, or a
  * graduation request (e.g. "custom client") would take the tree dialect and
  * never reach the scaffold (Greptile, PR #243).
+ * Ambiguous words like "api" or "function" count only when they are not
+ * labeling a visible element — "make the API status card blue" must stay on
+ * the cheap tree dialect instead of failing slowly through code (ENG-349).
  */
 export const instructionRequiresServer = (app: AppDocument, instruction: string): boolean =>
   SERVER_INSTRUCTION.test(instruction)
   || FULL_WEB_APP_INSTRUCTION.test(instruction)
-  || app.ui === "http";
+  || app.ui === "http"
+  || [...instruction.matchAll(AMBIGUOUS_SERVER_TERM)].some((match) =>
+    !VISIBLE_ELEMENT_LABEL.test(instruction.slice(match.index + match[0].length).trimStart()));
 
 /** 01-core §8 — generated component naming check exported for focused engine tests. */
 export const isGeneratedComponentName = (name: string): boolean =>


### PR DESCRIPTION
## Root cause

`instructionRequiresServer` (the edit-dialect router in the apps engine, `packages/apps/src/engine.ts`) used a single bare-keyword regex. Words like `api`, `function`, `http`, `external`, `secret` matched even when they merely labeled a visible element, so a UI-only ask like "make the API status card blue" or "rename the function list header" was misrouted to the code/server dialect — a slow failure (sandbox spin-up, code-plan validation) for an edit the tree dialect handles instantly. Found during ENG-288 M6 (PR #283).

## Fix

Tightened the heuristic — kept it deterministic, no new model call:

- **Unambiguous server terms** (`server`, `backend`, `database`, `persist`, `mutation`, `mutate`, `egress`) still route to code on their own.
- **Ambiguous terms** (`api`, `http`, `web app`, `function`, `external`, `secret`) now count only when they are *not* labeling a visible element: an occurrence immediately followed (within one word) by a UI element noun (`card`, `header`, `list`, `badge`, `table`, ...) is treated as a label, per occurrence. "Call the api and store the results" still routes to code; "make the API status card blue" routes to tree. A mixed ask ("make the api card blue and call the api for fresh data") routes to code.
- Rung-4 graduation phrases (`custom client`, `full web app`, ...) and `ui: "http"` apps route to code unchanged, preserving the PR #243 invariant.

`agentToolRisk` (read vs write classification for `vendo_apps_edit`) shares the router, so label-only asks are now read-class; the existing runtime guard still hard-stops any tree-classified edit that unexpectedly emits server code. No public API change; edit dialects stay engine internals per docs/contracts/06-apps.md §2.

## Tests (written first, TDD)

- `engine.test.ts`: focused `instructionRequiresServer` table — 5 UI asks containing trigger words route to tree, 8 genuine server/graduation asks route to code, http app always code.
- `engine.test.ts`: runtime-level regression — "Make the API status card blue" takes the tree dialect (rung 1) with no sandbox wired; before the fix it failed with `sandbox-unavailable`.
- `agent-tools.test.ts`: label-only ask is read-class, action-context api ask stays write-class.

## Gates

`pnpm build` / `pnpm typecheck` / `pnpm lint` green. `pnpm test`: `@vendoai/apps` fully green; one unrelated load-induced timeout flake in `@vendoai/vendo` `server.test.ts` ("routes every contracted method and path", 30s timeout under 57 parallel vitest workers) — passes 51/51 in isolation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops routing UI-only edits that mention server words to the code dialect in `@vendoai/apps` by tightening `instructionRequiresServer`. UI asks like “Make the API status card blue” now use the tree dialect, addressing ENG-349.

- **Bug Fixes**
  - Split routing terms: unambiguous server words still route to code; ambiguous terms (`api`, `http`, `web app`, `function`, `external`, `secret`) only count when not labeling a visible UI element (e.g., `card`, `header`, `list`).
  - Preserved invariants: rung-4 graduation phrases and `ui: "http"` apps still route to code.
  - Added regressions in `engine.test.ts` and `agent-tools.test.ts`; `vendo_apps_edit` treats label-only asks as read, action-context API asks remain write.

<sup>Written for commit ecf5230896145847814e7aa0e6118eb7a6b9c5ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

