### PR TITLE
feat(apps): guarded per-secret in-sandbox exposure toggle (ENG-345) [PARKED]

### DIFF
--- a/.changeset/eng-345-secret-exposure-toggle.md
+++ b/.changeset/eng-345-secret-exposure-toggle.md
@@ -1,0 +1,12 @@
+---
+"@vendoai/apps": minor
+---
+
+feat(apps): guarded per-secret in-sandbox exposure toggle (ENG-345)
+
+Adds the off-by-default exception path to the Option B secrets gateway: an
+owner-only, per-secret × per-app toggle that injects a secret's real value into
+the sandbox env instead of a handle. Flipping it on is a high-risk action gated
+by the guard's existing approval flow; every run with an exposed secret emits an
+audit event; and the grant lives outside the app document so it never travels
+with a share, remix, fork, export, or import (copies always revert to handles).

--- a/packages/apps/src/index.ts
+++ b/packages/apps/src/index.ts
@@ -21,8 +21,15 @@ export {
   type EditResult,
   type OpenSurface,
   type PinRebaseResult,
+  type SecretExposureState,
+  type SetExposureResult,
   type VersionEntry,
 } from "./runtime.js";
+export {
+  createSecretExposure,
+  type SecretExposure,
+  type SecretExposureGrant,
+} from "./secret-exposure.js";
 export type { SandboxAdapter, SandboxMachine } from "./sandbox.js";
 export {
   shareSnapshotSchema,

--- a/packages/apps/src/machine.ts
+++ b/packages/apps/src/machine.ts
@@ -49,8 +49,11 @@ export interface MachineSessionsConfig {
    */
   resolveExposedSecrets?: (app: AppDocument) => Promise<Set<string>>;
   /**
-   * ENG-345 — emit one audit event for a run that executes with a secret exposed
-   * in-sandbox (via the guard's existing report seam). Constraint 4.
+   * ENG-345 — emit one audit event for a run whose machine this runtime boots
+   * with a secret ACTUALLY exposed in-sandbox (via the guard's existing report
+   * seam). Constraint 4. Fired at the injection point (adapter.create), so it
+   * can never report an exposed run for a handle-only machine — including the
+   * resume path, which cannot inject env and therefore never triggers it.
    */
   reportExposedRun?: (app: AppDocument, ctx: RunContext, secrets: string[]) => Promise<void>;
 }
@@ -107,29 +110,9 @@ export const createMachineSessions = (config: MachineSessionsConfig): MachineSes
     return config.sandbox;
   };
 
