### PR TITLE
feat(vendo): doctor v2 (live model turn + --json) + cloud-in-init + starter allowance (ENG-339)

### DIFF
--- a/docs/evidence/eng-339-doctor-v2/README.md
+++ b/docs/evidence/eng-339-doctor-v2/README.md
@@ -1,0 +1,51 @@
+# ENG-339 Doctor v2 — live evidence
+
+Captured against the Maple demo host (`apps/demo-bank`) booted with a real
+`ANTHROPIC_API_KEY`, on 2026-07-16.
+
+## Files
+
+- `doctor-live-maple.txt` — `vendo doctor` text mode against the live Maple dev
+  server. A real Anthropic turn answered ("All systems are go — Vendo's agent
+  is online and ready to assist!") in ~2.7s; exit 0.
+- `doctor-live-maple.json` — `vendo doctor --json` against the same server. One
+  machine-readable object: `wired: true`, `exit: 0`, 17 `checks`,
+  `liveTurn.ok: true` over `env-key` (real reply captured), `cloud.present:
+  false` with the unlocks list, and `codex` drift `{ version: 0.144.4, tested:
+  0.144, drifted: false }`.
+- `doctor-live-unreachable.txt` — `vendo doctor` against a dead port. The live
+  turn cannot run ("live model turn cannot run; start the dev server …"); exit 1.
+
+## Live-turn design
+
+Doctor's live turn POSTs one seeded health-check prompt to `{base}/threads` —
+the same wired route the runtime serves — and streams the UI-message reply.
+Exit 0 == a non-empty reply arrived. The rung shown is resolved from the same
+wave-2 ladder the runtime uses, so doctor and runtime agree on what is wired.
+
+Live-model tests are gated: the unit/integration suites use seams and a
+scripted model (`corpus/hosts/express-host/e2e/doctor.e2e.test.ts` exercises the
+real HTTP turn end-to-end), so CI without keys passes. The transcripts above
+are the real-key verification run locally.
+
+## Starter-allowance console contract (parked hand-off)
+
+The vendo-side consumer is implemented (`vendo init` writes `.env.local` from a
+minted key; the resolver already has the `vendo-cloud` rung). The console
+endpoint is a Cloud console (vendo-web) follow-up:
+
+```
+POST /api/v1/dev/starter-key
+  auth:    user session (Bearer access token from `vendo cloud login`)
+  request: { "purpose": "dev-mode" }
+  response:
+    { "key": "vnd_<40 hex>",
+      "meter": { "runs": { "included": <n>, "remaining": <n> } } }
+  errors:  404 / not-implemented  → init degrades to a pointer (no block)
+```
+
+The key is a metered dev-mode API key scoped to the caller's default org.
+Separately, the `vendo-cloud` rung producing a working dev model needs a Cloud
+model gateway (console-side); until it ships, `devModel()` reports the rung as
+unavailable with instructions. Both are parked for the Cloud console project;
+the vendo side is ready to consume them.

--- a/docs/evidence/eng-339-doctor-v2/doctor-live-maple.json
+++ b/docs/evidence/eng-339-doctor-v2/doctor-live-maple.json
@@ -1,0 +1,104 @@
+{
+  "vendo": "doctor",
+  "version": "0.3.0",
+  "wired": true,
+  "exit": 0,
+  "checks": [
+    {
+      "status": "ok",
+      "message": "catch-all handler is wired"
+    },
+    {
+      "status": "ok",
+      "message": "<VendoRoot> wraps the app"
+    },
+    {
+      "status": "ok",
+      "message": "@vendoai/vendo dependency is declared"
+    },
+    {
+      "status": "ok",
+      "message": ".vendo/tools.json"
+    },
+    {
+      "status": "ok",
+      "message": ".vendo/overrides.json"
+    },
+    {
+      "status": "ok",
+      "message": ".vendo/policy.json"
+    },
+    {
+      "status": "ok",
+      "message": ".vendo/brief.md"
+    },
+    {
+      "status": "ok",
+      "message": ".vendo/theme.json"
+    },
+    {
+      "status": "warning",
+      "message": ".vendo/data/.gitignore is missing"
+    },
+    {
+      "status": "ok",
+      "message": "/status live round-trip (0.3.0, rules)"
+    },
+    {
+      "status": "ok",
+      "message": "execution venue: e2b"
+    },
+    {
+      "status": "ok",
+      "message": "present credentials reach the host API"
+    },
+    {
+      "status": "warning",
+      "message": "actAs is not configured; pass createVendo({ actAs }) before enabling away host actions"
+    },
+    {
+      "status": "ok",
+      "message": "MCP protected-resource metadata resolves"
+    },
+    {
+      "status": "ok",
+      "message": "MCP authorization-server metadata resolves"
+    },
+    {
+      "status": "ok",
+      "message": "MCP server card parses"
+    },
+    {
+      "status": "ok",
+      "message": "live model turn answered over explicit ANTHROPIC_API_KEY (anthropic) (4388ms)"
+    }
+  ],
+  "liveTurn": {
+    "attempted": true,
+    "rung": "env-key",
+    "credential": "explicit ANTHROPIC_API_KEY (anthropic)",
+    "elapsedMs": 4388,
+    "ok": true,
+    "reply": "All systems are healthy and I'm ready to assist you!"
+  },
+  "cloud": {
+    "present": false,
+    "ok": false,
+    "unlocks": [
+      "a free dev-mode starter model allowance (keyless first turns)",
+      "team sharing and org governance (roles, SSO)",
+      "hosted deploys of your enabled automations",
+      "session replay, insights, and the MCP broker"
+    ]
+  },
+  "codex": {
+    "installed": true,
+    "version": "0.144.4",
+    "tested": "0.144",
+    "drifted": false
+  },
+  "summary": {
+    "failures": 0,
+    "warnings": 2
+  }
+}

--- a/docs/evidence/eng-339-doctor-v2/doctor-live-maple.txt
+++ b/docs/evidence/eng-339-doctor-v2/doctor-live-maple.txt
@@ -1,0 +1,22 @@
+ok: catch-all handler is wired
+ok: <VendoRoot> wraps the app
+ok: @vendoai/vendo dependency is declared
+ok: .vendo/tools.json
+ok: .vendo/overrides.json
+ok: .vendo/policy.json
+ok: .vendo/brief.md
+ok: .vendo/theme.json
+warning: .vendo/data/.gitignore is missing
+ok: /status live round-trip (0.3.0, rules)
+ok: execution venue: e2b
+ok: present credentials reach the host API
+warning: actAs is not configured; pass createVendo({ actAs }) before enabling away host actions
+ok: MCP protected-resource metadata resolves
+ok: MCP authorization-server metadata resolves
+ok: MCP server card parses
+Ladder: execution venue is checked above; actAs for away host actions; connectors for external tools.
+ok: live model turn answered over explicit ANTHROPIC_API_KEY (anthropic) (2728ms)
+
+  All systems are go — Vendo's agent is online and ready to assist!
+
+Vendo Cloud (optional): no VENDO_API_KEY. A key unlocks a free dev-mode starter model allowance (keyless first turns); team sharing and org governance (roles, SSO); hosted deploys of your enabled automations; session replay, insights, and the MCP broker. Run `vendo cloud login` to start.

--- a/docs/evidence/eng-339-doctor-v2/doctor-live-unreachable.txt
+++ b/docs/evidence/eng-339-doctor-v2/doctor-live-unreachable.txt
@@ -1,0 +1,15 @@
+ok: catch-all handler is wired
+ok: <VendoRoot> wraps the app
+ok: @vendoai/vendo dependency is declared
+ok: .vendo/tools.json
+ok: .vendo/overrides.json
+ok: .vendo/policy.json
+ok: .vendo/brief.md
+ok: .vendo/theme.json
+warning: .vendo/data/.gitignore is missing
+broken: /status is unreachable at http://localhost:3999/api/vendo/status
+broken: present credential probe cannot run; start the dev server at http://localhost:3999/api/vendo and retry
+broken: cannot probe actAs; start the dev server at http://localhost:3999/api/vendo and retry
+Ladder: execution venue is checked above; actAs for away host actions; connectors for external tools.
+broken: live model turn cannot run; start the dev server at http://localhost:3999/api/vendo and retry
+Vendo Cloud (optional): no VENDO_API_KEY. A key unlocks a free dev-mode starter model allowance (keyless first turns); team sharing and org governance (roles, SSO); hosted deploys of your enabled automations; session replay, insights, and the MCP broker. Run `vendo cloud login` to start.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -22,7 +22,10 @@ install. `vendo init` proposes two host changes: a catch-all handler and a
    the wizard; needs `@anthropic-ai/claude-agent-sdk` in the app (init offers
    the install).
 3. Your authed Codex CLI session. Dev only, used after you consent.
-4. Nothing available: chat fails honestly, with exact instructions in the
+4. A Vendo Cloud starter allowance. When no local credential is found, init
+   offers `vendo cloud login`; after login it mints a metered dev-mode key and
+   writes `VENDO_API_KEY` to `.env.local` for you. You never paste a key.
+5. Nothing available: chat fails honestly, with exact instructions in the
    server log.
 
 The wizard states what it found. Consent for session rungs is recorded per
@@ -40,6 +43,10 @@ Init ends in the product: with your consent it starts the dev server, opens
 the app in your browser, and seeds a first agent turn. The seed adapts to what
 setup found: extracted tools get a live tool demo, a theme-only app gets an
 on-brand UI generation, a blank app gets a tour.
+
+Vendo Cloud is optional. When `VENDO_API_KEY` is set, init validates it and
+states the plan and what it unlocks; when it is absent, init prints one calm
+line and, if a starter key would help the ladder, offers `vendo cloud login`.
 
 ## Create the server
 
@@ -242,13 +249,25 @@ export const POST = forward;
 
 ```bash
 npx vendo doctor
+npx vendo doctor --json
 npx vendo sync
 ```
 
 `doctor` checks wiring, makes a live `/status` probe, verifies that present
 credentials reach the host API, and exercises `actAs` minting through the
-host's verifier when configured. `sync` extracts the host API and remix
-baselines. In strict mode, breaking extraction changes exit with code 2.
+host's verifier when configured. It then runs one real model turn through the
+same wired route your app serves and prints the reply: exit 0 means a user
+would have gotten an answer, nonzero means the turn failed. It also validates
+`VENDO_API_KEY` when set (and shows what Cloud unlocks), and warns when the
+installed `codex` CLI drifts off the tested app-server protocol line.
+
+When nothing is listening on the dev port, `doctor` offers to start the dev
+server for the probe (or pass `--yes` to start it non-interactively). `--json`
+prints one machine-readable object — `checks`, `liveTurn`, `cloud`, `codex`,
+and the exit code — for scripts and agents.
+
+`sync` extracts the host API and remix baselines. In strict mode, breaking
+extraction changes exit with code 2.
 
 To make the deployed door discoverable through the official registry, follow
 [Publish to the MCP registry](publish-mcp-registry.md).

--- a/packages/dev-riders/src/codex.test.ts
+++ b/packages/dev-riders/src/codex.test.ts
@@ -3,7 +3,12 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
 import { describe, expect, it } from "vitest";
-import { CodexSessionRider } from "./codex.js";
+import {
+  CodexSessionRider,
+  TESTED_CODEX_MINOR,
+  codexVersionMatchesTested,
+  probeCodexVersion,
+} from "./codex.js";
 
 const stub = join(dirname(fileURLToPath(import.meta.url)), "..", "test-fixtures", "stub-codex.mjs");
 
@@ -96,5 +101,21 @@ describe("CodexSessionRider against a protocol stub", () => {
     await expect(
       rider.start({ system: "sys", tools: [], onToolCall: async () => ({ text: "", ok: true }) }),
     ).rejects.toThrow(/needs the `definitely-not-codex-binary` CLI/);
+  });
+});
+
+describe("codex version drift helpers", () => {
+  it("matches the tested minor line regardless of patch", () => {
+    expect(codexVersionMatchesTested(`${TESTED_CODEX_MINOR}.4`)).toBe(true);
+    expect(codexVersionMatchesTested(`${TESTED_CODEX_MINOR}.99`)).toBe(true);
+  });
+
+  it("flags a drifted minor line", () => {
+    expect(codexVersionMatchesTested("0.160.0")).toBe(false);
+    expect(codexVersionMatchesTested("1.0.0")).toBe(false);
+  });
+
+  it("returns null when codex is absent", async () => {
+    expect(await probeCodexVersion("definitely-not-codex-binary")).toBeNull();
   });
 });

