### PR TITLE
init: let the user choose the AI-polish engine (--engine flag + pick-with-default consent)

### DIFF
--- a/docs-site/reference/cli.mdx
+++ b/docs-site/reference/cli.mdx
@@ -52,6 +52,14 @@ Options:
   `--byo` declines the Cloud offer (bring your own model key).
 - `--ai-polish` consents to the AI pass non-interactively: tool judgment
   (descriptions, risk, brief) and theme-slot filling, one consent for both.
+- `--engine <claude|codex|npx>` pins which engine runs the AI pass instead of
+  first-available (`claude` = Claude Agent SDK or the `claude` CLI, `codex` =
+  the `codex` CLI, `npx` = the npx-fetched engine on Vendo Cloud fuel). A
+  pinned engine that is not available skips the AI pass with one loud line —
+  it never falls back to a different provider. Interactively, when more than
+  one engine is available, the consent question itself becomes a pick (your
+  source goes to the provider you choose), so the flag is mostly for
+  unattended runs.
 - `--theme <slot=value>` overrides a theme slot value directly (repeatable).
 - `--force` regenerates Vendo-owned files under `.vendo/`. It does not replace
   existing host source files.

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -42,6 +42,7 @@ Options:
   --email <address>          Login only: pre-fill the approval page (login hint)
   --byo                      Init only: decline the Vendo Cloud offer (bring your own model key)
   --ai-polish                Init only: consent to the AI extraction pass without a prompt (works non-interactively)
+  --engine <name>            Init only: pin the AI-polish engine (claude, codex, npx) instead of first-available
   --theme <slot=value>       Init only: override a theme slot value directly (repeatable)
   --list                     Eject only: show the ejectable surfaces
   --model-import <specifier> Refine only: module exporting the host's ai-SDK model
@@ -73,11 +74,12 @@ function options(args: string[], name: string): string[] {
 }
 
 const INIT_FLAGS = new Set(["--agent", "--yes", "--force", "--byo", "--ai-polish"]);
-const INIT_VALUE_OPTIONS = ["--auth", "--framework", "--cloud-key", "--theme"];
+const INIT_VALUE_OPTIONS = ["--auth", "--framework", "--cloud-key", "--theme", "--engine"];
 /** Agent-install-dx: every init wizard question has a value-flag answer; a
     bad value fails as loudly as an unknown flag, with the valid choices. */
 const INIT_AUTH_VALUES = ["authJs", "clerk", "supabase", "auth0", "jwt", "none"];
 const INIT_FRAMEWORK_VALUES = ["next", "express"];
+const INIT_ENGINE_VALUES = ["claude", "codex", "npx"];
 const EXTRACT_FLAGS = new Set(["--force"]);
 const EXTRACT_VALUE_OPTIONS = ["--apply"];
 const DOCTOR_FLAGS = new Set(["--json", "--yes"]);
