### PR TITLE
feat(apps): parallel group fill with fix-it loop

### DIFF
--- a/packages/apps/src/generation/brain.ts
+++ b/packages/apps/src/generation/brain.ts
@@ -102,7 +102,11 @@ const extractApp = (text: string): string | undefined => {
   return start === -1 || close < start ? undefined : text.slice(start, close + "</App>".length);
 };
 
-const readEdits = (text: string): { edits?: TextEdit[]; issues: string[] } => {
+/** The `<Edit><Old>…</Old><New>…</New></Edit>` blocks in an answer, or the
+ *  sentences saying why none could be read. Shared with the fill workers'
+ *  fix-it turn (generation/fill.ts): there is one edit dialect, so there is one
+ *  reader for it. */
+export const readEdits = (text: string): { edits?: TextEdit[]; issues: string[] } => {
   const edits: TextEdit[] = [];
   const issues: string[] = [];
   for (const [, body] of text.replace(FENCE_LINE, "").matchAll(EDIT_BLOCK)) {

--- a/packages/apps/src/generation/fill.test.ts
+++ b/packages/apps/src/generation/fill.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Filling the plan (generation pipeline rebuild, Task 7). What these tests pin
+ * is not "the model wrote good markup" — it is the shape of the machine around
+ * it: one call per group, each one blinkered to its own section, fragments
+ * landing in their own slots, the dial that stops a burst of calls, reads
+ * executed once before anything is built and never a write, and a section that
+ * fails staying a section-sized failure.
+ */
+import { validateTree, type AppPlan, type NormalizedCatalog, type Tree } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { createCheckingLayer } from "../checking/layer.js";
+import { scriptedLanguageModel, type ScriptedModelCall } from "../testing/index.js";
+import { fillPlan } from "./fill.js";
+import { skeletonFromPlan } from "./skeleton.js";
+import type { GeneratedPartial, GenerationDependencies, HostToolInfo } from "./engine.js";
+
+const catalog: NormalizedCatalog = [{
+  name: "MetricCard",
+  description: "Use for a single important metric with a short label and display value.",
+  propsSchema: z.object({ label: z.string(), value: z.string() }),
+  propsJsonSchema: {
+    type: "object",
+    properties: { label: { type: "string" }, value: { type: "string" } },
+    required: ["label", "value"],
+    additionalProperties: false,
+  },
+}];
+
+const tools: HostToolInfo[] = [
+  { name: "host_listInvoices", description: "Every invoice with its amount and client.", risk: "read" },
+  { name: "host_sendReminder", description: "Email a client about an overdue invoice.", risk: "write" },
+];
+
+const INVOICES = [{ id: "in_1", amountCents: 129_900, client: "Northwind" }];
+
+/** The prompt of one scripted call, system and user together — a blinkered
+ *  worker is blinkered in BOTH halves (its components ride the system half). */
+const promptText = (call: ScriptedModelCall): string => call.prompt.map((message) => {
+  if (typeof message.content === "string") return message.content;
+  return message.content.map((part) => part.text ?? "").join("");
+}).join("\n");
+
+/** A model that answers from the prompt it was given rather than from call
+ *  order — workers run concurrently, so call order is not a thing a test may
+ *  depend on. */
+const answering = (reply: (prompt: string) => string | Promise<string>): GenerationDependencies["model"] =>
+  scriptedLanguageModel(async (call) => reply(promptText(call)));
+
+const depsWith = (
+  model: GenerationDependencies["model"],
+  extra: Partial<GenerationDependencies> = {},
+): GenerationDependencies => ({ model, catalog, tools, ...extra });
+
+const plan = (groups: AppPlan["groups"], queries: AppPlan["queries"] = []): AppPlan =>
+  ({ name: "Invoices", queries, groups, cannot: [] });
+
+const INVOICE_QUERY = { id: "invoices", tool: "host_listInvoices", input: { limit: 50 } };
+
+const TWO_GROUPS = plan([
+  {
+    tab: "Overview",
+    title: "Health",
+    leaves: [{ component: "MetricCard", query: "invoices", purpose: "GROUP0 the total outstanding across every open invoice" }],
+  },
+  {
+    tab: "Overdue",
+    leaves: [{ component: "Table", query: "invoices", purpose: "GROUP1 the overdue invoices, worst first" }],
+  },
+], [INVOICE_QUERY]);
+
+const METRIC = '<MetricCard label="Outstanding" value={invoices | sum(amountCents)}/>';
+const TABLE = '<Table columns={["id", "client"]} rows={invoices}/>';
+
+/** The fragment each group's worker writes, chosen by the purpose in its own
+ *  prompt (the only thing a worker sees of the plan). */
+const fragmentFor = (prompt: string): string => prompt.includes("GROUP0") ? METRIC : TABLE;
+
+const node = (tree: Tree, id: string) => tree.nodes.find((candidate) => candidate.id === id);
+const treeOf = (document: { tree?: unknown }): Tree => document.tree as Tree;
+
+const readingQueries = () => {
+  const calls: string[] = [];
+  return {
+    calls,
+    runQuery: async (query: { id: string; tool: string }) => {
+      calls.push(query.tool);
+      return INVOICES;
+    },
+  };
+};
+
+describe("fillPlan", () => {
+  it("makes ONE call per group, and each worker's prompt is blinkered to its own section", async () => {
+    const prompts: string[] = [];
+    const deps = depsWith(answering((prompt) => {
+      prompts.push(prompt);
+      return fragmentFor(prompt);
+    }));
+    const { runQuery } = readingQueries();
+
+    await fillPlan(TWO_GROUPS, skeletonFromPlan(TWO_GROUPS), deps, { runQuery });
+
+    expect(prompts).toHaveLength(2);
+    const overview = prompts.find((prompt) => prompt.includes("GROUP0")) as string;
+    const overdue = prompts.find((prompt) => prompt.includes("GROUP1")) as string;
+    // Its own purpose, its own component's docs, and its query's REAL rows.
+    expect(overview).toContain("GROUP0 the total outstanding across every open invoice");
+    expect(overview).toContain("MetricCard");
+    expect(overview).toContain("Northwind");
+    expect(overview).toContain("host_listInvoices");
+    // And nothing whatsoever about the other group.
+    expect(overview).not.toContain("GROUP1");
+    expect(overview).not.toContain("Table");
+    expect(overdue).not.toContain("GROUP0");
+    expect(overdue).not.toContain("MetricCard");
+  });
+
+  it("splices each group's fragment into ITS slot, and shows the app growing", async () => {
+    const partials: GeneratedPartial[] = [];
+    const deps = depsWith(answering(fragmentFor), {
+      onPartial: (partial) => { partials.push(structuredClone(partial) as GeneratedPartial); },
+    });
+    const { runQuery } = readingQueries();
+
+    const result = await fillPlan(TWO_GROUPS, skeletonFromPlan(TWO_GROUPS), deps, { runQuery });
+
+    const tree = treeOf(result.document);
+    expect(validateTree(tree).ok).toBe(true);
+    expect(result.findings).toEqual([]);
+    // Each slot container survived and now holds that worker's nodes, named
+    // under the slot so two workers minting "metriccard-1" cannot collide.
+    expect(node(tree, "group-0-body")?.children).toEqual(["group-0-body-metriccard-1"]);
+    expect(node(tree, "group-1-body")?.children).toEqual(["group-1-body-table-1"]);
+    expect(node(tree, "group-0-body-metriccard-1")).toMatchObject({
+      component: "MetricCard",
+      source: "host",
+      props: { label: "Outstanding" },
+    });
+    expect(node(tree, "group-1-body-table-1")).toMatchObject({ component: "Table" });
+    // Not one pending placeholder is left standing.
+    expect(tree.nodes.filter((candidate) => candidate.props?.pending === true)).toEqual([]);
+    // The screen saw each section land, one at a time.
+    expect(partials).toHaveLength(2);
+    expect(partials.map((partial) => partial.tree.nodes.filter((candidate) => candidate.props?.pending === true).length))
+      .toEqual([1, 0]);
+  });
+
+  it("respects the concurrency dial — never more than N workers in flight", async () => {
+    const groups: AppPlan["groups"] = [0, 1, 2, 3].map((index) => ({
+      tab: `Tab${index}`,
+      leaves: [{ component: "Table", query: "invoices", purpose: `GROUP${index} rows` }],
+    }));
+    const four = plan(groups, [INVOICE_QUERY]);
+    let inFlight = 0;
+    let peak = 0;
+    const deps = depsWith(answering(async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((resolve) => { setTimeout(resolve, 5); });
+      inFlight -= 1;
+      return TABLE;
+    }));
+    const { runQuery } = readingQueries();
+
+    const result = await fillPlan(four, skeletonFromPlan(four), deps, { runQuery, concurrency: 2 });
+
+    expect(peak).toBe(2);
+    expect(result.findings).toEqual([]);
+    for (const index of [0, 1, 2, 3]) {
+      expect(node(treeOf(result.document), `group-${index}-body`)?.children)
+        .toEqual([`group-${index}-body-table-1`]);
+    }
+  });
+
+  it("never executes a mutating tool at plan time, and says why that section has no rows", async () => {
+    const withWrite = plan([
+      { tab: "Overview", leaves: [{ component: "MetricCard", query: "invoices", purpose: "GROUP0 total" }] },
+      { tab: "Chase", leaves: [{ component: "Table", query: "reminders", purpose: "GROUP1 reminders sent" }] },
+    ], [INVOICE_QUERY, { id: "reminders", tool: "host_sendReminder", input: {} }]);
+    const deps = depsWith(answering(fragmentFor));
+    const { calls, runQuery } = readingQueries();
+
+    const result = await fillPlan(withWrite, skeletonFromPlan(withWrite), deps, { runQuery });
+
+    expect(calls).toEqual(["host_listInvoices"]);
+    expect(Object.keys(result.queryResults)).toEqual(["invoices"]);
+    expect(result.findings).toEqual([{
+      severity: "warn",
+      where: 'query "reminders"',
+      message: expect.stringContaining('names tool "host_sendReminder", which is not a read'),
+    }]);
+  });
+
+  it("feeds a fact finding back to the same worker, and splices the fixed fragment", async () => {
+    const one = plan([TWO_GROUPS.groups[0] as AppPlan["groups"][number]], [INVOICE_QUERY]);
+    const prompts: string[] = [];
+    const deps = depsWith(answering((prompt) => {
+      prompts.push(prompt);
+      // First pass: the metric has no value at all — a fact, not a taste.
+      if (!prompt.includes("WHAT IS WRONG WITH IT")) return '<MetricCard label="Outstanding"/>';
+      return `<Edit><Old><MetricCard label="Outstanding"/></Old><New>${METRIC}</New></Edit>`;
+    }));
+    const { runQuery } = readingQueries();
+
+    const result = await fillPlan(one, skeletonFromPlan(one), deps, { runQuery });
+
+    expect(prompts).toHaveLength(2);
+    // The finding reached the worker as an instruction, with its locus.
+    expect(prompts[1]).toContain('props invalid for host component "MetricCard"');
+    expect(prompts[1]).toContain('<MetricCard label="Outstanding"/>');
+    expect(result.findings).toEqual([]);
+    const tree = treeOf(result.document);
+    expect(node(tree, "group-0-body")?.children).toEqual(["group-0-body-metriccard-1"]);
+    expect(node(tree, "group-0-body-metriccard-1")?.props).toMatchObject({ label: "Outstanding" });
+  });
+
+  it("turns a section that fails both fix-it rounds into an honest note, and the rest of the app stands", async () => {
+    let fixTurns = 0;
+    const deps = depsWith(answering((prompt) => {
+      if (prompt.includes("GROUP1")) return TABLE;
+      if (!prompt.includes("WHAT IS WRONG WITH IT")) return '<MetricCard label="A"/>';
+      // Two real edits that change the label and never supply the value: the
+      // worker is trying and failing, which is the case this covers.
+      fixTurns += 1;
+      return prompt.includes('label="B"')
+        ? '<Edit><Old>label="B"</Old><New>label="C"</New></Edit>'
+        : '<Edit><Old>label="A"</Old><New>label="B"</New></Edit>';
+    }));
+    const { runQuery } = readingQueries();
+
+    const result = await fillPlan(TWO_GROUPS, skeletonFromPlan(TWO_GROUPS), deps, { runQuery });
+
+    expect(fixTurns).toBe(2);
+    const tree = treeOf(result.document);
+    // The failed section says so where it stood — no shimmering leftovers.
+    expect(node(tree, "group-0-body")?.children).toEqual(["group-0-body-failed"]);
+    expect(node(tree, "group-0-body-failed")).toEqual({
+      id: "group-0-body-failed",
+      component: "Text",
+      source: "prewired",
+      props: { text: "This section could not be built — retry the edit." },
+    });
+    expect(tree.nodes.some((candidate) => candidate.props?.pending === true)).toBe(false);
+    // ONE warn, naming the section and what was still wrong.
+    expect(result.findings).toEqual([{
+      severity: "warn",
+      where: 'group "Health"',
+      message: expect.stringContaining("could not be built after 2 fix-it attempts"),
+    }]);
+    // THE ISOLATION: the other group's fragment is untouched, the tab chrome
+    // still stands, and no fact check trips on what the failure left behind.
+    expect(node(tree, "group-1-body")?.children).toEqual(["group-1-body-table-1"]);
+    expect(node(tree, "tabs")?.props?.tabs).toEqual([
+      { value: "Overview", label: "Overview" },
+      { value: "Overdue", label: "Overdue" },
+    ]);
+    const checked = await createCheckingLayer({ deps }).run({ app: result.document, request: "invoices" });
+    expect(checked).toEqual([]);
+  });
+
+  it("returns what the plan's queries read, so the app's first open reuses it", async () => {
+    const deps = depsWith(answering(fragmentFor));
+    const { calls, runQuery } = readingQueries();
+
+    const result = await fillPlan(TWO_GROUPS, skeletonFromPlan(TWO_GROUPS), deps, { runQuery });
+
+    expect(result.queryResults).toEqual({ invoices: INVOICES });
+    // Once for the whole build, however many groups read it.
+    expect(calls).toEqual(["host_listInvoices"]);
+  });
+});

--- a/packages/apps/src/generation/fill.ts
+++ b/packages/apps/src/generation/fill.ts
@@ -1,0 +1,353 @@
+/**
+ * Filling the plan (generation pipeline rebuild, Task 7). The brain wrote a
+ * plan; skeleton.ts turned it into the app's real layout with a pending
+ * placeholder per leaf. This module writes the contents: ONE fast no-think
+ * model call per GROUP, running in parallel under a concurrency dial, each
+ * fragment spliced into its slot the moment it lands so the app grows on the
+ * screen instead of appearing all at once.
+ *
+ * Three properties are load-bearing:
+ *
+ * - BLINKERED WORKERS. A worker sees its own group, the queries that group
+ *   reads, and the docs for the components its leaves name. Nothing else. That
+ *   is why the calls can run at the same time without coordinating, and why
+ *   each one is small enough to be fast.
+ * - QUERIES FIRST. The plan's read-risk queries run BEFORE any worker, so every
+ *   worker writes against real example rows instead of a guessed shape. The
+ *   results come back out for the app's first open, so nothing is read twice.
+ *   A tool that can change data is never executed here — the plan is a
+ *   proposal, and a proposal must not have side effects.
+ * - SECTION-SIZED FAILURE. Each fragment is checked on its own (the fact
+ *   checks, scoped to the nodes that worker wrote) and gets two fix-it turns.
+ *   A section that still cannot be built says so where it stands; the rest of
+ *   the app ships.
+ *
+ * Pure module: injected deps, no I/O beyond the model calls and the query seam.
+ */
+import {
+  VENDO_APP_FORMAT,
+  VENDO_TREE_FORMAT,
+  applyTextEdits,
+  compileWire,
+  printWire,
+  recompileWithIdentity,
+  type AppPlan,
+  type PlanGroup,
+  type PlanQuery,
+  type Tree,
+  type TreeQuery,
+  type WireCompileResult,
+} from "@vendoai/core";
+import { createCheckingLayer } from "../checking/layer.js";
+import type { Finding } from "../checking/types.js";
+import { modelCallParams } from "../model-params.js";
+import { readEdits } from "./brain.js";
+import { spliceFragment, type Skeleton } from "./skeleton.js";
+import { workerFillMessage, workerFixMessage, workerSystemPrompt } from "./prompts/worker.js";
+import { wireCompileOptionsFor } from "./wire-options.js";
+import { cacheableGenerationMessages, type GeneratedAppDocument, type GenerationDependencies } from "./engine.js";
+
+/** Groups filled at once when the host set no dial. Two, not one, because the
+ *  point is parallelism; two, not eight, because every worker is a model call
+ *  against the same key and a burst of them is what trips a provider's rate
+ *  limit mid-build. */
+const DEFAULT_FILL_CONCURRENCY = 2;
+
+/** Fix-it turns a section gets after its first attempt. Two: a fact finding is
+ *  almost always fixed by being told exactly what it is, and a third round on
+ *  the same section has never been the difference between a good app and a bad
+ *  one — it is just the person waiting longer for the same answer. */
+const FIX_ROUNDS = 2;
+
+/** What a section that could not be built says, in the person's own terms. It
+ *  is a plain sentence and not a raw placeholder ON PURPOSE: a leftover pending
+ *  node would keep shimmering forever, and a leftover HOST-catalog leaf would
+ *  read to the checks as an unknown prewired component. */
+const FILL_FAILED_TEXT = "This section could not be built — retry the edit.";
+
+export interface FillOptions {
+  /** Groups filled at the same time (`AppsConfig.fillConcurrency`). */
+  concurrency?: number;
+  /**
+   * Executes one of the plan's queries against the host's tool registry.
+   * fillPlan calls this for READ-risk tools only. Absent (no registry wired)
+   * means workers fill without example rows — slower to get right, never wrong.
+   */
+  runQuery?: (query: PlanQuery) => Promise<unknown>;
+}
+
+export interface FillResult {
+  /** The app: the plan's skeleton with every group's contents written in. */
+  document: GeneratedAppDocument;
+  /** What is still wrong after the fix-it rounds — one per section that could
+   *  not be built, plus any query the plan declared that could not run. Always
+   *  `warn`: a missing section is not a reason to withhold the app. */
+  findings: Finding[];
+  /** What the plan's queries returned, keyed by query id — handed back so the
+   *  app's first open reuses the reads instead of repeating them. */
+  queryResults: Record<string, unknown>;
+}
+
+/** `node "n3"` / `node "n3" prop "rows"` → `n3`; anything else → undefined. */
+const NODE_LOCUS = /^node "([^"]+)"/;
+
+/** Run `tasks` with at most `limit` of them in flight, starting in order. */
+const withLimit = async (limit: number, tasks: ReadonlyArray<() => Promise<void>>): Promise<void> => {
+  let next = 0;
+  const lane = async (): Promise<void> => {
+    for (;;) {
+      const task = tasks[next];
+      next += 1;
+      if (task === undefined) return;
+      await task();
+    }
+  };
+  await Promise.all(Array.from({ length: Math.max(1, Math.min(limit, tasks.length)) }, lane));
+};
+
+/**
+ * The plan's queries, executed before anything is built. Read-risk only, all at
+ * once: they feed every worker's prompt, so a serial pass here would delay the
+ * whole fill.
+ */
+const runPlanQueries = async (
+  plan: AppPlan,
+  deps: GenerationDependencies,
+  options: FillOptions,
+): Promise<{ results: Record<string, unknown>; findings: Finding[] }> => {
+  const run = options.runQuery;
+  const results: Record<string, unknown> = {};
+  const findings: Finding[] = [];
+  if (run === undefined) return { results, findings };
+  const risk = new Map((deps.tools ?? []).map((tool) => [tool.name, tool.risk]));
+  await Promise.all(plan.queries.map(async (query) => {
+    if (risk.get(query.tool) !== "read") {
+      findings.push({
+        severity: "warn",
+        where: `query "${query.id}"`,
+        message: `names tool "${query.tool}", which is not a read — plan queries run before the app is built, so only reads execute here and this section was written without example rows. A section that has to act on data belongs behind a control the person presses.`,
+      });
+      return;
+    }
+    try {
+      results[query.id] = await run(query);
+    } catch (error) {
+      findings.push({
+        severity: "warn",
+        where: `query "${query.id}"`,
+        message: `could not be read while planning (${error instanceof Error ? error.message : "unknown error"}), so its sections were written from the tool's shape alone; the app still reads it live when it opens.`,
+      });
+    }
+  }));
+  return { results, findings };
+};
+
+/** The plan's `<Query>` declarations, printed in the same dialect the brain
+ *  writes them in (printWire owns the input-expression printing), so a
+ *  fragment's `{invoices.total}` resolves exactly as it would in a whole app. */
+const queryDeclarations = (queries: readonly TreeQuery[]): string => {
+  if (queries.length === 0) return "";
+  const printed = printWire({
+    tree: {
+      formatVersion: VENDO_TREE_FORMAT,
+      root: "root",
+      nodes: [{ id: "root", component: "Stack", source: "prewired" }],
+      queries: [...queries],
+    },
+    components: {},
+  }, { includeIds: false });
+  // `<App>` first line, `</App>` last: what is between them is the query block.
+  return printed.split("\n").slice(1, -1).join("\n");
+};
+
+/** A worker's fragment as a compilable document — this exact text is what the
+ *  fix-it turn's edits apply to. */
+const fragmentDocument = (name: string, queries: readonly TreeQuery[], fragment: string): string => [
+  `<App name="${name.replaceAll('"', "'")}">`,
+  queryDeclarations(queries),
+  fragment,
+  "</App>",
+].filter((line) => line !== "").join("\n");
+
+const FENCE_LINE = /^[ \t]*```[a-zA-Z]*[ \t]*$/gm;
+
+/** The markup a worker meant to write: fences dropped, and — when it wrapped
+ *  its section in a whole `<App>` despite being asked not to — the inside of
+ *  that app (the region-parallel lane's own tolerance). */
+const fragmentMarkup = (answer: string): string => {
+  const text = answer.replace(FENCE_LINE, "").trim();
+  const start = text.indexOf("<App");
+  if (start === -1) return text;
+  const open = text.indexOf(">", start);
+  if (open === -1) return text;
+  const close = text.lastIndexOf("</App>");
+  return (close === -1 ? text.slice(open + 1) : text.slice(open + 1, close)).trim();
+};
+
+/** One worker call: the fast, thinking-disabled model instance when the host
+ *  configured one, otherwise the main model. Text is accumulated off the stream
+ *  — a fragment is small and lands atomically. */
+const askWorker = async (
+  deps: GenerationDependencies,
+  system: string,
+  prompt: string,
+): Promise<string | undefined> => {
+  const model = deps.paint?.model ?? deps.model;
+  try {
+    const { streamText } = await import("ai");
+    const result = streamText({
+      model,
+      messages: cacheableGenerationMessages(system, prompt),
+      ...modelCallParams(model),
+      maxRetries: 0,
+    });
+    let text = "";
+    for await (const delta of result.textStream) text += delta;
+    return text.trim().length === 0 ? undefined : text;
+  } catch {
+    return undefined;
+  }
+};
+
+/** The honest stand-in for a section that could not be built. Spliced through
+ *  the same seam as a real fragment, so the failed group's placeholders leave
+ *  the tree exactly as a successful fill's would. */
+const disclaimSlot = (tree: Tree, slotNodeId: string): Tree => spliceFragment(tree, slotNodeId, {
+  formatVersion: VENDO_TREE_FORMAT,
+  root: "root",
+  nodes: [
+    { id: "root", component: "Stack", source: "prewired", children: ["failed"] },
+    { id: "failed", component: "Text", source: "prewired", props: { text: FILL_FAILED_TEXT } },
+  ],
+});
+
+const groupLocus = (group: PlanGroup, index: number): string =>
+  `group "${group.title ?? group.tab ?? `#${index + 1}`}"`;
+
+/**
+ * Fill every group of `plan` into `skeleton`, in parallel under the concurrency
+ * dial. Returns the finished app, whatever is still wrong with it, and the
+ * query results for the app's first open.
+ */
+export const fillPlan = async (
+  plan: AppPlan,
+  skeleton: Skeleton,
+  deps: GenerationDependencies,
+  options: FillOptions = {},
+): Promise<FillResult> => {
+  const { results: queryResults, findings: queryFindings } = await runPlanQueries(plan, deps, options);
+  const findings: Finding[] = [...queryFindings];
+  const compileOptions = wireCompileOptionsFor(deps, deps.catalog.map(({ name }) => name));
+  const checking = createCheckingLayer({ deps });
+  // The slot map is in plan order (skeleton.ts's Skeleton contract), so the
+  // worker for plan.groups[i] splices into the i-th slot.
+  const slots = Object.values(skeleton.slots);
+
+  let tree = skeleton.tree;
+  // The document's `tree` is the open UIPayload the store speaks; a v2 Tree is
+  // one, structurally (the same cast the brain makes when it prints an app).
+  const document = (of: Tree): GeneratedAppDocument =>
+    ({ format: VENDO_APP_FORMAT, name: plan.name, tree: of as unknown as GeneratedAppDocument["tree"] });
+  const emitted: Array<Promise<void>> = [];
+  /** Commit a splice and show it: the app grows a section at a time. */
+  const commit = (next: Tree): void => {
+    tree = next;
+    if (deps.onPartial === undefined) return;
+    emitted.push(Promise.resolve(deps.onPartial({ tree, name: plan.name })).catch(() => undefined));
+  };
+
+  /** What is wrong with one candidate fragment: its own compile issues, plus
+   *  the fact findings anchored on the nodes THIS worker wrote. Everything else
+   *  the checks report belongs to the plan or to another group — a worker that
+   *  cannot fix a finding must never be asked to. */
+  const problemsWith = async (compiled: WireCompileResult, candidate: Tree, slot: string): Promise<string[]> => {
+    const mine = new Set(candidate.nodes
+      .map(({ id }) => id)
+      .filter((id) => id.startsWith(`${slot}-`)));
+    // `request` is the reviewer's input; no fact check reads it, and the
+    // reviewer does not run per fragment (it judges the finished app).
+    const found = await checking.run({ app: document(candidate), request: plan.name, plan });
+    return [
+      ...compiled.issues.map((issue) => issue.message),
+      ...found
+        .filter((finding) => mine.has(NODE_LOCUS.exec(finding.where)?.[1] ?? ""))
+        .map((finding) => `${finding.where} ${finding.message}`),
+    ];
+  };
+
+  const fillGroup = async (index: number): Promise<void> => {
+    const group = plan.groups[index] as PlanGroup;
+    const slot = slots[index];
+    if (slot === undefined) return;
+    const system = workerSystemPrompt(deps, group);
+    const reads = new Set(group.leaves.flatMap((leaf) => leaf.query === undefined ? [] : [leaf.query]));
+    const fillMessage = (problems: readonly string[]): string => workerFillMessage({
+      appName: plan.name,
+      group,
+      queries: plan.queries.filter((query) => reads.has(query.id)),
+      samples: Object.fromEntries(Object.entries(queryResults).filter(([id]) => reads.has(id))),
+      problems,
+    }, deps);
+
+    let problems: string[] = [];
+    /** The fragment document as it stands, and the tree it compiled to — the
+     *  text a fix-it edit quotes, and the identity a fixed fragment carries. */
+    let written: { text: string; tree: Tree } | undefined;
+    for (let round = 0; round <= FIX_ROUNDS; round += 1) {
+      const answer = await askWorker(deps, system, written === undefined
+        ? fillMessage(problems)
+        : workerFixMessage(written.text, problems));
+      if (answer === undefined) {
+        problems = ["the fill worker's model call came back with nothing at all."];
+        continue;
+      }
+      let text: string;
+      let compiled: WireCompileResult;
+      if (written === undefined) {
+        // The PLAN's own declarations, not the tree's: a query some other
+        // group's fragment minted while this one was writing is not this
+        // worker's business, and reading the growing tree here would make the
+        // fragment text depend on which groups happened to land first.
+        text = fragmentDocument(plan.name, skeleton.tree.queries ?? [], fragmentMarkup(answer));
+        compiled = compileWire(text, compileOptions);
+      } else {
+        const edits = readEdits(answer);
+        if (edits.edits === undefined) {
+          problems = edits.issues;
+          continue;
+        }
+        const edited = applyTextEdits(written.text, edits.edits);
+        if (edited.text === undefined) {
+          problems = [edited.issue as string];
+          continue;
+        }
+        text = edited.text;
+        // Identity carry: the nodes the fix did not touch keep the ids the
+        // screen already mounted, so a repaired section does not re-mount whole.
+        compiled = recompileWithIdentity(text, written.tree, compileOptions);
+      }
+      const candidate = spliceFragment(tree, slot, compiled.tree);
+      problems = await problemsWith(compiled, candidate, slot);
+      written = { text, tree: compiled.tree };
+      if (problems.length === 0) {
+        // Re-splice onto the CURRENT tree: another group may have landed while
+        // this one was being checked, and the two slots are disjoint.
+        commit(spliceFragment(tree, slot, compiled.tree));
+        return;
+      }
+    }
+    commit(disclaimSlot(tree, slot));
+    findings.push({
+      severity: "warn",
+      where: groupLocus(group, index),
+      message: `could not be built after ${FIX_ROUNDS} fix-it attempts, so it shows a note asking for a retry instead of made-up content. What was still wrong: ${problems.join("; ")}`,
+    });
+  };
+
+  await withLimit(
+    options.concurrency ?? DEFAULT_FILL_CONCURRENCY,
+    plan.groups.map((_, index) => () => fillGroup(index)),
+  );
+  await Promise.all(emitted);
+  return { document: document(tree), findings, queryResults };
+};

--- a/packages/apps/src/generation/prompts/worker.ts
+++ b/packages/apps/src/generation/prompts/worker.ts
@@ -1,0 +1,137 @@
+/**
+ * What a fill worker is told (generation pipeline rebuild, Task 7). A worker is
+ * one fast, no-think model call that writes ONE group of the plan, and it is
+ * deliberately BLINKERED: it sees its own group, the queries that group's
+ * leaves read, and the docs for the components those leaves name — nothing
+ * about the rest of the app. That is what makes N groups fill in parallel
+ * without agreeing on anything, and what keeps each prompt small enough to be
+ * fast.
+ *
+ * Yousef iterates on this text — keep it one screen.
+ */
+import {
+  KIT_WIRE_COMPONENT_NAMES,
+  describeShapeWithSemantics,
+  kitPrompt,
+  type NormalizedCatalog,
+  type PlanGroup,
+  type PlanQuery,
+} from "@vendoai/core";
+import { PREWIRED_SCHEMAS } from "../../prewired-schema.js";
+import type { GenerationDependencies } from "../engine.js";
+
+/** One query result trimmed to this many characters of JSON. Enough rows to
+ *  show a worker what its fields really look like, small enough that a long
+ *  table cannot crowd out the section it is meant to fill. */
+const MAX_SAMPLE_CHARS = 600;
+
+// Yousef iterates on this text — keep it one screen.
+const ROLE = `You are filling in ONE section of an app somebody asked for. The app's layout already exists and its container is already on the screen, waiting for its contents.
+
+Write ONLY the markup that goes inside your section: one element per part listed below, in that order, and nothing else — no <App>, no wrapper around them, no explanation, no markdown fences.
+
+SHOW WHAT IS IN THE DATA. Every number, name, date, and status on the screen is a reference to one of the queries below. Never type a value yourself, however plausible it looks — a made-up figure is indistinguishable from a real one to the person reading it, which makes it the worst thing this section can ship. When a part's data is genuinely missing, let the component render its own empty state; never fill the hole with an example.
+
+Write a reference in braces, starting with the query's name: rows={invoices}, value={invoices | sum(amount_cents)}, cents={invoice.total_cents}. Text you write yourself is fine for LABELS and headings ("Outstanding", "Worst first") — never for data.
+
+You can only see your own section. Do not write anything belonging elsewhere in the app, and do not repeat the section's own heading — it is already on the screen above you.`;
+
+/** The docs for exactly the components this group's leaves name: the host's own
+ *  entries (schema and all — a host component is the brand-native answer), then
+ *  the Kit and legacy primitives from the generated specs. */
+const componentDocs = (group: PlanGroup, catalog: NormalizedCatalog): string => {
+  const named = new Set(group.leaves.map(({ component }) => component));
+  const host = catalog.filter(({ name }) => named.has(name));
+  const kit = KIT_WIRE_COMPONENT_NAMES.filter((name) => named.has(name));
+  const legacy = Object.entries(PREWIRED_SCHEMAS).filter(([name]) => named.has(name));
+  return [
+    host.length === 0 ? "" : `THIS HOST'S OWN COMPONENTS (use these exact prop names):\n${JSON.stringify(
+      host.map(({ name, description, propsJsonSchema, examples }) => ({
+        name,
+        whenToUse: description,
+        propsJsonSchema: propsJsonSchema ?? null,
+        examples: examples ?? [],
+      })),
+      null,
+      2,
+    )}`,
+    kit.length === 0 ? "" : kitPrompt({ only: [...kit] }),
+    legacy.length === 0 ? "" : `PRIMITIVES:\n${legacy.map(([, schema]) => `- ${schema.signature}`).join("\n")}`,
+  ].filter((section) => section !== "").join("\n\n");
+};
+
+/** The worker's system prompt: the role, then the docs for its own components.
+ *  Per-group by design — a shared prefix would mean showing every worker the
+ *  whole catalog, which is the blinkering this lane exists to remove. */
+export const workerSystemPrompt = (deps: GenerationDependencies, group: PlanGroup): string =>
+  [ROLE, componentDocs(group, deps.catalog)].filter((section) => section !== "").join("\n\n");
+
+export interface WorkerFillInput {
+  /** The app's display name — the only thing about the wider app a worker sees. */
+  appName: string;
+  group: PlanGroup;
+  /** The plan's queries this group's leaves actually read. */
+  queries: readonly PlanQuery[];
+  /** What those queries returned at plan time, keyed by query id. Absent for a
+   *  query the host could not read. */
+  samples: Readonly<Record<string, unknown>>;
+  /** Problems with the worker's previous fresh attempt, when there was one. */
+  problems?: readonly string[];
+}
+
+const sample = (value: unknown): string => {
+  const text = JSON.stringify(value) ?? "null";
+  return text.length > MAX_SAMPLE_CHARS ? `${text.slice(0, MAX_SAMPLE_CHARS)}…` : text;
+};
+
+/** One query as the worker meets it: how it is read, the shape of what comes
+ *  back, and real rows from the actual read. */
+const queryBriefs = (input: WorkerFillInput, deps: GenerationDependencies): string => input.queries
+  .map((query) => {
+    const shape = deps.toolShapes?.[query.tool];
+    return [
+      `${query.id} — read with ${query.tool}(${JSON.stringify(query.input)})`,
+      shape === undefined ? "" : `  shape: ${describeShapeWithSemantics(shape, deps.semantics?.[query.tool] ?? {})}`,
+      query.id in input.samples
+        ? `  real rows: ${sample(input.samples[query.id])}`
+        : "  real rows: this read did not come back, so bind the fields the shape names and let empty states show.",
+    ].filter((line) => line !== "").join("\n");
+  })
+  .join("\n");
+
+/** The fill turn: the app's name, the section to write, and its data. */
+export const workerFillMessage = (
+  input: WorkerFillInput,
+  deps: GenerationDependencies,
+): string => {
+  const { group } = input;
+  const where = [
+    group.tab === undefined ? "" : `in the "${group.tab}" tab`,
+    group.title === undefined ? "" : `titled "${group.title}"`,
+  ].filter((part) => part !== "").join(", ");
+  return [
+    `THE APP: "${input.appName}"`,
+    `YOUR SECTION${where === "" ? "" : ` (${where})`}, one element per part, in this order:\n${group.leaves
+      .map((leaf) => `- <${leaf.component}> — ${leaf.purpose}${leaf.attrs === undefined ? "" : ` [${Object.entries(leaf.attrs).map(([name, value]) => `${name}=${value}`).join(" ")}]`}`)
+      .join("\n")}`,
+    input.queries.length === 0
+      ? "THIS SECTION HAS NO DATA to read, so write honest static content only — never a number or a name that looks real."
+      : `THE DATA your section shows:\n${queryBriefs(input, deps)}`,
+    ...(input.problems === undefined || input.problems.length === 0 ? [] : [
+      `YOUR LAST ATTEMPT DID NOT WORK:\n${input.problems.map((problem) => `- ${problem}`).join("\n")}\nWrite the section again, fixed.`,
+    ]),
+  ].join("\n\n");
+};
+
+/** The fix-it turn: the section as it stands and what is wrong with it, edited
+ *  the way the brain edits an app — exact old text, exact replacement. */
+export const workerFixMessage = (fragment: string, problems: readonly string[]): string => [
+  `THE SECTION YOU WROTE (this exact text is what an <Old> must quote):\n${fragment}`,
+  `WHAT IS WRONG WITH IT:\n${problems.map((problem) => `- ${problem}`).join("\n")}`,
+  `Fix every one of them with edits over that text, and write nothing else:
+<Edit>
+  <Old>the exact text being replaced</Old>
+  <New>what replaces it</New>
+</Edit>
+One <Edit> per replacement, as many as the fixes need. <Old> is copied EXACTLY from the text above and has to appear there exactly once — include a surrounding line when it would otherwise match twice. To remove something, leave <New> empty.`,
+].join("\n\n");

