### PR TITLE
feat(agent,actions): runtime tool search + loadout meta-tool (ENG-252)

### DIFF
--- a/.changeset/eng-252-runtime-tool-search.md
+++ b/.changeset/eng-252-runtime-tool-search.md
@@ -1,0 +1,7 @@
+---
+"@vendoai/actions": minor
+"@vendoai/agent": minor
+"@vendoai/vendo": minor
+---
+
+Runtime tool search and loadout (ENG-252). Add a deterministic `ActionsRegistry.search` query API (plus the pure `searchToolDescriptors`) that ranks the merged, enabled tool surface by intent, excluding disabled tools. The agent gains a `vendo_tools_search` meta-tool: it starts from a bounded initial loadout — the whole enabled surface when it fits the cap, an explicit curated list when provided, otherwise a read-first bounded default (`DEFAULT_MAX_INITIAL_TOOLS`) — and discovers and loads the rest mid-run. Loaded tools persist across turns within a thread and execute through the same guard-bound registry as any initially-enabled tool, so there is no unguarded path. The umbrella wires the search seam to the guard-bound registry.

--- a/packages/actions/src/index.ts
+++ b/packages/actions/src/index.ts
@@ -5,6 +5,7 @@ export { composioConnector } from "./connectors/composio.js";
 export { composioToolRisk } from "./connectors/composio-risk.js";
 export { mcpConnector, type McpAuthContext, type McpHeadersResolver } from "./connectors/mcp.js";
 export { createActions, type ActionsRegistry, type ActionsRunContext } from "./runtime/registry.js";
+export { searchToolDescriptors, type ToolSearchMatch, type ToolSearchOptions } from "./runtime/search.js";
 export { validateCapabilities, type CapabilityIssue, type PrimitiveStepTarget } from "./runtime/compound.js";
 export { walkSteps, STEP_FOREACH_MAX_ITEMS, type StepResumePoint, type StepWalkOptions, type StepWalkResult } from "./runtime/steps.js";
 export { mergeOverrides, vendoSync, type SyncReportWithWarnings } from "./sync/index.js";

--- a/packages/actions/src/runtime/registry.ts
+++ b/packages/actions/src/runtime/registry.ts
@@ -33,11 +33,18 @@ import {
 } from "../formats.js";
 import { createCompoundExecutor, validateCapabilities, type PrimitiveStepTarget } from "./compound.js";
 import { error, isArgsObject } from "./outcome.js";
