### PR TITLE
kit: DataTable ignores sortBy/filterableBy naming an undeclared column

### DIFF
--- a/packages/ui/src/kit/data/data-table.tsx
+++ b/packages/ui/src/kit/data/data-table.tsx
@@ -93,12 +93,22 @@ export function DataTable(props: DataTableProps) {
     [rows, limit],
   );
 
+  // W3 again, for the sort seam: `sortBy` names a column by id, and generation
+  // sometimes names one that was never declared (e.g. sortBy="timestamp desc"
+  // over columns merchant/category/amount). TanStack resolves the id through
+  // `getColumn`, which returns undefined and console.errors once per render —
+  // so an unknown id bought a phantom sort plus a stream of dev-only noise the
+  // host cannot silence. Drop the sort we cannot honour and render honestly.
+  // Only when we actually know the column set: with no explicit `columns` the
+  // keys are derived from row 0, which is empty until the query resolves, and
+  // dropping there would discard a legitimate sort on the first render.
   const initialSorting = useMemo<SortingState>(() => {
     if (!sortBy) return [];
     const [id, dir] = sortBy.trim().split(/\s+/);
     if (!id) return [];
+    if (columns.length > 0 && !columns.some((col) => col.key === id)) return [];
     return [{ id, desc: (dir ?? "asc").toLowerCase() === "desc" }];
-  }, [sortBy]);
+  }, [sortBy, columns]);
 
   const tanstackColumns = useMemo<Array<ColumnDef<Record<string, unknown>>>>(
     () =>
@@ -137,9 +147,18 @@ export function DataTable(props: DataTableProps) {
       : {}),
   });
 
