### PR TITLE
Hosted store one-pager

### DIFF
--- a/docs/superpowers/specs/2026-07-18-hosted-store-onepager.md
+++ b/docs/superpowers/specs/2026-07-18-hosted-store-onepager.md
@@ -1,17 +1,20 @@
 # Hosted store — one-pager
 
 Date: 2026-07-18
-Status: DRAFT for Yousef's review (write-once decision doc, not living law)
+Status: ACCEPTED 2026-07-17 (Yousef, via the cloud-definition brainstorm; Q1/Q2
+as recommended, Q3 amended — see Decisions). Amended to match the realignment
+lane: the entitlement protocol and validate endpoint no longer exist.
 
 ## What it is
 
 A multi-tenant Postgres behind an HTTP API that the OSS `hostedStore` adapter
-speaks. With `VENDO_API_KEY` set and the `hosted-storage` entitlement present,
-the umbrella composes `hostedStore()` instead of `createStore()` — Vendo data
-(apps, threads, runs, grants, approvals, audit, state, sessions) lives with
-Vendo. Tenant = the key's org, resolved through the existing key-validation +
-entitlements path (`/api/v1/keys/validate`, entitlements contract v2, cached
-TTL). BYO-Postgres (`createStore`) remains, single-player only.
+speaks. With `VENDO_API_KEY` set and no explicit
+store passed, the umbrella composes `hostedStore()` instead of `createStore()`
+(adapter rule: the key fills only unset slots; an explicitly passed store
+always wins) — Vendo data (apps, threads, runs, grants, approvals, audit,
+state, sessions) lives with Vendo. Tenant = the key's org, resolved
+server-side on every call, never from the request body. BYO-Postgres
+(`createStore`) remains forever (hard BYO rule).
 
 From OSS's perspective the hosted backend is just another `StoreAdapter`
 (`packages/core/src/store.ts`). The service is dumb storage: it persists rows
@@ -59,7 +62,8 @@ grammar, `vendo_threads` revisions) are enforced server-side, same rules as
 ## Tenancy, limits, residency
 
 - Every row carries `org_id`; the org comes from the API key, never the
-  request body. Key rotation re-resolves via the cached entitlements lookup.
+  request body. Key rotation takes effect on the next call — there is no
+  client-side entitlement cache.
 - Orgs re-home here eventually (kill-list A5 cut them from OSS); v1 needs only
   tenant = key's org — no membership model yet.
 - Soft quotas per org at launch (rows, blob bytes, requests/s); 402 with
@@ -72,23 +76,26 @@ grammar, `vendo_threads` revisions) are enforced server-side, same rules as
 ## Seam split
 
 - **OSS (this repo):** `hostedStore(config)` in `packages/store` — a
-  fetch-backed `StoreAdapter` (~one file plus tests), reusing the cloud.ts
-  error mapping. Umbrella composition: key present + entitlement →
-  `hostedStore`, else `createStore`. Conformance: the existing store adapter
-  conformance suite runs against it via an in-memory fake of the HTTP API.
+  fetch-backed `StoreAdapter` (~one file plus tests), reusing the
+  `cloudSandbox` error-mapping table and the shared deployment-identity
+  headers. Umbrella composition via a `selectStore` seam cloned from
+  `selectConnections`: explicit store wins, else key → `hostedStore`, else
+  `createStore`. Conformance: the existing store adapter conformance suite
+  runs against it via an in-memory fake of the HTTP API.
 - **vendo-web (private):** the service — Postgres schema (org-scoped mirror of
   `packages/store/src/schema.ts`), the routes above beside the existing
-  broker/key-validation code, metering, migrations. Ships behind the
-  `hosted-storage` entitlement flag.
+  broker/key-introspection code, metering, migrations. Gated by valid key +
+  `storage_gb` quota — no entitlement flag (2026-07-17 decision: no capability
+  booleans anywhere).
 
-## Open questions
+## Decisions (Yousef, 2026-07-17)
 
