### PR TITLE
ci: corpus nightly → structural clean room (layer 1, zero model keys, fails closed)

### DIFF
--- a/.github/workflows/corpus-nightly.yml
+++ b/.github/workflows/corpus-nightly.yml
@@ -88,12 +88,14 @@ jobs:
             fi
             repos+=("$repo")
           done
-          # No `|| true`: a sweep failure (regression, crash) must fail this job
-          # loudly. The scorecard/trend/upload steps below run on `always()` so
-          # the evidence is still published before the job is marked red.
+          # Fail closed: `--strict` is what turns a hard structural failure
+          # into a nonzero exit — without it the harness reports failures and
+          # still exits 0 — and there is no `|| true` to swallow that exit.
+          # The scorecard/trend/upload steps below run on `always()` so the
+          # evidence is still published before the job is marked red.
           # --layer 1 is hardcoded: GH is the structural clean room; layer 2
           # (AI-scored) runs on the mini only.
-          pnpm corpus run "${repos[@]}" --layer 1 --json
+          pnpm corpus run "${repos[@]}" --layer 1 --json --strict
 
       - name: Diagnose scorecard artifact path
         if: always()

--- a/.github/workflows/corpus-nightly.yml
+++ b/.github/workflows/corpus-nightly.yml
@@ -1,3 +1,9 @@
+# Structural clean-room sweep: layer 1 only, zero model credentials.
+# The AI half of the nightly (layer 2 scoring, init AI polish, UI-parity
+# audit, engine-ladder legs) runs on the Mac mini, not on GitHub. Without
+# a model credential init's AI pass self-skips and still exits green
+# (packages/vendo/src/cli/extract/extraction.ts), so layer 1's structural
+# checks assert exactly as before.
 name: Corpus Nightly
 
 on:
@@ -10,10 +16,8 @@ on:
         description: "Space-separated development repo names (blank = all)"
         required: false
         default: ""
-      layer:
-        description: "Highest layer to run (1=structural, 2=scored)"
-        required: false
-        default: "2"
+      # No `layer` input: GH runs layer 1 only (structural). Layer 2 is
+      # mini-only — a manual dispatch must not be able to run it here.
 
 permissions:
   contents: read
@@ -25,7 +29,7 @@ concurrency:
 jobs:
   sweep:
     runs-on: ubuntu-latest
-    timeout-minutes: 210  # full sweep + per-repo AI polish pass exceeds 120 (run 29811235687 timed out)
+    timeout-minutes: 120  # structural-only (layer 1, no AI pass) fits well inside 120; the AI sweep that needed 210+ lives on the mini now
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -35,16 +39,6 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
-
-      - name: Check required secrets
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          if [ -z "$ANTHROPIC_API_KEY" ]; then
-            echo "::error::ANTHROPIC_API_KEY secret is not set. The corpus sweep runs real vendo init and needs an LLM key."
-            echo "Add it under Settings → Secrets and variables → Actions. Per-repo bootstrap secrets use CORPUS_<REPO>_<KEY>."
-            exit 1
-          fi
 
       - run: pnpm install --frozen-lockfile
 
@@ -82,22 +76,11 @@ jobs:
             fs.writeFileSync("previous-scorecard/artifact.zip", Buffer.from(download.data));
             await exec.exec("unzip", ["-o", "previous-scorecard/artifact.zip", "-d", "previous-scorecard"]);
 
-      - name: Install Claude Code for the init AI pass
-        run: npm install --global @anthropic-ai/claude-code@2.1.209
-
-      - name: Run corpus Layer 1/2 development sweep
+      - name: Run corpus Layer 1 structural sweep (clean room, no model credentials)
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CORPUS_REPOS: ${{ github.event.inputs.repos }}
-          CORPUS_LAYER: ${{ github.event.inputs.layer }}
         run: |
           set -euo pipefail
-          layer="${CORPUS_LAYER:-2}"
-          case "$layer" in
-            1|2) ;;
-            *) echo "::error::layer input must be 1 or 2 (got '$layer')"; exit 1 ;;
-          esac
           repos=()
           for repo in ${CORPUS_REPOS:-}; do
             if ! printf '%s' "$repo" | grep -Eq '^[a-z0-9][a-z0-9-]*$'; then
@@ -108,7 +91,9 @@ jobs:
           # No `|| true`: a sweep failure (regression, crash) must fail this job
           # loudly. The scorecard/trend/upload steps below run on `always()` so
           # the evidence is still published before the job is marked red.
