### PR TITLE
fix(demo-creator): the smoke gate tells a broken demo from a slow one

### DIFF
--- a/bench/src/demo-capture/capture.test.ts
+++ b/bench/src/demo-capture/capture.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Page } from "@playwright/test";
-import { demoBeatPlan, waitForTurn } from "./capture.js";
+import { demoBeatPlan, VendoTurnError, VendoTurnTimeout, waitForTurn } from "./capture.js";
 
 describe("demoBeatPlan", () => {
   it("sequences the config beats into one continuous overlay story", () => {
@@ -131,5 +131,34 @@ describe("waitForTurn", () => {
       requireView: false,
     });
     expect(approvals).toBe(0);
+  });
+
+  // A caller has to be able to tell "this turn errored" from "this turn ran out
+  // of clock" WITHOUT parsing prose. The demo pipeline's smoke gate decides
+  // whether a generated demo is broken or merely slow on exactly that
+  // difference, and it used to have nothing but the message text to go on.
+  it("throws a distinguishable error when the turn surfaces one", async () => {
+    const page = fakePage([{ composerEnabled: true, errorText: "Something went wrong and the response didn’t finish." }]);
+    const thrown = await waitForTurn({ page, previousAssistantTurns: 0, timeoutMs: 5_000, requireView: false })
+      .catch((error: unknown) => error);
+    expect(thrown).toBeInstanceOf(VendoTurnError);
+    expect(thrown).not.toBeInstanceOf(VendoTurnTimeout);
+    expect((thrown as VendoTurnError).surfaced).toBe("Something went wrong and the response didn’t finish.");
+  });
+
+  it("throws a distinguishable error when it runs out of clock", async () => {
+    const page = fakePage([{ composerEnabled: true }]);
+    const thrown = await waitForTurn({ page, previousAssistantTurns: 0, timeoutMs: 0, requireView: false })
+      .catch((error: unknown) => error);
+    expect(thrown).toBeInstanceOf(VendoTurnTimeout);
+    expect(thrown).not.toBeInstanceOf(VendoTurnError);
+  });
+
+  // Both stay plain Errors to every existing caller.
+  it("keeps both failures readable as ordinary errors", async () => {
+    const timedOut = await waitForTurn({ page: fakePage([{ composerEnabled: true }]), previousAssistantTurns: 0, timeoutMs: 0, requireView: false })
+      .catch((error: unknown) => error as Error);
+    expect(timedOut).toBeInstanceOf(Error);
+    expect(timedOut.message).toMatch(/Timed out after 0ms waiting for the generated Vendo turn/);
   });
 });

--- a/bench/src/demo-capture/capture.ts
+++ b/bench/src/demo-capture/capture.ts
@@ -155,6 +155,28 @@ async function demoCapsRefusal(page: Page): Promise<{ limit: string } | null> {
   }).catch(() => null);
 }
 
