### PR TITLE
fix(bench): a settled smoke turn is not a working demo — its API has to answer

### DIFF
--- a/bench/src/demo-creator/assemble.test.ts
+++ b/bench/src/demo-creator/assemble.test.ts
@@ -2,13 +2,13 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { runAssemble, SmokeBrokenError, SmokeTimeoutError, type AssembleIo } from "./assemble.js";
+import { runAssemble, SmokeBrokenError, SmokeTimeoutError, SmokeToolsUnreachableError, type AssembleIo } from "./assemble.js";
 import type { ExecFn, ExecResult } from "./exec.js";
-import type { RunningHost, SmokeTurnFn } from "./host-boot.js";
+import { localBootEnv, type RunningHost, type SmokeTurnFn } from "./host-boot.js";
 import { classifySmoke, noProgress, smokeBudgetMs, type SmokeProgress } from "./smoke.js";
 
 /** The shape of every healthy turn: the door answered, the model streamed. */
-const alive: SmokeProgress = { doorAnswered: true, turnStarted: true, toolCall: true };
+const alive: SmokeProgress = { doorAnswered: true, turnStarted: true, toolCall: true, hostToolAnswered: true };
 
 /** Smoke turns expressed the way the real one reports: an outcome, not a throw. */
 const settles: SmokeTurnFn = async () => classifySmoke({ settled: true, timedOut: false, progress: alive });
