### PR TITLE
feat(actions): GraphQL extractor + graphql binding kind + Twenty fixture (ENG-247)

### DIFF
--- a/.changeset/eng-247-graphql-extractor.md
+++ b/.changeset/eng-247-graphql-extractor.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/actions": minor
+---
+
+Static GraphQL extractor behind the extractor seam plus an additive `graphql` binding kind in `vendo/tools@1` (ENG-247). Schemas are read statically from SDL files (parsed with the host's own graphql package) and from code-first `@nestjs/graphql` / `type-graphql` resolvers (TypeScript compiler API) — no host code runs. One tool per query and mutation, deterministic `inputSchema` from GraphQL argument types, and depth-limited default selection sets baked into executable documents. Execution POSTs `{ query, variables }` to the host endpoint with auth semantics identical to route bindings; a 200-with-`errors` response surfaces as an http-error outcome. Fail-closed rules: queries earn `read` only with read-shaped names, mutations default `write`, the destructive word list applies unchanged, and subscriptions, statically-unresolvable types, and multi-endpoint hosts are emitted `disabled: true` with a note. Route-scan tools under a GraphQL endpoint are shadowed like tRPC mounts.

--- a/corpus/expectations/twenty/baseline.json
+++ b/corpus/expectations/twenty/baseline.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "generatedAt": "2026-07-16T10:19:06.476Z",
+  "score": {
+    "passed": 10,
+    "total": 10,
+    "value": 1
+  }
+}

--- a/corpus/expectations/twenty/expected.json
+++ b/corpus/expectations/twenty/expected.json
@@ -1,0 +1,2383 @@
+{
+  "version": 1,
+  "theme": {
+    "background": "#ffffff",
+    "surface": "#f8fafc",
+    "accent": "#2563eb",
+    "text": "#0f172a",
+    "mutedText": "#64748b",
+    "radius": 8,
+    "fontFamily": "system-ui, sans-serif"
+  },
+  "tools": [
+    {
+      "name": "activateSkill",
+      "kind": "graphql",
+      "operation": "activateSkill",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "activateWorkflowVersion",
+      "kind": "graphql",
+      "operation": "activateWorkflowVersion",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "activateWorkspace",
+      "kind": "graphql",
+      "operation": "activateWorkspace",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "addAiProvider",
+      "kind": "graphql",
+      "operation": "addAiProvider",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "addModelToProvider",
+      "kind": "graphql",
+      "operation": "addModelToProvider",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "addQueryToEventStream",
+      "kind": "graphql",
+      "operation": "addQueryToEventStream",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "adminPanelRecentUsers",
+      "kind": "graphql",
+      "operation": "adminPanelRecentUsers",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "adminPanelTopWorkspaces",
+      "kind": "graphql",
+      "operation": "adminPanelTopWorkspaces",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "agentTurns",
+      "kind": "graphql",
+      "operation": "agentTurns",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "apiKey",
+      "kind": "graphql",
+      "operation": "apiKey",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "apiKeys",
+      "kind": "graphql",
+      "operation": "apiKeys",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "applicationConnectionProviders",
+      "kind": "graphql",
+      "operation": "applicationConnectionProviders",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "applicationRegistrationTarballUrl",
+      "kind": "graphql",
+      "operation": "applicationRegistrationTarballUrl",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "archiveChatThread",
+      "kind": "graphql",
+      "operation": "archiveChatThread",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "assignRoleToAgent",
+      "kind": "graphql",
+      "operation": "assignRoleToAgent",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "assignRoleToApiKey",
+      "kind": "graphql",
+      "operation": "assignRoleToApiKey",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "authorizeApp",
+      "kind": "graphql",
+      "operation": "authorizeApp",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "barChartData",
+      "kind": "graphql",
+      "operation": "barChartData",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "billingPortalSession",
+      "kind": "graphql",
+      "operation": "billingPortalSession",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "cancelSwitchBillingInterval",
+      "kind": "graphql",
+      "operation": "cancelSwitchBillingInterval",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "cancelSwitchBillingPlan",
+      "kind": "graphql",
+      "operation": "cancelSwitchBillingPlan",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "cancelSwitchResourceCreditPrice",
+      "kind": "graphql",
+      "operation": "cancelSwitchResourceCreditPrice",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "chatMessages",
+      "kind": "graphql",
+      "operation": "chatMessages",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "chatStreamCatchupChunks",
+      "kind": "graphql",
+      "operation": "chatStreamCatchupChunks",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "chatThread",
+      "kind": "graphql",
+      "operation": "chatThread",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "chatThreads",
+      "kind": "graphql",
+      "operation": "chatThreads",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "checkCustomDomainValidRecords",
+      "kind": "graphql",
+      "operation": "checkCustomDomainValidRecords",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "checkPublicDomainValidRecords",
+      "kind": "graphql",
+      "operation": "checkPublicDomainValidRecords",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "checkUserExists",
+      "kind": "graphql",
+      "operation": "checkUserExists",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "checkWorkspaceInviteHashIsValid",
+      "kind": "graphql",
+      "operation": "checkWorkspaceInviteHashIsValid",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "checkoutSession",
+      "kind": "graphql",
+      "operation": "checkoutSession",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "clearMaintenanceMode",
+      "kind": "graphql",
+      "operation": "clearMaintenanceMode",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "commandMenuItem",
+      "kind": "graphql",
+      "operation": "commandMenuItem",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "commandMenuItems",
+      "kind": "graphql",
+      "operation": "commandMenuItems",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "computeStepOutputSchema",
+      "kind": "graphql",
+      "operation": "computeStepOutputSchema",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createApiKey",
+      "kind": "graphql",
+      "operation": "createApiKey",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createApplicationRegistration",
+      "kind": "graphql",
+      "operation": "createApplicationRegistration",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createApplicationRegistrationVariable",
+      "kind": "graphql",
+      "operation": "createApplicationRegistrationVariable",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createApprovedAccessDomain",
+      "kind": "graphql",
+      "operation": "createApprovedAccessDomain",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createChatThread",
+      "kind": "graphql",
+      "operation": "createChatThread",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createCommandMenuItem",
+      "kind": "graphql",
+      "operation": "createCommandMenuItem",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createDatabaseConfigVariable",
+      "kind": "graphql",
+      "operation": "createDatabaseConfigVariable",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createDevelopmentApplication",
+      "kind": "graphql",
+      "operation": "createDevelopmentApplication",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createDraftFromWorkflowVersion",
+      "kind": "graphql",
+      "operation": "createDraftFromWorkflowVersion",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createEmailGroupChannel",
+      "kind": "graphql",
+      "operation": "createEmailGroupChannel",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createEmailingDomain",
+      "kind": "graphql",
+      "operation": "createEmailingDomain",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createFrontComponent",
+      "kind": "graphql",
+      "operation": "createFrontComponent",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createManyNavigationMenuItems",
+      "kind": "graphql",
+      "operation": "createManyNavigationMenuItems",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createManyViewFieldGroups",
+      "kind": "graphql",
+      "operation": "createManyViewFieldGroups",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createManyViewFields",
+      "kind": "graphql",
+      "operation": "createManyViewFields",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createManyViewGroups",
+      "kind": "graphql",
+      "operation": "createManyViewGroups",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createNavigationMenuItem",
+      "kind": "graphql",
+      "operation": "createNavigationMenuItem",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createOIDCIdentityProvider",
+      "kind": "graphql",
+      "operation": "createOIDCIdentityProvider",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createObjectEvent",
+      "kind": "graphql",
+      "operation": "createObjectEvent",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createOneAgent",
+      "kind": "graphql",
+      "operation": "createOneAgent",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createOneField",
+      "kind": "graphql",
+      "operation": "createOneField",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createOneIndex",
+      "kind": "graphql",
+      "operation": "createOneIndex",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createOneLogicFunction",
+      "kind": "graphql",
+      "operation": "createOneLogicFunction",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createOneObject",
+      "kind": "graphql",
+      "operation": "createOneObject",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createOneRole",
+      "kind": "graphql",
+      "operation": "createOneRole",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createPageLayout",
+      "kind": "graphql",
+      "operation": "createPageLayout",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createPageLayoutTab",
+      "kind": "graphql",
+      "operation": "createPageLayoutTab",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createPageLayoutWidget",
+      "kind": "graphql",
+      "operation": "createPageLayoutWidget",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createPublicDomain",
+      "kind": "graphql",
+      "operation": "createPublicDomain",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createSAMLIdentityProvider",
+      "kind": "graphql",
+      "operation": "createSAMLIdentityProvider",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createSkill",
+      "kind": "graphql",
+      "operation": "createSkill",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createView",
+      "kind": "graphql",
+      "operation": "createView",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createViewField",
+      "kind": "graphql",
+      "operation": "createViewField",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createViewFieldGroup",
+      "kind": "graphql",
+      "operation": "createViewFieldGroup",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createViewFilter",
+      "kind": "graphql",
+      "operation": "createViewFilter",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createViewFilterGroup",
+      "kind": "graphql",
+      "operation": "createViewFilterGroup",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createViewGroup",
+      "kind": "graphql",
+      "operation": "createViewGroup",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createViewSort",
+      "kind": "graphql",
+      "operation": "createViewSort",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createWebhook",
+      "kind": "graphql",
+      "operation": "createWebhook",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createWorkflowVersionEdge",
+      "kind": "graphql",
+      "operation": "createWorkflowVersionEdge",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "createWorkflowVersionStep",
+      "kind": "graphql",
+      "operation": "createWorkflowVersionStep",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "currentUser",
+      "kind": "graphql",
+      "operation": "currentUser",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "currentWorkspace",
+      "kind": "graphql",
+      "operation": "currentWorkspace",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deactivateSkill",
+      "kind": "graphql",
+      "operation": "deactivateSkill",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deactivateWorkflowVersion",
+      "kind": "graphql",
+      "operation": "deactivateWorkflowVersion",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteApplicationRegistration",
+      "kind": "graphql",
+      "operation": "deleteApplicationRegistration",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteApplicationRegistrationVariable",
+      "kind": "graphql",
+      "operation": "deleteApplicationRegistrationVariable",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteApprovedAccessDomain",
+      "kind": "graphql",
+      "operation": "deleteApprovedAccessDomain",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteChatThread",
+      "kind": "graphql",
+      "operation": "deleteChatThread",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteCommandMenuItem",
+      "kind": "graphql",
+      "operation": "deleteCommandMenuItem",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteConnectedAccount",
+      "kind": "graphql",
+      "operation": "deleteConnectedAccount",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteCurrentWorkspace",
+      "kind": "graphql",
+      "operation": "deleteCurrentWorkspace",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteDatabaseConfigVariable",
+      "kind": "graphql",
+      "operation": "deleteDatabaseConfigVariable",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteEmailGroupChannel",
+      "kind": "graphql",
+      "operation": "deleteEmailGroupChannel",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteEmailingDomain",
+      "kind": "graphql",
+      "operation": "deleteEmailingDomain",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteFrontComponent",
+      "kind": "graphql",
+      "operation": "deleteFrontComponent",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteJobs",
+      "kind": "graphql",
+      "operation": "deleteJobs",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteManyNavigationMenuItems",
+      "kind": "graphql",
+      "operation": "deleteManyNavigationMenuItems",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteNavigationMenuItem",
+      "kind": "graphql",
+      "operation": "deleteNavigationMenuItem",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteOneAgent",
+      "kind": "graphql",
+      "operation": "deleteOneAgent",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteOneField",
+      "kind": "graphql",
+      "operation": "deleteOneField",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteOneIndex",
+      "kind": "graphql",
+      "operation": "deleteOneIndex",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteOneLogicFunction",
+      "kind": "graphql",
+      "operation": "deleteOneLogicFunction",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteOneObject",
+      "kind": "graphql",
+      "operation": "deleteOneObject",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteOneRole",
+      "kind": "graphql",
+      "operation": "deleteOneRole",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deletePublicDomain",
+      "kind": "graphql",
+      "operation": "deletePublicDomain",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteQueuedChatMessage",
+      "kind": "graphql",
+      "operation": "deleteQueuedChatMessage",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteSSOIdentityProvider",
+      "kind": "graphql",
+      "operation": "deleteSSOIdentityProvider",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteSkill",
+      "kind": "graphql",
+      "operation": "deleteSkill",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteTwoFactorAuthenticationMethod",
+      "kind": "graphql",
+      "operation": "deleteTwoFactorAuthenticationMethod",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteUser",
+      "kind": "graphql",
+      "operation": "deleteUser",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteUserFromWorkspace",
+      "kind": "graphql",
+      "operation": "deleteUserFromWorkspace",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteView",
+      "kind": "graphql",
+      "operation": "deleteView",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteViewField",
+      "kind": "graphql",
+      "operation": "deleteViewField",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteViewFieldGroup",
+      "kind": "graphql",
+      "operation": "deleteViewFieldGroup",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteViewFilter",
+      "kind": "graphql",
+      "operation": "deleteViewFilter",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteViewFilterGroup",
+      "kind": "graphql",
+      "operation": "deleteViewFilterGroup",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteViewGroup",
+      "kind": "graphql",
+      "operation": "deleteViewGroup",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteViewSort",
+      "kind": "graphql",
+      "operation": "deleteViewSort",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteWebhook",
+      "kind": "graphql",
+      "operation": "deleteWebhook",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteWorkflowVersionEdge",
+      "kind": "graphql",
+      "operation": "deleteWorkflowVersionEdge",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteWorkflowVersionStep",
+      "kind": "graphql",
+      "operation": "deleteWorkflowVersionStep",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "deleteWorkspaceInvitation",
+      "kind": "graphql",
+      "operation": "deleteWorkspaceInvitation",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "destroyPageLayout",
+      "kind": "graphql",
+      "operation": "destroyPageLayout",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "destroyPageLayoutTab",
+      "kind": "graphql",
+      "operation": "destroyPageLayoutTab",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "destroyPageLayoutWidget",
+      "kind": "graphql",
+      "operation": "destroyPageLayoutWidget",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "destroyView",
+      "kind": "graphql",
+      "operation": "destroyView",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "destroyViewField",
+      "kind": "graphql",
+      "operation": "destroyViewField",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "destroyViewFieldGroup",
+      "kind": "graphql",
+      "operation": "destroyViewFieldGroup",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "destroyViewFilter",
+      "kind": "graphql",
+      "operation": "destroyViewFilter",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "destroyViewFilterGroup",
+      "kind": "graphql",
+      "operation": "destroyViewFilterGroup",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "destroyViewGroup",
+      "kind": "graphql",
+      "operation": "destroyViewGroup",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "destroyViewSort",
+      "kind": "graphql",
+      "operation": "destroyViewSort",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "dismissMaintenanceModeBanner",
+      "kind": "graphql",
+      "operation": "dismissMaintenanceModeBanner",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "dismissReconnectAccountBanner",
+      "kind": "graphql",
+      "operation": "dismissReconnectAccountBanner",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "duplicateDashboard",
+      "kind": "graphql",
+      "operation": "duplicateDashboard",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "duplicateWorkflow",
+      "kind": "graphql",
+      "operation": "duplicateWorkflow",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "duplicateWorkflowVersionStep",
+      "kind": "graphql",
+      "operation": "duplicateWorkflowVersionStep",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "editSSOIdentityProvider",
+      "kind": "graphql",
+      "operation": "editSSOIdentityProvider",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "emailPasswordResetLink",
+      "kind": "graphql",
+      "operation": "emailPasswordResetLink",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "endSubscriptionTrialPeriod",
+      "kind": "graphql",
+      "operation": "endSubscriptionTrialPeriod",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "enterpriseCheckoutSession",
+      "kind": "graphql",
+      "operation": "enterpriseCheckoutSession",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "enterprisePortalSession",
+      "kind": "graphql",
+      "operation": "enterprisePortalSession",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "enterpriseSubscriptionStatus",
+      "kind": "graphql",
+      "operation": "enterpriseSubscriptionStatus",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "evaluateAgentTurn",
+      "kind": "graphql",
+      "operation": "evaluateAgentTurn",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "eventLogs",
+      "kind": "graphql",
+      "operation": "eventLogs",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "executeOneLogicFunction",
+      "kind": "graphql",
+      "operation": "executeOneLogicFunction",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "findAdminApplicationRegistrationVariables",
+      "kind": "graphql",
+      "operation": "findAdminApplicationRegistrationVariables",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "findAllApplicationRegistrations",
+      "kind": "graphql",
+      "operation": "findAllApplicationRegistrations",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "findApplicationRegistrationByClientId",
+      "kind": "graphql",
+      "operation": "findApplicationRegistrationByClientId",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "findApplicationRegistrationByUniversalIdentifier",
+      "kind": "graphql",
+      "operation": "findApplicationRegistrationByUniversalIdentifier",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "findApplicationRegistrationStats",
+      "kind": "graphql",
+      "operation": "findApplicationRegistrationStats",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "findApplicationRegistrationVariables",
+      "kind": "graphql",
+      "operation": "findApplicationRegistrationVariables",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "findManyAgents",
+      "kind": "graphql",
+      "operation": "findManyAgents",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "findManyApplicationRegistrations",
+      "kind": "graphql",
+      "operation": "findManyApplicationRegistrations",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "findManyApplications",
+      "kind": "graphql",
+      "operation": "findManyApplications",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "findManyLogicFunctions",
+      "kind": "graphql",
+      "operation": "findManyLogicFunctions",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "findManyMarketplaceApps",
+      "kind": "graphql",
+      "operation": "findManyMarketplaceApps",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "findManyPublicDomains",
+      "kind": "graphql",
+      "operation": "findManyPublicDomains",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "findMarketplaceAppDetail",
+      "kind": "graphql",
+      "operation": "findMarketplaceAppDetail",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "findOneAdminApplicationRegistration",
+      "kind": "graphql",
+      "operation": "findOneAdminApplicationRegistration",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "findOneAgent",
+      "kind": "graphql",
+      "operation": "findOneAgent",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "findOneApplication",
+      "kind": "graphql",
+      "operation": "findOneApplication",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "findOneApplicationRegistration",
+      "kind": "graphql",
+      "operation": "findOneApplicationRegistration",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "findOneLogicFunction",
+      "kind": "graphql",
+      "operation": "findOneLogicFunction",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "findWorkspaceAiStats",
+      "kind": "graphql",
+      "operation": "findWorkspaceAiStats",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "findWorkspaceFromInviteHash",
+      "kind": "graphql",
+      "operation": "findWorkspaceFromInviteHash",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "findWorkspaceInvitations",
+      "kind": "graphql",
+      "operation": "findWorkspaceInvitations",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "frontComponent",
+      "kind": "graphql",
+      "operation": "frontComponent",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "frontComponents",
+      "kind": "graphql",
+      "operation": "frontComponents",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "generateApiKeyToken",
+      "kind": "graphql",
+      "operation": "generateApiKeyToken",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "generateApplicationToken",
+      "kind": "graphql",
+      "operation": "generateApplicationToken",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "generatePlaygroundToken",
+      "kind": "graphql",
+      "operation": "generatePlaygroundToken",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "generateTransientToken",
+      "kind": "graphql",
+      "operation": "generateTransientToken",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "getAddressDetails",
+      "kind": "graphql",
+      "operation": "getAddressDetails",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getAdminAiModels",
+      "kind": "graphql",
+      "operation": "getAdminAiModels",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getAdminAiUsageByWorkspace",
+      "kind": "graphql",
+      "operation": "getAdminAiUsageByWorkspace",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getAdminChatThreadMessages",
+      "kind": "graphql",
+      "operation": "getAdminChatThreadMessages",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getAdminWorkspaceChatThreads",
+      "kind": "graphql",
+      "operation": "getAdminWorkspaceChatThreads",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getAiProviders",
+      "kind": "graphql",
+      "operation": "getAiProviders",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getAiSystemPromptPreview",
+      "kind": "graphql",
+      "operation": "getAiSystemPromptPreview",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getApprovedAccessDomains",
+      "kind": "graphql",
+      "operation": "getApprovedAccessDomains",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getAuthTokensFromLoginToken",
+      "kind": "graphql",
+      "operation": "getAuthTokensFromLoginToken",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "getAuthTokensFromOTP",
+      "kind": "graphql",
+      "operation": "getAuthTokensFromOTP",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "getAuthorizationUrlForSSO",
+      "kind": "graphql",
+      "operation": "getAuthorizationUrlForSSO",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "getAutoCompleteAddress",
+      "kind": "graphql",
+      "operation": "getAutoCompleteAddress",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getAvailablePackages",
+      "kind": "graphql",
+      "operation": "getAvailablePackages",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getConfigVariablesGrouped",
+      "kind": "graphql",
+      "operation": "getConfigVariablesGrouped",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getConnectedImapSmtpCaldavAccount",
+      "kind": "graphql",
+      "operation": "getConnectedImapSmtpCaldavAccount",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getDatabaseConfigVariable",
+      "kind": "graphql",
+      "operation": "getDatabaseConfigVariable",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getEmailingDomains",
+      "kind": "graphql",
+      "operation": "getEmailingDomains",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getIndicatorHealthStatus",
+      "kind": "graphql",
+      "operation": "getIndicatorHealthStatus",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getInstanceAndAllWorkspacesUpgradeStatus",
+      "kind": "graphql",
+      "operation": "getInstanceAndAllWorkspacesUpgradeStatus",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getLogicFunctionSourceCode",
+      "kind": "graphql",
+      "operation": "getLogicFunctionSourceCode",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getLoginTokenFromCredentials",
+      "kind": "graphql",
+      "operation": "getLoginTokenFromCredentials",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "getMaintenanceMode",
+      "kind": "graphql",
+      "operation": "getMaintenanceMode",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getModelsDevProviders",
+      "kind": "graphql",
+      "operation": "getModelsDevProviders",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getModelsDevSuggestions",
+      "kind": "graphql",
+      "operation": "getModelsDevSuggestions",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getPageLayout",
+      "kind": "graphql",
+      "operation": "getPageLayout",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getPageLayoutTab",
+      "kind": "graphql",
+      "operation": "getPageLayoutTab",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getPageLayoutTabs",
+      "kind": "graphql",
+      "operation": "getPageLayoutTabs",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getPageLayoutWidget",
+      "kind": "graphql",
+      "operation": "getPageLayoutWidget",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getPageLayoutWidgets",
+      "kind": "graphql",
+      "operation": "getPageLayoutWidgets",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getPageLayouts",
+      "kind": "graphql",
+      "operation": "getPageLayouts",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getPublicWorkspaceDataByDomain",
+      "kind": "graphql",
+      "operation": "getPublicWorkspaceDataByDomain",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getPublicWorkspaceDataById",
+      "kind": "graphql",
+      "operation": "getPublicWorkspaceDataById",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getQueueJobs",
+      "kind": "graphql",
+      "operation": "getQueueJobs",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getQueueMetrics",
+      "kind": "graphql",
+      "operation": "getQueueMetrics",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getResourceCreditUsage",
+      "kind": "graphql",
+      "operation": "getResourceCreditUsage",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getRoles",
+      "kind": "graphql",
+      "operation": "getRoles",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getSSOIdentityProviders",
+      "kind": "graphql",
+      "operation": "getSSOIdentityProviders",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getSigningKeys",
+      "kind": "graphql",
+      "operation": "getSigningKeys",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getSystemHealthStatus",
+      "kind": "graphql",
+      "operation": "getSystemHealthStatus",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getTimelineCalendarEventsFromCompanyId",
+      "kind": "graphql",
+      "operation": "getTimelineCalendarEventsFromCompanyId",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getTimelineCalendarEventsFromOpportunityId",
+      "kind": "graphql",
+      "operation": "getTimelineCalendarEventsFromOpportunityId",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getTimelineCalendarEventsFromPersonId",
+      "kind": "graphql",
+      "operation": "getTimelineCalendarEventsFromPersonId",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getTimelineThreadsFromCompanyId",
+      "kind": "graphql",
+      "operation": "getTimelineThreadsFromCompanyId",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getTimelineThreadsFromOpportunityId",
+      "kind": "graphql",
+      "operation": "getTimelineThreadsFromOpportunityId",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getTimelineThreadsFromPersonId",
+      "kind": "graphql",
+      "operation": "getTimelineThreadsFromPersonId",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getToolIndex",
+      "kind": "graphql",
+      "operation": "getToolIndex",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getToolInputSchema",
+      "kind": "graphql",
+      "operation": "getToolInputSchema",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getUpgradeStatus",
+      "kind": "graphql",
+      "operation": "getUpgradeStatus",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getUsageAnalytics",
+      "kind": "graphql",
+      "operation": "getUsageAnalytics",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getView",
+      "kind": "graphql",
+      "operation": "getView",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getViewField",
+      "kind": "graphql",
+      "operation": "getViewField",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getViewFieldGroup",
+      "kind": "graphql",
+      "operation": "getViewFieldGroup",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getViewFieldGroups",
+      "kind": "graphql",
+      "operation": "getViewFieldGroups",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getViewFields",
+      "kind": "graphql",
+      "operation": "getViewFields",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getViewFilter",
+      "kind": "graphql",
+      "operation": "getViewFilter",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getViewFilterGroup",
+      "kind": "graphql",
+      "operation": "getViewFilterGroup",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getViewFilterGroups",
+      "kind": "graphql",
+      "operation": "getViewFilterGroups",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getViewFilters",
+      "kind": "graphql",
+      "operation": "getViewFilters",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getViewGroup",
+      "kind": "graphql",
+      "operation": "getViewGroup",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getViewGroups",
+      "kind": "graphql",
+      "operation": "getViewGroups",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getViewSort",
+      "kind": "graphql",
+      "operation": "getViewSort",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getViewSorts",
+      "kind": "graphql",
+      "operation": "getViewSorts",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "getViews",
+      "kind": "graphql",
+      "operation": "getViews",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "impersonate",
+      "kind": "graphql",
+      "operation": "impersonate",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "initiateOTPProvisioning",
+      "kind": "graphql",
+      "operation": "initiateOTPProvisioning",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "initiateOTPProvisioningForAuthenticatedUser",
+      "kind": "graphql",
+      "operation": "initiateOTPProvisioningForAuthenticatedUser",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "installApplication",
+      "kind": "graphql",
+      "operation": "installApplication",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "installMarketplaceApp",
+      "kind": "graphql",
+      "operation": "installMarketplaceApp",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "isMaintenanceModeBannerDismissed",
+      "kind": "graphql",
+      "operation": "isMaintenanceModeBannerDismissed",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "lineChartData",
+      "kind": "graphql",
+      "operation": "lineChartData",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "listPlans",
+      "kind": "graphql",
+      "operation": "listPlans",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "logicFunctionLogs",
+      "kind": "graphql",
+      "operation": "logicFunctionLogs",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "minimalMetadata",
+      "kind": "graphql",
+      "operation": "minimalMetadata",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "myCalendarChannels",
+      "kind": "graphql",
+      "operation": "myCalendarChannels",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "myConnectedAccounts",
+      "kind": "graphql",
+      "operation": "myConnectedAccounts",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "myMessageChannels",
+      "kind": "graphql",
+      "operation": "myMessageChannels",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "myMessageFolders",
+      "kind": "graphql",
+      "operation": "myMessageFolders",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "navigationMenuItem",
+      "kind": "graphql",
+      "operation": "navigationMenuItem",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "navigationMenuItems",
+      "kind": "graphql",
+      "operation": "navigationMenuItems",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "objectRecordCounts",
+      "kind": "graphql",
+      "operation": "objectRecordCounts",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "onAgentChatEvent",
+      "kind": "graphql",
+      "operation": "onAgentChatEvent",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "onEventSubscription",
+      "kind": "graphql",
+      "operation": "onEventSubscription",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "pieChartData",
+      "kind": "graphql",
+      "operation": "pieChartData",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "refreshEnterpriseValidityToken",
+      "kind": "graphql",
+      "operation": "refreshEnterpriseValidityToken",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "refreshUpgradeStatus",
+      "kind": "graphql",
+      "operation": "refreshUpgradeStatus",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "removeAiProvider",
+      "kind": "graphql",
+      "operation": "removeAiProvider",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "removeModelFromProvider",
+      "kind": "graphql",
+      "operation": "removeModelFromProvider",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "removeQueryFromEventStream",
+      "kind": "graphql",
+      "operation": "removeQueryFromEventStream",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "removeRoleFromAgent",
+      "kind": "graphql",
+      "operation": "removeRoleFromAgent",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "renameChatThread",
+      "kind": "graphql",
+      "operation": "renameChatThread",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "renewApplicationToken",
+      "kind": "graphql",
+      "operation": "renewApplicationToken",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "renewToken",
+      "kind": "graphql",
+      "operation": "renewToken",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "resendEmailVerificationToken",
+      "kind": "graphql",
+      "operation": "resendEmailVerificationToken",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "resendWorkspaceInvitation",
+      "kind": "graphql",
+      "operation": "resendWorkspaceInvitation",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "resetPageLayoutTabToDefault",
+      "kind": "graphql",
+      "operation": "resetPageLayoutTabToDefault",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "resetPageLayoutToDefault",
+      "kind": "graphql",
+      "operation": "resetPageLayoutToDefault",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "resetPageLayoutWidgetToDefault",
+      "kind": "graphql",
+      "operation": "resetPageLayoutWidgetToDefault",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "retryJobs",
+      "kind": "graphql",
+      "operation": "retryJobs",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "revokeApiKey",
+      "kind": "graphql",
+      "operation": "revokeApiKey",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "revokeSigningKey",
+      "kind": "graphql",
+      "operation": "revokeSigningKey",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "rotateApplicationRegistrationClientSecret",
+      "kind": "graphql",
+      "operation": "rotateApplicationRegistrationClientSecret",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "runEvaluationInput",
+      "kind": "graphql",
+      "operation": "runEvaluationInput",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "runWorkflowVersion",
+      "kind": "graphql",
+      "operation": "runWorkflowVersion",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "runWorkspaceMigration",
+      "kind": "graphql",
+      "operation": "runWorkspaceMigration",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "saveImapSmtpCaldavAccount",
+      "kind": "graphql",
+      "operation": "saveImapSmtpCaldavAccount",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "search",
+      "kind": "graphql",
+      "operation": "search",
+      "readOrWrite": "read"
+    },
+    {
+      "name": "sendChatMessage",
+      "kind": "graphql",
+      "operation": "sendChatMessage",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "sendEmail",
+      "kind": "graphql",
+      "operation": "sendEmail",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "sendEmailViaEmailingDomain",
+      "kind": "graphql",
+      "operation": "sendEmailViaEmailingDomain",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "sendInvitations",
+      "kind": "graphql",
+      "operation": "sendInvitations",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "setAdminAiModelEnabled",
+      "kind": "graphql",
+      "operation": "setAdminAiModelEnabled",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "setAdminAiModelRecommended",
+      "kind": "graphql",
+      "operation": "setAdminAiModelRecommended",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "setAdminAiModelsEnabled",
+      "kind": "graphql",
+      "operation": "setAdminAiModelsEnabled",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "setAdminAiModelsRecommended",
+      "kind": "graphql",
+      "operation": "setAdminAiModelsRecommended",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "setAdminDefaultAiModel",
+      "kind": "graphql",
+      "operation": "setAdminDefaultAiModel",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "setEnterpriseKey",
+      "kind": "graphql",
+      "operation": "setEnterpriseKey",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "setMaintenanceMode",
+      "kind": "graphql",
+      "operation": "setMaintenanceMode",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "setResourceCreditSubscriptionPrice",
+      "kind": "graphql",
+      "operation": "setResourceCreditSubscriptionPrice",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "signIn",
+      "kind": "graphql",
+      "operation": "signIn",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "signUp",
+      "kind": "graphql",
+      "operation": "signUp",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "signUpInNewWorkspace",
+      "kind": "graphql",
+      "operation": "signUpInNewWorkspace",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "signUpInWorkspace",
+      "kind": "graphql",
+      "operation": "signUpInWorkspace",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "skill",
+      "kind": "graphql",
+      "operation": "skill",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "skills",
+      "kind": "graphql",
+      "operation": "skills",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "skipBookOnboardingStep",
+      "kind": "graphql",
+      "operation": "skipBookOnboardingStep",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "skipSyncEmailOnboardingStep",
+      "kind": "graphql",
+      "operation": "skipSyncEmailOnboardingStep",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "startChannelSync",
+      "kind": "graphql",
+      "operation": "startChannelSync",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "stopAgentChatStream",
+      "kind": "graphql",
+      "operation": "stopAgentChatStream",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "stopWorkflowRun",
+      "kind": "graphql",
+      "operation": "stopWorkflowRun",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "submitFormStep",
+      "kind": "graphql",
+      "operation": "submitFormStep",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "switchBillingPlan",
+      "kind": "graphql",
+      "operation": "switchBillingPlan",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "switchSubscriptionInterval",
+      "kind": "graphql",
+      "operation": "switchSubscriptionInterval",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "syncApplication",
+      "kind": "graphql",
+      "operation": "syncApplication",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "syncMarketplaceCatalog",
+      "kind": "graphql",
+      "operation": "syncMarketplaceCatalog",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "testHttpRequest",
+      "kind": "graphql",
+      "operation": "testHttpRequest",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "trackAnalytics",
+      "kind": "graphql",
+      "operation": "trackAnalytics",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "transferApplicationRegistrationOwnership",
+      "kind": "graphql",
+      "operation": "transferApplicationRegistrationOwnership",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "unarchiveChatThread",
+      "kind": "graphql",
+      "operation": "unarchiveChatThread",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "uninstallApplication",
+      "kind": "graphql",
+      "operation": "uninstallApplication",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateAdminApplicationRegistrationVariable",
+      "kind": "graphql",
+      "operation": "updateAdminApplicationRegistrationVariable",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateApiKey",
+      "kind": "graphql",
+      "operation": "updateApiKey",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateApplicationRegistration",
+      "kind": "graphql",
+      "operation": "updateApplicationRegistration",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateApplicationRegistrationVariable",
+      "kind": "graphql",
+      "operation": "updateApplicationRegistrationVariable",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateCalendarChannel",
+      "kind": "graphql",
+      "operation": "updateCalendarChannel",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateCommandMenuItem",
+      "kind": "graphql",
+      "operation": "updateCommandMenuItem",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateDatabaseConfigVariable",
+      "kind": "graphql",
+      "operation": "updateDatabaseConfigVariable",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateFrontComponent",
+      "kind": "graphql",
+      "operation": "updateFrontComponent",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateLabPublicFeatureFlag",
+      "kind": "graphql",
+      "operation": "updateLabPublicFeatureFlag",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateManyNavigationMenuItems",
+      "kind": "graphql",
+      "operation": "updateManyNavigationMenuItems",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateManyViewGroups",
+      "kind": "graphql",
+      "operation": "updateManyViewGroups",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateMessageChannel",
+      "kind": "graphql",
+      "operation": "updateMessageChannel",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateMessageFolder",
+      "kind": "graphql",
+      "operation": "updateMessageFolder",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateMessageFolders",
+      "kind": "graphql",
+      "operation": "updateMessageFolders",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateNavigationMenuItem",
+      "kind": "graphql",
+      "operation": "updateNavigationMenuItem",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateOneAgent",
+      "kind": "graphql",
+      "operation": "updateOneAgent",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateOneApplicationVariable",
+      "kind": "graphql",
+      "operation": "updateOneApplicationVariable",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateOneField",
+      "kind": "graphql",
+      "operation": "updateOneField",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateOneLogicFunction",
+      "kind": "graphql",
+      "operation": "updateOneLogicFunction",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateOneObject",
+      "kind": "graphql",
+      "operation": "updateOneObject",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateOneRole",
+      "kind": "graphql",
+      "operation": "updateOneRole",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updatePageLayout",
+      "kind": "graphql",
+      "operation": "updatePageLayout",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updatePageLayoutTab",
+      "kind": "graphql",
+      "operation": "updatePageLayoutTab",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updatePageLayoutWidget",
+      "kind": "graphql",
+      "operation": "updatePageLayoutWidget",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updatePageLayoutWithTabsAndWidgets",
+      "kind": "graphql",
+      "operation": "updatePageLayoutWithTabsAndWidgets",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updatePasswordViaResetToken",
+      "kind": "graphql",
+      "operation": "updatePasswordViaResetToken",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updatePublicDomain",
+      "kind": "graphql",
+      "operation": "updatePublicDomain",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateSkill",
+      "kind": "graphql",
+      "operation": "updateSkill",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateUserEmail",
+      "kind": "graphql",
+      "operation": "updateUserEmail",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateView",
+      "kind": "graphql",
+      "operation": "updateView",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateViewField",
+      "kind": "graphql",
+      "operation": "updateViewField",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateViewFieldGroup",
+      "kind": "graphql",
+      "operation": "updateViewFieldGroup",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateViewFilter",
+      "kind": "graphql",
+      "operation": "updateViewFilter",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateViewFilterGroup",
+      "kind": "graphql",
+      "operation": "updateViewFilterGroup",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateViewGroup",
+      "kind": "graphql",
+      "operation": "updateViewGroup",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateViewSort",
+      "kind": "graphql",
+      "operation": "updateViewSort",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateWebhook",
+      "kind": "graphql",
+      "operation": "updateWebhook",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateWorkflowRunStep",
+      "kind": "graphql",
+      "operation": "updateWorkflowRunStep",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateWorkflowVersionPositions",
+      "kind": "graphql",
+      "operation": "updateWorkflowVersionPositions",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateWorkflowVersionStep",
+      "kind": "graphql",
+      "operation": "updateWorkflowVersionStep",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateWorkspace",
+      "kind": "graphql",
+      "operation": "updateWorkspace",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateWorkspaceFeatureFlag",
+      "kind": "graphql",
+      "operation": "updateWorkspaceFeatureFlag",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateWorkspaceMemberRole",
+      "kind": "graphql",
+      "operation": "updateWorkspaceMemberRole",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "updateWorkspaceMemberSettings",
+      "kind": "graphql",
+      "operation": "updateWorkspaceMemberSettings",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "upgradeApplication",
+      "kind": "graphql",
+      "operation": "upgradeApplication",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "uploadAiChatFile",
+      "kind": "graphql",
+      "operation": "uploadAiChatFile",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "uploadAppTarball",
+      "kind": "graphql",
+      "operation": "uploadAppTarball",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "uploadApplicationFile",
+      "kind": "graphql",
+      "operation": "uploadApplicationFile",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "uploadEmailAttachmentFile",
+      "kind": "graphql",
+      "operation": "uploadEmailAttachmentFile",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "uploadFilesFieldFile",
+      "kind": "graphql",
+      "operation": "uploadFilesFieldFile",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "uploadFilesFieldFileByUniversalIdentifier",
+      "kind": "graphql",
+      "operation": "uploadFilesFieldFileByUniversalIdentifier",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "uploadWorkflowFile",
+      "kind": "graphql",
+      "operation": "uploadWorkflowFile",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "uploadWorkspaceLogo",
+      "kind": "graphql",
+      "operation": "uploadWorkspaceLogo",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "uploadWorkspaceMemberProfilePicture",
+      "kind": "graphql",
+      "operation": "uploadWorkspaceMemberProfilePicture",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "upsertFieldPermissions",
+      "kind": "graphql",
+      "operation": "upsertFieldPermissions",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "upsertFieldsWidget",
+      "kind": "graphql",
+      "operation": "upsertFieldsWidget",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "upsertObjectPermissions",
+      "kind": "graphql",
+      "operation": "upsertObjectPermissions",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "upsertPermissionFlags",
+      "kind": "graphql",
+      "operation": "upsertPermissionFlags",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "upsertRowLevelPermissionPredicates",
+      "kind": "graphql",
+      "operation": "upsertRowLevelPermissionPredicates",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "upsertViewWidget",
+      "kind": "graphql",
+      "operation": "upsertViewWidget",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "userLookupAdminPanel",
+      "kind": "graphql",
+      "operation": "userLookupAdminPanel",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "validateApprovedAccessDomain",
+      "kind": "graphql",
+      "operation": "validateApprovedAccessDomain",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "validatePasswordResetToken",
+      "kind": "graphql",
+      "operation": "validatePasswordResetToken",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "verifyEmailAndGetLoginToken",
+      "kind": "graphql",
+      "operation": "verifyEmailAndGetLoginToken",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "verifyEmailAndGetWorkspaceAgnosticToken",
+      "kind": "graphql",
+      "operation": "verifyEmailAndGetWorkspaceAgnosticToken",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "verifyEmailingDomain",
+      "kind": "graphql",
+      "operation": "verifyEmailingDomain",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "verifyTwoFactorAuthenticationMethodForAuthenticatedUser",
+      "kind": "graphql",
+      "operation": "verifyTwoFactorAuthenticationMethodForAuthenticatedUser",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "versionInfo",
+      "kind": "graphql",
+      "operation": "versionInfo",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "webhook",
+      "kind": "graphql",
+      "operation": "webhook",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "webhooks",
+      "kind": "graphql",
+      "operation": "webhooks",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "workflowStepConnectedAccountHandle",
+      "kind": "graphql",
+      "operation": "workflowStepConnectedAccountHandle",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "workspaceBillingAdminPanel",
+      "kind": "graphql",
+      "operation": "workspaceBillingAdminPanel",
+      "readOrWrite": "write"
+    },
+    {
+      "name": "workspaceLookupAdminPanel",
+      "kind": "graphql",
+      "operation": "workspaceLookupAdminPanel",
+      "readOrWrite": "write"
+    }
+  ],
+  "annotations": [
+    {
+      "name": "apiKeys",
+      "mutating": true,
+      "dangerous": false
+    },
+    {
+      "name": "apiKey",
+      "mutating": true,
+      "dangerous": false
+    },
+    {
+      "name": "createApiKey",
+      "mutating": true,
+      "dangerous": false
+    },
+    {
+      "name": "revokeApiKey",
+      "mutating": true,
+      "dangerous": true
+    },
+    {
+      "name": "getPageLayouts",
+      "mutating": false,
+      "dangerous": false
+    },
+    {
+      "name": "destroyPageLayout",
+      "mutating": true,
+      "dangerous": true
+    },
+    {
+      "name": "getMaintenanceMode",
+      "mutating": false,
+      "dangerous": false
+    },
+    {
+      "name": "currentUser",
+      "mutating": true,
+      "dangerous": false
+    },
+    {
+      "name": "deleteUser",
+      "mutating": true,
+      "dangerous": true
+    },
+    {
+      "name": "sendEmail",
+      "mutating": true,
+      "dangerous": true
+    },
+    {
+      "name": "createOneRole",
+      "mutating": true,
+      "dangerous": false
+    },
+    {
+      "name": "getViews",
+      "mutating": false,
+      "dangerous": false
+    },
+    {
+      "name": "uploadApplicationFile",
+      "mutating": true,
+      "dangerous": false
+    },
+    {
+      "name": "getToolInputSchema",
+      "mutating": false,
+      "dangerous": false
+    },
+    {
+      "name": "onEventSubscription",
+      "mutating": true,
+      "dangerous": true
+    },
+    {
+      "name": "checkoutSession",
+      "mutating": true,
+      "dangerous": false
+    }
+  ],
+  "components": []
+}

