### PR TITLE
playbook: stagger fetches to cut the silent startup

### DIFF
--- a/docs-site/agents/index.mdx
+++ b/docs-site/agents/index.mdx
@@ -15,16 +15,31 @@ playbook instead of the raw text, re-fetch it raw
 (`curl -sL https://docs.vendo.run/agents.md`) — the value flags, exact
 commands, and rules below don't survive paraphrase.
 
+**How to read this — fetch lean, act fast.** This page plus AT MOST ONE more
+is everything you need. Do step 1, commit to one path, then fetch only that
+path's page. Do NOT fetch `llms.txt`, `llms-full.txt`, the existing-agents
+overview, or the page for a path you are not taking — each extra fetch is a
+minute of latency and a chunk of context you will not use, and it is why
+installs feel slow to start. Read the repo's `package.json` before deep
+directory scans. Start acting after step 1, not after reading everything.
+
 ## Install flow
 
-1. **Check for an existing agent.** If the host repo already runs its own
+1. **Check for an existing agent — and branch here.** If the host repo already runs its own
    agent loop — an `ai` (AI SDK) dependency driving a chat route or
    `streamText` loop, or `@mastra/core` — stop and ask your human which path
    they want: install Vendo's agent (this playbook), or keep their loop and
-   add Vendo's tool pack instead
-   ([existing agents](/existing-agents); raw Markdown at
-   `https://docs.vendo.run/existing-agents.md`). Never assume the full
-   install in a repo that already has an agent.
+   add Vendo's tool pack. Never assume the full install in a repo that
+   already has an agent.
+
+   **If they choose the tool pack, leave this page now.** Fetch exactly ONE
+   framework walkthrough and follow it end to end — do not read both, and do
+   not read the overview:
+   - AI SDK loop → `https://docs.vendo.run/existing-agents/ai-sdk.md`
+   - Mastra loop → `https://docs.vendo.run/existing-agents/mastra.md`
+
+   Everything below (steps 2–8) is the FULL-install path. Continue only if
+   your human chose Vendo's agent.
 
 2. **Detect the stack.** Read `package.json`. A `next` dependency means
    Next.js; an `express` dependency means Express. Those are the two scaffolded


### PR DESCRIPTION
Live dogfood: agents fetched agents.md + llms.txt + both existing-agents pages (~50KB, 4 fetches) plus repo scans before their first action — ~7 min of silence. Two changes: a 'fetch lean, act fast' preamble (at most one more page; never llms.txt/overview/the-path-you're-not-taking; act after step 1), and step 1 now branches decisively — tool-pack path leaves immediately for exactly ONE framework walkthrough (ai-sdk.md OR mastra.md), full-install path continues inline. Cuts time-to-first-action and the context an agent carries. mint broken-links green.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Staggered doc fetches in the agents playbook to cut time-to-first-action: read this page and at most one framework page, then act. Step 1 now branches decisively (tool-pack vs full-install), bans fetching `llms.txt`/overviews/unused paths, and recommends reading `package.json` before deep scans.

<sup>Written for commit a4bf8fe906902d8076e37d3bdb4340fd7ca442cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

