### PR TITLE
fix(vendo): the model ladder drops sampling params a resolved Claude 5 rung rejects

### DIFF
--- a/.changeset/lazy-model-resolved-sampling.md
+++ b/.changeset/lazy-model-resolved-sampling.md
@@ -1,0 +1,19 @@
+---
+"@vendoai/vendo": patch
+"@vendoai/apps": patch
+---
+
+A Claude 5 model pinned through the model ladder can generate again (#692).
+
+`vendoModel()`'s lazy wrapper reports its family id (`"vendo-env"`) by design,
+so model-params' Claude 5 allowlist never saw the resolved rung's real id: the
+engine's `temperature: 0` rode through the ladder and a pinned Claude 5 model
+(`VENDO_MODEL=claude-sonnet-5` with `ANTHROPIC_API_KEY`) rejected every call
+with 400 "`temperature` is deprecated for this model". Sampling support is now
+re-decided at call time against the RESOLVED rung — the one moment the real id
+is known — dropping the sampling params such a rung rejects and setting the
+explicit output cap that guards against a sampling-era provider's silent 4096
+truncation. Sampling-era Claude and non-Claude rungs pass through untouched.
+`@vendoai/apps` exports the capability rule (`acceptsSamplingParams`,
+`UNKNOWN_MODEL_MAX_OUTPUT_TOKENS`) so the umbrella rides the engine's one
+allowlist instead of a copy.

--- a/packages/apps/src/index.ts
+++ b/packages/apps/src/index.ts
@@ -91,6 +91,16 @@ export {
   loadDemoBankCatalog,
   loadDemoBankTools,
 } from "./bench/demo-bank-surface.js";
+// The model-capability rule (model-params.ts): which Claude ids still accept
+// sampling params, and the output cap for ids a sampling-era provider registry
+// does not know. Exported for the umbrella's model ladder — its lazy wrapper
+// reports a family id ("vendo-env"), so the resolved rung's REAL id must be
+// re-checked at call time (#692). Data-only rule — no engine behavior rides
+// on the export.
+export {
+  acceptsSamplingParams,
+  UNKNOWN_MODEL_MAX_OUTPUT_TOKENS,
+} from "./model-params.js";
 // The generation seam for the genui-bench vendo lane: the SAME modelEngine
 // createApps() rides, driven directly with production PipelineConfig defaults
 // (no forked engine config). Additive export — engine behavior is unchanged.

--- a/packages/vendo/src/dev-creds/model.test.ts
+++ b/packages/vendo/src/dev-creds/model.test.ts
@@ -3,6 +3,7 @@ import Module from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { UNKNOWN_MODEL_MAX_OUTPUT_TOKENS } from "@vendoai/apps";
 import type { LanguageModel } from "ai";
 import {
   DevModelController,
@@ -187,6 +188,74 @@ describe("devModel (env-resolving default model)", () => {
       }),
     });
     expect(await controller.doGenerate({ prompt: [] })).toEqual({ modelId: "claude-opus-4-8" });
