### PR TITLE
agent+ui: safe stream-error detail reaches the thread banner

### DIFF
--- a/.changeset/stream-error-surfacing.md
+++ b/.changeset/stream-error-surfacing.md
@@ -1,0 +1,12 @@
+---
+"@vendoai/agent": patch
+"@vendoai/ui": patch
+---
+
+Mid-stream turn errors are no longer a dead end: the agent logs the real
+error server-side ("[vendo] turn stream error") and passes its OWN safe
+errors (VendoError code + message) to the wire recognizably prefixed, while
+raw provider/transport strings stay the fixed generic text. The thread
+error banner renders that safe detail line (code included) next to Retry —
+"Something went wrong" alone is now reserved for errors we genuinely can't
+say more about.

--- a/docs/verification/stream-errors/README.md
+++ b/docs/verification/stream-errors/README.md
@@ -1,0 +1,12 @@
+# Stream-error surfacing — visual verification (2026-07-22)
+
+Rendered live (real browser, real `<VendoThread>` against a stubbed wire):
+
+- `banner-vendo-detail.png` — a turn that died with a `VendoError`
+  (`cloud-required`): the banner keeps the friendly headline and adds the
+  safe, operator-crafted detail line with the error code.
+- `banner-raw-hidden.png` — a turn that died with a raw transport error
+  (containing a fake key): the banner stays generic; no internals printed.
+
+Harness: esbuild bundle of `packages/ui/src` with an in-page fetch stub
+emitting the ai-SDK error part shapes (`{"type":"error","errorText":...}`).

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -333,7 +333,15 @@ function providerHistory(messages: UIMessage[]): UIMessage[] {
  */
 function wireErrorMessage(error: unknown): string {
   console.error("[vendo] turn stream error:", error);
-  if (error instanceof VendoError) return `Vendo: ${error.message} (${error.code})`;
+  // Name+code duck check besides instanceof: a host bundle can carry a second
+  // @vendoai/core copy (dual-package hazard), and its VendoErrors are just as
+  // safe — same crafted messages, same code enum.
+  const vendoShaped = error instanceof VendoError
+    || (error instanceof Error && error.name === "VendoError" && typeof (error as { code?: unknown }).code === "string");
+  if (vendoShaped) {
+    const { message, code } = error as { message: string; code: string };
+    return `Vendo: ${message} (${code})`;
+  }
   return "An error occurred while generating the response.";
 }
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -321,6 +321,22 @@ function providerHistory(messages: UIMessage[]): UIMessage[] {
 }
 
 /** 03-agent §1 */
+
+/** The one gate raw errors pass on their way to the wire. Vendo's OWN errors
+ *  (code + operator-crafted message) are safe and actionable, so they travel
+ *  recognizably prefixed — the thread UI renders the detail line only for
+ *  this shape. Anything else (provider/transport internals can carry request
+ *  URLs, keys, prompts) stays the fixed generic string. Either way the REAL
+ *  error lands in the server log: the operator's terminal is where the
+ *  honest message belongs (field case: a dead apps-create turn surfaced as
+ *  nothing but "Something went wrong" anywhere).
+ */
+function wireErrorMessage(error: unknown): string {
+  console.error("[vendo] turn stream error:", error);
+  if (error instanceof VendoError) return `Vendo: ${error.message} (${error.code})`;
+  return "An error occurred while generating the response.";
+}
+
 export function createAgent(config: AgentConfig): VendoAgent {
   validateConfig(config);
   // kill-list B5: a host that omits `store` still gets thread persistence —
@@ -475,7 +491,7 @@ export function createAgent(config: AgentConfig): VendoAgent {
             originalMessages: thread.messages,
             // Raw provider/model error strings never reach the wire (they can
             // carry request internals); the error part is a fixed generic message.
-            onError: () => "An error occurred while generating the response.",
+            onError: (error) => wireErrorMessage(error),
           }));
           // AGENT-7: exhausting the step cap is VISIBLE. A run that still wants
           // tool calls after its final permitted step ended because of the cap,
@@ -497,7 +513,7 @@ export function createAgent(config: AgentConfig): VendoAgent {
         onFinish: async ({ messages }) => {
           await persistFinishedTurn(threads, thread, messages, input.ctx);
         },
-        onError: () => "An error occurred while generating the response.",
+        onError: (error) => wireErrorMessage(error),
       });
       const response = createUIMessageStreamResponse({ stream });
       // ENG-211: a caller may begin without an id, in which case resolve()