@@ -24,14 +24,27 @@ const manifestPath = (demosRepo: string): string =>
   path.join(demosRepo, "host", "src", "generated", "manifest.ts");
 
 /** A vendo-demos checkout whose manifest imports `slugs`; `installed` seeds
- * host/node_modules so the install step can be observed being skipped. */
-async function fakeDemosRepo(options: { slugs: string[]; installed?: boolean }): Promise<string> {
+ * host/node_modules so the install step can be observed being skipped. Each slug
+ * gets a tools.json, because stage 4 reads it to learn which tool names belong to
+ * the demo's OWN API — the ones the smoke turn must see answer. */
+async function fakeDemosRepo(options: {
+  slugs: string[];
+  installed?: boolean;
+  tools?: unknown;
+}): Promise<string> {
   const demosRepo = await mkdtemp(path.join(tmpdir(), "vendo-assemble-"));
   await mkdir(path.dirname(manifestPath(demosRepo)), { recursive: true });
   await writeFile(
     manifestPath(demosRepo),
     options.slugs.map((slug) => `import s from "../../../demos/${slug}/screens/index.js";`).join("\n"),
   );
+  for (const slug of new Set([...options.slugs, args.slug])) {
+    const demo = path.join(demosRepo, "demos", slug);
+    await mkdir(demo, { recursive: true });
+    await writeFile(path.join(demo, "tools.json"), JSON.stringify(options.tools ?? {
+      tools: [{ name: "host_listInvoices", binding: { kind: "openapi", method: "GET", path: "/api/invoices" } }],
+    }));
+  }
   if (options.installed === true) await mkdir(path.join(demosRepo, "host", "node_modules"), { recursive: true });
   return demosRepo;
 }
@@ -142,7 +155,10 @@ describe("runAssemble", () => {
     const result = await runAssemble(args, io(demosRepo, { boot: async () => host, smokeTurn: settles }));
     // Everything the gate is told about the turn — no view, no text, no tool
     // result. A gate that cannot see content cannot start judging it.
-    expect(Object.keys(result.smoke.progress).sort()).toEqual(["doorAnswered", "toolCall", "turnStarted"]);
+    // `hostToolAnswered` is a fact about the wire (did the API answer), never
+    // about what came back over it.
+    expect(Object.keys(result.smoke.progress).sort())
+      .toEqual(["doorAnswered", "hostToolAnswered", "toolCall", "turnStarted"]);
     expect(result.smoke).toEqual({
       prompt: args.smokePrompt,
       ms: expect.any(Number),
@@ -237,6 +253,152 @@ describe("runAssemble — the smoke gate tells BROKEN from SLOW", () => {
     const broken = await runAssemble(args, io(demosRepo, { smokeTurn: deadAgent })).catch((error: unknown) => error as Error);
     expect(timeout.message).not.toBe(broken.message);
     expect(broken.message).toMatch(/broken/i);
+  });
+});
+
+/**
+ * THE BLIND SPOT. A demo shipped that served 200, had a pixel-accurate palette
+ * and zero console errors — and every agent tool 404'd, so it could not answer a
+ * single question. The gate passed because the agent behaved WELL: it retried,
+ * diagnosed the 404s and honestly refused rather than fabricating an answer. The
+ * turn SETTLED, and settled was all the gate checked.
+ */
+describe("runAssemble — a demo whose own API never answered its agent", () => {
+  const unreachable: SmokeTurnFn = async () => classifySmoke({
+    settled: true,
+    timedOut: false,
+    progress: {
+      doorAnswered: true,
+      turnStarted: true,
+      toolCall: true,
+      hostToolAnswered: false,
+      hostToolProblem: `host_listInvoices → GET /api/acme/invoices → 404: {"error":{"message":"Not found"}}`,
+    },
+  });
+
+  it("fails a settled turn whose tools never answered, as its own verdict", async () => {
+    const demosRepo = await fakeDemosRepo({ slugs: ["acme"], installed: true });
+    const { host, stop } = fakeHost();
+    const lines: string[] = [];
+    const thrown = await runAssemble(args, io(demosRepo, {
+      boot: async () => host,
+      smokeTurn: unreachable,
+      write: (line) => lines.push(line),
+    })).catch((error: unknown) => error as Error);
+    expect(thrown).toBeInstanceOf(SmokeToolsUnreachableError);
+    expect(thrown).not.toBeInstanceOf(SmokeBrokenError);
+    expect(thrown).not.toBeInstanceOf(SmokeTimeoutError);
+    expect(lines.some((line) => line.startsWith("SMOKE: TOOLS-UNREACHABLE"))).toBe(true);
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * CAUSE-AGNOSTIC, deliberately. The 404s that motivated this gate were first
+   * diagnosed as a path-shape bug and were nothing of the kind — the real fault
+   * was a wire origin pointing at another host, and the runtime's own error clause
+   * reports a method, a path and a status but NEVER the origin. A message that
+   * named a suspected culprit sent a diagnosis down the wrong road for hours, so
+   * this one reports the request, the response and the origin the demo was served
+   * on, and names no cause at all.
+   */
+  it("reports the failing request, its response, and the origin — and blames nothing", async () => {
+    const demosRepo = await fakeDemosRepo({ slugs: ["acme"], installed: true });
+    const { host } = fakeHost();
+    const thrown = await runAssemble(args, io(demosRepo, { boot: async () => host, smokeTurn: unreachable }))
+      .catch((error: unknown) => error as Error);
+    // The request and the response the runtime actually saw.
+    expect(thrown.message).toContain("host_listInvoices");
+    expect(thrown.message).toContain("GET /api/acme/invoices");
+    expect(thrown.message).toContain("404");
+    // The origin, which the runtime's clause never carries — without it a reader
+    // cannot tell a wrong path from a wrong host.
+    expect(thrown.message).toContain(host.baseUrl);
+    // No guesses. Not the openapi file, not the routes file, not a convention.
+    expect(thrown.message).not.toMatch(/openapi|routes\.ts|check your/i);
+  });
+
+  it("hands the smoke turn the names of the demo's OWN tools, read from its tools.json", async () => {
+    const demosRepo = await fakeDemosRepo({
+      slugs: ["acme"],
+      installed: true,
+      tools: {
+        tools: [
+          { name: "host_listWidgets", binding: { kind: "openapi", method: "GET", path: "/api/widgets" } },
+          { name: "slack_SLACK_SEND_MESSAGE", binding: { kind: "connector" } },
+        ],
+      },
+    });
+    let given: readonly string[] | undefined;
+    const result = await runAssemble(args, io(demosRepo, {
+      smokeTurn: async (options) => {
+        given = options.hostToolNames;
+        return classifySmoke({ settled: true, timedOut: false, progress: alive });
+      },
+    }));
+    // Only the tools that execute against the demo's own API; a connector tool
+    // talks to Composio and could never prove this demo's API answers.
+    expect(given).toEqual(["host_listWidgets"]);
+    await result.host.stop();
+  });
+
+  // The known data-binding gaps must still ship. This gate asks whether the API
+  // answered, never what it answered with.
+  it("still passes a demo whose API answered but whose turn generated nothing", async () => {
+    const demosRepo = await fakeDemosRepo({ slugs: ["acme"], installed: true });
+    const result = await runAssemble(args, io(demosRepo, {
+      smokeTurn: async () => classifySmoke({
+        settled: true,
+        timedOut: false,
+        progress: { doorAnswered: true, turnStarted: true, toolCall: false, hostToolAnswered: true },
+      }),
+    }));
+    expect(result.smoke.verdict).toBe("settled");
+    await result.host.stop();
+  });
+});
+
+/**
+ * The wire origin — `VENDO_BASE_URL` — is the base every openapi tool binding is
+ * resolved against. Set to a hostname that resolved to the old router, it 404'd
+ * every tool call on every demo on the fleet while every page kept rendering, and
+ * no page-level check saw it. The cutover runbook tells operators to export that
+ * exact variable.
+ */
+describe("runAssemble — the wire origin belongs to the host being booted", () => {
+  it("boots the local host on its own origin even when the environment names another", async () => {
+    const demosRepo = await fakeDemosRepo({ slugs: ["acme"], installed: true });
+    const booted: NodeJS.ProcessEnv[] = [];
+    const boot: NonNullable<AssembleIo["boot"]> = async (options) => {
+      booted.push(localBootEnv(options.env ?? {}, options.port));
+      return fakeHost().host;
+    };
+    const result = await runAssemble(args, io(demosRepo, {
+      boot,
+      env: { VENDO_BASE_URL: "https://demos.vendo.run" },
+    }));
+    expect(booted[0]?.VENDO_BASE_URL).toBe("http://127.0.0.1:4311");
+    await result.host.stop();
+  });
+
+  it("says out loud that it had to override the environment's wire origin", async () => {
+    const demosRepo = await fakeDemosRepo({ slugs: ["acme"], installed: true });
+    const lines: string[] = [];
+    const result = await runAssemble(args, io(demosRepo, {
+      env: { VENDO_BASE_URL: "https://demos.vendo.run" },
+      write: (line) => lines.push(line),
+    }));
+    const complaint = lines.find((line) => line.includes("WIRE ORIGIN"));
+    expect(complaint).toContain("https://demos.vendo.run");
+    expect(complaint).toContain("http://127.0.0.1:4311");
+    await result.host.stop();
+  });
+
+  it("stays quiet when the environment names no foreign wire origin", async () => {
+    const demosRepo = await fakeDemosRepo({ slugs: ["acme"], installed: true });
+    const lines: string[] = [];
+    const result = await runAssemble(args, io(demosRepo, { env: {}, write: (line) => lines.push(line) }));
+    expect(lines.some((line) => line.includes("WIRE ORIGIN"))).toBe(false);
+    await result.host.stop();
   });
 });
 

--- a/bench/src/demo-creator/assemble.ts
+++ b/bench/src/demo-creator/assemble.ts
@@ -1,7 +1,8 @@
 import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { hostDir } from "./demo-folder.js";
+import { demoPaths, hostDir } from "./demo-folder.js";
 import { defaultExec, firstLine, type ExecFn } from "./exec.js";
 import {
   bootHost,
@@ -9,6 +10,7 @@ import {
   defaultHostCommands,
   defaultSmokeTurn,
   generateManifest,
+  inheritedWireOrigin,
   type HostCommands,
   type RunningHost,
   type SmokeTurnFn,
@@ -18,14 +20,22 @@ import { smokeBudgetMs, type SmokeOutcome, type SmokeProgress, type SmokeVerdict
 /**
  * Stage 4 — assemble. The gate that keeps a broken demo off demos.vendo.run:
  * the host must discover the new demo, compile it, boot, and survive ONE real
- * agent turn. The turn's CONTENT is not judged here (that is stage 5) — only
- * hard failure.
+ * agent turn whose tool calls the demo's own API actually answered. The turn's
+ * CONTENT is not judged here (that is stage 5) — only hard failure.
  *
- * "Hard failure" is the whole subtlety, and it used to be one 180s deadline. See
- * smoke.ts for the measured latencies that made that a coin flip; this stage now
- * asks the two questions separately — is the agent BROKEN (fail on the signal, in
- * seconds), or merely SLOW (let it finish inside a budget healthy turns cannot
- * reach) — and reports the two outcomes as different things.
+ * "Hard failure" is the whole subtlety. It used to be one 180s deadline; see
+ * smoke.ts for the measured latencies that made that a coin flip. Then it was
+ * "the turn settled", and a demo shipped that served 200, had a pixel-accurate
+ * palette and zero console errors while every single agent tool 404'd — the gate
+ * passed because the agent behaved WELL, retrying, diagnosing the 404s and
+ * honestly refusing. So the turn settled, and settled was all the gate checked.
+ *
+ * Three questions now, asked separately and reported as different things:
+ *   BROKEN            — the agent does not work. Fails on the signal, in seconds.
+ *   SLOW              — alive, unfinished inside a budget healthy turns cannot
+ *                       reach. Still fails, but never as a broken demo.
+ *   TOOLS-UNREACHABLE — the turn finished and the demo's own API never answered
+ *                       one of its own agent's tool calls.
  */
 
 export interface AssembleArgs {
@@ -87,9 +97,59 @@ export class SmokeTimeoutError extends Error {
   }
 }
 
+/**
+ * The turn finished and the demo's own API never answered it. Its own class
+ * because it is neither of the other two: the agent runs, the page renders, the
+ * clock was fine — the demo simply cannot answer anything.
+ *
+ * The message NAMES NO CAUSE, on purpose. These 404s were first diagnosed as a
+ * path-shape defect in the generated openapi.json and were nothing of the kind:
+ * the real fault was the host's wire origin pointing at another hostname, and
+ * every tool call on every demo on the fleet was 404ing. The runtime's own error
+ * clause reports a method, a path and a status but never the ORIGIN, which is
+ * exactly how a wrong host reads like a wrong path. So this carries the request,
+ * the response and the origin the demo was served on, and lets the reader
+ * diagnose from evidence instead of from a guess.
+ */
+export class SmokeToolsUnreachableError extends Error {
+  constructor(reason: string, baseUrl: string, readonly progress: SmokeProgress) {
+    super(`the generated demo's TOOLS ARE UNREACHABLE — ${reason}. The demo's own API was served at ${baseUrl}; the clause above carries a path and a status but not the origin the call was sent to, so both are worth checking`);
+    this.name = "SmokeToolsUnreachableError";
+  }
+}
+
 /** A cold `pnpm install` + `next build` runs for minutes. Generous but bounded:
  * a hang has to surface as a failure, not eat the whole pipeline budget. */
 const bootTimeoutMs = 180_000;
+
+/**
+ * The names of the tools that execute against the DEMO'S OWN API — the only ones
+ * whose success proves this demo can answer a question.
+ *
+ * Read from the demo's tools.json (what the host actually hands its agent), and
+ * filtered to openapi bindings: a connector tool talks to Composio and a Vendo
+ * tool to the runtime, so neither could ever prove the demo's API answered.
+ * Missing or unreadable is not this function's error to raise — gen-manifest
+ * validates the folder contract, and an empty list simply proves nothing, which
+ * the smoke verdict then says out loud.
+ */
+async function hostToolNames(demosRepo: string, slug: string): Promise<string[]> {
+  const source = await readFile(demoPaths(demosRepo, slug).tools, "utf8").catch(() => undefined);
+  if (source === undefined) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch {
+    return [];
+  }
+  const tools = (parsed as { tools?: unknown } | null)?.tools;
+  if (!Array.isArray(tools)) return [];
+  return tools
+    .filter((tool): tool is { name: string } =>
+      (tool as { binding?: { kind?: unknown } } | null)?.binding?.kind === "openapi"
+      && typeof (tool as { name?: unknown }).name === "string")
+    .map((tool) => tool.name);
+}
 
 export async function runAssemble(args: AssembleArgs, io: AssembleIo): Promise<AssembleResult> {
   const exec = io.exec ?? defaultExec;
@@ -101,6 +161,16 @@ export async function runAssemble(args: AssembleArgs, io: AssembleIo): Promise<A
   const host = path.join(io.demosRepo, hostDir);
   const signalOption = io.signal === undefined ? {} : { signal: io.signal };
   const envOption = io.env === undefined ? {} : { env: io.env };
+
+  // The wire origin is where every one of the demo's tool calls is SENT. A local
+  // boot's only correct one is itself, and localBootEnv makes that true by
+  // construction — but silently correcting it would hide the shape of a fault
+  // that 404'd every tool call on the whole fleet while every page still
+  // rendered. So when the environment was carrying another one, say so.
+  const foreign = inheritedWireOrigin(io.env ?? process.env, args.port);
+  if (foreign !== undefined) {
+    write(`[assemble] WIRE ORIGIN: the environment sets VENDO_BASE_URL=${foreign}, which is not the host this run boots — every one of the demo's tool calls would have left this machine and been answered by whatever is there. The local boot uses its own origin (http://127.0.0.1:${args.port}) instead.`);
+  }
 
   // Installing costs minutes and the checkout is long-lived, so it happens only
   // when the host has never been installed. Lane 6's push is what changes deps,
@@ -150,12 +220,17 @@ export async function runAssemble(args: AssembleArgs, io: AssembleIo): Promise<A
     ...envOption,
   }));
 
+  // Which tool names count as the demo's OWN, so the smoke turn can tell "the
+  // demo's API answered" from "the runtime's own tools ran".
+  const ownTools = await hostToolNames(io.demosRepo, args.slug);
+
   const startedAt = Date.now();
   const attempt = async (): Promise<SmokeOutcome> => await runStage("assemble:smoke", async () => await smokeTurn({
     baseUrl: running.baseUrl,
     slug: args.slug,
     prompt: args.smokePrompt,
     timeoutMs: smokeBudgetMs,
+    hostToolNames: ownTools,
   }));
 
   let outcome: SmokeOutcome;
@@ -186,9 +261,10 @@ export async function runAssemble(args: AssembleArgs, io: AssembleIo): Promise<A
     // caller only ever logs the failure's first sentence.
     write(`SMOKE: ${outcome.verdict.toUpperCase()} after ${ms}ms on ${attempts} attempt(s) — ${outcome.reason ?? "no reason recorded"}`);
     await running.stop();
-    throw outcome.verdict === "timeout"
-      ? new SmokeTimeoutError(ms, outcome.reason ?? "no reason recorded", outcome.progress)
-      : new SmokeBrokenError(outcome.reason ?? "no reason recorded", outcome.progress);
+    const reason = outcome.reason ?? "no reason recorded";
+    if (outcome.verdict === "timeout") throw new SmokeTimeoutError(ms, reason, outcome.progress);
+    if (outcome.verdict === "tools-unreachable") throw new SmokeToolsUnreachableError(reason, running.baseUrl, outcome.progress);
+    throw new SmokeBrokenError(reason, outcome.progress);
   }
 
   write(`[assemble] smoke turn settled in ${ms}ms — host still running at ${running.baseUrl} (caller owns stop())`);

--- a/bench/src/demo-creator/host-boot.test.ts
+++ b/bench/src/demo-creator/host-boot.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { ExecFn, ExecResult } from "./exec.js";
-import { buildHost, defaultHostCommands, generateManifest, localBootEnv, smokeTurnWaitOptions } from "./host-boot.js";
+import { buildHost, defaultHostCommands, generateManifest, inheritedWireOrigin, localBootEnv, smokeTurnWaitOptions } from "./host-boot.js";
 
 /** The frozen codegen target: host/src/generated/manifest.ts. */
 const manifestPath = (demosRepo: string): string =>
@@ -211,8 +211,52 @@ describe("localBootEnv", () => {
     });
   });
 
-  it("never overrides what the operator set", () => {
-    const env = { DEMO_AUTOLOGIN: "0", VENDO_BASE_URL: "https://demos.vendo.run" };
-    expect(localBootEnv(env, 3150)).toEqual(env);
+  it("keeps the operator's autologin choice", () => {
+    expect(localBootEnv({ DEMO_AUTOLOGIN: "0" }, 3150).DEMO_AUTOLOGIN).toBe("0");
+  });
+
+  /**
+   * The wire origin is NOT the operator's to choose for a loopback boot, and this
+   * is the one variable where "an operator who set it keeps their value" was
+   * actively dangerous.
+   *
+   * `VENDO_BASE_URL` is where the demo's own tool calls are sent: the runtime
+   * reads it and hands it to `@vendoai/actions`, which resolves every openapi
+   * binding against it. On 2026-07-28 it was briefly set to a hostname that still
+   * resolved to the old router, and EVERY tool call on EVERY demo left the host
+   * and 404'd elsewhere while every page still rendered perfectly. The cutover
+   * runbook tells operators to export exactly that variable, so a pipeline run on
+   * such a shell would have smoked a demo against somebody else's host and called
+   * the result evidence.
+   *
+   * A boot on 127.0.0.1 has exactly one correct wire origin — itself.
+   */
+  it("forces the wire origin to the host it just booted, whatever the environment says", () => {
+    expect(localBootEnv({ VENDO_BASE_URL: "https://demos.vendo.run" }, 3150).VENDO_BASE_URL)
+      .toBe("http://127.0.0.1:3150");
+  });
+});
+
+describe("inheritedWireOrigin", () => {
+  it("names a wire origin that is not the host being booted", () => {
+    expect(inheritedWireOrigin({ VENDO_BASE_URL: "https://demos.vendo.run" }, 3150)).toBe("https://demos.vendo.run");
+  });
+
+  it("says nothing when the environment names no wire origin", () => {
+    expect(inheritedWireOrigin({}, 3150)).toBeUndefined();
+    expect(inheritedWireOrigin({ VENDO_BASE_URL: "" }, 3150)).toBeUndefined();
+  });
+
+  // Already correct is not a finding, in either spelling — the host normalises a
+  // bare authority and tolerates a trailing slash.
+  it("says nothing when it already names this very boot", () => {
+    expect(inheritedWireOrigin({ VENDO_BASE_URL: "http://127.0.0.1:3150" }, 3150)).toBeUndefined();
+    expect(inheritedWireOrigin({ VENDO_BASE_URL: "http://127.0.0.1:3150/" }, 3150)).toBeUndefined();
+  });
+
+  // A different port is a different server, and on this machine it is very likely
+  // another lane's host.
+  it("names a loopback origin on the wrong port", () => {
+    expect(inheritedWireOrigin({ VENDO_BASE_URL: "http://127.0.0.1:3000" }, 3150)).toBe("http://127.0.0.1:3000");
   });
 });

--- a/bench/src/demo-creator/host-boot.ts
+++ b/bench/src/demo-creator/host-boot.ts
@@ -190,9 +190,6 @@ async function stopProcess(child: ChildProcess): Promise<void> {
   ]);
 }
 
-/** Boots the built host from its own directory (no workspace filter: the
- * vendo-demos checkout is foreign to this repo) and waits until it serves
- * HTTP. Stops itself if readiness fails, so a half-started host never leaks. */
 /** Where a local boot serves from, and therefore its only correct wire origin. */
 const loopbackOrigin = (port: number): string => `http://127.0.0.1:${port}`;
 
@@ -244,6 +241,9 @@ export function inheritedWireOrigin(env: NodeJS.ProcessEnv, port: number): strin
   return configured;
 }
 
