### PR TITLE
prompt(exemplar): iterate 2 — semantic action match + chart series binding (M3/M7)

### DIFF
--- a/packages/apps/src/engine.test.ts
+++ b/packages/apps/src/engine.test.ts
@@ -277,6 +277,8 @@ describe("generation engine through createApps", () => {
       expect(prompts[0]).toContain("<building_great_apps>");
       expect(prompts[0]).toContain("<examples>");
       expect(prompts[0]).toContain("Claims tell the truth");
+      expect(prompts[0]).toContain("a semantically wrong tool is worse than a disclaimer");
+      expect(prompts[0]).toContain("rows lacking the named series draws nothing");
       expect(prompts[0]).toContain(`CURRENT DATE: ${new Date().toISOString().slice(0, 10)}`);
       expect(prompts[1]).not.toContain("<building_great_apps>");
       expect(prompts[1]).toContain("WIRE DIALECT");

--- a/packages/apps/src/generation/contracts/exemplar.ts
+++ b/packages/apps/src/generation/contracts/exemplar.ts
@@ -139,7 +139,7 @@ Work in this order:
 const exemplarPrinciples = `<principles>
 1. Real data only. Every number, row, and chart point the user sees comes from a tool binding — including derived values: a computation may only combine tool data (an invented rate or constant is fabrication). When no tool backs an ask, the Disclaimer is the correct output.
 2. Claims tell the truth. Every title, header, badge, and sentence of copy is literally true of the data beneath it. When the data can't support the claim, change the words, not the data.
-3. Actions are real and gated. A button either names a host tool with its context bound into payload, or it doesn't exist. Mutations pause for user approval — render that state. When no tool can perform the ask, say so plainly instead.
+3. Actions are real and gated. A button either names a host tool with its context bound into payload, or it doesn't exist. The named tool actually performs what the button's label promises — a semantically wrong tool is worse than a disclaimer. Mutations pause for user approval — render that state. When no tool does what the ask needs, the honest Disclaimer IS the action.
 4. Brand-native. Host catalog components first, Kit second, host tokens always — on every host, the app should read as if the host shipped it.
 </principles>`;
 
@@ -173,7 +173,7 @@ Why this is right: ${why}
 
 /** Charts preamble carried with the components section (the historical $NaN
  *  class: a chart fed formatted strings draws nothing). */
-const COMPONENTS_PREAMBLE = "Charts and visualizations read RAW numeric fields — their format prop handles display. Money is integer cents end-to-end; the Kit formats it.";
+const COMPONENTS_PREAMBLE = "Charts and visualizations read RAW numeric fields — their format prop handles display. A chart binds to rows whose fields actually contain the plotted series (check TOOL RESPONSE SHAPES) — a chart bound to rows lacking the named series draws nothing. Money is integer cents end-to-end; the Kit formats it.";
 
 export const exemplarContract = (deps: GenerationDependencies): string => composePromptSections([
   { id: "role", content: exemplarRole },


### PR DESCRIPTION
## What

Restores two load-bearing rules to the exemplar create contract (`packages/apps/src/generation/contracts/exemplar.ts`, flag `pipeline.exemplarContract`) that the old contract taught and the rewrite lost. Gate evidence (`docs/eval/runs/2026-07-21/`, PR #481):

- **M3**: "cancel this payment" shipped a Cancel button wired to `host_transferMoney` with an EMPTY $0 payload — a semantically wrong tool behind an honest-sounding label.
- **M7**: a comparison chart rendered with zero bars — the chart was bound to rows that don't contain the plotted series.

## Changes

1. **Principles — actions** (one added statement, contract voice): *"The named tool actually performs what the button's label promises — a semantically wrong tool is worse than a disclaimer."* and the closing line now reads *"When no tool does what the ask needs, the honest Disclaimer IS the action."*
2. **Components preamble** (one added statement): *"A chart binds to rows whose fields actually contain the plotted series (check TOOL RESPONSE SHAPES) — a chart bound to rows lacking the named series draws nothing."*
3. `engine.test.ts` exemplar prompt-content test pins a distinctive phrase from each line.

## Verification

- `pnpm build` / `pnpm typecheck` / `pnpm lint` green.
- `pnpm test` green across all packages, with one machine-environmental exception verified pre-existing on clean main: `demo-accounting src/vendo/login-e2e.test.ts` fails locally because an unrelated `vendo-console` Supabase stack occupies port 54321 (GoTrue health probe passes, Cadence users absent → 401). Fails identically on clean `main`; skips cleanly when no stack is present; CI runs it in the dedicated `cadence-supabase-auth` job.

Prompt-only change — no UI code touched (no screenshots applicable; the effect is measured by the Job-2 rematch gate that follows).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores two guardrails in the exemplar contract to stop semantically wrong actions and empty charts, and pins tests to prevent regressions. Fixes M3/M7 evals by enforcing correct tool wiring and chart series binding.

- **Bug Fixes**
  - Actions: Button must name a tool that actually performs the label; else show Disclaimer. Blocks “Cancel payment” wired to empty `host_transferMoney`.
  - Charts: Bind only to rows that contain the series; missing rows render nothing. Blocks zero‑bar comparisons.

<sup>Written for commit 8ad92a1e6995b8892f7860835ee9c8a2308a1594. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