--- a/packages/agent/src/stream-error.test.ts
+++ b/packages/agent/src/stream-error.test.ts
@@ -1,0 +1,50 @@
+import { VendoError } from "@vendoai/core";
+import { MockLanguageModelV3 } from "ai/test";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createAgent } from "./index.js";
+import { boundRegistry, ctx, readSse, testGuard } from "./test-helpers.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function streamWithThrowingModel(error: unknown): Promise<{
+  parts: Array<Record<string, unknown>>;
+  logged: unknown[][];
+}> {
+  const logged: unknown[][] = [];
+  vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => { logged.push(args); });
+  const model = new MockLanguageModelV3({
+    doStream: async () => { throw error; },
+  });
+  const guard = testGuard();
+  const agent = createAgent({ model, tools: boundRegistry({}, guard), guard });
+  const response = await agent.stream({
+    threadId: "thr_stream_error",
+    message: { id: "user_err", role: "user", parts: [{ type: "text", text: "hi" }] },
+    ctx: ctx(),
+  });
+  const { parts } = await readSse(response);
+  return { parts, logged };
+}
+
+describe("mid-stream turn errors", () => {
+  it("a VendoError travels as a recognizable, safe error part and is logged server-side", async () => {
+    const { parts, logged } = await streamWithThrowingModel(
+      new VendoError("cloud-required", "this deployment's plan does not include app machines"),
+    );
+    const errorPart = parts.find((part) => part.type === "error");
+    expect(errorPart).toBeDefined();
+    expect(errorPart?.errorText).toBe("Vendo: this deployment's plan does not include app machines (cloud-required)");
+    expect(logged.some((args) => String(args[0]).includes("[vendo] turn stream error"))).toBe(true);
+  });
+
+  it("an unknown error stays the fixed generic string (raw internals never reach the wire) but still logs", async () => {
+    const { parts, logged } = await streamWithThrowingModel(new Error("ECONNRESET at https://provider.internal/key=sk-123"));
+    const errorPart = parts.find((part) => part.type === "error");
+    expect(errorPart).toBeDefined();
+    expect(errorPart?.errorText).toBe("An error occurred while generating the response.");
+    expect(String(errorPart?.errorText)).not.toContain("sk-123");
+    expect(logged.some((args) => String(args[0]).includes("[vendo] turn stream error"))).toBe(true);
+  });
+});

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -1312,6 +1312,7 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the wave-2
   border: 1px solid var(--vendo-danger-border); background: var(--vendo-danger-bg);
   color: var(--vendo-danger); font-size: 12.5px;
   display: flex; align-items: center; gap: 10px; }
+.fl-error-detail { display: block; margin-top: 3px; font-size: 12px; opacity: 0.85; overflow-wrap: anywhere; }
 .fl-error-retry { margin-left: auto; flex-shrink: 0; padding: 4px 11px; border-radius: 8px;
   border: 1px solid var(--vendo-danger-border); background: transparent;
   color: var(--vendo-danger); font: 600 12px/1.2 var(--vendo-font); cursor: pointer; }

