### PR TITLE
feat(apps): plug-in checking layer with built-in fact checks

### DIFF
--- a/packages/apps/src/checking/checking.test.ts
+++ b/packages/apps/src/checking/checking.test.ts
@@ -1,0 +1,223 @@
+/**
+ * The checking layer (generation pipeline rebuild, Task 3): the plug-in shape
+ * every check speaks, the parallel run that flat-merges their findings, and
+ * the built-in FACT checks — whose messages must teach (name the real
+ * alternative), because a model repairs from them and a human reads them.
+ */
+import {
+  VENDO_APP_FORMAT,
+  compileWire,
+  type NormalizedCatalog,
+  type ShapeType,
+} from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createCheckingLayer } from "./layer.js";
+import type { Check, CheckInput } from "./types.js";
+import type {
+  GeneratedAppDocument,
+  GenerationDependencies,
+  HostToolInfo,
+} from "../generation/engine.js";
+import { scriptedLanguageModel } from "../testing/scripted-model.js";
+
+const tools: HostToolInfo[] = [
+  {
+    name: "host_listInvoices",
+    description: "Open invoices",
+    risk: "read",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "host_listClients",
+    description: "Clients",
+    risk: "read",
+    inputSchema: { type: "object", properties: {} },
+  },
+];
+
+const toolShapes: Record<string, ShapeType> = {
+  host_listInvoices: {
+    kind: "object",
+    fields: {
+      data: {
+        kind: "array",
+        items: {
+          kind: "object",
+          fields: {
+            id: { kind: "string" },
+            client: { kind: "string" },
+            amountCents: { kind: "number" },
+          },
+        },
+      },
+    },
+  },
+};
+
+const catalog: NormalizedCatalog = [];
+
+const deps = (): GenerationDependencies => ({
+  model: scriptedLanguageModel(() => "<App name=\"unused\"/>"),
+  catalog,
+  tools,
+  toolShapes,
+});
+
+/** A document as the engine would emit it, compiled from wire so the tree is
+ *  the real thing rather than a hand-built lookalike. */
+const documentFrom = (wire: string): GeneratedAppDocument => {
+  const compiled = compileWire(wire, { toolShapes });
+  return {
+    format: VENDO_APP_FORMAT,
+    name: compiled.name ?? "Untitled",
+    ui: "tree",
+    tree: compiled.tree as GeneratedAppDocument["tree"],
+  };
+};
+
+const inputFor = (wire: string, request = "show me my invoices"): CheckInput =>
+  ({ app: documentFrom(wire), request });
+
+const cleanApp =
+  '<App name="Invoices"><Query id="invoices" tool="host_listInvoices"/><Stack gap={12}><Text text="Invoices" variant="heading"/><Table rows={invoices.data}/></Stack></App>';
+
+/** Blocks every arrival until `count` of them have arrived: a check that gets
+ *  past it can only have done so alongside the others. */
+const barrier = (count: number): (() => Promise<void>) => {
+  let arrived = 0;
+  let release: () => void = () => undefined;
+  const open = new Promise<void>((resolve) => { release = resolve; });
+  return async () => {
+    arrived += 1;
+    if (arrived === count) release();
+    await open;
+  };
+};
+
+describe("checking layer", () => {
+  it("runs checks in parallel and flat-merges their findings", async () => {
+    const arrive = barrier(2);
+    let ran = 0;
+    const gated = (name: string): Check => ({
+      name,
+      run: async () => {
+        await arrive();
+        ran += 1;
+        return [{ severity: "warn", where: name, message: `${name} ran` }];
+      },
+    });
+
+    const layer = createCheckingLayer({ deps: deps(), checks: [gated("one"), gated("two")] });
+    // Serial execution would deadlock on the barrier; reaching an assertion at
+    // all is the parallelism proof.
+    const findings = await layer.run(inputFor(cleanApp));
+
+    expect(ran).toBe(2);
+    // Flat, not nested: one array of findings, whatever each check returned.
+    expect(findings).toEqual(expect.arrayContaining([
+      { severity: "warn", where: "one", message: "one ran" },
+      { severity: "warn", where: "two", message: "two ran" },
+    ]));
+    expect(findings.every((finding) => typeof finding.message === "string")).toBe(true);
+  });
+
+  it("surfaces a host-registered check's findings alongside the built-ins", async () => {
+    const hostCheck: Check = {
+      name: "maple-house-style",
+      run: async ({ request }) => [{
+        severity: "block",
+        where: 'node "n2"',
+        message: `Maple never shows a bare table for "${request}" — wrap it in a Card`,
+      }],
+    };
+
+    const layer = createCheckingLayer({ deps: deps(), checks: [hostCheck] });
+    const findings = await layer.run(inputFor(cleanApp, "list my invoices"));
+
+    expect(layer.checks.map(({ name }) => name)).toContain("maple-house-style");
+    // Appended, never replacing: every built-in fact check is still registered.
+    expect(layer.checks.map(({ name }) => name)).toEqual(expect.arrayContaining([
+      "document", "tools-exist", "components-exist", "bindings-fit",
+      "query-inputs-literal", "no-string-interpolation", "maple-house-style",
+    ]));
+    expect(findings).toContainEqual({
+      severity: "block",
+      where: 'node "n2"',
+      message: 'Maple never shows a bare table for "list my invoices" — wrap it in a Card',
+    });
+  });
+
+  it("turns a check that throws into a warn finding naming it, never a crash", async () => {
+    const exploding: Check = {
+      name: "reviewer",
+      run: async () => { throw new Error("model call timed out"); },
+    };
+
+    const layer = createCheckingLayer({ deps: deps(), checks: [exploding] });
+    const findings = await layer.run(inputFor(cleanApp));
+
+    const crash = findings.find(({ where }) => where === "reviewer");
+    expect(crash).toEqual({
+      severity: "warn",
+      where: "reviewer",
+      message: 'the check "reviewer" failed to run (model call timed out), so whatever it would have found is missing from this report',
+    });
+    // The rest of the layer still reported: a broken check costs its findings,
+    // not the run.
+    expect(findings.filter(({ where }) => where !== "reviewer")).toEqual([]);
+  });
+
+  it("passes a clean app with no findings", async () => {
+    const layer = createCheckingLayer({ deps: deps() });
+    expect(await layer.run(inputFor(cleanApp))).toEqual([]);
+  });
+});
+
+describe("built-in fact checks", () => {
+  it("names the real tools when a query names one the host does not have", async () => {
+    const layer = createCheckingLayer({ deps: deps() });
+    const findings = await layer.run(inputFor(
+      '<App name="Invoices"><Query id="invoices" tool="host_getInvoices"/><Stack><Table rows={invoices.data}/></Stack></App>',
+    ));
+
+    const finding = findings.find(({ where }) => where === 'query "invoices"');
+    expect(finding?.severity).toBe("block");
+    expect(finding?.message).toContain('unknown tool "host_getInvoices"');
+    expect(finding?.message).toContain("host_listInvoices, host_listClients");
+  });
+
+  it("names the real fields when a binding reaches a field the tool shape has not got", async () => {
+    const layer = createCheckingLayer({ deps: deps() });
+    const findings = await layer.run(inputFor(
+      '<App name="Invoices"><Query id="invoices" tool="host_listInvoices"/><Stack><Text text={invoices.data.0.customer}/></Stack></App>',
+    ));
+
+    const finding = findings.find(({ where }) => where.includes('prop "text"'));
+    expect(finding?.severity).toBe("block");
+    expect(finding?.message).toContain("the real fields are: id, client, amountCents");
+  });
+
+  it("names the allowed props when a prewired component is given one it has not got", async () => {
+    const layer = createCheckingLayer({ deps: deps() });
+    const findings = await layer.run(inputFor(
+      '<App name="Invoices"><Query id="invoices" tool="host_listInvoices"/><Stack><Table data={invoices.data}/></Stack></App>',
+    ));
+
+    const finding = findings.find(({ message }) => message.includes('unknown prop "data"'));
+    expect(finding?.severity).toBe("block");
+    expect(finding?.message).toContain("Allowed props: ");
+    expect(finding?.message).toContain("rows");
+  });
+
+  it("blocks a document with no title and says what name is for", async () => {
+    const layer = createCheckingLayer({ deps: deps() });
+    const app = documentFrom(cleanApp);
+    const findings = await layer.run({ app: { ...app, name: "" }, request: "invoices" });
+
+    expect(findings).toContainEqual({
+      severity: "block",
+      where: "document",
+      message: 'must carry a non-empty name="..." attribute',
+    });
+  });
+});

