### PR TITLE
cloud: send vendo-default alias to the Cloud gateway (curated model aliases)

### DIFF
--- a/.changeset/cloud-model-aliases.md
+++ b/.changeset/cloud-model-aliases.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/vendo": patch
+---
+
+Vendo Cloud gateway calls now send curated model aliases instead of raw provider ids. The `VENDO_API_KEY` dev-mode rung requests `vendo-default` (Sonnet) by default; `VENDO_CLOUD_MODEL` picks `vendo-fast` (Haiku) or `vendo-strong` (Opus). The box's Cloud inference rung pins `vendo-default` the same way (`VENDO_INFERENCE_MODEL` still overrides). The gateway remaps any non-alias to `vendo-default` (with an `x-vendo-model-remapped` warning header) during a grace window and will reject non-aliases after it. BYO provider keys are unaffected and keep real model ids.

--- a/docs-site/connect/dev-mode.mdx
+++ b/docs-site/connect/dev-mode.mdx
@@ -26,8 +26,11 @@ resolves. Explicit keys always beat implicit ones.
   </Step>
   <Step title="Vendo Cloud key">
     `VENDO_API_KEY` delegates to the Vendo Cloud model gateway (Anthropic
-    Messages wire, served through the stock `@ai-sdk/anthropic` provider). No
-    key on hand? `npx vendo cloud login` mints a free metered dev key.
+    Messages wire, served through the stock `@ai-sdk/anthropic` provider).
+    The gateway serves curated model aliases — `vendo-default` (the default),
+    `vendo-fast`, and `vendo-strong` — pick one with `VENDO_CLOUD_MODEL`;
+    anything else is remapped to `vendo-default` server-side. No key on hand?
+    `npx vendo cloud login` mints a free metered dev key.
   </Step>
   <Step title="None">
     No credential resolves. The wire returns a generic error and the server

--- a/docs-site/reference/environment-variables.mdx
+++ b/docs-site/reference/environment-variables.mdx
@@ -27,6 +27,7 @@ description: "Every environment variable Vendo reads across host process, app ma
 | `VERCEL`, `CF_PAGES`, `AWS_LAMBDA_FUNCTION_NAME` | prevent the default PGlite store from opening on an ephemeral serverless filesystem; pass a Postgres URL instead |
 | `VENDO_STORE_ENCRYPTION_KEY` | 32-byte base64 key the default composition uses to encrypt secret values in `vendo_secrets`; read when no store is passed to `createVendo`. An explicitly configured store ignores it |
 | `VENDO_DEV_CREDENTIAL` | pins a [dev-mode credential ladder](/connect/dev-mode) rung: `env-key:anthropic` (or `:openai` / `:google`), `vendo-cloud`, or `none` |
+| `VENDO_CLOUD_MODEL` | model alias for the Vendo Cloud gateway: `vendo-default` (the default), `vendo-fast`, or `vendo-strong`; read by the `VENDO_API_KEY` dev-mode rung — the gateway remaps any other value to `vendo-default` during the grace window and will reject non-aliases after it |
 | `ANTHROPIC_API_KEY` · `OPENAI_API_KEY` · `GOOGLE_GENERATIVE_AI_API_KEY` | first-preferred rung of the dev-mode credential ladder read by `devModel()`; when set, `@vendoai/vendo/server` uses the matching `@ai-sdk/*@^3` provider installed in your app for the full native tool loop |
 
 `VENDO_TICK_SECRET`, `VENDO_BASE_URL`, `VENDO_POSTHOG_KEY`, and the

--- a/docs/machine-model.md
+++ b/docs/machine-model.md
@@ -242,7 +242,9 @@ headless with its own shell + file tools, working dir `/app`; its auth is the
 same inference door mapped onto plain env (`ANTHROPIC_API_KEY` =
 `VENDO_INFERENCE_KEY`, `ANTHROPIC_BASE_URL` = `VENDO_INFERENCE_URL` — BYO
 Anthropic and the Cloud gateway ride identically), and `VENDO_INFERENCE_MODEL`
-still picks the model (default `claude-sonnet-4-5`).
+still picks the model (default `claude-sonnet-4-5` on BYO; the Cloud rung
+injects the gateway's `vendo-default` alias — the gateway serves only
+`vendo-default` / `vendo-fast` / `vendo-strong`).
 
 "Edit this app" sends one prompt to `POST /agent/task`; the agent writes code,
 installs deps, runs the server, curls its own endpoints, fixes failures, and

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -44,9 +44,10 @@ this order:
    stdin (the browser flow is the separate `vendo cloud device-login`
    command), then mints a metered dev-mode starter key and writes it to
    `.env.local` for you. You never paste a key.
