### PR TITLE
fixes from the live install E2E: doctor reads .env.local, eval registry serves bin, Cloud-key provider note

### DIFF
--- a/corpus/harness/src/install-eval/registry.test.ts
+++ b/corpus/harness/src/install-eval/registry.test.ts
@@ -28,6 +28,7 @@ const vendoManifest = {
   name: "@vendoai/vendo",
   version: "0.3.0",
   dependencies: { "@vendoai/core": "0.3.0" },
+  bin: { vendo: "bin/vendo.mjs" },
 };
 
 let registry: LocalNpmRegistry | undefined;
@@ -38,9 +39,14 @@ afterEach(async () => {
 });
 
 describe("readTarballManifest", () => {
-  it("reads name, version, and pack-rewritten dependencies", () => {
+  it("reads name, version, pack-rewritten dependencies, and bin", () => {
     const manifest = readTarballManifest(makeTarball(vendoManifest));
-    expect(manifest).toEqual({ name: "@vendoai/vendo", version: "0.3.0", dependencies: { "@vendoai/core": "0.3.0" } });
+    expect(manifest).toEqual({
+      name: "@vendoai/vendo",
+      version: "0.3.0",
+      dependencies: { "@vendoai/core": "0.3.0" },
+      bin: { vendo: "bin/vendo.mjs" },
+    });
   });
 });
 
@@ -58,10 +64,14 @@ describe("local npm registry", () => {
     expect(packumentResponse.status).toBe(200);
     const packument = await packumentResponse.json() as {
       "dist-tags": { latest: string };
-      versions: Record<string, { dependencies: Record<string, string>; dist: { tarball: string; integrity: string } }>;
+      versions: Record<string, { dependencies: Record<string, string>; bin?: Record<string, string>; dist: { tarball: string; integrity: string } }>;
     };
     expect(packument["dist-tags"].latest).toBe("0.3.0");
     expect(packument.versions["0.3.0"]?.dependencies).toEqual({ "@vendoai/core": "0.3.0" });
+    // npm links CLI bins from the packument's version metadata, not the
+    // extracted package.json — omitting bin here means no node_modules/.bin
+    // symlink and a vendo-cli-missing doctor failure (install-E2E finding).
+    expect(packument.versions["0.3.0"]?.bin).toEqual({ vendo: "bin/vendo.mjs" });
 
     // The advertised tarball downloads from this server.
     const tarballResponse = await fetch(packument.versions["0.3.0"]!.dist.tarball);

--- a/corpus/harness/src/install-eval/registry.ts
+++ b/corpus/harness/src/install-eval/registry.ts
@@ -21,12 +21,15 @@ export interface LocalRegistryPackage {
   version: string;
   tarballFile: string;
   dependencies: Record<string, string>;
+  /** npm links CLI bins from the packument version metadata, not the
+   * extracted package.json — omit this and installs get no .bin symlink. */
+  bin?: string | Record<string, string>;
 }
 
 /** Read `package/package.json` out of an npm tarball (gzip + ustar). The
  * packed manifest is the truth: pnpm pack has already rewritten workspace:*
  * specs into real versions there. */
-export function readTarballManifest(tarball: Buffer): { name: string; version: string; dependencies: Record<string, string> } {
+export function readTarballManifest(tarball: Buffer): { name: string; version: string; dependencies: Record<string, string>; bin?: string | Record<string, string> } {
   const tar = gunzipSync(tarball);
   for (let offset = 0; offset + 512 <= tar.length; ) {
     const header = tar.subarray(offset, offset + 512);
@@ -38,11 +41,12 @@ export function readTarballManifest(tarball: Buffer): { name: string; version: s
         name?: string;
         version?: string;
         dependencies?: Record<string, string>;
+        bin?: string | Record<string, string>;
       };
       if (typeof manifest.name !== "string" || typeof manifest.version !== "string") {
         throw new Error("tarball package/package.json lacks name/version");
       }
-      return { name: manifest.name, version: manifest.version, dependencies: manifest.dependencies ?? {} };
+      return { name: manifest.name, version: manifest.version, dependencies: manifest.dependencies ?? {}, bin: manifest.bin };
     }
     offset += 512 + Math.ceil(size / 512) * 512;
   }
@@ -59,6 +63,7 @@ export async function indexLocalTarballs(tarballDir: string): Promise<Map<string
       version: manifest.version,
       tarballFile: entry,
       dependencies: manifest.dependencies,
+      bin: manifest.bin,
     });
   }
   return packages;
@@ -85,6 +90,7 @@ function packumentFor(pkg: LocalRegistryPackage, registryUrl: string, tarball: B
         name: pkg.name,
         version: pkg.version,
         dependencies: pkg.dependencies,
+        bin: pkg.bin,
         dist: {
           tarball: `${registryUrl}/-/local/${pkg.tarballFile}`,
           shasum: createHash("sha1").update(tarball).digest("hex"),

--- a/docs-site/connect/dev-mode.mdx
+++ b/docs-site/connect/dev-mode.mdx
@@ -28,10 +28,14 @@ resolves. Explicit keys always beat implicit ones.
   <Step title="Vendo Cloud key">
     `VENDO_API_KEY` delegates to the Vendo Cloud model gateway (Anthropic
     Messages wire, served through the stock `@ai-sdk/anthropic` provider).
-    The gateway serves curated model aliases: `vendo-default` (the default),
-    `vendo-fast`, and `vendo-strong`. Pick one with `VENDO_CLOUD_MODEL`;
-    anything else is remapped to `vendo-default` server-side. No key on hand?
-    `npx vendo login` mints a free metered dev key.
+    Because the gateway rides that provider locally, `ai@^6` and
+    `@ai-sdk/anthropic@^3` must be installed in your app even when the Cloud
+    key is your only credential — without them this rung fails the same way
+    a missing provider key does. The gateway serves curated model aliases:
+    `vendo-default` (the default), `vendo-fast`, and `vendo-strong`. Pick
+    one with `VENDO_CLOUD_MODEL`; anything else is remapped to
+    `vendo-default` server-side. No key on hand? `npx vendo login` mints a
+    free metered dev key.
   </Step>
   <Step title="None">
     No credential resolves. The wire returns a generic error and the server

--- a/packages/vendo/src/cli/doctor.test.ts
+++ b/packages/vendo/src/cli/doctor.test.ts
@@ -902,6 +902,28 @@ describe("readDotEnvFallback", () => {
     expect(Object.keys(env)).not.toContain("BROKEN LINE");
   });
 
+  it("strips inline comments from unquoted values, same grammar as envLocalValueSync", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-doctor-envc-"));
+    cleanup.push(() => rm(root, { recursive: true, force: true }));
+    await writeFile(join(root, ".env.local"), "VENDO_API_KEY=vnd_abc # dev key\nQUOTED=\"kept # inside\"\n");
+    const { readDotEnvFallback } = await import("./doctor.js");
+    const env = await readDotEnvFallback(root);
+    expect(env["VENDO_API_KEY"]).toBe("vnd_abc");
+    expect(env["QUOTED"]).toBe("kept # inside");
+  });
+
+  it("blank process values yield to concrete dotenv values at the merge", async () => {
+    const { mergeEnvOverDotEnv } = await import("./doctor.js");
+    const merged = mergeEnvOverDotEnv(
+      { VENDO_API_KEY: "vnd_real", ONLY_FILE: "x" },
+      { VENDO_API_KEY: "  ", SHELL_WINS: "yes", ONLY_PROC: "" },
+    );
+    expect(merged["VENDO_API_KEY"]).toBe("vnd_real");
+    expect(merged["ONLY_FILE"]).toBe("x");
+    expect(merged["SHELL_WINS"]).toBe("yes");
+    expect(merged["ONLY_PROC"]).toBe("");
+  });
+
   it("returns an empty object when no env files exist", async () => {
     const root = await mkdtemp(join(tmpdir(), "vendo-doctor-noenv-"));
     cleanup.push(() => rm(root, { recursive: true, force: true }));

--- a/packages/vendo/src/cli/doctor.test.ts
+++ b/packages/vendo/src/cli/doctor.test.ts
@@ -882,3 +882,30 @@ function discoveryFetch(challenge?: string): typeof fetch {
     throw new Error(`Unexpected URL: ${url}`);
   }) as typeof fetch;
 }
+
+describe("readDotEnvFallback", () => {
+  it("reads .env.local over .env, parses quotes/comments, never overrides process env at the merge site", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-doctor-env-"));
+    cleanup.push(() => rm(root, { recursive: true, force: true }));
+    await writeFile(join(root, ".env"), "SHARED=from-env\nENV_ONLY=plain\n");
+    await writeFile(
+      join(root, ".env.local"),
+      "# comment\nSHARED=from-local\nVENDO_API_KEY=\"vnd_0123\"\nexport EXPORTED=yes\nEMPTY=\nBROKEN LINE\n",
+    );
+    const { readDotEnvFallback } = await import("./doctor.js");
+    const env = await readDotEnvFallback(root);
+    expect(env["SHARED"]).toBe("from-local");
+    expect(env["ENV_ONLY"]).toBe("plain");
+    expect(env["VENDO_API_KEY"]).toBe("vnd_0123");
+    expect(env["EXPORTED"]).toBe("yes");
+    expect(env["EMPTY"]).toBe("");
+    expect(Object.keys(env)).not.toContain("BROKEN LINE");
+  });
+
+  it("returns an empty object when no env files exist", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-doctor-noenv-"));
+    cleanup.push(() => rm(root, { recursive: true, force: true }));
+    const { readDotEnvFallback } = await import("./doctor.js");
+    expect(await readDotEnvFallback(root)).toEqual({});
+  });
+});

--- a/packages/vendo/src/cli/doctor.ts
+++ b/packages/vendo/src/cli/doctor.ts
@@ -89,13 +89,39 @@ async function probeBody(response: Response): Promise<DoctorProbeBody> {
   }
 }
 
