### PR TITLE
auth: config commands use the key (not the session) + login sets session; load .env.local

### DIFF
--- a/packages/vendo/src/cli/cloud/device-login.test.ts
+++ b/packages/vendo/src/cli/cloud/device-login.test.ts
@@ -352,6 +352,62 @@ describe("runDeviceLogin", () => {
   });
 });
 
+// Unified auth: one `vendo login` establishes BOTH the project key (.env.local)
+// and the account-level session (~/.vendo/cloud-session.json), so a second
+// ceremony and a stale session can never strand the user. Older consoles that
+// return no session stay key-only — no empty file, no crash.
+describe("account session (same login)", () => {
+  const sessionPath = (home: string) => join(home, ".vendo", "cloud-session.json");
+  const SESSION = { access_token: "eyJhbGc.supabase.jwt", refresh_token: "r3fr3sh", expires_at: 1_893_456_000 };
+
+  it("writes the account session when the token response carries one", async () => {
+    const root = await tempRoot();
+    const home = await tempRoot();
+    const { fetchImpl } = scriptedFetch([
+      { status: 200, body: { access_token: KEY, token_type: "Bearer", session: SESSION } },
+    ]);
+    const exit = await runDeviceLogin(["--api-url", "https://console.test"], {
+      output: output().sink, fetchImpl, root, home, sleep: async () => {}, env: {}, isTty: false,
+    });
+    expect(exit).toBe(0);
+    // The key still lands in .env.local…
+    expect(await readFile(join(root, ".env.local"), "utf8")).toContain(`VENDO_API_KEY=${KEY}`);
+    // …and the session lands in ~/.vendo/cloud-session.json in the SAME login.
+    expect(JSON.parse(await readFile(sessionPath(home), "utf8"))).toEqual(SESSION);
+    // Owner-only, like every credential file.
+    expect((await stat(sessionPath(home))).mode & 0o777).toBe(0o600);
+  });
+
+  it("leaves the session file untouched when the response carries no session (older console)", async () => {
+    const root = await tempRoot();
+    const home = await tempRoot();
+    const { fetchImpl } = scriptedFetch([
+      { status: 200, body: { access_token: KEY, token_type: "Bearer" } },
+    ]);
+    const exit = await runDeviceLogin(["--api-url", "https://console.test"], {
+      output: output().sink, fetchImpl, root, home, sleep: async () => {}, env: {}, isTty: false,
+    });
+    expect(exit).toBe(0);
+    expect(await readFile(join(root, ".env.local"), "utf8")).toContain(`VENDO_API_KEY=${KEY}`);
+    // No empty session file was created — key-only, exactly as today.
+    await expect(stat(sessionPath(home))).rejects.toThrow();
+  });
+
+  it("ignores a malformed session (no access_token) — key-only, no crash, no file", async () => {
+    const root = await tempRoot();
+    const home = await tempRoot();
+    const { fetchImpl } = scriptedFetch([
+      { status: 200, body: { access_token: KEY, token_type: "Bearer", session: { refresh_token: "only" } } },
+    ]);
+    const exit = await runDeviceLogin(["--api-url", "https://console.test"], {
+      output: output().sink, fetchImpl, root, home, sleep: async () => {}, env: {}, isTty: false,
+    });
+    expect(exit).toBe(0);
+    expect(await readFile(join(root, ".env.local"), "utf8")).toContain(`VENDO_API_KEY=${KEY}`);
+    await expect(stat(sessionPath(home))).rejects.toThrow();
+  });
+});
+
 // The pending-claim file (#479): a claim survives the process that opened it,
 // so a fresh `vendo login` can resume polling after the original process dies
 // and a late human approval still lands the key.

--- a/packages/vendo/src/cli/cloud/device-login.ts
+++ b/packages/vendo/src/cli/cloud/device-login.ts
@@ -5,6 +5,7 @@ import { option } from "./args.js";
 import { isVendoKey, resolveCloudBaseUrl } from "./client.js";
 import { errorMessage, printJson } from "./output.js";
 import { deletePendingClaim, readPendingClaim, writePendingClaim } from "./pending-claim.js";
+import { writeCloudSession, type CloudSession } from "./session.js";
 import { upsertEnvLocal } from "../cloud-init.js";
 import { browserOpenCommand } from "../playground.js";
 import { CLI_VERSION, consoleOutput, withCommandRun, type Output, type TelemetryOptions } from "../shared.js";
@@ -97,6 +98,25 @@ function ceremonyFrom(value: unknown): Ceremony {
     throw new Error("Vendo Cloud returned an invalid claim ceremony");
   }
   return body as Ceremony;
+}
+
+/**
+ * Unified auth: the device-claim (`oauth/token`) response may carry the
+ * account-level Supabase session ALONGSIDE the minted project key. The key is
+ * the top-level `access_token` (a `vnd_` string), so the session — whose own
+ * `access_token` is a Supabase JWT — arrives nested under `session` to avoid
+ * the name collision. Returns it only when well-formed (a string
+ * `access_token`); anything else (older console, absent, malformed) → null, so
+ * the caller stays key-only with no session file and no crash.
+ */
+function accountSessionFrom(body: unknown): CloudSession | null {
+  const session = (body as { session?: unknown } | null)?.session;
+  if (typeof session !== "object" || session === null) return null;
+  const candidate = session as Partial<CloudSession>;
+  if (typeof candidate.access_token !== "string") return null;
+  if (candidate.refresh_token !== undefined && typeof candidate.refresh_token !== "string") return null;
+  if (candidate.expires_at !== undefined && typeof candidate.expires_at !== "number") return null;
+  return candidate as CloudSession;
 }
 
 async function postJson(
@@ -308,6 +328,20 @@ export async function runDeviceLogin(
           );
         }
         await deletePendingClaim(claimCwd, pendingHome);
