### PR TITLE
fix(ui): one visitor, one anonymous identity — consent writes land again

### DIFF
--- a/.changeset/one-visitor-one-anonymous-identity.md
+++ b/.changeset/one-visitor-one-anonymous-identity.md
@@ -1,0 +1,34 @@
+---
+"@vendoai/ui": patch
+---
+
+One visitor, one anonymous identity — consent-gated actions stop failing silently.
+
+An anonymous visitor's identity IS the opaque session pointer the door mints on a
+cookie-less wire request, and the door mints one PER REQUEST. A cold page load
+mounts several hooks at once (`/status`, `/approvals`, `/automations`,
+`/activity`, `/connections/catalog`, `/connections`), so every one of them left
+cookie-less and minted its own subject; the browser's jar kept whichever
+`Set-Cookie` landed last and the rest were orphaned. Measured live: one page load
+produced four distinct subjects, three orphaned.
+
+The damage lands on the trust mechanism at the centre of the product. An agent
+run created its consent approval under one subject, the user's Approve arrived as
+another, and guard correctly refused another subject's approval — surfacing as
+`Approval apr_… was not found` and a run stuck on "waiting for your approval"
+forever. Every consent-gated action failed this way, and the same split emptied
+the activity feed mid-run.
+
+The browser is the visitor boundary, so `createVendoClient` is the layer that can
+close the race honestly: the first request through a client may leave
+cookie-less, and every request issued before it answers now waits for it and
+travels with the pointer it established. Costs one extra round trip on a cold
+load and nothing afterwards; a failed first request releases the gate rather than
+holding it, so the old behaviour is the floor, never something worse.
+
+Deliberately NOT solved by fingerprinting the requester (IP/User-Agent would
+merge two real visitors behind one NAT into a single session, sharing threads,
+grants and approvals) nor by deriving the pointer from request attributes (that
+would make a live session guessable, where today it is a 2^128 search). Hosts
+that already mint the pointer on their document response keep working unchanged —
+the door treats a pre-established pointer as canonical.

