### PR TITLE
extract: delegate AI polish to external coding agents through the same guards

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -71,6 +71,27 @@ hand-written `brief.md` are never overwritten). The output lands in the
 override channel, so `vendo sync` regeneration keeps it. Skipped silently in
 non-interactive runs; re-run `vendo init` any time to add it.
 
+### Bring your own coding agent
+
+The extraction contract is portable: any coding agent already living in your
+repo (Claude Code, Cursor, Codex) can do the reading instead. `npx vendo init
+--agent` emits an `aiPolish` object in its read-only plan: the composed
+`instructions`, the exact draft `draftSchema`, and the apply command. Let your
+agent read the codebase against the instructions and write the draft JSON to a
+file, then apply it:
+
+```bash
+npx vendo extract --apply draft.json
+```
+
+The apply step is non-interactive safe and runs the same deterministic guards
+as the built-in pass, so delegation never becomes a second, weaker path into
+`.vendo/`. It writes the same artifacts, re-syncs, and prints the same
+summary. An unusable draft (unreadable file, schema mismatch) exits non-zero
+with the reason; guard refusals (unknown tool names, risk downgrades,
+unreasoned wakes) are printed per entry while the rest of the draft applies.
+`--force` replaces a hand-edited brief, exactly like `vendo init --force`.
+
 ## Create the server
 
 `createVendo` has this exact configuration surface:

--- a/packages/vendo/skills/vendo-setup/SKILL.md
+++ b/packages/vendo/skills/vendo-setup/SKILL.md
@@ -23,7 +23,7 @@ fetch it when you need more detail than this skill carries.
 2. Run init. As an agent, plan first, then apply:
 
    ```bash
-   npx vendo init --agent   # read-only JSON plan: framework, code diffs, questions, extracted tools, risk recommendations
+   npx vendo init --agent   # read-only JSON plan: framework, code diffs, extracted tools, risk recommendations, aiPolish delegation contract
    npx vendo init --yes --model-import "@/lib/ai" --brief "<one-paragraph product brief>"
    ```
 
@@ -76,6 +76,22 @@ fetch it when you need more detail than this skill carries.
 
 ## Stage 2 — review and keep extraction fresh
 
+- AI polish, delegated to you: the `--agent` plan's `aiPolish` object is a
+  contract you can execute yourself. Read the codebase per
+  `aiPolish.instructions` (task-oriented tool descriptions, risk review,
+  wakes with reasoning, the product brief), write one JSON draft matching
+  `aiPolish.draftSchema` to a file, then:
+
+  ```bash
+  npx vendo extract --apply draft.json
+  ```
+
+  Vendo runs the same deterministic guards as init's built-in pass (only
+  extracted tool names accepted, risk raised never lowered, wakes need
+  reasoning plus a grade, human decisions win), writes
+  `.vendo/overrides.json` and `.vendo/brief.md`, and re-syncs. Non-zero exit
+  means the draft was rejected with the reason printed; fix and re-apply.
+  `--force` replaces a hand-edited brief; leave it off otherwise.
 - Re-extract after API changes: `npx vendo sync` (fail-soft). In CI use
   `npx vendo sync --strict` — exit 2 on breaking tool changes, 3 when saved
   apps/automations/grants are impacted. `--json` emits one machine-readable

--- a/packages/vendo/src/cli.test.ts
+++ b/packages/vendo/src/cli.test.ts
@@ -82,6 +82,31 @@ describe("vendo CLI commands", () => {
     log.mockRestore();
   });
 
