### PR TITLE
fix(guard): restore policyFileSchema/policyRuleSchema public exports

### DIFF
--- a/packages/guard/src/index.ts
+++ b/packages/guard/src/index.ts
@@ -7,6 +7,10 @@ export { vendoAutoJudge } from "./judge.js";
 // a duplicate rule) can derive them from the one place presets are defined,
 // instead of drifting out of sync with a copy.
 export { resolvePolicyConfig } from "./policy.js";
+// Zod schemas for a .vendo/policy.json file and its rules. Public since 0.3.0
+// (hosts validating a policy file before handing it to the guard); 0.4.x
+// dropped them from the barrel by accident, so restore them here.
+export { policyFileSchema, policyRuleSchema } from "./types.js";
 export type {
   Judge,
   PolicyConfig,


### PR DESCRIPTION
0.3.0 exported `policyFileSchema`/`policyRuleSchema` from the guard barrel; a 0.4.x refactor dropped them while the schemas stayed defined+used internally (types.ts). A consumer validating a `.vendo/policy.json` before handing it to the guard (and the vendo-web console) still imports them, so the drop is a silent public-API regression. One-line restore. Guard build/typecheck/lint green; exports verified resolvable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore public exports of `policyFileSchema` and `policyRuleSchema` from the `guard` barrel to fix an accidental 0.4.x regression. Consumers can import these schemas again to validate `.vendo/policy.json` before invoking the guard.

<sup>Written for commit 5c2e19f13fa4d2c6a806539d084179cb0840df88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

