### PR TITLE
fix(apps): named-export remixable components (ENG-348)

### DIFF
--- a/packages/apps/src/engine.test.ts
+++ b/packages/apps/src/engine.test.ts
@@ -430,6 +430,93 @@ describe("generation engine through createApps", () => {
     expect(trails).toHaveLength(2);
   });
 
+  it("forks a named-export host slot with a synthesized default export (ENG-348)", async () => {
+    const store = memoryStore();
+    const source = `export function MapleNetWorthCard() {
+  return <section><h2>Net worth</h2><strong>$1.2M</strong></section>;
+}`;
+    const slot = "net-worth-card";
+    const componentName = pinComponentName(slot);
+    const runtime = createApps({
+      store,
+      guard: guardFixture(),
+      tools,
+      catalog,
+      model: scriptedLanguageModel(JSON.stringify({
+        ops: [{ op: "fork-pin", slot, nodeId: "maple-net-worth", parentId: "root" }],
+      })),
+      pinBaselines: [{
+        slot,
+        source,
+        hash: "sha256:maple-base",
+        exportable: false,
+        capturedAt: "2026-07-14T12:00:00.000Z",
+      }],
+    });
+    const original: AppDocument = {
+      format: "vendo/app@1",
+      id: "app_maple_named_pin",
+      name: "Maple overview",
+      ui: "tree",
+      tree: {
+        formatVersion: "vendo-genui/v1",
+        root: "root",
+        nodes: [{ id: "root", component: "Stack", source: "prewired" }],
+      },
+    };
+    await putApp(store, original);
+
+    const forked = await runtime.edit(original.id, "Remix the net worth card", ctx);
+    expect(forked.issues).toBeUndefined();
+    expect(forked.app.pins).toEqual([{ slot, base: "sha256:maple-base" }]);
+    // The jail entry renders only a default export; the fork ships the captured
+    // source plus the synthesized alias so the remix never crashes at render.
+    expect(forked.app.components?.[componentName])
+      .toBe(`${source}\nexport { MapleNetWorthCard as default };\n`);
+  });
+
+  it("refuses to fork a baseline with no detectable component export, loudly", async () => {
+    const store = memoryStore();
+    const slot = "net-worth-card";
+    const forkOps = JSON.stringify({
+      ops: [{ op: "fork-pin", slot, nodeId: "maple-net-worth", parentId: "root" }],
+    });
+    const runtime = createApps({
+      store,
+      guard: guardFixture(),
+      tools,
+      catalog,
+      model: scriptedLanguageModel(forkOps, forkOps),
+      pinBaselines: [{
+        slot,
+        source: "const NetWorthCard = () => null;",
+        hash: "sha256:maple-base",
+        exportable: false,
+        capturedAt: "2026-07-14T12:00:00.000Z",
+      }],
+    });
+    const original: AppDocument = {
+      format: "vendo/app@1",
+      id: "app_maple_unexported_pin",
+      name: "Maple overview",
+      ui: "tree",
+      tree: {
+        formatVersion: "vendo-genui/v1",
+        root: "root",
+        nodes: [{ id: "root", component: "Stack", source: "prewired" }],
+      },
+    };
+    await putApp(store, original);
+
+    const result = await runtime.edit(original.id, "Remix the net worth card", ctx);
+    expect(result.app).toEqual(original);
+    expect(result.issues).toEqual(expect.arrayContaining([
+      expect.stringContaining("no default export"),
+    ]));
+    // The unrenderable fork was refused at fork time, never persisted.
+    expect(await runtime.get(original.id, ctx)).toEqual(original);
+  });
+
   it("contains twice-broken tree ops and leaves the original document untouched", async () => {
     const store = memoryStore();
     const brokenOps = JSON.stringify({

--- a/packages/apps/src/engine.ts
+++ b/packages/apps/src/engine.ts
@@ -25,7 +25,7 @@ import {
   parseModelJson,
   type IncrementalGeneratedTree,
 } from "./incremental-tree.js";
-import { pinComponentName, type PinBaseline } from "./pins.js";
+import { hasDefaultExport, pinComponentName, pinForkSource, type PinBaseline } from "./pins.js";
 
 export interface GenerationDependencies {
   model: LanguageModel;
@@ -567,6 +567,14 @@ const applyTreeOps = (
         if (app.pins?.some(({ slot }) => slot === baseline.slot)) {
           return issue(index, operation, `pin slot "${baseline.slot}" is already forked`);
         }
+        // ENG-348 — a named-export capture forks with a synthesized default
+        // export (the jail entry renders only a default export). No detectable
+        // component export means the fork could never render: fail loudly here
+        // instead of crashing at render.
+        const forkSource = pinForkSource(baseline.source);
+        if (!hasDefaultExport(forkSource)) {
+          return issue(index, operation, `pin baseline "${baseline.slot}" has no default export and no detectable named component export; export the component from its module and re-run vendo sync`);
+        }
         const componentName = pinComponentName(baseline.slot);
         if (app.components?.[componentName] !== undefined) {
           return issue(index, operation, `generated component "${componentName}" already exists`);
@@ -588,7 +596,7 @@ const applyTreeOps = (
         };
         tree.nodes.push(node);
         insertChild(parent, node.id, operation.index);
-        app.components = { ...(app.components ?? {}), [componentName]: baseline.source };
+        app.components = { ...(app.components ?? {}), [componentName]: forkSource };
         app.pins = [...(app.pins ?? []), { slot: baseline.slot, base: baseline.hash }];
         break;
       }

--- a/packages/apps/src/pins.test.ts
+++ b/packages/apps/src/pins.test.ts
@@ -60,6 +60,8 @@ describe("pinForkSource", () => {
     expect(pinForkSource(inline)).toContain("export { InvoiceCard as default };");
     const statement = "export function InvoiceCard() { return null; }\nexport type { Props as default };";
     expect(pinForkSource(statement)).toContain("export { InvoiceCard as default };");
+    const declared = "export default interface Props { label: string }\nexport function InvoiceCard() { return null; }";
+    expect(pinForkSource(declared)).toContain("export { InvoiceCard as default };");
   });
 
   it("does not mistake a renamed default re-export for a default export", () => {

--- a/packages/apps/src/pins.test.ts
+++ b/packages/apps/src/pins.test.ts
@@ -55,6 +55,13 @@ describe("pinForkSource", () => {
     expect(pinForkSource(reExported)).toBe(reExported);
   });
 
+  it("ignores type-only default exports, which are erased at runtime", () => {
+    const inline = "export function InvoiceCard() { return null; }\nexport { type Props as default };";
+    expect(pinForkSource(inline)).toContain("export { InvoiceCard as default };");
+    const statement = "export function InvoiceCard() { return null; }\nexport type { Props as default };";
+    expect(pinForkSource(statement)).toContain("export { InvoiceCard as default };");
+  });
+
   it("does not mistake a renamed default re-export for a default export", () => {
     // `export { default as InvoiceCard } from …` exposes only the NAMED
     // binding; there is no local binding to alias either, so the source passes

--- a/packages/apps/src/pins.test.ts
+++ b/packages/apps/src/pins.test.ts
@@ -9,6 +9,7 @@ import {
   pinShipRequestSchema,
   type PinBaseline,
 } from "./index.js";
+import { pinForkSource } from "./pins.js";
 
 const capturedAt = "2026-07-11T12:00:00.000Z";
 
@@ -42,6 +43,47 @@ describe("pin contract shapes", () => {
     })).toMatchObject({ versionHash: "sha256:z" });
   });
 
+});
+
+describe("pinForkSource", () => {
+  it("keeps a source with a default export verbatim", () => {
+    const declared = "export default function Card() { return null; }";
+    expect(pinForkSource(declared)).toBe(declared);
+    const aliased = "function Card() { return null; }\nexport { Card as default };";
+    expect(pinForkSource(aliased)).toBe(aliased);
+    const reExported = "export { default } from \"./card\";";
+    expect(pinForkSource(reExported)).toBe(reExported);
+  });
+
+  it("synthesizes a default export for a named function export (ENG-348)", () => {
+    const source = "export function InvoiceCard() { return <b>invoices</b>; }";
+    expect(pinForkSource(source)).toBe(`${source}\nexport { InvoiceCard as default };\n`);
+  });
+
+  it("synthesizes a default export for a named const export", () => {
+    const source = "export const InvoiceCard = () => <b>invoices</b>;";
+    expect(pinForkSource(source)).toBe(`${source}\nexport { InvoiceCard as default };\n`);
+  });
+
+  it("picks the component-cased export over helper exports", () => {
+    const source = [
+      "export const useInvoiceTotals = () => 0;",
+      "export function InvoiceCard() { return null; }",
+    ].join("\n");
+    expect(pinForkSource(source)).toContain("export { InvoiceCard as default };");
+  });
+
+  it("aliases an export-list component back to its local binding", () => {
+    const source = "function Internal() { return null; }\nexport { Internal as InvoiceCard };";
+    expect(pinForkSource(source)).toContain("export { Internal as default };");
+  });
+
+  it("leaves a source with no detectable component export unchanged", () => {
+    const local = "const Card = () => null;";
+    expect(pinForkSource(local)).toBe(local);
+    const lowercase = "export const helpers = { format: (value: number) => value };";
+    expect(pinForkSource(lowercase)).toBe(lowercase);
+  });
 });
 
 describe("detectPinDrift", () => {

--- a/packages/apps/src/pins.test.ts
+++ b/packages/apps/src/pins.test.ts
@@ -55,6 +55,19 @@ describe("pinForkSource", () => {
     expect(pinForkSource(reExported)).toBe(reExported);
   });
 
+  it("ignores commented-out and quoted default exports", () => {
+    const commented = "// export default function Old() {}\nexport function InvoiceCard() { return null; }";
+    expect(pinForkSource(commented)).toBe(`${commented}\nexport { InvoiceCard as default };\n`);
+    const block = "/* export default Old */\nexport function InvoiceCard() { return null; }";
+    expect(pinForkSource(block)).toContain("export { InvoiceCard as default };");
+    // A commented-out export is never the alias target either.
+    const staleExport = "// export function OldCard() {}\nexport function InvoiceCard() { return null; }";
+    expect(pinForkSource(staleExport)).toContain("export { InvoiceCard as default };");
+    // A quoted phrase neither adds nor masks a real default export.
+    const quoted = "const hint = \"export default\";\nexport function InvoiceCard() { return null; }\nexport default InvoiceCard;";
+    expect(pinForkSource(quoted)).toBe(quoted);
+  });
+
   it("ignores type-only default exports, which are erased at runtime", () => {
     const inline = "export function InvoiceCard() { return null; }\nexport { type Props as default };";
     expect(pinForkSource(inline)).toContain("export { InvoiceCard as default };");

--- a/packages/apps/src/pins.test.ts
+++ b/packages/apps/src/pins.test.ts
@@ -55,6 +55,14 @@ describe("pinForkSource", () => {
     expect(pinForkSource(reExported)).toBe(reExported);
   });
 
+  it("does not mistake a renamed default re-export for a default export", () => {
+    // `export { default as InvoiceCard } from …` exposes only the NAMED
+    // binding; there is no local binding to alias either, so the source passes
+    // through unchanged and fork-pin refuses it loudly.
+    const renamed = "export { default as InvoiceCard } from \"./InvoiceCard\";";
+    expect(pinForkSource(renamed)).toBe(renamed);
+  });
+
   it("synthesizes a default export for a named function export (ENG-348)", () => {
     const source = "export function InvoiceCard() { return <b>invoices</b>; }";
     expect(pinForkSource(source)).toBe(`${source}\nexport { InvoiceCard as default };\n`);

--- a/packages/apps/src/pins.ts
+++ b/packages/apps/src/pins.ts
@@ -79,7 +79,10 @@ export const hasDefaultExport = (source: string): boolean => {
   if (/\bexport\s+default\b/u.test(source)) return true;
   for (const match of source.matchAll(EXPORT_LIST)) {
     for (const entry of match[1]!.split(",")) {
-      const [local, exported] = entry.trim().split(/\s+as\s+/u).map((part) => part.trim());
+      const trimmed = entry.trim();
+      // A `type` entry is erased from the emitted JavaScript — no runtime default.
+      if (/^type\s/u.test(trimmed)) continue;
+      const [local, exported] = trimmed.split(/\s+as\s+/u).map((part) => part.trim());
       if ((exported ?? local) === "default") return true;
     }
   }

--- a/packages/apps/src/pins.ts
+++ b/packages/apps/src/pins.ts
@@ -69,6 +69,48 @@ export const pinComponentName = (slot: string): string => {
   return `Pinned${stem}${sha256Hex(slot).slice(0, 8)}`;
 };
 
+/** Matches a default export in any spelling: `export default …`,
+    `export { X as default }`, `export { default } from …`. */
+const DEFAULT_EXPORT = /\bexport\s+default\b|\bexport\s*\{[^}]*\bdefault\b[^}]*\}/u;
+
+/** Whether the fork entry source exposes the default export the jail renders. */
+export const hasDefaultExport = (source: string): boolean => DEFAULT_EXPORT.test(source);
+
+/** Every named-export binding: the local name to alias plus the exported name. */
+const namedExportBindings = (source: string): Array<{ local: string; exported: string; at: number }> => {
+  const bindings: Array<{ local: string; exported: string; at: number }> = [];
+  const declaration = /\bexport\s+(?:async\s+)?(?:function\s*\*?|const|let|var|class)\s+([A-Za-z_$][\w$]*)/gu;
+  for (const match of source.matchAll(declaration)) {
+    bindings.push({ local: match[1]!, exported: match[1]!, at: match.index ?? 0 });
+  }
+  // Local export lists only — a `from` re-export has no local binding to alias.
+  const list = /\bexport\s*\{([^}]*)\}(?!\s*from\b)/gu;
+  for (const match of source.matchAll(list)) {
+    for (const entry of match[1]!.split(",")) {
+      const [local, exported] = entry.trim().split(/\s+as\s+/u).map((part) => part.trim());
+      if (!local || !/^[A-Za-z_$][\w$]*$/u.test(local)) continue;
+      bindings.push({ local, exported: exported ?? local, at: match.index ?? 0 });
+    }
+  }
+  return bindings.sort((left, right) => left.at - right.at);
+};
+
+/**
+ * ENG-348 — the generated-component entry source a fork ships. The jail entry
+ * renders only a default export, but a host may register a NAMED export as
+ * remixable and sync captures its module verbatim; forking that capture as-is
+ * crashes at render ("must have a React default export"). Synthesize the
+ * default export by aliasing the captured component's named export. A source
+ * that already has a default export — or offers no component-cased export to
+ * alias — passes through verbatim.
+ */
+export const pinForkSource = (source: string): string => {
+  if (hasDefaultExport(source)) return source;
+  const component = namedExportBindings(source).find(({ exported }) => /^[A-Z]/u.test(exported));
+  if (component === undefined) return source;
+  return `${source}\nexport { ${component.local} as default };\n`;
+};
+
 /** 06-apps §8 — unified source diff proposed for host approval. */
 export interface PinShipRequest {
   appId: AppId;

--- a/packages/apps/src/pins.ts
+++ b/packages/apps/src/pins.ts
@@ -76,7 +76,9 @@ const EXPORT_LIST = /\bexport\s*\{([^}]*)\}/gu;
     — but NOT a renamed re-export like `export { default as X } from …`, which
     exposes only the named binding. */
 export const hasDefaultExport = (source: string): boolean => {
-  if (/\bexport\s+default\b/u.test(source)) return true;
+  // `export default interface …` (and any type-level default) is erased from
+  // the emitted JavaScript, so it is not a runtime default export.
+  if (/\bexport\s+default\b(?!\s+(?:interface|type)\b)/u.test(source)) return true;
   for (const match of source.matchAll(EXPORT_LIST)) {
     for (const entry of match[1]!.split(",")) {
       const trimmed = entry.trim();

--- a/packages/apps/src/pins.ts
+++ b/packages/apps/src/pins.ts
@@ -69,13 +69,75 @@ export const pinComponentName = (slot: string): string => {
   return `Pinned${stem}${sha256Hex(slot).slice(0, 8)}`;
 };
 
+/**
+ * Blank comment and string/template contents (length-preserving) so export
+ * detection never matches commented-out or quoted code. Adapted from sync's
+ * `stripComments` (packages/actions/src/sync/common.ts — actions may not be
+ * imported here), extended to blank string contents too.
+ */
+const blankCommentsAndStrings = (source: string): string => {
+  let output = "";
+  let quote: "'" | "\"" | "`" | null = null;
+  let escaped = false;
+  for (let index = 0; index < source.length; index += 1) {
+    const character = source[index]!;
+    const next = source[index + 1];
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+        output += " ";
+        continue;
+      }
+      if (character === "\\") {
+        escaped = true;
+        output += " ";
+        continue;
+      }
+      if (character === quote) {
+        quote = null;
+        output += character;
+        continue;
+      }
+      output += character === "\n" ? "\n" : " ";
+      continue;
+    }
+    if (character === "'" || character === "\"" || character === "`") {
+      quote = character;
+      output += character;
+      continue;
+    }
+    if (character === "/" && next === "/") {
+      while (index < source.length && source[index] !== "\n") {
+        output += " ";
+        index += 1;
+      }
+      if (index < source.length) output += "\n";
+      continue;
+    }
+    if (character === "/" && next === "*") {
+      output += "  ";
+      index += 2;
+      while (index < source.length && !(source[index] === "*" && source[index + 1] === "/")) {
+        output += source[index] === "\n" ? "\n" : " ";
+        index += 1;
+      }
+      if (index < source.length) output += "  ";
+      index += 1;
+      continue;
+    }
+    output += character;
+  }
+  return output;
+};
+
 const EXPORT_LIST = /\bexport\s*\{([^}]*)\}/gu;
 
 /** Whether the fork entry source exposes the default export the jail renders:
     `export default …`, `export { X as default }`, or `export { default } from …`
     — but NOT a renamed re-export like `export { default as X } from …`, which
     exposes only the named binding. */
-export const hasDefaultExport = (source: string): boolean => {
+export const hasDefaultExport = (rawSource: string): boolean => {
+  const source = blankCommentsAndStrings(rawSource);
   // `export default interface …` (and any type-level default) is erased from
   // the emitted JavaScript, so it is not a runtime default export.
   if (/\bexport\s+default\b(?!\s+(?:interface|type)\b)/u.test(source)) return true;
@@ -121,7 +183,8 @@ const namedExportBindings = (source: string): Array<{ local: string; exported: s
  */
 export const pinForkSource = (source: string): string => {
   if (hasDefaultExport(source)) return source;
-  const component = namedExportBindings(source).find(({ exported }) => /^[A-Z]/u.test(exported));
+  const component = namedExportBindings(blankCommentsAndStrings(source))
+    .find(({ exported }) => /^[A-Z]/u.test(exported));
   if (component === undefined) return source;
   return `${source}\nexport { ${component.local} as default };\n`;
 };

--- a/packages/apps/src/pins.ts
+++ b/packages/apps/src/pins.ts
@@ -69,12 +69,22 @@ export const pinComponentName = (slot: string): string => {
   return `Pinned${stem}${sha256Hex(slot).slice(0, 8)}`;
 };
 
-/** Matches a default export in any spelling: `export default …`,
-    `export { X as default }`, `export { default } from …`. */
-const DEFAULT_EXPORT = /\bexport\s+default\b|\bexport\s*\{[^}]*\bdefault\b[^}]*\}/u;
+const EXPORT_LIST = /\bexport\s*\{([^}]*)\}/gu;
 
-/** Whether the fork entry source exposes the default export the jail renders. */
-export const hasDefaultExport = (source: string): boolean => DEFAULT_EXPORT.test(source);
+/** Whether the fork entry source exposes the default export the jail renders:
+    `export default …`, `export { X as default }`, or `export { default } from …`
+    — but NOT a renamed re-export like `export { default as X } from …`, which
+    exposes only the named binding. */
+export const hasDefaultExport = (source: string): boolean => {
+  if (/\bexport\s+default\b/u.test(source)) return true;
+  for (const match of source.matchAll(EXPORT_LIST)) {
+    for (const entry of match[1]!.split(",")) {
+      const [local, exported] = entry.trim().split(/\s+as\s+/u).map((part) => part.trim());
+      if ((exported ?? local) === "default") return true;
+    }
+  }
+  return false;
+};
 
 /** Every named-export binding: the local name to alias plus the exported name. */
 const namedExportBindings = (source: string): Array<{ local: string; exported: string; at: number }> => {

--- a/packages/apps/src/rebase.test.ts
+++ b/packages/apps/src/rebase.test.ts
@@ -253,6 +253,39 @@ describe("06-apps §8 — pin rebase via intent replay", () => {
     await expect(runtime.pins.drift(app.id, ctx)).resolves.toEqual([]);
   });
 
+  it("re-forks a host update that switched to a named export with a synthesized default export (ENG-348)", async () => {
+    const store = memoryStore();
+    const app = seedDoc("app_named_rebase");
+    await seedAppRow(store, app, ctx.principal.subject);
+    const original = createApps({
+      store,
+      guard: guardFixture(),
+      tools,
+      catalog: [],
+      model: scriptedLanguageModel(forkOps),
+      pinBaselines: [baseline(OLD_SOURCE, "sha256:maple-old")],
+    });
+    expect((await original.edit(app.id, "Remix the net worth card", ctx)).failure).toBeUndefined();
+
+    const namedSource = NEW_SOURCE.replace("export default function", "export function");
+    const runtime = createApps({
+      store,
+      guard: guardFixture(),
+      tools,
+      catalog: [],
+      model: scriptedLanguageModel(forkOps),
+      pinBaselines: [baseline(namedSource, "sha256:maple-named")],
+    });
+    const result = await runtime.pins.rebase({ appId: app.id, slot: SLOT }, ctx);
+
+    if (result.status !== "rebased") throw new Error("expected a rebased result");
+    expect(result.app.pins).toEqual([{ slot: SLOT, base: "sha256:maple-named" }]);
+    // The mechanical re-fork ships through pinForkSource, exactly like
+    // fork-pin, so the named-export capture still renders in the jail.
+    expect(result.app.components?.[COMPONENT])
+      .toBe(`${namedSource}\nexport { NetWorthCard as default };\n`);
+  });
+
   it("drops an in-client approval by construction: the rebased version needs re-approval", async () => {
     const store = memoryStore();
     const appId = await seedForkedHistory(store);

--- a/packages/apps/src/rebase.test.ts
+++ b/packages/apps/src/rebase.test.ts
@@ -286,6 +286,34 @@ describe("06-apps §8 — pin rebase via intent replay", () => {
       .toBe(`${namedSource}\nexport { NetWorthCard as default };\n`);
   });
 
+  it("refuses to rebase onto a baseline with no detectable component export, loudly", async () => {
+    const store = memoryStore();
+    const app = seedDoc("app_unexported_rebase");
+    await seedAppRow(store, app, ctx.principal.subject);
+    const original = createApps({
+      store,
+      guard: guardFixture(),
+      tools,
+      catalog: [],
+      model: scriptedLanguageModel(forkOps),
+      pinBaselines: [baseline(OLD_SOURCE, "sha256:maple-old")],
+    });
+    expect((await original.edit(app.id, "Remix the net worth card", ctx)).failure).toBeUndefined();
+
+    const runtime = createApps({
+      store,
+      guard: guardFixture(),
+      tools,
+      catalog: [],
+      model: scriptedLanguageModel(forkOps),
+      pinBaselines: [baseline("const NetWorthCard = () => null;", "sha256:maple-unexported")],
+    });
+    await expect(runtime.pins.rebase({ appId: app.id, slot: SLOT }, ctx)).rejects.toMatchObject({
+      code: "conflict",
+      message: expect.stringContaining("no default export"),
+    });
+  });
+
   it("drops an in-client approval by construction: the rebased version needs re-approval", async () => {
     const store = memoryStore();
     const appId = await seedForkedHistory(store);

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -43,7 +43,7 @@ import { createAppInterchange } from "./interchange.js";
 import { createMachineSessions } from "./machine.js";
 import { createAppOpener, createProgressiveQueryResolver } from "./open.js";
 import { appRecordInput, documentFromRecord, enabledAfterDocumentEdit, rowFromRecord } from "./persistence.js";
-import { detectPinDrift, pinComponentName, pinForkSource, type InClientApproval, type PinBaseline, type PinDrift } from "./pins.js";
+import { detectPinDrift, hasDefaultExport, pinComponentName, pinForkSource, type InClientApproval, type PinBaseline, type PinDrift } from "./pins.js";
 import { createAppsProxy } from "./proxy.js";
 import { createRunTokenGate } from "./run-token-gate.js";
 import { computeShipDiff, type ShipDiff } from "./ship-diff.js";
@@ -919,8 +919,14 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
         // fork-pin), so replay starts after it.
         const replayIntents = intents.slice(1);
         const componentName = pinComponentName(input.slot);
+        // ENG-348 — same bar as fork-pin: a baseline the jail could never
+        // render must not persist as a "successful" rebase.
+        const forkSource = pinForkSource(baseline.source);
+        if (!hasDefaultExport(forkSource)) {
+          throw new VendoError("conflict", `pin ${input.slot} baseline has no default export and no detectable named component export; export the component from its module and re-run vendo sync`);
+        }
         let working: AppDocument = structuredClone(app);
-        working.components = { ...(working.components ?? {}), [componentName]: pinForkSource(baseline.source) };
+        working.components = { ...(working.components ?? {}), [componentName]: forkSource };
         working.pins = (working.pins ?? []).map((candidate) => candidate.slot === input.slot
           ? { ...candidate, base: baseline.hash }
           : candidate);

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -43,7 +43,7 @@ import { createAppInterchange } from "./interchange.js";
 import { createMachineSessions } from "./machine.js";
 import { createAppOpener, createProgressiveQueryResolver } from "./open.js";
 import { appRecordInput, documentFromRecord, enabledAfterDocumentEdit, rowFromRecord } from "./persistence.js";
-import { detectPinDrift, pinComponentName, type InClientApproval, type PinBaseline, type PinDrift } from "./pins.js";
+import { detectPinDrift, pinComponentName, pinForkSource, type InClientApproval, type PinBaseline, type PinDrift } from "./pins.js";
 import { createAppsProxy } from "./proxy.js";
 import { createRunTokenGate } from "./run-token-gate.js";
 import { computeShipDiff, type ShipDiff } from "./ship-diff.js";
@@ -915,11 +915,12 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
         // intents[0] is the forking edit by construction: the first edit that
         // can touch a slot is the fork-pin that creates it, and undo removes a
         // reverted fork's intent. Re-forking is mechanical (the captured
-        // baseline source is copied verbatim), so replay starts after it.
+        // baseline source is copied through `pinForkSource`, exactly like
+        // fork-pin), so replay starts after it.
         const replayIntents = intents.slice(1);
         const componentName = pinComponentName(input.slot);
         let working: AppDocument = structuredClone(app);
-        working.components = { ...(working.components ?? {}), [componentName]: baseline.source };
+        working.components = { ...(working.components ?? {}), [componentName]: pinForkSource(baseline.source) };
         working.pins = (working.pins ?? []).map((candidate) => candidate.slot === input.slot
           ? { ...candidate, base: baseline.hash }
           : candidate);

--- a/packages/apps/src/ship-diff.test.ts
+++ b/packages/apps/src/ship-diff.test.ts
@@ -1,6 +1,6 @@
 import { VENDO_APP_FORMAT, type AppDocument } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
-import { pinComponentName, type PinBaseline } from "./pins.js";
+import { pinComponentName, pinForkSource, type PinBaseline } from "./pins.js";
 import { computeShipDiff } from "./ship-diff.js";
 import { appVersionHash } from "./version-hash.js";
 
@@ -58,6 +58,17 @@ describe("computeShipDiff", () => {
   it("reports an unchanged fork as an empty diff", () => {
     const doc = app({ components: { [componentName]: baseline.source } });
     expect(computeShipDiff(doc, [baseline]).pins[0]?.diff).toBe("");
+  });
+
+  it("reports an unedited fork of a named-export baseline as an empty diff (ENG-348)", () => {
+    const named: PinBaseline = {
+      ...baseline,
+      source: "export function Card() {\n  return <b>host</b>;\n}",
+    };
+    // The fork ships pinForkSource(baseline.source) — the synthesized default
+    // export is fork plumbing, not a host edit, so it never shows to approvers.
+    const doc = app({ components: { [componentName]: pinForkSource(named.source) } });
+    expect(computeShipDiff(doc, [named]).pins[0]?.diff).toBe("");
   });
 
   it("flags drift when the captured baseline hash no longer matches the pin base", () => {

--- a/packages/apps/src/ship-diff.ts
+++ b/packages/apps/src/ship-diff.ts
@@ -1,6 +1,6 @@
 import type { AppDocument, AppId } from "@vendoai/core";
 import { appVersionHash } from "./version-hash.js";
-import { pinComponentName, type PinBaseline } from "./pins.js";
+import { pinComponentName, pinForkSource, type PinBaseline } from "./pins.js";
 import { unifiedDiff } from "./unified-diff.js";
 
 /**
@@ -63,7 +63,10 @@ export const computeShipDiff = (
       baseHash: pin.base,
       ...(baseline === undefined ? {} : { baselineHash: baseline.hash }),
       drifted: baseline?.hash !== pin.base,
-      diff: unifiedDiff(`${pin.slot}/${component}.tsx`, baseline?.source ?? "", shipped),
+      // Diff from the source the fork actually started as (`pinForkSource`):
+      // the synthesized default-export alias on a named-export capture is fork
+      // plumbing, not a host edit, so an unedited fork reads as an empty diff.
+      diff: unifiedDiff(`${pin.slot}/${component}.tsx`, baseline === undefined ? "" : pinForkSource(baseline.source), shipped),
     };
   });
   const pinnedComponents = new Set(pins.map((pin) => pin.component));


### PR DESCRIPTION
## Problem (ENG-348)

A component registered remixable via a **named** export (`export function Foo()` / `export const Foo = ...`) captures cleanly at sync, but crashes at render with `generated component must have a React default export`. Found during ENG-288 M6 (PR #283), where the demos worked around it with default exports.

Root cause: `fork-pin` (engine) and the mechanical re-fork (pin rebase) copy the captured baseline module **verbatim** into the generated component, and the jail runtime entry renders only `exports.default`.

## Fix — option (a): synthesize the default export at the fork seam

New `pinForkSource(source)` in `packages/apps/src/pins.ts`: if the captured source has no default export, it detects the component-cased named export and appends `export { <local> as default };`. Wired at every place a baseline becomes fork entry source:

- **fork-pin** (`engine.ts`) — the fork ships the synthesized source; a baseline with no default export and *no detectable component export* is now refused **loudly at fork time** with an actionable message (export the component + re-run `vendo sync`) instead of crashing at render.
- **pin rebase** (`runtime.ts`) — the mechanical re-fork goes through the same helper.
- **ship-diff** (`ship-diff.ts`) — diffs from `pinForkSource(baseline.source)`, so the synthesized alias is fork plumbing, never a host edit: an unedited fork still reads as an empty diff for approvers.

Sync-side capture stays verbatim (baseline hash semantics, drift detection, and `.vendo/remixable/<slot>.json` are unchanged; contracts untouched). This also heals baselines already captured by older syncs and by runtime capture, since the synthesis happens at fork time. Layering note: a sync-time warning in `@vendoai/actions` would have required duplicating the heuristic (actions may import core only), so the loud failure lives at the one seam that owns fork construction.

Verified the synthesized alias compiles to `exports.default` under the exact sucrase config the jail uses (`typescript,jsx,imports`), satisfying the runtime-entry check. No changes to `packages/ui`.

## Tests

- `pins.test.ts` — `pinForkSource` unit coverage: default-export passthrough (declared / aliased / re-exported), named function/const synthesis, helper-export skipping, export-list alias to the local binding, undetectable-source passthrough.
- `engine.test.ts` — a named-export baseline forks with the synthesized default export; a baseline with no detectable component export is contained as a loud edit issue and never persisted.
- `rebase.test.ts` — a host update that switched to a named export mechanically re-forks through `pinForkSource`.
- `ship-diff.test.ts` — an unedited fork of a named-export baseline reports an empty diff.

## Gates

`pnpm build` / `pnpm typecheck` / `pnpm lint` green in the worktree; `pnpm test` green (41/41 tasks) in a space-free clone — the only worktree-local failure was `@vendoai/store` `durability.drill.test.ts`, the known spaces-in-path class (`fixture.pathname` leaves `%20` undecoded; this worktree lives under "Cool Code").
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes render crashes for remixable components exported by name by synthesizing a default export at fork and rebase. Fails fast with a clear error when a baseline has no runtime default or detectable component (ENG-348).

- **Bug Fixes**
  - Added `pinForkSource()` to append `export { <local> as default }` for component-cased named exports; used in fork-pin, rebase, and as the `ship-diff` base so unedited forks show an empty diff.
  - Hardened `hasDefaultExport()` to detect runtime defaults only: ignores renamed re-exports (`export { default as X } from …`), type-only defaults (`export { type X as default }` / `export type { … as default }`), and `export default interface …`; blanks comments and strings before scanning. Both fork and rebase now reject unrenderable baselines with a clear error.

<sup>Written for commit fe9a7fa7fc4804ba7c5385cd9d8bc22c79e92577. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

