### PR TITLE
small fixes: loadEncode retry-after-install + act-as-presets doc API corrections

### DIFF
--- a/docs-site/connect/act-as-presets.mdx
+++ b/docs-site/connect/act-as-presets.mdx
@@ -101,7 +101,8 @@ configurable claims and header shape.
 Import the preset you want and hand it to `createVendo` as `actAs`. Each
 preset closes over a secret you provision (session secret, project JWT
 secret, or a host-generated away secret) and returns the `ActAs` function
-Vendo calls before every away tool call.
+Vendo calls before every away tool call. Clerk and Auth0 return a preset
+object instead — pass its `actAs` half.
 
 ```ts
 import { createVendo } from "@vendoai/vendo/server";
@@ -126,7 +127,7 @@ should stamp on each minted token:
 import { supabasePreset } from "@vendoai/actions/presets";
 
 actAs: supabasePreset({
-  jwtSecret: process.env.SUPABASE_JWT_SECRET!,
+  secret: process.env.SUPABASE_JWT_SECRET!,
   role: "authenticated",
   audience: "authenticated",
 });
@@ -138,23 +139,24 @@ share with the verify middleware in the next section:
 ```ts
 import { clerkPreset } from "@vendoai/actions/presets";
 
-actAs: clerkPreset({
-  awaySecret: process.env.VENDO_AWAY_SECRET!,
+const clerk = clerkPreset({
+  secret: process.env.VENDO_AWAY_TOKEN_SECRET!,
 });
+
+// in createVendo:
+actAs: clerk.actAs,
 ```
 
-The generic preset covers anything else. Configure the claims map, header
-name, and prefix your host API expects:
+The generic preset covers anything else. Configure the claims map and the
+headers your host API expects (the default is `Authorization: Bearer`):
 
 ```ts
 import { genericJwtPreset } from "@vendoai/actions/presets";
 
 actAs: genericJwtPreset({
   secret: process.env.HOST_JWT_SECRET!,
-  header: "authorization",
-  prefix: "Bearer ",
+  headers: (token) => ({ authorization: `Bearer ${token}` }),
   claims: (principal) => ({
-    sub: principal.subject,
     scope: "api:call",
   }),
 });
@@ -171,9 +173,11 @@ middleware and an Express middleware — mount the one that fits your app.
 // middleware.ts (Next.js)
 import { clerkPreset } from "@vendoai/actions/presets";
 
-export const middleware = clerkPreset.nextMiddleware({
-  awaySecret: process.env.VENDO_AWAY_SECRET!,
+const clerk = clerkPreset({
+  secret: process.env.VENDO_AWAY_TOKEN_SECRET!,
 });
+
+export const middleware = clerk.nextMiddleware;
 
 export const config = { matcher: "/api/:path*" };
 ```
@@ -183,10 +187,12 @@ export const config = { matcher: "/api/:path*" };
 import express from "express";
 import { auth0Preset } from "@vendoai/actions/presets";
 
+const auth0 = auth0Preset({
+  secret: process.env.VENDO_AWAY_TOKEN_SECRET!,
+});
+
 const app = express();
-app.use(auth0Preset.expressMiddleware({
-  awaySecret: process.env.VENDO_AWAY_SECRET!,
-}));
+app.use(auth0.expressMiddleware);
 ```
 
 Middleware does three things on every request:
@@ -199,8 +205,9 @@ Middleware does three things on every request:
 - Rejects forged, expired, or wrong-audience tokens before your handler
   runs.
 
-The `awaySecret` you pass to the preset and the middleware must match. Store
-it as an environment variable and rotate by redeploying both halves.
+The `secret` the producer and the middleware constructions read must match
+(both default to the `VENDO_AWAY_TOKEN_SECRET` env variable). Store it as an
+environment variable and rotate by redeploying both halves.
 
 ## Impersonation guard
 
@@ -213,7 +220,7 @@ preset — you don't wire it separately.
 ## Token caching and rotation
 
 Every preset caches minted tokens in memory until just before expiry (default
-300 s safety margin, 30 s for the short-lived away tokens). Cache keys
+300 s token lifetime, refreshed 30 s before expiry). Cache keys
 include a fingerprint of the signing secret, so rotating the secret
 invalidates the cache immediately — the next away call mints against the new
 secret. Expired entries are dropped on write, so the cache size stays bounded

--- a/packages/actions/src/presets/auth-js.retry.test.ts
+++ b/packages/actions/src/presets/auth-js.retry.test.ts
@@ -1,0 +1,64 @@
+import type { PermissionGrant, Principal } from "@vendoai/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const principal: Principal = { kind: "user", subject: "user_authjs_retry" };
+const grant: PermissionGrant = {
+  id: "grt_authjs_retry",
+  subject: principal.subject,
+  tool: "host_profile",
+  descriptorHash: "sha256:authjs-retry",
+  scope: { kind: "tool" },
+  duration: "standing",
+  source: "automation",
+  grantedAt: "2026-07-14T00:00:00.000Z",
+};
+const secret = "authjs-secret-for-retry-verification";
+const cookieName = "authjs.session-token";
+
+/** Simulate `@auth/core` not being installed: the dynamic import rejects the
+    way Node rejects a missing package. */
+function mockAuthCoreMissing(): void {
+  vi.doMock("@auth/core/jwt", () => {
+    const error = new Error(
+      "Cannot find package '@auth/core' imported from packages/actions/src/presets/auth-js.ts",
+    ) as Error & { code: string };
+    error.code = "ERR_MODULE_NOT_FOUND";
+    throw error;
+  });
+}
+
+async function loadPreset(): Promise<typeof import("./auth-js.js")> {
+  return await import("./auth-js.js");
+}
+
+describe("authJsPreset @auth/core loading", () => {
+  afterEach(() => {
+    vi.doUnmock("@auth/core/jwt");
+    vi.resetModules();
+  });
+
+  it("rejects a missing @auth/core with an actionable install instruction", async () => {
+    mockAuthCoreMissing();
+    vi.resetModules();
+    const { authJsPreset } = await loadPreset();
+    const actAs = authJsPreset({ secret, cookieName });
+
+    await expect(actAs(principal, grant)).rejects.toThrow(/npm install @auth\/core/);
+  });
+
+  it("retries the import on the SAME preset instance after @auth/core is installed", async () => {
+    mockAuthCoreMissing();
+    vi.resetModules();
+    const { authJsPreset } = await loadPreset();
+    const actAs = authJsPreset({ secret, cookieName });
+
+    await expect(actAs(principal, grant)).rejects.toThrow(/npm install @auth\/core/);
+
+    // "Install" the package: the real module resolves from here on.
+    vi.doUnmock("@auth/core/jwt");
+    vi.resetModules();
+
+    const material = await actAs(principal, grant);
+    expect(material?.headers.cookie).toMatch(/^authjs\.session-token=/);
+  });
+});

--- a/packages/actions/src/presets/auth-js.ts
+++ b/packages/actions/src/presets/auth-js.ts
@@ -30,6 +30,13 @@ export interface AuthJsPresetOptions {
   cacheSafetySeconds?: number;
 }
 
+/** `@auth/core` is an optional peerDependency loaded lazily on first mint — a
+    host wiring this preset already runs Auth.js, so it is present next to their
+    auth setup. The failure is an actionable install instruction, not a bare
+    module-not-found. */
+const MISSING_AUTH_CORE_MESSAGE =
+  "authJsPreset() mints Auth.js sessions through @auth/core, which is not installed. Install it alongside your Auth.js setup: npm install @auth/core";
+
 /** Mint an Auth.js v5 encrypted session JWE using @auth/core's own encoder. */
 export function authJsPreset(options: AuthJsPresetOptions = {}): ActAs {
   const expiresInSeconds = options.expiresInSeconds ?? 300;
@@ -40,8 +47,13 @@ export function authJsPreset(options: AuthJsPresetOptions = {}): ActAs {
   const cache = new TokenCache();
   let encodePromise: Promise<AuthJsEncode> | undefined;
   const loadEncode = (): Promise<AuthJsEncode> => {
-    encodePromise ??= import("@auth/core/jwt")
-      .then((module) => module.encode as unknown as AuthJsEncode);
+    encodePromise ??= import("@auth/core/jwt").then(
+      (module) => module.encode as unknown as AuthJsEncode,
+      (cause) => {
+        encodePromise = undefined; // let a later call retry after an install
+        throw new Error(MISSING_AUTH_CORE_MESSAGE, { cause: cause as Error });
+      },
+    );
     return encodePromise;
   };
 


### PR DESCRIPTION
Follow-up batch from the PR #376 review list.

## What

**1. `authJsPreset` loadEncode retries after install** (`packages/actions/src/presets/auth-js.ts`)

The lazy `import("@auth/core/jwt")` cached a REJECTED promise permanently: after `npm install @auth/core`, every later mint in the same process kept replaying the original module-not-found. Now mirrors the vendo auth-presets `loadGetToken` pattern — the cache resets on rejection so a later call retries, and the failure is the actionable `npm install @auth/core` instruction (original error preserved as `cause`). TDD: `auth-js.retry.test.ts` proves the first call rejects actionably while the module is missing and a retry on the SAME preset instance succeeds once it resolves.

**2. `docs-site/connect/act-as-presets.mdx` per-seam API corrections** (each verified against `packages/actions/src/presets/` before changing)

- `supabasePreset({ jwtSecret })` → real option `secret`
- `clerkPreset({ awaySecret })` → real option `secret`; env `VENDO_AWAY_SECRET` → real default `VENDO_AWAY_TOKEN_SECRET`
- `clerkPreset.nextMiddleware({...})` / `auth0Preset.expressMiddleware({...})` were called as statics taking options — they are instance halves of the object the preset constructor returns; now shown construct-then-mount
- `actAs: clerkPreset({...})` passed the whole `AwayTokenPreset` object as `ActAs` — real shape is the `.actAs` half
- `genericJwtPreset({ header, prefix })` — those options don't exist; the real seam is `headers: (token) => Record<string, string>`
- Caching numbers were swapped: 300 s is the default token LIFETIME (all presets), 30 s the refresh safety margin — not "300 s safety margin, 30 s for away tokens"
- `awaySecret`-matching prose updated to the real `secret` option + `VENDO_AWAY_TOKEN_SECRET` default

Claims verified correct and left alone: `authJsPreset` snippet options, supabase `role`/`audience` defaults, preset table, `act-as-subject-mismatch` / `not-implemented` outcomes, secret-fingerprint cache keys, expired-entry eviction on write, doctor's actAs round-trip probe.

## Verify

- `turbo run test --filter=@vendoai/actions`: 331 passed, 4 skipped (35 files, incl. the 2 new retry tests)
- `turbo run typecheck --filter=@vendoai/actions`: green
- `packages/vendo` auth-presets suite (wraps the changed error path): 87 passed

https://claude.ai/code/session_018S4HHYRGSGyDXwNGo3oJWS

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a permanent failure when `authJsPreset` lazily imports `@auth/core` and it's installed later, and aligns the act-as preset docs with the actual API. This removes the need to restart after installing `@auth/core` and clarifies Clerk/Auth0 and generic JWT wiring.

- **Bug Fixes**
  - `authJsPreset`: if the `@auth/core` import fails, the rejected promise is no longer cached; later calls retry after install. Error now instructs to run `npm install @auth/core`. Added retry tests.
  - Docs (`docs-site/connect/act-as-presets.mdx`): corrected options (`jwtSecret`→`secret`, `awaySecret`→`secret` with `VENDO_AWAY_TOKEN_SECRET` default), show construct-then-mount for Clerk/Auth0 and passing `.actAs`, use `headers(token)` for `genericJwtPreset`, and fix cache timing (300 s lifetime, refresh 30 s before expiry).

<sup>Written for commit f1ac212be818977c0abceafec3e3b265d7e5635e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

