### PR TITLE
fix(vendo,core,ui): heartbeat-armed idle abort for client disconnects the runtime never surfaces (ENG-353)

### DIFF
--- a/.changeset/eng-353-heartbeat-idle-abort.md
+++ b/.changeset/eng-353-heartbeat-idle-abort.md
@@ -1,0 +1,7 @@
+---
+"@vendoai/core": patch
+"@vendoai/vendo": patch
+"@vendoai/ui": patch
+---
+
+Fix (ENG-353): heartbeat-armed idle-abort fallback for client disconnects the runtime never surfaces. Under `next dev` a real browser's graceful tab-close/navigate-away fires neither `request.signal` nor a stream cancel, so an abandoned turn ran to completion and burned provider tokens. The panel now beats `POST /threads/:id/heartbeat` while a turn streams; the first beat arms a server-side idle watchdog that aborts the turn through the same controller as the fast path after ~15s of silence. The fetch-abort fast path is unchanged, and consumers that never beat (curl/scripted clients) keep exact run-to-completion semantics.

--- a/docs/verification/foundations-wave6/resilience/07-heartbeat-idle-abort-transcript.txt
+++ b/docs/verification/foundations-wave6/resilience/07-heartbeat-idle-abort-transcript.txt
@@ -1,0 +1,41 @@
+ENG-353 fix verification — heartbeat-armed idle abort (2026-07-17, next dev / Turbopack, Next 16.2.9)
+
+Setup: demo host under `next dev` with ANTHROPIC_BASE_URL pointed at a mock
+Anthropic Messages endpoint that streams a long canned completion and logs
+every request + mid-stream teardown ("CLIENT ABORTED"). No real tokens burned.
+
+1) Fallback (the ENG-353 gap): zombie connection — socket stays open and
+   reading, panel-style beats STOP after 5s. Only the idle watchdog can fire.
+   Cadence host, authenticated turn:
+
+   [mock] 2026-07-17T19:02:05.138Z #3 POST /messages
+   (beats -> 200 {"active":true} at +0s, +3s; then silence)
+   [vendo] turn on thread thr_04acadece46d4f6dadf45ebd484cac0e lost its client
+           heartbeat for 15000ms — aborting the abandoned turn.
+   [mock] 2026-07-17T19:02:23.154Z #3 CLIENT ABORTED mid-stream
+
+   → abandoned turn cancelled ~15s after the last beat, with the connection
+     still open — no socket-close signal involved.
+
+2) Real browser (the field case): browser-disconnect.mjs navigate-away on the
+   Maple UI. The panel's transport now beats the wire (immediate + every 5s):
+
+   POST /api/vendo/threads/thr_87eb…/heartbeat 200   (x2 before disconnect)
+   [browser-drill] 19:00:25.062Z DISCONNECTING (navigate-away) mid-generation
+   [mock]          19:00:25.145Z #2 CLIENT ABORTED mid-stream
+
+   → cancelled in 83ms. In this capture the runtime surfaced the disconnect
+     (fast path won the race); had it not, the armed watchdog above bounds the
+     burn at ~15-20s instead of the previously captured ~7min run-to-completion.
+
+3) Fast path unchanged: client-disconnect.mjs --mode abort
+   [drill] +2053ms fetch torn down after client disconnect (AbortError)
+   [mock] 19:02:41.117Z #1 POST /messages
+   [mock] 19:02:43.127Z #1 CLIENT ABORTED mid-stream
+   (settle window clean — no further provider lines)
+
+4) Non-beating clients unaffected: client-disconnect.mjs --mode control
+   [drill] +30160ms stream ended normally (turn completed)
+   [mock] #2 completed (100 deltas)
+   → a consumer that never beats keeps exact run-to-completion semantics;
+     the watchdog only ever arms on a first heartbeat.

