### PR TITLE
fix(demo-creator): the brief may use hexes the operator pinned in the notes

### DIFF
--- a/bench/src/demo-creator/brief.test.ts
+++ b/bench/src/demo-creator/brief.test.ts
@@ -108,6 +108,25 @@ describe("allowedPalette", () => {
     expect(new Set(palette).size).toBe(palette.length);
   });
 
+  // The prompt tells the model "OPERATOR NOTES — AUTHORITATIVE ... where one
+  // contradicts anything below, the operator's note WINS", and the closed
+  // palette is below that line. A prospect whose in-product palette differs
+  // from their marketing site (SWICH Merchant Portal: dark emerald portal,
+  // white/blue website) made the two instructions unsatisfiable — the brief
+  // obeyed the notes and the validator rejected every sample, twice, ending the
+  // run. Hexes the operator pinned in the notes ARE evidence, so they join the
+  // closed list; the anti-invention guarantee is unchanged.
+  it("admits hexes the operator pinned in the notes, ahead of the site evidence", () => {
+    const result = evidence();
+    const notes = "Dark portal. --color-bg: #0A0D0C; accent #10b981 (emerald).";
+    const palette = allowedPalette(result, notes);
+    expect(palette.slice(0, 2)).toEqual(["#0A0D0C", "#10B981"]);
+    expect(palette).toContain("#1E6BFF");
+    expect(new Set(palette).size).toBe(palette.length);
+    expect(paletteProvenance(result, notes).get("#0A0D0C")).toContain("operator notes");
+    expect([...paletteProvenance(result, notes).keys()]).toEqual(palette);
+  });
+
   it("carries the styleguide colours even when stage 1 did not fold them into palette", () => {
     const palette = allowedPalette(evidence({ palette: [] }));
     expect(palette).toContain("#1E6BFF");

--- a/bench/src/demo-creator/brief.ts
+++ b/bench/src/demo-creator/brief.ts
@@ -104,7 +104,7 @@ export interface BriefIo {
  * model literally cannot pick the real accent when stage 1's colour call failed
  * soft but the styleguide call did not.
  */
-function paletteSources(evidence: EvidenceResult): { hex: string; provenance: string }[] {
+function paletteSources(evidence: EvidenceResult, notes?: string): { hex: string; provenance: string }[] {
   const sources: { hex: string; provenance: string }[] = [];
   const seen = new Set<string>();
   const add = (value: string | undefined, provenance: string): void => {
@@ -114,6 +114,14 @@ function paletteSources(evidence: EvidenceResult): { hex: string; provenance: st
       sources.push({ hex, provenance });
     }
   };
+  // FIRST, because the prompt promises it: operator notes outrank everything
+  // below them, and the closed palette is below them. A prospect's in-product
+  // palette is routinely NOT their marketing site's (a dark portal behind a
+  // white .com), and context.dev can only measure the public page — so without
+  // this the brief is told to obey the notes and then rejected for doing it.
+  for (const value of notes?.match(/#[0-9a-fA-F]{6}\b|#[0-9a-fA-F]{3}\b/g) ?? []) {
+    add(value, "operator notes (pinned by the operator)");
+  }
   const styleguide = evidence.styleguide;
   add(styleguide?.colors.accent, "brand evidence (styleguide accent)");
   add(styleguide?.colors.background, "brand evidence (styleguide background)");
@@ -128,14 +136,14 @@ function paletteSources(evidence: EvidenceResult): { hex: string; provenance: st
 
 /** Every hex the brief is allowed to assign, in the order the prompt numbers
  * them: real brand hexes first, then the neutral ramp. */
-export function allowedPalette(evidence: EvidenceResult): string[] {
-  return paletteSources(evidence).map((source) => source.hex);
+export function allowedPalette(evidence: EvidenceResult, notes?: string): string[] {
+  return paletteSources(evidence, notes).map((source) => source.hex);
 }
 
 /** Human-readable source for each allowed hex, keyed and ordered exactly like
  * {@link allowedPalette} — BRIEF.md quotes these per token. */
-export function paletteProvenance(evidence: EvidenceResult): Map<string, string> {
-  return new Map(paletteSources(evidence).map((source) => [source.hex, source.provenance]));
+export function paletteProvenance(evidence: EvidenceResult, notes?: string): Map<string, string> {
+  return new Map(paletteSources(evidence, notes).map((source) => [source.hex, source.provenance]));
 }
 
 // ---------------------------------------------------------------------------
@@ -367,10 +375,10 @@ function parseEnum<T extends string>(value: unknown, allowed: readonly T[], fiel
 
 export function parseBriefReply(
   raw: string,
-  options: { prospect: string; palette: string[]; evidence: EvidenceResult },
+  options: { prospect: string; palette: string[]; evidence: EvidenceResult; notes?: string },
 ): { theme: DemoTheme; brief: BrandBrief } {
   const parsed = extractJsonObject(raw, "Brief");
-  const provenance = paletteProvenance(options.evidence);
+  const provenance = paletteProvenance(options.evidence, options.notes);
   const allowed = new Set(options.palette);
 
   const themeNotes: string[] = [];
@@ -553,7 +561,7 @@ export async function runBrief(args: BriefArgs, io: BriefIo): Promise<BriefResul
   // standalone/`demo:fix` path re-reads RESEARCH/evidence.json from disk.
   const evidence = io.evidence ?? await readEvidence(io.demosRepo, args.slug);
 
-  const palette = allowedPalette(evidence);
+  const palette = allowedPalette(evidence, args.notes);
   // The scraped site copy is stage 1 evidence too, and it is the only source
   // for vocabulary and voice — screenshots show structure, not register. A
   // missing/unreadable file is not worth failing a run over.
@@ -578,7 +586,7 @@ export async function runBrief(args: BriefArgs, io: BriefIo): Promise<BriefResul
     images.push({ label: `EVIDENCE — ${args.prospect}'s real logo (${evidence.logo.file})`, path: path.join(paths.root, evidence.logo.file) });
   }
 
-  const parseOptions = { prospect: args.prospect, palette, evidence };
+  const parseOptions = { prospect: args.prospect, palette, evidence, ...(args.notes === undefined ? {} : { notes: args.notes }) };
   let parsed: { theme: DemoTheme; brief: BrandBrief };
   try {
     parsed = parseBriefReply(await model(prompt, images), parseOptions);


### PR DESCRIPTION
## The bug

Operator notes are **documented as authoritative** in the brief prompt, but the
validator only admitted hexes context.dev measured from the prospect's
**marketing site**. So **any** prospect whose product UI is a different palette
from their marketing site — a dark app behind a light site, which is extremely
common — has its operator-pinned theme silently rejected, and the run dies at the
brief stage with **no demo at all**.

That is the bug. "`numbers` didn't build" is only how it was noticed.

`brief.ts` gives the vision call two instructions that cannot both be obeyed.

The prompt promises the operator outranks everything:

> OPERATOR NOTES — AUTHORITATIVE. Established facts about this product, not
> suggestions. **Where one contradicts anything below, the operator's note WINS**

The closed-palette section sits *below* that line:

> Below is the CLOSED list of hexes you may use. … A hex that is not on this list
> is rejected outright.

But the closed list is built only from what context.dev could measure on the
prospect's **public marketing site**. So when a prospect's in-product palette is
not their website's palette, the model is told to follow the notes and then
rejected for following them.

## How it surfaced

Regenerating the `numbers` demo (the last slug blocking the demos.vendo.run
cutover). The product is the **SWICH Merchant Portal** — a near-black, emerald
portal — behind the white-and-blue `numbers.pk` marketing site. context.dev could
only ever offer:

```
#2878BD  #FFFFFF  #0D2240  #268BCB  #545454  #2A2A2A
```

The operator notes pinned the portal's real palette (recovered verbatim from the
original build's `globals.css`: `#0A0D0C` bg, `#121614` surface, `#10B981`
emerald accent). The brief obeyed the notes; the validator rejected it; the
single reroll was rejected identically; the run ended at stage 2 with no demo:

```
FAILED: brief: the reroll was rejected too — Brief output rejected: theme colour
"background" is "#0A0D0C", which is not in the evidence palette — the brief may
only assign hexes it was given
```

This is not specific to `numbers`. Any prospect with a dark product behind a
light marketing site — a common shape for fintech and developer tools — is
unbuildable by this pipeline today, and fails after burning both vision calls.

## The fix

Hexes the operator pinned in `--notes` join the closed list, ranked first
(the prompt already numbers the list and ranks the notes first).

The anti-invention guarantee is untouched: the model still cannot invent a
colour, it may only copy one it was given. The list simply now includes the
evidence the operator supplied, alongside the evidence context.dev measured.
`BRIEF.md` reports the new provenance per token, so a reader can still see where
every hex came from:

```
- accent: #10B981 — operator notes (pinned by the operator) · Emerald is the
  portal's action colour — filled KPI card, Generate button, active nav, chart line.
```

## Verification

- New test in `brief.test.ts` written first and watched fail for the right
  reason (`expected [ '#1E6BFF', '#FFFFFF' ] to deeply equal [ '#0A0D0C', '#10B981' ]`),
  then pass.
- `pnpm build && pnpm test && pnpm typecheck && pnpm lint` all green; full suite
  run twice.
- Proven end to end on a real run: the rerun produced `theme.json` matching the
  original build's `globals.css` hex for hex, 8/8, and shipped a live demo.
