### PR TITLE
dev-creds: make the vendo-cloud rung real — serve VENDO_API_KEY via the Cloud model gateway

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -27,6 +27,9 @@ this order:
 2. `VENDO_API_KEY` — a Vendo Cloud dev key. When init finds no key, it offers
    `vendo cloud login`: after the browser login it mints a metered dev-mode
    starter key and writes it to `.env.local` for you. You never paste a key.
+   Model calls go through the Vendo Cloud model gateway (Anthropic models,
+   served via the installed `@ai-sdk/anthropic`) and meter your dev-mode
+   runs allowance.
 3. Nothing available: chat fails honestly, with exact instructions in the
    server log.
 

--- a/packages/vendo/src/dev-creds/model.test.ts
+++ b/packages/vendo/src/dev-creds/model.test.ts
@@ -23,9 +23,79 @@ describe("devModel (env-resolving default model)", () => {
     await expect(record.doStream({ prompt: [] })).rejects.toThrow(NO_CREDENTIAL_MESSAGE);
   });
 
-  it("states that the Cloud model gateway is not live yet on the vendo-cloud rung", async () => {
-    const controller = new DevModelController({ env: { VENDO_API_KEY: "vnd_x" } });
-    await expect(controller.doGenerate({ prompt: [] })).rejects.toThrow(/gateway is not live yet/);
+  it("serves the vendo-cloud rung through @ai-sdk/anthropic pointed at the Cloud gateway", async () => {
+    const seen: Array<{ apiKey: string; baseURL: string }> = [];
+    const controller = new DevModelController({
+      env: { VENDO_API_KEY: "vnd_x" },
+      importModule: async (_root, specifier) => {
+        expect(specifier).toBe("@ai-sdk/anthropic");
+        return {
+          createAnthropic: (config: { apiKey: string; baseURL: string }) => {
+            seen.push(config);
+            return (modelId: string) => ({
+              specificationVersion: "v3",
+              provider: "anthropic",
+              modelId,
+              supportedUrls: {},
+              doGenerate: async (options: unknown) => ({ delegated: "generate", modelId, options }),
+              doStream: async (options: unknown) => ({ delegated: "stream", modelId, options }),
+            });
+          },
+        };
+      },
+    });
+    const callOptions = { prompt: [] };
+    expect(await controller.doGenerate(callOptions)).toEqual({
+      delegated: "generate",
+      modelId: "claude-sonnet-4-6",
+      options: callOptions,
+    });
+    expect(await controller.doStream(callOptions)).toEqual({
+      delegated: "stream",
+      modelId: "claude-sonnet-4-6",
+      options: callOptions,
+    });
+    // The key rides as the provider apiKey; the base is the production
+    // console's /api/v1, where the Anthropic-shaped /messages endpoint lives.
+    expect(seen).toEqual([
+      { apiKey: "vnd_x", baseURL: "https://console.vendo.run/api/v1" },
+    ]);
+  });
+
+  it("honors VENDO_CLOUD_URL and the anthropic model override on the vendo-cloud rung", async () => {
+    const seen: Array<{ baseURL: string }> = [];
+    const controller = new DevModelController({
+      env: {
+        VENDO_API_KEY: "vnd_x",
+        VENDO_CLOUD_URL: "http://localhost:3001/",
+        VENDO_DEV_ANTHROPIC_MODEL: "claude-opus-4-8",
+      },
+      importModule: async () => ({
+        createAnthropic: (config: { apiKey: string; baseURL: string }) => {
+          seen.push({ baseURL: config.baseURL });
+          return (modelId: string) => ({
+            specificationVersion: "v3",
+            provider: "anthropic",
+            modelId,
+            supportedUrls: {},
+            doGenerate: async () => ({ modelId }),
+            doStream: async () => ({ modelId }),
+          });
+        },
+      }),
+    });
+    expect(await controller.doGenerate({ prompt: [] })).toEqual({ modelId: "claude-opus-4-8" });
+    expect(seen).toEqual([{ baseURL: "http://localhost:3001/api/v1" }]);
+  });
+
+  it("names the missing anthropic install when the vendo-cloud rung lacks the provider", async () => {
+    const controller = new DevModelController({
+      env: { VENDO_API_KEY: "vnd_x" },
+      importModule: async (_root, specifier) => {
+        throw new Error(`Cannot find module '${specifier}'`);
+      },
+    });
+    await expect(controller.doGenerate({ prompt: [] })).rejects.toThrow(/@ai-sdk\/anthropic@\^3/);
   });
 
   it("names the missing provider install for an env-key rung without the package", async () => {

--- a/packages/vendo/src/dev-creds/model.ts
+++ b/packages/vendo/src/dev-creds/model.ts
@@ -2,6 +2,7 @@ import { createRequire } from "node:module";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { LanguageModel } from "ai";
+import { resolveCloudBaseUrl } from "../cli/cloud/client.js";
 import {
   describeDevCredential,
   resolveDevCredential,
@@ -17,8 +18,10 @@ import {
  *
  * - env-key rungs delegate to the host-installed @ai-sdk provider (^3, spec
  *   v3) with full native tool calling — works in production too.
- * - VENDO_API_KEY delegates to the Vendo Cloud model gateway once it ships;
- *   until then it fails honestly with instructions.
+ * - VENDO_API_KEY delegates to the Vendo Cloud model gateway: the
+ *   host-installed @ai-sdk/anthropic pointed at `<console>/api/v1`, whose
+ *   Anthropic-compatible /messages endpoint serves the metered dev-mode
+ *   allowance.
  * - nothing available → every call fails with the exact instructions.
  */
 
@@ -151,10 +154,26 @@ export class DevModelController {
     }
 
     if (credential.rung === "vendo-cloud") {
-      const message = "VENDO_API_KEY is set, but the Vendo Cloud dev-mode model gateway is not live yet. "
-        + "Set a provider key (ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_GENERATIVE_AI_API_KEY) for now.";
-      this.announce(credential, " — model gateway not live yet");
-      return { mode: "unavailable", credential, message };
+      // The gateway speaks the Anthropic Messages wire, so the anthropic
+      // provider serves it — pointed at the console instead of Anthropic.
+      const spec = DEFAULT_MODELS["anthropic"]!;
+      let loaded: Record<string, unknown>;
+      try {
+        loaded = await this.importModule(this.root, spec.module);
+      } catch {
+        const message = `VENDO_API_KEY is set but ${spec.module} is not installed in this app; install it (\`${spec.install}\`).`;
+        this.announce(credential, ` — but ${spec.module} is missing`);
+        return { mode: "unavailable", credential, message };
+      }
+      const factory = loaded[spec.factory] as (
+        config: { apiKey: string; baseURL: string },
+      ) => (model: string) => LanguageModelV3Like;
+      const base = resolveCloudBaseUrl({ env: this.env });
+      const baseURL = base.endsWith("/api/v1") ? base : `${base}/api/v1`;
+      const modelId = this.env[spec.modelEnv] ?? spec.model;
+      const model = factory({ apiKey: this.env["VENDO_API_KEY"]!, baseURL })(modelId);
+      this.announce(credential, ` → ${modelId} via the Cloud gateway`);
+      return { mode: "delegate", credential, model };
     }
 
     this.announce(credential);


### PR DESCRIPTION
Activation half of install-dx lane 1 (Cloud side: runvendo/vendo-web#73, merged and deploying).

The dev-creds ladder's `vendo-cloud` resolution previously returned unavailable ("gateway not live yet"). It now delegates to the host-installed `@ai-sdk/anthropic` with:

- `apiKey: VENDO_API_KEY` — the minted dev-mode starter key rides as the provider key (`x-api-key` on the wire),
- `baseURL: <VENDO_CLOUD_URL or https://console.vendo.run>/api/v1` — reusing `resolveCloudBaseUrl` from the cloud client, with the same `/api/v1`-suffix guard as `requestUrl`, so the provider's native `/messages` calls land on the console's Anthropic-compatible gateway, which proxies + meters them against the org's runs allowance.

Model id defaults to the anthropic rung's `claude-sonnet-4-6`, overridable via the existing `VENDO_DEV_ANTHROPIC_MODEL`. A host without `@ai-sdk/anthropic` fails honestly with the exact install line, matching the env-key rung's posture (the provider resolves from the host app, same as every other rung; it is not a dependency of vendo itself).

Tests: replaced the "not live yet" expectation with delegation coverage (apiKey/baseURL/model id land in the provider factory, doGenerate + doStream both delegate), a `VENDO_CLOUD_URL` + model-override case (trailing-slash normalization included), and a missing-provider install-message case. Docs: quickstart "Model keys" rung 2 now states calls go through the gateway and meter the dev-mode runs allowance.

Gates: `pnpm build`, `pnpm test` (405 passed), `pnpm typecheck`, `pnpm lint` all green. The `fixtures/host-app/next-env.d.ts` churn is deliberately not committed.

https://claude.ai/code/session_01H3xRmmXLUeCxry3nHyqJfh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activates the `vendo-cloud` rung: model calls now go through the Vendo Cloud gateway via the host `@ai-sdk/anthropic`, metered against the dev-mode runs allowance. Apps can use `VENDO_API_KEY` directly for Anthropic-compatible models.

- **New Features**
  - Delegates to `@ai-sdk/anthropic` with `apiKey: VENDO_API_KEY` and `baseURL: <VENDO_CLOUD_URL || https://console.vendo.run>/api/v1`.
  - Default model is `claude-sonnet-4-6`; override with `VENDO_DEV_ANTHROPIC_MODEL`.
  - If `@ai-sdk/anthropic` is missing, fail with a clear install hint.
  - Tests and quickstart updated for gateway routing, model override, and provider checks.

<sup>Written for commit c673c5115e2fc3783ae307365a3680aaca0522c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