+/** Doctor runs standalone, so unlike the dev server it gets no framework
+ *  dotenv loading — without this, `VENDO_API_KEY` sitting in `.env.local`
+ *  is invisible to the cloud/live-turn checks and users must export it by
+ *  hand. Reads `.env` then `.env.local` (local wins); real process env wins
+ *  over both at the merge site. Minimal KEY=VALUE parser: `export ` prefix,
+ *  matching single/double quotes, and `#` comment lines. */
+export async function readDotEnvFallback(root: string): Promise<Record<string, string>> {
+  const env: Record<string, string> = {};
+  for (const file of [".env", ".env.local"]) {
+    const source = await readOptional(join(root, file));
+    if (source === null) continue;
+    for (const rawLine of source.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (line === "" || line.startsWith("#")) continue;
+      const match = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
+      if (!match) continue;
+      let value = match[2]!.trim();
+      if (value.length >= 2 && ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'")))) {
+        value = value.slice(1, -1);
+      }
+      env[match[1]!] = value;
+    }
+  }
+  return env;
+}
+
 /** 09-vendo §5 / block-actions A — wiring checks plus live composition,
     present-credential, and actAs mint+verify round-trips. */
 export async function runDoctor(options: DoctorOptions): Promise<number> {
   const root = resolve(options.targetDir);
   const output = options.output ?? consoleOutput;
   const json = options.json === true;
-  const env = options.env ?? process.env;
+  const env = options.env ?? { ...(await readDotEnvFallback(root)), ...process.env };
   const telemetry = telemetryFor(options, output, root);
   let failures = 0;
   let warnings = 0;

--- a/packages/vendo/src/cli/doctor.ts
+++ b/packages/vendo/src/cli/doctor.ts
@@ -14,7 +14,7 @@ import { EJECT_MANIFEST_FILE, type EjectedManifest } from "./eject.js";
 import { detectFramework, detectVendoWiring } from "./framework.js";
 import { walk } from "./theme/walk.js";
 import { remoteUrls, sameUrl, validateRegistryServer } from "./mcp/registry.js";
-import { askYesNo, CLI_VERSION, consoleOutput, exists, readOptional, toolingTelemetry, type Output } from "./shared.js";
+import { askYesNo, CLI_VERSION, consoleOutput, exists, normalizeDotEnvValue, readOptional, toolingTelemetry, type Output } from "./shared.js";
 
 export interface DoctorOptions {
   targetDir: string;
@@ -105,14 +105,25 @@ export async function readDotEnvFallback(root: string): Promise<Record<string, s
       if (line === "" || line.startsWith("#")) continue;
       const match = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
       if (!match) continue;
-      let value = match[2]!.trim();
-      if (value.length >= 2 && ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'")))) {
-        value = value.slice(1, -1);
-      }
-      env[match[1]!] = value;
+      env[match[1]!] = normalizeDotEnvValue(match[2]!.trim());
     }
   }
   return env;