--- a/packages/dev-riders/src/codex.ts
+++ b/packages/dev-riders/src/codex.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcessByStdio } from "node:child_process";
+import { execFile, spawn, type ChildProcessByStdio } from "node:child_process";
 import { copyFile, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
@@ -32,6 +32,34 @@ import type { RiderSession, RiderSessionStart } from "./types.js";
  */
 
 type Json = Record<string, unknown>;
+
+/**
+ * The codex-cli minor line this rider's app-server protocol shapes were
+ * verified against (spike ENG-337 REPORT.md). The `dynamicTools` surface is
+ * upstream-experimental AND feature-gated, and this rider reads tool calls by
+ * field name (`params.tool` / `params.arguments`); a codex upgrade that renames
+ * those fields degrades tool calls to "Unknown tool" silently. Doctor v2 warns
+ * (dev-only, informational) when the installed codex drifts off this line.
+ */
+export const TESTED_CODEX_MINOR = "0.144";
+
+/** Best-effort `codex --version` probe. Returns the parsed x.y.z string, or
+ *  null when codex is absent or unparseable. Never throws. */
+export function probeCodexVersion(command = "codex"): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile(command, ["--version"], { timeout: 5_000 }, (error, stdout) => {
+      if (error !== null) return resolve(null);
+      const match = /(\d+\.\d+\.\d+)/.exec(stdout ?? "");
+      resolve(match ? match[1]! : null);
+    });
+  });
+}
+
+/** Whether an x.y.z version sits on the tested minor line (x.y match). */
+export function codexVersionMatchesTested(version: string): boolean {
+  const parts = version.split(".");
+  return parts.length >= 2 && `${parts[0]}.${parts[1]}` === TESTED_CODEX_MINOR;
+}
 
 export interface CodexRiderOptions {
   /** Binary to spawn; defaults to `codex` on PATH. Test seam: point at a stub. */

--- a/packages/dev-riders/src/index.ts
+++ b/packages/dev-riders/src/index.ts
@@ -1,5 +1,11 @@
 export { ClaudeSessionRider, CLAUDE_AGENT_SDK_PACKAGE, type ClaudeRiderOptions } from "./claude.js";
-export { CodexSessionRider, type CodexRiderOptions } from "./codex.js";
+export {
+  CodexSessionRider,
+  TESTED_CODEX_MINOR,
+  codexVersionMatchesTested,
+  probeCodexVersion,
+  type CodexRiderOptions,
+} from "./codex.js";
 export { claudeGenerate, codexGenerate, type RiderGenerateInput } from "./generate.js";
 export type {
   RiderSession,

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -14,7 +14,7 @@ Usage: vendo <command> [dir] [options]
 
 Commands:
   init [dir]      Scan, interview, write .vendo, and propose handler + VendoRoot wiring
-  doctor [dir]    Verify wiring, present credentials, and actAs over live HTTP
+  doctor [dir]    Verify wiring, present credentials, actAs, and one real model turn over live HTTP
   sync [dir]      Extract tools and remix baselines (use --strict for CI)
   refine [dir]    Propose compound capabilities, risk corrections, and brief updates as reviewable diffs
   mcp <command>   Generate MCP registry discovery and domain-verification files
@@ -22,14 +22,14 @@ Commands:
 
 Options:
   --agent                    Init only: print a read-only plan — four questions, code diffs, extracted tools, risk recommendations
-  --yes                      Init/refine: skip the interview and approve displayed changes
+  --yes                      Init/refine: skip the interview and approve displayed changes; doctor: auto-start the dev server for the probe
   --force                    Init/server-json: overwrite owned or generated files
   --model-import <specifier> Init/refine: module exporting the host's ai-SDK model
   --brief <text>             Init only: product brief used for non-interactive setup
   --ask <text>               Refine only: interview answer (repeatable) for non-interactive runs
   --url <url>                Doctor/refine/server-json: mounted wire base or public MCP URL
   --strict                   Sync only: exit 2 on breaking changes, 3 when saved references are impacted
-  --json                     Sync only: print one machine-readable report object
+  --json                     Sync/doctor: print one machine-readable report object
   --report                   Sync only: push the report to Vendo Cloud
   --key <key>                Sync/cloud: override VENDO_API_KEY
   --api-url <url>            Sync/cloud: override VENDO_CLOUD_URL
@@ -116,7 +116,12 @@ export async function main(argv: string[]): Promise<number> {
     });
   }
   if (command === "doctor") {
-    return runDoctor({ targetDir: target(args), url: option(args, "--url") });
+    return runDoctor({
+      targetDir: target(args),
+      url: option(args, "--url"),
+      json: args.includes("--json"),
+      yes: args.includes("--yes"),
+    });
   }
   if (command === "refine") {
     return runRefineCommand({

--- a/packages/vendo/src/cli/cloud-init.test.ts
+++ b/packages/vendo/src/cli/cloud-init.test.ts
@@ -1,0 +1,131 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DevCredential } from "../dev-creds/resolve.js";
+import { runCloudStep } from "./cloud-init.js";
+
+const cleanup: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const dispose of cleanup.splice(0).reverse()) await dispose();
+});
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-cloud-init-"));
+  cleanup.push(() => rm(root, { recursive: true, force: true }));
+  return root;
+}
+
+function output(): { logs: string[]; errors: string[]; sink: { log(m: string): void; error(m: string): void } } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return { logs, errors, sink: { log: (m) => logs.push(m), error: (m) => errors.push(m) } };
+}
+
+const noKey: DevCredential = { rung: "none" };
+const envKey: DevCredential = { rung: "env-key", provider: "anthropic", envVar: "ANTHROPIC_API_KEY" };
+const goodKey = `vnd_${"a".repeat(40)}`;
+
+describe("runCloudStep", () => {
+  it("states the plan when VENDO_API_KEY is valid", async () => {
+    const messages = output();
+    const result = await runCloudStep({
+      root: await tempRoot(),
+      output: messages.sink,
+      yes: false,
+      credential: envKey,
+      cloudProbe: async () => ({ present: true, ok: true, plan: { id: "pro", name: "Pro", status: "active" }, capabilities: ["sharing"], unlocks: ["x"] }),
+    });
+    expect(result.keyValid).toBe(true);
+    expect(messages.logs.some((l) => l.includes("VENDO_API_KEY valid (plan: Pro)"))).toBe(true);
+  });
+
+  it("one calm line + a pointer when no key and the ladder wants one", async () => {
+    const messages = output();
+    const result = await runCloudStep({
+      root: await tempRoot(),
+      output: messages.sink,
+      yes: true, // non-interactive: never prompt
+      credential: noKey,
+      cloudProbe: async () => ({ present: false, ok: false, unlocks: ["a starter allowance"] }),
+    });
+    expect(result.wroteEnvLocal).toBe(false);
+    expect(messages.logs.some((l) => l.includes("A key unlocks a starter allowance"))).toBe(true);
+    expect(messages.logs.some((l) => l.includes("vendo cloud login"))).toBe(true);
+  });
+
+  it("logs in, mints a starter allowance, and writes .env.local", async () => {
+    const root = await tempRoot();
+    const login = vi.fn(async () => 0);
+    const mint = vi.fn(async () => goodKey);
+    const messages = output();
+    const result = await runCloudStep({
+      root,
+      output: messages.sink,
+      yes: false,
+      credential: noKey,
+      cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
+      confirm: async () => true,
+      promptEmail: async () => "dev@example.com",
+      login,
+      mint,
+    });
+    expect(login).toHaveBeenCalledWith("dev@example.com");
+    expect(mint).toHaveBeenCalledOnce();
+    expect(result.wroteEnvLocal).toBe(true);
+    const envLocal = await readFile(join(root, ".env.local"), "utf8");
+    expect(envLocal).toContain(`VENDO_API_KEY=${goodKey}`);
+  });
+
+  it("upserts into an existing .env.local without clobbering other keys", async () => {
+    const root = await tempRoot();
+    await writeFile(join(root, ".env.local"), "FOO=bar\nVENDO_API_KEY=old\n");
+    await runCloudStep({
+      root,
+      output: output().sink,
+      yes: false,
+      credential: noKey,
+      cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
+      confirm: async () => true,
+      promptEmail: async () => "dev@example.com",
+      login: async () => 0,
+      mint: async () => goodKey,
+    });
+    const envLocal = await readFile(join(root, ".env.local"), "utf8");
+    expect(envLocal).toContain("FOO=bar");
+    expect(envLocal).toContain(`VENDO_API_KEY=${goodKey}`);
+    expect(envLocal).not.toContain("VENDO_API_KEY=old");
+  });
+
+  it("degrades gracefully when the starter allowance endpoint is absent", async () => {
+    const root = await tempRoot();
+    const messages = output();
+    const result = await runCloudStep({
+      root,
+      output: messages.sink,
+      yes: false,
+      credential: noKey,
+      cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
+      confirm: async () => true,
+      promptEmail: async () => "dev@example.com",
+      login: async () => 0,
+      mint: async () => null,
+    });
+    expect(result.wroteEnvLocal).toBe(false);
+    expect(messages.errors.some((l) => l.includes("starter allowance is not available yet"))).toBe(true);
+  });
+
+  it("does not offer login when the ladder already has a key rung", async () => {
+    const confirm = vi.fn(async () => true);
+    const messages = output();
+    await runCloudStep({
+      root: await tempRoot(),
+      output: messages.sink,
+      yes: false,
+      credential: envKey,
+      cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
+      confirm,
+    });
+    expect(confirm).not.toHaveBeenCalled();
+  });
+});

