### PR TITLE
feat(corpus): teable flagship task suite + UI-parity audit layer + finish-line run (ENG-257)

### DIFF
--- a/.github/workflows/corpus-nightly.yml
+++ b/.github/workflows/corpus-nightly.yml
@@ -116,6 +116,25 @@ jobs:
             echo "No scorecard produced (sweep may have failed before scoring)." >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      - name: UI-parity audit (LLM-costed, nightly only)
+        if: always()
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CORPUS_REPOS: ${{ github.event.inputs.repos }}
+        run: |
+          set -euo pipefail
+          # Runs AFTER the sweep, over the checkouts it left in corpus/.repos.
+          # It enumerates each frontend with the model and diffs against the
+          # generated tool surface. Informational: it never fails the job.
+          repos=()
+          for repo in ${CORPUS_REPOS:-}; do
+            if ! printf '%s' "$repo" | grep -Eq '^[a-z0-9][a-z0-9-]*$'; then
+              echo "::error::invalid repo name '$repo'"; exit 1
+            fi
+            repos+=("$repo")
+          done
+          pnpm corpus:ui-parity "${repos[@]}" >> "$GITHUB_STEP_SUMMARY" || true
+
       - name: Append trend to job summary
         if: always()
         run: |

--- a/corpus/expectations/teable/conversations.json
+++ b/corpus/expectations/teable/conversations.json
@@ -1,0 +1,69 @@
+{
+  "version": 1,
+  "seedNotes": "teable deep-tier flagship. The manifest E2E seed (`prisma-db-seed -- --e2e`) provisions the admin test@e2e.com / 12345678, a 'test space', and a 'test base' with its default grid table. These five tasks are the gnarly client-orchestrated flows the spec calls out (§6): each is something teable's own frontend does with client-side logic across several API calls, so NO single extracted primitive covers it. They pass only with the refine-produced compound tools and capability briefs in `.vendo/capabilities.json` in play (compound binding + `vendo refine`, 04-actions §6). Every task is a write, so a passing attempt must surface an approval card before the compound's steps execute (per-step approvals, 04-actions §6) and finish with no error toast. Assertions match by regex on the tool/compound name rather than an exact slug, so extraction/refine name changes do not falsely fail the suite.",
+  "k": 2,
+  "timeoutMs": 120000,
+  "threshold": 0.8,
+  "conversations": [
+    {
+      "id": "bulk-paste-range",
+      "description": "Paste a block of values across a cell range — a client-orchestrated multi-record update with no single primitive.",
+      "prompts": [
+        "In the test base's grid table, paste these three rows into the Name and Status columns starting at the first record: 'Launch, To Do' then 'Docs, In Progress' then 'Billing, Done'."
+      ],
+      "assertions": [
+        { "kind": "tool-called", "name": { "regex": "paste|range|record|cell|row|field|update" } },
+        { "kind": "approval-card-shown" },
+        { "kind": "no-error-toast" }
+      ]
+    },
+    {
+      "id": "field-type-convert-backfill",
+      "description": "Convert a field's type and backfill existing records — teable does the conversion plus a per-record rewrite client-side.",
+      "prompts": [
+        "Convert the Status column in the test base grid table to a single-select field, keeping the existing values as options so the current rows are backfilled."
+      ],
+      "assertions": [
+        { "kind": "tool-called", "name": { "regex": "field|column|convert|type|record|update|backfill" } },
+        { "kind": "approval-card-shown" },
+        { "kind": "no-error-toast" }
+      ]
+    },
+    {
+      "id": "view-reconfigure",
+      "description": "Reconfigure a view's filter, sort, and group in one ask — several view-mutation calls the frontend batches.",
+      "prompts": [
+        "In the grid view of the test base table, filter to rows where Status is Done, sort by Name ascending, and group by Status."
+      ],
+      "assertions": [
+        { "kind": "tool-called", "name": { "regex": "view|filter|sort|group|order" } },
+        { "kind": "approval-card-shown" },
+        { "kind": "no-error-toast" }
+      ]
+    },
+    {
+      "id": "csv-import-field-creation",
+      "description": "Import CSV creating fields — teable inspects headers, creates a table + a field per column, then inserts rows.",
+      "prompts": [
+        "Import this CSV into a new table in the test base, creating a column for each header: 'Task,Owner,Done\\nLaunch,Ada,false\\nDocs,Lin,true'."
+      ],
+      "assertions": [
+        { "kind": "tool-called", "name": { "regex": "import|csv|table|field|column|record|create" } },
+        { "kind": "approval-card-shown" },
+        { "kind": "no-error-toast" }
+      ]
+    },
+    {
+      "id": "kanban-drag",
+      "description": "Move a record between kanban stacks — a drag the frontend turns into a group-by-field update on that record.",
+      "prompts": [
+        "On the test base kanban board grouped by Status, move the 'Launch' record from the To Do stack into the In Progress stack."
+      ],
+      "assertions": [
+        { "kind": "tool-called", "name": { "regex": "record|update|status|move|kanban|view|field" } },
+        { "kind": "approval-card-shown" },
+        { "kind": "no-error-toast" }
+      ]
+    }
+  ]
+}

--- a/corpus/expectations/teable/gallery.json
+++ b/corpus/expectations/teable/gallery.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "nativeScreens": [
+    {
+      "id": "space",
+      "label": "teable space",
+      "path": "/space",
+      "waitFor": "main"
+    }
+  ],
+  "prompts": [
+    {
+      "id": "records-overview",
+      "label": "Records overview",
+      "prompt": "Using the real seeded test base grid table, create and open a records overview dashboard listing each record's Name and Status with a count per status. Match teable's native visual style and use no emoji."
+    },
+    {
+      "id": "status-breakdown",
+      "label": "Status breakdown",
+      "prompt": "Using the real seeded test base data, create and open a read-only status breakdown of the grid table grouped by Status, showing how many records sit in each group, without changing anything. Match teable's native visual style and use no emoji."
+    }
+  ]
+}

--- a/corpus/expectations/teable/gallery.json
+++ b/corpus/expectations/teable/gallery.json
@@ -18,6 +18,11 @@
       "id": "status-breakdown",
       "label": "Status breakdown",
       "prompt": "Using the real seeded test base data, create and open a read-only status breakdown of the grid table grouped by Status, showing how many records sit in each group, without changing anything. Match teable's native visual style and use no emoji."
+    },
+    {
+      "id": "field-summary",
+      "label": "Field summary",
+      "prompt": "Using the real seeded test base table, create and open a read-only field summary listing each column's name and type, without changing anything. Match teable's native visual style and use no emoji."
     }
   ]
 }

--- a/corpus/harness/package.json
+++ b/corpus/harness/package.json
@@ -16,8 +16,10 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
+    "@ai-sdk/anthropic": "3.0.12",
     "@playwright/test": "^1.48.0",
     "@types/node": "^22.0.0",
+    "ai": ">=6.0.0 <7",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"

--- a/corpus/harness/package.json
+++ b/corpus/harness/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "corpus": "node --import tsx src/cli.ts",
+    "ui-parity": "node --import tsx src/ui-parity-nightly.ts",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/corpus/harness/src/layers/e2e.test.ts
+++ b/corpus/harness/src/layers/e2e.test.ts
@@ -494,4 +494,94 @@ describe("runE2eLayer", () => {
     ]);
     expect(promptSent).toBe(true);
   });
