### PR TITLE
Hosted store: survive the console's removed session doors (PROD-IMPACT)

### DIFF
--- a/docs-site/deploy/persistence.mdx
+++ b/docs-site/deploy/persistence.mdx
@@ -52,6 +52,12 @@ environment](/reference/environment-variables#app-machine-environment) for the
 stay queryable. Ephemeral (anonymous) principals write ordinary rows under
 their subject; a TTL sweep erases idle sessions.
 
+On the Cloud hosted store the session doors are currently unavailable
+(the console removed `/api/v1/store/sessions/*`); the composition detects
+this, warns once, and disables anonymous-session registration, the
+anonymous→signed-in merge, and the hosted TTL sweep for the process.
+Anonymous traffic keeps serving. Local stores are unaffected.
+
 ## Encryption is on by default
 
 Set a 32-byte base64 key at `VENDO_STORE_ENCRYPTION_KEY` in your host `.env`.

--- a/docs/persistence-and-deploy.md
+++ b/docs/persistence-and-deploy.md
@@ -82,6 +82,12 @@ JOIN vendo_records r
 
 `subject` is the only partition axis. Ephemeral (anonymous) principals write ordinary rows under their subject; a TTL sweep erases sessions idle past `sessions.ttlMs`.
 
+On the Cloud hosted store the session doors are currently unavailable (the
+console removed `/api/v1/store/sessions/*`); the composition detects this,
+warns once, and disables anonymous-session registration, the
+anonymous→signed-in merge, and the hosted TTL sweep for the process.
+Anonymous traffic keeps serving. Local stores are unaffected.
+
 ## Long-lived hosts
 
 Call `automations.start()` to run the convenience timer around `tick()`. The

--- a/docs/verification/existing-agents/polish/hosted-sessions-404.md
+++ b/docs/verification/existing-agents/polish/hosted-sessions-404.md
@@ -1,0 +1,102 @@
+# Hosted-store session sweep 404 — findings + flowlet fix (Polish Lane B)
+
+**PROD-IMPACT.** Until this branch lands, any keyed host (Cloud hosted store)
+serving anonymous traffic hard-fails those requests in prod: the first
+session registration fails closed against a route the console no longer
+serves, and `wire/context.ts` awaits it un-caught. The Lane E symptom (noisy
+`session sweep failed` warns each interval) is the visible edge of the same
+removal.
+
+## Root cause
+
+Not path drift and not a missing deploy. vendo-web commit `7cd0a02`
+("data-plane: records API rides the table engine", 2026-07-19, on `main`,
+deployed to `console.vendo.run`) **deliberately deleted** the console's
+ephemeral-session op family per a newer spec:
+
+> The ephemeral-session op family is deleted per spec (an anonymous visitor
+> is an end_user row; adoption is PUT /users/{externalId}) — its routes 404.
+
+That conflicts with flowlet's hosted-store one-pager
+(`docs/superpowers/specs/2026-07-18-hosted-store-onepager.md`, amended
+2026-07-18), which specifies `POST /api/v1/store/sessions/register|adopt|stale|claim`
+plus the HOST-driven TTL sweep. The two Yousef-approved specs diverged one day
+apart; the console moved, the OSS client didn't.
+
+## Expected vs actual (live, 2026-07-20, key `vnd_ec2…` OSS_CONFORMANCE)
+
+| Route | Client expects | Prod console answers |
+| --- | --- | --- |
+| `POST /api/v1/store/sessions/register` | `{ ok: true }` | **bare HTML 404** (Next.js not-found page, no error envelope) |
+| `POST /api/v1/store/sessions/stale` | `{ subjects: [...] }` | **bare HTML 404** |
+| `POST /api/v1/store/sessions/claim` | `{ claimed: bool }` | **bare HTML 404** |
+| `POST /api/v1/store/records/{c}/list` (control) | `{ records: [...] }` | `200 {"records":[]}` ✓ |
+| `POST /api/v1/store/erase` (control, empty body) | validation envelope | `400 {"error":{"code":"validation","message":"Provide exactly one of subject or appId."}}` ✓ |
+
+Condensed curl transcript:
+
+```
+$ curl -X POST https://console.vendo.run/api/v1/store/sessions/stale \
+    -H "authorization: Bearer $KEY" -H "content-type: application/json" \
+    -d '{"idleMs": 999999999999, "now": 1752969600000}'
+HTTP 404
+<!DOCTYPE html>…<title>404: This page could not be found.</title>…   ← no envelope
+
+$ curl -X POST https://console.vendo.run/api/v1/store/records/probe_ctl/list \
+    -H "authorization: Bearer $KEY" -H "content-type: application/json" -d '{"query":{}}'
+HTTP 200
+{"records":[]}
+```
+
+vendo-web `origin/main` tree confirms: `apps/console/app/api/v1/store/` holds
+`records`, `blobs`, `schema`, `erase` — no `sessions`. The replacement surface
+on main is `PUT /api/v1/users/{externalId}` (end_user upsert-seen; traits
+merge; no stale/claim, no subject merge).
+
+## flowlet fix (this branch)
+
+The removed surface is now detected precisely and the doors go quiet instead
+of failing anonymous traffic:
+
+- `packages/vendo/src/hosted-store.ts` — session ops ride a sessions-only
+  error raise: a **bare 404** (no error envelope) throws the typed
+  `HostedSessionDoorsMissingError`. An enveloped 404 (`not-found` from a live
+  console) and every other failure keep the existing loud mapping.
+- `packages/vendo/src/server.ts` (`hostedSessionOps`) — on the typed error the
+  doors disable for the process with **one** warn naming `vendo-web@7cd0a02`
+  and the lost capabilities. After that: `register` no-ops (anonymous requests
+  serve again), `adopt` returns `null` (cookie still retires; no merge audit),
+  `sweep` returns `[]` (no per-interval retry noise).
+- Live-verified against prod: `sessions.stale`/`register` throw the typed
+  error; `records.list` unaffected. Covered by four new tests in
+  `packages/vendo/src/hosted-sessions.test.ts` (disable-once + warn contents,
+  sweep-leg quiescence, adopt/cookie path, enveloped-404 precision negative).
+
+## What is still lost on Cloud (needs vendo-web follow-up)
+
+With the doors gone the console has no equivalent for two contract promises:
+
+1. **Ephemeral TTL erasure** — nothing sweeps idle anonymous subjects' rows on
+   the hosted store. `POST /api/v1/store/erase` still exists, but the host has
+   no stale/claim legs to drive it. Anonymous data now accumulates until an
+   explicit erase.
+2. **Anonymous→signed-in merge** — `PUT /users/{externalId}` identifies a
+   user but moves no store rows; the anon session's threads/apps/state stay
+   orphaned under `anonymous_<id>`.
+
+Two fix directions for vendo-web (pick one):
+
+- **A. Restore the session doors over the new engine** — reimplement
+  `sessions/[op]` on top of end_users + the data plane (register =
+  upsert-seen; adopt = end_user identify + server-side subject merge; stale/
+  claim = last_seen predicate). Keeps the flowlet client and the one-pager
+  contract as written; the flowlet detection then simply never fires.
+- **B. Finish the new contract** — add a server-side TTL lifecycle for
+  anonymous end_users (console-owned sweep + erase cascade) and a subject-merge
+  door (or fold merge into `PUT /users/{externalId}` with a `mergeFrom`
+  field), then migrate flowlet's `hostedSessionOps` onto it and amend the
+  one-pager.
+
+Either way the flowlet-side graceful disable stays correct: it reacts only to
+the removed surface and re-arms automatically on any console that serves the
+doors again (detection is per-process, not persisted).

--- a/packages/vendo/src/hosted-sessions.test.ts
+++ b/packages/vendo/src/hosted-sessions.test.ts
@@ -228,6 +228,42 @@ describe("hosted store: ephemeral sessions over the wire", () => {
     expect(detail).toMatchObject({ event: "anon-merge", from: anonSubject });
   });
 
+  it("stays loud on an ENVELOPED 404 from a session door — only the bare 404 means the surface is gone", async () => {
+    // Precision guard: a console that answers the error envelope is alive and
+    // owns its answer — "not-found" from a session door is a real (if odd)
+    // service response, never the removed-surface signal. First registration
+    // keeps failing closed, and the doors stay armed for the next visitor.
+    let envelope404 = false;
+    const h = harness({ ttlMs: 3_600_000, sweepIntervalMs: 1_000 }, (inner) =>
+      async (input, init) => {
+        const url = new URL(new Request(input, init).url);
+        if (envelope404 && url.pathname.includes("/sessions/")) {
+          return Response.json(
+            { error: { code: "not-found", message: "no such session" } },
+            { status: 404 },
+          );
+        }
+        return inner(input, init);
+      });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    envelope404 = true;
+    h.setNow(0);
+    const denied = await h.vendo.handler(listThreads());
+    // The registration failed CLOSED and the enveloped "not-found" (a
+    // wire-legal VendoError code) rode through to the caller as-is.
+    expect(denied.status).toBe(404);
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("session doors"));
+
+    // The doors were NOT disabled: once the console answers again, the next
+    // visitor registers over the wire as normal.
+    envelope404 = false;
+    h.setNow(100);
+    const served = await h.vendo.handler(listThreads());
+    expect(served.status).toBe(200);
+    expect(h.wireCalls("/sessions/register").length).toBeGreaterThan(0);
+  });
+
   it("sweeps a stale subject host-side: stale → claim → erase.bySubject over the wire", async () => {
     const h = harness({ ttlMs: 1_000, sweepIntervalMs: 100 });
     h.setNow(0);
@@ -258,5 +294,122 @@ describe("hosted store: ephemeral sessions over the wire", () => {
     h.setNow(5_500);
     await h.vendo.handler(listThreads());
     expect(h.console_.eraseCalls).toHaveLength(1);
+  });
+});
+
+// vendo-web@7cd0a02 (2026-07-19, deployed) deleted the console's
+// /api/v1/store/sessions/* op family per spec ("an anonymous visitor is an
+// end_user row; adoption is PUT /users/{externalId} — its routes 404"); the
+// removed routes answer Next.js's BARE 404 page, no error envelope. The
+// composition must survive that console: anonymous traffic keeps serving,
+// the doors disable once with a single warn naming the removal, and the
+// periodic sweep stops hammering a route that no longer exists.
+describe("hosted store: console without session doors (vendo-web@7cd0a02)", () => {
+  const bare404 = (): Response =>
+    new Response(
+      "<!DOCTYPE html><html><body><h1>404</h1>This page could not be found.</body></html>",
+      { status: 404, headers: { "content-type": "text/html" } },
+    );
+
+  /** Intercepts session-door ops with the prod console's bare 404; everything
+   * else (records, blobs, erase) rides the fake console untouched. */
+  const withoutDoors = (ops: readonly string[] = ["register", "adopt", "stale", "claim"]) => {
+    const hits: string[] = [];
+    const wrap = (inner: FetchLike): FetchLike => async (input, init) => {
+      const url = new URL(new Request(input, init).url);
+      const op = url.pathname.split("/sessions/")[1];
+      if (op !== undefined && ops.includes(op)) {
+        hits.push(op);
+        return bare404();
+      }
+      return inner(input, init);
+    };
+    return { hits, wrap };
+  };
+
+  it("keeps serving anonymous traffic: registration disables once, with ONE warn naming the removal", async () => {
+    const doors = withoutDoors();
+    const h = harness({ ttlMs: 3_600_000, sweepIntervalMs: 1_000 }, doors.wrap);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    // First anonymous visitor: the register attempt hits the bare 404, the
+    // doors disable, and the request still lands (register would otherwise
+    // fail closed and 500 the innocent visitor).
+    h.setNow(0);
+    const first = await h.vendo.handler(listThreads());
+    expect(first.status).toBe(200);
+    expect(await first.json()).toEqual([]);
+    expect(doors.hits).toEqual(["register"]);
+
+    const doorWarns = warn.mock.calls.filter(([message]) =>
+      typeof message === "string" && message.includes("session doors"));
+    expect(doorWarns).toHaveLength(1);
+    expect(doorWarns[0]![0]).toContain("vendo-web@7cd0a02");
+    // The warn names every capability the process is giving up.
+    expect(doorWarns[0]![0]).toContain("registration");
+    expect(doorWarns[0]![0]).toContain("merge");
+    expect(doorWarns[0]![0]).toContain("sweep");
+
+    // A SECOND visitor (new subject, no debounce cover) makes no wire attempt
+    // and triggers no further warns — the doors are quiet for the process.
+    h.setNow(600);
+    const second = await h.vendo.handler(listThreads());
+    expect(second.status).toBe(200);
+    expect(doors.hits).toEqual(["register"]);
+    expect(warn.mock.calls.filter(([message]) =>
+      typeof message === "string" && message.includes("session doors"))).toHaveLength(1);
+  });
+
+  it("goes quiet on the sweep cadence: one warn, then zero wire calls and zero retry noise", async () => {
+    // Doors vanish on the SWEEP leg first (register still lands): the exact
+    // Lane E symptom — a keyed host whose periodic sweep 404s every interval.
+    const doors = withoutDoors(["stale", "claim"]);
+    const h = harness({ ttlMs: 1_000, sweepIntervalMs: 100 }, doors.wrap);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    h.setNow(0);
+    expect((await h.vendo.handler(listThreads())).status).toBe(200);
+
+    // Past the TTL the amortized sweep runs, meets the bare 404, and disables.
+    h.setNow(5_000);
+    expect((await h.vendo.handler(listThreads())).status).toBe(200);
+    expect(doors.hits).toEqual(["stale"]);
+    expect(warn.mock.calls.filter(([message]) =>
+      typeof message === "string" && message.includes("session doors"))).toHaveLength(1);
+    // The old symptom — "session sweep failed; will retry next interval" —
+    // must NOT fire for the removed surface.
+    expect(warn.mock.calls.filter(([message]) =>
+      typeof message === "string" && message.includes("session sweep failed"))).toHaveLength(0);
+
+    // Later sweep windows never touch the wire again and stay silent.
+    h.setNow(10_000);
+    expect((await h.vendo.handler(listThreads())).status).toBe(200);
+    h.setNow(15_000);
+    expect((await h.vendo.handler(listThreads())).status).toBe(200);
+    expect(doors.hits).toEqual(["stale"]);
+    expect(warn.mock.calls.filter(([message]) =>
+      typeof message === "string" && message.includes("session doors"))).toHaveLength(1);
+  });
+
+  it("retires the anon cookie on sign-in without a merge report when the doors are gone", async () => {
+    const doors = withoutDoors();
+    const h = harness({ ttlMs: 3_600_000, sweepIntervalMs: 1_000 }, doors.wrap);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    h.setNow(0);
+    const anonResponse = await h.vendo.handler(listThreads());
+    expect(anonResponse.status).toBe(200);
+    const cookie = cookieOf(anonResponse);
+
+    h.signIn();
+    h.setNow(100);
+    const signedResponse = await h.vendo.handler(listThreads(cookie));
+    expect(signedResponse.status).toBe(200);
+    // The cookie retires (the anonymous linkage is unrecoverable either way)…
+    expect(signedResponse.headers.get("set-cookie")).toMatch(/Max-Age=0/i);
+    // …but no adopt ever rode the wire and no anon-merge audit was minted.
+    expect(doors.hits).not.toContain("adopt");
+    expect(h.wireCalls("/records/vendo_audit/put").filter((request) =>
+      JSON.stringify(request.json).includes("anon-merge"))).toHaveLength(0);
   });
 });

