### PR TITLE
fix(vendo): the model ladder surfaces the resolved model id, so capability params see the real Claude family

### DIFF
--- a/.changeset/ladder-surfaces-resolved-model-id.md
+++ b/.changeset/ladder-surfaces-resolved-model-id.md
@@ -1,0 +1,22 @@
+---
+"@vendoai/vendo": patch
+---
+
+A model pinned to the Claude 5 line through the ladder generates again.
+
+`vendoModel()` hands back a lazily-resolving model, and its `modelId` was the
+seam's own placeholder — the literal `vendo-env` — until the rung resolved. But
+the id is not decoration: the generation engine reads it to decide HOW to make
+the call, and the Claude 5 line rejects `temperature` outright. A placeholder
+reads as "not a Claude model", so `VENDO_MODEL=claude-sonnet-5` with a provider
+key kept `temperature: 0` and every single generation came back
+``400 `temperature` is deprecated for this model``. Sonnet 4.6 hid it by
+accepting the parameter, which is why the default ladder never showed it.
+
+The wrapper now reports the rung it will actually call: the resolved model's own
+id once resolution has run, and before that the id resolution will pick, which
+the ladder can answer without waiting because credential detection is pure env
+reading. Nothing else moves — the same precedence chooses the id, the announce
+line still prints it, and a rung with no credential keeps the placeholder
+because there is no real id to give. Hosts on a sampling-era model see exactly
+what they saw before.

--- a/packages/apps/src/model-params.test.ts
+++ b/packages/apps/src/model-params.test.ts
@@ -217,3 +217,39 @@ describe("engine model calls (integration)", () => {
     for (const call of calls) expect(call.temperature).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #692: vendo's model ladder hands the engine a lazily-resolving wrapper whose
+// modelId is a GETTER over the resolved rung — the id is not a fixed string on
+// the object. The rule must read it at call time, per call, or a ladder pinned
+// to a Claude 5 rung keeps temperature: 0 and 400s. (The ladder half — that the
+// getter answers the real rung id — is pinned in
+// packages/vendo/src/dev-creds/model.test.ts.)
+// ---------------------------------------------------------------------------
+
+/** A recording model shaped like the ladder wrapper: the id is only knowable
+ *  through the getter, never as an own value on the object. */
+const laddered = (rungId: string): ReturnType<typeof recordingModel> => {
+  const { model, calls } = recordingModel("vendo-env");
+  Object.defineProperty(model, "modelId", { get: () => rungId });
+  return { model, calls };
+};
+
+describe("engine model calls behind the vendo model ladder", () => {
+  it("sends NO temperature when the ladder resolves to a Claude 5 rung", async () => {
+    const { model, calls } = laddered("claude-sonnet-5");
+    await createWith(model);
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      expect(call.temperature).toBeUndefined();
+      expect(call.maxOutputTokens).toBe(UNKNOWN_MODEL_MAX_OUTPUT_TOKENS);
+    }
+  });
+
+  it("still sends temperature: 0 when the ladder resolves to Sonnet 4.6", async () => {
+    const { model, calls } = laddered("claude-sonnet-4-6");
+    await createWith(model);
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) expect(call.temperature).toBe(0);
+  });
+});

--- a/packages/vendo/src/dev-creds/model.test.ts
+++ b/packages/vendo/src/dev-creds/model.test.ts
@@ -478,6 +478,55 @@ describe("vendoModel (the vendo model family entry)", () => {
     expect(await resolvedId(bound)).toBe("host-judge");
   });
 
