### PR TITLE
existing-agents: host-model credential warning + real-turn done proof

### DIFF
--- a/docs-site/existing-agents/ai-sdk.mdx
+++ b/docs-site/existing-agents/ai-sdk.mdx
@@ -109,6 +109,17 @@ case "dynamic-tool":
 
 ## Try it
 
+<Warning>
+  Your agent's OWN model still needs its own credential — `VENDO_API_KEY`
+  powers Vendo's internal turns (app builds, the delegate), never your loop.
+  If the starter's model has no key on this machine (e.g. no
+  `OPENAI_API_KEY`), either set one or point your agent's `model` at
+  `devModel()` from `@vendoai/vendo/server` to ride the same Vendo Cloud
+  credential. The done-criterion is a REAL chat turn that renders a Vendo
+  tool output — run ask 2 yourself before calling the install done; doctor
+  cannot check your loop's model.
+</Warning>
+
 One thread, three asks:
 
 1. **"What's the weather in Paris?"** A guarded read: the guard runs it,

--- a/docs-site/existing-agents/mastra.mdx
+++ b/docs-site/existing-agents/mastra.mdx
@@ -133,6 +133,17 @@ the embed contract is framework-agnostic.
 
 ## Try it
 
+<Warning>
+  Your agent's OWN model still needs its own credential — `VENDO_API_KEY`
+  powers Vendo's internal turns (app builds, the delegate), never your loop.
+  If the starter's model has no key on this machine (e.g. no
+  `OPENAI_API_KEY`), either set one or point your agent's `model` at
+  `devModel()` from `@vendoai/vendo/server` to ride the same Vendo Cloud
+  credential. The done-criterion is a REAL chat turn that renders a Vendo
+  tool output — run ask 2 yourself before calling the install done; doctor
+  cannot check your loop's model.
+</Warning>
+
 One thread, three asks:
 
 1. **"What's the weather in Paris?"** Your agent's own tool, untouched.


### PR DESCRIPTION
From live dogfooding: a BYO install went doctor-green while the host's own Mastra loop was unrunnable (starter model = openai/gpt-4.1-mini, no OPENAI_API_KEY on the machine) — first user message failed. Doctor can't check the host loop's model credential (any provider), so both BYO walkthroughs now carry a Warning before Try-it: your agent's own model needs its own key (or point it at devModel() to ride the Vendo Cloud credential), and the done-criterion is a REAL chat turn rendering a Vendo tool output — run ask 2 before declaring done. mint broken-links green.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Try-it warning to existing-agents (`ai-sdk.mdx`, `mastra.mdx`) about host model credentials and the done check. Your agent’s model needs its own key (e.g., `OPENAI_API_KEY`) or use `devModel()` from `@vendoai/vendo/server`; `VENDO_API_KEY` only powers Vendo internals, and completion now requires a real chat turn showing a Vendo tool output.

<sup>Written for commit 26a5ea138795471480c4e5adc365507b1c42d385. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

