### PR TITLE
docs(quickstart): match the shipped surfaces, add drift-parity test

### DIFF
--- a/.changeset/quickstart-parity-and-cli-copy.md
+++ b/.changeset/quickstart-parity-and-cli-copy.md
@@ -1,0 +1,19 @@
+---
+"@vendoai/vendo": patch
+---
+
+Three CLI help and error lines now say what the code actually does.
+
+`--yes` claimed only "skip the cloud-login offer". It also accepts the detected
+auth preset, skips the AI polish pass and the theme review, and swaps the
+interactive success screen for the agent tail — an agent reading the old line
+could not predict any of that. `--framework` listed `next, express` while
+`custom` (the runtime-neutral scaffold for Workers, Bun, Deno, Hono, and Lambda
+adapters) has been accepted all along.
+
+When `vendo login` dies on a transient failure — network, DNS, a killed fetch —
+it printed the raw error and nothing else, so the reader assumed the ceremony
+was lost and started over, abandoning an approval that would still have landed.
+It now names the surviving pairing code and says that re-running `vendo login`
+resumes the same request. The line appears only when a resume can actually
+succeed: every terminal outcome already deletes the claim.

--- a/.changeset/quickstart-parity-and-cli-copy.md
+++ b/.changeset/quickstart-parity-and-cli-copy.md
@@ -2,7 +2,19 @@
 "@vendoai/vendo": patch
 ---
 
