### PR TITLE
feat(apps): AI reviewer as a checking-layer adapter

### DIFF
--- a/packages/apps/src/checking/facts.ts
+++ b/packages/apps/src/checking/facts.ts
@@ -402,7 +402,7 @@ const documentIssues = (app: GeneratedAppDocument): FactIssue[] => {
 /** The document's tree, or undefined when it is not one — the `document`
  *  check reports that, and every other check stays quiet rather than
  *  repeating it. */
-const treeOf = (app: GeneratedAppDocument): Tree | undefined => {
+export const treeOf = (app: GeneratedAppDocument): Tree | undefined => {
   if (app.tree === undefined || app.tree.formatVersion !== VENDO_TREE_FORMAT) return undefined;
   const validation = validateTree(app.tree);
   return validation.ok ? validation.tree : undefined;

--- a/packages/apps/src/checking/reviewer.test.ts
+++ b/packages/apps/src/checking/reviewer.test.ts
@@ -1,0 +1,189 @@
+/**
+ * The AI reviewer (generation pipeline rebuild, Task 6): one strict
+ * `report_findings` call per finished app, its answer parsed into findings —
+ * and every way that call can go wrong parsed into no findings at all, because
+ * the reviewer must never be what kills a generated app.
+ */
+import {
+  VENDO_APP_FORMAT,
+  compileWire,
+  type NormalizedCatalog,
+  type ShapeType,
+} from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createCheckingLayer } from "./layer.js";
+import { reviewerCheck } from "./reviewer.js";
+import type { CheckInput } from "./types.js";
+import type {
+  GeneratedAppDocument,
+  GenerationDependencies,
+  HostToolInfo,
+} from "../generation/engine.js";
+import { scriptedLanguageModel, type ScriptedModelCall } from "../testing/scripted-model.js";
+
+const tools: HostToolInfo[] = [{
+  name: "host_listInvoices",
+  description: "Open invoices",
+  risk: "read",
+  inputSchema: { type: "object", properties: {} },
+}];
+
+const toolShapes: Record<string, ShapeType> = {
+  host_listInvoices: {
+    kind: "object",
+    fields: {
+      data: {
+        kind: "array",
+        items: {
+          kind: "object",
+          fields: {
+            id: { kind: "string" },
+            client: { kind: "string" },
+            amountCents: { kind: "number" },
+          },
+        },
+      },
+    },
+  },
+};
+
+const catalog: NormalizedCatalog = [];
+
+const deps = (model: GenerationDependencies["model"]): GenerationDependencies =>
+  ({ model, catalog, tools, toolShapes });
+
+const documentFrom = (wire: string): GeneratedAppDocument => {
+  const compiled = compileWire(wire, { toolShapes });
+  return {
+    format: VENDO_APP_FORMAT,
+    name: compiled.name ?? "Untitled",
+    ui: "tree",
+    tree: compiled.tree as GeneratedAppDocument["tree"],
+  };
+};
+
+const inputFor = (wire: string, request = "show me my invoices"): CheckInput =>
+  ({ app: documentFrom(wire), request });
+
+const invoicesApp =
+  '<App name="Invoices"><Query id="invoices" tool="host_listInvoices"/><Stack gap={12}><Text text="Total: $12,480" variant="heading"/><Table rows={invoices.data}/></Stack></App>';
+
+const samples = {
+  invoices: { data: [{ id: "inv_1", client: "Northwind", amountCents: 990_00 }] },
+};
+
+const reported = (findings: unknown): { tool: string; input: unknown } =>
+  ({ tool: "report_findings", input: { findings } });
+
+describe("the AI reviewer", () => {
+  it("parses the reported findings and returns them as Finding[]", async () => {
+    const model = scriptedLanguageModel(() => reported([
+      {
+        severity: "block",
+        where: '<Text> labeled "Total: $12,480"',
+        message: "the total is hand-typed; the invoices query returns amountCents — sum that instead",
+      },
+      {
+        severity: "warn",
+        where: "document",
+        message: "nothing here answers which invoices are overdue, which the ask named",
+      },
+    ]));
+
+    const findings = await reviewerCheck(deps(model), samples).run(inputFor(invoicesApp));
+
+    expect(findings).toEqual([
+      {
+        severity: "block",
+        where: '<Text> labeled "Total: $12,480"',
+        message: "the total is hand-typed; the invoices query returns amountCents — sum that instead",
+      },
+      {
+        severity: "warn",
+        where: "document",
+        message: "nothing here answers which invoices are overdue, which the ask named",
+      },
+    ]);
+  });
+
+  it("sends ONE strict report_findings call carrying the request, the printed app and the sample data", async () => {
+    const calls: ScriptedModelCall[] = [];
+    const model = scriptedLanguageModel((call) => {
+      calls.push(call);
+      return reported([]);
+    });
+
+    await reviewerCheck(deps(model), samples).run(inputFor(invoicesApp, "list my overdue invoices"));
+
+    expect(calls).toHaveLength(1);
+    const call = calls[0] as ScriptedModelCall;
+    const tool = call.tools?.[0] as { name?: string; strict?: boolean; inputSchema?: unknown };
+    expect(tool.name).toBe("report_findings");
+    expect(tool.strict).toBe(true);
+    const schema = tool.inputSchema as {
+      additionalProperties: boolean;
+      required: string[];
+      properties: {
+        findings: { type: string; items: { additionalProperties: boolean; required: string[]; properties: { severity: { enum: string[] } } } };
+      };
+    };
+    expect(schema.additionalProperties).toBe(false);
+    expect(schema.required).toEqual(["findings"]);
+    expect(schema.properties.findings.type).toBe("array");
+    expect(schema.properties.findings.items.additionalProperties).toBe(false);
+    expect(schema.properties.findings.items.required).toEqual(["severity", "where", "message"]);
+    expect(schema.properties.findings.items.properties.severity.enum).toEqual(["block", "warn"]);
+
+    const text = call.prompt.map((message) => typeof message.content === "string"
+      ? message.content
+      : message.content.map((part) => part.text ?? "").join("")).join("\n");
+    // The ask, verbatim.
+    expect(text).toContain("USER_REQUEST: list my overdue invoices");
+    // The app as a person sees it: id-free markup, not compiler bookkeeping.
+    expect(text).toContain('<Text text="Total: $12,480"');
+    expect(text).toContain("<Table rows={invoices.data}/>");
+    expect(text).not.toMatch(/id="n\d/);
+    // The truth the literals are judged against.
+    expect(text).toContain('invoices: {"data":[{"id":"inv_1","client":"Northwind","amountCents":99000}]}');
+  });
+
+  it("returns no findings when the model says nothing and calls no tool", async () => {
+    const model = scriptedLanguageModel("I have no comment on this app.");
+
+    const findings = await reviewerCheck(deps(model)).run(inputFor(invoicesApp));
+
+    expect(findings).toEqual([]);
+  });
+
+  it("returns no findings when the model call throws, so a broken reviewer never crashes generation", async () => {
+    const model = scriptedLanguageModel(() => { throw new Error("529 overloaded"); });
+
+    const findings = await reviewerCheck(deps(model), samples).run(inputFor(invoicesApp));
+
+    expect(findings).toEqual([]);
+  });
+
+  it("flows its findings through createCheckingLayer alongside the fact checks", async () => {
+    const model = scriptedLanguageModel(() => reported([{
+      severity: "block",
+      where: '<Button> labeled "Remind client"',
+      message: 'the button calls host_listInvoices, which only reads invoices — it sends no reminder; drop the button or say so honestly',
+    }]));
+    const layer = createCheckingLayer({ deps: deps(model), checks: [reviewerCheck(deps(model), samples)] });
+
+    // A query naming a tool the host has not got: one fact finding, alongside
+    // whatever the reviewer says.
+    const findings = await layer.run(inputFor(
+      '<App name="Invoices"><Query id="invoices" tool="host_getInvoices"/><Stack><Table rows={invoices.data}/></Stack></App>',
+    ));
+
+    expect(layer.checks.map(({ name }) => name)).toContain("reviewer");
+    expect(findings).toContainEqual({
+      severity: "block",
+      where: '<Button> labeled "Remind client"',
+      message: 'the button calls host_listInvoices, which only reads invoices — it sends no reminder; drop the button or say so honestly',
+    });
+    expect(findings.some(({ where, message }) =>
+      where === 'query "invoices"' && message.includes('unknown tool "host_getInvoices"'))).toBe(true);
+  });
+});

--- a/packages/apps/src/checking/reviewer.ts
+++ b/packages/apps/src/checking/reviewer.ts
@@ -1,0 +1,121 @@
+/**
+ * The AI reviewer (generation pipeline rebuild, Task 6): a checking-layer
+ * {@link Check} that spends ONE strict tool call judging what no lookup can —
+ * invented data, dishonest tool use, dead controls, sections that miss the ask.
+ *
+ * Its findings are advice like every other check's. Silence, a refusal to call
+ * the tool, and a failed request all mean "no findings": a reviewer must never
+ * be the reason a generated app dies (the layer guards a throw too, but this
+ * one does not throw in the first place).
+ */
+import { printWire } from "@vendoai/core";
+import { treeOf } from "./facts.js";
+import type { Check, Finding } from "./types.js";
+import { REPORT_FINDINGS_DESCRIPTION, REVIEWER_SYSTEM } from "../generation/prompts/reviewer.js";
+import { strictToolCall } from "../generation/stages/repair.js";
+import type { GeneratedAppDocument, GenerationDependencies } from "../generation/engine.js";
+
+export const REVIEWER_CHECK_NAME = "reviewer";
+
+const REPORT_FINDINGS_TOOL = "report_findings";
+
+/** One query result trimmed to this many characters of JSON — enough to judge
+ *  a literal against, small enough that a long table cannot crowd the app
+ *  markup out of the prompt. */
+const MAX_SAMPLE_CHARS = 800;
+
+/** The flat strict schema (Anthropic strict tool use: additionalProperties
+ *  false, every property required, no recursion) — one array of findings in
+ *  exactly the {@link Finding} shape. */
+const REPORT_FINDINGS_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  additionalProperties: false,
+  required: ["findings"],
+  properties: {
+    findings: {
+      type: "array",
+      description: "Everything wrong with the app; empty when nothing is.",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["severity", "where", "message"],
+        properties: {
+          severity: {
+            type: "string",
+            enum: ["block", "warn"],
+            description: "block for dishonesty and invented data; warn for everything else.",
+          },
+          where: {
+            type: "string",
+            description: 'The locus: the component and its label, the query name, or "document".',
+          },
+          message: {
+            type: "string",
+            description: "One sentence: what is wrong AND the real alternative.",
+          },
+        },
+      },
+    },
+  },
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/** The reported findings, keeping only entries that really are {@link Finding}s
+ *  — a malformed entry is dropped, never coerced and never thrown. */
+const findingsFrom = (reported: unknown): Finding[] => {
+  if (!Array.isArray(reported)) return [];
+  return reported.flatMap((entry) => {
+    if (!isRecord(entry)) return [];
+    const { severity, where, message } = entry;
+    if (severity !== "block" && severity !== "warn") return [];
+    if (typeof where !== "string" || typeof message !== "string") return [];
+    return [{ severity, where, message }];
+  });
+};
+
+/** The app as the reviewer reads it: id-free wire markup, so it judges what a
+ *  person sees rather than compiler bookkeeping. Undefined when the document
+ *  carries no valid tree — the `document` fact check reports that, and the
+ *  reviewer stays quiet instead of judging rubble. */
+const printedApp = (app: GeneratedAppDocument): string | undefined => {
+  const tree = treeOf(app);
+  if (tree === undefined) return undefined;
+  return printWire(
+    { tree, components: app.components ?? {}, name: app.name },
+    { includeIds: false },
+  );
+};
+
+const sampleLines = (samples: Readonly<Record<string, unknown>>): string => {
+  const lines = Object.entries(samples).map(([query, value]) => {
+    const text = JSON.stringify(value) ?? "null";
+    return `${query}: ${text.length > MAX_SAMPLE_CHARS ? `${text.slice(0, MAX_SAMPLE_CHARS)}…` : text}`;
+  });
+  return lines.length === 0 ? "" : `\nRESOLVED_DATA (what this app's queries actually returned):\n${lines.join("\n")}`;
+};
+
+/**
+ * The reviewer, bound to the model it calls with and (when generation resolved
+ * them) the query results the app's literals must match.
+ */
+export const reviewerCheck = (
+  deps: GenerationDependencies,
+  samples?: Readonly<Record<string, unknown>>,
+): Check => ({
+  name: REVIEWER_CHECK_NAME,
+  run: async ({ app, request }): Promise<Finding[]> => {
+    const printed = printedApp(app);
+    if (printed === undefined) return [];
+    const reported = await strictToolCall(
+      deps,
+      REPORT_FINDINGS_TOOL,
+      REPORT_FINDINGS_DESCRIPTION,
+      REPORT_FINDINGS_SCHEMA,
+      REVIEWER_SYSTEM,
+      `USER_REQUEST: ${request}\nAPP (wire markup):\n${printed}${samples === undefined ? "" : sampleLines(samples)}`,
+    );
+    return reported === undefined ? [] : findingsFrom(reported.findings);
+  },
+});

--- a/packages/apps/src/generation/prompts/reviewer.ts
+++ b/packages/apps/src/generation/prompts/reviewer.ts
@@ -1,0 +1,30 @@
+/**
+ * The reviewer's prompt (generation pipeline rebuild, Task 6): what the AI
+ * reviewer is asked to judge about a finished app, in plain English.
+ */
+
+// Yousef iterates on this text — keep it one screen.
+
+export const REVIEWER_SYSTEM = `You are the last reader of a generated app before a person uses it. You are shown what the user asked for, the app's markup, and the real data its queries returned. You cannot change anything: you report what is wrong and someone else fixes it.
+
+Judge four things:
+
+1. INVENTED DATA. Every number, name, date, and business fact on screen must come from a query result. Text typed to look like real data ("$12,480", "Acme Corp", "due Mar 14") is the worst thing this app can ship, because the user cannot tell it from the truth. Check the literals against the data you were given.
+
+2. DISHONEST TOOL USE. A tool may only be used for what its own description says it does. A payment tool is not a message channel. An invoice-creating tool is not a reminder. A search tool is not a delete. A control whose label promises something its tool does not do is dishonest even though it runs.
+
+3. DEAD OR UNGROUNDED CONTROLS. A button, form, or link that does nothing — or that acts without the data it needs, like a row action carrying no row id — is dead. Say what it promises and what it actually does.
+
+4. SECTIONS THAT DON'T ANSWER THE ASK. Part of the app the user never asked for and that answers nothing, or part of the ask that is missing entirely.
+
+Severity: "block" for dishonesty and invented data (1 and 2) — those must never ship. "warn" for everything else (3 and 4).
+
+Each finding has three fields:
+- severity: "block" or "warn".
+- where: the locus, as it appears in the app — the component and its label (<MetricCard> labeled "Revenue"), the query name, or "document" for the app as a whole.
+- message: ONE teaching sentence — what is wrong AND the real alternative ("the total is hand-typed as $12,480; the invoices query returns amountCents — bind and sum that instead"). Someone who cannot see the app has to understand it.
+
+Report nothing when nothing is wrong: an empty list is the normal, good answer. Never invent a finding to look thorough, and never report matters of taste (wording, colour, layout preference).`;
+
+export const REPORT_FINDINGS_DESCRIPTION =
+  "Report everything wrong with this app. Report an empty list when nothing is wrong.";


### PR DESCRIPTION
Task 6 of the generation pipeline rebuild plan (`docs/superpowers/plans/2026-07-28-generation-pipeline-rebuild.md`): the AI reviewer, as a plain `Check` on the layer that landed in Task 3.

## What it is

`reviewerCheck(deps, samples?)` returns a `Check` named `reviewer`. One model call per finished app, through the existing `strictToolCall` helper (`generation/stages/repair.ts` — reused, not re-written):

- tool `report_findings`, flat strict schema `{ findings: [{ severity: "block" | "warn", where, message }] }` — `additionalProperties: false`, everything required, no recursion.
- prompt = the user's request + the app printed with `printWire(..., { includeIds: false })` (it judges what a person sees, not compiler ids) + the resolved query samples when generation has them.
- system prompt in `generation/prompts/reviewer.ts`, one screen, marked `// Yousef iterates on this text — keep it one screen.` It judges invented data, dishonest tool use (a payment tool is not a message channel), dead or ungrounded controls, and sections that don't answer the ask. `block` only for dishonesty and invented data; `warn` otherwise.

## Findings are advice, never an exception

Model silence, a refused tool call, a malformed finding, a 529, a document with no valid tree — every one of them resolves to zero findings. The layer already turns a throwing check into a `warn`; this check does not throw in the first place, so the reviewer can never be the reason a generated app dies.

## Not wired in

Pure module + tests. Nothing in the engine or runtime calls it — composition happens at cutover (Task 10). The one existing-file change is a single `export` added to `checking/facts.ts` so the reviewer reuses `treeOf` instead of duplicating the tree-validity dance.

## Tests (`checking/reviewer.test.ts`, scripted models)

- parses the reported findings and returns them as `Finding[]`
- sends ONE strict `report_findings` call carrying the request, the printed app and the sample data (asserts the locked schema, `strict: true`, and that no node ids leak into the prompt)
- returns no findings when the model says nothing and calls no tool
- returns no findings when the model call throws, so a broken reviewer never crashes generation
- flows its findings through `createCheckingLayer` alongside the fact checks

## Gate

`pnpm --filter @vendoai/apps build && test && typecheck` green (784 passed, 18 skipped — no flakes, including the `away-park-revoke` e2e known flake), repo `pnpm build` + `pnpm lint` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `reviewer` check that makes one strict `report_findings` tool call per finished app to flag invented data, dishonest tool use, dead controls, and off-ask sections. Shipped as a checking-layer adapter (not yet wired into the engine) with advisory-only findings that never block generation.

- **New Features**
  - New `reviewerCheck(deps, samples?)`: prompts with the user request, id-free wire via `printWire`, and optional resolved data; uses `strictToolCall` with a flat strict schema.
  - Resilient by design: silence/refusals/errors/malformed output all return `[]`; the check itself never throws.
  - Exported `treeOf` for reuse and added the reviewer system prompt; tests cover strict tool use, parsing, id-free prompts, error paths, and flow through `createCheckingLayer`.

<sup>Written for commit 1edeee72fa0d86c54fc6fe227f1a790a06ad0a24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

