### PR TITLE
feat(chrome): ui polish wave + the automation card's missing emitter

### DIFF
--- a/.changeset/ui-polish-automation-card-workspace.md
+++ b/.changeset/ui-polish-automation-card-workspace.md
@@ -1,0 +1,31 @@
+---
+"@vendoai/ui": minor
+"@vendoai/agent": minor
+"@vendoai/apps": minor
+"@vendoai/vendo": patch
+---
+
+Chrome polish wave + the automation card's missing emitter.
+
+- **Status ribbon docks onto the composer** (Codex-style): narrower than the
+  composer, top corners only, its bottom edge tucked behind the card — no more
+  floating pill with a gap, on both the page surface and the overlay's
+  dock-anchor DOM.
+- **Approval card de-escalated**: the ceremony card keeps the neutral surface
+  with a single amber accent bar instead of the full yellow wash; the
+  ALL-CAPS "CRITICAL" eyebrow is gone; risk slugs render in the user's
+  language ("Irreversible", "Makes changes", "Read-only") with the raw slug
+  intact on `data-risk` and the tooltip.
+- **App-card dot stands down when ready**: the pulsing build dot fades and
+  collapses once the view is generated; the ready bar carries just the name.
+- **`.fl-btn` is a non-wrapping flex row**: icon + label ride one line (the
+  connect card's "Connecting…" spinner no longer folds onto its own line).
+- **`VendoPage` accepts `thread`** (`suggestions` + `discoverability`
+  passthrough to the chat tab), so hosts can move their curated landing onto
+  the full workspace; Maple's Ask Maple page and Cadence's assistant now
+  render the workspace console.
+- **The automation card now actually streams**: `vendo_apps_edit` ok-outputs
+  that armed an automation emit `data-vendo-automation` from the agent tool
+  bridge (name-scoped, 01 §16), and the apps runtime reports the armed
+  trigger's true `enabled` state on `EditResult.automation`. The playground
+  gallery gains an "Automation created" scenario.

--- a/apps/demo-accounting/src/app/assistant/page.test.tsx
+++ b/apps/demo-accounting/src/app/assistant/page.test.tsx
@@ -11,10 +11,11 @@ import { cadenceScenarios } from "@/vendo/scenarios"
 
 const threadProps = vi.fn()
 
+// The page now mounts the full workspace (VendoPage) and hands the thread
+// contract through its `thread` prop — same invariants, read at the new seam.
 vi.mock("@vendoai/ui/chrome", () => ({
-  ActivityPanel: () => null,
-  VendoThread: (props: Record<string, unknown>) => {
-    threadProps(props)
+  VendoPage: ({ thread }: { thread: Record<string, unknown> }) => {
+    threadProps(thread)
     return null
   },
 }))

--- a/apps/demo-accounting/src/app/assistant/page.tsx
+++ b/apps/demo-accounting/src/app/assistant/page.tsx
@@ -1,55 +1,20 @@
 "use client";
 
-import { useState } from "react";
-import { ActivityPanel, VendoThread } from "@vendoai/ui/chrome";
+import { VendoPage } from "@vendoai/ui/chrome";
 import { VendoRoot } from "@/components/vendo/VendoRoot";
 import { useTryThisChips } from "@/components/vendo/use-try-this-chips";
 import { cadenceScenarios } from "@/vendo/scenarios";
 
-function PageSurface() {
-  const [activityOpen, setActivityOpen] = useState(false);
+/** The assistant IS the shipped workspace console (VendoPage) — threads,
+ *  apps, automations, accounts and activity tabs, the same surface the Vendo
+ *  playground showcases — with Cadence's curated starter cards riding the
+ *  chat tab (2026-07-30 polish: replaces the hand-rolled Chat/Activity
+ *  two-tab shell). */
+export default function AssistantPage() {
   // "Try this" chips (demo-hygiene): pre-generated prompts as pill chips one
   // tier below the scenario cards; absent entirely while the cache is empty.
-  const chips = useTryThisChips()
-  const suggestions = chips.length === 0 ? cadenceScenarios : [...cadenceScenarios, ...chips]
-  return (
-    <div className="fl-page">
-      <div className="fl-tabbar">
-        <span className="fl-tab" aria-selected="true">Chat</span>
-        <button
-          type="button"
-          className="fl-tab fl-tab-trust"
-          aria-label="Activity — what Vendo has done"
-          onClick={() => setActivityOpen(true)}
-        >
-          Activity
-        </button>
-      </div>
-      <div className="fl-page-body">
-        <div className="fl-page-pane">
-          {/* demo-refresh Part 6 — the scenario ladder as starter cards on the
-              empty landing (same set the overlay's thread shows).
-              discoverability="quiet" matches Maple: the fire-once
-              greeting-as-tutorial would otherwise replace the cards+chips on
-              the FIRST-ever visit (and burn the flag). */}
-          <VendoThread suggestions={suggestions} discoverability="quiet" />
-        </div>
-      </div>
-      {activityOpen ? (
-        <div className="fl-trust-overlay" role="presentation" onClick={() => setActivityOpen(false)}>
-          <div onClick={(event) => event.stopPropagation()}>
-            <button type="button" onClick={() => setActivityOpen(false)}>Close</button>
-            <ActivityPanel />
-            {/* VENDO-MIGRATION: 08-ui ships activity, approvals, and grants
-                hooks, but no combined TrustScreen or compiled-rule editor. */}
-          </div>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-export default function AssistantPage() {
+  const chips = useTryThisChips();
+  const suggestions = chips.length === 0 ? cadenceScenarios : [...cadenceScenarios, ...chips];
   return (
     <div
       style={{
@@ -66,7 +31,7 @@ export default function AssistantPage() {
       }}
     >
       <VendoRoot>
-        <PageSurface />
+        <VendoPage thread={{ suggestions, discoverability: "quiet" }} />
       </VendoRoot>
     </div>
   );

--- a/apps/demo-bank/src/app/vendo/page.test.tsx
+++ b/apps/demo-bank/src/app/vendo/page.test.tsx
@@ -17,14 +17,15 @@ import { mapleScenarios } from "@/vendo/scenarios";
 
 const threadProps = vi.fn();
 
+// The page now mounts the full workspace (VendoPage) and hands the thread
+// contract through its `thread` prop — the invariants under test are the
+// same, read at the new seam.
 vi.mock("@vendoai/ui/chrome", () => ({
-  VendoActivities: () => null,
-  VendoThread: (props: Record<string, unknown>) => {
-    threadProps(props);
+  VendoPage: ({ thread }: { thread: Record<string, unknown> }) => {
+    threadProps(thread);
     return null;
   },
 }));
-vi.mock("@vendoai/ui/voice", () => ({ VendoStage: () => null }));
 vi.mock("@/components/vendo/VendoRoot", () => ({
   VendoRoot: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));

--- a/apps/demo-bank/src/app/vendo/page.tsx
+++ b/apps/demo-bank/src/app/vendo/page.tsx
@@ -1,11 +1,16 @@
 "use client";
 
-import { VendoActivities, VendoThread } from "@vendoai/ui/chrome";
-import { VendoStage } from "@vendoai/ui/voice";
+import { VendoPage } from "@vendoai/ui/chrome";
 import { VendoRoot } from "@/components/vendo/VendoRoot";
 import { useTryThisChips } from "@/components/vendo/use-try-this-chips";
 import { mapleScenarios } from "@/vendo/scenarios";
 
+/** Ask Maple IS the shipped workspace console (VendoPage): threads, apps,
+ *  automations, accounts and activity tabs — the same surface the Vendo
+ *  playground showcases — with Maple's curated starter cards riding the chat
+ *  tab. The voice stage no longer docks here (2026-07-30 polish: the fixed
+ *  260px slot under the thread was the clutter); /vendo/workspace stays as an
+ *  alias route. */
 export default function VendoTabPage() {
   // "Try this" chips (demo-hygiene): pre-generated prompts as pill chips one
   // tier below the scenario cards. An empty cache keeps the ORIGINAL
@@ -14,43 +19,9 @@ export default function VendoTabPage() {
   const chips = useTryThisChips();
   const suggestions = chips.length === 0 ? mapleScenarios : [...mapleScenarios, ...chips];
   return (
-    <div
-      style={{
-        height: "calc(100dvh - 112px)",
-        minHeight: 0,
-        display: "flex",
-        flexDirection: "column",
-        overflow: "auto",
-      }}
-    >
+    <div style={{ height: "calc(100dvh - 112px)", minHeight: 0, display: "flex", flexDirection: "column", overflow: "hidden" }}>
       <VendoRoot>
-        {/* ENG-286 → shelf: the hand-rolled MapleApprovals inbox is now the
-            shipped VendoActivities piece — pending approvals (including calls
-            arriving through the MCP door) plus the recent agent-activity feed.
-            flexShrink 0: a natural-height block; when space runs out the
-            column scrolls instead of squeezing content into overlap. */}
-        <div className="pb-4" style={{ flexShrink: 0 }}>
-          <VendoActivities />
-        </div>
-        {/* demo-refresh Part 6 — the scenario ladder as starter cards on the
-            empty landing (same set the overlay's thread shows).
-            discoverability="quiet" matches the overlay's MapleThread: the
-            fire-once greeting-as-tutorial would otherwise replace the cards on
-            the FIRST-ever visit (and burn the flag), so the funnel's opening
-            beat showed generic chips until a reload.
-            The 420px floor keeps the thread usable at short viewports: an
-            in-thread approval card + composer always fit, so consent is
-            clickable instead of being flex-squeezed under the sibling
-            surfaces (the column above scrolls when the floor doesn't fit). */}
-        <div style={{ flex: "1 0 auto", minHeight: 420, display: "flex", flexDirection: "column" }}>
-          <VendoThread suggestions={suggestions} discoverability="quiet" />
-        </div>
-        {/* The docked voice surface keeps a fixed slot below the thread — it
-            never shrinks into a sliver whose chrome paints over the thread
-            (the stage also clips to its box; see .fl-voice-root). */}
-        <div style={{ flex: "0 0 auto", height: 260 }}>
-          <VendoStage />
-        </div>
+        <VendoPage thread={{ suggestions, discoverability: "quiet" }} />
       </VendoRoot>
     </div>
   );

--- a/packages/agent/src/automation-part.test.ts
+++ b/packages/agent/src/automation-part.test.ts
@@ -1,0 +1,144 @@
+import { vendoAutomationPartSchema, type ToolDescriptor } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createAgent } from "./index.js";
+import {
+  boundRegistry,
+  ctx,
+  readSse,
+  scriptedModel,
+  testGuard,
+  textTurn,
+  toolCallTurn,
+  userMessage,
+} from "./test-helpers.js";
+
+// stream-parts VendoAutomationPart — an edit that rode the escalation ladder
+// to an automation must land in the thread as a `data-vendo-automation` part
+// (the AutomationCard), not just prose. The contract under test: the part is
+// emitted from the edit tool's ok output by NAME (never by duck-typing an
+// arbitrary tool's output — the same 01 §16 rule as the view part).
+
+const editDescriptor: ToolDescriptor = {
+  name: "vendo_apps_edit",
+  description: "Edit a Vendo app.",
+  inputSchema: {
+    type: "object",
+    properties: { appId: { type: "string" }, instruction: { type: "string" } },
+    required: ["appId", "instruction"],
+    additionalProperties: false,
+  },
+  risk: "read",
+};
+
+const echoDescriptor: ToolDescriptor = {
+  name: "echo",
+  description: "Return the supplied value.",
+  inputSchema: {
+    type: "object",
+    properties: { value: { type: "string" } },
+    required: ["value"],
+    additionalProperties: false,
+  },
+  risk: "read",
+};
+
+const TRIGGER = {
+  on: { kind: "schedule", every: "1d" },
+  run: { kind: "agentic", prompt: "check the balance" },
+};
+
+const AUTOMATED_EDIT_OUTPUT = {
+  app: { id: "app_auto_1", name: "Overdraft alert", description: "Emails you before an overdraft." },
+  automation: {
+    mode: "agentic",
+    trigger: TRIGGER,
+    enabled: true,
+    pendingGrants: [{ id: "apr_1" }, { id: "apr_2" }],
+  },
+};
+
+describe("automation card part (data-vendo-automation)", () => {
+  it("an edit that armed an automation streams the card part", async () => {
+    const guard = testGuard({});
+    const registry = boundRegistry({
+      vendo_apps_edit: {
+        descriptor: editDescriptor,
+        execute: () => AUTOMATED_EDIT_OUTPUT,
+      },
+    }, guard);
+    const model = scriptedModel([
+      toolCallTurn("vendo_apps_edit", { appId: "app_auto_1", instruction: "alert me before I overdraft" }, "call_edit_1"),
+      textTurn("Armed the overdraft alert.", "text_edit_1"),
+    ]);
+    const agent = createAgent({ model, tools: registry, guard });
+
+    const response = await agent.stream({
+      threadId: "thr_automation_part",
+      message: userMessage("user_automation_part", "alert me before I overdraft"),
+      ctx: ctx(),
+    });
+    const { parts } = await readSse(response);
+
+    expect(parts.filter((part) => part.type === "error")).toEqual([]);
+    const card = parts.find((part) => part.type === "data-vendo-automation");
+    expect(card).toBeDefined();
+    const data = (card as { data: Record<string, unknown> }).data;
+    expect(data.appId).toBe("app_auto_1");
+    expect(data.name).toBe("Overdraft alert");
+    expect(data.enabled).toBe(true);
+    expect(data.trigger).toEqual(TRIGGER);
+    expect(data.description).toBe("Emails you before an overdraft.");
+    // The wire carries a COUNT of undecided standing grants, never the
+    // approval objects themselves.
+    expect(data.pendingGrants).toBe(2);
+    expect(vendoAutomationPartSchema.safeParse({ type: "data-vendo-automation", ...data }).success).toBe(true);
+  });
+
+  it("an edit without an automation envelope emits no card", async () => {
+    const guard = testGuard({});
+    const registry = boundRegistry({
+      vendo_apps_edit: {
+        descriptor: editDescriptor,
+        execute: () => ({ app: { id: "app_plain", name: "Plain edit" } }),
+      },
+    }, guard);
+    const model = scriptedModel([
+      toolCallTurn("vendo_apps_edit", { appId: "app_plain", instruction: "retitle it" }, "call_edit_2"),
+      textTurn("Done.", "text_edit_2"),
+    ]);
+    const agent = createAgent({ model, tools: registry, guard });
+
+    const response = await agent.stream({
+      threadId: "thr_automation_none",
+      message: userMessage("user_automation_none", "retitle my app"),
+      ctx: ctx(),
+    });
+    const { parts } = await readSse(response);
+
+    expect(parts.some((part) => part.type === "data-vendo-automation")).toBe(false);
+  });
+
+  it("a non-edit tool with an automation-shaped output emits no card (name-scoped, not duck-typed)", async () => {
+    const guard = testGuard({});
+    const registry = boundRegistry({
+      echo: {
+        descriptor: echoDescriptor,
+        execute: () => AUTOMATED_EDIT_OUTPUT,
+      },
+    }, guard);
+    const model = scriptedModel([
+      toolCallTurn("echo", { value: "v" }, "call_echo_auto"),
+      textTurn("Echoed.", "text_echo_auto"),
+    ]);
+    const agent = createAgent({ model, tools: registry, guard });
+
+    const response = await agent.stream({
+      threadId: "thr_automation_duck",
+      message: userMessage("user_automation_duck", "echo something"),
+      ctx: ctx(),
+    });
+    const { parts } = await readSse(response);
+
+    expect(parts.some((part) => part.type === "data-vendo-automation")).toBe(false);
+  });
+});

--- a/packages/agent/src/tools.ts
+++ b/packages/agent/src/tools.ts
@@ -5,6 +5,7 @@ import {
   VENDO_KNOWLEDGE_RESULT_KIND,
   VENDO_VIEW_STREAM,
   toVendoWirePart,
+  vendoAutomationPartSchema,
   vendoCitationsPartSchema,
   vendoKnowledgeCitationSchema,
   vendoViewStreamId,
@@ -18,6 +19,7 @@ import {
   type ToolOutcome,
   type ToolRegistry,
   type VendoApprovalPart,
+  type VendoAutomationPart,
   type VendoBuildFailedPart,
   type VendoCitationsPart,
   type VendoConnectPart,
@@ -32,7 +34,7 @@ import {
   type UIMessageStreamWriter,
 } from "ai";
 
-type VendoPart = VendoApprovalPart | VendoBuildFailedPart | VendoCitationsPart | VendoConnectPart | VendoViewPart;
+type VendoPart = VendoApprovalPart | VendoAutomationPart | VendoBuildFailedPart | VendoCitationsPart | VendoConnectPart | VendoViewPart;
 
 /** 03-agent §2 */
 export interface ToolBridgeOptions {
@@ -204,6 +206,31 @@ export function addAgentTool(tools: ToolSet, descriptor: ToolDescriptor, options
           : null;
         const view = vendoViewPartSchema.safeParse(candidate);
         if (view.success) writePart(options.writer, view.data, vendoViewStreamId(view.data.appId));
+        // The automation card (01 §16 amendment, stream-parts): an edit that
+        // rode the escalation ladder to an automation carries the authored
+        // envelope on its output — land it in the thread as a card, not
+        // prose. Scoped to the edit tool by NAME, never by output shape,
+        // for the same §16 reason as the view part above.
+        if (descriptor.name === "vendo_apps_edit") {
+          const automation = surface?.automation as Record<string, unknown> | undefined;
+          const app = surface?.app as Record<string, unknown> | undefined;
+          if (automation !== undefined && app !== undefined) {
+            const part = vendoAutomationPartSchema.safeParse({
+              type: "data-vendo-automation",
+              appId: app.id,
+              name: app.name,
+              enabled: automation.enabled,
+              trigger: automation.trigger,
+              ...(typeof app.description === "string" && app.description.length > 0
+                ? { description: app.description }
+                : {}),
+              ...(Array.isArray(automation.pendingGrants) && automation.pendingGrants.length > 0
+                ? { pendingGrants: automation.pendingGrants.length }
+                : {}),
+            });
+            if (part.success) writePart(options.writer, part.data, `vendo-automation-${String(app.id)}`);
+          }
+        }
       } else if (outcome.status === "pending-approval") {
         writePart(options.writer, approvalPart(toolCallId, descriptor.risk, outcome.approvalId));
       } else if (outcome.status === "connect-required") {

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -249,6 +249,10 @@ export interface EditResult {
   automation?: {
     mode: "steps" | "agentic";
     trigger: Trigger;
+    /** What the arming actually produced — false when the seam left the
+     * trigger disarmed or arming threw (the issues entry says why). The
+     * thread's automation card needs the true state, not an inference. */
+    enabled: boolean;
     resultsCollection?: string;
     pendingGrants?: ApprovalRequest[];
   };
@@ -1700,10 +1704,14 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       armTrigger: config.armAutomation === undefined,
     });
     let pendingGrants: ApprovalRequest[] | undefined;
+    // Direct arming happened inside persistEdit (armTrigger) — enabled unless
+    // a seam below reports otherwise.
+    let enabled = true;
     if (config.armAutomation !== undefined) {
       try {
         const armed = await config.armAutomation(previous.id, ctx);
         if (armed.missing.length > 0) pendingGrants = structuredClone(armed.missing);
+        enabled = armed.enabled;
         // A seam that answers without arming is the same miss as a thrown one:
         // the trigger must never sit silently disarmed.
         if (!armed.enabled) {
@@ -1712,6 +1720,7 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       } catch (error) {
         // Never a silently dead automation: the trigger is on the document but
         // disarmed — say so, with the arming surface to use.
+        enabled = false;
         issues.push(`the automation was authored but arming it failed (${error instanceof Error ? error.message : "unknown error"}) — enable it explicitly via the automations engine (automations.enable / POST /automations/:appId/enable)`);
       }
     }
@@ -1727,6 +1736,7 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       automation: {
         mode,
         trigger: structuredClone(plan.trigger),
+        enabled,
         ...(plan.resultsCollection === undefined ? {} : { resultsCollection: plan.resultsCollection }),
         ...(pendingGrants === undefined ? {} : { pendingGrants }),
       },

--- a/packages/ui/src/chrome/approval-card.tsx
+++ b/packages/ui/src/chrome/approval-card.tsx
@@ -6,6 +6,14 @@ import { toolPresentation } from "./build-beat.js";
 import { ChromeRoot } from "./chrome-root.js";
 import { humanizeToolName, type ToolMeta } from "./humanize.js";
 
+/** The wire risk slugs, in the user's language (the raw slug stays available
+    on the chip's tooltip via the tool name; end users never read jargon). */
+const RISK_LABEL: Record<string, string> = {
+  read: "Read-only",
+  write: "Makes changes",
+  destructive: "Irreversible",
+};
+
 /** Flat, primitive-valued args render as aligned field rows — humanized label,
     host-formatted value (ToolMeta.formatField), raw value on the tooltip so
     the real input stays one hover away; anything nested falls back to the raw
@@ -143,7 +151,7 @@ export function ApprovalCard({ approval, onDecide, allowRemember = true, showCon
             )}
           </span>
           <div className="fl-approval-heading">
-            <div className="fl-approval-eyebrow">{critical ? "CRITICAL" : presentation.eyebrow}</div>
+            <div className="fl-approval-eyebrow">{presentation.eyebrow}</div>
             <div className="fl-approval-title">{title}</div>
             {showDescription ? <div className="fl-approval-desc">{description}</div> : null}
           </div>
@@ -153,7 +161,7 @@ export function ApprovalCard({ approval, onDecide, allowRemember = true, showCon
             title={approval.descriptor.name}
             style={{ marginLeft: "auto", padding: "2px 7px", fontSize: "10px", cursor: "default" }}
           >
-            {approval.descriptor.risk}
+            {RISK_LABEL[approval.descriptor.risk] ?? approval.descriptor.risk}
           </span>
         </div>
         {consequence ? (

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -238,7 +238,12 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the wave-2
   border-bottom: 1px solid var(--vendo-border);
   background: color-mix(in srgb, var(--vendo-surface) 92%, var(--vendo-fg) 8%); }
 .fl-appcard-dot { width: 8px; height: 8px; border-radius: 999px; flex: none;
-  background: var(--vendo-accent); box-shadow: 0 0 0 3px color-mix(in srgb, var(--vendo-accent) 16%, transparent); }
+  background: var(--vendo-accent); box-shadow: 0 0 0 3px color-mix(in srgb, var(--vendo-accent) 16%, transparent);
+  transition: width .2s ease, margin-right .2s ease, opacity .2s ease; }
+/* The dot narrates the BUILD only — once the view is ready it fades and
+   collapses (margin swallows the flex gap), leaving just the app's name. */
+.fl-appcard-bar[data-state="ready"] .fl-appcard-dot { opacity: 0; width: 0; margin-right: -8px;
+  box-shadow: none; }
 .fl-appcard-name { font: 600 12.5px/1 var(--vendo-font); color: var(--vendo-fg);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .fl-appcard-body { padding: 16px; display: flex; flex-direction: column; gap: 12px; }
@@ -529,7 +534,6 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the wave-2
 /* Connect-card lifecycle (2026-07 demo feedback): the button spins while the
    OAuth window is open, then becomes a quiet permanent Connected badge. */
 .fl-connect-spin { width: 12px; height: 12px; border-radius: 50%; flex-shrink: 0; display: inline-block;
-  vertical-align: -2px; margin-right: 7px;
   border: 2px solid color-mix(in srgb, currentColor 35%, transparent); border-top-color: currentColor;
   animation: fl-spin .7s linear infinite; }
 .fl-connect-done { display: inline-flex; align-items: center; gap: 6px; padding: 5px 11px 5px 8px;
@@ -643,6 +647,9 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the wave-2
   clip-path: polygon(14% 44%, 0 62%, 40% 100%, 100% 18%, 84% 4%, 39% 68%); }
 .fl-btn { border: 1px solid var(--vendo-border); border-radius: 9px; padding: 8px 15px;
   font: 550 12.5px/1 var(--vendo-font); letter-spacing: -.006em;
+  /* Icon + label ride one non-wrapping row (a squeezed flex row used to fold
+     the connect spinner onto its own line above the label). */
+  display: inline-flex; align-items: center; justify-content: center; gap: 7px; white-space: nowrap;
   background: var(--vendo-surface); color: var(--vendo-fg); cursor: pointer;
   box-shadow: 0 1px 1.5px color-mix(in srgb, var(--vendo-fg) 5%, transparent);
   transition: background .13s, border-color .13s, transform .05s, box-shadow .13s; }
@@ -658,7 +665,10 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the wave-2
 .fl-btn-spin { width: 12px; height: 12px; border-radius: 50%; flex-shrink: 0;
   border: 2px solid color-mix(in srgb, var(--vendo-accent-fg) 35%, transparent);
   border-top-color: var(--vendo-accent-fg); animation: fl-spin .7s linear infinite; }
-.fl-approval--ceremony { border-color: var(--vendo-warn-border); background: var(--vendo-warn-bg); }
+/* Ceremony stays on the neutral card — the amber lives in one accent bar,
+   the icon and the eyebrow (refactoring-ui: accent border over full wash). */
+.fl-approval--ceremony { border-color: var(--vendo-warn-border);
+  box-shadow: inset 3px 0 0 var(--vendo-warn), var(--vendo-shadow); }
 .fl-approval--ceremony .fl-approval-ic { color: var(--vendo-warn); background: color-mix(in srgb, var(--vendo-warn) 16%, transparent); }
 .fl-approval--ceremony .fl-approval-eyebrow { color: var(--vendo-warn); }
 .fl-approval-unverified { margin-left: 8px; padding: 1px 6px; border-radius: 999px; font-size: 9.5px;
@@ -668,7 +678,8 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the wave-2
 .fl-btn-ceremony { background: var(--vendo-warn); color: var(--vendo-warn-on-fill); border-color: transparent;
   box-shadow: 0 1px 2px color-mix(in srgb, var(--vendo-warn) 40%, transparent); }
 .fl-btn-ceremony:hover { opacity: .92; background: var(--vendo-warn); border-color: transparent; }
-.fl-approval--escalation { border-color: var(--vendo-warn-border); background: var(--vendo-warn-bg); }
+.fl-approval--escalation { border-color: var(--vendo-warn-border);
+  box-shadow: inset 3px 0 0 var(--vendo-warn), var(--vendo-shadow); }
 .fl-approval--escalation .fl-approval-ic { color: var(--vendo-warn); background: color-mix(in srgb, var(--vendo-warn) 16%, transparent); }
 .fl-approval--escalation .fl-approval-eyebrow { color: var(--vendo-warn); }
 .fl-approval-reason { margin: 10px 0 0; font: 400 12.5px/1.4 var(--vendo-font); color: var(--vendo-fg);
@@ -1952,11 +1963,18 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the wave-2
    mobile jump, 8A-8E markdown). Derived from existing tokens only.
    ==================================================================== */
 
-/* C1 — live status ribbon (glued above the composer while a turn works). */
-.fl-ribbon { display: flex; align-items: center; gap: 9px; margin: 0 16px -6px; padding: 8px 12px;
-  border: 1px solid var(--vendo-border); border-radius: 12px; background: var(--vendo-glass-strong);
+/* C1 — live status ribbon, tucked BEHIND the composer (one unit, Codex-
+   style): narrower than the composer, top corners only, and its bottom edge
+   slides under the card — the composer (position:relative) paints over the
+   overlap, so the composer keeps its own full radius. The composer sits
+   either adjacent or inside the dock anchor, so both DOM shapes lose their
+   top margin. */
+.fl-ribbon { display: flex; align-items: center; gap: 9px; margin: 0 30px -12px; padding: 7px 12px 19px;
+  border: 1px solid var(--vendo-border); border-bottom: 0; border-radius: 14px 14px 0 0;
+  background: color-mix(in srgb, var(--vendo-fg) 3%, var(--vendo-glass-strong));
   -webkit-backdrop-filter: var(--vendo-blur); backdrop-filter: var(--vendo-blur);
-  font: 500 12.5px/1.3 var(--vendo-font); color: var(--vendo-fg-muted); box-shadow: var(--vendo-shadow); }
+  font: 500 12.5px/1.3 var(--vendo-font); color: var(--vendo-fg-muted); }
+.fl-ribbon + .fl-composer, .fl-ribbon + .fl-dock-anchor .fl-composer { margin-top: 0; }
 .fl-ribbon .fl-beat-orb { width: 9px; height: 9px; }
 .fl-ribbon-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   color: var(--vendo-fg); font-weight: 550; }

--- a/packages/ui/src/chrome/index.ts
+++ b/packages/ui/src/chrome/index.ts
@@ -14,7 +14,7 @@ export { VendoOverlay, type VendoOverlayProps } from "./vendo-overlay.js";
 export { defaultVendoGreeting, hasSeen, markSeen, type VendoDiscoverability, type VendoGreeting } from "./discoverability.js";
 export { openVendoConversation, type OpenConversationOptions } from "./overlay-registry.js";
 export { VendoTrigger, type VendoTriggerProps } from "./vendo-trigger.js";
-export { VendoPage } from "./vendo-page.js";
+export { VendoPage, type VendoPageProps } from "./vendo-page.js";
 export { VendoPalette, type VendoCommand } from "./vendo-palette.js";
 export { type HotkeyChord, type PaletteHotkey } from "./palette-hotkey.js";
 export { VendoSlot } from "./vendo-slot.js";

--- a/packages/ui/src/chrome/vendo-page.tsx
+++ b/packages/ui/src/chrome/vendo-page.tsx
@@ -11,8 +11,15 @@ import { ChromeRoot } from "./chrome-root.js";
 import { ACTIVITY_ANCHOR_ATTRIBUTE, ACTIVITY_BUMP_EVENT } from "./morph-toast.js";
 import { ConnectedAccountsPanel } from "./connected-accounts-panel.js";
 import { TakeoverPortal } from "./takeover-portal.js";
-import { VendoThread } from "./thread/index.js";
+import { VendoThread, type VendoThreadProps } from "./thread/index.js";
 import { WaitingQueue } from "./waiting-queue.js";
+
+/** Host passthrough for the chat tab's thread — the same starter cards and
+    discoverability dial a standalone VendoThread takes, so a host's curated
+    landing survives the move onto the full workspace. */
+export interface VendoPageProps {
+  thread?: Pick<VendoThreadProps, "suggestions" | "discoverability">;
+}
 
 const TABS = ["chat", "apps", "automations", "accounts", "activity"] as const;
 
@@ -25,7 +32,7 @@ function title(tab: Tab): string {
   return tab[0]!.toUpperCase() + tab.slice(1);
 }
 
-function ChatWorkspace() {
+function ChatWorkspace({ thread }: { thread?: VendoPageProps["thread"] }) {
   const takeover = useMobileTakeover();
   const { threads, isLoading, error: threadsError, refresh } = useThreads();
   const [selected, setSelected] = useState<string>();
@@ -111,10 +118,12 @@ function ChatWorkspace() {
           <VendoThread
             threadId={selected}
             onThreadId={onThreadId}
+            {...(thread?.suggestions === undefined ? {} : { suggestions: thread.suggestions })}
             discoverability={
-              userChose.current || (!isLoading && threadsError === undefined && threads.length === 0)
-                ? undefined
-                : "quiet"
+              thread?.discoverability
+                ?? (userChose.current || (!isLoading && threadsError === undefined && threads.length === 0)
+                  ? undefined
+                  : "quiet")
             }
           />
         </div>
@@ -210,7 +219,7 @@ function AppsWorkspace() {
 }
 
 /** 08-ui §4 — full workspace with WAI-ARIA automatic-activation tabs. */
-export function VendoPage() {
+export function VendoPage({ thread }: VendoPageProps = {}) {
   const takeover = useMobileTakeover();
   const [tab, setTab] = useState<Tab>("chat");
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
@@ -275,7 +284,7 @@ export function VendoPage() {
         </div>
         <div className="fl-page-body">
           <section className="fl-page-pane" id={`vendo-panel-${tab}`} role="tabpanel" aria-labelledby={`vendo-tab-${tab}`}>
-            {tab === "chat" ? <ChatWorkspace /> : null}
+            {tab === "chat" ? <ChatWorkspace thread={thread} /> : null}
             {tab === "apps" ? <AppsWorkspace /> : null}
             {tab === "automations" ? <AutomationsPanel /> : null}
             {tab === "accounts" ? <ConnectedAccountsPanel /> : null}

--- a/packages/ui/test/chrome/approval-and-notice.test.tsx
+++ b/packages/ui/test/chrome/approval-and-notice.test.tsx
@@ -41,14 +41,17 @@ describe("ApprovalCard and NoPolicyNotice exports", () => {
   it("shows the real inputs as fields and emits basic approve and deny decisions", async () => {
     const onDecide = vi.fn();
     render(<VendoProvider client={client}><ApprovalCard approval={approval} onDecide={onDecide} /></VendoProvider>);
-    // Flat args render as aligned key→value rows — the same real values, structured.
+    // Flat args render as aligned key→value rows — labels prettified for
+    // reading, values verbatim unless the host formats them (then the raw
+    // value rides the dd tooltip — the consent honesty contract).
     const fields = screen.getByLabelText("Real tool inputs");
     const rows = [...fields.querySelectorAll(".fl-approval-field")].map(row => [
       row.querySelector("dt")?.textContent,
       row.querySelector("dd")?.textContent,
     ]);
     expect(rows).toEqual([["Invoice id", "inv_42"], ["Permanent", "true"]]);
-    expect(screen.getByText("destructive").getAttribute("data-risk")).toBe("destructive");
+    // The risk chip speaks the user's language; the data attr keeps the slug.
+    expect(screen.getByText("Irreversible").getAttribute("data-risk")).toBe("destructive");
     fireEvent.click(screen.getByRole("button", { name: "Approve" }));
     await waitFor(() => expect((screen.getByRole("button", { name: "Deny" }) as HTMLButtonElement).disabled).toBe(false));
     fireEvent.click(screen.getByRole("button", { name: "Deny" }));

--- a/packages/vendo/src/cli/playground/app/fixtures.ts
+++ b/packages/vendo/src/cli/playground/app/fixtures.ts
@@ -259,6 +259,52 @@ export function approvalScript(): DirectorScript {
   };
 }
 
+/** An edit that rides the escalation ladder to an automation: the authored
+    trigger→action card (data-vendo-automation) lands in the transcript with
+    the standing permission it still needs, then the agent narrates. */
+export function automationScript(): DirectorScript {
+  return {
+    turns: [
+      {
+        cues: [
+          chunk(0, { type: "start" }),
+          chunk(100, { type: "start-step" }),
+          chunk(400, { type: "tool-input-start", toolCallId: "call_arm", toolName: "vendo_apps_edit" }),
+          chunk(300, {
+            type: "tool-input-available",
+            toolCallId: "call_arm",
+            toolName: "vendo_apps_edit",
+            input: { appId: "app_renewals", instruction: "every morning, flag any renewal account that has gone quiet" },
+          }),
+          chunk(1600, {
+            type: "data-vendo-automation",
+            id: "vendo-automation-app_renewals",
+            data: {
+              appId: "app_renewals",
+              name: "Renewals watchdog",
+              enabled: true,
+              trigger: {
+                on: { kind: "schedule", every: "1d" },
+                run: { kind: "agentic", prompt: "check renewals; flag any account quiet for 60+ days" },
+              },
+              description: "Every morning, checks your renewals and flags any account that has gone quiet.",
+              pendingGrants: 1,
+            },
+          }),
+          chunk(500, { type: "tool-output-available", toolCallId: "call_arm", output: { ok: true, appId: "app_renewals" } }),
+          chunk(500, { type: "text-start", id: "txt_automation" }),
+          chunk(150, { type: "text-delta", id: "txt_automation", delta: "Your Renewals watchdog is armed — " }),
+          chunk(170, { type: "text-delta", id: "txt_automation", delta: "it runs every morning and flags any account that goes quiet. " }),
+          chunk(170, { type: "text-delta", id: "txt_automation", delta: "It still needs one standing permission to run while you're away." }),
+          chunk(120, { type: "text-end", id: "txt_automation" }),
+          chunk(100, { type: "finish-step" }),
+          chunk(50, { type: "finish" }),
+        ],
+      },
+    ],
+  };
+}
+
 /** A connector call that needs a per-user connected account first (04 §3). */
 export function connectScript(): DirectorScript {
   return {

--- a/packages/vendo/src/cli/playground/app/scenarios.tsx
+++ b/packages/vendo/src/cli/playground/app/scenarios.tsx
@@ -9,6 +9,7 @@ import { VendoActivities, VendoOverlay, VendoPage, VendoSlot, VendoThread } from
 import { useMemo, type ReactElement } from "react";
 import {
   approvalScript,
+  automationScript,
   brokenViewPayload,
   connectScript,
   emptyActivitiesFixtures,
@@ -20,7 +21,7 @@ import {
 
 export interface PlaygroundScenario {
   id: string;
-  group: "Overlay" | "Thread" | "Approvals" | "Activities" | "Slot" | "Page" | "Mobile";
+  group: "Overlay" | "Thread" | "Approvals" | "Automations" | "Activities" | "Slot" | "Page" | "Mobile";
   title: string;
   description: string;
   /** Scripted turns this scenario's sends play (ScriptedTransport). */
@@ -145,6 +146,15 @@ export const scenarios: PlaygroundScenario[] = [
     description: "A write action parks the turn on an in-thread approval card. Approve it and the SAME turn resumes: the tool runs and the agent confirms.",
     script: approvalScript(),
     autoSend: "Give my team a heads-up about the at-risk renewals.",
+    render: () => <ThreadPane />,
+  },
+  {
+    id: "automation-created",
+    group: "Automations",
+    title: "Automation created",
+    description: "A turn that arms an automation: the trigger → action card lands in the transcript as a card (data-vendo-automation), showing the standing permission it still needs.",
+    script: automationScript(),
+    autoSend: "Every morning, flag any renewal account that has gone quiet.",
     render: () => <ThreadPane />,
   },
   {


### PR DESCRIPTION
Yousef's live-iteration session (2026-07-30): the surface polish he directed on localhost, landed as one wave. Every change was verified in a real browser on the Maple demo and the vendo.run playground gallery before this PR.

## What changed

**Status ribbon docks onto the composer (Codex-style)** — narrower than the composer, top corners only, bottom edge tucked behind the card. Covers both the adjacent-composer DOM and the overlay's dock-anchor wrapper (the first selector missed it — that was the surviving gap).

![ribbon docked](https://raw.githubusercontent.com/runvendo/vendo/assets/ui-polish-2026-07-30/ribbon-tucked-final.jpeg)

**Approval ceremony de-escalated** — neutral card + one amber accent bar instead of the full yellow wash; no more ALL-CAPS "CRITICAL"; risk slugs speak the user's language ("Irreversible" / "Makes changes" / "Read-only") with the raw slug intact on `data-risk` + tooltip. Composes with #695's humanized labels + `formatField`.

Before → after:

![before](https://raw.githubusercontent.com/runvendo/vendo/assets/ui-polish-2026-07-30/maple-approval-baseline.jpeg)
![after](https://raw.githubusercontent.com/runvendo/vendo/assets/ui-polish-2026-07-30/approval-restyled2.jpeg)

**The automation card's missing emitter** — the `data-vendo-automation` part + `AutomationCard` existed with no writer (the open gap from the Maple fix wave). `vendo_apps_edit` ok-outputs that armed an automation now emit the part from the agent tool bridge (name-scoped per 01 §16), and the runtime reports the armed trigger's true `enabled` on `EditResult.automation`. Three new tests drive it through the real agent stream (`packages/agent/src/automation-part.test.ts`).

**Ask Maple / Cadence assistant = the workspace console** — `VendoPage` gained a `thread` passthrough (`suggestions` + `discoverability`), and both demo landing pages now render the real workspace (tabs, thread sidebar) instead of hand-rolled compositions. Maple's voice stage comes off the page (the fixed 260px slot was the clutter); `/vendo/workspace` remains.

![ask maple workspace](https://raw.githubusercontent.com/runvendo/vendo/assets/ui-polish-2026-07-30/ask-maple-workspace.jpeg)

**Playground: "Automation created" scenario** — the gallery now shows the automation card landing in a scripted turn.

![automation scenario](https://raw.githubusercontent.com/runvendo/vendo/assets/ui-polish-2026-07-30/playground-automation-scenario.jpeg)

Plus: app-card build dot fades once the view is ready; `.fl-btn` is a non-wrapping flex row (connect spinner no longer folds above its label).

## Tests

- `pnpm build` / `typecheck` / `lint` green; full `pnpm test` green except `demo-accounting`'s Supabase login e2e, which 401s locally without seeded GoTrue creds (pre-existing env-truth test — the `cadence-supabase-auth` CI check covers it with env).
- Test-file changes, stated out loud: the approval-card test now asserts humanized labels + "Irreversible" chip (values still verbatim); both demo landing-page tests re-seat the same invariants on the `VendoPage.thread` seam.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the Chrome UI and adds the missing automation card emitter so edits that arm automations stream a real `data-vendo-automation` card. Demo pages now mount the full workspace via `VendoPage` with starter suggestions.

- **New Features**
  - `vendo_apps_edit` now streams `data-vendo-automation` parts from the agent (name-scoped), with stable stream ids per app; includes app/name/trigger/true `enabled` and `pendingGrants` count (`@vendoai/agent`).
  - `EditResult.automation` reports the actual `enabled` state from arming, not an inference (`@vendoai/apps`).
  - Playground adds “Automation created” scenario; three new tests cover the stream path.

- **UI Polish**
  - Live status ribbon docks behind the composer (narrower, top corners only) and covers both adjacent-composer and dock-anchor DOM shapes; removes the gap.
  - Approval card is calmer: neutral surface with a single amber accent bar; no ALL-CAPS; risk chips read “Irreversible/Makes changes/Read‑only” with the raw slug on `data-risk` (`@vendoai/ui`).
  - App-card build dot fades once ready; `.fl-btn` is inline-flex and non-wrapping to keep spinner + label on one line.
  - `VendoPage` accepts `thread` props (`suggestions`, `discoverability`); Maple and Cadence landings now render the full workspace; Maple’s voice stage is removed from the page (`@vendoai/ui`, demos).

<sup>Written for commit 4574f5ded170a517f2854613f6f462da40982532. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

