### PR TITLE
fix(actions): a failed host call names the origin, not just the path

### DIFF
--- a/.changeset/tool-error-names-the-origin.md
+++ b/.changeset/tool-error-names-the-origin.md
@@ -1,0 +1,18 @@
+---
+"@vendoai/actions": patch
+---
+
+A failed host call now names the origin it called, not just the path.
+
+`http-error` outcomes were formatted `GET /customers → 404: …`. When a
+deployment's `VENDO_BASE_URL` points at the wrong host, every tool 404s while
+every path is correct — and that message reads exactly like a malformed path.
+It now reads:
+
+```
+GET https://api.example.com/customers → 404: no such route
+```
+
+The target is assembled from the URL's origin and path only, so a `baseUrl`
+carrying userinfo (`https://svc:pw@host`, `https://ghp_x@host`) or a
+query-string token never reaches an error message, a host log, or the model.

--- a/packages/actions/src/runtime/registry.test.ts
+++ b/packages/actions/src/runtime/registry.test.ts
@@ -486,9 +486,43 @@ describe("host HTTP execution", () => {
     const failed = await actions.execute({ id: "3", tool: "host_probe", args: { mode: "fail" } }, ctx);
     expect(toolOutcomeSchema.parse(failed)).toMatchObject({ status: "error", error: { code: "http-error" } });
     if (failed.status === "error") {
-      expect(failed.error.message).toContain("GET /probe → 503:");
-      expect(failed.error.message).toHaveLength("GET /probe → 503: ".length + 200);
+      const prefix = `GET http://127.0.0.1:${port}/probe → 503: `;
+      expect(failed.error.message).toContain(prefix);
+      expect(failed.error.message).toHaveLength(prefix.length + 200);
     }
+  });
+
+  // A wrong wire origin 404s every tool call while every path is correct, so an
+  // http failure that carries only the path reads exactly like a wrong path.
+  it("names the origin in an http failure without leaking the URL's credentials", async () => {
+    const actions = createActions({
+      tools: [routeTool("host_probe")],
+      baseUrl: "https://svc:s3cret-password@wrong-host.test:8443",
+      fetch: async () => new Response("no such route", { status: 404 }),
+    });
+    const failed = await actions.execute(
+      { id: "1", tool: "host_probe", args: { access_token: "sk-live-querytoken" } },
+      ctx,
+    );
+    expect(failed).toMatchObject({ status: "error", error: { code: "http-error" } });
+    if (failed.status !== "error") return;
+    expect(failed.error.message).toBe("GET https://wrong-host.test:8443/probe → 404: no such route");
+    expect(failed.error.message).not.toContain("s3cret-password");
+    expect(failed.error.message).not.toContain("svc");
+    expect(failed.error.message).not.toContain("sk-live-querytoken");
+  });
+
+  it("keeps token-only userinfo out of an http failure", async () => {
+    const actions = createActions({
+      tools: [routeTool("host_probe")],
+      baseUrl: "https://ghp_tokenonlyuserinfo@wrong-host.test",
+      fetch: async () => new Response("nope", { status: 500 }),
+    });
+    const failed = await actions.execute({ id: "1", tool: "host_probe", args: {} }, ctx);
+    expect(failed).toMatchObject({ status: "error", error: { code: "http-error" } });
+    if (failed.status !== "error") return;
+    expect(failed.error.message).toBe("GET https://wrong-host.test/probe → 500: nope");
+    expect(failed.error.message).not.toContain("ghp_");
   });
 
   it("returns validation and network outcomes instead of throwing per-call failures", async () => {

--- a/packages/actions/src/runtime/registry.ts
+++ b/packages/actions/src/runtime/registry.ts
@@ -246,6 +246,22 @@ function joinedUrl(baseUrl: string, path: string): URL {
   return new URL(`${baseUrl.replace(/\/$/, "")}${path}`);
 }
 
+/**
+ * How a failed host call names what it called: origin **and** path. A wire
+ * origin pointing at the wrong host 404s every tool while every path is
+ * correct, and a message carrying only the path reads exactly like a malformed
+ * path — so the origin is never omitted.
+ *
+ * Assembled from the URL's safe parts rather than scrubbed after the fact:
+ * `host` cannot contain userinfo, and dropping `search` drops query-string
+ * tokens. A baseUrl may carry either (`https://svc:pw@host`,
+ * `https://ghp_x@host`, `?access_token=…`) and this string reaches host logs
+ * and the model.
+ */
+function requestTarget(url: URL): string {
+  return `${url.protocol}//${url.host}${url.pathname}`;
+}
+
 function resolveUrl(binding: RouteBinding | OpenApiBinding, configuredBaseUrl?: string): URL {
   let baseUrl: string | undefined;
   if (binding.kind === "openapi" && binding.baseUrl) {
@@ -687,7 +703,7 @@ async function executeHost(config: RegistryConfig, tool: ExtractedTool, call: To
       if (!response.ok) {
         return error(
           "http-error",
-          `${method} ${url.pathname} → ${response.status}: ${text.slice(0, 200)}`,
+          `${method} ${requestTarget(url)} → ${response.status}: ${text.slice(0, 200)}`,
         );
       }
       if (text) {


### PR DESCRIPTION
## The one-line omission

`packages/actions/src/runtime/registry.ts` formatted an `http-error` outcome as
`${method} ${url.pathname} → ${status}` — it dropped the origin entirely.

That matters because openapi bindings resolve against `VENDO_BASE_URL`. When a
deployment's wire origin points at the wrong host, **every tool call 404s while
every path is correct**, and the error reads exactly like a malformed path. On
2026-07-28 that cost hours: the demo fleet's tool traffic was going to a
different host, and it was diagnosed twice as generated-openapi path bugs — once
confidently enough to dispatch an edit to five live prospect-facing demos. The
real cause was one environment variable. The symptom was found by a human
clicking a pill on a live demo.

## Before / after

```
- GET /customers → 404: no such route
+ GET https://api.example.com/customers → 404: no such route
```

## Credentials

The target is **assembled from the URL's safe parts, not scrubbed after the
fact** — `${url.protocol}//${url.host}${url.pathname}`:

- `host` structurally cannot contain userinfo, so `https://svc:pw@host` and
  token-only userinfo like `https://ghp_x@host` cannot appear;
- dropping `search` drops query-string tokens (`?access_token=…`).

Allowlisting the safe parts is preferred over a denylist regex here because this
string reaches host logs, the model, and Slack threads. (The demo pipeline's
`urlCredentials` scrubber in `bench/src/demo-creator/exec.ts` is the denylist
equivalent; it exists because git echoes a remote it does not control. Here we
build the string ourselves, so we can simply never include the unsafe parts.)

## The published-string change, handled deliberately

`@vendoai/actions` is published, so this text is a public surface. I searched the
repo for anything pinning it:

- `packages/actions/src/runtime/registry.test.ts:489` asserted `"GET /probe → 503:"`
  **and** pinned the truncation with `toHaveLength("GET /probe → 503: ".length + 200)`.
  Updated to build the prefix from the stub's real origin, so the 200-char
  truncation stays pinned.
- Every other `http-error` assertion matches loosely (`stringContaining("401")`,
  `stringContaining("500")`) and is unaffected.
- No doc, snapshot, or `.mdx` pins the format. `docs/archive/contracts/04-actions.md`
  describes only "the server's message".
- A patch changeset is included.

## Tests

Two regression tests, written first and watched fail for the right reason
(`expected 'GET /probe → 404: …' to be 'GET https://wrong-host.test:8443/probe → 404: …'`):

- origin present, and `svc:`/`s3cret-password`/a query token absent;
- token-only userinfo (`https://ghp_x@host`) absent.

## Gates

`pnpm build && pnpm test && pnpm typecheck && pnpm lint` green twice, the second
run cache-busted with `TURBO_FORCE=true` (1450 tests in `@vendoai/vendo` alone).

## Noticed, deliberately NOT fixed

The `network-error` clause two lines below has the same gap —
`` `Network request failed for ${call.tool}` `` names neither origin nor path, so
a wire origin pointing at a host that does not resolve is equally opaque. It is a
separate public string with its own test churn, so it is out of scope here rather
than bundled in silently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `http-error` messages in `@vendoai/actions` to include the full origin alongside the path, so wrong-host issues with `VENDO_BASE_URL` are clear.

- **Bug Fixes**
  - Error text now shows origin and path (e.g., from "GET /customers → 404" to "GET https://api.example.com/customers → 404").
  - Target is built as `${url.protocol}//${url.host}${url.pathname}` to exclude userinfo and query tokens.
  - Updated tests to build the prefix from the real origin and added regressions to ensure no credential leaks; patch changeset included.

<sup>Written for commit 9fe3aa71d58167590387bf42770cc03b5f945083. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

