### PR TITLE
fix(ui): a turn that builds nothing no longer looks like it is building something

### DIFF
--- a/.changeset/no-skeleton-card-before-first-chunk.md
+++ b/.changeset/no-skeleton-card-before-first-chunk.md
@@ -1,0 +1,21 @@
+---
+"@vendoai/ui": patch
+---
+
+A turn that builds nothing no longer looks like it is building something.
+
+Between send and the first streamed chunk the thread painted a document-shaped
+skeleton card under a "Generating…" label. That window has no idea yet whether
+the turn will produce a view: on the live demos it showed on every turn, then
+resolved into plain prose or a refusal, which read as a generated view that had
+failed to arrive.
+
+The pre-first-chunk window now uses the same quiet liveness indicator every
+other waiting moment in a turn already uses, so the transcript promises nothing
+it may not deliver. Nothing changed about how a real build narrates: tool calls
+still speak through the status ribbon, and a forming generated view still shows
+"Building your view…" on the app card until it settles.
+
+`.fl-generating` and the `.fl-skeleton` card are removed from the chrome
+stylesheet (`.fl-skeleton-bar` stays — the markdown table's forming row uses
+it). The internal `MessageList` no longer takes `awaitingFirstChunk`.

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -396,27 +396,13 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the wave-2
 .fl-md hr { border: 0; border-top: 1px solid var(--vendo-border); margin: 10px 0; }
 .fl-turn-user .fl-md a, .fl-turn-user .fl-md code { color: inherit; border-color: var(--vendo-border); }
 
-/* ---------- generating: quiet status + skeleton (tool chips are hidden) ---------- */
-.fl-generating { align-self: flex-start; display: flex; align-items: center; gap: 8px;
-  font-size: 12.5px; color: var(--vendo-fg-muted); }
-.fl-generating .fl-pulse { width: 8px; height: 8px; border-radius: 50%; background: var(--vendo-accent);
-  animation: fl-pulse 1.2s ease infinite; }
 @keyframes fl-pulse { 0%,100% { opacity: .28; transform: scale(.8); } 50% { opacity: 1; transform: scale(1); } }
-.fl-skeleton { align-self: flex-start; width: 100%; border-radius: var(--vendo-radius);
-  border: 1px solid var(--vendo-border); background: var(--vendo-glass-strong);
-  -webkit-backdrop-filter: var(--vendo-blur); backdrop-filter: var(--vendo-blur);
-  padding: var(--vendo-density-card-padding); box-shadow: var(--vendo-shadow); }
+/* The shimmer bar, shared by the markdown table's forming row. */
 .fl-skeleton-bar { background: linear-gradient(90deg,
     color-mix(in srgb, var(--vendo-fg) 5%, transparent) 25%,
     color-mix(in srgb, var(--vendo-fg) 10%, transparent) 37%,
     color-mix(in srgb, var(--vendo-fg) 5%, transparent) 63%);
   background-size: 400% 100%; animation: fl-shimmer 1.5s ease infinite; border-radius: 6px; }
-/* An answer taking shape: three shortening lines of "text". */
-.fl-skeleton-bar { height: 10px; }
-.fl-skeleton-bar + .fl-skeleton-bar { margin-top: 9px; }
-.fl-skeleton-bar:nth-child(1) { width: 91%; }
-.fl-skeleton-bar:nth-child(2) { width: 76%; }
-.fl-skeleton-bar:nth-child(3) { width: 58%; }
 @keyframes fl-shimmer { 0% { background-position: 100% 0; } 100% { background-position: 0 0; } }
 
 /* ---------- glass skeleton (2026-07-05 recipe): a view taking shape ---------- */
@@ -1182,7 +1168,7 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the wave-2
   .fl-stage { animation: none; }
   /* Silence every looping loader for vestibular-sensitive users. */
   .fl-caret, .fl-md--streaming > :last-child::after { animation: none; opacity: 1; }
-  .fl-typing span, .fl-generating .fl-pulse, .fl-skeleton-bar,
+  .fl-typing span, .fl-skeleton-bar,
   .fl-tool-spin, .fl-tool-spinner, .fl-act-pulse, .fl-act-spin, .fl-connect-spin,
   .fl-auto-created-live::after { animation: none; }
   /* Glass skeleton: the sweep and pulse freeze; the blocks stay tinted. */

