### PR TITLE
feat(core): plan dialect compiler with fact checks

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "croner": "^9.0.0",
     "zod": "^3.25.0"
   },
   "devDependencies": {

--- a/packages/core/src/genui/plan/compile.test.ts
+++ b/packages/core/src/genui/plan/compile.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "vitest";
+import { compilePlan, type PlanFacts } from "./compile.js";
+import { planTabs } from "./types.js";
+
+const FACTS: PlanFacts = {
+  tools: ["host_listInvoices", "host_listClients", "host_sendMessage"],
+  components: ["StatTile", "BarChart", "DataTable", "PageHeader"],
+};
+
+/** The shape of a plan the brain writes for a normal ask, wrapped in the
+ *  prose and fence models add despite instructions. */
+const FULL_EXAMPLE = `Here is the plan.
+
+\`\`\`xml
+<Plan name="Invoices workspace">
+  <Query id="invoices" tool="host_listInvoices" input={{ limit: 50 }}/>
+  <Query id="clients" tool="host_listClients"/>
+  <Group tab="Overview" title="Health" layout="grid">
+    <Leaf component="StatTile" query="invoices" purpose="Total outstanding across every open invoice" col="1"/>
+    <Leaf component="BarChart" query="invoices" purpose="Invoiced amount per month over the last year" col="2" span="2"/>
+  </Group>
+  <Group tab="Overview">
+    <Leaf component="DataTable" query="clients" purpose="Clients with the most outstanding, worst first"/>
+  </Group>
+  <Group tab="Payments" title="Payment history" waitsForServer>
+    <Leaf component="DataTable" query="invoices" purpose="Every payment recorded against an invoice"/>
+  </Group>
+  <Island name="RunwayDial" purpose="A cash dial no chart component can express"/>
+  <Server kind="steps" schedule="fridays" why="Chasing overdue invoices has to happen when nobody has the app open."/>
+  <Cannot>Your host has no way to send email, so reminders land in the app's own log instead.</Cannot>
+  <Cannot>Nothing here can write an invoice off — that tool is read-only.</Cannot>
+</Plan>
+\`\`\`
+`;
+
+describe("compilePlan", () => {
+  it("parses the full example to the locked flat plan", () => {
+    const result = compilePlan(FULL_EXAMPLE, FACTS);
+    expect(result.issues).toEqual([]);
+    expect(result.plan).toStrictEqual({
+      name: "Invoices workspace",
+      queries: [
+        { id: "invoices", tool: "host_listInvoices", input: { limit: 50 } },
+        { id: "clients", tool: "host_listClients", input: {} },
+      ],
+      groups: [
+        {
+          tab: "Overview",
+          title: "Health",
+          layout: "grid",
+          leaves: [
+            {
+              component: "StatTile",
+              query: "invoices",
+              purpose: "Total outstanding across every open invoice",
+              attrs: { col: "1" },
+            },
+            {
+              component: "BarChart",
+              query: "invoices",
+              purpose: "Invoiced amount per month over the last year",
+              attrs: { col: "2", span: "2" },
+            },
+          ],
+        },
+        {
+          tab: "Overview",
+          leaves: [
+            { component: "DataTable", query: "clients", purpose: "Clients with the most outstanding, worst first" },
+          ],
+        },
+        {
+          tab: "Payments",
+          title: "Payment history",
+          waitsForServer: true,
+          leaves: [
+            { component: "DataTable", query: "invoices", purpose: "Every payment recorded against an invoice" },
+          ],
+        },
+      ],
+      island: { name: "RunwayDial", purpose: "A cash dial no chart component can express" },
+      server: {
+        kind: "steps",
+        schedule: "fridays",
+        why: "Chasing overdue invoices has to happen when nobody has the app open.",
+      },
+      cannot: [
+        "Your host has no way to send email, so reminders land in the app's own log instead.",
+        "Nothing here can write an invoice off — that tool is read-only.",
+      ],
+    });
+  });
+
+  it("derives two tabs from the group labels, in order of first appearance", () => {
+    const plan = compilePlan(FULL_EXAMPLE, FACTS).plan;
+    expect(plan === undefined ? [] : planTabs(plan)).toEqual(["Overview", "Payments"]);
+  });
+
+  it("parses groups without tab labels as one surface", () => {
+    const result = compilePlan(
+      `<Plan name="Client list">
+         <Query id="clients" tool="host_listClients"/>
+         <Group title="Everyone">
+           <Leaf component="DataTable" query="clients" purpose="Every client with their outstanding balance"/>
+         </Group>
+       </Plan>`,
+      FACTS,
+    );
+    expect(result.issues).toEqual([]);
+    expect(result.plan?.groups).toStrictEqual([
+      {
+        title: "Everyone",
+        leaves: [
+          { component: "DataTable", query: "clients", purpose: "Every client with their outstanding balance" },
+        ],
+      },
+    ]);
+    expect(planTabs(result.plan as NonNullable<typeof result.plan>)).toEqual([]);
+  });
+
+  it("drops the sixth leaf in a group and says to split the group", () => {
+    const leaves = Array.from(
+      { length: 6 },
+      (_unused, index) => `<Leaf component="StatTile" purpose="Headline number ${index + 1}"/>`,
+    ).join("");
+    const result = compilePlan(`<Plan name="Six"><Group title="Health">${leaves}</Group></Plan>`, FACTS);
+    expect(result.plan?.groups[0]?.leaves).toHaveLength(5);
+    expect(result.issues).toEqual([
+      'the group "Health" holds 6 parts, and one group holds at most 5 — one worker writes a whole group, so split this into two groups (they can share a tab label). The last part was dropped.',
+    ]);
+  });
+
+  it("cannot write a group inside a group", () => {
+    const result = compilePlan(
+      `<Plan name="Nested">
+         <Group tab="Overview">
+           <Leaf component="StatTile" purpose="Total outstanding right now"/>
+           <Group tab="Overview" title="Inner">
+             <Leaf component="BarChart" purpose="Invoiced amount per month"/>
+           </Group>
+         </Group>
+       </Plan>`,
+      FACTS,
+    );
+    expect(result.issues).toEqual([
+      "a group cannot sit inside a group: a plan is two levels deep — groups hold leaves, and tabs come from each group's tab label. The nested group and everything in it was dropped.",
+    ]);
+    expect(result.plan?.groups).toStrictEqual([
+      { tab: "Overview", leaves: [{ component: "StatTile", purpose: "Total outstanding right now" }] },
+    ]);
+  });
+
+  it("names an unknown tool and lists the host's real ones", () => {
+    const result = compilePlan(
+      `<Plan name="Bad tool"><Query id="invoices" tool="stripe_invoices_list"/>
+         <Group><Leaf component="DataTable" query="invoices" purpose="Every invoice"/></Group></Plan>`,
+      FACTS,
+    );
+    expect(result.issues).toEqual([
+      'there is no tool called "stripe_invoices_list". This host\'s tools are: host_listInvoices, host_listClients, host_sendMessage. Point query "invoices" at one of those, or say what you cannot do in a <Cannot> line.',
+    ]);
+  });
+
+  it("names an unknown component and lists the real ones", () => {
+    const result = compilePlan(
+      `<Plan name="Bad component"><Group><Leaf component="InvoiceGrid" purpose="Every invoice in a grid"/></Group></Plan>`,
+      FACTS,
+    );
+    expect(result.issues).toEqual([
+      'there is no component called "InvoiceGrid". The components you can use are: StatTile, BarChart, DataTable, PageHeader. Pick the closest fit, or declare an <Island> when none of them can express it.',
+    ]);
+  });
+
+  it("reports a schedule no scheduler can read", () => {
+    const result = compilePlan(
+      `<Plan name="Bad schedule"><Group><Leaf component="StatTile" purpose="Total outstanding"/></Group>
+         <Server kind="steps" schedule="0 99 * * *" why="Nobody has the app open on a Friday night."/></Plan>`,
+      FACTS,
+    );
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0]).toContain('no scheduler can read the schedule "0 99 * * *"');
+    expect(result.issues[0]).toContain('say the cadence in words ("every Friday morning")');
+    expect(result.plan?.server?.schedule).toBe("0 99 * * *");
+  });
+
+  it("reports a cron with the wrong number of fields", () => {
+    const result = compilePlan(
+      `<Plan name="Short cron"><Group><Leaf component="StatTile" purpose="Total outstanding"/></Group>
+         <Server kind="steps" schedule="0 9 * *" why="Nobody has the app open in the morning."/></Plan>`,
+      FACTS,
+    );
+    expect(result.issues).toEqual([
+      'the schedule "0 9 * *" reads as a cron but has 4 fields instead of 5. Write a 5-field cron ("0 9 * * 5"), or just say the cadence in words ("every Friday morning").',
+    ]);
+  });
+
+  it("reports a leaf reading a query the plan never declared", () => {
+    const result = compilePlan(
+      `<Plan name="Dangling"><Query id="invoices" tool="host_listInvoices"/>
+         <Group><Leaf component="DataTable" query="overdue" purpose="Overdue invoices, worst first"/></Group></Plan>`,
+      FACTS,
+    );
+    expect(result.issues).toEqual([
+      'the DataTable leaf reads a query called "overdue", but this plan declares no <Query id="overdue">. Declare it at the top of the plan, or drop the query attribute.',
+    ]);
+    expect(result.plan?.groups[0]?.leaves[0]?.query).toBe("overdue");
+  });
+
+  it("reports missing structure instead of throwing", () => {
+    expect(compilePlan("I built the app already.", FACTS)).toStrictEqual({
+      issues: ['I could not find a plan here: a plan is one <Plan name="...">...</Plan> document and nothing else.'],
+    });
+    const truncated = compilePlan('<Plan name="Cut off"><Group tab="Overview"><Leaf component="StatTile"', FACTS);
+    expect(truncated.plan?.name).toBe("Cut off");
+    expect(truncated.issues.join(" ")).toContain("ended before </Plan>");
+  });
+
+  it("issues read as sentences a person could say, never error codes", () => {
+    const result = compilePlan(
+      `<Plan>
+         <Group tab="Overview" layout="masonry">
+           <Leaf purpose="Something"/>
+           <Leaf component="StatTile"/>
+         </Group>
+         <Server kind="magic" why="Because."/>
+         <Cannot></Cannot>
+       </Plan>`,
+      FACTS,
+    );
+    expect(result.issues.length).toBeGreaterThan(4);
+    for (const message of result.issues) {
+      expect(message.split(" ").length).toBeGreaterThan(4);
+    }
+  });
+});

