### PR TITLE
law 1 islands: exempt the user's own numbers and unit-conversion chains

### DIFF
--- a/apps/demo-template/.vendo/tools.json
+++ b/apps/demo-template/.vendo/tools.json
@@ -1,5 +1,5 @@
 {
-  "format": "vendo/tools@3",
+  "format": "vendo/tools@1",
   "tools": [
     {
       "name": "host_archiveItem",
@@ -22,8 +22,7 @@
         "operationId": "archiveItem",
         "method": "POST",
         "path": "/api/items/{id}/archive"
-      },
-      "srcHash": "sha256:2ca8a64aab13b4a5e72eaf875edbfc4e27f18325f8361a0b52479a049c542e33"
+      }
     },
     {
       "name": "host_listItems",
@@ -38,15 +37,7 @@
         "operationId": "listItems",
         "method": "GET",
         "path": "/api/items"
-      },
-      "srcHash": "sha256:2ca8a64aab13b4a5e72eaf875edbfc4e27f18325f8361a0b52479a049c542e33"
+      }
     }
-  ],
-  "domains": {
-    "has": [
-      "archive item",
-      "items"
-    ],
-    "hasNot": []
-  }
+  ]
 }

--- a/fixtures/host-app/next-env.d.ts
+++ b/fixtures/host-app/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/automations-e2e/dev/types/routes.d.ts";
+import "./.next/redteam-e2e/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/fixtures/host-app/next-env.d.ts
+++ b/fixtures/host-app/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/redteam-e2e/dev/types/routes.d.ts";
+import "./.next/automations-e2e/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/apps/src/engine-laws.test.ts
+++ b/packages/apps/src/engine-laws.test.ts
@@ -225,6 +225,75 @@ export default function SpendBars(props) {
   });
 });
 
