### PR TITLE
playbook: vendo login runs bare — no identity hints

### DIFF
--- a/docs-site/agents/index.mdx
+++ b/docs-site/agents/index.mdx
@@ -71,8 +71,11 @@ commands, and rules below don't survive paraphrase.
    npx vendo login --wait 90
    ```
 
-   Run it BARE — never pass `--email`, a positional email, or any identity
-   hint. You do not know which account your human wants; they sign in as
+   Run this step ALONE — never batched in parallel with other commands — and
+   the moment the URL and code print, STOP and put both in your very next
+   message to your human: they cannot see your shell. Do not start other
+   work until you have relayed them. Run it BARE — never pass `--email`, a
+   positional email, or any identity hint. You do not know which account your human wants; they sign in as
    whoever they choose on the approval page, and a guessed hint (from git
    config or anywhere else) is an assumption, not a fact. The first run
    prints an approval URL and code; relay both to your human so

--- a/docs-site/agents/index.mdx
+++ b/docs-site/agents/index.mdx
@@ -71,7 +71,11 @@ commands, and rules below don't survive paraphrase.
    npx vendo login --wait 90
    ```
 
-   The first run prints an approval URL and code; relay both to your human so
+   Run it BARE — never pass `--email`, a positional email, or any identity
+   hint. You do not know which account your human wants; they sign in as
+   whoever they choose on the approval page, and a guessed hint (from git
+   config or anywhere else) is an assumption, not a fact. The first run
+   prints an approval URL and code; relay both to your human so
    they approve in the browser. Then re-run `vendo login --wait 90` in a loop
    until it reports the key landed in `.env.local`. Each re-run resumes the
    SAME request — no new code, no duplicate key — so the human's approval lands


### PR DESCRIPTION
Live dogfood: the installing agent ran `npx vendo login --email yousef@vendo.run` — an identity guessed from git config. The human may sign in with any account (GitHub OAuth, a different email); a hint is an assumption and it also caused the earlier wrong-org key confusion. The playbook's login block now explicitly forbids passing --email/positional email/any hint.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the agent playbook so `npx vendo login` runs alone and bare—no `--email`, positional email, or identity hints—and the approval URL + code are relayed to the human immediately. This avoids guessed identities from git config and prevents wrong‑org keys.

<sup>Written for commit 4351dc947e6827e72df12c52e22bf131f6b02a92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

