### PR TITLE
fix: prevent assistant-start history window

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -350,6 +350,14 @@ function providerHistory(messages: UIMessage[]): UIMessage[] {
   }));
 }
 
+function trimInvalidHistoryStart(messages: UIMessage[]): UIMessage[] {
+  const firstValidIndex = messages.findIndex(
+    (message) => message.role === "system" || message.role === "user",
+  );
+
+  return firstValidIndex === -1 ? [] : messages.slice(firstValidIndex);
+}
+
 /** 03-agent §1 */
 
 /** The one gate raw errors pass on their way to the wire. Vendo's OWN errors
@@ -510,9 +518,12 @@ export function createAgent(config: AgentConfig): VendoAgent {
           // History windowing: bound what is re-sent per turn to the last N whole messages.
           // Slicing whole UIMessages keeps each turn's tool-call/result pairing intact.
           const window = config.context?.historyWindow;
-          const history = window !== undefined && thread.messages.length > window
+          const windowedHistory = window !== undefined && thread.messages.length > window
             ? thread.messages.slice(-window)
             : thread.messages;
+          const history = window !== undefined && thread.messages.length > window
+            ? trimInvalidHistoryStart(windowedHistory)
+            : windowedHistory;
           const converted = (await convertToModelMessages(providerHistory(history)))
             .filter((message) => message.content.length > 0);
           // Cache the stable history prefix (everything but the final message) alongside the

--- a/packages/agent/src/context.test.ts
+++ b/packages/agent/src/context.test.ts
@@ -5,11 +5,13 @@ import { createAgent } from "./index.js";
 import {
   boundRegistry,
   ctx,
+  memoryStore,
   readSse,
   scriptedModel,
   testGuard,
   textTurn,
   toolCallTurn,
+  userMessage,
 } from "./test-helpers.js";
 
 const descriptor: ToolDescriptor = {
@@ -131,5 +133,60 @@ describe("context engineering", () => {
     expect(report.toolCalls).toEqual([]);
     expect(model.doStreamCalls).toEqual([]);
     expect(model.doGenerateCalls).toEqual([]);
+  });
+
+  it("trims leading assistant messages from windowed history so the request does not start with an assistant role", async () => {
+    const store = memoryStore();
+    const guard = testGuard({});
+    const tools = boundRegistry({}, guard);
+    const model = scriptedModel([
+      textTurn("Reply to final turn.", "text_final"),
+    ]);
+
+    // Prepopulate thread with: user, assistant, user, assistant
+    const threadId = "thr_window_trim";
+    await store.records("vendo_threads").put({
+      id: threadId,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      data: {
+        subject: "u1",
+        messages: [
+          userMessage("user_1", "Hello"),
+          { id: "assistant_1", role: "assistant", parts: [{ type: "text", text: "Hi there" }] },
+          userMessage("user_2", "Second question"),
+          { id: "assistant_2", role: "assistant", parts: [{ type: "text", text: "Answer to second" }] },
+        ],
+      },
+    });
+
+    const agent = createAgent({
+      model,
+      tools,
+      guard,
+      store,
+      context: { historyWindow: 2 }, // window of 2 elements. With user_3 added, thread becomes 5 elements.
+      // Slicing last 2 elements gives: assistant_2, user_3.
+      // This is trimmed by trimInvalidHistoryStart to just: user_3.
+    });
+
+    const response = await agent.stream({
+      threadId,
+      message: userMessage("user_3", "Final message"),
+      ctx: ctx(),
+    });
+    await readSse(response);
+
+    // Verify model received the correct messages starting with a valid role.
+    const prompts = model.prompts;
+    expect(prompts).toHaveLength(1);
+    const sentMessages = prompts[0];
+
+    // sentMessages[0] is the system message.
+    expect(sentMessages[0]?.role).toBe("system");
+    // sentMessages[1] should be the trimmed history, starting with user_3's user message.
+    expect(sentMessages[1]?.role).toBe("user");
+    expect(sentMessages[1]?.content).toEqual([{ type: "text", text: "Final message" }]);
+    expect(sentMessages).toHaveLength(2); // System + User (user_3)
   });
 });


### PR DESCRIPTION
## Summary
- Prevent `historyWindow` slicing from sending message history that starts with an assistant message.
- Trim invalid leading messages after slicing so the request starts from a valid role: `system` or `user`.
- Add focused test coverage for slicing into the middle of a conversation.

## Testing
- `pnpm --filter @vendoai/agent typecheck`
- `pnpm --filter @vendoai/agent test`
- `node scripts/dependency-guard.mjs`

## Notes
No real AI provider API calls were needed. This was tested at the message-history construction level using the project's mocked scripted model framework.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes history windowing in `@vendoai/agent` so requests never start with an assistant message. After slicing, we trim leading assistant messages so the first role is always `system` or `user`.

- **Bug Fixes**
  - Added `trimInvalidHistoryStart` and applied it after windowing to ensure a valid starting role.
  - Added focused tests for mid-conversation slicing to verify the model receives only valid leading messages.

<sup>Written for commit f65dbdbd391d5437a65d2b0017068f2958c24b69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