@@ -184,6 +186,10 @@ export async function main(argv: string[]): Promise<number> {
     if (cloudKey !== undefined && !isVendoKey(cloudKey)) {
       problems.push("--cloud-key must be a Vendo Cloud key (vnd_ + 40 hex; `vendo login` issues one)");
     }
+    const engine = option(args, "--engine");
+    if (engine !== undefined && !INIT_ENGINE_VALUES.includes(engine)) {
+      problems.push(`--engine must be one of ${INIT_ENGINE_VALUES.join(", ")} (example: vendo init --engine codex)`);
+    }
     if (cloudKey !== undefined && args.includes("--byo")) {
       problems.push("--cloud-key and --byo answer the same question — pass one or the other");
     }
@@ -206,6 +212,7 @@ export async function main(argv: string[]): Promise<number> {
       ...(cloudKey === undefined ? {} : { cloudKey }),
       ...(args.includes("--byo") ? { byo: true } : {}),
       ...(args.includes("--ai-polish") ? { aiPolish: true } : {}),
+      ...(engine === undefined ? {} : { engine }),
       ...(themePairs.length === 0 ? {} : {
         themeAnswers: Object.fromEntries(themePairs.map((pair) => {
           const at = pair.indexOf("=");

--- a/packages/vendo/src/cli/extract/extraction.test.ts
+++ b/packages/vendo/src/cli/extract/extraction.test.ts
@@ -471,3 +471,162 @@ describe("runAiExtraction", () => {
     expect(result.ran).toBe(false);
   });
 });
+
+// Engine choice (agent-install-dx follow-up): `--engine` pins a rung family;
+// interactively, several available families turn the single consent question
+// into a single pick-with-default. One engine = the unchanged yes/no.
+describe("runAiExtraction engine choice", () => {
+  const scripted = "```json\n" + JSON.stringify({ brief: "b", tools: [] }) + "\n```";
+  function engineHarness(id: string, credential: string | null, onRun?: () => void): ExtractionHarness {
+    return {
+      id,
+      availability: async () => credential,
+      run: async () => {
+        onRun?.();
+        return scripted;
+      },
+    };
+  }
+  const neverConfirm = async (): Promise<boolean> => { throw new Error("confirm must not be asked"); };
+  const neverChoose = async (): Promise<string> => { throw new Error("select must not be asked"); };
+
+  it("engine pins the rung family and consent names its credential", async () => {
+    const root = await fixture();
+    const sink = output();
+    const questions: string[] = [];
+    const result = await runAiExtraction({
+      root, output: sink.output, env: {}, yes: false, interactive: true,
+      engine: "codex",
+      harnesses: [
+        engineHarness("claude-agent-sdk", "your Claude Code login"),
+        engineHarness("codex-cli", "your codex login"),
+      ],
+      confirm: async (question) => {
+        questions.push(question);
+        return true;
+      },
+      choose: neverChoose,
+    });
+    expect(result.ran).toBe(true);
+    expect(questions).toHaveLength(1);
+    expect(questions[0]).toContain("your codex login");
+    expect(sink.logs.join("\n")).toContain("Reading your product (your codex login)");
+  });
+
+  it("declines loudly when the pinned engine is unavailable, naming what is available", async () => {
+    const root = await fixture();
+    const sink = output();
+    const result = await runAiExtraction({
+      root, output: sink.output, env: {}, yes: false, interactive: true,
+      engine: "codex",
+      harnesses: [engineHarness("claude-agent-sdk", "your Claude Code login"), engineHarness("codex-cli", null)],
+      confirm: neverConfirm,
+      choose: neverChoose,
+    });
+    expect(result.ran).toBe(false);
+    const message = sink.logs.join("\n");
+    expect(message).toContain("--engine codex");
+    expect(message).toContain("--engine claude");
+    expect(message).toContain("your Claude Code login");
+  });
+
+  it("asks ONE select when several engines are available and runs the picked one", async () => {
+    const root = await fixture();
+    const sink = output();
+    let asked: { question: string; options: Array<{ value: string; label: string }>; defaultIndex: number } | null = null;
+    const result = await runAiExtraction({
+      root, output: sink.output, env: {}, yes: false, interactive: true,
+      harnesses: [
+        engineHarness("claude-agent-sdk", "your Claude Code login"),
+        engineHarness("codex-cli", "your OPENAI_API_KEY"),
+      ],
+      confirm: neverConfirm,
+      choose: async (question, options, defaultIndex) => {
+        asked = { question, options, defaultIndex };
+        return "codex";
+      },
+    });
+    expect(result.ran).toBe(true);
+    expect(asked).not.toBeNull();
+    expect(asked!.options.map((option) => option.value)).toEqual(["claude", "codex", "skip"]);
+    expect(asked!.defaultIndex).toBe(0);
+    expect(asked!.options[0]!.label).toContain("your Claude Code login");
+    expect(asked!.options[1]!.label).toContain("your OPENAI_API_KEY");
+    expect(sink.logs.join("\n")).toContain("Reading your product (your OPENAI_API_KEY)");
+  });
+
+  it("select's skip answer keeps extractor defaults without running anything", async () => {
+    const root = await fixture();
+    const sink = output();
+    let ran = false;
+    const result = await runAiExtraction({
+      root, output: sink.output, env: {}, yes: false, interactive: true,
+      harnesses: [
+        engineHarness("claude-agent-sdk", "your Claude Code login", () => { ran = true; }),
+        engineHarness("codex-cli", "your codex login", () => { ran = true; }),
+      ],
+      confirm: neverConfirm,
+      choose: async () => "skip",
+    });
+    expect(result.ran).toBe(false);
+    expect(ran).toBe(false);
+    expect(sink.logs.join("\n")).toContain("Skipped");
+  });
+
+  it("keeps the plain yes/no when only one engine family is available", async () => {
+    const root = await fixture();
+    const sink = output();
+    const result = await runAiExtraction({
+      root, output: sink.output, env: {}, yes: false, interactive: true,
+      harnesses: [
+        engineHarness("claude-agent-sdk", "your Claude Code login"),
+        engineHarness("claude-cli", "your Claude Code login"),
+        engineHarness("codex-cli", null),
+      ],
+      confirm: async () => true,
+      choose: neverChoose,
+    });
+    expect(result.ran).toBe(true);
+    expect(sink.logs.join("\n")).toContain("Reading your product (your Claude Code login)");
+  });
+
+  it("dedupes rungs of the same family: the first rung speaks for it in the select", async () => {
+    const root = await fixture();
+    const sink = output();
+    let values: string[] = [];
+    const result = await runAiExtraction({
+      root, output: sink.output, env: {}, yes: false, interactive: true,
+      harnesses: [
+        engineHarness("claude-agent-sdk", "your Claude Code login"),
+        engineHarness("claude-cli", "the claude CLI"),
+        engineHarness("codex-cli", "your codex login"),
+        engineHarness("npx-engine", "your VENDO_API_KEY"),
+      ],
+      confirm: neverConfirm,
+      choose: async (_question, options) => {
+        values = options.map((option) => option.value);
+        return "claude";
+      },
+    });
+    expect(result.ran).toBe(true);
+    expect(values).toEqual(["claude", "codex", "npx", "skip"]);
+    expect(sink.logs.join("\n")).toContain("Reading your product (your Claude Code login)");
+  });
+
+  it("consent flag plus engine runs pinned without any prompt", async () => {
+    const root = await fixture();
+    const sink = output();
+    const result = await runAiExtraction({
+      root, output: sink.output, env: {}, yes: true, interactive: false, consent: true,
+      engine: "codex",
+      harnesses: [
+        engineHarness("claude-agent-sdk", "your Claude Code login"),
+        engineHarness("codex-cli", "your codex login"),
+      ],
+      confirm: neverConfirm,
+      choose: neverChoose,
+    });
+    expect(result.ran).toBe(true);
+    expect(sink.logs.join("\n")).toContain("Reading your product (your codex login)");
+  });
+});

--- a/packages/vendo/src/cli/extract/extraction.ts
+++ b/packages/vendo/src/cli/extract/extraction.ts
@@ -7,6 +7,7 @@ import { claudeHarness } from "./claude-harness.js";
 import { codexCliHarness } from "./codex-cli-harness.js";
 import { parseDraft, type ExtractionHarness } from "./harness.js";
 import { npxEngineHarness } from "./npx-engine-harness.js";
+import { plainSelect, type SelectOption } from "../pretty.js";
 import {
   BRIEF_TEMPLATE,
   runStagedExtraction,
@@ -185,15 +186,31 @@ export interface AiExtractionOptions {
       when non-interactive (the flag IS the answer). */
   consent?: boolean;
   force?: boolean;
+  /** --engine: pin the rung family (claude | codex | npx) instead of
+      first-available. An unavailable pin skips loudly — never a fallback. */
+  engine?: string;
   /** Seams (tests / future harnesses). */
   harnesses?: ExtractionHarness[];
   confirm?: (question: string, defaultYes: boolean) => Promise<boolean>;
+  /** The multi-engine consent select (init passes pretty.select); default is
+      the plain numbered select. Resolves to an option value or "skip". */
+  choose?: (question: string, options: SelectOption[], defaultIndex: number) => Promise<string>;
   interactive?: boolean;
   /** Optional theme-stage input (init's exact-only summary, projected) — see
       `StagedExtractionInput.theme`. Omitted when init has no theme pass to
       run this call (a pre-existing theme.json, e.g.). */
   theme?: StagedExtractionInput["theme"];
 }
+
+/** Rung id → user-facing engine family (`--engine` values). The Agent SDK and
+    the claude CLI are one family: same provider, same credential story. An
+    unknown id (test fakes, future rungs) is its own family. */
+const ENGINE_FAMILIES: Record<string, string> = {
+  "claude-agent-sdk": "claude",
+  "claude-cli": "claude",
+  "codex-cli": "codex",
+  "npx-engine": "npx",
+};
 
 /** init's AI extraction step. Never changes init's exit code. */
 export async function runAiExtraction(
@@ -226,33 +243,74 @@ export async function runAiExtraction(
   // Ordered engine ladder (install-dx: init-selfcontained-engine, Task 2/4):
   // Agent SDK -> claude CLI -> codex CLI -> npx-fetched engine. A rung whose
   // availability() is null (binary missing or present-but-unauthenticated) is
-  // skipped and the next rung is tried; the first non-null credential wins.
-  // The npx rung is last on purpose: it's the only one with a real first-run
-  // cost (an npm fetch), so every rung that can run for free (something
-  // already installed) gets first refusal.
+  // skipped; ladder order encodes preference (the npx rung is last on purpose:
+  // it's the only one with a real first-run cost, an npm fetch, so every rung
+  // that can run for free gets first refusal). Availability is checked across
+  // the WHOLE ladder (every check is local and cheap) so `--engine` can pin a
+  // family and the interactive consent can offer a choice when there is one;
+  // the first available rung of a family speaks for that family.
   const harnesses = options.harnesses
     ?? [claudeHarness(), claudeCliHarness(), codexCliHarness(), npxEngineHarness()];
-  let chosen: { harness: ExtractionHarness; credential: string } | null = null;
+  const available: Array<{ harness: ExtractionHarness; credential: string; family: string }> = [];
   for (const harness of harnesses) {
+    const family = ENGINE_FAMILIES[harness.id] ?? harness.id;
+    if (available.some((entry) => entry.family === family)) continue;
     const credential = await harness.availability({ root, env });
-    if (credential !== null) {
-      chosen = { harness, credential };
-      break;
-    }
+    if (credential !== null) available.push({ harness, credential, family });
   }
-  if (chosen === null) {
+  if (available.length === 0) {
     output.log("AI polish: unavailable — needs Claude Code installed (`npm install -g @anthropic-ai/claude-code`) or @anthropic-ai/claude-agent-sdk resolvable, plus a Claude Code login or ANTHROPIC_API_KEY; or the `codex` CLI installed, plus a codex login (`codex login`) or OPENAI_API_KEY; or a VENDO_API_KEY (`vendo login`), which fetches Claude Code on the fly via npx. Extractor defaults stand; re-run `vendo init` once set up.");
     return { ran: false };
   }
 
-  const confirm = options.confirm ?? askYesNo;
-  const consented = options.consent === true || await confirm(
-    `Let ${chosen.credential} read this codebase to draft tool descriptions, review risk, write the product brief, and fill unresolved theme slots? Source goes to your model provider under your account.`,
-    true,
-  );
-  if (!consented) {
-    output.log("Skipped — extractor defaults stand; re-run `vendo init` any time to add the AI polish.");
-    return { ran: false };
+  // --engine pins a family. An unavailable pin never falls back to another
+  // provider (the pin is usually a privacy/policy choice about where source
+  // goes) — one loud line naming what IS available, exit code untouched.
+  let chosen: { harness: ExtractionHarness; credential: string };
+  if (options.engine !== undefined) {
+    const pinned = available.find((entry) => entry.family === options.engine);
+    if (pinned === undefined) {
+      const alternatives = available
+        .map((entry) => `\`--engine ${entry.family}\` (${entry.credential})`)
+        .join(", or ");
+      output.log(`AI polish: \`--engine ${options.engine}\` requested but that engine isn't available on this machine. Available: ${alternatives}. Extractor defaults stand; re-run \`vendo init\` once it's set up.`);
+      return { ran: false };
+    }
+    chosen = pinned;
+  } else {
+    chosen = available[0]!;
+  }
+
+  if (options.consent !== true) {
+    if (options.engine === undefined && available.length > 1) {
+      // Several engines: the SAME single consent question, as a pick-with-
+      // default instead of yes/no — never a second question.
+      const choose = options.choose ?? plainSelect;
+      const picked = await choose(
+        "Let a coding agent read this codebase to draft tool descriptions, review risk, write the product brief, and fill unresolved theme slots? Source goes to the chosen provider under your account.",
+        [
+          ...available.map((entry) => ({ value: entry.family, label: entry.credential, hint: `--engine ${entry.family}` })),
+          { value: "skip", label: "Skip — keep extractor defaults" },
+        ],
+        0,
+      );
+      const selected = available.find((entry) => entry.family === picked);
+      if (selected === undefined) {
+        output.log("Skipped — extractor defaults stand; re-run `vendo init` any time to add the AI polish.");
+        return { ran: false };
+      }
+      chosen = selected;
+    } else {
+      const confirm = options.confirm ?? askYesNo;
+      const consented = await confirm(
+        `Let ${chosen.credential} read this codebase to draft tool descriptions, review risk, write the product brief, and fill unresolved theme slots? Source goes to your model provider under your account.`,
+        true,
+      );
+      if (!consented) {
+        output.log("Skipped — extractor defaults stand; re-run `vendo init` any time to add the AI polish.");
+        return { ran: false };
+      }
+    }
   }
 
   let appName = "app";

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -143,6 +143,8 @@ export interface InitOptions {
   byo?: boolean;
   /** --ai-polish: consent to the AI extraction pass without the prompt. */
   aiPolish?: boolean;
+  /** --engine: pin the AI-polish rung family (claude | codex | npx). */
+  engine?: string;
   /** --theme slot=value answers for the uncertain-slot review. */
   themeAnswers?: Record<string, string>;
   output?: Output;
@@ -964,7 +966,8 @@ export async function runInit(options: InitOptions): Promise<number> {
       // stop skipping.
       ...(options.aiPolish === true ? { consent: true } : {}),
       ...(options.force === true ? { force: true } : {}),
-      ...(pretty === null ? {} : { confirm: pretty.confirm }),
+      ...(options.engine === undefined ? {} : { engine: options.engine }),
+      ...(pretty === null ? {} : { confirm: pretty.confirm, choose: pretty.select }),
       ...(themeCreatedThisRun && themeSummary !== null ? {
         theme: {
           needed: themeSummary.needed,


### PR DESCRIPTION
## What

The init AI-polish ladder (Claude Agent SDK → `claude` CLI → `codex` CLI → npx engine) always ran first-available: a machine with both `claude` and `codex` could never send its source to the provider of its choice short of PATH hacks, and declining consent was all-or-nothing.

- **Interactive, several engines available:** the single consent question becomes a single **pick-with-default** — options are the honest credential labels ("your Claude Code login", "your codex login"), each hinting its `--engine` value, plus "Skip — keep extractor defaults". Default = today's ladder winner. **One engine available = exactly the old yes/no.** Question count unchanged everywhere.
- **`--engine <claude|codex|npx>`** (init value flag, per the every-question-has-a-flag convention) pins a rung family for unattended runs. An unavailable pin skips the AI pass with one loud line naming what *is* available — it **never falls back to another provider** (the pin is usually a privacy/policy choice about where source goes). Composes with `--ai-polish` for fully unattended pinned runs.
- Availability is now read across the whole ladder (every check is local/cheap); the first available rung of a family speaks for it (SDK before CLI for claude).
- Docs: `--engine` added to the CLI reference (canonical flag home); dev-mode page already states the init-only role of coding-agent logins.

## Why

Which provider reads your source is a policy decision, not an implementation detail — the consent prompt literally says "source goes to your model provider under your account", but until now you couldn't change *which*. Raised by Yousef while manual-testing the 0.4.0 prompts.

## Verification

- [x] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green — one exception: `server.test.ts > routes every contracted method and path` timed out (30s) under full-turbo load in the gate run and passes standalone; matches the documented PGlite suite-load flake, unrelated file. All 7 new engine-choice tests + the 23 existing extraction tests green.
- [ ] Screenshots attached (if UI-affecting) — n/a (terminal prompt change only)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Init now lets you choose the AI‑polish engine via a new `--engine` flag or a pick‑with‑default prompt. This gives you control over which provider reads your source and prevents silent fallback.

- **New Features**
  - Added `--engine <claude|codex|npx>` to `vendo init` to pin the AI‑polish engine; if the pin isn’t available, the AI pass is skipped with a clear message and never falls back.
  - When several engines are available, the single consent becomes a single select with credential labels (e.g., “your Claude Code login”, “your OPENAI_API_KEY”) and `--engine` hints; with one engine, it stays a yes/no prompt.
  - Availability is checked across the whole ladder and deduped by family; the first available rung speaks for its family. Ladder order: `claude` (Agent SDK → `claude` CLI) → `codex` (`codex` CLI) → `npx`.
  - Works with `--ai-polish` for fully unattended runs. Updated CLI validation, help, and docs to include `--engine`.

<sup>Written for commit 32f7e795a2013e332c15926e0069daa9680dc850. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

