### PR TITLE
examples/ai-sdk-agent: 120s timeout for live-model e2e turns (fixes #501)

### DIFF
--- a/examples/ai-sdk-agent/vitest.config.ts
+++ b/examples/ai-sdk-agent/vitest.config.ts
@@ -4,7 +4,10 @@ export default defineConfig({
   test: {
     include: ["e2e/**/*.test.ts"],
     environment: "node",
-    testTimeout: 30_000,
-    hookTimeout: 30_000,
+    // Live model turns: 30s flaked twice in one day on model latency alone
+    // (release runs for v0.4.0 and v0.4.1, issue #501). mastra-agent already
+    // runs 60s; these turns compose a full agent first, so give them 120s.
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
   },
 });


### PR DESCRIPTION
The live-turn e2e suite runs real model calls with vitest's 30s default. It timed out in both of today's release runs (v0.4.0: run 29849964135, v0.4.1: run 29862136558) purely on model latency — each time the sibling turns in the same file passed and the re-run was green, so this is headroom, not a regression. An unattended release pipeline can't carry a test that needs a babysitter.

`mastra-agent` already uses 60s; these turns compose a full agent before the live call, so 120s.

Fixes #501.

Gates: suite green locally; config-only change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase `vitest` timeouts for live-model e2e turns from 30s to 120s to handle model latency and stop flaky release runs. Fixes #501.

- **Bug Fixes**
  - Update `examples/ai-sdk-agent/vitest.config.ts`: set `testTimeout` and `hookTimeout` to `120_000` (was `30_000`).

<sup>Written for commit f4adb712c18005dec43347ce0b8c331da4ce47b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