--- a/packages/core/src/heartbeat.test.ts
+++ b/packages/core/src/heartbeat.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withTurnHeartbeat } from "./heartbeat.js";
+
+// ENG-353 — panel-side turn heartbeat. While a wire turn streams, the client
+// beats POST /threads/:id/heartbeat so the server can idle-abort abandoned
+// turns on runtimes that never surface the socket close (`next dev`). The
+// helper wraps the turn Response: beats start when the response arrives and
+// stop the moment the stream ends, errors, is cancelled, or the wire answers
+// active: false.
+
+const encoder = new TextEncoder();
+
+function streamedResponse(headers: Record<string, string>): {
+  response: Response;
+  push: (text: string) => void;
+  end: () => void;
+} {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  return {
+    response: new Response(stream, { status: 200, headers }),
+    push: (text) => controller.enqueue(encoder.encode(text)),
+    end: () => controller.close(),
+  };
+}
+
+const beatUrl = "https://host.test/api/vendo/threads/thr_beat/heartbeat";
+
+describe("withTurnHeartbeat (ENG-353)", () => {
+  let beats: Array<{ url: string; init: RequestInit | undefined }>;
+  let beatResult: { active: boolean };
+  let fetchImpl: typeof fetch;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    beats = [];
+    beatResult = { active: true };
+    fetchImpl = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      beats.push({ url: String(url), init });
+      return Response.json(beatResult);
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const options = (intervalMs = 5_000) => ({
+    baseUrl: "https://host.test/api/vendo",
+    headers: { "x-host": "1" },
+    intervalMs,
+    fetch: fetchImpl,
+  });
+
+  it("beats immediately and on the interval while the stream is open, then stops at stream end", async () => {
+    const { response, push, end } = streamedResponse({ "x-vendo-thread-id": "thr_beat" });
+    const wrapped = withTurnHeartbeat(response, options());
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(beats).toHaveLength(1);
+    expect(beats[0]?.url).toBe(beatUrl);
+    expect(beats[0]?.init?.method).toBe("POST");
+    expect(new Headers(beats[0]?.init?.headers).get("content-type")).toBe("application/json");
+    expect(new Headers(beats[0]?.init?.headers).get("x-host")).toBe("1");
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(beats).toHaveLength(2);
+
+    // Consume the stream to its natural end — beats must stop.
+    push("data: x\n\n");
+    end();
+    const reader = wrapped.body!.getReader();
+    while (!(await reader.read()).done) { /* drain */ }
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(beats).toHaveLength(2);
+  });
+
+  it("stops beating when the wire answers active: false", async () => {
+    const { response } = streamedResponse({ "x-vendo-thread-id": "thr_beat" });
+    beatResult = { active: false };
+    withTurnHeartbeat(response, options());
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(beats).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(beats).toHaveLength(1);
+  });
+
+  it("stops beating when the consumer cancels (fetch abort fast path)", async () => {
+    const { response } = streamedResponse({ "x-vendo-thread-id": "thr_beat" });
+    const wrapped = withTurnHeartbeat(response, options());
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(beats).toHaveLength(1);
+    await wrapped.body!.cancel();
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(beats).toHaveLength(1);
+  });
+
+  it("passes through responses without a thread id, body, or ok status", async () => {
+    const plain = new Response("nope", { status: 400 });
+    expect(withTurnHeartbeat(plain, options())).toBe(plain);
+
+    const headerless = streamedResponse({}).response;
+    expect(withTurnHeartbeat(headerless, options())).toBe(headerless);
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(beats).toHaveLength(0);
+  });
+
+  it("keeps beating through transient beat failures", async () => {
+    const { response } = streamedResponse({ "x-vendo-thread-id": "thr_beat" });
+    vi.mocked(fetchImpl).mockRejectedValueOnce(new Error("network blip"));
+    withTurnHeartbeat(response, options());
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(beats.length).toBeGreaterThanOrEqual(1); // the rejected call + the retry tick
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(vi.mocked(fetchImpl).mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("preserves the response status and headers on the wrapped response", () => {
+    const { response } = streamedResponse({ "x-vendo-thread-id": "thr_beat", "content-type": "text/event-stream" });
+    const wrapped = withTurnHeartbeat(response, options());
+    expect(wrapped.status).toBe(200);
+    expect(wrapped.headers.get("content-type")).toBe("text/event-stream");
+    expect(wrapped.headers.get("x-vendo-thread-id")).toBe("thr_beat");
+  });
+});

--- a/packages/core/src/heartbeat.ts
+++ b/packages/core/src/heartbeat.ts
@@ -1,0 +1,97 @@
+/** ENG-353 — panel-side turn heartbeat.
+ *
+ * Some server runtimes never surface a graceful client disconnect to a
+ * streaming route handler (`next dev` is the field case: a closed tab fires
+ * neither `request.signal` nor a stream cancel), so an abandoned turn runs to
+ * completion and burns provider tokens. The wire's fallback is liveness by
+ * heartbeat: while a turn streams, the consumer beats
+ * `POST /threads/:id/heartbeat`; once a turn has been beaten at least once,
+ * ~15s of silence idle-aborts it server-side. Consumers that never beat are
+ * unaffected (scripted/curl clients keep their run-to-completion semantics),
+ * and the fetch-abort fast path stays the immediate cancellation road.
+ *
+ * `withTurnHeartbeat` wraps a `POST /threads` streaming Response: it starts
+ * beating the moment the response arrives (thread id from
+ * `X-Vendo-Thread-Id`) and stops when the stream ends, errors, is cancelled,
+ * or the wire answers `active: false`. Non-streaming, non-ok, or header-less
+ * responses pass through untouched.
+ */
+
+const THREAD_ID_HEADER = "x-vendo-thread-id";
+const DEFAULT_BEAT_INTERVAL_MS = 5_000;
+
+export interface TurnHeartbeatOptions {
+  /** The wire mount the turn was posted to (e.g. `https://host/api/vendo`). */
+  baseUrl: string;
+  /** Extra headers for beat requests (the client's wire headers). */
+  headers?: Record<string, string>;
+  /** Beat cadence; the server's idle window is a small multiple of this. */
+  intervalMs?: number;
+  /** Injection seam for tests; defaults to the global fetch. */
+  fetch?: typeof fetch;
+}
+
+export function withTurnHeartbeat(response: Response, options: TurnHeartbeatOptions): Response {
+  const threadId = response.headers.get(THREAD_ID_HEADER);
+  if (threadId === null || !response.ok || response.body === null) return response;
+
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const url = `${options.baseUrl.replace(/\/$/, "")}/threads/${encodeURIComponent(threadId)}/heartbeat`;
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let stopped = false;
+
+  const stop = (): void => {
+    if (stopped) return;
+    stopped = true;
+    if (timer !== undefined) clearInterval(timer);
+  };
+
+  const beat = async (): Promise<void> => {
+    try {
+      const result = await fetchImpl(url, {
+        method: "POST",
+        headers: { ...options.headers, "content-type": "application/json" },
+        body: "{}",
+      });
+      if (!result.ok) {
+        stop(); // wire without the route (or auth lost) — don't spam
+        return;
+      }
+      const payload = await result.json().catch(() => undefined) as { active?: boolean } | undefined;
+      if (payload?.active === false) stop();
+    } catch {
+      // Transient network failure — keep beating; the server's idle window
+      // tolerates a missed beat or two.
+    }
+  };
+
+  void beat();
+  timer = setInterval(() => {
+    if (!stopped) void beat();
+  }, options.intervalMs ?? DEFAULT_BEAT_INTERVAL_MS);
+  // In Node consumers the beat timer must never hold the process open.
+  (timer as { unref?: () => void }).unref?.();
+
+  const reader = response.body.getReader();
+  const tracked = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          stop();
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (error) {
+        stop();
+        controller.error(error);
+      }
+    },
+    cancel(reason) {
+      stop();
+      return reader.cancel(reason);
+    },
+  });
+  return new Response(tracked, response);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export * from "./errors.js";
 export * from "./formats.js";
 export * from "./grants.js";
 export * from "./guard.js";
+export * from "./heartbeat.js";
 export * from "./host-seams.js";
 export * from "./ids.js";
 export * from "./jcs.js";

--- a/packages/ui/src/hooks/use-vendo-thread.ts
+++ b/packages/ui/src/hooks/use-vendo-thread.ts
@@ -1,5 +1,5 @@
 /** ai-SDK v6-compatible conversation transport (08-ui §3, 03-agent §4). */
-import type { VendoApprovalPart } from "@vendoai/core";
+import { withTurnHeartbeat, type VendoApprovalPart } from "@vendoai/core";
 import { useChat } from "@ai-sdk/react";
 import {
   DefaultChatTransport,
@@ -106,7 +106,13 @@ export function useVendoThread(threadId?: string) {
             setEffectiveThreadId(returnedThreadId);
           }
           recordStream(response);
-          return response;
+          // ENG-353: beat /threads/:id/heartbeat while this turn streams so
+          // the server can idle-abort the turn if this tab closes on a
+          // runtime that never surfaces the disconnect (`next dev`).
+          return withTurnHeartbeat(response, {
+            baseUrl: client.baseUrl.replace(/\/$/, ""),
+            headers: client.headers,
+          });
         },
         prepareSendMessagesRequest: ({ messages }) => {
           const message = messages.at(-1);

--- a/packages/vendo/src/server.test.ts
+++ b/packages/vendo/src/server.test.ts
@@ -1559,3 +1559,131 @@ describe("kill-list A5 — orgs are a Vendo Cloud capability, not an OSS wire ro
     expect((await vendo.handler(request("DELETE", "/grants/grant_1?org=org_x"))).status).toBe(402);
   });
 });
