### PR TITLE
test(ui): stabilize chrome streaming coverage flakes (testTimeout + asyncUtilTimeout)

### DIFF
--- a/packages/ui/test/setup.ts
+++ b/packages/ui/test/setup.ts
@@ -6,8 +6,20 @@
  * one so cross-realm aborts keep working exactly like a browser.
  */
 import { transferableAbortController } from "node:util";
-import { cleanup } from "@testing-library/react";
+import { cleanup, configure } from "@testing-library/react";
 import { afterEach } from "vitest";
+
+/**
+ * Raise Testing Library's default async-utility window from 1s to 10s for the
+ * whole package. The chrome streaming tests await streamed UI with bare
+ * `findBy*` / `waitFor` calls (the retry banner, "Turn complete", a minted
+ * thread arriving in the sidebar); under the CI coverage (v8) instrumentation
+ * job those settles intermittently exceed the 1s default, surfacing as flaky
+ * "Unable to find role=button 'Retry' / 'Fixture thread'" failures on shared
+ * runners. Widening the ceiling only adds headroom under load — a query still
+ * resolves the moment its element appears, so fast local runs are unaffected.
+ */
+configure({ asyncUtilTimeout: 10000 });
 
 /**
  * This package's vitest config does not enable `globals`, so

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -15,6 +15,16 @@ export default defineConfig({
     environment: "jsdom",
     include: ["test/**/*.test.ts?(x)"],
     setupFiles: ["test/setup.ts"],
+    // Flake floor for the chrome streaming suite. These tests drive a turn and
+    // then await streamed UI (the sidebar refresh, the retry banner, "Turn
+    // complete"), each guarded by its own generous `waitFor`/`findBy` window.
+    // Under the CI coverage (v8) job those settles legitimately run past
+    // vitest's 5s default testTimeout, so the per-test cap — not the inner
+    // waits — was killing them ("Unable to find role=button 'Fixture thread' /
+    // 'Retry'"). A test cap comfortably above the inner waits lets those
+    // windows actually apply; passing tests still resolve the instant their
+    // condition is met, so this only adds headroom under load.
+    testTimeout: 30000,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## What

Stabilizes the `@vendoai/ui` chrome streaming tests that flake under the CI **Test with coverage** job. Two central levers in the package's vitest config/setup — no test-by-test edits, no product code change:

- `vitest.config.ts`: `testTimeout: 30000` (was vitest's 5s default)
- `test/setup.ts`: `configure({ asyncUtilTimeout: 10000 })` (was Testing Library's 1s default)

## Root cause

These tests drive a turn and then await streamed UI. Under v8 coverage instrumentation on shared runners the async settle intermittently exceeds the default windows, surfacing as:

- `page-sidebar-refresh.test.tsx` → *"Unable to find role=button 'Fixture thread'"* / *"Test timed out in 5000ms"*. The test already had generous 12s `waitFor` ceilings, but vitest's **5s default `testTimeout` killed the test before those 12s waits could apply** — the inner waits were inert.
- `error-surface.test.tsx` (the actual CI failure on the pre-merge commit — *"Unable to find role=button 'Retry'"*, 304/305) and `chrome-behavior` (*'kaboom'*, *'Fixture thread'*) → bare `findBy*` with the **1s default `asyncUtilTimeout`**, which the streamed settle occasionally overruns.

Both levers only raise ceilings — a query still resolves the instant its element appears, so passing runs are unaffected; only genuinely slow-under-load settles get the headroom.

## Verification

- **Mechanism proof (deterministic):** a throwaway test with (a) a 12s `waitFor` settling at ~6.5s and (b) a `findBy` for an element added at ~2.5s **fails on the old config** with the exact two CI symptoms (`Test timed out in 5000ms`, `Unable to find role=button`) and **passes with this change**.
- **20x loop:** full `@vendoai/ui` suite with `--coverage` (Node 22, matching CI), 20/20 green (305 passed each).
- Full gate (build/test/typecheck/lint) green.

## Not a UI change

Test-infra only (vitest timeouts). No runtime/rendered-output change, so no browser screenshots apply. The `fluidkit` alias-stub and all existing flake mitigations are untouched.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilize `@vendoai/ui` chrome streaming tests in the CI "Test with coverage" job by increasing global test timeouts. Prevents intermittent "Test timed out" and "Unable to find role=button" flakes without changing product code.

- **Bug Fixes**
  - `vitest.config.ts`: set `testTimeout` to 30s (from 5s).
  - `test/setup.ts`: `@testing-library/react` `configure({ asyncUtilTimeout: 10000 })` (from 1s).

<sup>Written for commit 0b65f2ef6ab03934228fb71d41993d3dc44b384e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