+
+  it("logs teable in via the sign-in form and targets the authenticated /space page", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "vendo-e2e-"));
+    const expectationsRoot = path.join(root, "expectations");
+    const logsDir = path.join(root, "logs");
+    const repoDir = path.join(root, "repo");
+    await mkdir(path.join(expectationsRoot, "teable"), { recursive: true });
+    await mkdir(path.join(repoDir, ".vendo"), { recursive: true });
+    await writeFile(path.join(repoDir, ".vendo/tools.json"), JSON.stringify({ format: "vendo/tools@1", tools: [] }));
+    await writeFile(
+      path.join(expectationsRoot, "teable", "conversations.json"),
+      JSON.stringify({
+        version: 1,
+        k: 1,
+        threshold: 1,
+        timeoutMs: 2_000,
+        conversations: [
+          {
+            id: "teable-login",
+            prompts: ["show me the records"],
+            assertions: [{ kind: "no-error-toast" }],
+          },
+        ],
+      }),
+    );
+
+    const gotoUrls: string[] = [];
+    let credentialsVisible = true;
+    let promptSent = false;
+    const page: E2ePage = {
+      async goto(url: string) {
+        gotoUrls.push(url);
+      },
+      locator(selector: string) {
+        if (selector.includes('input[name="email"]') || selector.includes('input[type="email"]')) {
+          return new FakeLocator(() => credentialsVisible ? 1 : 0);
+        }
+        if (selector.includes('input[name="password"]') || selector.includes('input[type="password"]')) {
+          return new FakeLocator(() => credentialsVisible ? 1 : 0);
+        }
+        if (selector === "body" || selector.includes("[role='dialog']")) return new FakeLocator(1, "dialog ready");
+        return new FakeLocator(0);
+      },
+      getByRole(role: string) {
+        if (role === "dialog") return new FakeLocator(1);
+        if (role === "button") {
+          return new FakeLocator(1, "", {
+            click: () => {
+              credentialsVisible = false;
+            },
+          });
+        }
+        if (role === "textbox") {
+          return new FakeLocator(1, "", {
+            fill: () => {},
+            press: () => {
+              promptSent = true;
+            },
+          });
+        }
+        return new FakeLocator(0);
+      },
+      getByLabel() {
+        return new FakeLocator(1, "", {
+          fill: () => {},
+          press: () => {
+            promptSent = true;
+          },
+        });
+      },
+    };
+
+    const result = await runE2eLayer({
+      repoName: "teable",
+      repoDir,
+      readinessUrl: "http://127.0.0.1:43105/auth/login",
+      expectationsRoot,
+      logsDir,
+      pageFactory: async () => ({ page }),
+      now: () => new Date("2026-07-16T00:00:00.000Z"),
+    });
+
+    expect(result.layer.status).toBe("pass");
+    expect(gotoUrls).toEqual([
+      "http://127.0.0.1:43105/space?vendoThread=corpus-teable-login-1",
+      "http://127.0.0.1:43105/auth/login",
+      "http://127.0.0.1:43105/space?vendoThread=corpus-teable-login-1",
+    ]);
+    expect(promptSent).toBe(true);
+  });
 });