--- a/packages/ui/src/client-impl.ts
+++ b/packages/ui/src/client-impl.ts
@@ -80,7 +80,7 @@ export function createVendoClient(config: VendoClientConfig): VendoClient {
   const baseUrl = config.baseUrl ?? "/api/vendo";
   const headers = { ...(config.headers ?? {}) };
 
-  async function request(path: string, init?: RequestInit): Promise<Response> {
+  async function send(path: string, init?: RequestInit): Promise<Response> {
     return ensureOk(
       await fetch(route(baseUrl, path), {
         ...init,
@@ -90,6 +90,47 @@ export function createVendoClient(config: VendoClientConfig): VendoClient {
         },
       }),
     );
+  }
+
+  /** ONE VISITOR, ONE ANONYMOUS IDENTITY.
+   *
+   *  An anonymous visitor's identity IS the opaque session pointer the door
+   *  mints on a cookie-less request, and the door mints one PER REQUEST — it
+   *  cannot do otherwise, because two cookie-less requests are indistinguishable
+   *  from two visitors and the cookie is the only identity there is. A cold load
+   *  mounts several hooks at once (/status, /approvals, /activity, …), so every
+   *  one of them left cookie-less and minted its own subject; the jar kept
+   *  whichever Set-Cookie landed last and the rest were orphaned. The run then
+   *  created its consent approval under one subject while Approve decided as
+   *  another, and guard correctly refused it: "Approval apr_… was not found".
+   *
+   *  The browser IS the visitor boundary, so this is the layer that can close
+   *  the race honestly: the FIRST request through a client may leave cookie-less,
+   *  and every request issued before it answers waits for it, then travels with
+   *  the pointer it established. Costs one extra round trip on a cold load and
+   *  nothing afterwards. Deliberately NOT solved by fingerprinting the requester
+   *  (IP/User-Agent would merge two real visitors behind one NAT into a single
+   *  session) nor by deriving the pointer from request attributes (that would
+   *  make a live session guessable, where today it is a 2^128 search).
+   *
+   *  A failed first request releases the gate rather than holding it, so a cold
+   *  load that starts with an error degrades to the old behaviour, never worse.
+   *  See test/anon-session-race.test.ts — the assertion only fails under real
+   *  concurrency, which is why a sequential probe once "eliminated" this bug. */
+  let established: Promise<void> | undefined;
+
+  async function request(path: string, init?: RequestInit): Promise<Response> {
+    if (established === undefined) {
+      let settle!: () => void;
+      established = new Promise<void>(resolve => { settle = resolve; });
+      try {
+        return await send(path, init);
+      } finally {
+        settle();
+      }
+    }
+    await established;
+    return send(path, init);
   }
 
   async function readJson<T>(path: string, init?: RequestInit): Promise<T> {

--- a/packages/ui/test/anon-session-race.test.ts
+++ b/packages/ui/test/anon-session-race.test.ts
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createVendoClient } from "../src/index.js";
+
+/**
+ * ONE VISITOR, ONE ANONYMOUS IDENTITY — the race.
+ *
+ * An anonymous visitor's identity IS the opaque session pointer the door mints
+ * on a cookie-less wire request, and the door mints one PER REQUEST (see
+ * `wire/context.ts`: the `AnonSession` cache is per-invocation, so it can only
+ * dedupe WITHIN one request). A cold page load mounts several hooks at once —
+ * measured on the live demos: `/status`, `/approvals`, `/automations`,
+ * `/activity`, `/connections/catalog`, `/connections` — and every one of them
+ * leaves cookie-less. Each therefore minted its own subject and the browser's
+ * jar kept whichever Set-Cookie landed last: one visitor became several
+ * identities, the rest orphaned.
+ *
+ * The consequence is the product's trust mechanism failing silently: an agent
+ * run creates a consent approval as identity A, the user's Approve arrives as
+ * identity B, and `guard.ts` correctly refuses another subject's approval —
+ * surfacing as `Approval apr_… was not found` and a run stuck on "waiting for
+ * your approval" forever.
+ *
+ * This MUST be tested as a race. A sequential probe cannot see the bug: the
+ * first request's Set-Cookie is already in the jar before the second leaves, so
+ * requests issued one at a time always agree on one identity. An earlier probe
+ * "eliminated" this very hypothesis for exactly that reason and was wrong.
+ */
+
+/** The door's pointer shape (`ANON_ID_PATTERN` in wire/context.ts). */
+const ANON_ID_PATTERN = /^[0-9a-f]{32}$/;
+const ANON_COOKIE = "vendo_anon_session";
+
+interface FakeDoor {
+  url: string;
+  /** One entry per request the door served, in completion order. */
+  identities: () => string[];
+  /** How many times the door had to MINT a new pointer (the bug's measure). */
+  mints: () => number;
+  close: () => Promise<void>;
+}
+
+function readCookie(header: string | undefined, name: string): string | null {
+  if (header === undefined) return null;
+  for (const part of header.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() === name) return part.slice(eq + 1).trim();
+  }
+  return null;
+}
+
+function randomPointer(): string {
+  const raw = new Uint8Array(16);
+  globalThis.crypto.getRandomValues(raw);
+  return Array.from(raw, byte => byte.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * A stand-in for the door that reproduces its anonymous-session contract
+ * exactly: read the opaque pointer from the Cookie header, and when it is
+ * absent or malformed mint a fresh 128-bit one and Set-Cookie it. Deliberately
+ * slow (10ms) so every request of a concurrent burst is genuinely in flight
+ * before any response returns — that is the window the bug lives in.
+ */
+async function fakeDoor(): Promise<FakeDoor> {
+  const identities: string[] = [];
+  let mints = 0;
+
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    let id = readCookie(req.headers.cookie, ANON_COOKIE);
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    if (id === null || !ANON_ID_PATTERN.test(id)) {
+      id = randomPointer();
+      mints += 1;
+      headers["set-cookie"] = `${ANON_COOKIE}=${id}; Path=/; HttpOnly; SameSite=Lax`;
+    }
+    identities.push(id);
+    setTimeout(() => {
+      res.writeHead(200, headers);
+      // Every burst route answers with an empty collection; `/status` is the one
+      // object-shaped response, and no assertion here reads the body.
+      res.end(req.url?.includes("/status") === true ? "{}" : "[]");
+    }, 10);
+  });
+
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    identities: () => [...identities],
+    mints: () => mints,
+    close: () => new Promise<void>(resolve => { server.close(() => resolve()); }),
+  };
+}
+
+/**
+ * Install a browser-grade cookie jar over `globalThis.fetch`: attach the stored
+ * cookie to every request, and store what comes back. jsdom/undici's `fetch`
+ * keeps no jar of its own, and the jar is the whole point of this test — it is
+ * what makes concurrent cookie-less requests indistinguishable to the door, and
+ * what keeps only the LAST Set-Cookie.
+ */
+function installCookieJar(): { restore: () => void; jar: () => Map<string, string> } {
+  const real = globalThis.fetch;
+  const jar = new Map<string, string>();
+
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const cookie = [...jar.entries()].map(([name, value]) => `${name}=${value}`).join("; ");
+    const response = await real(input, {
+      ...init,
+      headers: { ...(init?.headers as Record<string, string> | undefined), ...(cookie === "" ? {} : { cookie }) },
+    });
+    for (const setCookie of response.headers.getSetCookie()) {
+      const pair = setCookie.split(";")[0]!;
+      const eq = pair.indexOf("=");
+      if (eq !== -1) jar.set(pair.slice(0, eq).trim(), pair.slice(eq + 1).trim());
+    }
+    return response;
+  };
+
+  return { restore: () => { globalThis.fetch = real; }, jar: () => new Map(jar) };
+}
+
+describe("one visitor, one anonymous identity", () => {
+  let door: FakeDoor;
+  let cookies: ReturnType<typeof installCookieJar>;
+
+  beforeEach(async () => {
+    door = await fakeDoor();
+    cookies = installCookieJar();
+  });
+
+  afterEach(async () => {
+    cookies.restore();
+    await door.close();
+  });
+
+  it("resolves ONE identity across a concurrent cookie-less cold-load burst", async () => {
+    const client = createVendoClient({ baseUrl: door.url });
+
+    // The measured cold burst, fired the way mounting hooks fire it: all at
+    // once, none of them carrying a cookie yet.
+    await Promise.all([
+      client.status(),
+      client.approvals.pending(),
+      client.automations.list(),
+      client.activity.list(),
+      client.connections.catalog(),
+      client.connections.list(),
+    ]);
+
+    expect(door.identities()).toHaveLength(6);
+    // The bug: 6 requests → 6 mints → 6 subjects, 5 of them orphaned, and the
+    // jar keeping whichever landed last.
+    expect(new Set(door.identities()).size).toBe(1);
+    expect(door.mints()).toBe(1);
+    expect(cookies.jar().get(ANON_COOKIE)).toMatch(ANON_ID_PATTERN);
+  });
+
+  it("keeps the visitor on the identity the jar already holds (no re-mint)", async () => {
+    const client = createVendoClient({ baseUrl: door.url });
+
+    // A first call establishes the pointer, then a warm burst must reuse it —
+    // re-minting would move a returning visitor off the session holding their
+    // threads, apps and pending approvals.
+    await client.status();
+    const established = cookies.jar().get(ANON_COOKIE);
+
+    await Promise.all([
+      client.approvals.pending(),
+      client.automations.list(),
+      client.activity.list(),
+      client.connections.list(),
+    ]);
+
+    expect(door.mints()).toBe(1);
+    expect(new Set(door.identities()).size).toBe(1);
+    expect(cookies.jar().get(ANON_COOKIE)).toBe(established);
+  });
+});

