### PR TITLE
vendo init scaffolds the two-file surface — registry + silent auth-preset detection

### DIFF
--- a/docs-site/connect/vendo-init.mdx
+++ b/docs-site/connect/vendo-init.mdx
@@ -40,8 +40,10 @@ exists), preserves your existing formatting, and only writes if you approve
 the diff.
 
 Init also creates or appends `VENDO_BASE_URL=http://localhost:3000` to
-`.env.example` with a comment explaining that present-mode credential
-forwarding is disabled without it. The write is idempotent — existing lines
+`.env.example` with a comment explaining the trust semantics: development
+trusts the request's own origin automatically, while production fails loud
+without the variable set (a credential-forwarding call errors instead of
+silently running unauthenticated). The write is idempotent — existing lines
 are preserved — so it is safe to run `vendo init` again.
 
 One of those questions is whether to open the [MCP door](/capabilities/mcp).

--- a/docs-site/quickstart.mdx
+++ b/docs-site/quickstart.mdx
@@ -11,11 +11,13 @@ npx vendo init
 ```
 
 `vendo init` asks nothing on the happy path. It writes two code files — an
-empty `vendo/registry.tsx` and the catch-all handler wired to it, with your
-auth preset detected silently from package.json — plus two package.json
-script hooks, extracts your tools and brand theme into `.vendo/`, resolves a
-model key, and prints the one `<VendoRoot components={registry}>` line that
-is yours to paste. It never edits code you wrote.
+empty `vendo/registry.tsx` and the catch-all handler wired to it — plus two
+package.json script hooks, extracts your tools and brand theme into
+`.vendo/`, resolves a model key, and prints the one
+`<VendoRoot components={registry}>` line that is yours to paste. When it
+detects your auth provider in package.json it asks once to confirm the
+preset (Enter accepts; `--yes` and non-interactive runs accept it
+silently). It never edits code you wrote.
 
 ## The two files you own
 

--- a/docs-site/quickstart.mdx
+++ b/docs-site/quickstart.mdx
@@ -10,9 +10,12 @@ npm install @vendoai/vendo
 npx vendo init
 ```
 
-The init interview scans the app, recommends risk labels, extracts theme and
-remix candidates, and proposes the handler and `<VendoRoot>` edits. It shows
-each code diff before writing it.
+`vendo init` asks nothing on the happy path. It writes two code files — an
+empty `vendo/registry.tsx` and the catch-all handler wired to it, with your
+auth preset detected silently from package.json — plus two package.json
+script hooks, extracts your tools and brand theme into `.vendo/`, resolves a
+model key, and prints the one `<VendoRoot components={registry}>` line that
+is yours to paste. It never edits code you wrote.
 
 ## The two files you own
 

