### PR TITLE
fix(apps): smoke-render gate — an unloadable module is an environment skip, not an island crash

### DIFF
--- a/.changeset/smoke-render-environment-skip.md
+++ b/.changeset/smoke-render-environment-skip.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/apps": patch
+---
+
+Smoke-render gate: treat a module the worker cannot load as an environment failure (skip) instead of an island crash. Under Turbopack `require.resolve("jsdom")` does not throw — it succeeds with a synthetic `[externals]/jsdom [external] (…)` specifier — so the gate's documented "unresolvable → skip silently" path never fired, and the worker's prelude `require` failure was reported as a per-island render crash and routed to repair, which cannot fix a module that will not load. Every generated app carrying an island failed to build. Resolved paths are now checked against the filesystem, and any failure before the worker posts `ready` comes back as an environment failure.

--- a/packages/apps/src/generation/validation/smoke-render.ts
+++ b/packages/apps/src/generation/validation/smoke-render.ts
@@ -24,10 +24,14 @@
  * The worker gives two guarantees an in-process render cannot:
  *   - a hard per-island timeout (worker.terminate preempts infinite loops),
  *   - no globals leaked into the host server process.
- * Environment failures (react/jsdom unresolvable, worker "ready" never
- * arrives) skip the gate silently — the esbuild lazy-load precedent — so a
- * bundler that cannot reach the modules degrades to today's behavior instead
- * of failing creates.
+ * Environment failures (react/jsdom unresolvable or unloadable, worker "ready"
+ * never arrives) skip the gate silently — the esbuild lazy-load precedent — so
+ * a bundler that cannot reach the modules degrades to today's behavior instead
+ * of failing creates. "Unresolvable" includes a resolver that SUCCEEDS with a
+ * synthetic specifier (Turbopack hands back `[externals]/jsdom [external] …`):
+ * the paths are checked against the filesystem, and anything the worker still
+ * cannot load before it posts "ready" comes back as an environment failure
+ * rather than an island render error.
  */
 import {
   ISLAND_AMBIENT_KIT_NAMES,
@@ -92,10 +96,22 @@ const renderIssue = (island: string, message: string): string => {
 // Worker source (CJS eval worker). Embedded as a string so no worker FILE has
 // to survive a host bundler; module paths are resolved on the main thread and
 // passed in. No backticks/template literals in here — it is itself a literal.
+//
+// Exported for the regression test that drives it with an unloadable module
+// path directly — the only way to prove the pre-"ready" failure comes back as
+// an environment skip rather than a fabricated island crash.
 // ---------------------------------------------------------------------------
-const WORKER_SOURCE = String.raw`
+export const WORKER_SOURCE = String.raw`
 const { parentPort, workerData } = require("node:worker_threads");
 const finish = (errors) => { try { parentPort.postMessage({ type: "result", errors }); } catch {} };
+// Everything before the "ready" post is environment (jsdom/react loading), not
+// island code. A failure there must reach the main thread as an ENVIRONMENT
+// failure so the gate skips — the worker "error"/"exit" handlers already make
+// that distinction, but a throw inside this async IIFE is caught below and
+// would otherwise be posted as a per-island render error and routed to repair,
+// which cannot fix a module that will not load.
+let ready = false;
+const finishEnvironment = () => { try { parentPort.postMessage({ type: "environment" }); } catch {} };
 (async () => {
   const errors = [];
   const seen = new Set();
@@ -118,6 +134,7 @@ const finish = (errors) => { try { parentPort.postMessage({ type: "result", erro
   const React = require(workerData.paths.react);
   const { createRoot } = require(workerData.paths.reactDomClient);
   const { createPortal, flushSync } = require(workerData.paths.reactDom);
+  ready = true;
   parentPort.postMessage({ type: "ready" });
 
   // Ambient scope: real React/hooks, pass-through Kit, string fmt, tool stub.
@@ -187,7 +204,10 @@ const finish = (errors) => { try { parentPort.postMessage({ type: "result", erro
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   finish(errors);
-})().catch((error) => finish([error instanceof Error ? error.message : String(error)]));
+})().catch((error) => {
+  if (!ready) return finishEnvironment();
+  finish([error instanceof Error ? error.message : String(error)]);
+});
 `;
 
 interface WorkerModules {
@@ -201,6 +221,7 @@ const workerModules = (async (): Promise<WorkerModules | undefined> => {
   try {
     const { Worker } = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ "node:worker_threads");
     const { createRequire } = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ "node:module");
+    const { existsSync } = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ "node:fs");
     const resolvers: Array<() => NodeJS.Require> = [
       () => createRequire(import.meta.url),
       () => createRequire(`${process.cwd()}/package.json`),
@@ -208,15 +229,20 @@ const workerModules = (async (): Promise<WorkerModules | undefined> => {
     for (const make of resolvers) {
       try {
         const require_ = make();
-        return {
-          Worker,
-          paths: {
-            react: require_.resolve("react"),
-            reactDom: require_.resolve("react-dom"),
-            reactDomClient: require_.resolve("react-dom/client"),
-            jsdom: require_.resolve("jsdom"),
-          },
+        const paths = {
+          react: require_.resolve("react"),
+          reactDom: require_.resolve("react-dom"),
+          reactDomClient: require_.resolve("react-dom/client"),
+          jsdom: require_.resolve("jsdom"),
         };
+        // A bundler's require.resolve can SUCCEED and hand back a synthetic
+        // specifier instead of a file — Turbopack answers
+        // `[externals]/jsdom [external] (jsdom, cjs, …)`. The worker's plain
+        // `require` cannot load that, so accepting it turns a skippable
+        // environment gap into a per-island "your component crashed" issue.
+        // Demand real files, and let the next resolver (real Node resolution
+        // from cwd) have its turn.
+        if (Object.values(paths).every((path) => existsSync(path))) return { Worker, paths };
       } catch {
         continue;
       }
@@ -282,6 +308,13 @@ const renderOne = async (
       let ready = false;
       let timer = setTimeout(() => resolve([]), startupTimeoutMs); // env too slow → skip, not an island fault
       worker.on("message", (message: { type: string; errors?: string[] }) => {
+        if (message.type === "environment") {
+          // The worker could not load jsdom/react — the gate cannot run here.
+          // Skip, exactly as an unresolvable module does; never an island fault.
+          clearTimeout(timer);
+          resolve([]);
+          return;
+        }
         if (message.type === "ready") {
           ready = true;
           clearTimeout(timer);

--- a/packages/apps/src/smoke-render.test.ts
+++ b/packages/apps/src/smoke-render.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { NormalizedCatalog } from "@vendoai/core";
-import { sampleFromShape, smokeRenderIslands } from "./generation/validation/smoke-render.js";
+import { sampleFromShape, smokeRenderIslands, WORKER_SOURCE } from "./generation/validation/smoke-render.js";
 import { modelEngine } from "./engine.js";
 import { scriptedLanguageModel, type ScriptedModelCall } from "./testing/index.js";
 
@@ -278,6 +278,44 @@ describe("smoke-render gate inside create validation", () => {
     expect(prompts[1]).toContain("never inside .map(), loops, or conditions");
     expect(document.components?.ClientContactCards).not.toContain("clients.map((client) => {");
   }, 60_000);
+
+  // Regression, 2026-07-25 nightly demo QA: under Turbopack `require.resolve`
+  // does not throw for jsdom — it SUCCEEDS with a synthetic
+  // `[externals]/jsdom [external] (…)` specifier. The worker's plain `require`
+  // then failed in the prelude, and that failure was reported as a per-island
+  // render crash ("your component crashed, guard your .map") and routed to
+  // repair, which cannot fix a module that will not load. Every generated app
+  // carrying an island failed to build in the demo. A module the worker cannot
+  // load is an ENVIRONMENT failure and must skip the gate, per this file's
+  // contract — never an island fault.
+  it("reports an unloadable module as an environment failure, not an island crash", async () => {
+    const { Worker } = await import("node:worker_threads");
+    const message = await new Promise<{ type: string; errors?: string[] }>((resolve, reject) => {
+      const worker = new Worker(WORKER_SOURCE, {
+        eval: true,
+        workerData: {
+          compiled: "module.exports.default = function Card() { return null; };",
+          toolResults: {},
+          // Exactly the shape Turbopack hands back: resolution "succeeded",
+          // the path is not loadable.
+          paths: {
+            jsdom: "[externals]/jsdom [external] (jsdom, cjs, /nope/jsdom)",
+            react: "react",
+            reactDom: "react-dom",
+            reactDomClient: "react-dom/client",
+          },
+          reactNames: [],
+          kitNames: [],
+        },
+        env: {},
+      });
+      worker.on("message", resolve);
+      worker.on("error", reject);
+      worker.on("exit", () => reject(new Error("worker exited without a message")));
+    });
+    expect(message.type).toBe("environment");
+    expect(message.errors).toBeUndefined();
+  }, 30_000);
 
   it("can be disabled with pipeline.smokeRender: false", async () => {
     const broken = `<App name="Cards"><Island name="ClientContactCards">${HOOKS_IN_MAP}</Island><ClientContactCards/></App>`;


### PR DESCRIPTION
Found by the **2026-07-25 nightly demo QA** run against `eee10d2e`. The flagship
"ask Maple where my money went → get a live spending view" demo was broken: the
user got a red **"Couldn't build the app — app build failed: generation
failed"**.

## What was happening

The new smoke-render gate (#498) renders each island headless in a worker, with
module paths resolved on the main thread. Under Turbopack,
`require.resolve("jsdom")` **does not throw** — it *succeeds*, handing back a
synthetic specifier:

```
[externals]/jsdom [external] (jsdom, cjs, [project]/node_modules/.pnpm/jsdom@25.0.1/node_modules/jsdom)
```

Two things then go wrong:

1. **The escape hatch never fires.** The file's own contract promises
   *"Environment failures (react/jsdom unresolvable, worker 'ready' never
   arrives) skip the gate silently … so a bundler that cannot reach the modules
   degrades to today's behavior instead of failing creates."* That path is only
   reached when `.resolve()` **throws**.
2. **The failure is blamed on the island.** The worker's
   `require(workerData.paths.jsdom)` fails in the prelude; the IIFE's catch-all
   posts it as a per-island *result*, so the user is told:

   > island "LateNightTransactions" crashed when rendered against stubbed tool
   > results: Cannot find module '[externals]/jsdom [external] (…)' — the
   > component must render without throwing … guard undefined/empty results
   > before .map/.reduce

   …and it is routed to repair, which cannot fix a module that will not load.

**Why it looked intermittent.** Three generations on the unpatched server: 2
failed, 1 shipped. The one that shipped had **0 islands** — nothing for the gate
to render. Both failures carried islands, and *every* island failed with the
identical jsdom error (one hit both `RecentTxList` and `SummaryBar`). The rule
is not "sometimes": **any app with an island cannot ship.**

**Blast radius.** Published `0.4.8` is *not* affected — it has no smoke-render
gate and no `jsdom` dependency. But `packages/apps/package.json` now declares
`jsdom` in `dependencies`, so on the next release every Next+Turbopack host
installs it and takes this same path.

## The fix

- **Main thread** — a resolver only wins when every resolved path is a real file
  (`existsSync`). A synthetic specifier falls through to the next resolver and,
  failing that, skips the gate as designed.
- **Worker** — track whether `ready` was posted and report a pre-`ready` failure
  as `{type:"environment"}`; the main thread resolves that to *no issues*, the
  same skip an unresolvable module already produced. The `error`/`exit` handlers
  already drew this before/after-`ready` line — the IIFE catch-all did not.

## Scope, stated plainly

This restores the **documented degradation** (skip) under Turbopack. It does
**not** make the gate execute there — I verified from inside the running dev
server that Turbopack's `createRequire` returns non-existent synthetic paths for
`react` and throws for `jsdom` on both resolver rungs, so the gate correctly
skips rather than runs. Making it actually run under Turbopack is a separate
design call for whoever owns the gate; this PR stops it from failing every
island-bearing create.

## Verification

- `pnpm build` — **21/21 green**
- `pnpm typecheck` — **37/37 green**
- `pnpm lint` — **4/4 green**
- `pnpm --filter @vendoai/apps test` — **603 passed / 18 skipped** (was 602;
  +1 is the new regression test)
- The new test **fails without the worker-side change** (verified by reverting
  just that hunk: `1 failed | 602 passed`), so it is not vacuous.
- **In the real demo**, patched `demo-bank` on Turbopack: 5 generations, **zero**
  jsdom misattributions and zero island-blamed failures (the single failure was
  an unrelated genuine issue, *"tree root renders an empty layout"*).

**Honest gap:** I could not get the generator to emit an island on the patched
server across 5 attempts (all tree-only, 0 island nodes), so the island path is
proven by the regression test and the in-server resolver probe rather than by an
end-to-end browser capture of an island-bearing app.

### Pre-existing, not from this PR

Full `pnpm test` is **already red on `main`**: `@vendoai/ui` fails 5 files / 28
tests (`chrome/discoverability-*`, `lane-thread-picks`). Identical failures on a
clean checkout of `eee10d2e`. Untouched here, but worth a look given the repo's
"must be green before any PR" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the smoke-render gate to treat unloadable modules as environment failures and skip, instead of reporting island crashes. This prevents Turbopack builds from failing when `require.resolve("jsdom")` returns a synthetic external path.

- **Bug Fixes**
  - Main thread now accepts a resolver only if all resolved paths are real files (`existsSync`); synthetic externals fall through and, if unresolved, skip the gate.
  - Worker tracks a pre-`ready` state and posts `{ type: "environment" }` for failures before readiness; the main thread treats this as a skip, not an island error.
  - Exported the worker source and added a regression test to verify that an unloadable `jsdom` path reports an environment failure instead of an island crash.
  - Restores the documented skip behavior under Turbopack; the gate still does not execute there.

<sup>Written for commit 93a97f7bc5a0efe7d721ec82aeb265951ba24989. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

