### PR TITLE
test: defuse the ladder e2e date-bomb (blocks every merge after 08:00 UTC today)

### DIFF
--- a/packages/vendo/src/ladder.e2e.test.ts
+++ b/packages/vendo/src/ladder.e2e.test.ts
@@ -228,11 +228,19 @@ describe.sequential("Wave 9 rung (a) e2e — the 8am digest rides the automation
       await guard.approvals.decide(request.id, { approve: true }, principal);
     }
 
-    // 2. The EXISTING trigger machinery fires it. First tick seeds the
-    // schedule cursor; the next tick past 08:00 UTC fires the run.
-    const seededAt = new Date("2026-07-21T00:00:00.000Z");
+    // 2. The EXISTING trigger machinery fires it. Arming seeded the schedule
+    // cursor at the REAL current time (engine enable() writes lastFiredAt:
+    // iso()), so the tick times must be derived from the real clock — fixed
+    // calendar dates made this a date-bomb that went red the moment the wall
+    // clock passed the hardcoded cron hour. A tick at "now" fires nothing
+    // (the next 08:00 UTC is still ahead of the cursor); a tick just past the
+    // next 08:00 UTC fires exactly one run.
+    const seededAt = new Date();
     expect(await automations.tick(seededAt)).toHaveLength(0);
-    const runIds = await automations.tick(new Date("2026-07-21T08:00:05.000Z"));
+    const nextEight = new Date(seededAt);
+    nextEight.setUTCHours(8, 0, 0, 0);
+    if (nextEight.getTime() <= seededAt.getTime()) nextEight.setUTCDate(nextEight.getUTCDate() + 1);
+    const runIds = await automations.tick(new Date(nextEight.getTime() + 5_000));
     expect(runIds).toHaveLength(1);
 
     const run = await automations.runs.get(runIds[0]!, ctx);

--- a/packages/vendo/src/ladder.e2e.test.ts
+++ b/packages/vendo/src/ladder.e2e.test.ts
@@ -81,6 +81,12 @@ const scriptedModel = (...responses: string[]): LanguageModel => {
 
 const APP_ID = "app_digest";
 
+// The engine's pinned clock (see harness): arming seeds the schedule cursor
+// at this instant, so the cron's next fire is deterministically the following
+// 08:00 UTC — independent of when the suite actually runs.
+const ARMED_AT = new Date("2026-07-21T12:00:00.000Z");
+const FIRES_AT = new Date("2026-07-22T08:00:05.000Z");
+
 const PLAN = JSON.stringify({
   name: "Unpaid invoice digest",
   resultsCollection: "digest",
@@ -187,7 +193,10 @@ async function harness(): Promise<{
     // NO machine config at all: a sandbox is not merely unused, it does not exist.
   });
   appsTools = apps.agentTools();
-  const automations = createAutomations({ apps, tools: boundTools, guard, store });
+  // Deterministic clock: enable() seeds the schedule cursor with the engine's
+  // now(), so pinning it decouples the whole test from the wall clock — no
+  // boundary window even when the suite runs exactly at the cron hour.
+  const automations = createAutomations({ apps, tools: boundTools, guard, store, now: () => ARMED_AT });
   automationsRef = automations;
   await store.records("vendo_apps").put({
     id: APP_ID,
@@ -229,18 +238,14 @@ describe.sequential("Wave 9 rung (a) e2e — the 8am digest rides the automation
     }
 
     // 2. The EXISTING trigger machinery fires it. Arming seeded the schedule
-    // cursor at the REAL current time (engine enable() writes lastFiredAt:
-    // iso()), so the tick times must be derived from the real clock — fixed
-    // calendar dates made this a date-bomb that went red the moment the wall
-    // clock passed the hardcoded cron hour. A tick at "now" fires nothing
-    // (the next 08:00 UTC is still ahead of the cursor); a tick just past the
-    // next 08:00 UTC fires exactly one run.
-    const seededAt = new Date();
-    expect(await automations.tick(seededAt)).toHaveLength(0);
-    const nextEight = new Date(seededAt);
-    nextEight.setUTCHours(8, 0, 0, 0);
-    if (nextEight.getTime() <= seededAt.getTime()) nextEight.setUTCDate(nextEight.getUTCDate() + 1);
-    const runIds = await automations.tick(new Date(nextEight.getTime() + 5_000));
+    // cursor at the engine's PINNED clock (ARMED_AT — hardcoded wall-clock
+    // dates here were a date-bomb that went red the moment real time passed
+    // the cron hour, and deriving from the real clock still left a boundary
+    // window). A tick at the pinned instant fires nothing (the next 08:00 UTC
+    // is still ahead of the cursor); a tick just past that fire time fires
+    // exactly one run.
+    expect(await automations.tick(ARMED_AT)).toHaveLength(0);
+    const runIds = await automations.tick(FIRES_AT);
     expect(runIds).toHaveLength(1);
 
     const run = await automations.runs.get(runIds[0]!, ctx);


### PR DESCRIPTION
## What

The Wave 9 8am-digest e2e (`packages/vendo/src/ladder.e2e.test.ts`) hardcoded its tick dates (`2026-07-21T00:00Z` seed, `2026-07-21T08:00:05Z` fire). But `automations.enable()` seeds the schedule cursor at the **real** current time (`lastFiredAt: iso()`), so the moment the wall clock passed 08:00 UTC on 2026-07-21, the cron's next fire (after the arm-time cursor) moved past the hardcoded tick and the test went deterministically red — failing the required `ci` check on every PR (currently blocking #455 and #462, and any branch update on #460/#461).

## Fix

Derive the tick times from the real clock: seed at `now` (fires nothing — the next 08:00 UTC is still ahead of the arm-time cursor), then tick just past the next 08:00 UTC after seeding (fires exactly one run). Green at any wall-clock time, any day.

## Evidence

- Reproduced red on clean main locally at 08:08 UTC (same assertion as CI: `expected [] to have a length of 1` at line 236).
- Green after the fix (same machine, same wall-clock window).
- CI on this PR runs the fixed test, so this PR is the unblock.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Wave 9 8am digest e2e by pinning the automations engine clock and using deterministic tick times. Removes all wall-clock dependence and unblocks CI merges.

- **Bug Fixes**
  - In `packages/vendo/src/ladder.e2e.test.ts`, pass `now: () => ARMED_AT` to `createAutomations` and add `ARMED_AT`/`FIRES_AT` constants for deterministic ticks.
  - Tick at `ARMED_AT` expects 0 runs; tick at `FIRES_AT` expects 1 run, matching `automations.enable()` seeding the cursor to the pinned time.

<sup>Written for commit 715e8bdb410d7c6ae537270ccda31a7f36087b44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

