### PR TITLE
telemetry: VENDO_INTERNAL=1 tags events internal:true instead of dropping them

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -85,6 +85,10 @@ Any one of these disables product telemetry:
 
 Set `"optedOut": false` in `~/.vendo/telemetry.json` to clear the local opt-out flag. Scarf also honors `DO_NOT_TRACK`.
 
+## Internal Runs (VENDO_INTERNAL)
+
+`VENDO_INTERNAL=1` (or `true`) tags every event with `internal: true` instead of disabling telemetry. It exists for Vendo's own harnesses — certification campaigns, install evals, sandbox benches — that intentionally exercise the real telemetry path end-to-end: the events still flow (so the pipeline stays verifiable) but analytics excludes them from product metrics by filtering on the `internal` property. The marker is producer-set like the cloud markers, so event callers cannot spoof or clear it. It is not a consent mechanism and does not weaken any opt-out above: `CI`, `DO_NOT_TRACK`, and `VENDO_TELEMETRY_DISABLED` still send nothing regardless of `VENDO_INTERNAL`.
+
 ## Where Data Goes
 
 Product events are sent to PostHog US Cloud using a write-only project key. Network calls are fire-and-forget, use a short timeout, and failures are swallowed so telemetry cannot break builds or dev servers.

--- a/corpus/harness/src/install-eval/agent.test.ts
+++ b/corpus/harness/src/install-eval/agent.test.ts
@@ -194,4 +194,9 @@ describe("agentEnv", () => {
     expect(env["PATH"]).toBe("/bin");
     expect(env["ANTHROPIC_API_KEY"]).toBe("sk-ant-y");
   });
+
+  it("sets VENDO_INTERNAL=1 so the agent's real init telemetry is tagged, not counted as user traffic", () => {
+    const env = agentEnv({ PATH: "/bin" });
+    expect(env["VENDO_INTERNAL"]).toBe("1");
+  });
 });

--- a/corpus/harness/src/install-eval/agent.ts
+++ b/corpus/harness/src/install-eval/agent.ts
@@ -82,6 +82,13 @@ export function buildClaudeArgs(options: ClaudeArgsOptions): string[] {
 export function agentEnv(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const env = { ...base };
   delete env["VENDO_API_KEY"];
+  // The agent exercises the REAL end-user flow — `npx vendo init` runs with
+  // telemetry live on purpose, so the eval also certifies the telemetry path.
+  // VENDO_INTERNAL tags those events `internal: true` (the analytics project
+  // filters on it) instead of dropping them. Deliberately not
+  // VENDO_TELEMETRY_DISABLED: dropping would blind the cert to telemetry
+  // regressions while these runs polluted launch metrics untagged.
+  env["VENDO_INTERNAL"] = "1";
   return env;
 }
 

--- a/packages/vendo-telemetry/src/client.test.ts
+++ b/packages/vendo-telemetry/src/client.test.ts
@@ -255,3 +255,53 @@ describe("cloud lane (VENDO_API_KEY)", () => {
     expect("servedApps" in props).toBe(false);
   });
 });