--- a/packages/core/src/genui/plan/compile.ts
+++ b/packages/core/src/genui/plan/compile.ts
@@ -1,0 +1,536 @@
+/**
+ * The plan dialect compiler
+ * (docs/superpowers/plans/2026-07-28-generation-pipeline-rebuild.md, "Locked
+ * interfaces"): the brain writes a short `<Plan>` document; this reads it into
+ * the flat {@link AppPlan} the skeleton and the fill workers work from.
+ *
+ * The dialect is the wire grammar's little sibling and reuses its tokenizer
+ * (scan.ts / attributes.ts / state.ts) and its stance: pure, deterministic,
+ * TOTAL — never throws, a malformed part is dropped and reported, a truncated
+ * document yields the plan as far as it got (plans stream).
+ *
+ * Two deliberate differences from the wire compiler:
+ *
+ * - The shape is flat BY GRAMMAR. `<Plan>` holds `<Query>`, `<Group>`,
+ *   `<Server>`, `<Island>` and `<Cannot>`; a group holds `<Leaf>` elements and
+ *   nothing else. There is no production for a group inside a group, and tabs
+ *   are never written — they derive from the groups' tab labels (planTabs).
+ * - Issues are sentences, not codes. A plan issue is the WHOLE explanation
+ *   handed back to the model (or to a person) on a retry, so it names what was
+ *   wrong and what to write instead. Tokenizer issues are drained into the
+ *   same list by message, in source order.
+ *
+ * Fact checks (does the tool exist, does the component exist, can anything
+ * fire this schedule, is that query declared) run here against the caller's
+ * {@link PlanFacts}. Grammar problems DROP the offending element — there is
+ * nothing to keep; fact problems KEEP it and report, so a retry sees exactly
+ * what it wrote.
+ */
+
+import { Cron } from "croner";
+import { safeErrorMessage } from "../../errors.js";
+import type { Json } from "../../ids.js";
+import { defineOwn, isPlainObject } from "../tree-node.js";
+import { QUERY_NAME_PATTERN } from "../tree.js";
+import { parseAttributes, type ParsedAttributes } from "../wire/attributes.js";
+import { makeState, opensRoot, prescanDeclarations } from "../wire/compile.js";
+import { collectText, readName, scanCloseTag, skipComment, skipElement, skipWhitespace } from "../wire/scan.js";
+import { FAILED, type CompileState, type Failed } from "../wire/state.js";
+import type { AppPlan, PlanGroup, PlanLeaf, PlanQuery, PlanServer } from "./types.js";
+
+/** What the host actually has, for the fact checks. */
+export interface PlanFacts {
+  tools: readonly string[];
+  components: readonly string[];
+}
+
+/** `plan` is absent only when there was no `<Plan>` document to read at all;
+ *  otherwise it is the plan as far as it parsed, and `issues` says what a
+ *  rewrite has to fix. */
+export interface PlanCompileResult {
+  plan?: AppPlan;
+  issues: string[];
+}
+
+/** One worker writes one whole group, and five parts is the most a group can
+ *  hold together (spec: groups are the coherence unit). */
+const PLAN_MAX_GROUP_LEAVES = 5;
+
+/** A leaf's own fields; every other attribute is an arrangement hint
+ *  (col/row/span) and rides along in `attrs`. */
+const LEAF_FIELDS: ReadonlySet<string> = new Set(["component", "query", "purpose"]);
+
+const PLAN_CLOSE = "</Plan>";
+const CANNOT_CLOSE = "</Cannot>";
+const NO_NAMES: ReadonlySet<string> = new Set();
+
+/** At most this many host names are listed in one issue — a teaching sentence
+ *  stops teaching once it becomes a catalog dump. */
+const MAX_LISTED_NAMES = 12;
+
+const nameList = (names: readonly string[]): string => {
+  if (names.length === 0) return "none at all";
+  const shown = names.slice(0, MAX_LISTED_NAMES).join(", ");
+  return names.length <= MAX_LISTED_NAMES ? shown : `${shown}, and ${names.length - MAX_LISTED_NAMES} more`;
+};
+
+/** Names a wrong attribute value inside a sentence without dumping it. */
+const describe = (value: unknown): string => {
+  if (value === undefined) return "nothing";
+  if (typeof value === "string") return `"${value}"`;
+  if (Array.isArray(value)) return "a list";
+  if (typeof value === "object" && value !== null) return "an object";
+  return String(value);
+};
+
+const EXCERPT_LENGTH = 60;
+
+const excerpt = (text: string): string => {
+  const line = text.replace(/\s+/g, " ");
+  return line.length <= EXCERPT_LENGTH ? line : `${line.slice(0, EXCERPT_LENGTH)}…`;
+};
+
+interface PlanState {
+  state: CompileState;
+  issues: string[];
+  facts: PlanFacts;
+  tools: ReadonlySet<string>;
+  components: ReadonlySet<string>;
+  /** Every grammar-valid `<Query id>` in the document, pre-scanned, so a leaf
+   *  may reference a query declared further down. */
+  queryIds: ReadonlySet<string>;
+}
+
+/** The tokenizer records its own kebab-coded issues on the compile state; the
+ *  plan speaks sentences, so they are drained by message in source order. */
+const drain = (plan: PlanState): void => {
+  for (const entry of plan.state.issues.splice(0)) plan.issues.push(entry.message);
+};
+
+/** Reads one open tag's attributes. Every plan element is a `declaration`:
+ *  `id`/`name` are the element's own fields and no action compilation runs. */
+const openTag = (plan: PlanState): ParsedAttributes | Failed => {
+  const attrs = parseAttributes(plan.state, "declaration");
+  drain(plan);
+  return attrs;
+};
+
+const skipContent = (plan: PlanState, tag: string): void => {
+  skipElement(plan.state, tag);
+  drain(plan);
+};
+
+/** A present, non-blank string attribute. */
+const stringAttr = (props: Record<string, Json> | undefined, name: string): string | undefined => {
+  const value = props?.[name];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+};
+
+const groupLabel = (group: PlanGroup): string => {
+  const label = group.title ?? group.tab;
+  return label === undefined ? "an unlabelled group" : `the group "${label}"`;
+};
+
+/** A cadence is written the way a person says it ("every Friday morning") —
+ *  the automation planner turns it into a trigger. When the model writes a
+ *  CRON instead (a bare `*` field is the tell), it is checked with the same
+ *  parser the automations engine fires on, under the same 5-field rule, so an
+ *  unfireable schedule is caught while the plan can still be rewritten rather
+ *  than silently never firing. */
+const CRON_SHAPED = /(?:^|\s)\*/;
+
+const scheduleIssue = (schedule: string): string | undefined => {
+  if (!CRON_SHAPED.test(schedule)) return undefined;
+  const fields = schedule.trim().split(/\s+/).length;
+  if (fields !== 5) {
+    return `the schedule "${schedule}" reads as a cron but has ${fields} fields instead of 5. Write a 5-field cron ("0 9 * * 5"), or just say the cadence in words ("every Friday morning").`;
+  }
+  try {
+    new Cron(schedule, { timezone: "UTC", paused: true });
+  } catch (error) {
+    return `no scheduler can read the schedule "${schedule}" (${safeErrorMessage(error)}). Write a 5-field cron ("0 9 * * 5"), or say the cadence in words ("every Friday morning").`;
+  }
+  return undefined;
+};
+
+const compileQuery = (plan: PlanState, appPlan: AppPlan): void => {
+  const attrs = openTag(plan);
+  if (attrs === FAILED) return;
+  if (!attrs.selfClosing) {
+    plan.issues.push("<Query> holds nothing — write it as one self-closing element; its content was ignored.");
+    skipContent(plan, "Query");
+  }
+  const id = attrs.props?.id;
+  if (typeof id !== "string" || !QUERY_NAME_PATTERN.test(id) || id === "state") {
+    plan.issues.push(
+      'a <Query> needs an id that is a plain identifier (and never "state") — <Query id="invoices" tool="..."/> — so leaves can point at it. This query was dropped.',
+    );
+    return;
+  }
+  if (appPlan.queries.some((query) => query.id === id)) {
+    plan.issues.push(`two queries are called "${id}" — give each one its own id. The second was dropped.`);
+    return;
+  }
+  const tool = stringAttr(attrs.props, "tool");
+  if (tool === undefined) {
+    plan.issues.push(`query "${id}" needs a tool attribute naming the host tool it reads. The query was dropped.`);
+    return;
+  }
+  if (!plan.tools.has(tool)) {
+    plan.issues.push(
+      `there is no tool called "${tool}". This host's tools are: ${nameList(plan.facts.tools)}. Point query "${id}" at one of those, or say what you cannot do in a <Cannot> line.`,
+    );
+  }
+  const query: PlanQuery = { id, tool, input: {} };
+  const input = attrs.props?.input;
+  if (input !== undefined) {
+    if (isPlainObject(input)) {
+      query.input = input;
+    } else {
+      plan.issues.push(`query "${id}" input must be an object — input={{ limit: 20 }}. The input was dropped.`);
+    }
+  }
+  appPlan.queries.push(query);
+};
+
+const compileLeaf = (plan: PlanState, group: PlanGroup): PlanLeaf | undefined => {
+  const attrs = openTag(plan);
+  if (attrs === FAILED) return undefined;
+  if (!attrs.selfClosing) {
+    plan.issues.push("<Leaf> holds nothing — write it as one self-closing element; its content was ignored.");
+    skipContent(plan, "Leaf");
+  }
+  const props = attrs.props ?? {};
+  const component = stringAttr(props, "component");
+  if (component === undefined) {
+    plan.issues.push(
+      `a leaf in ${groupLabel(group)} says no component — <Leaf component="DataTable" purpose="..."/> — so nothing could show it. The leaf was dropped.`,
+    );
+    return undefined;
+  }
+  const purpose = stringAttr(props, "purpose");
+  if (purpose === undefined) {
+    plan.issues.push(
+      `the ${component} leaf in ${groupLabel(group)} needs a purpose saying in one sentence what it shows, because that sentence is all the worker writing it gets. The leaf was dropped.`,
+    );
+    return undefined;
+  }
+  if (!plan.components.has(component)) {
+    plan.issues.push(
+      `there is no component called "${component}". The components you can use are: ${nameList(plan.facts.components)}. Pick the closest fit, or declare an <Island> when none of them can express it.`,
+    );
+  }
+  const leaf: PlanLeaf = { component, purpose };
+  const query = stringAttr(props, "query");
+  if (query !== undefined) {
+    leaf.query = query;
+    if (!plan.queryIds.has(query)) {
+      plan.issues.push(
+        `the ${component} leaf reads a query called "${query}", but this plan declares no <Query id="${query}">. Declare it at the top of the plan, or drop the query attribute.`,
+      );
+    }
+  }
+  const arrangement: Record<string, string> = {};
+  for (const [key, value] of Object.entries(props)) {
+    if (LEAF_FIELDS.has(key)) continue;
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      defineOwn(arrangement, key, String(value));
+    } else {
+      plan.issues.push(
+        `the ${component} leaf's "${key}" is an arrangement hint like col="2", and ${describe(value)} cannot be one. It was dropped.`,
+      );
+    }
+  }
+  if (Object.keys(arrangement).length > 0) leaf.attrs = arrangement;
+  return leaf;
+};
+
+/** A group's children: `<Leaf>` elements only. Returns how many leaves the
+ *  per-group cap dropped. Exits on `</Group>`, at EOF, or — rewinding so the
+ *  enclosing loop still sees it — on any other close tag. */
+const compileGroupChildren = (plan: PlanState, group: PlanGroup): number => {
+  const state = plan.state;
+  let dropped = 0;
+  for (;;) {
+    const loose = collectText(state).trim();
+    if (loose.length > 0) {
+      plan.issues.push(
+        `"${excerpt(loose)}" sits loose inside ${groupLabel(group)}, which holds <Leaf> elements only; it was ignored.`,
+      );
+    }
+    if (state.index >= state.source.length) return dropped;
+    const comment = skipComment(state);
+    if (comment === "eof") return dropped;
+    if (comment === "skipped") continue;
+    if (state.source[state.index + 1] === "/") {
+      const before = state.index;
+      const close = scanCloseTag(state);
+      if (close === FAILED) return dropped;
+      if (close.name === "Group") return dropped;
+      state.index = before;
+      plan.issues.push(`${groupLabel(group)} was never closed — its </Group> is missing. It was closed for you.`);
+      return dropped;
+    }
+    state.index += 1;
+    const tag = readName(state);
+    if (tag.length === 0) {
+      if (state.index >= state.source.length) return dropped;
+      continue;
+    }
+    if (tag === "Leaf") {
+      const leaf = compileLeaf(plan, group);
+      if (leaf === undefined) continue;
+      if (group.leaves.length >= PLAN_MAX_GROUP_LEAVES) {
+        dropped += 1;
+        continue;
+      }
+      group.leaves.push(leaf);
+      continue;
+    }
+    plan.issues.push(
+      tag === "Group"
+        ? "a group cannot sit inside a group: a plan is two levels deep — groups hold leaves, and tabs come from each group's tab label. The nested group and everything in it was dropped."
+        : `<${tag}> means nothing inside a group, which holds <Leaf> elements only. It was dropped.`,
+    );
+    const attrs = openTag(plan);
+    if (attrs === FAILED) return dropped;
+    if (!attrs.selfClosing) skipContent(plan, tag);
+  }
+};
+
+const compileGroup = (plan: PlanState, appPlan: AppPlan): void => {
+  const attrs = openTag(plan);
+  if (attrs === FAILED) return;
+  const group: PlanGroup = { leaves: [] };
+  const tab = stringAttr(attrs.props, "tab");
+  if (tab !== undefined) group.tab = tab;
+  const title = stringAttr(attrs.props, "title");
+  if (title !== undefined) group.title = title;
+  const layout = attrs.props?.layout;
+  if (layout === "stack" || layout === "grid") {
+    group.layout = layout;
+  } else if (layout !== undefined) {
+    plan.issues.push(
+      `a group's layout is "stack" or "grid", and ${describe(layout)} is neither — ${groupLabel(group)} was left as a stack.`,
+    );
+  }
+  const waits = attrs.props?.waitsForServer;
+  if (waits === true) {
+    group.waitsForServer = true;
+  } else if (waits !== undefined) {
+    plan.issues.push(
+      "waitsForServer is a bare flag — write <Group waitsForServer> when a group fills only after the server reports its interface. It was ignored.",
+    );
+  }
+  appPlan.groups.push(group);
+  const dropped = attrs.selfClosing ? 0 : compileGroupChildren(plan, group);
+  if (dropped > 0) {
+    const parts = dropped === 1 ? "part was" : `${dropped} parts were`;
+    plan.issues.push(
+      `${groupLabel(group)} holds ${PLAN_MAX_GROUP_LEAVES + dropped} parts, and one group holds at most ${PLAN_MAX_GROUP_LEAVES} — one worker writes a whole group, so split this into two groups (they can share a tab label). The last ${parts} dropped.`,
+    );
+  }
+  if (group.leaves.length === 0) {
+    plan.issues.push(
+      `${groupLabel(group)} has no parts — a group is the handful of parts that tell one story, so give it at least one <Leaf>.`,
+    );
+  }
+};
+
+const compileServer = (plan: PlanState, appPlan: AppPlan): void => {
+  const attrs = openTag(plan);
+  if (attrs === FAILED) return;
+  if (!attrs.selfClosing) {
+    plan.issues.push("<Server> holds nothing — write it as one self-closing element; its content was ignored.");
+    skipContent(plan, "Server");
+  }
+  if (appPlan.server !== undefined) {
+    plan.issues.push("a plan declares server work once — the second <Server> was dropped.");
+    return;
+  }
+  const kind = attrs.props?.kind;
+  if (kind !== "steps" && kind !== "agentic" && kind !== "box") {
+    plan.issues.push(
+      `<Server> needs kind="steps" (fixed steps on a schedule), kind="agentic" (a judgment call every run) or kind="box" (a backend the sandbox builds), and ${describe(kind)} is none of those. The server work was dropped.`,
+    );
+    return;
+  }
+  const why = stringAttr(attrs.props, "why");
+  if (why === undefined) {
+    plan.issues.push(
+      "<Server> needs a why saying in one sentence why this cannot happen in the browser — the escape has to be earned. The server work was dropped.",
+    );
+    return;
+  }
+  const server: PlanServer = { kind, why };
+  const schedule = stringAttr(attrs.props, "schedule");
+  if (schedule !== undefined) {
+    server.schedule = schedule;
+    const bad = scheduleIssue(schedule);
+    if (bad !== undefined) plan.issues.push(bad);
+  }
+  appPlan.server = server;
+};
+
+const compileIsland = (plan: PlanState, appPlan: AppPlan): void => {
+  const attrs = openTag(plan);
+  if (attrs === FAILED) return;
+  if (!attrs.selfClosing) {
+    plan.issues.push("<Island> holds nothing here — the plan only names it; its content was ignored.");
+    skipContent(plan, "Island");
+  }
+  if (appPlan.island !== undefined) {
+    plan.issues.push("a plan asks for one island at most — the second <Island> was dropped.");
+    return;
+  }
+  const name = stringAttr(attrs.props, "name");
+  const purpose = stringAttr(attrs.props, "purpose");
+  if (name === undefined || purpose === undefined) {
+    plan.issues.push(
+      'an <Island> needs a name and a purpose — <Island name="RunwayDial" purpose="..."/> — so it can be built and screened. It was dropped.',
+    );
+    return;
+  }
+  appPlan.island = { name, purpose };
+};
+
+/** `<Cannot>` carries a sentence a person reads, so its text is taken
+ *  verbatim to the first `</Cannot>` (the raw-island capture stance). */
+const compileCannot = (plan: PlanState, appPlan: AppPlan): void => {
+  const state = plan.state;
+  const attrs = openTag(plan);
+  if (attrs === FAILED) return;
+  const close = attrs.selfClosing ? -1 : state.source.indexOf(CANNOT_CLOSE, state.index);
+  if (!attrs.selfClosing && close === -1) {
+    state.index = state.source.length;
+    return;
+  }
+  const reason = attrs.selfClosing ? "" : state.source.slice(state.index, close).trim();
+  if (!attrs.selfClosing) state.index = close + CANNOT_CLOSE.length;
+  if (reason.length === 0) {
+    plan.issues.push(
+      "<Cannot> carries the sentence the person reads — <Cannot>Your host has no way to send email.</Cannot>. The empty one was dropped.",
+    );
+    return;
+  }
+  appPlan.cannot.push(reason);
+};
+
+const compilePlanChildren = (plan: PlanState, appPlan: AppPlan): void => {
+  const state = plan.state;
+  for (;;) {
+    const loose = collectText(state).trim();
+    if (loose.length > 0) {
+      plan.issues.push(
+        `"${excerpt(loose)}" sits loose inside <Plan>, where only elements mean anything; it was ignored. An explanation belongs in a <Cannot> line or a leaf's purpose.`,
+      );
+    }
+    if (state.index >= state.source.length) break;
+    const comment = skipComment(state);
+    if (comment === "eof") break;
+    if (comment === "skipped") continue;
+    if (state.source[state.index + 1] === "/") {
+      const close = scanCloseTag(state);
+      if (close === FAILED) break;
+      if (close.name === "Plan") return;
+      plan.issues.push(`</${close.name}> closes nothing that is open here; it was ignored.`);
+      continue;
+    }
+    state.index += 1;
+    const tag = readName(state);
+    if (tag.length === 0) {
+      if (state.index >= state.source.length) break;
+      continue;
+    }
+    if (tag === "Query") {
+      compileQuery(plan, appPlan);
+      continue;
+    }
+    if (tag === "Group") {
+      compileGroup(plan, appPlan);
+      continue;
+    }
+    if (tag === "Server") {
+      compileServer(plan, appPlan);
+      continue;
+    }
+    if (tag === "Island") {
+      compileIsland(plan, appPlan);
+      continue;
+    }
+    if (tag === "Cannot") {
+      compileCannot(plan, appPlan);
+      continue;
+    }
+    plan.issues.push(
+      tag === "Leaf"
+        ? "a <Leaf> belongs inside a <Group>, never straight in the plan — the group is what one worker writes. It was dropped."
+        : `<${tag}> is not part of a plan, which holds <Query>, <Group> (of <Leaf> elements), <Server>, <Island> and <Cannot>. It was dropped.`,
+    );
+    const attrs = openTag(plan);
+    if (attrs === FAILED) break;
+    if (!attrs.selfClosing) skipContent(plan, tag);
+  }
+  plan.issues.push("the plan ended before </Plan>, so it was read only as far as it got. Write it again whole.");
+};
+
+/** Models wrap output in prose or a markdown fence despite instructions (the
+ *  engine's extractWire tolerance): the plan is everything from the first
+ *  `<Plan` through the last `</Plan>`, or the tail while it is still open. */
+const extractPlan = (text: string): string => {
+  const start = text.indexOf("<Plan");
+  if (start === -1) return text;
+  const close = text.lastIndexOf(PLAN_CLOSE);
+  return close === -1 ? text.slice(start) : text.slice(start, close + PLAN_CLOSE.length);
+};
+
+const compilePlanUnsafe = (text: string, facts: PlanFacts): PlanCompileResult => {
+  const source = extractPlan(text);
+  const declared = prescanDeclarations(source, "Plan");
+  const state = makeState(source, declared.queryNames, NO_NAMES, NO_NAMES);
+  const plan: PlanState = {
+    state,
+    issues: [],
+    facts,
+    tools: new Set(facts.tools),
+    components: new Set(facts.components),
+    queryIds: declared.queryNames,
+  };
+  skipWhitespace(state);
+  if (!opensRoot(state, "Plan")) {
+    return { issues: ['I could not find a plan here: a plan is one <Plan name="...">...</Plan> document and nothing else.'] };
+  }
+  state.index += 5; // consume "<Plan"
+  const head = openTag(plan);
+  if (head === FAILED) {
+    plan.issues.push("the <Plan ...> tag was cut off before it closed, so there was no plan to read.");
+    return { issues: plan.issues };
+  }
+  const name = stringAttr(head.props, "name");
+  if (name === undefined) {
+    plan.issues.push('the plan needs a name — <Plan name="Invoices workspace"> — because it becomes the app\'s title.');
+  }
+  const appPlan: AppPlan = { name: name ?? "", queries: [], groups: [], cannot: [] };
+  if (!head.selfClosing) compilePlanChildren(plan, appPlan);
+  if (appPlan.groups.length === 0 && appPlan.cannot.length === 0) {
+    plan.issues.push(
+      "this plan says nothing: it needs at least one <Group> of leaves, or a <Cannot> line explaining honestly why the ask cannot be built here.",
+    );
+  }
+  return { plan: appPlan, issues: plan.issues };
+};
+
+/**
+ * Read one `<Plan>` document into an {@link AppPlan}, checking it against what
+ * the host actually has. Pure, deterministic and total: never throws — an
+ * unexpected failure degrades to a single issue and no plan.
+ */
+export function compilePlan(text: string, facts: PlanFacts): PlanCompileResult {
+  try {
+    return compilePlanUnsafe(text, facts);
+  } catch (error) {
+    return {
+      issues: [`the plan could not be read (${safeErrorMessage(error)}); write it again as one <Plan> document.`],
+    };
+  }
+}

