### PR TITLE
apps: a storage fault costs the save, never the view

### DIFF
--- a/.changeset/create-view-survives-store-failure.md
+++ b/.changeset/create-view-survives-store-failure.md
@@ -1,0 +1,7 @@
+---
+"@vendoai/apps": patch
+---
+
+A create whose document generated cleanly no longer loses the whole turn when the store refuses to persist it. The final view part was emitted *after* `apps.put`, so a rejected write took the settling emit with it: every streamed card froze on whatever mid-stream payload it last held (a half-painted chart, an empty-state table) with no way to tell a frozen card from a genuinely empty one, the create tool answered the agent with a bare error, and the agent apologized and rebuilt the same app twice more — three cards for one prompt, none of them saved, nothing logged on the user path. Live on the deployed Maple demo, whose Cloud store was rejecting every `vendo_apps` write.
+
+Now the finished view is emitted before anything that can fail, a failed persist degrades the app to view-only instead of discarding it, and the failure is named in the operator log (`app not saved (<id>): the view rendered but the store rejected it`, plus `(NOT SAVED)` on the completion line) and handed to the agent as an `unsaved` note on an `ok` result — so it states the one true thing and stops, instead of apologizing for a view the user can see. Escalation is skipped for an unsaved app, since every rung writes through the same store. Separately, a query that resolves non-ok now warns once instead of silently rendering an empty card.