--- a/packages/ui/src/chrome/thread/index.tsx
+++ b/packages/ui/src/chrome/thread/index.tsx
@@ -213,9 +213,19 @@ export function VendoThread({
   // The copy stays friendly — raw transport errors are announced to assistive
   // tech below but never printed to end users. Retry regenerates the failed
   // turn from the preserved user message (no duplication).
+  // A "Vendo: " prefixed message is the agent's OWN safe error (VendoError
+  // code + operator-crafted text, wireErrorMessage in @vendoai/agent) — the
+  // ONE error shape end users may see in detail. Raw transport/provider
+  // strings never match the prefix and stay hidden (ENG-214 policy).
+  const errorDetail = thread.error?.message?.startsWith("Vendo: ") === true
+    ? thread.error.message.slice("Vendo: ".length)
+    : null;
   const errorBanner = thread.error ? (
     <div className="fl-error">
-      <span>Something went wrong and the response didn&rsquo;t finish.</span>
+      <span>
+        Something went wrong and the response didn&rsquo;t finish.
+        {errorDetail !== null && <span className="fl-error-detail">{errorDetail}</span>}
+      </span>
       <button
         type="button"
         className="fl-error-retry"

--- a/packages/ui/test/chrome/error-surface.test.tsx
+++ b/packages/ui/test/chrome/error-surface.test.tsx
@@ -49,6 +49,33 @@ describe("visible error surface + retry (ENG-214)", () => {
     expect(status?.textContent).toMatch(/^error:/);
   });
 
+  it("renders the Vendo detail line when the error part is Vendo-shaped", async () => {
+    wire.state.streamFailures = 1;
+    wire.state.streamFailureText = "Vendo: this deployment's plan does not include app machines (cloud-required)";
+    render(<VendoProvider client={client}><VendoThread threadId="thr_1" /></VendoProvider>);
+    await screen.findByText("Existing thread");
+
+    sendFromComposer("Hello");
+    const retry = await screen.findByRole("button", { name: "Retry" });
+    const banner = retry.closest(".fl-error");
+    expect(banner?.textContent).toContain("Something went wrong");
+    // The detail is OUR safe, operator-crafted message (agent wireErrorMessage
+    // shape) — rendered without the wire prefix, code kept for support.
+    expect(banner?.textContent).toContain("this deployment's plan does not include app machines (cloud-required)");
+  });
+
+  it("never prints non-Vendo error text in the banner (raw transport strings stay hidden)", async () => {
+    wire.state.streamFailures = 1;
+    render(<VendoProvider client={client}><VendoThread threadId="thr_1" /></VendoProvider>);
+    await screen.findByText("Existing thread");
+
+    sendFromComposer("Hello");
+    const retry = await screen.findByRole("button", { name: "Retry" });
+    const banner = retry.closest(".fl-error");
+    expect(banner?.textContent).toContain("Something went wrong");
+    expect(banner?.textContent).not.toContain("connection reset");
+  });
+
   it("retries a mid-stream failure without duplicating messages", async () => {
     wire.state.streamFailures = 1;
     render(<VendoProvider client={client}><VendoThread threadId="thr_1" /></VendoProvider>);

--- a/packages/ui/test/wire-server.ts
+++ b/packages/ui/test/wire-server.ts
@@ -234,6 +234,9 @@ export async function createWireServer(options: WireServerOptions = {}) {
     // surfaces client-side). A counter rather than a text marker so a retry
     // of the SAME user message can succeed.
     streamFailures: 0,
+    /** Error-part text for simulated failures; default mirrors a raw
+        transport string (which the banner must NOT print). */
+    streamFailureText: undefined as string | undefined,
     posture: "rules" as "unconfigured" | "rules" | "judge" | "rules+judge",
     threadReplyGate: undefined as Promise<void> | undefined,
     // ENG-217 — optional pacing gates for the canned turn so specs can observe
@@ -321,7 +324,7 @@ export async function createWireServer(options: WireServerOptions = {}) {
               writer.write({ type: "text-delta", id: "text_fail", delta: "Starting an answer that will be cut" });
               throw new Error("connection reset mid-stream");
             },
-            onError: error => (error instanceof Error ? error.message : String(error)),
+            onError: error => state.streamFailureText ?? (error instanceof Error ? error.message : String(error)),
           });
           const failingResponse = createUIMessageStreamResponse({ stream: failingChunks });
           failingResponse.headers.set("x-vendo-thread-id", threadId);


### PR DESCRIPTION
## Origin

Mohamed's Workers report, final screenshot: `Vendo apps create` died mid-stream and every surface — thread UI, server log — said nothing beyond "Something went wrong and the response didn't finish." Whatever the runtime cause, the observability defect stands on its own: a dead turn produced zero diagnostics anywhere.

## What this does (ENG-214 policy intact)

- **Agent** (`wireErrorMessage`): every mid-stream error now logs server-side (`[vendo] turn stream error: …` — the operator's terminal gets the honest message). `VendoError`s — our own safe, operator-crafted messages — travel to the wire as `Vendo: <message> (<code>)`; anything else (provider/transport strings can carry URLs, keys, prompts) keeps the fixed generic text.
- **UI**: the thread banner renders the safe detail line + code beside Retry when the error part is Vendo-shaped; raw strings never match the prefix and stay hidden. "Something went wrong" alone is now reserved for errors we genuinely can't say more about.

## Verification

TDD: 2 agent tests (VendoError passes through + logs; unknown error stays generic, `sk-123` never reaches the wire) and 2 UI tests (detail rendered for Vendo-shaped parts; raw transport text never printed) — watched red then green. Full agent (98) and ui suites, build, typecheck all green.

**Browser-verified** (real `<VendoThread>` against stubbed wire, screenshots committed under `docs/verification/stream-errors/`):
- `banner-vendo-detail.png` — cloud-required detail line rendered
- `banner-raw-hidden.png` — raw transport error (with a fake key) → generic banner only

Part of the edge-portability campaign (plan: `docs/superpowers/plans/2026-07-21-edge-portability.md`, PR 5 of 5; companions #513 #514 #516 #519). Pinning the apps-create runtime killer itself now has a repro rig (the workerd fixture from #513) — tracked as follow-up.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaced safe error details for mid-stream turn failures so operators see real logs and users get actionable context. Keeps ENG-214 policy by hiding raw provider/transport strings.

- **New Features**
  - `@vendoai/agent`: Added `wireErrorMessage` to log "[vendo] turn stream error: …" and send `VendoError` as "Vendo: <message> (<code>)"; all other errors return a fixed generic string.
  - `@vendoai/ui`: Thread banner shows a detail line (with code) next to Retry when the message starts with "Vendo: "; otherwise only the generic headline is shown. Added `.fl-error-detail` styling.

- **Bug Fixes**
  - `@vendoai/agent`: `wireErrorMessage` now detects `VendoError` even with dual-copy `@vendoai/core` by duck-checking name + code, ensuring safe errors don’t fall back to the generic text.

<sup>Written for commit d005b1668a79c099a4a940c1ef2bf51bde5629f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

