### PR TITLE
actions: feature detect modifier and satisfies APIs on old host TypeScript (#551)

### DIFF
--- a/.changeset/old-host-typescript-compat.md
+++ b/.changeset/old-host-typescript-compat.md
@@ -1,0 +1,6 @@
+---
+"@vendoai/actions": patch
+"@vendoai/vendo": patch
+---
+
+Feature detect the TS 4.8 modifier APIs and TS 4.9 `isSatisfiesExpression` in static extraction, falling back to the legacy node properties, so `vendo init` no longer crashes on hosts whose own TypeScript predates those APIs (#551).

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -80,6 +80,7 @@
     "jose": "^6.2.3",
     "next": "16.2.11",
     "typescript": "^5.6.0",
+    "typescript47": "npm:typescript@4.7.4",
     "vitest": "^2.1.0",
     "zod-to-json-schema": "^3.25.2"
   },

--- a/packages/actions/src/sync/catalog-scan.ts
+++ b/packages/actions/src/sync/catalog-scan.ts
@@ -5,6 +5,7 @@ import type tsTypes from "typescript";
 import type { CatalogEntry } from "../formats.js";
 import { walk } from "./common.js";
 import { parseModule, resolveIdentifier, zodFromExpression, type FileModule, type StaticExtraction } from "./static-ts.js";
+import { isSatisfiesExpressionNode } from "./ts-compat.js";
 
 let ts: typeof tsTypes;
 
@@ -76,7 +77,7 @@ function unwrapExpression(expression: tsTypes.Expression): tsTypes.Expression {
     ts.isAsExpression(current)
     || ts.isTypeAssertionExpression(current)
     || ts.isParenthesizedExpression(current)
-    || ts.isSatisfiesExpression(current)
+    || isSatisfiesExpressionNode(ts, current)
     || ts.isNonNullExpression(current)
   ) current = current.expression;
   return current;

--- a/packages/actions/src/sync/common.ts
+++ b/packages/actions/src/sync/common.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { sha256Hex } from "@vendoai/core";
 import type TS from "typescript";
 import type { ExtractedTool, HttpMethod, PrimitiveToolBinding } from "../formats.js";
+import { modifiersOf } from "./ts-compat.js";
 
 const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx"] as const;
 // Hidden directories are never route sources; alternate Next dist dirs
@@ -201,13 +202,11 @@ export function visitNodes(ts: typeof TS, root: TS.Node, visit: (node: TS.Node) 
 }
 
 function hasExportModifier(ts: typeof TS, statement: TS.Statement): boolean {
-  return ts.canHaveModifiers(statement) === true
-    && (ts.getModifiers(statement) ?? []).some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword);
+  return modifiersOf(ts, statement).some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword);
 }
 
 function hasDefaultModifier(ts: typeof TS, statement: TS.Statement): boolean {
-  return ts.canHaveModifiers(statement) === true
-    && (ts.getModifiers(statement) ?? []).some((modifier) => modifier.kind === ts.SyntaxKind.DefaultKeyword);
+  return modifiersOf(ts, statement).some((modifier) => modifier.kind === ts.SyntaxKind.DefaultKeyword);
 }
 
 function bindingDeclaresName(ts: typeof TS, name: TS.BindingName, exportedName: string): boolean {

--- a/packages/actions/src/sync/public.ts
+++ b/packages/actions/src/sync/public.ts
@@ -35,3 +35,6 @@ export {
   type StaticExtraction,
   type ZodSchemaResult,
 } from "./static-ts.js";
+// Version-tolerant probes for host TypeScript APIs (#551); shared so CLI-side
+// compiler consumers stay in lockstep with the extractors.
+export { isSatisfiesExpressionNode, modifiersOf } from "./ts-compat.js";

--- a/packages/actions/src/sync/route-scan.ts
+++ b/packages/actions/src/sync/route-scan.ts
@@ -16,6 +16,7 @@ import {
   type SourcedExtractedTool,
 } from "./common.js";
 import { createRouteScanState, inferRouteInput, type RouteInputResult } from "./route-schema.js";
+import { modifiersOf } from "./ts-compat.js";
 
 const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
 const HTTP_METHOD_SET = new Set<string>(HTTP_METHODS);
@@ -111,8 +112,7 @@ function isStringLike(ts: typeof TS, node: TS.Node): node is TS.StringLiteral | 
 }
 
 function hasModifier(ts: typeof TS, statement: TS.Statement, kind: TS.SyntaxKind): boolean {
-  return ts.canHaveModifiers(statement) === true
-    && (ts.getModifiers(statement) ?? []).some((modifier) => modifier.kind === kind);
+  return modifiersOf(ts, statement).some((modifier) => modifier.kind === kind);
 }
 
 function bindingNames(ts: typeof TS, name: TS.BindingName): string[] {

--- a/packages/actions/src/sync/route-schema.ts
+++ b/packages/actions/src/sync/route-schema.ts
@@ -10,6 +10,7 @@ import {
   type FileModule,
   type StaticExtraction,
 } from "./static-ts.js";
+import { isSatisfiesExpressionNode, modifiersOf } from "./ts-compat.js";
 
 /**
  * Route-scan input-schema inference (PR 2, 04 §1): a collector seam asked
@@ -149,8 +150,7 @@ export async function inferRouteInput(
 
 /** True when `statement` carries an `export` modifier. */
 function hasExportKeyword(ts: typeof TS, statement: TS.Statement): boolean {
-  return ts.canHaveModifiers(statement) === true
-    && (ts.getModifiers(statement) ?? []).some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword);
+  return modifiersOf(ts, statement).some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword);
 }
 
 /** A discovered handler: its body plus the identifier name of its first
@@ -213,7 +213,7 @@ function unwrapJsonCandidate(ts: typeof TS, node: TS.Node): TS.Node {
       current = current.expression;
     } else if (ts.isParenthesizedExpression(current)) {
       current = current.expression;
-    } else if (ts.isAsExpression(current) || ts.isSatisfiesExpression(current)) {
+    } else if (ts.isAsExpression(current) || isSatisfiesExpressionNode(ts, current)) {
       current = current.expression;
     } else if (ts.isNonNullExpression(current)) {
       current = current.expression;

--- a/packages/actions/src/sync/server-actions.ts
+++ b/packages/actions/src/sync/server-actions.ts
@@ -22,6 +22,7 @@ import {
   type Ts,
   type ZodSchemaResult,
 } from "./static-ts.js";
+import { isSatisfiesExpressionNode, modifiersOf } from "./ts-compat.js";
 
 /**
  * Static Next.js server-action extraction (04 §1, additive within
@@ -100,7 +101,7 @@ type FunctionNode = TS.FunctionDeclaration | TS.FunctionExpression | TS.ArrowFun
 
 function unwrapExpression(ts: Ts, expr: TS.Expression): TS.Expression {
   let current = expr;
-  while (ts.isParenthesizedExpression(current) || ts.isAsExpression(current) || ts.isSatisfiesExpression(current)) {
+  while (ts.isParenthesizedExpression(current) || ts.isAsExpression(current) || isSatisfiesExpressionNode(ts, current)) {
     current = current.expression;
   }
   return current;
@@ -326,7 +327,7 @@ async function collectModuleActions(
   };
 
   for (const statement of module.sf.statements) {
-    const modifiers = ts.canHaveModifiers(statement) ? ts.getModifiers(statement) ?? [] : [];
+    const modifiers = modifiersOf(ts, statement);
     const isExported = modifiers.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword);
     const isDefault = modifiers.some((modifier) => modifier.kind === ts.SyntaxKind.DefaultKeyword);
 

--- a/packages/actions/src/sync/static-ts.ts
+++ b/packages/actions/src/sync/static-ts.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import type TS from "typescript";
 import { resolveImportSource } from "./common.js";
+import { isSatisfiesExpressionNode } from "./ts-compat.js";
 
 /**
  * Shared static TypeScript-source machinery for the compiler-API extractors
@@ -295,7 +296,7 @@ export async function zodFromExpression(
     if (!resolved) return unrecognized(`schema reference "${expr.text}" could not be statically resolved`);
     return zodFromExpression(extraction, resolved.module, resolved.expr, depth + 1);
   }
-  if (ts.isParenthesizedExpression(expr) || ts.isAsExpression(expr) || ts.isSatisfiesExpression(expr)) {
+  if (ts.isParenthesizedExpression(expr) || ts.isAsExpression(expr) || isSatisfiesExpressionNode(ts, expr)) {
     return zodFromExpression(extraction, module, expr.expression, depth + 1);
   }
   if (!ts.isCallExpression(expr)) return unrecognized("schema expression is not a zod call");

--- a/packages/actions/src/sync/trpc.ts
+++ b/packages/actions/src/sync/trpc.ts
@@ -25,6 +25,7 @@ import {
   type FileModule,
   type StaticExtraction,
 } from "./static-ts.js";
+import { isSatisfiesExpressionNode } from "./ts-compat.js";
 
 /**
  * Static tRPC extraction (04 §1, additive within vendo/tools@1).
@@ -120,7 +121,7 @@ async function evaluateRouterExpression(
     if (!resolved) return null;
     return evaluateRouterExpression(extraction, resolved.module, resolved.expr, depth + 1, contextPath);
   }
-  if (ts.isParenthesizedExpression(expr) || ts.isAsExpression(expr) || ts.isSatisfiesExpression(expr)) {
+  if (ts.isParenthesizedExpression(expr) || ts.isAsExpression(expr) || isSatisfiesExpressionNode(ts, expr)) {
     return evaluateRouterExpression(extraction, module, expr.expression, depth + 1, contextPath);
   }
   if (!ts.isCallExpression(expr)) return null;

--- a/packages/actions/src/sync/ts-compat.test.ts
+++ b/packages/actions/src/sync/ts-compat.test.ts
@@ -62,6 +62,14 @@ describe("modifiersOf", () => {
     expect(modifiersOf(realTs, statement)).toEqual([]);
     expect(modifiersOf(legacyTs(), statement)).toEqual([]);
   });
+
+  it("reads modifiers from a real TypeScript 4.7 compiler through the legacy path", () => {
+    const oldTs = createRequire(import.meta.url)("typescript47") as unknown as Ts;
+    const sf = oldTs.createSourceFile("probe.ts", "export default async function run() {}", oldTs.ScriptTarget.Latest, true);
+    const kinds = modifiersOf(oldTs, sf.statements[0]!).map((modifier) => modifier.kind);
+    expect(kinds).toContain(oldTs.SyntaxKind.ExportKeyword);
+    expect(kinds).toContain(oldTs.SyntaxKind.DefaultKeyword);
+  });
 });
 
 describe("isSatisfiesExpressionNode", () => {
@@ -79,10 +87,14 @@ describe("isSatisfiesExpressionNode", () => {
   });
 });
 
-describe("extraction against a pre-4.8 host TypeScript", () => {
-  it("extracts server actions without crashing when the host compiler lacks getModifiers", async () => {
+describe("extraction against a real TypeScript 4.7 host", () => {
+  it("extracts server actions with the genuine 4.7 compiler, which lacks the 4.8/4.9 APIs", async () => {
     const root = await temporaryHost();
-    const workspaceTs = createRequire(import.meta.url).resolve("typescript");
+    const oldTs = createRequire(import.meta.url).resolve("typescript47");
+    const loaded = createRequire(import.meta.url)("typescript47") as { version: string; getModifiers?: unknown };
+    expect(loaded.version).toBe("4.7.4");
+    expect(loaded.getModifiers).toBeUndefined();
+
     await writeFile(root, "package.json", JSON.stringify({
       name: "old-ts-host",
       dependencies: { next: "16.0.0", typescript: "4.7.4" },
@@ -92,16 +104,7 @@ describe("extraction against a pre-4.8 host TypeScript", () => {
       version: "4.7.4",
       main: "index.js",
     }));
-    await writeFile(root, "node_modules/typescript/index.js", `
-const real = require(${JSON.stringify(workspaceTs)});
-module.exports = {
-  ...real,
-  version: "4.7.4",
-  canHaveModifiers: undefined,
-  getModifiers: undefined,
-  isSatisfiesExpression: undefined,
-};
-`);
+    await writeFile(root, "node_modules/typescript/index.js", `module.exports = require(${JSON.stringify(oldTs)});\n`);
     await writeFile(root, "src/actions/tokens.ts", `
 "use server";
 

--- a/packages/actions/src/sync/ts-compat.test.ts
+++ b/packages/actions/src/sync/ts-compat.test.ts
@@ -1,0 +1,118 @@
+import { createRequire } from "node:module";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import realTs from "typescript";
+import { extractServerActions } from "./server-actions.js";
+import type { Ts } from "./static-ts.js";
+import { isSatisfiesExpressionNode, modifiersOf } from "./ts-compat.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })));
+});
+
+async function temporaryHost(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "vendo-actions-tscompat-"));
+  temporaryDirectories.push(root);
+  return root;
+}
+
+async function writeFile(root: string, relative: string, source: string): Promise<void> {
+  const file = path.join(root, relative);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, source, "utf8");
+}
+
+/** The workspace compiler with the TS 4.8/4.9 APIs removed, approximating a
+ * pre-4.8 host TypeScript at the API-surface level. */
+function legacyTs(): Ts {
+  return {
+    ...realTs,
+    canHaveModifiers: undefined,
+    getModifiers: undefined,
+    isSatisfiesExpression: undefined,
+  } as unknown as Ts;
+}
+
+function firstStatement(source: string): realTs.Statement {
+  const sf = realTs.createSourceFile("probe.ts", source, realTs.ScriptTarget.Latest, true);
+  return sf.statements[0]!;
+}
+
+describe("modifiersOf", () => {
+  it("reads modifiers through the modern API when available", () => {
+    const statement = firstStatement("export default async function run() {}");
+    const kinds = modifiersOf(realTs, statement).map((modifier) => modifier.kind);
+    expect(kinds).toContain(realTs.SyntaxKind.ExportKeyword);
+    expect(kinds).toContain(realTs.SyntaxKind.DefaultKeyword);
+  });
+
+  it("falls back to the legacy modifiers property when the API is missing", () => {
+    const statement = firstStatement("export default async function run() {}");
+    const kinds = modifiersOf(legacyTs(), statement).map((modifier) => modifier.kind);
+    expect(kinds).toContain(realTs.SyntaxKind.ExportKeyword);
+    expect(kinds).toContain(realTs.SyntaxKind.DefaultKeyword);
+  });
+
+  it("returns an empty list for nodes without modifiers on both paths", () => {
+    const statement = firstStatement("const value = 1;");
+    expect(modifiersOf(realTs, statement)).toEqual([]);
+    expect(modifiersOf(legacyTs(), statement)).toEqual([]);
+  });
+});
+
+describe("isSatisfiesExpressionNode", () => {
+  it("detects satisfies expressions through the modern API", () => {
+    const statement = firstStatement("const value = {} satisfies object;");
+    const declaration = (statement as realTs.VariableStatement).declarationList.declarations[0]!;
+    expect(isSatisfiesExpressionNode(realTs, declaration.initializer!)).toBe(true);
+  });
+
+  it("reports false for other nodes and for compilers without the API", () => {
+    const statement = firstStatement("const value = {} satisfies object;");
+    const declaration = (statement as realTs.VariableStatement).declarationList.declarations[0]!;
+    expect(isSatisfiesExpressionNode(realTs, declaration)).toBe(false);
+    expect(isSatisfiesExpressionNode(legacyTs(), declaration.initializer!)).toBe(false);
+  });
+});
+
+describe("extraction against a pre-4.8 host TypeScript", () => {
+  it("extracts server actions without crashing when the host compiler lacks getModifiers", async () => {
+    const root = await temporaryHost();
+    const workspaceTs = createRequire(import.meta.url).resolve("typescript");
+    await writeFile(root, "package.json", JSON.stringify({
+      name: "old-ts-host",
+      dependencies: { next: "16.0.0", typescript: "4.7.4" },
+    }));
+    await writeFile(root, "node_modules/typescript/package.json", JSON.stringify({
+      name: "typescript",
+      version: "4.7.4",
+      main: "index.js",
+    }));
+    await writeFile(root, "node_modules/typescript/index.js", `
+const real = require(${JSON.stringify(workspaceTs)});
+module.exports = {
+  ...real,
+  version: "4.7.4",
+  canHaveModifiers: undefined,
+  getModifiers: undefined,
+  isSatisfiesExpression: undefined,
+};
+`);
+    await writeFile(root, "src/actions/tokens.ts", `
+"use server";
+
+export async function createToken(name: string) {
+  return { name };
+}
+`);
+
+    const result = await extractServerActions(root);
+    const names = result.tools.map((tool) => tool.name);
+    expect(names.some((name) => name.includes("create_token"))).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+});

--- a/packages/actions/src/sync/ts-compat.ts
+++ b/packages/actions/src/sync/ts-compat.ts
@@ -1,0 +1,33 @@
+import type TS from "typescript";
+
+type Ts = typeof TS;
+
+/**
+ * Version-tolerant accessors for TypeScript compiler APIs that the host may
+ * not have: extraction loads the host's own TypeScript (see `loadTypescript`),
+ * so APIs newer than the host's version must be probed before use (#551).
+ * Mirrors the `decoratorsOf` fallback in graphql.ts.
+ */
+
+/** Modifiers of `node`, via TS 4.8 `canHaveModifiers`/`getModifiers` when
+ * available, else the legacy `node.modifiers` property. */
+export function modifiersOf(ts: Ts, node: TS.Node): readonly TS.Modifier[] {
+  const modern = ts as unknown as {
+    canHaveModifiers?: (node: TS.Node) => boolean;
+    getModifiers?: (node: TS.Node) => readonly TS.Modifier[] | undefined;
+  };
+  if (modern.canHaveModifiers && modern.getModifiers) {
+    return modern.canHaveModifiers(node) ? modern.getModifiers(node) ?? [] : [];
+  }
+  const legacy = (node as { modifiers?: readonly TS.Modifier[] }).modifiers;
+  return legacy ?? [];
+}
+
+/** `ts.isSatisfiesExpression` appeared in TS 4.9. Hosts older than that
+ * cannot parse `satisfies` at all, so a missing API means `node` is not one. */
+export function isSatisfiesExpressionNode(ts: Ts, node: TS.Node): node is TS.SatisfiesExpression {
+  const modern = ts as unknown as {
+    isSatisfiesExpression?: (node: TS.Node) => node is TS.SatisfiesExpression;
+  };
+  return modern.isSatisfiesExpression ? modern.isSatisfiesExpression(node) : false;
+}

--- a/packages/vendo/src/cli/theme/font-stack.ts
+++ b/packages/vendo/src/cli/theme/font-stack.ts
@@ -95,9 +95,18 @@ function declarationOf(mod: BoundModule, node: TS.Node): TS.Declaration | undefi
   return symbol?.valueDeclaration ?? symbol?.declarations?.[0];
 }
 
+/** `ts.isSatisfiesExpression` appeared in TS 4.9; the compiler here is the
+ * host's own, so probe before use (#551). */
+function isSatisfiesExpressionNode(ts: typeof TS, node: TS.Node): node is TS.SatisfiesExpression {
+  const modern = ts as unknown as {
+    isSatisfiesExpression?: (node: TS.Node) => node is TS.SatisfiesExpression;
+  };
+  return modern.isSatisfiesExpression ? modern.isSatisfiesExpression(node) : false;
+}
+
 function unwrapExpression(ts: typeof TS, expression: TS.Expression): TS.Expression {
   let current = expression;
-  while (ts.isParenthesizedExpression(current) || ts.isAsExpression(current) || ts.isSatisfiesExpression(current)) {
+  while (ts.isParenthesizedExpression(current) || ts.isAsExpression(current) || isSatisfiesExpressionNode(ts, current)) {
     current = current.expression;
   }
   return current;

--- a/packages/vendo/src/cli/theme/font-stack.ts
+++ b/packages/vendo/src/cli/theme/font-stack.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import { isSatisfiesExpressionNode } from "@vendoai/actions/sync";
 import type TS from "typescript";
 
 /**
@@ -93,15 +94,6 @@ function boundModule(source: string, fileName: string): BoundModule | null {
 function declarationOf(mod: BoundModule, node: TS.Node): TS.Declaration | undefined {
   const symbol = mod.checker.getSymbolAtLocation(node);
   return symbol?.valueDeclaration ?? symbol?.declarations?.[0];
-}
-
-/** `ts.isSatisfiesExpression` appeared in TS 4.9; the compiler here is the
- * host's own, so probe before use (#551). */
-function isSatisfiesExpressionNode(ts: typeof TS, node: TS.Node): node is TS.SatisfiesExpression {
-  const modern = ts as unknown as {
-    isSatisfiesExpression?: (node: TS.Node) => node is TS.SatisfiesExpression;
-  };
-  return modern.isSatisfiesExpression ? modern.isSatisfiesExpression(node) : false;
 }
 
 function unwrapExpression(ts: typeof TS, expression: TS.Expression): TS.Expression {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ importers:
         version: 1.24.0(react@19.2.4)
       next:
         specifier: '>=16.2.11'
-        version: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -191,7 +191,7 @@ importers:
         version: 1.24.0(react@19.2.4)
       next:
         specifier: '>=16.2.11'
-        version: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: '>=5.0.0-beta.32'
         version: 5.0.0-beta.32(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
@@ -297,7 +297,7 @@ importers:
         version: 1.24.0(react@19.2.4)
       next:
         specifier: '>=16.2.11'
-        version: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -535,7 +535,7 @@ importers:
         version: 6.0.28(zod@3.25.76)
       next:
         specifier: '>=16.2.11'
-        version: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -749,7 +749,7 @@ importers:
     dependencies:
       next:
         specifier: '>=16.2.11'
-        version: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@22.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@22.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -986,6 +986,9 @@ importers:
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
+      typescript47:
+        specifier: npm:typescript@4.7.4
+        version: typescript@4.7.4
       vitest:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)
@@ -7742,6 +7745,11 @@ packages:
     peerDependencies:
       typescript: ^4.7.2 || ^5 || ^6
 
+  typescript@4.7.4:
+    resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -11923,7 +11931,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.9
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
@@ -11966,7 +11974,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11981,11 +11989,36 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.5(jiti@2.7.0)
+      get-tsconfig: 4.14.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.17
+      unrs-resolver: 1.12.2
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.5(jiti@2.7.0)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
@@ -12003,7 +12036,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -12032,7 +12065,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -13707,33 +13740,6 @@ snapshots:
       next: 16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
-  next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
-    dependencies:
-      '@next/env': 16.2.11
-      '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.43
-      caniuse-lite: 1.0.30001805
-      postcss: 8.5.22
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.4)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.11
-      '@next/swc-darwin-x64': 16.2.11
-      '@next/swc-linux-arm64-gnu': 16.2.11
-      '@next/swc-linux-arm64-musl': 16.2.11
-      '@next/swc-linux-x64-gnu': 16.2.11
-      '@next/swc-linux-x64-musl': 16.2.11
-      '@next/swc-win32-arm64-msvc': 16.2.11
-      '@next/swc-win32-x64-msvc': 16.2.11
-      '@opentelemetry/api': 1.9.1
-      '@playwright/test': 1.61.1
-      sharp: 0.35.3(@types/node@20.19.43)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@types/node'
-      - babel-plugin-macros
-
   next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@22.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.11
@@ -13770,7 +13776,7 @@ snapshots:
       postcss: 8.5.22
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.4)
+      styled-jsx: 5.1.6(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.11
       '@next/swc-darwin-x64': 16.2.11
@@ -13783,6 +13789,33 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.61.1
       sharp: 0.35.3(@types/node@20.19.43)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/node'
+      - babel-plugin-macros
+
+  next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@22.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@next/env': 16.2.11
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.43
+      caniuse-lite: 1.0.30001805
+      postcss: 8.5.22
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      styled-jsx: 5.1.6(react@19.2.4)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.11
+      '@next/swc-darwin-x64': 16.2.11
+      '@next/swc-linux-arm64-gnu': 16.2.11
+      '@next/swc-linux-arm64-musl': 16.2.11
+      '@next/swc-linux-x64-gnu': 16.2.11
+      '@next/swc-linux-x64-musl': 16.2.11
+      '@next/swc-win32-arm64-msvc': 16.2.11
+      '@next/swc-win32-x64-msvc': 16.2.11
+      '@opentelemetry/api': 1.9.1
+      '@playwright/test': 1.61.1
+      sharp: 0.35.3(@types/node@22.20.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/node'
@@ -14978,6 +15011,11 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.7
 
+  styled-jsx@5.1.6(react@19.2.4):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.4
+
   styled-jsx@5.1.6(react@19.2.7):
     dependencies:
       client-only: 0.0.1
@@ -15235,6 +15273,8 @@ snapshots:
   typescript-paths@1.5.2(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  typescript@4.7.4: {}
 
   typescript@5.9.3: {}
 


### PR DESCRIPTION
## What

Static extraction now probes the TS 4.8 modifier APIs (`canHaveModifiers` and `getModifiers`) and the TS 4.9 `ts.isSatisfiesExpression` before use, falling back to the legacy node properties. The probes live in a small `ts-compat` module that mirrors the existing `decoratorsOf` pattern in `graphql.ts`. All twelve unguarded call sites across the sync extractors and the theme font scan now go through it.

## Why

Extraction loads the host repo's own TypeScript (`loadTypescript` resolves the host first), so `vendo init` crashed with `TypeError: ts.getModifiers is not a function` on hosts whose TypeScript predates 4.8, as reported for the taxonomy corpus run in #551. Feature detection keeps the compiler out of our bundles, in line with the portability gate, and matches the direction suggested in the issue.

Note: the TS 5.0 only `resolveModuleNameLiterals` compiler host hook silently does nothing on older hosts. It does not crash, so it is left untouched here.

## Verification

- [x] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green
- [ ] Screenshots attached (if UI-affecting)

New tests in `ts-compat.test.ts` cover both helper paths (modern API and legacy fallback) plus an end to end case: a fabricated host with a simulated TypeScript 4.7 in `node_modules` extracts its server actions with zero warnings. Reverting the call site changes makes that test reproduce the exact #551 TypeError, so it guards the real path. Package coverage 91.85 percent with the helper at 100.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Feature-detect TypeScript 4.8 modifier APIs and 4.9 satisfies checks in static extraction, falling back to legacy node properties. Prevents `vendo init` crashes on hosts with TypeScript <4.8 (fixes #551).

- **Bug Fixes**
  - Added `ts-compat` helpers: `modifiersOf` and `isSatisfiesExpressionNode` with safe fallbacks.
  - Switched all extractor paths and the CLI theme font scan to use these helpers; exposed via `@vendoai/actions/sync`.
  - Added tests for modern and legacy paths, plus an end-to-end run against a real TS 4.7 compiler via a test-only `typescript47` alias.

<sup>Written for commit bc8564bb9d1304cad21636c89e1dd3198fd4645d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