+  it("wires extract: --apply is required, unknown flags fail loudly, errors route home", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(await main(["--help"])).toBe(0);
+    expect(log.mock.calls.flat().join("\n")).toContain("extract [dir]");
+    expect(log.mock.calls.flat().join("\n")).toContain("--apply <draft.json>");
+
+    // No --apply → loud error, nothing runs (ENG-335 posture).
+    expect(await main(["extract"])).toBe(1);
+    expect(error.mock.calls.flat().join("\n")).toContain("--apply <draft.json> is required");
+
+    expect(await main(["extract", "--apply", "draft.json", "--dry-run"])).toBe(1);
+    expect(error.mock.calls.flat().join("\n")).toContain("unknown option: --dry-run");
+
+    // A parsed --apply reaches the command: an un-inited dir fails honestly.
+    const root = await mkdtemp(join(tmpdir(), "vendo-cli-extract-"));
+    cleanup.push(root);
+    expect(await main(["extract", root, "--apply", join(root, "draft.json")])).toBe(1);
+    expect(error.mock.calls.flat().join("\n")).toContain("run `vendo init` first");
+
+    log.mockRestore();
+    error.mockRestore();
+  });
+
   it("wires eject: --list routes, surface + dir + --force parse, help documents it", async () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
     const error = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/packages/vendo/src/cli.test.ts
+++ b/packages/vendo/src/cli.test.ts
@@ -94,6 +94,10 @@ describe("vendo CLI commands", () => {
     expect(await main(["extract"])).toBe(1);
     expect(error.mock.calls.flat().join("\n")).toContain("--apply <draft.json> is required");
 
+    // `--apply=` (empty value) fails loudly instead of resolving to the cwd.
+    expect(await main(["extract", "--apply="])).toBe(1);
+    expect(error.mock.calls.flat().join("\n")).toContain("--apply requires a value");
+
     expect(await main(["extract", "--apply", "draft.json", "--dry-run"])).toBe(1);
     expect(error.mock.calls.flat().join("\n")).toContain("unknown option: --dry-run");
 

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -157,6 +157,10 @@ export async function main(argv: string[]): Promise<number> {
     const problems = optionErrors(args, EXTRACT_FLAGS, EXTRACT_VALUE_OPTIONS);
     if (!args.some((arg) => arg === "--apply" || arg.startsWith("--apply="))) {
       problems.push("--apply <draft.json> is required");
+    } else if (option(args, "--apply") === "") {
+      // `--apply=` slips past the missing-value check with an empty string,
+      // which would resolve to the cwd instead of failing loudly.
+      problems.push("--apply requires a value");
     }
     if (problems.length > 0) {
       console.error(`vendo extract: ${problems.join("; ")}\n\n${HELP}`);

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -3,6 +3,7 @@ import { pathToFileURL } from "node:url";
 import { runCloud } from "./cli/cloud/index.js";
 import { runDoctor } from "./cli/doctor.js";
 import { runEject } from "./cli/eject.js";
+import { runExtractApply } from "./cli/extract/apply.js";
 import { runInit } from "./cli/init.js";
 import { runMcp } from "./cli/mcp/index.js";
 import { runPlayground } from "./cli/playground.js";
@@ -21,13 +22,15 @@ Commands:
 Advanced:
   sync [dir]      Re-extract tools and baselines (init hooks this into predev/prebuild; --strict is the CI gate)
   eject <surface> [dir]  Copy a shipped chrome surface's presentation source into your repo (--list to see surfaces)
+  extract [dir]   Apply a coding agent's extraction draft through the deterministic guards (--apply <draft.json>)
   refine [dir]    Propose compound capabilities, risk corrections, and brief updates as reviewable diffs
   playground      Render every Vendo surface against scripted data in the browser — no model key needed
   mcp <command>   Generate MCP registry discovery and domain-verification files
   cloud <command> Use the public Vendo Cloud API
 
 Options:
-  --agent                    Init only: print a read-only JSON plan — code changes, extracted tools, risk recommendations
+  --agent                    Init only: print a read-only JSON plan — code changes, extracted tools, risk recommendations, the aiPolish delegation contract
+  --apply <draft.json>       Extract only: draft file an external agent produced from the plan's aiPolish contract
   --yes                      Init: skip the cloud-login offer; refine: approve displayed diffs; doctor: auto-start the dev server
   --force                    Init/server-json: overwrite owned or generated files; eject: overwrite an ejected dir
   --list                     Eject only: show the ejectable surfaces
@@ -61,18 +64,20 @@ function options(args: string[], name: string): string[] {
 
 const INIT_FLAGS = new Set(["--agent", "--yes", "--force"]);
 const INIT_VALUE_OPTIONS: string[] = [];
+const EXTRACT_FLAGS = new Set(["--force"]);
+const EXTRACT_VALUE_OPTIONS = ["--apply"];
 
-/** ENG-335: init options the CLI does not recognize — or value options missing
+/** ENG-335: options the CLI does not recognize — or value options missing
     their value — must fail loudly before anything runs. Silently dropping a
     flag is how the "--agent writes nothing" promise broke in the field: an
     older CLI ignored --agent and ran a full, writing init. */
-function initOptionErrors(args: string[]): string[] {
+function optionErrors(args: string[], flags: Set<string>, valueOptions: string[]): string[] {
   const errors: string[] = [];
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index]!;
     if (!arg.startsWith("--")) continue;
-    if (INIT_FLAGS.has(arg)) continue;
-    if (INIT_VALUE_OPTIONS.includes(arg)) {
+    if (flags.has(arg)) continue;
+    if (valueOptions.includes(arg)) {
       // A value that looks like another flag is a missing value, not a value —
       // otherwise `--model-import --force` proceeds with modelImport "--force".
       const value = args[index + 1];
@@ -80,7 +85,7 @@ function initOptionErrors(args: string[]): string[] {
       else index += 1;
       continue;
     }
-    if (INIT_VALUE_OPTIONS.some((name) => arg.startsWith(`${name}=`))) continue;
+    if (valueOptions.some((name) => arg.startsWith(`${name}=`))) continue;
     errors.push(`unknown option: ${arg}`);
   }
   return errors;
@@ -115,7 +120,7 @@ function playgroundOptionErrors(args: string[]): { errors: string[]; port?: numb
 
 function target(args: string[]): string {
   const optionValues = new Set<string>();
-  for (const name of ["--model-import", "--url", "--brief", "--key", "--api-url", "--ask"]) {
+  for (const name of ["--model-import", "--url", "--brief", "--key", "--api-url", "--ask", "--apply"]) {
     for (let index = 0; index < args.length; index += 1) {
       if (args[index] === name && args[index + 1] !== undefined) optionValues.add(args[index + 1]!);
     }
@@ -136,7 +141,7 @@ export async function main(argv: string[]): Promise<number> {
   if (command === "cloud") return runCloud(args);
   if (command === "mcp") return runMcp(args);
   if (command === "init") {
-    const problems = initOptionErrors(args);
+    const problems = optionErrors(args, INIT_FLAGS, INIT_VALUE_OPTIONS);
     if (problems.length > 0) {
       console.error(`vendo init: ${problems.join("; ")}\n\n${HELP}`);
       return 1;
@@ -145,6 +150,21 @@ export async function main(argv: string[]): Promise<number> {
       targetDir: target(args),
       agent: args.includes("--agent"),
       yes: args.includes("--yes"),
+      force: args.includes("--force"),
+    });
+  }
+  if (command === "extract") {
+    const problems = optionErrors(args, EXTRACT_FLAGS, EXTRACT_VALUE_OPTIONS);
+    if (!args.some((arg) => arg === "--apply" || arg.startsWith("--apply="))) {
+      problems.push("--apply <draft.json> is required");
+    }
+    if (problems.length > 0) {
+      console.error(`vendo extract: ${problems.join("; ")}\n\n${HELP}`);
+      return 1;
+    }
+    return runExtractApply({
+      targetDir: target(args),
+      apply: option(args, "--apply")!,
       force: args.includes("--force"),
     });
   }

--- a/packages/vendo/src/cli/extract/apply.test.ts
+++ b/packages/vendo/src/cli/extract/apply.test.ts
@@ -124,11 +124,29 @@ describe("vendo extract --apply (the delegation surface)", () => {
     expect(await runExtractApply({ targetDir: root, apply: join(root, "nope.json"), output: sink.output, sync: okSync() })).toBe(1);
     expect(sink.errors.join("\n")).toContain("Draft file not found");
 
+    // Non-ENOENT read failures (a directory, permissions) exit honestly too
+    // instead of escaping as an uncaught crash (Greptile P1).
+    expect(await runExtractApply({ targetDir: root, apply: root, output: sink.output, sync: okSync() })).toBe(1);
+    expect(sink.errors.join("\n")).toContain("Draft file unreadable");
+
     const bare = await mkdtemp(join(tmpdir(), "vendo-extract-apply-bare-"));
     cleanup.push(bare);
     const draft = await draftFile(bare, { brief: "b", tools: [] });
     expect(await runExtractApply({ targetDir: bare, apply: draft, output: sink.output, sync: okSync() })).toBe(1);
     expect(sink.errors.join("\n")).toContain("run `vendo init` first");
+  });
+
+  it("exits non-zero honestly when a hand-edited overrides.json cannot be parsed (Devin)", async () => {
+    const root = await fixture();
+    await writeFile(join(root, ".vendo", "overrides.json"), '{"format": "vendo/overrides@1", "tools": {');
+    const draft = await draftFile(root, {
+      brief: "b",
+      tools: [{ name: "host_invoices_list", description: "List invoices." }],
+    });
+    const sink = output();
+    expect(await runExtractApply({ targetDir: root, apply: draft, output: sink.output, sync: okSync() })).toBe(1);
+    expect(sink.errors.join("\n")).toContain("Could not apply the draft");
+    expect(sink.errors.join("\n")).toContain("overrides.json");
   });
 
   it("reports a failed re-sync as non-zero after applying (overrides landed, tools.json is stale)", async () => {

--- a/packages/vendo/src/cli/extract/apply.test.ts
+++ b/packages/vendo/src/cli/extract/apply.test.ts
@@ -1,0 +1,172 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runExtractApply } from "./apply.js";
+import { composeDelegatedInstructions, EXTRACTION_DRAFT_JSON_SCHEMA } from "./delegate.js";
+import type { Output } from "../shared.js";
+
+const cleanup: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+const TOOLS = [
+  { name: "host_invoices_list", description: "GET /api/invoices", risk: "read" as const, method: "GET", path: "/api/invoices" },
+  { name: "host_invoices_create", description: "POST /api/invoices", risk: "write" as const, method: "POST", path: "/api/invoices" },
+  { name: "host_admin_unclassified", description: "Route /api/admin could not be classified", risk: "destructive" as const, disabled: true },
+];
+
+async function fixture(brief?: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-extract-apply-"));
+  cleanup.push(root);
+  await mkdir(join(root, ".vendo"), { recursive: true });
+  await writeFile(join(root, ".vendo", "tools.json"), JSON.stringify({ format: "vendo/tools@1", tools: TOOLS }));
+  await writeFile(join(root, ".vendo", "overrides.json"), JSON.stringify(
+    { format: "vendo/overrides@1", tools: {}, remix: { ignoreSlots: [] } },
+  ));
+  await writeFile(join(root, ".vendo", "brief.md"),
+    `${brief ?? "Describe this product, its users, and the jobs the agent should help them complete."}\n`);
+  return root;
+}
+
+async function draftFile(root: string, content: unknown): Promise<string> {
+  const path = join(root, "draft.json");
+  await writeFile(path, typeof content === "string" ? content : JSON.stringify(content, null, 2));
+  return path;
+}
+
+function output(): { output: Output; logs: string[]; errors: string[] } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return { output: { log: (message) => logs.push(message), error: (message) => errors.push(message) }, logs, errors };
+}
+
+const okSync = () => vi.fn(async () => ({ warnings: [] }));
+
+describe("vendo extract --apply (the delegation surface)", () => {
+  it("applies a valid draft through the guards, re-syncs, and prints the init summary", async () => {
+    const root = await fixture();
+    const draft = await draftFile(root, {
+      brief: "Maple is a consumer bank; users check balances and pay bills.",
+      tools: [
+        { name: "host_invoices_list", description: "List invoices, filterable by status." },
+        { name: "host_invoices_create", description: "Create and send an invoice.", risk: "destructive", critical: true },
+        { name: "host_admin_unclassified", description: "Reset all demo data.", disabled: false, risk: "destructive", reasoning: "handler truncates tables" },
+      ],
+      missedSurfaces: ["/api/webhooks — event ingestion, not extracted"],
+    });
+    const sink = output();
+    const sync = okSync();
+    expect(await runExtractApply({ targetDir: root, apply: draft, output: sink.output, sync })).toBe(0);
+
+    const overrides = JSON.parse(await readFile(join(root, ".vendo", "overrides.json"), "utf8")) as
+      { tools: Record<string, Record<string, unknown>> };
+    expect(overrides.tools["host_invoices_list"]).toEqual({ description: "List invoices, filterable by status." });
+    expect(overrides.tools["host_invoices_create"]).toMatchObject({ risk: "destructive", critical: true });
+    expect(overrides.tools["host_admin_unclassified"]).toMatchObject({ disabled: false, risk: "destructive" });
+    expect(await readFile(join(root, ".vendo", "brief.md"), "utf8")).toContain("consumer bank");
+
+    expect(sync).toHaveBeenCalledWith({ root, out: join(root, ".vendo") });
+    const logs = sink.logs.join("\n");
+    expect(logs).toContain("AI polish applied: 3 descriptions · 1 risk raises · 1 critical marks · 1 tools woken · brief drafted");
+    expect(logs).toContain("missed surface (not extracted yet): /api/webhooks");
+  });
+
+  it("surfaces guard refusals honestly and still exits 0 (the guards worked)", async () => {
+    const root = await fixture();
+    const draft = await draftFile(root, {
+      brief: "b",
+      tools: [
+        { name: "invented_tool", description: "nope" },
+        { name: "host_invoices_create", description: "Create an invoice.", risk: "read" },
+      ],
+    });
+    const sink = output();
+    expect(await runExtractApply({ targetDir: root, apply: draft, output: sink.output, sync: okSync() })).toBe(0);
+    const errors = sink.errors.join("\n");
+    expect(errors).toContain("refused: invented_tool: not an extracted tool");
+    expect(errors).toContain("refused: host_invoices_create: risk downgrade write→read refused");
+    const overrides = JSON.parse(await readFile(join(root, ".vendo", "overrides.json"), "utf8")) as
+      { tools: Record<string, Record<string, unknown>> };
+    expect(overrides.tools["invented_tool"]).toBeUndefined();
+  });
+
+  it("keeps a hand-written brief unless --force, exactly like init", async () => {
+    const root = await fixture("The human already wrote this brief.");
+    const draft = await draftFile(root, { brief: "Model brief.", tools: [] });
+    const sink = output();
+    expect(await runExtractApply({ targetDir: root, apply: draft, output: sink.output, sync: okSync() })).toBe(0);
+    expect(await readFile(join(root, ".vendo", "brief.md"), "utf8")).toContain("human already wrote");
+
+    expect(await runExtractApply({ targetDir: root, apply: draft, force: true, output: sink.output, sync: okSync() })).toBe(0);
+    expect(await readFile(join(root, ".vendo", "brief.md"), "utf8")).toContain("Model brief.");
+  });
+
+  it("exits non-zero with an honest message on a schema-invalid draft", async () => {
+    const root = await fixture();
+    const draft = await draftFile(root, { brief: "", tools: [{ name: "t" }] });
+    const sink = output();
+    expect(await runExtractApply({ targetDir: root, apply: draft, output: sink.output, sync: okSync() })).toBe(1);
+    expect(sink.errors.join("\n")).toContain("Draft rejected");
+    expect(sink.errors.join("\n")).toContain("aiPolish.draftSchema");
+  });
+
+  it("exits non-zero on unparseable JSON, a missing draft file, and a missing tools.json", async () => {
+    const root = await fixture();
+    const sink = output();
+
+    const garbled = await draftFile(root, "not json at all");
+    expect(await runExtractApply({ targetDir: root, apply: garbled, output: sink.output, sync: okSync() })).toBe(1);
+    expect(sink.errors.join("\n")).toContain("Draft rejected");
+
+    expect(await runExtractApply({ targetDir: root, apply: join(root, "nope.json"), output: sink.output, sync: okSync() })).toBe(1);
+    expect(sink.errors.join("\n")).toContain("Draft file not found");
+
+    const bare = await mkdtemp(join(tmpdir(), "vendo-extract-apply-bare-"));
+    cleanup.push(bare);
+    const draft = await draftFile(bare, { brief: "b", tools: [] });
+    expect(await runExtractApply({ targetDir: bare, apply: draft, output: sink.output, sync: okSync() })).toBe(1);
+    expect(sink.errors.join("\n")).toContain("run `vendo init` first");
+  });
+
+  it("reports a failed re-sync as non-zero after applying (overrides landed, tools.json is stale)", async () => {
+    const root = await fixture();
+    const draft = await draftFile(root, {
+      brief: "b",
+      tools: [{ name: "host_invoices_list", description: "List invoices." }],
+    });
+    const sink = output();
+    const sync = vi.fn(async () => { throw new Error("scan blew up"); });
+    expect(await runExtractApply({ targetDir: root, apply: draft, output: sink.output, sync })).toBe(1);
+    expect(sink.errors.join("\n")).toContain("re-sync failed (scan blew up)");
+    const overrides = JSON.parse(await readFile(join(root, ".vendo", "overrides.json"), "utf8")) as
+      { tools: Record<string, Record<string, unknown>> };
+    expect(overrides.tools["host_invoices_list"]).toEqual({ description: "List invoices." });
+  });
+});
+
+describe("the delegation contract", () => {
+  it("composes one-shot instructions carrying the static facts, the guard rules, and the apply command", () => {
+    const instructions = composeDelegatedInstructions(TOOLS, "maple");
+    expect(instructions).toContain("maple");
+    expect(instructions).toContain("host_invoices_list");
+    expect(instructions).toContain('"disabled": true');
+    expect(instructions).toContain("never lower");
+    expect(instructions).toContain('"brief": string');
+    expect(instructions).toContain("vendo extract --apply");
+  });
+
+  it("publishes a draft schema whose shape matches parseDraft's expectations", () => {
+    const schema = EXTRACTION_DRAFT_JSON_SCHEMA as {
+      required: string[];
+      properties: { tools: { items: { required: string[]; properties: Record<string, unknown> } } };
+    };
+    expect(schema.required).toEqual(["brief", "tools"]);
+    expect(schema.properties.tools.items.required).toEqual(["name", "description"]);
+    expect(Object.keys(schema.properties.tools.items.properties)).toEqual(
+      ["name", "description", "risk", "critical", "disabled", "reasoning"],
+    );
+  });
+});

--- a/packages/vendo/src/cli/extract/apply.ts
+++ b/packages/vendo/src/cli/extract/apply.ts
@@ -1,0 +1,85 @@
+import { join, resolve } from "node:path";
+import { z } from "zod";
+import { vendoSync } from "@vendoai/actions";
+import { applyDraft, reportApplied } from "./extraction.js";
+import { parseDraft } from "./harness.js";
+import { staticToolSchema, type StaticTool } from "./stages.js";
+import { consoleOutput, readOptional, type Output } from "../shared.js";
+
+/**
+ * `vendo extract --apply <draft.json>` — the delegation surface. An external
+ * coding agent read the codebase against the aiPolish contract from
+ * `vendo init --agent` and wrote a draft; this command parses it (the same
+ * parseDraft init's built-in pass uses), runs the SAME deterministic guards
+ * (applyDraft), writes the same artifacts, re-syncs, and prints the same
+ * summary. Non-interactive safe; exits non-zero on an unusable draft.
+ */
+
+export interface ExtractApplyOptions {
+  targetDir: string;
+  /** Path to the draft file (cwd-relative or absolute). */
+  apply: string;
+  force?: boolean;
+  output?: Output;
+  /** Test seam (matches sync.ts): the re-sync implementation. */
+  sync?: (input: { root: string; out: string }) => Promise<{ warnings: string[] }>;
+}
+
+function describeError(error: unknown): string {
+  if (error instanceof z.ZodError) {
+    return error.issues
+      .slice(0, 5)
+      .map((issue) => `${issue.path.join(".") || "draft"}: ${issue.message}`)
+      .join("; ");
+  }
+  return error instanceof Error ? error.message : "unknown error";
+}
+
+export async function runExtractApply(options: ExtractApplyOptions): Promise<number> {
+  const output = options.output ?? consoleOutput;
+  const root = resolve(options.targetDir);
+
+  const toolsRaw = await readOptional(join(root, ".vendo", "tools.json"));
+  if (toolsRaw === null) {
+    output.error("No .vendo/tools.json here — run `vendo init` first, then apply the draft.");
+    return 1;
+  }
+  let tools: StaticTool[];
+  try {
+    tools = z.object({ tools: z.array(staticToolSchema) }).parse(JSON.parse(toolsRaw)).tools;
+  } catch (error) {
+    output.error(`.vendo/tools.json is unreadable (${describeError(error)}) — run \`vendo sync\` and try again.`);
+    return 1;
+  }
+
+  const draftRaw = await readOptional(resolve(options.apply));
+  if (draftRaw === null) {
+    output.error(`Draft file not found: ${options.apply}`);
+    return 1;
+  }
+  let draft: ReturnType<typeof parseDraft>;
+  try {
+    draft = parseDraft(draftRaw);
+  } catch (error) {
+    output.error(`Draft rejected — it must match the aiPolish.draftSchema from \`vendo init --agent\` (${describeError(error)}).`);
+    return 1;
+  }
+
+  const applied = await applyDraft({
+    root,
+    draft,
+    tools,
+    ...(options.force === undefined ? {} : { force: options.force }),
+  });
+  // Same as init's built-in pass: a successful apply re-syncs so tools.json
+  // reflects the polish immediately.
+  try {
+    const resynced = await (options.sync ?? vendoSync)({ root, out: join(root, ".vendo") });
+    for (const warning of resynced.warnings) output.error(`warning: ${warning}`);
+  } catch (error) {
+    output.error(`Draft applied, but re-sync failed (${describeError(error)}) — run \`vendo sync\` to refresh tools.json.`);
+    return 1;
+  }
+  reportApplied({ output, applied, briefDrafted: applied.briefWritten });
+  return 0;
+}

--- a/packages/vendo/src/cli/extract/apply.ts
+++ b/packages/vendo/src/cli/extract/apply.ts
@@ -52,7 +52,15 @@ export async function runExtractApply(options: ExtractApplyOptions): Promise<num
     return 1;
   }
 
-  const draftRaw = await readOptional(resolve(options.apply));
+  // readOptional only maps ENOENT to null — a directory (EISDIR) or a
+  // permission error must still exit honestly, not as an uncaught crash.
+  let draftRaw: string | null;
+  try {
+    draftRaw = await readOptional(resolve(options.apply));
+  } catch (error) {
+    output.error(`Draft file unreadable: ${options.apply} (${describeError(error)})`);
+    return 1;
+  }
   if (draftRaw === null) {
     output.error(`Draft file not found: ${options.apply}`);
     return 1;
@@ -65,12 +73,20 @@ export async function runExtractApply(options: ExtractApplyOptions): Promise<num
     return 1;
   }
 
-  const applied = await applyDraft({
-    root,
-    draft,
-    tools,
-    ...(options.force === undefined ? {} : { force: options.force }),
-  });
+  // applyDraft throws on a hand-edited overrides.json it cannot parse — the
+  // same honest-exit contract applies, never an unhandled stack trace.
+  let applied: Awaited<ReturnType<typeof applyDraft>>;
+  try {
+    applied = await applyDraft({
+      root,
+      draft,
+      tools,
+      ...(options.force === undefined ? {} : { force: options.force }),
+    });
+  } catch (error) {
+    output.error(`Could not apply the draft (${describeError(error)}) — check .vendo/overrides.json and re-apply.`);
+    return 1;
+  }
   // Same as init's built-in pass: a successful apply re-syncs so tools.json
   // reflects the polish immediately.
   try {

--- a/packages/vendo/src/cli/extract/delegate.ts
+++ b/packages/vendo/src/cli/extract/delegate.ts
@@ -1,0 +1,81 @@
+import { staticFacts, type StaticTool } from "./stages.js";
+
+/**
+ * The delegated-extraction contract (install-dx: external-agent delegation).
+ * Vendo's IP is the CONTRACT — the composed instructions, the draft schema,
+ * and the deterministic guards — not the reader: any competent coding agent
+ * (Claude Code, Cursor, Codex, …) can do the reading. `vendo init --agent`
+ * emits this contract in its plan; the dev's own agent reads the codebase,
+ * writes a draft, and `vendo extract --apply` runs it through the SAME
+ * applyDraft guards as init's built-in pass — delegation never becomes a
+ * second, weaker path into `.vendo/`.
+ */
+
+export const APPLY_COMMAND = "npx vendo extract --apply <draft.json>";
+
+/** JSON Schema mirror of extractionDraftSchema in harness.ts (hand-kept in
+ *  sync — zod v3 has no schema emitter). Stricter than parseDraft on unknown
+ *  keys, deliberately: the contract steers agents to the exact shape while
+ *  apply stays lenient. */
+export const EXTRACTION_DRAFT_JSON_SCHEMA: Record<string, unknown> = {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  type: "object",
+  additionalProperties: false,
+  required: ["brief", "tools"],
+  properties: {
+    brief: {
+      type: "string",
+      minLength: 1,
+      maxLength: 4000,
+      description: "One-paragraph product brief drafted from the codebase.",
+    },
+    tools: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["name", "description"],
+        properties: {
+          name: { type: "string", minLength: 1 },
+          description: { type: "string", minLength: 1, maxLength: 500 },
+          risk: { enum: ["read", "write", "destructive"] },
+          critical: { type: "boolean" },
+          disabled: {
+            type: "boolean",
+            description: "false = wake a statically-unclassifiable tool (requires reasoning and risk).",
+          },
+          reasoning: { type: "string", maxLength: 500 },
+        },
+      },
+    },
+    missedSurfaces: {
+      type: "array",
+      items: { type: "string", maxLength: 300 },
+      description: "API surfaces the static extractor missed (path + one line). Surfaced to the dev, never written.",
+    },
+  },
+};
+
+/** One-shot instructions for an external agent producing the FULL draft
+ *  (judgment on every tool plus the brief) — the same rules the staged
+ *  pipeline enforces per stage, phrased for a single delegated pass. */
+export function composeDelegatedInstructions(tools: StaticTool[], appName: string): string {
+  return [
+    "You are Vendo's extraction agent. Read this codebase (Read/Glob/Grep only) and draft",
+    "judgment on the API tools a static extractor already found, plus the product brief.",
+    "",
+    `Product/package name: ${appName}`,
+    "Statically extracted tools (name, method+path when known, current risk, disabled state):",
+    staticFacts(tools),
+    "",
+    "Rules:",
+    "- Produce ONE json document matching the provided draftSchema:",
+    '  { "brief": string, "tools": [{ "name", "description", "risk"?, "critical"?, "disabled"?, "reasoning"? }], "missedSurfaces"?: string[] }',
+    "- tools: include ONLY names from the list above. Rewrite each description so an agent choosing tools understands what it actually does (read the handler source). <= 200 chars each.",
+    "- risk: you may RAISE risk (read->write->destructive) when the handler is more dangerous than labeled; never lower it. Mark irreversible operations critical: true.",
+    "- A tool listed as disabled was statically unclassifiable. If you can read its handler and grade it, set disabled: false WITH a risk and one-line reasoning. Leave it out otherwise.",
+    "- missedSurfaces: API surfaces you found that the list is missing (path + one line). Do not invent tools for them.",
+    "- brief: one paragraph — what the product does, who uses it, the jobs the agent should help with. Written from the actual code, no marketing fluff.",
+    `- Save the draft to a json file and apply it with \`${APPLY_COMMAND}\` — deterministic guards validate every entry before anything lands in .vendo/.`,
+  ].join("\n");
+}

--- a/packages/vendo/src/cli/extract/extraction.ts
+++ b/packages/vendo/src/cli/extract/extraction.ts
@@ -43,7 +43,7 @@ const overridesSchema = z.object({
 }).passthrough();
 type Overrides = z.infer<typeof overridesSchema>;
 
-interface AppliedSummary {
+export interface AppliedSummary {
   described: number;
   riskRaised: number;
   critical: number;
@@ -127,6 +127,29 @@ export async function applyDraft(input: {
     summary.briefWritten = true;
   }
   return summary;
+}
+
+/** The one applied-polish summary both init's built-in pass and
+ *  `vendo extract --apply` print — delegation must read identically. */
+export function reportApplied(input: {
+  output: Output;
+  applied: AppliedSummary;
+  briefDrafted: boolean;
+  artifactsNote?: string;
+  notes?: string[];
+}): void {
+  const { output, applied } = input;
+  const parts = [
+    `${applied.described} descriptions`,
+    ...(applied.riskRaised > 0 ? [`${applied.riskRaised} risk raises`] : []),
+    ...(applied.critical > 0 ? [`${applied.critical} critical marks`] : []),
+    ...(applied.woken > 0 ? [`${applied.woken} tools woken`] : []),
+    ...(input.briefDrafted ? ["brief drafted"] : []),
+  ];
+  output.log(`AI polish applied: ${parts.join(" · ")} → .vendo/overrides.json, .vendo/brief.md${input.artifactsNote ?? ""}`);
+  for (const note of input.notes ?? []) output.error(`  ${note}`);
+  for (const refused of applied.refused) output.error(`  refused: ${refused}`);
+  for (const missed of applied.missedSurfaces) output.log(`  missed surface (not extracted yet): ${missed}`);
 }
 
 async function askYesNo(question: string, defaultYes: boolean): Promise<boolean> {
@@ -213,17 +236,13 @@ export async function runAiExtraction(options: AiExtractionOptions): Promise<{ r
       onProgress: (line) => output.log(`  ${line}`),
     });
     const applied = await applyDraft({ root, draft: staged.draft, tools, ...(options.force === undefined ? {} : { force: options.force }) });
-    const parts = [
-      `${applied.described} descriptions`,
-      ...(applied.riskRaised > 0 ? [`${applied.riskRaised} risk raises`] : []),
-      ...(applied.critical > 0 ? [`${applied.critical} critical marks`] : []),
-      ...(applied.woken > 0 ? [`${applied.woken} tools woken`] : []),
-      ...(applied.briefWritten && staged.briefFromStage ? ["brief drafted"] : []),
-    ];
-    output.log(`AI polish applied: ${parts.join(" · ")} → .vendo/overrides.json, .vendo/brief.md (stage artifacts: .vendo/data/extract/)`);
-    for (const note of staged.notes) output.error(`  ${note}`);
-    for (const refused of applied.refused) output.error(`  refused: ${refused}`);
-    for (const missed of applied.missedSurfaces) output.log(`  missed surface (not extracted yet): ${missed}`);
+    reportApplied({
+      output,
+      applied,
+      briefDrafted: applied.briefWritten && staged.briefFromStage,
+      artifactsNote: " (stage artifacts: .vendo/data/extract/)",
+      notes: staged.notes,
+    });
     return { ran: true };
   } catch (error) {
     output.error(`AI polish did not complete (${error instanceof Error ? error.message : "unknown error"}); extractor defaults stand. Re-run \`vendo init\` to retry — stage artifacts in .vendo/data/extract/ show how far it got.`);

--- a/packages/vendo/src/cli/extract/stages.ts
+++ b/packages/vendo/src/cli/extract/stages.ts
@@ -78,7 +78,7 @@ export const briefSchema = z.object({
  *  survey must not turn into a runaway number of model calls. */
 const MAX_SURFACES = 12;
 
-function staticFacts(tools: StaticTool[]): string {
+export function staticFacts(tools: StaticTool[]): string {
   return JSON.stringify(tools.map((tool) => ({
     name: tool.name,
     ...(tool.method === undefined ? {} : { method: tool.method }),

--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -390,6 +390,7 @@ describe("vendo init (zero-question)", () => {
       manualSteps: string[];
       extraction: { tools: unknown[]; warnings: string[] };
       riskRecommendations: unknown[];
+      aiPolish: { instructions: string; draftSchema: Record<string, unknown>; apply: string };
     };
     expect(plan.framework).toBe("next");
     expect(plan.writes).toContain(".vendo/tools.json");
@@ -398,6 +399,12 @@ describe("vendo init (zero-question)", () => {
     expect(plan.manualSteps.join("\n")).toContain("<VendoRoot");
     expect(Array.isArray(plan.extraction.tools)).toBe(true);
     expect(Array.isArray(plan.riskRecommendations)).toBe(true);
+    // The delegation contract rides the plan: instructions an external agent
+    // executes, the draft schema, and the apply command that runs the guards.
+    expect(plan.aiPolish.instructions).toContain("never lower");
+    expect(plan.aiPolish.instructions).toContain("Statically extracted tools");
+    expect(plan.aiPolish.draftSchema).toMatchObject({ type: "object", required: ["brief", "tools"] });
+    expect(plan.aiPolish.apply).toContain("vendo extract --apply");
     expect(await tree(root)).toEqual(before); // --agent wrote nothing
   });
 });

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -16,7 +16,9 @@ import type { VendoTheme } from "@vendoai/core";
 import type { Telemetry } from "@vendoai/telemetry";
 import type { LanguageModel } from "ai";
 import { runCloudStep, type CloudStepOptions } from "./cloud-init.js";
+import { APPLY_COMMAND, composeDelegatedInstructions, EXTRACTION_DRAFT_JSON_SCHEMA } from "./extract/delegate.js";
 import { runAiExtraction, type AiExtractionOptions } from "./extract/extraction.js";
+import type { StaticTool } from "./extract/stages.js";
 import { resolveDevCredential, describeDevCredential, type DevCredential } from "../dev-creds/resolve.js";
 import { detectFramework, detectVendoWiring, type HostFramework } from "./framework.js";
 import { resolveRefineModel } from "./refine.js";
@@ -101,6 +103,11 @@ export interface InitPlan {
       real tool names instead of re-deriving them. */
   extraction?: { tools: ExtractedTool[]; warnings: string[] };
   riskRecommendations?: RiskRecommendation[];
+  /** --agent only: the delegated AI-polish contract. An external coding agent
+      reads the codebase against `instructions`, writes a draft matching
+      `draftSchema`, and lands it with `apply` — the SAME deterministic guards
+      as init's built-in pass decide what applies. */
+  aiPolish?: { instructions: string; draftSchema: Record<string, unknown>; apply: string };
 }
 
 export interface InitOptions {
@@ -498,6 +505,22 @@ async function extractForPlan(root: string): Promise<{ tools: ExtractedTool[]; w
   }
 }
 
+/** Project extraction results onto the small static-facts shape the
+    delegation instructions carry (route bindings surface method+path). */
+function planStaticTools(tools: ExtractedTool[]): StaticTool[] {
+  return tools.map((tool) => {
+    const binding = tool.binding as { method?: unknown; path?: unknown };
+    return {
+      name: tool.name,
+      description: tool.description,
+      risk: tool.risk,
+      ...(tool.disabled === true ? { disabled: true } : {}),
+      ...(typeof binding.method === "string" ? { method: binding.method } : {}),
+      ...(typeof binding.path === "string" ? { path: binding.path } : {}),
+    };
+  });
+}
+
 /** 04-actions §1 risk ladder projected as advice: destructive asks first,
     writes get reviewed, reads auto-run (no entry). */
 function riskRecommendations(tools: ExtractedTool[]): RiskRecommendation[] {
@@ -687,10 +710,24 @@ export async function runInit(options: InitOptions): Promise<number> {
     // names and risk advice; the throwaway out dir keeps --agent read-only.
     const { plan } = await buildPlan(options);
     const extraction = await extractForPlan(root);
+    let appName = "app";
+    try {
+      appName = (JSON.parse((await readOptional(join(root, "package.json"))) ?? "{}") as { name?: string }).name ?? "app";
+    } catch {
+      // package.json is optional context
+    }
     output.log(JSON.stringify({
       ...plan,
       extraction,
       riskRecommendations: riskRecommendations(extraction.tools),
+      // The delegation contract: the agent reading this plan can do the AI
+      // polish itself and land it through `vendo extract --apply` — the same
+      // deterministic guards as init's built-in pass.
+      aiPolish: {
+        instructions: composeDelegatedInstructions(planStaticTools(extraction.tools), appName),
+        draftSchema: EXTRACTION_DRAFT_JSON_SCHEMA,
+        apply: APPLY_COMMAND,
+      },
     } satisfies InitPlan, null, 2));
     return 0;
   }


### PR DESCRIPTION
## What

Lane 5 of the install-dx program: external-agent delegation for AI extraction. Vendo's IP is the CONTRACT (instructions + deterministic guards + artifact schema); any competent coding agent can execute it.

- **`vendo init --agent` grows the delegation contract**: the read-only JSON plan now carries an `aiPolish` object — the composed one-shot extraction `instructions` (static tool facts + the same drafting/risk/wake/brief rules the staged pipeline enforces), the draft JSON `draftSchema` (hand-kept mirror of `extractionDraftSchema`), and the `apply` command.
- **New apply surface: `vendo extract --apply <draft.json>`** — parses the draft with the same `parseDraft`, runs the SAME deterministic `applyDraft` guards (only extracted tool names accepted, risk raised never lowered, wakes need reasoning + an explicit grade, human decisions win), writes the same artifacts (`.vendo/overrides.json`, `.vendo/brief.md`), re-syncs, and prints init's exact summary via a shared reporter. Non-interactive safe; exits non-zero on an unusable draft (missing file, unreadable JSON, schema mismatch, failed re-sync) with honest errors. Guard refusals surface per entry while the rest applies. `--force` replaces a hand-edited brief, exactly like `vendo init --force`. Follows the ENG-335 loud-unknown-flags posture.
- **vendo-setup skill** documents the loop for a host's coding agent: `init --agent` → read instructions → draft → `extract --apply`.
- **Docs**: quickstart's AI-polish section gains the bring-your-own-agent path.

Scope discipline: the staged pipeline's internals and harnesses are untouched (only a `staticFacts` export and a shared `reportApplied` summary formatter were lifted); the guards remain the single gate — delegation is not a second, weaker path into `.vendo/`.

## Tests

- Plan-shape test extended: `aiPolish` instructions/draftSchema/apply on the `--agent` plan (and `--agent` still writes nothing).
- New `apply.test.ts`: valid draft applies through guards + re-sync + summary; refusals surface with exit 0; schema-invalid/unparseable/missing draft and missing tools.json exit 1 with clear messages; hand-written brief kept unless `--force`; failed re-sync exits 1 after applying. Contract tests for instructions + schema shape. No live model calls.
- CLI routing test: `--apply` required, unknown flags fail loudly, help documents the verb.
- Verified end-to-end with the real CLI against a scratch Next fixture: `init --agent` emitted real tool names + the contract; a crafted draft applied through the guards (invented tool refused), re-synced, and printed the standard summary; bad/missing drafts exited 1.

`pnpm build && pnpm test && pnpm typecheck && pnpm lint` all green locally.

https://claude.ai/code/session_01BGEToaxHwdacENhmySG3VB
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables external coding agents to polish extraction via a portable contract and a guarded apply path, with stricter CLI validation and honest error exits. Adds `vendo extract --apply` and extends `vendo init --agent` to include an `aiPolish` contract; delegation goes through the same deterministic guards.

- New Features
  - `vendo init --agent` plan now includes `aiPolish`: `instructions`, `draftSchema`, and the `apply` command.
  - New `vendo extract --apply <draft.json>`: parses the draft, runs the same guards, writes `.vendo/overrides.json` and `.vendo/brief.md`, re-syncs, and prints the standard summary. Exits non-zero on unusable drafts; `--force` overwrites a hand-edited brief.
  - CLI posture: `--apply` is required; unknown flags fail loudly (ENG-335).
  - Shared summary reporter and `staticFacts` export; staged pipeline unchanged.
  - Quickstart and `vendo-setup` skill document the init → draft → apply loop.

- Bug Fixes
  - Non-ENOENT draft read failures (e.g., directory, permissions) exit 1 with a clear reason instead of crashing.
  - Malformed `.vendo/overrides.json` now reports a readable error and exits 1 during apply.
  - `--apply=` (empty value) fails loudly rather than resolving to the current directory.

<sup>Written for commit 42f809387c638d595f44d7a5c2ff1dad3dcc29bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