+        // Unified auth: one login establishes the account-level session too.
+        // When the claim response carries a Supabase session alongside the key,
+        // persist it so account-level `cloud` subcommands work immediately with
+        // no second ceremony (older consoles omit it — key-only). Best-effort:
+        // the key is the primary credential and is already saved, so a
+        // session-write failure must never turn a successful login into a fault.
+        const session = accountSessionFrom(poll.body);
+        if (session !== null) {
+          try {
+            await writeCloudSession(session, pendingHome);
+          } catch {
+            // A session-write failure must not strand a successful key login.
+          }
+        }
         // Never print the key itself — .env.local is the hand-off, last4 the
         // receipt. A resumed run names the full path: it may differ from cwd.
         output.log(`Approved — wrote VENDO_API_KEY (…${key.slice(-4)}) to ${

--- a/packages/vendo/src/cli/config.test.ts
+++ b/packages/vendo/src/cli/config.test.ts
@@ -312,6 +312,78 @@ describe("vendo config pull", () => {
   });
 });
 
+// `vendo login` writes VENDO_API_KEY to .env.local, so the config commands must
+// load .env (then .env.local, local wins) from the project dir before resolving
+// the key — matching how init/the runtime source credentials. Precedence: an
+// already-set process env VENDO_API_KEY wins; an unset one falls back to
+// .env.local. Without this a fresh shell after `vendo login` would fail the
+// guard until the user manually `source`d the file (the decoupling the live
+// e2e caught).
+describe("vendo config key resolution (.env.local)", () => {
+  const FILE_KEY = `vnd_${"f".repeat(40)}`;
+
+  it("push resolves VENDO_API_KEY from .env.local when the process env has none", async () => {
+    const dir = await tempProject({ "design-rules.md": "# local" });
+    await writeFile(join(dir, ".env.local"), `VENDO_API_KEY=${FILE_KEY}\n`, "utf8");
+    const seen: Array<{ auth?: string; env?: Record<string, string | undefined> }> = [];
+    const fetcher: CloudFetcher = vi.fn(async (path, options) => {
+      seen.push({ auth: options?.auth, env: options?.env });
+      if (path === "/api/v1/config/draft" && (options?.method ?? "GET") === "GET") return { draft: {} };
+      return { draft: (options!.body as { draft: unknown }).draft };
+    });
+    const code = await runConfig(["push", "design-rules.md"], {
+      targetDir: dir, fetcher, output: capture().output, confirm: async () => false, env: {},
+    });
+    expect(code).toBe(0);
+    // The .env.local key reached the fetcher (the server reads env.VENDO_API_KEY).
+    expect(seen[0]?.auth).toBe("key");
+    expect(seen[0]?.env?.VENDO_API_KEY).toBe(FILE_KEY);
+  });
+
+  it("pull resolves VENDO_API_KEY from .env.local when the process env has none", async () => {
+    const dir = await tempProject();
+    await writeFile(join(dir, ".env.local"), `VENDO_API_KEY=${FILE_KEY}\n`, "utf8");
+    const fetcher: CloudFetcher = vi.fn(async (path, options) => {
+      expect(options?.auth).toBe("key");
+      expect(options?.env?.VENDO_API_KEY).toBe(FILE_KEY);
+      return PUBLISHED;
+    });
+    const code = await runConfig(["pull", "design-rules.md"], {
+      targetDir: dir, fetcher, output: capture().output, env: {},
+    });
+    expect(code).toBe(0);
+    expect(await readFile(join(dir, ".vendo", "design-rules.md"), "utf8")).toBe("# cloud rules");
+  });
+
+  it("a set process env VENDO_API_KEY wins over .env.local (env wins, like the runtime)", async () => {
+    const dir = await tempProject();
+    await writeFile(join(dir, ".env.local"), `VENDO_API_KEY=${FILE_KEY}\n`, "utf8");
+    const envKey = `vnd_${"e".repeat(40)}`;
+    let seenEnvKey: string | undefined;
+    const fetcher: CloudFetcher = vi.fn(async (_path, options) => {
+      seenEnvKey = options?.env?.VENDO_API_KEY;
+      return PUBLISHED;
+    });
+    await runConfig(["pull", "design-rules.md"], {
+      targetDir: dir, fetcher, output: capture().output, env: { VENDO_API_KEY: envKey },
+    });
+    expect(seenEnvKey).toBe(envKey);
+  });
+
+  it("still fires the `vendo login` guard when neither env nor .env.local carries a key", async () => {
+    const dir = await tempProject({ "design-rules.md": "# local" });
+    await writeFile(join(dir, ".env.local"), "FOO=bar\n", "utf8"); // present but no key
+    const fetcher = vi.fn();
+    const cap = capture();
+    const code = await runConfig(["push", "design-rules.md"], {
+      targetDir: dir, fetcher: fetcher as unknown as CloudFetcher, output: cap.output, env: {},
+    });
+    expect(code).toBe(1);
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(cap.errors.join("\n")).toMatch(/vendo login/);
+  });
+});
+
 // A bare `--key X` (and --api-url) must never have its VALUE read as the
 // surface or the target dir, in EITHER order (Devin/Greptile P2 — same class as
 // cli.ts's --engine target() fix). These exercise the positional path (no

--- a/packages/vendo/src/cli/config.test.ts
+++ b/packages/vendo/src/cli/config.test.ts
@@ -6,10 +6,12 @@ import { runConfig } from "./config.js";
 import type { CloudFetcher } from "./cloud/command.js";
 import type { Output } from "./shared.js";
 
-// `vendo config` (cse lane 3): push/pull a `.vendo` content surface to/from the
-// hosted console, and report each surface's resolved OWNER. push writes the
-// console DRAFT (publish stays a console action); pull defaults to the PUBLISHED
-// value (--draft pulls the draft). Wire shapes mirror the config-wire fixtures.
+// `vendo config` (unified auth): push/pull/status are PROJECT-SCOPED, so they
+// authenticate with the single project credential — VENDO_API_KEY — and hit the
+// key-authed console plane (project derived from the key), NEVER the user
+// session (~/.vendo/cloud-session.json). push writes the key-authed console
+// DRAFT (`/api/v1/config/draft`; publish stays a console action); pull defaults
+// to the PUBLISHED value (`/api/v1/config`), `--draft` reads the draft plane.
 
 const dirs: string[] = [];
 afterEach(async () => {
@@ -40,6 +42,8 @@ const PUBLISHED = {
   },
 };
 
+const KEY = { VENDO_API_KEY: `vnd_${"a".repeat(40)}` };
+
 describe("vendo config status", () => {
   it("reports each surface as file / cloud / unset and notes explicit is not CLI-visible", async () => {
     const dir = await tempProject({ "brief.md": "on-disk brief" });
@@ -52,7 +56,7 @@ describe("vendo config status", () => {
       targetDir: dir,
       fetcher,
       output: cap.output,
-      env: { VENDO_API_KEY: "vnd_key" },
+      env: KEY,
     });
     expect(code).toBe(0);
     const joined = cap.lines.join("\n");
@@ -66,11 +70,21 @@ describe("vendo config status", () => {
     expect(joined.toLowerCase()).toContain("explicit");
   });
 
+  it("reads the published surface with the KEY, never the user session", async () => {
+    const dir = await tempProject({ "brief.md": "b" });
+    const fetcher: CloudFetcher = vi.fn(async () => PUBLISHED);
+    await runConfig(["status"], { targetDir: dir, fetcher, output: capture().output, env: KEY });
+    expect(fetcher).toHaveBeenCalledWith("/api/v1/config", expect.objectContaining({ auth: "key" }));
+    for (const [, options] of (fetcher as unknown as { mock: { calls: Array<[string, { auth?: string }]> } }).mock.calls) {
+      expect(options.auth).not.toBe("user");
+    }
+  });
+
   it("prints the overrides enablement caveat (#557)", async () => {
     const dir = await tempProject();
     const fetcher: CloudFetcher = vi.fn(async () => ({ version: null, config: null }));
     const cap = capture();
-    await runConfig(["status"], { targetDir: dir, fetcher, output: cap.output, env: { VENDO_API_KEY: "vnd_key" } });
+    await runConfig(["status"], { targetDir: dir, fetcher, output: cap.output, env: KEY });
     const joined = cap.lines.join("\n");
     expect(joined).toContain("#557");
     expect(joined.toLowerCase()).toContain("enablement");
@@ -92,37 +106,56 @@ describe("vendo config status", () => {
 });
 
 describe("vendo config push", () => {
-  it("merges the one surface into the console draft, PUTs it, and offers to delete the local file", async () => {
+  it("merges the one surface into the KEY-authed console draft and PUTs it — no session, no project", async () => {
     const dir = await tempProject({ "design-rules.md": "# local rules" });
-    const calls: Array<{ path: string; method: string; body: unknown }> = [];
+    const calls: Array<{ path: string; method: string; body: unknown; auth?: string }> = [];
     const fetcher: CloudFetcher = vi.fn(async (path, options) => {
-      calls.push({ path, method: options?.method ?? "GET", body: options?.body });
-      if (path.endsWith("/config") && (options?.method ?? "GET") === "GET") {
+      calls.push({ path, method: options?.method ?? "GET", body: options?.body, auth: options?.auth });
+      if (path === "/api/v1/config/draft" && (options?.method ?? "GET") === "GET") {
         return { draft: { "brief.md": "keep me" }, draftUpdatedAt: "t", draftUpdatedBy: "u" };
       }
-      if (path.endsWith("/config") && options?.method === "PUT") {
-        return { draft: options.body && (options.body as { draft: unknown }).draft, draftUpdatedAt: "t2", draftUpdatedBy: "u" };
+      if (path === "/api/v1/config/draft" && options?.method === "PUT") {
+        return { draft: options.body && (options.body as { draft: unknown }).draft, draftUpdatedAt: "t2" };
       }
       throw new Error(`unexpected ${path} ${options?.method}`);
     });
     const confirm = vi.fn(async () => true);
     const cap = capture();
-    const code = await runConfig(["push", "design-rules.md", "--project", "proj_1"], {
+    const code = await runConfig(["push", "design-rules.md"], {
       targetDir: dir,
       fetcher,
       output: cap.output,
       confirm,
-      env: {},
+      env: KEY,
     });
     expect(code).toBe(0);
     const put = calls.find((c) => c.method === "PUT");
     // The whole draft is replaced, so the surface is MERGED onto the current
     // draft (brief.md preserved), never dropped.
     expect(put?.body).toEqual({ draft: { "brief.md": "keep me", "design-rules.md": "# local rules" } });
-    expect(put?.path).toBe("/api/v1/projects/proj_1/config");
+    expect(put?.path).toBe("/api/v1/config/draft");
+    // Every call authenticated with the KEY, never the user session.
+    expect(calls.every((c) => c.auth === "key")).toBe(true);
     // Delete offered and accepted → local file gone (cloud is now the source).
     expect(confirm).toHaveBeenCalled();
     await expect(readFile(join(dir, ".vendo", "design-rules.md"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("errors with a `vendo login` hint when no key is present, before any network call", async () => {
+    const dir = await tempProject({ "design-rules.md": "# local" });
+    const fetcher = vi.fn();
+    const cap = capture();
+    const code = await runConfig(["push", "design-rules.md"], {
+      targetDir: dir,
+      fetcher: fetcher as unknown as CloudFetcher,
+      output: cap.output,
+      env: {},
+    });
+    expect(code).toBe(1);
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(cap.errors.join("\n")).toMatch(/vendo login/);
+    // The local file is untouched — nothing was pushed.
+    expect(await readFile(join(dir, ".vendo", "design-rules.md"), "utf8")).toBe("# local");
   });
 
   it("--yes skips the prompt and deletes the local file", async () => {
@@ -132,12 +165,12 @@ describe("vendo config push", () => {
       return { draft: (options!.body as { draft: unknown }).draft };
     });
     const confirm = vi.fn(async () => false);
-    const code = await runConfig(["push", "policy.json", "--project", "p", "--yes"], {
+    const code = await runConfig(["push", "policy.json", "--yes"], {
       targetDir: dir,
       fetcher,
       output: capture().output,
       confirm,
-      env: {},
+      env: KEY,
     });
     expect(code).toBe(0);
     expect(confirm).not.toHaveBeenCalled();
@@ -148,12 +181,12 @@ describe("vendo config push", () => {
     const dir = await tempProject({ "policy.json": "{}" });
     const fetcher: CloudFetcher = vi.fn(async (path, options) =>
       (options?.method ?? "GET") === "GET" ? { draft: {} } : { draft: (options!.body as { draft: unknown }).draft });
-    const code = await runConfig(["push", "policy.json", "--project", "p"], {
+    const code = await runConfig(["push", "policy.json"], {
       targetDir: dir,
       fetcher,
       output: capture().output,
       confirm: async () => false,
-      env: {},
+      env: KEY,
     });
     expect(code).toBe(0);
     expect(await readFile(join(dir, ".vendo", "policy.json"), "utf8")).toBe("{}");
@@ -164,27 +197,27 @@ describe("vendo config push", () => {
       (options?.method ?? "GET") === "GET" ? { draft: {} } : { draft: (options!.body as { draft: unknown }).draft });
     // overrides.json → caveat present
     const over = capture();
-    await runConfig(["push", "overrides.json", "--project", "p", "--yes"], {
+    await runConfig(["push", "overrides.json", "--yes"], {
       targetDir: await tempProject({ "overrides.json": "{}" }),
-      fetcher, output: over.output, env: {},
+      fetcher, output: over.output, env: KEY,
     });
     expect(over.lines.join("\n")).toContain("#557");
     // design-rules.md → no caveat
     const rules = capture();
-    await runConfig(["push", "design-rules.md", "--project", "p", "--yes"], {
+    await runConfig(["push", "design-rules.md", "--yes"], {
       targetDir: await tempProject({ "design-rules.md": "# rules" }),
-      fetcher, output: rules.output, env: {},
+      fetcher, output: rules.output, env: KEY,
     });
     expect(rules.lines.join("\n")).not.toContain("#557");
   });
 
   it("errors on an unknown surface", async () => {
     const cap = capture();
-    const code = await runConfig(["push", "tools.json", "--project", "p"], {
+    const code = await runConfig(["push", "tools.json"], {
       targetDir: await tempProject(),
       fetcher: vi.fn(),
       output: cap.output,
-      env: {},
+      env: KEY,
     });
     expect(code).toBe(1);
     expect(cap.errors.join("\n")).toMatch(/unknown surface/i);
@@ -192,11 +225,11 @@ describe("vendo config push", () => {
 
   it("errors when the local file is missing", async () => {
     const cap = capture();
-    const code = await runConfig(["push", "brief.md", "--project", "p"], {
+    const code = await runConfig(["push", "brief.md"], {
       targetDir: await tempProject(),
       fetcher: vi.fn(),
       output: cap.output,
-      env: {},
+      env: KEY,
     });
     expect(code).toBe(1);
     expect(cap.errors.join("\n")).toMatch(/no .*brief\.md|not found|does not exist/i);
@@ -204,7 +237,7 @@ describe("vendo config push", () => {
 });
 
 describe("vendo config pull", () => {
-  it("writes the PUBLISHED value to the local .vendo file by default", async () => {
+  it("writes the PUBLISHED value to the local .vendo file by default, KEY-authed", async () => {
     const dir = await tempProject();
     const fetcher: CloudFetcher = vi.fn(async (path, options) => {
       expect(path).toBe("/api/v1/config");
@@ -215,27 +248,41 @@ describe("vendo config pull", () => {
       targetDir: dir,
       fetcher,
       output: capture().output,
-      env: { VENDO_API_KEY: "vnd_key" },
+      env: KEY,
     });
     expect(code).toBe(0);
     expect(await readFile(join(dir, ".vendo", "design-rules.md"), "utf8")).toBe("# cloud rules");
   });
 
-  it("--draft pulls the console draft instead of the published value", async () => {
+  it("--draft pulls the KEY-authed console draft plane instead of the published value", async () => {
     const dir = await tempProject();
     const fetcher: CloudFetcher = vi.fn(async (path, options) => {
-      expect(path).toBe("/api/v1/projects/proj_1/config");
-      expect(options?.auth).toBe("user");
+      expect(path).toBe("/api/v1/config/draft");
+      expect(options?.auth).toBe("key");
       return { draft: { "brief.md": "draft brief" } };
     });
-    const code = await runConfig(["pull", "brief.md", "--draft", "--project", "proj_1"], {
+    const code = await runConfig(["pull", "brief.md", "--draft"], {
       targetDir: dir,
       fetcher,
       output: capture().output,
-      env: {},
+      env: KEY,
     });
     expect(code).toBe(0);
     expect(await readFile(join(dir, ".vendo", "brief.md"), "utf8")).toBe("draft brief");
+  });
+
+  it("errors with a `vendo login` hint when no key is present, before any network call", async () => {
+    const fetcher = vi.fn();
+    const cap = capture();
+    const code = await runConfig(["pull", "design-rules.md"], {
+      targetDir: await tempProject(),
+      fetcher: fetcher as unknown as CloudFetcher,
+      output: cap.output,
+      env: {},
+    });
+    expect(code).toBe(1);
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(cap.errors.join("\n")).toMatch(/vendo login/);
   });
 
   it("errors when the surface is not present in the published config", async () => {
@@ -244,7 +291,7 @@ describe("vendo config pull", () => {
       targetDir: await tempProject(),
       fetcher: vi.fn(async () => PUBLISHED),
       output: cap.output,
-      env: { VENDO_API_KEY: "vnd_key" },
+      env: KEY,
     });
     expect(code).toBe(1);
     expect(cap.errors.join("\n")).toMatch(/not (present|published)|no .*overrides/i);
@@ -257,7 +304,7 @@ describe("vendo config pull", () => {
       targetDir: await tempProject(),
       fetcher: fetcher as unknown as CloudFetcher,
       output: cap.output,
-      env: {},
+      env: KEY,
     });
     expect(code).toBe(1);
     expect(fetcher).not.toHaveBeenCalled();
@@ -265,16 +312,16 @@ describe("vendo config pull", () => {
   });
 });
 
-// A bare `--project X` (and --org/--key/--api-url) must never have its VALUE
-// read as the surface or the target dir, in EITHER order (Devin/Greptile P2 —
-// same class as cli.ts's --engine target() fix). These exercise the positional
-// path (no options.targetDir), so the dir comes from the args.
+// A bare `--key X` (and --api-url) must never have its VALUE read as the
+// surface or the target dir, in EITHER order (Devin/Greptile P2 — same class as
+// cli.ts's --engine target() fix). These exercise the positional path (no
+// options.targetDir), so the dir comes from the args.
 describe("vendo config positional parsing (value-flag orderings)", () => {
   function pushFetcher(calls: Array<{ path: string; method: string; body: unknown }>): CloudFetcher {
     return vi.fn(async (path: string, options?: { method?: string; body?: unknown }) => {
       calls.push({ path, method: options?.method ?? "GET", body: options?.body });
-      if (path.endsWith("/config") && (options?.method ?? "GET") === "GET") return { draft: {} };
-      if (path.endsWith("/config") && options?.method === "PUT") {
+      if (path === "/api/v1/config/draft" && (options?.method ?? "GET") === "GET") return { draft: {} };
+      if (path === "/api/v1/config/draft" && options?.method === "PUT") {
         return { draft: (options.body as { draft: unknown }).draft };
       }
       throw new Error(`unexpected ${path} ${options?.method}`);
@@ -285,7 +332,7 @@ describe("vendo config positional parsing (value-flag orderings)", () => {
     const dir = await tempProject({ "design-rules.md": "# local" });
     const calls: Array<{ path: string; method: string; body: unknown }> = [];
     const cap = capture();
-    const code = await runConfig(["push", "--project", "proj_1", "design-rules.md", dir], {
+    const code = await runConfig(["push", "--key", KEY.VENDO_API_KEY, "design-rules.md", dir], {
       fetcher: pushFetcher(calls),
       output: cap.output,
       confirm: async () => false, // keep the local file
@@ -293,7 +340,7 @@ describe("vendo config positional parsing (value-flag orderings)", () => {
     });
     expect(code).toBe(0);
     const put = calls.find((c) => c.method === "PUT");
-    expect(put?.path).toBe("/api/v1/projects/proj_1/config");
+    expect(put?.path).toBe("/api/v1/config/draft");
     expect(put?.body).toEqual({ draft: { "design-rules.md": "# local" } });
   });
 
@@ -301,7 +348,7 @@ describe("vendo config positional parsing (value-flag orderings)", () => {
     const dir = await tempProject({ "design-rules.md": "# local" });
     const calls: Array<{ path: string; method: string; body: unknown }> = [];
     const cap = capture();
-    const code = await runConfig(["push", "design-rules.md", dir, "--project", "proj_1"], {
+    const code = await runConfig(["push", "design-rules.md", dir, "--key", KEY.VENDO_API_KEY], {
       fetcher: pushFetcher(calls),
       output: cap.output,
       confirm: async () => false,
@@ -309,13 +356,13 @@ describe("vendo config positional parsing (value-flag orderings)", () => {
     });
     expect(code).toBe(0);
     const put = calls.find((c) => c.method === "PUT");
-    expect(put?.path).toBe("/api/v1/projects/proj_1/config");
+    expect(put?.path).toBe("/api/v1/config/draft");
     expect(put?.body).toEqual({ draft: { "design-rules.md": "# local" } });
   });
 
   it("push still reports an unknown surface when a value-flag precedes it", async () => {
     const cap = capture();
-    const code = await runConfig(["push", "--project", "proj_1", "not-a-surface"], {
+    const code = await runConfig(["push", "--key", KEY.VENDO_API_KEY, "not-a-surface"], {
       fetcher: vi.fn(async () => {
         throw new Error("must not fetch");
       }) as unknown as CloudFetcher,
@@ -326,21 +373,21 @@ describe("vendo config positional parsing (value-flag orderings)", () => {
     expect(cap.errors.join("\n")).toMatch(/unknown surface/i);
   });
 
-  it("status resolves its dir positional in either order, never reading the --project value as the dir", async () => {
+  it("status resolves its dir positional in either order, never reading the --key value as the dir", async () => {
     const dir = await tempProject({ "brief.md": "on disk" });
     for (const args of [
-      ["status", "--project", "X", dir],
-      ["status", dir, "--project", "X"],
+      ["status", "--key", KEY.VENDO_API_KEY, dir],
+      ["status", dir, "--key", KEY.VENDO_API_KEY],
     ]) {
       const cap = capture();
       const code = await runConfig(args, {
         fetcher: vi.fn(async () => ({ version: null, config: null })) as unknown as CloudFetcher,
         output: cap.output,
-        env: { VENDO_API_KEY: "vnd_key" },
+        env: {},
       });
       expect(code).toBe(0);
-      // brief.md is on disk in `dir` → "file". Had the dir resolved to "X" or
-      // cwd, this would read "unset".
+      // brief.md is on disk in `dir` → "file". Had the dir resolved to the key
+      // value or cwd, this would read "unset".
       expect(cap.lines.join("\n")).toMatch(/brief\.md\s+file/);
     }
   });

--- a/packages/vendo/src/cli/config.ts
+++ b/packages/vendo/src/cli/config.ts
@@ -5,14 +5,12 @@ import { option, positionals } from "./cloud/args.js";
 import type { CloudFetchOptions } from "./cloud/client.js";
 import {
   commandContext,
-  resolveProjectId,
-  userOptions,
   type CloudCommandOptions,
   type CloudFetcher,
 } from "./cloud/command.js";
 import { askYesNo, consoleOutput, exists, readOptional, writeText, type Output } from "./shared.js";
 
-/** `vendo config` (cse lane 3) — move a `.vendo` content surface between local
+/** `vendo config` (unified auth) — move a `.vendo` content surface between local
  * disk and the hosted console, and report each surface's resolved OWNER.
  *
  * The seam this drives (selectConfigSurface): per surface, resolution is
@@ -26,11 +24,12 @@ import { askYesNo, consoleOutput, exists, readOptional, writeText, type Output }
  *     for the working draft) into the local `.vendo` file, ejecting cloud→file.
  *   - `config status`   lists each surface's owner (file / cloud / unset).
  *
- * The console DRAFT plane is session-authed (`vendo login`), so push and
- * `pull --draft` resolve a project (org → project, or `--project <id>`) and use
- * the user session; the PUBLISHED read is key-authed (the same call the runtime
- * makes). `explicit` (a programmatic override in createVendo) is not visible to
- * the CLI, so `config status` reports only file / cloud / unset. */
+ * These are all PROJECT-SCOPED, so they authenticate with the single project
+ * credential — VENDO_API_KEY — against the key-authed console plane (the
+ * project is derived from the key), NOT the user session. `vendo login` mints
+ * that key, so one login is enough; there is no separate session to go stale.
+ * `explicit` (a programmatic override in createVendo) is not visible to the
+ * CLI, so `config status` reports only file / cloud / unset. */
 
 export interface ConfigCommandOptions extends CloudCommandOptions {
   targetDir?: string;
@@ -47,14 +46,15 @@ Usage:
   vendo config push <surface> [dir]      Write the local .vendo file into the console draft
   vendo config pull <surface> [dir]      Write the console value into the local .vendo file
 
+All commands authenticate with VENDO_API_KEY (run \`vendo login\` to mint one);
+the project is derived from the key.
+
 Surfaces: ${CONFIG_SURFACES.join(", ")}
 
 Options:
   --draft            Pull only: pull the working draft instead of the published value
   --yes              Push only: delete the local file without asking (cloud becomes the source)
-  --project <id>     Console draft: the project (omit only when the org has one project)
-  --org <id>         Console draft: the organization (omit only when you have one org)
-  --key <key>        Published read: override VENDO_API_KEY
+  --key <key>        Override VENDO_API_KEY
   --api-url <url>    Override VENDO_CLOUD_URL / https://console.vendo.run
 `;
 
@@ -63,12 +63,16 @@ function vendoPath(targetDir: string, surface: ConfigSurfaceName): string {
 }
 
 /** Value-taking flags whose VALUE must never be read as the surface or dir.
- *  A bare `--project X` leaks `X` into a naive non-`--` scan, so the surface or
+ *  A bare `--key X` leaks `X` into a naive non-`--` scan, so the surface or
  *  target dir is silently wrong (Devin/Greptile P2 — the same class as cli.ts's
  *  --engine target() fix). `positionals()` strips each `<opt> <value>` pair,
- *  which fixes BOTH orderings (`push <surface> --project X` and
- *  `push --project X <surface>`). Boolean flags (--draft, --yes) take no value. */
-const CONFIG_VALUE_OPTIONS = ["--project", "--org", "--key", "--api-url", "--token"];
+ *  which fixes BOTH orderings (`push <surface> --key X` and
+ *  `push --key X <surface>`). Boolean flags (--draft, --yes) take no value. */
+const CONFIG_VALUE_OPTIONS = ["--key", "--api-url"];
+
+/** The key-authed console DRAFT plane (project derived from the key). Mirrors
+ *  the published read `/api/v1/config`; PUT replaces the whole draft doc. */
+const DRAFT_PATH = "/api/v1/config/draft";
 
 function surfaceArg(args: string[]): { surface?: ConfigSurfaceName; error?: string } {
   const positional = positionals(args, CONFIG_VALUE_OPTIONS)[0];
@@ -97,6 +101,20 @@ function keyOptions(args: string[], options: ConfigCommandOptions): CloudFetchOp
     home: options.home,
     env: options.env ?? process.env,
   };
+}
+
+/** The same key resolution the runtime uses: an explicit `--key`, else
+ *  VENDO_API_KEY from the environment (.env.local is loaded into it). Returns
+ *  the key or, when none is present, prints the `vendo login` remedy and null —
+ *  so push/pull refuse up front instead of failing on the first service call
+ *  with a bare "missing key". status stays lenient (it degrades to "unknown"). */
+function requireKey(args: string[], options: ConfigCommandOptions, output: Output): string | null {
+  const key = option(args, "--key") ?? (options.env ?? process.env).VENDO_API_KEY;
+  if (key === undefined || key === "") {
+    output.error("No VENDO_API_KEY found. Run `vendo login` to mint a project key (or pass --key).");
+    return null;
+  }
+  return key;
 }
 
 interface PublishedConfig {
@@ -159,16 +177,15 @@ async function runPush(args: string[], context: {
     output.error(`no ${join(".vendo", surface)} to push (nothing local to make cloud the source of)`);
     return 1;
   }
-  const commandCtx = commandContext(options);
-  const projectId = await resolveProjectId(args, commandCtx);
-  const userOpts = userOptions(args, commandCtx);
-  const path = `/api/v1/projects/${encodeURIComponent(projectId)}/config`;
-  // Read-merge-write: the draft PUT replaces the WHOLE draft, so merge this one
-  // surface onto the current draft — never drop the others.
-  const current = (await fetcher(path, userOpts)) as DraftConfig;
+  if (requireKey(args, options, output) === null) return 1;
+  const keyOpts = keyOptions(args, options);
+  // Read-merge-write against the KEY-authed draft plane (project from the key):
+  // the draft PUT replaces the WHOLE draft, so merge this one surface onto the
+  // current draft — never drop the others.
+  const current = (await fetcher(DRAFT_PATH, keyOpts)) as DraftConfig;
   const nextDraft = { ...(current.draft ?? {}), [surface]: body };
-  await fetcher(path, { ...userOpts, method: "PUT", body: { draft: nextDraft } });
-  output.log(`Pushed ${surface} to the ${projectId} config draft. Publish it from the console to make it live.`);
+  await fetcher(DRAFT_PATH, { ...keyOpts, method: "PUT", body: { draft: nextDraft } });
+  output.log(`Pushed ${surface} to the config draft. Publish it from the console to make it live.`);
   // #557 — warn before the delete offer that a cloud overrides.json does not
   // disable tools at runtime, so removing the local file is not a tool-disable.
   if (surface === "overrides.json") output.log(OVERRIDES_ENABLEMENT_CAVEAT);
@@ -196,14 +213,12 @@ async function runPull(args: string[], context: {
   }
   const dir = targetDir(args, options, true); // dir follows the surface
   const wantDraft = args.includes("--draft");
+  if (requireKey(args, options, output) === null) return 1;
   let value: string | undefined;
   if (wantDraft) {
-    const commandCtx = commandContext(options);
-    const projectId = await resolveProjectId(args, commandCtx);
-    const result = (await fetcher(
-      `/api/v1/projects/${encodeURIComponent(projectId)}/config`,
-      userOptions(args, commandCtx),
-    )) as DraftConfig;
+    // The KEY-authed draft plane (project from the key) — same credential as
+    // the published read, no user session.
+    const result = (await fetcher(DRAFT_PATH, keyOptions(args, options))) as DraftConfig;
     value = result.draft?.[surface];
   } else {
     const result = (await fetcher("/api/v1/config", keyOptions(args, options))) as PublishedConfig;

--- a/packages/vendo/src/cli/config.ts
+++ b/packages/vendo/src/cli/config.ts
@@ -8,6 +8,7 @@ import {
   type CloudCommandOptions,
   type CloudFetcher,
 } from "./cloud/command.js";
+import { mergeEnvOverDotEnv, readDotEnvFallback } from "./doctor.js";
 import { askYesNo, consoleOutput, exists, readOptional, writeText, type Output } from "./shared.js";
 
 /** `vendo config` (unified auth) — move a `.vendo` content surface between local
@@ -103,11 +104,23 @@ function keyOptions(args: string[], options: ConfigCommandOptions): CloudFetchOp
   };
 }
 
+/** Load the project's dotenv (`.env` then `.env.local`; local wins) and merge
+ *  it UNDER the process/host env, then hand that back as the command's env.
+ *  `vendo login` writes VENDO_API_KEY to `.env.local`, so a fresh shell after
+ *  login must pick the key up from there with no manual `source` — while an
+ *  already-set process VENDO_API_KEY still wins, exactly as init and the
+ *  runtime resolve credentials. Reuses doctor's dotenv util (no hand-rolled
+ *  parser). */
+async function scopedEnv(dir: string, options: ConfigCommandOptions): Promise<Record<string, string | undefined>> {
+  return mergeEnvOverDotEnv(await readDotEnvFallback(dir), (options.env ?? process.env) as NodeJS.ProcessEnv);
+}
+
 /** The same key resolution the runtime uses: an explicit `--key`, else
- *  VENDO_API_KEY from the environment (.env.local is loaded into it). Returns
- *  the key or, when none is present, prints the `vendo login` remedy and null —
- *  so push/pull refuse up front instead of failing on the first service call
- *  with a bare "missing key". status stays lenient (it degrades to "unknown"). */
+ *  VENDO_API_KEY from the environment (with `.env.local` merged in by
+ *  scopedEnv). Returns the key or, when none is present, prints the `vendo
+ *  login` remedy and null — so push/pull refuse up front instead of failing on
+ *  the first service call with a bare "missing key". status stays lenient (it
+ *  degrades to "unknown"). */
 function requireKey(args: string[], options: ConfigCommandOptions, output: Output): string | null {
   const key = option(args, "--key") ?? (options.env ?? process.env).VENDO_API_KEY;
   if (key === undefined || key === "") {
@@ -133,11 +146,12 @@ async function runStatus(args: string[], context: {
 }): Promise<number> {
   const { fetcher, output, options } = context;
   const dir = targetDir(args, options, false); // status takes no surface
+  const scoped: ConfigCommandOptions = { ...options, env: await scopedEnv(dir, options) };
   // The published cloud doc (key-authed). A missing key / unreachable console
   // leaves cloud presence UNKNOWN rather than falsely reporting "unset".
   let published: Record<string, string> | null | undefined;
   try {
-    const result = (await fetcher("/api/v1/config", keyOptions(args, options))) as PublishedConfig;
+    const result = (await fetcher("/api/v1/config", keyOptions(args, scoped))) as PublishedConfig;
     published = result.config;
   } catch {
     published = undefined;
@@ -177,8 +191,9 @@ async function runPush(args: string[], context: {
     output.error(`no ${join(".vendo", surface)} to push (nothing local to make cloud the source of)`);
     return 1;
   }
-  if (requireKey(args, options, output) === null) return 1;
-  const keyOpts = keyOptions(args, options);
+  const scoped: ConfigCommandOptions = { ...options, env: await scopedEnv(dir, options) };
+  if (requireKey(args, scoped, output) === null) return 1;
+  const keyOpts = keyOptions(args, scoped);
   // Read-merge-write against the KEY-authed draft plane (project from the key):
   // the draft PUT replaces the WHOLE draft, so merge this one surface onto the
   // current draft — never drop the others.
@@ -213,15 +228,16 @@ async function runPull(args: string[], context: {
   }
   const dir = targetDir(args, options, true); // dir follows the surface
   const wantDraft = args.includes("--draft");
-  if (requireKey(args, options, output) === null) return 1;
+  const scoped: ConfigCommandOptions = { ...options, env: await scopedEnv(dir, options) };
+  if (requireKey(args, scoped, output) === null) return 1;
   let value: string | undefined;
   if (wantDraft) {
     // The KEY-authed draft plane (project from the key) — same credential as
     // the published read, no user session.
-    const result = (await fetcher(DRAFT_PATH, keyOptions(args, options))) as DraftConfig;
+    const result = (await fetcher(DRAFT_PATH, keyOptions(args, scoped))) as DraftConfig;
     value = result.draft?.[surface];
   } else {
-    const result = (await fetcher("/api/v1/config", keyOptions(args, options))) as PublishedConfig;
+    const result = (await fetcher("/api/v1/config", keyOptions(args, scoped))) as PublishedConfig;
     value = result.config?.[surface];
   }
   if (value === undefined) {


### PR DESCRIPTION
Part 2 of unified auth (approved 2026-07-26) — the CLI half. Pairs with vendo-web #168 (merged, deployed). LIVE e2e passed end-to-end with key-only auth.

## What
- `config push/pull/status` authenticate with VENDO_API_KEY, not the user session — hitting the console's new key-authed write endpoints (project derived from the key). This fixes the reported bug where a fresh `vendo login` (which mints a key, not a session) failed config-push with "invalid/expired refresh token". Headless/CI/agents can now config-push with just a key.
- `config push/pull/status` load `.env.local` (and `.env`) before resolving the key — reusing doctor's existing dotenv loader — so the key `vendo login` writes to `.env.local` is picked up without a manual `source`. Precedence: --key > process.env > .env.local; env wins over the file.
- `vendo login` also establishes the account session in the same device-claim ceremony IF the server returns one (client half; safely no-ops key-only until the server ships it — tracked #579). Account-level cloud subcommands (orgs/members/invites/whoami/keys) stay on session, now fresh from login.

## Live verification (against the deployed console)
With ONLY VENDO_API_KEY, no session: `config push` → publish (201) → runtime GET returns the published surface (marker present); secret set → runtime GET returns the value → delete. The exact flow that was broken now works. Attribution resolved the key's owner; secret values never echoed on write.

## Tests / gates
vendo 1159 passed / 13 skipped; typecheck + lint + dependency-guard + portability-gate green; next-env.d.ts zero-diff. Two-stage review: spec-compliant + secure (session write validated/best-effort, no token leakage, no cross-wiring).

Deferred (filed): #579 server oauth/token session mint.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `config push/pull/status` to authenticate with the project key and load `.env.local` before resolving it; `vendo login` now also writes the account session when the server returns one. This fixes fresh-login failures and enables key‑only CI flows.

- **New Features**
  - `vendo login` writes `~/.vendo/cloud-session.json` when the token response includes a session, while still saving `VENDO_API_KEY` to `.env.local` (best‑effort; older consoles stay key‑only).
  - `config push/pull/status` load `.env` then `.env.local` from the project dir before resolving the key. Precedence: `--key` > process env > `.env.local`.
  - Clear guard when no key is found with a hint to run `vendo login`.
  - Draft writes/read use the key‑authed plane at `/api/v1/config/draft` (project derived from the key).

- **Bug Fixes**
  - `config push/pull/status` no longer use the user session, fixing the “invalid/expired refresh token” after a fresh `vendo login`. Key‑only auth now works for headless/CI.

<sup>Written for commit b5c85c0d5048d31429eed9bfcd8f73d025498a0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

