### PR TITLE
fix(demo): maple demo polish — bullets, approval card, automations discoverability, connect honesty

### DIFF
--- a/apps/demo-bank/src/components/vendo/VendoRoot.tsx
+++ b/apps/demo-bank/src/components/vendo/VendoRoot.tsx
@@ -1,10 +1,24 @@
 "use client";
 
 import { useCallback, type ReactNode } from "react";
-import { VendoRoot as UmbrellaVendoRoot } from "@vendoai/vendo/react";
+import { VendoRoot as UmbrellaVendoRoot, type ToolMetaMap } from "@vendoai/vendo/react";
 import { mapleRegistry } from "@/vendo/registry";
 import { mapleTheme } from "@/vendo/theme";
 import { mapleRealtimeVoiceDriver } from "./voice-realtime";
+
+const usd = (cents: number) =>
+  `$${(cents / 100).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+/** Approval-card presentation for Maple's own money tool: the authored title
+ *  and cents → dollars on the amount field. Display-only — the raw args still
+ *  drive the decision hash (raw value stays on the field's tooltip). */
+const mapleToolMeta: ToolMetaMap = {
+  host_transferMoney: {
+    label: "Send money",
+    formatField: (key, value) =>
+      key === "amount" && typeof value === "number" ? usd(value) : undefined,
+  },
+};
 
 export function VendoRoot({
   children,
@@ -28,6 +42,7 @@ export function VendoRoot({
       theme={mapleTheme}
       voice={{ driver: mapleRealtimeVoiceDriver }}
       onPin={onPin}
+      tools={mapleToolMeta}
     >
       {/* VENDO-MIGRATION: thread selection moved from the provider to each
           thread surface in 08-ui §3; callers retain the prop during migration. */}

--- a/apps/demo-bank/src/vendo/server.ts
+++ b/apps/demo-bank/src/vendo/server.ts
@@ -49,6 +49,7 @@ export const vendo = createVendo({
       "No emojis, ever — not in prose, not in generated UI text.",
       "Format money as currency (e.g. $1,234.56), never raw cents.",
       "When you render a view, let it carry the data — don't restate it in prose.",
+      "For a recurring or scheduled payment/task, use vendo_apps_create (or vendo_apps_edit on an existing app) — describe the schedule in the prompt; the automation is armed automatically. There is no separate automations tool.",
     ].join("\n"),
   },
   // execution-v2 Waves 4+9 — the layer-2 (machines) and layer-3 (served apps)

--- a/packages/agent/src/prompt.ts
+++ b/packages/agent/src/prompt.ts
@@ -35,7 +35,7 @@ const PRESENTATION_PROMPT = `Presentation
 // side-quest of searches, speculative unconnected calls, and approval spam.
 const DISCOVERY_BUDGET_PROMPT = `Discovery budget
 - Use vendo_tools_search at most 2 times per user intent; prefer the host's own tools whenever they can fulfill the ask.
-- Never call a tool for a service you know is unconnected. A connect-required result means stop calling that service: tell the user what it needs and point them to the connect card that appeared.
+- Never call a tool for a service you know is unconnected. A connect-required result means stop calling that service: tell the user what it needs. A connect card appears with that result on that turn only — on later turns, point the user to the connect (link) button in the message box instead; never claim a card "should have appeared".
 - When a needed service is unconnected, say so plainly and surface the connect step — do not try other tools of the same service or hunt for substitutes across the catalog.`;
 
 /** 03-agent §3: company directions are mandatory policy context and fail closed. */

