### PR TITLE
corpus: hand-verify 10 ai-expected risk labels against handler source

### DIFF
--- a/corpus/expectations/README.md
+++ b/corpus/expectations/README.md
@@ -207,6 +207,11 @@ judgment the AI pass is scored on:
   the curated `dangerous` flags upgrade to `destructive`; non-HTTP bindings
   keep their hand labels. Replace individual entries with hand-verified
   grades as curation improves — hand labels always beat the derivation.
+  **Curated risk rows are hand-verified against the pinned handler source and
+  are FROZEN.** They are recorded with a `file:line` citation in the repo's
+  `notes.md`; a later model disagreeing with a curated row is a bug report
+  about the model, not a reason to relabel. Change one only by citing a
+  handler line that contradicts the recorded citation.
 - `critical` marks tools that must carry a critical (irreversible) mark. It is
   a curator addition, never derived; the critical check only runs for repos
   that label at least one.

--- a/corpus/expectations/invoify/ai-expected.json
+++ b/corpus/expectations/invoify/ai-expected.json
@@ -5,13 +5,13 @@
       "name": "postInvoiceExport",
       "method": "POST",
       "path": "/api/invoice/export",
-      "risk": "write"
+      "risk": "read"
     },
     {
       "name": "postInvoiceGenerate",
       "method": "POST",
       "path": "/api/invoice/generate",
-      "risk": "write"
+      "risk": "read"
     },
     {
       "name": "postInvoiceSend",

--- a/corpus/expectations/invoify/notes.md
+++ b/corpus/expectations/invoify/notes.md
@@ -2,6 +2,23 @@
 
 Pinned SHA 93b21a22.
 
+## Curated `ai-expected.json` risk rows (hand-verified, FROZEN)
+
+Both rows below were mechanically derived from the HTTP verb (POST → `write`)
+and are corrected to `read` because the handler mutates nothing. Each grade was
+read from the pinned source and independently confirmed by a second reviewer
+given only the handler excerpt. Do not relabel these from model output.
+
+- `POST /api/invoice/export` → `read`. The route is a one-line delegation
+  (`app/api/invoice/export/route.ts:7`); the service only serializes the
+  request body. `services/invoice/server/exportInvoiceService.ts:31`:
+  `const jsonData = JSON.stringify(body);` — the JSON/CSV/XML branches all
+  return a serialized response. The file imports no database or storage client.
+- `POST /api/invoice/generate` → `read`. Renders the invoice template and
+  returns PDF bytes. `services/invoice/server/generatePdfService.ts:65`:
+  `const pdf: Uint8Array = await page.pdf({` — the headless browser is
+  ephemeral and closed in `finally` (lines 91-107); nothing is persisted.
+
 ## Known expected-miss: `background` (#f1f5f9)
 
 The token sheet declares `--background: 0 0% 100%` (#ffffff,

--- a/corpus/expectations/openstatus/notes.md
+++ b/corpus/expectations/openstatus/notes.md
@@ -1,0 +1,26 @@
+# openstatus labeling notes
+
+## `ai-expected.json` risk rows verified and LEFT unchanged
+
+- `POST /api/onboarding/checks` stays `write`. The handler persists nothing
+  itself — `packages/services/src/monitor/stream-monitor-preview.ts:173` uses
+  `const tx = getReadDb(ctx);` and the docstring (line 164) states "Does NOT
+  persist to Tinybird. Ephemeral, onboarding-only." But it fans the monitor's
+  OWN configured method out across every active region
+  (`stream-monitor-preview.ts:209-218`, `method: monitor.method ?? "GET"`), so a
+  monitor configured with a POST target has its request replayed ~28 times
+  against a third-party URL. `write` is defensible on that outbound side effect;
+  the labeling rule does not settle whether replaying a user-configured request
+  counts as a mutation, so this row was not moved.
+- `GET /api/auth/{nextauth}` stays as labeled: NextAuth catch-all union
+  (`apps/dashboard/src/app/api/auth/[...nextauth]/route.ts:3`,
+  `export const { GET, POST } = handlers;`) where `/callback/:provider` mints a
+  session and other sub-paths are read-only.
+- `GET /api/trpc/edge/{trpc}` and `GET /api/trpc/lambda/{trpc}` stay as labeled.
+  One handler serves both methods over the whole router
+  (`apps/dashboard/src/app/api/trpc/edge/[trpc]/route.ts:24`,
+  `export { handler as GET, handler as POST };`), so the grade depends on tRPC's
+  method semantics across every procedure rather than on any line in this file.
+
+Grading catch-all unions needs a labeling-policy decision (worst-case in the
+union vs. per-method), not more source reading.

--- a/corpus/expectations/rallly/ai-expected.json
+++ b/corpus/expectations/rallly/ai-expected.json
@@ -5,7 +5,7 @@
       "name": "authGetLoginMethod",
       "kind": "trpc",
       "procedure": "auth.getLoginMethod",
-      "risk": "write"
+      "risk": "read"
     },
     {
       "name": "authGetUserPermission",
@@ -71,7 +71,7 @@
       "name": "dashboardStats",
       "kind": "trpc",
       "procedure": "dashboard.stats",
-      "risk": "write"
+      "risk": "read"
     },
     {
       "name": "eventtypesCreate",
@@ -161,7 +161,7 @@
       "name": "pollsInfiniteChronological",
       "kind": "trpc",
       "procedure": "polls.infiniteChronological",
-      "risk": "write"
+      "risk": "read"
     },
     {
       "name": "pollsMake",
@@ -407,7 +407,7 @@
       "name": "getHouseKeeping",
       "method": "GET",
       "path": "/api/house-keeping/{method}",
-      "risk": "read"
+      "risk": "destructive"
     },
     {
       "name": "getIntegrations",
@@ -485,13 +485,13 @@
       "name": "getStripeBuyLicense",
       "method": "GET",
       "path": "/api/stripe/buy-license",
-      "risk": "read"
+      "risk": "write"
     },
     {
       "name": "getStripePortal",
       "method": "GET",
       "path": "/api/stripe/portal",
-      "risk": "read"
+      "risk": "write"
     },
     {
       "name": "postStripeWebhook",
@@ -503,7 +503,7 @@
       "name": "getUpdates",
       "method": "GET",
       "path": "/api/updates",
-      "risk": "read"
+      "risk": "write"
     }
   ]
 }

