### PR TITLE
install-eval: scripted-human seam — live runs can reach doctor scoring

### DIFF
--- a/corpus/harness/src/install-eval/agent.test.ts
+++ b/corpus/harness/src/install-eval/agent.test.ts
@@ -2,27 +2,163 @@ import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { agentEnv, buildClaudeArgs, runInstallAgent } from "./agent.js";
+import { SCRIPTED_HUMAN_ANSWER, agentEnv, buildClaudeArgs, runInstallAgent } from "./agent.js";
+
+const SESSION_ID = "11111111-2222-4333-8444-555555555555";
 
 describe("buildClaudeArgs", () => {
-  it("builds a headless stream-json invocation with budget and model", () => {
-    const args = buildClaudeArgs({ prompt: "Install Vendo in this repo.", model: "haiku", maxBudgetUsd: 2.5 });
+  it("builds a headless stream-json invocation with budget, model, and a pinned session id", () => {
+    const args = buildClaudeArgs({
+      prompt: "Install Vendo in this repo.",
+      model: "haiku",
+      maxBudgetUsd: 2.5,
+      session: { id: SESSION_ID, resume: false },
+    });
     expect(args[0]).toBe("-p");
     expect(args[1]).toBe("Install Vendo in this repo.");
     expect(args).toContain("stream-json");
     expect(args).toContain("--verbose");
     expect(args).toContain("bypassPermissions");
-    expect(args).toContain("--no-session-persistence");
+    // Sessions persist now — the scripted-human continuation needs --resume.
+    expect(args).not.toContain("--no-session-persistence");
+    expect(args[args.indexOf("--session-id") + 1]).toBe(SESSION_ID);
+    expect(args).not.toContain("--resume");
     // User-level CLAUDE.md/skills stay out of the measurement.
     const settingSources = args[args.indexOf("--setting-sources") + 1];
     expect(settingSources).toBe("project");
     expect(args[args.indexOf("--model") + 1]).toBe("haiku");
     expect(args[args.indexOf("--max-budget-usd") + 1]).toBe("2.5");
   });
+
+  it("builds the scripted-human continuation as a --resume of the same session", () => {
+    const args = buildClaudeArgs({
+      prompt: SCRIPTED_HUMAN_ANSWER,
+      model: "haiku",
+      maxBudgetUsd: 2.1,
+      session: { id: SESSION_ID, resume: true },
+    });
+    expect(args[0]).toBe("-p");
+    expect(args[1]).toBe(SCRIPTED_HUMAN_ANSWER);
+    expect(args[args.indexOf("--resume") + 1]).toBe(SESSION_ID);
+    expect(args).not.toContain("--session-id");
+    expect(args[args.indexOf("--max-budget-usd") + 1]).toBe("2.1");
+  });
+});
+
+/** Fake claude: logs every invocation's args to args.log, then plays the
+ * scripted transcript for its mode (first turn vs --resume continuation). */
+async function writeFakeClaude(dir: string, script: { firstResult: string; resumeResult: string }): Promise<string> {
+  const fakeBin = path.join(dir, "fake-claude.sh");
+  const argsLog = path.join(dir, "args.log");
+  await writeFile(fakeBin, [
+    "#!/bin/sh",
+    `echo "$@" >> ${JSON.stringify(argsLog)}`,
+    'case "$*" in',
+    "  *--resume*)",
+    `    echo '{"type":"system","subtype":"init","session_id":"${SESSION_ID}"}'`,
+    `    echo '{"type":"result","subtype":"success","num_turns":5,"total_cost_usd":0.5,"result":${JSON.stringify(script.resumeResult)}}'`,
+    "    ;;",
+    "  *)",
+    `    echo '{"type":"system","subtype":"init","session_id":"${SESSION_ID}"}'`,
+    `    echo '{"type":"result","subtype":"success","num_turns":3,"total_cost_usd":0.4,"result":${JSON.stringify(script.firstResult)}}'`,
+    "    ;;",
+    "esac",
+    "",
+  ].join("\n"));
+  await chmod(fakeBin, 0o755);
+  return fakeBin;
+}
+
+const KEY_QUESTION_RESULT = "Before I run vendo init, the playbook requires me to ask: Cloud, or bring-your-own for the model key? Let me know which.";
+const STAR_ASK_RESULT = "Done — vendo doctor --json is green. Want me to star runvendo/vendo on GitHub to support the project?";
+
+async function readArgsLog(dir: string): Promise<string[]> {
+  return (await readFile(path.join(dir, "args.log"), "utf8")).split("\n").filter((line) => line.length > 0);
+}
+
+describe("runInstallAgent scripted-human continuation", () => {
+  it("answers the mandated key question exactly once via --resume and appends the second turn to the transcript", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "install-eval-agent-resume-"));
+    const fakeBin = await writeFakeClaude(dir, { firstResult: KEY_QUESTION_RESULT, resumeResult: STAR_ASK_RESULT });
+    const transcriptPath = path.join(dir, "logs", "transcript.jsonl");
+
+    const result = await runInstallAgent({
+      prompt: "Install Vendo in this repo.",
+      cwd: dir,
+      transcriptPath,
+      model: "haiku",
+      maxBudgetUsd: 2.5,
+      timeBudgetMs: 30_000,
+      claudeBin: fakeBin,
+      sessionId: SESSION_ID,
+      env: { PATH: process.env["PATH"] ?? "" },
+    });
+
+    expect(result.scriptedReplies).toBe(1);
+    expect(result.code).toBe(0);
+    expect(result.timedOut).toBe(false);
+    expect(result.command).toContain("--resume");
+
+    const invocations = await readArgsLog(dir);
+    expect(invocations).toHaveLength(2);
+    expect(invocations[0]).toContain(`--session-id ${SESSION_ID}`);
+    expect(invocations[0]).not.toContain("--no-session-persistence");
+    expect(invocations[1]).toContain(`--resume ${SESSION_ID}`);
+    expect(invocations[1]).toContain(SCRIPTED_HUMAN_ANSWER);
+    // The continuation spends what is LEFT of the money budget (2.5 - 0.4).
+    expect(invocations[1]).toContain("--max-budget-usd 2.1");
+
+    // Both invocations land in one transcript: scoring reads across turns.
+    const transcript = await readFile(transcriptPath, "utf8");
+    expect(transcript).toContain(KEY_QUESTION_RESULT.slice(0, 40));
+    expect(transcript).toContain(STAR_ASK_RESULT.slice(0, 40));
+    expect(transcript.match(/"subtype":"init"/g)).toHaveLength(2);
+  }, 15_000);
+
+  it("caps at ONE scripted reply — a second ask ends the run as today", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "install-eval-agent-cap-"));
+    // The fake agent asks the key question again even after the reply.
+    const fakeBin = await writeFakeClaude(dir, { firstResult: KEY_QUESTION_RESULT, resumeResult: KEY_QUESTION_RESULT });
+
+    const result = await runInstallAgent({
+      prompt: "p",
+      cwd: dir,
+      transcriptPath: path.join(dir, "logs", "transcript.jsonl"),
+      model: "haiku",
+      maxBudgetUsd: 2.5,
+      timeBudgetMs: 30_000,
+      claudeBin: fakeBin,
+      sessionId: SESSION_ID,
+      env: { PATH: process.env["PATH"] ?? "" },
+    });
+
+    expect(result.scriptedReplies).toBe(1);
+    expect(await readArgsLog(dir)).toHaveLength(2);
+  }, 15_000);
+
+  it("does NOT answer the star ask — that transcript is complete", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "install-eval-agent-star-"));
+    const fakeBin = await writeFakeClaude(dir, { firstResult: STAR_ASK_RESULT, resumeResult: KEY_QUESTION_RESULT });
+
+    const result = await runInstallAgent({
+      prompt: "p",
+      cwd: dir,
+      transcriptPath: path.join(dir, "logs", "transcript.jsonl"),
+      model: "haiku",
+      maxBudgetUsd: 2.5,
+      timeBudgetMs: 30_000,
+      claudeBin: fakeBin,
+      sessionId: SESSION_ID,
+      env: { PATH: process.env["PATH"] ?? "" },
+    });
+
+    expect(result.scriptedReplies).toBe(0);
+    expect(await readArgsLog(dir)).toHaveLength(1);
+  }, 15_000);
 });
 
 describe("runInstallAgent", () => {
-  it("enforces the time budget with a group kill and keeps the transcript pure JSONL", async () => {
+  it("enforces the time budget with a group kill, keeps the transcript pure JSONL, and never resumes a timed-out run", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "install-eval-agent-"));
     // Fake agent: one JSON line on stdout, noise on stderr, then hang — the
     // wall-clock kill has to end it (and its process group).
@@ -43,6 +179,7 @@ describe("runInstallAgent", () => {
     });
 
     expect(result.timedOut).toBe(true);
+    expect(result.scriptedReplies).toBe(0);
     const transcript = await readFile(transcriptPath, "utf8");
     expect(transcript).toContain('{"type":"assistant"}');
     expect(transcript).not.toContain("stderr noise");

--- a/corpus/harness/src/install-eval/agent.ts
+++ b/corpus/harness/src/install-eval/agent.ts
@@ -1,7 +1,10 @@
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { createWriteStream } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
+import { detectsKeyQuestion } from "./score.js";
+import { finalAssistantText, parseTranscript, totalCostUsd } from "./transcript.js";
 
 /**
  * Invoke a REAL headless coding agent — Claude Code (`claude -p …
@@ -9,7 +12,23 @@ import path from "node:path";
  * into the fixture. The full stream-json output is captured to a per-fixture
  * transcript file. Budgets: wall-clock (enforced by kill; the CLI has no
  * turn-cap flag in 2.1.x) and `--max-budget-usd` (enforced by the CLI).
+ *
+ * SCRIPTED-HUMAN SEAM (#480): the playbook mandates the agent STOP and ask
+ * Cloud-vs-BYO before touching keys, so a single-shot run always ends at that
+ * gate and doctor/star-ask scoring is unreachable. When the first invocation
+ * ends on that question (`detectsKeyQuestion`), the runner replies ONCE via
+ * `claude -p --resume <session-id> …` with a fixed bring-your-own answer and
+ * appends the continuation to the same transcript. Exactly one reply per run:
+ * a second ask (or the star ask, which is the run's terminal step) ends the
+ * run as before. Sessions therefore persist (`--session-id` replaces the old
+ * `--no-session-persistence`); the CLI has no session-delete flag in 2.1.x,
+ * so each run leaves one small JSONL session under ~/.claude/projects/ keyed
+ * by the harness-minted UUID below.
  */
+
+export const SCRIPTED_HUMAN_ANSWER =
+  "Bring-your-own — ANTHROPIC_API_KEY is already set in .env.local. Do not create any account. "
+  + "Continue to a green vendo doctor --json, then finish per the original instructions.";
 
 export interface RunInstallAgentOptions {
   prompt: string;
@@ -20,15 +39,26 @@ export interface RunInstallAgentOptions {
   timeBudgetMs: number;
   claudeBin?: string;
   env?: NodeJS.ProcessEnv;
+  /** Session UUID for the run (minted when omitted) — pinned so the scripted
+   * continuation can `--resume` it and tests stay deterministic. */
+  sessionId?: string;
 }
 
 export interface InstallAgentResult {
   code: number | null;
   timedOut: boolean;
   command: string;
+  /** How many scripted-human answers were sent (hard cap: 1 per run). */
+  scriptedReplies: number;
 }
 
-export function buildClaudeArgs(options: Pick<RunInstallAgentOptions, "prompt" | "model" | "maxBudgetUsd">): string[] {
+export interface ClaudeArgsOptions extends Pick<RunInstallAgentOptions, "prompt" | "model" | "maxBudgetUsd"> {
+  /** `resume: false` mints the session; `resume: true` is the scripted-human
+   * continuation of the same session. */
+  session: { id: string; resume: boolean };
+}
+
+export function buildClaudeArgs(options: ClaudeArgsOptions): string[] {
   return [
     "-p", options.prompt,
     "--output-format", "stream-json",
@@ -36,7 +66,7 @@ export function buildClaudeArgs(options: Pick<RunInstallAgentOptions, "prompt" |
     // The fixture is a disposable copy; the agent must run installs/inits
     // unattended. Never point this at a directory you care about.
     "--permission-mode", "bypassPermissions",
-    "--no-session-persistence",
+    ...(options.session.resume ? ["--resume", options.session.id] : ["--session-id", options.session.id]),
     // Exclude the machine's user-level CLAUDE.md/skills: the eval measures
     // the prompt + playbook, not a developer's personal setup. Fixtures ship
     // no project settings (prepareFixture strips .claude/, CLAUDE.md).
@@ -68,18 +98,35 @@ function killProcessGroup(child: ReturnType<typeof spawn>, signal: NodeJS.Signal
   }
 }
 
-export async function runInstallAgent(options: RunInstallAgentOptions): Promise<InstallAgentResult> {
-  const claudeBin = options.claudeBin ?? "claude";
-  const args = buildClaudeArgs(options);
-  await mkdir(path.dirname(options.transcriptPath), { recursive: true });
-  const transcript = createWriteStream(options.transcriptPath);
-  // stderr goes to its own log so the transcript stays pure JSONL.
-  const stderrLog = createWriteStream(`${options.transcriptPath}.stderr.log`);
+interface InvokeClaudeOnceOptions {
+  claudeBin: string;
+  args: string[];
+  cwd: string;
+  transcriptPath: string;
+  timeBudgetMs: number;
+  env: NodeJS.ProcessEnv;
+  /** The scripted-human continuation appends to the first turn's transcript
+   * so scoring reads one file across both invocations. */
+  append: boolean;
+}
 
-  return new Promise<InstallAgentResult>((resolve, reject) => {
-    const child = spawn(claudeBin, args, {
+interface InvokeClaudeOnceResult {
+  code: number | null;
+  timedOut: boolean;
+  command: string;
+}
+
+async function invokeClaudeOnce(options: InvokeClaudeOnceOptions): Promise<InvokeClaudeOnceResult> {
+  await mkdir(path.dirname(options.transcriptPath), { recursive: true });
+  const flags = options.append ? "a" : "w";
+  const transcript = createWriteStream(options.transcriptPath, { flags });
+  // stderr goes to its own log so the transcript stays pure JSONL.
+  const stderrLog = createWriteStream(`${options.transcriptPath}.stderr.log`, { flags });
+
+  return new Promise<InvokeClaudeOnceResult>((resolve, reject) => {
+    const child = spawn(options.claudeBin, options.args, {
       cwd: options.cwd,
-      env: agentEnv(options.env ?? process.env),
+      env: options.env,
       stdio: ["ignore", "pipe", "pipe"],
       detached: true,
     });
@@ -105,7 +152,59 @@ export async function runInstallAgent(options: RunInstallAgentOptions): Promise<
       finish();
       // The agent is done; sweep any process-group stragglers regardless.
       killProcessGroup(child, "SIGKILL");
-      resolve({ code, timedOut, command: `${claudeBin} ${args.map((arg) => (arg.includes(" ") ? JSON.stringify(arg) : arg)).join(" ")}` });
+      resolve({ code, timedOut, command: `${options.claudeBin} ${options.args.map((arg) => (arg.includes(" ") ? JSON.stringify(arg) : arg)).join(" ")}` });
     });
   });
+}
+
+export async function runInstallAgent(options: RunInstallAgentOptions): Promise<InstallAgentResult> {
+  const claudeBin = options.claudeBin ?? "claude";
+  const sessionId = options.sessionId ?? randomUUID();
+  const env = agentEnv(options.env ?? process.env);
+  const startedAt = Date.now();
+
+  const first = await invokeClaudeOnce({
+    claudeBin,
+    args: buildClaudeArgs({ ...options, session: { id: sessionId, resume: false } }),
+    cwd: options.cwd,
+    transcriptPath: options.transcriptPath,
+    timeBudgetMs: options.timeBudgetMs,
+    env,
+    append: false,
+  });
+  const singleShot: InstallAgentResult = { ...first, scriptedReplies: 0 };
+  // Only a clean first turn can be continued: a timed-out or errored run has
+  // no session to resume into (and is already a red result).
+  if (first.timedOut || first.code !== 0) return singleShot;
+
+  const events = parseTranscript(await readFile(options.transcriptPath, "utf8"));
+  const finalText = finalAssistantText(events);
+  if (finalText === null || !detectsKeyQuestion(finalText)) return singleShot;
+
+  // Both budgets cover the WHOLE run: the continuation only gets what the
+  // first invocation left over (cost rounded to cents for the CLI flag).
+  const timeLeftMs = options.timeBudgetMs - (Date.now() - startedAt);
+  const budgetLeftUsd = Math.round((options.maxBudgetUsd - (totalCostUsd(events) ?? 0)) * 100) / 100;
+  if (timeLeftMs <= 0 || budgetLeftUsd <= 0) return singleShot;
+
+  const second = await invokeClaudeOnce({
+    claudeBin,
+    args: buildClaudeArgs({
+      prompt: SCRIPTED_HUMAN_ANSWER,
+      model: options.model,
+      maxBudgetUsd: budgetLeftUsd,
+      session: { id: sessionId, resume: true },
+    }),
+    cwd: options.cwd,
+    transcriptPath: options.transcriptPath,
+    timeBudgetMs: timeLeftMs,
+    env,
+    append: true,
+  });
+  return {
+    code: second.code,
+    timedOut: second.timedOut,
+    command: `${first.command} && ${second.command}`,
+    scriptedReplies: 1,
+  };
 }

--- a/corpus/harness/src/install-eval/report.test.ts
+++ b/corpus/harness/src/install-eval/report.test.ts
@@ -12,6 +12,7 @@ function metrics(overrides: Partial<FixtureRunMetrics>): FixtureRunMetrics {
     costUsd: 2.31,
     durationMs: 480_000,
     askedBeforeAccount: { pass: true, accountActions: [], askEvidence: [] },
+    askGate: "reached-and-answered",
     violations: [],
     agentExit: { code: 0, timedOut: false },
     ...overrides,
@@ -33,6 +34,7 @@ describe("install-eval report", () => {
           fixture: "demo-bank",
           doctor: { ran: true, green: false, failingCodes: ["E-WIRE-004", "E-TURN-001"] },
           askedBeforeAccount: { pass: false, accountActions: ["Bash: npx vendo cloud login"], askEvidence: [] },
+          askGate: "reached-terminal",
           violations: [{ id: "skipped-star-ask", detail: "transcript never asks about starring" }],
         }),
       ],
@@ -41,7 +43,9 @@ describe("install-eval report", () => {
     expect(doc.summary).toEqual({ fixtureCount: 2, doctorGreen: 1, cleanRuns: 1 });
 
     const markdown = renderInstallEvalMarkdown(doc);
-    expect(markdown).toContain("| express-host | yes | 12/40 | yes | none | 2.31 | 480s |");
+    expect(markdown).toContain("| Ask gate |");
+    expect(markdown).toContain("| express-host | yes | 12/40 | yes | reached-and-answered | none | 2.31 | 480s |");
+    expect(markdown).toContain("| reached-terminal |");
     expect(markdown).toContain("NO (E-WIRE-004, E-TURN-001)");
     expect(markdown).toContain("## demo-bank — failure detail");
     expect(markdown).toContain("npx vendo cloud login");

--- a/corpus/harness/src/install-eval/report.ts
+++ b/corpus/harness/src/install-eval/report.ts
@@ -79,8 +79,8 @@ export function renderInstallEvalMarkdown(doc: InstallEvalReportDocument): strin
     `Summary: ${doc.summary.doctorGreen}/${doc.summary.fixtureCount} doctor-green; `
       + `${doc.summary.cleanRuns}/${doc.summary.fixtureCount} clean (green + asked + zero violations).`,
     "",
-    "| Fixture | Doctor green | Turns (budget) | Asked before account | Violations | Cost (USD) | Duration |",
-    "| --- | --- | --- | --- | --- | --- | --- |",
+    "| Fixture | Doctor green | Turns (budget) | Asked before account | Ask gate | Violations | Cost (USD) | Duration |",
+    "| --- | --- | --- | --- | --- | --- | --- | --- |",
   ];
 
   for (const fixture of doc.fixtures) {
@@ -91,7 +91,7 @@ export function renderInstallEvalMarkdown(doc: InstallEvalReportDocument): strin
     const violations = fixture.violations.length === 0
       ? "none"
       : fixture.violations.map((violation) => violation.id).join(", ");
-    lines.push(`| ${fixture.fixture} | ${escapeCell(doctor)} | ${turns} | ${yesNo(fixture.askedBeforeAccount.pass)} | ${escapeCell(violations)} | ${fixture.costUsd === null ? "—" : fixture.costUsd.toFixed(2)} | ${fixture.durationMs === null ? "—" : `${Math.round(fixture.durationMs / 1000)}s`} |`);
+    lines.push(`| ${fixture.fixture} | ${escapeCell(doctor)} | ${turns} | ${yesNo(fixture.askedBeforeAccount.pass)} | ${fixture.askGate} | ${escapeCell(violations)} | ${fixture.costUsd === null ? "—" : fixture.costUsd.toFixed(2)} | ${fixture.durationMs === null ? "—" : `${Math.round(fixture.durationMs / 1000)}s`} |`);
   }
 
   for (const fixture of doc.fixtures) {

--- a/corpus/harness/src/install-eval/run.test.ts
+++ b/corpus/harness/src/install-eval/run.test.ts
@@ -1,11 +1,13 @@
-import { mkdtemp, readFile, readdir } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { parseInstallEvalArgs, runCli } from "../cli.js";
 import { createRunContext } from "../run-context.js";
+import type { RunInstallAgentOptions } from "./agent.js";
 import { INSTALL_EVAL_DEFAULTS, runInstallEvalCommand, type InstallEvalCommandOptions } from "./run.js";
 import { writeInstallEvalReport } from "./report.js";
+import type { InstallEvalReportDocument } from "./report.js";
 
 describe("parseInstallEvalArgs", () => {
   it("applies documented defaults", () => {
@@ -103,7 +105,9 @@ describe("runInstallEvalCommand --dry-run", () => {
     const markdownFile = reports.find((file) => file.endsWith(".md"))!;
     const markdown = await readFile(path.join(reportsDir, markdownFile), "utf8");
     expect(markdown).toContain("Mode: dry-run");
-    expect(markdown).toContain("| express-host | yes | 7/40 | yes | none |");
+    // The canned agent asks mid-run but never STOPS on the question, so the
+    // ask gate never blocked it.
+    expect(markdown).toContain("| express-host | yes | 7/40 | yes | not-reached | none |");
     expect(stdout.join("\n")).toContain("Report:");
   });
 
@@ -127,6 +131,66 @@ describe("runInstallEvalCommand --dry-run", () => {
       writeReport: writeInstallEvalReport,
     });
     expect(exit).toBe(1);
+  });
+});
+
+/** What the transcript file looks like after the scripted-human seam replied
+ * once: the first `claude -p` invocation ends on the mandated key question,
+ * and the `--resume` continuation (appended to the same file) runs through
+ * doctor to the star ask. One init + one result event per invocation. */
+const TWO_TURN_TRANSCRIPT = [
+  JSON.stringify({ type: "system", subtype: "init", session_id: "s-1" }),
+  JSON.stringify({ type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "Cloud vs. bring-your-own for the model key — which do you want? I won't touch keys or accounts until you answer." }] } }),
+  JSON.stringify({ type: "result", subtype: "success", num_turns: 3, total_cost_usd: 0.4, duration_ms: 60_000, result: "Cloud vs. bring-your-own for the model key — which do you want? I won't touch keys or accounts until you answer." }),
+  JSON.stringify({ type: "system", subtype: "init", session_id: "s-1" }),
+  JSON.stringify({ type: "assistant", message: { role: "assistant", content: [{ type: "tool_use", id: "tu_1", name: "Bash", input: { command: "npx vendo init --yes --auth none --byo" } }] } }),
+  JSON.stringify({ type: "assistant", message: { role: "assistant", content: [{ type: "tool_use", id: "tu_2", name: "Bash", input: { command: "npx vendo doctor --json" } }] } }),
+  JSON.stringify({ type: "result", subtype: "success", num_turns: 9, total_cost_usd: 1.1, duration_ms: 240_000, result: "Doctor is green. Want me to star runvendo/vendo on GitHub to support the project?" }),
+  "",
+].join("\n");
+
+describe("runInstallEvalCommand with the scripted two-turn agent seam", () => {
+  it("scores turns, cost, and the ask gate across BOTH invocations of one run", async () => {
+    const corpusRoot = await mkdtemp(path.join(tmpdir(), "install-eval-two-turn-"));
+    const context = createRunContext({ corpusRoot });
+    const stdout: string[] = [];
+    let agentOptions: RunInstallAgentOptions | undefined;
+
+    const exit = await runInstallEvalCommand(dryRunOptions({ dryRun: false, json: true }), {
+      stdout: (line) => stdout.push(line),
+      stderr: () => {},
+      now: () => new Date("2026-07-21T12:00:00.000Z"),
+      env: {},
+      workspaceRoot: corpusRoot,
+      context,
+      readPrompt: async () => "Install Vendo in this repo.",
+      packTarballs: async (options) => options.cacheDir,
+      startRegistry: async () => ({ url: "http://127.0.0.1:9999", close: async () => {} }),
+      prepare: async () => path.join(corpusRoot, "fixture-copy"),
+      runAgent: async (options) => {
+        agentOptions = options;
+        // Stand-in for runInstallAgent: turn 1 ended on the key question, the
+        // scripted human answered once, turn 2 appended to the transcript.
+        await mkdir(path.dirname(options.transcriptPath), { recursive: true });
+        await writeFile(options.transcriptPath, TWO_TURN_TRANSCRIPT);
+        return { code: 0, timedOut: false, command: "fake-claude", scriptedReplies: 1 };
+      },
+      runDoctor: async () => ({ ran: true, green: true, failingCodes: [] }),
+      readToolState: async () => ({ toolNames: [], referencedToolNames: [] }),
+      writeReport: writeInstallEvalReport,
+    });
+
+    expect(exit).toBe(0);
+    expect(agentOptions?.prompt).toBe("Install Vendo in this repo.");
+    const report = JSON.parse(stdout.join("\n")) as InstallEvalReportDocument;
+    const fixture = report.fixtures[0]!;
+    expect(fixture.askGate).toBe("reached-and-answered");
+    // Budgets cover the whole run: both invocations' turns and cost sum.
+    expect(fixture.turns).toBe(12);
+    expect(fixture.costUsd).toBeCloseTo(1.5);
+    expect(fixture.durationMs).toBe(300_000);
+    expect(fixture.askedBeforeAccount.pass).toBe(true);
+    expect(fixture.violations).toHaveLength(0);
   });
 });
 

--- a/corpus/harness/src/install-eval/run.ts
+++ b/corpus/harness/src/install-eval/run.ts
@@ -31,9 +31,11 @@ import { parseTranscript } from "./transcript.js";
 /**
  * `pnpm corpus install-eval` — the agent-install eval (plan Phase 4). For
  * each fixture: clean copy, local-registry npm resolution, one REAL headless
- * Claude Code run with only the docs' copy-paste prompt, then machine
- * scoring (doctor run by the harness, transcript heuristics) and a matrix
- * report under corpus/reports/.
+ * Claude Code run with only the docs' copy-paste prompt (plus at most ONE
+ * scripted-human reply when the agent stops on the playbook's mandated
+ * Cloud-vs-BYO question — see agent.ts, #480), then machine scoring (doctor
+ * run by the harness, transcript heuristics) and a matrix report under
+ * corpus/reports/.
  *
  * NEVER in CI or `pnpm test`: every live run spends real model money. The
  * --dry-run mode exercises the entire pipeline against a canned transcript
@@ -120,6 +122,10 @@ async function runOneFixture(
   } else {
     progress(`install-eval: ${fixture.name} — running headless agent (model ${options.model}, `
       + `budget $${options.maxBudgetUsd} / ${Math.round(options.timeBudgetMs / 60_000)}min)…`);
+    // Budgets are per RUN, not per invocation: when the agent stops on the
+    // mandated Cloud-vs-BYO question, the runner's one scripted-human reply
+    // (`--resume`) spends what the first invocation left over, and scoring
+    // sums turns/cost/duration across both invocations' result events.
     const agent = await deps.runAgent({
       prompt,
       cwd: fixtureDir,
@@ -131,7 +137,8 @@ async function runOneFixture(
     });
     agentExit = { code: agent.code, timedOut: agent.timedOut };
     transcriptSource = await readFile(transcriptPath, "utf8");
-    progress(`install-eval: ${fixture.name} — agent exited ${agent.code ?? "by signal"}${agent.timedOut ? " (time budget hit)" : ""}; running doctor…`);
+    const scripted = agent.scriptedReplies > 0 ? ` after ${agent.scriptedReplies} scripted-human reply` : "";
+    progress(`install-eval: ${fixture.name} — agent exited ${agent.code ?? "by signal"}${agent.timedOut ? " (time budget hit)" : ""}${scripted}; running doctor…`);
     doctor = await deps.runDoctor({ fixture, fixtureDir, logsDir, env: deps.env });
   }
 

--- a/corpus/harness/src/install-eval/score.test.ts
+++ b/corpus/harness/src/install-eval/score.test.ts
@@ -2,6 +2,8 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
+  detectsKeyQuestion,
+  evaluateAskGate,
   evaluateAskedBeforeAccount,
   findInventedToolViolations,
   findScaffoldViolations,
@@ -24,6 +26,29 @@ function text(value: string): TranscriptEvent {
   return assistant([{ type: "text", text: value }]);
 }
 
+function init(sessionId: string): TranscriptEvent {
+  return { type: "system", subtype: "init", session_id: sessionId } as TranscriptEvent;
+}
+
+function result(finalText: string, extra: Partial<TranscriptEvent> = {}): TranscriptEvent {
+  return { type: "result", subtype: "success", result: finalText, ...extra } as TranscriptEvent;
+}
+
+/** Real ask texts captured from live runs 2026-07-21 (invoify, express-host). */
+const REAL_ASK_BYO_OR_CLOUD =
+  "Before running `npx vendo init`, I need one decision from you. The playbook says init requires "
+  + "either `--byo` (you bring an ANTHROPIC_API_KEY) or `--cloud-key` (a Vendo Cloud key). "
+  + "Want me to proceed with `--byo` and `--auth none`?";
+const REAL_ASK_PLAYBOOK_MANDATE =
+  "Before I run `vendo init`, the playbook requires me to ask you: **Cloud vs. bring-your-own for "
+  + "the model key.** Cloud needs an account; bring-your-own uses a key you already have. "
+  + "Let me know which, and I'll proceed with install → init → wiring → doctor.";
+const STAR_ASK_TEXT =
+  "Vendo install is done. Would you like me to star `runvendo/vendo` on GitHub to support the project?";
+const DOCTOR_GREEN_TEXT =
+  "Vendo is installed and wired: `npx vendo doctor --json` reports every check green, and the dev "
+  + "server renders the generated UI. Your ANTHROPIC_API_KEY from .env.local is what the runtime uses.";
+
 describe("parseTranscript", () => {
   it("skips non-JSON and truncated lines", () => {
     const events = parseTranscript('npm warn something\n{"type":"assistant","message":{"content":[]}}\n{"type":"resu');
@@ -34,6 +59,94 @@ describe("parseTranscript", () => {
     const events = parseTranscript(await readFile(cannedTranscriptPath, "utf8"));
     expect(countTurns(events)).toBe(7);
     expect(totalCostUsd(events)).toBeCloseTo(1.87);
+  });
+
+  it("sums turns and cost across resumed invocations (one result event each)", () => {
+    const events: TranscriptEvent[] = [
+      init("s1"),
+      text("Cloud or BYO?"),
+      result(REAL_ASK_BYO_OR_CLOUD, { num_turns: 3, total_cost_usd: 0.4, duration_ms: 60_000 }),
+      init("s1"),
+      bash("npx vendo doctor --json"),
+      result(STAR_ASK_TEXT, { num_turns: 9, total_cost_usd: 1.1, duration_ms: 240_000 }),
+    ];
+    expect(countTurns(events)).toBe(12);
+    expect(totalCostUsd(events)).toBeCloseTo(1.5);
+  });
+
+  it("still counts assistant events for an invocation whose result was cut off", () => {
+    const events: TranscriptEvent[] = [
+      init("s1"),
+      result(REAL_ASK_BYO_OR_CLOUD, { num_turns: 3, total_cost_usd: 0.4 }),
+      init("s1"),
+      bash("npm install vendoai"),
+      bash("npx vendo init --yes --auth none --byo"),
+      // timed out: no second result event
+    ];
+    expect(countTurns(events)).toBe(5);
+    expect(totalCostUsd(events)).toBeCloseTo(0.4);
+  });
+});
+
+describe("detectsKeyQuestion", () => {
+  it("matches the real byo-or-cloud-key ask (live run, invoify)", () => {
+    expect(detectsKeyQuestion(REAL_ASK_BYO_OR_CLOUD)).toBe(true);
+  });
+
+  it("matches the real playbook-mandated ask (live run, express-host)", () => {
+    expect(detectsKeyQuestion(REAL_ASK_PLAYBOOK_MANDATE)).toBe(true);
+  });
+
+  it("never matches the star ask — that question is the run's terminal step", () => {
+    expect(detectsKeyQuestion(STAR_ASK_TEXT)).toBe(false);
+  });
+
+  it("does not match a doctor-green completion summary", () => {
+    expect(detectsKeyQuestion(DOCTOR_GREEN_TEXT)).toBe(false);
+  });
+
+  it("does not match key-topic prose that is not awaiting input", () => {
+    expect(detectsKeyQuestion("I will use the bring-your-own key path since .env.local already has one.")).toBe(false);
+    expect(detectsKeyQuestion("")).toBe(false);
+  });
+
+  it("does not match a star ask that happens to mention the key setup", () => {
+    expect(detectsKeyQuestion(
+      "Doctor is green with your bring-your-own key. Want me to star runvendo/vendo on GitHub?",
+    )).toBe(false);
+  });
+});
+
+describe("evaluateAskGate", () => {
+  it("is not-reached when the run never ends on the key question", async () => {
+    const events = parseTranscript(await readFile(cannedTranscriptPath, "utf8"));
+    expect(evaluateAskGate(events)).toBe("not-reached");
+    expect(evaluateAskGate([])).toBe("not-reached");
+  });
+
+  it("is reached-terminal when the run ends awaiting the key answer", () => {
+    expect(evaluateAskGate([init("s1"), result(REAL_ASK_BYO_OR_CLOUD)])).toBe("reached-terminal");
+  });
+
+  it("is reached-and-answered when a scripted reply let the run continue past the gate", () => {
+    const events: TranscriptEvent[] = [
+      init("s1"),
+      result(REAL_ASK_PLAYBOOK_MANDATE),
+      init("s1"),
+      bash("npx vendo doctor --json"),
+      result(STAR_ASK_TEXT),
+    ];
+    expect(evaluateAskGate(events)).toBe("reached-and-answered");
+  });
+
+  it("is reached-terminal when the agent asks again after the scripted reply", () => {
+    const events: TranscriptEvent[] = [
+      init("s1"),
+      result(REAL_ASK_BYO_OR_CLOUD),
+      init("s1"),
+      result(REAL_ASK_PLAYBOOK_MANDATE),
+    ];
+    expect(evaluateAskGate(events)).toBe("reached-terminal");
   });
 });
 
@@ -170,6 +283,19 @@ describe("scoreFixtureRun", () => {
     expect(metrics.turns).toBe(7);
     expect(metrics.withinTurnBudget).toBe(true);
     expect(metrics.askedBeforeAccount.pass).toBe(true);
+    expect(metrics.askGate).toBe("not-reached");
     expect(metrics.violations).toHaveLength(0);
+  });
+
+  it("marks a run that ended at the ask gate as reached-terminal", () => {
+    const metrics = scoreFixtureRun({
+      fixture: "live",
+      events: [init("s1"), text(REAL_ASK_BYO_OR_CLOUD), result(REAL_ASK_BYO_OR_CLOUD, { num_turns: 4 })],
+      doctor: { ran: true, green: false, failingCodes: ["E-WIRE-001"] },
+      finalToolState: { toolNames: [], referencedToolNames: [] },
+      turnBudget: 40,
+      agentExit: { code: 0, timedOut: false },
+    });
+    expect(metrics.askGate).toBe("reached-terminal");
   });
 });

--- a/corpus/harness/src/install-eval/score.ts
+++ b/corpus/harness/src/install-eval/score.ts
@@ -3,6 +3,8 @@ import {
   assistantToolUses,
   countTurns,
   durationMs,
+  finalAssistantText,
+  invocationSegments,
   totalCostUsd,
   type TranscriptEvent,
 } from "./transcript.js";
@@ -44,6 +46,16 @@ export interface Violation {
   detail: string;
 }
 
+/** Where the run stood relative to the playbook's mandated stop-and-ask
+ * Cloud-vs-BYO gate:
+ * - `not-reached` — no invocation ever ENDED awaiting the key answer (the
+ *   agent either never gated, or asked mid-run and continued on its own);
+ * - `reached-and-answered` — an invocation ended on the key question and the
+ *   runner's ONE scripted-human reply let a later invocation finish past it;
+ * - `reached-terminal` — the run's last invocation ended still awaiting the
+ *   key answer (single-shot behavior, or a second ask after the reply). */
+export type AskGateOutcome = "not-reached" | "reached-and-answered" | "reached-terminal";
+
 export interface FixtureRunMetrics {
   fixture: string;
   doctor: DoctorOutcome;
@@ -53,6 +65,7 @@ export interface FixtureRunMetrics {
   costUsd: number | null;
   durationMs: number | null;
   askedBeforeAccount: AskedBeforeAccountOutcome;
+  askGate: AskGateOutcome;
   violations: Violation[];
   agentExit: { code: number | null; timedOut: boolean };
 }
@@ -204,6 +217,47 @@ export function findStarAskViolations(events: readonly TranscriptEvent[]): Viola
   }];
 }
 
+/** Topic gate for the mandated Cloud-vs-BYO question. Deliberately generous
+ * (a bare `key` counts): the scripted reply is cheap and harmless, while a
+ * missed ask strands the run at the gate. The star ask is excluded below. */
+const KEY_QUESTION_TOPIC_PATTERN = /\b(cloud|byo|bring[- ]your[- ]own|key)\b/i;
+
+/** "Ends awaiting input": a trailing question mark, or a handoff phrase in
+ * the tail (live asks sometimes end declaratively — "Let me know which…"). */
+const AWAITING_INPUT_PATTERN =
+  /(\?\s*$)|\blet me know\b|\bwant me to\b|\bshould i\b|\bwhich (?:do|would|should|one|option)\b|\byour (?:call|choice|decision|preference)\b|\bhow (?:do|would) you want\b/i;
+
+/**
+ * Is this final assistant text the playbook-mandated Cloud-vs-BYO / model-key
+ * question, left hanging for the human? Pure text heuristic used by BOTH the
+ * agent runner (to send its one scripted-human reply) and `evaluateAskGate`.
+ * The star ask is explicitly out: it is the run's terminal step — a transcript
+ * ending there is complete, and answering it would spend money re-entering a
+ * finished session.
+ */
+export function detectsKeyQuestion(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return false;
+  if (STAR_WORD_PATTERN.test(trimmed) && /runvendo\/vendo/i.test(trimmed)) return false;
+  if (!KEY_QUESTION_TOPIC_PATTERN.test(trimmed)) return false;
+  return AWAITING_INPUT_PATTERN.test(trimmed.slice(-300));
+}
+
+/** Classify the run against the mandated ask gate (see `AskGateOutcome`).
+ * Pure function of the transcript: each `claude` invocation (initial run or
+ * scripted-human `--resume`) is one segment, and what matters is whether a
+ * segment ENDED on the key question and whether the run got past it. */
+export function evaluateAskGate(events: readonly TranscriptEvent[]): AskGateOutcome {
+  const segments = invocationSegments(events);
+  if (segments.length === 0) return "not-reached";
+  const endedOnKeyQuestion = segments.map((segment) => {
+    const text = finalAssistantText(segment);
+    return text !== null && detectsKeyQuestion(text);
+  });
+  if (endedOnKeyQuestion[endedOnKeyQuestion.length - 1]) return "reached-terminal";
+  return endedOnKeyQuestion.some(Boolean) ? "reached-and-answered" : "not-reached";
+}
+
 export interface ScoreFixtureRunOptions {
   fixture: string;
   events: readonly TranscriptEvent[];
@@ -224,6 +278,7 @@ export function scoreFixtureRun(options: ScoreFixtureRunOptions): FixtureRunMetr
     costUsd: totalCostUsd(options.events),
     durationMs: durationMs(options.events),
     askedBeforeAccount: evaluateAskedBeforeAccount(options.events),
+    askGate: evaluateAskGate(options.events),
     violations: [
       ...findScaffoldViolations(options.events),
       ...findInventedToolViolations(options.finalToolState),

--- a/corpus/harness/src/install-eval/transcript.ts
+++ b/corpus/harness/src/install-eval/transcript.ts
@@ -84,29 +84,85 @@ export function assistantTexts(events: readonly TranscriptEvent[]): AssistantTex
       }
     }
   });
-  // The final result payload is the message the human actually reads — it
-  // counts as assistant text (the star ask usually lands there).
-  const result = events.find((event) => event.type === "result");
-  if (result && typeof result.result === "string" && result.result.trim().length > 0) {
-    texts.push({ eventIndex: events.indexOf(result), text: result.result });
+  // Result payloads are the messages the human actually reads — they count
+  // as assistant text (the star ask usually lands in the LAST one; a
+  // scripted-human run has one result event per invocation).
+  events.forEach((event, eventIndex) => {
+    if (event.type === "result" && typeof event.result === "string" && event.result.trim().length > 0) {
+      texts.push({ eventIndex, text: event.result });
+    }
+  });
+  return texts.sort((a, b) => a.eventIndex - b.eventIndex);
+}
+
+/** Split a transcript into per-invocation segments. Each `claude` invocation
+ * (the initial `-p` run and any scripted-human `--resume` continuation, which
+ * appends to the same transcript file) opens with a `system/init` event. */
+export function invocationSegments(events: readonly TranscriptEvent[]): TranscriptEvent[][] {
+  if (events.length === 0) return [];
+  const segments: TranscriptEvent[][] = [];
+  let current: TranscriptEvent[] = [];
+  for (const event of events) {
+    if (event.type === "system" && event.subtype === "init" && current.length > 0) {
+      segments.push(current);
+      current = [];
+    }
+    current.push(event);
   }
-  return texts;
+  segments.push(current);
+  return segments;
 }
 
-/** Turn count: trust the result event when present, else count assistant
- * messages (a timed-out run has no result event). */
+/** The last thing the human would have read from one invocation: the result
+ * payload when present, else the last assistant text (timed-out runs have no
+ * result event). */
+export function finalAssistantText(events: readonly TranscriptEvent[]): string | null {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index]!;
+    if (event.type === "result" && typeof event.result === "string" && event.result.trim().length > 0) {
+      return event.result;
+    }
+  }
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index]!;
+    if (event.type !== "assistant") continue;
+    const blocks = contentBlocks(event);
+    for (let blockIndex = blocks.length - 1; blockIndex >= 0; blockIndex -= 1) {
+      const block = blocks[blockIndex]!;
+      if (block.type === "text" && typeof block.text === "string" && block.text.trim().length > 0) {
+        return block.text;
+      }
+    }
+  }
+  return null;
+}
+
+/** Turn count, summed across invocations: per segment trust the result event
+ * when present, else count assistant messages (a timed-out invocation has no
+ * result event). A scripted-human continuation therefore spends from the SAME
+ * turn budget as the first invocation. */
 export function countTurns(events: readonly TranscriptEvent[]): number {
-  const result = events.find((event) => event.type === "result");
-  if (result && typeof result.num_turns === "number") return result.num_turns;
-  return events.filter((event) => event.type === "assistant").length;
+  return invocationSegments(events).reduce((sum, segment) => {
+    const result = segment.find((event) => event.type === "result");
+    if (result && typeof result.num_turns === "number") return sum + result.num_turns;
+    return sum + segment.filter((event) => event.type === "assistant").length;
+  }, 0);
 }
 
+function sumResultField(events: readonly TranscriptEvent[], field: "total_cost_usd" | "duration_ms"): number | null {
+  const values = events
+    .filter((event) => event.type === "result")
+    .map((event) => event[field])
+    .filter((value): value is number => typeof value === "number");
+  return values.length === 0 ? null : values.reduce((sum, value) => sum + value, 0);
+}
+
+/** Total cost, summed across invocations (each result event reports its own
+ * invocation's spend). */
 export function totalCostUsd(events: readonly TranscriptEvent[]): number | null {
-  const result = events.find((event) => event.type === "result");
-  return result && typeof result.total_cost_usd === "number" ? result.total_cost_usd : null;
+  return sumResultField(events, "total_cost_usd");
 }
 
 export function durationMs(events: readonly TranscriptEvent[]): number | null {
-  const result = events.find((event) => event.type === "result");
-  return result && typeof result.duration_ms === "number" ? result.duration_ms : null;
+  return sumResultField(events, "duration_ms");
 }


### PR DESCRIPTION
Closes #480. The runner now answers the playbook-mandated Cloud-vs-BYO question exactly once via `claude -p --resume` (structural one-reply cap; star ask explicitly excluded from detection), sums turns/cost/duration across both invocations, and scores a new `askGate` field (not-reached | reached-and-answered | reached-terminal) with an Ask-gate report column. Also fixes a latent scoring bug: `assistantTexts` only read the FIRST invocation's result payload, so multi-invocation runs false-flagged skipped-star-ask. Sessions now use harness-minted `--session-id` (no --no-session-persistence); CLI has no delete flag, noted in agent.ts. Tests: install-eval 66/66, full harness 278/278, tsc clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables install-eval runs to continue past the playbook’s Cloud-vs-BYO key gate by sending exactly one scripted-human `--resume` reply, so doctor scoring is reachable. Adds `askGate` scoring and fixes multi-invocation transcript handling and star-ask detection (addresses #480).

- **New Features**
  - Detects the key question (`detectsKeyQuestion`) and resumes once with `claude -p --resume <session-id>` using a fixed BYO answer; never answers the star ask; never resumes after a timeout/error.
  - Uses harness-minted `--session-id` (sessions persist; no `--no-session-persistence`); appends the continuation to the same transcript; logs scripted reply count.
  - Sums turns, cost, and duration across invocations; adds `askGate` with `not-reached | reached-and-answered | reached-terminal` and shows it in the report table.

- **Bug Fixes**
  - `assistantTexts` now reads result payloads from all invocations, fixing false “skipped-star-ask” flags on multi-invocation runs.
  - Transcript utilities (`countTurns`, `totalCostUsd`, `durationMs`, `finalAssistantText`, `invocationSegments`) correctly handle resumed sessions and timed-out runs.

<sup>Written for commit 8c2246fccf42f96e1ad5d6a86d2849018e68bd18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

