### PR TITLE
extract: staged AI pipeline — survey, draft-per-surface, cross-check, brief

### DIFF
--- a/docs/brainstorms/init-cli-dx.md
+++ b/docs/brainstorms/init-cli-dx.md
@@ -177,10 +177,13 @@ to keep improving the AI quality after. Do not overbuild v1.
   the v2 <10s bar applies to runtime generation, not this.
 - **Privacy:** on session/BYO paths, source goes to the dev's own provider
   account. One honest line up front plus a secrets filter (PostHog posture).
-- **Pipeline:** v1 = draft + verify, kept inspectable. The staged shape
-  (survey, draft per surface, cross-check, verify, brief+seed) is the
-  documented improvement path, scored per stage on the corpus harness, not a
-  v1 requirement.
+- **Pipeline:** now staged (shipped after the v1 draft+verify cut): survey
+  maps the repo and groups tools into surfaces, one focused pass drafts each
+  surface, a cross-check amends the combined draft, and the brief is drafted
+  from what the stages learned. Every stage emits an inspectable artifact
+  (`.vendo/data/extract/<stage>.json`), failures degrade per stage, and the
+  combined output still feeds the same deterministic guards. Per-stage
+  scoring on the corpus harness remains the improvement path.
 - **Sync/drift: deferred entirely.** v1 story for changed code is "run
   vendo init again" (idempotent). Drift triage, fail-closed rules, and CI
   strictness get designed when the base works.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -51,6 +51,15 @@ source goes to your model provider under your own account). It drafts
 task-oriented tool descriptions, reviews risk grades, wakes statically
 unclassifiable tools with reasoning, and writes the product brief.
 
+The pass runs as a staged pipeline, not one shot: a cheap survey maps the
+repo and groups tools into surfaces (`VENDO_EXTRACTION_SURVEY_MODEL` can
+point it at a faster model), one focused pass drafts each surface, a
+cross-check reviews the combined draft for consistency, and the brief is
+drafted last from what the stages learned. Each stage writes its artifact to
+`.vendo/data/extract/<stage>.json` (gitignored) for inspection, and failures
+degrade per stage — a failed surface is skipped with a note instead of
+aborting the run.
+
 Everything it proposes passes deterministic guards before applying: only
 extracted tool names are accepted, risk can be raised but never lowered,
 waking a disabled tool requires reasoning plus an explicit grade, and human

--- a/packages/vendo/src/cli/extract/extraction.ts
+++ b/packages/vendo/src/cli/extract/extraction.ts
@@ -3,14 +3,19 @@ import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import { z } from "zod";
 import { claudeHarness } from "./claude-harness.js";
-import { parseDraft, type DraftTool, type ExtractionHarness } from "./harness.js";
+import { parseDraft, type ExtractionHarness } from "./harness.js";
+import { BRIEF_TEMPLATE, runStagedExtraction, staticToolSchema, type StaticTool } from "./stages.js";
 import { readOptional, writeText, type Output } from "../shared.js";
 
+export { composeInstructions } from "./stages.js";
+
 /**
- * The AI extraction pass (install-dx v1: draft + deterministic verification).
- * The agent reads the codebase and drafts judgment on top of the static
- * facts: task-oriented tool descriptions, risk corrections, critical marks,
- * waking unclassifiable tools, and the product brief.
+ * The AI extraction pass (install-dx: staged pipeline + deterministic
+ * verification — see stages.ts for the survey / draft-per-surface /
+ * cross-check / brief orchestration). The agent reads the codebase and
+ * drafts judgment on top of the static facts: task-oriented tool
+ * descriptions, risk corrections, critical marks, waking unclassifiable
+ * tools, and the product brief.
  *
  * Output rides the channels that SURVIVE `vendo sync` regeneration:
  * `.vendo/overrides.json` (per-tool description/risk/critical/disabled — the
@@ -25,20 +30,7 @@ import { readOptional, writeText, type Output } from "../shared.js";
  *   a hand-written brief is never replaced (only the init template is).
  */
 
-const BRIEF_TEMPLATE =
-  "Describe this product, its users, and the jobs the agent should help them complete.";
-
 const RISK_ORDER = { read: 0, write: 1, destructive: 2 } as const;
-
-const staticToolSchema = z.object({
-  name: z.string(),
-  description: z.string().optional(),
-  risk: z.enum(["read", "write", "destructive"]).optional(),
-  disabled: z.boolean().optional(),
-  method: z.string().optional(),
-  path: z.string().optional(),
-});
-type StaticTool = z.infer<typeof staticToolSchema>;
 
 const overridesSchema = z.object({
   format: z.literal("vendo/overrides@1"),
@@ -50,33 +42,6 @@ const overridesSchema = z.object({
   }).passthrough()),
 }).passthrough();
 type Overrides = z.infer<typeof overridesSchema>;
