### PR TITLE
doctor: fail fast on ai@7 hosts — E-DEP-001 + verify anchor

### DIFF
--- a/docs-site/agents/verify.mdx
+++ b/docs-site/agents/verify.mdx
@@ -119,6 +119,28 @@ control was deleted, so `.vendo/data/` contents could get committed.
 !.gitignore
 ```
 
+## Host dependencies
+
+### E-DEP-001 {#E-DEP-001}
+
+**Symptom:** The installed `ai` package is major version 7 or newer; the
+message names the exact version found.
+
+**Cause:** `@vendoai/vendo` drives the host's `ai` package with AI SDK v6
+calls (peer range `ai >=6 <7`), but npm installs the peer conflict without
+failing. Every static check passes on such a host — and then every internal
+Vendo turn throws `AI_InvalidPromptError`, because ai@7 removed system-role
+messages from the messages array.
+
+**Fix:** Downgrade to the supported majors:
+
+```bash
+npm install ai@^6 @ai-sdk/anthropic@^3 @ai-sdk/react@^3
+```
+
+ai@7 support is tracked in
+[runvendo/vendo#478](https://github.com/runvendo/vendo/issues/478).
+
 ## Ejected UI
 
 ### E-UI-001 {#E-UI-001}

--- a/packages/vendo/src/cli/dep-versions.ts
+++ b/packages/vendo/src/cli/dep-versions.ts
@@ -45,6 +45,23 @@ function bareVersion(range: unknown): string | undefined {
 }
 
 /**
+ * The HOST's installed `ai` version (#478 short-term): @vendoai/vendo speaks
+ * AI SDK v6 to the host's `ai` package (peer `ai >=6 <7`), but npm installs
+ * the peer conflict anyway — so the version must be read from the TARGET
+ * dir's node_modules, never the CLI's own dependency tree. Non-throwing:
+ * an absent install or malformed metadata returns null (the missing-
+ * dependency story belongs to the wiring checks, not this reader).
+ */
+export async function installedAiVersion(root: string): Promise<string | null> {
+  try {
+    const manifest = JSON.parse(await readFile(join(root, "node_modules", "ai", "package.json"), "utf8")) as { version?: unknown };
+    return typeof manifest.version === "string" ? manifest.version : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Read the host project's dependency versions (deps + devDeps) for telemetry.
  * Non-throwing: a missing or malformed package.json returns {}.
  */

--- a/packages/vendo/src/cli/doctor-codes.test.ts
+++ b/packages/vendo/src/cli/doctor-codes.test.ts
@@ -28,6 +28,7 @@ describe("doctor error-code registry", () => {
         "E-CFG-001": "a required .vendo/ config file is missing",
         "E-CFG-002": ".vendo/data/.gitignore is missing",
         "E-CLOUD-001": "VENDO_API_KEY is set but not usable",
+        "E-DEP-001": "the installed ai package is a major version @vendoai/vendo does not support",
         "E-DEV-001": "the dev server could not be started for the probe",
         "E-LIVE-001": "/status returned an invalid composition response",
         "E-LIVE-002": "/status is unreachable",

--- a/packages/vendo/src/cli/doctor-codes.ts
+++ b/packages/vendo/src/cli/doctor-codes.ts
@@ -4,9 +4,9 @@ import { CLI_VERSION } from "./shared.js";
  * Agent-install DX (design 2026-07-19 §CLI-3) — the doctor error-code
  * registry. Every failure mode doctor can report (static and live) has one
  * stable, grep-able code here: E-<AREA>-<NNN>, where the area groups related
- * checks (WIRE wiring, CFG config files, UI eject drift, DEV probe server,
- * LIVE composition/status, AUTH credentials, MCP door, TURN model turn,
- * CLOUD key). Codes are append-only: never renumber or reuse one — the
+ * checks (WIRE wiring, CFG config files, DEP host dependency versions, UI
+ * eject drift, DEV probe server, LIVE composition/status, AUTH credentials,
+ * MCP door, TURN model turn, CLOUD key). Codes are append-only: never renumber or reuse one — the
  * verify page anchors (`fix_ref`) and agents' remediation notes depend on
  * them staying put.
  *
@@ -21,6 +21,7 @@ export const DOCTOR_ERROR_CODES = {
   "E-WIRE-005": "the @vendoai/vendo (or vendoai alias) dependency is not declared",
   "E-CFG-001": "a required .vendo/ config file is missing",
   "E-CFG-002": ".vendo/data/.gitignore is missing",
+  "E-DEP-001": "the installed ai package is a major version @vendoai/vendo does not support",
   "E-UI-001": "an ejected surface predates the installed @vendoai/ui",
   "E-DEV-001": "the dev server could not be started for the probe",
   "E-LIVE-001": "/status returned an invalid composition response",

--- a/packages/vendo/src/cli/doctor.test.ts
+++ b/packages/vendo/src/cli/doctor.test.ts
@@ -839,6 +839,56 @@ describe("vendo doctor error codes + fix_refs", () => {
     }
   });
 
+  // #478 short-term — npm installs the ai@7 peer conflict without failing, the
+  // static checks all pass, and then every internal turn throws
+  // AI_InvalidPromptError (v7 removed system-role messages). Doctor reads the
+  // HOST's installed `ai` and fails fast on an unsupported major.
+  it("fails fast with E-DEP-001 when the host has ai@7 installed", async () => {
+    const root = await healthy();
+    await mkdir(join(root, "node_modules", "ai"), { recursive: true });
+    await writeFile(join(root, "node_modules", "ai", "package.json"), JSON.stringify({ name: "ai", version: "7.0.2" }));
+    const { exit, report } = await jsonChecks({
+      targetDir: root,
+      fetchImpl: successfulProbeFetch(),
+    });
+    expect(exit).toBe(1);
+    const check = report.checks.find((entry) => entry.id === "deps/ai-sdk-major");
+    expect(check).toMatchObject({
+      status: "broken",
+      error_code: "E-DEP-001",
+      fix_ref: doctorFixRef("E-DEP-001"),
+    });
+    expect(check?.message).toContain("ai@7.0.2");
+    expect(check?.message).toContain("ai@6");
+    expect(check?.message).toContain("npm install ai@^6 @ai-sdk/anthropic@^3 @ai-sdk/react@^3");
+    expect(check?.message).toContain("github.com/runvendo/vendo/issues/478");
+  });
+
+  it("passes the ai major check on an ai@6 host", async () => {
+    const root = await healthy();
+    await mkdir(join(root, "node_modules", "ai"), { recursive: true });
+    await writeFile(join(root, "node_modules", "ai", "package.json"), JSON.stringify({ name: "ai", version: "6.0.28" }));
+    const { exit, report } = await jsonChecks({
+      targetDir: root,
+      fetchImpl: successfulProbeFetch(),
+    });
+    expect(exit).toBe(0);
+    const check = report.checks.find((entry) => entry.id === "deps/ai-sdk-major");
+    expect(check).toMatchObject({ status: "ok" });
+    expect(check?.message).toContain("ai@6.0.28");
+  });
+
+  it("skips the ai major check silently when ai is not installed", async () => {
+    // The missing-dependency story belongs to the wiring checks and the live
+    // turn — an absent node_modules/ai must not break (or even mention) this.
+    const { exit, report } = await jsonChecks({
+      targetDir: await healthy(),
+      fetchImpl: successfulProbeFetch(),
+    });
+    expect(exit).toBe(0);
+    expect(report.checks.some((entry) => entry.id === "deps/ai-sdk-major")).toBe(false);
+  });
+
   it("exits nonzero while any single check fails", async () => {
     const root = await healthy();
     await rm(join(root, ".vendo", "brief.md"));

--- a/packages/vendo/src/cli/doctor.ts
+++ b/packages/vendo/src/cli/doctor.ts
@@ -9,6 +9,7 @@ import {
   type CloudDoctorResult,
   type LiveTurnResult,
 } from "./doctor-live.js";
+import { installedAiVersion } from "./dep-versions.js";
 import { doctorFixRef, type DoctorErrorCode } from "./doctor-codes.js";
 import { EJECT_MANIFEST_FILE, type EjectedManifest } from "./eject.js";
 import { detectFramework, detectVendoWiring } from "./framework.js";
@@ -139,6 +140,20 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
 
   if (await hasDependency(root)) pass("wiring/dependency", "@vendoai/vendo dependency is declared");
   else fail("wiring/dependency", "E-WIRE-005", "@vendoai/vendo (or vendoai alias) is not declared");
+
+  // #478 short-term — @vendoai/vendo speaks AI SDK v6 to the host's `ai`
+  // package (peer `ai >=6 <7`), but npm installs the peer conflict anyway:
+  // the static checks all pass and every internal turn then throws
+  // AI_InvalidPromptError (v7 removed system-role messages). Fail fast on the
+  // installed major. An absent install is the wiring/turn checks' story, and
+  // pre-v6 installs predate the peer contract — both skip silently.
+  const aiVersion = await installedAiVersion(root);
+  const aiMajor = aiVersion === null ? Number.NaN : Number.parseInt(aiVersion, 10);
+  if (aiMajor >= 7) {
+    fail("deps/ai-sdk-major", "E-DEP-001", `installed ai@${aiVersion} is unsupported — Vendo supports ai@6; downgrade (npm install ai@^6 @ai-sdk/anthropic@^3 @ai-sdk/react@^3) or track github.com/runvendo/vendo/issues/478`);
+  } else if (aiMajor === 6) {
+    pass("deps/ai-sdk-major", `installed ai@${aiVersion} is the supported AI SDK major (v6)`);
+  }
 
   for (const file of ["tools.json", "overrides.json", "policy.json", "brief.md", "theme.json"]) {
     if (await exists(join(root, ".vendo", file))) pass(`config/${file}`, `.vendo/${file}`);

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -12,7 +12,7 @@ import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import type { VendoTheme } from "@vendoai/core";
 import { scrubErrorDetail, type Telemetry } from "@vendoai/telemetry";
-import { detectDepVersions } from "./dep-versions.js";
+import { detectDepVersions, installedAiVersion } from "./dep-versions.js";
 import { AUTH_MD_URL, runCloudStep, upsertEnvLocal, type CloudStepOptions } from "./cloud-init.js";
 import { APPLY_COMMAND, composeDelegatedInstructions, EXTRACTION_DRAFT_JSON_SCHEMA } from "./extract/delegate.js";
 import { askYesNo, runAiExtraction, type AiExtractionOptions } from "./extract/extraction.js";
@@ -1105,6 +1105,14 @@ export async function runInit(options: InitOptions): Promise<number> {
     // key exists (the full emphasized block already ran up top; no repeat).
     if (credential.rung === "none") {
       output.log("No model key yet: set ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_GENERATIVE_AI_API_KEY in .env.local, or run `vendo login` for a free dev key.");
+    }
+
+    // #478 short-term — npm installs the ai@7 peer conflict without failing
+    // and every internal turn then throws AI_InvalidPromptError; warn in the
+    // end-of-run summary instead of waiting for doctor to fail (E-DEP-001).
+    const aiVersion = await installedAiVersion(root);
+    if (aiVersion !== null && Number.parseInt(aiVersion, 10) >= 7) {
+      output.error(`warning: installed ai@${aiVersion} is unsupported — Vendo supports ai@6; downgrade (npm install ai@^6 @ai-sdk/anthropic@^3 @ai-sdk/react@^3) or track github.com/runvendo/vendo/issues/478`);
     }
 
     // Done — the one paste that is the user's, then their own dev server.


### PR DESCRIPTION
Closes #478 (short-term). New `deps/ai-sdk-major` doctor check reads the HOST's installed `ai` major: >=7 fails with new code E-DEP-001 (downgrade command + issue link), ==6 passes, absent/pre-v6 skips (covered by other checks / predates the peer contract). Verify page gains the anchored E-DEP-001 section (docs-anchor gate test green); init prints the same warning at its end-of-run summary. Found by the live install E2E: an ai@7 host wires green through every static check, then throws AI_InvalidPromptError on the first live turn. Tests: doctor 38/38, doctor-codes 4+1, init 73/73, tsc clean. Full v7 compat remains tracked in #478.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail fast on hosts with `ai` v7 by adding a new doctor check (E-DEP-001) and a matching verify-page section; `init` now warns at the end if `ai@>=7` is detected. Short-term mitigation for issue #478.

- **New Features**
  - Added `deps/ai-sdk-major` doctor check that reads the host’s installed `ai` from target `node_modules`; fails `ai@>=7` with E-DEP-001, passes `ai@6`, skips if missing.
  - Error copy includes a downgrade command: `npm install ai@^6 @ai-sdk/anthropic@^3 @ai-sdk/react@^3`, plus a link to #478.
  - Verify page now has an anchored E-DEP-001 section with symptom/cause/fix.
  - `init` prints the same E-DEP-001 warning at the end of the run when `ai@>=7` is installed.

<sup>Written for commit 580ed0ab083ba2751e9b610eb371894f5e39caa8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