--- a/packages/vendo/src/cli/cloud-init.ts
+++ b/packages/vendo/src/cli/cloud-init.ts
@@ -1,0 +1,176 @@
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+import { join } from "node:path";
+import type { DevCredential } from "../dev-creds/resolve.js";
+import { runLogin } from "./cloud/auth.js";
+import { CloudError, cloudFetch, type CloudFetchOptions } from "./cloud/client.js";
+import { isVendoKey } from "./cloud/entitlements.js";
+import { cloudDoctor, type CloudDoctorResult } from "./doctor-live.js";
+import { readOptional, writeText, type Output } from "./shared.js";
+
+/**
+ * ENG-339 (install-dx design §6) — cloud in init. Detect + validate
+ * VENDO_API_KEY when present (state what it unlocks), one calm line when
+ * absent, and — when a starter model key would actually help the ladder —
+ * offer `vendo cloud login` inline, then mint a metered dev-mode starter
+ * allowance and write it to .env.local so the dev never pastes a key.
+ *
+ * Starter-allowance minting is a Cloud console endpoint (see PR hand-off
+ * contract); until it lands, mint returns null and the step degrades to a
+ * clear pointer instead of blocking init.
+ */
+
+async function askYesNo(question: string, defaultYes = false): Promise<boolean> {
+  if (!stdin.isTTY || !stdout.isTTY) return false;
+  const prompt = createInterface({ input: stdin, output: stdout });
+  try {
+    const answer = (await prompt.question(`${question} ${defaultYes ? "[Y/n]" : "[y/N]"} `)).trim().toLowerCase();
+    if (answer === "") return defaultYes;
+    return ["y", "yes"].includes(answer);
+  } finally {
+    prompt.close();
+  }
+}
+
+async function askText(question: string): Promise<string> {
+  const prompt = createInterface({ input: stdin, output: stdout });
+  try {
+    return (await prompt.question(`${question}: `)).trim();
+  } finally {
+    prompt.close();
+  }
+}
+
+/**
+ * Console hand-off contract (parked follow-up in vendo-web):
+ *   POST /api/v1/dev/starter-key      auth: user session (Bearer access token)
+ *   request  { purpose: "dev-mode" }
+ *   response { key: "vnd_<40 hex>", meter: { runs: { included, remaining } } }
+ * The key is a metered dev-mode API key scoped to the caller's default org.
+ * Returns null when the endpoint is absent (404 / not-implemented) so init
+ * degrades gracefully; real auth/network errors propagate.
+ */
+export async function mintStarterAllowance(
+  options: Pick<CloudFetchOptions, "apiUrl" | "env" | "fetchImpl" | "home"> = {},
+): Promise<string | null> {
+  try {
+    const result = await cloudFetch("/api/v1/dev/starter-key", {
+      ...options,
+      auth: "user",
+      method: "POST",
+      body: { purpose: "dev-mode" },
+    });
+    const key = (result as { key?: unknown }).key;
+    return typeof key === "string" && isVendoKey(key) ? key : null;
+  } catch (error) {
+    if (error instanceof CloudError && (error.status === 404 || error.code === "not-implemented")) return null;
+    throw error;
+  }
+}
+
+/** Upsert VENDO_API_KEY in .env.local without clobbering other lines. */
+async function upsertEnvLocal(root: string, name: string, value: string): Promise<void> {
+  const path = join(root, ".env.local");
+  const current = await readOptional(path);
+  const line = `${name}=${value}`;
+  if (current === null || current.length === 0) {
+    await writeText(path, `${line}\n`);
+    return;
+  }
+  const pattern = new RegExp(`^\\s*${name}\\s*=.*$`, "m");
+  if (pattern.test(current)) {
+    await writeText(path, current.replace(pattern, line));
+    return;
+  }
+  const separator = current.endsWith("\n") ? "" : "\n";
+  await writeText(path, `${current}${separator}${line}\n`);
+}
+
+export interface CloudStepOptions {
+  root: string;
+  output: Output;
+  yes: boolean;
+  /** What the model ladder resolved — decides whether a starter key helps. */
+  credential: DevCredential;
+  env?: Record<string, string | undefined>;
+  apiUrl?: string;
+  home?: string;
+  /** Seams (tests). */
+  confirm?: (question: string, defaultYes?: boolean) => Promise<boolean>;
+  promptEmail?: (question: string) => Promise<string>;
+  cloudProbe?: (options: { env?: Record<string, string | undefined>; apiUrl?: string }) => Promise<CloudDoctorResult>;
+  login?: (email: string) => Promise<number>;
+  mint?: () => Promise<string | null>;
+}
+
+export interface CloudStepResult {
+  keyPresent: boolean;
+  keyValid: boolean;
+  wroteEnvLocal: boolean;
+}
+
+/** init's cloud step (design §6). Never changes init's exit code. */
+export async function runCloudStep(options: CloudStepOptions): Promise<CloudStepResult> {
+  const { root, output, credential } = options;
+  const env = options.env ?? process.env;
+  const cloud = await (options.cloudProbe ?? ((o) => cloudDoctor(o)))({
+    env,
+    ...(options.apiUrl === undefined ? {} : { apiUrl: options.apiUrl }),
+  });
+
+  if (cloud.present && cloud.ok) {
+    const plan = cloud.plan?.name || cloud.plan?.id || "unknown";
+    output.log(`\nVendo Cloud: VENDO_API_KEY valid (plan: ${plan}).`);
+    if (cloud.capabilities && cloud.capabilities.length > 0) {
+      output.log(`Unlocked: ${cloud.capabilities.join(", ")}.`);
+    }
+    return { keyPresent: true, keyValid: true, wroteEnvLocal: false };
+  }
+  if (cloud.present) {
+    output.error(`\nVendo Cloud: VENDO_API_KEY is set but not usable (${cloud.error ?? "validation failed"}). Fix or remove it; \`vendo cloud login\` can issue a fresh one.`);
+    return { keyPresent: true, keyValid: false, wroteEnvLocal: false };
+  }
+
+  // Absent — one calm line stating what Cloud unlocks.
+  output.log(`\nVendo Cloud (optional): not configured. A key unlocks ${cloud.unlocks.join("; ")}.`);
+
+  // A starter model key only helps when the local ladder has nothing better.
+  const laddersWantKey = credential.rung === "none" || credential.rung === "vendo-cloud";
+  if (options.yes || !laddersWantKey) {
+    if (laddersWantKey) {
+      output.log("Run `vendo cloud login` to grab a free dev-mode starter key; the wizard writes it to .env.local on your next `vendo init`.");
+    }
+    return { keyPresent: false, keyValid: false, wroteEnvLocal: false };
+  }
+
+  const confirm = options.confirm ?? askYesNo;
+  if (!(await confirm("Log in to Vendo Cloud now for a free dev-mode model key?", false))) {
+    output.log("Skipped — run `vendo cloud login` any time; the wizard will write the key to .env.local.");
+    return { keyPresent: false, keyValid: false, wroteEnvLocal: false };
+  }
+
+  const email = await (options.promptEmail ?? askText)("Vendo Cloud email");
+  if (email.length === 0) {
+    output.error("No email entered; skipped Vendo Cloud login.");
+    return { keyPresent: false, keyValid: false, wroteEnvLocal: false };
+  }
+  const login = options.login ?? ((address: string) => runLogin([address], { home: options.home, env }));
+  const exit = await login(email);
+  if (exit !== 0) {
+    output.error("Vendo Cloud login did not complete; run `vendo cloud login` and re-run `vendo init`.");
+    return { keyPresent: false, keyValid: false, wroteEnvLocal: false };
+  }
+
+  const key = await (options.mint ?? (() => mintStarterAllowance({
+    env,
+    ...(options.apiUrl === undefined ? {} : { apiUrl: options.apiUrl }),
+    ...(options.home === undefined ? {} : { home: options.home }),
+  })))();
+  if (key === null) {
+    output.error("Logged in, but the dev-mode starter allowance is not available yet (Cloud console follow-up). Set a provider key or ride your Claude/Codex CLI for now.");
+    return { keyPresent: false, keyValid: false, wroteEnvLocal: false };
+  }
+  await upsertEnvLocal(root, "VENDO_API_KEY", key);
+  output.log("Wrote VENDO_API_KEY to .env.local (dev-mode starter allowance). Production always needs a real server-side key.");
+  return { keyPresent: true, keyValid: true, wroteEnvLocal: true };
+}

