### PR TITLE
release: add Postgres leg to the release gate; fix runbook drift

### DIFF
--- a/.changeset/tokenless-release-proof.md
+++ b/.changeset/tokenless-release-proof.md
@@ -1,0 +1,10 @@
+---
+"@vendoai/core": patch
+"@vendoai/telemetry": patch
+"@vendoai/engine": patch
+---
+
+Release pipeline hardening: the release gate now runs the PostgreSQL store
+suite like CI does, and publishing uses npm trusted publishing (OIDC) with
+provenance — no npm tokens anywhere. This patch is the first release cut
+end-to-end by the automated pipeline.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,22 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Same Postgres leg as the `ci` gate: @vendoai/store's postgres-gate test
+    # requires POSTGRES_URL in CI so the PostgreSQL backend suite really runs.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: vendo
+          POSTGRES_PASSWORD: vendo
+          POSTGRES_DB: vendo_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U vendo"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -33,6 +49,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm test
+        env:
+          POSTGRES_URL: postgres://vendo:vendo@localhost:5432/vendo_test
       # Parity with the `ci` gate — a release must never publish something that
       # would have failed CI. typecheck + lint were previously missing here.
       - run: pnpm typecheck

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -124,7 +124,7 @@ NPM_CONFIG_MIN_RELEASE_AGE=0 npx create-next-app@latest app --ts --tailwind --es
 cd app
 NPM_CONFIG_MIN_RELEASE_AGE=0 npm install vendoai 'ai@^6' '@ai-sdk/anthropic@^3'
 npx --no-install vendo --version   # must print 0.4.0
-npx --no-install vendo init --yes --brief 'Vendo 0.4.0 registry verification.'
+npx --no-install vendo init --yes
 npm run build
 npm run dev -- --hostname 127.0.0.1 --port 3137 >"$root/dev.log" 2>&1 &
 server_pid=$!
@@ -134,7 +134,10 @@ kill "$server_pid"
 ```
 
 Success: CLI and `/status` both report `0.4.0`, init writes the `.vendo`
-contract and Next wiring, the app builds, doctor exits 0. Repeat with
+contract and Next wiring, the app builds, and doctor shows the wiring checks
+and the `/status` live round-trip green. Without a model key doctor's live
+model turn is `broken` by design and doctor exits nonzero — that is the
+expected keyless outcome, not a packaging failure. Repeat with
 `npm install @vendoai/vendo` for the scoped umbrella if paranoid.
 
 ## Releases after launch


### PR DESCRIPTION
## What

Two follow-ups from the live v0.4.0 release run (tag `v0.4.0`, run 29849964135):

1. **`release.yml` was missing the Postgres test leg.** `@vendoai/store`'s `postgres-gate.test.ts` asserts `POSTGRES_URL` is set in CI so the PostgreSQL backend suite really runs — `ci.yml` provisions a postgres:16 service for this, but the release workflow never did. It only passed historically on warm turbo caches; the v0.4.0 tag re-run executed the suite cold and failed the gate (the publish step was unaffected — everything was already on the registry). This mirrors ci.yml's service block and env exactly.
2. **PUBLISH.md drift caught during clean-room verification**: `vendo init` dropped `--brief` in the 0.4.0 CLI redesign, and doctor deliberately exits nonzero in a keyless clean room (the live-model-turn check), so the success bar now reads wiring + `/status` green rather than "doctor exits 0".

## Verification

- `actionlint` clean.
- `pnpm build && pnpm test && pnpm typecheck && pnpm lint` all green locally.
- No UI-affecting changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the Postgres leg to the release workflow so backend tests run during publish, update the 0.4.0 runbook, and add a patch changeset to prove tokenless npm trusted publishing with provenance end‑to‑end.

- **Bug Fixes**
  - Release workflow: add `postgres:16` service and set `POSTGRES_URL` for `pnpm test` in `release.yml`, matching `ci.yml` so `@vendoai/store`’s Postgres gate actually runs.
  - Runbook: remove `--brief` from `vendo init` and clarify that in a keyless clean room `vendo doctor` exits non‑zero; success is wiring + `/status` green.

<sup>Written for commit 18d5ecb82096ecc3f605dce7497e9c3b305d6e4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