+
+describe("ENG-353 — turn liveness: heartbeat-armed idle abort for disconnects the runtime never surfaces", () => {
+  // Generous margins: CI runners under coverage load stall for hundreds of
+  // milliseconds, and a spurious idle-abort here would flake the suite.
+  const IDLE_MS = 1_000;
+
+  /** agent.stream stub whose SSE body stays open until the handed signal
+   *  aborts — a long-generating turn. */
+  function streamingTurnStub(vendo: Vendo, threadId = "thr_live"): { signals: AbortSignal[] } {
+    const signals: AbortSignal[] = [];
+    vi.spyOn(vendo.agent, "stream").mockImplementation(async (input: { signal?: AbortSignal }) => {
+      signals.push(input.signal!);
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("data: {\"type\":\"start\"}\n\n"));
+          input.signal?.addEventListener("abort", () => {
+            try {
+              controller.close();
+            } catch {
+              /* already closed */
+            }
+          }, { once: true });
+        },
+      });
+      const response = new Response(stream, {
+        headers: { "content-type": "text/event-stream", "x-vendo-thread-id": threadId },
+      });
+      return response;
+    });
+    return { signals };
+  }
+
+  const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+  const turnBody = { message: { id: "m_live", role: "user", parts: [] } };
+  const beat = (vendo: Vendo, id = "thr_live"): Promise<Response> =>
+    vendo.handler(request("POST", `/threads/${id}/heartbeat`, {}));
+
+  it("aborts a turn whose heartbeats stop; beats keep it alive; never-beating turns run to completion", async () => {
+    vi.stubEnv("VENDO_TURN_IDLE_ABORT_MS", String(IDLE_MS));
+    try {
+      const { vendo } = await setup();
+      const { signals } = streamingTurnStub(vendo);
+
+      await vendo.handler(request("POST", "/threads", turnBody));
+      const signal = signals[0]!;
+
+      // Beats keep the turn alive well past the idle window…
+      for (let i = 0; i < 4; i += 1) {
+        expect(await (await beat(vendo)).json()).toEqual({ active: true });
+        await wait(IDLE_MS / 2);
+        expect(signal.aborted).toBe(false);
+      }
+      // …then silence idle-aborts it.
+      await wait(IDLE_MS * 3);
+      expect(signal.aborted).toBe(true);
+      // A beat after the turn ended reports it inactive.
+      expect(await (await beat(vendo)).json()).toEqual({ active: false });
+
+      // Opt-in by construction: a turn whose client NEVER beats is untouched.
+      const second = await vendo.handler(request("POST", "/threads", turnBody));
+      expect(second.status).toBe(200);
+      await wait(IDLE_MS * 3);
+      expect(signals[1]!.aborted).toBe(false);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("a foreign principal's beat neither refreshes nor reveals another's turn", async () => {
+    vi.stubEnv("VENDO_TURN_IDLE_ABORT_MS", String(IDLE_MS));
+    try {
+      const resolver = vi.fn(async () => principal);
+      const { vendo } = await setup(resolver);
+      const { signals } = streamingTurnStub(vendo);
+
+      await vendo.handler(request("POST", "/threads", turnBody));
+      // Arm the watchdog as the owner.
+      expect(await (await beat(vendo)).json()).toEqual({ active: true });
+
+      // The attacker keeps beating the same thread id — as someone else.
+      resolver.mockResolvedValue({ kind: "user", subject: "user_mallory" });
+      const foreign = await (await beat(vendo)).json();
+      expect(foreign).toEqual({ active: false });
+      for (let i = 0; i < 3; i += 1) {
+        await wait(IDLE_MS / 2);
+        await beat(vendo);
+      }
+      // Foreign beats did NOT keep the owner's turn alive.
+      expect(signals[0]!.aborted).toBe(true);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("keeps the fast path: the request signal still aborts the turn immediately", async () => {
+    const { vendo } = await setup();
+    const { signals } = streamingTurnStub(vendo);
+    const controller = new AbortController();
+    const disconnectable = new Request("https://host.test/api/vendo/threads", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(turnBody),
+      signal: controller.signal,
+    });
+    await vendo.handler(disconnectable);
+    expect(signals[0]!.aborted).toBe(false);
+    controller.abort();
+    expect(signals[0]!.aborted).toBe(true);
+  });
+
+  it("a completed turn unregisters: beats after the stream drained report inactive", async () => {
+    const { vendo } = await setup();
+    vi.spyOn(vendo.agent, "stream").mockResolvedValue(new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+          controller.close();
+        },
+      }),
+      { headers: { "content-type": "text/event-stream", "x-vendo-thread-id": "thr_done" } },
+    ));
+    const response = await vendo.handler(request("POST", "/threads", turnBody));
+    expect(await (await beat(vendo, "thr_done")).json()).toEqual({ active: true });
+    const reader = response.body!.getReader();
+    while (!(await reader.read()).done) { /* drain */ }
+    expect(await (await beat(vendo, "thr_done")).json()).toEqual({ active: false });
+  });
+});

