### PR TITLE
corpus: resolve the parked risk rows under two labeling-policy rules

### DIFF
--- a/.changeset/judge-labeling-policy-rules.md
+++ b/.changeset/judge-labeling-policy-rules.md
@@ -1,0 +1,25 @@
+---
+"@vendoai/vendo": patch
+---
+
+Teach the judge three labeling rules the mutation test cannot derive.
+
+The risk section of the judge prompt now states, alongside the mutation test:
+
+- **A catch-all route is graded at its worst operation.** When one URL fronts
+  many operations (`[...nextauth]`, `[trpc]`, an upload or OAuth SDK handler),
+  which method reaches which operation is decided inside the dependency, not in
+  the host's source — so the tool is graded at the most dangerous operation
+  reachable behind that URL, and when the source cannot settle it, at the worst
+  plausible one, said out loud in the reason.
+- **`destructive` needs bulk or irreversible loss.** A hard delete of one easily
+  re-created row or object — remove a member, cancel an invite, remove an image
+  — is a `write`. If every delete were destructive the top grade would mean
+  nothing.
+- **An unrecallable outbound effect is a `write` with no row written** — mail or
+  SMS sent, a webhook delivered, a payment captured, an external checkout or
+  billing-portal session created.
+
+Doctrine is unchanged: hardenings still apply immediately, loosenings still need
+the skeptic and a human, and the self-consistency check still drops a grade that
+contradicts its own reason.

--- a/corpus/expectations/README.md
+++ b/corpus/expectations/README.md
@@ -212,6 +212,27 @@ judgment the AI pass is scored on:
   `notes.md`; a later model disagreeing with a curated row is a bug report
   about the model, not a reason to relabel. Change one only by citing a
   handler line that contradicts the recorded citation.
+
+  Three rules the mutation test does not derive on its own decide the rows it
+  used to leave undecidable. They are the same rules the judge prompt states
+  (`packages/vendo/src/cli/judge/prompts.ts`), so labels and model are graded
+  against one policy rather than two:
+  - **A catch-all route is graded at its WORST reachable operation**, and carries
+    that grade on every method it exports. When one URL fronts many operations
+    (`[...nextauth]`, `[trpc]`, an upload or OAuth SDK handler), which method
+    reaches which operation is decided inside the dependency; splitting the grade
+    by verb invents a benign method that may not exist. Where the host's source
+    cannot settle what the catch-all exposes, read the pinned dependency and cite
+    it (see rallly's better-auth row and skateshop's uploadthing row), and if even
+    that cannot settle it, grade at the worst plausible operation and say so.
+  - **`destructive` needs BULK or IRREVERSIBLE loss** — a delete spanning many
+    records, or the loss of something that cannot be re-created. A hard delete of
+    ONE easily re-created row or object (remove a member, cancel an invite,
+    remove an image) is `write`. If every delete were `destructive` the top grade
+    would stop carrying information.
+  - **An unrecallable outbound effect is a `write` with no row written** — mail or
+    SMS sent, a webhook delivered, a payment captured, an external checkout or
+    billing-portal session created. Receiving a webhook is not one of these.
 - `critical` marks tools that must carry a critical (irreversible) mark. It is
   a curator addition, never derived; the critical check only runs for repos
   that label at least one.

--- a/corpus/expectations/openstatus/ai-expected.json
+++ b/corpus/expectations/openstatus/ai-expected.json
@@ -5,7 +5,7 @@
       "name": "getAuthNextauth",
       "method": "GET",
       "path": "/api/auth/{nextauth}",
-      "risk": "read"
+      "risk": "write"
     },
     {
       "name": "postAuthNextauth",
@@ -29,25 +29,25 @@
       "name": "getTrpcEdgeTrpc",
       "method": "GET",
       "path": "/api/trpc/edge/{trpc}",
-      "risk": "read"
+      "risk": "destructive"
     },
     {
       "name": "postTrpcEdgeTrpc",
       "method": "POST",
       "path": "/api/trpc/edge/{trpc}",
-      "risk": "write"
+      "risk": "destructive"
     },
     {
       "name": "getTrpcLambdaTrpc",
       "method": "GET",
       "path": "/api/trpc/lambda/{trpc}",
-      "risk": "read"
+      "risk": "destructive"
     },
     {
       "name": "postTrpcLambdaTrpc",
       "method": "POST",
       "path": "/api/trpc/lambda/{trpc}",
-      "risk": "write"
+      "risk": "destructive"
     }
   ]
 }

--- a/corpus/expectations/openstatus/notes.md
+++ b/corpus/expectations/openstatus/notes.md
@@ -1,6 +1,69 @@
 # openstatus labeling notes
 
