### PR TITLE
install-dx v1 (PR2): AI extraction — ExtractionHarness seam, Claude Agent SDK harness, guarded draft application

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,6 +37,24 @@ Vendo Cloud is optional. When `VENDO_API_KEY` is set, init validates it and
 states the plan and what it unlocks; when it is absent, init prints one calm
 line and offers `vendo cloud login` only when a starter key would help.
 
+## AI polish (extraction judgment)
+
+Static extraction gets the facts; a coding agent adds the judgment. During an
+interactive `vendo init`, when `@anthropic-ai/claude-agent-sdk` is resolvable
+and a Claude Code login or `ANTHROPIC_API_KEY` exists, init asks once for
+consent and lets the agent read your codebase (read-only: Read/Glob/Grep;
+source goes to your model provider under your own account). It drafts
+task-oriented tool descriptions, reviews risk grades, wakes statically
+unclassifiable tools with reasoning, and writes the product brief.
+
+Everything it proposes passes deterministic guards before applying: only
+extracted tool names are accepted, risk can be raised but never lowered,
+waking a disabled tool requires reasoning plus an explicit grade, and human
+decisions always win (existing `.vendo/overrides.json` fields and a
+hand-written `brief.md` are never overwritten). The output lands in the
+override channel, so `vendo sync` regeneration keeps it. Skipped silently in
+non-interactive runs; re-run `vendo init` any time to add it.
+
 ## Create the server
 
 `createVendo` has this exact configuration surface:

--- a/fixtures/host-app/next-env.d.ts
+++ b/fixtures/host-app/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/redteam-e2e/dev/types/routes.d.ts";
+import "./.next/integration-e2e/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/vendo/src/cli/extract/claude-harness.test.ts
+++ b/packages/vendo/src/cli/extract/claude-harness.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { claudeHarness } from "./claude-harness.js";
+
+const SDK = (messages: Array<Record<string, unknown>>) => ({
+  query: () => (async function* () {
+    for (const message of messages) yield message;
+  })(),
+});
+
+describe("claudeHarness", () => {
+  it("is unavailable without the SDK, regardless of credentials", async () => {
+    const harness = claudeHarness({ loadSdk: async () => null, probeLogin: async () => true });
+    expect(await harness.availability({ root: "/x", env: { ANTHROPIC_API_KEY: "sk" } })).toBeNull();
+  });
+
+  it("prefers the env key label, then the Claude Code login", async () => {
+    const withSdk = { loadSdk: async () => SDK([]) };
+    expect(await claudeHarness({ ...withSdk, probeLogin: async () => false })
+      .availability({ root: "/x", env: { ANTHROPIC_API_KEY: "sk" } })).toBe("your ANTHROPIC_API_KEY");
+    expect(await claudeHarness({ ...withSdk, probeLogin: async () => true })
+      .availability({ root: "/x", env: {} })).toBe("your Claude Code login");
+    expect(await claudeHarness({ ...withSdk, probeLogin: async () => false })
+      .availability({ root: "/x", env: {} })).toBeNull();
+  });
+
+  it("returns the final result text and narrates tool use", async () => {
+    const harness = claudeHarness({
+      loadSdk: async () => SDK([
+        { type: "assistant", message: { content: [
+          { type: "tool_use", name: "Read", input: { file_path: "app/api/invoices/route.ts" } },
+          { type: "text", text: "thinking…" },
+        ] } },
+        { type: "result", result: '{"brief":"b","tools":[]}' },
+      ]),
+    });
+    const progress: string[] = [];
+    const text = await harness.run({
+      root: "/x",
+      env: {},
+      instructions: "go",
+      onProgress: (line) => progress.push(line),
+    });
+    expect(text).toBe('{"brief":"b","tools":[]}');
+    expect(progress).toEqual(["read app/api/invoices/route.ts"]);
+  });
+
+  it("falls back to concatenated assistant text when no result message arrives", async () => {
+    const harness = claudeHarness({
+      loadSdk: async () => SDK([
+        { type: "assistant", message: { content: [{ type: "text", text: '{"brief":"b",' }] } },
+        { type: "assistant", message: { content: [{ type: "text", text: '"tools":[]}' }] } },
+      ]),
+    });
+    expect(await harness.run({ root: "/x", env: {}, instructions: "go" })).toBe('{"brief":"b",\n"tools":[]}');
+  });
+});

--- a/packages/vendo/src/cli/extract/claude-harness.ts
+++ b/packages/vendo/src/cli/extract/claude-harness.ts
@@ -101,6 +101,9 @@ export function claudeHarness(options: ClaudeHarnessOptions = {}): ExtractionHar
           ],
           permissionMode: "default",
           maxTurns: 40,
+          // Forward the caller's env so a key present only in the passed map
+          // (not process.env) still authenticates the SDK subprocess.
+          env: { ...process.env, ...input.env },
           ...(model === undefined ? {} : { model }),
         },
       });

