### PR TITLE
docs: persist embed load failure (unanimous #413 reviewer nit)

### DIFF
--- a/docs-site/snippets/vendo-embed.jsx
+++ b/docs-site/snippets/vendo-embed.jsx
@@ -28,6 +28,9 @@ export const VendoEmbed = ({ surface, poster, alt, height = 480, caption }) => {
 
     const onReady = () => mount();
     const onError = () => { if (!cancelled) setFailed(true); };
+    // A load failure that happened before this instance mounted is persisted
+    // on window — the ephemeral error event alone would never reach us.
+    if (window.__vendoDocsEmbedFailed) { setFailed(true); return; }
     if (window.VendoDocsEmbed) {
       mount();
     } else {
@@ -40,7 +43,7 @@ export const VendoEmbed = ({ surface, poster, alt, height = 480, caption }) => {
         script.src = "https://vendo.run/playground/embed.js";
         script.async = true;
         script.dataset.vendoDocsEmbed = "";
-        script.onerror = () => window.dispatchEvent(new Event("vendo-docs-embed-error"));
+        script.onerror = () => { window.__vendoDocsEmbedFailed = true; window.dispatchEvent(new Event("vendo-docs-embed-error")); };
         document.head.appendChild(script);
       }
       // The bundle may have finished between the check above and the listener
@@ -118,6 +121,7 @@ export const VendoLauncher = () => {
       if (cancelled || dispose || !window.VendoDocsEmbed) return;
       try { dispose = window.VendoDocsEmbed.mountLauncher(); } catch (error) { console.error("[vendo-embed]", error); }
     };
+    if (window.__vendoDocsEmbedFailed) return;
     if (window.VendoDocsEmbed) {
       mountIt();
     } else {
@@ -130,7 +134,7 @@ export const VendoLauncher = () => {
         script.dataset.vendoDocsEmbed = "";
         // A failed bundle means no launcher — silent by design, but announce
         // for any VendoEmbed instances sharing the tag.
-        script.onerror = () => window.dispatchEvent(new Event("vendo-docs-embed-error"));
+        script.onerror = () => { window.__vendoDocsEmbedFailed = true; window.dispatchEvent(new Event("vendo-docs-embed-error")); };
         document.head.appendChild(script);
       }
       if (window.VendoDocsEmbed) mountIt();


### PR DESCRIPTION
All three AI reviewers flagged the same residual P2 on #413: the shared embed.js failure is an ephemeral event, so instances mounting after the failure sit on the loading badge forever. Persist `window.__vendoDocsEmbedFailed` at the error source and check it at mount time in both `VendoEmbed` (flips to the fallback chip) and `VendoLauncher` (silent skip).

https://claude.ai/code/session_018jveoABa83rUsYnNRm9Yfk
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist docs embed load failure so late-mounting instances don’t get stuck on the loading badge. On embed.js error, set window.__vendoDocsEmbedFailed and dispatch the existing error event; at mount, VendoEmbed shows the fallback chip and VendoLauncher silently skips when the flag is set.

<sup>Written for commit 83b6e903034f3966c9e026393f4c0bb48cf006af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

