### PR TITLE
vendo: remove `vendo cloud deployments` — org-scoped endpoint died with spine v2

### DIFF
--- a/docs-site/deploy/vendo-cloud.mdx
+++ b/docs-site/deploy/vendo-cloud.mdx
@@ -91,10 +91,9 @@ revoked key surfaces on the first real service call with
 `Invalid or revoked API key (401)`.
 
 Every key-authed call carries sanitized deployment-identity headers
-(`X-Vendo-Deployment-Host`, `X-Vendo-Deployment-Name`), so usage and
-deployments appear in the console, `vendo cloud usage`, and
-`vendo cloud deployments` from real traffic. To confirm a CI key works, make
-a real call and check the exit code.
+(`X-Vendo-Deployment-Host`, `X-Vendo-Deployment-Name`), so usage appears in
+the console and `vendo cloud usage` from real traffic. To confirm a CI key
+works, make a real call and check the exit code.
 
 ## Point at a different Vendo Cloud URL
 

--- a/docs-site/reference/cli.mdx
+++ b/docs-site/reference/cli.mdx
@@ -383,10 +383,10 @@ email-OTP fallback `vendo cloud login <email>` sends a 6-10 digit code,
 prompts for it, and stores the session at `~/.vendo/cloud-session.json`;
 `--token <jwt>` stores an access token instead.
 Other subcommands: `logout`, `whoami`, `orgs`, `keys` (`list`, `create`,
-`revoke`), `members`, `invite`, `deployments`, `usage`, and `billing`. Read
+`revoke`), `members`, `invite`, `usage`, and `billing`. Read
 results print as JSON. There is no validate subcommand: key problems
-surface on the first real call, and `vendo cloud usage` and
-`vendo cloud deployments` read the server-side metering from real traffic.
+surface on the first real call, and `vendo cloud usage` reads the
+server-side metering from real traffic.
 
 There is no deploy subcommand. With `VENDO_API_KEY` set, automations you
 build sync to Vendo Cloud automatically and run on Vendo's schedulers — see

--- a/packages/vendo/src/cli/cloud/E2E.md
+++ b/packages/vendo/src/cli/cloud/E2E.md
@@ -35,7 +35,6 @@ for the current behavior.
 ## User principal (stored session or --token JWT)
 - `vendo cloud whoami --token <jwt>` → `{ orgs: [{id,name,role}] }`
 - `vendo cloud keys list --org <id> --token <jwt>` → `{ keys: [...] }`
-- `vendo cloud deployments --org <id> --token <jwt>` → `{ deployments: [...] }`
 
 All shapes match the frozen flowlet wave-2 contracts; the 402 `cloud-required`
 envelope is surfaced as a friendly message. The auth/share/publish flows were

