### PR TITLE
feat(vendo): per-user persona layer for the agent

### DIFF
--- a/.changeset/persona-layer.md
+++ b/.changeset/persona-layer.md
@@ -1,0 +1,12 @@
+---
+"@vendoai/vendo": minor
+---
+
+Add a per-user persona layer to the agent.
+
+- A per-subject persona record (how the user works, the tools they reach for, the formats they prefer, durable facts they state) stored as opaque data in a vendo_records collection keyed by subject, so it rides the host's own database with no schema change.
+- Two guard-bound, subject-scoped agent tools, vendo_persona_load and vendo_persona_remember, folded into the same registry the app tools use, so persona reads and writes are policed and audited like every other tool.
+- distillPersona, which builds or refreshes a subject's persona from their own threads and audit trail, deterministically by default.
+- An offline replay harness that measures whether a persona-conditioned turn reproduces a user's held-out decisions.
+
+Generation stays user-blind: the persona reaches the agent prompt only, never a generated document, and no subject boundary is crossed.

--- a/packages/vendo/src/persona-eval.test.ts
+++ b/packages/vendo/src/persona-eval.test.ts
@@ -1,0 +1,90 @@
+import { memoryStoreAdapter } from "@vendoai/core/conformance";
+import { describe, expect, it } from "vitest";
+import { distillPersona } from "./persona/index.js";
+import { runPersonaReplay, seedSubject, type RunTurn, type SubjectFixture } from "./persona/eval.js";
+import { GROUNDED_FIXTURES } from "./persona/eval-fixtures.js";
+
+const repeat = (value: string, times: number): string[] => Array.from({ length: times }, () => value);
+
+// Synthetic labeled subjects: each consistently reaches for one tool for a kind
+// of ask, and the deciding tool is held out of the history. This is the shape of
+// the real eval, at a scale that runs deterministically in CI.
+const FIXTURES: SubjectFixture[] = [
+  {
+    subject: "eval_invoices",
+    historyTools: [...repeat("host_invoices_list", 6), ...repeat("host_invoices_send", 2)],
+    historyAsks: ["show unpaid invoices as a table", "the invoice table again", "table of overdue invoices"],
+    holdout: [{ prompt: "what invoices are overdue", expectedTool: "host_invoices_list" }],
+  },
+  {
+    subject: "eval_orders",
+    historyTools: repeat("host_orders_list", 6),
+    historyAsks: ["list my orders", "orders list please", "a list of recent orders"],
+    holdout: [{ prompt: "which orders shipped", expectedTool: "host_orders_list" }],
+  },
+];
+
+const AVAILABLE_TOOLS = ["host_invoices_list", "host_invoices_send", "host_orders_list", "host_customers_get"];
+// Deliberately unrelated to the holdouts, so the stock agent misses.
+const STOCK_FALLBACK = "host_customers_get";
+
+const overlap = (tool: string, promptWords: Set<string>): number =>
+  tool.split("_").filter((token) => promptWords.has(token)).length;
+
+// Deterministic stand-in for a real agent turn. Without a persona it falls back
+// blindly; with one, it prefers a persona-named tool that overlaps the prompt.
+// This validates the harness and shows a persona can flip a decision; the
+// model-in-the-loop number comes from swapping this for a real turn (a run that
+// needs a model key, produced outside CI).
+const oracle: RunTurn = async ({ prompt, persona }) => {
+  if (persona === null) return STOCK_FALLBACK;
+  const workflow = persona.facts.find((entry) => entry.kind === "workflow")?.text ?? "";
+  const named = AVAILABLE_TOOLS.filter((tool) => workflow.includes(tool));
+  const promptWords = new Set(prompt.toLowerCase().split(/\W+/).filter(Boolean));
+  const ranked = [...named].sort((a, b) => overlap(b, promptWords) - overlap(a, promptWords));
+  return ranked[0] ?? STOCK_FALLBACK;
+};
+
+describe("persona replay eval", () => {
+  it("distills the deciding signal into each subject's persona", async () => {
+    const store = memoryStoreAdapter();
+    for (const fixture of FIXTURES) {
+      await seedSubject(store, fixture);
+      const persona = await distillPersona(store, fixture.subject);
+      const workflow = persona.facts.find((entry) => entry.kind === "workflow")?.text ?? "";
+      for (const decision of fixture.holdout) {
+        // The information needed to reproduce the held-out choice is present in
+        // the persona, which is the honest, model-free claim the harness rests on.
+        expect(workflow).toContain(decision.expectedTool);
+      }
+    }
+  });
+
+  it("a persona-conditioned turn reproduces held-out decisions the stock turn misses", async () => {
+    const store = memoryStoreAdapter();
+    for (const fixture of FIXTURES) await seedSubject(store, fixture);
+
+    const report = await runPersonaReplay(store, FIXTURES, oracle);
+
+    expect(report.cases).toBe(2);
+    expect(report.accuracyWith).toBeGreaterThan(report.accuracyWithout);
+    expect(report.delta).toBeGreaterThan(0);
+  });
+
+  // The grounded fixtures are what the model-in-the-loop replay runs over. Their
+  // held-out prompts are deliberately not lexically mappable to the deciding
+  // tool, so the deterministic oracle cannot score them (only a real model can).
+  // What holds model-free, and what CI asserts, is that the distilled persona
+  // carries the deciding tool for every subject: the signal a real agent needs.
+  it("distills the deciding tool into every grounded subject's persona", async () => {
+    const store = memoryStoreAdapter();
+    for (const fixture of GROUNDED_FIXTURES) {
+      await seedSubject(store, fixture);
+      const persona = await distillPersona(store, fixture.subject);
+      const workflow = persona.facts.find((entry) => entry.kind === "workflow")?.text ?? "";
+      for (const decision of fixture.holdout) {
+        expect(workflow).toContain(decision.expectedTool);
+      }
+    }
+  });
+});

