### PR TITLE
ci: make mintlify-automerge work under strict branch protection

### DIFF
--- a/.github/workflows/mintlify-automerge.yml
+++ b/.github/workflows/mintlify-automerge.yml
@@ -1,80 +1,101 @@
 # Auto-merge Mintlify docs PRs (Yousef, 2026-07-18).
 #
 # Mintlify's docs agent opens PRs as mintlify[bot] on in-repo mintlify/*
-# branches, touching only docs-site/**. Those merge themselves once every
-# other check on the head SHA has finished green. Two guards keep this
-# narrow: the author must be mintlify[bot], and the diff must stay entirely
-# inside docs-site/ — a bot PR touching anything else is left for humans.
+# branches, touching only docs-site/**. Two guards keep this narrow: the
+# author must be mintlify[bot], and the diff must stay entirely inside
+# docs-site/ — a bot PR touching anything else is left for humans.
 #
-# The wait loop polls check-runs + commit statuses itself (instead of GitHub
-# native auto-merge, which would merge instantly because main has no required
-# checks; instead of `gh pr checks --watch`, which would deadlock waiting on
-# this very job). Success/neutral/skipped pass; any failure aborts without
-# merging.
+# main's branch protection requires ci/integration/perf green on an
+# up-to-date branch (strict mode), so this workflow arms GitHub native
+# auto-merge (repo allow_auto_merge is on) and nudges behind branches with
+# update-branch. GitHub merges the PR itself the moment required checks
+# pass. Because update-branch runs under GITHUB_TOKEN, the synchronize it
+# causes does not re-trigger this workflow — the half-hourly sweep is the
+# safety net that re-nudges anything that went behind again, and it also
+# prunes merged mintlify/* branches (native auto-merge doesn't delete them).
 name: mintlify-automerge
 
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+  schedule:
+    - cron: "17,47 * * * *"
+  workflow_dispatch:
 
 permissions:
   contents: write
   pull-requests: write
 
 concurrency:
-  group: mintlify-automerge-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: mintlify-automerge
+  cancel-in-progress: false
 
 jobs:
   automerge:
     name: automerge
-    if: github.event.pull_request.user.login == 'mintlify[bot]'
+    if: github.event_name != 'pull_request' || github.event.pull_request.user.login == 'mintlify[bot]'
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 15
     env:
       GH_TOKEN: ${{ github.token }}
       REPO: ${{ github.repository }}
-      PR: ${{ github.event.pull_request.number }}
-      SHA: ${{ github.event.pull_request.head.sha }}
+      EVENT_PR: ${{ github.event.pull_request.number }}
     steps:
