### PR TITLE
fix(cli): a model's own explanation cannot cost a surface its extraction draft

### DIFF
--- a/packages/vendo/src/cli/enrich/engine.ts
+++ b/packages/vendo/src/cli/enrich/engine.ts
@@ -41,7 +41,10 @@ export const enrichmentToolProposalSchema = z.object({
   disabled: z.boolean().optional(),
   audience: z.enum(["end-user", "operator", "internal"]).optional(),
   semantics: z.record(fieldSemanticSchema).optional(),
-  reasoning: z.string().max(500).optional(),
+  /** Narration for the operator — never persisted, never read by code. Clamped
+   *  rather than rejected for the same reason as the extraction draft's field:
+   *  an over-long explanation must not invalidate sound judgment. */
+  reasoning: z.string().optional().transform((value) => value?.slice(0, 500)),
 });
 export type EnrichmentToolProposal = z.infer<typeof enrichmentToolProposalSchema>;
 

--- a/packages/vendo/src/cli/enrich/prompts.ts
+++ b/packages/vendo/src/cli/enrich/prompts.ts
@@ -37,6 +37,7 @@ export const ENRICHMENT_OUTPUT_RULES = [
   '  | { "kind": "date", "format": "iso"|"epoch" } | { "kind": "enum", "labels": {value: label} }',
   '  | { "kind": "id", "entity"? } | { "kind": "percent", "scale": "ratio"|"0-100" } |',
   '  { "kind": "plain" }. Only include fields you read evidence for in the handler code/types.',
+  "- reasoning: one short sentence on why you graded the tool this way. <= 500 chars (it is truncated there).",
   "- narrative: a short human-readable story of what changed and what you updated — new tools,",
   "  reclassified tools, anything suspicious. Plain prose, <= 30 lines.",
 ].join("\n");

--- a/packages/vendo/src/cli/extract/harness.ts
+++ b/packages/vendo/src/cli/extract/harness.ts
@@ -20,7 +20,11 @@ export const draftToolSchema = z.object({
   /** Who the handler's own auth admits; non-end-user grades exclude the tool
    *  by default (applyDraft). */
   audience: z.enum(["end-user", "operator", "internal"]).optional(),
-  reasoning: z.string().max(500).optional(),
+  /** Why the model graded the tool this way — narration for the operator, never
+   *  persisted and never read by code. Bounded so a model cannot spend a page on
+   *  it, but CLAMPED rather than rejected: a long explanation is the one thing
+   *  here that must not cost a surface its whole draft. */
+  reasoning: z.string().optional().transform((value) => value?.slice(0, 500)),
 });
 export type DraftTool = z.infer<typeof draftToolSchema>;
 

--- a/packages/vendo/src/cli/extract/stages.test.ts
+++ b/packages/vendo/src/cli/extract/stages.test.ts
@@ -152,6 +152,76 @@ describe("runStagedExtraction", () => {
     expect(await readArtifact(root, "draft.admin")).toMatchObject({ stage: "draft.admin", error: "rate limited" });
   });
 