-Three CLI help and error lines now say what the code actually does.
+`vendo init --yes` no longer blocks on the loosening review, and three CLI help
+and error lines now say what the code actually does.
+
+`--yes` promises every question is already answered. It kept that promise for
+the AI-polish consent and broke it one step later: with `--ai-polish` granting
+consent, a run in a terminal reached the aggregated loosening review and waited
+for a human the moment the judgment pass proposed waking a disabled tool or
+lowering a risk grade — so `vendo init --yes --ai-polish` could hang in CI or
+under an agent. Unattended runs now queue loosenings instead: held as `pending`,
+nothing applied, printed with `vendo sync --review`. Auto-applying was never an
+option — risk is not lowered without a human — and no `confirm` seam is handed
+to the pass at all when the run is unattended, so nothing downstream can block
+either.
 
 `--yes` claimed only "skip the cloud-login offer". It also accepts the detected
 auth preset, skips the AI polish pass and the theme review, and swaps the

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,8 +17,14 @@ npx vendo init
 ```
 
 The `vendoai` package is a thin alias. The scoped package is the canonical
-install. `vendo init` asks nothing on the happy path. It writes the whole
-server side and mounts the visible surface for you:
+install. `vendo init` asks for no data — no interview, no keys to paste, no
+per-diff approvals. What an interactive run does ask are consent questions you
+answer with Enter or y/n: the detected auth preset, the Vendo Cloud starter-key
+offer (only when no provider key is set), consent for the AI polish pass, a
+review of any theme slot the extractor was unsure about, a `zod` bump when your
+pin is below 3.25, and a closing "star the repo?". `--yes` and non-interactive
+runs answer all of them silently. Init writes the whole server side and mounts
+the visible surface for you:
 
 - the catch-all route `app/api/vendo/[...vendo]/route.ts` holding the entire
   `createVendo` composition (on Express or any other Web-standard runtime,
@@ -45,10 +51,8 @@ like everything else. When the layout can't be edited unambiguously, init
 degrades to printing the paste lines instead — see
 [the client mount](#vendovendo-roottsx--the-client-mount).
 
-When it detects your auth provider in package.json it asks once to confirm the
-preset (consent-style, Enter accepts; `--yes` and non-interactive runs accept
-it silently). Then start your dev server — the agent is live in your app — and
-run `npx vendo doctor` to verify everything with one real model turn.
+Then start your dev server — the agent is live in your app — and run
+`npx vendo doctor` to verify everything with one real model turn.
 
 ## Non-interactive runs (agents)
 
@@ -162,8 +166,10 @@ see [actAs preset recipes](./act-as-presets.md) for the full list, the
 hosts without a shipped preset.
 
 `models` and `catalog` are the only other keys most hosts touch on day one.
-Every key is optional — a bare `createVendo()` legitimately boots, with an
-env-resolved model, anonymous ephemeral sessions, and PGlite persistence.
+Every key is optional — `createVendo({})` legitimately boots, with an
+env-resolved model, anonymous ephemeral sessions, and PGlite persistence. (The
+config object itself is required: `createVendo()` with no argument does not
+typecheck and throws at runtime.)
 The `policy: {}` line activates the `.vendo/policy.json` file init wrote, so
 the scaffolded default posture is: destructive tools ask, reads run. Remove
 the `policy` key entirely and every call auto-runs (audited, with the
@@ -428,10 +434,11 @@ absent (see [Model keys](#model-keys)), and with neither `auth` nor
 validation error at compose time. Pick the preset or hand-wire the three
 seams, never both.
 
-Every type below is importable by a host: the umbrella's root entry re-exports
-the contract types, and `@vendoai/vendo/server` carries the composition ones.
-(`ServerActionHandler` is the only exception — the generated `vendo-actions.ts`
-map is the surface you use, never the type.)
+`createVendo(config: CreateVendoConfig): Vendo`, in full. Every type is
+importable by a host — the umbrella's root entry re-exports the contract types
+and `@vendoai/vendo/server` carries the composition ones — and this block is
+compiled against the real `CreateVendoConfig` in
+`packages/vendo/src/cli/quickstart-config-surface.ts`, so it cannot drift:
 
 ```ts
 import type {
@@ -441,10 +448,10 @@ import type {
   PolicyFile, Principal, RunId, SandboxAdapter, SecretsProvider, ToolRegistry,
   VendoAgent, VendoGuard, VendoStore, VendoTheme,
 } from "@vendoai/vendo";
-import type { ConnectionsService, HostAuthPreset, ModelsConfig } from "@vendoai/vendo/server";
+import type {
+  ConnectionsService, HostAuthPreset, ModelsConfig, ServerActionHandler,
+} from "@vendoai/vendo/server";
 import type { LanguageModel } from "ai";
-
-export function createVendo(config: CreateVendoConfig): Vendo;
 
 export interface CreateVendoConfig {
   /** @deprecated superseded by `models.agent`. */
@@ -481,7 +488,11 @@ export interface CreateVendoConfig {
     policy?: PolicyFile;
     designRules?: string;
   };
-  mcp?: boolean | { baseUrl?: string; remoteAs?: object; federation?: object };
+  mcp?: boolean | {            // the door; `baseUrl` is its PUBLIC base URL
+    baseUrl?: string;
+    remoteAs?: { issuer: string; jwksUri?: string; audience: string };
+    federation?: { secret: string };
+  };
   oauth?: HostOAuthAdapter;   // escape hatch; required when `mcp` is true and `auth` is absent
   agent?: {
     instructions?: string;
@@ -498,7 +509,14 @@ export interface CreateVendoConfig {
   apps?: {
     experimentalServedApps?: boolean;
     experimentalMachines?: boolean;
-    pipeline?: Record<string, boolean>; // generation-pipeline opt-ins
+    pipeline?: {              // generation-pipeline knobs, measured before default-on
+      structuredRepair?: boolean;
+      regionParallel?: boolean;
+      endPass?: boolean;
+      exemplarContract?: boolean;
+      smokeRender?: boolean;
+      rebind?: boolean;
+    };
     designRules?: string;
   };
 }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,62 +1,6 @@
 # Vendo quickstart
 
-Install the default composition and run setup:
-
-```bash
-npm install @vendoai/vendo
-npx vendo init
-```
-
-The `vendoai` package is a thin alias. The scoped package is the canonical
-install. `vendo init` asks nothing on the happy path. It writes two code
-files — an empty `vendo/registry.tsx` and the catch-all handler wired to
-it — plus two package.json script hooks, extracts your tools and brand
-theme into `.vendo/`, resolves a model key, and prints the one line that is
-yours to paste: the `<VendoRoot components={registry}>` wrap in your
-layout. When it detects your auth provider in package.json it asks once to
-confirm the preset (consent-style, Enter accepts; `--yes` and
-non-interactive runs accept it silently). It never edits code you wrote. Then start your dev server — the agent is live in your app —
-and run `npx vendo doctor` to verify everything with one real model turn.
-
-## Non-interactive runs (agents)
-
-Every init question has a value-flag answer, so a coding agent never hangs
-on a prompt: `--auth <preset>` (authJs, clerk, supabase, auth0, jwt, none)
-answers the auth confirm and picker, `--framework <next|express>` overrides
-detection, `--cloud-key <key>` or `--byo` answers the Cloud offer,
-`--ai-polish` grants consent for the AI pass (tool judgment and theme-slot
-filling, one consent for both), and `--theme slot=value` (repeatable)
-overrides a theme slot value directly. When a decision has no flag and
-no detected default — an undetectable framework — a non-interactive run
-errors with the exact flag to pass instead of guessing or prompting.
-
-## Model keys
-
-The agent needs an LLM. `createVendo`'s `model` is optional: when you don't
-pass one, the composed default resolves a real key from the environment, in
-this order:
-
-1. An explicit env key: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or
-   `GOOGLE_GENERATIVE_AI_API_KEY` (install the matching `@ai-sdk/*@^3`
-   provider). This same rung serves production.
-2. `VENDO_API_KEY` — a Vendo Cloud dev key. When init finds no key, it offers
-   `vendo login`: your browser opens on the approval page (a non-TTY caller
-   gets the URL and pairing code printed instead), you approve the code, and
-   the minted metered dev-mode key is written to `.env.local` for you. You
-   never paste a key. (`vendo cloud login <email>` remains as an email-OTP
-   fallback.)
-   Model calls go through the Vendo Cloud model gateway (`vendo` by
-   default — pin another id with `VENDO_MODEL`, served via the installed
-   `@ai-sdk/anthropic`) and meter your dev-mode runs allowance.
-3. Nothing available: chat fails honestly, with exact instructions in the
-   server log.
-
-Production deploys always need a real server-side key. To take full control
-of the model (BYO-LLM), pass any ai-SDK model to `createVendo({ model })`.
-
-Vendo Cloud is optional. When `VENDO_API_KEY` is set, init validates it and
-states the plan and what it unlocks; when it is absent, init prints one calm
-line and offers `vendo login` only when a starter key would help.
+## See it before you install
 
 To see your product's agent before installing anything, run `npx vendo try`
 from your app's repo: a read-only pass extracts tools and theme, a live local
@@ -64,6 +8,265 @@ demo opens in seconds, and the AI engine ladder deepens it in the background.
 Nothing is written to your repo and no key is required; with zero keys the
 surfaces serve against scripted data. (`vendo try` replaces the retired
 `vendo playground`.)
+
+## Install and init
+
+```bash
+npm install @vendoai/vendo
+npx vendo init
+```
+
+The `vendoai` package is a thin alias. The scoped package is the canonical
+install. `vendo init` asks nothing on the happy path. It writes the whole
+server side and mounts the visible surface for you:
+
+- the catch-all route `app/api/vendo/[...vendo]/route.ts` holding the entire
+  `createVendo` composition (on Express or any other Web-standard runtime,
+  `vendo/server.ts` instead)
+- an empty component registry, `vendo/registry.tsx`
+- the client mount `vendo/vendo-root.tsx` — a `"use client"` wrapper that
+  applies the registry and the extracted theme and mounts `<VendoOverlay />`,
+  the launcher pill + panel users actually see
+- one bounded edit to `app/layout.tsx` wrapping the single JSX `{children}` in
+  that wrapper, so a by-the-book install is visible the moment the dev server
+  starts
+- `vendo-actions.ts`, the server-action registration map, when `"use server"`
+  actions are detected
+- two `package.json` script hooks (`predev: vendo sync`,
+  `prebuild: vendo sync --strict`)
+- your tools and brand theme extracted into `.vendo/` (`tools.json`,
+  `overrides.json`, `policy.json`, `brief.md`, `theme.json`) plus
+  `.env.example`
+
+The layout edit is the one place init touches code you wrote. It is
+idempotent (skipped when a Vendo surface is already mounted), bounded (one
+import line plus the `{children}` wrap), and shows up as a reviewable diff
+like everything else. When the layout can't be edited unambiguously, init
+degrades to printing the paste lines instead — see
+[the client mount](#vendovendo-roottsx--the-client-mount).
+
+When it detects your auth provider in package.json it asks once to confirm the
+preset (consent-style, Enter accepts; `--yes` and non-interactive runs accept
+it silently). Then start your dev server — the agent is live in your app — and
+run `npx vendo doctor` to verify everything with one real model turn.
+
+## Non-interactive runs (agents)
+
+Every init question has a value-flag answer, so a coding agent never hangs
+on a prompt: `--auth <preset>` (authJs, clerk, supabase, auth0, jwt, none)
+answers the auth confirm and picker, `--framework <next|express|custom>`
+overrides detection (`custom` is the runtime-neutral scaffold for Cloudflare
+Workers, Bun, Deno, Hono, and Lambda adapters), `--cloud-key <key>` or `--byo`
+answers the Cloud offer, `--ai-polish` grants consent for the AI pass (tool
+judgment and theme-slot filling, one consent for both), and `--theme
+slot=value` (repeatable) overrides a theme slot value directly. When a
+decision has no flag and no detected default — an undetectable framework — a
+non-interactive run errors with the exact flag to pass instead of guessing or
+prompting.
+
+## The files you own
+
+A host's entire server wiring is two files: `vendo/registry.tsx`, which
+declares the components generated views can use, and the composition — one
+`createVendo` call with an auth preset and that registry. On Next.js the
+composition lives inline in the catch-all route
+`app/api/vendo/[...vendo]/route.ts`. A third file, `vendo/vendo-root.tsx`,
+carries the client mount. All three are scaffolded by `vendo init` and yours
+to change from there.
+
+### `vendo/registry.tsx` — the component registry
+
+One object, keyed by component name. Each entry holds the real component
+reference, a description the model reads, and an optional zod props schema.
+The same object serves both sides: `createVendo` reads the registry as
+`catalog` and uses only the data fields; `<VendoRoot>` reads it as `components`
+and uses only the component references. There is no second map to keep in
+sync.
+
+```tsx
+// vendo/registry.tsx — generated empty by `vendo init`, then yours
+import type { ComponentRegistry } from "@vendoai/vendo";
+import { z } from "zod";
+import { SpendingDonut } from "@/components/charts/spending-donut";
+
+export const registry = {
+  SpendingDonut: {
+    component: SpendingDonut,
+    description: "Spending by category. Use for where-did-my-money-go requests.",
+    props: z.object({
+      slices: z.array(z.object({ category: z.string(), amount: z.number() })),
+    }),
+    examples: ['{"slices":[{"category":"dining","amount":342.18}]}'],
+  },
+} satisfies ComponentRegistry;
+```
+
+`ComponentRegistry` comes from `@vendoai/vendo`, not `@vendoai/core`: a host
+only installs `@vendoai/vendo` (and `@vendoai/ui`), so under pnpm's strict
+linking a transitive package doesn't resolve for host code. The umbrella's
+root entry re-exports the full `@vendoai/core` type surface, so every contract
+type is one specifier away.
+
+The props schema is optional — a schema-less entry is legal and renders as a
+description-only prompt entry the model infers props for. When a schema is
+present, the model-facing JSON Schema is derived from it internally; you never
+hand-write one.
+
+### The catch-all route — the composition
+
+```ts
+// app/api/vendo/[...vendo]/route.ts — exactly what `vendo init` scaffolds
+import { authJs } from "@vendoai/vendo/auth/auth-js";
+import { createVendo, nextVendoHandler } from "@vendoai/vendo/server";
+import { registry } from "@/vendo/registry";
+
+const vendo = createVendo({
+  // Detected next-auth — authJs() fills the identity seams
+  // (request→user, actAs, door OAuth); options and the per-seam escape
+  // hatch: docs/act-as-presets.md.
+  auth: authJs(),
+  catalog: registry,
+  policy: {}, // .vendo/policy.json: destructive asks, reads run
+});
+
+export const { GET, POST, PUT, PATCH, DELETE } = nextVendoHandler(vendo);
+```
+
+There is no model line on purpose: the composed default resolves a real key
+from the environment (see [Model keys](#model-keys) below), so the first turn
+works before you have picked anything. To pin a model, name it in the `models`
+block — the name passes through verbatim to whatever credential resolves, so
+nothing extra needs installing on the Anthropic and Vendo Cloud rungs:
+
+```ts
+const vendo = createVendo({
+  models: { agent: "claude-sonnet-4-6" },
+  auth: authJs(),
+  catalog: registry,
+  policy: {},
+});
+```
+
+For full control (BYO-LLM), pass any AI SDK `LanguageModel` object instead of
+a name — `models: { agent: anthropic("claude-sonnet-4-6") }` — which is when
+you install the matching `@ai-sdk/*@^3` provider yourself.
+
+`authJs()` is zero-argument in the standard case: it reads `AUTH_SECRET`
+(mirroring Auth.js itself) and derives the principal's display name and email
+from the session-token claims. `auth` is one preset that fills all three
+identity seams `createVendo` needs — the request→principal resolver, the
+away/MCP `actAs` seam, and the door's OAuth adapter — from one config key.
+Presets exist for Auth.js, Clerk, Supabase, Auth0, and a generic JWT scheme;
+see [actAs preset recipes](./act-as-presets.md) for the full list, the
+`user` resolver for custom identity mapping, and the per-seam escape hatch for
+hosts without a shipped preset.
+
+`models` and `catalog` are the only other keys most hosts touch on day one.
+Every key is optional — a bare `createVendo()` legitimately boots, with an
+env-resolved model, anonymous ephemeral sessions, and PGlite persistence.
+The `policy: {}` line activates the `.vendo/policy.json` file init wrote, so
+the scaffolded default posture is: destructive tools ask, reads run. Remove
+the `policy` key entirely and every call auto-runs (audited, with the
+unconfigured-policy notice in shipped chrome). The default file is read
+fail-soft: deleting `.vendo/policy.json` while keeping `policy: {}` also
+auto-runs, silently and without the notice — keep the file in version
+control; it is part of your security posture. Named presets replace the
+file: `"cautious"` asks before write/destructive calls and runs reads,
+`"readonly"` runs reads and blocks everything else, and `"autopilot"` runs
+everything. Inline `{ rules }` and the explicit `{ file }` form cover
+anything a preset doesn't.
+
+Prefer a separate `vendo/server.ts` (exporting the same `createVendo`
+result) when code outside the route needs the `vendo` object — `vendo.emit`
+for host events, the MCP door's `.well-known` route, or tests. The route
+then shrinks to a re-export:
+
+```ts
+import { nextVendoHandler } from "@vendoai/vendo/server";
+import { vendo } from "@/vendo/server";
+
+export const { GET, POST, PUT, PATCH, DELETE } = nextVendoHandler(vendo);
+```
+
+Mount the route at `/api/vendo/[...]`. The fetch handler itself is
+framework-agnostic.
+
+### `vendo/vendo-root.tsx` — the client mount
+
+Init generates this wrapper and wires it into your layout. It is a
+`"use client"` boundary because the registry carries component references,
+which cannot cross a Server Component boundary as props (RSC serialization
+fails, and every page 500s).
+
+```tsx
+// vendo/vendo-root.tsx — generated by `vendo init`, then yours
+"use client";
+
+import { VendoOverlay, VendoRoot as VendoClientRoot } from "@vendoai/vendo/react";
+import type { ReactNode } from "react";
+import { registry } from "./registry";
+import theme from "../.vendo/theme.json";
+import type { VendoTheme } from "@vendoai/vendo";
+
+export function VendoRoot({ children }: { children: ReactNode }) {
+  return (
+    <VendoClientRoot components={registry} theme={theme as VendoTheme}>
+      {children}
+      <VendoOverlay />
+    </VendoClientRoot>
+  );
+}
+```
+
+`components` accepts the same registry object the composition passes as
+`catalog` — it reads only the component references and ignores the data
+fields. The `theme` prop applies the brand init captured; the cast narrows
+TypeScript's widened JSON-module string literals.
+
+`<VendoClientRoot>` is a context provider and renders nothing by itself,
+which is why the generated wrapper mounts `<VendoOverlay />` inside it. Swap
+that for `<VendoThread />`, `<VendoPage />`, `<VendoPalette />`, or the
+headless hooks from `@vendoai/ui` — they all speak to the same wire. The
+shipped surfaces live in `@vendoai/ui/chrome`, re-exported from
+`@vendoai/vendo/react`.
+
+When init cannot edit your layout safely (no single unambiguous `{children}`),
+it prints the paste that remains instead:
+
+```tsx
+// app/layout.tsx
+import { VendoRoot } from "../vendo/vendo-root";
+
+// then wrap the app:
+<VendoRoot>{children}</VendoRoot>
+```
+
+## Model keys
+
+The agent needs an LLM. `models.agent` is optional: when you don't name a
+model, the composed default resolves a real key from the environment, in this
+order:
+
+1. An explicit env key: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or
+   `GOOGLE_GENERATIVE_AI_API_KEY` (init installs the matching `@ai-sdk/*@^3`
+   provider for the key it resolves). This same rung serves production.
+2. `VENDO_API_KEY` — a Vendo Cloud dev key. When init finds no key, it offers
+   `vendo login`: your browser opens on the approval page (a non-TTY caller
+   gets the URL and pairing code printed instead), you approve the code, and
+   the minted metered dev-mode key is written to `.env.local` for you. You
+   never paste a key. (`vendo cloud login <email>` remains as an email-OTP
+   fallback.)
+   Model calls go through the Vendo Cloud model gateway (`vendo` by
+   default — pin another id with `VENDO_MODEL` or `models.agent`, served via
+   `@ai-sdk/anthropic`) and meter your dev-mode runs allowance.
+3. Nothing available: chat fails honestly, with exact instructions in the
+   server log.
+
+Production deploys always need a real server-side key.
+
+Vendo Cloud is optional. When `VENDO_API_KEY` is set, init validates it and
+states the plan and what it unlocks; when it is absent, init prints one calm
+line and offers `vendo login` only when a starter key would help.
 
 ## AI polish (tool judgment and theme)
 
@@ -147,186 +350,10 @@ with the reason; guard refusals (unknown tool names, risk downgrades,
 unreasoned wakes) are printed per entry while the rest of the draft applies.
 `--force` replaces a hand-edited brief, exactly like `vendo init --force`.
 
-## The two files you own
-
-A host's entire server wiring is two files: `vendo/registry.tsx`, which
-declares the components generated views can use, and the composition — one
-`createVendo` call with a model, an auth preset, and that registry. On
-Next.js the composition lives inline in the catch-all route
-`app/api/vendo/[...vendo]/route.ts`, which is exactly what `vendo init`
-scaffolds.
-
-### `vendo/registry.tsx` — the component registry
-
-One object, keyed by component name. Each entry holds the real component
-reference, a description the model reads, and an optional zod props schema.
-The same object serves both sides: `createVendo` reads the registry as
-`catalog` and uses only the data fields; `<VendoRoot>` reads it as `components`
-and uses only the component references. There is no second map to keep in
-sync.
-
-```tsx
-import type { ComponentRegistry } from "@vendoai/core";
-import { z } from "zod";
-import { SpendingDonut } from "@/components/charts/spending-donut";
-
-export const registry = {
-  SpendingDonut: {
-    component: SpendingDonut,
-    description: "Spending by category. Use for where-did-my-money-go requests.",
-    props: z.object({
-      slices: z.array(z.object({ category: z.string(), amount: z.number() })),
-    }),
-    examples: ['{"slices":[{"category":"dining","amount":342.18}]}'],
-  },
-} satisfies ComponentRegistry;
-```
-
-The props schema is optional — a schema-less entry is legal and renders as a
-description-only prompt entry the model infers props for. When a schema is
-present, the model-facing JSON Schema is derived from it internally; you never
-hand-write one.
-
-### The catch-all route — the composition
-
-```ts
-// app/api/vendo/[...vendo]/route.ts — the `vendo init` scaffold, plus an
-// explicit model pin (init itself writes no model line)
-import { anthropic } from "@ai-sdk/anthropic";
-import { authJs } from "@vendoai/vendo/auth/auth-js";
-import { createVendo, nextVendoHandler } from "@vendoai/vendo/server";
-import { registry } from "@/vendo/registry";
-
-const vendo = createVendo({
-  model: anthropic("claude-sonnet-4-6"),
-  auth: authJs(),
-  catalog: registry,
-  policy: {}, // .vendo/policy.json: destructive asks, reads run
-});
-
-export const { GET, POST, PUT, PATCH, DELETE } = nextVendoHandler(vendo);
-```
-
-The example pins an explicit provider. You can omit `model` entirely — the
-composed default resolves a real key from the environment (see Model keys
-above), so the first turn works before you have picked one; pass any AI SDK
-model whenever you want full control.
-
-`authJs()` is zero-argument in the standard case: it reads `AUTH_SECRET`
-(mirroring Auth.js itself) and derives the principal's display name and email
-from the session-token claims. `auth` is one preset that fills all three
-identity seams `createVendo` needs — the request→principal resolver, the
-away/MCP `actAs` seam, and the door's OAuth adapter — from one config key.
-Presets exist for Auth.js, Clerk, Supabase, Auth0, and a generic JWT scheme;
-see [actAs preset recipes](./act-as-presets.md) for the full list, the
-`user` resolver for custom identity mapping, and the per-seam escape hatch for
-hosts without a shipped preset.
-
-`model` and `catalog` are the only other keys most hosts touch on day one.
-Every key is optional — a bare `createVendo()` legitimately boots, with an
-env-resolved model, anonymous ephemeral sessions, and PGlite persistence.
-The `policy: {}` line activates the `.vendo/policy.json` file init wrote, so
-the scaffolded default posture is: destructive tools ask, reads run. Remove
-the `policy` key entirely and every call auto-runs (audited, with the
-unconfigured-policy notice in shipped chrome). The default file is read
-fail-soft: deleting `.vendo/policy.json` while keeping `policy: {}` also
-auto-runs, silently and without the notice — keep the file in version
-control; it is part of your security posture. Named presets replace the
-file: `"cautious"` asks before write/destructive calls and runs reads,
-`"readonly"` runs reads and blocks everything else, and `"autopilot"` runs
-everything. Inline `{ rules }` and the explicit `{ file }` form cover
-anything a preset doesn't.
-
-`createVendo`'s real configuration surface:
-
-```ts
-import type { Principal, ActAs, ComponentCatalog, ComponentRegistry, SecretsProvider, Json, RunId } from "@vendoai/core";
-import type { LanguageModel } from "ai";
-import type { VendoStore } from "@vendoai/store";
-import type { VendoAgent } from "@vendoai/agent";
-import type { Connector, ActionsRegistry, ServerActionHandler } from "@vendoai/actions";
-import type { VendoGuard, PolicyConfig, Judge } from "@vendoai/guard";
-import type { AppsConfig, AppsRuntime, SandboxAdapter } from "@vendoai/apps";
-import type { AutomationsEngine } from "@vendoai/automations";
-import type { ConnectionsService, HostAuthPreset, HostOAuthAdapter } from "@vendoai/vendo/server";
-
-export function createVendo(config: {
-  model?: LanguageModel;       // absent → env-resolved key (see Model keys above)
-  paint?: AppsConfig["paint"]; // paint-lane knob for app generation (no-think model, or `disabled`)
-  auth?: HostAuthPreset;       // one preset fills principal + actAs + oauth
-  principal?: (req: Request) => Promise<Principal | null>; // escape hatch
-  catalog?: ComponentCatalog | ComponentRegistry;           // registry.tsx, or the array form
-  store?: VendoStore;
-  sandbox?: SandboxAdapter;
-  connectors?: Connector[];
-  connections?: ConnectionsService; // explicit connections adapter; always wins over defaults
-  actAs?: ActAs;                // escape hatch
-  policy?: PolicyConfig;        // "cautious" | "readonly" | "autopilot" | { file } | { rules }
-  judge?: Judge;
-  secrets?: SecretsProvider;
-  telemetry?: boolean;
-  mcp?: boolean | { baseUrl?: string; remoteAs?: object; federation?: object };
-  oauth?: HostOAuthAdapter;     // escape hatch; required when `mcp` is true and `auth` is absent
-  serverActions?: Record<string, ServerActionHandler>; // generated by `vendo sync`
-  agent?: { toolOutputCap?: number; maxOutputTokens?: number; historyWindow?: number; maxInitialTools?: number; maxSteps?: number };
-  sessions?: { ttlMs?: number; sweepIntervalMs?: number };
-  development?: boolean | { root?: string; out?: string }; // dev-only source capture
-}): Vendo;
-
-export interface Vendo {
-  handler: (req: Request) => Promise<Response>;
-  emit(event: string, payload: Json, principal: Principal): Promise<RunId[]>;
-  agent: VendoAgent; guard: VendoGuard; apps: AppsRuntime; automations: AutomationsEngine; actions: ActionsRegistry; connections: ConnectionsService; store: VendoStore;
-}
-```
-
-Every key is optional: `model` resolves from the environment when absent (see
-Model keys above), and with neither `auth` nor `principal` every session is
-ephemeral and anonymous. `auth` and any of `principal`/`actAs`/`oauth` are
-mutually exclusive — supplying both throws a validation error at compose
-time. Pick the preset or hand-wire the three seams, never both.
-
-Prefer a separate `vendo/server.ts` (exporting the same `createVendo`
-result) when code outside the route needs the `vendo` object — `vendo.emit`
-for host events, the MCP door's `.well-known` route, or tests. The route
-then shrinks to a re-export:
-
-```ts
-import { nextVendoHandler } from "@vendoai/vendo/server";
-import { vendo } from "@/vendo/server";
-
-export const { GET, POST, PUT, PATCH, DELETE } = nextVendoHandler(vendo);
-```
-
-Mount the route at `/api/vendo/[...]`. The fetch handler itself is
-framework-agnostic.
-
-## Add the React root
-
-```tsx
-import { VendoRoot } from "@vendoai/vendo/react";
-import { registry } from "@/vendo/registry";
-
-export function Root({ children }: { children: React.ReactNode }) {
-  return <VendoRoot components={registry}>{children}</VendoRoot>;
-}
-```
-
-`components` accepts the same registry object the composition passes as
-`catalog` — it reads only the component references and ignores the data
-fields. `<VendoRoot>` is a context provider and renders nothing by itself:
-mount a visible surface inside it or users cannot reach the agent. Use the
-headless hooks from `@vendoai/ui`, or add a shipped surface from
-`@vendoai/ui/chrome` (also re-exported from `@vendoai/vendo/react`).
-`<VendoThread />`, `<VendoOverlay />`, `<VendoPage />`, and
-`<VendoPalette />` all speak to the same wire; on Next.js, `vendo init`
-generates `vendo/vendo-root.tsx` mounting `<VendoOverlay />` and wires it
-into the layout for you.
-
 ## First turn
 
-Open the mounted conversation surface and send a request such as “Build a view
-of my overdue invoices.” The browser posts one turn to `/threads`. The response
+Open the mounted overlay and send a request such as “Build a view of my
+overdue invoices.” The browser posts one turn to `/threads`. The response
 is an AI SDK UI message stream. Any generated app surface arrives in a
 `data-vendo-view` part and any approval metadata in a `data-vendo-approval`
 part.
@@ -391,6 +418,104 @@ Auth, Clerk, Auth0, or a host-owned generic JWT without changing the
 Away execution cannot create its own authority: it requires an app-bound
 automation grant captured while that user was present. Without that prior
 grant, the run parks for approval before `actAs` is called.
+
+## The whole configuration surface
+
+Every key is optional. `models.agent` resolves from the environment when
+absent (see [Model keys](#model-keys)), and with neither `auth` nor
+`principal` every session is ephemeral and anonymous. `auth` and any of
+`principal`/`actAs`/`oauth` are mutually exclusive — supplying both throws a
+validation error at compose time. Pick the preset or hand-wire the three
+seams, never both.
+
+Every type below is importable by a host: the umbrella's root entry re-exports
+the contract types, and `@vendoai/vendo/server` carries the composition ones.
+(`ServerActionHandler` is the only exception — the generated `vendo-actions.ts`
+map is the surface you use, never the type.)
+
+```ts
+import type {
+  ActAs, ActionsRegistry, AppsRuntime, AutomationsEngine, CatalogFile,
+  ComponentCatalog, ComponentRegistry, Connector, ExtractedTool,
+  HostOAuthAdapter, Json, Judge, KnowledgeAdapter, OverridesFile, PolicyConfig,
+  PolicyFile, Principal, RunId, SandboxAdapter, SecretsProvider, ToolRegistry,
+  VendoAgent, VendoGuard, VendoStore, VendoTheme,
+} from "@vendoai/vendo";
+import type { ConnectionsService, HostAuthPreset, ModelsConfig } from "@vendoai/vendo/server";
+import type { LanguageModel } from "ai";
+
+export function createVendo(config: CreateVendoConfig): Vendo;
+
+export interface CreateVendoConfig {
+  /** @deprecated superseded by `models.agent`. */
+  model?: LanguageModel;
+  /** @deprecated the model half is superseded by `models.paint`; `disabled` stays. */
+  paint?: { model?: LanguageModel; disabled?: boolean };
+  models?: ModelsConfig;      // { agent, paint, judge, knowledgeVerifier } — name or model object
+  auth?: HostAuthPreset;      // one preset fills principal + actAs + oauth
+  principal?: (req: Request) => Promise<Principal | null>; // escape hatch
+  catalog?: ComponentCatalog | ComponentRegistry;          // registry.tsx, or the array form
+  theme?: VendoTheme;         // programmatic override for .vendo/theme.json
+  brief?: string;             // programmatic override for .vendo/brief.md
+  store?: VendoStore;
+  sandbox?: SandboxAdapter;
+  knowledge?: KnowledgeAdapter; // unset → no vendo_knowledge_search tool
+  connectors?: Connector[];
+  connectorApps?: string[];   // toolkit scope for the auto-composed Cloud connector
+  connections?: ConnectionsService; // explicit connections adapter; always wins over defaults
+  actAs?: ActAs;              // escape hatch
+  serverActions?: Record<string, ServerActionHandler>; // the generated vendo-actions.ts map
+  policy?: PolicyConfig;      // "cautious" | "readonly" | "autopilot" | { file } | { rules }
+  judge?: Judge;
+  secrets?: SecretsProvider;
+  telemetry?: boolean;
+  development?: boolean | { root?: string; out?: string }; // dev-only source capture
+  profileDir?: string;        // the project root .vendo/ is read under
+  fetch?: typeof fetch;       // the fetch host tool bindings execute through
+  profile?: {                 // the same .vendo/ pieces, in memory (filesystem-less venues)
+    tools?: ExtractedTool[];
+    overrides?: OverridesFile;
+    theme?: VendoTheme;
+    brief?: string;
+    catalog?: CatalogFile;
+    policy?: PolicyFile;
+    designRules?: string;
+  };
+  mcp?: boolean | { baseUrl?: string; remoteAs?: object; federation?: object };
+  oauth?: HostOAuthAdapter;   // escape hatch; required when `mcp` is true and `auth` is absent
+  agent?: {
+    instructions?: string;
+    toolOutputCap?: number;
+    maxOutputTokens?: number;
+    historyWindow?: number;
+    maxInitialTools?: number;
+    loadout?: string[];
+    maxSearchExpansions?: number;
+    maxSteps?: number;
+  };
+  sessions?: { ttlMs?: number; sweepIntervalMs?: number; now?: () => number };
+  approvals?: { parkedCallTtlMs?: number };
+  apps?: {
+    experimentalServedApps?: boolean;
+    experimentalMachines?: boolean;
+    pipeline?: Record<string, boolean>; // generation-pipeline opt-ins
+    designRules?: string;
+  };
+}
+
+export interface Vendo {
+  handler: (req: Request) => Promise<Response>;
+  emit(event: string, payload: Json, principal: Principal): Promise<RunId[]>;
+  agent: VendoAgent;
+  guard: VendoGuard;
+  guardedTools: ToolRegistry; // the guard-bound registry the vendo_* tool pack executes through
+  apps: AppsRuntime;
+  automations: AutomationsEngine;
+  actions: ActionsRegistry;
+  connections: ConnectionsService;
+  store: VendoStore;
+}
+```
 
 ## Serve your product to MCP clients (the door)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,14 +17,28 @@ npx vendo init
 ```
 
 The `vendoai` package is a thin alias. The scoped package is the canonical
-install. `vendo init` asks for no data — no interview, no keys to paste, no
-per-diff approvals. What an interactive run does ask are consent questions you
-answer with Enter or y/n: the detected auth preset, the Vendo Cloud starter-key
-offer (only when no provider key is set), consent for the AI polish pass, a
-review of any theme slot the extractor was unsure about, a `zod` bump when your
-pin is below 3.25, and a closing "star the repo?". `--yes` and non-interactive
-runs answer all of them silently. Init writes the whole server side and mounts
-the visible surface for you:
+install. `vendo init` runs no interview: there are no keys to paste and no
+per-diff approvals. An interactive run does stop for a few decisions, all of
+them Enter-to-accept or y/n:
+
+- the detected auth preset;
+- the Vendo Cloud starter-key offer, only when no provider key is set;
+- consent for the AI polish pass, naming the provider your source goes to;
+- one aggregated **loosening review** — if the polish pass proposes waking a
+  disabled tool or lowering a risk grade, init shows the diff and asks once
+  before applying any of it;
+- a `zod` bump, when your pin is below 3.25;
+- a closing "star the repo?".
+
+One question is not y/n: when the extractor is unsure of a theme slot it prints
+what it found and takes a replacement **value** (a hex colour, a font stack) —
+Enter keeps the extracted one.
+
+`--yes` and non-interactive runs answer every one of them without stopping.
+Loosenings are the one decision that has no unattended default: risk is never
+lowered without a human, so they are held as pending and printed with the
+command to review them (`vendo sync --review`), never silently applied. Init
+writes the whole server side and mounts the visible surface for you:
 
 - the catch-all route `app/api/vendo/[...vendo]/route.ts` holding the entire
   `createVendo` composition (on Express or any other Web-standard runtime,
@@ -328,12 +342,23 @@ degrade per stage — a failed surface is skipped with a note instead of
 aborting the run.
 
 Everything it proposes passes deterministic guards before applying: only
-extracted tool names are accepted, risk can be raised but never lowered,
-waking a disabled tool requires reasoning plus an explicit grade, and human
-decisions always win (existing `.vendo/overrides.json` fields and a
-hand-written `brief.md` are never overwritten). The output lands in the
-override channel, so `vendo sync` regeneration keeps it. Skipped silently in
-non-interactive runs; re-run `vendo init` any time to add it.
+extracted tool names are accepted, every proposal carries a verbatim source
+quote and is checked by an independent skeptic, waking a disabled tool requires
+reasoning plus an explicit grade, and human decisions always win (existing
+`.vendo/overrides.json` fields and a hand-written `brief.md` are never
+overwritten).
+
+Tightenings — a raised risk grade, a better description — apply themselves.
+Loosenings do not: lowering a risk grade or waking a disabled tool is held as
+`pending` in `.vendo/judgments.json` until a human approves it, which is the
+aggregated review above. Any run with nobody to ask — `--yes` included — leaves
+them pending and prints `vendo sync --review`, never applying them silently and
+never stopping to wait. Judgments live in their own file, so
+`overrides.json` keeps meaning only "what a person decided" and a re-sync can
+never clobber either.
+
+Without `--ai-polish` the whole pass is skipped silently in non-interactive
+runs, since consent cannot be assumed; re-run `vendo init` any time to add it.
 
 ### Bring your own coding agent
 
@@ -438,7 +463,7 @@ seams, never both.
 importable by a host — the umbrella's root entry re-exports the contract types
 and `@vendoai/vendo/server` carries the composition ones — and this block is
 compiled against the real `CreateVendoConfig` in
-`packages/vendo/src/cli/quickstart-config-surface.ts`, so it cannot drift:
+`packages/vendo/src/cli/quickstart-config-surface.docs-check.ts`, so it cannot drift:
 
 ```ts
 import type {

--- a/packages/vendo/package.json
+++ b/packages/vendo/package.json
@@ -97,7 +97,7 @@
     "pretest": "pnpm run build:playground",
     "test": "vitest run",
     "pretypecheck": "pnpm run build:playground",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.docs-check.json --noEmit",
     "pretest:coverage": "pnpm run build:playground",
     "test:coverage": "vitest run --coverage"
   },

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -33,10 +33,10 @@ Advanced:
 
 Options:
   --agent                    Init only: print a read-only JSON plan — code changes, extracted tools, risk recommendations
-  --yes                      Init: skip the cloud-login offer; doctor: auto-start the dev server
+  --yes                      Init: accept the detected auth preset, skip the cloud offer + AI polish + theme review, end with the agent tail; doctor: auto-start the dev server
   --force                    Init/server-json: overwrite owned or generated files; eject: overwrite an ejected dir
   --auth <preset>            Init only: wire this auth preset without asking (authJs, clerk, supabase, auth0, jwt, none)
-  --framework <name>         Init only: override framework detection (next, express) — required non-interactively when detection fails
+  --framework <name>         Init only: override framework detection (next, express, custom) — required non-interactively when detection fails
   --cloud-key <key>          Init only: write this Vendo Cloud key to .env.local instead of the login offer
   --wait <seconds>           Login only: bound this call's polling to N seconds (agents loop re-runs; each resumes the same request), then exit resumably
   --byo                      Init only: decline the Vendo Cloud offer (bring your own model key)

--- a/packages/vendo/src/cli/cloud/device-login.ts
+++ b/packages/vendo/src/cli/cloud/device-login.ts
@@ -422,6 +422,18 @@ export async function runDeviceLogin(
     }
   } catch (error) {
     output.error(errorMessage(error));
+    // A transient failure (network, DNS, a killed fetch) deliberately leaves
+    // the claim file in place, so say so — otherwise the reader assumes the
+    // ceremony is lost and starts over, abandoning an approval that would
+    // still land. Terminal outcomes above already deleted the claim, so this
+    // line only appears when a resume can actually succeed.
+    const survived = await readPendingClaim(claimCwd, pendingHome);
+    if (survived !== null && survived.expires_at > now()) {
+      output.error(
+        `Your pending approval survives — code ${survived.user_code}. ` +
+        "Re-run `vendo login` to resume this same request.",
+      );
+    }
     return 1;
   }
 }

--- a/packages/vendo/src/cli/init-judgment.ts
+++ b/packages/vendo/src/cli/init-judgment.ts
@@ -206,21 +206,36 @@ export async function runInitJudgment(options: InitJudgmentOptions): Promise<Ini
     // Judgment first: the brief reads the GRADED catalog, so it must run after
     // the pass has settled names and descriptions. Init judges the whole
     // catalog (mode "full" — a fresh install has judged nothing), and an
-    // interactive run reviews loosenings inline instead of queueing them.
+    // ATTENDED run reviews loosenings inline instead of queueing them.
     if (toolsAvailable) {
-      await runJudgmentPass({
+      // `--yes` means every question is already answered, so it must not reach
+      // the aggregated loosening review either — a TTY run with --ai-polish
+      // --yes used to BLOCK there on the first proposed wake/downgrade. An
+      // unattended run cannot answer, and the guard law forbids the other
+      // default (risk is never lowered without a human), so loosenings queue:
+      // held as `pending`, nothing applied, and the pass prints the count plus
+      // `vendo sync --review`.
+      const attended = interactive && !options.yes;
+      const pass = await runJudgmentPass({
         root,
         out: vendoDir,
         mode: "full",
-        loosenings: interactive ? "review" : "queue",
+        loosenings: attended ? "review" : "queue",
         env,
         output,
         harness: chosen.harness,
         appName,
         onProgress,
-        ...(options.confirm === undefined ? {} : { confirm: options.confirm }),
+        // Withheld when unattended too: nothing downstream may acquire a way to
+        // ask, whatever the mode.
+        ...(attended && options.confirm !== undefined ? { confirm: options.confirm } : {}),
         ...(options.resolveCredential === undefined ? {} : { resolveCredential: options.resolveCredential }),
       });
+      // The pass already printed the count and `vendo sync --review`; say WHY
+      // they were held, so an unattended caller doesn't read it as a refusal.
+      if (!attended && pass.status === "judged" && pass.queued > 0) {
+        output.log("  (held, not applied: this run had no one to ask — re-run `vendo init` in a terminal to review them inline)");
+      }
 
       const brief = await runBriefStage({ ...context, judged: await judgedSummaries(vendoDir) });
       notes.push(...brief.notes);

--- a/packages/vendo/src/cli/init-judgment.unattended.test.ts
+++ b/packages/vendo/src/cli/init-judgment.unattended.test.ts
@@ -1,0 +1,154 @@
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `--yes` promises every prompt is already answered. It kept that promise for
+ * the consent question and broke it one step later: with `--ai-polish` granting
+ * consent, an interactive run reached the aggregated loosening review and
+ * BLOCKED on "Apply N loosenings…" the moment the judgment pass proposed waking
+ * a disabled tool or lowering a risk grade. An unattended run has nobody to ask.
+ *
+ * Auto-applying is not the alternative — this repo's guard law is that risk is
+ * never lowered without a human — so an unattended run must QUEUE loosenings
+ * (held as `pending`, nothing applied) and say so. These tests pin the mode the
+ * pass is asked for, plus the absence of any `confirm` seam it could block on.
+ */
+
+const runJudgmentPass = vi.hoisted(() => vi.fn());
+vi.mock("./judge/pass.js", () => ({ runJudgmentPass }));
+
+const selectJudgmentEngines = vi.hoisted(() => vi.fn());
+vi.mock("./judge/engine.js", () => ({ selectJudgmentEngines }));
+
+const runBriefStage = vi.hoisted(() => vi.fn());
+const runThemeStage = vi.hoisted(() => vi.fn());
+const applyBrief = vi.hoisted(() => vi.fn());
+vi.mock("./extract/stages.js", () => ({
+  runBriefStage,
+  runThemeStage,
+  applyBrief,
+  BRIEF_TEMPLATE: "",
+}));
+
+const { runInitJudgment } = await import("./init-judgment.js");
+
+async function projectWithTools(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-loosening-"));
+  await mkdir(join(root, ".vendo"), { recursive: true });
+  await writeFile(
+    join(root, ".vendo", "tools.json"),
+    JSON.stringify({ format: 3, tools: [] }),
+    "utf8",
+  );
+  return root;
+}
+
+function silentOutput(): { log: (line: string) => void; error: (line: string) => void; lines: string[] } {
+  const lines: string[] = [];
+  return { log: (line) => lines.push(line), error: (line) => lines.push(line), lines };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectJudgmentEngines.mockResolvedValue([
+    { family: "claude", credential: "Claude Code", harness: { id: "claude-cli" } },
+  ]);
+  runJudgmentPass.mockResolvedValue({
+    status: "judged",
+    judged: 1,
+    hardened: 0,
+    queued: 2,
+    approved: 0,
+    rejectedBySkeptic: 0,
+    unexaminedRejected: 0,
+    evidenceless: 0,
+    advisoriesClamped: 0,
+    inconsistentRisk: 0,
+  });
+  runBriefStage.mockResolvedValue({ brief: "", notes: [], fromStage: false });
+  runThemeStage.mockResolvedValue({ theme: undefined, notes: [] });
+  applyBrief.mockResolvedValue(false);
+});
+
+describe("the loosening review never blocks an unattended init", () => {
+  it("queues loosenings under --yes even in a TTY, and offers no confirm to block on", async () => {
+    const root = await projectWithTools();
+    const output = silentOutput();
+    // The exact broken combination: consent granted by flag, --yes set, and a
+    // real TTY (so the old `interactive ? "review" : "queue"` chose "review").
+    // A confirm seam IS supplied, as init does whenever it has pretty output —
+    // it must not be forwarded.
+    const confirm = vi.fn(async () => true);
+
+    const result = await runInitJudgment({
+      root,
+      output,
+      env: {},
+      yes: true,
+      consent: true,
+      interactive: true,
+      confirm,
+    });
+
+    expect(result.ran).toBe(true);
+    expect(runJudgmentPass).toHaveBeenCalledTimes(1);
+    const passed = runJudgmentPass.mock.calls[0]![0] as { loosenings: string; confirm?: unknown };
+    expect(passed.loosenings).toBe("queue");
+    expect(passed.confirm).toBeUndefined();
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it("queues loosenings in a non-TTY run", async () => {
+    const root = await projectWithTools();
+    const output = silentOutput();
+
+    await runInitJudgment({
+      root,
+      output,
+      env: {},
+      yes: false,
+      consent: true,
+      interactive: false,
+      confirm: vi.fn(async () => true),
+    });
+
+    const passed = runJudgmentPass.mock.calls[0]![0] as { loosenings: string; confirm?: unknown };
+    expect(passed.loosenings).toBe("queue");
+    expect(passed.confirm).toBeUndefined();
+  });
+
+  it("says the held loosenings were not applied and how to review them", async () => {
+    const root = await projectWithTools();
+    const output = silentOutput();
+
+    await runInitJudgment({ root, output, env: {}, yes: true, consent: true, interactive: true });
+
+    // The pass owns the count + `vendo sync --review` line; this is the WHY,
+    // so a queued result never reads as a refusal or a silent apply.
+    expect(output.lines.join("\n")).toContain("held, not applied");
+    expect(output.lines.join("\n")).toContain("re-run `vendo init` in a terminal");
+  });
+
+  it("still reviews inline when a human is actually there", async () => {
+    const root = await projectWithTools();
+    const output = silentOutput();
+    const confirm = vi.fn(async () => true);
+
+    await runInitJudgment({
+      root,
+      output,
+      env: {},
+      yes: false,
+      consent: true,
+      interactive: true,
+      confirm,
+    });
+
+    const passed = runJudgmentPass.mock.calls[0]![0] as { loosenings: string; confirm?: unknown };
+    expect(passed.loosenings).toBe("review");
+    expect(passed.confirm).toBe(confirm);
+    expect(output.lines.join("\n")).not.toContain("held, not applied");
+  });
+});

--- a/packages/vendo/src/cli/init-judgment.unattended.test.ts
+++ b/packages/vendo/src/cli/init-judgment.unattended.test.ts
@@ -98,6 +98,10 @@ describe("the loosening review never blocks an unattended init", () => {
     expect(passed.loosenings).toBe("queue");
     expect(passed.confirm).toBeUndefined();
     expect(confirm).not.toHaveBeenCalled();
+    // The pass owns the count + `vendo sync --review` line; this is the WHY,
+    // so a queued result never reads as a refusal or a silent apply.
+    expect(output.lines.join("\n")).toContain("held, not applied");
+    expect(output.lines.join("\n")).toContain("re-run `vendo init` in a terminal");
   });
 
   it("queues loosenings in a non-TTY run", async () => {
@@ -117,18 +121,6 @@ describe("the loosening review never blocks an unattended init", () => {
     const passed = runJudgmentPass.mock.calls[0]![0] as { loosenings: string; confirm?: unknown };
     expect(passed.loosenings).toBe("queue");
     expect(passed.confirm).toBeUndefined();
-  });
-
-  it("says the held loosenings were not applied and how to review them", async () => {
-    const root = await projectWithTools();
-    const output = silentOutput();
-
-    await runInitJudgment({ root, output, env: {}, yes: true, consent: true, interactive: true });
-
-    // The pass owns the count + `vendo sync --review` line; this is the WHY,
-    // so a queued result never reads as a refusal or a silent apply.
-    expect(output.lines.join("\n")).toContain("held, not applied");
-    expect(output.lines.join("\n")).toContain("re-run `vendo init` in a terminal");
   });
 
   it("still reviews inline when a human is actually there", async () => {

--- a/packages/vendo/src/cli/quickstart-config-surface.docs-check.ts
+++ b/packages/vendo/src/cli/quickstart-config-surface.docs-check.ts
@@ -15,6 +15,10 @@
  * import specifiers below: a package cannot resolve itself by name, so the
  * doc's host-facing `@vendoai/vendo` becomes the local entry here).
  *
+ * The `.docs-check.ts` suffix is load-bearing: `tsconfig.json` excludes it from
+ * the build (this is test scaffolding — it must not ship as dead declarations in
+ * every tarball) and `tsconfig.docs-check.json` picks it back up for typecheck.
+ *
  * Generated once from the doc; edit the doc and re-derive, never one alone.
  */
 import type { CreateVendoConfig as RealCreateVendoConfig, Vendo as RealVendo } from "../server.js";

--- a/packages/vendo/src/cli/quickstart-config-surface.ts
+++ b/packages/vendo/src/cli/quickstart-config-surface.ts
@@ -1,0 +1,123 @@
+/**
+ * The `createVendo` config surface that `docs/quickstart.md` publishes — the
+ * real thing, compiled.
+ *
+ * A quickstart's config listing is the one block readers paste and adapt, and
+ * it rotted three ways before this file existed (keys missing, `object` where a
+ * required shape belongs, types named from packages a host cannot import). A
+ * name-only comparison cannot catch that: it passes while nested members, their
+ * types, and their optionality all drift.
+ *
+ * So the doc's block lives here verbatim and the assertions at the bottom prove
+ * it is EXACTLY `CreateVendoConfig`/`Vendo`, nested shapes included — any
+ * mismatch is a `pnpm typecheck` failure. `quickstart.docs.test.ts` asserts
+ * this region and the doc's code block stay byte-identical (modulo the two
+ * import specifiers below: a package cannot resolve itself by name, so the
+ * doc's host-facing `@vendoai/vendo` becomes the local entry here).
+ *
+ * Generated once from the doc; edit the doc and re-derive, never one alone.
+ */
+import type { CreateVendoConfig as RealCreateVendoConfig, Vendo as RealVendo } from "../server.js";
+
+/** Invariant type identity — mutual assignability would let `object` stand in
+ *  for a required shape, which is one of the drifts this file exists to catch. */
+type Identical<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type Assert<T extends true> = T;
+
+// --- BEGIN docs/quickstart.md config surface ---
+import type {
+  ActAs, ActionsRegistry, AppsRuntime, AutomationsEngine, CatalogFile,
+  ComponentCatalog, ComponentRegistry, Connector, ExtractedTool,
+  HostOAuthAdapter, Json, Judge, KnowledgeAdapter, OverridesFile, PolicyConfig,
+  PolicyFile, Principal, RunId, SandboxAdapter, SecretsProvider, ToolRegistry,
+  VendoAgent, VendoGuard, VendoStore, VendoTheme,
+} from "../index.js";
+import type {
+  ConnectionsService, HostAuthPreset, ModelsConfig, ServerActionHandler,
+} from "../server.js";
+import type { LanguageModel } from "ai";
+
+export interface CreateVendoConfig {
+  /** @deprecated superseded by `models.agent`. */
+  model?: LanguageModel;
+  /** @deprecated the model half is superseded by `models.paint`; `disabled` stays. */
+  paint?: { model?: LanguageModel; disabled?: boolean };
+  models?: ModelsConfig;      // { agent, paint, judge, knowledgeVerifier } — name or model object
+  auth?: HostAuthPreset;      // one preset fills principal + actAs + oauth
+  principal?: (req: Request) => Promise<Principal | null>; // escape hatch
+  catalog?: ComponentCatalog | ComponentRegistry;          // registry.tsx, or the array form
+  theme?: VendoTheme;         // programmatic override for .vendo/theme.json
+  brief?: string;             // programmatic override for .vendo/brief.md
+  store?: VendoStore;
+  sandbox?: SandboxAdapter;
+  knowledge?: KnowledgeAdapter; // unset → no vendo_knowledge_search tool
+  connectors?: Connector[];
+  connectorApps?: string[];   // toolkit scope for the auto-composed Cloud connector
+  connections?: ConnectionsService; // explicit connections adapter; always wins over defaults
+  actAs?: ActAs;              // escape hatch
+  serverActions?: Record<string, ServerActionHandler>; // the generated vendo-actions.ts map
+  policy?: PolicyConfig;      // "cautious" | "readonly" | "autopilot" | { file } | { rules }
+  judge?: Judge;
+  secrets?: SecretsProvider;
+  telemetry?: boolean;
+  development?: boolean | { root?: string; out?: string }; // dev-only source capture
+  profileDir?: string;        // the project root .vendo/ is read under
+  fetch?: typeof fetch;       // the fetch host tool bindings execute through
+  profile?: {                 // the same .vendo/ pieces, in memory (filesystem-less venues)
+    tools?: ExtractedTool[];
+    overrides?: OverridesFile;
+    theme?: VendoTheme;
+    brief?: string;
+    catalog?: CatalogFile;
+    policy?: PolicyFile;
+    designRules?: string;
+  };
+  mcp?: boolean | {            // the door; `baseUrl` is its PUBLIC base URL
+    baseUrl?: string;
+    remoteAs?: { issuer: string; jwksUri?: string; audience: string };
+    federation?: { secret: string };
+  };
+  oauth?: HostOAuthAdapter;   // escape hatch; required when `mcp` is true and `auth` is absent
+  agent?: {
+    instructions?: string;
+    toolOutputCap?: number;
+    maxOutputTokens?: number;
+    historyWindow?: number;
+    maxInitialTools?: number;
+    loadout?: string[];
+    maxSearchExpansions?: number;
+    maxSteps?: number;
+  };
+  sessions?: { ttlMs?: number; sweepIntervalMs?: number; now?: () => number };
+  approvals?: { parkedCallTtlMs?: number };
+  apps?: {
+    experimentalServedApps?: boolean;
+    experimentalMachines?: boolean;
+    pipeline?: {              // generation-pipeline knobs, measured before default-on
+      structuredRepair?: boolean;
+      regionParallel?: boolean;
+      endPass?: boolean;
+      exemplarContract?: boolean;
+      smokeRender?: boolean;
+      rebind?: boolean;
+    };
+    designRules?: string;
+  };
+}
+
+export interface Vendo {
+  handler: (req: Request) => Promise<Response>;
+  emit(event: string, payload: Json, principal: Principal): Promise<RunId[]>;
+  agent: VendoAgent;
+  guard: VendoGuard;
+  guardedTools: ToolRegistry; // the guard-bound registry the vendo_* tool pack executes through
+  apps: AppsRuntime;
+  automations: AutomationsEngine;
+  actions: ActionsRegistry;
+  connections: ConnectionsService;
+  store: VendoStore;
+}
+// --- END docs/quickstart.md config surface ---
+
+export type ConfigSurfaceMatchesTheDoc = Assert<Identical<CreateVendoConfig, RealCreateVendoConfig>>;
+export type VendoSurfaceMatchesTheDoc = Assert<Identical<Vendo, RealVendo>>;

--- a/packages/vendo/src/cli/quickstart.docs.test.ts
+++ b/packages/vendo/src/cli/quickstart.docs.test.ts
@@ -1,0 +1,217 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { registrySource, routeSource, vendoRootWrapperSource } from "./init-scaffolds.js";
+// The quickstart's config-surface import block, compiled here: every type the
+// doc tells a host to import must really live on the umbrella's own entries, so
+// a rename or a removed re-export breaks `pnpm typecheck` instead of the reader.
+import type {
+  ActAs, ActionsRegistry, AppsRuntime, AutomationsEngine, CatalogFile,
+  ComponentCatalog, ComponentRegistry, Connector, ExtractedTool,
+  HostOAuthAdapter, Json, Judge, KnowledgeAdapter, OverridesFile, PolicyConfig,
+  PolicyFile, Principal, RunId, SandboxAdapter, SecretsProvider, ToolRegistry,
+  VendoAgent, VendoGuard, VendoStore, VendoTheme,
+} from "../index.js";
+import type { ConnectionsService, HostAuthPreset, ModelsConfig } from "../server.js";
+
+/**
+ * Quickstart drift gate. `docs/quickstart.md` is the first code a host ever
+ * pastes, and it rotted three ways at once (a `@vendoai/core` import no host
+ * can resolve under pnpm strict linking, a deprecated `model:` pin as the
+ * primary example, and a config listing missing keys its own prose referenced).
+ * Prose can't be tested; the load-bearing lines can:
+ *
+ *   1. the three generated files' code blocks vs the `init-scaffolds.ts`
+ *      exports that actually write them,
+ *   2. the config listing's key set vs `CreateVendoConfig`/`Vendo` in
+ *      `server.ts`, including which keys are marked @deprecated,
+ *   3. every `@vendoai/*` import specifier in a code block resolvable from a
+ *      host's own node_modules (never a transitive package),
+ *   4. no deprecated `model:` / `paint:` pin in the composition examples.
+ */
+
+const QUICKSTART = new URL("../../../../docs/quickstart.md", import.meta.url);
+const SERVER_SOURCE = new URL("../server.ts", import.meta.url);
+
+/** The packages a host installs directly (09-vendo §1): the umbrella, its
+ *  subpaths, the UI package, and the `vendoai` alias. Anything else in a
+ *  quickstart code block is a transitive dependency the reader cannot import. */
+const HOST_INSTALLABLE = /^(?:@vendoai\/(?:vendo|ui)|vendoai)(?:\/[\w./-]+)?$/;
+
+interface CodeBlock {
+  lang: string;
+  body: string;
+}
+
+function codeBlocks(markdown: string): CodeBlock[] {
+  const blocks: CodeBlock[] = [];
+  const pattern = /^```(\w*)\n([\s\S]*?)^```$/gm;
+  for (const match of markdown.matchAll(pattern)) blocks.push({ lang: match[1]!, body: match[2]! });
+  return blocks;
+}
+
+/** The block whose first line is the `// <path>` marker the doc labels it with. */
+function blockFor(blocks: CodeBlock[], marker: string): string {
+  const found = blocks.filter((block) => block.body.startsWith(`// ${marker}`));
+  expect(found.length, `expected exactly one code block starting with "// ${marker}"`).toBe(1);
+  return found[0]!.body;
+}
+
+/** The one block declaring the config surface. */
+function configListing(blocks: CodeBlock[]): string {
+  const found = blocks.filter((block) => block.body.includes("export interface CreateVendoConfig {"));
+  expect(found.length, "expected exactly one config-surface code block").toBe(1);
+  return found[0]!.body;
+}
+
+/** Load-bearing lines: code only, comments and blank lines dropped. */
+function codeLines(source: string): string[] {
+  return source
+    .split("\n")
+    .map((line) => line.replace(/\s*\/\/.*$/, "").trimEnd())
+    .filter((line) => line.trim() !== "" && !/^\s*(?:\/\*|\*)/.test(line));
+}
+
+/** Comments collapsed to a brace-free marker that survives the line scan, so
+ *  @deprecated stays attributable without a doc comment's `{tenant}` breaking
+ *  the depth count. */
+function markComments(source: string): string {
+  const mark = (comment: string): string => (comment.includes("@deprecated") ? "/*!*/" : "");
+  return source.replace(/\/\*[\s\S]*?\*\//g, mark).replace(/\/\/[^\n]*/g, mark);
+}
+
+/** The interface's own members — depth-1 keys, in declaration order, each
+ *  flagged when its comment says @deprecated. */
+function interfaceMembers(source: string, name: string): Array<{ key: string; deprecated: boolean }> {
+  const marked = markComments(source);
+  const declaration = marked.indexOf(`interface ${name} {`);
+  expect(declaration, `interface ${name} not found`).toBeGreaterThanOrEqual(0);
+  const bodyStart = marked.indexOf("{", declaration) + 1;
+  let depth = 1;
+  let cursor = bodyStart;
+  while (depth > 0) {
+    const char = marked[cursor];
+    expect(char, `unterminated interface ${name}`).toBeDefined();
+    if (char === "{") depth += 1;
+    else if (char === "}") depth -= 1;
+    cursor += 1;
+  }
+
+  const members: Array<{ key: string; deprecated: boolean }> = [];
+  let nesting = 0;
+  let pendingDeprecated = false;
+  for (const line of marked.slice(bodyStart, cursor - 1).split("\n")) {
+    if (nesting === 0) {
+      const member = /^\s*(\w+)\??\s*[:(]/.exec(line);
+      if (member !== null) {
+        members.push({ key: member[1]!, deprecated: pendingDeprecated || line.includes("/*!*/") });
+        pendingDeprecated = false;
+      } else if (line.includes("/*!*/")) {
+        pendingDeprecated = true;
+      }
+    }
+    nesting += (line.match(/\{/g)?.length ?? 0) - (line.match(/\}/g)?.length ?? 0);
+  }
+  return members;
+}
+
+describe("docs/quickstart.md stays 1:1 with the surfaces it documents", () => {
+  it("shows the registry scaffold's own import, not a transitive one", async () => {
+    const blocks = codeBlocks(await readFile(QUICKSTART, "utf8"));
+    const documented = blockFor(blocks, "vendo/registry.tsx");
+    const scaffold = registrySource("tsx");
+
+    // The specifier is the whole point (init-scaffolds.ts: @vendoai/core is
+    // transitive, so a host importing it fails to resolve with TS2307).
+    const scaffoldImport = codeLines(scaffold).find((line) => line.startsWith("import type {"))!;
+    expect(scaffoldImport).toBe(`import type { ComponentRegistry } from "@vendoai/vendo";`);
+    expect(codeLines(documented)).toContain(scaffoldImport);
+    expect(documented).toContain("satisfies ComponentRegistry");
+  });
+
+  it("shows the route scaffold verbatim as the primary composition", async () => {
+    const blocks = codeBlocks(await readFile(QUICKSTART, "utf8"));
+    const documented = blockFor(blocks, "app/api/vendo/[...vendo]/route.ts");
+    const scaffold = routeSource({
+      serverActions: false,
+      auth: { preset: "authJs", dependency: "next-auth" },
+      registrySpecifier: "@/vendo/registry",
+    });
+    expect(codeLines(documented)).toEqual(codeLines(scaffold));
+  });
+
+  it("shows the client-mount scaffold verbatim", async () => {
+    const blocks = codeBlocks(await readFile(QUICKSTART, "utf8"));
+    const documented = blockFor(blocks, "vendo/vendo-root.tsx");
+    const scaffold = vendoRootWrapperSource({ themeSpecifier: "../.vendo/theme.json" });
+    expect(codeLines(documented)).toEqual(codeLines(scaffold));
+  });
+
+  it("never tells a host to import a transitive package", async () => {
+    const blocks = codeBlocks(await readFile(QUICKSTART, "utf8"));
+    for (const block of blocks) {
+      for (const match of block.body.matchAll(/\bfrom ["']([^"']+)["']/g)) {
+        const specifier = match[1]!;
+        if (!specifier.startsWith("@vendoai/") && !specifier.startsWith("vendoai")) continue;
+        expect(HOST_INSTALLABLE.test(specifier), `${specifier} is not installable by a host`).toBe(true);
+      }
+    }
+  });
+
+  it("pins no deprecated model in the composition examples", async () => {
+    const blocks = codeBlocks(await readFile(QUICKSTART, "utf8"));
+    // Every ts/tsx block that composes: the deprecated top-level `model:` and
+    // `paint:` keys must never appear as the example a reader copies.
+    const compositions = blocks.filter((block) => block.body.includes("createVendo({"));
+    expect(compositions.length).toBeGreaterThan(0);
+    for (const block of compositions) {
+      for (const line of codeLines(block.body)) {
+        expect(/^\s*(?:model|paint)\s*:/.test(line), `deprecated pin in a composition example: ${line}`).toBe(false);
+      }
+    }
+  });
+
+  it("lists exactly createVendo's config keys, deprecations included", async () => {
+    const listing = configListing(codeBlocks(await readFile(QUICKSTART, "utf8")));
+    const source = await readFile(SERVER_SOURCE, "utf8");
+    expect(interfaceMembers(listing, "CreateVendoConfig"))
+      .toEqual(interfaceMembers(source, "CreateVendoConfig"));
+  });
+
+  it("lists exactly the Vendo interface's members", async () => {
+    const listing = configListing(codeBlocks(await readFile(QUICKSTART, "utf8")));
+    const source = await readFile(SERVER_SOURCE, "utf8");
+    expect(interfaceMembers(listing, "Vendo")).toEqual(interfaceMembers(source, "Vendo"));
+  });
+});
+
+/** Referencing every imported type keeps the compiled import block honest —
+ *  an unused type-only import is not an error, so it must be used. */
+export type QuickstartConfigSurface = {
+  actAs: ActAs;
+  actions: ActionsRegistry;
+  apps: AppsRuntime;
+  automations: AutomationsEngine;
+  catalogFile: CatalogFile;
+  catalog: ComponentCatalog | ComponentRegistry;
+  connectors: Connector[];
+  connections: ConnectionsService;
+  tools: ExtractedTool[];
+  oauth: HostOAuthAdapter;
+  auth: HostAuthPreset;
+  payload: Json;
+  judge: Judge;
+  knowledge: KnowledgeAdapter;
+  models: ModelsConfig;
+  overrides: OverridesFile;
+  policy: PolicyConfig;
+  policyFile: PolicyFile;
+  principal: Principal;
+  runs: RunId[];
+  sandbox: SandboxAdapter;
+  secrets: SecretsProvider;
+  guardedTools: ToolRegistry;
+  agent: VendoAgent;
+  guard: VendoGuard;
+  store: VendoStore;
+  theme: VendoTheme;
+};

--- a/packages/vendo/src/cli/quickstart.docs.test.ts
+++ b/packages/vendo/src/cli/quickstart.docs.test.ts
@@ -1,36 +1,47 @@
 import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import { registrySource, routeSource, vendoRootWrapperSource } from "./init-scaffolds.js";
-// The quickstart's config-surface import block, compiled here: every type the
-// doc tells a host to import must really live on the umbrella's own entries, so
-// a rename or a removed re-export breaks `pnpm typecheck` instead of the reader.
-import type {
-  ActAs, ActionsRegistry, AppsRuntime, AutomationsEngine, CatalogFile,
-  ComponentCatalog, ComponentRegistry, Connector, ExtractedTool,
-  HostOAuthAdapter, Json, Judge, KnowledgeAdapter, OverridesFile, PolicyConfig,
-  PolicyFile, Principal, RunId, SandboxAdapter, SecretsProvider, ToolRegistry,
-  VendoAgent, VendoGuard, VendoStore, VendoTheme,
-} from "../index.js";
-import type { ConnectionsService, HostAuthPreset, ModelsConfig } from "../server.js";
 
 /**
  * Quickstart drift gate. `docs/quickstart.md` is the first code a host ever
- * pastes, and it rotted three ways at once (a `@vendoai/core` import no host
- * can resolve under pnpm strict linking, a deprecated `model:` pin as the
- * primary example, and a config listing missing keys its own prose referenced).
- * Prose can't be tested; the load-bearing lines can:
+ * pastes, and it rotted four ways at once (a `@vendoai/core` import no host can
+ * resolve under pnpm strict linking, a deprecated `model:` pin as the primary
+ * example, a config listing missing keys its own prose referenced, and an intro
+ * describing an init that no longer exists). Prose can't be tested; the
+ * load-bearing lines can:
  *
  *   1. the three generated files' code blocks vs the `init-scaffolds.ts`
  *      exports that actually write them,
- *   2. the config listing's key set vs `CreateVendoConfig`/`Vendo` in
- *      `server.ts`, including which keys are marked @deprecated,
- *   3. every `@vendoai/*` import specifier in a code block resolvable from a
+ *   2. the config listing vs `quickstart-config-surface.ts`, byte for byte —
+ *      that file holds the same block and is compiled against the real
+ *      `CreateVendoConfig`/`Vendo` (nested shapes and optionality included), so
+ *      the types and the imports are checked by `pnpm typecheck` rather than by
+ *      a list maintained here,
+ *   3. the listing's top-level key set and @deprecated marks vs `server.ts` —
+ *      a readable failure for the most common drift, and the one thing types
+ *      cannot carry,
+ *   4. every `@vendoai/*` import specifier in a code block resolvable from a
  *      host's own node_modules (never a transitive package),
- *   4. no deprecated `model:` / `paint:` pin in the composition examples.
+ *   5. no deprecated `model:` / `paint:` pin in the composition examples.
+ *
+ * NOTE: `tsconfig.json` excludes `*.test.ts`, so nothing in THIS file is
+ * typechecked. Every compile-time guarantee lives in the fixture, which is not
+ * excluded — that is why it exists as its own module.
  */
 
 const QUICKSTART = new URL("../../../../docs/quickstart.md", import.meta.url);
 const SERVER_SOURCE = new URL("../server.ts", import.meta.url);
+const CONFIG_FIXTURE = new URL("./quickstart-config-surface.ts", import.meta.url);
+
+/** The fixture's copy of the doc block, between its markers. */
+const FIXTURE_REGION = /^\/\/ --- BEGIN docs\/quickstart\.md config surface ---\n([\s\S]*?)^\/\/ --- END docs\/quickstart\.md config surface ---$/m;
+
+/** The only difference the fixture is allowed: a package cannot resolve itself
+ *  by name, so the doc's host-facing specifiers become the local entries. */
+const LOCAL_ENTRIES: ReadonlyArray<readonly [string, string]> = [
+  ['from "@vendoai/vendo/server";', 'from "../server.js";'],
+  ['from "@vendoai/vendo";', 'from "../index.js";'],
+];
 
 /** The packages a host installs directly (09-vendo §1): the umbrella, its
  *  subpaths, the UI package, and the `vendoai` alias. Anything else in a
@@ -170,6 +181,25 @@ describe("docs/quickstart.md stays 1:1 with the surfaces it documents", () => {
     }
   });
 
+  it("keeps the config listing byte-identical to the compiled fixture", async () => {
+    const listing = configListing(codeBlocks(await readFile(QUICKSTART, "utf8")));
+    const fixture = await readFile(CONFIG_FIXTURE, "utf8");
+    const region = FIXTURE_REGION.exec(fixture)?.[1];
+    expect(region, "the fixture lost its BEGIN/END markers").toBeDefined();
+
+    const localized = LOCAL_ENTRIES.reduce(
+      (source, [published, local]) => source.replace(published, local),
+      listing,
+    );
+    // Byte equality is the point: the fixture is what `pnpm typecheck` compiles
+    // against the real types, so anything the doc says that the fixture doesn't
+    // is unverified. Re-derive the fixture from the doc block, never by hand.
+    expect(region).toBe(localized);
+    // And the rewrite must have actually applied — a doc that stopped naming
+    // the public specifiers would otherwise match a stale fixture.
+    for (const [published] of LOCAL_ENTRIES) expect(listing).toContain(published);
+  });
+
   it("lists exactly createVendo's config keys, deprecations included", async () => {
     const listing = configListing(codeBlocks(await readFile(QUICKSTART, "utf8")));
     const source = await readFile(SERVER_SOURCE, "utf8");
@@ -183,35 +213,3 @@ describe("docs/quickstart.md stays 1:1 with the surfaces it documents", () => {
     expect(interfaceMembers(listing, "Vendo")).toEqual(interfaceMembers(source, "Vendo"));
   });
 });
-
-/** Referencing every imported type keeps the compiled import block honest —
- *  an unused type-only import is not an error, so it must be used. */
-export type QuickstartConfigSurface = {
-  actAs: ActAs;
-  actions: ActionsRegistry;
-  apps: AppsRuntime;
-  automations: AutomationsEngine;
-  catalogFile: CatalogFile;
-  catalog: ComponentCatalog | ComponentRegistry;
-  connectors: Connector[];
-  connections: ConnectionsService;
-  tools: ExtractedTool[];
-  oauth: HostOAuthAdapter;
-  auth: HostAuthPreset;
-  payload: Json;
-  judge: Judge;
-  knowledge: KnowledgeAdapter;
-  models: ModelsConfig;
-  overrides: OverridesFile;
-  policy: PolicyConfig;
-  policyFile: PolicyFile;
-  principal: Principal;
-  runs: RunId[];
-  sandbox: SandboxAdapter;
-  secrets: SecretsProvider;
-  guardedTools: ToolRegistry;
-  agent: VendoAgent;
-  guard: VendoGuard;
-  store: VendoStore;
-  theme: VendoTheme;
-};

--- a/packages/vendo/src/cli/quickstart.docs.test.ts
+++ b/packages/vendo/src/cli/quickstart.docs.test.ts
@@ -40,18 +40,18 @@ const FIXTURE_REGION = /^\/\/ --- BEGIN docs\/quickstart\.md config surface ---\
  *  by name, so the doc's host-facing specifiers become the local entries.
  *
  *  Anchored to an import declaration's own closing line, not matched loosely:
- *  an unanchored replace lets a `from "@vendoai/vendo";` inside a COMMENT
- *  absorb the rewrite (String.replace takes the first hit only) while the real
- *  import already reads `from "../index.js";` — byte identity and the
- *  host-installability check would both pass over host code that cannot
- *  resolve. */
-const LOCAL_ENTRIES: ReadonlyArray<readonly [RegExp, string, string]> = [
-  [/^\} from "@vendoai\/vendo\/server";$/gm, '} from "../server.js";', '@vendoai/vendo/server'],
-  [/^\} from "@vendoai\/vendo";$/gm, '} from "../index.js";', '@vendoai/vendo'],
+ *  a `from "@vendoai/vendo";` quoted inside a COMMENT must not be able to
+ *  absorb the rewrite while the real import already reads `from "../index.js";`
+ *  — byte identity and the host-installability check would both then pass over
+ *  host code that cannot resolve. */
+const LOCAL_ENTRIES: ReadonlyArray<readonly [RegExp, string]> = [
+  [/^\} from "@vendoai\/vendo\/server";$/gm, '} from "../server.js";'],
+  [/^\} from "@vendoai\/vendo";$/gm, '} from "../index.js";'],
 ];
 
 /** Import declarations only — `from "x"` at the end of a line that is not a
- *  comment. Used to assert the doc names the PUBLIC specifiers for real. */
+ *  comment, so a specifier quoted in prose is never mistaken for one a host
+ *  pastes. */
 function importSpecifiers(source: string): string[] {
   return source
     .split("\n")
@@ -64,30 +64,23 @@ function importSpecifiers(source: string): string[] {
  *  quickstart code block is a transitive dependency the reader cannot import. */
 const HOST_INSTALLABLE = /^(?:@vendoai\/(?:vendo|ui)|vendoai)(?:\/[\w./-]+)?$/;
 
-interface CodeBlock {
-  lang: string;
-  body: string;
-}
-
-function codeBlocks(markdown: string): CodeBlock[] {
-  const blocks: CodeBlock[] = [];
-  const pattern = /^```(\w*)\n([\s\S]*?)^```$/gm;
-  for (const match of markdown.matchAll(pattern)) blocks.push({ lang: match[1]!, body: match[2]! });
-  return blocks;
+/** Every fenced block's body. */
+function codeBlocks(markdown: string): string[] {
+  return [...markdown.matchAll(/^```\w*\n([\s\S]*?)^```$/gm)].map((match) => match[1]!);
 }
 
 /** The block whose first line is the `// <path>` marker the doc labels it with. */
-function blockFor(blocks: CodeBlock[], marker: string): string {
-  const found = blocks.filter((block) => block.body.startsWith(`// ${marker}`));
+function blockFor(blocks: string[], marker: string): string {
+  const found = blocks.filter((block) => block.startsWith(`// ${marker}`));
   expect(found.length, `expected exactly one code block starting with "// ${marker}"`).toBe(1);
-  return found[0]!.body;
+  return found[0]!;
 }
 
 /** The one block declaring the config surface. */
-function configListing(blocks: CodeBlock[]): string {
-  const found = blocks.filter((block) => block.body.includes("export interface CreateVendoConfig {"));
+function configListing(blocks: string[]): string {
+  const found = blocks.filter((block) => block.includes("export interface CreateVendoConfig {"));
   expect(found.length, "expected exactly one config-surface code block").toBe(1);
-  return found[0]!.body;
+  return found[0]!;
 }
 
 /** Load-bearing lines: code only, comments and blank lines dropped. */
@@ -98,52 +91,31 @@ function codeLines(source: string): string[] {
     .filter((line) => line.trim() !== "" && !/^\s*(?:\/\*|\*)/.test(line));
 }
 
-/** Comments collapsed to a brace-free marker that survives the line scan, so
- *  @deprecated stays attributable without a doc comment's `{tenant}` breaking
- *  the depth count. */
-function markComments(source: string): string {
-  const mark = (comment: string): string => (comment.includes("@deprecated") ? "/*!*/" : "");
-  return source.replace(/\/\*[\s\S]*?\*\//g, mark).replace(/\/\/[^\n]*/g, mark);
-}
-
-/** The interface's own members — depth-1 keys, in declaration order, each
- *  flagged when its comment says @deprecated. */
-function interfaceMembers(source: string, name: string): Array<{ key: string; deprecated: boolean }> {
-  const marked = markComments(source);
-  const declaration = marked.indexOf(`interface ${name} {`);
+/** An interface declaration's body — through the closing `}` in column 0. Both
+ *  sources are 2-space formatted, so nothing but the terminator sits there. */
+function interfaceBody(source: string, name: string): string {
+  const declaration = source.indexOf(`interface ${name} {`);
   expect(declaration, `interface ${name} not found`).toBeGreaterThanOrEqual(0);
-  const bodyStart = marked.indexOf("{", declaration) + 1;
-  let depth = 1;
-  let cursor = bodyStart;
-  while (depth > 0) {
-    const char = marked[cursor];
-    expect(char, `unterminated interface ${name}`).toBeDefined();
-    if (char === "{") depth += 1;
-    else if (char === "}") depth -= 1;
-    cursor += 1;
-  }
-
-  const members: Array<{ key: string; deprecated: boolean }> = [];
-  let nesting = 0;
-  let pendingDeprecated = false;
-  for (const line of marked.slice(bodyStart, cursor - 1).split("\n")) {
-    if (nesting === 0) {
-      const member = /^\s*(\w+)\??\s*[:(]/.exec(line);
-      if (member !== null) {
-        members.push({ key: member[1]!, deprecated: pendingDeprecated || line.includes("/*!*/") });
-        pendingDeprecated = false;
-      } else if (line.includes("/*!*/")) {
-        pendingDeprecated = true;
-      }
-    }
-    nesting += (line.match(/\{/g)?.length ?? 0) - (line.match(/\}/g)?.length ?? 0);
-  }
-  return members;
+  return source.slice(declaration).split(/^\}$/m)[0]!;
 }
+
+/** The interface's own members, in declaration order. Indentation is the depth
+ *  signal: a nested member sits deeper than two spaces. */
+function interfaceMembers(source: string, name: string): string[] {
+  return [...interfaceBody(source, name).matchAll(/^ {2}(\w+)\??\s*[:(]/gm)].map((match) => match[1]!);
+}
+
+/** The members whose own comment says @deprecated — the one fact the compiled
+ *  fixture's type identity cannot carry. */
+function deprecatedMembers(source: string, name: string): string[] {
+  const pattern = /@deprecated[\s\S]*?\*\/\s+(\w+)\??\s*[:(]/g;
+  return [...interfaceBody(source, name).matchAll(pattern)].map((match) => match[1]!);
+}
+
+const blocks = codeBlocks(await readFile(QUICKSTART, "utf8"));
 
 describe("docs/quickstart.md stays 1:1 with the surfaces it documents", () => {
-  it("shows the registry scaffold's own import, not a transitive one", async () => {
-    const blocks = codeBlocks(await readFile(QUICKSTART, "utf8"));
+  it("shows the registry scaffold's own import, not a transitive one", () => {
     const documented = blockFor(blocks, "vendo/registry.tsx");
     const scaffold = registrySource("tsx");
 
@@ -155,8 +127,7 @@ describe("docs/quickstart.md stays 1:1 with the surfaces it documents", () => {
     expect(documented).toContain("satisfies ComponentRegistry");
   });
 
-  it("shows the route scaffold verbatim as the primary composition", async () => {
-    const blocks = codeBlocks(await readFile(QUICKSTART, "utf8"));
+  it("shows the route scaffold verbatim as the primary composition", () => {
     const documented = blockFor(blocks, "app/api/vendo/[...vendo]/route.ts");
     const scaffold = routeSource({
       serverActions: false,
@@ -166,40 +137,37 @@ describe("docs/quickstart.md stays 1:1 with the surfaces it documents", () => {
     expect(codeLines(documented)).toEqual(codeLines(scaffold));
   });
 
-  it("shows the client-mount scaffold verbatim", async () => {
-    const blocks = codeBlocks(await readFile(QUICKSTART, "utf8"));
+  it("shows the client-mount scaffold verbatim", () => {
     const documented = blockFor(blocks, "vendo/vendo-root.tsx");
     const scaffold = vendoRootWrapperSource({ themeSpecifier: "../.vendo/theme.json" });
     expect(codeLines(documented)).toEqual(codeLines(scaffold));
   });
 
-  it("never tells a host to import a transitive package", async () => {
-    const blocks = codeBlocks(await readFile(QUICKSTART, "utf8"));
+  it("never tells a host to import a transitive package", () => {
     for (const block of blocks) {
       // Import declarations only: a specifier quoted inside a comment is prose,
       // and must not be able to stand in for the one a host actually pastes.
-      for (const specifier of importSpecifiers(block.body)) {
+      for (const specifier of importSpecifiers(block)) {
         if (!specifier.startsWith("@vendoai/") && !specifier.startsWith("vendoai")) continue;
         expect(HOST_INSTALLABLE.test(specifier), `${specifier} is not installable by a host`).toBe(true);
       }
     }
   });
 
-  it("pins no deprecated model in the composition examples", async () => {
-    const blocks = codeBlocks(await readFile(QUICKSTART, "utf8"));
+  it("pins no deprecated model in the composition examples", () => {
     // Every ts/tsx block that composes: the deprecated top-level `model:` and
     // `paint:` keys must never appear as the example a reader copies.
-    const compositions = blocks.filter((block) => block.body.includes("createVendo({"));
+    const compositions = blocks.filter((block) => block.includes("createVendo({"));
     expect(compositions.length).toBeGreaterThan(0);
     for (const block of compositions) {
-      for (const line of codeLines(block.body)) {
+      for (const line of codeLines(block)) {
         expect(/^\s*(?:model|paint)\s*:/.test(line), `deprecated pin in a composition example: ${line}`).toBe(false);
       }
     }
   });
 
   it("keeps the config listing byte-identical to the compiled fixture", async () => {
-    const listing = configListing(codeBlocks(await readFile(QUICKSTART, "utf8")));
+    const listing = configListing(blocks);
     const fixture = await readFile(CONFIG_FIXTURE, "utf8");
     const region = FIXTURE_REGION.exec(fixture)?.[1];
     expect(region, "the fixture lost its BEGIN/END markers").toBeDefined();
@@ -211,31 +179,23 @@ describe("docs/quickstart.md stays 1:1 with the surfaces it documents", () => {
     // Byte equality is the point: the fixture is what `pnpm typecheck` compiles
     // against the real types, so anything the doc says that the fixture doesn't
     // is unverified. Re-derive the fixture from the doc block, never by hand.
+    // It also proves the rewrite hit real import declarations — a doc that
+    // stopped naming the public specifiers no longer matches the fixture.
     expect(region).toBe(localized);
-    // And the rewrite must have applied to real import declarations — a doc
-    // that stopped naming the public specifiers, or hid one in a comment,
-    // would otherwise match a stale fixture.
-    const specifiers = importSpecifiers(listing);
-    for (const [, , published] of LOCAL_ENTRIES) {
-      expect(specifiers, `the listing must import from ${published}`).toContain(published);
-    }
     // Nothing in the listing may import from a relative path: that is the
     // fixture's private rewrite, never something a host could paste.
-    for (const specifier of specifiers) {
+    for (const specifier of importSpecifiers(listing)) {
       expect(specifier.startsWith("."), `relative import in the doc: ${specifier}`).toBe(false);
     }
   });
 
-  it("lists exactly createVendo's config keys, deprecations included", async () => {
-    const listing = configListing(codeBlocks(await readFile(QUICKSTART, "utf8")));
+  it("lists exactly the documented interfaces' members, deprecations included", async () => {
+    const listing = configListing(blocks);
     const source = await readFile(SERVER_SOURCE, "utf8");
-    expect(interfaceMembers(listing, "CreateVendoConfig"))
-      .toEqual(interfaceMembers(source, "CreateVendoConfig"));
-  });
-
-  it("lists exactly the Vendo interface's members", async () => {
-    const listing = configListing(codeBlocks(await readFile(QUICKSTART, "utf8")));
-    const source = await readFile(SERVER_SOURCE, "utf8");
-    expect(interfaceMembers(listing, "Vendo")).toEqual(interfaceMembers(source, "Vendo"));
+    for (const name of ["CreateVendoConfig", "Vendo"]) {
+      expect(interfaceMembers(listing, name), name).toEqual(interfaceMembers(source, name));
+    }
+    expect(deprecatedMembers(listing, "CreateVendoConfig"))
+      .toEqual(deprecatedMembers(source, "CreateVendoConfig"));
   });
 });

--- a/packages/vendo/src/cli/quickstart.docs.test.ts
+++ b/packages/vendo/src/cli/quickstart.docs.test.ts
@@ -12,8 +12,8 @@ import { registrySource, routeSource, vendoRootWrapperSource } from "./init-scaf
  *
  *   1. the three generated files' code blocks vs the `init-scaffolds.ts`
  *      exports that actually write them,
- *   2. the config listing vs `quickstart-config-surface.ts`, byte for byte —
- *      that file holds the same block and is compiled against the real
+ *   2. the config listing vs `quickstart-config-surface.docs-check.ts`, byte for
+ *      byte — that file holds the same block and is compiled against the real
  *      `CreateVendoConfig`/`Vendo` (nested shapes and optionality included), so
  *      the types and the imports are checked by `pnpm typecheck` rather than by
  *      a list maintained here,
@@ -25,23 +25,39 @@ import { registrySource, routeSource, vendoRootWrapperSource } from "./init-scaf
  *   5. no deprecated `model:` / `paint:` pin in the composition examples.
  *
  * NOTE: `tsconfig.json` excludes `*.test.ts`, so nothing in THIS file is
- * typechecked. Every compile-time guarantee lives in the fixture, which is not
- * excluded — that is why it exists as its own module.
+ * typechecked. Every compile-time guarantee lives in the fixture instead, under
+ * its own `tsconfig.docs-check.json` — typechecked, never emitted.
  */
 
 const QUICKSTART = new URL("../../../../docs/quickstart.md", import.meta.url);
 const SERVER_SOURCE = new URL("../server.ts", import.meta.url);
-const CONFIG_FIXTURE = new URL("./quickstart-config-surface.ts", import.meta.url);
+const CONFIG_FIXTURE = new URL("./quickstart-config-surface.docs-check.ts", import.meta.url);
 
 /** The fixture's copy of the doc block, between its markers. */
 const FIXTURE_REGION = /^\/\/ --- BEGIN docs\/quickstart\.md config surface ---\n([\s\S]*?)^\/\/ --- END docs\/quickstart\.md config surface ---$/m;
 
 /** The only difference the fixture is allowed: a package cannot resolve itself
- *  by name, so the doc's host-facing specifiers become the local entries. */
-const LOCAL_ENTRIES: ReadonlyArray<readonly [string, string]> = [
-  ['from "@vendoai/vendo/server";', 'from "../server.js";'],
-  ['from "@vendoai/vendo";', 'from "../index.js";'],
+ *  by name, so the doc's host-facing specifiers become the local entries.
+ *
+ *  Anchored to an import declaration's own closing line, not matched loosely:
+ *  an unanchored replace lets a `from "@vendoai/vendo";` inside a COMMENT
+ *  absorb the rewrite (String.replace takes the first hit only) while the real
+ *  import already reads `from "../index.js";` — byte identity and the
+ *  host-installability check would both pass over host code that cannot
+ *  resolve. */
+const LOCAL_ENTRIES: ReadonlyArray<readonly [RegExp, string, string]> = [
+  [/^\} from "@vendoai\/vendo\/server";$/gm, '} from "../server.js";', '@vendoai/vendo/server'],
+  [/^\} from "@vendoai\/vendo";$/gm, '} from "../index.js";', '@vendoai/vendo'],
 ];
+
+/** Import declarations only — `from "x"` at the end of a line that is not a
+ *  comment. Used to assert the doc names the PUBLIC specifiers for real. */
+function importSpecifiers(source: string): string[] {
+  return source
+    .split("\n")
+    .filter((line) => !/^\s*(?:\/\/|\*|\/\*)/.test(line))
+    .flatMap((line) => [...line.matchAll(/\bfrom ["']([^"']+)["'];?\s*$/g)].map((match) => match[1]!));
+}
 
 /** The packages a host installs directly (09-vendo §1): the umbrella, its
  *  subpaths, the UI package, and the `vendoai` alias. Anything else in a
@@ -160,8 +176,9 @@ describe("docs/quickstart.md stays 1:1 with the surfaces it documents", () => {
   it("never tells a host to import a transitive package", async () => {
     const blocks = codeBlocks(await readFile(QUICKSTART, "utf8"));
     for (const block of blocks) {
-      for (const match of block.body.matchAll(/\bfrom ["']([^"']+)["']/g)) {
-        const specifier = match[1]!;
+      // Import declarations only: a specifier quoted inside a comment is prose,
+      // and must not be able to stand in for the one a host actually pastes.
+      for (const specifier of importSpecifiers(block.body)) {
         if (!specifier.startsWith("@vendoai/") && !specifier.startsWith("vendoai")) continue;
         expect(HOST_INSTALLABLE.test(specifier), `${specifier} is not installable by a host`).toBe(true);
       }
@@ -188,16 +205,25 @@ describe("docs/quickstart.md stays 1:1 with the surfaces it documents", () => {
     expect(region, "the fixture lost its BEGIN/END markers").toBeDefined();
 
     const localized = LOCAL_ENTRIES.reduce(
-      (source, [published, local]) => source.replace(published, local),
+      (source, [declaration, local]) => source.replace(declaration, local),
       listing,
     );
     // Byte equality is the point: the fixture is what `pnpm typecheck` compiles
     // against the real types, so anything the doc says that the fixture doesn't
     // is unverified. Re-derive the fixture from the doc block, never by hand.
     expect(region).toBe(localized);
-    // And the rewrite must have actually applied — a doc that stopped naming
-    // the public specifiers would otherwise match a stale fixture.
-    for (const [published] of LOCAL_ENTRIES) expect(listing).toContain(published);
+    // And the rewrite must have applied to real import declarations — a doc
+    // that stopped naming the public specifiers, or hid one in a comment,
+    // would otherwise match a stale fixture.
+    const specifiers = importSpecifiers(listing);
+    for (const [, , published] of LOCAL_ENTRIES) {
+      expect(specifiers, `the listing must import from ${published}`).toContain(published);
+    }
+    // Nothing in the listing may import from a relative path: that is the
+    // fixture's private rewrite, never something a host could paste.
+    for (const specifier of specifiers) {
+      expect(specifier.startsWith("."), `relative import in the doc: ${specifier}`).toBe(false);
+    }
   });
 
   it("lists exactly createVendo's config keys, deprecations included", async () => {

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -230,7 +230,10 @@ export interface Vendo {
 // beside createVendo/CreateVendoConfig: the hosted try venue (a Worker in the
 // console repo) composes typed `profile` pieces against the umbrella alone,
 // without adding a direct @vendoai/actions or @vendoai/core dependency.
-export type { CatalogFile, ExtractedTool, OverridesFile } from "@vendoai/actions";
+// ServerActionHandler rides along for the same reason: it is the value type of
+// the documented `serverActions` config key, so a host must be able to name it
+// without adding a direct @vendoai/actions dependency.
+export type { CatalogFile, ExtractedTool, OverridesFile, ServerActionHandler } from "@vendoai/actions";
 export type { VendoTheme } from "@vendoai/core";
 export type { PolicyFile } from "@vendoai/guard";
 

--- a/packages/vendo/tsconfig.docs-check.json
+++ b/packages/vendo/tsconfig.docs-check.json
@@ -5,8 +5,7 @@
   // every published tarball). Their own program, never built.
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": true,
-    "declaration": false
+    "noEmit": true
   },
   "include": ["src/**/*.docs-check.ts"]
 }

--- a/packages/vendo/tsconfig.docs-check.json
+++ b/packages/vendo/tsconfig.docs-check.json
@@ -1,0 +1,12 @@
+{
+  // The docs-parity fixtures. They assert that what `docs/` publishes IS the
+  // shipped type surface, so they must be typechecked — but they are test
+  // scaffolding, so they must not be emitted into `dist` (and from there into
+  // every published tarball). Their own program, never built.
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false
+  },
+  "include": ["src/**/*.docs-check.ts"]
+}

--- a/packages/vendo/tsconfig.json
+++ b/packages/vendo/tsconfig.json
@@ -5,5 +5,14 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.test-util.ts", "src/**/__fixtures__/**"]
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.test-util.ts",
+    "src/**/__fixtures__/**",
+    // Docs-parity fixtures: typechecked by tsconfig.docs-check.json (see the
+    // `typecheck` script), never emitted — they would otherwise ship dead
+    // declarations in every published tarball.
+    "src/**/*.docs-check.ts"
+  ]
 }


### PR DESCRIPTION
`docs/quickstart.md` is the first code a Vendo host ever pastes, and it had drifted from every surface it documents. This fixes the doc and adds a test so it cannot drift silently again.

## The rot, and what it is now

**1. The registry example imported a package a host cannot resolve.**
`import type { ComponentRegistry } from "@vendoai/core"` — `@vendoai/core` is transitive, so under pnpm strict linking a host that installed only `@vendoai/vendo` gets TS2307. The CLI's own scaffold imports it from `@vendoai/vendo` for exactly this reason ([`init-scaffolds.ts:46-52`](https://github.com/runvendo/vendo/blob/main/packages/vendo/src/cli/init-scaffolds.ts#L46-L52)). The doc now shows the scaffold's import and says why in one paragraph.

**2. The primary route example pinned a deprecated key.**
It pinned `model: anthropic(...)` and mentioned `paint:`; `CreateVendoConfig` marks both `@deprecated`, superseded by `models: ModelsConfig`. The primary example is now the init scaffold **verbatim** (no model line — the composed default resolves a key from the environment), with the current pin surface beside it:

```ts
models: { agent: "claude-sonnet-4-6" },
```

The `@ai-sdk/anthropic` install requirement was also wrong: `@ai-sdk/anthropic` is a real dependency of `@vendoai/vendo`, and `importHostModule` falls back to vendo's own copy for `@ai-sdk/*` specifiers. So the string form needs no host install on the Anthropic and Cloud rungs; only a BYO model **object** does. The doc now says that.

**3. The config-surface listing was wrong in three ways at once.**
It omitted nine real keys — including `knowledge` and `apps`, which its own prose referenced 100+ lines later — pulled types from six transitive packages a host cannot import, and dropped `guardedTools` from the `Vendo` interface. It is now regenerated from the actual `CreateVendoConfig` (all 30 keys, `model`/`paint` marked deprecated), with an import block that names only `@vendoai/vendo`, `@vendoai/vendo/server`, and `ai`.

**4. The intro described an init that no longer exists.**
It said init "writes two code files", "prints the one line that is yours to paste", and "never edits code you wrote". Init writes three code files plus the server-action map, makes one bounded `app/layout.tsx` edit itself, and the paste is the *degraded fallback* — which the doc's own §322 already admitted. The intro now matches `init.ts`, including the `.vendo/` artifacts and the two `package.json` hooks.

**5. `vendo try` was buried at line 61.** The zero-install look is now the first section.

Also: `--framework <next|express>` → `<next|express|custom>` in the non-interactive section, and the doc's client-mount section is now the generated `vendo/vendo-root.tsx` instead of a hand-rolled `Root` that nothing writes.

## The parity test (the load-bearing part)

New `packages/vendo/src/cli/quickstart.docs.test.ts`, patterned on `doctor-codes.docs.test.ts`. Seven checks, all mechanical:

| Check | Fails when |
| --- | --- |
| registry block vs `registrySource("tsx")` | the scaffold's import specifier changes |
| route block vs `routeSource(...)` | any load-bearing scaffold line changes (exact line-for-line) |
| client-mount block vs `vendoRootWrapperSource(...)` | same, for the wrapper |
| config listing vs `CreateVendoConfig` | a key is added, removed, reordered, or its `@deprecated` mark moves |
| `Vendo` listing vs the `Vendo` interface | a member is added or removed |
| every `@vendoai/*` specifier in a code block | the doc tells a host to import a transitive package |
| every composition example | a `model:` or `paint:` pin comes back |

Plus the doc's import block is **compiled inside the test file**, so a renamed or removed umbrella export breaks `pnpm typecheck` rather than the reader.

### Mutation check

Each check was proven to bite, then reverted:

| Mutation | Result |
| --- | --- |
| `routeSource`: `policy: {}` → `policy: "cautious"` | ❌ route block test fails, diffing the exact line |
| `registrySource`: import from `@vendoai/core` | ❌ two tests fail (parity + transitive-import) |
| `server.ts`: add a `brandNewKey?: string` config key | ❌ config-key test fails, 30 vs 31 |
| `server.ts`: delete `guardedTools` from `Vendo` | ❌ `Vendo` member test fails, 10 vs 9 |
| doc: drop the `@deprecated` mark on `model` | ❌ config-key test fails on the flag |
| doc: reintroduce `model: anthropic(...)` | ❌ deprecated-pin test fails, naming the line |

All reverted; `git status` clean of mutations before commit.

## Two CLI copy fixes

- `--yes` claimed only "skip the cloud-login offer". It also accepts the detected auth preset, skips AI polish and the theme review, and swaps the interactive success screen for the agent tail.
- `--framework` help listed `next, express`; `custom` has been valid all along (`INIT_FRAMEWORK_VALUES`).
- `vendo login`'s transient-failure catch printed the raw `error.message` and nothing else, so the reader assumed the ceremony was lost and started over — abandoning an approval that would still have landed. It now names the surviving pairing code and says a re-run resumes the same request, gated on a claim that actually survived and has not expired (every terminal outcome already deletes it, so the line never lies).

## Gate

- `pnpm build` ✅
- `pnpm typecheck` ✅ (41/41)
- `pnpm lint` ✅ (dependency-guard, portability-gate, eslint — force-run, not cached)
- `pnpm test` — 51/53 tasks green. Two pre-existing environmental failures, **identical on `origin/main` in this worktree**, unrelated to this diff:
  - `@vendoai/vendo` — 2 tests in `src/dev-creds/model.test.ts` ("provider module resolution"): `@ai-sdk/anthropic` does not resolve from vendo's own module context in this worktree's node_modules layout. Measured failing at baseline with the branch stashed. The other **1478 tests pass**, including the 7 new ones.
  - `demo-accounting` — `src/vendo/login-e2e.test.ts` needs a live Supabase/GoTrue; it passes when the container is up and fails when it is not, independent of this branch (which touches nothing demo-accounting runs).

No test files were edited — only the new one added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings the quickstart doc back in sync with the shipped scaffolds and types, compiles the published config surface to prevent drift, and makes `vendo init --yes` non-blocking by queueing loosening proposals instead of prompting.

- **Bug Fixes**
  - Quickstart examples now match `init` scaffolds verbatim: registry imports `ComponentRegistry` from `@vendoai/vendo`, the route uses `models` (no deprecated `model`/`paint`), and the client mount shows `vendo/vendo-root.tsx`.
  - Config listing rebuilt from the real `CreateVendoConfig`/`Vendo`: all keys included (adds `knowledge`, `apps`, `theme`, `brief`, `connectorApps`, `approvals`, `profileDir`, `profile`, `fetch`), `guardedTools` present, and closed shapes for `mcp.remoteAs`/`federation` and `apps.pipeline`.
  - Intro matches current `vendo init`: consent prompts listed (auth preset, Cloud offer, AI polish, loosenings review, theme value, zod bump, star), one bounded layout edit, full file set, and `createVendo({})` boots (no-arg throws).
  - CLI help: `--yes` describes all effects and now never blocks on the loosening review; unattended runs queue loosenings as pending and print `vendo sync --review` with a reason. `--framework` lists `custom`. `vendo login` prints the surviving pairing code and resume guidance on transient failures.

- **Refactors**
  - Added `packages/vendo/src/cli/quickstart.docs.test.ts` and compiled fixture `quickstart-config-surface.docs-check.ts`: the doc’s config block is typechecked against real types; the test asserts the doc stays byte-identical, forbids transitive `@vendoai/*` imports and deprecated `model`/`paint` pins, and anchors import rewrites to declarations. New `tsconfig.docs-check.json` typechecks fixtures without emitting; `typecheck` runs both programs.
  - Simplified the parity gate: replaced the interface parser with regex scans, merged per-interface key-set tests, dropped a redundant “must import from <specifier>” check (byte identity over anchored import lines already proves it), read markdown once per test file, and folded the queued-loosening message assertion into the `--yes` test. Minor `tsconfig.docs-check.json` cleanup.
  - Added `packages/vendo/src/cli/init-judgment.unattended.test.ts` to pin that `--yes` and non-TTY runs queue loosenings and never forward a confirm seam.
  - `@vendoai/vendo` re-exports `ServerActionHandler` so the copied config block typechecks.

<sup>Written for commit 4693681ccf0b23229e356f8027364521c1b6518c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

