### PR TITLE
store: transactional erase cascade — mid-cascade failure rolls back instead of half-erasing

### DIFF
--- a/packages/store/src/db-postgres.ts
+++ b/packages/store/src/db-postgres.ts
@@ -31,6 +31,13 @@ export interface Db {
       the advisory lock, and pulling `pg` into the shared modules would drag
       it into every entry's bundle graph. */
   withSchemaLock<T>(work: (query: Query) => Promise<T>): Promise<T>;
+  /** One transaction: every statement `work` issues through the handed query
+      commits together or not at all. Exists for the erase cascade (02-store
+      §5) — its sequential DELETEs used to run bare, so a mid-cascade failure
+      left a subject HALF-erased with no report of what was destroyed;
+      rollback turns that into a clean retry. On the handle for the same
+      bundle-graph reason as withSchemaLock. */
+  withTransaction<T>(work: (query: Query) => Promise<T>): Promise<T>;
 }
 
 const ADVISORY_LOCK_KEY = 7_461_001;
@@ -61,6 +68,37 @@ export function createPostgresDb(url: string): Db {
     },
     withSchemaLock(work) {
       return withAdvisoryLock(url, ADVISORY_LOCK_KEY, work);
+    },
+    // A dedicated Client, not the Pool: Pool.query has no statement affinity,
+    // and BEGIN/COMMIT must see one connection (same pattern as the schema
+    // lock's session-scoped client).
+    async withTransaction(work) {
+      if (closed) throw new Error("[vendo] store is closed");
+      const client = new Client({ connectionString: url });
+      await client.connect();
+      const query: Query = async (text, params = []) => {
+        const result = await client.query(text, params);
+        return { rows: result.rows as Record<string, unknown>[] };
+      };
+      try {
+        await query("BEGIN");
+        try {
+          const result = await work(query);
+          await query("COMMIT");
+          return result;
+        } catch (error) {
+          // Best-effort: if the connection itself died, the server aborts
+          // the transaction anyway — surface the original error.
+          try {
+            await query("ROLLBACK");
+          } catch {
+            /* noop */
+          }
+          throw error;
+        }
+      } finally {
+        await client.end();
+      }
     },
   };
 }

--- a/packages/store/src/db.ts
+++ b/packages/store/src/db.ts
@@ -6,7 +6,7 @@ import { PGlite } from "@electric-sql/pglite";
 import fs from "node:fs";
 import { join, resolve } from "node:path";
 
-import { createPostgresDb, type Db, type StoreConfig } from "./db-postgres.js";
+import { createPostgresDb, type Db, type Query, type StoreConfig } from "./db-postgres.js";
 
 export type { Db, Query, StoreConfig } from "./db-postgres.js";
 
@@ -332,6 +332,22 @@ function createPgliteDb(dataDir: string): Db {
     // lock session — the ENG-351 dir lock already serializes processes.
     withSchemaLock(work) {
       return work(db.query.bind(db));
+    },
+    // PGlite's own transaction() serializes concurrent queries, so a foreign
+    // statement can never join (or be rolled back with) this transaction on
+    // the shared single connection.
+    async withTransaction<T>(work: (query: Query) => Promise<T>): Promise<T> {
+      const active = await open();
+      const result = await active.transaction(async (tx) => {
+        const query: Query = async (text, params = []) => {
+          const queried = await tx.query<Record<string, unknown>>(text, params);
+          return { rows: queried.rows as Record<string, unknown>[] };
+        };
+        return work(query);
+      });
+      // transaction() types as T | undefined for callbacks that call
+      // tx.rollback(); this one never does — a throw is the only exit.
+      return result as T;
     },
   };
   return db;

