### PR TITLE
cloudSandbox: url(port) matches the shipped single-label ingress (port inserts before -m)

### DIFF
--- a/docs/served-apps.md
+++ b/docs/served-apps.md
@@ -27,12 +27,12 @@ Serving needs a sandbox provider with working public ingress:
 | Sandbox venue | Served apps |
 | --- | --- |
 | BYO e2b (`E2B_API_KEY` or an explicit `e2bSandbox`) | works |
-| Vendo Cloud hosted sandbox | pending the `*.m.vendo.run` ingress certificate |
+| Vendo Cloud hosted sandbox | works — single-label `<id-suffix>-m.vendo.run` ingress |
 
-On the Cloud venue, TLS for `*.m.vendo.run` is not yet live: the 2-to-3 flip
-succeeds, but the URL `open()` returns fails the TLS handshake in the browser.
-Use BYO e2b for served apps until the certificate lands; layers 1 and 2 are
-unaffected on both venues.
+The Cloud ingress moved to single-label hosts (`<id-suffix>-m.vendo.run`,
+ports as `<id-suffix>-<port>-m.vendo.run`) so the stock `*.vendo.run`
+certificate covers them; the earlier `*.m.vendo.run` TLS limitation no
+longer applies.
 
 ## How an app reaches layer 3
 

--- a/docs/served-apps.md
+++ b/docs/served-apps.md
@@ -14,7 +14,7 @@ createVendo({ apps: { experimentalServedApps: true } });
 
 Both venues serve layer-3 URLs: a BYO sandbox (`E2B_API_KEY`) on the
 provider's own hosts, and the Vendo Cloud sandbox on single-label
-`m-<id>.vendo.run` ingress hosts.
+`<id-suffix>-m.vendo.run` ingress hosts.
 
 With the flag off (the default), three things refuse with a typed
 `VendoError("not-implemented")` naming the flag: layer-3 generation, the 2-to-3

--- a/packages/vendo/src/sandbox-wire.ts
+++ b/packages/vendo/src/sandbox-wire.ts
@@ -50,16 +50,19 @@
  - exec/files also exist server-side (`POST /{id}/exec`,
  *   `GET|PUT /{id}/files?path=`, `GET /{id}/files/list?dir=`) — adapter-
  *   private, used for live-lane bootstrap and diagnostics only.
- * - ingress  the create/resume handle `url` (`https://m-<id>.vendo.run`,
- *   single-label scheme locked 2026-07-20) is the canonical-port public
- *   surface; `machine.url(port)` formats other ports as an e2b-style
- *   port-prefixed label on the same host (`https://<port>-m-<id>.vendo.run`),
- *   still single-label. Single-label hosts ride the existing `*.vendo.run`
- *   Universal SSL cert — no advanced certificate needed (live-verified
- *   2026-07-20: TLS fails on `test123.m.vendo.run`, succeeds on
- *   `m-test123.vendo.run`, which answers a JSON 404 for the unknown id).
- *   The console mints `url`, so the hostname shape is console-side; this
- *   adapter echoes whatever handle it is given.
+ * - ingress  the create/resume handle `url`
+ *   (`https://<id-suffix>-m.vendo.run`, single-label scheme SHIPPED by
+ *   vendo-web #85 on 2026-07-20; the -m is a SUFFIX, not a prefix —
+ *   Cloudflare worker routes only allow leading wildcards, so the route is
+ *   `*-m.vendo.run/*`) is the canonical-port public surface;
+ *   `machine.url(port)` inserts other ports before the suffix
+ *   (`https://<id-suffix>-<port>-m.vendo.run`), matching the machine-proxy
+ *   parse `^([a-z0-9]{24})(?:-(port))?-m\.vendo\.run$`. Single-label hosts
+ *   ride the existing `*.vendo.run` Universal SSL cert — no advanced
+ *   certificate needed (live-verified 2026-07-20: TLS fails on the legacy
+ *   dot shape `test123.m.vendo.run`, succeeds single-label; unknown ids
+ *   answer a JSON 404). The console mints `url`, so the hostname shape is
+ *   console-side; this adapter echoes whatever handle it is given.
  *
  * Adapter mapping:
  * - `machine.snapshot()` = the artifact mint, wrapped in the adapter's
@@ -98,5 +101,6 @@ export const CLOUD_SNAPSHOT_REF_PREFIX = "vendo:v2:";
 export const CONSOLE_SNAPSHOT_REF_PREFIX = "vendo:";
 
 /** The canonical box port the relay targets when no port rides the wire
- * (and the one the public ingress `https://m-<id>.vendo.run` serves). */
+ * (and the one the public ingress `https://<id-suffix>-m.vendo.run`
+ * serves). */
 export const CLOUD_BOX_PORT = 8080;

