### PR TITLE
login: resume pending claims across process restarts

### DIFF
--- a/docs-site/deploy/vendo-cloud.mdx
+++ b/docs-site/deploy/vendo-cloud.mdx
@@ -52,6 +52,11 @@ vendo login
 
 `vendo cloud device-login` is the same command, kept as an alias.
 
+If the polling process dies before you approve (common when a coding agent
+runs the command), just run `vendo login` again: it resumes the pending claim
+from `~/.vendo/pending-claim.json` and the code you were already shown still
+works.
+
 ### Email-OTP fallback
 
 `vendo cloud login <email>` sends a 6-10 digit code to your inbox, prompts for

--- a/docs-site/reference/cli.mdx
+++ b/docs-site/reference/cli.mdx
@@ -102,6 +102,13 @@ URL and code stay printed as the fallback. For a non-TTY caller — a coding
 agent driving the CLI — nothing opens: the command prints the approval URL and
 pairing code for the human to act on, exactly as before.
 
+The pending claim is persisted to `~/.vendo/pending-claim.json` (mode 0600),
+so if the polling process dies before the approval lands, a fresh `vendo
+login` resumes the same claim — it prints "Resuming pending approval" with the
+original code, and the approval still mints the key into the `.env.local` the
+original run was aimed at. An expired pending claim is discarded and a fresh
+one opened.
+
 Options:
 
 - `[email]` or `--email <address>` pre-fills the approval page (login hint).

