### PR TITLE
pipeline: data-sighted verification — labels checked against the actual resolved values

### DIFF
--- a/packages/apps/src/engine.test.ts
+++ b/packages/apps/src/engine.test.ts
@@ -188,6 +188,74 @@ describe("generation engine through createApps", () => {
     expect(prompts.at(-1)).toContain(`CURRENT DATE: ${today}`);
   });
 
+  describe("data-sighted verification pass (pipeline.endPass at the runtime seam)", () => {
+    const appWire = '<App name="Client board"><Query id="metric" tool="host_metric"/><Stack><Stat label="Total clients" value={metric.headline}/></Stack></App>';
+    const metricTools: ToolRegistry = {
+      async descriptors() {
+        return [{ name: "host_metric", description: "Client metrics", risk: "read", inputSchema: { type: "object", properties: {} } }];
+      },
+      async execute(call) {
+        if (call.tool === "host_metric") return { status: "ok", output: { headline: "cl_rivera", clientCount: 12 } };
+        return { status: "error", error: { code: "not-found", message: "missing" } };
+      },
+    };
+
+    it("sees the RESOLVED data, relabels a lying headline, and persists the corrected app", async () => {
+      let verifyPrompt = "";
+      let calls = 0;
+      const model = scriptedLanguageModel((call) => {
+        calls += 1;
+        const text = promptText(call);
+        if (text.includes("ACTUAL data")) {
+          verifyPrompt = text;
+          return '<Edit><Set id="stat-1" label="Latest client id"/></Edit>';
+        }
+        return appWire;
+      });
+      const runtime = createApps({
+        store: memoryStore(),
+        guard: guardFixture(),
+        tools: metricTools,
+        catalog: [],
+        model,
+        pipeline: { endPass: true },
+      });
+
+      const app = await runtime.create({ prompt: "how many clients do we have" }, ctx);
+
+      // The verifier saw the real resolved value next to the wire.
+      expect(verifyPrompt).toContain("cl_rivera");
+      expect(verifyPrompt).toContain('label="Total clients"');
+      // The lie was corrected before persistence; the stored app matches.
+      const stat = (app.tree as { nodes: Array<{ component: string; props?: Record<string, unknown> }> }).nodes
+        .find(({ component }) => component === "Stat");
+      expect(stat?.props?.label).toBe("Latest client id");
+      expect(await runtime.get(app.id, ctx)).toEqual(app);
+      // Exactly two model calls: create + the sighted pass (the blind engine
+      // end pass must NOT also run — the runtime owns the flag now).
+      expect(calls).toBe(2);
+    });
+
+    it("ships the original app untouched when the verifier finds nothing or fails", async () => {
+      const model = scriptedLanguageModel((call) =>
+        promptText(call).includes("ACTUAL data") ? "<Edit></Edit>" : appWire);
+      const runtime = createApps({
+        store: memoryStore(),
+        guard: guardFixture(),
+        tools: metricTools,
+        catalog: [],
+        model,
+        pipeline: { endPass: true },
+      });
+
+      const app = await runtime.create({ prompt: "how many clients do we have" }, ctx);
+
+      const stat = (app.tree as { nodes: Array<{ component: string; props?: Record<string, unknown> }> }).nodes
+        .find(({ component }) => component === "Stat");
+      expect(stat?.props?.label).toBe("Total clients");
+    });
+  });
+
   describe("v4 create contract (pipeline.promptRewrite)", () => {
     it("selects the rewritten contract only under the flag", async () => {
       const prompts: string[] = [];

--- a/packages/apps/src/engine.ts
+++ b/packages/apps/src/engine.ts
@@ -42,6 +42,7 @@ import {
 import type { LanguageModel } from "ai";
 import {
   actionFaults,
+  dataSightedVerify,
   endPass,
   extractEdit,
   literalDataFaults,
@@ -1160,6 +1161,23 @@ const validateCompiledCreate = async (
   if (!appValidation.ok) return { issues: [appValidation.error.message] };
   return { document, issues: [] };
 };
+
+/** v4 data-sighted verification (pipeline.ts) at the runtime seam: the
+ *  runtime resolves the app's queries after create and hands the ACTUAL
+ *  values here, so labels get checked against the data the writer never saw.
+ *  Same validator, same copy-only guard as the end pass — cannot break the
+ *  app; on any failure the original document ships. */
+export const verifyDocumentAgainstData = async (
+  document: GeneratedAppDocument,
+  userRequest: string,
+  resolvedData: Record<string, unknown>,
+  deps: GenerationDependencies,
+): Promise<GeneratedAppDocument> => dataSightedVerify(document, userRequest, resolvedData, {
+  deps,
+  hostComponents: deps.catalog.map(({ name }) => name),
+  startedAt: Date.now(),
+  validate: (compiled) => validateCompiledCreate(compiled, deps),
+});
 
 const withoutId = (app: AppDocument): GeneratedAppDocument => {
   const { id: _id, ...document } = structuredClone(app);

--- a/packages/apps/src/pipeline.ts
+++ b/packages/apps/src/pipeline.ts
@@ -46,7 +46,8 @@ export interface PipelineConfig {
 export type PipelineEvent =
   | { stage: "repair"; rounds: number; repaired: boolean; noValidFix: number; ms: number }
   | { stage: "region-parallel"; fallback?: "no-outline" | "sections-failed" | "assembly-invalid"; sectionsPlanned?: number; sectionsLanded?: number; ms: number }
-  | { stage: "end-pass"; applied: boolean; ms: number };
+  | { stage: "end-pass"; applied: boolean; ms: number }
+  | { stage: "data-verify"; applied: boolean; ms: number };
 
 /** The engine's create validation, passed in as a callback so pipeline.ts
  *  never imports engine internals (engine → pipeline stays one-directional). */
@@ -1075,6 +1076,89 @@ export const endPass = async (
     if (patched.appliedOps === 0 || patched.appliedOps > 4 || patched.extensionOps.length > 0) return finish(document);
     // Structural proofread guard: the patch may only relabel, remove, and
     // rename — a Set that rebinds or rewrites data drops the whole patch.
+    if (endPassViolations(base.tree, patched.tree, base.components, patched.components).length > 0) {
+      return finish(document);
+    }
+    const validated = await context.validate(recompile({
+      tree: patched.tree,
+      components: patched.components,
+      ...(patched.name === undefined ? {} : { name: patched.name }),
+    }, context));
+    return finish(validated.document ?? document);
+  } catch {
+    return finish(document);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Data-sighted verification — the v4 gate's lesson (14/21 fails were headline
+// lies the model wrote BLIND: queries resolve after generation, so labels are
+// claims about values the writer never saw, and the blind end pass could not
+// check them either). This pass runs at the runtime seam AFTER queries
+// resolve: the model sees the app AND the actual values, and may emit the
+// same copy-only, revalidated patch the end pass is limited to.
+// ---------------------------------------------------------------------------
+
+const DATA_VERIFY_CONTRACT = `You are the Vendo verification editor. You see a finished app AND the ACTUAL data its queries returned. Compare every label, title, badge text, caption, and the app name against the real values beneath them: a label claiming "total", "all", "this month", "largest", or a specific meaning must be TRUE of the value actually displayed. A raw identifier under a count label, a stale period under a "current" label, a single row's value under an aggregate label — these are lies to fix. Return ONLY one vendo-genui/v2 <Edit>...</Edit> patch document. No prose, no markdown, no JSON.
+AT MOST 4 ops, copy-only: <Set id="..." label=.../> (or another string copy prop), <SetName name="..."/>, <Remove id="..."/> for a node whose claim cannot be made true by rewording. RELABEL to describe what the data actually is — never invent numbers, never rebind, never touch queries or islands. If every claim is truthful, emit exactly <Edit></Edit>.`;
+
+/** A trimmed, prompt-safe digest of the resolved query data: arrays capped at
+ *  3 sample rows (+count), long strings truncated, whole digest hard-capped.
+ *  The verifier needs representative VALUES, not the full payload. */
+export const dataDigest = (data: Record<string, unknown>, capBytes = 6000): string => {
+  const trimValue = (value: unknown, depth: number): unknown => {
+    if (typeof value === "string") return value.length > 200 ? `${value.slice(0, 200)}…` : value;
+    if (Array.isArray(value)) {
+      const rows = value.slice(0, 3).map((item) => trimValue(item, depth + 1));
+      return value.length > 3 ? [...rows, `… (+${value.length - 3} more rows)`] : rows;
+    }
+    if (isRecord(value) && depth < 6) {
+      return Object.fromEntries(Object.entries(value).map(([key, child]) => [key, trimValue(child, depth + 1)]));
+    }
+    return value;
+  };
+  const digest = JSON.stringify(trimValue(data, 0), null, 1) ?? "{}";
+  return digest.length > capBytes ? `${digest.slice(0, capBytes)}\n… (digest truncated)` : digest;
+};
+
+/** The data-sighted verification pass. Same survival gauntlet as the end
+ *  pass — compile clean, ≤4 ops, copy-only structural guard, full
+ *  revalidation — so it structurally cannot break the app; the only new
+ *  input is the resolved data digest. The caller owns the flag decision. */
+export const dataSightedVerify = async (
+  document: GeneratedAppDocument,
+  userRequest: string,
+  resolvedData: Record<string, unknown>,
+  context: PipelineContext,
+): Promise<GeneratedAppDocument> => {
+  const { deps } = context;
+  const startedAtMs = Date.now();
+  const finish = (verified: GeneratedAppDocument): GeneratedAppDocument => {
+    deps.onPipeline?.({ stage: "data-verify", applied: verified !== document, ms: Date.now() - startedAtMs });
+    return verified;
+  };
+  try {
+    const base = {
+      tree: structuredClone(document.tree) as unknown as TreeV2,
+      components: { ...(document.components ?? {}) },
+      name: document.name,
+    };
+    const wire = printWireV2(base, { includeIds: true });
+    const model = deps.paint?.model ?? deps.model;
+    const { generateText } = await import("ai");
+    const result = await generateText({
+      model,
+      system: DATA_VERIFY_CONTRACT,
+      prompt: `USER_ASK: ${userRequest}\nCURRENT_APP (wire markup; id attributes are your anchors):\n${wire}\nACTUAL data the queries returned (trimmed sample):\n${dataDigest(resolvedData)}`,
+      temperature: 0,
+      maxRetries: 0,
+    });
+    const patched = compileWirePatchV2(extractEdit(result.text), base, {
+      hostComponents: [...context.hostComponents],
+      ...(deps.toolShapes === undefined ? {} : { toolShapes: deps.toolShapes }),
+    });
+    if (!patched.complete || patched.issues.length > 0 || patched.bindingErrors.length > 0) return finish(document);
+    if (patched.appliedOps === 0 || patched.appliedOps > 4 || patched.extensionOps.length > 0) return finish(document);
     if (endPassViolations(base.tree, patched.tree, base.components, patched.components).length > 0) {
       return finish(document);
     }

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -50,6 +50,7 @@ import {
   modelEngine,
   prewarmModels,
   serverWorkRung,
+  verifyDocumentAgainstData,
   type GenerationDependencies,
   type GenerationEngine,
 } from "./engine.js";
@@ -1712,18 +1713,24 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
           if (latestTree === undefined) return;
           emit({ ...structuredClone(latestTree), data, streaming: true } as TreeV2);
         });
+      // v4 data-verify — the runtime owns the endPass flag now: queries
+      // resolve HERE, so the verification runs data-sighted at this seam and
+      // the engine's blind end pass is suppressed (it demonstrably could not
+      // catch label-vs-data lies it never saw — gate 2026-07-21).
+      const verifyEnabled = config.pipeline?.endPass === true;
+      const engineConfig = verifyEnabled
+        ? { ...config, pipeline: { ...config.pipeline, endPass: false } }
+        : config;
+      const generationDeps = generationDependencies(engineConfig, config.model, await generationToolContext(ctx), input.onView === undefined ? undefined : (partial) => {
+        // v2 spec §1 — the payload carries islands at payload level (the
+        // renderer lifts them); a mid-stream payload is marked streaming.
+        latestTree = assembleTree(partial);
+        emit({ ...structuredClone(latestTree), streaming: true } as TreeV2);
+        queryResolver?.update(latestTree);
+      });
       let generated: Awaited<ReturnType<GenerationEngine["create"]>>;
       try {
-        generated = await engine.create(
-          { prompt: input.prompt },
-          generationDependencies(config, config.model, await generationToolContext(ctx), input.onView === undefined ? undefined : (partial) => {
-            // v2 spec §1 — the payload carries islands at payload level (the
-            // renderer lifts them); a mid-stream payload is marked streaming.
-            latestTree = assembleTree(partial);
-            emit({ ...structuredClone(latestTree), streaming: true } as TreeV2);
-            queryResolver?.update(latestTree);
-          }),
-        );
+        generated = await engine.create({ prompt: input.prompt }, generationDeps);
         // 0.4.5 E2E cert (defect D) — a build whose every substantive region
         // was disclaimed away "succeeds" into an app that only says "not
         // available": no failure record, no log line, and a host chat that
@@ -1767,7 +1774,7 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
           { appId, reason, retryable, issues: detailLines },
         );
       }
-      const app: AppDocument = {
+      let app: AppDocument = {
         ...generated,
         id: appId,
       };
@@ -1781,12 +1788,31 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       // successfully generated document never carries it, whatever the model
       // emitted into the tree markup.
       delete app.buildFailed;
+      // v4 data-verify: resolve the finished app's queries once, show the
+      // verifier the ACTUAL values next to the labels, adopt the (copy-only,
+      // revalidated) correction before anything persists or paints. The
+      // resolved data stays valid across the patch — the guard forbids
+      // touching queries — so the final view reuses it. Best-effort: any
+      // failure ships the unverified app.
+      let verifiedData: Record<string, Json> | undefined;
+      if (verifyEnabled && app.tree?.formatVersion === VENDO_TREE_FORMAT_V2) {
+        try {
+          const verifyResolver = createProgressiveQueryResolver(caller, app, ctx);
+          verifyResolver.update(assembleTree({ tree: app.tree, components: app.components, componentTools: app.componentTools }));
+          verifiedData = await verifyResolver.complete();
+          const { id: _verifyId, ...unidentified } = structuredClone(app);
+          const verified = await verifyDocumentAgainstData(unidentified, input.prompt, verifiedData, generationDeps);
+          app = { ...verified, id: appId };
+        } catch {
+          // The unverified app ships; open() resolves its data as always.
+        }
+      }
       let finalTree: TreeV2 | undefined;
       if (input.onView !== undefined && app.tree?.formatVersion === VENDO_TREE_FORMAT_V2) {
         finalTree = assembleTree({ tree: app.tree, components: app.components, componentTools: app.componentTools });
         latestTree = structuredClone(finalTree);
         queryResolver?.update(finalTree);
-        finalTree.data = await queryResolver?.complete() ?? structuredClone(finalTree.data ?? {});
+        finalTree.data = verifiedData ?? await queryResolver?.complete() ?? structuredClone(finalTree.data ?? {});
       }
       await apps.put(appRecordInput(app, ctx.principal.subject));
       clearTimeout(watchdog);


### PR DESCRIPTION
The v4 final gate's dominant fail class (14 of 21, docs/eval/runs/2026-07-21/) was headline lies: real data under labels that misdescribe it. Root cause is architectural — queries resolve AFTER generation, so the model writes every label blind, and the blind end pass reads only the wire, so it could not check them either. This PR makes the verification stage data-sighted.

## What it does

- **`dataSightedVerify` (pipeline.ts)**: after create, the runtime resolves the app's queries once and hands the verifier the wire + a trimmed digest of the ACTUAL values (arrays capped at 3 sample rows, 6KB hard cap). The verifier may emit the same patch the end pass was limited to: ≤4 ops, copy-only (relabel/rename/remove — the structural guard from #462), compile + full revalidation, original ships on any failure. Structurally cannot break the app.
- **Runtime owns the `endPass` flag now**: when it's on, the engine's blind end pass is suppressed (one model call, the sighted one) and the pass runs at the create seam before anything persists or paints. The resolved data is reused for the final streamed view (no double fetch on the streaming path beyond what already ran).
- Observability: new `data-verify` pipeline event (applied + ms).

## Why this shape

- W1's fetch-then-generate measured binding errors at ZERO when the model sees data — this is the cheap post-hoc version of "let the model see", and a fetch-then-generate revisit under the v4 contract is being measured in parallel (branch `yousefh409/fetch-then-gen-v4` when it lands).
- "cl_rivera" as "Total clients", April tiles under "this month", `38`+`59`="3859" — all trivially catchable by a model that can see value and label together; none catchable by one that can't.

## Status

Flag-gated exactly like before (`pipeline.endPass`, default off). Tests: runtime-seam tests prove the verifier sees resolved values, corrects a lying label pre-persistence, runs exactly once (blind pass suppressed), and ships untouched apps on empty/failed verdicts. Full apps suite 560 green, typecheck + lint green. Adoption call belongs to the next gate with a fresh tranche — this PR adds the mechanism, not the flip.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a data-sighted verification pass at the create seam that checks labels and titles against the actual resolved query values, fixing headline/label lies. When enabled, it suppresses the blind end pass and reuses the resolved data for the final streamed view.

- **New Features**
  - `dataSightedVerify` in `pipeline.ts`: resolves queries once post-create and verifies the wire plus a trimmed data digest; allows ≤4 copy-only ops (`<Set>`, `<SetName>`, `<Remove>`), compiles + fully revalidates, and ships the original on any failure.
  - Runtime owns `endPass`: when on, engine end pass is suppressed; verification runs before persistence/paint; resolved data is reused for the final view (safe — queries aren’t touched).
  - `data-verify` pipeline event (applied + ms).
  - `verifyDocumentAgainstData` in `engine.ts` and `dataDigest` helper for capped, prompt-safe data.

- **Migration**
  - Flag-gated via `pipeline.endPass` (default off). No breaking changes.

<sup>Written for commit 86091527c08e739dfd2d916737ec8dc78f830bfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

