### PR TITLE
fix(cli): onboarding safety and honesty — gitignore warn, single askYesNo, honest keyless line, pages-router/monorepo guidance

### DIFF
--- a/.changeset/onboarding-cli-safety-and-honesty.md
+++ b/.changeset/onboarding-cli-safety-and-honesty.md
@@ -1,0 +1,23 @@
+---
+"@vendoai/vendo": patch
+---
+
+Onboarding safety and honesty: four fixes to the first `vendo init`.
+
+- **A secret written into a committed file now says so.** `vendo login` and
+  `vendo init --cloud-key` land `VENDO_API_KEY` in `.env.local`. When
+  `git check-ignore` says that file is not ignored, both print one line naming
+  the fix. The write is never blocked — the key is already minted.
+- **The keyless closing line stopped over-promising.** A run that resolved no
+  model key now ends "the agent is live once you add a model key" instead of
+  claiming it is live in your app.
+- **A pages-only Next host gets instructions that work.** The manual wiring
+  paste and the agent tail named `app/layout.tsx`, a file such a host does not
+  have. They now name `pages/_app.tsx` and wrap `<Component {...pageProps} />`
+  (the generated `vendo/vendo-root.tsx` is a client component, so it mounts
+  there unchanged). Where the API route segment is scaffolded is unchanged.
+- **An interactive init at a monorepo root names the real host.** Detection
+  finds no `next`/`express` at a workspace root and falls through to the
+  runtime-neutral `custom` scaffold — silently one level too high. It now names
+  the workspace packages that do look like hosts ("did you mean apps/web?").
+  Non-interactive runs already errored with the exact flag; unchanged.

--- a/.changeset/onboarding-cli-safety-and-honesty.md
+++ b/.changeset/onboarding-cli-safety-and-honesty.md
@@ -9,14 +9,18 @@ Onboarding safety and honesty: four fixes to the first `vendo init`.
   line about whether git will commit it, with the remediation that actually
   works: `git rm --cached` when the file is already tracked (where .gitignore
   cannot help), the .gitignore line when it is untracked and unignored, and an
-  explicit "git could not answer" when a live repo errors. Silent when the file
-  is ignored, and when there is no repository or no git at all. The write is
-  never blocked — the key is already minted.
-- **The closing line stopped over-promising.** It claimed "the agent is live in
-  your app" whenever a rung resolved — including a malformed `VENDO_API_KEY` or
-  `VENDO_DEV_CREDENTIAL=vendo-cloud` with no key, both of which resolve a rung
-  and cannot serve a turn. It now says "the agent is live once you add a model
-  key" unless the credential is actually usable.
+  explicit "git could not answer" when a live repo errors. Symlinks are resolved
+  first, so a gitignored `.env.local` pointing at a tracked file is judged by
+  the file the write really lands in. Silent when the file is ignored, and when
+  there is no working tree or no git at all. The write is never blocked — the
+  key is already minted.
+- **The closing line stopped guessing in both directions.** It claimed "the
+  agent is live in your app" whenever a rung resolved — including a malformed
+  `VENDO_API_KEY` or `VENDO_DEV_CREDENTIAL=vendo-cloud` with no key, neither of
+  which can serve a turn. Now: a usable credential says live; a composition
+  scaffolded this run with no key says "live once you add a model key"; and a
+  re-run over a composition Vendo did not write states the condition, because
+  that composition may pass its own `model` and nothing here can see it.
 - **A pages-only Next host gets instructions that work.** The manual wiring
   paste and the agent tail named `app/layout.tsx`, a file such a host does not
   have. They now name `pages/_app.tsx` and wrap `<Component {...pageProps} />`
@@ -26,6 +30,6 @@ Onboarding safety and honesty: four fixes to the first `vendo init`.
   finds no `next`/`express` at a workspace root and falls through to the
   runtime-neutral `custom` scaffold — silently one level too high. It now names
   the workspace packages that do look like hosts ("did you mean apps/web?") and
-  suggests a path that resolves from the caller's own cwd, quoted when it
-  contains a space. Non-interactive runs already errored with the exact flag;
-  unchanged.
+  suggests a path that resolves from the caller's own cwd, single-quoted when the
+  shell would otherwise mangle it. Non-interactive runs already errored with the
+  exact flag; unchanged.

--- a/.changeset/onboarding-cli-safety-and-honesty.md
+++ b/.changeset/onboarding-cli-safety-and-honesty.md
@@ -5,12 +5,18 @@
 Onboarding safety and honesty: four fixes to the first `vendo init`.
 
 - **A secret written into a committed file now says so.** `vendo login` and
-  `vendo init --cloud-key` land `VENDO_API_KEY` in `.env.local`. When
-  `git check-ignore` says that file is not ignored, both print one line naming
-  the fix. The write is never blocked — the key is already minted.
-- **The keyless closing line stopped over-promising.** A run that resolved no
-  model key now ends "the agent is live once you add a model key" instead of
-  claiming it is live in your app.
+  `vendo init --cloud-key` land `VENDO_API_KEY` in `.env.local`, and now say one
+  line about whether git will commit it, with the remediation that actually
+  works: `git rm --cached` when the file is already tracked (where .gitignore
+  cannot help), the .gitignore line when it is untracked and unignored, and an
+  explicit "git could not answer" when a live repo errors. Silent when the file
+  is ignored, and when there is no repository or no git at all. The write is
+  never blocked — the key is already minted.
+- **The closing line stopped over-promising.** It claimed "the agent is live in
+  your app" whenever a rung resolved — including a malformed `VENDO_API_KEY` or
+  `VENDO_DEV_CREDENTIAL=vendo-cloud` with no key, both of which resolve a rung
+  and cannot serve a turn. It now says "the agent is live once you add a model
+  key" unless the credential is actually usable.
 - **A pages-only Next host gets instructions that work.** The manual wiring
   paste and the agent tail named `app/layout.tsx`, a file such a host does not
   have. They now name `pages/_app.tsx` and wrap `<Component {...pageProps} />`
@@ -19,5 +25,7 @@ Onboarding safety and honesty: four fixes to the first `vendo init`.
 - **An interactive init at a monorepo root names the real host.** Detection
   finds no `next`/`express` at a workspace root and falls through to the
   runtime-neutral `custom` scaffold — silently one level too high. It now names
-  the workspace packages that do look like hosts ("did you mean apps/web?").
-  Non-interactive runs already errored with the exact flag; unchanged.
+  the workspace packages that do look like hosts ("did you mean apps/web?") and
+  suggests a path that resolves from the caller's own cwd, quoted when it
+  contains a space. Non-interactive runs already errored with the exact flag;
+  unchanged.

--- a/packages/vendo/src/cli/cloud-init.ts
+++ b/packages/vendo/src/cli/cloud-init.ts
@@ -1,3 +1,4 @@
+import { execFile, type ExecFileException } from "node:child_process";
 import { stdin, stdout } from "node:process";
 import { join } from "node:path";
 import type { DevCredential } from "../dev-creds/resolve.js";
