### PR TITLE
demo-accounting: commit the Dockerfile the live demo-cadence service deploys with

### DIFF
--- a/apps/demo-accounting/Dockerfile
+++ b/apps/demo-accounting/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:22-bookworm-slim
+
+WORKDIR /app
+RUN npm install --global pnpm@11.10.0
+
+COPY . .
+RUN pnpm install --frozen-lockfile
+RUN pnpm exec turbo run build --filter=demo-accounting
+
+ENV NODE_ENV=production
+ENV HOSTNAME=0.0.0.0
+ENV PORT=3000
+
+EXPOSE 3000
+WORKDIR /app/apps/demo-accounting
+CMD ["pnpm", "start"]


### PR DESCRIPTION
The Cadence demo went live at demos.vendo.run/cadence (demo-live-readiness wave) deployed via an untracked local copy of demo-bank's Dockerfile with the filter switched to demo-accounting. This commits that exact file so a clean-checkout `railway up` reproduces the deploy. Verified identical to demo-bank's Dockerfile modulo the package name.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Dockerfile for `demo-accounting` so a clean checkout can reproduce the live demo-cadence Railway deploy. Mirrors the `demo-bank` Dockerfile with the build filter set to `demo-accounting`.

<sup>Written for commit 91bb0ff5fbc924db24b8aeb4ecdd758c41741b35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

