### PR TITLE
ui/kit: honour the host's display currency, and scale money by the ISO minor unit

### DIFF
--- a/packages/ui/src/context.tsx
+++ b/packages/ui/src/context.tsx
@@ -5,6 +5,7 @@ import { createContext, useContext, useMemo, type ComponentType, type ReactNode 
 import { createVendoClient, type VendoClient } from "./client.js";
 import type { VendoDiscoverability, VendoGreeting } from "./chrome/discoverability.js";
 import type { ToolMetaMap } from "./chrome/humanize.js";
+import { getKitIntl, setKitIntl, type KitIntl } from "./kit/format.js";
 import { defaultVendoTheme, resolveTheme } from "./theme.js";
 import type { VoiceDriver } from "./voice/driver.js";
 
@@ -43,6 +44,9 @@ export interface VendoContextValue {
   /** Host greeting-as-tutorial content (§6): intro + starter prompts, the
       `.vendo/greeting.json` shape. Absent = the built-in generic greeting. */
   greeting?: VendoGreeting;
+  /** The host's display currency + locale for every Kit formatter — what a
+      generated `format:"money"` column or `<Money cents/>` renders in. */
+  intl: KitIntl;
 }
 
 /** One connectable toolkit in the connect dock (ENG-225). */
@@ -94,9 +98,21 @@ export function VendoProvider(props: {
   connectors?: ConnectorOption[];
   discoverability?: VendoDiscoverability;
   greeting?: VendoGreeting;
+  /** Display currency + locale, e.g. `{ currency: "PKR" }` for a Pakistani
+      host. Omitted fields fall back to USD / en-US. */
+  intl?: Partial<KitIntl>;
   children: ReactNode;
 }): ReactNode {
-  const { client, components, theme, voice, transport, onPin, tools, connectors, discoverability, greeting, children } = props;
+  const { client, components, theme, voice, transport, onPin, tools, connectors, discoverability, greeting, intl, children } = props;
+  const currency = intl?.currency;
+  const locale = intl?.locale;
+  // Installed during RENDER, not in an effect: the formatters are called while
+  // children render (and on the server, where effects never run), so an effect
+  // would paint one pass of "$" before correcting itself.
+  const resolvedIntl = useMemo(() => {
+    setKitIntl({ ...(currency === undefined ? {} : { currency }), ...(locale === undefined ? {} : { locale }) });
+    return getKitIntl();
+  }, [currency, locale]);
   const value = useMemo<VendoContextValue>(
     () => ({
       client: client ?? createVendoClient({}),
@@ -109,8 +125,9 @@ export function VendoProvider(props: {
       connectors: connectors ?? "auto",
       discoverability: discoverability ?? "default",
       greeting,
+      intl: resolvedIntl,
     }),
-    [client, components, theme, voice, transport, onPin, tools, connectors, discoverability, greeting],
+    [client, components, theme, voice, transport, onPin, tools, connectors, discoverability, greeting, resolvedIntl],
   );
   return <VendoContext.Provider value={value}>{children}</VendoContext.Provider>;
 }
@@ -146,4 +163,10 @@ export function useVendoDiscoverability(): VendoDiscoverability {
 /** Host greeting-as-tutorial content, provider-optional (absent = built-in). */
 export function useVendoGreeting(): VendoGreeting | undefined {
   return useContext(VendoContext)?.greeting;
+}
+
+/** Display currency + locale, provider-optional (standalone surfaces get the
+    ambient defaults, which are USD/en-US until a provider sets them). */
+export function useVendoIntl(): KitIntl {
+  return useContext(VendoContext)?.intl ?? getKitIntl();
 }

--- a/packages/ui/src/kit/format.ts
+++ b/packages/ui/src/kit/format.ts
@@ -13,25 +13,117 @@ export function isRenderableNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
 }
 
+/** The host's display currency + locale for every Kit formatter. */
+export interface KitIntl {
+  /** ISO 4217 code, e.g. "PKR". */
+  currency: string;
+  /** BCP-47 locale, e.g. "en-PK". */
+  locale: string;
+}
+
+const FALLBACK_INTL: KitIntl = { currency: "USD", locale: "en-US" };
+
+/**
+ * Ambient, because the Kit's formatters are PURE FUNCTIONS, not components:
+ * `applyFormat` runs inside DataTable/CardList/Stat/every chart, and the jail
+ * hands islands a bare `fmt.money`. React context cannot reach those call
+ * sites, so a host that bills in rupees would otherwise be stuck with the
+ * hardcoded "$" no matter what its tool semantics declare.
+ *
+ * Set once per host (VendoProvider does it from its `intl` prop). One page =
+ * one display currency; a per-value currency still wins via the options
+ * argument, which is how a genuinely multi-currency row renders.
+ */
+let ambientIntl: KitIntl = FALLBACK_INTL;
+
+/** Does Intl accept this pair, or would every amount throw at render time? */
+function isUsableIntl(currency: string, locale: string): boolean {
+  try {
+    new Intl.NumberFormat(locale, { style: "currency", currency });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Install the ambient currency/locale. Unspecified fields RESET to the
+ * built-in default rather than merging with whatever ran before, so the same
+ * input always produces the same state regardless of call order.
+ *
+ * A currency/locale Intl rejects is dropped for the default: a typo in host
+ * config costs the "$" it would have fixed, never a screen of placeholders.
+ */
+export function setKitIntl(next: Partial<KitIntl> | undefined): void {
+  const candidate = {
+    currency: next?.currency ?? FALLBACK_INTL.currency,
+    locale: next?.locale ?? FALLBACK_INTL.locale,
+  };
+  ambientIntl = isUsableIntl(candidate.currency, candidate.locale) ? candidate : FALLBACK_INTL;
+}
+
+/** The currency/locale every formatter falls back to. */
+export function getKitIntl(): KitIntl {
+  return ambientIntl;
+}
+
 export interface MoneyOptions {
-  /** ISO 4217 code; defaults to USD. */
+  /** ISO 4217 code; defaults to the ambient currency (USD until set). */
   currency?: string;
-  /** BCP-47 locale; defaults to en-US. */
+  /** BCP-47 locale; defaults to the ambient locale (en-US until set). */
   locale?: string;
 }
 
 /**
- * Format an **integer number of cents** (the minor unit) as currency.
- * `123456` → `"$1,234.56"`. Zero-decimal currencies (JPY) are handled by Intl.
+ * ISO 4217 minor units, for the currencies that are not the 2-digit default.
+ *
+ * The divisor CANNOT come from `resolvedOptions().maximumFractionDigits`: that
+ * is a locale DISPLAY preference out of CLDR, and for some currencies it
+ * genuinely disagrees with the ISO minor unit. PKR is the case that bit us —
+ * Node's ICU reports 2 digits, Chrome's reports 0 — so the identical paisa
+ * amount formatted as "PKR 107.68" on the server and "PKR 10,768" in the
+ * browser. A static table is the only engine-independent answer.
+ */
+const MINOR_UNITS: Record<string, number> = {
+  BIF: 0, CLP: 0, DJF: 0, GNF: 0, ISK: 0, JPY: 0, KMF: 0, KRW: 0, PYG: 0,
+  RWF: 0, UGX: 0, VND: 0, VUV: 0, XAF: 0, XOF: 0, XPF: 0,
+  BHD: 3, IQD: 3, JOD: 3, KWD: 3, LYD: 3, OMR: 3, TND: 3,
+  CLF: 4,
+};
+
+/** How many minor units make one major unit of `currency`. */
+export function currencyMinorUnits(currency: string): number {
+  return MINOR_UNITS[currency.toUpperCase()] ?? 2;
+}
+
+/**
+ * Format an **integer number of minor units** as currency.
+ * `123456` → `"$1,234.56"`. Zero-decimal (JPY) and three-decimal (KWD)
+ * currencies scale by their own ISO minor unit.
  * Returns `null` for any non-finite input so `$NaN` can never ship.
  */
 export function formatMoney(cents: number, options: MoneyOptions = {}): string | null {
   if (!isRenderableNumber(cents)) return null;
-  const currency = options.currency ?? "USD";
-  const formatter = new Intl.NumberFormat(options.locale ?? "en-US", { style: "currency", currency });
-  // Divide by the currency's actual minor-unit exponent (2 for USD, 0 for JPY).
-  const fractionDigits = formatter.resolvedOptions().maximumFractionDigits ?? 2;
-  return formatter.format(cents / 10 ** fractionDigits);
+  const currency = options.currency ?? ambientIntl.currency;
+  const digits = currencyMinorUnits(currency);
+  let formatter: Intl.NumberFormat;
+  try {
+    // Pin the displayed digits to the ISO minor unit too: left to CLDR, a
+    // browser would round PKR 107.68 to "PKR 108" and silently drop the paisa
+    // the host actually stored.
+    formatter = new Intl.NumberFormat(options.locale ?? ambientIntl.locale, {
+      style: "currency",
+      currency,
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
+    });
+  } catch {
+    // A per-value `currency` is model-authored, so an invalid code is reachable
+    // from generation. Stay total like the rest of the tier: placeholder, not a
+    // thrown RangeError that takes the whole view down.
+    return null;
+  }
+  return formatter.format(cents / 10 ** digits);
 }
 
 export interface PercentOptions {
@@ -49,7 +141,7 @@ export interface PercentOptions {
 export function formatPercent(value: number, options: PercentOptions = {}): string | null {
   if (!isRenderableNumber(value)) return null;
   const ratio = options.whole ? value / 100 : value;
-  return new Intl.NumberFormat(options.locale ?? "en-US", {
+  return new Intl.NumberFormat(options.locale ?? ambientIntl.locale, {
     style: "percent",
     minimumFractionDigits: options.fractionDigits ?? 0,
     maximumFractionDigits: options.fractionDigits ?? 0,
@@ -66,7 +158,7 @@ export interface NumOptions {
 /** Format a plain number with thousands grouping. Returns `null` if non-finite. */
 export function formatNum(value: number, options: NumOptions = {}): string | null {
   if (!isRenderableNumber(value)) return null;
-  return new Intl.NumberFormat(options.locale ?? "en-US", {
+  return new Intl.NumberFormat(options.locale ?? ambientIntl.locale, {
     notation: options.notation ?? "standard",
     maximumFractionDigits: options.maximumFractionDigits,
     minimumFractionDigits: options.minimumFractionDigits,
@@ -109,7 +201,7 @@ export function formatDateTime(value: DateInput, options: DateTimeOptions = {}):
   const date = toDate(value);
   if (!date) return null;
   const mode = options.mode ?? "date";
-  const locale = options.locale ?? "en-US";
+  const locale = options.locale ?? ambientIntl.locale;
   // A date-only ISO string ("2026-03-14") is parsed as UTC midnight; formatting
   // it in a behind-UTC local zone would slip it to the previous calendar day.
   // Pin such values to UTC so the day the host meant is the day we show.

--- a/packages/ui/src/tree/jail/JailedComponent.tsx
+++ b/packages/ui/src/tree/jail/JailedComponent.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import { islandToolFallbackManifest, islandVendoActionNames, type Json, type ToolOutcome } from "@vendoai/core";
+import { useVendoIntl } from "../../context.js";
 import { ContainedNotice } from "../notice.js";
 import { FormingSkeleton } from "../forming-skeleton.js";
 import { JAIL_RUNTIME_SOURCE } from "./runtime-bundle.gen.js";
@@ -169,6 +170,9 @@ export function JailedComponent({
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [error, setError] = useState<string>();
   const srcDoc = useMemo(buildJailSrcdoc, []);
+  // Read from context rather than a prop: every caller already renders inside
+  // the provider, and the currency is not a per-island decision.
+  const intl = useVendoIntl();
   // The island's tool surface, resolved on the HOST side only. A stamped
   // manifest wins; an unstamped document falls back to scanning the source the
   // host itself holds. The legacy action channel additionally admits the
@@ -211,6 +215,7 @@ export function JailedComponent({
         ...(furnishing?.subSources === undefined ? {} : { subSources: furnishing.subSources }),
         ...(furnishing?.styles === undefined ? {} : { styles: furnishing.styles }),
         ...(themeVars === undefined ? {} : { themeVars }),
+        intl,
       }, "*");
     };
     const handleMessage = (event: MessageEvent) => {
@@ -315,7 +320,7 @@ export function JailedComponent({
       window.removeEventListener("message", handleMessage);
       iframe.removeEventListener("load", sendRender);
     };
-  }, [allowedActions, effectiveProps, furnishing, manifest, onAction, onStateSet, source, themeVars]);
+  }, [allowedActions, effectiveProps, furnishing, intl, manifest, onAction, onStateSet, source, themeVars]);
 
   if (error) {
     // Mid-stream, a crash is not a verdict: the island's source may still be

--- a/packages/ui/src/tree/jail/runtime-entry.tsx
+++ b/packages/ui/src/tree/jail/runtime-entry.tsx
@@ -11,6 +11,7 @@ import {
   Input, LineChart, Money, Num, Percent, Progress, Row, Select, Sparkline,
   Stack, Stat, Surface, Tabs, Text, Textarea,
   applyFormat, formatDateTime, formatMoney, formatNum, formatPercent,
+  setKitIntl, type KitIntl,
 } from "../../kit/index.js";
 
 declare global {
@@ -459,6 +460,11 @@ window.addEventListener("message", (event) => {
 
   if (message.kind === "render" && typeof message.source === "string") {
     applyThemeVars(message.themeVars);
+    // The jail is a separate realm with its own module instances, so the
+    // host's ambient currency does not cross the iframe boundary on its own —
+    // an island's <Money/> would print "$" while the tree around it prints
+    // the host's currency. Re-install it here, before anything renders.
+    setKitIntl(message.intl as Partial<KitIntl> | undefined);
     applyHostStyles(message.styles);
     void renderComponent(
       message.source,

--- a/packages/ui/test/kit-intl.test.tsx
+++ b/packages/ui/test/kit-intl.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+// Currency threading. `tools.json` semantics have carried `currency` since the
+// enrich pass, but every Kit formatter hardcoded USD — so a Pakistani payments
+// host rendered "$107.68" in a generated DataTable no matter what its host
+// tools declared. This suite pins that a host's declared currency reaches BOTH
+// the pure formatters (which is what `format:"money"` columns, Stat, CardList
+// and every chart call) and the Kit components, and that a per-value currency
+// still overrides it.
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  applyFormat,
+  currencyMinorUnits,
+  formatMoney,
+  getKitIntl,
+  setKitIntl,
+  DataTable,
+  Money,
+  Stat,
+} from "../src/kit/index.js";
+import { VendoProvider, createVendoClient } from "../src/index.js";
+
+// The ambient default is process-wide; leaving it set would leak into every
+// other suite in this file's worker.
+afterEach(() => setKitIntl(undefined));
+
+function renderInProvider(intl: { currency?: string; locale?: string } | undefined, node: React.ReactNode): string {
+  const client = createVendoClient({ baseUrl: "http://vendo.test/api/vendo" });
+  const { container } = render(
+    <VendoProvider client={client} intl={intl}>
+      {node}
+    </VendoProvider>,
+  );
+  return container.textContent ?? "";
+}
+
+describe("ambient Kit intl", () => {
+  it("defaults to USD so existing hosts are unchanged", () => {
+    expect(getKitIntl()).toEqual({ currency: "USD", locale: "en-US" });
+    expect(formatMoney(123456)).toBe("$1,234.56");
+  });
+
+  it("formats in the configured currency", () => {
+    setKitIntl({ currency: "PKR" });
+    // The regression itself: PKR 107.68, never $107.68.
+    expect(formatMoney(10768)).toContain("107.68");
+    expect(formatMoney(10768)).not.toContain("$");
+  });
+
+  it("reaches applyFormat — the path DataTable/Stat/charts actually call", () => {
+    setKitIntl({ currency: "PKR" });
+    expect(applyFormat(10768, "money")).not.toContain("$");
+  });
+
+  it("honours a zero-decimal currency's minor unit", () => {
+    setKitIntl({ currency: "JPY" });
+    // JPY has no minor unit, so 1234 is ¥1,234 — not ¥12.34.
+    expect(formatMoney(1234)).toContain("1,234");
+  });
+
+  it("scales by the ISO minor unit, not the locale's display preference", () => {
+    // The portability bug: Chrome's CLDR wants 0 decimals for PKR, Node's
+    // wants 2. Trusting that made the SAME paisa amount render "PKR 107.68"
+    // server-side and "PKR 10,768" in the browser.
+    expect(currencyMinorUnits("PKR")).toBe(2);
+    setKitIntl({ currency: "PKR" });
+    expect(formatMoney(10768)).toContain("107.68");
+    expect(formatMoney(10768)).not.toContain("10,768");
+  });
+
+  it("scales a three-decimal currency by 1000", () => {
+    expect(currencyMinorUnits("KWD")).toBe(3);
+    setKitIntl({ currency: "KWD" });
+    expect(formatMoney(10768)).toContain("10.768");
+  });
+
+  it("defaults an unlisted currency to two minor units", () => {
+    expect(currencyMinorUnits("gbp")).toBe(2);
+  });
+
+  it("lets a per-value currency override the ambient one", () => {
+    setKitIntl({ currency: "PKR" });
+    expect(formatMoney(10768, { currency: "USD" })).toBe("$107.68");
+  });
+
+  it("resets unspecified fields instead of merging with the previous call", () => {
+    setKitIntl({ currency: "PKR", locale: "en-PK" });
+    setKitIntl({ currency: "EUR" });
+    expect(getKitIntl()).toEqual({ currency: "EUR", locale: "en-US" });
+  });
+
+  it("drops a host-config currency Intl rejects, keeping amounts readable", () => {
+    setKitIntl({ currency: "not-a-currency" });
+    // A typo costs the currency, never the whole view.
+    expect(getKitIntl().currency).toBe("USD");
+    expect(formatMoney(10768)).toBe("$107.68");
+  });
+
+  it("stays total when generation authors an invalid per-value currency", () => {
+    // Reachable from the model, so it must placeholder rather than throw.
+    expect(() => formatMoney(10768, { currency: "not-a-currency" })).not.toThrow();
+    expect(formatMoney(10768, { currency: "not-a-currency" })).toBeNull();
+  });
+});
+
+describe("VendoProvider intl", () => {
+  it("installs the host currency before children render", () => {
+    const text = renderInProvider({ currency: "PKR" }, <Money cents={10768} />);
+    expect(text).toContain("107.68");
+    expect(text).not.toContain("$");
+  });
+
+  it("drives a generated format:\"money\" DataTable column", () => {
+    const text = renderInProvider(
+      { currency: "PKR" },
+      <DataTable
+        rows={[{ amount: 10768 }]}
+        columns={[{ key: "amount", label: "Amount", format: "money" }]}
+      />,
+    );
+    expect(text).toContain("107.68");
+    expect(text).not.toContain("$");
+  });
+
+  it("drives a format=\"money\" Stat", () => {
+    const text = renderInProvider({ currency: "PKR" }, <Stat label="Total" value={29792} format="money" />);
+    expect(text).not.toContain("$");
+  });
+
+  it("falls back to USD when the host declares nothing", () => {
+    expect(renderInProvider(undefined, <Money cents={123456} />)).toContain("$1,234.56");
+  });
+});


### PR DESCRIPTION
## What

Two fixes; the first hid the second.

**1. The host's currency never reached the renderer.** `tools.json` semantics have carried `currency` since the enrich pass, but `formatMoney` hardcoded a USD default — so a Pakistani payments host rendered `$107.68` in a generated `format:"money"` column. A host now declares it once:

```tsx
<VendoRoot components={...} theme={...} intl={{ currency: "PKR" }}>
```

**2. A latent portability bug the first fix exposed.** The cents divisor came from `resolvedOptions().maximumFractionDigits` — a CLDR **display preference**, not the ISO 4217 minor unit. For PKR the two genuinely disagree: **Node's ICU reports 2 digits, Chrome's reports 0**, so the identical paisa amount formatted `PKR 107.68` server-side and `PKR 10,768` in the browser. It never surfaced because USD (2) and JPY (0) happen to agree. The divisor now comes from a static ISO minor-unit table, and displayed digits are pinned to it — otherwise a browser rounds `PKR 107.68` to `PKR 108` and silently drops the paisa.

| File | Change |
| --- | --- |
| `kit/format.ts` | ambient `setKitIntl`/`getKitIntl`; every formatter reads it; `currencyMinorUnits` ISO table; `formatMoney` stays total on a bad code |
| `context.tsx` | `intl` prop on `VendoProvider` (so `VendoRoot` gets it for free), installed during render |
| `tree/jail/JailedComponent.tsx` | reads `intl` from context, ships it on the render message |
| `tree/jail/runtime-entry.tsx` | re-installs it inside the jail |

## Why

Why **ambient** rather than React context: the Kit's formatters are pure functions, not components. `applyFormat` runs inside DataTable, CardList, Stat and all four charts, and the jail hands islands a bare `fmt.money`. Context cannot reach those call sites, so a rupee host would be stuck with `$` whatever its tool semantics declared. One page = one display currency; a per-value `currency` still wins via the options argument.

Why installed **during render** and not in an effect: the formatters run while children render, and on the server where effects never run — an effect would paint one pass of `$` before correcting itself.

Why the jail needs its own install: it's a separate realm with separate module instances, so the host's ambient value doesn't cross the iframe boundary — an island's `<Money/>` would print `$` while the tree around it printed the host's currency.

**Default stays USD/en-US, so no existing host changes behaviour.**

## Verification

- [x] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green
- [x] Screenshots attached (if UI-affecting) — see the before/after values below; captured on the live `demos.vendo.run/numbers` demo

**15 new tests** (`packages/ui/test/kit-intl.test.tsx`): ambient path, `applyFormat` (the path tables/stats/charts actually call), a generated `format:"money"` DataTable column and Stat rendered through `VendoProvider`, per-value override, zero-decimal (JPY) and three-decimal (KWD) currencies, engine-independence of the divisor, unlisted-currency default, a bad host-config code falling back rather than blanking the view, and a model-authored invalid per-value code returning the placeholder instead of throwing.

Verified end-to-end on a live generated demo, in a real browser — a generated chargebacks table over paisa-denominated data:

| | Before | After |
| --- | --- | --- |
| generated DataTable | `$107.68`, `$131.43`, `$41.55` | `PKR 107.68`, `PKR 131.43`, `PKR 41.55` |
| generated Stat | `$999.67` | `PKR 999.67` |
| after fix 1 only (browser) | — | `PKR 10,768` ← the CLDR/ISO bug |

Values match the host's own product screens exactly, and a DOM scan of the generated view returns zero `$` amounts.

**Worth knowing for review:** the ISO minor-unit table is the kind of thing that rots. It's small and stable (ISO 4217 changes rarely), but a currency outside it silently gets 2 digits — correct for almost everything, wrong for the handful of 0- and 3-decimal ones, which are the ones listed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors the host’s display currency across the UI and formats money using ISO 4217 minor units. This fixes server/browser mismatches (e.g., PKR) while keeping USD/en-US as the default.

- Bug Fixes
  - Ambient intl: add `setKitIntl`/`getKitIntl`; `VendoProvider` exposes `intl` and installs it during render; the jail re-installs it for islands.
  - Money formatting: use a static ISO minor-unit table via `currencyMinorUnits`, pin fraction digits, and fall back safely on invalid codes; per-value `currency` still overrides.
  - Locale defaults: other formatters use the ambient locale; add 15 tests covering provider wiring, `applyFormat`, zero/three-decimal currencies, and error paths.

<sup>Written for commit 5057195a28e5d7f9c1ec8d4fb0b6d9840aea18f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