--- a/packages/core/src/genui/plan/types.ts
+++ b/packages/core/src/genui/plan/types.ts
@@ -1,0 +1,79 @@
+/**
+ * The app plan — what the brain writes before workers fill anything in
+ * (docs/superpowers/plans/2026-07-28-generation-pipeline-rebuild.md, "Locked
+ * interfaces"; design in
+ * docs/superpowers/specs/2026-07-28-generation-pipeline-v2-design.md).
+ *
+ * ONE shape, flat: queries, then groups of leaves, plus the rare escapes
+ * (island, server work) and honest refusals. Structure is exactly two levels
+ * deep — groups hold leaves, nothing holds groups — because a group is the
+ * coherence unit one fill worker writes whole. Arrangement inside a group is
+ * attributes (col/row/span), never nesting.
+ *
+ * Tabs are NOT part of the shape: they derive from the groups' tab labels
+ * (see {@link planTabs}).
+ */
+
+/** One host-data read the plan declares once and leaves reference by id.
+ *  Executed at plan time (read-risk only), so workers see real sample rows. */
+export interface PlanQuery {
+  id: string;
+  tool: string;
+  input: Record<string, unknown>;
+}
+
+/** One part of a group: which component shows it, which query feeds it, and
+ *  one sentence of what it is for. `attrs` carries arrangement hints
+ *  (col/row/span) as written. */
+export interface PlanLeaf {
+  component: string;
+  query?: string;
+  purpose: string;
+  attrs?: Record<string, string>;
+}
+
+/** A handful of parts that must tell one story — written by one worker. */
+export interface PlanGroup {
+  /** Tabs derive from these labels, in order of first appearance; groups
+   *  without one belong to a single-surface app. */
+  tab?: string;
+  title?: string;
+  layout?: "stack" | "grid";
+  /** This group fills after the sandbox box reports its real interface. */
+  waitsForServer?: boolean;
+  leaves: PlanLeaf[];
+}
+
+/** A custom component the plan asks for because no component can express it. */
+export interface PlanIsland {
+  name: string;
+  purpose: string;
+}
+
+/** Work that cannot happen in the browser: scheduled steps, an agentic run,
+ *  or a backend the sandbox builds. `why` is the earned justification. */
+export interface PlanServer {
+  kind: "steps" | "agentic" | "box";
+  schedule?: string;
+  why: string;
+}
+
+export interface AppPlan {
+  name: string;
+  queries: PlanQuery[];
+  groups: PlanGroup[];
+  island?: PlanIsland;
+  server?: PlanServer;
+  /** Honest refusals, verbatim user-facing. */
+  cannot: string[];
+}
+
+/** The app's tabs: each distinct group tab label, in order of first
+ *  appearance. Empty means one surface with no tab chrome. */
+export const planTabs = (plan: AppPlan): string[] => {
+  const tabs: string[] = [];
+  for (const group of plan.groups) {
+    if (group.tab !== undefined && !tabs.includes(group.tab)) tabs.push(group.tab);
+  }
+  return tabs;
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,6 +48,19 @@ export { WIRE_ISSUE_CODES, type WireIssue, type WireIssueCode } from "./genui/wi
 export { compileWirePatch, type PatchExtensionOp, type WirePatchBase, type WirePatchOptions, type WirePatchResult } from "./genui/wire/patch.js";
 export { printWire, type WirePrintInput, type WirePrintOptions } from "./genui/wire/print.js";
 export { checkBindingShapes, type BindingShapeError } from "./genui/wire/shape-check.js";
+// genui/plan — the plan dialect the brain writes before workers fill anything
+// in (generation pipeline rebuild, "Locked interfaces"): the flat AppPlan
+// shape plus its compiler, whose fact checks speak sentences, not codes.
+export { compilePlan, type PlanCompileResult, type PlanFacts } from "./genui/plan/compile.js";
+export {
+  planTabs,
+  type AppPlan,
+  type PlanGroup,
+  type PlanIsland,
+  type PlanLeaf,
+  type PlanQuery,
+  type PlanServer,
+} from "./genui/plan/types.js";
 
 // Deprecated aliases from the pre-de-versioning naming (0.4.x). Remove next minor.
 /** @deprecated Use compileWire. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1194,6 +1194,9 @@ importers:
 
   packages/core:
     dependencies:
+      croner:
+        specifier: ^9.0.0
+        version: 9.1.0
       zod:
         specifier: ^3.25.0
         version: 3.25.76


### PR DESCRIPTION
Task 1 of the generation pipeline rebuild plan (`docs/superpowers/plans/2026-07-28-generation-pipeline-rebuild.md`). Front half of the new pipeline's vocabulary: the brain's plan, read into a shape the skeleton and the fill workers can work from.

## What it builds

- `packages/core/src/genui/plan/types.ts` — the locked flat `AppPlan`: `queries`, `groups` of `leaves`, optional `island` / `server`, and `cannot`. Plus `planTabs(plan)`: tabs are not written anywhere, they DERIVE from each group's `tab` label in order of first appearance (Task 5's skeleton renders exactly this).
- `packages/core/src/genui/plan/compile.ts` — `compilePlan(text, facts)` with `facts = { tools, components }`. Reuses the wire tokenizer (`scan.ts` / `attributes.ts` / `state.ts`) and its stance: pure, deterministic, TOTAL (never throws), and forgiving about fences and prose the way `extractWire` is. Plans stream, so a truncated document yields the plan as far as it got.
- Exported from `packages/core/src/index.ts`.

Two deliberate departures from the wire compiler, both stated in the module header:

1. **Flat by grammar.** `<Group>` holds `<Leaf>` elements and nothing else — there is no production for a group inside a group, so the nesting the old contract had to forbid in prose is simply unwritable.
2. **Issues are sentences, not codes.** A plan issue is the whole explanation a retry (or a person) gets, so it names what was wrong and what to write instead. The tokenizer's own kebab-coded issues are drained into the same list by message, in source order.

Rule for what survives a problem: **grammar problems drop the element** (there is nothing to keep); **fact problems keep it and report**, so the retry sees exactly what it wrote.

## Named rejection tests (`compile.test.ts`, 12 tests)

| test | what it pins |
| --- | --- |
| parses the full example to the locked flat plan | `<Query>` + two tab labels + `<Server kind schedule why>` + `<Island>` + two `<Cannot>` lines, inside prose and a fence, → the locked shape exactly, zero issues |
| derives two tabs from the group labels, in order of first appearance | `planTabs` → `["Overview", "Payments"]` from three groups |
| parses groups without tab labels as one surface | unlabelled groups are legal; `planTabs` → `[]` |
| drops the sixth leaf in a group and says to split the group | cap is 5 (one worker writes one whole group) |
| cannot write a group inside a group | nested group + subtree dropped, one teaching sentence |
| names an unknown tool and lists the host's real ones | `stripe_invoices_list` → names it, lists the host's tools |
| names an unknown component and lists the real ones | same, for components |
| reports a schedule no scheduler can read | `0 99 * * *` |
| reports a cron with the wrong number of fields | `0 9 * *` |
| reports a leaf reading a query the plan never declared | dangling `query="overdue"` |
| reports missing structure instead of throwing | no `<Plan>` at all; a cut-off plan still yields its name |
| issues read as sentences a person could say, never error codes | every issue in a plan full of mistakes is a sentence |

Each of the four constant-driven rejections was mutation-checked (cap 5→6, cron detector disabled, nested-group branch renamed) — all four fail when the rule is removed, so none of the tests is vacuous.

## One judgment call to flag

`schedule` is a cadence written the way a person says it (`schedule="fridays"` in the plan's own example) — the existing `planAutomation` path turns it into a trigger. So the fact check is: a bare `*` field means the model wrote a CRON instead, and then it is validated with **the same parser the automations engine fires on** (croner, same 5-field rule as `automation-plan.ts`), rather than two cron validators drifting apart in one repo. That adds `croner@^9` to `@vendoai/core` (already in the lockfile via `apps` and `automations`; zero-dependency, and it passes the portability gate for the Worker target). Words are passed through untouched.

## Gate

`pnpm --filter @vendoai/core build` · `test` (44 files, 716 tests) · `typecheck` · root `pnpm lint` (dependency-guard, portability-gate, turbo lint) — all green. No UI surface in this task.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a plan dialect compiler that reads a `<Plan>` into a flat `AppPlan` and reports human-readable issues. Tabs now derive from group labels via `planTabs`, and cron-like schedules are validated with `croner`.

- **New Features**
  - `compilePlan(text, facts)` builds a flat `AppPlan` (queries, groups of leaves, optional `island`/`server`, `cannot`) and returns `{ plan, issues }`; pure and never throws.
  - Flat grammar: `<Group>` holds only `<Leaf>` elements; max 5 leaves per group; tabs derive from group `tab` labels with `planTabs(plan)`.
  - Fact checks: tools/components exist, leaves reference declared queries, and schedules are valid; grammar drops the element, fact issues keep it and report.
  - Adds plan types (`types.ts`) and exports everything from `@vendoai/core`; tests cover parsing, tabs, caps, nesting, and validations.

- **Dependencies**
  - Add `croner@^9.0.0` to `@vendoai/core` to validate 5-field cron schedules; natural-language cadences pass through.

<sup>Written for commit 724c152e88c83f11100b6659bc33295ec9076507. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

