### PR TITLE
supabase() preset: hybrid HS256 + ES256/JWKS verification; demo-accounting adopts auth: supabase()

### DIFF
--- a/apps/demo-accounting/README.md
+++ b/apps/demo-accounting/README.md
@@ -28,26 +28,30 @@ boots the local stack and seeds two demo users from `supabase/seed.sql`:
 
 Every page and firm API route requires a session (`src/proxy.ts`): pages
 bounce to `/login`, APIs answer 401. The login form posts to GoTrue's real
-password grant; the resulting Supabase access token becomes the
-`cadence-session` cookie. Verification is hybrid (`src/server/session.ts`):
-ES256 login tokens verify against GoTrue's JWKS, HS256 tokens verify offline
-against the project JWT secret. No env vars are needed locally — the app
-defaults to the well-known `supabase start` URL, anon key, and JWT secret.
+password grant; the resulting Supabase access token becomes the session
+cookie, named `sb-cadence-auth-token` per Supabase's own `sb-<ref>-auth-token`
+convention. Verification is hybrid (`src/server/session.ts`): ES256 login
+tokens verify against GoTrue's JWKS, HS256 tokens verify offline against the
+project JWT secret. No env vars are needed locally — the app defaults to the
+well-known `supabase start` URL, anon key, and JWT secret.
 
-Away execution needs no live session at all: `actAs` in `src/vendo/auth.ts`
-mints a real Supabase user JWT for the granting user with the project JWT
-secret via `@vendoai/actions/presets`. `src/vendo/away-drill.test.ts` proves
-it end to end (and runs without the Supabase stack — only login needs GoTrue;
-`src/vendo/login-e2e.test.ts` covers that and skips itself cleanly when the
-stack is down).
+The Supabase session is the identity for everything, wired with one config
+key — `auth: cadenceAuth` (the shipped `supabase()` preset, configured in
+`src/vendo/auth.ts`): the Vendo principal is the Supabase user id, the MCP
+OAuth adapter resolves the same session, and away execution needs no live
+session at all — the preset's actAs half mints a real Supabase user JWT for
+the granting user with the project JWT secret. `src/vendo/away-drill.test.ts`
+proves it end to end (and runs without the Supabase stack — only login needs
+GoTrue; `src/vendo/login-e2e.test.ts` covers that and skips itself cleanly
+when the stack is down).
 
 ## Architecture
 
 Cadence's product pages and seeded data remain self-contained under
 `src/app`, `src/components`, and `src/server`. Vendo is composed once in
-`src/vendo/server.ts` with the host model, the session-backed principal, the
-Supabase `actAs` preset for away execution, the deployed policy, optional
-Vendo Auto judge, and Gmail/Google Calendar Composio connector.
+`src/vendo/server.ts` with the host model, the `auth: supabase()` identity
+preset, the deployed policy, optional Vendo Auto judge, and Gmail/Google
+Calendar Composio connector.
 
 The umbrella is mounted by the single catch-all route at
 `/api/vendo/[...vendo]`. React surfaces use the umbrella `VendoRoot`, UI

--- a/apps/demo-accounting/src/server/session.ts
+++ b/apps/demo-accounting/src/server/session.ts
@@ -16,7 +16,10 @@
 import { createRemoteJWKSet, decodeProtectedHeader, jwtVerify, type JWTVerifyResult } from "jose"
 import { isSecureDeployment, supabaseJwtSecret, supabaseUrl } from "./users"
 
-export const SESSION_COOKIE = "cadence-session"
+/** Supabase's own `sb-<project-ref>-auth-token` cookie shape (ref "cadence"),
+ * holding the raw access token — so the shipped `auth: supabase()` preset
+ * (src/vendo/server.ts) reads the same session this module verifies. */
+export const SESSION_COOKIE = "sb-cadence-auth-token"
 
 export interface CadenceSession {
   /** The Supabase user id (JWT `sub`) — the Vendo principal subject. */

--- a/apps/demo-accounting/src/vendo/auth.test.ts
+++ b/apps/demo-accounting/src/vendo/auth.test.ts
@@ -1,8 +1,11 @@
+import { createServer } from "node:http"
+import type { AddressInfo } from "node:net"
 import type { PermissionGrant } from "@vendoai/core"
+import { SignJWT, exportJWK, generateKeyPair } from "jose"
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { resolveCadenceSession } from "@/server/session"
-import { cadenceDemoUsers } from "@/server/users"
-import { actAsCadenceUser, resolveCadencePrincipal, safeReturnTo } from "./auth"
+import { SESSION_COOKIE, resolveCadenceSession } from "@/server/session"
+import { cadenceDemoUsers, supabaseJwtSecret } from "@/server/users"
+import { cadenceAuth, safeReturnTo } from "./auth"
 
 afterEach(() => vi.unstubAllEnvs())
 
@@ -21,14 +24,81 @@ function grantFor(subject: string): PermissionGrant {
   }
 }
 
