### PR TITLE
fix(vendo): expose pinned lazy model id

### DIFF
--- a/packages/vendo/src/dev-creds/model.test.ts
+++ b/packages/vendo/src/dev-creds/model.test.ts
@@ -381,6 +381,21 @@ describe("vendoModel (the vendo model family entry)", () => {
   });
 
   it("keeps the deprecated VENDO_DEV_*_MODEL / VENDO_CLOUD_MODEL pins working on the agent slot only", async () => {
+    expect((vendoModel(undefined, {
+      env: { ANTHROPIC_API_KEY: "sk-a", VENDO_DEV_ANTHROPIC_MODEL: "claude-sonnet-5" },
+    }) as unknown as { modelId: string }).modelId).toBe("claude-sonnet-5");
+    expect((vendoModel(undefined, {
+      env: {
+        ANTHROPIC_API_KEY: "sk-a",
+        OPENAI_API_KEY: "sk-o",
+        VENDO_DEV_CREDENTIAL: "env-key:openai",
+        VENDO_DEV_ANTHROPIC_MODEL: "claude-sonnet-5",
+        VENDO_DEV_OPENAI_MODEL: "gpt-5",
+      },
+    }) as unknown as { modelId: string }).modelId).toBe("gpt-5");
+    expect((vendoModel(undefined, {
+      env: { VENDO_API_KEY: "vnd_x", VENDO_CLOUD_MODEL: "vendo-strong" },
+    }) as unknown as { modelId: string }).modelId).toBe("vendo-strong");
     expect(await resolvedId(vendoModel(undefined, {
       env: { ANTHROPIC_API_KEY: "sk-a", VENDO_DEV_ANTHROPIC_MODEL: "claude-opus-4-8" },
       importModule: scriptedProvider("createAnthropic"),

--- a/packages/vendo/src/dev-creds/model.test.ts
+++ b/packages/vendo/src/dev-creds/model.test.ts
@@ -493,6 +493,7 @@ describe("vendoModel (the vendo model family entry)", () => {
       importModule: scriptedProvider("createAnthropic"),
     });
     bindVendoModelSlots(bound, { judge: explicit });
+    expect((bound as unknown as { modelId: string }).modelId).toBe("host-judge");
     expect(await resolvedId(bound)).toBe("host-judge");
   });
 

--- a/packages/vendo/src/dev-creds/model.test.ts
+++ b/packages/vendo/src/dev-creds/model.test.ts
@@ -362,6 +362,9 @@ describe("vendoModel (the vendo model family entry)", () => {
   });
 
   it("VENDO_MODEL pins the agent slot above a configured name string", async () => {
+    expect((vendoModel(undefined, {
+      env: { ANTHROPIC_API_KEY: "sk-a", VENDO_MODEL: "claude-sonnet-5" },
+    }) as unknown as { modelId: string }).modelId).toBe("claude-sonnet-5");
     expect(await resolvedId(vendoModel("claude-opus-4-8", {
       env: { ANTHROPIC_API_KEY: "sk-a", VENDO_MODEL: "claude-sonnet-4-6" },
       importModule: scriptedProvider("createAnthropic"),

--- a/packages/vendo/src/dev-creds/model.ts
+++ b/packages/vendo/src/dev-creds/model.ts
@@ -331,6 +331,15 @@ export class DevModelController {
     return FAST_SLOTS.has(this.slot) ? spec.fast : spec.model;
   }
 
+  /** Best sync id for callers that inspect `model.modelId` before first use. */
+  lazyModelId(fallback: string): string {
+    const pin = nonBlank(this.env[SLOT_PIN_ENV[this.slot]]);
+    if (pin !== undefined) return pin;
+    const configured = this.configured;
+    if (typeof configured === "string" && nonBlank(configured) !== undefined) return configured.trim();
+    return fallback;
+  }
+
   /** The shared delegate rung: load the provider module (an install failure
    *  resolves unavailable with the exact install command), pick the model id
    *  (per-slot precedence above), and hand the factory-built model back. */
@@ -470,9 +479,12 @@ function rejectedKey(credential: DevCredential | undefined, error: unknown): Ven
 function lazyModel(controller: DevModelController, provider: string, modelId: string): LanguageModel {
   const model: LanguageModelV3Like = {
     specificationVersion: "v3",
-    // The lazy IDENTITY is vendo's own by design (the family name is the seam).
+    // The lazy id is usually Vendo's family seam, but sync pins/config must be
+    // visible to capability checks that inspect modelId before first use.
     provider,
-    modelId,
+    get modelId() {
+      return controller.lazyModelId(modelId);
+    },
     // CAPABILITY, though, must be the resolved provider's: the SDK reads
     // supportedUrls to decide whether a remote image/PDF is ingested natively
     // or downloaded first, so answering "none" makes callers fetch files the

--- a/packages/vendo/src/dev-creds/model.ts
+++ b/packages/vendo/src/dev-creds/model.ts
@@ -6,6 +6,7 @@ import type { LanguageModel } from "ai";
 import { resolveCloudBaseUrl } from "../cli/cloud/client.js";
 import {
   describeDevCredential,
+  ENV_KEY_VARS,
   resolveDevCredential,
   type DevCredential,
   type EnvKeyProvider,
@@ -335,9 +336,33 @@ export class DevModelController {
   lazyModelId(fallback: string): string {
     const pin = nonBlank(this.env[SLOT_PIN_ENV[this.slot]]);
     if (pin !== undefined) return pin;
+    const spec = this.lazyProviderSpec();
+    if (this.slot === "agent" && spec !== undefined) {
+      const legacy = nonBlank(this.env[spec.modelEnv]);
+      if (legacy !== undefined) return legacy;
+    }
     const configured = this.configured;
     if (typeof configured === "string" && nonBlank(configured) !== undefined) return configured.trim();
+    if (this.name !== undefined) return this.name;
+    if (spec === CLOUD_MODEL) return CLOUD_FAMILY[this.slot];
+    if (spec !== undefined) return FAST_SLOTS.has(this.slot) ? spec.fast : spec.model;
     return fallback;
+  }
+
+  private lazyProviderSpec(): ProviderSpec | undefined {
+    const pinned = nonBlank(this.env["VENDO_DEV_CREDENTIAL"]);
+    if (pinned === "vendo-cloud") return CLOUD_MODEL;
+    if (pinned === "none") return undefined;
+    const pinnedEnvKey = /^env-key:(anthropic|openai|google)$/.exec(pinned ?? "");
+    if (pinnedEnvKey !== null) {
+      const provider = pinnedEnvKey[1] as EnvKeyProvider;
+      const envVar = ENV_KEY_VARS.find((entry) => entry.provider === provider)!.envVar;
+      return nonBlank(this.env[envVar]) === undefined ? undefined : DEFAULT_MODELS[provider];
+    }
+    for (const { envVar, provider } of ENV_KEY_VARS) {
+      if (nonBlank(this.env[envVar]) !== undefined) return DEFAULT_MODELS[provider];
+    }
+    return nonBlank(this.env["VENDO_API_KEY"]) === undefined ? undefined : CLOUD_MODEL;
   }
 
   /** The shared delegate rung: load the provider module (an install failure

--- a/packages/vendo/src/dev-creds/model.ts
+++ b/packages/vendo/src/dev-creds/model.ts
@@ -334,6 +334,11 @@ export class DevModelController {
 
   /** Best sync id for callers that inspect `model.modelId` before first use. */
   lazyModelId(fallback: string): string {
+    const configured = this.configured;
+    if (configured !== undefined && typeof configured !== "string") {
+      const modelId = (configured as { modelId?: unknown }).modelId;
+      if (typeof modelId === "string" && nonBlank(modelId) !== undefined) return modelId.trim();
+    }
     const pin = nonBlank(this.env[SLOT_PIN_ENV[this.slot]]);
     if (pin !== undefined) return pin;
     const spec = this.lazyProviderSpec();
@@ -341,7 +346,6 @@ export class DevModelController {
       const legacy = nonBlank(this.env[spec.modelEnv]);
       if (legacy !== undefined) return legacy;
     }
-    const configured = this.configured;
     if (typeof configured === "string" && nonBlank(configured) !== undefined) return configured.trim();
     if (this.name !== undefined) return this.name;
     if (spec === CLOUD_MODEL) return CLOUD_FAMILY[this.slot];


### PR DESCRIPTION
## summary

- expose env-pinned/configured Vendo lazy model ids through `model.modelId`
- add a regression for `VENDO_MODEL=claude-sonnet-5` before first model resolution

fixes #692

## tests

- `pnpm --filter @vendoai/vendo exec vitest run src/dev-creds/model.test.ts`
- `pnpm --filter @vendoai/vendo typecheck`
- `pnpm --filter @vendoai/vendo build`
- `pnpm lint`

note: i also tried `pnpm --filter @vendoai/vendo test -- src/dev-creds/model.test.ts`; it included the broader package suite and hit an unrelated timeout in `src/knowledge-governance.test.ts` after `src/dev-creds/model.test.ts` passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the pinned or configured model id on lazy models in `@vendoai/vendo` via a `model.modelId` getter so callers see the correct id before first use. Mirrors provider pins from `VENDO_DEV_CREDENTIAL` and API keys. Fixes #692.

- **Bug Fixes**
  - `model.modelId` now prefers an explicit model object's id, then pins from `VENDO_MODEL`, deprecated `VENDO_DEV_*_MODEL`, or `VENDO_CLOUD_MODEL`; else the configured name, slot name, or inferred provider/cloud family id.
  - Added tests for env pins, `VENDO_DEV_CREDENTIAL`/API-key inference, and slot-bound overrides to ensure visibility before model resolution.

<sup>Written for commit 6fe0e8ccdf5851e1910af6a6180582937cc79175. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

