### PR TITLE
W5a triage: shape-check learns Select labelField/valueField; all repair hints go Kit-native

### DIFF
--- a/packages/core/src/wire-v2/compile.test.ts
+++ b/packages/core/src/wire-v2/compile.test.ts
@@ -1105,30 +1105,53 @@ describe("compileWireV2 prewired option projection (v2 spec §3)", () => {
   <Select options={${options}}/>
 </App>`;
 
-  it("an object array bound straight to Select options fails: needs asOptions projection", () => {
+  it("an object array bound straight to Select options fails, and the repair hint is Kit-native (W5a: labelField/valueField, never asOptions)", () => {
     const result = compile(selectWire("accts.data"), shapes);
     expect(codes(result)).toEqual(["shape-mismatch"]);
     const error = result.bindingErrors[0];
     expect(error?.nodeId).toBe("select-1");
     expect(error?.prop).toBe("options");
-    expect(error?.message).toContain("asOptions");
+    expect(error?.message).toContain("labelField");
+    expect(error?.message).not.toContain("asOptions");
     expect(error?.available).toEqual(["id", "name"]);
   });
 
-  it("the same array projected with asOptions passes", () => {
+  it("the taught path passes: RAW rows with labelField/valueField naming their fields (W5a)", () => {
+    const result = compile(`
+<App name="Transfer">
+  <Query id="accts" tool="host_listAccounts"/>
+  <Select options={accts.data} labelField="name" valueField="id"/>
+</App>`, shapes);
+    expect(result.issues).toEqual([]);
+    expect(result.bindingErrors).toEqual([]);
+  });
+
+  it("named fields absent from the rows are the blank-option class: flagged with the named field (W5a)", () => {
+    const result = compile(`
+<App name="Transfer">
+  <Query id="accts" tool="host_listAccounts"/>
+  <Select options={accts.data} labelField="title" valueField="id"/>
+</App>`, shapes);
+    expect(codes(result)).toEqual(["shape-mismatch"]);
+    expect(result.bindingErrors[0]?.message).toContain('"title"');
+    expect(result.bindingErrors[0]?.available).toEqual(["id", "name"]);
+  });
+
+  it("the deprecated asOptions projection STILL compiles (stored apps; staged retirement)", () => {
     const result = compile(selectWire("accts.data | asOptions(id, name)"), shapes);
     expect(result.issues).toEqual([]);
     expect(result.bindingErrors).toEqual([]);
   });
 
-  it("Tabs tabs bound to a raw object array is flagged the same way", () => {
+  it("Tabs tabs bound to a raw object array is flagged with a literal-items hint (never asOptions)", () => {
     const result = compile(`
 <App name="T">
   <Query id="accts" tool="host_listAccounts"/>
   <Tabs tabs={accts.data}/>
 </App>`, shapes);
     expect(codes(result)).toEqual(["shape-mismatch"]);
-    expect(result.bindingErrors[0]?.message).toContain("asOptions");
+    expect(result.bindingErrors[0]?.message).toContain("literal {value, label}");
+    expect(result.bindingErrors[0]?.message).not.toContain("asOptions");
   });
 
   it("a literal options array with inline bindings is not flagged (already value/label shaped)", () => {
@@ -1172,7 +1195,7 @@ describe("compileWireV2 prewired option projection (v2 spec §3)", () => {
 /** vendo-v2-cells — the raw-braces class: object shapes bound into display
  *  slots (Table cells, Text/Stat/Badge) render raw JSON; the shape check
  *  flags them and routes to template/scalar-field repair, mirroring the
- *  asOptions projection check. */
+ *  option-item projection check. */
 describe("compileWireV2 display-slot object check (raw-braces class)", () => {
   const deadlinesShape = {
     kind: "object" as const,
@@ -1216,7 +1239,11 @@ describe("compileWireV2 display-slot object check (raw-braces class)", () => {
     expect(error?.prop).toBe("rows");
     expect(error?.message).toContain("progress");
     expect(error?.message).toContain("assignedTo");
-    expect(error?.message).toContain("template");
+    // W5a — the repair hint is Kit-native (DataTable dot-path columns), never
+    // the deprecated template projection.
+    expect(error?.message).toContain("DataTable");
+    expect(error?.message).toContain('{key:"assignedTo.id"}');
+    expect(error?.message).not.toContain("template");
     expect(error?.available).toEqual(["client", "dueDate", "progress", "assignedTo"]);
   });
 
@@ -1234,7 +1261,7 @@ describe("compileWireV2 display-slot object check (raw-braces class)", () => {
     expect(result.bindingErrors).toEqual([]);
   });
 
-  it("template projections clear the error", () => {
+  it("the deprecated template projection STILL clears the error (stored apps; staged retirement)", () => {
     const result = compile(tableWire(
       'rows={dl.data | template(progress, "{progress.received} of {progress.total}") | template(assignedTo, "{assignedTo.name}")}',
     ), shapes);
@@ -1242,7 +1269,7 @@ describe("compileWireV2 display-slot object check (raw-braces class)", () => {
     expect(result.bindingErrors).toEqual([]);
   });
 
-  it("an object bound into Text text / Stat value / Badge label is flagged with template repair", () => {
+  it("an object bound into Text text / Stat value / Badge label is flagged with scalar-field repair (never template — W5a)", () => {
     for (const element of ["Text text={dl.nearest}", "Stat label=\"Next\" value={dl.nearest}", "Badge label={dl.nearest}"]) {
       const result = compile(`
 <App name="D">
@@ -1250,7 +1277,8 @@ describe("compileWireV2 display-slot object check (raw-braces class)", () => {
   <${element}/>
 </App>`, shapes);
       expect(codes(result)).toEqual(["shape-mismatch"]);
-      expect(result.bindingErrors[0]?.message).toContain("template");
+      expect(result.bindingErrors[0]?.message).toContain("scalar field");
+      expect(result.bindingErrors[0]?.message).not.toContain("template");
     }
   });
 

--- a/packages/core/src/wire-v2/shape-check.ts
+++ b/packages/core/src/wire-v2/shape-check.ts
@@ -54,9 +54,10 @@ const splitPath = (path: string): { query: string; pointer: string } | null => {
 /** The prewired props whose bound value must be `[{value, label}]` items (a
  *  bare `string[]` is also fine), with the item fields that component requires.
  *  A fetched object array lacking a required field renders blank options/tabs —
- *  the projection gap {@link optionItemMiss} routes to
- *  `| asOptions(valueField, labelField)` repair. Select labels are optional;
- *  Tabs need both (a labelless tab is a blank button). */
+ *  {@link optionItemMiss} routes the gap to Kit-native repair (W5a: Select
+ *  labelField/valueField over RAW rows; the deprecated asOptions projection
+ *  compiles for stored apps but is never suggested). Select labels are
+ *  optional; Tabs need both (a labelless tab is a blank button). */
 const OPTION_ITEM_PROPS: ReadonlyMap<string, { props: ReadonlySet<string>; required: readonly string[] }> = new Map([
   ["Select", { props: new Set(["options"]), required: ["value"] }],
   ["Tabs", { props: new Set(["tabs", "items"]), required: ["value", "label"] }],
@@ -80,7 +81,7 @@ const DISPLAY_TEXT_PROPS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
 
 /** What a checked binding's resolved shape must satisfy for its slot. */
 type SlotCheck =
-  | { kind: "options"; required: readonly string[] }
+  | { kind: "options"; required: readonly string[]; hint: string }
   /** A text display slot (Text.text, Stat.value, Badge.label). */
   | { kind: "display"; prop: string }
   /** Table rows: every DISPLAYED column cell must be a scalar. `displayed`
@@ -107,7 +108,22 @@ const literalColumnKeys = (columns: unknown): ReadonlySet<string> | null => {
 
 const slotFor = (node: TreeNode, prop: string): SlotCheck | null => {
   const required = optionRequired(node.component, prop);
-  if (required !== null) return { kind: "options", required };
+  if (required !== null) {
+    // W5a (dialect retirement) — Select's taught path binds RAW rows with
+    // labelField/valueField naming their fields: the required item fields
+    // become the NAMED ones, and every repair hint is Kit-native (the
+    // asOptions projection still compiles for stored apps but is never
+    // suggested).
+    if (node.component === "Select") {
+      const named = [node.props?.valueField, node.props?.labelField]
+        .filter((field): field is string => typeof field === "string");
+      if (named.length > 0) {
+        return { kind: "options", required: named, hint: "labelField/valueField must name fields the rows actually carry" };
+      }
+      return { kind: "options", required, hint: 'bind the RAW rows and add labelField/valueField naming their fields (e.g. labelField="name" valueField="id")' };
+    }
+    return { kind: "options", required, hint: "bind rows that carry those fields, or write literal {value, label} items" };
+  }
   if (DISPLAY_TEXT_PROPS.get(node.component)?.has(prop) === true) return { kind: "display", prop };
   if (node.component === "Table" && prop === "rows") {
     const columns = node.props?.columns;
@@ -122,15 +138,16 @@ const slotFor = (node: TreeNode, prop: string): SlotCheck | null => {
 };
 
 /** A non-scalar shape in a text display slot renders raw JSON braces. The
- *  repair hint matches the kind: template projects OBJECTS to one string;
- *  arrays reduce through an aggregate (template cannot string an array). */
+ *  repair hint matches the kind and is Kit-native (W5a — never the deprecated
+ *  template projection): objects bind one nested scalar field; arrays reduce
+ *  through an aggregate. */
 const displaySlotMiss = (shape: ShapeType, prop: string): MissReport | null => {
   if (shape.kind !== "object" && shape.kind !== "array") return null;
   const hint = shape.kind === "object"
-    ? 'project it to one string with | template("…{field}…")'
-    : "reduce it with an aggregate (| count(), | sum(field))";
+    ? "bind ONE of its scalar fields instead (extend the binding path, e.g. .name)"
+    : "reduce it with an aggregate (| count(), | sum(field)) or bind a single row's scalar field";
   return {
-    message: `this binds an ${shape.kind} into the "${prop}" display slot — it renders as raw JSON braces; bind a scalar field instead, or ${hint}`,
+    message: `this binds an ${shape.kind} into the "${prop}" display slot — it renders as raw JSON braces; ${hint}`,
     ...(shape.kind === "object" ? { available: Object.keys(shape.fields) } : {}),
   };
 };
@@ -143,29 +160,34 @@ const cellsMiss = (shape: ShapeType, displayed: ReadonlySet<string> | null): Mis
   const offenders = Object.entries(fields).filter(([field, fieldShape]) =>
     (displayed === null || displayed.has(field)) && (fieldShape.kind === "object" || fieldShape.kind === "array"));
   if (offenders.length === 0) return null;
+  // W5a — Kit-native repair: DataTable resolves dot-path column keys, so the
+  // remedy is the Kit table (or scalar-only columns), never the deprecated
+  // template projection.
   const hints = offenders.map(([field, fieldShape]) => {
     const sub = fieldShape.kind === "object" ? Object.keys(fieldShape.fields)[0] : undefined;
-    return `| template(${field}, "{${field}${sub === undefined ? "" : `.${sub}`}}")`;
+    return `{key:"${field}${sub === undefined ? "" : `.${sub}`}"}`;
   });
   return {
-    message: `these rows carry object-valued column(s) ${offenders.map(([field]) => `"${field}"`).join(", ")} — a Table cell renders an object as raw JSON braces; project each to one string (e.g. ${hints.join(" ")}) or list only scalar keys in columns`,
+    message: `these rows carry object-valued column(s) ${offenders.map(([field]) => `"${field}"`).join(", ")} — a Table cell renders an object as raw JSON braces; use the Kit <DataTable> with dot-path column keys reaching the nested scalars (e.g. columns={[${hints.join(", ")}]}) or list only scalar keys in columns`,
     available: Object.keys(fields),
   };
 };
 
 const slotMiss = (slot: SlotCheck, shape: ShapeType): MissReport | null => {
-  if (slot.kind === "options") return optionItemMiss(shape, slot.required);
+  if (slot.kind === "options") return optionItemMiss(shape, slot.required, slot.hint);
   if (slot.kind === "display") return displaySlotMiss(shape, slot.prop);
   return cellsMiss(shape, slot.displayed);
 };
 
 /** A resolved shape feeding an option prop must be a `string[]` or an object
- *  array carrying the fields that component's items need: Select items are
- *  `{value, label?}` (value required), Tabs items `{value, label}` (both
- *  required — a labelless tab renders a blank button). An object array missing
- *  a required field is the blank-option class; anything else (scalar, json,
- *  non-array) stays defensive. */
-const optionItemMiss = (shape: ShapeType, required: readonly string[]): MissReport | null => {
+ *  array carrying the fields that component's items need: Select reads RAW
+ *  rows via labelField/valueField (default `{value, label?}` items when the
+ *  fields are unnamed), Tabs items are `{value, label}` (both required — a
+ *  labelless tab renders a blank button). An object array missing a required
+ *  field is the blank-option class; anything else (scalar, json, non-array)
+ *  stays defensive. The repair hint arrives from {@link slotFor} and is
+ *  Kit-native (W5a — never the deprecated asOptions projection). */
+const optionItemMiss = (shape: ShapeType, required: readonly string[], hint: string): MissReport | null => {
   if (shape.kind !== "array") return null;
   const items = shape.items;
   if (items.kind !== "object") return null;
@@ -173,7 +195,7 @@ const optionItemMiss = (shape: ShapeType, required: readonly string[]): MissRepo
   if (missing.length === 0) return null;
   const available = Object.keys(items.fields);
   return {
-    message: `this binds an array of {${available.join(", ")}}, missing ${missing.map((field) => `"${field}"`).join(", ")}, but the list prop needs [{value, label}] items — project it with | asOptions(valueField, labelField) (e.g. | asOptions(id, name))`,
+    message: `this binds an array of {${available.join(", ")}}, missing ${missing.map((field) => `"${field}"`).join(", ")} — ${hint}`,
     available,
   };
 };


### PR DESCRIPTION
## W5a triage follow-up — align the binding shape-check with the taught Select path

#434 auto-merged while this reviewer-verified fix was still local; this is the immediate follow-up. All three AI reviewers on #434 (Greptile P1, cubic P1, Devin bug — T-Rex-verified repro) flagged the same real gap: with `toolShapes` present (the production configuration), `wire-v2/shape-check.ts` still required a `value` item field on `Select.options`, so the newly taught form `options={rows} labelField="name" valueField="id"` was rejected at compile and the repair message steered the model back to the retired `| asOptions(...)`.

### Fix

- `slotFor` (shape-check.ts): when a `Select` node names `labelField`/`valueField`, the required item fields become the NAMED fields — the taught form passes, and a named field absent from the rows is still caught (the blank-option class survives).
- Every option/display/cells repair hint is now Kit-native (W5a): Select → `labelField`/`valueField`; Tabs → literal `{value, label}` items; display slots → scalar-field path; Table object cells → Kit `<DataTable>` dot-path column keys. `asOptions`/`template` are never suggested — both still compile for stored apps (asserted by tests).

### Tests

- taught path passes under toolShapes; missing named field flagged with the named field; deprecated `asOptions`/`template` still compile; all hints asserted asOptions/template-free.
- Gates green: build/test/typecheck/lint 39/39.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teach the shape-checker to accept `Select` with `labelField`/`valueField` on raw rows and switch all repair hints to Kit-native guidance. This unblocks the W5a taught path while keeping deprecated projections compiling for stored apps.

- **Bug Fixes**
  - `Select` options now use the named `labelField`/`valueField` as required item fields; missing named fields are flagged with available keys.
  - Repair hints are Kit-native: Select → bind raw rows and add `labelField`/`valueField`; Tabs → use literal `{value, label}` items; display slots → bind a scalar field; Table rows → use Kit `<DataTable>` with dot-path column keys. 

- **Migration**
  - No action needed. `asOptions` and `template` still compile but are no longer suggested. You can adopt `labelField`/`valueField` on `Select` now.

<sup>Written for commit 4c88de83942808d3258fbb95d9dcb43b902238c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