+  });
+});
+
+// Sampling capability is re-decided at call time against the RESOLVED rung
+// (#692): the wrapper's own modelId is the family name by design, so
+// model-params' Claude 5 allowlist sends the engine's `temperature: 0`
+// through the ladder — the ladder must drop it before the rung 400s.
+describe("call-time sampling params on the resolved rung", () => {
+  /** Provider module whose stub model echoes the call options it received. */
+  function optionsEcho(factoryName: string) {
+    return async (): Promise<Record<string, unknown>> => ({
+      [factoryName]: () => (modelId: string) => ({
+        specificationVersion: "v3",
+        provider: "scripted",
+        modelId,
+        supportedUrls: {},
+        doGenerate: async (options: unknown) => ({ modelId, options }),
+        doStream: async (options: unknown) => ({ modelId, options }),
+      }),
+    });
+  }
+
+  it("drops temperature/topP/topK and caps output for a ladder-resolved Claude 5 model", async () => {
+    const controller = new DevModelController({
+      env: { ANTHROPIC_API_KEY: "sk-a", VENDO_MODEL: "claude-sonnet-5" },
+      importModule: optionsEcho("createAnthropic"),
+    });
+    expect(await controller.doGenerate({ prompt: [], temperature: 0, topP: 0.9, topK: 40 })).toEqual({
+      modelId: "claude-sonnet-5",
+      options: { prompt: [], maxOutputTokens: UNKNOWN_MODEL_MAX_OUTPUT_TOKENS },
+    });
+    expect(await controller.doStream({ prompt: [], temperature: 0 })).toEqual({
+      modelId: "claude-sonnet-5",
+      options: { prompt: [], maxOutputTokens: UNKNOWN_MODEL_MAX_OUTPUT_TOKENS },
+    });
+  });
+
+  it("keeps a caller's explicit output cap while dropping the sampling params", async () => {
+    const controller = new DevModelController({
+      env: { ANTHROPIC_API_KEY: "sk-a", VENDO_MODEL: "claude-opus-5" },
+      importModule: optionsEcho("createAnthropic"),
+    });
+    expect(await controller.doGenerate({ prompt: [], temperature: 0, maxOutputTokens: 9_000 })).toEqual({
+      modelId: "claude-opus-5",
+      options: { prompt: [], maxOutputTokens: 9_000 },
+    });
+  });
+
+  it("leaves a non-Claude resolution untouched — temperature still flows", async () => {
+    const controller = new DevModelController({
+      env: { OPENAI_API_KEY: "sk-o" },
+      importModule: optionsEcho("createOpenAI"),
+    });
+    expect(await controller.doGenerate({ prompt: [], temperature: 0 })).toEqual({
+      modelId: "gpt-5",
+      options: { prompt: [], temperature: 0 },
+    });
+  });
+
+  it("leaves a sampling-era Claude resolution untouched", async () => {
+    const controller = new DevModelController({
+      env: { ANTHROPIC_API_KEY: "sk-a", VENDO_MODEL: "claude-sonnet-4-6" },
+      importModule: optionsEcho("createAnthropic"),
+    });
+    expect(await controller.doGenerate({ prompt: [], temperature: 0 })).toEqual({
+      modelId: "claude-sonnet-4-6",
+      options: { prompt: [], temperature: 0 },
+    });
   });
 });
 

--- a/packages/vendo/src/dev-creds/model.ts
+++ b/packages/vendo/src/dev-creds/model.ts
@@ -1,6 +1,7 @@
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
+import { acceptsSamplingParams, UNKNOWN_MODEL_MAX_OUTPUT_TOKENS } from "@vendoai/apps";
 import { meterExhaustedFromError, VendoError } from "@vendoai/core";
 import type { LanguageModel } from "ai";
 import { resolveCloudBaseUrl } from "../cli/cloud/client.js";
@@ -408,18 +409,21 @@ export class DevModelController {
   }
 
   doGenerate(callOptions: unknown): Promise<unknown> {
-    return this.call((model) => model.doGenerate(callOptions));
+    return this.call(callOptions, (model, options) => model.doGenerate(options));
   }
 
   doStream(callOptions: unknown): Promise<unknown> {
-    return this.call((model) => model.doStream(callOptions));
+    return this.call(callOptions, (model, options) => model.doStream(options));
   }
 
