### PR TITLE
login: remove --email identity hint entirely

### DIFF
--- a/packages/vendo/src/cli.test.ts
+++ b/packages/vendo/src/cli.test.ts
@@ -128,14 +128,16 @@ describe("vendo CLI commands", () => {
 
     expect(await main(["--help"])).toBe(0);
     const help = log.mock.calls.flat().join("\n");
-    expect(help).toContain("login [email]");
-    expect(help).toContain("--email <address>");
+    expect(help).toContain("login");
+    // login takes no --email/identity flag: the human chooses the account
+    // on the approval page (removed 2026-07-21).
+    expect(help).not.toContain("--email <address>");
 
     expect(await main(["login", "--emial", "x@y.z"])).toBe(1);
     expect(error.mock.calls.flat().join("\n")).toContain("unknown option: --emial");
 
-    expect(await main(["login", "--email"])).toBe(1);
-    expect(error.mock.calls.flat().join("\n")).toContain("--email requires a value");
+    expect(await main(["login", "--email", "x@y.z"])).toBe(1);
+    expect(error.mock.calls.flat().join("\n")).toContain("unknown option: --email");
 
     log.mockRestore();
     error.mockRestore();

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -19,7 +19,7 @@ Usage: vendo <command> [dir] [options]
 
 Commands:
   init [dir]      Set up Vendo: wire the handler, extract tools + theme, resolve a model key
-  login [email]   Claim a Vendo Cloud key: approve in the browser; the key lands in .env.local
+  login           Claim a Vendo Cloud key: approve in the browser; the key lands in .env.local
   doctor [dir]    Verify the install: wiring, live probes, and one real model turn (--json for agents)
 
 Advanced:
@@ -39,7 +39,6 @@ Options:
   --auth <preset>            Init only: wire this auth preset without asking (authJs, clerk, supabase, auth0, jwt, none)
   --framework <name>         Init only: override framework detection (next, express) — required non-interactively when detection fails
   --cloud-key <key>          Init only: write this Vendo Cloud key to .env.local instead of the login offer
-  --email <address>          Login only: pre-fill the approval page (login hint)
   --wait <seconds>           Login only: bound this call's polling to N seconds (agents loop re-runs; each resumes the same request), then exit resumably
   --byo                      Init only: decline the Vendo Cloud offer (bring your own model key)
   --ai-polish                Init only: consent to the AI extraction pass without a prompt (works non-interactively)
@@ -89,7 +88,7 @@ const REFINE_FLAGS = new Set(["--yes"]);
 const REFINE_VALUE_OPTIONS = ["--url", "--model-import", "--ask"];
 const SYNC_FLAGS = new Set(["--strict", "--json", "--report"]);
 const SYNC_VALUE_OPTIONS = ["--url", "--key", "--api-url"];
-const LOGIN_VALUE_OPTIONS = ["--email", "--api-url", "--wait"];
+const LOGIN_VALUE_OPTIONS = ["--api-url", "--wait"];
 
 /** ENG-335: options the CLI does not recognize — or value options missing
     their value — must fail loudly before anything runs. Silently dropping a

--- a/packages/vendo/src/cli/cloud/device-login.test.ts
+++ b/packages/vendo/src/cli/cloud/device-login.test.ts
@@ -68,7 +68,7 @@ describe("runDeviceLogin", () => {
     ]);
     const messages = output();
 
-    const exit = await runDeviceLogin(["dev@example.com", "--api-url", "https://console.test"], {
+    const exit = await runDeviceLogin(["--api-url", "https://console.test"], {
       output: messages.sink,
       fetchImpl,
       root,
@@ -81,9 +81,9 @@ describe("runDeviceLogin", () => {
     });
 
     expect(exit).toBe(0);
-    // Claim request carried the login hint, JSON-encoded.
+    // Claim request carries NO identity hint — the human chooses the account.
     expect(requests[0].url).toBe("https://console.test/api/v1/agent/claim");
-    expect(JSON.parse(requests[0].body)).toEqual({ login_hint: "dev@example.com" });
+    expect(JSON.parse(requests[0].body)).toEqual({});
     // Polls are form-encoded with the auth.md grant type + claim token.
     expect(requests[1].contentType).toContain("application/x-www-form-urlencoded");
     const poll = new URLSearchParams(requests[1].body);

--- a/packages/vendo/src/cli/cloud/device-login.ts
+++ b/packages/vendo/src/cli/cloud/device-login.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { join } from "node:path";
-import { option, positionals } from "./args.js";
+import { option } from "./args.js";
 import { isVendoKey, resolveCloudBaseUrl } from "./client.js";
 import { errorMessage, printJson } from "./output.js";
 import { deletePendingClaim, readPendingClaim, writePendingClaim } from "./pending-claim.js";
@@ -173,13 +173,15 @@ export async function runDeviceLogin(
       userCode = resume.user_code;
       verificationUriComplete = resume.verification_uri_complete;
     } else {
-      // Optional email hint — shown to the human on the approval page.
-      const email = option(args, "--email") ?? positionals(args, ["--api-url", "--email", "--wait"])[0];
+      // No identity hint by design: the human signs in as whoever they choose
+      // on the approval page. A guessed login_hint (git email, positional arg)
+      // is an assumption that mis-attributes the claim, so the ceremony never
+      // sends one.
       const claim = await postJson(
         fetchImpl,
         `${base}${CLAIM_PATH}`,
         "application/json",
-        JSON.stringify(email === undefined ? {} : { login_hint: email }),
+        "{}",
       );
       if (claim.status !== 200) {
         const envelope = claim.body as { error?: { message?: unknown } } | null;


### PR DESCRIPTION
`vendo login` no longer accepts `--email` or a positional email — the ceremony sends no login_hint. The human signs in as whoever they choose on the approval page; a guessed hint (agents inferred it from git config, twice in live dogfooding) mis-attributes the claim and caused wrong-org key confusion. `vendo cloud invite --email` (a different command) is untouched. Tests: device-login + cli 30/30, tsc clean. Pairs with the playbook 'run bare' rule (#494).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the `--email` identity hint from `vendo login` and drop positional email support. The login flow no longer sends a login_hint; the user picks the account on the approval page to prevent mis-attributed claims.

- **Bug Fixes**
  - Prevent wrong-org key assignment caused by inferred emails (e.g., from git config).

- **Migration**
  - Stop passing `--email` or a positional email to `vendo login`; both now error.
  - Update any scripts or docs that relied on the hint.
  - `vendo cloud invite --email` is unchanged.

<sup>Written for commit c4756e1122b14259f9423b45e45bdb21fdc76a5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