--- a/packages/vendo/src/sandbox.test.ts
+++ b/packages/vendo/src/sandbox.test.ts
@@ -54,7 +54,8 @@ interface MockSnapshot {
 /** In-memory fake of the console's /api/v1/sandboxes surface, faithful to the
  * wire contract in sandbox-wire.ts (artifact model, verified live) — the ONE
  * place a Cloud-side change must land alongside the adapter. */
-function fakeConsole() {
+function fakeConsole(options: { mintUrl?: (id: string) => string } = {}) {
+  const mintUrl = options.mintUrl ?? ((id: string) => `https://${id.slice(2)}-m.vendo.run`);
   const requests: RecordedRequest[] = [];
   const machines = new Map<string, MockMachine>();
   const snapshots = new Map<string, MockSnapshot>();
@@ -96,7 +97,7 @@ function fakeConsole() {
         allowedDomains: body.egress === undefined ? undefined : [...body.egress],
         files: new Map(),
       });
-      return json({ id, url: `https://m-${id}.vendo.run` }, 201);
+      return json({ id, url: mintUrl(id) }, 201);
     }
     if (path === `${CLOUD_SANDBOX_PATH}/resume` && request.method === "POST") {
       const body = recorded.json as { ref: string; egress?: string[] };
@@ -113,7 +114,7 @@ function fakeConsole() {
         ...(snapshot.app === undefined ? {} : { app: snapshot.app }),
         files: new Map(snapshot.files),
       });
-      return json({ id, url: `https://m-${id}.vendo.run` });
+      return json({ id, url: mintUrl(id) });
     }
     const gc = new RegExp(`^${CLOUD_SANDBOX_PATH}/snapshots/([^/]+)$`).exec(path);
     if (gc && request.method === "DELETE") {
@@ -366,23 +367,31 @@ describe("cloudSandbox", () => {
       .rejects.toMatchObject({ code: "validation" });
   });
 
-  it("url() defaults to the app's $PORT and prefixes non-canonical ports onto the ingress host", async () => {
-    // Single-label scheme (locked 2026-07-20): the console mints
-    // `https://m-<id>.vendo.run` so the existing *.vendo.run Universal SSL
-    // cert covers it; port-prefixed labels stay single-label too
-    // (`https://<port>-m-<id>.vendo.run`).
+  it("url() defaults to the app's $PORT and inserts non-canonical ports before the -m suffix", async () => {
+    // Single-label scheme as SHIPPED by the console (vendo-web #85): the
+    // handle is `https://<id-suffix>-m.vendo.run` (-m is a SUFFIX — CF
+    // routes only allow leading wildcards, `*-m.vendo.run/*`), and other
+    // ports ride `https://<id-suffix>-<port>-m.vendo.run`, matching the
+    // machine-proxy parse `^([a-z0-9]{24})(?:-(port))?-m\.vendo\.run$`.
     const console_ = fakeConsole();
     const adapter = adapterFor(console_);
     const canonical = await adapter.create({ env: { PORT: "8080" } });
-    expect(await canonical.url()).toBe(`https://m-${canonical.id}.vendo.run`);
-    expect(await canonical.url(9090)).toBe(`https://9090-m-${canonical.id}.vendo.run`);
+    const suffix = (id: string) => id.slice(2);
+    expect(await canonical.url()).toBe(`https://${suffix(canonical.id)}-m.vendo.run`);
+    expect(await canonical.url(9090)).toBe(`https://${suffix(canonical.id)}-9090-m.vendo.run`);
 
     // An app listening elsewhere gets its OWN port surface by default, and
     // the $PORT rides refs so a resumed machine keeps it.
     const ported = await adapter.create({ env: { PORT: "9090" } });
-    expect(await ported.url()).toBe(`https://9090-m-${ported.id}.vendo.run`);
+    expect(await ported.url()).toBe(`https://${suffix(ported.id)}-9090-m.vendo.run`);
     const woken = await adapter.resume(await ported.snapshot());
-    expect(await woken.url()).toBe(`https://9090-m-${woken.id}.vendo.run`);
+    expect(await woken.url()).toBe(`https://${suffix(woken.id)}-9090-m.vendo.run`);
+
+    // A handle whose host does not end in a -m label (custom console,
+    // future shapes) falls back to the e2b-style port prefix.
+    const foreignConsole = fakeConsole({ mintUrl: (id) => `https://${id}.machines.example.dev` });
+    const foreign = await adapterFor(foreignConsole).create({ env: { PORT: "8080" } });
+    expect(await foreign.url(9090)).toBe(`https://9090-${foreign.id}.machines.example.dev`);
   });
 
   it("states the applicable allowlist explicitly on every resume — the wire inherits nothing", async () => {

--- a/packages/vendo/src/sandbox.ts
+++ b/packages/vendo/src/sandbox.ts
@@ -372,15 +372,20 @@ export function cloudSandbox(options: CloudSandboxOptions): SandboxAdapter {
       },
       async url(port?: number) {
         // Wave 4 (layer 3) — the browser→box serving path. The handle URL
-        // from create/resume IS the canonical-port ingress (single-label
-        // `m-<id>.vendo.run`, locked 2026-07-20 — sandbox-wire.ts ingress
-        // entry); other ports ride an e2b-style port-prefixed label on the
-        // same host (`<port>-m-<id>.vendo.run`), which stays single-label
-        // under the *.vendo.run Universal SSL cert.
+        // from create/resume IS the canonical-port ingress: single-label
+        // `<id-suffix>-m.vendo.run` as shipped by the console (vendo-web
+        // #85; -m is a SUFFIX because Cloudflare routes only allow leading
+        // wildcards, `*-m.vendo.run/*`). Other ports insert before the
+        // suffix — `<id-suffix>-<port>-m.vendo.run` — matching the
+        // machine-proxy parse (sandbox-wire.ts ingress entry). Hosts
+        // without a -m label (custom consoles) keep the e2b-style prefix.
         const target = port ?? state.port;
         if (target === CLOUD_BOX_PORT) return handle.url;
         const ingress = new URL(handle.url);
-        ingress.host = `${target}-${ingress.host}`;
+        const suffixed = /^(.+)-m(\..+)$/.exec(ingress.host);
+        ingress.host = suffixed === null
+          ? `${target}-${ingress.host}`
+          : `${suffixed[1]}-${target}-m${suffixed[2]}`;
         return ingress.origin;
       },
     } satisfies SandboxMachine & Record<string, unknown> as SandboxMachine;


### PR DESCRIPTION
## What

vendo-web #85 shipped the single-label machine ingress as `<id-suffix>-m.vendo.run` — the `-m` is a **suffix** (Cloudflare worker routes only allow leading wildcards, `*-m.vendo.run/*`), and non-canonical ports ride `<id-suffix>-<port>-m.vendo.run`, per the machine-proxy parse `^([a-z0-9]{24})(?:-([1-9][0-9]{0,4}))?-m\.vendo\.run$`.

Flowlet #431 assumed an `m-<id>.vendo.run` prefix shape and derived port URLs by prefixing the whole host (`9090-<suffix>-m.vendo.run`), which prod's proxy rejects with a 404 — breaking `machine.url(port)` for layer-3 apps on custom ports. Canonical-port URLs were unaffected (the adapter echoes the console-minted handle).

## Changes
- `cloudSandbox` `url(port)` inserts the port before the trailing `-m` label; hosts without a `-m` label (custom consoles) keep the e2b-style prefix fallback.
- Fake console in tests mints the real shipped shape (`<id.slice(2)>-m.vendo.run`); added a fallback-shape case.
- `sandbox-wire.ts` ingress notes and `docs/served-apps.md` corrected to the shipped contract.

## Verification
- TDD: tests updated to the prod wire first, implementation after; `sandbox.test.ts` 24 passed / 1 pre-existing skip.
- Full gate green (`build`/`test`/`typecheck`/`lint`); one redteam away-authority flake under parallel turbo load reruns clean in isolation (known contention gotcha).

Follow-up to the release-gap campaign (#431); wire shape cross-checked against `workers/machine-proxy/src/index.ts` in vendo-web.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cloudSandbox.url(port)` to match the shipped single-label ingress. Ports now insert before the `-m` suffix (e.g., `<id-suffix>-9090-m.vendo.run`), restoring working URLs for non-canonical ports.

- **Bug Fixes**
  - Insert port before `-m` when host ends with `-m.vendo.run`; canonical port unchanged.
  - Keep e2b-style `port-` prefix for hosts without a `-m` label.
  - Updated tests, wire notes, and docs; Cloud venue now marked live on single-label ingress and the `*.m.vendo.run` TLS caveat removed.
  - Resolves machine-proxy 404s caused by the old `port-<host>` derivation.

<sup>Written for commit 1feb0e125993c223f8545a6086e6b374c2f19794. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