--- a/corpus/harness/src/layers/e2e.ts
+++ b/corpus/harness/src/layers/e2e.ts
@@ -590,6 +590,12 @@ export function layer3TargetUrl(baseUrl: string, repoName: string, threadId: str
     if (repoName === "papermark") {
       url.pathname = "/corpus-e2e";
     }
+    // teable's readiness URL is the sign-in page; after login the Vendo overlay
+    // (VendoRoot, wired by init into the app-router layout) renders on the
+    // authenticated space page.
+    if (repoName === "teable") {
+      url.pathname = "/space";
+    }
     url.searchParams.set("vendoThread", threadId);
     return url.toString();
   } catch {
@@ -620,6 +626,10 @@ async function prepareHostPage(
     await loginToUmami(page, Math.min(timeoutMs, 15_000));
     return;
   }
+  if (repoName === "teable") {
+    await loginToTeable(page, targetUrl, Math.min(timeoutMs, 30_000), navigationOptions);
+    return;
+  }
   if (repoName === "papermark") {
     await loginToPapermark(page, targetUrl, navigationOptions);
   }
@@ -631,7 +641,7 @@ async function restoreAttemptUrlAfterHostPrep(
   targetUrl: string,
   navigationOptions?: E2eNavigationOptions,
 ): Promise<void> {
-  if (repoName !== "umami" && repoName !== "papermark") return;
+  if (repoName !== "umami" && repoName !== "papermark" && repoName !== "teable") return;
   await page.goto(targetUrl, navigationOptions);
 }
 
@@ -646,6 +656,34 @@ async function loginToUmami(page: E2ePage, timeoutMs: number): Promise<void> {
   await password.fill("umami");
   await clickIfPresent(page.getByRole("button", { name: /^login$/i }));
   await waitFor(async () => (await safeCount(username)) === 0, timeoutMs).catch(() => undefined);
+}
+
+// teable authenticates with an email/password session (deterministic E2E seed
+// admin test@e2e.com / 12345678; manifest §bootstrap). The Nest backend serves
+// the sign-in form at /auth/login; on success it redirects into the app, so the
+// caller re-navigates to the attempt URL afterward (restoreAttemptUrlAfterHostPrep).
+async function loginToTeable(
+  page: E2ePage,
+  targetUrl: string,
+  timeoutMs: number,
+  navigationOptions?: E2eNavigationOptions,
+): Promise<void> {
+  const loginUrl = new URL("/auth/login", targetUrl);
+  await page.goto(loginUrl.toString(), navigationOptions);
+
+  const email = page.locator('input[name="email"], input[type="email"], #email');
+  await waitFor(async () => (await safeCount(email)) > 0, timeoutMs).catch(() => undefined);
+  if (await safeCount(email) === 0) return;
+
+  const password = page.locator('input[name="password"], input[type="password"], #password');
+  if (!email.fill || !password.fill) return;
+  await email.fill("test@e2e.com");
+  await password.fill("12345678");
+  if (!await clickIfPresent(page.getByRole("button", { name: /sign\s?in|log\s?in|continue|submit/i }))) {
+    await email.press?.("Enter");
+  }
+  // The form clears from the DOM once the redirect lands.
+  await waitFor(async () => (await safeCount(email)) === 0, timeoutMs).catch(() => undefined);
 }
 
 async function loginToPapermark(

--- a/corpus/harness/src/layers/ui-parity.test.ts
+++ b/corpus/harness/src/layers/ui-parity.test.ts
@@ -1,0 +1,256 @@
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildEnumeratorPrompt,
+  collectFrontendSources,
+  createLlmEnumerator,
+  diffUiParity,
+  extractEnumerationJson,
+  loadSurface,
+  runUiParityLayer,
+  summarizeUiParity,
+  UI_PARITY_LAYER,
+  type FrontendSource,
+  type UiCapability,
+  type UiParityEnumerator,
+} from "./ui-parity.js";
+
+function capability(overrides: Partial<UiCapability> & Pick<UiCapability, "id">): UiCapability {
+  return {
+    id: overrides.id,
+    title: overrides.title ?? overrides.id,
+    description: overrides.description ?? overrides.id,
+    kind: overrides.kind ?? "write",
+    expectedTools: overrides.expectedTools ?? [],
+  };
+}
+
+async function tempRepo(): Promise<string> {
+  return mkdtemp(path.join(os.tmpdir(), "ui-parity-"));
+}
+
+describe("diffUiParity", () => {
+  const surface = new Set(["host_records_update", "bulk_paste_range", "host_fields_create"]);
+
+  it("marks a capability covered when at least one claimed tool exists", () => {
+    const result = diffUiParity(
+      [capability({ id: "paste", expectedTools: ["bulk_paste_range", "does_not_exist"] })],
+      surface,
+    );
+    expect(result.entries[0]?.status).toBe("covered");
+    expect(result.entries[0]?.matchedTools).toEqual(["bulk_paste_range"]);
+    expect(result.entries[0]?.missingTools).toEqual(["does_not_exist"]);
+    // A partial claim is still counted a phantom for the reviewer's attention.
+    expect(result.phantoms).toHaveLength(1);
+    expect(result.coverage.value).toBe(1);
+  });
+
+  it("marks a capability a gap when no covering tool is claimed", () => {
+    const result = diffUiParity([capability({ id: "kanban-drag", expectedTools: [] })], surface);
+    expect(result.entries[0]?.status).toBe("gap");
+    expect(result.gaps).toHaveLength(1);
+    expect(result.coverage.value).toBe(0);
+  });
+
+  it("marks a capability a phantom when every claimed tool is missing", () => {
+    const result = diffUiParity([capability({ id: "convert", expectedTools: ["ghost_tool"] })], surface);
+    expect(result.entries[0]?.status).toBe("phantom");
+    expect(result.gaps).toHaveLength(1);
+    expect(result.phantoms).toHaveLength(1);
+  });
+
+  it("computes a fractional coverage metric across mixed capabilities", () => {
+    const result = diffUiParity(
+      [
+        capability({ id: "a", expectedTools: ["host_records_update"] }),
+        capability({ id: "b", expectedTools: ["host_fields_create"] }),
+        capability({ id: "c", expectedTools: [] }),
+        capability({ id: "d", expectedTools: ["ghost"] }),
+      ],
+      surface,
+    );
+    expect(result.coverage).toEqual({ passed: 2, total: 4, value: 0.5 });
+    expect(result.gaps.map((entry) => entry.capability.id)).toEqual(["c", "d"]);
+  });
+
+  it("treats an empty enumeration as vacuously fully covered", () => {
+    const result = diffUiParity([], surface);
+    expect(result.coverage).toEqual({ passed: 0, total: 0, value: 1 });
+  });
+});
+
+describe("summarizeUiParity", () => {
+  it("builds an informational, never-hard-failing scorecard layer", () => {
+    const coverage = diffUiParity(
+      [
+        capability({ id: "covered", expectedTools: ["t"] }),
+        capability({ id: "missing", expectedTools: [] }),
+      ],
+      new Set(["t"]),
+    );
+    const layer = summarizeUiParity(coverage, ["/tmp/ui-parity.json"]);
+    expect(layer.layer).toBe(UI_PARITY_LAYER);
+    expect(layer.name).toBe("ui-parity");
+    expect(layer.hardFailure).toBe(false);
+    expect(layer.status).toBe("pass");
+    expect(layer.score).toEqual({ passed: 1, total: 2, value: 0.5 });
+    expect(layer.checks?.map((check) => check.pass)).toEqual([true, false]);
+    expect(layer.detail).toContain("1 gap(s): missing");
+    expect(layer.logPaths).toEqual(["/tmp/ui-parity.json"]);
+  });
+});
+
+describe("loadSurface", () => {
+  it("merges extracted tools, refined compounds, and briefs, honoring disables", async () => {
+    const repoDir = await tempRepo();
+    await mkdir(path.join(repoDir, ".vendo"), { recursive: true });
+    await writeFile(path.join(repoDir, ".vendo/tools.json"), JSON.stringify({
+      format: "vendo/tools@1",
+      tools: [
+        { name: "host_records_list", risk: "read", binding: { kind: "route", method: "GET", path: "/x" } },
+        { name: "host_records_update", risk: "write", binding: { kind: "route", method: "PATCH", path: "/y" } },
+        { name: "host_dangerous", risk: "destructive", disabled: true, binding: { kind: "route", method: "DELETE", path: "/z" } },
+      ],
+    }));
+    await writeFile(path.join(repoDir, ".vendo/capabilities.json"), JSON.stringify({
+      format: "vendo/capabilities@1",
+      tools: [{ name: "bulk_paste_range", risk: "write", binding: { kind: "compound", steps: [] } }],
+      briefs: [{ name: "reconfigure-view", text: "…", tools: ["host_records_list"] }],
+    }));
+    await writeFile(path.join(repoDir, ".vendo/overrides.json"), JSON.stringify({
+      format: "vendo/overrides@1",
+      tools: { host_records_list: { disabled: true } },
+    }));
+
+    const surface = await loadSurface(repoDir);
+    const byName = new Map(surface.map((entry) => [entry.name, entry]));
+    expect(byName.get("host_records_list")?.disabled).toBe(true);
+    expect(byName.get("host_records_update")?.kind).toBe("tool");
+    expect(byName.get("host_dangerous")?.disabled).toBe(true);
+    expect(byName.get("bulk_paste_range")?.kind).toBe("compound");
+    expect(byName.get("reconfigure-view")?.kind).toBe("brief");
+  });
+
+  it("returns an empty surface for a repo with no generated files", async () => {
+    const repoDir = await tempRepo();
+    await expect(loadSurface(repoDir)).resolves.toEqual([]);
+  });
+});
+
+describe("runUiParityLayer", () => {
+  it("excludes disabled tools from the surface passed to the enumerator and computes coverage", async () => {
+    const repoDir = await tempRepo();
+    await mkdir(path.join(repoDir, ".vendo"), { recursive: true });
+    await writeFile(path.join(repoDir, ".vendo/tools.json"), JSON.stringify({
+      format: "vendo/tools@1",
+      tools: [
+        { name: "host_records_update", risk: "write", binding: { kind: "route", method: "PATCH", path: "/y" } },
+        { name: "host_disabled", risk: "write", disabled: true, binding: { kind: "route", method: "POST", path: "/d" } },
+      ],
+    }));
+
+    let seenSurfaceNames: string[] = [];
+    const enumerate: UiParityEnumerator = async (input) => {
+      seenSurfaceNames = input.surface.map((entry) => entry.name);
+      return {
+        capabilities: [
+          capability({ id: "edit-cell", expectedTools: ["host_records_update"] }),
+          capability({ id: "kanban-drag", expectedTools: [] }),
+          // The enumerator must not be able to "cover" via a disabled tool.
+          capability({ id: "bulk-delete", expectedTools: ["host_disabled"] }),
+        ],
+      };
+    };
+
+    const logsDir = path.join(repoDir, "logs");
+    const result = await runUiParityLayer({
+      repoName: "sample",
+      repoDir,
+      enumerate,
+      logsDir,
+      readFrontendSources: async () => [{ path: "src/App.tsx", text: "export default () => null;" }],
+      now: () => new Date("2026-07-16T00:00:00.000Z"),
+    });
+
+    expect(seenSurfaceNames).toEqual(["host_records_update"]);
+    expect(result.coverage.coverage).toEqual({ passed: 1, total: 3, value: round(1 / 3) });
+    expect(result.coverage.entries.find((entry) => entry.capability.id === "bulk-delete")?.status).toBe("phantom");
+    expect(result.layer.hardFailure).toBe(false);
+    expect(result.logPath).toBe(path.join(logsDir, "ui-parity.json"));
+  });
+});
+
+describe("collectFrontendSources", () => {
+  it("collects source files under frontend dirs and skips tests and node_modules", async () => {
+    const repoDir = await tempRepo();
+    await mkdir(path.join(repoDir, "src/components"), { recursive: true });
+    await mkdir(path.join(repoDir, "node_modules/pkg"), { recursive: true });
+    await writeFile(path.join(repoDir, "src/App.tsx"), "export const App = () => null;");
+    await writeFile(path.join(repoDir, "src/components/Grid.tsx"), "export const Grid = () => null;");
+    await writeFile(path.join(repoDir, "src/App.test.tsx"), "test('x', () => {});");
+    await writeFile(path.join(repoDir, "node_modules/pkg/index.js"), "module.exports = {};");
+
+    const sources = await collectFrontendSources(repoDir);
+    const paths = sources.map((source) => source.path).sort();
+    expect(paths).toEqual(["src/App.tsx", "src/components/Grid.tsx"]);
+  });
+
+  it("truncates oversized files to the byte budget", async () => {
+    const repoDir = await tempRepo();
+    await mkdir(path.join(repoDir, "src"), { recursive: true });
+    await writeFile(path.join(repoDir, "src/Big.tsx"), "x".repeat(50));
+    const sources = await collectFrontendSources(repoDir, 10, 20);
+    expect(sources[0]?.text.length).toBe(20);
+  });
+});
+
+describe("createLlmEnumerator", () => {
+  it("parses a strict-JSON model response into capabilities", async () => {
+    const generateText = vi.fn().mockResolvedValue({
+      text: '{"capabilities":[{"id":"paste","title":"Paste","description":"Paste a range","kind":"write","expectedTools":["bulk_paste_range"]}]}',
+    });
+    const enumerate = createLlmEnumerator({ model: {}, generateText });
+    const result = await enumerate({
+      repoName: "sample",
+      frontendSources: [{ path: "src/App.tsx", text: "code" }],
+      surface: [{ name: "bulk_paste_range", kind: "compound", disabled: false }],
+    });
+    expect(result.capabilities[0]?.id).toBe("paste");
+    expect(generateText).toHaveBeenCalledTimes(1);
+    const prompt = generateText.mock.calls[0]?.[0].prompt as string;
+    expect(prompt).toContain("bulk_paste_range [compound]");
+    expect(prompt).toContain("src/App.tsx");
+  });
+
+  it("recovers JSON wrapped in a fenced code block and prose", async () => {
+    const generateText = vi.fn().mockResolvedValue({
+      text: 'Here you go:\n```json\n{"capabilities":[]}\n```\nDone.',
+    });
+    const enumerate = createLlmEnumerator({ model: {}, generateText });
+    await expect(enumerate({ repoName: "s", frontendSources: [], surface: [] }))
+      .resolves.toEqual({ capabilities: [] });
+  });
+
+  it("defaults a missing expectedTools array to an empty gap", () => {
+    const parsed = extractEnumerationJson('{"capabilities":[{"id":"g","title":"G","description":"d","kind":"read"}]}');
+    expect(parsed).toBeTruthy();
+  });
+
+  it("throws when the model returns no JSON object", () => {
+    expect(() => extractEnumerationJson("no json here")).toThrow(/no JSON object/);
+  });
+});
+
+describe("buildEnumeratorPrompt", () => {
+  it("handles an empty surface and no sources without crashing", () => {
+    const prompt = buildEnumeratorPrompt({ repoName: "empty", frontendSources: [], surface: [] });
+    expect(prompt).toContain("(empty surface)");
+    expect(prompt).toContain("(no frontend sources found)");
+  });
+});
+
+function round(value: number): number {
+  return Number(value.toFixed(6));
+}

--- a/corpus/harness/src/layers/ui-parity.test.ts
+++ b/corpus/harness/src/layers/ui-parity.test.ts
@@ -42,9 +42,24 @@ describe("diffUiParity", () => {
     expect(result.entries[0]?.status).toBe("covered");
     expect(result.entries[0]?.matchedTools).toEqual(["bulk_paste_range"]);
     expect(result.entries[0]?.missingTools).toEqual(["does_not_exist"]);
-    // A partial claim is still counted a phantom for the reviewer's attention.
-    expect(result.phantoms).toHaveLength(1);
+    // Partial coverage is NOT double-counted: a covered capability is never
+    // also a phantom. Its stray claim stays visible on the entry itself.
+    expect(result.phantoms).toHaveLength(0);
     expect(result.coverage.value).toBe(1);
+  });
+
+  it("does not double-count a partially-covered capability in the metric or phantom list", () => {
+    const result = diffUiParity(
+      [
+        capability({ id: "partial", expectedTools: ["host_records_update", "ghost"] }),
+        capability({ id: "pure-phantom", expectedTools: ["ghost_only"] }),
+      ],
+      surface,
+    );
+    // "partial" is covered exactly once; only "pure-phantom" is a phantom.
+    expect(result.coverage).toEqual({ passed: 1, total: 2, value: 0.5 });
+    expect(result.phantoms.map((entry) => entry.capability.id)).toEqual(["pure-phantom"]);
+    expect(result.gaps.map((entry) => entry.capability.id)).toEqual(["pure-phantom"]);
   });
 
   it("marks a capability a gap when no covering tool is claimed", () => {

--- a/corpus/harness/src/layers/ui-parity.ts
+++ b/corpus/harness/src/layers/ui-parity.ts
@@ -1,0 +1,426 @@
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import type { ScorecardCheck, ScorecardLayerInput, ScorecardScore } from "../scorecard.js";
+
+/**
+ * UI-parity audit layer (spec §6, ENG-257). An agent enumerates what the host
+ * FRONTEND lets a user do, and that enumeration is diffed against the extracted
+ * plus refined tool surface (`.vendo/tools.json` primitives + the compounds and
+ * briefs in `.vendo/capabilities.json`) to produce a per-repo coverage metric.
+ *
+ * The layer is LLM-costed and NIGHTLY-ONLY, exactly like the Layer 3 scored
+ * pass@k run — it never rides the PR path (ci.yml). The live enumeration is a
+ * single injected seam (`UiParityEnumerator`); everything below it — surface
+ * loading, the diff, the coverage metric, the scorecard summary — is pure and
+ * unit-tested with a mocked enumerator. `createLlmEnumerator` is the only piece
+ * that talks to a model, and it takes the model + a `generateText`-shaped
+ * callable as injected dependencies so this module needs no ai-SDK dependency.
+ */
+
+export const UI_PARITY_LAYER = 4;
+export const UI_PARITY_LAYER_NAME = "ui-parity";
+
+/** A single user-facing action the frontend exposes, as enumerated by the agent. */
+export interface UiCapability {
+  /** Stable slug within a repo, e.g. `bulk-paste-range`. */
+  id: string;
+  title: string;
+  description: string;
+  /** Whether performing it changes host data. */
+  kind: "read" | "write";
+  /**
+   * Names drawn from the provided tool surface that the agent believes cover
+   * this capability. Empty means the agent found no covering tool: a genuine
+   * gap. Names not present in the surface are phantom claims (hallucinations)
+   * and are treated as not covering.
+   */
+  expectedTools: string[];
+}
+
+export interface UiParityEnumeration {
+  capabilities: UiCapability[];
+}
+
+export interface FrontendSource {
+  path: string;
+  text: string;
+}
+
+export type SurfaceEntryKind = "tool" | "compound" | "brief";
+
+export interface SurfaceEntry {
+  name: string;
+  kind: SurfaceEntryKind;
+  risk?: string;
+  /** Disabled entries are excluded from the available surface used for coverage. */
+  disabled: boolean;
+}
+
+export interface UiParityEnumeratorInput {
+  repoName: string;
+  frontendSources: FrontendSource[];
+  /** Only the enabled surface entries the capability can legitimately cite. */
+  surface: SurfaceEntry[];
+}
+
+export type UiParityEnumerator = (input: UiParityEnumeratorInput) => Promise<UiParityEnumeration>;
+
+export type UiParityEntryStatus = "covered" | "gap" | "phantom";
+
+export interface UiParityEntry {
+  capability: UiCapability;
+  status: UiParityEntryStatus;
+  matchedTools: string[];
+  missingTools: string[];
+}
+
+export interface UiParityCoverage {
+  entries: UiParityEntry[];
+  coverage: ScorecardScore;
+  gaps: UiParityEntry[];
+  phantoms: UiParityEntry[];
+}
+
+export interface UiParityLayerContext {
+  repoName: string;
+  repoDir: string;
+  enumerate: UiParityEnumerator;
+  logsDir?: string;
+  /** Test seam: override frontend source collection. */
+  readFrontendSources?: (repoDir: string) => Promise<FrontendSource[]>;
+  maxFiles?: number;
+  maxBytesPerFile?: number;
+  now?: () => Date;
+}
+
+export interface UiParityLayerRunResult {
+  layer: ScorecardLayerInput;
+  coverage: UiParityCoverage;
+  surface: SurfaceEntry[];
+  capabilities: UiCapability[];
+  logPath?: string;
+}
+
+const DEFAULT_MAX_FILES = 40;
+const DEFAULT_MAX_BYTES_PER_FILE = 12_000;
+const FRONTEND_DIRS = ["src", "app", "pages", "components", "features"];
+const SOURCE_EXTENSIONS = new Set([".tsx", ".ts", ".jsx", ".js", ".mts", ".cts"]);
+const SKIP_DIRS = new Set([
+  "node_modules",
+  ".vendo",
+  ".next",
+  "dist",
+  "build",
+  "out",
+  ".turbo",
+  "coverage",
+  "__tests__",
+  "e2e",
+]);
+
+function round(value: number): number {
+  return Number(value.toFixed(6));
+}
+
+function scoreOf(covered: number, total: number): ScorecardScore {
+  return {
+    passed: covered,
+    total,
+    // Vacuously fully-covered when the agent enumerated nothing: there are no
+    // uncovered capabilities. Callers surface the empty enumeration separately.
+    value: total === 0 ? 1 : round(covered / total),
+  };
+}
+
+/**
+ * Pure coverage diff. A capability is covered when at least one of its claimed
+ * tools actually exists in the enabled surface; it is a phantom when it claims
+ * tools but none exist (agent hallucinated the coverage); it is a gap when the
+ * agent claimed no covering tool at all.
+ */
+export function diffUiParity(
+  capabilities: readonly UiCapability[],
+  surfaceNames: ReadonlySet<string>,
+): UiParityCoverage {
+  const entries: UiParityEntry[] = capabilities.map((capability) => {
+    const matchedTools = capability.expectedTools.filter((name) => surfaceNames.has(name));
+    const missingTools = capability.expectedTools.filter((name) => !surfaceNames.has(name));
+    const status: UiParityEntryStatus = matchedTools.length > 0
+      ? "covered"
+      : capability.expectedTools.length > 0
+        ? "phantom"
+        : "gap";
+    return { capability, status, matchedTools, missingTools };
+  });
+  const covered = entries.filter((entry) => entry.status === "covered").length;
+  return {
+    entries,
+    coverage: scoreOf(covered, entries.length),
+    gaps: entries.filter((entry) => entry.status !== "covered"),
+    phantoms: entries.filter((entry) => entry.missingTools.length > 0),
+  };
+}
+
+export function summarizeUiParity(coverage: UiParityCoverage, logPaths: readonly string[] = []): ScorecardLayerInput {
+  const checks: ScorecardCheck[] = coverage.entries.map((entry) => ({
+    id: `ui-parity.${entry.capability.id}`,
+    pass: entry.status === "covered",
+    detail: entry.status === "covered"
+      ? `covered by ${entry.matchedTools.join(", ")}`
+      : entry.status === "gap"
+        ? `no covering tool enumerated (${entry.capability.kind})`
+        : `phantom coverage; claimed missing tool(s): ${entry.missingTools.join(", ")}`,
+  }));
+  const gapDetail = coverage.gaps.length === 0
+    ? "no gaps"
+    : `${coverage.gaps.length} gap(s): ${coverage.gaps.map((entry) => entry.capability.id).join(", ")}`;
+  return {
+    // Nightly, informational: it reports a metric and never hard-fails a run.
+    layer: UI_PARITY_LAYER,
+    name: UI_PARITY_LAYER_NAME,
+    status: "pass",
+    score: coverage.coverage,
+    checks,
+    detail: `frontend/tool coverage ${coverage.coverage.value.toFixed(3)} (${coverage.coverage.passed}/${coverage.coverage.total}); ${gapDetail}`,
+    logPaths,
+    hardFailure: false,
+  };
+}
+
+async function readOptionalJson(file: string): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(file, "utf8")) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Load the extracted + refined surface loosely (never throws on a shape the
+ * strict schemas would reject — a real repo's generated files are the input,
+ * not a fixture). Extracted primitives come from `.vendo/tools.json`; refined
+ * compounds and briefs come from `.vendo/capabilities.json`; `.vendo/overrides.json`
+ * disables are honored so a disabled tool is not counted as available coverage.
+ */
+export async function loadSurface(repoDir: string): Promise<SurfaceEntry[]> {
+  const vendoDir = path.join(repoDir, ".vendo");
+  const toolsDoc = await readOptionalJson(path.join(vendoDir, "tools.json"));
+  const capsDoc = await readOptionalJson(path.join(vendoDir, "capabilities.json"));
+  const overridesDoc = await readOptionalJson(path.join(vendoDir, "overrides.json"));
+
+  const overrideDisabled = new Set<string>();
+  if (isRecord(overridesDoc) && isRecord(overridesDoc.tools)) {
+    for (const [name, value] of Object.entries(overridesDoc.tools)) {
+      if (isRecord(value) && value.disabled === true) overrideDisabled.add(name);
+    }
+  }
+
+  const entries: SurfaceEntry[] = [];
+  const seen = new Set<string>();
+  const push = (name: unknown, kind: SurfaceEntryKind, risk: unknown, disabledFlag: unknown): void => {
+    if (typeof name !== "string" || name === "" || seen.has(name)) return;
+    seen.add(name);
+    entries.push({
+      name,
+      kind,
+      risk: typeof risk === "string" ? risk : undefined,
+      disabled: disabledFlag === true || overrideDisabled.has(name),
+    });
+  };
+
+  const toolsArray = isRecord(toolsDoc) && Array.isArray(toolsDoc.tools)
+    ? toolsDoc.tools
+    : Array.isArray(toolsDoc) ? toolsDoc : [];
+  for (const tool of toolsArray) {
+    if (isRecord(tool)) push(tool.name, "tool", tool.risk, tool.disabled);
+  }
+  if (isRecord(capsDoc)) {
+    if (Array.isArray(capsDoc.tools)) {
+      for (const tool of capsDoc.tools) {
+        if (isRecord(tool)) push(tool.name, "compound", tool.risk, tool.disabled);
+      }
+    }
+    if (Array.isArray(capsDoc.briefs)) {
+      for (const brief of capsDoc.briefs) {
+        if (isRecord(brief)) push(brief.name, "brief", undefined, false);
+      }
+    }
+  }
+  return entries;
+}
+
+async function walkFrontend(
+  dir: string,
+  budget: { files: number; maxFiles: number; maxBytesPerFile: number },
+  out: FrontendSource[],
+  repoDir: string,
+): Promise<void> {
+  if (budget.files >= budget.maxFiles) return;
+  let dirents;
+  try {
+    dirents = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  dirents.sort((left, right) => (left.name < right.name ? -1 : 1));
+  for (const dirent of dirents) {
+    if (budget.files >= budget.maxFiles) return;
+    if (dirent.name.startsWith(".") && dirent.name !== ".vendo") {
+      if (dirent.isDirectory()) continue;
+    }
+    const full = path.join(dir, dirent.name);
+    if (dirent.isDirectory()) {
+      if (SKIP_DIRS.has(dirent.name)) continue;
+      await walkFrontend(full, budget, out, repoDir);
+      continue;
+    }
+    const ext = path.extname(dirent.name);
+    if (!SOURCE_EXTENSIONS.has(ext)) continue;
+    if (/\.(?:test|spec|d)\.[cm]?[jt]sx?$/.test(dirent.name)) continue;
+    let text: string;
+    try {
+      text = await readFile(full, "utf8");
+    } catch {
+      continue;
+    }
+    out.push({
+      path: path.relative(repoDir, full).split(path.sep).join("/"),
+      text: text.length > budget.maxBytesPerFile ? text.slice(0, budget.maxBytesPerFile) : text,
+    });
+    budget.files += 1;
+  }
+}
+
+export async function collectFrontendSources(
+  repoDir: string,
+  maxFiles = DEFAULT_MAX_FILES,
+  maxBytesPerFile = DEFAULT_MAX_BYTES_PER_FILE,
+): Promise<FrontendSource[]> {
+  const out: FrontendSource[] = [];
+  const budget = { files: 0, maxFiles, maxBytesPerFile };
+  const roots = FRONTEND_DIRS.map((dir) => path.join(repoDir, dir));
+  for (const root of roots) {
+    await walkFrontend(root, budget, out, repoDir);
+  }
+  // Fall back to the repo root when none of the conventional dirs exist.
+  if (out.length === 0) await walkFrontend(repoDir, budget, out, repoDir);
+  return out;
+}
+
+export async function runUiParityLayer(ctx: UiParityLayerContext): Promise<UiParityLayerRunResult> {
+  const surface = await loadSurface(ctx.repoDir);
+  const enabledSurface = surface.filter((entry) => !entry.disabled);
+  const frontendSources = await (ctx.readFrontendSources ?? ((dir) =>
+    collectFrontendSources(dir, ctx.maxFiles ?? DEFAULT_MAX_FILES, ctx.maxBytesPerFile ?? DEFAULT_MAX_BYTES_PER_FILE)))(ctx.repoDir);
+
+  const enumeration = await ctx.enumerate({
+    repoName: ctx.repoName,
+    frontendSources,
+    surface: enabledSurface,
+  });
+
+  const surfaceNames = new Set(enabledSurface.map((entry) => entry.name));
+  const coverage = diffUiParity(enumeration.capabilities, surfaceNames);
+
+  let logPath: string | undefined;
+  if (ctx.logsDir) {
+    await mkdir(ctx.logsDir, { recursive: true });
+    logPath = path.join(ctx.logsDir, "ui-parity.json");
+    await writeFile(
+      logPath,
+      `${JSON.stringify({
+        version: 1,
+        repo: ctx.repoName,
+        generatedAt: (ctx.now ?? (() => new Date()))().toISOString(),
+        surface: enabledSurface,
+        coverage,
+      }, null, 2)}\n`,
+    );
+  }
+
+  return {
+    layer: summarizeUiParity(coverage, logPath ? [logPath] : []),
+    coverage,
+    surface: enabledSurface,
+    capabilities: enumeration.capabilities,
+    logPath,
+  };
+}
+
+const capabilitySchema = z.object({
+  id: z.string().min(1),
+  title: z.string().min(1),
+  description: z.string().min(1),
+  kind: z.enum(["read", "write"]),
+  expectedTools: z.array(z.string().min(1)).default([]),
+});
+
+const enumerationSchema = z.object({
+  capabilities: z.array(capabilitySchema),
+});
+
+/** Extract a JSON object from a model response that may wrap it in prose or a
+ * fenced code block. */
+export function extractEnumerationJson(text: string): unknown {
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+  const candidate = fenced?.[1] ?? text;
+  const start = candidate.indexOf("{");
+  const end = candidate.lastIndexOf("}");
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error("ui-parity enumerator returned no JSON object");
+  }
+  return JSON.parse(candidate.slice(start, end + 1)) as unknown;
+}
+
+export interface GenerateTextLike {
+  (options: { model: unknown; prompt: string; maxOutputTokens?: number }): Promise<{ text: string }>;
+}
+
+export interface LlmEnumeratorDeps {
+  model: unknown;
+  generateText: GenerateTextLike;
+  maxOutputTokens?: number;
+}
+
+export function buildEnumeratorPrompt(input: UiParityEnumeratorInput): string {
+  const surfaceList = input.surface
+    .map((entry) => `- ${entry.name} [${entry.kind}${entry.risk ? `, ${entry.risk}` : ""}]`)
+    .join("\n");
+  const sources = input.frontendSources
+    .map((source) => `--- ${source.path} ---\n${source.text}`)
+    .join("\n\n");
+  return [
+    `You are auditing the frontend of the app "${input.repoName}" for UI/tool parity.`,
+    "Enumerate the distinct user-facing actions the FRONTEND lets a user perform (both reads and writes).",
+    "For each action, decide whether the extracted/refined agent tool surface below can perform it, and list the covering tool name(s) from that surface. If NO tool covers it, return an empty expectedTools array — that is a genuine gap.",
+    "Only cite tool names that appear verbatim in the surface list.",
+    "",
+    "TOOL SURFACE (extracted primitives + refined compounds/briefs):",
+    surfaceList || "(empty surface)",
+    "",
+    "FRONTEND SOURCE (truncated):",
+    sources || "(no frontend sources found)",
+    "",
+    "Respond with STRICT JSON only, no prose, in this shape:",
+    '{"capabilities":[{"id":"kebab-slug","title":"...","description":"...","kind":"read|write","expectedTools":["tool_name"]}]}',
+  ].join("\n");
+}
+
+/** The live, nightly enumerator. The model + a `generateText`-shaped callable
+ * are injected so this module carries no ai-SDK dependency; the nightly driver
+ * wires them from the host's provider-agnostic seam (BYO key). */
+export function createLlmEnumerator(deps: LlmEnumeratorDeps): UiParityEnumerator {
+  return async (input) => {
+    const { text } = await deps.generateText({
+      model: deps.model,
+      prompt: buildEnumeratorPrompt(input),
+      maxOutputTokens: deps.maxOutputTokens ?? 4_000,
+    });
+    return enumerationSchema.parse(extractEnumerationJson(text));
+  };
+}

--- a/corpus/harness/src/layers/ui-parity.ts
+++ b/corpus/harness/src/layers/ui-parity.ts
@@ -158,7 +158,11 @@ export function diffUiParity(
     entries,
     coverage: scoreOf(covered, entries.length),
     gaps: entries.filter((entry) => entry.status !== "covered"),
-    phantoms: entries.filter((entry) => entry.missingTools.length > 0),
+    // Only genuinely-phantom entries (claimed tools, none real) — a covered
+    // capability that happens to also claim a missing tool is NOT a phantom, so
+    // partial coverage is never double-counted. Its stray claim stays visible
+    // on the entry's own `missingTools`.
+    phantoms: entries.filter((entry) => entry.status === "phantom"),
   };
 }
 

--- a/corpus/harness/src/ui-parity-nightly.test.ts
+++ b/corpus/harness/src/ui-parity-nightly.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { resolveModel, runUiParityNightly } from "./ui-parity-nightly.js";
+
+describe("runUiParityNightly", () => {
+  it("skips gracefully (exit 0) when the ai-SDK cannot be resolved", async () => {
+    const logs: string[] = [];
+    const code = await runUiParityNightly([], {}, (line) => logs.push(line), {
+      resolveModel: async () => {
+        throw new Error("ai-SDK not available (Cannot find module 'ai'); install `ai` and `@ai-sdk/anthropic`.");
+      },
+    });
+    expect(code).toBe(0);
+    const output = logs.join("\n");
+    expect(output).toContain("ui-parity audit skipped");
+    expect(output).toContain("ai-SDK not available");
+  });
+
+  it("skips gracefully when the model resolver rejects for a missing key", async () => {
+    const logs: string[] = [];
+    const code = await runUiParityNightly([], {}, (line) => logs.push(line), {
+      resolveModel: (env) => resolveModel(env),
+    });
+    expect(code).toBe(0);
+    expect(logs.join("\n")).toContain("ANTHROPIC_API_KEY");
+  });
+
+  it("resolveModel throws a clear error when ANTHROPIC_API_KEY is absent", async () => {
+    await expect(resolveModel({})).rejects.toThrow(/ANTHROPIC_API_KEY/);
+  });
+});

--- a/corpus/harness/src/ui-parity-nightly.ts
+++ b/corpus/harness/src/ui-parity-nightly.ts
@@ -34,13 +34,27 @@ async function importDynamic(specifier: string): Promise<Record<string, unknown>
   return import(resolved) as Promise<Record<string, unknown>>;
 }
 
