### PR TITLE
init: self-contained AI engine ladder — codex driver, npx-fetched @vendoai/engine, gateway fuel

### DIFF
--- a/.github/workflows/corpus-nightly.yml
+++ b/.github/workflows/corpus-nightly.yml
@@ -201,16 +201,44 @@ jobs:
   # runs init's aiPolish pass unconditionally (cli.ts's runRepoThroughLayerOne)
   # and is far cheaper than the full multi-repo layer-2 sweep — these legs
   # exist to prove the rung actually runs, not to score extraction quality.
-  # Both are informational: `continue-on-error: true` at the job level keeps a
-  # red leg from failing the nightly, matching nightly.yml's continue-on-error
-  # precedent for its live legs; and gated on their credential secret so an
-  # unconfigured repo shows a clean, loud skip instead of a manufactured
-  # failure (corpus-nightly.yml's own "Check required secrets" step is a hard
-  # fail because ANTHROPIC_API_KEY is required infrastructure for the main
-  # sweep — these two legs are optional coverage, so a soft skip fits better
-  # here). The gate itself has to be a step (not job-level `if:`) — actionlint
+  #
+  # Liveness, not exit code: `pnpm corpus run` without `--strict` always exits
+  # 0 (scorecard.ts only turns non-zero on `--strict`), and even when a rung
+  # fails outright — e.g. the npx-engine rung 404ing because @vendoai/engine
+  # isn't published yet — extraction.ts's runAiExtraction() catches the error
+  # itself, logs it, and returns { ran: false } without touching init's exit
+  # code (extraction.ts:289-292). So a green corpus-run step here proves
+  # nothing about whether the intended rung actually ran; each leg's "Assert
+  # <rung> actually ran" step below greps the init log it just produced for
+  # two lines extraction.ts is guaranteed to emit: `Reading your product
+  # (<credential label>)…` (logged before the chosen harness's run() is even
+  # called — proves the ladder picked *this* rung and not an earlier one) and
+  # `AI polish applied:` (logged only after that harness's run() returns
+  # successfully — proves it didn't just get picked, it finished). The
+  # assertion step fails loudly when either is missing; job-level
+  # `continue-on-error: true` (see below) keeps that failure informational
+  # instead of reddening the nightly.
+  #
+  # Both legs are gated on their credential secret so an unconfigured repo
+  # shows a clean, loud skip instead of a manufactured failure
+  # (corpus-nightly.yml's own "Check required secrets" step is a hard fail
+  # because ANTHROPIC_API_KEY is required infrastructure for the main sweep —
+  # these two legs are optional coverage, so a soft skip fits better here).
+  # The gate itself has to be a step (not job-level `if:`) — actionlint
   # confirms the `secrets` context is unavailable in a job-level `if:`
   # condition, only step-level ones.
+  #
+  # `continue-on-error: true` sits at the JOB level here, not per-step like
+  # nightly.yml. That's a deliberate difference, not a copy of nightly.yml's
+  # pattern: nightly.yml scopes continue-on-error per-step because its steps
+  # share one job with a final aggregator step that decides real pass/fail.
+  # These two legs are standalone jobs with no `needs:` dependents and no
+  # aggregator — without job-level continue-on-error, an ordinary infra flake
+  # (e.g. `pnpm install` hiccup) would fail the *job*, which fails the whole
+  # workflow run's conclusion even though nothing downstream depends on it.
+  # Job-level continue-on-error is what keeps this leg — CLI install, corpus
+  # run, or the liveness assertion, whichever step trips — informational
+  # end to end.
 
   codex-leg:
     name: "Init engine ladder: codex CLI (informational)"
@@ -260,7 +288,36 @@ jobs:
           # this job's env, and no `claude` binary is installed, so rungs 1-2
           # of the ladder report unavailable and the codex-cli rung
           # (extraction.ts's third rung) is the first one with a credential.
+          # This step alone does NOT prove the codex rung ran — `pnpm corpus
+          # run` without `--strict` always exits 0 — the next step asserts
+          # that from the log content instead.
           pnpm corpus run umami --layer 1 --json
+
+      - name: Assert codex rung actually ran (liveness, not just exit code)
+        if: steps.check.outputs.ready == 'true'
+        run: |
+          log="corpus/.repos/.logs/umami/init.first.log"
+          if [ ! -f "$log" ]; then
+            echo "::error::$log not found — the corpus run step produced no init log to inspect."
+            exit 1
+          fi
+          # extraction.ts logs this line right before calling the chosen
+          # harness's run() — its exact credential label is unique to the
+          # codex-cli rung (no other rung's availability() ever returns
+          # "your OPENAI_API_KEY"), so its presence proves the ladder
+          # actually selected codex-cli and not an earlier rung.
+          if ! grep -q "Reading your product (your OPENAI_API_KEY)" "$log"; then
+            echo "::error::codex-cli rung was never selected — no 'Reading your product (your OPENAI_API_KEY)' line in $log. Check that codex is on PATH and OPENAI_API_KEY authenticates it."
+            exit 1
+          fi
+          # extraction.ts only logs this after the chosen harness's run()
+          # returns successfully — its presence proves the rung didn't just
+          # get picked, it finished.
+          if ! grep -q "AI polish applied:" "$log"; then
+            echo "::error::codex-cli rung was selected but did not complete — no 'AI polish applied:' line in $log. See the log for the actual error."
+            exit 1
+          fi
+          echo "codex-cli rung ran and completed — liveness confirmed."
 
       - name: Publish codex-leg scorecard to job summary
         if: always() && steps.check.outputs.ready == 'true'
@@ -330,11 +387,48 @@ jobs:
           # KNOWN, EXPECTED FAILURE MODE (see install-dx: init-selfcontained-
           # engine plan, Task 5): @vendoai/engine@0.1.0 is not published yet —
           # publishing is blocked on NPM_TOKEN alongside the rest of the
-          # @vendoai/* release train. `npm exec` will 404 until that lands.
-          # continue-on-error above absorbs that so this leg never reds the
-          # nightly; once the package is live this step starts passing for
-          # real with no workflow change required.
+          # @vendoai/* release train, so `npm exec` will 404 until that lands.
+          # That 404 is swallowed by init itself, not by continue-on-error:
+          # npx-engine-harness.ts's run() throws, extraction.ts's
+          # runAiExtraction() catches it, logs "AI polish did not complete
+          # (…)", and returns { ran: false } WITHOUT touching init's exit
+          # code (extraction.ts:289-292) — so this step still exits 0 either
+          # way. The next step's liveness assertion is what actually surfaces
+          # the 404: it greps for the "AI polish applied:" success line, which
+          # will be absent until the package is published, so that assertion
+          # is EXPECTED to fail (informationally — see job-level
+          # continue-on-error above) until then. Once @vendoai/engine is live
+          # on npm, the assertion starts passing for real with no workflow
+          # change required.
           pnpm corpus run umami --layer 1 --json
+
+      - name: Assert npx-engine rung actually ran (liveness, not just exit code)
+        if: steps.check.outputs.ready == 'true'
+        run: |
+          log="corpus/.repos/.logs/umami/init.first.log"
+          if [ ! -f "$log" ]; then
+            echo "::error::$log not found — the corpus run step produced no init log to inspect."
+            exit 1
+          fi
+          # extraction.ts logs this line right before calling the chosen
+          # harness's run() — "via the Vendo engine" only appears in
+          # npx-engine-harness.ts's two credential labels, so its presence
+          # proves the ladder actually reached the fourth rung (npx-engine)
+          # instead of stopping at an earlier one.
+          if ! grep -q "via the Vendo engine" "$log"; then
+            echo "::error::npx-engine rung was never selected — no 'Reading your product (… via the Vendo engine …)' line in $log. Check that no claude/codex binary is on PATH and VENDO_API_KEY is set."
+            exit 1
+          fi
+          # extraction.ts only logs this after the chosen harness's run()
+          # returns successfully. EXPECTED TO FAIL today: @vendoai/engine
+          # is not published yet (NPM_TOKEN-blocked), so `npm exec` 404s and
+          # this line is never written. Once the package is live, this
+          # assertion starts passing for real.
+          if ! grep -q "AI polish applied:" "$log"; then
+            echo "::error::npx-engine rung was selected but did not complete — no 'AI polish applied:' line in $log. Expected until @vendoai/engine@0.1.0 is published to npm (NPM_TOKEN-blocked); see the log for the actual error."
+            exit 1
+          fi
+          echo "npx-engine rung ran and completed — liveness confirmed."
 
       - name: Publish npx-engine-leg scorecard to job summary
         if: always() && steps.check.outputs.ready == 'true'

--- a/.github/workflows/corpus-nightly.yml
+++ b/.github/workflows/corpus-nightly.yml
@@ -182,3 +182,178 @@ jobs:
           # the artifact has been empty since Jul 17 (proven by the diagnostic
           # step on run 29768616216).
           include-hidden-files: true
