### PR TITLE
fix(demo-creator): the brief's slot is the generated-view panel, not the trigger

### DIFF
--- a/bench/src/demo-creator/brief.ts
+++ b/bench/src/demo-creator/brief.ts
@@ -240,7 +240,7 @@ Output ONLY a JSON object (no prose, no markdown fence), exactly this shape:
   "chipMaterial": ["<3-6 things a real ${prospect} user would ask for, imperative, in their vocabulary>"],
   "placement": {
     "trigger": "header" | "sidebar",
-    "slot": "<where in the cloned screen the Vendo trigger renders, e.g. 'beside the search field in the top bar'>"
+    "slot": "<where in the cloned screen the full-width generated-view PANEL renders, e.g. 'its own full-width row directly above the shipments table'>"
   },
   "colors": {
 ${themeColorTokens.map((token) => `    "${token}": { "hex": "<EXACT hex from the list>", "reason": "<one line>" }`).join(",\n")}
@@ -252,7 +252,12 @@ ${themeColorTokens.map((token) => `    "${token}": { "hex": "<EXACT hex from the
 ALL record names and data are INVENTED — the evidence informs STYLE, never DATA.
 Never reproduce a real customer, invoice or person from the screenshots.
 "trigger" is "header" if their chrome is a top bar, "sidebar" if the primary nav
-is a left rail. "density"/"motion" are your read of the screenshots.`;
+is a left rail. "slot" is a DIFFERENT surface from the trigger: the trigger is a
+button, the slot is the panel a generated view renders into, so it needs a
+content column — a row inside <main>, or a full-width band above a table or a
+stat strip. Never place it in a control row (a top bar, a filter/date cluster, a
+toolbar): those give it no width, and it is the panel, not the button, that goes
+there. "density"/"motion" are your read of the screenshots.`;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What broke

Two of two demos that put the Vendo slot in a header row shipped visibly broken, independently, each caught by its own judge:

- **zelty** — slot rendered **54px wide x 370px tall** in the top bar, chips one word per line, spilling 110px above the viewport and 217px below the header, over the `Ultimos 30 dias` date filter. Its judge called it "an overlapping tooltip panel covering the date filter".
- **fernway-freight** — same shape beside its search field: "clipped Ask Fernway suggestion panel breaking the header".

## Why

The brief prompt's own reply schema told the model to do it:

```
"slot": "<where in the cloned screen the Vendo trigger renders, e.g. 'beside the search field in the top bar'>"
```

Two errors in one line. `slot` is **not** the trigger — `host/src/lib/demo-config.ts` defines it as where `screens/index.tsx` puts the full-width `VendoSlot` panel — and the worked example points it straight into a control row. fernway-freight landed the example almost verbatim.

Evidence that the model followed the prompt rather than erring: zelty's first-generation config (`vendo-demos@78dc6c1`) reads

```json
"slot": "en la barra superior, a la izquierda del selector de idioma 'ES' y el toggle de tema"
```

and its `screens/topbar.tsx` faithfully rendered `<VendoSlot>` there. The trailing guidance explains `trigger` and never mentions `slot` at all.

## The change

Prompt text only. Describes what `slot` actually is, and names the control rows it must never go in. `placement.trigger` is untouched — `"header"` remains a correct trigger choice, and no placement is banned by a guard.

This is the *vocabulary* half of the defect. The rendering half — a cramped slot degrading gracefully instead of breaking the page — is fixed host-side in `runvendo/vendo-demos` (separate PR), so a host that chooses a cramped placement anyway no longer produces a broken page.

## Verification

```
bench/src/demo-creator/  463 passed | 1 skipped (464)   [run twice]
tsc --noEmit -p bench/tsconfig.json  exit 0
```

No test changed: `brief.test.ts` exercises the parser against a fixture, not the prompt text.

> Verified against node_modules borrowed from an older lockfile checkout, so treat CI as the truth on dep resolution.

## Needs porting

`yousefh409/pipeline-to-private` in `runvendo/vendo-demos` already carries this file as `pipeline/src/brief.ts` with the **identical** defective text at the identical lines (243, 254). Without porting, that move re-introduces the defect.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the demo-creator brief so `placement.slot` refers to the full-width generated-view panel (not the trigger) and updates the example to place it in a content row. This prevents slots from being put in header/filter/toolbar rows that cause clipped or overlapping panels; `placement.trigger` remains unchanged.

<sup>Written for commit 7c61c67da79198974a1c330715787dc4ac168bc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