--- a/packages/apps/src/generation/skeleton.ts
+++ b/packages/apps/src/generation/skeleton.ts
@@ -133,3 +133,62 @@ export const skeletonFromPlan = (plan: AppPlan): Skeleton => {
     slots,
   };
 };
+
+/** Every id reachable from `roots`, the roots included. */
+const subtree = (byId: ReadonlyMap<string, TreeNode>, roots: readonly string[]): Set<string> => {
+  const found = new Set<string>(roots);
+  const queue = [...roots];
+  for (let cursor = 0; cursor < queue.length; cursor += 1) {
+    for (const child of byId.get(queue[cursor] as string)?.children ?? []) {
+      if (found.has(child)) continue;
+      found.add(child);
+      queue.push(child);
+    }
+  }
+  return found;
+};
+
+/**
+ * One fill worker's fragment, spliced into one group's slot: the slot container
+ * survives (the plan decided its layout), its pending placeholders are gone,
+ * and the fragment's own nodes become its children. Pure — the tree handed in
+ * is never touched.
+ *
+ * Fragment ids are namespaced by the slot they land in. Every worker compiles
+ * its fragment alone and mints from zero, so two of them would otherwise both
+ * claim `stat-1`; the prefix also means re-filling ONE group renames nothing
+ * outside it.
+ */
+export const spliceFragment = (tree: Tree, slotNodeId: string, fragment: Tree): Tree => {
+  const byId = new Map(tree.nodes.map((node) => [node.id, node]));
+  const slot = byId.get(slotNodeId);
+  if (slot === undefined) return tree;
+  const stale = subtree(byId, slot.children ?? []);
+  const namespaced = (id: string): string => `${slotNodeId}-${id}`;
+  const landing = fragment.nodes.filter((node) => node.id !== fragment.root);
+  const nodes = tree.nodes.flatMap((node) => {
+    if (stale.has(node.id)) return [];
+    if (node.id !== slotNodeId) return [node];
+    const children = fragment.nodes
+      .find((candidate) => candidate.id === fragment.root)?.children ?? [];
+    return [
+      { ...node, children: children.map(namespaced) },
+      ...landing.map((child) => ({
+        ...child,
+        id: namespaced(child.id),
+        ...(child.children === undefined ? {} : { children: child.children.map(namespaced) }),
+      })),
+    ];
+  });
+  // Workers bind to the queries the plan declared, but a fragment may mint one
+  // of its own from an inline tool reference — it rides along so its bindings
+  // resolve. A name already declared keeps its original definition: two groups
+  // minting the same name mean the same read, and the plan's own declaration
+  // always outranks a worker's.
+  const declared = new Set((tree.queries ?? []).map((query) => query.name));
+  const queries = [
+    ...(tree.queries ?? []),
+    ...(fragment.queries ?? []).filter((query) => !declared.has(query.name)),
+  ];
+  return { ...tree, nodes, ...(queries.length === 0 ? {} : { queries }) };
+};


