### PR TITLE
fix(apps): inject proxy env when importApp provisions machines (ENG-347)

### DIFF
--- a/.changeset/eng-347-importapp-proxy-env.md
+++ b/.changeset/eng-347-importapp-proxy-env.md
@@ -1,0 +1,14 @@
+---
+"@vendoai/apps": patch
+---
+
+Inject the standard run environment when `importApp` provisions a machine (ENG-347, 06-apps §4.2).
+
+Import rebuilt an app-directory machine with `env: { PORT }` only, bypassing the
+shared env helper the create/edit path uses. The secrets egress fetch shim then
+declined to install (it requires `VENDO_PROXY_URL` + `VENDO_RUN_TOKEN`), so an
+imported rung-2/3 app could not reach host tools or the egress endpoint until it
+was re-edited. Provisioning now routes through the machine cache, baking the same
+§4.2 run environment (`PORT`, `VENDO_PROXY_URL`, a freshly minted `VENDO_RUN_TOKEN`,
+and declared secret handles) into the rebuilt snapshot, so an imported app reaches
+tools/egress with no subsequent edit.

--- a/packages/apps/src/interchange.test.ts
+++ b/packages/apps/src/interchange.test.ts
@@ -247,7 +247,11 @@ describe(".vendoapp interchange through createApps", () => {
     });
   });
 