+
+describe("internal lane (VENDO_INTERNAL)", () => {
+  it.each([["1"], ["true"]])("marks every event with internal: true when VENDO_INTERNAL=%s", async (value) => {
+    const deps = makeDeps({ env: { VENDO_INTERNAL: value } });
+    const t = createTelemetry(deps);
+    await t.track("agent_run", {});
+    expect(sentProps(deps).internal).toBe(true);
+  });
+
+  it.each([
+    ["absent", undefined],
+    ["empty", ""],
+    ["zero", "0"],
+    ["false", "false"],
+    ["arbitrary text", "yes"],
+  ])("omits the internal key when VENDO_INTERNAL is %s", async (_label, value) => {
+    const deps = makeDeps({ env: { VENDO_INTERNAL: value } });
+    const t = createTelemetry(deps);
+    await t.track("agent_run", {});
+    expect("internal" in sentProps(deps)).toBe(false);
+  });
+
+  it("callers cannot spoof internal", async () => {
+    // Flag unset: the caller-passed marker is stripped outright.
+    const external = makeDeps();
+    await createTelemetry(external).track("agent_run", { internal: true } as never);
+    expect("internal" in sentProps(external)).toBe(false);
+
+    // Flag set: the producer-set value wins over a caller-passed one.
+    const internal = makeDeps({ env: { VENDO_INTERNAL: "1" } });
+    await createTelemetry(internal).track("agent_run", { internal: false } as never);
+    expect(sentProps(internal).internal).toBe(true);
+  });
+
+  it("does not weaken consent: opt-outs still send nothing with the flag set", async () => {
+    const deps = makeDeps({ env: { VENDO_INTERNAL: "1", DO_NOT_TRACK: "1" } });
+    const t = createTelemetry(deps);
+    await t.track("agent_run", {});
+    expect(deps.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("composes with the cloud lane markers", async () => {
+    const deps = makeDeps({ env: { VENDO_INTERNAL: "1", VENDO_API_KEY: CLOUD_KEY } });
+    const t = createTelemetry(deps);
+    await t.track("agent_run", {});
+    const props = sentProps(deps);
+    expect(props.internal).toBe(true);
+    expect(props.cloud).toBe(true);
+  });
+});

--- a/packages/vendo-telemetry/src/client.ts
+++ b/packages/vendo-telemetry/src/client.ts
@@ -91,6 +91,17 @@ export function createTelemetry(deps: TelemetryDeps): Telemetry {
   const cloudMarkers = cloudActive
     ? { cloud: true, cloudKeyHash: createHash("sha256").update(cloudKey as string).digest("hex") }
     : {};
+  // Internal lane: VENDO_INTERNAL=1 tags events instead of dropping them, so
+  // internal harnesses (cert campaigns, eval sandboxes) that intentionally
+  // exercise the real telemetry path stay verifiable end-to-end while
+  // analytics filters them out on `internal = true`. Same truthy values as
+  // consent.ts. Deliberately NOT a consent input — CI / DO_NOT_TRACK /
+  // VENDO_TELEMETRY_DISABLED semantics are unchanged, and this marker is
+  // producer-set like the cloud markers so callers can never spoof it.
+  const internalMarker =
+    deps.env.VENDO_INTERNAL === "1" || deps.env.VENDO_INTERNAL === "true"
+      ? { internal: true }
+      : {};
   // Filesystem-backed props are computed once per client, never per event.
   // Guarded so the never-throw contract holds at the API surface even if
   // cwd resolution or the filesystem probes fail in an unexpected way.
@@ -111,13 +122,15 @@ export function createTelemetry(deps: TelemetryDeps): Telemetry {
         });
         if (!consent.allowed) return;
 
-        // Producer-set cloud markers spread last so a caller-passed `cloud`
-        // or `cloudKeyHash` (already filtered out above) can never win.
+        // Producer-set markers spread last so a caller-passed `cloud`,
+        // `cloudKeyHash`, or `internal` (already filtered out above) can
+        // never win.
         const properties = {
           ...baseProps(deps.version),
           ...project,
           ...filterToAllowlist(event, props, cloudActive),
           ...cloudMarkers,
+          ...internalMarker,
         };
         const body = JSON.stringify({
           api_key: deps.posthogKey,


### PR DESCRIPTION
## Why

Launch metrics in PostHog were dominated by our own traffic. Evidence from the telemetry-hygiene sweep (project 397743, last 7d):

- **14,357 events** (12,548 next + 2,160 express `init_started`/`init_completed` pairs + 525 `doctor_run`) from one dev machine's anonymousId, bursting up to **708 events/hour** on 07-15..07-18 — install-eval style agent runs at v0.3.0.
- **~6,400 events** from a sandbox egress IP across **19+ ephemeral anonymousIds** (fresh HOME per container, ~100 inits in ~90s each). Static distinct_id / IP test-account filters cannot keep up with ids that never repeat.
- Unfiltered `init_started` last 7d: **10,855**. After test-account filters: **39**. That is a 99.6% pollution rate.

The polluting paths (cert campaigns, install-eval agent runs) exercise the REAL end-user flow on purpose — force-disabling telemetry there would blind certification to telemetry regressions. So: tag, don't drop.

## What

- **`@vendoai/telemetry` client**: a truthy `VENDO_INTERNAL` (`1`/`true`, same truthy set as consent.ts) attaches `internal: true` to every event's properties. Producer-set and spread last like the cloud markers, so event callers can never spoof or clear it. **Consent semantics untouched** — `CI`, `DO_NOT_TRACK`, `VENDO_TELEMETRY_DISABLED`, config opt-out, and the production-runtime gate still send nothing regardless of this flag.
- **install-eval `agentEnv`** sets `VENDO_INTERNAL=1`: the headless agent's real `npx vendo init` telemetry stays live end-to-end but lands tagged. Spawn paths that already force-disable telemetry (`init-step.ts`, `doctor-live.ts`, `install-eval/doctor.ts`) are unchanged.
- **TELEMETRY.md**: documents the internal lane and that it is not a consent mechanism.

The PostHog project's "filter internal and test users" setting now also excludes `internal = true` (applied separately; verified with a synthetic tagged event).

## Tests

- `packages/vendo-telemetry`: 119/119 (new: marker on `1`/`true`, omitted on absent/empty/`0`/`false`/arbitrary, spoof-proofing both directions, opt-out still wins, composes with cloud lane).
- `corpus/harness`: 279/279 (new: `agentEnv` sets the flag).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `VENDO_INTERNAL` to tag telemetry from internal runs instead of dropping it. This keeps eval and certification events flowing while analytics filters them via `internal: true`.

- **New Features**
  - `packages/vendo-telemetry`: when `VENDO_INTERNAL` is `"1"` or `"true"`, every event includes `internal: true` (producer-set, spread last; callers cannot spoof). Consent gates (`CI`, `DO_NOT_TRACK`, `VENDO_TELEMETRY_DISABLED`) still block all sends. Composes with cloud markers.
  - `corpus/harness` install‑eval agent: sets `VENDO_INTERNAL=1` so real `npx vendo init` telemetry is tagged, not counted as user traffic.
  - Docs (`TELEMETRY.md`): added guidance for the flag and clarified it is not a consent mechanism.

<sup>Written for commit 7ba588ae3205857bb7e554f6b98ff96a933e7aed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

