### PR TITLE
actions(route-scan): rejection-guard Allow headers are not verb evidence

### DIFF
--- a/packages/actions/src/sync/route-scan.test.ts
+++ b/packages/actions/src/sync/route-scan.test.ts
@@ -262,6 +262,115 @@ describe("pages route verb evidence", () => {
     });
   });
 
+  it("does not treat a rejection branch's Allow header as verb evidence (papermark 405-guard shapes)", async () => {
+    const root = await temporaryRoot();
+    // Real shape from papermark's pages/api/teams/[teamId]/documents/agreement.ts:
+    // POST-only handler; the else/405 branch lists GET *and* POST in its
+    // Allow header even though GET is never served.
+    await write(
+      root,
+      "pages/api/teams/[teamId]/documents/agreement.ts",
+      [
+        "export default async function handle(req: any, res: any) {",
+        "  if (req.method === \"POST\") {",
+        "    return res.status(201).json({ ok: true });",
+        "  } else {",
+        "    res.setHeader(\"Allow\", [\"GET\", \"POST\"]);",
+        "    return res.status(405).end(`Method ${req.method} Not Allowed`);",
+        "  }",
+        "}",
+      ].join("\n"),
+    );
+    // Real shape from papermark's pages/api/teams/[teamId]/documents/[id]/versions/index.ts:
+    // POST-only handler; the else/405 branch's Allow header names GET alone.
+    await write(
+      root,
+      "pages/api/teams/[teamId]/documents/[id]/versions/index.ts",
+      [
+        "export default async function handle(req: any, res: any) {",
+        "  if (req.method === \"POST\") {",
+        "    return res.status(200).json({ id: \"x\" });",
+        "  } else {",
+        "    res.setHeader(\"Allow\", [\"GET\"]);",
+        "    return res.status(405).end(`Method ${req.method} Not Allowed`);",
+        "  }",
+        "}",
+      ].join("\n"),
+    );
+    // Real shape from papermark's pages/api/teams/[teamId]/datarooms/[id]/folders/[...name].ts:
+    // GET-only handler; the else/405 branch's Allow header names GET *and* POST.
+    await write(
+      root,
+      "pages/api/teams/[teamId]/datarooms/[id]/folders/[...name].ts",
+      [
+        "export default async function handle(req: any, res: any) {",
+        "  if (req.method === \"GET\") {",
+        "    return res.status(200).json([]);",
+        "  } else {",
+        "    res.setHeader(\"Allow\", [\"GET\", \"POST\"]);",
+        "    return res.status(405).end(`Method ${req.method} Not Allowed`);",
+        "  }",
+        "}",
+      ].join("\n"),
+    );
+    // Real shape from papermark's pages/api/teams/[teamId]/datarooms/[id]/folders/parents/[...name].ts:
+    // identical shape to the folders route above, different path.
+    await write(
+      root,
+      "pages/api/teams/[teamId]/datarooms/[id]/folders/parents/[...name].ts",
+      [
+        "export default async function handle(req: any, res: any) {",
+        "  if (req.method === \"GET\") {",
+        "    return res.status(200).json([]);",
+        "  } else {",
+        "    res.setHeader(\"Allow\", [\"GET\", \"POST\"]);",
+        "    return res.status(405).end(`Method ${req.method} Not Allowed`);",
+        "  }",
+        "}",
+      ].join("\n"),
+    );
+    // Positive control: an inequality guard whose Allow header lives inside
+    // the REJECTED (`!==`) branch — the guarded method (POST) still passes
+    // through as evidence, and the Allow header inside the guard must not
+    // add any other phantom method (there isn't one here, but the header
+    // must not be double-counted or otherwise misread).
+    await write(
+      root,
+      "pages/api/neq-guard.ts",
+      [
+        "export default async function handle(req: any, res: any) {",
+        "  if (req.method !== \"POST\") {",
+        "    res.setHeader(\"Allow\", [\"POST\"]);",
+        "    return res.status(405).end();",
+        "  }",
+        "  return res.status(200).end();",
+        "}",
+      ].join("\n"),
+    );
+    // Equality-dispatch control: a plain `if/else` with no Allow header at
+    // all must keep working exactly as before the fix.
+    await write(
+      root,
+      "pages/api/put-only.ts",
+      [
+        "export default async function handle(req: any, res: any) {",
+        "  if (req.method === \"PUT\") {",
+        "    return res.status(200).end();",
+        "  } else {",
+        "    return res.status(405).end();",
+        "  }",
+        "}",
+      ].join("\n"),
+    );
+
+    expect(await methodsFor(root, "/api/teams/{teamId}/documents/agreement")).toEqual(["POST"]);
+    expect(await methodsFor(root, "/api/teams/{teamId}/documents/{id}/versions")).toEqual(["POST"]);
+    expect(await methodsFor(root, "/api/teams/{teamId}/datarooms/{id}/folders/{name}")).toEqual(["GET"]);
+    expect(await methodsFor(root, "/api/teams/{teamId}/datarooms/{id}/folders/parents/{name}")).toEqual(["GET"]);
+    expect(await methodsFor(root, "/api/neq-guard")).toEqual(["POST"]);
+    expect(await methodsFor(root, "/api/put-only")).toEqual(["PUT"]);
+  });
+
   it("treats a NextAuth handler as GET+POST", async () => {
     const root = await temporaryRoot();
     await write(

--- a/packages/actions/src/sync/route-scan.ts
+++ b/packages/actions/src/sync/route-scan.ts
@@ -127,10 +127,63 @@ function isReqMethodAccess(ts: typeof TS, node: TS.Node): boolean {
     && node.expression.text === "req";
 }
 
+interface ReqMethodComparison {
+  operator: "eq" | "neq";
+  method: string;
+}
+
+/** Recognizes `req.method === "X"` / `!==` / `==` / `!=` — the same shape the
+ * binary-expression evidence scan below matches — so the Allow-header check
+ * can ask "which branch of this guard am I in?" */
+function reqMethodComparison(ts: typeof TS, node: TS.Node): ReqMethodComparison | null {
+  if (!ts.isBinaryExpression(node) || !isReqMethodAccess(ts, node.left) || !isStringLike(ts, node.right)) return null;
+  const { kind } = node.operatorToken;
+  if (kind === ts.SyntaxKind.EqualsEqualsToken || kind === ts.SyntaxKind.EqualsEqualsEqualsToken) {
+    return { operator: "eq", method: node.right.text };
+  }
+  if (kind === ts.SyntaxKind.ExclamationEqualsToken || kind === ts.SyntaxKind.ExclamationEqualsEqualsToken) {
+    return { operator: "neq", method: node.right.text };
+  }
+  return null;
+}
+
+/** A `res.setHeader("Allow", [...])` call reachable only when `req.method`
+ * did NOT match the method this branch handles is documentation for the
+ * REJECTED caller (a 405's Allow header lists what the route would have
+ * accepted), not evidence of what the handler does. Papermark's real shape:
+ * `if (req.method === "POST") { ...handle... } else { res.setHeader("Allow",
+ * ["GET", "POST"]); return res.status(405)...; }` — the else branch names
+ * GET in its Allow header even though this handler never serves GET. Walk up
+ * from the call to see whether it sits on the rejected side of a req.method
+ * guard: the `else` of an equality check, the `then` of an inequality
+ * (early-return-guard) check, or a switch's `default` clause on req.method.
+ * An unconditional setHeader (no enclosing req.method guard at all) is still
+ * evidence, unchanged from before this check existed. */
+function isInRejectedMethodBranch(ts: typeof TS, call: TS.CallExpression): boolean {
+  let current: TS.Node = call;
+  while (current.parent) {
+    const parent: TS.Node = current.parent;
+    if (ts.isIfStatement(parent)) {
+      const comparison = reqMethodComparison(ts, parent.expression);
+      if (comparison) {
+        if (comparison.operator === "eq" && parent.elseStatement === current) return true;
+        if (comparison.operator === "neq" && parent.thenStatement === current) return true;
+      }
+    }
+    if (ts.isDefaultClause(parent) && ts.isCaseBlock(parent.parent)
+      && isReqMethodAccess(ts, parent.parent.parent.expression)) {
+      return true;
+    }
+    current = parent;
+  }
+  return false;
+}
+
 function allowHeaderVerbs(ts: typeof TS, methods: Set<HttpMethod>, call: TS.CallExpression): void {
   if (calleeSimpleName(ts, call) !== "setHeader") return;
   const [header, value] = call.arguments;
   if (!header || !value || !isStringLike(ts, header) || header.text.toLowerCase() !== "allow") return;
+  if (isInRejectedMethodBranch(ts, call)) return;
   if (isStringLike(ts, value)) {
     for (const part of value.text.split(",")) addMethod(methods, part.trim());
   } else if (ts.isArrayLiteralExpression(value)) {


### PR DESCRIPTION
## Summary

Fixes a route-scan over-inference bug proven by the recent local corpus run and by the truth-set audit that just removed 4 phantom papermark labels (6e6f9bd4, #c1009321): the pages-router verb-evidence scan treated **any** `res.setHeader("Allow", [...])` call as proof the listed methods are handled — including ones that live entirely inside a 405-rejection branch.

Papermark's real handlers write this shape:

```ts
if (req.method === "POST") {
  // ...real logic...
} else {
  res.setHeader("Allow", ["GET", "POST"]);
  return res.status(405).end(`Method ${req.method} Not Allowed`);
}
```

The `else` branch names `GET` only to tell a rejected caller what it *could* have sent — this handler never serves GET. The extractor was reading that string as if it were dispatch evidence, generating a phantom `GET` tool. Papermark has 4 routes with exactly this shape (2 POST-only handlers whose Allow header also lists GET, 2 GET-only handlers whose Allow header also lists POST) — the same 4 the truth-set audit flagged as phantom expected labels in `6e6f9bd4`. The extractor had the identical bug the audit caught in the labels.

## Fix

`isInRejectedMethodBranch` (`packages/actions/src/sync/route-scan.ts`) walks up from a `setHeader("Allow", ...)` call to check whether it sits on the **rejected** side of a `req.method` guard — the `else` of an equality check, the `then` of an inequality early-return guard, or a switch's `default` clause on `req.method` — before letting its Allow-header methods count as evidence. An unconditional `setHeader` (no enclosing guard at all) is unaffected, so the existing "Allow-array"/"Allow-string" fixtures (informational headers with no dispatch) keep passing exactly as before.

The equality/inequality binary-expression evidence itself (`req.method === "POST"` → POST is evidence) is untouched — it was already correct on every real file and every existing fixture.

## Tests (TDD)

Added `packages/actions/src/sync/route-scan.test.ts` fixtures modeled on the four real papermark shapes, plus:
- an inequality-guard positive control (`if (req.method !== "POST") { setHeader Allow; 405 }` → POST only)
- an equality-dispatch control with no Allow header at all (`if (req.method === "PUT") {...} else {405}` → PUT only)

Confirmed red before the fix (phantom GET/POST reproduced exactly), green after.

## Verification

- `pnpm --filter @vendoai/actions test` — 454 passed (all 13 existing full-result baselines untouched, plus the new fixtures)
- `pnpm --filter @vendoai/actions typecheck` — clean
- Live corpus run against the pinned papermark clone (`corpus/.repos/papermark`): the actual `.vendo/tools.json` this worktree's `vendo init` produced no longer contains any of the 4 phantom entries, and scoring it against `corpus/expectations/papermark/expected.json` via the harness's own `runScoredLayer`:
  - `tools.precision`: 384/384 generated tools matched expected inventory — **1.000**
  - `tools.recall`: 384/384 expected tools were generated — **1.000** (unchanged, recall intact)
  - 384 = 388 − 4, matching the phantom-label removal in `6e6f9bd4`

## Test plan

- [x] `pnpm --filter @vendoai/actions test`
- [x] `pnpm --filter @vendoai/actions typecheck`
- [x] Live papermark corpus scoring: precision 1.000, recall 1.000
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops counting `res.setHeader("Allow", ...)` calls inside 405 rejection branches as verb evidence in the pages-router scan. Fixes over-inference and removes four phantom GET/POST tools in the papermark corpus.

- **Bug Fixes**
  - Added `isInRejectedMethodBranch` to detect Allow headers in rejected `req.method` guards (else of equality, then of inequality, switch default) and ignore them.
  - Unconditional `setHeader("Allow", ...)` and existing `req.method` equality/inequality evidence remain unchanged.
  - Tests cover the four papermark patterns and controls; papermark corpus now scores precision 1.000 and recall 1.000.

<sup>Written for commit 8f301fec18c9947cade24f93c74bcde0768f45d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

