### PR TITLE
cli: sync reads project .env for enrichment (#567); extract --apply stops waking disabled tools (#553)

### DIFF
--- a/packages/vendo/src/cli/extract/apply.test.ts
+++ b/packages/vendo/src/cli/extract/apply.test.ts
@@ -66,12 +66,15 @@ describe("vendo extract --apply (the delegation surface)", () => {
       { tools: Record<string, Record<string, unknown>> };
     expect(overrides.tools["host_invoices_list"]).toEqual({ description: "List invoices, filterable by status." });
     expect(overrides.tools["host_invoices_create"]).toMatchObject({ risk: "destructive", critical: true });
-    expect(overrides.tools["host_admin_unclassified"]).toMatchObject({ disabled: false, risk: "destructive" });
+    // Restrictive-only (#553): the description lands, but the enable attempt is
+    // refused — extract --apply never wakes a scanner-disabled tool.
+    expect(overrides.tools["host_admin_unclassified"]).toEqual({ description: "Reset all demo data." });
     expect(await readFile(join(root, ".vendo", "brief.md"), "utf8")).toContain("consumer bank");
 
     expect(sync).toHaveBeenCalledWith({ root, out: join(root, ".vendo") });
     const logs = sink.logs.join("\n");
-    expect(logs).toContain("AI polish applied: 3 descriptions · 1 risk raises · 1 critical marks · 1 tools woken · brief drafted");
+    expect(logs).toContain("AI polish applied: 3 descriptions · 1 risk raises · 1 critical marks · brief drafted");
+    expect(sink.errors.join("\n")).toContain("refused: host_admin_unclassified: enabling a disabled tool refused");
     expect(logs).toContain("missed surface (not extracted yet): /api/webhooks");
   });
 

--- a/packages/vendo/src/cli/extract/delegate.ts
+++ b/packages/vendo/src/cli/extract/delegate.ts
@@ -42,7 +42,7 @@ export const EXTRACTION_DRAFT_JSON_SCHEMA: Record<string, unknown> = {
           critical: { type: "boolean" },
           disabled: {
             type: "boolean",
-            description: "false = wake a statically-unclassifiable tool (requires reasoning and risk).",
+            description: "A scanner-disabled tool stays disabled: a draft may only make tools MORE restrictive, so disabled: false is refused on apply — waking a tool is a human edit in overrides.json.",
           },
           audience: {
             enum: ["end-user", "operator", "internal"],
@@ -77,7 +77,7 @@ export function composeDelegatedInstructions(tools: StaticTool[], appName: strin
     '  { "brief": string, "tools": [{ "name", "description", "risk"?, "critical"?, "disabled"?, "audience"?, "reasoning"? }], "missedSurfaces"?: string[] }',
     "- tools: include ONLY names from the list above. Rewrite each description so an agent choosing tools understands what it actually does (read the handler source). <= 200 chars each.",
     "- risk: you may RAISE risk (read->write->destructive) when the handler is more dangerous than labeled; never lower it. Mark irreversible operations critical: true.",
-    "- A tool listed as disabled was statically unclassifiable. If you can read its handler and grade it, set disabled: false WITH a risk and one-line reasoning. Leave it out otherwise.",
+    "- A tool listed as disabled stays disabled: a draft may only make tools MORE restrictive, so do NOT set disabled: false (it is refused on apply) — waking a tool is a human edit in overrides.json. You may still improve its description.",
     "- audience: who the handler's own auth admits — \"end-user\" (a signed-in customer acting on their own data),",
     "  \"operator\" (admin/staff/support consoles), or \"internal\" (machine-to-machine: webhooks, cron, reconciliation,",
     "  service tokens). Read the auth checks, not the route name. When unsure, default to internal — non-end-user",

--- a/packages/vendo/src/cli/extract/extraction.test.ts
+++ b/packages/vendo/src/cli/extract/extraction.test.ts
@@ -97,7 +97,7 @@ describe("composeInstructions", () => {
 });
 
 describe("applyDraft (deterministic verification)", () => {
-  it("applies descriptions, risk raises, critical marks, and wakes reasoned tools", async () => {
+  it("applies descriptions, risk raises, and critical marks; refuses to wake a scanner-disabled tool (#553)", async () => {
     const root = await fixture();
     const summary = await applyDraft({
       root,
@@ -111,11 +111,17 @@ describe("applyDraft (deterministic verification)", () => {
         ],
       },
     });
-    expect(summary).toMatchObject({ described: 3, riskRaised: 1, critical: 1, woken: 1, briefWritten: true, refused: [] });
+    // Restrictive-only doctrine: descriptions still land (additive), but the
+    // enable attempt is refused — a scanner-disabled tool is woken by hand in
+    // overrides.json, never by an AI draft.
+    expect(summary).toMatchObject({ described: 3, riskRaised: 1, critical: 1, briefWritten: true });
+    expect(summary.refused).toHaveLength(1);
+    expect(summary.refused[0]).toMatch(/host_admin_unclassified.*enabling a disabled tool refused.*overrides\.json/);
     const overrides = await readOverrides(root);
     expect(overrides.tools["host_invoices_list"]).toEqual({ description: "List invoices, filterable by status." });
     expect(overrides.tools["host_invoices_create"]).toMatchObject({ risk: "destructive", critical: true });
-    expect(overrides.tools["host_admin_unclassified"]).toMatchObject({ disabled: false, risk: "destructive" });
+    // The additive annotation applies; the loosening (disabled/risk) does not.
+    expect(overrides.tools["host_admin_unclassified"]).toEqual({ description: "Reset all demo data." });
     expect(await readFile(join(root, ".vendo", "brief.md"), "utf8")).toContain("consumer bank");
   });
 
@@ -248,7 +254,7 @@ describe("applyDraft (deterministic verification)", () => {
     expect(overrides.tools["host_admin_unclassified"]?.disabled).toBeUndefined();
   });
 
-  it("a reasoned wake carries the model's grade without a false downgrade refusal (Greptile P1)", async () => {
+  it("refuses to wake a scanner-disabled tool even with reasoning and a risk; the description still lands (#553)", async () => {
     const root = await fixture();
     const summary = await applyDraft({
       root,
@@ -261,21 +267,25 @@ describe("applyDraft (deterministic verification)", () => {
         }],
       },
     });
-    // The static "destructive" was a fail-closed placeholder, not evidence:
-    // the wake applies the model's grade with NO contradictory refusal line.
-    expect(summary).toMatchObject({ woken: 1, refused: [] });
+    // Enabling is a loosening — refused regardless of reasoning; only the
+    // additive description survives, and the tool stays disabled.
+    expect(summary.described).toBe(1);
+    expect(summary.refused).toHaveLength(1);
+    expect(summary.refused[0]).toMatch(/enabling a disabled tool refused/);
     const overrides = await readOverrides(root);
-    expect(overrides.tools["host_admin_unclassified"]).toMatchObject({ disabled: false, risk: "read" });
+    expect(overrides.tools["host_admin_unclassified"]).toEqual({ description: "Lists admin settings." });
+    expect(overrides.tools["host_admin_unclassified"]).not.toHaveProperty("disabled");
+    expect(overrides.tools["host_admin_unclassified"]).not.toHaveProperty("risk");
   });
 
-  it("a wake never replaces a human-set risk or reverses a human disable decision", async () => {
+  it("a refused wake never touches a human-set risk, and a human disable decision is never reversed (#553)", async () => {
     const root = await fixture({
       format: "vendo/overrides@1",
       tools: {
         host_admin_unclassified: { risk: "destructive" },
       },
     });
-    const woken = await applyDraft({
+    const refused = await applyDraft({
       root,
       tools: TOOLS,
       draft: {
@@ -283,8 +293,11 @@ describe("applyDraft (deterministic verification)", () => {
         tools: [{ name: "host_admin_unclassified", description: "d", disabled: false, risk: "read", reasoning: "r" }],
       },
     });
-    expect(woken.woken).toBe(1);
-    expect((await readOverrides(root)).tools["host_admin_unclassified"]).toMatchObject({ disabled: false, risk: "destructive" });
+    expect(refused.refused).toHaveLength(1);
+    expect(refused.refused[0]).toMatch(/enabling a disabled tool refused/);
+    // The human-authored risk is left exactly as written; the tool stays disabled.
+    expect((await readOverrides(root)).tools["host_admin_unclassified"]).toMatchObject({ risk: "destructive", description: "d" });
+    expect((await readOverrides(root)).tools["host_admin_unclassified"]).not.toHaveProperty("disabled");
 
     const humanDisabled = await fixture({
       format: "vendo/overrides@1",
@@ -298,7 +311,9 @@ describe("applyDraft (deterministic verification)", () => {
         tools: [{ name: "host_admin_unclassified", description: "d", disabled: false, risk: "read", reasoning: "r" }],
       },
     });
-    expect(kept.woken).toBe(0);
+    // A human already decided (disabled: true) — the AI draft cannot reverse it,
+    // and no refusal noise is needed because the human's decision simply wins.
+    expect(kept.refused).toEqual([]);
     expect((await readOverrides(humanDisabled)).tools["host_admin_unclassified"]?.disabled).toBe(true);
   });
 

--- a/packages/vendo/src/cli/extract/extraction.ts
+++ b/packages/vendo/src/cli/extract/extraction.ts
@@ -34,18 +34,20 @@ export { composeInstructions } from "./stages.js";
  * verification — see stages.ts for the survey / draft-per-surface /
  * cross-check / brief orchestration). The agent reads the codebase and
  * drafts judgment on top of the static facts: task-oriented tool
- * descriptions, risk corrections, critical marks, waking unclassifiable
- * tools, and the product brief.
+ * descriptions, risk corrections, critical marks, and the product brief.
  *
  * Output rides the channels that SURVIVE `vendo sync` regeneration:
  * `.vendo/overrides.json` (per-tool description/risk/critical/disabled — the
  * designed merge layer) and `.vendo/brief.md`. It never writes tools.json
  * directly, so predev/prebuild re-extraction cannot clobber it.
  *
- * Deterministic guards (never cross fingers, PostHog lesson):
+ * Deterministic guards (never cross fingers, PostHog lesson) — the SAME
+ * restrictive-only doctrine sync/init enforce via clampEnrichment: an AI draft
+ * may only make a tool MORE restrictive, never loosen it.
  * - only tool names the static extraction produced are accepted;
  * - risk may be RAISED, never lowered (fail-closed stays fail-closed);
- * - waking a disabled tool requires reasoning and an explicit risk;
+ * - a scanner-disabled tool is NEVER woken by the draft — enabling is a human
+ *   act and lives in overrides.json (disabled: false); the draft is refused;
  * - human decisions win: existing override fields are never overwritten, and
  *   a hand-written brief is never replaced (only the init template is).
  */
@@ -56,7 +58,6 @@ export interface AppliedSummary {
   described: number;
   riskRaised: number;
   critical: number;
-  woken: number;
   /** Non-end-user-audience tools excluded (disabled) this apply. */
   excluded: number;
   /** Tools still live after this apply — zero means the agent cannot act on the host API at all. */
@@ -91,7 +92,7 @@ export async function applyDraft(input: {
       })();
 
   const summary: AppliedSummary = {
-    described: 0, riskRaised: 0, critical: 0, woken: 0, excluded: 0, enabledAfter: 0,
+    described: 0, riskRaised: 0, critical: 0, excluded: 0, enabledAfter: 0,
     briefWritten: false, refused: [], missedSurfaces: input.draft.missedSurfaces ?? [],
   };
 
@@ -108,23 +109,20 @@ export async function applyDraft(input: {
       next.description = entry.description;
       summary.described += 1;
     }
-    // Waking a statically-unclassifiable tool is its own path: the static
-    // "destructive, disabled" grade is a fail-closed PLACEHOLDER, not
-    // evidence, so a reasoned wake carries the model's grade without tripping
-    // the downgrade guard (Greptile P1 / Devin on #363). A human-set risk or
-    // disabled decision always wins.
-    // A wake claiming a non-end-user audience is contradictory; audience
-    // exclusion (fail-closed) wins and the wake leg never runs.
+    // Restrictive-only doctrine (#553): enabling a scanner-disabled tool is a
+    // loosening, and an AI draft may only ever make a tool MORE restrictive —
+    // the SAME rule sync/init's clampEnrichment enforces on tools.json. So a
+    // draft that tries to wake a disabled tool is refused here, with a line
+    // pointing the operator to the human-written authored layer; overrides.json
+    // is where a human wakes it by hand (disabled: false). A wake claiming a
+    // non-end-user audience is contradictory anyway; audience exclusion
+    // (fail-closed) already wins, so the refusal leg only fires for the
+    // otherwise-plausible end-user wake. A human decision (existing.disabled
+    // set either way) simply wins — no refusal noise needed.
     const nonEndUser = entry.audience === "operator" || entry.audience === "internal";
-    const isWake = entry.disabled === false && fact.disabled === true && !nonEndUser;
-    if (isWake && existing.disabled === undefined) {
-      if (entry.reasoning === undefined || entry.risk === undefined) {
-        summary.refused.push(`${entry.name}: waking a disabled tool needs reasoning and a risk grade`);
-      } else {
-        next.disabled = false;
-        if (existing.risk === undefined) next.risk = entry.risk;
-        summary.woken += 1;
-      }
+    const proposesWake = entry.disabled === false && fact.disabled === true && !nonEndUser;
+    if (proposesWake && existing.disabled === undefined) {
+      summary.refused.push(`${entry.name}: enabling a disabled tool refused — wake it by hand in overrides.json (disabled: false)`);
     } else if (
       entry.risk !== undefined && existing.risk === undefined && fact.disabled !== true
     ) {
@@ -195,7 +193,6 @@ export function reportApplied(input: {
     `${applied.described} descriptions`,
     ...(applied.riskRaised > 0 ? [`${applied.riskRaised} risk raises`] : []),
     ...(applied.critical > 0 ? [`${applied.critical} critical marks`] : []),
-    ...(applied.woken > 0 ? [`${applied.woken} tools woken`] : []),
     ...(applied.excluded > 0 ? [`${applied.excluded} operator/internal tools excluded`] : []),
     ...(input.briefDrafted ? ["brief drafted"] : []),
   ];

--- a/packages/vendo/src/cli/extract/stages.ts
+++ b/packages/vendo/src/cli/extract/stages.ts
@@ -141,7 +141,7 @@ export function composeInstructions(
     '  { "tools": [{ "name", "description", "risk"?, "critical"?, "disabled"?, "audience"?, "reasoning"? }], "missedSurfaces"?: string[] }',
     "- tools: include ONLY names from the list above. Rewrite each description so an agent choosing tools understands what it actually does (read the handler source). <= 200 chars each.",
     "- risk: you may RAISE risk (read->write->destructive) when the handler is more dangerous than labeled; never lower it. Mark irreversible operations critical: true.",
-    "- A tool listed as disabled was statically unclassifiable. If you can read its handler and grade it, set disabled: false WITH a risk and one-line reasoning. Leave it out otherwise.",
+    "- A tool listed as disabled stays disabled: judgment may only make tools MORE restrictive, so do NOT set disabled: false (it is refused on apply) — waking a tool is a human edit in overrides.json. You may still improve its description.",
     "- audience: who the handler's own auth admits — \"end-user\" (a signed-in customer acting on their own data),",
     "  \"operator\" (admin/staff/support consoles), or \"internal\" (machine-to-machine: webhooks, cron, reconciliation,",
     "  service tokens). Read the auth checks, not the route name. When unsure, default to internal — non-end-user",

--- a/packages/vendo/src/cli/sync.test.ts
+++ b/packages/vendo/src/cli/sync.test.ts
@@ -602,6 +602,77 @@ describe("sync AI enrichment integration (cse lane 1c)", () => {
     expect(await readFile(toolsPath, "utf8")).toBe(before);
   });
 
+  it("resolves a model key that lives only in the sync dir's .env.local (#567)", async () => {
+    // The ONLY credential lives in the project's .env.local, exactly the case
+    // that previously fell through to structural-only. A sentinel var name
+    // keeps the assertion deterministic no matter what real ANTHROPIC_API_KEY /
+    // VENDO_API_KEY the developer/CI machine exports (which, with process env
+    // winning, would otherwise mask the .env.local value under test).
+    const { dir, toolsPath } = await hostWithTools();
+    await writeFile(join(dir, ".env.local"), "VENDO_TEST_ONLY_MODEL_KEY=sk-only-in-dotenv\n", "utf8");
+    const messages = captureOutput();
+    let seenKey: string | undefined;
+    const harness = {
+      id: "npx-engine",
+      availability: async ({ env }: { env: Record<string, string | undefined> }) =>
+        (typeof env.VENDO_TEST_ONLY_MODEL_KEY === "string" ? "byo (.env.local)" : null),
+      run: async () => `\`\`\`json\n${JSON.stringify({
+        tools: [{ name: "host_a", description: "Enriched via the .env.local key.", risk: "write" }],
+        narrative: "host_a mutates a counter.",
+      })}\n\`\`\``,
+    };
+    const exit = await runSync({
+      targetDir: dir,
+      output: messages.output,
+      fetchImpl: offline,
+      sync: async () => report(),
+      enrich: {
+        harnesses: [harness],
+        resolveCredential: async ({ env }) => {
+          seenKey = env.VENDO_TEST_ONLY_MODEL_KEY;
+          return typeof env.VENDO_TEST_ONLY_MODEL_KEY === "string"
+            ? { rung: "env-key", provider: "anthropic", envVar: "ANTHROPIC_API_KEY" }
+            : { rung: "none" };
+        },
+        treeHash: async () => "feedfacefeedfacefeedfacefeedfacefeedface",
+      },
+    });
+    expect(exit).toBe(0);
+    expect(seenKey).toBe("sk-only-in-dotenv");
+    const file = JSON.parse(await readFile(toolsPath, "utf8"));
+    expect(file.tools[0]).toMatchObject({ description: "Enriched via the .env.local key.", enriched: true });
+  });
+
+  it("no key in .env.local and none in process env stays structural-only (#567)", async () => {
+    // Sentinel var that only a .env.local could carry — kept out of process
+    // env so the "neither present" branch is deterministic regardless of the
+    // developer/CI machine's real ANTHROPIC_API_KEY / VENDO_API_KEY.
+    const { dir, toolsPath } = await hostWithTools();
+    const before = await readFile(toolsPath, "utf8");
+    const messages = captureOutput();
+    const exit = await runSync({
+      targetDir: dir,
+      output: messages.output,
+      fetchImpl: offline,
+      sync: async () => report(),
+      enrich: {
+        harnesses: [{
+          id: "npx-engine",
+          availability: async ({ env }: { env: Record<string, string | undefined> }) =>
+            (typeof env.VENDO_TEST_ONLY_MODEL_KEY === "string" ? "byo" : null),
+          run: async () => { throw new Error("must not run without a key"); },
+        }],
+        resolveCredential: async ({ env }) =>
+          (typeof env.VENDO_TEST_ONLY_MODEL_KEY === "string"
+            ? { rung: "env-key", provider: "anthropic", envVar: "ANTHROPIC_API_KEY" }
+            : { rung: "none" }),
+      },
+    });
+    expect(exit).toBe(0);
+    expect(messages.logs.join("\n")).toContain("enrichment: structural-only");
+    expect(await readFile(toolsPath, "utf8")).toBe(before);
+  });
+
   it("--json folds enrichment lines into notes, never stdout prose", async () => {
     const { dir } = await hostWithTools();
     const messages = captureOutput();

--- a/packages/vendo/src/cli/sync.ts
+++ b/packages/vendo/src/cli/sync.ts
@@ -2,6 +2,7 @@ import { join, resolve } from "node:path";
 import { vendoSync, type SyncReportWithWarnings } from "@vendoai/actions/sync";
 import type { ToolImpact } from "../sync-impact.js";
 import { pushSyncReport } from "./cloud/services.js";
+import { mergeEnvOverDotEnv, readDotEnvFallback } from "./doctor.js";
 import { askYesNo } from "./extract/extraction.js";
 import { readPreviousToolsState, runSyncEnrichment, type SyncEnrichmentOptions } from "./enrich/pass.js";
 import { syncSemantics } from "./semantics.js";
@@ -172,11 +173,18 @@ async function sync(options: SyncOptions): Promise<number> {
     // --no-watermark (workspace-internal syncs) skips the pass entirely.
     // Fail-soft like everything else in sync — the exit code never changes.
     if (options.noWatermark !== true) {
+      // The enrichment credential resolves from this env, so the project's
+      // dotenv must be visible: `vendo login` and BYO keys land in `.env.local`
+      // / `.env`, and a fresh shell that never `source`d them would otherwise
+      // sync structural-only with no signal why (#567). Reuse doctor's parser
+      // (never hand-roll) — real process env still wins over both files.
+      // Precedence end to end: explicit > process.env > .env.local > .env.
+      const enrichEnv = mergeEnvOverDotEnv(await readDotEnvFallback(root), process.env);
       try {
         await runSyncEnrichment({
           root,
           vendoDir,
-          env: process.env,
+          env: enrichEnv,
           note,
           warn: noteError,
           previous: previousTools,


### PR DESCRIPTION
Two contained backlog fixes.

## #567 — sync enrichment reads the project .env/.env.local
`vendo sync`'s AI enrichment resolved the model credential only from process.env, so a key in the project's dotenv (where `vendo login` writes it) was ignored → silent structural-only. Now loads `.env` then `.env.local` (reusing doctor's readDotEnvFallback/mergeEnvOverDotEnv — same util as the merged config-command fix), merged under process.env. Precedence: explicit > process.env > .env.local > .env. Keyless unchanged.

## #553 — extract --apply no longer wakes disabled tools
`vendo extract --apply` could set a scanner-disabled tool back to enabled from an agent draft — violating format-v3 restrictive-only doctrine (AI may only tighten). The wake branch now refuses with an actionable warning ("wake it by hand in overrides.json"), matching clampEnrichment's wording; additive annotations (descriptions, risk raises, critical) still apply; human overrides always win. Agent prompt/contract updated to stop instructing disabled:false.

## Gates
vendo 1169 passed / 13 skipped; typecheck + lint + dependency-guard + portability-gate green; next-env zero-diff. Two-stage review: SPEC_COMPLIANT + APPROVED (precedence verified, no loosening path remains, deterministic tests, clean commit separation).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync enrichment now reads project dotenv files so model keys from `vendo login` are used, preventing silent structural-only runs. Extract `--apply` now refuses to re-enable scanner-disabled tools and guides users to make that change by hand.

- **Bug Fixes**
  - Sync enrichment reads `.env` and `.env.local` before resolving the model credential; precedence: explicit > `process.env` > `.env.local` > `.env` via `readDotEnvFallback`/`mergeEnvOverDotEnv` (Linear #567).
  - `vendo extract --apply` refuses `disabled: false` for scanner-disabled tools; additive edits (descriptions, risk raises, critical) still apply, and users are directed to `overrides.json` to wake tools (Linear #553).

<sup>Written for commit 8daa5770b0fbed5caec1f7d9747f1156b5c50f6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