--- a/packages/apps/src/checking/facts.ts
+++ b/packages/apps/src/checking/facts.ts
@@ -1,0 +1,443 @@
+/**
+ * The built-in FACT checks: everything about a generated app that can be
+ * decided by looking things up rather than by judgement — the document parses
+ * and validates, its queries name tools the host really has, its nodes name
+ * components the catalog really carries, and its bindings reach fields the
+ * tool shapes really expose with types the props really accept.
+ *
+ * These helpers are the single home for that machinery. The create/edit
+ * validator (generation/validation/validate.ts) flattens the same anchored
+ * issues into its own issue strings, so there is one implementation and one
+ * message per fact for as long as both callers exist.
+ *
+ * Judgement checks (invented data, dishonest tool use, dead buttons, sections
+ * that miss the ask) are NOT here — they belong to the AI reviewer.
+ */
+import {
+  KIT_WIRE_COMPONENT_NAMES,
+  WIRE_COMPONENT_NAMES,
+  VENDO_TREE_FORMAT,
+  checkBindingShapes,
+  kitSpec,
+  shapeAtPointer,
+  isPathBinding,
+  isStateBinding,
+  validateAppDocument,
+  validateTree,
+  type NormalizedCatalog,
+  type ShapeType,
+  type Tree,
+  type TreeNode,
+} from "@vendoai/core";
+import { prewiredPropNames } from "../prewired-schema.js";
+import { APP_NAME_MAX_CHARS } from "../generation/contracts/sections.js";
+import type {
+  GeneratedAppDocument,
+  GenerationDependencies,
+  HostToolInfo,
+} from "../generation/engine.js";
+import type { Check, Finding } from "./types.js";
+
+/** One fact issue, anchored: `where` is the locus, `message` continues the
+ *  sentence from it. Read as one line (`node "n3" prop "rows" binds …`) they
+ *  are the validator's issue strings; read as a pair they are a {@link Finding}. */
+export interface FactIssue {
+  where: string;
+  message: string;
+}
+
+/** The validator's flat issue-string form of an anchored fact issue. */
+export const factIssueLine = ({ where, message }: FactIssue): string => `${where} ${message}`;
+
+const atNode = (nodeId: string, message: string): FactIssue => ({ where: `node "${nodeId}"`, message });
+const atProp = (nodeId: string, prop: string, message: string): FactIssue =>
+  ({ where: `node "${nodeId}" prop "${prop}"`, message });
+
+const reserved = new Set<string>(WIRE_COMPONENT_NAMES);
+
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isActionBinding = (value: unknown): boolean =>
+  isRecord(value) && typeof value.action === "string";
+
+export const isRuntimeBound = (value: unknown): boolean =>
+  isPathBinding(value) || isStateBinding(value) || isActionBinding(value);
+
+/** Conservative kind check between a bound field's shape and the host prop's
+ *  declared JSON-schema type: only CLEAR mismatches flag (an array of objects
+ *  where number[] is expected renders an empty chart — the silent-breakage
+ *  class); unknown shapes/schemas stay silent. */
+const shapeSchemaMismatch = (shape: ShapeType, schema: Record<string, unknown>): string | null => {
+  const type = typeof schema.type === "string" ? schema.type : undefined;
+  if (type === undefined || shape.kind === "json") return null;
+  if (type === "array") {
+    if (shape.kind !== "array") return `expected an array, the bound field is ${shape.kind}`;
+    const items = schema.items;
+    return isRecord(items) ? shapeSchemaMismatch(shape.items, items) : null;
+  }
+  if (type === "number" || type === "integer") {
+    return shape.kind === "number" ? null : `expected a number, the bound field is ${shape.kind}`;
+  }
+  if (type === "string") return shape.kind === "string" ? null : `expected a string, the bound field is ${shape.kind}`;
+  if (type === "boolean") return shape.kind === "boolean" ? null : `expected a boolean, the bound field is ${shape.kind}`;
+  if (type === "object") return shape.kind === "object" ? null : `expected an object, the bound field is ${shape.kind}`;
+  return null;
+};
+
+/** With tool shapes AND the catalog's prop schemas both in hand, a top-level
+ *  `$path` prop on a host node can be kind-checked end to end. Existence is
+ *  the wire compiler's shape check; this catches the type mismatches that
+ *  render silently broken (empty chart, blank stat). */
+export const bindingKindIssues = (tree: Tree, deps: GenerationDependencies): FactIssue[] => {
+  if (deps.toolShapes === undefined) return [];
+  const issues: FactIssue[] = [];
+  const queryTool = new Map((tree.queries ?? []).map((query) => [query.name, query.tool]));
+  const hostSchemas = new Map(deps.catalog.map((component) => [component.name, component.propsJsonSchema]));
+  for (const node of tree.nodes) {
+    if (node.source !== "host" || node.props === undefined) continue;
+    const schema = hostSchemas.get(node.component);
+    const properties = isRecord(schema) && isRecord(schema.properties) ? schema.properties : undefined;
+    if (properties === undefined) continue;
+    for (const [prop, value] of Object.entries(node.props)) {
+      if (!isPathBinding(value)) continue;
+      const [, queryName = "", ...rest] = value.$path.split("/");
+      const tool = queryTool.get(queryName);
+      const toolShape = tool === undefined ? undefined : deps.toolShapes[tool];
+      if (toolShape === undefined) continue;
+      const bound = shapeAtPointer(toolShape, rest.length === 0 ? "" : `/${rest.join("/")}`);
+      if (bound === undefined) continue;
+      const propSchema = properties[prop];
+      if (!isRecord(propSchema)) continue;
+      const mismatch = shapeSchemaMismatch(bound, propSchema);
+      if (mismatch !== null) {
+        issues.push(atProp(node.id, prop, `binds ${value.$path}: ${mismatch} — bind a field whose shape matches the component's prop type`));
+      }
+    }
+  }
+  return issues;
+};
+
+/** asPoints/asOptions produce generic {label,value}/{value,label} items; a
+ *  HOST prop whose schema declares its OWN item field names cannot read them
+ *  (live finding: the Maple donut drew $NaN). The raw rows are the legal
+ *  binding — reject the reshape at compile. */
+const GENERIC_ITEM_RESHAPES = new Set(["asPoints", "asOptions"]);
+
+export const hostReshapeIssues = (tree: Tree, deps: GenerationDependencies): FactIssue[] => {
+  const issues: FactIssue[] = [];
+  const hostSchemas = new Map(deps.catalog.map((component) => [component.name, component.propsJsonSchema]));
+  for (const node of tree.nodes) {
+    if (node.source !== "host" || node.props === undefined) continue;
+    const schema = hostSchemas.get(node.component);
+    const properties = isRecord(schema) && isRecord(schema.properties) ? schema.properties : undefined;
+    if (properties === undefined) continue;
+    for (const [prop, value] of Object.entries(node.props)) {
+      if (!isPathBinding(value)) continue;
+      const reshape = (value as unknown as { $reshape?: Array<{ op?: string }> }).$reshape;
+      if (!Array.isArray(reshape) || !reshape.some((step) => GENERIC_ITEM_RESHAPES.has(step?.op ?? ""))) continue;
+      const propSchema = properties[prop];
+      const items = isRecord(propSchema) && isRecord(propSchema.items) ? propSchema.items : undefined;
+      const itemProperties = items !== undefined && isRecord(items.properties) ? Object.keys(items.properties) : [];
+      if (itemProperties.length === 0) continue;
+      if (itemProperties.includes("label") && itemProperties.includes("value")) continue;
+      issues.push(atProp(node.id, prop, `reshapes with asPoints/asOptions, but host component "${node.component}" declares its own item fields (${itemProperties.join(", ")}) — it cannot read generic {label, value} items. Bind the RAW rows (drop the reshape) so the component receives the fields its schema names.`));
+    }
+  }
+  return issues;
+};
+
+/** Law 2 — a query input executes as LITERAL JSON: the runtime never
+ *  resolves bindings inside it, so a dependent call
+ *  (`accountId: accounts.data.0.id`) reaches the tool as an unresolved
+ *  binding object and the app ships broken. Reject at compile → repair. */
+export const queryInputIssues = (tree: Tree): FactIssue[] => {
+  const issues: FactIssue[] = [];
+  const findBinding = (value: unknown): boolean => {
+    if (isPathBinding(value) || isStateBinding(value)) return true;
+    if (Array.isArray(value)) return value.some(findBinding);
+    if (isRecord(value)) return Object.values(value).some(findBinding);
+    return false;
+  };
+  for (const query of tree.queries ?? []) {
+    if (query.input !== undefined && findBinding(query.input)) {
+      issues.push({
+        where: `query "${query.name}"`,
+        message: `(tool "${query.tool}") embeds a binding in its input — query inputs must be LITERAL JSON the tool can execute directly; another query's result can never feed a query input. Use a literal value (or drop the optional input), or build the dependent lookup inside an <Island> with ambient tools.`,
+      });
+    }
+  }
+  return issues;
+};
+
+/** Law 1 raw typing — probe values per shape kind, parsed against the Kit
+ *  prop's zod schema. Kind-level only: a string-shaped field bound into
+ *  Money.cents fails (pre-formatted money strings never reach a numeric
+ *  slot); unknown shapes stay silent. */
+const KIND_PROBES: Partial<Record<ShapeType["kind"], unknown>> = {
+  string: "probe",
+  number: 1,
+  boolean: true,
+  array: [],
+  object: {},
+};
+
+const KIT_WIRE_SET: ReadonlySet<string> = new Set(KIT_WIRE_COMPONENT_NAMES);
+
+export const kitSlotIssues = (tree: Tree, deps: GenerationDependencies): FactIssue[] => {
+  if (deps.toolShapes === undefined) return [];
+  const issues: FactIssue[] = [];
+  const queryTool = new Map((tree.queries ?? []).map((query) => [query.name, query.tool]));
+  for (const node of tree.nodes) {
+    if (node.source === "host" || node.source === "generated" || node.props === undefined) continue;
+    if (!KIT_WIRE_SET.has(node.component)) continue;
+    const spec = kitSpec(node.component);
+    if (spec === undefined) continue;
+    for (const [prop, value] of Object.entries(node.props)) {
+      if (!isPathBinding(value) || "$reshape" in (value as unknown as Record<string, unknown>)) continue;
+      const propSpec = spec.props[prop];
+      if (propSpec === undefined) continue;
+      const [, queryName = "", ...rest] = value.$path.split("/");
+      const tool = queryTool.get(queryName);
+      const shape = tool === undefined ? undefined : deps.toolShapes[tool];
+      if (shape === undefined) continue;
+      const bound = shapeAtPointer(shape, rest.length === 0 ? "" : `/${rest.join("/")}`);
+      if (bound === undefined || bound.kind === "json" || bound.kind === "null") continue;
+      const probe = KIND_PROBES[bound.kind];
+      if (probe === undefined) continue;
+      if (!propSpec.schema.safeParse(probe).success) {
+        issues.push(atProp(node.id, prop, `on <${node.component}> binds ${value.$path}, a ${bound.kind} field, but this slot takes a different RAW type (${propSpec.doc}) — bind the raw field with that type (e.g. the integer-cents field, not a pre-formatted display string).`));
+      }
+    }
+  }
+  return issues;
+};
+
+/** Models write "Total: {metric.total}" inside STRING attributes; the wire
+ *  has no string interpolation, so the braces render literally. Any string
+ *  prop embedding a declared query reference is a repair-routed error. */
+export const interpolationIssues = (tree: Tree): FactIssue[] => {
+  const queryNames = (tree.queries ?? []).map((query) => query.name);
+  if (queryNames.length === 0) return [];
+  const pattern = new RegExp(`\\{(?:${queryNames.join("|")})(?:\\.[A-Za-z0-9_]+)*\\}`);
+  const issues: FactIssue[] = [];
+  const walk = (nodeId: string, prop: string, value: unknown): void => {
+    if (typeof value === "string") {
+      if (pattern.test(value)) {
+        issues.push(atProp(nodeId, prop, "embeds a binding inside a string — string interpolation is unsupported; bind the prop to a single {reference} or split the text into separate Text nodes"));
+      }
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) walk(nodeId, prop, item);
+      return;
+    }
+    if (isRecord(value)) {
+      for (const child of Object.values(value)) walk(nodeId, prop, child);
+    }
+  };
+  for (const node of tree.nodes) {
+    for (const [prop, value] of Object.entries(node.props ?? {})) walk(node.id, prop, value);
+  }
+  return issues;
+};
+
+const standardIssuePath = (issue: unknown): Array<string | number> => {
+  if (!isRecord(issue) || !Array.isArray(issue.path)) return [];
+  return issue.path.flatMap((segment) => {
+    const key = isRecord(segment) && "key" in segment ? segment.key : segment;
+    return typeof key === "string" || typeof key === "number" ? [key] : [];
+  });
+};
+
+const pathTargetsRuntimeBinding = (value: unknown, path: Array<string | number>): boolean => {
+  let current = value;
+  if (isRuntimeBound(current)) return true;
+  for (const segment of path) {
+    if (Array.isArray(current) && typeof segment === "number") {
+      current = current[segment];
+    } else if (isRecord(current)) {
+      current = current[String(segment)];
+    } else {
+      return false;
+    }
+    if (isRuntimeBound(current)) return true;
+  }
+  return false;
+};
+
+const issueMessage = (issue: unknown): string => {
+  if (isRecord(issue) && typeof issue.message === "string") return issue.message;
+  return "props did not match the registered schema";
+};
+
+const hostPropsIssues = async (
+  node: TreeNode,
+  component: NormalizedCatalog[number],
+): Promise<FactIssue[]> => {
+  // 01 §14: schema-less entries validate permissively by design — the model
+  // infers props and the entry carries no validator.
+  if (component.propsSchema === undefined) return [];
+  const props = node.props ?? {};
+  try {
+    const result = await component.propsSchema["~standard"].validate(props);
+    if (!isRecord(result) || !Array.isArray(result.issues)) return [];
+    return result.issues.flatMap((issue) => {
+      const path = standardIssuePath(issue);
+      if (pathTargetsRuntimeBinding(props, path)) return [];
+      const location = path.length === 0 ? "" : ` at props.${path.join(".")}`;
+      return [atNode(node.id, `props invalid for host component "${component.name}"${location}: ${issueMessage(issue)}`)];
+    });
+  } catch (error) {
+    return [atNode(node.id, `props validation failed for host component "${component.name}": ${error instanceof Error ? error.message : "unknown schema error"}`)];
+  }
+};
+
+/** Prewired primitives are handed to the model by name plus an exact prop
+ *  signature (prewired-schema.ts). The compiler keeps any attribute the model
+ *  writes, so a wrong name (`data` for Table's `rows`, `onPress` for Button's
+ *  `onClick`) survives into props and the renderer silently ignores it — the
+ *  "valid table, empty rows" class. Reject unknown prop names so the model
+ *  repairs to the real one instead of shipping a dead component. */
+const prewiredPropsIssues = (node: TreeNode): FactIssue[] => {
+  const allowed = prewiredPropNames.get(node.component);
+  const props = node.props;
+  if (allowed === undefined || props === undefined) return [];
+  return Object.keys(props)
+    .filter((name) => !allowed.has(name))
+    .map((name) => atNode(node.id, `sets unknown prop "${name}" on prewired component "${node.component}"; the renderer drops it. Allowed props: ${[...allowed].join(", ") || "(none)"}`));
+};
+
+export const catalogIssues = async (
+  tree: Tree,
+  components: Record<string, string> | undefined,
+  catalog: NormalizedCatalog,
+): Promise<FactIssue[]> => {
+  const hostCatalog = new Map(catalog.map((component) => [component.name, component]));
+  const hostNames = new Set(hostCatalog.keys());
+  const generatedNames = new Set(Object.keys(components ?? {}));
+  const issues: FactIssue[] = [];
+  for (const node of tree.nodes) {
+    if (node.source === "host") {
+      const component = hostCatalog.get(node.component);
+      if (component === undefined) {
+        issues.push(atNode(node.id, `references host component "${node.component}" absent from the catalog`));
+      } else {
+        issues.push(...await hostPropsIssues(node, component));
+      }
+    } else if (node.source === "prewired") {
+      if (!reserved.has(node.component)) {
+        issues.push(atNode(node.id, `references unknown prewired component "${node.component}"`));
+      } else {
+        issues.push(...prewiredPropsIssues(node));
+      }
+    } else if (node.source === "generated" && !generatedNames.has(node.component)) {
+      issues.push(atNode(node.id, `references generated component "${node.component}" without source`));
+    } else if (node.source === undefined) {
+      // Legacy/direct trees can omit source; the renderer resolves the name to
+      // a prewired primitive first, so a reserved name here gets the same
+      // prop-name gate as an explicit source:"prewired" node — otherwise a
+      // stored tree could still ship an ignored prop (e.g. Table.data).
+      if (reserved.has(node.component)) {
+        issues.push(...prewiredPropsIssues(node));
+      } else if (!hostNames.has(node.component) && !generatedNames.has(node.component)) {
+        issues.push(atNode(node.id, `references unknown component "${node.component}"`));
+      }
+    }
+  }
+  return issues;
+};
+
+/** A query naming a tool the host does not have. The message lists the real
+ *  ones — a model reading it can pick, and a human reading it learns the
+ *  surface. `fn:` queries are the app's own server code, not host tools. */
+export const unknownToolIssues = (tree: Tree, tools: readonly HostToolInfo[] | undefined): FactIssue[] => {
+  if (tools === undefined) return [];
+  const known = new Set(tools.map((tool) => tool.name));
+  return (tree.queries ?? [])
+    .filter((query) => !query.tool.startsWith("fn:") && !known.has(query.tool))
+    .map((query) => ({
+      where: `query "${query.name}"`,
+      message: `names unknown tool "${query.tool}"; the host tools are: ${[...known].join(", ")}`,
+    }));
+};
+
+/** Every `$path` binding resolved query → tool → response shape by the wire
+ *  compiler's own checker. A miss carries the fields that ARE there, so the
+ *  message can teach instead of only refusing. */
+const bindingShapeIssues = (tree: Tree, deps: GenerationDependencies): FactIssue[] => {
+  if (deps.toolShapes === undefined) return [];
+  return checkBindingShapes(tree.nodes, tree.queries ?? [], deps.toolShapes).map((error) => atProp(
+    error.nodeId,
+    error.prop,
+    `binds ${error.path}: ${error.message}${error.available === undefined ? "" : ` — the real fields are: ${error.available.join(", ")}`}`,
+  ));
+};
+
+/** The document's own validity: it parses as an app, its tree is a tree of the
+ *  format this engine speaks, and it carries a short human title. */
+const documentIssues = (app: GeneratedAppDocument): FactIssue[] => {
+  const issues: FactIssue[] = [];
+  const name = app.name?.trim() ?? "";
+  if (name === "") {
+    issues.push({ where: "document", message: 'must carry a non-empty name="..." attribute' });
+  } else if (name.length > APP_NAME_MAX_CHARS) {
+    issues.push({ where: "document", message: `name="${name}" is ${name.length} characters — name is the app's display title (at most ${APP_NAME_MAX_CHARS} characters); write a short human title, never the request echoed back` });
+  }
+  const validation = validateAppDocument({ ...app, id: "app_generation_validation" });
+  if (!validation.ok) issues.push({ where: "document", message: validation.error.message });
+  if (app.tree === undefined) {
+    issues.push({ where: "document", message: "carries no tree — the engine emits tree documents only" });
+    return issues;
+  }
+  if (app.tree.formatVersion !== VENDO_TREE_FORMAT) {
+    issues.push({ where: "document", message: `carries tree format "${String(app.tree.formatVersion)}" — this engine speaks "${VENDO_TREE_FORMAT}"` });
+    return issues;
+  }
+  const treeValidation = validateTree(app.tree);
+  if (!treeValidation.ok) issues.push({ where: "document", message: treeValidation.error.message });
+  return issues;
+};
+
+/** The document's tree, or undefined when it is not one — the `document`
+ *  check reports that, and every other check stays quiet rather than
+ *  repeating it. */
+const treeOf = (app: GeneratedAppDocument): Tree | undefined => {
+  if (app.tree === undefined || app.tree.formatVersion !== VENDO_TREE_FORMAT) return undefined;
+  const validation = validateTree(app.tree);
+  return validation.ok ? validation.tree : undefined;
+};
+
+const blocking = (issues: readonly FactIssue[]): Finding[] =>
+  issues.map(({ where, message }) => ({ severity: "block", where, message }));
+
+/** A check over the document's tree; skipped silently when there is no valid
+ *  tree to look at. */
+const treeCheck = (
+  name: string,
+  issues: (tree: Tree, app: GeneratedAppDocument) => FactIssue[] | Promise<FactIssue[]>,
+): Check => ({
+  name,
+  run: async ({ app }) => {
+    const tree = treeOf(app);
+    return tree === undefined ? [] : blocking(await issues(tree, app));
+  },
+});
+
+/**
+ * The built-in fact checks, bound to the host surface they measure against.
+ * Every finding is `block`: a fact is not a matter of taste.
+ */
+export const factChecks = (deps: GenerationDependencies): Check[] => [
+  { name: "document", run: async ({ app }) => blocking(documentIssues(app)) },
+  treeCheck("tools-exist", (tree) => unknownToolIssues(tree, deps.tools)),
+  treeCheck("components-exist", (tree, app) => catalogIssues(tree, app.components, deps.catalog)),
+  treeCheck("bindings-fit", (tree) => [
+    ...bindingShapeIssues(tree, deps),
+    ...bindingKindIssues(tree, deps),
+    ...kitSlotIssues(tree, deps),
+    ...hostReshapeIssues(tree, deps),
+  ]),
+  treeCheck("query-inputs-literal", (tree) => queryInputIssues(tree)),
+  treeCheck("no-string-interpolation", (tree) => interpolationIssues(tree)),
+];

