### PR TITLE
feat(cli): remix is experimental — unresolved slots warn instead of failing sync

### DIFF
--- a/.changeset/remix-experimental-warning.md
+++ b/.changeset/remix-experimental-warning.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/vendo": patch
+---
+
+Remix is experimental: unresolved remixable slots now warn (`experimental:` prefix, slot + reason + fix hint) instead of failing `vendo sync` with exit 2. Slots are still never skipped silently; acknowledge intentionally uncapturable ones in `overrides.json` → `remix.ignoreSlots`.

--- a/docs-site/connect/host-components.mdx
+++ b/docs-site/connect/host-components.mdx
@@ -12,6 +12,10 @@ component drifts and rebases as your host code changes; the exact
 registration shapes and capture rules live in the reference section at the
 end.
 
+<Note>Remix — forking a captured component — is **experimental**. Capture
+failures warn instead of failing `vendo sync`, and baseline formats may
+evolve between versions.</Note>
+
 ## Register your components
 
 The shared registry is the current form: one object, keyed by component
@@ -154,7 +158,9 @@ is no reproducible trail to replay.
 `vendo sync` never skips a remixable slot silently. When it cannot follow the
 registration to real source (an inline component, a dynamic import, a path it
 cannot resolve, or source outside the project root), it lists the slot with a
-machine-readable reason and exits non-zero.
+machine-readable reason as an `experimental:` warning — the run still
+succeeds, but that component cannot be forked until the slot is resolved or
+acknowledged.
 
 To capture such a slot at runtime instead, wrap the registration with the
 `remixable` helper and pass the module URL:

--- a/docs-site/reference/cli.mdx
+++ b/docs-site/reference/cli.mdx
@@ -216,8 +216,10 @@ When tools changed or broke, sync asks the running dev server which saved
 apps, automations, and grants they impact and prints one `impact:` line per
 tool (or `impact unknown` when no server is reachable). Drifted pins get an
 advisory `drifted:` line. Drift never auto-rebases; each fork's owner