--- a/packages/vendo/src/cli/extract/claude-harness.ts
+++ b/packages/vendo/src/cli/extract/claude-harness.ts
@@ -1,0 +1,131 @@
+import { execFile } from "node:child_process";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import type { ExtractionHarness, ExtractionRunInput } from "./harness.js";
+
+/**
+ * V1 extraction harness: the Claude Agent SDK driven headless with READ-ONLY
+ * code tools (Read/Glob/Grep) over the host root. Credential = the dev's
+ * Claude Code login, or their ANTHROPIC_API_KEY. The SDK resolves from the
+ * CLI's own installation first, then the host app — it is never installed
+ * into the host app by init.
+ *
+ * Isolation: `settingSources: []` (never inherit the dev's personal Claude
+ * Code settings/hooks), read-only tool allowlist, no shell/web/write surface.
+ */
+
+const SDK_PACKAGE = "@anthropic-ai/claude-agent-sdk";
+const PROBE_TIMEOUT_MS = 5_000;
+
+interface SdkModule {
+  query(params: { prompt: string; options: Record<string, unknown> }): AsyncIterable<Record<string, unknown>>;
+}
+
+/** Bundler-proof dynamic import (same pattern as dev-riders/dev-creds): the
+ *  Function body is a FIXED literal — the specifier is a parameter, never
+ *  interpolated into code — so there is no injection surface. */
+async function dynamicImport(url: string): Promise<Record<string, unknown>> {
+  try {
+    return await import(url) as Record<string, unknown>;
+  } catch (nativeError) {
+    try {
+      const escaped = new Function("specifier", "return import(specifier)") as (
+        specifier: string,
+      ) => Promise<Record<string, unknown>>;
+      return await escaped(url);
+    } catch {
+      throw nativeError;
+    }
+  }
+}
+
+/** Resolve the SDK from the CLI package itself, then from the host app. */
+async function loadSdk(root: string): Promise<SdkModule | null> {
+  for (const base of [import.meta.url, pathToFileURL(join(root, "package.json")).href]) {
+    try {
+      const require = createRequire(base);
+      return await dynamicImport(pathToFileURL(require.resolve(SDK_PACKAGE)).href) as unknown as SdkModule;
+    } catch {
+      // try the next resolution base
+    }
+  }
+  return null;
+}
+
+/** `claude auth status` prints JSON with a `loggedIn` boolean. */
+function probeClaudeLogin(): Promise<boolean> {
+  return new Promise((resolve) => {
+    execFile("claude", ["auth", "status"], { timeout: PROBE_TIMEOUT_MS }, (error, stdout) => {
+      if (error !== null) return resolve(false);
+      try {
+        resolve((JSON.parse(stdout) as { loggedIn?: unknown }).loggedIn === true);
+      } catch {
+        resolve(false);
+      }
+    });
+  });
+}
+
+export interface ClaudeHarnessOptions {
+  /** Test seams. */
+  loadSdk?: (root: string) => Promise<SdkModule | null>;
+  probeLogin?: () => Promise<boolean>;
+}
+
+export function claudeHarness(options: ClaudeHarnessOptions = {}): ExtractionHarness {
+  const load = options.loadSdk ?? loadSdk;
+  const probe = options.probeLogin ?? probeClaudeLogin;
+  return {
+    id: "claude-agent-sdk",
+    async availability({ root, env }) {
+      if ((await load(root)) === null) return null;
+      const key = env["ANTHROPIC_API_KEY"];
+      if (typeof key === "string" && key.trim().length > 0) return "your ANTHROPIC_API_KEY";
+      if (await probe()) return "your Claude Code login";
+      return null;
+    },
+    async run(input: ExtractionRunInput): Promise<string> {
+      const sdk = await load(input.root);
+      if (sdk === null) throw new Error(`${SDK_PACKAGE} is not available`);
+      const model = input.env["VENDO_EXTRACTION_MODEL"];
+      const stream = sdk.query({
+        prompt: input.instructions,
+        options: {
+          cwd: input.root,
+          settingSources: [],
+          allowedTools: ["Read", "Glob", "Grep"],
+          disallowedTools: [
+            "Bash", "Write", "Edit", "WebFetch", "WebSearch", "Task",
+            "TodoWrite", "NotebookEdit", "KillShell", "BashOutput",
+          ],
+          permissionMode: "default",
+          maxTurns: 40,
+          ...(model === undefined ? {} : { model }),
+        },
+      });
+      let finalText = "";
+      const assistantText: string[] = [];
+      for await (const message of stream) {
+        const type = message["type"];
+        if (type === "assistant") {
+          const content = (message["message"] as { content?: Array<Record<string, unknown>> } | undefined)?.content;
+          for (const part of content ?? []) {
+            if (part["type"] === "text" && typeof part["text"] === "string") {
+              assistantText.push(part["text"]);
+            } else if (part["type"] === "tool_use") {
+              const name = part["name"];
+              const file = (part["input"] as { file_path?: unknown; pattern?: unknown } | undefined);
+              const target = typeof file?.file_path === "string" ? file.file_path
+                : typeof file?.pattern === "string" ? file.pattern : "";
+              if (typeof name === "string") input.onProgress?.(`${name.toLowerCase()} ${target}`.trim());
+            }
+          }
+        } else if (type === "result" && typeof message["result"] === "string") {
+          finalText = message["result"];
+        }
+      }
+      return finalText.length > 0 ? finalText : assistantText.join("\n");
+    },
+  };
+}

