### PR TITLE
ci: run multi-instance token-claim race e2e with Postgres service (ENG-321)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,11 +74,16 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      # Build only the workspace deps the two integration suites need (the `...`
+      # Build only the workspace deps the integration suites need (the `...`
       # suffix pulls each fixture package's transitive workspace deps).
-      - run: pnpm turbo run build --filter=@vendoai-fixtures/integration... --filter=@vendoai-fixtures/integration-browser...
+      - run: pnpm turbo run build --filter=@vendoai-fixtures/integration... --filter=@vendoai-fixtures/integration-browser... --filter=@vendoai-fixtures/mcp-e2e...
       # The node suite boots the real composed umbrella over HTTP against the host app.
       - run: pnpm --filter @vendoai-fixtures/integration test
+      # The MCP door e2e suite: its multi-instance token-claim race test
+      # (token-claim-race.e2e.test.ts, the ENG-270 single-use-token guarantee)
+      # gates on POSTGRES_URL and otherwise silently skips — the job-level
+      # POSTGRES_URL above makes it actually run its forced-overlap races here.
+      - run: pnpm --filter @vendoai-fixtures/mcp-e2e test
       # The browser leg drives the shipped hooks/chrome in Chromium against the same wire.
       - run: pnpm --filter @vendoai-fixtures/integration-browser exec playwright install --with-deps chromium
       - run: pnpm --filter @vendoai-fixtures/integration-browser test:browser


### PR DESCRIPTION
## What

The MCP door e2e suite `@vendoai-fixtures/mcp-e2e` — which contains `fixtures/mcp-e2e/src/token-claim-race.e2e.test.ts`, the CI regression guard for the ENG-270 atomic single-use-token guarantee (merged PR #166) — ran in **no** per-PR CI job:

- The main `ci` job runs `pnpm test:coverage`; `@vendoai-fixtures/mcp-e2e` defines only a `test` script (no `test:coverage`), so turbo skips it there.
- The `integration` job only filtered the `integration` / `integration-browser` fixtures.

The race suite gates on `POSTGRES_URL` (`const describePostgres = POSTGRES_URL ? describe : describe.skip`), so wherever it was invoked without one it silently skipped. Net: the single-use-token guarantee had **zero** per-PR regression protection.

## Change

`.github/workflows/ci.yml`, `integration` job (which already provisions a `postgres:16` service and sets a job-level `POSTGRES_URL`):

- Added `--filter=@vendoai-fixtures/mcp-e2e...` to the existing `turbo run build` so the suite's workspace deps are built.
- Added `pnpm --filter @vendoai-fixtures/mcp-e2e test` step. It inherits the job-level `POSTGRES_URL`, so the forced-overlap claim races execute for real.

No test weakened; no service added to a job that lacks Postgres. Follows the existing perf/ci/conformance `services: postgres:16` pattern (image tag, health-check, port mapping, POSTGRES_URL wiring).

## Local proof (throwaway postgres:16 via docker)

- With `POSTGRES_URL` set: `token-claim-race.e2e.test.ts (3 tests) — 3 passed` (code-claim, refresh-rotation, grant-family races, 25 forced-overlap iterations each).
- Without `POSTGRES_URL`: `3 skipped` — confirms the job-level env is exactly what flips it on.

CI proof (the integration job actually running the race test, not skipped) will be linked from the Actions log below once the checks run.

## Gates

`pnpm build` (18/18), `pnpm typecheck` (34/34), `pnpm lint` (2/2), `pnpm test` (41/41) all green locally.

Closes ENG-321.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the `@vendoai-fixtures/mcp-e2e` token-claim race e2e in the `integration` job using its existing Postgres service to enforce the single‑use token guarantee per PR. Builds the suite’s deps and runs `pnpm --filter @vendoai-fixtures/mcp-e2e test` with `POSTGRES_URL` so races execute instead of skipping, meeting ENG-321 and guarding ENG-270.

<sup>Written for commit 623d00be1240b0d9cd5773efade65b09ce3b548d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