--- a/packages/vendo/src/persona.test.ts
+++ b/packages/vendo/src/persona.test.ts
@@ -1,0 +1,192 @@
+import { memoryStoreAdapter } from "@vendoai/core/conformance";
+import type { AuditEvent, Json, Persona, RunContext, ToolCall, ToolOutcome } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import {
+  MAX_PERSONA_FACTS,
+  PERSONA_COLLECTION,
+  createPersonaTools,
+  distillPersona,
+  emptyPersona,
+  loadPersona,
+  mergeFacts,
+  rememberFact,
+  savePersona,
+  type PersonaFact,
+} from "./persona/index.js";
+
+const ctxFor = (subject: string): RunContext => ({
+  principal: { kind: "user", subject },
+  venue: "chat",
+  presence: "present",
+  sessionId: "session_test",
+});
+
+const call = (tool: string, args: Json = {}): ToolCall => ({ id: "call_test", tool, args });
+
+const fact = (over: Partial<PersonaFact> = {}): PersonaFact => ({
+  kind: "preference",
+  text: "t",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  ...over,
+});
+
+const okOutput = (outcome: ToolOutcome): Json => {
+  expect(outcome.status).toBe("ok");
+  return (outcome as { status: "ok"; output: Json }).output;
+};
+
+const auditToolCall = (subject: string, tool: string, i: number) => {
+  const event: AuditEvent = {
+    id: `aud_${subject}_${tool}_${i}`,
+    at: new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString(),
+    kind: "tool-call",
+    principal: { kind: "user", subject },
+    venue: "chat",
+    presence: "present",
+    tool,
+    outcome: "ok",
+  };
+  return { id: event.id, data: event as unknown as Json, refs: { subject } };
+};
+
+const thread = (subject: string, id: string, texts: string[]) => ({
+  id,
+  data: {
+    subject,
+    messages: texts.map((text, i) => ({ id: `m_${i}`, role: "user", parts: [{ type: "text", text }] })),
+  } as unknown as Json,
+  refs: { subject },
+});
+
+describe("persona store", () => {
+  it("round-trips a saved persona", async () => {
+    const store = memoryStoreAdapter();
+    await savePersona(store, { ...emptyPersona("user_1"), summary: "works in tables" });
+    const loaded = await loadPersona(store, "user_1");
+    expect(loaded?.summary).toBe("works in tables");
+    expect(loaded?.subject).toBe("user_1");
+  });
+
+  it("returns null when no persona exists", async () => {
+    const store = memoryStoreAdapter();
+    expect(await loadPersona(store, "user_absent")).toBeNull();
+  });
+
+  it("tolerates a malformed row as null rather than throwing", async () => {
+    const store = memoryStoreAdapter();
+    await store.records(PERSONA_COLLECTION).put({ id: "user_1", data: { unexpected: true }, refs: { subject: "user_1" } });
+    expect(await loadPersona(store, "user_1")).toBeNull();
+  });
+
+  it("refuses reserved subjects on read and write", async () => {
+    const store = memoryStoreAdapter();
+    await expect(loadPersona(store, "vendo:webhook:stripe")).rejects.toThrow();
+    await expect(rememberFact(store, "vendo:webhook:stripe", { kind: "preference", text: "x" })).rejects.toThrow();
+  });
+});
+
+describe("mergeFacts", () => {
+  it("dedupes by kind and normalized text, newest wins", () => {
+    const older = fact({ text: "Prefers Tables", updatedAt: "2026-01-01T00:00:00.000Z", evidence: "old" });
+    const newer = fact({ text: "prefers tables", updatedAt: "2026-02-01T00:00:00.000Z", evidence: "new" });
+    const merged = mergeFacts([older], [newer]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].evidence).toBe("new");
+  });
+
+  it("keeps different kinds with the same text apart", () => {
+    const merged = mergeFacts([], [fact({ kind: "format", text: "same" }), fact({ kind: "domain", text: "same" })]);
+    expect(merged).toHaveLength(2);
+  });
+
+  it("caps at MAX_PERSONA_FACTS, keeping the most recent", () => {
+    const many = Array.from({ length: MAX_PERSONA_FACTS + 10 }, (_, i) =>
+      fact({ text: `f_${i}`, updatedAt: new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString() }),
+    );
+    const merged = mergeFacts([], many);
+    expect(merged).toHaveLength(MAX_PERSONA_FACTS);
+    expect(merged.some((entry) => entry.text === `f_${MAX_PERSONA_FACTS + 9}`)).toBe(true);
+    expect(merged.some((entry) => entry.text === "f_0")).toBe(false);
+  });
+});
+
+describe("persona tools", () => {
+  it("loads null, then the persona after a remember", async () => {
+    const tools = createPersonaTools(memoryStoreAdapter());
+    const ctx = ctxFor("user_1");
+
+    expect(okOutput(await tools.execute(call("vendo_persona_load"), ctx))).toBeNull();
+
+    const wrote = await tools.execute(call("vendo_persona_remember", { kind: "preference", text: "Prefers brief answers" }), ctx);
+    expect(wrote.status).toBe("ok");
+
+    const loaded = okOutput(await tools.execute(call("vendo_persona_load"), ctx)) as Persona;
+    expect(loaded.facts).toHaveLength(1);
+    expect(loaded.facts[0].text).toBe("Prefers brief answers");
+  });
+
+  it("isolates personas by subject (invariant)", async () => {
+    const store = memoryStoreAdapter();
+    const tools = createPersonaTools(store);
+    await tools.execute(call("vendo_persona_remember", { kind: "domain", text: "alice-only fact" }), ctxFor("alice"));
+    expect(okOutput(await tools.execute(call("vendo_persona_load"), ctxFor("bob")))).toBeNull();
+  });
+
+  it("rejects an invalid fact kind", async () => {
+    const tools = createPersonaTools(memoryStoreAdapter());
+    const out = await tools.execute(call("vendo_persona_remember", { kind: "nonsense", text: "x" }), ctxFor("user_1"));
+    expect(out.status).toBe("error");
+  });
+
+  it("rejects empty text", async () => {
+    const tools = createPersonaTools(memoryStoreAdapter());
+    const out = await tools.execute(call("vendo_persona_remember", { kind: "preference", text: "   " }), ctxFor("user_1"));
+    expect(out.status).toBe("error");
+  });
+
+  it("declares read and write risk honestly", async () => {
+    const descriptors = await createPersonaTools(memoryStoreAdapter()).descriptors();
+    expect(descriptors.find((entry) => entry.name === "vendo_persona_load")?.risk).toBe("read");
+    expect(descriptors.find((entry) => entry.name === "vendo_persona_remember")?.risk).toBe("write");
+  });
+});
+
+describe("distillPersona", () => {
+  it("distills top tools and format cues into a persona", async () => {
+    const store = memoryStoreAdapter();
+    const subject = "user_distill";
+    for (let i = 0; i < 5; i += 1) await store.records("vendo_audit").put(auditToolCall(subject, "host_invoices_list", i));
+    for (let i = 0; i < 2; i += 1) await store.records("vendo_audit").put(auditToolCall(subject, "host_customers_get", i));
+    await store.records("vendo_threads").put(
+      thread(subject, "thr_1", [
+        "show me overdue invoices as a table",
+        "give me that table again",
+        "export the table to csv",
+        "the table should include amounts",
+      ]),
+    );
+
+    const persona = await distillPersona(store, subject);
+    const kinds = persona.facts.map((entry) => entry.kind);
+    expect(kinds).toContain("workflow");
+    expect(kinds).toContain("format");
+    expect(persona.facts.find((entry) => entry.kind === "workflow")?.text).toContain("host_invoices_list");
+    expect(persona.summary.toLowerCase()).toContain("table");
+    expect(persona.distilledFrom).toEqual({ threads: 1, auditEvents: 7 });
+  });
+
+  it("preserves a remembered fact across a distill pass", async () => {
+    const store = memoryStoreAdapter();
+    const subject = "user_merge";
+    await rememberFact(store, subject, { kind: "preference", text: "Prefers brief answers" });
+    await store.records("vendo_audit").put(auditToolCall(subject, "host_orders_list", 0));
+    await store.records("vendo_audit").put(auditToolCall(subject, "host_orders_list", 1));
+    const persona = await distillPersona(store, subject);
+    expect(persona.facts.some((entry) => entry.text === "Prefers brief answers")).toBe(true);
+    expect(persona.facts.some((entry) => entry.kind === "workflow")).toBe(true);
+  });
+
+  it("refuses to distill a reserved subject", async () => {
+    await expect(distillPersona(memoryStoreAdapter(), "vendo:webhook:stripe")).rejects.toThrow();
+  });
+});