--- a/packages/vendo/src/cli/extract/extraction.test.ts
+++ b/packages/vendo/src/cli/extract/extraction.test.ts
@@ -1,0 +1,210 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { applyDraft, composeInstructions, runAiExtraction } from "./extraction.js";
+import { parseDraft, type ExtractionHarness } from "./harness.js";
+import type { Output } from "../shared.js";
+
+const cleanup: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+const TOOLS = [
+  { name: "host_invoices_list", description: "GET /api/invoices", risk: "read" as const, method: "GET", path: "/api/invoices" },
+  { name: "host_invoices_create", description: "POST /api/invoices", risk: "write" as const, method: "POST", path: "/api/invoices" },
+  { name: "host_admin_unclassified", description: "Route /api/admin could not be classified", risk: "destructive" as const, disabled: true },
+];
+
+async function fixture(overrides?: object, brief?: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-extract-"));
+  cleanup.push(root);
+  await mkdir(join(root, ".vendo"), { recursive: true });
+  await writeFile(join(root, ".vendo", "tools.json"), JSON.stringify({ format: "vendo/tools@1", tools: TOOLS }));
+  await writeFile(join(root, ".vendo", "overrides.json"), JSON.stringify(
+    overrides ?? { format: "vendo/overrides@1", tools: {}, remix: { ignoreSlots: [] } },
+  ));
+  await writeFile(join(root, ".vendo", "brief.md"),
+    `${brief ?? "Describe this product, its users, and the jobs the agent should help them complete."}\n`);
+  await writeFile(join(root, "package.json"), JSON.stringify({ name: "maple" }));
+  return root;
+}
+
+function output(): { output: Output; logs: string[]; errors: string[] } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return { output: { log: (message) => logs.push(message), error: (message) => errors.push(message) }, logs, errors };
+}
+
+async function readOverrides(root: string): Promise<{ tools: Record<string, Record<string, unknown>> }> {
+  return JSON.parse(await readFile(join(root, ".vendo", "overrides.json"), "utf8"));
+}
+
+describe("parseDraft", () => {
+  it("parses a fenced json block and bare json", () => {
+    const draft = { brief: "A bank.", tools: [{ name: "t", description: "d" }] };
+    expect(parseDraft("Here you go:\n```json\n" + JSON.stringify(draft) + "\n```")).toEqual(draft);
+    expect(parseDraft(JSON.stringify(draft))).toEqual(draft);
+  });
+
+  it("throws on unparseable or schema-invalid output", () => {
+    expect(() => parseDraft("no json here")).toThrow();
+    expect(() => parseDraft('{"brief":""}')).toThrow();
+  });
+});
+
+describe("composeInstructions", () => {
+  it("carries the static facts and the guard rules", () => {
+    const instructions = composeInstructions(TOOLS, "maple");
+    expect(instructions).toContain("host_invoices_list");
+    expect(instructions).toContain('"disabled": true');
+    expect(instructions).toContain("never lower");
+    expect(instructions).toContain("maple");
+  });
+});
+
+describe("applyDraft (deterministic verification)", () => {
+  it("applies descriptions, risk raises, critical marks, and wakes reasoned tools", async () => {
+    const root = await fixture();
+    const summary = await applyDraft({
+      root,
+      tools: TOOLS,
+      draft: {
+        brief: "Maple is a consumer bank; users check balances and pay bills.",
+        tools: [
+          { name: "host_invoices_list", description: "List invoices, filterable by status." },
+          { name: "host_invoices_create", description: "Create and send an invoice.", risk: "destructive", critical: true },
+          { name: "host_admin_unclassified", description: "Reset all demo data.", disabled: false, risk: "destructive", reasoning: "handler truncates tables" },
+        ],
+      },
+    });
+    expect(summary).toMatchObject({ described: 3, riskRaised: 1, critical: 1, woken: 1, briefWritten: true, refused: [] });
+    const overrides = await readOverrides(root);
+    expect(overrides.tools["host_invoices_list"]).toEqual({ description: "List invoices, filterable by status." });
+    expect(overrides.tools["host_invoices_create"]).toMatchObject({ risk: "destructive", critical: true });
+    expect(overrides.tools["host_admin_unclassified"]).toMatchObject({ disabled: false, risk: "destructive" });
+    expect(await readFile(join(root, ".vendo", "brief.md"), "utf8")).toContain("consumer bank");
+  });
+
+  it("refuses unknown tools, risk downgrades, and unreasoned wakes", async () => {
+    const root = await fixture();
+    const summary = await applyDraft({
+      root,
+      tools: TOOLS,
+      draft: {
+        brief: "b",
+        tools: [
+          { name: "invented_tool", description: "nope" },
+          { name: "host_invoices_create", description: "Create an invoice.", risk: "read" },
+          { name: "host_admin_unclassified", description: "Wake me.", disabled: false },
+        ],
+      },
+    });
+    expect(summary.refused).toHaveLength(3);
+    const overrides = await readOverrides(root);
+    expect(overrides.tools["invented_tool"]).toBeUndefined();
+    expect(overrides.tools["host_invoices_create"]?.risk).toBeUndefined();
+    expect(overrides.tools["host_admin_unclassified"]?.disabled).toBeUndefined();
+  });
+
+  it("never overwrites human decisions: existing override fields and a hand-written brief win", async () => {
+    const root = await fixture(
+      { format: "vendo/overrides@1", tools: { host_invoices_create: { description: "Human wrote this.", critical: false } } },
+      "The humans already described this product.",
+    );
+    const summary = await applyDraft({
+      root,
+      tools: TOOLS,
+      draft: {
+        brief: "AI brief.",
+        tools: [{ name: "host_invoices_create", description: "AI description.", critical: true }],
+      },
+    });
+    expect(summary.briefWritten).toBe(false);
+    const overrides = await readOverrides(root);
+    expect(overrides.tools["host_invoices_create"]).toMatchObject({ description: "Human wrote this.", critical: false });
+    expect(await readFile(join(root, ".vendo", "brief.md"), "utf8")).toContain("humans already");
+  });
+});
+
+function fakeHarness(text: string | Error, credential: string | null = "your Claude Code login"): ExtractionHarness {
+  return {
+    id: "fake",
+    availability: async () => credential,
+    run: async () => {
+      if (text instanceof Error) throw text;
+      return text;
+    },
+  };
+}
+
+describe("runAiExtraction", () => {
+  it("skips silently-with-one-line when non-interactive", async () => {
+    const root = await fixture();
+    const sink = output();
+    const result = await runAiExtraction({ root, output: sink.output, env: {}, yes: true, interactive: true });
+    expect(result.ran).toBe(false);
+    expect(sink.logs.join("\n")).toContain("skipped");
+  });
+
+  it("states when no credential exists and stands on extractor defaults", async () => {
+    const root = await fixture();
+    const sink = output();
+    const result = await runAiExtraction({
+      root, output: sink.output, env: {}, yes: false, interactive: true,
+      harnesses: [fakeHarness("x", null)],
+    });
+    expect(result.ran).toBe(false);
+    expect(sink.logs.join("\n")).toContain("AI polish: unavailable");
+  });
+
+  it("respects a declined consent", async () => {
+    const root = await fixture();
+    const sink = output();
+    const result = await runAiExtraction({
+      root, output: sink.output, env: {}, yes: false, interactive: true,
+      harnesses: [fakeHarness("x")],
+      confirm: async () => false,
+    });
+    expect(result.ran).toBe(false);
+    expect(sink.logs.join("\n")).toContain("Skipped");
+  });
+
+  it("runs the harness, applies the draft, and summarizes", async () => {
+    const root = await fixture();
+    const sink = output();
+    const draft = {
+      brief: "Maple is a consumer bank.",
+      tools: [{ name: "host_invoices_list", description: "List invoices with status filters." }],
+      missedSurfaces: ["/api/reports (GET) — monthly aging report"],
+    };
+    const result = await runAiExtraction({
+      root, output: sink.output, env: {}, yes: false, interactive: true,
+      harnesses: [fakeHarness("```json\n" + JSON.stringify(draft) + "\n```")],
+      confirm: async () => true,
+    });
+    expect(result.ran).toBe(true);
+    const logs = sink.logs.join("\n");
+    expect(logs).toContain("Reading your product (your Claude Code login)");
+    expect(logs).toContain("1 descriptions");
+    expect(logs).toContain("brief drafted");
+    expect(logs).toContain("missed surface");
+    expect((await readOverrides(root)).tools["host_invoices_list"]?.description).toBe("List invoices with status filters.");
+  });
+
+  it("a failing harness degrades honestly and writes nothing", async () => {
+    const root = await fixture();
+    const before = await readFile(join(root, ".vendo", "overrides.json"), "utf8");
+    const sink = output();
+    const result = await runAiExtraction({
+      root, output: sink.output, env: {}, yes: false, interactive: true,
+      harnesses: [fakeHarness(new Error("model unreachable"))],
+      confirm: async () => true,
+    });
+    expect(result.ran).toBe(false);
+    expect(sink.errors.join("\n")).toContain("model unreachable");
+    expect(await readFile(join(root, ".vendo", "overrides.json"), "utf8")).toBe(before);
+  });
+});