--- a/docs/verification/demo-live-readiness/donut-render-resilience/README.md
+++ b/docs/verification/demo-live-readiness/donut-render-resilience/README.md
@@ -1,0 +1,104 @@
+# donut-render-resilience — a storage fault costs the save, not the view
+
+## The defect
+
+On the deployed Maple, "Show my spending by category" generated cleanly —
+`gen pipeline full attempt=0 valid=true`, no server error, no watchdog, no
+smoke-render failure — and the user still got nothing usable:
+
+- a half-painted donut and two more cards frozen on "Building your view…"
+  (verified on the DOM attribute `data-state="building"`, not the label text —
+  both labels stay mounted for the crossfade, so the text alone proves
+  nothing),
+- one of them reading "No spending data",
+- the agent finishing with "I'm running into a temporary issue creating the
+  app view" plus a plain text table,
+- and none of the three apps in the store afterwards.
+
+## Root cause
+
+`runtime.create` sequenced the final `emit(finalTree)` **after**
+`apps.put`. The Cloud console was rejecting every `vendo_apps` write, so the
+put threw and took the emit with it:
+
+- each card kept the last mid-stream payload it had received — forever. The
+  donut that looked "rendered" was a frozen streaming paint; the "No spending
+  data" card was a frozen partial emitted before its query resolved. Neither
+  is a render bug: both are the *absence* of the settling emit.
+- `createAgentTools` caught the throw and answered `status: "error"`, so the
+  agent apologized and rebuilt the app twice more — three cards for one
+  prompt.
+- nothing was logged on the user path, which is why the server looked healthy.
+
+The store failure itself is a Cloud console defect, out of this repo's reach:
+its `vendo_apps` table is missing the `revision` column the store engine's
+write path requires (OSS added it in Wave 7, #427 `schema.ts:167`;
+`ensureSchema()` is explicit and the console's database never ran it). Every
+write answers `503 {"code":"unavailable","detail":"column \"revision\" of
+relation \"vendo_apps\" does not exist"}`. Reads are unaffected, which is why
+the demo looks alive until you ask it to build something.
+
+## The fix
+
+A storage fault now costs the user the SAVE, never the VIEW.
+
+1. The finished view is emitted **before** anything that can fail. The
+   document is generated, validated and data-resolved by that point.
+2. A failed persist is caught, degrades the app to view-only, and is reported:
+   `[vendo] app not saved (<id>): the view rendered but the store rejected it
+   — <reason>` plus `(NOT SAVED)` on the completion line. Escalation is
+   skipped (every rung writes through the same store).
+3. The create tool answers `ok` with an `unsaved` note instead of an error, so
+   the agent states the one true thing and does not rebuild. The note's
+   guidance says so explicitly.
+4. Separately: a query that resolves non-ok contributed no data and said
+   nothing, so an empty card was indistinguishable from a frozen one. Each
+   distinct unresolved query now warns once. Render behavior unchanged.
+
+## Proof
+
+Maple run against the **live Cloud store** — the same store still rejecting
+every app write — with this branch's build. Real browser, prompt typed
+verbatim.
+
+Operator log:
+
+```
+[vendo] gen pipeline full attempt=0 valid=true ms=7198
+[vendo] app not saved (app_615f58df-…): the view rendered but the store rejected it — Store request failed.
+[vendo] gen create complete app=app_615f58df-… total=45.5s (NOT SAVED)
+```
+
+Browser (DOM-asserted, not eyeballed):
+
+| | before | after |
+| --- | --- | --- |
+| cards | 3 | **1** |
+| card state | `building` ×3 | **`ready`** |
+| donut drawn | frozen partial | **8 svg paths, Total $5,058.38** |
+| apology text present | yes | **no** |
+
+The assistant's closing line: *"Housing is the dominant line item… The view
+could not be saved to your apps list, but it's rendered above."*
+
+Screenshot rides the PR (`docs/verification/README.md`: media is not
+committed).
+
+## Cents seam — checked, clean
+
+Traced every hop for the donut slices: the route returns integer cents
+(`505838` total), the catalog declares cents, `MapleSpendingDonut` passes them
+through unscaled (`Math.round` only), and `formatUSD` divides by 100 exactly
+once. Rendered `$5,058.38` = 505838/100. The dollars in the old fallback table
+were the correct presentation of cents, not a unit bug.
+
+## Still open, not this branch
+
+- The console's missing `revision` column — every Cloud-backed deployment
+  cannot persist apps until that migration runs (vendo-web + production
+  database; needs Yousef's sign-off).
+- The console's store also 503s on writes ≥64KB ("Connection terminated
+  unexpectedly"; ≤48KB fine, 6/6 deterministic) — independent of the column,
+  and it will bite apps carrying island source once the column lands.
+- Cadence additionally has an exhausted `ai_tokens` meter (10.5 of 10, resets
+  2026-08-21), so its generation refuses outright.

--- a/packages/apps/src/agent-tools.ts
+++ b/packages/apps/src/agent-tools.ts
@@ -202,13 +202,31 @@ export const createAgentTools = (
       if (call.tool === "vendo_apps_create") {
         const args = input(call.args, ["prompt"]);
         const stream = (call as VendoViewStreamingToolCall)[VENDO_VIEW_STREAM];
+        let unsaved: string | undefined;
         const app = await runtime.create({
           prompt: args.prompt as string,
+          onUnsaved: (reason) => { unsaved = reason; },
           ...(stream === undefined ? {} : {
             onView: (part) => stream({ id: vendoViewStreamId(part.appId), part }),
           }),
         }, ctx);
-        return { status: "ok", output: app as unknown as Json };
+        // View-only (the store refused the write): the app IS on the user's
+        // screen, so this is a success with a caveat, not a failure. Reporting
+        // it as an error made the agent apologize for a rendered view and
+        // rebuild it two more times — three cards, one prompt (live
+        // 2026-07-27). The note rides the document so the model can say the
+        // one true thing and stop.
+        return {
+          status: "ok",
+          output: (unsaved === undefined ? app : {
+            ...app,
+            unsaved: {
+              reason: unsaved,
+              savedToAppsList: false,
+              guidance: "The view is already rendered on the user's screen. Say in one short sentence that it could not be saved to their apps, and do NOT call vendo_apps_create again for this request.",
+            },
+          }) as unknown as Json,
+        };
       }
       if (call.tool === "vendo_apps_edit") {
         const args = input(call.args, ["appId", "instruction"]);

--- a/packages/apps/src/create-unsaved.test.ts
+++ b/packages/apps/src/create-unsaved.test.ts
@@ -1,0 +1,134 @@
+import type { RunContext, ToolRegistry, VendoViewPart } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createAgentTools } from "./agent-tools.js";
+import { createApps } from "./index.js";
+import { basicLanguageModel, guardFixture, memoryStore } from "./testing/index.js";
+
+/**
+ * Regression guard for the LIVE deployed-Maple failure (2026-07-27): the
+ * prompt generated cleanly (`attempt=0 valid=true`) and the user still got
+ * nothing usable — a half-painted donut and two more cards frozen on
+ * "Building your view…", then the agent apologizing with a plain text table.
+ *
+ * Cause: the final `emit(finalTree)` was sequenced AFTER `apps.put`, so a
+ * store that refused the write (the Cloud console was 503ing every
+ * `vendo_apps` write) skipped the emit entirely. Every card kept whatever
+ * mid-stream payload it last received, forever, and the create tool answered
+ * the agent with a bare error — which it "fixed" by building the app twice
+ * more. Three cards, one prompt, nothing saved, nothing logged on the user
+ * path.
+ *
+ * The contract now: a storage fault costs the user the SAVE, never the VIEW.
+ */
+
+const ctx: RunContext = {
+  principal: { kind: "user", subject: "user_ada" },
+  venue: "app",
+  presence: "present",
+  sessionId: "session_ada",
+};
+
+const tools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "error", error: { code: "not-found", message: "no tools" } }; },
+};
+
+/** A store whose vendo_apps writes fail the way the live console did. */
+const storeRefusingAppWrites = (): ReturnType<typeof memoryStore> => {
+  const store = memoryStore();
+  const records = store.records.bind(store);
+  return Object.assign(store, {
+    records(collection: string) {
+      const inner = records(collection);
+      if (collection !== "vendo_apps") return inner;
+      return Object.assign(Object.create(Object.getPrototypeOf(inner) ?? {}), inner, {
+        async put() {
+          throw Object.assign(new Error("Store request failed."), { code: "unavailable" });
+        },
+      });
+    },
+  }) as ReturnType<typeof memoryStore>;
+};
+
+const settledParts = (parts: VendoViewPart[]): VendoViewPart[] =>
+  parts.filter((part) => (part.payload as { streaming?: boolean }).streaming !== true);
+
+describe("a create the store refuses to persist", () => {
+  it("still puts the finished view on screen and resolves with the document", async () => {
+    const runtime = createApps({
+      store: storeRefusingAppWrites(),
+      guard: guardFixture(),
+      tools,
+      catalog: [],
+      model: basicLanguageModel(),
+    });
+    const parts: VendoViewPart[] = [];
+    const unsaved: string[] = [];
+
+    const app = await runtime.create({
+      prompt: "Show my spending by category",
+      onView: (part) => parts.push(part),
+      onUnsaved: (reason) => unsaved.push(reason),
+    }, ctx);
+
+    // The turn survives: the caller gets the real document, not a throw.
+    expect(app.id).toMatch(/^app_/);
+    // The card RESOLVES — a settled (non-streaming) part is what flips it out
+    // of "Building your view…". This is the assertion the live bug failed.
+    expect(settledParts(parts)).toHaveLength(1);
+    expect(settledParts(parts)[0]?.appId).toBe(app.id);
+    // And the caller is told, exactly once, that it is view-only.
+    expect(unsaved).toHaveLength(1);
+    expect(unsaved[0]).toContain("Store request failed.");
+  });
+
+  it("reads to the agent as success with an honest note — never a failure it would retry", async () => {
+    const runtime = createApps({
+      store: storeRefusingAppWrites(),
+      guard: guardFixture(),
+      tools,
+      catalog: [],
+      model: basicLanguageModel(),
+    });
+    const agentTools = createAgentTools(runtime, {
+      data: {} as never,
+      requireOwned: async () => { throw new Error("unused"); },
+    });
+
+    const outcome = await agentTools.execute(
+      { id: "call_1", tool: "vendo_apps_create", args: { prompt: "Show my spending by category" } },
+      ctx,
+    );
+
+    expect(outcome.status).toBe("ok");
+    const output = (outcome as { output: Record<string, unknown> }).output;
+    const note = output.unsaved as { savedToAppsList?: boolean; guidance?: string };
+    expect(note?.savedToAppsList).toBe(false);
+    // The guidance is what stops the three-cards-per-prompt loop.
+    expect(note?.guidance).toMatch(/do NOT call vendo_apps_create again/);
+  });
+
+  it("says nothing extra when the store is healthy (the note is failure-only)", async () => {
+    const runtime = createApps({
+      store: memoryStore(),
+      guard: guardFixture(),
+      tools,
+      catalog: [],
+      model: basicLanguageModel(),
+    });
+    const parts: VendoViewPart[] = [];
+    const unsaved: string[] = [];
+
+    const app = await runtime.create({
+      prompt: "Show my spending by category",
+      onView: (part) => parts.push(part),
+      onUnsaved: (reason) => unsaved.push(reason),
+    }, ctx);
+
+    expect(unsaved).toEqual([]);
+    expect(settledParts(parts)).toHaveLength(1);
+    // Healthy path still persists — the resilience arm must not have replaced
+    // the save with a shrug.
+    expect(await runtime.get(app.id, ctx)).toMatchObject({ id: app.id });
+  });
+});

