### PR TITLE
actions: apply overrides.json rules to added sub-registries (#562)

### DIFF
--- a/packages/actions/src/runtime/registry.test.ts
+++ b/packages/actions/src/runtime/registry.test.ts
@@ -104,6 +104,40 @@ describe("createActions registry", () => {
     });
   });
 
+  it("applies overrides to added sub-registries and hides disabled tools", async () => {
+    const host = routeTool("host_probe");
+    const root = await tempVendo(
+      { format: VENDO_TOOLS_FORMAT, tools: [host] },
+      {
+        format: VENDO_OVERRIDES_FORMAT,
+        tools: {
+          sub_hidden: { disabled: true },
+          sub_overridden: { risk: "destructive", description: "Overridden added tool" },
+        },
+      },
+    );
+    const actions = createActions({ dir: root, fetch: vi.fn() as unknown as typeof fetch, baseUrl: "http://stub" });
+    const subRegistry: ToolRegistry = {
+      descriptors: async () => [
+        { name: "sub_hidden", description: "Hidden added", inputSchema: {}, risk: "write" },
+        { name: "sub_overridden", description: "Original added", inputSchema: {}, risk: "read" },
+      ],
+      execute: async () => ({ status: "ok", output: true }),
+    };
+    actions.add(subRegistry);
+
+    const descriptors = await actions.descriptors();
+    expect(descriptors).toEqual([
+      { name: "host_probe", description: "host_probe", inputSchema: { type: "object" }, risk: "read" },
+      { name: "sub_overridden", description: "Overridden added tool", inputSchema: {}, risk: "destructive" },
+    ]);
+
+    await expect(actions.execute({ id: "1", tool: "sub_hidden", args: {} }, ctx)).resolves.toMatchObject({
+      status: "error",
+      error: { code: "not-found" },
+    });
+  });
+
   it("throws validation errors for malformed files", async () => {
     const root = await mkdtemp(join(tmpdir(), "vendo-actions-bad-"));
     roots.push(root);

--- a/packages/actions/src/runtime/registry.ts
+++ b/packages/actions/src/runtime/registry.ts
@@ -786,11 +786,18 @@ export function createActions(config: RegistryConfig): ActionsRegistry {
       for (let index = 0; index < added.length; index += 1) {
         const registry = added[index]!;
         for (let descriptorIndex = 0; descriptorIndex < registryLists[index]!.length; descriptorIndex += 1) {
-          const descriptor = parseToolDescriptor(
+          const rawDescriptor = parseToolDescriptor(
             registryLists[index]![descriptorIndex],
             `added registry[${index}][${descriptorIndex}]`,
           );
-          register(descriptor.name, "added registry", { kind: "registry", descriptor, registry });
+          const merged = mergeOverride(rawDescriptor, host.overrides.tools[rawDescriptor.name]);
+          const { disabled: _disabled, ...descriptor } = merged;
+          register(
+            descriptor.name,
+            "added registry",
+            merged.disabled === true ? undefined : { kind: "registry", descriptor, registry },
+          );
+          primitives.set(descriptor.name, { risk: merged.risk, disabled: merged.disabled === true });
         }
       }
 

--- a/packages/actions/src/runtime/registry.ts
+++ b/packages/actions/src/runtime/registry.ts
@@ -797,7 +797,6 @@ export function createActions(config: RegistryConfig): ActionsRegistry {
             "added registry",
             merged.disabled === true ? undefined : { kind: "registry", descriptor, registry },
           );
-          primitives.set(descriptor.name, { risk: merged.risk, disabled: merged.disabled === true });
         }
       }
 


### PR DESCRIPTION
Fixes #562 
## What

Fixes `overrides.json` rules being bypassed for tools registered via `actions.add(subRegistry)`:
- Updates `createActions()` in `packages/actions/src/runtime/registry.ts` to run `mergeOverride()` against descriptors from sub-registries added via `add()`.
- Ensures overrides in `.vendo/overrides.json` (such as `disabled: true`, `risk`, `critical`, and `description`) are applied to added sub-registry tools, preventing disabled tools from being registered in `descriptors` or `dispatch`.
- Adds a unit test in `packages/actions/src/runtime/registry.test.ts` verifying that `overrides.json` rules apply to sub-registries and hide disabled tools.

## Why

In `createActions().load()`, `mergeOverride()` was applied to host tools, connector tools, and capability compound tools, but was omitted for tools coming from `added` sub-registries (`actions.add()`). 

As a result, if an administrator or policy configured `"disabled": true` in `overrides.json` for a tool provided by an added sub-registry, the override was ignored. The disabled tool remained visible in `descriptors()` and fully executable via `registry.execute()`.

Applying `mergeOverride()` to `added` sub-registry descriptors enforces consistent security policy across all registered tool sources.

## Verification

- [x] `pnpm --filter @vendoai/actions build` succeeded.
- [x] `pnpm --filter @vendoai/actions test src/runtime/registry.test.ts` passed (41 tests green).
- [x] New unit test in `src/runtime/registry.test.ts` (`applies overrides to added sub-registries and hides disabled tools`) verified.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies `.vendo/overrides.json` to tools from added sub-registries and blocks disabled tools from registering or executing. Fixes #562.

- **Bug Fixes**
  - `@vendoai/actions`: Apply `mergeOverride()` to `actions.add(subRegistry)` descriptors; skip registering tools with `disabled: true`; apply `risk` and `description`; exclude sub-registries’ tools from the compound primitives map.

- **Tests**
  - `registry.test.ts`: Verifies overrides apply to added sub-registries, hide disabled tools in `descriptors()`, and return `not-found` on execute for disabled tools.

<sup>Written for commit 279ec1e0f8a92118ad1539417d4aca3bec0f5eea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