### PR DESCRIPTION
Task 7 of the [generation pipeline rebuild](docs/superpowers/plans/2026-07-28-generation-pipeline-rebuild.md). The brain writes a plan, `skeletonFromPlan` turns it into the app's real layout with a shimmering placeholder per leaf — this PR writes the contents.

## What lands

- `generation/fill.ts` — `fillPlan(plan, skeleton, deps, options)`: runs the plan's queries, then one worker per group under the concurrency dial, splicing each fragment as it lands. Returns `{ document, findings, queryResults }`.
- `generation/prompts/worker.ts` — the blinkered one-pager a worker is told (`// Yousef iterates on this text — keep it one screen.`).
- `generation/skeleton.ts` — `spliceFragment(tree, slotNodeId, fragment)`: the slot container survives, its placeholders go, the fragment's nodes become its children under the slot's own id namespace.
- `generation/brain.ts` — `readEdits` exported. There is one edit dialect, so there is one reader for it; the fix-it turn uses the same one the brain does.

Pure module. Nothing is wired into the runtime — that is Task 10.

## The three properties this exists for

**Blinkered workers.** A worker sees its own group's purposes, the queries that group's leaves read (shape + real sample rows), and the docs for exactly the components those leaves name. Nothing about the rest of the app. That is what lets N groups fill at the same time without agreeing on anything, and what keeps each prompt small enough to be fast on the no-think model (`deps.paint?.model ?? deps.model`).

