### PR TITLE
vendo: repoint cloud keys/usage to project scope, retire billing

### DIFF
--- a/docs-site/deploy/vendo-cloud.mdx
+++ b/docs-site/deploy/vendo-cloud.mdx
@@ -78,12 +78,13 @@ Sign out with `vendo cloud logout`. Check that the session works with
 ## Create and rotate keys
 
 ```bash
-vendo cloud keys create --org <orgId> --name "ci-publisher"
-vendo cloud keys list --org <orgId>
-vendo cloud keys revoke --org <orgId> --id <keyId>
+vendo cloud keys create --project <projectId> --name "ci-publisher"
+vendo cloud keys list --project <projectId>
+vendo cloud keys revoke --project <projectId> --id <keyId>
 ```
 
-`--org` is optional only when your account has exactly one organization.
+Keys belong to a project. `--project` is optional only when there is exactly
+one candidate — one organization on your account with one project in it.
 
 There is no validate endpoint and no local entitlements cache. `vendo doctor`
 checks that `VENDO_API_KEY` is present and well formed locally; a bad or

--- a/docs-site/reference/cli.mdx
+++ b/docs-site/reference/cli.mdx
@@ -383,10 +383,11 @@ email-OTP fallback `vendo cloud login <email>` sends a 6-10 digit code,
 prompts for it, and stores the session at `~/.vendo/cloud-session.json`;
 `--token <jwt>` stores an access token instead.
 Other subcommands: `logout`, `whoami`, `orgs`, `keys` (`list`, `create`,
-`revoke`), `members`, `invite`, `usage`, and `billing`. Read
+`revoke`), `members`, `invite`, and `usage`. Read
 results print as JSON. There is no validate subcommand: key problems
 surface on the first real call, and `vendo cloud usage` reads the
-server-side metering from real traffic.
+server-side metering from real traffic. Billing lives in the
+[console](https://console.vendo.run) only.
 
 There is no deploy subcommand. With `VENDO_API_KEY` set, automations you
 build sync to Vendo Cloud automatically and run on Vendo's schedulers — see
@@ -396,8 +397,10 @@ Global options:
 
 - `--api-url <url>` overrides `VENDO_CLOUD_URL` (default `https://console.vendo.run`).
 
-Org-scoped commands take `--org <id>`; omit it only when your account has one
-organization. Run `vendo cloud help` for the full list. See
+`members` and `invite` take `--org <id>`; `keys` and `usage` take
+`--project <id>`. Either can be omitted when there is exactly one candidate —
+one organization on the account, one project in the organization. Run
+`vendo cloud help` for the full list. See
 [Vendo Cloud](/deploy/vendo-cloud) for setup, keys, and sharing.
 
 ## Telemetry opt-out

--- a/packages/vendo/src/cli/cloud/E2E.md
+++ b/packages/vendo/src/cli/cloud/E2E.md
@@ -34,7 +34,7 @@ for the current behavior.
 
 ## User principal (stored session or --token JWT)
 - `vendo cloud whoami --token <jwt>` → `{ orgs: [{id,name,role}] }`
-- `vendo cloud keys list --org <id> --token <jwt>` → `{ keys: [...] }`
+- `vendo cloud keys list --project <id> --token <jwt>` → `{ keys: [...] }`
 
 All shapes match the frozen flowlet wave-2 contracts; the 402 `cloud-required`
 envelope is surfaced as a friendly message. The auth/share/publish flows were

--- a/packages/vendo/src/cli/cloud/command.ts
+++ b/packages/vendo/src/cli/cloud/command.ts
@@ -63,6 +63,35 @@ export async function resolveOrgId(args: string[], context: CloudCommandContext)
   throw new Error("Pass --org <id> (it can only be omitted when your account has exactly one organization)");
 }
 
