### PR TITLE
fix(sync): load dotenv model credentials

### DIFF
--- a/packages/vendo/src/cli/doctor.ts
+++ b/packages/vendo/src/cli/doctor.ts
@@ -22,7 +22,19 @@ import { detectFramework, detectVendoWiring } from "./framework.js";
 import { CONFIG_SURFACES, OVERRIDES_ENABLEMENT_CAVEAT } from "../config-surface.js";
 import { walk } from "./theme/walk.js";
 import { remoteUrls, sameUrl, validateRegistryServer } from "./mcp/registry.js";
-import { askYesNo, CLI_VERSION, consoleOutput, exists, normalizeDotEnvValue, readOptional, toolingTelemetry, type Output } from "./shared.js";
+import {
+  askYesNo,
+  CLI_VERSION,
+  consoleOutput,
+  exists,
+  mergeEnvOverDotEnv,
+  readDotEnvFallback,
+  readOptional,
+  toolingTelemetry,
+  type Output,
+} from "./shared.js";
+
+export { mergeEnvOverDotEnv, readDotEnvFallback } from "./shared.js";
 
 export interface DoctorOptions {
   targetDir: string;
@@ -110,43 +122,6 @@ async function probeBody(response: Response): Promise<DoctorProbeBody> {
   } catch {
     return {};
   }
-}
-
-/** Doctor runs standalone, so unlike the dev server it gets no framework
- *  dotenv loading — without this, `VENDO_API_KEY` sitting in `.env.local`
- *  is invisible to the cloud/live-turn checks and users must export it by
- *  hand. Reads `.env` then `.env.local` (local wins); real process env wins
- *  over both at the merge site. Minimal KEY=VALUE parser: `export ` prefix,
- *  matching single/double quotes, and `#` comment lines. */
-export async function readDotEnvFallback(root: string): Promise<Record<string, string>> {
-  const env: Record<string, string> = {};
-  for (const file of [".env", ".env.local"]) {
-    const source = await readOptional(join(root, file));
-    if (source === null) continue;
-    for (const rawLine of source.split(/\r?\n/)) {
-      const line = rawLine.trim();
-      if (line === "" || line.startsWith("#")) continue;
-      const match = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
-      if (!match) continue;
-      env[match[1]!] = normalizeDotEnvValue(match[2]!.trim());
-    }
-  }
-  return env;
-}
-
-/** Process env wins over the dotenv fallback — except that a blank process
- *  value yields to a concrete dotenv one, matching toolingTelemetry's
- *  VENDO_API_KEY precedence (an exported empty `VENDO_API_KEY=` must not
- *  mask the real key in `.env.local`). */
-export function mergeEnvOverDotEnv(
-  fallback: Record<string, string>,
-  processEnv: NodeJS.ProcessEnv,
-): Record<string, string | undefined> {
-  const merged: Record<string, string | undefined> = { ...fallback, ...processEnv };
-  for (const [key, value] of Object.entries(processEnv)) {
-    if ((value ?? "").trim() === "" && fallback[key] !== undefined) merged[key] = fallback[key];
-  }
-  return merged;
 }
 
 /** 09-vendo §5 / block-actions A — wiring checks plus live composition,

--- a/packages/vendo/src/cli/shared.ts
+++ b/packages/vendo/src/cli/shared.ts
@@ -93,6 +93,37 @@ export function normalizeDotEnvValue(value: string): string {
   return value.replace(/\s+#.*$/, "").trimEnd();
 }
 
+/** Read target-project dotenv files in the order Next.js developers expect:
+ * `.env` first, then `.env.local`. Process env is merged separately so a CLI
+ * invocation never mutates its parent environment. */
+export async function readDotEnvFallback(root: string): Promise<Record<string, string>> {
+  const env: Record<string, string> = {};
+  for (const file of [".env", ".env.local"]) {
+    const source = await readOptional(join(root, file));
+    if (source === null) continue;
+    for (const rawLine of source.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (line === "" || line.startsWith("#")) continue;
+      const match = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
+      if (match !== null) env[match[1]!] = normalizeDotEnvValue(match[2]!.trim());
+    }
+  }
+  return env;
+}
+
+/** Explicit process env wins over dotenv fallback; a blank process value does
+ * not mask a concrete target-project value. */
+export function mergeEnvOverDotEnv(
+  fallback: Record<string, string>,
+  processEnv: NodeJS.ProcessEnv,
+): Record<string, string | undefined> {
+  const merged: Record<string, string | undefined> = { ...fallback, ...processEnv };
+  for (const [key, value] of Object.entries(processEnv)) {
+    if ((value ?? "").trim() === "" && fallback[key] !== undefined) merged[key] = fallback[key];
+  }
+  return merged;
+}
+
 export function toolingTelemetry(options: TelemetryOptions & {
   log?: (message: string) => void;
 } = {}): Telemetry {

--- a/packages/vendo/src/cli/sync.test.ts
+++ b/packages/vendo/src/cli/sync.test.ts
@@ -578,6 +578,49 @@ describe("sync AI enrichment integration (cse lane 1c)", () => {
     expect(messages.logs.join("\n")).toContain("host_a mutates a counter.");
   });
 
+  it("loads model credentials from the target dotenv files without overriding process env", async () => {
+    const { dir } = await hostWithTools();
+    await writeFile(join(dir, ".env"), "ANTHROPIC_API_KEY=from-env\nUNRELATED_SECRET_FOR_SYNC_TEST=never-forward\n");
+    await writeFile(join(dir, ".env.local"), 'ANTHROPIC_API_KEY="from-local"\nPATH=untrusted\n');
+    const seen: Array<Record<string, string | undefined>> = [];
+    const resolveCredential = async ({ env }: { env: Record<string, string | undefined> }) => {
+      seen.push(env);
+      return { rung: "none" as const };
+    };
+
+    await runSync({
+      targetDir: dir,
+      output: captureOutput().output,
+      fetchImpl: offline,
+      sync: async () => report(),
+      enrich: { resolveCredential },
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.ANTHROPIC_API_KEY).toBe("from-local");
+    expect(seen[0]?.UNRELATED_SECRET_FOR_SYNC_TEST).toBeUndefined();
+    expect(seen[0]?.PATH).not.toBe("untrusted");
+
+    vi.stubEnv("ANTHROPIC_API_KEY", "from-process");
+    await runSync({
+      targetDir: dir,
+      output: captureOutput().output,
+      fetchImpl: offline,
+      sync: async () => report(),
+      enrich: { resolveCredential },
+    });
+    expect(seen[1]?.ANTHROPIC_API_KEY).toBe("from-process");
+
+    vi.stubEnv("ANTHROPIC_API_KEY", "  ");
+    await runSync({
+      targetDir: dir,
+      output: captureOutput().output,
+      fetchImpl: offline,
+      sync: async () => report(),
+      enrich: { resolveCredential },
+    });
+    expect(seen[2]?.ANTHROPIC_API_KEY).toBe("from-local");
+  });
+
   it("--no-watermark passes watermark: false to the engine and skips enrichment entirely", async () => {
     const { dir, toolsPath } = await hostWithTools();
     const before = await readFile(toolsPath, "utf8");

--- a/packages/vendo/src/cli/sync.ts
+++ b/packages/vendo/src/cli/sync.ts
@@ -1,11 +1,19 @@
 import { join, resolve } from "node:path";
 import { vendoSync, type SyncReportWithWarnings } from "@vendoai/actions/sync";
 import type { ToolImpact } from "../sync-impact.js";
+import { ENV_KEY_VARS } from "../dev-creds/resolve.js";
 import { pushSyncReport } from "./cloud/services.js";
 import { askYesNo } from "./extract/extraction.js";
 import { readPreviousToolsState, runSyncEnrichment, type SyncEnrichmentOptions } from "./enrich/pass.js";
 import { syncSemantics } from "./semantics.js";
-import { consoleOutput, withCommandRun, type Output, type TelemetryOptions } from "./shared.js";
+import {
+  consoleOutput,
+  mergeEnvOverDotEnv,
+  readDotEnvFallback,
+  withCommandRun,
+  type Output,
+  type TelemetryOptions,
+} from "./shared.js";
 
 export interface SyncReportPayload {
   report: SyncReportWithWarnings;
@@ -40,6 +48,22 @@ export interface SyncOptions {
   /** Enrichment seams (tests / init's chosen harness). */
   enrich?: Pick<SyncEnrichmentOptions,
     "harness" | "harnesses" | "resolveCredential" | "computeDiff" | "treeHash" | "confirm" | "onProgress">;
+}
+
+const ENRICHMENT_CREDENTIAL_ENV_VARS = [...ENV_KEY_VARS.map(({ envVar }) => envVar), "VENDO_API_KEY"];
+
+/** Only model credentials cross from target dotenv files into model tooling.
+ * The host's other dotenv values can include application secrets or process
+ * controls and must never be forwarded to an enrichment subprocess. */
+function mergeEnrichmentCredentialEnv(
+  dotenv: Record<string, string>,
+  processEnv: NodeJS.ProcessEnv,
+): Record<string, string | undefined> {
+  const credentials: Record<string, string> = {};
+  for (const name of ENRICHMENT_CREDENTIAL_ENV_VARS) {
+    if (dotenv[name] !== undefined) credentials[name] = dotenv[name];
+  }
+  return mergeEnvOverDotEnv(credentials, processEnv);
 }
 
 /** `sync --json` — the one machine-readable object printed on stdout. */
@@ -173,10 +197,11 @@ async function sync(options: SyncOptions): Promise<number> {
     // Fail-soft like everything else in sync — the exit code never changes.
     if (options.noWatermark !== true) {
       try {
+        const enrichmentEnv = mergeEnrichmentCredentialEnv(await readDotEnvFallback(root), process.env);
         await runSyncEnrichment({
           root,
           vendoDir,
-          env: process.env,
+          env: enrichmentEnv,
           note,
           warn: noteError,
           previous: previousTools,


### PR DESCRIPTION
Closes #567.

Loads AI enrichment credentials from the target project's `.env` and `.env.local` files, with nonblank process environment values taking precedence. The dotenv bridge allowlists model credentials and `VENDO_API_KEY` so unrelated application secrets and process controls are not passed to enrichment subprocesses.

Tests:
- `pnpm --filter @vendoai/vendo exec vitest run src/cli/sync.test.ts src/cli/doctor.test.ts`
- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`