--- a/packages/vendo/src/cli/doctor-live.test.ts
+++ b/packages/vendo/src/cli/doctor-live.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  cloudDoctor,
+  codexDrift,
+  CLOUD_UNLOCKS,
+  liveModelTurn,
+} from "./doctor-live.js";
+import type { ContractV2 } from "./cloud/entitlements.js";
+
+function sseResponse(frames: string[]): Response {
+  return new Response(frames.join(""), { headers: { "content-type": "text/event-stream" } });
+}
+
+describe("liveModelTurn", () => {
+  const env = { ANTHROPIC_API_KEY: "sk-test" };
+
+  it("streams a UI-message SSE reply and reports ok with the rung", async () => {
+    const deltas: string[] = [];
+    const fetchImpl = vi.fn(async () => sseResponse([
+      'data: {"type":"text-delta","delta":"Hello "}\n\n',
+      'data: {"type":"text-delta","delta":"world"}\n\n',
+      "data: [DONE]\n\n",
+    ])) as unknown as typeof fetch;
+    const result = await liveModelTurn({
+      base: "http://localhost:3000/api/vendo",
+      fetchImpl,
+      env,
+      onDelta: (d) => deltas.push(d),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.reply).toBe("Hello world");
+    expect(result.rung).toBe("env-key");
+    expect(deltas).toEqual(["Hello ", "world"]);
+    expect((fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).toBe("http://localhost:3000/api/vendo/threads");
+  });
+
+  it("fails when the stream yields no text", async () => {
+    const fetchImpl = vi.fn(async () => sseResponse(["data: [DONE]\n\n"])) as unknown as typeof fetch;
+    const result = await liveModelTurn({ base: "http://x/api/vendo", fetchImpl, env });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("no reply text");
+  });
+
+  it("fails on a non-ok response", async () => {
+    const fetchImpl = vi.fn(async () => new Response("no", { status: 503 })) as unknown as typeof fetch;
+    const result = await liveModelTurn({ base: "http://x/api/vendo", fetchImpl, env });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("503");
+  });
+
+  it("fails gracefully on a network error", async () => {
+    const fetchImpl = vi.fn(async () => { throw new Error("ECONNREFUSED"); }) as unknown as typeof fetch;
+    const result = await liveModelTurn({ base: "http://x/api/vendo", fetchImpl, env });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("ECONNREFUSED");
+  });
+});
+
+describe("cloudDoctor", () => {
+  it("reports absent + unlocks when no key is set", async () => {
+    const result = await cloudDoctor({ env: {} });
+    expect(result.present).toBe(false);
+    expect(result.ok).toBe(false);
+    expect(result.unlocks).toEqual(CLOUD_UNLOCKS);
+  });
+
+  it("rejects a malformed key without a network call", async () => {
+    const validate = vi.fn();
+    const result = await cloudDoctor({ env: { VENDO_API_KEY: "nope" }, validate });
+    expect(result.present).toBe(true);
+    expect(result.ok).toBe(false);
+    expect(validate).not.toHaveBeenCalled();
+  });
+
+  it("returns the plan and enabled capabilities for a valid key", async () => {
+    const contract: ContractV2 = {
+      valid: true,
+      contract_version: 2,
+      org: { id: "o", name: "Org", slug: "org" },
+      plan: { id: "pro", name: "Pro", status: "active" },
+      capabilities: {
+        sharing: true, registry: false, guard_basic: true, pinning: false,
+        guard_full: false, session_replay: false, insights: true, mcp_broker: false,
+        sso_saml: false, orgs: true,
+      },
+      limits: {
+        sandbox_minutes: { included: 0, used: 0, remaining: 0, exhausted: false },
+        runs: { included: 0, used: 0, remaining: 0, exhausted: false },
+        storage_gb: { included: 0, used: 0, remaining: 0, exhausted: false },
+      },
+      cache: { ttl_seconds: 600, stale_if_error_seconds: 86400 },
+    };
+    const result = await cloudDoctor({
+      env: { VENDO_API_KEY: `vnd_${"a".repeat(40)}` },
+      validate: async () => contract,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.plan?.name).toBe("Pro");
+    expect(result.capabilities).toEqual(["sharing", "guard_basic", "insights", "orgs"]);
+  });
+
+  it("surfaces validation errors without throwing", async () => {
+    const result = await cloudDoctor({
+      env: { VENDO_API_KEY: `vnd_${"a".repeat(40)}` },
+      validate: async () => { throw new Error("401 invalid key"); },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("401");
+  });
+});
+
+describe("codexDrift", () => {
+  it("reports not installed when codex is absent", async () => {
+    const result = await codexDrift(async () => null);
+    expect(result.installed).toBe(false);
+    expect(result.drifted).toBe(false);
+  });
+
+  it("is not drifted on the tested minor line", async () => {
+    const result = await codexDrift(async () => "0.144.9");
+    expect(result.installed).toBe(true);
+    expect(result.drifted).toBe(false);
+  });
+
+  it("is drifted off the tested minor line", async () => {
+    const result = await codexDrift(async () => "0.160.0");
+    expect(result.drifted).toBe(true);
+    expect(result.version).toBe("0.160.0");
+  });
+});

--- a/packages/vendo/src/cli/doctor-live.ts
+++ b/packages/vendo/src/cli/doctor-live.ts
@@ -1,0 +1,305 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { stdout } from "node:process";
+import {
+  codexVersionMatchesTested,
+  probeCodexVersion,
+  TESTED_CODEX_MINOR,
+} from "@vendoai/dev-riders";
+import {
+  describeDevCredential,
+  resolveDevCredential,
+  type DevCredential,
+  type ResolveDevCredentialOptions,
+} from "../dev-creds/resolve.js";
+import { cloudFetch, resolveCloudBaseUrl, type CloudFetchOptions } from "./cloud/client.js";
+import { isVendoKey, parseContractV2, type ContractV2 } from "./cloud/entitlements.js";
+import { detectPackageManager } from "./dev-mode.js";
+
+/**
+ * ENG-339 (install-dx design §5-6) — doctor v2's live surface: one real model
+ * turn through the wired HTTP route, VENDO_API_KEY validation with what Cloud
+ * unlocks, a consent-gated dev-server starter for the probe, and a codex
+ * app-server protocol-drift warning. All seam-driven so doctor stays testable
+ * without live keys or a running server.
+ */
+
+/* ------------------------------------------------------------------------ *
+ * Live model turn — the same wired route the runtime serves.
+ * ------------------------------------------------------------------------ */
+
+export interface LiveTurnResult {
+  attempted: boolean;
+  ok: boolean;
+  /** Which ladder rung the runtime resolved (doctor and runtime read the same
+   *  resolver, so this is what the answering turn used). */
+  rung: DevCredential["rung"];
+  credential: string;
+  reply?: string;
+  error?: string;
+  elapsedMs: number;
+}
+
+export interface LiveTurnOptions {
+  /** Wire base, e.g. http://localhost:3000/api/vendo. */
+  base: string;
+  fetchImpl?: typeof fetch;
+  env?: Record<string, string | undefined>;
+  probes?: ResolveDevCredentialOptions["probes"];
+  /** Stream the reply to the terminal as it arrives. */
+  onDelta?: (delta: string) => void;
+  timeoutMs?: number;
+  /** Test seam: skip the real resolver probe. */
+  resolveCredential?: (options: ResolveDevCredentialOptions) => Promise<DevCredential>;
+}
+
+const DOCTOR_PROBE_PROMPT =
+  "This is a Vendo doctor health check. Reply in one short sentence confirming you can respond.";
+
+/** POST one seeded turn to the live wire and stream the reply — mirrors the
+ *  init finale's route (`POST {base}/threads`, UI-message SSE frames). Exit 0
+ *  means a user would have gotten an answer: a non-empty text reply arrived. */
+export async function liveModelTurn(options: LiveTurnOptions): Promise<LiveTurnResult> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const env = options.env ?? process.env;
+  const resolve = options.resolveCredential ?? resolveDevCredential;
+  const credential = await resolve({
+    env,
+    ...(options.probes === undefined ? {} : { probes: options.probes }),
+  });
+  const rung = credential.rung;
+  const label = describeDevCredential(credential);
+  const started = Date.now();
+  const done = (partial: Omit<LiveTurnResult, "attempted" | "rung" | "credential" | "elapsedMs">): LiveTurnResult => ({
+    attempted: true,
+    rung,
+    credential: label,
+    elapsedMs: Date.now() - started,
+    ...partial,
+  });
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 90_000);
+  try {
+    const response = await fetchImpl(`${options.base}/threads`, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "text/event-stream" },
+      body: JSON.stringify({
+        message: {
+          id: `msg_doctor_${Date.now()}`,
+          role: "user",
+          parts: [{ type: "text", text: DOCTOR_PROBE_PROMPT }],
+        },
+      }),
+      signal: controller.signal,
+    });
+    if (!response.ok || response.body === null) {
+      return done({ ok: false, error: `the wire returned ${response.status} with no stream` });
+    }
+    const reply = await readTurnStream(response.body, options.onDelta);
+    if (reply.error !== undefined) return done({ ok: false, error: reply.error, reply: reply.text || undefined });
+    if (reply.text.trim().length === 0) return done({ ok: false, error: "no reply text arrived" });
+    return done({ ok: true, reply: reply.text });
+  } catch (error) {
+    const message = error instanceof Error
+      ? (error.name === "AbortError" ? "the turn timed out" : error.message)
+      : "unknown error";
+    return done({ ok: false, error: message });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function readTurnStream(
+  body: ReadableStream<Uint8Array>,
+  onDelta?: (delta: string) => void,
+): Promise<{ text: string; error?: string }> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let text = "";
+  let error: string | undefined;
+  for (;;) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    buffer += decoder.decode(chunk.value, { stream: true });
+    for (;;) {
+      const frameEnd = buffer.indexOf("\n\n");
+      if (frameEnd === -1) break;
+      const frame = buffer.slice(0, frameEnd);
+      buffer = buffer.slice(frameEnd + 2);
+      if (!frame.startsWith("data: ") || frame === "data: [DONE]") continue;
+      try {
+        const part = JSON.parse(frame.slice("data: ".length)) as { type?: string; delta?: string };
+        if (part.type === "text-delta" && typeof part.delta === "string") {
+          text += part.delta;
+          onDelta?.(part.delta);
+        } else if (part.type === "error") {
+          error = "the turn returned an error frame";
+        }
+      } catch {
+        // skip malformed frame
+      }
+    }
+  }
+  return error === undefined ? { text } : { text, error };
+}
+
+/* ------------------------------------------------------------------------ *
+ * VENDO_API_KEY validation + what Cloud unlocks.
+ * ------------------------------------------------------------------------ */
+
+/** Human-facing list of what a Cloud key unlocks over OSS single-player. Shown
+ *  whether or not a key is present, so a keyless dev sees the offer. */
+export const CLOUD_UNLOCKS: readonly string[] = [
+  "a free dev-mode starter model allowance (keyless first turns)",
+  "team sharing and org governance (roles, SSO)",
+  "hosted deploys of your enabled automations",
+  "session replay, insights, and the MCP broker",
+];
+
+export interface CloudDoctorResult {
+  present: boolean;
+  ok: boolean;
+  plan?: { id: string; name: string; status: string };
+  capabilities?: string[];
+  unlocks: readonly string[];
+  error?: string;
+}
+
+export interface CloudDoctorOptions {
+  env?: Record<string, string | undefined>;
+  apiUrl?: string;
+  fetchImpl?: typeof fetch;
+  /** Test seam: validate a key without a network round-trip. */
+  validate?: (key: string) => Promise<ContractV2 | null>;
+}
+
+async function defaultValidate(
+  key: string,
+  options: Pick<CloudFetchOptions, "apiUrl" | "env" | "fetchImpl">,
+): Promise<ContractV2 | null> {
+  const raw = await cloudFetch("/api/v1/keys/validate", { ...options, auth: "key", apiKey: key, method: "POST" });
+  return parseContractV2(raw);
+}
+
+/** Validate VENDO_API_KEY when present; always surface what Cloud unlocks. */
+export async function cloudDoctor(options: CloudDoctorOptions = {}): Promise<CloudDoctorResult> {
+  const env = options.env ?? process.env;
+  const key = env["VENDO_API_KEY"];
+  if (key === undefined || key.trim().length === 0) {
+    return { present: false, ok: false, unlocks: CLOUD_UNLOCKS };
+  }
+  if (!isVendoKey(key)) {
+    return { present: true, ok: false, unlocks: CLOUD_UNLOCKS, error: "VENDO_API_KEY is malformed (expected vnd_ + 40 hex chars)" };
+  }
+  const validate = options.validate
+    ?? ((candidate: string) => defaultValidate(candidate, {
+      ...(options.apiUrl === undefined ? {} : { apiUrl: options.apiUrl }),
+      env,
+      ...(options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl }),
+    }));
+  try {
+    const contract = await validate(key);
+    if (contract === null) {
+      return { present: true, ok: false, unlocks: CLOUD_UNLOCKS, error: "Vendo Cloud did not return a valid entitlement contract" };
+    }
+    const capabilities = Object.entries(contract.capabilities)
+      .filter(([, on]) => on)
+      .map(([name]) => name);
+    return { present: true, ok: true, plan: contract.plan, capabilities, unlocks: CLOUD_UNLOCKS };
+  } catch (error) {
+    return {
+      present: true,
+      ok: false,
+      unlocks: CLOUD_UNLOCKS,
+      error: error instanceof Error ? error.message : "Vendo Cloud validation failed",
+    };
+  }
+}
+
+/* ------------------------------------------------------------------------ *
+ * Consent-gated dev-server starter for the probe.
+ * ------------------------------------------------------------------------ */
+
+export interface StartedDevServer {
+  ok: boolean;
+  stop: () => void;
+  log: string[];
+}
+
+export interface StartDevServerOptions {
+  root: string;
+  /** Wire base whose /status decides "up". */
+  statusUrl: string;
+  env?: Record<string, string | undefined>;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  spawnDev?: (packageManager: string, root: string) => ChildProcess;
+}
+
+function defaultSpawnDev(packageManager: string, root: string): ChildProcess {
+  return spawn(packageManager, ["run", "dev"], { cwd: root, stdio: ["ignore", "pipe", "pipe"] });
+}
+
+async function waitForStatus(statusUrl: string, fetchImpl: typeof fetch, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetchImpl(`${statusUrl}/status`);
+      if (response.ok) return true;
+    } catch {
+      // not up yet
+    }
+    await new Promise((resolve) => setTimeout(resolve, 750));
+  }
+  return false;
+}
+
+/** Spawn `run dev` and wait for the wire to answer. Caller stop()s it. */
+export async function startDevServerForProbe(options: StartDevServerOptions): Promise<StartedDevServer> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const packageManager = await detectPackageManager(options.root);
+  const child = (options.spawnDev ?? defaultSpawnDev)(packageManager, options.root);
+  const log: string[] = [];
+  const record = (data: Buffer): void => {
+    log.push(data.toString());
+    if (log.length > 200) log.shift();
+  };
+  child.stdout?.on("data", record);
+  child.stderr?.on("data", record);
+  const stop = (): void => { child.kill("SIGTERM"); };
+  const up = await waitForStatus(options.statusUrl, fetchImpl, options.timeoutMs ?? 120_000);
+  if (!up) stop();
+  return { ok: up, stop, log };
+}
+
+/* ------------------------------------------------------------------------ *
+ * Codex app-server protocol-drift warning (dev-only, informational).
+ * ------------------------------------------------------------------------ */
+
+export interface CodexDriftResult {
+  installed: boolean;
+  version?: string;
+  tested: string;
+  drifted: boolean;
+}
+
+/** Warn when the installed codex minor line differs from the one the rider's
+ *  app-server protocol shapes were verified against (spike ENG-337). */
+export async function codexDrift(
+  probe: (command?: string) => Promise<string | null> = probeCodexVersion,
+): Promise<CodexDriftResult> {
+  const version = await probe();
+  if (version === null) return { installed: false, tested: TESTED_CODEX_MINOR, drifted: false };
+  return {
+    installed: true,
+    version,
+    tested: TESTED_CODEX_MINOR,
+    drifted: !codexVersionMatchesTested(version),
+  };
+}
+
+/** Stream a delta to the terminal (default onDelta for the live turn). */
+export function writeDelta(delta: string): void {
+  stdout.write(delta);
+}

