### PR TITLE
release: publish tarballs with npm CLI — pnpm 11's OIDC token exchange 404s against npmjs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,16 @@ on:
   # or tagging. Runs the exact gate stack + `pnpm -r publish --dry-run`.
   workflow_dispatch:
 
-# id-token: write powers npm trusted publishing (OIDC) AND provenance: pnpm
-# exchanges the workflow's OIDC token for a short-lived npm credential, so
+# id-token: write powers npm trusted publishing (OIDC) AND provenance: the
+# workflow's OIDC token is exchanged for a short-lived npm credential, so
 # there is no NPM_TOKEN secret anywhere. Each package on npmjs.com lists this
 # repo + this workflow file as its trusted publisher (see PUBLISH.md).
+#
+# The publish itself uses the npm CLI (>= 11.5.1), not `pnpm publish`: pnpm
+# 11.10's own token exchange 404s against npmjs ("Unknown error"), verified
+# 2026-07-21 with a per-package exchange probe that returned 201 for the same
+# claims via the documented endpoint. pnpm still does the packing, because
+# `pnpm pack` rewrites workspace:* deps to real versions.
 permissions:
   contents: read
   id-token: write
@@ -63,9 +69,27 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: pnpm -r --filter './packages/*' publish --dry-run --no-git-checks --access public
 
-      # Real publish (v* tag): pnpm -r skips any version already on the registry
-      # (e.g. hand-versioned @vendoai/telemetry), so re-runs are safe.
-      # Auth is OIDC trusted publishing — no token env by design.
+      # Real publish (v* tag): pack every public workspace with pnpm (rewrites
+      # workspace:*), then publish each tarball with npm's OIDC trusted
+      # publishing + provenance. Versions already on the registry are skipped,
+      # so re-runs are safe. No token env by design.
       - name: Publish to npm
         if: github.event_name == 'push'
-        run: pnpm -r --filter './packages/*' publish --no-git-checks --access public --provenance
+        run: |
+          set -euo pipefail
+          npm install -g npm@11
+          npm --version
+          rm -rf /tmp/vendo-tarballs && mkdir -p /tmp/vendo-tarballs
+          pnpm -r --filter './packages/*' exec pnpm pack --out /tmp/vendo-tarballs/%s-%v.tgz
+          failed=0
+          while IFS= read -r tarball; do
+            name=$(tar -xzOf "$tarball" package/package.json | jq -r .name)
+            version=$(tar -xzOf "$tarball" package/package.json | jq -r .version)
+            if npm view "$name@$version" version >/dev/null 2>&1; then
+              echo "skip $name@$version (already on the registry)"
+              continue
+            fi
+            echo "publish $name@$version"
+            npm publish "$tarball" --access public --provenance || failed=1
+          done < <(find /tmp/vendo-tarballs -name '*.tgz' | sort)
+          exit "$failed"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,15 +81,22 @@ jobs:
           npm --version
           rm -rf /tmp/vendo-tarballs && mkdir -p /tmp/vendo-tarballs
           pnpm -r --filter './packages/*' exec pnpm pack --out /tmp/vendo-tarballs/%s-%v.tgz
-          failed=0
+          # Map package name -> tarball, then publish in DEPENDENCY order
+          # (pnpm -r exec runs topologically, umbrella last). Alphabetical
+          # order would publish the vendoai umbrella first — a mid-run
+          # failure would then leave an installable version pointing at
+          # unpublished deps.
+          declare -A TARBALL
           while IFS= read -r tarball; do
-            name=$(tar -xzOf "$tarball" package/package.json | jq -r .name)
+            TARBALL[$(tar -xzOf "$tarball" package/package.json | jq -r .name)]=$tarball
+          done < <(find /tmp/vendo-tarballs -name '*.tgz')
+          while IFS= read -r name; do
+            tarball=${TARBALL[$name]:?no tarball packed for $name}
             version=$(tar -xzOf "$tarball" package/package.json | jq -r .version)
             if npm view "$name@$version" version >/dev/null 2>&1; then
               echo "skip $name@$version (already on the registry)"
               continue
             fi
             echo "publish $name@$version"
-            npm publish "$tarball" --access public --provenance || failed=1
-          done < <(find /tmp/vendo-tarballs -name '*.tgz' | sort)
-          exit "$failed"
+            npm publish "$tarball" --access public --provenance
+          done < <(pnpm -r --filter './packages/*' exec node -e "process.stdout.write(require('./package.json').name+'\n')")

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -107,7 +107,10 @@ The Release workflow already carries `permissions: id-token: write` and
 deliberately does **not** set `registry-url` on setup-node — setup-node would
 write an `_authToken` placeholder into `.npmrc` that defeats OIDC
 (actions/setup-node#1551). Don't add it back, and never add an `NPM_TOKEN`
-secret; there is none by design.
+secret; there is none by design. The CI publish runs `pnpm pack` + `npm
+publish <tarball>` rather than `pnpm publish`: pnpm 11.10's own OIDC token
+exchange 404s against npmjs while the npm CLI (>= 11.5.1) works — don't
+"simplify" it back to `pnpm publish` without re-testing that.
 
 ## Step 5 — clean-room verification
 


### PR DESCRIPTION
## What

The v0.4.1 release run (29863789936) passed every gate and then failed the publish step: `pnpm publish`'s built-in OIDC exchange returned `ERR_PNPM_AUTH_TOKEN_EXCHANGE ... Unknown error (status code 404)` and skipped OIDC, so the PUTs went unauthenticated.

A per-package probe from a debug branch (run 29865453593, same `release.yml` filename claim) hit npm's documented exchange endpoint directly and got **HTTP 201 for 11/13 packages** — so the trusted-publisher configs and OIDC claims are fine; pnpm 11.10's exchange client is what's broken ("Unknown error" = wrong endpoint, vs npm's real miss message "package not found"). The two 404s (`@vendoai/ui`, `@vendoai/engine`) were genuinely unconfigured and are being added on npmjs.com.

## Change

- Publish step: `pnpm -r exec pnpm pack` (rewrites `workspace:*` to real versions — verified locally, 13 tarballs, zero workspace refs) → `npm publish <tarball> --access public --provenance` with npm@11 (>= 11.5.1 required for trusted publishing), skipping versions already on the registry so re-runs stay safe.
- PUBLISH.md: note not to simplify back to `pnpm publish` without re-testing.

## Verification

- actionlint clean; pack recipe tested locally (13 tarballs, workspace refs rewritten).
- Tree is otherwise identical to ad1068ce, which passed the full gate stack in run 29863789936 forty minutes ago.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches release publishing to `pnpm pack` + `npm publish` to work around `pnpm` 11’s broken OIDC exchange (404). Keeps trusted publishing, provenance, dependency-ordered publishes, and safe re-runs.

- Bug Fixes
  - Pack each workspace with `pnpm -r exec pnpm pack` (rewrites `workspace:*`), then publish tarballs with `npm@11` and `--provenance` in dependency order; fail fast.
  - Skip versions that already exist on the registry to allow safe re-runs.
  - Preserve OIDC trusted publishing (`id-token: write`); no `NPM_TOKEN` or `registry-url`.
  - Update PUBLISH.md to document the `pnpm publish` issue and the current approach.

<sup>Written for commit c1b5700e466aa96ffde00340f8a9d48dd35761ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

