### PR TITLE
vendo init: clack-style output, Vendo Cloud emphasis, credential-first order, auth picker

### DIFF
--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -1,4 +1,6 @@
 import { mkdtemp, readFile, readdir, rm, writeFile, mkdir } from "node:fs/promises";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { LanguageModel } from "ai";
@@ -335,14 +337,76 @@ describe("vendo init (zero-question)", () => {
     const logs = sink.logs.join("\n");
     expect(logs).toContain("Model: explicit ANTHROPIC_API_KEY (anthropic)");
     expect(logs).not.toContain("No model key yet");
+    // The credential story leads the run — before the AI passes and the summary.
+    expect(logs.indexOf("Model: explicit")).toBeLessThan(logs.indexOf("Wired ("));
   });
 
   it("points a keyless host at .env.local and `vendo cloud login`", async () => {
     const root = await fixture();
     const sink = output();
     expect(await run(root, sink)).toBe(0);
-    expect(sink.logs.join("\n")).toContain("No model key yet");
-    expect(sink.logs.join("\n")).toContain("vendo cloud login");
+    const logs = sink.logs.join("\n");
+    expect(logs).toContain("No model key yet");
+    expect(logs).toContain("vendo cloud login");
+    // The Cloud offer runs FIRST (before theme capture and the wired summary);
+    // the end of the run keeps only the short one-line reminder.
+    expect(logs.indexOf("Vendo Cloud")).toBeLessThan(logs.indexOf("Theme:"));
+    expect(logs.indexOf("Vendo Cloud")).toBeLessThan(logs.indexOf("Wired ("));
+    expect(logs.indexOf("No model key yet")).toBeGreaterThan(logs.indexOf("Wired ("));
+    expect(logs.match(/Vendo Cloud \(optional\)/g)).toHaveLength(1);
+  });
+
+  it("picks up a starter key minted mid-run: the same run's theme model pass sees it", async () => {
+    const root = await fixture();
+    const sink = output();
+    const key = `vnd_${"a".repeat(40)}`;
+    // A canned Cloud model gateway: records what credential the theme model
+    // pass presents, answers 401 so the pass degrades gracefully. VENDO_CLOUD_URL
+    // in the run's env points devModel's gateway at it — no real network.
+    const seen: Array<string | undefined> = [];
+    const gateway = createServer((request, response) => {
+      seen.push(request.headers["x-api-key"] as string | undefined);
+      response.statusCode = 401;
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ type: "error", error: { type: "authentication_error", message: "starter key rejected by test gateway" } }));
+    });
+    await new Promise<void>((resolveListen) => gateway.listen(0, "127.0.0.1", resolveListen));
+    const port = (gateway.address() as AddressInfo).port;
+
+    try {
+      // No themeModel seam here on purpose: the DEFAULT resolver must observe
+      // the key the cloud step just wrote to .env.local.
+      expect(await runInit({
+        targetDir: root,
+        output: sink.output,
+        env: { VENDO_CLOUD_URL: `http://127.0.0.1:${port}` },
+        telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+        cloud: {
+          cloudProbe: async () => ({ present: false, ok: false, unlocks: ["a starter allowance"] as readonly string[] }),
+          confirm: async () => true,
+          promptEmail: async () => "dev@example.com",
+          login: async () => 0,
+          mint: async () => key,
+        },
+      })).toBe(0);
+    } finally {
+      await new Promise<void>((resolveClose) => gateway.close(() => resolveClose()));
+    }
+
+    // The mint landed in .env.local…
+    expect(await readFile(join(root, ".env.local"), "utf8")).toContain(`VENDO_API_KEY=${key}`);
+    const logs = sink.logs.join("\n");
+    expect(logs).toContain("Wrote VENDO_API_KEY to .env.local");
+    // …the SAME run's theme model pass presented the minted key to the model
+    // gateway (same-run pickup, end to end)…
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen[0]).toBe(key);
+    // …and degraded with the gateway's real answer, never "no key".
+    const warnings = sink.errors.join("\n");
+    expect(warnings).toContain("theme model pass unavailable:");
+    expect(warnings).not.toContain("Vendo found no model key");
+    // A key now exists — the end-of-run reminder is suppressed.
+    expect(logs).not.toContain("No model key yet");
   });
 
   it("preserves an existing env example while appending the trusted Vendo origin once", async () => {

--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -323,9 +323,12 @@ describe("vendo init (zero-question)", () => {
     expect(values[values.length - 1]).toBe("jwt");
     expect(askedSelects[0]!.options[1]).toMatchObject({ value: "authJs", hint: "detected next-auth" });
 
-    // clerk() is wired exactly like a detection-accept…
+    // clerk() is wired exactly like a detection-accept, with an honest
+    // lead-in: it was picked, not detected.
     const route = await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8");
     expect(route).toContain("auth: clerk(),");
+    expect(route).toContain("// Selected Clerk — clerk() fills the identity seams");
+    expect(route).not.toContain("Detected");
     expect(route).toContain("docs/act-as-presets.md");
     expect(route).not.toContain("principal");
     // …plus one install hint, since @clerk/backend is not in package.json.

--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -738,6 +738,74 @@ describe("vendo init (zero-question)", () => {
     expect(theme.colors.accentText).toBe("#000000");
   });
 
+  it("the cloud step honors the run's env: a supplied VENDO_API_KEY skips the offer", async () => {
+    const root = await fixture();
+    const sink = output();
+    let offered = 0;
+    // No cloudProbe stub: the default probe must see the RUN's env (not
+    // process.env) and report the programmatically supplied key.
+    expect(await runInit({
+      targetDir: root,
+      output: sink.output,
+      env: { VENDO_API_KEY: `vnd_${"b".repeat(40)}` },
+      themeModel: themeModelOf({ slots: {} }),
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+      cloud: {
+        confirm: async () => {
+          offered += 1;
+          return false;
+        },
+      },
+    })).toBe(0);
+    expect(offered).toBe(0);
+    const logs = sink.logs.join("\n");
+    expect(logs).toContain("Vendo Cloud: VENDO_API_KEY present and well-formed.");
+    expect(logs).not.toContain("No model key yet");
+  });
+
+  it("a starter key from a PRIOR run's .env.local counts: no offer, and the theme pass sees it", async () => {
+    const root = await fixture();
+    const key = `vnd_${"d".repeat(40)}`;
+    await writeFile(join(root, ".env.local"), `VENDO_API_KEY=${key}\n`);
+    // The canned gateway again: proves the DEFAULT theme resolver received
+    // the .env.local key without any mint happening this run.
+    const seen: Array<string | undefined> = [];
+    const gateway = createServer((request, response) => {
+      seen.push(request.headers["x-api-key"] as string | undefined);
+      response.statusCode = 401;
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ type: "error", error: { type: "authentication_error", message: "rejected by test gateway" } }));
+    });
+    await new Promise<void>((resolveListen) => gateway.listen(0, "127.0.0.1", resolveListen));
+    const port = (gateway.address() as AddressInfo).port;
+
+    const sink = output();
+    let offered = 0;
+    try {
+      expect(await runInit({
+        targetDir: root,
+        output: sink.output,
+        env: { VENDO_CLOUD_URL: `http://127.0.0.1:${port}` },
+        telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+        cloud: {
+          confirm: async () => {
+            offered += 1;
+            return false;
+          },
+        },
+      })).toBe(0);
+    } finally {
+      await new Promise<void>((resolveClose) => gateway.close(() => resolveClose()));
+    }
+
+    expect(offered).toBe(0);
+    const logs = sink.logs.join("\n");
+    expect(logs).toContain("Vendo Cloud: VENDO_API_KEY present and well-formed.");
+    expect(logs).not.toContain("No model key yet");
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen[0]).toBe(key);
+  });
+
   it("emits a read-only agent plan with code changes, extraction, and paste steps", async () => {
     const root = await fixture();
     const before = await tree(root);

--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -249,14 +249,18 @@ describe("vendo init (zero-question)", () => {
     expect(sink.logs.join("\n")).not.toContain("Auth:");
   });
 
-  it("interactive decline keeps the composition anonymous and names the exact line to add later", async () => {
+  it("interactive decline + picking none keeps the composition anonymous and names the exact line to add later", async () => {
     const root = await fixture();
     await writeFile(join(root, "package.json"), JSON.stringify({
       name: "host",
       dependencies: { next: "16.0.0", "@clerk/nextjs": "6.0.0" },
     }));
     const sink = output();
-    expect(await run(root, sink, { interactive: true, confirmAuth: async () => false })).toBe(0);
+    expect(await run(root, sink, {
+      interactive: true,
+      confirmAuth: async () => false,
+      selectAuth: async () => "none",
+    })).toBe(0);
     const route = await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8");
     expect(route).not.toContain("auth:");
     expect(route).toContain("principal: async () => null");
@@ -268,13 +272,14 @@ describe("vendo init (zero-question)", () => {
     expect(advisories[0]).toContain(join("app", "api", "vendo", "[...vendo]", "route.ts"));
   });
 
-  it("--yes never asks even in an interactive run: the detected default is accepted", async () => {
+  it("--yes never asks even in an interactive run: the detected default is accepted, no picker either", async () => {
     const root = await fixture();
     await writeFile(join(root, "package.json"), JSON.stringify({
       name: "host",
       dependencies: { next: "16.0.0", "next-auth": "5.0.0" },
     }));
     let askedCount = 0;
+    let pickedCount = 0;
     expect(await run(root, output(), {
       yes: true,
       interactive: true,
@@ -282,10 +287,108 @@ describe("vendo init (zero-question)", () => {
         askedCount += 1;
         return false;
       },
+      selectAuth: async () => {
+        pickedCount += 1;
+        return "clerk";
+      },
     })).toBe(0);
     expect(askedCount).toBe(0);
+    expect(pickedCount).toBe(0);
     const route = await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8");
     expect(route).toContain("auth: authJs(),");
+  });
+
+  it("decline → picker → clerk wires clerk() and hints the missing SDK install", async () => {
+    const root = await fixture();
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      name: "host",
+      dependencies: { next: "16.0.0", "next-auth": "5.0.0" },
+    }));
+    const askedSelects: Array<{ question: string; options: Array<{ value: string; label: string; hint?: string }> }> = [];
+    const sink = output();
+    expect(await run(root, sink, {
+      interactive: true,
+      confirmAuth: async () => false,
+      selectAuth: async (question, options) => {
+        askedSelects.push({ question, options });
+        return "clerk";
+      },
+    })).toBe(0);
+
+    // One picker: none first (the default), detected authJs named, jwt last.
+    expect(askedSelects).toHaveLength(1);
+    expect(askedSelects[0]!.question).toBe("Which auth should Vendo wire?");
+    const values = askedSelects[0]!.options.map((option) => option.value);
+    expect(values[0]).toBe("none");
+    expect(values[values.length - 1]).toBe("jwt");
+    expect(askedSelects[0]!.options[1]).toMatchObject({ value: "authJs", hint: "detected next-auth" });
+
+    // clerk() is wired exactly like a detection-accept…
+    const route = await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8");
+    expect(route).toContain("auth: clerk(),");
+    expect(route).toContain("docs/act-as-presets.md");
+    expect(route).not.toContain("principal");
+    // …plus one install hint, since @clerk/backend is not in package.json.
+    const advisories = sink.logs.filter((line) => line.includes("Auth:"));
+    expect(advisories).toHaveLength(1);
+    expect(advisories[0]).toContain("clerk() wired");
+    expect(advisories[0]).toContain("npm install @clerk/backend");
+  });
+
+  it("decline → picker → jwt wires nothing and prints the jwt recipe", async () => {
+    const root = await fixture();
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      name: "host",
+      dependencies: { next: "16.0.0", "next-auth": "5.0.0" },
+    }));
+    const sink = output();
+    expect(await run(root, sink, {
+      interactive: true,
+      confirmAuth: async () => false,
+      selectAuth: async () => "jwt",
+    })).toBe(0);
+    const route = await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8");
+    expect(route).not.toContain("auth:");
+    expect(route).toContain("principal: async () => null");
+    const advisories = sink.logs.filter((line) => line.includes("Auth:"));
+    expect(advisories).toHaveLength(1);
+    expect(advisories[0]).toContain("auth: jwt({ secret:");
+    expect(advisories[0]).toContain("docs/act-as-presets.md");
+  });
+
+  it("ambiguous detection offers the picker with detected families first (after none)", async () => {
+    const root = await fixture();
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      name: "host",
+      dependencies: { next: "16.0.0", "@supabase/supabase-js": "2.0.0", "@auth0/nextjs-auth0": "3.0.0" },
+    }));
+    const askedSelects: Array<Array<{ value: string; hint?: string }>> = [];
+    let confirmCount = 0;
+    const sink = output();
+    expect(await run(root, sink, {
+      interactive: true,
+      confirmAuth: async () => {
+        confirmCount += 1;
+        return true;
+      },
+      selectAuth: async (_question, options) => {
+        askedSelects.push(options);
+        return "supabase";
+      },
+    })).toBe(0);
+
+    // Ambiguity never gets the single-family confirm — straight to the picker.
+    expect(confirmCount).toBe(0);
+    expect(askedSelects).toHaveLength(1);
+    expect(askedSelects[0]!.map((option) => option.value))
+      .toEqual(["none", "supabase", "auth0", "authJs", "clerk", "jwt"]);
+    expect(askedSelects[0]![1]).toMatchObject({ hint: "detected @supabase/supabase-js" });
+    expect(askedSelects[0]![2]).toMatchObject({ hint: "detected @auth0/nextjs-auth0" });
+
+    // The detected pick wires like a detection-accept: no advisory at all.
+    const route = await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8");
+    expect(route).toContain("auth: supabase(),");
+    expect(sink.logs.join("\n")).not.toContain("Auth:");
   });
 
   it("stays anonymous and advises once when several auth providers are present", async () => {

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -22,7 +22,7 @@ import type { StaticTool } from "./extract/stages.js";
 import { resolveDevCredential, describeDevCredential, type DevCredential } from "../dev-creds/resolve.js";
 import { detectFramework, detectVendoWiring, type HostFramework } from "./framework.js";
 import { createPrettyOutput, usePrettyOutput, type PrettyOutput } from "./pretty.js";
-import { resolveRefineModel } from "./refine.js";
+import { devModel, NO_CREDENTIAL_MESSAGE } from "../dev-creds/model.js";
 import { contrastingText } from "./theme/color.js";
 import {
   extractTheme as extractThemeSlots,
@@ -147,14 +147,20 @@ export interface InitOptions {
 }
 
 /**
- * Theme extraction's model comes from the SAME seam `vendo refine` uses (the
- * host's key + installed provider) — no theme-specific configuration exists.
- * Vendo-hosted inference will swap in behind this same seam later; total
- * failure is handled by extractTheme's graceful degradation to reported
- * defaults.
+ * Theme extraction's model rides the devModel ladder — the same env resolution
+ * the runtime composes when `model` is omitted: provider env keys, then
+ * VENDO_API_KEY via the Cloud gateway. That is what makes the same-run pickup
+ * real: a starter key minted moments earlier in this init powers this pass.
+ * No credential throws the honest instructions instead of constructing a model
+ * that can only fail later; total failure is handled by extractTheme's
+ * graceful degradation to reported defaults.
  */
-function themeModelResolver(root: string): () => Promise<LanguageModel> {
-  return () => resolveRefineModel({ root, env: process.env });
+function themeModelResolver(root: string, env: Record<string, string | undefined>): () => Promise<LanguageModel> {
+  return async () => {
+    const credential = await resolveDevCredential({ env });
+    if (credential.rung === "none") throw new Error(NO_CREDENTIAL_MESSAGE);
+    return devModel({ root, env });
+  };
 }
 
 const THEME_PALETTE_SLOTS = ["accent", "background", "surface", "text", "mutedText", "border", "danger"] as const;
@@ -886,6 +892,14 @@ async function writeIfMissing(path: string, content: string, force: boolean): Pr
   await writeText(path, content);
 }
 
+/** The value of one NAME=value line in .env.local (the cloud step's upsert
+    target) — the same-run pickup reads the freshly minted key back from disk. */
+async function envLocalValue(root: string, name: string): Promise<string | null> {
+  const raw = await readOptional(join(root, ".env.local"));
+  const match = raw?.match(new RegExp(`^\\s*${name}\\s*=\\s*(.+?)\\s*$`, "m"));
+  return match?.[1] ?? null;
+}
+
 async function ensureVendoEnvExample(root: string): Promise<void> {
   const path = join(root, ".env.example");
   const current = await readOptional(path);
@@ -956,6 +970,35 @@ export async function runInit(options: InitOptions): Promise<number> {
   await telemetry.track("init_started", { framework: plan.framework });
 
   try {
+    // Key first (product order fix): the model-credential story — env keys,
+    // else the Vendo Cloud offer — runs BEFORE the AI-assisted passes, so a
+    // starter key minted here powers the SAME run's theme model pass and AI
+    // polish instead of those passes reporting "no model" while the offer
+    // waits below them. --yes / non-interactive semantics are unchanged.
+    let credential = await (options.resolveCredential ?? resolveDevCredential)({ env });
+    if (credential.rung === "env-key") {
+      output.log(`Model: ${describeDevCredential(credential)} — production uses this same key server-side.`);
+    }
+    const cloud = await runCloudStep({
+      root,
+      output,
+      yes: options.yes === true,
+      credential,
+      ...(pretty === null ? {} : { confirm: pretty.confirm }),
+      ...(options.cloud ?? {}),
+    });
+    // Same-run pickup: a freshly minted starter key lands in .env.local, not
+    // in this process's env — merge it into the env every credential consumer
+    // below reads (theme model pass, AI polish, the end-of-run reminder).
+    let effectiveEnv = env;
+    if (cloud.wroteEnvLocal) {
+      const minted = await envLocalValue(root, "VENDO_API_KEY");
+      if (minted !== null) {
+        effectiveEnv = { ...env, VENDO_API_KEY: minted };
+        credential = await (options.resolveCredential ?? resolveDevCredential)({ env: effectiveEnv });
+      }
+    }
+
     // Wire — apply the bounded change set and list it. No gates, no prompts.
     for (const change of changes) {
       await writeText(change.absolute, change.after);
@@ -998,7 +1041,7 @@ export async function runInit(options: InitOptions): Promise<number> {
     if (options.force === true || !(await exists(themePath))) {
       pretty?.spin("Capturing your theme");
       const summary = await extractThemeSlots(root, {
-        resolveModel: options.themeModel ?? themeModelResolver(root),
+        resolveModel: options.themeModel ?? themeModelResolver(root, effectiveEnv),
       });
       pretty?.stopSpin();
       if (summary.uncertain.length > 0 && options.yes !== true) {
@@ -1063,23 +1106,6 @@ export async function runInit(options: InitOptions): Promise<number> {
     if (authAdvice !== null) output.log(authAdvice);
     output.log(`Learned: ${toolCount} tools · theme captured → .vendo/ (tools.json, theme.json, brief.md)`);
 
-    // Key — state the env credential, or offer the cloud starter key.
-    const credential = await (options.resolveCredential ?? resolveDevCredential)({ env });
-    if (credential.rung === "env-key") {
-      output.log(`Model: ${describeDevCredential(credential)} — production uses this same key server-side.`);
-    }
-    await runCloudStep({
-      root,
-      output,
-      yes: options.yes === true,
-      credential,
-      ...(pretty === null ? {} : { confirm: pretty.confirm }),
-      ...(options.cloud ?? {}),
-    });
-    if (credential.rung === "none") {
-      output.log("No model key yet: set ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_GENERATIVE_AI_API_KEY in .env.local, or run `vendo cloud login` for a free dev key.");
-    }
-
     // AI extraction (install-dx, staged): a coding agent surveys the repo,
     // drafts each surface in a focused pass, cross-checks the combined draft,
     // and drafts the brief — all into the override channel; deterministic
@@ -1089,7 +1115,7 @@ export async function runInit(options: InitOptions): Promise<number> {
     const polish = await runAiExtraction({
       root,
       output,
-      env,
+      env: effectiveEnv,
       yes: options.yes === true,
       ...(options.force === true ? { force: true } : {}),
       ...(pretty === null ? {} : { confirm: pretty.confirm }),
@@ -1106,6 +1132,12 @@ export async function runInit(options: InitOptions): Promise<number> {
       toolCount,
       durationMs: Date.now() - started,
     });
+
+    // The one short Cloud reminder in the end-of-run summary — ONLY while no
+    // key exists (the full emphasized block already ran up top; no repeat).
+    if (credential.rung === "none") {
+      output.log("No model key yet: set ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_GENERATIVE_AI_API_KEY in .env.local, or run `vendo cloud login` for a free dev key.");
+    }
 
     // Done — the one paste that is the user's, then their own dev server.
     output.log("\nLast steps are yours:");

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -228,6 +228,9 @@ type AuthPresetName = "authJs" | "clerk" | "supabase" | "auth0";
 interface AuthMatch {
   preset: AuthPresetName;
   dependency: string;
+  /** How the family was chosen: detection (default) cites the dependency it
+      found; a picker pick says so honestly — nothing was detected. */
+  source?: "picked";
 }
 
 interface AuthDetection {
@@ -290,11 +293,11 @@ type SelectAuth = (question: string, options: SelectOption[]) => Promise<string>
 /** Picker labels + the runtime package each zero-arg preset lazy-loads (the
     install hint when the picked family's SDK is absent; the preset's own
     lazy-load error already guards runtime). */
-const AUTH_FAMILY_INFO: Record<AuthPresetName, { label: string; runtime: string }> = {
-  authJs: { label: "authJs() — Auth.js / next-auth", runtime: "@auth/core" },
-  clerk: { label: "clerk() — Clerk", runtime: "@clerk/backend" },
-  supabase: { label: "supabase() — Supabase Auth", runtime: "jose" },
-  auth0: { label: "auth0() — Auth0", runtime: "jose" },
+const AUTH_FAMILY_INFO: Record<AuthPresetName, { name: string; label: string; runtime: string }> = {
+  authJs: { name: "Auth.js", label: "authJs() — Auth.js / next-auth", runtime: "@auth/core" },
+  clerk: { name: "Clerk", label: "clerk() — Clerk", runtime: "@clerk/backend" },
+  supabase: { name: "Supabase Auth", label: "supabase() — Supabase Auth", runtime: "jose" },
+  auth0: { name: "Auth0", label: "auth0() — Auth0", runtime: "jose" },
 };
 
 /** The auth picker (decline or ambiguity): none — stay anonymous — is first
@@ -334,7 +337,7 @@ async function pickScaffoldAuth(
     const preset = picked as AuthPresetName;
     const info = AUTH_FAMILY_INFO[preset];
     return {
-      wired: { preset, dependency: info.runtime },
+      wired: { preset, dependency: info.runtime, source: "picked" },
       advice: `Auth: ${preset}() wired — ${info.runtime} is not in package.json yet; install it ` +
         `(npm install ${info.runtime}) before the first authenticated run (the preset fails loud until then).`,
     };
@@ -378,9 +381,14 @@ async function resolveScaffoldAuth(
   return { wired: null, advice: authAdvisory(detection, compositionPath) };
 }
 
-/** The wired preset line plus its escape-hatch comment. */
+/** The wired preset line plus its escape-hatch comment. The lead-in stays
+    honest about how the preset got here: detection cites the found
+    dependency, a picker pick says "Selected". */
 function authConfigLines(auth: AuthMatch): string {
-  return `  // Detected ${auth.dependency} — ${auth.preset}() fills the identity seams\n` +
+  const origin = auth.source === "picked"
+    ? `Selected ${AUTH_FAMILY_INFO[auth.preset].name}`
+    : `Detected ${auth.dependency}`;
+  return `  // ${origin} — ${auth.preset}() fills the identity seams\n` +
     `  // (request→user, actAs, door OAuth); options and the per-seam escape\n` +
     `  // hatch: docs/act-as-presets.md.\n` +
     `  auth: ${auth.preset}(),\n`;

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -21,7 +21,7 @@ import { askYesNo, runAiExtraction, type AiExtractionOptions } from "./extract/e
 import type { StaticTool } from "./extract/stages.js";
 import { resolveDevCredential, describeDevCredential, type DevCredential } from "../dev-creds/resolve.js";
 import { detectFramework, detectVendoWiring, type HostFramework } from "./framework.js";
-import { createPrettyOutput, usePrettyOutput, type PrettyOutput } from "./pretty.js";
+import { createPrettyOutput, plainSelect, usePrettyOutput, type PrettyOutput, type SelectOption } from "./pretty.js";
 import { devModel, NO_CREDENTIAL_MESSAGE } from "../dev-creds/model.js";
 import { contrastingText } from "./theme/color.js";
 import {
@@ -137,6 +137,10 @@ export interface InitOptions {
       runs when exactly one auth family is detected and init is creating the
       composition. Mirrors the AI-polish consent's confirm shape. */
   confirmAuth?: (question: string, defaultYes: boolean) => Promise<boolean>;
+  /** Test seam: the auth picker shown when the confirm is declined or when
+      several families are detected. Receives the choice list (value/label/
+      hint) and resolves the chosen value. */
+  selectAuth?: (question: string, options: SelectOption[]) => Promise<string>;
   /** Test seam: interactivity override for the auth confirm (default: TTY),
       mirroring runAiExtraction's `interactive`. */
   interactive?: boolean;
@@ -281,28 +285,97 @@ function declinedAuthAdvisory(match: AuthMatch, compositionPath: string): string
 }
 
 type ConfirmAuth = (question: string, defaultYes: boolean) => Promise<boolean>;
+type SelectAuth = (question: string, options: SelectOption[]) => Promise<string>;
 
-/** Detect + confirm: in interactive runs, exactly one detected family gets
-    ONE calm [Y/n] question before anything is written (Enter accepts).
-    Without a confirm (non-interactive, --yes, --agent) silent detection
-    stands — a default has to exist. None/ambiguous never ask: nothing is
-    certain enough to confirm, the advisory line covers it. */
+/** Picker labels + the runtime package each zero-arg preset lazy-loads (the
+    install hint when the picked family's SDK is absent; the preset's own
+    lazy-load error already guards runtime). */
+const AUTH_FAMILY_INFO: Record<AuthPresetName, { label: string; runtime: string }> = {
+  authJs: { label: "authJs() — Auth.js / next-auth", runtime: "@auth/core" },
+  clerk: { label: "clerk() — Clerk", runtime: "@clerk/backend" },
+  supabase: { label: "supabase() — Supabase Auth", runtime: "jose" },
+  auth0: { label: "auth0() — Auth0", runtime: "jose" },
+};
+
+/** The auth picker (decline or ambiguity): none — stay anonymous — is first
+    and the default; detected families come next (named), then the remaining
+    zero-arg presets, then jwt (recipe only — it cannot be zero-arg). */
+async function pickScaffoldAuth(
+  detection: AuthDetection,
+  compositionPath: string,
+  selectAuth: SelectAuth,
+): Promise<{ wired: AuthMatch | null; advice: string | null }> {
+  const detected = detection.matches;
+  const undetected = (Object.keys(AUTH_FAMILY_INFO) as AuthPresetName[])
+    .filter((preset) => !detected.some((match) => match.preset === preset));
+  const picked = await selectAuth("Which auth should Vendo wire?", [
+    { value: "none", label: "none — stay anonymous, add it later" },
+    ...detected.map((match) => ({
+      value: match.preset,
+      label: AUTH_FAMILY_INFO[match.preset].label,
+      hint: `detected ${match.dependency}`,
+    })),
+    ...undetected.map((preset) => ({ value: preset, label: AUTH_FAMILY_INFO[preset].label })),
+    { value: "jwt", label: "jwt — my own JWT scheme (prints the recipe)" },
+  ]);
+  if (picked === "jwt") {
+    // jwt() cannot be zero-arg — nothing is wired; the recipe is the answer.
+    return {
+      wired: null,
+      advice: `Auth: your own JWT — add one line in ${compositionPath}: auth: jwt({ secret: <your signing secret> }). ` +
+        "Options and the claim mapping: docs/act-as-presets.md.",
+    };
+  }
+  const detectedMatch = detected.find((match) => match.preset === picked);
+  if (detectedMatch !== undefined) return { wired: detectedMatch, advice: null };
+  if (picked in AUTH_FAMILY_INFO) {
+    // Picked without its SDK in package.json: wire it exactly like a
+    // detection-accept, plus one install hint.
+    const preset = picked as AuthPresetName;
+    const info = AUTH_FAMILY_INFO[preset];
+    return {
+      wired: { preset, dependency: info.runtime },
+      advice: `Auth: ${preset}() wired — ${info.runtime} is not in package.json yet; install it ` +
+        `(npm install ${info.runtime}) before the first authenticated run (the preset fails loud until then).`,
+    };
+  }
+  // none (or anything unrecognized): today's decline behavior.
+  return detection.wired !== null
+    ? { wired: null, advice: declinedAuthAdvisory(detection.wired, compositionPath) }
+    : { wired: null, advice: authAdvisory(detection, compositionPath) };
+}
+
+/** Detect + confirm + choose: in interactive runs, exactly one detected
+    family gets ONE calm [Y/n] question before anything is written (Enter
+    accepts and wires it — no picker on the happy path). A decline — and the
+    ambiguous case (several families) — offers the picker instead of settling
+    for anonymous. Without the seams (non-interactive, --yes, --agent) silent
+    detection stands and none/ambiguous keep the advisory line — a default
+    has to exist. None-detected never asks: there is nothing to choose from
+    that the advisory doesn't already name. */
 async function resolveScaffoldAuth(
   root: string,
   compositionPath: string,
   confirmAuth: ConfirmAuth | undefined,
+  selectAuth: SelectAuth | undefined,
 ): Promise<{ wired: AuthMatch | null; advice: string | null }> {
   const detection = await detectAuthPreset(root);
-  if (detection.wired === null || confirmAuth === undefined) {
+  if (confirmAuth === undefined) {
     return { wired: detection.wired, advice: authAdvisory(detection, compositionPath) };
   }
-  const accepted = await confirmAuth(
-    `Detected ${detection.wired.dependency} — wire auth: ${detection.wired.preset}()?`,
-    true,
-  );
-  return accepted
-    ? { wired: detection.wired, advice: null }
-    : { wired: null, advice: declinedAuthAdvisory(detection.wired, compositionPath) };
+  if (detection.wired !== null) {
+    const accepted = await confirmAuth(
+      `Detected ${detection.wired.dependency} — wire auth: ${detection.wired.preset}()?`,
+      true,
+    );
+    if (accepted) return { wired: detection.wired, advice: null };
+    if (selectAuth !== undefined) return pickScaffoldAuth(detection, compositionPath, selectAuth);
+    return { wired: null, advice: declinedAuthAdvisory(detection.wired, compositionPath) };
+  }
+  if (detection.matches.length > 1 && selectAuth !== undefined) {
+    return pickScaffoldAuth(detection, compositionPath, selectAuth);
+  }
+  return { wired: null, advice: authAdvisory(detection, compositionPath) };
 }
 
 /** The wired preset line plus its escape-hatch comment. */
@@ -741,7 +814,7 @@ async function vendoRootPasteLines(root: string, framework: HostFramework, withR
   return [`In ${layout}:`, ...importLines.map((line) => `  ${line}`), `  … then wrap: ${wrap}`];
 }
 
-async function buildPlan(options: InitOptions, confirmAuth?: ConfirmAuth): Promise<{ plan: InitPlan; changes: PlannedChange[]; manualSteps: string[]; authAdvice: string | null }> {
+async function buildPlan(options: InitOptions, confirmAuth?: ConfirmAuth, selectAuth?: SelectAuth): Promise<{ plan: InitPlan; changes: PlannedChange[]; manualSteps: string[]; authAdvice: string | null }> {
   const root = resolve(options.targetDir);
   const framework = await detectFramework(root);
   const changes: PlannedChange[] = [];
@@ -777,7 +850,7 @@ async function buildPlan(options: InitOptions, confirmAuth?: ConfirmAuth): Promi
         // Detect + confirm happens only here — fresh composition creation —
         // so a re-run before the manual <VendoRoot> paste neither asks nor
         // re-fires the advisory after "Already wired".
-        const auth = await resolveScaffoldAuth(root, path, confirmAuth);
+        const auth = await resolveScaffoldAuth(root, path, confirmAuth, selectAuth);
         const serverAfter = expressServerSource(typescript, auth.wired);
         changes.push({ absolute: server, path, before: null, after: serverAfter, diff: diff(path, null, serverAfter) });
         authAdvice = auth.advice;
@@ -818,7 +891,7 @@ async function buildPlan(options: InitOptions, confirmAuth?: ConfirmAuth): Promi
     if (routeBefore === null) {
       const path = relative(root, route);
       // Detect + confirm happens only on fresh composition creation.
-      const auth = await resolveScaffoldAuth(root, path, confirmAuth);
+      const auth = await resolveScaffoldAuth(root, path, confirmAuth, selectAuth);
       const registrySpecifier = relative(dirname(route), join(dirname(app), "vendo", "registry")).split(sep).join("/");
       const routeAfter = routeSource({ serverActions: registrations.length > 0, auth: auth.wired, registrySpecifier });
       changes.push({ absolute: route, path, before: routeBefore, after: routeAfter, diff: diff(path, routeBefore, routeAfter) });
@@ -965,7 +1038,10 @@ export async function runInit(options: InitOptions): Promise<number> {
   const confirmAuth = options.yes === true || !interactive
     ? undefined
     : (options.confirmAuth ?? (pretty === null ? askYesNo : pretty.confirm));
-  const { plan, changes, manualSteps, authAdvice } = await buildPlan(options, confirmAuth);
+  const selectAuth = options.yes === true || !interactive
+    ? undefined
+    : (options.selectAuth ?? (pretty === null ? plainSelect : pretty.select));
+  const { plan, changes, manualSteps, authAdvice } = await buildPlan(options, confirmAuth, selectAuth);
   const telemetry = telemetryFor(options, output);
   await telemetry.track("init_started", { framework: plan.framework });
 

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -19,7 +19,7 @@ import { runCloudStep, type CloudStepOptions } from "./cloud-init.js";
 import { APPLY_COMMAND, composeDelegatedInstructions, EXTRACTION_DRAFT_JSON_SCHEMA } from "./extract/delegate.js";
 import { askYesNo, runAiExtraction, type AiExtractionOptions } from "./extract/extraction.js";
 import type { StaticTool } from "./extract/stages.js";
-import { resolveDevCredential, describeDevCredential, type DevCredential } from "../dev-creds/resolve.js";
+import { ENV_KEY_VARS, resolveDevCredential, describeDevCredential, type DevCredential } from "../dev-creds/resolve.js";
 import { detectFramework, detectVendoWiring, type HostFramework } from "./framework.js";
 import { createPrettyOutput, plainSelect, usePrettyOutput, type PrettyOutput, type SelectOption } from "./pretty.js";
 import { devModel, NO_CREDENTIAL_MESSAGE } from "../dev-creds/model.js";
@@ -1059,7 +1059,18 @@ export async function runInit(options: InitOptions): Promise<number> {
     // starter key minted here powers the SAME run's theme model pass and AI
     // polish instead of those passes reporting "no model" while the offer
     // waits below them. --yes / non-interactive semantics are unchanged.
-    let credential = await (options.resolveCredential ?? resolveDevCredential)({ env });
+    // Dev keys may live in .env.local rather than this process's env — a
+    // PRIOR run's minted starter key, or hand-added provider keys. Merge
+    // them into the env every credential consumer reads (credential ladder,
+    // cloud step, theme model pass, AI polish); an explicit env value
+    // always wins over .env.local.
+    let effectiveEnv = env;
+    for (const name of [...ENV_KEY_VARS.map((entry) => entry.envVar), "VENDO_API_KEY"]) {
+      if ((env[name] ?? "").trim() !== "") continue;
+      const stored = await envLocalValue(root, name);
+      if (stored !== null) effectiveEnv = { ...effectiveEnv, [name]: stored };
+    }
+    let credential = await (options.resolveCredential ?? resolveDevCredential)({ env: effectiveEnv });
     if (credential.rung === "env-key") {
       output.log(`Model: ${describeDevCredential(credential)} — production uses this same key server-side.`);
     }
@@ -1068,17 +1079,18 @@ export async function runInit(options: InitOptions): Promise<number> {
       output,
       yes: options.yes === true,
       credential,
+      // The RUN's env, not process.env: a programmatic caller's key must be
+      // what the probe and the mint see (seams in options.cloud still win).
+      env: effectiveEnv,
       ...(pretty === null ? {} : { confirm: pretty.confirm }),
       ...(options.cloud ?? {}),
     });
-    // Same-run pickup: a freshly minted starter key lands in .env.local, not
-    // in this process's env — merge it into the env every credential consumer
-    // below reads (theme model pass, AI polish, the end-of-run reminder).
-    let effectiveEnv = env;
+    // Same-run pickup: a starter key minted just now lands in .env.local —
+    // merge it the same way so THIS run's passes already benefit.
     if (cloud.wroteEnvLocal) {
       const minted = await envLocalValue(root, "VENDO_API_KEY");
       if (minted !== null) {
-        effectiveEnv = { ...env, VENDO_API_KEY: minted };
+        effectiveEnv = { ...effectiveEnv, VENDO_API_KEY: minted };
         credential = await (options.resolveCredential ?? resolveDevCredential)({ env: effectiveEnv });
       }
     }

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -21,6 +21,7 @@ import { askYesNo, runAiExtraction, type AiExtractionOptions } from "./extract/e
 import type { StaticTool } from "./extract/stages.js";
 import { resolveDevCredential, describeDevCredential, type DevCredential } from "../dev-creds/resolve.js";
 import { detectFramework, detectVendoWiring, type HostFramework } from "./framework.js";
+import { createPrettyOutput, usePrettyOutput, type PrettyOutput } from "./pretty.js";
 import { resolveRefineModel } from "./refine.js";
 import { contrastingText } from "./theme/color.js";
 import {
@@ -903,7 +904,15 @@ function telemetryFor(options: InitOptions, output: Output): Telemetry {
 
 /** 09-vendo §5 — idempotent, zero-question setup. */
 export async function runInit(options: InitOptions): Promise<number> {
-  const output = options.output ?? consoleOutput;
+  // The clack-style renderer rides the SAME Output seam: it restyles the
+  // exact plain messages below, and is selected only for a human terminal
+  // (TTY, no NO_COLOR/CI, never --agent, never an injected output). Every
+  // other run — tests, pipes, CI — keeps the plain strings byte-for-byte.
+  const pretty: PrettyOutput | null =
+    options.output === undefined && options.agent !== true && usePrettyOutput()
+      ? createPrettyOutput()
+      : null;
+  const output = options.output ?? pretty ?? consoleOutput;
   const started = Date.now();
   const root = resolve(options.targetDir);
   const env = options.env ?? process.env;
@@ -941,7 +950,7 @@ export async function runInit(options: InitOptions): Promise<number> {
   const interactive = options.interactive ?? (Boolean(stdin.isTTY) && Boolean(stdout.isTTY));
   const confirmAuth = options.yes === true || !interactive
     ? undefined
-    : (options.confirmAuth ?? askYesNo);
+    : (options.confirmAuth ?? (pretty === null ? askYesNo : pretty.confirm));
   const { plan, changes, manualSteps, authAdvice } = await buildPlan(options, confirmAuth);
   const telemetry = telemetryFor(options, output);
   await telemetry.track("init_started", { framework: plan.framework });
@@ -987,9 +996,11 @@ export async function runInit(options: InitOptions): Promise<number> {
     // reruns never spend a model call or overwrite hand edits.
     const themePath = join(root, ".vendo", "theme.json");
     if (options.force === true || !(await exists(themePath))) {
+      pretty?.spin("Capturing your theme");
       const summary = await extractThemeSlots(root, {
         resolveModel: options.themeModel ?? themeModelResolver(root),
       });
+      pretty?.stopSpin();
       if (summary.uncertain.length > 0 && options.yes !== true) {
         const overrides = await (options.themeReview ?? defaultThemeReview)(summary);
         for (const [slot, raw] of Object.entries(overrides)) {
@@ -1024,7 +1035,9 @@ export async function runInit(options: InitOptions): Promise<number> {
     }
     await writeIfMissing(join(root, ".vendo", "data", ".gitignore"), "*\n!.gitignore\n", options.force === true);
 
+    pretty?.spin("Learning your API surface");
     const report = await vendoSync({ root, out: join(root, ".vendo") });
+    pretty?.stopSpin();
     for (const warning of report.warnings) output.error(`warning: ${warning}`);
 
     let toolCount = 0;
@@ -1060,6 +1073,7 @@ export async function runInit(options: InitOptions): Promise<number> {
       output,
       yes: options.yes === true,
       credential,
+      ...(pretty === null ? {} : { confirm: pretty.confirm }),
       ...(options.cloud ?? {}),
     });
     if (credential.rung === "none") {
@@ -1078,6 +1092,7 @@ export async function runInit(options: InitOptions): Promise<number> {
       env,
       yes: options.yes === true,
       ...(options.force === true ? { force: true } : {}),
+      ...(pretty === null ? {} : { confirm: pretty.confirm }),
       ...(options.extract ?? {}),
     });
     if (polish.ran) {
@@ -1097,11 +1112,13 @@ export async function runInit(options: InitOptions): Promise<number> {
     for (const line of manualSteps) output.log(`  ${line}`);
     output.log("\nThen start your dev server — the agent is live in your app.");
     output.log("Verify everything: `npx vendo doctor` (it can start the server and run a live turn).");
+    pretty?.done(Date.now() - started, true);
     return 0;
   } catch (error) {
     await telemetry.track("init_failed", { framework: plan.framework, failedStep: "wiring" });
     await telemetry.track("error_class", { errorClass: errorClass(error) });
     output.error(error instanceof Error ? error.message : "vendo init failed");
+    pretty?.done(Date.now() - started, false);
     return 1;
   }
 }

--- a/packages/vendo/src/cli/pretty.test.ts
+++ b/packages/vendo/src/cli/pretty.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createPrettyOutput, usePrettyOutput } from "./pretty.js";
+
+const ESC = "\u001b";
+
+/** Drop SGR/erase sequences so structure asserts stay legible. */
+function stripAnsi(text: string): string {
+  return text.split(ESC).map((chunk, index) => {
+    if (index === 0) return chunk;
+    return chunk.replace(/^\[[0-9;]*[A-Za-z]/, "");
+  }).join("").replace(/\r/g, "");
+}
+
+function sink(): { write: (chunk: string) => void; raw: () => string; plain: () => string } {
+  let buffer = "";
+  return {
+    write: (chunk) => { buffer += chunk; },
+    raw: () => buffer,
+    plain: () => stripAnsi(buffer),
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("usePrettyOutput (selection)", () => {
+  it("selects pretty only on a TTY with no opt-outs", () => {
+    expect(usePrettyOutput({ isTTY: true }, {})).toBe(true);
+  });
+
+  it.each([
+    ["non-TTY stdout", { isTTY: false }, {}],
+    ["missing isTTY (pipes, tests)", {}, {}],
+    ["NO_COLOR set", { isTTY: true }, { NO_COLOR: "1" }],
+    ["CI set", { isTTY: true }, { CI: "true" }],
+    ["TERM=dumb", { isTTY: true }, { TERM: "dumb" }],
+  ] as const)("degrades to plain on %s", (_name, stream, env) => {
+    expect(usePrettyOutput(stream, env)).toBe(false);
+  });
+
+  it("treats empty NO_COLOR / CI as unset (no-color.org semantics)", () => {
+    expect(usePrettyOutput({ isTTY: true }, { NO_COLOR: "", CI: "" })).toBe(true);
+  });
+});
+
+describe("createPrettyOutput (visual system)", () => {
+  it("opens with the vendo init header exactly once", () => {
+    const out = sink();
+    const pretty = createPrettyOutput(out.write);
+    pretty.log("hello");
+    pretty.log("again");
+    expect(out.plain()).toContain("┌  vendo init");
+    expect(out.plain().match(/┌ {2}vendo init/g)).toHaveLength(1);
+  });
+
+  it("renders the wired section with colored diff markers and bar-prefixed paths", () => {
+    const out = sink();
+    const pretty = createPrettyOutput(out.write);
+    pretty.log("\nWired (3 files):");
+    pretty.log("  + vendo/registry.tsx");
+    pretty.log("  + app/api/vendo/[...vendo]/route.ts");
+    pretty.log("  ~ package.json");
+    const plain = out.plain();
+    expect(plain).toContain("◆  Wired (3 files)");
+    expect(plain).toContain("│  + vendo/registry.tsx");
+    expect(plain).toContain("│  ~ package.json");
+    // + green, ~ yellow, paths dimmed-cyan.
+    expect(out.raw()).toContain(`${ESC}[32m+${ESC}[39m`);
+    expect(out.raw()).toContain(`${ESC}[33m~${ESC}[39m`);
+    expect(out.raw()).toContain(`${ESC}[36mpackage.json${ESC}[39m`);
+  });
+
+  it("renders Vendo Cloud as the emphasized section: header, ✦ bullets, → CTA", () => {
+    const out = sink();
+    const pretty = createPrettyOutput(out.write);
+    pretty.log("\nVendo Cloud (optional): not configured. A key unlocks team sharing & org governance; hosted automations; the MCP broker.");
+    pretty.log("Run `vendo cloud login` to grab a free dev-mode starter key; the wizard writes it to .env.local on your next `vendo init`.");
+    const plain = out.plain();
+    expect(plain).toContain("◆  Vendo Cloud");
+    expect(plain).toContain("✦ team sharing & org governance");
+    expect(plain).toContain("✦ hosted automations");
+    expect(plain).toContain("✦ the MCP broker");
+    // The CTA line gets the arrow treatment and keeps the command visible.
+    expect(plain).toContain("→ ");
+    expect(plain).toContain("vendo cloud login");
+    // The header is bold + brand blue (the most prominent block on screen).
+    expect(out.raw()).toContain(`${ESC}[34mVendo Cloud${ESC}[39m`);
+    expect(out.raw()).toContain(`${ESC}[1m`);
+  });
+
+  it("renders a configured Vendo Cloud key under the same emphasized header", () => {
+    const out = sink();
+    const pretty = createPrettyOutput(out.write);
+    pretty.log("\nVendo Cloud: VENDO_API_KEY present and well-formed.");
+    const plain = out.plain();
+    expect(plain).toContain("◆  Vendo Cloud");
+    expect(plain).toContain("✦ VENDO_API_KEY present and well-formed.");
+  });
+
+  it("renders the theme summary as a captured section", () => {
+    const out = sink();
+    const pretty = createPrettyOutput(out.write);
+    pretty.log("Theme: accent #2b7fff · background #fafafa");
+    pretty.log("Type: Inter · radius 8px");
+    pretty.log("Theme lives in .vendo/theme.json — edit it anytime; it is the source of truth.");
+    const plain = out.plain();
+    expect(plain).toContain("◇  Theme captured");
+    expect(plain).toContain("│  accent #2b7fff · background #fafafa");
+    expect(plain).toContain("│  Type: Inter · radius 8px");
+  });
+
+  it("renders warnings yellow with ⚠ and other errors red with ✖", () => {
+    const out = sink();
+    const pretty = createPrettyOutput(out.write);
+    pretty.error("warning: extraction skipped app/broken.ts");
+    pretty.error("vendo init failed");
+    const plain = out.plain();
+    expect(plain).toContain("⚠ extraction skipped app/broken.ts");
+    expect(plain).toContain("✖ vendo init failed");
+    expect(out.raw()).toContain(`${ESC}[33m⚠ extraction skipped app/broken.ts${ESC}[39m`);
+    expect(out.raw()).toContain(`${ESC}[31m✖ vendo init failed${ESC}[39m`);
+  });
+
+  it("renders the last-steps section and closes with the done footer", () => {
+    const out = sink();
+    const pretty = createPrettyOutput(out.write);
+    pretty.log("\nLast steps are yours:");
+    pretty.log("  In app/layout.tsx:");
+    pretty.log("    import { VendoRoot } from \"@vendoai/vendo/react\";");
+    pretty.log("\nThen start your dev server — the agent is live in your app.");
+    pretty.log("Verify everything: `npx vendo doctor` (it can start the server and run a live turn).");
+    pretty.done(4230, true);
+    const plain = out.plain();
+    expect(plain).toContain("◇  Last steps are yours");
+    expect(plain).toContain("│  In app/layout.tsx:");
+    expect(plain).toContain("│    import { VendoRoot }");
+    expect(plain).toContain("npx vendo doctor");
+    expect(plain).toContain("└  Done in 4.2s");
+  });
+
+  it("closes with a red failure footer when init fails", () => {
+    const out = sink();
+    const pretty = createPrettyOutput(out.write);
+    pretty.error("boom");
+    pretty.done(900, false);
+    expect(out.plain()).toContain("└  Failed after 0.9s");
+    expect(out.raw()).toContain(`${ESC}[31mFailed after 0.9s${ESC}[39m`);
+  });
+
+  it("spins during slow phases and clears the frame before any log line", () => {
+    vi.useFakeTimers();
+    const out = sink();
+    const pretty = createPrettyOutput(out.write);
+    pretty.spin("Capturing your theme");
+    vi.advanceTimersByTime(300);
+    expect(out.plain()).toContain("Capturing your theme");
+    pretty.log("Theme: accent #2b7fff");
+    // The in-flight frame is erased (carriage return + erase-line) before printing.
+    expect(out.raw()).toContain(`${ESC}[2K`);
+    pretty.stopSpin();
+    vi.advanceTimersByTime(300);
+    const settled = out.raw();
+    vi.advanceTimersByTime(300);
+    expect(out.raw()).toBe(settled); // no frames after stopSpin
+  });
+});

--- a/packages/vendo/src/cli/pretty.test.ts
+++ b/packages/vendo/src/cli/pretty.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createPrettyOutput, usePrettyOutput } from "./pretty.js";
+import { createPrettyOutput, plainSelect, usePrettyOutput, type SelectInput } from "./pretty.js";
 
 const ESC = "\u001b";
 
@@ -23,6 +23,24 @@ function sink(): { write: (chunk: string) => void; raw: () => string; plain: () 
 afterEach(() => {
   vi.useRealTimers();
 });
+
+/** A PTY-free keypress source for the select loop. */
+function fakeInput(): { input: SelectInput; press: (text: string) => void } {
+  const listeners = new Set<(chunk: Buffer | string) => void>();
+  return {
+    input: {
+      isTTY: true,
+      setRawMode: () => undefined,
+      resume: () => undefined,
+      pause: () => undefined,
+      on: (_event, listener) => listeners.add(listener),
+      off: (_event, listener) => listeners.delete(listener),
+    },
+    press: (text) => {
+      for (const listener of [...listeners]) listener(text);
+    },
+  };
+}
 
 describe("usePrettyOutput (selection)", () => {
   it("selects pretty only on a TTY with no opt-outs", () => {
@@ -146,6 +164,47 @@ describe("createPrettyOutput (visual system)", () => {
     pretty.done(900, false);
     expect(out.plain()).toContain("└  Failed after 0.9s");
     expect(out.raw()).toContain(`${ESC}[31mFailed after 0.9s${ESC}[39m`);
+  });
+
+  it("select: arrow keys move the selection, Enter accepts, list collapses to the answer", async () => {
+    const out = sink();
+    const keys = fakeInput();
+    const pretty = createPrettyOutput(out.write, keys.input);
+    const choice = pretty.select("Which auth should Vendo wire?", [
+      { value: "none", label: "none — stay anonymous, add it later" },
+      { value: "clerk", label: "clerk() — Clerk", hint: "detected @clerk/nextjs" },
+      { value: "jwt", label: "jwt — my own JWT scheme" },
+    ]);
+    keys.press("\u001b[B");
+    keys.press("\r");
+    expect(await choice).toBe("clerk");
+    const plain = out.plain();
+    expect(plain).toContain("◇  Which auth should Vendo wire?");
+    expect(plain).toContain("○ ");
+    expect(plain).toContain("(detected @clerk/nextjs)");
+    // Collapsed to the chosen answer.
+    expect(plain).toContain("● clerk() — Clerk");
+  });
+
+  it("select: number keys pick directly without Enter", async () => {
+    const out = sink();
+    const keys = fakeInput();
+    const pretty = createPrettyOutput(out.write, keys.input);
+    const choice = pretty.select("Which auth should Vendo wire?", [
+      { value: "none", label: "none" },
+      { value: "authJs", label: "authJs()" },
+      { value: "jwt", label: "jwt" },
+    ]);
+    keys.press("3");
+    expect(await choice).toBe("jwt");
+    expect(out.plain()).toContain("● jwt");
+  });
+
+  it("plainSelect returns the default without prompting when not a TTY", async () => {
+    expect(await plainSelect("Which auth should Vendo wire?", [
+      { value: "none", label: "none — stay anonymous" },
+      { value: "clerk", label: "clerk()" },
+    ])).toBe("none");
   });
 
   it("spins during slow phases and clears the frame before any log line", () => {

--- a/packages/vendo/src/cli/pretty.test.ts
+++ b/packages/vendo/src/cli/pretty.test.ts
@@ -231,6 +231,47 @@ describe("createPrettyOutput (visual system)", () => {
     expect(out.plain()).not.toContain("Log in");
   });
 
+  it("select: one pasted chunk containing '2\\r' picks option 2", async () => {
+    const out = sink();
+    const keys = fakeInput();
+    const pretty = createPrettyOutput(out.write, keys.input);
+    const choice = pretty.select("Which auth should Vendo wire?", [
+      { value: "none", label: "none" },
+      { value: "authJs", label: "authJs()" },
+      { value: "jwt", label: "jwt" },
+    ]);
+    keys.press("2\r");
+    expect(await choice).toBe("authJs");
+  });
+
+  it("select: several keys in one chunk are all consumed (two arrow-downs move twice)", async () => {
+    const out = sink();
+    const keys = fakeInput();
+    const pretty = createPrettyOutput(out.write, keys.input);
+    const choice = pretty.select("Which auth should Vendo wire?", [
+      { value: "none", label: "none" },
+      { value: "authJs", label: "authJs()" },
+      { value: "jwt", label: "jwt" },
+    ]);
+    keys.press("\u001b[B\u001b[B");
+    keys.press("\r");
+    expect(await choice).toBe("jwt");
+  });
+
+  it("select: an escape sequence split across chunks still moves", async () => {
+    const out = sink();
+    const keys = fakeInput();
+    const pretty = createPrettyOutput(out.write, keys.input);
+    const choice = pretty.select("Which auth should Vendo wire?", [
+      { value: "none", label: "none" },
+      { value: "authJs", label: "authJs()" },
+    ]);
+    keys.press("\u001b");
+    keys.press("[B");
+    keys.press("\r");
+    expect(await choice).toBe("authJs");
+  });
+
   it("select returns the default option without prompting when stdin is not a TTY", async () => {
     const out = sink();
     const pretty = createPrettyOutput(out.write, {

--- a/packages/vendo/src/cli/pretty.test.ts
+++ b/packages/vendo/src/cli/pretty.test.ts
@@ -1,3 +1,4 @@
+import { PassThrough, Writable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createPrettyOutput, plainSelect, usePrettyOutput, type SelectInput } from "./pretty.js";
 
@@ -23,6 +24,25 @@ function sink(): { write: (chunk: string) => void; raw: () => string; plain: () 
 afterEach(() => {
   vi.useRealTimers();
 });
+
+/** Real streams posing as a TTY, so the readline-driven prompt bodies run. */
+function promptStreams(): {
+  input: PassThrough & { isTTY?: boolean };
+  output: Writable & { isTTY?: boolean };
+  echoed: () => string;
+} {
+  const input = new PassThrough() as PassThrough & { isTTY?: boolean };
+  input.isTTY = true;
+  let buffer = "";
+  const output = new Writable({
+    write(chunk, _encoding, callback) {
+      buffer += String(chunk);
+      callback();
+    },
+  }) as Writable & { isTTY?: boolean };
+  output.isTTY = true;
+  return { input, output, echoed: () => buffer };
+}
 
 /** A PTY-free keypress source for the select loop. */
 function fakeInput(): { input: SelectInput; press: (text: string) => void } {
@@ -230,6 +250,66 @@ describe("createPrettyOutput (visual system)", () => {
       { value: "none", label: "none — stay anonymous" },
       { value: "clerk", label: "clerk()" },
     ])).toBe("none");
+  });
+
+  it("confirm parses y / n / Enter-default / other text through a real readline", async () => {
+    const out = sink();
+    const io = promptStreams();
+    const pretty = createPrettyOutput(out.write, io.input, io.output);
+
+    const enterAccepts = pretty.confirm("Wire auth: authJs()?", true);
+    io.input.write("\n");
+    expect(await enterAccepts).toBe(true);
+
+    const explicitNo = pretty.confirm("Wire auth: authJs()?", true);
+    io.input.write("n\n");
+    expect(await explicitNo).toBe(false);
+
+    const explicitYes = pretty.confirm("Log in to Vendo Cloud now?", false);
+    io.input.write("y\n");
+    expect(await explicitYes).toBe(true);
+
+    // Anything that isn't a yes is a No — even against a Yes default.
+    const garbage = pretty.confirm("Wire auth: authJs()?", true);
+    io.input.write("whatever\n");
+    expect(await garbage).toBe(false);
+
+    const plain = out.plain();
+    expect(plain).toContain("◇  Wire auth: authJs()?");
+    expect(plain).toContain("● Yes");
+    expect(plain).toContain("● No");
+  });
+
+  it("plainSelect drives the numbered list: pick, Enter-default, out-of-range and garbage settle on the default", async () => {
+    const options = [
+      { value: "none", label: "none — stay anonymous, add it later" },
+      { value: "clerk", label: "clerk() — Clerk", hint: "detected @clerk/nextjs" },
+    ];
+
+    const picked = promptStreams();
+    const pick = plainSelect("Which auth should Vendo wire?", options, 0, picked.input, picked.output);
+    picked.input.write("2\n");
+    expect(await pick).toBe("clerk");
+    expect(picked.echoed()).toContain("Which auth should Vendo wire?");
+    expect(picked.echoed()).toContain("1. none — stay anonymous, add it later");
+    expect(picked.echoed()).toContain("2. clerk() — Clerk (detected @clerk/nextjs)");
+    expect(picked.echoed()).toContain("Choose [1]: ");
+
+    const defaulted = promptStreams();
+    const byEnter = plainSelect("Which auth should Vendo wire?", options, 0, defaulted.input, defaulted.output);
+    defaulted.input.write("\n");
+    expect(await byEnter).toBe("none");
+
+    // Out-of-range and non-numeric answers settle on the default (no re-ask).
+    const outOfRange = promptStreams();
+    const nine = plainSelect("Which auth should Vendo wire?", options, 0, outOfRange.input, outOfRange.output);
+    outOfRange.input.write("9\n");
+    expect(await nine).toBe("none");
+
+    const garbage = promptStreams();
+    const text = plainSelect("Which auth should Vendo wire?", options, 0, garbage.input, garbage.output);
+    garbage.input.write("clerk\n");
+    expect(await text).toBe("none");
   });
 
   it("spins during slow phases and clears the frame before any log line", () => {

--- a/packages/vendo/src/cli/pretty.test.ts
+++ b/packages/vendo/src/cli/pretty.test.ts
@@ -200,6 +200,31 @@ describe("createPrettyOutput (visual system)", () => {
     expect(out.plain()).toContain("● jwt");
   });
 
+  it("confirm returns the default without prompting when stdin is not a TTY", async () => {
+    // vitest's stdin is not a TTY: the styled confirm must never block
+    // readline — the default stands (stdout-TTY selection is stdout-only).
+    const out = sink();
+    const pretty = createPrettyOutput(out.write);
+    await expect(pretty.confirm("Wire auth: authJs()?", true)).resolves.toBe(true);
+    await expect(pretty.confirm("Log in to Vendo Cloud now?", false)).resolves.toBe(false);
+    expect(out.plain()).not.toContain("Wire auth");
+    expect(out.plain()).not.toContain("Log in");
+  });
+
+  it("select returns the default option without prompting when stdin is not a TTY", async () => {
+    const out = sink();
+    const pretty = createPrettyOutput(out.write, {
+      isTTY: false,
+      on: () => undefined,
+      off: () => undefined,
+    });
+    await expect(pretty.select("Which auth should Vendo wire?", [
+      { value: "none", label: "none — stay anonymous" },
+      { value: "clerk", label: "clerk()" },
+    ])).resolves.toBe("none");
+    expect(out.plain()).not.toContain("Which auth");
+  });
+
   it("plainSelect returns the default without prompting when not a TTY", async () => {
     expect(await plainSelect("Which auth should Vendo wire?", [
       { value: "none", label: "none — stay anonymous" },

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -1,0 +1,221 @@
+import { stdin, stdout } from "node:process";
+import { createInterface } from "node:readline/promises";
+import type { Output } from "./shared.js";
+
+/**
+ * The vendo CLI's TTY visual system (init first; doctor/sync can adopt the
+ * same primitives later). Clack-style vertical-bar layout: one `┌ vendo init`
+ * header, `◇`/`◆` section markers on a dim `│` rail, colored diff markers,
+ * a dots spinner for the slow phases, and ONE deliberately emphasized block —
+ * Vendo Cloud — in the brand accent (blue/cyan family, calm not neon).
+ *
+ * Degradation contract: this module is only selected when stdout is a real
+ * TTY and none of NO_COLOR / CI / TERM=dumb opt out (see usePrettyOutput).
+ * Every other run — tests, pipes, CI — keeps today's exact plain strings,
+ * because runInit's emissions are unchanged: this is a renderer over the
+ * existing Output seam, not a second copy of the copy.
+ */
+
+const ESC = "\u001b";
+const style = (open: string, close: string) => (text: string): string =>
+  `${ESC}[${open}m${text}${ESC}[${close}m`;
+
+export const bold = style("1", "22");
+export const dim = style("2", "22");
+export const red = style("31", "39");
+export const green = style("32", "39");
+export const yellow = style("33", "39");
+export const blue = style("34", "39");
+export const cyan = style("36", "39");
+export const brightCyan = style("96", "39");
+
+/** TTY + no opt-outs → the pretty renderer; anything else keeps plain output.
+    NO_COLOR and CI follow the "present and non-empty" convention. */
+export function usePrettyOutput(
+  stream: { isTTY?: boolean } = stdout,
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  if (stream.isTTY !== true) return false;
+  if ((env.NO_COLOR ?? "") !== "") return false;
+  if ((env.CI ?? "") !== "") return false;
+  if (env.TERM === "dumb") return false;
+  return true;
+}
+
+export interface PrettyOutput extends Output {
+  /** Dots spinner for a slow phase; any log/error line clears the frame. */
+  spin(label: string): void;
+  stopSpin(): void;
+  /** The styled [Y/n] confirm — Enter accepts the default, answer echoed. */
+  confirm(question: string, defaultYes?: boolean): Promise<boolean>;
+  /** The `└ Done in Xs` footer (red `Failed` when init exits non-zero). */
+  done(durationMs: number, ok: boolean): void;
+}
+
+const FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const BAR = dim("│");
+const CLEAR_LINE = `\r${ESC}[2K`;
+
+/** Inline `code spans` in the calm command color. */
+function styleInline(text: string): string {
+  return text.replace(/`([^`]+)`/g, (_match, code: string) => bold(cyan(code)));
+}
+
+export function createPrettyOutput(
+  write: (chunk: string) => void = (chunk) => { stdout.write(chunk); },
+): PrettyOutput {
+  let headerPrinted = false;
+  let lastWasBar = false;
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let frame = 0;
+
+  const line = (text: string): void => {
+    write(`${text}\n`);
+    lastWasBar = text === BAR;
+  };
+  const bar = (): void => {
+    if (!lastWasBar) line(BAR);
+  };
+  const ensureHeader = (): void => {
+    if (headerPrinted) return;
+    headerPrinted = true;
+    line(`${dim("┌")}  ${bold("vendo init")}`);
+    line(BAR);
+  };
+  const body = (text: string): void => line(`${BAR}  ${styleInline(text)}`);
+  const section = (marker: string, title: string): void => {
+    bar();
+    line(`${marker}  ${title}`);
+  };
+
+  const clearFrame = (): void => {
+    if (timer !== null) write(CLEAR_LINE);
+  };
+  const stopSpin = (): void => {
+    if (timer === null) return;
+    clearInterval(timer);
+    timer = null;
+    write(CLEAR_LINE);
+  };
+
+  /** The emphasized block: brand-blue header + ✦ bullets. */
+  const cloudHeader = (): void => section(blue("◆"), bold(blue("Vendo Cloud")));
+  const cloudBullet = (text: string): void => body(`${blue("✦")} ${blue(text)}`);
+
+  const render = (raw: string): void => {
+    if (raw === "") {
+      bar();
+      return;
+    }
+    const wired = raw.match(/^(Wired \(\d+ files?\)):$/);
+    if (wired !== null) {
+      section(cyan("◆"), bold(wired[1]!));
+      return;
+    }
+    if (raw === "Already wired — nothing to change.") {
+      section(cyan("◇"), `${bold("Already wired")} — nothing to change`);
+      return;
+    }
+    const marker = raw.match(/^ {2}([+~]) (.+)$/);
+    if (marker !== null) {
+      body(`${marker[1] === "+" ? green("+") : yellow("~")} ${dim(cyan(marker[2]!))}`);
+      return;
+    }
+    const theme = raw.match(/^Theme: (.*)$/);
+    if (theme !== null) {
+      section(cyan("◇"), bold("Theme captured"));
+      body(theme[1]!);
+      return;
+    }
+    if (raw.startsWith("Theme lives in ")) {
+      body(dim(raw));
+      return;
+    }
+    const cloudAbsent = raw.match(/^Vendo Cloud \(optional\): not configured\. A key unlocks (.+)\.$/);
+    if (cloudAbsent !== null) {
+      cloudHeader();
+      for (const bullet of cloudAbsent[1]!.split("; ")) cloudBullet(bullet);
+      return;
+    }
+    const cloud = raw.match(/^Vendo Cloud: (.+)$/);
+    if (cloud !== null) {
+      cloudHeader();
+      cloudBullet(cloud[1]!);
+      return;
+    }
+    if (raw.includes("`vendo cloud login`") || raw.includes("vendo cloud login")) {
+      // The CTA: bright, factual, pointing at the free dev-mode key.
+      body(`${bold(brightCyan("→"))} ${raw.replace(/`?vendo cloud login`?/g, bold(brightCyan("vendo cloud login")))}`);
+      return;
+    }
+    if (raw === "Last steps are yours:") {
+      section(cyan("◇"), bold("Last steps are yours"));
+      return;
+    }
+    // Generic indented detail (paste steps, progress lines): the plain
+    // two-space indent becomes the rail; deeper nesting is preserved.
+    const indented = raw.match(/^ {2}(.*)$/);
+    if (indented !== null) {
+      body(indented[1]!);
+      return;
+    }
+    body(raw);
+  };
+
+  return {
+    log(message) {
+      clearFrame();
+      ensureHeader();
+      if (message.startsWith("\n")) bar();
+      for (const raw of message.replace(/^\n+/, "").split("\n")) render(raw);
+    },
+    error(message) {
+      clearFrame();
+      ensureHeader();
+      if (message.startsWith("\n")) bar();
+      for (const raw of message.replace(/^\n+/, "").split("\n")) {
+        const warning = raw.match(/^\s*warning: (.*)$/);
+        if (warning !== null) body(yellow(`⚠ ${warning[1]!}`));
+        else if (raw.startsWith("Vendo Cloud: ")) {
+          cloudHeader();
+          body(yellow(`⚠ ${raw.slice("Vendo Cloud: ".length)}`));
+        } else body(red(`✖ ${raw}`));
+      }
+    },
+    spin(label) {
+      stopSpin();
+      ensureHeader();
+      const draw = (): void => {
+        frame = (frame + 1) % FRAMES.length;
+        write(`${CLEAR_LINE}${cyan(FRAMES[frame]!)}  ${dim(label)}`);
+      };
+      timer = setInterval(draw, 80);
+      timer.unref?.();
+      draw();
+    },
+    stopSpin,
+    async confirm(question, defaultYes = false) {
+      stopSpin();
+      ensureHeader();
+      section(cyan("◇"), bold(question));
+      const prompt = createInterface({ input: stdin, output: stdout });
+      try {
+        const answer = (await prompt.question(
+          `${BAR}  ${dim(defaultYes ? "Y/n" : "y/N")} ${dim("›")} `,
+        )).trim().toLowerCase();
+        const accepted = answer === "" ? defaultYes : ["y", "yes"].includes(answer);
+        line(`${BAR}  ${cyan("●")} ${accepted ? "Yes" : "No"}`);
+        return accepted;
+      } finally {
+        prompt.close();
+      }
+    },
+    done(durationMs, ok) {
+      stopSpin();
+      ensureHeader();
+      bar();
+      const seconds = `${(durationMs / 1000).toFixed(1)}s`;
+      line(`${dim("└")}  ${ok ? green(`Done in ${seconds}`) : red(`Failed after ${seconds}`)}`);
+    },
+  };
+}

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -67,7 +67,9 @@ export interface PrettyOutput extends Output {
   /** The styled [Y/n] confirm — Enter accepts the default, answer echoed. */
   confirm(question: string, defaultYes?: boolean): Promise<boolean>;
   /** The styled select — arrows move, Enter accepts, number keys pick
-      directly; collapses to the chosen answer. */
+      directly; collapses to the chosen answer. Number keys cover options
+      1-9 only: keep lists at nine options or fewer (a longer list stays
+      arrow-navigable, but two-digit entry is deliberately not built). */
   select(question: string, options: SelectOption[], defaultIndex?: number): Promise<string>;
   /** The `└ Done in Xs` footer (red `Failed` when init exits non-zero). */
   done(durationMs: number, ok: boolean): void;
@@ -83,19 +85,23 @@ function styleInline(text: string): string {
 }
 
 /** The plain-terminal select for non-pretty interactive runs: numbered list +
-    readline. Non-TTY runs never prompt — the default option stands. */
+    readline. Non-TTY runs never prompt — the default option stands; an
+    empty, garbage, or out-of-range answer also settles on the default.
+    Streams are injectable for tests only; call sites use the defaults. */
 export async function plainSelect(
   question: string,
   options: SelectOption[],
   defaultIndex = 0,
+  input: NodeJS.ReadableStream & { isTTY?: boolean } = stdin,
+  output: NodeJS.WritableStream & { isTTY?: boolean } = stdout,
 ): Promise<string> {
   const fallback = (options[defaultIndex] ?? options[0])!.value;
-  if (stdin.isTTY !== true || stdout.isTTY !== true) return fallback;
-  stdout.write(`${question}\n`);
+  if (input.isTTY !== true || output.isTTY !== true) return fallback;
+  output.write(`${question}\n`);
   options.forEach((option, index) => {
-    stdout.write(`  ${index + 1}. ${option.label}${option.hint === undefined ? "" : ` (${option.hint})`}\n`);
+    output.write(`  ${index + 1}. ${option.label}${option.hint === undefined ? "" : ` (${option.hint})`}\n`);
   });
-  const prompt = createInterface({ input: stdin, output: stdout });
+  const prompt = createInterface({ input, output });
   try {
     const answer = (await prompt.question(`Choose [${defaultIndex + 1}]: `)).trim();
     const number = /^\d+$/.test(answer) ? Number(answer) : NaN;
@@ -111,6 +117,7 @@ export async function plainSelect(
 export function createPrettyOutput(
   write: (chunk: string) => void = (chunk) => { stdout.write(chunk); },
   input: SelectInput = stdin,
+  promptOutput: NodeJS.WritableStream & { isTTY?: boolean } = stdout,
 ): PrettyOutput {
   let headerPrinted = false;
   let lastWasBar = false;
@@ -246,11 +253,16 @@ export function createPrettyOutput(
       // usePrettyOutput gates on stdout only; a piped/closed stdin can still
       // reach here (vendo init < file). Never block readline on a non-TTY —
       // the default stands, mirroring the plain askYesNo guard.
-      if (stdin.isTTY !== true) return defaultYes;
+      if (input.isTTY !== true) return defaultYes;
       stopSpin();
       ensureHeader();
       section(cyan("◇"), bold(question));
-      const prompt = createInterface({ input: stdin, output: stdout });
+      // SelectInput is the raw-key slice of the same real stream readline
+      // needs; the default (stdin) satisfies both.
+      const prompt = createInterface({
+        input: input as unknown as NodeJS.ReadableStream,
+        output: promptOutput,
+      });
       try {
         const answer = (await prompt.question(
           `${BAR}  ${dim(defaultYes ? "Y/n" : "y/N")} ${dim("›")} `,

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -243,6 +243,10 @@ export function createPrettyOutput(
     },
     stopSpin,
     async confirm(question, defaultYes = false) {
+      // usePrettyOutput gates on stdout only; a piped/closed stdin can still
+      // reach here (vendo init < file). Never block readline on a non-TTY —
+      // the default stands, mirroring the plain askYesNo guard.
+      if (stdin.isTTY !== true) return defaultYes;
       stopSpin();
       ensureHeader();
       section(cyan("◇"), bold(question));
@@ -259,6 +263,8 @@ export function createPrettyOutput(
       }
     },
     async select(question, options, defaultIndex = 0) {
+      // Same stdin guard as confirm: no keypress source → the default option.
+      if (input.isTTY !== true) return (options[defaultIndex] ?? options[0])!.value;
       stopSpin();
       ensureHeader();
       section(cyan("◇"), bold(question));

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -298,33 +298,54 @@ export function createPrettyOutput(
           input.setRawMode?.(false);
           input.pause?.();
         };
+        // Raw input arrives as arbitrary chunks - a paste ("2\r"), fast
+        // typing, or an escape sequence split across reads. Buffer and
+        // consume COMPLETE key sequences, handling several keys per chunk;
+        // an incomplete escape sequence waits for the next chunk.
+        let pending = "";
+        const move = (delta: number): void => {
+          index = (index + options.length + delta) % options.length;
+          redraw();
+        };
         const onData = (chunk: Buffer | string): void => {
-          const text = String(chunk);
-          if (text === "\u0003") { // Ctrl+C
-            cleanup();
-            write("\n");
-            process.exit(130);
-          }
-          if (text === "\r" || text === "\n") {
-            cleanup();
-            resolveChoice(index);
-            return;
-          }
-          if (text === `${ESC}[A` || text === `${ESC}[D`) {
-            index = (index + options.length - 1) % options.length;
-            redraw();
-            return;
-          }
-          if (text === `${ESC}[B` || text === `${ESC}[C`) {
-            index = (index + 1) % options.length;
-            redraw();
-            return;
-          }
-          // Number keys pick directly (the arrows-free fallback).
-          if (/^[1-9]$/.test(text) && Number(text) <= options.length) {
-            index = Number(text) - 1;
-            cleanup();
-            resolveChoice(index);
+          pending += String(chunk);
+          while (pending.length > 0) {
+            // A full CSI (ESC [ ... final byte) or SS3 (ESC O A-D) sequence.
+            const sequence = /^\u001b(?:\[[0-9;]*[@-~]|O[A-D])/.exec(pending)?.[0];
+            if (sequence !== undefined) {
+              pending = pending.slice(sequence.length);
+              const final = sequence[sequence.length - 1]!;
+              if (final === "A" || final === "D") move(-1);
+              else if (final === "B" || final === "C") move(1);
+              continue;
+            }
+            if (pending.startsWith(ESC)) {
+              // A prefix of a sequence still in flight waits for more bytes;
+              // any other escape is dropped.
+              if (/^\u001b(?:\[[0-9;]*|O)?$/.test(pending)) return;
+              pending = pending.slice(1);
+              continue;
+            }
+            const key = pending[0]!;
+            pending = pending.slice(1);
+            if (key === "\u0003") { // Ctrl+C
+              cleanup();
+              write("\n");
+              process.exit(130);
+            }
+            if (key === "\r" || key === "\n") {
+              cleanup();
+              resolveChoice(index);
+              return;
+            }
+            // Number keys pick directly (the arrows-free fallback).
+            if (/^[1-9]$/.test(key) && Number(key) <= options.length) {
+              index = Number(key) - 1;
+              cleanup();
+              resolveChoice(index);
+              return;
+            }
+            // Other printable bytes are ignored.
           }
         };
         input.setRawMode?.(true);

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -42,12 +42,33 @@ export function usePrettyOutput(
   return true;
 }
 
+export interface SelectOption {
+  value: string;
+  label: string;
+  /** Dim parenthetical after the label (e.g. what detection found). */
+  hint?: string;
+}
+
+/** The slice of a readable TTY stream the select loop needs (injectable for
+    tests — a plain emitter drives the keypress parser without a PTY). */
+export interface SelectInput {
+  isTTY?: boolean;
+  setRawMode?(mode: boolean): unknown;
+  resume?(): unknown;
+  pause?(): unknown;
+  on(event: "data", listener: (chunk: Buffer | string) => void): unknown;
+  off(event: "data", listener: (chunk: Buffer | string) => void): unknown;
+}
+
 export interface PrettyOutput extends Output {
   /** Dots spinner for a slow phase; any log/error line clears the frame. */
   spin(label: string): void;
   stopSpin(): void;
   /** The styled [Y/n] confirm — Enter accepts the default, answer echoed. */
   confirm(question: string, defaultYes?: boolean): Promise<boolean>;
+  /** The styled select — arrows move, Enter accepts, number keys pick
+      directly; collapses to the chosen answer. */
+  select(question: string, options: SelectOption[], defaultIndex?: number): Promise<string>;
   /** The `└ Done in Xs` footer (red `Failed` when init exits non-zero). */
   done(durationMs: number, ok: boolean): void;
 }
@@ -61,8 +82,35 @@ function styleInline(text: string): string {
   return text.replace(/`([^`]+)`/g, (_match, code: string) => bold(cyan(code)));
 }
 
+/** The plain-terminal select for non-pretty interactive runs: numbered list +
+    readline. Non-TTY runs never prompt — the default option stands. */
+export async function plainSelect(
+  question: string,
+  options: SelectOption[],
+  defaultIndex = 0,
+): Promise<string> {
+  const fallback = (options[defaultIndex] ?? options[0])!.value;
+  if (stdin.isTTY !== true || stdout.isTTY !== true) return fallback;
+  stdout.write(`${question}\n`);
+  options.forEach((option, index) => {
+    stdout.write(`  ${index + 1}. ${option.label}${option.hint === undefined ? "" : ` (${option.hint})`}\n`);
+  });
+  const prompt = createInterface({ input: stdin, output: stdout });
+  try {
+    const answer = (await prompt.question(`Choose [${defaultIndex + 1}]: `)).trim();
+    const number = /^\d+$/.test(answer) ? Number(answer) : NaN;
+    if (Number.isInteger(number) && number >= 1 && number <= options.length) {
+      return options[number - 1]!.value;
+    }
+    return fallback;
+  } finally {
+    prompt.close();
+  }
+}
+
 export function createPrettyOutput(
   write: (chunk: string) => void = (chunk) => { stdout.write(chunk); },
+  input: SelectInput = stdin,
 ): PrettyOutput {
   let headerPrinted = false;
   let lastWasBar = false;
@@ -209,6 +257,66 @@ export function createPrettyOutput(
       } finally {
         prompt.close();
       }
+    },
+    async select(question, options, defaultIndex = 0) {
+      stopSpin();
+      ensureHeader();
+      section(cyan("◇"), bold(question));
+      let index = defaultIndex;
+      const optionLine = (option: SelectOption, at: number): string => {
+        const marker = at === index ? cyan("●") : dim("○");
+        const label = at === index ? option.label : dim(option.label);
+        const hint = option.hint === undefined ? "" : ` ${dim(`(${option.hint})`)}`;
+        return `${BAR}  ${marker} ${label}${hint}`;
+      };
+      for (const [at, option] of options.entries()) line(optionLine(option, at));
+      const redraw = (): void => {
+        write(`${ESC}[${options.length}A`);
+        for (const [at, option] of options.entries()) write(`${ESC}[2K${optionLine(option, at)}\n`);
+      };
+      const chosen = await new Promise<number>((resolveChoice) => {
+        const cleanup = (): void => {
+          input.off("data", onData);
+          input.setRawMode?.(false);
+          input.pause?.();
+        };
+        const onData = (chunk: Buffer | string): void => {
+          const text = String(chunk);
+          if (text === "\u0003") { // Ctrl+C
+            cleanup();
+            write("\n");
+            process.exit(130);
+          }
+          if (text === "\r" || text === "\n") {
+            cleanup();
+            resolveChoice(index);
+            return;
+          }
+          if (text === `${ESC}[A` || text === `${ESC}[D`) {
+            index = (index + options.length - 1) % options.length;
+            redraw();
+            return;
+          }
+          if (text === `${ESC}[B` || text === `${ESC}[C`) {
+            index = (index + 1) % options.length;
+            redraw();
+            return;
+          }
+          // Number keys pick directly (the arrows-free fallback).
+          if (/^[1-9]$/.test(text) && Number(text) <= options.length) {
+            index = Number(text) - 1;
+            cleanup();
+            resolveChoice(index);
+          }
+        };
+        input.setRawMode?.(true);
+        input.resume?.();
+        input.on("data", onData);
+      });
+      // Collapse the option list to the chosen answer.
+      write(`${ESC}[${options.length}A${ESC}[0J`);
+      line(`${BAR}  ${cyan("●")} ${options[chosen]!.label}`);
+      return options[chosen]!.value;
     },
     done(durationMs, ok) {
       stopSpin();


### PR DESCRIPTION
`vendo init` gets a clack-style terminal experience, Vendo Cloud becomes the emphasized block, the model credential resolves BEFORE the AI passes, and declining the detected auth preset opens a picker. Six commits, each Yousef-directed:

## What changed

1. **Visual system** (`cli/pretty.ts`, zero new dependencies — hand-rolled ANSI): ┌/│/◇/◆ clack-style rail, colored diff markers, truecolor theme swatches, spinners on slow passes, styled `[Y/n]` confirms and a reusable arrow-key/number-key select primitive. **Strict degradation**: non-TTY, `NO_COLOR`, `CI`, `TERM=dumb`, and `--agent` get byte-identical plain output (the renderer sits over the existing output seam; existing tests run the plain path untouched).
2. **Vendo Cloud emphasized**: bold brand-blue `◆ Vendo Cloud` header, ✦ benefit bullets, bright `→ vendo cloud login` CTA — the most prominent block on screen; claims unchanged.
3. **Credential-first order** (Yousef: "shouldn't it be the opposite way around so the AI can actually be used"): key resolution + the Cloud offer moved before theme/extraction/AI-polish. A starter key minted mid-run genuinely powers the same run's AI passes — the theme resolver now rides the devModel ladder and a hermetic gateway test proves the freshly-minted `x-api-key` arrives. One short keyless reminder at the end; the block never repeats.
4. **Auth picker** (Yousef: "does the user have the choice to select others if no?"): declining the detected preset — or ambiguous detection, which previously never asked — opens a select: anonymous default first, detected families hinted and ordered first, zero-arg presets wire with an install hint when their SDK is absent, `jwt` prints its recipe (never scaffolds a broken line). `--yes`/CI/`--agent` never prompt. Picked presets say "Selected X" in the generated comment; detection says "Detected <dep>".
5. Fixes from review: pretty prompts return defaults when stdin is not a TTY (`vendo init < file` can't hang); interactive prompt bodies fully test-driven via injectable streams; select's 1-9 number-key constraint documented.

## Verification
- packages/vendo: init 36, pretty 23, cloud 11 — full monorepo build/test/typecheck/lint green (clean run).
- Real PTY captures (expect-driven, in the session scratchpad): accept path, decline→picker→clerk path (wires `auth: clerk()` + install hint, 2 real tools learned from a route-bearing fixture).
- Three review rounds (spec ×2 with targeted-suite runs + quality) — all findings fixed in-branch.

https://claude.ai/code/session_018S4HHYRGSGyDXwNGo3oJWS

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revamps `vendo init` with a clack-style TTY UI and a credential-first, Vendo Cloud–forward flow so a freshly minted or existing key powers the same run. Adds an auth picker on decline/ambiguity and makes the cloud step respect provided env and `.env.local`; non‑TTY/CI/`--agent` runs keep byte-identical plain output.

- New Features
  - Pretty TTY output: rail layout, colored diffs, spinners, styled `[Y/n]` and arrow/number select; emphasized Vendo Cloud header with benefits and `vendo cloud login` CTA (zero new deps).
  - Credential-first: resolve dev model credential before theme/extraction; theme model uses `devModel` and throws with a clear message when no credential; a minted `VENDO_API_KEY` is read from `.env.local` and used in the same run.
  - Auth picker: on decline or ambiguous detection, offer a select (none → detected families → other presets → `jwt` recipe). Picked presets say “Selected …” in the comment and add an install hint if their SDK (e.g. `@clerk/backend`) is missing. `--yes`/non-interactive never prompt.
  - Strict degradation: pretty output only on a human TTY (no `NO_COLOR`/`CI`/`TERM=dumb`); otherwise output is unchanged. Prompts return defaults when stdin isn’t a TTY.
  - Tests: coverage for the renderer, confirm/select flows, auth picker, same-run key pickup, run-env/`.env.local` behavior.

- Bug Fixes
  - Cloud step honors the run env and prior `.env.local` keys: skips the offer when `VENDO_API_KEY` is present, merges a minted key back into the same run’s env so theme/AI passes use it, and picks up existing keys on re-run without re-offering.
  - Select input buffers escape sequences and pasted numbers; arrow/number keys work even when keypresses arrive in split chunks.

<sup>Written for commit 1bc2c377635571cf3fae0fd1c728f00fb1ed3206. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

