### PR TITLE
feat(apps,ui): deterministic skeleton from plan with streaming placeholder states

### DIFF
--- a/apps/demo-bank/src/app/vendo/skeleton-harness/harness.tsx
+++ b/apps/demo-bank/src/app/vendo/skeleton-harness/harness.tsx
@@ -1,0 +1,35 @@
+"use client";
+/**
+ * DEV HARNESS (see page.tsx) — the client half. ChromeRoot supplies the host
+ * theme variables and the chrome stylesheet the shimmer reads, exactly as the
+ * agent surface does; TreeView is the production renderer, unmodified.
+ */
+import { ChromeRoot } from "@vendoai/ui/chrome";
+import { TreeView, type WalkTree } from "@vendoai/ui/tree";
+import { VendoRoot } from "@/components/vendo/VendoRoot";
+
+const noAction = async () => ({ status: "ok" as const, output: null });
+
+function Variant({ label, tree }: { label: string; tree: WalkTree }) {
+  return (
+    <section style={{ display: "flex", flexDirection: "column", gap: 12 }} data-harness-variant={label}>
+      <h2 style={{ font: "600 13px/1.2 system-ui, sans-serif", letterSpacing: "0.06em", textTransform: "uppercase", opacity: 0.5 }}>
+        {label}
+      </h2>
+      <TreeView tree={tree} components={{}} onAction={noAction} />
+    </section>
+  );
+}
+
+export function SkeletonHarness({ tabbed, single }: { tabbed: WalkTree; single: WalkTree }) {
+  return (
+    <VendoRoot>
+      <ChromeRoot automaticPolicyNotice={false}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 48, maxWidth: 880, margin: "0 auto", padding: 32 }}>
+          <Variant label="Tabbed skeleton" tree={tabbed} />
+          <Variant label="Single surface" tree={single} />
+        </div>
+      </ChromeRoot>
+    </VendoRoot>
+  );
+}

--- a/apps/demo-bank/src/app/vendo/skeleton-harness/page.tsx
+++ b/apps/demo-bank/src/app/vendo/skeleton-harness/page.tsx
@@ -1,0 +1,79 @@
+/**
+ * DEV HARNESS (generation pipeline rebuild, Task 5) — not part of the Maple
+ * product surface. It renders `skeletonFromPlan` output for two hardcoded
+ * plans through the production renderer, so the plan→layout step and its
+ * pending shimmer can be seen in a real browser instead of asserted in jsdom.
+ *
+ * Server component on purpose: `@vendoai/apps` is server-side, so the plans are
+ * turned into trees here and only plain JSON crosses into the client.
+ */
+import { skeletonFromPlan } from "@vendoai/apps";
+import type { AppPlan } from "@vendoai/core";
+import { SkeletonHarness } from "./harness";
+
+const tabbed: AppPlan = {
+  name: "Invoices workspace",
+  queries: [],
+  groups: [
+    {
+      tab: "Overview",
+      title: "Receivables health",
+      layout: "grid",
+      leaves: [
+        { component: "Stat", purpose: "outstanding total" },
+        { component: "Stat", purpose: "overdue total" },
+        { component: "Stat", purpose: "paid this month" },
+      ],
+    },
+    {
+      tab: "Overview",
+      title: "Invoiced per month",
+      leaves: [{ component: "BarChart", purpose: "invoiced per month, last twelve" }],
+    },
+    {
+      tab: "Overdue",
+      title: "Worst first",
+      leaves: [
+        { component: "DataTable", purpose: "overdue invoices, worst first" },
+        { component: "Button", purpose: "chase the worst one" },
+      ],
+    },
+    {
+      tab: "Payments",
+      title: "Payment history",
+      leaves: [{ component: "CardList", purpose: "recent payments" }],
+    },
+  ],
+  cannot: [],
+};
+
+const single: AppPlan = {
+  name: "Account balances",
+  queries: [],
+  groups: [
+    {
+      title: "Balances",
+      layout: "grid",
+      leaves: [
+        { component: "Stat", purpose: "checking balance" },
+        { component: "Stat", purpose: "savings balance" },
+      ],
+    },
+    {
+      title: "Recent transactions",
+      leaves: [{ component: "DataTable", purpose: "last thirty transactions" }],
+    },
+  ],
+  cannot: [],
+};
+
+export default function SkeletonHarnessPage() {
+  const tabbedSkeleton = skeletonFromPlan(tabbed);
+  const singleSkeleton = skeletonFromPlan(single);
+  return (
+    <SkeletonHarness
+      tabbed={{ root: tabbedSkeleton.tree.root, nodes: tabbedSkeleton.tree.nodes }}
+      single={{ root: singleSkeleton.tree.root, nodes: singleSkeleton.tree.nodes }}
+    />
+  );
+}