--- a/packages/store/src/ephemeral.test.ts
+++ b/packages/store/src/ephemeral.test.ts
@@ -195,19 +195,25 @@ for (const backend of backends()) {
       const opts = { idleMs: 30_000, now: base + 60_000 };
       await registerEphemeralSubject(made.store, "sess_erase_fail", base);
       const db = dbFor(made.store);
-      const original = db.query.bind(db);
+      // The cascade runs inside db.withTransaction (atomic erase), so the
+      // failure injects at that seam: the cascade's own query throws on the
+      // marker statement, everything else passes through.
+      const original = db.withTransaction.bind(db);
       let failed = false;
-      db.query = async (text, params) => {
-        if (text.includes("DELETE FROM vendo_threads") && params?.[0] === "sess_erase_fail") {
-          failed = true;
-          throw new Error("transient erase failure");
-        }
-        return original(text, params);
-      };
+      db.withTransaction = (work) =>
+        original((query) =>
+          work(async (text, params) => {
+            if (text.includes("DELETE FROM vendo_threads") && params?.[0] === "sess_erase_fail") {
+              failed = true;
+              throw new Error("transient erase failure");
+            }
+            return query(text, params);
+          }),
+        );
       try {
         await expect(sweepEphemeralSubjects(made.store, opts)).rejects.toThrow("transient erase failure");
       } finally {
-        db.query = original;
+        db.withTransaction = original;
       }
       expect(failed).toBe(true);
       // The subject is registered again and still sweep-eligible.

--- a/packages/store/src/erase.conformance.test.ts
+++ b/packages/store/src/erase.conformance.test.ts
@@ -239,4 +239,80 @@ for (const backend of backends()) {
       expect(await store.records("vendo_threads").get("thr_erase_by_app")).not.toBeNull();
     });
   });
+
+  describe(`${backend.name} 02-store §5 — the cascade is atomic`, () => {
+    let made: MadeBackend;
+
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    it("a mid-cascade failure rolls the whole erase back — nothing is deleted", async () => {
+      const store = made.store;
+      const subject = "user_erase_atomic";
+
+      // Seed the subject across EARLY cascade tables — the ones the old
+      // non-transactional cascade had already destroyed by the time a late
+      // leg threw (the 2026-07-27 field failure).
+      const doc = appFixture("app_erase_atomic");
+      await store.records("vendo_apps").put({ id: doc.id, data: { subject, enabled: true, doc } });
+      await store.records(`app:${doc.id}:notes`).put({ id: "note_atomic", data: { body: "mine" } });
+      await store.blobs(`app:${doc.id}:files`).put("report.txt", new Uint8Array([1, 2, 3]));
+      await store.records("vendo_threads").put({ id: "thr_atomic", data: { subject, messages: [] } });
+      const event = auditFixture("aud_atomic", { principal: { kind: "user", subject } });
+      await store.records("vendo_audit").put({ id: event.id, data: event });
+
+      // Break the LAST legs the way production broke: the knowledge tables
+      // vanish mid-cascade (renamed, not dropped, so they can be restored).
+      await made.sql("ALTER TABLE vendo_knowledge_chunks RENAME TO vendo_knowledge_chunks_hidden");
+      try {
+        await expect(eraseStore(store).bySubject(subject)).rejects.toThrow();
+
+        // The failed cascade deleted NOTHING: every early-table row survives,
+        // so a retry (after the schema is healed) starts from a clean state
+        // instead of a half-erased subject with no report of what was lost.
+        expect(await store.records("vendo_apps").get(doc.id)).not.toBeNull();
+        expect(await store.records(`app:${doc.id}:notes`).get("note_atomic")).not.toBeNull();
+        expect(await store.blobs(`app:${doc.id}:files`).get("report.txt")).not.toBeNull();
+        expect(await store.records("vendo_threads").get("thr_atomic")).not.toBeNull();
+        expect(await store.records("vendo_audit").get(event.id)).not.toBeNull();
+      } finally {
+        await made.sql("ALTER TABLE vendo_knowledge_chunks_hidden RENAME TO vendo_knowledge_chunks");
+      }
+
+      // With the schema healed, the SAME erase call succeeds cleanly.
+      const report = await eraseStore(store).bySubject(subject);
+      expect(report.vendo_apps).toBe(1);
+      expect(report.vendo_records).toBe(1);
+      expect(report.vendo_blobs).toBe(1);
+      expect(report.vendo_threads).toBe(1);
+      expect(report.vendo_audit).toBe(1);
+      expect(await store.records("vendo_apps").get(doc.id)).toBeNull();
+    });
+
+    it("byApp is atomic the same way", async () => {
+      const store = made.store;
+      const doc = appFixture("app_erase_atomic_byapp");
+      await store.records("vendo_apps").put({
+        id: doc.id,
+        data: { subject: "user_atomic_byapp", enabled: true, doc },
+      });
+      await store.records(`app:${doc.id}:notes`).put({ id: "note_byapp", data: { body: "mine" } });
+
+      await made.sql("ALTER TABLE vendo_knowledge_docs RENAME TO vendo_knowledge_docs_hidden");
+      try {
+        await expect(eraseStore(store).byApp(doc.id)).rejects.toThrow();
+        expect(await store.records("vendo_apps").get(doc.id)).not.toBeNull();
+        expect(await store.records(`app:${doc.id}:notes`).get("note_byapp")).not.toBeNull();
+      } finally {
+        await made.sql("ALTER TABLE vendo_knowledge_docs_hidden RENAME TO vendo_knowledge_docs");
+      }
+
+      const report = await eraseStore(store).byApp(doc.id);
+      expect(report.vendo_apps).toBe(1);
+      expect(report.vendo_records).toBe(1);
+    });
+  });
 }