+  // Nightly QA 2026-07-28: a real `vendo init` against fixtures/host-app lost 3
+  // of 4 surfaces AND the whole cross-check to this, on drafts whose judgment was
+  // entirely sound — the model simply explained itself at 540–1046 chars. The
+  // field is narration: never persisted to tools.json, never read by any code.
+  // Losing a surface's risk grades over it is the tail wagging the dog.
+  it("an over-long reasoning is clamped, never fatal — the surface keeps its judgment", async () => {
+    const root = await fixture();
+    const { harness } = scriptedHarness((stage, input) => {
+      if (stage === "survey") return SURVEY;
+      if (stage === "draft") {
+        return { tools: draftFor(input.instructions).tools.map((tool) => ({
+          ...tool,
+          risk: "destructive" as const,
+          critical: true,
+          reasoning: "x".repeat(900),
+        })) };
+      }
+      if (stage === "cross-check") return { tools: [] };
+      return { brief: "b" };
+    });
+    const result = await runStagedExtraction({ root, env: {}, harness, tools: TOOLS, appName: "maple" });
+
+    expect(result.notes).toEqual([]);
+    expect(result.draft.tools).toHaveLength(3);
+    // The judgment that actually matters survived, and the narration was cut to
+    // the bound rather than taking the draft down with it.
+    expect(result.draft.tools.every((tool) => tool.risk === "destructive" && tool.critical === true)).toBe(true);
+    expect(result.draft.tools.every((tool) => tool.reasoning?.length === 500)).toBe(true);
+  });
+
+  it("an over-long reasoning does not sink the cross-check amendments either", async () => {
+    const root = await fixture();
+    const { harness } = scriptedHarness((stage, input) => {
+      if (stage === "survey") return SURVEY;
+      if (stage === "draft") return draftFor(input.instructions);
+      if (stage === "cross-check") {
+        return { tools: [{
+          name: "host_admin_reset",
+          description: "amended: wipes every invoice",
+          risk: "destructive" as const,
+          critical: true,
+          reasoning: "y".repeat(1046),
+        }] };
+      }
+      return { brief: "b" };
+    });
+    const result = await runStagedExtraction({ root, env: {}, harness, tools: TOOLS, appName: "maple" });
+
+    expect(result.notes).toEqual([]);
+    expect(result.draft.tools.find((tool) => tool.name === "host_admin_reset")).toMatchObject({
+      description: "amended: wipes every invoice",
+      critical: true,
+    });
+  });
+
+  it("names the reasoning bound in the draft and cross-check instructions", async () => {
+    const root = await fixture();
+    const { harness, runs } = scriptedHarness((stage, input) => {
+      if (stage === "survey") return SURVEY;
+      if (stage === "draft") return draftFor(input.instructions);
+      if (stage === "cross-check") return { tools: [] };
+      return { brief: "b" };
+    });
+    await runStagedExtraction({ root, env: {}, harness, tools: TOOLS, appName: "maple" });
+    // A cap the model is never told about is a cap it cannot honor.
+    for (const stage of ["draft", "cross-check"]) {
+      expect(runs.find((run) => run.stage === stage)?.input.instructions).toContain("<= 500 chars");
+    }
+  });
+
   it("throws naming the stage when every surface pass fails", async () => {
     const root = await fixture();
     const { harness } = scriptedHarness((stage) => (stage === "survey" ? SURVEY : new Error("model unreachable")));

--- a/packages/vendo/src/cli/extract/stages.ts
+++ b/packages/vendo/src/cli/extract/stages.ts
@@ -146,6 +146,7 @@ export function composeInstructions(
     "  \"operator\" (admin/staff/support consoles), or \"internal\" (machine-to-machine: webhooks, cron, reconciliation,",
     "  service tokens). Read the auth checks, not the route name. When unsure, default to internal — non-end-user",
     "  tools are excluded from the embedded agent by default, and a wrong \"end-user\" grade exposes a privileged surface.",
+    "- reasoning: one short sentence on why you graded the tool this way. <= 500 chars (it is truncated there).",
     "- missedSurfaces: API surfaces you found that the list is missing (path + one line). Do not invent tools for them.",
   ].join("\n");
 }
@@ -171,6 +172,7 @@ function composeCrossCheckInstructions(
     '  { "tools": [{ "name", "description", "risk"?, "critical"?, "disabled"?, "reasoning"? }] }',
     "- Return ONLY the entries you want to AMEND. Entries you omit stand as drafted; you cannot remove a tool. Use only names from the combined draft.",
     "- Same rules as drafting: risk may be RAISED, never lowered; mark irreversible operations critical: true.",
+    "- reasoning: one short sentence per amendment. <= 500 chars (it is truncated there).",
   ].join("\n");
 }
 


### PR DESCRIPTION
Found by the nightly demo-QA rig (`eng-nightly-demo-qa`, 2026-07-28) while running the README quickstart as a new user.