+  // Same seam as `sortBy` above: a `filterableBy` key that names no declared
+  // column reaches TanStack as a column filter id it cannot resolve, so the
+  // dropdown renders but filtering silently does nothing. Drop those keys
+  // rather than ship a dead control.
+  const filterKeys = useMemo(
+    () => (filterableBy ?? []).filter((key) => columns.length === 0 || columns.some((col) => col.key === key)),
+    [filterableBy, columns],
+  );
+
   const distinctValues = useMemo(() => {
     const map = new Map<string, string[]>();
-    for (const key of filterableBy ?? []) {
+    for (const key of filterKeys) {
       const set = new Set<string>();
       for (const row of data) {
         const v = resolvePath(row, key);
@@ -148,7 +167,7 @@ export function DataTable(props: DataTableProps) {
       map.set(key, [...set].sort());
     }
     return map;
-  }, [filterableBy, data]);
+  }, [filterKeys, data]);
 
   const columnLabel = (key: string) =>
     columns.find((c) => c.key === key)?.label ?? humanizeEnum(key.split(".").pop() ?? key);
@@ -157,7 +176,7 @@ export function DataTable(props: DataTableProps) {
 
   return (
     <div data-kit="DataTable" style={{ ...font, display: "flex", flexDirection: "column", gap: "var(--vendo-density-content-gap, 10px)" }}>
-      {(searchable || (filterableBy && filterableBy.length > 0)) && (
+      {(searchable || filterKeys.length > 0) && (
         <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--vendo-density-inline-gap, 7px)", alignItems: "center" }}>
           {searchable && (
             <input
@@ -178,7 +197,7 @@ export function DataTable(props: DataTableProps) {
               }}
             />
           )}
-          {(filterableBy ?? []).map((key) => (
+          {filterKeys.map((key) => (
             <select
               key={key}
               aria-label={`Filter by ${columnLabel(key)}`}

--- a/packages/ui/test/kit/data-table.test.tsx
+++ b/packages/ui/test/kit/data-table.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { DataTable } from "../../src/kit/data/data-table.js";
 
 const rows = [
@@ -51,5 +51,39 @@ describe("DataTable", () => {
   it("renders an unrenderable numeric cell as a placeholder, never $NaN", () => {
     render(<DataTable rows={[{ id: 9, client: { name: "X" }, amountCents: Number.NaN }]} columns={columns} />);
     expect(screen.queryByText(/NaN/)).toBeNull();
+  });
+
+  // Generation names a column that was never declared often enough to matter:
+  // an unresolvable id reaches TanStack's getColumn, which console.errors on
+  // every render and applies nothing.
+  it("ignores a sortBy naming an undeclared column, without console noise", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      render(<DataTable rows={rows} columns={columns} sortBy="timestamp desc" />);
+      const bodyRows = screen.getAllByRole("row").slice(1);
+      const firstCells = bodyRows.map((r) => within(r).getAllByRole("cell")[0]?.textContent);
+      expect(firstCells).toEqual(["Hartwell", "Acme", "Borealis"]); // untouched row order
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("still applies a sortBy naming a dot-path column", () => {
+    render(<DataTable rows={rows} columns={columns} sortBy="client.name asc" />);
+    const bodyRows = screen.getAllByRole("row").slice(1);
+    expect(within(bodyRows[0]!).getAllByRole("cell")[0]?.textContent).toBe("Acme");
+  });
+
+  it("drops a filterableBy key naming an undeclared column rather than ship a dead control", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      render(<DataTable rows={rows} columns={columns} filterableBy={["status", "dueDate"]} />);
+      expect(screen.queryByLabelText("Filter by Status")).toBeNull();
+      expect(screen.getByLabelText("Filter by Due")).toBeTruthy();
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
Found by the nightly demo QA rig (`eng-nightly-demo-qa`, 2026-07-27) against `runvendo/vendo` @ `14130aa1`.

## The defect

`DataTable` passes `sortBy` and `filterableBy` ids straight into TanStack without checking them against the declared `columns`. TanStack resolves an id via `getColumn()`, which returns `undefined`, `console.error`s **once per render**, and applies nothing.

Tonight's run produced both halves for real:

| app | props | declared columns |
|---|---|---|
| `app_85323a30` "Last night's spending" | `sortBy: "timestamp asc"` | merchant, category, amount |
| `app_9f6188dd` "Card spend breakdown" | `filterableBy: ["category","status"]` | merchant, category, amount, timestamp |

Impact:

- **Phantom sort.** The user asked about *last night*; the table renders in raw tool order, not by date. Silent — nothing tells anyone the sort was dropped.
- **Dead control.** A `filterableBy` key with no column renders a dropdown that filters nothing.
- **Dev noise the host cannot silence.** 18 × `[Table] Column with id 'timestamp' does not exist.` in the nightly capture, which Next's dev overlay surfaces as a red **1 Issue** badge on the demo's headline screen.

The exemplar in `packages/apps/src/generation/contracts/exemplar.ts` models the correct usage (`sortBy="dueDate asc"` over a declared `dueDate`), so this is generation slipping the invariant rather than being taught the wrong thing — which is exactly why the component should hold the line. Generation is probabilistic; four of tonight's six generated apps got it right.

## The fix

Drop a `sortBy` / `filterableBy` id that names no declared column, matching the W3 fail-soft posture already documented above the `rows` memo ("the honest render, never a crash").

Guarded on `columns.length > 0`: with no explicit `columns` prop the keys are derived from row 0, which is empty until the query resolves, so dropping there would discard a legitimate sort on the first render.

## Verification

Gates, under Node v24.18.0 (per the standing rig note — Node 26 fakes 28 `@vendoai/ui` failures):

- `CI=true pnpm build` — 22/22
- `pnpm test` — 51/51 tasks; `@vendoai/vendo` 1441 passed / 15 skipped
- `CI=true pnpm typecheck` — 40/40
- `CI=true pnpm lint` — 5/5

New tests fail without the src change (2 failed / 7 passed), with the exact console error observed in the demo.

**Real browser, A/B on the identical stored document** (`app_85323a30`, tonight's genuine artifact, loaded into demo-bank at `/vendo/workspace?app=…`):

| | console errors | headers | first rows |
|---|---|---|---|
| before | 1 × `[Table] Column with id 'timestamp' does not exist.` | Merchant, Category, Amount | DoorDash \| dining \| -$87.00 … |
| after | **0** | Merchant, Category, Amount | DoorDash \| dining \| -$87.00 … |

Identical render, error gone — the fix drops only the phantom sort. Screenshot: `shots/2026-07-27/08-fix-verified.png` on the rig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drop invalid sortBy and filterableBy ids in DataTable to prevent phantom sorts, dead filter controls, and dev console noise. Keeps the table rendering honest without user-visible regressions.

- **Bug Fixes**
  - Ignore sortBy ids not present in declared columns; only apply this check when columns are known (columns.length > 0).
  - FilterableBy now excludes keys not in declared columns, so we don’t render no-op filter dropdowns.
  - Added filterKeys memo and updated sorting memo deps; eliminates console.error spam and adds tests for invalid ids, dot-path sorts, and no console noise.

<sup>Written for commit 1219c9bda7c7ff70b4ad8abbdb3733f2d3a7e37e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

