### PR TITLE
ci: auto-merge Mintlify docs-site PRs once checks pass

### DIFF
--- a/.github/workflows/mintlify-automerge.yml
+++ b/.github/workflows/mintlify-automerge.yml
@@ -1,0 +1,80 @@
+# Auto-merge Mintlify docs PRs (Yousef, 2026-07-18).
+#
+# Mintlify's docs agent opens PRs as mintlify[bot] on in-repo mintlify/*
+# branches, touching only docs-site/**. Those merge themselves once every
+# other check on the head SHA has finished green. Two guards keep this
+# narrow: the author must be mintlify[bot], and the diff must stay entirely
+# inside docs-site/ — a bot PR touching anything else is left for humans.
+#
+# The wait loop polls check-runs + commit statuses itself (instead of GitHub
+# native auto-merge, which would merge instantly because main has no required
+# checks; instead of `gh pr checks --watch`, which would deadlock waiting on
+# this very job). Success/neutral/skipped pass; any failure aborts without
+# merging.
+name: mintlify-automerge
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: mintlify-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  automerge:
+    name: automerge
+    if: github.event.pull_request.user.login == 'mintlify[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      PR: ${{ github.event.pull_request.number }}
+      SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Guard: diff is docs-site/** only
+        run: |
+          outside=$(gh api "repos/$REPO/pulls/$PR/files" --paginate \
+            --jq '.[].filename | select(startswith("docs-site/") | not)')
+          if [ -n "$outside" ]; then
+            echo "Not docs-site-only; leaving for humans:"
+            echo "$outside"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+        id: guard
+
+      - name: Wait for every other check on the head SHA
+        if: steps.guard.outputs.skip != 'true'
+        run: |
+          # Give slow-dispatching suites time to register before we trust
+          # "nothing pending" (this repo's check suites sometimes lag).
+          sleep 120
+          for i in $(seq 1 80); do
+            runs=$(gh api "repos/$REPO/commits/$SHA/check-runs" --paginate \
+              --jq '[.check_runs[] | select(.name != "automerge")]')
+            statuses=$(gh api "repos/$REPO/commits/$SHA/status" --jq '.statuses')
+            pending=$(jq -n --argjson r "$runs" --argjson s "$statuses" \
+              '([$r[] | select(.status != "completed")] + [$s[] | select(.state == "pending")]) | length')
+            failed=$(jq -n --argjson r "$runs" --argjson s "$statuses" \
+              '([$r[] | select(.conclusion and (.conclusion | IN("success","neutral","skipped") | not))] + [$s[] | select(.state | IN("failure","error"))]) | length')
+            total=$(jq -n --argjson r "$runs" --argjson s "$statuses" '($r + $s) | length')
+            echo "checks: total=$total pending=$pending failed=$failed"
+            if [ "$failed" -gt 0 ]; then
+              echo "A check failed — not merging."; exit 1
+            fi
+            if [ "$total" -gt 0 ] && [ "$pending" -eq 0 ]; then
+              echo "All green."; exit 0
+            fi
+            sleep 60
+          done
+          echo "Timed out waiting for checks."; exit 1
+
+      - name: Merge
+        if: steps.guard.outputs.skip != 'true'
+        run: gh pr merge "$PR" --squash --delete-branch


### PR DESCRIPTION
Requested by Yousef: Mintlify's docs-agent PRs (mintlify[bot], in-repo mintlify/* branches, docs-site/**-only — verified against #346/#341/#335/#333…) should merge themselves.

## How
- Triggers on mintlify[bot] PRs only.
- **Guard**: full file list must be inside `docs-site/`; anything else logs and skips (left for humans).
- **Wait**: polls check-runs + commit statuses on the head SHA, excluding its own job (native auto-merge would merge instantly — main has no required checks; `gh pr checks --watch` would deadlock on itself). success/neutral/skipped pass; any failure aborts with no merge. 2-min pre-sleep covers this repo's slow-dispatching check suites; 90-min timeout.
- **Merge**: squash + delete the mintlify branch. New pushes cancel the in-flight waiter (per-PR concurrency group).

## Security
No PR code is checked out; the only event inputs used are number/SHA/login (GitHub-controlled formats), passed via env.

https://claude.ai/code/session_01HtzSh9rhAnVU1zJpAMijQ7
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-merges `mintlify[bot]` PRs that only change `docs-site/` once all checks pass. Speeds up docs updates while keeping CI safety checks in place.

- **New Features**
  - Trigger: runs on PRs from `mintlify[bot]`.
  - Guard: only merges if all changed files are under `docs-site/`.
  - Wait: polls check runs and statuses on the head SHA; skips its own job; 2‑min pre‑sleep; 90‑min timeout; aborts on any failure.
  - Merge: squash-merge and delete the branch; per‑PR concurrency cancels on new pushes.

<sup>Written for commit 03e7fcb85726668bbf304fead32a21c9c0050192. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

