### PR TITLE
chore(cloud): key mint uses the generic /api/v1/keys path

### DIFF
--- a/docs/evidence/eng-339-doctor-v2/README.md
+++ b/docs/evidence/eng-339-doctor-v2/README.md
@@ -35,7 +35,7 @@ minted key; the resolver already has the `vendo-cloud` rung). The console
 endpoint is a Cloud console (vendo-web) follow-up:
 
 ```
-POST /api/v1/dev/starter-key
+POST /api/v1/keys
   auth:    user session (Bearer access token from `vendo cloud login`)
   request: { "purpose": "dev-mode" }
   response:

--- a/packages/vendo/src/cli/cloud-init.ts
+++ b/packages/vendo/src/cli/cloud-init.ts
@@ -43,7 +43,7 @@ async function askText(question: string): Promise<string> {
 
 /**
  * Console hand-off contract (parked follow-up in vendo-web):
- *   POST /api/v1/dev/starter-key      auth: user session (Bearer access token)
+ *   POST /api/v1/keys                 auth: user session (Bearer access token)
  *   request  { purpose: "dev-mode" }
  *   response { key: "vnd_<40 hex>", meter: { runs: { included, remaining } } }
  * The key is a metered dev-mode API key scoped to the caller's default org.
@@ -54,7 +54,10 @@ export async function mintStarterAllowance(
   options: Pick<CloudFetchOptions, "apiUrl" | "env" | "fetchImpl" | "home"> = {},
 ): Promise<string | null> {
   try {
-    const result = await cloudFetch("/api/v1/dev/starter-key", {
+    // One key-mint path for everyone (Yousef 2026-07-18): the generic keys
+    // resource beside /api/v1/keys/validate; the dev-mode meter comes from the
+    // purpose in the body, not a special path.
+    const result = await cloudFetch("/api/v1/keys", {
       ...options,
       auth: "user",
       method: "POST",


### PR DESCRIPTION
Per Yousef: one key-mint path for everyone. The dev starter-allowance mint moves from `POST /api/v1/dev/starter-key` to `POST /api/v1/keys` (purpose in the body), beside the existing `/api/v1/keys/validate`. Renamed now while the contract is still private — the vendo-web endpoint hasn't shipped, so the only touchpoints are `mintStarterAllowance` in cloud-init.ts, its hand-off comment, and the ENG-339 evidence doc.

Claude-Session: https://claude.ai/code/session_01PsnxHL6RCSL2ne7gpm68x6
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies key minting under POST /api/v1/keys by sending { "purpose": "dev-mode" } in the request body instead of calling /api/v1/dev/starter-key. Updates `mintStarterAllowance` in `packages/vendo/src/cli/cloud-init.ts` and the ENG-339 doc; /api/v1/keys/validate is unchanged.

<sup>Written for commit 25b9df4ca47e12fdb715874af2e517f36aee71aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