--- a/packages/apps/src/checking/layer.ts
+++ b/packages/apps/src/checking/layer.ts
@@ -1,0 +1,43 @@
+/**
+ * The checking layer: built-in fact checks plus whatever the host registered,
+ * run in parallel over one app and flat-merged into a single finding list.
+ *
+ * A check is untrusted code (the host's, or a model call): one that throws
+ * degrades to a `warn` naming it, so a broken check never takes the app down
+ * with it.
+ */
+import { factChecks } from "./facts.js";
+import type { Check, CheckInput, CheckingLayer, Finding } from "./types.js";
+import type { GenerationDependencies } from "../generation/engine.js";
+
+export interface CheckingLayerOptions {
+  /** The host surface the fact checks measure against (catalog, tools, tool
+   *  shapes). */
+  deps: GenerationDependencies;
+  /** Host-registered checks (AppsConfig.checks). APPENDED — they can add
+   *  findings, never remove or replace a built-in. */
+  checks?: readonly Check[];
+}
+
+const crashFinding = (check: Check, error: unknown): Finding => ({
+  severity: "warn",
+  where: check.name,
+  message: `the check "${check.name}" failed to run (${error instanceof Error ? error.message : String(error)}), so whatever it would have found is missing from this report`,
+});
+
+export const createCheckingLayer = ({ deps, checks = [] }: CheckingLayerOptions): CheckingLayer => {
+  const all = [...factChecks(deps), ...checks];
+  return {
+    checks: all,
+    run: async (input: CheckInput): Promise<Finding[]> => {
+      const results = await Promise.all(all.map(async (check) => {
+        try {
+          return await check.run(input);
+        } catch (error) {
+          return [crashFinding(check, error)];
+        }
+      }));
+      return results.flat();
+    },
+  };
+};