-## `ai-expected.json` risk rows verified and LEFT unchanged
+Pinned SHA f7dc9efe. Citations below are rooted at `apps/dashboard`, the app the
+existing labels were derived from. The grades do not depend on that choice:
+`apps/web` and `apps/status-page` carry their own copies of the tRPC catch-alls
+differing only in import paths, and all three mount the same `edgeRouter` /
+`lambdaRouter`. `apps/status-page` also has its own `[...nextauth]` route
+(`apps/web` has none), likewise adapter-backed and writing on sign-in
+(`apps/status-page/src/lib/auth/index.ts:47-51` `.update(viewer)`).
+
+## Curated `ai-expected.json` risk rows (hand-verified, FROZEN)
+
+Every row below is a catch-all URL graded at its WORST reachable operation, per
+the labeling rule the README now states. Each grade was read from the pinned
+source and independently confirmed by a second reviewer given only the handler
+excerpt, the then-current label and the rule. Do not relabel these from model
+output.
+
+- `GET /api/auth/{nextauth}` → `write` (`POST` was already `write`). One opaque
+  pair of handlers fronts the whole NextAuth surface —
+  `apps/dashboard/src/app/api/auth/[...nextauth]/route.ts:3`:
+  `export const { GET, POST } = handlers;`. The worst operation behind it writes
+  user rows: `apps/dashboard/src/lib/auth/index.ts:48`: `.update(user)` inside
+  the `signIn` callback (lines 47-60, and again at 66-74 and 80-84), on top of
+  the row-creating adapter at `apps/dashboard/src/lib/auth/adapter.ts:14`:
+  `...(DrizzleAdapter(db, {`. Nothing behind this URL deletes in bulk or
+  irreversibly — `grep -rni delete` over both auth directories and both auth
+  route directories returns no match — so `destructive` is not earned and
+  `write` is the worst grade.
+
+- `GET`/`POST /api/trpc/edge/{trpc}` → `destructive`. One handler serves both
+  methods over the entire edge router
+  (`apps/dashboard/src/app/api/trpc/edge/[trpc]/route.ts:24`:
+  `export { handler as GET, handler as POST };`), and the router mounts the user
+  procedures (`packages/api/src/edge.ts:35`: `  user: userRouter,`). The worst
+  operation reachable behind the URL is account deletion —
+  `packages/api/src/router/user.ts:18`:
+  `deleteAccount: protectedProcedure.mutation(async ({ ctx }) => {` →
+  `packages/services/src/user/delete.ts:174-175`:
+  `await tx.delete(session).where(eq(session.userId, userId));` /
+  `await tx.delete(account).where(eq(account.userId, userId));`, which also
+  strips non-owner memberships (`delete.ts:165-172`), blanks the user's PII
+  (`delete.ts:178-181`, `email: ""`) and fans out into `deleteMonitors` /
+  `deletePage` / `deleteNotification` for every owned workspace
+  (`delete.ts:138-140`, `:149-151`, `:160-162`). Many rows, many tables, not
+  recoverable.
+
+- `GET`/`POST /api/trpc/lambda/{trpc}` → `destructive`. Same one-handler shape
+  (`apps/dashboard/src/app/api/trpc/lambda/[trpc]/route.ts:25`) over the lambda
+  router, which mounts the Stripe webhook procedures
+  (`packages/api/src/lambda.ts:10`: `  stripeRouter: stripeRouter,`). Its worst
+  operation is the downgrade cleanup —
+  `packages/api/src/router/stripe/webhook.ts:210`:
+  `customerSubscriptionDeleted: webhookProcedure.mutation(async (opts) => {` —
+  which in one transaction hard-deletes every status page but the oldest
+  (`webhook.ts:274-276`, each cascading to its components, subscribers, status
+  reports and maintenances), every notification channel but one
+  (`:301-305`), every non-owner membership (`:308-316`) and every pending
+  invitation (`:319-322`). Bulk, and keyed only on
+  `eq(workspace.stripeId, customerId)` (`:236`).
+
+  The route's only gate is a header check —
+  `apps/dashboard/src/lib/trpc/shared.ts:22` `guardTRPCSource` 401s unless
+  `x-trpc-source` is `"server"` or `"client"` — so reachability is not in doubt.
+
+## Rows deliberately LEFT at their current grade
 
 - `POST /api/onboarding/checks` stays `write`. The handler persists nothing
   itself — `packages/services/src/monitor/stream-monitor-preview.ts:173` uses
@@ -9,18 +72,5 @@
   OWN configured method out across every active region
   (`stream-monitor-preview.ts:209-218`, `method: monitor.method ?? "GET"`), so a
   monitor configured with a POST target has its request replayed ~28 times
-  against a third-party URL. `write` is defensible on that outbound side effect;
-  the labeling rule does not settle whether replaying a user-configured request
-  counts as a mutation, so this row was not moved.
-- `GET /api/auth/{nextauth}` stays as labeled: NextAuth catch-all union
-  (`apps/dashboard/src/app/api/auth/[...nextauth]/route.ts:3`,
-  `export const { GET, POST } = handlers;`) where `/callback/:provider` mints a
-  session and other sub-paths are read-only.
-- `GET /api/trpc/edge/{trpc}` and `GET /api/trpc/lambda/{trpc}` stay as labeled.
-  One handler serves both methods over the whole router
-  (`apps/dashboard/src/app/api/trpc/edge/[trpc]/route.ts:24`,
-  `export { handler as GET, handler as POST };`), so the grade depends on tRPC's
-  method semantics across every procedure rather than on any line in this file.
-
-Grading catch-all unions needs a labeling-policy decision (worst-case in the
-union vs. per-method), not more source reading.
+  against a third-party URL. That is an outbound side effect the caller cannot
+  take back, which the rule now names as a `write`, so the row stands.

--- a/corpus/expectations/rallly/ai-expected.json
+++ b/corpus/expectations/rallly/ai-expected.json
@@ -389,13 +389,13 @@
       "name": "getBetterAuth",
       "method": "GET",
       "path": "/api/better-auth/{all}",