-          pnpm corpus run "${repos[@]}" --layer "$layer" --json
+          # --layer 1 is hardcoded: GH is the structural clean room; layer 2
+          # (AI-scored) runs on the mini only.
+          pnpm corpus run "${repos[@]}" --layer 1 --json
 
       - name: Diagnose scorecard artifact path
         if: always()
@@ -132,25 +117,6 @@ jobs:
           else
             echo "No scorecard produced (sweep may have failed before scoring)." >> "$GITHUB_STEP_SUMMARY"
           fi
-
-      - name: UI-parity audit (LLM-costed, nightly only)
-        if: always()
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          CORPUS_REPOS: ${{ github.event.inputs.repos }}
-        run: |
-          set -euo pipefail
-          # Runs AFTER the sweep, over the checkouts it left in corpus/.repos.
-          # It enumerates each frontend with the model and diffs against the
-          # generated tool surface. Informational: it never fails the job.
-          repos=()
-          for repo in ${CORPUS_REPOS:-}; do
-            if ! printf '%s' "$repo" | grep -Eq '^[a-z0-9][a-z0-9-]*$'; then
-              echo "::error::invalid repo name '$repo'"; exit 1
-            fi
-            repos+=("$repo")
-          done
-          pnpm corpus:ui-parity "${repos[@]}" >> "$GITHUB_STEP_SUMMARY" || true
 
       - name: Append trend to job summary
         if: always()
@@ -181,273 +147,4 @@ jobs:
           # upload-artifact v4 excludes hidden paths by default, which is why
           # the artifact has been empty since Jul 17 (proven by the diagnostic
           # step on run 29768616216).