--- a/corpus/harness/src/boot.test.ts
+++ b/corpus/harness/src/boot.test.ts
@@ -153,6 +153,44 @@ describe("bootRepo", () => {
     ]);
   });
 
+  it("provisions Redis after Postgres and tears both down in reverse order", async () => {
+    const corpusRoot = await makeTempRoot();
+    const context = createRunContext({ corpusRoot });
+    const repo = repoEntry("twentyish");
+    repo.bootstrap.redis = {
+      kind: "docker-redis",
+      containerName: "vendo-corpus-twentyish-redis",
+      image: "redis:7-alpine",
+      hostPort: 56379,
+    };
+    await mkdir(context.repoDir(repo.name), { recursive: true });
+    const events: string[] = [];
+    const server = fakeProcess(7788);
+
+    const boot = await bootRepo(repo, {
+      context,
+      provisionDatabase: async (database) => {
+        events.push(`service:start:${database.kind}:${database.containerName}`);
+        return { teardown: async () => { events.push(`service:stop:${database.kind}`); } };
+      },
+      runCommand: async () => ({ code: 0, signal: null, stdout: "", stderr: "" }),
+      spawnProcess: () => server,
+      checkReadiness: async () => true,
+      killProcessTree: async () => {},
+      sleep: async () => {},
+    });
+
+    expect(boot.logPaths.redis).toBe(path.join(context.logsDir(repo.name), "boot.redis.log"));
+    await boot.teardown();
+
+    expect(events).toEqual([
+      "service:start:docker-postgres:vendo-corpus-twentyish-postgres",
+      "service:start:docker-redis:vendo-corpus-twentyish-redis",
+      "service:stop:docker-redis",
+      "service:stop:docker-postgres",
+    ]);
+  });
+
   it("rejects a foreign readiness response until the configured body marker is present", async () => {
     const corpusRoot = await makeTempRoot();
     const context = createRunContext({ corpusRoot });

--- a/corpus/harness/src/boot.ts
+++ b/corpus/harness/src/boot.ts
@@ -26,6 +26,7 @@ export interface BootLogPaths {
   server: string;
   seed?: string;
   database?: string;
+  redis?: string;
 }
 
 export interface BootHandle {
@@ -157,7 +158,7 @@ async function defaultProvisionDatabase(
   context: DatabaseProvisionContext,
 ): Promise<DatabaseProvisionHandle> {
   await writeFile(context.logPath, "");
-  if (database.kind !== "docker-postgres") {
+  if (database.kind !== "docker-postgres" && database.kind !== "docker-redis") {
     throw new Error(`Unsupported database provisioning kind: ${(database as { kind: string }).kind}`);
   }
 
@@ -166,23 +167,40 @@ async function defaultProvisionDatabase(
   const removeBefore = await runBinary("docker", ["rm", "-f", database.containerName], dockerOptions);
   await appendDatabaseLog(context.logPath, `docker rm -f ${database.containerName}`, removeBefore);
 
+  const runArgs = database.kind === "docker-postgres"
+    ? [
+        "run",
+        "-d",
+        "--name",
+        database.containerName,
+        "-e",
+        `POSTGRES_USER=${database.username}`,
+        "-e",
+        `POSTGRES_PASSWORD=${database.password}`,
+        "-e",
+        `POSTGRES_DB=${database.database}`,
+        "-p",
+        `127.0.0.1:${database.hostPort}:5432`,
+        database.image,
+      ]
+    : [
+        "run",
+        "-d",
+        "--name",
+        database.containerName,
+        "-p",
+        `127.0.0.1:${database.hostPort}:6379`,
+        database.image,
+      ];
+  const readinessArgs = database.kind === "docker-postgres"
+    ? ["exec", database.containerName, "pg_isready", "-U", database.username, "-d", database.database]
+    : ["exec", database.containerName, "redis-cli", "ping"];
+  const readinessLabel = database.kind === "docker-postgres" ? "pg_isready" : "redis-cli ping";
+  const isReady = (result: BinaryResult): boolean =>
+    result.code === 0 && (database.kind !== "docker-redis" || result.stdout.includes("PONG"));
+
   let startedContainer = false;
   try {
-    const runArgs = [
-      "run",
-      "-d",
-      "--name",
-      database.containerName,
-      "-e",
-      `POSTGRES_USER=${database.username}`,
-      "-e",
-      `POSTGRES_PASSWORD=${database.password}`,
-      "-e",
-      `POSTGRES_DB=${database.database}`,
-      "-p",
-      `127.0.0.1:${database.hostPort}:5432`,
-      database.image,
-    ];
     const started = await checkedBinary("docker", runArgs, dockerOptions);
     startedContainer = true;
     await appendDatabaseLog(context.logPath, `docker ${runArgs.join(" ")}`, started);
@@ -192,17 +210,9 @@ async function defaultProvisionDatabase(
     const attempts = Math.max(1, Math.ceil(timeoutMs / intervalMs));
     let lastResult: BinaryResult | undefined;
     for (let attempt = 0; attempt < attempts; attempt += 1) {
-      lastResult = await runBinary("docker", [
-        "exec",
-        database.containerName,
-        "pg_isready",
-        "-U",
-        database.username,
-        "-d",
-        database.database,
-      ], dockerOptions);
-      await appendDatabaseLog(context.logPath, "docker exec ... pg_isready", lastResult);
-      if (lastResult.code === 0) {
+      lastResult = await runBinary("docker", readinessArgs, dockerOptions);
+      await appendDatabaseLog(context.logPath, `docker exec ... ${readinessLabel}`, lastResult);
+      if (isReady(lastResult)) {
         return {
           teardown: async () => {
             const stopped = await runBinary("docker", ["rm", "-f", database.containerName], dockerOptions);
@@ -392,10 +402,12 @@ export async function bootRepo(repo: BootRepo, options: BootRepoOptions = {}): P
   };
   if (repo.bootstrap.seedCommand) logPaths.seed = path.join(logsDir, "boot.seed.log");
   if (repo.bootstrap.database) logPaths.database = path.join(logsDir, "boot.database.log");
+  if (repo.bootstrap.redis) logPaths.redis = path.join(logsDir, "boot.redis.log");
 
   await mkdir(logsDir, { recursive: true });
 
   let databaseHandle: DatabaseProvisionHandle | undefined;
+  let redisHandle: DatabaseProvisionHandle | undefined;
   let serverProcess: BootProcess | undefined;
   let closeServerLog: (() => Promise<void>) | undefined;
   let serverExit: string | undefined;
@@ -427,6 +439,11 @@ export async function bootRepo(repo: BootRepo, options: BootRepoOptions = {}): P
       }
     }
     try {
+      await redisHandle?.teardown?.();
+    } catch (error) {
+      errors.push(error);
+    }
+    try {
       await databaseHandle?.teardown?.();
     } catch (error) {
       errors.push(error);
@@ -443,6 +460,17 @@ export async function bootRepo(repo: BootRepo, options: BootRepoOptions = {}): P
         context,
         logsDir,
         logPath: logPaths.database ?? path.join(logsDir, "boot.database.log"),
+        env,
+        sleep: sleepFn,
+      });
+    }
+
+    if (repo.bootstrap.redis) {
+      redisHandle = await provisionDatabase(repo.bootstrap.redis, {
+        repo,
+        context,
+        logsDir,
+        logPath: logPaths.redis ?? path.join(logsDir, "boot.redis.log"),
         env,
         sleep: sleepFn,
       });

--- a/corpus/harness/src/expectations.test.ts
+++ b/corpus/harness/src/expectations.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   THEME_RUBRIC_DIMENSIONS,
+  expectedToolIdentity,
   loadRepoBaseline,
   loadRepoExpectations,
   parseRepoBaseline,
@@ -75,6 +76,34 @@ describe("repo expectations format", () => {
       descriptionIncludes: ["invoice", "status"],
       props: ["status"],
     });
+  });
+
+  it("parses binding-kind-aware inventory rows and keys each by its own identity", () => {
+    const parsed = parseRepoExpectations({
+      version: 1,
+      theme,
+      tools: [
+        { name: "listInvoices", method: "GET", path: "/api/invoices", readOrWrite: "read" },
+        { name: "pollsList", kind: "trpc", procedure: "polls.list", readOrWrite: "read" },
+        { name: "createApiKey", kind: "graphql", operation: "createApiKey", readOrWrite: "write" },
+      ],
+      annotations: [],
+      components: [],
+    });
+    expect(parsed.tools.map(expectedToolIdentity)).toEqual([
+      "GET\t/api/invoices",
+      "trpc\tpolls.list",
+      "graphql\tcreateApiKey",
+    ]);
+
+    // A graphql row without its operation never parses.
+    expect(() => parseRepoExpectations({
+      version: 1,
+      theme,
+      tools: [{ name: "createApiKey", kind: "graphql", readOrWrite: "write" }],
+      annotations: [],
+      components: [],
+    })).toThrow();
   });
 
   it("rejects incomplete theme labels and incomplete tool inventory rows", () => {

--- a/corpus/harness/src/expectations.ts
+++ b/corpus/harness/src/expectations.ts
@@ -51,9 +51,21 @@ export const expectedTrpcToolInventorySchema = z
   })
   .strict();
 
+/** Binding-kind-aware tool identity: a GraphQL tool is identified by its
+ * operation name (the schema field on the query/mutation root). */
+export const expectedGraphqlToolInventorySchema = z
+  .object({
+    name: z.string().min(1),
+    kind: z.literal("graphql"),
+    operation: z.string().min(1),
+    readOrWrite: z.enum(["read", "write"]),
+  })
+  .strict();
+
 export const expectedToolInventorySchema = z.union([
   expectedHttpToolInventorySchema,
   expectedTrpcToolInventorySchema,
+  expectedGraphqlToolInventorySchema,
 ]);
 
 export const expectedToolAnnotationSchema = z
@@ -104,10 +116,13 @@ export type RepoExpectations = z.infer<typeof repoExpectationsSchema>;
 export type RepoBaseline = z.infer<typeof repoBaselineSchema>;
 
 /** The binding-kind-aware identity an expectation joins on: procedure for
- * tRPC entries, method+path for HTTP-shaped entries. Names stay out of the
- * key (01-core §15 renames them deterministically). */
+ * tRPC entries, operation for GraphQL entries, method+path for HTTP-shaped
+ * entries. Names stay out of the key (01-core §15 renames them
+ * deterministically). */
 export function expectedToolIdentity(item: ExpectedToolInventory): string {
-  return "procedure" in item ? `trpc\t${item.procedure}` : `${item.method}\t${item.path}`;
+  if ("procedure" in item) return `trpc\t${item.procedure}`;
+  if ("operation" in item) return `graphql\t${item.operation}`;
+  return `${item.method}\t${item.path}`;
 }
 
 export function repoExpectationsDir(expectationsRoot: string, repoName: string): string {

--- a/corpus/harness/src/layers/scored.test.ts
+++ b/corpus/harness/src/layers/scored.test.ts
@@ -279,6 +279,65 @@ describe("runScoredLayer", () => {
     expect(unsafe.layer.hardFailure).toBe(true);
   });
 
+  it("keys GraphQL tools by operation identity and applies mutation write-safety", async () => {
+    const { repoDir, expectationsRoot } = await makeFixture();
+    const graphqlExpectations: RepoExpectations = {
+      ...baseExpectations,
+      tools: [
+        { name: "apiKeys", kind: "graphql", operation: "apiKeys", readOrWrite: "read" },
+        { name: "createApiKey", kind: "graphql", operation: "createApiKey", readOrWrite: "write" },
+      ],
+      annotations: [
+        { name: "apiKeys", mutating: false, dangerous: false },
+        { name: "createApiKey", mutating: true, dangerous: false },
+      ],
+    };
+    await writeExpected(expectationsRoot, "repo-one", graphqlExpectations);
+    await mkdir(path.join(repoDir, ".vendo"), { recursive: true });
+    await writeInitOutput(repoDir); // writes theme.json + route tools.json; overwrite tools below
+    const graphqlTool = (name: string, operation: string, type: "query" | "mutation", risk: string) => ({
+      name,
+      description: `GraphQL ${type} ${operation}`,
+      inputSchema: { type: "object", properties: {} },
+      risk,
+      binding: { kind: "graphql", operation, type, endpoint: "/graphql", document: `${type} ${operation} { ${operation} }` },
+    });
+    await writeFile(
+      path.join(repoDir, ".vendo/tools.json"),
+      JSON.stringify({
+        format: "vendo/tools@1",
+        tools: [
+          graphqlTool("host_api_keys", "apiKeys", "query", "read"),
+          graphqlTool("host_create_api_key", "createApiKey", "mutation", "write"),
+        ],
+      }, null, 2) + "\n",
+    );
+
+    const result = await runScoredLayer({
+      repoName: "repo-one",
+      repoDir,
+      expectationsRoot,
+      now: () => new Date("2026-07-06T12:00:00.000Z"),
+    });
+    const checks = checkById(result.layer);
+    expect(checks["tools.precision"]).toMatchObject({ pass: true });
+    expect(checks["tools.recall"]).toMatchObject({ pass: true });
+    expect(checks["annotations.match"]).toMatchObject({ pass: true });
+    expect(checks["annotations.write-safety"]).toMatchObject({ pass: true });
+
+    // A read-labeled GraphQL mutation is unsafe exactly like a read-labeled POST.
+    await writeFile(
+      path.join(repoDir, ".vendo/tools.json"),
+      JSON.stringify({
+        format: "vendo/tools@1",
+        tools: [graphqlTool("host_create_api_key", "createApiKey", "mutation", "read")],
+      }, null, 2) + "\n",
+    );
+    const unsafe = await runScoredLayer({ repoName: "repo-one", repoDir, expectationsRoot });
+    expect(checkById(unsafe.layer)["annotations.write-safety"]).toMatchObject({ pass: false });
+    expect(unsafe.layer.hardFailure).toBe(true);
+  });
+
   it("skips repos that have not been labeled yet", async () => {
     const { repoDir, expectationsRoot } = await makeFixture();
     await writeInitOutput(repoDir);

--- a/corpus/harness/src/layers/scored.ts
+++ b/corpus/harness/src/layers/scored.ts
@@ -103,18 +103,18 @@ function scoreTheme(expected: RepoExpectations, actual: VendoTheme): WeightedRes
 }
 
 // A tool's IDENTITY for scoring is binding-kind-aware — the endpoint
-// (method + path) for HTTP-shaped bindings, the procedure dot-path for tRPC —
-// plus its read/write classification, and NOT its name. Tool names are a
-// deterministic, contract-defined value (01-core §15: provider-safe
-// `host_<path>` slugs), while the checked-in expectations carry the pre-freeze
-// OpenAPI-operationId names (`getAdminTeams`). Keying on the identity is the
-// "adapted names" the v0 corpus requires, and still catches every real
-// extraction defect: a missed surface drops recall, a mis-classified
-// read/write breaks the key.
+// (method + path) for HTTP-shaped bindings, the procedure dot-path for tRPC,
+// the operation name for GraphQL — plus its read/write classification, and
+// NOT its name. Tool names are a deterministic, contract-defined value
+// (01-core §15: provider-safe `host_<path>` slugs), while the checked-in
+// expectations carry the pre-freeze OpenAPI-operationId names
+// (`getAdminTeams`). Keying on the identity is the "adapted names" the v0
+// corpus requires, and still catches every real extraction defect: a missed
+// surface drops recall, a mis-classified read/write breaks the key.
 function actualToolIdentity(tool: ExtractedTool): string {
-  return tool.binding.kind === "trpc"
-    ? `trpc\t${tool.binding.procedure}`
-    : `${tool.binding.method}\t${tool.binding.path}`;
+  if (tool.binding.kind === "trpc") return `trpc\t${tool.binding.procedure}`;
+  if (tool.binding.kind === "graphql") return `graphql\t${tool.binding.operation}`;
+  return `${tool.binding.method}\t${tool.binding.path}`;
 }
 
 function actualInventoryKey(tool: ExtractedTool): string {
@@ -158,9 +158,12 @@ function expectedAnnotationMatches(expected: ExpectedToolAnnotation, actual: Ext
   return actual.risk === expectedRisk;
 }
 
-/** A tRPC mutation is write-shaped exactly like a POST; a query like a GET. */
+/** A tRPC or GraphQL mutation is write-shaped exactly like a POST; a query
+ * like a GET. */
 function effectiveWriteMethod(tool: ExtractedTool): string {
-  if (tool.binding.kind === "trpc") return tool.binding.type === "query" ? "GET" : "POST";
+  if (tool.binding.kind === "trpc" || tool.binding.kind === "graphql") {
+    return tool.binding.type === "query" ? "GET" : "POST";
+  }
   return tool.binding.method;
 }
 

--- a/corpus/harness/src/layers/structural.ts
+++ b/corpus/harness/src/layers/structural.ts
@@ -167,6 +167,21 @@ async function readText(repoDir: string, rel: string): Promise<string | null> {
   }
 }
 
+/** Two valid Express wirings exist: the pre-wired shape (an app like
+ * express-host that already composes createVendo in src/server + renders
+ * VendoRoot in src/client) and the generated shape `vendo init` writes for a
+ * real Express/Nest API host (vendo/server.ts|mjs; the client lives in a
+ * separate frontend, so no VendoRoot requirement). */
+async function expressShape(repoDir: string): Promise<"pre-wired" | "generated"> {
+  return await exists(path.join(repoDir, "src/server/vendo.ts")) ? "pre-wired" : "generated";
+}
+
+async function generatedExpressServerRel(repoDir: string): Promise<string> {
+  return await exists(path.join(repoDir, "vendo/server.mjs")) && !await exists(path.join(repoDir, "vendo/server.ts"))
+    ? "vendo/server.mjs"
+    : "vendo/server.ts";
+}
+
 async function defaultExpectedFilesForFramework(
   repoDir: string,
   framework: "next" | "express",
@@ -182,7 +197,11 @@ async function defaultExpectedFilesForFramework(
   ];
 
   if (framework === "express") {
-    files.push("src/server/vendo.ts", "src/server/index.ts", "src/client/main.tsx");
+    if (await expressShape(repoDir) === "pre-wired") {
+      files.push("src/server/vendo.ts", "src/server/index.ts", "src/client/main.tsx");
+    } else {
+      files.push(await generatedExpressServerRel(repoDir));
+    }
   } else if (app) {
     files.push(routeRel(app), app.layoutRel);
   }
@@ -248,16 +267,23 @@ async function checkExpectedFiles(ctx: StructuralLayerContext): Promise<Structur
   const wiringProblems: string[] = [];
   if (!ctx.expectedFiles) {
     if (framework === "express") {
-      const server = await sourceTreeText(ctx.repoDir, "src/server");
-      const client = await sourceTreeText(ctx.repoDir, "src/client");
-      if (!server.includes("@vendoai/vendo/server") || !server.includes("createVendo")) {
-        wiringProblems.push("Express server sources do not compose createVendo from @vendoai/vendo/server");
-      }
-      if (!hasFunctionalExpressVendoMount(server)) {
-        wiringProblems.push("Express server does not mount vendo.handler at /api/vendo");
-      }
-      if (!client.includes("<VendoRoot")) {
-        wiringProblems.push("Express client sources do not render <VendoRoot");
+      if (await expressShape(ctx.repoDir) === "pre-wired") {
+        const server = await sourceTreeText(ctx.repoDir, "src/server");
+        const client = await sourceTreeText(ctx.repoDir, "src/client");
+        if (!server.includes("@vendoai/vendo/server") || !server.includes("createVendo")) {
+          wiringProblems.push("Express server sources do not compose createVendo from @vendoai/vendo/server");
+        }
+        if (!hasFunctionalExpressVendoMount(server)) {
+          wiringProblems.push("Express server does not mount vendo.handler at /api/vendo");
+        }
+        if (!client.includes("<VendoRoot")) {
+          wiringProblems.push("Express client sources do not render <VendoRoot");
+        }
+      } else {
+        const server = await readText(ctx.repoDir, await generatedExpressServerRel(ctx.repoDir));
+        if (server !== null && (!server.includes("@vendoai/vendo/server") || !server.includes("createVendo"))) {
+          wiringProblems.push("generated vendo/server module does not compose createVendo from @vendoai/vendo/server");
+        }
       }
     } else if (!app) {
       wiringProblems.push("no App Router root layout found at app/layout.* or src/app/layout.*");
@@ -420,9 +446,12 @@ async function checkIdempotency(ctx: StructuralLayerContext): Promise<Structural
   return { id: "init.idempotent", pass: false, detail: pieces.join("; ") };
 }
 
-/** A tRPC mutation is write-shaped exactly like a POST; a query like a GET. */
+/** A tRPC or GraphQL mutation is write-shaped exactly like a POST; a query
+ * like a GET. */
 function effectiveWriteMethod(tool: ExtractedTool): string {
-  if (tool.binding.kind === "trpc") return tool.binding.type === "query" ? "GET" : "POST";
+  if (tool.binding.kind === "trpc" || tool.binding.kind === "graphql") {
+    return tool.binding.type === "query" ? "GET" : "POST";
+  }
   return tool.binding.method;
 }
 

--- a/corpus/harness/src/manifest.test.ts
+++ b/corpus/harness/src/manifest.test.ts
@@ -104,6 +104,35 @@ describe("parseManifest", () => {
     expect(() => parseManifest([invalid])).toThrow(/requiresBuild/i);
   });
 
+  it("accepts docker-redis service provisioning and rejects malformed redis recipes", () => {
+    const redis = {
+      kind: "docker-redis",
+      containerName: "vendo-corpus-twenty-redis",
+      image: "redis:7-alpine",
+      hostPort: 56379,
+      readinessTimeoutMs: 30_000,
+    };
+    const withRedis = {
+      ...entry,
+      bootstrap: { ...entry.bootstrap, redis },
+    };
+    expect(parseManifest([withRedis])[0]?.bootstrap.redis).toEqual(redis);
+
+    // The redis slot only takes the redis kind, and postgres-only fields never sneak in.
+    expect(() => parseManifest([{
+      ...entry,
+      bootstrap: { ...entry.bootstrap, redis: { ...redis, kind: "docker-postgres" } },
+    }])).toThrow(/kind/i);
+    expect(() => parseManifest([{
+      ...entry,
+      bootstrap: { ...entry.bootstrap, redis: { ...redis, username: "corpus" } },
+    }])).toThrow(/username/i);
+    expect(() => parseManifest([{
+      ...entry,
+      bootstrap: { ...entry.bootstrap, redis: { ...redis, hostPort: 70000 } },
+    }])).toThrow(/hostPort/i);
+  });
+
   it("rejects invalid deep-tier docker database provisioning", () => {
     const invalid = {
       ...entry,

--- a/corpus/harness/src/manifest.ts
+++ b/corpus/harness/src/manifest.ts
@@ -34,20 +34,36 @@ const devServerSchema = z
   })
   .strict();
 
+const dockerPostgresProvisioningSchema = z
+  .object({
+    kind: z.literal("docker-postgres"),
+    containerName: z.string().min(1),
+    image: z.string().min(1),
+    hostPort: z.number().int().min(1024).max(65535),
+    database: z.string().min(1),
+    username: z.string().min(1),
+    password: z.string().min(1),
+    readinessTimeoutMs: z.number().int().positive().optional(),
+    readinessIntervalMs: z.number().int().positive().optional(),
+  })
+  .strict();
+
+/** Redis mirrors the Postgres provisioning shape (docker container + readiness
+ * probe). Twenty is deliberately the only Redis boot in the corpus. */
+const dockerRedisProvisioningSchema = z
+  .object({
+    kind: z.literal("docker-redis"),
+    containerName: z.string().min(1),
+    image: z.string().min(1),
+    hostPort: z.number().int().min(1024).max(65535),
+    readinessTimeoutMs: z.number().int().positive().optional(),
+    readinessIntervalMs: z.number().int().positive().optional(),
+  })
+  .strict();
+
 const databaseProvisioningSchema = z.discriminatedUnion("kind", [
-  z
-    .object({
-      kind: z.literal("docker-postgres"),
-      containerName: z.string().min(1),
-      image: z.string().min(1),
-      hostPort: z.number().int().min(1024).max(65535),
-      database: z.string().min(1),
-      username: z.string().min(1),
-      password: z.string().min(1),
-      readinessTimeoutMs: z.number().int().positive().optional(),
-      readinessIntervalMs: z.number().int().positive().optional(),
-    })
-    .strict(),
+  dockerPostgresProvisioningSchema,
+  dockerRedisProvisioningSchema,
 ]);
 
 const bootstrapRecipeSchema = z
@@ -55,7 +71,8 @@ const bootstrapRecipeSchema = z
     installCommand: z.string().min(1),
     envTemplate: z.record(z.string(), z.string()),
     seedCommand: z.string().min(1).optional(),
-    database: databaseProvisioningSchema.optional(),
+    database: dockerPostgresProvisioningSchema.optional(),
+    redis: dockerRedisProvisioningSchema.optional(),
     typecheckCommand: z.string().min(1).optional(),
     buildCommand: z.string().min(1),
     devServer: devServerSchema.optional(),

--- a/corpus/manifest.json
+++ b/corpus/manifest.json
@@ -488,5 +488,56 @@
       }
     },
     "notes": "Permanent local Express host proving the framework-agnostic fetch handler composition through all corpus layers."
+  },
+  {
+    "name": "twenty",
+    "gitUrl": "https://github.com/twentyhq/twenty.git",
+    "pinnedSha": "b53f1832d80f87be2cfd88990b855c0e5f3cc926",
+    "appDir": "packages/twenty-server",
+    "framework": "express",
+    "license": "AGPL-3.0",
+    "tier": "broad",
+    "bootstrap": {
+      "installCommand": "YARN_ENABLE_HARDENED_MODE=false YARN_ENABLE_CONSTRAINTS_CHECKS=false corepack yarn install",
+      "envTemplate": {
+        "NODE_ENV": "development",
+        "PG_DATABASE_URL": "postgres://corpus:corpus@127.0.0.1:55437/twenty",
+        "REDIS_URL": "redis://127.0.0.1:56379",
+        "APP_SECRET": "corpus-twenty-app-secret-0123456789",
+        "SIGN_IN_PREFILLED": "true",
+        "NODE_PORT": "43120",
+        "SERVER_URL": "http://127.0.0.1:43120",
+        "FRONTEND_URL": "http://127.0.0.1:43120"
+      },
+      "seedCommand": "NX_DAEMON=false npx nx run twenty-server:database:init",
+      "database": {
+        "kind": "docker-postgres",
+        "containerName": "vendo-corpus-twenty-postgres",
+        "image": "postgres:16-alpine",
+        "hostPort": 55437,
+        "database": "twenty",
+        "username": "corpus",
+        "password": "corpus",
+        "readinessTimeoutMs": 30000,
+        "readinessIntervalMs": 500
+      },
+      "redis": {
+        "kind": "docker-redis",
+        "containerName": "vendo-corpus-twenty-redis",
+        "image": "redis:7-alpine",
+        "hostPort": 56379,
+        "readinessTimeoutMs": 30000,
+        "readinessIntervalMs": 500
+      },
+      "typecheckCommand": "NX_DAEMON=false npx nx run twenty-server:typecheck",
+      "buildCommand": "NX_DAEMON=false npx nx run twenty-server:build",
+      "devServer": {
+        "command": "NX_DAEMON=false npx nx run twenty-server:start",
+        "readinessUrl": "http://127.0.0.1:43120/graphql",
+        "readinessTimeoutMs": 900000,
+        "readinessIntervalMs": 2000
+      }
+    },
+    "notes": "First GraphQL corpus fixture (ENG-247): NestJS code-first GraphQL (yoga driver) in a yarn 4 + nx monorepo; appDir is packages/twenty-server (the API host; the Vite frontend lives in twenty-front). Pinned at the v2.9.0 release tag (b53f1832, 2026-06-04) verified via the GitHub tags API. The core /graphql workspace schema is metadata-generated at runtime; the statically extractable surface is the code-first resolver set, which spans three schema scopes (/graphql, /metadata, /admin-panel) so extraction emits every operation disabled fail-closed. Hardened mode and constraints checks are disabled for corpus installs (hardened-mode registry audits are slow and constraints reject the injected local Vendo tarballs). Redis (the corpus's only Redis boot) backs Twenty's cache storage; database:init needs both containers up."
   }
 ]

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -69,6 +69,7 @@
   "devDependencies": {
     "@auth/core": "^0.34.3",
     "@types/node": "^22.0.0",
+    "graphql": "^16.9.0",
     "jose": "^6.2.3",
     "next": "16.2.9",
     "typescript": "^5.6.0",

--- a/packages/actions/src/formats.ts
+++ b/packages/actions/src/formats.ts
@@ -180,6 +180,33 @@ export const trpcBindingSchema = z.object({
 }).passthrough() satisfies z.ZodType<TrpcBinding>;
 
 /**
+ * 04-actions §1 (additive within vendo/tools@1): execution binding for a
+ * GraphQL operation. Tool identity is endpoint + `operation` (the schema field
+ * name on the query/mutation root), not a method+path pair. Execution is a
+ * POST of `{ query: document, variables: args }` to the host endpoint; every
+ * tool argument rides as a same-named GraphQL variable. `document` carries the
+ * full statically-generated operation (variable declarations derived from the
+ * schema's argument types plus a depth-limited default selection set); it is
+ * absent only on disabled tools whose operation could not be made statically
+ * executable (fail-closed, 04 §1).
+ */
+export interface GraphqlBinding {
+  kind: "graphql";
+  operation: string;               // schema field name, e.g. "createInvoice"
+  type: "query" | "mutation";
+  endpoint: string;                // "/graphql" — resolved against createActions baseUrl
+  document?: string;
+}
+
+export const graphqlBindingSchema = z.object({
+  kind: z.literal("graphql"),
+  operation: z.string().min(1),
+  type: z.enum(["query", "mutation"]),
+  endpoint: z.string().startsWith("/"),
+  document: z.string().min(1).optional(),
+}).passthrough() satisfies z.ZodType<GraphqlBinding>;
+
+/**
  * 04-actions §6: ordered steps over primitive host/connector tools, reusing the
  * core §11 `Step` shape. Expressions see `{ args, steps, item }`. Compounds are
  * agent-authored: they live in `.vendo/capabilities.json`, never `tools.json`.
@@ -198,14 +225,15 @@ export const compoundBindingSchema = z.object({
 ) satisfies z.ZodType<CompoundBinding>;
 
 /** The bindings deterministic extraction may emit into `.vendo/tools.json`. */
-export type PrimitiveToolBinding = RouteBinding | OpenApiBinding | TrpcBinding;
+export type PrimitiveToolBinding = RouteBinding | OpenApiBinding | TrpcBinding | GraphqlBinding;
 
-export type ToolBinding = RouteBinding | OpenApiBinding | TrpcBinding | CompoundBinding;
+export type ToolBinding = RouteBinding | OpenApiBinding | TrpcBinding | GraphqlBinding | CompoundBinding;
 
 export const toolBindingSchema = z.union([
   routeBindingSchema,
   openApiBindingSchema,
   trpcBindingSchema,
+  graphqlBindingSchema,
   compoundBindingSchema,
 ]) satisfies z.ZodType<ToolBinding>;
 
@@ -220,6 +248,7 @@ const extractedBindingSchema = z.discriminatedUnion("kind", [
   routeBindingSchema,
   openApiBindingSchema,
   trpcBindingSchema,
+  graphqlBindingSchema,
   compoundKindSchema,
 ]) as unknown as z.ZodType<PrimitiveToolBinding>;
 

--- a/packages/actions/src/runtime/registry.test.ts
+++ b/packages/actions/src/runtime/registry.test.ts
@@ -775,3 +775,72 @@ describe("host HTTP execution — trpc bindings (04 §1 tRPC HTTP envelope)", ()
     });
   });
 });
+
+describe("host HTTP execution — graphql bindings (04 §1 GraphQL transport)", () => {
+  const document = "query pollGet($id: ID!) { pollGet(id: $id) { id title } }";
+  const graphqlTool = (extras: Partial<ExtractedTool["binding"] & Record<string, unknown>> = {}): ExtractedTool => ({
+    name: "host_poll_get",
+    description: "GraphQL query pollGet",
+    inputSchema: { type: "object", properties: { id: { type: "string" } }, required: ["id"] },
+    risk: "read",
+    binding: { kind: "graphql", operation: "pollGet", type: "query", endpoint: "/api/graphql", document, ...extras },
+  });
+
+  function capturingFetch(status: number, payload: unknown): { fetch: typeof fetch; seen: Array<{ url: string; method?: string; body?: unknown }> } {
+    const seen: Array<{ url: string; method?: string; body?: unknown }> = [];
+    const impl = (async (input: URL | RequestInfo, init?: RequestInit) => {
+      seen.push({
+        url: String(input),
+        method: init?.method,
+        body: typeof init?.body === "string" ? JSON.parse(init.body) : undefined,
+      });
+      return new Response(JSON.stringify(payload), { status, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+    return { fetch: impl, seen };
+  }
+
+  it("executes as POST {endpoint} with the document and args as variables, unwrapping the root field", async () => {
+    const { fetch, seen } = capturingFetch(200, { data: { pollGet: { id: "p1", title: "Standup" } } });
+    const actions = createActions({ tools: [graphqlTool()], baseUrl: "http://host.test", fetch });
+
+    const outcome = await actions.execute({ id: "1", tool: "host_poll_get", args: { id: "p1" } }, ctx);
+    expect(outcome).toEqual({ status: "ok", output: { id: "p1", title: "Standup" } });
+    expect(new URL(seen[0]!.url).pathname).toBe("/api/graphql");
+    expect(seen[0]!.method).toBe("POST");
+    expect(seen[0]!.body).toEqual({ query: document, variables: { id: "p1" } });
+  });
+
+  it("surfaces a 200-with-errors GraphQL response as an http-error outcome", async () => {
+    const { fetch } = capturingFetch(200, { data: null, errors: [{ message: "Poll not found" }] });
+    const actions = createActions({ tools: [graphqlTool()], baseUrl: "http://host.test", fetch });
+    await expect(actions.execute({ id: "1", tool: "host_poll_get", args: { id: "p1" } }, ctx)).resolves.toMatchObject({
+      status: "error",
+      error: { code: "http-error", message: expect.stringContaining("Poll not found") },
+    });
+  });
+
+  it("returns a validation outcome when no baseUrl is configured", async () => {
+    const actions = createActions({ tools: [graphqlTool()] });
+    await expect(actions.execute({ id: "1", tool: "host_poll_get", args: { id: "p1" } }, ctx)).resolves.toMatchObject({
+      status: "error",
+      error: { code: "validation", message: expect.stringContaining("baseUrl") },
+    });
+  });
+
+  it("fails closed with a validation outcome when the binding carries no executable document", async () => {
+    const actions = createActions({ tools: [graphqlTool({ document: undefined })], baseUrl: "http://host.test" });
+    await expect(actions.execute({ id: "1", tool: "host_poll_get", args: { id: "p1" } }, ctx)).resolves.toMatchObject({
+      status: "error",
+      error: { code: "validation", message: expect.stringContaining("no executable document") },
+    });
+  });
+
+  it("maps non-2xx graphql responses to http-error outcomes", async () => {
+    const { fetch } = capturingFetch(500, { errors: [{ message: "boom" }] });
+    const actions = createActions({ tools: [graphqlTool()], baseUrl: "http://host.test", fetch });
+    await expect(actions.execute({ id: "1", tool: "host_poll_get", args: { id: "p1" } }, ctx)).resolves.toMatchObject({
+      status: "error",
+      error: { code: "http-error", message: expect.stringContaining("500") },
+    });
+  });
+});

--- a/packages/actions/src/runtime/registry.ts
+++ b/packages/actions/src/runtime/registry.ts
@@ -23,6 +23,7 @@ import {
   type CapabilityBrief,
   type CompoundTool,
   type ExtractedTool,
+  type GraphqlBinding,
   type HttpMethod,
   type OpenApiBinding,
   type OverridesFile,
@@ -390,6 +391,64 @@ function trpcOutput(binding: TrpcBinding, parsed: unknown): unknown {
   return data;
 }
 
+/** The GraphQL HTTP transport (04 §1): every operation — query or mutation —
+ * is a POST of `{ query: document, variables: args }` to the host endpoint.
+ * The binding's document declares each tool argument as a same-named variable,
+ * so the agent's args ride through unmodified. Auth semantics (present-forward,
+ * away/actAs, venue=mcp) are identical to route bindings. */
+function graphqlRequest(binding: GraphqlBinding, args: Record<string, unknown>, configuredBaseUrl?: string): {
+  url: URL;
+  method: HttpMethod;
+  body: string;
+} {
+  if (!binding.document) {
+    throw new VendoError(
+      "validation",
+      `Cannot execute graphql binding ${binding.operation}; extraction emitted no executable document for it (fail-closed); review the tool's note before enabling`,
+    );
+  }
+  if (!configuredBaseUrl) {
+    throw new VendoError(
+      "validation",
+      `Cannot execute graphql binding ${binding.operation}; set createActions({ baseUrl }) for server-side graphql execution`,
+    );
+  }
+  let url: URL;
+  try {
+    url = joinedUrl(configuredBaseUrl, binding.endpoint.length > 1 ? binding.endpoint.replace(/\/+$/, "") : binding.endpoint);
+  } catch {
+    throw new VendoError("validation", `Invalid baseUrl for graphql operation ${binding.operation}; set createActions({ baseUrl }) to a valid origin`);
+  }
+  return { url, method: "POST", body: JSON.stringify({ query: binding.document, variables: args }) };
+}
+
+/** Unwrap the GraphQL response envelope. GraphQL reports failures as a 200
+ * with an `errors` array — that is still a failed call and surfaces as an
+ * http-error outcome so the agent sees the server's message. On success the
+ * single root field's value (the document has exactly one) is the output. */
+function graphqlOutput(binding: GraphqlBinding, parsed: unknown): ToolOutcome {
+  const envelope = parsed !== null && typeof parsed === "object"
+    ? parsed as { data?: unknown; errors?: unknown }
+    : undefined;
+  const errors = envelope?.errors;
+  if (Array.isArray(errors) && errors.length > 0) {
+    const message = errors
+      .map((item) => item !== null && typeof item === "object" && typeof (item as { message?: unknown }).message === "string"
+        ? (item as { message: string }).message
+        : "GraphQL error")
+      .join("; ");
+    return error("http-error", `graphql ${binding.operation} → errors: ${message.slice(0, 200)}`);
+  }
+  const data = envelope && "data" in envelope ? envelope.data : parsed;
+  if (data !== null && typeof data === "object" && !Array.isArray(data)) {
+    const record = data as Record<string, unknown>;
+    if (Object.keys(record).length === 1 && binding.operation in record) {
+      return { status: "ok", output: record[binding.operation] };
+    }
+  }
+  return { status: "ok", output: data };
+}
+
 async function executeHost(config: RegistryConfig, tool: ExtractedTool, call: ToolCall, ctx: RunContext): Promise<ToolOutcome> {
   if (!isArgsObject(call.args)) return error("validation", `Arguments for ${call.tool} must be an object`);
 
@@ -399,6 +458,11 @@ async function executeHost(config: RegistryConfig, tool: ExtractedTool, call: To
   try {
     if (tool.binding.kind === "trpc") {
       const request = trpcRequest(tool.binding, call.args, config.baseUrl);
+      url = request.url;
+      method = request.method;
+      body = request.body;
+    } else if (tool.binding.kind === "graphql") {
+      const request = graphqlRequest(tool.binding, call.args, config.baseUrl);
       url = request.url;
       method = request.method;
       body = request.body;
@@ -510,6 +574,7 @@ async function executeHost(config: RegistryConfig, tool: ExtractedTool, call: To
       if (text) {
         try {
           const parsed: unknown = JSON.parse(text);
+          if (tool.binding.kind === "graphql") return graphqlOutput(tool.binding, parsed);
           return {
             status: "ok",
             output: tool.binding.kind === "trpc" ? trpcOutput(tool.binding, parsed) : parsed,

--- a/packages/actions/src/sync/common.ts
+++ b/packages/actions/src/sync/common.ts
@@ -569,7 +569,9 @@ export function dedupKey(method: HttpMethod, urlPath: string): string {
  * endpoint+operation for GraphQL. */
 export function bindingIdentity(binding: PrimitiveToolBinding): string {
   if (binding.kind === "trpc") return `TRPC ${binding.mount.replace(/\/+$/g, "")} ${binding.procedure}`;
-  if (binding.kind === "graphql") return `GRAPHQL ${binding.endpoint.replace(/\/+$/g, "")} ${binding.operation}`;
+  // The operation kind joins the key: GraphQL allows a query and a mutation
+  // to share one field name across the two root types.
+  if (binding.kind === "graphql") return `GRAPHQL ${binding.endpoint.replace(/\/+$/g, "")} ${binding.type} ${binding.operation}`;
   return dedupKey(binding.method, binding.path);
 }
 

--- a/packages/actions/src/sync/common.ts
+++ b/packages/actions/src/sync/common.ts
@@ -565,14 +565,17 @@ export function dedupKey(method: HttpMethod, urlPath: string): string {
 
 /** The binding-kind-aware identity a tool is deduplicated and diffed by:
  * method+path for HTTP-shaped bindings, mount+procedure for tRPC (a host can
- * expose the same procedure name under two mounts — both tools must survive). */
+ * expose the same procedure name under two mounts — both tools must survive),
+ * endpoint+operation for GraphQL. */
 export function bindingIdentity(binding: PrimitiveToolBinding): string {
   if (binding.kind === "trpc") return `TRPC ${binding.mount.replace(/\/+$/g, "")} ${binding.procedure}`;
+  if (binding.kind === "graphql") return `GRAPHQL ${binding.endpoint.replace(/\/+$/g, "")} ${binding.operation}`;
   return dedupKey(binding.method, binding.path);
 }
 
 function uniqueNameFallback(binding: PrimitiveToolBinding): string {
-  return binding.kind === "trpc" ? binding.type : binding.method;
+  if (binding.kind === "trpc" || binding.kind === "graphql") return binding.type;
+  return binding.method;
 }
 
 export function withUniqueNames(tools: ExtractedTool[]): ExtractedTool[] {
@@ -620,4 +623,16 @@ export function trpcRisk(type: "query" | "mutation", procedure: string): Extract
 export function trpcToolFullName(procedure: string): string {
   const parts = words(procedure);
   return `host_${parts.length > 0 ? parts.join("_") : "procedure"}`;
+}
+
+/** GraphQL risk labeling (04 §1, fail-closed): identical semantics to tRPC —
+ * the destructive word list applies unchanged; a query earns `read` only with
+ * a read-shaped name; mutations and ambiguously-named queries default `write`. */
+export function graphqlRisk(type: "query" | "mutation", operation: string): ExtractedTool["risk"] {
+  return trpcRisk(type, operation);
+}
+
+export function graphqlToolFullName(operation: string): string {
+  const parts = words(operation);
+  return `host_${parts.length > 0 ? parts.join("_") : "operation"}`;
 }

--- a/packages/actions/src/sync/extractors.test.ts
+++ b/packages/actions/src/sync/extractors.test.ts
@@ -14,10 +14,11 @@ function routeTool(name: string, path: string): ExtractedTool {
 }
 
 describe("extractor registrations", () => {
-  it("keeps OpenAPI ahead of trpc ahead of route-scan", () => {
+  it("keeps OpenAPI ahead of trpc ahead of graphql ahead of route-scan", () => {
     expect(extractorRegistrations.map((extractor) => extractor.name)).toEqual([
       "openapi",
       "trpc",
+      "graphql",
       "route-scan",
     ]);
   });
@@ -81,6 +82,38 @@ describe("extractor registrations", () => {
       ]),
     ]);
     expect(result.tools.map((tool) => tool.name)).toEqual(["host_polls_list", "host_trpcish", "host_health"]);
+  });
+
+  it("drops route tools shadowed by a graphql endpoint, and only those", async () => {
+    const graphqlTool: ExtractedTool = {
+      name: "host_poll_get",
+      description: "GraphQL query pollGet",
+      inputSchema: { type: "object", properties: {} },
+      risk: "read",
+      binding: { kind: "graphql", operation: "pollGet", type: "query", endpoint: "/api/graphql", document: "query pollGet { pollGet }" },
+    };
+    const fake = (name: string, tools: ExtractedTool[]): Extractor => ({
+      name,
+      detect: async () => true,
+      extract: async () => ({ tools, warnings: [] }),
+    });
+    const result = await runExtractors("/host", [
+      fake("graphql", [graphqlTool]),
+      fake("route-scan", [
+        routeTool("host_graphql_catchall", "/api/graphql/{slug}"),
+        routeTool("host_graphql_root", "/api/graphql"),
+        routeTool("host_graphqlish", "/api/graphqlish"),
+        routeTool("host_health", "/api/health"),
+      ]),
+    ]);
+    expect(result.tools.map((tool) => tool.name)).toEqual(["host_poll_get", "host_graphqlish", "host_health"]);
+  });
+
+  it("keeps the same operation name distinct across two graphql endpoints", () => {
+    const first = bindingIdentity({ kind: "graphql", operation: "pollGet", type: "query", endpoint: "/graphql" });
+    const second = bindingIdentity({ kind: "graphql", operation: "pollGet", type: "query", endpoint: "/metadata" });
+    expect(first).not.toBe(second);
+    expect(bindingIdentity({ kind: "graphql", operation: "pollGet", type: "query", endpoint: "/graphql/" })).toBe(first);
   });
 
   it("keeps the same procedure name distinct across two trpc mounts", () => {

--- a/packages/actions/src/sync/extractors.ts
+++ b/packages/actions/src/sync/extractors.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import type { ExtractedTool } from "../formats.js";
+import { detectGraphql, extractGraphql, graphqlEndpoints } from "./graphql.js";
 import { extractOpenApi } from "./openapi.js";
 import { scanRoutes } from "./route-scan.js";
 import { detectTrpc, extractTrpc, trpcMounts } from "./trpc.js";
@@ -54,6 +55,12 @@ const trpcExtractor: Extractor = {
   extract: extractTrpc,
 };
 
+const graphqlExtractor: Extractor = {
+  name: "graphql",
+  detect: detectGraphql,
+  extract: extractGraphql,
+};
+
 const routeScanExtractor: Extractor = {
   name: "route-scan",
   async detect() {
@@ -65,15 +72,16 @@ const routeScanExtractor: Extractor = {
 export const extractorRegistrations: readonly Extractor[] = [
   openApiExtractor,
   trpcExtractor,
+  graphqlExtractor,
   routeScanExtractor,
 ];
 
-/** Route-scan sees a tRPC mount as an opaque catch-all HTTP route; when the
- * trpc extractor produced real procedure tools for that mount, the shadowing
- * route tools are dropped. No trpc tools → no filtering (unchanged behavior
- * for every non-tRPC host). */
+/** Route-scan sees a tRPC mount or a GraphQL endpoint as an opaque catch-all
+ * HTTP route; when the trpc/graphql extractors produced real operation tools
+ * for that mount, the shadowing route tools are dropped. No trpc/graphql
+ * tools → no filtering (unchanged behavior for every other host). */
 function withoutShadowedRoutes(tools: ExtractedTool[]): ExtractedTool[] {
-  const mounts = trpcMounts(tools);
+  const mounts = [...trpcMounts(tools), ...graphqlEndpoints(tools)];
   if (mounts.length === 0) return tools;
   return tools.filter((tool) => {
     if (tool.binding.kind !== "route") return true;

--- a/packages/actions/src/sync/graphql.test.ts
+++ b/packages/actions/src/sync/graphql.test.ts
@@ -1,0 +1,658 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { GraphqlBinding } from "../formats.js";
+import { runExtractors } from "./extractors.js";
+import { detectGraphql, extractGraphql } from "./graphql.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })));
+});
+
+async function temporaryHost(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "vendo-actions-graphql-"));
+  temporaryDirectories.push(root);
+  return root;
+}
+
+async function writeFile(root: string, relative: string, source: string): Promise<void> {
+  const file = path.join(root, relative);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, source, "utf8");
+}
+
+function binding(tool: { binding: unknown }): GraphqlBinding {
+  return tool.binding as GraphqlBinding;
+}
+
+/** An SDL-first Next host: yoga route mount, split schema files, enums,
+ * input objects, custom scalars, list/non-null wrappers, a subscription. */
+async function writeSdlHost(root: string): Promise<void> {
+  await writeFile(root, "package.json", JSON.stringify({
+    name: "sdl-host",
+    dependencies: { graphql: "^16.9.0", "graphql-yoga": "^5.0.0", next: "16.0.0" },
+  }));
+  await writeFile(root, "app/api/graphql/route.ts", `
+import { createYoga } from "graphql-yoga";
+import { schema } from "@/server/schema";
+
+const yoga = createYoga({ schema, graphqlEndpoint: "/api/graphql" });
+export { yoga as GET, yoga as POST };
+`);
+  await writeFile(root, "schema/query.graphql", `
+enum PollStatus {
+  OPEN
+  CLOSED
+}
+
+type Comment {
+  id: ID!
+  text: String!
+  author: User!
+}
+
+type User {
+  id: ID!
+  name: String!
+  email: String
+}
+
+type Poll {
+  id: ID!
+  title: String!
+  votes: Int!
+  score: Float
+  open: Boolean!
+  status: PollStatus!
+  createdAt: DateTime!
+  owner: User!
+  comments(first: Int): [Comment!]!
+}
+
+scalar DateTime
+
+type Query {
+  pollsList(status: PollStatus, search: String, limit: Int! = 20): [Poll!]!
+  pollGet(id: ID!): Poll
+  serverVersion: String!
+}
+`);
+  await writeFile(root, "schema/mutation.graphql", `
+input CreatePollInput {
+  title: String!
+  options: [String!]!
+  tags: [String]
+  status: PollStatus
+}
+
+type Mutation {
+  createPoll(input: CreatePollInput!): Poll!
+  renamePoll(id: ID!, title: String!): Poll!
+  deletePoll(id: ID!): Boolean!
+}
+
+type Subscription {
+  pollUpdated(id: ID!): Poll!
+}
+`);
+}
+
+/** A single-endpoint NestJS code-first host: GraphQLModule.forRoot path
+ * literal, resolvers with @Args variants, input/args classes, custom scalar. */
+async function writeNestHost(root: string): Promise<void> {
+  await writeFile(root, "package.json", JSON.stringify({
+    name: "nest-host",
+    dependencies: { "@nestjs/graphql": "^12.0.0", graphql: "^16.9.0" },
+  }));
+  await writeFile(root, "tsconfig.json", JSON.stringify({
+    compilerOptions: { paths: { "src/*": ["./src/*"] } },
+  }));
+  await writeFile(root, "src/app.module.ts", `
+import { Module } from "@nestjs/common";
+import { GraphQLModule } from "@nestjs/graphql";
+
+@Module({
+  imports: [
+    GraphQLModule.forRoot({ autoSchemaFile: true, path: "/api/gql" }),
+  ],
+})
+export class AppModule {}
+`);
+  await writeFile(root, "src/scalars.ts", `
+import { GraphQLScalarType } from "graphql";
+export const UUIDScalarType = new GraphQLScalarType({ name: "UUID", description: "uuid" });
+`);
+  await writeFile(root, "src/invoice/invoice.dto.ts", `
+import { Field, Float, ID, InputType, Int, ObjectType } from "@nestjs/graphql";
+
+@ObjectType()
+export class CustomerDto {
+  @Field(() => ID)
+  id: string;
+
+  @Field()
+  name: string;
+}
+
+@ObjectType("Invoice")
+export class InvoiceDto {
+  @Field(() => ID)
+  id: string;
+
+  @Field()
+  reference: string;
+
+  @Field(() => Float)
+  total: number;
+
+  @Field(() => Int, { nullable: true })
+  lineCount?: number;
+
+  @Field(() => CustomerDto)
+  customer: CustomerDto;
+}
+
+@InputType()
+export class CreateInvoiceInput {
+  @Field()
+  reference: string;
+
+  @Field(() => Float)
+  total: number;
+
+  @Field({ nullable: true })
+  note?: string;
+}
+`);
+  await writeFile(root, "src/invoice/invoice.resolver.ts", `
+import { Args, Mutation, Query, Resolver, Subscription } from "@nestjs/graphql";
+import { CreateInvoiceInput, InvoiceDto } from "src/invoice/invoice.dto";
+import { UUIDScalarType } from "src/scalars";
+
+@Resolver(() => InvoiceDto)
+export class InvoiceResolver {
+  @Query(() => [InvoiceDto])
+  async invoicesList(@Args("search", { nullable: true }) search: string): Promise<InvoiceDto[]> {
+    return [];
+  }
+
+  @Query(() => InvoiceDto, { nullable: true, name: "invoice" })
+  async findInvoice(@Args("id", { type: () => UUIDScalarType }) id: string): Promise<InvoiceDto | null> {
+    return null;
+  }
+
+  @Mutation(() => InvoiceDto)
+  async createInvoice(@Args("input") input: CreateInvoiceInput): Promise<InvoiceDto> {
+    return {} as InvoiceDto;
+  }
+
+  @Mutation(() => Boolean)
+  async removeInvoice(@Args("id", { type: () => UUIDScalarType }) id: string): Promise<boolean> {
+    return true;
+  }
+
+  @Subscription(() => InvoiceDto)
+  invoiceChanged() {
+    return null;
+  }
+}
+`);
+}
+
+describe("detectGraphql", () => {
+  it("detects graphql server dependencies", async () => {
+    const sdl = await temporaryHost();
+    await writeSdlHost(sdl);
+    expect(await detectGraphql(sdl)).toBe(true);
+
+    const nest = await temporaryHost();
+    await writeNestHost(nest);
+    expect(await detectGraphql(nest)).toBe(true);
+  });
+
+  it("stays quiet for hosts without graphql", async () => {
+    const root = await temporaryHost();
+    await writeFile(root, "package.json", JSON.stringify({ name: "plain", dependencies: { next: "16.0.0" } }));
+    expect(await detectGraphql(root)).toBe(false);
+  });
+});
+
+describe("extractGraphql — SDL sources", () => {
+  it("extracts one tool per query and mutation with the route-derived endpoint", async () => {
+    const root = await temporaryHost();
+    await writeSdlHost(root);
+    const result = await extractGraphql(root);
+    const byOperation = new Map(result.tools.map((tool) => [binding(tool).operation, tool]));
+    expect([...byOperation.keys()].sort()).toEqual([
+      "createPoll",
+      "deletePoll",
+      "pollGet",
+      "pollUpdated",
+      "pollsList",
+      "renamePoll",
+      "serverVersion",
+    ]);
+    for (const tool of result.tools) {
+      expect(binding(tool).endpoint).toBe("/api/graphql");
+      expect(binding(tool).kind).toBe("graphql");
+    }
+    expect(binding(byOperation.get("pollsList")!).type).toBe("query");
+    expect(binding(byOperation.get("createPoll")!).type).toBe("mutation");
+  });
+
+  it("labels risk fail-closed: read-shaped queries read, mutations write, destructive words destructive", async () => {
+    const root = await temporaryHost();
+    await writeSdlHost(root);
+    const { tools } = await extractGraphql(root);
+    const risk = (operation: string) => tools.find((tool) => binding(tool).operation === operation)?.risk;
+    expect(risk("pollsList")).toBe("read");
+    expect(risk("pollGet")).toBe("read");
+    // A query without a read-shaped name never auto-earns read.
+    expect(risk("serverVersion")).toBe("write");
+    expect(risk("createPoll")).toBe("write");
+    expect(risk("renamePoll")).toBe("write");
+    expect(risk("deletePoll")).toBe("destructive");
+  });
+
+  it("derives inputSchema deterministically from argument types", async () => {
+    const root = await temporaryHost();
+    await writeSdlHost(root);
+    const { tools } = await extractGraphql(root);
+    const list = tools.find((tool) => binding(tool).operation === "pollsList")!;
+    expect(list.inputSchema).toEqual({
+      type: "object",
+      properties: {
+        status: { type: "string", enum: ["OPEN", "CLOSED"] },
+        search: { type: "string" },
+        limit: { type: "integer", default: 20 },
+      },
+      additionalProperties: false,
+    });
+
+    const create = tools.find((tool) => binding(tool).operation === "createPoll")!;
+    expect(create.inputSchema).toEqual({
+      type: "object",
+      properties: {
+        input: {
+          type: "object",
+          properties: {
+            title: { type: "string" },
+            options: { type: "array", items: { type: "string" } },
+            tags: { type: "array", items: { type: "string" } },
+            status: { type: "string", enum: ["OPEN", "CLOSED"] },
+          },
+          required: ["title", "options"],
+          additionalProperties: false,
+        },
+      },
+      required: ["input"],
+      additionalProperties: false,
+    });
+
+    const get = tools.find((tool) => binding(tool).operation === "pollGet")!;
+    expect(get.inputSchema).toEqual({
+      type: "object",
+      properties: { id: { type: "string" } },
+      required: ["id"],
+      additionalProperties: false,
+    });
+  });
+
+  it("builds executable documents with depth-limited default selection sets", async () => {
+    const root = await temporaryHost();
+    await writeSdlHost(root);
+    const { tools } = await extractGraphql(root);
+    const get = tools.find((tool) => binding(tool).operation === "pollGet")!;
+    // Depth 1: Poll scalars + enum + custom scalar; depth 2: nested owner
+    // scalars; arg-bearing fields (comments) are skipped.
+    expect(binding(get).document).toBe(
+      "query pollGet($id: ID!) { pollGet(id: $id) { id title votes score open status createdAt owner { id name email } } }",
+    );
+
+    const version = tools.find((tool) => binding(tool).operation === "serverVersion")!;
+    expect(binding(version).document).toBe("query serverVersion { serverVersion }");
+
+    const remove = tools.find((tool) => binding(tool).operation === "deletePoll")!;
+    expect(binding(remove).document).toBe(
+      "mutation deletePoll($id: ID!) { deletePoll(id: $id) }",
+    );
+  });
+
+  it("emits subscriptions disabled with a note, never silently enabled", async () => {
+    const root = await temporaryHost();
+    await writeSdlHost(root);
+    const result = await extractGraphql(root);
+    const updated = result.tools.find((tool) => binding(tool).operation === "pollUpdated")!;
+    expect(updated.disabled).toBe(true);
+    expect(updated.risk).toBe("destructive");
+    expect(updated.note).toContain("subscriptions");
+    expect(binding(updated).type).toBe("mutation");
+    expect(result.warnings.some((warning) => warning.includes("pollUpdated"))).toBe(true);
+  });
+
+  it("falls back to the default /graphql endpoint without a discoverable mount", async () => {
+    const root = await temporaryHost();
+    await writeFile(root, "package.json", JSON.stringify({
+      name: "sdl-bare",
+      dependencies: { graphql: "^16.9.0" },
+    }));
+    await writeFile(root, "schema.graphql", `
+type Query {
+  healthGet: String!
+}
+`);
+    const { tools } = await extractGraphql(root);
+    expect(tools).toHaveLength(1);
+    expect(binding(tools[0]!).endpoint).toBe("/graphql");
+    expect(tools[0]!.risk).toBe("read");
+  });
+
+  it("warns and extracts nothing when no schema source exists", async () => {
+    const root = await temporaryHost();
+    await writeFile(root, "package.json", JSON.stringify({
+      name: "graphql-dep-only",
+      dependencies: { graphql: "^16.9.0" },
+    }));
+    const result = await extractGraphql(root);
+    expect(result.tools).toEqual([]);
+    expect(result.warnings.some((warning) => warning.includes("no SDL schema or code-first resolvers"))).toBe(true);
+  });
+
+  it("skips unparsable SDL files with a warning instead of failing extraction", async () => {
+    const root = await temporaryHost();
+    await writeFile(root, "package.json", JSON.stringify({
+      name: "sdl-broken",
+      dependencies: { graphql: "^16.9.0" },
+    }));
+    await writeFile(root, "schema.graphql", `type Query { ok: String! }`);
+    await writeFile(root, "broken.graphql", `type { nope`);
+    const result = await extractGraphql(root);
+    expect(result.tools.map((tool) => binding(tool).operation)).toEqual(["ok"]);
+    expect(result.warnings.some((warning) => warning.includes("broken.graphql"))).toBe(true);
+  });
+
+  it("resolves schema roots renamed through a schema definition and extend clauses", async () => {
+    const root = await temporaryHost();
+    await writeFile(root, "package.json", JSON.stringify({
+      name: "sdl-renamed",
+      dependencies: { graphql: "^16.9.0" },
+    }));
+    await writeFile(root, "schema.graphql", `
+schema {
+  query: RootQuery
+  mutation: RootMutation
+}
+
+type RootQuery {
+  itemsList: [String!]!
+}
+
+type RootMutation {
+  addItem(name: String!): String!
+}
+
+extend type RootQuery {
+  itemGet(id: ID!): String
+}
+`);
+    const { tools } = await extractGraphql(root);
+    expect(tools.map((tool) => binding(tool).operation).sort()).toEqual(["addItem", "itemGet", "itemsList"]);
+  });
+
+  it("fails closed to a permissive per-argument schema on unknown custom scalars", async () => {
+    const root = await temporaryHost();
+    await writeFile(root, "package.json", JSON.stringify({
+      name: "sdl-scalar",
+      dependencies: { graphql: "^16.9.0" },
+    }));
+    await writeFile(root, "schema.graphql", `
+scalar Opaque
+
+type Query {
+  thingGet(ref: Opaque!): String
+}
+`);
+    const { tools } = await extractGraphql(root);
+    const get = tools.find((tool) => binding(tool).operation === "thingGet")!;
+    expect(get.inputSchema).toEqual({
+      type: "object",
+      properties: { ref: {} },
+      required: ["ref"],
+      additionalProperties: false,
+    });
+    expect(get.note).toContain("Opaque");
+    expect(binding(get).document).toBe("query thingGet($ref: Opaque!) { thingGet(ref: $ref) }");
+  });
+});
+
+describe("extractGraphql — code-first NestJS sources", () => {
+  it("extracts decorated queries and mutations with the module path endpoint", async () => {
+    const root = await temporaryHost();
+    await writeNestHost(root);
+    const result = await extractGraphql(root);
+    const byOperation = new Map(result.tools.map((tool) => [binding(tool).operation, tool]));
+    expect([...byOperation.keys()].sort()).toEqual([
+      "createInvoice",
+      "invoice",
+      "invoiceChanged",
+      "invoicesList",
+      "removeInvoice",
+    ]);
+    for (const tool of result.tools) {
+      expect(binding(tool).endpoint).toBe("/api/gql");
+    }
+    // The name option overrides the method name.
+    expect(byOperation.get("invoice")).toBeDefined();
+    expect(byOperation.get("findInvoice")).toBeUndefined();
+  });
+
+  it("labels code-first risk with the same fail-closed rules", async () => {
+    const root = await temporaryHost();
+    await writeNestHost(root);
+    const { tools } = await extractGraphql(root);
+    const risk = (operation: string) => tools.find((tool) => binding(tool).operation === operation)?.risk;
+    expect(risk("invoicesList")).toBe("read");
+    expect(risk("invoice")).toBe("write");
+    expect(risk("createInvoice")).toBe("write");
+    expect(risk("removeInvoice")).toBe("destructive");
+  });
+
+  it("derives inputSchema from @Args decorators, input classes, and custom scalars", async () => {
+    const root = await temporaryHost();
+    await writeNestHost(root);
+    const { tools } = await extractGraphql(root);
+    const list = tools.find((tool) => binding(tool).operation === "invoicesList")!;
+    expect(list.inputSchema).toEqual({
+      type: "object",
+      properties: { search: { type: "string" } },
+      additionalProperties: false,
+    });
+
+    const create = tools.find((tool) => binding(tool).operation === "createInvoice")!;
+    expect(create.inputSchema).toEqual({
+      type: "object",
+      properties: {
+        input: {
+          type: "object",
+          properties: {
+            reference: { type: "string" },
+            total: { type: "number" },
+            note: { type: "string" },
+          },
+          required: ["reference", "total"],
+          additionalProperties: false,
+        },
+      },
+      required: ["input"],
+      additionalProperties: false,
+    });
+
+    const get = tools.find((tool) => binding(tool).operation === "invoice")!;
+    expect(get.inputSchema).toEqual({
+      type: "object",
+      properties: { id: { type: "string", format: "uuid" } },
+      required: ["id"],
+      additionalProperties: false,
+    });
+    expect(binding(get).document).toBe(
+      "query invoice($id: UUID!) { invoice(id: $id) { id reference total lineCount customer { id name } } }",
+    );
+  });
+
+  it("builds documents with class-declared GraphQL type names in variable declarations", async () => {
+    const root = await temporaryHost();
+    await writeNestHost(root);
+    const { tools } = await extractGraphql(root);
+    const create = tools.find((tool) => binding(tool).operation === "createInvoice")!;
+    expect(binding(create).document).toBe(
+      "mutation createInvoice($input: CreateInvoiceInput!) { createInvoice(input: $input) { id reference total lineCount customer { id name } } }",
+    );
+    const remove = tools.find((tool) => binding(tool).operation === "removeInvoice")!;
+    expect(binding(remove).document).toBe(
+      "mutation removeInvoice($id: UUID!) { removeInvoice(id: $id) }",
+    );
+  });
+
+  it("emits code-first subscriptions disabled with a note", async () => {
+    const root = await temporaryHost();
+    await writeNestHost(root);
+    const { tools } = await extractGraphql(root);
+    const changed = tools.find((tool) => binding(tool).operation === "invoiceChanged")!;
+    expect(changed.disabled).toBe(true);
+    expect(changed.risk).toBe("destructive");
+    expect(changed.note).toContain("subscriptions");
+  });
+
+  it("disables every operation when multiple GraphQL endpoints defeat static attribution", async () => {
+    const root = await temporaryHost();
+    await writeNestHost(root);
+    // A second GraphQL module whose factory declares another endpoint — the
+    // Twenty shape (core /graphql + metadata /metadata + admin schemas).
+    await writeFile(root, "src/metadata.module-factory.ts", `
+export const metadataModuleFactory = () => {
+  return {
+    autoSchemaFile: true,
+    path: "/metadata",
+  };
+};
+`);
+    await writeFile(root, "src/metadata.module.ts", `
+import { Module } from "@nestjs/common";
+import { GraphQLModule } from "@nestjs/graphql";
+import { metadataModuleFactory } from "src/metadata.module-factory";
+
+@Module({
+  imports: [
+    GraphQLModule.forRootAsync({ useFactory: metadataModuleFactory }),
+  ],
+})
+export class MetadataModule {}
+`);
+    const result = await extractGraphql(root);
+    expect(result.tools.length).toBeGreaterThan(0);
+    for (const tool of result.tools) {
+      expect(tool.disabled).toBe(true);
+      expect(tool.note).toContain("endpoint");
+    }
+    // Risk labels still apply to disabled tools.
+    expect(result.tools.find((tool) => binding(tool).operation === "removeInvoice")!.risk).toBe("destructive");
+    expect(result.warnings.some((warning) => warning.includes("/metadata"))).toBe(true);
+  });
+
+  it("fails closed with a permissive schema and note when an argument cannot be interpreted", async () => {
+    const root = await temporaryHost();
+    await writeFile(root, "package.json", JSON.stringify({
+      name: "nest-opaque",
+      dependencies: { "@nestjs/graphql": "^12.0.0", graphql: "^16.9.0" },
+    }));
+    await writeFile(root, "src/thing.resolver.ts", `
+import { Args, Query, Resolver } from "@nestjs/graphql";
+import { mysteryValidator } from "@somewhere/else";
+
+@Resolver()
+export class ThingResolver {
+  @Query(() => String)
+  thingFind(@Args("filter", { type: () => mysteryValidator }) filter: unknown): string {
+    return "";
+  }
+}
+`);
+    const result = await extractGraphql(root);
+    const find = result.tools.find((tool) => binding(tool).operation === "thingFind")!;
+    // The argument's GraphQL type name cannot be declared, so the document is
+    // not executable: fail closed to disabled, never guess a wire type.
+    expect(find.disabled).toBe(true);
+    expect(find.note).toContain("filter");
+  });
+
+  it("expands @Args() args-classes into per-field arguments", async () => {
+    const root = await temporaryHost();
+    await writeFile(root, "package.json", JSON.stringify({
+      name: "nest-argsclass",
+      dependencies: { "@nestjs/graphql": "^12.0.0", graphql: "^16.9.0" },
+    }));
+    await writeFile(root, "src/search.args.ts", `
+import { ArgsType, Field, Int } from "@nestjs/graphql";
+
+@ArgsType()
+export class SearchArgs {
+  @Field()
+  term: string;
+
+  @Field(() => Int, { nullable: true })
+  limit?: number;
+}
+`);
+    await writeFile(root, "src/search.resolver.ts", `
+import { Args, Query, Resolver } from "@nestjs/graphql";
+import { SearchArgs } from "./search.args";
+
+@Resolver()
+export class SearchResolver {
+  @Query(() => [String])
+  searchList(@Args() args: SearchArgs): string[] {
+    return [];
+  }
+}
+`);
+    const result = await extractGraphql(root);
+    const search = result.tools.find((tool) => binding(tool).operation === "searchList")!;
+    expect(search.inputSchema).toEqual({
+      type: "object",
+      properties: {
+        term: { type: "string" },
+        limit: { type: "integer" },
+      },
+      required: ["term"],
+      additionalProperties: false,
+    });
+    expect(binding(search).document).toBe(
+      "query searchList($term: String!, $limit: Int) { searchList(term: $term, limit: $limit) }",
+    );
+  });
+});
+
+describe("graphql + route-scan interplay", () => {
+  it("shadows the yoga route handler when graphql tools exist for that endpoint", async () => {
+    const root = await temporaryHost();
+    await writeSdlHost(root);
+    const result = await runExtractors(root);
+    expect(result.tools.some((tool) => tool.binding.kind === "route" && tool.binding.path.startsWith("/api/graphql"))).toBe(false);
+    expect(result.tools.some((tool) => tool.binding.kind === "graphql")).toBe(true);
+  });
+
+  it("keeps SDL and code-first from double-describing one operation", async () => {
+    const root = await temporaryHost();
+    await writeNestHost(root);
+    await writeFile(root, "schema.gql", `
+type Query {
+  invoicesList(search: String): [String!]!
+}
+`);
+    const { tools } = await extractGraphql(root);
+    expect(tools.filter((tool) => binding(tool).operation === "invoicesList")).toHaveLength(1);
+  });
+});

--- a/packages/actions/src/sync/graphql.test.ts
+++ b/packages/actions/src/sync/graphql.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { GraphqlBinding } from "../formats.js";
+import { bindingIdentity } from "./common.js";
 import { runExtractors } from "./extractors.js";
 import { detectGraphql, extractGraphql } from "./graphql.js";
 
@@ -516,6 +517,51 @@ describe("extractGraphql — code-first NestJS sources", () => {
     );
   });
 
+  it("gives list-returning operations the same selection depth as single-object ones", async () => {
+    const root = await temporaryHost();
+    await writeNestHost(root);
+    const { tools } = await extractGraphql(root);
+    // [InvoiceDto] must keep the nested customer selection exactly like the
+    // bare InvoiceDto return — the list wrapper is not a nesting level.
+    const list = tools.find((tool) => binding(tool).operation === "invoicesList")!;
+    expect(binding(list).document).toBe(
+      "query invoicesList($search: String) { invoicesList(search: $search) { id reference total lineCount customer { id name } } }",
+    );
+  });
+
+  it("keeps the list wrapper for Array<T> generic argument annotations", async () => {
+    const root = await temporaryHost();
+    await writeFile(root, "package.json", JSON.stringify({
+      name: "nest-array-generic",
+      dependencies: { "@nestjs/graphql": "^12.0.0", graphql: "^16.9.0" },
+    }));
+    await writeFile(root, "src/tags.resolver.ts", `
+import { Args, Mutation, Resolver } from "@nestjs/graphql";
+
+@Resolver()
+export class TagsResolver {
+  @Mutation(() => Boolean)
+  applyTags(@Args("tags") tags: Array<string>, @Args("names") names: string[]): boolean {
+    return true;
+  }
+}
+`);
+    const { tools } = await extractGraphql(root);
+    const apply = tools.find((tool) => binding(tool).operation === "applyTags")!;
+    expect(apply.inputSchema).toEqual({
+      type: "object",
+      properties: {
+        tags: { type: "array", items: { type: "string" } },
+        names: { type: "array", items: { type: "string" } },
+      },
+      required: ["tags", "names"],
+      additionalProperties: false,
+    });
+    expect(binding(apply).document).toBe(
+      "mutation applyTags($tags: [String!]!, $names: [String!]!) { applyTags(tags: $tags, names: $names) }",
+    );
+  });
+
   it("emits code-first subscriptions disabled with a note", async () => {
     const root = await temporaryHost();
     await writeNestHost(root);
@@ -671,6 +717,31 @@ describe("graphql + route-scan interplay", () => {
     const result = await runExtractors(root);
     expect(result.tools.some((tool) => tool.binding.kind === "route" && tool.binding.path.startsWith("/api/graphql"))).toBe(false);
     expect(result.tools.some((tool) => tool.binding.kind === "graphql")).toBe(true);
+  });
+
+  it("keeps a query and a mutation that share one field name as two tools", async () => {
+    const root = await temporaryHost();
+    await writeFile(root, "package.json", JSON.stringify({
+      name: "sdl-shared-name",
+      dependencies: { graphql: "^16.9.0" },
+    }));
+    await writeFile(root, "schema.graphql", `
+type Query {
+  sync: String!
+}
+
+type Mutation {
+  sync(force: Boolean): String!
+}
+`);
+    const { tools } = await extractGraphql(root);
+    const shared = tools.filter((tool) => binding(tool).operation === "sync");
+    expect(shared).toHaveLength(2);
+    expect(shared.map((tool) => binding(tool).type).sort()).toEqual(["mutation", "query"]);
+    // Distinct dedup identities and distinct provider-safe names survive the
+    // sync union unchanged.
+    expect(new Set(shared.map((tool) => bindingIdentity(tool.binding))).size).toBe(2);
+    expect(new Set(shared.map((tool) => tool.name)).size).toBe(2);
   });
 
   it("keeps SDL and code-first from double-describing one operation", async () => {

--- a/packages/actions/src/sync/graphql.test.ts
+++ b/packages/actions/src/sync/graphql.test.ts
@@ -588,6 +588,35 @@ export class ThingResolver {
     expect(find.note).toContain("filter");
   });
 
+  it("treats graphql-type-json imports as the JSON scalar", async () => {
+    const root = await temporaryHost();
+    await writeFile(root, "package.json", JSON.stringify({
+      name: "nest-json",
+      dependencies: { "@nestjs/graphql": "^12.0.0", graphql: "^16.9.0", "graphql-type-json": "^0.3.2" },
+    }));
+    await writeFile(root, "src/config.resolver.ts", `
+import { Args, Query, Resolver } from "@nestjs/graphql";
+import graphqlTypeJson from "graphql-type-json";
+
+@Resolver()
+export class ConfigResolver {
+  @Query(() => graphqlTypeJson)
+  configGet(@Args("section", { type: () => graphqlTypeJson, nullable: true }) section: unknown): unknown {
+    return {};
+  }
+}
+`);
+    const { tools } = await extractGraphql(root);
+    const get = tools.find((tool) => binding(tool).operation === "configGet")!;
+    expect(get.disabled).toBeUndefined();
+    expect(get.inputSchema).toEqual({
+      type: "object",
+      properties: { section: {} },
+      additionalProperties: false,
+    });
+    expect(binding(get).document).toBe("query configGet($section: JSON) { configGet(section: $section) }");
+  });
+
   it("expands @Args() args-classes into per-field arguments", async () => {
     const root = await temporaryHost();
     await writeFile(root, "package.json", JSON.stringify({

--- a/packages/actions/src/sync/graphql.ts
+++ b/packages/actions/src/sync/graphql.ts
@@ -863,8 +863,7 @@ async function classFields(
       interpretation = await interpretTypeExpression(extraction, module, unwrapArrowBody(ts, first), depth + 1);
     }
     if (!interpretation) {
-      const annotation = ts.isMethodDeclaration(member) || ts.isGetAccessorDeclaration(member) ? member.type : member.type;
-      interpretation = await interpretTypeAnnotation(extraction, module, annotation, depth + 1);
+      interpretation = await interpretTypeAnnotation(extraction, module, member.type, depth + 1);
     }
     const nullable = options ? isTruthyLiteral(ts, objectProperty(ts, options, "nullable")) : false;
     const questioned = ts.isPropertyDeclaration(member) && member.questionToken !== undefined;
@@ -1087,7 +1086,7 @@ function graphqlEndpointLiteral(source: string): string | null {
 /** All `path: "/x"` string literals within a node (a GraphQLModule options
  * object or a resolved module factory body). Non-absolute literals — like a
  * playground's `path: 'metadata'` — never count as endpoints. */
-function absolutePathLiterals(ts: Ts, sf: TS.SourceFile, node: TS.Node): string[] {
+function absolutePathLiterals(ts: Ts, node: TS.Node): string[] {
   const literals: string[] = [];
   const visit = (current: TS.Node): void => {
     if (ts.isPropertyAssignment(current)) {

--- a/packages/actions/src/sync/graphql.ts
+++ b/packages/actions/src/sync/graphql.ts
@@ -57,7 +57,6 @@ const DEFAULT_ENDPOINT = "/graphql";
 const MAX_SELECTION_DEPTH = 2;
 const MAX_RESOLVE_DEPTH = 16;
 const MAX_SOURCE_FILES = 20_000;
-const PERMISSIVE_INPUT: Record<string, unknown> = { type: "object", additionalProperties: true };
 
 const GRAPHQL_SERVER_DEPENDENCIES = [
   "graphql",

--- a/packages/actions/src/sync/graphql.ts
+++ b/packages/actions/src/sync/graphql.ts
@@ -727,7 +727,9 @@ async function interpretTypeExpression(
   if (ts.isArrayLiteralExpression(expr)) {
     const element = expr.elements[0];
     if (!element) return unresolvableType("empty list type expression");
-    const inner = await interpretTypeExpression(extraction, module, element, depth + 1);
+    // A list wrapper is not a nesting level: [Invoice] must produce the same
+    // depth-limited selection set as a bare Invoice return.
+    const inner = await interpretTypeExpression(extraction, module, element, depth);
     return {
       typeName: inner.typeName === null ? null : `[${inner.typeName}!]`,
       schema: { type: "array", items: inner.schema },
@@ -818,7 +820,7 @@ async function interpretTypeAnnotation(
   if (annotation.kind === ts.SyntaxKind.NumberKeyword) return scalarByName("Number")!;
   if (annotation.kind === ts.SyntaxKind.BooleanKeyword) return scalarByName("Boolean")!;
   if (ts.isArrayTypeNode(annotation)) {
-    const inner = await interpretTypeAnnotation(extraction, module, annotation.elementType, depth + 1);
+    const inner = await interpretTypeAnnotation(extraction, module, annotation.elementType, depth);
     return {
       typeName: inner.typeName === null ? null : `[${inner.typeName}!]`,
       schema: { type: "array", items: inner.schema },
@@ -828,8 +830,19 @@ async function interpretTypeAnnotation(
   }
   if (ts.isTypeReferenceNode(annotation) && ts.isIdentifier(annotation.typeName)) {
     const name = annotation.typeName.text;
-    if (name === "Promise" || name === "Array") {
-      return interpretTypeAnnotation(extraction, module, annotation.typeArguments?.[0], depth + 1);
+    // Promise<T> is a pure unwrap; Array<T> is the generic spelling of T[]
+    // and must keep its list wrapper in both the schema and the variable type.
+    if (name === "Promise") {
+      return interpretTypeAnnotation(extraction, module, annotation.typeArguments?.[0], depth);
+    }
+    if (name === "Array") {
+      const inner = await interpretTypeAnnotation(extraction, module, annotation.typeArguments?.[0], depth);
+      return {
+        typeName: inner.typeName === null ? null : `[${inner.typeName}!]`,
+        schema: { type: "array", items: inner.schema },
+        selection: inner.selection,
+        ...(inner.reason ? { reason: inner.reason } : {}),
+      };
     }
     const scalar = scalarByName(name);
     if (scalar && name !== "Number") return scalar; // Date and friends
@@ -1257,12 +1270,20 @@ export async function extractGraphql(root: string): Promise<GraphqlExtractResult
   }
 
   // SDL is the more authoritative schema description; code-first duplicates
-  // of the same operation name are dropped.
+  // of the same operation are dropped. The key carries the binding-visible
+  // kind, so a query and a mutation legitimately sharing one name stay two
+  // tools; invokable operations are deduplicated before subscription
+  // placeholders so a disabled placeholder never shadows a real operation.
   const seen = new Set<string>();
   const operations: OperationDef[] = [];
-  for (const def of [...sdlOperationDefs, ...codeFirstOperationDefs]) {
-    if (seen.has(def.operation)) continue;
-    seen.add(def.operation);
+  const ordered = [...sdlOperationDefs, ...codeFirstOperationDefs];
+  for (const def of [
+    ...ordered.filter((def) => def.type !== "subscription"),
+    ...ordered.filter((def) => def.type === "subscription"),
+  ]) {
+    const key = `${def.type === "query" ? "query" : "mutation"}\t${def.operation}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
     operations.push(def);
   }
 

--- a/packages/actions/src/sync/graphql.ts
+++ b/packages/actions/src/sync/graphql.ts
@@ -1120,7 +1120,7 @@ async function nestEndpoints(
           endpoints.push(DEFAULT_ENDPOINT);
           return;
         }
-        const direct = absolutePathLiterals(ts, module.sf, options);
+        const direct = absolutePathLiterals(ts, options);
         if (direct.length > 0) {
           endpoints.push(direct[0]!);
           return;
@@ -1129,7 +1129,7 @@ async function nestEndpoints(
         if (factory && ts.isIdentifier(factory)) {
           const resolved = await resolveIdentifier(extraction, module, factory.text, 0);
           if (resolved) {
-            const fromFactory = absolutePathLiterals(extraction.ts, resolved.module.sf, resolved.node);
+            const fromFactory = absolutePathLiterals(extraction.ts, resolved.node);
             if (fromFactory.length > 0) {
               endpoints.push(fromFactory[0]!);
               return;

--- a/packages/actions/src/sync/graphql.ts
+++ b/packages/actions/src/sync/graphql.ts
@@ -739,6 +739,11 @@ async function interpretTypeExpression(
   if (ts.isIdentifier(expr)) {
     const scalar = scalarByName(expr.text);
     if (scalar) return scalar;
+    // The graphql-type-json package IS the JSON scalar — no resolution needed.
+    const imported = importMap(extraction, module).get(expr.text);
+    if (imported?.specifier === "graphql-type-json") {
+      return { typeName: imported.imported === "GraphQLJSONObject" ? "JSONObject" : "JSON", schema: {}, selection: "" };
+    }
     const resolved = await resolveIdentifier(extraction, module, expr.text, depth + 1);
     if (!resolved) return unresolvableType(`type reference "${expr.text}" could not be statically resolved`);
     return interpretResolvedType(extraction, resolved, expr.text, depth + 1);

--- a/packages/actions/src/sync/graphql.ts
+++ b/packages/actions/src/sync/graphql.ts
@@ -1,0 +1,1287 @@
+import { promises as fs } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import type TS from "typescript";
+import type {
+  DefinitionNode,
+  EnumTypeDefinitionNode,
+  EnumTypeExtensionNode,
+  FieldDefinitionNode,
+  InputObjectTypeDefinitionNode,
+  InputObjectTypeExtensionNode,
+  InputValueDefinitionNode,
+  InterfaceTypeDefinitionNode,
+  InterfaceTypeExtensionNode,
+  ObjectTypeDefinitionNode,
+  ObjectTypeExtensionNode,
+  TypeNode,
+  ValueNode,
+} from "graphql";
+import type { ExtractedTool, GraphqlBinding } from "../formats.js";
+import {
+  allocateToolName,
+  graphqlRisk,
+  graphqlToolFullName,
+  resolveImportSource,
+  walk,
+} from "./common.js";
+import { loadTypescript } from "./trpc.js";
+
+/**
+ * Static GraphQL extraction (04 §1, additive within vendo/tools@1).
+ *
+ * The schema is read statically from SDL files (parsed with the HOST's own
+ * graphql package) and from code-first sources (@nestjs/graphql and
+ * type-graphql resolver classes, parsed with the TypeScript compiler API) —
+ * no host code is executed and no LLM runs. One tool per query and per
+ * mutation; inputSchema is derived deterministically from GraphQL argument
+ * types; execution documents carry depth-limited default selection sets.
+ *
+ * Fail-closed rules: subscriptions and operations whose arguments or return
+ * types cannot be statically interpreted are emitted `disabled: true` with a
+ * note; when several GraphQL endpoints defeat static operation-to-endpoint
+ * attribution, every operation is emitted disabled rather than guessing.
+ */
+
+type Ts = typeof TS;
+type GraphqlJs = { parse(source: string): { definitions: readonly DefinitionNode[] } };
+
+export interface GraphqlExtractResult {
+  tools: ExtractedTool[];
+  warnings: string[];
+}
+
+const SOURCE_FILE_PATTERN = /\.(?:tsx?|jsx?)$/;
+const SDL_FILE_PATTERN = /\.(?:graphql|graphqls|gql)$/i;
+const DEFAULT_ENDPOINT = "/graphql";
+const MAX_SELECTION_DEPTH = 2;
+const MAX_RESOLVE_DEPTH = 16;
+const MAX_SOURCE_FILES = 20_000;
+const PERMISSIVE_INPUT: Record<string, unknown> = { type: "object", additionalProperties: true };
+
+const GRAPHQL_SERVER_DEPENDENCIES = [
+  "graphql",
+  "@nestjs/graphql",
+  "graphql-yoga",
+  "@graphql-yoga/nestjs",
+  "@apollo/server",
+  "apollo-server",
+  "apollo-server-express",
+  "apollo-server-micro",
+  "type-graphql",
+  "graphql-http",
+  "express-graphql",
+];
+
+const CODE_FIRST_LIBS = new Set(["@nestjs/graphql", "type-graphql"]);
+const ROUTE_SERVER_MARKER = /graphql-yoga|@apollo\/server|apollo-server-micro|graphql-http|@as-integrations\/next/;
+
+/** Resolve the host's own graphql package (fail-closed). The fallback require
+ * targets our devDependency so tests and monorepo dev work without a host
+ * install. */
+export function loadGraphqlJs(root: string): GraphqlJs | null {
+  for (const base of [path.join(root, "package.json"), import.meta.url]) {
+    try {
+      return createRequire(base)("graphql") as GraphqlJs;
+    } catch {
+      // Try the next resolution base.
+    }
+  }
+  return null;
+}
+
+async function readPackageJson(root: string): Promise<Record<string, unknown> | null> {
+  try {
+    return JSON.parse(await fs.readFile(path.join(root, "package.json"), "utf8")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export async function detectGraphql(root: string): Promise<boolean> {
+  const pkg = await readPackageJson(root);
+  if (!pkg) return false;
+  for (const field of ["dependencies", "devDependencies", "peerDependencies"] as const) {
+    const deps = pkg[field];
+    if (!deps || typeof deps !== "object") continue;
+    if (GRAPHQL_SERVER_DEPENDENCIES.some((name) => name in (deps as Record<string, unknown>))) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Shared operation IR (SDL and code-first sources assemble the same shape)
+// ---------------------------------------------------------------------------
+
+interface OperationArg {
+  name: string;
+  /** Printed GraphQL variable type, e.g. "[String!]!" — null when the type
+   * cannot be statically named (the document is then not executable). */
+  typeName: string | null;
+  required: boolean;
+  schema: Record<string, unknown>;
+  reason?: string;
+}
+
+interface OperationDef {
+  operation: string;
+  type: "query" | "mutation" | "subscription";
+  args: OperationArg[];
+  /** "{ id name }" for object results, "" for scalar results, null when the
+   * return type cannot be statically resolved. */
+  selection: string | null;
+  selectionReason?: string;
+}
+
+function inputSchemaFor(def: OperationDef): { schema: Record<string, unknown>; reasons: string[] } {
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+  const reasons: string[] = [];
+  for (const arg of def.args) {
+    properties[arg.name] = arg.schema;
+    if (arg.required) required.push(arg.name);
+    if (arg.reason) reasons.push(`${arg.name}: ${arg.reason}`);
+  }
+  if (def.args.length === 0) return { schema: { type: "object", properties: {} }, reasons };
+  return {
+    schema: {
+      type: "object",
+      properties,
+      ...(required.length > 0 ? { required } : {}),
+      additionalProperties: false,
+    },
+    reasons,
+  };
+}
+
+function documentFor(def: OperationDef, type: "query" | "mutation" | "subscription"): string | null {
+  if (def.selection === null) return null;
+  if (def.args.some((arg) => arg.typeName === null)) return null;
+  const declarations = def.args.map((arg) => `$${arg.name}: ${arg.typeName!}`).join(", ");
+  const bindings = def.args.map((arg) => `${arg.name}: $${arg.name}`).join(", ");
+  const head = `${type} ${def.operation}${declarations ? `(${declarations})` : ""}`;
+  const field = `${def.operation}${bindings ? `(${bindings})` : ""}`;
+  return `${head} { ${field}${def.selection ? ` ${def.selection}` : ""} }`;
+}
+
+interface EndpointResolution {
+  endpoint: string;
+  ambiguous: boolean;
+  endpoints: string[];
+}
+
+function assembleTools(
+  operations: OperationDef[],
+  endpoints: EndpointResolution,
+  warnings: string[],
+): ExtractedTool[] {
+  const tools: ExtractedTool[] = [];
+  const usedNames = new Set<string>();
+  const ambiguousNote = endpoints.ambiguous
+    ? `operation-to-endpoint attribution is not static across ${endpoints.endpoints.length} GraphQL endpoints (${endpoints.endpoints.join(", ")}); bound to ${endpoints.endpoint}; verify the endpoint and enable via overrides.json`
+    : null;
+
+  for (const def of operations) {
+    const { schema, reasons } = inputSchemaFor(def);
+    const notes: string[] = [];
+    let disabled = false;
+
+    if (def.type === "subscription") {
+      const name = allocateToolName(graphqlToolFullName(def.operation), "mutation", usedNames);
+      const document = documentFor(def, "subscription");
+      tools.push({
+        name,
+        description: `GraphQL subscription ${def.operation} is not invokable over a single HTTP request`,
+        inputSchema: schema,
+        risk: "destructive",
+        disabled: true,
+        note: [
+          "GraphQL subscriptions are not invokable over the single-request HTTP transport; enable only after review; overrides.json can flip disabled/risk",
+          ...(ambiguousNote ? [ambiguousNote] : []),
+        ].join("; "),
+        binding: bindingFor(def.operation, "mutation", endpoints.endpoint, document),
+      });
+      warnings.push(`graphql subscription ${def.operation} was emitted disabled: subscriptions are not invokable over a single HTTP request`);
+      continue;
+    }
+
+    const unresolvableArgs = def.args.filter((arg) => arg.typeName === null).map((arg) => arg.name);
+    if (unresolvableArgs.length > 0) {
+      disabled = true;
+      notes.push(`argument${unresolvableArgs.length > 1 ? "s" : ""} ${unresolvableArgs.map((argName) => `"${argName}"`).join(", ")} could not be statically declared, so no executable document was generated; enable only after review`);
+    }
+    if (def.selection === null) {
+      disabled = true;
+      notes.push(`return type could not be statically resolved (${def.selectionReason ?? "unrecognized type"}), so no executable document was generated; enable only after review`);
+    }
+    if (reasons.length > 0) {
+      notes.push(`input schema partially interpreted; permissive where unknown (${reasons.join("; ")})`);
+    }
+    if (ambiguousNote) {
+      disabled = true;
+      notes.push(ambiguousNote);
+    }
+
+    const name = allocateToolName(graphqlToolFullName(def.operation), def.type, usedNames);
+    const document = documentFor(def, def.type);
+    tools.push({
+      name,
+      description: `GraphQL ${def.type} ${def.operation}`,
+      inputSchema: schema,
+      risk: graphqlRisk(def.type, def.operation),
+      ...(disabled ? { disabled: true } : {}),
+      ...(notes.length > 0 ? { note: notes.join("; ") } : {}),
+      binding: bindingFor(def.operation, def.type, endpoints.endpoint, document),
+    });
+    if (unresolvableArgs.length > 0 || def.selection === null) {
+      warnings.push(`graphql operation ${def.operation} was emitted disabled: ${notes[0]!}`);
+    }
+  }
+  return tools;
+}
+
+function bindingFor(
+  operation: string,
+  type: "query" | "mutation",
+  endpoint: string,
+  document: string | null,
+): GraphqlBinding {
+  return {
+    kind: "graphql",
+    operation,
+    type,
+    endpoint,
+    ...(document !== null ? { document } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SDL sources
+// ---------------------------------------------------------------------------
+
+interface SdlIndex {
+  objects: Map<string, FieldDefinitionNode[]>;    // object + interface types
+  inputs: Map<string, InputValueDefinitionNode[]>;
+  enums: Map<string, string[]>;
+  unions: Set<string>;
+  declaredScalars: Set<string>;
+  roots: { query: string; mutation: string; subscription: string };
+}
+
+type WithFields = ObjectTypeDefinitionNode | ObjectTypeExtensionNode | InterfaceTypeDefinitionNode | InterfaceTypeExtensionNode;
+type WithInputFields = InputObjectTypeDefinitionNode | InputObjectTypeExtensionNode;
+type WithEnumValues = EnumTypeDefinitionNode | EnumTypeExtensionNode;
+
+function indexSdlDefinitions(documents: readonly DefinitionNode[][]): SdlIndex {
+  const index: SdlIndex = {
+    objects: new Map(),
+    inputs: new Map(),
+    enums: new Map(),
+    unions: new Set(),
+    declaredScalars: new Set(),
+    roots: { query: "Query", mutation: "Mutation", subscription: "Subscription" },
+  };
+  const appendFields = (name: string, node: WithFields): void => {
+    const fields = index.objects.get(name) ?? [];
+    fields.push(...(node.fields ?? []));
+    index.objects.set(name, fields);
+  };
+  for (const definitions of documents) {
+    for (const definition of definitions) {
+      switch (definition.kind) {
+        case "SchemaDefinition":
+        case "SchemaExtension":
+          for (const operationType of definition.operationTypes ?? []) {
+            index.roots[operationType.operation] = operationType.type.name.value;
+          }
+          break;
+        case "ObjectTypeDefinition":
+        case "ObjectTypeExtension":
+        case "InterfaceTypeDefinition":
+        case "InterfaceTypeExtension":
+          appendFields(definition.name.value, definition as WithFields);
+          break;
+        case "InputObjectTypeDefinition":
+        case "InputObjectTypeExtension": {
+          const input = definition as WithInputFields;
+          const fields = index.inputs.get(input.name.value) ?? [];
+          fields.push(...(input.fields ?? []));
+          index.inputs.set(input.name.value, fields);
+          break;
+        }
+        case "EnumTypeDefinition":
+        case "EnumTypeExtension": {
+          const enumeration = definition as WithEnumValues;
+          const values = index.enums.get(enumeration.name.value) ?? [];
+          values.push(...(enumeration.values ?? []).map((value) => value.name.value));
+          index.enums.set(enumeration.name.value, values);
+          break;
+        }
+        case "UnionTypeDefinition":
+        case "UnionTypeExtension":
+          index.unions.add(definition.name.value);
+          break;
+        case "ScalarTypeDefinition":
+        case "ScalarTypeExtension":
+          index.declaredScalars.add(definition.name.value);
+          break;
+        default:
+          break;
+      }
+    }
+  }
+  return index;
+}
+
+function printSdlType(node: TypeNode): string {
+  if (node.kind === "NonNullType") return `${printSdlType(node.type)}!`;
+  if (node.kind === "ListType") return `[${printSdlType(node.type)}]`;
+  return node.name.value;
+}
+
+function unwrapSdlType(node: TypeNode): string {
+  if (node.kind === "NonNullType" || node.kind === "ListType") return unwrapSdlType(node.type);
+  return node.name.value;
+}
+
+const BUILTIN_SCALAR_SCHEMAS: Record<string, Record<string, unknown>> = {
+  String: { type: "string" },
+  ID: { type: "string" },
+  Int: { type: "integer" },
+  BigInt: { type: "integer" },
+  Float: { type: "number" },
+  BigFloat: { type: "number" },
+  Boolean: { type: "boolean" },
+  DateTime: { type: "string", format: "date-time" },
+  Date: { type: "string", format: "date" },
+  Time: { type: "string", format: "time" },
+  UUID: { type: "string", format: "uuid" },
+  JSON: {},
+  JSONObject: {},
+};
+
+function literalValueNode(node: ValueNode): string | number | boolean | null | undefined {
+  switch (node.kind) {
+    case "StringValue":
+    case "EnumValue":
+      return node.value;
+    case "IntValue":
+    case "FloatValue":
+      return Number(node.value);
+    case "BooleanValue":
+      return node.value;
+    case "NullValue":
+      return null;
+    default:
+      return undefined;
+  }
+}
+
+function sdlSchemaFor(
+  index: SdlIndex,
+  node: TypeNode,
+  seen: readonly string[],
+): { schema: Record<string, unknown>; reason?: string } {
+  if (node.kind === "NonNullType") return sdlSchemaFor(index, node.type, seen);
+  if (node.kind === "ListType") {
+    const items = sdlSchemaFor(index, node.type, seen);
+    return { schema: { type: "array", items: items.schema }, ...(items.reason ? { reason: items.reason } : {}) };
+  }
+  const name = node.name.value;
+  const builtin = BUILTIN_SCALAR_SCHEMAS[name];
+  if (builtin && !index.inputs.has(name) && !index.enums.has(name)) return { schema: { ...builtin } };
+  const values = index.enums.get(name);
+  if (values) return { schema: { type: "string", enum: values } };
+  const inputFields = index.inputs.get(name);
+  if (inputFields) {
+    if (seen.includes(name) || seen.length >= MAX_RESOLVE_DEPTH) {
+      return { schema: {}, reason: `input type ${name} exceeded the static interpretation depth` };
+    }
+    const properties: Record<string, unknown> = {};
+    const required: string[] = [];
+    const reasons: string[] = [];
+    for (const field of inputFields) {
+      const value = sdlSchemaFor(index, field.type, [...seen, name]);
+      const withDefault = applyDefault(value.schema, field.defaultValue);
+      properties[field.name.value] = withDefault.schema;
+      if (field.type.kind === "NonNullType" && !withDefault.hasDefault) required.push(field.name.value);
+      if (value.reason) reasons.push(value.reason);
+    }
+    return {
+      schema: {
+        type: "object",
+        properties,
+        ...(required.length > 0 ? { required } : {}),
+        additionalProperties: false,
+      },
+      ...(reasons.length > 0 ? { reason: reasons.join("; ") } : {}),
+    };
+  }
+  return { schema: {}, reason: `custom scalar ${name} is not statically interpreted` };
+}
+
+function applyDefault(
+  schema: Record<string, unknown>,
+  defaultValue: ValueNode | undefined,
+): { schema: Record<string, unknown>; hasDefault: boolean } {
+  if (!defaultValue) return { schema, hasDefault: false };
+  const literal = literalValueNode(defaultValue);
+  return {
+    schema: literal !== undefined ? { ...schema, default: literal } : schema,
+    hasDefault: true,
+  };
+}
+
+function sdlSelectionFor(index: SdlIndex, node: TypeNode, depth: number): string {
+  const name = unwrapSdlType(node);
+  if (index.unions.has(name)) return "{ __typename }";
+  const fields = index.objects.get(name);
+  if (!fields) return ""; // scalar or enum leaf
+  const parts: string[] = [];
+  for (const field of fields) {
+    if ((field.arguments ?? []).length > 0) continue; // parameterized fields never join default selections
+    const fieldTypeName = unwrapSdlType(field.type);
+    if (index.objects.has(fieldTypeName) || index.unions.has(fieldTypeName)) {
+      if (depth >= MAX_SELECTION_DEPTH) continue;
+      const nested = sdlSelectionFor(index, field.type, depth + 1);
+      if (nested !== "") parts.push(`${field.name.value} ${nested}`);
+      continue;
+    }
+    parts.push(field.name.value);
+  }
+  if (parts.length === 0) return "{ __typename }";
+  return `{ ${parts.join(" ")} }`;
+}
+
+function sdlVariableType(node: TypeNode, hasDefault: boolean): string {
+  const printed = printSdlType(node);
+  // A non-null argument with a schema default still accepts a nullable
+  // variable (spec: nullability + location default), and a nullable variable
+  // is the only way the agent can omit the optional argument.
+  if (hasDefault && printed.endsWith("!")) return printed.slice(0, -1);
+  return printed;
+}
+
+function sdlOperations(index: SdlIndex): OperationDef[] {
+  const operations: OperationDef[] = [];
+  const rootEntries: Array<{ type: OperationDef["type"]; rootName: string }> = [
+    { type: "query", rootName: index.roots.query },
+    { type: "mutation", rootName: index.roots.mutation },
+    { type: "subscription", rootName: index.roots.subscription },
+  ];
+  for (const { type, rootName } of rootEntries) {
+    const fields = index.objects.get(rootName);
+    if (!fields) continue;
+    for (const field of fields) {
+      const args: OperationArg[] = (field.arguments ?? []).map((argument) => {
+        const value = sdlSchemaFor(index, argument.type, []);
+        const withDefault = applyDefault(value.schema, argument.defaultValue);
+        return {
+          name: argument.name.value,
+          typeName: sdlVariableType(argument.type, withDefault.hasDefault),
+          required: argument.type.kind === "NonNullType" && !withDefault.hasDefault,
+          schema: withDefault.schema,
+          ...(value.reason ? { reason: value.reason } : {}),
+        };
+      });
+      operations.push({
+        operation: field.name.value,
+        type,
+        args,
+        selection: sdlSelectionFor(index, field.type, 1),
+      });
+    }
+  }
+  return operations;
+}
+
+// ---------------------------------------------------------------------------
+// Code-first sources (@nestjs/graphql, type-graphql) — TypeScript AST
+// ---------------------------------------------------------------------------
+
+interface FileModule {
+  file: string;
+  source: string;
+  sf: TS.SourceFile;
+}
+
+interface Extraction {
+  ts: Ts;
+  root: string;
+  modules: Map<string, FileModule>;
+}
+
+function parseModule(extraction: Extraction, file: string, source: string): FileModule {
+  const cached = extraction.modules.get(file);
+  if (cached) return cached;
+  const { ts } = extraction;
+  const scriptKind = file.endsWith(".tsx") || file.endsWith(".jsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+  const sf = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, scriptKind);
+  const module = { file, source, sf };
+  extraction.modules.set(file, module);
+  return module;
+}
+
+/** import local name → specifier + imported name, for one module. */
+function importMap(extraction: Extraction, module: FileModule): Map<string, { specifier: string; imported: string }> {
+  const { ts } = extraction;
+  const imports = new Map<string, { specifier: string; imported: string }>();
+  for (const statement of module.sf.statements) {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    const specifier = statement.moduleSpecifier.text;
+    const clause = statement.importClause;
+    if (!clause) continue;
+    if (clause.name) imports.set(clause.name.text, { specifier, imported: "default" });
+    const bindings = clause.namedBindings;
+    if (bindings && ts.isNamedImports(bindings)) {
+      for (const element of bindings.elements) {
+        imports.set(element.name.text, {
+          specifier,
+          imported: (element.propertyName ?? element.name).text,
+        });
+      }
+    }
+    if (bindings && ts.isNamespaceImport(bindings)) {
+      imports.set(bindings.name.text, { specifier, imported: "*" });
+    }
+  }
+  return imports;
+}
+
+type ResolvedNode = { module: FileModule; node: TS.Node };
+
+/** Find a top-level declaration by name: variable initializer, class, enum,
+ * or function declaration. */
+function localDeclaration(extraction: Extraction, module: FileModule, name: string): TS.Node | null {
+  const { ts } = extraction;
+  for (const statement of module.sf.statements) {
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (ts.isIdentifier(declaration.name) && declaration.name.text === name && declaration.initializer) {
+          return declaration.initializer;
+        }
+      }
+    }
+    if ((ts.isClassDeclaration(statement) || ts.isEnumDeclaration(statement) || ts.isFunctionDeclaration(statement))
+        && statement.name?.text === name) {
+      return statement;
+    }
+  }
+  return null;
+}
+
+/** Follow `export { x } from "./y"` and `export * from "./y"` chains. */
+async function resolveExport(
+  extraction: Extraction,
+  module: FileModule,
+  name: string,
+  depth: number,
+): Promise<ResolvedNode | null> {
+  if (depth > MAX_RESOLVE_DEPTH) return null;
+  const { ts } = extraction;
+  const local = localDeclaration(extraction, module, name);
+  if (local) return { module, node: local };
+
+  for (const statement of module.sf.statements) {
+    if (!ts.isExportDeclaration(statement) || !statement.moduleSpecifier || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    const clause = statement.exportClause;
+    let exportedAs: string | null = null;
+    if (clause && ts.isNamedExports(clause)) {
+      for (const element of clause.elements) {
+        if (element.name.text === name) exportedAs = (element.propertyName ?? element.name).text;
+      }
+      if (exportedAs === null) continue;
+    } else if (clause) {
+      continue; // namespace re-export
+    } else {
+      exportedAs = name; // export * — try the same name
+    }
+    const resolved = await resolveImportSource(module.file, statement.moduleSpecifier.text, extraction.root);
+    if (!resolved) continue;
+    const target = parseModule(extraction, resolved.file, resolved.source);
+    const found = await resolveExport(extraction, target, exportedAs, depth + 1);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Resolve an identifier to its defining declaration, following local
+ * declarations and one-hop-per-level imports. Returns null (fail-closed) for
+ * anything defined outside the host root. */
+async function resolveIdentifier(
+  extraction: Extraction,
+  module: FileModule,
+  name: string,
+  depth: number,
+): Promise<ResolvedNode | null> {
+  if (depth > MAX_RESOLVE_DEPTH) return null;
+  const local = localDeclaration(extraction, module, name);
+  if (local) return { module, node: local };
+  const imported = importMap(extraction, module).get(name);
+  if (!imported || imported.imported === "*") return null;
+  const resolved = await resolveImportSource(module.file, imported.specifier, extraction.root);
+  if (!resolved) return null;
+  const target = parseModule(extraction, resolved.file, resolved.source);
+  return resolveExport(extraction, target, imported.imported, depth + 1);
+}
+
+function decoratorsOf(ts: Ts, node: TS.Node): readonly TS.Decorator[] {
+  const modern = ts as unknown as {
+    canHaveDecorators?: (node: TS.Node) => boolean;
+    getDecorators?: (node: TS.Node) => readonly TS.Decorator[] | undefined;
+  };
+  if (modern.canHaveDecorators && modern.getDecorators) {
+    return modern.canHaveDecorators(node) ? modern.getDecorators(node) ?? [] : [];
+  }
+  const legacy = (node as { decorators?: readonly TS.Decorator[] }).decorators;
+  return legacy ?? [];
+}
+
+interface DecoratorCall {
+  name: string;
+  args: readonly TS.Expression[];
+}
+
+/** Decorator calls on a node whose factory is imported from a code-first
+ * GraphQL library — a same-named local helper never counts. */
+function graphqlDecorators(extraction: Extraction, module: FileModule, node: TS.Node): DecoratorCall[] {
+  const { ts } = extraction;
+  const imports = importMap(extraction, module);
+  const calls: DecoratorCall[] = [];
+  for (const decorator of decoratorsOf(ts, node)) {
+    const expr = decorator.expression;
+    if (!ts.isCallExpression(expr) || !ts.isIdentifier(expr.expression)) continue;
+    const imported = imports.get(expr.expression.text);
+    if (!imported || !CODE_FIRST_LIBS.has(imported.specifier)) continue;
+    calls.push({ name: imported.imported, args: expr.arguments });
+  }
+  return calls;
+}
+
+function objectProperty(ts: Ts, literal: TS.ObjectLiteralExpression, name: string): TS.Expression | null {
+  for (const property of literal.properties) {
+    if (!ts.isPropertyAssignment(property)) continue;
+    const key = ts.isIdentifier(property.name) || ts.isStringLiteral(property.name) ? property.name.text : null;
+    if (key === name) return property.initializer;
+  }
+  return null;
+}
+
+function stringLiteralValue(ts: Ts, expr: TS.Expression | null): string | null {
+  if (expr && (ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr))) return expr.text;
+  return null;
+}
+
+function isTruthyLiteral(ts: Ts, expr: TS.Expression | null): boolean {
+  if (!expr) return false;
+  if (expr.kind === ts.SyntaxKind.TrueKeyword) return true;
+  if (ts.isStringLiteral(expr)) return true; // nullable: "items" / "itemsAndList"
+  return false;
+}
+
+/** The statically-interpreted view of one GraphQL type expression. */
+interface TypeInterpretation {
+  /** Named GraphQL type with wrappers, e.g. "[Invoice!]" — null when unnameable. */
+  typeName: string | null;
+  schema: Record<string, unknown>;
+  /** "" for scalar leaves, "{ ... }" for objects, null when unresolvable. */
+  selection: string | null;
+  reason?: string;
+}
+
+const CODE_FIRST_SCALARS: Record<string, { typeName: string; schema: Record<string, unknown> }> = {
+  String: { typeName: "String", schema: { type: "string" } },
+  Number: { typeName: "Float", schema: { type: "number" } },
+  Boolean: { typeName: "Boolean", schema: { type: "boolean" } },
+  Int: { typeName: "Int", schema: { type: "integer" } },
+  Float: { typeName: "Float", schema: { type: "number" } },
+  ID: { typeName: "ID", schema: { type: "string" } },
+  Date: { typeName: "DateTime", schema: { type: "string", format: "date-time" } },
+  GraphQLISODateTime: { typeName: "DateTime", schema: { type: "string", format: "date-time" } },
+  GraphQLTimestamp: { typeName: "Timestamp", schema: { type: "number" } },
+  GraphQLJSON: { typeName: "JSON", schema: {} },
+  GraphQLJSONObject: { typeName: "JSONObject", schema: {} },
+};
+
+function scalarByName(name: string): TypeInterpretation | null {
+  const scalar = CODE_FIRST_SCALARS[name];
+  if (!scalar) return null;
+  return { typeName: scalar.typeName, schema: { ...scalar.schema }, selection: "" };
+}
+
+function unresolvableType(reason: string): TypeInterpretation {
+  return { typeName: null, schema: {}, selection: null, reason };
+}
+
+/** Interpret a `() => T` type expression from a decorator argument. */
+async function interpretTypeExpression(
+  extraction: Extraction,
+  module: FileModule,
+  expr: TS.Expression,
+  depth: number,
+): Promise<TypeInterpretation> {
+  const { ts } = extraction;
+  if (depth > MAX_RESOLVE_DEPTH) return unresolvableType("type nesting exceeded the static interpretation depth");
+  if (ts.isParenthesizedExpression(expr) || ts.isAsExpression(expr)) {
+    return interpretTypeExpression(extraction, module, expr.expression, depth + 1);
+  }
+  if (ts.isArrayLiteralExpression(expr)) {
+    const element = expr.elements[0];
+    if (!element) return unresolvableType("empty list type expression");
+    const inner = await interpretTypeExpression(extraction, module, element, depth + 1);
+    return {
+      typeName: inner.typeName === null ? null : `[${inner.typeName}!]`,
+      schema: { type: "array", items: inner.schema },
+      selection: inner.selection,
+      ...(inner.reason ? { reason: inner.reason } : {}),
+    };
+  }
+  if (ts.isIdentifier(expr)) {
+    const scalar = scalarByName(expr.text);
+    if (scalar) return scalar;
+    const resolved = await resolveIdentifier(extraction, module, expr.text, depth + 1);
+    if (!resolved) return unresolvableType(`type reference "${expr.text}" could not be statically resolved`);
+    return interpretResolvedType(extraction, resolved, expr.text, depth + 1);
+  }
+  return unresolvableType("type expression shape is not statically interpreted");
+}
+
+async function interpretResolvedType(
+  extraction: Extraction,
+  resolved: ResolvedNode,
+  referenceName: string,
+  depth: number,
+): Promise<TypeInterpretation> {
+  const { ts } = extraction;
+  const { node, module } = resolved;
+  if (ts.isClassDeclaration(node)) {
+    return interpretClassType(extraction, module, node, depth);
+  }
+  if (ts.isEnumDeclaration(node)) {
+    const values = node.members
+      .map((member) => ts.isIdentifier(member.name) || ts.isStringLiteral(member.name) ? member.name.text : null)
+      .filter((value): value is string => value !== null);
+    return { typeName: node.name.text, schema: { type: "string", enum: values }, selection: "" };
+  }
+  // `new GraphQLScalarType({ name: "UUID", ... })` — a custom scalar constant.
+  if (ts.isNewExpression(node) || ts.isCallExpression(node)) {
+    const argument = node.arguments?.[0];
+    if (argument && ts.isObjectLiteralExpression(argument)) {
+      const name = stringLiteralValue(ts, objectProperty(ts, argument, "name"));
+      if (name) {
+        const builtin = BUILTIN_SCALAR_SCHEMAS[name];
+        return {
+          typeName: name,
+          schema: builtin ? { ...builtin } : {},
+          selection: "",
+          ...(builtin ? {} : { reason: `custom scalar ${name} is not statically interpreted` }),
+        };
+      }
+    }
+  }
+  return unresolvableType(`type reference "${referenceName}" is not a statically interpretable GraphQL type`);
+}
+
+interface ClassFieldInfo {
+  name: string;
+  interpretation: TypeInterpretation;
+  optional: boolean;
+  hasArguments: boolean;
+}
+
+function graphqlClassName(extraction: Extraction, module: FileModule, node: TS.ClassDeclaration): string | null {
+  const { ts } = extraction;
+  for (const call of graphqlDecorators(extraction, module, node)) {
+    if (!["ObjectType", "InputType", "ArgsType", "InterfaceType"].includes(call.name)) continue;
+    const first = call.args[0];
+    if (first && (ts.isStringLiteral(first) || ts.isNoSubstitutionTemplateLiteral(first))) return first.text;
+    return node.name?.text ?? null;
+  }
+  return node.name?.text ?? null;
+}
+
+/** Interpret a TS type annotation as a GraphQL type (the code-first implicit
+ * scalar inference: string/number/boolean; class references resolve). */
+async function interpretTypeAnnotation(
+  extraction: Extraction,
+  module: FileModule,
+  annotation: TS.TypeNode | undefined,
+  depth: number,
+): Promise<TypeInterpretation> {
+  const { ts } = extraction;
+  if (!annotation) return unresolvableType("no static type annotation");
+  if (annotation.kind === ts.SyntaxKind.StringKeyword) return scalarByName("String")!;
+  if (annotation.kind === ts.SyntaxKind.NumberKeyword) return scalarByName("Number")!;
+  if (annotation.kind === ts.SyntaxKind.BooleanKeyword) return scalarByName("Boolean")!;
+  if (ts.isArrayTypeNode(annotation)) {
+    const inner = await interpretTypeAnnotation(extraction, module, annotation.elementType, depth + 1);
+    return {
+      typeName: inner.typeName === null ? null : `[${inner.typeName}!]`,
+      schema: { type: "array", items: inner.schema },
+      selection: inner.selection,
+      ...(inner.reason ? { reason: inner.reason } : {}),
+    };
+  }
+  if (ts.isTypeReferenceNode(annotation) && ts.isIdentifier(annotation.typeName)) {
+    const name = annotation.typeName.text;
+    if (name === "Promise" || name === "Array") {
+      return interpretTypeAnnotation(extraction, module, annotation.typeArguments?.[0], depth + 1);
+    }
+    const scalar = scalarByName(name);
+    if (scalar && name !== "Number") return scalar; // Date and friends
+    const resolved = await resolveIdentifier(extraction, module, name, depth + 1);
+    if (!resolved) return unresolvableType(`type reference "${name}" could not be statically resolved`);
+    return interpretResolvedType(extraction, resolved, name, depth + 1);
+  }
+  return unresolvableType("type annotation is not statically interpreted");
+}
+
+async function classFields(
+  extraction: Extraction,
+  module: FileModule,
+  node: TS.ClassDeclaration,
+  depth: number,
+): Promise<ClassFieldInfo[]> {
+  const { ts } = extraction;
+  const fields: ClassFieldInfo[] = [];
+  for (const member of node.members) {
+    if (!ts.isPropertyDeclaration(member) && !ts.isMethodDeclaration(member) && !ts.isGetAccessorDeclaration(member)) continue;
+    const fieldCall = graphqlDecorators(extraction, module, member).find((call) => call.name === "Field");
+    if (!fieldCall) continue;
+    const name = ts.isIdentifier(member.name) || ts.isStringLiteral(member.name) ? member.name.text : null;
+    if (!name) continue;
+
+    let interpretation: TypeInterpretation | null = null;
+    const first = fieldCall.args[0];
+    const options = fieldCall.args.find((argument) => ts.isObjectLiteralExpression(argument)) as TS.ObjectLiteralExpression | undefined;
+    if (first && ts.isArrowFunction(first)) {
+      interpretation = await interpretTypeExpression(extraction, module, unwrapArrowBody(ts, first), depth + 1);
+    }
+    if (!interpretation) {
+      const annotation = ts.isMethodDeclaration(member) || ts.isGetAccessorDeclaration(member) ? member.type : member.type;
+      interpretation = await interpretTypeAnnotation(extraction, module, annotation, depth + 1);
+    }
+    const nullable = options ? isTruthyLiteral(ts, objectProperty(ts, options, "nullable")) : false;
+    const questioned = ts.isPropertyDeclaration(member) && member.questionToken !== undefined;
+    fields.push({
+      name,
+      interpretation,
+      optional: nullable || questioned,
+      hasArguments: ts.isMethodDeclaration(member) && member.parameters.length > 0,
+    });
+  }
+  return fields;
+}
+
+async function interpretClassType(
+  extraction: Extraction,
+  module: FileModule,
+  node: TS.ClassDeclaration,
+  depth: number,
+): Promise<TypeInterpretation> {
+  const typeName = graphqlClassName(extraction, module, node);
+  if (depth > MAX_RESOLVE_DEPTH) return unresolvableType("type nesting exceeded the static interpretation depth");
+  const fields = await classFields(extraction, module, node, depth);
+
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+  const reasons: string[] = [];
+  const selectionParts: string[] = [];
+  for (const field of fields) {
+    properties[field.name] = field.interpretation.schema;
+    if (!field.optional && field.interpretation.typeName !== null) required.push(field.name);
+    if (field.interpretation.reason) reasons.push(`${field.name}: ${field.interpretation.reason}`);
+    if (field.hasArguments) continue;
+    if (field.interpretation.selection === "") selectionParts.push(field.name);
+    else if (field.interpretation.selection !== null && depth < MAX_SELECTION_DEPTH) {
+      selectionParts.push(`${field.name} ${field.interpretation.selection}`);
+    }
+  }
+  return {
+    typeName,
+    schema: {
+      type: "object",
+      properties,
+      ...(required.length > 0 ? { required } : {}),
+      additionalProperties: false,
+    },
+    selection: selectionParts.length === 0 ? "{ __typename }" : `{ ${selectionParts.join(" ")} }`,
+    ...(reasons.length > 0 ? { reason: reasons.join("; ") } : {}),
+  };
+}
+
+function unwrapArrowBody(ts: Ts, arrow: TS.ArrowFunction): TS.Expression {
+  if (ts.isBlock(arrow.body)) {
+    for (const statement of arrow.body.statements) {
+      if (ts.isReturnStatement(statement) && statement.expression) return statement.expression;
+    }
+  }
+  return arrow.body as TS.Expression;
+}
+
+function variableTypeFor(interpretation: TypeInterpretation, optional: boolean): string | null {
+  if (interpretation.typeName === null) return null;
+  return optional ? interpretation.typeName : `${interpretation.typeName}!`;
+}
+
+/** Arguments for one resolver method: named @Args entries plus expanded
+ * @Args() args-classes. */
+async function methodArgs(
+  extraction: Extraction,
+  module: FileModule,
+  method: TS.MethodDeclaration,
+): Promise<{ args: OperationArg[]; unresolved: string[] }> {
+  const { ts } = extraction;
+  const args: OperationArg[] = [];
+  const unresolved: string[] = [];
+  for (const parameter of method.parameters) {
+    const argsCall = graphqlDecorators(extraction, module, parameter).find((call) => call.name === "Args");
+    if (!argsCall) continue;
+    const nameLiteral = stringLiteralValue(ts, argsCall.args[0] ?? null);
+    const options = argsCall.args.find((argument) => ts.isObjectLiteralExpression(argument)) as TS.ObjectLiteralExpression | undefined;
+
+    if (nameLiteral !== null) {
+      const typeArrow = options ? objectProperty(ts, options, "type") : null;
+      const interpretation = typeArrow && ts.isArrowFunction(typeArrow)
+        ? await interpretTypeExpression(extraction, module, unwrapArrowBody(ts, typeArrow), 0)
+        : await interpretTypeAnnotation(extraction, module, parameter.type, 0);
+      const nullable = options ? isTruthyLiteral(ts, objectProperty(ts, options, "nullable")) : false;
+      const hasDefault = (options ? objectProperty(ts, options, "defaultValue") : null) !== null
+        || parameter.initializer !== undefined;
+      const optional = nullable || hasDefault || parameter.questionToken !== undefined;
+      const typeName = variableTypeFor(interpretation, optional);
+      if (typeName === null) unresolved.push(nameLiteral);
+      args.push({
+        name: nameLiteral,
+        typeName,
+        required: !optional && typeName !== null,
+        schema: interpretation.typeName === null ? {} : interpretation.schema,
+        ...(interpretation.reason ? { reason: interpretation.reason } : {}),
+      });
+      continue;
+    }
+
+    // `@Args() args: SearchArgs` — the class's fields are individual arguments.
+    const annotation = parameter.type;
+    if (!annotation || !ts.isTypeReferenceNode(annotation) || !ts.isIdentifier(annotation.typeName)) {
+      unresolved.push(parameter.name.getText(module.sf));
+      continue;
+    }
+    const resolved = await resolveIdentifier(extraction, module, annotation.typeName.text, 0);
+    if (!resolved || !ts.isClassDeclaration(resolved.node)) {
+      unresolved.push(annotation.typeName.text);
+      continue;
+    }
+    const fields = await classFields(extraction, resolved.module, resolved.node, 0);
+    for (const field of fields) {
+      const typeName = variableTypeFor(field.interpretation, field.optional);
+      if (typeName === null) unresolved.push(field.name);
+      args.push({
+        name: field.name,
+        typeName,
+        required: !field.optional && typeName !== null,
+        schema: field.interpretation.typeName === null ? {} : field.interpretation.schema,
+        ...(field.interpretation.reason ? { reason: field.interpretation.reason } : {}),
+      });
+    }
+  }
+  return { args, unresolved };
+}
+
+const OPERATION_DECORATORS = new Set(["Query", "Mutation", "Subscription"]);
+
+async function codeFirstOperations(
+  extraction: Extraction,
+  module: FileModule,
+  warnings: string[],
+): Promise<OperationDef[]> {
+  const { ts } = extraction;
+  const operations: OperationDef[] = [];
+  const visit = async (node: TS.Node): Promise<void> => {
+    if (ts.isClassDeclaration(node)) {
+      for (const member of node.members) {
+        if (!ts.isMethodDeclaration(member)) continue;
+        const operationCall = graphqlDecorators(extraction, module, member)
+          .find((call) => OPERATION_DECORATORS.has(call.name));
+        if (!operationCall) continue;
+        const methodName = ts.isIdentifier(member.name) || ts.isStringLiteral(member.name) ? member.name.text : null;
+        if (!methodName) continue;
+        const options = operationCall.args.find((argument) => ts.isObjectLiteralExpression(argument)) as TS.ObjectLiteralExpression | undefined;
+        const operation = (options ? stringLiteralValue(ts, objectProperty(ts, options, "name")) : null) ?? methodName;
+        const type = operationCall.name === "Query" ? "query" as const
+          : operationCall.name === "Mutation" ? "mutation" as const
+          : "subscription" as const;
+
+        const typeArrow = operationCall.args[0];
+        const returnInterpretation = typeArrow && ts.isArrowFunction(typeArrow)
+          ? await interpretTypeExpression(extraction, module, unwrapArrowBody(ts, typeArrow), 0)
+          : await interpretTypeAnnotation(extraction, module, member.type, 0);
+        const { args } = await methodArgs(extraction, module, member);
+        operations.push({
+          operation,
+          type,
+          args,
+          selection: returnInterpretation.selection,
+          ...(returnInterpretation.selection === null && returnInterpretation.reason
+            ? { selectionReason: returnInterpretation.reason }
+            : {}),
+        });
+      }
+    }
+    for (const child of node.getChildren(module.sf)) await visit(child);
+  };
+  try {
+    await visit(module.sf);
+  } catch (cause) {
+    warnings.push(`graphql code-first parse failed for ${path.relative(extraction.root, module.file)}: ${cause instanceof Error ? cause.message : String(cause)}`);
+  }
+  return operations;
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint discovery
+// ---------------------------------------------------------------------------
+
+function isRouteFileCandidate(relativePath: string): boolean {
+  const normalized = relativePath.replace(/\\/g, "/");
+  const parts = normalized.split("/");
+  const file = parts.at(-1) ?? "";
+  if (/^route\.(?:tsx?|jsx?)$/.test(file) && parts.includes("app")) return true;
+  const pagesIndex = parts.findIndex((part) => part === "pages");
+  return pagesIndex !== -1 && parts[pagesIndex + 1] === "api" && SOURCE_FILE_PATTERN.test(file) && !/\.d\.ts$/.test(file);
+}
+
+function isDynamicSegment(segment: string): boolean {
+  return /^\[.*\]$/.test(segment);
+}
+
+function endpointFromRouteFile(relativePath: string): string | null {
+  const parts = relativePath.replace(/\\/g, "/").split("/");
+  const file = parts.at(-1) ?? "";
+  if (/^route\.(?:tsx?|jsx?)$/.test(file)) {
+    const appIndex = parts.findIndex((part) => part === "app");
+    if (appIndex === -1) return null;
+    const segments = parts.slice(appIndex + 1, -1)
+      .filter((segment) => !(segment.startsWith("(") && segment.endsWith(")")) && !segment.startsWith("@"))
+      .filter((segment) => !isDynamicSegment(segment));
+    return `/${segments.join("/")}`.replace(/\/+/g, "/");
+  }
+  const pagesIndex = parts.findIndex((part) => part === "pages");
+  if (pagesIndex === -1) return null;
+  const fileBase = file.replace(/\.(?:tsx?|jsx?)$/, "");
+  const segments = [...parts.slice(pagesIndex + 1, -1), fileBase]
+    .filter((segment) => segment !== "index" && !isDynamicSegment(segment));
+  return `/${segments.join("/")}`.replace(/\/+/g, "/");
+}
+
+function graphqlEndpointLiteral(source: string): string | null {
+  const match = source.match(/graphqlEndpoint\s*:\s*["'`](\/[^"'`\s]*)["'`]/);
+  return match?.[1] ?? null;
+}
+
+/** All `path: "/x"` string literals within a node (a GraphQLModule options
+ * object or a resolved module factory body). Non-absolute literals — like a
+ * playground's `path: 'metadata'` — never count as endpoints. */
+function absolutePathLiterals(ts: Ts, sf: TS.SourceFile, node: TS.Node): string[] {
+  const literals: string[] = [];
+  const visit = (current: TS.Node): void => {
+    if (ts.isPropertyAssignment(current)) {
+      const key = ts.isIdentifier(current.name) || ts.isStringLiteral(current.name) ? current.name.text : null;
+      if (key === "path") {
+        const value = stringLiteralValue(ts, current.initializer);
+        if (value?.startsWith("/")) literals.push(value);
+      }
+    }
+    current.forEachChild(visit);
+  };
+  visit(node);
+  return literals;
+}
+
+async function nestEndpoints(
+  extraction: Extraction,
+  module: FileModule,
+): Promise<string[]> {
+  const { ts } = extraction;
+  const endpoints: string[] = [];
+  const visits: Array<Promise<void>> = [];
+  const visit = (node: TS.Node): void => {
+    if (ts.isCallExpression(node)
+        && ts.isPropertyAccessExpression(node.expression)
+        && ts.isIdentifier(node.expression.expression)
+        && node.expression.expression.text === "GraphQLModule"
+        && /^forRoot(Async)?$/.test(node.expression.name.text)) {
+      const options = node.arguments[0];
+      visits.push((async () => {
+        if (!options || !ts.isObjectLiteralExpression(options)) {
+          endpoints.push(DEFAULT_ENDPOINT);
+          return;
+        }
+        const direct = absolutePathLiterals(ts, module.sf, options);
+        if (direct.length > 0) {
+          endpoints.push(direct[0]!);
+          return;
+        }
+        const factory = objectProperty(ts, options, "useFactory");
+        if (factory && ts.isIdentifier(factory)) {
+          const resolved = await resolveIdentifier(extraction, module, factory.text, 0);
+          if (resolved) {
+            const fromFactory = absolutePathLiterals(extraction.ts, resolved.module.sf, resolved.node);
+            if (fromFactory.length > 0) {
+              endpoints.push(fromFactory[0]!);
+              return;
+            }
+          }
+        }
+        endpoints.push(DEFAULT_ENDPOINT);
+      })());
+    }
+    node.forEachChild(visit);
+  };
+  visit(module.sf);
+  await Promise.all(visits);
+  return endpoints;
+}
+
+// ---------------------------------------------------------------------------
+// Extraction entry point
+// ---------------------------------------------------------------------------
+
+export async function extractGraphql(root: string): Promise<GraphqlExtractResult> {
+  const warnings: string[] = [];
+
+  const sdlFiles = await walk(root, (relativePath) => SDL_FILE_PATTERN.test(relativePath));
+  // Test sources never describe a live API surface — a mock resolver in a
+  // spec must not become a host tool.
+  const testFilePattern = /(?:^|[\\/])(?:__tests__|__mocks__)[\\/]|\.(?:spec|test)\.[cm]?[jt]sx?$/;
+  const sourceFiles = await walk(
+    root,
+    (relativePath) => SOURCE_FILE_PATTERN.test(relativePath) && !/\.d\.ts$/.test(relativePath) && !testFilePattern.test(relativePath),
+    MAX_SOURCE_FILES,
+  );
+
+  const sources = new Map<string, string>();
+  for (const file of sourceFiles) {
+    try {
+      sources.set(file, await fs.readFile(file, "utf8"));
+    } catch {
+      // Unreadable sources never fail extraction.
+    }
+  }
+
+  const codeFirstFiles = [...sources.entries()].filter(([, source]) =>
+    (source.includes("@nestjs/graphql") || source.includes("\"type-graphql\"") || source.includes("'type-graphql'"))
+    && /@(?:Query|Mutation|Subscription)\s*\(/.test(source));
+
+  // --- Endpoint discovery -------------------------------------------------
+  const endpointSet = new Set<string>();
+  let extraction: Extraction | null = null;
+  const ensureExtraction = (): Extraction | null => {
+    if (extraction) return extraction;
+    const ts = loadTypescript(root);
+    if (!ts) return null;
+    extraction = { ts, root, modules: new Map() };
+    return extraction;
+  };
+
+  for (const [file, source] of sources) {
+    const relativePath = path.relative(root, file);
+    if (isRouteFileCandidate(relativePath) && ROUTE_SERVER_MARKER.test(source)) {
+      const endpoint = graphqlEndpointLiteral(source) ?? endpointFromRouteFile(relativePath) ?? DEFAULT_ENDPOINT;
+      endpointSet.add(endpoint.length > 1 ? endpoint.replace(/\/+$/, "") : endpoint);
+      continue;
+    }
+    if (source.includes("GraphQLModule")) {
+      const active = ensureExtraction();
+      if (active) {
+        const module = parseModule(active, file, source);
+        for (const endpoint of await nestEndpoints(active, module)) {
+          endpointSet.add(endpoint.length > 1 ? endpoint.replace(/\/+$/, "") : endpoint);
+        }
+      }
+      continue;
+    }
+    // Standalone yoga servers declare their endpoint on createYoga.
+    if (source.includes("createYoga(")) {
+      const literal = graphqlEndpointLiteral(source);
+      if (literal) endpointSet.add(literal.length > 1 ? literal.replace(/\/+$/, "") : literal);
+    }
+  }
+
+  // --- SDL operations -----------------------------------------------------
+  const sdlOperationDefs: OperationDef[] = [];
+  if (sdlFiles.length > 0) {
+    const graphqlJs = loadGraphqlJs(root);
+    if (!graphqlJs) {
+      warnings.push("graphql SDL extraction skipped: the graphql package could not be resolved from the host package");
+    } else {
+      const documents: DefinitionNode[][] = [];
+      for (const file of sdlFiles) {
+        try {
+          const source = await fs.readFile(file, "utf8");
+          documents.push([...graphqlJs.parse(source).definitions]);
+        } catch (cause) {
+          warnings.push(`graphql SDL file ${path.relative(root, file)} could not be parsed: ${cause instanceof Error ? cause.message.split("\n")[0] : String(cause)}`);
+        }
+      }
+      const index = indexSdlDefinitions(documents);
+      sdlOperationDefs.push(...sdlOperations(index));
+    }
+  }
+
+  // --- Code-first operations ----------------------------------------------
+  const codeFirstOperationDefs: OperationDef[] = [];
+  if (codeFirstFiles.length > 0) {
+    const active = ensureExtraction();
+    if (!active) {
+      warnings.push("graphql code-first extraction skipped: the TypeScript compiler could not be resolved from the host package");
+    } else {
+      for (const [file, source] of codeFirstFiles) {
+        const module = parseModule(active, file, source);
+        codeFirstOperationDefs.push(...await codeFirstOperations(active, module, warnings));
+      }
+    }
+  }
+
+  if (sdlOperationDefs.length === 0 && codeFirstOperationDefs.length === 0) {
+    return {
+      tools: [],
+      warnings: [
+        ...warnings,
+        "graphql detected (graphql dependency) but no SDL schema or code-first resolvers were found; no graphql tools extracted",
+      ],
+    };
+  }
+
+  // SDL is the more authoritative schema description; code-first duplicates
+  // of the same operation name are dropped.
+  const seen = new Set<string>();
+  const operations: OperationDef[] = [];
+  for (const def of [...sdlOperationDefs, ...codeFirstOperationDefs]) {
+    if (seen.has(def.operation)) continue;
+    seen.add(def.operation);
+    operations.push(def);
+  }
+
+  const endpoints = [...endpointSet].sort();
+  const resolution: EndpointResolution = {
+    endpoint: endpoints.includes(DEFAULT_ENDPOINT) ? DEFAULT_ENDPOINT : endpoints[0] ?? DEFAULT_ENDPOINT,
+    ambiguous: endpoints.length > 1,
+    endpoints,
+  };
+  if (resolution.ambiguous) {
+    warnings.push(`graphql: ${endpoints.length} GraphQL endpoints detected (${endpoints.join(", ")}); operation-to-endpoint attribution is not static, so every operation is emitted disabled`);
+  }
+
+  return { tools: assembleTools(operations, resolution, warnings), warnings };
+}
+
+/** The endpoints graphql tools were extracted from — route-scan tools under
+ * these paths are shadowed (the GraphQL transport route is not a REST surface). */
+export function graphqlEndpoints(tools: readonly ExtractedTool[]): string[] {
+  const endpoints = new Set<string>();
+  for (const tool of tools) {
+    if (tool.binding.kind === "graphql") endpoints.add(tool.binding.endpoint);
+  }
+  return [...endpoints];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -688,6 +688,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.0
+      graphql:
+        specifier: ^16.9.0
+        version: 16.14.2
       jose:
         specifier: ^6.2.3
         version: 6.2.3
@@ -4405,6 +4408,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graphql@16.14.2:
+    resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -9902,6 +9909,8 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  graphql@16.14.2: {}
 
   has-bigints@1.1.0: {}
 


### PR DESCRIPTION
Implements ENG-247 (M2 of the extraction project, spec: docs/superpowers/specs/2026-07-14-extraction-survives-real-apps-design.md §1/§6/§7). Mirrors the ENG-246/PR #229 tRPC pattern.

## What

- **GraphQL extractor** (`packages/actions/src/sync/graphql.ts`), registered behind the extractor seam (order: openapi → trpc → graphql → route-scan). Two static sources, no host code execution, no LLM:
  - **SDL**: `.graphql`/`.gql`/`.graphqls` files parsed with the *host's own* graphql package (fail-closed to a warning when unresolvable; our own devDependency only backs tests/monorepo dev). Handles split schema files, `schema { query: X }` root renames, `extend type`, enums, input objects, custom scalars, list/non-null wrappers.
  - **Code-first**: `@nestjs/graphql` / `type-graphql` resolver classes parsed with the TypeScript compiler API (resolved from the host, like tRPC). `@Query`/`@Mutation`/`@Subscription` methods (import-checked so `@nestjs/common`'s `@Query` param decorator never matches), `name` option overrides, `@Args("x", { type: () => T, nullable })`, `@Args()` args-class expansion, `@InputType`/`@ObjectType`/`@ArgsType` field graphs, TS-annotation scalar inference, `registerEnumType`-style TS enums, `new GraphQLScalarType({ name })` custom scalars, `graphql-type-json`.
- **One tool per query and per mutation**; `inputSchema` derived deterministically from GraphQL argument types; each binding carries a full executable `document` (variable declarations from the schema's argument types — nullable variables for optional/defaulted args so the agent can omit them; depth-limited default selection sets, depth 2, parameterized fields skipped, `{ __typename }` floor).
- **Additive `graphql` binding kind** in the `ToolBinding` union (`formats.ts`): `{ operation, type, endpoint, document? }`. `executeHost` POSTs `{ query: document, variables: args }` to the host endpoint; single root field unwrapped on success; a 200 with a non-empty `errors` array surfaces as an http-error outcome; a document-less binding refuses execution with a validation outcome. Auth semantics (present-forward / away / mcp) identical to route bindings and untouched.
- **Risk labeling, fail-closed**: queries get `read` ONLY with a read-shaped name; mutations default `write`; the destructive word list applies unchanged. Unclassifiable surfaces emit `disabled: true` + note: subscriptions, args/return types that cannot be statically named (e.g. types imported from a sibling workspace package outside the app root), and **multi-endpoint hosts** — several GraphQL schemas (the Twenty shape: `/graphql` + `/metadata` + `/admin-panel` scope decorators over Nest's global resolver discovery) genuinely defeat static operation-to-endpoint attribution, so every operation is emitted disabled rather than guessed.
- **Endpoint discovery**: Next route files hosting yoga/apollo handlers (path-derived or `graphqlEndpoint` literal), `GraphQLModule.forRoot*` `path` literals including through `useFactory` cross-file resolution, `createYoga` endpoint literals; default `/graphql`.
- **Endpoint shadowing**: route-scan catch-alls under a graphql endpoint are dropped, exactly like tRPC mounts.
- **Binding-kind-aware corpus keys** (shared with M3): graphql expectations key on operation name; scored/structural write-safety treats graphql mutations as POST-shaped; identity/dedup `GRAPHQL {endpoint} {operation}` in `bindingIdentity`.
- **Twenty onboarded** (`corpus/manifest.json` + `corpus/expectations/twenty/`): NestJS code-first GraphQL, yarn 4 + nx monorepo, `appDir: packages/twenty-server`, pinned at the v2.9.0 release tag (`b53f1832`), broad tier with a full boot recipe.
- **Redis service kind** (`docker-redis`) added to the corpus bootstrap schema, mirroring Postgres provisioning (docker run + `redis-cli ping` readiness, reverse-order teardown). Twenty is deliberately the only Redis boot. Recipe validated against real Docker (pull → start → PONG → teardown).
- **Structural express files check generalized**: the pre-wired express-host shape stays byte-identical in behavior; a real Express/Nest API host now validates against the wiring `vendo init` actually generates (`vendo/server.ts` composing `createVendo` from `@vendoai/vendo/server`; no `<VendoRoot>` requirement for API-only hosts whose client is a separate frontend).

## Contract freeze

`docs/contracts/` untouched here. The additive `vendo/tools@1` amendment (graphql binding kind) is a separate DRAFT PR gated on Yousef's sign-off: #306.

## Evidence

- **Twenty Layer 1: 7/7 structural checks pass** — init exit 0 (381 tools), files.expected (generated express wiring shape), config.schema, init.idempotent (empty second diff), tools.fail-closed (381 tools, write-safety clean). host.typecheck/host.build recorded `skipped-baseline-broken`; hand-verified afterwards: the baseline scorecard failure was a flaky `twenty-ui:build` nx task (nx itself flags it flaky; succeeds on retry), `twenty-server:build` (swc) passes both pre- and post-init on manual re-runs, and `twenty-server:typecheck` (tsgo) is **genuinely broken upstream at this pin** (`test/integration/.../make-unauthenticated-api-request.util.ts` TS2742) independent of Vendo — so the skip verdict is the correct one for typecheck. Known follow-up: the init starter `vendo/ai.ts` adds its own TS2742 under declaration-emitting tsconfigs (template fix belongs to init, not this extractor PR).
- **Twenty Layer 2: PASS 10/10 (score 1.000)** — tools precision **1.000** (381/381) / recall **1.000** (381/381), 16/16 safety annotations, write-safety hard check pass, theme 7/7 (API-only appDir → labeled the defaults Vendo should choose per the expectations README), recorded as baseline.
- **Hand audit**: expected.json derived independently from twenty-server source at the pinned SHA (line-level decorator scan over the 100 resolver files + the 04-actions risk rules applied by hand; spot-reviewed samples across scopes/risk classes). Counts: 381 operations = 128 queries + 250 mutations + 3 subscriptions; risk 81 read / 226 write / 74 destructive (incl. the 3 subscriptions forced destructive+disabled). Extractor vs audit: 0 missing, 0 extra, 0 kind mismatches, 0 risk mismatches. 379/381 operations carry executable documents (`graphql-type-json` returns map to the JSON scalar); the 2 without (args typed by enums imported from `twenty-shared`, outside the app root) are disabled with notes.
- Existing-repo blast radius: none of the 14 existing corpus repos declares a graphql server dependency at its pinned appDir (`detectGraphql` → false; verified per-repo via the GitHub contents API), so the new extractor never runs on them.
- Regression sweep: in progress; posted as a PR comment before merge. Completed so far:
  - **rallly: tools precision 1.000 / recall 1.000 (84/84) — unchanged**; Layer 2 PASS 6/10 exactly at its recorded 0.600 baseline (same 4 theme misses). Layer 1 6/7: post-init `host.build` fails on `@ai-sdk/provider-utils@4.0.39` importing `zod/v3` against Rallly's pinned `zod@3.24.0` — the ai-train drift class PR #229 fixed for `@vendoai/mcp`, freshly re-resolved at injection time; reproduction on pure origin/main running now and posted with the sweep comment.
  - **express-host: Layer 1 7/7, Layer 2 10/10** — the express structural generalization is behavior-identical for the pre-wired shape.
- Review triage (Devin findings, all fixed with regression tests): list-return operations now get the same selection depth as single-object returns; `Array<T>` generic argument annotations keep their list wrapper; a query and a mutation sharing one field name stay two tools (kind-aware dedup + `bindingIdentity`, subscriptions dedupe last). Twenty parity re-verified after the fixes: 381 tools, 0 missing/extra vs the audit.
- `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green at root. Changeset included.
