### PR TITLE
feat(store): knowledge record collections + SCHEMA_VERSION 4->5 (ENG-356)

### DIFF
--- a/.changeset/knowledge-store-ddl.md
+++ b/.changeset/knowledge-store-ddl.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/store": minor
+---
+
+Add the dedicated knowledge record collections `vendo_knowledge_docs` / `vendo_knowledge_chunks` (MCP-door table layout: id/data/refs/created_at/updated_at, GIN index on refs, newest-first keyset index) and bump `SCHEMA_VERSION` 4→5 so existing databases actually create them (the DDL loop only runs while `version < SCHEMA_VERSION` — review fix F1). Both tables join the erase-by-subject/app cascade.

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -78,4 +78,4 @@ Because the registry is a table in the same database, sessions survive restarts 
 
 ## Retention and erasure
 
-`eraseStore(store)` is the store-level erase API — `bySubject(subject)` for full erasure and `byApp(appId)` — cascading the matching rows across all 14 tables (ephemeral subjects included — their rows are ordinary disk rows) and returning per-table deleted counts. It is the only sanctioned deletion path for `vendo_audit` rows. It is also re-exported from `@vendoai/vendo/server`. Host SQL remains available for everything else.
+`eraseStore(store)` is the store-level erase API — `bySubject(subject)` for full erasure and `byApp(appId)` — cascading the matching rows across all 16 tables (ephemeral subjects included — their rows are ordinary disk rows) and returning per-table deleted counts. It is the only sanctioned deletion path for `vendo_audit` rows. It is also re-exported from `@vendoai/vendo/server`. Host SQL remains available for everything else.

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -31,10 +31,13 @@ For production, pass a Postgres connection string explicitly, for example `creat
 | `vendo_mcp_clients` | `id, data, refs, created_at, updated_at` | door-owned MCP client state |
 | `vendo_mcp_grants` | `id, data, refs, created_at, updated_at` | door-owned MCP grant state |
 | `vendo_sessions` | `subject, touched_at` | ephemeral (anonymous) session registry: last-activity touch per session, read by the TTL sweep |
+| `vendo_knowledge_docs` | `id, data, refs, created_at, updated_at` | knowledge corpus documents (built-in local engine) |
+| `vendo_knowledge_chunks` | `id, data, refs, created_at, updated_at` | knowledge corpus chunks (built-in local engine index) |
 
 App storage uses `app:<appId>:<name>` by convention. App-scoped record and blob WRITES require an existing `vendo_apps` row and fail closed with `not-found` ("session may have expired") when there is none — the app never existed, or its ephemeral session was swept; reads on a missing app return empty. Except for the reserved names below, collection names remain opaque and use `vendo_records`; non-`app:`-prefixed collections and namespaces have no principal linkage.
 
-Generic record collections and the two door-owned tables expose the optional
+Generic record collections and the dedicated door-owned and knowledge tables
+expose the optional
 `RecordStore.claim` capability: one database statement compares the current
 `data` and `refs`, then replaces or deletes the row. Exactly one concurrent
 claimant receives `true`.
@@ -55,8 +58,10 @@ Blocks receive core's plain `StoreAdapter`, so these exact `records()` collectio
 | `vendo_apps` | app id | `{ subject, enabled, doc }` | `subject` | table `created_at` / `updated_at` |
 | `vendo_mcp_clients` | client id | block-internal JSON | caller-supplied, arbitrary keys | table `created_at` / `updated_at` |
 | `vendo_mcp_grants` | grant id | block-internal JSON | caller-supplied, arbitrary keys | table `created_at` / `updated_at` |
+| `vendo_knowledge_docs` | doc id | knowledge-engine JSON | caller-supplied, arbitrary keys | table `created_at` / `updated_at` |
+| `vendo_knowledge_chunks` | chunk id | knowledge-engine JSON | caller-supplied, arbitrary keys | table `created_at` / `updated_at` |
 
-Typed reserved writes validate their data, require embedded ids to match the record id, and upsert the typed row — with two enforced exceptions. `vendo_audit` is append-only: `put` on an existing id and `delete` are both refused; audit rows are erased only through the erase API below. `vendo_apps`, `vendo_grants`, and `vendo_threads` refuse cross-subject flips atomically: a put whose id already belongs to another subject fails with a conflict. The data is authoritative: caller-supplied `refs` are ignored on write and synthesized from typed columns on read. Their routed `list({ refs })` accepts only the refs shown above. The two door-owned collections use generic record semantics in dedicated tables: the store does not validate their block-internal payloads, and refs filters accept arbitrary keys. Generic and routed record lists are uniformly newest-first by `(createdAt, id)`.
+Typed reserved writes validate their data, require embedded ids to match the record id, and upsert the typed row — with two enforced exceptions. `vendo_audit` is append-only: `put` on an existing id and `delete` are both refused; audit rows are erased only through the erase API below. `vendo_apps`, `vendo_grants`, and `vendo_threads` refuse cross-subject flips atomically: a put whose id already belongs to another subject fails with a conflict. The data is authoritative: caller-supplied `refs` are ignored on write and synthesized from typed columns on read. Their routed `list({ refs })` accepts only the refs shown above. The door-owned and knowledge collections use generic record semantics in dedicated tables: the store does not validate their payloads, and refs filters accept arbitrary keys. Generic and routed record lists are uniformly newest-first by `(createdAt, id)`.
 
 Ephemeral principals take the SAME path as everyone else: their rows are ordinary disk rows under their subject. What makes a session ephemeral is its registration (`registerEphemeralSubject`); see the lifecycle section below.
 

--- a/packages/store/src/erase.conformance.test.ts
+++ b/packages/store/src/erase.conformance.test.ts
@@ -85,6 +85,18 @@ for (const backend of backends()) {
         data: { open: true },
         refs: { subject: erased },
       });
+      // Knowledge corpus rows carrying the subject as a ref — exercise the new
+      // dedicated-table cascade (they'd read 0 and hide a broken DELETE if unseeded).
+      await store.records("vendo_knowledge_docs").put({
+        id: "kn_doc_erase_target",
+        data: { title: "mine" },
+        refs: { subject: erased },
+      });
+      await store.records("vendo_knowledge_chunks").put({
+        id: "kn_chunk_erase_target",
+        data: { text: "mine" },
+        refs: { subject: erased },
+      });
 
       // Seed the bystander, who must survive untouched.
       const bystanderDoc = appFixture("app_erase_bystander");
@@ -116,8 +128,8 @@ for (const backend of backends()) {
         vendo_mcp_clients: 0,
         vendo_mcp_grants: 1,
         vendo_sessions: 0, // durable subject — never registered as a session
-        vendo_knowledge_docs: 0, // no knowledge corpus seeded for this subject
-        vendo_knowledge_chunks: 0,
+        vendo_knowledge_docs: 1,
+        vendo_knowledge_chunks: 1,
       });
 
       // Gone through the doors...
@@ -195,6 +207,7 @@ for (const backend of backends()) {
         await store.records("vendo_grants").put({ id: grant.id, data: grant });
         const event = auditFixture(`aud_${id}`, { principal: { kind: "user", subject }, appId: id });
         await store.records("vendo_audit").put({ id: event.id, data: event });
+        await store.records("vendo_knowledge_docs").put({ id: `kn_${id}`, data: { t: id }, refs: { app_id: id } });
       };
       await seedApp("app_erase_drop");
       await seedApp("app_erase_keep");
@@ -211,6 +224,7 @@ for (const backend of backends()) {
       expect(report.vendo_runs).toBe(1);
       expect(report.vendo_grants).toBe(1);
       expect(report.vendo_audit).toBe(1);
+      expect(report.vendo_knowledge_docs).toBe(1);
       expect(report.vendo_threads).toBe(0); // no app axis (§2) — subject/age cover threads
 
       expect(await store.records("vendo_apps").get("app_erase_drop")).toBeNull();
@@ -221,6 +235,7 @@ for (const backend of backends()) {
       expect(await store.records("vendo_runs").get("run_app_erase_keep")).not.toBeNull();
       expect(await store.records("vendo_grants").get("grt_app_erase_keep")).not.toBeNull();
       expect(await store.records("vendo_audit").get("aud_app_erase_keep")).not.toBeNull();
+      expect(await store.records("vendo_knowledge_docs").get("kn_app_erase_keep")).not.toBeNull();
       expect(await store.records("vendo_threads").get("thr_erase_by_app")).not.toBeNull();
     });
   });

--- a/packages/store/src/erase.conformance.test.ts
+++ b/packages/store/src/erase.conformance.test.ts
@@ -7,7 +7,7 @@ import { appFixture, approvalFixture, auditFixture, grantFixture } from "./fixtu
 import { appStore, grantStore, registerEphemeralSubject } from "./index.js";
 
 // 02-store §5: "A store-level erase API ... erases by subject (full erasure)
-// or by app, cascading the matching data across all 14 tables, and is
+// or by app, cascading the matching data across all 16 tables, and is
 // exposed on the umbrella. It is the only sanctioned deletion path for audit
 // rows."
 
@@ -116,6 +116,8 @@ for (const backend of backends()) {
         vendo_mcp_clients: 0,
         vendo_mcp_grants: 1,
         vendo_sessions: 0, // durable subject — never registered as a session
+        vendo_knowledge_docs: 0, // no knowledge corpus seeded for this subject
+        vendo_knowledge_chunks: 0,
       });
 
       // Gone through the doors...

--- a/packages/store/src/erase.ts
+++ b/packages/store/src/erase.ts
@@ -23,6 +23,8 @@ export const ERASE_TABLES = [
   "vendo_mcp_clients",
   "vendo_mcp_grants",
   "vendo_sessions",
+  "vendo_knowledge_docs",
+  "vendo_knowledge_chunks",
 ] as const;
 
 export type EraseTable = typeof ERASE_TABLES[number];
@@ -36,7 +38,7 @@ function emptyReport(): EraseReport {
 
 /**
  * 02-store §5 — the store-level erase API: by subject (full erasure) or by
- * app, cascading the matching data across all 14 tables of §2's map. It is
+ * app, cascading the matching data across all 16 tables of §2's map. It is
  * the ONLY sanctioned deletion path for `vendo_audit` rows — the routed door
  * refuses audit deletion (§2); this API reaches the tables directly.
  * Ephemeral subjects are erased the same way (their rows are ordinary disk
@@ -109,6 +111,10 @@ export function eraseStore(store: VendoStore): {
       await del(report, "vendo_records", "refs @> $1::jsonb", [subjectRef]);
       await del(report, "vendo_mcp_clients", "refs @> $1::jsonb", [subjectRef]);
       await del(report, "vendo_mcp_grants", "refs @> $1::jsonb", [subjectRef]);
+      // Knowledge corpus rows the subject axis reaches carry the subject only as
+      // a ref, same as the door tables (the knowledge engine owns what it refs).
+      await del(report, "vendo_knowledge_docs", "refs @> $1::jsonb", [subjectRef]);
+      await del(report, "vendo_knowledge_chunks", "refs @> $1::jsonb", [subjectRef]);
       // The session registration (if any) is retired with the data (§4).
       await del(report, "vendo_sessions", "subject = $1", [subject]);
       return report;
@@ -129,6 +135,9 @@ export function eraseStore(store: VendoStore): {
       await del(report, "vendo_records", "refs @> $1::jsonb", [appRef]);
       await del(report, "vendo_mcp_clients", "refs @> $1::jsonb", [appRef]);
       await del(report, "vendo_mcp_grants", "refs @> $1::jsonb", [appRef]);
+      // An app's knowledge corpus (docs + their chunks) goes with the app.
+      await del(report, "vendo_knowledge_docs", "refs @> $1::jsonb", [appRef]);
+      await del(report, "vendo_knowledge_chunks", "refs @> $1::jsonb", [appRef]);
       return report;
     },
   };

--- a/packages/store/src/records.ts
+++ b/packages/store/src/records.ts
@@ -21,7 +21,11 @@ import {
   unknownAppError,
 } from "./helpers/utils.js";
 
-export type DedicatedRecordTable = "vendo_mcp_clients" | "vendo_mcp_grants";
+export type DedicatedRecordTable =
+  | "vendo_mcp_clients"
+  | "vendo_mcp_grants"
+  | "vendo_knowledge_docs"
+  | "vendo_knowledge_chunks";
 
 function recordFromRow(row: Record<string, unknown>): VendoRecord {
   const refs = row["refs"] as Record<string, string> | null;

--- a/packages/store/src/routing.test.ts
+++ b/packages/store/src/routing.test.ts
@@ -117,7 +117,7 @@ for (const backend of backends()) {
       expect(new Set(seen).size).toBe(ids.length);
     });
 
-    for (const collection of ["vendo_mcp_clients", "vendo_mcp_grants"] as const) {
+    for (const collection of ["vendo_mcp_clients", "vendo_mcp_grants", "vendo_knowledge_docs", "vendo_knowledge_chunks"] as const) {
       it(`round-trips ${collection} through its dedicated generic table`, async () => {
         const records = made.store.records(collection);
         const id = `${collection}_roundtrip`;

--- a/packages/store/src/routing.ts
+++ b/packages/store/src/routing.ts
@@ -52,7 +52,12 @@ export const RESERVED_COLLECTIONS = [
   "vendo_state",
 ] as const;
 
-export const DEDICATED_RECORD_COLLECTIONS = ["vendo_mcp_clients", "vendo_mcp_grants"] as const;
+export const DEDICATED_RECORD_COLLECTIONS = [
+  "vendo_mcp_clients",
+  "vendo_mcp_grants",
+  "vendo_knowledge_docs",
+  "vendo_knowledge_chunks",
+] as const;
 
 export type ReservedCollection = typeof RESERVED_COLLECTIONS[number];
 

--- a/packages/store/src/schema.test.ts
+++ b/packages/store/src/schema.test.ts
@@ -21,6 +21,8 @@ const CONTRACT_COLUMNS: Record<string, string[]> = {
   vendo_mcp_clients: ["id", "data", "refs", "created_at", "updated_at"],
   vendo_mcp_grants: ["id", "data", "refs", "created_at", "updated_at"],
   vendo_sessions: ["subject", "touched_at"],
+  vendo_knowledge_docs: ["id", "data", "refs", "created_at", "updated_at"],
+  vendo_knowledge_chunks: ["id", "data", "refs", "created_at", "updated_at"],
 };
 
 for (const backend of backends()) {
@@ -41,17 +43,17 @@ for (const backend of backends()) {
     it("stores schema_version and a boot_id in vendo_meta", async () => {
       const rows = await made.sql("SELECT key, value FROM vendo_meta ORDER BY key");
       expect(rows).toEqual(expect.arrayContaining([
-        expect.objectContaining({ key: "schema_version", value: 4 }),
+        expect.objectContaining({ key: "schema_version", value: 5 }),
         expect.objectContaining({ key: "boot_id" }),
       ]));
       expect(rows.find((row) => row.key === "boot_id")?.value).toEqual(expect.any(String));
     });
 
-    it("lands a fresh database directly on schema version 4", async () => {
+    it("lands a fresh database directly on schema version 5", async () => {
       // A brand-new DB never runs the v2 backfill's DELETE against real data; it
       // just records the current version. (beforeAll already ran ensureSchema.)
       const version = (await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value;
-      expect(version).toBe(4);
+      expect(version).toBe(5);
     });
 
     it("keeps boot_id stable across a close and reopen", async () => {
@@ -71,7 +73,7 @@ for (const backend of backends()) {
 
       await made.store.ensureSchema();
 
-      expect((await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value).toBe(4);
+      expect((await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value).toBe(5);
       const rows = await made.sql(
         `SELECT table_name FROM information_schema.tables
          WHERE table_schema = 'public' AND table_name IN ('vendo_mcp_clients', 'vendo_mcp_grants')