--- a/packages/apps/src/agent-tools.ts
+++ b/packages/apps/src/agent-tools.ts
@@ -25,7 +25,7 @@ const descriptors: ToolDescriptor[] = [
     // Empty-states batch — calling agents were pre-computing data into the
     // prompt ("Total Spent: $0.00"), which the engine's data-honesty law
     // rejects as hand-typed figures; the app binds live host data itself.
-    description: "Create a Vendo app from a natural-language prompt. Pass the user's request (with any clarifying context) as the prompt. Never bake data values you computed or fetched (counts, totals, amounts) into the prompt — the app binds live host data itself and hardcoded figures fail its build. Never specify fonts, colors, or branding — the app inherits the host theme.",
+    description: "Create a Vendo app from a natural-language prompt — including a recurring or scheduled task (e.g. a recurring payment, a daily digest): describe the schedule and the action in the prompt and the automation is armed as part of the same call; no separate automations tool exists. Pass the user's request (with any clarifying context) as the prompt. Never bake data values you computed or fetched (counts, totals, amounts) into the prompt — the app binds live host data itself and hardcoded figures fail its build. Never specify fonts, colors, or branding — the app inherits the host theme.",
     inputSchema: {
       $schema: DRAFT_2020_12,
       type: "object",
@@ -40,7 +40,7 @@ const descriptors: ToolDescriptor[] = [
   },
   {
     name: "vendo_apps_edit",
-    description: "Edit an existing Vendo app with one natural-language instruction. If the result has failure.retryable=true, retry vendo_apps_edit on the same appId with a narrower instruction; do not rebuild it with vendo_apps_create.",
+    description: "Edit an existing Vendo app with one natural-language instruction — this is also how you add or change a recurring/scheduled automation on an app (e.g. \"send this every hour\"). If the result has failure.retryable=true, retry vendo_apps_edit on the same appId with a narrower instruction; do not rebuild it with vendo_apps_create.",
     inputSchema: {
       $schema: DRAFT_2020_12,
       type: "object",

--- a/packages/ui/src/chrome/approval-card.tsx
+++ b/packages/ui/src/chrome/approval-card.tsx
@@ -1,20 +1,24 @@
-import { canonicalJson, sha256Hex, type ApprovalDecision, type ApprovalRequest } from "@vendoai/core";
+import { canonicalJson, sha256Hex, type ApprovalDecision, type ApprovalRequest, type Json } from "@vendoai/core";
 import { useState } from "react";
 import { useVendoTools } from "../context.js";
 import { ContainedNotice } from "../tree/notice.js";
 import { toolPresentation } from "./build-beat.js";
 import { ChromeRoot } from "./chrome-root.js";
+import { humanizeToolName, type ToolMeta } from "./humanize.js";
 
-/** Flat, primitive-valued args render as aligned field rows; anything nested
-    falls back to the raw JSON preview (real inputs, always). */
-function flatFields(args: unknown): Array<[string, string]> | undefined {
+/** Flat, primitive-valued args render as aligned field rows — humanized label,
+    host-formatted value (ToolMeta.formatField), raw value on the tooltip so
+    the real input stays one hover away; anything nested falls back to the raw
+    JSON preview (real inputs, always). */
+function flatFields(args: unknown, meta?: ToolMeta): Array<[string, string, string]> | undefined {
   if (typeof args !== "object" || args === null || Array.isArray(args)) return undefined;
   const entries = Object.entries(args as Record<string, unknown>);
   if (entries.length === 0 || entries.length > 8) return undefined;
-  const rows: Array<[string, string]> = [];
+  const rows: Array<[string, string, string]> = [];
   for (const [key, value] of entries) {
     if (value !== null && typeof value === "object") return undefined;
-    rows.push([key, String(value)]);
+    const raw = String(value);
+    rows.push([humanizeToolName(key), meta?.formatField?.(key, value as Json) ?? raw, raw]);
   }
   return rows;
 }
@@ -75,7 +79,7 @@ export function ApprovalCard({ approval, onDecide, allowRemember = true, showCon
   );
   const title = presentation.title;
   const description = (presentation.description ?? approval.descriptor.description).trim();
-  const fields = flatFields(approval.call.args);
+  const fields = flatFields(approval.call.args, meta);
   // Lane pick 1-A — consequence-first: when the presentation can truthfully
   // say what approving does in one sentence, that sentence leads and the raw
   // fields fold behind a "Details" disclosure (still the same real inputs,
@@ -164,10 +168,10 @@ export function ApprovalCard({ approval, onDecide, allowRemember = true, showCon
         {(() => {
           const inputs = fields ? (
             <dl className="fl-approval-fields" aria-label="Real tool inputs" style={{ display: "grid", gap: "7px", margin: 0 }}>
-              {fields.map(([key, value]) => (
-                <div className="fl-approval-field" key={key}>
-                  <dt>{key}</dt>
-                  <dd>{value}</dd>
+              {fields.map(([label, value, raw]) => (
+                <div className="fl-approval-field" key={label}>
+                  <dt>{label}</dt>
+                  <dd title={raw === value ? undefined : raw}>{value}</dd>
                 </div>
               ))}
             </dl>

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -366,7 +366,11 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the wave-2
 .fl-md > :first-child { margin-top: 0; }
 .fl-md > :last-child { margin-bottom: 0; }
 .fl-md p { margin: 0 0 8px; }
+/* Explicit list-style: host CSS resets (Tailwind preflight) set none globally
+   and the thread renders in the host's cascade, eating the bullets. */
 .fl-md ul, .fl-md ol { margin: 0 0 8px; padding-left: 20px; }
+.fl-md ul { list-style: disc; }
+.fl-md ol { list-style: decimal; }
 .fl-md li { margin: 2px 0; }
 .fl-md li > p { margin: 0; }
 .fl-md h1, .fl-md h2, .fl-md h3, .fl-md h4 { margin: 10px 0 6px; font-weight: 650; line-height: 1.3;

--- a/packages/ui/src/chrome/humanize.ts
+++ b/packages/ui/src/chrome/humanize.ts
@@ -19,6 +19,10 @@ export interface ToolMeta {
   description?: string;
   /** Custom one-line argument summary for the tool chip. */
   summarize?(args: Json): string | undefined;
+  /** Display formatting for one approval-card field value (e.g. integer cents
+      → "$500.00"). Return undefined to keep the raw value. Display-only: the
+      raw args still drive the decision hash and the exact-input grant. */
+  formatField?(key: string, value: Json): string | undefined;
 }
 
 export type ToolMetaMap = Record<string, ToolMeta>;

--- a/packages/ui/test/chrome/approval-and-notice.test.tsx
+++ b/packages/ui/test/chrome/approval-and-notice.test.tsx
@@ -47,7 +47,7 @@ describe("ApprovalCard and NoPolicyNotice exports", () => {
       row.querySelector("dt")?.textContent,
       row.querySelector("dd")?.textContent,
     ]);
-    expect(rows).toEqual([["invoiceId", "inv_42"], ["permanent", "true"]]);
+    expect(rows).toEqual([["Invoice id", "inv_42"], ["Permanent", "true"]]);
     expect(screen.getByText("destructive").getAttribute("data-risk")).toBe("destructive");
     fireEvent.click(screen.getByRole("button", { name: "Approve" }));
     await waitFor(() => expect((screen.getByRole("button", { name: "Deny" }) as HTMLButtonElement).disabled).toBe(false));


### PR DESCRIPTION
Pre-demo fix wave (live demo imminent — Yousef merging directly).

## What
1. **Markdown bullets missing in the thread** — `.fl-md ul/ol` never set `list-style`; the host's Tailwind preflight resets it to `none` and the thread renders in the host cascade. Now explicit `disc`/`decimal`.
2. **Approval card raw fields** — field labels are now humanized (`recipient_name` → "Recipient name") and a new optional `ToolMeta.formatField(key, value)` seam lets the host format a value for display (raw value stays on the tooltip; the decision hash and exact-input grant still use the raw args). Maple uses it: `amount` integer cents → `$100.00`, plus the authored "Send money" label.
3. **"No automations tool"** — the model truthfully reported it couldn't create recurring payments because nothing told it `vendo_apps_create`/`vendo_apps_edit` arm schedules (the runtime's escalation ladder already does). Tool descriptions now say so; Maple's instructions add a one-line pointer.
4. **Connect-card honesty** — the discovery-budget prompt told the model to "point them to the connect card that appeared" forever, but the in-thread card is one-shot by design and Maple's overlay has only the composer link button as a standing surface. The prompt now points there on later turns and forbids claiming a card "should have appeared".

## Test change (stated out loud)
`packages/ui/test/chrome/approval-and-notice.test.tsx` — the field-row assertion updated from raw keys to the humanized labels the card now renders.

## Verification
- `pnpm build` / `typecheck` / `lint` green; targeted tests green: @vendoai/ui (80), @vendoai/apps (63), @vendoai/agent (24), @vendoai/vendo (125), demo-bank (22). Remaining full-suite failures are pre-existing env-dependent e2e fixtures (Supabase login etc.), untouched by this diff.
- Browser verification happening post-merge on the redeployed maple.vendo.run (demo constraint); the deployed site is currently serving a stale build that also predates #682's generating-card fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the Maple demo for clearer UI and more accurate guidance. Restores markdown bullets, improves Approval card fields, clarifies schedules via `vendo_apps_create`/`vendo_apps_edit`, and updates connect messaging.

- **New Features**
  - Approval card: humanized field labels and a host hook `ToolMeta.formatField` for display formatting; raw values stay on the tooltip and drive approvals.
  - Maple adds ToolMeta for `host_transferMoney` (“Send money”; amount cents → "$X.XX").
  - Clarifies automations: schedules are created/edited via `vendo_apps_create` and `vendo_apps_edit`; no separate automations tool.

- **Bug Fixes**
  - Restores bullet points in thread markdown by explicitly setting `list-style` on `.fl-md ul/ol`.
  - Connect guidance: prompt no longer claims a card appears on later turns; points to the composer connect button instead.

<sup>Written for commit 23f4d686e63f30b895c79ad10811efa8b14fee27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