+/**
+ * The turn surfaced a visible error. Its own class, because a caller has to be
+ * able to tell this from {@link VendoTurnTimeout} without parsing prose: the demo
+ * pipeline's smoke gate decides whether a generated demo is BROKEN or merely SLOW
+ * on exactly that difference, and message-matching is not a contract.
+ */
+export class VendoTurnError extends Error {
+  constructor(readonly surfaced: string) {
+    super(`Vendo capture surfaced an error: ${surfaced}`);
+    this.name = "VendoTurnError";
+  }
+}
+
+/** The turn never settled inside its budget. Says nothing about whether the
+ *  agent works — see the smoke gate's classifier for that judgement. */
+export class VendoTurnTimeout extends Error {
+  constructor(readonly timeoutMs: number) {
+    super(`Timed out after ${timeoutMs}ms waiting for the generated Vendo turn`);
+    this.name = "VendoTurnTimeout";
+  }
+}
+
 /** Exported for the unit test of the approval-settle sequence. */
 export async function waitForTurn(options: {
   page: Page;
@@ -191,7 +213,7 @@ export async function waitForTurn(options: {
       if (refusal !== null) {
         throw new Error(`demo caps exhausted (${refusal.limit}) — the capture burned the demo's own turns; a capture-side condition, not a demo failure`);
       }
-      throw new Error(`Vendo capture surfaced an error: ${(await alert.textContent())?.trim() ?? "unknown error"}`);
+      throw new VendoTurnError((await alert.textContent())?.trim() ?? "unknown error");
     }
     const textarea = options.page.locator('form[aria-label="Message composer"]')
       .getByRole("textbox", { name: "Message" });
@@ -232,7 +254,7 @@ export async function waitForTurn(options: {
     }
     await options.page.waitForTimeout(300);
   }
-  throw new Error(`Timed out after ${options.timeoutMs}ms waiting for the generated Vendo turn`);
+  throw new VendoTurnTimeout(options.timeoutMs);
 }
 
 async function captureHost(options: {

--- a/bench/src/demo-creator/assemble.test.ts
+++ b/bench/src/demo-creator/assemble.test.ts
@@ -2,9 +2,23 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { runAssemble, type AssembleIo } from "./assemble.js";
+import { runAssemble, SmokeBrokenError, SmokeTimeoutError, type AssembleIo } from "./assemble.js";
 import type { ExecFn, ExecResult } from "./exec.js";
 import type { RunningHost, SmokeTurnFn } from "./host-boot.js";
+import { classifySmoke, noProgress, smokeBudgetMs, type SmokeProgress } from "./smoke.js";
+
+/** The shape of every healthy turn: the door answered, the model streamed. */
+const alive: SmokeProgress = { doorAnswered: true, turnStarted: true, toolCall: true };
+
+/** Smoke turns expressed the way the real one reports: an outcome, not a throw. */
+const settles: SmokeTurnFn = async () => classifySmoke({ settled: true, timedOut: false, progress: alive });
+const timesOutAlive: SmokeTurnFn = async () => classifySmoke({ settled: false, timedOut: true, progress: alive });
+const deadAgent: SmokeTurnFn = async () => classifySmoke({ settled: false, timedOut: true, progress: noProgress() });
+const doorErrors: SmokeTurnFn = async () => classifySmoke({
+  settled: false,
+  timedOut: false,
+  progress: { ...noProgress(), doorAnswered: true, doorError: "POST /api/vendo/acme → 500" },
+});
 
 const manifestPath = (demosRepo: string): string =>
   path.join(demosRepo, "host", "src", "generated", "manifest.ts");
@@ -45,7 +59,7 @@ function io(demosRepo: string, overrides: Partial<AssembleIo> = {}): AssembleIo 
     write: () => undefined,
     exec: fakeExec().exec,
     boot: async () => fakeHost().host,
-    smokeTurn: async () => undefined,
+    smokeTurn: settles,
     ...overrides,
   };
 }
@@ -94,12 +108,15 @@ describe("runAssemble", () => {
     expect(boot).not.toHaveBeenCalled();
   });
 
-  it("stops the host and rethrows when the smoke turn errors", async () => {
+  it("stops the host and fails when the smoke turn errors", async () => {
     const demosRepo = await fakeDemosRepo({ slugs: ["acme"], installed: true });
     const { host, stop } = fakeHost();
-    const smokeTurn: SmokeTurnFn = async () => {
-      throw new Error("Vendo capture surfaced an error: model overloaded");
-    };
+    const smokeTurn: SmokeTurnFn = async () => classifySmoke({
+      settled: false,
+      timedOut: false,
+      surfacedError: "model overloaded",
+      progress: alive,
+    });
     await expect(runAssemble(args, io(demosRepo, { boot: async () => host, smokeTurn })))
       .rejects.toThrow(/model overloaded/);
     expect(stop).toHaveBeenCalledTimes(1);
@@ -113,24 +130,176 @@ describe("runAssemble", () => {
     const demosRepo = await fakeDemosRepo({ slugs: ["acme"], installed: true });
     const { host, stop } = fakeHost();
     // A turn that answered in prose: no view, no approval, nothing to inspect.
-    const result = await runAssemble(args, io(demosRepo, { boot: async () => host, smokeTurn: async () => undefined }));
+    const result = await runAssemble(args, io(demosRepo, { boot: async () => host, smokeTurn: settles }));
     expect(result.host).toBe(host);
     expect(stop).not.toHaveBeenCalled();
     await result.host.stop();
   });
 
-  it("cannot gate on content, because content never reaches it", async () => {
+  it("cannot gate on content, because only liveness reaches it", async () => {
     const demosRepo = await fakeDemosRepo({ slugs: ["acme"], installed: true });
     const { host } = fakeHost();
-    // Whatever the smoke turn "returns" is discarded by the SmokeTurnFn contract
-    // (Promise<void>), so no assemble code path can branch on it.
-    const smokeTurn = (async () => "a view was generated" as unknown as void) as SmokeTurnFn;
-    const result = await runAssemble(args, io(demosRepo, { boot: async () => host, smokeTurn }));
-    expect(result.smoke).toEqual({ prompt: args.smokePrompt, ms: expect.any(Number) });
-    expect(Object.keys(result)).toEqual(["slugs", "host", "smoke"]);
+    const result = await runAssemble(args, io(demosRepo, { boot: async () => host, smokeTurn: settles }));
+    // Everything the gate is told about the turn — no view, no text, no tool
+    // result. A gate that cannot see content cannot start judging it.
+    expect(Object.keys(result.smoke.progress).sort()).toEqual(["doorAnswered", "toolCall", "turnStarted"]);
+    expect(result.smoke).toEqual({
+      prompt: args.smokePrompt,
+      ms: expect.any(Number),
+      verdict: "settled",
+      attempts: 1,
+      progress: alive,
+    });
+    await result.host.stop();
+  });
+});
+
+/**
+ * The defect this replaces: ONE 180s wall-clock deadline decided both questions.
+ * Measured turn latencies were 104s, 129s (errored), 135s, 165s and ≥183s, so the
+ * deadline sat inside the distribution and two of six runs died on demos that
+ * were fine. These are the two halves of the fix, held apart.
+ */
+describe("runAssemble — the smoke gate tells BROKEN from SLOW", () => {
+  it("passes a healthy turn that took longer than the old 180s gate allowed", async () => {
+    const demosRepo = await fakeDemosRepo({ slugs: ["acme"], installed: true });
+    const { host, stop } = fakeHost();
+    let budget = 0;
+    // 250s: comfortably past the old deadline, comfortably inside the new budget.
+    const slowButHealthy: SmokeTurnFn = async (options) => {
+      budget = options.timeoutMs;
+      return classifySmoke({ settled: true, timedOut: false, progress: alive });
+    };
+    const result = await runAssemble(args, io(demosRepo, { boot: async () => host, smokeTurn: slowButHealthy }));
+    expect(budget).toBeGreaterThan(250_000);
+    expect(result.smoke.verdict).toBe("settled");
+    expect(stop).not.toHaveBeenCalled();
     await result.host.stop();
   });
 
+  it("hands the smoke turn the evidence-derived budget, not the old deadline", async () => {
+    const demosRepo = await fakeDemosRepo({ slugs: ["acme"], installed: true });
+    let budget = 0;
+    const smokeTurn: SmokeTurnFn = async (options) => {
+      budget = options.timeoutMs;
+      return classifySmoke({ settled: true, timedOut: false, progress: alive });
+    };
+    const result = await runAssemble(args, io(demosRepo, { smokeTurn }));
+    expect(budget).toBe(smokeBudgetMs);
+    expect(budget).not.toBe(180_000);
+    await result.host.stop();
+  });
+
+  it("fails a genuinely broken agent FAST, on the signal and not on the clock", async () => {
+    const demosRepo = await fakeDemosRepo({ slugs: ["acme"], installed: true });
+    const { host, stop } = fakeHost();
+    const started = Date.now();
+    const thrown = await runAssemble(args, io(demosRepo, { boot: async () => host, smokeTurn: doorErrors }))
+      .catch((error: unknown) => error as Error);
+    expect(thrown).toBeInstanceOf(SmokeBrokenError);
+    expect(thrown.message).toMatch(/agent route answered/);
+    // The door's 500 arrives in the first seconds; nothing waited out a budget.
+    expect(Date.now() - started).toBeLessThan(smokeBudgetMs);
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls an agent that never produced a turn broken, not slow", async () => {
+    const demosRepo = await fakeDemosRepo({ slugs: ["acme"], installed: true });
+    const thrown = await runAssemble(args, io(demosRepo, { smokeTurn: deadAgent }))
+      .catch((error: unknown) => error as Error);
+    expect(thrown).toBeInstanceOf(SmokeBrokenError);
+    expect(thrown).not.toBeInstanceOf(SmokeTimeoutError);
+    expect(thrown.message).toMatch(/never produced a turn/);
+  });
+
+  // Not a silent pass — it still fails the run. But it fails as its own thing, so
+  // the Slack thread reads "the smoke turn timed out" instead of implying that a
+  // demo which compiled, booted and streamed is broken.
+  it("reports a living-but-unfinished turn as a TIMEOUT, distinct from broken", async () => {
+    const demosRepo = await fakeDemosRepo({ slugs: ["acme"], installed: true });
+    const lines: string[] = [];
+    const thrown = await runAssemble(args, io(demosRepo, { smokeTurn: timesOutAlive, write: (line) => lines.push(line) }))
+      .catch((error: unknown) => error as Error);
+    expect(thrown).toBeInstanceOf(SmokeTimeoutError);
+    expect(thrown).not.toBeInstanceOf(SmokeBrokenError);
+    expect(thrown.message).toMatch(/timed out/i);
+    // Never the broken verdict's own wording — and it says outright what it is,
+    // so a human reading the thread cannot take it for a broken demo either.
+    expect(thrown.message).not.toMatch(/is BROKEN/);
+    expect(thrown.message).toMatch(/not a broken demo/);
+    // …and it says so on stdout too, where the Slack driver can read it.
+    expect(lines.some((line) => line.startsWith("SMOKE: TIMEOUT"))).toBe(true);
+  });
+
+  it("gives the two verdicts messages an operator cannot confuse", async () => {
+    const demosRepo = await fakeDemosRepo({ slugs: ["acme"], installed: true });
+    const timeout = await runAssemble(args, io(demosRepo, { smokeTurn: timesOutAlive })).catch((error: unknown) => error as Error);
+    const broken = await runAssemble(args, io(demosRepo, { smokeTurn: deadAgent })).catch((error: unknown) => error as Error);
+    expect(timeout.message).not.toBe(broken.message);
+    expect(broken.message).toMatch(/broken/i);
+  });
+});
+
+describe("runAssemble — the one bounded retry", () => {
+  // Run E died exactly here: "Something went wrong and the response didn't
+  // finish" at 129s, on a demo that was fine. An external inference failure is
+  // not the demo's bug, and it is the one outcome a second attempt can clear.
+  it("retries ONCE when the turn failed on something outside the demo", async () => {
+    const demosRepo = await fakeDemosRepo({ slugs: ["acme"], installed: true });
+    let attempts = 0;
+    const flaky: SmokeTurnFn = async () => {
+      attempts += 1;
+      return attempts === 1
+        ? classifySmoke({ settled: false, timedOut: false, surfacedError: "the response didn’t finish", progress: alive })
+        : classifySmoke({ settled: true, timedOut: false, progress: alive });
+    };
+    const result = await runAssemble(args, io(demosRepo, { smokeTurn: flaky }));
+    expect(attempts).toBe(2);
+    expect(result.smoke.verdict).toBe("settled");
+    expect(result.smoke.attempts).toBe(2);
+    await result.host.stop();
+  });
+
+  it("retries at most once — a reproducible error is a real bug, not a canary", async () => {
+    const demosRepo = await fakeDemosRepo({ slugs: ["acme"], installed: true });
+    let attempts = 0;
+    const alwaysErrors: SmokeTurnFn = async () => {
+      attempts += 1;
+      return classifySmoke({ settled: false, timedOut: false, surfacedError: "tools file unreadable", progress: alive });
+    };
+    await expect(runAssemble(args, io(demosRepo, { smokeTurn: alwaysErrors }))).rejects.toThrow(SmokeBrokenError);
+    expect(attempts).toBe(2);
+  });
+
+  // A retry after a deadline costs another whole budget of wall clock inside a
+  // 40-minute cap and cannot change what the clock already proved.
+  it("never retries a deadline, whichever way it was classified", async () => {
+    const demosRepo = await fakeDemosRepo({ slugs: ["acme"], installed: true });
+    for (const smokeTurn of [timesOutAlive, deadAgent]) {
+      let attempts = 0;
+      const counted: SmokeTurnFn = async (options) => {
+        attempts += 1;
+        return await smokeTurn(options);
+      };
+      await expect(runAssemble(args, io(demosRepo, { smokeTurn: counted }))).rejects.toThrow();
+      expect(attempts).toBe(1);
+    }
+  });
+
+  it("never retries a turn that settled", async () => {
+    const demosRepo = await fakeDemosRepo({ slugs: ["acme"], installed: true });
+    let attempts = 0;
+    const counted: SmokeTurnFn = async () => {
+      attempts += 1;
+      return classifySmoke({ settled: true, timedOut: false, progress: alive });
+    };
+    const result = await runAssemble(args, io(demosRepo, { smokeTurn: counted }));
+    expect(attempts).toBe(1);
+    await result.host.stop();
+  });
+});
+
+describe("runAssemble — what it hands back", () => {
   it("returns the still-running host and the smoke prompt it drove", async () => {
     const demosRepo = await fakeDemosRepo({ slugs: ["acme", "globex"], installed: true });
     const { host, stop } = fakeHost();
@@ -139,6 +308,7 @@ describe("runAssemble", () => {
       boot: async () => host,
       smokeTurn: async (options) => {
         smoked.push({ baseUrl: options.baseUrl, slug: options.slug, prompt: options.prompt });
+        return classifySmoke({ settled: true, timedOut: false, progress: alive });
       },
     }));
     expect(result.slugs).toEqual(["acme", "globex"]);

--- a/bench/src/demo-creator/assemble.ts
+++ b/bench/src/demo-creator/assemble.ts
@@ -13,12 +13,19 @@ import {
   type RunningHost,
   type SmokeTurnFn,
 } from "./host-boot.js";
+import { smokeBudgetMs, type SmokeOutcome, type SmokeProgress, type SmokeVerdict } from "./smoke.js";
 
 /**
  * Stage 4 — assemble. The gate that keeps a broken demo off demos.vendo.run:
  * the host must discover the new demo, compile it, boot, and survive ONE real
  * agent turn. The turn's CONTENT is not judged here (that is stage 5) — only
- * hard failure: the turn errored, or never settled.
+ * hard failure.
+ *
+ * "Hard failure" is the whole subtlety, and it used to be one 180s deadline. See
+ * smoke.ts for the measured latencies that made that a coin flip; this stage now
+ * asks the two questions separately — is the agent BROKEN (fail on the signal, in
+ * seconds), or merely SLOW (let it finish inside a budget healthy turns cannot
+ * reach) — and reports the two outcomes as different things.
  */
 
 export interface AssembleArgs {
@@ -45,14 +52,44 @@ export interface AssembleResult {
   /** The booted host, still running — the CALLER stops it (the judge screenshots
    *  the same boot; a second boot would cost minutes of the 20-minute budget). */
   host: RunningHost;
-  smoke: { prompt: string; ms: number };
+  smoke: {
+    prompt: string;
+    ms: number;
+    verdict: SmokeVerdict;
+    /** Liveness only — never content. See {@link SmokeProgress}. */
+    progress: SmokeProgress;
+    /** 1, or 2 when the first attempt failed on a signal from outside the demo. */
+    attempts: number;
+  };
 }
 
-/** A cold `pnpm install` + `next build` runs for minutes, and one smoke turn is
- * a real model round trip. Generous but bounded: a hang has to surface as a
- * failure, not eat the whole pipeline budget. */
+/**
+ * The generated demo's agent does not work. This is what the gate exists to
+ * catch, and it is the verdict that means "do not ship this".
+ */
+export class SmokeBrokenError extends Error {
+  constructor(reason: string, readonly progress: SmokeProgress) {
+    super(`the generated demo's agent is BROKEN — ${reason}`);
+    this.name = "SmokeBrokenError";
+  }
+}
+
+/**
+ * The agent was demonstrably running and still did not finish inside a budget no
+ * measured healthy turn comes near. Its own class, and its own prose, so nothing
+ * downstream reports a demo that compiled, booted and streamed as broken — a turn
+ * this slow is not demoable, but it is not the same finding.
+ */
+export class SmokeTimeoutError extends Error {
+  constructor(ms: number, reason: string, readonly progress: SmokeProgress) {
+    super(`the smoke turn TIMED OUT after ${ms}ms — ${reason}`);
+    this.name = "SmokeTimeoutError";
+  }
+}
+
+/** A cold `pnpm install` + `next build` runs for minutes. Generous but bounded:
+ * a hang has to surface as a failure, not eat the whole pipeline budget. */
 const bootTimeoutMs = 180_000;
-const smokeTimeoutMs = 180_000;
 
 export async function runAssemble(args: AssembleArgs, io: AssembleIo): Promise<AssembleResult> {
   const exec = io.exec ?? defaultExec;
@@ -114,19 +151,50 @@ export async function runAssemble(args: AssembleArgs, io: AssembleIo): Promise<A
   }));
 
   const startedAt = Date.now();
+  const attempt = async (): Promise<SmokeOutcome> => await runStage("assemble:smoke", async () => await smokeTurn({
+    baseUrl: running.baseUrl,
+    slug: args.slug,
+    prompt: args.smokePrompt,
+    timeoutMs: smokeBudgetMs,
+  }));
+
+  let outcome: SmokeOutcome;
+  let attempts = 1;
   try {
-    await runStage("assemble:smoke", async () => await smokeTurn({
-      baseUrl: running.baseUrl,
-      slug: args.slug,
-      prompt: args.smokePrompt,
-      timeoutMs: smokeTimeoutMs,
-    }));
+    outcome = await attempt();
+    // ONE retry, and only for an outcome a signal produced rather than the clock.
+    // Run E lost a fine demo to "the response didn't finish" at 129s — an
+    // external inference failure, which is not this demo's bug. Bounded at one:
+    // an error that reproduces is a real bug, and these outcomes arrive in
+    // seconds, so the retry costs seconds of wall clock and one turn against the
+    // demo's own 20-turn cap. A DEADLINE is never retried: that would cost
+    // another whole budget inside a 40-minute cap and re-prove nothing.
+    if (outcome.verdict !== "settled" && outcome.retryable) {
+      write(`[assemble] the smoke turn failed on something that can come from outside the demo (${outcome.reason ?? outcome.verdict}) — retrying ONCE`);
+      attempts = 2;
+      outcome = await attempt();
+    }
   } catch (error) {
     // One dev server, no orphans: the host only survives a SUCCESSFUL smoke.
     await running.stop();
     throw error;
   }
   const ms = Date.now() - startedAt;
+
+  if (outcome.verdict !== "settled") {
+    // Loud and machine-readable before the throw, so the line survives even if a
+    // caller only ever logs the failure's first sentence.
+    write(`SMOKE: ${outcome.verdict.toUpperCase()} after ${ms}ms on ${attempts} attempt(s) — ${outcome.reason ?? "no reason recorded"}`);
+    await running.stop();
+    throw outcome.verdict === "timeout"
+      ? new SmokeTimeoutError(ms, outcome.reason ?? "no reason recorded", outcome.progress)
+      : new SmokeBrokenError(outcome.reason ?? "no reason recorded", outcome.progress);
+  }
+
   write(`[assemble] smoke turn settled in ${ms}ms — host still running at ${running.baseUrl} (caller owns stop())`);
-  return { slugs, host: running, smoke: { prompt: args.smokePrompt, ms } };
+  return {
+    slugs,
+    host: running,
+    smoke: { prompt: args.smokePrompt, ms, verdict: outcome.verdict, progress: outcome.progress, attempts },
+  };
 }

--- a/bench/src/demo-creator/fix.ts
+++ b/bench/src/demo-creator/fix.ts
@@ -7,7 +7,7 @@ import { demoPaths, parseDemoFolderConfig, parseDemoSlug } from "./demo-folder.j
 import { defaultDemosRepo, ensureDemosRepo } from "./demos-repo.js";
 import { createScrubber, defaultExec, type ExecFn } from "./exec.js";
 import { runJudge, type JudgeIo, type JudgeResult } from "./judge.js";
-import { assertOnlyDemoTouched, createStageRunner, createTimingsFile, localHostPort, snapshotHostBaseline, type StageTiming } from "./pipeline.js";
+import { assertOnlyDemoTouched, createStageRunner, createTimingsFile, localHostPort, quarantineFailedDemo, snapshotHostBaseline, type StageTiming } from "./pipeline.js";
 import { runShip, type ShipIo, type ShipResult } from "./ship.js";
 
 /**
@@ -243,6 +243,13 @@ export async function runDemoFix(args: DemoFixArgs, io: DemoFixIo = {}): Promise
       { demosRepo: args.demosRepo, write, env, exec, signal, runStage, finalizeTimings: timingsFile.finalize },
     ));
     return { slug: args.id, demoDir: paths.root, agent, timings, judge, scoresLine, ship: shipped, liveUrl: shipped.liveUrl };
+  } catch (error) {
+    // Same reason as the pipeline's: gen-manifest validates EVERY demo folder, so
+    // a failed fix's leftovers break the next run in this checkout. Here the demo
+    // is already committed, and git is what makes "clean" mean RESTORE rather
+    // than delete — a live demo's source is never this cleanup's to remove.
+    await quarantineFailedDemo({ demosRepo: args.demosRepo, slug: args.id, exec, write });
+    throw error;
   } finally {
     clearTimeout(capTimer);
     if (host !== undefined) await stopHost(host);

--- a/bench/src/demo-creator/host-boot.test.ts
+++ b/bench/src/demo-creator/host-boot.test.ts
@@ -63,10 +63,48 @@ describe("generateManifest", () => {
     });
   });
 
-  it("fails with the script's own first line when it exits non-zero", async () => {
+  it("fails with the script's own output when it exits non-zero", async () => {
     const demosRepo = await fakeDemosRepo(["acme"]);
     const { exec } = fakeExec([{ code: 1, stderr: "ENOENT demos/\nstack frame" }]);
     await expect(generateManifest({ demosRepo, exec })).rejects.toThrow(/gen-manifest failed[\s\S]*ENOENT demos\//);
+  });
+
+  /**
+   * The real script prints a HEADER and then the problems, one per line:
+   *
+   *   [gen-manifest] the demo folder contract is not honored:
+   *     demos/ramp-bills: missing tools.json
+   *
+   * Reporting only the first line therefore reported a failure with no reason at
+   * all — every actual cause is on a later line. It cost a diagnosis round on a
+   * live run, and in Slack it is a mystery failure.
+   */
+  it("relays the real cause, which the script prints AFTER its header line", async () => {
+    const demosRepo = await fakeDemosRepo(["acme"]);
+    const { exec } = fakeExec([{
+      code: 1,
+      stderr: "[gen-manifest] the demo folder contract is not honored:\n  demos/ramp-bills: missing tools.json\n  demos/zelty/theme.json is not legible",
+    }]);
+    const error = await generateManifest({ demosRepo, exec }).catch((thrown: unknown) => thrown as Error);
+    expect(error.message).toContain("missing tools.json");
+    expect(error.message).toContain("theme.json is not legible");
+  });
+
+  // Next-style failures split across the streams: the cause is on stdout while
+  // stderr holds only a warning, so picking one stream hides it.
+  it("relays both streams, because the cause is not reliably on either one", async () => {
+    const demosRepo = await fakeDemosRepo(["acme"]);
+    const { exec } = fakeExec([{ code: 1, stdout: "  demos/acme: missing openapi.json", stderr: "(node:1) ExperimentalWarning: type stripping" }]);
+    const error = await generateManifest({ demosRepo, exec }).catch((thrown: unknown) => thrown as Error);
+    expect(error.message).toContain("missing openapi.json");
+  });
+
+  it("stays bounded — a failing script can print megabytes", async () => {
+    const demosRepo = await fakeDemosRepo(["acme"]);
+    const { exec } = fakeExec([{ code: 1, stderr: `${"noise\n".repeat(4_000)}  demos/acme: missing tools.json` }]);
+    const error = await generateManifest({ demosRepo, exec }).catch((thrown: unknown) => thrown as Error);
+    expect(error.message).toContain("missing tools.json");
+    expect(error.message.length).toBeLessThan(3_200);
   });
 
   it("scrubs env secrets out of the script's failure line", async () => {

--- a/bench/src/demo-creator/host-boot.ts
+++ b/bench/src/demo-creator/host-boot.ts
@@ -7,7 +7,7 @@ import { chromium } from "@playwright/test";
 import { sendPrompt, VendoTurnError, VendoTurnTimeout, waitForTurn } from "../demo-capture/capture.js";
 import { genManifestScript, hostDir } from "./demo-folder.js";
 import { createScrubber, defaultExec, delay, scrubbingTransform, type ExecFn } from "./exec.js";
-import { agentRunDoorProblem, classifySmoke, installSmokeObserverInPage, noProgress, type SmokeOutcome } from "./smoke.js";
+import { agentRunDoorProblem, classifySmoke, installSmokeObserverInPage, noProgress, smokeReadyMs, type SmokeOutcome } from "./smoke.js";
 
 /**
  * Stage 4's plumbing: drive the vendo-demos HOST (a foreign checkout, not this
@@ -313,16 +313,30 @@ export const defaultSmokeTurn: SmokeTurnFn = async (options) => {
       });
       if (problem !== undefined && progress.doorError === undefined) progress.doorError = problem;
     });
-    await page.goto(new URL(`/${options.slug}/vendo`, options.baseUrl).toString(), {
-      waitUntil: "domcontentloaded",
-      timeout: options.timeoutMs,
-    });
-    await page.getByRole("textbox", { name: "Message" }).waitFor({ state: "visible", timeout: options.timeoutMs });
-    // Installed BEFORE the prompt is sent: the observer's baseline is "the turns
-    // already on this page", so a demo:fix re-smoke cannot mistake an old turn
-    // for this one's stream.
-    await page.evaluate(installSmokeObserverInPage);
-    const sent = await sendPrompt(page, options.prompt);
+    // GETTING TO A PROMPT is its own phase, on its own short budget. A demo whose
+    // page never renders a composer is broken NOW, and charging that wait against
+    // the turn budget is how a dead demo took the full 420s to fail and then threw
+    // a raw Playwright error instead of a verdict.
+    let sent: { assistantTurns: number };
+    try {
+      await page.goto(new URL(`/${options.slug}/vendo`, options.baseUrl).toString(), {
+        waitUntil: "domcontentloaded",
+        timeout: smokeReadyMs,
+      });
+      await page.getByRole("textbox", { name: "Message" }).waitFor({ state: "visible", timeout: smokeReadyMs });
+      // Installed BEFORE the prompt is sent: the observer's baseline is "the turns
+      // already on this page", so a demo:fix re-smoke cannot mistake an old turn
+      // for this one's stream.
+      await page.evaluate(installSmokeObserverInPage);
+      sent = await sendPrompt(page, options.prompt);
+    } catch (error) {
+      return classifySmoke({
+        settled: false,
+        timedOut: false,
+        pageUnusable: error instanceof Error ? (error.message.split("\n")[0] ?? error.message) : String(error),
+        progress,
+      });
+    }
     let settled = false;
     let surfacedError: string | undefined;
     let timedOut = false;

--- a/bench/src/demo-creator/host-boot.ts
+++ b/bench/src/demo-creator/host-boot.ts
@@ -4,9 +4,10 @@ import { mkdir, readFile } from "node:fs/promises";
 import { createConnection } from "node:net";
 import path from "node:path";
 import { chromium } from "@playwright/test";
-import { sendPrompt, waitForTurn } from "../demo-capture/capture.js";
+import { sendPrompt, VendoTurnError, VendoTurnTimeout, waitForTurn } from "../demo-capture/capture.js";
 import { genManifestScript, hostDir } from "./demo-folder.js";
-import { createScrubber, defaultExec, delay, firstLine, scrubbingTransform, type ExecFn } from "./exec.js";
+import { createScrubber, defaultExec, delay, scrubbingTransform, type ExecFn } from "./exec.js";
+import { classifySmoke, installSmokeObserverInPage, noProgress, type SmokeOutcome } from "./smoke.js";
 
 /**
  * Stage 4's plumbing: drive the vendo-demos HOST (a foreign checkout, not this
@@ -73,7 +74,14 @@ export async function generateManifest(options: {
     ...(options.env === undefined ? {} : { env: options.env }),
   });
   if (result.code !== 0) {
-    throw new Error(`gen-manifest failed (exit ${result.code}): ${scrub(firstLine(result.stderr || result.stdout) ?? "no output")}`);
+    // The TAIL of both streams, never the first line. The script prints a header
+    // ("the demo folder contract is not honored:") and then the problems one per
+    // line, so reporting the first line reported a failure with NO reason — and
+    // Next-style causes land on stdout while stderr carries only warnings, so
+    // picking one stream hides the cause about half the time. Bounded and
+    // scrubbed for the same reasons buildHost's tail is.
+    const output = `${result.stdout}${result.stderr}`.trim();
+    throw new Error(`gen-manifest failed (exit ${result.code}):\n${scrub(output.slice(-3_000)) || "no output"}`);
   }
   const generated = manifestPath(options.demosRepo);
   const source = await readFile(generated, "utf8").catch(() => undefined);
@@ -253,7 +261,7 @@ export async function bootHost(options: {
   };
 }
 
-export type SmokeTurnFn = (options: { baseUrl: string; slug: string; prompt: string; timeoutMs: number }) => Promise<void>;
+export type SmokeTurnFn = (options: { baseUrl: string; slug: string; prompt: string; timeoutMs: number }) => Promise<SmokeOutcome>;
 
 /** `requireView: false` is the contract's "gates on HARD error only": the smoke
  * turn passes as long as the turn did not error and did settle. What the agent
@@ -267,22 +275,73 @@ export function smokeTurnWaitOptions(options: { previousAssistantTurns: number; 
   return { previousAssistantTurns: options.previousAssistantTurns, timeoutMs: options.timeoutMs, requireView: false };
 }
 
-/** Drives /<slug>/vendo in a real browser: type the prompt, wait for the turn to
- *  settle. Throws on a surfaced error or a turn that never settles. */
+/**
+ * Drives /<slug>/vendo in a real browser and REPORTS what happened rather than
+ * throwing: whether the demo's agent is broken or merely slow is a judgement
+ * (see {@link classifySmoke}), and a thrown Error cannot carry the evidence that
+ * judgement needs.
+ *
+ * Three things are watched at once. The DOOR — the demo's own
+ * `/api/vendo/<slug>/…` route — is watched at the wire, because a 500 there is
+ * the dead-agent shape (no model provider, a tools file the runtime cannot parse)
+ * and it arrives within seconds. The in-page observer records the two signs of
+ * life. And the turn wait supplies the third answer: settled, errored, or out of
+ * clock.
+ */
 export const defaultSmokeTurn: SmokeTurnFn = async (options) => {
   const browser = await chromium.launch();
+  const progress = noProgress();
   try {
     const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
     const page = await context.newPage();
+    const doorPath = `/api/vendo/${options.slug}`;
+    page.on("response", (response) => {
+      if (!new URL(response.url()).pathname.startsWith(doorPath)) return;
+      progress.doorAnswered = true;
+      if (response.status() >= 400 && progress.doorError === undefined) {
+        progress.doorError = `${response.request().method()} ${new URL(response.url()).pathname} → ${response.status()}`;
+      }
+    });
+    page.on("requestfailed", (request) => {
+      if (!new URL(request.url()).pathname.startsWith(doorPath)) return;
+      if (progress.doorError === undefined) {
+        progress.doorError = `${request.method()} ${new URL(request.url()).pathname} → ${request.failure()?.errorText ?? "request failed"}`;
+      }
+    });
     await page.goto(new URL(`/${options.slug}/vendo`, options.baseUrl).toString(), {
       waitUntil: "domcontentloaded",
       timeout: options.timeoutMs,
     });
     await page.getByRole("textbox", { name: "Message" }).waitFor({ state: "visible", timeout: options.timeoutMs });
+    // Installed BEFORE the prompt is sent: the observer's baseline is "the turns
+    // already on this page", so a demo:fix re-smoke cannot mistake an old turn
+    // for this one's stream.
+    await page.evaluate(installSmokeObserverInPage);
     const sent = await sendPrompt(page, options.prompt);
-    await waitForTurn({
-      page,
-      ...smokeTurnWaitOptions({ previousAssistantTurns: sent.assistantTurns, timeoutMs: options.timeoutMs }),
+    let settled = false;
+    let surfacedError: string | undefined;
+    let timedOut = false;
+    try {
+      await waitForTurn({
+        page,
+        ...smokeTurnWaitOptions({ previousAssistantTurns: sent.assistantTurns, timeoutMs: options.timeoutMs }),
+      });
+      settled = true;
+    } catch (error) {
+      if (error instanceof VendoTurnError) surfacedError = error.surfaced;
+      else if (error instanceof VendoTurnTimeout) timedOut = true;
+      // Anything else is the harness failing, not a verdict about the demo.
+      else throw error;
+    }
+    const observed = await page.evaluate(() => window.__vendoSmoke?.snapshot())
+      ?? { turnStarted: false, toolCall: false };
+    progress.turnStarted = observed.turnStarted;
+    progress.toolCall = observed.toolCall;
+    return classifySmoke({
+      settled,
+      timedOut,
+      progress,
+      ...(surfacedError === undefined ? {} : { surfacedError }),
     });
   } finally {
     await browser.close().catch(() => undefined);

--- a/bench/src/demo-creator/host-boot.ts
+++ b/bench/src/demo-creator/host-boot.ts
@@ -7,7 +7,7 @@ import { chromium } from "@playwright/test";
 import { sendPrompt, VendoTurnError, VendoTurnTimeout, waitForTurn } from "../demo-capture/capture.js";
 import { genManifestScript, hostDir } from "./demo-folder.js";
 import { createScrubber, defaultExec, delay, scrubbingTransform, type ExecFn } from "./exec.js";
-import { classifySmoke, installSmokeObserverInPage, noProgress, type SmokeOutcome } from "./smoke.js";
+import { agentRunDoorProblem, classifySmoke, installSmokeObserverInPage, noProgress, type SmokeOutcome } from "./smoke.js";
 
 /**
  * Stage 4's plumbing: drive the vendo-demos HOST (a foreign checkout, not this
@@ -294,19 +294,24 @@ export const defaultSmokeTurn: SmokeTurnFn = async (options) => {
   try {
     const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
     const page = await context.newPage();
-    const doorPath = `/api/vendo/${options.slug}`;
+    // Only the request that RUNS the turn counts — see agentRunDoorProblem for
+    // why "any non-2xx under /api/vendo/<slug>" would fail healthy demos.
+    const agentRunDoor = `/api/vendo/${options.slug}/threads`;
     page.on("response", (response) => {
-      if (!new URL(response.url()).pathname.startsWith(doorPath)) return;
-      progress.doorAnswered = true;
-      if (response.status() >= 400 && progress.doorError === undefined) {
-        progress.doorError = `${response.request().method()} ${new URL(response.url()).pathname} → ${response.status()}`;
-      }
+      const pathname = new URL(response.url()).pathname;
+      const method = response.request().method();
+      if (method.toUpperCase() === "POST" && pathname === agentRunDoor) progress.doorAnswered = true;
+      const problem = agentRunDoorProblem({ slug: options.slug, method, pathname, status: response.status() });
+      if (problem !== undefined && progress.doorError === undefined) progress.doorError = problem;
     });
     page.on("requestfailed", (request) => {
-      if (!new URL(request.url()).pathname.startsWith(doorPath)) return;
-      if (progress.doorError === undefined) {
-        progress.doorError = `${request.method()} ${new URL(request.url()).pathname} → ${request.failure()?.errorText ?? "request failed"}`;
-      }
+      const problem = agentRunDoorProblem({
+        slug: options.slug,
+        method: request.method(),
+        pathname: new URL(request.url()).pathname,
+        ...(request.failure() === null ? {} : { failure: request.failure()?.errorText ?? "request failed" }),
+      });
+      if (problem !== undefined && progress.doorError === undefined) progress.doorError = problem;
     });
     await page.goto(new URL(`/${options.slug}/vendo`, options.baseUrl).toString(), {
       waitUntil: "domcontentloaded",

--- a/bench/src/demo-creator/pipeline.ts
+++ b/bench/src/demo-creator/pipeline.ts
@@ -1,5 +1,7 @@
 import { createHash } from "node:crypto";
-import { lstat, mkdir, readFile, readlink, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { cp, lstat, mkdir, readFile, readlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { runAssemble, type AssembleIo, type AssembleResult } from "./assemble.js";
@@ -306,6 +308,66 @@ export async function assertOnlyDemoTouched(
 }
 
 /**
+ * Puts demos/<slug>/ back the way git has it after a FAILED run, keeping what the
+ * run produced outside the checkout for diagnosis.
+ *
+ * Why a failed run cannot just be left where it fell: the host's gen-manifest
+ * validates EVERY demo folder and writes nothing unless all of them pass. So one
+ * half-generated leftover — no tools.json, an illegible theme — does not fail its
+ * own run twice, it fails every LATER run in that checkout. The mini's
+ * `~/.vendo/vendo-demos` lives forever, so one bad run bricked the Slack driver
+ * until a human moved the folder aside by hand.
+ *
+ * git decides what "clean" means, which is what makes this safe for demo:fix: a
+ * fix run works on a demo that is already live and COMMITTED, and the checkout
+ * plus clean restores that demo rather than deleting it. Only a demo this run
+ * created is untracked, and only an untracked folder disappears.
+ *
+ * Never throws. It runs on the failure path with a real cause already travelling
+ * to the operator, and replacing that cause with a cleanup detail is the worst
+ * trade available.
+ */
+export async function quarantineFailedDemo(options: {
+  demosRepo: string;
+  slug: string;
+  exec: ExecFn;
+  write: (line: string) => void;
+  /** Overridable so a test can see where things went. */
+  quarantineRoot?: string;
+}): Promise<{ quarantined?: string }> {
+  // demoPaths re-asserts the slug, so no caller can aim `git clean` with it.
+  const root = demoPaths(options.demosRepo, options.slug).root;
+  if (!existsSync(root)) return {};
+  const pathspec = `demos/${options.slug}`;
+  let quarantined: string | undefined;
+  try {
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    quarantined = path.join(
+      options.quarantineRoot ?? path.join(tmpdir(), "vendo-demo-failed"),
+      `${options.slug}-${stamp}`,
+    );
+    // Copied out BEFORE anything is removed: a failed run's folder is the only
+    // record of what the agents actually produced.
+    await cp(root, quarantined, { recursive: true, verbatimSymlinks: true });
+    // Tracked files first (a failed fix run's edits), then whatever is untracked.
+    // The checkout legitimately exits non-zero when nothing here is tracked —
+    // that is the new-demo case, and the clean below is what handles it.
+    await options.exec(["git", "-C", options.demosRepo, "checkout", "--", pathspec], { cwd: options.demosRepo });
+    const cleaned = await options.exec(["git", "-C", options.demosRepo, "clean", "-ffdxq", "--", pathspec], { cwd: options.demosRepo });
+    if (cleaned.code !== 0) {
+      throw new Error(`git clean exited ${cleaned.code}: ${cleaned.stderr.trim() || cleaned.stdout.trim()}`);
+    }
+    options.write(`[pipeline] the failed demo folder was moved out of the checkout to ${quarantined} — the next run starts from a clean ${pathspec}`);
+  } catch (error) {
+    options.write(
+      `[pipeline] WARNING: could not clean up demos/${options.slug}/ after the failure (${error instanceof Error ? error.message : String(error)})`
+      + ` — gen-manifest validates EVERY demo folder, so remove it by hand before the next run: rm -rf ${root}`,
+    );
+  }
+  return quarantined === undefined ? {} : { quarantined };
+}
+
+/**
  * One row of RESEARCH/timings.json — the per-stage wall-clock evidence.
  *
  * `depth` is what makes the table summable. Stages NEST: judge.ts wraps its body
@@ -600,6 +662,12 @@ export async function runDemoPipeline(args: DemoPipelineArgs, io: PipelineIo = {
       { demosRepo: args.demosRepo, write, env, exec, signal, runStage, finalizeTimings: timingsFile.finalize },
     ));
     return { slug: args.id, demoDir: paths.root, timings, judge, scoresLine, costUsd: built.costUsd, ship: shipped, liveUrl: shipped.liveUrl };
+  } catch (error) {
+    // A failed run does not get to leave its half-built folder behind: the host's
+    // gen-manifest validates EVERY demo, so this run's wreckage would fail the
+    // NEXT run in the same checkout, and the mini's checkout is permanent.
+    await quarantineFailedDemo({ demosRepo: args.demosRepo, slug: args.id, exec, write });
+    throw error;
   } finally {
     clearTimeout(capTimer);
     // One dev server, reaped by whoever started it — including on the failure

--- a/bench/src/demo-creator/quarantine.test.ts
+++ b/bench/src/demo-creator/quarantine.test.ts
@@ -1,0 +1,240 @@
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { demoPaths } from "./demo-folder.js";
+import { defaultExec } from "./exec.js";
+import { runDemoFix } from "./fix.js";
+import { quarantineFailedDemo, runDemoPipeline, type PipelineStages } from "./pipeline.js";
+
+/**
+ * The defect: `gen-manifest` validates EVERY demo folder and writes nothing
+ * unless all of them pass, so one non-conformant leftover from a dead run breaks
+ * every SUBSEQUENT run in that checkout. The mini's `~/.vendo/vendo-demos` lives
+ * forever, so one bad run bricked it until a human moved the folder aside by
+ * hand — which is exactly what happened to `built-ramp-bills-smoke-timeout`.
+ *
+ * Real git, because what is being proven is which files survive a checkout and a
+ * clean, and only git can answer that.
+ */
+async function gitRepo(): Promise<string> {
+  const repo = await mkdtemp(path.join(tmpdir(), "lane-quarantine-"));
+  await mkdir(path.join(repo, "host", "src"), { recursive: true });
+  await writeFile(path.join(repo, "host", "src", "app.ts"), "export const host = 1;\n");
+  await defaultExec(["git", "init", "-q", "."], { cwd: repo });
+  await defaultExec(["git", "add", "-A"], { cwd: repo });
+  await defaultExec(["git", "-c", "user.name=t", "-c", "user.email=t@t.test", "commit", "-qm", "base"], { cwd: repo });
+  return repo;
+}
+
+async function commitAll(repo: string, message: string): Promise<void> {
+  await defaultExec(["git", "add", "-A"], { cwd: repo });
+  await defaultExec(["git", "-c", "user.name=t", "-c", "user.email=t@t.test", "commit", "-qm", message], { cwd: repo });
+}
+
+/** A half-generated demo folder: the shape a dead run leaves behind. */
+async function halfBuiltDemo(repo: string, slug: string): Promise<void> {
+  await mkdir(path.join(repo, "demos", slug, "screens"), { recursive: true });
+  await writeFile(path.join(repo, "demos", slug, "screens", "index.tsx"), "export default () => null;\n");
+  // No tools.json, no theme.json — this is what gen-manifest refuses.
+  await writeFile(path.join(repo, "demos", slug, "BRIEF.md"), "# half a brief\n");
+}
+
+const io = (write: (line: string) => void = () => undefined) => ({ exec: defaultExec, write });
+
+describe("quarantineFailedDemo", () => {
+  it("leaves the checkout with no trace of a failed run's new demo folder", async () => {
+    const repo = await gitRepo();
+    await halfBuiltDemo(repo, "ramp-bills");
+    await quarantineFailedDemo({ demosRepo: repo, slug: "ramp-bills", ...io() });
+    // The whole point: the next run's gen-manifest must not see this folder.
+    expect(existsSync(path.join(repo, "demos", "ramp-bills"))).toBe(false);
+  });
+
+  it("keeps the failed artifacts outside the repo, so a failure is still diagnosable", async () => {
+    const repo = await gitRepo();
+    await halfBuiltDemo(repo, "ramp-bills");
+    const result = await quarantineFailedDemo({ demosRepo: repo, slug: "ramp-bills", ...io() });
+    expect(result.quarantined).toBeDefined();
+    expect(await readFile(path.join(result.quarantined!, "BRIEF.md"), "utf8")).toBe("# half a brief\n");
+    // OUTSIDE the checkout: `railway up` uploads the working directory, so a
+    // quarantine kept inside it would deploy every dead run's leftovers.
+    expect(path.relative(repo, result.quarantined!).startsWith("..")).toBe(true);
+  });
+
+  // demo:fix runs against a demo that is already LIVE and committed. Deleting
+  // that folder because the fix failed would erase a shipped demo's source.
+  it("restores a committed demo instead of deleting it when a fix run fails", async () => {
+    const repo = await gitRepo();
+    await mkdir(path.join(repo, "demos", "zelty"), { recursive: true });
+    await writeFile(path.join(repo, "demos", "zelty", "theme.json"), '{"good":true}\n');
+    await commitAll(repo, "demo(zelty): live");
+    // A failed fix run: the committed file mangled, plus a new stray.
+    await writeFile(path.join(repo, "demos", "zelty", "theme.json"), "{ broken\n");
+    await writeFile(path.join(repo, "demos", "zelty", "stray.tsx"), "export default 1;\n");
+
+    await quarantineFailedDemo({ demosRepo: repo, slug: "zelty", ...io() });
+
+    expect(await readFile(path.join(repo, "demos", "zelty", "theme.json"), "utf8")).toBe('{"good":true}\n');
+    expect(existsSync(path.join(repo, "demos", "zelty", "stray.tsx"))).toBe(false);
+  });
+
+  it("touches nothing outside the demo folder it is cleaning", async () => {
+    const repo = await gitRepo();
+    await halfBuiltDemo(repo, "ramp-bills");
+    await mkdir(path.join(repo, "demos", "zelty"), { recursive: true });
+    await writeFile(path.join(repo, "demos", "zelty", "theme.json"), '{"live":true}\n');
+    await commitAll(repo, "demo(zelty): live");
+    // Host artifacts a run legitimately leaves behind (the generated manifest).
+    await writeFile(path.join(repo, "host", "src", "generated.ts"), "export const slugs = [];\n");
+
+    await quarantineFailedDemo({ demosRepo: repo, slug: "ramp-bills", ...io() });
+
+    expect(existsSync(path.join(repo, "demos", "zelty", "theme.json"))).toBe(true);
+    expect(existsSync(path.join(repo, "host", "src", "generated.ts"))).toBe(true);
+    expect(await readFile(path.join(repo, "host", "src", "app.ts"), "utf8")).toBe("export const host = 1;\n");
+  });
+
+  it("is a no-op when the run died before the demo folder existed", async () => {
+    const repo = await gitRepo();
+    const result = await quarantineFailedDemo({ demosRepo: repo, slug: "never-started", ...io() });
+    expect(result.quarantined).toBeUndefined();
+  });
+
+  // This runs on the failure path, where an original error is already on its way
+  // to the operator. A throw here would replace the real cause with a cleanup
+  // detail — the worst possible trade.
+  it("never throws when cleanup itself fails, and says so instead", async () => {
+    const notARepo = await mkdtemp(path.join(tmpdir(), "lane-quarantine-bare-"));
+    await halfBuiltDemo(notARepo, "acme");
+    const lines: string[] = [];
+    await expect(quarantineFailedDemo({ demosRepo: notARepo, slug: "acme", ...io((line) => lines.push(line)) }))
+      .resolves.toBeDefined();
+    expect(lines.some((line) => line.includes("WARNING"))).toBe(true);
+  });
+
+  it("refuses a slug that is not a slug, before it builds a path from it", async () => {
+    const repo = await gitRepo();
+    await expect(quarantineFailedDemo({ demosRepo: repo, slug: "../../host", ...io() })).rejects.toThrow(/slug/);
+  });
+});
+
+/**
+ * The wiring. Cleaning up is only worth anything if a real failed run does it
+ * — the whole defect is that a dead run walked away and left the checkout
+ * broken for the next one.
+ */
+describe("a failed run cleans up after itself", () => {
+  /** Stage fakes for a run that gets as far as assemble and then dies there —
+   *  the exact shape of the smoke-timeout and contrast-gate runs. */
+  function stagesFailingAtAssemble(repo: string, slug: string): PipelineStages {
+    return {
+      ensureRepo: async (dir) => ({ dir, cloned: false, head: "head" }),
+      evidence: async () => {
+        await halfBuiltDemo(repo, slug);
+        return {} as never;
+      },
+      brief: async () => ({ theme: {}, brief: { company: "Acme" }, themePath: "t", briefPath: "b" }) as never,
+      build: async () => ({ agents: [], toolCount: 4, costUsd: 1, beats: [{ key: "generate-ui", prompt: "Show me a dashboard" }] }) as never,
+      assemble: async () => {
+        throw new Error("the smoke turn TIMED OUT after 420000ms — …");
+      },
+      judge: async () => ({}) as never,
+      ship: async () => ({}) as never,
+    };
+  }
+
+  it("leaves demos/<slug>/ out of the checkout when a stage fails", async () => {
+    const repo = await gitRepo();
+    const lines: string[] = [];
+    await expect(runDemoPipeline(
+      {
+        id: "ramp-bills",
+        prospect: "Ramp",
+        screenshots: ["/abs/a.png"],
+        ctaUrl: "https://cal.com/x",
+        expiresAt: "2026-08-31T00:00:00.000Z",
+        demosRepo: repo,
+        skipShip: false,
+      },
+      { stages: stagesFailingAtAssemble(repo, "ramp-bills"), write: (line) => lines.push(line), exec: defaultExec },
+    )).rejects.toThrow(/TIMED OUT/);
+
+    // Without this the NEXT run's gen-manifest refuses the whole checkout.
+    expect(existsSync(path.join(repo, "demos", "ramp-bills"))).toBe(false);
+    expect(lines.some((line) => line.includes("moved out of the checkout"))).toBe(true);
+  });
+
+  it("keeps the demo folder on a SUCCESSFUL run", async () => {
+    const repo = await gitRepo();
+    const stages = stagesFailingAtAssemble(repo, "ramp-bills");
+    const host = { baseUrl: "http://127.0.0.1:3150", stop: async () => undefined };
+    await runDemoPipeline(
+      {
+        id: "ramp-bills",
+        prospect: "Ramp",
+        screenshots: ["/abs/a.png"],
+        ctaUrl: "https://cal.com/x",
+        expiresAt: "2026-08-31T00:00:00.000Z",
+        demosRepo: repo,
+        skipShip: true,
+      },
+      {
+        stages: {
+          ...stages,
+          assemble: async () => ({ slugs: ["ramp-bills"], host, smoke: { prompt: "p", ms: 1 } }) as never,
+          judge: async () => ({ scoresLine: "logo=PASS palette=8 type=8 layout=8 copyTone=8" }) as never,
+        },
+        write: () => undefined,
+        exec: defaultExec,
+      },
+    );
+    expect(existsSync(path.join(repo, "demos", "ramp-bills"))).toBe(true);
+  });
+
+  // demo:fix poisons the checkout the same way, and its demo is COMMITTED — so
+  // the requirement here is the opposite one: restore it, never delete it.
+  it("restores a live demo's committed folder when a fix run fails", async () => {
+    const repo = await gitRepo();
+    const paths = demoPaths(repo, "zelty");
+    await mkdir(paths.root, { recursive: true });
+    await writeFile(paths.brief, "# BRIEF — Zelty\n");
+    await writeFile(paths.config, JSON.stringify({
+      id: "zelty",
+      prospect: "Zelty",
+      ctaUrl: "https://cal.com/x",
+      caps: { maxTurns: 20, maxSpendUsd: 5 },
+      expiresAt: "2026-08-31T00:00:00.000Z",
+      placement: { trigger: "header", slot: "top-right of the header bar" },
+      beats: [
+        { key: "generate-ui", chip: "Spend", prompt: "Build me a spend view", expectsView: true },
+        { key: "take-action", chip: "Pay", prompt: "Pay the oldest bill", expectsApproval: true },
+        { key: "automation", chip: "Watch", prompt: "Alert me on new bills" },
+        { key: "connect-account", chip: "Connect", prompt: "Connect my inbox" },
+        { key: "save-app", chip: "Save", prompt: "Save this as an app" },
+      ],
+    }));
+    await commitAll(repo, "demo(zelty): live");
+
+    await expect(runDemoFix(
+      { id: "zelty", instruction: "make the sidebar dark", demosRepo: repo, skipShip: false },
+      {
+        write: () => undefined,
+        env: {},
+        exec: defaultExec,
+        runAgent: async (job) => {
+          // The failed fix agent's damage: a stray file left in the folder.
+          await writeFile(path.join(paths.root, "stray.tsx"), "export default 1;\n");
+          return { name: job.name, code: 1, output: "the fix agent gave up", timedOut: false, permissionDenials: [] };
+        },
+      },
+    )).rejects.toThrow(/Fix agent failed/);
+
+    // The live demo's own source is intact…
+    expect(existsSync(paths.config)).toBe(true);
+    expect(await readFile(paths.brief, "utf8")).toBe("# BRIEF — Zelty\n");
+    // …and the failed run's leftover is gone, so gen-manifest still passes.
+    expect(existsSync(path.join(paths.root, "stray.tsx"))).toBe(false);
+  });
+});

--- a/bench/src/demo-creator/smoke-observer.test.ts
+++ b/bench/src/demo-creator/smoke-observer.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { installSmokeObserverInPage } from "./smoke.js";
+
+/** MutationObserver callbacks are microtasks; a macrotask tick drains them. */
+const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+function assistantTurn(): HTMLElement {
+  const article = document.createElement("article");
+  article.setAttribute("data-role", "assistant");
+  return article;
+}
+
+/** The live status ribbon the thread shows while a tool call is in flight. */
+function toolRibbon(name: string): HTMLElement {
+  const ribbon = document.createElement("div");
+  ribbon.className = "fl-ribbon";
+  ribbon.setAttribute("data-vendo-tool", name);
+  return ribbon;
+}
+
+afterEach(() => {
+  window.__vendoSmoke?.dispose();
+  delete window.__vendoSmoke;
+  document.body.innerHTML = "";
+});
+
+describe("installSmokeObserverInPage", () => {
+  it("reports no sign of life on a page where nothing has happened", () => {
+    installSmokeObserverInPage();
+    expect(window.__vendoSmoke?.snapshot()).toEqual({ turnStarted: false, toolCall: false });
+  });
+
+  it("reports a turn started once an assistant article attaches", async () => {
+    installSmokeObserverInPage();
+    document.body.append(assistantTurn());
+    await settle();
+    expect(window.__vendoSmoke?.snapshot().turnStarted).toBe(true);
+  });
+
+  // The smoke turn may run on a thread that already holds turns (demo:fix
+  // re-smokes a live demo). Counting a pre-existing article as this turn's
+  // stream would call a dead agent alive.
+  it("ignores assistant turns that were already on the page before it installed", async () => {
+    document.body.append(assistantTurn(), assistantTurn());
+    installSmokeObserverInPage();
+    await settle();
+    expect(window.__vendoSmoke?.snapshot().turnStarted).toBe(false);
+
+    document.body.append(assistantTurn());
+    await settle();
+    expect(window.__vendoSmoke?.snapshot().turnStarted).toBe(true);
+  });
+
+  // The reason this is an observer and not a poll. The ribbon exists only while
+  // a call is in flight, and a settled tool call leaves NO transcript trace at
+  // all — so a 300ms poll misses a fast call entirely and reports a healthy
+  // agent as one that never called a tool.
+  it("catches a tool call that appeared and vanished between polls", async () => {
+    installSmokeObserverInPage();
+    const ribbon = toolRibbon("listInvoices");
+    document.body.append(ribbon);
+    ribbon.remove();
+    await settle();
+    expect(window.__vendoSmoke?.snapshot().toolCall).toBe(true);
+  });
+
+  it("catches a tool ribbon that attaches deep inside a re-rendered subtree", async () => {
+    installSmokeObserverInPage();
+    const wrapper = document.createElement("div");
+    wrapper.append(toolRibbon("createInvoice"));
+    document.body.append(wrapper);
+    await settle();
+    expect(window.__vendoSmoke?.snapshot().toolCall).toBe(true);
+  });
+
+  it("keeps both signals sticky — a settled turn does not un-prove itself", async () => {
+    installSmokeObserverInPage();
+    const ribbon = toolRibbon("listInvoices");
+    const turn = assistantTurn();
+    document.body.append(turn, ribbon);
+    await settle();
+    ribbon.remove();
+    turn.remove();
+    await settle();
+    expect(window.__vendoSmoke?.snapshot()).toEqual({ turnStarted: true, toolCall: true });
+  });
+
+  it("stops recording once disposed", async () => {
+    installSmokeObserverInPage();
+    window.__vendoSmoke?.dispose();
+    document.body.append(assistantTurn());
+    await settle();
+    expect(window.__vendoSmoke?.snapshot().turnStarted).toBe(false);
+  });
+
+  it("replaces a previous observer instead of stacking one", async () => {
+    installSmokeObserverInPage();
+    document.body.append(assistantTurn());
+    await settle();
+    installSmokeObserverInPage();
+    expect(window.__vendoSmoke?.snapshot()).toEqual({ turnStarted: false, toolCall: false });
+  });
+});

--- a/bench/src/demo-creator/smoke.test.ts
+++ b/bench/src/demo-creator/smoke.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  agentRunDoorProblem,
   classifySmoke,
   noProgress,
   observedSmokeLatenciesMs,
@@ -25,6 +26,75 @@ describe("smokeBudgetMs", () => {
   it("stays small enough that one attempt cannot eat the pipeline's own cap", () => {
     // defaultCapMs is 40 minutes; a smoke attempt may not be a quarter of it.
     expect(smokeBudgetMs).toBeLessThanOrEqual(10 * 60 * 1000);
+  });
+});
+
+/**
+ * "A hard error from the door" has to mean the door that RUNS THE TURN, and
+ * nothing else. The Vendo client talks to many sub-paths under
+ * `/api/vendo/<slug>`, and several answer non-2xx in completely healthy
+ * operation — `GET /connections` is polled every three seconds and answers 402
+ * whenever Cloud connections are not composed, which the UI is explicitly built
+ * to survive. A gate that failed on "any 4xx under the route family" would call
+ * every healthy demo broken, which is worse than the coin flip it replaced.
+ */
+describe("agentRunDoorProblem", () => {
+  const door = (over: Partial<Parameters<typeof agentRunDoorProblem>[0]> = {}) => agentRunDoorProblem({
+    slug: "acme",
+    method: "POST",
+    pathname: "/api/vendo/acme/threads",
+    status: 200,
+    ...over,
+  });
+
+  it("passes the agent-run door when it answers", () => {
+    expect(door()).toBeUndefined();
+  });
+
+  // The dead-agent shape: no model provider, or a tools file the runtime cannot
+  // parse, both throw on the first actions use — which is this request.
+  it("reports the agent-run door answering a server error", () => {
+    expect(door({ status: 500 })).toMatch(/500/);
+  });
+
+  it("reports the agent-run door refusing the run", () => {
+    expect(door({ status: 402 })).toMatch(/402/);
+    expect(door({ status: 400 })).toMatch(/400/);
+  });
+
+  // The caps guard answering is the guard WORKING. It means this demo's own turn
+  // budget is spent or it has expired — a condition about the demo's lifecycle,
+  // never evidence that its agent cannot run.
+  it("does not call the caps guard's own refusals a broken agent", () => {
+    expect(door({ status: 429 })).toBeUndefined();
+    expect(door({ status: 410 })).toBeUndefined();
+  });
+
+  it("reports a request that never completed at all", () => {
+    expect(door({ status: undefined, failure: "net::ERR_CONNECTION_REFUSED" })).toMatch(/ERR_CONNECTION_REFUSED/);
+  });
+
+  // Every one of these is a normal, designed non-2xx on a healthy demo.
+  it.each([
+    ["GET", "/api/vendo/acme/connections", 402, "polled every 3s; 402 whenever Cloud connections are not composed"],
+    ["GET", "/api/vendo/acme/connections/catalog", 402, "same Cloud-entitlement condition"],
+    ["GET", "/api/vendo/acme/connections/acct_1", 404, "normal during the OAuth poll window"],
+    ["GET", "/api/vendo/acme/approvals/ap_1", 404, "the contracted 'expired' signal"],
+    ["POST", "/api/vendo/acme/approvals/decide", 409, "a normal multi-surface decide race"],
+    ["GET", "/api/vendo/acme/apps/app_1/open", 404, "contracted until the app is servable"],
+    ["POST", "/api/vendo/acme/dev/remixable-source", 401, "dev-only probe, ephemeral principal"],
+  ])("ignores %s %s → %i (%s)", (method, pathname, status) => {
+    expect(agentRunDoorProblem({ slug: "acme", method, pathname, status })).toBeUndefined();
+  });
+
+  it("ignores another demo's door entirely", () => {
+    expect(agentRunDoorProblem({ slug: "acme", method: "POST", pathname: "/api/vendo/globex/threads", status: 500 })).toBeUndefined();
+  });
+
+  // A per-thread sub-path is not the run door: heartbeat deliberately answers
+  // 200 for unknown ids, and a thread GET is guarded by a list call.
+  it("ignores sub-paths under threads", () => {
+    expect(agentRunDoorProblem({ slug: "acme", method: "POST", pathname: "/api/vendo/acme/threads/t1/heartbeat", status: 500 })).toBeUndefined();
   });
 });
 

--- a/bench/src/demo-creator/smoke.test.ts
+++ b/bench/src/demo-creator/smoke.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifySmoke,
+  noProgress,
+  observedSmokeLatenciesMs,
+  smokeBudgetMs,
+  type SmokeProgress,
+} from "./smoke.js";
+
+/** A turn that got as far as streaming — the shape of every healthy run. */
+const alive: SmokeProgress = { doorAnswered: true, turnStarted: true, toolCall: true };
+
+describe("smokeBudgetMs", () => {
+  // The gate this replaces sat at 180_000ms, INSIDE the measured distribution:
+  // two of six real runs died on it with demos that were otherwise fine. A
+  // budget is only a hard-failure gate if healthy runs cannot reach it, so the
+  // measured numbers are pinned here — re-tightening the budget into them has
+  // to break this test first.
+  it("clears every latency ever measured on a healthy turn, with room to spare", () => {
+    const worst = Math.max(...observedSmokeLatenciesMs);
+    expect(worst).toBe(182_835);
+    expect(smokeBudgetMs).toBeGreaterThanOrEqual(2 * worst);
+  });
+
+  it("stays small enough that one attempt cannot eat the pipeline's own cap", () => {
+    // defaultCapMs is 40 minutes; a smoke attempt may not be a quarter of it.
+    expect(smokeBudgetMs).toBeLessThanOrEqual(10 * 60 * 1000);
+  });
+});
+
+describe("classifySmoke — a genuinely BROKEN demo fails, and fails fast", () => {
+  // The dead-agent shape the gate exists to catch: the page renders, the agent
+  // route throws (no model provider, a tools file the runtime cannot parse), and
+  // the browser gets a 500 within seconds of the first send.
+  it("calls a hard error from the demo's own agent route broken", () => {
+    const outcome = classifySmoke({
+      settled: false,
+      timedOut: false,
+      progress: { doorAnswered: true, doorError: "POST /api/vendo/acme → 500", turnStarted: false, toolCall: false },
+    });
+    expect(outcome.verdict).toBe("broken");
+    expect(outcome.reason).toContain("500");
+  });
+
+  it("calls a turn that surfaced an error broken", () => {
+    const outcome = classifySmoke({
+      settled: false,
+      timedOut: false,
+      surfacedError: "Something went wrong and the response didn’t finish.",
+      progress: { doorAnswered: true, turnStarted: true, toolCall: false },
+    });
+    expect(outcome.verdict).toBe("broken");
+    expect(outcome.reason).toContain("didn’t finish");
+  });
+
+  // The other dead-agent shape: nothing errors, nothing arrives either. This is
+  // the ONE case where the clock is the evidence — and it is still called
+  // broken, not slow, because a demo that produced literally nothing in the
+  // whole budget has not been shown to work at all.
+  it("calls a deadline with no turn and no tool call broken, never merely slow", () => {
+    const outcome = classifySmoke({
+      settled: false,
+      timedOut: true,
+      progress: noProgress(),
+    });
+    expect(outcome.verdict).toBe("broken");
+    expect(outcome.reason).toMatch(/never/i);
+  });
+});
+
+describe("classifySmoke — a SLOW but healthy demo is not called broken", () => {
+  it("passes a turn that settled, however long it took", () => {
+    expect(classifySmoke({ settled: true, timedOut: false, progress: alive }).verdict).toBe("settled");
+  });
+
+  // The distinction that IS the fix. Same wall clock, same deadline; the demo
+  // that demonstrably streamed and called a tool is reported as a TIMEOUT, and
+  // the one that did nothing is reported as BROKEN. The old gate called both
+  // "Timed out after 180000ms waiting for the generated Vendo turn".
+  it("separates a slow living agent from a dead one at the very same deadline", () => {
+    const slow = classifySmoke({ settled: false, timedOut: true, progress: alive });
+    const dead = classifySmoke({ settled: false, timedOut: true, progress: noProgress() });
+    expect(slow.verdict).toBe("timeout");
+    expect(dead.verdict).toBe("broken");
+    expect(slow.verdict).not.toBe(dead.verdict);
+  });
+
+  it("counts a streamed turn as life even when no tool call was ever seen", () => {
+    // The transcript renders no trace of a SETTLED tool call, so the observer
+    // can miss one that really happened; a streamed turn alone is enough.
+    const outcome = classifySmoke({
+      settled: false,
+      timedOut: true,
+      progress: { doorAnswered: true, turnStarted: true, toolCall: false },
+    });
+    expect(outcome.verdict).toBe("timeout");
+  });
+
+  it("counts a tool call as life even when no assistant article ever attached", () => {
+    const outcome = classifySmoke({
+      settled: false,
+      timedOut: true,
+      progress: { doorAnswered: true, turnStarted: false, toolCall: true },
+    });
+    expect(outcome.verdict).toBe("timeout");
+  });
+});
+
+describe("classifySmoke — what a second attempt can and cannot fix", () => {
+  // Run E died here: "Something went wrong and the response didn't finish" at
+  // 129s, on a demo that was fine. An external inference failure is not the
+  // demo's bug, and it is the one outcome a retry can genuinely clear.
+  it("marks an errored turn retryable — that failure came from outside the demo", () => {
+    expect(classifySmoke({
+      settled: false,
+      timedOut: false,
+      surfacedError: "Something went wrong and the response didn’t finish.",
+      progress: alive,
+    }).retryable).toBe(true);
+  });
+
+  it("marks a hard door error retryable, because it costs seconds to re-prove", () => {
+    expect(classifySmoke({
+      settled: false,
+      timedOut: false,
+      progress: { doorAnswered: true, doorError: "POST /api/vendo/acme → 500", turnStarted: false, toolCall: false },
+    }).retryable).toBe(true);
+  });
+
+  // A retry after a deadline costs another whole budget of wall clock and
+  // cannot change what the clock already proved.
+  it("never marks a deadline retryable, whichever way it was classified", () => {
+    expect(classifySmoke({ settled: false, timedOut: true, progress: alive }).retryable).toBe(false);
+    expect(classifySmoke({ settled: false, timedOut: true, progress: noProgress() }).retryable).toBe(false);
+  });
+
+  it("never marks a settled turn retryable", () => {
+    expect(classifySmoke({ settled: true, timedOut: false, progress: alive }).retryable).toBe(false);
+  });
+});
+
+describe("classifySmoke — precedence", () => {
+  // A door that 500s while the page also shows an alert is ONE fault, and the
+  // door is the more specific evidence.
+  it("reports the door's own error ahead of the alert the page rendered", () => {
+    const outcome = classifySmoke({
+      settled: false,
+      timedOut: false,
+      surfacedError: "the response didn’t finish",
+      progress: { doorAnswered: true, doorError: "POST /api/vendo/acme → 500", turnStarted: false, toolCall: false },
+    });
+    expect(outcome.reason).toContain("500");
+  });
+
+  // Content is stage 5's business (frozen contract): the classifier is handed
+  // liveness signals only, so no verdict can depend on what was generated.
+  it("carries no content — only liveness signals", () => {
+    const outcome = classifySmoke({ settled: true, timedOut: false, progress: alive });
+    expect(Object.keys(outcome.progress).sort()).toEqual(["doorAnswered", "toolCall", "turnStarted"]);
+  });
+});

--- a/bench/src/demo-creator/smoke.test.ts
+++ b/bench/src/demo-creator/smoke.test.ts
@@ -5,11 +5,23 @@ import {
   noProgress,
   observedSmokeLatenciesMs,
   smokeBudgetMs,
+  smokeReadyMs,
   type SmokeProgress,
 } from "./smoke.js";
 
 /** A turn that got as far as streaming — the shape of every healthy run. */
 const alive: SmokeProgress = { doorAnswered: true, turnStarted: true, toolCall: true };
+
+describe("smokeReadyMs", () => {
+  // Getting to a composer is page load plus hydration, not a model round trip.
+  // It has its own budget because a demo whose page never renders is broken NOW,
+  // and charging that against the turn budget is how a dead demo took 420s to
+  // fail — the real-host probe caught exactly that.
+  it("is far shorter than the turn budget, because it is not waiting on a model", () => {
+    expect(smokeReadyMs).toBeLessThan(smokeBudgetMs / 4);
+    expect(smokeReadyMs).toBeGreaterThanOrEqual(30_000);
+  });
+});
 
 describe("smokeBudgetMs", () => {
   // The gate this replaces sat at 180_000ms, INSIDE the measured distribution:
@@ -121,6 +133,34 @@ describe("classifySmoke — a genuinely BROKEN demo fails, and fails fast", () =
     });
     expect(outcome.verdict).toBe("broken");
     expect(outcome.reason).toContain("didn’t finish");
+  });
+
+  /**
+   * Found by running the real thing with an invalid provider key: the demo's
+   * Vendo page never rendered a composer at all, so the wait for it burned the
+   * WHOLE turn budget and then threw a raw Playwright TimeoutError instead of a
+   * verdict. A genuinely broken demo took 420s to fail and reported nothing
+   * useful — and widening the budget had made that case worse, not better.
+   */
+  it("calls a page that never became usable broken, and says which part failed", () => {
+    const outcome = classifySmoke({
+      settled: false,
+      timedOut: false,
+      pageUnusable: "no composer appeared within 60000ms",
+      progress: noProgress(),
+    });
+    expect(outcome.verdict).toBe("broken");
+    expect(outcome.reason).toContain("composer");
+    // Cheap to re-prove: this fails in seconds, so one retry costs nothing.
+    expect(outcome.retryable).toBe(true);
+  });
+
+  it("prefers the page fault over the generic 'never produced a turn' reason", () => {
+    const vague = classifySmoke({ settled: false, timedOut: true, progress: noProgress() });
+    const precise = classifySmoke({ settled: false, timedOut: false, pageUnusable: "the composer never armed", progress: noProgress() });
+    expect(vague.verdict).toBe("broken");
+    expect(precise.verdict).toBe("broken");
+    expect(precise.reason).not.toBe(vague.reason);
   });
 
   // The other dead-agent shape: nothing errors, nothing arrives either. This is

--- a/bench/src/demo-creator/smoke.ts
+++ b/bench/src/demo-creator/smoke.ts
@@ -49,6 +49,22 @@ export const observedSmokeLatenciesMs = [89_122, 104_612, 129_058, 135_675, 165_
 export const smokeBudgetMs = 420_000;
 
 /**
+ * How long the demo's page gets to become usable — loaded, hydrated, composer
+ * present — BEFORE the turn budget starts.
+ *
+ * Its own budget because this phase waits on a Next production build and React
+ * hydration, not on a model, and a demo whose page never renders is broken right
+ * now. Found the hard way: a probe with an invalid provider key never rendered a
+ * composer, so the wait for one consumed the whole 420s turn budget and then
+ * threw a raw Playwright error instead of a verdict — a genuinely broken demo
+ * taking seven minutes to fail, which is the opposite of the point. Widening the
+ * turn budget had made that case worse.
+ *
+ * 60s is roughly 20x what a healthy freshly-booted host takes to paint.
+ */
+export const smokeReadyMs = 60_000;
+
+/**
  * What the smoke turn observed about the demo's agent while the turn ran.
  * LIVENESS ONLY — never what was generated. The frozen contract puts content in
  * stage 5, so no field here may describe a view, a tool result or any prose.
@@ -222,6 +238,11 @@ export function classifySmoke(observed: {
   timedOut: boolean;
   /** The visible error the turn surfaced, if it surfaced one. */
   surfacedError?: string;
+  /**
+   * The demo's page never got as far as accepting a prompt (no composer, or a
+   * Send that never armed). Set instead of running the turn at all.
+   */
+  pageUnusable?: string;
   progress: SmokeProgress;
 }): SmokeOutcome {
   const { progress } = observed;
@@ -231,6 +252,16 @@ export function classifySmoke(observed: {
     return {
       verdict: "broken",
       reason: `the demo's agent route answered ${progress.doorError} — the generated demo's own door is failing, not the model`,
+      progress,
+      retryable: true,
+    };
+  }
+  // Before the turn: a demo whose page will not accept a prompt is broken, and
+  // saying WHICH part failed is the difference between a diagnosis and a mystery.
+  if (observed.pageUnusable !== undefined) {
+    return {
+      verdict: "broken",
+      reason: `the demo's Vendo page never got as far as accepting a prompt — ${observed.pageUnusable}. The page itself is failing (a server component throwing, or the Vendo surface never mounting), so no turn was ever attempted`,
       progress,
       retryable: true,
     };

--- a/bench/src/demo-creator/smoke.ts
+++ b/bench/src/demo-creator/smoke.ts
@@ -11,6 +11,7 @@
  * wall-clock deadline, and these are the turn latencies measured on this machine
  * against the deployed Cloud posture (see {@link observedSmokeLatenciesMs}):
  *
+ *   run 2  zelty-orders          89_122ms  settled   (this gate, on the new budget)
  *   run C  ramp-invoices        104_612ms  settled
  *   run E  ramp-licenses        129_058ms  ERRORED ("the response didn't finish")
  *   run D  ramp-reimbursements  135_675ms  settled
@@ -30,7 +31,7 @@
 
 /** Every smoke-turn latency measured on a real run, in the order observed. The
  *  budget below is derived from these, and a test holds it against them. */
-export const observedSmokeLatenciesMs = [104_612, 129_058, 135_675, 165_121, 182_835] as const;
+export const observedSmokeLatenciesMs = [89_122, 104_612, 129_058, 135_675, 165_121, 182_835] as const;
 
 /**
  * How long ONE smoke attempt may run.
@@ -73,6 +74,47 @@ export interface SmokeProgress {
 /** A turn that showed no sign of life whatsoever. */
 export function noProgress(): SmokeProgress {
   return { doorAnswered: false, turnStarted: false, toolCall: false };
+}
+
+/**
+ * Whether a single browser request says the demo's AGENT DOOR is broken — and it
+ * is deliberately only ever ONE request: `POST /api/vendo/<slug>/threads`, the
+ * call that runs the turn.
+ *
+ * Scoped this tightly because the Vendo client talks to many sub-paths under the
+ * same prefix and several answer non-2xx in perfectly healthy operation:
+ * `GET /connections` is POLLED EVERY THREE SECONDS and answers 402 whenever Cloud
+ * connections are not composed (the UI is explicitly built to survive that),
+ * `GET /connections/:id` 404s throughout the OAuth poll window,
+ * `GET /approvals/:id` 404 IS the contracted "expired" signal, and
+ * `POST /approvals/decide` 409s on a normal multi-surface race. A gate that fired
+ * on "any 4xx under /api/vendo/<slug>" would call healthy demos broken — worse
+ * than the coin flip it replaces — and it would do so only on some machines,
+ * which is the least debuggable failure there is.
+ *
+ * The caps guard's own 429 (turns/spend spent) and 410 (expired or killed) are
+ * excluded for a different reason: those mean the guard WORKED. They are facts
+ * about this demo's lifecycle, never evidence that its agent cannot run.
+ */
+export function agentRunDoorProblem(request: {
+  slug: string;
+  method: string;
+  pathname: string;
+  /** Absent when the request never completed. */
+  status?: number;
+  /** Set when the request failed at the transport level. */
+  failure?: string;
+}): string | undefined {
+  const isAgentRun = request.method.toUpperCase() === "POST"
+    && request.pathname === `/api/vendo/${request.slug}/threads`;
+  if (!isAgentRun) return undefined;
+  if (request.status === undefined) {
+    return `POST ${request.pathname} → ${request.failure ?? "request failed"}`;
+  }
+  if (request.status < 400) return undefined;
+  // The caps guard doing its job, not a broken agent.
+  if (request.status === 429 || request.status === 410) return undefined;
+  return `POST ${request.pathname} → ${request.status}`;
 }
 
 /** The two in-page signs of life, read back after the turn. */

--- a/bench/src/demo-creator/smoke.ts
+++ b/bench/src/demo-creator/smoke.ts
@@ -1,0 +1,220 @@
+/**
+ * The smoke turn's verdict: is this demo's agent BROKEN, or just SLOW?
+ *
+ * Stage 4 proves a generated demo's agent works by driving one real turn. The
+ * question that gate has to answer is whether the demo is broken — no tools, a
+ * tools file the runtime cannot parse, no model provider — and every one of those
+ * is a real bug it has caught. The question it must NOT answer is whether
+ * Anthropic was fast today.
+ *
+ * The gate used to answer only the second question. It was a single 180s
+ * wall-clock deadline, and these are the turn latencies measured on this machine
+ * against the deployed Cloud posture (see {@link observedSmokeLatenciesMs}):
+ *
+ *   run C  ramp-invoices        104_612ms  settled
+ *   run E  ramp-licenses        129_058ms  ERRORED ("the response didn't finish")
+ *   run D  ramp-reimbursements  135_675ms  settled
+ *   run 1  ramp-cards           165_121ms  settled   ← 14.9s under the deadline
+ *   run B  ramp-bills          ≥182_835ms  KILLED BY THE DEADLINE
+ *
+ * The deadline sat inside that distribution, so it was a coin flip: two of six
+ * runs died on demos that were otherwise fine, each costing ~18 minutes and ~$4.
+ *
+ * This module splits the one question into two. The signals that actually mean
+ * BROKEN are watched directly and fail in seconds — a hard error from the demo's
+ * own agent route, an errored turn — while a turn that is merely slow is allowed
+ * to finish inside a budget the measured distribution cannot reach. The clock is
+ * evidence of brokenness in exactly one case, and it is a narrow one: a turn that
+ * produced nothing at all, no stream and no tool call, for the whole budget.
+ */
+
+/** Every smoke-turn latency measured on a real run, in the order observed. The
+ *  budget below is derived from these, and a test holds it against them. */
+export const observedSmokeLatenciesMs = [104_612, 129_058, 135_675, 165_121, 182_835] as const;
+
+/**
+ * How long ONE smoke attempt may run.
+ *
+ * 2.3x the longest latency ever measured (182_835ms, itself a censored lower
+ * bound — that run was killed at the old deadline, not finished), and 4.0x the
+ * fastest. Against the three completed settles (mean 135.1s, sd 30.3s) it is
+ * mean + 9.4sd, so a healthy turn reaching it would be unlike anything yet
+ * observed — which is what makes hitting it a finding rather than a coin toss.
+ *
+ * Bounded from above by the pipeline's own 40-minute cap: the worst observed run
+ * (build 604s + assemble's install/manifest/build/boot ~300s + judge ~120s)
+ * leaves this much room and no more.
+ */
+export const smokeBudgetMs = 420_000;
+
+/**
+ * What the smoke turn observed about the demo's agent while the turn ran.
+ * LIVENESS ONLY — never what was generated. The frozen contract puts content in
+ * stage 5, so no field here may describe a view, a tool result or any prose.
+ */
+export interface SmokeProgress {
+  /** The demo's own agent route (`/api/vendo/<slug>/…`) answered at least once. */
+  doorAnswered: boolean;
+  /** That route's first hard error — a >= 400 status or a failed request. */
+  doorError?: string;
+  /** An assistant turn began streaming: the model produced bytes. */
+  turnStarted: boolean;
+  /**
+   * A tool call was seen in flight.
+   *
+   * TRUE is proof a tool call happened; FALSE is NOT proof none did. A settled
+   * tool call leaves no trace in the transcript at all (only errored ones do),
+   * so this can only ever catch calls that were still live when observed — hence
+   * it is read as one of two independent signs of life, never as a requirement.
+   */
+  toolCall: boolean;
+}
+
+/** A turn that showed no sign of life whatsoever. */
+export function noProgress(): SmokeProgress {
+  return { doorAnswered: false, turnStarted: false, toolCall: false };
+}
+
+/** The two in-page signs of life, read back after the turn. */
+export interface SmokeObserverApi {
+  snapshot(): { turnStarted: boolean; toolCall: boolean };
+  dispose(): void;
+}
+
+declare global {
+  interface Window {
+    __vendoSmoke?: SmokeObserverApi;
+  }
+}
+
+/**
+ * Watches the thread for the two signs that the demo's agent is alive, and is a
+ * MutationObserver rather than a poll for one specific reason: a settled tool
+ * call leaves no trace in the transcript, so the only window in which a tool
+ * call is visible is while it runs — and a fast one opens and closes between two
+ * 300ms polls. The observer sees the mutation itself, so it cannot miss one.
+ *
+ * Both flags are STICKY. The question is "did this agent ever do anything", and
+ * a turn that finishes must not erase the evidence that it ran.
+ *
+ * STRICTLY SELF-CONTAINED: Playwright serializes this function's SOURCE and
+ * evaluates it in the page, where nothing from this module exists. Every selector
+ * is therefore a literal inside the body — hoisting one to a module constant
+ * reads fine, typechecks fine, passes a jsdom test fine, and throws
+ * ReferenceError in the only place that matters.
+ */
+export function installSmokeObserverInPage(): void {
+  const doc = document;
+  const view = doc.defaultView ?? window;
+  view.__vendoSmoke?.dispose();
+
+  /** An assistant article attaches the moment a turn STARTS streaming. */
+  const assistantTurn = 'article[data-role="assistant"]';
+  /** The live status ribbon, present only while a tool call is in flight. */
+  const toolRibbon = ".fl-ribbon[data-vendo-tool]";
+
+  // Turns already on the page are not this turn's doing: demo:fix re-smokes a
+  // demo whose thread may already hold turns, and counting one of those would
+  // call a dead agent alive.
+  const before = doc.querySelectorAll(assistantTurn).length;
+  let turnStarted = false;
+  let toolCall = false;
+
+  const scan = (records: MutationRecord[]): void => {
+    if (doc.querySelectorAll(assistantTurn).length > before) turnStarted = true;
+    if (doc.querySelector(toolRibbon) !== null) toolCall = true;
+    // The added nodes themselves, not just the current document: a ribbon that
+    // was attached and detached inside one mutation batch is gone by the time
+    // this callback runs, and it is exactly the evidence being looked for.
+    for (const record of records) {
+      for (const node of Array.from(record.addedNodes)) {
+        if (!(node instanceof view.HTMLElement)) continue;
+        if (node.matches(assistantTurn)) turnStarted = true;
+        if (node.matches(toolRibbon) || node.querySelector(toolRibbon) !== null) toolCall = true;
+      }
+    }
+  };
+
+  const observer = new view.MutationObserver(scan);
+  observer.observe(doc.body, { childList: true, subtree: true, attributes: true, attributeFilter: ["data-vendo-tool", "data-role", "class"] });
+
+  view.__vendoSmoke = {
+    snapshot: () => ({ turnStarted, toolCall }),
+    dispose: () => observer.disconnect(),
+  };
+}
+
+/**
+ * - `settled` — the turn finished. The gate passes; content is stage 5's.
+ * - `broken`  — the demo's agent does not work. The gate fails.
+ * - `timeout` — the agent was alive and did not finish in the budget. The gate
+ *               still fails (a turn this slow is not demoable), but it is
+ *               reported as its own thing so nobody reads it as a broken demo.
+ */
+export type SmokeVerdict = "settled" | "broken" | "timeout";
+
+export interface SmokeOutcome {
+  verdict: SmokeVerdict;
+  /** One operator-readable clause. Always set unless the turn settled. */
+  reason?: string;
+  progress: SmokeProgress;
+  /**
+   * Whether ONE more attempt could plausibly change this verdict.
+   *
+   * True only for the outcomes a SIGNAL produced, which are the ones that arrive
+   * in seconds and can come from outside the demo (a transient inference failure
+   * killed run E at 129s on a demo that was fine). Never true for an outcome the
+   * CLOCK produced: that costs another whole budget and re-proves nothing.
+   */
+  retryable: boolean;
+}
+
+/**
+ * The whole broken-vs-slow decision, as a pure function of what was observed —
+ * so the distinction is pinned by unit tests instead of by a live model run.
+ */
+export function classifySmoke(observed: {
+  /** The turn settled: a new assistant turn arrived and the composer went idle. */
+  settled: boolean;
+  /** The wait hit its deadline. */
+  timedOut: boolean;
+  /** The visible error the turn surfaced, if it surfaced one. */
+  surfacedError?: string;
+  progress: SmokeProgress;
+}): SmokeOutcome {
+  const { progress } = observed;
+  // The door first: when the demo's own route answers 500, that IS the fault,
+  // and any alert the page went on to render is the same fault seen downstream.
+  if (progress.doorError !== undefined) {
+    return {
+      verdict: "broken",
+      reason: `the demo's agent route answered ${progress.doorError} — the generated demo's own door is failing, not the model`,
+      progress,
+      retryable: true,
+    };
+  }
+  if (observed.surfacedError !== undefined) {
+    return {
+      verdict: "broken",
+      reason: `the smoke turn surfaced an error: ${observed.surfacedError}`,
+      progress,
+      retryable: true,
+    };
+  }
+  if (observed.settled) return { verdict: "settled", progress, retryable: false };
+  const alive = progress.turnStarted || progress.toolCall;
+  if (!alive) {
+    return {
+      verdict: "broken",
+      reason: "the demo's agent never produced a turn — no stream ever started and no tool call was ever seen, so nothing proves this demo's agent runs at all",
+      progress,
+      retryable: false,
+    };
+  }
+  return {
+    verdict: "timeout",
+    reason: "the smoke turn did not finish in its budget, but the demo's agent was demonstrably running (it streamed and/or called a tool) — this is turn latency, not a broken demo",
+    progress,
+    retryable: false,
+  };
+}


### PR DESCRIPTION
## The defect

The assemble stage's smoke turn — one real agent turn proving a generated demo's
agent works — was gated on **one 180s wall-clock deadline**. Measured turn
latencies on this machine, against the deployed Cloud posture:

| run | slug | smoke turn | outcome |
|---|---|---|---|
| C | ramp-invoices | 104,612ms | settled |
| E | ramp-licenses | 129,058ms | **errored** ("the response didn't finish") |
| D | ramp-reimbursements | 135,675ms | settled |
| 1 | ramp-cards | 165,121ms | settled — 14.9s of headroom |
| B | ramp-bills | **≥182,835ms** | **killed by the deadline** |

The deadline sat *inside* the distribution, so it was a coin flip: two of six
runs died on demos that were otherwise fine, at ~18 minutes and ~$4 each. The
gate's purpose is to catch a demo whose agent is genuinely broken — no tools, an
unparseable tools file, no model provider, all real bugs it has caught. Its
purpose is not to enforce a latency SLA on the model provider.

## The gate now asks the two questions separately

**BROKEN** is decided by signals, not the clock:

- the request that runs the turn (`POST /api/vendo/<slug>/threads`) answering
  `>= 400`, or failing outright;
- the turn surfacing an error;
- the demo's page never getting as far as accepting a prompt;
- a tools file the runtime cannot parse — already caught by `gen-manifest`
  *before* the build, and now legible (see below).

**SLOW** gets room to finish: a **420s** turn budget. That is 2.3x the longest
latency ever measured (itself a censored lower bound — that run was killed, not
finished), and mean + 9.4sd over the completed settles. Bounded above by the
pipeline's own 40-minute cap. Reaching it is now a finding rather than a toss.

The clock is evidence of brokenness in exactly one narrow case: a turn that
produced no stream and no tool call for the whole budget.

### The two outcomes are reported as different things

Neither passes silently; both fail the run, with prose an operator cannot confuse
(`SmokeTimeoutError` vs `SmokeBrokenError`, plus a machine-readable `SMOKE:` line).
The Slack driver's existing `FAILED:` grep carries the distinction with no change
on its side:

```
FAILED: the smoke turn TIMED OUT after 420000ms — … the demo's agent was
        demonstrably running (it streamed and/or called a tool) — this is turn
        latency, not a broken demo

FAILED: the generated demo's agent is BROKEN — the demo's agent never produced a
        turn — no stream ever started and no tool call was ever seen …
```

### Liveness is observed, not polled

A settled tool call leaves **no** transcript trace, so the only window in which a
tool call is visible is while it runs — and a fast one opens and closes between
two 300ms polls. A `MutationObserver` sees the mutation itself. Its selectors are
literals *inside* the page function: a module-scope constant typechecks, passes a
jsdom test, and throws `ReferenceError` inside `page.evaluate` — proven, not
assumed (`02-why-selectors-are-inlined.log`).

### One bounded retry

Only for an outcome a **signal** produced, never the clock. Run E lost a fine demo
to a transient "the response didn't finish" at 129s; that is not the demo's bug,
and it is the one outcome a second attempt can clear. Cost: one extra turn against
the demo's own 20-turn cap, and seconds of wall clock, since these outcomes arrive
fast. A deadline is never retried — that would cost another whole budget and
re-prove nothing.

### The door is one request, deliberately

The first cut treated any `>= 400` under `/api/vendo/<slug>` as broken. That
would have failed **healthy** demos, on some machines only — the worst kind of
bug. `GET /connections` is polled **every 3s** and answers 402 whenever Cloud
connections are not composed; `GET /approvals/:id` 404 *is* the contracted
"expired" signal; `POST /approvals/decide` 409s on a normal race. The door is now
exactly the request that runs the turn. Caps refusals (429/410) are excluded for a
different reason: they mean the guard **worked**.

## Two other fixes, same PR

**`host-boot.ts` swallowed every gen-manifest cause.** It reported
`firstLine(stderr || stdout)`, which is the script's bare header — `[gen-manifest]
the demo folder contract is not honored:` — while every actual problem is on a
later line. A failed run reported a failure with *no reason*. Now the bounded,
scrubbed tail of both streams, as `buildHost` already did.

**A failed run poisoned the checkout.** `gen-manifest` validates EVERY demo folder
and writes nothing unless all pass, so one half-built leftover broke every
*subsequent* run — and the mini's checkout lives forever. Both `demo:pipeline` and
`demo:fix` now restore `demos/<slug>/` to its committed state on failure, copying
the wreckage outside the repo first. **git** decides what "clean" means, which is
what makes this safe for `demo:fix`: a failed fix **restores** a live demo's
committed folder rather than deleting it.

## Proof

Red-green for every fix. **+74 tests** (bench 491 total, was 417).

**The distinction, on the real host** — same gate, same browser, two conditions
(`08-broken-vs-slow-real-host.log`):

```
A · healthy demo, 20s budget   → timeout   22.4s   {turnStarted:true, toolCall:true}
B · invalid provider key       → broken    60.9s   {turnStarted:false, toolCall:false}
```

Under the old gate both were the single message `Timed out after 180000ms`.

Case B is how the **readiness phase** was found: sharing the turn budget, a
genuinely broken demo took the full 420s and threw a raw Playwright error instead
of a verdict — the very defect being fixed, reintroduced one layer up. Getting to
a prompt now has its own 60s budget. Measured: a healthy composer appears ~2s
after load (~30x headroom), and the broken page answers **200** while issuing
**zero** agent-route requests, so no faster signal exists — checking `GET /status`
would not have helped, it is never called (`10-broken-vs-healthy-network.log`).

**One real end-to-end pipeline run to a live demo** — `zelty-orders`, exit 0,
$2.38, smoke settled in **89,122ms** (now the low end of the pinned distribution):

```
[pipeline] assemble finished in 102923ms
SCORES: logo=FAIL palette=5 type=7 layout=8 copyTone=8
LIVE: https://host-production-b9a5.up.railway.app/zelty-orders
```

Verified in a real browser, page identity asserted before the shots were trusted:
HTTP 200 on both routes, Vendo composer mounted, all five beat chips present.

⚠️ `demos.vendo.run` currently 404s **every** slug, including ones verified as
serving earlier today — a pre-existing routing/cutover condition in front of the
`host` service, not caused here. Details and evidence in `PARKED.md`.

Evidence: `/tmp/factory-demo-rebuild/evidence/lane-smoke-gate/`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the assemble-stage smoke gate to tell a broken agent from a slow turn, with clear outcomes and a longer, evidence-based budget. Also improved failure reporting and cleaned up failed runs so they don’t poison future pipelines.

- **Bug Fixes**
  - Evidence-based smoke gate: classify BROKEN via agent-door errors, surfaced turn errors, or an unusable page; SLOW gets a 420s turn budget; added a 60s page-readiness budget before sending the prompt; narrowed the “door” to `POST /api/vendo/<slug>/threads`; added an in-page MutationObserver to detect stream/tool-call liveness reliably.
  - Reporting: distinct `SmokeBrokenError` vs `SmokeTimeoutError`, plus a machine-readable `SMOKE:` line; the gate only considers liveness (no content checks).
  - Retry policy: a single retry only for retryable signals (e.g., “response didn’t finish”); never retry deadlines.
  - Repo hygiene: `gen-manifest` now reports the bounded, scrubbed tail of stdout+stderr to show real causes; on any failure, move `demos/<slug>/` out of the repo and restore committed state to keep later runs clean (applies to the pipeline and `demo:fix`).

<sup>Written for commit 81ffd1eece0603702a12dd34b2070fed1301e48c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