--- a/packages/vendo/src/cli/cloud/index.test.ts
+++ b/packages/vendo/src/cli/cloud/index.test.ts
@@ -13,12 +13,12 @@ describe("cloud command dispatch", () => {
     expect(await runCloud(["--help"], { output: messages.sink })).toBe(0);
     expect(messages.logs.join("\n")).toContain("login EMAIL");
     expect(messages.logs.join("\n")).not.toContain("validate");
-    // The retired machine trio is gone from the surface entirely.
-    for (const removed of ["share", "publish", "pin-ship"]) {
+    // The retired machine trio is gone from the surface entirely, and so is
+    // the deployments read (its org-scoped endpoint died with spine v2 and
+    // the console Deployments page was removed 2026-07-21).
+    for (const removed of ["share", "publish", "pin-ship", "deployments"]) {
       expect(messages.logs.join("\n")).not.toContain(removed);
     }
-    // "deploy" itself is gone too — matched with a word boundary since
-    // "deployments" (the org-deployments read command) legitimately stays.
     expect(messages.logs.join("\n")).not.toMatch(/\bdeploy\b/);
   });
 

--- a/packages/vendo/src/cli/cloud/index.ts
+++ b/packages/vendo/src/cli/cloud/index.ts
@@ -4,7 +4,7 @@ import { runDeviceLogin, type DeviceLoginOptions } from "./device-login.js";
 import { runKeys } from "./keys.js";
 import { runInvite, runMembers } from "./members.js";
 import { consoleOutput } from "../shared.js";
-import { runBilling, runDeployments, runOrgs, runUsage } from "./read.js";
+import { runBilling, runOrgs, runUsage } from "./read.js";
 
 const CLOUD_HELP = `vendo cloud — Vendo Cloud API client
 
@@ -23,7 +23,6 @@ User commands:
   keys list --org <id>                  List API keys
   keys create --org <id> --name <name> Create an API key
   keys revoke --org <id> --id <keyId>  Revoke an API key
-  deployments --org <id>               List deployments
   usage --org <id> [--days <days>]     Show usage (default 30 days)
   members --org <id>                   List organization members
   invite --org <id> --email <email> --role <admin|member>
@@ -49,7 +48,6 @@ export async function runCloud(args: string[], options: RunCloudOptions = {}): P
   if (command === "whoami") return runWhoami(commandArgs, options);
   if (command === "orgs") return runOrgs(commandArgs, options);
   if (command === "keys") return runKeys(commandArgs, options);
-  if (command === "deployments") return runDeployments(commandArgs, options);
   if (command === "usage") return runUsage(commandArgs, options);
   if (command === "members") return runMembers(commandArgs, options);
   if (command === "invite") return runInvite(commandArgs, options);

--- a/packages/vendo/src/cli/cloud/read.test.ts
+++ b/packages/vendo/src/cli/cloud/read.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { runDeployments, runOrgs, runUsage } from "./read.js";
+import { runBilling, runOrgs, runUsage } from "./read.js";
 
 function output() {
   const logs: string[] = [];
@@ -16,11 +16,11 @@ describe("cloud organization reads", () => {
     expect(JSON.parse(messages.logs[0]!)).toEqual({ orgs: [{ id: "org_1" }] });
   });
 
-  it("uses an explicit organization for deployments", async () => {
+  it("uses an explicit organization for billing", async () => {
     const messages = output();
-    const fetcher = vi.fn().mockResolvedValue({ deployments: [] });
-    expect(await runDeployments(["--org", "org/a"], { output: messages.sink, fetcher })).toBe(0);
-    expect(fetcher).toHaveBeenCalledWith("/api/v1/orgs/org%2Fa/deployments", expect.any(Object));
+    const fetcher = vi.fn().mockResolvedValue({ plan: "free" });
+    expect(await runBilling(["--org", "org/a"], { output: messages.sink, fetcher })).toBe(0);
+    expect(fetcher).toHaveBeenCalledWith("/api/v1/orgs/org%2Fa/billing", expect.any(Object));
   });
 
   it("defaults to the only organization and forwards usage days", async () => {
@@ -35,7 +35,7 @@ describe("cloud organization reads", () => {
   it("returns a clear error when an organization cannot be inferred", async () => {
     const messages = output();
     const fetcher = vi.fn().mockResolvedValue({ orgs: [{ id: "one" }, { id: "two" }] });
-    expect(await runDeployments([], { output: messages.sink, fetcher })).toBe(1);
+    expect(await runBilling([], { output: messages.sink, fetcher })).toBe(1);
     expect(messages.errors.join("\n")).toContain("--org <id>");
   });
 });

--- a/packages/vendo/src/cli/cloud/read.ts
+++ b/packages/vendo/src/cli/cloud/read.ts
@@ -25,10 +25,6 @@ function orgRead(
   });
 }
 
-export function runDeployments(args: string[], options: CloudCommandOptions = {}): Promise<number> {
-  return orgRead(args, options, "deployments");
-}
-
 export function runUsage(args: string[], options: CloudCommandOptions = {}): Promise<number> {
   const days = option(args, "--days") ?? "30";
   return orgRead(args, options, "usage", `?days=${encodeURIComponent(days)}`);


### PR DESCRIPTION
Follow-up to #472 (the commit was pushed to that branch moments after it merged, so it lands here instead).

## What

Removes the `vendo cloud deployments` read command: it hits `GET /api/v1/orgs/{id}/deployments`, which was removed server-side in the spine v2 route realignment, and the console Deployments page was removed today (vendo-web PR #128) — there is no deployments surface left to read. Command, dispatch, help entry, tests, `cloud/E2E.md`, and docs-site mentions all go. The `usage`/`billing` org-read plumbing is kept.

Known drift, deliberately untouched: `vendo cloud usage` and `vendo cloud billing` also hit org-scoped routes that spine v2 removed — those need their own decision (repoint or retire).

## Verification

`@vendoai/vendo` 935 passed / 13 pre-existing skips, `tsc --noEmit` clean, tree-wide grep shows no remaining `runDeployments`/`cloud deployments` in source.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `vendo cloud deployments` command after the org-scoped route `GET /api/v1/orgs/{id}/deployments` was removed in spine v2 and the console Deployments page was retired. This removes a broken CLI path while keeping `usage` and `billing` reads.

- **Bug Fixes**
  - Dropped the `deployments` command, dispatcher hook, help entry, and `runDeployments`.
  - Updated docs and tests to remove deployments references; CLI help test asserts it’s absent.
  - Retained org-read plumbing for `usage` and `billing` (to be repointed or retired separately).

<sup>Written for commit d25b609d916b557f94618fcf16c71ef8d872061d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