--- a/packages/apps/src/checking/types.ts
+++ b/packages/apps/src/checking/types.ts
@@ -1,0 +1,45 @@
+/**
+ * The checking layer's contract (generation pipeline rebuild, Task 3): one
+ * plug-in shape for every kind of check the pipeline runs over a generated
+ * app — the deterministic fact checks (facts.ts), the AI reviewer, and the
+ * host's own checks (AppsConfig.checks). Findings are advice, not exceptions:
+ * a check reports, it never throws the build away.
+ */
+import type { AppPlan } from "@vendoai/core";
+import type { GeneratedAppDocument } from "../generation/engine.js";
+
+/**
+ * One thing wrong with a generated app. `message` is a TEACHING sentence: it
+ * names what is wrong AND the real alternative ("…the real fields are: …"),
+ * because its readers are a model repairing the app and a human reading the
+ * refusal.
+ *
+ * `block` stops the app shipping as-is; `warn` rides along (the section-sized
+ * failure, and every check that could not run).
+ */
+export interface Finding {
+  severity: "block" | "warn";
+  /** The locus: `document`, `node "n3" prop "rows"`, `query "invoices"`, or a
+   *  check name when the finding is about the check itself. */
+  where: string;
+  message: string;
+}
+
+export interface CheckInput {
+  app: GeneratedAppDocument;
+  /** The user's own words — what the app was asked to be. */
+  request: string;
+  /** The plan the app was built from, when the check runs mid-pipeline; absent
+   *  for checks over a finished document. */
+  plan?: AppPlan;
+}
+
+export interface Check {
+  name: string;
+  run(input: CheckInput): Promise<Finding[]>;
+}
+
+export interface CheckingLayer {
+  checks: Check[];
+  run(input: CheckInput): Promise<Finding[]>;
+}