-          include-hidden-files: true
-
-  # --- Init engine-ladder legs (install-dx: init-selfcontained-engine, Task 6) ---
-  #
-  # extraction.ts's ladder is Agent SDK -> claude CLI -> codex CLI -> npx
-  # engine, and every rung's availability() only reads env vars and PATH
-  # (packages/vendo/src/cli/extract/{claude,claude-cli,codex-cli,npx-engine}-
-  # harness.ts) — there is no separate "force this rung" knob, and none is
-  # added here. Both legs below steer the ladder purely by controlling which
-  # credentials are in the job env and which CLIs get installed on PATH:
-  #   - Neither leg ever sets ANTHROPIC_API_KEY, so the Agent SDK rung (rung 1,
-  #     which resolves @anthropic-ai/claude-agent-sdk straight out of the
-  #     workspace's own node_modules regardless of any CLI install) stays
-  #     unavailable and falls through in both.
-  #   - Neither leg installs the `claude` CLI, so rung 2 (claude-cli) also
-  #     falls through in both.
-  # Both jobs run a single small repo (umami) at layer 1 only: layer 1 already
-  # runs init's aiPolish pass unconditionally (cli.ts's runRepoThroughLayerOne)
-  # and is far cheaper than the full multi-repo layer-2 sweep — these legs
-  # exist to prove the rung actually runs, not to score extraction quality.
-  #
-  # Liveness, not exit code: `pnpm corpus run` without `--strict` always exits
-  # 0 (scorecard.ts only turns non-zero on `--strict`), and even when a rung
-  # fails outright — e.g. the npx-engine rung 404ing because @vendoai/engine
-  # isn't published yet — extraction.ts's runAiExtraction() catches the error
-  # itself, logs it, and returns { ran: false } without touching init's exit
-  # code (extraction.ts:289-292). So a green corpus-run step here proves
-  # nothing about whether the intended rung actually ran; each leg's "Assert
-  # <rung> actually ran" step below greps the init log it just produced for
-  # two lines extraction.ts is guaranteed to emit: `Reading your product
-  # (<credential label>)…` (logged before the chosen harness's run() is even
-  # called — proves the ladder picked *this* rung and not an earlier one) and
-  # `AI polish applied:` (logged only after that harness's run() returns
-  # successfully — proves it didn't just get picked, it finished). The
-  # assertion step fails loudly when either is missing; job-level
-  # `continue-on-error: true` (see below) keeps that failure informational
-  # instead of reddening the nightly.
-  #
-  # Both legs are gated on their credential secret so an unconfigured repo
-  # shows a clean, loud skip instead of a manufactured failure
-  # (corpus-nightly.yml's own "Check required secrets" step is a hard fail
-  # because ANTHROPIC_API_KEY is required infrastructure for the main sweep —
-  # these two legs are optional coverage, so a soft skip fits better here).
-  # The gate itself has to be a step (not job-level `if:`) — actionlint
-  # confirms the `secrets` context is unavailable in a job-level `if:`
-  # condition, only step-level ones.
-  #
-  # `continue-on-error: true` sits at the JOB level here, not per-step like
-  # nightly.yml. That's a deliberate difference, not a copy of nightly.yml's
-  # pattern: nightly.yml scopes continue-on-error per-step because its steps
-  # share one job with a final aggregator step that decides real pass/fail.
-  # These two legs are standalone jobs with no `needs:` dependents and no
-  # aggregator — without job-level continue-on-error, an ordinary infra flake
-  # (e.g. `pnpm install` hiccup) would fail the *job*, which fails the whole
-  # workflow run's conclusion even though nothing downstream depends on it.
-  # Job-level continue-on-error is what keeps this leg — CLI install, corpus
-  # run, or the liveness assertion, whichever step trips — informational
-  # end to end.
-
-  codex-leg:
-    name: "Init engine ladder: codex CLI (informational)"
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    continue-on-error: true
-    steps:
-      - name: Check codex credential
-        id: check
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: |
-          if [ -z "$OPENAI_API_KEY" ]; then
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::OPENAI_API_KEY secret is not set — skipping the codex-cli engine-ladder leg (informational, optional coverage)."
-          else
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        if: steps.check.outputs.ready == 'true'
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-        if: steps.check.outputs.ready == 'true'
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        if: steps.check.outputs.ready == 'true'
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-        if: steps.check.outputs.ready == 'true'
-      - run: pnpm build
-        if: steps.check.outputs.ready == 'true'
-
-      # `npm view @openai/codex` confirms the package (bin: codex); pinned to
-      # match how the claude-code leg above pins its own CLI version.
-      - name: Install codex CLI
-        if: steps.check.outputs.ready == 'true'
-        run: npm install --global @openai/codex@0.144.6
-
-      - name: Run corpus init step against the codex CLI rung
-        if: steps.check.outputs.ready == 'true'
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: |
-          set -euo pipefail
-          # ANTHROPIC_API_KEY and VENDO_API_KEY are deliberately absent from
-          # this job's env, and no `claude` binary is installed, so rungs 1-2
-          # of the ladder report unavailable and the codex-cli rung
-          # (extraction.ts's third rung) is the first one with a credential.
-          # This step alone does NOT prove the codex rung ran — `pnpm corpus
-          # run` without `--strict` always exits 0 — the next step asserts
-          # that from the log content instead.
-          pnpm corpus run umami --layer 1 --json
-
-      - name: Assert codex rung actually ran (liveness, not just exit code)
-        if: steps.check.outputs.ready == 'true'
-        run: |
-          log="corpus/.repos/.logs/umami/init.first.log"
-          if [ ! -f "$log" ]; then
-            echo "::error::$log not found — the corpus run step produced no init log to inspect."
-            exit 1
-          fi
-          # extraction.ts logs this line right before calling the chosen
-          # harness's run() — its exact credential label is unique to the
-          # codex-cli rung (no other rung's availability() ever returns
-          # "your OPENAI_API_KEY"), so its presence proves the ladder
-          # actually selected codex-cli and not an earlier rung.
-          if ! grep -q "Reading your product (your OPENAI_API_KEY)" "$log"; then
-            echo "::error::codex-cli rung was never selected — no 'Reading your product (your OPENAI_API_KEY)' line in $log. Check that codex is on PATH and OPENAI_API_KEY authenticates it."
-            exit 1
-          fi
-          # extraction.ts only logs this after the chosen harness's run()
-          # returns successfully — its presence proves the rung didn't just
-          # get picked, it finished.
-          if ! grep -q "AI polish applied:" "$log"; then
-            echo "::error::codex-cli rung was selected but did not complete — no 'AI polish applied:' line in $log. See the log for the actual error."
-            exit 1
-          fi
-          echo "codex-cli rung ran and completed — liveness confirmed."
-
-      - name: Publish codex-leg scorecard to job summary
-        if: always() && steps.check.outputs.ready == 'true'
-        run: |
-          if [ -f corpus/.repos/.logs/scorecard.md ]; then
-            cat corpus/.repos/.logs/scorecard.md >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "No scorecard produced (codex leg may have failed before scoring)." >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-      - name: Upload codex-leg logs
-        if: always() && steps.check.outputs.ready == 'true'
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
-        with:
-          name: corpus-codex-leg-logs
-          path: |
-            corpus/.repos/.logs/scorecard.json
-            corpus/.repos/.logs/scorecard.md
-            corpus/.repos/.logs/**/*.log
-          retention-days: 14
-          if-no-files-found: warn
-          include-hidden-files: true
-
-  npx-engine-leg:
-    name: "Init engine ladder: npx @vendoai/engine (informational)"
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    continue-on-error: true
-    steps:
-      - name: Check Vendo Cloud credential
-        id: check
-        env:
-          VENDO_API_KEY: ${{ secrets.VENDO_API_KEY }}
-        run: |
-          if [ -z "$VENDO_API_KEY" ]; then
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::VENDO_API_KEY secret is not set — skipping the npx-engine engine-ladder leg (informational, optional coverage)."
-          else
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        if: steps.check.outputs.ready == 'true'
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-        if: steps.check.outputs.ready == 'true'
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        if: steps.check.outputs.ready == 'true'
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-        if: steps.check.outputs.ready == 'true'
-      - run: pnpm build
-        if: steps.check.outputs.ready == 'true'
-
-      - name: Run corpus init step against the npx engine rung
-        if: steps.check.outputs.ready == 'true'
-        env:
-          # Vendo Cloud key only (no ANTHROPIC_API_KEY): npx-engine-harness.ts's
-          # availability() accepts either an own ANTHROPIC_API_KEY or
-          # VENDO_API_KEY (gateway fuel) — using only the latter here is what
-          # actually forces the ladder down to the fourth rung instead of
-          # stopping at rung 1 (Agent SDK also honors a bare ANTHROPIC_API_KEY).
-          VENDO_API_KEY: ${{ secrets.VENDO_API_KEY }}
-        run: |
-          set -euo pipefail
-          # KNOWN, EXPECTED FAILURE MODE (see install-dx: init-selfcontained-
-          # engine plan, Task 5): @vendoai/engine@0.1.0 is not published yet —
-          # publishing is blocked on NPM_TOKEN alongside the rest of the
-          # @vendoai/* release train, so `npm exec` will 404 until that lands.
-          # That 404 is swallowed by init itself, not by continue-on-error:
-          # npx-engine-harness.ts's run() throws, extraction.ts's
-          # runAiExtraction() catches it, logs "AI polish did not complete
-          # (…)", and returns { ran: false } WITHOUT touching init's exit
-          # code (extraction.ts:289-292) — so this step still exits 0 either
-          # way. The next step's liveness assertion is what actually surfaces
-          # the 404: it greps for the "AI polish applied:" success line, which
-          # will be absent until the package is published, so that assertion
-          # is EXPECTED to fail (informationally — see job-level
-          # continue-on-error above) until then. Once @vendoai/engine is live
-          # on npm, the assertion starts passing for real with no workflow
-          # change required.
-          pnpm corpus run umami --layer 1 --json
-
-      - name: Assert npx-engine rung actually ran (liveness, not just exit code)
-        if: steps.check.outputs.ready == 'true'
-        run: |
-          log="corpus/.repos/.logs/umami/init.first.log"
-          if [ ! -f "$log" ]; then
-            echo "::error::$log not found — the corpus run step produced no init log to inspect."
-            exit 1
-          fi
-          # extraction.ts logs this line right before calling the chosen
-          # harness's run() — "via the Vendo engine" only appears in
-          # npx-engine-harness.ts's two credential labels, so its presence
-          # proves the ladder actually reached the fourth rung (npx-engine)
-          # instead of stopping at an earlier one.
-          if ! grep -q "via the Vendo engine" "$log"; then
-            echo "::error::npx-engine rung was never selected — no 'Reading your product (… via the Vendo engine …)' line in $log. Check that no claude/codex binary is on PATH and VENDO_API_KEY is set."
-            exit 1
-          fi
-          # extraction.ts only logs this after the chosen harness's run()
-          # returns successfully. EXPECTED TO FAIL today: @vendoai/engine
-          # is not published yet (NPM_TOKEN-blocked), so `npm exec` 404s and
-          # this line is never written. Once the package is live, this
-          # assertion starts passing for real.
-          if ! grep -q "AI polish applied:" "$log"; then
-            echo "::error::npx-engine rung was selected but did not complete — no 'AI polish applied:' line in $log. Expected until @vendoai/engine@0.1.0 is published to npm (NPM_TOKEN-blocked); see the log for the actual error."
-            exit 1
-          fi
-          echo "npx-engine rung ran and completed — liveness confirmed."
-
-      - name: Publish npx-engine-leg scorecard to job summary
-        if: always() && steps.check.outputs.ready == 'true'
-        run: |
-          if [ -f corpus/.repos/.logs/scorecard.md ]; then
-            cat corpus/.repos/.logs/scorecard.md >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "No scorecard produced (npm-engine leg may have failed before scoring — expected until @vendoai/engine is published)." >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-      - name: Upload npx-engine-leg logs
-        if: always() && steps.check.outputs.ready == 'true'
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
-        with:
-          name: corpus-npx-engine-leg-logs
-          path: |
-            corpus/.repos/.logs/scorecard.json
-            corpus/.repos/.logs/scorecard.md
-            corpus/.repos/.logs/**/*.log
-          retention-days: 14
-          if-no-files-found: warn
           include-hidden-files: true

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -101,7 +101,8 @@ structural clean room: it runs the layer 1 sweep across all manifest repos
 with zero model credentials, on a schedule (08:00 UTC daily) and on demand
 via `workflow_dispatch` (input: `repos` space-separated filter — there is no
 layer input; GH is layer 1 only). It builds the workspace, runs