-   Model calls go through the Vendo Cloud model gateway (Anthropic models,
-   served via the installed `@ai-sdk/anthropic`) and meter your dev-mode
-   runs allowance.
+   Model calls go through the Vendo Cloud model gateway (curated aliases:
+   `vendo-default`, `vendo-fast`, `vendo-strong` — pick with
+   `VENDO_CLOUD_MODEL`, served via the installed `@ai-sdk/anthropic`) and
+   meter your dev-mode runs allowance.
 3. Nothing available: chat fails honestly, with exact instructions in the
    server log.
 

--- a/packages/apps/box/README.md
+++ b/packages/apps/box/README.md
@@ -47,7 +47,9 @@ Reads `VENDO_INFERENCE_URL` / `VENDO_INFERENCE_KEY` (BYO Anthropic key, or the
 Cloud metered gateway behind the same two vars) and maps them onto the SDK's
 env auth: `ANTHROPIC_BASE_URL` / `ANTHROPIC_API_KEY`. `VENDO_INFERENCE_MODEL`
 still picks the model (default `claude-sonnet-4-5`; without the pin the SDK
-would default to its `sonnet` alias).
+would default to its `sonnet` alias). On the Cloud rung the host injects
+`vendo-default` — the gateway serves only the curated aliases
+`vendo-default` / `vendo-fast` / `vendo-strong`.
 
 ## Build
 