+/** Boots the built host from its own directory (no workspace filter: the
+ * vendo-demos checkout is foreign to this repo) and waits until it serves
+ * HTTP. Stops itself if readiness fails, so a half-started host never leaks. */
 export async function bootHost(options: {
   demosRepo: string;
   port: number;

--- a/bench/src/demo-creator/host-boot.ts
+++ b/bench/src/demo-creator/host-boot.ts
@@ -7,7 +7,7 @@ import { chromium } from "@playwright/test";
 import { sendPrompt, VendoTurnError, VendoTurnTimeout, waitForTurn } from "../demo-capture/capture.js";
 import { genManifestScript, hostDir } from "./demo-folder.js";
 import { createScrubber, defaultExec, delay, scrubbingTransform, type ExecFn } from "./exec.js";
-import { agentRunDoorProblem, classifySmoke, installSmokeObserverInPage, noProgress, smokeReadyMs, type SmokeOutcome } from "./smoke.js";
+import { agentRunDoorProblem, classifySmoke, installSmokeObserverInPage, noProgress, readHostToolTraffic, smokeReadyMs, type SmokeOutcome } from "./smoke.js";
 
 /**
  * Stage 4's plumbing: drive the vendo-demos HOST (a foreign checkout, not this
@@ -193,6 +193,9 @@ async function stopProcess(child: ChildProcess): Promise<void> {
 /** Boots the built host from its own directory (no workspace filter: the
  * vendo-demos checkout is foreign to this repo) and waits until it serves
  * HTTP. Stops itself if readiness fails, so a half-started host never leaks. */
+/** Where a local boot serves from, and therefore its only correct wire origin. */
+const loopbackOrigin = (port: number): string => `http://127.0.0.1:${port}`;
+
 /**
  * The env a LOCAL boot needs on top of the operator's.
  *
@@ -204,14 +207,41 @@ async function stopProcess(child: ChildProcess): Promise<void> {
  * `VENDO_BASE_URL`'s origin, which here is the loopback port this function just
  * started. So this is the deployed posture applied locally, not a loosened one.
  *
- * An operator who set either variable keeps their value.
+ * `DEMO_AUTOLOGIN` is the operator's to set. `VENDO_BASE_URL` is NOT, and that
+ * asymmetry is the whole point of this function now: it is the WIRE ORIGIN, the
+ * base every one of the demo's openapi tool bindings is resolved against
+ * (`@vendoai/vendo` reads it from the environment and hands it to
+ * `@vendoai/actions`). On 2026-07-28 it was briefly set to a hostname that still
+ * resolved to the old router, and every tool call on every demo left the host and
+ * 404'd elsewhere — while every page still rendered perfectly, so nothing
+ * page-level noticed. The cutover runbook tells operators to export exactly that
+ * variable, so inheriting it here would have pointed the smoke turn's tool calls
+ * at a completely different host and called whatever came back evidence.
+ *
+ * A server on 127.0.0.1 has exactly one correct wire origin: itself. So this is
+ * made true by construction rather than checked, and {@link inheritedWireOrigin}
+ * is what lets the caller say out loud that it had to be.
  */
 export function localBootEnv(env: NodeJS.ProcessEnv, port: number): NodeJS.ProcessEnv {
   return {
     ...env,
     DEMO_AUTOLOGIN: env.DEMO_AUTOLOGIN ?? "1",
-    VENDO_BASE_URL: env.VENDO_BASE_URL ?? `http://127.0.0.1:${port}`,
+    VENDO_BASE_URL: loopbackOrigin(port),
   };
+}
+
+/**
+ * The wire origin the environment was carrying, when it is not the host about to
+ * be booted — the one thing worth SAYING before a local boot silently corrects
+ * it, because it is the shape of a fault that killed every tool call on the whole
+ * fleet without touching a single page.
+ */
+export function inheritedWireOrigin(env: NodeJS.ProcessEnv, port: number): string | undefined {
+  const configured = env.VENDO_BASE_URL;
+  if (configured === undefined || configured === "") return undefined;
+  // A trailing slash is the same origin; the host normalises it too.
+  if (configured.replace(/\/$/, "") === loopbackOrigin(port)) return undefined;
+  return configured;
 }
 
 export async function bootHost(options: {
@@ -261,7 +291,25 @@ export async function bootHost(options: {
   };
 }
 
-export type SmokeTurnFn = (options: { baseUrl: string; slug: string; prompt: string; timeoutMs: number }) => Promise<SmokeOutcome>;
+export type SmokeTurnFn = (options: {
+  baseUrl: string;
+  slug: string;
+  prompt: string;
+  timeoutMs: number;
+  /** The names of the tools that execute against the DEMO'S OWN API — the only
+   *  ones whose success proves this demo can answer anything. */
+  hostToolNames: readonly string[];
+}) => Promise<SmokeOutcome>;
+
+/**
+ * How long to wait for the turn's response body after the turn itself is over.
+ *
+ * The body is an SSE stream that stays open for the whole turn, so by the time
+ * this is awaited it is almost always complete — EXCEPT on a deadline, where the
+ * turn is still streaming and this would otherwise wait forever. On that path the
+ * verdict is already decided, so a short bound costs nothing.
+ */
+const turnStreamDrainMs = 5_000;
 
 /** `requireView: false` is the contract's "gates on HARD error only": the smoke
  * turn passes as long as the turn did not error and did settle. What the agent
@@ -281,12 +329,17 @@ export function smokeTurnWaitOptions(options: { previousAssistantTurns: number; 
  * (see {@link classifySmoke}), and a thrown Error cannot carry the evidence that
  * judgement needs.
  *
- * Three things are watched at once. The DOOR — the demo's own
+ * Four things are watched at once. The DOOR — the demo's own
  * `/api/vendo/<slug>/…` route — is watched at the wire, because a 500 there is
  * the dead-agent shape (no model provider, a tools file the runtime cannot parse)
  * and it arrives within seconds. The in-page observer records the two signs of
- * life. And the turn wait supplies the third answer: settled, errored, or out of
- * clock.
+ * life. The turn wait supplies settled, errored, or out of clock. And the turn's
+ * own RESPONSE BODY is read back, because it is the only place that says whether
+ * the demo's API answered its agent: the transcript renders nothing for a settled
+ * tool call, and a FAILED call is not a stream error either — the runtime hands
+ * the failure to the model as the tool's output. Reading the body rather than
+ * intercepting the request keeps the stream streaming, so nothing about the turn's
+ * timing or its in-page liveness signals changes.
  */
 export const defaultSmokeTurn: SmokeTurnFn = async (options) => {
   const browser = await chromium.launch();
@@ -297,10 +350,15 @@ export const defaultSmokeTurn: SmokeTurnFn = async (options) => {
     // Only the request that RUNS the turn counts — see agentRunDoorProblem for
     // why "any non-2xx under /api/vendo/<slug>" would fail healthy demos.
     const agentRunDoor = `/api/vendo/${options.slug}/threads`;
+    /** The turn's own response bodies, read back after it ends. */
+    const turnStreams: Promise<string>[] = [];
     page.on("response", (response) => {
       const pathname = new URL(response.url()).pathname;
       const method = response.request().method();
-      if (method.toUpperCase() === "POST" && pathname === agentRunDoor) progress.doorAnswered = true;
+      if (method.toUpperCase() === "POST" && pathname === agentRunDoor) {
+        progress.doorAnswered = true;
+        turnStreams.push(response.text().catch(() => ""));
+      }
       const problem = agentRunDoorProblem({ slug: options.slug, method, pathname, status: response.status() });
       if (problem !== undefined && progress.doorError === undefined) progress.doorError = problem;
     });
@@ -356,6 +414,15 @@ export const defaultSmokeTurn: SmokeTurnFn = async (options) => {
       ?? { turnStarted: false, toolCall: false };
     progress.turnStarted = observed.turnStarted;
     progress.toolCall = observed.toolCall;
+    // Bounded: on a deadline the stream is still open, and the verdict is already
+    // decided, so waiting the rest of the turn out would buy nothing.
+    const streamed = await Promise.race([
+      Promise.all(turnStreams).then((bodies) => bodies.join("\n")),
+      delay(turnStreamDrainMs).then(() => ""),
+    ]);
+    const traffic = readHostToolTraffic(streamed, options.hostToolNames);
+    progress.hostToolAnswered = traffic.answered;
+    if (traffic.problem !== undefined) progress.hostToolProblem = traffic.problem;
     return classifySmoke({
       settled,
       timedOut,

--- a/bench/src/demo-creator/smoke.test.ts
+++ b/bench/src/demo-creator/smoke.test.ts
@@ -4,13 +4,15 @@ import {
   classifySmoke,
   noProgress,
   observedSmokeLatenciesMs,
+  readHostToolTraffic,
   smokeBudgetMs,
   smokeReadyMs,
   type SmokeProgress,
 } from "./smoke.js";
 
-/** A turn that got as far as streaming — the shape of every healthy run. */
-const alive: SmokeProgress = { doorAnswered: true, turnStarted: true, toolCall: true };
+/** A turn that got as far as streaming AND whose own API answered it — the shape
+ *  of every healthy run. */
+const alive: SmokeProgress = { doorAnswered: true, turnStarted: true, toolCall: true, hostToolAnswered: true };
 
 describe("smokeReadyMs", () => {
   // Getting to a composer is page load plus hydration, not a model round trip.
@@ -110,6 +112,204 @@ describe("agentRunDoorProblem", () => {
   });
 });
 
+/**
+ * The blind spot this closes. A demo shipped that served HTTP 200, had a
+ * pixel-accurate palette and zero console errors — and every agent tool 404'd,
+ * so it could not answer a single question. The gate passed because the agent
+ * behaved WELL: it retried, diagnosed the 404s and honestly refused rather than
+ * fabricating an answer. The turn SETTLED, and settled was all the gate checked.
+ *
+ * A failed tool call is NOT visible as a stream error: the runtime returns the
+ * failure as the tool's OUTPUT so the model can see and report it (see
+ * packages/actions registry — a non-2xx becomes `{status:"error",
+ * error:{code:"http-error"}}`), which is exactly why "the turn finished" and
+ * "the demo works" are different facts.
+ */
+describe("readHostToolTraffic — did the demo's own API answer its own agent?", () => {
+  const hostTools = ["host_listTransactions", "host_refundTransaction"];
+  const sse = (...events: unknown[]): string => events.map((event) => `data: ${JSON.stringify(event)}\n`).join("\n");
+
+  it("sees a host tool call that answered", () => {
+    const stream = sse(
+      { type: "start" },
+      { type: "tool-input-start", toolCallId: "c1", toolName: "host_listTransactions" },
+      { type: "tool-output-available", toolCallId: "c1", output: { status: "ok", output: { data: [] } } },
+      { type: "finish" },
+    );
+    expect(readHostToolTraffic(stream, hostTools)).toEqual({ answered: true });
+  });
+
+  // The numbers failure, byte for byte: the tool ran, the demo's own API 404'd,
+  // the runtime handed the model the error as the tool's output, and the turn
+  // went on to settle.
+  it("sees a host tool call the demo's own API 404'd, and names the path", () => {
+    const stream = sse(
+      { type: "tool-input-start", toolCallId: "c1", toolName: "host_listTransactions" },
+      {
+        type: "tool-output-available",
+        toolCallId: "c1",
+        output: {
+          status: "error",
+          error: { code: "http-error", message: `GET /api/numbers/api/transactions → 404: {"error":{"message":"Not found"}}` },
+        },
+      },
+    );
+    const traffic = readHostToolTraffic(stream, hostTools);
+    expect(traffic.answered).toBe(false);
+    expect(traffic.problem).toContain("host_listTransactions");
+    expect(traffic.problem).toContain("/api/numbers/api/transactions");
+    expect(traffic.problem).toContain("404");
+  });
+
+  // ONE success is the whole bar. A demo whose first tool errored and whose
+  // second answered has proven its API answers its agent.
+  it("passes on one success even when another call failed", () => {
+    const stream = sse(
+      { type: "tool-input-start", toolCallId: "c1", toolName: "host_listTransactions" },
+      { type: "tool-output-available", toolCallId: "c1", output: { status: "error", error: { code: "http-error", message: "GET /x → 404: " } } },
+      { type: "tool-input-start", toolCallId: "c2", toolName: "host_listTransactions" },
+      { type: "tool-output-available", toolCallId: "c2", output: { status: "ok", output: { data: [1] } } },
+    );
+    expect(readHostToolTraffic(stream, hostTools).answered).toBe(true);
+  });
+
+  // Vendo's own tools run inside the runtime and never touch the demo's API, so
+  // a turn that only built a view has NOT shown the demo's API answering.
+  it("ignores tools that are not the demo's own", () => {
+    const stream = sse(
+      { type: "tool-input-start", toolCallId: "c1", toolName: "vendo_apps_create" },
+      { type: "tool-output-available", toolCallId: "c1", output: { status: "ok", output: { appId: "app_1" } } },
+    );
+    expect(readHostToolTraffic(stream, hostTools)).toEqual({ answered: false });
+  });
+
+  // A write tool held at the approval gate never reached the API. Counting it
+  // would be the same blind spot in a new place.
+  it("does not count a call still waiting for approval", () => {
+    const stream = sse(
+      { type: "tool-input-start", toolCallId: "c1", toolName: "host_refundTransaction" },
+      { type: "tool-output-available", toolCallId: "c1", output: { status: "pending-approval", approvalId: "ap_1" } },
+    );
+    const traffic = readHostToolTraffic(stream, hostTools);
+    expect(traffic.answered).toBe(false);
+    expect(traffic.problem).toContain("pending-approval");
+  });
+
+  it("reads a call that threw instead of returning an outcome", () => {
+    const stream = sse(
+      { type: "tool-input-start", toolCallId: "c1", toolName: "host_listTransactions" },
+      { type: "tool-output-error", toolCallId: "c1", errorText: "fetch failed" },
+    );
+    expect(readHostToolTraffic(stream, hostTools).problem).toContain("fetch failed");
+  });
+
+  // tool-input-start can be missed (a reconnect, a clipped buffer); the same
+  // toolName rides tool-input-available.
+  it("correlates the tool name from either input event", () => {
+    const stream = sse(
+      { type: "tool-input-available", toolCallId: "c1", toolName: "host_listTransactions", input: {} },
+      { type: "tool-output-available", toolCallId: "c1", output: { status: "ok", output: {} } },
+    );
+    expect(readHostToolTraffic(stream, hostTools).answered).toBe(true);
+  });
+
+  // An output shape this harness does not recognise is NOT reported as a
+  // failure: the only way to get an `error` envelope is the failure path, so
+  // anything else came back from a 2xx. A protocol change must not invent a
+  // broken demo.
+  it("treats an unrecognised output envelope as the API having answered", () => {
+    const stream = sse(
+      { type: "tool-input-start", toolCallId: "c1", toolName: "host_listTransactions" },
+      { type: "tool-output-available", toolCallId: "c1", output: { data: [1, 2] } },
+    );
+    expect(readHostToolTraffic(stream, hostTools).answered).toBe(true);
+  });
+
+  it("survives a clipped or non-JSON stream without throwing", () => {
+    expect(readHostToolTraffic("", hostTools)).toEqual({ answered: false });
+    expect(readHostToolTraffic("data: [DONE]\n\ndata: {\"type\":\"st", hostTools)).toEqual({ answered: false });
+    expect(readHostToolTraffic("not a stream at all", hostTools)).toEqual({ answered: false });
+  });
+
+  it("reports nothing when the demo declares no host tools", () => {
+    const stream = sse({ type: "tool-input-start", toolCallId: "c1", toolName: "host_listTransactions" });
+    expect(readHostToolTraffic(stream, [])).toEqual({ answered: false });
+  });
+});
+
+/**
+ * The three-way distinction. Same settled turn, same clock — what separates them
+ * is whether the demo's own API ever answered its own agent.
+ */
+describe("classifySmoke — a demo whose tools are unreachable is its own verdict", () => {
+  it("passes a healthy demo", () => {
+    expect(classifySmoke({ settled: true, timedOut: false, progress: alive }).verdict).toBe("settled");
+  });
+
+  it("fails a demo whose every tool call was 404'd, even though the turn settled", () => {
+    const outcome = classifySmoke({
+      settled: true,
+      timedOut: false,
+      progress: {
+        doorAnswered: true,
+        turnStarted: true,
+        toolCall: true,
+        hostToolAnswered: false,
+        hostToolProblem: `host_listTransactions → GET /api/numbers/api/transactions → 404`,
+      },
+    });
+    expect(outcome.verdict).toBe("tools-unreachable");
+    expect(outcome.reason).toContain("404");
+    // Reproducible: the wiring is wrong, and a second turn re-proves it at cost.
+    expect(outcome.retryable).toBe(false);
+  });
+
+  it("keeps a slow-but-healthy turn passing — the tool answered, however late", () => {
+    // The turn ran 400s, well past the old 180s deadline, and settled with a
+    // successful tool call. Slowness is not this gate's business.
+    expect(classifySmoke({ settled: true, timedOut: false, progress: alive }).verdict).toBe("settled");
+  });
+
+  it("gives all three outcomes verdicts and messages an operator cannot confuse", () => {
+    const healthy = classifySmoke({ settled: true, timedOut: false, progress: alive });
+    const unreachable = classifySmoke({
+      settled: true,
+      timedOut: false,
+      progress: { ...alive, hostToolAnswered: false, hostToolProblem: "host_listTransactions → GET /x → 404" },
+    });
+    const brokenDemo = classifySmoke({ settled: false, timedOut: true, progress: noProgress() });
+    const slow = classifySmoke({ settled: false, timedOut: true, progress: { ...alive } });
+    expect([healthy.verdict, unreachable.verdict, brokenDemo.verdict, slow.verdict])
+      .toEqual(["settled", "tools-unreachable", "broken", "timeout"]);
+    expect(unreachable.reason).not.toBe(brokenDemo.reason);
+    expect(unreachable.reason).not.toBe(slow.reason);
+  });
+
+  // The one case a second attempt can genuinely clear: the model chose not to
+  // call a tool. Nothing about the demo is known to be wrong yet.
+  it("retries a turn in which the agent never called one of its own tools", () => {
+    const outcome = classifySmoke({
+      settled: true,
+      timedOut: false,
+      progress: { doorAnswered: true, turnStarted: true, toolCall: false, hostToolAnswered: false },
+    });
+    expect(outcome.verdict).toBe("tools-unreachable");
+    expect(outcome.reason).toMatch(/never called/i);
+    expect(outcome.retryable).toBe(true);
+  });
+
+  // The known data-binding gaps must still ship: a demo whose generated view
+  // renders the wrong column is stage 5's business, and stage 4 cannot see it.
+  it("passes a demo whose API answered even if the turn generated nothing at all", () => {
+    const outcome = classifySmoke({
+      settled: true,
+      timedOut: false,
+      progress: { doorAnswered: true, turnStarted: true, toolCall: false, hostToolAnswered: true },
+    });
+    expect(outcome.verdict).toBe("settled");
+  });
+});
+
 describe("classifySmoke — a genuinely BROKEN demo fails, and fails fast", () => {
   // The dead-agent shape the gate exists to catch: the page renders, the agent
   // route throws (no model provider, a tools file the runtime cannot parse), and
@@ -118,7 +318,7 @@ describe("classifySmoke — a genuinely BROKEN demo fails, and fails fast", () =
     const outcome = classifySmoke({
       settled: false,
       timedOut: false,
-      progress: { doorAnswered: true, doorError: "POST /api/vendo/acme → 500", turnStarted: false, toolCall: false },
+      progress: { doorAnswered: true, doorError: "POST /api/vendo/acme → 500", turnStarted: false, toolCall: false, hostToolAnswered: false },
     });
     expect(outcome.verdict).toBe("broken");
     expect(outcome.reason).toContain("500");
@@ -129,7 +329,7 @@ describe("classifySmoke — a genuinely BROKEN demo fails, and fails fast", () =
       settled: false,
       timedOut: false,
       surfacedError: "Something went wrong and the response didn’t finish.",
-      progress: { doorAnswered: true, turnStarted: true, toolCall: false },
+      progress: { doorAnswered: true, turnStarted: true, toolCall: false, hostToolAnswered: false },
     });
     expect(outcome.verdict).toBe("broken");
     expect(outcome.reason).toContain("didn’t finish");
@@ -201,7 +401,7 @@ describe("classifySmoke — a SLOW but healthy demo is not called broken", () =>
     const outcome = classifySmoke({
       settled: false,
       timedOut: true,
-      progress: { doorAnswered: true, turnStarted: true, toolCall: false },
+      progress: { doorAnswered: true, turnStarted: true, toolCall: false, hostToolAnswered: false },
     });
     expect(outcome.verdict).toBe("timeout");
   });
@@ -210,7 +410,7 @@ describe("classifySmoke — a SLOW but healthy demo is not called broken", () =>
     const outcome = classifySmoke({
       settled: false,
       timedOut: true,
-      progress: { doorAnswered: true, turnStarted: false, toolCall: true },
+      progress: { doorAnswered: true, turnStarted: false, toolCall: true, hostToolAnswered: false },
     });
     expect(outcome.verdict).toBe("timeout");
   });
@@ -233,7 +433,7 @@ describe("classifySmoke — what a second attempt can and cannot fix", () => {
     expect(classifySmoke({
       settled: false,
       timedOut: false,
-      progress: { doorAnswered: true, doorError: "POST /api/vendo/acme → 500", turnStarted: false, toolCall: false },
+      progress: { doorAnswered: true, doorError: "POST /api/vendo/acme → 500", turnStarted: false, toolCall: false, hostToolAnswered: false },
     }).retryable).toBe(true);
   });
 
@@ -257,15 +457,17 @@ describe("classifySmoke — precedence", () => {
       settled: false,
       timedOut: false,
       surfacedError: "the response didn’t finish",
-      progress: { doorAnswered: true, doorError: "POST /api/vendo/acme → 500", turnStarted: false, toolCall: false },
+      progress: { doorAnswered: true, doorError: "POST /api/vendo/acme → 500", turnStarted: false, toolCall: false, hostToolAnswered: false },
     });
     expect(outcome.reason).toContain("500");
   });
 
   // Content is stage 5's business (frozen contract): the classifier is handed
   // liveness signals only, so no verdict can depend on what was generated.
+  // `hostToolAnswered` is the fourth of them — whether the demo's API answered
+  // is a fact about the wire, not about what came back over it.
   it("carries no content — only liveness signals", () => {
     const outcome = classifySmoke({ settled: true, timedOut: false, progress: alive });
-    expect(Object.keys(outcome.progress).sort()).toEqual(["doorAnswered", "toolCall", "turnStarted"]);
+    expect(Object.keys(outcome.progress).sort()).toEqual(["doorAnswered", "hostToolAnswered", "toolCall", "turnStarted"]);
   });
 });

--- a/bench/src/demo-creator/smoke.ts
+++ b/bench/src/demo-creator/smoke.ts
@@ -85,11 +85,99 @@ export interface SmokeProgress {
    * it is read as one of two independent signs of life, never as a requirement.
    */
   toolCall: boolean;
+  /**
+   * The demo's OWN API answered its OWN agent: at least one openapi tool call
+   * came back with an ok outcome.
+   *
+   * The one fact "the turn settled" cannot carry, and the reason a demo shipped
+   * that looked perfect and could answer nothing. Read off the turn's own wire
+   * stream — see {@link readHostToolTraffic}.
+   */
+  hostToolAnswered: boolean;
+  /** Why not, when the answer is no: the FIRST host tool call that did not come
+   *  back ok, as one clause. Absent when no host tool was called at all. */
+  hostToolProblem?: string;
 }
 
 /** A turn that showed no sign of life whatsoever. */
 export function noProgress(): SmokeProgress {
-  return { doorAnswered: false, turnStarted: false, toolCall: false };
+  return { doorAnswered: false, turnStarted: false, toolCall: false, hostToolAnswered: false };
+}
+
+/** What the turn's wire stream said about the demo's OWN tool calls. */
+export interface HostToolTraffic {
+  /** At least one of the demo's own API tools came back with an ok outcome. */
+  answered: boolean;
+  /** The first host tool call that did not, as one operator-readable clause. */
+  problem?: string;
+}
+
+/**
+ * Reads the turn's own response stream and answers ONE question: did the demo's
+ * API answer the demo's agent?
+ *
+ * This has to be read off the wire, because neither of the other two places
+ * knows. The TRANSCRIPT renders nothing for a settled tool call and the ribbon
+ * only exists while one is in flight. And a FAILED call is not a stream error
+ * either: the runtime returns the failure as the tool's OUTPUT so the model can
+ * see it and say so (a non-2xx from the demo's API becomes
+ * `{status:"error", error:{code:"http-error", message:"GET /path → 404: …"}}` —
+ * packages/actions/src/runtime/registry.ts). That is exactly why a demo whose
+ * every tool 404'd still produced a turn that settled: the agent read the errors
+ * and honestly refused.
+ *
+ * LIVENESS ONLY. The output's SHAPE is inspected — ok, error, or held at the
+ * approval gate — and never its content. Nothing here can grow into a judgement
+ * about what a tool returned or what the view rendered; that is stage 5's.
+ */
+export function readHostToolTraffic(streamText: string, hostToolNames: readonly string[]): HostToolTraffic {
+  const isHostTool = new Set(hostToolNames);
+  if (isHostTool.size === 0) return { answered: false };
+  const nameOf = new Map<string, string>();
+  let problem: string | undefined;
+  for (const line of streamText.split("\n")) {
+    const payload = line.startsWith("data:") ? line.slice("data:".length).trim() : undefined;
+    if (payload === undefined || payload === "" || payload === "[DONE]") continue;
+    let event: Record<string, unknown>;
+    try {
+      const parsed: unknown = JSON.parse(payload);
+      if (parsed === null || typeof parsed !== "object") continue;
+      event = parsed as Record<string, unknown>;
+    } catch {
+      // A clipped final chunk is normal on a killed turn, not a finding.
+      continue;
+    }
+    const callId = typeof event.toolCallId === "string" ? event.toolCallId : undefined;
+    if (callId === undefined) continue;
+    if (typeof event.toolName === "string") nameOf.set(callId, event.toolName);
+    const name = nameOf.get(callId);
+    if (name === undefined || !isHostTool.has(name)) continue;
+
+    if (event.type === "tool-output-error") {
+      problem ??= `${name} → ${typeof event.errorText === "string" ? event.errorText : "the tool call threw"}`;
+      continue;
+    }
+    if (event.type !== "tool-output-available") continue;
+    const output = event.output;
+    const status = (output as { status?: unknown } | null)?.status;
+    if (status === "ok") return { answered: true };
+    if (status === "error") {
+      const message = (output as { error?: { message?: unknown } }).error?.message;
+      problem ??= `${name} → ${typeof message === "string" ? message : "the call failed"}`;
+      continue;
+    }
+    if (typeof status === "string") {
+      // `pending-approval`, `connect-required`: the call never reached the API.
+      problem ??= `${name} → ${status}`;
+      continue;
+    }
+    // An envelope this harness does not recognise. The ONLY way to get an error
+    // envelope is the failure path, so anything else came back from a 2xx —
+    // reporting it as a failure would invent a broken demo out of a protocol
+    // change, which is the opposite of what this gate is for.
+    return { answered: true };
+  }
+  return problem === undefined ? { answered: false } : { answered: false, problem };
 }
 
 /**
@@ -203,13 +291,18 @@ export function installSmokeObserverInPage(): void {
 }
 
 /**
- * - `settled` — the turn finished. The gate passes; content is stage 5's.
+ * - `settled` — the turn finished AND the demo's own API answered it. The gate
+ *               passes; content is stage 5's.
  * - `broken`  — the demo's agent does not work. The gate fails.
  * - `timeout` — the agent was alive and did not finish in the budget. The gate
  *               still fails (a turn this slow is not demoable), but it is
  *               reported as its own thing so nobody reads it as a broken demo.
+ * - `tools-unreachable` — the turn finished and the demo's API never answered a
+ *               single one of its own agent's tool calls. Its own verdict because
+ *               it is neither of the other two: the agent works, the page works,
+ *               the clock was fine — the demo simply cannot answer anything.
  */
-export type SmokeVerdict = "settled" | "broken" | "timeout";
+export type SmokeVerdict = "settled" | "broken" | "timeout" | "tools-unreachable";
 
 export interface SmokeOutcome {
   verdict: SmokeVerdict;
@@ -274,7 +367,25 @@ export function classifySmoke(observed: {
       retryable: true,
     };
   }
-  if (observed.settled) return { verdict: "settled", progress, retryable: false };
+  if (observed.settled) {
+    if (progress.hostToolAnswered) return { verdict: "settled", progress, retryable: false };
+    // THE BLIND SPOT. A settled turn used to pass here unconditionally, and a
+    // demo whose every tool 404'd settled cleanly: the agent retried, diagnosed
+    // the 404s and honestly refused. Good behaviour by the agent read as a
+    // healthy demo. This is still not a content judgement — the question is only
+    // whether the demo's API answered, never what it answered with.
+    return {
+      verdict: "tools-unreachable",
+      reason: progress.hostToolProblem === undefined
+        ? "the turn settled, but the agent never called one of the demo's own tools, so nothing proves this demo's API can answer it"
+        : `the turn settled, but the demo's own API never answered its own agent — ${progress.hostToolProblem}. Every tool the prospect's question needs is failing, so the demo would look perfect and answer nothing`,
+      progress,
+      // A tool call the API refused is this demo's own wiring, and it reproduces
+      // — a second turn costs another whole turn and re-proves it. The model
+      // simply not calling a tool is the one case a retry can genuinely clear.
+      retryable: progress.hostToolProblem === undefined,
+    };
+  }
   const alive = progress.turnStarted || progress.toolCall;
   if (!alive) {
     return {


### PR DESCRIPTION
## What shipped without this

The regenerated `numbers` demo served HTTP 200, had a pixel-accurate palette and
zero console errors — and **could not answer a single question**. Every one of
its agent's tool calls returned 404.

Stage 4 passed it *because the agent behaved well*: it retried, diagnosed the
404s, and honestly refused rather than fabricating an answer. So the turn
**settled**, and settled was all the gate checked.

## Why the gate could not have seen it

A failed tool call is not a stream error. The runtime hands the failure to the
model **as the tool's output** so it can report it:

```
{ status: "error", error: { code: "http-error", message: "GET /api/numbers/api/transactions → 404: …" } }
```

And the transcript renders *nothing at all* for a settled tool call, while the
status ribbon exists only while one is in flight. So neither the DOM nor an
exception knew. Third gate tonight that could not see the thing it guarded.

## The dynamic gate

Stage 4 now requires that **at least one of the demo's own tool calls came back
ok**, read off the turn's own response body.

- `readHostToolTraffic` parses the turn's UI-message stream, correlates each tool
  call id to its name, and reports whether any of the demo's *own* openapi tools
  answered. Connector and runtime tools are excluded — they could never prove the
  demo's API answered. A call held at the approval gate never reached the API and
  does not count. An envelope it doesn't recognise counts as an answer, because
  the only way to get an error envelope is the failure path.
- The body is **read, never intercepted**, so the stream keeps streaming and the
  in-page liveness signals still fire in real time.
- `tools-unreachable` is its own verdict beside `broken` and `timeout`.

**The broken-vs-slow logic is untouched.** Only the `settled` branch changed:

| turn | verdict |
|---|---|
| settled, a tool answered (however slowly) | `settled` ✅ |
| settled, every tool 404'd | `tools-unreachable` ❌ |
| streamed, never finished | `timeout` ❌ |
| nothing at all | `broken` ❌ |

Retryable only when the agent never called a tool at all — model discretion,
which a second turn can clear. A call the API *refused* reproduces, so it fails
on the first attempt instead of spending another turn re-proving it.

### Still not a content judgement

`SmokeProgress` gains one liveness field. The classifier still cannot see a view,
a tool result or any prose, so the known data-binding gaps still ship. Two tests
pin that field set for exactly this reason, and extending them to name the new
field is the only test edit in this PR.

### The message names no cause, deliberately

These 404s were first diagnosed as a path-shape defect in the generated
`openapi.json` and were nothing of the kind — the real fault was the host's wire
origin briefly pointing at a hostname that still resolved to the old router,
404ing every tool call on every demo on the fleet while every page kept
rendering. The runtime's own clause carries a method, a path and a status but
**never the origin**, which is exactly how a wrong host reads like a wrong path.
So the error carries the request, the response *and* the origin the demo was
served on:

```
the generated demo's TOOLS ARE UNREACHABLE — the turn settled, but the demo's own
API never answered its own agent — host_getChargeback → GET /api/numbers/api/transactions
→ 404: {"error":{"message":"Not found","code":"not_found"}}. Every tool the prospect's
question needs is failing, so the demo would look perfect and answer nothing. The
demo's own API was served at http://127.0.0.1:4399; the clause above carries a path
and a status but not the origin the call was sent to, so both are worth checking
```

## The wire origin can no longer be inherited

`VENDO_BASE_URL` is the base every openapi binding resolves against, and a boot on
127.0.0.1 has exactly one correct one: itself. `localBootEnv` no longer lets the
environment supply it (`DEMO_AUTOLOGIN` is still the operator's) — the cutover
runbook tells operators to export that variable, so a pipeline run on such a shell
would have smoked the new demo against a *different host* and called whatever came
back evidence. `inheritedWireOrigin` reports when one had to be overridden, and
assemble says so rather than correcting it in silence:

```
[assemble] WIRE ORIGIN: the environment sets VENDO_BASE_URL=https://demos.vendo.run,
which is not the host this run boots — every one of the demo's tool calls would have
left this machine and been answered by whatever is there. The local boot uses its own
origin (http://127.0.0.1:4399) instead.
```

## No static openapi-vs-routes check — and why not

One was written and **dropped**. Do not re-add it believing it was an oversight.

End to end with every link executed — the host's own `scopedTools`, the real
`@vendoai/actions` executor composing the URL, the real deployed host answering:

| declared in `openapi.json` | executor requested | deployed host |
|---|---|---|
| `/api/transactions` | `…/api/numbers/transactions` | **200**, 3749b real data |
| `/transactions` | `…/api/numbers/transactions` | **200**, 3749b real data |
| `/api/api/transactions` | `…/api/numbers/api/transactions` | **404**, 52b |

Both spellings reach the same handler, so there is no convention to enforce. The
check I wrote complained about **none of the seven demos live on vendo-demos main**
(34 paths, both spellings) — it enforced no convention. It was dropped anyway
because it mirrored two private functions in *another repo*, which goes stale
silently, and because this gate already catches the same class from observed
behaviour rather than from a mirror. Source and evidence are preserved in the
lane's evidence folder.

## Proof

- **Real browser**, streaming SSE POST: 6/6 chunks captured, arriving 300ms apart
  over a 1.5s spread (a buffered stream would arrive at once); healthy → `answered:
  true`, all-404 → `answered: false` with the failing request in the clause.
- **Real demo folder** (`numbers` as it stands on vendo-demos main): 9 real host
  tool names read from its real `tools.json`; healthy → `settled`; all-404 →
  `SmokeToolsUnreachableError` with the real request, response and origin.
- `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green **twice**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stage 4 smoke now fails demos whose own API never answers: we parse the turn’s SSE stream and require at least one of the demo’s `openapi` tools to succeed. Also force the local wire origin (`VENDO_BASE_URL`) to the loopback host and log when an inherited origin is overridden.

- **New Features**
  - Added `readHostToolTraffic` to parse the turn’s SSE body and detect if any host `openapi` tool succeeded; `hostToolNames` are read from each demo’s `tools.json` and exclude connector/runtime tools and pending-approval calls.
  - Introduced `tools-unreachable` verdict and `SmokeToolsUnreachableError` (message includes request, response, and host origin). `SmokeProgress` adds `hostToolAnswered` and optional `hostToolProblem`.

- **Bug Fixes**
  - Read, don’t intercept, the response body; add a short drain after the turn to keep live streaming unaffected.
  - Local boots now enforce `VENDO_BASE_URL` = `http://127.0.0.1:<port>`; added `inheritedWireOrigin` and a warning when an external origin is overridden.
  - Moved the `bootHost` comment next to the function for clarity (no runtime changes).

<sup>Written for commit a97d0b988363950fb7ce85b6245d87631b9b8885. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