--- a/packages/vendo/src/persona.test.ts
+++ b/packages/vendo/src/persona.test.ts
@@ -1,5 +1,5 @@
 import { memoryStoreAdapter } from "@vendoai/core/conformance";
-import type { AuditEvent, Json, Persona, RunContext, ToolCall, ToolOutcome } from "@vendoai/core";
+import type { AuditEvent, Json, Persona, RecordStore, RunContext, StoreAdapter, ToolCall, ToolOutcome } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import {
   MAX_PERSONA_FACTS,
@@ -107,6 +107,35 @@ describe("mergeFacts", () => {
     expect(merged).toHaveLength(MAX_PERSONA_FACTS);
     expect(merged.some((entry) => entry.text === `f_${MAX_PERSONA_FACTS + 9}`)).toBe(true);
     expect(merged.some((entry) => entry.text === "f_0")).toBe(false);
+  });
+});
+
+const withoutAtomic = (base: StoreAdapter): StoreAdapter => ({
+  ...base,
+  records(collection: string): RecordStore {
+    const inner = base.records(collection);
+    return {
+      get: (id) => inner.get(id),
+      put: (record) => inner.put(record),
+      delete: (id) => inner.delete(id),
+      list: (query) => inner.list(query),
+    };
+  },
+});
+
+describe("persona write concurrency", () => {
+  it("does not lose concurrent remembers (atomic read-modify-write)", async () => {
+    const store = memoryStoreAdapter();
+    const subject = "user_concurrent";
+    const kinds = ["workflow", "format", "domain", "preference", "approval-posture"] as const;
+    await Promise.all(kinds.map((kind, i) => rememberFact(store, subject, { kind, text: `fact ${i}` })));
+    const persona = await loadPersona(store, subject);
+    expect(persona?.facts).toHaveLength(kinds.length);
+  });
+
+  it("fails closed when the store omits the atomic capability", async () => {
+    const store = withoutAtomic(memoryStoreAdapter());
+    await expect(rememberFact(store, "user_x", { kind: "preference", text: "t" })).rejects.toThrow(/atomic/i);
   });
 });
 

