### PR TITLE
B1: extraction on the TypeScript AST (kill-list B1)

### DIFF
--- a/docs/superpowers/plans/2026-07-17-b1-extraction-ast.md
+++ b/docs/superpowers/plans/2026-07-17-b1-extraction-ast.md
@@ -47,6 +47,6 @@
 `docs/contracts/` is being retired (archived; the behavior contract is types + tests). Per coordinator instruction the 04-actions.md amendment was dropped from this branch; no docs/contracts/ file is touched.
 
 ## Task 6: Verification and PR
-- [ ] Re-run `pnpm corpus run --layer 2 --json` on the finished branch in the same clone; per-repo scores equal-or-better than the Task 0 baseline; fix any regression before proceeding
-- [ ] `pnpm build && pnpm exec turbo run test --concurrency=4 && pnpm typecheck && pnpm lint` green (actions fixture.e2e re-run once if sole failure)
-- [ ] Push branch, open PR "B1: extraction on the TypeScript AST (kill-list B1)" with before/after line counts, the corpus baseline-vs-after table, and the deletion inventory; do not merge
+- [x] Re-run `pnpm corpus run --layer 2 --json` on the finished branch in the same clone; per-repo scores equal-or-better than the Task 0 baseline — first branch sweep caught a real regression (rallly post-init host build: `zod ^3.24.0` floor let a stale host zod@3.24.0 poison @ai-sdk peer resolution); fixed by raising the floor to `^3.25.0`, full re-sweep clean: all 16 repos identical scores, zero regressions
+- [x] `pnpm build && pnpm exec turbo run test --concurrency=4 && pnpm typecheck && pnpm lint` green (run in a space-free checkout; core packaging.e2e cannot execute under a spaces path — pre-existing Vite %20 limitation)
+- [x] Push branch, open PR "B1: extraction on the TypeScript AST (kill-list B1)" with before/after line counts, the corpus baseline-vs-after table, and the deletion inventory; do not merge

--- a/docs/superpowers/plans/2026-07-17-b1-extraction-ast.md
+++ b/docs/superpowers/plans/2026-07-17-b1-extraction-ast.md
@@ -1,0 +1,54 @@
+# B1: Extraction on the TypeScript AST — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Kill-list item B1 (`docs/superpowers/specs/2026-07-16-simplify-v2-kill-list-design.md` §B1): the extraction pipeline keeps its exact behavior and coverage but every hand-rolled TypeScript parser in `packages/actions/src/sync/` — the route-scan verb regexes, the brace-walker toolkit in `common.ts`, and the pins `StaticValueParser` — is rewritten on the TypeScript compiler API the package already uses for tRPC, server actions, and catalog scanning. The zod→JSON-Schema interpreter's passthrough-modifier allowlist narrows to measured usage. Filenames, exports, and the public API do not change.
+
+**Behavior lock:** the existing `@vendoai/actions` test suite plus the corpus harness. A full `pnpm corpus run --layer 2` baseline is captured at the base commit (in a space-free clone — the harness rejects paths with spaces) before any change; the same sweep re-runs on the finished branch and must be equal-or-better per repo.
+
+**Why the module-lexer moves too:** simplify-v2 proved `fallbackModuleStatements` is the live TSX parser behind `resolveImportSource`/`importReferenceFor` (es-module-lexer throws on JSX). Its consumers are not just route-scan and pins — every extractor resolves imports through it. The only way it "loses all its consumers" (spec §A6-corrected / §B1) is to move the module-statement reading itself onto the TypeScript AST, which also retires the `es-module-lexer` dependency.
+
+**Per-task ritual:** tests first (add coverage locks against the current implementation where the exotic paths are untested, watch them pass, then swap internals), `pnpm --filter @vendoai/actions test` green, one commit.
+
+---
+
+## Task 0: Corpus baseline
+- [x] Clone the worktree at the base commit into a space-free scratch path, `pnpm install && pnpm build`, run `pnpm corpus run --layer 2 --json`, save the scorecard (runs in background alongside Tasks 1-4)
+
+## Task 1: Module analysis in common.ts onto the TS AST
+**Files:** `packages/actions/src/sync/common.ts` (module lexing internals), `packages/actions/package.json` (drop `es-module-lexer`).
+- [ ] Add behavior-lock tests for import/re-export resolution shapes only exercised implicitly today (namespace member references, export-star chains, semicolon-free TSX) — green against the current implementation
+- [ ] Replace the es-module-lexer + `fallbackModuleStatements` path inside the module reader with TypeScript-AST statement walks (host-first compiler loading, same fail-closed posture as `static-ts.ts`)
+- [ ] Delete `fallbackModuleStatements`; grep-verify no consumer remains; drop the `es-module-lexer` dependency
+- [ ] Actions suite green; commit
+
+## Task 2: route-scan.ts onto the TS AST
+**Files:** `packages/actions/src/sync/route-scan.ts`.
+- [ ] Add a route-scan behavior-lock test file covering the currently untested evidence paths: destructured verb exports, `export { x as GET }`, verb-keyed `defaultHandler` objects, `"VERB /path"` route maps, `setHeader("Allow", ...)` lists, `NextAuth()` pages, re-export/delegate chains, and the pages-inference heuristics — green against the current implementation
+- [ ] Rewrite verb evidence gathering (exported verbs, route maps, method-key objects, re-export targets, page inference) as AST queries over the parsed route module; file-path→URL mapping (`cleanSegment`/`routePath`) stays — those regexes match path segments, not code
+- [ ] Remove the now-dead statement/brace helpers from route-scan and the `splitTopLevel`/`stripComments`/`topLevelObjectLiteral` imports
+- [ ] Actions suite green; commit
+
+## Task 3: pins.ts onto the TS AST
+**Files:** `packages/actions/src/sync/pins.ts`, then dead-helper cleanup in `common.ts`.
+- [ ] Registration discovery (`{ name, component }` object literals, `remixable(` helper marking, router-table `path` exclusion, literal offsets) becomes an AST walk
+- [ ] `StaticValueParser` is replaced by static AST evaluation of the sampleProps initializer with the same JSON-compatible acceptance rules (same invalid-sampleProps warnings)
+- [ ] `importSpecifiers` (static, re-export, dynamic import; type-only skipped) becomes an AST walk
+- [ ] Delete `splitTopLevel`, `topLevelObjectLiteral`, and `stripComments` from common.ts once grep shows zero consumers; tsconfig JSONC parsing moves to the compiler API's config-text parser
+- [ ] Actions suite green; commit
+
+## Task 4: Narrow the zod passthrough allowlist
+**Files:** `packages/actions/src/sync/static-ts.ts`.
+- [ ] Measure: grep the corpus checkouts (from the Task 0 clone) and the actions test suite for zod modifier methods actually chained in extracted input schemas
+- [ ] Shrink `ZOD_PASSTHROUGH_MODIFIERS` to that measured set; unlisted modifiers keep failing closed (permissive schema + note); adjust any test that asserted passthrough of a removed modifier to assert the fail-closed result instead
+- [ ] Actions suite green; commit
+
+## Task 5: Contract amendment
+**Files:** `docs/contracts/04-actions.md`.
+- [ ] Amend §1 prose: route-scan and pin capture are now compiler-API static analysis like tRPC/GraphQL/server-actions; dated changelog entry, authorized-by kill-list §B1
+- [ ] Commit
+
+## Task 6: Verification and PR
+- [ ] Re-run `pnpm corpus run --layer 2 --json` on the finished branch in the same clone; per-repo scores equal-or-better than the Task 0 baseline; fix any regression before proceeding
+- [ ] `pnpm build && pnpm exec turbo run test --concurrency=4 && pnpm typecheck && pnpm lint` green (actions fixture.e2e re-run once if sole failure)
+- [ ] Push branch, open PR "B1: extraction on the TypeScript AST (kill-list B1)" with before/after line counts, the corpus baseline-vs-after table, and the deletion inventory; do not merge

--- a/docs/superpowers/plans/2026-07-17-b1-extraction-ast.md
+++ b/docs/superpowers/plans/2026-07-17-b1-extraction-ast.md
@@ -17,36 +17,34 @@
 
 ## Task 1: Module analysis in common.ts onto the TS AST
 **Files:** `packages/actions/src/sync/common.ts` (module lexing internals), `packages/actions/package.json` (drop `es-module-lexer`).
-- [ ] Add behavior-lock tests for import/re-export resolution shapes only exercised implicitly today (namespace member references, export-star chains, semicolon-free TSX) — green against the current implementation
-- [ ] Replace the es-module-lexer + `fallbackModuleStatements` path inside the module reader with TypeScript-AST statement walks (host-first compiler loading, same fail-closed posture as `static-ts.ts`)
-- [ ] Delete `fallbackModuleStatements`; grep-verify no consumer remains; drop the `es-module-lexer` dependency
-- [ ] Actions suite green; commit
+- [x] Add behavior-lock tests for import/re-export resolution shapes only exercised implicitly today (namespace member references, export-star chains, semicolon-free TSX) — green against the current implementation
+- [x] Replace the es-module-lexer + `fallbackModuleStatements` path inside the module reader with TypeScript-AST statement walks (host-first compiler loading, same fail-closed posture as `static-ts.ts`)
+- [x] Delete `fallbackModuleStatements`; grep-verify no consumer remains; drop the `es-module-lexer` dependency
+- [x] Actions suite green; commit
 
 ## Task 2: route-scan.ts onto the TS AST
 **Files:** `packages/actions/src/sync/route-scan.ts`.
-- [ ] Add a route-scan behavior-lock test file covering the currently untested evidence paths: destructured verb exports, `export { x as GET }`, verb-keyed `defaultHandler` objects, `"VERB /path"` route maps, `setHeader("Allow", ...)` lists, `NextAuth()` pages, re-export/delegate chains, and the pages-inference heuristics — green against the current implementation
-- [ ] Rewrite verb evidence gathering (exported verbs, route maps, method-key objects, re-export targets, page inference) as AST queries over the parsed route module; file-path→URL mapping (`cleanSegment`/`routePath`) stays — those regexes match path segments, not code
-- [ ] Remove the now-dead statement/brace helpers from route-scan and the `splitTopLevel`/`stripComments`/`topLevelObjectLiteral` imports
-- [ ] Actions suite green; commit
+- [x] Add a route-scan behavior-lock test file covering the currently untested evidence paths: destructured verb exports, `export { x as GET }`, verb-keyed `defaultHandler` objects, `"VERB /path"` route maps, `setHeader("Allow", ...)` lists, `NextAuth()` pages, re-export/delegate chains, and the pages-inference heuristics — green against the current implementation
+- [x] Rewrite verb evidence gathering (exported verbs, route maps, method-key objects, re-export targets, page inference) as AST queries over the parsed route module; file-path→URL mapping (`cleanSegment`/`routePath`) stays — those regexes match path segments, not code
+- [x] Remove the now-dead statement/brace helpers from route-scan and the `splitTopLevel`/`stripComments`/`topLevelObjectLiteral` imports
+- [x] Actions suite green; commit
 
 ## Task 3: pins.ts onto the TS AST
 **Files:** `packages/actions/src/sync/pins.ts`, then dead-helper cleanup in `common.ts`.
-- [ ] Registration discovery (`{ name, component }` object literals, `remixable(` helper marking, router-table `path` exclusion, literal offsets) becomes an AST walk
-- [ ] `StaticValueParser` is replaced by static AST evaluation of the sampleProps initializer with the same JSON-compatible acceptance rules (same invalid-sampleProps warnings)
-- [ ] `importSpecifiers` (static, re-export, dynamic import; type-only skipped) becomes an AST walk
-- [ ] Delete `splitTopLevel`, `topLevelObjectLiteral`, and `stripComments` from common.ts once grep shows zero consumers; tsconfig JSONC parsing moves to the compiler API's config-text parser
-- [ ] Actions suite green; commit
+- [x] Registration discovery (`{ name, component }` object literals, `remixable(` helper marking, router-table `path` exclusion, literal offsets) becomes an AST walk
+- [x] `StaticValueParser` is replaced by static AST evaluation of the sampleProps initializer with the same JSON-compatible acceptance rules (same invalid-sampleProps warnings)
+- [x] `importSpecifiers` (static, re-export, dynamic import; type-only skipped) becomes an AST walk
+- [x] Delete `splitTopLevel`, `topLevelObjectLiteral`, and `stripComments` from common.ts once grep shows zero consumers; tsconfig JSONC parsing moves to the compiler API's config-text parser
+- [x] Actions suite green; commit
 
 ## Task 4: Narrow the zod passthrough allowlist
 **Files:** `packages/actions/src/sync/static-ts.ts`.
