### PR TITLE
docs: name the custom framework path on the init page; troubleshoot the edge-seam refusals

### DIFF
--- a/docs-site/connect/vendo-init.mdx
+++ b/docs-site/connect/vendo-init.mdx
@@ -82,14 +82,18 @@ Init detects two frameworks by dependency and scaffolds only what applies:
   registry. Two manual steps remain, which init prints: mount the adapter with
   `app.use("/api/vendo", mountVendo())` and wrap the client entry in
   `<VendoRoot>`. `vendo doctor` reports broken until both are done.
+- **Everything else** (`--framework custom`, and the automatic landing for a
+  host with neither dependency): a runtime-neutral `vendo/server.ts` — one
+  exported `handleVendoRequest(request, env)` taking a web `Request` and
+  returning a `Response`, constructed lazily on the first request. Cloudflare
+  Workers, Bun, Deno, Hono, and Lambda adapters all mount it in one line. See
+  [Edge runtimes](/deploy/edge-runtimes) for the wiring and the adapter rules.
 
 Init checks `next` first, so an app with both dependencies gets the Next
-scaffold: framework detection precedence is Next.js over Express. Interactively,
-a host with neither is treated as Next. A non-interactive run (`--yes` or no
-TTY) with no detected framework errors and asks for `--framework` rather than
-guessing. For other runtimes (Fastify, Hono, Bun), follow the Express shape by
-hand. See
-[Quickstart: Express and other JavaScript servers](/quickstart#wire-the-express-adapter).
+scaffold: framework detection precedence is Next.js over Express, and a host
+with neither lands on the custom scaffold. A non-interactive run (`--yes` or
+no TTY) with no detected framework still errors and asks for an explicit
+`--framework` rather than guessing on an agent's behalf.
 
 ### Auth
 

--- a/docs-site/deploy/troubleshooting.mdx
+++ b/docs-site/deploy/troubleshooting.mdx
@@ -58,6 +58,13 @@ Every non-2xx response uses `{ "error": { "code", "message" } }`.
   the direct `@vendoai/vendo` entry to the same version (or drop it and
   depend on `vendoai` only), then reinstall. `vendo doctor` (0.4.3+) flags
   the mismatch.
+- On an edge runtime (Cloudflare Workers, Bun, Deno), a refusal naming the
+  local store engines ("the local store engines … need Node; pass `store:` …")
+  or the dev model ladder ("the dev model ladder needs Node; … pass `model:`
+  explicitly") means an infrastructure seam is unfilled: those two defaults
+  are Node-only by design. Set `VENDO_API_KEY` to wire the Cloud adapters, or
+  pass your own `store:`/`model:` — the generated custom wiring shows both
+  slots. See [Edge runtimes](/deploy/edge-runtimes).
 - Cookie-authenticated mutations require `Content-Type: application/json`.
 - `/tick` requires the configured bearer secret.
 - Webhook verification uses the raw body and delivery headers.


### PR DESCRIPTION
Two gaps found auditing the docs after the edge-portability campaign:

- **`connect/vendo-init.mdx`** only described the Next/Express recipes and still claimed interactive unknown-framework hosts are "treated as Next" — no longer true since #519. The framework section now names the third, runtime-neutral path (`--framework custom`, the automatic landing for undetected hosts), describes the one-function `handleVendoRequest` shape, and links [Edge runtimes](/deploy/edge-runtimes). The stale "follow the Express shape by hand" advice for Hono/Bun is gone — init generates that wiring now.
- **`deploy/troubleshooting.mdx`** gains the one edge-specific entry a current (0.4.8+) user can hit: the deliberate Node-only refusals from the store and model seams on Workers/Bun/Deno, with both remedies (`VENDO_API_KEY` for the Cloud adapters, or explicit `store:`/`model:`).

Docs only, no code. Scoped to current-version behavior per review — no legacy-error entries.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies init docs to add the runtime‑neutral custom path (`--framework custom`) with a one‑function `handleVendoRequest(request, env)`, corrects detection order (Next > Express; undetected hosts use custom), and removes outdated manual Hono/Bun wiring notes. Adds edge‑runtime troubleshooting for Node‑only store/model defaults with remedies: set `VENDO_API_KEY` for Cloud adapters or pass explicit `store:`/`model:`; links to Edge runtimes.

<sup>Written for commit 62909caf9f9eb763ca15149dd3c58f77105319c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