-  it("creates imported app directories with the conventional PORT environment", async () => {
+  it("provisions imported app directories with the full §4.2 run environment", async () => {
+    // ENG-347 — the rebuilt machine must carry the SAME run env the create/edit
+    // path injects (PORT + proxy URL + run token + declared secret handles), or
+    // the egress fetch shim declines to install and the imported rung-2/3 app
+    // cannot reach host tools or the egress endpoint until it is re-edited.
     const base = fakeSandbox();
     let createSpec: Parameters<SandboxAdapter["create"]>[0] | undefined;
     const sandbox: SandboxAdapter = {
@@ -258,9 +262,25 @@ describe(".vendoapp interchange through createApps", () => {
       resume: (ref) => base.resume(ref),
     };
     const runtime = createApps({
-      store: memoryStore(), guard: guardFixture(), tools, sandbox, catalog: [],
+      store: memoryStore(),
+      guard: guardFixture(),
+      tools,
+      sandbox,
+      catalog: [],
+      proxyUrl: "https://proxy.test",
     });
-    const { id: _id, ...exported } = document();
+    const { id: _id, ...exported } = document({
+      secrets: ["STRIPE_KEY"],
+      tree: {
+        formatVersion: "vendo-genui/v1",
+        root: "root",
+        nodes: [{
+          id: "root",
+          component: "Button",
+          props: { onClick: { action: "fn:send_invoice" } },
+        }],
+      },
+    });
     const archive = zipSync({
       "app.json": encoder.encode(JSON.stringify(exported)),
       "app/server.js": encoder.encode("export const ready = true;"),
@@ -268,7 +288,49 @@ describe(".vendoapp interchange through createApps", () => {
 
     await runtime.importApp(archive, context("user_ada"));
 
-    expect(createSpec?.env).toEqual({ PORT: "8080" });
+    expect(createSpec?.env.PORT).toBe("8080");
+    expect(createSpec?.env.VENDO_PROXY_URL).toBe("https://proxy.test");
+    expect(createSpec?.env.VENDO_RUN_TOKEN).toMatch(/.+/);
+    // Declared secrets are injected as handles, never values (§4.3).
+    expect(createSpec?.env.STRIPE_KEY).toMatch(/^vendo-secret:STRIPE_KEY:/);
+  });
+
+  it("lets an imported rung-2/3 app reach tools/egress without a subsequent edit", async () => {
+    // ENG-347 — resuming the imported snapshot must yield a machine whose env
+    // still carries the proxy URL + run token the fetch shim needs, so the
+    // imported app can call the proxy without first being re-edited.
+    const sandbox = fakeSandbox();
+    const runtime = createApps({
+      store: memoryStore(),
+      guard: guardFixture(),
+      tools,
+      sandbox,
+      catalog: [],
+      proxyUrl: "https://proxy.test",
+    });
+    const { id: _id, ...exported } = document({
+      tree: {
+        formatVersion: "vendo-genui/v1",
+        root: "root",
+        nodes: [{
+          id: "root",
+          component: "Button",
+          props: { onClick: { action: "fn:send_invoice" } },
+        }],
+      },
+    });
+    const archive = zipSync({
+      "app.json": encoder.encode(JSON.stringify(exported)),
+      "app/server.js": encoder.encode("export const ready = true;"),
+    });
+
+    const imported = await runtime.importApp(archive, context("user_ada"));
+    const outcome = await runtime.call(imported.id, "fn:send_invoice", {}, context("user_ada"));
+
+    expect(outcome.status).toBe("ok");
+    const resumed = [...sandbox.machines.values()].at(-1)!;
+    expect(resumed.env.VENDO_PROXY_URL).toBe("https://proxy.test");
+    expect(resumed.env.VENDO_RUN_TOKEN).toMatch(/.+/);
   });
 
   it("fails rather than stripping fn surfaces when app files cannot be rebuilt", async () => {

--- a/packages/apps/src/interchange.ts
+++ b/packages/apps/src/interchange.ts
@@ -9,10 +9,11 @@ import {
   type StoreAdapter,
 } from "@vendoai/core";
 import { unzipSync, zipSync, type Zippable } from "fflate";
+import type { MachineSessions } from "./machine.js";
 import { appRecordInput } from "./persistence.js";
 import { assertPinsExportable, type PinBaseline } from "./pins.js";
 import type { SandboxAdapter, SandboxMachine } from "./sandbox.js";
-import { FETCH_SHIM_PATH, FETCH_SHIM_SOURCE } from "./scaffold/fetch-shim.js";
+import { FETCH_SHIM_PATH } from "./scaffold/fetch-shim.js";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -206,6 +207,9 @@ export interface AppInterchangeDependencies {
   store: StoreAdapter;
   guard: Guard;
   sandbox?: SandboxAdapter;
+  /** Shared machine cache — import provisions its rebuilt snapshot through here
+   * so it inherits the create/edit §4.2 run environment (ENG-347). */
+  machines: MachineSessions;
   pinBaselines?: readonly PinBaseline[];
   requireOwned(appId: AppId, subject: string): Promise<AppDocument>;
 }
@@ -278,21 +282,18 @@ export const createAppInterchange = (
       let imported: AppDocument;
       let appDirectory: Json = "absent";
 
-      if (parsed.hasAppDirectory && dependencies.sandbox !== undefined) {
-        // A temporary non-authoritative ref lets core validate fn: surfaces before provisioning.
-        validateImportedDocument({ ...candidate, server: "import:pending" });
-        // The runtime-owned fetch shim is written LAST so the recipient's copy
-        // boots with the CURRENT shim, never one an archive smuggled in.
-        const machine = await dependencies.sandbox.create({
-          env: { PORT: "8080" },
-          files: { ...parsed.files, [FETCH_SHIM_PATH]: encoder.encode(FETCH_SHIM_SOURCE) },
-        });
-        try {
-          imported = validateImportedDocument({ ...candidate, server: await machine.snapshot() });
-          appDirectory = "rebuilt";
-        } finally {
-          await machine.stop().catch(() => undefined);
-        }
+      if (parsed.hasAppDirectory && dependencies.machines.available()) {
+        // A temporary non-authoritative ref lets core validate fn: surfaces before
+        // provisioning; the validated shape carries the secrets/egress the run
+        // environment needs (ENG-347).
+        const pending = validateImportedDocument({ ...candidate, server: "import:pending" });
+        // ENG-347 — provision through the shared machine cache so the rebuilt
+        // snapshot bakes in the SAME §4.2 run environment (proxy URL + run token
+        // + secret handles) the create/edit path injects; provisioning also
+        // writes the CURRENT runtime-owned fetch shim last.
+        const server = await dependencies.machines.provisionImport(pending, ctx, parsed.files);
+        imported = validateImportedDocument({ ...candidate, server });
+        appDirectory = "rebuilt";
       } else {
         imported = validateImportedDocument(candidate);
         if (parsed.hasAppDirectory) appDirectory = "contained-without-sandbox";

--- a/packages/apps/src/machine.ts
+++ b/packages/apps/src/machine.ts
@@ -56,6 +56,20 @@ export interface MachineSessions {
   withMachine<T>(app: AppDocument, ctx: RunContext, fn: (run: MachineRun) => Promise<T>): Promise<T>;
   /** 06-apps §2 — isolated edit/graduation machine; never enters the live cache before validation. */
   withFork<T>(app: AppDocument, ctx: RunContext, fn: (run: MachineRun) => Promise<T>): Promise<T>;
+  /**
+   * 06-apps §7 — provision a fresh machine for an imported app directory and
+   * snapshot it. Seeds the archive's files and injects the SAME §4.2 run
+   * environment the create/edit path builds (PORT + proxy URL + a freshly
+   * minted run token + declared secret handles), so an imported rung-2/3 app
+   * reaches host tools and the egress endpoint without a subsequent re-edit
+   * (ENG-347). The runtime-owned fetch shim is always written last so the copy
+   * boots with the current shim, never one an archive smuggled in.
+   */
+  provisionImport(
+    app: AppDocument,
+    ctx: RunContext,
+    files: Record<string, Uint8Array>,
+  ): Promise<string>;
 }
 
 /** 06-apps §4.2 and block-plan decision 5. */
@@ -179,6 +193,25 @@ export const createMachineSessions = (config: MachineSessionsConfig): MachineSes
     return fn({ machine, ...run });
   };
 
+  const provisionImport = async (
+    app: AppDocument,
+    ctx: RunContext,
+    files: Record<string, Uint8Array>,
+  ): Promise<string> => {
+    const adapter = requireAdapter();
+    const run = await newRun(app, ctx);
+    const machine = await adapter.create({
+      env: environment(app, run.runToken),
+      files: { ...files, [FETCH_SHIM_PATH]: FETCH_SHIM_SOURCE },
+      egress: app.egress,
+    });
+    try {
+      return await machine.snapshot();
+    } finally {
+      await machine.stop().catch(() => undefined);
+    }
+  };
+
   const evict = async (appId: string): Promise<void> => {
     const pending = waking.get(appId);
     if (pending !== undefined) await pending.catch(() => undefined);
@@ -211,5 +244,6 @@ export const createMachineSessions = (config: MachineSessionsConfig): MachineSes
     withAuthorization,
     withMachine,
     withFork,
+    provisionImport,
   };
 };

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -350,6 +350,7 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     store: config.store,
     guard: config.guard,
     sandbox: config.sandbox,
+    machines,
     pinBaselines: config.pinBaselines,
     requireOwned,
   });


### PR DESCRIPTION
## Problem (ENG-347)

`importApp` rebuilt an imported app-directory machine with `env: { PORT: "8080" }` only. It bypassed the shared `environment()` helper that the normal create/edit machine path uses to inject the full 06-apps §4.2 run environment (`VENDO_PROXY_URL`, `VENDO_RUN_TOKEN`, and declared secret handles).

Consequence: the secrets egress fetch shim correctly declines to install (it requires the proxy URL + run token), so an imported rung-2/3 app could not reach host tools or the egress endpoint until it was re-edited (a re-edit re-provisions the machine with the full env).

Found during ENG-290 M4 (PR #268).

## Fix

- Added `MachineSessions.provisionImport(app, ctx, files)` — provisions a fresh machine seeded with the archive's files, injecting the **same** §4.2 run environment `create`/`edit` build via the existing private `environment()` helper (PORT + proxy URL + a freshly minted per-run token + secret handles), plus the current runtime-owned fetch shim written last. Snapshots and stops. Run-token semantics match the create/edit path exactly (a fresh token is minted and baked into the snapshot; no stale token is hardcoded — it flows through the same `newRun` path).
- `importApp` now routes provisioning through `machines.provisionImport(...)` instead of calling `sandbox.create({ env: { PORT } })` directly. The env logic is reused, not duplicated.
- Wired the shared `machines` cache into `createAppInterchange`.

## Tests (TDD)

- New: an imported app directory is provisioned with the full §4.2 run env (proxy URL + run token + secret handles as handles, never values).
- New: an imported rung-2/3 app can call a fn (reach tools/egress) without a subsequent edit, and the resumed machine still carries the proxy URL + run token.
- Updated the prior PORT-only env assertion to the full env shape.

## Gates

`pnpm build` · `pnpm test` (41/41 tasks; apps suite 349 passed) · `pnpm typecheck` (34/34) · `pnpm lint` (dependency-guard OK) — all green.

Scope: `packages/apps` only. No `packages/ui`, `apps/console`, or `docs/contracts` changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `importApp` to provision machines with the full run environment so imported rung-2/3 apps can reach tools/egress without a re-edit. Addresses Linear ENG-347.

- **Bug Fixes**
  - Added `machines.provisionImport(...)` to seed archive files and inject the standard §4.2 env (`PORT`, `VENDO_PROXY_URL`, a fresh `VENDO_RUN_TOKEN`, and secret handles), writing the current fetch shim last and snapshotting.
  - Routed `importApp` through `machines.provisionImport(...)` instead of `sandbox.create`, reusing the same env and egress logic as create/edit.
  - Connected the shared `machines` cache in `createAppInterchange` to ensure imports inherit the same env as create/edit in `@vendoai/apps`.

<sup>Written for commit 7255d6667f9c260fa2ab7a1f860f891ba1c05d22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