--- a/packages/vendo/src/persona/distill.ts
+++ b/packages/vendo/src/persona/distill.ts
@@ -1,0 +1,212 @@
+import {
+  isReservedSubject,
+  VendoError,
+  type AuditEvent,
+  type StoreAdapter,
+  type VendoRecord,
+} from "@vendoai/core";
+import { emptyPersona, loadPersona, mergeFacts, savePersona } from "./store.js";
+import type { Persona, PersonaFact, PersonaFactKind } from "./types.js";
+
+/** What a distill pass saw, before it is turned into facts and a summary. A
+ *  caller (the eval, or a host that wants a model-authored summary) can read
+ *  this to shape its own summary via `DistillOptions.summarize`. */
+export interface DistillDigest {
+  subject: string;
+  threads: number;
+  auditEvents: number;
+  topTools: { tool: string; count: number }[];
+  formatCues: { phrase: string; kind: PersonaFactKind; count: number }[];
+  userAsks: string[];
+}
+
+export interface DistillOptions {
+  /** Cap the history scanned so distillation stays bounded on a heavy user. */
+  maxThreads?: number;
+  maxAuditEvents?: number;
+  /** Optional override for the summary paragraph. Default is a deterministic
+   *  render of the facts, so the feature carries no model dependency; a host or
+   *  the eval can pass a model-backed summarizer for a richer paragraph. */
+  summarize?: (digest: DistillDigest) => Promise<string>;
+}
+
+/** Format and preference cues we can read straight from a user's own words,
+ *  deterministically. Deliberately small and honest: this is keyword evidence,
+ *  not language understanding. */
+const FORMAT_CUES: { term: string; kind: PersonaFactKind; phrase: string }[] = [
+  { term: "table", kind: "format", phrase: "Often asks for results as a table" },
+  { term: "csv", kind: "format", phrase: "Often asks for CSV output" },
+  { term: "chart", kind: "format", phrase: "Often asks for charts" },
+  { term: "graph", kind: "format", phrase: "Often asks for charts" },
+  { term: "list", kind: "format", phrase: "Often asks for a list" },
+  { term: "summary", kind: "preference", phrase: "Prefers summarized answers" },
+  { term: "brief", kind: "preference", phrase: "Prefers brief answers" },
+  { term: "detailed", kind: "preference", phrase: "Prefers detailed answers" },
+];
+
+const listAllBySubject = async (
+  store: StoreAdapter,
+  collection: string,
+  subject: string,
+  cap: number,
+): Promise<VendoRecord[]> => {
+  const out: VendoRecord[] = [];
+  let cursor: string | undefined;
+  do {
+    const remaining = cap - out.length;
+    const page = await store.records(collection).list({
+      refs: { subject },
+      limit: Math.min(100, remaining),
+      ...(cursor === undefined ? {} : { cursor }),
+    });
+    out.push(...page.records);
+    cursor = page.cursor;
+  } while (cursor !== undefined && out.length < cap);
+  return out.slice(0, cap);
+};
+
+/** Pull the user's own text out of a thread's messages, mirroring the agent's
+ *  own defensive walk (role === "user", part.type === "text"). */
+const userTexts = (data: unknown): string[] => {
+  if (data === null || typeof data !== "object") return [];
+  const messages = (data as { messages?: unknown }).messages;
+  if (!Array.isArray(messages)) return [];
+  const texts: string[] = [];
+  for (const message of messages) {
+    if (message === null || typeof message !== "object") continue;
+    if ((message as { role?: unknown }).role !== "user") continue;
+    const parts = (message as { parts?: unknown }).parts;
+    if (!Array.isArray(parts)) continue;
+    for (const part of parts) {
+      if (
+        part !== null &&
+        typeof part === "object" &&
+        (part as { type?: unknown }).type === "text" &&
+        typeof (part as { text?: unknown }).text === "string"
+      ) {
+        const text = (part as { text: string }).text.trim();
+        if (text !== "") texts.push(text);
+      }
+    }
+  }
+  return texts;
+};
+
+const countTools = (rows: VendoRecord[]): { tool: string; count: number }[] => {
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    const event = row.data as Partial<AuditEvent> | null;
+    if (event?.kind !== "tool-call") continue;
+    if (typeof event.tool !== "string" || event.tool === "") continue;
+    counts.set(event.tool, (counts.get(event.tool) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([tool, count]) => ({ tool, count }))
+    .sort((a, b) => (b.count === a.count ? a.tool.localeCompare(b.tool) : b.count - a.count));
+};
+
+const scanFormatCues = (
+  asks: string[],
+): { phrase: string; kind: PersonaFactKind; count: number }[] => {
+  const lowered = asks.map((ask) => ask.toLowerCase());
+  const threshold = Math.max(2, Math.ceil(asks.length * 0.2));
+  const byPhrase = new Map<string, { phrase: string; kind: PersonaFactKind; count: number }>();
+  for (const cue of FORMAT_CUES) {
+    const count = lowered.filter((ask) => ask.includes(cue.term)).length;
+    if (count < threshold) continue;
+    const existing = byPhrase.get(cue.phrase);
+    // chart/graph collapse onto one phrase — keep the larger evidence count.
+    if (existing === undefined || count > existing.count) {
+      byPhrase.set(cue.phrase, { phrase: cue.phrase, kind: cue.kind, count });
+    }
+  }
+  return [...byPhrase.values()].sort((a, b) => b.count - a.count);
+};
+
+/** Facts carry STABLE text (so re-distilling dedupes cleanly) and put the volatile
+ *  counts in `evidence`. */
+const buildFacts = (
+  digest: DistillDigest,
+  at: string,
+): PersonaFact[] => {
+  const facts: PersonaFact[] = [];
+  if (digest.topTools.length > 0) {
+    const names = digest.topTools.slice(0, 3).map((entry) => entry.tool);
+    facts.push({
+      kind: "workflow",
+      text: `Reaches for ${names.join(", ")}`,
+      evidence: `top tools by usage across ${digest.auditEvents} audited actions`,
+      updatedAt: at,
+    });
+  }
+  for (const cue of digest.formatCues) {
+    facts.push({
+      kind: cue.kind,
+      text: cue.phrase,
+      evidence: `seen in ${cue.count} of ${digest.userAsks.length} recent requests`,
+      updatedAt: at,
+    });
+  }
+  return facts;
+};
+
+const defaultSummary = (digest: DistillDigest, facts: PersonaFact[]): string => {
+  if (facts.length === 0) return "";
+  const parts: string[] = [];
+  if (digest.topTools.length > 0) {
+    parts.push(`Reaches for ${digest.topTools.slice(0, 3).map((entry) => entry.tool).join(", ")}.`);
+  }
+  const shape = facts
+    .filter((fact) => fact.kind === "format" || fact.kind === "preference")
+    .map((fact) => fact.text);
+  if (shape.length > 0) parts.push(`${shape.join(". ")}.`);
+  return parts.join(" ");
+};
+
+/** Build or refresh a subject's persona from their own threads and audit trail.
+ *  Deterministic by default. Merges distilled facts into any existing record
+ *  (including facts the agent remembered mid-turn), keeping the record bounded. */
+export const distillPersona = async (
+  store: StoreAdapter,
+  subject: string,
+  options: DistillOptions = {},
+): Promise<Persona> => {
+  if (isReservedSubject(subject)) {
+    throw new VendoError("validation", "cannot distill a persona for a reserved subject");
+  }
+  const maxThreads = options.maxThreads ?? 100;
+  const maxAudit = options.maxAuditEvents ?? 500;
+
+  const threadRows = await listAllBySubject(store, "vendo_threads", subject, maxThreads);
+  const userAsks: string[] = [];
+  for (const row of threadRows) {
+    // list() may omit message bodies once a thread has a stored title; re-read
+    // the full row so we always distill from the real conversation.
+    const full = await store.records("vendo_threads").get(row.id);
+    userAsks.push(...userTexts(full?.data ?? row.data));
+  }
+
+  const auditRows = await listAllBySubject(store, "vendo_audit", subject, maxAudit);
+  const topTools = countTools(auditRows);
+  const formatCues = scanFormatCues(userAsks);
+
+  const digest: DistillDigest = {
+    subject,
+    threads: threadRows.length,
+    auditEvents: auditRows.length,
+    topTools,
+    formatCues,
+    userAsks,
+  };
+  const at = new Date().toISOString();
+  const facts = buildFacts(digest, at);
+  const summary = options.summarize ? await options.summarize(digest) : defaultSummary(digest, facts);
+
+  const base = (await loadPersona(store, subject)) ?? emptyPersona(subject);
+  return savePersona(store, {
+    ...base,
+    summary,
+    facts: mergeFacts(base.facts, facts),
+    distilledFrom: { threads: threadRows.length, auditEvents: auditRows.length },
+  });
+};

--- a/packages/vendo/src/persona/distill.ts
+++ b/packages/vendo/src/persona/distill.ts
@@ -5,7 +5,7 @@ import {
   type StoreAdapter,
   type VendoRecord,
 } from "@vendoai/core";
-import { emptyPersona, loadPersona, mergeFacts, savePersona } from "./store.js";
+import { emptyPersona, mergeFacts, mutatePersona } from "./store.js";
 import type { Persona, PersonaFact, PersonaFactKind } from "./types.js";
 
 /** What a distill pass saw, before it is turned into facts and a summary. A
@@ -202,11 +202,13 @@ export const distillPersona = async (
   const facts = buildFacts(digest, at);
   const summary = options.summarize ? await options.summarize(digest) : defaultSummary(digest, facts);
 
-  const base = (await loadPersona(store, subject)) ?? emptyPersona(subject);
-  return savePersona(store, {
-    ...base,
-    summary,
-    facts: mergeFacts(base.facts, facts),
-    distilledFrom: { threads: threadRows.length, auditEvents: auditRows.length },
+  return mutatePersona(store, subject, (current) => {
+    const base = current ?? emptyPersona(subject);
+    return {
+      ...base,
+      summary,
+      facts: mergeFacts(base.facts, facts),
+      distilledFrom: { threads: threadRows.length, auditEvents: auditRows.length },
+    };
   });
 };

--- a/packages/vendo/src/persona/eval-fixtures.ts
+++ b/packages/vendo/src/persona/eval-fixtures.ts
@@ -1,0 +1,122 @@
+import type { SubjectFixture } from "./eval.js";
+
+/** The tool menu a replayed agent chooses from. A realistic union of the two demo
+ *  hosts' surfaces (Cadence accounting, Maple bank) plus near-neighbors, so a
+ *  held-out decision is a genuine choice, not a one-option giveaway. */
+export const AVAILABLE_TOOLS: string[] = [
+  // Cadence (accounting)
+  "host_invoices_list",
+  "host_invoices_send",
+  "host_invoices_create",
+  "host_reports_revenue_create",
+  "host_clients_list",
+  "host_documents_list",
+  "host_messages_send",
+  "host_records_list",
+  // Maple (bank)
+  "host_accounts_list",
+  "host_transactions_list",
+  "host_transfers_create",
+  "host_cards_list",
+  "host_payments_list",
+  "host_orders_list",
+  "host_send_email",
+];
+
+const repeat = (value: string, times: number): string[] => Array.from({ length: times }, () => value);
+
+/** Grounded synthetic subjects over the real demo tool vocabulary. The held-out
+ *  prompts are deliberately ELLIPTICAL and SHARED: the same request ("pull up my
+ *  usual view", "do my routine thing for me") maps to a different tool for each
+ *  user, decided only by their habit. A stock agent sees an identical prompt for
+ *  four different users and cannot do better than one fixed guess; only the
+ *  persona distilled from each user's own history breaks the tie. This isolates
+ *  the case persona exists to serve: an under-specified request leaning on habit.
+ *  The dominant history tool is always the held-out `expectedTool`, so it is
+ *  guaranteed to surface in the distilled workflow fact (the model-free claim the
+ *  CI test asserts). */
+export const GROUNDED_FIXTURES: SubjectFixture[] = [
+  {
+    subject: "cadence_ar",
+    historyTools: [...repeat("host_invoices_list", 9), ...repeat("host_invoices_send", 2), "host_clients_list"],
+    historyAsks: [
+      "show unpaid invoices as a table",
+      "the overdue invoice table again",
+      "table of what clients owe us",
+      "export the invoices table",
+    ],
+    holdout: [{ prompt: "pull up my usual view", expectedTool: "host_invoices_list" }],
+  },
+  {
+    subject: "cadence_collections",
+    historyTools: [...repeat("host_invoices_send", 9), ...repeat("host_invoices_list", 3)],
+    historyAsks: [
+      "send the payment reminders",
+      "email the overdue accounts",
+      "remind the late clients again",
+      "send the usual reminders",
+    ],
+    holdout: [{ prompt: "do my routine thing for me", expectedTool: "host_invoices_send" }],
+  },
+  {
+    subject: "cadence_revenue",
+    historyTools: [...repeat("host_reports_revenue_create", 8), ...repeat("host_invoices_list", 2)],
+    historyAsks: [
+      "revenue chart for the month",
+      "show me a chart of revenue",
+      "the quarterly revenue chart",
+    ],
+    holdout: [{ prompt: "do my routine thing for me", expectedTool: "host_reports_revenue_create" }],
+  },
+  {
+    subject: "cadence_docs",
+    historyTools: [...repeat("host_documents_list", 8), ...repeat("host_clients_list", 3)],
+    historyAsks: [
+      "list the signed contracts",
+      "the documents for this client",
+      "a list of recent agreements",
+    ],
+    holdout: [{ prompt: "pull up my usual view", expectedTool: "host_documents_list" }],
+  },
+  {
+    subject: "maple_treasury",
+    historyTools: [...repeat("host_transfers_create", 8), ...repeat("host_accounts_list", 4)],
+    historyAsks: [
+      "move money to savings",
+      "transfer between the accounts",
+      "move funds over to reserves",
+    ],
+    holdout: [{ prompt: "do my routine thing for me", expectedTool: "host_transfers_create" }],
+  },
+  {
+    subject: "maple_recon",
+    historyTools: repeat("host_transactions_list", 10),
+    historyAsks: [
+      "transactions as a table",
+      "table of last month's spend",
+      "the transactions table again",
+      "show a table of charges",
+    ],
+    holdout: [{ prompt: "pull up my usual view", expectedTool: "host_transactions_list" }],
+  },
+  {
+    subject: "maple_cards",
+    historyTools: [...repeat("host_cards_list", 7), ...repeat("host_payments_list", 2)],
+    historyAsks: [
+      "list my cards",
+      "show the card details",
+      "a list of active cards",
+    ],
+    holdout: [{ prompt: "pull up my usual view", expectedTool: "host_cards_list" }],
+  },
+  {
+    subject: "maple_orders",
+    historyTools: repeat("host_orders_list", 8),
+    historyAsks: [
+      "list recent orders",
+      "orders list please",
+      "a list of open orders",
+    ],
+    holdout: [{ prompt: "do my routine thing for me", expectedTool: "host_orders_list" }],
+  },
+];

--- a/packages/vendo/src/persona/eval.ts
+++ b/packages/vendo/src/persona/eval.ts
@@ -1,0 +1,98 @@
+import type { Json, StoreAdapter } from "@vendoai/core";
+import { distillPersona } from "./distill.js";
+import type { Persona } from "./types.js";
+
+/** One held-out decision: the prompt the user sent and the tool they actually
+ *  chose. Replay asks whether an agent reproduces that choice. */
+export interface DecisionCase {
+  prompt: string;
+  expectedTool: string;
+}
+
+export interface SubjectFixture {
+  subject: string;
+  /** Past tool calls (a name repeated once per use) that shape the persona. */
+  historyTools: string[];
+  /** Past user asks that shape the persona (format cues live here). */
+  historyAsks: string[];
+  /** Decisions held out of the history, replayed to score reproduction. */
+  holdout: DecisionCase[];
+}
+
+/** Seed one subject's history so distillPersona has real rows to read: audit
+ *  tool-calls plus one thread of asks, exactly the two sources the distiller
+ *  mines in production. */
+export const seedSubject = async (store: StoreAdapter, fixture: SubjectFixture): Promise<void> => {
+  let index = 0;
+  for (const tool of fixture.historyTools) {
+    const event = {
+      id: `aud_${fixture.subject}_${index}`,
+      at: new Date(Date.UTC(2026, 0, 1, 0, 0, index)).toISOString(),
+      kind: "tool-call",
+      principal: { kind: "user", subject: fixture.subject },
+      venue: "chat",
+      presence: "present",
+      tool,
+      outcome: "ok",
+    };
+    await store.records("vendo_audit").put({ id: event.id, data: event as unknown as Json, refs: { subject: fixture.subject } });
+    index += 1;
+  }
+  await store.records("vendo_threads").put({
+    id: `thr_${fixture.subject}`,
+    data: {
+      subject: fixture.subject,
+      messages: fixture.historyAsks.map((text, k) => ({ id: `m_${k}`, role: "user", parts: [{ type: "text", text }] })),
+    } as unknown as Json,
+    refs: { subject: fixture.subject },
+  });
+};
+
+/** The turn under test: given a prompt and the caller's persona (or null for the
+ *  stock agent), return the tool the agent would call. A model-backed
+ *  implementation plugs in here to produce the real replay number; a
+ *  deterministic oracle stands in for CI, proving the harness and that a persona
+ *  can move a decision without a live model. */
+export type RunTurn = (input: { subject: string; prompt: string; persona: Persona | null }) => Promise<string>;
+
+export interface ReplayReport {
+  cases: number;
+  withoutPersona: number;
+  withPersona: number;
+  accuracyWithout: number;
+  accuracyWith: number;
+  delta: number;
+}
+
+/** Offline replay. For every fixture: distill a persona from its history, then
+ *  run each held-out decision twice (stock and persona-conditioned) and score
+ *  agreement with the user's actual choice. The delta is the persona's effect. */
+export const runPersonaReplay = async (
+  store: StoreAdapter,
+  fixtures: SubjectFixture[],
+  runTurn: RunTurn,
+): Promise<ReplayReport> => {
+  let cases = 0;
+  let withPersona = 0;
+  let withoutPersona = 0;
+  for (const fixture of fixtures) {
+    const persona = await distillPersona(store, fixture.subject);
+    for (const decision of fixture.holdout) {
+      cases += 1;
+      const stock = await runTurn({ subject: fixture.subject, prompt: decision.prompt, persona: null });
+      const conditioned = await runTurn({ subject: fixture.subject, prompt: decision.prompt, persona });
+      if (stock === decision.expectedTool) withoutPersona += 1;
+      if (conditioned === decision.expectedTool) withPersona += 1;
+    }
+  }
+  const accuracyWithout = cases === 0 ? 0 : withoutPersona / cases;
+  const accuracyWith = cases === 0 ? 0 : withPersona / cases;
+  return {
+    cases,
+    withoutPersona,
+    withPersona,
+    accuracyWithout,
+    accuracyWith,
+    delta: accuracyWith - accuracyWithout,
+  };
+};

--- a/packages/vendo/src/persona/index.ts
+++ b/packages/vendo/src/persona/index.ts
@@ -1,0 +1,20 @@
+export {
+  PERSONA_FORMAT,
+  personaFactKindSchema,
+  personaFactSchema,
+  personaSchema,
+  type Persona,
+  type PersonaFact,
+  type PersonaFactKind,
+} from "./types.js";
+export {
+  MAX_PERSONA_FACTS,
+  PERSONA_COLLECTION,
+  emptyPersona,
+  loadPersona,
+  mergeFacts,
+  rememberFact,
+  savePersona,
+} from "./store.js";
+export { createPersonaTools } from "./tools.js";
+export { distillPersona, type DistillDigest, type DistillOptions } from "./distill.js";

--- a/packages/vendo/src/persona/store.ts
+++ b/packages/vendo/src/persona/store.ts
@@ -1,0 +1,97 @@
+import { isReservedSubject, VendoError, type Json, type StoreAdapter } from "@vendoai/core";
+import {
+  PERSONA_FORMAT,
+  personaSchema,
+  type Persona,
+  type PersonaFact,
+  type PersonaFactKind,
+} from "./types.js";
+
+/** Generic, non-reserved `vendo_records` collection. Going straight to the
+ *  StoreAdapter (not the app-scoped AppDataAccess) is deliberate: a persona is
+ *  keyed by subject, not owned by an app. The name must not collide with the
+ *  umbrella's reserved collections (vendo_state, vendo_apps, vendo_threads, ...). */
+export const PERSONA_COLLECTION = "persona";
+
+/** A persona is a compact model, not a log. Keep the most recent facts and drop
+ *  the tail so one row can never grow without bound. */
+export const MAX_PERSONA_FACTS = 50;
+
+const now = (): string => new Date().toISOString();
+
+const assertRealSubject = (subject: string): void => {
+  if (subject.trim() === "") {
+    throw new VendoError("validation", "subject must be a non-empty string");
+  }
+  if (isReservedSubject(subject)) {
+    throw new VendoError("validation", "persona is not tracked for reserved subjects");
+  }
+};
+
+const factKey = (fact: { kind: PersonaFactKind; text: string }): string =>
+  `${fact.kind}::${fact.text.trim().toLowerCase()}`;
+
+/** Dedupe by (kind, normalized text) with newest winning, then keep the most
+ *  recently updated MAX_PERSONA_FACTS. Deterministic, no clock inside. */
+export const mergeFacts = (existing: PersonaFact[], incoming: PersonaFact[]): PersonaFact[] => {
+  const byKey = new Map<string, PersonaFact>();
+  for (const fact of existing) byKey.set(factKey(fact), fact);
+  for (const fact of incoming) byKey.set(factKey(fact), fact);
+  return [...byKey.values()]
+    .sort((a, b) => (a.updatedAt === b.updatedAt ? 0 : a.updatedAt < b.updatedAt ? 1 : -1))
+    .slice(0, MAX_PERSONA_FACTS);
+};
+
+export const emptyPersona = (subject: string): Persona => ({
+  format: PERSONA_FORMAT,
+  subject,
+  summary: "",
+  facts: [],
+  distilledFrom: { threads: 0, auditEvents: 0 },
+  updatedAt: now(),
+});
+
+/** Read a subject's persona, or null when none exists. A malformed or older-shape
+ *  row is tolerated as null rather than thrown: a persona miss must never break a
+ *  live turn, it just means the agent runs stock this time. */
+export const loadPersona = async (
+  store: StoreAdapter,
+  subject: string,
+): Promise<Persona | null> => {
+  assertRealSubject(subject);
+  const record = await store.records(PERSONA_COLLECTION).get(subject);
+  if (record === null) return null;
+  const parsed = personaSchema.safeParse(record.data);
+  return parsed.success ? parsed.data : null;
+};
+
+/** Validate, stamp, and persist. `refs.subject` is set so a host can join the
+ *  row against its own tables the same way every other Vendo row is joinable. */
+export const savePersona = async (
+  store: StoreAdapter,
+  persona: Persona,
+): Promise<Persona> => {
+  assertRealSubject(persona.subject);
+  const next = personaSchema.parse({
+    ...persona,
+    facts: persona.facts.slice(0, MAX_PERSONA_FACTS),
+    updatedAt: now(),
+  });
+  await store.records(PERSONA_COLLECTION).put({
+    id: next.subject,
+    data: next as unknown as Json,
+    refs: { subject: next.subject },
+  });
+  return next;
+};
+
+/** Append one durable fact, merging into the existing record (or a fresh one). */
+export const rememberFact = async (
+  store: StoreAdapter,
+  subject: string,
+  fact: { kind: PersonaFactKind; text: string; evidence?: string },
+): Promise<Persona> => {
+  const existing = (await loadPersona(store, subject)) ?? emptyPersona(subject);
+  const merged = mergeFacts(existing.facts, [{ ...fact, updatedAt: now() }]);
+  return savePersona(store, { ...existing, facts: merged });
+};

--- a/packages/vendo/src/persona/store.ts
+++ b/packages/vendo/src/persona/store.ts
@@ -17,6 +17,10 @@ export const PERSONA_COLLECTION = "persona";
  *  the tail so one row can never grow without bound. */
 export const MAX_PERSONA_FACTS = 50;
 
+/** How many times a guarded write re-reads and re-applies after losing the CAS
+ *  race, before giving up. Mirrors thread persistence (03 §5). */
+const MAX_WRITE_ATTEMPTS = 5;
+
 const now = (): string => new Date().toISOString();
 
 const assertRealSubject = (subject: string): void => {
@@ -26,6 +30,11 @@ const assertRealSubject = (subject: string): void => {
   if (isReservedSubject(subject)) {
     throw new VendoError("validation", "persona is not tracked for reserved subjects");
   }
+};
+
+const parsePersona = (data: Json): Persona | null => {
+  const parsed = personaSchema.safeParse(data);
+  return parsed.success ? parsed.data : null;
 };
 
 const factKey = (fact: { kind: PersonaFactKind; text: string }): string =>
@@ -60,38 +69,66 @@ export const loadPersona = async (
 ): Promise<Persona | null> => {
   assertRealSubject(subject);
   const record = await store.records(PERSONA_COLLECTION).get(subject);
-  if (record === null) return null;
-  const parsed = personaSchema.safeParse(record.data);
-  return parsed.success ? parsed.data : null;
+  return record === null ? null : parsePersona(record.data);
 };
 
-/** Validate, stamp, and persist. `refs.subject` is set so a host can join the
- *  row against its own tables the same way every other Vendo row is joinable. */
-export const savePersona = async (
+/** The one write path: a bounded-retry, revision-guarded read-modify-write, so
+ *  two concurrent persona writers can never lose an update. Mirrors thread
+ *  persistence exactly (threads.ts, 02-store §4): insert-if-absent for a first
+ *  write, revision CAS for an existing row, and an adapter that omits `atomic`
+ *  fails closed rather than risking a blind overwrite. `mutate` receives the
+ *  current persona (or null) and returns the next one; it is re-run on each
+ *  attempt against the freshly re-read row, so the merge is never lost. */
+export const mutatePersona = async (
   store: StoreAdapter,
-  persona: Persona,
+  subject: string,
+  mutate: (current: Persona | null) => Persona,
 ): Promise<Persona> => {
-  assertRealSubject(persona.subject);
-  const next = personaSchema.parse({
-    ...persona,
-    facts: persona.facts.slice(0, MAX_PERSONA_FACTS),
-    updatedAt: now(),
-  });
-  await store.records(PERSONA_COLLECTION).put({
-    id: next.subject,
-    data: next as unknown as Json,
-    refs: { subject: next.subject },
-  });
-  return next;
+  assertRealSubject(subject);
+  const records = store.records(PERSONA_COLLECTION);
+  const atomic = records.atomic;
+  if (atomic === undefined) {
+    throw new VendoError(
+      "not-implemented",
+      "persona writes need a store with atomic record claims (02-store §4); this adapter omits the capability",
+    );
+  }
+  for (let attempt = 0; attempt < MAX_WRITE_ATTEMPTS; attempt += 1) {
+    const record = await records.get(subject);
+    const current = record === null ? null : parsePersona(record.data);
+    const draft = mutate(current);
+    const next = personaSchema.parse({
+      ...draft,
+      subject,
+      facts: draft.facts.slice(0, MAX_PERSONA_FACTS),
+      updatedAt: now(),
+    });
+    const input = { id: subject, data: next as unknown as Json, refs: { subject } };
+    const written = record === null
+      ? await atomic.insertIfAbsent(input)
+      : await atomic.compareAndSwap(input, record.revision!);
+    if (written !== null) return next;
+  }
+  throw new VendoError(
+    "conflict",
+    `persona ${subject} write lost the update race ${MAX_WRITE_ATTEMPTS} times`,
+  );
 };
 
-/** Append one durable fact, merging into the existing record (or a fresh one). */
+/** Validate and persist a full persona, replacing whatever is there. Atomic like
+ *  every write, but a deliberate blind set (used for seeding and tests), not a
+ *  merge. Prefer `rememberFact` / `distillPersona` for incremental updates. */
+export const savePersona = async (store: StoreAdapter, persona: Persona): Promise<Persona> =>
+  mutatePersona(store, persona.subject, () => persona);
+
+/** Append one durable fact, merging into the existing record (or a fresh one),
+ *  concurrency-safe. */
 export const rememberFact = async (
   store: StoreAdapter,
   subject: string,
   fact: { kind: PersonaFactKind; text: string; evidence?: string },
-): Promise<Persona> => {
-  const existing = (await loadPersona(store, subject)) ?? emptyPersona(subject);
-  const merged = mergeFacts(existing.facts, [{ ...fact, updatedAt: now() }]);
-  return savePersona(store, { ...existing, facts: merged });
-};
+): Promise<Persona> =>
+  mutatePersona(store, subject, (current) => {
+    const base = current ?? emptyPersona(subject);
+    return { ...base, facts: mergeFacts(base.facts, [{ ...fact, updatedAt: now() }]) };
+  });

--- a/packages/vendo/src/persona/tools.ts
+++ b/packages/vendo/src/persona/tools.ts
@@ -1,0 +1,115 @@
+import {
+  VendoError,
+  type Json,
+  type RunContext,
+  type StoreAdapter,
+  type ToolDescriptor,
+  type ToolOutcome,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { personaFactKindSchema } from "./types.js";
+import { loadPersona, rememberFact } from "./store.js";
+
+const DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema";
+const FACT_KINDS = [...personaFactKindSchema.options];
+
+const descriptors: ToolDescriptor[] = [
+  {
+    name: "vendo_persona_load",
+    description:
+      "Load the current user's persona: a short model of how they work, the formats and tools they prefer, their recurring intents, and durable facts they have stated. Call this at the start of a turn and let it shape how you answer. Returns null when the user has no persona yet.",
+    inputSchema: {
+      $schema: DRAFT_2020_12,
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    // Reads the caller's own record, so it runs silently under every policy.
+    risk: "read",
+  },
+  {
+    name: "vendo_persona_remember",
+    description:
+      "Record one durable fact about the current user for future sessions. Use only for stable preferences or recurring patterns (how they like output formatted, the domains and tools they keep returning to, standing instructions, how much they want to be asked before a write), never one-off details from this turn.",
+    inputSchema: {
+      $schema: DRAFT_2020_12,
+      type: "object",
+      properties: {
+        kind: { type: "string", enum: FACT_KINDS },
+        text: { type: "string", minLength: 1 },
+        evidence: { type: "string", minLength: 1 },
+      },
+      required: ["kind", "text"],
+      additionalProperties: false,
+    },
+    // Writes the user's own self-data, not a host resource. Auto-runs in the
+    // default composition; a host with a strict write policy can gate it by name.
+    risk: "write",
+  },
+];
+
+const asObject = (value: Json): Record<string, Json> => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new VendoError("validation", "tool input must be an object");
+  }
+  return value as Record<string, Json>;
+};
+
+const errorOutcome = (error: unknown): ToolOutcome => ({
+  status: "error",
+  error:
+    error instanceof VendoError
+      ? { code: error.code, message: error.message }
+      : { code: "internal", message: error instanceof Error ? error.message : "unknown persona error" },
+});
+
+/** The persona capability tools, mirroring apps' `createAgentTools`: an unbound
+ *  ToolRegistry the umbrella folds into `actions` and guard binds. Handlers key
+ *  every read and write on `ctx.principal.subject`, so a caller can only ever
+ *  touch its own persona. */
+export const createPersonaTools = (store: StoreAdapter): ToolRegistry => ({
+  async descriptors() {
+    return structuredClone(descriptors);
+  },
+  async execute(call, ctx: RunContext): Promise<ToolOutcome> {
+    try {
+      const subject = ctx.principal.subject;
+
+      if (call.tool === "vendo_persona_load") {
+        asObject(call.args);
+        const persona = await loadPersona(store, subject);
+        return { status: "ok", output: persona as unknown as Json };
+      }
+
+      if (call.tool === "vendo_persona_remember") {
+        const args = asObject(call.args);
+        const kind = personaFactKindSchema.safeParse(args.kind);
+        if (!kind.success) {
+          throw new VendoError("validation", `kind must be one of: ${FACT_KINDS.join(", ")}`);
+        }
+        if (typeof args.text !== "string" || args.text.trim() === "") {
+          throw new VendoError("validation", "text must be a non-empty string");
+        }
+        if (
+          args.evidence !== undefined &&
+          (typeof args.evidence !== "string" || args.evidence.trim() === "")
+        ) {
+          throw new VendoError("validation", "evidence must be a non-empty string when provided");
+        }
+        const persona = await rememberFact(store, subject, {
+          kind: kind.data,
+          text: args.text.trim(),
+          ...(args.evidence === undefined ? {} : { evidence: (args.evidence as string).trim() }),
+        });
+        return {
+          status: "ok",
+          output: { remembered: true, facts: persona.facts.length } as unknown as Json,
+        };
+      }
+
+      return { status: "error", error: { code: "not-found", message: `Unknown tool: ${call.tool}` } };
+    } catch (error) {
+      return errorOutcome(error);
+    }
+  },
+});

--- a/packages/vendo/src/persona/types.ts
+++ b/packages/vendo/src/persona/types.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+import { isoDateTimeSchema, type IsoDateTime } from "@vendoai/core";
+
+/** Format tag on the persisted persona record, so a future shape can be
+ *  introduced without breaking readers (the contracts' own evolution rule for
+ *  self-describing documents). */
+export const PERSONA_FORMAT = "vendo/persona@1";
+
+/** The five things worth knowing about a user of an agent product: what they are
+ *  trying to do (workflow, domain), how they want it back (format), what they
+ *  have told us to always do (preference), and how much they want to be asked
+ *  before a write happens (approval-posture). A closed set now, additive later
+ *  the same way the contracts grow binding kinds and trigger kinds. */
+export type PersonaFactKind =
+  | "workflow"
+  | "format"
+  | "domain"
+  | "preference"
+  | "approval-posture";
+
+export const personaFactKindSchema = z.enum([
+  "workflow",
+  "format",
+  "domain",
+  "preference",
+  "approval-posture",
+]) satisfies z.ZodType<PersonaFactKind>;
+
+/** One durable observation about the user, with a pointer to where it came from. */
+export interface PersonaFact {
+  kind: PersonaFactKind;
+  text: string;
+  evidence?: string;
+  updatedAt: IsoDateTime;
+}
+
+export const personaFactSchema = z.object({
+  kind: personaFactKindSchema,
+  text: z.string().min(1),
+  evidence: z.string().min(1).optional(),
+  updatedAt: isoDateTimeSchema,
+}).passthrough() satisfies z.ZodType<PersonaFact>;
+
+/** A compact model of how one user works, keyed by subject. Stored as opaque
+ *  data in a `vendo_records` row (id = subject). A bounded record, not a growing
+ *  log, so it stays inside Vendo's Postgres-only, no-vector-search doctrine. */
+export interface Persona {
+  format: typeof PERSONA_FORMAT;
+  subject: string;
+  /** One short paragraph: how this user works. The field the agent reads first. */
+  summary: string;
+  facts: PersonaFact[];
+  /** Provenance: how much history this was distilled from. */
+  distilledFrom: { threads: number; auditEvents: number };
+  updatedAt: IsoDateTime;
+}
+
+export const personaSchema = z.object({
+  format: z.literal(PERSONA_FORMAT),
+  subject: z.string().min(1),
+  summary: z.string(),
+  facts: z.array(personaFactSchema),
+  distilledFrom: z.object({
+    threads: z.number().int().nonnegative(),
+    auditEvents: z.number().int().nonnegative(),
+  }).passthrough(),
+  updatedAt: isoDateTimeSchema,
+}).passthrough() satisfies z.ZodType<Persona>;

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -124,6 +124,7 @@ import { HostedSessionDoorsMissingError, hostedStore, type HostedStore } from ".
 // own options instead of relying on the VENDO_API_KEY default.
 export { hostedStore, type HostedStore, type HostedStoreOptions } from "./hosted-store.js";
 import { createRuntimeCapture } from "./runtime-capture.js";
+import { createPersonaTools } from "./persona/index.js";
 import {
   BASE_PATH,
   VERSION,
@@ -1308,6 +1309,11 @@ export function createVendo(config: CreateVendoConfig): Vendo {
   });
   resolveAppToolRisk = apps.agentToolRisk;
   actions.add(apps.agentTools());
+  // Persona layer: two guard-bound, subject-scoped tools (load + remember)
+  // folded into the same registry apps rides. They inherit the guard binding
+  // above (boundTools re-reads descriptors per call), so persona reads and
+  // writes are policed and audited like every other tool, with no separate path.
+  actions.add(createPersonaTools(store));
   const missSurface = actions.descriptors()
     .then(capabilitySurfaceSnapshot)
     .catch(() => capabilitySurfaceSnapshot([]));


### PR DESCRIPTION
Draft, tied to the design discussion in #521. Opening it so the code is visible and easy to react to. Happy to iterate on the shape or hold it entirely per your steer.

## What

A per-user persona layer for the agent, additive and living entirely in the umbrella so no frozen block changes. A per-subject persona record (how the user works, the tools they reach for, the formats they prefer, durable facts they state) in a `vendo_records` collection keyed by subject, with no schema change. Two guard-bound, subject-scoped tools, `vendo_persona_load` and `vendo_persona_remember`, folded into the same registry the app tools use, so persona reads and writes are policed and audited like every other tool. `distillPersona` builds a persona from a subject's own threads and audit trail, deterministically by default. An offline replay harness plus fixtures measure whether a persona-conditioned agent reproduces a user's held-out decisions.

## Why

Vendo has no model of who the user is across sessions, so the agent starts every turn cold and cannot resolve habit-driven requests: "pull up my usual view" should mean different things to a user who lives in invoices and one who lives in transfers, and today it cannot. This adds that model in the smallest additive way. The persona reaches the agent prompt only, generation stays user-blind, and subject isolation is never crossed. The always-on `assembleSystemPrompt` variant is deliberately left out as a follow-up, since it would touch the frozen agent contract. Full rationale and alternatives are in #521.

## Verification

- [x] `pnpm build`, `pnpm typecheck`, `pnpm lint` green, dependency-guard passes.
- [x] New persona unit and eval tests pass (18 of 18). The full `@vendoai/vendo` suite shows only failures that pre-date this change and are unrelated to it, confirmed by running the suite on a clean baseline with this diff removed. They trace to the local Node version, not this code, and should clear on CI.
- No UI-affecting changes, so no screenshots.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a per-user persona layer so the agent remembers how each user works across sessions. Persona writes are now concurrency-safe with atomic CAS to prevent lost updates.

- **New Features**
  - Per-subject persona stored in `vendo_records` (collection `persona`, id = subject); bounded facts with tolerant reads.
  - Guard-bound tools added to the action registry: `vendo_persona_load` (risk: read) and `vendo_persona_remember` (risk: write), audited like app tools.
  - `distillPersona` builds/refines a persona from the user’s own `vendo_threads` and `vendo_audit`; deterministic by default with an optional summarizer hook.
  - Offline replay eval (`runPersonaReplay`) plus grounded fixtures to measure how persona-conditioned turns reproduce held-out tool choices.
  - Server wires in `createPersonaTools`, keeping subject isolation; persona only influences the system prompt, never generated documents.

- **Bug Fixes**
  - Persona writes now use the store’s atomic compare-and-swap with bounded retries; fails closed when the adapter omits `atomic`.

<sup>Written for commit 9052f9bc81be57f449ab32ddb7c86c3e6db1eb81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

