### PR TITLE
docs(readme): plain-language GEO pass on the top section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@
 </p>
 
 <p align="center">
-  Vendo puts an agent inside your product: customers build views, act through your APIs, and automate work, inside your brand and guardrails.
+  Vendo embeds an agent in your product that lets every customer automate their work, build their own views, and connect their tools, inside your brand and your guardrails.
+</p>
+
+<p align="center">
+  Vendo is for B2B SaaS teams whose customers keep asking for bespoke features. It is an <b>embedded agent</b>: it acts through your product's own API as the signed-in user, and renders the UI it generates in a sandboxed, brand-native surface. Your source code is never touched. Learn more at <a href="https://vendo.run">vendo.run</a>, or read the docs at <a href="https://docs.vendo.run">docs.vendo.run</a>.
 </p>
 
 <p align="center">


### PR DESCRIPTION
## What

Rewrites only the intro paragraph block at the top of `README.md`:

- Uses the vendo.run homepage meta description **verbatim** as the lead sentence, so the README, the site, and the `sameAs` entity graph all say the same thing.
- Adds one plain declarative paragraph: who Vendo is for, the category term ("embedded agent"), and how it works, with links to https://vendo.run and https://docs.vendo.run.

Everything below the header block is untouched. Net +5/-1 lines.

## Why

Part of the SEO/GEO wave (Workstream 3, off-site consistency pass). AI answer engines and Google both read this README as a primary source on "what is Vendo" — it is the #1 starred surface we own. It previously paraphrased the positioning in its own words, which fragmented the entity instead of reinforcing it. Consistent, quotable, declarative sentences are what GEO engines extract.

## Verification

- [x] Docs-only change — no build/test/typecheck/lint surface touched
- [x] Markdown/HTML header block renders as before (same `<p align="center">` pattern, same order)
- [ ] Screenshots attached (if UI-affecting) — n/a, no UI change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the README intro with the homepage meta description and adds a short paragraph that states the audience (B2B SaaS), the “embedded agent” category, how it works, and links to the site and docs. Improves GEO/SEO consistency across surfaces; no other content changed.

<sup>Written for commit 7b1df3331f7bd5d2c13b9b67fa19db5cba258f85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