-`pnpm corpus run --layer 1 --json`, writes the scorecard to the job summary,
+`pnpm corpus run --layer 1 --json --strict` (`--strict` makes any hard
+structural failure fail the job), writes the scorecard to the job summary,
 appends a trend delta versus the previous run
 (`corpus/scripts/corpus-trend.mjs`), and uploads `scorecard.json` + `.md` +
 per-repo logs as the `corpus-scorecard` artifact (30-day retention). The AI

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -31,12 +31,14 @@ injection. Pass `--json` to print the machine-readable scorecard, and
 `--strict` to make hard failures return a nonzero exit code. Without `--strict`,
 the sweep reports all repo failures and exits 0.
 
-The sweep always consents to init's AI extraction pass (`--ai-polish`), so the
-theme stage's LLM fallback runs through the staged extraction pipeline instead
-of silently skipping — the only reason nightly theme coverage stays honest.
-That pass needs `ANTHROPIC_API_KEY` in the environment plus a `claude` binary
-on `PATH` (the harness does not ship the Agent SDK); without either, init
-degrades gracefully and the deterministic checks still run.
+The sweep always consents to init's AI extraction pass (`--ai-polish`). That
+pass needs `ANTHROPIC_API_KEY` in the environment plus a `claude` binary on
+`PATH` (the harness does not ship the Agent SDK); without either, init
+degrades gracefully — the AI pass self-skips, init exits green, and the
+deterministic structural checks still run. The nightly split leans on exactly
+that: GitHub runs the structural clean room (layer 1, zero model
+credentials), and the full AI sweep (layer 2 scoring + AI polish) runs
+nightly on the Mac mini instead.
 
 ## Local Vendo injection
 
