### PR TITLE
portability: the server runs on Web-standard runtimes — Workers fixes + CI gate

### DIFF
--- a/.changeset/edge-portability.md
+++ b/.changeset/edge-portability.md
@@ -1,0 +1,18 @@
+---
+"@vendoai/core": patch
+"@vendoai/actions": patch
+"@vendoai/apps": patch
+"@vendoai/automations": patch
+"@vendoai/store": patch
+"@vendoai/telemetry": patch
+"@vendoai/vendo": patch
+---
+
+Edge-runtime portability: the server entry now bundles and boots on
+Web-standard runtimes (Cloudflare Workers first). Fetch defaults are
+invocation-safe, the optional e2b SDK no longer breaks esbuild/Wrangler
+builds, Node-only legs (local store engines, dev model ladder, telemetry
+disk config, actions sync tooling) sit behind worker/edge export
+conditions with honest guidance, and createVendo performs no I/O, timers,
+or random generation at construction — module-scope wiring works. A CI
+portability gate (bundle + real workerd boot) keeps it that way.

--- a/.changeset/edge-portability.md
+++ b/.changeset/edge-portability.md
@@ -16,3 +16,9 @@ disk config, actions sync tooling) sit behind worker/edge export
 conditions with honest guidance, and createVendo performs no I/O, timers,
 or random generation at construction — module-scope wiring works. A CI
 portability gate (bundle + real workerd boot) keeps it that way.
+
+Note for hosts that reach into composed blocks directly: the BYO tool seam
+(`vendo.guardedTools`, and the ai-sdk/mastra packs built on it) arms schema
+readiness on first execute. Raw `vendo.store`/`vendo.automations` reach-ins
+should `await vendo.store.ensureSchema()` first — the previous eager kick
+only ever gave that pattern a racy head start.

--- a/docs/superpowers/plans/2026-07-21-edge-portability.md
+++ b/docs/superpowers/plans/2026-07-21-edge-portability.md
@@ -1,0 +1,130 @@
+# Edge Portability Campaign
+
+> Origin: Mohamed Habib (digger.dev) deployed Vendo on Cloudflare Workers and hit nine
+> issues (email 2026-07-21, branch diggerhq/opencomputer#feat/vendo-cloudflare-edge).
+> Root-cause analysis reduced them to three broken assumptions. This plan removes the
+> assumptions, not just the symptoms, so any Web-standard runtime (Workers, Bun, Deno,
+> Vercel/Netlify Edge) works without golden-path treatment.
+
+**Goal:** `@vendoai/vendo/server` provably runs on Web-standard JavaScript runtimes,
+init/doctor stop assuming Next or Express, and the core promise (agent acts through
+the host API) can never degrade silently.
+
+**Coordination:** two wave2 agents are mid-flight in sibling worktrees
+(`wave2-runtime-fixes`: apps engine + mastra; `wave2-init-doctor`: init install funnel
++ framework detection). PR 1 has no file overlap and ships first. PRs 3-5 rebase after
+wave2 lands. npm release goes through the npm-2 session after merges.
+
+**Decisions locked during root-cause analysis:**
+- Portability mechanism = package export **conditions** (`worker`, `workerd`,
+  `edge-light`, `browser` map Node-only legs to fail-with-guidance stubs; `default`
+  keeps today's Node behavior). One mechanism every bundler and Node itself respects;
+  no bundler-specific magic comments (that was the e2b failure mode).
+- The e2b optional SDK import becomes non-analyzable (variable specifier) so no
+  bundler resolves it at build time; a missing SDK errors at use with guidance.
+- `createVendo()` becomes construction-pure: schema readiness, the session sweep
+  timer, and telemetry init defer to first handler touch. Lazy is correct on Node too.
+- The gate, not review, enforces all of this forever: bundle the server entry for
+  a worker target with zero unresolved imports, then boot it under workerd and serve
+  requests at module scope.
+
+---
+
+## PR 1 — Workers runtime portability + CI gate (this worktree)
+
+### Task 1: bound-fetch helper
+- Add a `boundFetch`-style default helper in `packages/core` (test: calling the
+  stored default with a mock strict-`this` fetch must not throw).
+- Replace `options.fetch ?? globalThis.fetch` at all seven sites:
+  `core/src/heartbeat.ts:38`, `vendo/src/hosted-store.ts:133`,
+  `vendo/src/cloud-apps.ts:47`, `vendo/src/sandbox.ts:195`,
+  `vendo/src/connections.ts:165`, `vendo/src/refine.ts:639`,
+  `vendo/src/cloud-console.ts` call-through.
+- Guard against regression: lint-style unit test greps source for the raw pattern.
+
+### Task 2: e2b import made bundler-safe
+- `packages/apps/src/e2b/index.ts`: route the three `import("e2b")` sites through a
+  non-analyzable specifier; keep the ignore comments for webpack/turbopack warnings.
+- Test: esbuild-bundle a probe entry importing `@vendoai/apps/e2b` with e2b absent —
+  must succeed; invoking create without the SDK must throw the guidance error.
+
+### Task 3: telemetry off the edge path
+- `packages/vendo-telemetry`: config/base-props (node:crypto, fs, os, homedir) move
+  behind an internal conditional import; worker/edge condition gets a no-op telemetry
+  (init returns disabled client). `globalThis.crypto.randomUUID` replaces node:crypto
+  everywhere it survives.
+- Test: bundle probe with worker condition contains no `node:` specifiers.
+
+### Task 4: dev-creds ladder contained
+- `packages/vendo/src/dev-creds/model.ts` (and its `cli/cloud/client` import chain):
+  Node-only resolution (createRequire, file URLs, ~/.vendo session reads) moves behind
+  an internal conditional subpath; worker/edge condition yields a resolver that
+  reports "no dev credential ladder on this runtime" through the existing unavailable
+  path, so explicit model / VENDO_API_KEY setups never touch it.
+- Managed-inference fix inside the same seam: when the cloud key path is taken, build
+  the gateway provider statically (no require.resolve), matching what Mohamed
+  hand-wired.
+
+### Task 5: local store leg contained
+- `packages/store`: the pg/PGlite local engine goes behind an internal conditional
+  subpath; worker/edge condition throws with guidance ("pass store: or set
+  VENDO_API_KEY"). Hosted store stays portable.
+
+### Task 6: actions sync split out of the runtime entry
+- `packages/actions`: `vendoSync` + static extractors (TypeScript compiler, node:fs)
+  move from the main entry to an `@vendoai/actions/sync` subpath. Update all
+  importers (CLI, corpus, tests). Runtime registry keeps zero sync imports; verify
+  `runtime/registry.js`'s node imports and contain them the same way.
+
+### Task 7: construction-pure createVendo
+- `packages/vendo/src/server.ts`: `ensureSchema()` kick-off, sweep `setInterval`,
+  and `initTelemetry` defer to a once-guarded first-request hook on the handler
+  path. `close()` still tears the timer down; Node behavior unchanged (existing
+  tests prove it).
+- Test: constructing at simulated module scope performs no I/O and starts no timer
+  (spies); first handler call performs both exactly once.
+
+### Task 8: the portability gate
+- `scripts/portability-gate.mjs`: (a) esbuild-bundles `packages/vendo/dist/server.js`
+  with a worker condition set, fails on ANY unresolved import; (b) boots the bundle
+  under workerd (miniflare devDep) from a fixture worker that calls createVendo at
+  module scope and serves `/status`, asserts 200 and a streamed turn survives.
+- Fixture lives in `scripts/fixtures/portability-worker/`.
+- Wire into root `pnpm lint` (alongside dependency-guard) and the PR workflow.
+
+### Task 9: gates + PR
+- `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green; PR with the
+  gate output and the fixture boot log; the email symptoms mapped to fixes in the
+  PR body.
+
+## PR 2 — universal wiring + Workers docs (after PR 1)
+- Runtime-neutral lazy-singleton wiring template (env-in, Request→Response out) as
+  the init fallback for unrecognized frameworks; Mohamed's hand-rolled file is the
+  reference shape. Coordinate with wave2-init-doctor's init changes; rebase on it.
+- docs + docs-site: "Vendo on Cloudflare Workers" page: wrangler config, conditions,
+  VENDO_BASE_URL, what the free plan covers.
+
+## PR 3 — behavior-based doctor (after wave2-init-doctor lands)
+- Unknown-framework detection outcome: generic wiring checks (createVendo imported,
+  handler mounted, VendoRoot rendered anywhere) as warnings, not E-WIRE-003/004
+  failures; live probes stay the source of truth.
+- New checks: empty applied tool surface = failure; VENDO_BASE_URL guidance in the
+  present-credentials probe failure.
+
+## PR 4 — extraction audience classification
+- `cli/extract`: classify candidate endpoints end-user vs internal/operator (auth
+  scope heuristics + extraction-model judgment); internal excluded by default,
+  surfaced in the brief as an explicit "excluded internal surface" section.
+- Empty-surface warnings at init apply time and server boot.
+
+## PR 5 — structured stream errors
+- Wire + UI: a stream that dies carries a structured terminal error event; the thread
+  renders cause + retry guidance instead of the bare "Something went wrong" banner
+  (`ui/chrome/thread/index.tsx:218`). Rebase after wave2-runtime-fixes (ui overlap).
+- Use the workerd fixture from PR 1 to reproduce the apps-create mid-stream death and
+  pin the actual killer; fix what it reveals.
+
+## Ship
+- npm release via the npm-2 session once merged; then send Mohamed the follow-up
+  (draft already sitting in the Gmail thread) and diff his branch's workarounds
+  against the fixes.

--- a/fixtures/host-app/next-env.d.ts
+++ b/fixtures/host-app/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/integration-e2e/dev/types/routes.d.ts";
+import "./.next/mcp-e2e/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/fixtures/integration/src/actions-sync.e2e.test.ts
+++ b/fixtures/integration/src/actions-sync.e2e.test.ts
@@ -22,7 +22,7 @@ import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { vendoSync } from "@vendoai/actions";
+import { vendoSync } from "@vendoai/actions/sync";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   ADA,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "turbo run test",
     "conformance": "turbo run conformance --filter=@vendoai/core --filter=@vendoai/store --filter=@vendoai/agent",
     "typecheck": "turbo run typecheck",
-    "lint": "node scripts/dependency-guard.mjs && turbo run lint",
+    "lint": "node scripts/dependency-guard.mjs && node scripts/portability-gate.mjs && turbo run lint",
     "deps:guard": "node scripts/dependency-guard.mjs",
     "corpus": "pnpm --filter @vendoai/corpus-harness corpus",
     "corpus:ui-parity": "pnpm --filter @vendoai/corpus-harness ui-parity",
@@ -17,11 +17,14 @@
     "changeset": "changeset",
     "changeset:status": "changeset status --since=origin/main",
     "changeset:version": "changeset version && node scripts/sync-version-constants.mjs",
-    "changeset:publish": "changeset publish"
+    "changeset:publish": "changeset publish",
+    "portability": "node scripts/portability-gate.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
     "@vitest/coverage-v8": "^2.1.0",
+    "esbuild": "^0.25.12",
+    "miniflare": "^4.20260714.0",
     "opentype.js": "^2.0.0",
     "turbo": "^2.1.0",
     "typescript": "^5.6.0",

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -39,6 +39,10 @@
     "./presets/auth-js": {
       "types": "./dist/presets/auth-js.d.ts",
       "default": "./dist/presets/auth-js.js"
+    },
+    "./sync": {
+      "types": "./dist/sync/public.d.ts",
+      "default": "./dist/sync/public.js"
     }
   },
   "files": [
@@ -78,5 +82,14 @@
     "typescript": "^5.6.0",
     "vitest": "^2.1.0",
     "zod-to-json-schema": "^3.25.2"
+  },
+  "imports": {
+    "#actions/host-files": {
+      "workerd": "./dist/runtime/host-files-edge.js",
+      "worker": "./dist/runtime/host-files-edge.js",
+      "edge-light": "./dist/runtime/host-files-edge.js",
+      "browser": "./dist/runtime/host-files-edge.js",
+      "default": "./dist/runtime/host-files.js"
+    }
   }
 }

--- a/packages/actions/src/index.ts
+++ b/packages/actions/src/index.ts
@@ -10,21 +10,6 @@ export { mcpConnector, type McpAuthContext, type McpHeadersResolver } from "./co
 export { createActions, type ActionsRegistry, type ActionsRunContext, type ServerActionHandler } from "./runtime/registry.js";
 export { type ToolSearchMatch, type ToolSearchOptions } from "./runtime/search.js";
 export { validateCapabilities, type CapabilityIssue, type PrimitiveStepTarget } from "./runtime/compound.js";
-export { mergeOverrides, vendoSync, type SyncReportWithWarnings } from "./sync/index.js";
-export {
-  extractServerActions,
-  serverActionRegistrations,
-  type ServerActionRegistration,
-  type ServerActionsExtractResult,
-} from "./sync/server-actions.js";
-// The static zod → JSON Schema interpreter (04 §1). Exported so the
-// composition can pin static/runtime derivation parity in tests — sync's
-// static output feeds the ajv-compiled disk validator while the runtime
-// derives from the live zod object, and the two must agree.
-export {
-  parseModule,
-  zodFromExpression,
-  type FileModule,
-  type StaticExtraction,
-  type ZodSchemaResult,
-} from "./sync/static-ts.js";
+// Build-/dev-time extraction surface moved to `@vendoai/actions/sync` so the
+// runtime entry stays portable (no node:fs / TypeScript compiler in server
+// bundles). See src/sync/public.ts.

--- a/packages/actions/src/runtime/host-files-edge.ts
+++ b/packages/actions/src/runtime/host-files-edge.ts
@@ -1,0 +1,11 @@
+/** Edge build of the registry's filesystem leg (`#actions/host-files`):
+ *  there is no disk on Web-standard runtimes, so every optional host config
+ *  file reads as absent and the registry composes from inline config alone.
+ *  Keep this module free of node builtins; the portability gate bundles it. */
+export function readOptionalVendoJson<T>(
+  _dir: string,
+  _file: string,
+  _parse: (value: unknown) => T,
+): Promise<T | undefined> {
+  return Promise.resolve(undefined);
+}

--- a/packages/actions/src/runtime/host-files.test.ts
+++ b/packages/actions/src/runtime/host-files.test.ts
@@ -1,0 +1,37 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { readOptionalVendoJson } from "./host-files.js";
+import { readOptionalVendoJson as readOnEdge } from "./host-files-edge.js";
+
+describe("host config files, node entry", () => {
+  it("reads and parses a .vendo file, resolving the dir from a host root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-host-files-"));
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(join(root, ".vendo"));
+    await writeFile(join(root, ".vendo", "tools.json"), JSON.stringify({ format: "vendo/tools@1", tools: [] }));
+    const parsed = await readOptionalVendoJson(root, "tools.json", (value) => value as { tools: unknown[] });
+    expect(parsed).toEqual({ format: "vendo/tools@1", tools: [] });
+  });
+
+  it("returns undefined for a missing file", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-host-files-"));
+    const parsed = await readOptionalVendoJson(root, "tools.json", (value) => value);
+    expect(parsed).toBeUndefined();
+  });
+});
+
+describe("host config files, edge entry", () => {
+  it("reports every file absent (no filesystem on edge runtimes)", async () => {
+    await expect(readOnEdge("/srv/app", "tools.json", (value) => value)).resolves.toBeUndefined();
+  });
+
+  it("keeps the edge module free of node builtins", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const source = await readFile(new URL("./host-files-edge.ts", import.meta.url), "utf8");
+    expect(source).not.toMatch(/from "node:/);
+  });
+});