--- a/packages/apps/src/generation/validation/validate.ts
+++ b/packages/apps/src/generation/validation/validate.ts
@@ -5,24 +5,26 @@
  * bindings shape-checked, and the assembled document valid.
  */
 import {
-  KIT_WIRE_COMPONENT_NAMES,
-  WIRE_COMPONENT_NAMES,
   VENDO_APP_FORMAT,
   VENDO_TREE_FORMAT,
-  kitSpec,
-  shapeAtPointer,
-  isPathBinding,
-  isStateBinding,
   validateAppDocument,
   validateTree,
   type AppDocument,
-  type NormalizedCatalog,
-  type ShapeType,
-  type TreeNode,
   type Tree,
   type WireCompileResult,
 } from "@vendoai/core";
-import { prewiredPropNames } from "../../prewired-schema.js";
+import {
+  bindingKindIssues,
+  catalogIssues,
+  factIssueLine,
+  hostReshapeIssues,
+  interpolationIssues,
+  isRecord,
+  isRuntimeBound,
+  kitSlotIssues,
+  queryInputIssues,
+  unknownToolIssues,
+} from "../../checking/facts.js";
 import { APP_NAME_MAX_CHARS } from "../contracts/sections.js";
 import type {
   GeneratedAppDocument,
@@ -34,300 +36,6 @@ import { DISCLAIMER_TEXT } from "./disclaimer.js";
 import { literalDataIssues } from "./literals.js";
 import { prepareIslands } from "./islands.js";
 import { smokeRenderIslands } from "./smoke-render.js";
-
-const reserved = new Set<string>(WIRE_COMPONENT_NAMES);
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
-/** Conservative kind check between a bound field's shape and the host prop's
- *  declared JSON-schema type: only CLEAR mismatches flag (an array of objects
- *  where number[] is expected renders an empty chart — the silent-breakage
- *  class); unknown shapes/schemas stay silent. */
-const shapeSchemaMismatch = (shape: ShapeType, schema: Record<string, unknown>): string | null => {
-  const type = typeof schema.type === "string" ? schema.type : undefined;
-  if (type === undefined || shape.kind === "json") return null;
-  if (type === "array") {
-    if (shape.kind !== "array") return `expected an array, the bound field is ${shape.kind}`;
-    const items = schema.items;
-    return isRecord(items) ? shapeSchemaMismatch(shape.items, items) : null;
-  }
-  if (type === "number" || type === "integer") {
-    return shape.kind === "number" ? null : `expected a number, the bound field is ${shape.kind}`;
-  }
-  if (type === "string") return shape.kind === "string" ? null : `expected a string, the bound field is ${shape.kind}`;
-  if (type === "boolean") return shape.kind === "boolean" ? null : `expected a boolean, the bound field is ${shape.kind}`;
-  if (type === "object") return shape.kind === "object" ? null : `expected an object, the bound field is ${shape.kind}`;
-  return null;
-};
-
-/** With tool shapes AND the catalog's prop schemas both in hand, a top-level
- *  `$path` prop on a host node can be kind-checked end to end. Existence is
- *  shape-check.ts's job; this catches the type mismatches that render
- *  silently broken (empty chart, blank stat). */
-const bindingKindIssues = (
-  compiled: WireCompileResult,
-  deps: GenerationDependencies,
-): string[] => {
-  if (deps.toolShapes === undefined) return [];
-  const issues: string[] = [];
-  const queryTool = new Map((compiled.tree.queries ?? []).map((query) => [query.name, query.tool]));
-  const hostSchemas = new Map(deps.catalog.map((component) => [component.name, component.propsJsonSchema]));
-  for (const node of compiled.tree.nodes) {
-    if (node.source !== "host" || node.props === undefined) continue;
-    const schema = hostSchemas.get(node.component);
-    const properties = isRecord(schema) && isRecord(schema.properties) ? schema.properties : undefined;
-    if (properties === undefined) continue;
-    for (const [prop, value] of Object.entries(node.props)) {
-      if (!isPathBinding(value)) continue;
-      const [, queryName = "", ...rest] = value.$path.split("/");
-      const tool = queryTool.get(queryName);
-      const toolShape = tool === undefined ? undefined : deps.toolShapes[tool];
-      if (toolShape === undefined) continue;
-      const bound = shapeAtPointer(toolShape, rest.length === 0 ? "" : `/${rest.join("/")}`);
-      if (bound === undefined) continue;
-      const propSchema = properties[prop];
-      if (!isRecord(propSchema)) continue;
-      const mismatch = shapeSchemaMismatch(bound, propSchema);
-      if (mismatch !== null) {
-        issues.push(`node "${node.id}" prop "${prop}" binds ${value.$path}: ${mismatch} — bind a field whose shape matches the component's prop type`);
-      }
-    }
-  }
-  return issues;
-};
-
-/** asPoints/asOptions produce generic {label,value}/{value,label} items; a
- *  HOST prop whose schema declares its OWN item field names cannot read them
- *  (live finding: the Maple donut drew $NaN). The raw rows are the legal
- *  binding — reject the reshape at compile. */
-const GENERIC_ITEM_RESHAPES = new Set(["asPoints", "asOptions"]);
-const hostReshapeIssues = (compiled: WireCompileResult, deps: GenerationDependencies): string[] => {
-  const issues: string[] = [];
-  const hostSchemas = new Map(deps.catalog.map((component) => [component.name, component.propsJsonSchema]));
-  for (const node of compiled.tree.nodes) {
-    if (node.source !== "host" || node.props === undefined) continue;
-    const schema = hostSchemas.get(node.component);
-    const properties = isRecord(schema) && isRecord(schema.properties) ? schema.properties : undefined;
-    if (properties === undefined) continue;
-    for (const [prop, value] of Object.entries(node.props)) {
-      if (!isPathBinding(value)) continue;
-      const reshape = (value as unknown as { $reshape?: Array<{ op?: string }> }).$reshape;
-      if (!Array.isArray(reshape) || !reshape.some((step) => GENERIC_ITEM_RESHAPES.has(step?.op ?? ""))) continue;
-      const propSchema = properties[prop];
-      const items = isRecord(propSchema) && isRecord(propSchema.items) ? propSchema.items : undefined;
-      const itemProperties = items !== undefined && isRecord(items.properties) ? Object.keys(items.properties) : [];
-      if (itemProperties.length === 0) continue;
-      if (itemProperties.includes("label") && itemProperties.includes("value")) continue;
-      issues.push(`node "${node.id}" prop "${prop}" reshapes with asPoints/asOptions, but host component "${node.component}" declares its own item fields (${itemProperties.join(", ")}) — it cannot read generic {label, value} items. Bind the RAW rows (drop the reshape) so the component receives the fields its schema names.`);
-    }
-  }
-  return issues;
-};
-
-/** Law 2 — a query input executes as LITERAL JSON: the runtime never
- *  resolves bindings inside it, so a dependent call
- *  (`accountId: accounts.data.0.id`) reaches the tool as an unresolved
- *  binding object and the app ships broken. Reject at compile → repair. */
-const queryInputIssues = (tree: Tree): string[] => {
-  const issues: string[] = [];
-  const findBinding = (value: unknown): boolean => {
-    if (isPathBinding(value) || isStateBinding(value)) return true;
-    if (Array.isArray(value)) return value.some(findBinding);
-    if (isRecord(value)) return Object.values(value).some(findBinding);
-    return false;
-  };
-  for (const query of tree.queries ?? []) {
-    if (query.input !== undefined && findBinding(query.input)) {
-      issues.push(`query "${query.name}" (tool "${query.tool}") embeds a binding in its input — query inputs must be LITERAL JSON the tool can execute directly; another query's result can never feed a query input. Use a literal value (or drop the optional input), or build the dependent lookup inside an <Island> with ambient tools.`);
-    }
-  }
-  return issues;
-};
-
-/** Law 1 raw typing — probe values per shape kind, parsed against the Kit
- *  prop's zod schema. Kind-level only: a string-shaped field bound into
- *  Money.cents fails (pre-formatted money strings never reach a numeric
- *  slot); unknown shapes stay silent. */
-const KIND_PROBES: Partial<Record<ShapeType["kind"], unknown>> = {
-  string: "probe",
-  number: 1,
-  boolean: true,
-  array: [],
-  object: {},
-};
-
-const KIT_WIRE_SET: ReadonlySet<string> = new Set(KIT_WIRE_COMPONENT_NAMES);
-
-const kitSlotIssues = (compiled: WireCompileResult, deps: GenerationDependencies): string[] => {
-  if (deps.toolShapes === undefined) return [];
-  const issues: string[] = [];
-  const queryTool = new Map((compiled.tree.queries ?? []).map((query) => [query.name, query.tool]));
-  for (const node of compiled.tree.nodes) {
-    if (node.source === "host" || node.source === "generated" || node.props === undefined) continue;
-    if (!KIT_WIRE_SET.has(node.component)) continue;
-    const spec = kitSpec(node.component);
-    if (spec === undefined) continue;
-    for (const [prop, value] of Object.entries(node.props)) {
-      if (!isPathBinding(value) || "$reshape" in (value as unknown as Record<string, unknown>)) continue;
-      const propSpec = spec.props[prop];
-      if (propSpec === undefined) continue;
-      const [, queryName = "", ...rest] = value.$path.split("/");
-      const tool = queryTool.get(queryName);
-      const shape = tool === undefined ? undefined : deps.toolShapes[tool];
-      if (shape === undefined) continue;
-      const bound = shapeAtPointer(shape, rest.length === 0 ? "" : `/${rest.join("/")}`);
-      if (bound === undefined || bound.kind === "json" || bound.kind === "null") continue;
-      const probe = KIND_PROBES[bound.kind];
-      if (probe === undefined) continue;
-      if (!propSpec.schema.safeParse(probe).success) {
-        issues.push(`node "${node.id}" prop "${prop}" on <${node.component}> binds ${value.$path}, a ${bound.kind} field, but this slot takes a different RAW type (${propSpec.doc}) — bind the raw field with that type (e.g. the integer-cents field, not a pre-formatted display string).`);
-      }
-    }
-  }
-  return issues;
-};
-
-/** Models write "Total: {metric.total}" inside STRING attributes; the wire
- *  has no string interpolation, so the braces render literally. Any string
- *  prop embedding a declared query reference is a repair-routed error. */
-const interpolationIssues = (compiled: WireCompileResult): string[] => {
-  const queryNames = (compiled.tree.queries ?? []).map((query) => query.name);
-  if (queryNames.length === 0) return [];
-  const pattern = new RegExp(`\\{(?:${queryNames.join("|")})(?:\\.[A-Za-z0-9_]+)*\\}`);
-  const issues: string[] = [];
-  const walk = (nodeId: string, prop: string, value: unknown): void => {
-    if (typeof value === "string") {
-      if (pattern.test(value)) {
-        issues.push(`node "${nodeId}" prop "${prop}" embeds a binding inside a string — string interpolation is unsupported; bind the prop to a single {reference} or split the text into separate Text nodes`);
-      }
-      return;
-    }
-    if (Array.isArray(value)) {
-      for (const item of value) walk(nodeId, prop, item);
-      return;
-    }
-    if (isRecord(value)) {
-      for (const child of Object.values(value)) walk(nodeId, prop, child);
-    }
-  };
-  for (const node of compiled.tree.nodes) {
-    for (const [prop, value] of Object.entries(node.props ?? {})) walk(node.id, prop, value);
-  }
-  return issues;
-};
-
-const standardIssuePath = (issue: unknown): Array<string | number> => {
-  if (!isRecord(issue) || !Array.isArray(issue.path)) return [];
-  return issue.path.flatMap((segment) => {
-    const key = isRecord(segment) && "key" in segment ? segment.key : segment;
-    return typeof key === "string" || typeof key === "number" ? [key] : [];
-  });
-};
-
-const isActionBinding = (value: unknown): boolean =>
-  isRecord(value) && typeof value.action === "string";
-
-const isRuntimeBound = (value: unknown): boolean =>
-  isPathBinding(value) || isStateBinding(value) || isActionBinding(value);
-
-const pathTargetsRuntimeBinding = (value: unknown, path: Array<string | number>): boolean => {
-  let current = value;
-  if (isRuntimeBound(current)) return true;
-  for (const segment of path) {
-    if (Array.isArray(current) && typeof segment === "number") {
-      current = current[segment];
-    } else if (isRecord(current)) {
-      current = current[String(segment)];
-    } else {
-      return false;
-    }
-    if (isRuntimeBound(current)) return true;
-  }
-  return false;
-};
-
-const issueMessage = (issue: unknown): string => {
-  if (isRecord(issue) && typeof issue.message === "string") return issue.message;
-  return "props did not match the registered schema";
-};
-
-const hostPropsIssues = async (
-  node: TreeNode,
-  component: NormalizedCatalog[number],
-): Promise<string[]> => {
-  // 01 §14: schema-less entries validate permissively by design — the model
-  // infers props and the entry carries no validator.
-  if (component.propsSchema === undefined) return [];
-  const props = node.props ?? {};
-  try {
-    const result = await component.propsSchema["~standard"].validate(props);
-    if (!isRecord(result) || !Array.isArray(result.issues)) return [];
-    return result.issues.flatMap((issue) => {
-      const path = standardIssuePath(issue);
-      if (pathTargetsRuntimeBinding(props, path)) return [];
-      const location = path.length === 0 ? "" : ` at props.${path.join(".")}`;
-      return [`node "${node.id}" props invalid for host component "${component.name}"${location}: ${issueMessage(issue)}`];
-    });
-  } catch (error) {
-    return [`node "${node.id}" props validation failed for host component "${component.name}": ${error instanceof Error ? error.message : "unknown schema error"}`];
-  }
-};
-
-/** Prewired primitives are handed to the model by name plus an exact prop
- *  signature (prewired-schema.ts). The compiler keeps any attribute the model
- *  writes, so a wrong name (`data` for Table's `rows`, `onPress` for Button's
- *  `onClick`) survives into props and the renderer silently ignores it — the
- *  "valid table, empty rows" class. Reject unknown prop names so the model
- *  repairs to the real one instead of shipping a dead component. */
-const prewiredPropsIssues = (node: TreeNode): string[] => {
-  const allowed = prewiredPropNames.get(node.component);
-  const props = node.props;
-  if (allowed === undefined || props === undefined) return [];
-  return Object.keys(props)
-    .filter((name) => !allowed.has(name))
-    .map((name) => `node "${node.id}" sets unknown prop "${name}" on prewired component "${node.component}"; the renderer drops it. Allowed props: ${[...allowed].join(", ") || "(none)"}`);
-};
-
-const catalogIssues = async (
-  tree: Tree,
-  components: Record<string, string> | undefined,
-  catalog: NormalizedCatalog,
-): Promise<string[]> => {
-  const hostCatalog = new Map(catalog.map((component) => [component.name, component]));
-  const hostNames = new Set(hostCatalog.keys());
-  const generatedNames = new Set(Object.keys(components ?? {}));
-  const issues: string[] = [];
-  for (const node of tree.nodes) {
-    if (node.source === "host") {
-      const component = hostCatalog.get(node.component);
-      if (component === undefined) {
-        issues.push(`node "${node.id}" references host component "${node.component}" absent from the catalog`);
-      } else {
-        issues.push(...await hostPropsIssues(node, component));
-      }
-    } else if (node.source === "prewired") {
-      if (!reserved.has(node.component)) {
-        issues.push(`node "${node.id}" references unknown prewired component "${node.component}"`);
-      } else {
-        issues.push(...prewiredPropsIssues(node));
-      }
-    } else if (node.source === "generated" && !generatedNames.has(node.component)) {
-      issues.push(`node "${node.id}" references generated component "${node.component}" without source`);
-    } else if (node.source === undefined) {
-      // Legacy/direct trees can omit source; the renderer resolves the name to
-      // a prewired primitive first, so a reserved name here gets the same
-      // prop-name gate as an explicit source:"prewired" node — otherwise a
-      // stored tree could still ship an ignored prop (e.g. Table.data).
-      if (reserved.has(node.component)) {
-        issues.push(...prewiredPropsIssues(node));
-      } else if (!hostNames.has(node.component) && !generatedNames.has(node.component)) {
-        issues.push(`node "${node.id}" references unknown component "${node.component}"`);
-      }
-    }
-  }
-  return issues;
-};
 
 /** The per-region unavailability line the repair stage substitutes for a node
  *  it cannot fix (stages/repair.ts disclaims through it). Lives in
@@ -460,22 +168,15 @@ export const validateCompiledCreate = async (
   const prepared = await prepareIslands(compiled.components, deps.tools, deps.catalog.map(({ name: componentName }) => componentName), requestText);
   const components = Object.keys(prepared.components).length === 0 ? undefined : prepared.components;
   issues.push(...prepared.issues);
-  if (deps.tools !== undefined) {
-    const known = new Set(deps.tools.map((tool) => tool.name));
-    for (const query of compiled.tree.queries ?? []) {
-      if (!query.tool.startsWith("fn:") && !known.has(query.tool)) {
-        issues.push(`query "${query.name}" names unknown tool "${query.tool}"; the host tools are: ${[...known].join(", ")}`);
-      }
-    }
-  }
+  issues.push(...unknownToolIssues(compiled.tree, deps.tools).map(factIssueLine));
   issues.push(...compiled.bindingErrors.map((error) =>
     `binding ${error.path} on node "${error.nodeId}" prop "${error.prop}": ${error.message}${error.available === undefined ? "" : ` (available: ${error.available.join(", ")})`}`));
-  issues.push(...bindingKindIssues(compiled, deps));
-  issues.push(...kitSlotIssues(compiled, deps));
-  issues.push(...hostReshapeIssues(compiled, deps));
-  issues.push(...queryInputIssues(compiled.tree));
-  issues.push(...interpolationIssues(compiled));
-  issues.push(...await catalogIssues(compiled.tree, components, deps.catalog));
+  issues.push(...bindingKindIssues(compiled.tree, deps).map(factIssueLine));
+  issues.push(...kitSlotIssues(compiled.tree, deps).map(factIssueLine));
+  issues.push(...hostReshapeIssues(compiled.tree, deps).map(factIssueLine));
+  issues.push(...queryInputIssues(compiled.tree).map(factIssueLine));
+  issues.push(...interpolationIssues(compiled.tree).map(factIssueLine));
+  issues.push(...(await catalogIssues(compiled.tree, components, deps.catalog)).map(factIssueLine));
   // Law 1 is checkable only when a tool surface exists to trace data to —
   // a tool-less composition (fresh init, bare tests) has nothing to bind.
   if (deps.tools !== undefined && deps.tools.length > 0) {
@@ -545,7 +246,7 @@ export const validateEditedApp = async (
     : new Set<string>();
   const sourceCatalogIssues = sourceTreeValidation.ok
     ? new Set([
-      ...await catalogIssues(sourceTreeValidation.tree, source.components, deps.catalog),
+      ...(await catalogIssues(sourceTreeValidation.tree, source.components, deps.catalog)).map(factIssueLine),
       ...literalDataIssues(sourceTreeValidation.tree, deps.catalog),
       ...actionIssues(sourceTreeValidation.tree, deps.tools),
       ...capabilitySubstitutionIssues(sourceTreeValidation.tree, deps.tools, requestText),
@@ -553,7 +254,7 @@ export const validateEditedApp = async (
     : new Set<string>();
   return [
     ...rootedRenderIssues(treeValidation.tree).filter((issue) => !sourceRenderIssues.has(issue)),
-    ...(await catalogIssues(treeValidation.tree, app.components, deps.catalog)).filter((issue) => !sourceCatalogIssues.has(issue)),
+    ...(await catalogIssues(treeValidation.tree, app.components, deps.catalog)).map(factIssueLine).filter((issue) => !sourceCatalogIssues.has(issue)),
     ...literalDataIssues(treeValidation.tree, deps.catalog).filter((issue) => !sourceCatalogIssues.has(issue)),
     ...actionIssues(treeValidation.tree, deps.tools).filter((issue) => !sourceCatalogIssues.has(issue)),
     ...capabilitySubstitutionIssues(treeValidation.tree, deps.tools, requestText).filter((issue) => !sourceCatalogIssues.has(issue)),

--- a/packages/apps/src/index.ts
+++ b/packages/apps/src/index.ts
@@ -94,6 +94,14 @@ export {
 // The generation seam for the genui-bench vendo lane: the SAME modelEngine
 // createApps() rides, driven directly with production PipelineConfig defaults
 // (no forked engine config). Additive export — engine behavior is unchanged.
+// The checking layer's contract: the shape a host writes an AppsConfig.checks
+// entry in, and the finding shape every check reports (checking/types.ts).
+export type {
+  Check,
+  CheckInput,
+  CheckingLayer,
+  Finding,
+} from "./checking/types.js";
 export {
   modelEngine,
   type GeneratedAppDocument,

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -39,6 +39,7 @@ import { createAppData } from "./app-data.js";
 import { appLifecycleEvent } from "./audit.js";
 import { createAppCaller } from "./call.js";
 import { createParkedActions } from "./parked-action.js";
+import type { Check } from "./checking/types.js";
 import type {
   CloudAppsClient,
   PublishRecord,
@@ -175,6 +176,10 @@ export interface AppsConfig {
   /** W4 pipeline knobs, passed to the generation engine: structured repair
    *  (default on), outline+region-parallel tier-2 and the end pass (opt-in). */
   pipeline?: GenerationDependencies["pipeline"];
+  /** The host's own checks over a generated app (checking/types.ts). APPENDED
+   *  to the built-in fact checks and the reviewer — a host can add findings,
+   *  never remove or replace a built-in one. */
+  checks?: readonly Check[];
   /** The composition-normalized catalog (01 §14): derived schemas included.
    *  The provider (function) form of theme/semantics/domains below mirrors
    *  designRules: it is resolved lazily per create/edit (in

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -455,6 +455,11 @@ export interface CreateVendoConfig {
         regionParallel, endPass) — opt-in while the A/B is measured; threaded
         verbatim to the apps engine. */
     pipeline?: AppsConfig["pipeline"];
+    /** The host's own checks over a generated app: each one reports findings
+        (`block` stops the app shipping as-is, `warn` rides along) the same way
+        the built-in fact checks and the AI reviewer do. APPENDED to the
+        built-ins — a host adds findings, it never removes one. */
+    checks?: AppsConfig["checks"];
     /** Host design rules for app generation (spec 2026-07-20): the same prose
         `.vendo/design-rules.md` carries, for hosts that prefer programmatic
         config. A non-blank string wins over the file and is fixed for the
@@ -1771,6 +1776,7 @@ export function createVendo(config: CreateVendoConfig): Vendo {
     // paint.model otherwise; paint.disabled survives as the one-lane switch.
     ...(inference.paint === undefined ? {} : { paint: inference.paint }),
     ...(config.apps?.pipeline === undefined ? {} : { pipeline: config.apps.pipeline }),
+    ...(config.apps?.checks === undefined ? {} : { checks: config.apps.checks }),
     // cse lane 3 — theme/semantics/domains flow as PROVIDER thunks so a
     // cloud-owned surface applies without a compose-time fetch. semantics/domains
     // resolve live per generation (pick up cloud overrides as the snapshot warms);


### PR DESCRIPTION
## Task 3 — the checking layer

The generation pipeline's plug-in checking layer: one shape every check speaks,
one parallel run that flat-merges their findings, and the built-in **fact**
checks moved into it.

`packages/apps/src/checking/`
- **`types.ts`** — the locked contract: `Finding { severity: "block" | "warn", where, message }`,
  `Check { name, run({ app, request, plan? }) }`, `CheckingLayer`. `plan` is the
  `AppPlan` Task 1 landed.
- **`layer.ts`** — `createCheckingLayer({ deps, checks })`: built-in fact checks
  first, host checks **appended** (a host adds findings, never removes one), all
  run with `Promise.all` and flat-merged. A check that throws degrades to a
  `warn` naming it — a broken host check or a timed-out model call costs its own
  findings, not the run.
- **`facts.ts`** — the six built-in checks: `document`, `tools-exist`,
  `components-exist`, `bindings-fit`, `query-inputs-literal`,
  `no-string-interpolation`. Every finding is `block` (a fact is not a matter of
  taste) and every message names the real alternative: *"…the real fields are:
  id, client, amountCents"*, *"the host tools are: …"*, *"Allowed props: …"*.

### What moved, what was reused, what was left alone in `validate.ts`

**Moved** into `facts.ts` (exported there, imported back by `validate.ts` — one
implementation, one message text, no duplication): `bindingKindIssues`,
`hostReshapeIssues`, `queryInputIssues`, `kitSlotIssues`, `interpolationIssues`,
`catalogIssues` (with `hostPropsIssues`, `prewiredPropsIssues`,
`shapeSchemaMismatch`, `standardIssuePath`, `issueMessage`,
`pathTargetsRuntimeBinding`, `isActionBinding`, `isRecord`, `isRuntimeBound`,
`reserved`, `KIND_PROBES`, `KIT_WIRE_SET`, `GENERIC_ITEM_RESHAPES`). The
create-path tool-exists loop became `unknownToolIssues`.

Those helpers now return **anchored** issues (`FactIssue { where, message }`) so
a finding has a real locus. `validate.ts` flattens them with `factIssueLine`
(`` `${where} ${message}` ``), which reproduces its previous issue strings
**byte for byte** — the existing assertions on those exact messages
(`engine.test.ts` "unknown tool" / "string interpolation is unsupported",
`engine-laws.test.ts` "query inputs must be LITERAL JSON" / "declares its own
item fields") pass untouched.

**Reused, not re-implemented:** the wire compiler's own `checkBindingShapes`
from `@vendoai/core` is the `bindings-fit` field-existence check — its
`available` list is what makes the message teach.

**Left alone:** `validate.ts` keeps both public exports (`validateCompiledCreate`,
`validateEditedApp`) and its behavior, and keeps every **judgment** check —
`literalDataIssues`, `actionIssues`, `capabilitySubstitutionIssues`,
`emptyDocumentIssues`, `rootedRenderIssues`. Those die at cutover (Task 10) with
the reviewer in place; nothing about them changed here. The current pipeline
keeps working on this branch — this layer is new code beside it, wired into
nothing yet.

### Threading

`AppsConfig.checks?: readonly Check[]` (`packages/apps/src/runtime.ts`), exposed
as `createVendo({ apps: { checks } })` following the existing
`apps.pipeline` pattern in `packages/vendo/src/server.ts`. `Check`, `CheckInput`,
`CheckingLayer` and `Finding` are exported from `packages/apps/src/index.ts` so a
host can write one.

### Tests (`checking.test.ts`, 8 green)

- runs checks in parallel and flat-merges their findings *(a two-arrival barrier
  inside each check — serial execution would deadlock, so reaching the
  assertions is the proof)*
- surfaces a host-registered check's findings alongside the built-ins
- turns a check that throws into a warn finding naming it, never a crash
- passes a clean app with no findings
- names the real tools when a query names one the host does not have
- names the real fields when a binding reaches a field the tool shape has not got
- names the allowed props when a prewired component is given one it has not got
- blocks a document with no title and says what name is for

### Gate

`pnpm build` · `pnpm typecheck` · `pnpm lint` green. `pnpm test` green
(`@vendoai/apps` 779, `@vendoai/vendo` 1450, `@vendoai/core` 45 files, `@vendoai/ui`
78 files). `fixtures/integration`'s `away-park-revoke.e2e.test.ts` fails only
under full-suite parallel load — its 100 ms poll loops time out — and is green
in isolation (`17 passed`); it exercises the grant/automation path, which this
diff does not touch.

No UI surface in this task.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a plug-in checking layer for generated apps with built-in fact checks that run in parallel and flat-merge findings. Host checks are appended, and a failed check degrades to a warn instead of crashing.

- **New Features**
  - New checking layer: `createCheckingLayer` runs all checks in parallel and returns a flat list of findings; thrown errors become `warn` findings.
  - Built-in fact checks: document, tools-exist, components-exist, bindings-fit (shape, kind, Kit slots, host reshapes), query-inputs-literal, no-string-interpolation. All findings are `block` with clear, “teaching” messages.
  - Host extension: add checks via `AppsConfig.checks` and `createVendo({ apps: { checks } })`. Types `Check`, `CheckInput`, `Finding`, `CheckingLayer` exported from `@vendoai/apps`.
  - Tests added for parallel execution, host checks, error handling, and key fact scenarios.

- **Refactors**
  - Moved fact-check helpers to `checking/facts.ts` and reused in `generation/validation/validate.ts`. Existing validator message strings are preserved.
  - No behavior changes to public validators; judgment checks remain in place.

<sup>Written for commit d9eb533b25732f71764965525136acbeedbc3ea9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

