### PR TITLE
fixtures: adapt AppsPort mapping to OpenSurface's new failed variant (fixes red main)

### DIFF
--- a/fixtures/integration/src/harness.ts
+++ b/fixtures/integration/src/harness.ts
@@ -298,14 +298,17 @@ export async function createStack(options: StackOptions = {}): Promise<Stack> {
         return control.revoked.has(subject) ? null : { kind: "user", subject };
       },
     };
-    // AppsPort adapter over vendo.apps — AppsRuntime.open has an extra "resuming"
-    // variant AppsPort does not, so map it (the door is a viewer + runner, 10-mcp §4).
+    // AppsPort adapter over vendo.apps — AppsRuntime.open has extra "resuming"
+    // and "failed" variants AppsPort does not, so map positively like the
+    // production adapter in @vendoai/vendo server.ts (the door is a viewer +
+    // runner, 10-mcp §4).
     const appsPort: AppsPort = {
       list: (ctx) => vendo.apps.list(ctx),
       async open(appId, ctx) {
         const opened = await vendo.apps.open(appId, ctx);
-        if (opened.kind === "resuming") throw new Error("app is resuming; unreachable for the door viewer role");
-        return opened.kind === "tree" ? { kind: "tree", payload: opened.payload } : opened;
+        if (opened.kind === "tree") return { kind: "tree", payload: opened.payload };
+        if (opened.kind === "http") return { kind: "http", url: opened.url };
+        throw new Error(`app surface "${opened.kind}" is unreachable for the door viewer role`);
       },
       call: (appId, ref, args, ctx) => vendo.apps.call(appId, ref, args, ctx),
     };

--- a/fixtures/mcp-e2e/src/harness.ts
+++ b/fixtures/mcp-e2e/src/harness.ts
@@ -226,10 +226,9 @@ export async function createStack(options: StackOptions = {}): Promise<Stack> {
         return { kind: "http", url: `${origin}/fixture/apps/${HTTP_FIXTURE_APP_ID}` };
       }
       const opened = await apps.open(appId, ctx);
-      if (opened.kind === "resuming") throw new Error("rung-1 fixture cannot resume");
-      return opened.kind === "tree"
-        ? { kind: "tree", payload: opened.payload }
-        : opened;
+      if (opened.kind === "tree") return { kind: "tree", payload: opened.payload };
+      if (opened.kind === "http") return { kind: "http", url: opened.url };
+      throw new Error(`rung-1 fixture cannot serve app surface "${opened.kind}"`);
     },
     call: (appId, ref, args, ctx) => apps.call(appId, ref, args, ctx),
   };


### PR DESCRIPTION
main's typecheck is red since #502 (67e11ed4): it added `{ kind: "failed" }` to `AppsRuntime`'s `OpenSurface`, and the `integration` + `mcp-e2e` fixture adapters narrowed the union by excluding only `resuming`, so the new variant leaks into `AppsPort`'s `tree | http` return type — `src/harness.ts(305,13)` and `(224,11)` TS2322.

Fix: match positively (return `tree`/`http`, throw with the surface kind otherwise), mirroring the production adapter in `@vendoai/vendo` `server.ts` — which is why product packages kept typechecking while only fixtures broke. Behavior for a failed build in these harnesses = loud throw with the reason kind, same as the existing `resuming` handling.

Gates: `pnpm build && pnpm test && pnpm typecheck && pnpm lint` all green locally. Blocks #500 (its merge-with-main CI inherits the red).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes red typecheck on main by updating fixture `AppsPort` adapters to handle `OpenSurface`’s new `failed` variant. Only `tree` and `http` are returned; other kinds throw. Mirrors the production adapter in `@vendoai/vendo`.

- **Bug Fixes**
  - Updated `fixtures/integration` and `fixtures/mcp-e2e` harnesses to match positively on `tree`/`http` and throw for `resuming` or `failed`.
  - Keeps `AppsPort.open` return type as `tree | http` and prevents the `failed` variant from leaking into types (introduced in #502).

<sup>Written for commit b7b8cf66cf88869e5ca056e8ee620b73c22e6db8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