--- a/packages/vendo/src/cli/doctor.live.test.ts
+++ b/packages/vendo/src/cli/doctor.live.test.ts
@@ -113,6 +113,13 @@ describe("vendo doctor MCP discovery live", () => {
       url: `${origin}/api/vendo`,
       output: { log: (message) => logs.push(message), error: (message) => errors.push(message) },
       telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+      // This test proves MCP discovery, not the model turn (the fixture uses a
+      // stub model). Stub doctor v2's live surface so the discovery checks stay
+      // the subject.
+      interactive: false,
+      liveTurn: async () => ({ attempted: true, ok: true, rung: "env-key", credential: "stub", reply: "ok", elapsedMs: 1 }),
+      cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
+      codexDriftProbe: async () => ({ installed: false, tested: "0.144", drifted: false }),
     })).toBe(0);
     expect(errors).toEqual([]);
     expect(logs).toContain("ok: server.json remote agrees with the live MCP door");

--- a/packages/vendo/src/cli/doctor.test.ts
+++ b/packages/vendo/src/cli/doctor.test.ts
@@ -17,6 +17,28 @@ afterEach(async () => {
   for (const dispose of cleanup.splice(0).reverse()) await dispose();
 });
 
+/** Existing checks are about static wiring + the HTTP probes, not the new
+ *  live-turn/cloud/dev-server-probe surface (those get dedicated tests below).
+ *  This wrapper stubs the new seams so the legacy assertions stay focused:
+ *  a canned successful live turn, no cloud key, no codex, non-interactive. */
+async function doctor(options: Parameters<typeof runDoctor>[0]): Promise<number> {
+  return runDoctor({
+    env: {},
+    interactive: false,
+    liveTurn: async () => ({
+      attempted: true,
+      ok: true,
+      rung: "env-key",
+      credential: "explicit ANTHROPIC_API_KEY (anthropic)",
+      reply: "ok",
+      elapsedMs: 1,
+    }),
+    cloudProbe: async () => ({ present: false, ok: false, unlocks: ["a starter allowance"] }),
+    codexDriftProbe: async () => ({ installed: false, tested: "0.144", drifted: false }),
+    ...options,
+  });
+}
+
 async function healthy(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "vendo-doctor-"));
   cleanup.push(() => rm(root, { recursive: true, force: true }));