-      "risk": "read"
+      "risk": "destructive"
     },
     {
       "name": "postBetterAuth",
       "method": "POST",
       "path": "/api/better-auth/{all}",
-      "risk": "write"
+      "risk": "destructive"
     },
     {
       "name": "getEvent",
@@ -413,7 +413,7 @@
       "name": "getIntegrations",
       "method": "GET",
       "path": "/api/integrations/{connection}",
-      "risk": "read"
+      "risk": "write"
     },
     {
       "name": "postIntegrations",

--- a/corpus/expectations/rallly/notes.md
+++ b/corpus/expectations/rallly/notes.md
@@ -73,21 +73,69 @@ not re-litigate them:
   (`apps/web/src/trpc/routers/spaces.ts:403` `prisma.spaceMemberInvite.create({`).
   The only `delete` in the procedure is a compensating rollback when the invite
   email fails (line 427), not destructive intent.
-- `GET /api/better-auth/{all}`, `GET`/`POST /api/integrations/{connection}`
-  stay as labeled: SDK/OAuth catch-all unions whose per-method reachability is
-  not decidable from this repo's source. `api/better-auth/[...all]/route.ts:5`
-  exports one opaque `toNextJsHandler(authLib)` pair; the integrations route
-  persists credentials inside an `onConnect` callback
-  (`api/integrations/[...connection]/route.ts:45` `saveOAuthCredentials`) whose
-  triggering method lives inside `OAuthIntegration`. Grading these needs a
-  decision about how to label catch-all unions, not more source reading.
 - `trpc polls.reopen`, `spaces.acceptInvite`, `spaces.cancelInvite`,
-  `spaces.removeMember`, `spaces.removeImage` stay `write`: each performs a
-  single-row (or single-object) hard delete of a re-creatable record —
-  `polls.ts:1125` `prisma.scheduledEvent.delete({`, `spaces.ts:493`
-  `tx.spaceMemberInvite.delete({`, `spaces.ts:629`
-  `prisma.spaceMemberInvite.delete({`, `spaces.ts:545`
-  `prisma.spaceMember.delete({`, `spaces.ts:862` `deleteImageFromS3(oldImageKey)`.
-  Whether a single irreversible row delete crosses into `destructive` is a
-  threshold the labeling rule does not fix, so these were left alone rather
-  than moved on a judgment call.
+  `spaces.removeMember`, `spaces.removeImage` stay `write`, now on the rule
+  rather than for want of one: `destructive` takes bulk or irreversible loss,
+  and each of these hard-deletes exactly ONE easily re-created row or object.
+  Verified single, not `deleteMany` and not in a loop:
+  `polls.ts:1125` `await prisma.scheduledEvent.delete({` by
+  `poll.scheduledEventId` (guarded by `if (poll.scheduledEventId)` at `:1124`);
+  `spaces.ts:493` `await tx.spaceMemberInvite.delete({` by the id of the one
+  invite fetched at `:455`; `spaces.ts:629`
+  `await prisma.spaceMemberInvite.delete({` by `input.inviteId`;
+  `spaces.ts:545` `const deletedMember = await prisma.spaceMember.delete({` by
+  `input.memberId` (the `:549` sibling call is a `count`, not a delete);
+  `spaces.ts:862` `await deleteImageFromS3(oldImageKey);` for the single key
+  previously on `ctx.space.image`, guarded by `if (oldImageKey)` at `:861`.
+- `trpc user.submitFeedback` stays `write` — the row that would have been graded
+  `read` by the bare mutation test, since it writes nothing to a database.
+  `apps/web/src/trpc/routers/user.ts:125`: `      sendRawEmail({` sends one mail
+  to the hardcoded `feedback@rallly.co` (`:126`) carrying the caller's name,
+  email and free text (`:129`). Mail sent is an outbound effect the caller
+  cannot take back, which the rule names as a `write`.
+- `POST /api/integrations/{connection}` stays `write` — already the grade its
+  whole URL carries (see the catch-all section below); only its `GET` twin moved.
+
+## Curated catch-all rows (hand-verified, FROZEN)
+
+Both URLs below are graded at their WORST reachable operation, the same grade on
+every method they export, per the rule the README now states. Independently
+confirmed by a second reviewer given only the excerpt, the then-current labels
+and the rule.
+
+- `GET`/`POST /api/integrations/{connection}` → `write` (the `GET` row moved from
+  `read`). One handler serves both methods —
+  `apps/web/src/app/api/integrations/[...connection]/route.ts:73-74`:
+  `export const GET = handler;` / `export const POST = handler;` — over a Hono
+  app built inside `OAuthIntegration` (`apps/web/src/lib/oauth/server.ts:16`),
+  whose OAuth callback (`server.ts:102`) invokes the route's `onConnect` at
+  `server.ts:141`. That callback persists encrypted OAuth tokens:
+  `route.ts:45` `const credential = await saveOAuthCredentials({` →
+  `apps/web/src/features/credentials/mutations.ts:42`:
+  `const credential = await prisma.credential.create({` with
+  `secret: encrypt(JSON.stringify(tokens), env.SECRET_PASSWORD),` (`:48`), then
+  creates a calendar connection (`route.ts:53`) and syncs it (`route.ts:63`).
+  Nothing behind this URL deletes anything, so `write` is the worst grade.
+
+- `GET`/`POST /api/better-auth/{all}` → `destructive` (both rows moved). One
+  opaque handler pair fronts the whole better-auth surface —
+  `apps/web/src/app/api/better-auth/[...all]/route.ts:5`:
+  `const { POST: authPost, GET: authGet } = toNextJsHandler(authLib);`. The
+  worst operation behind it is a hard account delete, reachable because this
+  repo mounts the admin plugin: `apps/web/src/lib/auth.ts:139`: `    admin(),`.
+  The endpoint that plugin registers is not in this repo's source, so it was
+  read from the pinned dependency (`better-auth` `^1.6.0`,
+  `apps/web/package.json:61`) — `dist/plugins/admin/admin.mjs:83`:
+  `			removeUser: removeUser(opts),` in the plugin's unconditional endpoint map,
+  implemented in `dist/plugins/admin/routes.mjs` as
+  `createAuthEndpoint("/admin/remove-user"` whose own description reads
+  `"Delete a user and all their sessions and accounts. Cannot be undone."` and
+  whose body calls `await ctx.context.internalAdapter.deleteUser(ctx.body.userId);`.
+  Irreversible, so `destructive`.
+
+  Two things this row is NOT resting on: better-auth's `user.deleteUser`
+  endpoint is *not* enabled (there is no `deleteUser` key anywhere in
+  `apps/web/src/lib/auth.ts`), and rallly's own account deletion goes through
+  `trpc user.deleteMe`, already labeled `destructive`. The admin plugin's
+  `remove-user` is a separate, always-mounted path, and a catch-all is graded at
+  the worst thing behind it even when the host app never links to it.

--- a/corpus/expectations/skateshop/ai-expected.json
+++ b/corpus/expectations/skateshop/ai-expected.json
@@ -23,13 +23,13 @@
       "name": "postRevalidateTag",
       "method": "POST",
       "path": "/api/revalidate/{tag}",
-      "risk": "write"
+      "risk": "read"
     },
     {
       "name": "getUploadthing",
       "method": "GET",
       "path": "/api/uploadthing",
-      "risk": "read"
+      "risk": "write"
     },
     {
       "name": "postUploadthing",

--- a/corpus/expectations/skateshop/notes.md
+++ b/corpus/expectations/skateshop/notes.md
@@ -1,17 +1,47 @@
 # skateshop labeling notes
 
-## `ai-expected.json` risk rows verified and LEFT unchanged
+Pinned SHA e954d543.
 
-Both rows below are repeatedly flagged as mislabeled by extraction runs. They
-were checked against the pinned source and are CORRECT as labeled; a model
-disagreeing with them is a bug report about the model, not a reason to relabel.
+## Curated `ai-expected.json` risk rows (hand-verified, FROZEN)
+
+Read from the pinned source and independently confirmed by a second reviewer
+given only the handler excerpt, the then-current label and the applicable rule.
+Do not relabel these from model output.
+
+- `POST /api/revalidate/{tag}` → `read` (was the mechanical `POST` → `write`).
+  The whole body is a cache invalidation, which the labeling rule explicitly does
+  not count as a mutation. `src/app/api/revalidate/[tag]/route.ts:20`:
+  `  revalidateTag(tag)` — and lines 12-14 gate the route to 403 unless
+  `env.NODE_ENV` is `"development"` anyway. This is the grade its
+  `GET /api/revalidate` sibling already carried; the two rows disagreed only
+  because one verb is `GET` and the other `POST`.
+
+- `GET /api/uploadthing` → `write` (`POST` was already `write`), the catch-all
+  graded at its worst reachable operation. `src/app/api/uploadthing/route.ts:6`:
+  `export const { GET, POST } = createRouteHandler({` — one SDK handler pair for
+  every action. The worst action is an upload, which creates a stored file object
+  at the provider: `src/app/api/uploadthing/core.ts:12`:
+  `  productImage: f({ image: { maxFileSize: "4MB", maxFileCount: 3 } })`.
+  Nothing behind the URL deletes: the handler's complete action set lives in the
+  pinned dependency (`uploadthing` `^6.13.2`, `package.json:104`) —
+  `internal/types.d.ts:407`:
+  `declare const VALID_ACTION_TYPES: readonly ["upload", "failure", "multipart-complete"];` —
+  and `grep -rni "utapi\|deleteFiles\|deleteFile"` over `src/` returns nothing,
+  so no path in this repo deletes an uploaded object. `write`, not `destructive`.
+
+  Worth knowing for the description dimension rather than the risk one:
+  `core.ts:34-42` persists NOTHING locally — `onUploadComplete` only
+  `console.log`s (`:36`, `:38`) and returns `{ uploadedBy: metadata.userId }`.
+  The stored state this row is graded on is the file at the provider, not a row
+  in skateshop's own database.
+
+## Rows verified and LEFT unchanged
 
 - `GET /api/revalidate` stays `read`. The handler's entire body is a cache
-  invalidation, which the labeling rule explicitly does not count as a
-  mutation. `src/app/api/revalidate/route.ts:9`: `revalidatePath("/")` — and
-  lines 5-7 gate the route to `NODE_ENV === "development"` anyway.
-- `GET /api/uploadthing` stays as labeled. `src/app/api/uploadthing/route.ts:6`
-  is `export const { GET, POST } = createRouteHandler({` — an SDK catch-all
-  where GET serves router config and POST carries uploads. Per-method behaviour
-  lives inside the `uploadthing` package, so this repo's source cannot settle
-  the grade.
+  invalidation. `src/app/api/revalidate/route.ts:9`: `revalidatePath("/")` — and
+  lines 5-7 gate the route to `NODE_ENV === "development"` anyway. This row is
+  repeatedly flagged as mislabeled by extraction runs; it is CORRECT as labeled,
+  and a model disagreeing with it is a bug report about the model, not a reason
+  to relabel.
+- `POST /api/uploadthing` stays `write` — the same catch-all grade as its `GET`
+  twin above.

--- a/corpus/expectations/taxonomy/ai-expected.json
+++ b/corpus/expectations/taxonomy/ai-expected.json
@@ -5,7 +5,7 @@
       "name": "getAuthNextauth",
       "method": "GET",
       "path": "/api/auth/{nextauth}",
-      "risk": "read"
+      "risk": "write"
     },
     {
       "name": "postAuthNextauth",

--- a/corpus/expectations/taxonomy/notes.md
+++ b/corpus/expectations/taxonomy/notes.md
@@ -14,10 +14,15 @@ given only the handler excerpt. Do not relabel from model output.
   users, and line 35 `const stripeSession = await stripe.checkout.sessions.create({`
   for free users. There is no read-only branch.
 
-## Rows deliberately LEFT at their current grade
-
-- `GET /api/auth/{nextauth}` stays as labeled. `pages/api/auth/[...nextauth].ts:6`
-  is `export default NextAuth(authOptions)` — a catch-all union in which
-  `/callback/:provider` mints a session while other sub-paths are read-only.
-  Which grade a catch-all union should carry is a labeling-policy decision, not
-  something this repo's source settles.
+- `GET /api/auth/{nextauth}` → `write` (`POST` was already `write`), the
+  catch-all graded at its worst reachable operation per the rule the README now
+  states. `pages/api/auth/[...nextauth].ts:6` is
+  `export default NextAuth(authOptions)` — one opaque default export for every
+  sub-path and every method. (The App Router copy at
+  `app/api/auth/[...nextauth]/_route.ts` is inert: the underscore prefix means
+  Next never routes it.) Two things behind the URL change stored state:
+  `lib/auth.ts:17`: `  adapter: PrismaAdapter(db as any),` persists the user,
+  account and verification-token rows, and `lib/auth.ts:48`:
+  `const result = await postmarkClient.sendEmailWithTemplate({` sends the
+  magic-link email — an outbound effect the caller cannot take back. Neither is
+  bulk or irreversible, so `write` is the worst grade, not `destructive`.

--- a/corpus/expectations/vercel-commerce/ai-expected.json
+++ b/corpus/expectations/vercel-commerce/ai-expected.json
@@ -5,7 +5,7 @@
       "name": "postRevalidate",
       "method": "POST",
       "path": "/api/revalidate",
-      "risk": "write"
+      "risk": "read"
     }
   ]
 }

