### PR TITLE
fix(tsconfig): add "types" field for Node.js type definitions

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types":["node"],
     "strict": true,
     "declaration": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## What
updates the TypeScript configuration to explicitly support Node.js built-in modules like `node:child_process`.

## Why
The project was throwing a TypeScript compilation error: `Cannot find name 'node:child_process'. Do you need to install type definitions for node?`. Because pnpm uses strict dependency resolution, TypeScript cannot automatically infer or resolve global Node types without explicit declaration.

## Verification

- [x] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green
- [ ] Screenshots attached (if UI-affecting)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Node.js type definitions in TypeScript by adding `types: ["node"]` to `tsconfig.base.json`, so built-in module imports like `node:child_process` resolve. Fixes TypeScript compile errors when using `pnpm` with strict dependency resolution.

<sup>Written for commit 3da3cecd7cbed5557b3252997e1f0b1f6669bfe7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

