### PR TITLE
fix(ui): share anonymous session gate

### DIFF
--- a/packages/ui/src/client-impl.ts
+++ b/packages/ui/src/client-impl.ts
@@ -75,9 +75,11 @@ function announceApprovalsDecided(detail: ApprovalsDecidedDetail): void {
   window.dispatchEvent(new CustomEvent<ApprovalsDecidedDetail>(APPROVALS_DECIDED_EVENT, { detail }));
 }
 
+const anonymousSessionGates = new Map<string, Promise<void>>();
+
 /** 08-ui §2 */
 export function createVendoClient(config: VendoClientConfig): VendoClient {
-  const baseUrl = config.baseUrl ?? "/api/vendo";
+  const baseUrl = (config.baseUrl ?? "/api/vendo").replace(/\/$/, "");
   const headers = { ...(config.headers ?? {}) };
 
   async function send(path: string, init?: RequestInit): Promise<Response> {
@@ -105,24 +107,25 @@ export function createVendoClient(config: VendoClientConfig): VendoClient {
    *  another, and guard correctly refused it: "Approval apr_… was not found".
    *
    *  The browser IS the visitor boundary, so this is the layer that can close
-   *  the race honestly: the FIRST request through a client may leave cookie-less,
-   *  and every request issued before it answers waits for it, then travels with
-   *  the pointer it established. Costs one extra round trip on a cold load and
-   *  nothing afterwards. Deliberately NOT solved by fingerprinting the requester
-   *  (IP/User-Agent would merge two real visitors behind one NAT into a single
-   *  session) nor by deriving the pointer from request attributes (that would
-   *  make a live session guessable, where today it is a 2^128 search).
+   *  the race honestly: the FIRST request through a wire base may leave
+   *  cookie-less, and every request issued before it answers waits for it, then
+   *  travels with the pointer it established. Costs one extra round trip on a
+   *  cold load and nothing afterwards. Deliberately NOT solved by fingerprinting
+   *  the requester (IP/User-Agent would merge two real visitors behind one NAT
+   *  into a single session) nor by deriving the pointer from request attributes
+   *  (that would make a live session guessable, where today it is a 2^128
+   *  search).
    *
    *  A failed first request releases the gate rather than holding it, so a cold
    *  load that starts with an error degrades to the old behaviour, never worse.
    *  See test/anon-session-race.test.ts — the assertion only fails under real
    *  concurrency, which is why a sequential probe once "eliminated" this bug. */
-  let established: Promise<void> | undefined;
-
   async function request(path: string, init?: RequestInit): Promise<Response> {
+    const established = anonymousSessionGates.get(baseUrl);
     if (established === undefined) {
       let settle!: () => void;
-      established = new Promise<void>(resolve => { settle = resolve; });
+      const first = new Promise<void>(resolve => { settle = resolve; });
+      anonymousSessionGates.set(baseUrl, first);
       try {
         return await send(path, init);
       } finally {

--- a/packages/ui/test/anon-session-race.test.ts
+++ b/packages/ui/test/anon-session-race.test.ts
@@ -160,6 +160,24 @@ describe("one visitor, one anonymous identity", () => {
     expect(cookies.jar().get(ANON_COOKIE)).toMatch(ANON_ID_PATTERN);
   });
 
+  it("shares the cold-load gate across client instances for the same wire base", async () => {
+    const clients = [
+      createVendoClient({ baseUrl: door.url }),
+      createVendoClient({ baseUrl: `${door.url}/` }),
+      createVendoClient({ baseUrl: door.url }),
+    ];
+
+    await Promise.all([
+      clients[0]!.apps.list(),
+      clients[1]!.threads.list(),
+      clients[2]!.connections.list(),
+    ]);
+
+    expect(door.identities()).toHaveLength(3);
+    expect(new Set(door.identities()).size).toBe(1);
+    expect(door.mints()).toBe(1);
+  });
+
   it("keeps the visitor on the identity the jar already holds (no re-mint)", async () => {
     const client = createVendoClient({ baseUrl: door.url });
 


### PR DESCRIPTION
## summary

- share the anonymous-session cold-load gate across Vendo client instances for the same wire base
- normalize trailing slashes on `baseUrl` so `/api/vendo` and `/api/vendo/` use the same gate
- add a regression for concurrent first requests from multiple clients

fixes #693

## tests

- `pnpm --filter @vendoai/ui exec vitest run test/anon-session-race.test.ts`
- `pnpm --filter @vendoai/ui exec vitest run test/chrome/workspace-palette-slot.test.tsx`
- `pnpm --filter @vendoai/ui typecheck`
- `pnpm --filter @vendoai/ui build`
- `pnpm --filter @vendoai/vendo... build`
- `pnpm lint`

note: `pnpm --filter @vendoai/ui test -- test/anon-session-race.test.ts` ran the broader UI suite; the new race test passed, but one palette test failed there and passed when rerun directly.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share the anonymous-session cold-load gate across all `@vendoai/ui` client instances for the same base URL to stop races that mint multiple anonymous identities, fixing #693. Normalize `baseUrl` trailing slashes so `/api/vendo` and `/api/vendo/` use the same gate, and add a concurrency regression test.

<sup>Written for commit 96dd4b2ebda77f289c785933e0892e23e5b0eba6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