-1. **Postgres substrate.** The broker runs on Cloudflare Workers, which can't
-   embed Postgres. Recommendation: managed Postgres (Neon or similar) reached
-   via Hyperdrive from the existing broker — no new deploy target.
-2. **Blob transport.** Raw bytes through the API vs presigned object-storage
-   URLs. Recommendation: raw bytes now (blobs today are app docs and small
-   artifacts); revisit presigned R2 URLs only when size or egress cost says so.
-3. **Entitlement granularity.** Single `hosted-storage` boolean vs metered
-   tiers at launch. Recommendation: boolean + soft quotas; wire metering into
-   pricing tiers only after real usage exists.
+1. **Postgres substrate — accepted as recommended.** Managed Postgres (Neon or
+   similar) reached via Hyperdrive from the existing broker — no new deploy
+   target.
+2. **Blob transport — accepted as recommended.** Raw bytes through the API
+   now; revisit presigned R2 URLs only when size or egress cost says so.
+3. **Gating — amended.** No `hosted-storage` boolean, no entitlement flag of
+   any kind. A valid key gets the hosted store; `storage_gb` soft quotas do
+   the limiting, with the standard quota-exhausted error past caps. Metered
+   pricing tiers wire in only after real usage exists.

--- a/docs/superpowers/specs/2026-07-18-hosted-store-onepager.md
+++ b/docs/superpowers/specs/2026-07-18-hosted-store-onepager.md
@@ -1,0 +1,94 @@
+# Hosted store — one-pager
+
+Date: 2026-07-18
+Status: DRAFT for Yousef's review (write-once decision doc, not living law)
+
+## What it is
+
+A multi-tenant Postgres behind an HTTP API that the OSS `hostedStore` adapter
+speaks. With `VENDO_API_KEY` set and the `hosted-storage` entitlement present,
+the umbrella composes `hostedStore()` instead of `createStore()` — Vendo data
+(apps, threads, runs, grants, approvals, audit, state, sessions) lives with
+Vendo. Tenant = the key's org, resolved through the existing key-validation +
+entitlements path (`/api/v1/keys/validate`, entitlements contract v2, cached
+TTL). BYO-Postgres (`createStore`) remains, single-player only.
+
+From OSS's perspective the hosted backend is just another `StoreAdapter`
+(`packages/core/src/store.ts`). The service is dumb storage: it persists rows
+and bytes, nothing else.
+
+## API shape
+
+RPC-over-HTTP mirroring the `StoreAdapter` surface, method for method. The
+TypeScript types ARE the contract — bodies are the method arguments, responses
+the return values, same client pattern as `packages/apps/src/cloud.ts`
+(Bearer `VENDO_API_KEY`, `{ error: { code, message } }` envelope, 402 →
+`cloud-required`). Base: `VENDO_CLOUD_URL` (default `https://console.vendo.run`).
+
+Records — `POST /api/v1/store/records/:collection/<method>`:
+`get` · `put` · `delete` · `list` · `claim` ·
+`atomic/insert-if-absent` · `atomic/compare-and-swap`
+
+Blobs — `/api/v1/store/blobs/:namespace/:key`:
+`PUT` (raw bytes + Content-Type) · `GET` · `DELETE`, and
+`GET /api/v1/store/blobs/:namespace?prefix=` for list.
+
+Erase — `POST /api/v1/store/erase` (subject cascade, 02-store §5 semantics —
+the ephemeral-session TTL sweep still runs host-side and calls this).
+
+`ensureSchema()` is a client-side no-op; the service owns its migrations.
+Reserved-collection semantics (`vendo_audit` append-only, `vendo_state` id
+grammar, `vendo_threads` revisions) are enforced server-side, same rules as
+`packages/store/src/routing.ts`.
+
+## What does NOT change
+
+- **The guard runs host-side.** Judge, consent, approvals logic all stay in the
+  host process. The hosted store never evaluates policy; it stores the rows.
+- **Secrets NEVER leave the host.** Today `vendo_secrets` is AES-encrypted with
+  a host-held key via `createStore({ encryption: { key } })`, and
+  `storeSecrets`/`secretStore` are functions of the local `VendoStore` handle —
+  they cannot route to a plain `StoreAdapter`. That stays true by construction:
+  the hosted API has no secrets endpoints, and `vendo_secrets` is not a
+  syncable collection. Secrets stay in `envSecrets` or the local store.
+- **Sandbox/egress model.** Generated code still runs in the host's sandbox;
+  the hosted store is a data plane, not an execution venue.
+- **The OSS seam.** `StoreAdapter` is unchanged; everything downstream of it
+  (runtime, apps, ui) is oblivious to which store it got.
+
+## Tenancy, limits, residency
+
+- Every row carries `org_id`; the org comes from the API key, never the
+  request body. Key rotation re-resolves via the cached entitlements lookup.
+- Orgs re-home here eventually (kill-list A5 cut them from OSS); v1 needs only
+  tenant = key's org — no membership model yet.
+- Soft quotas per org at launch (rows, blob bytes, requests/s); 402 with
+  `cloud-required` past hard caps, consistent with the existing envelope.
+- Residency: single US region at launch; EU later as a per-org region pin.
+  State it on the pricing page, don't build it yet.
+- Retention/erase parity with OSS: the erase endpoint cascades exactly like
+  `eraseStore`, so a swept subject leaves zero rows — same guarantee, hosted.
+
+## Seam split
+
+- **OSS (this repo):** `hostedStore(config)` in `packages/store` — a
+  fetch-backed `StoreAdapter` (~one file plus tests), reusing the cloud.ts
+  error mapping. Umbrella composition: key present + entitlement →
+  `hostedStore`, else `createStore`. Conformance: the existing store adapter
+  conformance suite runs against it via an in-memory fake of the HTTP API.
+- **vendo-web (private):** the service — Postgres schema (org-scoped mirror of
+  `packages/store/src/schema.ts`), the routes above beside the existing
+  broker/key-validation code, metering, migrations. Ships behind the
+  `hosted-storage` entitlement flag.
+
+## Open questions
+
+1. **Postgres substrate.** The broker runs on Cloudflare Workers, which can't
+   embed Postgres. Recommendation: managed Postgres (Neon or similar) reached
+   via Hyperdrive from the existing broker — no new deploy target.
+2. **Blob transport.** Raw bytes through the API vs presigned object-storage
+   URLs. Recommendation: raw bytes now (blobs today are app docs and small
+   artifacts); revisit presigned R2 URLs only when size or egress cost says so.
+3. **Entitlement granularity.** Single `hosted-storage` boolean vs metered
+   tiers at launch. Recommendation: boolean + soft quotas; wire metering into
+   pricing tiers only after real usage exists.


