### PR TITLE
docs(quickstart): init writes three code files and mounts VendoRoot itself

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,15 +8,18 @@ npx vendo init
 ```
 
 The `vendoai` package is a thin alias. The scoped package is the canonical
-install. `vendo init` asks nothing on the happy path. It writes two code
-files — an empty `vendo/registry.tsx` and the catch-all handler wired to
-it — plus two package.json script hooks, extracts your tools and brand
-theme into `.vendo/`, resolves a model key, and prints the one line that is
-yours to paste: the `<VendoRoot components={registry}>` wrap in your
-layout. When it detects your auth provider in package.json it asks once to
-confirm the preset (consent-style, Enter accepts; `--yes` and
-non-interactive runs accept it silently). It never edits code you wrote. Then start your dev server — the agent is live in your app —
-and run `npx vendo doctor` to verify everything with one real model turn.
+install. `vendo init` asks nothing on the happy path. It writes three code
+files — an empty `vendo/registry.tsx`, the catch-all handler wired to it,
+and `vendo/vendo-root.tsx` (the `"use client"` mount that owns the registry
+and theme imports) — plus two package.json script hooks, extracts your
+tools and brand theme into `.vendo/`, and resolves a model key. It also
+mounts `<VendoRoot>` and `<VendoOverlay />` in your layout for you, the one
+edit it makes to a file you wrote; it reports that file in the wired list
+so you can review the diff before committing. When it detects your auth
+provider in package.json it asks once to confirm the preset (consent-style,
+Enter accepts; `--yes` and non-interactive runs accept it silently). Then
+start your dev server — the agent is live in your app — and run
+`npx vendo doctor` to verify everything with one real model turn.
 
 ## Non-interactive runs (agents)
 


### PR DESCRIPTION
## What

`docs/quickstart.md`'s opening paragraph makes three claims about `vendo init` that are false against a real run. Nightly demo QA has reproduced this drift every night since 2026-07-22.

## Evidence

Ran the documented quickstart verbatim, as a new user would, against a genuinely bare Next host — the `fixtures/host-app` tree copied out with its pre-wired `src/vendo/` and `src/app/api/vendo/` removed, so init had to do all the wiring itself:

```
npm install @vendoai/vendo     # 0.4.8, current latest
npx vendo init --byo --yes     # --byo --yes only to answer the Cloud offer non-interactively
```

Init reported:

```
Wired (5 files):
  + src/vendo/registry.tsx
  + src/app/api/vendo/[...vendo]/route.ts
  + src/vendo/vendo-root.tsx
  ~ src/app/layout.tsx
  ~ package.json
Learned: 12 tools · theme captured → .vendo/
Mounted <VendoRoot> + <VendoOverlay /> (the visible launcher + panel) in
src/app/layout.tsx — review the diff before committing.
```

| Doc claim | Reality |
| --- | --- |
| "writes two code files" | **three**: `registry.tsx`, the catch-all handler, and `vendo-root.tsx` |
| "prints the one line that is yours to paste: the `<VendoRoot components={registry}>` wrap" | init performs the wrap itself; the registry/theme imports live inside the generated `vendo-root.tsx` `"use client"` boundary, so no line is left for the reader |
| "It never edits code you wrote" | it edited `src/app/layout.tsx` |

The resulting `src/app/layout.tsx`:

```tsx
import { VendoRoot } from "../vendo/vendo-root";
...
<body><VendoRoot>{children}</VendoRoot></body>
```

The CLI is not wrong here — it lists `~ src/app/layout.tsx` in the wired set and tells you to review the diff. Only the doc is stale, so this PR changes the doc and keeps the review-the-diff affordance visible so the layout edit is not a surprise.

The "two package.json script hooks" claim was accurate (`predev: vendo sync`, `prebuild: vendo sync --strict`) and is unchanged.

## Gates

Docs-only change; no code touched. All run on `76dcf6a3` + this commit:

- `pnpm build` — 22/22 green
- `pnpm typecheck` — 38/38 green
- `pnpm lint` — 5/5 green
- `pnpm test` — green

Correction to a claim in the 2026-07-25 nightly QA report: that run stated `pnpm test` was "already red on clean main" (`@vendoai/ui`, 5 files / 28 tests) and concluded the repo's own `build && test && typecheck && lint` gate rule was "currently unmeetable on main". That was wrong — it was an artifact of the QA rig's Node version, not a main break.

Node 26 defines a global `localStorage` accessor that returns `undefined` unless `--localstorage-file` is passed. vitest 2.1.9's jsdom environment skips copying jsdom's real `localStorage` onto the test realm because the key already exists on `globalThis`, so `window.localStorage` is `undefined` and the discoverability suites fail. jsdom itself is fine standalone (verified on both 25.0.1 and 29.1.1). Under Node v24.18.0 those same 5 files pass 28/28, and the full suite is green. The mini's default `node` had drifted to v26.5.0; the repo declares `engines: node >= 20`.

The only failure remaining under `CI=true` is `@vendoai/store`'s deliberate `POSTGRES_URL must be set in CI` guard, which correctly demands a real Postgres the QA rig does not have; without `CI=true` that leg skips and store is 218 passed / 1 skipped.

## Verification

`vendo init` output typechecks clean (`tsc --noEmit`) and builds clean (14 routes) on the scratch host, and a second `init` run is idempotent (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)