--- a/packages/vendo/src/anon-session-race.test.ts
+++ b/packages/vendo/src/anon-session-race.test.ts
@@ -1,0 +1,118 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createStore } from "@vendoai/store";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVendo } from "./server.js";
+
+/**
+ * THE DOOR'S HALF OF "one visitor, one anonymous identity".
+ *
+ * The race itself is closed in the SDK's browser client, which is the only
+ * layer that can close it honestly (see @vendoai/ui
+ * test/anon-session-race.test.ts). These two tests pin the door contract that
+ * fix depends on, so it cannot regress silently:
+ *
+ *  1. The door mints one pointer PER cookie-less request — it genuinely cannot
+ *     do otherwise, since two cookie-less requests are indistinguishable from
+ *     two visitors. This test states that plainly, because it is the reason the
+ *     race is not solvable here and must not be "fixed" here later by
+ *     fingerprinting the requester (which would merge two real visitors behind
+ *     one NAT) or by deriving the pointer from request attributes (which would
+ *     make a live session guessable, where today it is a 2^128 search).
+ *
+ *  2. A burst that already carries a pointer produces exactly ONE session and
+ *     ZERO re-mints. This is what makes the client-side fix work, and equally
+ *     what lets a host mint the pointer on its document response: the cookie is
+ *     an opaque unsigned pointer whose session row is the authority, so a
+ *     pre-established pointer is exactly as valid as a door-minted one.
+ */
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => { for (const cleanup of cleanups.splice(0).reverse()) await cleanup(); });
+
+const ANON_ID_PATTERN = /^[0-9a-f]{32}$/;
+
+async function harness(): Promise<{
+  handler: (req: Request) => Promise<Response>;
+  sessions: () => Promise<number>;
+}> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-anon-race-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => { await store.close(); await rm(dataDir, { recursive: true, force: true }); });
+  await store.ensureSchema();
+  // Anonymous visitor: no host principal resolver result, so every request
+  // resolves through the anonymous-session path in wire/context.ts.
+  const vendo = createVendo({ principal: async () => null, store });
+  const sessions = async (): Promise<number> => {
+    const raw = store.raw() as { query<T>(text: string, params?: unknown[]): Promise<{ rows: T[] }> };
+    const result = await raw.query<{ count: number }>("SELECT COUNT(*)::int AS count FROM vendo_sessions WHERE TRUE");
+    return Number(result.rows[0]?.count);
+  };
+  return { handler: req => vendo.handler(req), sessions };
+}
+
+/** A cheap GET that resolves context, and so mints/touches the session. */
+const listThreads = (cookie?: string): Request =>
+  new Request("https://host.test/api/vendo/threads", {
+    headers: cookie === undefined ? {} : { cookie },
+  });
+
+/** The pointer a response minted, if it minted one. */
+const mintedPointer = (res: Response): string | undefined => {
+  const setCookie = res.headers.getSetCookie().find(value => value.includes("vendo_anon_session="));
+  if (setCookie === undefined) return undefined;
+  return setCookie.split(";")[0]!.split("=")[1];
+};
+
+describe("the door's anonymous-session minting under a concurrent burst", () => {
+  it("mints one pointer per cookie-less request — the race it cannot close alone", async () => {
+    const { handler, sessions } = await harness();
+
+    const responses = await Promise.all([
+      handler(listThreads()),
+      handler(listThreads()),
+      handler(listThreads()),
+      handler(listThreads()),
+    ]);
+    await Promise.all(responses.map(res => res.text()));
+
+    const minted = responses.map(mintedPointer);
+    expect(minted.every(pointer => pointer !== undefined && ANON_ID_PATTERN.test(pointer))).toBe(true);
+    // Four cookie-less requests are four visitors as far as the door can tell,
+    // so they are four identities and four sessions. A browser jar would keep
+    // only the last, orphaning three — that is the bug, and it is closed in the
+    // client, not here.
+    expect(new Set(minted).size).toBe(4);
+    expect(await sessions()).toBe(4);
+  });
+
+  it("accepts an already-established pointer across a parallel burst: one session, zero re-mints", async () => {
+    const { handler, sessions } = await harness();
+
+    // A pointer the door never minted — the client's first call, or a host
+    // minting on its document response, produces exactly this. The door treats
+    // it as canonical because the session row is the authority.
+    //
+    // The name must match the door's own secure determination: these requests
+    // are https, so the door reads ONLY the fixation-proof `__Host-` form. Send
+    // the plain name on a secure request and the door reads it as absent and
+    // mints its own — silently back to per-request identities. A browser-side
+    // fix never has to know this; anything minting the pointer by hand does.
+    const established = "0123456789abcdef0123456789abcdef";
+    const pointer = `__Host-vendo_anon_session=${established}`;
+
+    const responses = await Promise.all([
+      handler(listThreads(pointer)),
+      handler(listThreads(pointer)),
+      handler(listThreads(pointer)),
+      handler(listThreads(pointer)),
+      handler(listThreads(pointer)),
+      handler(listThreads(pointer)),
+    ]);
+    await Promise.all(responses.map(res => res.text()));
+
+    expect(responses.map(mintedPointer)).toEqual([undefined, undefined, undefined, undefined, undefined, undefined]);
+    expect(await sessions()).toBe(1);
+  });
+});