--- a/packages/ui/src/chrome/thread/index.tsx
+++ b/packages/ui/src/chrome/thread/index.tsx
@@ -213,12 +213,12 @@ export function VendoThread({
   const assistantHasVisibleText = activeAssistant?.parts.some(
     part => part.type === "text" && part.text.trim().length > 0,
   ) ?? false;
-  // ENG-217 — the three streaming moments each get exactly ONE affordance:
-  // before the first chunk the generating skeleton holds the floor; a streamed
+  // ENG-217 — the streaming moments each get exactly ONE affordance: a streamed
   // turn whose text is still empty shows the lone caret (renderPart); once
-  // text flows the trailing caret rides .fl-md--streaming. FluidThinking
-  // covers the remaining gap (tool phases with no text yet).
-  const awaitingFirstChunk = busy && (activeAssistant === undefined || activeAssistant.parts.length === 0);
+  // text flows the trailing caret rides .fl-md--streaming. FluidThinking covers
+  // every remaining gap, INCLUDING the wait before the first chunk — that
+  // window used to get a document-shaped skeleton card, which promised a view
+  // on turns that never build one (live demo, 2026-07-28).
   const lastPart = activeAssistant?.parts.at(-1);
   const caretShowing = busy && lastPart?.type === "text" && lastPart.state === "streaming"
     && lastPart.text.trim().length === 0;
@@ -226,7 +226,7 @@ export function VendoThread({
   // progress voice — the thinking indicator between beats reads as two
   // indicators fighting.
   const hasBeats = activeAssistant?.parts.some(part => isToolUIPart(part)) ?? false;
-  const working = busy && !assistantHasVisibleText && !awaitingFirstChunk && !caretShowing && !hasBeats;
+  const working = busy && !assistantHasVisibleText && !caretShowing && !hasBeats;
 
   // ENG-215 — edit the last user turn: drop it (and anything after) from the
   // transcript and refill the composer, so re-sending amends rather than
@@ -366,7 +366,7 @@ export function VendoThread({
   // other busy moment narrates through the quiet Working ribbon.
   const textActivelyStreaming = lastPart?.type === "text" && lastPart.state === "streaming"
     && lastPart.text.trim().length > 0;
-  const quietBusy = busy && !awaitingFirstChunk && activeToolPart === undefined
+  const quietBusy = busy && activeToolPart === undefined
     && !textActivelyStreaming && !caretShowing && !working;
   const ribbon = activeToolPart ? (
     <StatusRibbon
@@ -523,7 +523,6 @@ export function VendoThread({
           respond={respondOnce}
           onMorph={setMorph}
           sendMessage={message => thread.sendMessage(message)}
-          awaitingFirstChunk={awaitingFirstChunk}
           working={working}
         />
         {errorBanner}

--- a/packages/ui/src/chrome/thread/message-list.tsx
+++ b/packages/ui/src/chrome/thread/message-list.tsx
@@ -13,7 +13,7 @@ export function MessageList({
   scroll, messageWindow, busy, risks, isRestored,
   activeAssistantId, lastUserId, lastAssistantId, onEditLast, onRegenerateLast,
   approvals, guardApprovals, cardRefs, respond, onMorph,
-  sendMessage, awaitingFirstChunk, working,
+  sendMessage, working,
 }: {
   scroll: ReturnType<typeof useStickToBottom>;
   messageWindow: ReturnType<typeof useMessageWindow>;
@@ -32,7 +32,6 @@ export function MessageList({
   onMorph: ComponentProps<typeof ThreadApprovals>["onMorph"];
   /** The thread's send — connect cards use it for the post-connect continuation. */
   sendMessage: (message: { text: string }) => unknown;
-  awaitingFirstChunk: boolean;
   working: boolean;
 }) {
   return (
@@ -81,19 +80,6 @@ export function MessageList({
           respond={respond}
           onMorph={onMorph}
         />
-        {awaitingFirstChunk ? (
-          <>
-            <div className="fl-generating">
-              <span className="fl-pulse" aria-hidden="true" />
-              Generating&hellip;
-            </div>
-            <div className="fl-skeleton" aria-hidden="true">
-              <div className="fl-skeleton-bar" />
-              <div className="fl-skeleton-bar" />
-              <div className="fl-skeleton-bar" />
-            </div>
-          </>
-        ) : null}
         {working ? <FluidThinking label="Working" /> : null}
       </div>
       {/* Lane picks 3A + 6B — the jump affordance ("N new replies · …") now

--- a/packages/ui/test/chrome/streaming-polish.test.tsx
+++ b/packages/ui/test/chrome/streaming-polish.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-// ENG-217 — streaming polish: the generating skeleton fills the window between
+// ENG-217 — streaming polish: liveness (FluidThinking) fills the window between
 // send and the FIRST chunk, the lone caret marks a streamed turn that is still
 // empty, and the trailing caret (.fl-md--streaming) rides actively-flowing
 // text. Each affordance exists only during its own streaming moment.
@@ -15,7 +15,7 @@ function sendFromComposer(text: string) {
   fireEvent.keyDown(composer, { key: "Enter" });
 }
 
-describe("streaming polish: caret + generating skeleton (ENG-217)", () => {
+describe("streaming polish: caret + liveness (ENG-217)", () => {
   let wire: Awaited<ReturnType<typeof createWireServer>>;
   let client: VendoClient;
 
@@ -29,25 +29,6 @@ describe("streaming polish: caret + generating skeleton (ENG-217)", () => {
     await wire.close();
   });
 
-  it("shows the generating skeleton between send and the first chunk, then yields", async () => {
-    let releaseTurn = () => undefined as void;
-    wire.state.turnStartGate = new Promise<void>(resolve => { releaseTurn = resolve; });
-    const view = render(<VendoProvider client={client}><VendoThread threadId="thr_1" /></VendoProvider>);
-    await screen.findByText("Existing thread");
-
-    sendFromComposer("Hello");
-    await waitFor(() => expect(view.container.querySelector(".fl-generating")).toBeTruthy());
-    expect(view.container.querySelector(".fl-skeleton")).toBeTruthy();
-    // the skeleton replaces the working dots in this window
-    expect(view.container.querySelector(".fl-typing")).toBeNull();
-
-    await act(async () => releaseTurn());
-    // first chunk landed: the skeleton yields (tool chips + working take over)
-    await waitFor(() => expect(view.container.querySelector(".fl-generating")).toBeNull());
-    expect(view.container.querySelector(".fl-skeleton")).toBeNull();
-    expect(await screen.findByText("Turn complete")).toBeTruthy();
-  });
-
   it("shows the lone caret while a streamed turn is still empty, never after", async () => {
     let releaseText = () => undefined as void;
     wire.state.textStartGate = new Promise<void>(resolve => { releaseText = resolve; });
@@ -58,11 +39,31 @@ describe("streaming polish: caret + generating skeleton (ENG-217)", () => {
     await waitFor(() => expect(view.container.querySelector(".fl-caret")).toBeTruthy());
     // the caret IS the liveness indicator now — no doubled affordances
     expect(view.container.querySelector(".fl-typing")).toBeNull();
-    expect(view.container.querySelector(".fl-generating")).toBeNull();
 
     await act(async () => releaseText());
     expect(await screen.findByText("Turn complete")).toBeTruthy();
     await waitFor(() => expect(view.container.querySelector(".fl-caret")).toBeNull());
+  });
+
+  it("narrates the pre-first-chunk wait with liveness only — never view-shaped furniture", async () => {
+    let releaseTurn = () => undefined as void;
+    wire.state.turnStartGate = new Promise<void>(resolve => { releaseTurn = resolve; });
+    const view = render(<VendoProvider client={client}><VendoThread threadId="thr_1" /></VendoProvider>);
+    await screen.findByText("Existing thread");
+
+    sendFromComposer("What is this?");
+    // The turn is live and has produced nothing: liveness shows.
+    await waitFor(() => expect(view.container.querySelector(".fl-typing, .fl-thinking")).toBeTruthy());
+    // …and NOTHING that reads as a view being built. A prose-only turn never
+    // calls vendo_apps_create, so a document-shaped skeleton card here is a
+    // promise the turn may never keep (live demo, 2026-07-28).
+    expect(view.container.querySelector(".fl-skeleton")).toBeNull();
+    expect(view.container.querySelector(".fl-generating")).toBeNull();
+
+    await act(async () => releaseTurn());
+    expect(await screen.findByText("Turn complete")).toBeTruthy();
+    // …and liveness stands down once the turn settles.
+    await waitFor(() => expect(view.container.querySelector(".fl-typing, .fl-thinking")).toBeNull());
   });
 
   it("marks flowing text as streaming (trailing caret) only while the stream is live", async () => {

--- a/tools/video-studio/src/scenes/agent-surface.tsx
+++ b/tools/video-studio/src/scenes/agent-surface.tsx
@@ -223,7 +223,6 @@ export const Transcript: React.FC<{messages: UIMessage[]}> = ({messages}) => (
     respond={noop}
     onMorph={noop}
     sendMessage={noop}
-    awaitingFirstChunk={false}
     working={false}
   />
 );


### PR DESCRIPTION
## What Yousef saw

> "why does it always show the generating card, even if we are not creating anything.
> Shouldn't that only show if `vendo_apps_create` is being called (and lowkey we can just
> use the thing that `vendo_apps_create` has so not sure we even need it)"

## What the wire actually does

Measured on the deployed host (`https://demos.vendo.run/zelty`), raw SSE captured
from a real browser, DOM polled every 150ms. Two turns.

**A prose-only turn** — typed "Hola, ¿qué es esto?"

```
stream part types, in wire order:
  start-step · text-start · text-delta ×10 · text-end · finish-step · finish

  data-vendo-view parts on the wire:      0
  vendo_apps_create mentioned on the wire: false

DOM furniture (t=0 is submit; only rows where the set CHANGED):
     t(ms)   .fl-generating  .fl-skeleton  .fl-appcard-bar  "Building your view"
       151                1             1                0                     0
      3451                0             0                0                     0
```

**A view turn** — typed "Genera un panel con los mensajes enviados y el costo estimado por agente"

```
stream part types, in wire order (abbreviated):
   1 tool-input-start(host_listAgents)
   …
  14 tool-input-start(vendo_apps_create)
  23 tool-input-available(vendo_apps_create)
  24 data-vendo-view          <-- FIRST view part, strictly AFTER the create tool
  …  data-vendo-view ×26
  52 tool-input-start(vendo_apps_open)

DOM furniture:
     t(ms)   .fl-generating  .fl-skeleton  .fl-appcard-bar  appcard state
       153                1             1                0  —
      4802                0             0                0  —            (.fl-ribbon appears)
     24902                0             0                1  building
     39923                0             0                1  ready
```

### So, taking the two questions in turn

**1. Why does "Building your view…" appear on turns that produce no view?**
It does not. `.fl-appcard-bar` count is `0` for the entire prose-only turn, and
"Building your view" never appears in the document. The `parts.tsx:382-383`
read is accurate as code — both labels do stay mounted for the crossfade — but
they only mount when a `data-vendo-view` part exists, and `packages/apps`
emits that part exclusively from inside `create` (`runtime.ts` `emit`). The wire
confirms it: the first `data-vendo-view` arrives at index 24, after
`tool-input-available(vendo_apps_create)` at index 23. That hypothesis is
refuted; that code is innocent and untouched here.

**The card is a different component.** It is the `awaitingFirstChunk` block in
`chrome/thread/message-list.tsx` — a `.fl-generating` "Generating…" label plus a
`.fl-skeleton` card (bordered, glassy, shadowed, three shortening shimmer bars,
i.e. a document taking shape). It mounts ~150ms into **every** turn and is the
only thing on screen for the first several seconds. That is "the generating
card [that] always shows even if we are not creating anything."

**2. Is it redundant furniture that should just be deleted?**
Half. The create path does have its own affordances — the status ribbon from
~4.8s and the app-card bar from ~24.9s — but **neither covers t=0 → ~4.8s**.
Deleting the block outright would leave every turn with no feedback at all for
several seconds, which is worse than a spurious card. And gating it on
`vendo_apps_create` is not implementable as literally stated: at t=150ms nothing
knows whether a view is coming, and on this turn the create tool was not invoked
for another ~25 seconds.

## The change

It still lands as a deletion, because the codebase already had the right
affordance for this moment and was excluding it by one guard:

```
working = busy && !assistantHasVisibleText && !awaitingFirstChunk && !caretShowing && !hasBeats
                                             ^^^^^^^^^^^^^^^^^^^^
```

Drop that guard and `working` (→ `FluidThinking`) covers the pre-first-chunk
window; `quietBusy` already carries `&& !working`, so exactly one affordance
still shows. `awaitingFirstChunk`, its JSX, its prop, and the `.fl-generating` /
`.fl-skeleton` CSS all disappear. Net **-61 / +53**, and most of the additions
are the changeset.

`.fl-skeleton-bar` stays — the markdown table's forming row uses it.

## Real-browser evidence

`packages/ui`'s own e2e harness, which serves the chrome from source and proxies
`/api/vendo` to the unit-test wire fixture. The send's response is held 6s so the
pre-first-chunk window is capturable; the view turn replays the **recorded live
zelty wire**, truncated right after a streaming `data-vendo-view` part so the card
stays mid-build.

| capture | before | after |
|---|---|---|
| prose turn, 2.2s in | `.fl-generating` ×1, `.fl-skeleton` ×1, `.fl-skeleton-bar` ×3, "Generating" | `.fl-thinking` ×1 — nothing else |
| prose turn, settled | no furniture | no furniture |
| view turn, mid-build | appcard `data-state="building"`, visible label "Building your view…" | **identical** |

Screenshots (read and checked against each claim):
`/tmp/lane-building-card/evidence/browser/{before,after}-{1-prose-gap,2-prose-settled,3-view-building}.png`

Live wire captures + DOM timelines:
`/tmp/lane-building-card/evidence/{A-prose-only,B-view-turn}.log` (+ `-wire.sse`, `-furniture.json`)

## Tests

TDD: the new test failed first for the right reason (no liveness indicator, with
`Generating…` and `.fl-skeleton` in the DOM dump), then passed.

**Stated test change:** `streaming-polish.test.tsx`'s first case asserted the
removed furniture *was* present (`.fl-skeleton` truthy, `.fl-typing` null). That
test encoded the behaviour this PR deliberately changes, so it is replaced by
`"narrates the pre-first-chunk wait with liveness only — never view-shaped
furniture"`, which also keeps its stand-down assertion. One now-vacuous
`.fl-generating` assertion in the caret test was dropped with the class.

`pnpm build && pnpm test && pnpm typecheck && pnpm lint` green **twice**:
build 23/23 · test 53/53 · typecheck 41/41 · lint 6/6, exit 0 both runs.

## Reaching the demos

This does **not** reach `demos.vendo.run` on merge. `@vendoai/ui` is at 0.5.0,
0.5.0 is the published `latest`, and the demo host is a separate repo installing
from npm. It needs the pending release (#654 `chore: version packages`) plus a
host dependency bump and redeploy. A changeset is included so it rides that
release as a patch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the pre-first-chunk “Generating…” skeleton card and shows a quiet liveness indicator instead, so prose-only turns no longer look like a view is being built. Real builds still show the status ribbon and “Building your view…” on the app card.

- **Bug Fixes**
  - Replace pre-first-chunk skeleton with `FluidThinking` liveness; avoids false “building” on prose turns (ENG-217).
  - Remove `awaitingFirstChunk`; delete `.fl-generating` and `.fl-skeleton` styles; keep `.fl-skeleton-bar`.
  - Let `working` cover the pre-first-chunk and other no-text/no-beats gaps; still only one affordance at a time.
  - Update tests and `tools/video-studio` usage; add patch changeset for `@vendoai/ui`.

<sup>Written for commit 779a859a850cd9d3c68e737f1a5b06d432b34727. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