+}
+
+/** Process env wins over the dotenv fallback — except that a blank process
+ *  value yields to a concrete dotenv one, matching toolingTelemetry's
+ *  VENDO_API_KEY precedence (an exported empty `VENDO_API_KEY=` must not
+ *  mask the real key in `.env.local`). */
+export function mergeEnvOverDotEnv(
+  fallback: Record<string, string>,
+  processEnv: NodeJS.ProcessEnv,
+): Record<string, string | undefined> {
+  const merged: Record<string, string | undefined> = { ...fallback, ...processEnv };
+  for (const [key, value] of Object.entries(processEnv)) {
+    if ((value ?? "").trim() === "" && fallback[key] !== undefined) merged[key] = fallback[key];
+  }
+  return merged;
 }
 
 /** 09-vendo §5 / block-actions A — wiring checks plus live composition,
@@ -121,7 +132,7 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
   const root = resolve(options.targetDir);
   const output = options.output ?? consoleOutput;
   const json = options.json === true;
-  const env = options.env ?? { ...(await readDotEnvFallback(root)), ...process.env };
+  const env = options.env ?? mergeEnvOverDotEnv(await readDotEnvFallback(root), process.env);
   const telemetry = telemetryFor(options, output, root);
   let failures = 0;
   let warnings = 0;

--- a/packages/vendo/src/cli/shared.ts
+++ b/packages/vendo/src/cli/shared.ts
@@ -78,12 +78,19 @@ export function envLocalValueSync(root: string, name: string): string | null {
     const match = raw.match(new RegExp(`^\\s*${name}\\s*=\\s*(.+?)\\s*$`, "m"));
     const value = match?.[1];
     if (value === undefined) return null;
-    const quoted = value.match(/^(["'])(.*)\1$/);
-    if (quoted?.[2] !== undefined) return quoted[2];
-    return value.replace(/\s+#.*$/, "").trimEnd();
+    return normalizeDotEnvValue(value);
   } catch {
     return null;
   }
+}
+
+/** One value grammar for every CLI dotenv reader (envLocalValueSync, doctor's
+ * readDotEnvFallback): matching surrounding quotes are stripped; unquoted
+ * values lose their ` #…` inline comment. */
+export function normalizeDotEnvValue(value: string): string {
+  const quoted = value.match(/^(["'])(.*)\1$/);
+  if (quoted?.[2] !== undefined) return quoted[2];
+  return value.replace(/\s+#.*$/, "").trimEnd();
 }
 
 export function toolingTelemetry(options: TelemetryOptions & {


### PR DESCRIPTION
Three small fixes from today's live two-path install E2E (real headless agents driving the canonical prompts; findings memo in the vendo-web session):

1. **`vendo doctor` now reads `.env.local`/`.env` from the target dir** (process env still wins; explicit `options.env` untouched for tests). Standalone doctor runs previously saw no `VENDO_API_KEY` even though the dev server did — the E2E agent had to `export` it by hand. New `readDotEnvFallback` + tests (37/37 green).

2. **install-eval local registry: packument now carries `bin`.** npm links CLI bins from packument version metadata, not the extracted package.json — omitting it meant every eval install got no `node_modules/.bin/vendo`, which is the real cause of express-host's `vendo-cli-missing` failures. Threaded through `readTarballManifest` → `LocalRegistryPackage` → `packumentFor`, with tests (48/48 install-eval suite green).

3. **dev-mode docs:** the Cloud-key rung needs `ai@^6` + `@ai-sdk/anthropic@^3` installed locally even when `VENDO_API_KEY` is the only credential — previously only stated on the provider-key path; the E2E's doctor-green required discovering this.

Not addressed here (issues to follow): ai@7 hard incompatibility with Vendo's internal loop; approved-claim loss when the login poller dies; the eval's single-shot turn vs. the mandated ask-before-keys gate.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix three install issues from the live E2E: standalone `vendo doctor` now reads `.env.local`/`.env` with correct precedence and parsing, the local eval registry exposes `bin` so npm links the `vendo` CLI, and dev-mode docs clarify required local packages for the Cloud key path.

- **Bug Fixes**
  - `vendo doctor` loads `.env.local` over `.env` from the target dir with consistent dotenv parsing; process env still wins, but blank process values yield to values from dotenv.
  - Local registry packument now includes `bin` from the tarball manifest so installs get `node_modules/.bin/vendo`.

- **Migration**
  - For the Cloud key path, install `ai@^6` and `@ai-sdk/anthropic@^3` in your app.

<sup>Written for commit dbd673c13cef600a5bb2b415ef4a31656b6e043a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