-- [ ] Measure: grep the corpus checkouts (from the Task 0 clone) and the actions test suite for zod modifier methods actually chained in extracted input schemas
-- [ ] Shrink `ZOD_PASSTHROUGH_MODIFIERS` to that measured set; unlisted modifiers keep failing closed (permissive schema + note); adjust any test that asserted passthrough of a removed modifier to assert the fail-closed result instead
-- [ ] Actions suite green; commit
+- [x] Measure: grep the corpus checkouts (from the Task 0 clone) and the actions test suite for zod modifier methods actually chained in extracted input schemas
+- [x] Shrink `ZOD_PASSTHROUGH_MODIFIERS` to that measured set; unlisted modifiers keep failing closed (permissive schema + note); adjust any test that asserted passthrough of a removed modifier to assert the fail-closed result instead
+- [x] Actions suite green; commit
 
-## Task 5: Contract amendment
-**Files:** `docs/contracts/04-actions.md`.
-- [ ] Amend §1 prose: route-scan and pin capture are now compiler-API static analysis like tRPC/GraphQL/server-actions; dated changelog entry, authorized-by kill-list §B1
-- [ ] Commit
+## Task 5: Contract amendment — SKIPPED (doctrine change 2026-07-17)
+`docs/contracts/` is being retired (archived; the behavior contract is types + tests). Per coordinator instruction the 04-actions.md amendment was dropped from this branch; no docs/contracts/ file is touched.
 
 ## Task 6: Verification and PR
 - [ ] Re-run `pnpm corpus run --layer 2 --json` on the finished branch in the same clone; per-repo scores equal-or-better than the Task 0 baseline; fix any regression before proceeding

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -51,7 +51,7 @@
     "@vendoai/core": "workspace:*",
     "jsonata": "^2.0.5",
     "yaml": "^2.6.0",
-    "zod": "^3.24.0"
+    "zod": "^3.25.0"
   },
   "peerDependencies": {
     "@auth/core": "^0.34.3",

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -49,7 +49,6 @@
   },
   "dependencies": {
     "@vendoai/core": "workspace:*",
-    "es-module-lexer": "^1.7.0",
     "jsonata": "^2.0.5",
     "yaml": "^2.6.0",
     "zod": "^3.24.0"

--- a/packages/actions/src/sync/common.test.ts
+++ b/packages/actions/src/sync/common.test.ts
@@ -79,6 +79,19 @@ describe("resolveImportSource", () => {
     expect(resolved?.file).toBe(await fs.realpath(path.join(root, "src/barrel/cards.tsx")));
   });
 
+  it("resolves a namespace re-export (`export * as X`) to the barrel that declares it", async () => {
+    const root = await temporaryRoot();
+    await write(root, "src/entry.ts", `import { Icons } from "./barrel";`);
+    await write(root, "src/barrel/index.ts", `export * as Icons from "./icons";\n`);
+    await write(root, "src/barrel/icons.tsx", `export const Check = () => <svg />;\n`);
+
+    // `export * as Icons` declares Icons on the barrel itself — the member
+    // module has no `Icons` export to chase (lexer-era parity: the barrel is
+    // the owning module).
+    const resolved = await resolveImportSource(path.join(root, "src/entry.ts"), "./barrel", root, "Icons");
+    expect(resolved?.file).toBe(await fs.realpath(path.join(root, "src/barrel/index.ts")));
+  });
+
   it("returns null when a named re-export chain dead-ends", async () => {
     const root = await temporaryRoot();
     await write(root, "src/entry.ts", `import { Card } from "./barrel";`);

--- a/packages/actions/src/sync/common.test.ts
+++ b/packages/actions/src/sync/common.test.ts
@@ -1,0 +1,102 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { importReferenceFor, resolveImportSource } from "./common.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })));
+});
+
+async function temporaryRoot(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "vendo-actions-common-"));
+  temporaryDirectories.push(root);
+  return root;
+}
+
+async function write(root: string, relativePath: string, source: string): Promise<void> {
+  const file = path.join(root, relativePath);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, source, "utf8");
+}
+
+describe("importReferenceFor", () => {
+  it("resolves named, aliased, default, and namespace-member references", async () => {
+    const source = [
+      `import Widget from "./widget";`,
+      `import { Card, Badge as LocalBadge } from "./cards";`,
+      `import * as UI from "./ui";`,
+      `export const registered = [Widget, Card, LocalBadge, UI.Panel];`,
+    ].join("\n");
+
+    expect(await importReferenceFor(source, "Widget")).toEqual({ specifier: "./widget", imported: "default" });
+    expect(await importReferenceFor(source, "Card")).toEqual({ specifier: "./cards", imported: "Card" });
+    expect(await importReferenceFor(source, "LocalBadge")).toEqual({ specifier: "./cards", imported: "Badge" });
+    expect(await importReferenceFor(source, "UI.Panel")).toEqual({ specifier: "./ui", imported: "Panel" });
+    expect(await importReferenceFor(source, "Undeclared")).toBeUndefined();
+    // A namespace member on a plainly-imported name is not a reference.
+    expect(await importReferenceFor(source, "Card.Section")).toBeUndefined();
+  });
+
+  it("reads references out of a semicolon-free TSX module", async () => {
+    const source = [
+      `"use client"`,
+      `import { Card } from "./cards"`,
+      ``,
+      `export interface Props {`,
+      `  title: string`,
+      `}`,
+      ``,
+      `export function Wrapper({ title }: Props) {`,
+      `  return <Card title={title} />`,
+      `}`,
+    ].join("\n");
+
+    expect(await importReferenceFor(source, "Card")).toEqual({ specifier: "./cards", imported: "Card" });
+  });
+});
+
+describe("resolveImportSource", () => {
+  it("follows export-star chains to the owning module", async () => {
+    const root = await temporaryRoot();
+    await write(root, "src/entry.ts", `import { Card } from "./barrel";`);
+    await write(root, "src/barrel/index.ts", `export * from "./cards";\n`);
+    await write(root, "src/barrel/cards.tsx", `export function Card() { return <div>card</div>; }\n`);
+
+    const resolved = await resolveImportSource(path.join(root, "src/entry.ts"), "./barrel", root, "Card");
+    expect(resolved?.file).toBe(await fs.realpath(path.join(root, "src/barrel/cards.tsx")));
+  });
+
+  it("follows aliased named re-exports through a barrel", async () => {
+    const root = await temporaryRoot();
+    await write(root, "src/entry.ts", `import { PublicCard } from "./barrel";`);
+    await write(root, "src/barrel/index.ts", `export { InnerCard as PublicCard } from "./cards";\n`);
+    await write(root, "src/barrel/cards.tsx", `export const InnerCard = () => <div>card</div>;\n`);
+
+    const resolved = await resolveImportSource(path.join(root, "src/entry.ts"), "./barrel", root, "PublicCard");
+    expect(resolved?.file).toBe(await fs.realpath(path.join(root, "src/barrel/cards.tsx")));
+  });
+
+  it("returns null when a named re-export chain dead-ends", async () => {
+    const root = await temporaryRoot();
+    await write(root, "src/entry.ts", `import { Card } from "./barrel";`);
+    await write(root, "src/barrel/index.ts", `export { Card } from "./missing";\n`);
+
+    expect(await resolveImportSource(path.join(root, "src/entry.ts"), "./barrel", root, "Card")).toBeNull();
+  });
+
+  it("finds a direct export declared after an exported interface in semicolon-free TSX", async () => {
+    const root = await temporaryRoot();
+    await write(root, "src/entry.ts", `import { Card } from "./Card";`);
+    await write(
+      root,
+      "src/Card.tsx",
+      `"use client"\nexport interface CardProps {\n  title: string\n}\n\nexport function Card({ title }: CardProps) {\n  return <div>{title}</div>\n}\n`,
+    );
+
+    const resolved = await resolveImportSource(path.join(root, "src/entry.ts"), "./Card", root, "Card");
+    expect(resolved?.file).toBe(await fs.realpath(path.join(root, "src/Card.tsx")));
+  });
+});

--- a/packages/actions/src/sync/common.ts
+++ b/packages/actions/src/sync/common.ts
@@ -240,13 +240,17 @@ async function reExportTarget(source: string, exportedName: string, fileName?: s
   if (!parsed) return { direct: false, stars: [] };
   const { ts, sf } = parsed;
   const stars: string[] = [];
+  let namespaceDeclared = false;
   for (const statement of sf.statements) {
     if (!ts.isExportDeclaration(statement) || !statement.moduleSpecifier || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
     const specifier = statement.moduleSpecifier.text;
     const clause = statement.exportClause;
     if (!clause || ts.isNamespaceExport(clause)) {
-      // `export * from` and `export * as ns from` both surface the target
-      // module for name-by-name probing, matching the lexer-era behavior.
+      // `export * as X from "./y"` declares X on this module itself — the
+      // barrel is the owning module (checked before any star chase, matching
+      // the lexer era, which listed X in the barrel's exports). Both forms
+      // also surface the target module for name-by-name probing.
+      if (clause && clause.name.text === exportedName) namespaceDeclared = true;
       stars.push(specifier);
       continue;
     }
@@ -259,7 +263,7 @@ async function reExportTarget(source: string, exportedName: string, fileName?: s
       };
     }
   }
-  return { direct: declaresExport(ts, sf, exportedName), stars };
+  return { direct: namespaceDeclared || declaresExport(ts, sf, exportedName), stars };
 }
 
 async function importBases(importer: string, specifier: string, root: string): Promise<string[]> {

--- a/packages/actions/src/sync/common.ts
+++ b/packages/actions/src/sync/common.ts
@@ -61,53 +61,6 @@ export async function walk(
   return files.sort();
 }
 
-export function stripComments(source: string): string {
-  let output = "";
-  let quote: "'" | "\"" | "`" | null = null;
-  let escaped = false;
-  for (let index = 0; index < source.length; index += 1) {
-    const character = source[index]!;
-    const next = source[index + 1];
-    if (quote) {
-      output += character;
-      if (escaped) escaped = false;
-      else if (character === "\\") escaped = true;
-      else if (character === quote) quote = null;
-      continue;
-    }
-    if (character === "'" || character === "\"" || character === "`") {
-      quote = character;
-      output += character;
-      continue;
-    }
-    if (character === "/" && next === "/") {
-      while (index < source.length && source[index] !== "\n") {
-        output += " ";
-        index += 1;
-      }
-      if (index < source.length) output += "\n";
-      continue;
-    }
-    if (character === "/" && next === "*") {
-      output += "  ";
-      index += 2;
-      while (index < source.length && !(source[index] === "*" && source[index + 1] === "/")) {
-        output += source[index] === "\n" ? "\n" : " ";
-        index += 1;
-      }
-      if (index < source.length) output += "  ";
-      index += 1;
-      continue;
-    }
-    output += character;
-  }
-  return output;
-}
-
-function parseJsonLike(source: string): unknown {
-  return JSON.parse(stripComments(source).replace(/,\s*([}\]])/g, "$1"));
-}
-
 function extendsPath(value: unknown, configDir: string): string | null {
   if (typeof value !== "string" || (!value.startsWith(".") && !path.isAbsolute(value))) return null;
   const resolved = path.resolve(configDir, value);
@@ -115,12 +68,15 @@ function extendsPath(value: unknown, configDir: string): string | null {
 }
 
 async function loadAliases(configPath: string, depth = 0): Promise<TsconfigPathAlias[]> {
+  // tsconfig files are JSONC; the compiler's own config parser reads them.
+  const ts = loadCompiler();
   let parsed: any;
   try {
-    parsed = parseJsonLike(await fs.readFile(configPath, "utf8"));
+    parsed = ts?.parseConfigFileTextToJson(configPath, await fs.readFile(configPath, "utf8")).config;
   } catch {
     return [];
   }
+  if (!parsed || typeof parsed !== "object") return [];
   const configDir = path.dirname(configPath);
   const aliases: TsconfigPathAlias[] = [];
   const extended = depth < 4 ? extendsPath(parsed?.extends, configDir) : null;
@@ -222,6 +178,15 @@ export function parseModuleSource(source: string, fileName = "module.tsx"): Pars
   if (!ts) return null;
   const kind = /\.[cm]?ts$/u.test(fileName) ? ts.ScriptKind.TS : ts.ScriptKind.TSX;
   return { ts, sf: ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true, kind) };
+}
+
+/** Depth-first visit of every node under `root` (root excluded). */
+export function visitNodes(ts: typeof TS, root: TS.Node, visit: (node: TS.Node) => void): void {
+  const walkNode = (node: TS.Node): void => {
+    visit(node);
+    ts.forEachChild(node, walkNode);
+  };
+  ts.forEachChild(root, walkNode);
 }
 
 function hasExportModifier(ts: typeof TS, statement: TS.Statement): boolean {
@@ -390,60 +355,6 @@ export async function importReferenceFor(source: string, localExpression: string
     if (clause.name?.text === localName) return { specifier, imported: "default" };
   }
   return undefined;
-}
-
-export function topLevelObjectLiteral(source: string, openBrace: number): string | null {
-  let depth = 0;
-  let quote: "'" | "\"" | "`" | null = null;
-  let escaped = false;
-  for (let index = openBrace; index < source.length; index += 1) {
-    const character = source[index]!;
-    if (quote) {
-      if (escaped) escaped = false;
-      else if (character === "\\") escaped = true;
-      else if (character === quote) quote = null;
-      continue;
-    }
-    if (character === "'" || character === "\"" || character === "`") {
-      quote = character;
-      continue;
-    }
-    if (character === "{") depth += 1;
-    else if (character === "}") {
-      depth -= 1;
-      if (depth === 0) return source.slice(openBrace + 1, index);
-    }
-  }
-  return null;
-}
-
-export function splitTopLevel(source: string): string[] {
-  const parts: string[] = [];
-  let depth = 0;
-  let quote: "'" | "\"" | "`" | null = null;
-  let escaped = false;
-  let start = 0;
-  for (let index = 0; index < source.length; index += 1) {
-    const character = source[index]!;
-    if (quote) {
-      if (escaped) escaped = false;
-      else if (character === "\\") escaped = true;
-      else if (character === quote) quote = null;
-      continue;
-    }
-    if (character === "'" || character === "\"" || character === "`") {
-      quote = character;
-      continue;
-    }
-    if (character === "(" || character === "[" || character === "{") depth += 1;
-    else if (character === ")" || character === "]" || character === "}") depth = Math.max(0, depth - 1);
-    else if (character === "," && depth === 0) {
-      parts.push(source.slice(start, index));
-      start = index + 1;
-    }
-  }
-  parts.push(source.slice(start));
-  return parts;
 }
 
 export function limitToolName(fullName: string): string {

--- a/packages/actions/src/sync/common.ts
+++ b/packages/actions/src/sync/common.ts
@@ -1,7 +1,8 @@
 import { promises as fs } from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { sha256Hex } from "@vendoai/core";
-import { init, parse } from "es-module-lexer";
+import type TS from "typescript";
 import type { ExtractedTool, HttpMethod, PrimitiveToolBinding } from "../formats.js";
 
 const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx"] as const;
@@ -190,169 +191,110 @@ async function resolvedCandidate(base: string, realRoot: string): Promise<Resolv
   return null;
 }
 