--- a/packages/vendo/src/cli/extract/extraction.test.ts
+++ b/packages/vendo/src/cli/extract/extraction.test.ts
@@ -53,6 +53,12 @@ describe("parseDraft", () => {
     expect(() => parseDraft("no json here")).toThrow();
     expect(() => parseDraft('{"brief":""}')).toThrow();
   });
+
+  it("survives stray braces in surrounding prose (Greptile P2)", () => {
+    const draft = { brief: "A bank.", tools: [{ name: "t", description: 'has "quotes" and {braces}' }] };
+    const noisy = `Checked {src/api} — handler is write-only.\n${JSON.stringify(draft)}\nNote: {unbalanced`;
+    expect(parseDraft(noisy)).toEqual(draft);
+  });
 });
 
 describe("composeInstructions", () => {
@@ -107,6 +113,60 @@ describe("applyDraft (deterministic verification)", () => {
     expect(overrides.tools["invented_tool"]).toBeUndefined();
     expect(overrides.tools["host_invoices_create"]?.risk).toBeUndefined();
     expect(overrides.tools["host_admin_unclassified"]?.disabled).toBeUndefined();
+  });
+
+  it("a reasoned wake carries the model's grade without a false downgrade refusal (Greptile P1)", async () => {
+    const root = await fixture();
+    const summary = await applyDraft({
+      root,
+      tools: TOOLS,
+      draft: {
+        brief: "b",
+        tools: [{
+          name: "host_admin_unclassified", description: "Lists admin settings.",
+          disabled: false, risk: "read", reasoning: "handler only reads config rows",
+        }],
+      },
+    });
+    // The static "destructive" was a fail-closed placeholder, not evidence:
+    // the wake applies the model's grade with NO contradictory refusal line.
+    expect(summary).toMatchObject({ woken: 1, refused: [] });
+    const overrides = await readOverrides(root);
+    expect(overrides.tools["host_admin_unclassified"]).toMatchObject({ disabled: false, risk: "read" });
+  });
+
+  it("a wake never replaces a human-set risk or reverses a human disable decision", async () => {
+    const root = await fixture({
+      format: "vendo/overrides@1",
+      tools: {
+        host_admin_unclassified: { risk: "destructive" },
+      },
+    });
+    const woken = await applyDraft({
+      root,
+      tools: TOOLS,
+      draft: {
+        brief: "b",
+        tools: [{ name: "host_admin_unclassified", description: "d", disabled: false, risk: "read", reasoning: "r" }],
+      },
+    });
+    expect(woken.woken).toBe(1);
+    expect((await readOverrides(root)).tools["host_admin_unclassified"]).toMatchObject({ disabled: false, risk: "destructive" });
+
+    const humanDisabled = await fixture({
+      format: "vendo/overrides@1",
+      tools: { host_admin_unclassified: { disabled: true } },
+    });
+    const kept = await applyDraft({
+      root: humanDisabled,
+      tools: TOOLS,
+      draft: {
+        brief: "b",
+        tools: [{ name: "host_admin_unclassified", description: "d", disabled: false, risk: "read", reasoning: "r" }],
+      },
+    });
+    expect(kept.woken).toBe(0);
+    expect((await readOverrides(humanDisabled)).tools["host_admin_unclassified"]?.disabled).toBe(true);
   });
 
   it("never overwrites human decisions: existing override fields and a hand-written brief win", async () => {

--- a/packages/vendo/src/cli/extract/extraction.ts
+++ b/packages/vendo/src/cli/extract/extraction.ts
@@ -121,7 +121,23 @@ export async function applyDraft(input: {
       next.description = entry.description;
       summary.described += 1;
     }
-    if (entry.risk !== undefined && existing.risk === undefined) {
+    // Waking a statically-unclassifiable tool is its own path: the static
+    // "destructive, disabled" grade is a fail-closed PLACEHOLDER, not
+    // evidence, so a reasoned wake carries the model's grade without tripping
+    // the downgrade guard (Greptile P1 / Devin on #363). A human-set risk or
+    // disabled decision always wins.
+    const isWake = entry.disabled === false && fact.disabled === true;
+    if (isWake && existing.disabled === undefined) {
+      if (entry.reasoning === undefined || entry.risk === undefined) {
+        summary.refused.push(`${entry.name}: waking a disabled tool needs reasoning and a risk grade`);
+      } else {
+        next.disabled = false;
+        if (existing.risk === undefined) next.risk = entry.risk;
+        summary.woken += 1;
+      }
+    } else if (
+      entry.risk !== undefined && existing.risk === undefined && fact.disabled !== true
+    ) {
       const current = fact.risk ?? "destructive";
       if (RISK_ORDER[entry.risk] > RISK_ORDER[current]) {
         next.risk = entry.risk;
@@ -133,15 +149,6 @@ export async function applyDraft(input: {
     if (entry.critical === true && existing.critical === undefined) {
       next.critical = true;
       summary.critical += 1;
-    }
-    if (entry.disabled === false && fact.disabled === true && existing.disabled === undefined) {
-      if (entry.reasoning === undefined || entry.risk === undefined) {
-        summary.refused.push(`${entry.name}: waking a disabled tool needs reasoning and a risk grade`);
-      } else {
-        next.disabled = false;
-        next.risk = entry.risk;
-        summary.woken += 1;
-      }
     }
     if (JSON.stringify(next) !== JSON.stringify(existing)) overrides.tools[entry.name] = next;
   }

--- a/packages/vendo/src/cli/extract/extraction.ts
+++ b/packages/vendo/src/cli/extract/extraction.ts
@@ -1,0 +1,258 @@
+import { join } from "node:path";
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+import { z } from "zod";
+import { claudeHarness } from "./claude-harness.js";
+import { parseDraft, type DraftTool, type ExtractionHarness } from "./harness.js";
+import { readOptional, writeText, type Output } from "../shared.js";
+
+/**
+ * The AI extraction pass (install-dx v1: draft + deterministic verification).
+ * The agent reads the codebase and drafts judgment on top of the static
+ * facts: task-oriented tool descriptions, risk corrections, critical marks,
+ * waking unclassifiable tools, and the product brief.
+ *
+ * Output rides the channels that SURVIVE `vendo sync` regeneration:
+ * `.vendo/overrides.json` (per-tool description/risk/critical/disabled — the
+ * designed merge layer) and `.vendo/brief.md`. It never writes tools.json
+ * directly, so predev/prebuild re-extraction cannot clobber it.
+ *
+ * Deterministic guards (never cross fingers, PostHog lesson):
+ * - only tool names the static extraction produced are accepted;
+ * - risk may be RAISED, never lowered (fail-closed stays fail-closed);
+ * - waking a disabled tool requires reasoning and an explicit risk;
+ * - human decisions win: existing override fields are never overwritten, and
+ *   a hand-written brief is never replaced (only the init template is).
+ */
+
+const BRIEF_TEMPLATE =
+  "Describe this product, its users, and the jobs the agent should help them complete.";
+
+const RISK_ORDER = { read: 0, write: 1, destructive: 2 } as const;
+
+const staticToolSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  risk: z.enum(["read", "write", "destructive"]).optional(),
+  disabled: z.boolean().optional(),
+  method: z.string().optional(),
+  path: z.string().optional(),
+});
+type StaticTool = z.infer<typeof staticToolSchema>;
+
+const overridesSchema = z.object({
+  format: z.literal("vendo/overrides@1"),
+  tools: z.record(z.object({
+    risk: z.enum(["read", "write", "destructive"]).optional(),
+    critical: z.boolean().optional(),
+    disabled: z.boolean().optional(),
+    description: z.string().optional(),
+  }).passthrough()),
+}).passthrough();
+type Overrides = z.infer<typeof overridesSchema>;
+
+export function composeInstructions(tools: StaticTool[], appName: string): string {
+  return [
+    "You are Vendo's extraction agent. Read this codebase (Read/Glob/Grep only) and return",
+    "judgment on the API tools a static extractor already found, plus a product brief.",
+    "",
+    `Product/package name: ${appName}`,
+    "Statically extracted tools (name, method+path when known, current risk, disabled state):",
+    JSON.stringify(tools.map((tool) => ({
+      name: tool.name,
+      ...(tool.method === undefined ? {} : { method: tool.method }),
+      ...(tool.path === undefined ? {} : { path: tool.path }),
+      risk: tool.risk,
+      ...(tool.disabled === true ? { disabled: true } : {}),
+      description: tool.description,
+    })), null, 2),
+    "",
+    "Rules:",
+    "- Reply with ONLY one fenced json block matching:",
+    '  { "brief": string, "tools": [{ "name", "description", "risk"?, "critical"?, "disabled"?, "reasoning"? }], "missedSurfaces"?: string[] }',
+    "- brief: one paragraph — what the product does, who uses it, the jobs the agent should help with. Written from the actual code, no marketing fluff.",
+    "- tools: include ONLY names from the list above. Rewrite each description so an agent choosing tools understands what it actually does (read the handler source). <= 200 chars each.",
+    "- risk: you may RAISE risk (read->write->destructive) when the handler is more dangerous than labeled; never lower it. Mark irreversible operations critical: true.",
+    "- A tool listed as disabled was statically unclassifiable. If you can read its handler and grade it, set disabled: false WITH a risk and one-line reasoning. Leave it out otherwise.",
+    "- missedSurfaces: API surfaces you found that the list is missing (path + one line). Do not invent tools for them.",
+  ].join("\n");
+}
+
+interface AppliedSummary {
+  described: number;
+  riskRaised: number;
+  critical: number;
+  woken: number;
+  briefWritten: boolean;
+  refused: string[];
+  missedSurfaces: string[];
+}
+
+/** Deterministic verification + application of a parsed draft. Exported for
+ *  tests; init uses runAiExtraction below. */
+export async function applyDraft(input: {
+  root: string;
+  draft: ReturnType<typeof parseDraft>;
+  tools: StaticTool[];
+  force?: boolean;
+}): Promise<AppliedSummary> {
+  const byName = new Map(input.tools.map((tool) => [tool.name, tool]));
+  const overridesPath = join(input.root, ".vendo", "overrides.json");
+  const raw = await readOptional(overridesPath);
+  const overrides: Overrides = raw === null
+    ? { format: "vendo/overrides@1", tools: {} }
+    : overridesSchema.parse(JSON.parse(raw));
+
+  const summary: AppliedSummary = {
+    described: 0, riskRaised: 0, critical: 0, woken: 0,
+    briefWritten: false, refused: [], missedSurfaces: input.draft.missedSurfaces ?? [],
+  };
+
+  for (const entry of input.draft.tools) {
+    const fact = byName.get(entry.name);
+    if (fact === undefined) {
+      summary.refused.push(`${entry.name}: not an extracted tool`);
+      continue;
+    }
+    const existing = overrides.tools[entry.name] ?? {};
+    const next = { ...existing };
+
+    if (existing.description === undefined && entry.description !== fact.description) {
+      next.description = entry.description;
+      summary.described += 1;
+    }
+    if (entry.risk !== undefined && existing.risk === undefined) {
+      const current = fact.risk ?? "destructive";
+      if (RISK_ORDER[entry.risk] > RISK_ORDER[current]) {
+        next.risk = entry.risk;
+        summary.riskRaised += 1;
+      } else if (RISK_ORDER[entry.risk] < RISK_ORDER[current]) {
+        summary.refused.push(`${entry.name}: risk downgrade ${current}→${entry.risk} refused`);
+      }
+    }
+    if (entry.critical === true && existing.critical === undefined) {
+      next.critical = true;
+      summary.critical += 1;
+    }
+    if (entry.disabled === false && fact.disabled === true && existing.disabled === undefined) {
+      if (entry.reasoning === undefined || entry.risk === undefined) {
+        summary.refused.push(`${entry.name}: waking a disabled tool needs reasoning and a risk grade`);
+      } else {
+        next.disabled = false;
+        next.risk = entry.risk;
+        summary.woken += 1;
+      }
+    }
+    if (JSON.stringify(next) !== JSON.stringify(existing)) overrides.tools[entry.name] = next;
+  }
+
+  await writeText(overridesPath, `${JSON.stringify(overrides, null, 2)}\n`);
+
+  const briefPath = join(input.root, ".vendo", "brief.md");
+  const currentBrief = ((await readOptional(briefPath)) ?? "").trim();
+  if (input.force === true || currentBrief === "" || currentBrief === BRIEF_TEMPLATE) {
+    await writeText(briefPath, `${input.draft.brief.trim()}\n`);
+    summary.briefWritten = true;
+  }
+  return summary;
+}
+
+async function askYesNo(question: string, defaultYes: boolean): Promise<boolean> {
+  const prompt = createInterface({ input: stdin, output: stdout });
+  try {
+    const answer = (await prompt.question(`${question} ${defaultYes ? "[Y/n]" : "[y/N]"} `)).trim().toLowerCase();
+    if (answer === "") return defaultYes;
+    return ["y", "yes"].includes(answer);
+  } finally {
+    prompt.close();
+  }
+}
+
+export interface AiExtractionOptions {
+  root: string;
+  output: Output;
+  env: Record<string, string | undefined>;
+  /** Non-interactive (--yes / no TTY): no consent possible — skip silently. */
+  yes: boolean;
+  force?: boolean;
+  /** Seams (tests / future harnesses). */
+  harnesses?: ExtractionHarness[];
+  confirm?: (question: string, defaultYes: boolean) => Promise<boolean>;
+  interactive?: boolean;
+}
+
+/** init's AI extraction step. Never changes init's exit code. */
+export async function runAiExtraction(options: AiExtractionOptions): Promise<{ ran: boolean }> {
+  const { root, output, env } = options;
+  const toolsRaw = await readOptional(join(root, ".vendo", "tools.json"));
+  if (toolsRaw === null) return { ran: false };
+  let tools: StaticTool[];
+  try {
+    tools = z.object({ tools: z.array(staticToolSchema) }).parse(JSON.parse(toolsRaw)).tools;
+  } catch {
+    return { ran: false };
+  }
+
+  const interactive = options.interactive ?? (Boolean(stdin.isTTY) && Boolean(stdout.isTTY));
+  if (options.yes || !interactive) {
+    output.log("AI polish (descriptions, risk review, brief): skipped — needs an interactive run (`vendo init` in a terminal).");
+    return { ran: false };
+  }
+
+  const harnesses = options.harnesses ?? [claudeHarness()];
+  let chosen: { harness: ExtractionHarness; credential: string } | null = null;
+  for (const harness of harnesses) {
+    const credential = await harness.availability({ root, env });
+    if (credential !== null) {
+      chosen = { harness, credential };
+      break;
+    }
+  }
+  if (chosen === null) {
+    output.log("AI polish: unavailable — needs @anthropic-ai/claude-agent-sdk resolvable (`npm install -D @anthropic-ai/claude-agent-sdk`) plus a Claude Code login or ANTHROPIC_API_KEY. Extractor defaults stand; re-run `vendo init` once set up.");
+    return { ran: false };
+  }
+
+  const confirm = options.confirm ?? askYesNo;
+  const consented = await confirm(
+    `Let ${chosen.credential} read this codebase to draft tool descriptions, review risk, and write the product brief? Source goes to your model provider under your account.`,
+    true,
+  );
+  if (!consented) {
+    output.log("Skipped — extractor defaults stand; re-run `vendo init` any time to add the AI polish.");
+    return { ran: false };
+  }
+
+  let appName = "app";
+  try {
+    appName = (JSON.parse((await readOptional(join(root, "package.json"))) ?? "{}") as { name?: string }).name ?? "app";
+  } catch {
+    // package.json is optional context
+  }
+
+  output.log(`\nReading your product (${chosen.credential})…`);
+  try {
+    const text = await chosen.harness.run({
+      root,
+      env,
+      instructions: composeInstructions(tools, appName),
+      onProgress: (line) => output.log(`  ${line}`),
+    });
+    const draft = parseDraft(text);
+    const applied = await applyDraft({ root, draft, tools, ...(options.force === undefined ? {} : { force: options.force }) });
+    const parts = [
+      `${applied.described} descriptions`,
+      ...(applied.riskRaised > 0 ? [`${applied.riskRaised} risk raises`] : []),
+      ...(applied.critical > 0 ? [`${applied.critical} critical marks`] : []),
+      ...(applied.woken > 0 ? [`${applied.woken} tools woken`] : []),
+      ...(applied.briefWritten ? ["brief drafted"] : []),
+    ];
+    output.log(`AI polish applied: ${parts.join(" · ")} → .vendo/overrides.json, .vendo/brief.md`);
+    for (const refused of applied.refused) output.error(`  refused: ${refused}`);
+    for (const missed of applied.missedSurfaces) output.log(`  missed surface (not extracted yet): ${missed}`);
+    return { ran: true };
+  } catch (error) {
+    output.error(`AI polish did not complete (${error instanceof Error ? error.message : "unknown error"}); extractor defaults stand. Re-run \`vendo init\` to retry.`);
+    return { ran: false };
+  }
+}

--- a/packages/vendo/src/cli/extract/harness.ts
+++ b/packages/vendo/src/cli/extract/harness.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+
+/**
+ * The ExtractionHarness seam (install-dx v1, brainstorm 2026-07-18): Vendo
+ * owns the instructions, the deterministic validation, and the artifact
+ * contract; a world-class coding agent does the reading. Everything above
+ * this seam is vendor-neutral — swapping the harness (Claude Agent SDK today,
+ * anything tomorrow) is a config change, not an architecture change.
+ */
+
+/** One drafted polish entry for an extracted tool. The AI pass proposes;
+ *  deterministic guards in extraction.ts decide what applies. */
+export const draftToolSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1).max(500),
+  risk: z.enum(["read", "write", "destructive"]).optional(),
+  critical: z.boolean().optional(),
+  /** false = wake a statically-unclassifiable tool (needs reasoning). */
+  disabled: z.boolean().optional(),
+  reasoning: z.string().max(500).optional(),
+});
+export type DraftTool = z.infer<typeof draftToolSchema>;
+
+export const extractionDraftSchema = z.object({
+  /** One-paragraph product brief drafted from the codebase. */
+  brief: z.string().min(1).max(4000),
+  tools: z.array(draftToolSchema),
+  /** API surfaces the static extractor missed — surfaced to the dev, not
+   *  written anywhere (adding tools is future work on the sync side). */
+  missedSurfaces: z.array(z.string().max(300)).optional(),
+});
+export type ExtractionDraft = z.infer<typeof extractionDraftSchema>;
+
+export interface ExtractionRunInput {
+  root: string;
+  /** The complete staged instructions, composed by extraction.ts. */
+  instructions: string;
+  env: Record<string, string | undefined>;
+  /** Live narration line (surface discoveries, files being read). */
+  onProgress?: (line: string) => void;
+}
+
+export interface ExtractionHarness {
+  /** Stable identifier ("claude-agent-sdk"). */
+  id: string;
+  /** A short human label of the credential this harness would use
+   *  ("your Claude Code login", "your ANTHROPIC_API_KEY"), or null when the
+   *  harness cannot run on this machine. */
+  availability(input: { root: string; env: Record<string, string | undefined> }): Promise<string | null>;
+  /** Run the instructions and return the agent's final text (extraction.ts
+   *  parses and validates; the harness never interprets the draft). */
+  run(input: ExtractionRunInput): Promise<string>;
+}
+
+/** Extract the draft JSON from an agent's final text: prefer a fenced block,
+ *  fall back to the widest braces span. Throws on unparseable output. */
+export function parseDraft(text: string): ExtractionDraft {
+  const fenced = text.match(/```(?:json)?\s*\n([\s\S]*?)\n```/);
+  const candidate = fenced?.[1] ?? text.slice(text.indexOf("{"), text.lastIndexOf("}") + 1);
+  return extractionDraftSchema.parse(JSON.parse(candidate));
+}

--- a/packages/vendo/src/cli/extract/harness.ts
+++ b/packages/vendo/src/cli/extract/harness.ts
@@ -52,10 +52,51 @@ export interface ExtractionHarness {
   run(input: ExtractionRunInput): Promise<string>;
 }
 
+/** Walk balanced `{…}` spans (string-aware) starting at each `{`, returning
+ *  each complete candidate — so prose containing stray braces around the real
+ *  JSON object cannot poison the parse (Greptile P2 on #363). */
+function* balancedObjectSpans(text: string): Generator<string> {
+  for (let start = text.indexOf("{"); start !== -1; start = text.indexOf("{", start + 1)) {
+    let depth = 0;
+    let inString = false;
+    for (let index = start; index < text.length; index += 1) {
+      const char = text[index];
+      if (inString) {
+        if (char === "\\") index += 1;
+        else if (char === '"') inString = false;
+        continue;
+      }
+      if (char === '"') inString = true;
+      else if (char === "{") depth += 1;
+      else if (char === "}") {
+        depth -= 1;
+        if (depth === 0) {
+          yield text.slice(start, index + 1);
+          break;
+        }
+      }
+    }
+  }
+}
+
 /** Extract the draft JSON from an agent's final text: prefer a fenced block,
- *  fall back to the widest braces span. Throws on unparseable output. */
+ *  else try each balanced object span until one validates. Throws on
+ *  unparseable output. */
 export function parseDraft(text: string): ExtractionDraft {
   const fenced = text.match(/```(?:json)?\s*\n([\s\S]*?)\n```/);
-  const candidate = fenced?.[1] ?? text.slice(text.indexOf("{"), text.lastIndexOf("}") + 1);
-  return extractionDraftSchema.parse(JSON.parse(candidate));
+  if (fenced?.[1] !== undefined) {
+    return extractionDraftSchema.parse(JSON.parse(fenced[1]));
+  }
+  let firstError: unknown = new Error("no JSON object found in the agent's output");
+  let attempts = 0;
+  for (const span of balancedObjectSpans(text)) {
+    if (attempts >= 20) break;
+    attempts += 1;
+    try {
+      return extractionDraftSchema.parse(JSON.parse(span));
+    } catch (error) {
+      if (attempts === 1) firstError = error;
+    }
+  }
+  throw firstError;
 }

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -16,6 +16,7 @@ import type { VendoTheme } from "@vendoai/core";
 import type { Telemetry } from "@vendoai/telemetry";
 import type { LanguageModel } from "ai";
 import { runCloudStep, type CloudStepOptions } from "./cloud-init.js";
+import { runAiExtraction, type AiExtractionOptions } from "./extract/extraction.js";
 import { resolveDevCredential, describeDevCredential, type DevCredential } from "../dev-creds/resolve.js";
 import { detectFramework, detectVendoWiring, type HostFramework } from "./framework.js";
 import { resolveRefineModel } from "./refine.js";
@@ -119,6 +120,8 @@ export interface InitOptions {
   resolveCredential?: (options: { env: Record<string, string | undefined> }) => Promise<DevCredential>;
   /** Test seam (ENG-339): cloud-in-init step overrides. */
   cloud?: Partial<Omit<CloudStepOptions, "root" | "output" | "yes" | "credential">>;
+  /** Test seam: AI extraction step overrides (harnesses, consent). */
+  extract?: Partial<Omit<AiExtractionOptions, "root" | "output" | "yes" | "env">>;
   /** Test seam: the theme LLM pass's model; default rides the refine seam. */
   themeModel?: () => Promise<LanguageModel>;
   /** Uncertain-slot review — asked ONLY when the model reports uncertainty. */
@@ -810,6 +813,24 @@ export async function runInit(options: InitOptions): Promise<number> {
     });
     if (credential.rung === "none") {
       output.log("No model key yet: set ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_GENERATIVE_AI_API_KEY in .env.local, or run `vendo cloud login` for a free dev key.");
+    }
+
+    // AI extraction (install-dx v1): a coding agent reads the codebase and
+    // drafts descriptions/risk/brief into the override channel; deterministic
+    // guards decide what applies. Consent-gated; skipped silently when
+    // non-interactive or credential-less. A successful pass re-syncs so
+    // tools.json reflects the polish immediately.
+    const polish = await runAiExtraction({
+      root,
+      output,
+      env,
+      yes: options.yes === true,
+      ...(options.force === true ? { force: true } : {}),
+      ...(options.extract ?? {}),
+    });
+    if (polish.ran) {
+      const resynced = await vendoSync({ root, out: join(root, ".vendo") });
+      for (const warning of resynced.warnings) output.error(`warning: ${warning}`);
     }
 
     await telemetry.track("init_completed", {


### PR DESCRIPTION
## Summary

Second PR of the install-dx v1 rewrite (spec: `docs/brainstorms/init-cli-dx.md`; PR1 was #362). The AI extraction layer: a coding agent reads the host codebase and adds judgment on top of static extraction's facts.

**Architecture — Vendo owns the contract, the agent does the reading:**
- `cli/extract/harness.ts`: the vendor-neutral `ExtractionHarness` seam + zod draft contract. Nothing above the seam assumes a vendor; swapping harnesses is a config change.
- `cli/extract/claude-harness.ts`: v1 harness — Claude Agent SDK driven headless with **read-only** tools (Read/Glob/Grep), `settingSources: []`, no shell/web/write surface. Credential = the dev's `ANTHROPIC_API_KEY` or Claude Code login. The SDK resolves from the CLI install or the host app; init never installs it into the host.
- `cli/extract/extraction.ts`: the consent-gated init step. Composes instructions with static extraction as hints, then applies the draft through **deterministic guards**: only extracted tool names accepted; risk can be raised, never lowered; waking a statically-unclassifiable tool requires reasoning + an explicit grade; human decisions always win (existing override fields and a hand-written brief are never overwritten).
- Output rides the channels that **survive `vendo sync` regeneration**: `.vendo/overrides.json` (descriptions, risk, critical, disabled) and `.vendo/brief.md`. tools.json is never written directly; init re-syncs after a successful pass.
- Skipped silently when non-interactive, `--yes`, credential-less, or on declined consent — init's exit code never changes.

**Tests**: 15 new unit tests over a fake harness (guards, non-clobber, consent paths, honest failure) + SDK message-stream parsing tests. Full workspace gates green.

Deferred per spec (seam keeps the door open): external-agent delegation (Cursor/skill/--agent unification), staged multi-pass pipeline, live probe verification (doctor owns live), corpus eval matrix.

Claude-Session: https://claude.ai/code/session_01PsnxHL6RCSL2ne7gpm68x6
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds v1 AI extraction to `vendo init` with a vendor-neutral `ExtractionHarness` and a `@anthropic-ai/claude-agent-sdk` harness that reads your codebase (read-only) to draft tool descriptions, risk corrections, and a product brief. Drafts are guard-checked and applied to `.vendo/overrides.json` and `.vendo/brief.md`, then `vendo sync` runs.

- **New Features**
  - `ExtractionHarness` seam with a zod-validated draft contract and robust `parseDraft` (string-aware balanced-brace scan).
  - Claude harness: resolves `@anthropic-ai/claude-agent-sdk` from CLI or host; uses `Read/Glob/Grep` only, `settingSources: []`, no shell/web/write; works with `ANTHROPIC_API_KEY` or a Claude Code login; forwards env to the SDK; optional `VENDO_EXTRACTION_MODEL`.
  - Consent-gated; skipped in non-interactive runs or when unavailable; init’s exit code never changes.
  - Guard rules: only extracted tool names; risk can be raised (never lowered); waking disabled tools needs reasoning plus explicit risk; human decisions win (existing overrides and a hand-written brief are never overwritten).

- **Bug Fixes**
  - Reasoned wakes now carry the model’s risk grade without false downgrade refusals; human-set risk/disable choices are preserved.
  - `parseDraft` resists stray braces in surrounding prose; env passed to init is forwarded to the SDK subprocess for auth.

<sup>Written for commit a088f9a447049e4a0644e4b23190dc20def5baf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

