### PR TITLE
feat(apps): island/automation/box lanes driven by the plan; box binds after build

### DIFF
--- a/packages/apps/src/generation/engine.ts
+++ b/packages/apps/src/generation/engine.ts
@@ -438,8 +438,9 @@ const repairPrompt = (issues: string[]): string =>
   issues.length === 0 ? "" : `\nREPAIR_THESE_ISSUES: ${JSON.stringify(issues)}`;
 
 /** Raw-text model call for the edit dialect (no streaming seam: edits are
- *  small and apply atomically). */
-const generateWireText = async (
+ *  small and apply atomically). Shared with the island lane (lanes.ts), whose
+ *  answers are the same shape: one small, atomic piece of markup. */
+export const generateWireText = async (
   deps: GenerationDependencies,
   system: string,
   prompt: string,

--- a/packages/apps/src/generation/lanes.test.ts
+++ b/packages/apps/src/generation/lanes.test.ts
@@ -1,0 +1,459 @@
+import {
+  VENDO_APP_FORMAT,
+  type AppPlan,
+  type ApprovalRequest,
+  type RunContext,
+  type ShapeType,
+} from "@vendoai/core";
+import type { LanguageModel } from "ai";
+import { describe, expect, it } from "vitest";
+import { scriptedLanguageModel, type ScriptedModelCall } from "../testing/index.js";
+import type { GeneratedAppDocument, HostToolInfo } from "./engine.js";
+import {
+  laneGates,
+  runIslandLane,
+  runServerLane,
+  type BoxOutcome,
+  type BoxSeam,
+  type IslandLaneDeps,
+  type ServerLaneDeps,
+} from "./lanes.js";
+
+/**
+ * The rare lanes (generation pipeline rebuild, Task 8): the island the plan
+ * declares, the automation it declares, and the box — whose whole law is that
+ * NOTHING is written against its functions until it says what it built.
+ */
+
+const ctx: RunContext = {
+  principal: { kind: "user", subject: "user_ada" },
+  venue: "chat",
+  presence: "present",
+  sessionId: "session_ada",
+};
+
+const tools: HostToolInfo[] = [
+  { name: "host_listInvoices", description: "Every invoice with its amount and due date.", risk: "read" },
+  { name: "host_send_email", description: "Send an email.", risk: "write", inputSchema: { type: "object", properties: { subject: {}, body: {} } } },
+  { name: "vendo_apps_data_put", description: "Publish an app record.", risk: "write" },
+  { name: "vendo_apps_data_list", description: "Read app records.", risk: "read" },
+];
+
+const invoiceShape: ShapeType = {
+  kind: "array",
+  items: { kind: "object", fields: { client: { kind: "string" }, amountCents: { kind: "number" } } },
+};
+
+const document = (): GeneratedAppDocument => ({
+  format: VENDO_APP_FORMAT,
+  name: "Invoices workspace",
+  ui: "tree",
+  tree: {
+    formatVersion: "vendo-genui/v2",
+    root: "app",
+    nodes: [{ id: "app", component: "Stack", source: "prewired", children: [] }],
+  } as GeneratedAppDocument["tree"],
+});
+
+/** A scripted model that also records every prompt it was handed. */
+const scripted = (calls: ScriptedModelCall[], ...answers: string[]): LanguageModel =>
+  scriptedLanguageModel((call, index) => {
+    calls.push(call);
+    return answers[Math.min(index, answers.length - 1)] as string;
+  });
+
+const promptText = (call: ScriptedModelCall | undefined): string => (call?.prompt ?? []).map((message) => (
+  typeof message.content === "string" ? message.content : message.content.map((part) => part.text ?? "").join("")
+)).join("\n");
+
+// ---------------------------------------------------------------------------
+// The island lane
+// ---------------------------------------------------------------------------
+
+const islandPlan = (): AppPlan => ({
+  name: "Invoices workspace",
+  queries: [{ id: "invoices", tool: "host_listInvoices", input: { limit: 50 } }],
+  groups: [{
+    tab: "Overview",
+    leaves: [{ component: "SpendHeatmap", query: "invoices", purpose: "Spend by day, darker where more money left" }],
+  }],
+  island: { name: "SpendHeatmap", purpose: "A day-by-day heat grid of spend" },
+  cannot: [],
+});
+
+/** Reaches for the network — the sandbox has none, so this island would render
+ *  a permanent empty grid in production. */
+const NETWORK_ISLAND = `<Island name="SpendHeatmap">
+export default function SpendHeatmap() {
+  const [live, setLive] = React.useState([]);
+  React.useEffect(() => { fetch("/api/spend").then((response) => response.json()).then(setLive); }, []);
+  return <div>{live.length}</div>;
+}
+</Island>`;
+
+/** Static reads pass; it crashes the moment it renders without rows. */
+const CRASHING_ISLAND = `<Island name="SpendHeatmap">
+export default function SpendHeatmap({ rows }) {
+  return <div>{rows.map((row, index) => <span key={index}>{fmt.money(row.amountCents)}</span>)}</div>;
+}
+</Island>`;
+
+const GOOD_ISLAND = `<Island name="SpendHeatmap">
+export default function SpendHeatmap({ rows }) {
+  const cells = Array.isArray(rows) ? rows : [];
+  return <div>{cells.map((cell, index) => <span key={index}>{fmt.money(cell.amountCents)}</span>)}</div>;
+}
+</Island>`;
+
+const islandDeps = (model: LanguageModel, overrides: Partial<IslandLaneDeps> = {}): IslandLaneDeps => ({
+  model,
+  catalog: [],
+  tools,
+  toolShapes: { host_listInvoices: invoiceShape },
+  ...overrides,
+});
+
+describe("runIslandLane", () => {
+  it("screens the island through prepareIslands: a network-violating island is rejected with the teaching message", async () => {
+    const calls: ScriptedModelCall[] = [];
+    const before = document();
+    const result = await runIslandLane(islandPlan(), before, islandDeps(scripted(calls, NETWORK_ISLAND)));
+
+    expect(result.findings.map(({ message }) => message).join(" ")).toContain("an island has no network");
+    expect(result.findings.every(({ severity }) => severity === "warn")).toBe(true);
+    expect(result.document).toEqual(before);
+    // The retry is handed the teaching sentence, not just "try again".
+    expect(promptText(calls[1])).toContain("an island has no network");
+  });
+
+  it("writes the island against its plan's purpose and query shapes", async () => {
+    const calls: ScriptedModelCall[] = [];
+    await runIslandLane(islandPlan(), document(), islandDeps(scripted(calls, GOOD_ISLAND), { pipeline: { smokeRender: false } }));
+
+    const prompt = promptText(calls[0]);
+    expect(prompt).toContain("ISLAND: SpendHeatmap");
+    expect(prompt).toContain("A day-by-day heat grid of spend");
+    expect(prompt).toContain("invoices: host_listInvoices");
+    expect(prompt).toContain("amountCents");
+  });
+
+  it("takes one fix-it retry with the issues and lands the corrected island", async () => {
+    const calls: ScriptedModelCall[] = [];
+    const result = await runIslandLane(islandPlan(), document(), islandDeps(scripted(calls, NETWORK_ISLAND, GOOD_ISLAND)));
+
+    expect(calls).toHaveLength(2);
+    expect(result.findings).toEqual([]);
+    expect(result.document.components?.SpendHeatmap).toContain("export default function SpendHeatmap");
+    // The per-island tool manifest is stamped even when it is empty (least
+    // privilege: this island reads no tools of its own).
+    expect(result.document.componentTools?.SpendHeatmap).toEqual([]);
+  });
+
+  it("screens through the smoke render too: a crash no static read can see drives the retry", async () => {
+    const calls: ScriptedModelCall[] = [];
+    const result = await runIslandLane(islandPlan(), document(), islandDeps(scripted(calls, CRASHING_ISLAND, GOOD_ISLAND)));
+
+    expect(promptText(calls[1])).toContain("crashed");
+    expect(result.findings).toEqual([]);
+    expect(result.document.components?.SpendHeatmap).toContain("Array.isArray(rows)");
+  });
+
+  it("fails honestly after the retry: the document is unchanged and the app stands without the island", async () => {
+    const calls: ScriptedModelCall[] = [];
+    const before = document();
+    const result = await runIslandLane(islandPlan(), before, islandDeps(scripted(calls, NETWORK_ISLAND, NETWORK_ISLAND)));
+
+    expect(calls).toHaveLength(2);
+    expect(result.document).toEqual(before);
+    expect(result.document.components).toBeUndefined();
+    expect(result.findings.length).toBeGreaterThan(0);
+    expect(result.findings.every(({ severity, where }) => severity === "warn" && where === 'island "SpendHeatmap"')).toBe(true);
+  });
+
+  it("does nothing at all when the plan declared no island", async () => {
+    const calls: ScriptedModelCall[] = [];
+    const plan = { ...islandPlan(), island: undefined };
+    const before = document();
+    const result = await runIslandLane(plan, before, islandDeps(scripted(calls, GOOD_ISLAND)));
+
+    expect(calls).toEqual([]);
+    expect(result).toEqual({ document: before, findings: [] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The server lane — steps / agentic
+// ---------------------------------------------------------------------------
+
+const APP_ID = "app_lanes";
+
+const stepsPlan = (): AppPlan => ({
+  name: "Invoices workspace",
+  queries: [],
+  groups: [{ title: "Health", leaves: [{ component: "Stat", purpose: "Total outstanding" }] }],
+  server: { kind: "steps", schedule: "fridays at 8am", why: "the digest has to be emailed while nobody is looking at the app" },
+  cannot: [],
+});
+
+const agenticPlan = (): AppPlan => ({
+  ...stepsPlan(),
+  server: { kind: "agentic", schedule: "every day", why: "each invoice needs a judgment call on how firm the nudge should be" },
+});
+
+const DIGEST_PLAN = JSON.stringify({
+  name: "Unpaid invoice digest",
+  resultsCollection: "digest",
+  trigger: {
+    on: { kind: "schedule", cron: "0 8 * * 5" },
+    run: {
+      kind: "steps",
+      steps: [
+        { id: "invoices", tool: "host_listInvoices" },
+        { id: "email", tool: "host_send_email", args: { subject: "'Unpaid invoice digest'", body: "steps.invoices" } },
+        { id: "publish", tool: "vendo_apps_data_put", args: { appId: `'${APP_ID}'`, collection: "'digest'", id: "'latest'", data: "steps.invoices" } },
+      ],
+    },
+  },
+});
+
+const NUDGE_PLAN = JSON.stringify({
+  name: "Invoice nudge triage",
+  trigger: {
+    on: { kind: "schedule", every: "1d" },
+    run: { kind: "agentic", prompt: "Decide who deserves a gentle vs firm nudge and draft accordingly.", budget: { maxToolCalls: 20 } },
+  },
+});
+
+const pendingApproval = (): ApprovalRequest => ({
+  id: "apr_email",
+  call: { id: "call_1", tool: "host_send_email", args: {} },
+  descriptor: { name: "host_send_email", description: "Send an email.", inputSchema: { type: "object" }, risk: "write" },
+  inputPreview: "host_send_email({})",
+  ctx: { principal: ctx.principal, venue: ctx.venue, presence: ctx.presence },
+  createdAt: new Date().toISOString(),
+});
+
+const serverDeps = (model: LanguageModel, overrides: Partial<ServerLaneDeps> = {}): ServerLaneDeps => ({
+  model,
+  catalog: [],
+  tools,
+  appId: APP_ID,
+  ctx,
+  ...overrides,
+});
+
+describe("runServerLane — steps and agentic automations", () => {
+  it("arms a trigger, declares its results storage, and binds the board to the results collection", async () => {
+    const calls: ScriptedModelCall[] = [];
+    const rebinds: string[] = [];
+    const landed: Array<{ document: GeneratedAppDocument; armTrigger: boolean }> = [];
+
+    const result = await runServerLane(stepsPlan(), document(), serverDeps(scripted(calls, DIGEST_PLAN), {
+      rebind: async (instruction, doc) => {
+        rebinds.push(instruction);
+        return { document: { ...doc, name: "Invoices workspace + digest" }, issues: [] };
+      },
+      land: async (doc, options) => { landed.push({ document: doc, armTrigger: options.armTrigger }); },
+    }));
+
+    expect(result.document.trigger?.on).toEqual({ kind: "schedule", cron: "0 8 * * 5" });
+    expect(result.document.storage?.digest?.kind).toBe("records");
+    // The rewire survives, and the automation it was authored for survives the
+    // rewire (a rebind that dropped the trigger would ship a dead automation).
+    expect(result.document.name).toBe("Invoices workspace + digest");
+    expect(rebinds[0]).toContain('collection:"digest"');
+    expect(rebinds[0]).toContain(`appId:"${APP_ID}"`);
+    expect(landed).toHaveLength(1);
+    expect(landed[0]?.document.trigger).toBeDefined();
+    // No arming seam wired → the persist arms the stored row itself.
+    expect(landed[0]?.armTrigger).toBe(true);
+    expect(result.automation).toMatchObject({ mode: "steps", resultsCollection: "digest" });
+    expect(result.findings).toEqual([]);
+  });
+
+  it("arms an agentic automation through the host's seam and surfaces the grants it is missing", async () => {
+    const landed: Array<{ armTrigger: boolean }> = [];
+    const result = await runServerLane(agenticPlan(), document(), serverDeps(scripted([], NUDGE_PLAN), {
+      land: async (_doc, options) => { landed.push({ armTrigger: options.armTrigger }); },
+      armAutomation: async () => ({ enabled: true, missing: [pendingApproval()] }),
+    }));
+
+    expect(result.automation?.mode).toBe("agentic");
+    expect(result.automation?.trigger.run.kind).toBe("agentic");
+    // The seam owns arming, so the persist must not arm the row behind it.
+    expect(landed[0]?.armTrigger).toBe(false);
+    expect(result.automation?.pendingGrants?.[0]?.id).toBe("apr_email");
+    expect(result.findings).toEqual([]);
+  });
+
+  it("says out loud when the arming seam leaves the trigger disabled", async () => {
+    const result = await runServerLane(agenticPlan(), document(), serverDeps(scripted([], NUDGE_PLAN), {
+      land: async () => undefined,
+      armAutomation: async () => ({ enabled: false, missing: [] }),
+    }));
+
+    expect(result.automation?.mode).toBe("agentic");
+    expect(result.findings.map(({ message }) => message).join(" ")).toContain("left it disabled");
+  });
+
+  it("keeps the automation when the board rewire fails, and reports the missing board", async () => {
+    const result = await runServerLane(stepsPlan(), document(), serverDeps(scripted([], DIGEST_PLAN), {
+      rebind: async () => ({ issues: ["binding /results/records/0 does not exist"] }),
+      land: async () => undefined,
+    }));
+
+    expect(result.document.trigger).toBeDefined();
+    expect(result.findings.map(({ message }) => message).join(" ")).toContain("was not rewired to show its results");
+    expect(result.findings.every(({ severity }) => severity === "warn")).toBe(true);
+  });
+
+  it("fails honestly when no automation plan validates: the app stands unchanged", async () => {
+    const before = document();
+    const result = await runServerLane(stepsPlan(), before, serverDeps(scripted([], "not an automation plan at all")));
+
+    expect(result.document).toEqual(before);
+    expect(result.automation).toBeUndefined();
+    expect(result.findings[0]?.severity).toBe("warn");
+    expect(result.findings.map(({ message }) => message).join(" ")).toContain("no valid plan validated");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The server lane — the box (bind after build)
+// ---------------------------------------------------------------------------
+
+const boxPlan = (): AppPlan => ({
+  name: "Ledger workspace",
+  queries: [],
+  groups: [
+    { title: "Uploads", leaves: [{ component: "DataTable", purpose: "the CSVs that landed today" }] },
+    { title: "Ledger", waitsForServer: true, leaves: [{ component: "DataTable", purpose: "the reconciled ledger, newest first" }] },
+  ],
+  server: { kind: "box", why: "reconciling the uploads needs custom dedup logic no tool can express" },
+  cannot: [],
+});
+
+/** A box that models the host's own rollback: a successful edit snapshots the
+ *  new code, a failed one is discarded WITHOUT a snapshot (runtime.ts
+ *  editServerViaBox). */
+const fakeBox = (outcome: BoxOutcome, available = true) => {
+  const state = { provisions: 0, instructions: [] as string[], snapshots: 0, discarded: false };
+  const seam: BoxSeam = {
+    available: () => available,
+    provision: async () => { state.provisions += 1; },
+    instruct: async (instruction) => {
+      state.instructions.push(instruction);
+      if (outcome.ok) state.snapshots += 1;
+      else state.discarded = true;
+      return outcome;
+    },
+  };
+  return { seam, state };
+};
+
+const BUILT_LEDGER: BoxOutcome = {
+  ok: true,
+  summary: "wrote the reconciliation ledger and verified it",
+  functions: [{ name: "reconciledLedger", sampleOutput: { rows: [{ client: "Acme", cents: 420000 }] } }],
+};
+
+describe("runServerLane — the box binds after build", () => {
+  it("sends the box no function signatures: it states the need and asks what got built", async () => {
+    const { seam, state } = fakeBox(BUILT_LEDGER);
+    await runServerLane(boxPlan(), document(), serverDeps(scripted([], "unused"), { box: seam }));
+
+    const instruction = state.instructions[0] ?? "";
+    expect(instruction).toContain("custom dedup logic");
+    expect(instruction).toContain("the reconciled ledger, newest first");
+    expect(instruction).toContain("report the interface you ended up serving");
+    // The law: nothing the app will bind to exists in the instruction — not the
+    // function the box goes on to write, and not an fn: reference to it.
+    expect(instruction).not.toContain("reconciledLedger");
+    expect(instruction).not.toContain("fn:");
+  });
+
+  it("returns the interface the box reports, with the samples its own code produced", async () => {
+    const { seam, state } = fakeBox(BUILT_LEDGER);
+    const result = await runServerLane(boxPlan(), document(), serverDeps(scripted([], "unused"), { box: seam }));
+
+    expect(state.provisions).toBe(1);
+    expect(result.server?.functions).toEqual([
+      { name: "reconciledLedger", sampleOutput: { rows: [{ client: "Acme", cents: 420000 }] } },
+    ]);
+    expect(result.findings).toEqual([]);
+  });
+
+  it("reports a box that built something but named no functions, so the waiting sections say so", async () => {
+    const { seam } = fakeBox({ ok: true, summary: "tidied the scaffold" });
+    const result = await runServerLane(boxPlan(), document(), serverDeps(scripted([], "unused"), { box: seam }));
+
+    expect(result.server?.functions).toEqual([]);
+    expect(result.findings.map(({ message }) => message).join(" ")).toContain("named no functions");
+  });
+
+  it("leaves the document unchanged and keeps no snapshot when the box fails", async () => {
+    const { seam, state } = fakeBox({ ok: false, summary: "the dedup tests never passed" });
+    const before = document();
+    const result = await runServerLane(boxPlan(), before, serverDeps(scripted([], "unused"), { box: seam }));
+
+    expect(result.document).toEqual(before);
+    expect(result.server).toBeUndefined();
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]?.severity).toBe("warn");
+    expect(result.findings[0]?.message).toContain("could not build the server work");
+    expect(state.snapshots).toBe(0);
+    expect(state.discarded).toBe(true);
+  });
+
+  it("refuses before provisioning anything when the host cannot run a box", async () => {
+    const { seam, state } = fakeBox(BUILT_LEDGER, false);
+    const before = document();
+    const result = await runServerLane(boxPlan(), before, serverDeps(scripted([], "unused"), { box: seam }));
+
+    expect(state.provisions).toBe(0);
+    expect(state.instructions).toEqual([]);
+    expect(result.document).toEqual(before);
+    expect(result.findings[0]?.message).toContain("cannot provision a machine");
+  });
+
+  it("does nothing at all when the plan declared no server work", async () => {
+    const plan = { ...boxPlan(), server: undefined };
+    const before = document();
+    const result = await runServerLane(plan, before, serverDeps(scripted([], "unused")));
+
+    expect(result).toEqual({ document: before, findings: [] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The gates the brain hears BEFORE it plans
+// ---------------------------------------------------------------------------
+
+describe("laneGates", () => {
+  it("yields the cannot reasons when the host's machine flags are off", () => {
+    const gates = laneGates({ machine: { sandbox: {} } });
+
+    expect(gates.box).toBe(false);
+    expect(gates.served).toBe(false);
+    expect(gates.cannot.join(" ")).toContain("machines disabled");
+    expect(gates.cannot.join(" ")).toContain("automations engine");
+  });
+
+  it("says a host with no sandbox at all cannot run server code, flag or no flag", () => {
+    const gates = laneGates({ experimentalMachines: true });
+
+    expect(gates.box).toBe(false);
+    expect(gates.cannot.join(" ")).toContain("no sandbox configured");
+  });
+
+  it("opens the box lane when the host has a sandbox and the flag on, and served only with its own flag", () => {
+    const withBox = laneGates({ machine: { sandbox: {} }, experimentalMachines: true });
+    expect(withBox.box).toBe(true);
+    expect(withBox.served).toBe(false);
+    expect(withBox.cannot.join(" ")).toContain("cannot serve its own web pages");
+
+    const withServed = laneGates({ machine: { sandbox: {} }, experimentalMachines: true, experimentalServedApps: true });
+    expect(withServed.served).toBe(true);
+    expect(withServed.cannot).toEqual([]);
+  });
+});

--- a/packages/apps/src/generation/lanes.ts
+++ b/packages/apps/src/generation/lanes.ts
@@ -1,0 +1,559 @@
+/**
+ * The rare lanes (generation pipeline rebuild, Task 8): the two things a plan
+ * can declare that no fill worker can write — a generated ISLAND, and SERVER
+ * work.
+ *
+ * Both are EARNED escapes. The brain decided in the plan that a component
+ * cannot express the need, or that the work cannot happen in the browser;
+ * these runners just execute what it declared. Nothing here re-judges the
+ * escape, and nothing here rebuilds the machinery it drives: island source is
+ * screened by `prepareIslands` and the smoke render, automations ride
+ * `planAutomation` and the automations engine's own arming, and the box is the
+ * existing machine lifecycle plus the in-box agent.
+ *
+ * The box lane is where the bind-after-build law lives: NOTHING pre-declares
+ * the functions a box will serve. The lane hands the box the plan's reason and
+ * the app's intent, the box writes whatever code the job needs, and only then
+ * does it report the interface it actually serves — with real sampled output.
+ * The groups the plan marked `waitsForServer` fill against those samples. A
+ * pre-declared signature would be the app promising something no one has
+ * written yet.
+ *
+ * Every failure here is SECTION-sized, never app-sized: a failed island or a
+ * failed box comes back as `warn` findings with the document unchanged, and the
+ * rest of the app stands.
+ */
+import {
+  compileWire,
+  describeShapeWithSemantics,
+  type AppDocument,
+  type AppId,
+  type AppPlan,
+  type ApprovalRequest,
+  type Json,
+  type PlanIsland,
+  type PlanServer,
+  type RunContext,
+  type Trigger,
+} from "@vendoai/core";
+import { planAutomation, type AutomationPlan } from "../automation-plan.js";
+import type { Finding } from "../checking/types.js";
+import { composePromptSections, hostToolSections, islandContract } from "./contracts/sections.js";
+import { generateWireText, type GeneratedAppDocument, type GenerationDependencies } from "./engine.js";
+import { prepareIslands } from "./validation/islands.js";
+import { smokeRenderIslands } from "./validation/smoke-render.js";
+import { wireCompileOptionsFor } from "./wire-options.js";
+
+/** What a lane leaves behind. `document` is byte-identical to the input when
+ *  the lane failed honestly — a lane never ships half of itself. */
+export interface LaneResult {
+  document: GeneratedAppDocument;
+  findings: Finding[];
+}
+
+const warn = (where: string, message: string): Finding => ({ severity: "warn", where, message });
+
+// ---------------------------------------------------------------------------
+// Flag gating — stated as fact BEFORE the plan exists
+// ---------------------------------------------------------------------------
+
+/** The slice of `AppsConfig` the gates read (structurally satisfied by it; the
+ *  lanes never import the runtime). */
+export interface LaneGateConfig {
+  experimentalMachines?: boolean;
+  experimentalServedApps?: boolean;
+  /** The machine seams. No sandbox adapter → nothing can be provisioned at
+   *  all, flag or no flag. */
+  machine?: { sandbox?: unknown };
+}
+
+export interface LaneGates {
+  /** May a plan declare `server.kind: "box"`? */
+  box: boolean;
+  /** May this host serve the app surface from a machine (layer 3)? */
+  served: boolean;
+  /**
+   * What the brain hears as FACT before it plans. A lane this host does not
+   * have must become a `<Cannot>` line in the plan — an honest refusal the
+   * person reads in seconds — instead of a build that runs, escalates, and
+   * only then discovers the flag is off.
+   */
+  cannot: string[];
+}
+
+/**
+ * The lanes this host actually has. Task 10's brain-facts assembly passes
+ * `cannot` into the plan call, so "this host has machines disabled" is
+ * something the brain KNOWS rather than something it finds out afterwards.
+ */
+export const laneGates = (config: LaneGateConfig): LaneGates => {
+  const sandbox = config.machine?.sandbox !== undefined;
+  const box = sandbox && config.experimentalMachines === true;
+  // Layer 3 is a machine surface, so served implies box (createApps refuses the
+  // other combination outright).
+  const served = box && config.experimentalServedApps === true;
+  const cannot: string[] = [];
+  if (!sandbox) {
+    cannot.push("This host has no sandbox configured, so no machine can be provisioned: custom server code is out of reach. Scheduled or triggered work the host's own tools can express still runs on the automations engine.");
+  } else if (config.experimentalMachines !== true) {
+    cannot.push("This host has machines disabled, so custom server code cannot run for it. Scheduled or triggered work the host's own tools can express still runs on the automations engine.");
+  }
+  if (!served) {
+    cannot.push("This host cannot serve its own web pages for an app: the app is the generated view, so anything that needs a hand-built page or a custom frontend is out of reach.");
+  }
+  return { box, served, cannot };
+};
+
+// ---------------------------------------------------------------------------
+// The island lane
+// ---------------------------------------------------------------------------
+
+export interface IslandLaneDeps extends GenerationDependencies {
+  /** The person's own words. Threaded into the island law-1 scan so their own
+   *  numbers are never refused as invented data (see prepareIslands). */
+  request?: string;
+}
+
+/** One retry, and only one. An island that fails its screening twice is a real
+ *  failure; a third big-model call costs the person time for a class the second
+ *  attempt already reproduced (the brain's rule, same reason). */
+const ISLAND_ATTEMPTS = 2;
+
+const hostComponentNames = (deps: GenerationDependencies): string[] =>
+  deps.catalog.map(({ name }) => name);
+
+const islandLaneContract = (deps: IslandLaneDeps): string => composePromptSections([{
+  id: "role",
+  content: "You are the Vendo island specialist. The app's plan asked for ONE generated component because no host, Kit, or prewired component can express what it needs. Write that component and nothing else: reply with exactly one <Island name=\"...\">TSX</Island> element — the name you are given — with no prose, no markdown fences, no <App> wrapper, and no other markup.",
+}, {
+  id: "tree-contract",
+  content: islandContract(),
+}, ...hostToolSections(deps)]);
+
+/** The queries this island's own leaves read. An island binds against REAL
+ *  shapes or it invents fields, so the plan's own query declarations — tool,
+ *  input, and sampled shape card — travel with the purpose. */
+const islandQueryLines = (plan: AppPlan, island: PlanIsland, deps: IslandLaneDeps): string[] => {
+  const referenced = new Set(plan.groups.flatMap(({ leaves }) => leaves
+    .filter((leaf) => leaf.component === island.name && leaf.query !== undefined)
+    .map((leaf) => leaf.query as string)));
+  return plan.queries.filter(({ id }) => referenced.has(id)).map(({ id, tool, input }) => {
+    const shape = deps.toolShapes?.[tool];
+    const card = shape === undefined ? "shape unknown" : describeShapeWithSemantics(shape, deps.semantics?.[tool] ?? {});
+    return `- ${id}: ${tool}(${JSON.stringify(input)}) → ${card}`;
+  });
+};
+
+const islandLaneMessage = (
+  plan: AppPlan,
+  island: PlanIsland,
+  deps: IslandLaneDeps,
+  previous: { source: string; issues: string[] } | undefined,
+): string => {
+  const queries = islandQueryLines(plan, island, deps);
+  return [
+    `APP: ${plan.name}`,
+    `ISLAND: ${island.name}`,
+    `WHAT IT IS FOR: ${island.purpose}`,
+    ...(queries.length === 0 ? [] : [`THE DATA IT SHOWS (the plan's queries this island reads — bind against these fields, never invent one):\n${queries.join("\n")}`]),
+    ...(previous === undefined ? [] : [
+      `YOUR LAST ISLAND DID NOT PASS:\n${previous.source}`,
+      `WHAT WAS WRONG WITH IT:\n${previous.issues.map((issue) => `- ${issue}`).join("\n")}\nWrite the whole island again, fixed.`,
+    ]),
+  ].join("\n\n");
+};
+
+/** The island source out of one answer. Models wrap bare elements in fences or
+ *  an <App> anyway, and the wire compiler extracts islands from either shape —
+ *  the same tolerance the engine's island repair relies on. */
+const islandSourceFrom = (text: string, name: string, deps: IslandLaneDeps): string | undefined => {
+  const markup = text.replaceAll(/```[a-z]*\n?/gi, "");
+  const start = markup.indexOf("<App");
+  const close = markup.lastIndexOf("</App>");
+  const wire = start !== -1 && close > start
+    ? markup.slice(start, close + "</App>".length)
+    : `<App name="__island_lane__">${markup}</App>`;
+  const compiled = compileWire(wire, wireCompileOptionsFor(deps, hostComponentNames(deps)));
+  const source = compiled.components[name];
+  return typeof source === "string" && source.trim() !== "" ? source : undefined;
+};
+
+/** The screening every island in the product goes through, in the same order
+ *  create validation runs it: the static contract first (imports, network,
+ *  host tags, law 1, the tools manifest), then — only on an otherwise-clean
+ *  island — one headless render, which is the only thing that sees a crash. */
+const screenIsland = async (
+  name: string,
+  source: string,
+  deps: IslandLaneDeps,
+): Promise<{ source: string; tools: string[]; issues: string[] }> => {
+  const prepared = await prepareIslands({ [name]: source }, deps.tools, hostComponentNames(deps), deps.request);
+  const canonical = prepared.components[name] ?? source;
+  const tools = prepared.componentTools[name] ?? [];
+  if (prepared.issues.length > 0) return { source: canonical, tools, issues: prepared.issues };
+  const issues = deps.pipeline?.smokeRender === false ? [] : await smokeRenderIslands({
+    components: { [name]: canonical },
+    componentTools: prepared.componentTools,
+    tools: deps.tools,
+    toolShapes: deps.toolShapes,
+  });
+  return { source: canonical, tools, issues };
+};
+
+/**
+ * Write the island the plan declared, screen it, and stamp it onto the
+ * document. A screening failure buys exactly one fix-it retry carrying the
+ * issues; after that the app ships WITHOUT the island and says why — a broken
+ * island renders as an error box where a section should be, which is worse
+ * than a missing section.
+ */
+export const runIslandLane = async (
+  plan: AppPlan,
+  document: GeneratedAppDocument,
+  deps: IslandLaneDeps,
+): Promise<LaneResult> => {
+  const island = plan.island;
+  if (island === undefined) return { document, findings: [] };
+  const where = `island "${island.name}"`;
+  const system = islandLaneContract(deps);
+  let previous: { source: string; issues: string[] } | undefined;
+  for (let attempt = 0; attempt < ISLAND_ATTEMPTS; attempt += 1) {
+    const answer = await generateWireText(deps, system, islandLaneMessage(plan, island, deps, previous));
+    if (answer.text === undefined) {
+      // A failed call is not a bad island: there is nothing to show on a
+      // retry, so the reason stands as the failure.
+      return { document, findings: answer.issues.map((issue) => warn(where, issue)) };
+    }
+    const source = islandSourceFrom(answer.text, island.name, deps);
+    if (source === undefined) {
+      previous = {
+        source: answer.text,
+        issues: [`no island came through: reply with exactly one <Island name="${island.name}">TSX</Island> element holding plain TSX with an \`export default\` component, and nothing else.`],
+      };
+      continue;
+    }
+    const screened = await screenIsland(island.name, source, deps);
+    if (screened.issues.length === 0) {
+      return {
+        document: {
+          ...document,
+          components: { ...document.components, [island.name]: screened.source },
+          componentTools: { ...document.componentTools, [island.name]: screened.tools },
+        },
+        findings: [],
+      };
+    }
+    previous = { source: screened.source, issues: screened.issues };
+  }
+  return {
+    document,
+    findings: (previous?.issues ?? []).map((issue) => warn(where, issue)),
+  };
+};
+
+// ---------------------------------------------------------------------------
+// The automation arm's reusable internals (shared with runtime.ts automate())
+// ---------------------------------------------------------------------------
+
+/** The host's arming seam (`AppsConfig.armAutomation`). */
+export type ArmAutomationSeam = (
+  appId: AppId,
+  ctx: RunContext,
+) => Promise<{ enabled: boolean; missing: ApprovalRequest[] }>;
+
+/** Put a planned automation onto a document: the trigger the automations
+ *  engine fires, plus the results collection its last step publishes into.
+ *  Idempotent, so re-stamping it over a rewired document (which must never
+ *  drop the just-authored fields) is the same call. */
+export const applyAutomationPlan = <Doc extends Pick<AppDocument, "trigger" | "storage">>(
+  document: Doc,
+  plan: AutomationPlan,
+): Doc => {
+  const automated = structuredClone(document);
+  automated.trigger = structuredClone(plan.trigger);
+  if (plan.resultsCollection !== undefined && automated.storage?.[plan.resultsCollection] === undefined) {
+    automated.storage = {
+      ...automated.storage,
+      [plan.resultsCollection]: {
+        about: `Latest results written by the "${plan.name ?? "automation"}" automation for the app board.`,
+        kind: "records",
+      },
+    };
+  }
+  return automated;
+};
+
+/** The rewire that makes an away run VISIBLE: the app's board reads the store
+ *  rows the automation publishes, so without this the automation fires into
+ *  nothing the person can see. */
+export const automationResultsInstruction = (input: {
+  appId: string;
+  mode: "steps" | "agentic";
+  /** The automation's own name, when it has one. */
+  name?: string;
+  resultsCollection: string;
+}): string => `The app now has a ${input.mode} automation${input.name === undefined ? "" : ` ("${input.name}")`} that runs while the user is away and writes its latest displayable result into the app data collection "${input.resultsCollection}" (record id "latest"). Rewire the tree to show those results:
+- Add (or repoint) a query over the results rows: <Query id="results" tool="vendo_apps_data_list" input={{appId:"${input.appId}", collection:"${input.resultsCollection}"}}/> — the input is LITERAL JSON exactly as written. The tool's result shape is {records: [{id, data: <what the automation stored>}]}, so bind node props against /results/records/... paths (e.g. {results.records.0.data.summary}).
+- Keep the layout; change only what is needed to surface the automation's results (add a small section if none fits).
+- Emit no id attributes on nodes (ids are compiler-owned); a <Query> id is its name.`;
+
+/**
+ * Arm a freshly authored trigger through the host's seam. A seam that throws
+ * and a seam that answers without arming are the SAME miss — a trigger sitting
+ * silently disarmed is an automation the person believes is running — so both
+ * come back as an honest sentence naming the surface to use. No seam means the
+ * stored row was armed by the persist itself, and there is nothing to do.
+ */
+export const armAutomationTrigger = async (
+  seam: ArmAutomationSeam | undefined,
+  appId: AppId,
+  ctx: RunContext,
+): Promise<{ pendingGrants?: ApprovalRequest[]; issues: string[] }> => {
+  if (seam === undefined) return { issues: [] };
+  try {
+    const armed = await seam(appId, ctx);
+    return {
+      ...(armed.missing.length === 0 ? {} : { pendingGrants: structuredClone(armed.missing) }),
+      issues: armed.enabled
+        ? []
+        : ["the automation was authored but the arming seam left it disabled — enable it explicitly via the automations engine (automations.enable / POST /automations/:appId/enable)"],
+    };
+  } catch (error) {
+    return {
+      issues: [`the automation was authored but arming it failed (${error instanceof Error ? error.message : "unknown error"}) — enable it explicitly via the automations engine (automations.enable / POST /automations/:appId/enable)`],
+    };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// The server lane
+// ---------------------------------------------------------------------------
+
+/**
+ * One function a box reports AFTER building it. The sample is the only real
+ * shape in existence for it: nothing declared these functions up front, so the
+ * app's waiting groups bind against what actually ran.
+ */
+export interface ServerFunction {
+  name: string;
+  /** A real sample of the function's output. Absent when no sample could be
+   *  taken — a group binding then has the name and nothing else. */
+  sampleOutput?: Json;
+}
+
+/** What the box says after the work (pure data — a box result never carries
+ *  host authority; see box-agent.ts). */
+export interface BoxOutcome {
+  ok: boolean;
+  /** The box's own words about what it did; user- and model-facing on failure. */
+  summary: string;
+  functions?: readonly ServerFunction[];
+}
+
+/**
+ * The box, as the lane needs it, in the order it needs it. Task 10 wires this
+ * to the runtime's machine lifecycle and `editServerViaBox`: `instruct` wakes
+ * the machine, hands the in-box agent the prompt, and — on failure — discards
+ * the live machine WITHOUT snapshotting, so a failed box leaves nothing to
+ * inherit. `functions` comes from the box's reported fn list, each sampled by
+ * calling it (the fn caller the graduation path already uses).
+ */
+export interface BoxSeam {
+  /** False when no sandbox adapter is configured or machines are disabled. The
+   *  lane checks this BEFORE provisioning anything. */
+  available(): boolean;
+  /** Provision a machine for an app that has none. Idempotent. */
+  provision(): Promise<void>;
+  instruct(instruction: string): Promise<BoxOutcome>;
+}
+
+export interface ServerLaneDeps extends GenerationDependencies {
+  /** The stored app's id: the automation's publish step and the results query
+   *  both name it literally. */
+  appId: AppId;
+  ctx: RunContext;
+  /**
+   * Rewire the app to surface something new (the automation's results rows).
+   * Task 10 wires this to a brain edit turn. Absent → the automation still
+   * arms and the missing board is a `warn`, exactly as a failed rewire is.
+   */
+  rebind?: (
+    instruction: string,
+    document: GeneratedAppDocument,
+  ) => Promise<{ document?: GeneratedAppDocument; issues: string[] }>;
+  /**
+   * The ONE place the automation reaches the stored row. `armTrigger` is the
+   * persist's own arming — true exactly when the host wired no arming seam.
+   * Absent → the lane authors the automation and hands it back unlanded, and
+   * arms nothing (arming a row whose trigger is not stored yet would enable an
+   * automation that does not exist).
+   */
+  land?: (document: GeneratedAppDocument, options: { armTrigger: boolean }) => Promise<void>;
+  armAutomation?: ArmAutomationSeam;
+  box?: BoxSeam;
+}
+
+export interface ServerLaneResult extends LaneResult {
+  /** steps/agentic: the automation that was authored and armed. */
+  automation?: {
+    mode: "steps" | "agentic";
+    trigger: Trigger;
+    resultsCollection?: string;
+    /** Standing-grant approvals the arming seam surfaced. */
+    pendingGrants?: ApprovalRequest[];
+  };
+  /** box: the interface the box reported after building. The plan's
+   *  `waitsForServer` groups fill against these samples. */
+  server?: { summary: string; functions: ServerFunction[] };
+}
+
+/** The plan's `why` IS the instruction: the brain wrote that sentence to
+ *  explain what has to happen away from the browser, which is exactly what the
+ *  automation planner reads. */
+const automationInstruction = (server: PlanServer): string =>
+  server.schedule === undefined ? server.why : `${server.why}\nWHEN: ${server.schedule}`;
+
+const runAutomationArm = async (
+  plan: AppPlan,
+  document: GeneratedAppDocument,
+  deps: ServerLaneDeps,
+  mode: "steps" | "agentic",
+): Promise<ServerLaneResult> => {
+  const server = plan.server as PlanServer;
+  const where = `server (${mode})`;
+  const planned = await planAutomation({
+    appId: deps.appId,
+    appName: plan.name,
+    instruction: automationInstruction(server),
+    mode,
+    tools: deps.tools ?? [],
+    ...(deps.toolShapes === undefined ? {} : { toolShapes: deps.toolShapes }),
+  }, deps.model);
+  if (planned.kind === "failure") {
+    return {
+      document,
+      findings: [
+        warn(where, `this app needs ${mode === "steps" ? "a scheduled/triggered steps" : "an agentic"} automation, but no valid plan validated — the rest of the app stands without it.`),
+        ...planned.issues.map((issue) => warn(where, issue)),
+      ],
+    };
+  }
+  const { plan: automation } = planned;
+  const findings: Finding[] = [];
+  let landed = applyAutomationPlan(document, automation);
+  // Bind the board to the results rows BEFORE landing, so one write carries the
+  // whole change. A failed rewire never blocks the automation: the trigger
+  // still lands and the miss is reported for a retry.
+  if (automation.resultsCollection !== undefined && deps.rebind !== undefined) {
+    const rebound = await deps.rebind(automationResultsInstruction({
+      appId: deps.appId,
+      mode,
+      ...(automation.name === undefined ? {} : { name: automation.name }),
+      resultsCollection: automation.resultsCollection,
+    }), landed);
+    if (rebound.document === undefined) {
+      findings.push(warn(where, "the automation is armed, but the app was not rewired to show its results — ask for the board again and it will bind to the results collection."));
+      findings.push(...rebound.issues.map((issue) => warn(where, issue)));
+    } else {
+      // Re-stamp: the rewire must never drop the just-authored automation.
+      landed = applyAutomationPlan(rebound.document, automation);
+    }
+  }
+  let pendingGrants: ApprovalRequest[] | undefined;
+  if (deps.land !== undefined) {
+    await deps.land(landed, { armTrigger: deps.armAutomation === undefined });
+    const armed = await armAutomationTrigger(deps.armAutomation, deps.appId, deps.ctx);
+    pendingGrants = armed.pendingGrants;
+    findings.push(...armed.issues.map((issue) => warn(where, issue)));
+  }
+  return {
+    document: landed,
+    findings,
+    automation: {
+      mode,
+      trigger: structuredClone(automation.trigger),
+      ...(automation.resultsCollection === undefined ? {} : { resultsCollection: automation.resultsCollection }),
+      ...(pendingGrants === undefined ? {} : { pendingGrants }),
+    },
+  };
+};
+
+/**
+ * What the box is told — the bind-after-build law in one function. The box
+ * hears WHY the work cannot happen in the browser and WHAT the app intends to
+ * show; it never hears a function name, a signature, or a shape to implement.
+ * It decides its own interface, verifies its own code, and reports what it
+ * actually serves. A pre-declared signature here would be the app binding to a
+ * promise, and every mismatch afterwards would be invisible.
+ */
+const boxInstruction = (plan: AppPlan, server: PlanServer): string => {
+  const waiting = plan.groups
+    .filter(({ waitsForServer }) => waitsForServer === true)
+    .flatMap(({ leaves }) => leaves.map(({ purpose }) => purpose));
+  return [
+    `Build the server work this app needs, then report what you built.`,
+    `APP: ${plan.name}`,
+    `WHY THIS CANNOT HAPPEN IN THE BROWSER: ${server.why}`,
+    ...(server.schedule === undefined ? [] : [`WHEN IT RUNS: ${server.schedule}`]),
+    ...(waiting.length === 0 ? [] : [
+      `WHAT THE APP INTENDS TO SHOW FROM IT (intent, NOT an interface to match — you decide the functions):\n${waiting.map((purpose) => `- ${purpose}`).join("\n")}`,
+    ]),
+    `Nothing in this app has been written against your code yet: no function name, no argument, and no result shape has been decided for you. Write whatever the job needs, verify it by running it, and report the interface you ended up serving — each function's name plus a REAL sample of its output. The app is wired to what you report, so report exactly what exists.`,
+  ].join("\n");
+};
+
+const runBoxArm = async (
+  plan: AppPlan,
+  document: GeneratedAppDocument,
+  deps: ServerLaneDeps,
+): Promise<ServerLaneResult> => {
+  const server = plan.server as PlanServer;
+  const where = "server (box)";
+  const box = deps.box;
+  if (box === undefined || !box.available()) {
+    // The plan should never have reached here — laneGates() states this host's
+    // missing lanes as fact before planning — so this is the backstop, and it
+    // still costs nothing: no machine is provisioned.
+    return {
+      document,
+      findings: [warn(where, "this app's plan asked for custom server code, but this host cannot provision a machine (no sandbox adapter, or machine-backed execution disabled) — the app stands without it.")],
+    };
+  }
+  await box.provision();
+  const outcome = await box.instruct(boxInstruction(plan, server));
+  if (!outcome.ok) {
+    // The machine is already discarded without a snapshot (the box seam's
+    // rollback), so there is nothing to inherit and nothing to undo here: the
+    // document never changed.
+    return {
+      document,
+      findings: [warn(where, `the in-box agent could not build the server work: ${outcome.summary} — the machine was discarded, the rest of the app stands, and the sections that waited on it have nothing to show.`)],
+    };
+  }
+  const functions = (outcome.functions ?? []).map((fn) => structuredClone(fn) as ServerFunction);
+  return {
+    document,
+    findings: functions.length > 0 ? [] : [
+      warn(where, `the box reported building the server work (${outcome.summary}) but named no functions, so the sections that waited on it have nothing to bind to.`),
+    ],
+    server: { summary: outcome.summary, functions },
+  };
+};
+
+/**
+ * Run the server work the plan declared. `steps` and `agentic` author an
+ * automation on the existing automations engine (seconds, no machine); `box`
+ * provisions a machine and lets the in-box agent write real code, then reports
+ * back the interface it built so the waiting groups can bind to it.
+ */
+export const runServerLane = async (
+  plan: AppPlan,
+  document: GeneratedAppDocument,
+  deps: ServerLaneDeps,
+): Promise<ServerLaneResult> => {
+  const server = plan.server;
+  if (server === undefined) return { document, findings: [] };
+  return server.kind === "box"
+    ? runBoxArm(plan, document, deps)
+    : runAutomationArm(plan, document, deps, server.kind);
+};

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -59,6 +59,11 @@ import {
 } from "./engine.js";
 import type { PipelineEvent } from "./pipeline.js";
 import { planAutomation } from "./automation-plan.js";
+import {
+  applyAutomationPlan,
+  armAutomationTrigger,
+  automationResultsInstruction,
+} from "./generation/lanes.js";
 import { createAppHistory } from "./history.js";
 import { createInClientApprovals, type InClientVerdict } from "./inclient.js";
 import { createAppInterchange } from "./interchange.js";
@@ -1652,17 +1657,7 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       ]);
     }
     const { plan } = planned;
-    const automated = structuredClone(previous);
-    automated.trigger = structuredClone(plan.trigger);
-    if (plan.resultsCollection !== undefined && automated.storage?.[plan.resultsCollection] === undefined) {
-      automated.storage = {
-        ...automated.storage,
-        [plan.resultsCollection]: {
-          about: `Latest results written by the "${plan.name ?? "automation"}" automation for the app board.`,
-          kind: "records",
-        },
-      };
-    }
+    const automated = applyAutomationPlan(previous, plan);
     // Bind the tree to the results rows BEFORE the single persist, so one
     // version entry carries the whole edit. A failed rebind never blocks the
     // automation (same rule as graduation's fn: bindings): the trigger still
@@ -1670,10 +1665,12 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     let bound = automated;
     const issues: string[] = [];
     if (plan.resultsCollection !== undefined && automated.tree?.formatVersion === VENDO_TREE_FORMAT) {
-      const rebindInstruction = `The app now has a ${mode} automation${plan.name === undefined ? "" : ` ("${plan.name}")`} that runs while the user is away and writes its latest displayable result into the app data collection "${plan.resultsCollection}" (record id "latest"). Rewire the tree to show those results:
-- Add (or repoint) a query over the results rows: <Query id="results" tool="vendo_apps_data_list" input={{appId:"${previous.id}", collection:"${plan.resultsCollection}"}}/> — the input is LITERAL JSON exactly as written. The tool's result shape is {records: [{id, data: <what the automation stored>}]}, so bind node props against /results/records/... paths (e.g. {results.records.0.data.summary}).
-- Keep the layout; change only what is needed to surface the automation's results (add a small section if none fits).
-- Emit no id attributes on nodes (ids are compiler-owned); a <Query> id is its name.`;
+      const rebindInstruction = automationResultsInstruction({
+        appId: previous.id,
+        mode,
+        ...(plan.name === undefined ? {} : { name: plan.name }),
+        resultsCollection: plan.resultsCollection,
+      });
       let treeIssues: string[] = [];
       let rebound: AppDocument | undefined;
       for (let attempt = 0; attempt < 2 && rebound === undefined; attempt += 1) {
@@ -1710,22 +1707,9 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     const persisted = await persistEdit(previous, bound, version, ctx.principal.subject, undefined, {
       armTrigger: config.armAutomation === undefined,
     });
-    let pendingGrants: ApprovalRequest[] | undefined;
-    if (config.armAutomation !== undefined) {
-      try {
-        const armed = await config.armAutomation(previous.id, ctx);
-        if (armed.missing.length > 0) pendingGrants = structuredClone(armed.missing);
-        // A seam that answers without arming is the same miss as a thrown one:
-        // the trigger must never sit silently disarmed.
-        if (!armed.enabled) {
-          issues.push("the automation was authored but the arming seam left it disabled — enable it explicitly via the automations engine (automations.enable / POST /automations/:appId/enable)");
-        }
-      } catch (error) {
-        // Never a silently dead automation: the trigger is on the document but
-        // disarmed — say so, with the arming surface to use.
-        issues.push(`the automation was authored but arming it failed (${error instanceof Error ? error.message : "unknown error"}) — enable it explicitly via the automations engine (automations.enable / POST /automations/:appId/enable)`);
-      }
-    }
+    const armed = await armAutomationTrigger(config.armAutomation, previous.id, ctx);
+    issues.push(...armed.issues);
+    const pendingGrants = armed.pendingGrants;
     await reportGuard(ctx.principal.subject, previous.id, ctx, {
       operation: "automation-created",
       mode,


### PR DESCRIPTION
Task 8 of `docs/superpowers/plans/2026-07-28-generation-pipeline-rebuild.md`. The lane runners a conductor (Task 10) calls with a compiled plan: the two things a plan declares that no fill worker can write.

## What landed

`packages/apps/src/generation/lanes.ts` (+ `lanes.test.ts`, 20 tests)

- **`runIslandLane(plan, document, deps)`** — one island specialist call (own contract reusing `islandContract()`, the plan's island purpose, and the shape cards of the queries its own leaves read), source screened through **`prepareIslands` then the existing smoke render** — unchanged, in the same order create validation runs them. One fix-it retry carrying the issues; after that an honest `warn` with the document byte-identical. Success stamps `components` + `componentTools`.
- **`runServerLane(plan, document, deps)`**
  - `steps` / `agentic`: `planAutomation` → the trigger + results-storage stamp → the results-collection rewire → arming, all through internals **extracted** from `automate()` (see below), not copied.
  - `box`: **intent-only**. Provision, hand the in-box agent the plan's `why` + the app's intent, collect the interface it reports (`{functions: [{name, sampleOutput}]}`) and return it so `waitsForServer` groups fill against real sampled shapes. Failure → warn finding, document unchanged, machine already discarded without a snapshot; the rest of the app stands.
- **`laneGates(config)`** — the lanes this host does *not* have, as sentences the brain hears BEFORE planning, so an impossible ask becomes a `<Cannot>` line instead of a build that escalates into a disabled flag.

## Reused vs extracted

Reused untouched: `prepareIslands`, `smokeRenderIslands`, `planAutomation`, the machine lifecycle + `editServerViaBox` (behind the box seam), `islandContract()` / `hostToolSections()`, `wireCompileOptionsFor`.

Extracted from `automate()` into `lanes.ts`, with `automate()` now calling the same helpers (one implementation, no copy to drift):
- `applyAutomationPlan(document, plan)` — the trigger + results-collection storage stamp, idempotent so re-stamping over a rewired document is the same call.
- `automationResultsInstruction({appId, mode, name?, resultsCollection})` — the rewire text, verbatim.
- `armAutomationTrigger(seam, appId, ctx)` — the arming law: a seam that throws and a seam that answers "not enabled" are the same miss, and both come back as an honest sentence.

`generateWireText` in `engine.ts` is now exported (the island answer is the same small atomic markup the edit dialect returns). `automate()` and `graduate()` keep working — they die at cutover.

## Bind-after-build

The box instruction contains no function name, no argument, and no result shape. The test asserts the function the scripted box goes on to report (`reconciledLedger`) does not appear in what the box was told, and that no `fn:` reference does either.

## Gate

`pnpm --filter @vendoai/apps build && test && typecheck` green (818 passed / 18 skipped, includes `escalation-ladder.test.ts` over the refactored `automate()`), repo `pnpm build` + `pnpm lint` green. Not a UI change.

## For Task 10 (wiring notes)

- `BoxSeam.instruct` → `editServerViaBox`; `functions[].sampleOutput` comes from sampling each reported fn with the existing `fnCaller.callFn` path (what `graduate()` already does for its shape cards). `box-agent.ts` and the in-box harness are untouched.
- `ServerLaneDeps.land` is the one place the automation reaches the stored row (`persistEdit(..., { armTrigger })`); the lane arms after it. Absent → the lane authors but does not land or arm.
- The skeleton stamps every leaf `source: "prewired"`; an island leaf's node needs `source: "generated"` when the group is filled. The island lane deliberately only touches `components` / `componentTools`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces plan-driven lanes for islands and server work, with box “bind-after-build” so UI binds only to functions the box actually built. Adds gates so planning refuses impossible lanes up front and extracts shared automation helpers to avoid drift.

- **New Features**
  - `runIslandLane(plan, document, deps)`: generates one island from the plan’s purpose and referenced query shapes, screens via `prepareIslands` + smoke render, retries once, then warns with the document unchanged; stamps `components` and `componentTools` on success.
  - `runServerLane(plan, document, deps)`:
    - steps/agentic: reuses `planAutomation`, stamps trigger + results storage, rewires the board to the results collection, arms the trigger, and surfaces pending grants or disabled state.
    - box: intent-only. Provisions a machine, sends the plan’s “why” and the app’s intent, then returns the functions and `sampleOutput` the box reports. Failure warns; document unchanged; no snapshot kept. Enforces “bind-after-build” (no function names or `fn:` refs in the instruction).
  - `laneGates(config)`: reports which lanes the host lacks (e.g., machines/served) as sentences for the planner to refuse before planning.

- **Refactors**
  - Extracted `applyAutomationPlan`, `automationResultsInstruction`, and `armAutomationTrigger` from `automate()` into `lanes.ts`; `runtime` now calls the same helpers.
  - Exported `generateWireText` for the island lane and removed duplicated arming/rewire logic in `runtime`.

<sup>Written for commit e01ddf9c81cd401d20e58cf4d41a98162beeb71c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

