### PR TITLE
demo-creator: stop guessing motion from static screenshots

### DIFF
--- a/bench/src/demo-creator/brief.test.ts
+++ b/bench/src/demo-creator/brief.test.ts
@@ -208,11 +208,22 @@ describe("parseBriefReply colours", () => {
     expect(theme.colors.surface).toBe("#FFFFFF");
   });
 
-  it("produces a theme parseDemoTheme accepts, with the model's density and motion", () => {
+  it("produces a theme parseDemoTheme accepts, with the model's density", () => {
     const { theme } = parseBriefReply(reply(), parseOptions());
     expect(() => parseDemoTheme(theme)).not.toThrow();
     expect(theme.colors.accent).toBe("#1E6BFF");
     expect(theme.density).toBe("compact");
+    expect(theme.motion).toBe("full");
+  });
+
+  // A static screenshot carries no motion signal — the vision call is never
+  // asked for one, and even a reply that volunteers "reduced" (e.g. a stale
+  // fixture, or a model that ignores the schema) must not silence every
+  // built-in @vendoai/ui animation sitewide.
+  it("hardcodes motion to full regardless of what the model reply says", () => {
+    const parsed = JSON.parse(reply()) as Record<string, unknown>;
+    parsed["motion"] = "reduced";
+    const { theme } = parseBriefReply(JSON.stringify(parsed), parseOptions());
     expect(theme.motion).toBe("full");
   });
 

--- a/bench/src/demo-creator/brief.ts
+++ b/bench/src/demo-creator/brief.ts
@@ -30,8 +30,14 @@ import { causeLine, defaultJudgeModel, extractJsonObject, type JudgeImage, type 
  *
  * Everything else that can be measured IS measured: font family, body size and
  * radius come off the styleguide, not the model's eye. The model's own calls are
- * limited to what only eyes can decide — density, motion, and the structural
- * reading of the screenshots.
+ * limited to what only eyes can decide — density and the structural reading of
+ * the screenshots. Motion is NOT one of those: a static screenshot carries no
+ * motion signal, so asking the vision call to guess "full" vs "reduced" is
+ * asking it to hallucinate — it guessed "reduced" on more than half of every
+ * demo built so far, which zeroes out every built-in @vendoai/ui animation
+ * (VendoOverlay open/close, MorphToast, ...) sitewide. Motion is hardcoded
+ * "full" instead; a real prefers-reduced-motion accessibility need is already
+ * handled at runtime by the components themselves, not by a per-brand guess.
  */
 
 export interface BriefEntity {
@@ -245,8 +251,7 @@ Output ONLY a JSON object (no prose, no markdown fence), exactly this shape:
   "colors": {
 ${themeColorTokens.map((token) => `    "${token}": { "hex": "<EXACT hex from the list>", "reason": "<one line>" }`).join(",\n")}
   },
-  "density": "compact" | "comfortable",
-  "motion": "full" | "reduced"
+  "density": "compact" | "comfortable"
 }
 
 ALL record names and data are INVENTED — the evidence informs STYLE, never DATA.
@@ -257,7 +262,7 @@ button, the slot is the panel a generated view renders into, so it needs a
 content column — a row inside <main>, or a full-width band above a table or a
 stat strip. Never place it in a control row (a top bar, a filter/date cluster, a
 toolbar): those give it no width, and it is the panel, not the button, that goes
-there. "density"/"motion" are your read of the screenshots.`;
+there. "density" is your read of the screenshots.`;
 }
 
 // ---------------------------------------------------------------------------
@@ -409,9 +414,11 @@ export function parseBriefReply(
     typography: deriveTypography(options.evidence, themeNotes),
     radius: deriveRadius(options.evidence, themeNotes),
     density: parseEnum(parsed["density"], ["compact", "comfortable"] as const, "density"),
-    motion: parseEnum(parsed["motion"], ["full", "reduced"] as const, "motion"),
+    // Not a vision read: a static screenshot has no motion signal, so this is
+    // never asked of the model — see the module doc comment.
+    motion: "full",
   };
-  themeNotes.push(`density/motion: ${theme.density}/${theme.motion} — the vision call's read of the screenshots`);
+  themeNotes.push(`density: ${theme.density} — the vision call's read of the screenshots; motion: full (not derived from screenshots)`);
 
   const referenceScreenshot = requireString(parsed["referenceScreenshot"], "referenceScreenshot");
   if (!options.evidence.screenshots.some((shot) => shot.file === referenceScreenshot)) {


### PR DESCRIPTION
## Summary
- The brief's vision prompt asked the model to read `"motion": full|reduced` off a static screenshot — there's no motion signal in a static image, so it was guessing. Across the demo fleet's `theme.json`s it guessed `"reduced"` more than half the time (grafana, numbers, plausible, ramp-licenses, toggletravel, zelty).
- `"reduced"` sets `--vendo-motion-duration: 0ms`, which silences every built-in `@vendoai/ui` animation (`VendoOverlay` open/close, `MorphToast`, etc.) sitewide. Nothing was actually missing — it was switched off by a hallucinated read.
- `motion` is now hardcoded `"full"` and dropped from the vision prompt's schema entirely. Real `prefers-reduced-motion` accessibility support is already handled at runtime by the components themselves, independent of this per-brand guess.

## Test plan
- [x] `vitest run src/demo-creator/` — 464 passed, 1 pre-existing skip (`judge.live.test.ts`)
- [x] `tsc --noEmit` on `bench/`
- [x] Added a regression test asserting `motion` is hardcoded to `"full"` even if a model reply volunteers `"reduced"`
- [ ] Already-shipped demos with `motion: "reduced"` in their `theme.json` are unaffected by this PR (theme.json is fenced from `demo:fix` by design) — separately patched `toggletravel`'s `theme.json` by hand in the demos repo; the other 5 (grafana, numbers, plausible, ramp-licenses, zelty) are untouched and still reduced pending a similar one-off fix if wanted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop guessing motion from static screenshots by hardcoding `motion: "full"` so demos no longer disable `@vendoai/ui` animations due to bad reads.

- **Bug Fixes**
  - Removed `motion` from the vision prompt schema and guidance; only `density` is read from screenshots.
  - In `parseBriefReply`, set `motion` to `"full"` and update `themeNotes` to reflect it is not derived from screenshots.
  - Added a regression test to keep `motion` at `"full"` even if a model reply includes `"reduced"`.
  - Prevents sitewide animation suppression (`VendoOverlay`, `MorphToast`, etc.) caused by previous `"reduced"` guesses.

<sup>Written for commit 77107510c40153c4a8436402c878f77cca7750c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