--- a/packages/actions/src/runtime/host-files.ts
+++ b/packages/actions/src/runtime/host-files.ts
@@ -1,0 +1,38 @@
+/** The registry's one filesystem leg: optional `.vendo/*.json` host config.
+ *  Split behind `#actions/host-files` conditions so Worker/edge bundles never
+ *  carry node:fs — there, hosts pass catalog config inline and every file
+ *  simply reads as absent (see host-files-edge.ts). */
+import { readFile } from "node:fs/promises";
+import { basename, join, resolve } from "node:path";
+
+import { VendoError } from "@vendoai/core";
+
+/** `dir` may be the host root (we look inside its .vendo/) or the .vendo
+ *  directory itself; reads `file` from it, undefined when absent. */
+export async function readOptionalVendoJson<T>(
+  dir: string,
+  file: string,
+  parse: (value: unknown) => T,
+): Promise<T | undefined> {
+  const vendoDir = basename(resolve(dir)) === ".vendo" ? dir : join(dir, ".vendo");
+  const path = join(vendoDir, file);
+  let source: string;
+  try {
+    source = await readFile(path, "utf8");
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw new VendoError("validation", `Could not read ${path}`, {
+      cause: cause instanceof Error ? cause.message : String(cause),
+    });
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(source);
+  } catch (cause) {
+    throw new VendoError("validation", `Malformed JSON in ${path}`, {
+      cause: cause instanceof Error ? cause.message : String(cause),
+    });
+  }
+  return parse(value);
+}

--- a/packages/actions/src/runtime/host-files.ts
+++ b/packages/actions/src/runtime/host-files.ts
@@ -34,5 +34,12 @@ export async function readOptionalVendoJson<T>(
       cause: cause instanceof Error ? cause.message : String(cause),
     });
   }
-  return parse(value);
+
+  try {
+    return parse(value);
+  } catch (cause) {
+    throw new VendoError("validation", `Invalid Vendo actions file ${path}`, {
+      cause: cause instanceof Error ? cause.message : String(cause),
+    });
+  }
 }

--- a/packages/actions/src/runtime/registry.ts
+++ b/packages/actions/src/runtime/registry.ts
@@ -1,5 +1,4 @@
-import { readFile } from "node:fs/promises";
-import { basename, join, resolve } from "node:path";
+import { readOptionalVendoJson } from "#actions/host-files";
 import {
   VendoError,
   descriptorHash,
@@ -166,34 +165,6 @@ function mergeOverride<T extends ToolDescriptor>(descriptor: T, override?: ToolO
   };
 }
 
-async function readOptionalJson<T>(path: string, parse: (value: unknown) => T): Promise<T | undefined> {
-  let source: string;
-  try {
-    source = await readFile(path, "utf8");
-  } catch (cause) {
-    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return undefined;
-    throw new VendoError("validation", `Could not read ${path}`, {
-      cause: cause instanceof Error ? cause.message : String(cause),
-    });
-  }
-
-  let value: unknown;
-  try {
-    value = JSON.parse(source);
-  } catch (cause) {
-    throw new VendoError("validation", `Malformed JSON in ${path}`, {
-      cause: cause instanceof Error ? cause.message : String(cause),
-    });
-  }
-
-  try {
-    return parse(value);
-  } catch (cause) {
-    throw new VendoError("validation", `Invalid Vendo actions file ${path}`, {
-      cause: cause instanceof Error ? cause.message : String(cause),
-    });
-  }
-}
 
 function appendQuery(url: URL, key: string, value: unknown): void {
   const values = Array.isArray(value) ? value : [value];
@@ -728,12 +699,10 @@ export function createActions(config: RegistryConfig): ActionsRegistry {
           ...(configuredCapabilities === undefined ? {} : { capabilities: configuredCapabilities }),
         };
       }