-decides. Unresolved remixable slots are listed and fail the run with exit 2
-regardless of `--strict` (silent remix skips are eliminated).
+decides. Unresolved remixable slots are listed as `experimental:` warnings —
+remix is experimental, so they never fail the run, but silent remix skips are
+still eliminated: every unresolved slot is named with its reason and fix
+hint.
 
 Sync scans exported JSX components referenced by your `<VendoRoot>`
 `components` map and writes `.vendo/catalog.json` (see

--- a/docs/host-components.md
+++ b/docs/host-components.md
@@ -74,9 +74,10 @@ const invoiceCard = remixable({
 
 In development the helper reports the module to the Vendo wire, which captures
 the source only when no valid static baseline exists. The capture route is not
-mounted in production. `vendo sync` exits non-zero for any unresolved slot; a
-slot that is intentionally never capturable can be acknowledged in the
-human-owned `.vendo/overrides.json`:
+mounted in production. Remix is experimental: `vendo sync` warns for any
+unresolved slot (the component cannot be forked until resolved) but never
+fails the run; a slot that is intentionally never capturable can be
+acknowledged in the human-owned `.vendo/overrides.json`:
 
 `vendo init` offers remix wrapping: every statically capturable
 `{ name, component }` registration that is not yet remixable becomes a

--- a/fixtures/host-app/next-env.d.ts
+++ b/fixtures/host-app/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/automations-e2e/dev/types/routes.d.ts";
+import "./.next/redteam-e2e/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/vendo/src/cli/sync.test.ts
+++ b/packages/vendo/src/cli/sync.test.ts
@@ -206,7 +206,7 @@ describe("vendo sync", () => {
     expect(messages.errors).toContain("warning: failed to push sync report: cloud offline");
   });
 
-  it("exits two and lists every unresolved remixable slot", async () => {
+  it("warns about every unresolved remixable slot as experimental and exits zero", async () => {
     const errors: string[] = [];
     const output = { log() {}, error(message: string) { errors.push(message); } };
     const unresolved = {
@@ -218,7 +218,10 @@ describe("vendo sync", () => {
         hint: "run the host in dev with Vendo mounted to runtime-capture it",
       }],
     };
-    expect(await runSync({ targetDir: ".", output, sync: async () => unresolved })).toBe(2);
+    // Remix is experimental: the failed capture warns loudly but never fails
+    // the host's build.
+    expect(await runSync({ targetDir: ".", output, sync: async () => unresolved })).toBe(0);
+    expect(errors.join("\n")).toContain("experimental");
     expect(errors.join("\n")).toContain("InlineCard [inline-component]");
     expect(errors.join("\n")).toContain("run the host in dev with Vendo mounted to runtime-capture it");
   });
@@ -303,7 +306,7 @@ describe("vendo sync", () => {
     });
   });
 
-  it("--json carries unresolved slots in the report, exits two, and keeps stdout to one object", async () => {
+  it("--json carries unresolved slots in the report, exits zero, and keeps stdout to one object", async () => {
     const messages = captureOutput();
     const unresolved = {
       ...report(),
@@ -315,13 +318,13 @@ describe("vendo sync", () => {
       }],
     };
 
-    expect(await runSync({ targetDir: ".", json: true, output: messages.output, sync: async () => unresolved })).toBe(2);
+    expect(await runSync({ targetDir: ".", json: true, output: messages.output, sync: async () => unresolved })).toBe(0);
 
     expect(messages.logs).toHaveLength(1);
     expect(messages.errors).toHaveLength(0);
     expect(JSON.parse(messages.logs[0]!)).toMatchObject({
-      ok: false,
-      exitCode: 2,
+      ok: true,
+      exitCode: 0,
       report: { unresolvedPins: [{ slot: "InlineCard", reason: "inline-component" }] },
       notes: [],
     });

--- a/packages/vendo/src/cli/sync.ts
+++ b/packages/vendo/src/cli/sync.ts
@@ -133,19 +133,17 @@ async function sync(options: SyncOptions): Promise<number> {
         output.log(`drifted: ${report.pins.drifted.join(", ")} — existing forks stay on the old capture until each owner rebases (POST /apps/:id/rebase-pin or the vendo_apps_rebase_pin agent tool)`);
       }
     }
-    // Unresolved slots fail the run regardless of --strict (silent remix skips
-    // are eliminated), but impact analysis, the report push, and the breaking
-    // gate below still execute so the most severe exit code wins. In --json
-    // mode the human lines are dropped: the pins ride in report.unresolvedPins.
-    let unresolvedExit: 0 | 2 = 0;
-    if (report.unresolvedPins.length > 0) {
-      if (!json) {
-        output.error("unresolved remixable slots:");
-        for (const pin of report.unresolvedPins) {
-          output.error(`  ${pin.slot} [${pin.reason}]: ${pin.hint}`);
-        }
+    // Remix is experimental: unresolved slots warn loudly (slot + reason +
+    // fix hint) but never fail the run — breaking a host's build over a
+    // feature labeled experimental is the wrong contract. When remix
+    // graduates, this returns to a hard exit so the remixable promise is
+    // enforced at dev time. In --json mode the human lines are dropped: the
+    // pins ride in report.unresolvedPins.
+    if (report.unresolvedPins.length > 0 && !json) {
+      output.error("experimental: unresolved remixable slots (remix is experimental — these components cannot be forked until resolved):");
+      for (const pin of report.unresolvedPins) {
+        output.error(`  ${pin.slot} [${pin.reason}]: ${pin.hint}`);
       }
-      unresolvedExit = 2;
     }
 
     const wireUrl = (options.url ?? process.env.VENDO_URL ?? "http://localhost:3000/api/vendo").replace(/\/+$/, "");
@@ -231,9 +229,7 @@ async function sync(options: SyncOptions): Promise<number> {
       }
     }
 
-    // Unresolved slots set the floor; the strict breaking gate overrides with
-    // its own (equal-or-worse) code, so the most severe exit wins.
-    let exitCode: SyncJsonResult["exitCode"] = unresolvedExit;
+    let exitCode: SyncJsonResult["exitCode"] = 0;
     if (options.strict === true && report.breaking.length > 0) {
       if (!json) for (const breaking of report.breaking) output.error(`breaking: ${breaking.tool} ${breaking.change}`);
       const breakingTools = new Set(report.breaking.map((breaking) => breaking.tool));


### PR DESCRIPTION
Remix (component forking) is now labeled an experimental feature (Yousef, 2026-07-28).

## What changed
- `vendo sync` no longer exits 2 on unresolved remixable slots. They print as `experimental:` warnings — slot, machine-readable reason, fix hint — and the run succeeds. Slots are still never skipped silently; `overrides.json → remix.ignoreSlots` remains the acknowledgment for intentionally uncapturable slots.
- Docs updated in the three places describing the old exit-2 behavior (docs-site host-components + CLI reference, docs/host-components.md), plus an experimental note on the host-components page.
- When remix graduates, the hard exit returns as part of the promise (tracked in Linear).

## Test changes (stated explicitly)
Two tests asserting the old exit-2 now assert warn-and-exit-zero — that IS the approved behavior change ("exits two and lists every unresolved remixable slot" → "warns … as experimental and exits zero"; the --json twin likewise). The blast-radius exit-3 test is untouched and still passes.

## Gate
Full `build && test && typecheck && lint` — green except 5 test files that failed as 30s timeouts/Cloud-fetch 404s under parallel load, all in files this diff does not touch; all 5 pass in isolation (119/119). Changeset included (patch @vendoai/vendo).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark Remix (component forking) as experimental and update `vendo sync` to warn (not fail) on unresolved remixable slots. Runs now exit 0 while still listing each slot with a machine-readable reason and a fix hint; the hard exit returns when Remix graduates (tracked in Linear).

- **New Features**
  - `vendo sync`: prints `experimental:` warnings for unresolved remixable slots and exits 0; `--json` returns ok: true with `unresolvedPins`.
  - No silent skips: keep acknowledging intentionally uncapturable slots in `.vendo/overrides.json` → `remix.ignoreSlots`. Docs updated with the experimental note; tests adjusted to assert warn-and-exit-zero.

<sup>Written for commit a4fbf818547f6837122e222e7364160e01fadfa6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