### PR DESCRIPTION
One-page design decision doc for the Vendo-hosted store backend: a multi-tenant Postgres behind an HTTP API that an OSS `hostedStore` adapter (a plain `StoreAdapter`) speaks, keyed by `VENDO_API_KEY`, tenant = the key's org.

Covers: API shape at StoreAdapter granularity, what does NOT change (guard host-side, secrets never leave the host — `vendo_secrets` excluded by construction), tenancy/limits/residency, OSS-vs-vendo-web seam split, and 3 open questions with recommendations (Postgres substrate, blob transport, entitlement granularity).

Docs-only; 94 lines. Do not merge without Yousef's review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-page design doc for the hosted store backend. It specifies a multi-tenant Postgres behind an HTTP API used by an OSS `hostedStore` `StoreAdapter` keyed by `VENDO_API_KEY`, outlines the RPC endpoints, host-side guard with no secrets over the wire, tenancy/limits and US-only residency at launch, the OSS/`vendo-web` split, and folds in Yousef’s decisions: drop entitlement/validate, gate by key + `storage_gb` quotas, use raw-bytes blob uploads, managed Postgres via the existing broker, and make `ensureSchema()` a client no‑op.

<sup>Written for commit b1bd5a2c74920aba58bd1d01682db0882c854619. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