@@ -95,7 +97,7 @@ for (const backend of backends()) {
 
       await made.store.ensureSchema();
 
-      expect((await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value).toBe(4);
+      expect((await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value).toBe(5);
       const survivor = await made.sql(
         "SELECT id FROM vendo_records WHERE collection = 'vendo_state' AND id = 'app_live:subject_live'",
       );
@@ -103,7 +105,7 @@ for (const backend of backends()) {
       await made.sql("DELETE FROM vendo_records WHERE collection = 'vendo_state' AND id = 'app_live:subject_live'");
     });
 
-    it("creates all 14 contract tables with every contracted key column", async () => {
+    it("creates all 16 contract tables with every contracted key column", async () => {
       const rows = await made.sql(
         "SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name LIKE 'vendo_%'",
       );
@@ -114,7 +116,7 @@ for (const backend of backends()) {
         columns.add(String(row.column_name));
         actual.set(table, columns);
       }
-      expect(actual.size).toBe(14);
+      expect(actual.size).toBe(16);
       for (const [table, columns] of Object.entries(CONTRACT_COLUMNS)) {
         expect(actual.has(table), table).toBe(true);
         for (const column of columns) expect(actual.get(table)?.has(column), `${table}.${column}`).toBe(true);
@@ -137,6 +139,8 @@ for (const backend of backends()) {
         ["vendo_runs", "record"],
         ["vendo_mcp_clients", "data"],
         ["vendo_mcp_grants", "data"],
+        ["vendo_knowledge_docs", "data"],
+        ["vendo_knowledge_chunks", "data"],
       ];
       const rows = await made.sql(
         "SELECT table_name, column_name, data_type FROM information_schema.columns WHERE table_schema = 'public' AND table_name LIKE 'vendo_%'",
@@ -151,7 +155,7 @@ for (const backend of backends()) {
 
     // Parameterized over vendo_records plus the wave-6 door tables (supersedes a
     // single-table check): every refs column the host joins on gets a GIN index.
-    for (const table of ["vendo_records", "vendo_mcp_clients", "vendo_mcp_grants"] as const) {
+    for (const table of ["vendo_records", "vendo_mcp_clients", "vendo_mcp_grants", "vendo_knowledge_docs", "vendo_knowledge_chunks"] as const) {
       it(`creates a GIN index on ${table}.refs`, async () => {
         const rows = await made.sql(
           "SELECT indexdef FROM pg_indexes WHERE schemaname = 'public' AND tablename = $1",

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -12,8 +12,15 @@ import { withSchemaLock } from "#store/db";
 
     v4 (kill-list §B3) adds `vendo_sessions`: the ephemeral in-memory overlay is
     gone, anonymous rows are ordinary disk rows, and this table is the session
-    registry the TTL sweep reads (02 §4). */
-export const SCHEMA_VERSION = 4;
+    registry the TTL sweep reads (02 §4).
+
+    v5 (ENG-356, knowledge design v2 (2026-07-22) R1) adds the dedicated
+    knowledge record collections `vendo_knowledge_docs` / `vendo_knowledge_chunks`.
+    Bumping the version is load-bearing, not cosmetic (review fix F1): the DDL
+    loop runs only while `version < SCHEMA_VERSION`, so appending the tables
+    WITHOUT this bump would leave every existing v4 database on 4 forever and the
+    new tables would never be created. */
+export const SCHEMA_VERSION = 5;
 
 /** 02-store §2 */
 export const DDL = [
@@ -85,6 +92,23 @@ export const DDL = [
   `CREATE TABLE IF NOT EXISTS vendo_sessions (
     subject text PRIMARY KEY, touched_at timestamptz NOT NULL
   )`,
+  // 02-store §2 + knowledge design v2 (2026-07-22) R1 (ENG-356, v5): the
+  // dedicated knowledge record collections. `vendo_knowledge_docs` is one row
+  // per document-level corpus entry; `vendo_knowledge_chunks` is one row per
+  // engine-minted chunk of a synced doc (the local engine's index — the cloud
+  // engine keeps its corpus server-side and never populates these). Same
+  // id/data/refs/created_at/updated_at layout as the MCP door tables; `refs`
+  // carries the subject/app keys the erase cascade matches (§5).
+  `CREATE TABLE IF NOT EXISTS vendo_knowledge_docs (
+    id text PRIMARY KEY, data jsonb NOT NULL, refs jsonb,
+    created_at timestamptz NOT NULL, updated_at timestamptz NOT NULL
+  )`,
+  "CREATE INDEX IF NOT EXISTS vendo_knowledge_docs_refs_idx ON vendo_knowledge_docs USING GIN (refs jsonb_path_ops)",
+  `CREATE TABLE IF NOT EXISTS vendo_knowledge_chunks (
+    id text PRIMARY KEY, data jsonb NOT NULL, refs jsonb,
+    created_at timestamptz NOT NULL, updated_at timestamptz NOT NULL
+  )`,
+  "CREATE INDEX IF NOT EXISTS vendo_knowledge_chunks_refs_idx ON vendo_knowledge_chunks USING GIN (refs jsonb_path_ops)",
 ] as const;
 
 // Additive columns stay compatible with same-version development databases (02 §2
@@ -115,6 +139,11 @@ const ADDITIVE_DDL = [
   "CREATE INDEX IF NOT EXISTS vendo_records_collection_created_idx ON vendo_records (collection, created_at DESC, id DESC)",
   "CREATE INDEX IF NOT EXISTS vendo_mcp_clients_created_idx ON vendo_mcp_clients (created_at DESC, id DESC)",
   "CREATE INDEX IF NOT EXISTS vendo_mcp_grants_created_idx ON vendo_mcp_grants (created_at DESC, id DESC)",
+  // The knowledge collections list newest-first for the corpus read-back
+  // (status()/listing, F2's 1000-row page bound), same keyset shape as the door
+  // tables above.
+  "CREATE INDEX IF NOT EXISTS vendo_knowledge_docs_created_idx ON vendo_knowledge_docs (created_at DESC, id DESC)",
+  "CREATE INDEX IF NOT EXISTS vendo_knowledge_chunks_created_idx ON vendo_knowledge_chunks (created_at DESC, id DESC)",
   // The automations tick and vendo.emit fetch apps by trigger kind (schedule / host-event).
   // A STORED generated column projects doc->trigger->on->kind into an indexable value so
   // those paths query only the matching apps instead of scanning every app for every subject.

--- a/packages/store/src/state-routing.test.ts
+++ b/packages/store/src/state-routing.test.ts
@@ -339,7 +339,7 @@ for (const backend of backends()) {
 
       // The v1 -> v3 upgrade performs the (v2) backfill on the way through.
       await made.store.ensureSchema();
-      expect((await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value).toBe(4);
+      expect((await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value).toBe(5);
 
       expect(await made.sql(
         "SELECT app_id, subject, data FROM vendo_state WHERE app_id = 'app_legacy'",


### PR DESCRIPTION
Closes ENG-356 (Stage 0 — Foundations, @vendoai/knowledge). Builds on Amr's contract freeze (#543) and wire protocol (#545).

## What

Adds the store-side home for the knowledge corpus, in `@vendoai/store`:

- **Two dedicated record collections** in `schema.ts` `DDL` — `vendo_knowledge_docs` (one row per document-level corpus entry) and `vendo_knowledge_chunks` (one row per engine-minted chunk of a synced doc; the local engine's index — the cloud engine keeps its corpus server-side and never populates these). Same `id / data / refs / created_at / updated_at` layout as the MCP door tables, each with a `refs` GIN index (`jsonb_path_ops`) and a newest-first keyset index in `ADDITIVE_DDL` (F2's 1000-row page bound).
- **`SCHEMA_VERSION` 4 → 5.** This is load-bearing, not cosmetic — the fix the ticket calls F1: the `DDL` loop runs only while `version < SCHEMA_VERSION`, so appending the tables **without** the bump would leave every existing v4 database on 4 forever and the new tables would never be created.
- **Erase cascade.** Both tables join `ERASE_TABLES` and the `bySubject` / `byApp` cascades via `refs @> selector`, exactly like the door tables (the knowledge engine owns what it refs). The existing `erase.conformance.test.ts` invariant — `ERASE_TABLES` must equal the tables `DDL` creates (+ `vendo_meta`) — keeps the two in lockstep, so a missed cascade entry fails the suite.

Docs/tests updated in step: `schema.test.ts` (contract columns, jsonb columns, GIN-index loop, version + 14→16 table count), `state-routing.test.ts` version assertion, `erase.conformance.test.ts` report + comment, `packages/store/README.md` (14→16 tables).

## Verification

**CI is authoritative for this PR — I could not run the gates locally.** The dev box's git transport resets on any large pack, so the full workspace tree / `node_modules` could not be materialized (I worked from a partial + sparse checkout of `packages/store`). This is the same "CI is authoritative" posture as #543/#545 (there it was the broken Windows turbo binary; here it's the transport). The change is deliberately narrow and self-checking:

- The DDL mirrors the `vendo_mcp_clients` / `vendo_mcp_grants` precedent statement-for-statement.
- `schema.test.ts` asserts the tables, key columns, jsonb storage, and GIN indexes exist; the version-migration tests (v1→current, v2→current) assert the 4→5 landing.
- The `ERASE_TABLES` ⇔ `DDL` invariant test guarantees cascade completeness.

Please confirm the store package's test job (both pglite + postgres backends) is green before merge.

Changeset: minor bump of `@vendoai/store` (fixed lockstep group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qx6i5Q7h2qpvGpRcPXp91n

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->