### PR TITLE
fix(changeset): judgment-layer-runtime-merge names the workspace package

### DIFF
--- a/.changeset/judgment-layer-runtime-merge.md
+++ b/.changeset/judgment-layer-runtime-merge.md
@@ -1,6 +1,6 @@
 ---
 "@vendoai/actions": patch
-"vendo": patch
+"@vendoai/vendo": patch
 ---
 
 Wire `.vendo/judgments.json` into the runtime read path: the AI layer now


### PR DESCRIPTION
The changeset said "vendo" — not a workspace package — which crashes
`changeset version` and has been failing the version-packages workflow on
every main push (release PR frozen at 2026-07-28). The umbrella is
@vendoai/vendo.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the changeset to reference the correct workspace package `@vendoai/vendo`, preventing `changeset version` from crashing and unblocking the version-packages workflow on main.

- **Bug Fixes**
  - Updated `.changeset/judgment-layer-runtime-merge.md` to use `@vendoai/vendo` instead of "vendo".

<sup>Written for commit 11b03b1a2f51e3b38ac094949ffb48fb843074d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