--- a/corpus/expectations/vercel-commerce/notes.md
+++ b/corpus/expectations/vercel-commerce/notes.md
@@ -2,6 +2,27 @@
 
 Pinned SHA 3761e52e.
 
+## Curated `ai-expected.json` risk rows (hand-verified, FROZEN)
+
+- `POST /api/revalidate` → `read` (was the mechanical `POST` → `write`). This is
+  a Shopify webhook RECEIVER whose only effect is invalidating the Next.js cache,
+  which the labeling rule explicitly does not count as a mutation. The route is a
+  one-line delegation (`app/api/revalidate/route.ts:5`: `  return revalidate(req);`)
+  and the function it delegates to does exactly two things —
+  `lib/shopify/index.ts:535`: `    revalidateTag(TAGS.collections, "seconds");`
+  and `:539`: `    revalidateTag(TAGS.products, "seconds");`. `revalidateTag` is
+  `next/cache` (`lib/shopify/index.ts:11`). There is no `fetch`, no Shopify
+  Admin/Storefront mutation, no datastore client and no cookie or session write
+  anywhere in the function (`:506-543`); its other statements read a header,
+  read a query parameter, compare a secret, and build the JSON response.
+
+  Receiving a webhook is not the same as firing one: the rule counts an outbound
+  effect the caller cannot take back, and this handler makes no outbound call.
+
+  Read from the pinned source and independently confirmed by a second reviewer
+  given only the handler excerpt, the then-current label and the rule. Do not
+  relabel from model output.
+
 ## fontFamily provenance
 
 `app/globals.css:1` is Tailwind v4 (`@import "tailwindcss"`) with no

