### PR TITLE
apps: prompt-cache the generation prompt's stable prefix (rules + catalog + semantics)

### DIFF
--- a/packages/apps/src/engine.test.ts
+++ b/packages/apps/src/engine.test.ts
@@ -191,6 +191,85 @@ describe("generation engine through createApps", () => {
     expect(prompts.at(-1)).toContain("No emojis, ever");
   });
 
+  describe("Anthropic prompt-cache breakpoint on the generation prompt", () => {
+    // Back-to-back generations (a user iterating on a design) re-pay full
+    // input price for the identical stable prefix (design rules + component
+    // catalog + field semantics) unless it is marked cacheable. The engine
+    // marks the END of the stable prefix — the system message — with the
+    // ephemeral breakpoint, exactly like the chat agent, so the variable
+    // tail (the user's request / the app being edited) stays OUT of the
+    // cached prefix.
+    const ephemeral = (message: ScriptedModelCall["prompt"][number] | undefined): unknown =>
+      (message?.providerOptions as { anthropic?: { cacheControl?: unknown } } | undefined)?.anthropic?.cacheControl;
+    const systemText = (call: ScriptedModelCall): string => {
+      const system = call.prompt.find((message) => message.role === "system");
+      return typeof system?.content === "string" ? system.content : "";
+    };
+    const userText = (call: ScriptedModelCall): string => call.prompt
+      .filter((message) => message.role === "user")
+      .map((message) => typeof message.content === "string"
+        ? message.content
+        : message.content.map((part) => part.text ?? "").join(""))
+      .join("\n");
+
+    it("marks the create system prefix cacheable, and never the variable user prompt", async () => {
+      const calls: ScriptedModelCall[] = [];
+      const runtime = createApps({
+        store: memoryStore(),
+        guard: guardFixture(),
+        tools,
+        catalog,
+        model: scriptedLanguageModel((call) => { calls.push(call); return validCreate(); }),
+      });
+
+      const app = await runtime.create({ prompt: "Build a revenue dashboard" }, ctx);
+      // Off-Anthropic no-op: the scripted (non-Anthropic) model ignores the
+      // breakpoint entirely and generation still returns a valid document.
+      expect(app.tree).toBeDefined();
+
+      const call = calls[0];
+      const system = call?.prompt.find((message) => message.role === "system");
+      const user = call?.prompt.find((message) => message.role === "user");
+      // The stable prefix (design rules + catalog + semantics) really lives in
+      // the system message, and it carries the breakpoint.
+      expect(systemText(call!)).toContain("HOST DESIGN RULES");
+      expect(ephemeral(system)).toEqual({ type: "ephemeral" });
+      // The variable tail (the user request) is NOT inside the cached prefix.
+      expect(userText(call!)).toContain("Build a revenue dashboard");
+      expect(ephemeral(user)).toBeUndefined();
+    });
+
+    it("marks the edit system prefix cacheable, and never the variable edit instruction / app document", async () => {
+      const store = memoryStore();
+      await putApp(store, generatedTreeApp());
+      const calls: ScriptedModelCall[] = [];
+      const runtime = createApps({
+        store,
+        guard: guardFixture(),
+        tools,
+        catalog,
+        model: scriptedLanguageModel((call) => {
+          calls.push(call);
+          return '<Edit><SetName name="Renamed"/></Edit>';
+        }),
+      });
+
+      const result = await runtime.edit("app_generated_edit", "rename it to Renamed", ctx);
+      expect(result.failure).toBeUndefined();
+
+      const call = calls[0];
+      const system = call?.prompt.find((message) => message.role === "system");
+      const user = call?.prompt.find((message) => message.role === "user");
+      // The edit contract (stable prefix) carries the breakpoint.
+      expect(systemText(call!)).toContain("EDIT DIALECT");
+      expect(ephemeral(system)).toEqual({ type: "ephemeral" });
+      // The instruction and the app document being edited are the variable
+      // tail — outside the cached prefix.
+      expect(userText(call!)).toContain("rename it to Renamed");
+      expect(ephemeral(user)).toBeUndefined();
+    });
+  });
+
   describe("data-sighted verification pass (pipeline.endPass at the runtime seam)", () => {
     const appWire = '<App name="Client board"><Query id="metric" tool="host_metric"/><Stack><Stat label="Total clients" value={metric.headline}/></Stack></App>';
     const metricTools: ToolRegistry = {

--- a/packages/apps/src/generation/engine.ts
+++ b/packages/apps/src/generation/engine.ts
@@ -23,7 +23,7 @@ import {
   type VendoTheme,
   type WireCompileResult,
 } from "@vendoai/core";
-import type { LanguageModel } from "ai";
+import type { LanguageModel, ModelMessage } from "ai";
 import { hasDefaultExport, pinComponentName, pinForkSource, type PinBaseline } from "../pins.js";
 import { createContract } from "./contracts/create.js";
 import { editContract } from "./contracts/edit.js";
@@ -270,6 +270,25 @@ const extractWire = (text: string): string => {
   return close === -1 ? text.slice(start) : text.slice(start, close + closeTag.length);
 };
 
+// Anthropic prompt-caching breakpoint (mirrors packages/agent/src/agent.ts's
+// CACHE_BREAKPOINT). providerOptions.anthropic is ignored by every other
+// provider and by the test mocks, so marking the breakpoint degrades to a
+// no-op off-Anthropic.
+const CACHE_BREAKPOINT = { anthropic: { cacheControl: { type: "ephemeral" } } } as const;
+
+/** The generation prompt as a two-message model prompt with the stable prefix
+ *  (the contract: role, tree/edit dialect, component catalog, host tool +
+ *  field semantics, design rules) marked cacheable. The system message is the
+ *  END of the stable prefix — identical across back-to-back generations for a
+ *  deployment — so Anthropic re-reads it from cache instead of re-billing it.
+ *  The user message is the per-request variable tail (the request / the app
+ *  being edited / repair issues) and is deliberately left OUT of the cached
+ *  prefix. WHAT the model sees is unchanged — only the prefix is marked. */
+const cacheableGenerationMessages = (system: string, prompt: string): ModelMessage[] => [
+  { role: "system", content: system, providerOptions: CACHE_BREAKPOINT },
+  { role: "user", content: prompt },
+];
+
 /** Stream the wire, compiling each accumulated prefix (throttled) into a
  *  valid-while-partial tree for the onPartial seam. */
 const streamWire = async (
@@ -335,8 +354,7 @@ const streamWire = async (
     let streamError: unknown;
     const result = streamText({
       model: deps.model,
-      system,
-      prompt,
+      messages: cacheableGenerationMessages(system, prompt),
       temperature: 0,
       maxRetries: 0,
       onError: ({ error }) => { streamError = error; },
@@ -418,8 +436,7 @@ const generateWireText = async (
     const { streamText } = await import("ai");
     const result = streamText({
       model: deps.model,
-      system,
-      prompt,
+      messages: cacheableGenerationMessages(system, prompt),
       temperature: 0,
       maxRetries: 0,
     });

--- a/packages/apps/src/testing/scripted-model.ts
+++ b/packages/apps/src/testing/scripted-model.ts
@@ -4,6 +4,10 @@ export interface ScriptedModelCall {
   prompt: Array<{
     role: string;
     content: string | Array<{ type?: string; text?: string }>;
+    /** Per-message provider hints (e.g. the Anthropic ephemeral cache
+     *  breakpoint the generation prompt sets on its stable prefix). Present in
+     *  the normalized LanguageModelV2 prompt so tests can assert on it. */
+    providerOptions?: Record<string, unknown>;
   }>;
   /** W4 pipeline — the tool definitions the caller passed (strict tool-use
    *  calls), so tests can assert on the generated fix-space schema. */


### PR DESCRIPTION
The chat agent already caches its stable system-prompt prefix (agent.ts CACHE_BREAKPOINT); the apps GENERATION path did not — so a user iterating on a design re-paid full input-token price for the identical rules + component-catalog + field-semantics prefix on every create/edit. This marks that prefix cacheable.

## What
`streamWire` (create) and `generateWireText` (edit) now send `{messages:[system, user]}` instead of `{system, prompt}`, with an ephemeral Anthropic cacheControl breakpoint on the system message (the stable prefix) and none on the user message (the per-request variable tail). Mirrors agent.ts exactly.

## No behavior change
In ai@6.0.28, `{system, prompt}` and `{messages:[{system},{user}]}` normalize to the identical model prompt — same content, same order; the only added byte is the provider-agnostic cache marker. Generation output is provably unchanged (review confirmed via normalization + content-preserving tests + the full 117-test engine suite passing).

## Coverage
Cached: create paint/full/section lanes, parallel section writers, edit, island-repair — every path re-sending the large stable contract. Deliberately NOT cached (would never fire): verify passes (<4096-token Anthropic cache minimum) and repair strictToolCall (per-call tool schema renders before system → prefix never repeats).

## Off-Anthropic
providerOptions.anthropic is ignored by non-Anthropic providers + the scripted/dev mock — verified no-op.

## Tests / gates
+2 TDD tests (create + edit: breakpoint on system, none on user, generation still returns a valid doc); apps 677 passed / 18 skipped; vendo 1407; typecheck/lint/dependency-guard/portability-gate green; next-env zero-diff. Two-stage review: APPROVED (semantic equivalence the key verdict).

Note: cache efficacy is production-only (fires when the prefix ≥ Anthropic's per-tier minimum) — worth a one-time spot-check of usage.cache_read_input_tokens on a real Anthropic generation; no correctness impact if a lean deployment's prefix falls short (silent no-op).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches the stable system prefix in the apps generation prompt so back-to-back create/edit runs reuse Anthropic’s cached tokens. Reduces input token cost with no behavior change; non-Anthropic providers are unaffected.

- **New Features**
  - `streamWire` and `generateWireText` now send `messages: [system, user]` via `cacheableGenerationMessages`; the system carries `providerOptions.anthropic.cacheControl: { type: "ephemeral" }`, the user remains uncached. Mirrors the chat agent’s breakpoint and applies across create, edit, and island-repair; verification pass and strictToolCall remain uncached.
  - Added tests for create and edit to verify the breakpoint is on the system message only and outputs remain valid; `scripted-model` now exposes `providerOptions` in the normalized prompt for assertions.

<sup>Written for commit 78948d9d6a4045b9c4e7a4401212f12ce336ca20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

