### PR TITLE
feat(demos): Maple and Cadence offer the full connector catalog (incl. Outlook)

### DIFF
--- a/apps/demo-accounting/src/vendo/server.ts
+++ b/apps/demo-accounting/src/vendo/server.ts
@@ -42,6 +42,6 @@ export const vendo = createVendo({
   // scopes the VENDO_API_KEY-composed Cloud pair to the same toolkits — the
   // demo gets connectors in cloud posture, never the console's full catalog.
   ...(composioApiKey
-    ? { connectors: [composioConnector({ apiKey: composioApiKey, apps: ["gmail", "googlecalendar", "slack"] })] }
-    : { connectorApps: ["gmail", "googlecalendar", "slack"] }),
+    ? { connectors: [composioConnector({ apiKey: composioApiKey, apps: ["gmail", "googlecalendar", "outlook", "slack"] })] }
+    : { connectorApps: ["gmail", "googlecalendar", "outlook", "slack"] }),
 });

--- a/apps/demo-accounting/src/vendo/server.ts
+++ b/apps/demo-accounting/src/vendo/server.ts
@@ -38,10 +38,9 @@ export const vendo = createVendo({
       endPass: true,
     },
   },
-  // BYO Composio when Cadence brings its own key; otherwise connectorApps
-  // scopes the VENDO_API_KEY-composed Cloud pair to the same toolkits — the
-  // demo gets connectors in cloud posture, never the console's full catalog.
-  ...(composioApiKey
-    ? { connectors: [composioConnector({ apiKey: composioApiKey, apps: ["gmail", "googlecalendar", "outlook", "slack"] })] }
-    : { connectorApps: ["gmail", "googlecalendar", "outlook", "slack"] }),
+  // BYO Composio when Cadence brings its own key; otherwise the slot stays
+  // UNSET so a VENDO_API_KEY deployment composes the Cloud pair. No apps
+  // scoping (2026-07-30 ruling): the dock offers every toolkit with an
+  // enabled auth config on the account — new connectors need no redeploy.
+  ...(composioApiKey ? { connectors: [composioConnector({ apiKey: composioApiKey })] } : {}),
 });

--- a/apps/demo-bank/src/vendo/server.ts
+++ b/apps/demo-bank/src/vendo/server.ts
@@ -86,8 +86,8 @@ export const vendo = createVendo({
   // connectorApps scopes THAT auto-composed cloud pair to the same toolkits
   // the BYO line uses — the demo never advertises the console's full catalog.
   ...(composioApiKey
-    ? { connectors: [composioConnector({ apiKey: composioApiKey, apps: ["gmail", "slack"] })] }
-    : { connectorApps: ["gmail", "slack"] }),
+    ? { connectors: [composioConnector({ apiKey: composioApiKey, apps: ["gmail", "outlook", "slack"] })] }
+    : { connectorApps: ["gmail", "outlook", "slack"] }),
   // Store posture — an explicit demo decision (README "Store posture"). The
   // DEPLOYED demo leaves this slot unset so the VENDO_API_KEY env ladder
   // composes the Cloud HOSTED store: Railway's container filesystem is

--- a/apps/demo-bank/src/vendo/server.ts
+++ b/apps/demo-bank/src/vendo/server.ts
@@ -83,11 +83,10 @@ export const vendo = createVendo({
   // BYO Composio when Maple brings its own key; otherwise the slot stays
   // UNSET so a VENDO_API_KEY deployment composes the Cloud tools connector
   // (an explicit [] would read as "no connectors, ever" — the seam honors it).
-  // connectorApps scopes THAT auto-composed cloud pair to the same toolkits
-  // the BYO line uses — the demo never advertises the console's full catalog.
-  ...(composioApiKey
-    ? { connectors: [composioConnector({ apiKey: composioApiKey, apps: ["gmail", "outlook", "slack"] })] }
-    : { connectorApps: ["gmail", "outlook", "slack"] }),
+  // No apps scoping (2026-07-30 ruling): the dock offers every toolkit with
+  // an enabled auth config on the account, so new connectors go live by
+  // enabling them in Composio — no redeploy.
+  ...(composioApiKey ? { connectors: [composioConnector({ apiKey: composioApiKey })] } : {}),
   // Store posture — an explicit demo decision (README "Store posture"). The
   // DEPLOYED demo leaves this slot unset so the VENDO_API_KEY env ladder
   // composes the Cloud HOSTED store: Railway's container filesystem is


### PR DESCRIPTION
## What

Removes the curated `connectorApps` scoping from demo-bank (Maple) and demo-accounting (Cadence). The connect dock now auto-derives from the account's catalog: every toolkit with an enabled Composio auth config shows up, in both the Cloud (`VENDO_API_KEY`) and BYO (`COMPOSIO_API_KEY`) postures.

## Why

A customer asked for Outlook. The auth config was already enabled on the Composio account, but the demos' hardcoded scoping filtered it out of the dock. First commit added the slug; second commit (Yousef's call) drops the scoping entirely so future connectors go live by enabling them in Composio — no redeploy.

## Verification

- [x] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green locally (one known-flaky `packages/ui` connect-tray test fails in-file on macOS from cross-test catalog-cache pollution; passes in isolation and on main CI for identical package code — this diff only edits the two demo apps)
- [ ] Screenshots attached (if UI-affecting) — the demos are not GitHub-linked on Railway; live-browser proof of the full dock on demos.vendo.run/{maple,cadence} will be posted here after merge + `railway up` redeploy