--- a/packages/apps/src/open.ts
+++ b/packages/apps/src/open.ts
@@ -1,6 +1,7 @@
 import {
   VENDO_TREE_FORMAT_V2,
   VendoError,
+  safeErrorMessage,
   validateTreeV2,
   type AppDocument,
   type Json,
@@ -114,11 +115,35 @@ export const createProgressiveQueryResolver = (
   let baseData: Record<string, Json> = {};
   let resolvedData: Record<string, Json> = {};
 
+  // A query that does not settle "ok" contributes NO data, so the app renders
+  // its empty state ("No spending data") with the tree, the document and the
+  // logs all looking perfectly healthy. That silence cost a live triage
+  // (2026-07-27): the empty card had to be told apart from a frozen one by
+  // reading DOM attributes. Report each distinct non-ok query once — the
+  // render behavior is unchanged, it just stops being invisible.
+  const reported = new Set<string>();
+  const reportUnresolved = (state: QueryState): void => {
+    if (state.result?.status === "ok" || reported.has(state.key)) return;
+    reported.add(state.key);
+    const why = state.error !== undefined
+      ? safeErrorMessage(state.error)
+      : state.result === undefined
+        ? "the call did not settle"
+        : `the call answered "${state.result.status}"`;
+    console.warn(`[vendo] query "${state.query.name}" (tool "${state.query.tool}") resolved no data for app ${app.id} — ${why}; anything bound to it renders empty`);
+  };
+
   const recompute = (notify = true): void => {
     const data = structuredClone(baseData);
     for (const state of states) {
-      if (!state.settled || state.result === undefined) continue;
-      if (state.result.status !== "ok") continue;
+      if (!state.settled || state.result === undefined) {
+        if (state.settled) reportUnresolved(state);
+        continue;
+      }
+      if (state.result.status !== "ok") {
+        reportUnresolved(state);
+        continue;
+      }
       setQueryData(data, queryPointer(state.query), state.result.output);
     }
     resolvedData = data;

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -485,6 +485,14 @@ export interface AppsRuntime {
     prompt: string;
     /** Additive per-call stream hook used by the agent bridge. */
     onView?: (part: VendoViewPart) => void;
+    /** Called when the app was generated and STREAMED to the surface but the
+     *  store refused to persist it: the view is on screen, the app is not in
+     *  the user's list and cannot be reopened. The create still resolves with
+     *  the document — losing a working view to a storage fault is the worse
+     *  failure — so this is the only signal that the app is view-only, and
+     *  the agent bridge turns it into an honest sentence instead of an
+     *  apology for something the user can see. */
+    onUnsaved?: (reason: string) => void;
   }, ctx: RunContext): Promise<AppDocument>;
   /** Speed lane — best-effort page-open warm-up of the generation model(s)
    *  (full + paint), so the first create reuses a live connection. Safe to
@@ -1910,11 +1918,38 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
         queryResolver?.update(finalTree);
         finalTree.data = verifiedData ?? await queryResolver?.complete() ?? structuredClone(finalTree.data ?? {});
       }
-      await apps.put(appRecordInput(app, ctx.principal.subject));
-      clearTimeout(watchdog);
-      await reportLifecycle("create", app.id, ctx);
+      // The finished view reaches the screen BEFORE anything that can fail.
+      // Live 2026-07-27 (deployed Maple): the emit sat after the persist, so a
+      // store that refused the write froze every card mid-stream — one
+      // half-painted donut, one blank, one empty-state table, none of them
+      // ever resolving — while the engine's own logs read all-green. The
+      // document is generated, validated and data-resolved by this point; a
+      // storage fault is no reason to withhold it.
       if (finalTree !== undefined) emit(finalTree);
-      console.info(`[vendo] gen create complete app=${appId} total=${((Date.now() - createStartedAt) / 1000).toFixed(1)}s`);
+      let unsavedReason: string | undefined;
+      try {
+        await apps.put(appRecordInput(app, ctx.principal.subject));
+      } catch (error) {
+        // A persist failure degrades the app to view-only — it renders, it
+        // just is not in the user's apps list and cannot be reopened. That is
+        // a far better outcome than discarding a working view, but it is
+        // never silent: the operator gets a classified line (the user path
+        // previously logged NOTHING here, so the outage read as a mystery),
+        // and the caller is told so the agent can say it plainly instead of
+        // apologizing for a view the user can see.
+        unsavedReason = safeErrorMessage(error);
+        console.error(`[vendo] app not saved (${appId}): the view rendered but the store rejected it — ${unsavedReason}`);
+      }
+      clearTimeout(watchdog);
+      if (unsavedReason === undefined) await reportLifecycle("create", app.id, ctx);
+      console.info(`[vendo] gen create complete app=${appId} total=${((Date.now() - createStartedAt) / 1000).toFixed(1)}s${unsavedReason === undefined ? "" : " (NOT SAVED)"}`);
+      if (unsavedReason !== undefined) {
+        // Escalation (automations, graduation) all write through the same
+        // store the persist just failed on, and every one of them assumes a
+        // stored app — so an unsaved create ends here, with the view up.
+        input.onUnsaved?.(unsavedReason);
+        return structuredClone(app);
+      }
       // execution-v2 Wave 9 — escalate on create when the prompt needs server
       // capability, walking the ladder: a steps/agentic automation (seconds,
       // no machine) before box graduation. The tree is already on screen; the


### PR DESCRIPTION
apps: a storage fault costs the save, never the view

Live on the deployed Maple: "Show my spending by category" generated cleanly
(attempt=0 valid=true, no server error, no watchdog) and the user still got
nothing usable — a half-painted donut plus two cards frozen on "Building your
view…", one reading "No spending data", and the agent apologizing with a
plain text table. Three cards for one prompt, none of them saved.

The final emit(finalTree) was sequenced AFTER apps.put. The Cloud console is
rejecting every vendo_apps write (its table is missing the `revision` column
the store engine's write path needs — OSS added it in #427; that console's
database never ran the migration), so the put threw and took the settling
emit with it. Every card kept the last mid-stream payload it had received,
forever: the "rendered" donut was a frozen streaming paint and the "No
spending data" card was a frozen pre-resolution partial. Neither is a render
bug — both are the ABSENCE of the settling emit. createAgentTools then
answered the agent with a bare error, so it apologized and rebuilt twice.
Nothing was logged on the user path, which is why the server looked healthy.

The view now reaches the screen before anything that can fail; a failed
persist degrades the app to view-only instead of discarding it, and says so
("app not saved (<id>): the view rendered but the store rejected it", plus
"(NOT SAVED)" on the completion line). Escalation is skipped for an unsaved
app — every rung writes through the same store. The create tool answers ok
with an `unsaved` note whose guidance tells the agent to state it once and
not rebuild.

Separately: a query resolving non-ok contributed no data and said nothing, so
an empty card could not be told from a frozen one. Each distinct unresolved
query now warns once; render behavior is unchanged.

Proven in a real browser against the LIVE Cloud store still rejecting every
write: 1 card (was 3), state ready (was building x3), donut drawn with Total
$5,058.38, no apology — the agent closes with "The view could not be saved to
your apps list, but it's rendered above."

Cents seam checked clean end to end: route returns 505838 integer cents, the
catalog declares cents, the component passes them through unscaled, formatUSD
divides by 100 exactly once → $5,058.38.

Found by live verification of the deployed Maple demo (the flagship prompt 'Show my spending by category' produced three unusable cards and an apology while the server looked healthy).

**Companion production issue, NOT fixed here:** the Cloud console's `vendo_apps` table is missing the `revision` column OSS added in #427 — that database never ran the migration, so every hosted-store app write currently throws for every Cloud customer, not just our demos. That is a vendo-web production DB change and needs Yousef's sign-off; flagged separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures a storage failure costs the save, never the view: the finished app view is emitted before any write, and failed persists degrade to view-only with clear operator logs and an agent note.

- **Bug Fixes**
  - Emit final view before persist; on write failure, resolve with the document and call `onUnsaved` so the UI stays usable.
  - Update `createAgentTools` to return `status: "ok"` with an `unsaved` note (plus guidance to not retry); skip escalation when unsaved; log `(NOT SAVED)` and a clear reject reason.
  - Warn once per non-ok query during data resolution so empty cards are distinguishable from frozen ones; render behavior unchanged.

<sup>Written for commit ac043abaa68351a38c76fa0894e4cda2544376c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

