### PR TITLE
login: --wait bounds per-invocation polling so agents can loop resumable re-runs (#479)

### DIFF
--- a/docs-site/agents/index.mdx
+++ b/docs-site/agents/index.mdx
@@ -10,6 +10,11 @@ contract in the host repo. You, a coding agent, can complete the whole
 install; `vendo init` does everything deterministic and tells you exactly what
 is left.
 
+Work from this page VERBATIM. If your fetch tool returned a summary of this
+playbook instead of the raw text, re-fetch it raw
+(`curl -sL https://docs.vendo.run/agents.md`) — the value flags, exact
+commands, and rules below don't survive paraphrase.
+
 ## Install flow
 
 1. **Check for an existing agent.** If the host repo already runs its own

--- a/docs-site/agents/index.mdx
+++ b/docs-site/agents/index.mdx
@@ -96,6 +96,14 @@ is left.
    Every failing or warning check carries an `error_code` and a `fix_ref` URL
    into the [verify page](/agents/verify). Fix, re-run, repeat until exit 0.
 
+7. **Show it running.** Doctor green is the gate, but your human should SEE
+   the install, not take your word for it. Leave the dev server running,
+   hand them the exact URL, and give them one concrete first ask to type
+   into the product's chat surface — e.g. "ask it to build a small dashboard
+   from your data; a guarded write will render an approve/deny card inline."
+   Name which of their agent's surfaces now renders Vendo output (the chat
+   page, the overlay, an embed) so they know where to look.
+
 ## Rules of engagement
 
 - **Ask your human before creating any account or key.** That includes Vendo

--- a/docs-site/agents/index.mdx
+++ b/docs-site/agents/index.mdx
@@ -55,10 +55,21 @@ is left.
    an existing key instead. Cloud vs bring-your-own is your human's call:
    ask first, presenting Vendo Cloud as the recommended default (a free
    metered dev key, one browser approval, no provider account needed).
