### PR TITLE
cli: per-project login claims + init installs the credential's model provider (0.4.2)

### DIFF
--- a/.changeset/cli-042-login-provider-fixes.md
+++ b/.changeset/cli-042-login-provider-fixes.md
@@ -1,0 +1,13 @@
+---
+"@vendoai/vendo": patch
+---
+
+Login and first-turn fixes from the 0.4.1 E2E certification campaign:
+`vendo login` pending claims are now scoped per project directory —
+concurrent logins in different repos can no longer clobber or resume each
+other's ceremonies (the machine-global file could deliver one project's key
+to another). A matching pre-0.4.2 claim file is migrated automatically.
+`vendo init` now installs the model provider its resolved credential loads
+at runtime (`ai@^6` plus `@ai-sdk/anthropic@^3` / `@ai-sdk/openai@^3` /
+`@ai-sdk/google@^3`), so the first turn no longer 500s on a fresh install
+until the provider is added by hand.

--- a/packages/vendo/src/cli/cloud/device-login.test.ts
+++ b/packages/vendo/src/cli/cloud/device-login.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -274,18 +275,22 @@ describe("runDeviceLogin", () => {
 // so a fresh `vendo login` can resume polling after the original process dies
 // and a late human approval still lands the key.
 describe("pending claim persistence", () => {
-  const pendingPath = (home: string) => join(home, ".vendo", "pending-claim.json");
+  // Claims are scoped per project directory (0.4.2): the file name is the
+  // cwd hash, so concurrent logins in different repos cannot clobber or
+  // resume each other's ceremonies.
+  const pendingPath = (home: string, cwd: string) =>
+    join(home, ".vendo", "pending-claims", `${createHash("sha256").update(cwd).digest("hex").slice(0, 16)}.json`);
 
-  async function writePending(home: string, overrides: Record<string, unknown> = {}): Promise<void> {
-    await mkdir(join(home, ".vendo"), { recursive: true });
-    await writeFile(pendingPath(home), JSON.stringify({
+  async function writePending(home: string, cwd: string, overrides: Record<string, unknown> = {}): Promise<void> {
+    await mkdir(join(pendingPath(home, cwd), ".."), { recursive: true });
+    await writeFile(pendingPath(home, cwd), JSON.stringify({
       claim_token: `vct_${"c".repeat(64)}`,
       user_code: "WXYZ-PQRS",
       verification_uri_complete: "https://console.test/claim?code=WXYZ-PQRS",
       expires_at: Date.now() + 600_000,
       interval: 5,
       api_url: "https://console.test",
-      cwd: home,
+      cwd,
       ...overrides,
     }));
   }
@@ -304,8 +309,8 @@ describe("pending claim persistence", () => {
       root,
       home,
       sleep: async () => {
-        const mode = (await stat(pendingPath(home))).mode & 0o777;
-        seenDuringPoll.push({ ...JSON.parse(await readFile(pendingPath(home), "utf8")), mode });
+        const mode = (await stat(pendingPath(home, root))).mode & 0o777;
+        seenDuringPoll.push({ ...JSON.parse(await readFile(pendingPath(home, root), "utf8")), mode });
       },
       env: {},
       isTty: false,
@@ -323,14 +328,13 @@ describe("pending claim persistence", () => {
     });
     expect(typeof (seenDuringPoll[0] as { expires_at: unknown }).expires_at).toBe("number");
     // Redeemed — nothing left to resume.
-    await expect(stat(pendingPath(home))).rejects.toThrow();
+    await expect(stat(pendingPath(home, root))).rejects.toThrow();
   });
 
-  it("resumes a pending claim: polls the same claim_token without re-opening a claim", async () => {
+  it("resumes this project's pending claim: polls the same claim_token without re-opening", async () => {
     const home = await tempRoot();
-    const originalCwd = await tempRoot();
-    const otherCwd = await tempRoot();
-    await writePending(home, { cwd: originalCwd });
+    const projectCwd = await tempRoot();
+    await writePending(home, projectCwd);
     const { fetchImpl, requests } = scriptedFetch([
       { status: 200, body: { access_token: KEY, token_type: "Bearer" } },
     ]);
@@ -338,7 +342,7 @@ describe("pending claim persistence", () => {
     const exit = await runDeviceLogin(["--api-url", "https://console.test"], {
       output: messages.sink,
       fetchImpl,
-      root: otherCwd,
+      root: projectCwd,
       home,
       sleep: async () => {},
       env: {},
@@ -352,24 +356,82 @@ describe("pending claim persistence", () => {
     expect(messages.logs.join("\n")).toContain(
       "Resuming pending approval — code WXYZ-PQRS, approve at https://console.test/claim?code=WXYZ-PQRS",
     );
-    // The key lands where the ORIGINAL run intended, and the output says so.
-    const envLocal = await readFile(join(originalCwd, ".env.local"), "utf8");
+    const envLocal = await readFile(join(projectCwd, ".env.local"), "utf8");
     expect(envLocal).toContain(`VENDO_API_KEY=${KEY}`);
-    await expect(readFile(join(otherCwd, ".env.local"), "utf8")).rejects.toThrow();
-    expect(messages.logs.join("\n")).toContain(join(originalCwd, ".env.local"));
-    await expect(stat(pendingPath(home))).rejects.toThrow();
+    await expect(stat(pendingPath(home, projectCwd))).rejects.toThrow();
   });
 
-  it("discards an expired pending claim and opens a fresh one", async () => {
+  it("never resumes ANOTHER project's claim — a fresh ceremony opens and theirs survives (0.4.2)", async () => {
     const home = await tempRoot();
-    await writePending(home, { expires_at: Date.now() - 1_000 });
+    const otherProject = await tempRoot();
+    const thisProject = await tempRoot();
+    await writePending(home, otherProject);
     const { fetchImpl, requests } = scriptedFetch([
       { status: 200, body: { access_token: KEY, token_type: "Bearer" } },
     ]);
     const exit = await runDeviceLogin(["--api-url", "https://console.test"], {
       output: output().sink,
       fetchImpl,
-      root: await tempRoot(),
+      root: thisProject,
+      home,
+      sleep: async () => {},
+      env: {},
+      isTty: false,
+    });
+    expect(exit).toBe(0);
+    // A fresh ceremony was opened for THIS project…
+    expect(requests[0].url).toBe("https://console.test/api/v1/agent/claim");
+    // …the key lands here, not in the other project…
+    expect(await readFile(join(thisProject, ".env.local"), "utf8")).toContain(`VENDO_API_KEY=${KEY}`);
+    await expect(readFile(join(otherProject, ".env.local"), "utf8")).rejects.toThrow();
+    // …and the other project's pending ceremony is untouched, still resumable.
+    await expect(stat(pendingPath(home, otherProject))).resolves.toBeTruthy();
+  });
+
+  it("migrates a matching pre-0.4.2 machine-global claim file and resumes it", async () => {
+    const home = await tempRoot();
+    const projectCwd = await tempRoot();
+    const legacyPath = join(home, ".vendo", "pending-claim.json");
+    await mkdir(join(home, ".vendo"), { recursive: true });
+    await writeFile(legacyPath, JSON.stringify({
+      claim_token: `vct_${"c".repeat(64)}`,
+      user_code: "WXYZ-PQRS",
+      verification_uri_complete: "https://console.test/claim?code=WXYZ-PQRS",
+      expires_at: Date.now() + 600_000,
+      interval: 5,
+      api_url: "https://console.test",
+      cwd: projectCwd,
+    }));
+    const { fetchImpl, requests } = scriptedFetch([
+      { status: 200, body: { access_token: KEY, token_type: "Bearer" } },
+    ]);
+    const exit = await runDeviceLogin(["--api-url", "https://console.test"], {
+      output: output().sink,
+      fetchImpl,
+      root: projectCwd,
+      home,
+      sleep: async () => {},
+      env: {},
+      isTty: false,
+    });
+    expect(exit).toBe(0);
+    // Resumed (no fresh claim), key landed, and the legacy file is gone.
+    expect(requests.some((request) => request.url.endsWith("/api/v1/agent/claim"))).toBe(false);
+    expect(await readFile(join(projectCwd, ".env.local"), "utf8")).toContain(`VENDO_API_KEY=${KEY}`);
+    await expect(stat(legacyPath)).rejects.toThrow();
+  });
+
+  it("discards an expired pending claim and opens a fresh one", async () => {
+    const home = await tempRoot();
+    const root = await tempRoot();
+    await writePending(home, root, { expires_at: Date.now() - 1_000 });
+    const { fetchImpl, requests } = scriptedFetch([
+      { status: 200, body: { access_token: KEY, token_type: "Bearer" } },
+    ]);
+    const exit = await runDeviceLogin(["--api-url", "https://console.test"], {
+      output: output().sink,
+      fetchImpl,
+      root,
       home,
       sleep: async () => {},
       env: {},
@@ -383,18 +445,19 @@ describe("pending claim persistence", () => {
 
   it("removes the pending claim when the human denies the request", async () => {
     const home = await tempRoot();
+    const root = await tempRoot();
     const { fetchImpl } = scriptedFetch([{ status: 400, body: { error: "access_denied" } }]);
     const exit = await runDeviceLogin(["--api-url", "https://console.test"], {
       output: output().sink,
       fetchImpl,
-      root: await tempRoot(),
+      root,
       home,
       sleep: async () => {},
       env: {},
       isTty: false,
     });
     expect(exit).toBe(1);
-    await expect(stat(pendingPath(home))).rejects.toThrow();
+    await expect(stat(pendingPath(home, root))).rejects.toThrow();
   });
 });
 
@@ -402,20 +465,24 @@ describe("pending claim persistence", () => {
 // long ONE call polls before exiting resumably, so a coding agent can loop
 // short re-runs (each resuming the same claim) instead of a 10-min block.
 describe("bounded --wait budget (#479)", () => {
-  const pendingPath = (home: string) => join(home, ".vendo", "pending-claim.json");
+  // Claims are scoped per project directory (0.4.2): the file name is the
+  // cwd hash, so concurrent logins in different repos cannot clobber or
+  // resume each other's ceremonies.
+  const pendingPath = (home: string, cwd: string) =>
+    join(home, ".vendo", "pending-claims", `${createHash("sha256").update(cwd).digest("hex").slice(0, 16)}.json`);
   const tokenPolls = (requests: Array<{ url: string }>) =>
     requests.filter((request) => request.url.endsWith("/api/v1/oauth/token"));
 
-  async function writePending(home: string, overrides: Record<string, unknown> = {}): Promise<void> {
-    await mkdir(join(home, ".vendo"), { recursive: true });
-    await writeFile(pendingPath(home), JSON.stringify({
+  async function writePending(home: string, cwd: string, overrides: Record<string, unknown> = {}): Promise<void> {
+    await mkdir(join(pendingPath(home, cwd), ".."), { recursive: true });
+    await writeFile(pendingPath(home, cwd), JSON.stringify({
       claim_token: `vct_${"c".repeat(64)}`,
       user_code: "WXYZ-PQRS",
       verification_uri_complete: "https://console.test/claim?code=WXYZ-PQRS",
       expires_at: Date.now() + 600_000,
       interval: 5,
       api_url: "https://console.test",
-      cwd: home,
+      cwd,
       ...overrides,
     }));
   }
@@ -444,7 +511,7 @@ describe("bounded --wait budget (#479)", () => {
     expect(exit).toBe(0);
     expect(messages.errors).toEqual([]);
     // The claim file stays on disk for the next re-run to resume.
-    await expect(stat(pendingPath(home))).resolves.toBeTruthy();
+    await expect(stat(pendingPath(home, root))).resolves.toBeTruthy();
     // No key was written.
     await expect(readFile(join(root, ".env.local"), "utf8")).rejects.toThrow();
     // The resumable line + budget hint were printed, with the JSON pending shape.
@@ -463,16 +530,15 @@ describe("bounded --wait budget (#479)", () => {
 
   it("(b) a --wait re-run resumes the same claim_token and lands the key when approval arrives", async () => {
     const home = await tempRoot();
-    const originalCwd = await tempRoot();
-    const otherCwd = await tempRoot();
-    await writePending(home, { cwd: originalCwd });
+    const projectCwd = await tempRoot();
+    await writePending(home, projectCwd);
     const { fetchImpl, requests } = scriptedFetch([
       { status: 200, body: { access_token: KEY, token_type: "Bearer" } },
     ]);
     const exit = await runDeviceLogin(["--api-url", "https://console.test", "--wait", "90"], {
       output: output().sink,
       fetchImpl,
-      root: otherCwd,
+      root: projectCwd,
       home,
       sleep: async () => {},
       env: {},
@@ -482,10 +548,10 @@ describe("bounded --wait budget (#479)", () => {
     // No new claim opened — it polls the persisted claim_token directly.
     expect(requests.some((request) => request.url.endsWith("/api/v1/agent/claim"))).toBe(false);
     expect(new URLSearchParams(requests[0].body).get("claim_token")).toBe(`vct_${"c".repeat(64)}`);
-    // The key lands where the ORIGINAL run intended, and the pending file is gone.
-    const envLocal = await readFile(join(originalCwd, ".env.local"), "utf8");
+    // The key landed and the pending file is gone.
+    const envLocal = await readFile(join(projectCwd, ".env.local"), "utf8");
     expect(envLocal).toContain(`VENDO_API_KEY=${KEY}`);
-    await expect(stat(pendingPath(home))).rejects.toThrow();
+    await expect(stat(pendingPath(home, projectCwd))).rejects.toThrow();
   });
 
   it("(c) without --wait the call still blocks to the claim deadline (unchanged)", async () => {
@@ -513,7 +579,7 @@ describe("bounded --wait budget (#479)", () => {
     expect(exit).toBe(1);
     expect(messages.errors.join("\n")).toContain("expired");
     expect(messages.logs.join("\n")).not.toContain("Still waiting on approval");
-    await expect(stat(pendingPath(home))).rejects.toThrow();
+    await expect(stat(pendingPath(home, root))).rejects.toThrow();
   });
 
   it("(d) --wait 0 does exactly one poll then exits resumably if still pending", async () => {
@@ -540,7 +606,7 @@ describe("bounded --wait budget (#479)", () => {
     expect(tokenPolls(requests)).toHaveLength(1);
     expect(sleeps).toEqual([]);
     // Still resumable: claim on disk, no key, resumable line printed.
-    await expect(stat(pendingPath(home))).resolves.toBeTruthy();
+    await expect(stat(pendingPath(home, root))).resolves.toBeTruthy();
     await expect(readFile(join(root, ".env.local"), "utf8")).rejects.toThrow();
     expect(messages.logs.join("\n")).toContain("Still waiting on approval — code BCDF-GHJK");
   });
@@ -548,7 +614,7 @@ describe("bounded --wait budget (#479)", () => {
   it("(f) a terminal token error (invalid_grant) deletes the pending claim — no resume trap", async () => {
     const root = await tempRoot();
     const home = await tempRoot();
-    await writePending(home, { cwd: root });
+    await writePending(home, root);
     // Server says the claim is consumed/denied: single-use, never succeeds again.
     const { fetchImpl } = scriptedFetch([
       { status: 400, body: { error: "invalid_grant" } },
@@ -565,7 +631,7 @@ describe("bounded --wait budget (#479)", () => {
     });
     expect(exit).toBe(1);
     // The dead claim is gone: the next `vendo login` opens a fresh one.
-    await expect(stat(pendingPath(home))).rejects.toThrow();
+    await expect(stat(pendingPath(home, root))).rejects.toThrow();
   });
 
   it("(e) caps the pacing sleep to the remaining budget so a sub-interval --wait honors its bound", async () => {

--- a/packages/vendo/src/cli/cloud/device-login.ts
+++ b/packages/vendo/src/cli/cloud/device-login.ts
@@ -145,14 +145,17 @@ export async function runDeviceLogin(
   const waitMs = waitSeconds === undefined ? undefined : waitSeconds * 1000;
 
   const pendingHome = options.home === undefined ? {} : { home: options.home };
+  const claimCwd = options.root ?? process.cwd();
 
   try {
     // A still-open claim from a dead process (#479): resume polling it so the
     // human's late approval — against the code they were already shown —
-    // still lands the key. An expired or unreadable file is discarded (a
-    // fresh ceremony overwrites it below).
-    const pending = await readPendingClaim(pendingHome);
-    const resume = pending !== null && pending.api_url === base && pending.expires_at > now()
+    // still lands the key. Claims are scoped per project directory (0.4.2):
+    // only THIS cwd's ceremony is ever resumed, so concurrent logins in other
+    // repos neither clobber this one nor get resumed by it. An expired or
+    // unreadable file is discarded (a fresh ceremony overwrites it below).
+    const pending = await readPendingClaim(claimCwd, pendingHome);
+    const resume = pending !== null && pending.api_url === base && pending.cwd === claimCwd && pending.expires_at > now()
       ? pending
       : null;
 
@@ -250,7 +253,7 @@ export async function runDeviceLogin(
           throw new Error("Vendo Cloud returned an invalid credential");
         }
         await upsertEnvLocal(root, "VENDO_API_KEY", key);
-        await deletePendingClaim(pendingHome);
+        await deletePendingClaim(claimCwd, pendingHome);
         // Never print the key itself — .env.local is the hand-off, last4 the
         // receipt. A resumed run names the full path: it may differ from cwd.
         output.log(`Approved — wrote VENDO_API_KEY (…${key.slice(-4)}) to ${
@@ -266,11 +269,11 @@ export async function runDeviceLogin(
       if (error === "authorization_pending") return "pending";
       if (error === "slow_down") return "slow_down"; // RFC 8628 §3.5
       if (error === "expired_token") {
-        await deletePendingClaim(pendingHome);
+        await deletePendingClaim(claimCwd, pendingHome);
         throw new Error("The code expired before it was approved; run `vendo login` again.");
       }
       if (error === "access_denied") {
-        await deletePendingClaim(pendingHome);
+        await deletePendingClaim(claimCwd, pendingHome);
         throw new Error("Your human denied the request — no key was minted.");
       }
       // Any other token error is terminal for THIS claim (invalid_grant =
@@ -278,7 +281,7 @@ export async function runDeviceLogin(
       // again). Delete the pending file so the next `vendo login` opens a
       // fresh claim instead of resuming into the same error forever — the
       // exact trap a live install hit.
-      await deletePendingClaim(pendingHome);
+      await deletePendingClaim(claimCwd, pendingHome);
       const description = (poll.body as { error_description?: unknown } | null)?.error_description;
       throw new Error(
         typeof description === "string"
@@ -308,7 +311,7 @@ export async function runDeviceLogin(
         if (result === "approved") return 0;
         if (result === "slow_down") intervalMs += 5000;
       }
-      await deletePendingClaim(pendingHome);
+      await deletePendingClaim(claimCwd, pendingHome);
       throw new Error("The code expired before it was approved; run `vendo login` again.");
     }
 
@@ -320,7 +323,7 @@ export async function runDeviceLogin(
       if (result === "approved") return 0;
       if (result === "slow_down") intervalMs += 5000;
       if (now() >= deadline) {
-        await deletePendingClaim(pendingHome);
+        await deletePendingClaim(claimCwd, pendingHome);
         throw new Error("The code expired before it was approved; run `vendo login` again.");
       }
       if (now() >= pollDeadline) return pendingExit();

--- a/packages/vendo/src/cli/cloud/pending-claim.ts
+++ b/packages/vendo/src/cli/cloud/pending-claim.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -28,7 +29,17 @@ export interface PendingClaimOptions {
   home?: string;
 }
 
-function pendingClaimPath(options: PendingClaimOptions = {}): string {
+/** Claims are keyed by the project directory they were opened for. A single
+    machine-global file let two concurrent `vendo login` runs clobber each
+    other, and let project A resume (and receive the key for) project B's
+    ceremony — found by the 0.4.1 E2E certification campaign. */
+function pendingClaimPath(cwd: string, options: PendingClaimOptions = {}): string {
+  const name = `${createHash("sha256").update(cwd).digest("hex").slice(0, 16)}.json`;
+  return join(options.home ?? homedir(), ".vendo", "pending-claims", name);
+}
+
+/** The pre-0.4.2 machine-global location — read once for migration. */
+function legacyPendingClaimPath(options: PendingClaimOptions = {}): string {
   return join(options.home ?? homedir(), ".vendo", "pending-claim.json");
 }
 
@@ -44,24 +55,38 @@ function isPendingClaim(value: unknown): value is PendingClaim {
     && typeof claim.cwd === "string";
 }
 
-/** An unreadable or malformed file reads as "no pending claim" — the caller
-    discards it by opening (and persisting) a fresh ceremony. */
-export async function readPendingClaim(options: PendingClaimOptions = {}): Promise<PendingClaim | null> {
+async function readClaimFile(path: string): Promise<PendingClaim | null> {
   try {
-    const value: unknown = JSON.parse(await readFile(pendingClaimPath(options), "utf8"));
+    const value: unknown = JSON.parse(await readFile(path, "utf8"));
     return isPendingClaim(value) ? value : null;
   } catch {
     return null;
   }
 }
 
+/** An unreadable or malformed file reads as "no pending claim" — the caller
+    discards it by opening (and persisting) a fresh ceremony. Only a claim
+    opened for THIS cwd is ever returned. A pre-0.4.2 machine-global file is
+    honored (and migrated) only when its recorded cwd matches; someone else's
+    ceremony is never resumed. */
+export async function readPendingClaim(cwd: string, options: PendingClaimOptions = {}): Promise<PendingClaim | null> {
+  const scoped = await readClaimFile(pendingClaimPath(cwd, options));
+  if (scoped !== null) return scoped.cwd === cwd ? scoped : null;
+
+  const legacy = await readClaimFile(legacyPendingClaimPath(options));
+  if (legacy === null || legacy.cwd !== cwd) return null;
+  await writePendingClaim(legacy, options);
+  await rm(legacyPendingClaimPath(options), { force: true });
+  return legacy;
+}
+
 export async function writePendingClaim(claim: PendingClaim, options: PendingClaimOptions = {}): Promise<void> {
-  const path = pendingClaimPath(options);
+  const path = pendingClaimPath(claim.cwd, options);
   await mkdir(join(path, ".."), { recursive: true, mode: 0o700 });
   await writeFile(path, `${JSON.stringify(claim, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
   await chmod(path, 0o600);
 }
 
-export async function deletePendingClaim(options: PendingClaimOptions = {}): Promise<void> {
-  await rm(pendingClaimPath(options), { force: true });
+export async function deletePendingClaim(cwd: string, options: PendingClaimOptions = {}): Promise<void> {
+  await rm(pendingClaimPath(cwd, options), { force: true });
 }

--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -1287,6 +1287,7 @@ describe("vendo init (zero-question)", () => {
       "",
     ].join("\n"));
     const seenEnv: Array<Record<string, string | undefined>> = [];
+    const installs: Array<{ command: string; args: string[] }> = [];
     const sink = output();
     expect(await runInit({
       targetDir: root,
@@ -1297,8 +1298,15 @@ describe("vendo init (zero-question)", () => {
         seenEnv.push(env);
         return { rung: "env-key", provider: "anthropic", envVar: "ANTHROPIC_API_KEY" };
       },
+      installProvider: async (command, args) => {
+        installs.push({ command, args });
+        return 0;
+      },
       cloud: { confirm: async () => false },
     })).toBe(0);
+    // A resolved credential installs the provider its runtime ladder loads
+    // (0.4.2): the fixture resolves neither ai nor @ai-sdk/anthropic.
+    expect(installs).toEqual([{ command: "npm", args: ["install", "ai@^6", "@ai-sdk/anthropic@^3"] }]);
     expect(seenEnv[0]?.ANTHROPIC_API_KEY).toBe("sk-ant-quoted");
     expect(seenEnv[0]?.OPENAI_API_KEY).toBe("sk-openai-plain");
     expect(seenEnv[0]?.VENDO_API_KEY).toBe(key);

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -20,6 +20,7 @@ import { BRIEF_TEMPLATE, type StaticTool } from "./extract/stages.js";
 import { ENV_KEY_VARS, resolveDevCredential, describeDevCredential, type DevCredential } from "../dev-creds/resolve.js";
 import { detectFramework, detectVendoWiring, type HostFramework } from "./framework.js";
 import { resolveScaffoldAuth, type AuthMatch, type AuthPresetName, type ConfirmAuth, type SelectAuth } from "./init-auth.js";
+import { ensureProviderDeps, type InstallRunner } from "./provider-deps.js";
 import {
   expressServerSource,
   registrySource,
@@ -160,6 +161,8 @@ export interface InitOptions {
   env?: Record<string, string | undefined>;
   /** Test seam: credential detection for the key step. */
   resolveCredential?: (options: { env: Record<string, string | undefined> }) => Promise<DevCredential>;
+  /** Test seam: the provider-dependency install subprocess (provider-deps.ts). */
+  installProvider?: InstallRunner;
   /** Test seam (ENG-339): cloud-in-init step overrides. */
   cloud?: Partial<Omit<CloudStepOptions, "root" | "output" | "yes" | "credential">>;
   /** Test seam: AI extraction step overrides (harnesses, consent). */
@@ -1101,6 +1104,17 @@ export async function runInit(options: InitOptions): Promise<number> {
       ...(themeMs === undefined ? {} : { themeMs }),
       wiringMs,
       ...(await cloudProjectProps(root)),
+    });
+
+    // The credential's runtime provider must be resolvable from the host or
+    // the FIRST turn 500s (dev-creds/model.ts loads it host-side; nothing
+    // declares @ai-sdk/* — 0.4.1 E2E cert finding). Install exactly what the
+    // resolved credential needs; a failure degrades to the manual command.
+    await ensureProviderDeps({
+      root,
+      credential,
+      output,
+      ...(options.installProvider === undefined ? {} : { run: options.installProvider }),
     });
 
     // The one short Cloud reminder in the end-of-run summary — ONLY while no

--- a/packages/vendo/src/cli/provider-deps.test.ts
+++ b/packages/vendo/src/cli/provider-deps.test.ts
@@ -1,0 +1,134 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ensureProviderDeps, installCommandFor, providerModuleFor } from "./provider-deps.js";
+
+// Init installs the provider module the resolved credential loads at
+// runtime (0.4.1 E2E cert finding: nothing declares @ai-sdk/*, so a fresh
+// install 500s on the first turn until it's installed by hand).
+
+const cleanup: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const dispose of cleanup.splice(0).reverse()) await dispose();
+});
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-provider-deps-"));
+  cleanup.push(() => rm(root, { recursive: true, force: true }));
+  return root;
+}
+
+async function installModule(root: string, name: string): Promise<void> {
+  const dir = join(root, "node_modules", ...name.split("/"));
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "package.json"), JSON.stringify({ name, version: "0.0.0" }));
+}
+
+function output() {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return { logs, errors, sink: { log: (m: string) => logs.push(m), error: (m: string) => errors.push(m) } };
+}
+
+describe("providerModuleFor", () => {
+  it("maps each credential rung to the module the runtime ladder loads", () => {
+    expect(providerModuleFor({ rung: "env-key", provider: "anthropic", envVar: "ANTHROPIC_API_KEY" }))
+      .toMatchObject({ module: "@ai-sdk/anthropic" });
+    expect(providerModuleFor({ rung: "env-key", provider: "openai", envVar: "OPENAI_API_KEY" }))
+      .toMatchObject({ module: "@ai-sdk/openai" });
+    // The Cloud gateway is Anthropic-compatible and rides @ai-sdk/anthropic.
+    expect(providerModuleFor({ rung: "vendo-cloud" })).toMatchObject({ module: "@ai-sdk/anthropic" });
+    expect(providerModuleFor({ rung: "none" })).toBeNull();
+  });
+});
+
+describe("installCommandFor", () => {
+  it("sniffs the lockfile, npm as the fallback", async () => {
+    const root = await tempRoot();
+    expect(await installCommandFor(root)).toEqual({ command: "npm", args: ["install"] });
+    await writeFile(join(root, "pnpm-lock.yaml"), "");
+    expect(await installCommandFor(root)).toEqual({ command: "pnpm", args: ["add"] });
+  });
+});
+
+describe("ensureProviderDeps", () => {
+  it("installs ai@^6 + the credential's provider when neither resolves", async () => {
+    const root = await tempRoot();
+    const calls: Array<{ command: string; args: string[]; cwd: string }> = [];
+    const messages = output();
+    await ensureProviderDeps({
+      root,
+      credential: { rung: "vendo-cloud" },
+      output: messages.sink,
+      run: async (command, args, cwd) => {
+        calls.push({ command, args, cwd });
+        return 0;
+      },
+    });
+    expect(calls).toEqual([{ command: "npm", args: ["install", "ai@^6", "@ai-sdk/anthropic@^3"], cwd: root }]);
+    expect(messages.logs.join("\n")).toContain("Installed ai@^6 @ai-sdk/anthropic@^3.");
+    expect(messages.errors).toEqual([]);
+  });
+
+  it("is a no-op when the host already resolves both modules", async () => {
+    const root = await tempRoot();
+    await installModule(root, "ai");
+    await installModule(root, "@ai-sdk/anthropic");
+    const calls: unknown[] = [];
+    await ensureProviderDeps({
+      root,
+      credential: { rung: "env-key", provider: "anthropic", envVar: "ANTHROPIC_API_KEY" },
+      output: output().sink,
+      run: async (...call) => {
+        calls.push(call);
+        return 0;
+      },
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it("installs only the missing half", async () => {
+    const root = await tempRoot();
+    await installModule(root, "ai");
+    const calls: Array<{ args: string[] }> = [];
+    await ensureProviderDeps({
+      root,
+      credential: { rung: "env-key", provider: "openai", envVar: "OPENAI_API_KEY" },
+      output: output().sink,
+      run: async (_command, args) => {
+        calls.push({ args });
+        return 0;
+      },
+    });
+    expect(calls).toEqual([{ args: ["install", "@ai-sdk/openai@^3"] }]);
+  });
+
+  it("does nothing without a credential — there is no provider to install for", async () => {
+    const root = await tempRoot();
+    const calls: unknown[] = [];
+    await ensureProviderDeps({
+      root,
+      credential: { rung: "none" },
+      output: output().sink,
+      run: async (...call) => {
+        calls.push(call);
+        return 0;
+      },
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it("degrades to the exact manual command when the install fails, never throws", async () => {
+    const root = await tempRoot();
+    const messages = output();
+    await ensureProviderDeps({
+      root,
+      credential: { rung: "vendo-cloud" },
+      output: messages.sink,
+      run: async () => null,
+    });
+    expect(messages.errors.join("\n")).toContain("npm install ai@^6 @ai-sdk/anthropic@^3");
+    expect(messages.errors.join("\n")).toContain("E-DEP-001");
+  });
+});

--- a/packages/vendo/src/cli/provider-deps.ts
+++ b/packages/vendo/src/cli/provider-deps.ts
@@ -1,0 +1,115 @@
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { DevCredential, EnvKeyProvider } from "../dev-creds/resolve.js";
+import type { Output } from "./shared.js";
+
+/**
+ * The starter model ladder resolves its provider from the HOST's
+ * node_modules at runtime (dev-creds/model.ts) — nothing declares
+ * `@ai-sdk/*` as a dependency, so a fresh install 500s on the first turn
+ * until the user reads the dev-server error and installs it by hand (0.4.1
+ * E2E certification finding). Init knows the resolved credential, so it can
+ * install exactly the provider that credential needs, up front.
+ */
+
+const PROVIDER_SPECS: Record<EnvKeyProvider, { module: string; spec: string }> = {
+  anthropic: { module: "@ai-sdk/anthropic", spec: "@ai-sdk/anthropic@^3" },
+  openai: { module: "@ai-sdk/openai", spec: "@ai-sdk/openai@^3" },
+  google: { module: "@ai-sdk/google", spec: "@ai-sdk/google@^3" },
+};
+const AI_SPEC = "ai@^6";
+
+/** Which provider module the resolved credential will load at runtime.
+    The Vendo Cloud gateway speaks the Anthropic-compatible /messages API
+    through the host-installed @ai-sdk/anthropic (dev-creds/model.ts). */
+export function providerModuleFor(credential: DevCredential): { module: string; spec: string } | null {
+  if (credential.rung === "env-key") return PROVIDER_SPECS[credential.provider];
+  if (credential.rung === "vendo-cloud") return PROVIDER_SPECS.anthropic;
+  return null;
+}
+
+/** Resolvability is what the runtime ladder checks, so node_modules is the
+    evidence — not package.json (a hoisting monorepo satisfies the import
+    without a local entry). */
+async function isInstalled(root: string, moduleName: string): Promise<boolean> {
+  try {
+    await readFile(join(root, "node_modules", ...moduleName.split("/"), "package.json"), "utf8");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function fileExists(root: string, name: string): Promise<boolean> {
+  try {
+    await readFile(join(root, name));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Lockfile-sniffed installer; npm is the fallback. */
+export async function installCommandFor(root: string): Promise<{ command: string; args: string[] }> {
+  if (await fileExists(root, "pnpm-lock.yaml")) return { command: "pnpm", args: ["add"] };
+  if (await fileExists(root, "yarn.lock")) return { command: "yarn", args: ["add"] };
+  if ((await fileExists(root, "bun.lockb")) || (await fileExists(root, "bun.lock"))) {
+    return { command: "bun", args: ["add"] };
+  }
+  return { command: "npm", args: ["install"] };
+}
+
+/** Test seam: resolves to the child's exit code (null on spawn error). */
+export type InstallRunner = (command: string, args: string[], cwd: string) => Promise<number | null>;
+
+const INSTALL_TIMEOUT_MS = 240_000;
+
+const defaultRunner: InstallRunner = (command, args, cwd) =>
+  new Promise((resolve) => {
+    const child = spawn(command, args, { cwd, stdio: "ignore" });
+    const timer = setTimeout(() => {
+      child.kill();
+      resolve(null);
+    }, INSTALL_TIMEOUT_MS);
+    child.on("error", () => {
+      clearTimeout(timer);
+      resolve(null);
+    });
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+
+export interface EnsureProviderDepsOptions {
+  root: string;
+  credential: DevCredential;
+  output: Output;
+  run?: InstallRunner;
+}
+
+/** Installs `ai@^6` + the credential's provider when the host can't resolve
+    them. Never fatal: a failed install degrades to the exact manual command
+    (the same one doctor's E-DEP-001 story names). */
+export async function ensureProviderDeps(options: EnsureProviderDepsOptions): Promise<void> {
+  const provider = providerModuleFor(options.credential);
+  if (provider === null) return;
+
+  const specs: string[] = [];
+  if (!(await isInstalled(options.root, "ai"))) specs.push(AI_SPEC);
+  if (!(await isInstalled(options.root, provider.module))) specs.push(provider.spec);
+  if (specs.length === 0) return;
+
+  const { command, args } = await installCommandFor(options.root);
+  const invocation = `${command} ${[...args, ...specs].join(" ")}`;
+  options.output.log(`Installing the model provider this credential uses: ${specs.join(" ")} (${command})…`);
+  const code = await (options.run ?? defaultRunner)(command, [...args, ...specs], options.root);
+  if (code === 0) {
+    options.output.log(`Installed ${specs.join(" ")}.`);
+  } else {
+    options.output.error(
+      `warning: could not install ${specs.join(" ")} — run \`${invocation}\` yourself before the first turn, or it fails at runtime (E-DEP-001).`,
+    );
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   '@types/react': ^19.2.0
+  fast-uri: '>=3.1.4'
+  sharp: '>=0.35.0'
   '@types/react-dom': ^19.2.0
   postcss@<8.5.10: '>=8.5.10'
 
@@ -69,7 +71,7 @@ importers:
         version: 1.24.0(react@19.2.4)
       next:
         specifier: 16.2.9
-        version: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -181,10 +183,10 @@ importers:
         version: 1.24.0(react@19.2.4)
       next:
         specifier: 16.2.9
-        version: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: 5.0.0-beta.31
-        version: 5.0.0-beta.31(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 5.0.0-beta.31(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -425,7 +427,7 @@ importers:
         version: 6.0.28(zod@3.25.76)
       next:
         specifier: 16.2.9
-        version: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -513,7 +515,7 @@ importers:
         version: 1.19.0(@hono/node-server@1.19.14(hono@4.12.29))(@mastra/core@1.51.0(@bufbuild/protobuf@2.12.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(zod@3.25.76))(typescript@5.9.3)(zod@3.25.76)
       next:
         specifier: 16.2.9
-        version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@22.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -639,7 +641,7 @@ importers:
     dependencies:
       next:
         specifier: 16.2.9
-        version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@22.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -872,7 +874,7 @@ importers:
         version: 6.2.3
       next:
         specifier: 16.2.9
-        version: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@22.20.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -2475,152 +2477,161 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-darwin-arm64@0.35.3':
+    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-darwin-x64@0.35.3':
+    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-arm64@0.35.3':
+    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-arm@0.35.3':
+    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-ppc64@0.34.5':
-    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-ppc64@0.35.3':
+    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
+    engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-riscv64@0.34.5':
-    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-riscv64@0.35.3':
+    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-s390x@0.34.5':
-    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-s390x@0.35.3':
+    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
+    engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-x64@0.35.3':
+    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-wasm32@0.35.3':
+    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
+    engines: {node: '>=20.9.0'}
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-arm64@0.35.3':
+    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.34.5':
-    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-ia32@0.35.3':
+    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
+    engines: {node: ^20.9.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-x64@0.35.3':
+    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
 
@@ -5171,8 +5182,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@4.1.1:
+    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -7095,9 +7106,14 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  sharp@0.34.5:
-    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  sharp@0.35.3:
+    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -9027,98 +9043,108 @@ snapshots:
   '@img/colour@1.1.0':
     optional: true
 
-  '@img/sharp-darwin-arm64@0.34.5':
+  '@img/sharp-darwin-arm64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
     optional: true
 
-  '@img/sharp-darwin-x64@0.34.5':
+  '@img/sharp-darwin-x64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.3.2
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.2.4':
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
+  '@img/sharp-libvips-darwin-x64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.2.4':
+  '@img/sharp-libvips-linux-arm64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
+  '@img/sharp-libvips-linux-arm@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.2.4':
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.2.4':
+  '@img/sharp-libvips-linux-s390x@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+  '@img/sharp-libvips-linux-x64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
     optional: true
 
-  '@img/sharp-linux-arm64@0.34.5':
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.3.2
     optional: true
 
-  '@img/sharp-linux-arm@0.34.5':
+  '@img/sharp-linux-arm@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.3.2
     optional: true
 
-  '@img/sharp-linux-ppc64@0.34.5':
+  '@img/sharp-linux-ppc64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
     optional: true
 
-  '@img/sharp-linux-riscv64@0.34.5':
+  '@img/sharp-linux-riscv64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
     optional: true
 
-  '@img/sharp-linux-s390x@0.34.5':
+  '@img/sharp-linux-s390x@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.3.2
     optional: true
 
-  '@img/sharp-linux-x64@0.34.5':
+  '@img/sharp-linux-x64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.3.2
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.34.5':
+  '@img/sharp-linuxmusl-arm64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.34.5':
+  '@img/sharp-linuxmusl-x64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
     optional: true
 
-  '@img/sharp-wasm32@0.34.5':
+  '@img/sharp-wasm32@0.35.3':
     dependencies:
       '@emnapi/runtime': 1.11.2
     optional: true
 
-  '@img/sharp-win32-arm64@0.34.5':
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
     optional: true
 
-  '@img/sharp-win32-ia32@0.34.5':
+  '@img/sharp-win32-arm64@0.35.3':
     optional: true
 
-  '@img/sharp-win32-x64@0.34.5':
+  '@img/sharp-win32-ia32@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.3':
     optional: true
 
   '@inquirer/external-editor@1.0.3(@types/node@22.20.0)':
@@ -10722,14 +10748,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 4.1.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 4.1.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -11631,7 +11657,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.9
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
@@ -11674,7 +11700,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11689,36 +11715,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.5(jiti@2.7.0)
-      get-tsconfig: 4.14.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.17
-      unrs-resolver: 1.12.2
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 9.39.5(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
@@ -11736,7 +11737,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -11765,7 +11766,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -12046,7 +12047,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.3: {}
+  fast-uri@4.1.1: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -13419,13 +13420,13 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next-auth@5.0.0-beta.31(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  next-auth@5.0.0-beta.31(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
     dependencies:
       '@auth/core': 0.41.2
-      next: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
-  next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@22.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
@@ -13446,12 +13447,13 @@ snapshots:
       '@next/swc-win32-x64-msvc': 16.2.9
       '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.61.1
-      sharp: 0.34.5
+      sharp: 0.35.3(@types/node@22.20.0)
     transitivePeerDependencies:
       - '@babel/core'
+      - '@types/node'
       - babel-plugin-macros
 
-  next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
@@ -13460,7 +13462,7 @@ snapshots:
       postcss: 8.5.16
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.9
       '@next/swc-darwin-x64': 16.2.9
@@ -13472,12 +13474,13 @@ snapshots:
       '@next/swc-win32-x64-msvc': 16.2.9
       '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.61.1
-      sharp: 0.34.5
+      sharp: 0.35.3(@types/node@20.19.43)
     transitivePeerDependencies:
       - '@babel/core'
+      - '@types/node'
       - babel-plugin-macros
 
-  next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@22.20.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
@@ -13498,9 +13501,10 @@ snapshots:
       '@next/swc-win32-x64-msvc': 16.2.9
       '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.61.1
-      sharp: 0.34.5
+      sharp: 0.35.3(@types/node@22.20.0)
     transitivePeerDependencies:
       - '@babel/core'
+      - '@types/node'
       - babel-plugin-macros
 
   node-exports-info@1.6.2:
@@ -14377,36 +14381,72 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  sharp@0.34.5:
+  sharp@0.35.3(@types/node@20.19.43):
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
       semver: 7.8.5
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-      '@img/sharp-libvips-linux-arm': 1.2.4
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-      '@img/sharp-libvips-linux-x64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-ppc64': 0.34.5
-      '@img/sharp-linux-riscv64': 0.34.5
-      '@img/sharp-linux-s390x': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-wasm32': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-ia32': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
+      '@img/sharp-darwin-arm64': 0.35.3
+      '@img/sharp-darwin-x64': 0.35.3
+      '@img/sharp-freebsd-wasm32': 0.35.3
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-linux-arm': 0.35.3
+      '@img/sharp-linux-arm64': 0.35.3
+      '@img/sharp-linux-ppc64': 0.35.3
+      '@img/sharp-linux-riscv64': 0.35.3
+      '@img/sharp-linux-s390x': 0.35.3
+      '@img/sharp-linux-x64': 0.35.3
+      '@img/sharp-linuxmusl-arm64': 0.35.3
+      '@img/sharp-linuxmusl-x64': 0.35.3
+      '@img/sharp-webcontainers-wasm32': 0.35.3
+      '@img/sharp-win32-arm64': 0.35.3
+      '@img/sharp-win32-ia32': 0.35.3
+      '@img/sharp-win32-x64': 0.35.3
+      '@types/node': 20.19.43
+    optional: true
+
+  sharp@0.35.3(@types/node@22.20.0):
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.3
+      '@img/sharp-darwin-x64': 0.35.3
+      '@img/sharp-freebsd-wasm32': 0.35.3
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-linux-arm': 0.35.3
+      '@img/sharp-linux-arm64': 0.35.3
+      '@img/sharp-linux-ppc64': 0.35.3
+      '@img/sharp-linux-riscv64': 0.35.3
+      '@img/sharp-linux-s390x': 0.35.3
+      '@img/sharp-linux-x64': 0.35.3
+      '@img/sharp-linuxmusl-arm64': 0.35.3
+      '@img/sharp-linuxmusl-x64': 0.35.3
+      '@img/sharp-webcontainers-wasm32': 0.35.3
+      '@img/sharp-win32-arm64': 0.35.3
+      '@img/sharp-win32-ia32': 0.35.3
+      '@img/sharp-win32-x64': 0.35.3
+      '@types/node': 22.20.0
     optional: true
 
   shebang-command@2.0.0:
@@ -14630,11 +14670,6 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@babel/core': 7.29.7
-
-  styled-jsx@5.1.6(react@19.2.4):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.2.4
 
   styled-jsx@5.1.6(react@19.2.7):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,5 +37,9 @@ minimumReleaseAgeExclude:
 # pnpm 11 no longer reads the `pnpm` field in package.json; overrides live here.
 overrides:
   "@types/react": "^19.2.0"
+  # Security floors (2026-07-21 advisories): fast-uri GHSA-v2hh-gcrm-f6hx,
+  # sharp/libvips GHSA-f88m-g3jw-g9cj — both reach us only via examples/demos.
+  "fast-uri": ">=3.1.4"
+  "sharp": ">=0.35.0"
   "@types/react-dom": "^19.2.0"
   "postcss@<8.5.10": ">=8.5.10"


### PR DESCRIPTION
## From the 0.4.1 E2E certification campaign (task_6c4184006aab)

Two CLI defects with full repro in the campaign reports (`~/vendo-test-repos/.e2e-harness/`):

### 1. Per-project `vendo login` claims (cross-project key-delivery risk)

`~/.vendo/pending-claim.json` was machine-global: concurrent logins in different repos clobbered each other, and resume ignored the recorded cwd — project A could resume (and receive the key for) project B's ceremony. The campaign had to serialize its four lanes' logins around this.

Now: claims live at `~/.vendo/pending-claims/<sha256(cwd)[0:16]>.json`; only the current project's ceremony is resumed; other projects' pending ceremonies survive a fresh login elsewhere; a matching pre-0.4.2 machine-global file migrates on first read. This deliberately changes the #479 contract (resume-from-anywhere) — the campaign flagged that behavior as the risk. Two new contract tests (cross-project isolation, legacy migration).

### 2. Init installs the model provider the credential actually loads

`dev-creds/model.ts` resolves `@ai-sdk/*` from the host at runtime and nothing declares it — every fresh install 500'd on the first turn (MAJOR-5 in the campaign matrix). Init now checks resolvability after the credential lands and installs `ai@^6` + the matching provider (`@ai-sdk/anthropic` for env-key and the Cloud gateway, openai/google for theirs), lockfile-sniffed PM, non-fatal with the exact manual command on failure. New `provider-deps.ts` + 7 unit tests + init integration assertion.

Includes the 0.4.2 changeset (fixed-group patch).

## Verification

`pnpm build && pnpm test && pnpm typecheck && pnpm lint` all green locally (46/46 tasks); cloud CLI suite 73/73; init suite 74/74.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes `vendo login` pending claims per project to prevent cross-project key delivery, and makes `vendo init` install the credential’s model provider so first turns don’t fail. Also raises security floors for `fast-uri` and `sharp` to clear advisories.

- **Bug Fixes**
  - `vendo login`: pending claims are saved per project under `~/.vendo/pending-claims/<sha256(cwd)[0:16]>.json`; only the same project resumes; a matching legacy `~/.vendo/pending-claim.json` auto-migrates when `cwd` matches; terminal token errors delete the pending file.
  - `vendo init`: after resolving the dev credential, installs `ai@^6` plus the matching provider (`@ai-sdk/anthropic` for env-key and Cloud, `@ai-sdk/openai` or `@ai-sdk/google`); package manager is lockfile-sniffed; failures are non-fatal and print the exact manual command.

- **Dependencies**
  - Workspace overrides set `fast-uri>=3.1.4` and `sharp>=0.35.0` to address GHSA advisories; lockfile updated.

<sup>Written for commit f7dba8e88a193e0d47170c01b1928527bde8d86a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