-  // ENG-345 — a run touches a real sandbox (so a secret can actually be exposed
-  // in-sandbox) only when the app is machine-backed. A rung-1 pure-tree app has
-  // no machine, so an exposure grant on it exposes nothing and audits nothing.
-  const machineBacked = (app: AppDocument): boolean =>
-    app.server !== undefined || app.ui === "http";
-
-  const newRun = async (
-    app: AppDocument,
-    ctx: RunContext,
-    opts: { auditExposure?: boolean } = {},
-  ): Promise<MachineAuthorization> => {
+  const newRun = async (app: AppDocument, ctx: RunContext): Promise<MachineAuthorization> => {
     const runId = `run_${globalThis.crypto.randomUUID()}`;
     const jti = `jti_${randomHex(16)}`; // 128-bit anti-replay nonce (ENG-251)
-    // ENG-345 — one exposed-run audit per run (open()/call()) that executes with
-    // an in-sandbox exposure grant active on a machine-backed app (constraint 4).
-    if (opts.auditExposure === true
-      && machineBacked(app)
-      && config.resolveExposedSecrets !== undefined
-      && config.reportExposedRun !== undefined) {
-      const exposed = await config.resolveExposedSecrets(app);
-      const present = (app.secrets ?? []).filter((name) => exposed.has(name));
-      if (present.length > 0) await config.reportExposedRun(app, ctx, present);
-    }
     return {
       runId,
       jti,
@@ -144,7 +127,10 @@ export const createMachineSessions = (config: MachineSessionsConfig): MachineSes
     };
   };
 
-  const environment = async (app: AppDocument, runToken: string): Promise<Record<string, string>> => {
+  const environment = async (
+    app: AppDocument,
+    runToken: string,
+  ): Promise<{ env: Record<string, string>; injected: string[] }> => {
     // ENG-345 — the ONE place a secret's real value can replace its handle in the
     // sandbox env, and ONLY for a secret with an active exposure grant (the
     // exception to §4.3). Every other secret stays an opaque handle (Option B).
@@ -153,22 +139,40 @@ export const createMachineSessions = (config: MachineSessionsConfig): MachineSes
       : await config.resolveExposedSecrets(app);
     const nonce = randomHex(4);
     const secretEnv: Record<string, string> = {};
+    const injected: string[] = [];
     for (const name of app.secrets ?? []) {
       if (exposed.has(name) && config.secrets !== undefined) {
         const value = await config.secrets.get(name);
         if (typeof value === "string" && value.length > 0) {
           secretEnv[name] = value; // exposed: REAL value in-sandbox
+          injected.push(name);
           continue;
         }
       }
       secretEnv[name] = `vendo-secret:${name}:${nonce}`; // default: opaque handle
     }
     return {
-      ...secretEnv,
-      PORT,
-      ...(config.proxyUrl === undefined ? {} : { VENDO_PROXY_URL: config.proxyUrl }),
-      VENDO_RUN_TOKEN: runToken,
+      env: {
+        ...secretEnv,
+        PORT,
+        ...(config.proxyUrl === undefined ? {} : { VENDO_PROXY_URL: config.proxyUrl }),
+        VENDO_RUN_TOKEN: runToken,
+      },
+      injected,
     };
+  };
+
+  // ENG-345 — one audit event per run whose machine this runtime boots with a
+  // secret ACTUALLY exposed in-sandbox (constraint 4). Emitted at the injection
+  // point (adapter.create), so it is impossible to report an exposed run for a
+  // machine that carries only handles — including the resume path, which cannot
+  // inject env (adapter.resume takes no env) and therefore never audits here.
+  const auditInjection = async (
+    app: AppDocument,
+    ctx: RunContext,
+    injected: string[],
+  ): Promise<void> => {
+    if (injected.length > 0) await config.reportExposedRun?.(app, ctx, injected);
   };
 
   const start = async (
@@ -183,15 +187,16 @@ export const createMachineSessions = (config: MachineSessionsConfig): MachineSes
     if (pending !== undefined) return pending;
 
     const fresh = app.server === undefined;
-    const promise = app.server === undefined
+    const built = fresh ? await environment(app, auth.runToken) : undefined;
+    const promise = built !== undefined
       ? adapter.create({
-        env: await environment(app, auth.runToken),
+        env: built.env,
         // ENG-290 M4 — every fresh machine carries the egress fetch shim; the
         // boot convention (runtime.ts) requires it into the app's node processes.
         files: { [FETCH_SHIM_PATH]: FETCH_SHIM_SOURCE },
         egress: app.egress,
       })
-      : adapter.resume(app.server);
+      : adapter.resume(app.server as string);
     waking.set(app.id, promise);
     try {
       const machine = await promise;
@@ -199,6 +204,9 @@ export const createMachineSessions = (config: MachineSessionsConfig): MachineSes
       // Only a freshly created machine carries THIS run's env token; a resume
       // keeps its snapshot-time token, whose jti is not ours to burn.
       if (fresh) envJti.set(app.id, auth.jti);
+      // ENG-345 — audit the exposed run at the moment real values enter the
+      // sandbox (fresh boot only). A resume injects nothing, so it never fires.
+      if (built !== undefined) await auditInjection(app, ctx, built.injected);
       return machine;
     } finally {
       if (waking.get(app.id) === promise) waking.delete(app.id);
@@ -211,7 +219,7 @@ export const createMachineSessions = (config: MachineSessionsConfig): MachineSes
     fn: (run: MachineRun) => Promise<T>,
   ): Promise<T> => {
     requireAdapter();
-    const run = await newRun(app, ctx, { auditExposure: true });
+    const run = await newRun(app, ctx);
     const machine = await start(app, ctx, run);
     return fn({ machine, ...run });
   };
@@ -234,13 +242,20 @@ export const createMachineSessions = (config: MachineSessionsConfig): MachineSes
   ): Promise<T> => {
     const adapter = requireAdapter();
     const run = await newRun(app, ctx);
-    const machine = app.server === undefined
-      ? await adapter.create({
-        env: await environment(app, run.runToken),
-        files: { [FETCH_SHIM_PATH]: FETCH_SHIM_SOURCE },
-        egress: app.egress,
-      })
-      : await adapter.resume(app.server);
+    if (app.server !== undefined) {
+      const machine = await adapter.resume(app.server);
+      return fn({ machine, ...run });
+    }
+    // A fresh edit/graduation fork bakes the current exposure state into its
+    // snapshot: this is the materialization path for a served app (its next
+    // snapshot carries the real value the owner approved). Audit that boot too.
+    const built = await environment(app, run.runToken);
+    const machine = await adapter.create({
+      env: built.env,
+      files: { [FETCH_SHIM_PATH]: FETCH_SHIM_SOURCE },
+      egress: app.egress,
+    });
+    await auditInjection(app, ctx, built.injected);
     return fn({ machine, ...run });
   };
 
@@ -251,12 +266,16 @@ export const createMachineSessions = (config: MachineSessionsConfig): MachineSes
   ): Promise<string> => {
     const adapter = requireAdapter();
     const run = await newRun(app, ctx);
+    // An imported app has a fresh AppId with no grants, so environment() injects
+    // no real values here — a copy always boots handle-only (constraint 5).
+    const built = await environment(app, run.runToken);
     const machine = await adapter.create({
-      env: await environment(app, run.runToken),
+      env: built.env,
       files: { ...files, [FETCH_SHIM_PATH]: FETCH_SHIM_SOURCE },
       egress: app.egress,
     });
     try {
+      await auditInjection(app, ctx, built.injected);
       return await machine.snapshot();
     } finally {
       await machine.stop().catch(() => undefined);
@@ -282,8 +301,7 @@ export const createMachineSessions = (config: MachineSessionsConfig): MachineSes
     available: () => config.sandbox !== undefined,
     peek: (appId) => live.get(appId),
     isWaking: (appId) => waking.has(appId),
-    // open() mints one run and fans it out to every query — audit exposure once here.
-    mintRun: (app, ctx) => newRun(app, ctx, { auditExposure: true }),
+    mintRun: newRun,
     wake(app, ctx, authorization) {
       if (live.has(app.id) || waking.has(app.id)) return;
       requireAdapter();

--- a/packages/apps/src/machine.ts
+++ b/packages/apps/src/machine.ts
@@ -1,4 +1,4 @@
-import { VendoError, type AppDocument, type RunContext } from "@vendoai/core";
+import { VendoError, type AppDocument, type RunContext, type SecretsProvider } from "@vendoai/core";
 import { mintRunToken, type RunTokenSecret } from "./run-token.js";
 import type { RunTokenGate } from "./run-token-gate.js";
 import type { SandboxAdapter, SandboxMachine } from "./sandbox.js";
@@ -35,6 +35,24 @@ export interface MachineSessionsConfig {
       machine is torn down its env token's jti is burned here, revoking the token
       before its TTL elapses. */
   consumedRunTokens?: RunTokenGate;
+  /**
+   * ENG-345 — resolves real secret values, the SAME seam the egress proxy uses.
+   * Consulted ONLY for a secret with an active in-sandbox exposure grant; a
+   * secret with no grant stays a handle (Option B default, §4.3).
+   */
+  secrets?: SecretsProvider;
+  /**
+   * ENG-345 — the set of declared secret names currently exposed in-sandbox for
+   * this app (its active exposure grants). Absent → nothing is exposed, so every
+   * secret is a handle. Injected by the runtime from the exposure store so this
+   * cache reads the current grant state at every boot.
+   */
+  resolveExposedSecrets?: (app: AppDocument) => Promise<Set<string>>;
+  /**
+   * ENG-345 — emit one audit event for a run that executes with a secret exposed
+   * in-sandbox (via the guard's existing report seam). Constraint 4.
+   */
+  reportExposedRun?: (app: AppDocument, ctx: RunContext, secrets: string[]) => Promise<void>;
 }
 
 /** 06-apps §4.2 — cache, boot, and resume live machines by app id. */
@@ -89,9 +107,29 @@ export const createMachineSessions = (config: MachineSessionsConfig): MachineSes
     return config.sandbox;
   };
 
-  const newRun = async (app: AppDocument, ctx: RunContext): Promise<MachineAuthorization> => {
+  // ENG-345 — a run touches a real sandbox (so a secret can actually be exposed
+  // in-sandbox) only when the app is machine-backed. A rung-1 pure-tree app has
+  // no machine, so an exposure grant on it exposes nothing and audits nothing.
+  const machineBacked = (app: AppDocument): boolean =>
+    app.server !== undefined || app.ui === "http";
+
+  const newRun = async (
+    app: AppDocument,
+    ctx: RunContext,
+    opts: { auditExposure?: boolean } = {},
+  ): Promise<MachineAuthorization> => {
     const runId = `run_${globalThis.crypto.randomUUID()}`;
     const jti = `jti_${randomHex(16)}`; // 128-bit anti-replay nonce (ENG-251)
+    // ENG-345 — one exposed-run audit per run (open()/call()) that executes with
+    // an in-sandbox exposure grant active on a machine-backed app (constraint 4).
+    if (opts.auditExposure === true
+      && machineBacked(app)
+      && config.resolveExposedSecrets !== undefined
+      && config.reportExposedRun !== undefined) {
+      const exposed = await config.resolveExposedSecrets(app);
+      const present = (app.secrets ?? []).filter((name) => exposed.has(name));
+      if (present.length > 0) await config.reportExposedRun(app, ctx, present);
+    }
     return {
       runId,
       jti,
@@ -106,12 +144,25 @@ export const createMachineSessions = (config: MachineSessionsConfig): MachineSes
     };
   };
 
-  const environment = (app: AppDocument, runToken: string): Record<string, string> => {
+  const environment = async (app: AppDocument, runToken: string): Promise<Record<string, string>> => {
+    // ENG-345 — the ONE place a secret's real value can replace its handle in the
+    // sandbox env, and ONLY for a secret with an active exposure grant (the
+    // exception to §4.3). Every other secret stays an opaque handle (Option B).
+    const exposed = config.resolveExposedSecrets === undefined
+      ? new Set<string>()
+      : await config.resolveExposedSecrets(app);
     const nonce = randomHex(4);
-    const secretEnv = Object.fromEntries((app.secrets ?? []).map((name) => [
-      name,
-      `vendo-secret:${name}:${nonce}`,
-    ]));
+    const secretEnv: Record<string, string> = {};
+    for (const name of app.secrets ?? []) {
+      if (exposed.has(name) && config.secrets !== undefined) {
+        const value = await config.secrets.get(name);
+        if (typeof value === "string" && value.length > 0) {
+          secretEnv[name] = value; // exposed: REAL value in-sandbox
+          continue;
+        }
+      }
+      secretEnv[name] = `vendo-secret:${name}:${nonce}`; // default: opaque handle
+    }
     return {
       ...secretEnv,
       PORT,
@@ -134,7 +185,7 @@ export const createMachineSessions = (config: MachineSessionsConfig): MachineSes
     const fresh = app.server === undefined;
     const promise = app.server === undefined
       ? adapter.create({
-        env: environment(app, auth.runToken),
+        env: await environment(app, auth.runToken),
         // ENG-290 M4 — every fresh machine carries the egress fetch shim; the
         // boot convention (runtime.ts) requires it into the app's node processes.
         files: { [FETCH_SHIM_PATH]: FETCH_SHIM_SOURCE },
@@ -160,7 +211,7 @@ export const createMachineSessions = (config: MachineSessionsConfig): MachineSes
     fn: (run: MachineRun) => Promise<T>,
   ): Promise<T> => {
     requireAdapter();
-    const run = await newRun(app, ctx);
+    const run = await newRun(app, ctx, { auditExposure: true });
     const machine = await start(app, ctx, run);
     return fn({ machine, ...run });
   };
@@ -185,7 +236,7 @@ export const createMachineSessions = (config: MachineSessionsConfig): MachineSes
     const run = await newRun(app, ctx);
     const machine = app.server === undefined
       ? await adapter.create({
-        env: environment(app, run.runToken),
+        env: await environment(app, run.runToken),
         files: { [FETCH_SHIM_PATH]: FETCH_SHIM_SOURCE },
         egress: app.egress,
       })
@@ -201,7 +252,7 @@ export const createMachineSessions = (config: MachineSessionsConfig): MachineSes
     const adapter = requireAdapter();
     const run = await newRun(app, ctx);
     const machine = await adapter.create({
-      env: environment(app, run.runToken),
+      env: await environment(app, run.runToken),
       files: { ...files, [FETCH_SHIM_PATH]: FETCH_SHIM_SOURCE },
       egress: app.egress,
     });
@@ -231,7 +282,8 @@ export const createMachineSessions = (config: MachineSessionsConfig): MachineSes
     available: () => config.sandbox !== undefined,
     peek: (appId) => live.get(appId),
     isWaking: (appId) => waking.has(appId),
-    mintRun: newRun,
+    // open() mints one run and fans it out to every query — audit exposure once here.
+    mintRun: (app, ctx) => newRun(app, ctx, { auditExposure: true }),
     wake(app, ctx, authorization) {
       if (live.has(app.id) || waking.has(app.id)) return;
       requireAdapter();

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -8,10 +8,12 @@ import {
   type IsoDateTime,
   type Json,
   type RunContext,
+  type ApprovalId,
   type RiskLabel,
   type SecretsProvider,
   type StoreAdapter,
   type ToolCall,
+  type ToolDescriptor,
   type ToolOutcome,
   type ToolRegistry,
   type Tree,
@@ -46,6 +48,7 @@ import { appRecordInput, documentFromRecord, enabledAfterDocumentEdit, rowFromRe
 import { detectPinDrift, hasDefaultExport, pinComponentName, pinForkSource, type InClientApproval, type PinBaseline, type PinDrift } from "./pins.js";
 import { createAppsProxy } from "./proxy.js";
 import { createRunTokenGate } from "./run-token-gate.js";
+import { createSecretExposure, type SecretExposureGrant } from "./secret-exposure.js";
 import { computeShipDiff, type ShipDiff } from "./ship-diff.js";
 import { appVersionHash } from "./version-hash.js";
 import type { SandboxAdapter } from "./sandbox.js";
@@ -111,6 +114,24 @@ export type OpenSurface =
 export interface AppsProxy {
   handler(request: Request): Promise<Response>;
 }
+
+/**
+ * ENG-345 — the in-sandbox status of one declared secret for one app.
+ * `handle` is the Option B default; `exposed` means an active owner-approved
+ * grant places its real value in the sandbox env; `pending` means a flip-on is
+ * parked awaiting the high-risk guard approval.
+ */
+export interface SecretExposureState {
+  secretName: string;
+  status: "handle" | "pending" | "exposed";
+  approvalId?: ApprovalId;
+}
+
+/** ENG-345 — the outcome of a setExposure() call. */
+export type SetExposureResult =
+  | { status: "handles" }
+  | { status: "exposed" }
+  | { status: "pending-approval"; approvalId: ApprovalId };
 
 /**
  * 06-apps §8 — the outcome of one pin rebase. `failed` persists NOTHING: the
@@ -191,6 +212,30 @@ export interface AppsRuntime {
   pins: {
     drift(appId: AppId, ctx: RunContext): Promise<PinDrift[]>;
     rebase(input: { appId: AppId; slot: string }, ctx: RunContext): Promise<PinRebaseResult>;
+  };
+  /**
+   * ENG-345 — additive guarded per-secret in-sandbox exposure surface (same
+   * additive precedent as `inClient`/`pins`, not part of the frozen §1 method
+   * table). Option B (handles + egress substitution) stays the default; this is
+   * the exception path, off by default, per-secret × per-app, OWNER-ONLY, and
+   * gated by the guard's existing high-risk approval flow. The grant NEVER
+   * travels with a copy: it lives in its own store collection keyed by the app
+   * id, so exportApp/importApp/fork/share/publish (all of which mint or copy a
+   * fresh app id) can never carry it. Requires a docs/contracts/06-apps.md §4.3
+   * amendment (parked, Yousef-gated).
+   */
+  secrets: {
+    /** Current in-sandbox status of every declared secret for one app (owner-only). */
+    exposure(appId: AppId, ctx: RunContext): Promise<SecretExposureState[]>;
+    /**
+     * Flip one secret's in-sandbox exposure. Turning ON routes through the
+     * guard's high-risk approval flow and returns `pending-approval` until the
+     * owner decides it; turning OFF reverts to handles immediately.
+     */
+    setExposure(
+      input: { appId: AppId; secretName: string; expose: boolean },
+      ctx: RunContext,
+    ): Promise<SetExposureResult>;
   };
 }
 
@@ -327,11 +372,46 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
   // ENG-251 — one anti-replay gate shared by the machine cache (which burns a
   // run's jti on teardown) and the proxy (which rejects a burned jti).
   const consumedRunTokens = createRunTokenGate();
+  // ENG-345 — per-secret × per-app in-sandbox exposure grants. A dedicated store
+  // collection, NEVER part of the app document, so no copy path can carry it.
+  const exposure = createSecretExposure(config.store);
+
+  const reportGuard = async (
+    kind: "app-lifecycle",
+    principalSubject: string,
+    appId: AppId,
+    ctx: Pick<RunContext, "venue" | "presence"> & { trigger?: RunContext["trigger"] },
+    detail: Record<string, Json>,
+  ): Promise<void> => {
+    await config.guard.report({
+      id: `aud_${globalThis.crypto.randomUUID()}`,
+      at: new Date().toISOString(),
+      kind,
+      principal: { kind: "user", subject: principalSubject },
+      venue: ctx.venue,
+      presence: ctx.presence,
+      appId,
+      ...(ctx.trigger === undefined ? {} : { trigger: { ...ctx.trigger } }),
+      outcome: "ok",
+      detail,
+    });
+  };
+
   const machines = createMachineSessions({
     sandbox: config.sandbox,
     proxyUrl: config.proxyUrl,
     tokenSecret,
     consumedRunTokens,
+    // ENG-345 — the machine cache injects a REAL value only for a secret with an
+    // active grant, and audits one exposed-run event per run. Same SecretsProvider
+    // seam the egress proxy uses; without it every secret stays a handle.
+    ...(config.secrets === undefined ? {} : { secrets: config.secrets }),
+    resolveExposedSecrets: (app) => exposure.activeNames(app.id),
+    reportExposedRun: (app, ctx, secrets) =>
+      reportGuard("app-lifecycle", ctx.principal.subject, app.id, ctx, {
+        operation: "secret-exposed-run",
+        secrets,
+      }),
   });
 
   const owned = async (appId: AppId, subject: string): Promise<AppDocument | null> => {
@@ -354,6 +434,57 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     pinBaselines: config.pinBaselines,
     requireOwned,
   });
+
+  // ENG-345 — turning a secret ON is a HIGH-RISK approval reusing the guard's
+  // existing critical-approval flow: check() with a critical descriptor parks an
+  // approval, and this subscription commits the parked exposure grant only when
+  // that approval is decided approved. Denial (or any non-approval) reverts it.
+  // This is the SAME onApprovalDecision seam automations use to resume a parked
+  // run — no parallel approval mechanism is introduced.
+  const EXPOSURE_TOOL = "vendo_secret_expose";
+  const exposureDescriptor = (): ToolDescriptor => ({
+    name: EXPOSURE_TOOL,
+    description: "Expose a declared secret's real value inside this app's sandbox (high-risk, owner-only).",
+    inputSchema: {
+      type: "object",
+      properties: { appId: { type: "string" }, secretName: { type: "string" } },
+      required: ["appId", "secretName"],
+    },
+    risk: "destructive",
+    critical: true,
+  });
+  // Stable across the park/approve phases so the real guard's approved-replay
+  // match (subject + call id + args + descriptor + venue/presence/app) lines up.
+  const exposureCall = (appId: AppId, secretName: string): ToolCall => ({
+    id: `call_expose_${appId}_${secretName}`,
+    tool: EXPOSURE_TOOL,
+    args: { appId, secretName },
+  });
+
+  const commitExposure = async (grant: SecretExposureGrant): Promise<void> => {
+    await exposure.activate(grant.appId, grant.secretName);
+    // Re-boot the machine so the next run's env reflects the new grant state.
+    await machines.evict(grant.appId);
+    await reportGuard("app-lifecycle", grant.owner, grant.appId, { venue: "app", presence: "present" }, {
+      operation: "secret-exposure-set",
+      secretName: grant.secretName,
+      expose: true,
+    });
+  };
+
+  const onApprovalDecision = async (id: ApprovalId, approved: boolean): Promise<void> => {
+    const parked = await exposure.byApproval(id);
+    for (const grant of parked) {
+      if (grant.status !== "pending") continue;
+      if (approved) {
+        await commitExposure(grant);
+      } else {
+        // Denied high-risk approval leaves the secret a handle (fail closed).
+        await exposure.revoke(grant.appId, grant.secretName);
+      }
+    }
+  };
+  config.guard.onApprovalDecision((id, approved) => onApprovalDecision(id, approved));
 
   const inClientApprovals = createInClientApprovals(config.store);
   const caller = createAppCaller(machines, config.tools);
@@ -662,6 +793,7 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       await data.clear(app, ctx.principal.subject, await history.documents(appId));
       await history.clear(appId);
       await inClientApprovals.clear(appId);
+      await exposure.clearForApp(appId);
       await apps.delete(appId);
       await reportLifecycle("delete", appId, ctx);
     },
@@ -990,6 +1122,84 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
           baseHash: baseline.hash,
           replayed,
         };
+      },
+    },
+
+    secrets: {
+      async exposure(appId, ctx) {
+        const app = await requireOwned(appId, ctx.principal.subject); // owner-only read
+        const grants = new Map((await exposure.list(appId)).map((grant) => [grant.secretName, grant]));
+        return (app.secrets ?? []).map((secretName) => {
+          const grant = grants.get(secretName);
+          if (grant === undefined) return { secretName, status: "handle" as const };
+          return grant.status === "active"
+            ? { secretName, status: "exposed" as const }
+            : { secretName, status: "pending" as const, approvalId: grant.approvalId };
+        });
+      },
+
+      async setExposure(input, ctx) {
+        // Owner-only: requireOwned throws not-found for any non-owner principal.
+        const app = await requireOwned(input.appId, ctx.principal.subject);
+        if (!(app.secrets ?? []).includes(input.secretName)) {
+          throw new VendoError("validation", `secret not declared by app: ${input.secretName}`);
+        }
+
+        if (input.expose === false) {
+          // Turning OFF is safe — revert to the Option B handle default at once.
+          await exposure.revoke(input.appId, input.secretName);
+          await machines.evict(input.appId);
+          await reportGuard("app-lifecycle", ctx.principal.subject, input.appId, ctx, {
+            operation: "secret-exposure-set",
+            secretName: input.secretName,
+            expose: false,
+          });
+          return { status: "handles" };
+        }
+
+        // Turning ON is HIGH-RISK: route through the guard's existing critical
+        // approval flow. appId is pinned in the guard ctx so the parked approval
+        // is app-scoped (and, for the real guard, so an approved replay matches).
+        const guardCtx: RunContext = { ...ctx, appId: input.appId };
+        const decision = await config.guard.check(
+          exposureCall(input.appId, input.secretName),
+          exposureDescriptor(),
+          guardCtx,
+        );
+        if (decision.action === "block") {
+          throw new VendoError("blocked", decision.reason);
+        }
+        if (decision.action === "run") {
+          // A pre-approved replay already cleared the high-risk gate — commit now.
+          const approvalId: ApprovalId = decision.grantId === undefined
+            ? `apr_replayed_${globalThis.crypto.randomUUID()}`
+            : `apr_${decision.grantId}`;
+          await exposure.putPending({
+            appId: input.appId,
+            secretName: input.secretName,
+            owner: ctx.principal.subject,
+            approvalId,
+            requestedAt: new Date().toISOString(),
+          });
+          await exposure.activate(input.appId, input.secretName);
+          await machines.evict(input.appId);
+          await reportGuard("app-lifecycle", ctx.principal.subject, input.appId, ctx, {
+            operation: "secret-exposure-set",
+            secretName: input.secretName,
+            expose: true,
+          });
+          return { status: "exposed" };
+        }
+        // Parked: record the pending grant against this approval; it flips to
+        // active only when onApprovalDecision fires with approved=true.
+        await exposure.putPending({
+          appId: input.appId,
+          secretName: input.secretName,
+          owner: ctx.principal.subject,
+          approvalId: decision.approval.id,
+          requestedAt: new Date().toISOString(),
+        });
+        return { status: "pending-approval", approvalId: decision.approval.id };
       },
     },
 

--- a/packages/apps/src/secret-exposure.test.ts
+++ b/packages/apps/src/secret-exposure.test.ts
@@ -1,0 +1,418 @@
+import type { AppDocument, AuditEvent, RunContext, ToolRegistry } from "@vendoai/core";
+import { VENDO_APP_FORMAT } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createApps } from "./index.js";
+import { createMachineSessions } from "./machine.js";
+import { substituteSecretHandles } from "./egress.js";
+import {
+  FakeSandboxMachine,
+  basicLanguageModel,
+  fakeSandbox,
+  guardFixture,
+  memoryStore,
+  seedAppRow,
+  type FakeSandboxAdapter,
+} from "./testing/index.js";
+
+// ENG-345 — guarded per-secret in-sandbox exposure toggle. The five locked
+// constraints, each with the test that proves it, plus the required red-team
+// pass. Option B (handles + egress substitution) stays the DEFAULT throughout;
+// this toggle is the OFF-by-default exception path.
+
+const SECRET_VALUES: Record<string, string> = {
+  STRIPE_KEY: "sk_live_REALSECRET",
+  OTHER: "other_real_value",
+};
+const secrets = { get: async (name: string): Promise<string | undefined> => SECRET_VALUES[name] };
+
+const tools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "error", error: { code: "not-found", message: "no tools" } }; },
+};
+
+const context = (subject: string): RunContext => ({
+  principal: { kind: "user", subject },
+  venue: "app",
+  presence: "present",
+  sessionId: `session_${subject}`,
+});
+
+const HANDLE = /^vendo-secret:[A-Za-z_][A-Za-z0-9_]*:[0-9a-f]+$/;
+
+const flush = async (): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+const waitFor = async (predicate: () => Promise<boolean>): Promise<void> => {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 2));
+  }
+  throw new Error("waitFor timed out");
+};
+
+const setup = () => {
+  const store = memoryStore();
+  const guard = guardFixture();
+  const sandbox = fakeSandbox();
+  const runtime = createApps({
+    store,
+    guard,
+    tools,
+    sandbox,
+    catalog: [],
+    secrets,
+    model: basicLanguageModel(),
+  });
+  return { store, guard, sandbox, runtime };
+};
+
+/** A valid rung-2 (tree + server) app owned by `subject`, declaring two secrets. */
+const seedServedApp = async (
+  store: ReturnType<typeof memoryStore>,
+  sandbox: FakeSandboxAdapter,
+  id: string,
+  subject: string,
+): Promise<AppDocument> => {
+  const machine = await sandbox.create({ env: { PORT: "8080" } });
+  const server = await machine.snapshot();
+  await machine.stop();
+  const app: AppDocument = {
+    format: VENDO_APP_FORMAT,
+    id,
+    name: "Payments",
+    ui: "tree",
+    tree: {
+      formatVersion: "vendo-genui/v1",
+      root: "root",
+      nodes: [{ id: "root", component: "Text", props: { text: "Payments" } }],
+    },
+    server,
+    secrets: ["STRIPE_KEY", "OTHER"],
+    egress: ["api.stripe.com"],
+  };
+  await seedAppRow(store, app, subject);
+  return app;
+};
+
+const statusOf = async (
+  runtime: ReturnType<typeof setup>["runtime"],
+  appId: string,
+  ctx: RunContext,
+  secretName: string,
+): Promise<string> => {
+  const states = await runtime.secrets.exposure(appId, ctx);
+  return states.find((state) => state.secretName === secretName)?.status ?? "missing";
+};
+
+const exposedRunEvents = (audit: AuditEvent[]): AuditEvent[] =>
+  audit.filter((event) => (event.detail as { operation?: string } | undefined)?.operation === "secret-exposed-run");
+
+/** Drive the owner-approved ON flip end to end. */
+const expose = async (
+  runtime: ReturnType<typeof setup>["runtime"],
+  guard: ReturnType<typeof guardFixture>,
+  appId: string,
+  ctx: RunContext,
+  secretName: string,
+): Promise<void> => {
+  const result = await runtime.secrets.setExposure({ appId, secretName, expose: true }, ctx);
+  if (result.status !== "pending-approval") throw new Error(`expected pending-approval, got ${result.status}`);
+  guard.decide(result.approvalId, true);
+  await waitFor(async () => await statusOf(runtime, appId, ctx, secretName) === "exposed");
+};
+
+// ── Constraint 1 + (a): Option B is the default; no opt-in → handle in sandbox env.
+describe("ENG-345 constraint 1 & (a) — Option B default: no grant leaves a handle in-sandbox", () => {
+  it("machine env carries an opaque handle, not the value, when nothing is exposed", async () => {
+    const sandbox = fakeSandbox();
+    const machines = createMachineSessions({
+      sandbox,
+      tokenSecret: new Uint8Array(32),
+      secrets,
+      resolveExposedSecrets: async () => new Set<string>(),
+      reportExposedRun: async () => undefined,
+    });
+    const app: AppDocument = {
+      format: VENDO_APP_FORMAT,
+      id: "app_default",
+      name: "n",
+      ui: "http",
+      secrets: ["STRIPE_KEY", "OTHER"],
+    };
+    await machines.withMachine(app, context("user_ada"), async ({ machine }) => {
+      const env = (machine as FakeSandboxMachine).env;
+      expect(env.STRIPE_KEY).toMatch(HANDLE);
+      expect(env.OTHER).toMatch(HANDLE);
+      expect(JSON.stringify(env)).not.toContain(SECRET_VALUES.STRIPE_KEY);
+    });
+  });
+
+  it("open() over an ungranted served app emits no exposed-run audit", async () => {
+    const { store, guard, sandbox, runtime } = setup();
+    await seedServedApp(store, sandbox, "app_plain", "user_ada");
+    guard.audit.length = 0;
+    await runtime.open("app_plain", context("user_ada"));
+    expect(exposedRunEvents(guard.audit)).toHaveLength(0);
+  });
+});
+
+// ── Constraint 2 + 3 + (b): owner-only opt-in, high-risk approval, denial leaves OFF.
+describe("ENG-345 constraint 2 & 3 & (b) — owner-only, approval-gated flip", () => {
+  it("a non-owner cannot set or read the toggle", async () => {
+    const { store, sandbox, runtime } = setup();
+    await seedServedApp(store, sandbox, "app_ada", "user_ada");
+    const bob = context("user_bob");
+    await expect(
+      runtime.secrets.setExposure({ appId: "app_ada", secretName: "STRIPE_KEY", expose: true }, bob),
+    ).rejects.toMatchObject({ code: "not-found" });
+    await expect(runtime.secrets.exposure("app_ada", bob)).rejects.toMatchObject({ code: "not-found" });
+  });
+
+  it("rejects a secret the app never declared", async () => {
+    const { store, sandbox, runtime } = setup();
+    await seedServedApp(store, sandbox, "app_ada", "user_ada");
+    await expect(
+      runtime.secrets.setExposure({ appId: "app_ada", secretName: "UNKNOWN", expose: true }, context("user_ada")),
+    ).rejects.toMatchObject({ code: "validation" });
+  });
+
+  it("owner flip ON parks on a high-risk approval; a DENIED approval leaves it OFF", async () => {
+    const { store, guard, sandbox, runtime } = setup();
+    await seedServedApp(store, sandbox, "app_ada", "user_ada");
+    const ada = context("user_ada");
+
+    const parked = await runtime.secrets.setExposure({ appId: "app_ada", secretName: "STRIPE_KEY", expose: true }, ada);
+    expect(parked.status).toBe("pending-approval");
+    // The flip rode the guard's CRITICAL approval flow (constraint 3).
+    expect(guard.approvals.some((approval) => approval.descriptor.critical === true)).toBe(true);
+    expect(await statusOf(runtime, "app_ada", ada, "STRIPE_KEY")).toBe("pending");
+
+    if (parked.status !== "pending-approval") throw new Error("unreachable");
+    guard.decide(parked.approvalId, false);
+    await flush();
+    expect(await statusOf(runtime, "app_ada", ada, "STRIPE_KEY")).toBe("handle");
+  });
+
+  it("owner flip ON becomes exposed only after the approval is APPROVED", async () => {
+    const { store, guard, sandbox, runtime } = setup();
+    await seedServedApp(store, sandbox, "app_ada", "user_ada");
+    const ada = context("user_ada");
+    await expose(runtime, guard, "app_ada", ada, "STRIPE_KEY");
+    expect(await statusOf(runtime, "app_ada", ada, "STRIPE_KEY")).toBe("exposed");
+    // OTHER was never touched — still a handle.
+    expect(await statusOf(runtime, "app_ada", ada, "OTHER")).toBe("handle");
+  });
+});
+
+// ── Constraint (c): ON+approved injects the REAL value into sandbox env.
+describe("ENG-345 (c) — an active grant injects the real value into sandbox env", () => {
+  it("machine env carries the real value for the granted secret and a handle for the rest", async () => {
+    const sandbox = fakeSandbox();
+    const machines = createMachineSessions({
+      sandbox,
+      tokenSecret: new Uint8Array(32),
+      secrets,
+      resolveExposedSecrets: async () => new Set(["STRIPE_KEY"]),
+      reportExposedRun: async () => undefined,
+    });
+    const app: AppDocument = {
+      format: VENDO_APP_FORMAT,
+      id: "app_exposed",
+      name: "n",
+      ui: "http",
+      secrets: ["STRIPE_KEY", "OTHER"],
+    };
+    await machines.withMachine(app, context("user_ada"), async ({ machine }) => {
+      const env = (machine as FakeSandboxMachine).env;
+      expect(env.STRIPE_KEY).toBe(SECRET_VALUES.STRIPE_KEY); // exception path
+      expect(env.OTHER).toMatch(HANDLE); // still the default
+    });
+  });
+});
+
+// ── Constraint 4 + (d): one audit event per run that executes with an exposed secret.
+describe("ENG-345 constraint 4 & (d) — one exposed-run audit per run", () => {
+  it("emits exactly one exposed-run event per run.mint, and none once machine-backed is false", async () => {
+    const sandbox = fakeSandbox();
+    const reported: string[][] = [];
+    const machines = createMachineSessions({
+      sandbox,
+      tokenSecret: new Uint8Array(32),
+      secrets,
+      resolveExposedSecrets: async () => new Set(["STRIPE_KEY"]),
+      reportExposedRun: async (_app, _ctx, names) => { reported.push(names); },
+    });
+    const httpApp: AppDocument = {
+      format: VENDO_APP_FORMAT, id: "app_http", name: "n", ui: "http", secrets: ["STRIPE_KEY"],
+    };
+    await machines.withMachine(httpApp, context("user_ada"), async () => undefined);
+    expect(reported).toEqual([["STRIPE_KEY"]]);
+
+    // A rung-1 tree app has no machine → an exposure grant exposes nothing → no audit.
+    const treeApp: AppDocument = {
+      format: VENDO_APP_FORMAT, id: "app_tree", name: "n", ui: "tree", secrets: ["STRIPE_KEY"],
+    };
+    reported.length = 0;
+    await machines.withMachine(treeApp, context("user_ada"), async () => undefined);
+    expect(reported).toEqual([]);
+  });
+
+  it("runtime open() emits one exposed-run event carrying the exposed secret name", async () => {
+    const { store, guard, sandbox, runtime } = setup();
+    await seedServedApp(store, sandbox, "app_srv", "user_ada");
+    const ada = context("user_ada");
+    await expose(runtime, guard, "app_srv", ada, "STRIPE_KEY");
+
+    guard.audit.length = 0;
+    await runtime.open("app_srv", ada);
+    const first = exposedRunEvents(guard.audit);
+    expect(first).toHaveLength(1);
+    expect((first[0]?.detail as { secrets?: string[] }).secrets).toEqual(["STRIPE_KEY"]);
+    expect(first[0]?.appId).toBe("app_srv");
+
+    await runtime.open("app_srv", ada);
+    expect(exposedRunEvents(guard.audit)).toHaveLength(2);
+  });
+});
+
+// ── Constraint 5 + (e): copies ALWAYS revert to handles — the grant never travels.
+describe("ENG-345 constraint 5 & (e) — the grant never travels with a copy", () => {
+  it("fork, export→import, and a foreign import all revert to handles while the source stays exposed", async () => {
+    const { store, guard, sandbox, runtime } = setup();
+    await seedServedApp(store, sandbox, "app_src", "user_ada");
+    const ada = context("user_ada");
+    await expose(runtime, guard, "app_src", ada, "STRIPE_KEY");
+
+    // fork
+    const forked = await runtime.fork("app_src", ada);
+    const forkStates = await runtime.secrets.exposure(forked.id, ada);
+    expect(forkStates.every((state) => state.status === "handle")).toBe(true);
+
+    // export → import (same owner)
+    const bytes = await runtime.exportApp("app_src", ada);
+    const imported = await runtime.importApp(bytes, ada);
+    expect(imported.id).not.toBe("app_src");
+    expect((await runtime.secrets.exposure(imported.id, ada)).every((state) => state.status === "handle")).toBe(true);
+
+    // import by a DIFFERENT principal (a remixer) — cannot inherit the grant
+    const bob = context("user_bob");
+    const importedByBob = await runtime.importApp(bytes, bob);
+    expect((await runtime.secrets.exposure(importedByBob.id, bob)).every((state) => state.status === "handle")).toBe(true);
+
+    // the ORIGINAL app is still exposed — the copies did not disturb it
+    expect(await statusOf(runtime, "app_src", ada, "STRIPE_KEY")).toBe("exposed");
+  });
+
+  it("deleting an app clears its exposure grants (no orphan can bind a re-minted id)", async () => {
+    const { store, guard, sandbox, runtime } = setup();
+    await seedServedApp(store, sandbox, "app_gone", "user_ada");
+    const ada = context("user_ada");
+    await expose(runtime, guard, "app_gone", ada, "STRIPE_KEY");
+    await runtime.delete("app_gone", ada);
+    // Re-seed the SAME id: it must start with no exposure (grant did not survive delete).
+    await seedServedApp(store, sandbox, "app_gone", "user_ada");
+    expect(await statusOf(runtime, "app_gone", ada, "STRIPE_KEY")).toBe("handle");
+  });
+});
+
+// ── Red-team matrix (explicit ship requirement).
+describe("ENG-345 red-team — every bypass must fail", () => {
+  it("rt1: a shared/imported copy cannot carry the grant (covered above, asserted here on a fresh id)", async () => {
+    const { store, guard, sandbox, runtime } = setup();
+    await seedServedApp(store, sandbox, "app_rt1", "user_ada");
+    const ada = context("user_ada");
+    await expose(runtime, guard, "app_rt1", ada, "STRIPE_KEY");
+    const copy = await runtime.importApp(await runtime.exportApp("app_rt1", ada), ada);
+    // The copy's machine env is handle-only because its fresh id has no grant.
+    const machines = createMachineSessions({
+      sandbox,
+      tokenSecret: new Uint8Array(32),
+      secrets,
+      resolveExposedSecrets: async (app) => new Set((await runtime.secrets.exposure(app.id, ada))
+        .filter((state) => state.status === "exposed").map((state) => state.secretName)),
+      reportExposedRun: async () => undefined,
+    });
+    await machines.withMachine(
+      { format: VENDO_APP_FORMAT, id: copy.id, name: "n", ui: "http", secrets: ["STRIPE_KEY"] },
+      ada,
+      async ({ machine }) => {
+        expect((machine as FakeSandboxMachine).env.STRIPE_KEY).toMatch(HANDLE);
+      },
+    );
+  });
+
+  it("rt2: a non-owner (remixer/co-user) cannot flip or inherit the toggle", async () => {
+    const { store, sandbox, runtime } = setup();
+    await seedServedApp(store, sandbox, "app_rt2", "user_ada");
+    const bob = context("user_bob");
+    await expect(
+      runtime.secrets.setExposure({ appId: "app_rt2", secretName: "STRIPE_KEY", expose: false }, bob),
+    ).rejects.toMatchObject({ code: "not-found" });
+    await expect(
+      runtime.secrets.setExposure({ appId: "app_rt2", secretName: "STRIPE_KEY", expose: true }, bob),
+    ).rejects.toMatchObject({ code: "not-found" });
+  });
+
+  it("rt3: flipping ON WITHOUT completing approval never exposes", async () => {
+    const { store, guard, sandbox, runtime } = setup();
+    await seedServedApp(store, sandbox, "app_rt3", "user_ada");
+    const ada = context("user_ada");
+    const parked = await runtime.secrets.setExposure({ appId: "app_rt3", secretName: "STRIPE_KEY", expose: true }, ada);
+    expect(parked.status).toBe("pending-approval");
+    // No decide() call — grant stays pending. A run must not expose.
+    guard.audit.length = 0;
+    await runtime.open("app_rt3", ada);
+    expect(exposedRunEvents(guard.audit)).toHaveLength(0);
+    expect(await statusOf(runtime, "app_rt3", ada, "STRIPE_KEY")).toBe("pending");
+  });
+
+  it("rt4: a grant for A never exposes B, and app X's grant never affects app Y", async () => {
+    const { store, guard, sandbox, runtime } = setup();
+    await seedServedApp(store, sandbox, "app_x", "user_ada");
+    await seedServedApp(store, sandbox, "app_y", "user_ada");
+    const ada = context("user_ada");
+    await expose(runtime, guard, "app_x", ada, "STRIPE_KEY");
+
+    expect(await statusOf(runtime, "app_x", ada, "STRIPE_KEY")).toBe("exposed");
+    expect(await statusOf(runtime, "app_x", ada, "OTHER")).toBe("handle"); // A's grant ≠ B
+    expect(await statusOf(runtime, "app_y", ada, "STRIPE_KEY")).toBe("handle"); // X's grant ≠ Y
+    expect(await statusOf(runtime, "app_y", ada, "OTHER")).toBe("handle");
+  });
+
+  it("rt5: revoking (flip OFF) an active grant reverts to handles and stops exposing", async () => {
+    const { store, guard, sandbox, runtime } = setup();
+    await seedServedApp(store, sandbox, "app_rt5", "user_ada");
+    const ada = context("user_ada");
+    await expose(runtime, guard, "app_rt5", ada, "STRIPE_KEY");
+
+    const off = await runtime.secrets.setExposure({ appId: "app_rt5", secretName: "STRIPE_KEY", expose: false }, ada);
+    expect(off.status).toBe("handles");
+    expect(await statusOf(runtime, "app_rt5", ada, "STRIPE_KEY")).toBe("handle");
+
+    guard.audit.length = 0;
+    await runtime.open("app_rt5", ada);
+    expect(exposedRunEvents(guard.audit)).toHaveLength(0);
+  });
+
+  it("rt6: egress substitution + redaction (§4.5) still holds when exposure is ON", async () => {
+    // Exposure changes ONLY the boot env; the egress proxy boundary is unchanged.
+    // The allowlisted-host substitution still maps handle→value, and a
+    // non-allowlisted host still fails closed (the value never egresses).
+    const handleMap = { "vendo-secret:STRIPE_KEY:nonce": SECRET_VALUES.STRIPE_KEY };
+    const allowed = substituteSecretHandles(
+      { url: "https://api.stripe.com/charge", headers: { authorization: "Bearer vendo-secret:STRIPE_KEY:nonce" } },
+      handleMap,
+      ["api.stripe.com"],
+    );
+    expect(allowed.headers?.authorization).toBe(`Bearer ${SECRET_VALUES.STRIPE_KEY}`);
+
+    const blocked = substituteSecretHandles(
+      { url: "https://evil.test/collect", body: "vendo-secret:STRIPE_KEY:nonce" },
+      handleMap,
+      ["api.stripe.com"],
+    );
+    expect(blocked.body).toBe("vendo-secret:STRIPE_KEY:nonce");
+    expect(JSON.stringify(blocked)).not.toContain(SECRET_VALUES.STRIPE_KEY);
+  });
+});

