### PR TITLE
islands: teach the repair path the host-component substitution

### DIFF
--- a/packages/apps/src/generation/validation/islands.ts
+++ b/packages/apps/src/generation/validation/islands.ts
@@ -8,6 +8,7 @@
 import {
   KIT_WIRE_COMPONENT_NAMES,
   RESERVED_COMPONENT_NAMES,
+  WIRE_COMPONENT_NAMES,
   ISLAND_AMBIENT_KIT_NAMES,
   ISLAND_STRIPPED_SPECIFIERS,
   islandDerivedValueViolations,
@@ -86,6 +87,79 @@ const islandImportSpecifiers = (source: string): string[] => {
 
 const ISLAND_RESOLVABLE_MODULE_SET = new Set<string>(ISLAND_STRIPPED_SPECIFIERS);
 
+// ---------------------------------------------------------------------------
+// Host-component-in-island teaching. Rematch gate 2026-07-25: 17+ Cadence and
+// several Maple creates burned EVERY repair round on islands rendering
+// <CadenceStatusBadge>/<MapleSparkline>/<Skeleton> — the issue string named
+// the whole ambient list but no concrete substitution, so repair reproduced
+// the class instead of fixing it. Each offending tag now carries the specific
+// ambient Kit equivalent the rewrite should use.
+// ---------------------------------------------------------------------------
+
+/** A loading placeholder has no ambient equivalent — the substitution is a
+ *  loading STATE, not a component. */
+const LOADING_PLACEHOLDER = /skeleton|spinner|loader|shimmer/i;
+
+/** Keyword → ambient Kit vocabulary for host component names whose suffix is
+ *  not itself an ambient name. Ordered: first hit wins. */
+const KIT_VOCABULARY: ReadonlyArray<readonly [RegExp, string]> = [
+  [/status/i, "EnumBadge"],
+  [/badge|pill|chip/i, "Badge"],
+  [/sparkline/i, "Sparkline"],
+  [/donut|pie/i, "DonutChart"],
+  [/bar\s*chart|histogram/i, "BarChart"],
+  [/chart|graph|trend/i, "LineChart"],
+  [/progress|meter|gauge/i, "Progress"],
+  [/table|datagrid/i, "DataTable"],
+  [/stat|metric|kpi|tile/i, "Stat"],
+  [/callout|banner|alert|notice/i, "Callout"],
+  [/card|panel|surface/i, "Surface"],
+  [/list|feed/i, "CardList"],
+  [/money|amount|currency|price/i, "Money"],
+  [/date|time/i, "DateTime"],
+];
+
+const AMBIENT_KIT_SET = new Set<string>(ISLAND_AMBIENT_KIT_NAMES);
+
+/** The ambient Kit component an island should render in place of a host
+ *  catalog / non-ambient prewired name — teaching heuristic for the repair
+ *  prompt, never a rewrite the engine performs itself. Undefined when the
+ *  name is a loading placeholder (the substitution is a loading state) or
+ *  maps to nothing recognizable. */
+export const ambientKitEquivalent = (name: string): string | undefined => {
+  if (LOADING_PLACEHOLDER.test(name)) return undefined;
+  // "…StatusBadge" wants the ENUM badge, so the status keyword outranks the
+  // Badge suffix.
+  if (/status/i.test(name)) return "EnumBadge";
+  // An ambient-name suffix is the strongest signal: MapleSparkline →
+  // Sparkline, CadenceDocProgress → Progress (longest match wins).
+  let suffix: string | undefined;
+  for (const kitName of AMBIENT_KIT_SET) {
+    if (name.length > kitName.length && name.endsWith(kitName)
+      && (suffix === undefined || kitName.length > suffix.length)) {
+      suffix = kitName;
+    }
+  }
+  if (suffix !== undefined) return suffix;
+  for (const [pattern, kitName] of KIT_VOCABULARY) {
+    if (pattern.test(name)) return kitName;
+  }
+  return undefined;
+};
+
+/** One teaching issue per offending tag, naming the concrete substitution so
+ *  a repair round can act (the generic all-ambient-names list demonstrably
+ *  did not converge — rematch 2026-07-25). */
+const hostTagIssue = (island: string, tag: string): string => {
+  const equivalent = ambientKitEquivalent(tag);
+  const substitution = equivalent !== undefined
+    ? `use the ambient Kit equivalent (${equivalent}) inside the island, or move it to a tree node`
+    : LOADING_PLACEHOLDER.test(tag)
+      ? `islands render against live tool data — replace it with a brief loading state (e.g. <Text text="Loading…"/> until the data arrives), or move it to a tree node`
+      : `use one of the ambient Kit components inside the island (${ISLAND_AMBIENT_KIT_NAMES.join(", ")}), or move it to a tree node`;
+  return `island "${island}" renders <${tag}> — <${tag}> renders on the host page and cannot exist inside an island (the name is undefined in the sandbox): ${substitution}.`;
+};
+
 export interface PreparedIslands {
   /** name → stripped canonical source. Empty record when there are no islands. */
   components: Record<string, string>;
@@ -112,12 +186,14 @@ export const prepareIslands = async (
   const components: Record<string, string> = {};
   const componentTools: Record<string, string[]> = {};
   const knownTools = tools === undefined ? undefined : new Set(tools.map((tool) => tool.name));
-  // Host catalog + prewired components render in the HOST page — they can
-  // never cross into the opaque-origin jail, so an island JSX tag naming one
-  // is a guaranteed ReferenceError (live example: <MapleSpendingDonut/>).
-  // Names the ambient Kit also provides are fine — the Kit version renders.
+  // Host catalog + tree-resolvable components (prewired AND branded — a
+  // non-ambient <Table>/<Card> dies exactly like <Skeleton>) render in the
+  // HOST page — they can never cross into the opaque-origin jail, so an
+  // island JSX tag naming one is a guaranteed ReferenceError (live example:
+  // <MapleSpendingDonut/>). Names the ambient Kit also provides are fine —
+  // the Kit version renders.
   const ambientNames = new Set<string>(ISLAND_AMBIENT_KIT_NAMES);
-  const hostOnlyNames = [...new Set([...hostComponents, ...RESERVED_COMPONENT_NAMES])]
+  const hostOnlyNames = [...new Set([...hostComponents, ...WIRE_COMPONENT_NAMES])]
     .filter((componentName) => !ambientNames.has(componentName));
   // Name resolution is host catalog → built-ins → islands, so an island NAMED
   // after any of those never renders: the built-in wins and the island is
@@ -150,8 +226,8 @@ export const prepareIslands = async (
       // A locally-declared component of the same name is the island's own:
       // the local binding wins inside the jail, so don't reject it.
       && !new RegExp(`\\b(?:function|const|let|var|class)\\s+${componentName}\\b`).test(source));
-    if (hostTags.length > 0) {
-      issues.push(`island "${name}" renders ${hostTags.map((tag) => `<${tag}>`).join(", ")} — host catalog and prewired components exist only in the host page and can never load inside an island. Compose them in the TREE, or use the ambient Kit inside the island (${ISLAND_AMBIENT_KIT_NAMES.join(", ")}).`);
+    for (const tag of hostTags) {
+      issues.push(hostTagIssue(name, tag));
     }
     // The jail has no network: a habit-written fetch/XHR dies silently at the
     // CSP, so catch it here and repair to the ambient tools API instead.

--- a/packages/apps/src/island-host-components.test.ts
+++ b/packages/apps/src/island-host-components.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { ambientKitEquivalent, prepareIslands } from "./generation/validation/islands.js";
+import { islandIssueNames } from "./engine.js";
+
+/**
+ * Rematch gate 2026-07-25 (docs/eval/runs/2026-07-25-rematch): 17+ Cadence
+ * and several Maple creates burned every repair round on islands referencing
+ * host catalog components (<CadenceStatusBadge>, <MapleSparkline>) or
+ * non-ambient prewired names (<Skeleton>, <Table>) that can never resolve in
+ * the sandbox. The create contract warns about this, but the repair prompt
+ * only carried a generic issue naming the WHOLE ambient list — no concrete
+ * substitution — so repair reproduced the class instead of fixing it. Each
+ * offending tag now gets its own teaching issue that names the ambient Kit
+ * equivalent (or, for loading placeholders, the loading-state advice).
+ * Detection is static (tag scan against catalog + non-ambient tree names) —
+ * never dependent on the smoke worker.
+ */
+
+const island = (body: string): Record<string, string> => ({
+  Panel: `export default function Panel() {\n  return (\n    <Stack>${body}</Stack>\n  );\n}\n`,
+});
+
+const prepare = (body: string, hostComponents: string[] = []) =>
+  prepareIslands(island(body), undefined, hostComponents);
+
+describe("ambientKitEquivalent", () => {
+  it("maps host status/badge components to EnumBadge", () => {
+    expect(ambientKitEquivalent("CadenceStatusBadge")).toBe("EnumBadge");
+    expect(ambientKitEquivalent("MapleStatusPill")).toBe("EnumBadge");
+  });
+
+  it("maps by ambient-name suffix (MapleSparkline → Sparkline, CadenceDocProgress → Progress)", () => {
+    expect(ambientKitEquivalent("MapleSparkline")).toBe("Sparkline");
+    expect(ambientKitEquivalent("CadenceDocProgress")).toBe("Progress");
+    expect(ambientKitEquivalent("AcmeDataTable")).toBe("DataTable");
+    expect(ambientKitEquivalent("HostDonutChart")).toBe("DonutChart");
+  });
+
+  it("maps common host-component vocabulary to the closest Kit name", () => {
+    expect(ambientKitEquivalent("Table")).toBe("DataTable");
+    expect(ambientKitEquivalent("Card")).toBe("Surface");
+    expect(ambientKitEquivalent("MapleMetricTile")).toBe("Stat");
+    expect(ambientKitEquivalent("CadenceAlertBanner")).toBe("Callout");
+  });
+
+  it("returns undefined for loading placeholders and unmappable names", () => {
+    expect(ambientKitEquivalent("Skeleton")).toBeUndefined();
+    expect(ambientKitEquivalent("CadenceQuantumFlux")).toBeUndefined();
+  });
+});
+
+describe("prepareIslands — host components inside islands teach the substitution", () => {
+  it("names the ambient Kit equivalent for a host catalog component (the H17-H29 Cadence class)", async () => {
+    const prepared = await prepare("<CadenceStatusBadge status=\"late\" />", ["CadenceStatusBadge"]);
+    expect(prepared.issues).toHaveLength(1);
+    expect(prepared.issues[0]).toContain("<CadenceStatusBadge> renders on the host page and cannot exist inside an island");
+    expect(prepared.issues[0]).toContain("ambient Kit equivalent (EnumBadge)");
+    expect(prepared.issues[0]).toContain("move it to a tree node");
+  });
+
+  it("suggests Sparkline for <MapleSparkline> (the H14 Maple class)", async () => {
+    const prepared = await prepare("<MapleSparkline points={[]} />", ["MapleSparkline"]);
+    expect(prepared.issues).toHaveLength(1);
+    expect(prepared.issues[0]).toContain("ambient Kit equivalent (Sparkline)");
+  });
+
+  it("teaches the loading-state substitution for <Skeleton> (non-ambient prewired, no catalog needed)", async () => {
+    const prepared = await prepare("<Skeleton />");
+    expect(prepared.issues).toHaveLength(1);
+    expect(prepared.issues[0]).toContain("<Skeleton> renders on the host page and cannot exist inside an island");
+    expect(prepared.issues[0]).toContain("loading");
+  });
+
+  it("catches non-ambient BRANDED prewired names (<Table>, <Card>) the reserved list missed", async () => {
+    const prepared = await prepare("<Card><Table rows={[]} /></Card>");
+    expect(prepared.issues).toHaveLength(2);
+    expect(prepared.issues.join("\n")).toContain("ambient Kit equivalent (DataTable)");
+    expect(prepared.issues.join("\n")).toContain("ambient Kit equivalent (Surface)");
+  });
+
+  it("emits one teaching issue per offending tag", async () => {
+    const prepared = await prepare(
+      "<CadenceStatusBadge /><Skeleton />",
+      ["CadenceStatusBadge"],
+    );
+    expect(prepared.issues).toHaveLength(2);
+  });
+
+  it("keeps ambient Kit names clean inside islands", async () => {
+    const prepared = await prepare(
+      "<EnumBadge value=\"ok\" /><DataTable rows={[]} /><Stat label=\"x\" value=\"1\" /><Sparkline points={[]} />",
+      ["CadenceStatusBadge"],
+    );
+    expect(prepared.issues).toEqual([]);
+  });
+
+  it("keeps a locally-declared component of the same name clean (the local binding wins)", async () => {
+    const source = {
+      Panel: "function CadenceStatusBadge() { return <Badge value=\"ok\" />; }\nexport default function Panel() {\n  return <CadenceStatusBadge />;\n}\n",
+    };
+    const prepared = await prepareIslands(source, undefined, ["CadenceStatusBadge"]);
+    expect(prepared.issues).toEqual([]);
+  });
+
+  it("routes the teaching issues to the island-scoped repair (issue shape stays island-prefixed)", async () => {
+    const prepared = await prepare("<CadenceStatusBadge />", ["CadenceStatusBadge"]);
+    expect(islandIssueNames(prepared.issues)).toEqual(["Panel"]);
+  });
+});


### PR DESCRIPTION
## What

The 2026-07-25 rematch gate (#577): 17+ Cadence and several Maple creates died with islands rendering host catalog components (`<CadenceStatusBadge>`, `<CadenceDocProgress>`, `<MapleSparkline>`) or non-ambient prewired names (`<Skeleton>`) that can never resolve in the sandbox. The create contract already warns about this; the validation issue named the whole ambient list but no concrete substitution, so **repair burned every round reproducing the class** (see the identical refusal strings across H17-H29 in `pipeline-events-cadence.json`).

## Fix — teach the substitution

- One teaching issue **per offending tag**, naming the exact rewrite: `island "AtRiskTable" renders <CadenceStatusBadge> — <CadenceStatusBadge> renders on the host page and cannot exist inside an island (the name is undefined in the sandbox): use the ambient Kit equivalent (EnumBadge) inside the island, or move it to a tree node.`
- `ambientKitEquivalent(name)`: status keyword → `EnumBadge`; ambient-name suffix (`MapleSparkline` → `Sparkline`, `CadenceDocProgress` → `Progress`); then a small keyword vocabulary (table → `DataTable`, card → `Surface`, metric/tile → `Stat`, banner → `Callout`, …). Loading placeholders (`<Skeleton>`) teach a loading **state** instead; unmappable names keep the full ambient list.
- The static scan now covers **all** non-ambient tree-resolvable names (`WIRE_COMPONENT_NAMES`): a branded `<Table>`/`<Card>` inside an island died in the smoke gate exactly like `<Skeleton>` but was never caught statically before.
- Detection stays fully **static** (JSX tag scan against catalog + non-ambient names) — never dependent on the smoke worker. Issues keep the `island "<name>" renders <Tag>` prefix, so `islandIssueNames` still routes them to the island-scoped repair (regression-tested).

## Tests (red-first)

`packages/apps/src/island-host-components.test.ts`: catalog name → teaching issue with the named equivalent; `<Skeleton>` → loading-state advice; branded `<Table>`/`<Card>` now caught; ambient Kit names stay clean; locally-declared same-name components stay clean; island-repair routing preserved. Existing `engine.test.ts` host-tag repair test unchanged and green.

## Gates

`pnpm build && pnpm test && pnpm typecheck && pnpm lint` green.

No UI-affecting change (validation-issue copy + static scan only).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teaches islands validation to suggest concrete ambient Kit substitutes for host catalog and non-ambient tree components, preventing repair loops on tags like <CadenceStatusBadge>, <MapleSparkline>, <Skeleton>, <Table>, and <Card>. Emits one issue per offending tag with the exact rewrite; detection stays fully static.

- **Bug Fixes**
  - Added `ambientKitEquivalent` to name the Kit swap (status → `EnumBadge`, ambient-name suffix, small keyword vocabulary); loading placeholders teach a loading state instead.
  - Expanded the static scan to `WIRE_COMPONENT_NAMES` to catch branded components inside islands (e.g., `Table`, `Card`); ambient Kit names remain allowed.
  - Issues are island-prefixed and per-tag to preserve island-scoped repair routing; local same-name bindings are ignored.

<sup>Written for commit e5e067377c1ddb7d9e56f14a6846b5cbbedae083. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

