### PR TITLE
docs: embed snippet resilience (post-merge triage of #409 review findings)

### DIFF
--- a/docs-site/snippets/vendo-embed.jsx
+++ b/docs-site/snippets/vendo-embed.jsx
@@ -26,29 +26,32 @@ export const VendoEmbed = ({ surface, poster, alt, height = 480, caption }) => {
       }
     };
 
+    const onReady = () => mount();
+    const onError = () => { if (!cancelled) setFailed(true); };
     if (window.VendoDocsEmbed) {
       mount();
     } else {
-      const existing = document.querySelector('script[data-vendo-docs-embed]');
-      const script = existing ?? document.createElement("script");
-      const onReady = () => mount();
       window.addEventListener("vendo-docs-embed-ready", onReady, { once: true });
+      // Every instance hears a shared load failure, not just the tag creator.
+      window.addEventListener("vendo-docs-embed-error", onError, { once: true });
+      const existing = document.querySelector('script[data-vendo-docs-embed]');
       if (!existing) {
+        const script = document.createElement("script");
         script.src = "https://vendo.run/playground/embed.js";
         script.async = true;
         script.dataset.vendoDocsEmbed = "";
-        script.onerror = () => { if (!cancelled) setFailed(true); };
+        script.onerror = () => window.dispatchEvent(new Event("vendo-docs-embed-error"));
         document.head.appendChild(script);
       }
-      return () => {
-        cancelled = true;
-        window.removeEventListener("vendo-docs-embed-ready", onReady);
-        if (disposeRef.current) { disposeRef.current(); disposeRef.current = null; }
-      };
+      // The bundle may have finished between the check above and the listener
+      // registration — re-check so a won race never strands the poster.
+      if (window.VendoDocsEmbed) mount();
     }
 
     return () => {
       cancelled = true;
+      window.removeEventListener("vendo-docs-embed-ready", onReady);
+      window.removeEventListener("vendo-docs-embed-error", onError);
       if (disposeRef.current) { disposeRef.current(); disposeRef.current = null; }
     };
   }, [surface]);
@@ -118,15 +121,19 @@ export const VendoLauncher = () => {
     if (window.VendoDocsEmbed) {
       mountIt();
     } else {
-      const existing = document.querySelector('script[data-vendo-docs-embed]');
-      const script = existing ?? document.createElement("script");
       window.addEventListener("vendo-docs-embed-ready", mountIt, { once: true });
+      const existing = document.querySelector('script[data-vendo-docs-embed]');
       if (!existing) {
+        const script = document.createElement("script");
         script.src = "https://vendo.run/playground/embed.js";
         script.async = true;
         script.dataset.vendoDocsEmbed = "";
+        // A failed bundle means no launcher — silent by design, but announce
+        // for any VendoEmbed instances sharing the tag.
+        script.onerror = () => window.dispatchEvent(new Event("vendo-docs-embed-error"));
         document.head.appendChild(script);
       }
+      if (window.VendoDocsEmbed) mountIt();
     }
     return () => {
       cancelled = true;


### PR DESCRIPTION
Post-merge triage of the #409 AI-review findings (the comments API was erroring pre-merge; read after). Dispositions:

- **Fixed here** — shared `embed.js` failure now reaches every embed instance (cubic P2); ready-event race no longer strands the poster (Devin); `VendoLauncher` script path announces failure + closes the same race (cubic P2).
- **Stale** — three findings target `docs-site/vendo-launcher.js`, which was deleted in #409's final revision (Mintlify plan-gates root custom scripts).
- **Acceptable-by-design** — poster-stays-visible is the intended degraded state in all failure modes; the P1 'poster files missing' is a false positive (the heroes merged in #402 and exist on main).
- **Deferred** — autoSend cross-submission with two overlay embeds on one page (cubic P2): the docs mount only in-flow surfaces plus one launcher; tightening tracked for when a second portal surface is ever embedded.

https://claude.ai/code/session_018jveoABa83rUsYnNRm9Yfk
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the docs embed more resilient by propagating load failures to all instances and closing a race that could strand the poster. `VendoLauncher` gets the same fixes.

- Bug Fixes
  - Dispatch `vendo-docs-embed-error` on `embed.js` load failure; all `VendoEmbed` instances listen and switch to fallback instead of hanging.
  - After adding the ready listener, re-check `window.VendoDocsEmbed` and mount immediately to avoid missing a just-finished load; same logic in `VendoLauncher`.
  - Remove ready/error listeners on unmount and dispose safely; launcher stays silent by design but announces failures for shared instances.

<sup>Written for commit 9eabf771b4ad8a0448e60c885de9f73c1d351a6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