-      - name: Guard: diff is docs-site/** only
+      - name: Arm auto-merge and nudge behind branches
         run: |
-          outside=$(gh api "repos/$REPO/pulls/$PR/files" --paginate \
-            --jq '.[].filename | select(startswith("docs-site/") | not)')
-          if [ -n "$outside" ]; then
-            echo "Not docs-site-only; leaving for humans:"
-            echo "$outside"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
+          process_pr() {
+            local pr="$1"
+
+            local outside
+            outside=$(gh api "repos/$REPO/pulls/$pr/files" --paginate \
+              --jq '.[].filename | select(startswith("docs-site/") | not)')
+            if [ -n "$outside" ]; then
+              echo "PR #$pr touches files outside docs-site/; leaving for humans:"
+              echo "$outside"
+              return 0
+            fi
+
+            local state mss
+            state=$(gh pr view "$pr" --repo "$REPO" --json state --jq .state)
+            mss=$(gh pr view "$pr" --repo "$REPO" --json mergeStateStatus --jq .mergeStateStatus)
+            echo "PR #$pr: state=$state mergeStateStatus=$mss"
+            [ "$state" = "OPEN" ] || return 0
+
+            if [ "$mss" = "DIRTY" ]; then
+              echo "PR #$pr has conflicts; leaving for humans."
+              return 0
+            fi
+
+            # Arm native auto-merge; if the PR is already clean this call is
+            # rejected, so fall through to an immediate merge.
+            if ! gh pr merge "$pr" --repo "$REPO" --auto --squash; then
+              gh pr merge "$pr" --repo "$REPO" --squash --delete-branch || true
+            fi
+
+            # Strict required checks demand an up-to-date branch, and GitHub
+            # never updates it for us.
+            if [ "$mss" = "BEHIND" ]; then
+              echo "PR #$pr is behind main; updating branch."
+              gh api -X PUT "repos/$REPO/pulls/$pr/update-branch" || true
+            fi
+          }
+
+          if [ -n "$EVENT_PR" ]; then
+            process_pr "$EVENT_PR"
+          else
+            for pr in $(gh pr list --repo "$REPO" --author 'app/mintlify' --state open --json number --jq '.[].number'); do
+              process_pr "$pr"
+            done
           fi
-        id: guard
 
-      - name: Wait for every other check on the head SHA
-        if: steps.guard.outputs.skip != 'true'
+      - name: Prune merged mintlify/* branches
+        if: github.event_name != 'pull_request'
         run: |
-          # Give slow-dispatching suites time to register before we trust
-          # "nothing pending" (this repo's check suites sometimes lag).
-          sleep 120
-          for i in $(seq 1 80); do
-            runs=$(gh api "repos/$REPO/commits/$SHA/check-runs" --paginate \
-              --jq '[.check_runs[] | select(.name != "automerge")]')
-            statuses=$(gh api "repos/$REPO/commits/$SHA/status" --jq '.statuses')
-            pending=$(jq -n --argjson r "$runs" --argjson s "$statuses" \
-              '([$r[] | select(.status != "completed")] + [$s[] | select(.state == "pending")]) | length')
-            failed=$(jq -n --argjson r "$runs" --argjson s "$statuses" \
-              '([$r[] | select(.conclusion and (.conclusion | IN("success","neutral","skipped") | not))] + [$s[] | select(.state | IN("failure","error"))]) | length')
-            total=$(jq -n --argjson r "$runs" --argjson s "$statuses" '($r + $s) | length')
-            echo "checks: total=$total pending=$pending failed=$failed"
-            if [ "$failed" -gt 0 ]; then
-              echo "A check failed — not merging."; exit 1
+          gh pr list --repo "$REPO" --author 'app/mintlify' --state merged --limit 30 \
+            --json headRefName --jq '.[].headRefName | select(startswith("mintlify/"))' |
+          while read -r branch; do
+            if gh api "repos/$REPO/git/refs/heads/$branch" --silent 2>/dev/null; then
+              echo "Deleting merged branch $branch"
+              gh api -X DELETE "repos/$REPO/git/refs/heads/$branch" || true
             fi
-            if [ "$total" -gt 0 ] && [ "$pending" -eq 0 ]; then
-              echo "All green."; exit 0
-            fi
-            sleep 60
           done
-          echo "Timed out waiting for checks."; exit 1
-
-      - name: Merge
-        if: steps.guard.outputs.skip != 'true'
-        run: gh pr merge "$PR" --squash --delete-branch

--- a/.github/workflows/mintlify-automerge.yml
+++ b/.github/workflows/mintlify-automerge.yml
@@ -27,7 +27,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: mintlify-automerge
+  group: mintlify-automerge-${{ github.event.pull_request.number || 'sweep' }}
   cancel-in-progress: false
 
 jobs:
@@ -92,10 +92,15 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           gh pr list --repo "$REPO" --author 'app/mintlify' --state merged --limit 30 \
-            --json headRefName --jq '.[].headRefName | select(startswith("mintlify/"))' |
-          while read -r branch; do
-            if gh api "repos/$REPO/git/refs/heads/$branch" --silent 2>/dev/null; then
-              echo "Deleting merged branch $branch"
-              gh api -X DELETE "repos/$REPO/git/refs/heads/$branch" || true
+            --json headRefName,headRefOid \
+            --jq '.[] | select(.headRefName | startswith("mintlify/")) | "\(.headRefName) \(.headRefOid)"' |
+          while read -r branch merged_sha; do
+            # Exact-match ref lookup (git/ref, not git/refs, which prefix-matches).
+            current_sha=$(gh api "repos/$REPO/git/ref/heads/$branch" --jq .object.sha 2>/dev/null) || continue
+            if [ "$current_sha" != "$merged_sha" ]; then
+              echo "Branch $branch moved since its PR merged; leaving it."
+              continue
             fi
+            echo "Deleting merged branch $branch"
+            gh api -X DELETE "repos/$REPO/git/refs/heads/$branch" || true
           done


### PR DESCRIPTION
## Why

#367's workflow assumed main had no required checks and polled check-runs itself, then ran a plain `gh pr merge`. Main now has required checks (`ci`/`integration`/`perf`) in strict (up-to-date) mode, so that merge call fails for any Mintlify branch that is behind main — which is nearly always. None of the 12 backlog Mintlify PRs could ever self-merge (those are now merged by hand).

## What

- Repo setting `allow_auto_merge` is now on (flipped via API).
- The workflow arms **GitHub native auto-merge** (squash) instead of polling checks — GitHub merges the moment required checks pass on an up-to-date branch.
- Branches behind main get an `update-branch` nudge (strict mode never updates them for us).
- Since GITHUB_TOKEN-caused synchronize events don't re-trigger workflows, a half-hourly **sweep** re-nudges any Mintlify PR that went behind again, and prunes merged `mintlify/*` branches.
- Guards unchanged: author must be `mintlify[bot]` and the diff must stay entirely inside `docs-site/`; conflicted PRs are left for humans.

https://claude.ai/code/session_01TKrV77JsfwNEmZP811oiyn
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Mintlify docs auto-merge to GitHub native auto-merge with update-branch nudges so PRs merge under strict, up-to-date branch protection. Adds a half-hourly sweep to re-nudge behind PRs and safely delete merged bot branches with exact-ref + SHA guard.

- **Refactors**
  - Arm native auto-merge (squash); GitHub merges when required checks pass on an up-to-date branch.
  - Nudge BEHIND PRs via update-branch; skip DIRTY (conflicted) PRs for humans.
  - Keep guards: author is `mintlify[bot]` and changes limited to `docs-site/`.
  - Add schedule (every 30 min) to re-nudge open PRs by `app/mintlify` and prune merged `mintlify/*` branches via exact-ref delete with SHA match.
  - Per-PR concurrency groups (separate `sweep` group), no cancel-in-progress, shorter timeout; remove the old check-polling loop.

<sup>Written for commit f1f61b867aaef36480d7a92fbd297a429c9c71e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

