### PR TITLE
docs(pricing spec): Free runs 100→300

### DIFF
--- a/docs/superpowers/specs/2026-07-24-usage-and-pricing-design.md
+++ b/docs/superpowers/specs/2026-07-24-usage-and-pricing-design.md
@@ -32,12 +32,12 @@ Free $0 / Pro $49/mo / Teams $499/mo / Enterprise custom. The Pro→Teams line i
 | **Sandbox minutes** | 200, hard cap | 2,000 incl., then $0.01/min | 10,000 incl., then $0.01/min | Committed |
 | **Storage — files & app data (GB-mo)** | 1 GB, hard cap | 20 GB incl., then $0.25/GB-mo | 100 GB incl., then $0.25/GB-mo | Committed |
 | **Knowledge base (GB-mo)** | 1 GB, hard cap | 10 GB incl., then $0.60/GB-mo | 50 GB incl., then $0.60/GB-mo | Committed |
-| **Automation runs** | 100/mo, hard cap | 3,000/mo incl., then $3/1k | 30,000/mo incl., then $3/1k | Committed |
+| **Automation runs** | 300/mo, hard cap | 3,000/mo incl., then $3/1k | 30,000/mo incl., then $3/1k | Committed |
 | **Active connections** | 20, hard cap | 150 incl., then ~$0.30/conn-mo | 2,000 incl., then ~$0.30/conn-mo | Committed |
 | **Threads, memory, audit logs** | Free — 7-day retention | Free — 90-day retention | Free — unlimited threads; 1-yr audit retention | Free — custom / compliance-grade retention |
 | **Support** | Community | Email | Priority | Named SE, private channel, SLA |
 
-All allowance and overage numbers are structural placeholders **pending COGS validation against real usage data** before the pricing page ships. The structure (which meters exist, hard-stop vs overage, ratios between tiers) is the locked part.
+All allowance and overage numbers are structural placeholders **pending COGS validation against real usage data** before the pricing page ships. The structure (which meters exist, hard-stop vs overage, ratios between tiers) is the locked part. Free runs raised 100→300 on 2026-07-26 from live evidence: a real evaluation sprint burns ~100/day; 300 holds three sprint days while staying under half of one hourly job.
 
 ## 3. The six meters
 


### PR DESCRIPTION
Live-evidence recalibration: a genuine evaluation sprint (luminovo) burns ~100 runs/day; 300 covers three sprint days and remains under half of one hourly job (720/mo), keeping the production boundary bright. Implementation ships in vendo-web.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised Free plan automation runs in the pricing spec from 100/mo to 300/mo to better match real evaluation usage. Based on live evidence (~100 runs/day), this covers three sprint days while staying under half of an hourly job.

<sup>Written for commit 51eb0ef90ad3bed48c4b75643c2fd433d00b3e28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

