### PR TITLE
validator: island constants feeding displayed math are invented data (law 1) — the M12 FX-rate class

### DIFF
--- a/packages/apps/src/engine-laws.test.ts
+++ b/packages/apps/src/engine-laws.test.ts
@@ -167,6 +167,64 @@ describe("law 1 — data-classed props must be bindings", () => {
   });
 });
 
+describe("law 1 in islands — constants feeding displayed math (the M12 class)", () => {
+  const fabricated = `<App name="FX"><Island name="CurrencyView">
+export default function CurrencyView() {
+  const RATE = 0.92;
+  const [total, setTotal] = useState(0);
+  useEffect(() => { tools.host_metric({}).then((res) => setTotal(res.totalCents ?? 0)); }, []);
+  return <Stat label="EUR" value={fmt.money(total * RATE)} />;
+}
+</Island><CurrencyView/></App>`;
+  const honest = `<App name="FX"><Island name="CurrencyView">
+export default function CurrencyView() {
+  const [total, setTotal] = useState(0);
+  useEffect(() => { tools.host_metric({}).then((res) => setTotal(res.totalCents ?? 0)); }, []);
+  return <Stack><Stat label="USD total" value={fmt.money(total)} /><Disclaimer reason="No live FX rate is available on this host, so converted values can't be shown." /></Stack>;
+}
+</Island><CurrencyView/></App>`;
+
+  it("rejects an island computing displayed values from a hand-typed constant and routes it to repair", async () => {
+    const prompts: string[] = [];
+    const model = scriptedLanguageModel((call) => {
+      prompts.push(promptText(call));
+      return prompts.length === 1 ? fabricated : honest;
+    });
+    const document = await modelEngine.create(
+      { prompt: "a currency converter for my balances" },
+      deps(model, { pipeline: { structuredRepair: false } }),
+    );
+    expect(prompts).toHaveLength(2);
+    expect(prompts[1]).toContain("RATE = 0.92");
+    expect(prompts[1]).toContain("a constant feeding displayed math is invented data (law 1)");
+    expect(prompts[1]).toContain("Disclaimer");
+    expect(document.components?.CurrencyView).toContain("Disclaimer");
+  });
+
+  it("keeps style math and percent scaling in islands free — one call, no repair", async () => {
+    const styled = `<App name="Bars"><Island name="SpendBars">
+export default function SpendBars(props) {
+  const BAR = 8;
+  const rows = props.rows ?? [];
+  const max = rows.reduce((m, r) => Math.max(m, r.amountCents), 0) || 1;
+  return <Stack>{rows.map((r) => (
+    <div key={r.id} style={{ width: (r.amountCents / max) * 240, padding: BAR * 2 }}>
+      <Percent value={(r.amountCents / max) * 100} />
+    </div>
+  ))}</Stack>;
+}
+</Island><Query id="metric" tool="host_metric"/><SpendBars rows={metric.rows}/></App>`;
+    let calls = 0;
+    const model = scriptedLanguageModel(() => {
+      calls += 1;
+      return styled;
+    });
+    const document = await modelEngine.create({ prompt: "spending bars" }, deps(model));
+    expect(calls).toBe(1);
+    expect(document.components?.SpendBars).toContain("BAR * 2");
+  });
+});
+
 describe("law 2 — actions ground in the real tool surface", () => {
   it("rejects an action naming a tool absent from the registry", async () => {
     const invented = '<App name="Act"><Query id="metric" tool="host_metric"/><DataTable rows={metric.rows}/><Button label="Send reminder" onClick="host_invented"/></App>';

--- a/packages/apps/src/engine.ts
+++ b/packages/apps/src/engine.ts
@@ -18,6 +18,7 @@ import {
   kitSpec,
   ISLAND_AMBIENT_KIT_NAMES,
   ISLAND_STRIPPED_SPECIFIERS,
+  islandDerivedValueViolations,
   islandNetworkViolations,
   resolveIslandToolName,
   scanIslandTools,
@@ -860,6 +861,11 @@ const prepareIslands = async (
     // CSP, so catch it here and repair to the ambient tools API instead.
     for (const api of islandNetworkViolations(source)) {
       issues.push(`island "${name}" calls ${api}(…) — an island has no network (the sandbox blocks fetch/XHR/WebSocket); the ambient tools API is the ONLY way to read or act: \`await tools.<tool_name>(args)\` with a HOST TOOLS name.`);
+    }
+    // v4 (M12) — law 1 teeth for island math: a hand-typed constant feeding
+    // displayed arithmetic over tool-derived values is invented data.
+    for (const violation of islandDerivedValueViolations(source)) {
+      issues.push(`island "${name}" ${violation}`);
     }
     // The ambient tools contract: literal member access only, every chain
     // resolved against the live registry, the result stamped as the island's

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export * from "./heartbeat.js";
 export * from "./host-seams.js";
 export * from "./ids.js";
 export * from "./island-ambient.js";
+export * from "./island-derived-values.js";
 export * from "./jail-modules.js";
 export * from "./jcs.js";
 export * from "./knowledge.js";

--- a/packages/core/src/island-ambient.ts
+++ b/packages/core/src/island-ambient.ts
@@ -180,8 +180,10 @@ export interface IslandToolScan {
 }
 
 /** Blank string literals, template literals (keeping `${…}` code), and
- *  comments so the tools scan never fires on prose. Offsets are preserved. */
-const blankNonCode = (source: string): string => {
+ *  comments so the tools scan never fires on prose. Offsets are preserved.
+ *  Exported for the island source scanners that share this code-only view
+ *  (island-derived-values.ts); not part of the public contract surface. */
+export const blankNonCode = (source: string): string => {
   const out = source.split("");
   const blank = (from: number, to: number): void => {
     for (let position = from; position < to; position += 1) {

--- a/packages/core/src/island-derived-values.test.ts
+++ b/packages/core/src/island-derived-values.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "vitest";
+import { islandDerivedValueViolations } from "./island-derived-values.js";
+
+/**
+ * v4 wave — the M12 class (final gate 2026-07-21, third run in a row): an
+ * island computed displayed EUR values from `const RATE = 0.92`. Law 1's
+ * prompt principle did not hold; this scanner gives it teeth for constants
+ * feeding displayed math. Scoped NARROWLY — a false positive here poisons
+ * trust in the validator, so when in doubt it does not flag.
+ */
+
+const FX_ISLAND = `
+export default function CurrencyConverter() {
+  const RATE = 0.92;
+  const [accounts, setAccounts] = useState([]);
+  useEffect(() => {
+    tools.host_listAccounts({}).then((res) => setAccounts(res.accounts ?? []));
+  }, []);
+  const totalUsd = accounts.reduce((sum, account) => sum + account.balance_cents, 0);
+  const totalEur = totalUsd * RATE;
+  return (
+    <Stack>
+      <Stat label="Total in EUR" value={fmt.money(totalEur)} />
+      <DataTable rows={accounts.map((account) => ({
+        name: account.name,
+        eur: account.balance_cents * RATE,
+      }))} />
+    </Stack>
+  );
+}
+`;
+
+describe("islandDerivedValueViolations — the M12 FX-rate shape is caught", () => {
+  it("flags a hand-typed constant multiplied into tool-derived values that render", () => {
+    const violations = islandDerivedValueViolations(FX_ISLAND);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain("RATE = 0.92");
+    expect(violations[0]).toContain("a constant feeding displayed math is invented data (law 1)");
+    expect(violations[0]).toContain("derive it from a tool result");
+    expect(violations[0]).toContain("Disclaimer");
+  });
+
+  it("flags a bare numeric literal multiplied inline into rendered tool data", () => {
+    const source = `
+export default function Converter() {
+  const [total, setTotal] = useState(0);
+  useEffect(() => {
+    tools.host_getBalance({}).then((res) => setTotal(res.total_cents ?? 0));
+  }, []);
+  return <Stat label="EUR estimate" value={fmt.money(total * 0.92)} />;
+}
+`;
+    const violations = islandDerivedValueViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain("0.92");
+  });
+
+  it("flags when the tool result arrives through await instead of .then", () => {
+    const source = `
+export default function Converter() {
+  const FX = 1.08;
+  const [balance, setBalance] = useState(null);
+  useEffect(() => {
+    const load = async () => {
+      const res = await tools.host_getBalance({});
+      setBalance(res.balance_cents);
+    };
+    load();
+  }, []);
+  if (balance === null) return <Text text="Loading" />;
+  const converted = balance * FX;
+  return <Stat label="GBP" value={fmt.money(converted)} />;
+}
+`;
+    const violations = islandDerivedValueViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain("FX = 1.08");
+  });
+
+  it("flags a hand-typed rate TABLE looked up into displayed math", () => {
+    const source = `
+export default function MultiConverter() {
+  const RATES = { EUR: 0.92, GBP: 0.79 };
+  const [accounts, setAccounts] = useState([]);
+  useEffect(() => {
+    tools.host_listAccounts({}).then((res) => setAccounts(res.accounts ?? []));
+  }, []);
+  const [currency, setCurrency] = useState("EUR");
+  return (
+    <Stack>
+      <DataTable rows={accounts.map((account) => ({
+        name: account.name,
+        converted: account.balance_cents * RATES[currency],
+      }))} />
+    </Stack>
+  );
+}
+`;
+    const violations = islandDerivedValueViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain("RATES");
+    expect(violations[0]).toContain("a constant feeding displayed math is invented data (law 1)");
+  });
+
+  it("flags props-derived data multiplied by a hand-typed constant into render", () => {
+    const source = `
+export default function Projection({ monthlyCents }) {
+  const GROWTH = 1.07;
+  const nextYear = monthlyCents * GROWTH;
+  return <Stat label="Projected" value={fmt.money(nextYear)} />;
+}
+`;
+    const violations = islandDerivedValueViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain("GROWTH = 1.07");
+  });
+});
+
+describe("islandDerivedValueViolations — exemptions (when in doubt, don't flag)", () => {
+  it("passes a style-heavy island with padding math and a percent conversion untouched", () => {
+    const source = `
+export default function SpendBars(props) {
+  const BAR = 8;
+  const rows = props.categories ?? [];
+  const max = rows.reduce((m, r) => Math.max(m, r.total_cents), 0) || 1;
+  return (
+    <Stack>
+      {rows.map((r, i) => (
+        <div key={r.name} style={{ width: (r.total_cents / max) * 240, padding: BAR * 2, gap: BAR }}>
+          <Text text={r.name} />
+          <Percent value={(r.total_cents / max) * 100} />
+          <Money cents={r.total_cents} />
+        </div>
+      ))}
+    </Stack>
+  );
+}
+`;
+    expect(islandDerivedValueViolations(source)).toEqual([]);
+  });
+
+  it("exempts 0, 1, and 100 (unit math and percent scaling)", () => {
+    const source = `
+export default function Summary(props) {
+  const dollars = props.totalCents / 100;
+  const next = props.count + 1;
+  const ratio = props.received / (props.total || 1);
+  return <Stat label="Collected" value={ratio * 100} hint={dollars + next} />;
+}
+`;
+    expect(islandDerivedValueViolations(source)).toEqual([]);
+  });
+
+  it("exempts array-index arithmetic", () => {
+    const source = `
+export default function LastRow(props) {
+  const rows = props.rows ?? [];
+  const last = rows[rows.length - 1];
+  return <Text text={last ? last.name : "none"} />;
+}
+`;
+    expect(islandDerivedValueViolations(source)).toEqual([]);
+  });
+
+  it("exempts timeout and interval delays", () => {
+    const source = `
+export default function Poller(props) {
+  const POLL_SECONDS = 30;
+  const [rows, setRows] = useState([]);
+  useEffect(() => {
+    const id = setInterval(() => {
+      tools.host_listRows({}).then((res) => setRows(res.rows ?? []));
+    }, POLL_SECONDS * 1000);
+    return () => clearInterval(id);
+  }, []);
+  return <DataTable rows={rows} />;
+}
+`;
+    expect(islandDerivedValueViolations(source)).toEqual([]);
+  });
+
+  it("exempts layout-named constants used in sizing math", () => {
+    const source = `
+export default function Chart(props) {
+  const CHART_HEIGHT = 240;
+  const rows = props.points ?? [];
+  const scale = rows.length ? CHART_HEIGHT / rows.length : CHART_HEIGHT;
+  return <div style={{ height: CHART_HEIGHT }}>{rows.map((r, i) => <div key={i} style={{ height: r.value * scale }} />)}</div>;
+}
+`;
+    expect(islandDerivedValueViolations(source)).toEqual([]);
+  });
+
+  it("does not flag constants whose math never touches tool or prop data", () => {
+    const source = `
+export default function Countdown() {
+  const STEP = 5;
+  const [count, setCount] = useState(60);
+  return <Button label="Tick" onClick={() => setCount(count - STEP)} />;
+}
+`;
+    expect(islandDerivedValueViolations(source)).toEqual([]);
+  });
+
+  it("does not flag tool-derived math that never renders", () => {
+    const source = `
+export default function Alerting() {
+  const THRESHOLD = 2.5;
+  const [rows, setRows] = useState([]);
+  const [flagged, setFlagged] = useState(false);
+  useEffect(() => {
+    tools.host_listCharges({}).then((res) => {
+      const items = res.charges ?? [];
+      setRows(items);
+      const mean = items.reduce((s, c) => s + c.amount_cents, 0) / (items.length || 1);
+      if (items.some((c) => c.amount_cents > mean * THRESHOLD)) setFlagged(true);
+    });
+  }, []);
+  return <DataTable rows={rows} emptyState={flagged ? "Unusual charges found" : "All clear"} />;
+}
+`;
+    expect(islandDerivedValueViolations(source)).toEqual([]);
+  });
+
+  it("never fires on prose, strings, or comments", () => {
+    const source = `
+export default function Notes(props) {
+  // the rate is 0.92 per the old spec * total
+  const label = "converted at 0.92 * balance";
+  return <Text text={label + " " + props.note} />;
+}
+`;
+    expect(islandDerivedValueViolations(source)).toEqual([]);
+  });
+});

--- a/packages/core/src/island-derived-values.test.ts
+++ b/packages/core/src/island-derived-values.test.ts
@@ -102,6 +102,27 @@ export default function MultiConverter() {
     expect(violations[0]).toContain("a constant feeding displayed math is invented data (law 1)");
   });
 
+  it("flags derived math that reaches render through a state setter", () => {
+    const source = `
+export default function Converter() {
+  const RATE = 1.08;
+  const [total, setTotal] = useState(0);
+  const [eur, setEur] = useState(0);
+  useEffect(() => {
+    tools.host_getBalance({}).then((res) => {
+      setTotal(res.total_cents ?? 0);
+      const eurCents = (res.total_cents ?? 0) * RATE;
+      setEur(eurCents);
+    });
+  }, []);
+  return <Stat label="EUR" value={fmt.money(eur)} />;
+}
+`;
+    const violations = islandDerivedValueViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain("RATE = 1.08");
+  });
+
   it("flags props-derived data multiplied by a hand-typed constant into render", () => {
     const source = `
 export default function Projection({ monthlyCents }) {

--- a/packages/core/src/island-derived-values.ts
+++ b/packages/core/src/island-derived-values.ts
@@ -1,0 +1,422 @@
+/**
+ * v4 wave — law 1 teeth for island math (the M12 class).
+ *
+ * Final gate 2026-07-21: "a currency converter for my balances" fabricated an
+ * FX rate for the THIRD straight run — an island computing displayed EUR
+ * values from `const RATE = 0.92`. The prompt principle ("every number comes
+ * from a tool result") does not hold for constants feeding displayed math, so
+ * this scanner catches the shape at compile and routes it to repair.
+ *
+ * Scoped NARROWLY — a false positive here poisons trust in the validator, so
+ * when in doubt it does NOT flag. A violation needs ALL of:
+ *   1. a hand-typed numeric literal (bare, or bound to a `const NAME = 0.92`
+ *      declaration) participating in arithmetic (* / % + -),
+ *   2. the other side of that math tracing to TOOL-DERIVED data (a `tools.`
+ *      result or component props, propagated through declarations, useState
+ *      setters, and iteration callbacks),
+ *   3. the result flowing into rendered output (JSX or an `fmt` call).
+ *
+ * Explicitly EXEMPT (each one a legitimate hand-typed number):
+ *   - the values 0, 1, and 100 (unit math and percent scaling),
+ *   - style/layout math (anything inside a `style` object) and constants with
+ *     layout/timing names (width/height/size/padding/gap/radius/timeout/…),
+ *   - array-index arithmetic (`rows[rows.length - 1]`),
+ *   - setTimeout/setInterval delay arguments.
+ */
+import { blankNonCode } from "./island-ambient.js";
+
+/** Values that are unit math / percent scaling, never invented data. */
+const EXEMPT_VALUES = new Set([0, 1, 100]);
+
+/** Constant names that declare layout, sizing, or timing intent. */
+const EXEMPT_NAME =
+  /(width|height|size|px$|padding|gap|radius|margin|spacing|inset|offset|opacity|zoom|zindex|z_index|duration|delay|timeout|interval|poll|debounce|throttle|retry|ttl|ms$|millis|frames?$|index$|idx$|columns?$|cols?$|rows?_per|per_page|page_size|limit$|precision|decimals?$|digits$)/i;
+
+const IDENTIFIER = /[A-Za-z_$][\w$]*/g;
+const ARITHMETIC = new Set(["*", "/", "%", "+", "-"]);
+
+interface Span {
+  start: number;
+  end: number;
+}
+
+const inSpans = (spans: readonly Span[], index: number): boolean =>
+  spans.some((span) => index >= span.start && index < span.end);
+
+/** Walk forward from an opener to its matching closer (bounded, blanked view
+ *  so delimiters inside strings/comments never miscount). */
+const matchForward = (code: string, openIndex: number): number => {
+  const open = code[openIndex];
+  const close = open === "(" ? ")" : open === "[" ? "]" : "}";
+  let depth = 0;
+  for (let index = openIndex; index < code.length; index += 1) {
+    const char = code[index];
+    if (char === open) depth += 1;
+    else if (char === close) {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return code.length - 1;
+};
+
+/** The spans of every `style` object literal — `style={{…}}` in JSX and
+ *  `style: {…}` in object form. Layout math lives here by design. */
+const styleSpans = (code: string): Span[] => {
+  const spans: Span[] = [];
+  for (const match of code.matchAll(/\bstyle\s*[=:]\s*\{/g)) {
+    const open = match.index + match[0].length - 1;
+    spans.push({ start: match.index, end: matchForward(code, open) + 1 });
+  }
+  return spans;
+};
+
+/** The argument spans of setTimeout/setInterval calls — delays are config. */
+const timerSpans = (code: string): Span[] => {
+  const spans: Span[] = [];
+  for (const match of code.matchAll(/\b(?:setTimeout|setInterval)\s*\(/g)) {
+    const open = match.index + match[0].length - 1;
+    spans.push({ start: match.index, end: matchForward(code, open) + 1 });
+  }
+  return spans;
+};
+
+/** Computed-member-access spans (`rows[rows.length - 1]`) — index math. */
+const indexSpans = (code: string): Span[] => {
+  const spans: Span[] = [];
+  for (let index = 0; index < code.length; index += 1) {
+    if (code[index] !== "[") continue;
+    let before = index - 1;
+    while (before >= 0 && /\s/.test(code[before] as string)) before -= 1;
+    const preceding = before >= 0 ? (code[before] as string) : "";
+    // `[` after an identifier/`)`/`]` is member access; after anything else
+    // it opens an array literal (destructuring, array values) — not an index.
+    if (/[\w$)\]]/.test(preceding)) {
+      spans.push({ start: index, end: matchForward(code, index) + 1 });
+    }
+  }
+  return spans;
+};
+
+/** `fmt.money(…)` / `fmt.percent(…)` call spans — direct display formatting. */
+const fmtSpans = (code: string): Span[] => {
+  const spans: Span[] = [];
+  for (const match of code.matchAll(/\bfmt\s*\.\s*[\w$]+\s*\(/g)) {
+    const open = match.index + match[0].length - 1;
+    spans.push({ start: match.index, end: matchForward(code, open) + 1 });
+  }
+  return spans;
+};
+
+/** Render spans: for each JSX tag start, the innermost balanced `(…)` group
+ *  containing it (the `return (…)` / attr-expression case), falling back to
+ *  the tag's own line. Everything inside is display context. */
+const renderSpans = (code: string): Span[] => {
+  const spans: Span[] = [];
+  for (const match of code.matchAll(/<[A-Za-z][\w.]*[\s/>]/g)) {
+    const tagStart = match.index;
+    // Nearest unmatched `(` walking backward from the tag.
+    let depth = 0;
+    let opener = -1;
+    for (let index = tagStart - 1; index >= 0; index -= 1) {
+      const char = code[index];
+      if (char === ")") depth += 1;
+      else if (char === "(") {
+        if (depth === 0) {
+          opener = index;
+          break;
+        }
+        depth -= 1;
+      }
+    }
+    if (opener >= 0) {
+      spans.push({ start: opener, end: matchForward(code, opener) + 1 });
+    } else {
+      const lineStart = code.lastIndexOf("\n", tagStart) + 1;
+      const lineEnd = code.indexOf("\n", tagStart);
+      spans.push({ start: lineStart, end: lineEnd === -1 ? code.length : lineEnd });
+    }
+  }
+  return spans;
+};
+
+interface Declaration {
+  /** The declared names (plain, destructured object, or array pattern). */
+  names: string[];
+  /** The init expression text (through the terminating `;`/newline). */
+  init: string;
+  initStart: number;
+}
+
+/** Every `const|let|var` declaration with its init span (multi-line safe:
+ *  the init runs to the first `;` or newline at bracket depth zero). */
+const declarations = (code: string): Declaration[] => {
+  const found: Declaration[] = [];
+  for (const match of code.matchAll(/\b(?:const|let|var)\s+([A-Za-z_$][\w$]*|\{[^}]*\}|\[[^\]]*\])\s*=(?![=>])/g)) {
+    const pattern = match[1] as string;
+    const initStart = match.index + match[0].length;
+    let depth = 0;
+    let end = code.length;
+    for (let index = initStart; index < code.length; index += 1) {
+      const char = code[index] as string;
+      if (char === "(" || char === "[" || char === "{") depth += 1;
+      else if (char === ")" || char === "]" || char === "}") depth -= 1;
+      else if ((char === ";" || char === "\n") && depth <= 0) {
+        end = index;
+        break;
+      }
+    }
+    const names = (pattern.match(IDENTIFIER) ?? []).filter((name) => name !== "const");
+    found.push({ names, init: code.slice(initStart, end), initStart });
+  }
+  return found;
+};
+
+/** Whether text references any tainted name as a real identifier (never a
+ *  `.member` position) or reaches `tools.` directly. */
+const referencesTainted = (code: string, text: string, offset: number, tainted: ReadonlySet<string>): boolean => {
+  if (/\btools\s*\./.test(text)) return true;
+  for (const match of text.matchAll(IDENTIFIER)) {
+    const before = code[offset + match.index - 1];
+    if (before === ".") continue;
+    if (tainted.has(match[0])) return true;
+  }
+  return false;
+};
+
+/** The component's props parameter names — props are host-bound data. */
+const propsParamNames = (code: string): string[] => {
+  const names: string[] = [];
+  const params: string[] = [];
+  const direct = /export\s+default\s+(?:async\s+)?function\s*[\w$]*\s*\(([^)]*)\)/.exec(code);
+  if (direct?.[1] !== undefined) params.push(direct[1]);
+  const named = /export\s+default\s+([A-Za-z_$][\w$]*)\s*;?/.exec(code);
+  if (named?.[1] !== undefined) {
+    const component = named[1];
+    const asFunction = new RegExp(`\\bfunction\\s+${component}\\s*\\(([^)]*)\\)`).exec(code);
+    if (asFunction?.[1] !== undefined) params.push(asFunction[1]);
+    const asArrow = new RegExp(`\\b(?:const|let|var)\\s+${component}\\s*=\\s*(?:async\\s*)?\\(([^)]*)\\)\\s*=>`).exec(code);
+    if (asArrow?.[1] !== undefined) params.push(asArrow[1]);
+  }
+  for (const param of params) {
+    names.push(...(param.match(IDENTIFIER) ?? []));
+  }
+  return names;
+};
+
+/** Tool/props-derived identifiers, propagated to a fixpoint through plain
+ *  declarations, useState setters, and iteration-callback parameters. */
+const taintedIdentifiers = (code: string): Set<string> => {
+  const tainted = new Set<string>(propsParamNames(code));
+  // Seed: names bound from `await tools.…`.
+  for (const declaration of declarations(code)) {
+    if (/^\s*await\s+tools\s*\./.test(declaration.init)) {
+      for (const name of declaration.names) tainted.add(name);
+    }
+  }
+  // Seed: `.then((res) => …)` params on tools chains.
+  for (const match of code.matchAll(/\btools\s*\.[\w$.]+\s*\([^()]*\)\s*\.\s*then\s*\(\s*(?:async\s*)?\(?([^)=]*)\)?\s*=>/g)) {
+    for (const name of (match[1] ?? "").match(IDENTIFIER) ?? []) tainted.add(name);
+  }
+  const useStatePairs: Array<{ value: string; setter: string }> = [];
+  for (const match of code.matchAll(/\b(?:const|let|var)\s*\[\s*([A-Za-z_$][\w$]*)\s*,\s*([A-Za-z_$][\w$]*)\s*\]\s*=\s*(?:React\s*\.\s*)?useState\b/g)) {
+    useStatePairs.push({ value: match[1] as string, setter: match[2] as string });
+  }
+  const declarationList = declarations(code);
+  for (let pass = 0; pass < 10; pass += 1) {
+    const sizeBefore = tainted.size;
+    // Declarations whose init references tainted data.
+    for (const declaration of declarationList) {
+      if (declaration.names.some((name) => tainted.has(name))) continue;
+      if (referencesTainted(code, declaration.init, declaration.initStart, tainted)) {
+        for (const name of declaration.names) tainted.add(name);
+      }
+    }
+    // useState values whose setter is ever called with tainted data.
+    for (const pair of useStatePairs) {
+      if (tainted.has(pair.value)) continue;
+      for (const call of code.matchAll(new RegExp(`\\b${pair.setter}\\s*\\(`, "g"))) {
+        const open = call.index + call[0].length - 1;
+        const argsEnd = matchForward(code, open);
+        if (referencesTainted(code, code.slice(open + 1, argsEnd), open + 1, tainted)) {
+          tainted.add(pair.value);
+          break;
+        }
+      }
+    }
+    // Iteration-callback params over tainted collections
+    // (`accounts.map((account) => …)` taints `account`).
+    for (const match of code.matchAll(/\b([A-Za-z_$][\w$]*)(?:\.[\w$]+|\([^()]*\))*\s*\.\s*(?:map|flatMap|filter|forEach|reduce|reduceRight|find|findLast|some|every|sort|toSorted|slice)\s*\(\s*(?:async\s*)?(?:\(([^)]*)\)|([A-Za-z_$][\w$]*))\s*=>/g)) {
+      const base = match[1] as string;
+      if (!tainted.has(base)) continue;
+      const params = match[2] ?? match[3] ?? "";
+      for (const name of params.match(IDENTIFIER) ?? []) tainted.add(name);
+    }
+    if (tainted.size === sizeBefore) break;
+  }
+  return tainted;
+};
+
+/** Whether a numeric-literal/constant occurrence participates in arithmetic:
+ *  a `* / % + -` operator directly joining it to another value. Unary signs,
+ *  `=>`, and `++`/`--` never count. */
+const arithmeticAdjacent = (code: string, start: number, end: number): boolean => {
+  let after = end;
+  while (after < code.length && /[ \t]/.test(code[after] as string)) after += 1;
+  const operatorAfter = code[after];
+  if (operatorAfter !== undefined && ARITHMETIC.has(operatorAfter)
+    && code[after + 1] !== operatorAfter && code[after + 1] !== "=" && code[after + 1] !== ">") {
+    return true;
+  }
+  let before = start - 1;
+  while (before >= 0 && /[ \t]/.test(code[before] as string)) before -= 1;
+  const operatorBefore = code[before];
+  if (operatorBefore === undefined || !ARITHMETIC.has(operatorBefore)) return false;
+  if (code[before - 1] === operatorBefore || code[before - 1] === "=") return false;
+  // A `-`/`+` reached from an opener/comma/assignment is a unary sign.
+  let beforeOperator = before - 1;
+  while (beforeOperator >= 0 && /[ \t]/.test(code[beforeOperator] as string)) beforeOperator -= 1;
+  const left = beforeOperator >= 0 ? (code[beforeOperator] as string) : "";
+  return /[\w$)\]]/.test(left);
+};
+
+/** The declared variable an expression at `index` is assigned to, if the
+ *  enclosing declaration's init covers it. */
+const assignmentTarget = (declarationList: readonly Declaration[], index: number): Declaration | undefined =>
+  declarationList.find((declaration) =>
+    index >= declaration.initStart && index < declaration.initStart + declaration.init.length
+    && declaration.names.length > 0);
+
+/** Whether the value in `names` (or anything derived from it) reaches display:
+ *  an occurrence inside a render span or an fmt call. Derivation follows the
+ *  same declaration/setter propagation as taint. */
+const reachesRender = (
+  code: string,
+  seeds: readonly string[],
+  declarationList: readonly Declaration[],
+  display: readonly Span[],
+): boolean => {
+  const carriers = new Set(seeds);
+  for (let pass = 0; pass < 10; pass += 1) {
+    const sizeBefore = carriers.size;
+    for (const declaration of declarationList) {
+      if (declaration.names.some((name) => carriers.has(name))) continue;
+      if (referencesTainted(code, declaration.init, declaration.initStart, carriers)) {
+        for (const name of declaration.names) carriers.add(name);
+      }
+    }
+    if (carriers.size === sizeBefore) break;
+  }
+  for (const match of code.matchAll(IDENTIFIER)) {
+    if (!carriers.has(match[0])) continue;
+    if (code[match.index - 1] === ".") continue;
+    if (inSpans(display, match.index)) return true;
+  }
+  return false;
+};
+
+/**
+ * Law 1 extension (M12): hand-typed numeric constants participating in
+ * arithmetic with tool-derived values that flow into rendered output. One
+ * violation per constant/literal, message written to teach the repair.
+ */
+export function islandDerivedValueViolations(source: string): string[] {
+  const code = blankNonCode(source);
+  const exempt = [...styleSpans(code), ...timerSpans(code), ...indexSpans(code)];
+  const display = [...renderSpans(code), ...fmtSpans(code)];
+  const declarationList = declarations(code);
+  const tainted = taintedIdentifiers(code);
+  if (tainted.size === 0) return [];
+
+  // Suspect constants: `const NAME = <number>` — or a hand-typed rate TABLE
+  // (`const RATES = { EUR: 0.92, GBP: 0.79 }` / `[0.92, 1.08]`) — with a
+  // non-exempt name and at least one non-exempt numeric value.
+  const constants = new Map<string, string>();
+  for (const declaration of declarationList) {
+    const name = declaration.names.length >= 1 ? (declaration.names[0] as string) : undefined;
+    if (name === undefined || EXEMPT_NAME.test(name)) continue;
+    const init = declaration.init.trim();
+    const literal = /^(-?\d+(?:\.\d+)?)$/.exec(init);
+    if (literal !== null) {
+      const value = Number(literal[1]);
+      if (EXEMPT_VALUES.has(Math.abs(value))) continue;
+      constants.set(name, `${name} = ${literal[1]}`);
+      continue;
+    }
+    // Object/array literals whose values are ALL hand-typed numbers. The
+    // declaration must bind exactly one name (a destructured pattern is not
+    // a constant table).
+    if (declaration.names.length !== 1) continue;
+    const table = /^[{[]([^{}[\]]*)[}\]]$/.exec(init);
+    if (table === null) continue;
+    const entries = (table[1] as string).split(",").map((entry) => entry.trim()).filter((entry) => entry !== "");
+    if (entries.length === 0) continue;
+    // Keys may be blanked string literals (blankNonCode keeps delimiters).
+    const values = entries.map((entry) => /^(?:(?:["'][^"']*["']|[\w$]+)\s*:\s*)?(-?\d+(?:\.\d+)?)$/.exec(entry));
+    if (values.some((match) => match === null)) continue;
+    if (!values.some((match) => !EXEMPT_VALUES.has(Math.abs(Number(match?.[1]))))) continue;
+    constants.set(name, `${name} = ${init.length > 60 ? `${init.slice(0, 57)}…` : init}`);
+  }
+
+  const violations: string[] = [];
+  const flagged = new Set<string>();
+  const lineAround = (index: number): { text: string; start: number } => {
+    const start = code.lastIndexOf("\n", index) + 1;
+    const end = code.indexOf("\n", index);
+    return { text: code.slice(start, end === -1 ? code.length : end), start };
+  };
+  const flag = (key: string, described: string): void => {
+    if (flagged.has(key)) return;
+    flagged.add(key);
+    violations.push(
+      `computes displayed values from the hand-typed constant ${described} — a constant feeding displayed math is invented data (law 1): derive it from a tool result, or render an honest <Disclaimer/> that the rate/value isn't available on this host.`,
+    );
+  };
+  // A constant table participates through its lookup (`RATES[cur] * total`),
+  // so adjacency is checked past any trailing member/index chain.
+  const extendPastChain = (from: number): number => {
+    let end = from;
+    for (;;) {
+      if (code[end] === "." && /[A-Za-z_$]/.test(code[end + 1] ?? "")) {
+        end += 2;
+        while (end < code.length && /[\w$]/.test(code[end] as string)) end += 1;
+      } else if (code[end] === "[") {
+        end = matchForward(code, end) + 1;
+      } else {
+        return end;
+      }
+    }
+  };
+  const checkOccurrence = (key: string, described: string, start: number, rawEnd: number): void => {
+    if (flagged.has(key)) return;
+    if (inSpans(exempt, start)) return;
+    const end = extendPastChain(rawEnd);
+    if (!arithmeticAdjacent(code, start, end)) return;
+    // The other side of the math must trace to tool/props data — checked on
+    // the surrounding line so unrelated tainted code never triggers it.
+    const line = lineAround(start);
+    const masked = line.text.slice(0, start - line.start) + " ".repeat(end - start) + line.text.slice(end - line.start);
+    if (!referencesTainted(code, masked, line.start, tainted)) return;
+    // …and the result must flow into rendered output.
+    const target = assignmentTarget(declarationList, start);
+    const rendered = target !== undefined
+      ? reachesRender(code, target.names, declarationList, display)
+      : inSpans(display, start);
+    if (!rendered) return;
+    flag(key, described);
+  };
+
+  for (const [name, described] of constants) {
+    for (const match of code.matchAll(new RegExp(`\\b${name}\\b`, "g"))) {
+      if (code[match.index - 1] === ".") continue;
+      checkOccurrence(name, described, match.index, match.index + name.length);
+    }
+  }
+  // Bare numeric literals in arithmetic with tainted data (`total * 0.92`).
+  for (const match of code.matchAll(/(?<![\w$.])(\d+(?:\.\d+)?)(?![\w$.])/g)) {
+    const value = Number(match[1]);
+    if (EXEMPT_VALUES.has(Math.abs(value))) continue;
+    checkOccurrence(`literal:${match[1]}`, `${match[1]}`, match.index, match.index + (match[1] as string).length);
+  }
+  return violations;
+}

--- a/packages/core/src/island-derived-values.ts
+++ b/packages/core/src/island-derived-values.ts
@@ -204,6 +204,36 @@ const propsParamNames = (code: string): string[] => {
   return names;
 };
 
+interface StatePair {
+  value: string;
+  setter: string;
+}
+
+/** Every `const [value, setValue] = useState(…)` pair. */
+const useStatePairs = (code: string): StatePair[] => {
+  const pairs: StatePair[] = [];
+  for (const match of code.matchAll(/\b(?:const|let|var)\s*\[\s*([A-Za-z_$][\w$]*)\s*,\s*([A-Za-z_$][\w$]*)\s*\]\s*=\s*(?:React\s*\.\s*)?useState\b/g)) {
+    pairs.push({ value: match[1] as string, setter: match[2] as string });
+  }
+  return pairs;
+};
+
+/** One fixpoint step: state values whose setter is ever called with an
+ *  argument referencing a marked name get marked themselves. */
+const propagateThroughSetters = (code: string, statePairs: readonly StatePair[], marked: Set<string>): void => {
+  for (const pair of statePairs) {
+    if (marked.has(pair.value)) continue;
+    for (const call of code.matchAll(new RegExp(`\\b${pair.setter}\\s*\\(`, "g"))) {
+      const open = call.index + call[0].length - 1;
+      const argsEnd = matchForward(code, open);
+      if (referencesTainted(code, code.slice(open + 1, argsEnd), open + 1, marked)) {
+        marked.add(pair.value);
+        break;
+      }
+    }
+  }
+};
+
 /** Tool/props-derived identifiers, propagated to a fixpoint through plain
  *  declarations, useState setters, and iteration-callback parameters. */
 const taintedIdentifiers = (code: string): Set<string> => {
@@ -218,10 +248,7 @@ const taintedIdentifiers = (code: string): Set<string> => {
   for (const match of code.matchAll(/\btools\s*\.[\w$.]+\s*\([^()]*\)\s*\.\s*then\s*\(\s*(?:async\s*)?\(?([^)=]*)\)?\s*=>/g)) {
     for (const name of (match[1] ?? "").match(IDENTIFIER) ?? []) tainted.add(name);
   }
-  const useStatePairs: Array<{ value: string; setter: string }> = [];
-  for (const match of code.matchAll(/\b(?:const|let|var)\s*\[\s*([A-Za-z_$][\w$]*)\s*,\s*([A-Za-z_$][\w$]*)\s*\]\s*=\s*(?:React\s*\.\s*)?useState\b/g)) {
-    useStatePairs.push({ value: match[1] as string, setter: match[2] as string });
-  }
+  const statePairs = useStatePairs(code);
   const declarationList = declarations(code);
   for (let pass = 0; pass < 10; pass += 1) {
     const sizeBefore = tainted.size;
@@ -233,17 +260,7 @@ const taintedIdentifiers = (code: string): Set<string> => {
       }
     }
     // useState values whose setter is ever called with tainted data.
-    for (const pair of useStatePairs) {
-      if (tainted.has(pair.value)) continue;
-      for (const call of code.matchAll(new RegExp(`\\b${pair.setter}\\s*\\(`, "g"))) {
-        const open = call.index + call[0].length - 1;
-        const argsEnd = matchForward(code, open);
-        if (referencesTainted(code, code.slice(open + 1, argsEnd), open + 1, tainted)) {
-          tainted.add(pair.value);
-          break;
-        }
-      }
-    }
+    propagateThroughSetters(code, statePairs, tainted);
     // Iteration-callback params over tainted collections
     // (`accounts.map((account) => …)` taints `account`).
     for (const match of code.matchAll(/\b([A-Za-z_$][\w$]*)(?:\.[\w$]+|\([^()]*\))*\s*\.\s*(?:map|flatMap|filter|forEach|reduce|reduceRight|find|findLast|some|every|sort|toSorted|slice)\s*\(\s*(?:async\s*)?(?:\(([^)]*)\)|([A-Za-z_$][\w$]*))\s*=>/g)) {
@@ -294,6 +311,7 @@ const reachesRender = (
   code: string,
   seeds: readonly string[],
   declarationList: readonly Declaration[],
+  statePairs: readonly StatePair[],
   display: readonly Span[],
 ): boolean => {
   const carriers = new Set(seeds);
@@ -305,6 +323,8 @@ const reachesRender = (
         for (const name of declaration.names) carriers.add(name);
       }
     }
+    // Derived values stored via a state setter render through the state value.
+    propagateThroughSetters(code, statePairs, carriers);
     if (carriers.size === sizeBefore) break;
   }
   for (const match of code.matchAll(IDENTIFIER)) {
@@ -325,6 +345,7 @@ export function islandDerivedValueViolations(source: string): string[] {
   const exempt = [...styleSpans(code), ...timerSpans(code), ...indexSpans(code)];
   const display = [...renderSpans(code), ...fmtSpans(code)];
   const declarationList = declarations(code);
+  const statePairs = useStatePairs(code);
   const tainted = taintedIdentifiers(code);
   if (tainted.size === 0) return [];
 
@@ -400,7 +421,7 @@ export function islandDerivedValueViolations(source: string): string[] {
     // …and the result must flow into rendered output.
     const target = assignmentTarget(declarationList, start);
     const rendered = target !== undefined
-      ? reachesRender(code, target.names, declarationList, display)
+      ? reachesRender(code, target.names, declarationList, statePairs, display)
       : inSpans(display, start);
     if (!rendered) return;
     flag(key, described);


### PR DESCRIPTION
## What

Law 1 gets teeth inside islands: a new derived-values validator flags a hand-typed numeric constant that participates in arithmetic (`* / % + -`) with tool-derived values and flows into rendered output. Violations route through the normal create/edit validation → repair path, with a teaching message:

> island "CurrencyView" computes displayed values from the hand-typed constant RATE = 0.92 — a constant feeding displayed math is invented data (law 1): derive it from a tool result, or render an honest `<Disclaimer/>` that the rate/value isn't available on this host.

## Why (gate evidence)

M12 ("a currency converter for my balances") fabricated an FX rate for the THIRD straight run — `docs/eval/runs/2026-07-21/README-MAPLE.md`:

> **M12 | FAIL | fabrication (invented FX rate, better-disclosed)** — Repeat offender, third run in a row. Working converter on a made-up "1 USD = 0.92 EUR": €50,514.58 hero + per-account EUR values. […] the fabricated constant still drives the primary displayed math — the Law-1 extension (constant must trace to a tool) did not stop it.

The prompt principle does not hold; the v4 spec's fix line ("Law 1 extension: a constant feeding displayed math must trace to a tool, else disclaimer arm — small validator change") is this PR.

## How it stays narrow (false positives poison trust)

A violation needs ALL of:
1. a hand-typed numeric literal — bare (`total * 0.92`), a `const RATE = 0.92` declaration, or a rate table (`const RATES = { EUR: 0.92 }`),
2. arithmetic against TOOL-DERIVED data (a `tools.` result or component props, propagated through declarations, `useState` setters, and iteration callbacks — the same taint reaches `res.accounts → accounts → account` inside `.map`),
3. the result flowing into rendered output (JSX or `fmt.*` calls).

Explicitly EXEMPT, per the class scoping:
- the values **0 / 1 / 100** (unit math, `cents / 100`, `ratio * 100` percent scaling),
- **style/layout math** — anything inside a `style` object, plus constants with layout/timing names (width/height/size/padding/gap/radius/timeout/…),
- **array-index arithmetic** (`rows[rows.length - 1]`),
- **setTimeout/setInterval delays**.

When in doubt it does not flag: identifier-only arithmetic (no literal) never flags, untainted math never flags, tainted math that never renders (e.g. a threshold check gating an empty-state string) never flags.

## Where

- `packages/core/src/island-derived-values.ts` — the scanner (beside the other island source scanners; `blankNonCode` shared so strings/comments/prose can never trip it).
- `packages/apps/src/engine.ts` — wired into `prepareIslands`, so both create and edit validation route it to repair like every other island issue.

## Tests

- `packages/core/src/island-derived-values.test.ts` — 13 scanner tests: the M12 FX-rate shape (const, bare literal, await path, props path, rate table) is caught; a style-heavy island with padding math and a `ratio*100` percent conversion passes untouched; 0/1/100, index math, timer delays, layout-named constants, untainted math, unrendered math, and prose/strings/comments all stay silent.
- `packages/apps/src/engine-laws.test.ts` — integration: a fabricated-constant island is rejected and repairs to the honest `<Disclaimer/>` arm through the normal repair prompt; the style-math island ships in one call with no repair.

## Verification

- `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green.
- Not UI-affecting (server-side validation only) — no browser screenshots required.
- Known pre-existing local quirk: `packages/core` packaging/cjs e2e tests fail in any checkout whose absolute path contains a space (vite URL-encodes the space and can't load the packed dist) — unrelated to this change, green in CI.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a validator that blocks hand‑typed numeric constants used in displayed arithmetic inside islands (Law 1), stopping the M12 FX‑rate fabrication. It also follows values through declarations and `useState` setters so constants that reach render via state or callbacks are caught.

- **New Features**
  - Adds `islandDerivedValueViolations` to flag constants/literals (incl. rate tables) used in `* / % + -` with tool/prop‑derived data that renders (JSX or `fmt.*`), and wires it into `prepareIslands` to route repairs with guidance to derive from a tool or show a `<Disclaimer/>`.
  - Narrow scope with exemptions: 0/1/100; style/layout math (`style` blocks and layout/timing‑named constants); array‑index math; `setTimeout`/`setInterval` delays.

- **Bug Fixes**
  - Render reachability now traces through `useState` setters (e.g., compute → `setX(eur)` → render `x`), closing a gap where setter‑carried derived math escaped detection.

<sup>Written for commit 2229519307a530a6e386a7520ce7d84d75ab5c18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