--- a/packages/vendo/src/cli/cloud/device-login.test.ts
+++ b/packages/vendo/src/cli/cloud/device-login.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -72,6 +72,7 @@ describe("runDeviceLogin", () => {
       output: messages.sink,
       fetchImpl,
       root,
+      home: await tempRoot(),
       sleep: async (ms) => {
         sleeps.push(ms);
       },
@@ -113,6 +114,7 @@ describe("runDeviceLogin", () => {
       output: output().sink,
       fetchImpl,
       root,
+      home: await tempRoot(),
       sleep: async () => {},
       env: {},
       isTty: false,
@@ -135,6 +137,7 @@ describe("runDeviceLogin", () => {
         output: messages.sink,
         fetchImpl,
         root: await tempRoot(),
+        home: await tempRoot(),
         sleep: async () => {},
         env: {},
         isTty: false,
@@ -154,6 +157,7 @@ describe("runDeviceLogin", () => {
       output: messages.sink,
       fetchImpl,
       root: await tempRoot(),
+      home: await tempRoot(),
       sleep: async (ms) => {
         clock += ms;
       },
@@ -174,6 +178,7 @@ describe("runDeviceLogin", () => {
       output: output().sink,
       fetchImpl,
       root,
+      home: await tempRoot(),
       sleep: async () => {},
       env: {},
       isTty: false,
@@ -193,6 +198,7 @@ describe("runDeviceLogin", () => {
       output: messages.sink,
       fetchImpl,
       root: await tempRoot(),
+      home: await tempRoot(),
       sleep: async () => {},
       env: {},
       isTty: false,
@@ -211,6 +217,7 @@ describe("runDeviceLogin", () => {
       output: messages.sink,
       fetchImpl,
       root: await tempRoot(),
+      home: await tempRoot(),
       sleep: async () => {},
       env: {},
       isTty: true,
@@ -233,6 +240,7 @@ describe("runDeviceLogin", () => {
       output: output().sink,
       fetchImpl,
       root: await tempRoot(),
+      home: await tempRoot(),
       sleep: async () => {},
       env: {},
       isTty: false,
@@ -251,6 +259,7 @@ describe("runDeviceLogin", () => {
       output: messages.sink,
       fetchImpl,
       root: await tempRoot(),
+      home: await tempRoot(),
       sleep: async () => {},
       env: {},
       isTty: false,
@@ -258,6 +267,134 @@ describe("runDeviceLogin", () => {
     });
     expect(exit).toBe(0);
     expect(messages.logs.join("\n")).not.toContain("Re-run `vendo init`");
+  });
+});
+
+// The pending-claim file (#479): a claim survives the process that opened it,
+// so a fresh `vendo login` can resume polling after the original process dies
+// and a late human approval still lands the key.
+describe("pending claim persistence", () => {
+  const pendingPath = (home: string) => join(home, ".vendo", "pending-claim.json");
+
+  async function writePending(home: string, overrides: Record<string, unknown> = {}): Promise<void> {
+    await mkdir(join(home, ".vendo"), { recursive: true });
+    await writeFile(pendingPath(home), JSON.stringify({
+      claim_token: `vct_${"c".repeat(64)}`,
+      user_code: "WXYZ-PQRS",
+      verification_uri_complete: "https://console.test/claim?code=WXYZ-PQRS",
+      expires_at: Date.now() + 600_000,
+      interval: 5,
+      api_url: "https://console.test",
+      cwd: home,
+      ...overrides,
+    }));
+  }
+
+  it("persists the claim (mode 0600) while polling and removes it on success", async () => {
+    const root = await tempRoot();
+    const home = await tempRoot();
+    const seenDuringPoll: unknown[] = [];
+    const { fetchImpl } = scriptedFetch([
+      { status: 400, body: { error: "authorization_pending" } },
+      { status: 200, body: { access_token: KEY, token_type: "Bearer" } },
+    ]);
+    const exit = await runDeviceLogin(["--api-url", "https://console.test"], {
+      output: output().sink,
+      fetchImpl,
+      root,
+      home,
+      sleep: async () => {
+        const mode = (await stat(pendingPath(home))).mode & 0o777;
+        seenDuringPoll.push({ ...JSON.parse(await readFile(pendingPath(home), "utf8")), mode });
+      },
+      env: {},
+      isTty: false,
+    });
+    expect(exit).toBe(0);
+    // The claim was on disk for every poll, owner-only, carrying the resume state.
+    expect(seenDuringPoll[0]).toMatchObject({
+      claim_token: CEREMONY.claim_token,
+      user_code: CEREMONY.user_code,
+      verification_uri_complete: CEREMONY.verification_uri_complete,
+      interval: CEREMONY.interval,
+      api_url: "https://console.test",
+      cwd: root,
+      mode: 0o600,
+    });
+    expect(typeof (seenDuringPoll[0] as { expires_at: unknown }).expires_at).toBe("number");
+    // Redeemed — nothing left to resume.
+    await expect(stat(pendingPath(home))).rejects.toThrow();
+  });
+
+  it("resumes a pending claim: polls the same claim_token without re-opening a claim", async () => {
+    const home = await tempRoot();
+    const originalCwd = await tempRoot();
+    const otherCwd = await tempRoot();
+    await writePending(home, { cwd: originalCwd });
+    const { fetchImpl, requests } = scriptedFetch([
+      { status: 200, body: { access_token: KEY, token_type: "Bearer" } },
+    ]);
+    const messages = output();
+    const exit = await runDeviceLogin(["--api-url", "https://console.test"], {
+      output: messages.sink,
+      fetchImpl,
+      root: otherCwd,
+      home,
+      sleep: async () => {},
+      env: {},
+      isTty: false,
+    });
+    expect(exit).toBe(0);
+    // No new claim was opened — the first request already polls the token endpoint.
+    expect(requests.some((request) => request.url.endsWith("/api/v1/agent/claim"))).toBe(false);
+    expect(new URLSearchParams(requests[0].body).get("claim_token")).toBe(`vct_${"c".repeat(64)}`);
+    // The human is told the old code is still the one to approve.
+    expect(messages.logs.join("\n")).toContain(
+      "Resuming pending approval — code WXYZ-PQRS, approve at https://console.test/claim?code=WXYZ-PQRS",
+    );
+    // The key lands where the ORIGINAL run intended, and the output says so.
+    const envLocal = await readFile(join(originalCwd, ".env.local"), "utf8");
+    expect(envLocal).toContain(`VENDO_API_KEY=${KEY}`);
+    await expect(readFile(join(otherCwd, ".env.local"), "utf8")).rejects.toThrow();
+    expect(messages.logs.join("\n")).toContain(join(originalCwd, ".env.local"));
+    await expect(stat(pendingPath(home))).rejects.toThrow();
+  });
+
+  it("discards an expired pending claim and opens a fresh one", async () => {
+    const home = await tempRoot();
+    await writePending(home, { expires_at: Date.now() - 1_000 });
+    const { fetchImpl, requests } = scriptedFetch([
+      { status: 200, body: { access_token: KEY, token_type: "Bearer" } },
+    ]);
+    const exit = await runDeviceLogin(["--api-url", "https://console.test"], {
+      output: output().sink,
+      fetchImpl,
+      root: await tempRoot(),
+      home,
+      sleep: async () => {},
+      env: {},
+      isTty: false,
+    });
+    expect(exit).toBe(0);
+    // The stale claim is ignored: a fresh ceremony opens and its token is polled.
+    expect(requests[0].url).toBe("https://console.test/api/v1/agent/claim");
+    expect(new URLSearchParams(requests[1].body).get("claim_token")).toBe(CEREMONY.claim_token);
+  });
+
+  it("removes the pending claim when the human denies the request", async () => {
+    const home = await tempRoot();
+    const { fetchImpl } = scriptedFetch([{ status: 400, body: { error: "access_denied" } }]);
+    const exit = await runDeviceLogin(["--api-url", "https://console.test"], {
+      output: output().sink,
+      fetchImpl,
+      root: await tempRoot(),
+      home,
+      sleep: async () => {},
+      env: {},
+      isTty: false,
+    });
+    expect(exit).toBe(1);
+    await expect(stat(pendingPath(home))).rejects.toThrow();
   });
 });
 
@@ -273,6 +410,7 @@ describe("login telemetry (runLoginCommand)", () => {
       output: output().sink,
       fetchImpl: approved.fetchImpl,
       root,
+      home: await tempRoot(),
       sleep: async () => {},
       env: {},
       isTty: false,
@@ -290,6 +428,7 @@ describe("login telemetry (runLoginCommand)", () => {
       output: output().sink,
       fetchImpl: deniedConsole.fetchImpl,
       root,
+      home: await tempRoot(),
       sleep: async () => {},
       env: {},
       isTty: false,

--- a/packages/vendo/src/cli/cloud/device-login.ts
+++ b/packages/vendo/src/cli/cloud/device-login.ts
@@ -1,7 +1,9 @@
 import { execFile } from "node:child_process";
+import { join } from "node:path";
 import { option, positionals } from "./args.js";
 import { isVendoKey, resolveCloudBaseUrl } from "./client.js";
 import { errorMessage, printJson } from "./output.js";
+import { deletePendingClaim, readPendingClaim, writePendingClaim } from "./pending-claim.js";
 import { upsertEnvLocal } from "../cloud-init.js";
 import { browserOpenCommand } from "../playground.js";
 import { CLI_VERSION, consoleOutput, withCommandRun, type Output, type TelemetryOptions } from "../shared.js";
@@ -40,6 +42,9 @@ export interface DeviceLoginOptions {
   /** init runs the ceremony inline and picks the key up in the same run —
       it suppresses the standalone "re-run `vendo init`" tail. */
   rerunHint?: boolean;
+  /** Where ~/.vendo lives (default: the home directory) — the pending-claim
+      file that lets a fresh run resume a still-open ceremony (#479). */
+  home?: string;
 }
 
 function defaultOpenBrowser(url: string): void {
@@ -130,41 +135,81 @@ export async function runDeviceLogin(
     env: options.env ?? process.env,
   });
 
+  const pendingHome = options.home === undefined ? {} : { home: options.home };
+
   try {
-    // Optional email hint — shown to the human on the approval page.
-    const email = option(args, "--email") ?? positionals(args, ["--api-url", "--email"])[0];
-    const claim = await postJson(
-      fetchImpl,
-      `${base}${CLAIM_PATH}`,
-      "application/json",
-      JSON.stringify(email === undefined ? {} : { login_hint: email }),
-    );
-    if (claim.status !== 200) {
-      const envelope = claim.body as { error?: { message?: unknown } } | null;
-      throw new Error(
-        typeof envelope?.error?.message === "string"
-          ? envelope.error.message
-          : `Vendo Cloud could not open a claim (${claim.status})`,
+    // A still-open claim from a dead process (#479): resume polling it so the
+    // human's late approval — against the code they were already shown —
+    // still lands the key. An expired or unreadable file is discarded (a
+    // fresh ceremony overwrites it below).
+    const pending = await readPendingClaim(pendingHome);
+    const resume = pending !== null && pending.api_url === base && pending.expires_at > now()
+      ? pending
+      : null;
+
+    let claimToken: string;
+    let deadline: number;
+    let intervalMs: number;
+    let root: string;
+    if (resume !== null) {
+      output.log(`Resuming pending approval — code ${resume.user_code}, approve at ${resume.verification_uri_complete}`);
+      output.log(`Waiting for approval (the code expires in ${Math.max(1, Math.round((resume.expires_at - now()) / 60_000))} minutes)…`);
+      claimToken = resume.claim_token;
+      deadline = resume.expires_at;
+      intervalMs = Math.max(resume.interval, 1) * 1000;
+      // The key lands where the ORIGINAL run intended, not where the resume runs.
+      root = resume.cwd;
+    } else {
+      // Optional email hint — shown to the human on the approval page.
+      const email = option(args, "--email") ?? positionals(args, ["--api-url", "--email"])[0];
+      const claim = await postJson(
+        fetchImpl,
+        `${base}${CLAIM_PATH}`,
+        "application/json",
+        JSON.stringify(email === undefined ? {} : { login_hint: email }),
       );
-    }
-    const ceremony = ceremonyFrom(claim.body);
+      if (claim.status !== 200) {
+        const envelope = claim.body as { error?: { message?: unknown } } | null;
+        throw new Error(
+          typeof envelope?.error?.message === "string"
+            ? envelope.error.message
+            : `Vendo Cloud could not open a claim (${claim.status})`,
+        );
+      }
+      const ceremony = ceremonyFrom(claim.body);
 
-    const approvalUrl = ceremony.verification_uri_complete ?? ceremony.verification_uri;
-    output.log("Vendo Cloud device login — ask your human to approve this request:");
-    output.log(`  1. Open ${approvalUrl}`);
-    output.log(`  2. Confirm the code: ${ceremony.user_code}`);
-    const tty = options.isTty ?? (process.stdout.isTTY === true);
-    if (tty) {
-      output.log("Opening your browser… (approve there, then come back here)");
-      (options.openBrowser ?? defaultOpenBrowser)(approvalUrl);
-    }
-    output.log(`Waiting for approval (the code expires in ${Math.round(ceremony.expires_in / 60)} minutes)…`);
+      const approvalUrl = ceremony.verification_uri_complete ?? ceremony.verification_uri;
+      output.log("Vendo Cloud device login — ask your human to approve this request:");
+      output.log(`  1. Open ${approvalUrl}`);
+      output.log(`  2. Confirm the code: ${ceremony.user_code}`);
+      const tty = options.isTty ?? (process.stdout.isTTY === true);
+      if (tty) {
+        output.log("Opening your browser… (approve there, then come back here)");
+        (options.openBrowser ?? defaultOpenBrowser)(approvalUrl);
+      }
+      output.log(`Waiting for approval (the code expires in ${Math.round(ceremony.expires_in / 60)} minutes)…`);
 
-    const deadline = now() + ceremony.expires_in * 1000;
-    let intervalMs = Math.max(ceremony.interval, 1) * 1000;
+      claimToken = ceremony.claim_token;
+      deadline = now() + ceremony.expires_in * 1000;
+      intervalMs = Math.max(ceremony.interval, 1) * 1000;
+      root = options.root ?? process.cwd();
+      // Persist the ceremony so a fresh run can resume it if this process
+      // dies mid-poll. Deleted on redemption/denial/expiry; deliberately left
+      // in place on transient errors and interrupts.
+      await writePendingClaim({
+        claim_token: claimToken,
+        user_code: ceremony.user_code,
+        verification_uri_complete: approvalUrl,
+        expires_at: deadline,
+        interval: ceremony.interval,
+        api_url: base,
+        cwd: root,
+      }, pendingHome);
+    }
+
     const pollBody = new URLSearchParams({
       grant_type: CLAIM_GRANT_TYPE,
-      claim_token: ceremony.claim_token,
+      claim_token: claimToken,
     }).toString();
 
     while (now() < deadline) {
@@ -181,10 +226,12 @@ export async function runDeviceLogin(
         if (typeof key !== "string" || !isVendoKey(key)) {
           throw new Error("Vendo Cloud returned an invalid credential");
         }
-        const root = options.root ?? process.cwd();
         await upsertEnvLocal(root, "VENDO_API_KEY", key);
-        // Never print the key itself — .env.local is the hand-off, last4 the receipt.
-        output.log(`Approved — wrote VENDO_API_KEY (…${key.slice(-4)}) to .env.local.`);
+        await deletePendingClaim(pendingHome);
+        // Never print the key itself — .env.local is the hand-off, last4 the
+        // receipt. A resumed run names the full path: it may differ from cwd.
+        output.log(`Approved — wrote VENDO_API_KEY (…${key.slice(-4)}) to ${
+          resume !== null ? join(root, ".env.local") : ".env.local"}.`);
         if (options.rerunHint !== false) {
           output.log("Re-run `vendo init` to finish wiring (it picks the key up from .env.local).");
         }
@@ -199,9 +246,11 @@ export async function runDeviceLogin(
         continue;
       }
       if (error === "expired_token") {
+        await deletePendingClaim(pendingHome);
         throw new Error("The code expired before it was approved; run `vendo login` again.");
       }
       if (error === "access_denied") {
+        await deletePendingClaim(pendingHome);
         throw new Error("Your human denied the request — no key was minted.");
       }
       const description = (poll.body as { error_description?: unknown } | null)?.error_description;
@@ -211,6 +260,7 @@ export async function runDeviceLogin(
           : `Vendo Cloud token polling failed (${typeof error === "string" ? error : poll.status})`,
       );
     }
+    await deletePendingClaim(pendingHome);
     throw new Error("The code expired before it was approved; run `vendo login` again.");
   } catch (error) {
     output.error(errorMessage(error));

--- a/packages/vendo/src/cli/cloud/pending-claim.ts
+++ b/packages/vendo/src/cli/cloud/pending-claim.ts
@@ -1,0 +1,67 @@
+import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * The pending-claim file (#479): a `vendo login` claim outlives the process
+ * that opened it. Coding agents' processes often live exactly one turn — if
+ * the poller dies and the human approves afterwards, the approval succeeds
+ * server-side but the claim_token existed only in the dead process's memory.
+ * Persisting the claim lets a fresh `vendo login` resume polling the SAME
+ * claim, so the late approval still lands the key.
+ */
+export interface PendingClaim {
+  claim_token: string;
+  user_code: string;
+  verification_uri_complete: string;
+  /** Unix timestamp in milliseconds — computed from the ceremony's expires_in. */
+  expires_at: number;
+  /** Poll pacing in seconds (RFC 8628). */
+  interval: number;
+  /** The console the claim was opened against — resume only on a match. */
+  api_url: string;
+  /** Where the original run intended .env.local to land. */
+  cwd: string;
+}
+
+export interface PendingClaimOptions {
+  home?: string;
+}
+
+function pendingClaimPath(options: PendingClaimOptions = {}): string {
+  return join(options.home ?? homedir(), ".vendo", "pending-claim.json");
+}
+
+function isPendingClaim(value: unknown): value is PendingClaim {
+  if (typeof value !== "object" || value === null) return false;
+  const claim = value as Partial<PendingClaim>;
+  return typeof claim.claim_token === "string"
+    && typeof claim.user_code === "string"
+    && typeof claim.verification_uri_complete === "string"
+    && typeof claim.expires_at === "number"
+    && typeof claim.interval === "number"
+    && typeof claim.api_url === "string"
+    && typeof claim.cwd === "string";
+}
+
+/** An unreadable or malformed file reads as "no pending claim" — the caller
+    discards it by opening (and persisting) a fresh ceremony. */
+export async function readPendingClaim(options: PendingClaimOptions = {}): Promise<PendingClaim | null> {
+  try {
+    const value: unknown = JSON.parse(await readFile(pendingClaimPath(options), "utf8"));
+    return isPendingClaim(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function writePendingClaim(claim: PendingClaim, options: PendingClaimOptions = {}): Promise<void> {
+  const path = pendingClaimPath(options);
+  await mkdir(join(path, ".."), { recursive: true, mode: 0o700 });
+  await writeFile(path, `${JSON.stringify(claim, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  await chmod(path, 0o600);
+}
+
+export async function deletePendingClaim(options: PendingClaimOptions = {}): Promise<void> {
+  await rm(pendingClaimPath(options), { force: true });
+}


### PR DESCRIPTION
Closes #479. `vendo login` now persists the pending claim to `~/.vendo/pending-claim.json` (0600, mirrors cloud-session.json handling) while polling; a rerun resumes an unexpired same-api_url claim without opening a new code ('Resuming pending approval — code XXXX-XXXX…'), and the key writes to the ORIGINAL run's cwd. File is removed on redemption/denied/expired, kept on transient errors. Found by the live E2E twice: coding agents' processes live one turn, so the human approved a claim whose poller was already dead and the minted key was lost behind a success screen. Tests: device-login 14/14, cloud suite green, tsc clean; docs updated (cli reference + vendo-cloud ceremony section).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`vendo login` now persists device-login claims and resumes them after process restarts, so late approvals still mint keys instead of being lost. Closes #479.

- **New Features**
  - Persist pending claims to `~/.vendo/pending-claim.json` (0600) while polling; on rerun, resume the same `api_url` claim without opening a new code and print "Resuming pending approval".
  - On resume, write `VENDO_API_KEY` to the ORIGINAL run’s `.env.local` (not the current cwd); remove the pending file on success/denied/expired, keep it on transient errors.
  - Added `pending-claim` module, tests for persistence/resume/cleanup, and docs explaining the resume flow.

<sup>Written for commit 0be2c8f8880c707a75c08a6c50ea9751f0bc6c71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

