### PR TITLE
smoke-render: non-string resolve results are environment skips, never refusals

### DIFF
--- a/packages/apps/src/generation/validation/smoke-render.ts
+++ b/packages/apps/src/generation/validation/smoke-render.ts
@@ -196,42 +196,71 @@ interface WorkerModules {
 }
 
 /** A resolved specifier the WORKER's plain-Node require can actually load: an
- *  absolute filesystem path. Under a bundled dev server (Turbopack) the
- *  bundler intercepts `createRequire(import.meta.url).resolve(...)` and
- *  returns an externals WRAPPER id like `[externals]/jsdom [external] (…)` —
- *  it does not throw, but plain require in the worker fails on it (live
- *  2026-07-23: every island-bearing app failed validation on that message).
- *  Only real paths may cross into the worker; anything else tries the next
- *  resolver or skips the gate. */
-export const isWorkerLoadablePath = (path: string): boolean =>
-  /^(?:\/|[A-Za-z]:[\\/])/.test(path);
+ *  absolute filesystem path STRING. A bundler that intercepts
+ *  `createRequire(import.meta.url).resolve(...)` does not throw — it returns
+ *  something plain require cannot load:
+ *   - Turbopack DEV servers return an externals WRAPPER id like
+ *     `[externals]/jsdom [external] (…)` (live 2026-07-23: every
+ *     island-bearing app failed validation on that message);
+ *   - Turbopack PRODUCTION servers (`next start`) return the bundler's
+ *     NUMERIC module id (rematch gate 2026-07-25: constant 429302 on both
+ *     hosts; `require(429302)` crashed the worker, every island-bearing app
+ *     was refused — 65/90 creates).
+ *  Only real path strings may cross into the worker; anything else tries the
+ *  next resolver or skips the gate. */
+export const isWorkerLoadablePath = (path: unknown): path is string =>
+  typeof path === "string" && /^(?:\/|[A-Za-z]:[\\/])/.test(path);
 
