### PR TITLE
ci: corpus nightly timeout 210m — AI pass outgrew the 2h ceiling

### DIFF
--- a/.github/workflows/corpus-nightly.yml
+++ b/.github/workflows/corpus-nightly.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   sweep:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 210  # full sweep + per-repo AI polish pass exceeds 120 (run 29811235687 timed out)
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 


### PR DESCRIPTION
Run 29811235687 (first full sweep with the merged init AI pass + UI-parity audit) was cancelled at exactly the 120-minute job timeout with the sweep step still running. Every future scheduled nightly hits the same wall. One line: timeout-minutes 120 -> 210. Evidence: run timing 07:39:04Z dispatch -> cancelled ~09:39Z, no failure conclusion, sweep step in_progress at cancellation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase corpus nightly job timeout from 120 to 210 minutes so the full sweep can complete. Recent runs hit the 2-hour limit and were cancelled mid-sweep; this avoids premature cancellations.

<sup>Written for commit 46868426c3579179e08357139b782abcc6b5fb8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