+interface ProjectRecord {
+  id?: unknown;
+  [key: string]: unknown;
+}
+
+function projectRecords(value: unknown): ProjectRecord[] {
+  if (Array.isArray(value)) return value as ProjectRecord[];
+  if (typeof value === "object" && value !== null && Array.isArray((value as { projects?: unknown }).projects)) {
+    return (value as { projects: ProjectRecord[] }).projects;
+  }
+  return [];
+}
+
+// Keys and usage live under the project since the spine v2 realignment; a
+// bare command walks org -> only project the same way resolveOrgId walks
+// account -> only org.
+export async function resolveProjectId(args: string[], context: CloudCommandContext): Promise<string> {
+  const explicit = option(args, "--project");
+  if (explicit) return explicit;
+  const orgId = await resolveOrgId(args, context);
+  const value = await context.fetcher(
+    `/api/v1/orgs/${encodeURIComponent(orgId)}/projects`,
+    userOptions(args, context),
+  );
+  const projects = projectRecords(value);
+  if (projects.length === 1 && typeof projects[0]?.id === "string") return projects[0].id;
+  throw new Error("Pass --project <id> (it can only be omitted when the organization has exactly one project)");
+}
+
 export async function runCommand(
   options: CloudCommandOptions,
   operation: (context: CloudCommandContext) => Promise<unknown>,

--- a/packages/vendo/src/cli/cloud/index.test.ts
+++ b/packages/vendo/src/cli/cloud/index.test.ts
@@ -13,10 +13,10 @@ describe("cloud command dispatch", () => {
     expect(await runCloud(["--help"], { output: messages.sink })).toBe(0);
     expect(messages.logs.join("\n")).toContain("login EMAIL");
     expect(messages.logs.join("\n")).not.toContain("validate");
-    // The retired machine trio is gone from the surface entirely, and so is
-    // the deployments read (its org-scoped endpoint died with spine v2 and
-    // the console Deployments page was removed 2026-07-21).
-    for (const removed of ["share", "publish", "pin-ship", "deployments"]) {
+    // The retired machine trio is gone from the surface entirely, and so are
+    // the deployments and billing reads (their org-scoped endpoints died with
+    // spine v2; billing has no API route — the console is its only surface).
+    for (const removed of ["share", "publish", "pin-ship", "deployments", "billing"]) {
       expect(messages.logs.join("\n")).not.toContain(removed);
     }
     expect(messages.logs.join("\n")).not.toMatch(/\bdeploy\b/);

--- a/packages/vendo/src/cli/cloud/index.ts
+++ b/packages/vendo/src/cli/cloud/index.ts
@@ -4,7 +4,7 @@ import { runDeviceLogin, type DeviceLoginOptions } from "./device-login.js";
 import { runKeys } from "./keys.js";
 import { runInvite, runMembers } from "./members.js";
 import { consoleOutput } from "../shared.js";
-import { runBilling, runOrgs, runUsage } from "./read.js";
+import { runOrgs, runUsage } from "./read.js";
 
 const CLOUD_HELP = `vendo cloud — Vendo Cloud API client
 
@@ -20,13 +20,12 @@ User commands:
   logout                               Delete the stored cloud session
   whoami [--token <jwt>]                List organizations for the current user
   orgs                                  List organizations
-  keys list --org <id>                  List API keys
-  keys create --org <id> --name <name> Create an API key
-  keys revoke --org <id> --id <keyId>  Revoke an API key
-  usage --org <id> [--days <days>]     Show usage (default 30 days)
+  keys list --project <id>              List API keys
+  keys create --project <id> --name <name>  Create an API key
+  keys revoke --project <id> --id <keyId>   Revoke an API key
+  usage --project <id> [--days <days>]  Show usage (default 30 days)
   members --org <id>                   List organization members
   invite --org <id> --email <email> --role <admin|member>
-  billing --org <id>                   Show billing status
 
 Global options:
   --api-url <url>  Override VENDO_CLOUD_URL / https://console.vendo.run
@@ -51,7 +50,6 @@ export async function runCloud(args: string[], options: RunCloudOptions = {}): P
   if (command === "usage") return runUsage(commandArgs, options);
   if (command === "members") return runMembers(commandArgs, options);
   if (command === "invite") return runInvite(commandArgs, options);
-  if (command === "billing") return runBilling(commandArgs, options);
   output.error(`Unknown cloud command: ${command}\n\n${CLOUD_HELP}`);
   return 1;
 }

--- a/packages/vendo/src/cli/cloud/keys.test.ts
+++ b/packages/vendo/src/cli/cloud/keys.test.ts
@@ -6,8 +6,8 @@ const sink = { log() {}, error() {} };
 describe("cloud keys", () => {
   it("creates a key with the console API shape", async () => {
     const fetcher = vi.fn().mockResolvedValue({ key: { plaintext: "vnd_secret" } });
-    expect(await runKeys(["create", "--org", "org_1", "--name", "CI"], { output: sink, fetcher })).toBe(0);
-    expect(fetcher).toHaveBeenCalledWith("/api/v1/orgs/org_1/keys", expect.objectContaining({
+    expect(await runKeys(["create", "--project", "proj_1", "--name", "CI"], { output: sink, fetcher })).toBe(0);
+    expect(fetcher).toHaveBeenCalledWith("/api/v1/projects/proj_1/keys", expect.objectContaining({
       auth: "user",
       method: "POST",
       body: { name: "CI" },
@@ -16,7 +16,16 @@ describe("cloud keys", () => {
 
   it("revokes the requested key", async () => {
     const fetcher = vi.fn().mockResolvedValue({});
-    expect(await runKeys(["revoke", "--org=org_1", "--id", "key/a"], { output: sink, fetcher })).toBe(0);
-    expect(fetcher).toHaveBeenCalledWith("/api/v1/orgs/org_1/keys/key%2Fa/revoke", expect.objectContaining({ method: "POST" }));
+    expect(await runKeys(["revoke", "--project=proj_1", "--id", "key/a"], { output: sink, fetcher })).toBe(0);
+    expect(fetcher).toHaveBeenCalledWith("/api/v1/projects/proj_1/keys/key%2Fa/revoke", expect.objectContaining({ method: "POST" }));
+  });
+
+  it("lists keys resolving the project through the org", async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce({ projects: [{ id: "proj_only" }] })
+      .mockResolvedValueOnce({ keys: [] });
+    expect(await runKeys(["list", "--org", "org_1"], { output: sink, fetcher })).toBe(0);
+    expect(fetcher.mock.calls[0]?.[0]).toBe("/api/v1/orgs/org_1/projects");
+    expect(fetcher.mock.calls[1]?.[0]).toBe("/api/v1/projects/proj_only/keys");
   });
 });

--- a/packages/vendo/src/cli/cloud/keys.ts
+++ b/packages/vendo/src/cli/cloud/keys.ts
@@ -1,6 +1,6 @@
 import { option } from "./args.js";
 import {
-  resolveOrgId,
+  resolveProjectId,
   runCommand,
   userOptions,
   type CloudCommandOptions,
@@ -10,10 +10,10 @@ export function runKeys(args: string[], options: CloudCommandOptions = {}): Prom
   return runCommand(options, async (context) => {
     const [action] = args;
     if (!action || !["list", "create", "revoke"].includes(action)) {
-      throw new Error("Usage: vendo cloud keys <list|create|revoke> --org <id>");
+      throw new Error("Usage: vendo cloud keys <list|create|revoke> --project <id>");
     }
-    const orgId = await resolveOrgId(args, context);
-    const root = `/api/v1/orgs/${encodeURIComponent(orgId)}/keys`;
+    const projectId = await resolveProjectId(args, context);
+    const root = `/api/v1/projects/${encodeURIComponent(projectId)}/keys`;
     if (action === "list") return context.fetcher(root, userOptions(args, context));
     if (action === "create") {
       const name = option(args, "--name");

--- a/packages/vendo/src/cli/cloud/read.test.ts
+++ b/packages/vendo/src/cli/cloud/read.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { runBilling, runOrgs, runUsage } from "./read.js";
+import { runOrgs, runUsage } from "./read.js";
 
 function output() {
   const logs: string[] = [];
@@ -16,26 +16,35 @@ describe("cloud organization reads", () => {
     expect(JSON.parse(messages.logs[0]!)).toEqual({ orgs: [{ id: "org_1" }] });
   });
 
-  it("uses an explicit organization for billing", async () => {
+  it("uses an explicit project for usage and forwards days", async () => {
     const messages = output();
-    const fetcher = vi.fn().mockResolvedValue({ plan: "free" });
-    expect(await runBilling(["--org", "org/a"], { output: messages.sink, fetcher })).toBe(0);
-    expect(fetcher).toHaveBeenCalledWith("/api/v1/orgs/org%2Fa/billing", expect.any(Object));
+    const fetcher = vi.fn().mockResolvedValue({ days: [] });
+    expect(await runUsage(["--project", "proj/a", "--days", "7"], { output: messages.sink, fetcher })).toBe(0);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher).toHaveBeenCalledWith(
+      "/api/v1/projects/proj%2Fa/usage?days=7",
+      expect.objectContaining({ auth: "user" }),
+    );
   });
 
-  it("defaults to the only organization and forwards usage days", async () => {
+  it("defaults to the only project of the only organization", async () => {
     const messages = output();
     const fetcher = vi.fn()
       .mockResolvedValueOnce({ orgs: [{ id: "org_only" }] })
-      .mockResolvedValueOnce({ days: 7, totals: [] });
-    expect(await runUsage(["--days", "7"], { output: messages.sink, fetcher })).toBe(0);
-    expect(fetcher.mock.calls[1]?.[0]).toBe("/api/v1/orgs/org_only/usage?days=7");
+      .mockResolvedValueOnce({ projects: [{ id: "proj_only" }] })
+      .mockResolvedValueOnce({ days: [] });
+    expect(await runUsage([], { output: messages.sink, fetcher })).toBe(0);
+    expect(fetcher.mock.calls[0]?.[0]).toBe("/api/v1/orgs");
+    expect(fetcher.mock.calls[1]?.[0]).toBe("/api/v1/orgs/org_only/projects");
+    expect(fetcher.mock.calls[2]?.[0]).toBe("/api/v1/projects/proj_only/usage?days=30");
   });
 
-  it("returns a clear error when an organization cannot be inferred", async () => {
+  it("returns a clear error when a project cannot be inferred", async () => {
     const messages = output();
-    const fetcher = vi.fn().mockResolvedValue({ orgs: [{ id: "one" }, { id: "two" }] });
-    expect(await runBilling([], { output: messages.sink, fetcher })).toBe(1);
-    expect(messages.errors.join("\n")).toContain("--org <id>");
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce({ orgs: [{ id: "org_only" }] })
+      .mockResolvedValueOnce({ projects: [{ id: "one" }, { id: "two" }] });
+    expect(await runUsage([], { output: messages.sink, fetcher })).toBe(1);
+    expect(messages.errors.join("\n")).toContain("--project <id>");
   });
 });

--- a/packages/vendo/src/cli/cloud/read.ts
+++ b/packages/vendo/src/cli/cloud/read.ts
@@ -1,6 +1,6 @@
 import { option } from "./args.js";
 import {
-  resolveOrgId,
+  resolveProjectId,
   runCommand,
   userOptions,
   type CloudCommandOptions,
@@ -10,26 +10,13 @@ export function runOrgs(args: string[], options: CloudCommandOptions = {}): Prom
   return runCommand(options, (context) => context.fetcher("/api/v1/orgs", userOptions(args, context)));
 }
 
-function orgRead(
-  args: string[],
-  options: CloudCommandOptions,
-  resource: string,
-  query = "",
-): Promise<number> {
+export function runUsage(args: string[], options: CloudCommandOptions = {}): Promise<number> {
+  const days = option(args, "--days") ?? "30";
   return runCommand(options, async (context) => {
-    const orgId = await resolveOrgId(args, context);
+    const projectId = await resolveProjectId(args, context);
     return context.fetcher(
-      `/api/v1/orgs/${encodeURIComponent(orgId)}/${resource}${query}`,
+      `/api/v1/projects/${encodeURIComponent(projectId)}/usage?days=${encodeURIComponent(days)}`,
       userOptions(args, context),
     );
   });
-}
-
-export function runUsage(args: string[], options: CloudCommandOptions = {}): Promise<number> {
-  const days = option(args, "--days") ?? "30";
-  return orgRead(args, options, "usage", `?days=${encodeURIComponent(days)}`);
-}
-
-export function runBilling(args: string[], options: CloudCommandOptions = {}): Promise<number> {
-  return orgRead(args, options, "billing");
 }


### PR DESCRIPTION
Closes out the dead-reads drift found while removing `vendo cloud deployments` (#473): spine v2 moved session-authed resource reads under the project, but the CLI kept calling the deleted org-scoped routes — `vendo cloud keys`, `usage`, and `billing` have all 404ed since the cutover.

## What

- **`keys` (`list`/`create`/`revoke`) and `usage` now call the project-scoped routes** (`/api/v1/projects/{id}/keys[...]`, `/api/v1/projects/{id}/usage?days=N`) and take `--project <id>`. When omitted, the project is inferred by walking account → only org → only project (`resolveProjectId`, mirroring the existing `--org` inference); ambiguity errors with a clear `--project <id>` message.
- **`billing` retired** — no API route survived spine v2; the console at /org/billing is its only surface. Unknown-subcommand now, same pattern as `validate`/`deployments`.
- Docs: `reference/cli.mdx` and `deploy/vendo-cloud.mdx` examples/scoping notes updated; `cloud/E2E.md` updated.

## Verification

TDD (new tests watched fail first). `@vendoai/vendo` 936 passed / 13 pre-existing skips, `tsc --noEmit` clean, tree-wide grep shows no remaining `runBilling` / org-scoped keys/usage references in source or docs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repointed `vendo cloud keys` and `usage` to project-scoped APIs with `--project <id>` and clear inference; retired `billing` since spine v2 has no API. Fixes 404s from org-scoped routes and aligns the CLI with the console.

- **Bug Fixes**
  - `keys list/create/revoke` and `usage` now call `/api/v1/projects/{id}/...`.
  - Added `--project <id>`; when omitted, we resolve org → only project or show a clear error. Only keys/usage moved; `members`/`invite` stay org-scoped.
  - Removed the `billing` subcommand; billing lives in the console.

- **Migration**
  - Replace `--org` with `--project` for `vendo cloud keys` and `vendo cloud usage`.
  - Use the console for billing.

<sup>Written for commit 013324de2750358406ecc30c4f3b4f758a733a7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