@@ -25,22 +26,39 @@ import {
 
 /** Upsert one NAME=value line in .env.local without clobbering other lines.
     Exported for init's --cloud-key flag, which lands a supplied key exactly
-    where the mint below would. */
+    where the mint below would. Every caller follows the write with
+    `warnEnvLocalNotIgnored` — a secret just landed on disk. */
 export async function upsertEnvLocal(root: string, name: string, value: string): Promise<void> {
   const path = join(root, ".env.local");
-  const current = await readOptional(path);
+  await writeText(path, upsertLine(await readOptional(path), name, value));
+}
+
+function upsertLine(current: string | null, name: string, value: string): string {
   const line = `${name}=${value}`;
-  if (current === null || current.length === 0) {
-    await writeText(path, `${line}\n`);
-    return;
-  }
+  if (current === null || current.length === 0) return `${line}\n`;
   const pattern = new RegExp(`^\\s*${name}\\s*=.*$`, "m");
-  if (pattern.test(current)) {
-    await writeText(path, current.replace(pattern, line));
-    return;
-  }
-  const separator = current.endsWith("\n") ? "" : "\n";
-  await writeText(path, `${current}${separator}${line}\n`);
+  if (pattern.test(current)) return current.replace(pattern, line);
+  return `${current}${current.endsWith("\n") ? "" : "\n"}${line}\n`;
+}
+
+/** One loud line when the file we just wrote a secret into would be committed.
+    Never blocks the write (the key is already minted and unrecoverable) — the
+    dev needs to know, not to be stopped. */
+export async function warnEnvLocalNotIgnored(root: string, output: Output): Promise<void> {
+  if (await gitIgnoresEnvLocal(root)) return;
+  output.error("warning: .env.local holds a secret and is NOT gitignored — add `.env.local` to .gitignore before you commit.");
+}
+
+/** `git check-ignore` is the only authority that reads nested .gitignore files
+    and negations correctly. Exit 1 is the ONLY "not ignored" answer: exit 128
+    (not a repo) and a failed spawn (no git) mean there is nothing to leak
+    into, so they stay silent. */
+function gitIgnoresEnvLocal(root: string): Promise<boolean> {
+  return new Promise((settle) => {
+    execFile("git", ["check-ignore", "-q", ".env.local"], { cwd: root }, (error) => {
+      settle((error as ExecFileException | null)?.code !== 1);
+    });
+  });
 }
 
 /** The auth.md protocol file on Vendo Cloud (Agent Install DX, Layer 2). */

--- a/packages/vendo/src/cli/cloud-init.ts
+++ b/packages/vendo/src/cli/cloud-init.ts
@@ -1,6 +1,7 @@
 import { execFile, type ExecFileException } from "node:child_process";
+import { realpath } from "node:fs/promises";
 import { stdin, stdout } from "node:process";
-import { join } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import type { DevCredential } from "../dev-creds/resolve.js";
 import { runDeviceLogin } from "./cloud/device-login.js";
 import { cloudDoctor, type CloudDoctorResult } from "./doctor-live.js";
@@ -8,6 +9,7 @@ import {
   askYesNo,
   cloudProjectProps,
   errorClass,
+  exists,
   readOptional,
   toolingTelemetry,
   writeText,
@@ -46,49 +48,74 @@ function upsertLine(current: string | null, name: string, value: string): string
     dev needs to know, not to be stopped. Three honest outcomes, each with the
     remediation that actually works for it. */
 export async function warnEnvLocalNotIgnored(root: string, output: Output): Promise<void> {
+  // The write follows symlinks, so the file git must be asked about is the REAL
+  // one: a .env.local that is itself gitignored can point straight at a tracked
+  // file, and asking about the link would call that safe.
+  const link = join(root, ".env.local");
+  const file = await realpath(link).catch(() => link);
+  // Both sides resolved, or the name is nonsense whenever the ROOT itself sits
+  // under a link (every macOS temp dir: /var → /private/var).
+  const name = relative(await realpath(root).catch(() => root), file);
+  // Ask the repository that holds the SECRET, which a link can move (or take
+  // out of every working tree, where there is nothing to leak into).
+  const where = dirname(file);
+  if (!(await insideWorkTree(where))) return;
+
   // Tracked outranks ignored: a file already in the index is committed no
   // matter what .gitignore says (check-ignore answers from the patterns alone,
-  // so it can call a tracked file "ignored"), and only `git rm --cached`
-  // undoes that.
-  if (await gitTracks(root, ".env.local")) {
-    output.error("warning: .env.local holds a secret and is TRACKED by git — .gitignore alone will NOT stop the next commit: run `git rm --cached .env.local`, then add `.env.local` to .gitignore.");
+  // and reports a tracked file as NOT ignored even when a pattern matches it),
+  // and only `git rm --cached` undoes that.
+  if (await gitTracks(where, file)) {
+    output.error(`warning: ${name} holds a secret and is TRACKED by git — .gitignore alone will NOT stop the next commit: run \`git rm --cached ${name}\`, then add \`${name}\` to .gitignore.`);
     return;
   }
-  const verdict = await gitCheckIgnore(root, ".env.local");
+  const verdict = await gitCheckIgnore(where, file);
   if (verdict.kind === "ignored") return;
   if (verdict.kind === "not-ignored") {
-    output.error("warning: .env.local holds a secret and is NOT gitignored — add `.env.local` to .gitignore before you commit.");
+    output.error(`warning: ${name} holds a secret and is NOT gitignored — add \`${name}\` to .gitignore before you commit.`);
     return;
   }
-  output.error(`warning: .env.local holds a secret and git could not say whether it is ignored (${verdict.reason}) — check it yourself before you commit.`);
+  output.error(`warning: ${name} holds a secret and git could not say whether it is ignored (${verdict.reason}) — check it yourself before you commit.`);
+}
+
+/** Is this path inside a git working tree? Answered by walking up for a `.git`
+    entry (a directory, or the file a worktree/submodule uses) — never by
+    matching git's stderr, which a localized git translates: deciding "no
+    repository" from English text is how an outside-repo write starts warning
+    and a broken repo inside one goes quiet. */
+async function insideWorkTree(from: string): Promise<boolean> {
+  for (let dir = resolve(from); ; dir = dirname(dir)) {
+    if (await exists(join(dir, ".git"))) return true;
+    if (dirname(dir) === dir) return false;
+  }
 }
 
 /** Exit 0 only when the path is in the index. Every other outcome (untracked,
-    no repository, no git) is "not tracked" — the check-ignore verdict is what
-    decides those. */
-function gitTracks(root: string, path: string): Promise<boolean> {
+    git cannot run) is "not tracked" — the check-ignore verdict decides those. */
+function gitTracks(cwd: string, path: string): Promise<boolean> {
   return new Promise((settle) => {
-    execFile("git", ["ls-files", "--error-unmatch", "--", path], { cwd: root }, (error) => settle(error === null));
+    execFile("git", ["ls-files", "--error-unmatch", "--", path], { cwd }, (error) => settle(error === null));
   });
 }
 
 type IgnoreVerdict = { kind: "ignored" } | { kind: "not-ignored" } | { kind: "unknown"; reason: string };
 
 /** `git check-ignore` is the only authority that reads nested .gitignore files
-    and negations correctly: exit 0 is "ignored", exit 1 is "not ignored".
-    Everything else is a failure, and the failure MODE decides — no git and no
-    repository anywhere mean there is nothing to leak into (silent), but a real
-    repository that errors (dubious ownership, an unreadable config) must not
-    pass silently for "ignored"; the caller says so out loud instead. */
-function gitCheckIgnore(root: string, path: string): Promise<IgnoreVerdict> {
+    and negations correctly: exit 0 is "ignored", exit 1 is "not ignored". The
+    caller has already established that a working tree exists, so any OTHER
+    exit is a repository that cannot answer (dubious ownership, an unreadable
+    config, no git binary) and must never pass for "ignored". git's own stderr
+    is quoted to the human but never parsed for the decision. */
+function gitCheckIgnore(cwd: string, path: string): Promise<IgnoreVerdict> {
   return new Promise((settle) => {
-    execFile("git", ["check-ignore", "-q", "--", path], { cwd: root }, (error, _stdout, stderr) => {
+    execFile("git", ["check-ignore", "-q", "--", path], { cwd }, (error, _stdout, stderr) => {
       if (error === null) return settle({ kind: "ignored" });
       if ((error as ExecFileException).code === 1) return settle({ kind: "not-ignored" });
-      if ((error as ExecFileException).code === "ENOENT" || /not a git repository/i.test(stderr)) {
-        return settle({ kind: "ignored" });
-      }
-      settle({ kind: "unknown", reason: (stderr.trim().split("\n")[0] ?? "git failed").slice(0, 200) });
+      const reported = stderr.trim().split("\n")[0];
+      const reason = reported !== undefined && reported.length > 0
+        ? reported.slice(0, 200)
+        : ((error as ExecFileException).code === "ENOENT" ? "git is not installed" : "git failed");
+      settle({ kind: "unknown", reason });
     });
   });
 }

--- a/packages/vendo/src/cli/cloud-init.ts
+++ b/packages/vendo/src/cli/cloud-init.ts
@@ -43,20 +43,52 @@ function upsertLine(current: string | null, name: string, value: string): string
 
 /** One loud line when the file we just wrote a secret into would be committed.
     Never blocks the write (the key is already minted and unrecoverable) — the
-    dev needs to know, not to be stopped. */
+    dev needs to know, not to be stopped. Three honest outcomes, each with the
+    remediation that actually works for it. */
 export async function warnEnvLocalNotIgnored(root: string, output: Output): Promise<void> {
-  if (await gitIgnoresEnvLocal(root)) return;
-  output.error("warning: .env.local holds a secret and is NOT gitignored — add `.env.local` to .gitignore before you commit.");
+  // Tracked outranks ignored: a file already in the index is committed no
+  // matter what .gitignore says (check-ignore answers from the patterns alone,
+  // so it can call a tracked file "ignored"), and only `git rm --cached`
+  // undoes that.
+  if (await gitTracks(root, ".env.local")) {
+    output.error("warning: .env.local holds a secret and is TRACKED by git — .gitignore alone will NOT stop the next commit: run `git rm --cached .env.local`, then add `.env.local` to .gitignore.");
+    return;
+  }
+  const verdict = await gitCheckIgnore(root, ".env.local");
+  if (verdict.kind === "ignored") return;
+  if (verdict.kind === "not-ignored") {
+    output.error("warning: .env.local holds a secret and is NOT gitignored — add `.env.local` to .gitignore before you commit.");
+    return;
+  }
+  output.error(`warning: .env.local holds a secret and git could not say whether it is ignored (${verdict.reason}) — check it yourself before you commit.`);
 }
 
-/** `git check-ignore` is the only authority that reads nested .gitignore files
-    and negations correctly. Exit 1 is the ONLY "not ignored" answer: exit 128
-    (not a repo) and a failed spawn (no git) mean there is nothing to leak
-    into, so they stay silent. */
-function gitIgnoresEnvLocal(root: string): Promise<boolean> {
+/** Exit 0 only when the path is in the index. Every other outcome (untracked,
+    no repository, no git) is "not tracked" — the check-ignore verdict is what
+    decides those. */
+function gitTracks(root: string, path: string): Promise<boolean> {
   return new Promise((settle) => {
-    execFile("git", ["check-ignore", "-q", ".env.local"], { cwd: root }, (error) => {
-      settle((error as ExecFileException | null)?.code !== 1);
+    execFile("git", ["ls-files", "--error-unmatch", "--", path], { cwd: root }, (error) => settle(error === null));
+  });
+}
+
+type IgnoreVerdict = { kind: "ignored" } | { kind: "not-ignored" } | { kind: "unknown"; reason: string };
+
+/** `git check-ignore` is the only authority that reads nested .gitignore files
+    and negations correctly: exit 0 is "ignored", exit 1 is "not ignored".
+    Everything else is a failure, and the failure MODE decides — no git and no
+    repository anywhere mean there is nothing to leak into (silent), but a real
+    repository that errors (dubious ownership, an unreadable config) must not
+    pass silently for "ignored"; the caller says so out loud instead. */
+function gitCheckIgnore(root: string, path: string): Promise<IgnoreVerdict> {
+  return new Promise((settle) => {
+    execFile("git", ["check-ignore", "-q", "--", path], { cwd: root }, (error, _stdout, stderr) => {
+      if (error === null) return settle({ kind: "ignored" });
+      if ((error as ExecFileException).code === 1) return settle({ kind: "not-ignored" });
+      if ((error as ExecFileException).code === "ENOENT" || /not a git repository/i.test(stderr)) {
+        return settle({ kind: "ignored" });
+      }
+      settle({ kind: "unknown", reason: (stderr.trim().split("\n")[0] ?? "git failed").slice(0, 200) });
     });
   });
 }

--- a/packages/vendo/src/cli/cloud-init.ts
+++ b/packages/vendo/src/cli/cloud-init.ts
@@ -32,15 +32,12 @@ import {
     `warnEnvLocalNotIgnored` — a secret just landed on disk. */
 export async function upsertEnvLocal(root: string, name: string, value: string): Promise<void> {
   const path = join(root, ".env.local");
-  await writeText(path, upsertLine(await readOptional(path), name, value));
-}
-
-function upsertLine(current: string | null, name: string, value: string): string {
+  const current = (await readOptional(path)) ?? "";
   const line = `${name}=${value}`;
-  if (current === null || current.length === 0) return `${line}\n`;
   const pattern = new RegExp(`^\\s*${name}\\s*=.*$`, "m");
-  if (pattern.test(current)) return current.replace(pattern, line);
-  return `${current}${current.endsWith("\n") ? "" : "\n"}${line}\n`;
+  await writeText(path, pattern.test(current)
+    ? current.replace(pattern, line)
+    : `${current}${current === "" || current.endsWith("\n") ? "" : "\n"}${line}\n`);
 }
 
 /** One loud line when the file we just wrote a secret into would be committed.
@@ -50,32 +47,32 @@ function upsertLine(current: string | null, name: string, value: string): string
 export async function warnEnvLocalNotIgnored(root: string, output: Output): Promise<void> {
   // The write follows symlinks, so the file git must be asked about is the REAL
   // one: a .env.local that is itself gitignored can point straight at a tracked
-  // file, and asking about the link would call that safe.
+  // file, and asking about the link would call that safe. Both sides resolved,
+  // or the name is nonsense whenever the ROOT itself sits under a link (every
+  // macOS temp dir: /var → /private/var). Ask the repository that holds the
+  // SECRET, which a link can move — or take out of every working tree, where
+  // there is nothing to leak into.
   const link = join(root, ".env.local");
   const file = await realpath(link).catch(() => link);
-  // Both sides resolved, or the name is nonsense whenever the ROOT itself sits
-  // under a link (every macOS temp dir: /var → /private/var).
   const name = relative(await realpath(root).catch(() => root), file);
-  // Ask the repository that holds the SECRET, which a link can move (or take
-  // out of every working tree, where there is nothing to leak into).
   const where = dirname(file);
   if (!(await insideWorkTree(where))) return;
 
-  // Tracked outranks ignored: a file already in the index is committed no
-  // matter what .gitignore says (check-ignore answers from the patterns alone,
-  // and reports a tracked file as NOT ignored even when a pattern matches it),
-  // and only `git rm --cached` undoes that.
+  const verdict = await gitCheckIgnore(where, file);
+  if (verdict.kind === "ignored") return;
+  if (verdict.kind === "unknown") {
+    output.error(`warning: ${name} holds a secret and git could not say whether it is ignored (${verdict.reason}) — check it yourself before you commit.`);
+    return;
+  }
+  // check-ignore answers from the patterns alone, so it calls a TRACKED file
+  // "not ignored" even when a pattern matches it — and a file already in the
+  // index commits no matter what .gitignore says. Only `git rm --cached` undoes
+  // that, so the index is what decides between the two remedies.
   if (await gitTracks(where, file)) {
     output.error(`warning: ${name} holds a secret and is TRACKED by git — .gitignore alone will NOT stop the next commit: run \`git rm --cached ${name}\`, then add \`${name}\` to .gitignore.`);
     return;
   }
-  const verdict = await gitCheckIgnore(where, file);
-  if (verdict.kind === "ignored") return;
-  if (verdict.kind === "not-ignored") {
-    output.error(`warning: ${name} holds a secret and is NOT gitignored — add \`${name}\` to .gitignore before you commit.`);
-    return;
-  }
-  output.error(`warning: ${name} holds a secret and git could not say whether it is ignored (${verdict.reason}) — check it yourself before you commit.`);
+  output.error(`warning: ${name} holds a secret and is NOT gitignored — add \`${name}\` to .gitignore before you commit.`);
 }
 
 /** Is this path inside a git working tree? Answered by walking up for a `.git`
@@ -90,8 +87,9 @@ async function insideWorkTree(from: string): Promise<boolean> {
   }
 }
 
-/** Exit 0 only when the path is in the index. Every other outcome (untracked,
-    git cannot run) is "not tracked" — the check-ignore verdict decides those. */
+/** Exit 0 only when the path is in the index — every other outcome is "not
+    tracked". Asked only after check-ignore reported "not ignored", so the
+    common (ignored) case costs no second subprocess. */
 function gitTracks(cwd: string, path: string): Promise<boolean> {
   return new Promise((settle) => {
     execFile("git", ["ls-files", "--error-unmatch", "--", path], { cwd }, (error) => settle(error === null));

--- a/packages/vendo/src/cli/cloud/device-login.ts
+++ b/packages/vendo/src/cli/cloud/device-login.ts
@@ -6,7 +6,7 @@ import { isVendoKey, resolveCloudBaseUrl } from "./client.js";
 import { errorMessage, printJson } from "./output.js";
 import { deletePendingClaim, readPendingClaim, writePendingClaim } from "./pending-claim.js";
 import { writeCloudSession, type CloudSession } from "./session.js";
-import { upsertEnvLocal } from "../cloud-init.js";
+import { upsertEnvLocal, warnEnvLocalNotIgnored } from "../cloud-init.js";
 import { browserOpenCommand } from "../playground.js";
 import { CLI_VERSION, consoleOutput, withCommandRun, type Output, type TelemetryOptions } from "../shared.js";
 
@@ -346,6 +346,7 @@ export async function runDeviceLogin(
         // receipt. A resumed run names the full path: it may differ from cwd.
         output.log(`Approved — wrote VENDO_API_KEY (…${key.slice(-4)}) to ${
           resume !== null ? join(root, ".env.local") : ".env.local"}.`);
+        await warnEnvLocalNotIgnored(root, output);
         if (options.rerunHint !== false) {
           output.log("Re-run `vendo init` to finish wiring (it picks the key up from .env.local).");
         }

--- a/packages/vendo/src/cli/framework.ts
+++ b/packages/vendo/src/cli/framework.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { walk } from "./theme/walk.js";
 
@@ -48,6 +48,24 @@ export async function detectFramework(root: string): Promise<HostFramework> {
   } catch {
     return "unknown";
   }
+}
+
+/** The workspace packages that look like the real host, for an init run one
+    level too high: a monorepo root declares neither next nor express, so
+    detection lands on the runtime-neutral custom scaffold and the dev never
+    notices. Deliberately just the two conventional workspace dirs — a hint
+    that names a candidate, not a workspace-glob resolver. Paths are relative
+    and posix-style (they go straight into a `vendo init <dir>` suggestion). */
+export async function workspaceHostCandidates(root: string): Promise<string[]> {
+  const candidates: string[] = [];
+  for (const group of ["apps", "packages"]) {
+    const entries = await readdir(join(root, group), { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (await detectFramework(join(root, group, entry.name)) !== "unknown") candidates.push(`${group}/${entry.name}`);
+    }
+  }
+  return candidates;
 }
 
 /** Bounded source scan shared by init and doctor so their wiring verdicts

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -271,6 +271,17 @@ async function detectRouter(root: string, framework: Exclude<HostFramework, "unk
   return "none";
 }
 
+/** A path for a command the caller will paste into their OWN shell: relative
+    to their cwd while it stays inside it, else absolute. A path relative to
+    init's target root resolves somewhere else entirely when the two differ
+    (`vendo init monorepo` from /work must not suggest `vendo init apps/web`).
+    Quoted when it contains a space, so the suggestion survives copy-paste. */
+function pastePath(target: string): string {
+  const rel = relative(process.cwd(), target);
+  const path = rel !== "" && !rel.startsWith("..") ? rel : target;
+  return path.includes(" ") ? JSON.stringify(path) : path;
+}
+
 /** The file whose client root the <VendoRoot> paste belongs in, and the child
     expression it wraps there. A pages-only host has NO app/layout.tsx to wrap
     — its client root is pages/_app.tsx, and the generated vendo-root.tsx is a
@@ -1017,8 +1028,9 @@ export async function runInit(options: InitOptions): Promise<number> {
     const candidates = await workspaceHostCandidates(root);
     if (candidates.length > 0) {
       output.error(
-        `warning: no next or express dependency here, but ${candidates.join(", ")} look like hosts — ` +
-        `did you mean ${candidates[0]}? Re-run there (vendo init ${candidates[0]}) or pass --framework to scaffold this directory anyway.`,
+        `warning: no next or express dependency in this directory, but ${candidates.join(", ")} ` +
+        `${candidates.length === 1 ? "looks" : "look"} like the host — did you mean ${candidates[0]}? ` +
+        `Re-run there (vendo init ${pastePath(join(root, candidates[0]!))}) or pass --framework to scaffold this directory anyway.`,
       );
     }
   }
@@ -1365,11 +1377,17 @@ export async function runInit(options: InitOptions): Promise<number> {
       output.log("\nLast steps are yours:");
       for (const line of manualSteps) output.log(`  ${line}`);
     }
-    // Keyless runs are wired but not answering: the agent needs a model before
-    // anything happens, so the closing line must not claim otherwise.
-    output.log(credential.rung === "none"
-      ? "\nThen start your dev server — the agent is live once you add a model key."
-      : "\nThen start your dev server — the agent is live in your app.");
+    // A run without a USABLE model credential is wired but not answering, so
+    // the closing line must not claim otherwise. The rung alone is not that
+    // answer: resolveDevCredential only checks that VENDO_API_KEY is non-blank
+    // (and VENDO_DEV_CREDENTIAL=vendo-cloud pins the rung with no key at all),
+    // so a malformed key resolves "vendo-cloud" while the cloud step — the one
+    // thing that inspected the key — already said it is not usable.
+    const modelReady = credential.rung === "env-key"
+      || (credential.rung === "vendo-cloud" && cloud.keyValid);
+    output.log(modelReady
+      ? "\nThen start your dev server — the agent is live in your app."
+      : "\nThen start your dev server — the agent is live once you add a model key.");
     output.log("Verify everything: `npx vendo doctor` (it can start the server and run a live turn).");
 
     // Agent tail (agent-install-dx): the --yes-or-non-TTY path is agent-driven

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -275,21 +275,14 @@ async function detectRouter(root: string, framework: Exclude<HostFramework, "unk
     to their cwd while it stays inside it, "." when it IS their cwd, else
     absolute. A path relative to init's target root resolves somewhere else
     entirely when the two differ (`vendo init monorepo` from /work must not
-    suggest `vendo init apps/web`). */
+    suggest `vendo init apps/web`). Quoted with POSIX single quotes when it
+    needs it: nothing expands inside them, while double quotes would still let
+    a directory named `$(…)` be substituted by the pasting shell. */
 function pastePath(target: string): string {
   const rel = relative(process.cwd(), target);
   if (rel === "") return ".";
-  return shellQuote(rel.startsWith("..") ? target : rel);
-}
-
-/** POSIX single-quote escaping, applied only to a path that needs it. Single
-    quotes are the only inert quoting: nothing expands inside them, and an
-    embedded quote closes-escapes-reopens. Double quotes would NOT be safe — a
-    directory named `$(…)` or holding a backtick is substituted by the shell
-    that pastes the suggestion, so the "safe" quoting would run it. */
-function shellQuote(path: string): string {
-  if (/^[\w./@+-]+$/.test(path)) return path;
-  return `'${path.replace(/'/g, "'\\''")}'`;
+  const path = rel.startsWith("..") ? target : rel;
+  return /^[\w./@+-]+$/.test(path) ? path : `'${path.replace(/'/g, "'\\''")}'`;
 }
 
 /** The file whose client root the <VendoRoot> paste belongs in, and the child
@@ -512,8 +505,6 @@ async function manualWiringLines(root: string, layout: LayoutWiring, withRegistr
     ];
   }
   const app = await appDirectory(root);
-  // app/layout.tsx for an app-router host, pages/_app.tsx for a pages-only one
-  // — never an instruction naming a file the host doesn't have.
   const { file: entry, children } = await clientRoot(root);
   const entryDir = dirname(entry);
   const entryRel = relative(root, entry);
@@ -1021,20 +1012,17 @@ export async function runInit(options: InitOptions): Promise<number> {
   const interactive = options.interactive ?? (Boolean(stdin.isTTY) && Boolean(stdout.isTTY));
   // An undetectable framework has NO safe default: a non-interactive run
   // (agents) errors with the exact flag instead of guessing the Next layout
-  // into an unknown host. Interactive runs keep today's fall-through.
-  if (options.framework === undefined && (options.yes === true || !interactive)
-    && await detectFramework(root) === "unknown") {
-    output.error(
-      "Framework not detected (no next or express dependency in package.json) and this run cannot ask. " +
-      "Pass --framework. Examples: vendo init --yes --framework next · --framework custom (any Web-standard runtime: Cloudflare Workers, Bun, Hono, ...)",
-    );
-    return 1;
-  }
-  // The interactive counterpart: an undetectable root falls through to the
-  // custom scaffold, which is silently wrong when the host is a workspace
-  // package one level down. Name the candidates instead of guessing for them.
-  if (options.framework === undefined && options.yes !== true && interactive
-    && await detectFramework(root) === "unknown") {
+  // into an unknown host. An interactive run keeps today's fall-through to the
+  // custom scaffold — silently wrong when the host is a workspace package one
+  // level down, so name the candidates instead of guessing for them.
+  if (options.framework === undefined && await detectFramework(root) === "unknown") {
+    if (options.yes === true || !interactive) {
+      output.error(
+        "Framework not detected (no next or express dependency in package.json) and this run cannot ask. " +
+        "Pass --framework. Examples: vendo init --yes --framework next · --framework custom (any Web-standard runtime: Cloudflare Workers, Bun, Hono, ...)",
+      );
+      return 1;
+    }
     const candidates = await workspaceHostCandidates(root);
     if (candidates.length > 0) {
       output.error(
@@ -1392,21 +1380,18 @@ export async function runInit(options: InitOptions): Promise<number> {
     // answer: resolveDevCredential only checks that VENDO_API_KEY is non-blank
     // (and VENDO_DEV_CREDENTIAL=vendo-cloud pins the rung with no key at all),
     // so a malformed key resolves "vendo-cloud" while the cloud step — the one
-    // thing that inspected the key — already said it is not usable.
+    // thing that inspected the key — already said it is not usable. Keyless,
+    // the composition decides: one written THIS run passes no model, so "no
+    // key" is the whole story, while one init did not write may pass its own
+    // `model` to createVendo — nothing here can see that, so state the
+    // condition rather than guess either way.
     const modelReady = credential.rung === "env-key"
       || (credential.rung === "vendo-cloud" && cloud.keyValid);
-    if (modelReady) {
-      output.log("\nThen start your dev server — the agent is live in your app.");
-    } else if (compositionPath !== null) {
-      // The composition was written THIS run and the generated one passes no
-      // model, so "no key" really is the whole story.
-      output.log("\nThen start your dev server — the agent is live once you add a model key.");
-    } else {
-      // A composition this run did not write may pass its own `model` to
-      // createVendo, which needs no env key at all. Nothing here can see that,
-      // so state the condition rather than guess either way.
-      output.log("\nThen start your dev server — no model key resolved here, so the agent is live only if your composition passes its own model.");
-    }
+    output.log(`\nThen start your dev server — ${modelReady
+      ? "the agent is live in your app."
+      : compositionPath !== null
+        ? "the agent is live once you add a model key."
+        : "no model key resolved here, so the agent is live only if your composition passes its own model."}`);
     output.log("Verify everything: `npx vendo doctor` (it can start the server and run a live turn).");
 
     // Agent tail (agent-install-dx): the --yes-or-non-TTY path is agent-driven

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -9,11 +9,11 @@ import { stdin, stdout } from "node:process";
 import type { VendoTheme } from "@vendoai/core";
 import { scrubErrorDetail, type Telemetry } from "@vendoai/telemetry";
 import { detectDepVersions, installedAiVersion } from "./dep-versions.js";
-import { AUTH_MD_URL, runCloudStep, upsertEnvLocal, type CloudStepOptions } from "./cloud-init.js";
+import { AUTH_MD_URL, runCloudStep, upsertEnvLocal, warnEnvLocalNotIgnored, type CloudStepOptions } from "./cloud-init.js";
 import { runInitJudgment, type InitJudgmentOptions } from "./init-judgment.js";
 import { BRIEF_TEMPLATE } from "./extract/stages.js";
 import { ENV_KEY_VARS, resolveDevCredential, describeDevCredential, type DevCredential } from "../dev-creds/resolve.js";
-import { detectFramework, detectVendoWiring, type HostFramework } from "./framework.js";
+import { detectFramework, detectVendoWiring, workspaceHostCandidates, type HostFramework } from "./framework.js";
 import { resolveScaffoldAuth, type AuthMatch, type AuthPresetName, type ConfirmAuth, type SelectAuth } from "./init-auth.js";
 import { ensureProviderDeps, ensureZodFloor, type InstallRunner } from "./provider-deps.js";
 import {
@@ -271,6 +271,23 @@ async function detectRouter(root: string, framework: Exclude<HostFramework, "unk
   return "none";
 }
 
+/** The file whose client root the <VendoRoot> paste belongs in, and the child
+    expression it wraps there. A pages-only host has NO app/layout.tsx to wrap
+    — its client root is pages/_app.tsx, and the generated vendo-root.tsx is a
+    client component that mounts there unchanged. (Where the API route segment
+    gets scaffolded is a separate, deliberate choice — see appDirectory.)
+    Keyed on the layout FILE, not on detectRouter: the scaffold creates app/
+    mid-run, and the answer must be the same before and after it. */
+async function clientRoot(root: string): Promise<{ file: string; children: string }> {
+  const layout = join(await appDirectory(root), "layout.tsx");
+  if (!(await exists(layout))) {
+    for (const pages of [join(root, "src", "pages"), join(root, "pages")]) {
+      if (await exists(pages)) return { file: join(pages, "_app.tsx"), children: "<Component {...pageProps} />" };
+    }
+  }
+  return { file: layout, children: "{children}" };
+}
+
 /** Relative, posix-style import specifier from the layout's directory to the
     project-root `.vendo/theme.json` — printed for the user's paste, never
     written by init. Returns null when the project EXPLICITLY disables
@@ -474,20 +491,24 @@ async function manualWiringLines(root: string, layout: LayoutWiring, withRegistr
     ];
   }
   const app = await appDirectory(root);
-  const layoutRel = relative(root, join(app, "layout.tsx"));
+  // app/layout.tsx for an app-router host, pages/_app.tsx for a pages-only one
+  // — never an instruction naming a file the host doesn't have.
+  const { file: entry, children } = await clientRoot(root);
+  const entryDir = dirname(entry);
+  const entryRel = relative(root, entry);
   if (withRegistry) {
-    const wrapperSpecifier = relative(app, join(dirname(app), "vendo", "vendo-root")).split(sep).join("/");
+    const wrapperSpecifier = relative(entryDir, join(dirname(app), "vendo", "vendo-root")).split(sep).join("/");
     return [
-      `In ${layoutRel}:`,
+      `In ${entryRel}:`,
       `  import { VendoRoot } from ${JSON.stringify(wrapperSpecifier)};`,
-      `  … then wrap: <VendoRoot>{children}</VendoRoot>`,
+      `  … then wrap: <VendoRoot>${children}</VendoRoot>`,
       `  (${join("vendo", "vendo-root.tsx")} mounts <VendoOverlay />, the visible launcher + panel)`,
     ];
   }
   // No registry consumer (a hand-wired route that ignores it): the direct
   // provider + overlay paste — theme.json is serializable, so it may cross
   // the Server Component boundary; the registry may not.
-  const specifier = await themeImportSpecifier(root, app);
+  const specifier = await themeImportSpecifier(root, entryDir);
   const importLines = [
     `import { VendoOverlay, VendoRoot } from "@vendoai/vendo/react";`,
     ...(specifier === null
@@ -497,8 +518,8 @@ async function manualWiringLines(root: string, layout: LayoutWiring, withRegistr
           `import type { VendoTheme } from "@vendoai/vendo";`,
         ]),
   ];
-  const wrap = `<VendoRoot${specifier === null ? "" : " theme={theme as VendoTheme}"}>{children}<VendoOverlay /></VendoRoot>`;
-  return [`In ${layoutRel}:`, ...importLines.map((line) => `  ${line}`), `  … then wrap: ${wrap}`];
+  const wrap = `<VendoRoot${specifier === null ? "" : " theme={theme as VendoTheme}"}>${children}<VendoOverlay /></VendoRoot>`;
+  return [`In ${entryRel}:`, ...importLines.map((line) => `  ${line}`), `  … then wrap: ${wrap}`];
 }
 
 /** The repo-specific agent tail (agent-install-dx): a non-interactive
@@ -546,8 +567,8 @@ async function agentTailLines(args: {
   } else if (args.layout.kind === "overlay-missing") {
     lines.push(`edit ${args.layout.layoutPath} — add <VendoOverlay /> inside your <VendoRoot> (see the lines above; <VendoRoot> alone renders NOTHING visible)`);
   } else if (args.layout.kind === "manual") {
-    const layout = relative(args.root, join(await appDirectory(args.root), "layout.tsx"));
-    lines.push(`edit ${layout} — wrap the app in the <VendoRoot> lines above (it mounts <VendoOverlay />, the visible surface; without it users see nothing)`);
+    const entry = relative(args.root, (await clientRoot(args.root)).file);
+    lines.push(`edit ${entry} — wrap the app in the <VendoRoot> lines above (it mounts <VendoOverlay />, the visible surface; without it users see nothing)`);
   }
   if (await readOptional(join(args.root, ".vendo", "brief.md")) === BRIEF_PLACEHOLDER) {
     lines.push(`edit ${join(".vendo", "brief.md")} — replace the placeholder with what this product does and for whom`);
@@ -835,7 +856,9 @@ async function buildPlan(options: InitOptions, confirmAuth?: ConfirmAuth, select
       // the wrapper renders <VendoOverlay /> (the re-run after an auto-wire).
       layout = mounts.surface || wrapperBefore !== null
         ? { kind: "already" }
-        : { kind: "overlay-missing", layoutPath: relative(root, layoutFile) };
+        // A pages-only host mounted <VendoRoot> in pages/_app.tsx, not in an
+        // app/layout.tsx it doesn't have — name the file it really wraps in.
+        : { kind: "overlay-missing", layoutPath: relative(root, (await clientRoot(root)).file) };
     } else if (withRegistry) {
       // The wrapper consumes ./registry, so it exists only alongside one —
       // a hand-wired host that ignores the registry keeps the manual paste.
@@ -986,6 +1009,19 @@ export async function runInit(options: InitOptions): Promise<number> {
     );
     return 1;
   }
+  // The interactive counterpart: an undetectable root falls through to the
+  // custom scaffold, which is silently wrong when the host is a workspace
+  // package one level down. Name the candidates instead of guessing for them.
+  if (options.framework === undefined && options.yes !== true && interactive
+    && await detectFramework(root) === "unknown") {
+    const candidates = await workspaceHostCandidates(root);
+    if (candidates.length > 0) {
+      output.error(
+        `warning: no next or express dependency here, but ${candidates.join(", ")} look like hosts — ` +
+        `did you mean ${candidates[0]}? Re-run there (vendo init ${candidates[0]}) or pass --framework to scaffold this directory anyway.`,
+      );
+    }
+  }
   // (No stdin-TTY guard on these defaults, unlike the star ask's: an unshown
   // auth confirm resolving its default just wires the detected preset — the
   // very accept the non-interactive path performs silently anyway.)
@@ -1008,6 +1044,7 @@ export async function runInit(options: InitOptions): Promise<number> {
     if (options.cloudKey !== undefined) {
       await upsertEnvLocal(root, "VENDO_API_KEY", options.cloudKey);
       output.log("Wrote VENDO_API_KEY to .env.local (--cloud-key).");
+      await warnEnvLocalNotIgnored(root, output);
     }
     // Key first (product order fix): the model-credential story — env keys,
     // else the Vendo Cloud offer — runs BEFORE the AI-assisted passes, so a
@@ -1328,7 +1365,11 @@ export async function runInit(options: InitOptions): Promise<number> {
       output.log("\nLast steps are yours:");
       for (const line of manualSteps) output.log(`  ${line}`);
     }
-    output.log("\nThen start your dev server — the agent is live in your app.");
+    // Keyless runs are wired but not answering: the agent needs a model before
+    // anything happens, so the closing line must not claim otherwise.
+    output.log(credential.rung === "none"
+      ? "\nThen start your dev server — the agent is live once you add a model key."
+      : "\nThen start your dev server — the agent is live in your app.");
     output.log("Verify everything: `npx vendo doctor` (it can start the server and run a live turn).");
 
     // Agent tail (agent-install-dx): the --yes-or-non-TTY path is agent-driven

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -272,14 +272,24 @@ async function detectRouter(root: string, framework: Exclude<HostFramework, "unk
 }
 
 /** A path for a command the caller will paste into their OWN shell: relative
-    to their cwd while it stays inside it, else absolute. A path relative to
-    init's target root resolves somewhere else entirely when the two differ
-    (`vendo init monorepo` from /work must not suggest `vendo init apps/web`).
-    Quoted when it contains a space, so the suggestion survives copy-paste. */
+    to their cwd while it stays inside it, "." when it IS their cwd, else
+    absolute. A path relative to init's target root resolves somewhere else
+    entirely when the two differ (`vendo init monorepo` from /work must not
+    suggest `vendo init apps/web`). */
 function pastePath(target: string): string {
   const rel = relative(process.cwd(), target);
-  const path = rel !== "" && !rel.startsWith("..") ? rel : target;
-  return path.includes(" ") ? JSON.stringify(path) : path;
+  if (rel === "") return ".";
+  return shellQuote(rel.startsWith("..") ? target : rel);
+}
+
+/** POSIX single-quote escaping, applied only to a path that needs it. Single
+    quotes are the only inert quoting: nothing expands inside them, and an
+    embedded quote closes-escapes-reopens. Double quotes would NOT be safe — a
+    directory named `$(…)` or holding a backtick is substituted by the shell
+    that pastes the suggestion, so the "safe" quoting would run it. */
+function shellQuote(path: string): string {
+  if (/^[\w./@+-]+$/.test(path)) return path;
+  return `'${path.replace(/'/g, "'\\''")}'`;
 }
 
 /** The file whose client root the <VendoRoot> paste belongs in, and the child
@@ -1385,9 +1395,18 @@ export async function runInit(options: InitOptions): Promise<number> {
     // thing that inspected the key — already said it is not usable.
     const modelReady = credential.rung === "env-key"
       || (credential.rung === "vendo-cloud" && cloud.keyValid);
-    output.log(modelReady
-      ? "\nThen start your dev server — the agent is live in your app."
-      : "\nThen start your dev server — the agent is live once you add a model key.");
+    if (modelReady) {
+      output.log("\nThen start your dev server — the agent is live in your app.");
+    } else if (compositionPath !== null) {
+      // The composition was written THIS run and the generated one passes no
+      // model, so "no key" really is the whole story.
+      output.log("\nThen start your dev server — the agent is live once you add a model key.");
+    } else {
+      // A composition this run did not write may pass its own `model` to
+      // createVendo, which needs no env key at all. Nothing here can see that,
+      // so state the condition rather than guess either way.
+      output.log("\nThen start your dev server — no model key resolved here, so the agent is live only if your composition passes its own model.");
+    }
     output.log("Verify everything: `npx vendo doctor` (it can start the server and run a live turn).");
 
     // Agent tail (agent-install-dx): the --yes-or-non-TTY path is agent-driven

--- a/packages/vendo/src/cli/onboarding-safety.test.ts
+++ b/packages/vendo/src/cli/onboarding-safety.test.ts
@@ -177,38 +177,31 @@ describe("the closing line tells the truth about the model key", () => {
   const LIVE = "Then start your dev server — the agent is live in your app.";
   const PENDING = "Then start your dev server — the agent is live once you add a model key.";
 
-  it("keyless: live once a key is added", async () => {
-    const sink = output();
-    expect(await run(await pagesHost(), sink)).toBe(0);
-    expect(sink.logs.join("\n")).toContain(PENDING);
-    expect(sink.logs.join("\n")).not.toContain(LIVE);
+  it("no usable key — however the rung resolved — is live only once one is added", async () => {
+    // A resolved rung is not a usable key: resolveDevCredential only checks
+    // that VENDO_API_KEY is non-blank, and VENDO_DEV_CREDENTIAL=vendo-cloud
+    // pins the rung with no key at all — so both used to print "the agent is
+    // live in your app", the malformed one right beside "not usable".
+    const keyless: Partial<Parameters<typeof runInit>[0]>[] = [
+      {},
+      {
+        env: { VENDO_API_KEY: "not-a-vendo-key" },
+        cloud: { cloudProbe: async () => ({ present: true, ok: false, error: "malformed", unlocks: ["x"] as readonly string[] }) },
+      },
+      { env: { VENDO_DEV_CREDENTIAL: "vendo-cloud" } },
+    ];
+    for (const extra of keyless) {
+      const sink = output();
+      expect(await run(await pagesHost(), sink, extra)).toBe(0);
+      expect(sink.logs.join("\n")).toContain(PENDING);
+      expect(sink.logs.join("\n")).not.toContain(LIVE);
+    }
   });
 
   it("keyed: live in your app", async () => {
     const sink = output();
     expect(await run(await pagesHost(), sink, { env: { ANTHROPIC_API_KEY: "sk-a" } })).toBe(0);
     expect(sink.logs.join("\n")).toContain(LIVE);
-  });
-
-  it("an UNUSABLE VENDO_API_KEY is not a live agent, even though it resolves a rung", async () => {
-    // resolveDevCredential only checks that VENDO_API_KEY is non-blank, so a
-    // malformed key still resolves rung "vendo-cloud" — and the run would
-    // print "not usable" and "the agent is live in your app" together.
-    const sink = output();
-    expect(await run(await pagesHost(), sink, {
-      env: { VENDO_API_KEY: "not-a-vendo-key" },
-      cloud: { cloudProbe: async () => ({ present: true, ok: false, error: "malformed", unlocks: ["x"] as readonly string[] }) },
-    })).toBe(0);
-    expect(sink.errors.join("\n")).toContain("not usable");
-    expect(sink.logs.join("\n")).toContain(PENDING);
-    expect(sink.logs.join("\n")).not.toContain(LIVE);
-  });
-
-  it("VENDO_DEV_CREDENTIAL=vendo-cloud with no key at all is not live either", async () => {
-    const sink = output();
-    expect(await run(await pagesHost(), sink, { env: { VENDO_DEV_CREDENTIAL: "vendo-cloud" } })).toBe(0);
-    expect(sink.logs.join("\n")).toContain(PENDING);
-    expect(sink.logs.join("\n")).not.toContain(LIVE);
   });
 
   it("a re-run over an existing composition states the condition — it may pass its own model", async () => {

--- a/packages/vendo/src/cli/onboarding-safety.test.ts
+++ b/packages/vendo/src/cli/onboarding-safety.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
@@ -120,6 +120,23 @@ describe("the .env.local secret write warns when git would commit it", () => {
     expect(sink.errors).toEqual([]);
   });
 
+  it("a symlinked .env.local is judged by the file the write really lands in", async () => {
+    // The write follows the link, so a gitignored .env.local pointing at a
+    // TRACKED file is the worst case: asking git about the link calls it safe.
+    const root = await repo();
+    await mkdir(join(root, "config"), { recursive: true });
+    await writeFile(join(root, "config", "dev.env"), "SOMETHING=1\n");
+    execFileSync("git", ["add", "-f", join("config", "dev.env")], { cwd: root });
+    await writeFile(join(root, ".gitignore"), ".env.local\n");
+    await rm(join(root, ".env.local"));
+    await symlink(join(root, "config", "dev.env"), join(root, ".env.local"));
+    const sink = output();
+    await warnEnvLocalNotIgnored(root, sink.output);
+    const warning = sink.errors.join("\n");
+    expect(warning).toContain("TRACKED by git");
+    expect(warning).toContain(join("config", "dev.env"));
+  });
+
   it("a real repo where git ERRORS is never silently treated as ignored", async () => {
     // Broken config inside a live repo: git can answer neither question, and
     // the old "anything but exit 1 means ignored" rule swallowed the warning.
@@ -194,6 +211,19 @@ describe("the closing line tells the truth about the model key", () => {
     expect(sink.logs.join("\n")).not.toContain(LIVE);
   });
 
+  it("a re-run over an existing composition states the condition — it may pass its own model", async () => {
+    // createVendo({ model }) needs no env key, so a keyless re-run over a
+    // composition init did not write must claim neither "live" nor "not live".
+    const root = await pagesHost();
+    expect(await run(root, output())).toBe(0);
+    const sink = output();
+    expect(await run(root, sink)).toBe(0);
+    const logs = sink.logs.join("\n");
+    expect(logs).toContain("no model key resolved here, so the agent is live only if your composition passes its own model.");
+    expect(logs).not.toContain(LIVE);
+    expect(logs).not.toContain(PENDING);
+  });
+
   it("a key minted mid-run IS live", async () => {
     const root = await pagesHost();
     const sink = output();
@@ -258,11 +288,30 @@ describe("an init at a monorepo root names the workspace host", () => {
     expect(hint).toContain(`vendo init ${join(root, "apps", "web")}`);
   });
 
-  it("quotes a suggested path containing a space", async () => {
-    const root = await monorepo("vendo init monorepo ");
+  it("single-quotes a suggested path the shell would otherwise mangle", async () => {
+    // Double quotes are NOT enough: `$(…)` inside them is command-substituted
+    // by the shell the suggestion is pasted into.
+    const root = await monorepo("vendo init $(printf SUBSTITUTED) ");
     const sink = output();
     expect(await hintFor(root, sink)).toBe(0);
-    expect(sink.errors.join("\n")).toContain(`vendo init ${JSON.stringify(join(root, "apps", "web"))}`);
+    const hint = sink.errors.join("\n");
+    expect(hint).toContain(`vendo init '${join(root, "apps", "web")}'`);
+    expect(hint).not.toContain(`"${join(root, "apps", "web")}"`);
+  });
+
+  it("suggests `.` when the caller is already standing in the host dir", async () => {
+    // `cd repo/apps/web && vendo init ../..` — the suggestion must be the cwd
+    // itself, not an absolute path (relative() returns "" for that case).
+    const root = await monorepo();
+    const host = join(root, "apps", "web");
+    const spy = vi.spyOn(process, "cwd").mockReturnValue(host);
+    try {
+      const sink = output();
+      expect(await hintFor(root, sink)).toBe(0);
+      expect(sink.errors.join("\n")).toContain("vendo init .");
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("non-interactive is unchanged: the exact-flag error, no hint", async () => {

--- a/packages/vendo/src/cli/onboarding-safety.test.ts
+++ b/packages/vendo/src/cli/onboarding-safety.test.ts
@@ -1,0 +1,176 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { warnEnvLocalNotIgnored } from "./cloud-init.js";
+import { workspaceHostCandidates } from "./framework.js";
+import { runInit } from "./init.js";
+import type { Output } from "./shared.js";
+import { walk } from "./theme/walk.js";
+
+/**
+ * Onboarding safety + honesty: the four things a first `vendo init` must not
+ * do — leak a secret into a committed file, hang a non-TTY caller on a
+ * question, claim the agent is live when no model key exists, or hand a host
+ * wiring instructions for a file it doesn't have.
+ */
+
+const cleanup: string[] = [];
+afterEach(async () => {
+  await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+function output(): { output: Output; logs: string[]; errors: string[] } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return { output: { log: (message) => logs.push(message), error: (message) => errors.push(message) }, logs, errors };
+}
+
+async function tempDir(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  cleanup.push(root);
+  return root;
+}
+
+/** A Next host whose ONLY router is pages/ — no app/layout.tsx exists. */
+async function pagesHost(): Promise<string> {
+  const root = await tempDir("vendo-init-pagesonly-");
+  await mkdir(join(root, "pages"), { recursive: true });
+  await writeFile(join(root, "package.json"), JSON.stringify({ name: "host", dependencies: { next: "16.0.0" } }));
+  await writeFile(join(root, "pages", "index.tsx"), "export default function Home() { return null; }\n");
+  await writeFile(join(root, "pages", "_app.tsx"),
+    "export default function App({ Component, pageProps }) { return <Component {...pageProps} />; }\n");
+  return root;
+}
+
+function run(root: string, sink: { output: Output }, extra: Partial<Parameters<typeof runInit>[0]> = {}): Promise<number> {
+  return runInit({
+    targetDir: root,
+    output: sink.output,
+    env: {},
+    cloud: { cloudProbe: async () => ({ present: false, ok: false, unlocks: ["a starter allowance"] as readonly string[] }) },
+    telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    // A resolved credential makes init install the provider it needs — never
+    // a real npm install from a test fixture.
+    installProvider: async () => 0,
+    ...extra,
+  });
+}
+
+describe("the .env.local secret write warns when git would commit it", () => {
+  it("warns, naming the fix, when .env.local is not ignored", async () => {
+    const root = await tempDir("vendo-gitignore-");
+    execFileSync("git", ["init", "-q"], { cwd: root });
+    const sink = output();
+    await warnEnvLocalNotIgnored(root, sink.output);
+    const warning = sink.errors.join("\n");
+    expect(warning).toContain(".env.local");
+    expect(warning).toContain(".gitignore");
+    expect(sink.logs).toEqual([]);
+  });
+
+  it("stays silent when .gitignore covers .env.local", async () => {
+    const root = await tempDir("vendo-gitignore-ok-");
+    execFileSync("git", ["init", "-q"], { cwd: root });
+    await writeFile(join(root, ".gitignore"), ".env*.local\n");
+    const sink = output();
+    await warnEnvLocalNotIgnored(root, sink.output);
+    expect(sink.errors).toEqual([]);
+  });
+
+  it("stays silent outside a git repo — nothing to leak into", async () => {
+    const sink = output();
+    await warnEnvLocalNotIgnored(await tempDir("vendo-gitignore-nogit-"), sink.output);
+    expect(sink.errors).toEqual([]);
+  });
+
+  it("--cloud-key surfaces the warning right after the write, and never blocks it", async () => {
+    const root = await pagesHost();
+    execFileSync("git", ["init", "-q"], { cwd: root });
+    const sink = output();
+    expect(await run(root, sink, { cloudKey: `vnd_${"a".repeat(40)}` })).toBe(0);
+    expect(await readFile(join(root, ".env.local"), "utf8")).toContain("VENDO_API_KEY=vnd_");
+    expect(sink.errors.join("\n")).toContain("NOT gitignored");
+  });
+});
+
+describe("exactly one askYesNo", () => {
+  it("only shared.ts defines it, and that copy guards non-TTY callers", async () => {
+    const cli = fileURLToPath(new URL(".", import.meta.url));
+    const sources = await walk(cli, (path) => path.endsWith(".ts") && !path.endsWith(".test.ts"));
+    const definers: string[] = [];
+    for (const file of sources) {
+      if ((await readFile(file, "utf8")).includes("function askYesNo")) definers.push(file.slice(cli.length));
+    }
+    // A second, unguarded copy is how non-TTY callers used to hang.
+    expect(definers).toEqual(["shared.ts"]);
+    expect(await readFile(join(cli, "shared.ts"), "utf8")).toContain("if (!stdin.isTTY || !stdout.isTTY) return false;");
+  });
+});
+
+describe("the closing line tells the truth about the model key", () => {
+  it("keyless: live once a key is added", async () => {
+    const sink = output();
+    expect(await run(await pagesHost(), sink)).toBe(0);
+    expect(sink.logs.join("\n")).toContain("Then start your dev server — the agent is live once you add a model key.");
+    expect(sink.logs.join("\n")).not.toContain("the agent is live in your app.");
+  });
+
+  it("keyed: live in your app", async () => {
+    const sink = output();
+    expect(await run(await pagesHost(), sink, { env: { ANTHROPIC_API_KEY: "sk-a" } })).toBe(0);
+    expect(sink.logs.join("\n")).toContain("Then start your dev server — the agent is live in your app.");
+  });
+});
+
+describe("a pages-only host is told to wire the file it actually has", () => {
+  it("names pages/_app.tsx and never app/layout.tsx", async () => {
+    const sink = output();
+    expect(await run(await pagesHost(), sink)).toBe(0);
+    const logs = sink.logs.join("\n");
+    expect(logs).toContain("Last steps are yours:");
+    expect(logs).toContain(`In ${join("pages", "_app.tsx")}:`);
+    // The wrapped child is the pages-router one, not app-router's {children}.
+    expect(logs).toContain("<VendoRoot><Component {...pageProps} /></VendoRoot>");
+    expect(logs).not.toContain(join("app", "layout.tsx"));
+  });
+});
+
+describe("an init at a monorepo root names the workspace host", () => {
+  async function monorepo(): Promise<string> {
+    const root = await tempDir("vendo-init-monorepo-");
+    await mkdir(join(root, "apps", "web"), { recursive: true });
+    await mkdir(join(root, "packages", "ui"), { recursive: true });
+    await writeFile(join(root, "package.json"), JSON.stringify({ name: "monorepo", private: true }));
+    await writeFile(join(root, "apps", "web", "package.json"), JSON.stringify({ name: "web", dependencies: { next: "16.0.0" } }));
+    await writeFile(join(root, "packages", "ui", "package.json"), JSON.stringify({ name: "ui" }));
+    return root;
+  }
+
+  it("lists only the workspace packages that look like hosts", async () => {
+    expect(await workspaceHostCandidates(await monorepo())).toEqual(["apps/web"]);
+    expect(await workspaceHostCandidates(await tempDir("vendo-init-flat-"))).toEqual([]);
+  });
+
+  it("interactive: hints at apps/web instead of silently scaffolding the root", async () => {
+    const sink = output();
+    expect(await run(await monorepo(), sink, {
+      interactive: true,
+      confirmAuth: async () => false,
+      selectAuth: async () => "none",
+    })).toBe(0);
+    const hint = sink.errors.join("\n");
+    expect(hint).toContain("did you mean apps/web?");
+    expect(hint).toContain("vendo init apps/web");
+    expect(hint).toContain("--framework");
+  });
+
+  it("non-interactive is unchanged: the exact-flag error, no hint", async () => {
+    const sink = output();
+    expect(await run(await monorepo(), sink, { yes: true })).toBe(1);
+    expect(sink.errors.join("\n")).toContain("Pass --framework");
+    expect(sink.errors.join("\n")).not.toContain("did you mean");
+  });
+});

--- a/packages/vendo/src/cli/onboarding-safety.test.ts
+++ b/packages/vendo/src/cli/onboarding-safety.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { warnEnvLocalNotIgnored } from "./cloud-init.js";
 import { workspaceHostCandidates } from "./framework.js";
 import { runInit } from "./init.js";
@@ -60,30 +60,76 @@ function run(root: string, sink: { output: Output }, extra: Partial<Parameters<t
 }
 
 describe("the .env.local secret write warns when git would commit it", () => {
-  it("warns, naming the fix, when .env.local is not ignored", async () => {
+  /** The verdict must come from the REPO, never from whoever runs the suite: a
+      developer with .env.local in their global excludes (or a ~/.gitconfig
+      core.excludesFile) would otherwise flip these assertions. */
+  beforeEach(async () => {
+    const home = await tempDir("vendo-git-home-");
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("XDG_CONFIG_HOME", home);
+    vi.stubEnv("GIT_CONFIG_GLOBAL", "/dev/null");
+    vi.stubEnv("GIT_CONFIG_SYSTEM", "/dev/null");
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  /** A repo holding an untracked .env.local — the state right after a mint. */
+  async function repo(): Promise<string> {
     const root = await tempDir("vendo-gitignore-");
     execFileSync("git", ["init", "-q"], { cwd: root });
+    await writeFile(join(root, ".env.local"), "VENDO_API_KEY=x\n");
+    return root;
+  }
+
+  it("warns, naming the fix, when .env.local is not ignored", async () => {
     const sink = output();
-    await warnEnvLocalNotIgnored(root, sink.output);
+    await warnEnvLocalNotIgnored(await repo(), sink.output);
     const warning = sink.errors.join("\n");
-    expect(warning).toContain(".env.local");
-    expect(warning).toContain(".gitignore");
+    expect(warning).toContain("NOT gitignored");
+    expect(warning).toContain("add `.env.local` to .gitignore");
     expect(sink.logs).toEqual([]);
   });
 
   it("stays silent when .gitignore covers .env.local", async () => {
-    const root = await tempDir("vendo-gitignore-ok-");
-    execFileSync("git", ["init", "-q"], { cwd: root });
+    const root = await repo();
     await writeFile(join(root, ".gitignore"), ".env*.local\n");
     const sink = output();
     await warnEnvLocalNotIgnored(root, sink.output);
     expect(sink.errors).toEqual([]);
   });
 
+  it("an ALREADY TRACKED .env.local gets the remediation that actually works", async () => {
+    // git check-ignore reports a tracked file as NOT ignored even when a
+    // pattern matches it, so "add it to .gitignore" would be both the wrong
+    // advice and useless: the file is in the index and commits anyway.
+    const root = await repo();
+    await writeFile(join(root, ".gitignore"), ".env*.local\n");
+    execFileSync("git", ["add", "-f", ".env.local"], { cwd: root });
+    const sink = output();
+    await warnEnvLocalNotIgnored(root, sink.output);
+    const warning = sink.errors.join("\n");
+    expect(warning).toContain("TRACKED by git");
+    expect(warning).toContain("git rm --cached .env.local");
+    expect(warning).not.toContain("is NOT gitignored");
+  });
+
   it("stays silent outside a git repo — nothing to leak into", async () => {
     const sink = output();
     await warnEnvLocalNotIgnored(await tempDir("vendo-gitignore-nogit-"), sink.output);
     expect(sink.errors).toEqual([]);
+  });
+
+  it("a real repo where git ERRORS is never silently treated as ignored", async () => {
+    // Broken config inside a live repo: git can answer neither question, and
+    // the old "anything but exit 1 means ignored" rule swallowed the warning.
+    const root = await repo();
+    await writeFile(join(root, ".git", "config"), "[core\nnot valid\n");
+    const sink = output();
+    await warnEnvLocalNotIgnored(root, sink.output);
+    const warning = sink.errors.join("\n");
+    expect(warning).toContain("could not say whether it is ignored");
+    expect(warning).toContain("bad config line");
   });
 
   it("--cloud-key surfaces the warning right after the write, and never blocks it", async () => {
@@ -111,17 +157,57 @@ describe("exactly one askYesNo", () => {
 });
 
 describe("the closing line tells the truth about the model key", () => {
+  const LIVE = "Then start your dev server — the agent is live in your app.";
+  const PENDING = "Then start your dev server — the agent is live once you add a model key.";
+
   it("keyless: live once a key is added", async () => {
     const sink = output();
     expect(await run(await pagesHost(), sink)).toBe(0);
-    expect(sink.logs.join("\n")).toContain("Then start your dev server — the agent is live once you add a model key.");
-    expect(sink.logs.join("\n")).not.toContain("the agent is live in your app.");
+    expect(sink.logs.join("\n")).toContain(PENDING);
+    expect(sink.logs.join("\n")).not.toContain(LIVE);
   });
 
   it("keyed: live in your app", async () => {
     const sink = output();
     expect(await run(await pagesHost(), sink, { env: { ANTHROPIC_API_KEY: "sk-a" } })).toBe(0);
-    expect(sink.logs.join("\n")).toContain("Then start your dev server — the agent is live in your app.");
+    expect(sink.logs.join("\n")).toContain(LIVE);
+  });
+
+  it("an UNUSABLE VENDO_API_KEY is not a live agent, even though it resolves a rung", async () => {
+    // resolveDevCredential only checks that VENDO_API_KEY is non-blank, so a
+    // malformed key still resolves rung "vendo-cloud" — and the run would
+    // print "not usable" and "the agent is live in your app" together.
+    const sink = output();
+    expect(await run(await pagesHost(), sink, {
+      env: { VENDO_API_KEY: "not-a-vendo-key" },
+      cloud: { cloudProbe: async () => ({ present: true, ok: false, error: "malformed", unlocks: ["x"] as readonly string[] }) },
+    })).toBe(0);
+    expect(sink.errors.join("\n")).toContain("not usable");
+    expect(sink.logs.join("\n")).toContain(PENDING);
+    expect(sink.logs.join("\n")).not.toContain(LIVE);
+  });
+
+  it("VENDO_DEV_CREDENTIAL=vendo-cloud with no key at all is not live either", async () => {
+    const sink = output();
+    expect(await run(await pagesHost(), sink, { env: { VENDO_DEV_CREDENTIAL: "vendo-cloud" } })).toBe(0);
+    expect(sink.logs.join("\n")).toContain(PENDING);
+    expect(sink.logs.join("\n")).not.toContain(LIVE);
+  });
+
+  it("a key minted mid-run IS live", async () => {
+    const root = await pagesHost();
+    const sink = output();
+    expect(await run(root, sink, {
+      cloud: {
+        cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] as readonly string[] }),
+        confirm: async () => true,
+        deviceLogin: async () => {
+          await writeFile(join(root, ".env.local"), `VENDO_API_KEY=vnd_${"a".repeat(40)}\n`);
+          return 0;
+        },
+      },
+    })).toBe(0);
+    expect(sink.logs.join("\n")).toContain(LIVE);
   });
 });
 
@@ -139,8 +225,8 @@ describe("a pages-only host is told to wire the file it actually has", () => {
 });
 
 describe("an init at a monorepo root names the workspace host", () => {
-  async function monorepo(): Promise<string> {
-    const root = await tempDir("vendo-init-monorepo-");
+  async function monorepo(prefix = "vendo-init-monorepo-"): Promise<string> {
+    const root = await tempDir(prefix);
     await mkdir(join(root, "apps", "web"), { recursive: true });
     await mkdir(join(root, "packages", "ui"), { recursive: true });
     await writeFile(join(root, "package.json"), JSON.stringify({ name: "monorepo", private: true }));
@@ -149,22 +235,34 @@ describe("an init at a monorepo root names the workspace host", () => {
     return root;
   }
 
+  function hintFor(root: string, sink: { output: Output }): Promise<number> {
+    return run(root, sink, { interactive: true, confirmAuth: async () => false, selectAuth: async () => "none" });
+  }
+
   it("lists only the workspace packages that look like hosts", async () => {
     expect(await workspaceHostCandidates(await monorepo())).toEqual(["apps/web"]);
     expect(await workspaceHostCandidates(await tempDir("vendo-init-flat-"))).toEqual([]);
   });
 
   it("interactive: hints at apps/web instead of silently scaffolding the root", async () => {
+    const root = await monorepo();
     const sink = output();
-    expect(await run(await monorepo(), sink, {
-      interactive: true,
-      confirmAuth: async () => false,
-      selectAuth: async () => "none",
-    })).toBe(0);
+    expect(await hintFor(root, sink)).toBe(0);
     const hint = sink.errors.join("\n");
     expect(hint).toContain("did you mean apps/web?");
-    expect(hint).toContain("vendo init apps/web");
+    expect(hint).toContain("looks like the host");
     expect(hint).toContain("--framework");
+    // The suggested command has to resolve from the CALLER's cwd, not from
+    // init's target root: `vendo init apps/web` run from elsewhere lands in a
+    // sibling of the caller, not inside the monorepo.
+    expect(hint).toContain(`vendo init ${join(root, "apps", "web")}`);
+  });
+
+  it("quotes a suggested path containing a space", async () => {
+    const root = await monorepo("vendo init monorepo ");
+    const sink = output();
+    expect(await hintFor(root, sink)).toBe(0);
+    expect(sink.errors.join("\n")).toContain(`vendo init ${JSON.stringify(join(root, "apps", "web"))}`);
   });
 
   it("non-interactive is unchanged: the exact-flag error, no hint", async () => {


### PR DESCRIPTION
Four onboarding fixes, all in `packages/vendo/src/cli/`. Every one is a thing the first `vendo init` got wrong in a way the dev could not see.

## 1 — A secret written into a committed file now says so

`vendo login` and `vendo init --cloud-key` land `VENDO_API_KEY` in `<root>/.env.local`. Nothing checked whether git would commit it.

Both call sites now follow the write with `git check-ignore -q .env.local` from the target root and print, when it is NOT ignored:

```
warning: .env.local holds a secret and is NOT gitignored — add `.env.local` to .gitignore before you commit.
```

- **Never blocks the write.** The key is already minted and is never printed anywhere, so failing the write would lose it. Warn only.
- **Silent when there is nothing to leak into.** `git check-ignore` exit 1 is the only "not ignored" answer; exit 128 (not a repo) and a failed spawn (no git) stay quiet.
- The warning is emitted at the call sites, after the "wrote it" line, so it reads as part of that narration and can never turn a successful mint into device-login's write-failure copy.

## 2 — Exactly one `askYesNo`

The unguarded duplicate in `extract/extraction.ts` — identical body, no `if (!stdin.isTTY || !stdout.isTTY) return false`, so it hung every non-TTY caller — was already deleted upstream with #671. This PR pins the invariant with a test: exactly one definition, in `shared.ts`, with its guard intact. A second copy cannot come back unnoticed.

## 3 — The keyless closing line stopped over-promising

`init` ended every run with "the agent is live in your app", including runs where no model key resolved — the one case where nothing happens.

| Credential | Closing line |
| --- | --- |
| keyless (`rung === "none"`) | `Then start your dev server — the agent is live once you add a model key.` |
| any key | `Then start your dev server — the agent is live in your app.` (unchanged) |

## 4 — Pages-router honesty + a monorepo hint

**(a)** A pages-only Next host was told to `import { VendoRoot } …` into `app/layout.tsx` and wrap `{children}` — a file it does not have. Both the manual paste and the agent tail now name the file it does have:

```
In pages/_app.tsx:
  import { VendoRoot } from "../vendo/vendo-root";
  … then wrap: <VendoRoot><Component {...pageProps} /></VendoRoot>
  (vendo/vendo-root.tsx mounts <VendoOverlay />, the visible launcher + panel)
```

The generated `vendo-root.tsx` is a client component, so it mounts in `_app.tsx` unchanged.

Two notes on scope:
- **Where the route segment is scaffolded is untouched.** Handing a pages-only host an `app/api/vendo/[...vendo]` segment is valid in Next as long as both routers share one base, and that placement is a deliberately deferred design question (see `appDirectory`'s docstring). Only the instruction text changed.
- **The client root is keyed on whether `app/layout.tsx` exists**, not on `detectRouter` — the scaffold creates `app/` mid-run, so a `detectRouter`-based answer flipped between the manual paste (computed pre-write) and the agent tail (post-write). Caught by the test.

**(b)** `detectFramework` reads only the target dir's `package.json`, so an interactive `vendo init` at a monorepo root found no `next`/`express` and silently scaffolded the runtime-neutral `custom` target one level too high. It now names the candidates:

```
warning: no next or express dependency here, but apps/web look like hosts — did you mean apps/web?
Re-run there (vendo init apps/web) or pass --framework to scaffold this directory anyway.
```

Candidates come from `apps/*` and `packages/*` whose own `package.json` declares `next` or `express` — a hint that names a candidate, not a workspace-glob resolver. Non-interactive runs already errored with the exact flag and are unchanged; the hint is advisory and never changes the exit code.

## Proof

New file `packages/vendo/src/cli/onboarding-safety.test.ts` (11 tests, no existing test file touched):

- gitignore warning present / absent / silent-outside-git, plus the `--cloud-key` path end to end (warning surfaced, key still written)
- exactly one `askYesNo` definition, in `shared.ts`, guard string present
- keyless vs keyed closing line, both exact strings
- pages-only host: output contains `pages/_app.tsx` and the `<Component {...pageProps} />` wrap, and does NOT contain `app/layout.tsx`
- monorepo root: `workspaceHostCandidates` picks `apps/web` and skips `packages/ui`; the interactive run emits the hint; the non-interactive run keeps its exact-flag error and emits no hint

## Gate

`pnpm build` ✅ · `pnpm typecheck` ✅ (41 tasks) · `pnpm lint` ✅ (dependency-guard + portability-gate + eslint) · `pnpm test` — 1499 tests, 1482 pass, 2 fail

The 2 failures are `src/dev-creds/model.test.ts` (`@ai-sdk/anthropic` module resolution under `withoutGlobalPaths`) and are **pre-existing on `origin/main`** — verified by stashing this branch's changes and re-running the same file: identical 2 failed / 23 passed.

No UI surface in this change (CLI strings only), so no screenshots apply.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `vendo init` safer and more honest. Adds git warnings for `.env.local` secrets, fixes a non‑TTY prompt hang, corrects Next pages‑router guidance, improves monorepo hints, and clarifies the closing “live” line.

- **Bug Fixes**
  - After writing `VENDO_API_KEY`, warn if `.env.local` would commit (covers tracked files and symlinks); stay quiet outside git; on repo/git failures say “git could not answer” with the reason.
  - Ensure exactly one `askYesNo` with a non‑TTY guard; tests pin this invariant.
  - Closing line now has three states: usable key → “live in your app”; scaffolded this run with no key → “live once you add a model key”; re‑run over an existing composition with no resolved key → “live only if your composition passes its own model.”
  - Pages‑only Next hosts get instructions for `pages/_app.tsx`, wrapping `<Component {...pageProps} />`; agent tail updated.
  - At monorepo roots, suggest likely hosts (e.g., `apps/web`); rerun hint resolves from the caller’s cwd, prints `.` when already there, and is POSIX single‑quoted; non‑interactive behavior unchanged.

- **Refactors**
  - Simplified git probe flow (`check-ignore` first, index check only if needed), unified closing‑line log, streamlined framework fall‑through, and inlined small helpers; consolidated tests. No behavior change.

<sup>Written for commit e4e705653eb78012df09bbd4d63f35d516cbb9b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