--- a/packages/vendo/src/box-inference.test.ts
+++ b/packages/vendo/src/box-inference.test.ts
@@ -73,7 +73,7 @@ function captureSandbox(specs: SandboxSpec[]): SandboxAdapter {
  * runner's own environment can never leak into a rung assertion. */
 async function provisionedEnv(rungs: Record<string, string> = {}): Promise<Record<string, string>> {
   vi.stubEnv("VENDO_BASE_URL", "http://box-inference.test");
-  for (const name of ["VENDO_INFERENCE_URL", "VENDO_INFERENCE_KEY", "ANTHROPIC_API_KEY", "VENDO_API_KEY", "VENDO_CLOUD_URL"]) {
+  for (const name of ["VENDO_INFERENCE_URL", "VENDO_INFERENCE_KEY", "VENDO_INFERENCE_MODEL", "ANTHROPIC_API_KEY", "VENDO_API_KEY", "VENDO_CLOUD_URL"]) {
     vi.stubEnv(name, rungs[name] ?? "");
   }
   const store = await tempStore("vendo-box-inference-");
@@ -107,6 +107,18 @@ describe("boxInference ladder (the in-box agent's model door)", () => {
     const env = await provisionedEnv({ VENDO_API_KEY: "vnd_cloud_key" });
     expect(env["VENDO_INFERENCE_URL"]).toBe("https://console.vendo.run/api/v1");
     expect(env["VENDO_INFERENCE_KEY"]).toBe("vnd_cloud_key");
+    // The gateway serves curated aliases only; the box harness's raw claude-*
+    // default would be grace-remapped server-side, so the Cloud rung pins it.
+    expect(env["VENDO_INFERENCE_MODEL"]).toBe("vendo-default");
+  });
+
+  it("VENDO_INFERENCE_MODEL still picks the Cloud alias on the Cloud rung", async () => {
+    const env = await provisionedEnv({
+      VENDO_API_KEY: "vnd_cloud_key",
+      VENDO_INFERENCE_MODEL: "vendo-strong",
+    });
+    expect(env["VENDO_INFERENCE_URL"]).toBe("https://console.vendo.run/api/v1");
+    expect(env["VENDO_INFERENCE_MODEL"]).toBe("vendo-strong");
   });
 
   it("respects VENDO_CLOUD_URL as the gateway base for the Cloud rung", async () => {
@@ -136,6 +148,8 @@ describe("boxInference ladder (the in-box agent's model door)", () => {
     });
     expect(env["VENDO_INFERENCE_URL"]).toBe("https://api.anthropic.com");
     expect(env["VENDO_INFERENCE_KEY"]).toBe("sk-ant-byo");
+    // BYO keeps the box harness's own real-model default — no alias pin.
+    expect(env["VENDO_INFERENCE_MODEL"]).toBeUndefined();
   });
 
   it("no key on any rung leaves the box without an inference door", async () => {

--- a/packages/vendo/src/cli/refine.test.ts
+++ b/packages/vendo/src/cli/refine.test.ts
@@ -234,7 +234,7 @@ describe("resolveRefineModel", () => {
       },
     });
     expect(created).toEqual([{ apiKey: "vnd_refine_key", baseURL: "https://console.vendo.run/api/v1" }]);
-    expect((model as { modelId: string }).modelId).toBe("claude-sonnet-4-6");
+    expect((model as { modelId: string }).modelId).toBe("vendo-default");
   });
 
   it("a provider env key still outranks VENDO_API_KEY on the ladder", async () => {

--- a/packages/vendo/src/dev-creds/model.test.ts
+++ b/packages/vendo/src/dev-creds/model.test.ts
@@ -45,14 +45,16 @@ describe("devModel (env-resolving default model)", () => {
       },
     });
     const callOptions = { prompt: [] };
+    // The gateway serves curated aliases only; vendo-default is the SDK's
+    // default (raw claude-* ids would be grace-remapped server-side).
     expect(await controller.doGenerate(callOptions)).toEqual({
       delegated: "generate",
-      modelId: "claude-sonnet-4-6",
+      modelId: "vendo-default",
       options: callOptions,
     });
     expect(await controller.doStream(callOptions)).toEqual({
       delegated: "stream",
-      modelId: "claude-sonnet-4-6",
+      modelId: "vendo-default",
       options: callOptions,
     });
     // The key rides as the provider apiKey; the base is the production
@@ -62,12 +64,14 @@ describe("devModel (env-resolving default model)", () => {
     ]);
   });
 
-  it("honors VENDO_CLOUD_URL and the anthropic model override on the vendo-cloud rung", async () => {
+  it("honors VENDO_CLOUD_URL and the VENDO_CLOUD_MODEL alias override on the vendo-cloud rung", async () => {
     const seen: Array<{ baseURL: string }> = [];
     const controller = new DevModelController({
       env: {
         VENDO_API_KEY: "vnd_x",
         VENDO_CLOUD_URL: "http://localhost:3001/",
+        VENDO_CLOUD_MODEL: "vendo-strong",
+        // The anthropic env-key override must NOT leak onto the cloud rung.
         VENDO_DEV_ANTHROPIC_MODEL: "claude-opus-4-8",
       },
       importModule: async () => ({
@@ -84,7 +88,7 @@ describe("devModel (env-resolving default model)", () => {
         },
       }),
     });
-    expect(await controller.doGenerate({ prompt: [] })).toEqual({ modelId: "claude-opus-4-8" });
+    expect(await controller.doGenerate({ prompt: [] })).toEqual({ modelId: "vendo-strong" });
     expect(seen).toEqual([{ baseURL: "http://localhost:3001/api/v1" }]);
   });
 

--- a/packages/vendo/src/dev-creds/model.ts
+++ b/packages/vendo/src/dev-creds/model.ts
@@ -21,7 +21,7 @@ import {
  * - VENDO_API_KEY delegates to the Vendo Cloud model gateway: the
  *   host-installed @ai-sdk/anthropic pointed at `<console>/api/v1`, whose
  *   Anthropic-compatible /messages endpoint serves the metered dev-mode
- *   allowance.
+ *   allowance under curated model aliases (vendo-default by default).
  * - nothing available → every call fails with the exact instructions.
  */
 
@@ -68,6 +68,21 @@ const DEFAULT_MODELS: Record<string, { module: string; factory: string; model: s
     modelEnv: "VENDO_DEV_GOOGLE_MODEL",
     install: "npm install ai@^6 @ai-sdk/google@^3",
   },
+};
+
+/** The Cloud gateway serves curated model aliases, never raw provider ids:
+ *  `vendo-default` (Sonnet), `vendo-fast` (Haiku), `vendo-strong` (Opus).
+ *  VENDO_CLOUD_MODEL picks among them; the gateway remaps any other value to
+ *  vendo-default (with an `x-vendo-model-remapped` warning header) during the
+ *  grace window, and will hard-reject non-aliases after it. Same module/
+ *  factory/install as anthropic — the gateway speaks the Anthropic Messages
+ *  wire. */
+const CLOUD_MODEL: (typeof DEFAULT_MODELS)[string] = {
+  module: "@ai-sdk/anthropic",
+  factory: "createAnthropic",
+  model: "vendo-default",
+  modelEnv: "VENDO_CLOUD_MODEL",
+  install: "npm install ai@^6 @ai-sdk/anthropic@^3",
 };
 
 export const NO_CREDENTIAL_MESSAGE =
@@ -180,7 +195,7 @@ export class DevModelController {
       const baseURL = base.endsWith("/api/v1") ? base : `${base}/api/v1`;
       return this.delegate(
         credential,
-        DEFAULT_MODELS["anthropic"]!,
+        CLOUD_MODEL,
         "VENDO_API_KEY",
         { apiKey: this.env["VENDO_API_KEY"]!, baseURL },
         " via the Cloud gateway",

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -1156,10 +1156,14 @@ export function createVendo(config: CreateVendoConfig): Vendo {
     if (cloud !== undefined) {
       // The gateway base mirrors devModel's vendo-cloud rung: `<console>/api/v1`.
       const base = (cloud.baseUrl ?? "https://console.vendo.run").replace(/\/+$/, "");
+      // The gateway serves curated aliases only (vendo-default / vendo-fast /
+      // vendo-strong); the box harness's own default is a raw claude-* id the
+      // gateway would grace-remap, so pin the alias unless the operator chose
+      // a model via VENDO_INFERENCE_MODEL.
       return {
         url: base.endsWith("/api/v1") ? base : `${base}/api/v1`,
         key: cloud.apiKey,
-        ...(model === undefined ? {} : { model }),
+        model: model ?? "vendo-default",
       };
     }
     return undefined;


### PR DESCRIPTION
## What

The Vendo Cloud inference gateway now serves **only curated model aliases**: `vendo-default` (Sonnet 5), `vendo-fast` (Haiku 4.5), `vendo-strong` (Opus 4.8). This PR makes the OSS SDK send those aliases everywhere it talks to the Cloud gateway:

- **devModel's `vendo-cloud` rung** now uses a dedicated cloud spec (same `@ai-sdk/anthropic` module/factory/install — the gateway speaks the Anthropic Messages wire) with default model `vendo-default` and a new `VENDO_CLOUD_MODEL` env override to pick `vendo-fast` / `vendo-strong`. The `VENDO_DEV_ANTHROPIC_MODEL` override stays scoped to the BYO anthropic env-key rung and no longer leaks onto the Cloud rung.
- **boxInference's Cloud rung** (the in-box agent's model door) pins `VENDO_INFERENCE_MODEL=vendo-default` when the operator hasn't chosen a model, so the box harness's raw `claude-*` default never reaches the gateway. Explicit `VENDO_INFERENCE_MODEL` still wins; BYO Anthropic and explicit `VENDO_INFERENCE_URL/KEY` rungs are untouched.
- Docs (`docs-site/connect/dev-mode`, `docs-site/reference/environment-variables`, `docs/quickstart`, `docs/machine-model`, box README) name the three aliases and the `VENDO_CLOUD_MODEL` override.
- Patch changeset for `@vendoai/vendo`.

## Why

Server-side change on the Cloud gateway: non-alias model names are **grace-remapped** to `vendo-default` (with an `x-vendo-model-remapped` warning header) during a grace window, and will be **hard-rejected** after it. Sending aliases now keeps the SDK off the remap path before the rejection lands.

BYO-provider paths (direct Anthropic/OpenAI/Google with the user's own keys — env-key rungs, examples, demo apps, bench harness) keep their real model ids; they never touch the gateway.

## Verification

- [x] `pnpm --filter @vendoai/vendo` vitest run (live tests excluded): 80 files, 844 passed, 1 skipped
- [x] `pnpm --filter @vendoai/vendo typecheck` green
- [ ] Screenshots attached (if UI-affecting) — n/a
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send curated model aliases to the Vendo Cloud gateway and default to `vendo-default`. Add `VENDO_CLOUD_MODEL` to select `vendo-fast` or `vendo-strong`; the box Cloud rung pins `vendo-default` unless `VENDO_INFERENCE_MODEL` is set, and BYO providers are unchanged.

- New Features
  - `devModel` `vendo-cloud` rung uses a dedicated Cloud spec via `@ai-sdk/anthropic`; defaults to `vendo-default` and reads `VENDO_CLOUD_MODEL` (the `VENDO_DEV_ANTHROPIC_MODEL` override no longer affects this rung).
  - Box inference Cloud rung sets `VENDO_INFERENCE_MODEL=vendo-default` when unset; explicit `VENDO_INFERENCE_MODEL` still wins.
  - Docs updated to list aliases and env vars; patch changeset for `@vendoai/vendo`.

<sup>Written for commit b675a669ba5cbcff767caebb29d144a571a85165. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