--- a/packages/apps/src/checking/facts.ts
+++ b/packages/apps/src/checking/facts.ts
@@ -304,7 +304,10 @@ const prewiredPropsIssues = (node: TreeNode): FactIssue[] => {
   const props = node.props;
   if (allowed === undefined || props === undefined) return [];
   return Object.keys(props)
-    .filter((name) => !allowed.has(name))
+    // `pending` is the renderer's own placeholder cue, not a component prop —
+    // the plan skeleton writes it on every leaf (generation/skeleton.ts) and a
+    // section whose fill honestly failed keeps it.
+    .filter((name) => name !== "pending" && !allowed.has(name))
     .map((name) => atNode(node.id, `sets unknown prop "${name}" on prewired component "${node.component}"; the renderer drops it. Allowed props: ${[...allowed].join(", ") || "(none)"}`));
 };
 

--- a/packages/apps/src/generation/skeleton.test.ts
+++ b/packages/apps/src/generation/skeleton.test.ts
@@ -1,0 +1,136 @@
+/**
+ * The deterministic skeleton (generation pipeline rebuild, Task 5): a plan
+ * becomes the app's REAL layout the moment the plan lands — tab chrome from
+ * the group labels, one shimmering placeholder per leaf, and a slot map the
+ * fill workers splice their fragments into.
+ *
+ * The load-bearing property is streaming-prefix stability: the skeleton of a
+ * PREFIX of the plan must mint the same ids as the skeleton of the whole plan,
+ * so a plan arriving group by group makes the UI GROW instead of re-mounting.
+ */
+import { validateTree, type AppPlan } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { skeletonFromPlan } from "./skeleton.js";
+
+const plan = (groups: AppPlan["groups"], extra: Partial<AppPlan> = {}): AppPlan => ({
+  name: "Invoices",
+  queries: [],
+  groups,
+  cannot: [],
+  ...extra,
+});
+
+const tabbed = plan([
+  {
+    tab: "Overview",
+    title: "Health",
+    leaves: [
+      { component: "Stat", purpose: "outstanding total" },
+      { component: "BarChart", purpose: "invoiced per month" },
+    ],
+  },
+  {
+    tab: "Overdue",
+    title: "Worst first",
+    layout: "grid",
+    leaves: [{ component: "DataTable", purpose: "overdue invoices, worst first" }],
+  },
+  {
+    tab: "Overview",
+    leaves: [{ component: "CardList", purpose: "recent payments" }],
+  },
+]);
+
+const node = (skeleton: ReturnType<typeof skeletonFromPlan>, id: string) =>
+  skeleton.tree.nodes.find((candidate) => candidate.id === id);
+
+describe("skeletonFromPlan", () => {
+  it("gives a tabbed plan tab chrome carrying the tab titles, in order of first appearance", () => {
+    const skeleton = skeletonFromPlan(tabbed);
+    const chrome = skeleton.tree.nodes.find((candidate) => candidate.component === "Tabs");
+    expect(chrome?.props?.tabs).toEqual([
+      { value: "Overview", label: "Overview" },
+      { value: "Overdue", label: "Overdue" },
+    ]);
+    // One panel per tab, nested under the bar so the bar owns the switch.
+    expect(node(skeleton, skeleton.tree.root)?.children).toEqual(["tabs"]);
+    expect(chrome?.children).toEqual(["tab-0", "tab-1"]);
+    // The two Overview groups share one panel; the panel holds them in plan order.
+    const panels = skeleton.tree.nodes.filter((candidate) => candidate.id.startsWith("tab-"));
+    expect(panels.map((panel) => panel.children)).toEqual([["group-0", "group-2"], ["group-1"]]);
+    expect(validateTree(skeleton.tree).ok).toBe(true);
+  });
+
+  it("renders every leaf as one pending placeholder and records each group's fill slot", () => {
+    const skeleton = skeletonFromPlan(tabbed);
+    const placeholders = skeleton.tree.nodes.filter((candidate) => candidate.props?.pending === true);
+    expect(placeholders).toEqual([
+      { id: "group-0-leaf-0", component: "Stat", source: "prewired", props: { pending: true } },
+      { id: "group-0-leaf-1", component: "BarChart", source: "prewired", props: { pending: true } },
+      { id: "group-1-leaf-0", component: "DataTable", source: "prewired", props: { pending: true } },
+      { id: "group-2-leaf-0", component: "CardList", source: "prewired", props: { pending: true } },
+    ]);
+    expect(skeleton.slots).toEqual({
+      "group-0": "group-0-body",
+      "group-1": "group-1-body",
+      "group-2": "group-2-body",
+    });
+    // Each slot is the container whose children a fill fragment replaces, and
+    // it holds exactly that group's placeholders.
+    expect(node(skeleton, "group-0-body")?.children).toEqual(["group-0-leaf-0", "group-0-leaf-1"]);
+    // A group's title is chrome the worker never has to rewrite; `layout` picks
+    // the slot's container.
+    expect(node(skeleton, "group-0-title")?.props).toEqual({ text: "Health", variant: "heading" });
+    expect(node(skeleton, "group-1-body")?.component).toBe("Grid");
+    expect(node(skeleton, "group-1-body")?.props).toEqual({ columns: 1 });
+    expect(node(skeleton, "group-0-body")?.component).toBe("Stack");
+  });
+
+  it("gives a plan with no tab labels a single surface and no tab chrome", () => {
+    const skeleton = skeletonFromPlan(plan([
+      { title: "Balances", leaves: [{ component: "Stat", purpose: "balance" }] },
+      { leaves: [{ component: "DataTable", purpose: "transactions" }] },
+    ]));
+    expect(skeleton.tree.nodes.some((candidate) => candidate.component === "Tabs")).toBe(false);
+    expect(node(skeleton, skeleton.tree.root)?.children).toEqual(["group-0", "group-1"]);
+    expect(validateTree(skeleton.tree).ok).toBe(true);
+  });
+
+  it("carries the plan's queries onto the tree so fragments have something to bind to", () => {
+    const skeleton = skeletonFromPlan(plan(
+      [{ leaves: [{ component: "DataTable", query: "invoices", purpose: "invoices" }] }],
+      { queries: [{ id: "invoices", tool: "host_listInvoices", input: { status: "overdue" } }] },
+    ));
+    expect(skeleton.tree.queries).toEqual([
+      { name: "invoices", tool: "host_listInvoices", input: { status: "overdue" } },
+    ]);
+  });
+
+  it("STREAMING-PREFIX STABILITY: a prefix plan's ids are the full skeleton's, unchanged", () => {
+    const full = skeletonFromPlan(tabbed);
+    const fullIds = new Set(full.tree.nodes.map((candidate) => candidate.id));
+
+    for (let count = 1; count <= tabbed.groups.length; count += 1) {
+      const prefix = skeletonFromPlan({ ...tabbed, groups: tabbed.groups.slice(0, count) });
+      // No id may change, so ids can never be derived from what comes LATER
+      // (a count, a total, a hash of the whole plan).
+      for (const candidate of prefix.tree.nodes) {
+        expect(fullIds.has(candidate.id), `prefix ${count} minted unknown id "${candidate.id}"`).toBe(true);
+      }
+      // The UI grows: every surviving parent keeps its children in place and
+      // only appends, so React re-mounts nothing.
+      for (const candidate of prefix.tree.nodes) {
+        const grown = node(full, candidate.id);
+        expect(grown?.children ?? []).toEqual(
+          expect.arrayContaining(candidate.children ?? []),
+        );
+        expect((grown?.children ?? []).slice(0, (candidate.children ?? []).length))
+          .toEqual(candidate.children ?? []);
+      }
+      // And every slot the prefix reported still points at the same node.
+      for (const [group, slot] of Object.entries(prefix.slots)) {
+        expect(full.slots[group]).toBe(slot);
+      }
+    }
+  });
+});

