### PR TITLE
feat(knowledge): scaffold @vendoai/knowledge package (ENG-355)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,6 +13,7 @@
       "@vendoai/automations",
       "@vendoai/ui",
       "@vendoai/mcp",
+      "@vendoai/knowledge",
       "@vendoai/vendo",
       "vendoai"
     ]

--- a/.changeset/scaffold-knowledge-package.md
+++ b/.changeset/scaffold-knowledge-package.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/knowledge": patch
+---
+
+Scaffold `@vendoai/knowledge` — the package that will hold the KnowledgeAdapter engines (local, cloud client, BYO HTTP template) and ingestion, behind core's frozen contract. Stage 0: package + toolchain only, exporting the store collection names the local engine binds to (`vendo_knowledge_docs` / `vendo_knowledge_chunks`). Added to the fixed version-lockstep group.

--- a/packages/knowledge/README.md
+++ b/packages/knowledge/README.md
@@ -1,0 +1,17 @@
+# @vendoai/knowledge
+
+`@vendoai/knowledge` is Vendo's product knowledge base: the concrete retrieval engines and the ingestion pipeline that sit behind core's frozen `KnowledgeAdapter` contract (`@vendoai/core`).
+
+One contract, three engines:
+
+- **Built-in local engine** — lexical retrieval over the host's own store (the free tier), reading and writing the `vendo_knowledge_docs` / `vendo_knowledge_chunks` collections.
+- **Cloud client** — speaks the knowledge wire protocol (`vendo/knowledge-wire@1`) to a managed backend.
+- **BYO HTTP template** — the same wire protocol pointed at a host-supplied endpoint.
+
+Ingestion (parse → normalize → structural chunk → sync) turns a host's local sources into document-level upserts; chunking, embedding, and indexing belong to the engine behind the contract.
+
+The umbrella package wires the resolved adapter into the agent loop so knowledge-backed retrieval grounds chat, generated apps, and action planning with citations, under the same guard policy and audit trail as every other tool.
+
+## Status
+
+Stage 0 scaffold (ENG-355). The package + toolchain are in place; the engines and ingestion land across Stages 1–3 of the knowledge build. See the `@vendoai/knowledge` project in Linear.

--- a/packages/knowledge/package.json
+++ b/packages/knowledge/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@vendoai/knowledge",
+  "version": "0.4.8",
+  "description": "The product knowledge base: KnowledgeAdapter engines (local, cloud client, BYO HTTP) and ingestion, behind core's frozen contract.",
+  "keywords": [
+    "ai",
+    "agent",
+    "rag",
+    "retrieval",
+    "knowledge",
+    "vendo"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/runvendo/vendo.git",
+    "directory": "packages/knowledge"
+  },
+  "homepage": "https://vendo.run",
+  "bugs": "https://github.com/runvendo/vendo/issues",
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@vendoai/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/knowledge/src/index.test.ts
+++ b/packages/knowledge/src/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { KNOWLEDGE_CHUNKS_COLLECTION, KNOWLEDGE_DOCS_COLLECTION } from "./index.js";
+
+describe("@vendoai/knowledge scaffold", () => {
+  it("names the store collections the local engine binds to (ENG-356 DDL)", () => {
+    expect(KNOWLEDGE_DOCS_COLLECTION).toBe("vendo_knowledge_docs");
+    expect(KNOWLEDGE_CHUNKS_COLLECTION).toBe("vendo_knowledge_chunks");
+  });
+});

--- a/packages/knowledge/src/index.ts
+++ b/packages/knowledge/src/index.ts
@@ -1,0 +1,27 @@
+/**
+ * @vendoai/knowledge — the product knowledge base (knowledge design v2,
+ * 2026-07-22).
+ *
+ * This package holds the concrete `KnowledgeAdapter` engines — the built-in
+ * local lexical engine, the cloud client, and the BYO HTTP template — plus the
+ * ingestion pipeline (parse → normalize → structural chunk → sync), all behind
+ * core's frozen contract (`@vendoai/core`, ENG-358).
+ *
+ * Stage 0 (ENG-355) is the scaffold: package + toolchain only. Ingestion lands
+ * in Stage 1 (ENG-361/362), the engines in Stage 2 (ENG-363/364/365).
+ */
+
+/**
+ * The adapter contract every engine in this package implements — re-exported so
+ * consumers pull the seam from the package that ships the engines.
+ */
+export type { KnowledgeAdapter } from "@vendoai/core";
+
+/**
+ * The store record collections backing the built-in local engine, created by
+ * the store DDL (ENG-356). The local engine reads/writes documents and their
+ * chunks through these; the cloud engine keeps its corpus server-side and never
+ * touches them.
+ */
+export const KNOWLEDGE_DOCS_COLLECTION = "vendo_knowledge_docs" as const;
+export const KNOWLEDGE_CHUNKS_COLLECTION = "vendo_knowledge_chunks" as const;

