### PR TITLE
fix(wire): plain-http anon cookie is Path=/ — stops per-request anonymous identity churn in local dev

### DIFF
--- a/.changeset/anon-cookie-path-root.md
+++ b/.changeset/anon-cookie-path-root.md
@@ -1,0 +1,14 @@
+---
+"@vendoai/vendo": patch
+---
+
+The plain-http anonymous-session cookie is now `Path=/`, matching the secure
+`__Host-` form (#693). The cold-load race fix has hosts mint the pointer on
+their document response, mint-unless-present — but a `Path=/api/vendo` cookie
+never rides a document/page request, so on plain-http localhost such a host
+re-minted on every page load and status poll, overwriting the cookie's one jar
+slot and moving the visitor onto a fresh `anonymous_<id>` subject: list
+endpoints answered `[]` and the second message on any thread failed with
+`threadId is already in use`. https was never affected because `__Host-`
+requires `Path=/`. Existing `Path=/api/vendo` cookies keep working — the wire
+reads the pointer by name and honors it as-is.

--- a/packages/vendo/src/server.test.ts
+++ b/packages/vendo/src/server.test.ts
@@ -1527,7 +1527,7 @@ describe("00 overview / 01-core §2 — per-client anonymous sessions", () => {
     expect(setCookie(response)).toBeNull();        // no new cookie minted
   });
 
-  it("uses Secure __Host- over https and the plain wire-scoped name over http", async () => {
+  it("uses Secure __Host- over https and the plain name over http — both Path=/", async () => {
     const resolver = vi.fn(async () => null);
     const { vendo } = await setup(resolver);
     vi.spyOn(vendo.apps, "list").mockResolvedValue([]);
@@ -1537,12 +1537,82 @@ describe("00 overview / 01-core §2 — per-client anonymous sessions", () => {
     expect(setCookie(https)).toContain("Secure");
     expect(setCookie(https)).toContain("Path=/;");
 
+    // Path=/ on http too (#693): the pointer must ride DOCUMENT requests so a
+    // host minting on its document response can see an existing one.
     const httpReq = new Request("http://host.test/api/vendo/apps", { method: "GET" });
     const http = await vendo.handler(httpReq);
     expect(setCookie(http)).toContain("vendo_anon_session=");
     expect(setCookie(http)).not.toContain("__Host-");
     expect(setCookie(http)).not.toContain("Secure");
-    expect(setCookie(http)).toContain("Path=/api/vendo");
+    expect(setCookie(http)).toContain("Path=/;");
+  });
+
+  it("REGRESSION #693: a plain-http identity survives the host's document-response mint (path-scoped browser jar)", async () => {
+    // The blessed cold-load fix (anon-session-race.test.ts) has the HOST mint
+    // the pointer on its document response, mirroring the wire's own cookie
+    // contract: mint UNLESS the request already carries one. A document path
+    // lives outside BASE_PATH, so whether the browser presents the wire's
+    // cookie there is decided by the cookie's Path attribute alone. A
+    // BASE_PATH-scoped plain-http cookie is invisible on every document/page
+    // request, so the host re-mints per page load and poll — and the re-mint
+    // shares the cookie's one jar slot (same name/host/path), moving the
+    // visitor onto a fresh subject: list endpoints answer [], and the second
+    // message on any thread conflicts. https never had the bug because the
+    // __Host- form REQUIRES Path=/.
+    const seen: string[] = [];
+    const resolver = vi.fn(async () => null);
+    const { vendo } = await setup(resolver);
+    vi.spyOn(vendo.apps, "list").mockImplementation(async (ctx) => {
+      seen.push(ctx.principal.subject);
+      return [];
+    });
+
+    // A browser jar the way real jars work: one slot per name (RFC 6265 §5.3
+    // step 11 — same name/host/path overwrites), and a cookie rides a request
+    // only when the request path falls under its Path attribute (§5.1.4).
+    const jar = new Map<string, { value: string; path: string }>();
+    const storeSetCookie = (header: string | null): void => {
+      if (header === null) return;
+      const [pair, ...attrs] = header.split(";");
+      const eq = pair!.indexOf("=");
+      const path = attrs.map(attr => attr.trim()).find(attr => attr.toLowerCase().startsWith("path="))?.slice(5) ?? "/";
+      jar.set(pair!.slice(0, eq).trim(), { value: pair!.slice(eq + 1).trim(), path });
+    };
+    const cookiesFor = (requestPath: string): string =>
+      [...jar.entries()]
+        .filter(([, cookie]) =>
+          requestPath === cookie.path
+          || (cookie.path.endsWith("/") && requestPath.startsWith(cookie.path))
+          || requestPath.startsWith(`${cookie.path}/`))
+        .map(([name, cookie]) => `${name}=${cookie.value}`)
+        .join("; ");
+    const listApps = async (): Promise<Response> => {
+      const cookie = cookiesFor("/api/vendo/apps");
+      const response = await vendo.handler(new Request("http://localhost:3000/api/vendo/apps", {
+        headers: cookie === "" ? {} : { cookie },
+      }));
+      storeSetCookie(setCookie(response));
+      return response;
+    };
+
+    // 1. A plain-http wire request mints the pointer into the jar.
+    await listApps();
+    const wireCookie = jar.get("vendo_anon_session")!;
+
+    // 2. The host's document response runs mint-unless-present, mirroring the
+    //    wire's contract (name, attributes, and Path all taken from the wire's
+    //    own mint) — exactly what the demos host's middleware does.
+    if (!cookiesFor("/pricing").includes("vendo_anon_session=")) {
+      const raw = new Uint8Array(16);
+      globalThis.crypto.getRandomValues(raw);
+      const hostMinted = Array.from(raw, byte => byte.toString(16).padStart(2, "0")).join("");
+      storeSetCookie(`vendo_anon_session=${hostMinted}; Path=${wireCookie.path}; HttpOnly; SameSite=Lax`);
+    }
+
+    // 3. The next wire request is still the SAME visitor in the same browser.
+    await listApps();
+    expect(seen).toHaveLength(2);
+    expect(seen[1]).toBe(seen[0]);
   });
 
   it("ignores a valid cookie presented under the wrong name for the protocol", async () => {

--- a/packages/vendo/src/wire/context.ts
+++ b/packages/vendo/src/wire/context.ts
@@ -5,7 +5,7 @@ import {
   type Principal,
   type RunContext,
 } from "@vendoai/core";
-import { BASE_PATH, hex, type WireDeps } from "./shared.js";
+import { hex, type WireDeps } from "./shared.js";
 
 /** The anonymous-session machinery + the one shared per-request context
     resolution pass (kill-list B4): opaque anon cookie mint/read/clear, the
@@ -83,11 +83,18 @@ function readAnonCookie(cookieHeader: string | null, secure: boolean): string | 
 
 /** The Set-Cookie for a freshly minted anonymous session. Secure requests get
     the fixation-proof `__Host-` form (Secure + Path=/, per the prefix rules);
-    insecure (localhost http dev) keeps the plain name scoped to the wire base. */
+    insecure (localhost http dev) keeps the plain name. BOTH forms are Path=/:
+    the cold-load race fix lets a host mint the pointer on its DOCUMENT
+    response, mint-unless-present (anon-session-race.test.ts) — and a document
+    request only presents the cookie if its Path covers paths outside the wire
+    base. A BASE_PATH-scoped plain-http cookie was invisible on every page
+    request, so such a host re-minted per page load into the cookie's one jar
+    slot, moving the visitor onto a fresh subject each time (#693); https never
+    had the bug because `__Host-` REQUIRES Path=/. */
 function buildAnonCookie(id: string, secure: boolean): string {
   return secure
     ? `${ANON_COOKIE_SECURE}=${id}; Path=/; HttpOnly; SameSite=Lax; Secure`
-    : `${ANON_COOKIE}=${id}; Path=${BASE_PATH}; HttpOnly; SameSite=Lax`;
+    : `${ANON_COOKIE}=${id}; Path=/; HttpOnly; SameSite=Lax`;
 }
 
 /** The Set-Cookie that CLEARS the anonymous session (block-actions design §C:
@@ -97,7 +104,7 @@ function buildAnonCookie(id: string, secure: boolean): string {
 function clearedAnonCookie(secure: boolean): string {
   return secure
     ? `${ANON_COOKIE_SECURE}=; Path=/; HttpOnly; SameSite=Lax; Secure; Max-Age=0`
-    : `${ANON_COOKIE}=; Path=${BASE_PATH}; HttpOnly; SameSite=Lax; Max-Age=0`;
+    : `${ANON_COOKIE}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0`;
 }
 
 /** Append the minted Set-Cookie to the response. Stream/SSE responses carry


### PR DESCRIPTION
Fixes #693.

## Root cause

The wire mints the anonymous-session cookie with an http/https asymmetry:

- https → `__Host-vendo_anon_session; Path=/` (the prefix REQUIRES `Path=/`)
- plain http → `vendo_anon_session; Path=/api/vendo`

The cold-load race fix (`packages/vendo/src/anon-session-race.test.ts`, `packages/ui/src/client-impl.ts`) blesses hosts minting the pointer on their **document response**, mint-unless-present — and the demos host's middleware implements exactly that, mirroring the wire's cookie contract verbatim. But a `Path=/api/vendo` cookie **never rides a document/page request**, so on plain-http localhost the host sees "no pointer" on every page load and every `/<slug>/demo-status` poll (every 8s), re-mints — and the re-mint shares the cookie's one jar slot (same name/host/path), silently moving the visitor onto a fresh `anonymous_<id>`:

- subject-filtered lists (`GET /api/vendo/<slug>/apps`, `/threads`) answer `[]` forever;
- the second message on any thread hits `{"error":{"code":"conflict","message":"threadId is already in use"}}` (thread owned by the previous identity);
- by-id ops and heartbeats still 200, masking it.

curl never showed it because a curl jar honors `Path=/api/vendo` and curl only talks to the wire — the churn engine is the host's *document-side* surface. https never had it because `__Host-` forces `Path=/`.

## Fix

`buildAnonCookie`/`clearedAnonCookie` use `Path=/` in the insecure form too, matching the secure form. Old `Path=/api/vendo` cookies keep working — the wire reads the pointer by name and honors it as-is (the session row is the authority).

## Proof

**Reproduced live** in the reporter's environment (runvendo/vendo-demos, `next dev`, real Chrome, plain http, `@vendoai/vendo@0.6.0`): turn 1 → 200 + thread id; one demo-status poll; list → `[]`; turn 2 on the same thread → **409 conflict**. With the patched wire (this diff applied to the installed dist) plus the middleware mirroring the new contract: list shows the thread, turn 2 → 200, polls interleaved throughout.

**Regression test** (`server.test.ts` › `REGRESSION #693`): simulates a real path-scoped browser jar plus the blessed document-response mint between two plain-http wire requests, asserting the subject stays stable. Fails on `main` (two different `anonymous_<id>` subjects), passes with the fix. The existing http-cookie-form pin is updated to `Path=/`.

## Gates

- `pnpm build` ✅ (23/23)
- `pnpm test` ✅ — all green except two suites that fail identically on untouched `origin/main` in this environment (worktree path contains a space): `store/src/durability.drill.test.ts` (`Cannot find module '.../Cool%20Code/...'`) and `vendo/src/dev-creds/model.test.ts` (provider module resolution). Both verified pre-existing via `git stash` runs. `packages/vendo` otherwise 1507 passed incl. the new regression test.
- `pnpm typecheck` ✅ · `pnpm lint` ✅

## Follow-up (other repo)

runvendo/vendo-demos' `host/src/middleware.ts` mirrors the wire contract and must update its insecure mint branch to `path: "/"` — until then its own document mint keeps the churn alive locally regardless of the wire version. One-line change, verified locally as part of the proof above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the plain-http anonymous-session cookie to `Path=/` to match the secure `__Host-` form, stopping anonymous identity churn in local dev. Fixes #693.

- **Bug Fixes**
  - Mint and clear now use `Path=/` for http; https behavior unchanged.
  - Added regression test to ensure identity stays stable across document-response mints.
  - Existing `Path=/api/vendo` cookies continue to work; the pointer is read by name.

- **Migration**
  - Update the demos host middleware to mint the insecure cookie with `path: "/"` to fully prevent churn.

<sup>Written for commit 1e8a661ed957f424b80f2ea63092e611010b3b4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

