### PR TITLE
demo-accounting: rewrite Cadence design rules from the pairwise verdicts — titled, hero-led, one table per question

### DIFF
--- a/apps/demo-accounting/.vendo/design-rules.md
+++ b/apps/demo-accounting/.vendo/design-rules.md
@@ -1,18 +1,30 @@
 # Cadence design rules
 
-Cadence is a professional workspace for a firm in tax season: dense, ordered,
-trustworthy. A generated app should read like part of the practice.
+Cadence is a professional workspace for a firm in tax season: calm, ordered,
+trustworthy. A generated app reads like a well-set page of the practice —
+titled, unhurried, one clear answer on top.
 
-- Warm neutrals from the theme tokens. Accent is reserved for the primary
-  action and the single most urgent element on screen. Danger marks real
-  deadline risk or missing documents only — never decoration.
-- The work list is usually the hero. Tables are the center of gravity:
-  compact rows, deadline-sorted by default, search and filters on any list
-  longer than about eight rows. Stat cards summarize; they don't lead unless
-  the ask is explicitly a summary.
-- People are first-class. Show client and contact together; keep staff
-  assignments visible; humanize entity types (S-Corp, Sole Prop) and render
-  statuses through EnumBadge — never raw snake_case in a cell.
+- Open with a header moment: the app's title with a one-line purpose under it
+  ("Firm-wide document collection progress for the current filing season").
+  Never start at a bare row of tiles.
+- One hero answers the ask. Give it a full-width card with a large figure and
+  a plain-words caption ("8 of 12 active clients need chasing"). Supporting
+  stats sit under it as two to four EQUAL cards with big numbers — never a
+  strip of small cramped tiles, and never a second hero.
+- Warm neutrals from the theme tokens. Charts draw in ink and the theme's
+  muted neutrals — no green/yellow/traffic-light palettes. Accent is reserved
+  for the primary action; danger marks real deadline risk or missing
+  documents only, never decoration or ordinary counts.
+- Tables do the work, one table per question. Deadline-sorted by default,
+  search and filters on any list longer than about eight rows, comfortable
+  row height. Never stack two tables that answer the same question.
+- People are first-class. Show client and contact together, and keep staff
+  assignments visible on any list of work.
+- Humanize every value, including table cells: entity types read as words
+  (S-Corp, Sole Prop), statuses render as EnumBadge chips ("Missing docs"),
+  activity as plain sentences — raw snake_case (missing_docs, s_corp,
+  upload_received) never reaches the screen; map it in the island if the
+  column would otherwise show it.
 - Dates carry the app. Filing deadlines are always formatted, near deadlines
   get a day count ("3 days away"), and weeks frame the work (this week, next
   week) rather than raw date ranges.