### PR DESCRIPTION
## The bug

An anonymous visitor's identity **is** the opaque session pointer the door mints on a cookie-less wire request, and the door mints one **per request**. A cold page load mounts several hooks at once — `/status`, `/approvals`, `/automations`, `/activity`, `/connections/catalog`, `/connections` — so every one of them leaves cookie-less and mints its own subject. The browser's jar keeps whichever `Set-Cookie` landed last; the rest are orphaned. Measured live on the demos: **one page load produced four distinct subjects, three orphaned.**

The damage lands on the trust mechanism at the centre of the product:

- the run creates its consent approval under subject A
- the user's **Approve** arrives as subject B
- `packages/guard/src/guard.ts:1037` correctly refuses another subject's approval
- it surfaces as `Approval apr_… was not found`, and the run sits on *"waiting for your approval"* forever

**Every consent-gated action silently fails.** The same split is why the activity feed reads empty during a live run.

This was previously fixed host-side only (mint the pointer once on the page response). Any customer embedding Vendo the documented way still has the bug, because the SDK still mints per request — it is live in the published 0.5.0. This is the SDK-side fix.

## Why the fix is in the client, not the door

The door genuinely **cannot** close this alone: two cookie-less requests are indistinguishable from two visitors, and the cookie is the only identity there is.

