### PR TITLE
build: migrate repo to pnpm 11 (pnpm.overrides → pnpm-workspace.yaml); drop CI audit workaround (ENG-332)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,15 +176,9 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       # npm permanently retired the legacy audit endpoints on 2026-07-15 (HTTP
-      # 410); `pnpm audit` only queries the replacement bulk-advisory endpoint
-      # from pnpm 11 (pnpm/pnpm#11265). The repo pins pnpm 9 via packageManager
-      # and pnpm 11 auto-delegates to that pin, so strip the field in this
-      # throwaway checkout before auditing. 11.10.0 is the newest release that
-      # clears the .npmrc minimumReleaseAge window. Remove this workaround when
-      # the repo itself moves to pnpm 11 (tracked in Linear).
-      - run: |
-          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));delete p.packageManager;fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
-          npx -y pnpm@11.10.0 audit --prod --audit-level high
+      # 410); `pnpm audit` queries the replacement bulk-advisory endpoint from
+      # pnpm 11 (pnpm/pnpm#11265), which the repo now pins via packageManager.
+      - run: pnpm audit --prod --audit-level high
 
   # Reminder that a user-facing change should ship a changeset. NON-BLOCKING by
   # design (the fleet auto-merges): this job is not a required check and its one

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ pnpm build
 pnpm test
 ```
 
-Node 20+, pnpm 9. The repo is a turbo monorepo: `packages/` are the published
+Node 22+, pnpm 11. The repo is a turbo monorepo: `packages/` are the published
 `@vendoai/*` libraries, built against the frozen contracts in `docs/contracts/`
 (read `00-overview.md` first; layering is enforced in `pnpm lint`). The demo
 host apps live under `apps/`.

--- a/apps/demo-bank/Dockerfile
+++ b/apps/demo-bank/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22-bookworm-slim
 
 WORKDIR /app
-RUN npm install --global pnpm@9.12.0
+RUN npm install --global pnpm@11.10.0
 
 COPY . .
 RUN pnpm install --frozen-lockfile

--- a/corpus/harness/src/inject.test.ts
+++ b/corpus/harness/src/inject.test.ts
@@ -349,6 +349,163 @@ describe("createLocalVendoInjector", () => {
     });
   }
 
+  for (const target of [
+    { name: "a packageManager pin of pnpm@11", pin: "pnpm@11.2.1" as string | undefined },
+    { name: "no packageManager pin (harness pnpm is 11+)", pin: undefined },
+  ]) {
+    it(`mirrors overrides into a created pnpm-workspace.yaml and drops --ignore-workspace for a standalone target with ${target.name}`, async () => {
+      const workspaceRoot = await createWorkspace();
+      const corpusRoot = await makeTempRoot();
+      const context = createRunContext({ corpusRoot });
+      const repoDir = context.repoDir("repo-pnpm11-standalone");
+      await writeJson(path.join(repoDir, "package.json"), {
+        name: "repo-pnpm11-standalone",
+        ...(target.pin ? { packageManager: target.pin } : {}),
+        dependencies: {
+          "@vendoai/vendo": "latest",
+          "vendoai": "latest",
+        },
+      });
+      // Unpinned targets are detected as pnpm via their lockfile.
+      if (!target.pin) await writeFile(path.join(repoDir, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+      const pack: PackWorkspacePackage = async (pkg, opts) => {
+        await mkdir(opts.vendorDir, { recursive: true });
+        await writeFile(path.join(opts.vendorDir, opts.fileName), `packed ${pkg.name}`);
+      };
+      const installCalls: string[] = [];
+      const injector = createLocalVendoInjector({
+        context,
+        workspaceRoot,
+        pack,
+        log() {},
+        async buildWorkspace() {},
+        async runInstallCommand(command, cwd) {
+          installCalls.push(`${command} @ ${cwd}`);
+          await writeFile(path.join(cwd, "pnpm-lock.yaml"), [
+            "dependencies:",
+            "  '@vendoai/vendo':",
+            "    specifier: file:vendor/vendoai-vendo-0.3.0.tgz",
+            "    version: file:vendor/vendoai-vendo-0.3.0.tgz",
+            "",
+          ].join("\n"));
+        },
+      });
+
+      await injector.inject({
+        name: "repo-pnpm11-standalone",
+        bootstrap: {
+          installCommand: "pnpm install --frozen-lockfile --force --ignore-workspace",
+          envTemplate: {},
+          buildCommand: "pnpm build",
+        },
+      });
+
+      expect(installCalls).toEqual([
+        `pnpm --config.minimumReleaseAge=0 --config.dangerouslyAllowAllBuilds=true install --no-frozen-lockfile --force @ ${repoDir}`,
+      ]);
+      const workspaceYaml = await readFile(path.join(repoDir, "pnpm-workspace.yaml"), "utf8");
+      expect(workspaceYaml).toContain('packages:\n  - "."');
+      expect(workspaceYaml).toContain('"@vendoai/vendo": "file:vendor/vendoai-vendo-0.3.0.tgz"');
+      expect(workspaceYaml).toContain('"vendoai": "file:vendor/vendoai-0.3.0.tgz"');
+      expect(workspaceYaml).toContain('"ai": "6.0.28"');
+      // package.json keeps the overrides too, for pnpm ≤10 dev environments.
+      const pkg = await readPackageJson(repoDir);
+      expect(pkg.pnpm.overrides["@vendoai/vendo"]).toBe("file:vendor/vendoai-vendo-0.3.0.tgz");
+    });
+  }
+
+  it("keeps --ignore-workspace and writes no pnpm-workspace.yaml for a standalone target pinned to pnpm 9", async () => {
+    const workspaceRoot = await createWorkspace();
+    const corpusRoot = await makeTempRoot();
+    const repoDir = await createTargetRepo(corpusRoot, "repo-pnpm9-standalone");
+    const pack: PackWorkspacePackage = async (pkg, opts) => {
+      await mkdir(opts.vendorDir, { recursive: true });
+      await writeFile(path.join(opts.vendorDir, opts.fileName), `packed ${pkg.name}`);
+    };
+    const installCalls: string[] = [];
+    const injector = createLocalVendoInjector({
+      context: createRunContext({ corpusRoot }),
+      workspaceRoot,
+      pack,
+      log() {},
+      async buildWorkspace() {},
+      async runInstallCommand(command, cwd) {
+        installCalls.push(`${command} @ ${cwd}`);
+        await writeFile(path.join(cwd, "pnpm-lock.yaml"), [
+          "dependencies:",
+          "  '@vendoai/vendo':",
+          "    specifier: file:vendor/vendoai-vendo-0.3.0.tgz",
+          "    version: file:vendor/vendoai-vendo-0.3.0.tgz",
+          "",
+        ].join("\n"));
+      },
+    });
+
+    await injector.inject({
+      name: "repo-pnpm9-standalone",
+      bootstrap: {
+        installCommand: "pnpm install --frozen-lockfile --ignore-workspace",
+        envTemplate: {},
+        buildCommand: "pnpm build",
+      },
+    });
+
+    expect(installCalls).toEqual([
+      `pnpm --config.minimumReleaseAge=0 --config.dangerouslyAllowAllBuilds=true install --no-frozen-lockfile --ignore-workspace @ ${repoDir}`,
+    ]);
+    await expect(readFile(path.join(repoDir, "pnpm-workspace.yaml"), "utf8")).rejects.toThrow();
+  });
+
+  it("merges overrides into an existing pnpm-workspace.yaml for a standalone pnpm 11 target that curates builds", async () => {
+    const workspaceRoot = await createWorkspace();
+    const corpusRoot = await makeTempRoot();
+    const context = createRunContext({ corpusRoot });
+    const repoDir = context.repoDir("repo-pnpm11-curated");
+    await writeJson(path.join(repoDir, "package.json"), {
+      name: "repo-pnpm11-curated",
+      packageManager: "pnpm@11.2.1",
+      dependencies: {
+        "@vendoai/vendo": "latest",
+        "vendoai": "latest",
+      },
+    });
+    await writeFile(
+      path.join(repoDir, "pnpm-workspace.yaml"),
+      "packages:\n  - '.'\nallowBuilds:\n  esbuild: true\n",
+    );
+    const pack: PackWorkspacePackage = async (pkg, opts) => {
+      await mkdir(opts.vendorDir, { recursive: true });
+      await writeFile(path.join(opts.vendorDir, opts.fileName), `packed ${pkg.name}`);
+    };
+    const installCalls: string[] = [];
+    const injector = createLocalVendoInjector({
+      context,
+      workspaceRoot,
+      pack,
+      log() {},
+      async buildWorkspace() {},
+      async runInstallCommand(command, cwd) {
+        installCalls.push(`${command} @ ${cwd}`);
+        await writeFile(path.join(cwd, "pnpm-lock.yaml"), [
+          "dependencies:",
+          "  '@vendoai/vendo':",
+          "    specifier: file:vendor/vendoai-vendo-0.3.0.tgz",
+          "    version: file:vendor/vendoai-vendo-0.3.0.tgz",
+          "",
+        ].join("\n"));
+      },
+    });
+
+    await injector.inject({ name: "repo-pnpm11-curated" });
+
+    expect(installCalls).toEqual([
+      `pnpm --config.minimumReleaseAge=0 install --no-frozen-lockfile @ ${repoDir}`,
+    ]);
+    const workspaceYaml = await readFile(path.join(repoDir, "pnpm-workspace.yaml"), "utf8");
+    expect(workspaceYaml).toContain("allowBuilds:\n  esbuild: true");
+    expect(workspaceYaml).toContain('"@vendoai/vendo": "file:vendor/vendoai-vendo-0.3.0.tgz"');
+  });
+
   it("targets appDir package.json when injecting into monorepo apps", async () => {
     const workspaceRoot = await createWorkspace();
     const corpusRoot = await makeTempRoot();

--- a/corpus/harness/src/inject.ts
+++ b/corpus/harness/src/inject.ts
@@ -309,6 +309,38 @@ async function writePnpmWorkspaceRootOverrides(
   await writeFile(workspaceYaml, mergePnpmWorkspaceYamlOverrides(source, overrides));
 }
 
+/** pnpm ≥11 no longer reads the `pnpm` field from package.json, so the
+ * overrides rewritePackageJsonForLocalVendo writes there are silently ignored
+ * and transitive @vendoai deps would resolve from the registry. For standalone
+ * pnpm targets that will run pnpm ≥11 — a packageManager pin ≥11, or no pin at
+ * all (the harness environment provides pnpm 11) — mirror those overrides into
+ * the target's pnpm-workspace.yaml, creating it as a single-project workspace
+ * when missing. `packages: ["."]` keeps the created file valid for a dev
+ * machine still running pnpm 9, which reads the package.json overrides and
+ * ignores the yaml ones. Returns true when the yaml carries the overrides, so
+ * the caller must drop --ignore-workspace (pnpm 11 skips pnpm-workspace.yaml
+ * settings entirely under that flag). */
+async function writeStandalonePnpmWorkspaceOverrides(
+  repoDir: string,
+  summary: LocalVendoInstallSummary,
+): Promise<boolean> {
+  if (
+    summary.packageManager !== "pnpm"
+    || path.resolve(summary.installDir ?? repoDir) !== path.resolve(repoDir)
+    || (summary.pnpmMajor != null && summary.pnpmMajor < 11)
+  ) {
+    return false;
+  }
+  const pkg = JSON.parse(await readFile(path.join(repoDir, "package.json"), "utf8")) as Record<string, unknown>;
+  const overrides = isRecord(pkg["pnpm"]) ? stringRecord(pkg["pnpm"]["overrides"]) : {};
+  if (Object.keys(overrides).length === 0) return false;
+
+  const workspaceYaml = path.join(repoDir, "pnpm-workspace.yaml");
+  const source = await readOptional(workspaceYaml) ?? 'packages:\n  - "."\n';
+  await writeFile(workspaceYaml, mergePnpmWorkspaceYamlOverrides(source, overrides));
+  return true;
+}
+
 async function assertLocalVendoResolution(repoDir: string, summary: LocalVendoInstallSummary): Promise<void> {
   const pkg = JSON.parse(await readFile(path.join(repoDir, "package.json"), "utf8")) as Record<string, unknown>;
   const dependencySections = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"];
@@ -400,6 +432,7 @@ export function createLocalVendoInjector(options: CreateLocalVendoInjectorOption
       const installDir = pnpmWorkspaceRoot ?? summary.installDir ?? repoDir;
       const installSummary = installDir === summary.installDir ? summary : { ...summary, installDir };
       await writePnpmWorkspaceRootOverrides(repoDir, installSummary);
+      const standaloneWorkspaceOverrides = await writeStandalonePnpmWorkspaceOverrides(repoDir, installSummary);
       if (runInstall) {
         const sourceCommand = installCommandSource(repo, installSummary);
         // pnpm ≥10 rejects dangerouslyAllowAllBuilds when the repo curates its
@@ -408,7 +441,8 @@ export function createLocalVendoInjector(options: CreateLocalVendoInjectorOption
         const repoCuratesBuilds = installSummary.packageManager === "pnpm"
           && await pnpmDeclaresBuiltDependencies(installDir);
         const installCommand = normalizePostInjectionInstallCommand(sourceCommand, {
-          dropIgnoreWorkspace: installSummary.packageManager === "pnpm" && installDir !== repoDir,
+          dropIgnoreWorkspace: installSummary.packageManager === "pnpm"
+            && (installDir !== repoDir || standaloneWorkspaceOverrides),
           disableYarnImmutableInstalls: installSummary.packageManager === "yarn-berry",
           pnpmConfig: installSummary.packageManager === "pnpm"
             ? [

--- a/corpus/harness/src/local-pack.ts
+++ b/corpus/harness/src/local-pack.ts
@@ -36,6 +36,10 @@ export interface LocalTarball {
 
 export interface LocalVendoInstallSummary {
   packageManager: LocalPackageManager;
+  /** Major of the pnpm version pinned via packageManager, when detection found
+   * one. null = no pin (the install runs whatever pnpm the harness environment
+   * provides — pnpm 11+, which no longer reads package.json pnpm.overrides). */
+  pnpmMajor?: number | null;
   installCommand: string;
   installDir?: string;
   packages: string[];
@@ -166,6 +170,12 @@ function packageManagerFromField(value: unknown): LocalPackageManager | null {
   return Number.isFinite(major) && major < 2 ? "yarn-classic" : "yarn-berry";
 }
 
+function pnpmMajorFromField(value: unknown): number | null {
+  if (typeof value !== "string" || !value.startsWith("pnpm@")) return null;
+  const major = Number.parseInt(value.slice("pnpm@".length).split(".")[0] ?? "", 10);
+  return Number.isFinite(major) ? major : null;
+}
+
 async function readOptional(file: string): Promise<string | null> {
   try {
     return await fs.readFile(file, "utf8");
@@ -212,29 +222,30 @@ async function detectPackageManager(
   targetDir: string,
   targetPkg: PackageJson,
   packageManagerRoot?: string,
-): Promise<{ packageManager: LocalPackageManager; installDir: string }> {
+): Promise<{ packageManager: LocalPackageManager; pnpmMajor: number | null; installDir: string }> {
   const target = path.resolve(targetDir);
   const dirs = await packageManagerSearchDirs(target, packageManagerRoot);
   const targetField = packageManagerFromField(targetPkg["packageManager"]);
-  if (targetField) return { packageManager: targetField, installDir: target };
+  if (targetField) return { packageManager: targetField, pnpmMajor: pnpmMajorFromField(targetPkg["packageManager"]), installDir: target };
   for (const dir of dirs) {
     if (dir === target) continue;
-    const manager = packageManagerFromField((await readOptionalPackageJson(dir))?.["packageManager"]);
-    if (manager) return { packageManager: manager, installDir: dir };
+    const field = (await readOptionalPackageJson(dir))?.["packageManager"];
+    const manager = packageManagerFromField(field);
+    if (manager) return { packageManager: manager, pnpmMajor: pnpmMajorFromField(field), installDir: dir };
   }
   for (const dir of dirs) {
     const yarnLock = await readOptional(path.join(dir, "yarn.lock"));
-    if (yarnLock) return { packageManager: yarnLock.includes("__metadata:") ? "yarn-berry" : "yarn-classic", installDir: dir };
+    if (yarnLock) return { packageManager: yarnLock.includes("__metadata:") ? "yarn-berry" : "yarn-classic", pnpmMajor: null, installDir: dir };
   }
   for (const dir of dirs) {
     if (await pathExists(path.join(dir, "package-lock.json")) || await pathExists(path.join(dir, "npm-shrinkwrap.json"))) {
-      return { packageManager: "npm", installDir: dir };
+      return { packageManager: "npm", pnpmMajor: null, installDir: dir };
     }
   }
   for (const dir of dirs) {
-    if (await pathExists(path.join(dir, "pnpm-lock.yaml"))) return { packageManager: "pnpm", installDir: dir };
+    if (await pathExists(path.join(dir, "pnpm-lock.yaml"))) return { packageManager: "pnpm", pnpmMajor: null, installDir: dir };
   }
-  return { packageManager: "pnpm", installDir: target };
+  return { packageManager: "pnpm", pnpmMajor: null, installDir: target };
 }
 
 // The umbrella's ai peer is >=6 <7 and init's starter provider is v6-era. A
@@ -392,6 +403,7 @@ export async function installLocalVendoPackages(
   if (rootRewritten) await fs.writeFile(rootPackageJsonPath, rootRewritten);
   return {
     packageManager: detected.packageManager,
+    pnpmMajor: detected.pnpmMajor,
     installCommand: detected.packageManager === "pnpm"
       ? "pnpm install"
       : detected.packageManager === "npm"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "license": "Apache-2.0",
-  "packageManager": "pnpm@9.12.0",
+  "packageManager": "pnpm@11.10.0",
   "scripts": {
     "build": "turbo run build",
     "test": "turbo run test",
@@ -25,12 +25,5 @@
     "turbo": "^2.1.0",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "@types/react": "^19.2.0",
-      "@types/react-dom": "^19.2.0",
-      "postcss@<8.5.10": ">=8.5.10"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,3 +11,19 @@ packages:
   # ai-SDK consumer (packages/agent, packages/ui, fixtures, ...). It installs
   # standalone with its own lockfile instead — see spikes/install-dx-creds/README.md.
   - "!spikes/install-dx-creds"
+
+# pnpm 9 ran every dependency build script; pnpm 11 (strictDepBuilds) requires
+# an explicit allowlist. These five are the deps with build scripts in the
+# tree — all allowed, preserving pnpm 9 behavior.
+allowBuilds:
+  cbor-extract: true
+  esbuild: true
+  protobufjs: true
+  sharp: true
+  unrs-resolver: true
+
+# pnpm 11 no longer reads the `pnpm` field in package.json; overrides live here.
+overrides:
+  "@types/react": "^19.2.0"
+  "@types/react-dom": "^19.2.0"
+  "postcss@<8.5.10": ">=8.5.10"


### PR DESCRIPTION
## ⚠️ MERGE HOLD — merges LAST

This is a repo-wide toolchain migration: it forces every other open branch to rebase. **Do not merge until `ui-block-finish` + `eng-351-353-bugs` land.** (Held per worktree comment; admin-merge authorized only once it's last + green.)

Closes ENG-332.

## What

- **`packageManager`**: `pnpm@9.12.0` → `pnpm@11.10.0`. Chose 11.10.0 because it's the exact release the CI audit workaround (#184) has been running against this repo, and it's comfortably past any release-age window (published 2026-07-04).
- **`pnpm.overrides` → `pnpm-workspace.yaml`**: pnpm 11 no longer reads the `pnpm` field in package.json (silently — pnpm/pnpm#11536), so the three overrides move to `pnpm-workspace.yaml`.
- **`allowBuilds`**: pnpm 11 defaults `strictDepBuilds` on; the five deps with build scripts (cbor-extract, esbuild, protobufjs, sharp, unrs-resolver) are explicitly allowed — pnpm 9 ran all build scripts, so this preserves behavior exactly.
- **Lockfile**: re-resolved under pnpm 11 → **byte-identical** (pnpm 11 still writes `lockfileVersion: '9.0'`). Other branches get zero lockfile conflicts from this PR; only package.json / pnpm-workspace.yaml can conflict.
- **CI audit job**: the #184 workaround (strip `packageManager`, `npx -y pnpm@11.10.0 audit`) is gone; plain `pnpm audit --prod --audit-level high` now runs on the repo's own pin. Verified locally: "No known vulnerabilities found".
- **demo-bank Dockerfile** + **CONTRIBUTING** (Node 22+, pnpm 11) bumped. No other Dockerfiles/wrangler configs exist; workflows use `pnpm/action-setup` with no version input, so they pick up the new pin automatically.

## Corpus harness re-verification (the vendored-install path)

Checked what pnpm version each of the 16 corpus repos resolves at its pinned SHA:

- **Monorepo targets pinning pnpm 11** (formbricks 11.7, inbox-zero 11.9, openstatus 11.2): already safe — the harness merges vendor overrides into their existing workspace-root `pnpm-workspace.yaml`.
- **Standalone targets pinning pnpm ≤10** (skateshop 9.5, dub 9.15, teable 9.13, rallly 10.28): unaffected — pnpm 11 auto-delegates to the pin, which still reads `package.json` `pnpm.overrides`. Their path is unchanged.
- **Standalone unpinned pnpm targets** (umami, taxonomy, vercel-commerce, nextcrm, express-host): these run whatever pnpm the harness env provides — pnpm 11 after this PR — which silently ignores `package.json` `pnpm.overrides`, so transitive `@vendoai/*` deps would have resolved from the registry. **Fixed**: the harness now mirrors the overrides into a created/merged `pnpm-workspace.yaml` (`packages: ["."]` keeps the file valid for a dev machine still on pnpm 9, which ignores yaml overrides and uses the package.json ones) and drops `--ignore-workspace` from the install command — verified empirically that pnpm 11 skips `pnpm-workspace.yaml` settings entirely under `--ignore-workspace`.

New tests: standalone pinned-11, standalone unpinned, standalone pinned-9 (unchanged behavior guard), pinned-11 with existing curated-builds yaml (merge, no `dangerouslyAllowAllBuilds`).

## pnpm 11 default changes now active (intentional, no config added)

- `minimumReleaseAge=1440`: deps <1 day old won't resolve on updates — aligns with the repo's supply-chain posture.
- `verifyDepsBeforeRun=install`, `blockExoticSubdeps=true`: no exotic deps in the tree; CI installs before running.

## Watch items

- **Corpus nightly (deep tier)**: bootstrap seed/build/dev commands for unpinned targets still pass `--ignore-workspace` to `pnpm run`-style commands; installs are normalized but runs aren't. If `verifyDepsBeforeRun` misfires there, the fix is scoped to the nightly manifest commands.
- All open branches must rebase after this merges (package.json / pnpm-workspace.yaml / ci.yml conflicts only — no lockfile churn).

## Gate

`pnpm build` 19/19 ✓ · `pnpm test` 43/43 ✓ · `pnpm typecheck` 36/36 ✓ · `pnpm lint` (incl. dependency-guard) ✓ · `pnpm audit --prod --audit-level high` clean ✓ — all under pnpm 11.10.0.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades the repo to `pnpm@11.10.0` and migrates overrides to `pnpm-workspace.yaml`. Fulfills ENG-332 by removing the CI audit workaround and ensuring vendored `@vendoai/*` overrides still apply under `pnpm` 11.

- **Dependencies**
  - `packageManager`: `pnpm@9.12.0` → `pnpm@11.10.0` (lockfile stays byte-identical; still `lockfileVersion: '9.0'`).
  - Moved `pnpm.overrides` from `package.json` to `pnpm-workspace.yaml`.
  - Added `allowBuilds` allowlist: `cbor-extract`, `esbuild`, `protobufjs`, `sharp`, `unrs-resolver`.
  - CI: drop workaround; run `pnpm audit --prod --audit-level high`.
  - Docs/Docker: Node 22+ and `pnpm` 11.
  - Corpus harness: for standalone targets on `pnpm` 11 or unpinned, mirror vendored overrides into a created/merged `pnpm-workspace.yaml` and drop `--ignore-workspace`; targets pinned to `pnpm` ≤10 remain unchanged.

- **Migration**
  - Devs use Node 22+ and `pnpm` 11 (corepack/workflows pick the repo pin).
  - After merge, rebase open branches; expect conflicts only in `package.json`, `pnpm-workspace.yaml`, or CI workflow.
  - pnpm 11 defaults now apply: `minimumReleaseAge=1440`, `verifyDepsBeforeRun`, `blockExoticSubdeps`.

<sup>Written for commit dcf8bee70130ca830570182d2dd1e9135a1aa4b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