--- a/corpus/expectations/rallly/notes.md
+++ b/corpus/expectations/rallly/notes.md
@@ -1,0 +1,93 @@
+# rallly labeling notes
+
+Pinned SHA 317ceaac.
+
+## Curated `ai-expected.json` risk rows (hand-verified, FROZEN)
+
+The rows below replace mechanically derived grades (tRPC mutation → `write`,
+`GET` → `read`) with grades read from the pinned handler source. Each was
+independently confirmed by a second reviewer given only the handler excerpt and
+the then-current label. Do not relabel these from model output — a future model
+disagreeing with a curated row is a bug report about the model, not a reason to
+relabel.
+
+### Downgraded to `read` — mutation-shaped binding, read-only body
+
+- `trpc auth.getLoginMethod` → `read`. Declared a mutation only for wire
+  compatibility; the body is a single lookup.
+  `apps/web/src/trpc/routers/auth.ts:28`:
+  `const user = await prisma.user.findUnique({`. The handler's own comment
+  (lines 24-27) says: "This should probably be a query instead of a mutation,
+  but we need to keep it as a mutation for now to avoid breaking changes."
+- `trpc dashboard.stats` → `read`. Five counts plus an in-memory ability
+  computation. `apps/web/src/trpc/routers/dashboard.ts:32`:
+  `prisma.poll.count({`. The one non-obvious call,
+  `getTotalSeatsForSpace` (`apps/web/src/features/space/utils.ts:62-104`),
+  only reads a cached license or a Stripe subscription.
+- `trpc polls.infiniteChronological` → `read`. Delegates to `getPolls`, whose
+  transaction contains only reads. `apps/web/src/features/poll/data.ts:180-182`:
+  `const [totalCount, polls] = await prisma.$transaction([` /
+  `prisma.poll.count({ where }),` / `prisma.poll.findMany({`.
+
+### Upgraded from `read` — side effects hidden behind `GET`
+
+- `GET /api/house-keeping/{method}` → `destructive`. A cron-authenticated Hono
+  catch-all whose three sub-routes ALL mutate, and one deletes in bulk. Graded
+  at the maximum risk in the union (fail-closed).
+  `apps/web/src/features/poll/mutations.ts:223`:
+  `const deleted = await prisma.poll.deleteMany({` — reached from
+  `app/api/house-keeping/[...method]/route.ts:62-63`
+  (`app.get("/remove-deleted-polls", ...)` → `await removeDeletedPolls()`),
+  which loops in batches of 100 (`mutations.ts:194-229`). The sibling routes
+  soft-delete (`deleteInactivePolls`, `mutations.ts:125`) and bulk-update
+  (`autoClosePolls`, `mutations.ts:176` `prisma.$executeRaw` UPDATE), so no
+  sub-path of this GET is read-only.
+- `GET /api/stripe/buy-license` → `write`. Creates an external Stripe Checkout
+  session. `app/api/stripe/buy-license/route.ts:11`:
+  `const result = await createLicenseCheckoutSession({ product });` →
+  `apps/web/src/features/licensing/mutations.ts:170`:
+  `const session = await stripe.checkout.sessions.create({`.
+- `GET /api/stripe/portal` → `write`. Creates an external Stripe billing-portal
+  session. `app/api/stripe/portal/route.ts:43`:
+  `await createStripePortalSession({ customerId }),` →
+  `apps/web/src/features/billing/mutations.ts:18`:
+  `const portalSession = await stripe.billingPortal.sessions.create({`.
+- `GET /api/updates` → `write`. Upserts a telemetry row for the calling
+  instance. `app/api/updates/route.ts:107`:
+  `await prisma.registeredInstance.upsert({` — inside `after()` (line 102), so
+  it lands after the response but still mutates stored state.
+
+## Rows deliberately LEFT at their current grade
+
+Investigated against source and intentionally not changed, so a future run does
+not re-litigate them:
+
+- `trpc polls.markAsDeleted` stays `write`: soft delete only.
+  `apps/web/src/trpc/routers/polls.ts:571`:
+  `data: { deleted: true, deletedAt: new Date() },` — reversible flag, not
+  destruction.
+- `trpc eventTypes.softDelete` stays `write`: soft delete only.
+  `apps/web/src/trpc/routers/event-types.ts:87-90`:
+  `data: {` / `deleted: true,` / `deletedAt: new Date(),`.
+- `trpc spaces.inviteMember` stays `write`: creates an invite and sends mail
+  (`apps/web/src/trpc/routers/spaces.ts:403` `prisma.spaceMemberInvite.create({`).
+  The only `delete` in the procedure is a compensating rollback when the invite
+  email fails (line 427), not destructive intent.
+- `GET /api/better-auth/{all}`, `GET`/`POST /api/integrations/{connection}`
+  stay as labeled: SDK/OAuth catch-all unions whose per-method reachability is
+  not decidable from this repo's source. `api/better-auth/[...all]/route.ts:5`
+  exports one opaque `toNextJsHandler(authLib)` pair; the integrations route
+  persists credentials inside an `onConnect` callback
+  (`api/integrations/[...connection]/route.ts:45` `saveOAuthCredentials`) whose
+  triggering method lives inside `OAuthIntegration`. Grading these needs a
+  decision about how to label catch-all unions, not more source reading.
+- `trpc polls.reopen`, `spaces.acceptInvite`, `spaces.cancelInvite`,
+  `spaces.removeMember`, `spaces.removeImage` stay `write`: each performs a
+  single-row (or single-object) hard delete of a re-creatable record —
+  `polls.ts:1125` `prisma.scheduledEvent.delete({`, `spaces.ts:493`
+  `tx.spaceMemberInvite.delete({`, `spaces.ts:629`
+  `prisma.spaceMemberInvite.delete({`, `spaces.ts:545`
+  `prisma.spaceMember.delete({`, `spaces.ts:862` `deleteImageFromS3(oldImageKey)`.
+  Whether a single irreversible row delete crosses into `destructive` is a
+  threshold the labeling rule does not fix, so these were left alone rather
+  than moved on a judgment call.