**Queries first.** The plan's read-risk queries execute before any worker, in parallel, through an injected `runQuery` seam — so every worker writes against real rows instead of a guessed shape, and the results come back out for the app's first open instead of being read twice. A tool that is not a read is never executed: a plan is a proposal, and a proposal must not have side effects. The skipped query gets a `warn` finding saying so.

**Section-sized failure.** Each candidate fragment goes through the checking layer's fact checks, filtered to the nodes THAT worker wrote — a worker is never asked to fix a finding about someone else's section or about the plan. On findings it gets two fix-it turns over its own fragment text (old/new edits, identity carried through `recompileWithIdentity` so a repaired section does not re-mount whole). A section that still cannot be built swaps its placeholders for an honest \`Text\` note — "This section could not be built — retry the edit." — plus one `warn` finding naming the section and what was still wrong. The rest of the app ships. That swap is also why nothing trips afterwards: a leftover pending HOST-catalog leaf would read to the checks as an unknown prewired component, and the last test proves a full fact-check over the returned document is silent.

## Tests (`generation/fill.test.ts`)

1. makes ONE call per group, and each worker's prompt is blinkered to its own section
2. splices each group's fragment into ITS slot, and shows the app growing
3. respects the concurrency dial — never more than N workers in flight
4. never executes a mutating tool at plan time, and says why that section has no rows
5. feeds a fact finding back to the same worker, and splices the fixed fragment
6. turns a section that fails both fix-it rounds into an honest note, and the rest of the app stands
7. returns what the plan's queries read, so the app's first open reuses it

Each was falsified against the implementation before landing: ignoring the dial makes (3) read `expected 4 to be 2`; un-scoping the component docs makes (1) fail on the other group's material; dropping the slot id namespace fails (2), (3), (5) and (6).

## Gate

`pnpm --filter @vendoai/apps build && test && typecheck` green (805 passed, 18 skipped), full `pnpm build` and repo `pnpm lint` green. No UI surface in this PR — the placeholder rendering it fills in landed with Task 5 (#663).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds parallel group fill with a fix-it loop for the generation pipeline. Runs read-only plan queries first, then calls one fast worker per group under a concurrency cap, splicing each fragment into its slot as it lands and isolating failures to their section.

- **New Features**
  - `packages/apps/src/generation/fill.ts` — `fillPlan(plan, skeleton, deps, options)`: runs read queries via `runQuery`, creates one blinkered worker per group (uses `deps.paint?.model ?? deps.model`), emits partials via `deps.onPartial`, and returns `{ document, findings, queryResults }`.
  - `packages/apps/src/generation/skeleton.ts` — `spliceFragment(tree, slotNodeId, fragment)`: keeps the slot container, removes placeholders, namespaces child ids by slot, and merges fragment-declared queries that aren’t already in the tree.
  - `packages/apps/src/generation/prompts/worker.ts`: system + fill/fix messages that show only the group’s leaves, relevant component docs, and query briefs with real samples.
  - `packages/apps/src/generation/brain.ts`: exports `readEdits` for fix-it turns; fixed fragments keep identity via `recompileWithIdentity`.
  - Defaults: concurrency `2`; up to `2` fix-it rounds; persistent failures render a `Text` note — "This section could not be built — retry the edit." — and add a `warn` finding.

<sup>Written for commit b0ff8ee9e06d457aca578467c537814aee7467c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