--- a/packages/vendo/src/turn-liveness.ts
+++ b/packages/vendo/src/turn-liveness.ts
@@ -1,0 +1,113 @@
+/** ENG-353 — server-side turn liveness: the idle-abort fallback for client
+ * disconnects the runtime never surfaces.
+ *
+ * The fast path is unchanged: `request.signal` cancels the turn the moment the
+ * runtime propagates a fetch abort (wave-5 AGENT-3). But under `next dev` a
+ * real browser's graceful tab-close/navigate-away fires neither the signal nor
+ * a stream cancel, so an abandoned turn runs to completion. The fallback is
+ * liveness by heartbeat: the panel beats `POST /threads/:id/heartbeat` while
+ * it consumes the stream (08 — `withTurnHeartbeat`); the FIRST beat arms the
+ * watchdog, and from then on `IDLE_ABORT_MS` of silence aborts the turn.
+ * Arming is opt-in by construction: consumers that never beat (curl drills,
+ * scripted clients, older panels) keep run-to-completion semantics.
+ *
+ * The registry lives on globalThis (Symbol.for) so HMR copies of this module
+ * under a dev server share one view: a turn registered before an edit is still
+ * beatable after it.
+ */
+
+const IDLE_ABORT_MS = 15_000;
+
+interface ActiveTurn {
+  threadId: string;
+  subject: string;
+  abort: () => void;
+  idleTimer?: ReturnType<typeof setTimeout>;
+}
+
+const ACTIVE_TURNS_KEY = Symbol.for("vendoai.vendo.active-turns@1");
+
+function activeTurns(): Set<ActiveTurn> {
+  const holder = globalThis as { [ACTIVE_TURNS_KEY]?: Set<ActiveTurn> };
+  return (holder[ACTIVE_TURNS_KEY] ??= new Set());
+}
+
+/** Test seam only: the idle window, overridable per call site via env. */
+function idleAbortMs(): number {
+  const configured = Number(process.env.VENDO_TURN_IDLE_ABORT_MS);
+  return Number.isFinite(configured) && configured > 0 ? configured : IDLE_ABORT_MS;
+}
+
+/** Track one streaming turn; returns its unregister. Registration alone never
+ *  arms the watchdog — only a first heartbeat does. */
+export function registerActiveTurn(turn: { threadId: string; subject: string; abort: () => void }): () => void {
+  const entry: ActiveTurn = { ...turn };
+  activeTurns().add(entry);
+  return () => {
+    if (entry.idleTimer !== undefined) clearTimeout(entry.idleTimer);
+    activeTurns().delete(entry);
+  };
+}
+
+/** A heartbeat for `threadId` from `subject`. Refreshes (and on first beat
+ *  arms) the idle watchdog of every matching in-flight turn. Foreign or
+ *  unknown ids answer false — no oracle, and a beat can never keep (or end)
+ *  another principal's turn. */
+export function touchActiveTurn(threadId: string, subject: string): boolean {
+  let active = false;
+  for (const turn of activeTurns()) {
+    if (turn.threadId !== threadId || turn.subject !== subject) continue;
+    active = true;
+    if (turn.idleTimer !== undefined) clearTimeout(turn.idleTimer);
+    turn.idleTimer = setTimeout(() => {
+      console.warn(
+        `[vendo] turn on thread ${turn.threadId} lost its client heartbeat for ${idleAbortMs()}ms — aborting the abandoned turn.`,
+      );
+      // Drop the entry now (idempotent with the stream-settled unregister):
+      // an idle-aborted turn is over, and a late beat must see it inactive
+      // even before the runtime drains the closing stream.
+      activeTurns().delete(turn);
+      turn.abort();
+    }, idleAbortMs());
+    turn.idleTimer.unref?.();
+  }
+  return active;
+}
+
+/** Wrap a turn response so `onSettled` runs exactly once when its stream
+ *  finishes, errors, or is cancelled — the turn's registry entry must not
+ *  outlive the stream. Mirrors the wire's inflight-bracket wrapper. */
+export function trackTurnResponse(response: Response, onSettled: () => void): Response {
+  if (response.body === null) {
+    onSettled();
+    return response;
+  }
+  let settled = false;
+  const settle = (): void => {
+    if (settled) return;
+    settled = true;
+    onSettled();
+  };
+  const reader = response.body.getReader();
+  const tracked = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          settle();
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (error) {
+        settle();
+        controller.error(error);
+      }
+    },
+    cancel(reason) {
+      settle();
+      return reader.cancel(reason);
+    },
+  });
+  return new Response(tracked, response);
+}