--- a/docs-site/quickstart.mdx
+++ b/docs-site/quickstart.mdx
@@ -73,8 +73,8 @@ const vendo = createVendo({
 export const { GET, POST, DELETE } = nextVendoHandler(vendo);
 ```
 
-`model` is the only required key — `createVendo({ model })` alone boots, with
-anonymous ephemeral sessions and PGlite persistence. `authJs()` is
+Every key is optional — a bare `createVendo()` boots with an env-resolved
+model, anonymous ephemeral sessions, and PGlite persistence. `authJs()` is
 zero-argument in the standard case: it reads `AUTH_SECRET` (mirroring Auth.js
 itself) and derives the principal's display name and email from the
 session-token claims. `auth` is one preset that fills all three identity

--- a/docs-site/quickstart.mdx
+++ b/docs-site/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Quickstart: Next.js"
-description: "Install @vendoai/vendo in a Next.js app, wire vendo/registry.tsx and vendo/server.ts, drop in VendoRoot, and ship a first working agent turn."
+description: "Install @vendoai/vendo in a Next.js app, wire vendo/registry.tsx and the catch-all handler, drop in VendoRoot, and ship a first working agent turn."
 ---
 
 ## Install
@@ -20,8 +20,10 @@ is yours to paste. It never edits code you wrote.
 ## The two files you own
 
 A host's entire server wiring is two files: `vendo/registry.tsx`, the shared
-component registry, and `vendo/server.ts`, which calls `createVendo` with a
-model, an auth preset, and that registry.
+component registry, and the composition — one `createVendo` call with a
+model, an auth preset, and that registry. On Next.js the composition lives
+inline in the catch-all route `app/api/vendo/[...vendo]/route.ts`, which is
+exactly what `vendo init` scaffolds.
 
 ### `vendo/registry.tsx`
 
@@ -54,19 +56,21 @@ The props schema is optional — a schema-less entry is legal and renders as a
 description-only prompt entry the model infers props for. The model-facing
 JSON Schema is derived from `props` internally; you never hand-write it.
 
-### `vendo/server.ts`
+### The catch-all route — the composition
 
 ```ts
-// vendo/server.ts
+// app/api/vendo/[...vendo]/route.ts — what `vendo init` scaffolds
 import { anthropic } from "@ai-sdk/anthropic";
-import { authJs, createVendo } from "@vendoai/vendo/server";
-import { registry } from "./registry";
+import { authJs, createVendo, nextVendoHandler } from "@vendoai/vendo/server";
+import { registry } from "@/vendo/registry";
 
-export const vendo = createVendo({
+const vendo = createVendo({
   model: anthropic("claude-sonnet-4-6"),
   auth: authJs(),
   catalog: registry,
 });
+
+export const { GET, POST, DELETE } = nextVendoHandler(vendo);
 ```
 
 `model` is the only required key — `createVendo({ model })` alone boots, with
@@ -81,6 +85,11 @@ also exist for Clerk, Supabase, Auth0, and a generic JWT scheme; see
 escape hatch (`principal`/`actAs`/`oauth`) for hosts without a shipped
 preset — supplying `auth` together with any of those three throws a
 validation error at compose time.
+
+Prefer a separate `vendo/server.ts` (exporting the same `createVendo`
+result) when code outside the route needs the `vendo` object — `vendo.emit`
+for host events, the MCP door's `.well-known` route, or tests. The route
+then shrinks to a re-export:
 
 ```ts
 // app/api/vendo/[...vendo]/route.ts
@@ -105,7 +114,7 @@ export function Root({ children }: { children: React.ReactNode }) {
 }
 ```
 
-`components` accepts the same registry object `server.ts` passes as
+`components` accepts the same registry object the composition passes as
 `catalog` — it reads only the component references and ignores the data
 fields. Choose headless hooks from `@vendoai/ui` or a ready-made surface from
 `@vendoai/ui/chrome`. Every read hook shares a

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,12 +9,13 @@ npx vendo init
 
 The `vendoai` package is a thin alias. The scoped package is the canonical
 install. `vendo init` asks nothing on the happy path. It writes two code
-files — an empty `vendo/registry.tsx` and the catch-all handler wired to it,
-with your auth preset detected silently from package.json — plus two
-package.json script hooks, extracts your tools and brand theme into
-`.vendo/`, resolves a model key, and prints the one line that is yours to
-paste: the `<VendoRoot components={registry}>` wrap in your layout. It never
-edits code you wrote. Then start your dev server — the agent is live in your app —
+files — an empty `vendo/registry.tsx` and the catch-all handler wired to
+it — plus two package.json script hooks, extracts your tools and brand
+theme into `.vendo/`, resolves a model key, and prints the one line that is
+yours to paste: the `<VendoRoot components={registry}>` wrap in your
+layout. When it detects your auth provider in package.json it asks once to
+confirm the preset (consent-style, Enter accepts; `--yes` and
+non-interactive runs accept it silently). It never edits code you wrote. Then start your dev server — the agent is live in your app —
 and run `npx vendo doctor` to verify everything with one real model turn.
 
 ## Model keys

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -97,8 +97,11 @@ unreasoned wakes) are printed per entry while the rest of the draft applies.
 ## The two files you own
 
 A host's entire server wiring is two files: `vendo/registry.tsx`, which
-declares the components generated views can use, and `vendo/server.ts`, which
-calls `createVendo` with a model, an auth preset, and that registry.
+declares the components generated views can use, and the composition — one
+`createVendo` call with a model, an auth preset, and that registry. On
+Next.js the composition lives inline in the catch-all route
+`app/api/vendo/[...vendo]/route.ts`, which is exactly what `vendo init`
+scaffolds.
 
 ### `vendo/registry.tsx` — the component registry
 
@@ -131,18 +134,21 @@ description-only prompt entry the model infers props for. When a schema is
 present, the model-facing JSON Schema is derived from it internally; you never
 hand-write one.
 
-### `vendo/server.ts` — the composition
+### The catch-all route — the composition
 
 ```ts
+// app/api/vendo/[...vendo]/route.ts — what `vendo init` scaffolds
 import { anthropic } from "@ai-sdk/anthropic";
-import { authJs, createVendo } from "@vendoai/vendo/server";
-import { registry } from "./registry";
+import { authJs, createVendo, nextVendoHandler } from "@vendoai/vendo/server";
+import { registry } from "@/vendo/registry";
 
-export const vendo = createVendo({
+const vendo = createVendo({
   model: anthropic("claude-sonnet-4-6"),
   auth: authJs(),
   catalog: registry,
 });
+
+export const { GET, POST, DELETE } = nextVendoHandler(vendo);
 ```
 
 The example pins an explicit provider. You can omit `model` entirely — the
@@ -216,8 +222,13 @@ ephemeral and anonymous. `auth` and any of `principal`/`actAs`/`oauth` are
 mutually exclusive — supplying both throws a validation error at compose
 time. Pick the preset or hand-wire the three seams, never both.
 
+Prefer a separate `vendo/server.ts` (exporting the same `createVendo`
+result) when code outside the route needs the `vendo` object — `vendo.emit`
+for host events, the MCP door's `.well-known` route, or tests. The route
+then shrinks to a re-export:
+
 ```ts
-import { createVendo, nextVendoHandler } from "@vendoai/vendo/server";
+import { nextVendoHandler } from "@vendoai/vendo/server";
 import { vendo } from "@/vendo/server";
 
 export const { GET, POST, DELETE } = nextVendoHandler(vendo);
@@ -237,7 +248,7 @@ export function Root({ children }: { children: React.ReactNode }) {
 }
 ```
 
-`components` accepts the same registry object `server.ts` passes as
+`components` accepts the same registry object the composition passes as
 `catalog` — it reads only the component references and ignores the data
 fields. Use the headless hooks from `@vendoai/ui`, or add a shipped surface
 from `@vendoai/ui/chrome`. `<VendoThread />`, `<VendoOverlay />`,

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,11 +8,13 @@ npx vendo init
 ```
 
 The `vendoai` package is a thin alias. The scoped package is the canonical
-install. `vendo init` asks nothing on the happy path. It writes one code file
-(the catch-all handler) and two package.json script hooks, extracts your tools
-and brand theme into `.vendo/`, resolves a model key, and prints the one line
-that is yours to paste: the `<VendoRoot>` wrap in your layout. It never edits
-code you wrote. Then start your dev server — the agent is live in your app —
+install. `vendo init` asks nothing on the happy path. It writes two code
+files — an empty `vendo/registry.tsx` and the catch-all handler wired to it,
+with your auth preset detected silently from package.json — plus two
+package.json script hooks, extracts your tools and brand theme into
+`.vendo/`, resolves a model key, and prints the one line that is yours to
+paste: the `<VendoRoot components={registry}>` wrap in your layout. It never
+edits code you wrote. Then start your dev server — the agent is live in your app —
 and run `npx vendo doctor` to verify everything with one real model turn.
 
 ## Model keys

--- a/docs/superpowers/plans/2026-07-18-init-lane-handoff.md
+++ b/docs/superpowers/plans/2026-07-18-init-lane-handoff.md
@@ -6,6 +6,12 @@ touched `packages/vendo/src/cli/init.ts` or any scaffold template — this note
 is the handoff instead. Read docs/brainstorms/server-wiring-dx.md for the
 full design; this note is the scaffold-facing summary plus known gaps.
 
+> **Status 2026-07-18: CLOSED.** Adopted by the init-scaffold lane
+> (branch `yousefh409/init-scaffolds-two-file-surface`). Every item below
+> carries its own dated closure line; the one remaining OPEN item is the
+> pre-existing demo-bank `mcp-config.test.ts` tsc errors, re-verified still
+> present and still out of scope here.
+
 ## What init currently scaffolds (stale)
 
 `packages/vendo/src/cli/init.ts` (`nextServerSource` around line 149,
@@ -36,6 +42,12 @@ and is now the old surface — every demo and the docs have moved past it.
    examples in `apps/demo-bank/src/vendo/registry.tsx` (post wave-3/4) and
    `apps/demo-accounting/src/vendo/registry.tsx` (migrated this wave).
 
+   **CLOSED 2026-07-18** — init scaffolds `vendo/registry.tsx` (mirroring the
+   app dir: `src/app` → `src/vendo`; Express: `vendo/registry.tsx`/`.mjs`),
+   empty with the one-file/two-consumers doc-comment and a commented
+   SpendingDonut example. Generated only while absent — never clobbered, and
+   never orphaned next to a hand-wired route that ignores it.
+
 2. **`vendo/server.ts`** — `model` + an `auth` preset + the registry as
    `catalog`:
 
@@ -60,6 +72,17 @@ and is now the old surface — every demo and the docs have moved past it.
    `@vendoai/vendo/server`; the full option shape (including the `secret` and
    `user` overrides) is in `docs/act-as-presets.md`.
 
+   **CLOSED 2026-07-18, with one deliberate deviation** — the composition
+   stays INLINE in the generated catch-all route rather than splitting into a
+   separate `vendo/server.ts`: the route is init's one recognized createVendo
+   shape (the ENG-248 serverActions rewiring depends on it), and a split
+   would add a third generated file for no behavior. The route now carries
+   `catalog: registry` plus silent auth detection from package.json
+   dependencies (one unambiguous family → the preset line with an
+   escape-hatch comment; none or several → anonymous plus ONE advisory line
+   naming the exact line to add — zero-question contract preserved, `jwt()`
+   is advice-only, never scaffolded).
+
 3. **`<VendoRoot>` wiring** — pass the same registry object as `components`:
 
    ```tsx
@@ -72,6 +95,11 @@ and is now the old surface — every demo and the docs have moved past it.
    `components` accepts either the registry or a plain `Record<string,
    ComponentType>` (`packages/ui/src/context.tsx` — `HostComponentsInput`), so
    this is additive, not breaking, if init needs a transition period.
+
+   **CLOSED 2026-07-18** — the printed paste block gains
+   `import { registry } from "../vendo/registry";` and the wrap becomes
+   `<VendoRoot components={registry} …>` (still one pasted line plus its
+   imports; omitted honestly when no registry file exists or is planned).
 
 4. **`.well-known/[...vendo]/route.ts`** — a two-line re-export of the shipped
    handler, not a hand-copied allowlist:
@@ -93,9 +121,18 @@ and is now the old surface — every demo and the docs have moved past it.
    the `wellKnownVendoHandler` re-export above; delete `wellKnownRouteSource()`
    once nothing calls it.
 
+   **CLOSED 2026-07-18 (was already done)** — this bullet was stale when
+   written: `wellKnownRouteSource()` was added in c2bd4c37 and deleted by the
+   zero-question init rewrite (f2c23568), before this handoff landed. Current
+   init generates no well-known route at all (it does not enable `mcp:`), so
+   no hand-copied allowlist exists outside the package; a host that turns on
+   the door adds the two-line `wellKnownVendoHandler` re-export per
+   `docs-site/capabilities/mcp.mdx`.
+
 ## Known gaps for the init lane to be aware of
 
-- **`supabase()` preset verifies sessions hybrid (CLOSED — was: HS256-only).**
+- **`supabase()` preset verifies sessions hybrid (CLOSED 2026-07-18 by
+  PR #379 — was: HS256-only).**
   The shipped preset (`packages/vendo/src/auth-presets/supabase.ts`) now
   verifies HS256 sessions offline against the project's legacy JWT secret AND
   ES256 login sessions (`supabase start` >= v2.71, hosted projects on JWT
@@ -105,7 +142,10 @@ and is now the old surface — every demo and the docs have moved past it.
   `src/server/session.ts` keeps the same hybrid for non-vendo routes. Init can
   offer `auth: supabase()` for both project key setups.
 - **`@vendoai/actions`' `authJsPreset`'s dynamic `@auth/core/jwt` import
-  caches a rejection permanently.** `packages/actions/src/presets/auth-js.ts`
+  caches a rejection permanently. (CLOSED 2026-07-18 by PR #378 —
+  `loadEncode` now clears `encodePromise` in the rejection handler so the
+  next call retries after an install; same pattern applied in the umbrella
+  preset's `loadGetToken`.)** `packages/actions/src/presets/auth-js.ts`
   line ~42-46:
 
   ```ts
@@ -132,6 +172,8 @@ and is now the old surface — every demo and the docs have moved past it.
   call sites. Verified present on this branch before and after Wave 4's
   changes — vitest passes, only `tsc --noEmit` on demo-bank flags it. Leave
   for whichever lane next touches that file's env-shaped test fixtures.
+  (Re-verified STILL OPEN 2026-07-18 by the init-scaffold lane — three
+  `error TS2345` sites remain; deliberately not closed here.)
 
 ## Where the new surface is documented
 

--- a/docs/superpowers/plans/2026-07-18-init-lane-handoff.md
+++ b/docs/superpowers/plans/2026-07-18-init-lane-handoff.md
@@ -77,11 +77,14 @@ and is now the old surface — every demo and the docs have moved past it.
    separate `vendo/server.ts`: the route is init's one recognized createVendo
    shape (the ENG-248 serverActions rewiring depends on it), and a split
    would add a third generated file for no behavior. The route now carries
-   `catalog: registry` plus silent auth detection from package.json
-   dependencies (one unambiguous family → the preset line with an
-   escape-hatch comment; none or several → anonymous plus ONE advisory line
-   naming the exact line to add — zero-question contract preserved, `jwt()`
-   is advice-only, never scaffolded).
+   `catalog: registry` plus detect+confirm auth wiring from package.json
+   dependencies (Yousef's revision over the original silent-detection ask):
+   one unambiguous family → ONE consent-style [Y/n] confirm in interactive
+   runs (Enter accepts; decline stays anonymous with the exact line named),
+   accepted silently under `--yes`/non-interactive/--agent; none or several
+   → anonymous plus ONE advisory line naming the exact line to add. `jwt()`
+   is advice-only, never scaffolded; the wired preset line carries an
+   escape-hatch comment.
 
 3. **`<VendoRoot>` wiring** — pass the same registry object as `components`:
 

--- a/packages/vendo/src/cli/extract/extraction.ts
+++ b/packages/vendo/src/cli/extract/extraction.ts
@@ -152,7 +152,9 @@ export function reportApplied(input: {
   for (const missed of applied.missedSurfaces) output.log(`  missed surface (not extracted yet): ${missed}`);
 }
 
-async function askYesNo(question: string, defaultYes: boolean): Promise<boolean> {
+/** Consent-style one-line prompt — shared machinery: the AI-polish consent
+    here and init's detected-auth confirm both use it. */
+export async function askYesNo(question: string, defaultYes: boolean): Promise<boolean> {
   const prompt = createInterface({ input: stdin, output: stdout });
   try {
     const answer = (await prompt.question(`${question} ${defaultYes ? "[Y/n]" : "[y/N]"} `)).trim().toLowerCase();

--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -113,11 +113,18 @@ describe("vendo init (zero-question)", () => {
     const sink = output();
     expect(await run(root, sink)).toBe(0);
 
-    // The one generated code file: model-less createVendo (model is optional).
+    // The two generated code files: model-less createVendo (model is optional)
+    // wired to the empty shared registry.
     const route = await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8");
     expect(route).toContain('import { createVendo, nextVendoHandler } from "@vendoai/vendo/server";');
+    expect(route).toContain('import { registry } from ' + '"../../../../vendo/registry";');
+    expect(route).toContain("catalog: registry,");
     expect(route).toContain("principal: async () => null");
     expect(route).not.toContain("model");
+    const registry = await readFile(join(root, "vendo", "registry.tsx"), "utf8");
+    expect(registry).toContain('import type { ComponentRegistry } from "@vendoai/core";');
+    expect(registry).toContain("export const registry = {} satisfies ComponentRegistry;");
+    expect(registry).toContain("SpendingDonut"); // the commented example entry
 
     // package.json gains the sync hooks.
     const manifest = JSON.parse(await readFile(join(root, "package.json"), "utf8")) as { scripts?: Record<string, string> };
@@ -137,12 +144,16 @@ describe("vendo init (zero-question)", () => {
 
     // The summary lists what changed and hands the paste + next steps over.
     const logs = sink.logs.join("\n");
-    expect(logs).toContain("Wired (2 files):");
+    expect(logs).toContain("Wired (3 files):");
+    expect(logs).toContain("+ " + join("vendo", "registry.tsx"));
     expect(logs).toContain("+ " + join("app", "api", "vendo", "[...vendo]", "route.ts"));
     expect(logs).toContain("~ package.json");
+    // No auth dependency in the fixture: one calm advisory, nothing guessed.
+    expect(logs).toContain("Auth: no provider detected");
     expect(logs).toContain("Last steps are yours:");
     expect(logs).toContain('import { VendoRoot } from "@vendoai/vendo/react";');
-    expect(logs).toContain("<VendoRoot theme={theme as VendoTheme}>{children}</VendoRoot>");
+    expect(logs).toContain('import { registry } from "../vendo/registry";');
+    expect(logs).toContain("<VendoRoot components={registry} theme={theme as VendoTheme}>{children}</VendoRoot>");
     expect(logs).toContain("npx vendo doctor");
     // No interview, no per-diff consent, no refine offer, no finale.
     expect(logs).not.toContain("[y/N]");
@@ -168,8 +179,13 @@ describe("vendo init (zero-question)", () => {
       "export default function Layout({ children }) { return <html><body>{children}</body></html>; }\n");
     const sink = output();
     expect(await run(root, sink)).toBe(0);
-    await expect(readFile(join(root, "src", "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8")).resolves.toBeTruthy();
-    expect(sink.logs.join("\n")).toContain('import theme from "../../.vendo/theme.json";');
+    const route = await readFile(join(root, "src", "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8");
+    expect(route).toContain('import { registry } from ' + '"../../../../vendo/registry";');
+    // The registry mirrors the app dir: src/app → src/vendo/registry.tsx.
+    await expect(readFile(join(root, "src", "vendo", "registry.tsx"), "utf8")).resolves.toContain("ComponentRegistry");
+    const logs = sink.logs.join("\n");
+    expect(logs).toContain('import theme from "../../.vendo/theme.json";');
+    expect(logs).toContain('import { registry } from "../vendo/registry";');
   });
 
   it("prints a theme-less paste when the project disables resolveJsonModule", async () => {
@@ -178,8 +194,76 @@ describe("vendo init (zero-question)", () => {
     const sink = output();
     expect(await run(root, sink)).toBe(0);
     const logs = sink.logs.join("\n");
-    expect(logs).toContain("<VendoRoot>{children}</VendoRoot>");
+    expect(logs).toContain("<VendoRoot components={registry}>{children}</VendoRoot>");
     expect(logs).not.toContain("import theme from");
+  });
+
+  it.each([
+    ["next-auth", "authJs"],
+    ["@auth/core", "authJs"],
+    ["@clerk/nextjs", "clerk"],
+    ["@supabase/supabase-js", "supabase"],
+    ["@auth0/nextjs-auth0", "auth0"],
+  ] as const)("silently wires auth from %s → %s()", async (dependency, preset) => {
+    const root = await fixture();
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      name: "host",
+      dependencies: { next: "16.0.0", [dependency]: "1.0.0" },
+    }));
+    const sink = output();
+    expect(await run(root, sink)).toBe(0);
+    const route = await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8");
+    const named = [preset, "createVendo", "nextVendoHandler"].sort().join(", ");
+    expect(route).toContain(`import { ${named} } from "@vendoai/vendo/server";`);
+    expect(route).toContain(`auth: ${preset}(),`);
+    // The detected line carries its escape hatch, and the preset owns the
+    // principal seam — no hand-wired anonymous resolver remains.
+    expect(route).toContain("docs/act-as-presets.md");
+    expect(route).not.toContain("principal");
+    // Detection is silent: no question, no advisory.
+    expect(sink.logs.join("\n")).not.toContain("Auth:");
+  });
+
+  it("stays anonymous and advises once when several auth providers are present", async () => {
+    const root = await fixture();
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      name: "host",
+      dependencies: { next: "16.0.0", "next-auth": "5.0.0", "@clerk/nextjs": "6.0.0" },
+    }));
+    const sink = output();
+    expect(await run(root, sink)).toBe(0);
+    const route = await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8");
+    expect(route).not.toContain("auth:");
+    expect(route).toContain("principal: async () => null");
+    const advisories = sink.logs.filter((line) => line.includes("Auth:"));
+    expect(advisories).toHaveLength(1);
+    expect(advisories[0]).toContain("next-auth, @clerk/nextjs");
+    expect(advisories[0]).toContain("auth: authJs() or auth: clerk()");
+  });
+
+  it("never clobbers an existing registry and still wires the route to it", async () => {
+    const root = await fixture();
+    await mkdir(join(root, "vendo"), { recursive: true });
+    const custom = "export const registry = { /* host-authored */ };\n";
+    await writeFile(join(root, "vendo", "registry.tsx"), custom);
+    expect(await run(root, output())).toBe(0);
+    expect(await readFile(join(root, "vendo", "registry.tsx"), "utf8")).toBe(custom);
+    const route = await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8");
+    expect(route).toContain('import { registry } from ' + '"../../../../vendo/registry";');
+  });
+
+  it("does not scaffold a registry next to a hand-written route that ignores it", async () => {
+    const root = await fixture();
+    await mkdir(join(root, "app", "api", "vendo", "[...vendo]"), { recursive: true });
+    await writeFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"),
+      'import { createVendo, nextVendoHandler } from "@vendoai/vendo/server";\n' +
+      "const vendo = createVendo({ principal: async () => null });\n" +
+      "export const { GET, POST, DELETE } = nextVendoHandler(vendo);\n");
+    const sink = output();
+    expect(await run(root, sink)).toBe(0);
+    await expect(readFile(join(root, "vendo", "registry.tsx"))).rejects.toMatchObject({ code: "ENOENT" });
+    // The paste line stays honest: no components prop without a registry file.
+    expect(sink.logs.join("\n")).not.toContain("components={registry}");
   });
 
   it("states an env key in one line and skips the cloud offer", async () => {
@@ -206,6 +290,11 @@ describe("vendo init (zero-question)", () => {
     const example = await readFile(join(root, ".env.example"), "utf8");
     expect(example).toContain("HOST_FLAG=1");
     expect(example).toContain("VENDO_BASE_URL=http://localhost:3000");
+    // Post server-wiring semantics: dev trusts its own origin; production
+    // fails loud without the variable — no silent credential drop.
+    expect(example).toContain("Dev trusts the request's own");
+    expect(example).toContain("production fails loud");
+    expect(example).not.toContain("disabled without it");
     expect(await run(root, output())).toBe(0);
     expect((await readFile(join(root, ".env.example"), "utf8")).match(/VENDO_BASE_URL/g)).toHaveLength(1);
   });
@@ -255,9 +344,13 @@ describe("vendo init (zero-question)", () => {
     expect(await run(unwired, sink)).toBe(0);
     const server = await readFile(join(unwired, "vendo", "server.ts"), "utf8");
     expect(server).toContain("createVendo({");
+    expect(server).toContain('import { registry } from "./registry";');
+    expect(server).toContain("catalog: registry,");
     expect(server).not.toContain("model");
+    await expect(readFile(join(unwired, "vendo", "registry.tsx"), "utf8")).resolves.toContain("ComponentRegistry");
     await expect(readFile(join(unwired, "vendo", "ai.ts"))).rejects.toMatchObject({ code: "ENOENT" });
     expect(sink.logs.join("\n")).toContain('app.use("/api/vendo", mountVendo());');
+    expect(sink.logs.join("\n")).toContain("components={registry}");
 
     const wired = await expressFixture(true);
     expect(await run(wired, output())).toBe(0);
@@ -265,6 +358,7 @@ describe("vendo init (zero-question)", () => {
     expect(await run(wired, output())).toBe(0);
     expect(await tree(wired)).toEqual(first);
     await expect(readFile(join(wired, "vendo", "server.ts"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(join(wired, "vendo", "registry.tsx"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("uses an ESM scaffold when an Express host has no tsconfig", async () => {
@@ -274,6 +368,8 @@ describe("vendo init (zero-question)", () => {
     const server = await readFile(join(root, "vendo", "server.mjs"), "utf8");
     expect(server).not.toContain(": Headers");
     expect(server).toContain("mountVendo");
+    expect(server).toContain('import { registry } from "./registry.mjs";');
+    await expect(readFile(join(root, "vendo", "registry.mjs"), "utf8")).resolves.toContain("export const registry = {};");
   });
 
   it("writes the setup skill silently when .claude exists and respects an edited copy", async () => {
@@ -396,6 +492,7 @@ describe("vendo init (zero-question)", () => {
     expect(plan.writes).toContain(".vendo/tools.json");
     expect(plan.writes).not.toContain(".env");
     expect(plan.codeChanges.map((change) => change.path)).toContain(join("app", "api", "vendo", "[...vendo]", "route.ts"));
+    expect(plan.codeChanges.map((change) => change.path)).toContain(join("vendo", "registry.tsx"));
     expect(plan.manualSteps.join("\n")).toContain("<VendoRoot");
     expect(Array.isArray(plan.extraction.tools)).toBe(true);
     expect(Array.isArray(plan.riskRecommendations)).toBe(true);

--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -204,7 +204,9 @@ describe("vendo init (zero-question)", () => {
     ["@clerk/nextjs", "clerk"],
     ["@supabase/supabase-js", "supabase"],
     ["@auth0/nextjs-auth0", "auth0"],
-  ] as const)("silently wires auth from %s → %s()", async (dependency, preset) => {
+  ] as const)("non-interactive runs silently wire auth from %s → %s()", async (dependency, preset) => {
+    // No `interactive` override and vitest has no TTY: the detected default
+    // is accepted without a question (--yes behaves identically).
     const root = await fixture();
     await writeFile(join(root, "package.json"), JSON.stringify({
       name: "host",
@@ -222,6 +224,66 @@ describe("vendo init (zero-question)", () => {
     expect(route).not.toContain("principal");
     // Detection is silent: no question, no advisory.
     expect(sink.logs.join("\n")).not.toContain("Auth:");
+  });
+
+  it("interactive runs confirm the detected preset with one [Y/n]-style question — accept wires it", async () => {
+    const root = await fixture();
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      name: "host",
+      dependencies: { next: "16.0.0", "next-auth": "5.0.0" },
+    }));
+    const asked: Array<{ question: string; defaultYes: boolean }> = [];
+    const sink = output();
+    expect(await run(root, sink, {
+      interactive: true,
+      confirmAuth: async (question, defaultYes) => {
+        asked.push({ question, defaultYes });
+        return true; // Enter/Y
+      },
+    })).toBe(0);
+    expect(asked).toEqual([{ question: "Detected next-auth — wire auth: authJs()?", defaultYes: true }]);
+    const route = await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8");
+    expect(route).toContain("auth: authJs(),");
+    expect(sink.logs.join("\n")).not.toContain("Auth:");
+  });
+
+  it("interactive decline keeps the composition anonymous and names the exact line to add later", async () => {
+    const root = await fixture();
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      name: "host",
+      dependencies: { next: "16.0.0", "@clerk/nextjs": "6.0.0" },
+    }));
+    const sink = output();
+    expect(await run(root, sink, { interactive: true, confirmAuth: async () => false })).toBe(0);
+    const route = await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8");
+    expect(route).not.toContain("auth:");
+    expect(route).toContain("principal: async () => null");
+    const advisories = sink.logs.filter((line) => line.includes("Auth:"));
+    expect(advisories).toHaveLength(1);
+    expect(advisories[0]).toContain("left anonymous");
+    expect(advisories[0]).toContain("@clerk/nextjs");
+    expect(advisories[0]).toContain("auth: clerk()");
+    expect(advisories[0]).toContain(join("app", "api", "vendo", "[...vendo]", "route.ts"));
+  });
+
+  it("--yes never asks even in an interactive run: the detected default is accepted", async () => {
+    const root = await fixture();
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      name: "host",
+      dependencies: { next: "16.0.0", "next-auth": "5.0.0" },
+    }));
+    let askedCount = 0;
+    expect(await run(root, output(), {
+      yes: true,
+      interactive: true,
+      confirmAuth: async () => {
+        askedCount += 1;
+        return false;
+      },
+    })).toBe(0);
+    expect(askedCount).toBe(0);
+    const route = await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8");
+    expect(route).toContain("auth: authJs(),");
   });
 
   it("stays anonymous and advises once when several auth providers are present", async () => {

--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -351,6 +351,8 @@ describe("vendo init (zero-question)", () => {
     await expect(readFile(join(unwired, "vendo", "ai.ts"))).rejects.toMatchObject({ code: "ENOENT" });
     expect(sink.logs.join("\n")).toContain('app.use("/api/vendo", mountVendo());');
     expect(sink.logs.join("\n")).toContain("components={registry}");
+    // Fresh composition creation with no auth dependency: one calm advisory.
+    expect(sink.logs.join("\n")).toContain("Auth: no provider detected");
 
     const wired = await expressFixture(true);
     expect(await run(wired, output())).toBe(0);
@@ -359,6 +361,36 @@ describe("vendo init (zero-question)", () => {
     expect(await tree(wired)).toEqual(first);
     await expect(readFile(join(wired, "vendo", "server.ts"))).rejects.toMatchObject({ code: "ENOENT" });
     await expect(readFile(join(wired, "vendo", "registry.tsx"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("re-init on a scaffolded, not-yet-client-wired Express host changes nothing and stays silent", async () => {
+    const root = await expressFixture(false);
+    expect(await run(root, output())).toBe(0);
+    const first = await tree(root);
+    const again = output();
+    expect(await run(root, again)).toBe(0);
+    expect(await tree(root)).toEqual(first);
+    const logs = again.logs.join("\n");
+    expect(logs).toContain("Already wired — nothing to change.");
+    // The advisory fires only when the composition is created, never on the
+    // re-run between scaffold and the manual <VendoRoot> paste.
+    expect(logs).not.toContain("Auth:");
+  });
+
+  it("leaves a hand-wired Express composition at a custom path alone", async () => {
+    const root = await expressFixture(false);
+    await mkdir(join(root, "src"), { recursive: true });
+    await writeFile(join(root, "src", "agent.ts"),
+      'import { createVendo } from "@vendoai/vendo/server";\nexport const vendo = createVendo({ principal: async () => null });\n');
+    const sink = output();
+    expect(await run(root, sink)).toBe(0);
+    // No duplicate server module, no orphaned registry, no advisory about a
+    // composition init does not own — and the paste line stays honest.
+    await expect(readFile(join(root, "vendo", "server.ts"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(join(root, "vendo", "registry.tsx"))).rejects.toMatchObject({ code: "ENOENT" });
+    const logs = sink.logs.join("\n");
+    expect(logs).not.toContain("Auth:");
+    expect(logs).not.toContain("components={registry}");
   });
 
   it("uses an ESM scaffold when an Express host has no tsconfig", async () => {

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -710,22 +710,34 @@ async function buildPlan(options: InitOptions): Promise<{ plan: InitPlan; change
       const server = join(root, "vendo", typescript ? "server.ts" : "server.mjs");
       const registryFile = join(root, "vendo", typescript ? "registry.tsx" : "registry.mjs");
       const registryBefore = await readOptional(registryFile);
-      const auth = await detectAuthPreset(root);
-      // The registry is generated only while absent — never clobbered; the
-      // server file imports it as `catalog` (one file, two consumers).
-      if (registryBefore === null) {
+      const serverBefore = await readOptional(server);
+      // Init owns the composition only when it CREATES it: no generated
+      // server module yet AND no hand-wired createVendo anywhere else. A host
+      // that composed at its own path but hasn't pasted <VendoRoot> yet gets
+      // neither a duplicate server module nor an orphaned registry — the
+      // Express analog of the Next branch's routeBefore === null guard.
+      const scaffolding = serverBefore === null && !wiring.server;
+      // The registry regenerates only for a composition that uses it: the one
+      // being created now, or a previously generated server module whose
+      // ./registry import would otherwise dangle. Never clobbered.
+      const registryPlanned = registryBefore === null
+        && (scaffolding || serverBefore?.includes("./registry") === true);
+      if (registryPlanned) {
         const path = relative(root, registryFile);
         const registryAfter = registrySource(typescript ? "tsx" : "mjs");
         changes.push({ absolute: registryFile, path, before: null, after: registryAfter, diff: diff(path, null, registryAfter) });
       }
-      const serverBefore = await readOptional(server);
-      const serverAfter = expressServerSource(typescript, auth.wired);
-      if (serverBefore !== serverAfter) {
+      if (scaffolding) {
+        const auth = await detectAuthPreset(root);
+        const serverAfter = expressServerSource(typescript, auth.wired);
         const path = relative(root, server);
-        changes.push({ absolute: server, path, before: serverBefore, after: serverAfter, diff: diff(path, serverBefore, serverAfter) });
+        changes.push({ absolute: server, path, before: null, after: serverAfter, diff: diff(path, null, serverAfter) });
+        // Advisory only on fresh composition creation — a re-run before the
+        // manual <VendoRoot> paste stays silent instead of re-firing after
+        // "Already wired".
+        authAdvice = authAdvisory(auth, path);
       }
-      authAdvice = authAdvisory(auth, relative(root, server));
-      withRegistry = true;
+      withRegistry = registryBefore !== null || registryPlanned;
     }
   } else {
     const app = await appDirectory(root);

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -43,9 +43,11 @@ import {
  * `vendo init` (install-dx v1, re-derived 2026-07-18): one command, zero
  * questions on the happy path, no ceremony.
  *
- *   scan → wire (ONE new file + package.json hooks; never edits user-authored
- *   code) → key (env stated, else the cloud starter offer) → done summary
- *   (files changed, the VendoRoot line to paste, next steps).
+ *   scan → wire (the two-file surface — empty vendo/registry.tsx + the
+ *   catch-all handler wired to it, auth preset detected silently — plus
+ *   package.json hooks; never edits user-authored code) → key (env stated,
+ *   else the cloud starter offer) → done summary (files changed, the
+ *   VendoRoot line to paste, next steps).
  *
  * Removed by design: the interview, per-diff y/N approvals, the layout
  * codemod, the lib/ai.ts scaffold (createVendo's `model` is optional now),
@@ -200,12 +202,110 @@ async function appDirectory(root: string): Promise<string> {
   return join(root, "app");
 }
 
-function routeSource(withServerActions = false): string {
-  return `import { createVendo, nextVendoHandler } from "@vendoai/vendo/server";\n` +
-    (withServerActions ? `import { serverActions } from "./vendo-actions";\n` : "") +
+/** The auth families init detects in package.json (09-vendo §2.1). Preset
+    names double as the zero-arg `@vendoai/vendo/server` export names. */
+type AuthPresetName = "authJs" | "clerk" | "supabase" | "auth0";
+
+interface AuthMatch {
+  preset: AuthPresetName;
+  dependency: string;
+}
+
+interface AuthDetection {
+  /** Exactly one family matched — the preset init wires silently. */
+  wired: AuthMatch | null;
+  /** Every family that matched (for the ambiguity advisory). */
+  matches: AuthMatch[];
+}
+
+const AUTH_FAMILIES: ReadonlyArray<{ preset: AuthPresetName; test: (dependency: string) => boolean }> = [
+  { preset: "authJs", test: (dependency) => dependency === "next-auth" || dependency.startsWith("@auth/") },
+  { preset: "clerk", test: (dependency) => dependency.startsWith("@clerk/") },
+  { preset: "supabase", test: (dependency) => dependency.startsWith("@supabase/") },
+  { preset: "auth0", test: (dependency) => dependency.startsWith("@auth0/") },
+];
+
+/** Silent auth-preset detection from the host's package.json (zero-question
+    contract): one unambiguous family gets wired; none or several stay
+    anonymous and become one advisory line (detection-as-advice). */
+async function detectAuthPreset(root: string): Promise<AuthDetection> {
+  let dependencies: string[] = [];
+  try {
+    const manifest = JSON.parse((await readOptional(join(root, "package.json"))) ?? "{}") as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    dependencies = Object.keys({ ...manifest.dependencies, ...manifest.devDependencies });
+  } catch {
+    // No readable manifest — nothing to detect; anonymous is the safe default.
+  }
+  const matches = AUTH_FAMILIES.flatMap(({ preset, test }) => {
+    const dependency = dependencies.find(test);
+    return dependency === undefined ? [] : [{ preset, dependency }];
+  });
+  return { wired: matches.length === 1 ? matches[0]! : null, matches };
+}
+
+/** The one calm auth line for the none/ambiguous cases — names the exact
+    line to add, never asks a question. Emitted only when init scaffolds the
+    composition (a hand-wired host may already have auth). */
+function authAdvisory(detection: AuthDetection, compositionPath: string): string | null {
+  if (detection.wired !== null) return null;
+  if (detection.matches.length === 0) {
+    return `Auth: no provider detected — sessions stay anonymous. When you add one, add one line in ${compositionPath}: ` +
+      `auth: authJs() (Auth.js), clerk(), supabase(), auth0(), or jwt({ secret }).`;
+  }
+  const names = detection.matches.map((match) => match.dependency).join(", ");
+  const calls = detection.matches.map((match) => `auth: ${match.preset}()`).join(" or ");
+  return `Auth: several providers detected (${names}) — staying anonymous rather than guessing. Add one line in ${compositionPath}: ${calls}.`;
+}
+
+/** The wired preset line plus its escape-hatch comment. */
+function authConfigLines(auth: AuthMatch): string {
+  return `  // Detected ${auth.dependency} — ${auth.preset}() fills the identity seams\n` +
+    `  // (request→user, actAs, door OAuth); options and the per-seam escape\n` +
+    `  // hatch: docs/act-as-presets.md.\n` +
+    `  auth: ${auth.preset}(),\n`;
+}
+
+/** The empty shared registry (one file, two consumers): `createVendo` reads it
+    as `catalog` (data fields only), `<VendoRoot components={registry}>` reads
+    the component references. Generated only while absent — never clobbered. */
+function registrySource(variant: "tsx" | "mjs"): string {
+  const header = `/**\n` +
+    ` * The Vendo component registry — generated empty by \`vendo init\`, then yours.\n` +
+    ` * One file, two consumers: \`createVendo\` takes this object as \`catalog\` and\n` +
+    ` * reads only the data fields (description, props, examples); <VendoRoot\n` +
+    ` * components={registry}> takes the same object and reads only the component\n` +
+    ` * references. There is no second map to keep in sync.\n` +
+    ` *\n` +
+    ` * Add entries keyed by component name, e.g.:\n` +
+    ` *\n` +
+    ` *   SpendingDonut: {\n` +
+    ` *     component: SpendingDonut,\n` +
+    ` *     description: "Spending by category. Use for where-did-my-money-go requests.",\n` +
+    ` *     props: z.object({\n` +
+    ` *       slices: z.array(z.object({ category: z.string(), amount: z.number() })),\n` +
+    ` *     }),\n` +
+    ` *     examples: ['{"slices":[{"category":"dining","amount":342.18}]}'],\n` +
+    ` *   },\n` +
+    ` *\n` +
+    ` * (\`props\` is an optional zod schema; a schema-less entry is legal.)\n` +
+    ` */\n`;
+  return variant === "tsx"
+    ? `${header}import type { ComponentRegistry } from "@vendoai/core";\n\nexport const registry = {} satisfies ComponentRegistry;\n`
+    : `${header}export const registry = {};\n`;
+}
+
+function routeSource(options: { serverActions: boolean; auth: AuthMatch | null; registrySpecifier: string }): string {
+  const named = [...(options.auth === null ? [] : [options.auth.preset]), "createVendo", "nextVendoHandler"].sort();
+  return `import { ${named.join(", ")} } from "@vendoai/vendo/server";\n` +
+    (options.serverActions ? `import { serverActions } from "./vendo-actions";\n` : "") +
+    `import { registry } from ${JSON.stringify(options.registrySpecifier)};\n` +
     `\nconst vendo = createVendo({\n` +
-    `  principal: async () => null,\n` +
-    (withServerActions ? `  serverActions,\n` : "") +
+    (options.auth === null ? `  principal: async () => null,\n` : authConfigLines(options.auth)) +
+    `  catalog: registry,\n` +
+    (options.serverActions ? `  serverActions,\n` : "") +
     `});\n\n` +
     `export const { GET, POST, DELETE } = nextVendoHandler(vendo);\n`;
 }
@@ -253,7 +353,7 @@ function serverActionsModuleSource(root: string, wiringDir: string, registration
     `export const serverActions = {\n${entries.join("\n")}\n};\n`;
 }
 
-function expressServerSource(typescript: boolean): string {
+function expressServerSource(typescript: boolean, auth: AuthMatch | null = null): string {
   const imports = typescript
     ? `import { once } from "node:events";\n` +
       `import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "node:http";\n` +
@@ -283,17 +383,21 @@ function expressServerSource(typescript: boolean): string {
   // The client-entry hint mirrors the host's language: the TS variant needs the
   // VendoTheme cast (JSON-module literals widen to string), the JS variant must
   // not show type-only syntax a JavaScript host cannot paste.
+  const registrySpecifier = typescript ? "./registry" : "./registry.mjs";
   const clientHint = typescript
     ? ` *   // in the client entry — theme.json adopts the host brand (08 §4);\n` +
       ` *   // the cast narrows TypeScript's widened JSON-module string literals:\n` +
       ` *   import { VendoRoot } from "@vendoai/vendo/react";\n` +
+      ` *   import { registry } from "<path-to>/vendo/registry";\n` +
       ` *   import theme from "<path-to>/.vendo/theme.json";\n` +
       ` *   import type { VendoTheme } from "@vendoai/vendo";\n` +
-      ` *   root.render(<VendoRoot theme={theme as VendoTheme}><App /></VendoRoot>);\n`
+      ` *   root.render(<VendoRoot components={registry} theme={theme as VendoTheme}><App /></VendoRoot>);\n`
     : ` *   // in the client entry — theme.json adopts the host brand (08 §4):\n` +
       ` *   import { VendoRoot } from "@vendoai/vendo/react";\n` +
+      ` *   import { registry } from "<path-to>/vendo/registry.mjs";\n` +
       ` *   import theme from "<path-to>/.vendo/theme.json";\n` +
-      ` *   root.render(<VendoRoot theme={theme}><App /></VendoRoot>);\n`;
+      ` *   root.render(<VendoRoot components={registry} theme={theme}><App /></VendoRoot>);\n`;
+  const serverNamed = [...(auth === null ? [] : [auth.preset]), "createVendo"].sort();
 
   return `/**\n` +
     ` * Add these wiring lines in your host:\n` +
@@ -301,10 +405,12 @@ function expressServerSource(typescript: boolean): string {
     clientHint +
     ` */\n` +
     imports +
-    `import { createVendo } from "@vendoai/vendo/server";\n` +
+    `import { ${serverNamed.join(", ")} } from "@vendoai/vendo/server";\n` +
+    `import { registry } from ${JSON.stringify(registrySpecifier)};\n` +
     types +
     `\nconst vendo = createVendo({\n` +
-    `  principal: async () => null,\n` +
+    (auth === null ? `  principal: async () => null,\n` : authConfigLines(auth)) +
+    `  catalog: registry,\n` +
     `});\n\n` +
     `function requestHeaders${signatures.requestHeaders} {\n` +
     `  const result = new Headers();\n` +
@@ -366,7 +472,9 @@ function expressServerSource(typescript: boolean): string {
 }
 
 const VENDO_ENV_EXAMPLE =
-  "# Trusted host origin for same-origin API calls; credential forwarding is disabled without it.\n" +
+  "# Trusted host origin for same-origin API calls. Dev trusts the request's own\n" +
+  "# origin automatically; production fails loud without this set (a credential-\n" +
+  "# forwarding call errors instead of silently running unauthenticated).\n" +
   "VENDO_BASE_URL=http://localhost:3000\n" +
   "# Model key — REQUIRED in production. In dev, `vendo init` can mint a free starter key instead.\n" +
   "# ANTHROPIC_API_KEY=\n";
@@ -552,46 +660,72 @@ async function setupSkillSource(): Promise<string | null> {
   }
 }
 
-/** The one line init never writes: the user pastes the VendoRoot wrap. */
-async function vendoRootPasteLines(root: string, framework: HostFramework): Promise<string[]> {
+/** The one line init never writes: the user pastes the VendoRoot wrap. When
+    the shared registry exists (scaffolded or host-authored) the wrap carries
+    `components={registry}` — the client half of the one-file/two-consumers
+    pattern; it stays ONE pasted line plus its imports. */
+async function vendoRootPasteLines(root: string, framework: HostFramework, withRegistry: boolean): Promise<string[]> {
   if (framework === "express") {
+    const wrap = withRegistry
+      ? `<VendoRoot components={registry} theme={theme}>…</VendoRoot>`
+      : `<VendoRoot theme={theme}>…</VendoRoot>`;
     return [
       `app.use("/api/vendo", mountVendo());   // in your server`,
-      `<VendoRoot theme={theme}>…</VendoRoot>  // around your client root (see vendo/server for the imports)`,
+      `${wrap}  // around your client root (see vendo/server for the imports)`,
     ];
   }
   const app = await appDirectory(root);
   const specifier = await themeImportSpecifier(root, app);
   const layout = relative(root, join(app, "layout.tsx"));
-  const importLines = specifier === null
-    ? [`import { VendoRoot } from "@vendoai/vendo/react";`]
-    : [
-        `import { VendoRoot } from "@vendoai/vendo/react";`,
-        `import theme from ${JSON.stringify(specifier)};`,
-        `import type { VendoTheme } from "@vendoai/vendo";`,
-      ];
-  const wrap = specifier === null
-    ? `<VendoRoot>{children}</VendoRoot>`
-    : `<VendoRoot theme={theme as VendoTheme}>{children}</VendoRoot>`;
+  const registrySpecifier = relative(app, join(dirname(app), "vendo", "registry")).split(sep).join("/");
+  const importLines = [
+    `import { VendoRoot } from "@vendoai/vendo/react";`,
+    ...(withRegistry ? [`import { registry } from ${JSON.stringify(registrySpecifier)};`] : []),
+    ...(specifier === null
+      ? []
+      : [
+          `import theme from ${JSON.stringify(specifier)};`,
+          `import type { VendoTheme } from "@vendoai/vendo";`,
+        ]),
+  ];
+  const props = [
+    ...(withRegistry ? ["components={registry}"] : []),
+    ...(specifier === null ? [] : ["theme={theme as VendoTheme}"]),
+  ];
+  const wrap = `<VendoRoot${props.length === 0 ? "" : ` ${props.join(" ")}`}>{children}</VendoRoot>`;
   return [`In ${layout}:`, ...importLines.map((line) => `  ${line}`), `  … then wrap: ${wrap}`];
 }
 
-async function buildPlan(options: InitOptions): Promise<{ plan: InitPlan; changes: PlannedChange[]; manualSteps: string[] }> {
+async function buildPlan(options: InitOptions): Promise<{ plan: InitPlan; changes: PlannedChange[]; manualSteps: string[]; authAdvice: string | null }> {
   const root = resolve(options.targetDir);
   const framework = await detectFramework(root);
   const changes: PlannedChange[] = [];
+  let authAdvice: string | null = null;
+  let withRegistry = false;
 
   if (framework === "express") {
     const wiring = await detectVendoWiring(root);
     if (!wiring.server || !wiring.client) {
       const typescript = await exists(join(root, "tsconfig.json"));
       const server = join(root, "vendo", typescript ? "server.ts" : "server.mjs");
+      const registryFile = join(root, "vendo", typescript ? "registry.tsx" : "registry.mjs");
+      const registryBefore = await readOptional(registryFile);
+      const auth = await detectAuthPreset(root);
+      // The registry is generated only while absent — never clobbered; the
+      // server file imports it as `catalog` (one file, two consumers).
+      if (registryBefore === null) {
+        const path = relative(root, registryFile);
+        const registryAfter = registrySource(typescript ? "tsx" : "mjs");
+        changes.push({ absolute: registryFile, path, before: null, after: registryAfter, diff: diff(path, null, registryAfter) });
+      }
       const serverBefore = await readOptional(server);
-      const serverAfter = expressServerSource(typescript);
+      const serverAfter = expressServerSource(typescript, auth.wired);
       if (serverBefore !== serverAfter) {
         const path = relative(root, server);
         changes.push({ absolute: server, path, before: serverBefore, after: serverAfter, diff: diff(path, serverBefore, serverAfter) });
       }
+      authAdvice = authAdvisory(auth, relative(root, server));
+      withRegistry = true;
     }
   } else {
     const app = await appDirectory(root);
@@ -600,6 +734,20 @@ async function buildPlan(options: InitOptions): Promise<{ plan: InitPlan; change
     const routeBefore = await readOptional(route);
     const actionsBefore = await readOptional(actionsModule);
     const registrations = await wiringServerActions(root);
+    // The shared registry mirrors the app dir (src/app → src/vendo): generated
+    // only while absent and only when the route uses it — a fresh scaffold, or
+    // a route that already imports vendo/registry. A hand-wired route that
+    // ignores the registry never grows an orphan file.
+    const registryFile = join(dirname(app), "vendo", "registry.tsx");
+    const registryBefore = await readOptional(registryFile);
+    const registryPlanned = registryBefore === null
+      && (routeBefore === null || routeBefore.includes("vendo/registry"));
+    if (registryPlanned) {
+      const path = relative(root, registryFile);
+      const registryAfter = registrySource("tsx");
+      changes.push({ absolute: registryFile, path, before: null, after: registryAfter, diff: diff(path, null, registryAfter) });
+    }
+    withRegistry = registryBefore !== null || registryPlanned;
     // The registration map regenerates whenever the detected "use server"
     // surface changes; an existing map is kept compiling (emptied, never
     // deleted) when the last action disappears.
@@ -611,9 +759,12 @@ async function buildPlan(options: InitOptions): Promise<{ plan: InitPlan; change
       }
     }
     if (routeBefore === null) {
+      const auth = await detectAuthPreset(root);
       const path = relative(root, route);
-      const routeAfter = routeSource(registrations.length > 0);
+      const registrySpecifier = relative(dirname(route), join(dirname(app), "vendo", "registry")).split(sep).join("/");
+      const routeAfter = routeSource({ serverActions: registrations.length > 0, auth: auth.wired, registrySpecifier });
       changes.push({ absolute: route, path, before: routeBefore, after: routeAfter, diff: diff(path, routeBefore, routeAfter) });
+      authAdvice = authAdvisory(auth, path);
     } else if (registrations.length > 0) {
       // The route already exists but server actions appeared since it was
       // generated: wire the registration map into the existing createVendo so
@@ -663,10 +814,11 @@ async function buildPlan(options: InitOptions): Promise<{ plan: InitPlan; change
     ".vendo/theme.json",
     ".vendo/data/.gitignore",
   ];
-  const manualSteps = await vendoRootPasteLines(root, framework);
+  const manualSteps = await vendoRootPasteLines(root, framework, withRegistry);
   return {
     changes,
     manualSteps,
+    authAdvice,
     plan: {
       framework,
       root,
@@ -732,7 +884,7 @@ export async function runInit(options: InitOptions): Promise<number> {
     return 0;
   }
 
-  const { plan, changes, manualSteps } = await buildPlan(options);
+  const { plan, changes, manualSteps, authAdvice } = await buildPlan(options);
   const telemetry = telemetryFor(options, output);
   await telemetry.track("init_started", { framework: plan.framework });
 
@@ -834,6 +986,10 @@ export async function runInit(options: InitOptions): Promise<number> {
     } else {
       output.log("\nAlready wired — nothing to change.");
     }
+    // Detection-as-advice (zero-question contract): a wired preset stays
+    // silent — the comment in the scaffold cites the escape hatch; none or
+    // ambiguous gets exactly one calm line naming the line to add.
+    if (authAdvice !== null) output.log(authAdvice);
     output.log(`Learned: ${toolCount} tools · theme captured → .vendo/ (tools.json, theme.json, brief.md)`);
 
     // Key — state the env credential, or offer the cloud starter key.

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -17,7 +17,7 @@ import type { Telemetry } from "@vendoai/telemetry";
 import type { LanguageModel } from "ai";
 import { runCloudStep, type CloudStepOptions } from "./cloud-init.js";
 import { APPLY_COMMAND, composeDelegatedInstructions, EXTRACTION_DRAFT_JSON_SCHEMA } from "./extract/delegate.js";
-import { runAiExtraction, type AiExtractionOptions } from "./extract/extraction.js";
+import { askYesNo, runAiExtraction, type AiExtractionOptions } from "./extract/extraction.js";
 import type { StaticTool } from "./extract/stages.js";
 import { resolveDevCredential, describeDevCredential, type DevCredential } from "../dev-creds/resolve.js";
 import { detectFramework, detectVendoWiring, type HostFramework } from "./framework.js";
@@ -44,10 +44,11 @@ import {
  * questions on the happy path, no ceremony.
  *
  *   scan → wire (the two-file surface — empty vendo/registry.tsx + the
- *   catch-all handler wired to it, auth preset detected silently — plus
- *   package.json hooks; never edits user-authored code) → key (env stated,
- *   else the cloud starter offer) → done summary (files changed, the
- *   VendoRoot line to paste, next steps).
+ *   catch-all handler wired to it; a detected auth preset gets one
+ *   consent-style confirm in interactive runs, --yes/non-interactive accept
+ *   it silently — plus package.json hooks; never edits user-authored code)
+ *   → key (env stated, else the cloud starter offer) → done summary (files
+ *   changed, the VendoRoot line to paste, next steps).
  *
  * Removed by design: the interview, per-diff y/N approvals, the layout
  * codemod, the lib/ai.ts scaffold (createVendo's `model` is optional now),
@@ -131,6 +132,13 @@ export interface InitOptions {
   cloud?: Partial<Omit<CloudStepOptions, "root" | "output" | "yes" | "credential">>;
   /** Test seam: AI extraction step overrides (harnesses, consent). */
   extract?: Partial<Omit<AiExtractionOptions, "root" | "output" | "yes" | "env">>;
+  /** Test seam: the detect+confirm auth question, asked only in interactive
+      runs when exactly one auth family is detected and init is creating the
+      composition. Mirrors the AI-polish consent's confirm shape. */
+  confirmAuth?: (question: string, defaultYes: boolean) => Promise<boolean>;
+  /** Test seam: interactivity override for the auth confirm (default: TTY),
+      mirroring runAiExtraction's `interactive`. */
+  interactive?: boolean;
   /** Test seam: the theme LLM pass's model; default rides the refine seam. */
   themeModel?: () => Promise<LanguageModel>;
   /** Uncertain-slot review — asked ONLY when the model reports uncertainty. */
@@ -258,6 +266,36 @@ function authAdvisory(detection: AuthDetection, compositionPath: string): string
   const names = detection.matches.map((match) => match.dependency).join(", ");
   const calls = detection.matches.map((match) => `auth: ${match.preset}()`).join(" or ");
   return `Auth: several providers detected (${names}) — staying anonymous rather than guessing. Add one line in ${compositionPath}: ${calls}.`;
+}
+
+/** The declined-confirm advisory: anonymous composition, exact line in hand. */
+function declinedAuthAdvisory(match: AuthMatch, compositionPath: string): string {
+  return `Auth: left anonymous. To wire ${match.dependency} later, add one line in ${compositionPath}: auth: ${match.preset}().`;
+}
+
+type ConfirmAuth = (question: string, defaultYes: boolean) => Promise<boolean>;
+
+/** Detect + confirm: in interactive runs, exactly one detected family gets
+    ONE calm [Y/n] question before anything is written (Enter accepts).
+    Without a confirm (non-interactive, --yes, --agent) silent detection
+    stands — a default has to exist. None/ambiguous never ask: nothing is
+    certain enough to confirm, the advisory line covers it. */
+async function resolveScaffoldAuth(
+  root: string,
+  compositionPath: string,
+  confirmAuth: ConfirmAuth | undefined,
+): Promise<{ wired: AuthMatch | null; advice: string | null }> {
+  const detection = await detectAuthPreset(root);
+  if (detection.wired === null || confirmAuth === undefined) {
+    return { wired: detection.wired, advice: authAdvisory(detection, compositionPath) };
+  }
+  const accepted = await confirmAuth(
+    `Detected ${detection.wired.dependency} — wire auth: ${detection.wired.preset}()?`,
+    true,
+  );
+  return accepted
+    ? { wired: detection.wired, advice: null }
+    : { wired: null, advice: declinedAuthAdvisory(detection.wired, compositionPath) };
 }
 
 /** The wired preset line plus its escape-hatch comment. */
@@ -696,7 +734,7 @@ async function vendoRootPasteLines(root: string, framework: HostFramework, withR
   return [`In ${layout}:`, ...importLines.map((line) => `  ${line}`), `  … then wrap: ${wrap}`];
 }
 
-async function buildPlan(options: InitOptions): Promise<{ plan: InitPlan; changes: PlannedChange[]; manualSteps: string[]; authAdvice: string | null }> {
+async function buildPlan(options: InitOptions, confirmAuth?: ConfirmAuth): Promise<{ plan: InitPlan; changes: PlannedChange[]; manualSteps: string[]; authAdvice: string | null }> {
   const root = resolve(options.targetDir);
   const framework = await detectFramework(root);
   const changes: PlannedChange[] = [];
@@ -728,14 +766,14 @@ async function buildPlan(options: InitOptions): Promise<{ plan: InitPlan; change
         changes.push({ absolute: registryFile, path, before: null, after: registryAfter, diff: diff(path, null, registryAfter) });
       }
       if (scaffolding) {
-        const auth = await detectAuthPreset(root);
-        const serverAfter = expressServerSource(typescript, auth.wired);
         const path = relative(root, server);
+        // Detect + confirm happens only here — fresh composition creation —
+        // so a re-run before the manual <VendoRoot> paste neither asks nor
+        // re-fires the advisory after "Already wired".
+        const auth = await resolveScaffoldAuth(root, path, confirmAuth);
+        const serverAfter = expressServerSource(typescript, auth.wired);
         changes.push({ absolute: server, path, before: null, after: serverAfter, diff: diff(path, null, serverAfter) });
-        // Advisory only on fresh composition creation — a re-run before the
-        // manual <VendoRoot> paste stays silent instead of re-firing after
-        // "Already wired".
-        authAdvice = authAdvisory(auth, path);
+        authAdvice = auth.advice;
       }
       withRegistry = registryBefore !== null || registryPlanned;
     }
@@ -771,12 +809,13 @@ async function buildPlan(options: InitOptions): Promise<{ plan: InitPlan; change
       }
     }
     if (routeBefore === null) {
-      const auth = await detectAuthPreset(root);
       const path = relative(root, route);
+      // Detect + confirm happens only on fresh composition creation.
+      const auth = await resolveScaffoldAuth(root, path, confirmAuth);
       const registrySpecifier = relative(dirname(route), join(dirname(app), "vendo", "registry")).split(sep).join("/");
       const routeAfter = routeSource({ serverActions: registrations.length > 0, auth: auth.wired, registrySpecifier });
       changes.push({ absolute: route, path, before: routeBefore, after: routeAfter, diff: diff(path, routeBefore, routeAfter) });
-      authAdvice = authAdvisory(auth, path);
+      authAdvice = auth.advice;
     } else if (registrations.length > 0) {
       // The route already exists but server actions appeared since it was
       // generated: wire the registration map into the existing createVendo so
@@ -896,7 +935,14 @@ export async function runInit(options: InitOptions): Promise<number> {
     return 0;
   }
 
-  const { plan, changes, manualSteps, authAdvice } = await buildPlan(options);
+  // Detect + confirm (interactive runs only): --yes and non-interactive runs
+  // accept the detected default silently — the same interactivity posture as
+  // the AI-polish consent.
+  const interactive = options.interactive ?? (Boolean(stdin.isTTY) && Boolean(stdout.isTTY));
+  const confirmAuth = options.yes === true || !interactive
+    ? undefined
+    : (options.confirmAuth ?? askYesNo);
+  const { plan, changes, manualSteps, authAdvice } = await buildPlan(options, confirmAuth);
   const telemetry = telemetryFor(options, output);
   await telemetry.track("init_started", { framework: plan.framework });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2887,6 +2887,9 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -4235,6 +4238,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-uri@3.1.3:
     resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
@@ -5892,6 +5898,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -8067,6 +8076,8 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -9707,6 +9718,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-sha256@1.3.0: {}
 
   fast-uri@3.1.3: {}
 
@@ -11703,6 +11716,11 @@ snapshots:
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   statuses@2.0.2: {}
 


### PR DESCRIPTION
`vendo init` adopts the two-file surface that PR #376 shipped — closing the init-lane handoff note (docs/superpowers/plans/2026-07-18-init-lane-handoff.md, all bullets now dated-closed).

## What a fresh init now scaffolds (zero questions, unchanged contract)

```
Wired (3 files):
  + src/vendo/registry.tsx                      ← empty registry, self-teaching doc comment
  + src/app/api/vendo/[...vendo]/route.ts       ← composition inline: auth preset + catalog: registry
  ~ package.json
```

- **Silent auth detection** from package.json deps: exactly one of next-auth/@auth/* → `auth: authJs()`, @clerk/* → `clerk()`, @supabase/* → `supabase()`, @auth0/* → `auth0()` (with an escape-hatch comment). None or several → anonymous as before, plus ONE advisory line naming the exact line to add. `jwt()` is advice-only, never scaffolded.
- **The one pasted line** becomes `<VendoRoot components={registry} theme={theme}>` — still one line, contract preserved.
- **Composition stays inline in the route** (deliberate: no third generated file, keeps the ENG-248 serverActions rewiring seam; both quickstarts updated to frame the route as the composition, with the vendo/server.ts split documented as the variant for hosts that need the `vendo` object elsewhere).
- Ownership guards: init only scaffolds registry/composition when it CREATES the composition — hand-wired hosts (any path) get no orphaned files, no advisory, and an honest paste line without `components={registry}`. Re-init is fully idempotent and silent (Express advisory re-fire fixed + tested).
- `.env.example`'s VENDO_BASE_URL comment now states the real semantics (dev trusts its own origin; production fails loud).
- Lockfile repair: restores @clerk/backend's transitive entries (@stablelib/base64, fast-sha256, standardwebhooks) dropped in the same-day lockfile merge races.

## Verification
- init.test.ts 29/29 (5 preset detections, ambiguity advisory, never-clobber, no-orphan, quiet re-init ×2 frameworks, ESM variant); full monorepo build/test/typecheck/lint green (clean run).
- Real CLI smoke: fresh next-auth fixture → files above; re-init → "Already wired — nothing to change."; hand-wired-at-custom-path fixture → no new files.
- Two-stage review (spec ×2 rounds with independent repros + quality) passed.

Also fixes the stale "model is the only required key" claim in docs-site/quickstart.mdx. Known out-of-scope: docs-site/connect/vendo-init.mdx is broadly pre-existing stale (describes the removed interview wizard) — needs its own pass.

https://claude.ai/code/session_018S4HHYRGSGyDXwNGo3oJWS

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`vendo init` now scaffolds the two-file surface: a shared `vendo/registry.tsx` and an inline catch-all route composition wired to it, with auth preset detect + confirm in interactive runs. Init stays zero‑question under `--yes` and non‑interactive modes, and reduces setup to a single `<VendoRoot components={registry}>` paste.

- **New Features**
  - Scaffolds `vendo/registry.tsx` and wires `catalog: registry` in the generated Next catch‑all route and Express server module; composition stays inline.
  - Auth detection from `package.json`: `next-auth`/`@auth/*` → `authJs()`, `@clerk/*` → `clerk()`, `@supabase/*` → `supabase()`, `@auth0/*` → `auth0()`; interactive runs ask one `[Y/n]` to confirm, `--yes`/non‑interactive accept silently; none or several stays anonymous with one advisory line.
  - Printed paste now uses `<VendoRoot components={registry}>` with imports; user code is never edited.
  - `.env.example` clarifies `VENDO_BASE_URL`: dev trusts its own origin; production fails loud without it.
  - Quickstarts updated to the two‑file surface and note that `createVendo()` can be called without explicit `model`.

- **Bug Fixes**
  - Ownership guards prevent orphan registries and duplicate Express server modules; re‑init is quiet and idempotent.
  - Tests cover preset detect+confirm, ambiguity advisory, never‑clobber registry, ESM variant, and Express re‑init behavior.
  - Restores missing transitive lockfile entries for `@clerk/backend` (`@stablelib/base64`, `fast-sha256`, `standardwebhooks`).

<sup>Written for commit 7b17c8a4066de6bebc2a4058aca35a2cf415890f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