--- a/packages/store/src/erase.ts
+++ b/packages/store/src/erase.ts
@@ -1,3 +1,4 @@
+import type { Query } from "./db-postgres.js";
 import { escapeLike } from "./helpers/utils.js";
 import { dbFor, type VendoStore } from "./store.js";
 import { invalid } from "./validate.js";
@@ -60,85 +61,96 @@ export function eraseStore(store: VendoStore): {
   const db = dbFor(store);
 
   const del = async (
+    query: Query,
     report: EraseReport,
     table: EraseTable,
     where: string,
     params: unknown[],
   ): Promise<void> => {
-    const result = await db.query(`DELETE FROM ${table} WHERE ${where} RETURNING 1`, params);
+    const result = await query(`DELETE FROM ${table} WHERE ${where} RETURNING 1`, params);
     report[table] += result.rows.length;
   };
 
   /** App-scoped data shared by the subject and app cascades: the app's record
       collections and blob namespaces (`app:<appId>:...` — §3's naming
       convention), its per-user state, and its run records. */
-  const eraseAppData = async (report: EraseReport, appId: string): Promise<void> => {
+  const eraseAppData = async (query: Query, report: EraseReport, appId: string): Promise<void> => {
     const prefix = `app:${escapeLike(appId)}:%`;
-    await del(report, "vendo_records", "collection LIKE $1 ESCAPE '\\'", [prefix]);
-    await del(report, "vendo_blobs", "namespace LIKE $1 ESCAPE '\\'", [prefix]);
-    await del(report, "vendo_state", "app_id = $1", [appId]);
-    await del(report, "vendo_runs", "app_id = $1", [appId]);
+    await del(query, report, "vendo_records", "collection LIKE $1 ESCAPE '\\'", [prefix]);
+    await del(query, report, "vendo_blobs", "namespace LIKE $1 ESCAPE '\\'", [prefix]);
+    await del(query, report, "vendo_state", "app_id = $1", [appId]);
+    await del(query, report, "vendo_runs", "app_id = $1", [appId]);
   };
 
+  // Each cascade is ONE transaction: erase either completes across every
+  // table or leaves nothing changed. Before this, a mid-cascade failure
+  // (the 2026-07-27 incident: a missing knowledge table on stale-schema
+  // tenants) left the subject HALF-erased — apps, records, blobs and audit
+  // rows already gone, the caller holding an error and no report of what
+  // was destroyed. Rollback makes a failed erase a clean retry instead.
   return {
     async bySubject(subject) {
       if (typeof subject !== "string" || subject === "") {
         invalid("erase subject must be a non-empty string");
       }
-      const report = emptyReport();
-      const subjectRef = JSON.stringify({ subject });
+      return db.withTransaction(async (query) => {
+        const report = emptyReport();
+        const subjectRef = JSON.stringify({ subject });
 
-      // The subject's apps drive the app-scoped cascade (records/blobs/state/runs
-      // carry the app id, not the subject). The app ROWS are deleted FIRST:
-      // once they are gone, no new gated write (records/blobs WHERE EXISTS)
-      // can land, so the data deletes below collect any stragglers — the
-      // remaining race residue is a write statement already in flight.
-      const owned = (await db.query("SELECT id FROM vendo_apps WHERE subject = $1", [subject])).rows
-        .map((row) => String(row["id"]));
-      await del(report, "vendo_apps", "subject = $1", [subject]);
-      for (const appId of owned) await eraseAppData(report, appId);
+        // The subject's apps drive the app-scoped cascade (records/blobs/state/runs
+        // carry the app id, not the subject). The app ROWS are deleted FIRST:
+        // once they are gone, no new gated write (records/blobs WHERE EXISTS)
+        // can land, so the data deletes below collect any stragglers — the
+        // remaining race residue is a write statement already in flight.
+        const owned = (await query("SELECT id FROM vendo_apps WHERE subject = $1", [subject])).rows
+          .map((row) => String(row["id"]));
+        await del(query, report, "vendo_apps", "subject = $1", [subject]);
+        for (const appId of owned) await eraseAppData(query, report, appId);
 
-      // Ordering matters for accurate counts: the app cascade above already
-      // removed the subject's own state/run rows, so the subject-level deletes
-      // below only count rows the cascade did not reach (e.g. this subject's
-      // state under ANOTHER owner's app).
-      await del(report, "vendo_state", "subject = $1", [subject]);
-      await del(report, "vendo_threads", "subject = $1", [subject]);
-      await del(report, "vendo_grants", "subject = $1", [subject]);
-      await del(report, "vendo_approvals", "subject = $1", [subject]);
-      await del(report, "vendo_audit", "subject = $1", [subject]);
-      // Generic and door-owned rows carry the subject only as a ref (§2/§3).
-      await del(report, "vendo_records", "refs @> $1::jsonb", [subjectRef]);
-      await del(report, "vendo_mcp_clients", "refs @> $1::jsonb", [subjectRef]);
-      await del(report, "vendo_mcp_grants", "refs @> $1::jsonb", [subjectRef]);
-      // Knowledge corpus rows the subject axis reaches carry the subject only as
-      // a ref, same as the door tables (the knowledge engine owns what it refs).
-      await del(report, "vendo_knowledge_docs", "refs @> $1::jsonb", [subjectRef]);
-      await del(report, "vendo_knowledge_chunks", "refs @> $1::jsonb", [subjectRef]);
-      // The session registration (if any) is retired with the data (§4).
-      await del(report, "vendo_sessions", "subject = $1", [subject]);
-      return report;
+        // Ordering matters for accurate counts: the app cascade above already
+        // removed the subject's own state/run rows, so the subject-level deletes
+        // below only count rows the cascade did not reach (e.g. this subject's
+        // state under ANOTHER owner's app).
+        await del(query, report, "vendo_state", "subject = $1", [subject]);
+        await del(query, report, "vendo_threads", "subject = $1", [subject]);
+        await del(query, report, "vendo_grants", "subject = $1", [subject]);
+        await del(query, report, "vendo_approvals", "subject = $1", [subject]);
+        await del(query, report, "vendo_audit", "subject = $1", [subject]);
+        // Generic and door-owned rows carry the subject only as a ref (§2/§3).
+        await del(query, report, "vendo_records", "refs @> $1::jsonb", [subjectRef]);
+        await del(query, report, "vendo_mcp_clients", "refs @> $1::jsonb", [subjectRef]);
+        await del(query, report, "vendo_mcp_grants", "refs @> $1::jsonb", [subjectRef]);
+        // Knowledge corpus rows the subject axis reaches carry the subject only as
+        // a ref, same as the door tables (the knowledge engine owns what it refs).
+        await del(query, report, "vendo_knowledge_docs", "refs @> $1::jsonb", [subjectRef]);
+        await del(query, report, "vendo_knowledge_chunks", "refs @> $1::jsonb", [subjectRef]);
+        // The session registration (if any) is retired with the data (§4).
+        await del(query, report, "vendo_sessions", "subject = $1", [subject]);
+        return report;
+      });
     },
 
     async byApp(appId) {
       if (typeof appId !== "string" || appId === "") {
         invalid("erase appId must be a non-empty string");
       }
-      const report = emptyReport();
-      const appRef = JSON.stringify({ app_id: appId });
+      return db.withTransaction(async (query) => {
+        const report = emptyReport();
+        const appRef = JSON.stringify({ app_id: appId });
 
-      // App row first (same gate-closing order as bySubject), then its data.
-      await del(report, "vendo_apps", "id = $1", [appId]);
-      await eraseAppData(report, appId);
-      await del(report, "vendo_grants", "app_id = $1", [appId]);
-      await del(report, "vendo_audit", "app_id = $1", [appId]);
-      await del(report, "vendo_records", "refs @> $1::jsonb", [appRef]);
-      await del(report, "vendo_mcp_clients", "refs @> $1::jsonb", [appRef]);
-      await del(report, "vendo_mcp_grants", "refs @> $1::jsonb", [appRef]);
-      // An app's knowledge corpus (docs + their chunks) goes with the app.
-      await del(report, "vendo_knowledge_docs", "refs @> $1::jsonb", [appRef]);
-      await del(report, "vendo_knowledge_chunks", "refs @> $1::jsonb", [appRef]);
-      return report;
+        // App row first (same gate-closing order as bySubject), then its data.
+        await del(query, report, "vendo_apps", "id = $1", [appId]);
+        await eraseAppData(query, report, appId);
+        await del(query, report, "vendo_grants", "app_id = $1", [appId]);
+        await del(query, report, "vendo_audit", "app_id = $1", [appId]);
+        await del(query, report, "vendo_records", "refs @> $1::jsonb", [appRef]);
+        await del(query, report, "vendo_mcp_clients", "refs @> $1::jsonb", [appRef]);
+        await del(query, report, "vendo_mcp_grants", "refs @> $1::jsonb", [appRef]);
+        // An app's knowledge corpus (docs + their chunks) goes with the app.
+        await del(query, report, "vendo_knowledge_docs", "refs @> $1::jsonb", [appRef]);
+        await del(query, report, "vendo_knowledge_chunks", "refs @> $1::jsonb", [appRef]);
+        return report;
+      });
     },
   };
 }


### PR DESCRIPTION
## Why

`erase.bySubject` / `erase.byApp` (the GDPR / data-subject deletion path) issued their 16-table DELETE cascade **with no transaction**. When a late statement failed — the 2026-07-27 production case: knowledge tables missing on stale-schema hosted tenants — the subject's apps, records, blobs, state, runs, threads, grants, approvals and audit rows were already destroyed. The caller received an error, the data was half-gone, and no report said what had been deleted. 47 of 52 hosted tenants were in that state (fixed fleet-wide on the vendo-web side; this PR is the engine hardening so the failure mode itself is gone).

## What

- **`Db.withTransaction`** — new engine primitive, on the handle like `withSchemaLock` so `erase.ts` needs no driver import and the `/postgres` entry stays PGlite-free:
  - pg: a dedicated `Client` (`Pool.query` has no statement affinity; BEGIN/COMMIT must see one connection) — the same pattern as the schema lock.
  - PGlite: the driver's own `transaction()`, which serializes concurrent queries so a foreign statement can never join (or be rolled back with) the cascade on the shared single connection.
  - db-edge is unaffected (its `createDb` throws by design).
- **Both erase cascades run inside it**: erase completes across every table or leaves nothing changed. A failed erase becomes a clean retry instead of a partial destruction.

## Tests

- New conformance tests (both backends, bySubject **and** byApp): seed the early-cascade tables, break a late leg exactly the way production broke (knowledge table renamed away mid-cascade), assert the erase **throws and deletes nothing**, then heal the schema and assert the very same call succeeds cleanly.
- `ephemeral.test.ts`'s transient-failure injection moved to the `withTransaction` seam (the cascade no longer flows through `db.query`); its claim-restoration contract is unchanged and still enforced.
- Full store suite: 412 passed (PGlite + real Postgres via `POSTGRES_URL`), portability gate green, `turbo build` green across all 20 dependent tasks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make subject/app erase cascades transactional and atomic. Adds `Db.withTransaction` so a mid-cascade failure rolls back instead of half-deleting data.

- **Bug Fixes**
  - Added `Db.withTransaction` on the store handle. Postgres uses a dedicated `pg` `Client`; `@electric-sql/pglite` uses `transaction()`. Edge DB unchanged.
  - `erase.bySubject` and `erase.byApp` now run inside one transaction. A failure rolls back the whole cascade, preserving data and allowing a clean retry with correct counts.
  - Added conformance tests for mid-cascade failures on both backends; moved transient failure injection to the transaction seam.

<sup>Written for commit 2a517ba5dfbf728e49f30c32d331a43f21b3a5c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