+import { searchToolDescriptors, type ToolSearchMatch, type ToolSearchOptions } from "./search.js";
 
 export interface ActionsRegistry extends ToolRegistry {
   add(tools: ToolRegistry): void;
   /** Capability briefs carried by `.vendo/capabilities.json` (04 §1). Validated and exposed; consumed by later milestones. */
   briefs(): Promise<CapabilityBrief[]>;
+  /**
+   * Runtime tool search (ENG-252): rank the merged, enabled tool surface against
+   * a free-text intent. Disabled tools are excluded (they never enter the loaded
+   * descriptor set), so a hit is always a loadable, guard-bound tool.
+   */
+  search(query: string, options?: ToolSearchOptions): Promise<ToolSearchMatch[]>;
 }
 
 /** Away calls carry the exact grant captured by the guard binding; venue="mcp"
@@ -712,6 +719,12 @@ export function createActions(config: RegistryConfig): ActionsRegistry {
 
     async briefs(): Promise<CapabilityBrief[]> {
       return (await loadHost()).capabilities?.briefs ?? [];
+    },
+
+    async search(query: string, options?: ToolSearchOptions): Promise<ToolSearchMatch[]> {
+      // load().descriptors is the post-override, enabled-only surface — disabled
+      // tools never reach it, so they can never be returned as loadable.
+      return searchToolDescriptors((await load()).descriptors, query, options);
     },
 
     async execute(call: ToolCall, ctx: RunContext): Promise<ToolOutcome> {

--- a/packages/actions/src/runtime/search.test.ts
+++ b/packages/actions/src/runtime/search.test.ts
@@ -1,0 +1,86 @@
+import type { ToolDescriptor } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createActions, type ExtractedTool } from "../index.js";
+import { searchToolDescriptors } from "./search.js";
+
+function descriptor(name: string, description: string, risk: ToolDescriptor["risk"] = "read"): ToolDescriptor {
+  return { name, description, inputSchema: { type: "object" }, risk };
+}
+
+describe("searchToolDescriptors (pure ranking)", () => {
+  const surface: ToolDescriptor[] = [
+    descriptor("host_invoices_create", "Create a new invoice for a customer", "write"),
+    descriptor("host_invoices_list", "List invoices"),
+    descriptor("host_customers_list", "List customers"),
+    descriptor("host_reports_export", "Export a financial report as CSV", "read"),
+  ];
+
+  it("returns an empty list for a blank or symbol-only query", () => {
+    expect(searchToolDescriptors(surface, "")).toEqual([]);
+    expect(searchToolDescriptors(surface, "   ---  ")).toEqual([]);
+  });
+
+  it("ranks a whole-name intent match above partial matches", () => {
+    const matches = searchToolDescriptors(surface, "create invoice");
+    expect(matches[0]?.name).toBe("host_invoices_create");
+    // The list tool shares the "invoice" token but not "create" → strictly lower.
+    const listScore = matches.find((m) => m.name === "host_invoices_list")?.score ?? 0;
+    expect(matches[0]!.score).toBeGreaterThan(listScore);
+  });
+
+  it("matches on description tokens when the name does not carry the intent", () => {
+    const matches = searchToolDescriptors(surface, "csv");
+    expect(matches.map((m) => m.name)).toContain("host_reports_export");
+  });
+
+  it("is deterministic and breaks ties by name ascending", () => {
+    const tie = [descriptor("host_b_list", "list things"), descriptor("host_a_list", "list things")];
+    const first = searchToolDescriptors(tie, "list");
+    const second = searchToolDescriptors(tie, "list");
+    expect(first).toEqual(second);
+    expect(first.map((m) => m.name)).toEqual(["host_a_list", "host_b_list"]);
+  });
+
+  it("clamps the limit into [1, 50]", () => {
+    expect(searchToolDescriptors(surface, "list", { limit: 0 })).toHaveLength(1);
+    expect(searchToolDescriptors(surface, "list", { limit: 999 }).length).toBeLessThanOrEqual(50);
+  });
+});
+
+describe("ActionsRegistry.search (over the merged surface)", () => {
+  it("excludes tools disabled via overrides from the loadable results", async () => {
+    const tools: ExtractedTool[] = [
+      { ...descriptor("host_secret_wipe", "Wipe all data", "destructive"), binding: { kind: "route", method: "POST", path: "/wipe", argsIn: "body" } },
+      { ...descriptor("host_data_list", "List data"), binding: { kind: "route", method: "GET", path: "/data", argsIn: "query" } },
+    ];
+    // With no override, the destructive tool IS searchable.
+    const registry = createActions({ tools });
+    expect((await registry.search("wipe data")).map((m) => m.name)).toContain("host_secret_wipe");
+
+    // A disabled tool must be hidden from search entirely (never a loadable hit).
+    const withDisabled = createActions({ tools: [{ ...tools[0]!, disabled: true }, tools[1]!] });
+    const results = await withDisabled.search("wipe data");
+    expect(results.map((m) => m.name)).not.toContain("host_secret_wipe");
+  });
+
+  it("ranks the intended tool first within a 300+ tool host surface", async () => {
+    const tools: ExtractedTool[] = [];
+    for (let index = 0; index < 320; index += 1) {
+      tools.push({
+        ...descriptor(`host_widget_${index}_get`, `Fetch widget ${index} details`),
+        binding: { kind: "route", method: "GET", path: `/widgets/${index}`, argsIn: "query" },
+      });
+    }
+    // The single needle: a payout refund tool buried in the noise.
+    tools.push({
+      ...descriptor("host_payouts_refund", "Refund a customer payout", "destructive"),
+      binding: { kind: "route", method: "POST", path: "/payouts/refund", argsIn: "body" },
+    });
+    const registry = createActions({ tools });
+    expect(await registry.descriptors()).toHaveLength(321);
+
+    const matches = await registry.search("refund a payout", { limit: 5 });
+    expect(matches[0]?.name).toBe("host_payouts_refund");
+    expect(matches[0]?.risk).toBe("destructive");
+  });
+});

--- a/packages/actions/src/runtime/search.ts
+++ b/packages/actions/src/runtime/search.ts
@@ -1,0 +1,85 @@
+import type { RiskLabel, ToolDescriptor } from "@vendoai/core";
+
+/** A ranked hit from {@link searchToolDescriptors}. Carries just enough to load
+ * the tool into a run and describe it to the model — never the input schema. */
+export interface ToolSearchMatch {
+  name: string;
+  description: string;
+  risk: RiskLabel;
+  /** Deterministic relevance score; higher is a stronger match. Always > 0. */
+  score: number;
+}
+
+export interface ToolSearchOptions {
+  /** Max matches returned. Defaults to 10; clamped to [1, 50]. */
+  limit?: number;
+}
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 50;
+
+const EXACT_NAME_TOKEN = 8;
+const NAME_SUBSTRING = 4;
+const DESCRIPTION_MATCH = 2;
+const WHOLE_QUERY_IN_NAME = 5;
+
+/** Lowercase alphanumeric tokens, de-duplicated, order-preserving. */
+function tokenize(value: string): string[] {
+  const seen = new Set<string>();
+  const tokens: string[] = [];
+  for (const raw of value.toLowerCase().split(/[^a-z0-9]+/)) {
+    if (raw.length === 0 || seen.has(raw)) continue;
+    seen.add(raw);
+    tokens.push(raw);
+  }
+  return tokens;
+}
+
+function scoreDescriptor(descriptor: ToolDescriptor, queryTokens: string[], collapsedQuery: string): number {
+  const name = descriptor.name.toLowerCase();
+  const nameTokens = new Set(tokenize(descriptor.name));
+  const description = descriptor.description.toLowerCase();
+  let score = 0;
+
+  for (const token of queryTokens) {
+    if (nameTokens.has(token)) score += EXACT_NAME_TOKEN;
+    else if (name.includes(token)) score += NAME_SUBSTRING;
+    if (description.includes(token)) score += DESCRIPTION_MATCH;
+  }
+
+  // A contiguous run of the whole query inside the name (ignoring separators) is
+  // a strong signal, e.g. "createinvoice" matching host_create_invoice.
+  if (collapsedQuery.length > 0 && name.replace(/[^a-z0-9]+/g, "").includes(collapsedQuery)) {
+    score += WHOLE_QUERY_IN_NAME;
+  }
+
+  return score;
+}
+
+/**
+ * Pure, deterministic ranking of tool descriptors against a free-text intent.
+ *
+ * Callers pass the ALREADY-enabled descriptor set (disabled tools excluded
+ * upstream), so a disabled tool is never returned as a loadable match. Ties
+ * break by name ascending; the result is stable for a given input.
+ */
+export function searchToolDescriptors(
+  descriptors: readonly ToolDescriptor[],
+  query: string,
+  options?: ToolSearchOptions,
+): ToolSearchMatch[] {
+  const queryTokens = tokenize(query);
+  if (queryTokens.length === 0) return [];
+  const collapsedQuery = query.toLowerCase().replace(/[^a-z0-9]+/g, "");
+  const limit = Math.min(Math.max(Math.trunc(options?.limit ?? DEFAULT_LIMIT), 1), MAX_LIMIT);
+
+  const matches: ToolSearchMatch[] = [];
+  for (const descriptor of descriptors) {
+    const score = scoreDescriptor(descriptor, queryTokens, collapsedQuery);
+    if (score <= 0) continue;
+    matches.push({ name: descriptor.name, description: descriptor.description, risk: descriptor.risk, score });
+  }
+
+  matches.sort((a, b) => (b.score - a.score) || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  return matches.slice(0, limit);
+}

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -191,8 +191,28 @@ export function createAgent(config: AgentConfig): VendoAgent {
   validateConfig(config);
   const threads = new ThreadRepository(config.store);
   // ENG-252: per-thread set of tools loaded in via `vendo_tools_search`. It
-  // persists across turns within a run so a discovered tool stays callable.
+  // persists across turns within a run so a discovered tool stays callable, and
+  // is reclaimed on thread delete + session eviction. The LRU cap bounds memory
+  // for long-lived, store-backed processes where threads never get evicted (a
+  // reused/live thread is touched to the end, so only cold threads are dropped).
   const loadedTools = new Map<string, Set<string>>();
+  const MAX_LOADED_THREADS = 1024;
+  const loadedFor = (threadId: string): Set<string> => {
+    const existing = loadedTools.get(threadId);
+    if (existing !== undefined) {
+      loadedTools.delete(threadId);
+      loadedTools.set(threadId, existing); // touch: most-recently-used
+      return existing;
+    }
+    const fresh = new Set<string>();
+    loadedTools.set(threadId, fresh);
+    while (loadedTools.size > MAX_LOADED_THREADS) {
+      const oldest = loadedTools.keys().next().value;
+      if (oldest === undefined) break;
+      loadedTools.delete(oldest);
+    }
+    return fresh;
+  };
 
   return {
     async stream(input) {
@@ -235,11 +255,7 @@ export function createAgent(config: AgentConfig): VendoAgent {
             : createToolSearchSession({
                 config: config.toolSearch,
                 descriptors: await config.tools.descriptors(),
-                loaded: (() => {
-                  const existing = loadedTools.get(thread.id) ?? new Set<string>();
-                  loadedTools.set(thread.id, existing);
-                  return existing;
-                })(),
+                loaded: loadedFor(thread.id),
               });
           toolSearch?.attach(tools);
           // History windowing: bound what is re-sent per turn to the last N whole messages.
@@ -306,7 +322,11 @@ export function createAgent(config: AgentConfig): VendoAgent {
         await threads.delete(id, ctx);
       },
     },
-    evictSubject: (subject) => threads.evictSubject(subject),
+    evictSubject: (subject) => {
+      // Release each evicted thread's searched-in loadout so a reused id can't
+      // inherit stale tools, and so memory is reclaimed on session sweep.
+      for (const id of threads.evictSubject(subject)) loadedTools.delete(id);
+    },
     asRunner: () => createRunner(config),
   };
 }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -27,6 +27,7 @@ import {
   latestUserIntent,
   type CapabilityMissConfig,
 } from "./capability-miss.js";
+import { createToolSearchSession, type ToolSearchConfig } from "./tool-search.js";
 
 const THREAD_ID_HEADER = "x-vendo-thread-id";
 
@@ -91,6 +92,11 @@ interface AgentConfig {
     historyWindow?: number;
   };
   capabilityMiss?: CapabilityMissConfig;
+  /** ENG-252: enable the `vendo_tools_search` meta-tool and runtime loadout.
+   *  When set, the model starts with a bounded initial loadout and discovers the
+   *  rest through search; searched-in tools execute through the same guard-bound
+   *  registry as any initially-enabled tool. */
+  toolSearch?: ToolSearchConfig;
 }
 
 // Anthropic prompt-caching breakpoint. providerOptions.anthropic is ignored by every
@@ -184,6 +190,9 @@ function providerHistory(messages: UIMessage[]): UIMessage[] {
 export function createAgent(config: AgentConfig): VendoAgent {
   validateConfig(config);
   const threads = new ThreadRepository(config.store);
+  // ENG-252: per-thread set of tools loaded in via `vendo_tools_search`. It
+  // persists across turns within a run so a discovered tool stays callable.
+  const loadedTools = new Map<string, Set<string>>();
 
   return {
     async stream(input) {
@@ -221,6 +230,18 @@ export function createAgent(config: AgentConfig): VendoAgent {
             ...(missDetector === undefined ? {} : { onCall: missDetector.onCall }),
           });
           missDetector?.attach(tools);
+          const toolSearch = config.toolSearch === undefined
+            ? undefined
+            : createToolSearchSession({
+                config: config.toolSearch,
+                descriptors: await config.tools.descriptors(),
+                loaded: (() => {
+                  const existing = loadedTools.get(thread.id) ?? new Set<string>();
+                  loadedTools.set(thread.id, existing);
+                  return existing;
+                })(),
+              });
+          toolSearch?.attach(tools);
           // History windowing: bound what is re-sent per turn to the last N whole messages.
           // Slicing whole UIMessages keeps each turn's tool-call/result pairing intact.
           const window = config.context?.historyWindow;
@@ -246,6 +267,17 @@ export function createAgent(config: AgentConfig): VendoAgent {
             tools,
             stopWhen: stepCountIs(20),
             maxOutputTokens: config.context?.maxOutputTokens,
+            // ENG-252 loadout: restrict what the model may pick to the current
+            // loadout. `prepareStep` re-reads it each step so a tool loaded via
+            // `vendo_tools_search` becomes callable on the very next step. This
+            // gates the model's CHOICE only — every tool still executes through
+            // the guard-bound registry, so there is no unguarded path.
+            ...(toolSearch === undefined
+              ? {}
+              : {
+                  activeTools: toolSearch.activeToolNames(),
+                  prepareStep: () => ({ activeTools: toolSearch.activeToolNames() }),
+                }),
           });
           writer.merge(result.toUIMessageStream({
             originalMessages: thread.messages,
@@ -269,7 +301,10 @@ export function createAgent(config: AgentConfig): VendoAgent {
     threads: {
       get: (id, ctx) => threads.get(id, ctx),
       list: (ctx) => threads.list(ctx),
-      delete: (id, ctx) => threads.delete(id, ctx),
+      delete: async (id, ctx) => {
+        loadedTools.delete(id);
+        await threads.delete(id, ctx);
+      },
     },
     evictSubject: (subject) => threads.evictSubject(subject),
     asRunner: () => createRunner(config),

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2,4 +2,10 @@ export { createAgent } from "./agent.js";
 export type { VendoAgent } from "./agent.js";
 export { CAPABILITY_MISS_TOOL_NAME } from "./capability-miss.js";
 export type { CapabilityMissConfig } from "./capability-miss.js";
+export {
+  VENDO_TOOLS_SEARCH_TOOL_NAME,
+  DEFAULT_MAX_INITIAL_TOOLS,
+  computeInitialLoadout,
+} from "./tool-search.js";
+export type { ToolSearchConfig, ToolSearchFn, ToolSearchMatch } from "./tool-search.js";
 export type { Thread, ThreadSummary } from "./threads.js";

--- a/packages/agent/src/test-helpers.ts
+++ b/packages/agent/src/test-helpers.ts
@@ -49,24 +49,29 @@ export function toolCallTurn(
 
 export type ScriptedModel = MockLanguageModelV3 & {
   prompts: LanguageModelV3Prompt[];
+  /** The tool names offered to the model on each call, in order — i.e. the
+   *  effective loadout after `activeTools`/`prepareStep` filtering (ENG-252). */
+  toolNamesPerCall: string[][];
 };
 
 export function scriptedModel(turns: LanguageModelV3StreamPart[][]): ScriptedModel {
   const remaining = turns.map((turn) => [...turn]);
   const prompts: LanguageModelV3Prompt[] = [];
-  const shift = (prompt: LanguageModelV3Prompt): LanguageModelV3StreamPart[] => {
-    prompts.push(structuredClone(prompt));
+  const toolNamesPerCall: string[][] = [];
+  const shift = (request: { prompt: LanguageModelV3Prompt; tools?: Array<{ name: string }> }): LanguageModelV3StreamPart[] => {
+    prompts.push(structuredClone(request.prompt));
+    toolNamesPerCall.push((request.tools ?? []).map((tool) => tool.name));
     const chunks = remaining.shift();
     if (chunks === undefined) throw new Error("scripted model exhausted");
     return chunks;
   };
   const model = new MockLanguageModelV3({
     doStream: async (request) => {
-      const chunks = shift(request.prompt);
+      const chunks = shift(request);
       return { stream: simulateReadableStream({ chunks }) };
     },
     doGenerate: async (request): Promise<LanguageModelV3GenerateResult> => {
-      const chunks = shift(request.prompt);
+      const chunks = shift(request);
       const finish = chunks.find((part) => part.type === "finish");
       const content: LanguageModelV3Content[] = [];
       const text = chunks
@@ -86,6 +91,7 @@ export function scriptedModel(turns: LanguageModelV3StreamPart[][]): ScriptedMod
     },
   }) as ScriptedModel;
   model.prompts = prompts;
+  model.toolNamesPerCall = toolNamesPerCall;
   return model;
 }
 

--- a/packages/agent/src/threads.ts
+++ b/packages/agent/src/threads.ts
@@ -279,9 +279,14 @@ export class ThreadRepository {
   /** AGENT-11 / ENG-237: drop a subject's in-memory threads on session
    *  eviction. Only the no-store (BYO) composition keeps threads here; a
    *  store-backed agent holds them in the store overlay (cascaded there), so
-   *  this is a no-op then. The umbrella calls it per swept ephemeral subject. */
-  evictSubject(subject: string): void {
+   *  this is a no-op then. The umbrella calls it per swept ephemeral subject.
+   *  Returns the evicted thread ids so callers can release any per-thread state
+   *  keyed by id (ENG-252 loadouts) — otherwise a reused `thr_*` id would inherit
+   *  the evicted thread's searched-in tools. */
+  evictSubject(subject: string): ThreadId[] {
+    const evicted = [...(this.#memory.get(subject)?.keys() ?? [])];
     this.#memory.delete(subject);
+    return evicted;
   }
 
   private usesMemory(_ctx: RunContext): boolean {

--- a/packages/agent/src/tool-search.test.ts
+++ b/packages/agent/src/tool-search.test.ts
@@ -1,6 +1,7 @@
 import type { ToolDescriptor } from "@vendoai/core";
 import { describe, expect, it, vi } from "vitest";
 import {
+  CAPABILITY_MISS_TOOL_NAME,
   DEFAULT_MAX_INITIAL_TOOLS,
   VENDO_TOOLS_SEARCH_TOOL_NAME,
   computeInitialLoadout,
@@ -39,6 +40,8 @@ function registrySearch(tools: BoundRegistry): ToolSearchFn {
       .map((d) => ({ name: d.name, description: d.description, risk: d.risk, score: 1 }));
   };
 }
+
+const missSurface = { format: "vendo/tools@1" as const, hash: `sha256:${"c".repeat(64)}` };
 
 const impls: Record<string, TestToolImplementation> = {
   host_transactions_list: {
@@ -167,6 +170,57 @@ describe("vendo_tools_search meta-tool", () => {
     // The second turn's FIRST model call already offers the tool loaded last turn.
     const secondTurnFirstCall = model.toolNamesPerCall[2]!;
     expect(secondTurnFirstCall).toContain("host_export_csv");
+  });
+
+  it("keeps the capability-miss meta-tool active when tool search is enabled (regression)", async () => {
+    const misses: unknown[] = [];
+    const model = scriptedModel([textTurn("Nothing to do.", "text_only")]);
+    const guard = testGuard({});
+    const tools = boundRegistry(impls, guard);
+    const agent = createAgent({
+      model,
+      tools,
+      guard,
+      capabilityMiss: { hostId: "host_x", surface: Promise.resolve(missSurface), emit: (e) => misses.push(e) },
+      toolSearch: { search: registrySearch(tools), loadout: [] },
+    });
+
+    await readSse(await agent.stream({ threadId: "thr_both", message: userMessage("u1", "hi"), ctx: ctx() }));
+
+    // Both meta-tools stay offered even though host tools are gated by the loadout.
+    expect(model.toolNamesPerCall[0]).toContain(VENDO_TOOLS_SEARCH_TOOL_NAME);
+    expect(model.toolNamesPerCall[0]).toContain(CAPABILITY_MISS_TOOL_NAME);
+    expect(model.toolNamesPerCall[0]).not.toContain("host_export_csv");
+  });
+
+  it("clears a thread's loaded tools on session eviction so a reused id starts fresh (regression)", async () => {
+    const model = scriptedModel([
+      toolCallTurn(VENDO_TOOLS_SEARCH_TOOL_NAME, { query: "export csv" }, "call_search"),
+      textTurn("Found it.", "text_first"),
+      textTurn("Fresh turn.", "text_second"),
+    ]);
+    const guard = testGuard({});
+    const tools = boundRegistry(impls, guard);
+    // No store → the in-memory (BYO) path, which is the one evictSubject reclaims.
+    const agent = createAgent({ model, tools, guard, toolSearch: { search: registrySearch(tools), loadout: [] } });
+
+    await readSse(await agent.stream({
+      threadId: "thr_evict",
+      message: userMessage("u1", "Find a way to export CSV"),
+      ctx: ctx({ principal: { kind: "user", subject: "u_evict" } }),
+    }));
+    // Loaded within the first run.
+    expect(model.toolNamesPerCall[1]).toContain("host_export_csv");
+
+    agent.evictSubject("u_evict");
+
+    await readSse(await agent.stream({
+      threadId: "thr_evict",
+      message: userMessage("u2", "now do it"),
+      ctx: ctx({ principal: { kind: "user", subject: "u_evict" } }),
+    }));
+    // A reused thread id after eviction must NOT inherit the evicted loadout.
+    expect(model.toolNamesPerCall[2]).not.toContain("host_export_csv");
   });
 
   it("bounds the initial loadout and searches in the needle on a 300+ tool host", async () => {

--- a/packages/agent/src/tool-search.test.ts
+++ b/packages/agent/src/tool-search.test.ts
@@ -1,0 +1,206 @@
+import type { ToolDescriptor } from "@vendoai/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_MAX_INITIAL_TOOLS,
+  VENDO_TOOLS_SEARCH_TOOL_NAME,
+  computeInitialLoadout,
+  createAgent,
+  type ToolSearchFn,
+} from "./index.js";
+import {
+  boundRegistry,
+  ctx,
+  partOfType,
+  readSse,
+  scriptedModel,
+  testGuard,
+  textTurn,
+  toolCallTurn,
+  userMessage,
+  type BoundRegistry,
+  type TestToolImplementation,
+} from "./test-helpers.js";
+
+function descriptor(name: string, description: string, risk: ToolDescriptor["risk"] = "read"): ToolDescriptor {
+  return { name, description, inputSchema: { type: "object" }, risk };
+}
+
+/** A stand-in search seam over a registry's descriptors. The REAL deterministic
+ * ranker (ActionsRegistry.search / searchToolDescriptors) is unit-tested in
+ * @vendoai/actions; the agent block depends on core only and cannot import it,
+ * so these tests exercise the loadout + guard mechanics against a simple seam. */
+function registrySearch(tools: BoundRegistry): ToolSearchFn {
+  return async (query, options) => {
+    const descriptors = await tools.descriptors();
+    const tokens = query.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+    return descriptors
+      .filter((d) => tokens.some((t) => d.name.toLowerCase().includes(t) || d.description.toLowerCase().includes(t)))
+      .slice(0, options?.limit ?? 10)
+      .map((d) => ({ name: d.name, description: d.description, risk: d.risk, score: 1 }));
+  };
+}
+
+const impls: Record<string, TestToolImplementation> = {
+  host_transactions_list: {
+    descriptor: descriptor("host_transactions_list", "List transactions"),
+    execute: async () => ({ items: [] }),
+  },
+  host_export_csv: {
+    descriptor: descriptor("host_export_csv", "Export transactions to CSV", "write"),
+    execute: async () => ({ url: "/download.csv" }),
+  },
+};
+
+describe("computeInitialLoadout (loadout policy)", () => {
+  const surface = [
+    descriptor("vendo_apps_open", "Open an app"),
+    descriptor("host_a_read", "read a"),
+    descriptor("host_b_write", "write b", "write"),
+    descriptor("host_c_wipe", "wipe c", "destructive"),
+  ];
+  const search: ToolSearchFn = async () => [];
+
+  it("keeps the whole surface active when it fits the cap", () => {
+    const loadout = computeInitialLoadout(surface, { search });
+    expect(loadout).toEqual(new Set(["vendo_apps_open", "host_a_read", "host_b_write", "host_c_wipe"]));
+  });
+
+  it("honors an explicit curated loadout and always keeps vendo_* tools", () => {
+    const loadout = computeInitialLoadout(surface, { search, loadout: ["host_b_write", "does_not_exist"] });
+    expect(loadout).toEqual(new Set(["vendo_apps_open", "host_b_write"]));
+  });
+
+  it("applies a deterministic read-first bounded default when uncurated and large", () => {
+    const big = [descriptor("vendo_apps_open", "Open an app")];
+    for (let i = 0; i < 10; i += 1) big.push(descriptor(`host_w_${i}`, "w", "destructive"));
+    for (let i = 0; i < 10; i += 1) big.push(descriptor(`host_r_${i}`, "r", "read"));
+    const loadout = computeInitialLoadout(big, { search, maxInitialTools: 5 });
+    // vendo_* always in; the 5 host slots go to read-risk tools first, by name.
+    expect(loadout.has("vendo_apps_open")).toBe(true);
+    const hostNames = [...loadout].filter((n) => n.startsWith("host_"));
+    expect(hostNames).toHaveLength(5);
+    expect(hostNames.every((n) => n.startsWith("host_r_"))).toBe(true);
+  });
+
+  it("defaults the cap to DEFAULT_MAX_INITIAL_TOOLS", () => {
+    const big = [descriptor("vendo_apps_open", "Open an app")];
+    for (let i = 0; i < DEFAULT_MAX_INITIAL_TOOLS + 50; i += 1) big.push(descriptor(`host_${i}`, "x"));
+    const loadout = computeInitialLoadout(big, { search });
+    expect([...loadout].filter((n) => n.startsWith("host_"))).toHaveLength(DEFAULT_MAX_INITIAL_TOOLS);
+  });
+});
+
+describe("vendo_tools_search meta-tool", () => {
+  it("loads a previously-unavailable tool and executes it through the guard-bound registry", async () => {
+    const model = scriptedModel([
+      toolCallTurn(VENDO_TOOLS_SEARCH_TOOL_NAME, { query: "export csv" }, "call_search"),
+      toolCallTurn("host_export_csv", {}, "call_export"),
+      textTurn("Exported.", "text_done"),
+    ]);
+    const guard = testGuard({ host_export_csv: "run" });
+    const tools = boundRegistry(impls, guard);
+    const search = vi.fn(registrySearch(tools));
+    const agent = createAgent({ model, tools, guard, toolSearch: { search, loadout: [] } });
+
+    await readSse(await agent.stream({
+      threadId: "thr_load",
+      message: userMessage("u1", "Export my transactions to CSV"),
+      ctx: ctx(),
+    }));
+
+    expect(search).toHaveBeenCalledWith("export csv", undefined);
+    // Gated at the start: the host tool is not offered until it is searched in.
+    expect(model.toolNamesPerCall[0]).toContain(VENDO_TOOLS_SEARCH_TOOL_NAME);
+    expect(model.toolNamesPerCall[0]).not.toContain("host_export_csv");
+    // After search, the very next step offers — and the model calls — the tool.
+    expect(model.toolNamesPerCall[1]).toContain("host_export_csv");
+    expect(tools.invocations.host_export_csv).toBe(1);
+    // Executed through the guard binding: an audit event was reported.
+    expect(guard.events.some((e) => e.kind === "tool-call" && e.tool === "host_export_csv")).toBe(true);
+  });
+
+  it("still gates a searched-in WRITE tool through the guard (no unguarded path)", async () => {
+    const model = scriptedModel([
+      toolCallTurn(VENDO_TOOLS_SEARCH_TOOL_NAME, { query: "export csv" }, "call_search"),
+      toolCallTurn("host_export_csv", {}, "call_export"),
+      textTurn("unreached", "text_unreached"),
+    ]);
+    const guard = testGuard({ host_export_csv: "ask" });
+    const tools = boundRegistry(impls, guard);
+    const agent = createAgent({ model, tools, guard, toolSearch: { search: registrySearch(tools), loadout: [] } });
+
+    const { parts } = await readSse(await agent.stream({
+      threadId: "thr_gate",
+      message: userMessage("u1", "Export my transactions to CSV"),
+      ctx: ctx(),
+    }));
+
+    // The searched-in write tool was offered but its execution parked on approval.
+    expect(model.toolNamesPerCall[1]).toContain("host_export_csv");
+    expect(tools.invocations.host_export_csv).toBe(0);
+    expect(guard.pending()).toHaveLength(1);
+    const approval = parts.find((part) => part.type === "data-vendo-approval");
+    expect(approval).toBeDefined();
+  });
+
+  it("persists loaded tools across turns within a thread", async () => {
+    const model = scriptedModel([
+      toolCallTurn(VENDO_TOOLS_SEARCH_TOOL_NAME, { query: "export csv" }, "call_search"),
+      textTurn("Found it.", "text_first"),
+      textTurn("Second turn.", "text_second"),
+    ]);
+    const guard = testGuard({});
+    const tools = boundRegistry(impls, guard);
+    const agent = createAgent({ model, tools, guard, toolSearch: { search: registrySearch(tools), loadout: [] } });
+
+    await readSse(await agent.stream({
+      threadId: "thr_persist",
+      message: userMessage("u1", "Find a way to export CSV"),
+      ctx: ctx(),
+    }));
+    await readSse(await agent.stream({
+      threadId: "thr_persist",
+      message: userMessage("u2", "now do it"),
+      ctx: ctx(),
+    }));
+
+    // The second turn's FIRST model call already offers the tool loaded last turn.
+    const secondTurnFirstCall = model.toolNamesPerCall[2]!;
+    expect(secondTurnFirstCall).toContain("host_export_csv");
+  });
+
+  it("bounds the initial loadout and searches in the needle on a 300+ tool host", async () => {
+    const big: Record<string, TestToolImplementation> = {};
+    for (let i = 0; i < 320; i += 1) {
+      const name = `host_widget_${i}_get`;
+      big[name] = { descriptor: descriptor(name, `Fetch widget ${i}`), execute: async () => ({ ok: true }) };
+    }
+    big.host_payouts_refund = {
+      descriptor: descriptor("host_payouts_refund", "Refund a customer payout", "destructive"),
+      execute: async () => ({ refunded: true }),
+    };
+    const model = scriptedModel([
+      toolCallTurn(VENDO_TOOLS_SEARCH_TOOL_NAME, { query: "refund payout" }, "call_search"),
+      toolCallTurn("host_payouts_refund", {}, "call_refund"),
+      textTurn("done", "text_done"),
+    ]);
+    const guard = testGuard({ host_payouts_refund: "ask" });
+    const tools = boundRegistry(big, guard);
+    const agent = createAgent({ model, tools, guard, toolSearch: { search: registrySearch(tools) } });
+
+    const { parts } = await readSse(await agent.stream({
+      threadId: "thr_big",
+      message: userMessage("u1", "Refund the last payout"),
+      ctx: ctx(),
+    }));
+
+    // Bounded: the model is never handed all 321 tools; the destructive needle is
+    // NOT in the initial loadout and only becomes callable after search.
+    expect(model.toolNamesPerCall[0]!.length).toBeLessThanOrEqual(DEFAULT_MAX_INITIAL_TOOLS + 2);
+    expect(model.toolNamesPerCall[0]).not.toContain("host_payouts_refund");
+    expect(model.toolNamesPerCall[1]).toContain("host_payouts_refund");
+    // The searched-in destructive tool is still guard-gated.
+    expect(tools.invocations.host_payouts_refund).toBe(0);
+    expect(parts.some((part) => part.type === "data-vendo-approval")).toBe(true);
+  });
+});

--- a/packages/agent/src/tool-search.ts
+++ b/packages/agent/src/tool-search.ts
@@ -1,0 +1,156 @@
+import {
+  VendoError,
+  type RiskLabel,
+  type ToolDescriptor,
+  type ToolOutcome,
+} from "@vendoai/core";
+import { dynamicTool, jsonSchema, type ToolSet } from "ai";
+
+/** The meta-tool the agent uses to discover and load host tools mid-run. */
+export const VENDO_TOOLS_SEARCH_TOOL_NAME = "vendo_tools_search";
+
+/** Default bound on the uncurated initial loadout. A large host (dub ≈ 617
+ * tools, papermark ≈ 388) would otherwise flood the model's context; the rest
+ * stay reachable through {@link VENDO_TOOLS_SEARCH_TOOL_NAME}. */
+export const DEFAULT_MAX_INITIAL_TOOLS = 128;
+
+const RISK_ORDER: Record<RiskLabel, number> = { read: 0, write: 1, destructive: 2 };
+
+/** A hit from the injected search seam — the structural twin of actions'
+ * `ToolSearchMatch` (the agent block depends on core only, so it cannot import
+ * the actions type). */
+export interface ToolSearchMatch {
+  name: string;
+  description: string;
+  risk: RiskLabel;
+  score: number;
+}
+
+/** Ranks the merged, enabled, guard-bound tool surface against a free-text
+ * intent. The umbrella wires this to `ActionsRegistry.search`. */
+export type ToolSearchFn = (query: string, options?: { limit?: number }) => Promise<ToolSearchMatch[]>;
+
+export interface ToolSearchConfig {
+  /** The registry query seam (umbrella wires it to the guard-bound registry). */
+  search: ToolSearchFn;
+  /** Uncurated loadout cap. Defaults to {@link DEFAULT_MAX_INITIAL_TOOLS}. */
+  maxInitialTools?: number;
+  /** Explicit curated initial loadout by tool name. When set, exactly these
+   *  (that exist and are enabled) start active; the cap is not applied. */
+  loadout?: string[];
+}
+
+const SEARCH_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    query: { type: "string", minLength: 1, maxLength: 200 },
+    limit: { type: "integer", minimum: 1, maximum: 25 },
+  },
+  required: ["query"],
+  additionalProperties: false,
+} as Parameters<typeof jsonSchema>[0];
+
+/** Vendo's own always-available tools (apps, connect, the meta-tools) are never
+ * loadout-gated: they are not host API tools that explode in number, and gating
+ * them out would break the product surface. Everything `vendo_`-prefixed stays
+ * active; host tools are what the loadout bounds. */
+function isAlwaysActive(name: string): boolean {
+  return name.startsWith("vendo_");
+}
+
+/**
+ * The INITIAL enabled set (loadout policy, ENG-252 spec §4):
+ *  - Explicit `loadout` present → exactly those names that exist, deduped
+ *    (curation, e.g. derived from overrides).
+ *  - Otherwise, if the enabled host surface fits the cap → the whole surface.
+ *  - Otherwise (uncurated + large) → a deterministic bounded default: safest
+ *    risk first (read < write < destructive), then name, capped. The remainder
+ *    stays discoverable via search.
+ * Vendo's own `vendo_*` tools are always active and excluded from the cap.
+ */
+export function computeInitialLoadout(descriptors: readonly ToolDescriptor[], config: ToolSearchConfig): Set<string> {
+  const available = new Set(descriptors.map((descriptor) => descriptor.name));
+  const alwaysActive = descriptors.filter((descriptor) => isAlwaysActive(descriptor.name)).map((d) => d.name);
+  const hostTools = descriptors.filter((descriptor) => !isAlwaysActive(descriptor.name));
+
+  if (config.loadout !== undefined) {
+    return new Set([...alwaysActive, ...config.loadout.filter((name) => available.has(name))]);
+  }
+
+  const cap = Math.max(Math.trunc(config.maxInitialTools ?? DEFAULT_MAX_INITIAL_TOOLS), 1);
+  if (hostTools.length <= cap) return new Set([...alwaysActive, ...hostTools.map((d) => d.name)]);
+
+  const bounded = [...hostTools]
+    .sort((a, b) => (RISK_ORDER[a.risk] - RISK_ORDER[b.risk]) || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+    .slice(0, cap)
+    .map((descriptor) => descriptor.name);
+  return new Set([...alwaysActive, ...bounded]);
+}
+
+export interface ToolSearchSession {
+  /** Names the model may call this step: initial loadout ∪ everything loaded so
+   *  far ∪ the always-active `vendo_*` tools (which include this meta-tool). */
+  activeToolNames(): string[];
+  /** Register `vendo_tools_search` into the run's toolset. */
+  attach(tools: ToolSet): void;
+}
+
+export interface ToolSearchSessionOptions {
+  config: ToolSearchConfig;
+  /** The full built toolset's descriptors (names available to load). */
+  descriptors: readonly ToolDescriptor[];
+  /** Per-run loaded set — persists across turns within a thread. Mutated here. */
+  loaded: Set<string>;
+}
+
+export function createToolSearchSession(options: ToolSearchSessionOptions): ToolSearchSession {
+  const available = new Set(options.descriptors.map((descriptor) => descriptor.name));
+  const initial = computeInitialLoadout(options.descriptors, options.config);
+
+  return {
+    activeToolNames() {
+      const active = new Set<string>(initial);
+      active.add(VENDO_TOOLS_SEARCH_TOOL_NAME);
+      for (const descriptor of options.descriptors) if (isAlwaysActive(descriptor.name)) active.add(descriptor.name);
+      for (const name of options.loaded) if (available.has(name)) active.add(name);
+      return [...active];
+    },
+
+    attach(tools) {
+      if (tools[VENDO_TOOLS_SEARCH_TOOL_NAME] !== undefined) {
+        throw new VendoError("conflict", `Reserved internal tool name: ${VENDO_TOOLS_SEARCH_TOOL_NAME}`);
+      }
+      tools[VENDO_TOOLS_SEARCH_TOOL_NAME] = dynamicTool({
+        description:
+          "Search the host's full tool surface by intent and LOAD the matches so you can call them this run. "
+          + "Use this when no currently-available tool fits the user's ask before giving up.",
+        inputSchema: jsonSchema(SEARCH_INPUT_SCHEMA),
+        execute: async (input): Promise<ToolOutcome> => {
+          const parsed = input as { query?: unknown; limit?: unknown } | null;
+          const query = typeof parsed?.query === "string" ? parsed.query : "";
+          if (query.trim().length === 0) {
+            return { status: "error", error: { code: "validation", message: "query must be a non-empty string" } };
+          }
+          const limit = typeof parsed?.limit === "number" ? parsed.limit : undefined;
+          let matches: ToolSearchMatch[];
+          try {
+            matches = await options.config.search(query, limit === undefined ? undefined : { limit });
+          } catch {
+            return { status: "error", error: { code: "execution", message: "Tool search failed." } };
+          }
+          // Only load names that actually exist in this run's guard-bound toolset
+          // — a stale or drifting search seam can never conjure an unbound tool.
+          const loadable = matches.filter((match) => available.has(match.name));
+          for (const match of loadable) options.loaded.add(match.name);
+          return {
+            status: "ok",
+            output: {
+              loaded: loadable.map((match) => match.name),
+              tools: loadable.map((match) => ({ name: match.name, description: match.description, risk: match.risk })),
+            },
+          };
+        },
+      });
+    },
+  };
+}

--- a/packages/agent/src/tool-search.ts
+++ b/packages/agent/src/tool-search.ts
@@ -106,17 +106,24 @@ export interface ToolSearchSessionOptions {
 export function createToolSearchSession(options: ToolSearchSessionOptions): ToolSearchSession {
   const available = new Set(options.descriptors.map((descriptor) => descriptor.name));
   const initial = computeInitialLoadout(options.descriptors, options.config);
+  // Captured at attach: the full run toolset. Every Vendo-owned `vendo_*` tool
+  // in it stays active regardless of loadout — including the OTHER meta-tools
+  // (notably `vendo_report_capability_miss`) that are attached after the host
+  // descriptors and so are NOT in `options.descriptors`. Gating them out would
+  // silently disable miss capture whenever tool search is on.
+  let attached: ToolSet | undefined;
 
   return {
     activeToolNames() {
       const active = new Set<string>(initial);
       active.add(VENDO_TOOLS_SEARCH_TOOL_NAME);
-      for (const descriptor of options.descriptors) if (isAlwaysActive(descriptor.name)) active.add(descriptor.name);
+      for (const name of Object.keys(attached ?? {})) if (isAlwaysActive(name)) active.add(name);
       for (const name of options.loaded) if (available.has(name)) active.add(name);
       return [...active];
     },
 
     attach(tools) {
+      attached = tools;
       if (tools[VENDO_TOOLS_SEARCH_TOOL_NAME] !== undefined) {
         throw new VendoError("conflict", `Reserved internal tool name: ${VENDO_TOOLS_SEARCH_TOOL_NAME}`);
       }

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -176,6 +176,10 @@ export interface CreateVendoConfig {
     toolOutputCap?: number;
     maxOutputTokens?: number;
     historyWindow?: number;
+    /** ENG-252 — cap on the uncurated initial tool loadout; the rest stay
+        discoverable via `vendo_tools_search`. Defaults to the agent block's
+        DEFAULT_MAX_INITIAL_TOOLS. */
+    maxInitialTools?: number;
   };
   /** 02-store §4 / ENG-237 — ephemeral (anonymous) session lifecycle. Anonymous
       visitors get a TTL-based session: every request touches it, an idle session
@@ -1498,6 +1502,13 @@ export function createVendo(config: CreateVendoConfig): Vendo {
       hostId: missCapture.hostId,
       surface: missSurface.then(({ hash }) => ({ format: "vendo/tools@1" as const, hash })),
       emit: (event) => missCapture.record(event),
+    },
+    // ENG-252: the agent starts with a bounded loadout and discovers the rest via
+    // `vendo_tools_search`. The search seam is the SAME guard-bound registry the
+    // agent executes through — a searched-in tool has no unguarded path.
+    toolSearch: {
+      search: (query, options) => actions.search(query, options),
+      ...(config.agent?.maxInitialTools === undefined ? {} : { maxInitialTools: config.agent.maxInitialTools }),
     },
   });
   // ENG-237 idle sweep: evict every idle, not-inflight ephemeral session from the


### PR DESCRIPTION
## ENG-252 — Runtime tool search / loadout meta-tool

Implements section 4 of the approved "extraction that survives real apps" design. Large hosts (dub extracts ~617 tools, papermark ~388) would flood the model's context; the agent now starts from a **bounded loadout** and discovers the rest at runtime.

### What changed

**`@vendoai/actions` — registry query API**
- `searchToolDescriptors(descriptors, query, options)` — pure, deterministic intent ranking (name tokens > name substring > description; whole-query-in-name bonus; ties break by name). Clamps limit to [1, 50].
- `ActionsRegistry.search(query, options)` — searches the merged, post-override, **enabled-only** descriptor set, so a disabled tool is never returned as loadable.

**`@vendoai/agent` — `vendo_tools_search` meta-tool + loadout**
- New `vendo_tools_search` meta-tool (mirrors the `vendo_report_capability_miss` registration pattern); name constant exported from the package index.
- Loadout gating via the ai-SDK `activeTools` + `prepareStep` seam: the full toolset is always built (so execution is unchanged), but the model only *sees* the current loadout. `prepareStep` re-reads the loadout each step, so a searched-in tool is callable on the very next step.
- Loaded tools persist per-thread across turns; cleared on thread delete.

**Loadout policy** (`computeInitialLoadout`)
- Explicit `loadout` list present → exactly those (that exist), deduped (curation).
- Else if the enabled host surface fits the cap → the whole surface.
- Else (uncurated + large) → deterministic **read-first bounded default** (`DEFAULT_MAX_INITIAL_TOOLS = 128`), safest risk first then name; the remainder stays discoverable via search.
- Vendo's own `vendo_*` tools (apps, meta-tools) are always active and excluded from the cap.

**Umbrella** wires `toolSearch.search` to the same guard-bound registry the agent executes through (`config.agent.maxInitialTools` opt-in cap).

### Guard invariant
Every tool — initial or searched-in — executes through the guard-bound registry. `activeTools` gates the model's *choice* only; there is no second execution path. Proven by tests.

### Tests
- `actions/src/runtime/search.test.ts` — ranking, description-token match, determinism/tie-break, limit clamp, **disabled excluded**, **321-tool** fixture ranks the needle first.
- `agent/src/tool-search.test.ts` — loadout policy (curated / passthrough / read-first bounded default / default cap); search loads a previously-unavailable tool and it executes through the guard binding; **guard still gates a searched-in write tool** (approval, zero invocations); loaded tools persist across turns; **321-tool** synthetic host: bounded initial loadout, needle searched in and still guard-gated.

The 300+-tool proof is **synthetic** (in-memory registry fixtures), not a live corpus boot.

### Gate
`pnpm build && pnpm test && pnpm typecheck && pnpm lint` all green (test: 41/41 turbo tasks). Changeset added (`@vendoai/actions`, `@vendoai/agent`, `@vendoai/vendo` minor).

Does **not** touch `docs/contracts/`. No new normative contract surface was required (see the linked notes).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runtime tool search and a bounded initial loadout so the agent starts small and loads tools on demand for large hosts (ENG-252). All calls still run through the guard-bound registry; disabled tools never appear in results.

- **New Features**
  - `@vendoai/actions`: Added `searchToolDescriptors` and `ActionsRegistry.search` for deterministic, enabled-only tool ranking with a clamped limit.
  - `@vendoai/agent`: Introduced `vendo_tools_search` meta-tool with loadout gating via `activeTools`/`prepareStep`; `computeInitialLoadout` (explicit curated list, whole surface if under cap, else read-first bounded default). Loaded tools persist per thread, `vendo_*` tools stay always active, eviction clears loaded sets, and loadout state is LRU-bounded. Exported `VENDO_TOOLS_SEARCH_TOOL_NAME`, `DEFAULT_MAX_INITIAL_TOOLS`, and `computeInitialLoadout`.
  - `@vendoai/vendo`: Wired the search seam to the same guard-bound registry and added optional `agent.maxInitialTools` configuration.

<sup>Written for commit ebc72e43af0cb7081dab2f40ea3cfe00b2d3e82c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