But the **browser is the visitor boundary**, and every route the cold burst touches already funnels through `createVendoClient`'s single `request()` helper. So the client is the layer where the race closes honestly: the first request through a client may leave cookie-less, and every request issued before it answers waits for it, then travels with the pointer it established. One extra round trip on a cold load, nothing afterwards. A failed first request **releases** the gate rather than holding it, so today's behaviour is the floor — never something worse.

### Two mechanisms considered and rejected as unsound

Both were plausible-sounding suggestions, and the tests state the reasoning so they don't get "fixed" in later:

1. **Fingerprinting the requester (IP / User-Agent) to single-flight the mint** — would merge two real visitors behind one corporate NAT into a *single* session, sharing threads, grants and approvals. That is a worse bug, and it breaks the invariant `wire/context.ts` documents ("two anonymous visitors never share threads, grants, approvals, or apps").
2. **Deriving the pointer deterministically from request attributes** — would make a live session *guessable*, where today guessing one is a 2^128 search.

## Tested as a race — the detail that matters most

A sequential probe **cannot** see this bug: the first request's `Set-Cookie` is in the jar before the second leaves, so requests issued one at a time always agree. An earlier probe "eliminated" this very hypothesis for exactly that reason and was wrong.

`packages/ui/test/anon-session-race.test.ts` uses a **real `node:http` door** reproducing the mint-per-cookie-less-request contract, a **real browser-style cookie jar**, and fires the measured six-call burst **concurrently**:

| | identities | mints |
|---|---|---|
| before | **6** | 6 |
| after | **1** | 1 |

Red/green was verified by reverting the fix (`expected 6 to be 1`) and restoring it.

The second test in that file is the **control**: it passes both before *and* after by design, demonstrating why a sequential probe misses this.

`packages/vendo/src/anon-session-race.test.ts` pins the **door half** of the contract against silent regression, using the real door and a real store:

- the door mints one pointer per cookie-less request (stated plainly, because that is *why* the race isn't solvable there)
- a burst that already carries a pointer yields **exactly one session and zero re-mints** — which is also what keeps hosts that mint on their document response working unchanged

That second test also caught a real hazard worth knowing: on an `https` request the door reads **only** the `__Host-` prefixed cookie name. Send the plain name and it reads as absent and mints its own — silently back to per-request identities. A browser-side fix never has to know this; anything minting the pointer by hand does.

## Known residual (not fixed here)

`packages/ui/src/hooks/use-vendo-thread.ts:102` and `packages/ui/src/voice/voice-act.ts:156` post to `/threads` through a bare `fetch` (they need raw headers), so they bypass the gate. In practice this is unreachable: on any chrome-mounted page `/status` fires at mount long before a user can send, so the cookie already exists; and on a bare `<VendoThread>` page the POST is the *only* request, so there is no race. Closing it properly means sharing the gate with those transports without widening the public client surface — worth a follow-up, deliberately not bundled here.

## Verification

- `pnpm build` 23/23 · `pnpm test` 53/53 · `pnpm typecheck` 41/41 · `pnpm lint` 6/6
- full suite run **twice**, the second with `TURBO_FORCE=true` (0 cached, 53/53)
- `packages/ui` alone: 80 files / 665 tests green

No UI/visual surface changes — this changes request sequencing only, so there are no screenshots to attach.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an anonymous-session race so one visitor keeps one identity. This restores consent approvals and live activity by making concurrent cold-load requests share the same cookie.

- **Bug Fixes**
  - Gate session minting in `@vendoai/ui`: the first request establishes the cookie; concurrent requests wait and reuse it.
  - On failure, the gate releases (falls back to current behavior). No UI changes.
  - Added race-focused tests in `packages/ui` and `packages/vendo` to prevent regressions.

<sup>Written for commit a907dd95a95ac7980bf7dd67ddf71109dffb65bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