--- a/packages/vendo/src/hosted-store.ts
+++ b/packages/vendo/src/hosted-store.ts
@@ -74,6 +74,38 @@ const raiseStoreError = (response: Response): Promise<never> =>
     throw Object.assign(new Error(message), { code: code ?? "unavailable" });
   });
 
+/** vendo-web@7cd0a02 (2026-07-19) deleted the console's ephemeral-session op
+ * family (/api/v1/store/sessions/*) per spec — the removed routes answer
+ * Next.js's BARE 404 page, no error envelope. Typed so the composition layer
+ * (hostedSessionOps in server.ts) can disable the session doors gracefully
+ * instead of failing anonymous traffic; an ENVELOPED 404 is a live console
+ * answering "not-found" and keeps the loud path, same for every other
+ * failure. */
+export class HostedSessionDoorsMissingError extends Error {
+  constructor() {
+    super(
+      "Vendo Cloud console does not serve /api/v1/store/sessions/* (removed in vendo-web@7cd0a02)",
+    );
+    this.name = "HostedSessionDoorsMissingError";
+  }
+}
+
+/** The session doors' raise: a bare 404 (no envelope) is the one
+ * removed-surface signal; everything else defers to the store mapping. */
+const raiseSessionsError = async (response: Response): Promise<never> => {
+  if (response.status === 404) {
+    let payload: unknown;
+    try {
+      payload = JSON.parse(await response.clone().text());
+    } catch {
+      payload = undefined;
+    }
+    const enveloped = typeof payload === "object" && payload !== null && "error" in payload;
+    if (!enveloped) throw new HostedSessionDoorsMissingError();
+  }
+  return raiseStoreError(response);
+};
+
 function parseRecord(value: unknown): VendoRecord {
   const parsed = vendoRecordSchema.safeParse(value);
   if (!parsed.success) invalidResponse("invalid record");
@@ -109,8 +141,19 @@ export function hostedStore(options: HostedStoreOptions): HostedStore {
     raise: raiseStoreError,
   });
 