-      // `dir` may be the host root (we look inside its .vendo/) or the .vendo directory itself.
-      const vendoDir = basename(resolve(config.dir)) === ".vendo" ? config.dir : join(config.dir, ".vendo");
       const [toolsFile, overrides, capabilitiesFile] = await Promise.all([
-        readOptionalJson(join(vendoDir, "tools.json"), (value) => toolsFileSchema.parse(value)),
-        readOptionalJson(join(vendoDir, "overrides.json"), (value) => overridesFileSchema.parse(value)),
-        readOptionalJson(join(vendoDir, "capabilities.json"), (value) => capabilitiesFileSchema.parse(value)),
+        readOptionalVendoJson(config.dir, "tools.json", (value) => toolsFileSchema.parse(value)),
+        readOptionalVendoJson(config.dir, "overrides.json", (value) => overridesFileSchema.parse(value)),
+        readOptionalVendoJson(config.dir, "capabilities.json", (value) => capabilitiesFileSchema.parse(value)),
       ]);
       const capabilities = configuredCapabilities ?? capabilitiesFile;
       return {

--- a/packages/actions/src/runtime/registry.ts
+++ b/packages/actions/src/runtime/registry.ts
@@ -36,6 +36,7 @@ import {
 import { createCompoundExecutor, validateCapabilities, type PrimitiveStepTarget } from "./compound.js";
 import { error, isArgsObject } from "./outcome.js";
 import { searchToolDescriptors, tokenize, type ToolSearchMatch, type ToolSearchOptions } from "./search.js";
+import { defaultFetch } from "@vendoai/core";
 
 export interface ActionsRegistry extends ToolRegistry {
   add(tools: ToolRegistry): void;
@@ -655,7 +656,7 @@ async function executeHost(config: RegistryConfig, tool: ExtractedTool, call: To
 
   const outcome = await (async (): Promise<ToolOutcome> => {
     try {
-      const request = config.fetch ?? globalThis.fetch;
+      const request = config.fetch ?? defaultFetch;
       const response = await request(url, {
         method,
         headers,

--- a/packages/actions/src/sync/public.ts
+++ b/packages/actions/src/sync/public.ts
@@ -1,0 +1,24 @@
+/** `@vendoai/actions/sync` — the build-/dev-time extraction surface (vendo
+ *  sync, server-action extraction, the static zod interpreter). Split from
+ *  the package root so the RUNTIME entry a server bundles never drags in
+ *  node:fs and the TypeScript compiler: the root export used to re-export
+ *  these, which put ~4MB of dev tooling (and hard Node deps) into every
+ *  Worker bundle. CLI and tests import from here. */
+export { mergeOverrides, vendoSync, type SyncReportWithWarnings } from "./index.js";
+export {
+  extractServerActions,
+  serverActionRegistrations,
+  type ServerActionRegistration,
+  type ServerActionsExtractResult,
+} from "./server-actions.js";
+// The static zod → JSON Schema interpreter (04 §1). Exported so the
+// composition can pin static/runtime derivation parity in tests — sync's
+// static output feeds the ajv-compiled disk validator while the runtime
+// derives from the live zod object, and the two must agree.
+export {
+  parseModule,
+  zodFromExpression,
+  type FileModule,
+  type StaticExtraction,
+  type ZodSchemaResult,
+} from "./static-ts.js";

--- a/packages/apps/src/e2b/index.ts
+++ b/packages/apps/src/e2b/index.ts
@@ -1,4 +1,4 @@
-import { VendoError } from "@vendoai/core";
+import { safeErrorMessage, VendoError } from "@vendoai/core";
 import type { SandboxAdapter, SandboxMachine } from "../sandbox.js";
 
 const DEFAULT_TIMEOUT_MS = 300_000;
@@ -123,10 +123,31 @@ const networkOptions = (allowedDomains: string[] | undefined, allTraffic: string
 export const e2bInstalled = (): boolean => {
   if (typeof import.meta.resolve !== "function") return true;
   try {
-    import.meta.resolve("e2b");
+    import.meta.resolve(E2B_SPECIFIER);
     return true;
   } catch {
     return false;
+  }
+};
+
+/** Routed through a mutable binding so NO bundler statically resolves the
+    optional SDK: the webpack/turbopack ignore comments below are webpack
+    dialect, and esbuild (Wrangler, Bun) ignores them and hard-fails the build
+    on a literal `import("e2b")` when the SDK isn't installed (field case:
+    vendo-on-Cloudflare-Workers). A `let` defeats esbuild constant folding. */
+let E2B_SPECIFIER = "e2b";
+
+type E2BModule = typeof import("e2b");
+
+const loadE2b = async (): Promise<E2BModule> => {
+  try {
+    return await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ E2B_SPECIFIER) as E2BModule;
+  } catch (error) {
+    throw new VendoError(
+      "sandbox-unavailable",
+      "the optional `e2b` SDK is not installed in this deployment; install `e2b` (and set E2B_API_KEY) to use the E2B sandbox adapter, or leave the sandbox seam to Vendo Cloud / a custom adapter",
+      { loadError: safeErrorMessage(error) },
+    );
   }
 };
 
@@ -266,7 +287,7 @@ export const e2bSandbox = (options: E2BSandboxOptions = {}): SandboxAdapter => {
     async create(spec: E2BCreateSpec) {
       // Optional SDK: keep it a runtime import so hosts without e2b installed
       // don't fail Next's (webpack/Turbopack) bundling of the vendo route.
-      const { ALL_TRAFFIC, Sandbox } = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ "e2b");
+      const { ALL_TRAFFIC, Sandbox } = await loadE2b();
       const allowedDomains = spec.allowedDomains;
       const createOptions = {
         ...(options.apiKey === undefined ? {} : { apiKey: options.apiKey }),
@@ -284,7 +305,7 @@ export const e2bSandbox = (options: E2BSandboxOptions = {}): SandboxAdapter => {
       // Lane E — a wake enforces the CURRENT egress policy when the caller
       // passes one; the snapshot-time allowlist applies only to a bare resume.
       const allowedDomains = policy === undefined ? state.allowedDomains : policy.allowedDomains;
-      const { ALL_TRAFFIC, Sandbox } = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ "e2b");
+      const { ALL_TRAFFIC, Sandbox } = await loadE2b();
       return wrap(await Sandbox.create(state.snapshotId, {
         ...(options.apiKey === undefined ? {} : { apiKey: options.apiKey }),
         timeoutMs,
@@ -293,7 +314,7 @@ export const e2bSandbox = (options: E2BSandboxOptions = {}): SandboxAdapter => {
     },
     async destroy(snapshotRef) {
       const state = decodeSnapshotRef(snapshotRef);
-      const { NotFoundError, Sandbox } = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ "e2b");
+      const { NotFoundError, Sandbox } = await loadE2b();
       const apiOptions = options.apiKey === undefined ? {} : { apiKey: options.apiKey };
       // Best-effort reap of the sandbox the sleep flow left paused behind this
       // ref (recorded by v2 refs; absent from retired v1 refs). It is usually

--- a/packages/automations/src/engine.ts
+++ b/packages/automations/src/engine.ts
@@ -361,7 +361,11 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
   const resuming = new Set<string>();
   const inFlightDeliveries = new Set<string>();
   const abortControllers = new Map<string, AbortController>();
-  const engineInstanceId = globalThis.crypto.randomUUID();
+  // Minted on first claim, not at construction: Workers forbids generating
+  // random values in global scope, and createVendo composes this engine at
+  // module init in the edge wiring.
+  let engineInstanceId: string | undefined;
+  const instanceId = (): string => (engineInstanceId ??= globalThis.crypto.randomUUID());
   let tickTail: Promise<void> = Promise.resolve();
   // Absent localTriggerKinds → every kind fires locally (today's behavior, unchanged).
   const firesLocally = (kind: "schedule" | "external"): boolean =>
@@ -826,7 +830,7 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
       if (approval === null) return;
       const approvalData = approvalRowSchema.parse(approval.data);
 
-      const claimedBy = `${engineInstanceId}:${globalThis.crypto.randomUUID()}`;
+      const claimedBy = `${instanceId()}:${globalThis.crypto.randomUUID()}`;
       const claims = config.store.records(RESUME_CLAIMS);
       const atomicClaim = claims.atomic === undefined
         ? undefined

--- a/packages/core/src/fetch.test.ts
+++ b/packages/core/src/fetch.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defaultFetch } from "./fetch.js";
+
+const realFetch = globalThis.fetch;
+
+/** Mimics Workers/browser strict Web APIs: invoking a detached `fetch`
+    reference (`this` !== globalThis) throws "Illegal invocation". */
+function installStrictFetch(): { calls: Array<{ input: unknown; init: unknown }> } {
+  const calls: Array<{ input: unknown; init: unknown }> = [];
+  function strictFetch(this: unknown, input: unknown, init?: unknown): Promise<Response> {
+    if (this !== globalThis) throw new TypeError("Illegal invocation");
+    calls.push({ input, init });
+    return Promise.resolve(new Response("ok"));
+  }
+  globalThis.fetch = strictFetch as typeof fetch;
+  return { calls };
+}
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("defaultFetch", () => {
+  it("survives runtimes that reject a detached fetch reference", async () => {
+    const { calls } = installStrictFetch();
+    // The raw pattern this helper replaces is exactly the hazard:
+    const detached = globalThis.fetch;
+    await expect(async () => detached("https://vendo.invalid/")).rejects.toThrow("Illegal invocation");
+    // The helper, stored and called the same detached way, must not throw.
+    const stored = defaultFetch;
+    const response = await stored("https://vendo.invalid/");
+    expect(await response.text()).toBe("ok");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("late-binds so a fetch installed after capture is used", async () => {
+    const stored = defaultFetch;
+    installStrictFetch();
+    let sawUrl: unknown;
+    const probe: typeof fetch = (input, init) => {
+      sawUrl = input;
+      void init;
+      return Promise.resolve(new Response("late"));
+    };
+    globalThis.fetch = probe;
+    const response = await stored("https://vendo.invalid/late");
+    expect(sawUrl).toBe("https://vendo.invalid/late");
+    expect(await response.text()).toBe("late");
+  });
+});

--- a/packages/core/src/fetch.ts
+++ b/packages/core/src/fetch.ts
@@ -1,0 +1,7 @@
+/** The safe default for every `options.fetch ?? …` seam. A bare
+ *  `globalThis.fetch` stored in a variable and invoked later arrives with the
+ *  wrong receiver, which strict Web runtimes (Cloudflare Workers, browsers)
+ *  reject as "Illegal invocation"; the wrapper late-binds through globalThis
+ *  on every call, so it also tracks fetch replacements (polyfills, test
+ *  mocks) installed after capture. */
+export const defaultFetch: typeof fetch = (input, init) => globalThis.fetch(input, init);

--- a/packages/core/src/heartbeat.ts
+++ b/packages/core/src/heartbeat.ts
@@ -16,6 +16,7 @@
  * or the wire answers `active: false`. Non-streaming, non-ok, or header-less
  * responses pass through untouched.
  */
+import { defaultFetch } from "./fetch.js";
 
 const THREAD_ID_HEADER = "x-vendo-thread-id";
 const DEFAULT_BEAT_INTERVAL_MS = 5_000;
@@ -35,7 +36,7 @@ export function withTurnHeartbeat(response: Response, options: TurnHeartbeatOpti
   const threadId = response.headers.get(THREAD_ID_HEADER);
   if (threadId === null || !response.ok || response.body === null) return response;
 
-  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const fetchImpl = options.fetch ?? defaultFetch;
   const url = `${options.baseUrl.replace(/\/$/, "")}/threads/${encodeURIComponent(threadId)}/heartbeat`;
   let timer: ReturnType<typeof setInterval> | undefined;
   let stopped = false;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export * from "./errors.js";
 export * from "./formats.js";
 export * from "./grants.js";
 export * from "./guard.js";
+export * from "./fetch.js";
 export * from "./heartbeat.js";
 export * from "./host-seams.js";
 export * from "./ids.js";

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -55,5 +55,21 @@
     "@types/pg": "^8.11.10",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"
+  },
+  "imports": {
+    "#store/db": {
+      "workerd": "./dist/db-edge.js",
+      "worker": "./dist/db-edge.js",
+      "edge-light": "./dist/db-edge.js",
+      "browser": "./dist/db-edge.js",
+      "default": "./dist/db.js"
+    },
+    "#store/crypto": {
+      "workerd": "./dist/crypto-edge.js",
+      "worker": "./dist/crypto-edge.js",
+      "edge-light": "./dist/crypto-edge.js",
+      "browser": "./dist/crypto-edge.js",
+      "default": "./dist/crypto.js"
+    }
   }
 }

--- a/packages/store/src/crypto-edge.ts
+++ b/packages/store/src/crypto-edge.ts
@@ -1,0 +1,20 @@
+/** Edge build of the at-rest secret cipher (see db-edge.ts for the pattern).
+ *  The cipher rides node:crypto AES and Buffer keys; hosted deployments keep
+ *  secrets on the console side, so edge builds only need honest failure. */
+import { VendoError } from "@vendoai/core";
+
+const EDGE_MESSAGE =
+  "store secret encryption (VENDO_STORE_ENCRYPTION_KEY) needs the Node runtime; on edge deployments keep "
+  + "secrets on the hosted store or a custom adapter";
+
+export function validateEncryptionKey(_value: string): never {
+  throw new VendoError("validation", EDGE_MESSAGE);
+}
+
+export function encryptSecret(_value: string, _key: unknown, _name: string): never {
+  throw new VendoError("validation", EDGE_MESSAGE);
+}
+
+export function decryptSecret(_value: string, _key: unknown, _name: string): never {
+  throw new VendoError("validation", EDGE_MESSAGE);
+}

--- a/packages/store/src/db-edge.ts
+++ b/packages/store/src/db-edge.ts
@@ -1,0 +1,23 @@
+/** Web-standard-runtime build of the store engines, selected by the package's
+ *  `worker`/`workerd`/`edge-light`/`browser` conditions on `#store/db`. The
+ *  local engines are Node by nature (PGlite on the filesystem, pg over TCP),
+ *  so edge deployments must fill the store seam explicitly — hostedStore via
+ *  VENDO_API_KEY, or a custom adapter. Keep this module free of node builtins;
+ *  the portability gate bundles it. */
+import { VendoError } from "@vendoai/core";
+
+import type { Db, StoreConfig } from "./db.js";
+
+export type { Db, StoreConfig };
+
+const EDGE_MESSAGE =
+  "the local store engines (PGlite on disk, Postgres over TCP) need Node; on this runtime pass `store:` to "
+  + "createVendo explicitly — hostedStore via VENDO_API_KEY, or a custom adapter";
+
+export function createDb(_config: StoreConfig = {}): Db {
+  throw new VendoError("validation", EDGE_MESSAGE);
+}
+
+export function withSchemaLock<T>(_db: Db, _work: (query: unknown) => Promise<T>): Promise<T> {
+  return Promise.reject(new VendoError("validation", EDGE_MESSAGE));
+}

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -1,7 +1,6 @@
 import { VendoError } from "@vendoai/core";
-import { randomUUID } from "node:crypto";
-import type { Db } from "./db.js";
-import { withSchemaLock } from "./db.js";
+import type { Db } from "#store/db";
+import { withSchemaLock } from "#store/db";
 
 /** 02-store §4. v3 (block-actions design §C, ENG-263) historically added the
     Vendo-owned org tables (`vendo_orgs` + `vendo_org_members`); those tables
@@ -210,7 +209,7 @@ async function migrate(query: Query): Promise<void> {
   await query(
     `INSERT INTO vendo_meta (key, value) VALUES ('boot_id', $1::jsonb)
      ON CONFLICT (key) DO NOTHING`,
-    [JSON.stringify(randomUUID())],
+    [JSON.stringify(globalThis.crypto.randomUUID())],
   );
 }
 

--- a/packages/store/src/secrets.ts
+++ b/packages/store/src/secrets.ts
@@ -1,5 +1,5 @@
 import { VendoError, type SecretsProvider } from "@vendoai/core";
-import { decryptSecret, encryptSecret } from "./crypto.js";
+import { decryptSecret, encryptSecret } from "#store/crypto";
 import { dbFor, secretsConfigFor, type VendoStore } from "./store.js";
 import { text } from "./helpers/utils.js";
 

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -1,7 +1,7 @@
 import type { BlobStore, RecordStore, StoreAdapter } from "@vendoai/core";
 import { createBlobStore } from "./blobs.js";
-import { validateEncryptionKey } from "./crypto.js";
-import { createDb, type Db, type StoreConfig } from "./db.js";
+import { validateEncryptionKey } from "#store/crypto";
+import { createDb, type Db, type StoreConfig } from "#store/db";
 import { createRecordStore } from "./records.js";
 import { createReservedRecordStore } from "./routing.js";
 import { ensureSchema as migrateSchema } from "./schema.js";

--- a/packages/vendo-telemetry/package.json
+++ b/packages/vendo-telemetry/package.json
@@ -27,6 +27,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "workerd": "./dist/edge.js",
+      "worker": "./dist/edge.js",
+      "edge-light": "./dist/edge.js",
+      "browser": "./dist/edge.js",
       "default": "./dist/index.js"
     }
   },

--- a/packages/vendo-telemetry/src/edge.test.ts
+++ b/packages/vendo-telemetry/src/edge.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { initTelemetry } from "./edge.js";
+
+describe("edge telemetry entry", () => {
+  it("returns a no-op client without touching disk, process, or node builtins", async () => {
+    const telemetry = initTelemetry({ version: "0.0.0-test", runtime: true });
+    await expect(telemetry.track("doctor_run", { ok: true })).resolves.toBeUndefined();
+  });
+
+  it("keeps the module free of node builtin imports", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const source = await readFile(new URL("./edge.ts", import.meta.url), "utf8");
+    expect(source).not.toMatch(/from "node:/);
+    expect(source).not.toMatch(/require\(/);
+  });
+});

--- a/packages/vendo-telemetry/src/edge.test.ts
+++ b/packages/vendo-telemetry/src/edge.test.ts
@@ -14,4 +14,26 @@ describe("edge telemetry entry", () => {
     expect(source).not.toMatch(/from "node:/);
     expect(source).not.toMatch(/require\(/);
   });
+
+  it("reads as opted out with nothing persisted (no disk on the edge)", async () => {
+    const { loadConfig, saveConfig } = await import("./edge.js");
+    const config = loadConfig();
+    expect(config).toEqual({ anonymousId: "", optedOut: true, noticeShown: true });
+    // No disk: saving is a no-op and the next read stays opted out.
+    saveConfig("/nowhere", { anonymousId: "x", optedOut: false, noticeShown: false });
+    expect(loadConfig()).toEqual(config);
+  });
+
+  it("reports no git remote host (deployed bundles have no working copy)", async () => {
+    const { repoHost } = await import("./edge.js");
+    expect(repoHost()).toBeUndefined();
+    expect(repoHost("/srv/app")).toBeUndefined();
+  });
+
+  it("shares the pure consent module with the Node build", async () => {
+    const edge = await import("./edge.js");
+    const node = await import("./consent.js");
+    expect(edge.envOptOut).toBe(node.envOptOut);
+    expect(edge.resolveConsent).toBe(node.resolveConsent);
+  });
 });

--- a/packages/vendo-telemetry/src/edge.ts
+++ b/packages/vendo-telemetry/src/edge.ts
@@ -6,10 +6,29 @@
  *  is a no-op client rather than a porting exercise: deployments there simply
  *  don't report. Keep this module free of node builtins; the portability gate
  *  bundles it. */
+import type { RepoHost } from "./base-props.js";
+import type { TelemetryConfig } from "./config.js";
 import type { InitTelemetryOptions, Telemetry } from "./index.js";
 
-export type { InitTelemetryOptions, Telemetry };
+export type { InitTelemetryOptions, RepoHost, Telemetry, TelemetryConfig };
+
+// Pure module (no imports at all) — shared with the Node build.
+export { envOptOut, resolveConsent } from "./consent.js";
 
 export function initTelemetry(_opts: InitTelemetryOptions): Telemetry {
   return { track: () => Promise.resolve() };
+}
+
+/** No disk on the edge: every deployment reads as opted out, nothing persists. */
+export function loadConfig(_home?: string, _env?: Record<string, string | undefined>): TelemetryConfig {
+  return { anonymousId: "", optedOut: true, noticeShown: true };
+}
+
+export function saveConfig(_home: string, _config: TelemetryConfig): void {
+  // No disk on the edge; opt-out state is implicit (loadConfig above).
+}
+
+/** Git remotes are a working-copy concept; deployed edge bundles have none. */
+export function repoHost(_cwd?: string): RepoHost | undefined {
+  return undefined;
 }

--- a/packages/vendo-telemetry/src/edge.ts
+++ b/packages/vendo-telemetry/src/edge.ts
@@ -1,0 +1,15 @@
+/** Web-standard-runtime entry (Cloudflare Workers, Bun workers, edge
+ *  functions), selected by the package's `worker`/`workerd`/`edge-light`/
+ *  `browser` export conditions. Telemetry's real client is Node-shaped through
+ *  and through — disk-backed anonymous id under ~/.vendo, os/fs base props,
+ *  node:crypto hashes — none of which exists on the edge, so the edge build
+ *  is a no-op client rather than a porting exercise: deployments there simply
+ *  don't report. Keep this module free of node builtins; the portability gate
+ *  bundles it. */
+import type { InitTelemetryOptions, Telemetry } from "./index.js";
+
+export type { InitTelemetryOptions, Telemetry };
+
+export function initTelemetry(_opts: InitTelemetryOptions): Telemetry {
+  return { track: () => Promise.resolve() };
+}

--- a/packages/vendo/package.json
+++ b/packages/vendo/package.json
@@ -147,5 +147,14 @@
     "typescript": "^5.6.0",
     "vite": "^6.0.0",
     "vitest": "^2.1.0"
+  },
+  "imports": {
+    "#dev-creds/model": {
+      "workerd": "./dist/dev-creds/model-edge.js",
+      "worker": "./dist/dev-creds/model-edge.js",
+      "edge-light": "./dist/dev-creds/model-edge.js",
+      "browser": "./dist/dev-creds/model-edge.js",
+      "default": "./dist/dev-creds/model.js"
+    }
   }
 }

--- a/packages/vendo/src/capability-misses.ts
+++ b/packages/vendo/src/capability-misses.ts
@@ -6,7 +6,7 @@ import {
   type ToolDescriptor,
 } from "@vendoai/core";
 import { envOptOut, loadConfig, type TelemetryConfig } from "@vendoai/telemetry";
-import { cloudFetch } from "./cli/cloud/client.js";
+import { cloudKeyFetch } from "./cloud-key-fetch.js";
 
 const DEFAULT_DATA_DIR = ".vendo/data";
 const DEFAULT_BATCH_SIZE = 100;
@@ -130,8 +130,7 @@ function createMissUploader(options: {
       unrefTimer(timeout);
       try {
         const surface = await options.surface;
-        const response = await cloudFetch<{ accepted: number; duplicates: number }>("/api/v1/misses", {
-          auth: "key",
+        const response = await cloudKeyFetch<{ accepted: number; duplicates: number }>("/api/v1/misses", {
           apiKey: options.apiKey,
           env: options.env,
           fetchImpl: options.fetchImpl,

--- a/packages/vendo/src/catalog.test.ts
+++ b/packages/vendo/src/catalog.test.ts
@@ -1,4 +1,4 @@
-import { parseModule, zodFromExpression, type StaticExtraction } from "@vendoai/actions";
+import { parseModule, zodFromExpression, type StaticExtraction } from "@vendoai/actions/sync";
 import type { ComponentCatalog, ComponentRegistry, NormalizedCatalog } from "@vendoai/core";
 import ts from "typescript";
 import { describe, expect, it, vi } from "vitest";

--- a/packages/vendo/src/cli/cloud/client.ts
+++ b/packages/vendo/src/cli/cloud/client.ts
@@ -25,15 +25,10 @@ export class CloudError extends Error {
   }
 }
 
-export interface CloudUrlOptions {
-  apiUrl?: string;
-  env?: Record<string, string | undefined>;
-}
-
-export function resolveCloudBaseUrl(options: CloudUrlOptions = {}): string {
-  const value = options.apiUrl ?? (options.env ?? process.env).VENDO_CLOUD_URL ?? DEFAULT_CLOUD_URL;
-  return value.replace(/\/+$/, "");
-}
+// Base-URL resolution lives with the portable runtime helper so server-side
+// code (capability misses) never imports this Node/CLI module.
+export { resolveCloudBaseUrl, type CloudUrlOptions } from "../../cloud-key-fetch.js";
+import { resolveCloudBaseUrl, type CloudUrlOptions } from "../../cloud-key-fetch.js";
 
 export interface SessionStore {
   read(): Promise<CloudSession | null>;

--- a/packages/vendo/src/cli/extract/apply.ts
+++ b/packages/vendo/src/cli/extract/apply.ts
@@ -1,6 +1,6 @@
 import { join, resolve } from "node:path";
 import { z } from "zod";
-import { vendoSync } from "@vendoai/actions";
+import { vendoSync } from "@vendoai/actions/sync";
 import type { Telemetry } from "@vendoai/telemetry";
 import { detectDepVersions } from "../dep-versions.js";
 import { detectFramework } from "../framework.js";

--- a/packages/vendo/src/cli/init-scaffolds.ts
+++ b/packages/vendo/src/cli/init-scaffolds.ts
@@ -3,7 +3,7 @@ import {
   extractServerActions,
   serverActionRegistrations,
   type ServerActionRegistration,
-} from "@vendoai/actions";
+} from "@vendoai/actions/sync";
 import { AUTH_FAMILY_INFO, AUTH_PRESET_SPECIFIER, type AuthMatch } from "./init-auth.js";
 
 /** The wired preset line plus its escape-hatch comment. The lead-in stays

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -2,12 +2,8 @@ import { spawn } from "node:child_process";
 import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, relative, resolve, sep } from "node:path";
-import {
-  mergeOverrides,
-  vendoSync,
-  type ExtractedTool,
-  type OverridesFile,
-} from "@vendoai/actions";
+import type { ExtractedTool, OverridesFile } from "@vendoai/actions";
+import { mergeOverrides, vendoSync } from "@vendoai/actions/sync";
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import type { VendoTheme } from "@vendoai/core";

--- a/packages/vendo/src/cli/sync.ts
+++ b/packages/vendo/src/cli/sync.ts
@@ -1,5 +1,5 @@
 import { join, resolve } from "node:path";
-import { vendoSync, type SyncReportWithWarnings } from "@vendoai/actions";
+import { vendoSync, type SyncReportWithWarnings } from "@vendoai/actions/sync";
 import type { ToolImpact } from "../sync-impact.js";
 import { pushSyncReport } from "./cloud/services.js";
 import { syncSemantics } from "./semantics.js";

--- a/packages/vendo/src/cloud-apps.ts
+++ b/packages/vendo/src/cloud-apps.ts
@@ -5,6 +5,7 @@ import {
   type CloudAppsClient,
 } from "@vendoai/apps";
 import { consoleSender, raiseCloudError } from "./cloud-console.js";
+import { defaultFetch } from "@vendoai/core";
 
 /** The Cloud share/publish client — the implementation the composition seam
  * (createVendo) injects into the apps block's CloudAppsClient seam when
@@ -44,7 +45,7 @@ export function cloudApps(options: CloudAppsOptions): CloudAppsClient {
     mountPath: CONSOLE_APPS_PATH,
     apiKey: options.apiKey,
     timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-    fetchImpl: options.fetch ?? globalThis.fetch,
+    fetchImpl: options.fetch ?? defaultFetch,
     raise: raiseAppsError,
   });
 

--- a/packages/vendo/src/cloud-key-fetch.test.ts
+++ b/packages/vendo/src/cloud-key-fetch.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { cloudKeyFetch, resolveCloudBaseUrl } from "./cloud-key-fetch.js";
+
+describe("resolveCloudBaseUrl", () => {
+  it("prefers explicit apiUrl, then env, then the console default, trimming slashes", () => {
+    expect(resolveCloudBaseUrl({ apiUrl: "https://x.test//" })).toBe("https://x.test");
+    expect(resolveCloudBaseUrl({ env: { VENDO_CLOUD_URL: "https://env.test/" } })).toBe("https://env.test");
+    expect(resolveCloudBaseUrl({ env: {} })).toBe("https://console.vendo.run");
+  });
+
+  it("works without a process global (Workers)", () => {
+    expect(resolveCloudBaseUrl({ env: {} })).toBe("https://console.vendo.run");
+  });
+});
+
+describe("cloudKeyFetch", () => {
+  it("POSTs JSON with bearer key auth and parses the JSON response", async () => {
+    let seen: { url: string; method?: string; headers: Record<string, string>; body?: string } | undefined;
+    const fetchImpl: typeof fetch = (input, init) => {
+      seen = {
+        url: String(input),
+        ...(init?.method === undefined ? {} : { method: init.method }),
+        headers: (init?.headers ?? {}) as Record<string, string>,
+        ...(typeof init?.body === "string" ? { body: init.body } : {}),
+      };
+      return Promise.resolve(new Response(JSON.stringify({ accepted: 1 }), {
+        headers: { "content-type": "application/json" },
+      }));
+    };
+    const result = await cloudKeyFetch<{ accepted: number }>("/api/v1/misses", {
+      apiKey: "vnd_test",
+      env: { VENDO_CLOUD_URL: "https://console.test" },
+      fetchImpl,
+      body: { events: [] },
+    });
+    expect(result).toEqual({ accepted: 1 });
+    expect(seen?.url).toBe("https://console.test/api/v1/misses");
+    expect(seen?.method).toBe("POST");
+    expect(seen?.headers.authorization).toBe("Bearer vnd_test");
+    expect(seen?.headers["content-type"]).toBe("application/json");
+    expect(seen?.body).toBe(JSON.stringify({ events: [] }));
+  });
+
+  it("throws on a non-ok response", async () => {
+    const fetchImpl: typeof fetch = () => Promise.resolve(new Response("no", { status: 402 }));
+    await expect(cloudKeyFetch("/api/v1/misses", { apiKey: "vnd_test", env: {}, fetchImpl, body: {} }))
+      .rejects.toThrow(/402/);
+  });
+
+  it("keeps the module free of node builtins and CLI imports", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const source = await readFile(new URL("./cloud-key-fetch.ts", import.meta.url), "utf8");
+    expect(source).not.toMatch(/from "node:/);
+    expect(source).not.toMatch(/\.\/cli\//);
+    expect(source).not.toMatch(/process\.env[^?]/);
+  });
+});

--- a/packages/vendo/src/cloud-key-fetch.ts
+++ b/packages/vendo/src/cloud-key-fetch.ts
@@ -1,0 +1,59 @@
+/** Portable key-authenticated console calls for RUNTIME code (capability
+ *  misses today). The CLI's cloudFetch adds user sessions, refresh, and disk
+ *  state on top — Node-only concerns that used to ride into Worker bundles
+ *  whenever runtime code borrowed it. Keep this module free of node builtins
+ *  and CLI imports; the portability gate bundles it. */
+import { defaultFetch } from "@vendoai/core";
+
+import { deploymentIdentityHeaders } from "./deployment-identity.js";
+import { VERSION } from "./wire/shared.js";
+
+const DEFAULT_CLOUD_URL = "https://console.vendo.run";
+
+export interface CloudUrlOptions {
+  apiUrl?: string;
+  env?: Record<string, string | undefined>;
+}
+
+const processEnv = (): Record<string, string | undefined> =>
+  (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {};
+
+export function resolveCloudBaseUrl(options: CloudUrlOptions = {}): string {
+  const value = options.apiUrl ?? (options.env ?? processEnv()).VENDO_CLOUD_URL ?? DEFAULT_CLOUD_URL;
+  return value.replace(/\/+$/, "");
+}
+
+export interface CloudKeyFetchOptions extends CloudUrlOptions {
+  apiKey?: string;
+  method?: string;
+  body?: unknown;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+}
+
+/** POST/GET a console API path with VENDO_API_KEY bearer auth. The console's
+ *  shared auth middleware upserts deployment inventory and meters usage from
+ *  the identity headers on real service calls (deployment-identity.ts). */
+export async function cloudKeyFetch<T = unknown>(path: string, options: CloudKeyFetchOptions = {}): Promise<T> {
+  const token = options.apiKey ?? (options.env ?? processEnv()).VENDO_API_KEY;
+  if (token === undefined || token === "") {
+    throw new Error("Vendo Cloud key call without a key: pass apiKey or set VENDO_API_KEY");
+  }
+  const headers: Record<string, string> = {
+    accept: "application/json",
+    authorization: `Bearer ${token}`,
+    "user-agent": `vendo-cli/${VERSION}`,
+    ...(options.body === undefined ? {} : { "content-type": "application/json" }),
+    ...(await deploymentIdentityHeaders()),
+  };
+  const response = await (options.fetchImpl ?? defaultFetch)(`${resolveCloudBaseUrl(options)}${path}`, {
+    method: options.method ?? (options.body === undefined ? "GET" : "POST"),
+    headers,
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+    ...(options.signal === undefined ? {} : { signal: options.signal }),
+  });
+  if (!response.ok) {
+    throw new Error(`Vendo Cloud ${path} answered ${response.status}`);
+  }
+  return await response.json() as T;
+}

--- a/packages/vendo/src/cloud-tools.ts
+++ b/packages/vendo/src/cloud-tools.ts
@@ -1,6 +1,7 @@
 import { composioToolRisk, normalizeToolName, type Connector, type ConnectorAccountIdentity } from "@vendoai/actions";
 import type { RunContext, ToolCall, ToolDescriptor, ToolOutcome } from "@vendoai/core";
 import { deploymentIdentityHeaders } from "./deployment-identity.js";
+import { defaultFetch } from "@vendoai/core";
 
 /** The Cloud tools adapter — the execution half of the zero-key Composio
  * seam (cloudConnections is the account half). Tools list and execute ride
@@ -42,7 +43,7 @@ function withIdentity(outcome: ToolOutcome, identity: ConnectorAccountIdentity):
 
 export function cloudTools(options: CloudToolsOptions): Connector {
   const base = (options.baseUrl ?? "https://console.vendo.run").replace(/\/$/, "");
-  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const fetchImpl = options.fetch ?? defaultFetch;
   let normalizedToRaw = new Map<string, { raw: string; toolkit: string }>();
 
   async function cloudFetch(path: string, init?: RequestInit): Promise<{ ok: boolean; status: number; payload: unknown }> {

--- a/packages/vendo/src/connections.ts
+++ b/packages/vendo/src/connections.ts
@@ -1,4 +1,4 @@
-import { VendoError, type Principal } from "@vendoai/core";
+import { defaultFetch, VendoError, type Principal } from "@vendoai/core";
 import type { Connector, ConnectorAccount, ConnectorConnections } from "@vendoai/actions";
 import { consoleSender, raiseCloudError } from "./cloud-console.js";
 
@@ -162,7 +162,7 @@ const raiseConnectionsError = (response: Response): Promise<never> =>
  * the wire it must serve. */
 export function cloudConnections(options: CloudConnectionsOptions): ConnectionsService {
   const base = (options.baseUrl ?? "https://console.vendo.run").replace(/\/$/, "");
-  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const fetchImpl = options.fetch ?? defaultFetch;
   // The key-authed console sender (cloud-console.ts): Bearer auth + deployment
   // identity (the console meters usage from real traffic) + per-request abort
   // timeout, raising through the shared error table on any non-2xx.

--- a/packages/vendo/src/dev-creds/model-edge.test.ts
+++ b/packages/vendo/src/dev-creds/model-edge.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { devModel } from "./model-edge.js";
+
+describe("dev-creds model, edge entry", () => {
+  it("fails a model call with wiring guidance instead of reaching for Node resolution", async () => {
+    const model = devModel();
+    const call = (model as { doStream: (options: unknown) => Promise<unknown> }).doStream({});
+    await expect(call).rejects.toThrow(/pass `model:`/);
+    await expect(call).rejects.toThrow(/VENDO_API_KEY/);
+  });
+
+  it("keeps the module free of node builtins and CLI imports", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const source = await readFile(new URL("./model-edge.ts", import.meta.url), "utf8");
+    expect(source).not.toMatch(/from "node:/);
+    expect(source).not.toMatch(/\.\.\/cli\//);
+  });
+});

--- a/packages/vendo/src/dev-creds/model-edge.ts
+++ b/packages/vendo/src/dev-creds/model-edge.ts
@@ -1,0 +1,56 @@
+/** Web-standard-runtime build of the dev credential ladder, selected by the
+ *  package's `worker`/`workerd`/`edge-light`/`browser` import conditions
+ *  (see `#dev-creds/model` in package.json).
+ *
+ *  The real ladder is Node by design: it resolves the host's own @ai-sdk
+ *  provider install via createRequire from the project root, reads `vendo
+ *  login` sessions off disk, and anchors on process.cwd(). None of that
+ *  exists inside a Worker bundle — Mohamed's field report had the ladder
+ *  dying on runtime require.resolve under Wrangler even with VENDO_API_KEY
+ *  set. On these runtimes the model seam is explicit by contract: the host
+ *  wiring constructs the provider (init generates it; the Cloud gateway is
+ *  the stock Anthropic provider pointed at the console). The ladder's edge
+ *  build therefore resolves to honest guidance instead of half-working
+ *  magic. Keep this module free of node builtins and CLI imports; the
+ *  portability gate bundles it. */
+import type { LanguageModel } from "ai";
+
+import type { DevModelOptions } from "./model.js";
+
+export type { DevModelOptions };
+
+const EDGE_MESSAGE =
+  "the dev model ladder needs Node (it resolves the host's provider install and dev credentials from disk); "
+  + "on this runtime pass `model:` to createVendo explicitly — with a Vendo Cloud key that is the stock Anthropic "
+  + "provider pointed at the console gateway: createAnthropic({ apiKey: VENDO_API_KEY, baseURL: `${VENDO_CLOUD_URL ?? \"https://console.vendo.run\"}/api/v1` })(\"vendo-default\")";
+
+interface LanguageModelV3Like {
+  specificationVersion: "v3";
+  provider: string;
+  modelId: string;
+  supportedUrls: Record<string, RegExp[]>;
+  doGenerate(options: unknown): Promise<unknown>;
+  doStream(options: unknown): Promise<unknown>;
+}
+
+/** Same seam as the Node build; announces its unavailability once on first
+ *  use through the server log, like the Node ladder's unavailable rung. */
+export function devModel(_options: DevModelOptions = {}): LanguageModel {
+  let announced = false;
+  const refuse = (): never => {
+    if (!announced) {
+      announced = true;
+      console.error(`[vendo] model: ${EDGE_MESSAGE}`);
+    }
+    throw new Error(EDGE_MESSAGE);
+  };
+  const model: LanguageModelV3Like = {
+    specificationVersion: "v3",
+    provider: "vendo-dev",
+    modelId: "dev-env",
+    supportedUrls: {},
+    doGenerate: () => Promise.resolve().then(refuse),
+    doStream: () => Promise.resolve().then(refuse),
+  };
+  return model as unknown as LanguageModel;
+}

--- a/packages/vendo/src/drift-rebase.fixture.test.ts
+++ b/packages/vendo/src/drift-rebase.fixture.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { vendoSync } from "@vendoai/actions";
+import { vendoSync } from "@vendoai/actions/sync";
 import { appVersionHash, pinBaselineSchema, pinComponentName } from "@vendoai/apps";
 import { VENDO_APP_FORMAT, type AppDocument, type Principal } from "@vendoai/core";
 import { createStore } from "@vendoai/store";

--- a/packages/vendo/src/hosted-store.ts
+++ b/packages/vendo/src/hosted-store.ts
@@ -15,6 +15,7 @@ import {
 } from "@vendoai/store";
 import { consoleSender, raiseCloudError, toArrayBuffer } from "./cloud-console.js";
 import { deploymentIdentityHeaders } from "./deployment-identity.js";
+import { defaultFetch } from "@vendoai/core";
 
 /** The console mounts the hosted-store surface here
  * (apps/console/app/api/v1/store/*). */
@@ -130,7 +131,7 @@ function parseNullableRecord(value: unknown): VendoRecord | null {
 export function hostedStore(options: HostedStoreOptions): HostedStore {
   const base = (options.baseUrl ?? "https://console.vendo.run").replace(/\/$/, "");
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const fetchImpl = options.fetch ?? defaultFetch;
 
   const send = consoleSender({
     base,

--- a/packages/vendo/src/inclient.fixture.test.ts
+++ b/packages/vendo/src/inclient.fixture.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { vendoSync } from "@vendoai/actions";
+import { vendoSync } from "@vendoai/actions/sync";
 import { appVersionHash, pinComponentName } from "@vendoai/apps";
 import { VENDO_APP_FORMAT, type AppDocument, type Principal } from "@vendoai/core";
 import { createStore } from "@vendoai/store";

--- a/packages/vendo/src/pins.fixture.test.ts
+++ b/packages/vendo/src/pins.fixture.test.ts
@@ -1,7 +1,8 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { capturedPinBaselineSchema, vendoSync } from "@vendoai/actions";
+import { capturedPinBaselineSchema } from "@vendoai/actions";
+import { vendoSync } from "@vendoai/actions/sync";
 import { pinBaselineSchema } from "@vendoai/apps";
 import { VENDO_APP_FORMAT, type AppDocument, type RunContext } from "@vendoai/core";
 import { createStore } from "@vendoai/store";

--- a/packages/vendo/src/refine.ts
+++ b/packages/vendo/src/refine.ts
@@ -25,6 +25,7 @@ import {
 import { generateObject } from "ai";
 import type { LanguageModel } from "ai";
 import { z } from "zod";
+import { defaultFetch } from "@vendoai/core";
 
 /**
  * The refine engine (ENG-250, extraction spec §3). One engine, two surfaces:
@@ -636,7 +637,7 @@ const stringify = (value: unknown): string => `${JSON.stringify(value, null, 2)}
 
 export async function runRefine(options: RefineOptions): Promise<RefineResult> {
   const root = resolve(options.root);
-  const fetchImpl = options.fetchImpl ?? fetch;
+  const fetchImpl = options.fetchImpl ?? defaultFetch;
   const interview = options.interview ?? [];
   const startedAt = new Date().toISOString();
 

--- a/packages/vendo/src/sandbox.ts
+++ b/packages/vendo/src/sandbox.ts
@@ -1,5 +1,5 @@
 import type { SandboxAdapter, SandboxMachine, SandboxResumePolicy } from "@vendoai/apps";
-import { VendoError, type VendoErrorCode } from "@vendoai/core";
+import { defaultFetch, VendoError, type VendoErrorCode } from "@vendoai/core";
 import { deploymentIdentityHeaders } from "./deployment-identity.js";
 import {
   CLOUD_BOX_PORT,
@@ -192,7 +192,7 @@ const isGone = (error: unknown): boolean =>
 export function cloudSandbox(options: CloudSandboxOptions): SandboxAdapter {
   const base = (options.baseUrl ?? "https://console.vendo.run").replace(/\/$/, "");
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const fetchImpl = options.fetch ?? defaultFetch;
 
   const send = async (path: string, init: RequestInit = {}): Promise<Response> => {
     const response = await fetchImpl(`${base}${CLOUD_SANDBOX_PATH}${path}`, {

--- a/packages/vendo/src/server-lazy.test.ts
+++ b/packages/vendo/src/server-lazy.test.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { LanguageModel } from "ai";
+import type { Principal } from "@vendoai/core";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createVendo } from "./server.js";
+
+const principal: Principal = { kind: "user", subject: "user_lazy" };
+
+const cleanups: Array<() => Promise<void>> = [];
+
+async function tempStore(): Promise<{ store: VendoStore; ensureSchema: ReturnType<typeof vi.fn> }> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-lazy-"));
+  const store = createStore({ dataDir });
+  const realEnsureSchema = store.ensureSchema.bind(store);
+  const ensureSchema = vi.fn(realEnsureSchema);
+  store.ensureSchema = ensureSchema;
+  cleanups.push(async () => {
+    await realEnsureSchema().catch(() => undefined);
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return { store, ensureSchema };
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  for (const cleanup of cleanups.splice(0)) await cleanup();
+});
+
+describe("createVendo construction purity (Workers global scope)", () => {
+  it("performs no store I/O and starts no timers at construction", async () => {
+    const timerSpy = vi.spyOn(globalThis, "setInterval");
+    const { store, ensureSchema } = await tempStore();
+    createVendo({ model: {} as LanguageModel, principal: async () => principal, store });
+    expect(ensureSchema).not.toHaveBeenCalled();
+    expect(timerSpy).not.toHaveBeenCalled();
+  });
+
+  it("runs schema readiness once, on first request, and starts the sweep then", async () => {
+    const timerSpy = vi.spyOn(globalThis, "setInterval");
+    const { store, ensureSchema } = await tempStore();
+    const vendo = createVendo({ model: {} as LanguageModel, principal: async () => principal, store });
+    expect(timerSpy).not.toHaveBeenCalled();
+    const status = () => vendo.handler(new Request("https://host.test/api/vendo/status"));
+    const first = await status();
+    expect(first.status).toBe(200);
+    await status();
+    expect(ensureSchema).toHaveBeenCalledTimes(1);
+    expect(timerSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/vendo/src/server-lazy.test.ts
+++ b/packages/vendo/src/server-lazy.test.ts
@@ -41,6 +41,17 @@ describe("createVendo construction purity (Workers global scope)", () => {
     expect(timerSpy).not.toHaveBeenCalled();
   });
 
+  it("triggers schema readiness from a guardedTools execute (BYO agent loops never call the handler)", async () => {
+    const { store, ensureSchema } = await tempStore();
+    const vendo = createVendo({ model: {} as LanguageModel, principal: async () => principal, store });
+    expect(ensureSchema).not.toHaveBeenCalled();
+    await vendo.guardedTools.execute(
+      { id: "call_lazy", tool: "vendo_apps_list", args: {} },
+      { principal, venue: "byo", presence: "absent", sessionId: "session_lazy" },
+    ).catch(() => undefined);
+    expect(ensureSchema).toHaveBeenCalledTimes(1);
+  });
+
   it("runs schema readiness once, on first request, and starts the sweep then", async () => {
     const timerSpy = vi.spyOn(globalThis, "setInterval");
     const { store, ensureSchema } = await tempStore();

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -1523,7 +1523,11 @@ export function createVendo(config: CreateVendoConfig): Vendo {
       ...(theme === undefined ? {} : { theme }),
     });
   }
-  const sessionId = `session_${globalThis.crypto.randomUUID()}`;
+  // Minted on first request via the deps getter below — Workers forbids
+  // generating random values in global scope, and createVendo runs at module
+  // init in the edge wiring. Still one fallback id per process.
+  let processSessionId: string | undefined;
+  const sessionId = (): string => (processSessionId ??= `session_${globalThis.crypto.randomUUID()}`);
   // Anonymous principals are minted per-CLIENT in the handler (opaque cookie
   // pointer; the store's vendo_sessions row is the authority — kill-list B3).
   // An https VENDO_BASE_URL means TLS terminates at a trusted proxy and requests
@@ -1545,7 +1549,7 @@ export function createVendo(config: CreateVendoConfig): Vendo {
     principal: resolvePrincipal,
     ready,
     trustedBaseIsHttps,
-    sessionId,
+    get sessionId() { return sessionId(); },
     store,
     telemetry: telemetryClient(config.telemetry),
     agent,

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -874,7 +874,7 @@ function createWireHandler(deps: WireDeps): (request: Request) => Promise<Respon
       // addressing a real Vendo WIRE route may (04 §4), and the door's paths are
       // the door's, not wire routes.
       if (deps.door !== undefined && isDoorPath(url.pathname)) {
-        await deps.ready;
+        await deps.ready();
         return await deps.door.handler(request);
       }
       const path = relativePath(url);
@@ -885,7 +885,7 @@ function createWireHandler(deps: WireDeps): (request: Request) => Promise<Respon
       if (jsonMutationRequired(request, path) && !isJsonRequest(request)) {
         throw new VendoError("validation", "content-type must be application/json");
       }
-      await deps.ready;
+      await deps.ready();
 
       // The per-request view the route table dispatches on (kill-list B4).
       // Segments decode lazily so raw-matched pre-routes (proxy, webhooks,
@@ -977,10 +977,23 @@ export function createVendo(config: CreateVendoConfig): Vendo {
   // Inference, selected by the adapter rule at this composition seam
   // (selectModel above) — the one model the agent and apps blocks consume.
   const inference = selectModel(config.model);
-  const ready = store.ensureSchema();
-  // Keep eager schema readiness for hosts that reach into composed blocks,
-  // while preventing an unhandled rejection before the first handler/emit awaits it.
-  void ready.catch(() => undefined);
+  // Construction stays PURE — no I/O, no timers — because the common edge
+  // wiring calls createVendo() at module init, where Workers forbids both
+  // (Mohamed's field report: "Disallowed operation called within global
+  // scope"). The first handler/emit touch starts schema readiness and the
+  // background sweep together through this once-latch; on Node the first
+  // request pays the same cost the old eager kick merely front-loaded.
+  let startBackgroundSweep: () => void = () => undefined;
+  let readyState: Promise<void> | undefined;
+  const ready = (): Promise<void> => {
+    if (readyState === undefined) {
+      readyState = store.ensureSchema();
+      // No unhandled rejection before a handler/emit awaits the latch.
+      void readyState.catch(() => undefined);
+      startBackgroundSweep();
+    }
+    return readyState;
+  };
   let resolveAppToolRisk: AppsRuntime["agentToolRisk"] | undefined;
   const guard = createGuard({
     store,
@@ -1404,16 +1417,21 @@ export function createVendo(config: CreateVendoConfig): Vendo {
   // engine pattern) so an idle process still reclaims sessions with no traffic;
   // unref'd means it never keeps the event loop alive. Torn down with the store.
   if (sweepEnabled) {
-    const sweepTimer = setInterval(() => {
-      runSweep().catch((error: unknown) => {
-        console.warn(`[vendo] session sweep failed; will retry next interval: ${error instanceof Error ? error.message : String(error)}`);
-      });
-    }, sessionsConfig.sweepIntervalMs);
-    (sweepTimer as unknown as { unref?: () => void }).unref?.();
-    const closeStore = store.close.bind(store);
-    store.close = async (): Promise<void> => {
-      clearInterval(sweepTimer);
-      await closeStore();
+    // Armed by the ready() latch above, NOT at construction: timers are
+    // illegal in Workers global scope, and a process that never serves a
+    // request has nothing to sweep.
+    startBackgroundSweep = (): void => {
+      const sweepTimer = setInterval(() => {
+        runSweep().catch((error: unknown) => {
+          console.warn(`[vendo] session sweep failed; will retry next interval: ${error instanceof Error ? error.message : String(error)}`);
+        });
+      }, sessionsConfig.sweepIntervalMs);
+      (sweepTimer as unknown as { unref?: () => void }).unref?.();
+      const closeStore = store.close.bind(store);
+      store.close = async (): Promise<void> => {
+        clearInterval(sweepTimer);
+        await closeStore();
+      };
     };
   }
   // Wave 2 (Cloud auto): a keyed deployment's schedule- and external-triggered
@@ -1575,7 +1593,7 @@ export function createVendo(config: CreateVendoConfig): Vendo {
   return {
     handler,
     async emit(event, payload, principal) {
-      await ready;
+      await ready();
       return automations.emit(event, payload, principal);
     },
     agent,

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -1602,7 +1602,19 @@ export function createVendo(config: CreateVendoConfig): Vendo {
     },
     agent,
     guard,
-    guardedTools: byoApprovals.registry,
+    // The BYO seam (ai-sdk.ts / mastra.ts tool packs) reaches the store
+    // without ever touching handler/emit, so its execute leg arms the same
+    // ready() latch — the composed-block head start the old eager kick gave
+    // such hosts, without the construction-time I/O Workers forbids. Direct
+    // vendo.store/automations reach-ins still own their readiness (await
+    // store.ensureSchema(), as the mastra example and defer tests do).
+    guardedTools: {
+      ...byoApprovals.registry,
+      execute: async (call, ctx) => {
+        await ready();
+        return byoApprovals.registry.execute(call, ctx);
+      },
+    },
     apps,
     automations,
     actions,

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -86,11 +86,11 @@ import {
   createCapabilityMissCapture,
 } from "./capability-misses.js";
 import { catalogThemeSummary, mergeRuntimeCatalog, normalizeCatalogConfig, runtimeCatalogFromJson } from "./catalog.js";
-import { devModel } from "./dev-creds/model.js";
+import { devModel } from "#dev-creds/model";
 // install-dx v1 — `devModel()` is the env-resolving model createVendo composes
 // when the host passes none; the resolver is shared by init and doctor (one
 // credential story, real keys only).
-export { devModel, type DevModelOptions } from "./dev-creds/model.js";
+export { devModel, type DevModelOptions } from "#dev-creds/model";
 import {
   byoConnections,
   cloudConnections,

--- a/packages/vendo/src/wire/shared.ts
+++ b/packages/vendo/src/wire/shared.ts
@@ -46,7 +46,7 @@ const STATUS_BY_CODE: Record<VendoErrorCode, number> = {
 
 export interface WireDeps {
   principal: (req: Request) => Promise<Principal | null>;
-  ready: Promise<void>;
+  ready: () => Promise<void>;
   /** VENDO_BASE_URL is https → TLS terminates upstream; see secureRequest. */
   trustedBaseIsHttps: boolean;
   sessionId: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,12 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^2.1.0
         version: 2.1.9(vitest@2.1.9(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0))
+      esbuild:
+        specifier: ^0.25.12
+        version: 0.25.12
+      miniflare:
+        specifier: ^4.20260714.0
+        version: 4.20260714.0(@types/node@22.20.0)
       opentype.js:
         specifier: ^2.0.0
         version: 2.0.0
@@ -1779,6 +1785,36 @@ packages:
       react-dom:
         optional: true
 
+  '@cloudflare/workerd-darwin-64@1.20260714.1':
+    resolution: {integrity: sha512-ZWXqAN8G7Cx9hMRQuk+59ziJhR3j1F4iO+Qs8aHdfKZ3Dq5Yi/57xvkJTgCGBnW1YU/L78r8f6HEy51bwbTpNw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260714.1':
+    resolution: {integrity: sha512-tueWxWC3wyCbMG6zRAxsMXX0YLgrRWbiAPYFQ2uJ7dUH8G+5E7UTWaQS9B1HdJ0bpKFW1NWxhs1o2noKVFSUYg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260714.1':
+    resolution: {integrity: sha512-1VChTZRb0l0F7R4e1G5RtLKV4oFi6x+rQgxh2+yu887j3l/3TLgatuv1L8/5zhc9gKEhATTxOh0e52Rtd9dDWQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260714.1':
+    resolution: {integrity: sha512-rMm3G+NirG2UdgHIRDdF1asNC6FqgIzZzkRG+VDhhDGcVxAQwvrMT1E38BivEvHr3G04MB4AfhcOczX0+GtRkQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260714.1':
+    resolution: {integrity: sha512-cGqnU3Hg2YZS/k3SAqrMp1DjpdsyFde72tWltdl6ZT9+SFz/Zrk/8gyTU1TcxC4YApXeNVH5TyU5cOGPgUJ0pg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
   '@connectrpc/connect-web@2.0.0-rc.3':
     resolution: {integrity: sha512-w88P8Lsn5CCsA7MFRl2e6oLY4J/5toiNtJns/YJrlyQaWOy3RO8pDgkz+iIkG98RPMhj2thuBvsd3Cn4DKKCkw==}
     peerDependencies:
@@ -1789,6 +1825,10 @@ packages:
     resolution: {integrity: sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==}
     peerDependencies:
       '@bufbuild/protobuf': ^2.2.0
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -2683,6 +2723,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
   '@libsql/client@0.17.4':
     resolution: {integrity: sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw==}
 
@@ -2960,6 +3003,15 @@ packages:
     resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
   '@posthog/core@1.43.1':
     resolution: {integrity: sha512-hGM8f5sp3we6Em/RQHXbmyYm554hUx9+9jhf92ZQgDS4/xW72KHyZiO9wcFye+qAx2cJAOhOCDIznmO1FV8IbA==}
@@ -3528,6 +3580,10 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
@@ -3539,6 +3595,9 @@ packages:
   '@sindresorhus/transliterate@1.6.0':
     resolution: {integrity: sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==}
     engines: {node: '>=12'}
+
+  '@speed-highlight/core@1.2.17':
+    resolution: {integrity: sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==}
 
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
@@ -4612,6 +4671,10 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -4879,6 +4942,9 @@ packages:
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
+
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
   es-abstract-get@1.0.0:
     resolution: {integrity: sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==}
@@ -5901,6 +5967,10 @@ packages:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
 
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
 
@@ -6247,6 +6317,11 @@ packages:
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
+
+  miniflare@4.20260714.0:
+    resolution: {integrity: sha512-MYlTCLdWCPqvrYY2uLwOjXwmglXuiHE3TGGkbOW4BwjUPa1r07E0iuHwrNDIs/sxK21r+o90Jx58AV2KeNdJZw==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -7316,6 +7391,10 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -7854,6 +7933,11 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  workerd@1.20260714.1:
+    resolution: {integrity: sha512-oIbQzfdyl9UQUnG6XLegcSq0Mgt/7WKDbFOoqGgOWCS+/fhyGB460uKEgdAQQ9RHCO/ttcNCX/KiMIQzdoeu3Q==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -7914,6 +7998,12 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   zip-stream@7.0.5:
     resolution: {integrity: sha512-dSvYKdvLsAHCDqPOhIwk/q5CvuWtTB3Dgpoe0uVEFjTzIOAmsQpprX25InCvrvJsirEbu1OHyy67n/kAj1Sw/w==}
@@ -8591,6 +8681,21 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  '@cloudflare/workerd-darwin-64@1.20260714.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260714.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260714.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260714.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260714.1':
+    optional: true
+
   '@connectrpc/connect-web@2.0.0-rc.3(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.12.1))':
     dependencies:
       '@bufbuild/protobuf': 2.12.1
@@ -8599,6 +8704,10 @@ snapshots:
   '@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.12.1)':
     dependencies:
       '@bufbuild/protobuf': 2.12.1
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -9040,8 +9149,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.35.3':
     optionalDependencies:
@@ -9194,6 +9302,11 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -9610,6 +9723,18 @@ snapshots:
   '@playwright/test@1.61.1':
     dependencies:
       playwright: 1.61.1
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
 
   '@posthog/core@1.43.1':
     dependencies:
@@ -10101,6 +10226,8 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
+  '@sindresorhus/is@7.2.0': {}
+
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@sindresorhus/slugify@2.2.1':
@@ -10111,6 +10238,8 @@ snapshots:
   '@sindresorhus/transliterate@1.6.0':
     dependencies:
       escape-string-regexp: 5.0.0
+
+  '@speed-highlight/core@1.2.17': {}
 
   '@stablelib/base64@1.0.1': {}
 
@@ -11208,6 +11337,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cookie@1.1.1: {}
+
   core-util-is@1.0.3: {}
 
   cors@2.8.6:
@@ -11445,6 +11576,8 @@ snapshots:
 
   entities@8.0.0: {}
 
+  error-stack-parser-es@1.0.5: {}
+
   es-abstract-get@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -11657,7 +11790,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.9
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
@@ -11700,7 +11833,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11715,11 +11848,36 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.5(jiti@2.7.0)
+      get-tsconfig: 4.14.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.17
+      unrs-resolver: 1.12.2
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.5(jiti@2.7.0)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
@@ -11737,7 +11895,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -11766,7 +11924,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -12787,6 +12945,8 @@ snapshots:
 
   kind-of@6.0.3: {}
 
+  kleur@4.1.5: {}
+
   language-subtag-registry@0.3.23: {}
 
   language-tags@1.0.9:
@@ -13343,6 +13503,19 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  miniflare@4.20260714.0(@types/node@22.20.0):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.35.3(@types/node@22.20.0)
+      undici: 7.28.0
+      workerd: 1.20260714.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - utf-8-validate
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.7
@@ -13462,7 +13635,7 @@ snapshots:
       postcss: 8.5.16
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.4)
+      styled-jsx: 5.1.6(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.9
       '@next/swc-darwin-x64': 16.2.9
@@ -14447,7 +14620,6 @@ snapshots:
       '@img/sharp-win32-ia32': 0.35.3
       '@img/sharp-win32-x64': 0.35.3
       '@types/node': 22.20.0
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -14671,6 +14843,11 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.7
 
+  styled-jsx@5.1.6(react@19.2.4):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.4
+
   styled-jsx@5.1.6(react@19.2.7):
     dependencies:
       client-only: 0.0.1
@@ -14685,6 +14862,8 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
+
+  supports-color@10.2.2: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -15374,6 +15553,14 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  workerd@1.20260714.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260714.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260714.1
+      '@cloudflare/workerd-linux-64': 1.20260714.1
+      '@cloudflare/workerd-linux-arm64': 1.20260714.1
+      '@cloudflare/workerd-windows-64': 1.20260714.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -15411,6 +15598,19 @@ snapshots:
       yoctocolors: 2.1.2
 
   yoctocolors@2.1.2: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.17
+      cookie: 1.1.1
+      youch-core: 0.3.3
 
   zip-stream@7.0.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,13 +15,15 @@ packages:
 
 # pnpm 9 ran every dependency build script; pnpm 11 (strictDepBuilds) requires
 # an explicit allowlist. These five are the deps with build scripts in the
-# tree — all allowed, preserving pnpm 9 behavior.
+# tree — all allowed, preserving pnpm 9 behavior. workerd is miniflare's
+# runtime for the portability gate (scripts/portability-gate.mjs).
 allowBuilds:
   cbor-extract: true
   esbuild: true
   protobufjs: true
   sharp: true
   unrs-resolver: true
+  workerd: true
 
 minimumReleaseAgeExclude:
   - '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.214'

--- a/scripts/fixtures/portability-worker/.gitignore
+++ b/scripts/fixtures/portability-worker/.gitignore
@@ -1,0 +1,1 @@
+.bundle.mjs

--- a/scripts/fixtures/portability-worker/worker.mjs
+++ b/scripts/fixtures/portability-worker/worker.mjs
@@ -1,0 +1,50 @@
+/** Portability-gate fixture: the exact wiring shape a Cloudflare Worker host
+ *  uses — createVendo at MODULE SCOPE (where Workers forbids I/O, timers, and
+ *  randomness), a stub store/model so the fixture needs no credentials, and
+ *  the wire handler exported as the fetch entry. If construction regresses to
+ *  eager work, workerd refuses to instantiate this module and the gate fails
+ *  before any request is served. */
+import { createVendo } from "@vendoai/vendo/server";
+
+/** Callable-anything proxy: every property is a callable that resolves to
+ *  undefined, so composition-time store binding (records(), blobs(), ...)
+ *  succeeds without a database. The /status probe never reads data. */
+const anything = new Proxy(function anything() {}, {
+  get(_target, property) {
+    if (property === Symbol.toPrimitive || property === "then") return undefined;
+    return anything;
+  },
+  apply() {
+    return Promise.resolve(undefined);
+  },
+});
+
+const stubStore = new Proxy(function stubStore() {}, {
+  get(_target, property) {
+    if (property === Symbol.toPrimitive || property === "then") return undefined;
+    if (property === "ensureSchema" || property === "close") return () => Promise.resolve(undefined);
+    if (property === "query") return () => Promise.resolve({ rows: [] });
+    return anything;
+  },
+});
+
+const stubModel = {
+  specificationVersion: "v3",
+  provider: "gate-stub",
+  modelId: "gate-stub",
+  supportedUrls: {},
+  doGenerate: () => Promise.reject(new Error("gate stub model")),
+  doStream: () => Promise.reject(new Error("gate stub model")),
+};
+
+const vendo = createVendo({
+  principal: async () => null,
+  model: stubModel,
+  store: stubStore,
+});
+
+export default {
+  fetch(request) {
+    return vendo.handler(request);
+  },
+};

--- a/scripts/portability-gate.mjs
+++ b/scripts/portability-gate.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/** Portability gate — the enforcement half of the edge-portability contract
+ *  (docs/superpowers/plans/2026-07-21-edge-portability.md; field origin:
+ *  vendo-on-Cloudflare-Workers, Mohamed/digger.dev, 2026-07-21).
+ *
+ *  Leg A (bundle): the server entry must bundle for a Worker target with no
+ *    unresolved imports and none of the known Node-only legs in the graph
+ *    (CLI, dev-creds ladder, actions sync, telemetry disk config, store
+ *    engines). Bare node builtins stay external — that mirrors Wrangler's
+ *    nodejs_compat, the Workers baseline.
+ *  Leg B (boot): the fixture worker constructs createVendo at MODULE SCOPE
+ *    under real workerd and must serve GET /status 200 — catching
+ *    global-scope I/O and timers, unbound fetch, and anything a bundle
+ *    check can't see.
+ *  Leg C (source): the raw hazard patterns must not reappear in source.
+ *
+ *  Run: node scripts/portability-gate.mjs  (wired into `pnpm lint`). */
+import { readFile, readdir } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+const SERVER_ENTRY = join(root, "packages/vendo/dist/server.js");
+const { existsSync } = await import("node:fs");
+if (!existsSync(SERVER_ENTRY)) {
+  console.error("portability-gate: packages/vendo/dist/server.js missing — run `pnpm build` first");
+  process.exit(1);
+}
+const FIXTURE_ENTRY = join(root, "scripts/fixtures/portability-worker/worker.mjs");
+
+/** Wrangler's nodejs_compat provides these; anything else must resolve. */
+const NODE_BUILTIN_EXTERNALS = [
+  "node:*", "assert", "buffer", "child_process", "crypto", "dns", "events", "fs", "fs/promises",
+  "http", "https", "module", "net", "os", "path", "process", "stream", "stream/promises",
+  "string_decoder", "tls", "tty", "url", "util", "util/types", "worker_threads", "zlib",
+];
+
+/** Node-only legs that must NEVER be reachable from the worker-condition
+ *  server graph. Each entry names the containment seam that keeps it out. */
+const FORBIDDEN_INPUTS = [
+  { fragment: "packages/vendo/dist/cli/", seam: "cloud-key-fetch.ts (runtime code must not borrow CLI modules)" },
+  { fragment: "packages/vendo/dist/dev-creds/model.js", seam: "#dev-creds/model conditions" },
+  { fragment: "packages/actions/dist/sync/", seam: "@vendoai/actions/sync subpath split" },
+  { fragment: "packages/actions/dist/runtime/host-files.js", seam: "#actions/host-files conditions" },
+  { fragment: "packages/vendo-telemetry/dist/config.js", seam: "@vendoai/telemetry worker conditions" },
+  { fragment: "packages/vendo-telemetry/dist/base-props.js", seam: "@vendoai/telemetry worker conditions" },
+  { fragment: "packages/store/dist/db.js", seam: "#store/db conditions" },
+  { fragment: "packages/store/dist/crypto.js", seam: "#store/crypto conditions" },
+  { fragment: "node_modules/.pnpm/pg@", seam: "#store/db conditions" },
+  { fragment: "node_modules/.pnpm/typescript@", seam: "@vendoai/actions/sync subpath split" },
+  { fragment: "node_modules/.pnpm/e2b@", seam: "bundler-blind e2b specifier (apps/src/e2b)" },
+];
+
+/** Raw source patterns whose fix classes this gate owns. */
+const SOURCE_GUARDS = [
+  {
+    pattern: /\?\?\s*globalThis\.fetch\b/,
+    message: "detached `?? globalThis.fetch` default (Illegal invocation on Workers) — use defaultFetch from @vendoai/core",
+  },
+  {
+    pattern: /await import\((?:\/\*[^*]*\*\/\s*)*["']e2b["']\)/,
+    message: "literal import(\"e2b\") — esbuild hard-resolves it; route through the bundler-blind specifier in packages/apps/src/e2b",
+  },
+];
+
+let failures = 0;
+const fail = (message) => {
+  failures += 1;
+  console.error(`portability-gate: BROKEN — ${message}`);
+};
+const ok = (message) => console.log(`portability-gate: ok — ${message}`);
+
+// ---- Leg A: worker-condition bundle of the server entry ----
+const esbuild = require("esbuild");
+async function bundle(entry, outAs) {
+  return await esbuild.build({
+    entryPoints: [entry],
+    bundle: true,
+    format: "esm",
+    platform: "neutral",
+    conditions: ["workerd", "worker"],
+    mainFields: ["module", "main"],
+    external: NODE_BUILTIN_EXTERNALS,
+    // scripts/ is not a workspace package; the fixture's umbrella import
+    // resolves straight to the built entry.
+    alias: { "@vendoai/vendo/server": SERVER_ENTRY },
+    metafile: true,
+    write: outAs !== undefined,
+    outfile: outAs,
+    logLevel: "silent",
+  });
+}
+
+let serverMeta;
+try {
+  const result = await bundle(SERVER_ENTRY);
+  serverMeta = result.metafile;
+  ok("server entry bundles for a Worker target with zero unresolved imports");
+} catch (error) {
+  const messages = (error.errors ?? []).slice(0, 8).map((e) => `\n    ${e.text} (${e.location?.file ?? "?"})`).join("");
+  fail(`server entry does not bundle for a Worker target:${messages || `\n    ${error.message}`}`);
+}
+
+if (serverMeta !== undefined) {
+  const inputs = Object.keys(serverMeta.inputs);
+  for (const { fragment, seam } of FORBIDDEN_INPUTS) {
+    const hit = inputs.find((input) => input.includes(fragment));
+    if (hit === undefined) continue;
+    fail(`Node-only leg reached the worker server graph: ${hit}\n    containment seam: ${seam}`);
+  }
+  if (!inputs.some((input) => FORBIDDEN_INPUTS.some(({ fragment }) => input.includes(fragment)))) {
+    ok(`no Node-only leg in the worker server graph (${inputs.length} modules checked)`);
+  }
+}
+
+// ---- Leg C: raw hazard patterns in source ----
+async function* sourceFiles(dir) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === "dist" || entry.name.startsWith(".")) continue;
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) yield* sourceFiles(path);
+    else if (/\.(ts|tsx|mts)$/.test(entry.name) && !/\.test\./.test(entry.name)) yield path;
+  }
+}
+
+let guardHits = 0;
+for await (const file of sourceFiles(join(root, "packages"))) {
+  const source = await readFile(file, "utf8");
+  for (const { pattern, message } of SOURCE_GUARDS) {
+    if (!pattern.test(source)) continue;
+    guardHits += 1;
+    fail(`${file.replace(`${root}/`, "")}: ${message}`);
+  }
+}
+if (guardHits === 0) ok("no raw hazard patterns in package sources");
+
+// ---- Leg B: module-scope boot + /status under real workerd ----
+try {
+  const fixture = await bundle(FIXTURE_ENTRY, join(root, "scripts/fixtures/portability-worker/.bundle.mjs"));
+  void fixture;
+  const bundled = await readFile(join(root, "scripts/fixtures/portability-worker/.bundle.mjs"), "utf8");
+  const { Miniflare } = await import("miniflare");
+  // Explicit modules array: miniflare's automatic locator statically scans
+  // for import() and rejects non-literal specifiers (our bundler-blind e2b
+  // import); the explicit form defers that to workerd's runtime, where the
+  // optional load correctly fails only when invoked.
+  const mf = new Miniflare({
+    modules: [{ type: "ESModule", path: "worker.mjs", contents: bundled }],
+    compatibilityDate: "2026-07-01",
+    compatibilityFlags: ["nodejs_compat"],
+  });
+  try {
+    const response = await mf.dispatchFetch("https://portability.gate/api/vendo/status");
+    const body = await response.text();
+    if (response.status === 200) ok("fixture worker constructed createVendo at module scope and served /status 200 under workerd");
+    else fail(`fixture worker /status answered ${response.status}: ${body.slice(0, 300)}`);
+  } finally {
+    await mf.dispose();
+  }
+} catch (error) {
+  fail(`fixture worker did not boot under workerd: ${error instanceof Error ? error.message : String(error)}`);
+}
+
+if (failures > 0) {
+  console.error(`portability-gate: ${failures} failure(s)`);
+  process.exit(1);
+}
+console.log("portability-gate: all legs green");


### PR DESCRIPTION
## Origin

Mohamed Habib (digger.dev) deployed Vendo on Cloudflare Workers (codex, initial prompt) and reported nine issues (email 2026-07-21; branch `diggerhq/opencomputer#feat/vendo-cloudflare-edge`). Root-cause analysis reduced six of them to one broken assumption: **the server runtime silently assumed Node**. This PR removes the assumption and adds a CI gate so the class cannot come back. Plan: `docs/superpowers/plans/2026-07-21-edge-portability.md`.

## Field symptom → fix

| Mohamed's report | Root cause | Fix |
|---|---|---|
| e2b broke Wrangler bundling | literal `import("e2b")`; ignore comments are webpack dialect, esbuild hard-resolves | bundler-blind specifier; missing SDK errors at use with guidance |
| `createVendo()` illegal at module scope | eager `ensureSchema()` I/O + sweep `setInterval` (+ engine instance id, fallback session id randomness) | construction is pure; once-latch on first handler/emit touch |
| "Illegal invocation" on fetch | `options.fetch ?? globalThis.fetch` stored detached (8 sites) | `defaultFetch` late-binding wrapper in @vendoai/core |
| model needed hand-wiring despite VENDO_API_KEY | dev ladder resolves providers via `createRequire`/disk sessions | `#dev-creds/model` worker condition → honest guidance; explicit wiring is the edge contract (init template lands in the follow-up PR) |
| "crypto.uuid undesirable" | `@vendoai/telemetry` drags `node:crypto` + fs config into every bundle | worker-condition no-op telemetry entry |
| (latent) pg/PGlite, TS compiler, CLI fs in every Worker bundle | store engines, actions sync re-export, capability-misses borrowing the CLI's cloudFetch | `#store/db`/`#store/crypto` conditions; `@vendoai/actions/sync` subpath split; portable `cloud-key-fetch.ts` |

## The gate (`scripts/portability-gate.mjs`, wired into `pnpm lint`)

- **Bundle leg**: server entry must bundle for a Worker target (worker/workerd conditions, node builtins external per `nodejs_compat`) with zero unresolved imports and zero Node-only legs in the module graph (496 modules checked).
- **Boot leg**: a fixture worker constructs `createVendo` **at module scope** under real workerd and serves `GET /status` 200. Its first run already caught two offenders no code review had (automations engine id, wire fallback session id) — fixed here.
- **Source leg**: the raw hazard patterns (`?? globalThis.fetch`, literal `import("e2b")`) fail lint if they reappear.

## Mechanism

Package export **conditions** (`workerd`/`worker`/`edge-light`/`browser` → guidance-throwing or no-op edge modules; `default` → today's Node behavior). One mechanism every bundler and Node itself respects — no bundler-specific magic comments, which is exactly what failed in the field. Bun/Deno/Vercel Edge/Netlify ride the same target.

## Verification

- `pnpm build` / `pnpm test` (46 tasks, vendo 1001 passed) / `pnpm typecheck` / `pnpm lint` (incl. the gate) — all exit 0.
- New TDD suites: `core/fetch.test.ts`, `telemetry/edge.test.ts`, `dev-creds/model-edge.test.ts`, `actions/runtime/host-files.test.ts`, `vendo/cloud-key-fetch.test.ts`, `vendo/server-lazy.test.ts`.
- Node behavior unchanged by contract: default conditions resolve the exact modules that shipped before.

## Follow-ups (planned, separate PRs)

Universal init wiring + Workers docs; behavior-based doctor (after #510); extraction audience classification; structured stream errors (the apps-create mid-stream death — the workerd fixture is the repro rig).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `@vendoai/vendo/server` run on Web-standard runtimes (Cloudflare Workers first) and adds a CI portability gate so Node-only assumptions can’t slip back. Removes eager I/O and timers so module-scope wiring works, and fixes strict Web API issues (fetch, optional SDK).

- **New Features**
  - CI portability gate (`scripts/portability-gate.mjs`, in `pnpm lint`): bundles the server for a Worker target, boots a fixture under `workerd` at module scope, and guards source patterns.
  - Edge export conditions keep Node-only legs out: telemetry no‑op; `#store/db` and `#store/crypto` guidance stubs; `#actions/host-files` edge leg; `#dev-creds/model` guidance. Build-/dev-time extraction moved to `@vendoai/actions/sync`.
  - Portable helpers: `cloud-key-fetch.ts` for key‑auth console calls; `@vendoai/core` `defaultFetch` used across clients.

- **Bug Fixes**
  - Replaced detached `globalThis.fetch` defaults with `defaultFetch` to avoid “Illegal invocation” on strict Web runtimes.
  - Optional `e2b` SDK import is bundler‑blind; missing SDK now errors at use with install guidance.
  - `createVendo()` is construction‑pure; schema readiness and the sweep start on first handler/emit or BYO tool execute, with engine instance id and fallback `sessionId` minted lazily.

<sup>Written for commit 2e47f7f7ac8e5f74df272f788369e74bdd3679a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