@@ -159,7 +181,7 @@ describe("vendo doctor", () => {
   it("checks Express server and client wiring instead of Next files", async () => {
     const fetchImpl = successfulProbeFetch();
     const messages = output();
-    expect(await runDoctor({
+    expect(await doctor({
       targetDir: await expressHost(true),
       fetchImpl,
       output: messages.sink,
@@ -173,7 +195,7 @@ describe("vendo doctor", () => {
 
   it("returns one when an Express host is missing server and client wiring", async () => {
     const messages = output();
-    expect(await runDoctor({
+    expect(await doctor({
       targetDir: await expressHost(false),
       fetchImpl: successfulProbeFetch(),
       output: messages.sink,
@@ -187,7 +209,7 @@ describe("vendo doctor", () => {
 
   it("checks wiring and performs one live status round-trip", async () => {
     const fetchImpl = successfulProbeFetch();
-    expect(await runDoctor({
+    expect(await doctor({
       targetDir: await healthy(),
       fetchImpl,
       output: { log() {}, error() {} },
@@ -201,7 +223,7 @@ describe("vendo doctor", () => {
 
   it.each(["e2b", "modal", "custom"] as const)("reports a lit %s execution venue", async (sandbox) => {
     const messages = output();
-    expect(await runDoctor({
+    expect(await doctor({
       targetDir: await healthy(),
       fetchImpl: successfulProbeFetch({ store: true, sandbox }),
       output: messages.sink,
@@ -212,7 +234,7 @@ describe("vendo doctor", () => {
 
   it("warns with actionable guidance when the execution venue is dark", async () => {
     const messages = output();
-    expect(await runDoctor({
+    expect(await doctor({
       targetDir: await healthy(),
       fetchImpl: successfulProbeFetch({ store: true, sandbox: false }),
       output: messages.sink,
@@ -228,7 +250,7 @@ describe("vendo doctor", () => {
 
   it("warns instead of failing when an older host omits the execution venue", async () => {
     const messages = output();
-    expect(await runDoctor({
+    expect(await doctor({
       targetDir: await healthy(),
       fetchImpl: successfulProbeFetch({ store: true }),
       output: messages.sink,
@@ -241,7 +263,7 @@ describe("vendo doctor", () => {
 
   it("fails when /status reports an unknown execution venue", async () => {
     const messages = output();
-    expect(await runDoctor({
+    expect(await doctor({
       targetDir: await healthy(),
       fetchImpl: successfulProbeFetch({ store: true, sandbox: "mainframe" }),
       output: messages.sink,
@@ -255,7 +277,7 @@ describe("vendo doctor", () => {
     cleanup.push(() => rm(root, { recursive: true, force: true }));
     const fetchImpl = vi.fn().mockRejectedValue(new Error("offline"));
     const messages = output();
-    expect(await runDoctor({ targetDir: root, fetchImpl, output: messages.sink })).toBe(1);
+    expect(await doctor({ targetDir: root, fetchImpl, output: messages.sink })).toBe(1);
     expect(messages.errors).toEqual(expect.arrayContaining([
       expect.stringContaining("start the dev server"),
       expect.stringContaining("cannot probe actAs"),
@@ -265,7 +287,7 @@ describe("vendo doctor", () => {
   it("proves present credentials and actAs mint+verify over a real booted server", async () => {
     const host = await liveHost();
     const messages = output();
-    expect(await runDoctor({
+    expect(await doctor({
       targetDir: host.root,
       url: host.url,
       output: messages.sink,
@@ -288,7 +310,7 @@ describe("vendo doctor", () => {
   it("fails actionably when VENDO_BASE_URL leaves present credentials disabled", async () => {
     const host = await liveHost({ configureBaseUrl: false });
     const messages = output();
-    expect(await runDoctor({
+    expect(await doctor({
       targetDir: host.root,
       url: host.url,
       output: messages.sink,
@@ -302,7 +324,7 @@ describe("vendo doctor", () => {
   it("warns actionably when actAs is not configured without breaking present-only hosts", async () => {
     const host = await liveHost({ actAs: false });
     const messages = output();
-    expect(await runDoctor({
+    expect(await doctor({
       targetDir: host.root,
       url: host.url,
       output: messages.sink,
@@ -324,7 +346,7 @@ describe("vendo doctor", () => {
     }));
     const messages = output();
 
-    expect(await runDoctor({
+    expect(await doctor({
       targetDir: root,
       url: "https://mcp.example.com/api/vendo",
       fetchImpl: discoveryFetch(),
@@ -346,7 +368,7 @@ describe("vendo doctor", () => {
     }));
     const messages = output();
 
-    expect(await runDoctor({
+    expect(await doctor({
       targetDir: root,
       url: "https://mcp.example.com/api/vendo",
       fetchImpl: discoveryFetch(),
@@ -361,7 +383,7 @@ describe("vendo doctor", () => {
     const root = await healthy();
     const messages = output();
 
-    expect(await runDoctor({
+    expect(await doctor({
       targetDir: root,
       url: "https://mcp.example.com/api/vendo",
       fetchImpl: discoveryFetch("not-an-mcp-challenge"),
@@ -369,6 +391,192 @@ describe("vendo doctor", () => {
       telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
     })).toBe(1);
     expect(messages.errors).toContain("broken: MCP registry auth challenge must start with v=MCPv1");
+  });
+});
+
+/** Probe fetch that also answers the live-turn POST /threads with a UI-message
+ *  SSE stream. `reply` "" simulates a turn that produces no text. */
+function probeFetchWithTurn(reply = "I can respond.", options: { errorFrame?: boolean } = {}): ReturnType<typeof vi.fn> {
+  return vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (url.endsWith("/status")) return Response.json({ posture: "unconfigured", version: "0.3.0", blocks: { store: true, sandbox: "e2b" } });
+    if (url.endsWith("/doctor/present")) return Response.json({ ok: true });
+    if (url.endsWith("/doctor/act-as")) return Response.json({ ok: true });
+    if (url.endsWith("/threads") && init?.method === "POST") {
+      const frames: string[] = [];
+      if (options.errorFrame) frames.push('data: {"type":"error"}\n\n');
+      else if (reply.length > 0) frames.push(`data: ${JSON.stringify({ type: "text-delta", delta: reply })}\n\n`);
+      frames.push("data: [DONE]\n\n");
+      return new Response(frames.join(""), { headers: { "content-type": "text/event-stream" } });
+    }
+    return Response.json({ error: { message: "unexpected probe" } }, { status: 404 });
+  });
+}
+
+describe("vendo doctor v2 (live turn + --json + cloud + dev-server probe)", () => {
+  it("runs one real model turn over the wired route and exits 0 when it answers", async () => {
+    const fetchImpl = probeFetchWithTurn("Yes, I can respond.");
+    const messages = output();
+    expect(await runDoctor({
+      targetDir: await healthy(),
+      fetchImpl,
+      env: { ANTHROPIC_API_KEY: "sk-test" },
+      interactive: false,
+      cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
+      codexDriftProbe: async () => ({ installed: false, tested: "0.144", drifted: false }),
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0);
+    expect(fetchImpl.mock.calls.some(([u]) => String(u).endsWith("/threads"))).toBe(true);
+    expect(messages.logs.some((line) => line.startsWith("ok: live model turn answered"))).toBe(true);
+    expect(messages.logs.join("\n")).toContain("Yes, I can respond.");
+  });
+
+  it("exits nonzero when the live turn produces no answer", async () => {
+    const fetchImpl = probeFetchWithTurn("", { errorFrame: true });
+    const messages = output();
+    expect(await runDoctor({
+      targetDir: await healthy(),
+      fetchImpl,
+      env: { ANTHROPIC_API_KEY: "sk-test" },
+      interactive: false,
+      cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
+      codexDriftProbe: async () => ({ installed: false, tested: "0.144", drifted: false }),
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(1);
+    expect(messages.errors.some((line) => line.startsWith("broken: live model turn did not answer"))).toBe(true);
+  });
+
+  it("emits one machine-readable JSON object a script can consume", async () => {
+    const logs: string[] = [];
+    const exit = await doctor({
+      targetDir: await healthy(),
+      fetchImpl: successfulProbeFetch(),
+      json: true,
+      output: { log: (m) => logs.push(m), error: () => {} },
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    });
+    // --json prints exactly one object to stdout and nothing else.
+    expect(logs).toHaveLength(1);
+    const report = JSON.parse(logs[0]!) as {
+      vendo: string; wired: boolean; exit: number;
+      checks: Array<{ status: string; message: string }>;
+      liveTurn: { ok: boolean }; cloud: { present: boolean };
+      summary: { failures: number; warnings: number };
+    };
+    expect(report.vendo).toBe("doctor");
+    expect(report.exit).toBe(exit);
+    expect(report.wired).toBe(true);
+    expect(report.liveTurn.ok).toBe(true);
+    expect(report.cloud.present).toBe(false);
+    expect(report.checks.some((c) => c.status === "ok")).toBe(true);
+    expect(report.summary.failures).toBe(0);
+  });
+
+  it("reports exit 1 in --json when wiring is broken", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-doctor-json-broken-"));
+    cleanup.push(() => rm(root, { recursive: true, force: true }));
+    const logs: string[] = [];
+    const exit = await doctor({
+      targetDir: root,
+      fetchImpl: vi.fn().mockRejectedValue(new Error("offline")),
+      json: true,
+      liveTurn: undefined, // exercise the real skip path (server unreachable)
+      output: { log: (m) => logs.push(m), error: () => {} },
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    });
+    const report = JSON.parse(logs[0]!) as { exit: number; wired: boolean; liveTurn: { attempted: boolean } };
+    expect(exit).toBe(1);
+    expect(report.exit).toBe(1);
+    expect(report.wired).toBe(false);
+    expect(report.liveTurn.attempted).toBe(false);
+  });
+
+  it("validates a present VENDO_API_KEY and shows the plan", async () => {
+    const messages = output();
+    expect(await doctor({
+      targetDir: await healthy(),
+      fetchImpl: successfulProbeFetch(),
+      cloudProbe: async () => ({ present: true, ok: true, plan: { id: "pro", name: "Pro", status: "active" }, capabilities: ["sharing", "insights"], unlocks: ["x"] }),
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0);
+    expect(messages.logs).toContain("ok: Vendo Cloud key valid (plan: Pro)");
+    expect(messages.logs).toContain("Cloud capabilities: sharing, insights.");
+  });
+
+  it("warns when VENDO_API_KEY is present but invalid", async () => {
+    const messages = output();
+    await doctor({
+      targetDir: await healthy(),
+      fetchImpl: successfulProbeFetch(),
+      cloudProbe: async () => ({ present: true, ok: false, unlocks: ["x"], error: "revoked" }),
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    });
+    expect(messages.errors).toContain("warning: VENDO_API_KEY is set but not usable: revoked");
+  });
+
+  it("prints what Cloud unlocks when no key is set", async () => {
+    const messages = output();
+    await doctor({
+      targetDir: await healthy(),
+      fetchImpl: successfulProbeFetch(),
+      cloudProbe: async () => ({ present: false, ok: false, unlocks: ["a starter allowance", "team sharing"] }),
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    });
+    expect(messages.logs.some((l) => l.includes("A key unlocks a starter allowance; team sharing"))).toBe(true);
+  });
+
+  it("offers (consent) to start the dev server when nothing is listening", async () => {
+    let serverUp = false;
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/status")) {
+        if (!serverUp) throw new Error("connection refused");
+        return Response.json({ posture: "unconfigured", version: "0.3.0", blocks: { store: true, sandbox: "e2b" } });
+      }
+      if (url.endsWith("/doctor/present")) return Response.json({ ok: true });
+      if (url.endsWith("/doctor/act-as")) return Response.json({ ok: true });
+      if (url.endsWith("/threads") && init?.method === "POST") {
+        return new Response('data: {"type":"text-delta","delta":"hi"}\n\ndata: [DONE]\n\n', { headers: { "content-type": "text/event-stream" } });
+      }
+      return Response.json({ error: { message: "unexpected" } }, { status: 404 });
+    });
+    const stop = vi.fn();
+    const startDevServer = vi.fn(async () => { serverUp = true; return { ok: true, stop }; });
+    const confirm = vi.fn(async () => true);
+    const messages = output();
+    expect(await runDoctor({
+      targetDir: await healthy(),
+      fetchImpl,
+      env: { ANTHROPIC_API_KEY: "sk-test" },
+      interactive: true,
+      confirm,
+      startDevServer,
+      cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
+      codexDriftProbe: async () => ({ installed: false, tested: "0.144", drifted: false }),
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0);
+    expect(confirm).toHaveBeenCalledOnce();
+    expect(startDevServer).toHaveBeenCalledOnce();
+    expect(messages.logs).toContain("ok: started the dev server for the probe");
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it("warns on codex app-server protocol drift", async () => {
+    const messages = output();
+    await doctor({
+      targetDir: await healthy(),
+      fetchImpl: successfulProbeFetch(),
+      codexDriftProbe: async () => ({ installed: true, version: "0.160.0", tested: "0.144", drifted: true }),
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    });
+    expect(messages.errors.some((l) => l.includes("codex 0.160.0 is off the tested 0.144.x line"))).toBe(true);
   });
 });
 

--- a/packages/vendo/src/cli/doctor.ts
+++ b/packages/vendo/src/cli/doctor.ts
@@ -1,21 +1,63 @@
 import { readFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
 import type { Telemetry } from "@vendoai/telemetry";
+import type { ResolveDevCredentialOptions } from "../dev-creds/resolve.js";
+import {
+  cloudDoctor,
+  codexDrift,
+  liveModelTurn,
+  startDevServerForProbe,
+  type CloudDoctorResult,
+  type CodexDriftResult,
+  type LiveTurnResult,
+} from "./doctor-live.js";
 import { detectFramework, detectVendoWiring } from "./framework.js";
 import { remoteUrls, sameUrl, validateRegistryServer } from "./mcp/registry.js";
-import { consoleOutput, exists, readOptional, toolingTelemetry, type Output } from "./shared.js";
+import { CLI_VERSION, consoleOutput, exists, readOptional, toolingTelemetry, type Output } from "./shared.js";
 
 export interface DoctorOptions {
   targetDir: string;
   url?: string;
   fetchImpl?: typeof fetch;
   output?: Output;
+  /** Machine-readable single-object output (design §5). */
+  json?: boolean;
+  /** Auto-confirm the dev-server-probe consent (non-interactive). */
+  yes?: boolean;
+  env?: Record<string, string | undefined>;
+  apiUrl?: string;
+  probes?: ResolveDevCredentialOptions["probes"];
   telemetry?: {
     home?: string;
     env?: Record<string, string | undefined>;
     posthogKey?: string;
     fetchImpl?: typeof fetch;
   };
+  /** Seams (tests): each new probe is injectable so doctor runs without keys,
+   *  a running server, or the codex CLI. */
+  interactive?: boolean;
+  confirm?: (question: string, defaultYes?: boolean) => Promise<boolean>;
+  liveTurn?: (base: string) => Promise<LiveTurnResult>;
+  cloudProbe?: (options: { env?: Record<string, string | undefined>; apiUrl?: string; fetchImpl?: typeof fetch }) => Promise<CloudDoctorResult>;
+  startDevServer?: (options: { root: string; statusUrl: string; env?: Record<string, string | undefined>; fetchImpl?: typeof fetch }) => Promise<{ ok: boolean; stop: () => void }>;
+  codexDriftProbe?: () => Promise<CodexDriftResult>;
+}
+
+type CheckStatus = "ok" | "broken" | "warning";
+interface DoctorCheck { status: CheckStatus; message: string; }
+
+async function askYesNo(question: string, defaultYes = false): Promise<boolean> {
+  if (!stdin.isTTY || !stdout.isTTY) return false;
+  const prompt = createInterface({ input: stdin, output: stdout });
+  try {
+    const answer = (await prompt.question(`${question} ${defaultYes ? "[Y/n]" : "[y/N]"} `)).trim().toLowerCase();
+    if (answer === "") return defaultYes;
+    return ["y", "yes"].includes(answer);
+  } finally {
+    prompt.close();
+  }
 }
 
 async function hasDependency(root: string): Promise<boolean> {
@@ -54,12 +96,18 @@ async function probeBody(response: Response): Promise<DoctorProbeBody> {
 export async function runDoctor(options: DoctorOptions): Promise<number> {
   const root = resolve(options.targetDir);
   const output = options.output ?? consoleOutput;
+  const json = options.json === true;
+  const env = options.env ?? process.env;
   const telemetry = telemetryFor(options, output);
   let failures = 0;
   let warnings = 0;
-  const pass = (message: string): void => output.log(`ok: ${message}`);
-  const fail = (message: string): void => { failures += 1; output.error(`broken: ${message}`); };
-  const warn = (message: string): void => { warnings += 1; output.error(`warning: ${message}`); };
+  const checks: DoctorCheck[] = [];
+  // In --json mode nothing but the final object may reach stdout; human lines
+  // are suppressed and the same information rides the checks array instead.
+  const note = (message: string): void => { if (!json) output.log(message); };
+  const pass = (message: string): void => { checks.push({ status: "ok", message }); if (!json) output.log(`ok: ${message}`); };
+  const fail = (message: string): void => { failures += 1; checks.push({ status: "broken", message }); if (!json) output.error(`broken: ${message}`); };
+  const warn = (message: string): void => { warnings += 1; checks.push({ status: "warning", message }); if (!json) output.error(`warning: ${message}`); };
 
   const framework = await detectFramework(root);
   if (framework === "express") {
@@ -99,9 +147,33 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
   if (!await exists(join(root, ".vendo", "data", ".gitignore"))) warn(".vendo/data/.gitignore is missing");
 
   const statusUrl = options.url
-    ?? process.env.VENDO_URL?.replace(/\/$/, "")
+    ?? env.VENDO_URL?.replace(/\/$/, "")
     ?? "http://localhost:3000/api/vendo";
   const fetchImpl = options.fetchImpl ?? fetch;
+
+  // Consent-gated dev-server start (design §5): when nothing is listening on
+  // the dev port and doctor is interactive, offer to boot it so the live probes
+  // have something to reach. Skipped in --json and non-interactive runs.
+  const interactive = options.interactive ?? (Boolean(stdout.isTTY) && Boolean(stdin.isTTY));
+  const confirm = options.confirm ?? askYesNo;
+  let devServerStop: (() => void) | null = null;
+  if (!json && interactive) {
+    let listening = false;
+    try { listening = (await fetchImpl(`${statusUrl}/status`)).ok; } catch { listening = false; }
+    if (!listening) {
+      const go = options.yes === true
+        || await confirm("Nothing is listening on the dev port. Start the dev server for the probe?", true);
+      if (go) {
+        note(`\nStarting the dev server so the probe has a live composition to reach…`);
+        const start = options.startDevServer
+          ?? ((o) => startDevServerForProbe(o));
+        const started = await start({ root, statusUrl, env, fetchImpl });
+        if (started.ok) { devServerStop = started.stop; pass("started the dev server for the probe"); }
+        else warn("could not start the dev server for the probe; start it yourself (e.g. `npm run dev`) and re-run `vendo doctor`");
+      }
+    }
+  }
+
   let mcpEnabled = false;
   let sandboxVenue: unknown;
   let liveComposition = false;
@@ -254,8 +326,70 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
     }
   }
 
-  output.log("Ladder: execution venue is checked above; actAs for away host actions; connectors for external tools.");
+  note("Ladder: execution venue is checked above; actAs for away host actions; connectors for external tools.");
+
+  // One real model turn through the wired route (design §5). Exit 0 == a user
+  // would have gotten an answer. Reuses the wave-2 resolver + devModel: the
+  // running dev server serves the turn over the same ladder doctor reports.
+  let liveTurn: LiveTurnResult;
+  if (liveComposition) {
+    liveTurn = await (options.liveTurn ?? ((base: string) => liveModelTurn({
+      base,
+      fetchImpl,
+      env,
+      ...(options.probes === undefined ? {} : { probes: options.probes }),
+    })))(statusUrl);
+    if (liveTurn.ok) {
+      pass(`live model turn answered over ${liveTurn.credential} (${liveTurn.elapsedMs}ms)`);
+      if (liveTurn.reply !== undefined) note(`\n  ${liveTurn.reply.trim()}\n`);
+    } else {
+      fail(`live model turn did not answer over ${liveTurn.credential}: ${liveTurn.error ?? "no reply"}`);
+    }
+  } else {
+    liveTurn = { attempted: false, ok: false, rung: "none", credential: "n/a", elapsedMs: 0, error: "dev server unreachable" };
+    fail(`live model turn cannot run; start the dev server at ${statusUrl} and retry`);
+  }
+
+  // VENDO_API_KEY validation + what Cloud unlocks (design §5-6).
+  const cloud = await (options.cloudProbe ?? ((o) => cloudDoctor(o)))({
+    env,
+    ...(options.apiUrl === undefined ? {} : { apiUrl: options.apiUrl }),
+    ...(options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl }),
+  });
+  if (cloud.present && cloud.ok) {
+    pass(`Vendo Cloud key valid (plan: ${cloud.plan?.name || cloud.plan?.id || "unknown"})`);
+    if (cloud.capabilities && cloud.capabilities.length > 0) {
+      note(`Cloud capabilities: ${cloud.capabilities.join(", ")}.`);
+    }
+  } else if (cloud.present) {
+    warn(`VENDO_API_KEY is set but not usable: ${cloud.error ?? "validation failed"}`);
+  } else {
+    note(`Vendo Cloud (optional): no VENDO_API_KEY. A key unlocks ${cloud.unlocks.join("; ")}. Run \`vendo cloud login\` to start.`);
+  }
+
+  // Codex app-server protocol-drift warning (dev-only, informational).
+  const codex = await (options.codexDriftProbe ?? codexDrift)();
+  if (codex.installed && codex.drifted) {
+    warn(`codex ${codex.version} is off the tested ${codex.tested}.x line; the app-server tool-call surface may have drifted. Re-verify with \`codex app-server generate-ts\` before relying on the codex rung.`);
+  }
+
+  if (devServerStop !== null) devServerStop();
+
   const wired = failures === 0;
   await telemetry.track("doctor_run", { failures, warnings, wired });
+
+  if (json) {
+    output.log(JSON.stringify({
+      vendo: "doctor",
+      version: CLI_VERSION,
+      wired,
+      exit: wired ? 0 : 1,
+      checks,
+      liveTurn,
+      cloud,
+      codex,
+      summary: { failures, warnings },
+    }, null, 2));
+  }
   return wired ? 0 : 1;
 }

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -17,6 +17,7 @@ import {
 } from "@vendoai/actions";
 import type { VendoTheme } from "@vendoai/core";
 import type { Telemetry } from "@vendoai/telemetry";
+import { runCloudStep, type CloudStepOptions } from "./cloud-init.js";
 import {
   runDevModeStep,
   runInitFinale,
@@ -120,6 +121,8 @@ export interface InitOptions {
   /** ENG-338 seams (tests): dev-mode ladder step + init finale overrides. */
   devMode?: Partial<Omit<DevModeStepOptions, "root" | "output" | "yes">>;
   finale?: Partial<Omit<InitFinaleOptions, "root" | "output" | "yes" | "framework" | "credential">> & { skip?: boolean };
+  /** ENG-339 seam (tests): cloud-in-init step overrides. */
+  cloud?: Partial<Omit<CloudStepOptions, "root" | "output" | "yes" | "credential">>;
 }
 
 /** Interactive y/N for the end-of-init `vendo refine` offer. */
@@ -1024,6 +1027,15 @@ export async function runInit(options: InitOptions): Promise<number> {
       output,
       yes: options.yes === true,
       ...(options.devMode ?? {}),
+    });
+    // ENG-339: cloud in init — validate VENDO_API_KEY (state what it unlocks),
+    // else offer `vendo cloud login` + a starter allowance written to .env.local.
+    await runCloudStep({
+      root,
+      output,
+      yes: options.yes === true,
+      credential: devCredential,
+      ...(options.cloud ?? {}),
     });
     // 10-mcp §2: the door never opens by default. When the host asks to open it,
     // point them at the one code change they make deliberately — a HostOAuthAdapter

--- a/packages/vendo/src/dev-creds/model.ts
+++ b/packages/vendo/src/dev-creds/model.ts
@@ -218,9 +218,10 @@ export class DevModelController {
     }
 
     if (credential.rung === "vendo-cloud") {
-      const message = "VENDO_API_KEY is set, but Vendo Cloud dev-mode model keys are minted by `vendo cloud login` "
-        + "(landing with doctor v2). Until then set a provider key, or log in to the Claude Code / Codex CLI for dev mode.";
-      this.announce(credential, " — no model gateway yet");
+      const message = "VENDO_API_KEY is set, but the Vendo Cloud dev-mode model gateway is not live yet "
+        + "(console follow-up). `vendo init` writes a starter-allowance key to .env.local after `vendo cloud login`; "
+        + "until the gateway ships, set a provider key or log in to the Claude Code / Codex CLI for dev mode.";
+      this.announce(credential, " — model gateway not live yet");
       return { mode: "unavailable", credential, message };
     }
 


### PR DESCRIPTION
## What

Wave 3 of the Install DX project (ENG-339): doctor v2 + cloud-in-init + the
starter-allowance consumer. Builds on the wave-2 credential ladder
(`resolveDevCredential` + `devModel()`).

> Stacked on wave-2 (**#314**). Base is `main`, so this PR's diff currently
> includes wave-2's two commits. **Merge this AFTER #314**, or rebase onto
> `main` once #314 lands.

## Doctor v2 (`packages/vendo/src/cli/`)

- **One real model turn** through the wired route. Doctor POSTs one seeded
  health-check prompt to `{base}/threads` — the same route the runtime serves —
  and streams the UI-message reply. **Exit 0 == a user would have gotten an
  answer** (a non-empty reply arrived); nonzero when the turn fails or the
  server is unreachable. The rung is resolved from the same wave-2 ladder the
  runtime uses, so doctor and runtime agree on what is wired.
- **`--json`**: one machine-readable object — `{ vendo, version, wired, exit,
  checks[], liveTurn, cloud, codex, summary }`. In `--json` mode nothing but
  that object reaches stdout. A test parses it (`emits one machine-readable
  JSON object a script can consume`).
- **VENDO_API_KEY validation** via the Cloud entitlements contract, plus a
  standing "what Cloud unlocks" hint whether or not a key is present.
- **Consent-gated dev-server start**: when nothing is listening on the dev port
  and doctor is interactive, it offers to `npm run dev` for the probe (or
  `--yes` to start non-interactively), and stops it afterward.
- **Codex protocol-drift warning** (folded in from the wave-2 review): detects
  the installed `codex --version` and warns when it drifts off the tested
  `0.144.x` app-server line the rider's tool-call shapes were verified against
  (spike ENG-337). Dev-only, informational, in `--json`. The full
  `generate-json-schema` diff is a follow-up.

Exit semantics: `wired = failures === 0`; the live turn is a hard check, so
exit 0 requires both the static/HTTP checks and an answered turn.

## Cloud in init (`packages/vendo/src/cli/cloud-init.ts`)

Runs right after the dev-mode ladder step. Present `VENDO_API_KEY` → validate and
state the plan + unlocked capabilities. Absent → one calm line, and (only when a
starter key would actually help the ladder) offer `vendo cloud login` inline,
then mint a starter allowance and upsert `VENDO_API_KEY` into `.env.local`
without clobbering other keys. Never changes init's exit code.

> Deviation: the existing `vendo cloud login` is email-OTP (+ `--token`), not
> browser OAuth. This wires init to the existing sub-CLI as instructed; browser
> OAuth is a separate console follow-up.

## Starter allowance — vendo side implemented, console PARKED

I found the vendo-web checkout (`runvendo/vendo-web`, `apps/console/…`), but it
is a separate repo with its own gates and an in-flight Cloud console project
(untracked `console/` WIP). Per "coordinate schema but do not wait," I
implemented the **vendo-side consumer** and parked the console endpoint with an
exact contract instead of opening a competing PR there.

Console hand-off contract (needed in vendo-web `apps/console`):

```
POST /api/v1/dev/starter-key
  auth:    user session (Bearer access token from `vendo cloud login`)
  request: { "purpose": "dev-mode" }
  response: { "key": "vnd_<40 hex>",
              "meter": { "runs": { "included": n, "remaining": n } } }
  errors:  404 / not-implemented → init degrades to a pointer (no block)
```

Separately, the `vendo-cloud` rung producing a *working dev model* needs a Cloud
model gateway (console-side); until it ships `devModel()` reports the rung as
unavailable with instructions. Both are parked for the Cloud console project;
the vendo side is ready to consume them the moment they land.

## Live verification (real ANTHROPIC_API_KEY, Maple host)

Transcripts in `docs/evidence/eng-339-doctor-v2/`:
- `doctor-live-maple.txt` — real Anthropic turn answered in ~2.7s, exit 0.
- `doctor-live-maple.json` — `--json`: `wired: true`, `exit: 0`, `liveTurn.ok:
  true` over `env-key` (real reply captured), `codex` `0.144.4` not drifted.
- `doctor-live-unreachable.txt` — dead port → live turn cannot run → exit 1.

`corpus/hosts/express-host/e2e/doctor.e2e.test.ts` exercises the real HTTP turn
end-to-end against a composed Express host (scripted model) — CI-safe, no keys.

## Gates

`pnpm build && pnpm test && pnpm typecheck && pnpm lint` all green locally from a
space-free path. No new runtime deps (live turn is HTTP+SSE), and
`git diff pnpm-lock.yaml | grep zod@4` is empty (no zod-4 flip).

## Notes / deviations

- `docs/contracts/` untouched. No contract edits in this PR.
- Did not touch `packages/ui` or `apps/console`.
- Behavior change (not a gate): the manual corpus harness `doctor.live` scorecard
  now includes the model turn, so corpus apps need a model credential to pass it.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds doctor v2 with a real model turn and `--json`, and wires Vendo Cloud into init with inline login and a starter allowance to smooth dev-mode setup. Implements Linear ENG-339 and builds on the wave-2 credential ladder so doctor and runtime use the same wired model.

- **New Features**
  - Doctor v2: runs one seeded turn via `{base}/threads` and streams the reply; exit 0 only if answered; `--json` single-object output with `checks`, `liveTurn`, `cloud`, `codex`, and `exit`; consent-gated dev-server start for the probe (`--yes` to auto); validates `VENDO_API_KEY` and lists Cloud unlocks; warns on Codex CLI protocol drift off tested `0.144.x`.
  - Cloud in init: validates an existing `VENDO_API_KEY` and shows plan/capabilities; if absent and helpful, offers `vendo cloud login`, mints a metered starter key, and writes it to `.env.local` without clobbering; cleanly degrades when the console endpoint isn’t live; never changes init’s exit code.
  - Starter allowance: implements the Vendo-side consumer; the console endpoint is parked with an exact contract and falls back to guidance if missing.

- **Dependencies**
  - Adds `@vendoai/dev-riders` (Claude Code and Codex riders + codex version helpers) for dev-mode/doctor; SDKs resolve from the host app at runtime; no new runtime dependencies.

<sup>Written for commit ca41337fa889048ee7655c2519b0c513d985cb3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