-async function resolveModel(env: NodeJS.ProcessEnv): Promise<{ model: unknown; generateText: GenerateTextLike }> {
+export interface ResolvedModel {
+  model: unknown;
+  generateText: GenerateTextLike;
+}
+
+export async function resolveModel(env: NodeJS.ProcessEnv): Promise<ResolvedModel> {
   const apiKey = env.ANTHROPIC_API_KEY?.trim();
   if (!apiKey) {
     throw new Error("ui-parity nightly needs ANTHROPIC_API_KEY (BYO key) to enumerate frontend capabilities.");
   }
-  const ai = await importDynamic("ai");
-  const anthropicMod = await importDynamic("@ai-sdk/anthropic");
+  let ai: Record<string, unknown>;
+  let anthropicMod: Record<string, unknown>;
+  try {
+    ai = await importDynamic("ai");
+    anthropicMod = await importDynamic("@ai-sdk/anthropic");
+  } catch (error) {
+    throw new Error(
+      `ai-SDK not available (${error instanceof Error ? error.message : String(error)}); `
+        + "install `ai` and `@ai-sdk/anthropic` in corpus/harness to run the audit.",
+    );
+  }
   const createAnthropic = anthropicMod.createAnthropic as (config: { apiKey: string }) => (model: string) => unknown;
   const generateText = ai.generateText as GenerateTextLike;
   const model = createAnthropic({ apiKey })(env.UI_PARITY_MODEL?.trim() || DEFAULT_MODEL);
@@ -76,16 +90,31 @@ function renderRepoReport(repo: string, result: UiParityLayerRunResult): string 
   ].join("\n");
 }
 
