### PR TITLE
execution v2 lane D: fn runtime resolution + schedule execution

### DIFF
--- a/docs-site/agents/verify.mdx
+++ b/docs-site/agents/verify.mdx
@@ -374,6 +374,23 @@ does not start with `v=MCPv1`, usually a stale or hand-edited deployed copy.
 [E-MCP-007](#E-MCP-007)); DNS verification is an alternative to serving it
 over HTTP.
 
+## Machine schedules
+
+### E-SCHED-001 {#E-SCHED-001}
+
+**Symptom (warning):** Apps declare `vendo.json` schedules but no schedule
+caller is configured.
+
+**Cause:** At least one machine-bearing app's `vendo.json` declares a
+schedule, but `VENDO_TICK_SECRET` is not set, so nothing can hit the
+authenticated `POST /api/vendo/tick` surface and the schedules never fire.
+
+**Fix:** Set `VENDO_TICK_SECRET` to a random secret in the server environment,
+then point any external cron — Vercel cron, a GitHub Actions schedule, or
+crontab — at `POST <base>/tick` with the header
+`Authorization: Bearer $VENDO_TICK_SECRET`. Every hit fires due schedules
+exactly once per cron window; a double-hit is a safe no-op.
+
 ## Live model turn
 
 ### E-TURN-001 {#E-TURN-001}

--- a/docs-site/deploy/scheduler-and-webhooks.mdx
+++ b/docs-site/deploy/scheduler-and-webhooks.mdx
@@ -16,6 +16,33 @@ Schedules support exactly one of a five-field `cron`, a duration such as
 `15m`, or a one-shot UTC timestamp. Cron evaluates in UTC. If the host misses a
 window, the next tick fires once and never back-fills.
 
+The bearer is the host-configured `VENDO_TICK_SECRET`. Point any external cron
+at it — Vercel cron, a GitHub Actions schedule, or crontab — as often as you
+like: firing is idempotent within a cron window, so a double-hit never
+double-runs anything.
+
+## Machine app schedules
+
+The same tick drives graduated apps' machines. An app whose box ships a
+`vendo.json` manifest declaring schedules —
+
+```json
+{ "schedules": [{ "cron": "0 8 * * *", "fn": "chaseInvoices" }] }
+```
+
+— gets each due target fired as `POST /fn/<name>` on its machine: the tick
+wakes the machine, posts the fn as the app owner's away execution, records
+last-fired state, and the machine goes back to sleep on the normal idle
+policy. Due-ness is computed from store-cached state, so a tick never wakes a
+machine with nothing due. The response's additive `schedules` field reports
+what fired.
+
+The host learns a box's schedules by reading `vendo.json` over the machine
+door whenever the machine is awake at tick time (and once, on the first tick
+after graduation). A manifest edited while the machine sleeps is picked up the
+next time it is awake. `vendo doctor` reports machine-bearing apps, whether a
+schedule caller is configured, and last-fired times.
+
 ## Host events
 
 Emit from the host code path that owns the event:

--- a/docs/persistence-and-deploy.md
+++ b/docs/persistence-and-deploy.md
@@ -92,7 +92,10 @@ Schedule `POST /api/vendo/tick` from the platform cron. Send:
 Authorization: Bearer <secret>
 ```
 
-The `/tick` endpoint is outside cookie auth and requires this bearer secret.
+The `/tick` endpoint is outside cookie auth and requires this bearer secret
+(`VENDO_TICK_SECRET`). One tick drives both schedulers: automation schedules
+and graduated apps' `vendo.json` machine schedules (each due target fires as
+`POST /fn/<name>` on the app's machine, exactly once per cron window).
 Use hosted Postgres for serverless deployment. Local PGlite files are suitable
 for a durable single-process host, not an ephemeral filesystem.
 

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@vendoai/core": "workspace:*",
+    "croner": "^9.0.0",
     "esbuild": "^0.25.0",
     "fflate": "^0.8.2",
     "zod": "^3.25.0"

--- a/packages/apps/src/fn-runtime.e2e.test.ts
+++ b/packages/apps/src/fn-runtime.e2e.test.ts
@@ -1,0 +1,191 @@
+import {
+  VENDO_APP_FORMAT,
+  VENDO_TREE_FORMAT_V2,
+  type AppDocument,
+  type Json,
+  type RunContext,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createApps } from "./index.js";
+import type { SandboxAdapter, SandboxMachine } from "./sandbox.js";
+import { basicLanguageModel, guardFixture, memoryStore, seedAppRow } from "./testing/index.js";
+
+/**
+ * execution-v2 Lane D gate (fake adapter): a v2 tree whose query names
+ * `fn:<name>` binds its data through the box door at open(); an fn: action
+ * round-trips on call() and a re-open re-binds the changed data; a failed fn
+ * is a contained outcome, never a thrown white box.
+ */
+
+const model = basicLanguageModel();
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const ctx = (subject = "user_ada"): RunContext => ({
+  principal: { kind: "user", subject },
+  venue: "app",
+  presence: "present",
+  sessionId: `session_${subject}`,
+});
+
+const registryTools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "ok", output: { via: "registry" } }; },
+};
+
+/** A stateful fake box: /fn/report answers the running total, /fn/add adds. */
+const statefulBox = () => {
+  const state = { total: 40 };
+  const seen: Array<{ method: string; path: string; body?: string }> = [];
+  const machine: SandboxMachine = {
+    id: "fake_fn_runtime",
+    async request(request) {
+      const body = request.body === undefined
+        ? undefined
+        : typeof request.body === "string" ? request.body : decoder.decode(request.body);
+      seen.push({ method: request.method, path: request.path, ...(body === undefined ? {} : { body }) });
+      const respond = (status: number, payload: unknown) => ({
+        status,
+        headers: { "content-type": "application/json" },
+        body: encoder.encode(JSON.stringify(payload)),
+      });
+      if (request.method === "POST" && request.path === "/fn/report") {
+        return respond(200, { result: { total: state.total } });
+      }
+      if (request.method === "POST" && request.path === "/fn/add") {
+        const args = (JSON.parse(body ?? "{}") as { args?: { amount?: number } }).args;
+        state.total += args?.amount ?? 0;
+        return respond(200, { result: { total: state.total } });
+      }
+      if (request.method === "POST" && request.path === "/fn/broken") {
+        return respond(500, { error: { code: "box-broke", message: "the box failed honestly" } });
+      }
+      return { status: 404, headers: {}, body: new Uint8Array() };
+    },
+    async snapshot() { return "fake:fn-runtime"; },
+    async stop() { /* sleep */ },
+    async destroy() { /* gone */ },
+  };
+  const adapter: SandboxAdapter = {
+    async create() { return machine; },
+    async resume() { return machine; },
+    async destroy() { /* released */ },
+  };
+  return { adapter, seen, state };
+};
+
+const fnTreeApp = (id: string): AppDocument => ({
+  format: VENDO_APP_FORMAT,
+  id,
+  name: "Fn tree app",
+  ui: "tree",
+  machine: { snapshotRef: "fake:fn-runtime", provisionedAt: "2026-07-19T00:00:00.000Z" },
+  tree: {
+    formatVersion: VENDO_TREE_FORMAT_V2,
+    root: "n1",
+    nodes: [
+      {
+        id: "n1",
+        component: "Stat",
+        source: "prewired",
+        props: {
+          label: "Total",
+          value: { $path: "/report/total" },
+          onClick: { action: "fn:add", payload: { amount: 2 } },
+        },
+      },
+    ],
+    queries: [
+      { name: "report", tool: "fn:report" },
+      { name: "host", tool: "host_reader" },
+    ],
+  } as unknown as NonNullable<AppDocument["tree"]>,
+});
+
+const setup = (id = "app_fn_runtime") => {
+  const { adapter, seen, state } = statefulBox();
+  const store = memoryStore();
+  const runtime = createApps({
+    store,
+    guard: guardFixture(),
+    tools: registryTools,
+    catalog: [],
+    model,
+    machine: { sandbox: adapter },
+  });
+  return { runtime, store, seen, state, id };
+};
+
+describe("fn: runtime resolution (execution-v2 Lane D gate)", () => {
+  it("open() resolves an fn: query through the box door and binds it beside host-tool queries", async () => {
+    const { runtime, store, seen, id } = setup();
+    await seedAppRow(store, fnTreeApp(id), "user_ada");
+
+    const surface = await runtime.open(id, ctx());
+    if (surface.kind !== "tree") throw new Error(`expected tree surface, got ${surface.kind}`);
+    const data = (surface.payload as { data?: Record<string, Json> }).data;
+    // The fn: query bound through the box; the host query bound through the
+    // registry — shape-aware binding is one path for both.
+    expect(data).toMatchObject({ report: { total: 40 }, host: { via: "registry" } });
+    expect(seen).toEqual([{
+      method: "POST",
+      path: "/fn/report",
+      body: JSON.stringify({ args: {} }),
+    }]);
+  });
+
+  it("an fn: action round-trips on call() and a re-open re-binds the new data", async () => {
+    const { runtime, store, seen, id } = setup();
+    await seedAppRow(store, fnTreeApp(id), "user_ada");
+
+    const outcome = await runtime.call(id, "fn:add", { amount: 2 }, ctx());
+    expect(outcome).toEqual({ status: "ok", output: { total: 42 } });
+    expect(seen).toEqual([{
+      method: "POST",
+      path: "/fn/add",
+      body: JSON.stringify({ args: { amount: 2 } }),
+    }]);
+
+    const surface = await runtime.open(id, ctx());
+    if (surface.kind !== "tree") throw new Error(`expected tree surface, got ${surface.kind}`);
+    expect((surface.payload as { data?: Record<string, Json> }).data).toMatchObject({
+      report: { total: 42 },
+    });
+  });
+
+  it("a failed fn is a contained outcome — open() still serves the tree", async () => {
+    const { runtime, store, id } = setup();
+    const app = fnTreeApp(id);
+    (app.tree as unknown as { queries: Array<{ name: string; tool: string }> }).queries = [
+      { name: "report", tool: "fn:broken" },
+      { name: "host", tool: "host_reader" },
+    ];
+    await seedAppRow(store, app, "user_ada");
+
+    const surface = await runtime.open(id, ctx());
+    if (surface.kind !== "tree") throw new Error(`expected tree surface, got ${surface.kind}`);
+    const data = (surface.payload as { data?: Record<string, Json> }).data;
+    // The broken fn's slot stays unbound; the rest of the app still rendered.
+    expect(data).toMatchObject({ host: { via: "registry" } });
+    expect(data).not.toHaveProperty("report");
+
+    const outcome = await runtime.call(id, "fn:broken", {}, ctx());
+    expect(outcome).toEqual({
+      status: "error",
+      error: { code: "box-broke", message: "the box failed honestly" },
+    });
+  });
+
+  it("a machine-bearing app with no adapter contains sandbox-unavailable per query", async () => {
+    const store = memoryStore();
+    const runtime = createApps({ store, guard: guardFixture(), tools: registryTools, catalog: [], model });
+    await seedAppRow(store, fnTreeApp("app_no_adapter"), "user_ada");
+
+    const surface = await runtime.open("app_no_adapter", ctx());
+    if (surface.kind !== "tree") throw new Error(`expected tree surface, got ${surface.kind}`);
+    const data = (surface.payload as { data?: Record<string, Json> }).data;
+    expect(data).toMatchObject({ host: { via: "registry" } });
+    expect(data).not.toHaveProperty("report");
+  });
+});

--- a/packages/apps/src/fn.test.ts
+++ b/packages/apps/src/fn.test.ts
@@ -1,0 +1,171 @@
+import { VENDO_APP_FORMAT, VendoError, type AppDocument, type RunContext, type ToolOutcome } from "@vendoai/core";
+import { describe, expect, it, vi } from "vitest";
+import type { AppCaller } from "./call.js";
+import { createFnCaller } from "./fn.js";
+import type { SandboxMachine } from "./sandbox.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const ctx: RunContext = {
+  principal: { kind: "user", subject: "user_ada" },
+  venue: "app",
+  presence: "present",
+  sessionId: "session_fn",
+};
+
+const machineApp = (id = "app_fn"): AppDocument => ({
+  format: VENDO_APP_FORMAT,
+  id,
+  name: "Fn app",
+  machine: { snapshotRef: "fake-v2:snap_1", provisionedAt: "2026-07-19T00:00:00.000Z" },
+});
+
+const treeApp = (id = "app_tree"): AppDocument => ({
+  format: VENDO_APP_FORMAT,
+  id,
+  name: "Tree app",
+});
+
+interface BoxAnswer {
+  status: number;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+/** A wake seam whose machine dispatches requests to the given handler. */
+const boxWake = (handler: (request: {
+  method: string;
+  path: string;
+  headers?: Record<string, string>;
+  body?: Uint8Array | string;
+}) => BoxAnswer) => {
+  const seen: Array<{ method: string; path: string; headers?: Record<string, string>; body?: string }> = [];
+  const machine: SandboxMachine = {
+    id: "fake_fn_box",
+    async request(request) {
+      seen.push({
+        method: request.method,
+        path: request.path,
+        ...(request.headers === undefined ? {} : { headers: request.headers }),
+        ...(request.body === undefined
+          ? {}
+          : { body: typeof request.body === "string" ? request.body : decoder.decode(request.body) }),
+      });
+      const answer = handler(request);
+      return {
+        status: answer.status,
+        headers: answer.headers ?? {},
+        body: encoder.encode(answer.body ?? ""),
+      };
+    },
+    async snapshot() { return "fake-v2:snap_next"; },
+    async stop() { /* sleep */ },
+    async destroy() { /* gone */ },
+  };
+  return { seen, wake: vi.fn(async () => machine) };
+};
+
+describe("createFnCaller (execution-v2 fn resolution over the box door)", () => {
+  it("POSTs /fn/<name> with the {args} envelope and binds {result} like a tool outcome", async () => {
+    const { seen, wake } = boxWake(() => ({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ result: { total: 42 } }),
+    }));
+    const fn = createFnCaller({ wake });
+    const outcome = await fn.callFn(machineApp(), "total", { rows: [1, 41] }, ctx);
+    expect(outcome).toEqual({ status: "ok", output: { total: 42 } });
+    expect(seen).toEqual([{
+      method: "POST",
+      path: "/fn/total",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ args: { rows: [1, 41] } }),
+    }]);
+  });
+
+  it("relays a structured box error envelope as a contained error outcome", async () => {
+    const { wake } = boxWake(() => ({
+      status: 422,
+      body: JSON.stringify({ error: { code: "invoice-missing", message: "no such invoice" } }),
+    }));
+    const outcome = await createFnCaller({ wake }).callFn(machineApp(), "chase", {}, ctx);
+    expect(outcome).toEqual({
+      status: "error",
+      error: { code: "invoice-missing", message: "no such invoice" },
+    });
+  });
+
+  it("contains an unstructured box failure as a machine error", async () => {
+    const { wake } = boxWake(() => ({ status: 500, body: "boom" }));
+    const outcome = await createFnCaller({ wake }).callFn(machineApp(), "chase", {}, ctx);
+    expect(outcome).toMatchObject({ status: "error", error: { code: "machine" } });
+  });
+
+  it("rejects a success body that is not a {result} envelope (the machine never draws)", async () => {
+    for (const body of ["not json", JSON.stringify([1]), JSON.stringify({}), JSON.stringify({ ui: {} }), JSON.stringify({ result: 1, ui: {} })]) {
+      const { wake } = boxWake(() => ({ status: 200, body }));
+      const outcome = await createFnCaller({ wake }).callFn(machineApp(), "report", {}, ctx);
+      expect(outcome).toMatchObject({ status: "error", error: { code: "validation" } });
+    }
+  });
+
+  it("rejects an invalid fn name without waking the machine", async () => {
+    const { wake } = boxWake(() => ({ status: 200 }));
+    const outcome = await createFnCaller({ wake }).callFn(machineApp(), "9bad name", {}, ctx);
+    expect(outcome).toMatchObject({ status: "error", error: { code: "validation" } });
+    expect(wake).not.toHaveBeenCalled();
+  });
+
+  it("contains a machine-less app as a validation error without waking", async () => {
+    const { wake } = boxWake(() => ({ status: 200 }));
+    const outcome = await createFnCaller({ wake }).callFn(treeApp(), "total", {}, ctx);
+    expect(outcome).toMatchObject({ status: "error", error: { code: "validation" } });
+    expect(wake).not.toHaveBeenCalled();
+  });
+
+  it("contains a wake failure as an error outcome, never a thrown white box", async () => {
+    const wake = vi.fn(async (): Promise<SandboxMachine> => {
+      throw new VendoError("sandbox-unavailable", "sandbox execution is unavailable");
+    });
+    const outcome = await createFnCaller({ wake }).callFn(machineApp(), "total", {}, ctx);
+    expect(outcome).toEqual({
+      status: "error",
+      error: { code: "sandbox-unavailable", message: "sandbox execution is unavailable" },
+    });
+  });
+
+  describe("wrap(caller)", () => {
+    const innerOutcome: ToolOutcome = { status: "ok", output: "inner" };
+    const inner: AppCaller = {
+      call: vi.fn(async () => innerOutcome),
+      callFn: vi.fn(async () => innerOutcome),
+      callQuery: vi.fn(async () => ({ outcome: innerOutcome, uiEnvelope: false })),
+    };
+
+    it("routes fn: refs on a machine-bearing app to the box for call and callQuery", async () => {
+      const { seen, wake } = boxWake(() => ({
+        status: 200,
+        body: JSON.stringify({ result: { ok: true } }),
+      }));
+      const wrapped = createFnCaller({ wake }).wrap(inner);
+      const call = await wrapped.call(machineApp(), "fn:submit", { id: "i1" }, ctx);
+      const query = await wrapped.callQuery(machineApp(), "fn:report", {}, ctx);
+      expect(call).toEqual({ status: "ok", output: { ok: true } });
+      expect(query).toEqual({ outcome: { status: "ok", output: { ok: true } }, uiEnvelope: false });
+      expect(seen.map((request) => request.path)).toEqual(["/fn/submit", "/fn/report"]);
+      expect(inner.call).not.toHaveBeenCalled();
+      expect(inner.callQuery).not.toHaveBeenCalled();
+    });
+
+    it("delegates host tool refs and machine-less fn: refs to the inner caller", async () => {
+      const { wake } = boxWake(() => ({ status: 200, body: JSON.stringify({ result: 1 }) }));
+      const wrapped = createFnCaller({ wake }).wrap(inner);
+      expect(await wrapped.call(machineApp(), "host_tool", {}, ctx)).toEqual(innerOutcome);
+      expect(await wrapped.call(treeApp(), "fn:total", {}, ctx)).toEqual(innerOutcome);
+      expect((await wrapped.callQuery(treeApp(), "host_tool", {}, ctx)).outcome).toEqual(innerOutcome);
+      expect(await wrapped.callFn(treeApp(), "total", {}, ctx)).toEqual(innerOutcome);
+      expect(wake).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/apps/src/fn.ts
+++ b/packages/apps/src/fn.ts
@@ -1,0 +1,140 @@
+import {
+  VendoError,
+  type AppDocument,
+  type Json,
+  type RunContext,
+  type ToolOutcome,
+} from "@vendoai/core";
+import type { AppCaller } from "./call.js";
+import type { SandboxMachine } from "./sandbox.js";
+
+/**
+ * execution-v2 Wave 2 Lane D — fn: resolution over the box door. A v2 tree
+ * whose query or action names `fn:<name>` resolves here: wake the app's
+ * machine (Lane B's lifecycle) and POST the skin-contract `/fn/<name>` route
+ * (Lane C's proxy speaks the same door from the wire). The host ToolRegistry
+ * never sees an fn: ref; the box never sees host credentials — only
+ * content-type crosses the skin, exactly like the wire proxy.
+ *
+ * Containment rule: a failed fn is a contained error OUTCOME (the query slot
+ * stays unbound, the action renders its error state) — never a thrown white
+ * box. Responses bind exactly like tool results: `{result}` becomes
+ * `{status:"ok", output}`, `{error:{code,message}}` relays as-is.
+ */
+
+/** The name half of core's 01 §8 `fn:<name>` grammar. */
+const FN_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+
+const decoder = new TextDecoder();
+
+const errorOutcome = (code: string, message: string): ToolOutcome => ({
+  status: "error",
+  error: { code, message },
+});
+
+const own = (value: object, key: string): boolean => Object.prototype.hasOwnProperty.call(value, key);
+
+export interface FnCallerConfig {
+  /** Lane B's machine lifecycle wake — the only runtime door into the box. */
+  wake(app: AppDocument): Promise<SandboxMachine>;
+}
+
+export interface FnCaller {
+  /** Execute one box function as a tool outcome (see containment rule above). */
+  callFn(app: AppDocument, name: string, args: Json, ctx: RunContext): Promise<ToolOutcome>;
+  /**
+   * Decorate an AppCaller so fn: refs on a machine-bearing app ride the v2
+   * box door; every other ref (host tools, fn: on an app that never
+   * graduated) keeps the inner caller's behavior.
+   */
+  wrap(caller: AppCaller): AppCaller;
+}
+
+/**
+ * Parse one box answer into a tool outcome. Success (2xx) must be exactly a
+ * `{result}` JSON envelope — the machine never draws UI in v2, so a `ui`
+ * member (or anything else) is a validation error routed to containment.
+ */
+const outcomeFromBoxAnswer = (status: number, body: Uint8Array): ToolOutcome => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(decoder.decode(body)) as unknown;
+  } catch {
+    return status >= 200 && status < 300
+      ? errorOutcome("validation", "machine response is not valid JSON")
+      : errorOutcome("machine", `machine function failed (${status})`);
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return status >= 200 && status < 300
+      ? errorOutcome("validation", "machine response must be an object envelope")
+      : errorOutcome("machine", `machine function failed (${status})`);
+  }
+  const envelope = parsed as Record<string, unknown>;
+  if (status >= 200 && status < 300) {
+    if (!own(envelope, "result") || own(envelope, "ui")) {
+      return errorOutcome("validation", "machine success response must be exactly a {result} envelope — the machine never draws UI");
+    }
+    return { status: "ok", output: envelope.result as Json };
+  }
+  const error = envelope.error;
+  if (typeof error === "object" && error !== null && !Array.isArray(error)) {
+    const candidate = error as Record<string, unknown>;
+    if (typeof candidate.code === "string" && typeof candidate.message === "string") {
+      return errorOutcome(candidate.code, candidate.message);
+    }
+  }
+  return errorOutcome("machine", `machine function failed (${status})`);
+};
+
+export const createFnCaller = (config: FnCallerConfig): FnCaller => {
+  const callFn = async (
+    app: AppDocument,
+    name: string,
+    args: Json,
+    _ctx: RunContext,
+  ): Promise<ToolOutcome> => {
+    if (!FN_NAME_PATTERN.test(name)) {
+      return errorOutcome("validation", `invalid fn reference: fn:${name}`);
+    }
+    if (app.machine === undefined) {
+      return errorOutcome("validation", `fn:${name} requires a machine; the app has not graduated`);
+    }
+    try {
+      const machine = await config.wake(app);
+      const answer = await machine.request({
+        method: "POST",
+        path: `/fn/${name}`,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ args }),
+      });
+      return outcomeFromBoxAnswer(answer.status, answer.body);
+    } catch (error) {
+      // Containment: wake and transport failures surface as error outcomes
+      // (VendoError codes kept — sandbox-unavailable stays diagnosable).
+      if (error instanceof VendoError) return errorOutcome(error.code, error.message);
+      return errorOutcome("machine", error instanceof Error ? error.message : "machine function failed");
+    }
+  };
+
+  return {
+    callFn,
+    wrap: (inner) => ({
+      async call(app, ref, args, ctx, authorization) {
+        if (ref.startsWith("fn:") && app.machine !== undefined) {
+          return callFn(app, ref.slice(3), args, ctx);
+        }
+        return inner.call(app, ref, args, ctx, authorization);
+      },
+      async callFn(app, name, args, ctx, authorization) {
+        if (app.machine !== undefined) return callFn(app, name, args, ctx);
+        return inner.callFn(app, name, args, ctx, authorization);
+      },
+      async callQuery(app, ref, args, ctx, authorization) {
+        if (ref.startsWith("fn:") && app.machine !== undefined) {
+          return { outcome: await callFn(app, ref.slice(3), args, ctx), uiEnvelope: false };
+        }
+        return inner.callQuery(app, ref, args, ctx, authorization);
+      },
+    }),
+  };
+};

--- a/packages/apps/src/index.ts
+++ b/packages/apps/src/index.ts
@@ -56,6 +56,24 @@ export {
   type BuiltBoxEnv,
   type InferenceResolver,
 } from "./box-env.js";
+// execution-v2 Lane D — fn: resolution over the box door and the BYO
+// schedule-execution engine (vendo.json schedules → authenticated tick).
+export {
+  createFnCaller,
+  type FnCaller,
+  type FnCallerConfig,
+} from "./fn.js";
+export {
+  createScheduleEngine,
+  SCHEDULE_STATE_COLLECTION,
+  type AppScheduleState,
+  type AppScheduleStatus,
+  type ScheduleEngine,
+  type ScheduleEngineConfig,
+  type ScheduleFire,
+  type ScheduleState,
+  type ScheduleTickReport,
+} from "./schedules.js";
 // execution-v2 Lane B — the machine lifecycle over the canonical seam.
 // (MachineSandboxAdapter has collapsed to a deprecated alias of SandboxAdapter
 // now that destroy-by-ref lives on the seam itself.)

--- a/packages/apps/src/interchange.test.ts
+++ b/packages/apps/src/interchange.test.ts
@@ -356,7 +356,7 @@ describe(".vendoapp interchange through createApps", () => {
 
     await expect(runtime.importApp(archive, context("user_ada"))).rejects.toMatchObject({
       code: "validation",
-      message: expect.stringContaining("fn: references require an app server"),
+      message: expect.stringContaining("fn: references require a machine"),
     });
   });
 

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -53,11 +53,18 @@ import {
   type LifecycleClock,
   type MachineSandboxAdapter,
 } from "./machine-lifecycle.js";
+import { createFnCaller } from "./fn.js";
 import { createAppOpener, createProgressiveQueryResolver } from "./open.js";
 import { appRecordInput, documentFromRecord, enabledAfterDocumentEdit, rowFromRecord } from "./persistence.js";
 import { detectPinDrift, hasDefaultExport, pinComponentName, pinForkSource, type InClientApproval, type PinBaseline, type PinDrift } from "./pins.js";
 import { createAppsProxy } from "./proxy.js";
 import { createRunTokenGate } from "./run-token-gate.js";
+import {
+  createScheduleEngine,
+  type AppScheduleState,
+  type AppScheduleStatus,
+  type ScheduleTickReport,
+} from "./schedules.js";
 import { createSecretExposure, type SecretExposureGrant } from "./secret-exposure.js";
 import { computeShipDiff, type ShipDiff } from "./ship-diff.js";
 import { appVersionHash } from "./version-hash.js";
@@ -290,6 +297,20 @@ export interface AppsRuntime {
     sleep(appId: AppId, ctx: RunContext): Promise<AppDocument>;
     /** Destroy the sandbox and clear the document's machine field (de-graduation). */
     destroy(appId: AppId, ctx: RunContext): Promise<AppDocument>;
+  };
+  /**
+   * execution-v2 Wave 2 Lane D — additive BYO schedule-execution surface (same
+   * additive precedent as `machine`/`box`). `tick` is what the host's
+   * authenticated scheduler endpoint calls on every external-cron hit: it
+   * fires due `vendo.json` schedules exactly once per cron window (see
+   * schedules.ts for the store-claimed idempotency rule). `sync` is the
+   * owner-scoped manifest re-read (the Wave-3 in-box agent's edit-complete
+   * hook); `report` feeds the doctor's machine/schedule reporting.
+   */
+  schedules: {
+    tick(at?: Date): Promise<ScheduleTickReport>;
+    sync(appId: AppId, ctx: RunContext): Promise<AppScheduleState>;
+    report(): Promise<AppScheduleStatus[]>;
   };
   /**
    * ENG-345 — additive guarded per-secret in-sandbox exposure surface (same
@@ -575,7 +596,18 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
   config.guard.onApprovalDecision((id, approved) => onApprovalDecision(id, approved));
 
   const inClientApprovals = createInClientApprovals(config.store);
-  const caller = createAppCaller(machines, config.tools);
+  // execution-v2 Lane D — fn: refs on a machine-bearing app resolve over the
+  // v2 box door (the same wake Lane C's wire proxy rides); the wrap leaves
+  // every other ref on the existing caller. Queries hit this at open(),
+  // actions at call().
+  const fnCaller = createFnCaller({ wake: (app) => lifecycle.wake(app) });
+  const scheduleEngine = createScheduleEngine({
+    store: config.store,
+    lifecycle,
+    callFn: fnCaller.callFn,
+    audit: (event) => config.guard.report(event),
+  });
+  const caller = fnCaller.wrap(createAppCaller(machines, config.tools));
   const opener = createAppOpener(
     machines,
     caller,
@@ -936,6 +968,7 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       await machines.stop(appId);
       // execution-v2 — deleting the app destroys its machine (sandbox + snapshot).
       await lifecycle.destroyMachine(app);
+      await scheduleEngine.clearForApp(appId);
       await data.clear(app, ctx.principal.subject, await history.documents(appId));
       await history.clear(appId);
       await inClientApprovals.clear(appId);
@@ -1293,9 +1326,20 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       async destroy(appId, ctx) {
         const app = await requireOwned(appId, ctx.principal.subject);
         const cleared = await lifecycle.destroyMachine(app);
+        // De-graduation retires the cached schedule state with the machine.
+        await scheduleEngine.clearForApp(appId);
         if (app.machine !== undefined) await reportLifecycle("machine-destroy", appId, ctx);
         return cleared;
       },
+    },
+
+    schedules: {
+      tick: (at) => scheduleEngine.tick(at),
+      async sync(appId, ctx) {
+        const app = await requireOwned(appId, ctx.principal.subject);
+        return scheduleEngine.syncManifest(app);
+      },
+      report: () => scheduleEngine.report(),
     },
 
     secrets: {

--- a/packages/apps/src/schedules.test.ts
+++ b/packages/apps/src/schedules.test.ts
@@ -1,0 +1,253 @@
+import { VENDO_APP_FORMAT, type AppDocument, type AuditEvent } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createFnCaller } from "./fn.js";
+import { createMachineLifecycle } from "./machine-lifecycle.js";
+import { createScheduleEngine, SCHEDULE_STATE_COLLECTION } from "./schedules.js";
+import type { SandboxAdapter, SandboxMachine } from "./sandbox.js";
+import { memoryStore } from "./testing/index.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+interface BoxAnswer {
+  status: number;
+  headers?: Record<string, string>;
+  body?: string;
+}
+type BoxHandler = (request: {
+  method: string;
+  path: string;
+  body?: Uint8Array | string;
+}) => BoxAnswer;
+
+/** A v2 adapter whose machines dispatch to a swappable handler, counting resumes. */
+const handlerSandbox = (initial: BoxHandler) => {
+  const state = {
+    handler: initial,
+    resumes: 0,
+    seen: [] as Array<{ method: string; path: string; body?: string }>,
+  };
+  const machine: SandboxMachine = {
+    id: "fake_schedule_box",
+    async request(request) {
+      state.seen.push({
+        method: request.method,
+        path: request.path,
+        ...(request.body === undefined
+          ? {}
+          : { body: typeof request.body === "string" ? request.body : decoder.decode(request.body) }),
+      });
+      const answer = state.handler(request);
+      return { status: answer.status, headers: answer.headers ?? {}, body: encoder.encode(answer.body ?? "") };
+    },
+    async snapshot() { return "fake:snap"; },
+    async stop() { /* sleep */ },
+    async destroy() { /* gone */ },
+  };
+  const adapter: SandboxAdapter = {
+    async create() { return machine; },
+    async resume() { state.resumes += 1; return machine; },
+    async destroy() { /* released */ },
+  };
+  return { adapter, state };
+};
+
+const machineDoc = (id = "app_sched"): AppDocument => ({
+  format: VENDO_APP_FORMAT,
+  id,
+  name: "Schedule app",
+  machine: { snapshotRef: "fake:snap", provisionedAt: "2026-07-19T00:00:00.000Z" },
+});
+
+const manifest = (schedules: Array<{ cron: string; fn: string }>): BoxAnswer => ({
+  status: 200,
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ schedules }),
+});
+
+const fnOk: BoxAnswer = { status: 200, body: JSON.stringify({ result: { chased: true } }) };
+
+const defaultHandler: BoxHandler = (request) => {
+  if (request.method === "GET" && request.path === "/vendo.json") {
+    return manifest([{ cron: "* * * * *", fn: "chase" }]);
+  }
+  if (request.method === "POST" && request.path === "/fn/chase") return fnOk;
+  return { status: 404 };
+};
+
+async function setup(handler: BoxHandler = defaultHandler, doc: AppDocument = machineDoc()) {
+  const store = memoryStore();
+  const { adapter, state } = handlerSandbox(handler);
+  const lifecycle = createMachineLifecycle({
+    store,
+    sandbox: adapter,
+    // Idle auto-sleep is irrelevant to these tests; a no-op clock keeps
+    // machines awake until the test sleeps them explicitly.
+    clock: { setTimeout: () => 0, clearTimeout: () => undefined },
+  });
+  await store.records("vendo_apps").put({
+    id: doc.id,
+    data: { subject: "user_ada", enabled: false, doc },
+    refs: { subject: "user_ada" },
+  });
+  const audits: AuditEvent[] = [];
+  const engine = createScheduleEngine({
+    store,
+    lifecycle,
+    callFn: createFnCaller({ wake: (app) => lifecycle.wake(app) }).callFn,
+    audit: async (event) => { audits.push(event); },
+  });
+  return { store, state, lifecycle, engine, audits, doc };
+}
+
+const at = (iso: string): Date => new Date(iso);
+
+describe("createScheduleEngine (execution-v2 BYO schedule execution)", () => {
+  it("first tick syncs the manifest over the box door and fires nothing", async () => {
+    const { state, engine } = await setup();
+    const report = await engine.tick(at("2026-07-19T12:00:10.000Z"));
+    expect(report.fired).toEqual([]);
+    expect(report.errors).toEqual([]);
+    expect(report.checked).toBe(1);
+    expect(state.seen).toEqual([{ method: "GET", path: "/vendo.json" }]);
+  });
+
+  it("fires a due schedule exactly once and records last-fired state", async () => {
+    const { state, engine, store, audits } = await setup();
+    await engine.tick(at("2026-07-19T12:00:10.000Z"));
+    const report = await engine.tick(at("2026-07-19T12:01:30.000Z"));
+    expect(report.fired).toEqual([{
+      appId: "app_sched",
+      fn: "chase",
+      cron: "* * * * *",
+      scheduledFor: "2026-07-19T12:01:00.000Z",
+      status: "ok",
+    }]);
+    const fires = state.seen.filter((request) => request.path === "/fn/chase");
+    expect(fires).toEqual([{ method: "POST", path: "/fn/chase", body: JSON.stringify({ args: {} }) }]);
+
+    // The store carries the fired state for doctor and idempotency.
+    const record = await store.records(SCHEDULE_STATE_COLLECTION).get("app_sched");
+    expect(record?.data).toMatchObject({
+      schedules: [{ cron: "* * * * *", fn: "chase", lastFiredAt: "2026-07-19T12:01:00.000Z" }],
+    });
+    // The fire is audited as the app owner's away schedule execution.
+    expect(audits).toEqual([expect.objectContaining({
+      kind: "app-lifecycle",
+      principal: { kind: "user", subject: "user_ada" },
+      presence: "away",
+      appId: "app_sched",
+      detail: expect.objectContaining({ operation: "schedule-fire", fn: "chase" }),
+    })]);
+
+    // A second hit inside the same cron window is a no-op (double-hit safety).
+    const again = await engine.tick(at("2026-07-19T12:01:45.000Z"));
+    expect(again.fired).toEqual([]);
+    expect(state.seen.filter((request) => request.path === "/fn/chase")).toHaveLength(1);
+  });
+
+  it("collapses missed occurrences into one fire at the latest due time", async () => {
+    const { state, engine } = await setup();
+    await engine.tick(at("2026-07-19T12:00:10.000Z"));
+    const report = await engine.tick(at("2026-07-19T12:10:05.000Z"));
+    expect(report.fired).toEqual([expect.objectContaining({ scheduledFor: "2026-07-19T12:10:00.000Z" })]);
+    expect(state.seen.filter((request) => request.path === "/fn/chase")).toHaveLength(1);
+  });
+
+  it("never wakes a sleeping machine with no due schedule", async () => {
+    const { state, engine, lifecycle, doc } = await setup((request) =>
+      request.path === "/vendo.json" ? manifest([{ cron: "0 8 * * *", fn: "chase" }]) : fnOk);
+    await engine.tick(at("2026-07-19T12:00:10.000Z"));
+    const resumesAfterSync = state.resumes;
+    await lifecycle.sleep(doc);
+    const report = await engine.tick(at("2026-07-19T12:05:00.000Z"));
+    expect(report.fired).toEqual([]);
+    expect(state.resumes).toBe(resumesAfterSync);
+  });
+
+  it("caches an absent manifest (404) as no schedules", async () => {
+    const { state, engine, lifecycle, doc } = await setup(() => ({ status: 404 }));
+    const report = await engine.tick(at("2026-07-19T12:00:10.000Z"));
+    expect(report.errors).toEqual([]);
+    await lifecycle.sleep(doc);
+    await engine.tick(at("2026-07-19T12:10:00.000Z"));
+    expect(state.resumes).toBe(1);
+  });
+
+  it("reports an invalid manifest loudly and fires nothing", async () => {
+    const { engine } = await setup(() => ({ status: 200, body: JSON.stringify({ schedules: [{ cron: "not cron", fn: "x" }] }) }));
+    const report = await engine.tick(at("2026-07-19T12:00:10.000Z"));
+    expect(report.errors).toEqual([expect.objectContaining({ appId: "app_sched" })]);
+    expect(report.fired).toEqual([]);
+  });
+
+  it("records a failed fn fire as consumed (no retry storm) with error status", async () => {
+    const { state, engine } = await setup((request) => {
+      if (request.path === "/vendo.json") return manifest([{ cron: "* * * * *", fn: "chase" }]);
+      return { status: 500, body: "boom" };
+    });
+    await engine.tick(at("2026-07-19T12:00:10.000Z"));
+    const report = await engine.tick(at("2026-07-19T12:01:30.000Z"));
+    expect(report.fired).toEqual([expect.objectContaining({ status: "error" })]);
+    const again = await engine.tick(at("2026-07-19T12:01:50.000Z"));
+    expect(again.fired).toEqual([]);
+    expect(state.seen.filter((request) => request.path === "/fn/chase")).toHaveLength(1);
+  });
+
+  it("refreshes the manifest while the machine is awake, preserving last-fired state", async () => {
+    const { state, engine } = await setup();
+    await engine.tick(at("2026-07-19T12:00:10.000Z"));
+    await engine.tick(at("2026-07-19T12:01:30.000Z"));
+    // The box's manifest grows a second schedule while the machine is awake.
+    state.handler = (request) => {
+      if (request.path === "/vendo.json") {
+        return manifest([{ cron: "* * * * *", fn: "chase" }, { cron: "0 8 * * *", fn: "digest" }]);
+      }
+      return fnOk;
+    };
+    await engine.tick(at("2026-07-19T12:01:40.000Z"));
+    const status = await engine.report();
+    expect(status).toEqual([expect.objectContaining({
+      appId: "app_sched",
+      awake: true,
+      schedules: [
+        expect.objectContaining({ cron: "* * * * *", fn: "chase", lastFiredAt: "2026-07-19T12:01:00.000Z" }),
+        expect.objectContaining({ cron: "0 8 * * *", fn: "digest" }),
+      ],
+    })]);
+  });
+
+  it("skips apps without a machine and clears their stale schedule state", async () => {
+    const { engine, store } = await setup(defaultHandler, {
+      format: VENDO_APP_FORMAT,
+      id: "app_sched",
+      name: "De-graduated app",
+    });
+    await store.records(SCHEDULE_STATE_COLLECTION).put({
+      id: "app_sched",
+      data: { syncedAt: "2026-07-19T00:00:00.000Z", schedules: [{ cron: "* * * * *", fn: "chase" }] },
+    });
+    const report = await engine.tick(at("2026-07-19T12:00:10.000Z"));
+    expect(report.checked).toBe(0);
+    expect(report.fired).toEqual([]);
+    expect(await store.records(SCHEDULE_STATE_COLLECTION).get("app_sched")).toBeNull();
+  });
+
+  it("syncManifest is the Wave-3 hook: an explicit sync makes new schedules fireable", async () => {
+    const { engine, doc } = await setup();
+    await engine.syncManifest(doc, at("2026-07-19T12:00:10.000Z"));
+    const report = await engine.tick(at("2026-07-19T12:01:30.000Z"));
+    expect(report.fired).toEqual([expect.objectContaining({ fn: "chase" })]);
+  });
+
+  it("concurrent ticks coalesce to one run", async () => {
+    const { state, engine } = await setup();
+    await engine.tick(at("2026-07-19T12:00:10.000Z"));
+    const [first, second] = await Promise.all([
+      engine.tick(at("2026-07-19T12:01:30.000Z")),
+      engine.tick(at("2026-07-19T12:01:30.000Z")),
+    ]);
+    expect(first).toBe(second);
+    expect(state.seen.filter((request) => request.path === "/fn/chase")).toHaveLength(1);
+  });
+});

--- a/packages/apps/src/schedules.ts
+++ b/packages/apps/src/schedules.ts
@@ -1,0 +1,374 @@
+import {
+  VendoError,
+  type AppDocument,
+  type AppId,
+  type AuditEvent,
+  type Json,
+  type RunContext,
+  type StoreAdapter,
+  type ToolOutcome,
+} from "@vendoai/core";
+import { Cron } from "croner";
+import { z } from "zod";
+import type { MachineLifecycle } from "./machine-lifecycle.js";
+import { parseVendoManifest } from "./manifest.js";
+import { rowFromRecord } from "./persistence.js";
+
+/**
+ * execution-v2 Wave 2 Lane D — BYO schedule execution. Any external cron
+ * (Vercel cron, GitHub Actions, crontab — or later the Cloud broker calling
+ * the same surface) hits the host's authenticated tick; this engine reads each
+ * machine-bearing app's `vendo.json` schedule declarations (Lane C's parser)
+ * over the box door, computes due-ness against store-cached last-fired state,
+ * wakes ONLY due machines, POSTs their declared `/fn/<name>` targets as the
+ * app owner's away execution, and lets the normal idle policy put the box back
+ * to sleep.
+ *
+ * The store cache is what keeps sleeping machines asleep: due-ness never
+ * requires a wake. The accepted consequence is that a manifest edited while
+ * the machine sleeps is not seen until the machine is next awake — the engine
+ * re-reads `vendo.json` whenever the machine is awake at tick time (and on the
+ * first tick after graduation, which wakes once to learn the schedules), and
+ * {@link ScheduleEngine.syncManifest} is the explicit hook the Wave-3 in-box
+ * agent calls at edit-complete.
+ */
+
+export const SCHEDULE_STATE_COLLECTION = "vendo_app_schedules";
+
+/** Bounded catch-up: a schedule fires at most once per tick, at the LATEST
+ *  missed occurrence — a host that slept through a window never replays it. */
+const MAX_OCCURRENCE_SCAN = 10_000;
+/** Bounded CAS retries before an app's claim reports a conflict. */
+const CLAIM_ATTEMPTS = 3;
+
+const decoder = new TextDecoder();
+
+/** One declared schedule plus its execution state. `since` is the first time
+ *  the host learned of this (cron, fn) declaration — the fire baseline until a
+ *  first fire records `lastFiredAt` (schedules never back-fire history). */
+export interface ScheduleState {
+  cron: string;
+  fn: string;
+  since: string;
+  lastFiredAt?: string;
+  lastStatus?: "ok" | "error";
+}
+
+export interface AppScheduleState {
+  syncedAt: string;
+  schedules: ScheduleState[];
+}
+
+const scheduleStateSchema = z.object({
+  syncedAt: z.string(),
+  schedules: z.array(z.object({
+    cron: z.string(),
+    fn: z.string(),
+    since: z.string(),
+    lastFiredAt: z.string().optional(),
+    lastStatus: z.enum(["ok", "error"]).optional(),
+  })),
+});
+
+export interface ScheduleFire {
+  appId: AppId;
+  fn: string;
+  cron: string;
+  scheduledFor: string;
+  status: "ok" | "error";
+  message?: string;
+}
+
+export interface ScheduleTickReport {
+  /** Machine-bearing apps considered this tick. */
+  checked: number;
+  fired: ScheduleFire[];
+  errors: Array<{ appId: AppId; message: string }>;
+}
+
+/** The doctor's view of one machine-bearing app (reporting only). */
+export interface AppScheduleStatus {
+  appId: AppId;
+  name: string;
+  provisionedAt: string;
+  awake: boolean;
+  /** Undefined = the host has never read this box's vendo.json. */
+  syncedAt?: string;
+  schedules: ScheduleState[];
+}
+
+export interface ScheduleEngineConfig {
+  store: StoreAdapter;
+  lifecycle: MachineLifecycle;
+  /** The v2 fn door (fn.ts): POST /fn/<name> with outcome containment. */
+  callFn(app: AppDocument, name: string, args: Json, ctx: RunContext): Promise<ToolOutcome>;
+  /** Guard audit seam — every fire is reported as the owner's away execution. */
+  audit?(event: AuditEvent): Promise<void>;
+}
+
+export interface ScheduleEngine {
+  /**
+   * Fire every due schedule once. Idempotent within a cron window: last-fired
+   * state is claimed in the store BEFORE the fn POST, so a double-hit (two
+   * cron services, a retrying runner) cannot double-fire. In-process
+   * concurrent ticks coalesce onto the running one.
+   */
+  tick(at?: Date): Promise<ScheduleTickReport>;
+  /** Wake the box, read vendo.json, and cache its schedules (Wave-3 edit hook). */
+  syncManifest(app: AppDocument, at?: Date): Promise<AppScheduleState>;
+  /** Remove an app's cached schedule state (delete / de-graduation hygiene). */
+  clearForApp(appId: AppId): Promise<void>;
+  /** Doctor reporting: machine-bearing apps with schedules and last-fired times. */
+  report(): Promise<AppScheduleStatus[]>;
+}
+
+interface AppRow {
+  id: AppId;
+  subject: string;
+  doc: AppDocument;
+}
+
+/** The latest occurrence of `cron` after `baseline` and at or before `at`. */
+const latestDueOccurrence = (cron: string, baseline: string, at: Date): string | undefined => {
+  const job = new Cron(cron, { timezone: "UTC", paused: true });
+  let occurrence: Date | undefined;
+  let from = new Date(baseline);
+  for (let scanned = 0; scanned < MAX_OCCURRENCE_SCAN; scanned += 1) {
+    const next = job.nextRun(from);
+    if (next === null || next.getTime() > at.getTime()) break;
+    occurrence = next;
+    from = next;
+  }
+  return occurrence?.toISOString();
+};
+
+export const createScheduleEngine = (config: ScheduleEngineConfig): ScheduleEngine => {
+  const states = config.store.records(SCHEDULE_STATE_COLLECTION);
+  const apps = config.store.records("vendo_apps");
+  let running: Promise<ScheduleTickReport> | undefined;
+
+  const machineRows = async (): Promise<AppRow[]> => {
+    const machineBearing: AppRow[] = [];
+    let cursor: string | undefined;
+    do {
+      const page = await apps.list(cursor === undefined ? {} : { cursor });
+      for (const record of page.records) {
+        let row;
+        try {
+          row = rowFromRecord(record);
+        } catch {
+          continue; // Corrupt rows cannot schedule, and must not break the tick.
+        }
+        if (row.doc.machine === undefined) continue;
+        machineBearing.push({ id: record.id, subject: row.subject, doc: row.doc });
+      }
+      cursor = page.cursor;
+    } while (cursor !== undefined);
+    return machineBearing;
+  };
+
+  /** State rows whose app lost its machine (or is gone) are ghost schedules —
+   *  swept by listing the (small) state collection, never by probing every
+   *  layer-1 app row. */
+  const sweepStaleStates = async (machineBearing: ReadonlySet<AppId>): Promise<void> => {
+    let cursor: string | undefined;
+    const stale: AppId[] = [];
+    do {
+      const page = await states.list(cursor === undefined ? {} : { cursor });
+      for (const record of page.records) {
+        if (!machineBearing.has(record.id)) stale.push(record.id);
+      }
+      cursor = page.cursor;
+    } while (cursor !== undefined);
+    for (const appId of stale) await states.delete(appId).catch(() => undefined);
+  };
+
+  const readState = async (appId: AppId): Promise<AppScheduleState | null> => {
+    const record = await states.get(appId);
+    if (record === null) return null;
+    const parsed = scheduleStateSchema.safeParse(record.data);
+    // Corrupt state re-syncs from the box rather than wedging the tick.
+    return parsed.success ? parsed.data : null;
+  };
+
+  const writeState = async (appId: AppId, state: AppScheduleState): Promise<void> => {
+    await states.put({ id: appId, data: state as unknown as Json });
+  };
+
+  const syncManifest = async (app: AppDocument, at = new Date()): Promise<AppScheduleState> => {
+    const machine = await config.lifecycle.wake(app);
+    const answer = await machine.request({ method: "GET", path: "/vendo.json" });
+    let declared: Array<{ cron: string; fn: string }>;
+    if (answer.status === 404) {
+      // No manifest is a valid box: it just declares no schedules.
+      declared = [];
+    } else if (answer.status >= 200 && answer.status < 300) {
+      declared = parseVendoManifest(decoder.decode(answer.body)).schedules ?? [];
+    } else {
+      throw new VendoError("validation", `vendo.json read failed (${answer.status})`, { appId: app.id });
+    }
+    const previous = await readState(app.id);
+    const carried = new Map((previous?.schedules ?? []).map((schedule) => [`${schedule.cron}\n${schedule.fn}`, schedule]));
+    const state: AppScheduleState = {
+      syncedAt: at.toISOString(),
+      schedules: declared.map(({ cron, fn }) => {
+        const kept = carried.get(`${cron}\n${fn}`);
+        return kept === undefined ? { cron, fn, since: at.toISOString() } : { ...kept };
+      }),
+    };
+    await writeState(app.id, state);
+    return state;
+  };
+
+  /** Claim the due occurrences in the store BEFORE firing (at-most-once): a
+   *  racer re-reads and finds nothing due. CAS when the store supports it;
+   *  read-then-put otherwise (the lifecycle's own degradation posture). */
+  const claimDue = async (
+    appId: AppId,
+    at: Date,
+  ): Promise<{ state: AppScheduleState; due: Array<{ cron: string; fn: string; scheduledFor: string }> } | { conflict: true } | null> => {
+    for (let attempt = 0; attempt < CLAIM_ATTEMPTS; attempt += 1) {
+      const record = await states.get(appId);
+      if (record === null) return null;
+      const parsed = scheduleStateSchema.safeParse(record.data);
+      if (!parsed.success) return null;
+      const state = parsed.data;
+      const due: Array<{ cron: string; fn: string; scheduledFor: string }> = [];
+      const next: AppScheduleState = {
+        ...state,
+        schedules: state.schedules.map((schedule) => {
+          const scheduledFor = latestDueOccurrence(schedule.cron, schedule.lastFiredAt ?? schedule.since, at);
+          if (scheduledFor === undefined) return schedule;
+          due.push({ cron: schedule.cron, fn: schedule.fn, scheduledFor });
+          return { ...schedule, lastFiredAt: scheduledFor };
+        }),
+      };
+      if (due.length === 0) return { state, due };
+      const input = { id: appId, data: next as unknown as Json };
+      if (states.atomic === undefined || record.revision === undefined) {
+        await states.put(input);
+        return { state: next, due };
+      }
+      const swapped = await states.atomic.compareAndSwap(input, record.revision);
+      if (swapped !== null) return { state: next, due };
+    }
+    return { conflict: true };
+  };
+
+  const recordOutcome = async (appId: AppId, fn: string, cron: string, status: "ok" | "error"): Promise<void> => {
+    // Best-effort doctor detail; the claim already made the fire durable.
+    const state = await readState(appId);
+    if (state === null) return;
+    await writeState(appId, {
+      ...state,
+      schedules: state.schedules.map((schedule) =>
+        schedule.cron === cron && schedule.fn === fn ? { ...schedule, lastStatus: status } : schedule),
+    }).catch(() => undefined);
+  };
+
+  const fireApp = async (row: AppRow, at: Date, report: ScheduleTickReport): Promise<void> => {
+    let state = await readState(row.id);
+    if (state === null) {
+      // First tick after graduation: wake once to learn the schedules. Nothing
+      // can be due yet — declarations only fire forward from their sync.
+      state = await syncManifest(row.doc, at);
+      return;
+    }
+    if (config.lifecycle.peek(row.id) !== undefined) {
+      // The box is awake anyway — re-read vendo.json so schedule edits made
+      // inside the box (agent sessions, layer-3 apps) are picked up.
+      try {
+        state = await syncManifest(row.doc, at);
+      } catch (error) {
+        report.errors.push({ appId: row.id, message: error instanceof Error ? error.message : "manifest refresh failed" });
+      }
+    }
+    const claimed = await claimDue(row.id, at);
+    if (claimed === null) return;
+    if ("conflict" in claimed) {
+      report.errors.push({ appId: row.id, message: "schedule state was concurrently modified" });
+      return;
+    }
+    for (const { cron, fn, scheduledFor } of claimed.due) {
+      // The app's owner, away, in the app venue — the same authority a tree
+      // action carries when the owner isn't looking; box callbacks during the
+      // run ride the app token through the existing guard seams.
+      const ctx: RunContext = {
+        principal: { kind: "user", subject: row.subject },
+        venue: "app",
+        presence: "away",
+        sessionId: `schedule_${row.id}`,
+        appId: row.id,
+      };
+      const outcome = await config.callFn(row.doc, fn, {}, ctx);
+      const status = outcome.status === "ok" ? "ok" : "error";
+      report.fired.push({
+        appId: row.id,
+        fn,
+        cron,
+        scheduledFor,
+        status,
+        ...(outcome.status === "error" ? { message: outcome.error.message } : {}),
+      });
+      await recordOutcome(row.id, fn, cron, status);
+      await config.audit?.({
+        id: `aud_${globalThis.crypto.randomUUID()}`,
+        at: new Date().toISOString(),
+        kind: "app-lifecycle",
+        principal: { kind: "user", subject: row.subject },
+        venue: "app",
+        presence: "away",
+        appId: row.id,
+        outcome: outcome.status,
+        detail: { operation: "schedule-fire", fn, cron, scheduledFor },
+      });
+    }
+  };
+
+  const runTick = async (at: Date): Promise<ScheduleTickReport> => {
+    const report: ScheduleTickReport = { checked: 0, fired: [], errors: [] };
+    const machineBearing = await machineRows();
+    await sweepStaleStates(new Set(machineBearing.map((row) => row.id)));
+    for (const row of machineBearing) {
+      report.checked += 1;
+      try {
+        await fireApp(row, at, report);
+      } catch (error) {
+        report.errors.push({ appId: row.id, message: error instanceof Error ? error.message : "schedule tick failed" });
+      }
+    }
+    return report;
+  };
+
+  return {
+    tick(at = new Date()) {
+      const inflight = running;
+      if (inflight !== undefined) return inflight;
+      const run = runTick(at).finally(() => {
+        running = undefined;
+      });
+      running = run;
+      return run;
+    },
+    syncManifest,
+    async clearForApp(appId) {
+      await states.delete(appId).catch(() => undefined);
+    },
+    async report() {
+      const machineBearing = await machineRows();
+      const statuses: AppScheduleStatus[] = [];
+      for (const row of machineBearing) {
+        const state = await readState(row.id);
+        statuses.push({
+          appId: row.id,
+          name: row.doc.name,
+          provisionedAt: row.doc.machine?.provisionedAt ?? "",
+          awake: config.lifecycle.peek(row.id) !== undefined,
+          ...(state === null ? {} : { syncedAt: state.syncedAt }),
+          schedules: state?.schedules ?? [],
+        });
+      }
+      return statuses;
+    },
+  };
+};

--- a/packages/core/src/app-document.test.ts
+++ b/packages/core/src/app-document.test.ts
@@ -312,13 +312,18 @@ describe("validateAppDocument with vendo-genui/v2 trees", () => {
     expectValidation({ ...v2Minimal(), components: { "not-pascal": "x" } });
   });
 
-  it("requires a server for fn: v2 query tools and prop actions", () => {
+  it("requires a machine (or legacy server) for fn: v2 query tools and prop actions", () => {
     const withQuery = {
       ...v2Minimal(),
       tree: { ...v2Minimal().tree, queries: [{ name: "load", tool: "fn:load" }] },
     };
-    expectValidationMessage(withQuery, "fn: references require an app server");
+    expectValidationMessage(withQuery, "fn: references require a machine (or legacy app server)");
     expect(validateAppDocument({ ...withQuery, server: "e2b:snap_ok" }).ok).toBe(true);
+    // execution-v2: the v2 machine satisfies the presence rule the same way.
+    expect(validateAppDocument({
+      ...withQuery,
+      machine: { snapshotRef: "e2b:v2:snap_ok", provisionedAt: "2026-07-19T00:00:00.000Z" },
+    }).ok).toBe(true);
     expectValidationMessage(
       {
         ...v2Minimal(),
@@ -327,7 +332,7 @@ describe("validateAppDocument with vendo-genui/v2 trees", () => {
           nodes: [{ id: "root", component: "Button", props: { nested: [{ action: "fn:click" }] } }],
         },
       },
-      "fn: references require an app server",
+      "fn: references require a machine (or legacy app server)",
     );
   });
 

--- a/packages/core/src/app-document.ts
+++ b/packages/core/src/app-document.ts
@@ -190,8 +190,11 @@ const validateAppDocumentUnsafe = (input: unknown): AppDocumentValidation => {
       return fail("validation", `invalid fn: reference "${reference}"`);
     }
   }
-  if (fnReferences.length > 0 && app.server === undefined) {
-    return fail("validation", "fn: references require an app server");
+  // execution-v2 machine-presence rule: an fn: ref is only meaningful when the
+  // document carries a box to answer it — the v2 `machine` (Lane B), or the
+  // dying v1 `server` snapshot until its execution path is fully removed.
+  if (fnReferences.length > 0 && app.server === undefined && app.machine === undefined) {
+    return fail("validation", "fn: references require a machine (or legacy app server)");
   }
 
   for (const [name, declaration] of Object.entries(app.storage ?? {})) {

--- a/packages/vendo/src/cli/doctor-codes.test.ts
+++ b/packages/vendo/src/cli/doctor-codes.test.ts
@@ -42,6 +42,7 @@ describe("doctor error-code registry", () => {
         "E-MCP-006": "server.json is invalid JSON",
         "E-MCP-007": "the local MCP registry auth challenge is malformed",
         "E-MCP-008": "the live MCP registry auth challenge is malformed",
+        "E-SCHED-001": "apps declare vendo.json schedules but no schedule caller is configured",
         "E-TURN-001": "the live model turn did not answer",
         "E-TURN-002": "the live model turn cannot run while the dev server is down",
         "E-UI-001": "an ejected surface predates the installed @vendoai/ui",

--- a/packages/vendo/src/cli/doctor-codes.ts
+++ b/packages/vendo/src/cli/doctor-codes.ts
@@ -43,6 +43,7 @@ export const DOCTOR_ERROR_CODES = {
   "E-MCP-006": "server.json is invalid JSON",
   "E-MCP-007": "the local MCP registry auth challenge is malformed",
   "E-MCP-008": "the live MCP registry auth challenge is malformed",
+  "E-SCHED-001": "apps declare vendo.json schedules but no schedule caller is configured",
   "E-TURN-001": "the live model turn did not answer",
   "E-TURN-002": "the live model turn cannot run while the dev server is down",
   "E-CLOUD-001": "VENDO_API_KEY is set but not usable",

--- a/packages/vendo/src/cli/doctor.test.ts
+++ b/packages/vendo/src/cli/doctor.test.ts
@@ -98,6 +98,9 @@ function successfulProbeFetch(
     }
     if (url.endsWith("/doctor/present")) return Response.json({ ok: true });
     if (url.endsWith("/doctor/act-as")) return Response.json({ ok: true });
+    if (url.endsWith("/doctor/machines")) {
+      return Response.json({ scheduleCallerConfigured: false, machines: [] });
+    }
     return Response.json({ error: { message: "unexpected probe" } }, { status: 404 });
   });
 }
@@ -216,10 +219,69 @@ describe("vendo doctor", () => {
       output: { log() {}, error() {} },
       telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
     })).toBe(0);
-    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
     expect(fetchImpl.mock.calls[0]?.[0]).toBe("http://localhost:3000/api/vendo/status");
     expect(fetchImpl.mock.calls[1]?.[0]).toBe("http://localhost:3000/api/vendo/doctor/present");
     expect(fetchImpl.mock.calls[2]?.[0]).toBe("http://localhost:3000/api/vendo/doctor/act-as");
+    expect(fetchImpl.mock.calls[3]?.[0]).toBe("http://localhost:3000/api/vendo/doctor/machines");
+  });
+
+  // execution-v2 Lane D — machine/schedule reporting (dev-only wire surface).
+  it("reports machine-bearing apps and warns when schedules have no caller", async () => {
+    const fetchImpl = successfulProbeFetch();
+    fetchImpl.mockImplementation(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.endsWith("/status")) {
+        return Response.json({ posture: "unconfigured", version: "0.3.0", blocks: { store: true, sandbox: "e2b" } });
+      }
+      if (url.endsWith("/doctor/present") || url.endsWith("/doctor/act-as")) return Response.json({ ok: true });
+      if (url.endsWith("/doctor/machines")) {
+        return Response.json({
+          scheduleCallerConfigured: false,
+          machines: [{
+            appId: "app_cron",
+            name: "Cron app",
+            awake: false,
+            schedules: [{ cron: "0 8 * * *", fn: "chase", lastFiredAt: "2026-07-19T08:00:00.000Z" }],
+          }],
+        });
+      }
+      return Response.json({ error: { message: "unexpected probe" } }, { status: 404 });
+    });
+    const messages = output();
+    expect(await doctor({
+      targetDir: await healthy(),
+      fetchImpl,
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0); // reporting only — a missing caller warns, never fails
+    expect(messages.logs).toContain("ok: 1 machine-bearing app");
+    expect(messages.logs.join("\n")).toContain("0 8 * * * -> POST /fn/chase — last fired 2026-07-19T08:00:00.000Z");
+    expect(messages.errors.join("\n")).toContain("set VENDO_TICK_SECRET");
+  });
+
+  it("passes the schedule-caller check when the tick secret is configured", async () => {
+    const fetchImpl = successfulProbeFetch();
+    fetchImpl.mockImplementation(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.endsWith("/status")) {
+        return Response.json({ posture: "unconfigured", version: "0.3.0", blocks: { store: true, sandbox: "e2b" } });
+      }
+      if (url.endsWith("/doctor/present") || url.endsWith("/doctor/act-as")) return Response.json({ ok: true });
+      if (url.endsWith("/doctor/machines")) {
+        return Response.json({ scheduleCallerConfigured: true, machines: [{ appId: "app_cron", name: "Cron app", awake: true, schedules: [] }] });
+      }
+      return Response.json({ error: { message: "unexpected probe" } }, { status: 404 });
+    });
+    const messages = output();
+    expect(await doctor({
+      targetDir: await healthy(),
+      fetchImpl,
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0);
+    expect(messages.errors).toEqual([]);
+    expect(messages.logs.join("\n")).toContain("schedule caller configured");
   });
 
   it.each(["e2b", "cloud", "custom"] as const)("reports a lit %s execution venue", async (sandbox) => {

--- a/packages/vendo/src/cli/doctor.ts
+++ b/packages/vendo/src/cli/doctor.ts
@@ -367,6 +367,51 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
     }
   }
 
+  // execution-v2 Lane D — machine + schedule REPORTING (no new subcommand):
+  // which apps carry a machine, whether a schedule caller is configured for
+  // the authenticated /tick surface, and each schedule's last-fired time.
+  // /doctor/machines is a dev-only route, so an unreachable or older host
+  // simply skips the section (reporting must never break doctor).
+  if (liveComposition) {
+    try {
+      const response = await fetchImpl(`${statusUrl}/doctor/machines`, { headers: { accept: "application/json" } });
+      if (response.ok) {
+        const body = await response.json() as {
+          scheduleCallerConfigured?: unknown;
+          machines?: Array<{
+            appId?: string;
+            name?: string;
+            awake?: boolean;
+            schedules?: Array<{ cron?: string; fn?: string; lastFiredAt?: string; lastStatus?: string }>;
+          }>;
+        };
+        const machines = Array.isArray(body.machines) ? body.machines : [];
+        pass("machines/apps", machines.length === 0
+          ? "no machine-bearing apps"
+          : `${machines.length} machine-bearing app${machines.length === 1 ? "" : "s"}`);
+        for (const machine of machines) {
+          note(`  ${machine.appId ?? "?"} (${machine.name ?? "unnamed"}): ${machine.awake === true ? "awake" : "asleep"}`);
+          for (const schedule of machine.schedules ?? []) {
+            const lastFired = schedule.lastFiredAt === undefined
+              ? "never fired"
+              : `last fired ${schedule.lastFiredAt}${schedule.lastStatus === "error" ? " (error)" : ""}`;
+            note(`    ${schedule.cron ?? "?"} -> POST /fn/${schedule.fn ?? "?"} — ${lastFired}`);
+          }
+        }
+        const declaresSchedules = machines.some((machine) => (machine.schedules?.length ?? 0) > 0);
+        if (body.scheduleCallerConfigured === true) {
+          pass("machines/schedule-caller", "schedule caller configured (VENDO_TICK_SECRET); point an external cron at POST /tick");
+        } else if (declaresSchedules) {
+          warn("machines/schedule-caller", "E-SCHED-001", "apps declare vendo.json schedules but no schedule caller is configured — set VENDO_TICK_SECRET and point an external cron (Vercel cron, GitHub Actions, crontab) at POST /api/vendo/tick");
+        } else if (machines.length > 0) {
+          note("  no schedule caller configured (VENDO_TICK_SECRET unset) — needed once an app declares vendo.json schedules");
+        }
+      }
+    } catch {
+      // Reporting only — an unreachable machines route never fails doctor.
+    }
+  }
+
   note("Ladder: execution venue is checked above; actAs for away host actions; connectors for external tools.");
 
   // One real model turn through the wired route (design §5). Exit 0 == a user

--- a/packages/vendo/src/schedule-wire.test.ts
+++ b/packages/vendo/src/schedule-wire.test.ts
@@ -1,0 +1,185 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  VENDO_APP_FORMAT,
+  type AppDocument,
+  type Principal,
+} from "@vendoai/core";
+import { SCHEDULE_STATE_COLLECTION, type SandboxAdapter, type SandboxMachine } from "@vendoai/apps";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createVendo, type Vendo } from "./server.js";
+
+/**
+ * execution-v2 Lane D gate (wire level): an external-cron hit on the
+ * authenticated POST /tick fires a due vendo.json schedule exactly once — a
+ * second hit inside the same cron window is a no-op — the box received the
+ * fn POST, the store records last-fired, and GET /doctor/machines reports it.
+ *
+ * Time is faked Date-only (timers stay real) so the cron window is
+ * deterministic; the schedule engine reads the clock through `new Date()`.
+ */
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+async function tempStore(prefix: string): Promise<VendoStore> {
+  const dataDir = await mkdtemp(join(tmpdir(), prefix));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.ensureSchema().catch(() => undefined);
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return store;
+}
+
+const ADA: Principal = { kind: "user", subject: "user_ada" };
+const TICK_SECRET = "tick-secret-for-tests";
+
+const encoder = new TextEncoder();
+
+const doc: AppDocument = {
+  format: VENDO_APP_FORMAT,
+  id: "app_cron",
+  name: "Cron app",
+};
+
+/** A box declaring one every-minute schedule, counting its fn fires. */
+function cronBox() {
+  const fires: string[] = [];
+  const machine: SandboxMachine = {
+    id: "fake_cron_box",
+    async request(request) {
+      const respond = (status: number, payload: unknown) => ({
+        status,
+        headers: { "content-type": "application/json" },
+        body: encoder.encode(JSON.stringify(payload)),
+      });
+      if (request.method === "GET" && request.path === "/vendo.json") {
+        return respond(200, { schedules: [{ cron: "* * * * *", fn: "chase" }] });
+      }
+      if (request.method === "POST" && request.path === "/fn/chase") {
+        fires.push(new Date().toISOString());
+        return respond(200, { result: { chased: true } });
+      }
+      return { status: 404, headers: {}, body: new Uint8Array() };
+    },
+    async snapshot() { return "fake:cron-snap"; },
+    async stop() { /* sleep */ },
+    async destroy() { /* gone */ },
+  };
+  const adapter: SandboxAdapter = {
+    async create() { return machine; },
+    async resume() { return machine; },
+    async destroy() { /* released */ },
+  };
+  return { adapter, fires };
+}
+
+async function setup(): Promise<{ vendo: Vendo; store: VendoStore; fires: string[] }> {
+  vi.stubEnv("VENDO_BASE_URL", "http://wire.test");
+  vi.stubEnv("VENDO_TICK_SECRET", TICK_SECRET);
+  const store = await tempStore("vendo-schedule-wire-");
+  await store.ensureSchema();
+  await store.records("vendo_apps").put({
+    id: doc.id,
+    data: { subject: ADA.subject, enabled: false, doc },
+    refs: { subject: ADA.subject },
+  });
+  const { adapter, fires } = cronBox();
+  const vendo = createVendo({
+    model: {} as LanguageModel,
+    principal: async (req) => {
+      const subject = req.headers.get("x-test-user");
+      return subject === null ? null : { kind: "user", subject };
+    },
+    store,
+    sandbox: adapter,
+  });
+  await vendo.apps.machine.provision(doc.id, {
+    principal: ADA,
+    venue: "app",
+    presence: "present",
+    sessionId: "session_schedule_wire",
+  });
+  return { vendo, store, fires };
+}
+
+const tick = (vendo: Vendo, authorization?: string): Promise<Response> =>
+  vendo.handler(new Request("http://wire.test/api/vendo/tick", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(authorization === undefined ? {} : { authorization }),
+    },
+    body: "{}",
+  }));
+
+describe("POST /tick fires vendo.json schedules (execution-v2 Lane D gate)", () => {
+  it("rejects a caller without the host-configured token", async () => {
+    const { vendo } = await setup();
+    expect((await tick(vendo)).status).toBe(401);
+    expect((await tick(vendo, "Bearer wrong")).status).toBe(401);
+  });
+
+  it("fires a due schedule exactly once across double-hits, records last-fired, and reports via doctor", async () => {
+    const { vendo, store, fires } = await setup();
+    vi.useFakeTimers({ toFake: ["Date"], now: new Date("2026-07-19T12:00:10.000Z") });
+
+    // First hit learns the box's schedules (wakes once to read vendo.json);
+    // declarations only fire forward from their sync.
+    const first = await tick(vendo, `Bearer ${TICK_SECRET}`);
+    expect(first.status).toBe(200);
+    expect(await first.json()).toMatchObject({
+      runIds: [],
+      schedules: { checked: 1, fired: [], errors: [] },
+    });
+
+    // Next cron window: the schedule is due — the box gets exactly one POST.
+    vi.setSystemTime(new Date("2026-07-19T12:01:30.000Z"));
+    const second = await tick(vendo, `Bearer ${TICK_SECRET}`);
+    expect(await second.json()).toMatchObject({
+      schedules: {
+        fired: [{
+          appId: "app_cron",
+          fn: "chase",
+          cron: "* * * * *",
+          scheduledFor: "2026-07-19T12:01:00.000Z",
+          status: "ok",
+        }],
+      },
+    });
+    expect(fires).toHaveLength(1);
+
+    // Double-hit inside the same window: a no-op, not a double-fire.
+    vi.setSystemTime(new Date("2026-07-19T12:01:45.000Z"));
+    const third = await tick(vendo, `Bearer ${TICK_SECRET}`);
+    expect(await third.json()).toMatchObject({ schedules: { fired: [] } });
+    expect(fires).toHaveLength(1);
+
+    // The store carries the last-fired state...
+    const record = await store.records(SCHEDULE_STATE_COLLECTION).get("app_cron");
+    expect(record?.data).toMatchObject({
+      schedules: [{ cron: "* * * * *", fn: "chase", lastFiredAt: "2026-07-19T12:01:00.000Z", lastStatus: "ok" }],
+    });
+
+    // ...and the doctor surface reports machine, schedule caller, last-fired.
+    const machines = await vendo.handler(new Request("http://wire.test/api/vendo/doctor/machines"));
+    expect(machines.status).toBe(200);
+    expect(await machines.json()).toMatchObject({
+      scheduleCallerConfigured: true,
+      machines: [{
+        appId: "app_cron",
+        awake: true,
+        schedules: [{ cron: "* * * * *", fn: "chase", lastFiredAt: "2026-07-19T12:01:00.000Z" }],
+      }],
+    });
+  });
+});

--- a/packages/vendo/src/wire/doctor.ts
+++ b/packages/vendo/src/wire/doctor.ts
@@ -64,6 +64,16 @@ export const doctorRoutes: RouteEntry[] = [
     }
     return undefined;
   }),
+  // execution-v2 Lane D — dev-only machine/schedule reporting (sits AFTER the
+  // production gate above, like every probe route). Reporting only: which apps
+  // carry a machine, whether a schedule caller (VENDO_TICK_SECRET) is
+  // configured for the /tick surface, and each schedule's last-fired state.
+  route("GET", "/doctor/machines", async ({ deps }) => {
+    return json({
+      scheduleCallerConfigured: environment("VENDO_TICK_SECRET") !== undefined,
+      machines: await deps.apps.schedules.report(),
+    });
+  }),
   route("GET", "/doctor/present/echo", async ({ request }) => {
     return json({
       ok: request.headers.get("authorization") === DOCTOR_PRESENT_AUTHORIZATION

--- a/packages/vendo/src/wire/misc.ts
+++ b/packages/vendo/src/wire/misc.ts
@@ -117,7 +117,14 @@ export const systemRoutes: RouteEntry[] = [
     if (!await tickAuthorized(request)) {
       return json({ error: { code: "blocked", message: "invalid tick credential" } }, 401);
     }
-    return json({ runIds: await deps.automations.tick() });
+    // execution-v2 Lane D — one authenticated tick drives BOTH schedulers: the
+    // automations engine and the machine-app vendo.json schedules (additive
+    // `schedules` field). Point any external cron here (Vercel cron, GitHub
+    // Actions, crontab); the Cloud broker calls this same surface.
+    return json({
+      runIds: await deps.automations.tick(),
+      schedules: await deps.apps.schedules.tick(),
+    });
   }),
   route("POST", "/sync/impact", async ({ request, deps }) => {
     if (environment("NODE_ENV") === "production") {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -746,6 +746,9 @@ importers:
       '@vendoai/core':
         specifier: workspace:*
         version: link:../core
+      croner:
+        specifier: ^9.0.0
+        version: 9.1.0
       esbuild:
         specifier: ^0.25.0
         version: 0.25.12


### PR DESCRIPTION
## execution v2 lane D: fn runtime resolution + schedule execution

Wave 2 Lane D of the machine model (`docs/superpowers/specs/2026-07-19-execution-v2-design.md`, plan Wave 2 Lane D). Builds on Lane A's seam (#393/#398), Lane B's lifecycle (#390), and Lane C's skin contract (#394). Wire grammar untouched (fn: grammar already existed in wire-v2).

### 1. fn: runtime resolution over the box door (`packages/apps/src/fn.ts`, NEW module)

- A v2 tree whose **query** names `fn:<name>` resolves through the box door at `open()`; an **action** `fn:` ref resolves on interaction via `call()`. Both ride Lane B's `lifecycle.wake` + `POST /fn/<name>` — the exact door Lane C's wire proxy (`POST /apps/:id/fn/:name`) speaks. The host ToolRegistry never sees an fn: ref; no host credentials cross the skin (content-type only, like the proxy).
- Envelope: request `{"args": ...}`, success `{result}` → `{status:"ok", output}` (binds exactly like a tool result — shape-aware binding unchanged), failure `{error:{code,message}}` relays as-is. A `ui` member is rejected: **the machine never draws in v2**.
- Containment: a failed fn (box error, invalid envelope, wake failure, missing adapter) is a contained error **outcome** — the query slot stays unbound, the rest of the app renders; never a thrown white box.
- Per the orchestrator ruling, this is a NEW module wired as a decorator around the existing `AppCaller` (one construction line in runtime.ts). `call.ts` is untouched — the Wave-1.5 cleanup lane owns deleting its v1 path; after that merge the typed-throw there can dispatch into this module (rebase note below).
- **Machine-presence rule amended** (`core/app-document.ts`): fn: refs at rest now accept the v2 `machine` field beside the dying v1 `server` field (previously a v2 machine-bearing app with an fn: query failed document validation).

### 2. Schedule execution surface (`packages/apps/src/schedules.ts`, NEW + `/tick` extension)

- **Endpoint = the existing authenticated `POST /tick`** (`VENDO_TICK_SECRET` bearer, timing-safe compare — the surface already documented for external cron). One tick now drives both schedulers; the response gains an additive `schedules` field. Vercel cron / GitHub Actions / crontab / the future Cloud broker all call this same surface.
- The engine reads each machine-bearing app's `vendo.json` over the box door (`GET /vendo.json`; 404 = no schedules; invalid manifest = loud per-app error via Lane C's `parseVendoManifest`), caches declarations + last-fired state in a new store collection (`vendo_app_schedules`), and computes due-ness from the cache — **a tick never wakes a machine with nothing due**.
- Firing: due occurrences are **claimed in the store before the POST** (CAS where the store supports it), so a double-hit within a cron window is a no-op, never a double-fire. Missed windows collapse to one fire at the latest due occurrence (no back-fill, matching automations). Fires run as the app owner's away execution (`presence:"away"`, `sessionId schedule_<appId>`), audited as `app-lifecycle`/`schedule-fire`; box callbacks during the run ride the existing app-token guard seams unchanged.
- Manifest freshness: re-read whenever the machine is awake at tick time + once on the first tick after graduation. Accepted consequence (per orchestrator): a manifest edited while asleep is seen at the next wake. `runtime.schedules.sync(appId, ctx)` / `ScheduleEngine.syncManifest(app)` is exported as the Wave-3 in-box agent's edit-complete hook.
- Hygiene: app delete and machine destroy clear the cached schedule state; the tick sweeps ghost state rows.

### 3. Doctor reporting (no new subcommands)

- Dev-gated wire route `GET /doctor/machines` (behind the existing production prefix gate): machine-bearing apps, whether a schedule caller is configured (`VENDO_TICK_SECRET`), per-schedule last-fired times.
- `vendo doctor` gains a reporting section from it: pass/warn only — `E-SCHED-001` (new registry code + `verify.mdx` anchor) warns when apps declare schedules but no caller is configured. Unreachable/older hosts skip the section; reporting never fails doctor.

### Gate (fake adapter, all green)

- `packages/apps/src/fn-runtime.e2e.test.ts`: (a) fn: query binds its data through the box door at `open()` beside a host-tool query; (b) fn: action round-trips on `call()` and a re-open re-binds the changed data; failed fn = contained outcome; missing adapter = contained per query.
- `packages/vendo/src/schedule-wire.test.ts`: cron endpoint hit fires a due schedule exactly once (second hit in the window = no-op), the box received the POST, the store shows last-fired, `/doctor/machines` reports it; unauthenticated hit = 401.
- Unit: `fn.test.ts` (9), `schedules.test.ts` (11), doctor CLI section tests.
- Root gates: `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green.

### Rebase note for the Wave-1.5 cleanup lane

When cleanup's call.ts ruling lands (fn: → typed VendoError), replace that throw with a one-line dispatch into `fn.ts`'s caller — the decorator here already intercepts fn: for machine-bearing apps ahead of the inner caller, so ordering is safe either way.

### Docs

`docs-site/deploy/scheduler-and-webhooks.mdx` (machine app schedules section), `docs/persistence-and-deploy.md` (tick note), `docs-site/agents/verify.mdx` (E-SCHED-001).

Scope discipline: no egress/secrets (Lane E), no agent-in-box (Wave 3), wire fn: grammar untouched.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds execution v2 Lane D: resolve `fn:` calls over the machine door and add schedule execution for machine apps, driven by the authenticated `POST /api/vendo/tick`. This also extends doctor reporting and updates validation to accept `machine` for `fn:` refs.

- **New Features**
  - `fn:` runtime resolution: v2 trees call `POST /fn/<name>` via lifecycle wake; `{args}` in, `{result}` out; `{error}` relayed; UI envelopes are rejected. Failures are contained outcomes, not thrown.
  - Schedule execution: reads `vendo.json` from the box, caches in `vendo_app_schedules`, computes due without waking idle boxes, and claims before firing for idempotency. Fires as the owner’s away execution; missed windows collapse to one fire.
  - `POST /api/vendo/tick`: now drives automations and machine app schedules; response adds a `schedules` report.
  - Doctor: dev route `GET /doctor/machines` and CLI report of machine apps, schedule-caller status, and last-fired; warns with E-SCHED-001 if schedules exist but no caller.
  - Validation: `fn:` refs now accept `machine` (beside legacy `server`).
  - Exports: `createFnCaller` and `createScheduleEngine` from `@vendoai/apps`.
  - Docs: scheduler setup, tick notes, and doctor guidance.
  - Tests: fn runtime e2e, schedule engine/unit, wire-level tick/doctor.

- **Dependencies**
  - Added `croner` for cron evaluation.

<sup>Written for commit 76b7d388fc5df35cd5c5d026fcac2fd411985c36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