--- a/packages/vendo/src/wire/threads.ts
+++ b/packages/vendo/src/wire/threads.ts
@@ -1,5 +1,9 @@
 import { VendoError } from "@vendoai/core";
+import { registerActiveTurn, touchActiveTurn, trackTurnResponse } from "../turn-liveness.js";
 import { json, requestJson, route, string, type RouteEntry } from "./shared.js";
+
+/** The effective thread id the agent stamps on every turn response (03 §1). */
+const THREAD_ID_HEADER = "x-vendo-thread-id";
 
 /** 09 §3 — the /threads wire area: chat streaming plus thread list/get/delete. */
 export const threadRoutes: RouteEntry[] = [
@@ -7,15 +11,38 @@ export const threadRoutes: RouteEntry[] = [
     const body = await requestJson(request);
     const ctx = await context("chat");
     void deps.telemetry?.track("agent_run", {});
-    return await deps.agent.stream({
+    // AGENT-3 (fast path): a propagated client disconnect aborts the request,
+    // which cancels the agent loop — provider calls stop instead of running to
+    // completion for a reader that is gone.
+    // ENG-353 (fallback): some runtimes never surface a graceful disconnect
+    // (`next dev` fires neither the signal nor a cancel), so a heartbeat-armed
+    // idle watchdog can abort the turn through the same controller. Consumers
+    // that never beat keep run-to-completion semantics.
+    const turnAbort = new AbortController();
+    if (request.signal.aborted) turnAbort.abort();
+    else request.signal.addEventListener("abort", () => turnAbort.abort(), { once: true });
+    const turn = await deps.agent.stream({
       ...(body["threadId"] === undefined ? {} : { threadId: string(body["threadId"], "threadId") }),
       message: body["message"] as never,
       ctx,
-      // AGENT-3: client disconnect aborts the request, which cancels the
-      // agent loop — provider calls stop instead of running to completion
-      // for a reader that is gone.
-      signal: request.signal,
+      signal: turnAbort.signal,
     });
+    const threadId = turn.headers.get(THREAD_ID_HEADER);
+    if (threadId === null) return turn;
+    const unregister = registerActiveTurn({
+      threadId,
+      subject: ctx.principal.subject,
+      abort: () => turnAbort.abort(),
+    });
+    return trackTurnResponse(turn, unregister);
+  }),
+  // ENG-353 — turn-liveness beat. Principal-scoped: it refreshes only the
+  // caller's own in-flight turns, and unknown/foreign ids answer
+  // `active: false` (no oracle).
+  route("POST", "/threads/:id/heartbeat", async ({ context, params }) => {
+    const ctx = await context("chat");
+    const id = string(params["id"], "thread id");
+    return json({ active: touchActiveTurn(id, ctx.principal.subject) });
   }),
   route("GET", "/threads", async ({ deps, context }) => {
     return json(await deps.agent.threads.list(await context("chat")));


### PR DESCRIPTION
## ENG-353 (High) — client-disconnect cancellation does not fire on real-browser tab-close under `next dev`

### Problem
Wave-5 cancellation (ENG-238) rides `request.signal`. Under `next dev` (Turbopack), a real Chromium client's graceful tab-close / navigate-away fires neither the signal nor a stream cancel, so the abandoned agent turn runs to completion against a reader that is gone — observed **7 provider calls over ~7m14s** after a tab close. It only worked when Next surfaced the socket close (scripted fetch-abort / killed curl → 3-7ms teardown).

### Fix — heartbeat-armed idle-abort fallback (opt-in by construction)
- **wire** (`packages/vendo`): new `POST /threads/:id/heartbeat` route, principal-scoped (no oracle — unknown/foreign ids answer `active: false`). The `POST /threads` turn now runs on a dedicated `AbortController` mirrored from `request.signal`; the **first** heartbeat arms a ~15s idle watchdog on the caller's in-flight turn, and silence aborts it through the **same controller** as the fast path. A completed/aborted turn unregisters when its stream settles.
- **core** (`packages/core`): `withTurnHeartbeat(response, …)` wraps a streaming turn `Response` — beats immediately and every 5s until the stream ends/errors/cancels or the wire answers `active: false`.
- **ui** (`packages/ui`): the default transport wraps its turn responses with the helper (one call site).

The fetch-abort **fast path is unchanged** and stays the immediate cancellation road. Consumers that never beat (curl drills, scripted clients) keep **exact run-to-completion** semantics — the watchdog only ever arms on a first heartbeat.

### Tests (regression)
- `packages/core/src/heartbeat.test.ts` — client helper: immediate + interval beats, stop on stream end / `active:false` / cancel, pass-through for non-stream/headerless, resilience to transient beat failures.
- `packages/vendo/src/server.test.ts` (ENG-353 suite) — idle-abort after silence, beats keeping a turn alive, **principal isolation** (a foreign beat neither refreshes nor reveals another's turn), unchanged fast path, completed-turn unregistration.

### Verification
Live-verified under `next dev` (Turbopack, Next 16.2.9) with a mock Anthropic endpoint (no real tokens): a zombie connection whose beats stop is idle-aborted ~15s later; real-browser navigate-away cancels in <100ms (fast path wins the race, watchdog bounds the burn otherwise); the control drill still runs to completion. Transcript: `docs/verification/foundations-wave6/resilience/07-heartbeat-idle-abort-transcript.txt`.

### Gate
`pnpm build && pnpm test:coverage && pnpm typecheck && pnpm lint` green (each affected package green under the CI coverage gate: core 25 files, ui 40, vendo 45; dependency-guard OK).

Closes ENG-353.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a heartbeat-armed idle-abort fallback to reliably cancel abandoned streaming turns when real-browser disconnects aren’t surfaced (e.g., `next dev`). This prevents long-running provider calls after tab close and keeps the fast abort path unchanged. Addresses ENG-353.

- New Features
  - Added `POST /threads/:id/heartbeat` in `@vendoai/vendo` (principal-scoped; first beat arms ~15s idle watchdog; silence aborts via the same controller; foreign/unknown ids return `active: false`).
  - Introduced `withTurnHeartbeat` in `@vendoai/core` to beat immediately and every 5s while a turn streams; stops on end/error/cancel or `active:false`.
  - `@vendoai/ui` wraps turn responses with `withTurnHeartbeat` so the panel beats automatically during streams.

- Bug Fixes
  - Under `next dev`, real-browser tab close/navigate-away now cancels turns even when the runtime doesn’t propagate `request.signal`.
  - Fast path unchanged: `request.signal` still aborts immediately.
  - Non-beating clients keep run-to-completion; completed turns unregister and later beats report inactive.

<sup>Written for commit 51f3fc98ed487e9bb258a27279b18116ef98c6a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

