### PR TITLE
fix(ui): de-flake containment.spec.ts (ENG-343)

### DIFF
--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -214,11 +214,19 @@ const unknownViewThread: Thread = {
 };
 
 function threadClient(client: VendoClient, thread: Thread): VendoClient {
+  // A thread that get() serves must also appear in list(): useVendoThread only
+  // adopts a supplied threadId after confirming it exists in list() (the ENG-211
+  // stale-id graceful degradation guard). Stubbing get() alone would degrade the
+  // thread to the empty greeting state.
   return {
     ...client,
     threads: {
       ...client.threads,
       get: async id => id === thread.id ? thread : client.threads.get(id),
+      list: async () => {
+        const rest = (await client.threads.list()).filter(summary => summary.id !== thread.id);
+        return [{ id: thread.id, title: thread.subject, updatedAt: thread.updatedAt }, ...rest];
+      },
     },
   };
 }


### PR DESCRIPTION
## ENG-343 — Pre-existing ui e2e failure: containment.spec.ts:27

### Root cause
`containment.spec.ts:27` (the unknown-formatVersion containment test) deterministically failed on its **in-thread** assertion (line 40). The direct `PayloadView` case passed; the in-thread case rendered the empty greeting state instead of the "Unsupported UI format" notice.

The test harness's `threadClient()` helper (`e2e/harness/main.tsx`) stubbed `threads.get()` but **not** `threads.list()`. `useVendoThread` only adopts a supplied `threadId` after confirming it exists in `list()` — the stale-id graceful-degradation guard added by ENG-211 (b7041112). Because `list()` fell through to the base client (which doesn't know `thr_unknown`), the thread degraded to a fresh empty thread, so the `data-vendo-view` unknown payload — and its contained notice — never rendered.

This was a harness/stub inconsistency exposed when ENG-211 landed after the containment harness was written, not a race. It failed 100% of the time once the workspace was built.

### Fix
Make `threadClient()` consistent: a thread served by `get()` now also appears in `list()`, mirroring the existing `boundedThreadsClient()` pattern. No product/source code changed — only the e2e harness stub. The fluidkit-alias-stub pattern is untouched.

### Stability evidence
`containment.spec.ts` run 20 times in a loop:

```
=== RESULT: 20 passed / 20 total, 0 failed ===
```

Gates (space-free `/tmp/eng-343` checkout off `origin/main`):
- `pnpm --filter @vendoai/ui test` — 214 passed (30 files)
- `pnpm --filter @vendoai/ui typecheck` — clean
- `pnpm lint` (dependency-guard + turbo) — OK, 12 packages checked
- full e2e suite — 67 passed; the only 2 failures (`chrome-behavior.spec.ts:13`, `keyboard.spec.ts:4`) are **separate pre-existing failures** verified on clean `origin/main` (out of scope for ENG-343 — parked for follow-up).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the in-thread unknown-format containment e2e by making the harness `threadClient()` consistent with `useVendoThread`. Addresses ENG-343 and makes `containment.spec.ts` pass reliably without changing app code.

- **Bug Fixes**
  - Stubbed `threads.list()` in `threadClient()` so threads returned by `get()` also appear in `list()`, preventing stale-id degradation; matches `boundedThreadsClient()` behavior.
  - Verified stability: `containment.spec.ts` passed 20/20 runs; only `packages/ui/e2e/harness/main.tsx` was changed in `@vendoai/ui`.

<sup>Written for commit 23d236ef58ca88f343b3da6711075c72c59eb837. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