--- a/packages/apps/src/secret-exposure.test.ts
+++ b/packages/apps/src/secret-exposure.test.ts
@@ -231,9 +231,10 @@ describe("ENG-345 (c) — an active grant injects the real value into sandbox en
   });
 });
 
-// ── Constraint 4 + (d): one audit event per run that executes with an exposed secret.
-describe("ENG-345 constraint 4 & (d) — one exposed-run audit per run", () => {
-  it("emits exactly one exposed-run event per run.mint, and none once machine-backed is false", async () => {
+// ── Constraint 4 + (d): one audit event per run that ACTUALLY exposes a secret,
+// emitted at the injection point — never a false positive on a handle-only boot.
+describe("ENG-345 constraint 4 & (d) — one exposed-run audit at the injection point", () => {
+  it("emits exactly one exposed-run event when a fresh boot injects a real value", async () => {
     const sandbox = fakeSandbox();
     const reported: string[][] = [];
     const machines = createMachineSessions({
@@ -248,31 +249,49 @@ describe("ENG-345 constraint 4 & (d) — one exposed-run audit per run", () => {
     };
     await machines.withMachine(httpApp, context("user_ada"), async () => undefined);
     expect(reported).toEqual([["STRIPE_KEY"]]);
+  });
 
-    // A rung-1 tree app has no machine → an exposure grant exposes nothing → no audit.
-    const treeApp: AppDocument = {
-      format: VENDO_APP_FORMAT, id: "app_tree", name: "n", ui: "tree", secrets: ["STRIPE_KEY"],
+  it("regression (Greptile P1): a RESUME never reports an exposed run — a handle-only snapshot cannot lie", async () => {
+    const sandbox = fakeSandbox();
+    // A snapshot baked with a HANDLE (the app was built before any grant).
+    const seed = await sandbox.create({ env: { PORT: "8080", STRIPE_KEY: "vendo-secret:STRIPE_KEY:abc123" } });
+    const server = await seed.snapshot();
+    await seed.stop();
+
+    const reported: string[][] = [];
+    const machines = createMachineSessions({
+      sandbox,
+      tokenSecret: new Uint8Array(32),
+      secrets,
+      // Grant is active now, but the RESUMED snapshot still carries the handle:
+      // resume cannot inject env, so no exposed-run audit may be emitted.
+      resolveExposedSecrets: async () => new Set(["STRIPE_KEY"]),
+      reportExposedRun: async (_app, _ctx, names) => { reported.push(names); },
+    });
+    const servedApp: AppDocument = {
+      format: VENDO_APP_FORMAT, id: "app_resumed", name: "n", ui: "tree", server, secrets: ["STRIPE_KEY"],
     };
-    reported.length = 0;
-    await machines.withMachine(treeApp, context("user_ada"), async () => undefined);
+    await machines.withMachine(servedApp, context("user_ada"), async ({ machine }) => {
+      // The resumed env is still a handle — and the audit below must agree.
+      expect((machine as FakeSandboxMachine).env.STRIPE_KEY).toMatch(HANDLE);
+    });
     expect(reported).toEqual([]);
   });
 
-  it("runtime open() emits one exposed-run event carrying the exposed secret name", async () => {
+  it("runtime open() over a served app resumed from a handle snapshot emits NO false exposed-run event", async () => {
     const { store, guard, sandbox, runtime } = setup();
     await seedServedApp(store, sandbox, "app_srv", "user_ada");
     const ada = context("user_ada");
     await expose(runtime, guard, "app_srv", ada, "STRIPE_KEY");
 
+    // The flip itself is audited as a lifecycle event (constraint 3 / audit trail).
+    expect(guard.audit.some((event) =>
+      (event.detail as { operation?: string } | undefined)?.operation === "secret-exposure-set")).toBe(true);
+
+    // But open() resumes a handle-only snapshot, so it must NOT claim an exposed run.
     guard.audit.length = 0;
     await runtime.open("app_srv", ada);
-    const first = exposedRunEvents(guard.audit);
-    expect(first).toHaveLength(1);
-    expect((first[0]?.detail as { secrets?: string[] }).secrets).toEqual(["STRIPE_KEY"]);
-    expect(first[0]?.appId).toBe("app_srv");
-
-    await runtime.open("app_srv", ada);
-    expect(exposedRunEvents(guard.audit)).toHaveLength(2);
+    expect(exposedRunEvents(guard.audit)).toHaveLength(0);
   });
 });
 

--- a/packages/apps/src/secret-exposure.ts
+++ b/packages/apps/src/secret-exposure.ts
@@ -1,0 +1,134 @@
+import {
+  type AppId,
+  type ApprovalId,
+  type IsoDateTime,
+  type StoreAdapter,
+  type VendoRecord,
+} from "@vendoai/core";
+
+/**
+ * ENG-345 — the guarded per-secret in-sandbox exposure grant (secrets
+ * fast-follow to the Option B gateway pick).
+ *
+ * Option B stays the DEFAULT: a declared secret enters the sandbox as an opaque
+ * handle and is substituted only at the egress proxy (06-apps §4.3). This grant
+ * is the EXCEPTION path — an explicit, per-secret × per-app, owner-only opt-in
+ * that places the REAL value into the sandbox env instead of a handle. It is:
+ *   - off by default (no record → handle),
+ *   - owner-only (only the principal who owns the app copy can set it),
+ *   - gated by the guard's existing high-risk approval flow (written `active`
+ *     only after the parked critical approval is decided approved),
+ *   - audited per run (machine.ts emits one exposed-run event per run), and
+ *   - NEVER carried by shares/remixes.
+ *
+ * The last invariant is enforced structurally, not by stripping: these grants
+ * live in their OWN store collection keyed by the app's id, and are never part
+ * of the app document that exportApp/share/publish/fork/importApp copy. A copy
+ * always gets a fresh AppId (06-apps §7), which by construction has no grants —
+ * so a copied app can never inherit an exposure grant.
+ */
+export interface SecretExposureGrant {
+  appId: AppId;
+  secretName: string;
+  /** The app owner's principal subject — the only principal who may set this. */
+  owner: string;
+  /** `pending` = parked on a high-risk approval; `active` = approved and live. */
+  status: "pending" | "active";
+  /** The guard approval that gates turning this on (06-apps §9 approval model). */
+  approvalId: ApprovalId;
+  requestedAt: IsoDateTime;
+  grantedAt?: IsoDateTime;
+}
+
+/** Deterministic id so re-requesting the same (app, secret) overwrites, never duplicates. */
+const recordId = (appId: AppId, secretName: string): string => `xpo_${appId}__${secretName}`;
+
+const COLLECTION = "vendo_secret_exposure";
+
+const grantData = (record: VendoRecord): SecretExposureGrant => record.data as SecretExposureGrant;
+
+const listAll = async (
+  store: StoreAdapter,
+  refs: Record<string, string>,
+): Promise<VendoRecord[]> => {
+  const records: VendoRecord[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await store.records(COLLECTION).list(
+      cursor === undefined ? { refs } : { refs, cursor },
+    );
+    records.push(...page.records);
+    if (page.cursor === undefined || page.cursor === cursor) break;
+    cursor = page.cursor;
+  } while (cursor !== undefined);
+  return records;
+};
+
+/** ENG-345 — persistence for per-secret × per-app in-sandbox exposure grants. */
+export interface SecretExposure {
+  /** Active grants for one app (owner-scoped by construction). */
+  active(appId: AppId): Promise<SecretExposureGrant[]>;
+  /** Names of secrets currently exposed in-sandbox for one app. */
+  activeNames(appId: AppId): Promise<Set<string>>;
+  /** Every grant (pending + active) for one app. */
+  list(appId: AppId): Promise<SecretExposureGrant[]>;
+  /** Park a grant on a high-risk approval (status `pending`). */
+  putPending(grant: Omit<SecretExposureGrant, "status">): Promise<void>;
+  /** Flip a parked grant to `active` once its approval is approved. Returns the grant, or null if none pending. */
+  activate(appId: AppId, secretName: string): Promise<SecretExposureGrant | null>;
+  /** Turn a secret off — reverts to the Option B handle default. */
+  revoke(appId: AppId, secretName: string): Promise<void>;
+  /** Grants (pending/active) parked on a specific approval id. */
+  byApproval(approvalId: ApprovalId): Promise<SecretExposureGrant[]>;
+  /** Delete every grant for one app (app deletion cleanup). */
+  clearForApp(appId: AppId): Promise<void>;
+}
+
+export const createSecretExposure = (store: StoreAdapter): SecretExposure => {
+  const collection = store.records(COLLECTION);
+
+  const refsFor = (grant: SecretExposureGrant): Record<string, string> => ({
+    subject: grant.owner,
+    app_id: grant.appId,
+    secret: grant.secretName,
+    status: grant.status,
+    approval: grant.approvalId,
+  });
+
+  const list = async (appId: AppId): Promise<SecretExposureGrant[]> =>
+    (await listAll(store, { app_id: appId })).map(grantData);
+
+  return {
+    list,
+    async active(appId) {
+      return (await list(appId)).filter((grant) => grant.status === "active");
+    },
+    async activeNames(appId) {
+      return new Set((await list(appId)).filter((grant) => grant.status === "active").map((grant) => grant.secretName));
+    },
+    async putPending(grant) {
+      const full: SecretExposureGrant = { ...grant, status: "pending" };
+      await collection.put({ id: recordId(grant.appId, grant.secretName), data: full, refs: refsFor(full) });
+    },
+    async activate(appId, secretName) {
+      const record = await collection.get(recordId(appId, secretName));
+      if (record === null) return null;
+      const grant = grantData(record);
+      if (grant.status === "active") return grant;
+      const activated: SecretExposureGrant = { ...grant, status: "active", grantedAt: new Date().toISOString() };
+      await collection.put({ id: record.id, data: activated, refs: refsFor(activated) });
+      return activated;
+    },
+    async revoke(appId, secretName) {
+      await collection.delete(recordId(appId, secretName));
+    },
+    async byApproval(approvalId) {
+      return (await listAll(store, { approval: approvalId })).map(grantData);
+    },
+    async clearForApp(appId) {
+      for (const record of await listAll(store, { app_id: appId })) {
+        await collection.delete(record.id);
+      }
+    },
+  };
+};


### PR DESCRIPTION
## ENG-345 — guarded per-secret in-sandbox exposure toggle

Fast-follow to the secrets-gateway pick (Option B). Adds the OFF-by-default **exception** path to Option B: an owner-only, per-secret × per-app toggle that places a secret's real value into the sandbox env instead of a handle. Option B (handles + egress substitution, §4.3/§4.5) stays the default and is fully intact.

### Design
- **Persistence** — grants live in their own store collection `vendo_secret_exposure`, keyed by app id, **never in the app document**. Because `exportApp`/`importApp`/`fork`/`share`/`publish` all mint or copy a fresh `AppId` (§7), a copy structurally cannot inherit a grant.
- **Flip ON = high-risk approval** — `runtime.secrets.setExposure({expose:true})` routes through the guard's **existing** critical-approval flow (`guard.check` with a `critical` descriptor + `onApprovalDecision`, the same seam automations use to resume a parked run). The grant activates only on approval; denial/OFF reverts to handles. No parallel approval mechanism.
- **Injection** — `machine.ts` `environment()` injects the real value (via the same `SecretsProvider` the egress proxy uses) only for a secret with an active grant; every other secret stays an opaque handle.
- **Audit** — one `secret-exposed-run` audit event per run (open()/call()) on a machine-backed app, via the guard report seam (constraint 4).

### The 5 locked constraints → proving test
1. Option B default → `(a) machine env carries an opaque handle when nothing is exposed`
2. Owner-only, per-secret×per-app → `(b) a non-owner cannot set or read the toggle`
3. High-risk approval → `(b) owner flip ON parks on a high-risk approval; a DENIED approval leaves it OFF`
4. Audit per exposed run → `(d) runtime open() emits one exposed-run event`
5. Never travels with a copy → `(e) fork, export→import, and a foreign import all revert to handles`

### Red-team matrix (all green)
copy cannot carry the grant · non-owner cannot flip/inherit · ON-without-approval never exposes · secret-A grant ≠ secret-B and app-X ≠ app-Y · revoke reverts · egress substitution+redaction (§4.5) unaffected.

### Gates
`build` ✓ · `typecheck` ✓ · `lint` ✓ · `@vendoai/apps` tests ✓ (383, incl. 17 new). Full `pnpm test` verified in a space-free /tmp clone (store-durability gotcha); `redteam-e2e` passes in isolation (full-suite failures were port/parallelism flakiness, documented gotcha).

### Known boundary
Injection is at machine boot (`environment()`). A served app whose snapshot predates the flip picks up the value on its next machine (re)build; flipping evicts the live machine so the next fresh boot reflects the new grant state. Documented in code.

### DO NOT MERGE
Merge blocked on the ENG-345 contract amendment (#325) landing first (Yousef-gated). Implements the principle stated in that §4.3 amendment.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an owner-only, per-secret toggle to inject a secret’s real value into an app’s sandbox while keeping Option B (handles + egress substitution) as the default. Auditing now fires only when a fresh machine actually injects real values, avoiding false exposed-run reports on resume (ENG-345).

- **New Features**
  - Storage: Persist grants in `vendo_secret_exposure` keyed by app id; never in the app document, so copies revert to handles.
  - Approval: Turning ON goes through the guard’s critical-approval flow; approval activates the grant, DENIED/OFF reverts to handles; machine is evicted after changes.
  - Runtime/Machine: Inject real values via the `SecretsProvider` only for active grants; others stay handles.
  - API/Types: New runtime surface `secrets.exposure(appId)` and `secrets.setExposure({ appId, secretName, expose })`; exports `SecretExposure`, `SecretExposureGrant`, `SecretExposureState`, and `SetExposureResult`.
  - Release: Minor bump to `@vendoai/apps`.

- **Bug Fixes**
  - Tie the `secret-exposed-run` audit to actual env injection at machine creation; never emit on resume. This also audits forks/import materialization when they inject real values.

<sup>Written for commit c44d01557cc12283b5d847f53c8993de6b81e329. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