--- a/packages/apps/src/generation/skeleton.ts
+++ b/packages/apps/src/generation/skeleton.ts
@@ -1,0 +1,135 @@
+/**
+ * The deterministic skeleton (generation pipeline rebuild, Task 5;
+ * docs/superpowers/plans/2026-07-28-generation-pipeline-rebuild.md).
+ *
+ * A plan is not a preview — it IS the app's layout. The moment the brain's
+ * plan lands, this turns it into the real tree: tab chrome derived from the
+ * group labels, one titled surface per group, and one placeholder per leaf
+ * that shimmers until a fill worker writes the real thing into its slot.
+ * Nothing here calls a model; the same plan always yields the same tree.
+ *
+ * Ids are positional ON PURPOSE. A plan streams in group by group, and the
+ * skeleton is re-derived on every arrival, so an id may never depend on
+ * anything that comes LATER (a count, a hash of the whole plan) — otherwise
+ * the growing app re-mounts under the user instead of filling in.
+ */
+import {
+  VENDO_TREE_FORMAT,
+  planTabs,
+  type AppPlan,
+  type Json,
+  type Tree,
+  type TreeNode,
+  type TreeQuery,
+} from "@vendoai/core";
+
+export interface Skeleton {
+  tree: Tree;
+  /** Group id → the node whose children a fill fragment replaces. Group ids are
+   *  positional (`group-{index in plan.groups}`) and the keys are in plan
+   *  order, so a fill worker for `plan.groups[i]` splices into
+   *  `slots[`group-${i}`]`. */
+  slots: Record<string, string>;
+}
+
+const APP_ID = "app";
+const TAB_CHROME_ID = "tabs";
+const groupId = (index: number): string => `group-${index}`;
+const tabPanelId = (index: number): string => `tab-${index}`;
+
+/** The plan's layout as a tree, with every leaf still pending. */
+export const skeletonFromPlan = (plan: AppPlan): Skeleton => {
+  const tabs = planTabs(plan);
+  const nodes: TreeNode[] = [];
+  const slots: Record<string, string> = {};
+  const groupIdsWithTab = (tab: string | undefined): string[] =>
+    plan.groups.flatMap((group, index) => (group.tab === tab ? [groupId(index)] : []));
+
+  // Groups the plan never labelled stand above the tab bar as one shared
+  // surface — a label-less group belongs to no tab, and hiding it inside the
+  // first one would be a quiet lie about where it lives.
+  nodes.push({
+    id: APP_ID,
+    component: "Stack",
+    source: "prewired",
+    children: [
+      ...groupIdsWithTab(undefined),
+      ...(tabs.length === 0 ? [] : [TAB_CHROME_ID]),
+    ],
+  });
+
+  if (tabs.length > 0) {
+    // The panels are the bar's CHILDREN, one per tab in tab order — that
+    // nesting is what makes the bar own which panel shows (packages/ui
+    // tree/branded.tsx Tabs), so switching tabs never leaves the browser.
+    nodes.push({
+      id: TAB_CHROME_ID,
+      component: "Tabs",
+      source: "prewired",
+      props: { tabs: tabs.map((label) => ({ value: label, label })), value: tabs[0] as string },
+      children: tabs.map((_, index) => tabPanelId(index)),
+    });
+    for (const [index, label] of tabs.entries()) {
+      nodes.push({
+        id: tabPanelId(index),
+        component: "Stack",
+        source: "prewired",
+        children: groupIdsWithTab(label),
+      });
+    }
+  }
+
+  for (const [index, group] of plan.groups.entries()) {
+    const id = groupId(index);
+    const slot = `${id}-body`;
+    const title = group.title === undefined ? undefined : `${id}-title`;
+    nodes.push({
+      id,
+      component: "Surface",
+      source: "prewired",
+      children: [...(title === undefined ? [] : [title]), slot],
+    });
+    if (title !== undefined) {
+      nodes.push({
+        id: title,
+        component: "Text",
+        source: "prewired",
+        props: { text: group.title as string, variant: "heading" },
+      });
+    }
+    // The slot container survives the fill (the worker writes its CHILDREN), so
+    // a grid group's column count is decided here: one column per leaf, capped
+    // at four — beyond that a single row is unreadable at panel width.
+    nodes.push({
+      id: slot,
+      component: group.layout === "grid" ? "Grid" : "Stack",
+      source: "prewired",
+      ...(group.layout === "grid"
+        ? { props: { columns: Math.min(Math.max(group.leaves.length, 1), 4) } }
+        : {}),
+      children: group.leaves.map((_, leaf) => `${id}-leaf-${leaf}`),
+    });
+    for (const [leaf, { component }] of group.leaves.entries()) {
+      // `pending: true` is the renderer's cue to hold the component's shimmer
+      // silhouette (packages/ui tree/renderer.tsx) — the app's real geometry,
+      // arriving in pieces, never a spinner over the whole surface.
+      nodes.push({ id: `${id}-leaf-${leaf}`, component, source: "prewired", props: { pending: true } });
+    }
+    slots[id] = slot;
+  }
+
+  const queries: TreeQuery[] = plan.queries.map((query) => ({
+    name: query.id,
+    tool: query.tool,
+    input: query.input as Record<string, Json>,
+  }));
+  return {
+    tree: {
+      formatVersion: VENDO_TREE_FORMAT,
+      root: APP_ID,
+      nodes,
+      ...(queries.length === 0 ? {} : { queries }),
+    },
+    slots,
+  };
+};