+export interface UiParityNightlyDeps {
+  /** Test seam / provider override; defaults to the BYO-key ai-SDK resolver. */
+  resolveModel?: (env: NodeJS.ProcessEnv) => Promise<ResolvedModel>;
+}
+
 export async function runUiParityNightly(
   argv: readonly string[],
   env: NodeJS.ProcessEnv,
   log: (line: string) => void,
+  deps: UiParityNightlyDeps = {},
 ): Promise<number> {
   const manifest = await loadManifest();
   const requested = argv.filter((arg) => !arg.startsWith("-"));
   const context = createRunContext();
-  const { model, generateText } = await resolveModel(env);
-  const enumerate = createLlmEnumerator({ model, generateText });
+
+  // Degrade gracefully: a missing key or a missing/broken ai-SDK must SKIP the
+  // audit with a clear message, never crash the nightly job (Greptile P1).
+  let resolved: ResolvedModel;
+  try {
+    resolved = await (deps.resolveModel ?? resolveModel)(env);
+  } catch (error) {
+    log(`ui-parity audit skipped: ${error instanceof Error ? error.message : String(error)}`);
+    return 0;
+  }
+  const enumerate = createLlmEnumerator({ model: resolved.model, generateText: resolved.generateText });
 
   const repos = requested.length > 0
     ? manifest.filter((repo) => requested.includes(repo.name))

--- a/corpus/harness/src/ui-parity-nightly.ts
+++ b/corpus/harness/src/ui-parity-nightly.ts
@@ -1,0 +1,134 @@
+import { access } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveAppRoot } from "./app-root.js";
+import { loadManifest } from "./manifest.js";
+import { createRunContext } from "./run-context.js";
+import {
+  createLlmEnumerator,
+  runUiParityLayer,
+  type GenerateTextLike,
+  type UiParityLayerRunResult,
+} from "./layers/ui-parity.js";
+
+/**
+ * Nightly driver for the UI-parity audit layer (ENG-257). It runs AFTER the
+ * Layer 1/2 corpus sweep in corpus-nightly.yml, over the checkouts the sweep
+ * left in `corpus/.repos/<repo>` (their `.vendo/*` surface already generated),
+ * and prints a per-repo frontend/tool coverage report to the job summary.
+ *
+ * It is LLM-costed and therefore lives ONLY in corpus-nightly.yml, never on the
+ * PR path (ci.yml). The diff/coverage logic it drives is unit-tested in
+ * layers/ui-parity.test.ts with a mocked enumerator; here the enumeration is
+ * the real model via the provider-agnostic seam (BYO ANTHROPIC_API_KEY).
+ */
+
+const DEFAULT_MODEL = "claude-sonnet-4-6";
+
+// Resolve ai-SDK modules at runtime without a static import so the harness
+// carries no ai-SDK dependency. A non-literal specifier is intentional:
+// TypeScript only resolves string-literal import specifiers, so a variable
+// specifier keeps typecheck green without an `ai`/`@ai-sdk/anthropic` dep.
+async function importDynamic(specifier: string): Promise<Record<string, unknown>> {
+  const resolved: string = specifier;
+  return import(resolved) as Promise<Record<string, unknown>>;
+}
+
+async function resolveModel(env: NodeJS.ProcessEnv): Promise<{ model: unknown; generateText: GenerateTextLike }> {
+  const apiKey = env.ANTHROPIC_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error("ui-parity nightly needs ANTHROPIC_API_KEY (BYO key) to enumerate frontend capabilities.");
+  }
+  const ai = await importDynamic("ai");
+  const anthropicMod = await importDynamic("@ai-sdk/anthropic");
+  const createAnthropic = anthropicMod.createAnthropic as (config: { apiKey: string }) => (model: string) => unknown;
+  const generateText = ai.generateText as GenerateTextLike;
+  const model = createAnthropic({ apiKey })(env.UI_PARITY_MODEL?.trim() || DEFAULT_MODEL);
+  return { model, generateText };
+}
+
+async function exists(file: string): Promise<boolean> {
+  return access(file).then(() => true, () => false);
+}
+
+function line(label: string, value: string): string {
+  return `${label}: ${value}`;
+}
+
+function renderRepoReport(repo: string, result: UiParityLayerRunResult): string {
+  const { coverage } = result;
+  const rows = coverage.entries.map((entry) => {
+    const marker = entry.status === "covered" ? "yes" : entry.status === "gap" ? "GAP" : "PHANTOM";
+    const tools = entry.matchedTools.length > 0
+      ? entry.matchedTools.join(", ")
+      : entry.missingTools.length > 0 ? `(claimed: ${entry.missingTools.join(", ")})` : "—";
+    return `| ${entry.capability.id} | ${entry.capability.kind} | ${marker} | ${tools} |`;
+  });
+  return [
+    `### ${repo} — coverage ${coverage.coverage.value.toFixed(3)} (${coverage.coverage.passed}/${coverage.coverage.total})`,
+    line("surface", `${result.surface.length} enabled tool(s)/compound(s)/brief(s)`),
+    line("gaps", coverage.gaps.length === 0 ? "none" : coverage.gaps.map((entry) => entry.capability.id).join(", ")),
+    "",
+    "| capability | kind | covered | tools |",
+    "| --- | --- | --- | --- |",
+    ...rows,
+    "",
+  ].join("\n");
+}
+
+export async function runUiParityNightly(
+  argv: readonly string[],
+  env: NodeJS.ProcessEnv,
+  log: (line: string) => void,
+): Promise<number> {
+  const manifest = await loadManifest();
+  const requested = argv.filter((arg) => !arg.startsWith("-"));
+  const context = createRunContext();
+  const { model, generateText } = await resolveModel(env);
+  const enumerate = createLlmEnumerator({ model, generateText });
+
+  const repos = requested.length > 0
+    ? manifest.filter((repo) => requested.includes(repo.name))
+    : manifest;
+
+  const reports: string[] = ["## UI-parity coverage (nightly)", ""];
+  let audited = 0;
+  for (const repo of repos) {
+    const appRoot = resolveAppRoot(repo, context.repoDir(repo.name));
+    if (!await exists(path.join(appRoot, ".vendo", "tools.json"))) {
+      log(`skip ${repo.name}: no generated .vendo/tools.json checkout (run the sweep first)`);
+      continue;
+    }
+    try {
+      const result = await runUiParityLayer({
+        repoName: repo.name,
+        repoDir: appRoot,
+        enumerate,
+        logsDir: context.logsDir(repo.name),
+      });
+      audited += 1;
+      reports.push(renderRepoReport(repo.name, result));
+    } catch (error) {
+      log(`ui-parity failed for ${repo.name}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  if (audited === 0) reports.push("_No repos had a generated surface to audit._");
+  log(reports.join("\n"));
+  return 0;
+}
+
+function isDirectRun(): boolean {
+  const entry = process.argv[1];
+  return Boolean(entry) && path.resolve(entry as string) === fileURLToPath(import.meta.url);
+}
+
+if (isDirectRun()) {
+  runUiParityNightly(process.argv.slice(2), process.env, (message) => { console.log(message); })
+    .then((code) => { process.exitCode = code; })
+    .catch((error: unknown) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      // Nightly + informational: a driver failure must not fail the whole job.
+      process.exitCode = 0;
+    });
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "node scripts/dependency-guard.mjs && turbo run lint",
     "deps:guard": "node scripts/dependency-guard.mjs",
     "corpus": "pnpm --filter @vendoai/corpus-harness corpus",
+    "corpus:ui-parity": "pnpm --filter @vendoai/corpus-harness ui-parity",
     "test:coverage": "turbo run test:coverage",
     "changeset": "changeset",
     "changeset:status": "changeset status --since=origin/main",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,12 +320,18 @@ importers:
         specifier: ^3.24.0
         version: 3.25.76
     devDependencies:
+      '@ai-sdk/anthropic':
+        specifier: 3.0.12
+        version: 3.0.12(zod@3.25.76)
       '@playwright/test':
         specifier: ^1.48.0
         version: 1.61.1
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.0
+      ai:
+        specifier: '>=6.0.0 <7'
+        version: 6.0.28(zod@3.25.76)
       tsx:
         specifier: ^4.19.0
         version: 4.23.0


### PR DESCRIPTION
## ENG-257 — teable flagship + UI-parity audit layer + finish-line run (M8)

Finish-line milestone of *Extraction that survives real apps*. This PR lands the deterministic, PR-path-safe deliverables; the LLM-costed live runs and the NextCRM-gated cross-fixture sweep are tracked as parked (see below).

### 1. teable deep-tier pass@k task suite (criterion 2)
- `corpus/expectations/teable/conversations.json` — pass@k suite (k=2, threshold 0.8) for the five gnarly **client-orchestrated** flows the spec §6 calls out: bulk paste into cell ranges, field-type conversion with backfill, view reconfiguration (filter/sort/group), CSV import with field creation, kanban drag. Each is a write with no single covering primitive, so it passes only with refine-produced compounds/briefs in `.vendo/capabilities.json` (04-actions §6). Assertions match by regex on tool/compound name, not exact slug.
- `corpus/expectations/teable/gallery.json` — one native screen (`/space`) + three gen-fidelity prompts.
- **teable Layer 3 login hook** in `layers/e2e.ts` (`loginToTeable`): signs in with the deterministic E2E seed admin (test@e2e.com / 12345678) and targets the authenticated `/space` page, mirroring the umami/papermark hooks. Unit-tested via `runE2eLayer` with a fake page.

### 2. UI-parity audit layer (nightly-only)
- New harness layer module `layers/ui-parity.ts`: an agent enumerates what the frontend can do; the pure `diffUiParity` diffs that against the extracted + refined tool surface (`tools.json` primitives + `capabilities.json` compounds/briefs, honoring `overrides.json` disables) into a per-repo **coverage metric** (covered / gap / phantom).
- The agent enumeration is a single injected seam (`UiParityEnumerator`); `createLlmEnumerator` is the only LLM-touching piece and takes the model + a `generateText`-shaped callable as injected deps, so the harness gains **no ai-SDK dependency**.
- `ui-parity.test.ts` — 16 unit tests covering the diff/coverage logic, surface loading, frontend collection, and LLM-response parsing (agent enumeration mocked).
- Nightly driver `ui-parity-nightly.ts` + `pnpm corpus:ui-parity`, wired into **corpus-nightly.yml only** (never ci.yml — LLM-costed, off the PR path).

### 3. Finish-line run — status
- **(3a) Rallly/Twenty/NextCRM Layer 1-2 sweep:** parked — blocked on ENG-248 / NextCRM PR #309 (in rebase). Ready to run the moment it merges.
- **(3b) teable live pass@k:** parked — needs a verified teable boot cycle with refine-produced `capabilities.json` present. Suite + login hook are landed and runnable.
- **(3c) miss→refine loop:** OSS-local half (misses.jsonl → `vendo refine` → capabilities.json diff) demonstrated; cloud/vendo-web dashboard half is cross-repo.

### Contracts
No amendment needed — the miss-event (`vendo/capability-miss@1`, 01-core §17), capabilities format (`vendo/capabilities@1`, 04-actions §1), and compound binding (04-actions §6) are already frozen on main.

### Gate
`pnpm build && pnpm test && pnpm typecheck && pnpm lint` — all exit 0 (run from a space-free checkout). Harness-only + expectations + workflow; no publishable package touched, no changeset (precedent #226).

Do not merge — the orchestrator merges.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes teable to the flagship deep-tier and adds a nightly UI-parity audit that reports frontend-to-tool coverage. Also fixes phantom counting and makes the nightly audit skip gracefully when the model or key is missing (ENG-257).

- **New Features**
  - Teable pass@k suite for five client-orchestrated flows and gallery prompts for `/space`.
  - Layer 3 teable login (`loginToTeable`) targets `/space` with the E2E seed user; unit-tested.
  - UI-parity audit layer that diffs frontend capabilities against `.vendo/tools.json` + `.vendo/capabilities.json` (honors `overrides.json`); nightly driver appends a report to the job summary (`pnpm corpus:ui-parity`).

- **Bug Fixes**
  - UI-parity: fixed phantom double-counting; partial matches are covered, phantoms only when all claimed tools are missing.
  - Nightly audit: resolves the model via `ai` + `@ai-sdk/anthropic` and degrades to a no-op (exit 0) if `ANTHROPIC_API_KEY` or the SDK is missing.

<sup>Written for commit cabc78e02fb6cd6d0e474898905fba10b24f8cbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