-/** Lazy module resolution, esbuild-pattern: unavailable → gate skips. The
- *  magic comments keep bundlers from walking into jsdom/react-dom. */
+/** The resolve surface `resolveWorkerModulePaths` needs. `resolve` returns
+ *  `unknown` on purpose: at RUNTIME a bundler-shimmed require hands back
+ *  numeric module ids despite NodeJS.Require's `string` claim. */
+export interface WorkerPathResolver {
+  resolve: (specifier: string) => unknown;
+}
+
+/** Resolve the worker's module paths through the first resolver whose EVERY
+ *  result is a worker-loadable absolute path. Non-string results (Turbopack
+ *  numeric ids), wrapper ids, and thrown resolutions fall through to the
+ *  next resolver — and to `undefined` (gate skips, the esbuild precedent)
+ *  when none qualifies. An environment failure is never an island refusal. */
+export const resolveWorkerModulePaths = (
+  resolvers: ReadonlyArray<() => WorkerPathResolver>,
+): WorkerModules["paths"] | undefined => {
+  for (const make of resolvers) {
+    try {
+      const require_ = make();
+      const paths = {
+        react: require_.resolve("react"),
+        reactDom: require_.resolve("react-dom"),
+        reactDomClient: require_.resolve("react-dom/client"),
+        jsdom: require_.resolve("jsdom"),
+      };
+      if (!Object.values(paths).every(isWorkerLoadablePath)) continue;
+      return paths as WorkerModules["paths"];
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+};
+
+/** Lazy module resolution, esbuild-pattern: unavailable → gate skips (logged
+ *  once — a silent skip hid the 2026-07-25 Turbopack signature for a full
+ *  gate run). The magic comments keep bundlers from walking into
+ *  jsdom/react-dom. */
 const workerModules = (async (): Promise<WorkerModules | undefined> => {
   try {
     const { Worker } = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ "node:worker_threads");
     const { createRequire } = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ "node:module");
-    const resolvers: Array<() => NodeJS.Require> = [
+    const paths = resolveWorkerModulePaths([
       () => createRequire(import.meta.url),
       () => createRequire(`${process.cwd()}/package.json`),
-    ];
-    for (const make of resolvers) {
-      try {
-        const require_ = make();
-        const paths = {
-          react: require_.resolve("react"),
-          reactDom: require_.resolve("react-dom"),
-          reactDomClient: require_.resolve("react-dom/client"),
-          jsdom: require_.resolve("jsdom"),
-        };
-        if (!Object.values(paths).every(isWorkerLoadablePath)) continue;
-        return { Worker, paths };
-      } catch {
-        continue;
-      }
+    ]);
+    if (paths === undefined) {
+      console.warn("[vendo] smoke-render gate skipped: react/jsdom did not resolve to filesystem paths in this environment (bundled server); islands ship without the crash gate");
+      return undefined;
     }
-    return undefined;
+    return { Worker, paths };
   } catch {
     return undefined;
   }

--- a/packages/apps/src/smoke-render.test.ts
+++ b/packages/apps/src/smoke-render.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { NormalizedCatalog } from "@vendoai/core";
-import { isWorkerLoadablePath, sampleFromShape, smokeRenderIslands } from "./generation/validation/smoke-render.js";
+import { isWorkerLoadablePath, resolveWorkerModulePaths, sampleFromShape, smokeRenderIslands } from "./generation/validation/smoke-render.js";
 import { modelEngine } from "./engine.js";
 import { scriptedLanguageModel, type ScriptedModelCall } from "./testing/index.js";
 
@@ -93,6 +93,64 @@ describe("isWorkerLoadablePath", () => {
     expect(isWorkerLoadablePath("C:\\dev\\app\\node_modules\\jsdom\\lib\\api.js")).toBe(true);
     expect(isWorkerLoadablePath("[externals]/jsdom [external] (jsdom, cjs)")).toBe(false);
     expect(isWorkerLoadablePath("jsdom")).toBe(false);
+  });
+
+  it("rejects NON-STRING resolve results — the Turbopack production numeric module id", () => {
+    // Rematch gate 2026-07-25 (docs/eval/runs/2026-07-25-rematch): under a
+    // Turbopack-bundled `next start` server, createRequire().resolve("react")
+    // returned Turbopack's NUMERIC module id (constant 429302 on both hosts);
+    // require(429302) in the worker crashed EVERY island-bearing app and
+    // 65/90 creates were refused. A non-string is never a loadable path.
+    expect(isWorkerLoadablePath(429302)).toBe(false);
+    expect(isWorkerLoadablePath(undefined)).toBe(false);
+    expect(isWorkerLoadablePath(null)).toBe(false);
+    expect(isWorkerLoadablePath({ id: "/real/path.js" })).toBe(false);
+  });
+});
+
+describe("resolveWorkerModulePaths", () => {
+  const absolute = (specifier: string): string => `/repo/node_modules/${specifier}/index.js`;
+
+  it("treats a resolver returning Turbopack numeric module ids as environment-unresolvable (gate skips, never a refusal)", () => {
+    // The 2026-07-25 rematch signature: every specifier resolves to the same
+    // bundler-internal number. No resolver qualifies → undefined → the gate
+    // skips per the esbuild precedent instead of refusing every island.
+    expect(resolveWorkerModulePaths([() => ({ resolve: () => 429302 })])).toBeUndefined();
+  });
+
+  it("falls through a numeric-id resolver to one returning real absolute paths", () => {
+    const paths = resolveWorkerModulePaths([
+      () => ({ resolve: () => 429302 }),
+      () => ({ resolve: absolute }),
+    ]);
+    expect(paths).toEqual({
+      react: absolute("react"),
+      reactDom: absolute("react-dom"),
+      reactDomClient: absolute("react-dom/client"),
+      jsdom: absolute("jsdom"),
+    });
+  });
+
+  it("rejects a resolver where ANY single specifier resolves non-string or to a wrapper id", () => {
+    const oneNumeric = (specifier: string): unknown => (specifier === "jsdom" ? 429302 : absolute(specifier));
+    expect(resolveWorkerModulePaths([() => ({ resolve: oneNumeric })])).toBeUndefined();
+    const oneWrapper = (specifier: string): unknown =>
+      (specifier === "jsdom" ? "[externals]/jsdom [external] (jsdom, cjs)" : absolute(specifier));
+    expect(resolveWorkerModulePaths([() => ({ resolve: oneWrapper })])).toBeUndefined();
+  });
+
+  it("treats throwing resolvers (and an empty resolver list) as environment-unresolvable", () => {
+    const throwing = (): { resolve: (specifier: string) => unknown } => ({
+      resolve: () => { throw new Error("Cannot find module"); },
+    });
+    expect(resolveWorkerModulePaths([throwing])).toBeUndefined();
+    expect(resolveWorkerModulePaths([throwing, () => ({ resolve: absolute })])).toEqual({
+      react: absolute("react"),
+      reactDom: absolute("react-dom"),
+      reactDomClient: absolute("react-dom/client"),
+      jsdom: absolute("jsdom"),
+    });
+    expect(resolveWorkerModulePaths([])).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## What

The 2026-07-25 rematch gate (#577, `docs/eval/runs/2026-07-25-rematch/`) hit a 65/90 refusal wall with one dominant mechanical cause: under **Turbopack-bundled production servers** (`next start`), `createRequire(import.meta.url).resolve("react")` returns Turbopack's **numeric module id** (constant `429302` on both hosts) instead of a filesystem path. The smoke-render worker then called `require(429302)`, crashed with `The "id" argument must be of type string`, and EVERY island-bearing app was refused as a fake "render crash".

## Fix (the gate's own documented esbuild precedent)

Any resolved specifier that is not an absolute path **string** — or a resolution that throws — is environment-unresolvable: the next resolver is tried, and when none qualifies the gate **skips gracefully** (logged once), never a refusal.

- `isWorkerLoadablePath` now takes `unknown` and requires `typeof === "string"` before the absolute-path test.
- Resolution is extracted into `resolveWorkerModulePaths` with injectable resolvers, so the Turbopack-shaped failure is directly unit-testable (red-first: numeric id → skip, wrapper id → skip, throw → fall through, mixed → skip, real paths → run).
- The skip logs once — a silent skip hid this signature for a full gate run.

## Audit

Per the task: the same file was audited for other `resolve()` results used as `require` targets — the four react/react-dom/react-dom-client/jsdom paths are the only ones, and all four cross the same `isWorkerLoadablePath` guard before entering the worker. The worker's only other require target is the literal `"node:worker_threads"`.

## Reproduction

Shimming `Module.createRequire` so `.resolve` returns `429302` (the Turbopack production signature), then running `smokeRenderIslands` on a healthy island:

- **gate commit (afa66bec)**: emits the exact live refusal — `island "ClientList" crashed … The "id" argument must be of type string. Received type number (429302) …`
- **this branch**: `[vendo] smoke-render gate skipped: react/jsdom did not resolve to filesystem paths in this environment (bundled server); islands ship without the crash gate` → zero issues, app ships.

## Gates

`pnpm build && pnpm test && pnpm typecheck && pnpm lint` green (vendo package test flaked once under a concurrent second suite binding the same ports; green standalone: 98 passed / 2 skipped).

No UI-affecting change (validation-gate internals only).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat non-string module resolve results in the smoke-render gate as environment skips, not refusals, to prevent false “render crash” failures under bundled servers like Turbopack. Adds a resolver pipeline and tests so the gate only runs when `react`/`jsdom` resolve to real filesystem paths; otherwise it logs once and skips.

- **Bug Fixes**
  - `isWorkerLoadablePath` is now a type guard that requires a string absolute path; numeric IDs and wrapper IDs are rejected before the worker.
  - When no resolver yields real paths, the gate logs once and skips instead of refusing islands.

- **Refactors**
  - Introduced `resolveWorkerModulePaths` (with `WorkerPathResolver`) to try multiple `createRequire` contexts; only proceeds when `react`, `react-dom`, `react-dom/client`, and `jsdom` resolve to absolute paths.
  - Added unit tests covering numeric IDs, wrapper IDs, thrown resolutions, fall-through to a valid resolver, and empty resolver lists.

<sup>Written for commit d8c09c0e4ab9f01871e267d0276f467bb9785a28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