--- a/packages/knowledge/tsconfig.json
+++ b/packages/knowledge/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/knowledge/vitest.config.ts
+++ b/packages/knowledge/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json-summary"],
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: ["src/**/*.test.{ts,tsx}", "src/**/*.test-util.{ts,tsx}"],
+      // No ratcheted threshold yet — this is the Stage 0 scaffold (ENG-355).
+      // The line-coverage floor gets set the way the sibling packages do it
+      // (at/just below the measured value, so it can only rise) once the
+      // engines land in Stage 1/2.
+    },
+    include: ["src/**/*.test.ts"],
+    testTimeout: 30_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1052,6 +1052,22 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)
 
+  packages/knowledge:
+    dependencies:
+      '@vendoai/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.0
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)
+
   packages/mcp:
     dependencies:
       '@modelcontextprotocol/sdk':

--- a/scripts/dependency-guard.mjs
+++ b/scripts/dependency-guard.mjs
@@ -66,6 +66,9 @@ const LAYERS = {
   // the door (10-mcp): depends on core only; the ui/tree shim arrives as a
   // prebuilt committed artifact (built by packages/ui/scripts), never an import
   "@vendoai/mcp": ["@vendoai/core"],
+  // the product knowledge base (knowledge design v2): engines + ingestion behind
+  // core's KnowledgeAdapter contract; core-only, like the other engine blocks
+  "@vendoai/knowledge": ["@vendoai/core"],
   "@vendoai/automations": ["@vendoai/core", "@vendoai/apps"],
   // the canonical umbrella is the only package allowed to depend on every block
   "@vendoai/vendo": "*",


### PR DESCRIPTION
Closes ENG-355 (Stage 0 — Foundations, @vendoai/knowledge).

## What

Scaffolds `packages/knowledge` (`@vendoai/knowledge`) following the `@vendoai/mcp` addition precedent — the package that will hold the retrieval engines (built-in local, cloud client, BYO HTTP template) and the ingestion pipeline, all behind core's frozen `KnowledgeAdapter` contract (#543):

- **Toolchain**: `package.json` (build/test/typecheck/test:coverage, `@vendoai/core` workspace dep), `tsconfig.json` (extends the base, NodeNext, declaration + maps), `vitest.config.ts` (no ratcheted coverage floor yet — set once the engines land, sibling-style), `README.md`.
- **`src/index.ts`**: re-exports core's `KnowledgeAdapter` (the seam this package implements) and names the two store collections the local engine binds to — `vendo_knowledge_docs` / `vendo_knowledge_chunks`, created by the store DDL in #546 (ENG-356) — plus a unit test.
- Picked up automatically by the `packages/*` workspace glob (no `pnpm-workspace.yaml` edit); added to the changeset **fixed** version-lockstep group so it versions with the family.

Engines land in Stage 2 (ENG-363/364/365), ingestion in Stage 1 (ENG-361/362).

## Re-clone main + seam re-verification

The ticket calls for re-syncing main (161 PRs since the 07-18 snapshot) and re-verifying the load-bearing seams before foundations work. Done at the contract level: the branch is cut from current `main` (`f7be05e`), and the two seams this package sits on are present and unchanged — Amr's `@vendoai/core` knowledge contract (`knowledge.ts` / `knowledge-wire.ts`, #543/#545) and the store's dedicated-record-collection precedent (`vendo_mcp_*`, which #546 extends for knowledge).

## Verification

**CI is authoritative for this PR — I could not run the gates locally.** The dev box's git transport resets on any large pack, so the full workspace tree / `node_modules` could not be materialized (I worked from a partial + sparse checkout). The scaffold is a byte-for-byte structural mirror of the green `@vendoai/mcp` package (same tsconfig, same vitest config shape, same script set), so `build` / `typecheck` / `test` should pass on first run; please confirm the `@vendoai/knowledge` jobs are green before merge.

Changeset: patch bump of `@vendoai/knowledge` (fixed lockstep group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qx6i5Q7h2qpvGpRcPXp91n

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->