@@ -94,13 +96,17 @@ the orchestrating environment; Vendo-specific wiring never belongs here.
 
 ## Continuous integration
 
-The `Corpus Nightly` workflow (`.github/workflows/corpus-nightly.yml`) runs the
-development sweep on a schedule (08:00 UTC daily) and on demand via
-`workflow_dispatch` (inputs: `repos` space-separated filter, `layer` 1/2). It builds the
-workspace, runs `pnpm corpus run --json`, writes the scorecard to the job
-summary, appends a trend delta versus the previous run
+The `Corpus Nightly` workflow (`.github/workflows/corpus-nightly.yml`) is the
+structural clean room: it runs the layer 1 sweep across all manifest repos
+with zero model credentials, on a schedule (08:00 UTC daily) and on demand
+via `workflow_dispatch` (input: `repos` space-separated filter — there is no
+layer input; GH is layer 1 only). It builds the workspace, runs
+`pnpm corpus run --layer 1 --json`, writes the scorecard to the job summary,
+appends a trend delta versus the previous run
 (`corpus/scripts/corpus-trend.mjs`), and uploads `scorecard.json` + `.md` +
-per-repo logs as the `corpus-scorecard` artifact (30-day retention).
+per-repo logs as the `corpus-scorecard` artifact (30-day retention). The AI
+half — layer 2 scoring and the init AI polish pass — runs nightly on the Mac
+mini, not on GitHub.
 
 ## AI extraction matrix
 