+describe("law 1 in islands — the user's numbers and unit conversions (rematch 2026-07-25 carve-outs)", () => {
+  const budget = `<App name="Budget"><Island name="BudgetTracker">
+export default function BudgetTracker() {
+  const BUDGET_CENTS = 20000;
+  const [total, setTotal] = useState(0);
+  useEffect(() => { tools.host_metric({}).then((res) => setTotal(res.totalCents ?? 0)); }, []);
+  return <Stat label="Left this month" value={fmt.money(BUDGET_CENTS - total)} />;
+}
+</Island><BudgetTracker/></App>`;
+
+  it("ships the user's own $200 budget (BUDGET_CENTS = 20000) in ONE call — H12: no refusal, no repair", async () => {
+    let calls = 0;
+    const model = scriptedLanguageModel(() => {
+      calls += 1;
+      return budget;
+    });
+    const document = await modelEngine.create(
+      { prompt: "keep my entertainment spending under a $200 monthly budget" },
+      deps(model, { pipeline: { structuredRepair: false } }),
+    );
+    expect(calls).toBe(1);
+    expect(document.components?.BudgetTracker).toContain("BUDGET_CENTS = 20000");
+  });
+
+  it("still routes the same constant to repair when the request never mentioned the number", async () => {
+    const honest = `<App name="Budget"><Island name="BudgetTracker">
+export default function BudgetTracker() {
+  const [total, setTotal] = useState(0);
+  useEffect(() => { tools.host_metric({}).then((res) => setTotal(res.totalCents ?? 0)); }, []);
+  return <Stack><Stat label="Spent" value={fmt.money(total)} /><Disclaimer reason="No budget amount is available on this host." /></Stack>;
+}
+</Island><BudgetTracker/></App>`;
+    const prompts: string[] = [];
+    const model = scriptedLanguageModel((call) => {
+      prompts.push(promptText(call));
+      return prompts.length === 1 ? budget : honest;
+    });
+    await modelEngine.create(
+      { prompt: "track my entertainment spending" },
+      deps(model, { pipeline: { structuredRepair: false } }),
+    );
+    expect(prompts).toHaveLength(2);
+    expect(prompts[1]).toContain("BUDGET_CENTS = 20000");
+    expect(prompts[1]).toContain("a constant feeding displayed math is invented data (law 1)");
+  });
+
+  it("ships per-month conversion math (÷ 12, × 4.33) in one call — H3", async () => {
+    const recurring = `<App name="Recurring"><Island name="MonthlyView">
+export default function MonthlyView() {
+  const [rows, setRows] = useState([]);
+  useEffect(() => { tools.host_metric({}).then((res) => setRows(res.rows ?? [])); }, []);
+  const monthly = rows.reduce((sum, row) => sum + (row.amountCents / 12) + (row.amountCents * 4.33), 0);
+  return <Stat label="Per month" value={fmt.money(monthly)} />;
+}
+</Island><MonthlyView/></App>`;
+    let calls = 0;
+    const model = scriptedLanguageModel(() => {
+      calls += 1;
+      return recurring;
+    });
+    const document = await modelEngine.create(
+      { prompt: "what do my recurring charges add up to per month?" },
+      deps(model, { pipeline: { structuredRepair: false } }),
+    );
+    expect(calls).toBe(1);
+    expect(document.components?.MonthlyView).toContain("4.33");
+  });
+});
+
 describe("law 2 — actions ground in the real tool surface", () => {
   it("rejects an action naming a tool absent from the registry", async () => {
     const invented = '<App name="Act"><Query id="metric" tool="host_metric"/><DataTable rows={metric.rows}/><Button label="Send reminder" onClick="host_invented"/></App>';

--- a/packages/apps/src/generation/engine.ts
+++ b/packages/apps/src/generation/engine.ts
@@ -367,7 +367,7 @@ export const verifyDocumentAgainstData = async (
   deps,
   hostComponents: deps.catalog.map(({ name }) => name),
   startedAt: Date.now(),
-  validate: (compiled) => validateCompiledCreate(compiled, deps),
+  validate: (compiled) => validateCompiledCreate(compiled, deps, userRequest),
 });
 
 const withoutId = (app: AppDocument): GeneratedAppDocument => {
@@ -620,10 +620,13 @@ const editTree = async (
           model: Object.fromEntries(Object.entries(all).filter((entry) => !isPinned(entry))),
         });
         const patchedIslands = splitIslands(patched.components);
-        const prepared = await prepareIslands(patchedIslands.model, deps.tools, hostComponents);
+        // The edit instruction is the user text in scope here; both prepares
+        // get the SAME text so a carried-over issue stays byte-identical for
+        // the pre-existing-issue filter below.
+        const prepared = await prepareIslands(patchedIslands.model, deps.tools, hostComponents, input.instruction);
         // Pre-existing island issues never block an unrelated edit (same
         // filtering rule as catalog/action issues in validateEditedApp).
-        const sourcePrepared = await prepareIslands(splitIslands(input.app.components ?? {}).model, deps.tools, hostComponents);
+        const sourcePrepared = await prepareIslands(splitIslands(input.app.components ?? {}).model, deps.tools, hostComponents, input.instruction);
         const sourceIslandIssues = new Set(sourcePrepared.issues);
         const islandIssues = prepared.issues.filter((issue) => !sourceIslandIssues.has(issue));
         const nextComponents = { ...patchedIslands.pinned, ...prepared.components };
@@ -729,7 +732,7 @@ export const modelEngine: GenerationEngine = {
       deps,
       hostComponents,
       startedAt,
-      validate: (compiled) => validateCompiledCreate(compiled, deps),
+      validate: (compiled) => validateCompiledCreate(compiled, deps, input.prompt),
       repairIslands: (compiled, repairIssues) => {
         logInvalidLane("assembly", repairIssues);
         return repairIslandsScoped(compiled, repairIssues, input.prompt, pipelineContext);
@@ -765,7 +768,7 @@ export const modelEngine: GenerationEngine = {
         const paintDeps = deps.paint?.model === undefined ? gatedDeps : { ...gatedDeps, model: deps.paint.model };
         const paint = await streamWire(paintDeps, tier0Contract(deps), basePrompt, hostComponents, { lane: "paint", thinking: false, startedAt });
         if (paint.compiled !== undefined) {
-          const validated = await validateCompiledCreate(paint.compiled, deps);
+          const validated = await validateCompiledCreate(paint.compiled, deps, input.prompt);
           if (validated.document !== undefined) {
             resident = validated.document;
             residentLayout = layoutHeader(paint.compiled);
@@ -832,7 +835,7 @@ export const modelEngine: GenerationEngine = {
       );
       issues = distinctIssues(issues, output.issues);
       if (output.compiled !== undefined) {
-        const validated = await validateCompiledCreate(output.compiled, deps);
+        const validated = await validateCompiledCreate(output.compiled, deps, input.prompt);
         if (validated.document !== undefined) return finish(validated.document);
         logInvalidLane("full", validated.issues);
         issues = distinctIssues(issues, validated.issues);

--- a/packages/apps/src/generation/validation/islands.ts
+++ b/packages/apps/src/generation/validation/islands.ts
@@ -104,6 +104,9 @@ export const prepareIslands = async (
   rawComponents: Record<string, string>,
   tools: readonly HostToolInfo[] | undefined,
   hostComponents: readonly string[] = [],
+  /** The user's request text — law 1 exempts constants that are the user's
+   *  own numbers (see islandDerivedValueViolations). Absent → no carve-out. */
+  requestText?: string,
 ): Promise<PreparedIslands> => {
   const issues: string[] = [];
   const components: Record<string, string> = {};
@@ -158,7 +161,7 @@ export const prepareIslands = async (
     // Law 1 teeth for island math: a hand-typed constant feeding displayed
     // arithmetic over tool-derived values is invented data (the FX-rate
     // class).
-    for (const violation of islandDerivedValueViolations(source)) {
+    for (const violation of islandDerivedValueViolations(source, requestText === undefined ? undefined : { requestText })) {
       issues.push(`island "${name}" ${violation}`);
     }
     // The ambient tools contract: literal member access only, every chain

--- a/packages/apps/src/generation/validation/validate.ts
+++ b/packages/apps/src/generation/validation/validate.ts
@@ -365,6 +365,10 @@ const rootedRenderIssues = (tree: TreeV2): string[] => {
 export const validateCompiledCreate = async (
   compiled: WireCompileResult,
   deps: GenerationDependencies,
+  /** The user's request text, threaded into the island law-1 scan so the
+   *  user's own numbers are never refused as invented data (rematch
+   *  2026-07-25 rows H12/H14). Absent → no carve-out. */
+  requestText?: string,
 ): Promise<{ document?: GeneratedAppDocument; issues: string[] }> => {
   const issues: string[] = [];
   if (!compiled.complete) issues.push("wire did not parse to a complete <App> document");
@@ -375,7 +379,7 @@ export const validateCompiledCreate = async (
   } else if (name.length > APP_NAME_MAX_CHARS) {
     issues.push(`App name="${name}" is ${name.length} characters — name is the app's display title (at most ${APP_NAME_MAX_CHARS} characters); write a short human title, never the request echoed back`);
   }
-  const prepared = await prepareIslands(compiled.components, deps.tools, deps.catalog.map(({ name: componentName }) => componentName));
+  const prepared = await prepareIslands(compiled.components, deps.tools, deps.catalog.map(({ name: componentName }) => componentName), requestText);
   const components = Object.keys(prepared.components).length === 0 ? undefined : prepared.components;
   issues.push(...prepared.issues);
   if (deps.tools !== undefined) {

--- a/packages/core/src/island-derived-values.test.ts
+++ b/packages/core/src/island-derived-values.test.ts
@@ -254,3 +254,158 @@ export default function Notes(props) {
     expect(islandDerivedValueViolations(source)).toEqual([]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Rematch gate 2026-07-25 (docs/eval/runs/2026-07-25-rematch, rows H3, H12,
+// H14, H16, H17, H24): the scanner refused the user's OWN numbers
+// ($200 budget → BUDGET_CENTS = 20000) and plain unit conversions
+// (12 months, 4.33 weeks/month, 1000*60*60*24 ms/day) as invented data.
+// Two carve-outs; the M12 invented-FX-rate class must stay caught.
+// ---------------------------------------------------------------------------
+
+describe("islandDerivedValueViolations — user's own numbers (carve-out 1)", () => {
+  const BUDGET_ISLAND = `
+export default function BudgetTracker() {
+  const BUDGET_CENTS = 20000;
+  const [spent, setSpent] = useState(0);
+  useEffect(() => {
+    tools.host_listTransactions({}).then((res) => {
+      setSpent((res.transactions ?? []).reduce((sum, txn) => sum + txn.amount_cents, 0));
+    });
+  }, []);
+  const remaining = BUDGET_CENTS - spent;
+  return <Stat label="Left this month" value={fmt.money(remaining)} />;
+}
+`;
+
+  it("does not flag a constant that is the cent-scaled form of the user's typed number (H12: $200 → 20000)", () => {
+    expect(islandDerivedValueViolations(BUDGET_ISLAND, {
+      requestText: "keep my entertainment spending under a $200 monthly budget",
+    })).toEqual([]);
+  });
+
+  it("without the request text the default stays no-carve-out (API compatible)", () => {
+    expect(islandDerivedValueViolations(BUDGET_ISLAND)).toHaveLength(1);
+    expect(islandDerivedValueViolations(BUDGET_ISLAND, {})).toHaveLength(1);
+  });
+
+  it("does not flag the user's comma-formatted $2,000 as NEED = 200000 (H14)", () => {
+    const source = `
+export default function SavingsGap() {
+  const NEED = 200000;
+  const [saved, setSaved] = useState(0);
+  useEffect(() => {
+    tools.host_listAccounts({}).then((res) => {
+      setSaved((res.accounts ?? []).reduce((sum, account) => sum + account.balance_cents, 0));
+    });
+  }, []);
+  return <Stat label="Still to save" value={fmt.money(NEED - saved)} />;
+}
+`;
+    expect(islandDerivedValueViolations(source, {
+      requestText: "show how far I am from saving $2,000 for the trip",
+    })).toEqual([]);
+    expect(islandDerivedValueViolations(source)).toHaveLength(1);
+  });
+
+  it("does not flag a bare literal that IS the user's number, unscaled", () => {
+    const source = `
+export default function Threshold() {
+  const [charges, setCharges] = useState([]);
+  useEffect(() => {
+    tools.host_listCharges({}).then((res) => setCharges(res.charges ?? []));
+  }, []);
+  return <DataTable rows={charges.filter((charge) => charge.amount - 50 > 0).map((charge) => ({ name: charge.name }))} />;
+}
+`;
+    expect(islandDerivedValueViolations(source, { requestText: "flag charges over 50 dollars" })).toEqual([]);
+  });
+
+  it("still flags an invented rate even when the request carries unrelated numbers", () => {
+    expect(islandDerivedValueViolations(FX_ISLAND, {
+      requestText: "convert my 3 accounts to euros",
+    })).toHaveLength(1);
+  });
+});
+
+describe("islandDerivedValueViolations — unit-conversion constants (carve-out 2)", () => {
+  it("does not flag 12 / 52 / 4.33 in per-month math over tool data (H3)", () => {
+    const source = `
+export default function MonthlyRecurring() {
+  const [charges, setCharges] = useState([]);
+  useEffect(() => {
+    tools.host_listRecurring({}).then((res) => setCharges(res.charges ?? []));
+  }, []);
+  const monthly = charges.reduce((sum, charge) => {
+    if (charge.cadence === "yearly") return sum + charge.amount_cents / 12;
+    if (charge.cadence === "weekly") return sum + charge.amount_cents * 4.33;
+    return sum + charge.amount_cents;
+  }, 0);
+  const annual = charges.reduce((sum, charge) => (charge.cadence === "weekly" ? sum + charge.amount_cents * 52 : sum), 0);
+  return (
+    <Stack>
+      <Stat label="Per month" value={fmt.money(monthly)} />
+      <Stat label="Weekly, annualized" value={fmt.money(annual)} />
+    </Stack>
+  );
+}
+`;
+    expect(islandDerivedValueViolations(source)).toEqual([]);
+  });
+
+  it("does not flag the 1000*60*60*24 ms/day chain in deadline math (H16/H17)", () => {
+    const source = `
+export default function DeadlineRisk() {
+  const [clients, setClients] = useState([]);
+  useEffect(() => {
+    tools.host_listClients({}).then((res) => setClients(res.clients ?? []));
+  }, []);
+  return <DataTable rows={clients.map((client) => ({
+    name: client.name,
+    daysLeft: Math.ceil((new Date(client.deadline).getTime() - Date.now()) / (1000 * 60 * 60 * 24)),
+  }))} />;
+}
+`;
+    expect(islandDerivedValueViolations(source)).toEqual([]);
+  });
+
+  it("does not flag the composite ms/day product 86400000 in a division", () => {
+    const source = `
+export default function Aging({ invoices }) {
+  const rows = (invoices ?? []).map((invoice) => ({
+    id: invoice.id,
+    ageDays: Math.floor((Date.now() - new Date(invoice.issued_at).getTime()) / 86400000),
+  }));
+  return <DataTable rows={rows} />;
+}
+`;
+    expect(islandDerivedValueViolations(source)).toEqual([]);
+  });
+
+  it("does not flag a NAMED unit constant used multiplicatively", () => {
+    const source = `
+export default function Annualized({ weeklyCents }) {
+  const WEEKS_PER_YEAR = 52;
+  return <Stat label="Annualized" value={fmt.money(weeklyCents * WEEKS_PER_YEAR)} />;
+}
+`;
+    expect(islandDerivedValueViolations(source)).toEqual([]);
+  });
+
+  it("STILL flags a unit-set value in additive math — a magic +12 is not a conversion", () => {
+    const source = `
+export default function Padded({ totalCents }) {
+  const padded = totalCents + 12;
+  return <Stat label="Total" value={fmt.money(padded)} />;
+}
+`;
+    expect(islandDerivedValueViolations(source)).toHaveLength(1);
+  });
+
+  it("STILL flags the M12 FX-rate class — 0.92 is neither a user number nor a unit constant", () => {
+    expect(islandDerivedValueViolations(FX_ISLAND)).toHaveLength(1);
+    expect(islandDerivedValueViolations(FX_ISLAND, {
+      requestText: "a currency converter for my balances",
+    })).toHaveLength(1);
+  });
+});

--- a/packages/core/src/island-derived-values.test.ts
+++ b/packages/core/src/island-derived-values.test.ts
@@ -308,6 +308,22 @@ export default function SavingsGap() {
     expect(islandDerivedValueViolations(source)).toHaveLength(1);
   });
 
+  it("cent-scales fractional dollar amounts without float drift ($4.99 → 499)", () => {
+    const source = `
+export default function PriceGap() {
+  const PRICE_CENTS = 499;
+  const [balance, setBalance] = useState(0);
+  useEffect(() => {
+    tools.host_getBalance({}).then((res) => setBalance(res.balance_cents ?? 0));
+  }, []);
+  return <Stat label="After the subscription" value={fmt.money(balance - PRICE_CENTS)} />;
+}
+`;
+    expect(islandDerivedValueViolations(source, {
+      requestText: "what's left after my $4.99 subscription renews?",
+    })).toEqual([]);
+  });
+
   it("does not flag a bare literal that IS the user's number, unscaled", () => {
     const source = `
 export default function Threshold() {

--- a/packages/core/src/island-derived-values.ts
+++ b/packages/core/src/island-derived-values.ts
@@ -21,12 +21,56 @@
  *   - style/layout math (anything inside a `style` object) and constants with
  *     layout/timing names (width/height/size/padding/gap/radius/timeout/…),
  *   - array-index arithmetic (`rows[rows.length - 1]`),
- *   - setTimeout/setInterval delay arguments.
+ *   - setTimeout/setInterval delay arguments,
+ *   - numbers the USER typed in the request (and their cent-scaled ×100
+ *     forms) — a $200 budget the user asked for is the user's parameter,
+ *     not invented data (rematch 2026-07-25 rows H12/H14),
+ *   - unit-conversion constants (7, 12, 24, 52, 60, 365, 4.33, 1000 and
+ *     their products, e.g. 86400000 ms/day) in MULTIPLICATIVE chains —
+ *     "per month" and date-difference math is conversion, not invention
+ *     (rematch rows H3/H16/H17/H24); an additive `+ 12` still flags.
  */
 import { blankNonCode } from "./island-ambient.js";
 
 /** Values that are unit math / percent scaling, never invented data. */
 const EXEMPT_VALUES = new Set([0, 1, 100]);
+
+/** Time/calendar conversion factors. A value equal to one of these — or to a
+ *  product of them, like 1000*60*60*24 = 86400000 — is a unit conversion
+ *  when it participates MULTIPLICATIVELY (never when added/subtracted). */
+const UNIT_CONVERSION_FACTORS = [1000, 365, 60, 52, 24, 12, 7];
+const WEEKS_PER_MONTH = 4.33;
+
+const isUnitConversionValue = (value: number): boolean => {
+  const magnitude = Math.abs(value);
+  if (Math.abs(magnitude - WEEKS_PER_MONTH) < 1e-9) return true;
+  if (!Number.isInteger(magnitude) || magnitude <= 1) return false;
+  let rest = magnitude;
+  for (const factor of UNIT_CONVERSION_FACTORS) {
+    while (rest % factor === 0) rest /= factor;
+  }
+  return rest === 1;
+};
+
+/** Every number the user typed in the request, plus its cent-scaled ×100
+ *  form ("a $200 budget" arrives in the island as 20000 integer cents). */
+const requestNumberValues = (requestText: string): Set<number> => {
+  const values = new Set<number>();
+  for (const match of requestText.matchAll(/\d[\d,]*(?:\.\d+)?/g)) {
+    const value = Number(match[0].replaceAll(",", ""));
+    if (!Number.isFinite(value)) continue;
+    values.add(value);
+    values.add(value * 100);
+  }
+  return values;
+};
+
+export interface DerivedValueScanOptions {
+  /** The user's request text. Numbers present in it (and their cent-scaled
+   *  forms) are the user's own parameters, exempt from law 1. Absent →
+   *  no carve-out (the API-compatible default). */
+  requestText?: string;
+}
 
 /** Constant names that declare layout, sizing, or timing intent. */
 const EXEMPT_NAME =
@@ -297,6 +341,24 @@ const arithmeticAdjacent = (code: string, start: number, end: number): boolean =
   return /[\w$)\]]/.test(left);
 };
 
+/** Whether the occurrence joins the surrounding expression through `*` or `/`
+ *  on either side — the shape of a unit CONVERSION chain. Additive joins
+ *  (`total + 12`) stay flaggable: adding a magic number invents data. */
+const multiplicativeAdjacent = (code: string, start: number, end: number): boolean => {
+  let after = end;
+  while (after < code.length && /[ \t]/.test(code[after] as string)) after += 1;
+  const operatorAfter = code[after];
+  if ((operatorAfter === "*" || operatorAfter === "/")
+    && code[after + 1] !== operatorAfter && code[after + 1] !== "=") {
+    return true;
+  }
+  let before = start - 1;
+  while (before >= 0 && /[ \t]/.test(code[before] as string)) before -= 1;
+  const operatorBefore = code[before];
+  return (operatorBefore === "*" || operatorBefore === "/")
+    && code[before - 1] !== operatorBefore && code[before - 1] !== "=";
+};
+
 /** The declared variable an expression at `index` is assigned to, if the
  *  enclosing declaration's init covers it. */
 const assignmentTarget = (declarationList: readonly Declaration[], index: number): Declaration | undefined =>
@@ -340,7 +402,10 @@ const reachesRender = (
  * arithmetic with tool-derived values that flow into rendered output. One
  * violation per constant/literal, message written to teach the repair.
  */
-export function islandDerivedValueViolations(source: string): string[] {
+export function islandDerivedValueViolations(source: string, options?: DerivedValueScanOptions): string[] {
+  const userNumbers = options?.requestText === undefined
+    ? new Set<number>()
+    : requestNumberValues(options.requestText);
   const code = blankNonCode(source);
   const exempt = [...styleSpans(code), ...timerSpans(code), ...indexSpans(code)];
   const display = [...renderSpans(code), ...fmtSpans(code)];
@@ -352,7 +417,7 @@ export function islandDerivedValueViolations(source: string): string[] {
   // Suspect constants: `const NAME = <number>` — or a hand-typed rate TABLE
   // (`const RATES = { EUR: 0.92, GBP: 0.79 }` / `[0.92, 1.08]`) — with a
   // non-exempt name and at least one non-exempt numeric value.
-  const constants = new Map<string, string>();
+  const constants = new Map<string, { described: string; value?: number }>();
   for (const declaration of declarationList) {
     const name = declaration.names.length >= 1 ? (declaration.names[0] as string) : undefined;
     if (name === undefined || EXEMPT_NAME.test(name)) continue;
@@ -360,8 +425,10 @@ export function islandDerivedValueViolations(source: string): string[] {
     const literal = /^(-?\d+(?:\.\d+)?)$/.exec(init);
     if (literal !== null) {
       const value = Number(literal[1]);
-      if (EXEMPT_VALUES.has(Math.abs(value))) continue;
-      constants.set(name, `${name} = ${literal[1]}`);
+      // The user's own number (H12: "$200 budget" → BUDGET_CENTS = 20000) is
+      // a request parameter, never invented data.
+      if (EXEMPT_VALUES.has(Math.abs(value)) || userNumbers.has(Math.abs(value))) continue;
+      constants.set(name, { described: `${name} = ${literal[1]}`, value });
       continue;
     }
     // Object/array literals whose values are ALL hand-typed numbers. The
@@ -376,7 +443,7 @@ export function islandDerivedValueViolations(source: string): string[] {
     const values = entries.map((entry) => /^(?:(?:["'][^"']*["']|[\w$]+)\s*:\s*)?(-?\d+(?:\.\d+)?)$/.exec(entry));
     if (values.some((match) => match === null)) continue;
     if (!values.some((match) => !EXEMPT_VALUES.has(Math.abs(Number(match?.[1]))))) continue;
-    constants.set(name, `${name} = ${init.length > 60 ? `${init.slice(0, 57)}…` : init}`);
+    constants.set(name, { described: `${name} = ${init.length > 60 ? `${init.slice(0, 57)}…` : init}` });
   }
 
   const violations: string[] = [];
@@ -408,10 +475,14 @@ export function islandDerivedValueViolations(source: string): string[] {
       }
     }
   };
-  const checkOccurrence = (key: string, described: string, start: number, rawEnd: number): void => {
+  const checkOccurrence = (key: string, described: string, start: number, rawEnd: number, value?: number): void => {
     if (flagged.has(key)) return;
     if (inSpans(exempt, start)) return;
     const end = extendPastChain(rawEnd);
+    // Unit-conversion factors joined by * or / are conversion chains
+    // (per-month math, ms/day date differences — rematch H3/H16), not
+    // invented data; the same value ADDED to tool data still flags.
+    if (value !== undefined && isUnitConversionValue(value) && multiplicativeAdjacent(code, start, end)) return;
     if (!arithmeticAdjacent(code, start, end)) return;
     // The other side of the math must trace to tool/props data — checked on
     // the surrounding line so unrelated tainted code never triggers it.
@@ -427,17 +498,17 @@ export function islandDerivedValueViolations(source: string): string[] {
     flag(key, described);
   };
 
-  for (const [name, described] of constants) {
+  for (const [name, constant] of constants) {
     for (const match of code.matchAll(new RegExp(`\\b${name}\\b`, "g"))) {
       if (code[match.index - 1] === ".") continue;
-      checkOccurrence(name, described, match.index, match.index + name.length);
+      checkOccurrence(name, constant.described, match.index, match.index + name.length, constant.value);
     }
   }
   // Bare numeric literals in arithmetic with tainted data (`total * 0.92`).
   for (const match of code.matchAll(/(?<![\w$.])(\d+(?:\.\d+)?)(?![\w$.])/g)) {
     const value = Number(match[1]);
-    if (EXEMPT_VALUES.has(Math.abs(value))) continue;
-    checkOccurrence(`literal:${match[1]}`, `${match[1]}`, match.index, match.index + (match[1] as string).length);
+    if (EXEMPT_VALUES.has(Math.abs(value)) || userNumbers.has(Math.abs(value))) continue;
+    checkOccurrence(`literal:${match[1]}`, `${match[1]}`, match.index, match.index + (match[1] as string).length, value);
   }
   return violations;
 }

--- a/packages/core/src/island-derived-values.ts
+++ b/packages/core/src/island-derived-values.ts
@@ -60,7 +60,9 @@ const requestNumberValues = (requestText: string): Set<number> => {
     const value = Number(match[0].replaceAll(",", ""));
     if (!Number.isFinite(value)) continue;
     values.add(value);
-    values.add(value * 100);
+    // Rounded: cents are integers, and 4.99 * 100 is 498.99999999999994 in
+    // floating point — the island's hand-typed 499 must still match.
+    values.add(Math.round(value * 100));
   }
   return values;
 };


### PR DESCRIPTION
## What

The 2026-07-25 rematch gate (#577) showed the island derived-values scanner (law 1) refusing legitimate constants — gate rows H3, H12, H14, H16, H17, H24 carry the reproductions:

- **The user's own numbers**: "a $200 monthly budget" → `const BUDGET_CENTS = 20000` refused as invented data (H12); "$2,000" → `NEED = 200000` (H14). H14 was refused under all three arms.
- **Unit/time conversions**: 12 months, 52 weeks, 4.33 weeks/month, `1000*60*60*24` ms/day date math (H3, H16, H17, H24 — 11 Cadence refusals carried this class). H3 was unbuildable under all three arms.

## Fix — two narrow carve-outs

1. **Request numbers**: constants equal to a number present in the user request — or its cent-scaled ×100 form — are the user's parameters, not invented data. The request text threads `create` → `validateCompiledCreate` → `prepareIslands` → `islandDerivedValueViolations` as a new **optional** param defaulting to no-carve-out, so the API stays compatible and every existing caller keeps its exact behavior. The edit path passes the instruction (same text to both prepares, keeping the pre-existing-issue filter byte-identical); the data-sighted verify seam passes its `userRequest`.
2. **Unit-conversion constants**: 7, 12, 24, 52, 60, 365, 4.33, 1000 and their products (86400000 ms/day) are exempt **only in multiplicative chains** (`*` `/`). An additive `total + 12` still flags — adding a magic number invents data.

## M12 stays caught

The invented-FX-rate class (`const RATE = 0.92`) remains flagged — 0.92 is neither a request number nor a unit constant. Regression-tested with and without request text, plus with a request carrying unrelated numbers. All 10 pre-existing scanner tests unchanged and green.

## Tests

Red-first unit tests per carve-out in `packages/core/src/island-derived-values.test.ts` (H12/H14/H3/H16 shapes + additive-12 still-flags + FX regression) and end-to-end create tests in `packages/apps/src/engine-laws.test.ts` proving the prompt threads through validation (one call, no refusal, no repair — and still repairs when the request never mentioned the number).

## Gates

`pnpm build && pnpm test && pnpm typecheck && pnpm lint` green (four e2e packages flaked under a concurrent second suite binding the same ports; all green standalone).

No UI-affecting change (validation internals only).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false positives in law 1 (islands) by exempting the user's own numbers and multiplicative unit-conversion chains, so legit constants aren’t flagged and unnecessary refusals/repairs drop.

- **Bug Fixes**
  - Exempt request numbers: constants and bare literals equal to numbers in the user’s request (and their cent-scaled ×100 forms) are allowed; cent scaling is rounded to avoid float drift. The request text threads as an optional param through `validateCompiledCreate` → `prepareIslands` → `islandDerivedValueViolations` (defaults to no carve-out); create/paint/verify paths pass it, and the edit path passes the same instruction to both prepares to keep pre-existing-issue filtering stable.
  - Exempt unit conversions in multiplicative chains: 7, 12, 24, 52, 60, 365, 4.33, 1000 and products like 86400000 are allowed only with `*` or `/` (named or literal). Additive uses (e.g., `+ 12`) still flag.
  - FX-rate class remains blocked (e.g., `0.92` is still flagged). New tests in `packages/core/src/island-derived-values.test.ts` and `packages/apps/src/engine-laws.test.ts`; existing tests remain green.

- **Refactors**
  - Cleaned up generated churn in `apps/demo-template/.vendo/tools.json` (format normalization, removed generated fields); no runtime changes.

<sup>Written for commit e6ed63c71a9626d7ab0b8fcd1fa94021b9274333. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