--- a/packages/apps/src/index.ts
+++ b/packages/apps/src/index.ts
@@ -102,6 +102,11 @@ export type {
   CheckingLayer,
   Finding,
 } from "./checking/types.js";
+// The plan→layout function, exported for the same reason as the bench loaders
+// above (the exports map closes deep imports): it is a pure, deterministic
+// function of the public AppPlan, so demo/harness surfaces can render a plan's
+// skeleton without booting the engine.
+export { skeletonFromPlan, type Skeleton } from "./generation/skeleton.js";
 export {
   modelEngine,
   type GeneratedAppDocument,

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -445,7 +445,13 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the wave-2
     light-dark(color-mix(in srgb, var(--vendo-accent) 10%, transparent), color-mix(in srgb, var(--vendo-accent) 16%, transparent)) 30%,
     light-dark(color-mix(in srgb, var(--vendo-accent) 22%, transparent), color-mix(in srgb, var(--vendo-accent) 32%, transparent)) 50%,
     light-dark(color-mix(in srgb, var(--vendo-accent) 10%, transparent), color-mix(in srgb, var(--vendo-accent) 16%, transparent)) 70%);
-  background-size: 200% 100%; animation: fl-glass-shimmer 1.8s linear infinite; }
+  background-size: 200% 100%; }
+/* The sweep is decoration over the tint, and a skeleton can sit on screen for
+   seconds while a plan fills in — reduced motion keeps the placeholder and
+   drops the movement. */
+@media (prefers-reduced-motion: no-preference) {
+  .fl-glass-shimmer { animation: fl-glass-shimmer 1.8s linear infinite; }
+}
 @keyframes fl-glass-shimmer { from { background-position: 120% 0; } to { background-position: -80% 0; } }
 /* The approved grid: a view forming — 3 stat tiles, a wide chart, two rows. */
 .fl-glass-grid { display: grid; gap: 8px; margin-top: 12px; grid-template-columns: repeat(3, 1fr); }