-function namedBindings(statement: string): Array<{ imported: string; exported: string }> {
-  const body = statement.match(/\{([\s\S]*?)\}/)?.[1];
-  if (body === undefined) return [];
-  return body.split(",").flatMap((raw) => {
-    const part = raw.trim().replace(/^type\s+/, "");
-    if (part === "") return [];
-    const pieces = part.split(/\s+as\s+/).map((value) => value.trim());
-    const imported = pieces[0];
-    const exported = pieces[1] ?? imported;
-    return imported && exported ? [{ imported, exported }] : [];
-  });
-}
+/** The TypeScript compiler, resolved lazily through this package's own
+ * dependency graph (the same posture as catalog-scan). Module analysis is
+ * fail-closed: when the compiler cannot be loaded, imports and exports
+ * resolve to nothing rather than being guessed at with string scans. */
+let compilerModule: typeof TS | null | undefined;
 
-interface ModuleImport {
-  statement: string;
-  specifier: string;
-}
-
-function fallbackModuleStatements(source: string): string[] {
-  const statements: string[] = [];
-  let quote: "'" | "\"" | "`" | null = null;
-  let escaped = false;
-  let lineComment = false;
-  let blockComment = false;
-  let depth = 0;
-  for (let index = 0; index < source.length; index += 1) {
-    const character = source[index]!;
-    const next = source[index + 1];
-    if (lineComment) {
-      if (character === "\n") lineComment = false;
-      continue;
+function loadCompiler(): typeof TS | null {
+  if (compilerModule === undefined) {
+    try {
+      compilerModule = createRequire(import.meta.url)("typescript") as typeof TS;
+    } catch {
+      compilerModule = null;
     }
-    if (blockComment) {
-      if (character === "*" && next === "/") {
-        blockComment = false;
-        index += 1;
-      }
-      continue;
-    }
-    if (quote) {
-      if (escaped) escaped = false;
-      else if (character === "\\") escaped = true;
-      else if (character === quote) quote = null;
-      continue;
-    }
-    if (character === "/" && next === "/") {
-      lineComment = true;
-      index += 1;
-      continue;
-    }
-    if (character === "/" && next === "*") {
-      blockComment = true;
-      index += 1;
-      continue;
-    }
-    if (character === "'" || character === "\"" || character === "`") {
-      quote = character;
-      continue;
-    }
-    if (character === "{" || character === "(" || character === "[") depth += 1;
-    else if (character === "}" || character === ")" || character === "]") depth = Math.max(0, depth - 1);
-    if (depth !== 0) continue;
-    const keyword = source.startsWith("import", index) ? "import"
-      : source.startsWith("export", index) ? "export"
-      : undefined;
-    if (!keyword || /[\w$]/.test(source[index - 1] ?? "") || /[\w$]/.test(source[index + keyword.length] ?? "")) continue;
-
-    let localDepth = 0;
-    let localQuote: "'" | "\"" | "`" | null = null;
-    let localEscaped = false;
-    let end = source.length;
-    for (let cursor = index; cursor < source.length; cursor += 1) {
-      const value = source[cursor]!;
-      if (localQuote) {
-        if (localEscaped) localEscaped = false;
-        else if (value === "\\") localEscaped = true;
-        else if (value === localQuote) localQuote = null;
-        continue;
-      }
-      if (value === "'" || value === "\"" || value === "`") {
-        localQuote = value;
-        continue;
-      }
-      if (value === "{" || value === "(" || value === "[") localDepth += 1;
-      else if (value === "}" || value === ")" || value === "]") localDepth = Math.max(0, localDepth - 1);
-      if (value === ";" && localDepth === 0) {
-        end = cursor;
-        break;
-      }
-      if (value === "\n" && localDepth === 0) {
-        const candidate = source.slice(index, cursor);
-        if (/\bfrom\s*["'][^"']+["']/.test(candidate)
-            || /^import\s*["'][^"']+["']/.test(candidate)
-            || /^export\s+(?:default\s+)?(?:async\s+)?(?:function|class|const|let|var)\b/.test(candidate)) {
-          end = cursor;
-          break;
-        }
-        // Semicolon-free sources: a balanced newline followed by a fresh
-        // import/export keyword always ends the current statement — otherwise
-        // `export interface X { … }` swallows every later export in the file.
-        if (/^\s*(?:import|export)[\s{"'(]/.test(source.slice(cursor + 1, cursor + 64))) {
-          end = cursor;
-          break;
-        }
-      }
-    }
-    statements.push(source.slice(index, end).trim());
-    index = end;
   }
-  return statements;
+  return compilerModule;
 }
 
-async function lexModule(source: string): Promise<{ imports: ModuleImport[]; exports: Set<string> }> {
-  await init;
-  try {
-    const [imports, exports] = parse(source);
-    return {
-      imports: imports.flatMap((item) => item.d === -1 && item.n !== undefined
-        ? [{ statement: source.slice(item.ss, item.se).trim(), specifier: item.n }]
-        : []),
-      exports: new Set(exports.map((item) => item.n)),
-    };
-  } catch {
-    const statements = fallbackModuleStatements(source);
-    const imports = statements.flatMap((statement) => {
-      const specifier = statement.match(/\bfrom\s*["']([^"']+)["']/)?.[1]
-        ?? statement.match(/^import\s*["']([^"']+)["']/)?.[1];
-      return specifier ? [{ statement, specifier }] : [];
-    });
-    const exports = new Set<string>();
-    for (const statement of statements) {
-      const declaration = statement.match(/^export\s+(?:default\s+)?(?:async\s+)?(?:function|class|const|let|var)\s+([A-Za-z_$][\w$]*)/)?.[1];
-      if (declaration) exports.add(declaration);
-      if (/^export\s+default\b/.test(statement)) exports.add("default");
-      if (/^export\s*\{/.test(statement)) {
-        for (const binding of namedBindings(statement)) exports.add(binding.exported);
-      }
+export interface ParsedModule {
+  ts: typeof TS;
+  sf: TS.SourceFile;
+}
+
+/** Parse one module's source for statement-level analysis (no type checking,
+ * no host code execution). TSX is the default script kind — extraction mostly
+ * reads component and route modules — with plain TS for `.ts`/`.mts`/`.cts`
+ * files so generic arrows are not mis-lexed as JSX. */
+export function parseModuleSource(source: string, fileName = "module.tsx"): ParsedModule | null {
+  const ts = loadCompiler();
+  if (!ts) return null;
+  const kind = /\.[cm]?ts$/u.test(fileName) ? ts.ScriptKind.TS : ts.ScriptKind.TSX;
+  return { ts, sf: ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true, kind) };
+}
+
+function hasExportModifier(ts: typeof TS, statement: TS.Statement): boolean {
+  return ts.canHaveModifiers(statement) === true
+    && (ts.getModifiers(statement) ?? []).some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword);
+}
+
+function hasDefaultModifier(ts: typeof TS, statement: TS.Statement): boolean {
+  return ts.canHaveModifiers(statement) === true
+    && (ts.getModifiers(statement) ?? []).some((modifier) => modifier.kind === ts.SyntaxKind.DefaultKeyword);
+}
+
+function bindingDeclaresName(ts: typeof TS, name: TS.BindingName, exportedName: string): boolean {
+  if (ts.isIdentifier(name)) return name.text === exportedName;
+  return name.elements.some((element) =>
+    !ts.isOmittedExpression(element) && bindingDeclaresName(ts, element.name, exportedName));
+}
+
+/** True when the module itself declares an export named `exportedName`
+ * (declaration exports, `export default`, and specifier-only `export { x }`
+ * lists — the local-value cases resolution treats as owned by this module). */
+function declaresExport(ts: typeof TS, sf: TS.SourceFile, exportedName: string): boolean {
+  for (const statement of sf.statements) {
+    if (ts.isExportAssignment(statement)) {
+      if (exportedName === "default") return true;
+      continue;
     }
-    return { imports, exports };
+    if (ts.isExportDeclaration(statement)) {
+      if (statement.moduleSpecifier || !statement.exportClause || !ts.isNamedExports(statement.exportClause)) continue;
+      if (statement.exportClause.elements.some((element) => element.name.text === exportedName)) return true;
+      continue;
+    }
+    if (!hasExportModifier(ts, statement)) continue;
+    if (hasDefaultModifier(ts, statement) && exportedName === "default") return true;
+    if ((ts.isFunctionDeclaration(statement) || ts.isClassDeclaration(statement) || ts.isEnumDeclaration(statement))
+      && statement.name?.text === exportedName) return true;
+    if (ts.isVariableStatement(statement)
+      && statement.declarationList.declarations.some((declaration) => bindingDeclaresName(ts, declaration.name, exportedName))) {
+      return true;
+    }
   }
+  return false;
 }
 
-async function reExportTarget(source: string, exportedName: string): Promise<{
+async function reExportTarget(source: string, exportedName: string, fileName?: string): Promise<{
   direct: boolean;
   named?: { specifier: string; imported: string };
   stars: string[];
 }> {
-  const module = await lexModule(source);
+  const parsed = parseModuleSource(source, fileName);
+  if (!parsed) return { direct: false, stars: [] };
+  const { ts, sf } = parsed;
   const stars: string[] = [];
-  for (const imported of module.imports) {
-    const statement = imported.statement;
-    if (!statement.startsWith("export")) continue;
-    if (/^export\s*\*/.test(statement)) {
-      stars.push(imported.specifier);
+  for (const statement of sf.statements) {
+    if (!ts.isExportDeclaration(statement) || !statement.moduleSpecifier || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    const specifier = statement.moduleSpecifier.text;
+    const clause = statement.exportClause;
+    if (!clause || ts.isNamespaceExport(clause)) {
+      // `export * from` and `export * as ns from` both surface the target
+      // module for name-by-name probing, matching the lexer-era behavior.
+      stars.push(specifier);
       continue;
     }
-    const binding = namedBindings(statement).find((item) => item.exported === exportedName);
-    if (binding) return { direct: false, named: { specifier: imported.specifier, imported: binding.imported }, stars };
+    const element = clause.elements.find((item) => item.name.text === exportedName);
+    if (element) {
+      return {
+        direct: false,
+        named: { specifier, imported: (element.propertyName ?? element.name).text },
+        stars,
+      };
+    }
   }
-  return {
-    direct: module.exports.has(exportedName),
-    stars,
-  };
+  return { direct: declaresExport(ts, sf, exportedName), stars };
 }
 
 async function importBases(importer: string, specifier: string, root: string): Promise<string[]> {
@@ -384,7 +326,7 @@ async function resolveImportedSource(
   for (const base of bases) {
     const resolved = await resolvedCandidate(base, realRoot);
     if (!resolved) continue;
-    const target = await reExportTarget(resolved.source, importedName);
+    const target = await reExportTarget(resolved.source, importedName, resolved.file);
     if (target.named) {
       // A named re-export is authoritative: when its chain cannot be followed
       // the export does not resolve, and returning the barrel here would
@@ -427,26 +369,25 @@ export async function resolveImportSource(
 }
 
 export async function importReferenceFor(source: string, localExpression: string): Promise<ImportReference | undefined> {
-  const module = await lexModule(source);
+  const parsed = parseModuleSource(source);
   const [localName, namespaceMember] = localExpression.split(".", 2);
-  if (!localName) return undefined;
-  for (const imported of module.imports) {
-    const statement = imported.statement;
-    const clause = statement.match(/^import\s+(?:type\s+)?([\s\S]*?)\s+from\b/)?.[1]?.trim();
+  if (!parsed || !localName) return undefined;
+  const { ts, sf } = parsed;
+  for (const statement of sf.statements) {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    const specifier = statement.moduleSpecifier.text;
+    const clause = statement.importClause;
     if (!clause) continue;
-    const namespace = clause.match(/(?:^|,)\s*\*\s+as\s+([A-Za-z_$][\w$]*)\s*$/)?.[1];
-    if (namespace === localName && namespaceMember) {
-      return { specifier: imported.specifier, imported: namespaceMember };
+    const bindings = clause.namedBindings;
+    if (bindings && ts.isNamespaceImport(bindings) && bindings.name.text === localName && namespaceMember) {
+      return { specifier, imported: namespaceMember };
     }
-    for (const binding of namedBindings(clause)) {
-      if (binding.exported === localName && namespaceMember === undefined) {
-        return { specifier: imported.specifier, imported: binding.imported };
-      }
+    if (namespaceMember !== undefined) continue;
+    if (bindings && ts.isNamedImports(bindings)) {
+      const element = bindings.elements.find((item) => item.name.text === localName);
+      if (element) return { specifier, imported: (element.propertyName ?? element.name).text };
     }
-    const defaultBinding = clause.split(",", 1)[0]?.trim();
-    if (defaultBinding === localName && namespaceMember === undefined) {
-      return { specifier: imported.specifier, imported: "default" };
-    }
+    if (clause.name?.text === localName) return { specifier, imported: "default" };
   }
   return undefined;
 }

--- a/packages/actions/src/sync/pins.ts
+++ b/packages/actions/src/sync/pins.ts
@@ -9,13 +9,13 @@ import {
   type UnresolvedPin,
   type UnresolvedPinReason,
 } from "../formats.js";
+import type TS from "typescript";
 import {
   importReferenceFor,
   isInside,
+  parseModuleSource,
   resolveImportSource,
-  splitTopLevel,
-  stripComments,
-  topLevelObjectLiteral,
+  visitNodes,
   walk,
 } from "./common.js";
 
@@ -39,6 +39,9 @@ interface PinRegistration {
   invalidSampleProps: boolean;
   /** Offset of the registration object literal's opening brace in its module source. */
   at: number;
+  /** True when the literal also carries a `path` field — a router-table entry,
+   * never offered for remix wrapping. */
+  routerTable: boolean;
 }
 
 export interface PinCaptureResult {
@@ -50,168 +53,125 @@ export interface PinCaptureResult {
 
 const RUNTIME_CAPTURE_HINT = "run the host in dev with Vendo mounted to runtime-capture it";
 
-class StaticValueParser {
-  private index = 0;
+const INVALID_STATIC_VALUE = Symbol("invalid-static-value");
 
-  constructor(private readonly source: string) {}
-
-  parse(): unknown {
-    const value = this.value();
-    this.space();
-    if (this.index !== this.source.length) throw new Error("unexpected trailing input");
-    return value;
+/** Statically evaluate an expression to a JSON-compatible value: string,
+ * number, boolean, and null literals, plus object and array literals of the
+ * same. Anything dynamic — identifiers, calls, spreads, templates — is
+ * invalid; sampleProps must be a value the runtime can replay verbatim. */
+function staticJsonValue(ts: typeof TS, expression: TS.Expression): unknown {
+  if (ts.isStringLiteral(expression)) return expression.text;
+  if (ts.isNumericLiteral(expression)) {
+    const value = Number(expression.text);
+    return Number.isFinite(value) ? value : INVALID_STATIC_VALUE;
   }
-
-  private space(): void {
-    while (/\s/u.test(this.source[this.index] ?? "")) this.index += 1;
+  if (ts.isPrefixUnaryExpression(expression)
+    && expression.operator === ts.SyntaxKind.MinusToken
+    && ts.isNumericLiteral(expression.operand)) {
+    const value = -Number(expression.operand.text);
+    return Number.isFinite(value) ? value : INVALID_STATIC_VALUE;
   }
-
-  private value(): unknown {
-    this.space();
-    const character = this.source[this.index];
-    if (character === "{" ) return this.object();
-    if (character === "[") return this.array();
-    if (character === "\"" || character === "'") return this.string();
-    const rest = this.source.slice(this.index);
-    for (const [literal, value] of [["true", true], ["false", false], ["null", null]] as const) {
-      if (rest.startsWith(literal) && !/[A-Za-z0-9_$]/u.test(rest[literal.length] ?? "")) {
-        this.index += literal.length;
-        return value;
-      }
-    }
-    const number = rest.match(/^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/u)?.[0];
-    if (number !== undefined) {
-      this.index += number.length;
-      const value = Number(number);
-      if (Number.isFinite(value)) return value;
-    }
-    throw new Error("sampleProps must be a static JSON-compatible value");
-  }
-
-  private string(): string {
-    const quote = this.source[this.index++];
-    let value = "";
-    while (this.index < this.source.length) {
-      const character = this.source[this.index++];
-      if (character === quote) return value;
-      if (character !== "\\") {
-        value += character;
-        continue;
-      }
-      const escaped = this.source[this.index++];
-      const simple: Record<string, string> = {
-        "\"": "\"", "'": "'", "\\": "\\", "/": "/", b: "\b", f: "\f", n: "\n", r: "\r", t: "\t",
-      };
-      if (escaped !== undefined && simple[escaped] !== undefined) {
-        value += simple[escaped];
-        continue;
-      }
-      if (escaped === "u") {
-        const hex = this.source.slice(this.index, this.index + 4);
-        if (!/^[0-9a-f]{4}$/iu.test(hex)) throw new Error("invalid unicode escape");
-        value += String.fromCharCode(Number.parseInt(hex, 16));
-        this.index += 4;
-        continue;
-      }
-      throw new Error("unsupported string escape");
-    }
-    throw new Error("unterminated string");
-  }
-
-  private key(): string {
-    this.space();
-    if (this.source[this.index] === "\"" || this.source[this.index] === "'") return this.string();
-    const identifier = this.source.slice(this.index).match(/^[A-Za-z_$][\w$]*/u)?.[0];
-    if (identifier === undefined) throw new Error("object keys must be static");
-    this.index += identifier.length;
-    return identifier;
-  }
-
-  private object(): Record<string, unknown> {
-    this.index += 1;
+  if (expression.kind === ts.SyntaxKind.TrueKeyword) return true;
+  if (expression.kind === ts.SyntaxKind.FalseKeyword) return false;
+  if (expression.kind === ts.SyntaxKind.NullKeyword) return null;
+  if (ts.isObjectLiteralExpression(expression)) {
     const value = Object.create(null) as Record<string, unknown>;
-    this.space();
-    while (this.source[this.index] !== "}") {
-      const key = this.key();
-      this.space();
-      if (this.source[this.index++] !== ":") throw new Error("object property needs a colon");
-      value[key] = this.value();
-      this.space();
-      if (this.source[this.index] === "}") break;
-      if (this.source[this.index++] !== ",") throw new Error("object properties need commas");
-      this.space();
-      if (this.source[this.index] === "}") break;
+    for (const property of expression.properties) {
+      if (!ts.isPropertyAssignment(property)) return INVALID_STATIC_VALUE;
+      const name = property.name;
+      if (!ts.isIdentifier(name) && !ts.isStringLiteral(name)) return INVALID_STATIC_VALUE;
+      const item = staticJsonValue(ts, property.initializer);
+      if (item === INVALID_STATIC_VALUE) return INVALID_STATIC_VALUE;
+      value[name.text] = item;
     }
-    if (this.source[this.index++] !== "}") throw new Error("unterminated object");
     return value;
   }
-
-  private array(): unknown[] {
-    this.index += 1;
+  if (ts.isArrayLiteralExpression(expression)) {
     const value: unknown[] = [];
-    this.space();
-    while (this.source[this.index] !== "]") {
-      value.push(this.value());
-      this.space();
-      if (this.source[this.index] === "]") break;
-      if (this.source[this.index++] !== ",") throw new Error("array items need commas");
-      this.space();
-      if (this.source[this.index] === "]") break;
+    for (const element of expression.elements) {
+      if (ts.isSpreadElement(element) || ts.isOmittedExpression(element)) return INVALID_STATIC_VALUE;
+      const item = staticJsonValue(ts, element);
+      if (item === INVALID_STATIC_VALUE) return INVALID_STATIC_VALUE;
+      value.push(item);
     }
-    if (this.source[this.index++] !== "]") throw new Error("unterminated array");
     return value;
   }
+  return INVALID_STATIC_VALUE;
 }
 
-function staticSampleProps(source: string): Record<string, unknown> | null {
-  try {
-    const parsed = new StaticValueParser(source).parse();
-    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
-      ? parsed as Record<string, unknown>
-      : null;
-  } catch {
-    return null;
-  }
+function staticSampleProps(ts: typeof TS, expression: TS.Expression): Record<string, unknown> | null {
+  const parsed = staticJsonValue(ts, expression);
+  return parsed !== INVALID_STATIC_VALUE && typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+    ? parsed as Record<string, unknown>
+    : null;
 }
 
-function registrationFromBody(body: string, helperMarked: boolean, at: number): PinRegistration | null {
+function propertyName(ts: typeof TS, property: TS.ObjectLiteralElementLike): string | null {
+  if (!ts.isPropertyAssignment(property)) return null;
+  const name = property.name;
+  return ts.isIdentifier(name) || ts.isStringLiteral(name) ? name.text : null;
+}
+
+/** The registration is `remixable(…)`'s first argument. */
+function isRemixableHelperArgument(ts: typeof TS, literal: TS.ObjectLiteralExpression): boolean {
+  const parent = literal.parent;
+  if (!ts.isCallExpression(parent) || parent.arguments[0] !== literal) return false;
+  const callee = parent.expression;
+  if (ts.isIdentifier(callee)) return callee.text === "remixable";
+  return ts.isPropertyAccessExpression(callee) && callee.name.text === "remixable";
+}
+
+function registrationFromLiteral(ts: typeof TS, sf: TS.SourceFile, literal: TS.ObjectLiteralExpression): PinRegistration | null {
   let slot: string | undefined;
   let component: string | undefined;
-  let remixable = helperMarked;
+  let remixable = isRemixableHelperArgument(ts, literal);
   let exportable = false;
+  let routerTable = false;
   let sampleProps: Record<string, unknown> | undefined;
   let invalidSampleProps = false;
-  for (const rawField of splitTopLevel(body)) {
-    const field = rawField.trim();
-    const nameMatch = field.match(/^(?:["']name["']|name)\s*:\s*["']([^"']+)["']\s*$/su);
-    if (nameMatch?.[1]) slot = nameMatch[1];
-    const componentMatch = field.match(/^(?:["']component["']|component)\s*:\s*(.+)$/su);
-    if (componentMatch?.[1]) component = componentMatch[1].trim();
-    if (/^(?:["']remixable["']|remixable)\s*:\s*true\s*$/su.test(field)) remixable = true;
-    if (/^(?:["']exportable["']|exportable)\s*:\s*true\s*$/su.test(field)) exportable = true;
-    const sampleMatch = field.match(/^(?:["']sampleProps["']|sampleProps)\s*:\s*([\s\S]+)$/u);
-    if (sampleMatch?.[1] !== undefined) {
-      const parsed = staticSampleProps(sampleMatch[1]);
+  for (const property of literal.properties) {
+    const name = propertyName(ts, property);
+    if (name === null || !ts.isPropertyAssignment(property)) continue;
+    const initializer = property.initializer;
+    if (name === "name" && ts.isStringLiteral(initializer) && initializer.text.length > 0) slot = initializer.text;
+    if (name === "component") component = initializer.getText(sf).trim();
+    if (name === "remixable" && initializer.kind === ts.SyntaxKind.TrueKeyword) remixable = true;
+    if (name === "exportable" && initializer.kind === ts.SyntaxKind.TrueKeyword) exportable = true;
+    if (name === "path") routerTable = true;
+    if (name === "sampleProps") {
+      const parsed = staticSampleProps(ts, initializer);
       if (parsed === null) invalidSampleProps = true;
       else sampleProps = parsed;
     }
   }
   return slot && component
-    ? { slot, component, remixable, exportable, invalidSampleProps, at, ...(sampleProps === undefined ? {} : { sampleProps }) }
+    ? {
+        slot,
+        component,
+        remixable,
+        exportable,
+        invalidSampleProps,
+        at: literal.getStart(sf),
+        routerTable,
+        ...(sampleProps === undefined ? {} : { sampleProps }),
+      }
     : null;
 }
 
 /** Every `{ name, component }` registration literal in one module, remixable or not. */
-function registrations(source: string): PinRegistration[] {
+function registrations(source: string, fileName?: string): PinRegistration[] {
+  // A registration needs a `component` property; the token's absence is a
+  // cheap skip that avoids parsing every walked module.
+  if (!source.includes("component")) return [];
+  const parsed = parseModuleSource(source, fileName);
+  if (!parsed) return [];
+  const { ts, sf } = parsed;
   const found: PinRegistration[] = [];
-  for (let index = 0; index < source.length; index += 1) {
-    if (source[index] !== "{") continue;
-    const body = topLevelObjectLiteral(source, index);
-    if (!body) continue;
-    const helperMarked = /\bremixable\s*\(\s*$/.test(source.slice(Math.max(0, index - 80), index));
-    const registration = registrationFromBody(body, helperMarked, index);
+  visitNodes(ts, sf, (node) => {
+    if (!ts.isObjectLiteralExpression(node)) return;
+    const registration = registrationFromLiteral(ts, sf, node);
     if (registration) found.push(registration);
-  }
+  });
   return found;
 }
 
@@ -219,22 +179,27 @@ function portablePath(root: string, file: string): string {
   return path.relative(root, file).split(path.sep).join("/");
 }
 
-function importSpecifiers(source: string): string[] {
-  // `[^;\n]*` keeps the type-erasure line-scoped: in a semicolon-free module a
-  // newline-spanning `[^;]*` would greedily erase everything after the first
-  // `import type` — including real stylesheet and component imports.
-  const withoutTypes = stripComments(source)
-    .replace(/\bimport\s+type\b[^;\n]*(?:;|$)/gmu, "")
-    .replace(/\bexport\s+type\b[^;\n]*(?:;|$)/gmu, "");
+function importSpecifiers(source: string, fileName?: string): string[] {
+  const parsed = parseModuleSource(source, fileName);
+  if (!parsed) return [];
+  const { ts, sf } = parsed;
   const found: Array<{ at: number; specifier: string }> = [];
-  const staticImport = /\bimport\s+(?:[^"'`;]*?\s+from\s+)?["']([^"']+)["']/gmu;
-  const reExport = /\bexport\s+[^"'`;]*?\s+from\s+["']([^"']+)["']/gmu;
-  const dynamicImport = /\bimport\s*\(\s*["']([^"']+)["']\s*\)/gmu;
-  for (const pattern of [staticImport, reExport, dynamicImport]) {
-    for (const match of withoutTypes.matchAll(pattern)) {
-      if (match[1] !== undefined && match.index !== undefined) found.push({ at: match.index, specifier: match[1] });
+  for (const statement of sf.statements) {
+    if (ts.isImportDeclaration(statement) && ts.isStringLiteral(statement.moduleSpecifier)
+      && statement.importClause?.isTypeOnly !== true) {
+      found.push({ at: statement.getStart(sf), specifier: statement.moduleSpecifier.text });
+    }
+    if (ts.isExportDeclaration(statement) && statement.moduleSpecifier && ts.isStringLiteral(statement.moduleSpecifier)
+      && !statement.isTypeOnly) {
+      found.push({ at: statement.getStart(sf), specifier: statement.moduleSpecifier.text });
     }
   }
+  visitNodes(ts, sf, (node) => {
+    if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+      const [argument] = node.arguments;
+      if (argument && ts.isStringLiteral(argument)) found.push({ at: node.getStart(sf), specifier: argument.text });
+    }
+  });
   found.sort((left, right) => left.at - right.at || left.specifier.localeCompare(right.specifier));
   return [...new Set(found.map(({ specifier }) => specifier))];
 }
@@ -276,7 +241,7 @@ async function captureRootStyles(
   const seen = new Set<string>();
   for (const rootFile of files.filter((file) => ROOT_FILE.test(portablePath(root, file)))) {
     const source = await fs.readFile(rootFile, "utf8");
-    for (const specifier of importSpecifiers(source).filter((value) => /\.css$/iu.test(value))) {
+    for (const specifier of importSpecifiers(source, rootFile).filter((value) => /\.css$/iu.test(value))) {
       const resolved = await resolveImportSource(rootFile, specifier, root);
       if (resolved === null) {
         warnings.push(`host app root ${portablePath(root, rootFile)} stylesheet import ${specifier} could not be resolved`);
@@ -324,7 +289,7 @@ async function captureSubSources(
   while (queue.length > 0) {
     const task = queue.shift()!;
     const imports = task.id === null ? sourceImports : captured.get(task.id)!.imports;
-    for (const specifier of importSpecifiers(task.source)) {
+    for (const specifier of importSpecifiers(task.source, task.file)) {
       if (BLESSED_JAIL_MODULES.has(specifier)) continue;
       const importer = task.id ?? portablePath(realRoot, primaryFile);
       if (/\.css(?:$|\?)/iu.test(specifier)) {
@@ -407,7 +372,7 @@ export async function capturePins(
 
   for (const file of files) {
     const source = await fs.readFile(file, "utf8");
-    for (const registration of registrations(source).filter((candidate) => candidate.remixable)) {
+    for (const registration of registrations(source, file).filter((candidate) => candidate.remixable)) {
       if (seenSlots.has(registration.slot)) {
         result.warnings.push(`remixable slot ${registration.slot} is registered more than once; kept the first registration`);
         continue;
@@ -541,12 +506,11 @@ export async function scanRemixRegistrations(root: string): Promise<RemixRegistr
   const files = await walk(root, (relativePath) => /\.(?:[cm]?[jt]sx?)$/u.test(relativePath) && !/\.d\.ts$/u.test(relativePath));
   for (const file of files) {
     const source = await fs.readFile(file, "utf8");
-    for (const registration of registrations(source)) {
+    for (const registration of registrations(source, file)) {
       if (!/^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?$/.test(registration.component)) continue;
       // A `path` field marks a router table (`{ path, name, component }`), not a
       // host component registration — never offer to wrap those.
-      const body = topLevelObjectLiteral(source, registration.at);
-      if (body && splitTopLevel(body).some((field) => /^(?:["']path["']|path)\s*:/u.test(field.trim()))) continue;
+      if (registration.routerTable) continue;
       const reference = await importReferenceFor(source, registration.component);
       if (!reference) continue;
       const resolved = await resolveImportSource(file, reference.specifier, root, reference.imported);

--- a/packages/actions/src/sync/route-scan.test.ts
+++ b/packages/actions/src/sync/route-scan.test.ts
@@ -1,0 +1,215 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { scanRoutes } from "./route-scan.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })));
+});
+
+async function temporaryRoot(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "vendo-actions-routes-"));
+  temporaryDirectories.push(root);
+  return root;
+}
+
+async function write(root: string, relativePath: string, source: string): Promise<void> {
+  const file = path.join(root, relativePath);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, source, "utf8");
+}
+
+async function methodsFor(root: string, urlPath: string): Promise<string[]> {
+  const { tools } = await scanRoutes(root);
+  return tools
+    .filter((tool) => tool.binding.kind === "route" && tool.binding.path === urlPath && !tool.disabled)
+    .map((tool) => (tool.binding.kind === "route" ? tool.binding.method : ""))
+    .sort();
+}
+
+describe("app route verb evidence", () => {
+  it("reads exported declarations, declaration lists, and destructured exports", async () => {
+    const root = await temporaryRoot();
+    await write(root, "app/api/fn/route.ts", "export async function GET() { return new Response(); }\n");
+    await write(root, "app/api/list/route.ts", "const handler = () => new Response();\nexport const runtime = \"edge\", POST = handler;\n");
+    await write(root, "app/api/pair/route.ts", "const handlers = { GET: () => null, PUT: () => null };\nexport const { GET, PUT } = handlers;\n");
+
+    expect(await methodsFor(root, "/api/fn")).toEqual(["GET"]);
+    expect(await methodsFor(root, "/api/list")).toEqual(["POST"]);
+    expect(await methodsFor(root, "/api/pair")).toEqual(["GET", "PUT"]);
+  });
+
+  it("reads local aliased export lists and ignores non-verb names", async () => {
+    const root = await temporaryRoot();
+    await write(
+      root,
+      "app/api/aliased/route.ts",
+      "async function handle() { return new Response(); }\nexport { handle as PATCH, handle as helper };\n",
+    );
+    expect(await methodsFor(root, "/api/aliased")).toEqual(["PATCH"]);
+  });
+
+  it("follows named and star re-exports to the implementing module", async () => {
+    const root = await temporaryRoot();
+    await write(root, "lib/impl.ts", "export function GET() { return new Response(); }\nexport function DELETE() { return new Response(); }\n");
+    await write(root, "app/api/named/route.ts", "export { GET } from \"../../../lib/impl\";\n");
+    await write(root, "app/api/star/route.ts", "export * from \"../../../lib/impl\";\n");
+
+    // A named verb re-export marks the target module as route evidence; the
+    // route then carries every verb the target exports (long-standing union
+    // semantics — the corpus locks it).
+    expect(await methodsFor(root, "/api/named")).toEqual(["DELETE", "GET"]);
+    expect(await methodsFor(root, "/api/star")).toEqual(["DELETE", "GET"]);
+  });
+
+  it("ignores verb-looking text inside strings and comments", async () => {
+    const root = await temporaryRoot();
+    await write(
+      root,
+      "app/api/noise/route.ts",
+      "// export function GET() {}\nconst usage = \"export function POST\";\nexport function PUT() { return new Response(usage); }\n",
+    );
+    expect(await methodsFor(root, "/api/noise")).toEqual(["PUT"]);
+  });
+
+  it("classifies a defaultHandler verb-keyed object argument", async () => {
+    const root = await temporaryRoot();
+    await write(
+      root,
+      "app/api/keyed/route.ts",
+      "import { defaultHandler } from \"../../../lib/router\";\nconst run = defaultHandler({ GET: () => null, \"POST\": () => null, other: () => null });\nexport default run;\n",
+    );
+    expect(await methodsFor(root, "/api/keyed")).toEqual(["GET", "POST"]);
+  });
+
+  it("assigns route-map entries to collection, item, and catch-all routes", async () => {
+    const root = await temporaryRoot();
+    const routeMap = [
+      "const routes = {",
+      "  \"GET /\": () => null,",
+      "  \"POST /\": () => null,",
+      "  \"PUT /:id\": () => null,",
+      "};",
+      "export default routes;",
+    ].join("\n");
+    await write(root, "app/api/things/route.ts", routeMap);
+    await write(root, "app/api/things/[id]/route.ts", routeMap);
+    await write(root, "app/api/blob/[...rest]/route.ts", routeMap);
+
+    expect(await methodsFor(root, "/api/things")).toEqual(["GET", "POST"]);
+    expect(await methodsFor(root, "/api/things/{id}")).toEqual(["PUT"]);
+    expect(await methodsFor(root, "/api/blob/{rest}")).toEqual(["GET", "POST", "PUT"]);
+  });
+});
+
+describe("pages route verb evidence", () => {
+  it("reads req.method comparisons, switch cases, and Allow headers", async () => {
+    const root = await temporaryRoot();
+    await write(
+      root,
+      "pages/api/compare.ts",
+      "export default function handler(req: any, res: any) { if (req.method !== \"PUT\") return res.status(405).end(); res.end(); }\n",
+    );
+    await write(
+      root,
+      "pages/api/switch.ts",
+      "export default function handler(req: any, res: any) { switch (req.method) { case \"GET\": return res.end(); case \"DELETE\": return res.end(); default: return res.status(405).end(); } }\n",
+    );
+    await write(
+      root,
+      "pages/api/allow-array.ts",
+      "export default function handler(req: any, res: any) { res.setHeader(\"Allow\", [\"GET\", \"POST\"]); res.end(); }\n",
+    );
+    await write(
+      root,
+      "pages/api/allow-string.ts",
+      "export default function handler(req: any, res: any) { res.setHeader(\"Allow\", \"GET, PATCH\"); res.end(); }\n",
+    );
+
+    expect(await methodsFor(root, "/api/compare")).toEqual(["PUT"]);
+    expect(await methodsFor(root, "/api/switch")).toEqual(["DELETE", "GET"]);
+    expect(await methodsFor(root, "/api/allow-array")).toEqual(["GET", "POST"]);
+    expect(await methodsFor(root, "/api/allow-string")).toEqual(["GET", "PATCH"]);
+  });
+
+  it("treats a NextAuth handler as GET+POST", async () => {
+    const root = await temporaryRoot();
+    await write(
+      root,
+      "pages/api/auth/[...nextauth].ts",
+      "import NextAuth from \"next-auth\";\nexport default NextAuth({ providers: [] });\n",
+    );
+    expect(await methodsFor(root, "/api/auth/{nextauth}")).toEqual(["GET", "POST"]);
+  });
+
+  it("follows a req/res delegate call into the imported handler", async () => {
+    const root = await temporaryRoot();
+    await write(
+      root,
+      "lib/impl.ts",
+      "export default function impl(req: any, res: any) { if (req.method === \"POST\") return res.end(); res.status(405).end(); }\n",
+    );
+    await write(
+      root,
+      "pages/api/delegate.ts",
+      "import impl from \"../../lib/impl\";\nexport default function handler(req: any, res: any) { return impl(req, res); }\n",
+    );
+    expect(await methodsFor(root, "/api/delegate")).toEqual(["POST"]);
+  });
+
+  it("follows an imported default re-export into the implementing module", async () => {
+    const root = await temporaryRoot();
+    await write(
+      root,
+      "lib/impl.ts",
+      "export default function impl(req: any, res: any) { if (req.method === \"DELETE\") return res.end(); res.status(405).end(); }\n",
+    );
+    await write(root, "pages/api/re-exported.ts", "import impl from \"../../lib/impl\";\nexport default impl;\n");
+    expect(await methodsFor(root, "/api/re-exported")).toEqual(["DELETE"]);
+  });
+
+  it("infers verbs for method-blind default handlers", async () => {
+    const root = await temporaryRoot();
+    await write(
+      root,
+      "pages/api/trpc-page.ts",
+      "import { createNextApiHandler } from \"@trpc/server/adapters/next\";\nexport default createNextApiHandler({});\n",
+    );
+    await write(
+      root,
+      "pages/api/upload.ts",
+      "export default async function handler(req: any, res: any) { const body = req.body; res.status(201).json({ body }); }\n",
+    );
+    await write(
+      root,
+      "pages/api/stripe/webhook.ts",
+      "export default async function handler(_req: any, res: any) { res.end(); }\n",
+    );
+    await write(
+      root,
+      "pages/api/raw.ts",
+      "export const config = { api: { bodyParser: false } };\nexport default async function handler(_req: any, res: any) { res.end(); }\n",
+    );
+
+    expect(await methodsFor(root, "/api/trpc-page")).toEqual(["GET", "POST"]);
+    expect(await methodsFor(root, "/api/upload")).toEqual(["POST"]);
+    expect(await methodsFor(root, "/api/stripe/webhook")).toEqual(["POST"]);
+    expect(await methodsFor(root, "/api/raw")).toEqual(["POST"]);
+  });
+
+  it("emits an unclassified disabled tool when no evidence exists", async () => {
+    const root = await temporaryRoot();
+    await write(root, "pages/api/opaque.ts", "const helper = () => null;\nexport const settings = { helper };\n");
+    const { tools, warnings } = await scanRoutes(root);
+    expect(tools).toEqual([expect.objectContaining({
+      name: "host_opaque_unclassified",
+      disabled: true,
+      risk: "destructive",
+      binding: expect.objectContaining({ method: "POST", path: "/api/opaque" }),
+    })]);
+    expect(warnings).toEqual([expect.stringContaining("/api/opaque")]);
+  });
+});

--- a/packages/actions/src/sync/route-scan.ts
+++ b/packages/actions/src/sync/route-scan.ts
@@ -10,6 +10,7 @@ import {
   resolveImportSource,
   routeToolFullName,
   unclassifiedToolFullName,
+  visitNodes,
   walk,
   type ParsedModule,
 } from "./common.js";
@@ -94,14 +95,6 @@ function isVendoRoute(urlPath: string): boolean {
 function addMethod(methods: Set<HttpMethod>, value: string | undefined): void {
   const method = value?.toUpperCase();
   if (method && HTTP_METHOD_SET.has(method)) methods.add(method as HttpMethod);
-}
-
-function visitNodes(ts: typeof TS, root: TS.Node, visit: (node: TS.Node) => void): void {
-  const walkNode = (node: TS.Node): void => {
-    visit(node);
-    ts.forEachChild(node, walkNode);
-  };
-  ts.forEachChild(root, walkNode);
 }
 
 function calleeSimpleName(ts: typeof TS, expression: TS.CallExpression): string | null {

--- a/packages/actions/src/sync/route-scan.ts
+++ b/packages/actions/src/sync/route-scan.ts
@@ -1,17 +1,17 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import type TS from "typescript";
 import type { ExtractedTool, HttpMethod } from "../formats.js";
 import {
   allocateToolName,
   extractedRisk,
   importReferenceFor,
+  parseModuleSource,
   resolveImportSource,
   routeToolFullName,
-  splitTopLevel,
-  stripComments,
-  topLevelObjectLiteral,
   unclassifiedToolFullName,
   walk,
+  type ParsedModule,
 } from "./common.js";
 
 const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
@@ -96,144 +96,243 @@ function addMethod(methods: Set<HttpMethod>, value: string | undefined): void {
   if (method && HTTP_METHOD_SET.has(method)) methods.add(method as HttpMethod);
 }
 
-function addMethodsFromList(methods: Set<HttpMethod>, value: string): void {
-  for (const match of value.matchAll(/["'](GET|POST|PUT|PATCH|DELETE)["']/g)) addMethod(methods, match[1]);
-  for (const part of value.split(",")) addMethod(methods, part.trim());
+function visitNodes(ts: typeof TS, root: TS.Node, visit: (node: TS.Node) => void): void {
+  const walkNode = (node: TS.Node): void => {
+    visit(node);
+    ts.forEachChild(node, walkNode);
+  };
+  ts.forEachChild(root, walkNode);
 }
 
-function statementEnd(source: string, start: number): number {
-  let depth = 0;
-  let quote: "'" | "\"" | "`" | null = null;
-  let escaped = false;
-  for (let index = start; index < source.length; index += 1) {
-    const character = source[index]!;
-    if (quote) {
-      if (escaped) escaped = false;
-      else if (character === "\\") escaped = true;
-      else if (character === quote) quote = null;
-      continue;
+function calleeSimpleName(ts: typeof TS, expression: TS.CallExpression): string | null {
+  const callee = expression.expression;
+  if (ts.isIdentifier(callee)) return callee.text;
+  if (ts.isPropertyAccessExpression(callee)) return callee.name.text;
+  return null;
+}
+
+function isStringLike(ts: typeof TS, node: TS.Node): node is TS.StringLiteral | TS.NoSubstitutionTemplateLiteral {
+  return ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node);
+}
+
+function hasModifier(ts: typeof TS, statement: TS.Statement, kind: TS.SyntaxKind): boolean {
+  return ts.canHaveModifiers(statement) === true
+    && (ts.getModifiers(statement) ?? []).some((modifier) => modifier.kind === kind);
+}
+
+function bindingNames(ts: typeof TS, name: TS.BindingName): string[] {
+  if (ts.isIdentifier(name)) return [name.text];
+  return name.elements.flatMap((element) =>
+    ts.isOmittedExpression(element) ? [] : bindingNames(ts, element.name));
+}
+
+function isReqMethodAccess(ts: typeof TS, node: TS.Node): boolean {
+  return ts.isPropertyAccessExpression(node)
+    && node.name.text === "method"
+    && ts.isIdentifier(node.expression)
+    && node.expression.text === "req";
+}
+
+function allowHeaderVerbs(ts: typeof TS, methods: Set<HttpMethod>, call: TS.CallExpression): void {
+  if (calleeSimpleName(ts, call) !== "setHeader") return;
+  const [header, value] = call.arguments;
+  if (!header || !value || !isStringLike(ts, header) || header.text.toLowerCase() !== "allow") return;
+  if (isStringLike(ts, value)) {
+    for (const part of value.text.split(",")) addMethod(methods, part.trim());
+  } else if (ts.isArrayLiteralExpression(value)) {
+    for (const element of value.elements) {
+      if (isStringLike(ts, element)) addMethod(methods, element.text);
     }
-    if (character === "'" || character === "\"" || character === "`") {
-      quote = character;
-      continue;
-    }
-    if (character === "(" || character === "[" || character === "{") depth += 1;
-    else if (character === ")" || character === "]" || character === "}") depth = Math.max(0, depth - 1);
-    else if (character === ";" && depth === 0) return index;
-    else if (character === "\n" && depth === 0 && /^(?:export|import|const|let|var|function|class)\b/.test(source.slice(index + 1).trimStart())) return index;
   }
-  return source.length;
 }
 
-function exportedVerbs(source: string, kind: RouteSource["kind"]): Set<HttpMethod> {
+function exportedVerbs(module: ParsedModule, kind: RouteSource["kind"]): Set<HttpMethod> {
+  const { ts, sf } = module;
   const methods = new Set<HttpMethod>();
-  for (const match of source.matchAll(/export\s+(?:async\s+)?function\s+(GET|POST|PUT|PATCH|DELETE)\b/g)) {
-    addMethod(methods, match[1]);
-  }
-  for (const match of source.matchAll(/export\s+(?:const|let|var)\s+/g)) {
-    const start = (match.index ?? 0) + match[0].length;
-    for (const declaration of splitTopLevel(source.slice(start, statementEnd(source, start)))) {
-      addMethod(methods, declaration.trim().match(/^([A-Za-z_$][\w$]*)\b/)?.[1]);
+  for (const statement of sf.statements) {
+    if (ts.isFunctionDeclaration(statement) && hasModifier(ts, statement, ts.SyntaxKind.ExportKeyword)) {
+      addMethod(methods, statement.name?.text);
+      continue;
     }
-  }
-  for (const match of source.matchAll(/export\s+(?:const|let|var)\s*\{([^}]+)\}\s*=/g)) {
-    addMethodsFromList(methods, match[1] ?? "");
-  }
-  for (const match of source.matchAll(/export\s*\{([^}]+)\}(?!\s*from\b)/g)) {
-    for (const part of (match[1] ?? "").split(",")) {
-      const trimmed = part.trim();
-      addMethod(methods, trimmed.match(/\bas\s+(GET|POST|PUT|PATCH|DELETE)\b/)?.[1] ?? trimmed);
+    if (ts.isVariableStatement(statement) && hasModifier(ts, statement, ts.SyntaxKind.ExportKeyword)) {
+      for (const declaration of statement.declarationList.declarations) {
+        for (const name of bindingNames(ts, declaration.name)) addMethod(methods, name);
+      }
+      continue;
+    }
+    // Local export lists: `export { handler as PATCH }` (re-export lists from
+    // other modules are handled by reExportTargets).
+    if (ts.isExportDeclaration(statement) && !statement.moduleSpecifier
+      && statement.exportClause && ts.isNamedExports(statement.exportClause)) {
+      for (const element of statement.exportClause.elements) addMethod(methods, element.name.text);
     }
   }
   if (kind === "pages") {
-    for (const match of source.matchAll(/\breq\.method\s*(?:={2,3}|!={1,2})\s*["'](GET|POST|PUT|PATCH|DELETE)["']/g)) {
-      addMethod(methods, match[1]);
-    }
-    for (const match of source.matchAll(/\bcase\s+["'](GET|POST|PUT|PATCH|DELETE)["']/g)) addMethod(methods, match[1]);
-    for (const match of source.matchAll(/setHeader\(\s*["']Allow["']\s*,\s*\[([^\]]+)\]/g)) addMethodsFromList(methods, match[1] ?? "");
-    for (const match of source.matchAll(/setHeader\(\s*["']Allow["']\s*,\s*["']([^"']+)["']/g)) addMethodsFromList(methods, match[1] ?? "");
-    if (/\bNextAuth\s*\(/.test(source)) {
-      methods.add("GET");
-      methods.add("POST");
-    }
+    visitNodes(ts, sf, (node) => {
+      if (ts.isBinaryExpression(node)
+        && [ts.SyntaxKind.EqualsEqualsToken, ts.SyntaxKind.EqualsEqualsEqualsToken,
+          ts.SyntaxKind.ExclamationEqualsToken, ts.SyntaxKind.ExclamationEqualsEqualsToken,
+        ].includes(node.operatorToken.kind)
+        && isReqMethodAccess(ts, node.left)
+        && isStringLike(ts, node.right)) {
+        addMethod(methods, node.right.text);
+      }
+      if (ts.isCaseClause(node) && isStringLike(ts, node.expression)) addMethod(methods, node.expression.text);
+      if (ts.isCallExpression(node)) {
+        allowHeaderVerbs(ts, methods, node);
+        if (calleeSimpleName(ts, node) === "NextAuth") {
+          methods.add("GET");
+          methods.add("POST");
+        }
+      }
+    });
   }
   return methods;
 }
 
-function firstObjectArgument(source: string, callee: RegExp): string | null {
-  for (const match of source.matchAll(callee)) {
-    let index = (match.index ?? 0) + match[0].length;
-    while (/\s/.test(source[index] ?? "")) index += 1;
-    if (source[index] !== "(") continue;
-    index += 1;
-    while (/\s/.test(source[index] ?? "")) index += 1;
-    if (source[index] === "{") return topLevelObjectLiteral(source, index);
-  }
-  return null;
-}
-
-function methodKeyObjectVerbs(source: string): Set<HttpMethod> | null {
-  const body = firstObjectArgument(source, /\bdefaultHandler\s*/g);
-  if (!body) return null;
+function verbKeyedProperties(ts: typeof TS, literal: TS.ObjectLiteralExpression): Set<HttpMethod> {
   const methods = new Set<HttpMethod>();
-  for (const entry of splitTopLevel(body)) {
-    const key = entry.trim().match(/^(?:(["'])(GET|POST|PUT|PATCH|DELETE)\1|(GET|POST|PUT|PATCH|DELETE))\s*:/);
-    addMethod(methods, key?.[2] ?? key?.[3]);
+  for (const property of literal.properties) {
+    if (!ts.isPropertyAssignment(property)) continue;
+    const name = property.name;
+    if (ts.isIdentifier(name) || ts.isStringLiteral(name)) addMethod(methods, name.text);
   }
-  return methods.size > 0 ? methods : null;
+  return methods;
 }
 
-function routeMapVerbs(source: string, route: RouteSource): Set<HttpMethod> | null {
-  const entries = [...source.matchAll(/["'](GET|POST|PUT|PATCH|DELETE)\s+([^"']+)["']\s*:/g)];
+function methodKeyObjectVerbs(module: ParsedModule): Set<HttpMethod> | null {
+  const { ts, sf } = module;
+  let found: Set<HttpMethod> | null = null;
+  visitNodes(ts, sf, (node) => {
+    if (found || !ts.isCallExpression(node) || calleeSimpleName(ts, node) !== "defaultHandler") return;
+    const argument = node.arguments[0];
+    if (!argument || !ts.isObjectLiteralExpression(argument)) return;
+    const methods = verbKeyedProperties(ts, argument);
+    if (methods.size > 0) found = methods;
+  });
+  return found;
+}
+
+function routeMapVerbs(module: ParsedModule, route: RouteSource): Set<HttpMethod> | null {
+  const { ts, sf } = module;
+  const entries: Array<{ method: string; entryPath: string }> = [];
+  visitNodes(ts, sf, (node) => {
+    if (!ts.isPropertyAssignment(node) || !ts.isStringLiteral(node.name)) return;
+    const match = node.name.text.match(/^(GET|POST|PUT|PATCH|DELETE)\s+(\S.*)$/);
+    if (match) entries.push({ method: match[1]!, entryPath: match[2]! });
+  });
   if (entries.length === 0) return null;
   const methods = new Set<HttpMethod>();
   const itemRoute = /\/\{[^}]+\}$/.test(route.urlPath);
   for (const entry of entries) {
-    const rootEntry = (entry[2] ?? "/") === "/";
-    if (route.catchAll || (itemRoute ? !rootEntry : rootEntry)) addMethod(methods, entry[1]);
+    const rootEntry = entry.entryPath === "/";
+    if (route.catchAll || (itemRoute ? !rootEntry : rootEntry)) addMethod(methods, entry.method);
   }
   return methods;
 }
 
-async function reExportTargets(source: string): Promise<ReExportTarget[]> {
-  const targets: ReExportTarget[] = [];
-  for (const match of source.matchAll(/export\s+\*\s+from\s+["']([^"']+)["']/g)) {
-    if (match[1]) targets.push({ specifier: match[1], assumeDefaultExport: false });
+function defaultImportSpecifier(ts: typeof TS, sf: TS.SourceFile, localName: string): string | null {
+  for (const statement of sf.statements) {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    if (statement.importClause?.name?.text === localName) return statement.moduleSpecifier.text;
   }
-  for (const match of source.matchAll(/export\s*\{([^}]+)\}\s*from\s+["']([^"']+)["']/g)) {
-    const specifier = match[2];
-    if (!specifier) continue;
-    for (const part of (match[1] ?? "").split(",")) {
-      const names = part.trim().split(/\s+as\s+/).map((name) => name.trim());
-      if ((names[1] ?? names[0]) === "default") targets.push({ specifier, assumeDefaultExport: true });
-      else if (HTTP_METHOD_SET.has(names[1] ?? names[0] ?? "")) {
+  return null;
+}
+
+function delegateCallName(ts: typeof TS, sf: TS.SourceFile): string | null {
+  let found: string | null = null;
+  visitNodes(ts, sf, (node) => {
+    if (found || !ts.isReturnStatement(node) || !node.expression) return;
+    const returned = ts.isAwaitExpression(node.expression) ? node.expression.expression : node.expression;
+    if (!ts.isCallExpression(returned) || !ts.isIdentifier(returned.expression)) return;
+    const [first, second] = returned.arguments;
+    if (first && second && ts.isIdentifier(first) && first.text === "req" && ts.isIdentifier(second) && second.text === "res") {
+      found = returned.expression.text;
+    }
+  });
+  return found;
+}
+
+async function reExportTargets(module: ParsedModule, source: string): Promise<ReExportTarget[]> {
+  const { ts, sf } = module;
+  const targets: ReExportTarget[] = [];
+  for (const statement of sf.statements) {
+    if (ts.isExportDeclaration(statement) && statement.moduleSpecifier && ts.isStringLiteral(statement.moduleSpecifier)) {
+      const specifier = statement.moduleSpecifier.text;
+      const clause = statement.exportClause;
+      if (!clause) {
         targets.push({ specifier, assumeDefaultExport: false });
+        continue;
       }
+      if (!ts.isNamedExports(clause)) continue;
+      for (const element of clause.elements) {
+        if (element.name.text === "default") targets.push({ specifier, assumeDefaultExport: true });
+        else if (HTTP_METHOD_SET.has(element.name.text)) targets.push({ specifier, assumeDefaultExport: false });
+      }
+      continue;
+    }
+    if (ts.isExportAssignment(statement) && !statement.isExportEquals && ts.isIdentifier(statement.expression)) {
+      const specifier = defaultImportSpecifier(ts, sf, statement.expression.text);
+      if (specifier) targets.push({ specifier, assumeDefaultExport: true });
     }
   }
-  const importedDefault = source.match(/import\s+([A-Za-z_$][\w$]*)\s+from\s+["']([^"']+)["'][\s\S]*?export\s+default\s+\1\b/);
-  if (importedDefault?.[2]) targets.push({ specifier: importedDefault[2], assumeDefaultExport: true });
-  const delegate = source.match(/return\s+(?:await\s+)?([A-Za-z_$][\w$]*)\s*\(\s*req\s*,\s*res\b/);
-  const delegateReference = delegate?.[1] ? await importReferenceFor(source, delegate[1]) : undefined;
+  const delegate = delegateCallName(ts, sf);
+  const delegateReference = delegate ? await importReferenceFor(source, delegate) : undefined;
   if (delegateReference) targets.push({ specifier: delegateReference.specifier, assumeDefaultExport: true });
   return targets;
 }
 
-function hasDefaultHandler(source: string, assumed: boolean): boolean {
-  return assumed || /\bexport\s+default\b/.test(source) || /export\s*\{[^}]+(?:\bas\s+default\b|\bdefault\b)[^}]*\}\s*from\b/.test(source);
+function hasDefaultHandler(module: ParsedModule, assumed: boolean): boolean {
+  if (assumed) return true;
+  const { ts, sf } = module;
+  return sf.statements.some((statement) =>
+    ts.isExportAssignment(statement)
+    || hasModifier(ts, statement, ts.SyntaxKind.DefaultKeyword)
+    || (ts.isExportDeclaration(statement) && Boolean(statement.moduleSpecifier)
+      && statement.exportClause !== undefined && ts.isNamedExports(statement.exportClause)
+      && statement.exportClause.elements.some((element) => element.name.text === "default")));
 }
 
-function inferredPageVerbs(source: string, route: RouteSource, assumed = false): Set<HttpMethod> {
+function inferredPageVerbs(module: ParsedModule, route: RouteSource, assumed = false): Set<HttpMethod> {
+  const { ts, sf } = module;
   const methods = new Set<HttpMethod>();
-  if (route.kind !== "pages" || !hasDefaultHandler(source, assumed) || /\breq\.method\b/.test(source)) return methods;
-  if (/\bcreateNextApiHandler\s*\(/.test(source)) {
+  if (route.kind !== "pages" || !hasDefaultHandler(module, assumed)) return methods;
+
+  let reqMethod = false;
+  let reqBody = false;
+  let handlerMap = false;
+  let apiHandlers = false;
+  let createNextApiHandlerCall = false;
+  let handleUploadCall = false;
+  let bodyParserDisabled = false;
+  visitNodes(ts, sf, (node) => {
+    if (isReqMethodAccess(ts, node)) reqMethod = true;
+    if (ts.isPropertyAccessExpression(node) && node.name.text === "body"
+      && ts.isIdentifier(node.expression) && node.expression.text === "req") reqBody = true;
+    if (ts.isIdentifier(node)) {
+      if (node.text === "handlerMap") handlerMap = true;
+      if (node.text === "apiHandlers") apiHandlers = true;
+    }
+    if (ts.isCallExpression(node)) {
+      const name = calleeSimpleName(ts, node);
+      if (name === "createNextApiHandler") createNextApiHandlerCall = true;
+      if (name === "handleUpload") handleUploadCall = true;
+    }
+    if (ts.isPropertyAssignment(node) && (ts.isIdentifier(node.name) || ts.isStringLiteral(node.name))
+      && node.name.text === "bodyParser" && node.initializer.kind === ts.SyntaxKind.FalseKeyword) {
+      bodyParserDisabled = true;
+    }
+  });
+
+  if (reqMethod) return methods;
+  if (createNextApiHandlerCall) {
     methods.add("GET");
     methods.add("POST");
-  } else if (/\bhandlerMap\b/.test(source) && /\bapiHandlers\b/.test(source) && route.catchAll) {
+  } else if (handlerMap && apiHandlers && route.catchAll) {
     methods.add("POST");
-  } else if (/\bhandleUpload\s*\(/.test(source) || /\breq\.body\b/.test(source)) {
+  } else if (handleUploadCall || reqBody) {
     methods.add("POST");
-  } else if (/\bbodyParser\s*:\s*false\b/.test(source) || route.urlPath.endsWith("/webhook")) {
+  } else if (bodyParserDisabled || route.urlPath.endsWith("/webhook")) {
     methods.add("POST");
   }
   return methods;
@@ -251,16 +350,17 @@ async function verbsFromSource(
   const key = `${file}\t${assumeDefaultExport ? "default" : "named"}`;
   if (visited.has(key)) return new Set();
   visited.add(key);
-  const evidenceSource = stripComments(source);
-  const direct = exportedVerbs(evidenceSource, route.kind);
+  const module = parseModuleSource(source, file);
+  if (!module) return new Set();
+  const direct = exportedVerbs(module, route.kind);
   if (direct.size > 0) return direct;
-  const mapped = routeMapVerbs(evidenceSource, route);
+  const mapped = routeMapVerbs(module, route);
   if (mapped) return mapped;
-  const objectMethods = methodKeyObjectVerbs(evidenceSource);
+  const objectMethods = methodKeyObjectVerbs(module);
   if (objectMethods) return objectMethods;
   if (depth < MAX_REEXPORT_DEPTH) {
     const resolvedMethods = new Set<HttpMethod>();
-    for (const target of await reExportTargets(evidenceSource)) {
+    for (const target of await reExportTargets(module, source)) {
       const resolved = await resolveImportSource(file, target.specifier, root);
       if (!resolved) continue;
       const nested = await verbsFromSource(
@@ -276,7 +376,7 @@ async function verbsFromSource(
     }
     if (resolvedMethods.size > 0) return resolvedMethods;
   }
-  return inferredPageVerbs(evidenceSource, route, assumeDefaultExport);
+  return inferredPageVerbs(module, route, assumeDefaultExport);
 }
 
 function routeInputSchema(urlPath: string): Record<string, unknown> {

--- a/packages/actions/src/sync/static-ts.ts
+++ b/packages/actions/src/sync/static-ts.ts
@@ -226,11 +226,15 @@ export function unrecognized(reason: string): ZodSchemaResult {
   return { schema: {}, optional: false, recognized: false, reason };
 }
 
+/** Modifiers that pass the inner schema through unchanged on the wire.
+ * Narrowed (kill-list §B1) to the set the corpus fixtures and the actions
+ * suite actually exercise — measured 2026-07-17 over the pinned rallly tRPC
+ * routers and nextcrm server actions. Anything else fails closed (permissive
+ * schema + note), which is the correct posture for modifiers nobody has
+ * proven against the corpus. */
 const ZOD_PASSTHROUGH_MODIFIERS = new Set([
-  "trim", "refine", "superRefine", "transform", "describe", "brand", "readonly",
-  "regex", "startsWith", "endsWith", "includes", "toLowerCase", "toUpperCase",
-  "catch", "passthrough", "strict", "strip", "positive", "nonnegative", "negative",
-  "nonpositive", "finite", "safe", "step", "multipleOf", "length", "nonempty", "cuid", "cuid2", "ulid", "nanoid",
+  "trim", "refine", "transform", "describe", "regex", "toUpperCase", "catch",
+  "positive", "nonnegative", "length", "nonempty", "cuid",
 ]);
 
 export async function zodFromExpression(

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@vendoai/core": "workspace:*",
     "fflate": "^0.8.2",
-    "zod": "^3.24.0"
+    "zod": "^3.25.0"
   },
   "peerDependencies": {
     "ai": ">=6.0.0 <7",

--- a/packages/apps/src/pins.ts
+++ b/packages/apps/src/pins.ts
@@ -71,9 +71,9 @@ export const pinComponentName = (slot: string): string => {
 
 /**
  * Blank comment and string/template contents (length-preserving) so export
- * detection never matches commented-out or quoted code. Adapted from sync's
- * `stripComments` (packages/actions/src/sync/common.ts — actions may not be
- * imported here), extended to blank string contents too.
+ * detection never matches commented-out or quoted code. (Adapted from the
+ * `stripComments` helper sync's extraction carried before it moved onto the
+ * TypeScript AST — actions may not be imported here.)
  */
 const blankCommentsAndStrings = (source: string): string => {
   let output = "";

--- a/packages/automations/package.json
+++ b/packages/automations/package.json
@@ -47,7 +47,7 @@
     "@vendoai/core": "workspace:*",
     "croner": "^9.0.0",
     "jsonata": "^2.0.5",
-    "zod": "^3.24.0"
+    "zod": "^3.25.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "zod": "^3.24.0"
+    "zod": "^3.25.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/guard/package.json
+++ b/packages/guard/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@vendoai/core": "workspace:*",
-    "zod": "^3.24.0"
+    "zod": "^3.25.0"
   },
   "peerDependencies": {
     "ai": ">=6.0.0 <7"

--- a/packages/vendo/package.json
+++ b/packages/vendo/package.json
@@ -70,7 +70,7 @@
     "@vendoai/ui": "workspace:*",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
-    "zod": "^3.24.0"
+    "zod": "^3.25.0"
   },
   "peerDependencies": {
     "ai": ">=6.0.0 <7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -682,7 +682,7 @@ importers:
         specifier: ^2.6.0
         version: 2.9.0
       zod:
-        specifier: ^3.24.0
+        specifier: ^3.25.0
         version: 3.25.76
     devDependencies:
       '@auth/core':
@@ -744,7 +744,7 @@ importers:
         specifier: ^0.8.2
         version: 0.8.3
       zod:
-        specifier: ^3.24.0
+        specifier: ^3.25.0
         version: 3.25.76
     devDependencies:
       '@ai-sdk/anthropic':
@@ -787,7 +787,7 @@ importers:
         specifier: ^2.0.5
         version: 2.2.1
       zod:
-        specifier: ^3.24.0
+        specifier: ^3.25.0
         version: 3.25.76
     devDependencies:
       '@types/node':
@@ -803,7 +803,7 @@ importers:
   packages/core:
     dependencies:
       zod:
-        specifier: ^3.24.0
+        specifier: ^3.25.0
         version: 3.25.76
     devDependencies:
       '@types/node':
@@ -834,7 +834,7 @@ importers:
         specifier: workspace:*
         version: link:../core
       zod:
-        specifier: ^3.24.0
+        specifier: ^3.25.0
         version: 3.25.76
     devDependencies:
       '@ai-sdk/anthropic':
@@ -1015,7 +1015,7 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.20.0)
       zod:
-        specifier: ^3.24.0
+        specifier: ^3.25.0
         version: 3.25.76
     devDependencies:
       '@types/node':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -675,9 +675,6 @@ importers:
       '@vendoai/core':
         specifier: workspace:*
         version: link:../core
-      es-module-lexer:
-        specifier: ^1.7.0
-        version: 1.7.0
       jsonata:
         specifier: ^2.0.5
         version: 2.2.1


### PR DESCRIPTION
Kill-list item **B1** (`docs/superpowers/specs/2026-07-16-simplify-v2-kill-list-design.md` §B1): the extraction pipeline keeps its exact behavior and coverage, but every hand-rolled TypeScript parser in `packages/actions/src/sync/` now runs on the TypeScript compiler API the package already used for tRPC/GraphQL/catalog scanning. Internal implementation swap only — filenames, exports, and the public API are unchanged.

## What moved onto the AST

- **Module analysis (`common.ts`)** — `resolveImportSource`/`importReferenceFor` read imports, re-exports, and export declarations from a parsed `SourceFile`. This retires `fallbackModuleStatements` (the hand-rolled tokenizer simplify-v2 proved was the LIVE parser for TSX/JSX modules) **and the `es-module-lexer` dependency** (its happy path). tsconfig JSONC parsing moved to `ts.parseConfigFileTextToJson`.
- **Route-scan (`route-scan.ts`)** — the ~30 verb-guessing regexes and the statement/brace walkers became AST queries: exported declarations (incl. destructured/aliased export lists), `"VERB /path"` route maps, `defaultHandler` verb-keyed objects, `req.method`/`case`/`Allow`-header/`NextAuth` pages evidence, re-export + req/res-delegate chains, and the method-blind pages inference heuristics. File-path→URL segment mapping keeps its regexes (little strings, not code). Bonus fix locked by test: verb-looking text inside string literals is no longer route evidence.
- **Pins (`pins.ts`)** — registration discovery is an object-literal walk (`remixable(` marking via call-argument parent, router-table `path` exclusion, byte-exact literal offsets); the bespoke `StaticValueParser` JSON-with-trailing-commas scanner became static AST evaluation of the `sampleProps` initializer; `importSpecifiers` reads static/re-export/dynamic-import specifiers from statements instead of type-erasure regexes.
- **Zod interpreter (`static-ts.ts`)** — `ZOD_PASSTHROUGH_MODIFIERS` narrowed **30 → 12**, measured against what the corpus fixtures actually exercise (grep in zod-chain position over the pinned rallly tRPC routers + nextcrm server actions, plus the actions suite). Extraction output over both checkouts is byte-identical before/after; unlisted modifiers keep failing closed (permissive schema + note).

## Deleted

| Machinery | Where |
|---|---|
| `fallbackModuleStatements` tokenizer (~93 lines) | common.ts |
| `lexModule` + es-module-lexer wrapper + `namedBindings` regex helper | common.ts |
| `stripComments` char-scanner (~42) | common.ts |
| `splitTopLevel` / `topLevelObjectLiteral` brace walkers (~52) | common.ts |
| `parseJsonLike` trailing-comma regex | common.ts |
| `StaticValueParser` class + `registrationFromBody` field regexes (~150) | pins.ts |
| ~30 verb regexes, `statementEnd`, `firstObjectArgument` | route-scan.ts |
| 18 unproven zod passthrough modifiers | static-ts.ts |
| `es-module-lexer` | package.json dependency |

## Line counts

| File | Before | After |
|---|---|---|
| `sync/common.ts` | 655 | 507 |
| `sync/route-scan.ts` | 366 | 459 (AST evidence queries are wordier than regexes; zero string-scanning) |
| `sync/pins.ts` | 574 | 538 |
| `sync/static-ts.ts` | 423 | 427 |
| **Net source** | **2,018** | **1,931 (−87), minus one dependency** |

New behavior-lock tests: `common.test.ts` (+102) and `route-scan.test.ts` (+215) pin the exotic resolution/evidence paths (written against the old implementation first, then the swap).

## Corpus gate (the quality lock)

Full `pnpm corpus run --layer 2` sweeps at the base commit and at this branch, same clone/caches/environment, all 16 manifest repos:

| repo | L1 base → branch | L2 base | L2 branch | Δ |
|---|---|---|---|---|
| umami | fail → fail | 1.000 | 1.000 | 0.000 |
| skateshop | fail → fail | 0.918 | 0.918 | 0.000 |
| taxonomy | fail → fail | 1.000 | 1.000 | 0.000 |
| invoify | fail → fail | 1.000 | 1.000 | 0.000 |
| papermark | pass → pass | 0.998 | 0.998 | 0.000 |
| cal-com | fail → fail | 0.986 | 0.986 | 0.000 |
| dub | pass → pass | 0.883 | 0.883 | 0.000 |
| formbricks | pass → pass | 0.836 | 0.836 | 0.000 |
| inbox-zero | pass → pass | 0.953 | 0.953 | 0.000 |
| openstatus | pass → pass | 0.989 | 0.989 | 0.000 |
| vercel-commerce | pass → pass | 0.917 | 0.917 | 0.000 |
| rallly | pass → pass | 0.579 | 0.579 | 0.000 |
| nextcrm | pass → pass | 1.000 | 1.000 | 0.000 |
| teable | fail → fail | 0.850 | 0.850 | 0.000 |
| express-host | pass → pass | 1.000 | 1.000 | 0.000 |
| twenty | pass → pass | 1.000 | 1.000 | 0.000 |

**Zero regressions.** Every layer-2 extraction score is identical to six decimals, and every layer-1 structural status is unchanged. Reading notes:
- The six repos failing L1 at *base* fail identically on both sides (pre-existing host typecheck/build baseline issues in this environment, unrelated to extraction — their builds fail before `vendo init` is judged).
- Several repos score below their *checked-in* `baseline.json` at the base commit too (e.g. rallly 0.579 vs 0.600 accepted) — pre-existing environment drift; the gate here is the same-clone, same-environment A/B above.
- The first branch sweep DID catch one real landmine: rallly's post-init host build broke because the vendo packages' `zod ^3.24.0` floor let a stale host `zod@3.24.0` satisfy the graph, and pnpm peer-resolved `@ai-sdk/provider-utils` against it (`zod/v3` subpath missing). The B1 tarball change merely re-rolled that peer-resolution dice. Fixed in-branch by raising the floor to `^3.25.0` (the workspace already resolves 3.25.76 everywhere — every suite already runs on it), then the full 16-repo sweep re-ran clean: rallly pass → pass.

Package gates: `@vendoai/actions` 318 passed; full `pnpm build && turbo run test --concurrency=4 && pnpm typecheck && pnpm lint` green (run in a space-free checkout — `core` packaging.e2e cannot execute under a path containing spaces, a pre-existing Vite `%20` limitation unrelated to this PR).

Note: per the 2026-07-17 doctrine change (contracts system retired) this PR intentionally does **not** amend `docs/contracts/04-actions.md`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the extraction pipeline onto the TypeScript compiler AST for module analysis, route scanning, and pin capture, replacing hand-rolled parsers while keeping behavior and the public API unchanged. Fixed a regression where `export * as X` namespace re-exports did not resolve to the declaring barrel.

- **Refactors**
  - Module analysis runs on the TS AST; removed the fallback TSX tokenizer and `es-module-lexer`; tsconfig JSONC parsed via the TS API.
  - Route verbs now come from AST queries (exports, route maps, `defaultHandler` objects, pages heuristics, re-exports, delegate calls); no string scanning.
  - Pin registration discovery uses AST walks; `sampleProps` statically evaluated from AST; removed brace-walker helpers.
  - Namespace re-exports (`export * as X`) resolve to the barrel that declares them; added a behavior-lock test.
  - Narrowed `ZOD_PASSTHROUGH_MODIFIERS` to measured usage; extraction outputs are unchanged across the corpus; added behavior-lock tests and removed a regex-era false positive where verb-like text inside strings/comments was treated as route evidence.

- **Dependencies**
  - Removed `es-module-lexer`.
  - Bumped `zod` to `^3.25.0` across packages to avoid host build issues; no API or behavior changes expected.

<sup>Written for commit c32a451d880e2235820209fdd61ebadd616cbe16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