+
+  # --- Init engine-ladder legs (install-dx: init-selfcontained-engine, Task 6) ---
+  #
+  # extraction.ts's ladder is Agent SDK -> claude CLI -> codex CLI -> npx
+  # engine, and every rung's availability() only reads env vars and PATH
+  # (packages/vendo/src/cli/extract/{claude,claude-cli,codex-cli,npx-engine}-
+  # harness.ts) — there is no separate "force this rung" knob, and none is
+  # added here. Both legs below steer the ladder purely by controlling which
+  # credentials are in the job env and which CLIs get installed on PATH:
+  #   - Neither leg ever sets ANTHROPIC_API_KEY, so the Agent SDK rung (rung 1,
+  #     which resolves @anthropic-ai/claude-agent-sdk straight out of the
+  #     workspace's own node_modules regardless of any CLI install) stays
+  #     unavailable and falls through in both.
+  #   - Neither leg installs the `claude` CLI, so rung 2 (claude-cli) also
+  #     falls through in both.
+  # Both jobs run a single small repo (umami) at layer 1 only: layer 1 already
+  # runs init's aiPolish pass unconditionally (cli.ts's runRepoThroughLayerOne)
+  # and is far cheaper than the full multi-repo layer-2 sweep — these legs
+  # exist to prove the rung actually runs, not to score extraction quality.
+  # Both are informational: `continue-on-error: true` at the job level keeps a
+  # red leg from failing the nightly, matching nightly.yml's continue-on-error
+  # precedent for its live legs; and gated on their credential secret so an
+  # unconfigured repo shows a clean, loud skip instead of a manufactured
+  # failure (corpus-nightly.yml's own "Check required secrets" step is a hard
+  # fail because ANTHROPIC_API_KEY is required infrastructure for the main
+  # sweep — these two legs are optional coverage, so a soft skip fits better
+  # here). The gate itself has to be a step (not job-level `if:`) — actionlint
+  # confirms the `secrets` context is unavailable in a job-level `if:`
+  # condition, only step-level ones.
+
+  codex-leg:
+    name: "Init engine ladder: codex CLI (informational)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+      - name: Check codex credential
+        id: check
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -z "$OPENAI_API_KEY" ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::OPENAI_API_KEY secret is not set — skipping the codex-cli engine-ladder leg (informational, optional coverage)."
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        if: steps.check.outputs.ready == 'true'
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        if: steps.check.outputs.ready == 'true'
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        if: steps.check.outputs.ready == 'true'
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+        if: steps.check.outputs.ready == 'true'
+      - run: pnpm build
+        if: steps.check.outputs.ready == 'true'
+
+      # `npm view @openai/codex` confirms the package (bin: codex); pinned to
+      # match how the claude-code leg above pins its own CLI version.
+      - name: Install codex CLI
+        if: steps.check.outputs.ready == 'true'
+        run: npm install --global @openai/codex@0.144.6
+
+      - name: Run corpus init step against the codex CLI rung
+        if: steps.check.outputs.ready == 'true'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+          # ANTHROPIC_API_KEY and VENDO_API_KEY are deliberately absent from
+          # this job's env, and no `claude` binary is installed, so rungs 1-2
+          # of the ladder report unavailable and the codex-cli rung
+          # (extraction.ts's third rung) is the first one with a credential.
+          pnpm corpus run umami --layer 1 --json
+
+      - name: Publish codex-leg scorecard to job summary
+        if: always() && steps.check.outputs.ready == 'true'
+        run: |
+          if [ -f corpus/.repos/.logs/scorecard.md ]; then
+            cat corpus/.repos/.logs/scorecard.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No scorecard produced (codex leg may have failed before scoring)." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload codex-leg logs
+        if: always() && steps.check.outputs.ready == 'true'
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: corpus-codex-leg-logs
+          path: |
+            corpus/.repos/.logs/scorecard.json
+            corpus/.repos/.logs/scorecard.md
+            corpus/.repos/.logs/**/*.log
+          retention-days: 14
+          if-no-files-found: warn
+          include-hidden-files: true
+
+  npx-engine-leg:
+    name: "Init engine ladder: npx @vendoai/engine (informational)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+      - name: Check Vendo Cloud credential
+        id: check
+        env:
+          VENDO_API_KEY: ${{ secrets.VENDO_API_KEY }}
+        run: |
+          if [ -z "$VENDO_API_KEY" ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::VENDO_API_KEY secret is not set — skipping the npx-engine engine-ladder leg (informational, optional coverage)."
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        if: steps.check.outputs.ready == 'true'
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        if: steps.check.outputs.ready == 'true'
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        if: steps.check.outputs.ready == 'true'
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+        if: steps.check.outputs.ready == 'true'
+      - run: pnpm build
+        if: steps.check.outputs.ready == 'true'
+
+      - name: Run corpus init step against the npx engine rung
+        if: steps.check.outputs.ready == 'true'
+        env:
+          # Vendo Cloud key only (no ANTHROPIC_API_KEY): npx-engine-harness.ts's
+          # availability() accepts either an own ANTHROPIC_API_KEY or
+          # VENDO_API_KEY (gateway fuel) — using only the latter here is what
+          # actually forces the ladder down to the fourth rung instead of
+          # stopping at rung 1 (Agent SDK also honors a bare ANTHROPIC_API_KEY).
+          VENDO_API_KEY: ${{ secrets.VENDO_API_KEY }}
+        run: |
+          set -euo pipefail
+          # KNOWN, EXPECTED FAILURE MODE (see install-dx: init-selfcontained-
+          # engine plan, Task 5): @vendoai/engine@0.1.0 is not published yet —
+          # publishing is blocked on NPM_TOKEN alongside the rest of the
+          # @vendoai/* release train. `npm exec` will 404 until that lands.
+          # continue-on-error above absorbs that so this leg never reds the
+          # nightly; once the package is live this step starts passing for
+          # real with no workflow change required.
+          pnpm corpus run umami --layer 1 --json
+
+      - name: Publish npx-engine-leg scorecard to job summary
+        if: always() && steps.check.outputs.ready == 'true'
+        run: |
+          if [ -f corpus/.repos/.logs/scorecard.md ]; then
+            cat corpus/.repos/.logs/scorecard.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No scorecard produced (npm-engine leg may have failed before scoring — expected until @vendoai/engine is published)." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload npx-engine-leg logs
+        if: always() && steps.check.outputs.ready == 'true'
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: corpus-npx-engine-leg-logs
+          path: |
+            corpus/.repos/.logs/scorecard.json
+            corpus/.repos/.logs/scorecard.md
+            corpus/.repos/.logs/**/*.log
+          retention-days: 14
+          if-no-files-found: warn
+          include-hidden-files: true

--- a/corpus/harness/src/ai/matrix.ts
+++ b/corpus/harness/src/ai/matrix.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { realpathSync } from "node:fs";
 import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -186,7 +187,22 @@ export function agentSdkDir(reposDir: string): string {
 
 function resolveAgentSdk(sdkDir: string): string | null {
   try {
-    return createRequire(path.join(sdkDir, "package.json")).resolve(AGENT_SDK_PACKAGE);
+    const resolved = createRequire(path.join(sdkDir, "package.json")).resolve(AGENT_SDK_PACKAGE);
+    // Node's resolver also walks NODE_PATH / GLOBAL_FOLDERS (Vitest injects
+    // pnpm's flat virtual-store `node_modules` there), which would make any
+    // copy of the SDK hoisted anywhere in the workspace resolve here too —
+    // exactly the ambient-resolution hazard called out above. Only accept a
+    // resolution that actually lives under the cache dir this function
+    // provisions; anything else is not "resolvable from the cache", so
+    // report it as absent and let ensureAgentSdk provision its own copy.
+    // Compare real paths — `resolved` is symlink-resolved by Node, so a
+    // sdkDir that is itself reached through a symlink (e.g. macOS's
+    // /var -> /private/var) must be realpath'd too before the containment
+    // check, or a genuine in-cache resolution looks like it escaped sdkDir.
+    const realSdkDir = realpathSync(sdkDir);
+    const relativeToSdkDir = path.relative(realSdkDir, resolved);
+    if (relativeToSdkDir.startsWith("..") || path.isAbsolute(relativeToSdkDir)) return null;
+    return resolved;
   } catch {
     return null;
   }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -66,15 +66,43 @@ workspace page) against scripted data first — no model key, no wiring — run
 Static extraction gets the facts; a coding agent adds the judgment. The
 deterministic exact pass always reads conventional CSS tokens into
 `theme.json` first; whatever slots it can't read ride this same
-consent-gated pass. During an interactive `vendo init`, when the `claude` CLI
-is on PATH (or `@anthropic-ai/claude-agent-sdk` is resolvable) and a Claude
-Code login or `ANTHROPIC_API_KEY` exists, init asks once for consent and lets
-the agent read your codebase (read-only: Read/Glob/Grep; source goes to your
-model provider under your own account). Nothing needs installing in your app
-for this pass: no `@ai-sdk/anthropic`, no bundled SDK. It drafts
+consent-gated pass. During an interactive `vendo init`, init asks once for
+consent and lets the agent read your codebase (read-only: Read/Glob/Grep;
+source goes to your model provider under your own account). It drafts
 task-oriented tool descriptions, reviews risk grades, wakes statically
 unclassifiable tools with reasoning, fills theme slots the exact pass
-couldn't resolve, and writes the product brief.
+couldn't resolve, and writes the product brief. Nothing needs installing in
+your app for any of this: no `@ai-sdk/anthropic`, no bundled SDK.
+
+### Which engine runs it
+
+Init resolves an engine for the pass through an ordered ladder — first
+available rung wins, a rung that's missing or unauthenticated is skipped and
+the next one is tried:
+
+1. The Claude Agent SDK, when resolvable in your app (a Claude Code login or
+   `ANTHROPIC_API_KEY` pays).
+2. The `claude` CLI on PATH, driven headless and read-only — same
+   credentials, plus corporate-gateway setups (`ANTHROPIC_AUTH_TOKEN`,
+   `CLAUDE_CODE_OAUTH_TOKEN`, or a custom `ANTHROPIC_BASE_URL`). Your own
+   endpoint is always honored, never overridden by anything below.
+3. The `codex` CLI on PATH, driven headless and read-only. A ChatGPT login
+   or `OPENAI_API_KEY` pays.
+4. `@vendoai/engine`, fetched on the fly with `npm exec` at a pinned
+   version — real Claude Code, no local install required. This is a
+   one-time ~250MB download (npm caches it, so later runs skip it); init
+   prints the download notice before it starts. `ANTHROPIC_API_KEY` pays,
+   or `VENDO_API_KEY` through the Vendo Cloud model gateway.
+
+When none of the four resolves, init still completes — extraction defaults
+stand — and prints every rung's remedy. If a chosen rung fails partway
+(a killed fetch, a 404, a network error), init reports it and leaves
+defaults in place; re-run `vendo init` to retry.
+
+Init-time inference through the Vendo Cloud gateway meters normally on paid
+plans; free-plan orgs get a clear refusal pointing you at your own Claude
+Code login or API key, or an upgrade. Your own credentials always work, on
+every plan.
 
 The pass runs as a staged pipeline, not one shot: a cheap survey maps the
 repo and groups tools into surfaces (`VENDO_EXTRACTION_SURVEY_MODEL` can

--- a/docs/superpowers/plans/2026-07-20-init-selfcontained-engine.md
+++ b/docs/superpowers/plans/2026-07-20-init-selfcontained-engine.md
@@ -88,6 +88,14 @@
 
 ## Follow-ups
 
+- Scope model/gateway credentials inside the corpus harness to the init child
+  only: today the harness's clone bootstrap (third-party `pnpm install`,
+  lifecycle scripts) inherits the step env, so `ANTHROPIC_API_KEY` (pre-existing,
+  ai-matrix legs) and now `VENDO_API_KEY` (npx-engine leg) are visible to
+  untrusted install scripts. Both keys are metered/revocable CI credentials and
+  the exposure class predates this program, but the harness should strip them
+  from bootstrap commands and inject them only into the `vendo init` subprocess.
+  (Raised by cubic on PR #457.)
 - Remove the corpus harness's `@ai-sdk/anthropic` injection into cloned repos
   (see `corpus/harness` bootstrap/injection code) once the npx-engine rung is
   proven live in a nightly run (`npx-engine-leg` in

--- a/docs/superpowers/plans/2026-07-20-init-selfcontained-engine.md
+++ b/docs/superpowers/plans/2026-07-20-init-selfcontained-engine.md
@@ -1,0 +1,87 @@
+# Init Self-Contained Engine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make init's consented AI pass self-contained (codex driver + npx-fetched Claude Code engine) and enforce the free-plan no-gateway-tokens policy server-side.
+
+**Spec:** `docs/superpowers/specs/2026-07-20-init-builtin-agent-harness-design.md`
+
+**Architecture:** Everything extends the theme-detect lane's `ExtractionHarness` seam (`packages/vendo/src/cli/extract/harness.ts`: `id` / `availability` / `run`). Two new harnesses join the ladder (codex CLI, npx engine); a gateway-fuel env layer makes `VENDO_API_KEY` usable as Claude Code credentials; the console refuses init-tagged inference for free orgs. Two repos, three PRs: flowlet harness work, flowlet engine package, vendo-web policy.
+
+**Preconditions (do not start before):**
+- Theme-detect lane's harness/stage tasks and api-detect lane's held init-wiring tasks are on `main` (the harness files this plan touches live on `yousefh409/theme-detect` today).
+- Coordinate with the theme-detect session before touching `packages/vendo/src/cli/extract/*` (reply channel in that lane's memory).
+- Publishing `@vendoai/engine` stays blocked on NPM_TOKEN with every other release item; all other tasks can land before publish.
+
+---
+
+## Part A — flowlet: harnesses and ladder (PR 1)
+
+### Task 1: Codex CLI harness
+
+**Files:** create `packages/vendo/src/cli/extract/codex-cli-harness.ts` + its test file, mirroring `claude-cli-harness.ts` and its scripted-spawn test seam.
+
+- [ ] Write failing tests first: availability (codex on PATH and authenticated; absent; present-but-unauthenticated returns null so the ladder falls through), headless run happy path, artifact parsed from machine-readable output, non-zero exit surfaces a degradation error. Use a scripted spawn seam; no real codex in unit tests.
+- [ ] Implement: availability probe, non-interactive `codex exec` invocation with read-only sandbox flags, final-message capture, reuse of the existing `parseArtifact` helper. Credential story: ChatGPT login or `OPENAI_API_KEY`.
+- [ ] Verify the suite passes, then commit.
+
+### Task 2: Engine ladder with fall-through
+
+**Files:** modify the harness selection in `packages/vendo/src/cli/extract/index.ts` (and its tests).
+
+- [ ] Tests first: resolution order is Agent SDK → claude CLI → codex CLI → npx engine; a rung whose availability is null (missing or unauthenticated) falls through; the consented-but-nothing-available skip message names every rung tried and the exact fixes (per spec's degradation section).
+- [ ] Implement the ordered ladder; keep each harness's availability label in the skip message.
+- [ ] Verify, commit.
+
+### Task 3: Gateway fuel for Claude Code rungs
+
+**Files:** new small module under `packages/vendo/src/cli/extract/` for credential/env composition + tests; wire into the claude-CLI and npx-engine harness launches.
+
+- [ ] Tests first: when own Anthropic credentials exist, env passes through untouched; when absent but `VENDO_API_KEY` is set, the launch env carries the gateway base URL (from `resolveCloudBaseUrl`), the key as the auth token, and the init-purpose tag header (Claude Code's custom-headers mechanism); a structured gateway refusal is relayed to the user verbatim, not swallowed.
+- [ ] Implement; the tag header name is one shared constant exported for the console tests to mirror.
+- [ ] Verify, commit.
+
+### Task 4: npx engine harness
+
+**Files:** create `packages/vendo/src/cli/extract/npx-engine-harness.ts` + tests.
+
+- [ ] Tests first (scripted exec seam, no real download): availability requires a usable credential (own key or `VENDO_API_KEY`) and reports the download-size notice in its label; run invokes `npm exec` on `@vendoai/engine` at an exact pinned version constant; the serialized job (instructions, root, artifact expectations) round-trips; offline/exec failure degrades to the honest skip.
+- [ ] Implement, including the visible first-run download notice through `onProgress`.
+- [ ] Verify, commit. Browser/live proof is not applicable; this is CLI-only.
+
+## Part B — flowlet: the engine package (PR 2)
+
+### Task 5: `@vendoai/engine` package
+
+**Files:** create `packages/engine/` (package.json, thin runner entry, tests); add to the workspace build and the dependency guard's layering config; add a publish-pipeline entry alongside the other `@vendoai/*` packages.
+
+- [ ] Tests first: the runner accepts a serialized harness job on stdin, executes it through the Agent SDK seam (scripted in tests), writes the final text to stdout, exits non-zero on failure with a structured error; settings are isolated so the dev's personal Claude Code config cannot leak in; tool policy is read-only rooted at the given directory.
+- [ ] Implement the runner with `@anthropic-ai/claude-agent-sdk` as its only substantial dependency. No init logic, no vendo imports beyond shared types — the package stays command-agnostic per the spec.
+- [ ] One gated live test (env-flagged, like `extract-theme.live.test.ts`) proving a real end-to-end stage run through the packed package.
+- [ ] Verify `pnpm build && pnpm test && pnpm typecheck && pnpm lint`, commit.
+
+### Task 6: Corpus legs
+
+**Files:** corpus workflow config additions only; do not touch harness bootstrap/injection code (another lane's surface) beyond what its owner agrees to.
+
+- [ ] Add informational codex and npx-engine legs to the nightly matrix, gated on their credentials being present.
+- [ ] File (not do) the follow-up: remove the harness's `@ai-sdk/anthropic` injection once the engine rung is live in a nightly.
+- [ ] Commit.
+
+## Part C — vendo-web: free-plan policy (PR 3, can land any time before Part A ships)
+
+### Task 7: Init inference policy in the gateway
+
+**Files:** modify `apps/console/lib/api/messages-gateway.ts`, the plans data (migration adding the per-plan init-inference flag: free refuses, paid allows; org override via the existing `subscriptions.overrides`), plus `apps/console/tests/` coverage.
+
+- [ ] Tests first: the policy matrix (free/paid × tagged/untagged × override set/unset); refusal is a structured error with the honest upgrade-or-bring-your-own message; allowed init traffic still meters `llm_tokens` normally; untagged traffic is completely unaffected.
+- [ ] Implement: read the tag header (same constant as Task 3), resolve plan via the existing plan-resolution path, check the flag, refuse or pass through.
+- [ ] Verify console suite green, commit.
+
+---
+
+## Verification (whole program)
+
+- Both repos: full green gates (`pnpm build && pnpm test && pnpm typecheck && pnpm lint`).
+- Live proof for the PR: one recorded init run on a clean machine profile with no claude/codex on PATH and a paid-org `VENDO_API_KEY` (download notice → engine runs → metered), and one with a free-org key (server refusal relayed). CLI transcript evidence in the PR; no UI change, so no screenshots needed.
+- Docs sync after landing: init docs mention the auto-fetched engine, its size, cache location, and the free-plan policy.

--- a/docs/superpowers/plans/2026-07-20-init-selfcontained-engine.md
+++ b/docs/superpowers/plans/2026-07-20-init-selfcontained-engine.md
@@ -64,9 +64,9 @@
 
 **Files:** corpus workflow config additions only; do not touch harness bootstrap/injection code (another lane's surface) beyond what its owner agrees to.
 
-- [ ] Add informational codex and npx-engine legs to the nightly matrix, gated on their credentials being present.
-- [ ] File (not do) the follow-up: remove the harness's `@ai-sdk/anthropic` injection once the engine rung is live in a nightly.
-- [ ] Commit.
+- [x] Add informational codex and npx-engine legs to the nightly matrix, gated on their credentials being present.
+- [x] File (not do) the follow-up: remove the harness's `@ai-sdk/anthropic` injection once the engine rung is live in a nightly.
+- [x] Commit.
 
 ## Part C — vendo-web: free-plan policy (PR 3, can land any time before Part A ships)
 
@@ -85,3 +85,13 @@
 - Both repos: full green gates (`pnpm build && pnpm test && pnpm typecheck && pnpm lint`).
 - Live proof for the PR: one recorded init run on a clean machine profile with no claude/codex on PATH and a paid-org `VENDO_API_KEY` (download notice → engine runs → metered), and one with a free-org key (server refusal relayed). CLI transcript evidence in the PR; no UI change, so no screenshots needed.
 - Docs sync after landing: init docs mention the auto-fetched engine, its size, cache location, and the free-plan policy.
+
+## Follow-ups
+
+- Remove the corpus harness's `@ai-sdk/anthropic` injection into cloned repos
+  (see `corpus/harness` bootstrap/injection code) once the npx-engine rung is
+  proven live in a nightly run (`npx-engine-leg` in
+  `.github/workflows/corpus-nightly.yml`, Task 6) — the injection was a
+  stand-in for host-side model access that the engine rung now covers, but
+  pulling it before the rung has nightly evidence would remove coverage with
+  nothing proven to replace it. Filed, not done, by Task 6.

--- a/docs/superpowers/specs/2026-07-20-init-builtin-agent-harness-design.md
+++ b/docs/superpowers/specs/2026-07-20-init-builtin-agent-harness-design.md
@@ -1,11 +1,13 @@
-# Init built-in agent harness: self-contained AI pass, codex driver, free-plan gateway policy
+# Init self-contained AI pass: npx engine package, codex driver, free-plan gateway policy
 
 **Date:** 2026-07-20
-**Status:** Approved (Yousef, 2026-07-20)
-**Extends:** `2026-07-20-init-ai-unification-design.md` (theme-detect lane). Nothing
-in that spec is reversed: the devModel ladder still leaves init, the theme
-structured call still dies, the Agent SDK and `claude -p` harnesses stay as
-built. This spec adds engines and the credential/policy story around them.
+**Status:** Approved (Yousef, 2026-07-20; engine revised same day from plain-SDK
+loop to npx-fetched Agent SDK after review)
+**Extends:** `2026-07-20-init-ai-unification-design.md` (theme-detect lane).
+Nothing in that spec is reversed except the shape of the last engine rung: the
+devModel ladder still leaves init, the theme structured call still dies, the
+Agent SDK and `claude -p` harnesses stay as built. This spec adds the
+self-contained engine, the codex driver, and the credential/policy story.
 
 ## Problem
 
@@ -14,41 +16,57 @@ theme stage) runs only when the dev's environment happens to carry an engine:
 a resolvable Agent SDK or a `claude` binary on PATH. Two gaps:
 
 1. **Not self-contained.** A dev with neither gets an honest skip. Everything
-   the CLI needs should ship with the CLI; the user should never have to
-   install something else to get the pass. Shipping the Agent SDK stays
-   vetoed (measured ~245 MB per host install, zod-4 peer conflict).
+   the CLI needs should come with the CLI; the user must never be told to
+   install something else. But shipping the Agent SDK as a normal dependency
+   stays off the table: measured ~245 MB per host install (its platform
+   packages bundle the full Claude Code binary; `query()` hard-requires it),
+   and vendo is a library inside the host app, so its dependencies land in
+   every install, CI run, and production image.
 2. **Free-plan token policy.** The Vendo Cloud gateway must not fund init
-   inference for free orgs. Free plan: the dev brings their own Claude Code
-   or API key. Paid plans: gateway inference during init is allowed and
-   metered normally. The policy must be changeable without a CLI release.
+   inference for free orgs. Free plan: the dev brings their own Claude Code,
+   codex, or API key. Paid plans: gateway inference during init is allowed
+   and metered normally. The policy must be changeable without a CLI release.
 
 ## Decisions (locked)
 
-1. **The vendo CLI ships a built-in agent engine.** The official Anthropic
-   SDK (`@anthropic-ai/sdk`, a few MB, a real dependency of the CLI, never
-   resolved from the host) running its agentic tool loop with vendo-provided
-   read-only repo tools (Read/Glob/Grep equivalents). Not to be confused
-   with `@anthropic-ai/claude-agent-sdk` (the Agent SDK), which is Claude
-   Code itself packaged programmatically: same model either way, but the
-   built-in engine carries our minimal tool scaffolding instead of Claude
-   Code's full harness, which is what the 245 MB buys. It implements the same
-   `ExtractionHarness` interface: same stages, same prompts, same consent
-   gate, same artifact trail. No ai-sdk (`ai` / `@ai-sdk/*`) anywhere in init.
-2. **Codex driver ships in the same program.** A harness that drives the
+1. **The heavy engine ships as a separate npx-fetched package, not a
+   dependency.** A generic engine package (working name `@vendoai/engine`)
+   carries `@anthropic-ai/claude-agent-sdk` as its only substantial
+   dependency and exposes a thin runner: harness job in, stage artifacts
+   out. When init needs it, the CLI invokes it via `npm exec` at a pinned
+   version; npm caches it on the dev's machine (~245 MB, first run only,
+   with a visible download notice). The host app's package.json,
+   node_modules, builds, and CI never see it. The npx isolation also
+   sidesteps the SDK's zod-4 peer conflict with our zod-3 pins.
+2. **The engine package is command-agnostic.** It contains no init logic:
+   the harness interface, engine ladder, prompts, and stage logic all live
+   in the vendo package. Init is the first caller; `refine`, future
+   `sync`/drift, or any later AI command reuse the same ladder and the same
+   cached download. Out of scope now: this program wires init only;
+   `resolveRefineModel` stays untouched (boundary locked in the unification
+   spec).
+3. **No plain-SDK loop.** The earlier idea of a hand-rolled
+   `@anthropic-ai/sdk` tool loop is dropped: the engine everywhere is real
+   Claude Code (dev's own binary or the npx-fetched Agent SDK), so there is
+   one prompt surface, one quality bar, and no DIY agent scaffolding to
+   maintain.
+4. **Codex driver ships in the same program.** A harness that drives the
    dev's own `codex` CLI headless (`codex exec`, read-only sandbox), paid by
-   their ChatGPT login or `OPENAI_API_KEY`. Sits after claude in the ladder.
-3. **Engine ladder (automatic, first available wins):**
-   Agent SDK if resolvable -> `claude` on PATH -> `codex` on PATH ->
-   built-in engine. A rung that is present but cannot authenticate (for
-   example claude installed but logged out with no key) falls through to
-   the next rung. The built-in engine is always available; only its fuel
-   can be missing.
-4. **Built-in engine credentials:** `ANTHROPIC_API_KEY` directly, else
-   `VENDO_API_KEY` through the console's Anthropic-compatible gateway.
-   Neither present: the existing honest skip (a nothing-to-pay-with problem,
-   not an install problem).
-5. **Free-plan enforcement is server-side only.** Init tags its gateway
-   traffic (request header carried through the Anthropic client). The
+   their ChatGPT login or `OPENAI_API_KEY`. Supported only once corpus runs
+   validate extraction quality on it; scores stay informational.
+5. **Engine ladder (automatic, first available wins):** Agent SDK if already
+   resolvable -> `claude` on PATH -> `codex` on PATH -> npx engine package
+   (auto-download). A rung that is present but cannot authenticate (for
+   example claude installed but logged out with no key) falls through to the
+   next rung. The npx rung fails only offline or credential-less, which
+   degrades to the honest skip.
+6. **Engine credentials:** the dev's own Claude Code login or
+   `ANTHROPIC_API_KEY`; else `VENDO_API_KEY` through the console's
+   Anthropic-compatible gateway (Claude Code honors `ANTHROPIC_BASE_URL` and
+   `ANTHROPIC_AUTH_TOKEN`, so gateway fuel works for both the PATH claude
+   rung and the npx engine).
+7. **Free-plan enforcement is server-side only.** Init tags its gateway
+   traffic (request header, via Claude Code's custom-headers support). The
    gateway refuses init-tagged inference for free orgs with an honest
    message (use your own Claude Code or API key, or upgrade); paid orgs pass
    through and meter `llm_tokens` as normal. The policy lives as a per-plan
@@ -58,64 +76,67 @@ a resolvable Agent SDK or a `claude` binary on PATH. Two gaps:
 
 ## Design
 
-### Built-in engine
+### Engine package
 
-Another `ExtractionHarness` implementation inside the vendo package. The
-Anthropic SDK tool-runner loop executes a stage: stage instructions in, the
-model iterates with the read-only repo tools, structured stage artifact out,
-validated by the same zod schemas and apply guards as the other harnesses.
-Tool surface is read-only and rooted at the host app directory. Base URL and
-API key come from the credential resolution above; pointing the same client
-at Anthropic or at the console gateway is the only difference between the
-two fuels.
+A new published package whose runner accepts a serialized harness job
+(stage instructions, tool policy, artifact schema reference, credential env)
+and executes it through the Agent SDK, returning stage artifacts on stdout
+or the artifact dir. Pinned invocation from the CLI (exact version, not a
+range). Read-only tool policy rooted at the host app directory, isolated
+settings so the dev's personal Claude Code config does not leak in. The
+download moment is explicit in init output: what is being fetched, how big,
+that it is cached for next time.
 
 ### Codex driver
 
 Mirrors the claude PATH-CLI harness: availability probe on PATH, headless
 non-interactive run, read-only tool policy, artifact parsed from the
-machine-readable output. Extraction prompts are Anthropic-tuned; corpus runs
-must validate quality on codex before the rung counts as supported, and the
-rubric stays informational.
+machine-readable output. Prompt-portability risk is real (prompts are
+Anthropic-tuned); the corpus codex leg decides when the rung counts as
+supported.
 
 ### Console gateway change (vendo-web)
 
 The messages gateway learns to distinguish init-tagged requests. Resolution
-order: valid key -> org plan -> init policy flag -> allow (meter normally) or
-refuse with a structured error the CLI relays verbatim. Default flags: free
-refuses, paid plans allow. Changing the policy is a console data change.
+order: valid key -> org plan -> init policy flag -> allow (meter normally)
+or refuse with a structured error the CLI relays verbatim. Default flags:
+free refuses, paid plans allow. Changing the policy is a console data
+change, no CLI release.
 
 ### Degradation (visible, never silent)
 
 - No consent: unchanged (exact reads, derivations, defaults).
-- Consent, no engine credential: honest skip naming every rung tried and the
-  exact fixes (install/login claude or codex, set `ANTHROPIC_API_KEY`, or
-  `vendo cloud login` on a paid org).
+- Consent, offline or no credential on any rung: honest skip naming every
+  rung tried and the exact fixes (log into claude or codex, set
+  `ANTHROPIC_API_KEY`, or `vendo cloud login` on a paid org).
 - Free org over the gateway: the server refusal, relayed verbatim.
 - Stage failure: pipeline degradation note; deterministic results stand.
 
 ### Tests and corpus
 
-- Unit: engine ladder resolution order, built-in loop through a scripted
-  wire seam, codex output parsing, credential fallbacks, refusal relay.
+- Unit: engine ladder resolution order (including auth fall-through), npx
+  invocation seam (scripted, no real download), codex output parsing,
+  credential fallbacks, refusal relay.
 - Console: gateway policy matrix (free/paid x tagged/untagged), meter still
   ingests on allowed init traffic.
-- Corpus: existing claude-path baselines unchanged; add a codex leg and a
-  built-in-engine leg (the harness's `@ai-sdk/anthropic` injection becomes
-  removable once the built-in engine ships, since the CLI now carries its
-  own client). Scores stay informational.
+- Corpus: existing claude-path baselines unchanged; add a codex leg and an
+  npx-engine leg. The harness's `@ai-sdk/anthropic` injection becomes
+  removable once the engine rung ships. Scores stay informational.
 
 ## Sequencing
 
 Rides after the theme-detect lane's harness/stage work and the api-detect
 lane's held init-wiring tasks land on main; the console change is a separate
-vendo-web PR that can land any time before the CLI rungs ship. Coordinate
-with the theme-detect lane before touching harness files on its surface.
+vendo-web PR that can land any time before the CLI rungs ship. The engine
+package needs a publish pipeline entry (blocked with everything else on
+NPM_TOKEN). Coordinate with the theme-detect lane before touching harness
+files on its surface.
 
 ## Accepted costs
 
-- The vendo package grows by the Anthropic SDK (a few MB, bounded, audited).
-- Built-in engine quality may trail Claude Code on repo navigation; corpus
-  measures the gap and the ladder prefers real agent CLIs when present.
+- First npx run downloads ~245 MB (network required, visible notice);
+  offline devs keep the honest skip. Nothing ships in host installs.
+- A second published package to version, pin, and release.
 - Codex support carries prompt-portability risk; gated on corpus evidence.
 - Paid orgs can spend metered `llm_tokens` on init (their choice, honest
   meter); free orgs get a refusal instead of a surprise spend.

--- a/docs/superpowers/specs/2026-07-20-init-builtin-agent-harness-design.md
+++ b/docs/superpowers/specs/2026-07-20-init-builtin-agent-harness-design.md
@@ -1,0 +1,117 @@
+# Init built-in agent harness: self-contained AI pass, codex driver, free-plan gateway policy
+
+**Date:** 2026-07-20
+**Status:** Approved (Yousef, 2026-07-20)
+**Extends:** `2026-07-20-init-ai-unification-design.md` (theme-detect lane). Nothing
+in that spec is reversed: the devModel ladder still leaves init, the theme
+structured call still dies, the Agent SDK and `claude -p` harnesses stay as
+built. This spec adds engines and the credential/policy story around them.
+
+## Problem
+
+After init AI unification, the consented AI pass (staged tool extraction +
+theme stage) runs only when the dev's environment happens to carry an engine:
+a resolvable Agent SDK or a `claude` binary on PATH. Two gaps:
+
+1. **Not self-contained.** A dev with neither gets an honest skip. Everything
+   the CLI needs should ship with the CLI; the user should never have to
+   install something else to get the pass. Shipping the Agent SDK stays
+   vetoed (measured ~245 MB per host install, zod-4 peer conflict).
+2. **Free-plan token policy.** The Vendo Cloud gateway must not fund init
+   inference for free orgs. Free plan: the dev brings their own Claude Code
+   or API key. Paid plans: gateway inference during init is allowed and
+   metered normally. The policy must be changeable without a CLI release.
+
+## Decisions (locked)
+
+1. **The vendo CLI ships a built-in agent engine.** The official Anthropic
+   SDK (`@anthropic-ai/sdk`, a few MB, a real dependency of the CLI, never
+   resolved from the host) running its agentic tool loop with vendo-provided
+   read-only repo tools (Read/Glob/Grep equivalents). It implements the same
+   `ExtractionHarness` interface: same stages, same prompts, same consent
+   gate, same artifact trail. No ai-sdk (`ai` / `@ai-sdk/*`) anywhere in init.
+2. **Codex driver ships in the same program.** A harness that drives the
+   dev's own `codex` CLI headless (`codex exec`, read-only sandbox), paid by
+   their ChatGPT login or `OPENAI_API_KEY`. Sits after claude in the ladder.
+3. **Engine ladder (automatic, first available wins):**
+   Agent SDK if resolvable -> `claude` on PATH -> `codex` on PATH ->
+   built-in engine. A rung that is present but cannot authenticate (for
+   example claude installed but logged out with no key) falls through to
+   the next rung. The built-in engine is always available; only its fuel
+   can be missing.
+4. **Built-in engine credentials:** `ANTHROPIC_API_KEY` directly, else
+   `VENDO_API_KEY` through the console's Anthropic-compatible gateway.
+   Neither present: the existing honest skip (a nothing-to-pay-with problem,
+   not an install problem).
+5. **Free-plan enforcement is server-side only.** Init tags its gateway
+   traffic (request header carried through the Anthropic client). The
+   gateway refuses init-tagged inference for free orgs with an honest
+   message (use your own Claude Code or API key, or upgrade); paid orgs pass
+   through and meter `llm_tokens` as normal. The policy lives as a per-plan
+   flag in the console's plans data, per-org overridable via the existing
+   subscription overrides. No client-side plan or entitlement checks, per
+   the locked Cloud rule (gating is valid key + meter, nothing else).
+
+## Design
+
+### Built-in engine
+
+Another `ExtractionHarness` implementation inside the vendo package. The
+Anthropic SDK tool-runner loop executes a stage: stage instructions in, the
+model iterates with the read-only repo tools, structured stage artifact out,
+validated by the same zod schemas and apply guards as the other harnesses.
+Tool surface is read-only and rooted at the host app directory. Base URL and
+API key come from the credential resolution above; pointing the same client
+at Anthropic or at the console gateway is the only difference between the
+two fuels.
+
+### Codex driver
+
+Mirrors the claude PATH-CLI harness: availability probe on PATH, headless
+non-interactive run, read-only tool policy, artifact parsed from the
+machine-readable output. Extraction prompts are Anthropic-tuned; corpus runs
+must validate quality on codex before the rung counts as supported, and the
+rubric stays informational.
+
+### Console gateway change (vendo-web)
+
+The messages gateway learns to distinguish init-tagged requests. Resolution
+order: valid key -> org plan -> init policy flag -> allow (meter normally) or
+refuse with a structured error the CLI relays verbatim. Default flags: free
+refuses, paid plans allow. Changing the policy is a console data change.
+
+### Degradation (visible, never silent)
+
+- No consent: unchanged (exact reads, derivations, defaults).
+- Consent, no engine credential: honest skip naming every rung tried and the
+  exact fixes (install/login claude or codex, set `ANTHROPIC_API_KEY`, or
+  `vendo cloud login` on a paid org).
+- Free org over the gateway: the server refusal, relayed verbatim.
+- Stage failure: pipeline degradation note; deterministic results stand.
+
+### Tests and corpus
+
+- Unit: engine ladder resolution order, built-in loop through a scripted
+  wire seam, codex output parsing, credential fallbacks, refusal relay.
+- Console: gateway policy matrix (free/paid x tagged/untagged), meter still
+  ingests on allowed init traffic.
+- Corpus: existing claude-path baselines unchanged; add a codex leg and a
+  built-in-engine leg (the harness's `@ai-sdk/anthropic` injection becomes
+  removable once the built-in engine ships, since the CLI now carries its
+  own client). Scores stay informational.
+
+## Sequencing
+
+Rides after the theme-detect lane's harness/stage work and the api-detect
+lane's held init-wiring tasks land on main; the console change is a separate
+vendo-web PR that can land any time before the CLI rungs ship. Coordinate
+with the theme-detect lane before touching harness files on its surface.
+
+## Accepted costs
+
+- The vendo package grows by the Anthropic SDK (a few MB, bounded, audited).
+- Built-in engine quality may trail Claude Code on repo navigation; corpus
+  measures the gap and the ladder prefers real agent CLIs when present.
+- Codex support carries prompt-portability risk; gated on corpus evidence.
+- Paid orgs can spend metered `llm_tokens` on init (their choice, honest
+  meter); free orgs get a refusal instead of a surprise spend.

--- a/docs/superpowers/specs/2026-07-20-init-builtin-agent-harness-design.md
+++ b/docs/superpowers/specs/2026-07-20-init-builtin-agent-harness-design.md
@@ -27,7 +27,11 @@ a resolvable Agent SDK or a `claude` binary on PATH. Two gaps:
 1. **The vendo CLI ships a built-in agent engine.** The official Anthropic
    SDK (`@anthropic-ai/sdk`, a few MB, a real dependency of the CLI, never
    resolved from the host) running its agentic tool loop with vendo-provided
-   read-only repo tools (Read/Glob/Grep equivalents). It implements the same
+   read-only repo tools (Read/Glob/Grep equivalents). Not to be confused
+   with `@anthropic-ai/claude-agent-sdk` (the Agent SDK), which is Claude
+   Code itself packaged programmatically: same model either way, but the
+   built-in engine carries our minimal tool scaffolding instead of Claude
+   Code's full harness, which is what the 245 MB buys. It implements the same
    `ExtractionHarness` interface: same stages, same prompts, same consent
    gate, same artifact trail. No ai-sdk (`ai` / `@ai-sdk/*`) anywhere in init.
 2. **Codex driver ships in the same program.** A harness that drives the

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -1,0 +1,41 @@
+# @vendoai/engine
+
+A thin, command-agnostic runner around `@anthropic-ai/claude-agent-sdk`: a
+job goes in on stdin, the agent's final message text comes out on stdout.
+No init logic, no Vendo-specific prompts or schemas — those all live in the
+caller (`vendo`'s init/extract ladder).
+
+This package is **not** a dependency of any `@vendoai/*` package. It exists
+so that init's last-resort engine rung can run:
+
+```sh
+npm exec @vendoai/engine@<pinned-version> -- run
+```
+
+without ever installing the Agent SDK's ~245MB bundled Claude Code binary
+into a host app's `node_modules`. `npm exec` fetches and caches it on the
+dev's machine on first use only.
+
+## Contract
+
+- stdin: a job JSON object — `{ "instructions": string, "root": string }`.
+- Credentials: `ANTHROPIC_API_KEY`, or `ANTHROPIC_BASE_URL` +
+  `ANTHROPIC_AUTH_TOKEN` (+ optional `ANTHROPIC_CUSTOM_HEADERS`) — read
+  directly from the process environment, passed through untouched.
+- stdout: exactly the agent's final message text. Nothing else.
+- stderr: progress narration (tool use, intermediate assistant text).
+- Exit code: `0` on success, non-zero on any failure (bad job, engine error).
+
+Tool policy is read-only (`Read`/`Glob`/`Grep`) rooted at `job.root`, and the
+session's `settingSources` are isolated (`[]`) so the dev's personal Claude
+Code settings/hooks never leak into the run.
+
+## Why zod ^4 here only
+
+`@anthropic-ai/claude-agent-sdk` peer-requires `zod ^4.0.0`. The rest of the
+workspace pins zod 3.x for its `ai`-SDK peers (see
+`scripts/dependency-guard.mjs` rule 4). This package declares its own zod ^4
+dependency to satisfy that peer in its own dependency subtree; pnpm resolves
+it as a separate instance scoped to this package (already precedented in the
+workspace lockfile via `@mastra/schema-compat`'s zod-3/zod-4 dual instances),
+so it does not affect any other package's zod resolution.

--- a/packages/engine/bin/vendo-engine.mjs
+++ b/packages/engine/bin/vendo-engine.mjs
@@ -1,6 +1,17 @@
 #!/usr/bin/env node
 import { runCli } from "../dist/cli.js";
 
+// `runCli` reads the job from stdin to EOF — with no piped input and a real
+// terminal attached, that read never resolves. Fail fast instead of hanging
+// forever. Kept here (not in runCli) so runCli stays pure/testable: its
+// tests drive stdin with an in-memory Readable that has no `isTTY`.
+if (process.stdin.isTTY) {
+  process.stderr.write(
+    "vendo-engine: expects a job JSON on stdin, e.g. `echo '{\"instructions\":...,\"root\":...}' | vendo-engine`. No interactive terminal input is supported.\n",
+  );
+  process.exit(1);
+}
+
 process.exitCode = await runCli(process.argv.slice(2), {
   stdin: process.stdin,
   stdout: (text) => process.stdout.write(text),

--- a/packages/engine/bin/vendo-engine.mjs
+++ b/packages/engine/bin/vendo-engine.mjs
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+import { runCli } from "../dist/cli.js";
+
+process.exitCode = await runCli(process.argv.slice(2), {
+  stdin: process.stdin,
+  stdout: (text) => process.stdout.write(text),
+  stderr: (text) => process.stderr.write(text),
+});

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@vendoai/engine",
+  "version": "0.1.0",
+  "description": "npx-fetched Agent SDK runner: harness job in, final agent text out. Not a dependency of any Vendo package — init's last-resort engine rung fetches it via `npm exec` at a pinned version so its ~245MB Claude Code binary never lands in a host app's install.",
+  "keywords": [
+    "ai",
+    "agent",
+    "vendo"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/runvendo/vendo.git",
+    "directory": "packages/engine"
+  },
+  "homepage": "https://vendo.run",
+  "bugs": "https://github.com/runvendo/vendo/issues",
+  "engines": {
+    "node": ">=20"
+  },
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "vendo-engine": "./bin/vendo-engine.mjs"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "bin",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "0.3.214",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vendoai/engine",
   "version": "0.1.0",
-  "description": "npx-fetched Agent SDK runner: harness job in, final agent text out. Not a dependency of any Vendo package — init's last-resort engine rung fetches it via `npm exec` at a pinned version so its ~245MB Claude Code binary never lands in a host app's install.",
+  "description": "npx-fetched Agent SDK runner: harness job in, final agent text out. Not a dependency of any Vendo package — init's last-resort engine rung fetches it via `npm exec` at a pinned version so its ~250MB Claude Code binary never lands in a host app's install.",
   "keywords": [
     "ai",
     "agent",

--- a/packages/engine/src/cli.test.ts
+++ b/packages/engine/src/cli.test.ts
@@ -1,0 +1,134 @@
+import { Readable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { runCli } from "./cli.js";
+import type { EngineDeps, EngineMessage } from "./types.js";
+
+function streamOf(text: string): Readable {
+  return Readable.from([Buffer.from(text, "utf8")]);
+}
+
+function scripted(...messages: EngineMessage[]): EngineDeps {
+  return {
+    async *query() {
+      for (const m of messages) yield m;
+    },
+  };
+}
+
+function io() {
+  const out: string[] = [];
+  const err: string[] = [];
+  return {
+    out,
+    err,
+    stdout: (t: string) => out.push(t),
+    stderr: (t: string) => err.push(t),
+  };
+}
+
+const validJob = JSON.stringify({ instructions: "list files", root: "/abs/root" });
+
+describe("runCli", () => {
+  it('"run" with a valid job writes ONLY the final text to stdout, nothing on stderr\'s stdout channel', async () => {
+    const { out, err, stdout, stderr } = io();
+    const code = await runCli(["run"], { stdin: streamOf(validJob), stdout, stderr }, scripted({ kind: "success", text: "the final answer" }));
+    expect(code).toBe(0);
+    expect(out).toEqual(["the final answer"]);
+    expect(err).toEqual([]);
+  });
+
+  it("defaults to run with no subcommand argument", async () => {
+    const { out, stdout, stderr } = io();
+    const code = await runCli([], { stdin: streamOf(validJob), stdout, stderr }, scripted({ kind: "success", text: "ok" }));
+    expect(code).toBe(0);
+    expect(out).toEqual(["ok"]);
+  });
+
+  it("sends progress narration to stderr, not stdout", async () => {
+    const { out, err, stdout, stderr } = io();
+    await runCli(
+      ["run"],
+      { stdin: streamOf(validJob), stdout, stderr },
+      scripted({ kind: "progress", text: "Read foo.ts" }, { kind: "success", text: "done" }),
+    );
+    expect(out).toEqual(["done"]);
+    expect(err.join("")).toContain("Read foo.ts");
+  });
+
+  it("an unknown subcommand exits non-zero with nothing on stdout", async () => {
+    const { out, err, stdout, stderr } = io();
+    const code = await runCli(["bogus"], { stdin: streamOf(validJob), stdout, stderr }, scripted());
+    expect(code).not.toBe(0);
+    expect(out).toEqual([]);
+    expect(err.join("")).toMatch(/unknown subcommand/);
+  });
+
+  it("malformed job JSON exits non-zero, error on stderr, nothing on stdout", async () => {
+    const { out, err, stdout, stderr } = io();
+    const code = await runCli(["run"], { stdin: streamOf("{not json"), stdout, stderr }, scripted());
+    expect(code).not.toBe(0);
+    expect(out).toEqual([]);
+    expect(err.join("")).toMatch(/not valid JSON/);
+  });
+
+  it("a job missing required fields exits non-zero with a clear error", async () => {
+    const { out, err, stdout, stderr } = io();
+    const code = await runCli(["run"], { stdin: streamOf("{}"), stdout, stderr }, scripted());
+    expect(code).not.toBe(0);
+    expect(out).toEqual([]);
+    expect(err.join("")).toMatch(/instructions/);
+  });
+
+  it("an engine failure result exits non-zero, error on stderr, nothing on stdout", async () => {
+    const { out, err, stdout, stderr } = io();
+    const code = await runCli(
+      ["run"],
+      { stdin: streamOf(validJob), stdout, stderr },
+      scripted({ kind: "failure", errors: ["model refused"] }),
+    );
+    expect(code).not.toBe(0);
+    expect(out).toEqual([]);
+    expect(err.join("")).toMatch(/model refused/);
+  });
+
+  it("a thrown error from the query seam is caught, not an uncaught rejection", async () => {
+    const { out, err, stdout, stderr } = io();
+    const deps: EngineDeps = {
+      // eslint-disable-next-line require-yield
+      async *query() {
+        throw new Error("subprocess spawn failed");
+      },
+    };
+    const code = await runCli(["run"], { stdin: streamOf(validJob), stdout, stderr }, deps);
+    expect(code).not.toBe(0);
+    expect(out).toEqual([]);
+    expect(err.join("")).toMatch(/subprocess spawn failed/);
+  });
+
+  it("a thrown non-Error value from the query seam is stringified, not swallowed", async () => {
+    const { out, err, stdout, stderr } = io();
+    const deps: EngineDeps = {
+      // eslint-disable-next-line require-yield
+      async *query() {
+        throw "a bare string throw";
+      },
+    };
+    const code = await runCli(["run"], { stdin: streamOf(validJob), stdout, stderr }, deps);
+    expect(code).not.toBe(0);
+    expect(out).toEqual([]);
+    expect(err.join("")).toMatch(/a bare string throw/);
+  });
+
+  it("a stream error while reading the job (not a validation error) is caught cleanly", async () => {
+    const { out, err, stdout, stderr } = io();
+    const broken = new Readable({
+      read() {
+        this.destroy(new Error("stdin pipe broke"));
+      },
+    });
+    const code = await runCli(["run"], { stdin: broken, stdout, stderr }, scripted());
+    expect(code).not.toBe(0);
+    expect(out).toEqual([]);
+    expect(err.join("")).toMatch(/stdin pipe broke/);
+  });
+});

--- a/packages/engine/src/cli.ts
+++ b/packages/engine/src/cli.ts
@@ -1,0 +1,77 @@
+import type { Readable } from "node:stream";
+import { JobValidationError, parseJob, readJobFromStream } from "./job.js";
+import { runEngineJob } from "./run-engine-job.js";
+import { createSdkQuery } from "./sdk-seam.js";
+import type { EngineDeps } from "./types.js";
+
+/** I/O seam so tests can drive `runCli` without touching real stdio or the
+ *  real SDK. `bin/vendo-engine.mjs` wires the real process.stdin/stdout/stderr
+ *  and (via the default `deps` parameter below) the real Agent SDK query. */
+export interface CliIo {
+  stdin: Readable;
+  stdout: (text: string) => void;
+  stderr: (text: string) => void;
+}
+
+const PREFIX = "vendo-engine";
+
+/**
+ * `vendo-engine run` (also the default with no subcommand — the contract's
+ * only entry point). Reads the job from `io.stdin`, runs it, and writes
+ * EXACTLY the agent's final text to `io.stdout` — no banners, no logs, so a
+ * caller can pipe stdout straight into its own artifact parser. Everything
+ * else (progress narration, errors) goes to `io.stderr`. Returns the
+ * process exit code; never throws.
+ */
+export async function runCli(
+  argv: string[],
+  io: CliIo,
+  deps: EngineDeps = { query: createSdkQuery() },
+): Promise<number> {
+  const sub = argv[0] === undefined || argv[0].startsWith("-") ? "run" : argv[0];
+  if (sub !== "run") {
+    io.stderr(`${PREFIX}: unknown subcommand "${sub}" (only "run" is supported)\n`);
+    return 1;
+  }
+
+  let raw: string;
+  try {
+    raw = await readJobFromStream(io.stdin);
+  } catch (err) {
+    io.stderr(`${PREFIX}: ${describeError(err)}\n`);
+    return 1;
+  }
+
+  let job;
+  try {
+    job = parseJob(raw);
+  } catch (err) {
+    io.stderr(`${PREFIX}: ${describeError(err)}\n`);
+    return 1;
+  }
+
+  let result;
+  try {
+    result = await runEngineJob(job, deps, (line) => io.stderr(`[${PREFIX}] ${line}\n`));
+  } catch (err) {
+    // A thrown error (e.g. the SDK subprocess failed to spawn at all) is a
+    // failure, not a crash — the contract promises "non-zero exit, clear
+    // error on stderr", not an uncaught rejection.
+    io.stderr(`${PREFIX}: ${describeError(err)}\n`);
+    return 1;
+  }
+
+  if (!result.ok) {
+    io.stderr(`${PREFIX}: run failed: ${result.errors.join("; ")}\n`);
+    return 1;
+  }
+
+  io.stdout(result.text);
+  return 0;
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof JobValidationError) return err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/packages/engine/src/engine.live.test.ts
+++ b/packages/engine/src/engine.live.test.ts
@@ -1,0 +1,46 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import { afterAll, describe, expect, it } from "vitest";
+import { runCli } from "./cli.js";
+
+/**
+ * Live end-to-end gate: a real Agent SDK session through this package's own
+ * runner (no scripted seam) — the CLI reads a job from stdin, runs the real
+ * `createSdkQuery()` default, and the final text lands on stdout. Mirrors
+ * the gating shape of `extract-theme.live.test.ts`: skipped without a real
+ * credential, so it never runs (or costs anything) in ordinary CI.
+ *
+ * Env-flagged on top of the credential check (VENDO_ENGINE_LIVE=1) so this
+ * ~245MB-SDK, real-network test only ever runs when explicitly asked for —
+ * unlike the extraction harness's live test, which only needs an API key
+ * because its harness is already a normal in-repo dependency.
+ */
+const hasKey = typeof process.env["ANTHROPIC_API_KEY"] === "string" && process.env["ANTHROPIC_API_KEY"]!.trim().length > 0;
+const live = process.env["VENDO_ENGINE_LIVE"] === "1" && hasKey;
+
+describe.skipIf(!live)("vendo-engine live run", () => {
+  const dir = mkdtempSync(join(tmpdir(), "vendo-engine-live-"));
+  const marker = "vendo-engine-live-marker-7f3a9c";
+  writeFileSync(join(dir, "marker.txt"), marker, "utf8");
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("reads a real file through the read-only tool policy and returns exactly the final text on stdout", async () => {
+    const job = JSON.stringify({
+      instructions:
+        `Read the file "marker.txt" in the current directory and reply with ONLY its exact contents, nothing else — no preamble, no quotes, no explanation.`,
+      root: dir,
+    });
+    const out: string[] = [];
+    const err: string[] = [];
+    const code = await runCli(["run"], {
+      stdin: Readable.from([Buffer.from(job, "utf8")]),
+      stdout: (t) => out.push(t),
+      stderr: (t) => err.push(t),
+    });
+    expect(code, `stderr: ${err.join("")}`).toBe(0);
+    expect(out.join("")).toContain(marker);
+  }, 120_000);
+});

--- a/packages/engine/src/index.test.ts
+++ b/packages/engine/src/index.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import * as engine from "./index.js";
+
+describe("index (public surface)", () => {
+  it("exports the runner, job parsing, seam, and CLI entry points", () => {
+    expect(typeof engine.runEngineJob).toBe("function");
+    expect(typeof engine.parseJob).toBe("function");
+    expect(typeof engine.readJobFromStream).toBe("function");
+    expect(typeof engine.JobValidationError).toBe("function");
+    expect(typeof engine.JOB_MAX_BYTES).toBe("number");
+    expect(typeof engine.createSdkQuery).toBe("function");
+    expect(typeof engine.runCli).toBe("function");
+  });
+
+  it("createSdkQuery returns a callable query function without loading the real SDK", () => {
+    // Merely calling createSdkQuery() must not trigger the dynamic import —
+    // that only happens once the returned generator is actually iterated.
+    const query = engine.createSdkQuery();
+    expect(typeof query).toBe("function");
+  });
+});

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,0 +1,6 @@
+export { runEngineJob } from "./run-engine-job.js";
+export type { EngineDeps, EngineJob, EngineMessage, EngineRunResult } from "./types.js";
+export { JOB_MAX_BYTES, JobValidationError, parseJob, readJobFromStream } from "./job.js";
+export { createSdkQuery } from "./sdk-seam.js";
+export { runCli } from "./cli.js";
+export type { CliIo } from "./cli.js";

--- a/packages/engine/src/job.test.ts
+++ b/packages/engine/src/job.test.ts
@@ -1,0 +1,62 @@
+import { Readable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { JOB_MAX_BYTES, JobValidationError, parseJob, readJobFromStream } from "./job.js";
+
+function streamOf(text: string): Readable {
+  return Readable.from([Buffer.from(text, "utf8")]);
+}
+
+describe("readJobFromStream", () => {
+  it("reads a small stream to a utf8 string", async () => {
+    await expect(readJobFromStream(streamOf('{"a":1}'))).resolves.toBe('{"a":1}');
+  });
+
+  it("rejects input over JOB_MAX_BYTES without buffering it all", async () => {
+    const big = "x".repeat(JOB_MAX_BYTES + 1);
+    await expect(readJobFromStream(streamOf(big))).rejects.toThrow(JobValidationError);
+  });
+
+  it("accepts input exactly at JOB_MAX_BYTES", async () => {
+    const exact = "a".repeat(JOB_MAX_BYTES);
+    await expect(readJobFromStream(streamOf(exact))).resolves.toHaveLength(JOB_MAX_BYTES);
+  });
+
+  it("accepts a stream that yields string chunks, not just Buffers", async () => {
+    const stream = Readable.from(["hello ", "world"], { objectMode: true });
+    await expect(readJobFromStream(stream)).resolves.toBe("hello world");
+  });
+});
+
+describe("parseJob", () => {
+  const valid = { instructions: "list files", root: "/abs/root" };
+
+  it("round-trips a valid job", () => {
+    expect(parseJob(JSON.stringify(valid))).toEqual(valid);
+  });
+
+  it("rejects invalid JSON", () => {
+    expect(() => parseJob("{not json")).toThrow(JobValidationError);
+    expect(() => parseJob("{not json")).toThrow(/not valid JSON/);
+  });
+
+  it("rejects a non-object JSON value", () => {
+    expect(() => parseJob("42")).toThrow(/must be a JSON object/);
+    expect(() => parseJob("null")).toThrow(/must be a JSON object/);
+    expect(() => parseJob("[1,2]")).toThrow(/must be a JSON object/);
+  });
+
+  it("rejects a missing or empty instructions field", () => {
+    expect(() => parseJob(JSON.stringify({ ...valid, instructions: "" }))).toThrow(/instructions/);
+    expect(() => parseJob(JSON.stringify({ root: valid.root }))).toThrow(/instructions/);
+    expect(() => parseJob(JSON.stringify({ ...valid, instructions: 7 }))).toThrow(/instructions/);
+  });
+
+  it("rejects a missing or empty root field", () => {
+    expect(() => parseJob(JSON.stringify({ ...valid, root: "" }))).toThrow(/root/);
+    expect(() => parseJob(JSON.stringify({ instructions: valid.instructions }))).toThrow(/root/);
+  });
+
+  it("rejects a relative root", () => {
+    expect(() => parseJob(JSON.stringify({ ...valid, root: "relative/path" }))).toThrow(/absolute path/);
+  });
+});

--- a/packages/engine/src/job.ts
+++ b/packages/engine/src/job.ts
@@ -1,0 +1,63 @@
+import { isAbsolute } from "node:path";
+import type { Readable } from "node:stream";
+import type { EngineJob } from "./types.js";
+
+/** Generous headroom for `{instructions, root}` — both plain strings — not
+ *  a budget to fill. Guards against a misbehaving caller piping something
+ *  unbounded into stdin; the read loop aborts (and destroys the stream, so
+ *  it stops pulling more data) the moment this is exceeded, rather than
+ *  buffering everything first and rejecting only after the fact. */
+export const JOB_MAX_BYTES = 1024 * 1024;
+
+export class JobValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "JobValidationError";
+  }
+}
+
+/** Reads stdin (or any Readable) to a UTF-8 string, enforcing JOB_MAX_BYTES. */
+export async function readJobFromStream(stream: Readable): Promise<string> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of stream) {
+    const buf: Buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string);
+    total += buf.length;
+    if (total > JOB_MAX_BYTES) {
+      stream.destroy();
+      throw new JobValidationError(`job input exceeds ${JOB_MAX_BYTES} bytes`);
+    }
+    chunks.push(buf);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+/** Parses and validates the job contract. Every failure is a
+ *  JobValidationError with a message specific enough to fix without
+ *  reading this file — malformed input must never reach the SDK seam. */
+export function parseJob(raw: string): EngineJob {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new JobValidationError("job input is not valid JSON");
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new JobValidationError("job input must be a JSON object");
+  }
+  const { instructions, root } = value as Record<string, unknown>;
+
+  if (typeof instructions !== "string" || instructions.trim().length === 0) {
+    throw new JobValidationError('job.instructions must be a non-empty string');
+  }
+  if (typeof root !== "string" || root.trim().length === 0) {
+    throw new JobValidationError('job.root must be a non-empty string');
+  }
+  // Relative roots would resolve against this process's own cwd, not the
+  // caller's intended host directory — fail closed instead of guessing.
+  if (!isAbsolute(root)) {
+    throw new JobValidationError("job.root must be an absolute path");
+  }
+
+  return { instructions, root };
+}

--- a/packages/engine/src/run-engine-job.test.ts
+++ b/packages/engine/src/run-engine-job.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { runEngineJob } from "./run-engine-job.js";
+import type { EngineDeps, EngineMessage, EngineJob } from "./types.js";
+
+const job: EngineJob = { instructions: "do the thing", root: "/tmp/root" };
+
+function scripted(...messages: EngineMessage[]): EngineDeps {
+  return {
+    async *query() {
+      for (const m of messages) yield m;
+    },
+  };
+}
+
+describe("runEngineJob", () => {
+  it("resolves ok with the success message's text", async () => {
+    const result = await runEngineJob(job, scripted({ kind: "success", text: "final answer" }));
+    expect(result).toEqual({ ok: true, text: "final answer", errors: [] });
+  });
+
+  it("routes progress messages to onProgress, not into the result", async () => {
+    const seen: string[] = [];
+    const result = await runEngineJob(
+      job,
+      scripted({ kind: "progress", text: "Read foo.ts" }, { kind: "progress", text: "Glob **/*.ts" }, { kind: "success", text: "done" }),
+      (line) => seen.push(line),
+    );
+    expect(seen).toEqual(["Read foo.ts", "Glob **/*.ts"]);
+    expect(result).toEqual({ ok: true, text: "done", errors: [] });
+  });
+
+  it("resolves not-ok with the failure message's errors", async () => {
+    const result = await runEngineJob(job, scripted({ kind: "failure", errors: ["boom", "again"] }));
+    expect(result).toEqual({ ok: false, text: "", errors: ["boom", "again"] });
+  });
+
+  it("stops draining after a failure message (does not read further)", async () => {
+    let readAfterFailure = false;
+    const deps: EngineDeps = {
+      async *query() {
+        yield { kind: "failure", errors: ["stop here"] };
+        readAfterFailure = true; // would only run if the generator is pumped again
+        yield { kind: "success", text: "should never appear" };
+      },
+    };
+    const result = await runEngineJob(job, deps);
+    expect(result).toEqual({ ok: false, text: "", errors: ["stop here"] });
+    expect(readAfterFailure).toBe(false);
+  });
+
+  it("treats a stream that ends without a result message as a failure", async () => {
+    const result = await runEngineJob(job, scripted({ kind: "progress", text: "only progress, no terminal message" }));
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toMatch(/ended without a result/);
+  });
+
+  it("treats an empty stream (no messages at all) as a failure", async () => {
+    const result = await runEngineJob(job, scripted());
+    expect(result.ok).toBe(false);
+  });
+
+  it("passes the job through to the query seam unmodified", async () => {
+    let received: EngineJob | undefined;
+    const deps: EngineDeps = {
+      async *query(j) {
+        received = j;
+        yield { kind: "success", text: "ok" };
+      },
+    };
+    await runEngineJob(job, deps);
+    expect(received).toEqual(job);
+  });
+});

--- a/packages/engine/src/run-engine-job.ts
+++ b/packages/engine/src/run-engine-job.ts
@@ -1,0 +1,33 @@
+import type { EngineDeps, EngineJob, EngineRunResult } from "./types.js";
+
+/**
+ * The runner core. Deliberately dumb: drain `deps.query(job)`, route
+ * "progress" messages to the caller's `onProgress` (stderr, in the real
+ * CLI), and settle on the first "success" or "failure" message. No
+ * knowledge of the Agent SDK, init, or any Vendo concept lives here — this
+ * function is the entire "job in, final text out" contract, independent of
+ * how the job actually gets executed.
+ */
+export async function runEngineJob(
+  job: EngineJob,
+  deps: EngineDeps,
+  onProgress?: (line: string) => void,
+): Promise<EngineRunResult> {
+  for await (const message of deps.query(job)) {
+    if (message.kind === "progress") {
+      onProgress?.(message.text);
+      continue;
+    }
+    if (message.kind === "success") {
+      return { ok: true, text: message.text, errors: [] };
+    }
+    // "failure" — stop draining immediately; a failure message is terminal
+    // by construction (sdk-seam.ts's `adapt` returns right after yielding one).
+    return { ok: false, text: "", errors: message.errors };
+  }
+  // The stream closed without ever yielding a result. The real SDK always
+  // terminates with a `result` message (success or error) per its own
+  // contract, so reaching this is itself a bug worth surfacing loudly
+  // rather than returning a silently-empty "success".
+  return { ok: false, text: "", errors: ["engine stream ended without a result message"] };
+}

--- a/packages/engine/src/sdk-seam.test.ts
+++ b/packages/engine/src/sdk-seam.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { adapt } from "./sdk-seam.js";
+
+async function* streamOf(...messages: Record<string, unknown>[]): AsyncGenerator<Record<string, unknown>> {
+  for (const m of messages) yield m;
+}
+
+async function collect(gen: AsyncGenerator<unknown>): Promise<unknown[]> {
+  const out: unknown[] = [];
+  for await (const m of gen) out.push(m);
+  return out;
+}
+
+describe("adapt (raw SDK message stream -> EngineMessage)", () => {
+  it("yields a progress message for assistant text blocks", async () => {
+    const raw = { type: "assistant", message: { content: [{ type: "text", text: "thinking about it" }] } };
+    await expect(collect(adapt(streamOf(raw)))).resolves.toEqual([{ kind: "progress", text: "thinking about it" }]);
+  });
+
+  it("drops empty assistant text blocks", async () => {
+    const raw = { type: "assistant", message: { content: [{ type: "text", text: "" }] } };
+    await expect(collect(adapt(streamOf(raw)))).resolves.toEqual([]);
+  });
+
+  it("yields a progress message naming the tool and its file_path target", async () => {
+    const raw = { type: "assistant", message: { content: [{ type: "tool_use", name: "Read", input: { file_path: "src/index.ts" } }] } };
+    await expect(collect(adapt(streamOf(raw)))).resolves.toEqual([{ kind: "progress", text: "Read src/index.ts" }]);
+  });
+
+  it("yields a progress message naming the tool and its glob pattern target", async () => {
+    const raw = { type: "assistant", message: { content: [{ type: "tool_use", name: "Glob", input: { pattern: "**/*.ts" } }] } };
+    await expect(collect(adapt(streamOf(raw)))).resolves.toEqual([{ kind: "progress", text: "Glob **/*.ts" }]);
+  });
+
+  it("yields just the tool name when tool_use carries no recognizable target", async () => {
+    const raw = { type: "assistant", message: { content: [{ type: "tool_use", name: "Grep", input: {} }] } };
+    await expect(collect(adapt(streamOf(raw)))).resolves.toEqual([{ kind: "progress", text: "Grep" }]);
+  });
+
+  it("handles multiple content blocks in one assistant message", async () => {
+    const raw = {
+      type: "assistant",
+      message: { content: [{ type: "text", text: "checking" }, { type: "tool_use", name: "Read", input: { file_path: "a.ts" } }] },
+    };
+    await expect(collect(adapt(streamOf(raw)))).resolves.toEqual([
+      { kind: "progress", text: "checking" },
+      { kind: "progress", text: "Read a.ts" },
+    ]);
+  });
+
+  it("yields success from a result message and stops (does not read past it)", async () => {
+    let readAfter = false;
+    async function* gen() {
+      yield { type: "result", subtype: "success", result: "the final answer" };
+      readAfter = true;
+      yield { type: "assistant", message: { content: [] } };
+    }
+    await expect(collect(adapt(gen()))).resolves.toEqual([{ kind: "success", text: "the final answer" }]);
+    expect(readAfter).toBe(false);
+  });
+
+  it("yields failure with the error subtype's errors array", async () => {
+    const raw = { type: "result", subtype: "error_max_turns", errors: ["ran out of turns"] };
+    await expect(collect(adapt(streamOf(raw)))).resolves.toEqual([{ kind: "failure", errors: ["ran out of turns"] }]);
+  });
+
+  it("synthesizes an error message from the subtype when errors is missing or malformed", async () => {
+    await expect(collect(adapt(streamOf({ type: "result", subtype: "error_max_budget_usd" })))).resolves.toEqual([
+      { kind: "failure", errors: ["engine error_max_budget_usd"] },
+    ]);
+    await expect(collect(adapt(streamOf({ type: "result", subtype: "error_during_execution", errors: "not an array" })))).resolves.toEqual([
+      { kind: "failure", errors: ["engine error_during_execution"] },
+    ]);
+  });
+
+  it("yields nothing for message types it doesn't recognize", async () => {
+    await expect(collect(adapt(streamOf({ type: "system", subtype: "init" })))).resolves.toEqual([]);
+  });
+});

--- a/packages/engine/src/sdk-seam.test.ts
+++ b/packages/engine/src/sdk-seam.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest";
-import { adapt } from "./sdk-seam.js";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { adapt, confineToolToRoot } from "./sdk-seam.js";
 
 async function* streamOf(...messages: Record<string, unknown>[]): AsyncGenerator<Record<string, unknown>> {
   for (const m of messages) yield m;
@@ -75,5 +78,80 @@ describe("adapt (raw SDK message stream -> EngineMessage)", () => {
 
   it("yields nothing for message types it doesn't recognize", async () => {
     await expect(collect(adapt(streamOf({ type: "system", subtype: "init" })))).resolves.toEqual([]);
+  });
+});
+
+describe("confineToolToRoot (read confinement for the canUseTool callback)", () => {
+  // Real directories so the symlink case is a real symlink, not a mock.
+  // realpathSync because tmpdir() itself sits behind a symlink on macOS
+  // (/var -> /private/var) — same normalization createSdkQuery applies.
+  const outside = realpathSync(mkdtempSync(join(tmpdir(), "vendo-engine-outside-")));
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "vendo-engine-root-")));
+  writeFileSync(join(root, "in-root.txt"), "in-root", "utf8");
+  writeFileSync(join(outside, "secret.txt"), "credentials", "utf8");
+  mkdirSync(join(root, "sub"));
+  symlinkSync(outside, join(root, "escape-link"));
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  });
+
+  const allow = (input: Record<string, unknown>) => ({ behavior: "allow", updatedInput: input });
+
+  it("allows a Read of a relative path inside the root", () => {
+    const input = { file_path: "in-root.txt" };
+    expect(confineToolToRoot("Read", input, root)).toEqual(allow(input));
+  });
+
+  it("allows a Read of an absolute path inside the root", () => {
+    const input = { file_path: join(root, "sub", "not-yet-created.txt") };
+    expect(confineToolToRoot("Read", input, root)).toEqual(allow(input));
+  });
+
+  it("denies a Read of an absolute path outside the root", () => {
+    const verdict = confineToolToRoot("Read", { file_path: join(outside, "secret.txt") }, root);
+    expect(verdict.behavior).toBe("deny");
+    expect(verdict).toMatchObject({ message: expect.stringContaining("outside the engine job root") });
+  });
+
+  it("denies a ../ escape even when the traversal is buried mid-path", () => {
+    const verdict = confineToolToRoot("Read", { file_path: `sub/../../${"secret.txt"}` }, root);
+    expect(verdict.behavior).toBe("deny");
+  });
+
+  it("denies a Read through a symlink inside the root that points outside it", () => {
+    const verdict = confineToolToRoot("Read", { file_path: "escape-link/secret.txt" }, root);
+    expect(verdict.behavior).toBe("deny");
+  });
+
+  it("denies a prefix-sibling of the root (root + suffix without a separator)", () => {
+    const verdict = confineToolToRoot("Read", { file_path: `${root}-sibling/file.txt` }, root);
+    expect(verdict.behavior).toBe("deny");
+  });
+
+  it("confines Grep's path search root, and allows Grep with no path (defaults to cwd)", () => {
+    expect(confineToolToRoot("Grep", { pattern: "secret", path: outside }, root).behavior).toBe("deny");
+    const input = { pattern: "/etc/passwd" }; // regex, not a path — must not be confined
+    expect(confineToolToRoot("Grep", input, root)).toEqual(allow(input));
+  });
+
+  it("confines Glob's path field and an absolute pattern's static base", () => {
+    expect(confineToolToRoot("Glob", { pattern: "**/*.ts", path: outside }, root).behavior).toBe("deny");
+    expect(confineToolToRoot("Glob", { pattern: `${outside}/**/*.txt` }, root).behavior).toBe("deny");
+    expect(confineToolToRoot("Glob", { pattern: "../**/*.txt" }, root).behavior).toBe("deny");
+    expect(confineToolToRoot("Glob", { pattern: "/*" }, root).behavior).toBe("deny");
+    const relative = { pattern: "**/*.ts" };
+    expect(confineToolToRoot("Glob", relative, root)).toEqual(allow(relative));
+  });
+
+  it("allows the root itself as a target", () => {
+    const input = { path: root, pattern: "**/*" };
+    expect(confineToolToRoot("Glob", input, root)).toEqual(allow(input));
+  });
+
+  it("allows tools without path-shaped inputs (the tools option already bounds the set)", () => {
+    const input = { anything: "goes" };
+    expect(confineToolToRoot("SomeOtherTool", input, root)).toEqual(allow(input));
   });
 });

--- a/packages/engine/src/sdk-seam.ts
+++ b/packages/engine/src/sdk-seam.ts
@@ -1,3 +1,5 @@
+import { realpathSync } from "node:fs";
+import { basename, dirname, join, resolve, sep } from "node:path";
 import type { EngineDeps, EngineJob, EngineMessage } from "./types.js";
 
 /**
@@ -19,6 +21,86 @@ const DISALLOWED_TOOLS = [
 const MAX_TURNS = 60;
 
 const SDK_PACKAGE = "@anthropic-ai/claude-agent-sdk";
+
+/** The subset of a PermissionResult (the SDK's canUseTool return union) this
+ *  file produces. Local shape for the same reason as SdkModule below: the
+ *  real type lives behind the dynamic import. */
+type ConfinementVerdict =
+  | { behavior: "allow"; updatedInput: Record<string, unknown> }
+  | { behavior: "deny"; message: string };
+
+/** The path-shaped inputs of the three allowed read-only tools. A Glob
+ *  `pattern` can itself be an absolute path (or climb with `..`), so its
+ *  static, glob-free base directory is confined too — not just the `path`
+ *  search-root field. Grep's `pattern` is a regex, never a path. */
+function candidatePaths(toolName: string, input: Record<string, unknown>): string[] {
+  const paths: string[] = [];
+  const push = (value: unknown) => {
+    if (typeof value === "string" && value.length > 0) paths.push(value);
+  };
+  if (toolName === "Read") push(input["file_path"]);
+  if (toolName === "Grep") push(input["path"]);
+  if (toolName === "Glob") {
+    push(input["path"]);
+    const pattern = input["pattern"];
+    if (typeof pattern === "string") {
+      // Static prefix: everything before the first glob metacharacter,
+      // trimmed back to the last full path segment.
+      const magic = pattern.search(/[*?[{]/);
+      const prefix = magic === -1 ? pattern : pattern.slice(0, magic);
+      const cut = prefix.lastIndexOf("/");
+      // cut 0 means a filesystem-root pattern like "/*" — the base is "/".
+      if (cut === 0) push(sep);
+      else if (cut > 0) push(prefix.slice(0, cut));
+    }
+  }
+  return paths;
+}
+
+/** Realpath of the deepest existing ancestor, with the not-yet-existing tail
+ *  re-appended — so a symlink anywhere on the path is resolved to its real
+ *  target before containment is judged, and a path that does not exist yet
+ *  still gets an honest verdict from its existing parent. */
+function resolveThroughSymlinks(target: string): string {
+  let current = target;
+  const tail: string[] = [];
+  for (;;) {
+    try {
+      return join(realpathSync(current), ...tail);
+    } catch {
+      const parent = dirname(current);
+      if (parent === current) return target; // hit the filesystem root; nothing existed
+      tail.unshift(basename(current));
+      current = parent;
+    }
+  }
+}
+
+/** The pure(-ish: it reads the filesystem for realpath, never writes) heart
+ *  of the read confinement, exported for direct unit tests. Denies any
+ *  Read/Glob/Grep whose path input — absolute, relative, `..`-climbing, or
+ *  reached through a symlink — resolves outside `rootRealpath` (which must
+ *  already be a realpath, see createSdkQuery). Everything else is allowed:
+ *  the session's `tools` option already bounds the tool set to the read-only
+ *  three, so this callback is a path check, not a second allowlist. */
+export function confineToolToRoot(
+  toolName: string,
+  input: Record<string, unknown>,
+  rootRealpath: string,
+): ConfinementVerdict {
+  for (const candidate of candidatePaths(toolName, input)) {
+    const resolved = resolveThroughSymlinks(resolve(rootRealpath, candidate));
+    if (resolved !== rootRealpath && !resolved.startsWith(rootRealpath + sep)) {
+      return {
+        behavior: "deny",
+        message:
+          `${toolName} of ${candidate} denied: it resolves outside the engine job root (${rootRealpath}). `
+          + "This engine only reads within the directory it was given.",
+      };
+    }
+  }
+  return { behavior: "allow", updatedInput: input };
+}
 
 /** Loosely-typed shape of the bits of the real SDK module this file uses.
  *  Not the full official types: the SDK's message union has ~40 variants
@@ -83,10 +165,18 @@ export async function* adapt(stream: AsyncIterable<Record<string, unknown>>): As
  *  - `settingSources: []` — never load the dev's ~/.claude or project
  *    settings/hooks (the whole point of running this as a separate,
  *    npx-fetched process rather than the dev's own `claude` session).
- *  - `tools`/`allowedTools` restrict AND auto-allow the read-only set so a
- *    headless run never blocks on a permission prompt nobody can answer;
+ *  - `tools` restricts the tool set to the read-only three;
  *    `disallowedTools` is belt-and-suspenders against upstream additions to
  *    the default tool set.
+ *  - `canUseTool` (not a blanket `allowedTools` auto-allow, which would
+ *    grant Read/Glob/Grep on ANY path and never consult a callback) answers
+ *    every permission ask programmatically, so a headless run still never
+ *    blocks on a prompt nobody can answer — but reads outside the job root
+ *    are DENIED. A hostile repo's content can prompt-inject the agent into
+ *    `Read /Users/dev/.aws/credentials`; the package contract ("tool policy
+ *    rooted at the given directory") means that must fail, not ship the
+ *    dev's unrelated local files to the model. Containment is judged
+ *    against the realpath of job.root so symlinks can't smuggle either side.
  *  - `persistSession: false` — one-shot job, no ~/.claude/projects/
  *    transcript left behind on whatever machine runs this.
  *  - No `env` option is set: per the SDK's own default, omitting it means
@@ -96,15 +186,20 @@ export async function* adapt(stream: AsyncIterable<Record<string, unknown>>): As
 export function createSdkQuery(): EngineDeps["query"] {
   return async function* query(job: EngineJob): AsyncGenerator<EngineMessage> {
     const sdk = await loadSdk();
+    // Realpath once up front: if job.root is itself reached through a
+    // symlink (macOS /tmp -> /private/tmp), tool paths resolve to the real
+    // side and a string-prefix check against the raw root would misjudge.
+    const rootRealpath = realpathSync(job.root);
     const stream = sdk.query({
       prompt: job.instructions,
       options: {
         cwd: job.root,
         settingSources: [],
         tools: ALLOWED_TOOLS,
-        allowedTools: ALLOWED_TOOLS,
         disallowedTools: DISALLOWED_TOOLS,
         permissionMode: "default",
+        canUseTool: async (toolName: string, input: Record<string, unknown>) =>
+          confineToolToRoot(toolName, input, rootRealpath),
         maxTurns: MAX_TURNS,
         persistSession: false,
       },

--- a/packages/engine/src/sdk-seam.ts
+++ b/packages/engine/src/sdk-seam.ts
@@ -1,0 +1,114 @@
+import type { EngineDeps, EngineJob, EngineMessage } from "./types.js";
+
+/**
+ * The one file in this package allowed to touch the real
+ * `@anthropic-ai/claude-agent-sdk`. Mirrors the read-only isolation posture
+ * of the sibling in-process harness (packages/vendo's `claude-harness.ts`):
+ * settings isolated, tools restricted to Read/Glob/Grep, no shell/write/web
+ * surface. This package has no ExtractionHarness/init concept of its own —
+ * it only knows `{instructions, root}` in, final text out.
+ */
+
+const ALLOWED_TOOLS = ["Read", "Glob", "Grep"];
+const DISALLOWED_TOOLS = [
+  "Bash", "Write", "Edit", "WebFetch", "WebSearch", "Task",
+  "TodoWrite", "NotebookEdit", "KillShell", "BashOutput", "ExitPlanMode",
+];
+// Generic jobs can be more open-ended than a single extraction stage; same
+// order of magnitude as the sibling harness's cap (40) with headroom.
+const MAX_TURNS = 60;
+
+const SDK_PACKAGE = "@anthropic-ai/claude-agent-sdk";
+
+/** Loosely-typed shape of the bits of the real SDK module this file uses.
+ *  Not the full official types: the SDK's message union has ~40 variants
+ *  and this file only ever branches on 2 of them (see `adapt` below); a
+ *  narrow local shape is both enough and immune to upstream additions. */
+interface SdkModule {
+  query(params: { prompt: string; options: Record<string, unknown> }): AsyncIterable<Record<string, unknown>>;
+}
+
+/** Dynamic, not static: a static `import` would resolve this package the
+ *  moment any file in @vendoai/engine is imported — including by every unit
+ *  test and by `tsc --noEmit`, which must never require the SDK's ~245MB
+ *  platform binary to be present. Only the real run path (this function,
+ *  called from createSdkQuery's returned generator) ever loads it. */
+async function loadSdk(): Promise<SdkModule> {
+  return (await import(SDK_PACKAGE)) as unknown as SdkModule;
+}
+
+/** Projects the raw SDK message stream onto EngineMessage. Assistant text
+ *  and tool_use blocks become "progress" (destined for stderr); the
+ *  terminal `result` message becomes "success" or "failure" and ends the
+ *  generator — the SDK's own contract is that `result` is always last.
+ *
+ *  Exported (only) so unit tests can exercise this projection directly
+ *  against hand-built raw messages, without ever loading the real SDK —
+ *  `loadSdk`/`createSdkQuery`'s own dynamic import is the one thing here
+ *  that genuinely needs a live credential, and is covered by the gated
+ *  engine.live.test.ts instead. */
+export async function* adapt(stream: AsyncIterable<Record<string, unknown>>): AsyncGenerator<EngineMessage> {
+  for await (const message of stream) {
+    const type = message["type"];
+    if (type === "assistant") {
+      const content = (message["message"] as { content?: Array<Record<string, unknown>> } | undefined)?.content;
+      for (const block of content ?? []) {
+        if (block["type"] === "text" && typeof block["text"] === "string" && block["text"].length > 0) {
+          yield { kind: "progress", text: block["text"] };
+        } else if (block["type"] === "tool_use" && typeof block["name"] === "string") {
+          const input = block["input"] as { file_path?: unknown; pattern?: unknown } | undefined;
+          const target = typeof input?.file_path === "string" ? input.file_path
+            : typeof input?.pattern === "string" ? input.pattern : "";
+          yield { kind: "progress", text: `${block["name"]} ${target}`.trim() };
+        }
+      }
+    } else if (type === "result") {
+      if (message["subtype"] === "success" && typeof message["result"] === "string") {
+        yield { kind: "success", text: message["result"] };
+      } else {
+        const errors = message["errors"];
+        yield {
+          kind: "failure",
+          errors: Array.isArray(errors) && errors.every((e) => typeof e === "string")
+            ? errors
+            : [`engine ${String(message["subtype"] ?? "error")}`],
+        };
+      }
+      return;
+    }
+  }
+}
+
+/** Builds the real EngineDeps["query"]. Isolation notes:
+ *  - `settingSources: []` — never load the dev's ~/.claude or project
+ *    settings/hooks (the whole point of running this as a separate,
+ *    npx-fetched process rather than the dev's own `claude` session).
+ *  - `tools`/`allowedTools` restrict AND auto-allow the read-only set so a
+ *    headless run never blocks on a permission prompt nobody can answer;
+ *    `disallowedTools` is belt-and-suspenders against upstream additions to
+ *    the default tool set.
+ *  - `persistSession: false` — one-shot job, no ~/.claude/projects/
+ *    transcript left behind on whatever machine runs this.
+ *  - No `env` option is set: per the SDK's own default, omitting it means
+ *    the subprocess inherits `process.env` verbatim — exactly the "pass
+ *    credentials through untouched" contract (ANTHROPIC_API_KEY or
+ *    ANTHROPIC_BASE_URL/ANTHROPIC_AUTH_TOKEN/ANTHROPIC_CUSTOM_HEADERS). */
+export function createSdkQuery(): EngineDeps["query"] {
+  return async function* query(job: EngineJob): AsyncGenerator<EngineMessage> {
+    const sdk = await loadSdk();
+    const stream = sdk.query({
+      prompt: job.instructions,
+      options: {
+        cwd: job.root,
+        settingSources: [],
+        tools: ALLOWED_TOOLS,
+        allowedTools: ALLOWED_TOOLS,
+        disallowedTools: DISALLOWED_TOOLS,
+        permissionMode: "default",
+        maxTurns: MAX_TURNS,
+        persistSession: false,
+      },
+    });
+    yield* adapt(stream);
+  };
+}

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -1,0 +1,42 @@
+/**
+ * The whole cross-repo contract lives here: a job in, a result out. Nothing
+ * in this file (or in run-engine-job.ts, which is the only file that reads
+ * it) may import the real `@anthropic-ai/claude-agent-sdk` package — that
+ * import is confined to sdk-seam.ts, and only inside a dynamic `import()`
+ * that fires at run time, never at module-load time. That is what lets
+ * unit tests (and typecheck of the core) exercise this package without ever
+ * resolving the SDK's ~245MB platform binary.
+ */
+
+/** Stdin shape, verbatim from the harness that invokes `vendo-engine run`. */
+export interface EngineJob {
+  /** The full task prompt for the agent. Opaque to this package. */
+  instructions: string;
+  /** Absolute path the read-only tool policy is rooted at (session cwd). */
+  root: string;
+}
+
+/**
+ * A hand-rolled, minimal projection of the Agent SDK's message stream —
+ * only the three shapes the runner core actually branches on. Real SDK
+ * messages carry dozens of variants (see sdk-seam.ts's `adapt`); everything
+ * else collapses into "progress" narration.
+ */
+export type EngineMessage =
+  | { kind: "progress"; text: string }
+  | { kind: "success"; text: string }
+  | { kind: "failure"; errors: string[] };
+
+/** The injectable seam. Tests script this directly; the CLI wires the real
+ *  Agent SDK session through sdk-seam.ts's `createSdkQuery()`. */
+export interface EngineDeps {
+  query(job: EngineJob): AsyncIterable<EngineMessage>;
+}
+
+export interface EngineRunResult {
+  ok: boolean;
+  /** The agent's final message text. Only meaningful when `ok` is true. */
+  text: string;
+  /** Populated only when `ok` is false. */
+  errors: string[];
+}

--- a/packages/engine/tsconfig.json
+++ b/packages/engine/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.live.test.ts"]
+}

--- a/packages/engine/tsconfig.test.json
+++ b/packages/engine/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json-summary"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/**/*.live.test.ts"],
+      // Ratcheted line-coverage floor (ENG-255 convention): set at/just below
+      // the measured value (88.62%). The remaining gap is entirely
+      // sdk-seam.ts's `loadSdk`/`createSdkQuery` — the one place that
+      // touches the real Agent SDK via a dynamic import, deliberately
+      // exercised only by the gated engine.live.test.ts, never by a
+      // scripted unit test (see that file's own seam-boundary comment).
+      thresholds: { lines: 88 },
+    },
+  },
+});

--- a/packages/vendo/src/cli/extract/claude-cli-harness.test.ts
+++ b/packages/vendo/src/cli/extract/claude-cli-harness.test.ts
@@ -90,4 +90,117 @@ describe("claudeCliHarness", () => {
     await expect(harness.run({ root: "/x", env: {}, instructions: "go" }))
       .rejects.toThrow(/auth failed: token expired/);
   });
+
+  it("relays a gateway refusal message verbatim, without truncation", async () => {
+    const refusal =
+      "init-inference-blocked: Vendo Cloud gateway inference is not available on the free plan during "
+      + "`vendo init`. Bring your own Claude Code login or ANTHROPIC_API_KEY, or upgrade your org's plan.";
+    const harness = claudeCliHarness({
+      exec: async () => ({ stdout: "", stderr: refusal, code: 1 }),
+    });
+    await expect(harness.run({ root: "/x", env: {}, instructions: "go" }))
+      .rejects.toThrow(new RegExp(refusal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  });
+
+  describe("Vendo Cloud gateway fuel", () => {
+    it("does not label or fuel the rung on VENDO_API_KEY alone when the binary is absent", async () => {
+      const harness = claudeCliHarness({ probeBinary: async () => false, probeLogin: async () => false });
+      expect(await harness.availability({ root: "/x", env: { VENDO_API_KEY: "vnd_x" } })).toBeNull();
+    });
+
+    it("labels the rung with the Vendo Cloud key when no own credential is available", async () => {
+      const harness = claudeCliHarness({
+        probeBinary: async () => true,
+        probeLogin: async () => false,
+      });
+      expect(await harness.availability({ root: "/x", env: { VENDO_API_KEY: "vnd_x" } }))
+        .toBe("your Vendo Cloud key (managed inference)");
+    });
+
+    it("prefers ANTHROPIC_API_KEY's label over the Vendo Cloud key when both are set", async () => {
+      const harness = claudeCliHarness({
+        probeBinary: async () => true,
+        probeLogin: async () => false,
+      });
+      expect(await harness.availability({
+        root: "/x",
+        env: { ANTHROPIC_API_KEY: "sk", VENDO_API_KEY: "vnd_x" },
+      })).toBe("your ANTHROPIC_API_KEY");
+    });
+
+    it("prefers the Claude Code login label over the Vendo Cloud key when both are usable", async () => {
+      const harness = claudeCliHarness({
+        probeBinary: async () => true,
+        probeLogin: async () => true,
+      });
+      expect(await harness.availability({ root: "/x", env: { VENDO_API_KEY: "vnd_x" } }))
+        .toBe("your Claude Code login");
+    });
+
+    it("does not overlay the env when ANTHROPIC_API_KEY is present (own credential wins)", async () => {
+      let capturedEnv: NodeJS.ProcessEnv | undefined;
+      const harness = claudeCliHarness({
+        probeLogin: async () => false,
+        exec: async (_args, options) => {
+          capturedEnv = options.env;
+          return { stdout: "ok", stderr: "", code: 0 };
+        },
+      });
+      await harness.run({
+        root: "/x",
+        env: { ANTHROPIC_API_KEY: "sk", VENDO_API_KEY: "vnd_x" },
+        instructions: "go",
+      });
+      expect(capturedEnv?.ANTHROPIC_BASE_URL).toBeUndefined();
+      expect(capturedEnv?.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+      expect(capturedEnv?.ANTHROPIC_CUSTOM_HEADERS).toBeUndefined();
+    });
+
+    it("does not overlay the env when the Claude Code login is satisfied (own credential wins)", async () => {
+      let capturedEnv: NodeJS.ProcessEnv | undefined;
+      const harness = claudeCliHarness({
+        probeLogin: async () => true,
+        exec: async (_args, options) => {
+          capturedEnv = options.env;
+          return { stdout: "ok", stderr: "", code: 0 };
+        },
+      });
+      await harness.run({ root: "/x", env: { VENDO_API_KEY: "vnd_x" }, instructions: "go" });
+      expect(capturedEnv?.ANTHROPIC_BASE_URL).toBeUndefined();
+      expect(capturedEnv?.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+      expect(capturedEnv?.ANTHROPIC_CUSTOM_HEADERS).toBeUndefined();
+    });
+
+    it("does not probe the Claude Code login (no side effect) when VENDO_API_KEY is unset", async () => {
+      let probeCalls = 0;
+      const harness = claudeCliHarness({
+        probeLogin: async () => {
+          probeCalls += 1;
+          return false;
+        },
+        exec: async () => ({ stdout: "ok", stderr: "", code: 0 }),
+      });
+      await harness.run({ root: "/x", env: {}, instructions: "go" });
+      expect(probeCalls).toBe(0);
+    });
+
+    it("overlays the gateway env, tagged with the init-purpose header, when unauthenticated and VENDO_API_KEY is set", async () => {
+      let capturedEnv: NodeJS.ProcessEnv | undefined;
+      const harness = claudeCliHarness({
+        probeLogin: async () => false,
+        exec: async (_args, options) => {
+          capturedEnv = options.env;
+          return { stdout: "ok", stderr: "", code: 0 };
+        },
+      });
+      await harness.run({
+        root: "/x",
+        env: { VENDO_API_KEY: "vnd_x", VENDO_CLOUD_URL: "http://localhost:3001/" },
+        instructions: "go",
+      });
+      expect(capturedEnv?.ANTHROPIC_BASE_URL).toBe("http://localhost:3001/api/v1");
+      expect(capturedEnv?.ANTHROPIC_AUTH_TOKEN).toBe("vnd_x");
+      expect(capturedEnv?.ANTHROPIC_CUSTOM_HEADERS).toBe("x-vendo-purpose: init");
+    });
+  });
 });

--- a/packages/vendo/src/cli/extract/claude-cli-harness.test.ts
+++ b/packages/vendo/src/cli/extract/claude-cli-harness.test.ts
@@ -137,6 +137,42 @@ describe("claudeCliHarness", () => {
         .toBe("your Claude Code login");
     });
 
+    it("labels the rung with ANTHROPIC_AUTH_TOKEN, not the Vendo Cloud key, when both are set (corporate gateway)", async () => {
+      const harness = claudeCliHarness({ probeBinary: async () => true, probeLogin: async () => false });
+      expect(await harness.availability({
+        root: "/x",
+        env: { ANTHROPIC_AUTH_TOKEN: "corp-token", VENDO_API_KEY: "vnd_x" },
+      })).toBe("your ANTHROPIC_AUTH_TOKEN");
+    });
+
+    it("labels the rung with ANTHROPIC_AUTH_TOKEN even with a custom ANTHROPIC_BASE_URL set alongside it", async () => {
+      const harness = claudeCliHarness({ probeBinary: async () => true, probeLogin: async () => false });
+      expect(await harness.availability({
+        root: "/x",
+        env: {
+          ANTHROPIC_AUTH_TOKEN: "corp-token",
+          ANTHROPIC_BASE_URL: "https://anthropic.corp.example.com",
+          VENDO_API_KEY: "vnd_x",
+        },
+      })).toBe("your ANTHROPIC_AUTH_TOKEN");
+    });
+
+    it("labels the rung with CLAUDE_CODE_OAUTH_TOKEN, not the Vendo Cloud key, when both are set", async () => {
+      const harness = claudeCliHarness({ probeBinary: async () => true, probeLogin: async () => false });
+      expect(await harness.availability({
+        root: "/x",
+        env: { CLAUDE_CODE_OAUTH_TOKEN: "oauth-token", VENDO_API_KEY: "vnd_x" },
+      })).toBe("your CLAUDE_CODE_OAUTH_TOKEN");
+    });
+
+    it("labels the rung with ANTHROPIC_BASE_URL when only a custom base URL is set (no token), not the Vendo Cloud key", async () => {
+      const harness = claudeCliHarness({ probeBinary: async () => true, probeLogin: async () => false });
+      expect(await harness.availability({
+        root: "/x",
+        env: { ANTHROPIC_BASE_URL: "https://anthropic.corp.example.com", VENDO_API_KEY: "vnd_x" },
+      })).toBe("your ANTHROPIC_BASE_URL");
+    });
+
     it("does not overlay the env when ANTHROPIC_API_KEY is present (own credential wins)", async () => {
       let capturedEnv: NodeJS.ProcessEnv | undefined;
       const harness = claudeCliHarness({
@@ -181,6 +217,101 @@ describe("claudeCliHarness", () => {
         exec: async () => ({ stdout: "ok", stderr: "", code: 0 }),
       });
       await harness.run({ root: "/x", env: {}, instructions: "go" });
+      expect(probeCalls).toBe(0);
+    });
+
+    it("does not overlay when ANTHROPIC_AUTH_TOKEN is set (corporate gateway), and skips the login probe", async () => {
+      let capturedEnv: NodeJS.ProcessEnv | undefined;
+      let probeCalls = 0;
+      const harness = claudeCliHarness({
+        probeLogin: async () => {
+          probeCalls += 1;
+          return false;
+        },
+        exec: async (_args, options) => {
+          capturedEnv = options.env;
+          return { stdout: "ok", stderr: "", code: 0 };
+        },
+      });
+      await harness.run({
+        root: "/x",
+        env: { ANTHROPIC_AUTH_TOKEN: "corp-token", VENDO_API_KEY: "vnd_x" },
+        instructions: "go",
+      });
+      expect(capturedEnv?.ANTHROPIC_BASE_URL).toBeUndefined();
+      expect(capturedEnv?.ANTHROPIC_CUSTOM_HEADERS).toBeUndefined();
+      // the caller's own ANTHROPIC_AUTH_TOKEN must survive untouched
+      expect(capturedEnv?.ANTHROPIC_AUTH_TOKEN).toBe("corp-token");
+      expect(probeCalls).toBe(0);
+    });
+
+    it("does not overlay when ANTHROPIC_AUTH_TOKEN is paired with a custom ANTHROPIC_BASE_URL (corporate gateway)", async () => {
+      let capturedEnv: NodeJS.ProcessEnv | undefined;
+      const harness = claudeCliHarness({
+        probeLogin: async () => false,
+        exec: async (_args, options) => {
+          capturedEnv = options.env;
+          return { stdout: "ok", stderr: "", code: 0 };
+        },
+      });
+      await harness.run({
+        root: "/x",
+        env: {
+          ANTHROPIC_AUTH_TOKEN: "corp-token",
+          ANTHROPIC_BASE_URL: "https://anthropic.corp.example.com",
+          VENDO_API_KEY: "vnd_x",
+        },
+        instructions: "go",
+      });
+      expect(capturedEnv?.ANTHROPIC_BASE_URL).toBe("https://anthropic.corp.example.com");
+      expect(capturedEnv?.ANTHROPIC_AUTH_TOKEN).toBe("corp-token");
+      expect(capturedEnv?.ANTHROPIC_CUSTOM_HEADERS).toBeUndefined();
+    });
+
+    it("does not overlay when CLAUDE_CODE_OAUTH_TOKEN is set, and skips the login probe", async () => {
+      let capturedEnv: NodeJS.ProcessEnv | undefined;
+      let probeCalls = 0;
+      const harness = claudeCliHarness({
+        probeLogin: async () => {
+          probeCalls += 1;
+          return false;
+        },
+        exec: async (_args, options) => {
+          capturedEnv = options.env;
+          return { stdout: "ok", stderr: "", code: 0 };
+        },
+      });
+      await harness.run({
+        root: "/x",
+        env: { CLAUDE_CODE_OAUTH_TOKEN: "oauth-token", VENDO_API_KEY: "vnd_x" },
+        instructions: "go",
+      });
+      expect(capturedEnv?.ANTHROPIC_BASE_URL).toBeUndefined();
+      expect(capturedEnv?.ANTHROPIC_CUSTOM_HEADERS).toBeUndefined();
+      expect(capturedEnv?.CLAUDE_CODE_OAUTH_TOKEN).toBe("oauth-token");
+      expect(probeCalls).toBe(0);
+    });
+
+    it("does not overlay when only ANTHROPIC_BASE_URL is set (no token), and skips the login probe", async () => {
+      let capturedEnv: NodeJS.ProcessEnv | undefined;
+      let probeCalls = 0;
+      const harness = claudeCliHarness({
+        probeLogin: async () => {
+          probeCalls += 1;
+          return false;
+        },
+        exec: async (_args, options) => {
+          capturedEnv = options.env;
+          return { stdout: "ok", stderr: "", code: 0 };
+        },
+      });
+      await harness.run({
+        root: "/x",
+        env: { ANTHROPIC_BASE_URL: "https://anthropic.corp.example.com", VENDO_API_KEY: "vnd_x" },
+        instructions: "go",
+      });
+      expect(capturedEnv?.ANTHROPIC_BASE_URL).toBe("https://anthropic.corp.example.com");
+      expect(capturedEnv?.ANTHROPIC_CUSTOM_HEADERS).toBeUndefined();
       expect(probeCalls).toBe(0);
     });
 

--- a/packages/vendo/src/cli/extract/claude-cli-harness.test.ts
+++ b/packages/vendo/src/cli/extract/claude-cli-harness.test.ts
@@ -1,7 +1,28 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { claudeCliHarness } from "./claude-cli-harness.js";
 
+// The harness now judges credentials against {...process.env, ...input.env}
+// (the env the child actually spawns with), so ambient credentials on the
+// machine running the suite must be cleared for these controlled-env
+// expectations to hold anywhere.
+const AMBIENT_CREDENTIAL_VARS = [
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "ANTHROPIC_BASE_URL",
+  "ANTHROPIC_CUSTOM_HEADERS",
+  "VENDO_API_KEY",
+  "VENDO_CLOUD_URL",
+] as const;
+
 describe("claudeCliHarness", () => {
+  beforeEach(() => {
+    for (const name of AMBIENT_CREDENTIAL_VARS) vi.stubEnv(name, undefined);
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("is unavailable without the claude binary on PATH, regardless of credentials", async () => {
     const harness = claudeCliHarness({ probeBinary: async () => false, probeLogin: async () => true });
     expect(await harness.availability({ root: "/x", env: { ANTHROPIC_API_KEY: "sk" } })).toBeNull();
@@ -313,6 +334,61 @@ describe("claudeCliHarness", () => {
       expect(capturedEnv?.ANTHROPIC_BASE_URL).toBe("https://anthropic.corp.example.com");
       expect(capturedEnv?.ANTHROPIC_CUSTOM_HEADERS).toBeUndefined();
       expect(probeCalls).toBe(0);
+    });
+
+    // AI-review fix: the guard must see the child's REAL env. The child
+    // spawns with {...process.env, ...input.env, ...overlay}, so an ambient
+    // (process.env) BYO credential with a partial input.env carrying only
+    // VENDO_API_KEY previously slipped past the input.env-only guard and got
+    // its endpoint clobbered by the gateway overlay.
+    it("does not overlay when ANTHROPIC_AUTH_TOKEN is ambient in process.env and input.env carries only VENDO_API_KEY", async () => {
+      vi.stubEnv("ANTHROPIC_AUTH_TOKEN", "ambient-corp-token");
+      let capturedEnv: NodeJS.ProcessEnv | undefined;
+      let probeCalls = 0;
+      const harness = claudeCliHarness({
+        probeLogin: async () => {
+          probeCalls += 1;
+          return false;
+        },
+        exec: async (_args, options) => {
+          capturedEnv = options.env;
+          return { stdout: "ok", stderr: "", code: 0 };
+        },
+      });
+      await harness.run({ root: "/x", env: { VENDO_API_KEY: "vnd_x" }, instructions: "go" });
+      // The ambient token survives untouched — the overlay must not clobber it.
+      expect(capturedEnv?.ANTHROPIC_AUTH_TOKEN).toBe("ambient-corp-token");
+      expect(capturedEnv?.ANTHROPIC_BASE_URL).toBeUndefined();
+      expect(capturedEnv?.ANTHROPIC_CUSTOM_HEADERS).toBeUndefined();
+      // Env-based own credential short-circuits the login probe, same as
+      // when the token rides input.env.
+      expect(probeCalls).toBe(0);
+    });
+
+    it("labels the rung with the ambient ANTHROPIC_AUTH_TOKEN, not the Vendo Cloud key (labels agree with run())", async () => {
+      vi.stubEnv("ANTHROPIC_AUTH_TOKEN", "ambient-corp-token");
+      const harness = claudeCliHarness({ probeBinary: async () => true, probeLogin: async () => false });
+      expect(await harness.availability({ root: "/x", env: { VENDO_API_KEY: "vnd_x" } }))
+        .toBe("your ANTHROPIC_AUTH_TOKEN");
+    });
+
+    it("lets input.env win over an ambient credential for the guard, matching child-env precedence", async () => {
+      vi.stubEnv("ANTHROPIC_AUTH_TOKEN", "ambient-corp-token");
+      let capturedEnv: NodeJS.ProcessEnv | undefined;
+      const harness = claudeCliHarness({
+        probeLogin: async () => false,
+        exec: async (_args, options) => {
+          capturedEnv = options.env;
+          return { stdout: "ok", stderr: "", code: 0 };
+        },
+      });
+      await harness.run({
+        root: "/x",
+        env: { ANTHROPIC_AUTH_TOKEN: "caller-token", VENDO_API_KEY: "vnd_x" },
+        instructions: "go",
+      });
+      expect(capturedEnv?.ANTHROPIC_AUTH_TOKEN).toBe("caller-token");
+      expect(capturedEnv?.ANTHROPIC_CUSTOM_HEADERS).toBeUndefined();
     });
 
     it("overlays the gateway env, tagged with the init-purpose header, when unauthenticated and VENDO_API_KEY is set", async () => {

--- a/packages/vendo/src/cli/extract/claude-cli-harness.ts
+++ b/packages/vendo/src/cli/extract/claude-cli-harness.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { composeGatewayFuel, type GatewayFuelOverlay } from "./gateway-fuel.js";
 import type { ExtractionHarness, ExtractionRunInput } from "./harness.js";
 
 /**
@@ -14,6 +15,12 @@ import type { ExtractionHarness, ExtractionRunInput } from "./harness.js";
  * Isolation: `--setting-sources ""` (never inherit the dev's personal Claude
  * Code settings/hooks — same intent as claude-harness.ts's
  * `settingSources: []`), read-only tool allowlist, no shell/web/write surface.
+ *
+ * Gateway fuel: when neither an ANTHROPIC_API_KEY nor a Claude Code login is
+ * available but VENDO_API_KEY is set, the rung runs on Vendo Cloud's model
+ * gateway instead of degrading to unavailable (see gateway-fuel.ts). Own
+ * credential always wins — this never overrides a working ANTHROPIC_API_KEY
+ * or login.
  */
 
 const ALLOWED_TOOLS = ["Read", "Glob", "Grep"];
@@ -76,6 +83,21 @@ export interface ClaudeCliHarnessOptions {
   exec?: Exec;
 }
 
+/** Gateway fuel only ever matters when VENDO_API_KEY is set — skip the
+ *  (async) login probe entirely otherwise, so the own-credential path never
+ *  pays for or is affected by this check. */
+async function resolveGatewayFuelOverlay(
+  env: Record<string, string | undefined>,
+  probeLogin: () => Promise<boolean>,
+): Promise<GatewayFuelOverlay | null> {
+  const cloudKey = env["VENDO_API_KEY"];
+  if (typeof cloudKey !== "string" || cloudKey.trim().length === 0) return null;
+  const ownKey = env["ANTHROPIC_API_KEY"];
+  const hasOwnKey = typeof ownKey === "string" && ownKey.trim().length > 0;
+  const ownCredentialAvailable = hasOwnKey || (await probeLogin());
+  return composeGatewayFuel({ env, ownCredentialAvailable });
+}
+
 export function claudeCliHarness(options: ClaudeCliHarnessOptions = {}): ExtractionHarness {
   const hasBinary = options.probeBinary ?? probeClaudeBinary;
   const probe = options.probeLogin ?? probeClaudeLogin;
@@ -87,6 +109,10 @@ export function claudeCliHarness(options: ClaudeCliHarnessOptions = {}): Extract
       const key = env["ANTHROPIC_API_KEY"];
       if (typeof key === "string" && key.trim().length > 0) return "your ANTHROPIC_API_KEY";
       if (await probe()) return "your Claude Code login";
+      const cloudKey = env["VENDO_API_KEY"];
+      if (typeof cloudKey === "string" && cloudKey.trim().length > 0) {
+        return "your Vendo Cloud key (managed inference)";
+      }
       return null;
     },
     async run(input: ExtractionRunInput): Promise<string> {
@@ -98,9 +124,11 @@ export function claudeCliHarness(options: ClaudeCliHarnessOptions = {}): Extract
         "--setting-sources", "",
         ...(model === undefined ? [] : ["--model", model]),
       ];
+      const overlay = await resolveGatewayFuelOverlay(input.env, probe);
       // Forward the caller's env so a key present only in the passed map
-      // (not process.env) still authenticates the subprocess.
-      const result = await exec(args, { cwd: input.root, env: { ...process.env, ...input.env } });
+      // (not process.env) still authenticates the subprocess; gateway fuel
+      // (if applicable) wins last.
+      const result = await exec(args, { cwd: input.root, env: { ...process.env, ...input.env, ...overlay } });
       if (result.code !== 0) {
         throw new Error(`claude exited with code ${result.code}: ${result.stderr.trim() || "(no stderr)"}`);
       }

--- a/packages/vendo/src/cli/extract/claude-cli-harness.ts
+++ b/packages/vendo/src/cli/extract/claude-cli-harness.ts
@@ -113,12 +113,19 @@ export function claudeCliHarness(options: ClaudeCliHarnessOptions = {}): Extract
     id: "claude-cli",
     async availability({ env }) {
       if (!(await hasBinary())) return null;
-      if (isSet(env["ANTHROPIC_API_KEY"])) return "your ANTHROPIC_API_KEY";
-      if (isSet(env["ANTHROPIC_AUTH_TOKEN"])) return "your ANTHROPIC_AUTH_TOKEN";
-      if (isSet(env["CLAUDE_CODE_OAUTH_TOKEN"])) return "your CLAUDE_CODE_OAUTH_TOKEN";
-      if (isSet(env["ANTHROPIC_BASE_URL"])) return "your ANTHROPIC_BASE_URL";
+      // The child spawns with {...process.env, ...input.env} (see run()), so
+      // credential checks and labels must see that SAME merged view: a
+      // programmatic caller passing a partial env (say VENDO_API_KEY only)
+      // while ambient process.env carries an ANTHROPIC_AUTH_TOKEN really
+      // runs on that ambient token — labeling (or fueling) it as the Vendo
+      // Cloud key would lie about, or worse clobber, the dev's own endpoint.
+      const merged = { ...process.env, ...env };
+      if (isSet(merged["ANTHROPIC_API_KEY"])) return "your ANTHROPIC_API_KEY";
+      if (isSet(merged["ANTHROPIC_AUTH_TOKEN"])) return "your ANTHROPIC_AUTH_TOKEN";
+      if (isSet(merged["CLAUDE_CODE_OAUTH_TOKEN"])) return "your CLAUDE_CODE_OAUTH_TOKEN";
+      if (isSet(merged["ANTHROPIC_BASE_URL"])) return "your ANTHROPIC_BASE_URL";
       if (await probe()) return "your Claude Code login";
-      if (isSet(env["VENDO_API_KEY"])) return "your Vendo Cloud key (managed inference)";
+      if (isSet(merged["VENDO_API_KEY"])) return "your Vendo Cloud key (managed inference)";
       return null;
     },
     async run(input: ExtractionRunInput): Promise<string> {
@@ -130,11 +137,14 @@ export function claudeCliHarness(options: ClaudeCliHarnessOptions = {}): Extract
         "--setting-sources", "",
         ...(model === undefined ? [] : ["--model", model]),
       ];
-      const overlay = await resolveGatewayFuelOverlay(input.env, probe);
-      // Forward the caller's env so a key present only in the passed map
-      // (not process.env) still authenticates the subprocess; gateway fuel
-      // (if applicable) wins last.
-      const result = await exec(args, { cwd: input.root, env: { ...process.env, ...input.env, ...overlay } });
+      // Merge FIRST, then guard: the child is spawned with the caller's env
+      // over process.env, so the own-credential check and gateway fuel must
+      // evaluate that same merged env — guarding input.env alone would let
+      // the overlay clobber an ambient (process.env) BYO endpoint the child
+      // would otherwise have used. Gateway fuel (if applicable) wins last.
+      const merged = { ...process.env, ...input.env };
+      const overlay = await resolveGatewayFuelOverlay(merged, probe);
+      const result = await exec(args, { cwd: input.root, env: { ...merged, ...overlay } });
       if (result.code !== 0) {
         throw new Error(`claude exited with code ${result.code}: ${result.stderr.trim() || "(no stderr)"}`);
       }

--- a/packages/vendo/src/cli/extract/claude-cli-harness.ts
+++ b/packages/vendo/src/cli/extract/claude-cli-harness.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { composeGatewayFuel, type GatewayFuelOverlay } from "./gateway-fuel.js";
+import { composeGatewayFuel, hasOwnAnthropicEnvOverride, type GatewayFuelOverlay } from "./gateway-fuel.js";
 import type { ExtractionHarness, ExtractionRunInput } from "./harness.js";
 
 /**
@@ -16,11 +16,12 @@ import type { ExtractionHarness, ExtractionRunInput } from "./harness.js";
  * Code settings/hooks — same intent as claude-harness.ts's
  * `settingSources: []`), read-only tool allowlist, no shell/web/write surface.
  *
- * Gateway fuel: when neither an ANTHROPIC_API_KEY nor a Claude Code login is
- * available but VENDO_API_KEY is set, the rung runs on Vendo Cloud's model
- * gateway instead of degrading to unavailable (see gateway-fuel.ts). Own
- * credential always wins — this never overrides a working ANTHROPIC_API_KEY
- * or login.
+ * Gateway fuel: when the dev has none of ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN,
+ * CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_BASE_URL (the corporate-gateway/custom-
+ * endpoint path), or a Claude Code login, but VENDO_API_KEY is set, the rung
+ * runs on Vendo Cloud's model gateway instead of degrading to unavailable
+ * (see gateway-fuel.ts). Own credential always wins — this never overrides a
+ * working ANTHROPIC_API_KEY, login, or any of those env vars.
  */
 
 const ALLOWED_TOOLS = ["Read", "Glob", "Grep"];
@@ -83,18 +84,24 @@ export interface ClaudeCliHarnessOptions {
   exec?: Exec;
 }
 
+function isSet(value: string | undefined): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
 /** Gateway fuel only ever matters when VENDO_API_KEY is set — skip the
  *  (async) login probe entirely otherwise, so the own-credential path never
- *  pays for or is affected by this check. */
+ *  pays for or is affected by this check. Env-based own-credential checks
+ *  (ANTHROPIC_API_KEY, then OWN_CREDENTIAL_ENV_VARS) run before the probe
+ *  too, since they're cheap and the probe is a subprocess spawn. */
 async function resolveGatewayFuelOverlay(
   env: Record<string, string | undefined>,
   probeLogin: () => Promise<boolean>,
 ): Promise<GatewayFuelOverlay | null> {
   const cloudKey = env["VENDO_API_KEY"];
-  if (typeof cloudKey !== "string" || cloudKey.trim().length === 0) return null;
-  const ownKey = env["ANTHROPIC_API_KEY"];
-  const hasOwnKey = typeof ownKey === "string" && ownKey.trim().length > 0;
-  const ownCredentialAvailable = hasOwnKey || (await probeLogin());
+  if (!isSet(cloudKey)) return null;
+  const ownCredentialAvailable = isSet(env["ANTHROPIC_API_KEY"])
+    || hasOwnAnthropicEnvOverride(env)
+    || (await probeLogin());
   return composeGatewayFuel({ env, ownCredentialAvailable });
 }
 
@@ -106,13 +113,12 @@ export function claudeCliHarness(options: ClaudeCliHarnessOptions = {}): Extract
     id: "claude-cli",
     async availability({ env }) {
       if (!(await hasBinary())) return null;
-      const key = env["ANTHROPIC_API_KEY"];
-      if (typeof key === "string" && key.trim().length > 0) return "your ANTHROPIC_API_KEY";
+      if (isSet(env["ANTHROPIC_API_KEY"])) return "your ANTHROPIC_API_KEY";
+      if (isSet(env["ANTHROPIC_AUTH_TOKEN"])) return "your ANTHROPIC_AUTH_TOKEN";
+      if (isSet(env["CLAUDE_CODE_OAUTH_TOKEN"])) return "your CLAUDE_CODE_OAUTH_TOKEN";
+      if (isSet(env["ANTHROPIC_BASE_URL"])) return "your ANTHROPIC_BASE_URL";
       if (await probe()) return "your Claude Code login";
-      const cloudKey = env["VENDO_API_KEY"];
-      if (typeof cloudKey === "string" && cloudKey.trim().length > 0) {
-        return "your Vendo Cloud key (managed inference)";
-      }
+      if (isSet(env["VENDO_API_KEY"])) return "your Vendo Cloud key (managed inference)";
       return null;
     },
     async run(input: ExtractionRunInput): Promise<string> {

--- a/packages/vendo/src/cli/extract/codex-cli-harness.test.ts
+++ b/packages/vendo/src/cli/extract/codex-cli-harness.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { codexCliHarness } from "./codex-cli-harness.js";
+
+describe("codexCliHarness", () => {
+  it("is unavailable without the codex binary on PATH, regardless of credentials", async () => {
+    const harness = codexCliHarness({ probeBinary: async () => false, probeLogin: async () => true });
+    expect(await harness.availability({ root: "/x", env: { OPENAI_API_KEY: "sk" } })).toBeNull();
+  });
+
+  it("prefers the env key label, then the ChatGPT login", async () => {
+    const withBinary = { probeBinary: async () => true };
+    expect(await codexCliHarness({ ...withBinary, probeLogin: async () => false })
+      .availability({ root: "/x", env: { OPENAI_API_KEY: "sk" } })).toBe("your OPENAI_API_KEY");
+    expect(await codexCliHarness({ ...withBinary, probeLogin: async () => true })
+      .availability({ root: "/x", env: {} })).toBe("your ChatGPT login");
+    expect(await codexCliHarness({ ...withBinary, probeLogin: async () => false })
+      .availability({ root: "/x", env: {} })).toBeNull();
+  });
+
+  it("falls through to null when codex is present but unauthenticated (no env key, no login)", async () => {
+    const harness = codexCliHarness({ probeBinary: async () => true, probeLogin: async () => false });
+    expect(await harness.availability({ root: "/x", env: {} })).toBeNull();
+  });
+
+  it("invokes codex headless with exec mode, read-only sandbox, and isolated config", async () => {
+    let capturedArgs: string[] = [];
+    const harness = codexCliHarness({
+      exec: async (args) => {
+        capturedArgs = args;
+        return { stdout: "the result", stderr: "", code: 0 };
+      },
+    });
+    const text = await harness.run({ root: "/host/root", env: {}, instructions: "go read the codebase" });
+    expect(text).toBe("the result");
+    expect(capturedArgs).toEqual([
+      "exec",
+      "--sandbox", "read-only",
+      "--skip-git-repo-check",
+      "--ignore-user-config",
+      "-C", "/host/root",
+      "go read the codebase",
+    ]);
+  });
+
+  it("passes cwd = host root and forwards the caller's env over process.env", async () => {
+    let capturedOptions: { cwd: string; env: NodeJS.ProcessEnv } | undefined;
+    const harness = codexCliHarness({
+      exec: async (_args, options) => {
+        capturedOptions = options;
+        return { stdout: "ok", stderr: "", code: 0 };
+      },
+    });
+    process.env["VENDO_CODEX_HARNESS_TEST_MARKER"] = "from-process-env";
+    try {
+      await harness.run({
+        root: "/host/root",
+        env: { CALLER_ONLY: "yes", VENDO_CODEX_HARNESS_TEST_MARKER: "from-caller" },
+        instructions: "go",
+      });
+    } finally {
+      delete process.env["VENDO_CODEX_HARNESS_TEST_MARKER"];
+    }
+    expect(capturedOptions?.cwd).toBe("/host/root");
+    expect(capturedOptions?.env["CALLER_ONLY"]).toBe("yes");
+    // caller env wins over process.env for a key present in both.
+    expect(capturedOptions?.env["VENDO_CODEX_HARNESS_TEST_MARKER"]).toBe("from-caller");
+  });
+
+  it("passes VENDO_EXTRACTION_MODEL as --model when set, and omits it otherwise", async () => {
+    let capturedArgs: string[] = [];
+    const harness = codexCliHarness({
+      exec: async (args) => {
+        capturedArgs = args;
+        return { stdout: "ok", stderr: "", code: 0 };
+      },
+    });
+    await harness.run({ root: "/x", env: {}, instructions: "go" });
+    expect(capturedArgs).not.toContain("--model");
+
+    await harness.run({ root: "/x", env: { VENDO_EXTRACTION_MODEL: "gpt-5-codex" }, instructions: "go" });
+    expect(capturedArgs.slice(-3)).toEqual(["--model", "gpt-5-codex", "go"]);
+  });
+
+  it("returns the final message text on success", async () => {
+    const harness = codexCliHarness({
+      exec: async () => ({ stdout: '{"brief":"b","tools":[]}', stderr: "", code: 0 }),
+    });
+    expect(await harness.run({ root: "/x", env: {}, instructions: "go" })).toBe('{"brief":"b","tools":[]}');
+  });
+
+  it("throws including stderr context on nonzero exit", async () => {
+    const harness = codexCliHarness({
+      exec: async () => ({ stdout: "", stderr: "auth failed: token expired", code: 1 }),
+    });
+    await expect(harness.run({ root: "/x", env: {}, instructions: "go" }))
+      .rejects.toThrow(/auth failed: token expired/);
+  });
+
+  it("throws a clear error when the exec seam reports failure without stderr", async () => {
+    const harness = codexCliHarness({
+      exec: async () => ({ stdout: "", stderr: "", code: 1 }),
+    });
+    await expect(harness.run({ root: "/x", env: {}, instructions: "go" }))
+      .rejects.toThrow(/codex exited with code 1/);
+  });
+});

--- a/packages/vendo/src/cli/extract/codex-cli-harness.test.ts
+++ b/packages/vendo/src/cli/extract/codex-cli-harness.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { codexCliHarness } from "./codex-cli-harness.js";
+import { codexCliHarness, insertOutputLastMessageFlag, resolveCodexExecResult } from "./codex-cli-harness.js";
 
 describe("codexCliHarness", () => {
   it("is unavailable without the codex binary on PATH, regardless of credentials", async () => {
@@ -102,5 +102,42 @@ describe("codexCliHarness", () => {
     });
     await expect(harness.run({ root: "/x", env: {}, instructions: "go" }))
       .rejects.toThrow(/codex exited with code 1/);
+  });
+});
+
+describe("insertOutputLastMessageFlag", () => {
+  it("inserts --output-last-message before the trailing free-text instructions positional, not after it", () => {
+    const args = ["exec", "--sandbox", "read-only", "-C", "/root", "go read the codebase --with a dash"];
+    expect(insertOutputLastMessageFlag(args, "/tmp/out.txt")).toEqual([
+      "exec", "--sandbox", "read-only", "-C", "/root",
+      "--output-last-message", "/tmp/out.txt",
+      "go read the codebase --with a dash",
+    ]);
+  });
+});
+
+describe("resolveCodexExecResult", () => {
+  it("passes the raw process result through unchanged on nonzero exit", () => {
+    expect(resolveCodexExecResult(1, "narration", "boom", undefined)).toEqual({
+      stdout: "narration",
+      stderr: "boom",
+      code: 1,
+    });
+  });
+
+  it("returns the final message as stdout on a clean exit with a readable output file", () => {
+    expect(resolveCodexExecResult(0, "narration", "", '{"brief":"b","tools":[]}')).toEqual({
+      stdout: '{"brief":"b","tools":[]}',
+      stderr: "",
+      code: 0,
+    });
+  });
+
+  it("synthesizes a code-1 failure when codex exits 0 but the output-last-message file is missing", () => {
+    expect(resolveCodexExecResult(0, "narration", "", undefined)).toEqual({
+      stdout: "",
+      stderr: "codex produced no final message (--output-last-message file missing)",
+      code: 1,
+    });
   });
 });

--- a/packages/vendo/src/cli/extract/codex-cli-harness.ts
+++ b/packages/vendo/src/cli/extract/codex-cli-harness.ts
@@ -1,0 +1,149 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtractionHarness, ExtractionRunInput } from "./harness.js";
+
+/**
+ * Fallback extraction harness: the `codex` CLI already on the dev's PATH,
+ * driven headless (`codex exec`) with a READ-ONLY sandbox over the host
+ * root. Credential = the dev's ChatGPT login (`codex login`), or their
+ * OPENAI_API_KEY — this is the third rung of the ladder (after the Agent SDK
+ * and claude-cli-harness.ts), for devs whose daily driver is Codex instead of
+ * Claude Code and who don't want to install anything new.
+ *
+ * Isolation: `--sandbox read-only` (model-generated shell commands can only
+ * read, never write or reach the network), `--skip-git-repo-check` (the host
+ * root may not itself be a git repo — codex refuses to run outside one by
+ * default, and extraction has no business caring), `--ignore-user-config`
+ * (never load the dev's personal `~/.codex/config.toml` — same intent as
+ * claude-cli-harness.ts's `--setting-sources ""`: their own MCP servers,
+ * custom instructions, or notify hooks must not leak into extraction; auth
+ * still resolves via CODEX_HOME regardless of this flag), `-C <root>` pins
+ * the agent's working root explicitly.
+ */
+
+const PROBE_TIMEOUT_MS = 5_000;
+// Extraction stages can run for minutes over a real codebase.
+const RUN_TIMEOUT_MS = 10 * 60 * 1_000;
+const MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+
+interface ExecResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+type Exec = (args: string[], options: { cwd: string; env: NodeJS.ProcessEnv }) => Promise<ExecResult>;
+
+/** `codex exec` has no print-mode equivalent to claude's `-p` stdout capture
+ *  — the terminal stream is full of tool-call narration. `--output-last-
+ *  message <file>` is codex's own mechanism for isolating just the agent's
+ *  final text, so the real spawn writes it to a throwaway temp file and
+ *  reads it back once the process exits cleanly. */
+function execCodex(args: string[], options: { cwd: string; env: NodeJS.ProcessEnv }): Promise<ExecResult> {
+  return (async () => {
+    const outDir = await mkdtemp(join(tmpdir(), "vendo-codex-extract-"));
+    const outputFile = join(outDir, "last-message.txt");
+    try {
+      return await new Promise<ExecResult>((resolve) => {
+        execFile(
+          "codex",
+          [...args, "--output-last-message", outputFile],
+          { cwd: options.cwd, env: options.env, timeout: RUN_TIMEOUT_MS, maxBuffer: MAX_BUFFER_BYTES },
+          (error, stdout, stderr) => {
+            const code = error === null ? 0 : typeof error.code === "number" ? error.code : 1;
+            if (code !== 0) {
+              resolve({ stdout, stderr, code });
+              return;
+            }
+            readFile(outputFile, "utf8").then(
+              (finalMessage) => resolve({ stdout: finalMessage, stderr, code }),
+              // codex exited 0 but wrote no final-message file — there is
+              // nothing for extraction.ts to parse; surface it as a failure
+              // through the same code-path run() already uses for errors.
+              () => resolve({
+                stdout: "",
+                stderr: "codex produced no final message (--output-last-message file missing)",
+                code: 1,
+              }),
+            );
+          },
+        );
+      });
+    } finally {
+      await rm(outDir, { recursive: true, force: true });
+    }
+  })();
+}
+
+/** Cheap presence check: does `codex` resolve and run at all? */
+function probeCodexBinary(): Promise<boolean> {
+  return new Promise((resolve) => {
+    execFile("codex", ["--version"], { timeout: PROBE_TIMEOUT_MS }, (error) => resolve(error === null));
+  });
+}
+
+/** Codex persists login state to `$CODEX_HOME/auth.json` (default
+ *  `~/.codex/auth.json`) — either a ChatGPT OAuth token pair (`auth_mode:
+ *  "chatgpt"`) or an API key saved via `codex login --with-api-key`.
+ *  `codex login status` has no machine-readable output, so this reads the
+ *  file directly: a plain fs read that's cheap and trivially fake-able in
+ *  tests without a real login. */
+async function probeCodexLogin(): Promise<boolean> {
+  const authPath = join(process.env["CODEX_HOME"] ?? join(homedir(), ".codex"), "auth.json");
+  try {
+    const parsed = JSON.parse(await readFile(authPath, "utf8")) as {
+      OPENAI_API_KEY?: unknown;
+      tokens?: { id_token?: unknown; access_token?: unknown };
+    };
+    if (typeof parsed.OPENAI_API_KEY === "string" && parsed.OPENAI_API_KEY.trim().length > 0) return true;
+    if (typeof parsed.tokens?.id_token === "string" && parsed.tokens.id_token.trim().length > 0) return true;
+    if (typeof parsed.tokens?.access_token === "string" && parsed.tokens.access_token.trim().length > 0) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+export interface CodexCliHarnessOptions {
+  /** Test seams. */
+  probeBinary?: () => Promise<boolean>;
+  probeLogin?: () => Promise<boolean>;
+  exec?: Exec;
+}
+
+export function codexCliHarness(options: CodexCliHarnessOptions = {}): ExtractionHarness {
+  const hasBinary = options.probeBinary ?? probeCodexBinary;
+  const probe = options.probeLogin ?? probeCodexLogin;
+  const exec = options.exec ?? execCodex;
+  return {
+    id: "codex-cli",
+    async availability({ env }) {
+      if (!(await hasBinary())) return null;
+      const key = env["OPENAI_API_KEY"];
+      if (typeof key === "string" && key.trim().length > 0) return "your OPENAI_API_KEY";
+      if (await probe()) return "your ChatGPT login";
+      return null;
+    },
+    async run(input: ExtractionRunInput): Promise<string> {
+      const model = input.env["VENDO_EXTRACTION_MODEL"];
+      const args = [
+        "exec",
+        "--sandbox", "read-only",
+        "--skip-git-repo-check",
+        "--ignore-user-config",
+        "-C", input.root,
+        ...(model === undefined ? [] : ["--model", model]),
+        input.instructions,
+      ];
+      // Forward the caller's env so a key present only in the passed map
+      // (not process.env) still authenticates the subprocess.
+      const result = await exec(args, { cwd: input.root, env: { ...process.env, ...input.env } });
+      if (result.code !== 0) {
+        throw new Error(`codex exited with code ${result.code}: ${result.stderr.trim() || "(no stderr)"}`);
+      }
+      return result.stdout;
+    },
+  };
+}

--- a/packages/vendo/src/cli/extract/codex-cli-harness.ts
+++ b/packages/vendo/src/cli/extract/codex-cli-harness.ts
@@ -26,6 +26,11 @@ import type { ExtractionHarness, ExtractionRunInput } from "./harness.js";
 const PROBE_TIMEOUT_MS = 5_000;
 // Extraction stages can run for minutes over a real codebase.
 const RUN_TIMEOUT_MS = 10 * 60 * 1_000;
+// codex's stdout under `exec` is throwaway tool-call narration — the actual
+// payload comes back via --output-last-message and is read separately below.
+// A narration stream over 10MB still trips execFile's maxBuffer and throws;
+// that's a known, accepted failure mode (loud, not silent), not something
+// worth raising just to tolerate noisier runs.
 const MAX_BUFFER_BYTES = 10 * 1024 * 1024;
 
 interface ExecResult {
@@ -35,6 +40,39 @@ interface ExecResult {
 }
 
 type Exec = (args: string[], options: { cwd: string; env: NodeJS.ProcessEnv }) => Promise<ExecResult>;
+
+/** Pure mapping from a completed `codex exec` subprocess (exit code/stderr)
+ *  plus the outcome of reading its `--output-last-message` file into the
+ *  harness's ExecResult. Pulled out of execCodex's callback and exported so
+ *  the missing-file fallback — codex exited 0 but somehow wrote nothing —
+ *  has direct unit coverage instead of living only behind the exec seam. */
+export function resolveCodexExecResult(
+  code: number,
+  processStdout: string,
+  stderr: string,
+  finalMessage: string | undefined,
+): ExecResult {
+  if (code !== 0) return { stdout: processStdout, stderr, code };
+  if (finalMessage !== undefined) return { stdout: finalMessage, stderr, code };
+  // codex exited 0 but wrote no final-message file — there is nothing for
+  // extraction.ts to parse; surface it as a failure through the same
+  // code-path run() already uses for errors.
+  return {
+    stdout: "",
+    stderr: "codex produced no final message (--output-last-message file missing)",
+    code: 1,
+  };
+}
+
+/** Insert `--output-last-message <file>` immediately before the free-text
+ *  instructions positional (always the last element of a codex exec argv)
+ *  rather than appending after it — a flag placed after a long, arbitrary
+ *  free-text argument is fragile (positional/option disambiguation, and any
+ *  prompt that happens to start with `-`). Exported and pure so the ordering
+ *  is unit-tested without spawning a real process. */
+export function insertOutputLastMessageFlag(args: string[], outputFile: string): string[] {
+  return [...args.slice(0, -1), "--output-last-message", outputFile, ...args.slice(-1)];
+}
 
 /** `codex exec` has no print-mode equivalent to claude's `-p` stdout capture
  *  — the terminal stream is full of tool-call narration. `--output-last-
@@ -49,24 +87,17 @@ function execCodex(args: string[], options: { cwd: string; env: NodeJS.ProcessEn
       return await new Promise<ExecResult>((resolve) => {
         execFile(
           "codex",
-          [...args, "--output-last-message", outputFile],
+          insertOutputLastMessageFlag(args, outputFile),
           { cwd: options.cwd, env: options.env, timeout: RUN_TIMEOUT_MS, maxBuffer: MAX_BUFFER_BYTES },
           (error, stdout, stderr) => {
             const code = error === null ? 0 : typeof error.code === "number" ? error.code : 1;
             if (code !== 0) {
-              resolve({ stdout, stderr, code });
+              resolve(resolveCodexExecResult(code, stdout, stderr, undefined));
               return;
             }
             readFile(outputFile, "utf8").then(
-              (finalMessage) => resolve({ stdout: finalMessage, stderr, code }),
-              // codex exited 0 but wrote no final-message file — there is
-              // nothing for extraction.ts to parse; surface it as a failure
-              // through the same code-path run() already uses for errors.
-              () => resolve({
-                stdout: "",
-                stderr: "codex produced no final message (--output-last-message file missing)",
-                code: 1,
-              }),
+              (finalMessage) => resolve(resolveCodexExecResult(code, stdout, stderr, finalMessage)),
+              () => resolve(resolveCodexExecResult(code, stdout, stderr, undefined)),
             );
           },
         );
@@ -89,9 +120,13 @@ function probeCodexBinary(): Promise<boolean> {
  *  "chatgpt"`) or an API key saved via `codex login --with-api-key`.
  *  `codex login status` has no machine-readable output, so this reads the
  *  file directly: a plain fs read that's cheap and trivially fake-able in
- *  tests without a real login. */
-async function probeCodexLogin(): Promise<boolean> {
-  const authPath = join(process.env["CODEX_HOME"] ?? join(homedir(), ".codex"), "auth.json");
+ *  tests without a real login. CODEX_HOME resolution mirrors run()'s own
+ *  env merge (the caller's env wins over process.env) so availability's
+ *  login check and the actual subprocess spawn never disagree about which
+ *  codex home is in play. */
+async function probeCodexLogin(env: Record<string, string | undefined>): Promise<boolean> {
+  const codexHome = env["CODEX_HOME"] ?? process.env["CODEX_HOME"] ?? join(homedir(), ".codex");
+  const authPath = join(codexHome, "auth.json");
   try {
     const parsed = JSON.parse(await readFile(authPath, "utf8")) as {
       OPENAI_API_KEY?: unknown;
@@ -109,7 +144,7 @@ async function probeCodexLogin(): Promise<boolean> {
 export interface CodexCliHarnessOptions {
   /** Test seams. */
   probeBinary?: () => Promise<boolean>;
-  probeLogin?: () => Promise<boolean>;
+  probeLogin?: (env: Record<string, string | undefined>) => Promise<boolean>;
   exec?: Exec;
 }
 
@@ -123,7 +158,7 @@ export function codexCliHarness(options: CodexCliHarnessOptions = {}): Extractio
       if (!(await hasBinary())) return null;
       const key = env["OPENAI_API_KEY"];
       if (typeof key === "string" && key.trim().length > 0) return "your OPENAI_API_KEY";
-      if (await probe()) return "your ChatGPT login";
+      if (await probe(env)) return "your ChatGPT login";
       return null;
     },
     async run(input: ExtractionRunInput): Promise<string> {

--- a/packages/vendo/src/cli/extract/extraction.test.ts
+++ b/packages/vendo/src/cli/extract/extraction.test.ts
@@ -235,15 +235,81 @@ describe("runAiExtraction", () => {
     expect(sink.logs.join("\n")).toContain("skipped");
   });
 
-  it("states when no credential exists and stands on extractor defaults", async () => {
+  it("states when no credential exists and names every rung's remedy", async () => {
     const root = await fixture();
     const sink = output();
     const result = await runAiExtraction({
       root, output: sink.output, env: {}, yes: false, interactive: true,
-      harnesses: [fakeHarness("x", null)],
+      harnesses: [fakeHarness("x", null), fakeHarness("x", null), fakeHarness("x", null)],
     });
     expect(result.ran).toBe(false);
-    expect(sink.logs.join("\n")).toContain("AI polish: unavailable");
+    const message = sink.logs.join("\n");
+    expect(message).toContain("AI polish: unavailable");
+    // Every rung's remedy is named — visible-never-silent (Task 2).
+    expect(message).toContain("Claude Code installed");
+    expect(message).toContain("ANTHROPIC_API_KEY");
+    expect(message).toContain("codex");
+    expect(message).toContain("codex login");
+    expect(message).toContain("OPENAI_API_KEY");
+  });
+
+  it("picks the first rung when every rung is available (order matters)", async () => {
+    const root = await fixture();
+    const sink = output();
+    const draft = { brief: "b", tools: [] };
+    const scripted = "```json\n" + JSON.stringify(draft) + "\n```";
+    const result = await runAiExtraction({
+      root, output: sink.output, env: {}, yes: false, interactive: true,
+      harnesses: [
+        fakeHarness(scripted, "Agent SDK credential"),
+        fakeHarness(scripted, "claude CLI credential"),
+        fakeHarness(scripted, "codex CLI credential"),
+      ],
+      confirm: async () => true,
+    });
+    expect(result.ran).toBe(true);
+    const logs = sink.logs.join("\n");
+    expect(logs).toContain("Reading your product (Agent SDK credential)");
+    expect(logs).not.toContain("claude CLI credential");
+    expect(logs).not.toContain("codex CLI credential");
+  });
+
+  it("falls through to the claude CLI rung when the Agent SDK rung is unavailable", async () => {
+    const root = await fixture();
+    const sink = output();
+    const draft = { brief: "b", tools: [] };
+    const scripted = "```json\n" + JSON.stringify(draft) + "\n```";
+    const result = await runAiExtraction({
+      root, output: sink.output, env: {}, yes: false, interactive: true,
+      harnesses: [
+        fakeHarness("x", null),
+        fakeHarness(scripted, "claude CLI credential"),
+        fakeHarness(scripted, "codex CLI credential"),
+      ],
+      confirm: async () => true,
+    });
+    expect(result.ran).toBe(true);
+    const logs = sink.logs.join("\n");
+    expect(logs).toContain("Reading your product (claude CLI credential)");
+    expect(logs).not.toContain("codex CLI credential");
+  });
+
+  it("falls through past two unavailable rungs to the codex CLI rung", async () => {
+    const root = await fixture();
+    const sink = output();
+    const draft = { brief: "b", tools: [] };
+    const scripted = "```json\n" + JSON.stringify(draft) + "\n```";
+    const result = await runAiExtraction({
+      root, output: sink.output, env: {}, yes: false, interactive: true,
+      harnesses: [
+        fakeHarness("x", null),
+        fakeHarness("x", null),
+        fakeHarness(scripted, "codex CLI credential"),
+      ],
+      confirm: async () => true,
+    });
+    expect(result.ran).toBe(true);
+    expect(sink.logs.join("\n")).toContain("Reading your product (codex CLI credential)");
   });
 
   it("respects a declined consent", async () => {

--- a/packages/vendo/src/cli/extract/extraction.test.ts
+++ b/packages/vendo/src/cli/extract/extraction.test.ts
@@ -240,17 +240,19 @@ describe("runAiExtraction", () => {
     const sink = output();
     const result = await runAiExtraction({
       root, output: sink.output, env: {}, yes: false, interactive: true,
-      harnesses: [fakeHarness("x", null), fakeHarness("x", null), fakeHarness("x", null)],
+      harnesses: [fakeHarness("x", null), fakeHarness("x", null), fakeHarness("x", null), fakeHarness("x", null)],
     });
     expect(result.ran).toBe(false);
     const message = sink.logs.join("\n");
     expect(message).toContain("AI polish: unavailable");
-    // Every rung's remedy is named — visible-never-silent (Task 2).
+    // Every rung's remedy is named — visible-never-silent (Task 2/4).
     expect(message).toContain("Claude Code installed");
     expect(message).toContain("ANTHROPIC_API_KEY");
     expect(message).toContain("codex");
     expect(message).toContain("codex login");
     expect(message).toContain("OPENAI_API_KEY");
+    expect(message).toContain("VENDO_API_KEY");
+    expect(message).toContain("vendo cloud login");
   });
 
   it("picks the first rung when every rung is available (order matters)", async () => {
@@ -264,6 +266,7 @@ describe("runAiExtraction", () => {
         fakeHarness(scripted, "Agent SDK credential"),
         fakeHarness(scripted, "claude CLI credential"),
         fakeHarness(scripted, "codex CLI credential"),
+        fakeHarness(scripted, "npx engine credential"),
       ],
       confirm: async () => true,
     });
@@ -272,6 +275,7 @@ describe("runAiExtraction", () => {
     expect(logs).toContain("Reading your product (Agent SDK credential)");
     expect(logs).not.toContain("claude CLI credential");
     expect(logs).not.toContain("codex CLI credential");
+    expect(logs).not.toContain("npx engine credential");
   });
 
   it("falls through to the claude CLI rung when the Agent SDK rung is unavailable", async () => {
@@ -305,11 +309,33 @@ describe("runAiExtraction", () => {
         fakeHarness("x", null),
         fakeHarness("x", null),
         fakeHarness(scripted, "codex CLI credential"),
+        fakeHarness(scripted, "npx engine credential"),
       ],
       confirm: async () => true,
     });
     expect(result.ran).toBe(true);
-    expect(sink.logs.join("\n")).toContain("Reading your product (codex CLI credential)");
+    const logs = sink.logs.join("\n");
+    expect(logs).toContain("Reading your product (codex CLI credential)");
+    expect(logs).not.toContain("npx engine credential");
+  });
+
+  it("falls through past three unavailable rungs to the npx engine rung (fourth and last)", async () => {
+    const root = await fixture();
+    const sink = output();
+    const draft = { brief: "b", tools: [] };
+    const scripted = "```json\n" + JSON.stringify(draft) + "\n```";
+    const result = await runAiExtraction({
+      root, output: sink.output, env: {}, yes: false, interactive: true,
+      harnesses: [
+        fakeHarness("x", null),
+        fakeHarness("x", null),
+        fakeHarness("x", null),
+        fakeHarness(scripted, "npx engine credential"),
+      ],
+      confirm: async () => true,
+    });
+    expect(result.ran).toBe(true);
+    expect(sink.logs.join("\n")).toContain("Reading your product (npx engine credential)");
   });
 
   it("respects a declined consent", async () => {

--- a/packages/vendo/src/cli/extract/extraction.ts
+++ b/packages/vendo/src/cli/extract/extraction.ts
@@ -4,6 +4,7 @@ import { stdin, stdout } from "node:process";
 import { z } from "zod";
 import { claudeCliHarness } from "./claude-cli-harness.js";
 import { claudeHarness } from "./claude-harness.js";
+import { codexCliHarness } from "./codex-cli-harness.js";
 import { parseDraft, type ExtractionHarness } from "./harness.js";
 import {
   BRIEF_TEMPLATE,
@@ -221,7 +222,12 @@ export async function runAiExtraction(
     return { ran: false };
   }
 
-  const harnesses = options.harnesses ?? [claudeHarness(), claudeCliHarness()];
+  // Ordered engine ladder (install-dx: init-selfcontained-engine, Task 2):
+  // Agent SDK -> claude CLI -> codex CLI. A rung whose availability() is
+  // null (binary missing or present-but-unauthenticated) is skipped and the
+  // next rung is tried; the first non-null credential wins. The future
+  // npx-fetched engine rung is a one-line append here.
+  const harnesses = options.harnesses ?? [claudeHarness(), claudeCliHarness(), codexCliHarness()];
   let chosen: { harness: ExtractionHarness; credential: string } | null = null;
   for (const harness of harnesses) {
     const credential = await harness.availability({ root, env });
@@ -231,7 +237,7 @@ export async function runAiExtraction(
     }
   }
   if (chosen === null) {
-    output.log("AI polish: unavailable — needs Claude Code installed (`npm install -g @anthropic-ai/claude-code`) or @anthropic-ai/claude-agent-sdk resolvable, plus a Claude Code login or ANTHROPIC_API_KEY. Extractor defaults stand; re-run `vendo init` once set up.");
+    output.log("AI polish: unavailable — needs Claude Code installed (`npm install -g @anthropic-ai/claude-code`) or @anthropic-ai/claude-agent-sdk resolvable, plus a Claude Code login or ANTHROPIC_API_KEY; or the `codex` CLI installed, plus a codex login (`codex login`) or OPENAI_API_KEY. Extractor defaults stand; re-run `vendo init` once set up.");
     return { ran: false };
   }
 

--- a/packages/vendo/src/cli/extract/extraction.ts
+++ b/packages/vendo/src/cli/extract/extraction.ts
@@ -6,6 +6,7 @@ import { claudeCliHarness } from "./claude-cli-harness.js";
 import { claudeHarness } from "./claude-harness.js";
 import { codexCliHarness } from "./codex-cli-harness.js";
 import { parseDraft, type ExtractionHarness } from "./harness.js";
+import { npxEngineHarness } from "./npx-engine-harness.js";
 import {
   BRIEF_TEMPLATE,
   runStagedExtraction,
@@ -222,12 +223,15 @@ export async function runAiExtraction(
     return { ran: false };
   }
 
-  // Ordered engine ladder (install-dx: init-selfcontained-engine, Task 2):
-  // Agent SDK -> claude CLI -> codex CLI. A rung whose availability() is
-  // null (binary missing or present-but-unauthenticated) is skipped and the
-  // next rung is tried; the first non-null credential wins. The future
-  // npx-fetched engine rung is a one-line append here.
-  const harnesses = options.harnesses ?? [claudeHarness(), claudeCliHarness(), codexCliHarness()];
+  // Ordered engine ladder (install-dx: init-selfcontained-engine, Task 2/4):
+  // Agent SDK -> claude CLI -> codex CLI -> npx-fetched engine. A rung whose
+  // availability() is null (binary missing or present-but-unauthenticated) is
+  // skipped and the next rung is tried; the first non-null credential wins.
+  // The npx rung is last on purpose: it's the only one with a real first-run
+  // cost (an npm fetch), so every rung that can run for free (something
+  // already installed) gets first refusal.
+  const harnesses = options.harnesses
+    ?? [claudeHarness(), claudeCliHarness(), codexCliHarness(), npxEngineHarness()];
   let chosen: { harness: ExtractionHarness; credential: string } | null = null;
   for (const harness of harnesses) {
     const credential = await harness.availability({ root, env });
@@ -237,7 +241,7 @@ export async function runAiExtraction(
     }
   }
   if (chosen === null) {
-    output.log("AI polish: unavailable — needs Claude Code installed (`npm install -g @anthropic-ai/claude-code`) or @anthropic-ai/claude-agent-sdk resolvable, plus a Claude Code login or ANTHROPIC_API_KEY; or the `codex` CLI installed, plus a codex login (`codex login`) or OPENAI_API_KEY. Extractor defaults stand; re-run `vendo init` once set up.");
+    output.log("AI polish: unavailable — needs Claude Code installed (`npm install -g @anthropic-ai/claude-code`) or @anthropic-ai/claude-agent-sdk resolvable, plus a Claude Code login or ANTHROPIC_API_KEY; or the `codex` CLI installed, plus a codex login (`codex login`) or OPENAI_API_KEY; or a VENDO_API_KEY (`vendo cloud login`), which fetches Claude Code on the fly via npx. Extractor defaults stand; re-run `vendo init` once set up.");
     return { ran: false };
   }
 

--- a/packages/vendo/src/cli/extract/gateway-fuel.test.ts
+++ b/packages/vendo/src/cli/extract/gateway-fuel.test.ts
@@ -59,4 +59,67 @@ describe("composeGatewayFuel", () => {
     expect(INIT_PURPOSE_HEADER_NAME).toBe("x-vendo-purpose");
     expect(INIT_PURPOSE_HEADER_VALUE).toBe("init");
   });
+
+  it("trims VENDO_API_KEY before assigning it to ANTHROPIC_AUTH_TOKEN", () => {
+    const overlay = composeGatewayFuel({
+      env: { VENDO_API_KEY: "  vnd_x  " },
+      ownCredentialAvailable: false,
+    });
+    expect(overlay?.ANTHROPIC_AUTH_TOKEN).toBe("vnd_x");
+  });
+
+  describe("defense in depth: a user-set Anthropic env override is always its own credential", () => {
+    it("never overlays when ANTHROPIC_AUTH_TOKEN is set, even if the caller wrongly says ownCredentialAvailable=false", () => {
+      expect(
+        composeGatewayFuel({
+          env: { VENDO_API_KEY: "vnd_x", ANTHROPIC_AUTH_TOKEN: "corp-token" },
+          ownCredentialAvailable: false,
+        }),
+      ).toBeNull();
+    });
+
+    it("never overlays when ANTHROPIC_AUTH_TOKEN is paired with a custom ANTHROPIC_BASE_URL (corporate gateway)", () => {
+      expect(
+        composeGatewayFuel({
+          env: {
+            VENDO_API_KEY: "vnd_x",
+            ANTHROPIC_AUTH_TOKEN: "corp-token",
+            ANTHROPIC_BASE_URL: "https://anthropic.corp.example.com",
+          },
+          ownCredentialAvailable: false,
+        }),
+      ).toBeNull();
+    });
+
+    it("never overlays when CLAUDE_CODE_OAUTH_TOKEN is set", () => {
+      expect(
+        composeGatewayFuel({
+          env: { VENDO_API_KEY: "vnd_x", CLAUDE_CODE_OAUTH_TOKEN: "oauth-token" },
+          ownCredentialAvailable: false,
+        }),
+      ).toBeNull();
+    });
+
+    it("never overlays when only ANTHROPIC_BASE_URL is set (no token — e.g. mTLS/proxy auth)", () => {
+      expect(
+        composeGatewayFuel({
+          env: { VENDO_API_KEY: "vnd_x", ANTHROPIC_BASE_URL: "https://anthropic.corp.example.com" },
+          ownCredentialAvailable: false,
+        }),
+      ).toBeNull();
+    });
+
+    it("ignores a blank ANTHROPIC_AUTH_TOKEN/CLAUDE_CODE_OAUTH_TOKEN/ANTHROPIC_BASE_URL (still composes)", () => {
+      const overlay = composeGatewayFuel({
+        env: {
+          VENDO_API_KEY: "vnd_x",
+          ANTHROPIC_AUTH_TOKEN: "   ",
+          CLAUDE_CODE_OAUTH_TOKEN: "",
+          ANTHROPIC_BASE_URL: "   ",
+        },
+        ownCredentialAvailable: false,
+      });
+      expect(overlay).not.toBeNull();
+    });
+  });
 });

--- a/packages/vendo/src/cli/extract/gateway-fuel.test.ts
+++ b/packages/vendo/src/cli/extract/gateway-fuel.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  composeGatewayFuel,
+  INIT_PURPOSE_HEADER_NAME,
+  INIT_PURPOSE_HEADER_VALUE,
+} from "./gateway-fuel.js";
+
+describe("composeGatewayFuel", () => {
+  it("does nothing when the rung already has its own credential, even if VENDO_API_KEY is set", () => {
+    expect(
+      composeGatewayFuel({
+        env: { VENDO_API_KEY: "vnd_x" },
+        ownCredentialAvailable: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("does nothing when no VENDO_API_KEY is set, even without an own credential", () => {
+    expect(
+      composeGatewayFuel({ env: {}, ownCredentialAvailable: false }),
+    ).toBeNull();
+  });
+
+  it("does nothing when VENDO_API_KEY is present but blank", () => {
+    expect(
+      composeGatewayFuel({ env: { VENDO_API_KEY: "   " }, ownCredentialAvailable: false }),
+    ).toBeNull();
+  });
+
+  it("composes the gateway overlay when unauthenticated and VENDO_API_KEY is set", () => {
+    const overlay = composeGatewayFuel({
+      env: { VENDO_API_KEY: "vnd_x" },
+      ownCredentialAvailable: false,
+    });
+    expect(overlay).toEqual({
+      ANTHROPIC_BASE_URL: "https://console.vendo.run/api/v1",
+      ANTHROPIC_AUTH_TOKEN: "vnd_x",
+      ANTHROPIC_CUSTOM_HEADERS: "x-vendo-purpose: init",
+    });
+  });
+
+  it("honors VENDO_CLOUD_URL, matching resolveCloudBaseUrl's endsWith('/api/v1') composition", () => {
+    const overlay = composeGatewayFuel({
+      env: { VENDO_API_KEY: "vnd_x", VENDO_CLOUD_URL: "http://localhost:3001/" },
+      ownCredentialAvailable: false,
+    });
+    expect(overlay?.ANTHROPIC_BASE_URL).toBe("http://localhost:3001/api/v1");
+  });
+
+  it("does not double-append /api/v1 when the configured base URL already ends with it", () => {
+    const overlay = composeGatewayFuel({
+      env: { VENDO_API_KEY: "vnd_x", VENDO_CLOUD_URL: "http://localhost:3001/api/v1" },
+      ownCredentialAvailable: false,
+    });
+    expect(overlay?.ANTHROPIC_BASE_URL).toBe("http://localhost:3001/api/v1");
+  });
+
+  it("exports the shared tag header name/value as the single source of truth", () => {
+    expect(INIT_PURPOSE_HEADER_NAME).toBe("x-vendo-purpose");
+    expect(INIT_PURPOSE_HEADER_VALUE).toBe("init");
+  });
+});

--- a/packages/vendo/src/cli/extract/gateway-fuel.ts
+++ b/packages/vendo/src/cli/extract/gateway-fuel.ts
@@ -10,6 +10,15 @@ import { resolveCloudBaseUrl } from "../cloud/client.js";
  * VENDO_API_KEY. Own credential always wins — this module never overrides
  * it, and callers must never call it when one is available.
  *
+ * INVARIANT: a non-blank ANTHROPIC_AUTH_TOKEN, CLAUDE_CODE_OAUTH_TOKEN, or
+ * ANTHROPIC_BASE_URL in the passed env IS an own credential (the corporate-
+ * gateway / custom-endpoint path Claude Code also supports, none of which
+ * show up in a `claude auth status` login probe) and always wins, even if a
+ * caller mistakenly passes `ownCredentialAvailable: false`. Overwriting a
+ * dev's already-configured BYO endpoint would silently redirect their
+ * inference through Vendo's gateway and bill their org's meter — this
+ * module checks it directly rather than trusting callers to remember.
+ *
  * The gateway must be able to refuse this traffic for free-plan orgs
  * (spec's free-plan policy), so every request gets tagged with the
  * INIT_PURPOSE_HEADER — a plain "name: value" line via Claude Code's
@@ -19,6 +28,30 @@ import { resolveCloudBaseUrl } from "../cloud/client.js";
 
 export const INIT_PURPOSE_HEADER_NAME = "x-vendo-purpose";
 export const INIT_PURPOSE_HEADER_VALUE = "init";
+
+/** Env vars that Claude Code itself accepts as an own credential besides
+ *  ANTHROPIC_API_KEY and a CLI login: a corporate-gateway auth token, a
+ *  device-flow OAuth token, or a custom base URL with no token at all
+ *  (mTLS/proxy auth). None of these are visible to a `claude auth status`
+ *  probe, so any caller folding "own credential" into its own predicate
+ *  (claude-cli-harness.ts's availability()/run()) must check these three
+ *  directly rather than relying solely on the login probe. Exported so
+ *  every harness checks the identical set. */
+export const OWN_CREDENTIAL_ENV_VARS = [
+  "ANTHROPIC_AUTH_TOKEN",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "ANTHROPIC_BASE_URL",
+] as const;
+
+function nonBlank(value: string | undefined): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/** True when the env alone (no async probe needed) already carries one of
+ *  Claude Code's own-credential env vars (see OWN_CREDENTIAL_ENV_VARS). */
+export function hasOwnAnthropicEnvOverride(env: Record<string, string | undefined>): boolean {
+  return OWN_CREDENTIAL_ENV_VARS.some((name) => nonBlank(env[name]));
+}
 
 export interface GatewayFuelOverlay {
   ANTHROPIC_BASE_URL: string;
@@ -34,22 +67,26 @@ export interface GatewayFuelOptions {
    *  whatever its rung needs — and passes the verdict in, so this module
    *  stays a pure, harness-agnostic composition step reusable by every
    *  Claude-Code-shaped rung (claude-cli-harness.ts today; the future
-   *  npx-engine harness reuses the same function). */
+   *  npx-engine harness reuses the same function). This module additionally
+   *  checks OWN_CREDENTIAL_ENV_VARS itself regardless of this flag — see
+   *  the module-level INVARIANT note. */
   ownCredentialAvailable: boolean;
 }
 
 /** Compose the gateway-fuel env overlay for a Claude-Code-shaped rung, or
- *  null when gateway fuel does not apply: own credential wins, or there is
- *  no VENDO_API_KEY to fuel with. */
+ *  null when gateway fuel does not apply: own credential wins (either the
+ *  caller's verdict or a directly-detected env override), or there is no
+ *  VENDO_API_KEY to fuel with. */
 export function composeGatewayFuel(options: GatewayFuelOptions): GatewayFuelOverlay | null {
   if (options.ownCredentialAvailable) return null;
+  if (hasOwnAnthropicEnvOverride(options.env)) return null;
   const key = options.env["VENDO_API_KEY"];
-  if (typeof key !== "string" || key.trim().length === 0) return null;
+  if (!nonBlank(key)) return null;
   const base = resolveCloudBaseUrl({ env: options.env });
   const baseURL = base.endsWith("/api/v1") ? base : `${base}/api/v1`;
   return {
     ANTHROPIC_BASE_URL: baseURL,
-    ANTHROPIC_AUTH_TOKEN: key,
+    ANTHROPIC_AUTH_TOKEN: key.trim(),
     ANTHROPIC_CUSTOM_HEADERS: `${INIT_PURPOSE_HEADER_NAME}: ${INIT_PURPOSE_HEADER_VALUE}`,
   };
 }

--- a/packages/vendo/src/cli/extract/gateway-fuel.ts
+++ b/packages/vendo/src/cli/extract/gateway-fuel.ts
@@ -1,0 +1,55 @@
+import { resolveCloudBaseUrl } from "../cloud/client.js";
+
+/**
+ * Gateway fuel: the env overlay that makes Claude Code (any rung that reads
+ * ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN / ANTHROPIC_CUSTOM_HEADERS — the
+ * PATH `claude` binary today, the npx-fetched engine package tomorrow, per
+ * `docs/superpowers/plans/2026-07-20-init-selfcontained-engine.md` Task 3/4)
+ * speak to the Vendo Cloud model gateway instead of Anthropic directly, when
+ * the dev has no Anthropic credential of their own but does have
+ * VENDO_API_KEY. Own credential always wins — this module never overrides
+ * it, and callers must never call it when one is available.
+ *
+ * The gateway must be able to refuse this traffic for free-plan orgs
+ * (spec's free-plan policy), so every request gets tagged with the
+ * INIT_PURPOSE_HEADER — a plain "name: value" line via Claude Code's
+ * ANTHROPIC_CUSTOM_HEADERS mechanism. The constant is the single source of
+ * truth; the console mirrors the literal in its own tests (plan Task 7).
+ */
+
+export const INIT_PURPOSE_HEADER_NAME = "x-vendo-purpose";
+export const INIT_PURPOSE_HEADER_VALUE = "init";
+
+export interface GatewayFuelOverlay {
+  ANTHROPIC_BASE_URL: string;
+  ANTHROPIC_AUTH_TOKEN: string;
+  ANTHROPIC_CUSTOM_HEADERS: string;
+}
+
+export interface GatewayFuelOptions {
+  env: Record<string, string | undefined>;
+  /** True when the rung already has a working credential of its own (its
+   *  own ANTHROPIC_API_KEY, a satisfied Claude Code login, ...). Each
+   *  harness computes this itself — an env check, an async login probe,
+   *  whatever its rung needs — and passes the verdict in, so this module
+   *  stays a pure, harness-agnostic composition step reusable by every
+   *  Claude-Code-shaped rung (claude-cli-harness.ts today; the future
+   *  npx-engine harness reuses the same function). */
+  ownCredentialAvailable: boolean;
+}
+
+/** Compose the gateway-fuel env overlay for a Claude-Code-shaped rung, or
+ *  null when gateway fuel does not apply: own credential wins, or there is
+ *  no VENDO_API_KEY to fuel with. */
+export function composeGatewayFuel(options: GatewayFuelOptions): GatewayFuelOverlay | null {
+  if (options.ownCredentialAvailable) return null;
+  const key = options.env["VENDO_API_KEY"];
+  if (typeof key !== "string" || key.trim().length === 0) return null;
+  const base = resolveCloudBaseUrl({ env: options.env });
+  const baseURL = base.endsWith("/api/v1") ? base : `${base}/api/v1`;
+  return {
+    ANTHROPIC_BASE_URL: baseURL,
+    ANTHROPIC_AUTH_TOKEN: key,
+    ANTHROPIC_CUSTOM_HEADERS: `${INIT_PURPOSE_HEADER_NAME}: ${INIT_PURPOSE_HEADER_VALUE}`,
+  };
+}

--- a/packages/vendo/src/cli/extract/gateway-fuel.ts
+++ b/packages/vendo/src/cli/extract/gateway-fuel.ts
@@ -60,6 +60,13 @@ export interface GatewayFuelOverlay {
 }
 
 export interface GatewayFuelOptions {
+  /** The CHILD'S real env — i.e. the same merged {...process.env,
+   *  ...input.env} the harness is about to spawn with, never the caller's
+   *  partial input env alone. The INVARIANT above is only worth anything if
+   *  it is checked against the env the subprocess will actually read: an
+   *  ambient (process.env) ANTHROPIC_AUTH_TOKEN/ANTHROPIC_BASE_URL is a
+   *  live BYO endpoint that an overlay composed from input.env alone would
+   *  silently clobber. */
   env: Record<string, string | undefined>;
   /** True when the rung already has a working credential of its own (its
    *  own ANTHROPIC_API_KEY, a satisfied Claude Code login, ...). Each

--- a/packages/vendo/src/cli/extract/npx-engine-harness.test.ts
+++ b/packages/vendo/src/cli/extract/npx-engine-harness.test.ts
@@ -1,0 +1,234 @@
+import type { ExecFileException } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import {
+  ENGINE_PACKAGE_NAME,
+  ENGINE_PACKAGE_VERSION,
+  npxEngineHarness,
+  resolveNpmExecResult,
+} from "./npx-engine-harness.js";
+
+describe("npxEngineHarness", () => {
+  describe("availability", () => {
+    it("is unavailable with no credential at all", async () => {
+      const harness = npxEngineHarness();
+      expect(await harness.availability({ root: "/x", env: {} })).toBeNull();
+    });
+
+    it("labels ANTHROPIC_API_KEY, naming the download", async () => {
+      const harness = npxEngineHarness();
+      expect(await harness.availability({ root: "/x", env: { ANTHROPIC_API_KEY: "sk" } }))
+        .toBe("your ANTHROPIC_API_KEY (via the Vendo engine, ~250MB one-time download)");
+    });
+
+    it("falls back to VENDO_API_KEY, naming the Vendo Cloud key and the download", async () => {
+      const harness = npxEngineHarness();
+      expect(await harness.availability({ root: "/x", env: { VENDO_API_KEY: "vnd_x" } }))
+        .toBe("your Vendo Cloud key (managed inference, via the Vendo engine, ~250MB one-time download)");
+    });
+
+    it("prefers ANTHROPIC_API_KEY's label over the Vendo Cloud key when both are set", async () => {
+      const harness = npxEngineHarness();
+      expect(await harness.availability({
+        root: "/x",
+        env: { ANTHROPIC_API_KEY: "sk", VENDO_API_KEY: "vnd_x" },
+      })).toBe("your ANTHROPIC_API_KEY (via the Vendo engine, ~250MB one-time download)");
+    });
+
+    it("treats a blank ANTHROPIC_API_KEY as absent and falls back to VENDO_API_KEY", async () => {
+      const harness = npxEngineHarness();
+      expect(await harness.availability({ root: "/x", env: { ANTHROPIC_API_KEY: "   ", VENDO_API_KEY: "vnd_x" } }))
+        .toBe("your Vendo Cloud key (managed inference, via the Vendo engine, ~250MB one-time download)");
+    });
+
+    it("never invokes the exec seam (no npm/network probe)", async () => {
+      let execCalls = 0;
+      const harness = npxEngineHarness({ exec: async () => { execCalls += 1; return { stdout: "", stderr: "", code: 0 }; } });
+      await harness.availability({ root: "/x", env: { ANTHROPIC_API_KEY: "sk" } });
+      await harness.availability({ root: "/x", env: {} });
+      expect(execCalls).toBe(0);
+    });
+  });
+
+  describe("run", () => {
+    it("invokes `npm exec --yes @vendoai/engine@<PINNED_VERSION> -- run` with cwd = host root", async () => {
+      let capturedArgs: string[] = [];
+      let capturedOptions: { cwd: string; env: NodeJS.ProcessEnv } | undefined;
+      const harness = npxEngineHarness({
+        exec: async (args, options) => {
+          capturedArgs = args;
+          capturedOptions = options;
+          return { stdout: "the result", stderr: "", code: 0 };
+        },
+      });
+      const text = await harness.run({ root: "/host/root", env: {}, instructions: "go read the codebase" });
+      expect(text).toBe("the result");
+      expect(capturedArgs).toEqual(["exec", "--yes", `${ENGINE_PACKAGE_NAME}@${ENGINE_PACKAGE_VERSION}`, "--", "run"]);
+      expect(capturedOptions?.cwd).toBe("/host/root");
+    });
+
+    it("pins an exact version, never a range", () => {
+      expect(ENGINE_PACKAGE_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+      expect(ENGINE_PACKAGE_NAME).toBe("@vendoai/engine");
+    });
+
+    it("writes the job JSON ({ instructions, root }) to the child's stdin — no credentials inside it", async () => {
+      let capturedInput = "";
+      const harness = npxEngineHarness({
+        exec: async (_args, options) => { capturedInput = options.input; return { stdout: "ok", stderr: "", code: 0 }; },
+      });
+      await harness.run({
+        root: "/host/root",
+        env: { ANTHROPIC_API_KEY: "sk-should-not-appear-in-job" },
+        instructions: "go read the codebase",
+      });
+      expect(JSON.parse(capturedInput)).toEqual({ instructions: "go read the codebase", root: "/host/root" });
+      expect(capturedInput).not.toContain("sk-should-not-appear-in-job");
+    });
+
+    it("passes cwd = host root and forwards the caller's env over process.env", async () => {
+      let capturedOptions: { cwd: string; env: NodeJS.ProcessEnv } | undefined;
+      const harness = npxEngineHarness({
+        exec: async (_args, options) => { capturedOptions = options; return { stdout: "ok", stderr: "", code: 0 }; },
+      });
+      process.env["VENDO_NPX_ENGINE_TEST_MARKER"] = "from-process-env";
+      try {
+        await harness.run({
+          root: "/host/root",
+          env: { CALLER_ONLY: "yes", VENDO_NPX_ENGINE_TEST_MARKER: "from-caller", ANTHROPIC_API_KEY: "sk" },
+          instructions: "go",
+        });
+      } finally {
+        delete process.env["VENDO_NPX_ENGINE_TEST_MARKER"];
+      }
+      expect(capturedOptions?.cwd).toBe("/host/root");
+      expect(capturedOptions?.env["CALLER_ONLY"]).toBe("yes");
+      expect(capturedOptions?.env["VENDO_NPX_ENGINE_TEST_MARKER"]).toBe("from-caller");
+    });
+
+    it("emits a first-run download notice via onProgress before invoking exec", async () => {
+      const order: string[] = [];
+      const harness = npxEngineHarness({
+        exec: async () => { order.push("exec-called"); return { stdout: "ok", stderr: "", code: 0 }; },
+      });
+      await harness.run({
+        root: "/x",
+        env: { ANTHROPIC_API_KEY: "sk" },
+        instructions: "go",
+        onProgress: (line) => order.push(`progress:${line}`),
+      });
+      expect(order[0]).toMatch(/^progress:/);
+      expect(order[0]).toMatch(/250MB/);
+      expect(order[0]).toMatch(/cach/i);
+      expect(order.indexOf("exec-called")).toBeGreaterThan(order.indexOf(order[0]));
+      expect(order.indexOf("exec-called")).toBe(1);
+    });
+
+    it("forwards child stderr lines to onProgress via onStderrLine", async () => {
+      const progressLines: string[] = [];
+      const harness = npxEngineHarness({
+        exec: async (_args, options) => {
+          options.onStderrLine?.("resolving dependencies…");
+          options.onStderrLine?.("running extraction…");
+          return { stdout: "ok", stderr: "", code: 0 };
+        },
+      });
+      await harness.run({
+        root: "/x",
+        env: { ANTHROPIC_API_KEY: "sk" },
+        instructions: "go",
+        onProgress: (line) => progressLines.push(line),
+      });
+      expect(progressLines).toContain("resolving dependencies…");
+      expect(progressLines).toContain("running extraction…");
+    });
+
+    it("returns stdout verbatim on success", async () => {
+      const harness = npxEngineHarness({
+        exec: async () => ({ stdout: '{"brief":"b","tools":[]}', stderr: "", code: 0 }),
+      });
+      expect(await harness.run({ root: "/x", env: { ANTHROPIC_API_KEY: "sk" }, instructions: "go" }))
+        .toBe('{"brief":"b","tools":[]}');
+    });
+
+    it("throws including stderr context on nonzero exit", async () => {
+      const harness = npxEngineHarness({
+        exec: async () => ({ stdout: "", stderr: "auth failed: token expired", code: 1 }),
+      });
+      await expect(harness.run({ root: "/x", env: { ANTHROPIC_API_KEY: "sk" }, instructions: "go" }))
+        .rejects.toThrow(/auth failed: token expired/);
+    });
+
+    it("surfaces an offline/registry-unreachable failure with npm's own descriptive stderr", async () => {
+      const harness = npxEngineHarness({
+        exec: async () => ({ stdout: "", stderr: "npm error code ENOTFOUND registry.npmjs.org", code: 1 }),
+      });
+      await expect(harness.run({ root: "/x", env: { ANTHROPIC_API_KEY: "sk" }, instructions: "go" }))
+        .rejects.toThrow(/ENOTFOUND/);
+    });
+
+    describe("Vendo Cloud gateway fuel", () => {
+      it("does not overlay the env when ANTHROPIC_API_KEY is present (own credential wins)", async () => {
+        let capturedEnv: NodeJS.ProcessEnv | undefined;
+        const harness = npxEngineHarness({
+          exec: async (_args, options) => { capturedEnv = options.env; return { stdout: "ok", stderr: "", code: 0 }; },
+        });
+        await harness.run({
+          root: "/x",
+          env: { ANTHROPIC_API_KEY: "sk", VENDO_API_KEY: "vnd_x" },
+          instructions: "go",
+        });
+        expect(capturedEnv?.ANTHROPIC_BASE_URL).toBeUndefined();
+        expect(capturedEnv?.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+        expect(capturedEnv?.ANTHROPIC_CUSTOM_HEADERS).toBeUndefined();
+      });
+
+      it("overlays the gateway env, tagged with the init-purpose header, when only VENDO_API_KEY is set", async () => {
+        let capturedEnv: NodeJS.ProcessEnv | undefined;
+        const harness = npxEngineHarness({
+          exec: async (_args, options) => { capturedEnv = options.env; return { stdout: "ok", stderr: "", code: 0 }; },
+        });
+        await harness.run({
+          root: "/x",
+          env: { VENDO_API_KEY: "vnd_x", VENDO_CLOUD_URL: "http://localhost:3001/" },
+          instructions: "go",
+        });
+        expect(capturedEnv?.ANTHROPIC_BASE_URL).toBe("http://localhost:3001/api/v1");
+        expect(capturedEnv?.ANTHROPIC_AUTH_TOKEN).toBe("vnd_x");
+        expect(capturedEnv?.ANTHROPIC_CUSTOM_HEADERS).toBe("x-vendo-purpose: init");
+      });
+
+      it("does not overlay the env when neither credential is set (unreachable via availability(), belt-and-suspenders)", async () => {
+        let capturedEnv: NodeJS.ProcessEnv | undefined;
+        const harness = npxEngineHarness({
+          exec: async (_args, options) => { capturedEnv = options.env; return { stdout: "ok", stderr: "", code: 0 }; },
+        });
+        await harness.run({ root: "/x", env: {}, instructions: "go" });
+        expect(capturedEnv?.ANTHROPIC_BASE_URL).toBeUndefined();
+      });
+    });
+  });
+
+  describe("resolveNpmExecResult", () => {
+    it("maps a successful exit (no error) straight through", () => {
+      expect(resolveNpmExecResult(null, "out", "err")).toEqual({ stdout: "out", stderr: "err", code: 0 });
+    });
+
+    it("maps a normal nonzero process exit through its numeric code", () => {
+      const error = Object.assign(new Error("Command failed"), { code: 1 }) as ExecFileException;
+      expect(resolveNpmExecResult(error, "", "npm error code ENOTFOUND")).toEqual({
+        stdout: "",
+        stderr: "npm error code ENOTFOUND",
+        code: 1,
+      });
+    });
+
+    it("produces a clear, actionable message when npm itself cannot be launched (ENOENT)", () => {
+      const error = Object.assign(new Error("spawn npm ENOENT"), { code: "ENOENT" }) as ExecFileException;
+      const result = resolveNpmExecResult(error, "", "");
+      expect(result.code).toBe(1);
+      expect(result.stderr).toMatch(/npm could not be launched/);
+      expect(result.stderr).toMatch(/is npm installed and on PATH\?/);
+      expect(result.stderr).toContain("spawn npm ENOENT");
+    });
+  });
+});

--- a/packages/vendo/src/cli/extract/npx-engine-harness.test.ts
+++ b/packages/vendo/src/cli/extract/npx-engine-harness.test.ts
@@ -1,5 +1,5 @@
 import type { ExecFileException } from "node:child_process";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createLineSplitter,
   ENGINE_PACKAGE_NAME,
@@ -8,7 +8,28 @@ import {
   resolveNpmExecResult,
 } from "./npx-engine-harness.js";
 
+// The harness now judges credentials against {...process.env, ...input.env}
+// (the env the child actually spawns with), so ambient credentials on the
+// machine running the suite must be cleared for these controlled-env
+// expectations to hold anywhere.
+const AMBIENT_CREDENTIAL_VARS = [
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "ANTHROPIC_BASE_URL",
+  "ANTHROPIC_CUSTOM_HEADERS",
+  "VENDO_API_KEY",
+  "VENDO_CLOUD_URL",
+] as const;
+
 describe("npxEngineHarness", () => {
+  beforeEach(() => {
+    for (const name of AMBIENT_CREDENTIAL_VARS) vi.stubEnv(name, undefined);
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   describe("availability", () => {
     it("is unavailable with no credential at all", async () => {
       const harness = npxEngineHarness();
@@ -244,6 +265,31 @@ describe("npxEngineHarness", () => {
       // the child completely untouched — composeGatewayFuel must not clobber
       // a dev's already-configured BYO endpoint just because VENDO_API_KEY is
       // also present, matching the label availability() now gives this case.
+      // AI-review fix: the guard must see the child's REAL env. The child
+      // spawns with {...process.env, ...input.env, ...overlay}, so an
+      // ambient (process.env) BYO credential with a partial input.env
+      // carrying only VENDO_API_KEY previously slipped past the
+      // input.env-only guard and got its endpoint clobbered by the overlay.
+      it("does not overlay when ANTHROPIC_AUTH_TOKEN is ambient in process.env and input.env carries only VENDO_API_KEY", async () => {
+        vi.stubEnv("ANTHROPIC_AUTH_TOKEN", "ambient-corp-token");
+        let capturedEnv: NodeJS.ProcessEnv | undefined;
+        const harness = npxEngineHarness({
+          exec: async (_args, options) => { capturedEnv = options.env; return { stdout: "ok", stderr: "", code: 0 }; },
+        });
+        await harness.run({ root: "/x", env: { VENDO_API_KEY: "vnd_x" }, instructions: "go" });
+        // The ambient token survives untouched — the overlay must not clobber it.
+        expect(capturedEnv?.ANTHROPIC_AUTH_TOKEN).toBe("ambient-corp-token");
+        expect(capturedEnv?.ANTHROPIC_BASE_URL).toBeUndefined();
+        expect(capturedEnv?.ANTHROPIC_CUSTOM_HEADERS).toBeUndefined();
+      });
+
+      it("labels the rung with the ambient ANTHROPIC_AUTH_TOKEN, not the Vendo Cloud key (labels agree with run())", async () => {
+        vi.stubEnv("ANTHROPIC_AUTH_TOKEN", "ambient-corp-token");
+        const harness = npxEngineHarness();
+        expect(await harness.availability({ root: "/x", env: { VENDO_API_KEY: "vnd_x" } }))
+          .toBe("your ANTHROPIC_AUTH_TOKEN (via the Vendo engine, ~250MB one-time download)");
+      });
+
       it("passes ANTHROPIC_AUTH_TOKEN + ANTHROPIC_BASE_URL through untouched even with VENDO_API_KEY set (no CUSTOM_HEADERS)", async () => {
         let capturedEnv: NodeJS.ProcessEnv | undefined;
         const harness = npxEngineHarness({
@@ -316,6 +362,23 @@ describe("npxEngineHarness", () => {
       expect(result.stderr).toContain("SIGTERM");
       expect(result.stderr).not.toMatch(/npm could not be launched/);
       expect(result.stderr).not.toMatch(/is npm installed/);
+    });
+
+    // AI-review fix: a maxBuffer kill sets BOTH killed: true and the
+    // ERR_CHILD_PROCESS_STDIO_MAXBUFFER code — checking killed first
+    // mislabeled a >10MB narration stream as the 15-minute timeout.
+    it("labels a maxBuffer kill honestly (10MB buffer message wins over the timeout branch even with killed: true)", () => {
+      const error = Object.assign(new Error("stderr maxBuffer length exceeded"), {
+        killed: true,
+        signal: "SIGTERM",
+        code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER",
+      }) as unknown as ExecFileException;
+      const result = resolveNpmExecResult(error, "", "");
+      expect(result.code).toBe(1);
+      expect(result.stderr).toMatch(/10MB buffer/);
+      expect(result.stderr).toMatch(/narration stream/);
+      expect(result.stderr).not.toMatch(/timeout/);
+      expect(result.stderr).not.toMatch(/npm could not be launched/);
     });
 
     it("checks killed before the spawn-failure branch even if a stray string code is also present", () => {

--- a/packages/vendo/src/cli/extract/npx-engine-harness.test.ts
+++ b/packages/vendo/src/cli/extract/npx-engine-harness.test.ts
@@ -1,6 +1,7 @@
 import type { ExecFileException } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import {
+  createLineSplitter,
   ENGINE_PACKAGE_NAME,
   ENGINE_PACKAGE_VERSION,
   npxEngineHarness,
@@ -285,6 +286,94 @@ describe("npxEngineHarness", () => {
       expect(result.stderr).toMatch(/npm could not be launched/);
       expect(result.stderr).toMatch(/is npm installed and on PATH\?/);
       expect(result.stderr).toContain("spawn npm ENOENT");
+    });
+
+    // Code-review follow-up: EACCES (npm present but not executable — a
+    // permissions problem, not a missing install) is "similar spawn-level
+    // string code" to ENOENT and must route the same way, not fall through
+    // to the timeout/generic branches.
+    it("treats EACCES the same as ENOENT — a real spawn-layer failure", () => {
+      const error = Object.assign(new Error("spawn npm EACCES"), { code: "EACCES" }) as ExecFileException;
+      const result = resolveNpmExecResult(error, "", "");
+      expect(result.code).toBe(1);
+      expect(result.stderr).toMatch(/npm could not be launched/);
+      expect(result.stderr).toContain("spawn npm EACCES");
+    });
+
+    // Code-review follow-up: previously this fell into the SAME "npm could
+    // not be launched" branch as ENOENT (error.code is null here, which also
+    // fails `typeof error.code === "number"`), falsely telling a dev whose
+    // 15-minute extraction just timed out that npm isn't installed.
+    it("gives a killed/timeout its own honest message naming the timeout duration — never the npm-not-installed message", () => {
+      const error = Object.assign(new Error("Command failed"), {
+        killed: true,
+        signal: "SIGTERM",
+        code: null,
+      }) as unknown as ExecFileException;
+      const result = resolveNpmExecResult(error, "", "");
+      expect(result.code).toBe(1);
+      expect(result.stderr).toMatch(/15-minute timeout/);
+      expect(result.stderr).toContain("SIGTERM");
+      expect(result.stderr).not.toMatch(/npm could not be launched/);
+      expect(result.stderr).not.toMatch(/is npm installed/);
+    });
+
+    it("checks killed before the spawn-failure branch even if a stray string code is also present", () => {
+      const error = Object.assign(new Error("Command failed"), {
+        killed: true,
+        signal: "SIGTERM",
+        code: "SOMETHING",
+      }) as unknown as ExecFileException;
+      const result = resolveNpmExecResult(error, "", "");
+      expect(result.stderr).toMatch(/timeout/);
+      expect(result.stderr).not.toMatch(/npm could not be launched/);
+    });
+
+    it("forwards npm's own stderr without fabricating a diagnosis for any other non-numeric, non-killed shape", () => {
+      const error = Object.assign(new Error("weird"), {}) as ExecFileException;
+      const result = resolveNpmExecResult(error, "", "npm warn deprecated foo@1.0.0");
+      expect(result).toEqual({ stdout: "", stderr: "npm warn deprecated foo@1.0.0", code: 1 });
+    });
+  });
+
+  describe("createLineSplitter", () => {
+    it("emits each line from a single multi-line chunk", () => {
+      const lines: string[] = [];
+      const splitter = createLineSplitter((line) => lines.push(line));
+      splitter.push("first\nsecond\nthird\n");
+      expect(lines).toEqual(["first", "second", "third"]);
+    });
+
+    it("reassembles a line split across two chunks", () => {
+      const lines: string[] = [];
+      const splitter = createLineSplitter((line) => lines.push(line));
+      splitter.push("resolving depend");
+      splitter.push("encies…\n");
+      expect(lines).toEqual(["resolving dependencies…"]);
+    });
+
+    it("flushes a trailing line with no final newline instead of dropping it", () => {
+      const lines: string[] = [];
+      const splitter = createLineSplitter((line) => lines.push(line));
+      splitter.push("complete line\nno trailing newline");
+      expect(lines).toEqual(["complete line"]);
+      splitter.flush();
+      expect(lines).toEqual(["complete line", "no trailing newline"]);
+    });
+
+    it("flush is a no-op when there is no pending partial line", () => {
+      const lines: string[] = [];
+      const splitter = createLineSplitter((line) => lines.push(line));
+      splitter.push("one\n");
+      splitter.flush();
+      expect(lines).toEqual(["one"]);
+    });
+
+    it("skips blank lines, matching the child protocol's narration framing", () => {
+      const lines: string[] = [];
+      const splitter = createLineSplitter((line) => lines.push(line));
+      splitter.push("a\n\nb\n");
+      expect(lines).toEqual(["a", "b"]);
     });
   });
 });

--- a/packages/vendo/src/cli/extract/npx-engine-harness.test.ts
+++ b/packages/vendo/src/cli/extract/npx-engine-harness.test.ts
@@ -40,6 +40,38 @@ describe("npxEngineHarness", () => {
         .toBe("your Vendo Cloud key (managed inference, via the Vendo engine, ~250MB one-time download)");
     });
 
+    // Spec-review follow-up (b216d0f4 landed hasOwnAnthropicEnvOverride after
+    // this rung shipped): ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN /
+    // ANTHROPIC_BASE_URL are each an own credential too — composeGatewayFuel
+    // refuses to overlay onto any of them, so labeling the rung "your Vendo
+    // Cloud key" for a dev who has one of these would misdescribe what run()
+    // actually does with their env.
+    it("labels ANTHROPIC_AUTH_TOKEN as an own credential, naming the download", async () => {
+      const harness = npxEngineHarness();
+      expect(await harness.availability({ root: "/x", env: { ANTHROPIC_AUTH_TOKEN: "corp-tok" } }))
+        .toBe("your ANTHROPIC_AUTH_TOKEN (via the Vendo engine, ~250MB one-time download)");
+    });
+
+    it("labels CLAUDE_CODE_OAUTH_TOKEN as an own credential, naming the download", async () => {
+      const harness = npxEngineHarness();
+      expect(await harness.availability({ root: "/x", env: { CLAUDE_CODE_OAUTH_TOKEN: "oauth-tok" } }))
+        .toBe("your CLAUDE_CODE_OAUTH_TOKEN (via the Vendo engine, ~250MB one-time download)");
+    });
+
+    it("labels ANTHROPIC_BASE_URL as an own credential, naming the download", async () => {
+      const harness = npxEngineHarness();
+      expect(await harness.availability({ root: "/x", env: { ANTHROPIC_BASE_URL: "https://corp.example/v1" } }))
+        .toBe("your ANTHROPIC_BASE_URL (via the Vendo engine, ~250MB one-time download)");
+    });
+
+    it("prefers the own-credential env-override label over the Vendo Cloud key when both are set", async () => {
+      const harness = npxEngineHarness();
+      expect(await harness.availability({
+        root: "/x",
+        env: { ANTHROPIC_AUTH_TOKEN: "corp-tok", ANTHROPIC_BASE_URL: "https://corp.example/v1", VENDO_API_KEY: "vnd_x" },
+      })).toBe("your ANTHROPIC_AUTH_TOKEN (via the Vendo engine, ~250MB one-time download)");
+    });
+
     it("never invokes the exec seam (no npm/network probe)", async () => {
       let execCalls = 0;
       const harness = npxEngineHarness({ exec: async () => { execCalls += 1; return { stdout: "", stderr: "", code: 0 }; } });
@@ -204,6 +236,30 @@ describe("npxEngineHarness", () => {
         });
         await harness.run({ root: "/x", env: {}, instructions: "go" });
         expect(capturedEnv?.ANTHROPIC_BASE_URL).toBeUndefined();
+      });
+
+      // Spec-review follow-up: the corporate-gateway pair (own auth token +
+      // own base URL) plus a VENDO_API_KEY alongside it must pass through to
+      // the child completely untouched — composeGatewayFuel must not clobber
+      // a dev's already-configured BYO endpoint just because VENDO_API_KEY is
+      // also present, matching the label availability() now gives this case.
+      it("passes ANTHROPIC_AUTH_TOKEN + ANTHROPIC_BASE_URL through untouched even with VENDO_API_KEY set (no CUSTOM_HEADERS)", async () => {
+        let capturedEnv: NodeJS.ProcessEnv | undefined;
+        const harness = npxEngineHarness({
+          exec: async (_args, options) => { capturedEnv = options.env; return { stdout: "ok", stderr: "", code: 0 }; },
+        });
+        await harness.run({
+          root: "/x",
+          env: {
+            ANTHROPIC_AUTH_TOKEN: "corp-tok",
+            ANTHROPIC_BASE_URL: "https://corp.example/v1",
+            VENDO_API_KEY: "vnd_x",
+          },
+          instructions: "go",
+        });
+        expect(capturedEnv?.ANTHROPIC_AUTH_TOKEN).toBe("corp-tok");
+        expect(capturedEnv?.ANTHROPIC_BASE_URL).toBe("https://corp.example/v1");
+        expect(capturedEnv?.ANTHROPIC_CUSTOM_HEADERS).toBeUndefined();
       });
     });
   });

--- a/packages/vendo/src/cli/extract/npx-engine-harness.ts
+++ b/packages/vendo/src/cli/extract/npx-engine-harness.ts
@@ -1,0 +1,166 @@
+import { execFile, type ExecFileException } from "node:child_process";
+import { composeGatewayFuel } from "./gateway-fuel.js";
+import type { ExtractionHarness, ExtractionRunInput } from "./harness.js";
+
+/**
+ * Last-resort extraction harness: nothing Claude-shaped is installed on the
+ * dev's machine (no Agent SDK, no `claude` binary, no `codex` binary), but
+ * they do have a usable credential — so init fetches Claude Code itself via
+ * `npm exec` rather than degrading straight to the honest skip. This is the
+ * fourth and final rung of the ladder in extraction.ts.
+ *
+ * Cross-task contract (a parallel task builds `@vendoai/engine` to this exact
+ * shape): `npm exec --yes @vendoai/engine@<PINNED_VERSION> -- run`, job JSON
+ * `{ instructions, root }` on the child's stdin, credentials/base-url/headers
+ * ride the child's process env (never the job JSON), stdout is EXACTLY the
+ * agent's final text, stderr is progress/narration, exit 0 = success. The
+ * version is pinned exact (never a range) so this rung's behavior can't
+ * drift out from under init on a machine with no local install to pin
+ * instead.
+ *
+ * Availability deliberately never touches npm or the network — it is called
+ * eagerly for every rung on every `vendo init`, and a probe here would mean
+ * every init pays an npm-registry round trip just to build the "AI polish?"
+ * prompt. The ~250MB download surprise is disclosed instead via the
+ * run-time notice below, right before the first real network access.
+ *
+ * Gateway fuel: mirrors claude-cli-harness.ts — when only VENDO_API_KEY is
+ * set (no ANTHROPIC_API_KEY), the child runs against Vendo Cloud's model
+ * gateway instead of degrading to unavailable (see gateway-fuel.ts). Own
+ * credential always wins.
+ */
+
+export const ENGINE_PACKAGE_NAME = "@vendoai/engine";
+export const ENGINE_PACKAGE_VERSION = "0.1.0";
+
+// A one-time ~250MB package fetch plus the extraction stages themselves (which
+// can already run for minutes over a real codebase on the other rungs) needs
+// more headroom than the PATH-binary rungs' 10-minute budget.
+const RUN_TIMEOUT_MS = 15 * 60 * 1_000;
+const MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+
+interface ExecResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+// Extends the sibling harnesses' (args, options) Exec seam with `input` and
+// `onStderrLine`: unlike `claude -p "<prompt>"` (prompt rides argv), this
+// rung's child protocol reads the job off stdin and narrates progress over
+// stderr line-by-line, so the seam needs both to be scriptable in tests.
+type Exec = (
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv; input: string; onStderrLine?: (line: string) => void },
+) => Promise<ExecResult>;
+
+/** Pure mapping from a completed `execFile` callback into an ExecResult —
+ *  pulled out of the real spawn so the npm-not-found case (execFile's error
+ *  has a string `code` like "ENOENT", not a process exit number) has direct
+ *  unit coverage without actually spawning a missing binary (mirrors
+ *  resolveCodexExecResult in codex-cli-harness.ts). */
+export function resolveNpmExecResult(
+  error: ExecFileException | null,
+  stdout: string,
+  stderr: string,
+): ExecResult {
+  if (error === null) return { stdout, stderr, code: 0 };
+  if (typeof error.code === "number") return { stdout, stderr, code: error.code };
+  // npm itself could not be launched — not installed, not on PATH, or the OS
+  // refused to spawn it (error.code is a string like "ENOENT", not a process
+  // exit number). execFile's own stdout/stderr are empty in this case, so the
+  // actionable detail has to come from error.message; an offline registry, by
+  // contrast, still lets npm launch and exit non-zero with its own
+  // descriptive stderr, handled by the branch above and forwarded verbatim.
+  return {
+    stdout: "",
+    stderr: `npm could not be launched (${error.message}) — is npm installed and on PATH?`,
+    code: 1,
+  };
+}
+
+function execNpmEngine(
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv; input: string; onStderrLine?: (line: string) => void },
+): Promise<ExecResult> {
+  return new Promise((resolve) => {
+    const child = execFile(
+      "npm",
+      args,
+      { cwd: options.cwd, env: options.env, timeout: RUN_TIMEOUT_MS, maxBuffer: MAX_BUFFER_BYTES },
+      (error, stdout, stderr) => {
+        resolve(resolveNpmExecResult(error, stdout, stderr));
+      },
+    );
+    // stderr is progress/narration per the child protocol — forward it line
+    // by line as it streams in, not just once the process exits.
+    let buffer = "";
+    child.stderr?.on("data", (chunk: Buffer | string) => {
+      buffer += chunk.toString();
+      let index = buffer.indexOf("\n");
+      while (index !== -1) {
+        const line = buffer.slice(0, index);
+        buffer = buffer.slice(index + 1);
+        if (line.length > 0) options.onStderrLine?.(line);
+        index = buffer.indexOf("\n");
+      }
+    });
+    child.stdin?.write(options.input);
+    child.stdin?.end();
+  });
+}
+
+export interface NpxEngineHarnessOptions {
+  /** Test seam. */
+  exec?: Exec;
+}
+
+export function npxEngineHarness(options: NpxEngineHarnessOptions = {}): ExtractionHarness {
+  const exec = options.exec ?? execNpmEngine;
+  return {
+    id: "npx-engine",
+    async availability({ env }) {
+      const key = env["ANTHROPIC_API_KEY"];
+      if (typeof key === "string" && key.trim().length > 0) {
+        return "your ANTHROPIC_API_KEY (via the Vendo engine, ~250MB one-time download)";
+      }
+      const cloudKey = env["VENDO_API_KEY"];
+      if (typeof cloudKey === "string" && cloudKey.trim().length > 0) {
+        return "your Vendo Cloud key (managed inference, via the Vendo engine, ~250MB one-time download)";
+      }
+      return null;
+    },
+    async run(input: ExtractionRunInput): Promise<string> {
+      const ownKey = input.env["ANTHROPIC_API_KEY"];
+      const hasOwnKey = typeof ownKey === "string" && ownKey.trim().length > 0;
+      const overlay = composeGatewayFuel({ env: input.env, ownCredentialAvailable: hasOwnKey });
+
+      // Visible-never-silent: the ~250MB fetch is a real surprise on a
+      // machine with nothing installed, so it's disclosed up front, before
+      // the child (and its network access) ever starts.
+      input.onProgress?.(
+        `Fetching ${ENGINE_PACKAGE_NAME}@${ENGINE_PACKAGE_VERSION} via npm exec (~250MB one-time download; `
+        + "npm caches it locally, so later runs skip the download)…",
+      );
+
+      const job = JSON.stringify({ instructions: input.instructions, root: input.root });
+      const args = ["exec", "--yes", `${ENGINE_PACKAGE_NAME}@${ENGINE_PACKAGE_VERSION}`, "--", "run"];
+      // Forward the caller's env so a key present only in the passed map
+      // (not process.env) still authenticates the child; gateway fuel (if
+      // applicable) wins last — mirrors claude-cli-harness.ts.
+      const result = await exec(args, {
+        cwd: input.root,
+        env: { ...process.env, ...input.env, ...overlay },
+        input: job,
+        onStderrLine: input.onProgress,
+      });
+      if (result.code !== 0) {
+        throw new Error(
+          `npm exec ${ENGINE_PACKAGE_NAME}@${ENGINE_PACKAGE_VERSION} exited with code ${result.code}: `
+          + `${result.stderr.trim() || "(no stderr)"}`,
+        );
+      }
+      return result.stdout;
+    },
+  };
+}

--- a/packages/vendo/src/cli/extract/npx-engine-harness.ts
+++ b/packages/vendo/src/cli/extract/npx-engine-harness.ts
@@ -60,12 +60,14 @@ type Exec = (
 ) => Promise<ExecResult>;
 
 /** Pure mapping from a completed `execFile` callback into an ExecResult —
- *  pulled out of the real spawn so the three ways `error` shows up (a normal
- *  nonzero exit, a real spawn-layer failure, or the RUN_TIMEOUT_MS kill) each
- *  get direct unit coverage without actually spawning anything (mirrors
- *  resolveCodexExecResult in codex-cli-harness.ts). The three are easy to
- *  conflate — all leave `error.code` non-numeric — but they need different
- *  messages: a killed 15-minute extraction run is not npm being uninstalled. */
+ *  pulled out of the real spawn so the four ways `error` shows up (a normal
+ *  nonzero exit, a real spawn-layer failure, the RUN_TIMEOUT_MS kill, or the
+ *  MAX_BUFFER_BYTES kill) each get direct unit coverage without actually
+ *  spawning anything (mirrors resolveCodexExecResult in
+ *  codex-cli-harness.ts). The four are easy to conflate — all leave
+ *  `error.code` non-numeric — but they need different messages: a killed
+ *  15-minute extraction run is not npm being uninstalled, and a >10MB
+ *  narration stream is not a timeout. */
 export function resolveNpmExecResult(
   error: ExecFileException | null,
   stdout: string,
@@ -73,6 +75,19 @@ export function resolveNpmExecResult(
 ): ExecResult {
   if (error === null) return { stdout, stderr, code: 0 };
   if (typeof error.code === "number") return { stdout, stderr, code: error.code };
+  if (error.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER") {
+    // execFile's `maxBuffer` kill also sets error.killed, so this must be
+    // checked BEFORE the killed branch below — a >10MB narration stream is
+    // not the 15-minute timeout, and labeling it as one would send the dev
+    // chasing a slowness that isn't there.
+    const megabytes = Math.round(MAX_BUFFER_BYTES / (1024 * 1024));
+    return {
+      stdout: "",
+      stderr: `npm exec output exceeded the ${megabytes}MB buffer — the engine's narration stream was `
+        + "larger than expected, so the child was killed before finishing",
+      code: 1,
+    };
+  }
   if (error.killed === true) {
     // execFile's `timeout` option SIGTERMs a still-running child — a
     // legitimate long extraction run, not a broken npm install. This must be
@@ -184,30 +199,41 @@ export function npxEngineHarness(options: NpxEngineHarnessOptions = {}): Extract
   return {
     id: "npx-engine",
     async availability({ env }) {
-      if (isSet(env["ANTHROPIC_API_KEY"])) return `your ANTHROPIC_API_KEY${DOWNLOAD_SUFFIX}`;
+      // The child spawns with {...process.env, ...input.env} (see run()), so
+      // the label must be judged against that SAME merged view — an ambient
+      // (process.env) own credential is the one the child would actually
+      // use, even when the caller's partial env carries only VENDO_API_KEY.
+      const merged = { ...process.env, ...env };
+      if (isSet(merged["ANTHROPIC_API_KEY"])) return `your ANTHROPIC_API_KEY${DOWNLOAD_SUFFIX}`;
       // The corporate-gateway/custom-endpoint env vars are an own credential
       // too (see gateway-fuel.ts's INVARIANT) — composeGatewayFuel refuses to
       // overlay onto them regardless of what run() passes, so labeling this
       // rung "your Vendo Cloud key" here would be a lie about what actually
       // runs. Per-var labels (same priority order as claude-cli-harness.ts)
       // so the consent line names the credential that's really in play.
-      if (hasOwnAnthropicEnvOverride(env)) {
-        if (isSet(env["ANTHROPIC_AUTH_TOKEN"])) return `your ANTHROPIC_AUTH_TOKEN${DOWNLOAD_SUFFIX}`;
-        if (isSet(env["CLAUDE_CODE_OAUTH_TOKEN"])) return `your CLAUDE_CODE_OAUTH_TOKEN${DOWNLOAD_SUFFIX}`;
+      if (hasOwnAnthropicEnvOverride(merged)) {
+        if (isSet(merged["ANTHROPIC_AUTH_TOKEN"])) return `your ANTHROPIC_AUTH_TOKEN${DOWNLOAD_SUFFIX}`;
+        if (isSet(merged["CLAUDE_CODE_OAUTH_TOKEN"])) return `your CLAUDE_CODE_OAUTH_TOKEN${DOWNLOAD_SUFFIX}`;
         return `your ANTHROPIC_BASE_URL${DOWNLOAD_SUFFIX}`;
       }
-      if (isSet(env["VENDO_API_KEY"])) {
+      if (isSet(merged["VENDO_API_KEY"])) {
         return `your Vendo Cloud key (managed inference, ${DOWNLOAD_NOTE})`;
       }
       return null;
     },
     async run(input: ExtractionRunInput): Promise<string> {
-      // composeGatewayFuel already refuses to overlay onto any of these env
-      // vars on its own (defense in depth) — computed explicitly here too so
-      // this rung's own-credential verdict matches availability()'s exactly,
-      // the same belt-and-suspenders style as claude-cli-harness.ts.
-      const hasOwnKey = isSet(input.env["ANTHROPIC_API_KEY"]) || hasOwnAnthropicEnvOverride(input.env);
-      const overlay = composeGatewayFuel({ env: input.env, ownCredentialAvailable: hasOwnKey });
+      // Merge FIRST, then guard — the child is spawned with the caller's env
+      // over process.env, so the own-credential verdict and composeGatewayFuel
+      // must evaluate that same merged env. Guarding input.env alone would
+      // let the overlay clobber an ambient (process.env) BYO endpoint the
+      // child would otherwise have used. composeGatewayFuel already refuses
+      // to overlay onto these env vars on its own (defense in depth) —
+      // computed explicitly here too so this rung's own-credential verdict
+      // matches availability()'s exactly, the same belt-and-suspenders style
+      // as claude-cli-harness.ts.
+      const merged = { ...process.env, ...input.env };
+      const hasOwnKey = isSet(merged["ANTHROPIC_API_KEY"]) || hasOwnAnthropicEnvOverride(merged);
+      const overlay = composeGatewayFuel({ env: merged, ownCredentialAvailable: hasOwnKey });
 
       // Visible-never-silent: the ~250MB fetch is a real surprise on a
       // machine with nothing installed, so it's disclosed up front, before
@@ -224,7 +250,7 @@ export function npxEngineHarness(options: NpxEngineHarnessOptions = {}): Extract
       // applicable) wins last — mirrors claude-cli-harness.ts.
       const result = await exec(args, {
         cwd: input.root,
-        env: { ...process.env, ...input.env, ...overlay },
+        env: { ...merged, ...overlay },
         input: job,
         onStderrLine: input.onProgress,
       });

--- a/packages/vendo/src/cli/extract/npx-engine-harness.ts
+++ b/packages/vendo/src/cli/extract/npx-engine-harness.ts
@@ -1,5 +1,5 @@
 import { execFile, type ExecFileException } from "node:child_process";
-import { composeGatewayFuel } from "./gateway-fuel.js";
+import { composeGatewayFuel, hasOwnAnthropicEnvOverride } from "./gateway-fuel.js";
 import type { ExtractionHarness, ExtractionRunInput } from "./harness.js";
 
 /**
@@ -24,10 +24,15 @@ import type { ExtractionHarness, ExtractionRunInput } from "./harness.js";
  * prompt. The ~250MB download surprise is disclosed instead via the
  * run-time notice below, right before the first real network access.
  *
- * Gateway fuel: mirrors claude-cli-harness.ts — when only VENDO_API_KEY is
- * set (no ANTHROPIC_API_KEY), the child runs against Vendo Cloud's model
- * gateway instead of degrading to unavailable (see gateway-fuel.ts). Own
- * credential always wins.
+ * Gateway fuel: mirrors claude-cli-harness.ts — when the dev has none of
+ * ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN, CLAUDE_CODE_OAUTH_TOKEN, or
+ * ANTHROPIC_BASE_URL (the corporate-gateway/custom-endpoint path) but
+ * VENDO_API_KEY is set, the child runs against Vendo Cloud's model gateway
+ * instead of degrading to unavailable (see gateway-fuel.ts). Own credential
+ * always wins — availability() must label these honestly (not as "Vendo
+ * Cloud key") since composeGatewayFuel itself refuses to overlay onto any of
+ * them; a wrong label here would make the consent prompt lie about what
+ * run() actually does.
  */
 
 export const ENGINE_PACKAGE_NAME = "@vendoai/engine";
@@ -110,6 +115,15 @@ function execNpmEngine(
   });
 }
 
+function isSet(value: string | undefined): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+// Every label this rung can return carries the download disclosure, since
+// (unlike the PATH-binary rungs) a fetch always happens here.
+const DOWNLOAD_NOTE = "via the Vendo engine, ~250MB one-time download";
+const DOWNLOAD_SUFFIX = ` (${DOWNLOAD_NOTE})`;
+
 export interface NpxEngineHarnessOptions {
   /** Test seam. */
   exec?: Exec;
@@ -120,19 +134,29 @@ export function npxEngineHarness(options: NpxEngineHarnessOptions = {}): Extract
   return {
     id: "npx-engine",
     async availability({ env }) {
-      const key = env["ANTHROPIC_API_KEY"];
-      if (typeof key === "string" && key.trim().length > 0) {
-        return "your ANTHROPIC_API_KEY (via the Vendo engine, ~250MB one-time download)";
+      if (isSet(env["ANTHROPIC_API_KEY"])) return `your ANTHROPIC_API_KEY${DOWNLOAD_SUFFIX}`;
+      // The corporate-gateway/custom-endpoint env vars are an own credential
+      // too (see gateway-fuel.ts's INVARIANT) — composeGatewayFuel refuses to
+      // overlay onto them regardless of what run() passes, so labeling this
+      // rung "your Vendo Cloud key" here would be a lie about what actually
+      // runs. Per-var labels (same priority order as claude-cli-harness.ts)
+      // so the consent line names the credential that's really in play.
+      if (hasOwnAnthropicEnvOverride(env)) {
+        if (isSet(env["ANTHROPIC_AUTH_TOKEN"])) return `your ANTHROPIC_AUTH_TOKEN${DOWNLOAD_SUFFIX}`;
+        if (isSet(env["CLAUDE_CODE_OAUTH_TOKEN"])) return `your CLAUDE_CODE_OAUTH_TOKEN${DOWNLOAD_SUFFIX}`;
+        return `your ANTHROPIC_BASE_URL${DOWNLOAD_SUFFIX}`;
       }
-      const cloudKey = env["VENDO_API_KEY"];
-      if (typeof cloudKey === "string" && cloudKey.trim().length > 0) {
-        return "your Vendo Cloud key (managed inference, via the Vendo engine, ~250MB one-time download)";
+      if (isSet(env["VENDO_API_KEY"])) {
+        return `your Vendo Cloud key (managed inference, ${DOWNLOAD_NOTE})`;
       }
       return null;
     },
     async run(input: ExtractionRunInput): Promise<string> {
-      const ownKey = input.env["ANTHROPIC_API_KEY"];
-      const hasOwnKey = typeof ownKey === "string" && ownKey.trim().length > 0;
+      // composeGatewayFuel already refuses to overlay onto any of these env
+      // vars on its own (defense in depth) — computed explicitly here too so
+      // this rung's own-credential verdict matches availability()'s exactly,
+      // the same belt-and-suspenders style as claude-cli-harness.ts.
+      const hasOwnKey = isSet(input.env["ANTHROPIC_API_KEY"]) || hasOwnAnthropicEnvOverride(input.env);
       const overlay = composeGatewayFuel({ env: input.env, ownCredentialAvailable: hasOwnKey });
 
       // Visible-never-silent: the ~250MB fetch is a real surprise on a

--- a/packages/vendo/src/cli/extract/npx-engine-harness.ts
+++ b/packages/vendo/src/cli/extract/npx-engine-harness.ts
@@ -60,10 +60,12 @@ type Exec = (
 ) => Promise<ExecResult>;
 
 /** Pure mapping from a completed `execFile` callback into an ExecResult —
- *  pulled out of the real spawn so the npm-not-found case (execFile's error
- *  has a string `code` like "ENOENT", not a process exit number) has direct
- *  unit coverage without actually spawning a missing binary (mirrors
- *  resolveCodexExecResult in codex-cli-harness.ts). */
+ *  pulled out of the real spawn so the three ways `error` shows up (a normal
+ *  nonzero exit, a real spawn-layer failure, or the RUN_TIMEOUT_MS kill) each
+ *  get direct unit coverage without actually spawning anything (mirrors
+ *  resolveCodexExecResult in codex-cli-harness.ts). The three are easy to
+ *  conflate — all leave `error.code` non-numeric — but they need different
+ *  messages: a killed 15-minute extraction run is not npm being uninstalled. */
 export function resolveNpmExecResult(
   error: ExecFileException | null,
   stdout: string,
@@ -71,16 +73,64 @@ export function resolveNpmExecResult(
 ): ExecResult {
   if (error === null) return { stdout, stderr, code: 0 };
   if (typeof error.code === "number") return { stdout, stderr, code: error.code };
-  // npm itself could not be launched — not installed, not on PATH, or the OS
-  // refused to spawn it (error.code is a string like "ENOENT", not a process
-  // exit number). execFile's own stdout/stderr are empty in this case, so the
-  // actionable detail has to come from error.message; an offline registry, by
-  // contrast, still lets npm launch and exit non-zero with its own
-  // descriptive stderr, handled by the branch above and forwarded verbatim.
+  if (error.killed === true) {
+    // execFile's `timeout` option SIGTERMs a still-running child — a
+    // legitimate long extraction run, not a broken npm install. This must be
+    // checked before the spawn-failure branch below: a kill leaves
+    // error.code null (not a string), so it would otherwise fall into "npm
+    // could not be launched" and mislabel the dev's own long-running job as
+    // a missing npm.
+    const minutes = Math.round(RUN_TIMEOUT_MS / 60_000);
+    return {
+      stdout: "",
+      stderr: `npm exec was killed for exceeding the ${minutes}-minute timeout`
+        + (error.signal !== undefined ? ` (${error.signal})` : ""),
+      code: 1,
+    };
+  }
+  if (typeof error.code === "string") {
+    // A real spawn-layer failure (error.code is an errno string like
+    // "ENOENT" or "EACCES", set when the OS never launched the child at
+    // all) — npm itself could not be launched: not installed, not on PATH,
+    // or not executable. execFile's own stdout/stderr are empty in this
+    // case, so the actionable detail has to come from error.message.
+    return {
+      stdout: "",
+      stderr: `npm could not be launched (${error.message}) — is npm installed and on PATH?`,
+      code: 1,
+    };
+  }
+  // Any other shape (no numeric exit code, not killed, no string spawn
+  // code) — don't fabricate a diagnosis; forward whatever npm itself wrote.
+  // An offline registry lands here: npm still launches and exits non-zero
+  // with its own descriptive stderr (e.g. "npm error code ENOTFOUND"),
+  // which run()'s nonzero-exit handling forwards to the dev verbatim.
+  return { stdout, stderr, code: 1 };
+}
+
+/** Line-buffered splitter for a live-streaming descriptor, extracted out of
+ *  execNpmEngine so it's directly unit-testable without a real child
+ *  process: a line split across two `data` chunks, and — the bug this
+ *  fixes — a trailing line with no final newline, which `flush()` still
+ *  delivers instead of silently dropping the child's last progress line
+ *  when the stream ends without one. */
+export function createLineSplitter(onLine: (line: string) => void): { push(chunk: string): void; flush(): void } {
+  let buffer = "";
   return {
-    stdout: "",
-    stderr: `npm could not be launched (${error.message}) — is npm installed and on PATH?`,
-    code: 1,
+    push(chunk: string) {
+      buffer += chunk;
+      let index = buffer.indexOf("\n");
+      while (index !== -1) {
+        const line = buffer.slice(0, index);
+        buffer = buffer.slice(index + 1);
+        if (line.length > 0) onLine(line);
+        index = buffer.indexOf("\n");
+      }
+    },
+    flush() {
+      if (buffer.length > 0) onLine(buffer);
+      buffer = "";
+    },
   };
 }
 
@@ -89,27 +139,27 @@ function execNpmEngine(
   options: { cwd: string; env: NodeJS.ProcessEnv; input: string; onStderrLine?: (line: string) => void },
 ): Promise<ExecResult> {
   return new Promise((resolve) => {
+    // stderr is progress/narration per the child protocol — forward it line
+    // by line as it streams in, not just once the process exits; flush()
+    // in the callback below delivers any trailing partial line too.
+    const splitter = createLineSplitter((line) => options.onStderrLine?.(line));
     const child = execFile(
       "npm",
       args,
       { cwd: options.cwd, env: options.env, timeout: RUN_TIMEOUT_MS, maxBuffer: MAX_BUFFER_BYTES },
       (error, stdout, stderr) => {
+        splitter.flush();
         resolve(resolveNpmExecResult(error, stdout, stderr));
       },
     );
-    // stderr is progress/narration per the child protocol — forward it line
-    // by line as it streams in, not just once the process exits.
-    let buffer = "";
-    child.stderr?.on("data", (chunk: Buffer | string) => {
-      buffer += chunk.toString();
-      let index = buffer.indexOf("\n");
-      while (index !== -1) {
-        const line = buffer.slice(0, index);
-        buffer = buffer.slice(index + 1);
-        if (line.length > 0) options.onStderrLine?.(line);
-        index = buffer.indexOf("\n");
-      }
-    });
+    child.stderr?.on("data", (chunk: Buffer | string) => splitter.push(chunk.toString()));
+    // If the child exits (or is killed by the timeout) before the stdin
+    // write drains, Node emits an unhandled EPIPE 'error' on this stream —
+    // with no listener, that's an uncaughtException that aborts all of
+    // `vendo init`, bypassing extraction.ts's graceful per-rung degradation.
+    // The real outcome always arrives via the execFile callback's exit code
+    // + stderr above, so this handler is intentionally a no-op.
+    child.stdin?.on("error", () => {});
     child.stdin?.write(options.input);
     child.stdin?.end();
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -992,6 +992,25 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)
 
+  packages/engine:
+    dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: 0.3.214
+        version: 0.3.214(@anthropic-ai/sdk@0.112.3(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.0
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)
+
   packages/guard:
     dependencies:
       '@vendoai/core':
@@ -1408,6 +1427,67 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.214':
+    resolution: {integrity: sha512-vAAOeVtlXs3p7MpFVfvfu9ja32eaKtB+MDZnPxCbdzxJk5nofCHlNsHa1UJwXHOsP9lOnFYNIccYztsZ4DNaJA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.214':
+    resolution: {integrity: sha512-NTbV8U2yucxCWqEiDC7L0MUehNmd8x3Op8OGzLZRhMF3xmQBy2DxpXiNZgSwwKWNDC3HdgKmJM5ZBbT7XrF/0g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.214':
+    resolution: {integrity: sha512-i06wQRsmevE7spY1ryYfs+NP+xdZ1FwAyTjDaF0k/xG+cgtzZYghTFUemdYF3GVwgWgpcava9GiCFDT3DoHI6w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.214':
+    resolution: {integrity: sha512-KBCf+BlusG0ZcgvpjjHwv1kh+6WiR8vJbPjpR2udwkrtcQgKLN+24l+FeaQEzO2TL+ExCmM1KC4tNPvnPpy+tw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.214':
+    resolution: {integrity: sha512-948RstHDhs0E69h+2dKYWIAL1kcwEme4zvtgNUwP8XpKXzWOhrTKmd6MAokHn25zwfuSx5d+HE0XHfFH6R4hLg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.214':
+    resolution: {integrity: sha512-vqadSceJkBKHaTUszxI35uTuECGWtsHWK/mOwIJ4b9DUtYYySz6EJEk4gHg4ccutisJ/oRVCpFXHIKFb+osrKw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.214':
+    resolution: {integrity: sha512-CEKlPFCPv+ee79utQMEDSsgeo2f27ulhNHpjrKIt1jXz5G04J7lAWN/QwvPDv9XaLBkWpyfqZWiPXlRcwuaO/w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.214':
+    resolution: {integrity: sha512-cJMJfFoR9IWBZWnTtt9PnEm89hGOsZjoDNjOCEOF3+x+g/ANIXAjMJTcaQYv2HKh6MylWZ0AkxBASI+twkukaQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.3.214':
+    resolution: {integrity: sha512-wt5ImwhU+p259Zt4K/Q9v5xVi6ruxYO5+KFICyJxnjs/QFEClAeSRqhcXx1J8jgGfatPW1faw09hkm66680UjA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
+      zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.112.3':
+    resolution: {integrity: sha512-wjcozJlitVIuBEw9cj/xBuRznwkhcLmXmNzlFoeHbh4AvrDG3HGZrdvEOTTmobcbhjGkfOpKbmDTCQ4s9LQvCg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -5754,6 +5834,10 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-to-zod@2.8.1:
     resolution: {integrity: sha512-fRr1mHgZ7hboLKBUdR428gd9dIHUFGivUqOeiDcSmyXkNZCtB1uGaZLvsjZ4GaN5pwBIs+TGIOf6s+Rp5/R/zA==}
     hasBin: true
@@ -7356,6 +7440,9 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -8003,6 +8090,52 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.214':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.214':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.214':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.214':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.214':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.214':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.214':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.214':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.3.214(@anthropic-ai/sdk@0.112.3(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.112.3(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.214
+
+  '@anthropic-ai/sdk@0.112.3(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.4.3
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -9338,6 +9471,28 @@ snapshots:
       raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.29)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.29
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -11469,7 +11624,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.9
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
@@ -11512,7 +11667,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11527,36 +11682,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.5(jiti@2.7.0)
-      get-tsconfig: 4.14.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.17
-      unrs-resolver: 1.12.2
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 9.39.5(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
@@ -11574,7 +11704,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -11603,7 +11733,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -12575,6 +12705,11 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
 
   json-schema-to-zod@2.8.1: {}
 
@@ -14625,6 +14760,8 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:

--- a/scripts/dependency-guard.mjs
+++ b/scripts/dependency-guard.mjs
@@ -73,6 +73,13 @@ const LAYERS = {
   vendoai: ["@vendoai/vendo"],
   // orthogonal to the campaign (00-overview: "stays as-is"); no vendo deps
   "@vendoai/telemetry": [],
+  // npx-fetched Agent SDK runner for init's last-resort engine rung
+  // (docs/superpowers/specs/2026-07-20-init-builtin-agent-harness-design.md).
+  // Deliberately a leaf: NOT a dependency of @vendoai/vendo or anything
+  // else — the whole point is that its ~245MB Agent SDK dependency never
+  // lands in a host app's install. Fetched via `npm exec` at a pinned
+  // version at run time instead.
+  "@vendoai/engine": [],
 };
 
 /**

--- a/scripts/dependency-guard.mjs
+++ b/scripts/dependency-guard.mjs
@@ -76,7 +76,7 @@ const LAYERS = {
   // npx-fetched Agent SDK runner for init's last-resort engine rung
   // (docs/superpowers/specs/2026-07-20-init-builtin-agent-harness-design.md).
   // Deliberately a leaf: NOT a dependency of @vendoai/vendo or anything
-  // else — the whole point is that its ~245MB Agent SDK dependency never
+  // else — the whole point is that its ~250MB Agent SDK dependency never
   // lands in a host app's install. Fetched via `npm exec` at a pinned
   // version at run time instead.
   "@vendoai/engine": [],


### PR DESCRIPTION
## What

\`vendo init\`'s consent-gated AI pass now resolves its engine through a four-rung ladder — first available wins, falling through when a rung is missing or unauthenticated:

1. **Claude Agent SDK** (if resolvable in the host) — dev's Claude Code login / ANTHROPIC_API_KEY
2. **\`claude\` CLI on PATH** — same credentials, plus ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / custom ANTHROPIC_BASE_URL setups (own endpoints are always honored, never overridden)
3. **\`codex\` CLI on PATH** (new) — ChatGPT login or OPENAI_API_KEY, headless \`codex exec --sandbox read-only\`
4. **\`@vendoai/engine\`** (new package) — real Claude Code (Agent SDK inside) fetched via pinned \`npm exec\`, ~250MB one-time into npm's cache, **never a host dependency** (dependency-guard leaf); fueled by ANTHROPIC_API_KEY or VENDO_API_KEY through the Cloud gateway

**Gateway fuel + free-plan policy:** when a Claude Code rung runs on VENDO_API_KEY, traffic carries \`x-vendo-purpose: init\`; the console (merged: runvendo/vendo-web#92) refuses init-tagged inference for free orgs with an honest bring-your-own-or-upgrade error and meters paid orgs normally. \`composeGatewayFuel\` refuses to overlay whenever the dev has any own Anthropic credential (key, token, or custom base URL) — BYO always wins, enforced inside the pure function so every present and future caller inherits it.

**Corpus:** informational nightly codex + npx-engine legs with liveness assertions (grep for rung-selection + completion lines; the npx leg is expected to fail its assertion until the package publishes — no false green). Follow-up filed to remove the harness's \`@ai-sdk/anthropic\` injection once the rung is nightly-proven.

Spec: \`docs/superpowers/specs/2026-07-20-init-builtin-agent-harness-design.md\` · Plan: \`docs/superpowers/plans/2026-07-20-init-selfcontained-engine.md\`

## Not in this PR

- \`@vendoai/engine\` is **not published** (NPM_TOKEN) — the rung degrades visibly (E404 forwarded, defaults stand) until then; release.yml picks it up automatically.

## Testing

- Full root gates green: build, test (all packages, incl. the corpus-harness probe fix for the SDK-now-in-workspace interaction), typecheck, lint.
- ~90 new unit tests across the two harnesses, gateway-fuel, ladder, and the engine package (39, incl. real-SDK-types seam).
- Every task went through two-stage agent review (spec + quality) with fix rounds; final cross-cutting whole-branch review APPROVED (engine↔npx contract manually verified end-to-end).
- **Live proof 1:** gated engine live test — real Agent SDK session, read-only tools, exact final text on stdout (8.3s).
- **Live proof 2:** real \`vendo init --ai-polish\` on a fixture with claude/codex stripped from PATH:
  \`\`\`
  Reading your product (your ANTHROPIC_API_KEY (via the Vendo engine, ~250MB one-time download))…
    Fetching @vendoai/engine@0.1.0 via npm exec (~250MB one-time download; npm caches it locally…)…
  AI polish did not complete (… npm error code E404 …); extractor defaults stand. Re-run \`vendo init\` to retry
  \`\`\`
  Ladder falls through to the npx rung, shows the download notice, degrades honestly on the unpublished package, init completes with exact reads + defaults.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `vendo init` self-contained with a four-rung engine ladder and an npx-fetched `@vendoai/engine`, so the consented polish step runs even without local tools. Hardens safety and correctness: engine reads are confined to the project root, BYO Anthropic endpoints always win (checked against the merged child env), and buffer/timeouts are labeled clearly.

- **New Features**
  - Engine ladder: Agent SDK -> `claude` CLI -> `codex` CLI -> npx `@vendoai/engine` (first available wins).
  - `codex` CLI harness: headless `codex exec` with a read-only sandbox; supports ChatGPT login or `OPENAI_API_KEY`.
  - npx engine harness: runs `npm exec --yes @vendoai/engine@<pin> -- run`; ~250MB one-time download, cached; no host dependency; passes env credentials through unchanged.
  - Gateway fuel: when no own Anthropic cred is present, `VENDO_API_KEY` supplies `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN` with `x-vendo-purpose: init`; any of `ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN`/`CLAUDE_CODE_OAUTH_TOKEN`/`ANTHROPIC_BASE_URL` always wins and is never overridden (now checked against the merged child env).
  - Safety and resilience: Read/Glob/Grep confined to the realpath of the project root (blocks absolute paths, .. climbs, symlink escapes); clearer timeout vs spawn vs 10MB maxBuffer errors; safe stdin/EPIPE handling, TTY fast-fail, and line-buffered progress.
  - Docs and CI: quickstart updated for the full ladder; corpus nightly legs for `codex` and npx-engine with liveness assertions; extensive tests. Note: `@vendoai/engine` is not yet published; the npx rung degrades honestly (E404).

- **Migration**
  - No changes required; the ladder auto-detects what’s available.
  - First use of the npx rung may download ~250MB.
  - Free orgs using `VENDO_API_KEY` during init will see a refusal message; use your own Anthropic credential or upgrade.
  - Optional paths: install/login `claude`, put `codex` on PATH or set `OPENAI_API_KEY`, or set `ANTHROPIC_API_KEY`.

<sup>Written for commit 6d67f98a1150e1443fff76643899c7fd08467256. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

