### PR TITLE
fix(ui): de-flake keyboard.spec.ts (ENG-344)

### DIFF
--- a/packages/ui/e2e/helpers.ts
+++ b/packages/ui/e2e/helpers.ts
@@ -29,6 +29,14 @@ export async function expectKeyboardReachability(page: Page, scopeSelector = "bo
     const candidates = [...scope.querySelectorAll<HTMLElement>(selector)];
     return candidates.filter(element => {
       if (element.matches(":disabled") || element.tabIndex < 0) return false;
+      // `checkVisibility()` is the source of truth for reachability: it accounts
+      // for `content-visibility: hidden` subtrees (e.g. the controls inside a
+      // collapsed <details>), which modern Chromium keeps laid out with a
+      // non-zero box and `display` other than `none` — so the old
+      // offset/display heuristic counted them as tab targets even though the
+      // browser correctly skips them in the sequential focus order. The extra
+      // style/offset checks stay as a belt-and-braces guard for older engines.
+      if (!element.checkVisibility()) return false;
       const style = getComputedStyle(element);
       return style.visibility !== "hidden"
         && style.display !== "none"


### PR DESCRIPTION
## ENG-344 — Pre-existing ui e2e failure: keyboard.spec.ts:4 fails on main

### Root cause
`keyboard.spec.ts:4` ("thread is keyboard-complete with visible focus") failed **deterministically** (0/10), not intermittently.

The `expectKeyboardReachability` helper asserts that every visible interactive control in a scope is reachable by Tab. It counted the controls inside the ApprovalCard **"Remember this decision"** disclosure — a collapsed `<details>` — as required tab targets. Modern Chromium renders `content-visibility: hidden` subtrees (which a closed `<details>` uses) with a **non-zero bounding box** and a `display` value other than `none`, so the helper's `visibility/display/offsetWidth` heuristic saw the collapsed checkbox as "visible." The browser, correctly, does **not** include collapsed-disclosure controls in the sequential focus order — so the assertion "all visible interactions must be tabbable" could never be satisfied and the spec failed every run.

Evidence gathered during debugging:
- `details.open === false`, yet the nested checkbox reports `getBoundingClientRect()` 15x15 and `display: grid`.
- `element.checkVisibility()` returns **false** for that checkbox (it accounts for `content-visibility: hidden`).
- Observed tab cycle: Summary → Approve → Deny → Attach files → Message (the collapsed checkbox is never focused — correct browser behavior).

This is a test-helper bug, not a product bug: the disclosure correctly hides and skips its controls when collapsed.

### Fix
Gate reachability candidates on `element.checkVisibility()`, which correctly treats `content-visibility: hidden` (collapsed `<details>`) content as not visible. The existing `visibility`/`display`/`offset` checks are kept as a belt-and-braces guard for older engines. Change is confined to `e2e/helpers.ts`; `keyboard.spec.ts` is the only spec that uses this helper.

### Stability evidence
- `keyboard.spec.ts:4` **before fix: 0/10** passes (deterministic failure).
- `keyboard.spec.ts:4` **after fix: 20/20** passes in a loop.
- Full `keyboard.spec.ts`: **9/9** pass.

### Gates
- `pnpm --filter @vendoai/ui test` (vitest): **214/214** pass
- `pnpm --filter @vendoai/ui typecheck`: pass (`checkVisibility` typechecks clean)
- `pnpm lint` (dependency-guard + turbo): pass

Note: the ui `test:browser` Playwright suite (which includes `keyboard.spec.ts`) is not run in CI today — only `test:mcp-shim` and the integration-browser fixture are — which is why this regression sat undetected on main. Wiring the full ui browser suite into CI is out of scope here and left as a follow-up.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the deterministic failure in `packages/ui/e2e/keyboard.spec.ts:4` (ENG-344) by using `element.checkVisibility()` in the keyboard reachability helper so collapsed `<details>` content isn’t counted as tabbable.

- **Bug Fixes**
  - Gate candidates in `expectKeyboardReachability` on `element.checkVisibility()`; keep existing visibility/display/offset checks for older engines.
  - Stability: `keyboard.spec.ts:4` now passes 20/20; full file 9/9; `pnpm --filter @vendoai/ui test` 214/214; typecheck and lint pass.

<sup>Written for commit 58dc5a74086a9298bdd0ebeb137a3ca10b13beac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

