### PR TITLE
apps/ui: failed builds resolve the embed with a reason instead of spinning (#492)

### DIFF
--- a/packages/agent/src/pack.ts
+++ b/packages/agent/src/pack.ts
@@ -164,7 +164,7 @@ function wrapHostTool(registry: ToolRegistry, descriptor: ToolDescriptor): Vendo
 function createAppTool(registry: ToolRegistry, descriptor: ToolDescriptor): VendoPackTool {
   return {
     name: VENDO_CREATE_APP_TOOL,
-    description: "Create a Vendo app (generated UI) from a natural-language prompt. Returns fast with a vendo/app-ref@1 envelope; the build streams to the host's embed over the Vendo wire, so never wait for or report on build completion.",
+    description: "Create a Vendo app (generated UI) from a natural-language prompt. Returns fast with a vendo/app-ref@1 envelope meaning the build was ACCEPTED and is still streaming — the app is NOT built yet. Do not tell the user the app is created/ready/done; the embed shows live build progress and the final result (including any build failure) itself, so never wait for or report on build completion.",
     inputSchema: {
       $schema: DRAFT_2020_12,
       type: "object",

--- a/packages/apps/src/build-failure.test.ts
+++ b/packages/apps/src/build-failure.test.ts
@@ -1,0 +1,120 @@
+import type { LanguageModel } from "ai";
+import type { RunContext, ToolRegistry } from "@vendoai/core";
+import { VendoError } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { buildFailureReason, createApps } from "./index.js";
+import { guardFixture, memoryStore, scriptedLanguageModel } from "./testing/index.js";
+
+// Incident (runvendo/vendo#492): vendo_create_app returns fast with a
+// vendo/app-ref@1 while the build streams server-side. When the build turn
+// THROWS (model error / quota / timeout) the app record never landed, so
+// open() kept answering not-found → the embed spun to APP_BUILD_DEADLINE_MS
+// before the generic failed beat. The fix persists a TERMINAL failed record so
+// open() resolves the embed promptly with the reason.
+
+const tools: ToolRegistry = {
+  async descriptors() {
+    return [];
+  },
+  async execute() {
+    return { status: "error", error: { code: "not-found", message: "No fixture tools" } };
+  },
+};
+
+const context = (subject: string): RunContext => ({
+  principal: { kind: "user", subject },
+  venue: "app",
+  presence: "present",
+  sessionId: `session_${subject}`,
+});
+
+/** A model whose every turn throws — the provider-error build path. */
+const throwingModel = (message: string): LanguageModel =>
+  scriptedLanguageModel(() => {
+    throw new Error(message);
+  });
+
+const setup = (model: LanguageModel) => {
+  const store = memoryStore();
+  const runtime = createApps({ store, guard: guardFixture(), tools, catalog: [], model });
+  return { store, runtime };
+};
+
+describe("build-failure lifecycle (#492)", () => {
+  it("persists a terminal failed record when the build turn throws, and open() resolves to {kind:\"failed\"}", async () => {
+    const { runtime, store } = setup(throwingModel("boom"));
+    const ctx = context("user_ada");
+
+    let appId: string | undefined;
+    // create() still rejects (the tool contract is unchanged), but now it
+    // leaves a persisted failed record behind.
+    await expect(
+      (async () => {
+        try {
+          await runtime.create({ prompt: "A weather board" }, ctx);
+        } catch (error) {
+          // Recover the minted app id from the persisted record.
+          const rows = await store.records("vendo_apps").list({});
+          appId = rows.records[0]?.id;
+          throw error;
+        }
+      })(),
+    ).rejects.toBeInstanceOf(VendoError);
+
+    expect(appId).toBeDefined();
+    const record = await store.records("vendo_apps").get(appId!);
+    expect(record?.data).toMatchObject({
+      subject: "user_ada",
+      enabled: false,
+      doc: { buildFailed: { reason: "generation failed", retryable: true } },
+    });
+
+    const surface = await runtime.open(appId!, ctx);
+    expect(surface).toEqual({ kind: "failed", reason: "generation failed", retryable: true });
+  });
+
+  it("persists a failed record for every throwing build, so open() never leaves the embed pending", async () => {
+    // The `ai` SDK wraps the provider message before it reaches the engine's
+    // swallowed issues, so the precise quota/timeout CLASS is asserted by the
+    // buildFailureReason unit tests below; here we assert the record is always
+    // persisted as a terminal failure open() resolves promptly.
+    const { runtime, store } = setup(throwingModel("insufficient quota (402)"));
+    const ctx = context("user_grace");
+    await expect(runtime.create({ prompt: "Dashboard" }, ctx)).rejects.toBeInstanceOf(VendoError);
+    const rows = await store.records("vendo_apps").list({});
+    const surface = await runtime.open(rows.records[0]!.id, ctx);
+    expect(surface).toMatchObject({ kind: "failed" });
+    expect((surface as { reason: string }).reason).toMatch(/\S/);
+  });
+
+  it("still throws not-found (→ the wire's {kind:\"pending\"}) for an app that never persisted", async () => {
+    const { runtime } = setup(throwingModel("boom"));
+    await expect(runtime.open("app_never", context("user_ada"))).rejects.toMatchObject({ code: "not-found" });
+  });
+});
+
+describe("buildFailureReason", () => {
+  it("maps an aborted turn to a retryable timeout", () => {
+    const aborted = Object.assign(new Error("aborted"), { name: "AbortError" });
+    expect(buildFailureReason(aborted)).toEqual({ reason: "timed out", retryable: true });
+  });
+
+  it("maps a 402 (statusCode or cloud-required) to a non-retryable quota exhaustion", () => {
+    expect(buildFailureReason(Object.assign(new Error("payment required"), { statusCode: 402 })))
+      .toEqual({ reason: "quota exhausted", retryable: false });
+    expect(buildFailureReason(new VendoError("cloud-required", "VENDO_API_KEY required")))
+      .toEqual({ reason: "quota exhausted", retryable: false });
+  });
+
+  it("classifies the terminal validation throw from its swallowed issues", () => {
+    expect(buildFailureReason(new VendoError("validation", "model could not produce a valid app", [
+      "model generation failed: insufficient quota",
+    ]))).toEqual({ reason: "quota exhausted", retryable: false });
+    expect(buildFailureReason(new VendoError("validation", "model could not produce a valid app", [
+      "model generation failed: the request timed out",
+    ]))).toEqual({ reason: "timed out", retryable: true });
+    expect(buildFailureReason(new VendoError("validation", "model could not produce a valid app", [
+      "model generation failed: unparseable output",
+    ]))).toEqual({ reason: "generation failed", retryable: true });
+  });
+});

--- a/packages/apps/src/index.ts
+++ b/packages/apps/src/index.ts
@@ -11,6 +11,7 @@
  * and reachable only through AppsRuntime.
  */
 export {
+  buildFailureReason,
   createApps,
   type AppsConfig,
   type AppsRuntime,

--- a/packages/apps/src/open.ts
+++ b/packages/apps/src/open.ts
@@ -238,6 +238,16 @@ export const createAppOpener = (
   inClientVenue?: (app: AppDocument) => Promise<InClientVenueState | undefined>,
   served?: ServedSurface,
 ): ((app: AppDocument, ctx: RunContext) => Promise<OpenSurface>) => async (app, ctx) => {
+  // A terminally failed build never becomes servable: resolve the poll now
+  // with the persisted reason (approvals resolve to denied/expired the same
+  // way) instead of leaving the embed to spin to its client deadline.
+  if (app.buildFailed !== undefined) {
+    return {
+      kind: "failed",
+      reason: app.buildFailed.reason,
+      ...(app.buildFailed.retryable === undefined ? {} : { retryable: app.buildFailed.retryable }),
+    };
+  }
   if (app.ui === "http") {
     // execution-v2 Wave 4 — the layer-3 served surface, host-gated behind the
     // experimental flag: opening a served app while the flag is off refuses

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -265,7 +265,59 @@ export interface VersionEntry {
 export type OpenSurface =
   | { kind: "tree"; payload: UIPayload; components?: Record<string, string> }
   | { kind: "http"; url: string }
-  | { kind: "resuming"; cover?: string };
+  | { kind: "resuming"; cover?: string }
+  /**
+   * The build turn terminally FAILED (model error, quota, timeout): the app
+   * will never become servable. Surfaced so the embed resolves promptly with
+   * the reason instead of polling to its client deadline — the same prompt
+   * resolution the approval embed gets from denied/expired.
+   */
+  | { kind: "failed"; reason: string; retryable?: boolean };
+
+/** The non-empty name a failed build record ships under (open() ignores it —
+ *  the embed's title rides the app-ref — but validateAppDocument requires one).
+ *  Collapsed and capped like the pack's fast-return title. */
+const fallbackAppName = (prompt: string): string => {
+  const collapsed = prompt.replace(/\s+/g, " ").trim();
+  if (collapsed.length === 0) return "Vendo app";
+  return collapsed.length > 60 ? collapsed.slice(0, 60) : collapsed;
+};
+
+const QUOTA_SIGNAL = /quota|insufficient|payment|billing|\b402\b/i;
+const TIMEOUT_SIGNAL = /time?d?\s*out|timeout|abort/i;
+
+/**
+ * Map a generation-turn throw to the short, honest, NON-LEAKY reason persisted
+ * on the failed app record. Only the CANNED reason is ever emitted — the raw
+ * provider message is used solely to classify, never surfaced.
+ *
+ * The engine's stream helper catches provider errors and folds their message
+ * into the `issues` of the terminal `VendoError("validation", "model could not
+ * produce a valid app")`, so the raw 402/AbortError rarely propagates intact:
+ * classify from a raw error when it does (quota/timeout/cloud-required), and
+ * otherwise scan the validation issues for the same signals, defaulting to a
+ * generic generation failure the user can retry.
+ */
+export const buildFailureReason = (
+  error: unknown,
+): { reason: string; retryable: boolean } => {
+  if (error instanceof Error && error.name === "AbortError") {
+    return { reason: "timed out", retryable: true };
+  }
+  const statusCode = (error as { statusCode?: unknown } | null)?.statusCode;
+  if (statusCode === 402 || (error instanceof VendoError && error.code === "cloud-required")) {
+    return { reason: "quota exhausted", retryable: false };
+  }
+  const text = [
+    error instanceof Error ? error.message : String(error),
+    ...(error instanceof VendoError && Array.isArray(error.detail)
+      ? error.detail.filter((item): item is string => typeof item === "string")
+      : []),
+  ].join(" ");
+  if (QUOTA_SIGNAL.test(text)) return { reason: "quota exhausted", retryable: false };
+  if (TIMEOUT_SIGNAL.test(text)) return { reason: "timed out", retryable: true };
+  return { reason: "generation failed", retryable: true };
+};
 
 /** execution-v2 Lane C — one HTTP request across the skin of the box (the
  * shape SandboxMachine.request speaks, named at the runtime surface). */
@@ -1583,16 +1635,34 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
           if (latestTree === undefined) return;
           emit({ ...structuredClone(latestTree), data, streaming: true } as TreeV2);
         });
-      const generated = await engine.create(
-        { prompt: input.prompt },
-        generationDependencies(config, config.model, await generationToolContext(ctx), input.onView === undefined ? undefined : (partial) => {
-          // v2 spec §1 — the payload carries islands at payload level (the
-          // renderer lifts them); a mid-stream payload is marked streaming.
-          latestTree = assembleTree(partial);
-          emit({ ...structuredClone(latestTree), streaming: true } as TreeV2);
-          queryResolver?.update(latestTree);
-        }),
-      );
+      let generated: Awaited<ReturnType<GenerationEngine["create"]>>;
+      try {
+        generated = await engine.create(
+          { prompt: input.prompt },
+          generationDependencies(config, config.model, await generationToolContext(ctx), input.onView === undefined ? undefined : (partial) => {
+            // v2 spec §1 — the payload carries islands at payload level (the
+            // renderer lifts them); a mid-stream payload is marked streaming.
+            latestTree = assembleTree(partial);
+            emit({ ...structuredClone(latestTree), streaming: true } as TreeV2);
+            queryResolver?.update(latestTree);
+          }),
+        );
+      } catch (error) {
+        // The build turn threw (model error, quota, timeout). `vendo_create_app`
+        // already returned an app-ref the instant the FIRST partial streamed, so
+        // the embed is mounted polling open() — with no persisted record it would
+        // spin to APP_BUILD_DEADLINE_MS and then show the generic failed beat.
+        // Persist a TERMINAL failed record so open() answers {kind:"failed"} with
+        // the reason on the very next poll — the prompt resolution approvals get.
+        const { reason, retryable } = buildFailureReason(error);
+        await apps.put(appRecordInput({
+          format: "vendo/app@1",
+          id: appId,
+          name: fallbackAppName(input.prompt),
+          buildFailed: { reason, retryable, at: new Date().toISOString() },
+        }, ctx.principal.subject)).catch(() => undefined);
+        throw error;
+      }
       const app: AppDocument = {
         ...generated,
         id: appId,
@@ -1603,6 +1673,10 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       // Lane E — same rule for egress grant state: a freshly generated app
       // has approved nothing, whatever the model emitted.
       delete app.egressApproved;
+      // buildFailed is server-written only (the create catch above): a
+      // successfully generated document never carries it, whatever the model
+      // emitted into the tree markup.
+      delete app.buildFailed;
       let finalTree: TreeV2 | undefined;
       if (input.onView !== undefined && app.tree?.formatVersion === VENDO_TREE_FORMAT_V2) {
         finalTree = assembleTree({ tree: app.tree, components: app.components, componentTools: app.componentTools });
@@ -1679,7 +1753,11 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       for (const record of records
         .sort((left, right) => right.createdAt.localeCompare(left.createdAt) || right.id.localeCompare(left.id))) {
         try {
-          documents.push(documentFromRecord(record));
+          const document = documentFromRecord(record);
+          // A terminally failed build is a tombstone open() reads to resolve
+          // the embed — not a real app; it never joins the listable surface.
+          if (document.buildFailed !== undefined) continue;
+          documents.push(document);
         } catch {
           // Corrupt rows cannot be surfaced, but must not hide valid owned apps.
         }

--- a/packages/core/src/app-document.ts
+++ b/packages/core/src/app-document.ts
@@ -23,6 +23,20 @@ export const storageDeclSchema = z.object({
   refs: z.record(z.string()).optional(),
 }).passthrough() satisfies z.ZodType<StorageDecl>;
 
+/**
+ * A terminal build failure recorded by the runtime when app generation threw
+ * (model error, quota exhaustion, timeout). SERVER-WRITTEN ONLY: the model
+ * never authors it — the runtime persists it on the create catch path so
+ * open() can surface `{kind:"failed"}` and the embed resolves PROMPTLY with the
+ * reason instead of spinning to the client build deadline. `reason` is a short,
+ * honest, non-leaky line (never a raw provider stack).
+ */
+export interface AppBuildFailure {
+  reason: string;
+  retryable?: boolean;
+  at: IsoDateTime;
+}
+
 /** 01-core §9 */
 export interface Pin {
   slot: string;
@@ -62,6 +76,13 @@ const appMachineSchema = z.object({
 }).passthrough() satisfies z.ZodType<AppMachine>;
 
 /** 01-core §9 */
+const appBuildFailureSchema = z.object({
+  reason: z.string(),
+  retryable: z.boolean().optional(),
+  at: isoDateTimeSchema,
+}).passthrough() satisfies z.ZodType<AppBuildFailure>;
+
+/** 01-core §9 */
 export interface AppDocument {
   format: typeof VENDO_APP_FORMAT;
   id: AppId;
@@ -96,6 +117,13 @@ export interface AppDocument {
   secrets?: string[];
   pins?: Pin[];
   forkedFrom?: AppId;
+  /**
+   * A terminal build failure. Present only on a record the runtime persisted
+   * when generation threw; open() reads it to answer `{kind:"failed"}`.
+   * Server-written — stripped from a successful create/edit like the other
+   * server-authoritative fields.
+   */
+  buildFailed?: AppBuildFailure;
 }
 
 /**
@@ -124,6 +152,7 @@ export const appDocumentSchema = z.object({
   secrets: z.array(z.string()).optional(),
   pins: z.array(pinSchema).optional(),
   forkedFrom: appIdSchema.optional(),
+  buildFailed: appBuildFailureSchema.optional(),
 }).passthrough() satisfies z.ZodType<AppDocument>;
 
 type AppDocumentValidation =

--- a/packages/core/src/tool-envelopes.ts
+++ b/packages/core/src/tool-envelopes.ts
@@ -13,8 +13,10 @@ import { appIdSchema, approvalIdSchema, type AppId, type ApprovalId } from "./id
 export const VENDO_APP_REF_KIND = "vendo/app-ref@1" as const;
 export const VENDO_APPROVAL_REF_KIND = "vendo/approval-ref@1" as const;
 
-/** `vendo_create_app` returned fast: the app exists and its build streams over
- *  the wire. `<VendoAppEmbed>` mounts the app by this ref. */
+/** `vendo_create_app` returned fast: the build was ACCEPTED and is still
+ *  streaming over the wire — the app is NOT built yet. `<VendoAppEmbed>` mounts
+ *  it by this ref and shows live build progress, the finished app, or the build
+ *  failure itself, so the model must not claim the app is created/ready/done. */
 export interface VendoAppRef {
   kind: typeof VENDO_APP_REF_KIND;
   appId: AppId;

--- a/packages/ui/src/chrome/embeds.tsx
+++ b/packages/ui/src/chrome/embeds.tsx
@@ -199,7 +199,7 @@ export function VendoAppEmbed({ refValue }: VendoAppEmbedProps) {
   const { client, components } = useVendoContext();
   const { appId, title } = refValue;
   const [surface, setSurface] = useState<OpenSurface>();
-  const [failed, setFailed] = useState<Error>();
+  const [failed, setFailed] = useState<{ reason: string }>();
 
   useEffect(() => {
     setSurface(undefined);
@@ -213,23 +213,31 @@ export function VendoAppEmbed({ refValue }: VendoAppEmbedProps) {
     // serve the flagged poll answers a quiet `{kind:"pending"}` (a wire that
     // predates the flag still 404s — the catch arm keeps the same cadence, so
     // older servers only lose the quiet console). Keep asking until the app
-    // lands or the deadline turns the beat into the failed vocabulary.
+    // lands, the build reports a terminal failure, or the deadline turns the
+    // beat into the failed vocabulary.
     const attempt = async () => {
       try {
         const next = await client.apps.open(appId, { pending: true });
         if (cancelled) return;
+        // A terminal build failure resolves the embed PROMPTLY with its
+        // reason — the same in-place resolution a denied/expired approval
+        // gets — never a wait for the client build deadline.
+        if (next.kind === "failed") {
+          setFailed({ reason: next.reason });
+          return;
+        }
         if (next.kind !== "pending") {
           setSurface(next);
           return;
         }
         if (Date.now() - startedAt >= APP_BUILD_DEADLINE_MS) {
-          setFailed(new Error(`app never became servable: ${appId}`));
+          setFailed({ reason: "the build never finished" });
           return;
         }
       } catch (reason) {
         if (cancelled) return;
         if (Date.now() - startedAt >= APP_BUILD_DEADLINE_MS) {
-          setFailed(asError(reason));
+          setFailed({ reason: asError(reason).message });
           return;
         }
       }
@@ -264,7 +272,10 @@ export function VendoAppEmbed({ refValue }: VendoAppEmbedProps) {
               onAction={({ action, payload }) => client.apps.call(appId, action, payload ?? {})}
             />
           ) : failed !== undefined ? (
-            <BeatLine state="error">{title} — couldn't finish</BeatLine>
+            <>
+              <BeatLine state="error">{title} — couldn't finish</BeatLine>
+              <div className="fl-approval-more">{failed.reason}</div>
+            </>
           ) : (
             <span className="fl-slot-skel" role="status" aria-label={`Building ${title}`}>
               <span className="fl-skel-line" style={{ width: "54%" }} />

--- a/packages/ui/src/wire-types.ts
+++ b/packages/ui/src/wire-types.ts
@@ -25,7 +25,13 @@ import type { UIMessage } from "ai";
 export type OpenSurface =
   | { kind: "tree"; payload: UIPayload; components?: Record<string, string> }
   | { kind: "http"; url: string }
-  | { kind: "resuming"; cover?: string };
+  | { kind: "resuming"; cover?: string }
+  /**
+   * The build turn terminally FAILED (model error, quota, timeout): the app
+   * will never become servable. The embed resolves promptly to the failed
+   * vocabulary with this reason instead of polling to its build deadline.
+   */
+  | { kind: "failed"; reason: string; retryable?: boolean };
 
 /** Existing-agents polish — the flag-gated build-window answer: what
  *  `GET /apps/:id/open?pending=1` returns while the app is not yet servable

--- a/packages/ui/test/embeds.test.tsx
+++ b/packages/ui/test/embeds.test.tsx
@@ -166,6 +166,20 @@ describe("existing-agents embeds", () => {
       expect(screen.getByText(/Building/)).toBeDefined();
     });
 
+    it("resolves the failed vocabulary WITH the reason promptly when the build terminally fails (#492)", async () => {
+      const doomed: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_doomed", title: "Budget tracker" };
+      // The build turn threw server-side: open() now answers {kind:"failed"}
+      // instead of an eternal pending, so the embed resolves on the FIRST poll
+      // rather than waiting for APP_BUILD_DEADLINE_MS.
+      wire.state.failedApps.set("app_doomed", { reason: "quota exhausted", retryable: false });
+      mount(<VendoAppEmbed refValue={doomed} />);
+      await waitFor(() => expect(screen.getByText(/couldn't finish/i)).toBeDefined());
+      // The honest reason is shown, not just the generic failed beat.
+      expect(screen.getByText("quota exhausted")).toBeDefined();
+      // Resolved terminally — no skeletons still building.
+      expect(screen.queryByRole("status")).toBeNull();
+    });
+
     it("resolves the build beat into the app when the build lands mid-poll", async () => {
       const late: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_late", title: "Late app" };
       mount(<VendoAppEmbed refValue={late} />);

--- a/packages/ui/test/wire-server.ts
+++ b/packages/ui/test/wire-server.ts
@@ -223,6 +223,10 @@ export async function createWireServer(options: WireServerOptions = {}) {
     // Existing-agents polish — how many open polls `app_building_lands`
     // misses before its build "lands" (the browser harness's build window).
     buildingOpensRemaining: 2,
+    // #492 — apps whose build turn terminally FAILED: a flagged open poll
+    // answers {kind:"failed"} with the reason (the record exists as a failure),
+    // so the embed resolves promptly instead of spinning to its deadline.
+    failedApps: new Map<string, { reason: string; retryable?: boolean }>(),
     statusErrorCode: undefined as string | undefined,
     failures: [] as Array<{ method: string; path: string; code: string; message: string; status: number }>,
     // ENG-214 — how many upcoming /threads turns die MID-stream (a partial
@@ -589,6 +593,13 @@ export async function createWireServer(options: WireServerOptions = {}) {
         }
         const index = state.apps.findIndex(item => item.id === id);
         if (index < 0) {
+          // #492 — a terminally failed build resolves open() with its reason
+          // whether or not the poll carried the pending flag (the failure
+          // record exists), so the embed shows the reason promptly.
+          if (action === "open" && method === "GET" && state.failedApps.has(id)) {
+            const failure = state.failedApps.get(id)!;
+            return json(response, { kind: "failed", reason: failure.reason, ...(failure.retryable === undefined ? {} : { retryable: failure.retryable }) });
+          }
           // The real wire's flag-gated build-window answer: a flagged open
           // poll gets a quiet 200 pending envelope instead of the 404.
           if (action === "open" && method === "GET" && url.searchParams.get("pending") === "1") {

--- a/packages/vendo/src/server.test.ts
+++ b/packages/vendo/src/server.test.ts
@@ -251,6 +251,24 @@ describe("09 §3 public wire", () => {
     expect(blocked.status).toBe(403);
   });
 
+  it("open passes a terminal build failure through as 200 {kind:'failed'} (#492)", async () => {
+    // A failed build persists a record, so open() returns {kind:"failed"} — not
+    // a not-found. It must flow through the wire verbatim (flagged or not) so
+    // the embed resolves promptly with the reason instead of the ?pending=1
+    // arm swallowing it into a spinning {kind:"pending"}.
+    const { vendo } = await setup();
+    stubRouteBlocks(vendo);
+    vi.spyOn(vendo.apps, "open").mockResolvedValue({ kind: "failed", reason: "quota exhausted", retryable: false });
+
+    const bare = await vendo.handler(request("GET", "/apps/app_doomed/open"));
+    expect(bare.status).toBe(200);
+    expect(await bare.json()).toEqual({ kind: "failed", reason: "quota exhausted", retryable: false });
+
+    const flagged = await vendo.handler(request("GET", "/apps/app_doomed/open?pending=1"));
+    expect(flagged.status).toBe(200);
+    expect(await flagged.json()).toEqual({ kind: "failed", reason: "quota exhausted", retryable: false });
+  });
+
   it("does not read history for an unowned app on GET or undo", async () => {
     const { vendo } = await setup();
     stubRouteBlocks(vendo);


### PR DESCRIPTION
Closes #492. Live dogfood: `vendo_create_app` returns an app-ref fast; when the server-side build turn fails (model/quota/timeout) the app record was never persisted, so `open(...,{pending:true})` returned `{kind:"pending"}` forever and `<VendoAppEmbed>` spun on "Building…" until only a long client deadline flipped it to a generic failure — no reason, no promptness (approval embeds resolve to denied/expired right away).

**Fix:** persist a terminal `buildFailed` record when `engine.create()` throws (honest, non-leaky reason classifier — timed out / quota exhausted / generation failed; raw provider text is used only to classify, never surfaced); `open()` returns a new terminal `{kind:"failed", reason, retryable?}`; threaded through the wire route (JSON passthrough) and the UI client; the embed resolves promptly on `failed` showing the reason, with the deadline kept as the never-reports fallback. `list()` skips the tombstones.

Secondary (per the issue): `VendoAppRef` JSDoc + the `vendo_create_app` description reworded so the model treats the ref as "accepted, building", not "built".

Doctor-code: justified skip — a per-request runtime build failure isn't a probeable wiring misconfiguration; it's the downstream consequence of conditions doctor already probes (E-TURN-001/E-CLOUD-001). Reasoning in the agent report; docs-anchor test stays green.

Tests (red-first): apps build-failure 6, ui embeds 15, vendo server 98; full touched suites green (core 611, agent 96, ui 548, apps 564, vendo 983), tsc clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Failed app builds now resolve promptly in the embed with a clear, honest reason instead of spinning until the client deadline. We persist a terminal failure server-side and surface it through `open()` and the UI.

- **Bug Fixes**
  - Apps runtime: on build errors, persist `buildFailed { reason, retryable?, at }` using `buildFailureReason` (quota exhausted / timed out / generation failed); `list()` skips these tombstones.
  - API: `OpenSurface` gains `{kind:"failed"}`; `apps.open()` returns it when present; the wire passes it through as 200 (also with `?pending=1`).
  - UI: `VendoAppEmbed` stops polling on `{kind:"failed"}` and shows the reason; the deadline remains a fallback for builds that never report.
  - Docs: clarified `vendo_create_app` and `VendoAppRef` mean “accepted, building” — not “built”.

<sup>Written for commit 4cc9e94a0df65e18a1ade66043611bc088fb59db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