--- a/packages/vendo/src/cli/judge/prompts.test.ts
+++ b/packages/vendo/src/cli/judge/prompts.test.ts
@@ -148,3 +148,53 @@ describe("JUDGE_OUTPUT_RULES — the risk test is mutation of stored state", () 
     expect(JUDGE_OUTPUT_RULES).toMatch(/queued for a human/i);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Three labeling-policy rules the mutation test alone does not settle. Each one
+// was a row the corpus curation lane had to PARK because the prompt had no
+// answer for it (PR #684): the catch-all unions, the write-vs-destructive
+// threshold on a single-row delete, and a handler that only sends mail.
+// ---------------------------------------------------------------------------
+
+describe("JUDGE_OUTPUT_RULES — a catch-all route is graded at its worst operation", () => {
+  it("says to grade the whole URL at the most dangerous operation reachable behind it", () => {
+    expect(JUDGE_OUTPUT_RULES).toMatch(/catch-all/i);
+    expect(JUDGE_OUTPUT_RULES).toMatch(/worst operation|most dangerous operation/i);
+  });
+
+  it("names the shapes so the model recognizes one", () => {
+    expect(JUDGE_OUTPUT_RULES).toContain("[...nextauth]");
+    expect(JUDGE_OUTPUT_RULES).toContain("[trpc]");
+  });
+
+  it("says a benign method split may not be guessed when reachability lives in the dependency", () => {
+    expect(JUDGE_OUTPUT_RULES).toMatch(/inside the dependency|in the dependency/i);
+    expect(JUDGE_OUTPUT_RULES).toMatch(/worst plausible/i);
+    expect(JUDGE_OUTPUT_RULES).toMatch(/say so in the reason/i);
+  });
+});
+
+describe("JUDGE_OUTPUT_RULES — `destructive` is reserved for bulk or irreversible loss", () => {
+  it("states the threshold as bulk OR irreversible", () => {
+    expect(JUDGE_OUTPUT_RULES).toMatch(/bulk or irreversible/i);
+  });
+
+  it("grades a hard delete of one easily re-created row as write, not destructive", () => {
+    expect(JUDGE_OUTPUT_RULES).toMatch(/re-created|recreated/i);
+    expect(JUDGE_OUTPUT_RULES).toMatch(/single|one/i);
+    // The reason has to be in the prompt too: a top grade everyone earns is not a grade.
+    expect(JUDGE_OUTPUT_RULES).toMatch(/click through|means nothing|mean nothing/i);
+  });
+});
+
+describe("JUDGE_OUTPUT_RULES — an outbound side effect is a write with no row written", () => {
+  it("names the unrecallable outbound effects that count as mutations", () => {
+    expect(JUDGE_OUTPUT_RULES).toMatch(/email/i);
+    expect(JUDGE_OUTPUT_RULES).toMatch(/webhook/i);
+    expect(JUDGE_OUTPUT_RULES).toMatch(/payment/i);
+  });
+
+  it("says stored state is not only the handler's own database", () => {
+    expect(JUDGE_OUTPUT_RULES).toMatch(/not only your own database|not only the database|not only your database/i);
+  });
+});

--- a/packages/vendo/src/cli/judge/prompts.ts
+++ b/packages/vendo/src/cli/judge/prompts.ts
@@ -23,6 +23,15 @@ import type { ExtractedTool } from "@vendoai/actions";
  *
  * Nothing here is trusted. The rules tell the model what may land; the
  * deterministic direction rule in `@vendoai/actions` decides what actually does.
+ *
+ * The risk section also carries three LABELING-POLICY rules the mutation test
+ * cannot derive on its own. Each one is here because a corpus row had to be
+ * parked without it (PR #684): a catch-all URL is graded at its worst operation
+ * because per-method reachability lives inside the dependency; `destructive`
+ * needs bulk or irreversible loss, so a single re-creatable row delete is a
+ * `write`; and an unrecallable outbound effect (mail sent, payment captured) is
+ * a `write` with no row written. They are conventions, not derivations — a model
+ * cannot guess them, so they have to be stated.
  */
 
 export const JUDGE_OUTPUT_RULES = [
@@ -52,6 +61,21 @@ export const JUDGE_OUTPUT_RULES = [
   "  reshaping of data already fetched; and protocol metadata (handshakes, capability or schema",
   "  listings, presigned-URL issuance that stores nothing). \"Not an application read\" is not a",
   "  reason to call something a write — the only question is whether stored state changes.",
+  "  Stored state is not only your own database. An OUTBOUND side effect the caller cannot take",
+  "  back is a write even when no row is written: an email or SMS sent, a webhook or push",
+  "  delivered, a payment captured, an external checkout or billing-portal session created.",
+  "  DESTRUCTIVE is reserved for BULK OR IRREVERSIBLE loss: a delete that spans many records",
+  "  (deleteMany, truncate, purge, reset), or the loss of something that cannot be re-created",
+  "  (an account and its history, an uploaded original, an audit trail). A hard delete of ONE",
+  "  easily re-created row or object — remove a member, cancel an invite, remove an image — is",
+  "  `write`. If every delete were destructive the top grade would mean nothing and people would",
+  "  click through the one warning that matters.",
+  "  A CATCH-ALL route is graded at its WORST operation. When one URL fronts many operations",
+  "  (`[...nextauth]`, `[trpc]`, an upload or OAuth SDK handler), which method reaches which",
+  "  operation is usually decided inside the dependency, not in this repo's source. Do not guess",
+  "  a benign method split: grade the tool at the most dangerous operation reachable behind that",
+  "  URL, and when you cannot determine from source which operations it exposes, grade at the",
+  "  worst PLAUSIBLE one and say so in the reason.",
   "  You may move risk in BOTH directions: RAISE it when the handler mutates more than its label",
   "  admits, and LOWER it when it mutates nothing. A raise applies immediately; a lowering is",
   "  queued for a human. Do NOT hedge upward to be safe: an over-tight grade silently breaks a",


### PR DESCRIPTION
## Why

`corpus/expectations/*/ai-expected.json` had ten rows the curation lane (#684)
could not decide, and it said so rather than guessing: catch-all SDK/OAuth
unions, and the write-vs-`destructive` threshold on a single-row hard delete.
Both were **labeling-policy** questions, not missing source reading. Yousef
settled them on 2026-07-28, plus a third gap this lane found in the same place.

This PR states all three rules in the judge prompt, resolves the parked rows
against them, and re-scores the corpus.

## 1. The three rules, in the judge prompt

`packages/vendo/src/cli/judge/prompts.ts`, inside the existing risk bullet, +24
lines. Covered by 7 new tests in `prompts.test.ts` (`22 passed`), written and
watched fail before the prompt changed.

- **A catch-all route is graded at its WORST operation** — when one URL fronts
  many operations (`[...nextauth]`, `[trpc]`, an upload or OAuth SDK handler),
  which method reaches which operation is decided inside the dependency, so a
  benign method split may not be guessed. Where source cannot settle what the
  catch-all exposes: grade at the worst *plausible* operation and say so in the
  reason.
- **`destructive` needs BULK OR IRREVERSIBLE loss** — a delete spanning many
  records, or loss of something that cannot be re-created. A hard delete of ONE
  easily re-created row or object is `write`. "If every delete were destructive
  the top grade would mean nothing and people would click through the one warning
  that matters."
- **An unrecallable outbound effect is a `write` with no row written** — mail or
  SMS sent, a webhook delivered, a payment captured, an external checkout or
  billing-portal session created. (Scope item 5: rallly `user.submitFeedback`
  sends mail and writes nothing, so the bare mutation test would have graded it
  `read`; it is `write` and now for a stated reason.)

Doctrine untouched: hardenings still apply immediately, loosenings still need the
skeptic **and** the human gate, the self-consistency check still drops a grade
that contradicts its own reason. All 15 pre-existing tests in the file still pass
unchanged (15 → 22 with the new ones).

The same three rules are added to `corpus/expectations/README.md` so labels and
model are graded against one policy rather than two.

## 2. Discipline — identical to #684

Every change cites the deciding `file:line`, quoted. Every intended change was
then re-graded by an **independent blind verifier** (`codex exec --sandbox
read-only`) given only the handler excerpt, the *then-current* label, and the
applicable rule — never my grade, never the judge's grade, never the fact that a
change was proposed. Prompts were scanned for leakage first (`propos`, `correct`,
`judge`, `channel`, `landed`, `wrong`, … → no hits). 15 verification units cover
22 label rows.

The verifier is a different model family (`gpt-5.6-sol`), piped the prompt on
stdin in a read-only sandbox, with no knowledge of this branch. Ten of the 15
verdicts cite the exact line I cite; the other five cite a different line inside
the same procedure or URL (e.g. on openstatus's lambda catch-all it named the
bulk page delete at `webhook.ts:274-275` where I named the bulk membership delete
at `:308-316` — same procedure, same conclusion). None cited a different
handler.

**Verifier agreement: 15/15.** No disagreements, so no row was held back for
one; ambiguous rows are named in §5 instead.

## 3. Label changes (12 rows) — with the blind verifier's independent answer

| tool | repo | old → new | deciding line | verifier |
|---|---|---|---|---|
| `getAuthNextauth` | openstatus | read → **write** | `apps/dashboard/src/lib/auth/index.ts:48` `.update(user)` — the `signIn` callback writes user rows on all three providers; adapter at `auth/adapter.ts:14` | `write` |
| `getTrpcEdgeTrpc` | openstatus | read → **destructive** | `packages/services/src/user/delete.ts:174` `await tx.delete(session).where(eq(session.userId, userId));`, reached via `router/user.ts:18` `deleteAccount` mounted at `edge.ts:35` | `destructive` |
| `postTrpcEdgeTrpc` | openstatus | write → **destructive** | same URL, same worst operation | `destructive` |
| `getTrpcLambdaTrpc` | openstatus | read → **destructive** | `router/stripe/webhook.ts:308-316` `.delete(usersToWorkspaces)` — every non-owner membership, plus `:274-276` all-but-one page and `:319-322` every invitation | `destructive` |
| `postTrpcLambdaTrpc` | openstatus | write → **destructive** | same URL, same worst operation | `destructive` |
| `getAuthNextauth` | taxonomy | read → **write** | `lib/auth.ts:17` `adapter: PrismaAdapter(db as any),` + `:48` `await postmarkClient.sendEmailWithTemplate({` | `write` |
| `getBetterAuth` | rallly | read → **destructive** | `lib/auth.ts:139` `admin(),` → better-auth@1.6.0 `dist/plugins/admin/admin.mjs:83` `removeUser: removeUser(opts),`, whose endpoint's own description is *"Delete a user and all their sessions and accounts. Cannot be undone."* | `destructive` |
| `postBetterAuth` | rallly | write → **destructive** | same URL, same worst operation | `destructive` |
| `getIntegrations` | rallly | read → **write** | `features/credentials/mutations.ts:42` `const credential = await prisma.credential.create({` with `secret: encrypt(...)` at `:48`, reached from `route.ts:45` | `write` |
| `getUploadthing` | skateshop | read → **write** | `api/uploadthing/route.ts:6` `export const { GET, POST } = createRouteHandler({` + `core.ts:12` upload route; the dependency's whole action set is `["upload","failure","multipart-complete"]` (no delete) | `write` |
| `postRevalidateTag` | skateshop | write → **read** | `api/revalidate/[tag]/route.ts:20` `revalidateTag(tag)` — the entire body | `read` |
| `postRevalidate` | vercel-commerce | write → **read** | `lib/shopify/index.ts:535` `revalidateTag(TAGS.collections, "seconds");` (and `:539`) — the whole function's only effects | `read` |

Two of these rest on a **pinned dependency** rather than the host's source, read
and cited because the host's source genuinely cannot settle them: better-auth
`^1.6.0` (`apps/web/package.json:61`) and uploadthing `^6.13.2`
(`package.json:104`). That is the catch-all rule's escape hatch used one step
earlier than "worst plausible" — read the dependency if you can, guess only if
you can't.

### Direction counts, BOTH ways

Against the grade the recorded judgment run actually landed on each row:

| direction | rows |
|---|---|
| **toward** the judge (row was wrong, now right) | **4** |
| **away** from the judge (row was right, now wrong) | **5** |
| neither (judge wrong before and after) | 3 |

This is the control #684 could not have: its worklist *was* the judge's
disagreement list, so every correct fix necessarily flattered the judge. This
worklist is policy-derived, and it moves against the judge more often than for
it. The net score delta is **negative** (§6).

## 4. Rows investigated and deliberately LEFT unchanged (10 label rows)

- **`destructive` threshold, 5 rows — the rule confirms them as `write`.**
  `polls.reopen`, `spaces.{acceptInvite,cancelInvite,removeMember,removeImage}`
  each hard-delete exactly ONE easily re-created row or object, verified single
  (not `deleteMany`, not in a loop): `polls.ts:1125`, `spaces.ts:493`, `:629`,
  `:545`, `:862`, each guarded and keyed by a single id. Verifier said `write` on
  all five. **The recorded judge graded all five `destructive`, so it stays
  penalized on all five** — this is the rule costing the model, not excusing it.
- **`user.submitFeedback` stays `write`** — `trpc/routers/user.ts:125`
  `sendRawEmail({`, no database write anywhere in the body. Verifier: `write`.
- **The POST twins of the catch-alls that were already at the URL's worst grade**
  — openstatus/taxonomy `postAuthNextauth`, rallly `postIntegrations`, skateshop
  `postUploadthing`. Same verification unit, no change needed.
- **`POST /api/onboarding/checks` (openstatus) stays `write`** — it replays the
  monitor's own configured method ~28 times against a third-party URL
  (`stream-monitor-preview.ts:209-218`). #684 left it because the rule did not
  settle it; the new outbound-effect rule does, in favour of the existing label.
- **`GET /api/revalidate` (skateshop) stays `read`** — frozen by #684, untouched.

## 5. Ambiguity called out rather than resolved by taste

The better-auth row is the one I would want a second opinion on. `deleteUser` is
**not** enabled in rallly's config and rallly's own account deletion goes through
`trpc user.deleteMe`; the `destructive` grade rests entirely on the `admin()`
plugin's always-mounted `/admin/remove-user`, which the host app never links to.
Grading it `destructive` is the fail-closed reading of the rule ("the worst thing
behind the URL"), the blind verifier reached it independently from the same
excerpt, and it costs the judge a row rather than gaining it one. Recorded in
`rallly/notes.md` including what it does *not* rest on, so a future reader can
disagree with the policy without re-deriving the facts.

## 6. Scores — label-change delta only

**No model calls were made.** Same recorded lane-D run on both sides, so the
delta is purely the relabel.

| repo | risk before | risk after | score before | score after | delta |
|---|---|---|---|---|---|
| express-host | 5/5 | 5/5 | 0.971 | 0.971 | +0.000 |
| invoify | 3/3 | 3/3 | 1.000 | 1.000 | +0.000 |
| openstatus | 4/8 | **3/8** | 0.833 | **0.815** | −0.018 |
| rallly | 73/84 | 73/84 | 0.916 | 0.916 | ±0.000 |
| skateshop | 5/7 | 5/7 | 0.940 | 0.940 | ±0.000 |
| taxonomy | 9/10 | **10/10** | 0.971 | **0.985** | +0.014 |
| teable | 0/1 | 0/1 | 0.000 | 0.000 | +0.000 (floored — its cell wrote no judgments) |
| vercel-commerce | 1/1 | **0/1** | 0.929 | **0.786** | −0.143 |

**Mean 0.8200 → 0.8017 (−0.0183).** A curation pass that lowers the score is the
strongest evidence available that it was not steering.

### The prompt-change delta is NOT measured, deliberately

The contract allows skipping the re-judge and requires the two deltas be reported
separately if one happens. It did not happen. Measuring it needs a fresh
judgment pass over bootstrapped clones; the prepared repos and per-cell artifacts
from lane D are gone (below), the pass runs ~5 min per 20-tool batch, and #674
measured the same cell at 0.762 then 0.714 — and another at 0.000 then 0.950 — on
identical inputs, so one re-run could not separate a prompt effect from that
noise. **There is no prompt-change number in this PR. Do not infer one from the
table above; that table is the label change alone.**

### Provenance of the re-score, stated because it is not reproducible from a clean checkout

The lane-D artifact tree (`jl-lane-d/corpus/.repos/.logs`) no longer exists on
this machine. What survives is #684's replication of it: per repo, one row per
joined label carrying `static` (the scanner's grade) and `landed` (the grade the
channel wrote) — both label-independent. Before trusting it, recomputing risk
accuracy from those rows was checked against **both** of #684's published risk
columns and reproduced them **exactly, 8/8 repos**. The overall column carries
#684's published per-repo value forward and moves only the risk dimension
(`passed − risk_before + risk_after` over the same 7 checks). That is valid only
if no changed row can move the `critical` or `wake` dimension, which is checked
rather than assumed: `grep -rc '"critical"\|"wake"'` over all 16 label files
returns 0 everywhere, and #674's scoreboard shows `—` in both columns for all 8
repos, i.e. `wakeLabels.length === 0` (no joined label row is a disabled tool).

## 7. Corrections to the contract's own premises

- **Scope item 3 said the vercel-commerce row "cost vercel-commerce its risk
  score in the final matrix".** It did not: in the recorded run the judge graded
  it `write`, the label was `write`, the row matched, and vercel-commerce scored
  risk 1/1 (corroborated by #674's scoreboard and #684's table). I verified the
  handler from source anyway, because the rule is the instruction — and the
  correction runs the *other* way, taking it from 1/1 to 0/1. Same for
  skateshop's equivalent row.

## 8. Label files are not gate-checked — validated by hand

Nothing in `pnpm test` parses the real `ai-expected.json` files (the harness
tests build temp fixture roots). All 16 were parsed against the shipped schema
via `discoverAiConfiguredRepoNames` + `loadRepoAiExpectations`: **16 files / 2310
tools parse**, risk distribution `read 883 / write 1244 / destructive 183`.

## Gate

`pnpm build` 23/23 · `pnpm test` 53/53 twice (second pass `--force
--concurrency=1 --continue`, 0 cached) · `pnpm typecheck` 41/41 · `pnpm lint` 6/6.
Changeset: patch `@vendoai/vendo` (only `packages/` change is the prompt).

## Unrelated things noticed, not fixed

- `Mark irreversible operations critical: true.` still sits at the end of the
  risk bullet. Under the new threshold a single-row hard delete is a `write` that
  is nonetheless irreversible, so `critical` and `destructive` now come apart —
  which is arguably correct, but nothing states it, and no corpus repo carries a
  single `critical` label to test it against (0 of 2310).
- `review.ts` still renders "1 loosening **need** a human decision" (#674's
  finding 8, one-word fix, untouched).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three labeling-policy rules to the judge and applies them to the corpus to resolve previously parked risk rows. This aligns labels and judging under one policy and re-scores affected repos.

- **New Features**
  - Judge prompt (`packages/vendo/src/cli/judge/prompts.ts`): add three rules
    - Catch-all routes are graded at their worst reachable operation.
    - `destructive` requires bulk or irreversible loss; single-row hard deletes are `write`.
    - Unrecallable outbound effects (email, webhooks, payments, external sessions) are `write` even without DB writes.
  - Tests: +7 cases in `packages/vendo/src/cli/judge/prompts.test.ts`.
  - Corpus updates: 12 risk rows updated to match the rules (examples: `[...nextauth]` GET → write; tRPC and `better-auth` catch-alls → destructive; `uploadthing` GET → write; cache revalidate POSTs → read).
  - Docs: rules added to `corpus/expectations/README.md` so labels and judge use one policy.
  - Notes: two catch-all grades cite pinned deps (`better-auth` and `uploadthing`) where host source can’t decide.
  - Scoring: corpus re-scored; overall mean moved −0.0183.

<sup>Written for commit 08d75e73a8ecff63c3f4985ad11e513d568fc8cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