-  private async call<T>(invoke: (model: LanguageModelV3Like) => PromiseLike<T>): Promise<T> {
+  private async call<T>(
+    callOptions: unknown,
+    invoke: (model: LanguageModelV3Like, options: unknown) => PromiseLike<T>,
+  ): Promise<T> {
     const resolution = await this.resolve();
     if (resolution.mode === "unavailable") throw new VendoError("validation", resolution.message);
     try {
-      return await invoke(resolution.model);
+      return await invoke(resolution.model, resolvedCallOptions(callOptions, resolution.model));
     } catch (error) {
       const fix = rejectedKey(resolution.credential, error);
       if (fix === undefined) throw error;
@@ -465,6 +469,25 @@ function rejectedKey(credential: DevCredential | undefined, error: unknown): Ven
     );
   }
   return undefined;
+}
+
+/** Sampling params, re-decided against the RESOLVED rung. The lazy wrapper's
+ *  modelId is the family name by design (lazyModel below), so model-params'
+ *  Claude 5 allowlist never sees the real id: the engine's `temperature: 0`
+ *  rides through the ladder and a pinned Claude 5 rung 400s every call (#692).
+ *  Call time is after resolution — the one moment the real id is known — so a
+ *  rejecting rung's sampling params are dropped here and the explicit output
+ *  cap is set (same rule and reasons as modelCallParams: a sampling-era
+ *  provider registry silently truncates an unknown id at 4096 otherwise).
+ *  Sampling-era Claude and non-Claude rungs pass through untouched. */
+function resolvedCallOptions(callOptions: unknown, model: LanguageModelV3Like): unknown {
+  if (acceptsSamplingParams(model.modelId)) return callOptions;
+  const options = { ...(callOptions as Record<string, unknown>) };
+  delete options["temperature"];
+  delete options["topP"];
+  delete options["topK"];
+  options["maxOutputTokens"] ??= UNKNOWN_MODEL_MAX_OUTPUT_TOKENS;
+  return options;
 }
 
 function lazyModel(controller: DevModelController, provider: string, modelId: string): LanguageModel {


### PR DESCRIPTION
Fixes #692.

## What broke

`vendoModel()`'s lazy wrapper reports its family id (`"vendo-env"`) by design — the family name is the seam. But `packages/apps/src/model-params.ts` decides Claude-5-vs-not from `model.modelId`, so the allowlist never saw the resolved rung's real id: `claudeToken("vendo-env")` finds no claude token → non-Claude branch → the engine's `temperature: 0` is sent → a pinned Claude 5 rung (`VENDO_MODEL=claude-sonnet-5` with `ANTHROPIC_API_KEY`) rejects every generation with 400 `"temperature" is deprecated for this model`. The quieter twin (silent 4096 `max_tokens` truncation on a sampling-era provider registry) was defeated the same way, since the unknown-id output cap never fired either.

## The fix

Re-decide sampling capability **at call time against the RESOLVED rung**. The wrapper is lazy — its id can't be honest at construction, and `modelCallParams` is computed before the first call ever triggers resolution — but `DevModelController.call()` awaits `resolve()` before invoking the real model, so that seam is the one moment the real id is guaranteed known. `resolvedCallOptions()` there:

- drops `temperature` / `topP` / `topK` when the resolved rung rejects sampling (per the existing allowlist rule), and
- sets `maxOutputTokens` to the unknown-id cap unless the caller set one — both halves of the b6fdfc106 fix, same trigger, traveling together.

Sampling-era Claude, non-Claude, and Cloud-gateway rungs pass through untouched (existing full-fidelity delegation tests still pin that). This follows the precedent already written in `lazyModel`: identity is vendo's own, **capability must be the resolved provider's** (same reasoning as the `supportedUrls` forwarding).

`@vendoai/apps` now exports the capability rule (`acceptsSamplingParams`, `UNKNOWN_MODEL_MAX_OUTPUT_TOKENS`) so the umbrella rides the engine's one allowlist instead of a copy (layer-legal: vendo → apps).

## Tests

New `call-time sampling params on the resolved rung` block in `packages/vendo/src/dev-creds/model.test.ts`, following the existing scripted-provider pattern:

- ladder-resolved `claude-sonnet-5` (`VENDO_MODEL` pin + `ANTHROPIC_API_KEY`) gets NO temperature/topP/topK and the 64K cap, on both `doGenerate` and `doStream`
- a caller's explicit `maxOutputTokens` survives the drop
- a non-Claude resolution (`OPENAI_API_KEY` → `gpt-5`) still gets `temperature: 0` untouched
- a sampling-era Claude resolution (`claude-sonnet-4-6`) still gets `temperature: 0` untouched

## Gates

`pnpm build` (23/23), `pnpm typecheck` (41/41), `pnpm lint --force` (6/6) all green locally. `pnpm test`: 51/53 tasks green; the only 4 failing tests (store SIGKILL drills, vendo provider-fallback resolution) fail identically on clean origin/main in this checkout — they are a local-environment artifact of the worktree living under a path with a space (vitest/child-process file URLs keep `%20` undecoded), unrelated to this change. Changeset included (patch: `@vendoai/vendo`, `@vendoai/apps`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops 400 errors when a Claude 5 model is pinned via the ladder by re-checking sampling support at call time against the resolved rung. Drops rejected sampling params and applies an output cap when the model id is unknown. Fixes #692.

- **Bug Fixes**
  - Re-check sampling capability at call time using the resolved model id.
  - Drop `temperature`, `topP`, `topK` for Claude 5; set `maxOutputTokens` to `UNKNOWN_MODEL_MAX_OUTPUT_TOKENS` unless the caller sets one.
  - Leave sampling-era Claude and non-Claude models unchanged.
  - Export `acceptsSamplingParams` and `UNKNOWN_MODEL_MAX_OUTPUT_TOKENS` from `@vendoai/apps`; add tests for generate and stream paths.

<sup>Written for commit 3bcdfc7a25db48a12a93097b776fab2549284b10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