+  // #692: the wrapper reported the literal "vendo-env" as its modelId, so
+  // @vendoai/apps' model-params (which reads model.modelId to decide whether
+  // the family still accepts `temperature`) saw a non-Claude id behind every
+  // ladder, kept temperature: 0, and every Claude 5 rung 400'd on the first
+  // call. The id has to be honest BEFORE resolution, which the pure env ladder
+  // can answer. The other half of the chain — the engine reading that id per
+  // call — is pinned in packages/apps/src/model-params.test.ts.
+  it("reports the pinned rung's real model id BEFORE the first call", () => {
+    const idOf = (model: LanguageModel): string => (model as unknown as { modelId: string }).modelId;
+    const pinned = vendoModel(undefined, {
+      env: { ANTHROPIC_API_KEY: "sk-a", VENDO_MODEL: "claude-sonnet-5" },
+      importModule: scriptedProvider("createAnthropic"),
+    });
+    expect(idOf(pinned)).toBe("claude-sonnet-5");
+    // Every other way the id is chosen answers the same way, unresolved.
+    expect(idOf(vendoModel("claude-opus-4-8", { env: { ANTHROPIC_API_KEY: "sk-a" } }))).toBe("claude-opus-4-8");
+    expect(idOf(vendoModel(undefined, { env: { ANTHROPIC_API_KEY: "sk-a" } }))).toBe("claude-sonnet-4-6");
+    expect(idOf(vendoModel(undefined, { slot: "paint", env: { OPENAI_API_KEY: "sk-o" } }))).toBe("gpt-5-mini");
+    expect(idOf(vendoModel(undefined, { env: { VENDO_API_KEY: "vnd_x" } }))).toBe("vendo");
+    // No credential, no real id: the placeholder stays, and no call succeeds.
+    expect(idOf(vendoModel(undefined, { env: {} }))).toBe("vendo-env");
+  });
+
+  it("keeps reporting the id it actually called the provider with", async () => {
+    const model = vendoModel(undefined, {
+      env: { ANTHROPIC_API_KEY: "sk-a", VENDO_MODEL: "claude-sonnet-5" },
+      importModule: scriptedProvider("createAnthropic"),
+    });
+    expect(await resolvedId(model)).toBe("claude-sonnet-5");
+    expect((model as unknown as { modelId: string }).modelId).toBe("claude-sonnet-5");
+    // A binding that arrives late cannot rewrite the id already in flight.
+    bindVendoModelSlots(model, { judge: "vendo-strong" });
+    expect((model as unknown as { modelId: string }).modelId).toBe("claude-sonnet-5");
+  });
+
+  it("reports a bound explicit model object's own id", () => {
+    const explicit = {
+      specificationVersion: "v3",
+      provider: "host",
+      modelId: "host-judge",
+      supportedUrls: {},
+      doGenerate: async () => ({ modelId: "host-judge" }),
+      doStream: async () => ({ modelId: "host-judge" }),
+    } as unknown as LanguageModel;
+    const bound = vendoModel("vendo-judge", { env: { VENDO_API_KEY: "vnd_x" } });
+    bindVendoModelSlots(bound, { judge: explicit });
+    expect((bound as unknown as { modelId: string }).modelId).toBe("host-judge");
+  });
+
   it("binding a BYO model object (not a vendoModel instance) is a no-op", () => {
     const byo = {
       specificationVersion: "v3",

--- a/packages/vendo/src/dev-creds/model.ts
+++ b/packages/vendo/src/dev-creds/model.ts
@@ -6,6 +6,7 @@ import type { LanguageModel } from "ai";
 import { resolveCloudBaseUrl } from "../cli/cloud/client.js";
 import {
   describeDevCredential,
+  detectDevCredential,
   resolveDevCredential,
   type DevCredential,
   type EnvKeyProvider,
@@ -265,6 +266,7 @@ export class DevModelController {
   private readonly slot: VendoModelSlot;
   private readonly name: string | undefined;
   private resolution: Promise<Resolution> | null = null;
+  private resolvedModelId: string | undefined;
   private announced = false;
   /** Per-instance slot config bound by createVendo (bindVendoModelSlots). */
   private slotModels: ConfigurableSlotModels = {};
@@ -302,9 +304,34 @@ export class DevModelController {
   resolve(): Promise<Resolution> {
     this.resolution ??= this.resolveOnce().then((resolution) => {
       if (resolution.mode === "unavailable") console.error(`[vendo] ${resolution.message}`);
+      else this.resolvedModelId = resolution.model.modelId;
       return resolution;
     });
     return this.resolution;
+  }
+
+  /** The model id this instance calls — the resolved rung's own id once
+   *  resolution has run, and before that the id resolution WILL pick, which
+   *  the pure env ladder can answer synchronously (detectDevCredential).
+   *
+   *  It has to be answerable BEFORE the first call, because that call is
+   *  composed from it: @vendoai/apps reads `model.modelId` to decide whether
+   *  the family still accepts `temperature`. A placeholder id there reads as
+   *  "not a Claude model", so a ladder pinned to a Claude 5 rung kept
+   *  `temperature: 0` and every generation 400'd.
+   *
+   *  Undefined only when there is no credential to resolve at all — the
+   *  wrapper keeps its placeholder id, and no call can succeed anyway. */
+  get modelId(): string | undefined {
+    if (this.resolvedModelId !== undefined) return this.resolvedModelId;
+    const configured = this.configured;
+    if (configured !== undefined && typeof configured !== "string") {
+      return (configured as { modelId?: string }).modelId;
+    }
+    const credential = detectDevCredential({ env: this.env });
+    if (credential.rung === "env-key") return this.pickModelId(DEFAULT_MODELS[credential.provider]!);
+    if (credential.rung === "vendo-cloud") return this.pickModelId(CLOUD_MODEL);
+    return undefined;
   }
 
   private announce(line: string): void {
@@ -317,7 +344,7 @@ export class DevModelController {
   /** The string-tier model id for the resolved rung. Precedence (spec §DX
    *  surfaces): env pin → deprecated agent-slot pin → configured slot string
    *  (models.judge) → the verbatim name → the per-rung slot default. */
-  private modelId(spec: ProviderSpec): string {
+  private pickModelId(spec: ProviderSpec): string {
     const pin = nonBlank(this.env[SLOT_PIN_ENV[this.slot]]);
     if (pin !== undefined) return pin;
     if (this.slot === "agent") {
@@ -352,7 +379,7 @@ export class DevModelController {
     const factory = loaded[spec.factory] as (
       config: { apiKey: string; baseURL?: string },
     ) => (model: string) => LanguageModelV3Like;
-    const modelId = this.modelId(spec);
+    const modelId = this.pickModelId(spec);
     const model = factory(config)(modelId);
     this.announce(`${describeDevCredential(credential)} → ${modelId}${announceSuffix}`);
     return { mode: "delegate", model, credential };
@@ -467,12 +494,18 @@ function rejectedKey(credential: DevCredential | undefined, error: unknown): Ven
   return undefined;
 }
 
-function lazyModel(controller: DevModelController, provider: string, modelId: string): LanguageModel {
+function lazyModel(controller: DevModelController, provider: string, placeholder: string): LanguageModel {
   const model: LanguageModelV3Like = {
     specificationVersion: "v3",
     // The lazy IDENTITY is vendo's own by design (the family name is the seam).
     provider,
-    modelId,
+    // The model ID is NOT: a caller composing this call decides how to call it
+    // from the id (sampling params, above all), so it has to name the resolved
+    // rung, not the seam. A getter because the rung resolves lazily; the
+    // placeholder survives only where there is no credential and so no real id.
+    get modelId() {
+      return controller.modelId ?? placeholder;
+    },
     // CAPABILITY, though, must be the resolved provider's: the SDK reads
     // supportedUrls to decide whether a remote image/PDF is ingested natively
     // or downloaded first, so answering "none" makes callers fetch files the

--- a/packages/vendo/src/dev-creds/resolve.ts
+++ b/packages/vendo/src/dev-creds/resolve.ts
@@ -40,6 +40,16 @@ function present(env: Record<string, string | undefined>, name: string): boolean
 export async function resolveDevCredential(
   options: ResolveDevCredentialOptions = {},
 ): Promise<DevCredential> {
+  return detectDevCredential(options);
+}
+
+/** The same detection, without the awaitable seam: nothing here touches the
+ *  network or the disk, so the rung — and with it the model id the ladder will
+ *  call — is knowable synchronously. The lazy model wrapper needs exactly that
+ *  to answer `modelId` honestly before its first call (dev-creds/model.ts). */
+export function detectDevCredential(
+  options: ResolveDevCredentialOptions = {},
+): DevCredential {
   const env = options.env ?? process.env;
 
   const pinned = env["VENDO_DEV_CREDENTIAL"]?.trim();


### PR DESCRIPTION
Fixes #692.

## What broke

`vendoModel()` hands back a lazily-resolving model. Its `modelId` was the seam's
own placeholder — the literal `vendo-env` — and it stayed that way forever,
because nothing ever wrote the resolved rung's id back onto the wrapper.

That id is not decoration. `packages/apps/src/model-params.ts` reads
`model.modelId` to decide HOW to make the call: the Claude 5 line removed the
sampling parameters and rejects `temperature` outright. `claudeToken("vendo-env")`
finds no Claude token, so the rule took the non-Claude branch, kept
`temperature: 0`, and the resolved Claude 5 rung answered:

```
[vendo] gen pipeline full attempt=0 valid=false issues=model generation failed: `temperature` is deprecated for this model. ms=268
```

Every create, edit, repair and verify pass, on the first request. Observed live
2026-07-29 on a prospect demo with `VENDO_MODEL=claude-sonnet-5` and an explicit
`ANTHROPIC_API_KEY`. Sonnet 4.6 masks it by still accepting `temperature`, which
is why default-ladder hosts never saw it.

## The fix

The wrapper reports the rung it will actually call.

`modelId` is now a getter over the controller. It answers the resolved model's
own id once resolution has run, and before that the id resolution WILL pick —
which the ladder can answer without waiting, because credential detection is
pure env reading with no network and no disk. `resolveDevCredential` keeps its
awaitable seam and delegates to a new synchronous `detectDevCredential`.

That mattered for the timing: capability params are computed while COMPOSING the
first call, before any resolution has happened. A getter that only became honest
after the first call would still have 400'd on that first call — the only one
that matters here.

Fixing the id rather than stripping parameters inside `doGenerate` was the call
because the id is what everything downstream reasons from. Stripping would put a
second copy of the sampling policy behind the ladder, would silently drop a
caller's explicit `temperature` (which `explicitSamplingParams` deliberately
throws on), and would leave every other reader — error messages, the output cap,
logs — still looking at `vendo-env`.

## What does not change

- The same precedence picks the id (env pin → deprecated pin → configured string
  → verbatim name → per-rung default); only the reporting is new.
- `describeDevCredential` announce lines still print the real id, from the same
  code path as before.
- A rung with no credential keeps the placeholder — there is no real id, and no
  call can succeed anyway.
- Non-ladder callers are untouched: nothing in `model-params.ts` moved. Ladder
  hosts on the default rungs resolve to `claude-sonnet-4-6` / `vendo` / `gpt-5`,
  all of which take sampling, so they get exactly today's `temperature: 0`.

## Tests

Both halves of the chain, each pinned in its own package (`model-params` is
internal to `@vendoai/apps`, and widening that package's public API for a test
is not worth it):

- `packages/vendo/src/dev-creds/model.test.ts` — the ladder reports
  `claude-sonnet-5` BEFORE the first call under
  `ANTHROPIC_API_KEY` + `VENDO_MODEL=claude-sonnet-5`, keeps reporting the id it
  actually called the provider with, answers a bound explicit model object's own
  id, and still falls back to the placeholder with no credential. This is the
  test that fails on `main`.
- `packages/apps/src/model-params.test.ts` — the REAL engine, driven with a
  recording model shaped like the ladder wrapper (id readable only through a
  getter): a Claude 5 rung sends NO temperature and an explicit output cap, a
  Sonnet 4.6 rung still sends `temperature: 0`.

No existing test was modified.

## Gates

- `pnpm --filter @vendoai/vendo test` — 1511 passed, 15 skipped
- `pnpm --filter @vendoai/apps test` — 773 passed, 18 skipped
- `pnpm build`, `pnpm typecheck`, `pnpm lint` (dependency guard + portability
  gate included) — green

No UI surface is touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where `vendoModel()` exposed the placeholder id `vendo-env`, causing `@vendoai/apps` to treat Claude 5 as non-Claude and send `temperature: 0` (400 errors). The ladder now surfaces the resolved rung’s model id before the first call so sampling params are correct for the Claude 5 family.

- **Bug Fixes**
  - `modelId` on the ladder wrapper is now a getter that returns the resolved rung id, or the id chosen via sync env-based detection before the first call.
  - Introduced `detectDevCredential` (sync); `resolveDevCredential` now delegates to it so the id can be known without awaiting.
  - If no credential is present, the placeholder remains and no call succeeds. Tests in `@vendoai/vendo` and `@vendoai/apps` pin the pre-call id and parameter behavior (no `temperature` for Claude 5; `temperature: 0` for Sonnet 4.6).

<sup>Written for commit ca39ad6bb2c06512870ca6d31b0bcbad9814e135. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

