### PR TITLE
playbook: mandatory version check after install (release-age cooldown resolves to stale 0.1.x)

### DIFF
--- a/docs-site/agents/index.mdx
+++ b/docs-site/agents/index.mdx
@@ -33,15 +33,31 @@ commands, and rules below don't survive paraphrase.
    ([Express & other runtimes quickstart](/quickstart#wire-the-express-adapter))
    and tell your human detection did not apply.
 
-3. **Install the package.**
+3. **Install the package, then verify what actually resolved.**
 
    ```bash
    npm install vendoai
+   npx vendo --version   # must be >= 0.4.0
    ```
 
-   `vendoai` is a thin alias of `@vendoai/vendo`; see the
-   [quickstart](/quickstart) for the full picture (including the
-   release-cooldown gotcha right after a Vendo release).
+   `vendoai` is a thin alias of `@vendoai/vendo`. The version check is not
+   optional: stale placeholder versions (0.1.x) exist on npm, and package
+   managers with a release-age cooldown (pnpm 11 holds new releases for a
+   day by default via `minimumReleaseAge`; npm's `min-release-age` is
+   opt-in) will SILENTLY resolve a fresh Vendo release to that stale
+   version — or to nothing. Everything this playbook uses (`init --agent`,
+   `vendo login`, `doctor --json`) does not exist there. If the version is
+   old or missing, exclude Vendo from the cooldown and reinstall:
+
+   ```yaml
+   # pnpm-workspace.yaml
+   minimumReleaseAgeExclude:
+     - vendoai
+     - "@vendoai/*"
+   ```
+
+   (npm: unset `min-release-age` for this install, or pin the exact latest
+   version.) Re-run the version check before continuing.
 
 4. **Run init with value flags.** Every wizard question has a flag, so a
    non-interactive run never hangs on a prompt. Answer auth


### PR DESCRIPTION
Live E2E proof: on a machine with npm min-release-age=7, `npm install vendoai` silently installed the stale 0.1.0 placeholder (old enough to pass quarantine) — broken CLI, no doctor --json, dead @vendoai/next check. At publish time every pnpm 11 default user (1-day minimumReleaseAge) hits the same path. Step 3 now requires `npx vendo --version >= 0.4.0` with the cooldown-exclusion fix inline (the quickstart link alone was never followed by agents working the playbook verbatim). Publish-runbook note: deprecating the 0.1.x placeholders (`npm deprecate`, needs the passkey TTY) would make stale resolution fail loudly instead of silently.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the agent playbook to require a version check after `npm install` and document how to bypass release-age cooldowns that can resolve `vendoai` to the stale 0.1.x placeholder. Users now run `npx vendo --version` (must be >= 0.4.0) and, if stale, exclude `vendoai`/`@vendoai/*` from pnpm `minimumReleaseAge` or unset npm `min-release-age` and reinstall.

<sup>Written for commit 4a27a5e3481e48924e10a4ab831881d746a2a55d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