-  const sendJson = async (path: string, body: unknown): Promise<unknown> => {
-    const response = await send(path, {
+  // Same wire, sessions-only raise — the doors are the one surface the prod
+  // console may legitimately not serve (vendo-web@7cd0a02).
+  const sendSessions = consoleSender({
+    base,
+    mountPath: CONSOLE_STORE_PATH,
+    apiKey: options.apiKey,
+    timeoutMs,
+    fetchImpl,
+    raise: raiseSessionsError,
+  });
+
+  const postJson = (sender: typeof send) => async (path: string, body: unknown): Promise<unknown> => {
+    const response = await sender(path, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(body),
@@ -121,6 +164,8 @@ export function hostedStore(options: HostedStoreOptions): HostedStore {
       return {};
     }
   };
+  const sendJson = postJson(send);
+  const sendSessionsJson = postJson(sendSessions);
 
   const records = (collection: string): RecordStore => {
     const prefix = `/records/${encodeURIComponent(collection)}`;
@@ -290,13 +335,13 @@ export function hostedStore(options: HostedStoreOptions): HostedStore {
     blobs,
     sessions: {
       async register(subject, now) {
-        await sendJson("/sessions/register", { subject, ...(now === undefined ? {} : { now }) });
+        await sendSessionsJson("/sessions/register", { subject, ...(now === undefined ? {} : { now }) });
       },
       async adopt(from, to) {
-        return parseMergeReport(await sendJson("/sessions/adopt", { from, to }));
+        return parseMergeReport(await sendSessionsJson("/sessions/adopt", { from, to }));
       },
       async stale(idleMs, now) {
-        const payload = await sendJson("/sessions/stale", {
+        const payload = await sendSessionsJson("/sessions/stale", {
           idleMs,
           ...(now === undefined ? {} : { now }),
         }) as { subjects?: unknown };
@@ -306,7 +351,7 @@ export function hostedStore(options: HostedStoreOptions): HostedStore {
         return payload.subjects as string[];
       },
       async claim(subject, idleMs, now) {
-        const payload = await sendJson("/sessions/claim", {
+        const payload = await sendSessionsJson("/sessions/claim", {
           subject,
           idleMs,
           ...(now === undefined ? {} : { now }),

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -118,7 +118,7 @@ import { cloudTools } from "./cloud-tools.js";
 // rides the server surface the same way: pass it explicitly via
 // createVendo({ connectors: [cloudTools({...})] }) to scope with `apps`.
 export { cloudTools, type CloudToolsOptions } from "./cloud-tools.js";
-import { hostedStore, type HostedStore } from "./hosted-store.js";
+import { HostedSessionDoorsMissingError, hostedStore, type HostedStore } from "./hosted-store.js";
 // The hosted-store adapter rides the server surface like the other Cloud
 // adapters: a host can pass it explicitly via createVendo({ store }) with its
 // own options instead of relying on the VENDO_API_KEY default.
@@ -506,8 +506,27 @@ function hostedSessionOps(store: HostedStore, touchDebounceMs: number): SessionO
   // registered on the console; entries retire with the session (adopt/sweep),
   // so the map tracks at most the live anonymous sessions of this process.
   const wireTouched = new Map<string, number>();
+  // vendo-web@7cd0a02 (2026-07-19) removed the console's session doors per a
+  // newer spec (anonymous visitor = end_user row; adoption = PUT
+  // /users/{externalId}); against that console every door op meets a bare
+  // 404. The doors then go quiet for the process — one warn, no per-request
+  // failures, no per-interval sweep retries — because anonymous traffic must
+  // keep serving and there is nothing to retry INTO. The full contract catch-
+  // up (merge + TTL lifecycle on the new surface) is the vendo-web follow-up
+  // tracked in docs/verification/existing-agents/polish/hosted-sessions-404.md.
+  let doorsMissing = false;
+  const disableDoors = (): void => {
+    if (doorsMissing) return;
+    doorsMissing = true;
+    console.warn(
+      "[vendo] Vendo Cloud console does not serve the hosted session doors (/api/v1/store/sessions/* was removed in vendo-web@7cd0a02): "
+      + "anonymous-session registration, the anonymous→signed-in merge, and the hosted TTL sweep are disabled for this process. "
+      + "Hosted anonymous sessions will not be swept until the console grows a replacement surface.",
+    );
+  };
   return {
     async register(subject, now) {
+      if (doorsMissing) return;
       // In-process debounce: skip the wire touch when this subject's LAST
       // successful touch is younger than sweepIntervalMs/2. TTLs are hours
       // while the debounce window is seconds, and the claim leg re-checks
@@ -520,6 +539,12 @@ function hostedSessionOps(store: HostedStore, touchDebounceMs: number): SessionO
         await store.sessions.register(subject, now);
         wireTouched.set(subject, now);
       } catch (error) {
+        // The registry itself is gone: failing closed would 500 every
+        // anonymous request while protecting a sweep that cannot run.
+        if (error instanceof HostedSessionDoorsMissingError) {
+          disableDoors();
+          return;
+        }
         // INVARIANT: registered ⇒ sweepable. The FIRST registration must fail
         // closed — if it doesn't land, rows written under this subject would
         // be unreachable by the TTL sweep forever. A subsequent touch only
@@ -531,21 +556,37 @@ function hostedSessionOps(store: HostedStore, touchDebounceMs: number): SessionO
       }
     },
     async adopt(from, to) {
-      const report = await store.sessions.adopt(from, to);
-      wireTouched.delete(from);
-      return report;
+      // No doors, no merge report: the caller still retires the anon cookie
+      // (the linkage is unrecoverable either way) and skips the merge audit.
+      if (doorsMissing) return null;
+      try {
+        const report = await store.sessions.adopt(from, to);
+        wireTouched.delete(from);
+        return report;
+      } catch (error) {
+        if (!(error instanceof HostedSessionDoorsMissingError)) throw error;
+        disableDoors();
+        wireTouched.delete(from);
+        return null;
+      }
     },
     // The HOST-driven sweep (hosted-store one-pager): list stale candidates,
     // claim each (the wire claim repeats the idleness predicate — a re-touch
     // defeats it, same serialization as sweepEphemeralSubjects), and finish
     // every claimed subject through the erase cascade.
     async sweep(idleMs, now) {
+      if (doorsMissing) return [];
       const evicted: string[] = [];
-      for (const subject of await store.sessions.stale(idleMs, now)) {
-        if (!(await store.sessions.claim(subject, idleMs, now))) continue;
-        await store.erase.bySubject(subject);
-        wireTouched.delete(subject);
-        evicted.push(subject);
+      try {
+        for (const subject of await store.sessions.stale(idleMs, now)) {
+          if (!(await store.sessions.claim(subject, idleMs, now))) continue;
+          await store.erase.bySubject(subject);
+          wireTouched.delete(subject);
+          evicted.push(subject);
+        }
+      } catch (error) {
+        if (!(error instanceof HostedSessionDoorsMissingError)) throw error;
+        disableDoors();
       }
       return evicted;
     },


### PR DESCRIPTION
## What

**PROD-IMPACT fix.** vendo-web commit `7cd0a02` (deployed 2026-07-19) deleted the console's `/api/v1/store/sessions/register|adopt|stale|claim` routes per the newer data-plane spec, while flowlet's hosted store still calls them per the 2026-07-18 hosted-store one-pager. Result in prod today: hosted session registration fails closed and `wire/context` awaits it un-caught, so **anonymous requests against a Cloud hosted store hard-fail**; the session sweep also warns every interval (the symptom that led here).

This makes the OSS client survive the removed surface:
- Session ops throw a typed `HostedSessionDoorsMissingError` on the **bare-404-only** signal (enveloped errors and other failures stay loud — precision tested).
- The composition disables the doors once per process with a single warn naming `7cd0a02` and the lost capabilities: register no-ops (anon traffic serves again), adopt returns null (cookie retires without merge audit), sweep returns empty (noise gone).
- TDD both paths (removed-surface graceful / genuine-error loud), 4 new tests; live-verified against `console.vendo.run` with the OSS conformance key.

## Follow-up owned by vendo-web (report: `docs/verification/existing-agents/polish/hosted-sessions-404.md`)

Either restore the session doors over the new table engine, or finish the new contract (end_user merge door + console-owned TTL lifecycle). Until then, hosted anonymous sessions are never swept and anon→signed-in row merge is lost on Cloud. The report carries the full curl transcript and both directions.

## Verification

Root gates green (build/test/typecheck/lint); live control probes against prod confirm records/erase still healthy while sessions ops bare-404.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gracefully handle the console’s removed `/api/v1/store/sessions/*` routes by auto-disabling session doors on bare 404s. Anonymous traffic serves again on Cloud, and periodic sweep warnings stop.

- **Bug Fixes**
  - Detect bare 404s from session routes and throw `HostedSessionDoorsMissingError` (`packages/vendo/src/hosted-store.ts`).
  - Disable doors once per process in `hostedSessionOps` (`packages/vendo/src/server.ts`): register no-op; adopt returns `null`; sweep returns `[]`; single warn naming `vendo-web@7cd0a02`.
  - Keep other errors loud; enveloped 404s still surface as failures. Added 4 tests covering detection, disable-once, sweep quiescence, adopt path, and the enveloped-404 guard (`packages/vendo/src/hosted-sessions.test.ts`).
  - Docs updated to note temporary loss on Cloud and added a verification report with live transcript (`docs-site/deploy/persistence.mdx`, `docs/persistence-and-deploy.md`, `docs/verification/existing-agents/polish/hosted-sessions-404.md`).

- **Migration**
  - No action required. Behavior auto-detects at runtime; hosted anonymous sessions won’t be swept until the console provides a replacement surface.

<sup>Written for commit 6a841907a5945df54505776b0d371472450c2ccd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