@@ -252,11 +258,12 @@ PR CI is untouched — no LLM cost or flakiness is added to the merge path.
 
 Required secrets (Settings → Secrets and variables → Actions):
 
-- `ANTHROPIC_API_KEY` (required) — real `vendo init` extraction needs an LLM
-  key. The workflow fails fast if it is missing.
-- `OPENAI_API_KEY` (optional) — alternate provider.
 - `CORPUS_<REPO>_<KEY>` — per-repo bootstrap secrets referenced as
   `${CORPUS_<REPO>_<KEY>}` placeholders in a manifest `envTemplate`.
+- No model credentials: the GitHub nightly is the structural clean room and
+  deliberately carries no `ANTHROPIC_API_KEY`/`OPENAI_API_KEY`. LLM-costed
+  runs (layer 2, `corpus ai`, gallery, install-eval) happen on the Mac mini
+  or on demand locally.
 
 Run a filtered sweep on demand from the Actions tab → Corpus Nightly → Run
-workflow, e.g. `repos: umami taxonomy`, `layer: 1`.
+workflow, e.g. `repos: umami taxonomy` (always layer 1 on GitHub).


### PR DESCRIPTION
## Impact

The corpus nightly has produced **zero data for 4 nights** — the AI-polish pass takes 6–8h/16 repos and the job dies at its 210-min timeout with nothing scored. This PR makes the GH nightly do only what a clean room is good at: cold-clone **layer-1 structural** checks across all 16 corpus repos, no model credentials, finishing well inside a 120-min timeout — and actually going **red** when a structural check fails (`--strict`; previously hard failures exited 0). The full AI sweep now runs nightly on dedicated infrastructure (02:00 PT, reports to #corpus-nightly) — companion lane of the same signed spec.

## What changed

- `.github/workflows/corpus-nightly.yml` (454 → ~150 lines): sweep hardcodes `--layer 1 --json --strict`; `layer` dispatch input removed (manual runs can't select the AI layer here); claude-code install, `ANTHROPIC_API_KEY`, UI-parity step, and both engine-ladder jobs removed; timeout 210 → 120; comments rewritten for the split. Scorecard artifact (`corpus-scorecard`, `include-hidden-files`, `if: always()`) unchanged.
- `corpus/README.md`: nightly section now documents the split (GH = structural clean room; AI sweep = nightly on the mini) and the `--strict` failure semantics.

## Verification

- Adversarial checker verdict: **pass** (3 rounds; round 1 caught the missing `--strict` — the harness exits 0 on hard failures without it — fixed in the second commit).
- actionlint clean; keyless layer-1 proxy run green (express-host, all model env stripped: AI pass self-skips, init green, 7/7 structural checks).
- `git diff origin/main`: exactly these two files. No harness/scoring code touched.

## Code tour

- `.github/workflows/corpus-nightly.yml:79` — the one load-bearing line: `pnpm corpus run … --layer 1 --json --strict` (structural-only + fail-closed exit).
- `corpus/README.md` — the split documented for the next person who wonders where the AI scores went.

Spec: factory wave "nightly corpus split" (signed 2026-07-25).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the GitHub corpus nightly to a structural-only clean room. It now hardcodes layer 1 with `--strict`, removes model credentials and LLM-costed steps, finishes within 120 minutes, and fails closed on structural regressions while still publishing the scorecard.

- **Refactors**
  - `.github/workflows/corpus-nightly.yml`
    - Hardcode `--layer 1 --json --strict`; remove `layer` input from `workflow_dispatch`.
    - Drop `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` checks and `@anthropic-ai/claude-code` install; remove UI-parity and engine-ladder jobs.
    - Reduce timeout from 210 to 120 minutes.
    - Keep `corpus-scorecard` artifact upload with `if: always()` and `include-hidden-files`.
  - `corpus/README.md`
    - Document the split: GitHub runs structural clean room; scored sweep runs on the Mac mini.
    - Clarify strict failure semantics and that manual runs on GitHub are layer 1 only.

<sup>Written for commit de56744fe4aced69a3c8002eca3e890ffec4c28f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