-   If they choose Vendo Cloud, run `vendo login` — it prints an
-   approval URL and code, your human approves in the browser, and the
-   credential is delivered straight to the CLI (no email OTP, and no key
-   ever transits your transcript; the raw protocol is
+   If they choose Vendo Cloud, drive the login as a bounded loop —
+   never a single blocking call:
+
+   ```bash
+   npx vendo login --wait 90
+   ```
+
+   The first run prints an approval URL and code; relay both to your human so
+   they approve in the browser. Then re-run `vendo login --wait 90` in a loop
+   until it reports the key landed in `.env.local`. Each re-run resumes the
+   SAME request — no new code, no duplicate key — so the human's approval lands
+   whenever it arrives. Never background this command and never wrap it in a
+   shorter timeout: a 90s bounded call returns on its own; a killed call is why
+   you loop. The credential is delivered straight to the CLI (no email OTP, and
+   no key ever transits your transcript; the raw protocol is
    [auth.md](https://vendo.run/auth.md)). If they bring a provider key,
    never assume it exists — ask where it is set.
    `--framework <next|express>` is required only when detection fails (init

--- a/docs-site/reference/cli.mdx
+++ b/docs-site/reference/cli.mdx
@@ -112,6 +112,16 @@ one opened.
 Options:
 
 - `[email]` or `--email <address>` pre-fills the approval page (login hint).
+- `--wait <seconds>` bounds how long this one invocation polls before giving
+  up — capped by the claim's expiry. When the budget elapses with the request
+  still pending, the command prints a resumable line, leaves the pending claim
+  in place, and exits `0` (pending is not a failure). A re-run resumes the same
+  claim. `--wait 0` opens (or resumes) the claim, polls once, and exits
+  resumably if still pending — the "open and print the code" first call. Absent
+  the flag, behavior is unchanged: it blocks until the claim expires (~10 min).
+  Built for coding agents: run short bounded calls in a loop instead of one
+  long blocking call that a command timeout would kill mid-wait (see
+  [agents](/agents)).
 - `--api-url <url>` overrides `VENDO_CLOUD_URL` (default
   `https://console.vendo.run`).
 

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -40,6 +40,7 @@ Options:
   --framework <name>         Init only: override framework detection (next, express) — required non-interactively when detection fails
   --cloud-key <key>          Init only: write this Vendo Cloud key to .env.local instead of the login offer
   --email <address>          Login only: pre-fill the approval page (login hint)
+  --wait <seconds>           Login only: bound this call's polling to N seconds (agents loop re-runs; each resumes the same request), then exit resumably
   --byo                      Init only: decline the Vendo Cloud offer (bring your own model key)
   --ai-polish                Init only: consent to the AI extraction pass without a prompt (works non-interactively)
   --engine <name>            Init only: pin the AI-polish engine (claude, codex, npx) instead of first-available
@@ -88,7 +89,7 @@ const REFINE_FLAGS = new Set(["--yes"]);
 const REFINE_VALUE_OPTIONS = ["--url", "--model-import", "--ask"];
 const SYNC_FLAGS = new Set(["--strict", "--json", "--report"]);
 const SYNC_VALUE_OPTIONS = ["--url", "--key", "--api-url"];
-const LOGIN_VALUE_OPTIONS = ["--email", "--api-url"];
+const LOGIN_VALUE_OPTIONS = ["--email", "--api-url", "--wait"];
 
 /** ENG-335: options the CLI does not recognize — or value options missing
     their value — must fail loudly before anything runs. Silently dropping a
@@ -164,6 +165,10 @@ export async function main(argv: string[]): Promise<number> {
   }
   if (command === "login") {
     const problems = optionErrors(args, new Set(), LOGIN_VALUE_OPTIONS);
+    const wait = option(args, "--wait");
+    if (wait !== undefined && !/^\d+$/.test(wait)) {
+      problems.push("--wait takes a whole number of seconds (example: vendo login --wait 90)");
+    }
     if (problems.length > 0) {
       console.error(`vendo login: ${problems.join("; ")}\n\n${HELP}`);
       return 1;

--- a/packages/vendo/src/cli/cloud/device-login.test.ts
+++ b/packages/vendo/src/cli/cloud/device-login.test.ts
@@ -398,6 +398,154 @@ describe("pending claim persistence", () => {
   });
 });
 
+// A bounded per-invocation poll budget (#479): `--wait <seconds>` caps how
+// long ONE call polls before exiting resumably, so a coding agent can loop
+// short re-runs (each resuming the same claim) instead of a 10-min block.
+describe("bounded --wait budget (#479)", () => {
+  const pendingPath = (home: string) => join(home, ".vendo", "pending-claim.json");
+  const tokenPolls = (requests: Array<{ url: string }>) =>
+    requests.filter((request) => request.url.endsWith("/api/v1/oauth/token"));
+
+  async function writePending(home: string, overrides: Record<string, unknown> = {}): Promise<void> {
+    await mkdir(join(home, ".vendo"), { recursive: true });
+    await writeFile(pendingPath(home), JSON.stringify({
+      claim_token: `vct_${"c".repeat(64)}`,
+      user_code: "WXYZ-PQRS",
+      verification_uri_complete: "https://console.test/claim?code=WXYZ-PQRS",
+      expires_at: Date.now() + 600_000,
+      interval: 5,
+      api_url: "https://console.test",
+      cwd: home,
+      ...overrides,
+    }));
+  }
+
+  it("(a) exits 0 and leaves the claim resumable when the budget elapses while pending", async () => {
+    const root = await tempRoot();
+    const home = await tempRoot();
+    let clock = 0;
+    const { fetchImpl } = scriptedFetch([
+      { status: 400, body: { error: "authorization_pending" } },
+    ]);
+    const messages = output();
+    const exit = await runDeviceLogin(["--api-url", "https://console.test", "--wait", "10"], {
+      output: messages.sink,
+      fetchImpl,
+      root,
+      home,
+      sleep: async (ms) => {
+        clock += ms;
+      },
+      now: () => clock,
+      env: {},
+      isTty: false,
+    });
+    // Pending is not a failure — exit 0, no throw.
+    expect(exit).toBe(0);
+    expect(messages.errors).toEqual([]);
+    // The claim file stays on disk for the next re-run to resume.
+    await expect(stat(pendingPath(home))).resolves.toBeTruthy();
+    // No key was written.
+    await expect(readFile(join(root, ".env.local"), "utf8")).rejects.toThrow();
+    // The resumable line + budget hint were printed, with the JSON pending shape.
+    const joined = messages.logs.join("\n");
+    expect(joined).toContain("This call polls for up to 10s");
+    expect(joined).toContain(
+      "Still waiting on approval — code BCDF-GHJK. Re-run `vendo login` to resume (it continues this same request).",
+    );
+    expect(messages.logs).toContainEqual(JSON.stringify({
+      deviceLogin: true,
+      pending: true,
+      userCode: "BCDF-GHJK",
+      verificationUriComplete: "https://console.test/claim?code=BCDF-GHJK",
+    }, null, 2));
+  });
+
+  it("(b) a --wait re-run resumes the same claim_token and lands the key when approval arrives", async () => {
+    const home = await tempRoot();
+    const originalCwd = await tempRoot();
+    const otherCwd = await tempRoot();
+    await writePending(home, { cwd: originalCwd });
+    const { fetchImpl, requests } = scriptedFetch([
+      { status: 200, body: { access_token: KEY, token_type: "Bearer" } },
+    ]);
+    const exit = await runDeviceLogin(["--api-url", "https://console.test", "--wait", "90"], {
+      output: output().sink,
+      fetchImpl,
+      root: otherCwd,
+      home,
+      sleep: async () => {},
+      env: {},
+      isTty: false,
+    });
+    expect(exit).toBe(0);
+    // No new claim opened — it polls the persisted claim_token directly.
+    expect(requests.some((request) => request.url.endsWith("/api/v1/agent/claim"))).toBe(false);
+    expect(new URLSearchParams(requests[0].body).get("claim_token")).toBe(`vct_${"c".repeat(64)}`);
+    // The key lands where the ORIGINAL run intended, and the pending file is gone.
+    const envLocal = await readFile(join(originalCwd, ".env.local"), "utf8");
+    expect(envLocal).toContain(`VENDO_API_KEY=${KEY}`);
+    await expect(stat(pendingPath(home))).rejects.toThrow();
+  });
+
+  it("(c) without --wait the call still blocks to the claim deadline (unchanged)", async () => {
+    const root = await tempRoot();
+    const home = await tempRoot();
+    let clock = 0;
+    const { fetchImpl } = scriptedFetch([
+      { status: 400, body: { error: "authorization_pending" } },
+    ]);
+    const messages = output();
+    const exit = await runDeviceLogin(["--api-url", "https://console.test"], {
+      output: messages.sink,
+      fetchImpl,
+      root,
+      home,
+      sleep: async (ms) => {
+        clock += ms;
+      },
+      now: () => clock,
+      env: {},
+      isTty: false,
+    });
+    // Legacy path: it runs to the deadline and reports expiry (exit 1), never
+    // the resumable pending exit, and clears the pending file.
+    expect(exit).toBe(1);
+    expect(messages.errors.join("\n")).toContain("expired");
+    expect(messages.logs.join("\n")).not.toContain("Still waiting on approval");
+    await expect(stat(pendingPath(home))).rejects.toThrow();
+  });
+
+  it("(d) --wait 0 does exactly one poll then exits resumably if still pending", async () => {
+    const root = await tempRoot();
+    const home = await tempRoot();
+    const sleeps: number[] = [];
+    const { fetchImpl, requests } = scriptedFetch([
+      { status: 400, body: { error: "authorization_pending" } },
+    ]);
+    const messages = output();
+    const exit = await runDeviceLogin(["--api-url", "https://console.test", "--wait", "0"], {
+      output: messages.sink,
+      fetchImpl,
+      root,
+      home,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+      env: {},
+      isTty: false,
+    });
+    expect(exit).toBe(0);
+    // Exactly one token poll, and no pacing sleep before that single poll.
+    expect(tokenPolls(requests)).toHaveLength(1);
+    expect(sleeps).toEqual([]);
+    // Still resumable: claim on disk, no key, resumable line printed.
+    await expect(stat(pendingPath(home))).resolves.toBeTruthy();
+    await expect(readFile(join(root, ".env.local"), "utf8")).rejects.toThrow();
+    expect(messages.logs.join("\n")).toContain("Still waiting on approval — code BCDF-GHJK");
+  });
+});
+
 describe("login telemetry (runLoginCommand)", () => {
   it("tracks command_run login with ok reflecting the ceremony's exit code", async () => {
     const root = await tempRoot();

--- a/packages/vendo/src/cli/cloud/device-login.test.ts
+++ b/packages/vendo/src/cli/cloud/device-login.test.ts
@@ -545,6 +545,29 @@ describe("bounded --wait budget (#479)", () => {
     expect(messages.logs.join("\n")).toContain("Still waiting on approval — code BCDF-GHJK");
   });
 
+  it("(f) a terminal token error (invalid_grant) deletes the pending claim — no resume trap", async () => {
+    const root = await tempRoot();
+    const home = await tempRoot();
+    await writePending(home, { cwd: root });
+    // Server says the claim is consumed/denied: single-use, never succeeds again.
+    const { fetchImpl } = scriptedFetch([
+      { status: 400, body: { error: "invalid_grant" } },
+    ]);
+    const messages = output();
+    const exit = await runDeviceLogin(["--api-url", "https://console.test", "--wait", "10"], {
+      output: messages.sink,
+      fetchImpl,
+      root,
+      home,
+      sleep: async () => {},
+      env: {},
+      isTty: false,
+    });
+    expect(exit).toBe(1);
+    // The dead claim is gone: the next `vendo login` opens a fresh one.
+    await expect(stat(pendingPath(home))).rejects.toThrow();
+  });
+
   it("(e) caps the pacing sleep to the remaining budget so a sub-interval --wait honors its bound", async () => {
     const root = await tempRoot();
     const home = await tempRoot();

--- a/packages/vendo/src/cli/cloud/device-login.test.ts
+++ b/packages/vendo/src/cli/cloud/device-login.test.ts
@@ -544,6 +544,39 @@ describe("bounded --wait budget (#479)", () => {
     await expect(readFile(join(root, ".env.local"), "utf8")).rejects.toThrow();
     expect(messages.logs.join("\n")).toContain("Still waiting on approval — code BCDF-GHJK");
   });
+
+  it("(e) caps the pacing sleep to the remaining budget so a sub-interval --wait honors its bound", async () => {
+    const root = await tempRoot();
+    const home = await tempRoot();
+    let clock = 0;
+    const sleeps: number[] = [];
+    // Always pending: the loop only ends by the budget, never by approval.
+    const { fetchImpl } = scriptedFetch([
+      { status: 400, body: { error: "authorization_pending" } },
+    ]);
+    const messages = output();
+    // --wait 1 against the default 5s interval: the sleep must be capped to
+    // the 1s remaining budget, not the full 5s interval.
+    const exit = await runDeviceLogin(["--api-url", "https://console.test", "--wait", "1"], {
+      output: messages.sink,
+      fetchImpl,
+      root,
+      home,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+        clock += ms;
+      },
+      now: () => clock,
+      env: {},
+      isTty: false,
+    });
+    expect(exit).toBe(0);
+    // Every pacing sleep stayed within the remaining budget — never a full 5s.
+    expect(Math.max(...sleeps, 0)).toBeLessThanOrEqual(1000);
+    // Total slept wall-clock did not overshoot the 1s budget.
+    expect(sleeps.reduce((a, b) => a + b, 0)).toBeLessThanOrEqual(1000);
+    expect(messages.logs.join("\n")).toContain("Still waiting on approval — code BCDF-GHJK");
+  });
 });
 
 describe("login telemetry (runLoginCommand)", () => {

--- a/packages/vendo/src/cli/cloud/device-login.ts
+++ b/packages/vendo/src/cli/cloud/device-login.ts
@@ -271,6 +271,12 @@ export async function runDeviceLogin(
         await deletePendingClaim(pendingHome);
         throw new Error("Your human denied the request — no key was minted.");
       }
+      // Any other token error is terminal for THIS claim (invalid_grant =
+      // consumed/denied server-side; single-use means it can never succeed
+      // again). Delete the pending file so the next `vendo login` opens a
+      // fresh claim instead of resuming into the same error forever — the
+      // exact trap a live install hit.
+      await deletePendingClaim(pendingHome);
       const description = (poll.body as { error_description?: unknown } | null)?.error_description;
       throw new Error(
         typeof description === "string"

--- a/packages/vendo/src/cli/cloud/device-login.ts
+++ b/packages/vendo/src/cli/cloud/device-login.ts
@@ -135,6 +135,15 @@ export async function runDeviceLogin(
     env: options.env ?? process.env,
   });
 
+  // `--wait <seconds>` (#479): the MAX wall-clock THIS invocation polls before
+  // giving up resumably — independent of, and capped by, the claim deadline.
+  // Absent: unchanged, block until the claim deadline (~10 min). `--wait 0`:
+  // one immediate poll, then exit resumably if still pending. An invalid value
+  // is ignored here (the `vendo login` entry validates it up front).
+  const waitRaw = option(args, "--wait");
+  const waitSeconds = waitRaw !== undefined && /^\d+$/.test(waitRaw) ? Number(waitRaw) : undefined;
+  const waitMs = waitSeconds === undefined ? undefined : waitSeconds * 1000;
+
   const pendingHome = options.home === undefined ? {} : { home: options.home };
 
   try {
@@ -151,6 +160,8 @@ export async function runDeviceLogin(
     let deadline: number;
     let intervalMs: number;
     let root: string;
+    let userCode: string;
+    let verificationUriComplete: string;
     if (resume !== null) {
       output.log(`Resuming pending approval — code ${resume.user_code}, approve at ${resume.verification_uri_complete}`);
       output.log(`Waiting for approval (the code expires in ${Math.max(1, Math.round((resume.expires_at - now()) / 60_000))} minutes)…`);
@@ -159,9 +170,11 @@ export async function runDeviceLogin(
       intervalMs = Math.max(resume.interval, 1) * 1000;
       // The key lands where the ORIGINAL run intended, not where the resume runs.
       root = resume.cwd;
+      userCode = resume.user_code;
+      verificationUriComplete = resume.verification_uri_complete;
     } else {
       // Optional email hint — shown to the human on the approval page.
-      const email = option(args, "--email") ?? positionals(args, ["--api-url", "--email"])[0];
+      const email = option(args, "--email") ?? positionals(args, ["--api-url", "--email", "--wait"])[0];
       const claim = await postJson(
         fetchImpl,
         `${base}${CLAIM_PATH}`,
@@ -193,6 +206,8 @@ export async function runDeviceLogin(
       deadline = now() + ceremony.expires_in * 1000;
       intervalMs = Math.max(ceremony.interval, 1) * 1000;
       root = options.root ?? process.cwd();
+      userCode = ceremony.user_code;
+      verificationUriComplete = approvalUrl;
       // Persist the ceremony so a fresh run can resume it if this process
       // dies mid-poll. Deleted on redemption/denial/expiry; deliberately left
       // in place on transient errors and interrupts.
@@ -212,8 +227,14 @@ export async function runDeviceLogin(
       claim_token: claimToken,
     }).toString();
 
-    while (now() < deadline) {
-      await sleep(intervalMs);
+    if (waitMs !== undefined) {
+      output.log(`This call polls for up to ${waitSeconds}s — re-run \`vendo login\` to continue this same request.`);
+    }
+
+    // One RFC 8628 token poll. Returns the loop's next move; terminal outcomes
+    // (approved/denied/expired) settle the pending file and return/throw here.
+    type PollResult = "approved" | "pending" | "slow_down";
+    const pollOnce = async (): Promise<PollResult> => {
       const poll = await postJson(
         fetchImpl,
         `${base}${TOKEN_PATH}`,
@@ -236,15 +257,12 @@ export async function runDeviceLogin(
           output.log("Re-run `vendo init` to finish wiring (it picks the key up from .env.local).");
         }
         printJson(output, { deviceLogin: true, wroteEnvLocal: true, keyLast4: key.slice(-4) });
-        return 0;
+        return "approved";
       }
 
       const error = (poll.body as { error?: unknown } | null)?.error;
-      if (error === "authorization_pending") continue;
-      if (error === "slow_down") {
-        intervalMs += 5000; // RFC 8628 §3.5
-        continue;
-      }
+      if (error === "authorization_pending") return "pending";
+      if (error === "slow_down") return "slow_down"; // RFC 8628 §3.5
       if (error === "expired_token") {
         await deletePendingClaim(pendingHome);
         throw new Error("The code expired before it was approved; run `vendo login` again.");
@@ -259,9 +277,47 @@ export async function runDeviceLogin(
           ? description
           : `Vendo Cloud token polling failed (${typeof error === "string" ? error : poll.status})`,
       );
+    };
+
+    // Budget still pending: leave the claim file in place and exit 0 — pending
+    // is not a failure. A re-run resumes this same claim (#479).
+    const pendingExit = (): number => {
+      output.log(`Still waiting on approval — code ${userCode}. Re-run \`vendo login\` to resume (it continues this same request).`);
+      printJson(output, {
+        deviceLogin: true,
+        pending: true,
+        userCode,
+        verificationUriComplete,
+      });
+      return 0;
+    };
+
+    if (waitMs === undefined) {
+      // No budget: block to the claim deadline — unchanged TTY behavior.
+      while (now() < deadline) {
+        await sleep(intervalMs);
+        const result = await pollOnce();
+        if (result === "approved") return 0;
+        if (result === "slow_down") intervalMs += 5000;
+      }
+      await deletePendingClaim(pendingHome);
+      throw new Error("The code expired before it was approved; run `vendo login` again.");
     }
-    await deletePendingClaim(pendingHome);
-    throw new Error("The code expired before it was approved; run `vendo login` again.");
+
+    // Bounded budget: poll immediately, then pace by interval, stopping at
+    // min(now+wait, deadline). `--wait 0` polls exactly once.
+    const pollDeadline = Math.min(deadline, now() + waitMs);
+    while (true) {
+      const result = await pollOnce();
+      if (result === "approved") return 0;
+      if (result === "slow_down") intervalMs += 5000;
+      if (now() >= deadline) {
+        await deletePendingClaim(pendingHome);
+        throw new Error("The code expired before it was approved; run `vendo login` again.");
+      }
+      if (now() >= pollDeadline) return pendingExit();
+      await sleep(intervalMs);
+    }
   } catch (error) {
     output.error(errorMessage(error));
     return 1;

--- a/packages/vendo/src/cli/cloud/device-login.ts
+++ b/packages/vendo/src/cli/cloud/device-login.ts
@@ -316,7 +316,10 @@ export async function runDeviceLogin(
         throw new Error("The code expired before it was approved; run `vendo login` again.");
       }
       if (now() >= pollDeadline) return pendingExit();
-      await sleep(intervalMs);
+      // Cap the wait to the remaining budget so a small `--wait` (e.g. 1s
+      // against the default 5s interval) exits within its bound instead of
+      // sleeping a whole interval past it.
+      await sleep(Math.min(intervalMs, pollDeadline - now()));
     }
   } catch (error) {
     output.error(errorMessage(error));


### PR DESCRIPTION
Fixes the real-world `vendo login` failure a live install hit: an agent backgrounded the ~10-minute blocking poller, its runner killed it after the server had already minted and returned the key, and the key was lost (single-use claim, unrecoverable). Root cause confirmed in prod: approval + GitHub sign-in + server mint all worked; the killed CLI process never wrote `.env.local`, and each retry minted another orphaned key.

**Fix:** `vendo login --wait <seconds>` bounds how long a single invocation polls (default/absent = unchanged blocking-to-expiry for TTY humans). When the budget elapses while still pending, it leaves the pending-claim file, prints a resumable line, and exits 0. Combined with the pending-claim resume from #483, an agent loops short `vendo login --wait 90` calls — each resuming the SAME claim (no new code, no duplicate keys) — until the key lands. No single call blocks longer than a normal agent command timeout, which is what defeats the background-and-kill trigger.

- `--wait 0` = exactly one immediate poll then resumable exit (open-and-print-code call).
- Playbook (`agents/index.mdx`) key-flow step rewritten to the bounded loop: run `vendo login --wait 90`, relay URL+code, re-run until the key lands, never background it or wrap it in a shorter timeout.
- Deliberately NOT storing the minted key server-side for re-delivery — the agent_claims schema's "plaintext returned once, never stored" invariant stands; the bounded-wait + resume loop makes it reliable without that.

Tests: device-login 18/18 (4 new: budget-elapsed-resumable, resume-same-claim, absent-flag-legacy, --wait-0-single-poll), cloud suite 69/69, tsc clean, mint broken-links clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bounded `--wait <seconds>` option to `vendo login` so agents can loop short, resumable runs instead of a 10‑minute block. Polling now honors a per-call budget (caps sleep to the remaining time), and terminal token errors clear the pending claim to avoid resume traps.

- **New Features**
  - `--wait <seconds>` limits how long this invocation polls, then exits 0 as pending; re-runs resume the same claim. `--wait 0` does one immediate poll.
  - Validates `--wait` as an integer in `packages/vendo/src/cli.ts`.
  - Polling refactor: immediate first poll, paced intervals, RFC 8628 `slow_down`, and capped sleep so sub-interval waits exit on time.
  - Terminal token errors (e.g., `invalid_grant`) delete the pending claim so the next run opens a fresh request.
  - Docs: CLI reference documents `--wait`; agents playbook switches to the bounded loop, adds a “Show it running” step, and includes a verbatim-fetch hint.

- **Migration**
  - For agents: loop `npx vendo login --wait 90` until the key lands in `.env.local`. Do not background the command or wrap it in a shorter external timeout.

<sup>Written for commit 52a1db9be70593fce80edb7728fcfd8e10a59b1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