@@ -20,6 +32,9 @@ trustworthy. A generated app should read like part of the practice.
   received-vs-outstanding as the house pattern. No decorative charts.
 - Progress is a signature stat: firm-wide completion shows the math ("38 of
   59 collected, 64%"), not just a bar.
+- Generous spacing throughout — sections breathe, nothing is squeezed to fit.
+  An honest fallback (payroll, billing, revenue asks) still gets the full
+  layout: title, banner, one labeled section — not a shrunken afterthought.
 - Copy is professional and brief: sentence case, no exclamation points. An
   empty state states the fact and the next step ("No documents outstanding —
   nothing to chase this week.").


### PR DESCRIPTION
## What

Rewrite `apps/demo-accounting/.vendo/design-rules.md` (Cadence's host design rules). Host-config only — no code changes. No frozen set was re-run; the next gate measures it.

## Why (gate evidence)

The v4 design pairwise (`docs/eval/runs/2026-07-21/design-pairwise.md`, claude-opus-4-8, blind A/B in both orderings) split by host:

> **Maple 11W–2L–7T for NEW · Cadence 6W–11L–3T for BASELINE.** The v4 prompt stack reads as a design improvement on Maple and a design regression on Cadence (where several new-run fails — C11's error blob, C13's dead form — also lose on looks, and the baseline's island-rendered boards were strong).

Maple's design-rules.md worked; Cadence's made things worse. Judge criteria were: "hierarchy (one clear hero), layout balance (no dead space / floating cards), density consistency, humanized labels (no raw enums/cents/ISO), brand feel, designed empty states."

## Diagnosis (from the losing pairs, verdicts in design-pairwise.json)

Excluding the functional-breakage losses (C11 error blob, C13 dead form), the judge kept preferring the same things in the baseline screenshots:

- **C12** (BASELINE): the baseline opens with a titled header ("Season Progress Tracker — Firm-wide document collection progress for the current filing season") and a full-width hero card ("8 — of 12 active clients need chasing"); the new run opens at a lone narrow tile floating beside dead space and buries the summary ask under an all-12-client table full of raw `missing_docs` / `s_corp` cells — the ask WAS the summary.
- **C15** (BASELINE): baseline = titled report ("End-of-Week Status Report / Week ending Jul 22, 2026") with three LARGE stat cards and one filtered table; new run = no title, four cramped small tiles, then three stacked tables — two of them ("Clients still missing documents" and "Upcoming deadlines at risk") answering the same question with near-identical rows.
- **C14** (BASELINE): baseline draws the stacked completion chart in monochrome ink; the new run ships green/yellow bars with red/green colored table numbers — traffic-light decoration on a warm-neutral host.
- **C09 / F8** (BASELINE, the honest impossibles): baseline gives the fallback the full layout (title, banner, "What this dashboard does cover" section, big stats); the new run shrinks it to a tiny section label + a cramped 4-tile strip + a raw-enum table.
- The Cadence run README's recurring-wart line confirms the label failure mode: "raw enums in table cells (missing_docs, s_corp) persist despite `.vendo/design-rules.md` asking for humanized labels — EXCEPT chip/badge renderings […] the rules reach islands, not host DataTable cells."

In short: the old rules' "dense, table-first, stat-cards-don't-lead" posture produced title-less, cramped, stat-suppressed, sometimes duplicate-table layouts, while the judge consistently rewarded the baseline's titled, hero-led, generously spaced report pages. Where the new run DID lead with a strong hero row and balanced sections it won (C1, C2, C8, F6, F7, G7-noted ranking praise).

## Rule changes (each ← its evidence)

Kept the voice/format of the Maple file (which won 11–2). Changes:

1. **Dropped "dense" from the identity line; added "titled, unhurried, one clear answer on top"** ← C12/C15/C09/F8 all lost on cramped small-type layouts vs the baseline's larger, breathing pages.
2. **New: open with a header moment (title + one-line purpose), never a bare tile row** ← C12/C15/C09 baseline wins all carry titled headers with subtitles; the new-run losers all start at an unlabeled tile strip.
3. **Replaced "Stat cards summarize; they don't lead unless the ask is explicitly a summary" with: one full-width hero answers the ask; supporting stats are 2–4 EQUAL cards with big numbers, never a strip of small tiles, never a second hero** ← C12's lone floating tile + dead space (judge criterion "layout balance"), C15/F8's cramped 4-tile strips vs baseline's three large cards.
4. **Softened "Tables are the center of gravity: compact rows" to "Tables do the work, one table per question … comfortable row height … never stack two tables that answer the same question"** ← C15's near-duplicate tables; C12's summary ask answered with a full client table.
5. **New: chart color discipline — ink + muted theme neutrals, no green/yellow/traffic-light palettes** ← C14's loss (old rules pinned the chart TYPE but not its color; the winning baseline chart was monochrome).
6. **Strengthened humanized labels to cover table CELLS, with an explicit "map it in the island" instruction** ← the recurring-wart line: chips humanized, DataTable cells still raw; the rule now names the failure surface instead of restating the preference.
7. **New: honest fallbacks get the full layout (title, banner, one labeled section), not a shrunken afterthought** ← C09/F8 honest impossibles lost on looks despite honesty parity.
8. **Kept**: people-first-class (C1/C2 wins show client + contact + staff together), deadline day-counts and week framing (the baseline C6 timeline the judge loved; F6/G6 new-run wins use it), stacked received-vs-outstanding as the house chart, progress-shows-the-math, danger-only-for-real-risk, professional brief copy.

## Verification

- `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green (config-file-only change).
- This file is a generation-prompt seam (`HOST DESIGN RULES:`), not rendered UI — there is no deterministic screen to screenshot; per the wave plan the frozen sets are NOT re-run here, the next gate measures the effect.
- Known pre-existing local quirk: core packaging / store pglite-drill tests fail in any checkout whose absolute path contains a space — unrelated, green in CI.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites Cadence host design rules to produce titled, hero-led pages with one clear answer on top and one table per question. Config-only change that moves Cadence to Maple’s calm, humanized style to address v4 design regressions.

- **Refactors**
  - Start with a page title and one-line purpose; never a bare tile row.
  - Lead with one full-width hero and a plain-words caption; add 2–4 equal stat cards; never tile strips or a second hero.
  - Tables: one per question; comfortable rows; deadline-sorted; search/filters when >8 rows; never near-duplicate stacks.
  - Charts draw in ink and muted neutrals; accent only for the primary action; danger only for true risk; no traffic-light palettes.
  - People-first: show client + contact together; keep staff assignments visible.
  - Humanize every value, including table cells; statuses via EnumBadge; map raw enums in the island; no snake_case on screen.
  - Dates with day counts and week framing (this/next week), not raw ranges.
  - Generous spacing; honest fallbacks get full layout (title, banner, one section); progress shows the math.

<sup>Written for commit aea978342b24410000da4d1219078af9c901cf95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