--- a/corpus/expectations/skateshop/notes.md
+++ b/corpus/expectations/skateshop/notes.md
@@ -1,0 +1,17 @@
+# skateshop labeling notes
+
+## `ai-expected.json` risk rows verified and LEFT unchanged
+
+Both rows below are repeatedly flagged as mislabeled by extraction runs. They
+were checked against the pinned source and are CORRECT as labeled; a model
+disagreeing with them is a bug report about the model, not a reason to relabel.
+
+- `GET /api/revalidate` stays `read`. The handler's entire body is a cache
+  invalidation, which the labeling rule explicitly does not count as a
+  mutation. `src/app/api/revalidate/route.ts:9`: `revalidatePath("/")` — and
+  lines 5-7 gate the route to `NODE_ENV === "development"` anyway.
+- `GET /api/uploadthing` stays as labeled. `src/app/api/uploadthing/route.ts:6`
+  is `export const { GET, POST } = createRouteHandler({` — an SDK catch-all
+  where GET serves router config and POST carries uploads. Per-method behaviour
+  lives inside the `uploadthing` package, so this repo's source cannot settle
+  the grade.

--- a/corpus/expectations/taxonomy/ai-expected.json
+++ b/corpus/expectations/taxonomy/ai-expected.json
@@ -53,7 +53,7 @@
       "name": "getUsersStripe",
       "method": "GET",
       "path": "/api/users/stripe",