-describe("actAsCadenceUser (Supabase preset)", () => {
+/** Mint a GoTrue-shaped HS256 access token the way Supabase local would. */
+async function accessToken(sub: string): Promise<string> {
+  const now = Math.floor(Date.now() / 1000)
+  return new SignJWT({ role: "authenticated" })
+    .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+    .setSubject(sub)
+    .setAudience("authenticated")
+    .setIssuedAt(now)
+    .setExpirationTime(now + 300)
+    .sign(new TextEncoder().encode(supabaseJwtSecret()))
+}
+
+function withSessionCookie(token: string): Request {
+  return new Request("http://localhost:3000/api/vendo/threads", {
+    headers: { cookie: `${SESSION_COOKIE}=${token}` },
+  })
+}
+
+describe("cadenceAuth (the shipped supabase() preset, Cadence-configured)", () => {
+  it("resolves the login session cookie to the seeded Vendo principal", async () => {
+    // The cookie the /login route sets is readable by the shipped preset —
+    // Cadence's cookie name follows Supabase's `sb-<ref>-auth-token` shape.
+    const request = withSessionCookie(await accessToken(MAYA!.subject))
+    await expect(cadenceAuth.principal(request)).resolves.toEqual({
+      kind: "user",
+      subject: MAYA!.subject,
+      display: MAYA!.display,
+    })
+  })
+
+  it("declines unseeded subjects and sessionless requests", async () => {
+    const stranger = "1c9e6f2a-5d4b-4a3c-8b7e-0f1e2d3c4b5a"
+    await expect(cadenceAuth.principal(withSessionCookie(await accessToken(stranger))))
+      .resolves.toBeNull()
+    await expect(cadenceAuth.principal(new Request("http://localhost:3000/api/vendo/threads")))
+      .resolves.toBeNull()
+  })
+
+  it("verifies an ES256 login token against GoTrue's JWKS (supabase start ≥ v2.71)", async () => {
+    const { publicKey, privateKey } = await generateKeyPair("ES256")
+    const jwk = { ...(await exportJWK(publicKey)), kid: "cadence-test-kid", alg: "ES256" }
+    const server = createServer((_req, res) => {
+      res.setHeader("content-type", "application/json")
+      res.end(JSON.stringify({ keys: [jwk] }))
+    })
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+    vi.stubEnv("SUPABASE_URL", `http://127.0.0.1:${(server.address() as AddressInfo).port}`)
+    try {
+      const now = Math.floor(Date.now() / 1000)
+      const token = await new SignJWT({ role: "authenticated" })
+        .setProtectedHeader({ alg: "ES256", kid: "cadence-test-kid", typ: "JWT" })
+        .setSubject(DANIEL!.subject)
+        .setAudience("authenticated")
+        .setIssuedAt(now)
+        .setExpirationTime(now + 300)
+        .sign(privateKey)
+      await expect(cadenceAuth.principal(withSessionCookie(token))).resolves.toEqual({
+        kind: "user",
+        subject: DANIEL!.subject,
+        display: DANIEL!.display,
+      })
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+})
+
+describe("cadenceAuth actAs half (shipped Supabase minting preset)", () => {
   it("mints an away token Cadence's own session verification accepts", async () => {
-    const material = await actAsCadenceUser(
+    const material = await cadenceAuth.actAs!(
       { kind: "user", subject: DANIEL!.subject, display: DANIEL!.display },
       grantFor(DANIEL!.subject),
     )
     expect(material?.headers.authorization).toMatch(/^Bearer /)
-    // Round trip through the same verifier the proxy wall and principal use.
+    // Round trip through the same verifier the proxy wall uses.
     const request = new Request("http://localhost:3000/api/clients", {
       headers: material!.headers,
     })
@@ -37,7 +107,8 @@ describe("actAsCadenceUser (Supabase preset)", () => {
       display: DANIEL!.display,
       email: DANIEL!.email,
     })
-    await expect(resolveCadencePrincipal(request)).resolves.toEqual({
+    // And through the preset's own principal seam (the doctor round-trip).
+    await expect(cadenceAuth.principal(request)).resolves.toEqual({
       kind: "user",
       subject: DANIEL!.subject,
       display: DANIEL!.display,
@@ -45,17 +116,17 @@ describe("actAsCadenceUser (Supabase preset)", () => {
   })
 
   it("declines subjects Cadence never seeded", async () => {
-    await expect(actAsCadenceUser(
+    await expect(cadenceAuth.actAs!(
       { kind: "user", subject: "1c9e6f2a-5d4b-4a3c-8b7e-0f1e2d3c4b5a" },
       grantFor("1c9e6f2a-5d4b-4a3c-8b7e-0f1e2d3c4b5a"),
     )).resolves.toBeNull()
   })
 
-  it("declines when the project JWT secret is unavailable", async () => {
+  it("fails loud when the project JWT secret is unavailable", async () => {
     vi.stubEnv("NODE_ENV", "production")
     // supabaseJwtSecret() throws without SUPABASE_JWT_SECRET in production;
-    // the preset must surface that as a decline, not a minted token.
-    await expect(actAsCadenceUser(
+    // the preset must surface that, not mint with a default.
+    await expect(cadenceAuth.actAs!(
       { kind: "user", subject: MAYA!.subject },
       grantFor(MAYA!.subject),
     )).rejects.toThrow(/SUPABASE_JWT_SECRET/)

--- a/apps/demo-accounting/src/vendo/auth.ts
+++ b/apps/demo-accounting/src/vendo/auth.ts
@@ -1,15 +1,24 @@
-import { supabasePreset } from "@vendoai/actions/presets"
-import type { ActAs, Principal } from "@vendoai/vendo"
-import { resolveCadenceSession } from "@/server/session"
-import { resolveCadenceSubject, supabaseJwtSecret } from "@/server/users"
+import { supabase } from "@vendoai/vendo/server"
+import { resolveCadenceSubject, supabaseJwtSecret, supabaseUrl } from "@/server/users"
 
-/** Session-backed principal: the Supabase user id is the Vendo subject.
- * Requests without a valid session resolve to null and ride the umbrella's
- * per-client anonymous principal. */
-export async function resolveCadencePrincipal(request: Request): Promise<Principal | null> {
-  const session = await resolveCadenceSession(request)
-  return session ? { kind: "user", subject: session.subject, display: session.display } : null
-}
+/** One preset fills all three identity seams (09-vendo §2.1): the
+ * request→Principal resolver, the away/MCP actAs seam, and the door's OAuth
+ * adapter. Sessions verify the same hybrid way `src/server/session.ts` does —
+ * HS256 offline against the project JWT secret (also what away execution
+ * mints with), ES256 login tokens (`supabase start` ≥ v2.71) against GoTrue's
+ * JWKS. `user` maps a Supabase user id to the seeded Cadence identity;
+ * returning null means "not a Cadence user" — the principal resolves to
+ * anonymous and away/MCP minting for that subject declines. */
+export const cadenceAuth = supabase({
+  secret: () => supabaseJwtSecret(),
+  // Lazy: supabaseUrl() defaults to the `supabase start` stack when
+  // SUPABASE_URL is unset, keeping local dev zero-config.
+  jwks: () => new URL("/auth/v1/.well-known/jwks.json", supabaseUrl()),
+  user: (subject) => {
+    const user = resolveCadenceSubject(subject)
+    return user ? { display: user.display, email: user.email } : null
+  },
+})
 
 /** The operator-set public origin (VENDO_BASE_URL) or, failing that, the
  * request's own origin. */
@@ -33,17 +42,3 @@ export function safeReturnTo(candidate: string | null | undefined, base: URL = p
 export function cadencePublicUrl(request: Request, path: string): URL {
   return new URL(path, publicOrigin(request))
 }
-
-/** Away + MCP execution: mint a REAL Supabase access token for the grant's
- * subject with the project's own JWT secret, via the shipped Supabase preset.
- * Subjects Cadence never seeded are declined through the claims resolver
- * (null → the seam surfaces "host declined"). The secret resolves per mint
- * and minted tokens live only inside the preset's in-memory cache — never
- * logged, never persisted. */
-export const actAsCadenceUser: ActAs = supabasePreset({
-  secret: () => supabaseJwtSecret(),
-  claims: (principal) => {
-    const user = resolveCadenceSubject(principal.subject)
-    return user ? { email: user.email, user_metadata: { name: user.display } } : null
-  },
-})

--- a/apps/demo-accounting/src/vendo/login-e2e.test.ts
+++ b/apps/demo-accounting/src/vendo/login-e2e.test.ts
@@ -12,6 +12,7 @@
  * cadence-supabase-auth job.
  */
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { SESSION_COOKIE } from "../server/session"
 import { cadenceDemoEmail, cadenceDemoPassword, cadenceDemoUsers, supabaseUrl } from "../server/users"
 import { appFetch, bootCadence, BOOT_MS, type CadenceApp } from "./e2e-harness"
 
@@ -42,8 +43,8 @@ async function login(email: string, password: string): Promise<Response> {
 
 function sessionCookieFrom(response: Response): string {
   const setCookie = response.headers.get("set-cookie") ?? ""
-  const session = setCookie.split(",").find((part) => part.trim().startsWith("cadence-session="))
-  expect(session, `expected a cadence-session cookie in: ${setCookie}`).toBeDefined()
+  const session = setCookie.split(",").find((part) => part.trim().startsWith(`${SESSION_COOKIE}=`))
+  expect(session, `expected a ${SESSION_COOKIE} cookie in: ${setCookie}`).toBeDefined()
   return session!.split(";")[0]!.trim()
 }
 
@@ -78,7 +79,7 @@ describe.skipIf(!supabaseRunning)("Cadence Supabase login (ENG-260)", () => {
     expect(dashboard.status).toBe(200)
 
     // Sanity: the token in the cookie is a Supabase JWT for the seeded user.
-    const token = cookie.slice("cadence-session=".length)
+    const token = cookie.slice(`${SESSION_COOKIE}=`.length)
     const payload = JSON.parse(Buffer.from(token.split(".")[1]!, "base64url").toString()) as {
       sub: string
       role: string
@@ -100,6 +101,6 @@ describe.skipIf(!supabaseRunning)("Cadence Supabase login (ENG-260)", () => {
     const [, daniel] = cadenceDemoUsers()
     const response = await login(daniel!.email, cadenceDemoPassword())
     expect(response.status).toBe(303)
-    expect(sessionCookieFrom(response)).toContain("cadence-session=")
+    expect(sessionCookieFrom(response)).toContain(`${SESSION_COOKIE}=`)
   })
 })

--- a/apps/demo-accounting/src/vendo/principal.ts
+++ b/apps/demo-accounting/src/vendo/principal.ts
@@ -1,9 +1,0 @@
-import type { Principal } from "@vendoai/vendo"
-import { resolveCadencePrincipal } from "./auth"
-
-/** Session-backed resolver: the Supabase user id is the Vendo subject.
- * Requests without a session resolve to null and ride the umbrella's
- * per-client anonymous principal — there is no fixed demo principal anymore. */
-export async function resolveDemoPrincipal(req: Request): Promise<Principal | null> {
-  return resolveCadencePrincipal(req)
-}

--- a/apps/demo-accounting/src/vendo/server.ts
+++ b/apps/demo-accounting/src/vendo/server.ts
@@ -2,8 +2,7 @@ import { anthropic } from "@ai-sdk/anthropic";
 import { composioConnector } from "@vendoai/actions";
 import { vendoAutoJudge } from "@vendoai/guard";
 import { createVendo } from "@vendoai/vendo/server";
-import { actAsCadenceUser } from "./auth";
-import { resolveDemoPrincipal } from "./principal";
+import { cadenceAuth } from "./auth";
 import { cadenceRegistry } from "./registry";
 
 const model = anthropic(process.env.VENDO_DEMO_MODEL ?? "claude-sonnet-4-6");
@@ -13,19 +12,10 @@ const judge = judgeModelName ? vendoAutoJudge({ model: anthropic(judgeModelName)
 
 export const vendo = createVendo({
   model,
-  // Hand-wired trio, NOT `auth: supabase()`: Cadence verifies BOTH the legacy
-  // HS256 project secret and GoTrue's ES256 JWKS (../server/session.ts,
-  // `supabase start` >= v2.71 signs logins with the latter). The shipped
-  // `auth: supabase()` preset (packages/vendo/src/auth-presets/supabase.ts)
-  // only verifies HS256 sessions — no JWKS support yet — so it would silently
-  // reject any Cadence login signed with the newer key. Known preset gap, not
-  // a Cadence bug; see docs/superpowers/plans/2026-07-18-init-lane-handoff.md.
-  // `actAsCadenceUser` (./auth) still mints real HS256 Supabase away tokens
-  // for the away/MCP seam through the SAME preset (its actAs half never
-  // touches session verification); only the inbound present-mode session
-  // check stays hand-rolled (./auth's resolveCadencePrincipal).
-  principal: resolveDemoPrincipal,
-  actAs: actAsCadenceUser,
+  // One preset fills all three identity seams (09-vendo §2.1) — the shipped
+  // supabase() preset, hybrid HS256 + ES256/JWKS like ../server/session.ts;
+  // see ./auth for the Cadence-specific configuration.
+  auth: cadenceAuth,
   // The shared registry (01 §14): the server reads only the data fields;
   // <VendoRoot> takes the same object and reads only component references.
   catalog: cadenceRegistry,

--- a/docs-site/connect/act-as-presets.mdx
+++ b/docs-site/connect/act-as-presets.mdx
@@ -27,7 +27,7 @@ name/email session-token claims:
 | --- | --- |
 | `authJs()` | `AUTH_SECRET` |
 | `clerk()` | `CLERK_SECRET_KEY` |
-| `supabase()` | `SUPABASE_JWT_SECRET` |
+| `supabase()` | `SUPABASE_JWT_SECRET` (HS256, offline) and/or `SUPABASE_URL` (ES256 logins via GoTrue's JWKS) |
 | `auth0()` | `AUTH0_DOMAIN` / `AUTH0_ISSUER_BASE_URL` |
 | `jwt({ secret })` | none — a host-owned scheme has no vendor env, so `secret` is required |
 

--- a/docs/superpowers/plans/2026-07-18-init-lane-handoff.md
+++ b/docs/superpowers/plans/2026-07-18-init-lane-handoff.md
@@ -95,17 +95,15 @@ and is now the old surface — every demo and the docs have moved past it.
 
 ## Known gaps for the init lane to be aware of
 
-- **`supabase()` preset can't verify ES256 sessions.** The shipped preset
-  (`packages/vendo/src/auth-presets/supabase.ts`) verifies only HS256 sessions
-  against the project's legacy JWT secret. Supabase projects using JWT signing
-  keys (`supabase start` >= v2.71) issue ES256-signed login sessions verified
-  through GoTrue's JWKS — the preset has no JWKS support. `apps/demo-accounting`
-  hits this for real (see its `src/server/session.ts` hybrid HS256+JWKS
-  verifier) and was deliberately NOT migrated to `auth: supabase()` this wave;
-  its `vendo/server.ts` keeps the hand-wired `principal`/`actAs` trio with a
-  comment citing this gap. If init auto-detects `@supabase/*` and offers
-  `auth: supabase()`, it should say out loud that this only covers the legacy
-  HS256 JWT-secret project setting, not the newer JWKS-signed one.
+- **`supabase()` preset verifies sessions hybrid (CLOSED — was: HS256-only).**
+  The shipped preset (`packages/vendo/src/auth-presets/supabase.ts`) now
+  verifies HS256 sessions offline against the project's legacy JWT secret AND
+  ES256 login sessions (`supabase start` >= v2.71, hosted projects on JWT
+  signing keys) against GoTrue's JWKS (SUPABASE_URL-derived, `jwks` option
+  override, lazy jose). `apps/demo-accounting` is migrated to
+  `auth: supabase()` (`cadenceAuth` in its `src/vendo/auth.ts`); its own
+  `src/server/session.ts` keeps the same hybrid for non-vendo routes. Init can
+  offer `auth: supabase()` for both project key setups.
 - **`@vendoai/actions`' `authJsPreset`'s dynamic `@auth/core/jwt` import
   caches a rejection permanently.** `packages/actions/src/presets/auth-js.ts`
   line ~42-46:

--- a/packages/vendo/src/auth-presets/index.ts
+++ b/packages/vendo/src/auth-presets/index.ts
@@ -5,7 +5,7 @@ export { auth0 } from "./auth0.js";
 export { authJs } from "./auth-js.js";
 export { clerk } from "./clerk.js";
 export { jwt } from "./jwt.js";
-export { supabase } from "./supabase.js";
+export { supabase, type SupabaseHostAuthPresetOptions } from "./supabase.js";
 // The three-seam conformance kit ships publicly (the @vendoai/core
 // "./conformance" precedent): the named presets above and host-custom presets
 // are its consumers.

--- a/packages/vendo/src/auth-presets/supabase.test.ts
+++ b/packages/vendo/src/auth-presets/supabase.test.ts
@@ -1,14 +1,70 @@
 import { supabasePreset } from "@vendoai/actions/presets";
 import type { PermissionGrant } from "@vendoai/core";
+import { SignJWT } from "jose";
 import { afterEach, describe, expect, it, vi } from "vitest";
 // Imported through the same entry hosts use, pinning the re-export.
 import { hostAuthPresetConformance, supabase } from "./index.js";
 
+/** Hermetic GoTrue: jose is real (ES256 sign + verify run locally); ONLY the
+    network-touching JWKS fetch is mocked at the lazy-import seam, resolving
+    keys from our in-memory GoTrue JWKS instead of the wire (auth0's pattern). */
+const jwksState = vi.hoisted(() => ({
+  jwks: undefined as unknown,
+  url: undefined as string | undefined,
+}));
+vi.mock("jose", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("jose")>();
+  return {
+    ...actual,
+    createRemoteJWKSet: (url: URL) => {
+      jwksState.url = url.toString();
+      return actual.createLocalJWKSet(jwksState.jwks as never);
+    },
+  };
+});
+
+const gotrueKeys = (async () => {
+  const { generateKeyPair, exportJWK } = await vi.importActual<typeof import("jose")>("jose");
+  const { publicKey, privateKey } = await generateKeyPair("ES256", { extractable: true });
+  const jwk = await exportJWK(publicKey);
+  jwksState.jwks = { keys: [{ ...jwk, alg: "ES256", kid: "vendo-supabase-test-kid", use: "sig" }] };
+  return { privateKey };
+})();
+
 afterEach(() => {
+  jwksState.url = undefined;
   vi.unstubAllEnvs();
 });
 
 const secret = "supabase-project-jwt-secret-at-least-32-bytes";
+const projectUrl = "https://testref.supabase.co";
+const jwksUrl = `${projectUrl}/auth/v1/.well-known/jwks.json`;
+
+interface Es256Overrides {
+  claims?: Record<string, unknown>;
+  audience?: string | false;
+  expiresIn?: string;
+  key?: CryptoKey;
+}
+
+/** Mint a GoTrue-shaped ES256 login token — what `supabase start` ≥ v2.71 and
+    hosted projects on the new key system sign interactive logins with. */
+async function es256Token(subject: string, overrides: Es256Overrides = {}): Promise<string> {
+  const { privateKey } = await gotrueKeys;
+  const jwt = new SignJWT({ role: "authenticated", ...overrides.claims })
+    .setProtectedHeader({ alg: "ES256", typ: "JWT", kid: "vendo-supabase-test-kid" })
+    .setSubject(subject)
+    .setIssuedAt()
+    .setExpirationTime(overrides.expiresIn ?? "5m");
+  if (overrides.audience !== false) jwt.setAudience(overrides.audience ?? "authenticated");
+  return jwt.sign(overrides.key ?? (privateKey as CryptoKey));
+}
+
+function withBearer(token: string): Request {
+  return new Request("https://host.test/api/vendo/threads", {
+    headers: { authorization: `Bearer ${token}` },
+  });
+}
 
 /** The host-side user table a subject→user resolver fronts (demo-bank idiom). */
 const users: Record<string, { display: string; email: string }> = {
@@ -72,12 +128,87 @@ describe("supabase() zero-argument standard case", () => {
       .resolves.toEqual({ kind: "user", subject: "user_env" });
   });
 
-  it("throws an actionable error naming SUPABASE_JWT_SECRET when no secret is configured", async () => {
+  it("reads SUPABASE_URL from the environment and verifies ES256 logins against GoTrue's JWKS", async () => {
     vi.stubEnv("SUPABASE_JWT_SECRET", "");
+    vi.stubEnv("SUPABASE_URL", projectUrl);
+    const preset = supabase();
+    await expect(preset.principal(withBearer(await es256Token("user_es256_env"))))
+      .resolves.toEqual({ kind: "user", subject: "user_es256_env" });
+    expect(jwksState.url).toBe(jwksUrl);
+  });
+
+  it("throws an actionable error naming BOTH SUPABASE_JWT_SECRET and SUPABASE_URL when neither is configured", async () => {
+    vi.stubEnv("SUPABASE_JWT_SECRET", "");
+    vi.stubEnv("SUPABASE_URL", "");
     const preset = supabase();
     await expect(preset.principal(await sessionRequest("user_env")))
-      .rejects.toThrow(/SUPABASE_JWT_SECRET/);
+      .rejects.toThrow(/SUPABASE_JWT_SECRET.*SUPABASE_URL|SUPABASE_URL.*SUPABASE_JWT_SECRET/s);
   });
+});
+
+describe("supabase() hybrid ES256/JWKS verification (Supabase's newer signing keys)", () => {
+  it("resolves an ES256 login token to a principal with claims-derived display", async () => {
+    const preset = supabase({ jwks: jwksUrl });
+    await expect(preset.principal(withBearer(await es256Token("user_es256", {
+      claims: { email: "ada@supa.test", user_metadata: { name: "Ada Lovelace" } },
+    })))).resolves.toEqual({ kind: "user", subject: "user_es256", display: "Ada Lovelace" });
+    await expect(preset.principal(withBearer(await es256Token("user_es256_mail", {
+      claims: { email: "ada@supa.test" },
+    })))).resolves.toEqual({ kind: "user", subject: "user_es256_mail", display: "ada@supa.test" });
+  });
+
+  it("accepts the ES256 login token off the @supabase/ssr cookie too (lazy jwks thunk)", async () => {
+    // The thunk form resolves per call, so a host can derive the URL from env
+    // without racing env loading at composition (the SecretSource pattern).
+    const preset = supabase({ jwks: () => jwksUrl });
+    const cookie = `sb-testref-auth-token=${ssrCookieValue(await es256Token("user_es256_cookie"))}`;
+    await expect(preset.principal(withCookie(cookie)))
+      .resolves.toEqual({ kind: "user", subject: "user_es256_cookie" });
+  });
+
+  it("verifies HS256 sessions OFFLINE first — the JWKS is never touched for them", async () => {
+    vi.stubEnv("SUPABASE_URL", projectUrl);
+    const preset = supabase({ secret });
+    await expect(preset.principal(await sessionRequest("user_hybrid_hs")))
+      .resolves.toEqual({ kind: "user", subject: "user_hybrid_hs" });
+    expect(jwksState.url).toBeUndefined();
+  });
+
+  it("resolves forged (wrong-key), expired, and wrong-audience ES256 tokens to null", async () => {
+    const { generateKeyPair } = await vi.importActual<typeof import("jose")>("jose");
+    const { privateKey: strangerKey } = await generateKeyPair("ES256");
+    const preset = supabase({ secret, jwks: jwksUrl });
+    await expect(preset.principal(withBearer(await es256Token("user_forged", { key: strangerKey as CryptoKey }))))
+      .resolves.toBeNull();
+    await expect(preset.principal(withBearer(await es256Token("user_expired", { expiresIn: "-5m" }))))
+      .resolves.toBeNull();
+    await expect(preset.principal(withBearer(await es256Token("user_noaud", { audience: false }))))
+      .resolves.toBeNull();
+    await expect(preset.principal(withBearer(await es256Token("user_wrongaud", { audience: "anon" }))))
+      .resolves.toBeNull();
+  });
+
+  it("resolves an ES256 token to null when only the HS256 secret is configured (no JWKS source)", async () => {
+    vi.stubEnv("SUPABASE_URL", "");
+    const preset = supabase({ secret });
+    await expect(preset.principal(withBearer(await es256Token("user_no_jwks")))).resolves.toBeNull();
+  });
+});
+
+describe("supabase() hybrid three-seam conformance (ES256 sessions, HS256 actAs mints)", () => {
+  // The Cadence shape: interactive logins arrive ES256-signed (verified via
+  // JWKS), while the actAs half keeps minting offline HS256 tokens with the
+  // project secret — one preset serves both halves.
+  const suite = hostAuthPresetConformance({
+    preset: supabase({ secret, jwks: jwksUrl, user: userResolver }),
+    sessionRequest: async (subject) => withBearer(await es256Token(subject)),
+    knownSubject: "supa_yousef",
+    unknownSubject: "intruder",
+    expectedDisplay: "Yousef Helal",
+  });
+  for (const conformanceCase of suite.cases) {
+    it(conformanceCase.name, conformanceCase.run);
+  }
 });
 
 describe("supabase() session resolution — Supabase's own formats", () => {
@@ -104,6 +235,12 @@ describe("supabase() session resolution — Supabase's own formats", () => {
     await expect(preset.principal(withCookie(objectCookie))).resolves.toEqual({ kind: "user", subject: "user_legacy" });
     const arrayCookie = `sb-testref-auth-token=${encodeURIComponent(JSON.stringify([token, "refresh"]))}`;
     await expect(preset.principal(withCookie(arrayCookie))).resolves.toEqual({ kind: "user", subject: "user_legacy" });
+  });
+
+  it("reads a raw access token as the cookie value (hand-rolled hosts, legacy auth-helpers)", async () => {
+    const preset = supabase({ secret });
+    const cookie = `sb-cadence-auth-token=${await accessToken("user_raw")}`;
+    await expect(preset.principal(withCookie(cookie))).resolves.toEqual({ kind: "user", subject: "user_raw" });
   });
 
   it("resolves a cookie-less request to null and an unverifiable token to null", async () => {

--- a/packages/vendo/src/auth-presets/supabase.ts
+++ b/packages/vendo/src/auth-presets/supabase.ts
@@ -1,10 +1,12 @@
 import { supabasePreset, verifyHs256 } from "@vendoai/actions/presets";
+import { environment } from "../wire/shared.js";
 import {
   actAsClaimsFromUser,
   bearerToken,
   claimString,
   composeHostAuthPreset,
   lazyActAs,
+  lazyModule,
   loginRedirect,
   makeUserResolver,
   requestCookies,
@@ -13,12 +15,57 @@ import {
 } from "./identity.js";
 import type { HostAuthPreset, HostAuthPresetOptions, HostAuthPresetUser } from "./shared.js";
 
-const MISSING_SECRET_MESSAGE =
-  "supabase() has no JWT secret: set SUPABASE_JWT_SECRET (the project's legacy JWT signing secret — the same one supabasePreset mints with, never the anon key) or pass supabase({ secret }).";
+const MISSING_VERIFIER_MESSAGE =
+  "supabase() has no way to verify sessions: set SUPABASE_JWT_SECRET (the project's legacy JWT signing secret — verifies HS256 access tokens offline; the same one supabasePreset mints with, never the anon key) and/or SUPABASE_URL (the project URL — ES256 logins verify against its GoTrue JWKS at /auth/v1/.well-known/jwks.json), or pass supabase({ secret }) / supabase({ jwks }).";
+
+/** Same optional-dependency strategy as auth0's jose: ES256 login tokens
+    (Supabase's newer signing keys) verify against GoTrue's JWKS through jose,
+    an optional peerDependency loaded lazily on first use. HS256-only hosts
+    never hit this path and need nothing installed. */
+const MISSING_JOSE_MESSAGE =
+  "supabase() verifies ES256 Supabase session tokens through jose, which is not installed. Install it next to your Supabase setup: npm install jose";
+
+interface JoseModule {
+  createRemoteJWKSet(url: URL): unknown;
+  jwtVerify(
+    token: string,
+    key: unknown,
+    options: { audience: string; algorithms: string[] },
+  ): Promise<{ payload: JwtClaims }>;
+}
+
+const loadJose = lazyModule<JoseModule>(
+  () => import("jose").then((module) => module as unknown as JoseModule),
+  MISSING_JOSE_MESSAGE,
+);
+
+/** jose's remote JWKS resolvers cache fetched keys per instance — keep one per
+    URL so verification never refetches per request (auth0's pattern). */
+const jwksByUrl = new Map<string, unknown>();
+function remoteJwks(jose: JoseModule, url: string): unknown {
+  let jwks = jwksByUrl.get(url);
+  if (jwks === undefined) {
+    jwks = jose.createRemoteJWKSet(new URL(url));
+    jwksByUrl.set(url, jwks);
+  }
+  return jwks;
+}
+
+export interface SupabaseHostAuthPresetOptions extends HostAuthPresetOptions {
+  /** GoTrue's JWKS URL for ES256 session verification. Default: derived from
+      SUPABASE_URL as `<url>/auth/v1/.well-known/jwks.json` (GoTrue's own
+      well-known path); pass this to point somewhere else. The thunk form
+      resolves lazily per call (the SecretSource pattern), so composition
+      order never races env loading. */
+  jwks?: string | URL | (() => string | URL | undefined);
+}
 
 /** Supabase's auth cookie: `sb-<project-ref>-auth-token`, optionally chunked
     across `.0`, `.1`, ... suffixes by @supabase/ssr. */
 const SUPABASE_AUTH_COOKIE = /^(sb-.+-auth-token)(?:\.(\d+))?$/;
+
+/** A compact JWS: three non-empty base64url segments. */
+const RAW_JWT = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
 
 function decodeBase64Url(value: string): string | undefined {
   if (!/^[A-Za-z0-9_-]+$/.test(value) || value.length % 4 === 1) return undefined;
@@ -31,10 +78,12 @@ function decodeBase64Url(value: string): string | undefined {
   }
 }
 
-/** Extract the access token from a reassembled cookie value. Three shapes ship
-    in the wild: @supabase/ssr's `base64-` + base64url(JSON session), and the
-    legacy plain-JSON session object / `[access_token, ...]` array. */
+/** Extract the access token from a reassembled cookie value. Four shapes ship
+    in the wild: @supabase/ssr's `base64-` + base64url(JSON session), the
+    legacy plain-JSON session object / `[access_token, ...]` array, and the
+    raw access token itself (hand-rolled hosts, the old auth-helpers). */
 function accessTokenFrom(value: string): string | undefined {
+  if (RAW_JWT.test(value)) return value;
   const raw = value.startsWith("base64-") ? decodeBase64Url(value.slice("base64-".length)) : value;
   if (raw === undefined) return undefined;
   let session: unknown;
@@ -78,6 +127,35 @@ function sessionTokenFrom(request: Request): string | undefined {
   return undefined;
 }
 
+/** The token's protected-header `alg`, decoded without verification — only to
+    route the token to the verifier that can possibly accept it. */
+function tokenAlg(token: string): string | undefined {
+  const header = decodeBase64Url(token.split(".")[0] ?? "");
+  if (header === undefined) return undefined;
+  try {
+    const parsed = JSON.parse(header) as unknown;
+    return parsed !== null && typeof parsed === "object" && typeof (parsed as { alg?: unknown }).alg === "string"
+      ? (parsed as { alg: string }).alg
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** GoTrue's JWKS URL: the `jwks` option (thunks resolved per call), else
+    SUPABASE_URL's well-known path. */
+function jwksUrlFrom(jwks: SupabaseHostAuthPresetOptions["jwks"]): string | undefined {
+  const resolved = typeof jwks === "function" ? jwks() : jwks;
+  if (resolved !== undefined) return resolved.toString();
+  const projectUrl = environment("SUPABASE_URL");
+  if (projectUrl === undefined) return undefined;
+  try {
+    return new URL("/auth/v1/.well-known/jwks.json", projectUrl).toString();
+  } catch {
+    return undefined;
+  }
+}
+
 /** Supabase's claims→user defaults: identity lives in `user_metadata`
     (name/full_name) with the email as a top-level claim. */
 function supabaseUser(claims: JwtClaims): HostAuthPresetUser {
@@ -99,34 +177,72 @@ function supabaseUser(claims: JwtClaims): HostAuthPresetUser {
 
 /**
  * 09-vendo §2.1 — the Supabase Auth host-identity preset. Zero-argument in
- * the standard case: the secret is SUPABASE_JWT_SECRET (the project's legacy
- * JWT signing secret, matching the shipped supabasePreset actAs half), the
- * session resolves off a plain Request per Supabase's own formats
- * (Authorization: Bearer, or the `sb-*-auth-token` cookie — @supabase/ssr's
- * `base64-`/chunked shape and the legacy JSON shapes), and display derives
- * from user_metadata.name/full_name/email. The optional subject→user resolver
- * has the same semantics as authJs (null = subject unknown → decline/null).
+ * the standard case: it reads Supabase's own env, the session resolves off a
+ * plain Request per Supabase's own formats (Authorization: Bearer, or the
+ * `sb-*-auth-token` cookie — @supabase/ssr's `base64-`/chunked shape, the
+ * legacy JSON shapes, and the raw access token), and display derives from
+ * user_metadata.name/full_name/email. The optional subject→user resolver has
+ * the same semantics as authJs (null = subject unknown → decline/null).
  *
- * No optional SDK is needed: Supabase access tokens are symmetric HS256, so
- * the SAME shared `verifyHs256` the minting half targets verifies sessions —
- * hermetic, no network, nothing to install.
+ * Session verification is Supabase's documented HYBRID (the same one a
+ * project with JWT signing keys needs), routed by the token's own `alg`:
+ *
+ * 1. HS256 first — the project's legacy JWT secret (SUPABASE_JWT_SECRET or
+ *    `secret`), verified OFFLINE through the SAME shared `verifyHs256` the
+ *    minting half targets: no network, no optional SDK, and every actAs-minted
+ *    away token stays verifiable with no Supabase stack running.
+ * 2. ES256 fallback — what `supabase start` ≥ v2.71 and hosted projects on
+ *    the new key system sign interactive logins with, verified against
+ *    GoTrue's JWKS (SUPABASE_URL → /auth/v1/.well-known/jwks.json, or the
+ *    `jwks` option) through a lazily-imported jose (optional peer, cached
+ *    remote key set per URL).
+ *
+ * Both paths enforce Supabase's `authenticated` audience, which is also what
+ * keeps the project's API keys (anon/service_role — HS256 JWTs under the same
+ * secret, but without that audience) from ever counting as a signed-in user.
+ * Tokens neither path can verify resolve to null (no session); construction
+ * with NEITHER a secret NOR a JWKS source fails loud, naming both.
  *
  * The actAs half IS the shipped `@vendoai/actions/presets` supabasePreset —
  * one minting story (04 §2.1), configured from these same options. Tokens
  * mint (and verify) under Supabase's `authenticated` audience convention.
  */
-export function supabase(options: HostAuthPresetOptions = {}): HostAuthPreset {
-  const { secret, user } = options;
+export function supabase(options: SupabaseHostAuthPresetOptions = {}): HostAuthPreset {
+  const { secret, user, jwks } = options;
 
   const sessionClaims = async (request: Request): Promise<JwtClaims | null> => {
     const token = sessionTokenFrom(request);
     if (token === undefined) return null;
-    const jwtSecret = await resolvePresetSecret(secret, "SUPABASE_JWT_SECRET", MISSING_SECRET_MESSAGE);
-    try {
-      return (await verifyHs256(token, jwtSecret, { audience: "authenticated" })).payload;
-    } catch {
-      return null; // unverifiable/expired/foreign token = no session
+    const jwtSecret = secret === undefined && environment("SUPABASE_JWT_SECRET") === undefined
+      ? undefined
+      : await resolvePresetSecret(secret, "SUPABASE_JWT_SECRET", MISSING_VERIFIER_MESSAGE);
+    const jwksUrl = jwksUrlFrom(jwks);
+    if (jwtSecret === undefined && jwksUrl === undefined) {
+      throw new Error(MISSING_VERIFIER_MESSAGE);
     }
+    const alg = tokenAlg(token);
+    // HS256 first: offline, no network — and the only path a JWKS could never
+    // serve. ES256 is the fallback for logins under the newer signing keys.
+    if (alg === "HS256" && jwtSecret !== undefined) {
+      try {
+        return (await verifyHs256(token, jwtSecret, { audience: "authenticated" })).payload;
+      } catch {
+        return null; // unverifiable/expired/foreign token = no session
+      }
+    }
+    if (alg === "ES256" && jwksUrl !== undefined) {
+      const jose = await loadJose();
+      try {
+        const { payload } = await jose.jwtVerify(token, remoteJwks(jose, jwksUrl), {
+          audience: "authenticated",
+          algorithms: ["ES256"],
+        });
+        return payload;
+      } catch {
+        return null; // unverifiable/expired/foreign token = no session
+      }
+    }
+    return null; // an alg (or config) neither verifier serves = no session
   };
 
   return composeHostAuthPreset({

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -82,6 +82,7 @@ export {
   type HostAuthPresetOptions,
   type HostAuthPresetUser,
   type HostAuthPresetUserResolver,
+  type SupabaseHostAuthPresetOptions,
 } from "./auth-presets/index.js";
 import type { HostAuthPreset } from "./auth-presets/index.js";
 import { initTelemetry, type Telemetry } from "@vendoai/telemetry";


### PR DESCRIPTION
Follow-up from the PR #376 follow-up list ("`supabase()` preset: add ES256/GoTrue-JWKS verification (blocks demo-accounting auth migration)").

## What

**`supabase()` auth preset — hybrid HS256 + ES256/JWKS session verification** (`packages/vendo/src/auth-presets/supabase.ts`)

- Verification routes by the token's own `alg`. **HS256 first**: offline against the project JWT secret (`SUPABASE_JWT_SECRET` / `secret` option) — no network, no optional SDK, and every actAs-minted away token stays verifiable with no Supabase stack running. **ES256 fallback**: what `supabase start` ≥ v2.71 and hosted projects on the new key system sign interactive logins with, verified against GoTrue's JWKS.
- JWKS URL derived the way demo-accounting's reference implementation (`src/server/session.ts`) does: `SUPABASE_URL` env → `/auth/v1/.well-known/jwks.json`, with a `jwks` option override (`string | URL | lazy thunk` — the thunk resolves per call, SecretSource-style, so composition never races env loading).
- jose loads lazily (already an optional peer of `@vendoai/vendo`), reusing auth0's pattern: cached remote JWKS per URL, actionable install error instead of a bare module-not-found.
- Both paths enforce Supabase's `authenticated` audience (also what keeps anon/service_role API keys — HS256 JWTs under the same secret — from counting as sessions).
- Missing BOTH `SUPABASE_JWT_SECRET` and `SUPABASE_URL` (and neither option) fails loud naming both. Tokens neither verifier serves resolve to null (no session), as ever.
- Cookie extraction learns a fourth in-the-wild shape: the raw access token as the `sb-*-auth-token` cookie value (hand-rolled hosts, the old auth-helpers), alongside @supabase/ssr's `base64-`/chunked shape and the legacy JSON shapes.

**demo-accounting adopts `auth: supabase()`** (mirroring demo-bank's authJs migration in #376)

- `vendo/server.ts` → `createVendo({ auth: cadenceAuth })`; `cadenceAuth = supabase({ secret, jwks, user })` lives in `vendo/auth.ts`. The hand-wired glue (`vendo/principal.ts`, `resolveCadencePrincipal`, `actAsCadenceUser`) is deleted; the ES256-gap comment is gone; the init-lane handoff note's known-gap bullet is marked CLOSED.
- The session cookie adopts Supabase's own `sb-<ref>-auth-token` convention (`sb-cadence-auth-token`, raw access token value) instead of the bespoke `cadence-session`, so the shipped preset reads the login session natively — the same reason `authJs()` was drop-in for Maple's standard Auth.js cookie. `src/server/session.ts` is kept and stays authoritative for the demo's own non-vendo routes (proxy wall, app shell, login/logout); only the constant changed.

## Why

Real Supabase signs interactive logins ES256 against GoTrue's JWKS; the preset verified HS256 only, so it silently rejected Cadence logins under the newer keys and the demo had to hand-wire its identity seams. With the hybrid, one preset covers both project key setups, and the demo's wiring collapses to the one-key `auth` story.

## Tests

- `packages/vendo` auth-presets: **101 passed** (supabase.test.ts grew 16 → 30). New coverage mirrors auth0's harness — `vi.mock("jose")` replaces ONLY `createRemoteJWKSet` with a local JWKS; ES256 sign/verify run real jose. Cases: ES256 login → principal with claims-derived display; offline-HS256 proof (JWKS never touched); forged (wrong-key)/expired/wrong-audience ES256 → null; env + option + thunk JWKS sources; missing-both actionable error; raw-token cookie shape; and a SECOND shared-conformance run in the hybrid shape (ES256 sessions, HS256 actAs mints — the Cadence shape).
- `apps/demo-accounting`: full vitest **99 passed** (login-e2e's 4 stay skip-gated without the local stack; the CI `cadence-supabase-auth` job runs them against a real `supabase start`). New `vendo/auth.test.ts` pins the migrated seams: login cookie → seeded principal through the preset, ES256 token verified via a real local JWKS HTTP server, actAs round-trip through both session.ts and the preset, unseeded-subject declines, prod missing-secret fails loud. Away drill green.
- `pnpm build`, `pnpm typecheck`, `pnpm lint` green at root; demo-accounting `tsc --noEmit` + `next build` green.

## Notes for review

- The demo cookie rename is the one judgment call beyond the follow-up's literal text: without it the preset (which reads Supabase's own cookie/Bearer conventions) could never see Cadence's browser session and present-mode principals would silently regress to anonymous. All cookie references flow through the `SESSION_COOKIE` constant (login-e2e included), so nothing else hardcodes the name.
- Local run could not exercise the Supabase-gated login e2e (Docker down); it is constant-driven and covered by the dedicated CI job.

https://claude.ai/code/session_018S4HHYRGSGyDXwNGo3oJWS

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hybrid HS256 + ES256/JWKS verification to the `supabase()` host auth preset so ES256 login sessions work out of the box. Migrates `apps/demo-accounting` to `auth: supabase()` and adopts Supabase’s `sb-<ref>-auth-token` cookie.

- **New Features**
  - `supabase()` now routes by `alg`: HS256 offline via `SUPABASE_JWT_SECRET`; ES256 via GoTrue JWKS from `SUPABASE_URL` or a new `jwks` option.
  - ES256 verification uses lazily loaded `jose` with cached remote JWKS per URL.
  - Enforces `aud` = `authenticated`; API keys won’t resolve as sessions.
  - Reads a raw access token in `sb-*-auth-token` cookies in addition to `@supabase/ssr` and legacy JSON formats.
  - Fails loud when both `SUPABASE_JWT_SECRET` and a JWKS source are missing.

- **Migration**
  - `apps/demo-accounting`: switch to `createVendo({ auth: cadenceAuth })` with `cadenceAuth = supabase({ secret, jwks, user })`; remove hand-wired principal/actAs.
  - Rename session cookie to `sb-cadence-auth-token` (raw access token) so the preset reads the same login state.
  - Tests updated to cover ES256 via JWKS and HS256 offline; docs reflect the hybrid behavior.

<sup>Written for commit 5ffde8d6e7b301be236e8739bbbe6e48b9141161. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