## What broke

`npx vendo init --ai-polish` against a bare Next host lost **3 of 4 surfaces and the entire cross-check pass**. Every drafted grade was sound — the model just explained itself at 540–1046 chars in `reasoning`, which `draftToolSchema` caps at `max(500)`. One over-long advisory string throws the whole surface's parse, and `runStagedExtraction` degrades it to *"its N tools keep extractor defaults"*.

Net: **7 of 12 tools enriched, exit 0**, and the only trace is a soft note most people will scroll past.

From tonight's saved stage artifacts (`.vendo/data/extract/`) — every failure is *only* the advisory field, every `description` well inside its own 500 cap:

```
draft.customers.json        host_listCustomers           reasoning=686  description=195
draft.auth-session.json     host_login_create            reasoning=688  description=186
draft.reports-exports.json  host_reports_summary_list    reasoning=775  description=199
cross-check.json            host_downloadInvoicesArchive reasoning=1046 description=312  risk=destructive
```

That last row is the sharpest edge: the cross-check wanted to raise `host_downloadInvoicesArchive` to `destructive`, and the amendment was discarded over its explanation's length.

## Why this is the wrong trade

`reasoning` is narration. It is **never persisted** to `tools.json` (`proposalFields` in `enrich/engine.ts` doesn't carry it) and **no code reads it** anywhere in the repo. Losing a surface's risk and audience judgment over how verbose the model was about it is the tail wagging the dog — and it contradicts the posture documented right above these schemas, where unknown keys strip and invented skeleton fields are *"ignored rather than fatal"*.

## The fix

Two changes, because the cap had two distinct problems:

1. **The prompts never named the bound.** `description` is spelled out (`<= 200 chars`); `reasoning` was not — a cap the model had no way to honor. Now named in the draft, cross-check, and sync-enrichment rules.
2. **The bound clamps instead of rejecting**, in both the extraction draft schema and the sync enrichment schema. A model that still overshoots gets truncated rather than taking sound judgment down with it.

## Verification

`fixtures/host-app`, stripped to a genuinely bare host (`rm -rf src/vendo src/app/api/vendo` — the fixture ships pre-wired), run through the real CLI with a live model:

| | before (npm `0.5.0`) | after |
|---|---|---|
| surfaces skipped | 3 of 4 | **0** |
| cross-check | failed | **ok** |
| tools enriched | 7 of 12 | **12 of 12** |

**Being precise about what did the work:** the live run improved because of the *prompt* change — told the bound, the model wrote 114–449 chars and nothing needed clamping. The clamp is the belt for when a model overshoots anyway, and that half is covered by unit tests: 900- and 1046-char `reasoning` values that were previously fatal now truncate to 500 with the surface's `risk`/`critical` judgment intact. Both live runs are real model calls, so the survey partitioned surfaces differently between them; the controlled evidence for the clamp is the tests, not the A/B.

New tests fail without the src change (3 failed / 19 passed) and pass with it (22/22).

## Gates

All green on this branch, under Node 24 (the mini's default Node 26 produces spurious `@vendoai/ui` failures):

- `CI=true pnpm build` — 23/23
- `pnpm test` — 53/53
- `CI=true pnpm typecheck` — 41/41
- `CI=true pnpm lint` — 6/6

No UI surface is touched, so there are no browser screenshots for this change; the CLI evidence above is the A/B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops surfaces from being dropped during extraction when the model’s `reasoning` runs long by truncating it to 500 chars and telling the model about the limit. Cross-check amendments and risk/audience judgments now survive.

- **Bug Fixes**
  - Clamp `reasoning` to 500 chars in extraction and sync enrichment (`draftToolSchema`, `enrichmentToolProposalSchema`) so narration never invalidates a draft.
  - Update drafting, cross-check, and enrichment prompts to state the 500-char `reasoning` limit, reducing overshoots.

<sup>Written for commit 1007087beed503b93e2317e54d45b66ce49caa36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