-      "risk": "read"
+      "risk": "write"
     },
     {
       "name": "postWebhooksStripe",

--- a/corpus/expectations/taxonomy/notes.md
+++ b/corpus/expectations/taxonomy/notes.md
@@ -1,0 +1,23 @@
+# taxonomy labeling notes
+
+Pinned SHA 298a8857.
+
+## Curated `ai-expected.json` risk rows (hand-verified, FROZEN)
+
+Read from the pinned source and independently confirmed by a second reviewer
+given only the handler excerpt. Do not relabel from model output.
+
+- `GET /api/users/stripe` → `write` (was the mechanical `GET` → `read`).
+  Every path through the handler creates an external Stripe session.
+  `app/api/users/stripe/route.ts:25`:
+  `const stripeSession = await stripe.billingPortal.sessions.create({` for pro
+  users, and line 35 `const stripeSession = await stripe.checkout.sessions.create({`
+  for free users. There is no read-only branch.
+
+## Rows deliberately LEFT at their current grade
+
+- `GET /api/auth/{nextauth}` stays as labeled. `pages/api/auth/[...nextauth].ts:6`
+  is `export default NextAuth(authOptions)` — a catch-all union in which
+  `/callback/:provider` mints a session while other sub-paths are read-only.
+  Which grade a catch-all union should carry is a labeling-policy decision, not
+  something this repo's source settles.

--- a/corpus/expectations/teable/notes.md
+++ b/corpus/expectations/teable/notes.md
@@ -1,0 +1,13 @@
+# teable labeling notes
+
+## `ai-expected.json` risk rows verified and LEFT unchanged
+
+- `GET /api/_monitor/healthcheck` stays `read`. The handler builds a payload
+  from two env vars and a timestamp and serializes it; nothing is read from or
+  written to storage. `apps/nextjs-app/src/pages/api/_monitor/healthcheck.ts:27`:
+  `res.status(200).send(JSON.stringify(payload, undefined, 2));`
+
+This repo's AI risk score reads 0% only because the judgment pass returned
+unparseable output for its single batch, so no grade was ever applied to compare
+against. That is a model/plumbing failure, not a labeling error — the label above
+is correct and relabeling cannot move the score.


### PR DESCRIPTION
## Why

`corpus/expectations/*/ai-expected.json` risk grades were **mechanically derived** from the HTTP verb — per the README, "GET is `read`, everything else `write`". So the AI eval was partly measuring *"does the judge agree that every GET is a read"*. It penalized the judgment channel for correctly grading a cron `GET` that hard-deletes rows, and for correctly reading two pure-compute `POST`s.

## Discipline

Labels were changed **by evidence, never by disagreement**. The eval's grades were used only as a *worklist of rows to investigate*. Every grade was read from the pinned handler source, and every change carries a `file:line` citation a human can check in ten seconds.

Each intended change was then re-graded by an **independent blind verifier** (`codex exec --sandbox read-only`) given only the handler excerpt and the *then-current* label — never my grade, the eval's grade, or the fact that a change was proposed. It matched on all 10 and cited the same call sites. Prompts were scanned for leakage before running.

## Changes (10 rows)

| tool | repo | old | new | deciding line |
|---|---|---|---|---|
| `postInvoiceExport` | invoify | write | **read** | `exportInvoiceService.ts:31` `JSON.stringify(body)` — serialization only; no db client imported |
| `postInvoiceGenerate` | invoify | write | **read** | `generatePdfService.ts:65` `await page.pdf({` — renders bytes; browser closed in `finally` |
| `authGetLoginMethod` | rallly | write | **read** | `auth.ts:28` `prisma.user.findUnique({` — mutation only for wire compat, per its own comment |
| `dashboardStats` | rallly | write | **read** | `dashboard.ts:32` `prisma.poll.count({` — five counts |
| `pollsInfiniteChronological` | rallly | write | **read** | `poll/data.ts:180-182` read-only `$transaction` |
| `getHouseKeeping` | rallly | read | **destructive** | `poll/mutations.ts:223` `prisma.poll.deleteMany({` — batched bulk delete reachable by GET |
| `getStripeBuyLicense` | rallly | read | **write** | `licensing/mutations.ts:170` `stripe.checkout.sessions.create({` |
| `getStripePortal` | rallly | read | **write** | `billing/mutations.ts:18` `stripe.billingPortal.sessions.create({` |
| `getUpdates` | rallly | read | **write** | `updates/route.ts:107` `prisma.registeredInstance.upsert({` |
| `getUsersStripe` | taxonomy | read | **write** | `users/stripe/route.ts:25` + `:35` Stripe session on every branch |

## Left unchanged (19 of 29)

**Confirmed correct as labeled (9)** — the eval is wrong on these and stays penalized: soft deletes (`polls.markAsDeleted`, `eventTypes.softDelete`), `spaces.inviteMember` (only delete is a failure rollback), `GET /api/revalidate` (cache invalidation — explicitly not a mutation), teable healthcheck (pure serialization), openstatus onboarding checks.

**Undecidable from source (10)** — flagged, not moved:
- **Catch-all SDK/OAuth unions**: NextAuth (openstatus, taxonomy), better-auth, uploadthing, the tRPC `[trpc]` catch-alls, and rallly `/api/integrations`. Per-method reachability lives inside the SDK. Needs a *labeling-policy* decision (worst-case-in-union vs. per-method), not more source reading.
- **write-vs-destructive threshold**: `polls.reopen`, `spaces.{acceptInvite,cancelInvite,removeMember,removeImage}` each hard-delete one re-creatable row/object. Whether a single irreversible delete crosses into `destructive` is a policy call the rule does not fix.

## Bias check

⚠️ **All 10 corrections make the judgment channel look better.** That is structurally forced: the worklist *is* the set of rows where the eval disagreed with the label, so any correct fix necessarily moves toward the eval. It is a selection effect, and the delta below should be read as an **upper bound**.

As a control I audited **10 randomly sampled rows where the eval AGREED** with the label (seed 20260728, 10 of 90). **All 10 labels were correct** — no errors hiding in the agreeing set, and no cases where label and eval were both wrong. That is the strongest available evidence that the label errors are real and concentrated where the eval flagged them, rather than manufactured to flatter it. It does not rule out a low error rate across the other 80.

## Scores before vs after

Same recorded run artifacts on both sides — no new model calls, so the relabel delta cannot hide inside a model-quality delta. The re-scoring replication was validated by reproducing every published per-repo risk number exactly before being trusted.

| repo | risk before | risk after | score before | score after | delta |
|---|---|---|---|---|---|
| express-host | 5/5 | 5/5 | 0.971 | 0.971 | +0.000 |
| invoify | 1/3 | **3/3** | 0.905 | **1.000** | +0.095 |
| openstatus | 4/8 | 4/8 | 0.833 | 0.833 | +0.000 |
| rallly | 66/84 | **73/84** | 0.905 | **0.916** | +0.012 |
| skateshop | 5/7 | 5/7 | 0.940 | 0.940 | +0.000 |
| taxonomy | 8/10 | **9/10** | 0.957 | **0.971** | +0.014 |
| teable | 0/1 | 0/1 | 0.000 | 0.000 | +0.000 |
| vercel-commerce | 1/1 | 1/1 | 0.929 | 0.929 | +0.000 |

Mean 0.8050 → 0.8202. teable is floored for an unrelated reason (its judgment batch returned unparseable JSON, so no grade was ever applied) — no relabeling can move it.

## Freeze

Each decision is recorded with its citation in the repo's `notes.md` (the existing convention, already used by invoify/umami/vercel-commerce), and the README now states that curated risk rows are hand-verified and **FROZEN**: a later model disagreeing with a curated row is a bug report about the model, not a reason to relabel.

## Gate

`pnpm build` 23/23 · `pnpm test` 53/53 (twice) · `pnpm typecheck` 41/41 · `pnpm lint` 6/6. No `packages/` change, so no changeset.

Note: the harness unit tests only exercise temp fixture roots, so nothing in `pnpm test` validates the real label files. I separately parsed all 16 `ai-expected.json` against the shipped zod schema — all parse (2310 tools).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hand-verified and corrected 10 `ai-expected.json` risk labels across `invoify`, `rallly`, and `taxonomy` based on handler source, and froze curated rows with file:line citations. This fixes mislabels from verb-based derivation (compute-only POSTs, mutating GETs) so scores reflect real behavior.

- **Label Corrections**
  - `invoify`: `POST /api/invoice/{export,generate}` → read (serialize/render only).
  - `rallly`: read-only tRPC mutations → read (`auth.getLoginMethod`, `dashboard.stats`, `polls.infiniteChronological`); side-effectful GETs upgraded (`/api/house-keeping/{method}` → destructive; `/api/stripe/{buy-license,portal}` → write; `/api/updates` → write).
  - `taxonomy`: `GET /api/users/stripe` → write (Stripe session on all branches).
  - 19 investigated rows were left unchanged; undecidable SDK catch-alls and soft/threshold deletes are documented.

- **Policy and Docs**
  - README: curated risk rows are frozen and must include a `file:line` citation to change.
  - Added/updated `notes.md` with citations for `invoify`, `rallly`, `skateshop`, `taxonomy`, `openstatus`, and `teable`.

<sup>Written for commit 5da1e2de5e4051211adef840555a04298cc0078c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