--- a/packages/ui/src/tree/branded.tsx
+++ b/packages/ui/src/tree/branded.tsx
@@ -1,5 +1,7 @@
 import {
+  Children,
   useId,
+  useState,
   type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
   type PropsWithChildren,
@@ -537,10 +539,20 @@ export interface TabsProps {
   tabs?: TabItem[];
   items?: TabItem[];
   onChange?: PrimitiveAction;
+  /** One panel per tab, in tab order. Present when the tree nests each tab's
+   *  content under the bar (the plan skeleton does); a bar with no panels stays
+   *  the pure chrome + action surface stored apps were written against. */
+  children?: ReactNode;
 }
 
-/** Bound per-tab actions preserve selected-value payloads without event plumbing. */
-export function Tabs({ label = "Tabs", value, tabs, items, onChange }: TabsProps) {
+/** Bound per-tab actions preserve selected-value payloads without event plumbing.
+ *  With panels nested inside, the bar also owns which one shows: switching tabs
+ *  is view state, so it must never need a round trip. */
+export function Tabs({ label = "Tabs", value, tabs, items, onChange, children }: TabsProps) {
+  const panels = Children.toArray(children);
+  const selfManaged = panels.length > 0;
+  const [picked, setPicked] = useState<number | undefined>(undefined);
+  const panelIdBase = useId();
   const normalized = (tabs ?? items ?? []).map((item) => {
     if (typeof item !== "object" || item === null) {
       return { value: content(item), label: content(item), disabled: false, onSelect: undefined };
@@ -555,6 +567,9 @@ export function Tabs({ label = "Tabs", value, tabs, items, onChange }: TabsProps
   const selected = value === undefined || value === null
     ? normalized.find((item) => !item.disabled)?.value
     : content(value);
+  // Panels are positional, so a bar that owns them selects by index. With no
+  // panels nothing changes: `value` stays the only truth, as stored apps expect.
+  const activeIndex = picked ?? Math.max(0, normalized.findIndex((item) => item.value === selected));
   const focusTab = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
     const offsets: Partial<Record<string, number>> = { ArrowLeft: -1, ArrowUp: -1, ArrowRight: 1, ArrowDown: 1 };
     const offset = offsets[event.key];
@@ -572,7 +587,7 @@ export function Tabs({ label = "Tabs", value, tabs, items, onChange }: TabsProps
         : (current + (offset ?? 0) + buttons.length) % buttons.length;
     buttons[target]?.focus();
   };
-  return (
+  const bar = (
     <div
       role="tablist"
       aria-label={label}
@@ -592,16 +607,21 @@ export function Tabs({ label = "Tabs", value, tabs, items, onChange }: TabsProps
       }}
     >
       {normalized.map((item, index) => {
-        const active = item.value === selected;
+        const active = selfManaged ? index === activeIndex : item.value === selected;
         return (
           <button
             key={`${item.value}-${index}`}
+            id={selfManaged ? `${panelIdBase}-tab-${index}` : undefined}
             type="button"
             role="tab"
             aria-selected={active}
+            aria-controls={selfManaged ? `${panelIdBase}-panel-${index}` : undefined}
             tabIndex={active ? 0 : -1}
             disabled={item.disabled}
-            onClick={() => run(item.onSelect ?? onChange)}
+            onClick={() => {
+              if (selfManaged) setPicked(index);
+              run(item.onSelect ?? onChange);
+            }}
             onKeyDown={focusTab}
             style={{
               ...font,
@@ -626,6 +646,19 @@ export function Tabs({ label = "Tabs", value, tabs, items, onChange }: TabsProps
           </button>
         );
       })}
+    </div>
+  );
+  if (!selfManaged) return bar;
+  return (
+    <div style={{ ...font, display: "flex", flexDirection: "column", gap: "var(--vendo-density-content-gap, 10px)" }}>
+      {bar}
+      <div
+        role="tabpanel"
+        id={`${panelIdBase}-panel-${activeIndex}`}
+        aria-labelledby={`${panelIdBase}-tab-${activeIndex}`}
+      >
+        {panels[activeIndex]}
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/tree/forming-skeleton.tsx
+++ b/packages/ui/src/tree/forming-skeleton.tsx
@@ -1,7 +1,7 @@
 import type { CSSProperties } from "react";
 import { Skeleton } from "./primitives.js";
 
-export type FormShape = "slab" | "tiles" | "rows" | "pill";
+export type FormShape = "slab" | "tiles" | "rows" | "pill" | "chart" | "control";
 
 /**
  * Pick A (ui-lane-renderer, 2026-07-19) — the tree streams before generated
@@ -10,6 +10,13 @@ export type FormShape = "slab" | "tiles" | "rows" | "pill";
  * historical 72px slab, so the fallback is never worse than before.
  */
 export function deriveFormShape(componentName: string): FormShape {
+  // A plot is the tallest thing in an app; a 72px slab that becomes a 180px
+  // chart is the layout jump the skeleton exists to prevent. Sparkline is
+  // deliberately excluded — it is an inline mark, not a plot.
+  if (/chart|graph|plot/i.test(componentName)) return "chart";
+  // A control is a small left-aligned thing; a full-width slab where a button
+  // lands reads as a broken section and then collapses when the real one lands.
+  if (/button|submit|cta/i.test(componentName)) return "control";
   if (/badge|pill|tags?|chips?/i.test(componentName)) return "pill";
   if (/list|table|rows?|feed|history|log/i.test(componentName)) return "rows";
   // stat(?!us) — "RenewalStats" forms tiles, but "StatusRow" must not.
@@ -42,6 +49,20 @@ export function FormingSkeleton({ name }: { name: string }) {
       </span>
     );
   }
+  if (shape === "chart") {
+    return (
+      <span data-form-shape="chart" style={{ display: "block", width: "100%" }} aria-hidden="true">
+        <Skeleton height={180} />
+      </span>
+    );
+  }
+  if (shape === "control") {
+    return (
+      <span data-form-shape="control" style={{ display: "block", width: "100%" }} aria-hidden="true">
+        <Skeleton width={148} height="var(--vendo-density-control-height, 38px)" />
+      </span>
+    );
+  }
   if (shape === "pill") {
     return (
       <span data-form-shape="pill" style={{ display: "flex", justifyContent: "flex-end", width: "100%" }} aria-hidden="true">
@@ -52,6 +73,21 @@ export function FormingSkeleton({ name }: { name: string }) {
   return (
     <span data-form-shape="slab" style={{ display: "block", width: "100%" }} aria-hidden="true">
       <Skeleton height="72px" />
+    </span>
+  );
+}
+
+/**
+ * One PLAN LEAF that has not been filled yet (generation pipeline rebuild,
+ * Task 5). A leaf is exactly one component, so a stat-shaped leaf is one tile —
+ * the three-tile band above is the silhouette of a whole forming REGION, and
+ * repeating it per leaf would show nine tiles for three stats.
+ */
+export function PendingLeaf({ name }: { name: string }) {
+  if (deriveFormShape(name) !== "tiles") return <FormingSkeleton name={name} />;
+  return (
+    <span data-form-shape="tile" style={{ display: "block", width: "100%" }} aria-hidden="true">
+      <Skeleton height={64} />
     </span>
   );
 }

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -28,7 +28,7 @@ import type { InClientVenue, PinDrift } from "../wire-types.js";
 import { resolvePointer } from "./bindings.js";
 import { NodeErrorBoundary } from "./error-boundary.js";
 import { FluidReveal } from "./fluid-reveal.js";
-import { deriveFormShape, FormingSkeleton } from "./forming-skeleton.js";
+import { deriveFormShape, FormingSkeleton, PendingLeaf } from "./forming-skeleton.js";
 import { InClientMount } from "./host-mount.js";
 import { JailedComponent, type JailFurnishing } from "./jail/JailedComponent.js";
 import { ContainedNotice } from "./notice.js";
@@ -374,6 +374,20 @@ function NodeRenderer(props: NodeRendererProps) {
   }
   if (props.ancestry.has(node.id)) {
     return <ContainedNotice label="Cyclic tree node">{`Node "${node.id}" forms a cycle.`}</ContainedNotice>;
+  }
+  // The plan's skeleton (packages/apps generation/skeleton.ts) prewires one
+  // `pending` placeholder per plan leaf and a fill worker later replaces it
+  // with the real component. Until then the node holds the same shape-derived
+  // shimmer a streaming node holds — the app's real geometry arriving in
+  // pieces, never a spinner over the whole surface. This runs BEFORE component
+  // resolution on purpose: a placeholder for a name that resolves later (an
+  // island the plan declared) shimmers instead of reading as unknown.
+  if (node.props?.pending === true) {
+    return (
+      <div data-vendo-node-id={node.id} data-vendo-pending="" aria-busy="true">
+        <PendingLeaf name={node.component} />
+      </div>
+    );
   }
 
   const ancestry = new Set(props.ancestry);


### PR DESCRIPTION
## Task 5 — Skeleton + renderer pending states

`skeletonFromPlan(plan)` turns an `AppPlan` into the app's **real layout** the
moment the plan lands: tab chrome derived from the group labels (via the landed
`planTabs`, not re-derived), one titled `Surface` per group, one placeholder per
leaf, and `slots: Record<groupId, nodeId>` for the fill workers (Task 7) to
splice fragments into. Deterministic — no model call, same plan → same tree.

Ids are **positional on purpose**. A plan streams group by group and the
skeleton is re-derived on each arrival, so no id may depend on anything later.
The streaming-prefix test is mutation-proven: making `groupId` include
`plan.groups.length` fails it with `prefix 1 minted unknown id "group-0-of-1"`.

### Browser proof (demo-bank, real Chromium)

Hardcoded plans rendered through the production `TreeView` at
`/vendo/skeleton-harness` (dev harness, demo-only — no library code).
Screenshots are on `proof/rebuild-skeleton` because `.gitignore` +
`docs/verification/README.md` keep media out of the tree.

**Tabbed skeleton — Overview tab.** Tab bar carries the three plan labels;
three `Stat` leaves as one tile each in a 3-column grid; the `BarChart` leaf as
a chart-height silhouette.

![tabbed overview](https://raw.githubusercontent.com/runvendo/vendo/proof/rebuild-skeleton/tabbed-overview.png)

**Tabbed skeleton — Overdue tab, after a real click.** Tabs switch client-side,
no round trip; the `DataTable` leaf takes row shape, the `Button` leaf a control
shape.

![tabbed overdue](https://raw.githubusercontent.com/runvendo/vendo/proof/rebuild-skeleton/tabbed-overdue.png)

**Single-surface variant.** A plan with no tab labels: no tab chrome at all.

![single surface](https://raw.githubusercontent.com/runvendo/vendo/proof/rebuild-skeleton/single-surface.png)

### Design pass (`design` → `emil-design-eng`, `refactoring-ui`)

- **Reuse over invention.** The pending state is the existing
  `fl-glass-shimmer` treatment (host accent via `color-mix`, `light-dark()`);
  zero new colors, zero hardcoded values, all spacing from theme tokens.
- **A leaf is one component.** `PendingLeaf` shows one tile where the
  region-sized `FormingSkeleton` shows a three-tile band — three `Stat` leaves
  were painting nine tiles.
- **No layout jumps.** New `chart` (180px) and `control` (148×control-height)
  silhouettes, so a chart placeholder isn't a 72px slab that triples in height
  and a button isn't a full-width slab that collapses.
- **Grid columns are decided in the skeleton** (one per leaf, capped at 4)
  because the slot container survives the fill — the worker writes children,
  not the container.
- **Reduced motion.** `.fl-glass-shimmer`'s sweep is now gated behind
  `prefers-reduced-motion: no-preference` (verified with `emulateMedia`:
  `animationName: none`, tint retained). A skeleton can sit on screen for
  seconds; the movement is decoration, the placeholder is not.

### Renderer

`pending: true` renders **before** component resolution, so a placeholder for a
name that resolves later (an island the plan declared) shimmers instead of
reading as an unknown component. `aria-busy` on the wrapper.

Tab panels are the bar's **children** — that nesting is what lets the bar own
which panel shows (switching tabs is view state and must never need a round
trip). A bar with no children behaves exactly as before, so stored apps render
byte-identically.

### Two small cross-task edits, called out

- `packages/apps/src/index.ts` exports `skeletonFromPlan` — the exports map
  closes deep imports, and the browser proof needs it (same reason the bench
  loaders are exported). Pure function of the public `AppPlan`.
- `packages/apps/src/checking/facts.ts` allows the `pending` prop name: it is a
  renderer cue, not a component prop, so a section whose fill honestly failed
  (Task 7) must not also collect a bogus unknown-prop finding.

### Gates

`pnpm build` · `pnpm typecheck` · `pnpm lint` · `pnpm --filter @vendoai/apps
test` (784 passed) · `pnpm --filter @vendoai/ui test` (648 passed) — all green.

Tests added (`packages/apps/src/generation/skeleton.test.ts`):
1. gives a tabbed plan tab chrome carrying the tab titles, in order of first appearance
2. renders every leaf as one pending placeholder and records each group's fill slot
3. gives a plan with no tab labels a single surface and no tab chrome
4. carries the plan's queries onto the tree so fragments have something to bind to
5. STREAMING-PREFIX STABILITY: a prefix plan's ids are the full skeleton's, unchanged


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a deterministic app skeleton from `AppPlan` with per-leaf pending placeholders and streaming‑safe IDs. The renderer now shows component‑shaped shimmers and tabs switch panels client‑side without layout jumps.

- **New Features**
  - Deterministic skeleton: `skeletonFromPlan(plan)` builds tabs from labels, one `Surface` per group, one placeholder per leaf, and a slots map for fills; IDs are positional and streaming‑prefix stable; carries plan queries; exported from `@vendoai/apps`.
  - Renderer + UI: `pending: true` renders a `PendingLeaf` before component resolution with chart/control silhouettes and `aria-busy`; `Tabs` now accept panels as children and manage selection locally; shimmer animation respects `prefers-reduced-motion`.
  - Dev harness + tests: demo at `/vendo/skeleton-harness` (tabbed and single‑surface plans) using `@vendoai/ui` `TreeView`; added tests for tabs, placeholders/slots, single‑surface variant, queries, and streaming‑prefix stability.

<sup>Written for commit 2edd4da9be8a91edd934bd1987b8563f54a5a5b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

