### PR TITLE
apps+cli: island validator survives Worker bundles — the real apps-create killer, found by live e2e

### DIFF
--- a/.changeset/e2e-workers-findings.md
+++ b/.changeset/e2e-workers-findings.md
@@ -1,0 +1,13 @@
+---
+"@vendoai/apps": patch
+"@vendoai/vendo": patch
+---
+
+Two fixes from the first full init→app-generated e2e on real workerd:
+the island TSX validator's esbuild import is now bundler-blind (Wrangler
+inlined the Node-only package into Worker bundles, where its __filename
+crash was misread as "invalid TSX" and failed EVERY app build — the field
+report's apps-create death), and a validator that crashes at runtime now
+degrades to no validation instead of failing every island. The CLI also
+accepts `--framework custom` (the flag whitelist had missed it; only the
+programmatic path worked).

--- a/packages/apps/src/engine.bundler-safety.e2e.test.ts
+++ b/packages/apps/src/engine.bundler-safety.e2e.test.ts
@@ -45,8 +45,15 @@ const NAKED_ESBUILD_IMPORT = /import\(\s*["']esbuild["']\s*\)/;
  *  directives immediately precede the specifier, inside the `import(...)`
  *  call. Both are asserted (not just one) because real hosts build with
  *  either bundler depending on their Next.js mode/version. */
+/** 2026-07 Workers field failure: the LITERAL guarded form was still
+ *  hard-resolved by esbuild-the-bundler (Wrangler ignores webpack-dialect
+ *  comments), inlining esbuild-the-package into Worker bundles where its
+ *  __filename reference crashed the island validator and failed every app
+ *  build. The guard is now a MUTABLE SPECIFIER (invisible to every bundler,
+ *  still a plain dynamic import under Node/Vitest) with the magic comments
+ *  kept so webpack/turbopack emit no critical-dependency warning. */
 const GUARDED_ESBUILD_IMPORT =
-  /import\(\s*\/\*\s*webpackIgnore:\s*true\s*\*\/\s*\/\*\s*turbopackIgnore:\s*true\s*\*\/\s*["']esbuild["']\s*\)/;
+  /import\(\s*\/\*\s*webpackIgnore:\s*true\s*\*\/\s*\/\*\s*turbopackIgnore:\s*true\s*\*\/\s*(?:\/\*\s*@vite-ignore\s*\*\/\s*)?ESBUILD_SPECIFIER\s*\)/;
 
 function buildDistEngineSource(): string {
   execFileSync("npx", ["tsc", "-p", "tsconfig.json"], { cwd: PACKAGE_DIR, stdio: "pipe" });

--- a/packages/apps/src/engine.ts
+++ b/packages/apps/src/engine.ts
@@ -751,9 +751,18 @@ const normalizeIslandSource = (source: string): string => {
  *  "invalid utf-8 sequence" on esbuild's platform binary; with them, the
  *  same host builds clean with esbuild left OUT of `serverExternalPackages`
  *  entirely (corpus-triage Task 10). */
+/** Routed through a mutable binding so NO bundler statically resolves the
+    optional validator: the ignore comments above only speak webpack dialect,
+    and Wrangler (esbuild-the-bundler) inlined esbuild-the-package into Worker
+    bundles, where its lib/main.js dies on `__filename` the moment the
+    transform runs — misread below as "invalid TSX", failing EVERY island and
+    therefore every app build on Workers (the 2026-07 field report's
+    apps-create death; same class as the e2b import). */
+let ESBUILD_SPECIFIER = "esbuild";
+
 const esbuildTransform = (async () => {
   try {
-    const esbuild = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ "esbuild");
+    const esbuild = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ ESBUILD_SPECIFIER) as { transformSync: (source: string, options: { loader: string }) => unknown };
     return (source: string) => void esbuild.transformSync(source, { loader: "tsx" });
   } catch {
     return undefined;
@@ -821,7 +830,7 @@ const prepareIslands = async (
     ...RESERVED_COMPONENT_NAMES,
     ...KIT_WIRE_COMPONENT_NAMES,
   ]);
-  const transform = await esbuildTransform;
+  let transform = await esbuildTransform;
   for (const [name, rawSource] of Object.entries(rawComponents)) {
     if (unreachableIslandNames.has(name)) {
       issues.push(`island "${name}" would never render — component names resolve host catalog → built-ins (Kit/prewired) → islands, so "${name}" always resolves to the built-in/host component instead. Rename the island to a distinct PascalCase name.`);
@@ -875,7 +884,17 @@ const prepareIslands = async (
     try {
       transform(source);
     } catch (error) {
-      issues.push(`island "${name}" is not valid TSX: ${error instanceof Error ? error.message.split("\n")[0] : "syntax error"}`);
+      // Only a real syntax verdict may fail the island: esbuild transform
+      // errors carry an `errors` array. Anything else means the VALIDATOR
+      // broke (a runtime without its native binary, an inlined bundle
+      // resolving __filename) — best-effort validation degrades to none
+      // instead of failing every island in the build.
+      if (typeof error === "object" && error !== null && Array.isArray((error as { errors?: unknown }).errors)) {
+        issues.push(`island "${name}" is not valid TSX: ${error instanceof Error ? error.message.split("\n")[0] : "syntax error"}`);
+      } else {
+        console.warn(`[vendo] island TSX validation unavailable on this runtime (${error instanceof Error ? error.message.split("\n")[0] : String(error)}); islands ship unvalidated`);
+        transform = undefined;
+      }
     }
   }
   return { components, componentTools, issues };

--- a/packages/apps/src/island-validator.test.ts
+++ b/packages/apps/src/island-validator.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+/** The failure classes the island validation catch must separate (field case
+ *  2026-07: an inlined esbuild dying on __filename in workerd was misread as
+ *  "invalid TSX" for EVERY island, failing every app build on Workers). The
+ *  discriminator is esbuild's TransformError shape: a real syntax verdict
+ *  carries an `errors` array; a broken validator throws anything else. */
+const isSyntaxVerdict = (error: unknown): boolean =>
+  typeof error === "object" && error !== null && Array.isArray((error as { errors?: unknown }).errors);
+
+describe("island validator error classification", () => {
+  it("an esbuild TransformError (errors array) is a syntax verdict", () => {
+    const transformError = Object.assign(new Error("Expected \")\" but found \"}\""), { errors: [{}] });
+    expect(isSyntaxVerdict(transformError)).toBe(true);
+  });
+
+  it("a runtime crash of the validator itself is NOT a syntax verdict", () => {
+    expect(isSyntaxVerdict(new ReferenceError("__filename is not defined"))).toBe(false);
+    expect(isSyntaxVerdict(new Error("spawnSync esbuild ENOENT"))).toBe(false);
+  });
+});

--- a/packages/vendo/src/cli.test.ts
+++ b/packages/vendo/src/cli.test.ts
@@ -105,7 +105,7 @@ describe("vendo CLI commands", () => {
     expect(error.mock.calls.flat().join("\n")).toContain("--auth must be one of authJs, clerk, supabase, auth0, jwt, none");
 
     expect(await main(["init", root, "--framework", "rails"])).toBe(1);
-    expect(error.mock.calls.flat().join("\n")).toContain("--framework must be next or express");
+    expect(error.mock.calls.flat().join("\n")).toContain("--framework must be next, express, or custom");
 
     expect(await main(["init", root, "--cloud-key", "not-a-key"])).toBe(1);
     expect(error.mock.calls.flat().join("\n")).toContain("--cloud-key must be a Vendo Cloud key");

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -78,7 +78,7 @@ const INIT_VALUE_OPTIONS = ["--auth", "--framework", "--cloud-key", "--theme", "
 /** Agent-install-dx: every init wizard question has a value-flag answer; a
     bad value fails as loudly as an unknown flag, with the valid choices. */
 const INIT_AUTH_VALUES = ["authJs", "clerk", "supabase", "auth0", "jwt", "none"];
-const INIT_FRAMEWORK_VALUES = ["next", "express"];
+const INIT_FRAMEWORK_VALUES = ["next", "express", "custom"];
 const INIT_ENGINE_VALUES = ["claude", "codex", "npx"];
 const EXTRACT_FLAGS = new Set(["--force"]);
 const EXTRACT_VALUE_OPTIONS = ["--apply"];
@@ -184,7 +184,7 @@ export async function main(argv: string[]): Promise<number> {
     }
     const framework = option(args, "--framework");
     if (framework !== undefined && !INIT_FRAMEWORK_VALUES.includes(framework)) {
-      problems.push("--framework must be next or express (example: vendo init --framework next)");
+      problems.push("--framework must be next, express, or custom (example: vendo init --framework custom for a Cloudflare Worker / Bun / Deno host)");
     }
     const cloudKey = option(args, "--cloud-key");
     if (cloudKey !== undefined && !isVendoKey(cloudKey)) {

--- a/scripts/portability-gate.mjs
+++ b/scripts/portability-gate.mjs
@@ -52,6 +52,7 @@ const FORBIDDEN_INPUTS = [
   { fragment: "node_modules/.pnpm/pg@", seam: "#store/db conditions" },
   { fragment: "node_modules/.pnpm/typescript@", seam: "@vendoai/actions/sync subpath split" },
   { fragment: "node_modules/.pnpm/e2b@", seam: "bundler-blind e2b specifier (apps/src/e2b)" },
+  { fragment: "node_modules/.pnpm/esbuild@", seam: "bundler-blind esbuild specifier (apps/src/engine island validator)" },
 ];
 
 /** Raw source patterns whose fix classes this gate owns. */
@@ -63,6 +64,10 @@ const SOURCE_GUARDS = [
   {
     pattern: /await import\((?:\/\*[^*]*\*\/\s*)*["']e2b["']\)/,
     message: "literal import(\"e2b\") — esbuild hard-resolves it; route through the bundler-blind specifier in packages/apps/src/e2b",
+  },
+  {
+    pattern: /await import\((?:\/\*[^*]*\*\/\s*)*["']esbuild["']\)/,
+    message: "literal import(\"esbuild\") — Wrangler inlines the Node-only package into Worker bundles (island validator field failure); use the mutable-specifier pattern",
   },
 ];
 


### PR DESCRIPTION
## How this was found

First full end-to-end on the published packages: fresh host → `vendo init --framework custom` (0.4.7 from the registry) → `wrangler dev` on real workerd → chat turn → app generation. Two shipped bugs surfaced; both fixed here with the e2e as proof.

## Bug 1 — every app build fails on Workers (the field report's apps-create death)

The island TSX validator lazily imports **esbuild** with webpack/turbopack ignore comments — the *same* pattern class #513 fixed for e2b. Wrangler (esbuild-the-bundler) ignores those comments, inlines esbuild-the-package into the Worker bundle, and its `lib/main.js` dies on `__filename` the moment the transform runs. The validator's catch misread that runtime crash as `island "X" is not valid TSX` — every island rejected → empty tree → `app build failed: generation failed`, on every request.

Fix, two layers:
- the import rides a mutable specifier (bundler-blind everywhere; magic comments kept so webpack emits no critical-dependency warning) — the existing `engine.bundler-safety.e2e.test.ts` pin is upgraded to assert the stronger form;
- a validator that crashes at runtime (anything without esbuild's `errors` array) now degrades to unvalidated islands with one server warn, instead of failing every island — a broken validator must never be a build verdict.

The portability gate now also forbids `esbuild` in the worker server graph and greps the literal-import hazard, so this class is CI-caught from now on.

**Proof:** the same workerd fixture that failed 3/3 app builds before the fix generated a working Pomodoro app (valid `vendo/app@1`, 3-node tree, live island source) immediately after.

## Bug 2 — `--framework custom` rejected by the CLI

#519 taught init the custom framework but missed the CLI's own flag whitelist (`INIT_FRAMEWORK_VALUES`), so `vendo init --framework custom` failed argument validation in 0.4.4+ while the programmatic path worked. Whitelist + error message + test updated.

## Verification

Full `build/test/typecheck/lint` green (lint includes the extended gate); apps suite 586 passed incl. new classification tests and the upgraded bundler-safety pin; cli tests 10/10. Live e2e transcript: three consecutive `build-failed` before, `Pomodoro` app document after.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes app builds on Cloudflare Workers by making the island TSX validator’s `esbuild` import bundler-blind and downgrading validator runtime crashes to a warning so islands still build. Also lets the CLI accept `--framework custom`.

- **Bug Fixes**
  - Apps: use a mutable `esbuild` specifier in the validator so bundlers don’t inline Node-only code; avoids `__filename` crashes misreported as “invalid TSX.”
  - Apps: if the validator crashes without an `errors` array, skip TSX validation and warn once instead of failing all islands.
  - Apps: portability gate forbids `esbuild` in the worker server graph and flags literal `import("esbuild")`.
  - Apps: tests updated for bundler safety and error classification.
  - CLI: `--framework custom` added to the whitelist and error message.

<sup>Written for commit 9c5f4b5784dd30048154e7ce1b8007f6210cfd85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

