### PR TITLE
engine: smoke-render gate — every island renders once, headless, before ship (C11 React #310 class)

### DIFF
--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -55,6 +55,9 @@
     "croner": "^9.0.0",
     "esbuild": "^0.25.0",
     "fflate": "^0.8.2",
+    "jsdom": "^25.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "zod": "^3.25.0"
   },
   "peerDependencies": {

--- a/packages/apps/src/engine.ts
+++ b/packages/apps/src/engine.ts
@@ -52,6 +52,7 @@ import {
   type PipelineEvent,
 } from "./pipeline.js";
 import { hasDefaultExport, pinComponentName, pinForkSource, type PinBaseline } from "./pins.js";
+import { smokeRenderIslands } from "./smoke-render.js";
 import { prewiredPropNames, prewiredSchemaPrompt } from "./prewired-schema.js";
 
 /** The slice of a tool descriptor generation needs: prompt context and the
@@ -452,7 +453,7 @@ export default function PayInvoicePanel() {
   const [invoices, setInvoices] = useState([]);
   const [invoiceId, setInvoiceId] = useState("");
   const [phase, setPhase] = useState("idle");
-  useEffect(() => { tools.acme_listInvoices({ status: "open" }).then((r) => setInvoices(r.data)); }, []);
+  useEffect(() => { tools.acme_listInvoices({ status: "open" }).then((r) => setInvoices(r.data ?? [])); }, []);
   const pay = async () => {
     setPhase("sending");
     const result = await tools.acme_payInvoice({ invoiceId });
@@ -1129,6 +1130,20 @@ const validateCompiledCreate = async (
   issues.push(...actionIssues(compiled.tree, deps.tools));
   issues.push(...rootedRenderIssues(compiled.tree));
   if (issues.length > 0) return { issues };
+  // v4 — the smoke-render gate (crash classes the 2026-07-21 gate shipped:
+  // C11's React #310 hooks-in-map, undefined names, unguarded-data throws).
+  // Runs LAST, only on otherwise-clean documents, so cheap failures never pay
+  // for a render; source-keyed caching makes repair/end-pass revalidation of
+  // unchanged islands free.
+  if (components !== undefined && deps.pipeline?.smokeRender !== false) {
+    issues.push(...await smokeRenderIslands({
+      components,
+      componentTools: prepared.componentTools,
+      tools: deps.tools,
+      toolShapes: deps.toolShapes,
+    }));
+    if (issues.length > 0) return { issues };
+  }
   const document: GeneratedAppDocument = {
     format: VENDO_APP_FORMAT,
     name,

--- a/packages/apps/src/pipeline.ts
+++ b/packages/apps/src/pipeline.ts
@@ -32,6 +32,12 @@ export interface PipelineConfig {
    *  stated once, worked exemplars; scar-tissue rules retired to validators +
    *  repair). Opt-in while the A/B against the current contract is measured. */
   promptRewrite?: boolean;
+  /** v4 wave — the smoke-render gate: every island renders once in a headless
+   *  DOM (dedicated worker + jsdom, ambient scope stubbed) inside create
+   *  validation; a crash routes to repair like any issue. On by default;
+   *  `false` disables. Catches the crash classes the 2026-07-21 gate shipped
+   *  (C11's React #310 hooks-in-map, undefined names, unguarded-data throws). */
+  smokeRender?: boolean;
 }
 
 /** W4 pipeline — opt-in per-stage diagnostics: rounds, no-valid-fix

--- a/packages/apps/src/smoke-render.test.ts
+++ b/packages/apps/src/smoke-render.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from "vitest";
+import type { NormalizedCatalog } from "@vendoai/core";
+import { sampleFromShape, smokeRenderIslands } from "./smoke-render.js";
+import { modelEngine } from "./engine.js";
+import { scriptedLanguageModel, type ScriptedModelCall } from "./testing/index.js";
+
+/**
+ * v4 wave — the smoke-render gate. Final gate 2026-07-21: two crash forms
+ * shipped because nothing executed island code before ship — C11 (React
+ * error #310: useState inside a client .map; the whole app rendered as an
+ * error blob) and the broken-render class generally. Each island now renders
+ * once, headless, against a stubbed ambient scope; a crash is a normal
+ * validation issue routed to repair.
+ *
+ * Scope: CRASHES only (throw on render, hooks-order violations, undefined
+ * names). Visual wrongness (M7's zero-bar chart) is data-shape territory —
+ * deliberately out of scope here.
+ */
+
+const tools = [
+  { name: "host_listClients", description: "List clients", risk: "read" as const },
+  { name: "host_sendMessage", description: "Send a message", risk: "write" as const },
+];
+
+const toolShapes = {
+  host_listClients: {
+    kind: "object" as const,
+    fields: {
+      clients: {
+        kind: "array" as const,
+        items: {
+          kind: "object" as const,
+          fields: {
+            id: { kind: "string" as const },
+            name: { kind: "string" as const },
+            missingDocs: { kind: "number" as const },
+          },
+        },
+      },
+    },
+  },
+};
+
+// The C11 shape: clients load through the ambient tools read, and each row
+// mints its own useState INSIDE the .map — hook count grows when data lands,
+// React #310 fires on the re-render.
+const HOOKS_IN_MAP = `
+export default function ClientContactCards() {
+  const [clients, setClients] = useState([]);
+  useEffect(() => {
+    tools.host_listClients({}).then((res) => setClients(res.clients ?? []));
+  }, []);
+  return (
+    <Stack>
+      {clients.map((client) => {
+        const [expanded, setExpanded] = useState(false);
+        return (
+          <Surface key={client.id}>
+            <Text text={client.name} />
+            <Button label="Details" onClick={() => setExpanded(!expanded)} />
+            {expanded ? <Text text={client.id} /> : null}
+          </Surface>
+        );
+      })}
+    </Stack>
+  );
+}
+`;
+
+const HEALTHY = `
+export default function ClientList() {
+  const [clients, setClients] = useState([]);
+  useEffect(() => {
+    tools.host_listClients({}).then((res) => setClients(res.clients ?? []));
+  }, []);
+  if (clients.length === 0) return <Text text="Loading clients" />;
+  return (
+    <Stack>
+      <Stat label="Clients" value={String(clients.length)} />
+      <DataTable rows={clients.map((client) => ({ name: client.name, missing: client.missingDocs }))} />
+    </Stack>
+  );
+}
+`;
+
+describe("smokeRenderIslands", () => {
+  it("fails an island calling useState inside a .map with a teaching message", async () => {
+    const issues = await smokeRenderIslands({
+      components: { ClientContactCards: HOOKS_IN_MAP },
+      componentTools: { ClientContactCards: ["host_listClients"] },
+      tools,
+      toolShapes,
+    });
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toContain('island "ClientContactCards"');
+    expect(issues[0]).toContain("never inside .map(), loops, or conditions");
+  }, 30_000);
+
+  it("passes a healthy tools-calling island, rendered against the stub without network", async () => {
+    const issues = await smokeRenderIslands({
+      components: { ClientList: HEALTHY },
+      componentTools: { ClientList: ["host_listClients"] },
+      tools,
+      toolShapes,
+    });
+    expect(issues).toEqual([]);
+  }, 30_000);
+
+  it("fails an island referencing an undefined component with a teaching message", async () => {
+    const source = `
+export default function Card() {
+  return <MapleNetWorthCard valueCents={1200} />;
+}
+`;
+    const issues = await smokeRenderIslands({
+      components: { Card: source },
+      componentTools: { Card: [] },
+      tools,
+    });
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toContain("MapleNetWorthCard is not defined");
+    expect(issues[0]).toContain("ambient scope");
+  }, 30_000);
+
+  it("fails an island that crashes on unguarded tool data (no shape known → {})", async () => {
+    const source = `
+export default function Rows() {
+  const [rows, setRows] = useState(null);
+  useEffect(() => {
+    tools.host_listRows({}).then((res) => setRows(res.rows));
+  }, []);
+  if (rows === null) return <Text text="Loading" />;
+  return <Stack>{rows.map((row) => <Text key={row.id} text={row.id} />)}</Stack>;
+}
+`;
+    const issues = await smokeRenderIslands({
+      components: { Rows: source },
+      componentTools: { Rows: ["host_listRows"] },
+      tools: [{ name: "host_listRows", description: "rows", risk: "read" }],
+    });
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toContain("crashed when rendered against stubbed tool results");
+  }, 30_000);
+
+  it("resolves mutating tools as pending-approval, never a failure", async () => {
+    const source = `
+export default function Sender() {
+  const [state, setState] = useState("idle");
+  useEffect(() => {
+    tools.host_sendMessage({ id: "cl_1", body: "hi" }).then((res) => {
+      setState(res && res.status === "pending-approval" ? "awaiting approval" : "sent");
+    });
+  }, []);
+  return <Text text={state} />;
+}
+`;
+    const issues = await smokeRenderIslands({
+      components: { Sender: source },
+      componentTools: { Sender: ["host_sendMessage"] },
+      tools,
+    });
+    expect(issues).toEqual([]);
+  }, 30_000);
+
+  it("terminates an infinite render loop within the render budget", async () => {
+    const source = `
+export default function Spinner() {
+  const [n, setN] = useState(0);
+  while (true) { /* spin forever on first render */ }
+  return <Text text={String(n)} />;
+}
+`;
+    const issues = await smokeRenderIslands({
+      components: { Spinner: source },
+      componentTools: { Spinner: [] },
+      tools,
+      renderTimeoutMs: 500,
+    });
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toContain("did not finish rendering");
+  }, 30_000);
+
+  it("renders islands in parallel and stays within budget", async () => {
+    const components: Record<string, string> = {};
+    const componentTools: Record<string, string[]> = {};
+    for (let index = 0; index < 3; index += 1) {
+      components[`Island${index}`] = HEALTHY.replace("ClientList", `Island${index}`);
+      componentTools[`Island${index}`] = ["host_listClients"];
+    }
+    const startedAt = Date.now();
+    const issues = await smokeRenderIslands({ components, componentTools, tools, toolShapes });
+    const elapsed = Date.now() - startedAt;
+    expect(issues).toEqual([]);
+    // Report the measured latency (cold: worker spawn + jsdom/react import;
+    // warm: the source-keyed cache, what repair/end-pass revalidation pays).
+    const warmStartedAt = Date.now();
+    await smokeRenderIslands({ components, componentTools, tools, toolShapes });
+    console.info(`[smoke-render] 3 islands in parallel: ${elapsed}ms cold, ${Date.now() - warmStartedAt}ms warm-cached`);
+    expect(elapsed).toBeLessThan(15_000);
+  }, 30_000);
+});
+
+describe("sampleFromShape", () => {
+  it("builds arrays with two items so data-driven re-renders exercise hooks", () => {
+    const sample = sampleFromShape(toolShapes.host_listClients) as { clients: unknown[] };
+    expect(sample.clients).toHaveLength(2);
+    expect(sample.clients[0]).toEqual({ id: "sample", name: "sample", missingDocs: 2 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: the gate runs inside create's validation and routes to repair.
+// ---------------------------------------------------------------------------
+
+const promptText = (call: ScriptedModelCall): string => call.prompt.map((message) => {
+  if (typeof message.content === "string") return message.content;
+  return message.content.map((part) => part.text ?? "").join("");
+}).join("\n");
+
+const deps = (model: unknown, extra: Record<string, unknown> = {}) => ({
+  model,
+  catalog: [] as unknown as NormalizedCatalog,
+  tools,
+  toolShapes,
+  ...extra,
+}) as unknown as Parameters<typeof modelEngine.create>[1];
+
+describe("smoke-render gate inside create validation", () => {
+  it("routes a hooks-in-map island to repair and ships the repaired app", async () => {
+    const broken = `<App name="Cards"><Island name="ClientContactCards">${HOOKS_IN_MAP}</Island><ClientContactCards/></App>`;
+    const fixed = `<App name="Cards"><Island name="ClientContactCards">${HEALTHY.replace("ClientList", "ClientContactCards")}</Island><ClientContactCards/></App>`;
+    const prompts: string[] = [];
+    const model = scriptedLanguageModel((call) => {
+      prompts.push(promptText(call));
+      return prompts.length === 1 ? broken : fixed;
+    });
+    const document = await modelEngine.create(
+      { prompt: "contact cards with a quick message button" },
+      deps(model, { pipeline: { structuredRepair: false } }),
+    );
+    expect(prompts).toHaveLength(2);
+    expect(prompts[1]).toContain("never inside .map(), loops, or conditions");
+    expect(document.components?.ClientContactCards).not.toContain("clients.map((client) => {");
+  }, 60_000);
+
+  it("can be disabled with pipeline.smokeRender: false", async () => {
+    const broken = `<App name="Cards"><Island name="ClientContactCards">${HOOKS_IN_MAP}</Island><ClientContactCards/></App>`;
+    let calls = 0;
+    const model = scriptedLanguageModel(() => {
+      calls += 1;
+      return broken;
+    });
+    const document = await modelEngine.create(
+      { prompt: "contact cards" },
+      deps(model, { pipeline: { structuredRepair: false, smokeRender: false } }),
+    );
+    expect(calls).toBe(1);
+    expect(document.components?.ClientContactCards).toBeDefined();
+  }, 60_000);
+});

--- a/packages/apps/src/smoke-render.test.ts
+++ b/packages/apps/src/smoke-render.test.ts
@@ -162,6 +162,42 @@ export default function Sender() {
     expect(issues).toEqual([]);
   }, 30_000);
 
+  it("fails an island that terminates the worker before the render completes", async () => {
+    const source = `
+export default function Quitter() {
+  process.exit(0);
+  return <Text text="never" />;
+}
+`;
+    const issues = await smokeRenderIslands({
+      components: { Quitter: source },
+      componentTools: { Quitter: [] },
+      tools,
+    });
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toContain('island "Quitter"');
+    expect(issues[0]).toContain("exited before the component finished rendering");
+  }, 30_000);
+
+  it("passes an island using ReactDOM portals and fmt.format — names the real jail scope provides", async () => {
+    const source = `
+export default function PortalNote() {
+  return (
+    <Surface>
+      <Text text={fmt.format(123456, "money")} />
+      {ReactDOM.createPortal(<Text text="floating" />, document.body)}
+    </Surface>
+  );
+}
+`;
+    const issues = await smokeRenderIslands({
+      components: { PortalNote: source },
+      componentTools: { PortalNote: [] },
+      tools,
+    });
+    expect(issues).toEqual([]);
+  }, 30_000);
+
   it("terminates an infinite render loop within the render budget", async () => {
     const source = `
 export default function Spinner() {

--- a/packages/apps/src/smoke-render.ts
+++ b/packages/apps/src/smoke-render.ts
@@ -1,0 +1,346 @@
+/**
+ * v4 wave — the smoke-render gate (spec §The fixes: "execute each island
+ * headless before ship").
+ *
+ * Final gate 2026-07-21: the blank-island class is dead, but two crash forms
+ * still shipped — C11 (React error #310: useState inside a client .map, the
+ * whole app an error blob) and M3-adjacent action-path breakage. Nothing
+ * executed island code before ship; this gate does, once, at validation time.
+ *
+ * Each island's compiled component renders ONCE in a jsdom environment inside
+ * a dedicated worker thread, with the ambient scope stubbed:
+ *   - real React + real hooks (hooks-order violations must genuinely fire),
+ *   - the Kit as minimal pass-through components,
+ *   - `fmt` as plain string formatters,
+ *   - `tools` as an async stub: read tools resolve a sample instance derived
+ *     from the tool's ShapeType (arrays get two items, so data-driven
+ *     re-renders exercise hooks the way live data does) or `{}` when no shape
+ *     is known; mutating tools resolve {status:"pending-approval"}.
+ *
+ * SCOPE: this catches CRASHES — throw on render/commit, hooks-order
+ * violations, undefined-name references. It deliberately does NOT judge
+ * visual wrongness (a zero-bar chart is data-shape territory, out of scope).
+ * A render failure is a normal validation issue routed to repair.
+ *
+ * The worker gives two guarantees an in-process render cannot:
+ *   - a hard per-island timeout (worker.terminate preempts infinite loops),
+ *   - no globals leaked into the host server process.
+ * Environment failures (react/jsdom unresolvable, worker "ready" never
+ * arrives) skip the gate silently — the esbuild lazy-load precedent — so a
+ * bundler that cannot reach the modules degrades to today's behavior instead
+ * of failing creates.
+ */
+import {
+  ISLAND_AMBIENT_KIT_NAMES,
+  ISLAND_AMBIENT_REACT_NAMES,
+  type ShapeType,
+} from "@vendoai/core";
+import type { HostToolInfo } from "./engine.js";
+
+export interface SmokeRenderOptions {
+  /** name → island TSX source (post-prepare, canonical). */
+  components: Record<string, string>;
+  /** name → registry tool names the island reaches (the stamped manifest). */
+  componentTools: Record<string, string[]>;
+  tools?: readonly HostToolInfo[] | undefined;
+  toolShapes?: Record<string, ShapeType> | undefined;
+  /** Per-island render budget AFTER the worker reports ready (default 1000ms). */
+  renderTimeoutMs?: number;
+  /** Worker startup budget — imports of react/jsdom (default 10000ms). */
+  startupTimeoutMs?: number;
+}
+
+/** A sample instance of a tool's response shape. Arrays carry TWO items so an
+ *  island that maps rows re-renders with grown collections — the exact motion
+ *  that fires hooks-order violations (C11) with live data. */
+export const sampleFromShape = (shape: ShapeType): unknown => {
+  switch (shape.kind) {
+    case "string": return "sample";
+    case "number": return 2;
+    case "boolean": return false;
+    case "null": return null;
+    case "json": return {};
+    case "array": return [sampleFromShape(shape.items), sampleFromShape(shape.items)];
+    case "object": {
+      const value: Record<string, unknown> = {};
+      for (const [field, fieldShape] of Object.entries(shape.fields)) {
+        value[field] = sampleFromShape(fieldShape);
+      }
+      return value;
+    }
+  }
+};
+
+const isMutating = (tool: HostToolInfo | undefined): boolean =>
+  tool?.risk === "write" || tool?.risk === "destructive";
+
+/** Teaching messages per crash class — routed to repair like any issue. */
+const HOOKS_ORDER = /rendered (more|fewer) hooks|change in the order of hooks|#31[01]\b/i;
+const NOT_DEFINED = /^([A-Za-z_$][\w$]*) is not defined/;
+
+const renderIssue = (island: string, message: string): string => {
+  if (HOOKS_ORDER.test(message)) {
+    return `island "${island}" crashed in the smoke render (${message.split("\n")[0]}) — React hooks (useState/useEffect/useMemo/…) must be called at the top level of the component, never inside .map(), loops, or conditions. Hoist the state to the component, or extract the repeated block into its own local component that owns its hooks.`;
+  }
+  const undefined_ = NOT_DEFINED.exec(message);
+  if (undefined_ !== null) {
+    return `island "${island}" crashed in the smoke render: ${undefined_[1]} is not defined — an island can only use the ambient scope (React and its hooks, the Kit components, fmt, tools) and names it declares itself; host catalog and prewired components never exist inside an island.`;
+  }
+  return `island "${island}" crashed when rendered against stubbed tool results: ${message.split("\n")[0]} — the component must render without throwing for any tool data it can receive: guard undefined/empty results before .map/.reduce and render a loading or empty state instead of crashing.`;
+};
+
+// ---------------------------------------------------------------------------
+// Worker source (CJS eval worker). Embedded as a string so no worker FILE has
+// to survive a host bundler; module paths are resolved on the main thread and
+// passed in. No backticks/template literals in here — it is itself a literal.
+// ---------------------------------------------------------------------------
+const WORKER_SOURCE = String.raw`
+const { parentPort, workerData } = require("node:worker_threads");
+const finish = (errors) => { try { parentPort.postMessage({ type: "result", errors }); } catch {} };
+(async () => {
+  const errors = [];
+  const seen = new Set();
+  const record = (error) => {
+    const message = error instanceof Error ? (error.message || String(error)) : String(error);
+    if (!seen.has(message)) { seen.add(message); errors.push(message); }
+  };
+  // React logs every boundary-caught error loudly, and a chatty island could
+  // fill the piped (never-consumed) stdio; the smoke render is a gate, not a
+  // console feed.
+  console.error = () => {};
+  console.warn = () => {};
+  console.log = () => {};
+  console.info = () => {};
+  const { JSDOM } = require(workerData.paths.jsdom);
+  const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body></html>", { pretendToBeVisual: true });
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  globalThis.navigator = dom.window.navigator;
+  const React = require(workerData.paths.react);
+  const { createRoot } = require(workerData.paths.reactDomClient);
+  parentPort.postMessage({ type: "ready" });
+
+  // Ambient scope: real React/hooks, pass-through Kit, string fmt, tool stub.
+  const scope = { React, ReactDOM: {}, Fragment: React.Fragment };
+  for (const name of workerData.reactNames) {
+    if (scope[name] === undefined && typeof React[name] === "function") scope[name] = React[name];
+  }
+  for (const name of workerData.kitNames) {
+    const Kit = (props) => React.createElement("div", { "data-kit": name }, props && props.children ? props.children : null);
+    Kit.displayName = name;
+    scope[name] = Kit;
+  }
+  const asText = (value) => (value === null || value === undefined ? "" : String(value));
+  scope.fmt = { money: asText, dateTime: asText, percent: asText, num: asText, date: asText, time: asText };
+  const toolStub = (path) => new Proxy(function () {}, {
+    get: (_target, key) => (typeof key === "string" ? toolStub(path.concat(key)) : undefined),
+    apply: () => {
+      const name = path.join("_");
+      const results = workerData.toolResults;
+      const value = Object.prototype.hasOwnProperty.call(results, name) ? results[name] : {};
+      return new Promise((resolve) => setTimeout(() => resolve(value), 0));
+    },
+  });
+  scope.tools = toolStub([]);
+
+  // Evaluate the compiled island (CJS) with the ambient names as parameters.
+  const moduleRef = { exports: {} };
+  const names = Object.keys(scope);
+  let Component;
+  try {
+    const factory = new Function("module", "exports", "require", ...names, workerData.compiled);
+    factory(moduleRef, moduleRef.exports, () => ({}), ...names.map((name) => scope[name]));
+    Component = moduleRef.exports.default || moduleRef.exports;
+  } catch (error) {
+    record(error);
+    return finish(errors);
+  }
+  if (typeof Component !== "function") {
+    record(new Error("the island's default export is not a component"));
+    return finish(errors);
+  }
+
+  class Boundary extends React.Component {
+    constructor(props) { super(props); this.state = { failed: false }; }
+    static getDerivedStateFromError() { return { failed: true }; }
+    componentDidCatch(error) { record(error); }
+    render() { return this.state.failed ? null : this.props.children; }
+  }
+  dom.window.addEventListener("error", (event) => { if (event.error) record(event.error); });
+  const container = dom.window.document.getElementById("root");
+  try {
+    const root = createRoot(container, {
+      onUncaughtError: (error) => record(error),
+      onCaughtError: (error) => record(error),
+    });
+    root.render(React.createElement(Boundary, null, React.createElement(Component, {})));
+  } catch (error) {
+    record(error);
+    return finish(errors);
+  }
+  // Flush: effects run, the tool stub resolves, setState re-renders land.
+  for (let round = 0; round < 4; round += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  finish(errors);
+})().catch((error) => finish([error instanceof Error ? error.message : String(error)]));
+`;
+
+interface WorkerModules {
+  paths: { react: string; reactDomClient: string; jsdom: string };
+  Worker: typeof import("node:worker_threads").Worker;
+}
+
+/** Lazy module resolution, esbuild-pattern: unavailable → gate skips. The
+ *  magic comments keep bundlers from walking into jsdom/react-dom. */
+const workerModules = (async (): Promise<WorkerModules | undefined> => {
+  try {
+    const { Worker } = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ "node:worker_threads");
+    const { createRequire } = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ "node:module");
+    const resolvers: Array<() => NodeJS.Require> = [
+      () => createRequire(import.meta.url),
+      () => createRequire(`${process.cwd()}/package.json`),
+    ];
+    for (const make of resolvers) {
+      try {
+        const require_ = make();
+        return {
+          Worker,
+          paths: {
+            react: require_.resolve("react"),
+            reactDomClient: require_.resolve("react-dom/client"),
+            jsdom: require_.resolve("jsdom"),
+          },
+        };
+      } catch {
+        continue;
+      }
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+})();
+
+/** esbuild, lazily and bundler-safely (same pattern + rationale as engine.ts). */
+const esbuildCompile = (async () => {
+  try {
+    const esbuild = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ "esbuild");
+    return (source: string): string =>
+      esbuild.transformSync(source, { loader: "tsx", format: "cjs", target: "es2020" }).code;
+  } catch {
+    return undefined;
+  }
+})();
+
+/** Source-keyed cache: the same island revalidates on every repair round and
+ *  end-pass read-through; only changed sources pay for a render. */
+const cache = new Map<string, string[]>();
+const CACHE_LIMIT = 256;
+
+const renderOne = async (
+  modules: WorkerModules,
+  island: string,
+  compiled: string,
+  toolResults: Record<string, unknown>,
+  renderTimeoutMs: number,
+  startupTimeoutMs: number,
+): Promise<string[]> => {
+  // The worker deliberately EXECUTES generated island code — that is the
+  // gate. Containment: island code is model-generated and has already passed
+  // the import/network/tools gates, the worker gets an EMPTY env (no host
+  // secrets are readable), require inside the island scope is stubbed, memory
+  // is capped, and the main thread hard-terminates on timeout. This is a
+  // robustness gate at the model trust level, not a substitute for the jail.
+  const worker = new modules.Worker(WORKER_SOURCE, {
+    eval: true,
+    workerData: {
+      compiled,
+      toolResults,
+      paths: modules.paths,
+      reactNames: ISLAND_AMBIENT_REACT_NAMES,
+      kitNames: ISLAND_AMBIENT_KIT_NAMES,
+    },
+    env: {},
+    resourceLimits: { maxOldGenerationSizeMb: 256 },
+    stderr: true,
+    stdout: true,
+  });
+  try {
+    return await new Promise<string[]>((resolve) => {
+      let ready = false;
+      let timer = setTimeout(() => resolve([]), startupTimeoutMs); // env too slow → skip, not an island fault
+      worker.on("message", (message: { type: string; errors?: string[] }) => {
+        if (message.type === "ready") {
+          ready = true;
+          clearTimeout(timer);
+          timer = setTimeout(() => resolve([
+            renderIssue(island, `the component did not finish rendering within ${renderTimeoutMs}ms (likely an infinite render/effect loop)`),
+          ]), renderTimeoutMs);
+          return;
+        }
+        clearTimeout(timer);
+        resolve((message.errors ?? []).map((error) => renderIssue(island, error)));
+      });
+      worker.on("error", (error) => {
+        clearTimeout(timer);
+        // A worker-level crash after ready is the island's doing; before
+        // ready it is the environment's — skip.
+        resolve(ready ? [renderIssue(island, error.message)] : []);
+      });
+      worker.on("exit", () => {
+        clearTimeout(timer);
+        resolve([]);
+      });
+    });
+  } finally {
+    void worker.terminate();
+  }
+};
+
+/**
+ * Smoke-render every island in parallel; returns validation issues (empty =
+ * all islands rendered clean, or the environment cannot run the gate).
+ */
+export const smokeRenderIslands = async (options: SmokeRenderOptions): Promise<string[]> => {
+  const names = Object.keys(options.components);
+  if (names.length === 0) return [];
+  const modules = await workerModules;
+  const compile = await esbuildCompile;
+  if (modules === undefined || compile === undefined) return [];
+  const byName = new Map((options.tools ?? []).map((tool) => [tool.name, tool]));
+  const issues = await Promise.all(names.map(async (island) => {
+    const source = options.components[island] as string;
+    const manifest = options.componentTools[island] ?? [];
+    const toolResults: Record<string, unknown> = {};
+    for (const tool of manifest) {
+      if (isMutating(byName.get(tool))) {
+        toolResults[tool] = { status: "pending-approval" };
+      } else {
+        const shape = options.toolShapes?.[tool];
+        toolResults[tool] = shape === undefined ? {} : sampleFromShape(shape);
+      }
+    }
+    const key = `${island} ${source} ${JSON.stringify(toolResults)}`;
+    const cached = cache.get(key);
+    if (cached !== undefined) return cached;
+    let compiled: string;
+    try {
+      compiled = compile(source);
+    } catch {
+      return []; // not valid TSX — prepareIslands owns that message
+    }
+    const result = await renderOne(
+      modules,
+      island,
+      compiled,
+      toolResults,
+      options.renderTimeoutMs ?? 1000,
+      options.startupTimeoutMs ?? 10_000,
+    );
+    if (cache.size >= CACHE_LIMIT) cache.clear();
+    cache.set(key, result);
+    return result;
+  }));
+  return issues.flat();
+};

--- a/packages/apps/src/smoke-render.ts
+++ b/packages/apps/src/smoke-render.ts
@@ -118,10 +118,13 @@ const finish = (errors) => { try { parentPort.postMessage({ type: "result", erro
   globalThis.navigator = dom.window.navigator;
   const React = require(workerData.paths.react);
   const { createRoot } = require(workerData.paths.reactDomClient);
+  const { createPortal, flushSync } = require(workerData.paths.reactDom);
   parentPort.postMessage({ type: "ready" });
 
   // Ambient scope: real React/hooks, pass-through Kit, string fmt, tool stub.
-  const scope = { React, ReactDOM: {}, Fragment: React.Fragment };
+  // ReactDOM mirrors the real jail scope (runtime-entry.tsx AMBIENT_SCOPE) so
+  // a legitimate portal/flushSync island never false-positives here.
+  const scope = { React, ReactDOM: { createPortal, flushSync }, Fragment: React.Fragment };
   for (const name of workerData.reactNames) {
     if (scope[name] === undefined && typeof React[name] === "function") scope[name] = React[name];
   }
@@ -130,8 +133,10 @@ const finish = (errors) => { try { parentPort.postMessage({ type: "result", erro
     Kit.displayName = name;
     scope[name] = Kit;
   }
+  // Same members as the real jail fmt (money/percent/num/dateTime/format) —
+  // no extras, so an island using a name production lacks still crashes here.
   const asText = (value) => (value === null || value === undefined ? "" : String(value));
-  scope.fmt = { money: asText, dateTime: asText, percent: asText, num: asText, date: asText, time: asText };
+  scope.fmt = { money: asText, percent: asText, num: asText, dateTime: asText, format: asText };
   const toolStub = (path) => new Proxy(function () {}, {
     get: (_target, key) => (typeof key === "string" ? toolStub(path.concat(key)) : undefined),
     apply: () => {
@@ -187,7 +192,7 @@ const finish = (errors) => { try { parentPort.postMessage({ type: "result", erro
 `;
 
 interface WorkerModules {
-  paths: { react: string; reactDomClient: string; jsdom: string };
+  paths: { react: string; reactDom: string; reactDomClient: string; jsdom: string };
   Worker: typeof import("node:worker_threads").Worker;
 }
 
@@ -208,6 +213,7 @@ const workerModules = (async (): Promise<WorkerModules | undefined> => {
           Worker,
           paths: {
             react: require_.resolve("react"),
+            reactDom: require_.resolve("react-dom"),
             reactDomClient: require_.resolve("react-dom/client"),
             jsdom: require_.resolve("jsdom"),
           },
@@ -290,7 +296,14 @@ const renderOne = async (
       });
       worker.on("exit", () => {
         clearTimeout(timer);
-        resolve([]);
+        // Reaching here with the promise unsettled means the worker died
+        // before posting a result. After ready that is the island's doing
+        // (e.g. process.exit during render) — a render failure, not a skip.
+        // Before ready it is the environment's — skip. A resolve after the
+        // result/timeout already settled is a no-op.
+        resolve(ready
+          ? [`island "${island}" crashed in the smoke render: the render process exited before the component finished rendering — an island must not call process.exit or otherwise terminate its environment; return normally and let React render.`]
+          : []);
       });
     });
   } finally {

--- a/packages/apps/src/smoke-render.ts
+++ b/packages/apps/src/smoke-render.ts
@@ -228,10 +228,16 @@ const workerModules = (async (): Promise<WorkerModules | undefined> => {
   }
 })();
 
-/** esbuild, lazily and bundler-safely (same pattern + rationale as engine.ts). */
+/** esbuild, lazily and bundler-safely (same pattern + rationale as engine.ts):
+ *  routed through a mutable binding so NO bundler statically resolves the
+ *  optional compiler — Wrangler ignores the webpack-dialect comments and would
+ *  inline esbuild's Node-only lib/main.js into Worker bundles (the portability
+ *  gate's island-validator field failure). Unavailable → the gate skips. */
+let ESBUILD_SPECIFIER = "esbuild";
+
 const esbuildCompile = (async () => {
   try {
-    const esbuild = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ "esbuild");
+    const esbuild = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ ESBUILD_SPECIFIER) as typeof import("esbuild");
     return (source: string): string =>
       esbuild.transformSync(source, { loader: "tsx", format: "cjs", target: "es2020" }).code;
   } catch {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -938,6 +938,15 @@ importers:
       fflate:
         specifier: ^0.8.2
         version: 0.8.3
+      jsdom:
+        specifier: ^25.0.0
+        version: 25.0.1
+      react:
+        specifier: ^19.0.0
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.7(react@19.2.7)
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -6405,11 +6414,6 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -8109,7 +8113,7 @@ snapshots:
   '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       secure-json-parse: 2.7.0
       zod: 3.25.76
 
@@ -13572,8 +13576,6 @@ snapshots:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
-
-  nanoid@3.3.15: {}
 
   nanoid@3.3.16: {}
 


### PR DESCRIPTION
## What

The smoke-render gate: every island's compiled component now renders ONCE, headless, inside create's validation — a dedicated `worker_thread` with jsdom, real React (hooks-order violations must genuinely fire), the Kit stubbed as pass-through components, `fmt` as string formatters, and `tools` as an async stub (reads resolve a sample instance derived from the tool's ShapeType — arrays get two items so data-driven re-renders exercise hooks the way live data does — or `{}` when no shape is known; mutating tools resolve `{status:"pending-approval"}`). A render failure is a normal validation issue routed to repair, with teaching messages per crash class.

On by default; `pipeline: { smokeRender: false }` disables.

## Why (gate evidence)

The blank-island class is dead, but two crash forms shipped on 2026-07-21 because nothing executed island code before ship:

> **C11 | FAIL | island-render-error (React #310 — useState inside .map, whole app is an error blob)** — REGRESSION (baseline PASS + the approve→effect showcase). The app renders ONLY "ClientContactCards: Minified React error #310…" — the island calls useState inside a client .map loop and crashes; no cards, no buttons. […] repair engaged but repaired only compilation. (`docs/eval/runs/2026-07-21/README-CADENCE.md`)

and the same run's diagnostics: "Structured repair … repair fixes compilation, not truth, and cannot catch runtime hook crashes like React #310." The v4 spec names this "the one genuinely new mechanism this wave".

## Scope: crashes, not visual wrongness

The gate catches: throw on render/commit, React hooks-order violations (#310 class), undefined-name references, unguarded-data throws, and infinite render loops (hard timeout → terminate). It deliberately does NOT judge visual wrongness — **M7's zero-bar chart is data-shape territory and stays out of scope here.**

## Design notes

- **Worker isolation**: the worker gives a hard per-island timeout (`worker.terminate()` preempts `while(true)`) and keeps jsdom globals out of the host server process. The worker runs with an EMPTY `env` (island code cannot read host secrets), a memory cap, and a stubbed `require`; this is a robustness gate at the model trust level, not a substitute for the jail — noted for review.
- **Graceful skip**: react/react-dom/jsdom load lazily with the engine's established esbuild bundler-safe pattern; an environment that cannot resolve them (or a worker that never reports ready) skips the gate silently instead of failing creates.
- **Runs last, cached**: only otherwise-clean documents pay for a render; a source-keyed cache makes repair/end-pass revalidation of unchanged islands free.
- The gate immediately caught a real bug in the pinned v4 exemplar itself: `PayInvoicePanel` set state from unguarded `r.data`, which crashes when a tool result lacks the field — fixed to `r.data ?? []` (the exemplar now models the defensive pattern the gate teaches).

## Measured latency (fixture app, Apple Silicon dev machine)

Reported by the suite's parallel-islands test (`smoke-render.test.ts`):

```
[smoke-render] 3 islands in parallel: 289ms cold, 0ms warm-cached (representative runs: 256–294ms cold)
```

- Cold (first validation of a create): ~250–300ms added — worker spawn + jsdom/react import per island, all islands in parallel.
- Warm (repair rounds / end-pass revalidation of unchanged sources): 0ms (cache hit).
- Per-island render budget: 1s after the worker reports ready (configurable); startup budget separate, so a slow environment skips rather than false-flags an island.

## Tests

`packages/apps/src/smoke-render.test.ts` (10):
- useState-in-a-map island fails validation with the hooks teaching message ("never inside .map(), loops, or conditions") — fired genuinely by the shape-derived stub growing the mapped collection;
- a healthy tools-calling island renders against the stub without network and passes;
- undefined component reference (`<MapleNetWorthCard/>` inside an island) fails with a ReferenceError teaching message;
- unguarded tool data (`res.rows.map` with no shape → `{}` stub) fails with the guard-your-data message;
- mutating tools resolve `{status:"pending-approval"}` and never read as failures;
- an infinite render loop is terminated within the budget;
- parallel latency measured and bounded;
- integration through `modelEngine.create`: the crash routes to repair and the repaired app ships; `pipeline.smokeRender: false` disables.

## Verification

- `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green (including the demo hosts' Next builds with the new `@vendoai/apps` deps: react, react-dom, jsdom).
- Not UI-affecting (server-side validation) — no browser screenshots required.
- Known pre-existing local quirk: core packaging / store pglite-drill tests fail in any checkout whose absolute path contains a space (vite/`URL.pathname` %20-encode the space) — unrelated, green in CI.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render each island once, headless, during create validation to catch runtime crashes (e.g., React #310) before ship. On by default; set `pipeline.smokeRender: false` to disable.

- **New Features**
  - Headless render gate: dedicated worker with `jsdom` and real React catches throw-on-render, hooks-in-`.map` (React #310), undefined names, unguarded tool data, and infinite loops (timeout).
  - Robustness/parity: worker exits after ready are failures; before ready is an env skip. Ambient stub mirrors the jail scope—real `react-dom` (portals/flushSync), `fmt` exposes `money`, `percent`, `num`, `dateTime`, `format`; tools reads return shape-derived samples (arrays x2), writes resolve `pending-approval`. Runs last, caches by source, skips if `react`, `react-dom`, or `jsdom` are missing. Lazy esbuild import uses a mutable specifier to avoid Worker bundlers inlining Node-only code. Adds `jsdom`, `react`, `react-dom` to `@vendoai/apps`.

- **Bug Fixes**
  - `PayInvoicePanel`: guard `setInvoices(r.data ?? [])` to avoid crashes when `data` is missing.

<sup>Written for commit 79d16d93e200e3f8802e11c6bc68c1ab0a4327b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

