### PR TITLE
composio: auth_configs paginates by page number, not cursor

### DIFF
--- a/fixtures/host-app/next-env.d.ts
+++ b/fixtures/host-app/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/redteam-e2e/dev/types/routes.d.ts";
+import "./.next/actions-e2e/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/actions/src/connectors/composio-catalog.test.ts
+++ b/packages/actions/src/connectors/composio-catalog.test.ts
@@ -38,12 +38,17 @@ function authConfigsStub() {
     res.setHeader("content-type", "application/json");
     if (req.method === "GET" && url.pathname === "/api/v3/auth_configs") {
       requests += 1;
-      if (url.searchParams.get("cursor") === "page2") {
+      // Page-number pagination with a LYING next_cursor (null) — exactly the
+      // live API shape probed 2026-07-20: total_items is the only honest
+      // signal that more pages exist.
+      if (url.searchParams.get("cursor") === "2") {
         res.end(JSON.stringify({
           items: [
             { id: "ac_slack_2", toolkit: { slug: "slack" }, status: "ENABLED" }, // duplicate toolkit
             { id: "ac_linear", toolkit: { slug: "linear" }, status: "ENABLED" },
           ],
+          total_items: 5,
+          next_cursor: null,
         }));
         return;
       }
@@ -53,7 +58,8 @@ function authConfigsStub() {
           { id: "ac_slack", toolkit: { slug: "slack" }, status: "ENABLED" },
           { id: "ac_notion", toolkit: { slug: "notion" }, status: "DISABLED" },
         ],
-        next_cursor: "page2",
+        total_items: 5,
+        next_cursor: null,
       }));
       return;
     }

--- a/packages/actions/src/connectors/composio.ts
+++ b/packages/actions/src/connectors/composio.ts
@@ -191,15 +191,17 @@ export function composioConnector(config: {
       return connectableCache.entries;
     }
 
+    // auth_configs paginates by PAGE NUMBER, not cursor: live-probed
+    // 2026-07-20, the API clamps limit to 50 and answers `total_pages: 1,
+    // next_cursor: null` even when total_items is larger — cursor-following
+    // silently drops the tail. Walk `cursor=1,2,…` until the item count
+    // reaches total_items.
     const toolkits = new Set<string>();
-    let cursor: string | undefined;
-    const seenCursors = new Set<string>();
+    let itemsSeen = 0;
 
-    for (let page = 0; page < MAX_PAGES; page += 1) {
+    for (let page = 1; page <= MAX_PAGES; page += 1) {
       const response = await composioFetch("/api/v3/auth_configs", {
-        // Large page size so MAX_PAGES bounds the real catalog rather than
-        // the API's small default (same reasoning as fetchTools).
-        query: { limit: "100", ...(cursor === undefined ? {} : { cursor }) },
+        query: { limit: "100", cursor: String(page) },
       });
       if (!response.ok) {
         const { message } = responseErrorParts(response.payload);
@@ -211,14 +213,16 @@ export function composioConnector(config: {
         if (item.status === "DISABLED") continue;
         if (typeof item.toolkit?.slug === "string") toolkits.add(item.toolkit.slug);
       }
-      cursor = parsed.nextCursor;
-      if (!cursor) {
+      itemsSeen += parsed.items.length;
+      const totalItems = (response.payload as { total_items?: unknown }).total_items;
+      const done = parsed.items.length === 0
+        || typeof totalItems !== "number"
+        || itemsSeen >= totalItems;
+      if (done) {
         const entries = [...toolkits].map((toolkit) => ({ toolkit }));
         connectableCache = { at: Date.now(), entries };
         return entries;
       }
-      if (seenCursors.has(cursor)) throw new Error(`Composio pagination loop at cursor ${cursor}`);
-      seenCursors.add(cursor);
     }
 
     throw new Error(`Composio auth-configs pagination exceeded ${MAX_PAGES} pages`);


### PR DESCRIPTION
Live-probed after #420 deployed: Composio's auth_configs endpoint clamps `limit` to 50 and answers `total_pages: 1, next_cursor: null` even when `total_items` is larger — so the cursor-following walk stopped after one page and the connectable catalog silently lost every toolkit past the 50th (production probe returned 50 of 56). Walk `cursor=1,2,…` until the item count reaches `total_items`. Companion console fix: runvendo/vendo-web#82.

Tests updated to mirror the real (lying) API shape. `@vendoai/actions` suite green.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Composio `auth_configs` pagination to use page numbers and fetch all items, so the connectable catalog in `@vendoai/actions` no longer drops toolkits past the 50th. Prevents missing tools caused by `next_cursor: null` and a clamped `limit`.

- **Bug Fixes**
  - Iterate with `cursor=1,2,…` and track `itemsSeen` until it reaches `total_items`.
  - Stop on empty page or when `itemsSeen >= total_items`, instead of relying on `next_cursor`.
  - Updated tests to mirror live API shape (`next_cursor: null`, `total_items` provided).

<sup>Written for commit a2dae4056ce3b2f1f741747df0d389146d37ab54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