-
-export function composeInstructions(tools: StaticTool[], appName: string): string {
-  return [
-    "You are Vendo's extraction agent. Read this codebase (Read/Glob/Grep only) and return",
-    "judgment on the API tools a static extractor already found, plus a product brief.",
-    "",
-    `Product/package name: ${appName}`,
-    "Statically extracted tools (name, method+path when known, current risk, disabled state):",
-    JSON.stringify(tools.map((tool) => ({
-      name: tool.name,
-      ...(tool.method === undefined ? {} : { method: tool.method }),
-      ...(tool.path === undefined ? {} : { path: tool.path }),
-      risk: tool.risk,
-      ...(tool.disabled === true ? { disabled: true } : {}),
-      description: tool.description,
-    })), null, 2),
-    "",
-    "Rules:",
-    "- Reply with ONLY one fenced json block matching:",
-    '  { "brief": string, "tools": [{ "name", "description", "risk"?, "critical"?, "disabled"?, "reasoning"? }], "missedSurfaces"?: string[] }',
-    "- brief: one paragraph — what the product does, who uses it, the jobs the agent should help with. Written from the actual code, no marketing fluff.",
-    "- tools: include ONLY names from the list above. Rewrite each description so an agent choosing tools understands what it actually does (read the handler source). <= 200 chars each.",
-    "- risk: you may RAISE risk (read->write->destructive) when the handler is more dangerous than labeled; never lower it. Mark irreversible operations critical: true.",
-    "- A tool listed as disabled was statically unclassifiable. If you can read its handler and grade it, set disabled: false WITH a risk and one-line reasoning. Leave it out otherwise.",
-    "- missedSurfaces: API surfaces you found that the list is missing (path + one line). Do not invent tools for them.",
-  ].join("\n");
-}
 
 interface AppliedSummary {
   described: number;
@@ -239,27 +204,29 @@ export async function runAiExtraction(options: AiExtractionOptions): Promise<{ r
 
   output.log(`\nReading your product (${chosen.credential})…`);
   try {
-    const text = await chosen.harness.run({
+    const staged = await runStagedExtraction({
       root,
       env,
-      instructions: composeInstructions(tools, appName),
+      harness: chosen.harness,
+      tools,
+      appName,
       onProgress: (line) => output.log(`  ${line}`),
     });
-    const draft = parseDraft(text);
-    const applied = await applyDraft({ root, draft, tools, ...(options.force === undefined ? {} : { force: options.force }) });
+    const applied = await applyDraft({ root, draft: staged.draft, tools, ...(options.force === undefined ? {} : { force: options.force }) });
     const parts = [
       `${applied.described} descriptions`,
       ...(applied.riskRaised > 0 ? [`${applied.riskRaised} risk raises`] : []),
       ...(applied.critical > 0 ? [`${applied.critical} critical marks`] : []),
       ...(applied.woken > 0 ? [`${applied.woken} tools woken`] : []),
-      ...(applied.briefWritten ? ["brief drafted"] : []),
+      ...(applied.briefWritten && staged.briefFromStage ? ["brief drafted"] : []),
     ];
-    output.log(`AI polish applied: ${parts.join(" · ")} → .vendo/overrides.json, .vendo/brief.md`);
+    output.log(`AI polish applied: ${parts.join(" · ")} → .vendo/overrides.json, .vendo/brief.md (stage artifacts: .vendo/data/extract/)`);
+    for (const note of staged.notes) output.error(`  ${note}`);
     for (const refused of applied.refused) output.error(`  refused: ${refused}`);
     for (const missed of applied.missedSurfaces) output.log(`  missed surface (not extracted yet): ${missed}`);
     return { ran: true };
   } catch (error) {
-    output.error(`AI polish did not complete (${error instanceof Error ? error.message : "unknown error"}); extractor defaults stand. Re-run \`vendo init\` to retry.`);
+    output.error(`AI polish did not complete (${error instanceof Error ? error.message : "unknown error"}); extractor defaults stand. Re-run \`vendo init\` to retry — stage artifacts in .vendo/data/extract/ show how far it got.`);
     return { ran: false };
   }
 }

--- a/packages/vendo/src/cli/extract/harness.ts
+++ b/packages/vendo/src/cli/extract/harness.ts
@@ -79,13 +79,13 @@ function* balancedObjectSpans(text: string): Generator<string> {
   }
 }
 
-/** Extract the draft JSON from an agent's final text: prefer a fenced block,
- *  else try each balanced object span until one validates. Throws on
- *  unparseable output. */
-export function parseDraft(text: string): ExtractionDraft {
+/** Extract a stage artifact from an agent's final text: prefer a fenced
+ *  block, else try each balanced object span until one validates against the
+ *  stage's schema. Throws on unparseable output. */
+export function parseArtifact<Schema extends z.ZodTypeAny>(text: string, schema: Schema): z.infer<Schema> {
   const fenced = text.match(/```(?:json)?\s*\n([\s\S]*?)\n```/);
   if (fenced?.[1] !== undefined) {
-    return extractionDraftSchema.parse(JSON.parse(fenced[1]));
+    return schema.parse(JSON.parse(fenced[1]));
   }
   let firstError: unknown = new Error("no JSON object found in the agent's output");
   let attempts = 0;
@@ -93,10 +93,14 @@ export function parseDraft(text: string): ExtractionDraft {
     if (attempts >= 20) break;
     attempts += 1;
     try {
-      return extractionDraftSchema.parse(JSON.parse(span));
+      return schema.parse(JSON.parse(span));
     } catch (error) {
       if (attempts === 1) firstError = error;
     }
   }
   throw firstError;
+}
+
+export function parseDraft(text: string): ExtractionDraft {
+  return parseArtifact(text, extractionDraftSchema);
 }

--- a/packages/vendo/src/cli/extract/stages.test.ts
+++ b/packages/vendo/src/cli/extract/stages.test.ts
@@ -170,6 +170,52 @@ describe("runStagedExtraction", () => {
     expect(result.notes).toEqual(['cross-check: amendment for undrafted tool "invented_tool" ignored']);
   });
 
+  it("a description-only amendment merges onto the surface draft, keeping its risk/critical/wake judgment", async () => {
+    const root = await fixture();
+    const { harness } = scriptedHarness((stage, input) => {
+      if (stage === "survey") return SURVEY;
+      if (stage === "draft" && input.instructions.includes("host_admin_reset")) {
+        return { tools: [{
+          name: "host_admin_reset", description: "Reset all demo data.",
+          risk: "destructive" as const, critical: true, disabled: false, reasoning: "handler truncates tables",
+        }] };
+      }
+      if (stage === "draft") return draftFor(input.instructions);
+      if (stage === "cross-check") return { tools: [{ name: "host_admin_reset", description: "amended: reset demo data" }] };
+      return { brief: "b" };
+    });
+    const result = await runStagedExtraction({ root, env: {}, harness, tools: TOOLS, appName: "maple" });
+    expect(result.draft.tools.find((tool) => tool.name === "host_admin_reset")).toEqual({
+      name: "host_admin_reset",
+      description: "amended: reset demo data",
+      risk: "destructive",
+      critical: true,
+      disabled: false,
+      reasoning: "handler truncates tables",
+    });
+  });
+
+  it("a surface pass drafting another surface's tool is ignored, keeping containment honest", async () => {
+    const root = await fixture();
+    const { harness } = scriptedHarness((stage, input) => {
+      if (stage === "survey") return SURVEY;
+      if (stage === "draft" && input.instructions.includes("host_admin_reset")) return new Error("rate limited");
+      if (stage === "draft") {
+        return { tools: [
+          ...draftFor(input.instructions).tools,
+          { name: "host_admin_reset", description: "poached from another surface" },
+        ] };
+      }
+      if (stage === "cross-check") return { tools: [] };
+      return { brief: "b" };
+    });
+    const result = await runStagedExtraction({ root, env: {}, harness, tools: TOOLS, appName: "maple" });
+    // The admin surface failed, so its tool keeps extractor defaults — the
+    // invoices pass cannot smuggle in a draft for it.
+    expect(result.draft.tools.map((tool) => tool.name).sort()).toEqual(["host_invoices_create", "host_invoices_list"]);
+    expect(result.notes).toContain('surface "Invoices": draft for out-of-surface tool "host_admin_reset" ignored');
+  });
+
   it("a failed survey degrades to drafting everything as one surface", async () => {
     const root = await fixture();
     const { harness, runs } = scriptedHarness((stage, input) => {

--- a/packages/vendo/src/cli/extract/stages.test.ts
+++ b/packages/vendo/src/cli/extract/stages.test.ts
@@ -1,0 +1,249 @@
+import { mkdtemp, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ExtractionHarness, ExtractionRunInput } from "./harness.js";
+import { normalizeSurfaces, runStagedExtraction, type StaticTool } from "./stages.js";
+
+const cleanup: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+const TOOLS: StaticTool[] = [
+  { name: "host_invoices_list", description: "GET /api/invoices", risk: "read", method: "GET", path: "/api/invoices" },
+  { name: "host_invoices_create", description: "POST /api/invoices", risk: "write", method: "POST", path: "/api/invoices" },
+  { name: "host_admin_reset", description: "POST /api/admin/reset", risk: "destructive", method: "POST", path: "/api/admin/reset" },
+];
+
+async function fixture(brief?: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-stages-"));
+  cleanup.push(root);
+  await mkdir(join(root, ".vendo"), { recursive: true });
+  if (brief !== undefined) await writeFile(join(root, ".vendo", "brief.md"), `${brief}\n`);
+  return root;
+}
+
+/** Identify which stage an instruction string belongs to. */
+function stageOf(instructions: string): "survey" | "draft" | "cross-check" | "brief" {
+  if (instructions.includes("extraction surveyor")) return "survey";
+  if (instructions.includes("cross-checker")) return "cross-check";
+  if (instructions.includes("drafting the product brief")) return "brief";
+  return "draft";
+}
+
+/** A scripted harness: responds per stage, records every run. */
+function scriptedHarness(
+  respond: (stage: string, input: ExtractionRunInput) => object | Error,
+): { harness: ExtractionHarness; runs: Array<{ stage: string; input: ExtractionRunInput }> } {
+  const runs: Array<{ stage: string; input: ExtractionRunInput }> = [];
+  return {
+    runs,
+    harness: {
+      id: "scripted",
+      availability: async () => "a scripted fake",
+      run: async (input) => {
+        const stage = stageOf(input.instructions);
+        runs.push({ stage, input });
+        const response = respond(stage, input);
+        if (response instanceof Error) throw response;
+        return "```json\n" + JSON.stringify(response) + "\n```";
+      },
+    },
+  };
+}
+
+const SURVEY = {
+  frameworks: ["next"],
+  surfaces: [
+    { name: "Invoices", note: "app/api/invoices", tools: ["host_invoices_list", "host_invoices_create"] },
+    { name: "Admin", tools: ["host_admin_reset"] },
+  ],
+};
+
+function draftFor(instructions: string): { tools: Array<{ name: string; description: string }> } {
+  const names = TOOLS.map((tool) => tool.name).filter((name) => instructions.includes(name));
+  return { tools: names.map((name) => ({ name, description: `drafted: ${name}` })) };
+}
+
+async function readArtifact(root: string, stage: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(join(root, ".vendo", "data", "extract", `${stage}.json`), "utf8"));
+}
+
+describe("runStagedExtraction", () => {
+  it("sequences survey → draft-per-surface → cross-check → brief and writes every stage artifact", async () => {
+    const root = await fixture();
+    const { harness, runs } = scriptedHarness((stage, input) => {
+      if (stage === "survey") return SURVEY;
+      if (stage === "draft") return draftFor(input.instructions);
+      if (stage === "cross-check") {
+        return { tools: [{ name: "host_admin_reset", description: "amended: reset all demo data", risk: "destructive" as const, critical: true }] };
+      }
+      return { brief: "Maple is a consumer bank." };
+    });
+    const result = await runStagedExtraction({
+      root,
+      env: { VENDO_EXTRACTION_MODEL: "big-model", VENDO_EXTRACTION_SURVEY_MODEL: "small-model" },
+      harness,
+      tools: TOOLS,
+      appName: "maple",
+    });
+
+    expect(runs.map((run) => run.stage)).toEqual(["survey", "draft", "draft", "cross-check", "brief"]);
+    // The survey pass runs on its override model; every other stage keeps the base model.
+    expect(runs[0]?.input.env["VENDO_EXTRACTION_MODEL"]).toBe("small-model");
+    expect(runs.slice(1).every((run) => run.input.env["VENDO_EXTRACTION_MODEL"] === "big-model")).toBe(true);
+    // Per-surface passes carry only their own surface's tools.
+    expect(runs[1]?.input.instructions).toContain("host_invoices_list");
+    expect(runs[1]?.input.instructions).not.toContain("host_admin_reset");
+
+    expect(result.notes).toEqual([]);
+    expect(result.briefFromStage).toBe(true);
+    expect(result.draft.brief).toBe("Maple is a consumer bank.");
+    expect(result.draft.tools).toHaveLength(3);
+    expect(result.draft.tools.find((tool) => tool.name === "host_admin_reset")).toMatchObject({
+      description: "amended: reset all demo data",
+      critical: true,
+    });
+
+    const files = await readdir(join(root, ".vendo", "data", "extract"));
+    expect(files.sort()).toEqual(["brief.json", "cross-check.json", "draft.admin.json", "draft.invoices.json", "draft.json", "survey.json"]);
+    expect(await readArtifact(root, "survey")).toMatchObject({ frameworks: ["next"] });
+    expect(await readArtifact(root, "draft")).toMatchObject({ brief: "Maple is a consumer bank." });
+  });
+
+  it("a failed surface pass is skipped with an honest note, not fatal", async () => {
+    const root = await fixture();
+    const { harness } = scriptedHarness((stage, input) => {
+      if (stage === "survey") return SURVEY;
+      if (stage === "draft" && input.instructions.includes("host_admin_reset")) return new Error("rate limited");
+      if (stage === "draft") return draftFor(input.instructions);
+      if (stage === "cross-check") return { tools: [] };
+      return { brief: "b" };
+    });
+    const result = await runStagedExtraction({ root, env: {}, harness, tools: TOOLS, appName: "maple" });
+    expect(result.draft.tools.map((tool) => tool.name).sort()).toEqual(["host_invoices_create", "host_invoices_list"]);
+    expect(result.notes).toEqual(['surface "Admin" skipped (rate limited) — its 1 tools keep extractor defaults']);
+    // The failed stage's artifact records the error for diagnosis.
+    expect(await readArtifact(root, "draft.admin")).toMatchObject({ stage: "draft.admin", error: "rate limited" });
+  });
+
+  it("throws naming the stage when every surface pass fails", async () => {
+    const root = await fixture();
+    const { harness } = scriptedHarness((stage) => (stage === "survey" ? SURVEY : new Error("model unreachable")));
+    await expect(runStagedExtraction({ root, env: {}, harness, tools: TOOLS, appName: "maple" }))
+      .rejects.toThrow("draft stage failed for every surface (model unreachable)");
+  });
+
+  it("a failed cross-check degrades to the uncross-checked drafts", async () => {
+    const root = await fixture();
+    const { harness } = scriptedHarness((stage, input) => {
+      if (stage === "survey") return SURVEY;
+      if (stage === "draft") return draftFor(input.instructions);
+      if (stage === "cross-check") return new Error("overloaded");
+      return { brief: "b" };
+    });
+    const result = await runStagedExtraction({ root, env: {}, harness, tools: TOOLS, appName: "maple" });
+    expect(result.draft.tools).toHaveLength(3);
+    expect(result.draft.tools.every((tool) => tool.description.startsWith("drafted:"))).toBe(true);
+    expect(result.notes).toEqual(["cross-check stage failed (overloaded) — using the uncross-checked drafts"]);
+  });
+
+  it("cross-check may only amend: unknown names are ignored, omitted entries stand", async () => {
+    const root = await fixture();
+    const { harness } = scriptedHarness((stage, input) => {
+      if (stage === "survey") return SURVEY;
+      if (stage === "draft") return draftFor(input.instructions);
+      if (stage === "cross-check") {
+        return { tools: [
+          { name: "host_invoices_list", description: "amended: list invoices" },
+          { name: "invented_tool", description: "not drafted by any surface" },
+        ] };
+      }
+      return { brief: "b" };
+    });
+    const result = await runStagedExtraction({ root, env: {}, harness, tools: TOOLS, appName: "maple" });
+    expect(result.draft.tools.map((tool) => tool.name).sort()).toEqual(TOOLS.map((tool) => tool.name).sort());
+    expect(result.draft.tools.find((tool) => tool.name === "host_invoices_list")?.description).toBe("amended: list invoices");
+    expect(result.draft.tools.find((tool) => tool.name === "host_invoices_create")?.description).toBe("drafted: host_invoices_create");
+    expect(result.notes).toEqual(['cross-check: amendment for undrafted tool "invented_tool" ignored']);
+  });
+
+  it("a failed survey degrades to drafting everything as one surface", async () => {
+    const root = await fixture();
+    const { harness, runs } = scriptedHarness((stage, input) => {
+      if (stage === "survey") return new Error("bad json");
+      if (stage === "draft") return draftFor(input.instructions);
+      if (stage === "cross-check") return { tools: [] };
+      return { brief: "b" };
+    });
+    const result = await runStagedExtraction({ root, env: {}, harness, tools: TOOLS, appName: "maple" });
+    expect(runs.filter((run) => run.stage === "draft")).toHaveLength(1);
+    expect(result.draft.tools).toHaveLength(3);
+    expect(result.notes).toEqual(["survey stage failed (bad json) — drafting all 3 tools as one surface"]);
+    expect(await readArtifact(root, "survey")).toMatchObject({ stage: "survey", error: "bad json" });
+    expect(await readArtifact(root, "draft.all-tools")).toBeDefined();
+  });
+
+  it("a failed brief stage keeps the current brief", async () => {
+    const root = await fixture("The humans already described this product.");
+    const { harness } = scriptedHarness((stage, input) => {
+      if (stage === "survey") return SURVEY;
+      if (stage === "draft") return draftFor(input.instructions);
+      if (stage === "cross-check") return { tools: [] };
+      return new Error("timed out");
+    });
+    const result = await runStagedExtraction({ root, env: {}, harness, tools: TOOLS, appName: "maple" });
+    expect(result.briefFromStage).toBe(false);
+    expect(result.draft.brief).toBe("The humans already described this product.");
+    expect(result.notes).toEqual(["brief stage failed (timed out) — keeping the current brief"]);
+  });
+
+  it("clears artifacts from a previous run before starting", async () => {
+    const root = await fixture();
+    await mkdir(join(root, ".vendo", "data", "extract"), { recursive: true });
+    await writeFile(join(root, ".vendo", "data", "extract", "draft.stale-surface.json"), "{}");
+    const { harness } = scriptedHarness((stage, input) => {
+      if (stage === "survey") return SURVEY;
+      if (stage === "draft") return draftFor(input.instructions);
+      if (stage === "cross-check") return { tools: [] };
+      return { brief: "b" };
+    });
+    await runStagedExtraction({ root, env: {}, harness, tools: TOOLS, appName: "maple" });
+    const files = await readdir(join(root, ".vendo", "data", "extract"));
+    expect(files).not.toContain("draft.stale-surface.json");
+  });
+});
+
+describe("normalizeSurfaces", () => {
+  it("drops unknown names, keeps first assignment, and sweeps unassigned tools into a catch-all", () => {
+    const notes: string[] = [];
+    const surfaces = normalizeSurfaces(
+      { surfaces: [
+        { name: "Invoices", tools: ["host_invoices_list", "ghost_tool"] },
+        { name: "Also invoices", tools: ["host_invoices_list"] },
+      ] },
+      TOOLS,
+      notes,
+    );
+    expect(surfaces.map((surface) => surface.name)).toEqual(["Invoices", "everything else"]);
+    expect(surfaces[1]?.tools.map((tool) => tool.name).sort()).toEqual(["host_admin_reset", "host_invoices_create"]);
+    expect(notes.some((note) => note.includes('"ghost_tool"'))).toBe(true);
+    expect(notes.some((note) => note.includes("2 tools unassigned"))).toBe(true);
+  });
+
+  it("merges a runaway surface count into one tail pass and dedupes slugs", () => {
+    const many = Array.from({ length: 20 }, (_, index) => ({ name: `t${index}`, description: "d" }));
+    const notes: string[] = [];
+    const surfaces = normalizeSurfaces(
+      { surfaces: many.map((tool) => ({ name: "Same Name!", tools: [tool.name] })) },
+      many,
+      notes,
+    );
+    expect(surfaces).toHaveLength(12);
+    expect(surfaces[11]?.tools).toHaveLength(9);
+    expect(new Set(surfaces.map((surface) => surface.slug)).size).toBe(12);
+    expect(notes.some((note) => note.includes("merged the tail"))).toBe(true);
+  });
+});

--- a/packages/vendo/src/cli/extract/stages.ts
+++ b/packages/vendo/src/cli/extract/stages.ts
@@ -329,8 +329,15 @@ export async function runStagedExtraction(input: StagedExtractionInput): Promise
         surfaceDraftSchema,
         env,
       );
+      // A focused pass may only draft its own surface's tools — an
+      // out-of-surface entry would defeat the containment story (a skipped
+      // surface must actually keep extractor defaults).
+      const members = new Set(surface.tools.map((tool) => tool.name));
       for (const entry of artifact.tools) {
-        if (drafted.has(entry.name)) continue;
+        if (!members.has(entry.name)) {
+          notes.push(`surface "${surface.name}": draft for out-of-surface tool "${entry.name}" ignored`);
+          continue;
+        }
         drafted.set(entry.name, entry);
       }
       missedSurfaces.push(...(artifact.missedSurfaces ?? []));
@@ -356,11 +363,14 @@ export async function runStagedExtraction(input: StagedExtractionInput): Promise
         env,
       );
       for (const amendment of artifact.tools) {
-        if (!drafted.has(amendment.name)) {
+        const existing = drafted.get(amendment.name);
+        if (existing === undefined) {
           notes.push(`cross-check: amendment for undrafted tool "${amendment.name}" ignored`);
           continue;
         }
-        drafted.set(amendment.name, amendment);
+        // Merge, never replace: a description-only amendment must not drop
+        // the risk/critical/wake judgment the focused pass produced.
+        drafted.set(amendment.name, { ...existing, ...amendment });
       }
     } catch (error) {
       notes.push(`cross-check stage failed (${message(error)}) — using the uncross-checked drafts`);

--- a/packages/vendo/src/cli/extract/stages.ts
+++ b/packages/vendo/src/cli/extract/stages.ts
@@ -1,0 +1,393 @@
+import { join } from "node:path";
+import { rm } from "node:fs/promises";
+import { z } from "zod";
+import {
+  draftToolSchema,
+  parseArtifact,
+  type DraftTool,
+  type ExtractionDraft,
+  type ExtractionHarness,
+} from "./harness.js";
+import { readOptional, writeText } from "../shared.js";
+
+/**
+ * The staged extraction pipeline (install-dx, PostHog lesson: narrow stages
+ * beat one-shot). Four passes over the SAME harness seam — each is one
+ * `harness.run(instructions)` with its own narrow instructions and its own
+ * zod-validated artifact, written to `.vendo/data/extract/<stage>.json` so a
+ * failed run is diagnosable stage by stage:
+ *
+ * 1. survey — map the repo: frameworks, where the API surfaces live, and a
+ *    grouping of the static tool list into surfaces (cheap/fast; respects a
+ *    VENDO_EXTRACTION_SURVEY_MODEL override).
+ * 2. draft — one focused pass per surface, drafting judgment for just that
+ *    surface's tools. Surfaces run sequentially (rate-limit friendly); a
+ *    failed surface is SKIPPED with an honest note, never aborting the run.
+ * 3. cross-check — one pass over the combined draft for naming consistency,
+ *    duplicate coverage, and risk sanity. It may only AMEND entries within
+ *    the same schema (unknown names ignored, omitted entries stand); a
+ *    failure degrades to the uncross-checked drafts.
+ * 4. brief — drafted from what the survey and drafts learned; a failure
+ *    keeps the current brief.
+ *
+ * The combined output feeds the EXISTING applyDraft guards in extraction.ts
+ * unchanged — deterministic verification stays the single gate. Nothing here
+ * assumes a vendor; the model override rides VENDO_EXTRACTION_MODEL, which
+ * every harness already honors.
+ */
+
+export const BRIEF_TEMPLATE =
+  "Describe this product, its users, and the jobs the agent should help them complete.";
+
+/** Static facts don't clutter passes that only need names — kept small. */
+export const staticToolSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  risk: z.enum(["read", "write", "destructive"]).optional(),
+  disabled: z.boolean().optional(),
+  method: z.string().optional(),
+  path: z.string().optional(),
+});
+export type StaticTool = z.infer<typeof staticToolSchema>;
+
+export const surveySchema = z.object({
+  /** Frameworks/routers the surveyor identified (context for later stages). */
+  frameworks: z.array(z.string().max(120)).optional(),
+  surfaces: z.array(z.object({
+    name: z.string().min(1).max(80),
+    /** One line on where the surface lives in the code. */
+    note: z.string().max(300).optional(),
+    tools: z.array(z.string().min(1)),
+  })).min(1),
+});
+export type Survey = z.infer<typeof surveySchema>;
+
+/** Draft and cross-check share one schema: the cross-check may only AMEND
+ *  the draft within it. */
+export const surfaceDraftSchema = z.object({
+  tools: z.array(draftToolSchema),
+  missedSurfaces: z.array(z.string().max(300)).optional(),
+});
+export type SurfaceDraft = z.infer<typeof surfaceDraftSchema>;
+
+export const briefSchema = z.object({
+  brief: z.string().min(1).max(4000),
+});
+
+/** More surfaces than this get their tail merged into one pass — a runaway
+ *  survey must not turn into a runaway number of model calls. */
+const MAX_SURFACES = 12;
+
+function staticFacts(tools: StaticTool[]): string {
+  return JSON.stringify(tools.map((tool) => ({
+    name: tool.name,
+    ...(tool.method === undefined ? {} : { method: tool.method }),
+    ...(tool.path === undefined ? {} : { path: tool.path }),
+    risk: tool.risk,
+    ...(tool.disabled === true ? { disabled: true } : {}),
+    description: tool.description,
+  })), null, 2);
+}
+
+export function composeSurveyInstructions(tools: StaticTool[], appName: string): string {
+  return [
+    "You are Vendo's extraction surveyor. Map this repo (Read/Glob/Grep only) so later",
+    "focused passes can draft tool documentation surface by surface.",
+    "",
+    `Product/package name: ${appName}`,
+    "Statically extracted tools (name, method+path when known):",
+    JSON.stringify(tools.map((tool) => ({
+      name: tool.name,
+      ...(tool.method === undefined ? {} : { method: tool.method }),
+      ...(tool.path === undefined ? {} : { path: tool.path }),
+    })), null, 2),
+    "",
+    "Rules:",
+    "- Reply with ONLY one fenced json block matching:",
+    '  { "frameworks"?: string[], "surfaces": [{ "name", "note"?, "tools": string[] }] }',
+    "- surfaces: group EVERY tool above into a small number of product surfaces (billing,",
+    "  auth, admin, …) by reading where their routes live. Each tool name appears in exactly",
+    "  one surface; use only names from the list.",
+    "- name: a short surface label. note: one line on where the surface lives in the code.",
+    "- frameworks: the frameworks/routers you identified.",
+    "- Survey only — do not draft descriptions or risk grades here.",
+  ].join("\n");
+}
+
+export function composeInstructions(
+  tools: StaticTool[],
+  appName: string,
+  surface?: { name: string; note?: string },
+): string {
+  return [
+    "You are Vendo's extraction agent. Read this codebase (Read/Glob/Grep only) and return",
+    surface === undefined
+      ? "judgment on the API tools a static extractor already found."
+      : `judgment on the API tools a static extractor already found, focusing ONLY on the "${surface.name}" surface.`,
+    "",
+    `Product/package name: ${appName}`,
+    ...(surface?.note === undefined ? [] : [`Where this surface lives: ${surface.note}`]),
+    "Statically extracted tools (name, method+path when known, current risk, disabled state):",
+    staticFacts(tools),
+    "",
+    "Rules:",
+    "- Reply with ONLY one fenced json block matching:",
+    '  { "tools": [{ "name", "description", "risk"?, "critical"?, "disabled"?, "reasoning"? }], "missedSurfaces"?: string[] }',
+    "- tools: include ONLY names from the list above. Rewrite each description so an agent choosing tools understands what it actually does (read the handler source). <= 200 chars each.",
+    "- risk: you may RAISE risk (read->write->destructive) when the handler is more dangerous than labeled; never lower it. Mark irreversible operations critical: true.",
+    "- A tool listed as disabled was statically unclassifiable. If you can read its handler and grade it, set disabled: false WITH a risk and one-line reasoning. Leave it out otherwise.",
+    "- missedSurfaces: API surfaces you found that the list is missing (path + one line). Do not invent tools for them.",
+  ].join("\n");
+}
+
+export function composeCrossCheckInstructions(
+  drafted: DraftTool[],
+  tools: StaticTool[],
+  appName: string,
+): string {
+  return [
+    "You are Vendo's extraction cross-checker. Focused passes drafted judgment surface by",
+    "surface; review the COMBINED draft for naming consistency, duplicate coverage, and",
+    "risk sanity.",
+    "",
+    `Product/package name: ${appName}`,
+    "Combined draft:",
+    JSON.stringify(drafted, null, 2),
+    "Static facts for the same tools:",
+    staticFacts(tools),
+    "",
+    "Rules:",
+    "- Reply with ONLY one fenced json block matching:",
+    '  { "tools": [{ "name", "description", "risk"?, "critical"?, "disabled"?, "reasoning"? }] }',
+    "- Return ONLY the entries you want to AMEND. Entries you omit stand as drafted; you cannot remove a tool. Use only names from the combined draft.",
+    "- Same rules as drafting: risk may be RAISED, never lowered; mark irreversible operations critical: true.",
+  ].join("\n");
+}
+
+export function composeBriefInstructions(input: {
+  appName: string;
+  survey: Survey | null;
+  drafted: DraftTool[];
+}): string {
+  return [
+    "You are Vendo's extraction agent, drafting the product brief. A survey and per-surface",
+    "drafting passes already ran; build on what they learned plus the code itself.",
+    "",
+    `Product/package name: ${input.appName}`,
+    ...(input.survey === null ? [] : [
+      "Surveyed surfaces:",
+      JSON.stringify(input.survey.surfaces.map(({ name, note }) => ({ name, ...(note === undefined ? {} : { note }) })), null, 2),
+    ]),
+    "Drafted tools (name + description):",
+    JSON.stringify(input.drafted.map(({ name, description }) => ({ name, description })), null, 2),
+    "",
+    "Rules:",
+    '- Reply with ONLY one fenced json block matching: { "brief": string }',
+    "- brief: one paragraph — what the product does, who uses it, the jobs the agent should help with. Written from the actual code, no marketing fluff.",
+  ].join("\n");
+}
+
+interface NormalizedSurface {
+  name: string;
+  slug: string;
+  note?: string;
+  tools: StaticTool[];
+}
+
+function slugify(name: string, taken: Set<string>): string {
+  const base = name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "surface";
+  let slug = base;
+  for (let suffix = 2; taken.has(slug); suffix += 1) slug = `${base}-${suffix}`;
+  taken.add(slug);
+  return slug;
+}
+
+/** Deterministic normalization of the survey grouping: unknown names are
+ *  dropped, a tool claimed twice keeps its first surface, unassigned tools
+ *  land in a catch-all pass, and a runaway surface count is merged down. The
+ *  drafting stage always covers EVERY static tool exactly once. */
+export function normalizeSurfaces(
+  survey: Survey | null,
+  tools: StaticTool[],
+  notes: string[],
+): NormalizedSurface[] {
+  const byName = new Map(tools.map((tool) => [tool.name, tool]));
+  const assigned = new Set<string>();
+  const surfaces: Array<Omit<NormalizedSurface, "slug">> = [];
+  for (const surface of survey?.surfaces ?? []) {
+    const members: StaticTool[] = [];
+    for (const name of surface.tools) {
+      const fact = byName.get(name);
+      if (fact === undefined) {
+        notes.push(`survey: unknown tool "${name}" in surface "${surface.name}" ignored`);
+        continue;
+      }
+      if (assigned.has(name)) continue;
+      assigned.add(name);
+      members.push(fact);
+    }
+    if (members.length > 0) {
+      surfaces.push({ name: surface.name, ...(surface.note === undefined ? {} : { note: surface.note }), tools: members });
+    }
+  }
+  const unassigned = tools.filter((tool) => !assigned.has(tool.name));
+  if (unassigned.length > 0) {
+    if (surfaces.length > 0) {
+      notes.push(`survey left ${unassigned.length} tools unassigned — drafting them as "everything else"`);
+    }
+    surfaces.push({ name: surfaces.length > 0 ? "everything else" : "all tools", tools: unassigned });
+  }
+  if (surfaces.length > MAX_SURFACES) {
+    const tail = surfaces.splice(MAX_SURFACES - 1);
+    surfaces.push({ name: "everything else", tools: tail.flatMap((surface) => surface.tools) });
+    notes.push(`survey produced ${MAX_SURFACES - 1 + tail.length} surfaces — merged the tail into one pass`);
+  }
+  const taken = new Set<string>();
+  return surfaces.map((surface) => ({ ...surface, slug: slugify(surface.name, taken) }));
+}
+
+export interface StagedExtractionInput {
+  root: string;
+  env: Record<string, string | undefined>;
+  harness: ExtractionHarness;
+  tools: StaticTool[];
+  appName: string;
+  onProgress?: (line: string) => void;
+}
+
+export interface StagedExtractionResult {
+  draft: ExtractionDraft;
+  /** Honest degradation notes (skipped surfaces, failed cross-check, …). */
+  notes: string[];
+  /** false = the brief stage failed and draft.brief is the pre-existing one. */
+  briefFromStage: boolean;
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : "unknown error";
+}
+
+/** Orchestrate the staged pipeline. Throws only when no stage produced
+ *  anything usable (the error names the failed stage); partial failures
+ *  degrade with notes instead. */
+export async function runStagedExtraction(input: StagedExtractionInput): Promise<StagedExtractionResult> {
+  const { root, env, harness, tools, appName, onProgress } = input;
+  const artifactDir = join(root, ".vendo", "data", "extract");
+  await rm(artifactDir, { recursive: true, force: true });
+  const notes: string[] = [];
+
+  async function runStage<Schema extends z.ZodTypeAny>(
+    stage: string,
+    instructions: string,
+    schema: Schema,
+    stageEnv: Record<string, string | undefined>,
+  ): Promise<z.infer<Schema>> {
+    let text: string | null = null;
+    try {
+      text = await harness.run({ root, env: stageEnv, instructions, ...(onProgress === undefined ? {} : { onProgress }) });
+      const artifact = parseArtifact(text, schema);
+      await writeText(join(artifactDir, `${stage}.json`), `${JSON.stringify(artifact, null, 2)}\n`);
+      return artifact;
+    } catch (error) {
+      await writeText(
+        join(artifactDir, `${stage}.json`),
+        `${JSON.stringify({ stage, error: message(error), ...(text === null ? {} : { raw: text }) }, null, 2)}\n`,
+      );
+      throw error;
+    }
+  }
+
+  // Survey: cheap repo map; an override can point it at a faster model. A
+  // failed survey degrades to drafting everything as one surface (= v1).
+  const surveyModel = env["VENDO_EXTRACTION_SURVEY_MODEL"];
+  let survey: Survey | null = null;
+  onProgress?.("survey: mapping API surfaces");
+  try {
+    survey = await runStage(
+      "survey",
+      composeSurveyInstructions(tools, appName),
+      surveySchema,
+      surveyModel === undefined ? env : { ...env, VENDO_EXTRACTION_MODEL: surveyModel },
+    );
+  } catch (error) {
+    notes.push(`survey stage failed (${message(error)}) — drafting all ${tools.length} tools as one surface`);
+  }
+  const surfaces = normalizeSurfaces(survey, tools, notes);
+
+  // Draft per surface, sequentially. A failed surface is skipped, not fatal —
+  // unless EVERY surface failed, which means the harness itself is broken.
+  const drafted = new Map<string, DraftTool>();
+  const missedSurfaces: string[] = [];
+  let failures = 0;
+  let lastError = "";
+  for (const surface of surfaces) {
+    onProgress?.(`drafting "${surface.name}" (${surface.tools.length} tools)`);
+    try {
+      const artifact = await runStage(
+        `draft.${surface.slug}`,
+        composeInstructions(surface.tools, appName, surface),
+        surfaceDraftSchema,
+        env,
+      );
+      for (const entry of artifact.tools) {
+        if (drafted.has(entry.name)) continue;
+        drafted.set(entry.name, entry);
+      }
+      missedSurfaces.push(...(artifact.missedSurfaces ?? []));
+    } catch (error) {
+      failures += 1;
+      lastError = message(error);
+      notes.push(`surface "${surface.name}" skipped (${lastError}) — its ${surface.tools.length} tools keep extractor defaults`);
+    }
+  }
+  if (surfaces.length > 0 && failures === surfaces.length) {
+    throw new Error(`draft stage failed for every surface (${lastError})`);
+  }
+
+  // Cross-check: amendments only, within the draft schema. applyDraft remains
+  // the gate — an amendment can no more downgrade risk than a draft can.
+  if (drafted.size > 0) {
+    onProgress?.("cross-check: consistency pass over the combined draft");
+    try {
+      const artifact = await runStage(
+        "cross-check",
+        composeCrossCheckInstructions([...drafted.values()], tools, appName),
+        surfaceDraftSchema,
+        env,
+      );
+      for (const amendment of artifact.tools) {
+        if (!drafted.has(amendment.name)) {
+          notes.push(`cross-check: amendment for undrafted tool "${amendment.name}" ignored`);
+          continue;
+        }
+        drafted.set(amendment.name, amendment);
+      }
+    } catch (error) {
+      notes.push(`cross-check stage failed (${message(error)}) — using the uncross-checked drafts`);
+    }
+  }
+
+  // Brief: drafted from what the earlier stages learned; on failure the
+  // current brief stands (applyDraft's hand-written-brief guard still wins).
+  let brief: string | null = null;
+  onProgress?.("brief: drafting the product brief");
+  try {
+    brief = (await runStage("brief", composeBriefInstructions({ appName, survey, drafted: [...drafted.values()] }), briefSchema, env)).brief;
+  } catch (error) {
+    notes.push(`brief stage failed (${message(error)}) — keeping the current brief`);
+  }
+  const briefFromStage = brief !== null;
+  if (brief === null) {
+    const current = ((await readOptional(join(root, ".vendo", "brief.md"))) ?? "").trim();
+    brief = current === "" ? BRIEF_TEMPLATE : current;
+  }
+
+  const missed = [...new Set(missedSurfaces)];
+  const draft: ExtractionDraft = {
+    brief,
+    tools: [...drafted.values()],
+    ...(missed.length === 0 ? {} : { missedSurfaces: missed }),
+  };
+  await writeText(join(artifactDir, "draft.json"), `${JSON.stringify(draft, null, 2)}\n`);
+  return { draft, notes, briefFromStage };
+}

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -815,8 +815,9 @@ export async function runInit(options: InitOptions): Promise<number> {
       output.log("No model key yet: set ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_GENERATIVE_AI_API_KEY in .env.local, or run `vendo cloud login` for a free dev key.");
     }
 
-    // AI extraction (install-dx v1): a coding agent reads the codebase and
-    // drafts descriptions/risk/brief into the override channel; deterministic
+    // AI extraction (install-dx, staged): a coding agent surveys the repo,
+    // drafts each surface in a focused pass, cross-checks the combined draft,
+    // and drafts the brief — all into the override channel; deterministic
     // guards decide what applies. Consent-gated; skipped silently when
     // non-interactive or credential-less. A successful pass re-syncs so
     // tools.json reflects the polish immediately.


### PR DESCRIPTION
## What

Upgrades AI extraction from the v1 single draft pass to the staged pipeline documented in `docs/brainstorms/init-cli-dx.md` — without changing the `ExtractionHarness` seam, the `applyDraft` guards, or the consent flow.

Four stages, each one narrow `harness.run(instructions)` with its own zod-validated artifact:

1. **survey** — maps the repo (frameworks, where API surfaces live) and groups the static tool list into surfaces. Respects `VENDO_EXTRACTION_SURVEY_MODEL` for a cheaper/faster model; the grouping is deterministically normalized (unknown names dropped, duplicates deduped, unassigned tools swept into a catch-all, runaway surface counts merged) so every static tool drafts exactly once.
2. **draft-per-surface** — one focused pass per surface, run sequentially (rate-limit friendly), emitting draft tools for just that surface.
3. **cross-check** — one pass over the combined draft for naming consistency, duplicate coverage, and risk sanity. It may only AMEND within the same schema: unknown names are ignored, omitted entries stand, deletion is impossible.
4. **brief** — drafted last from what survey + drafts learned.

## Doctrine held

- **Deterministic verification stays the single gate**: the combined draft feeds the existing `applyDraft` guards unchanged (only extracted names, no risk downgrades, reasoned wakes only, human decisions win).
- **Inspectability**: every stage writes `.vendo/data/extract/<stage>.json` (gitignored; error + raw agent text on a failed parse), and a previous run's artifacts are cleared first. The failure summary names the stage.
- **Failure containment**: a failed surface degrades to skipping that surface with an honest note; a failed cross-check degrades to the uncross-checked drafts; a failed brief keeps the current brief; a failed survey degrades to drafting everything as one surface (= v1 behavior). Only every-surface-failed aborts.
- **Vendor-neutral**: nothing above the seam assumes a vendor; the survey model override rides `VENDO_EXTRACTION_MODEL`, which every harness already honors. The harness interface is unchanged.

## Tests

- New `stages.test.ts`: 10 fake-harness tests — stage sequencing + artifact writing, survey model override routing, per-surface failure containment, every-surface-failed abort, cross-check failure degradation, cross-check amendment bounds, survey failure fallback, brief failure fallback, stale-artifact cleanup, survey normalization (unknown/duplicate/unassigned/runaway).
- All 14 pre-existing extraction guard regression tests pass **unchanged** (wake-path grade ownership, no risk downgrades, human decisions win, parseDraft noise tolerance).
- No live model calls in CI.

## Docs

- `docs/quickstart.md` AI-polish section: one paragraph on the stages.
- `docs/brainstorms/init-cli-dx.md`: the "v1 = draft + verify" pipeline note now records the staged shape as shipped.

## Gates

`pnpm build` ✓ · `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm test` ✓ (the three suites that failed under the parallel turbo run — vendo, mcp-e2e, integration — all pass isolated; known port/PGlite contention flake classes).

https://claude.ai/code/session_01Da6ija6uB4GRbcHQ47zrha
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches extraction from a single pass to a staged pipeline (survey → draft-per-surface → cross-check → brief) on the same `ExtractionHarness`, improving reliability and inspectability. Adds strict per-surface containment and safer cross-check merging; verification and consent flow remain unchanged.

- New Features
  - Four-stage pipeline with zod-validated artifacts in `.vendo/data/extract/<stage>.json` (errors include raw output; stale artifacts cleared).
  - Graceful degradation: skip failed surfaces; fallback when survey/cross-check/brief fail; only “every surface failed” aborts.
  - Deterministic surface grouping and capping; sequential per-surface runs. Survey supports `VENDO_EXTRACTION_SURVEY_MODEL`.
  - Seam unchanged; `applyDraft` guards still gate all changes. Docs updated; new tests cover sequencing, fallbacks, normalization, and artifacts.

- Bug Fixes
  - Cross-check amendments now merge onto drafted entries (never replace) so risk/critical/disabled/reasoning aren’t dropped.
  - Per-surface passes ignore out-of-surface tool drafts to keep containment honest; skipped surfaces truly keep defaults.

<sup>Written for commit 06813226001fabd354fab7308f85faea7d2ae750. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

