### PR TITLE
feat(core,ui): live-computed expressions

### DIFF
--- a/packages/apps/src/checking/checking.test.ts
+++ b/packages/apps/src/checking/checking.test.ts
@@ -137,7 +137,7 @@ describe("checking layer", () => {
     expect(layer.checks.map(({ name }) => name)).toContain("maple-house-style");
     // Appended, never replacing: every built-in fact check is still registered.
     expect(layer.checks.map(({ name }) => name)).toEqual(expect.arrayContaining([
-      "document", "tools-exist", "components-exist", "bindings-fit",
+      "document", "tools-exist", "components-exist", "bindings-fit", "expressions-compute",
       "query-inputs-literal", "no-string-interpolation", "maple-house-style",
     ]));
     expect(findings).toContainEqual({
@@ -207,6 +207,54 @@ describe("built-in fact checks", () => {
     expect(finding?.severity).toBe("block");
     expect(finding?.message).toContain("Allowed props: ");
     expect(finding?.message).toContain("rows");
+  });
+
+  it("names the real fields when a computed value reaches a field the tool shape has not got", async () => {
+    const layer = createCheckingLayer({ deps: deps() });
+    const findings = await layer.run(inputFor(
+      '<App name="Invoices"><Query id="invoices" tool="host_listInvoices"/><Stack><Stat value={sum(invoices.data.amountCent)}/></Stack></App>',
+    ));
+
+    const finding = findings.find(({ where }) => where.includes('prop "value"'));
+    expect(finding?.severity).toBe("block");
+    expect(finding?.message).toContain("computes {sum(invoices.data.amountCent)}");
+    expect(finding?.message).toContain("the real fields are: id, client, amountCents");
+  });
+
+  it("names the numeric fields when a computed value sums a string field", async () => {
+    const layer = createCheckingLayer({ deps: deps() });
+    const findings = await layer.run(inputFor(
+      '<App name="Invoices"><Query id="invoices" tool="host_listInvoices"/><Stack><Stat value={sum(invoices.data.client) / count(invoices.data)}/></Stack></App>',
+    ));
+
+    const finding = findings.find(({ where }) => where.includes('prop "value"'));
+    expect(finding?.severity).toBe("block");
+    expect(finding?.message).toContain("sum() needs numeric values");
+    expect(finding?.message).toContain("the numeric fields are: amountCents");
+  });
+
+  it("reports an unparseable computed value as a sentence naming the bad token", async () => {
+    // Hand-set: the wire compiler drops an attribute whose expression does not
+    // parse, so a stored/assembled tree is the only way one arrives.
+    const layer = createCheckingLayer({ deps: deps() });
+    const app = documentFrom(cleanApp);
+    const tree = structuredClone(app.tree) as NonNullable<GeneratedAppDocument["tree"]>;
+    const table = tree.nodes.find((node) => node.component === "Table");
+    (table as { props?: Record<string, unknown> }).props = { rows: { $expr: "sum(invoices.data.amountCents) + * 2" } };
+    const findings = await layer.run({ app: { ...app, tree }, request: "invoices" });
+
+    const finding = findings.find(({ where }) => where.includes('prop "rows"'));
+    expect(finding?.severity).toBe("block");
+    expect(finding?.message).toContain('"*"');
+  });
+
+  it("passes a computed value whose fields and types all check out", async () => {
+    const layer = createCheckingLayer({ deps: deps() });
+    const findings = await layer.run(inputFor(
+      '<App name="Invoices"><Query id="invoices" tool="host_listInvoices"/><Stack><Stat value={sum(invoices.data.amountCents) / count(invoices.data)}/></Stack></App>',
+    ));
+
+    expect(findings).toEqual([]);
   });
 
   it("blocks a document with no title and says what name is for", async () => {

--- a/packages/apps/src/checking/facts.ts
+++ b/packages/apps/src/checking/facts.ts
@@ -18,8 +18,10 @@ import {
   WIRE_COMPONENT_NAMES,
   VENDO_TREE_FORMAT,
   checkBindingShapes,
+  checkExpr,
   kitSpec,
   shapeAtPointer,
+  isExprBinding,
   isPathBinding,
   isStateBinding,
   validateAppDocument,
@@ -62,7 +64,7 @@ const isActionBinding = (value: unknown): boolean =>
   isRecord(value) && typeof value.action === "string";
 
 export const isRuntimeBound = (value: unknown): boolean =>
-  isPathBinding(value) || isStateBinding(value) || isActionBinding(value);
+  isPathBinding(value) || isStateBinding(value) || isExprBinding(value) || isActionBinding(value);
 
 /** Conservative kind check between a bound field's shape and the host prop's
  *  declared JSON-schema type: only CLEAR mismatches flag (an array of objects
@@ -154,7 +156,7 @@ export const hostReshapeIssues = (tree: Tree, deps: GenerationDependencies): Fac
 export const queryInputIssues = (tree: Tree): FactIssue[] => {
   const issues: FactIssue[] = [];
   const findBinding = (value: unknown): boolean => {
-    if (isPathBinding(value) || isStateBinding(value)) return true;
+    if (isPathBinding(value) || isStateBinding(value) || isExprBinding(value)) return true;
     if (Array.isArray(value)) return value.some(findBinding);
     if (isRecord(value)) return Object.values(value).some(findBinding);
     return false;
@@ -209,6 +211,43 @@ export const kitSlotIssues = (tree: Tree, deps: GenerationDependencies): FactIss
         issues.push(atProp(node.id, prop, `on <${node.component}> binds ${value.$path}, a ${bound.kind} field, but this slot takes a different RAW type (${propSpec.doc}) — bind the raw field with that type (e.g. the integer-cents field, not a pre-formatted display string).`));
       }
     }
+  }
+  return issues;
+};
+
+/** A computed value (`{ $expr }`) is evaluated live in the renderer, so a bad
+ *  expression is a blank stat rather than a crash — exactly the silent-breakage
+ *  class facts exist to catch. Three kinds are decidable by looking things up:
+ *  the expression parses, its field paths reach fields the tool shapes really
+ *  expose, and every slot's type can compute (sum over a string cannot).
+ *  Whether the number MEANS anything is the reviewer's judgement, not a fact. */
+export const exprIssues = (tree: Tree, deps: GenerationDependencies): FactIssue[] => {
+  const queryTool = new Map((tree.queries ?? []).map((query) => [query.name, query.tool]));
+  const context = {
+    queryNames: [...queryTool.keys()],
+    shapeOf: (queryName: string) => {
+      const tool = queryTool.get(queryName);
+      return tool === undefined || deps.toolShapes === undefined ? undefined : deps.toolShapes[tool];
+    },
+  };
+  const issues: FactIssue[] = [];
+  const walk = (nodeId: string, prop: string, value: unknown): void => {
+    if (isExprBinding(value)) {
+      for (const message of checkExpr(value.$expr, context)) {
+        issues.push(atProp(nodeId, prop, `computes {${value.$expr}}: ${message}`));
+      }
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) walk(nodeId, prop, item);
+      return;
+    }
+    if (isRecord(value)) {
+      for (const child of Object.values(value)) walk(nodeId, prop, child);
+    }
+  };
+  for (const node of tree.nodes) {
+    for (const [prop, value] of Object.entries(node.props ?? {})) walk(node.id, prop, value);
   }
   return issues;
 };
@@ -441,6 +480,7 @@ export const factChecks = (deps: GenerationDependencies): Check[] => [
     ...kitSlotIssues(tree, deps),
     ...hostReshapeIssues(tree, deps),
   ]),
+  treeCheck("expressions-compute", (tree) => exprIssues(tree, deps)),
   treeCheck("query-inputs-literal", (tree) => queryInputIssues(tree)),
   treeCheck("no-string-interpolation", (tree) => interpolationIssues(tree)),
 ];

--- a/packages/apps/src/generation/validation/validate.ts
+++ b/packages/apps/src/generation/validation/validate.ts
@@ -16,6 +16,7 @@ import {
 import {
   bindingKindIssues,
   catalogIssues,
+  exprIssues,
   factIssueLine,
   hostReshapeIssues,
   interpolationIssues,
@@ -174,6 +175,7 @@ export const validateCompiledCreate = async (
   issues.push(...bindingKindIssues(compiled.tree, deps).map(factIssueLine));
   issues.push(...kitSlotIssues(compiled.tree, deps).map(factIssueLine));
   issues.push(...hostReshapeIssues(compiled.tree, deps).map(factIssueLine));
+  issues.push(...exprIssues(compiled.tree, deps).map(factIssueLine));
   issues.push(...queryInputIssues(compiled.tree).map(factIssueLine));
   issues.push(...interpolationIssues(compiled.tree).map(factIssueLine));
   issues.push(...(await catalogIssues(compiled.tree, components, deps.catalog)).map(factIssueLine));

--- a/packages/core/src/genui/expr.test.ts
+++ b/packages/core/src/genui/expr.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from "vitest";
+import type { Json } from "../ids.js";
+import type { ShapeType } from "../shape.js";
+import {
+  checkExpr,
+  evaluateExpr,
+  exprPathHeads,
+  isExprBinding,
+  parseExpr,
+  type ExprCheckContext,
+} from "./expr.js";
+
+const data: Record<string, Json> = {
+  invoices: [
+    { id: "i1", client_name: "Acme", amount_cents: 12_000, due_date: "2026-01-14" },
+    { id: "i2", client_name: "Globex", amount_cents: 8_000, due_date: "2026-01-28" },
+    { id: "i3", client_name: "Initech", amount_cents: 5_000, due_date: "2026-02-03" },
+  ],
+  clients: [{ id: "c1", name: "Acme" }, { id: "c2", name: "Globex" }],
+  empty: [],
+  metrics: { total_cents: 25_000, label: "all invoices" },
+};
+
+/** Fixed reference instant so `days_until` is deterministic. */
+const now = Date.parse("2026-01-25T10:00:00.000Z");
+
+const evaluate = (source: string, over: Record<string, Json> = data) =>
+  evaluateExpr(source, over, { now });
+
+const valueOf = (source: string, over: Record<string, Json> = data): Json | undefined => {
+  const result = evaluate(source, over);
+  if (!result.ok) throw new Error(`expected a value, got the issue: ${result.issue}`);
+  return result.value;
+};
+
+const issueOf = (source: string, over: Record<string, Json> = data): string => {
+  const result = evaluate(source, over);
+  if (result.ok) throw new Error(`expected an issue, got the value: ${JSON.stringify(result.value)}`);
+  return result.issue;
+};
+
+const invoicesShape: ShapeType = {
+  kind: "array",
+  items: {
+    kind: "object",
+    fields: {
+      id: { kind: "string" },
+      client_name: { kind: "string" },
+      amount_cents: { kind: "number" },
+      due_date: { kind: "string" },
+    },
+  },
+};
+
+const clientsShape: ShapeType = {
+  kind: "array",
+  items: { kind: "object", fields: { id: { kind: "string" }, name: { kind: "string" } } },
+};
+
+const shapes: Record<string, ShapeType> = {
+  invoices: invoicesShape,
+  clients: clientsShape,
+  metrics: { kind: "object", fields: { total_cents: { kind: "number" }, label: { kind: "string" } } },
+  logs: { kind: "array", items: { kind: "json" } },
+};
+
+const context: ExprCheckContext = {
+  queryNames: ["invoices", "clients", "metrics", "unsampled", "logs"],
+  shapeOf: (name) => shapes[name],
+};
+
+describe("evaluateExpr", () => {
+  it("arithmetic over aggregates evaluates against sample rows", () => {
+    expect(valueOf("sum(invoices.amount_cents) / count(clients)")).toBe(12_500);
+    expect(valueOf("sum(invoices.amount_cents)")).toBe(25_000);
+    expect(valueOf("count(invoices)")).toBe(3);
+    expect(valueOf("(sum(invoices.amount_cents) - 5000) * 2")).toBe(40_000);
+    expect(valueOf("metrics.total_cents / 100")).toBe(250);
+    expect(valueOf("-sum(invoices.amount_cents) + 25000")).toBe(0);
+  });
+
+  it("parse error reported as a sentence with the bad token", () => {
+    const issue = issueOf("sum(invoices.amount_cents) + * 2");
+    expect(issue).toContain('"*"');
+    expect(issue).toMatch(/^[a-z"(].* /);
+    expect(issueOf("sum(invoices.amount_cents")).toContain(")");
+    expect(issueOf("total(invoices.amount_cents)")).toContain("total");
+    expect(issueOf("sum(invoices.amount_cents) +")).toContain("ends");
+    expect(issueOf("sum(invoices.amount_cents) # 2")).toContain('"#"');
+    expect(issueOf('group_by(invoices.due_date, "month')).toContain("unterminated");
+    expect(issueOf("sum(invoices.amount_cents, clients)")).toContain("one argument");
+    expect(issueOf("difference(invoices.amount_cents)")).toContain("two arguments");
+    expect(issueOf("count()")).toContain("one argument");
+    expect(issueOf("(1 + 2")).toContain('")"');
+    expect(issueOf("1 2")).toContain("trails");
+  });
+
+  it("reports a group_by written with the wrong argument kinds", () => {
+    expect(issueOf('group_by(5, "month", sum(invoices.amount_cents))')).toContain("date field path");
+    expect(issueOf('group_by(invoices.due_date, "month", days_until(invoices.due_date))')).toContain("aggregates");
+  });
+
+  it("unknown field reported naming the real fields", () => {
+    const issue = issueOf("sum(invoices.amont_cents)");
+    expect(issue).toContain("amont_cents");
+    expect(issue).toContain("amount_cents");
+    expect(issue).toContain("client_name");
+    expect(issueOf("metrics.totl_cents / 100")).toContain("total_cents");
+  });
+
+  it("sum over a string field reported as a type mismatch", () => {
+    const issue = issueOf("sum(invoices.client_name)");
+    expect(issue).toContain("sum()");
+    expect(issue).toContain("numeric");
+    expect(issue).toContain("Acme");
+  });
+
+  it("days_until on a date field", () => {
+    expect(valueOf("days_until(metrics.due)", { metrics: { due: "2026-02-01" } })).toBe(7);
+    expect(valueOf("days_until(metrics.due)", { metrics: { due: "2026-01-20T23:00:00Z" } })).toBe(-5);
+    expect(valueOf("days_until(metrics.due) * 24", { metrics: { due: "2026-01-27" } })).toBe(48);
+    expect(issueOf("days_until(metrics.label)")).toContain("ISO date");
+    expect(issueOf("days_until(metrics.total_cents)")).toContain("ISO date");
+    expect(issueOf("days_until(invoices.due_date)")).toContain("one date");
+  });
+
+  it("group_by monthly bucketing", () => {
+    expect(valueOf('group_by(invoices.due_date, "month", sum(invoices.amount_cents))')).toEqual([
+      { key: "2026-01", value: 20_000 },
+      { key: "2026-02", value: 5_000 },
+    ]);
+    expect(valueOf('group_by(invoices.due_date, "month", count(invoices))')).toEqual([
+      { key: "2026-01", value: 2 },
+      { key: "2026-02", value: 1 },
+    ]);
+    expect(valueOf('group_by(invoices.due_date, "day", max(invoices.amount_cents))')).toEqual([
+      { key: "2026-01-14", value: 12_000 },
+      { key: "2026-01-28", value: 8_000 },
+      { key: "2026-02-03", value: 5_000 },
+    ]);
+    expect(valueOf('group_by(invoices.due_date, "year", average(invoices.amount_cents))')).toEqual([
+      { key: "2026", value: 25_000 / 3 },
+    ]);
+    expect(valueOf('group_by(empty.due_date, "month", sum(empty.amount_cents))')).toEqual([]);
+  });
+
+  it("reports the group_by shapes it cannot bucket", () => {
+    expect(issueOf('group_by(invoices.due_date, "week", sum(invoices.amount_cents))')).toContain("month");
+    expect(issueOf('group_by(invoices.due_date, "month", sum(clients.name))')).toMatch(/same rows/i);
+    expect(issueOf('group_by(invoices.client_name, "month", sum(invoices.amount_cents))')).toContain("date");
+    expect(issueOf('group_by(metrics.label, "month", sum(metrics.total_cents))')).toContain("list of rows");
+    expect(issueOf('group_by(invoices.due_date, "month", sum(invoices.balance))')).toContain("balance");
+    expect(issueOf('group_by(invoices.amount_cents, "month", sum(invoices.amount_cents))')).toContain("date");
+    expect(issueOf('group_by(loose.due_date, "month", sum(loose.cents))', { loose: [1, 2] })).toContain("list of rows");
+    const mixed: Record<string, Json> = { mixed: [{ due_date: "2026-01-01", cents: 1 }, { cents: 2 }] };
+    expect(issueOf('group_by(mixed.due_date, "month", sum(mixed.cents))', mixed)).toContain("due_date");
+  });
+
+  it("division by zero safe", () => {
+    const result = evaluate("sum(invoices.amount_cents) / count(empty)");
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.issue).toContain("zero");
+    expect(issueOf("sum(invoices.amount_cents) / 0")).toContain("zero");
+    expect(issueOf("average(empty.amount_cents)")).toContain("average()");
+    expect(issueOf("min(empty.amount_cents)")).toContain("min()");
+  });
+
+  it("treats data that has not arrived as loading, never as a problem", () => {
+    expect(valueOf("sum(invoices.amount_cents) / count(clients)", {})).toBeUndefined();
+    expect(valueOf("sum(invoices.amount_cents) + 1", { clients: [] })).toBeUndefined();
+    expect(valueOf("count(invoices)", { invoices: null })).toBeUndefined();
+    expect(valueOf("days_until(metrics.due)", { metrics: { due: null } })).toBeUndefined();
+    expect(valueOf('group_by(invoices.due_date, "month", sum(invoices.amount_cents))', {})).toBeUndefined();
+    expect(valueOf("-invoices", { invoices: null })).toBeUndefined();
+  });
+
+  it("says which value is not a number instead of computing with it", () => {
+    expect(issueOf("metrics.label / 2")).toContain("not a number");
+    expect(issueOf("invoices / 2")).toContain("reduce it");
+    expect(issueOf("-metrics.label")).toContain("not a number");
+    expect(issueOf("count(metrics)")).toContain("count()");
+    expect(issueOf("count(metrics.label)")).toContain("count()");
+    expect(issueOf("difference(metrics.total_cents, metrics.label)")).toContain("not a number");
+    expect(valueOf("difference(metrics.total_cents, 5000)")).toBe(20_000);
+  });
+
+  it("reads columns out of rows and past nested objects", () => {
+    const nested: Record<string, Json> = {
+      orders: [
+        { lines: [{ cents: 100 }, { cents: 200 }] },
+        { lines: [{ cents: 300 }] },
+      ],
+      wrapped: { rows: [{ cents: 5 }, { cents: 6 }] },
+    };
+    expect(valueOf("sum(orders.lines.cents)", nested)).toBe(600);
+    expect(valueOf("sum(wrapped.rows.cents)", nested)).toBe(11);
+    expect(valueOf("count(wrapped.rows)", nested)).toBe(2);
+    expect(valueOf("sum(orders.0.lines.cents)", nested)).toBe(300);
+    expect(issueOf("sum(orders.lines.total)", nested)).toContain("cents");
+    expect(issueOf("sum(wrapped.rows.cents.deeper)", nested)).toContain("reads past");
+    expect(issueOf("count(orders.lines)", { orders: [1, 2] })).toContain("rows");
+  });
+
+  it("is total on pathological input", () => {
+    const deep = `${"(".repeat(200)}1${")".repeat(200)}`;
+    expect(issueOf(deep)).toContain("nested");
+    expect(issueOf("")).toContain("ends");
+    expect(issueOf("1e999")).toContain("too large");
+    expect(issueOf("invoices.")).toContain('"."');
+  });
+});
+
+describe("parseExpr", () => {
+  it("parses numbers, strings, paths, and precedence", () => {
+    expect(parseExpr("1 + 2 * 3").ok).toBe(true);
+    const parsed = parseExpr("sum(a.b) / count(c)");
+    expect(parsed.ok && parsed.node.kind).toBe("binary");
+    expect(parsed.ok && exprPathHeads(parsed.node)).toEqual(["a", "c"]);
+    expect(exprPathHeads({ kind: "number", value: 1 })).toEqual([]);
+  });
+
+  it("recognises an $expr binding object", () => {
+    expect(isExprBinding({ $expr: "count(a)" })).toBe(true);
+    expect(isExprBinding({ $path: "/a" })).toBe(false);
+    expect(isExprBinding(null)).toBe(false);
+    expect(isExprBinding({ $expr: 3 })).toBe(false);
+  });
+});
+
+describe("checkExpr", () => {
+  it("passes an expression whose fields and types all check out", () => {
+    expect(checkExpr("sum(invoices.amount_cents) / count(clients)", context)).toEqual([]);
+    expect(checkExpr('group_by(invoices.due_date, "month", sum(invoices.amount_cents))', context)).toEqual([]);
+    expect(checkExpr("days_until(invoices.0.due_date) * 2", context)).toEqual([]);
+    expect(checkExpr("metrics.total_cents - 1", context)).toEqual([]);
+    // No shape card for the query, or an unknown region inside one: unknown
+    // regions stay silent (defensive).
+    expect(checkExpr("sum(unsampled.whatever)", context)).toEqual([]);
+    expect(checkExpr("sum(logs.cents)", context)).toEqual([]);
+  });
+
+  it("reports a parse error as the expression's one issue", () => {
+    expect(checkExpr("sum(invoices.amount_cents) + * 2", context)).toEqual([expect.stringContaining('"*"')]);
+  });
+
+  it("unknown field reported naming the real fields", () => {
+    const [issue, ...rest] = checkExpr("sum(invoices.amont_cents)", context);
+    expect(rest).toEqual([]);
+    expect(issue).toContain("amont_cents");
+    expect(issue).toContain("amount_cents");
+    expect(issue).toContain("client_name");
+    expect(checkExpr("count(nope.rows)", context)).toEqual([
+      expect.stringContaining("does not name a declared query"),
+    ]);
+    expect(checkExpr("metrics.totl_cents", context)).toEqual([expect.stringContaining("total_cents")]);
+    expect(checkExpr("metrics.total_cents.deeper", context)).toEqual([expect.stringContaining("reads past")]);
+    expect(checkExpr("sum(invoices.amount_cents.deeper)", context)).toEqual([
+      expect.stringContaining("reads past"),
+    ]);
+  });
+
+  it("sum over a string field reported as a type mismatch", () => {
+    const [issue] = checkExpr("sum(invoices.client_name)", context);
+    expect(issue).toContain("sum()");
+    expect(issue).toContain("client_name");
+    expect(issue).toContain("string");
+    expect(issue).toContain("amount_cents");
+  });
+
+  it("reports every other slot whose type cannot compute", () => {
+    expect(checkExpr("count(metrics.label)", context)).toEqual([expect.stringContaining("count()")]);
+    expect(checkExpr("count(metrics)", context)).toEqual([expect.stringContaining("count()")]);
+    expect(checkExpr("days_until(invoices.amount_cents)", context)).toEqual([
+      expect.stringContaining("days_until()"),
+    ]);
+    expect(checkExpr("metrics.label / 2", context)).toEqual([expect.stringContaining("not a number")]);
+    expect(checkExpr("-metrics.label", context)).toEqual([expect.stringContaining("not a number")]);
+    expect(checkExpr("invoices / 2", context)).toEqual([expect.stringContaining("reduce it")]);
+    expect(checkExpr('group_by(invoices.amount_cents, "month", sum(invoices.amount_cents))', context)).toEqual([
+      expect.stringContaining("date"),
+    ]);
+    expect(checkExpr('difference(invoices.client_name, "x")', context).length).toBeGreaterThan(0);
+    // Rows with no numeric field at all: the finding still names the offender,
+    // it just has no numeric field to suggest.
+    expect(checkExpr("sum(clients.name)", context)).toEqual([expect.stringContaining("sum()")]);
+    expect(checkExpr('"x" / 2', context)).toEqual([expect.stringContaining("not a number")]);
+    expect(checkExpr('group_by(invoices.due_date, "month", sum(invoices.amount_cents)) / 2', context)).toEqual([
+      expect.stringContaining("reduce it"),
+    ]);
+  });
+});

--- a/packages/core/src/genui/expr.ts
+++ b/packages/core/src/genui/expr.ts
@@ -1,0 +1,827 @@
+/**
+ * `$expr` — the COMPUTED binding value: `{ $expr: "sum(invoices.amount_cents) / count(clients)" }`.
+ *
+ * A computed value is evaluated LIVE at bind resolution in the renderer — the
+ * same place `$path` resolves — and re-evaluated whenever the query data
+ * changes. Nothing is ever computed at generation time: a headline total that
+ * was frozen into the document the moment a model wrote it would be a lie by
+ * the next refresh.
+ *
+ * Three surfaces:
+ *   - {@link parseExpr}    source → AST. Total, depth-bounded.
+ *   - {@link evaluateExpr} source + resolved query data → a value. Total: an
+ *                          evaluation problem yields `undefined` plus a
+ *                          described issue, never a throw.
+ *   - {@link checkExpr}    source + the tool SHAPES → the fact findings before
+ *                          it ships (parse errors, fields the shapes do not
+ *                          carry, types that cannot compute). The apps fact
+ *                          check (checking/facts.ts) speaks these.
+ *
+ * Grammar: field paths (`invoices.amount_cents`), numbers, `+ - * / ( )`, and
+ * the closed call list {@link EXPR_CALLS}. A field name against a list of rows
+ * reads the COLUMN (`invoices.amount_cents` is every row's cents), which is
+ * what the aggregates consume.
+ *
+ * Data that has not arrived is not a problem: it resolves to `undefined` and
+ * flows through arithmetic as `undefined` — the same discipline as `$reshape`
+ * (loading is never a mismatch).
+ */
+
+import type { Json } from "../ids.js";
+import type { ShapeType } from "../shape.js";
+import { isPlainObject } from "./tree-node.js";
+
+/** A computed binding value; the string is the expression source. */
+export interface ExprBinding {
+  $expr: string;
+}
+
+/** The `$path`/`$state` guards' sibling (tree-node.ts). */
+export function isExprBinding(value: unknown): value is ExprBinding {
+  return typeof value === "object"
+    && value !== null
+    && typeof (value as { $expr?: unknown }).$expr === "string";
+}
+
+/** The closed call vocabulary. Adding a call means adding it here first. */
+export const EXPR_CALLS = [
+  "sum",
+  "count",
+  "average",
+  "min",
+  "max",
+  "difference",
+  "days_until",
+  "group_by",
+] as const;
+
+export type ExprCall = (typeof EXPR_CALLS)[number];
+
+/** The `group_by` bucket vocabulary (its second argument). */
+export const EXPR_BUCKETS = ["day", "month", "year"] as const;
+
+type ExprBucket = (typeof EXPR_BUCKETS)[number];
+
+const ARITY: Record<ExprCall, number> = {
+  sum: 1,
+  count: 1,
+  average: 1,
+  min: 1,
+  max: 1,
+  difference: 2,
+  days_until: 1,
+  group_by: 3,
+};
+
+const COUNT_WORDS = ["no", "one", "two", "three"] as const;
+
+const argumentCount = (count: number): string =>
+  `${COUNT_WORDS[count] ?? count} argument${count === 1 ? "" : "s"}`;
+
+/** The calls that reduce numbers, and so may aggregate a `group_by` bucket. */
+const NUMERIC_AGGREGATES: ReadonlySet<string> = new Set(["sum", "average", "min", "max"]);
+const GROUPABLE: ReadonlySet<string> = new Set([...NUMERIC_AGGREGATES, "count"]);
+
+const isExprCall = (name: string): name is ExprCall => (EXPR_CALLS as readonly string[]).includes(name);
+
+// ── grammar ─────────────────────────────────────────────────────────────────
+
+export type ExprNode =
+  | { kind: "number"; value: number }
+  | { kind: "string"; value: string }
+  | { kind: "path"; segments: readonly string[]; text: string }
+  | { kind: "negate"; operand: ExprNode }
+  | { kind: "binary"; op: "+" | "-" | "*" | "/"; left: ExprNode; right: ExprNode }
+  | { kind: "call"; name: ExprCall; args: readonly ExprNode[] };
+
+export type ExprParse =
+  | { ok: true; node: ExprNode }
+  | { ok: false; issue: string };
+
+/** Deeper than any real computed value; the bound is what keeps parsing and
+ *  evaluation total (no input can reach the call-stack limit). */
+const EXPR_MAX_DEPTH = 32;
+
+type Token =
+  | { type: "number"; at: number; text: string; value: number }
+  | { type: "string"; at: number; text: string; value: string }
+  | { type: "path"; at: number; text: string; segments: string[] }
+  | { type: "punct"; at: number; text: string };
+
+const WHITESPACE = /\s/;
+const IDENTIFIER_START = /[A-Za-z_]/;
+const IDENTIFIER_CHAR = /[A-Za-z0-9_]/;
+const DIGIT = /[0-9]/;
+/** JSON number grammar, matched sticky at the cursor (wire/expression.ts's). */
+const NUMBER_PATTERN = /-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/y;
+const PUNCTUATION: ReadonlySet<string> = new Set(["+", "-", "*", "/", "(", ")", ","]);
+
+/** Reads a dotted field path as ONE token: a call name is a path of one
+ *  segment, so the parser never has to re-join dots. */
+const readPath = (source: string, start: number): { segments: string[]; end: number } => {
+  let end = start + 1;
+  while (end < source.length && IDENTIFIER_CHAR.test(source[end] as string)) end += 1;
+  const segments = [source.slice(start, end)];
+  while (source[end] === "." && IDENTIFIER_CHAR.test(source[end + 1] ?? "")) {
+    let segmentEnd = end + 1;
+    while (segmentEnd < source.length && IDENTIFIER_CHAR.test(source[segmentEnd] as string)) segmentEnd += 1;
+    segments.push(source.slice(end + 1, segmentEnd));
+    end = segmentEnd;
+  }
+  return { segments, end };
+};
+
+const tokenize = (source: string): { tokens: Token[] } | { issue: string } => {
+  const tokens: Token[] = [];
+  let index = 0;
+  while (index < source.length) {
+    const char = source[index] as string;
+    if (WHITESPACE.test(char)) {
+      index += 1;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      const end = source.indexOf(char, index + 1);
+      if (end === -1) {
+        return { issue: `this expression has an unterminated string starting at position ${index + 1}` };
+      }
+      tokens.push({ type: "string", at: index, text: source.slice(index + 1, end), value: source.slice(index + 1, end) });
+      index = end + 1;
+      continue;
+    }
+    if (DIGIT.test(char)) {
+      NUMBER_PATTERN.lastIndex = index;
+      // A digit always starts a match — the pattern's integer part is `0` or
+      // `[1-9]\d*` — so the fallback is unreachable, not a real branch.
+      const [text = char] = NUMBER_PATTERN.exec(source) ?? [];
+      const value = Number(text);
+      if (!Number.isFinite(value)) {
+        return { issue: `the number "${text}" in this expression is too large to compute with` };
+      }
+      tokens.push({ type: "number", at: index, text, value });
+      index = NUMBER_PATTERN.lastIndex;
+      continue;
+    }
+    if (IDENTIFIER_START.test(char)) {
+      const path = readPath(source, index);
+      tokens.push({ type: "path", at: index, text: path.segments.join("."), segments: path.segments });
+      index = path.end;
+      continue;
+    }
+    if (PUNCTUATION.has(char)) {
+      tokens.push({ type: "punct", at: index, text: char });
+      index += 1;
+      continue;
+    }
+    return { issue: `"${char}" is not something an expression can contain (position ${index + 1})` };
+  }
+  return { tokens };
+};
+
+/** Internal parse-failure sentinel — flows up the recursion instead of a throw
+ *  so every frame unwinds with the issue already recorded (wire/expression.ts's
+ *  discipline). */
+const PARSE_FAILED: unique symbol = Symbol("expr-parse-failed");
+type ParseFailed = typeof PARSE_FAILED;
+
+interface ParseState {
+  readonly tokens: readonly Token[];
+  index: number;
+  issue: string | null;
+}
+
+const failParse = (state: ParseState, message: string): ParseFailed => {
+  state.issue ??= message;
+  return PARSE_FAILED;
+};
+
+const isPunct = (token: Token | undefined, text: string): boolean =>
+  token !== undefined && token.type === "punct" && token.text === text;
+
+const describeToken = (token: Token | undefined): string =>
+  token === undefined ? "the end of the expression" : `"${token.text}"`;
+
+const parseGroupBy = (state: ParseState, args: readonly ExprNode[]): ExprNode | ParseFailed => {
+  const [key, bucket, aggregate] = args;
+  if (key?.kind !== "path") {
+    return failParse(state, "group_by() groups by a date field path, like group_by(invoices.due_date, \"month\", sum(invoices.amount_cents))");
+  }
+  if (bucket?.kind !== "string" || !(EXPR_BUCKETS as readonly string[]).includes(bucket.value)) {
+    return failParse(state, `group_by() buckets by ${EXPR_BUCKETS.join(", ")} — write one of them as a quoted second argument`);
+  }
+  if (aggregate?.kind !== "call" || !GROUPABLE.has(aggregate.name) || aggregate.args[0]?.kind !== "path") {
+    return failParse(state, `group_by()'s third argument aggregates each bucket, like sum(invoices.amount_cents) — one of ${[...GROUPABLE].join(", ")} over a field path`);
+  }
+  const collection = key.segments.slice(0, -1).join(".");
+  const aggregated = aggregate.args[0].segments;
+  const sameRows = aggregate.name === "count"
+    ? aggregated.join(".") === collection || aggregated.slice(0, -1).join(".") === collection
+    : aggregated.slice(0, -1).join(".") === collection;
+  if (!sameRows) {
+    return failParse(state, `group_by() aggregates the SAME rows it groups: ${aggregate.name}(${aggregate.args[0].text}) reads different rows than ${key.text}`);
+  }
+  return { kind: "call", name: "group_by", args };
+};
+
+const parseCall = (state: ParseState, nameToken: Token & { type: "path" }, depth: number): ExprNode | ParseFailed => {
+  const name = nameToken.text;
+  if (nameToken.segments.length !== 1 || !isExprCall(name)) {
+    return failParse(state, `"${name}" is not a function an expression can call — the functions are: ${EXPR_CALLS.join(", ")}`);
+  }
+  state.index += 1; // consume "("
+  const args: ExprNode[] = [];
+  if (isPunct(state.tokens[state.index], ")")) {
+    state.index += 1;
+  } else {
+    for (;;) {
+      const arg = parseSum(state, depth + 1);
+      if (arg === PARSE_FAILED) return PARSE_FAILED;
+      args.push(arg);
+      const next = state.tokens[state.index];
+      if (isPunct(next, ",")) {
+        state.index += 1;
+        continue;
+      }
+      if (isPunct(next, ")")) {
+        state.index += 1;
+        break;
+      }
+      return failParse(state, `the expression ends inside ${name}(…) where a "," or ")" was expected`);
+    }
+  }
+  if (args.length !== ARITY[name]) {
+    return failParse(state, `${name}() takes ${argumentCount(ARITY[name])}, not ${args.length}`);
+  }
+  if (name === "group_by") return parseGroupBy(state, args);
+  return { kind: "call", name, args };
+};
+
+const parsePrimary = (state: ParseState, depth: number): ExprNode | ParseFailed => {
+  const token = state.tokens[state.index];
+  if (token === undefined) return failParse(state, "this expression ends where a value was expected");
+  if (token.type === "number") {
+    state.index += 1;
+    return { kind: "number", value: token.value };
+  }
+  if (token.type === "string") {
+    state.index += 1;
+    return { kind: "string", value: token.value };
+  }
+  if (token.type === "path") {
+    if (isPunct(state.tokens[state.index + 1], "(")) {
+      state.index += 1;
+      return parseCall(state, token, depth);
+    }
+    state.index += 1;
+    return { kind: "path", segments: token.segments, text: token.text };
+  }
+  if (token.text === "(") {
+    state.index += 1;
+    const inner = parseSum(state, depth + 1);
+    if (inner === PARSE_FAILED) return PARSE_FAILED;
+    const close = state.tokens[state.index];
+    if (!isPunct(close, ")")) {
+      return failParse(state, `this expression is missing a ")" — ${describeToken(close)} appears where the closing parenthesis should be`);
+    }
+    state.index += 1;
+    return inner;
+  }
+  return failParse(state, `${describeToken(token)} is not a value — an expression takes numbers, field paths, ${EXPR_CALLS.join("/")} calls, and ( )`);
+};
+
+const parseUnary = (state: ParseState, depth: number): ExprNode | ParseFailed => {
+  if (depth > EXPR_MAX_DEPTH) {
+    return failParse(state, `this expression is nested more than ${EXPR_MAX_DEPTH} levels deep`);
+  }
+  if (isPunct(state.tokens[state.index], "-")) {
+    state.index += 1;
+    const operand = parseUnary(state, depth + 1);
+    return operand === PARSE_FAILED ? PARSE_FAILED : { kind: "negate", operand };
+  }
+  return parsePrimary(state, depth);
+};
+
+const parseBinary = (
+  state: ParseState,
+  depth: number,
+  operators: readonly string[],
+  next: (state: ParseState, depth: number) => ExprNode | ParseFailed,
+): ExprNode | ParseFailed => {
+  let left = next(state, depth);
+  if (left === PARSE_FAILED) return PARSE_FAILED;
+  for (;;) {
+    const token = state.tokens[state.index];
+    if (token === undefined || token.type !== "punct" || !operators.includes(token.text)) return left;
+    state.index += 1;
+    const right = next(state, depth + 1);
+    if (right === PARSE_FAILED) return PARSE_FAILED;
+    left = { kind: "binary", op: token.text as "+" | "-" | "*" | "/", left, right };
+  }
+};
+
+const parseProduct = (state: ParseState, depth: number): ExprNode | ParseFailed =>
+  parseBinary(state, depth, ["*", "/"], parseUnary);
+
+function parseSum(state: ParseState, depth: number): ExprNode | ParseFailed {
+  return parseBinary(state, depth, ["+", "-"], parseProduct);
+}
+
+/** Parse one expression source. Pure, deterministic, total: any input either
+ *  yields an AST or one issue written as a sentence naming the bad token. */
+export function parseExpr(source: string): ExprParse {
+  const tokenized = tokenize(source);
+  if ("issue" in tokenized) return { ok: false, issue: tokenized.issue };
+  const state: ParseState = { tokens: tokenized.tokens, index: 0, issue: null };
+  const node = parseSum(state, 0);
+  if (node === PARSE_FAILED) {
+    return { ok: false, issue: state.issue ?? "this expression could not be read" };
+  }
+  const trailing = state.tokens[state.index];
+  if (trailing !== undefined) {
+    return { ok: false, issue: `${describeToken(trailing)} trails the end of this expression (position ${trailing.at + 1})` };
+  }
+  return { ok: true, node };
+}
+
+/** The query names an expression reads — the compiler's unknown-reference gate. */
+export function exprPathHeads(node: ExprNode): string[] {
+  const heads: string[] = [];
+  const walk = (current: ExprNode): void => {
+    if (current.kind === "path") {
+      const head = current.segments[0];
+      if (head !== undefined && !heads.includes(head)) heads.push(head);
+      return;
+    }
+    if (current.kind === "negate") walk(current.operand);
+    else if (current.kind === "binary") {
+      walk(current.left);
+      walk(current.right);
+    } else if (current.kind === "call") current.args.forEach(walk);
+  };
+  walk(node);
+  return heads;
+}
+
+/** How a node reads back in an issue message. */
+const printExpr = (node: ExprNode): string => {
+  if (node.kind === "number") return String(node.value);
+  if (node.kind === "string") return `"${node.value}"`;
+  if (node.kind === "path") return node.text;
+  if (node.kind === "negate") return `-${printExpr(node.operand)}`;
+  if (node.kind === "call") return `${node.name}(${node.args.map(printExpr).join(", ")})`;
+  return `${printExpr(node.left)} ${node.op} ${printExpr(node.right)}`;
+};
+
+// ── evaluation ──────────────────────────────────────────────────────────────
+
+/** The total evaluation result. `ok: false` is the renderer's contained
+ *  data-shape-notice path (the `$reshape` convention), never a throw. */
+export type ExprResult =
+  | { ok: true; value: Json | undefined }
+  | { ok: false; issue: string };
+
+export interface ExprEvalOptions {
+  /** `days_until`'s reference instant in epoch ms; defaults to now. Supplied
+   *  so evaluation is deterministic under test. */
+  now?: number;
+}
+
+const EVAL_FAILED: unique symbol = Symbol("expr-evaluation-failed");
+type EvalFailed = typeof EVAL_FAILED;
+
+interface EvalState {
+  readonly data: Record<string, Json>;
+  readonly now: number;
+  issue: string | null;
+}
+
+const failEval = (state: EvalState, message: string): EvalFailed => {
+  state.issue ??= message;
+  return EVAL_FAILED;
+};
+
+const describeValue = (value: unknown): string => {
+  if (value === null || value === undefined) return "empty";
+  if (Array.isArray(value)) return `a list of ${value.length}`;
+  if (isPlainObject(value)) return "an object";
+  if (typeof value === "string") return `the text "${value}"`;
+  return String(value);
+};
+
+const INDEX_PATTERN = /^(?:0|[1-9]\d*)$/;
+
+const fieldsOf = (rows: readonly Record<string, unknown>[]): string => {
+  const fields: string[] = [];
+  for (const row of rows) {
+    for (const field of Object.keys(row)) if (!fields.includes(field)) fields.push(field);
+  }
+  return fields.join(", ");
+};
+
+const walkValue = (
+  state: EvalState,
+  value: unknown,
+  segments: readonly string[],
+  consumed: readonly string[],
+): unknown | EvalFailed => {
+  if (segments.length === 0) return value === null ? undefined : value;
+  if (value === null || value === undefined) return undefined;
+  const [head, ...rest] = segments as [string, ...string[]];
+  const at = `"${consumed.join(".")}"`;
+  if (Array.isArray(value)) {
+    if (INDEX_PATTERN.test(head)) return walkValue(state, value[Number(head)], rest, [...consumed, head]);
+    const rows = value.filter(isPlainObject);
+    if (rows.length === 0) {
+      if (value.length === 0) return [];
+      return failEval(state, `"${head}" reads a field out of ${at}, but its items are not rows (the first is ${describeValue(value[0])})`);
+    }
+    const carrying = rows.filter((row) => Object.prototype.hasOwnProperty.call(row, head));
+    if (carrying.length === 0) {
+      return failEval(state, `"${head}" is absent from the rows of ${at} — the fields they carry are: ${fieldsOf(rows)}`);
+    }
+    // A field name against rows reads the COLUMN; nested lists flatten, so a
+    // column of columns is still one column for the aggregates.
+    const column: unknown[] = [];
+    for (const row of carrying) {
+      const item = walkValue(state, row[head], rest, [...consumed, head]);
+      if (item === EVAL_FAILED) return EVAL_FAILED;
+      if (item === undefined) continue;
+      if (Array.isArray(item)) column.push(...item);
+      else column.push(item);
+    }
+    return column;
+  }
+  if (isPlainObject(value)) {
+    if (!Object.prototype.hasOwnProperty.call(value, head)) {
+      return failEval(state, `"${head}" is absent from ${at} — its fields are: ${Object.keys(value).join(", ")}`);
+    }
+    return walkValue(state, value[head], rest, [...consumed, head]);
+  }
+  return failEval(state, `"${head}" reads past ${describeValue(value)} in ${at}`);
+};
+
+const resolveSegments = (state: EvalState, segments: readonly string[]): unknown | EvalFailed => {
+  const [head, ...rest] = segments;
+  // A query whose data has not arrived resolves to `undefined` — loading is
+  // never a mismatch. A head that names no query at all is a FACT, caught by
+  // checkExpr before the app ships (the renderer cannot tell them apart).
+  if (head === undefined || !Object.prototype.hasOwnProperty.call(state.data, head)) return undefined;
+  return walkValue(state, state.data[head], rest, [head]);
+};
+
+const asNumber = (state: EvalState, value: unknown, label: string): number | EvalFailed => {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (Array.isArray(value)) {
+    return failEval(state, `${label} is a list of ${value.length} values, not a single number — reduce it with sum(), count(), or average() first`);
+  }
+  return failEval(state, `${label} is ${describeValue(value)}, not a number — arithmetic needs numbers`);
+};
+
+const numbersOf = (state: EvalState, value: unknown, call: string, label: string): number[] | EvalFailed => {
+  const items = Array.isArray(value) ? value : [value];
+  const numbers: number[] = [];
+  for (const item of items) {
+    // Sparse data carries explicit nulls; they are not a type mismatch.
+    if (item === null || item === undefined) continue;
+    if (typeof item !== "number" || !Number.isFinite(item)) {
+      return failEval(state, `${call}() needs numeric values, but ${label} holds ${describeValue(item)}`);
+    }
+    numbers.push(item);
+  }
+  return numbers;
+};
+
+const reduceNumbers = (state: EvalState, numbers: readonly number[], call: string, label: string): number | EvalFailed => {
+  if (call === "sum") return numbers.reduce((total, value) => total + value, 0);
+  if (numbers.length === 0) return failEval(state, `${call}() has no values to work with in ${label}`);
+  if (call === "average") return numbers.reduce((total, value) => total + value, 0) / numbers.length;
+  return call === "min" ? Math.min(...numbers) : Math.max(...numbers);
+};
+
+const DAY_MS = 86_400_000;
+
+/** Whole days from the reference instant's UTC day to the target's. */
+const daysUntil = (state: EvalState, value: unknown, label: string): number | EvalFailed => {
+  if (Array.isArray(value)) {
+    return failEval(state, `days_until() reads one date, but ${label} is a list of ${value.length} — point it at a single row's date field`);
+  }
+  if (typeof value !== "string") {
+    return failEval(state, `days_until() reads an ISO date string, but ${label} is ${describeValue(value)}`);
+  }
+  const time = Date.parse(value);
+  if (!Number.isFinite(time)) {
+    return failEval(state, `days_until() reads an ISO date string, and "${value}" is not one`);
+  }
+  return Math.floor(time / DAY_MS) - Math.floor(state.now / DAY_MS);
+};
+
+const bucketKey = (value: unknown, bucket: ExprBucket): string | null => {
+  // ISO date strings only: an epoch-ms number read as a date is how a numeric
+  // field silently buckets into 1970 instead of saying it is not a date.
+  if (typeof value !== "string") return null;
+  const time = Date.parse(value);
+  if (!Number.isFinite(time)) return null;
+  const iso = new Date(time).toISOString();
+  return bucket === "year" ? iso.slice(0, 4) : bucket === "month" ? iso.slice(0, 7) : iso.slice(0, 10);
+};
+
+const evaluateGroupBy = (state: EvalState, args: readonly ExprNode[]): unknown | EvalFailed => {
+  const key = args[0] as ExprNode & { kind: "path" };
+  const bucket = (args[1] as ExprNode & { kind: "string" }).value as ExprBucket;
+  const aggregate = args[2] as ExprNode & { kind: "call" };
+  const valuePath = aggregate.args[0] as ExprNode & { kind: "path" };
+  const collection = key.segments.slice(0, -1);
+  const keyField = key.segments[key.segments.length - 1] as string;
+  const valueField = valuePath.segments[valuePath.segments.length - 1] as string;
+
+  const resolved = resolveSegments(state, collection);
+  if (resolved === EVAL_FAILED) return EVAL_FAILED;
+  if (resolved === undefined) return undefined;
+  if (!Array.isArray(resolved)) {
+    return failEval(state, `group_by() groups a list of rows, but "${collection.join(".")}" is ${describeValue(resolved)}`);
+  }
+  const rows = resolved.filter(isPlainObject);
+  if (rows.length === 0) {
+    if (resolved.length === 0) return [];
+    return failEval(state, `group_by() groups a list of rows, but "${collection.join(".")}" holds ${describeValue(resolved[0])}`);
+  }
+  if (aggregate.name !== "count"
+    && !rows.some((row) => Object.prototype.hasOwnProperty.call(row, valueField))) {
+    return failEval(state, `"${valueField}" is absent from the rows of "${collection.join(".")}" — the fields they carry are: ${fieldsOf(rows)}`);
+  }
+  const groups = new Map<string, unknown[]>();
+  for (const row of rows) {
+    if (!Object.prototype.hasOwnProperty.call(row, keyField)) {
+      return failEval(state, `group_by() reads "${keyField}" from each row of "${collection.join(".")}" — the fields they carry are: ${fieldsOf(rows)}`);
+    }
+    const groupKey = bucketKey(row[keyField], bucket);
+    if (groupKey === null) {
+      return failEval(state, `group_by() buckets by date, and ${describeValue(row[keyField])} in "${keyField}" is not an ISO date`);
+    }
+    const existing = groups.get(groupKey);
+    if (existing === undefined) groups.set(groupKey, [row[valueField]]);
+    else existing.push(row[valueField]);
+  }
+  const buckets = [...groups.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  const label = `"${collection.join(".")}.${valueField}"`;
+  const points: Array<{ key: string; value: number }> = [];
+  for (const [groupKey, values] of buckets) {
+    if (aggregate.name === "count") {
+      points.push({ key: groupKey, value: values.length });
+      continue;
+    }
+    const numbers = numbersOf(state, values, aggregate.name, label);
+    if (numbers === EVAL_FAILED) return EVAL_FAILED;
+    const reduced = reduceNumbers(state, numbers, aggregate.name, label);
+    if (reduced === EVAL_FAILED) return EVAL_FAILED;
+    points.push({ key: groupKey, value: reduced });
+  }
+  return points;
+};
+
+const evaluateCall = (state: EvalState, node: ExprNode & { kind: "call" }): unknown | EvalFailed => {
+  if (node.name === "group_by") return evaluateGroupBy(state, node.args);
+  const label = printExpr(node.args[0] as ExprNode);
+  const first = evaluate(state, node.args[0] as ExprNode);
+  if (first === EVAL_FAILED) return EVAL_FAILED;
+  if (first === undefined) return undefined;
+  if (node.name === "count") {
+    if (Array.isArray(first)) return first.length;
+    const listFields = isPlainObject(first)
+      ? Object.entries(first).filter(([, value]) => Array.isArray(value)).map(([field]) => field)
+      : [];
+    const hint = listFields.length > 0 ? ` — name the list (e.g. ${label}.${listFields[0]})` : "";
+    return failEval(state, `count() counts a list, but ${label} is ${describeValue(first)}${hint}`);
+  }
+  if (node.name === "days_until") return daysUntil(state, first, label);
+  if (node.name === "difference") {
+    const second = evaluate(state, node.args[1] as ExprNode);
+    if (second === EVAL_FAILED) return EVAL_FAILED;
+    if (second === undefined) return undefined;
+    const left = asNumber(state, first, label);
+    if (left === EVAL_FAILED) return EVAL_FAILED;
+    const right = asNumber(state, second, printExpr(node.args[1] as ExprNode));
+    return right === EVAL_FAILED ? EVAL_FAILED : left - right;
+  }
+  const numbers = numbersOf(state, first, node.name, label);
+  if (numbers === EVAL_FAILED) return EVAL_FAILED;
+  return reduceNumbers(state, numbers, node.name, label);
+};
+
+function evaluate(state: EvalState, node: ExprNode): unknown | EvalFailed {
+  if (node.kind === "number") return node.value;
+  if (node.kind === "string") return node.value;
+  if (node.kind === "path") return resolveSegments(state, node.segments);
+  if (node.kind === "call") return evaluateCall(state, node);
+  if (node.kind === "negate") {
+    const operand = evaluate(state, node.operand);
+    if (operand === EVAL_FAILED) return EVAL_FAILED;
+    if (operand === undefined) return undefined;
+    const number = asNumber(state, operand, printExpr(node.operand));
+    return number === EVAL_FAILED ? EVAL_FAILED : -number;
+  }
+  const left = evaluate(state, node.left);
+  if (left === EVAL_FAILED) return EVAL_FAILED;
+  const right = evaluate(state, node.right);
+  if (right === EVAL_FAILED) return EVAL_FAILED;
+  // Either side still loading means the whole value is still loading.
+  if (left === undefined || right === undefined) return undefined;
+  const a = asNumber(state, left, printExpr(node.left));
+  if (a === EVAL_FAILED) return EVAL_FAILED;
+  const b = asNumber(state, right, printExpr(node.right));
+  if (b === EVAL_FAILED) return EVAL_FAILED;
+  if (node.op === "+") return a + b;
+  if (node.op === "-") return a - b;
+  if (node.op === "*") return a * b;
+  if (b === 0) {
+    return failEval(state, `${printExpr(node.right)} is zero, and dividing by zero has no value`);
+  }
+  return a / b;
+}
+
+/**
+ * Evaluate one expression against the renderer's resolved query data (keyed by
+ * query name). Total: an evaluation problem yields the issue the renderer shows
+ * as its contained data-shape notice, never a throw. Pure — same source, same
+ * data, same answer.
+ */
+export function evaluateExpr(
+  source: string,
+  data: Record<string, Json>,
+  options: ExprEvalOptions = {},
+): ExprResult {
+  const parsed = parseExpr(source);
+  if (!parsed.ok) return { ok: false, issue: parsed.issue };
+  const state: EvalState = { data, now: options.now ?? Date.now(), issue: null };
+  const value = evaluate(state, parsed.node);
+  if (value === EVAL_FAILED) {
+    return { ok: false, issue: state.issue ?? "this expression could not be computed" };
+  }
+  return { ok: true, value: value as Json | undefined };
+}
+
+// ── the fact check ──────────────────────────────────────────────────────────
+
+export interface ExprCheckContext {
+  /** The declared query names; a path head naming none is a fact finding. */
+  queryNames: readonly string[];
+  /** The query's response shape, or undefined when nothing is known about it —
+   *  unknown regions stay silent, as in the binding shape check. */
+  shapeOf(queryName: string): ShapeType | undefined;
+}
+
+const UNKNOWN: ShapeType = { kind: "json" };
+
+type ShapeWalk =
+  | { ok: true; shape: ShapeType; container?: Record<string, ShapeType> }
+  | { ok: false; issue: string };
+
+const numericFields = (fields: Record<string, ShapeType>): string[] =>
+  Object.entries(fields).filter(([, field]) => field.kind === "number").map(([name]) => name);
+
+const walkShape = (
+  shape: ShapeType,
+  segments: readonly string[],
+  consumed: readonly string[],
+  container: Record<string, ShapeType> | undefined,
+): ShapeWalk => {
+  if (segments.length === 0) {
+    return container === undefined ? { ok: true, shape } : { ok: true, shape, container };
+  }
+  const [head, ...rest] = segments as [string, ...string[]];
+  const at = `"${consumed.join(".")}"`;
+  if (shape.kind === "json") return { ok: true, shape: UNKNOWN };
+  if (shape.kind === "object") {
+    const field = shape.fields[head];
+    if (field === undefined) {
+      return { ok: false, issue: `"${head}" is absent from ${at} — the real fields are: ${Object.keys(shape.fields).join(", ")}` };
+    }
+    return walkShape(field, rest, [...consumed, head], shape.fields);
+  }
+  if (shape.kind === "array") {
+    if (INDEX_PATTERN.test(head)) return walkShape(shape.items, rest, [...consumed, head], container);
+    // A field name against rows reads the column: the resolved shape is an
+    // array of the field's shape.
+    const inner = walkShape(shape.items, segments, consumed, container);
+    if (!inner.ok) return inner;
+    return inner.container === undefined
+      ? { ok: true, shape: { kind: "array", items: inner.shape } }
+      : { ok: true, shape: { kind: "array", items: inner.shape }, container: inner.container };
+  }
+  return { ok: false, issue: `"${head}" reads past the ${shape.kind} at ${at}` };
+};
+
+/** The item shape behind a column (`invoices.amount_cents` is `number[]`). */
+const columnItems = (shape: ShapeType): ShapeType => (shape.kind === "array" ? shape.items : shape);
+
+interface CheckState {
+  readonly context: ExprCheckContext;
+  readonly issues: string[];
+}
+
+/** The static shape of an expression node, recording every issue it finds.
+ *  `undefined` means "nothing known" — the defensive silence. */
+const shapeOfNode = (state: CheckState, node: ExprNode): ShapeType => {
+  if (node.kind === "number") return { kind: "number" };
+  if (node.kind === "string") return { kind: "string" };
+  if (node.kind === "path") return pathShape(state, node).shape;
+  if (node.kind === "negate") {
+    requireNumeric(state, node.operand, "arithmetic");
+    return { kind: "number" };
+  }
+  if (node.kind === "binary") {
+    requireNumeric(state, node.left, "arithmetic");
+    requireNumeric(state, node.right, "arithmetic");
+    return { kind: "number" };
+  }
+  return callShape(state, node);
+};
+
+const pathShape = (state: CheckState, node: ExprNode & { kind: "path" }): { shape: ShapeType; container?: Record<string, ShapeType> } => {
+  const head = node.segments[0] as string;
+  if (!state.context.queryNames.includes(head)) {
+    state.issues.push(`"${node.text}" does not name a declared query; the queries are: ${state.context.queryNames.join(", ")}`);
+    return { shape: UNKNOWN };
+  }
+  const shape = state.context.shapeOf(head);
+  if (shape === undefined) return { shape: UNKNOWN };
+  const walked = walkShape(shape, node.segments.slice(1), [head], undefined);
+  if (!walked.ok) {
+    state.issues.push(walked.issue);
+    return { shape: UNKNOWN };
+  }
+  return walked.container === undefined ? { shape: walked.shape } : { shape: walked.shape, container: walked.container };
+};
+
+const requireNumeric = (state: CheckState, node: ExprNode, call: string): void => {
+  if (node.kind === "path") {
+    const { shape, container } = pathShape(state, node);
+    const items = columnItems(shape);
+    if (items.kind === "json" || items.kind === "number") return;
+    if (call === "arithmetic" && shape.kind === "array") {
+      state.issues.push(`${node.text} is a list, not a single number — reduce it with sum(), count(), or average() first`);
+      return;
+    }
+    const hint = container === undefined || numericFields(container).length === 0
+      ? ""
+      : ` — the numeric fields are: ${numericFields(container).join(", ")}`;
+    state.issues.push(call === "arithmetic"
+      ? `${node.text} is a ${items.kind} field, not a number — arithmetic needs numbers${hint}`
+      : `${call}() needs numeric values, but ${node.text} is a ${items.kind} field${hint}`);
+    return;
+  }
+  const shape = shapeOfNode(state, node);
+  const items = columnItems(shape);
+  if (items.kind === "json" || items.kind === "number") return;
+  if (call === "arithmetic" && shape.kind === "array") {
+    state.issues.push(`${printExpr(node)} is a list, not a single number — reduce it with sum(), count(), or average() first`);
+    return;
+  }
+  state.issues.push(call === "arithmetic"
+    ? `${printExpr(node)} is ${items.kind}, not a number — arithmetic needs numbers`
+    : `${call}() needs numeric values, but ${printExpr(node)} is ${items.kind}`);
+};
+
+const callShape = (state: CheckState, node: ExprNode & { kind: "call" }): ShapeType => {
+  const first = node.args[0] as ExprNode;
+  if (node.name === "group_by") {
+    const key = node.args[0] as ExprNode & { kind: "path" };
+    const keyShape = columnItems(pathShape(state, key).shape);
+    if (keyShape.kind !== "json" && keyShape.kind !== "string") {
+      state.issues.push(`group_by() buckets by date, but ${key.text} is a ${keyShape.kind} field — group by an ISO date field`);
+    }
+    callShape(state, node.args[2] as ExprNode & { kind: "call" });
+    return { kind: "array", items: { kind: "object", fields: { key: { kind: "string" }, value: { kind: "number" } } } };
+  }
+  if (node.name === "count") {
+    const shape = shapeOfNode(state, first);
+    if (shape.kind !== "json" && shape.kind !== "array") {
+      state.issues.push(`count() counts a list, but ${printExpr(first)} is ${shape.kind === "object" ? "an object" : `a ${shape.kind}`}`);
+    }
+    return { kind: "number" };
+  }
+  if (node.name === "days_until") {
+    const shape = columnItems(shapeOfNode(state, first));
+    if (shape.kind !== "json" && shape.kind !== "string") {
+      state.issues.push(`days_until() reads an ISO date string, but ${printExpr(first)} is a ${shape.kind} field`);
+    }
+    return { kind: "number" };
+  }
+  requireNumeric(state, first, node.name);
+  if (node.name === "difference") requireNumeric(state, node.args[1] as ExprNode, node.name);
+  return { kind: "number" };
+};
+
+/**
+ * The FACT check behind an `$expr`: it parses, every field path reaches a field
+ * the tool shapes really expose, and every slot's type can actually compute.
+ * Returns one sentence per finding — teaching messages that name the real
+ * fields, since the model reading them has to pick the right one.
+ */
+export function checkExpr(source: string, context: ExprCheckContext): string[] {
+  const parsed = parseExpr(source);
+  if (!parsed.ok) return [parsed.issue];
+  const state: CheckState = { context, issues: [] };
+  shapeOfNode(state, parsed.node);
+  return state.issues;
+}

--- a/packages/core/src/genui/wire/expression.test.ts
+++ b/packages/core/src/genui/wire/expression.test.ts
@@ -362,3 +362,44 @@ describe("numeric path segments", () => {
     expect(result.value).toEqual({ $path: "/accounts/data/0/sparkline" });
   });
 });
+
+describe("computed values ($expr)", () => {
+  it("compiles an attribute carrying an operator or a known call to { $expr }", () => {
+    expectValue("sum(revenue.amount_cents) / count(payments)", {
+      $expr: "sum(revenue.amount_cents) / count(payments)",
+    });
+    expectValue("count(payments)", { $expr: "count(payments)" });
+    expectValue("revenue.total / 100", { $expr: "revenue.total / 100" });
+    expectValue("(revenue.total - 500) * 2", { $expr: "(revenue.total - 500) * 2" });
+    expectValue("days_until(revenue.due)", { $expr: "days_until(revenue.due)" });
+    expectValue('group_by(payments.paid_at, "month", sum(payments.amount))', {
+      $expr: 'group_by(payments.paid_at, "month", sum(payments.amount))',
+    });
+    expectValue("-revenue.total + 1", { $expr: "-revenue.total + 1" });
+    // A bare subtraction is infix even with whitespace around the operator.
+    expectValue("revenue.total - 500", { $expr: "revenue.total - 500" });
+    expectValue("sum(revenue.rows) - 1", { $expr: "sum(revenue.rows) - 1" });
+    expectValue("difference(revenue.total, payments.total)", {
+      $expr: "difference(revenue.total, payments.total)",
+    });
+  });
+
+  it("leaves every non-computed value on the binding/literal grammar", () => {
+    // The tell: no infix operator and no expression call.
+    expectValue("revenue.total", { $path: "/revenue/total" });
+    expectValue("state.note", { $state: "note" });
+    expectValue("revenue.rows | count()", { $path: "/revenue/rows", $reshape: [{ op: "count", args: [] }] });
+    expectValue("-2", -2);
+    expectValue("2.5E-2", 0.025);
+    expectValue('"a / b"', "a / b");
+    expectValue("[1, 2]", [1, 2]);
+    expectValue("{ limit: 5 }", { limit: 5 });
+    expectValue("{ note: 5 }", { note: 5 });
+  });
+
+  it("drops a computed value whose expression does not parse or names no query", () => {
+    expectDropped("sum(revenue.total) + * 2", "malformed-expression");
+    expectDropped("total(revenue.total) + 1", "malformed-expression");
+    expectDropped("sum(ghost.total) / count(payments)", "unknown-reference");
+  });
+});

--- a/packages/core/src/genui/wire/expression.ts
+++ b/packages/core/src/genui/wire/expression.ts
@@ -16,6 +16,7 @@
 import { safeErrorMessage } from "../../errors.js";
 import type { Json } from "../../ids.js";
 import { findInvalidReshapeSteps, type ReshapeStep } from "../../reshape.js";
+import { EXPR_CALLS, exprPathHeads, parseExpr, type ExprBinding } from "../expr.js";
 import { defineOwn, isPathBinding, isStateBinding, type PathBinding, type StateBinding } from "../tree-node.js";
 import { isWellFormedUtf16 } from "./state.js";
 
@@ -485,7 +486,90 @@ const parseValue = (state: ParserState): Json | Failed => {
   return malformed(state, `unexpected character "${char}" at index ${state.index}`);
 };
 
+const EXPR_CALL_NAMES: ReadonlySet<string> = new Set(EXPR_CALLS);
+
+/**
+ * The brace-expression tell (genui/expr.ts): one attribute value grammar
+ * decides between a BINDING and a COMPUTED value. `{...}` is computed when it
+ * carries an infix arithmetic operator or calls one of the expression
+ * functions — `{sum(invoices.amount_cents) / count(clients)}` — and is the
+ * JSON5-lite literal/`$path` grammar otherwise. Two things are decisive the
+ * other way: a `|` reshape pipe (`{accounts.rows | count()}` is a binding with
+ * a reshape chain) and a `[`/`{` literal, which no computation contains.
+ */
+const looksComputed = (source: string): boolean => {
+  let computed = false;
+  /** Whether the cursor follows a complete value — the infix/prefix tell for
+   *  `-` (a leading `-` is a negative literal, not an operator). */
+  let sawValue = false;
+  let index = 0;
+  while (index < source.length) {
+    const char = source[index] as string;
+    if (char === "|" || char === "[" || char === "{") return false;
+    if (char === '"' || char === "'") {
+      const end = source.indexOf(char, index + 1);
+      if (end === -1) return computed;
+      index = end + 1;
+      sawValue = true;
+      continue;
+    }
+    if (IDENTIFIER_START.test(char)) {
+      let end = index + 1;
+      while (end < source.length && (IDENTIFIER_CHAR.test(source[end] as string) || source[end] === ".")) end += 1;
+      if (EXPR_CALL_NAMES.has(source.slice(index, end)) && source[end] === "(") computed = true;
+      index = end;
+      sawValue = true;
+      continue;
+    }
+    if (DIGIT.test(char) || (char === "-" && !sawValue)) {
+      NUMBER_PATTERN.lastIndex = index;
+      if (NUMBER_PATTERN.exec(source) !== null) {
+        index = NUMBER_PATTERN.lastIndex;
+        sawValue = true;
+        continue;
+      }
+    }
+    if (char === "+" || char === "*" || char === "/" || (char === "-" && sawValue)) {
+      computed = true;
+      index += 1;
+      continue;
+    }
+    if (WHITESPACE.test(char)) {
+      index += 1;
+      continue;
+    }
+    // ")" closes a value; "(" and "," open a fresh one.
+    sawValue = char === ")";
+    index += 1;
+  }
+  return computed;
+};
+
+/** A computed attribute value compiles to `{ $expr }` with its source kept
+ *  verbatim; evaluation happens at bind resolution in the renderer, never
+ *  here. Unknown heads drop the attribute like any other unknown reference. */
+const parseComputed = (source: string, context: ExpressionContext): ExpressionResult => {
+  const expr = source.trim();
+  const parsed = parseExpr(expr);
+  if (!parsed.ok) {
+    return { dropped: true, issues: [{ code: "malformed-expression", message: parsed.issue }] };
+  }
+  const unknown = exprPathHeads(parsed.node).filter((head) => !context.queryNames.has(head));
+  if (unknown.length > 0) {
+    return {
+      dropped: true,
+      issues: unknown.map((head) => ({
+        code: "unknown-reference" as const,
+        message: `"${head}" does not name a declared <Query>`,
+      })),
+    };
+  }
+  const binding: ExprBinding = { $expr: expr };
+  return { value: binding as unknown as Json, dropped: false, issues: [] };
+};
+
 const parseExpressionUnsafe = (source: string, context: ExpressionContext): ExpressionResult => {
+  if (looksComputed(source)) return parseComputed(source, context);
   const state: ParserState = { source, index: 0, issues: [], queryNames: context.queryNames };
   const value = parseValue(state);
   if (value === FAILED) {

--- a/packages/core/src/genui/wire/print.test.ts
+++ b/packages/core/src/genui/wire/print.test.ts
@@ -114,3 +114,26 @@ describe("printWire totality fallbacks", () => {
     expect(printed).toContain("broken={null}");
   });
 });
+
+describe("printWire computed values", () => {
+  it("round-trips a { $expr } prop as its own source", () => {
+    const wire = '<App><Query id="invoices" tool="invoices.list"/><Stat value={sum(invoices.amount_cents) / count(invoices)}/></App>';
+    const compiled = compileWire(wire);
+    expect(compiled.issues).toEqual([]);
+    expect(compiled.tree.nodes.find((node) => node.component === "Stat")?.props)
+      .toStrictEqual({ value: { $expr: "sum(invoices.amount_cents) / count(invoices)" } });
+    const printed = printWire(compiled, { includeIds: false });
+    expect(printed).toContain("value={sum(invoices.amount_cents) / count(invoices)}");
+    expect(compileWire(printed).tree).toStrictEqual(compiled.tree);
+  });
+
+  it("falls back to the object literal for an $expr source that no longer parses", () => {
+    const base = compileWire('<App><Query id="q" tool="t"/><Card v={q.rows}/></App>');
+    const tree = structuredClone(base.tree);
+    const card = tree.nodes.find((node) => node.id === "card-1");
+    (card as { props?: Record<string, unknown> }).props = { v: { $expr: "sum(" } };
+    const printed = printWire({ ...base, tree }, { includeIds: false });
+    expect(printed).toContain('"$expr"');
+    expect(compileWire(printed).tree).toStrictEqual(tree);
+  });
+});

--- a/packages/core/src/genui/wire/print.ts
+++ b/packages/core/src/genui/wire/print.ts
@@ -17,6 +17,7 @@
 import { TOOL_NAME_PATTERN } from "../../tools.js";
 import { findInvalidReshapeSteps, type ReshapeStep } from "../../reshape.js";
 import { FN_REFERENCE_PATTERN } from "../../fn-references.js";
+import { isExprBinding, parseExpr } from "../expr.js";
 import { isPathBinding, isPlainObject, isStateBinding, type TreeNode } from "../tree-node.js";
 import type { TreeQuery } from "../tree.js";
 import type { WireCompileResult } from "./compile.js";
@@ -77,6 +78,12 @@ const printExpression = (value: unknown, queryNames: ReadonlySet<string>): strin
   }
   if (isPlainObject(value)) {
     const record = value as Record<string, unknown>;
+    // A computed value prints back as its own source, the form the compiler's
+    // brace-expression tell reads as `$expr` again. A source that no longer
+    // parses falls through to the object literal (totality over fidelity).
+    if (isExprBinding(record) && Object.keys(record).length === 1 && parseExpr(record.$expr).ok) {
+      return record.$expr;
+    }
     const reference = isPathBinding(record) || isStateBinding(record)
       ? referenceForBinding(record, queryNames)
       : null;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,7 @@ export * from "./store.js";
 export * from "./stream-parts.js";
 export * from "./tool-envelopes.js";
 export * from "./tools.js";
+export * from "./genui/expr.js";
 export * from "./genui/tree-node.js";
 export * from "./genui/tree.js";
 export * from "./triggers.js";

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -4,6 +4,8 @@ import {
   TREE_MAX_GENERATED_COMPONENTS,
   TREE_MAX_TOTAL_COMPONENT_CHARS,
   applyReshape,
+  evaluateExpr,
+  isExprBinding,
   isPathBinding,
   isStateBinding,
   VENDO_TREE_FORMAT,
@@ -222,6 +224,17 @@ function bindValue(
 ): unknown {
   if (isPathBinding(value)) return resolveReshaped(resolvePointer(data, value.$path), value.$reshape, onMismatch);
   if (isStateBinding(value)) return resolveReshaped(state[value.$state] as Json | undefined, value.$reshape, onMismatch);
+  // A computed value is evaluated HERE, on every bind resolution, against the
+  // data this render holds — so it re-computes the moment the query data
+  // changes. Nothing about it is ever cached across renders.
+  if (isExprBinding(value)) {
+    const computed = evaluateExpr(value.$expr, data);
+    if (!computed.ok) {
+      onMismatch?.(computed.issue);
+      return undefined;
+    }
+    return computed.value;
+  }
   if (isActionBinding(value)) {
     const payload = bindValue(value.payload, mode, data, state, action, onMismatch) as Json;
     if (mode === "jail") {

--- a/packages/ui/test/tree/expr-binding.test.tsx
+++ b/packages/ui/test/tree/expr-binding.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { VENDO_TREE_FORMAT, type Json, type ToolOutcome } from "@vendoai/core";
+import { TreeView, type WalkTree } from "../../src/tree/index.js";
+
+afterEach(cleanup);
+
+const ok = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
+
+const tree = (nodes: WalkTree["nodes"]): WalkTree =>
+  ({ formatVersion: VENDO_TREE_FORMAT, root: "root", nodes } as WalkTree);
+
+/** One computed headline: average invoice value in cents. */
+const nodes: WalkTree["nodes"] = [
+  { id: "root", component: "Stack", children: ["headline"] },
+  {
+    id: "headline",
+    component: "Text",
+    props: { text: { $expr: "sum(invoices.amount_cents) / count(invoices)" } },
+  },
+];
+
+const dataWith = (...cents: number[]): Record<string, Json> => ({
+  invoices: cents.map((amount_cents, index) => ({ id: `i${index}`, amount_cents })),
+});
+
+describe("$expr bindings in the renderer", () => {
+  it("re-evaluates the same $expr binding when the query data changes", () => {
+    const view = render(
+      <TreeView tree={tree(nodes)} components={{}} data={dataWith(1000, 3000)} onAction={ok} />,
+    );
+    expect(screen.getByText("2000")).toBeTruthy();
+
+    // The tree is byte-identical; ONLY the data moved. A value computed once
+    // and frozen (memoised on the tree, or resolved at generation time) would
+    // still read 2000 here — that is what this assertion exists to catch.
+    view.rerender(
+      <TreeView tree={tree(nodes)} components={{}} data={dataWith(1000, 3000, 8000)} onAction={ok} />,
+    );
+    expect(screen.queryByText("2000")).toBeNull();
+    expect(screen.getByText("4000")).toBeTruthy();
+
+    view.rerender(<TreeView tree={tree(nodes)} components={{}} data={dataWith(500)} onAction={ok} />);
+    expect(screen.getByText("500")).toBeTruthy();
+  });
+
+  it("holds the value empty while the data is still loading", () => {
+    render(<TreeView tree={tree(nodes)} components={{}} data={{}} onAction={ok} />);
+
+    expect(screen.queryByRole("note", { name: /data shape/i })).toBeNull();
+    expect(document.querySelector('[data-vendo-node-id="headline"]')?.textContent).toBe("");
+  });
+
+  it("shows the contained data-shape notice when the expression cannot compute", () => {
+    const mismatched: WalkTree["nodes"] = [
+      { id: "root", component: "Stack", children: ["headline"] },
+      { id: "headline", component: "Text", props: { text: { $expr: "sum(invoices.client_name)" } } },
+    ];
+
+    render(
+      <TreeView
+        tree={tree(mismatched)}
+        components={{}}
+        data={{ invoices: [{ client_name: "Acme" }] }}
+        onAction={ok}
+      />,
+    );
+
+    const notice = screen.getByRole("note", { name: /data shape/i });
+    expect(notice.textContent).toContain("numeric");
+    expect(notice.textContent).toContain("Acme");
+  });
+});


### PR DESCRIPTION
Task 9 of the generation pipeline rebuild. A binding value may now be **computed**:

```
<Stat value={sum(invoices.amount_cents) / count(clients)}/>
  →  { $expr: "sum(invoices.amount_cents) / count(clients)" }
```

The expression is evaluated at bind resolution **in the renderer** — the same place `$path` resolves — so it re-computes whenever the query data changes. Nothing is computed at generation time: a total frozen into the document the moment a model wrote it would be a lie by the next refresh.

## What landed

- **`packages/core/src/genui/expr.ts`** — tokenizer + recursive-descent parser + evaluator. Grammar: field paths, numbers, `+ - * / ( )`, and the closed call list `sum count average min max difference days_until group_by`. Total and deterministic: any evaluation problem yields `undefined` plus a described issue, never a throw (depth-bounded, so no input can reach the call-stack limit). A field name against a list of rows reads the *column*, which is what the aggregates consume. `days_until` reads ISO date strings; `group_by(field, "month", sum(other))` returns `[{key, value}]` for chart bucketing; division by zero is `undefined` + an issue.
- **Loading is not a mismatch** — a query whose data has not arrived resolves to `undefined` and flows through arithmetic as `undefined` (the `$reshape` discipline), so a computed headline shows empty while loading instead of a notice.
- **The compiler seam** — one brace-expression grammar, one tell (see below).
- **The printer** — a computed value prints back as its own source, so the edit dialect round-trips it byte-identically.
- **The renderer** — `$expr` resolves in `bindValue`, beside `$path`/`$state`, on every render. No new subscription, no memo: the existing data prop is the liveness path.
- **The fact check** — `checkExpr` in core + the new built-in `expressions-compute` check in `packages/apps/src/checking/facts.ts` (and the create/edit validator, which flattens the same anchored issues). Parse errors, fields the tool shapes do not carry, and types that cannot compute are `block` findings whose messages name the real fields:
  - `computes {sum(invoices.data.amountCent)}: "amountCent" is absent from "invoices.data" — the real fields are: id, client, amountCents`
  - `computes {sum(invoices.data.client) / count(invoices.data)}: sum() needs numeric values, but invoices.data.client is a string field — the numeric fields are: amountCents`

## The tell: `$expr` vs `$path`

The brace-expression grammar is shared, so one scan over the attribute's inner text decides:

- contains an **infix** arithmetic operator (`+ * /`, or `-` following a complete value) **or** calls one of the eight expression functions → `$expr`
- a `|` reshape pipe (`{accounts.rows | count()}`) or a `[`/`{` literal is decisive the other way → binding/literal grammar
- everything else → `$path` / `$state` / literal, exactly as before

Number literals are consumed whole, so `{2.5E-2}` stays the number `0.025` rather than reading `E-2` as subtraction; a leading `-` is a negative literal, not an operator.

## Tests

Core (`packages/core/src/genui/expr.test.ts`, 100% line coverage of the new module):
- `arithmetic over aggregates evaluates against sample rows`
- `parse error reported as a sentence with the bad token`
- `unknown field reported naming the real fields`
- `sum over a string field reported as a type mismatch`
- `days_until on a date field`
- `group_by monthly bucketing`
- `division by zero safe`
- plus: loading is never a problem, columns out of nested rows, group_by argument-kind errors, totality on pathological input, and the `checkExpr` mirror of each finding.

Compiler/printer: `computed values ($expr)` in `wire/expression.test.ts` (the tell, in both directions) and `printWire computed values` (round-trip + the unparseable-source fallback).

Renderer (`packages/ui/test/tree/expr-binding.test.tsx`):
- **`re-evaluates the same $expr binding when the query data changes`** — the tree is byte-identical across rerenders and only the data moves; a value computed once and frozen would still read the old number, which is exactly what the assertion catches.
- holds empty while loading; shows the contained data-shape notice when the expression cannot compute.

## Gate

`@vendoai/core` build+test+typecheck ✅ (754 tests) · `@vendoai/ui` build+test+typecheck ✅ (651 tests) · `@vendoai/apps` test ✅ (802 tests) · repo `pnpm build`, `pnpm typecheck`, `pnpm lint` ✅.

Pre-existing on this branch, not touched here: the `@vendoai/core` coverage floor is already under its 97% threshold (95.98% at the branch head; this change raises it to 96.35%), and `apps/demo-accounting`'s Supabase login e2e fails against the local GoTrue seed. The full-suite parallel run also flakes packages that pass individually.

No UI surface changed (a computed value renders through the components that already existed), so there are no screenshots to attach; the end-to-end computed-and-live proof is Task 10's one-prompt run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds live computed bindings with `$expr` so props can do math and aggregations that re-evaluate on every render as data changes. Includes compiler/printer support and a fact check to catch invalid expressions before shipping.

- **New Features**
  - Computed bindings: `{ $expr: "sum(invoices.amount_cents) / count(clients)" }`, evaluated in the renderer via `evaluateExpr`; re-computes on data updates and shows empty while loading.
  - Core (`@vendoai/core`): new `expr.ts` with tokenizer, recursive-descent parser, and evaluator supporting paths, numbers, `+ - * / ( )`, and calls: `sum`, `count`, `average`, `min`, `max`, `difference`, `days_until`, `group_by`. Total and deterministic; errors yield an issue, not a throw.
  - Compiler/printer: brace-expression tell compiles infix/call forms to `{ $expr }`; `|` pipes and `{[` literals stay on binding/literal grammar. Printer round-trips `$expr` back to its source; unknown query heads are dropped at compile time.
  - Validation (`@vendoai/apps`): `checkExpr` + `expressions-compute` fact check flag parse errors, unknown fields, and type mismatches (e.g., `sum()` over strings). Wired into create/edit validation.
  - UI (`@vendoai/ui`): renderer resolves `$expr` in `bindValue` alongside `$path`/`$state`; no extra subscriptions or memoization.
  - Tests: added end-to-end and unit tests for parsing, evaluation, compiler tell, printer round-trip, and renderer re-evaluation.

<sup>Written for commit d1d60da5b2e917157ebfc16ce1a93a9d3bd81e0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

