### PR TITLE
fix(demo-router): forward the visitor's query on the 302

### DIFF
--- a/tools/demo-router/README.md
+++ b/tools/demo-router/README.md
@@ -25,8 +25,9 @@ or rows vanish on redeploy.
 
 - `GET /healthz` → `{ok, demos}`
 - `GET /` → 302 `https://vendo.run`
-- `GET /:id` → live: 302 to the demo (counts a hit); expired/killed: 410 page;
-  unknown: 404 page. Ids are never listed publicly.
+- `GET /:id` → live: 302 to the demo, forwarding the visitor's query so deep
+  links survive the hop (counts a hit); expired/killed: 410 page; unknown: 404
+  page. Ids are never listed publicly.
 
 ## Admin API
 

--- a/tools/demo-router/server.mjs
+++ b/tools/demo-router/server.mjs
@@ -9,7 +9,8 @@ import { createRegistry, RegistryCorruptError, RegistryValidationError, SLUG_PAT
  * Public surface:
  *   GET /            302 -> https://vendo.run
  *   GET /healthz     200 {ok, demos}
- *   GET /:id         live: 302 -> the demo's Railway domain (+ hit counter)
+ *   GET /:id         live: 302 -> the demo's Railway domain, query forwarded
+ *                    (+ hit counter)
  *                    expired/killed: 410 branded "demo has ended" page
  *                    unknown: 404 variant of the same page
  *   Demo ids are NEVER listed publicly.
@@ -87,6 +88,21 @@ const isHttpsUrl = (value) => {
 };
 
 const isIsoDate = (value) => typeof value === "string" && !Number.isNaN(Date.parse(value));
+
+/**
+ * Carry the visitor's query across the 302. A deep link is only a deep link if
+ * its params survive the hop to the demo's own origin —
+ * `demos.vendo.run/keystone?view=rent-roll` landed on the default view without
+ * this. A registry url may carry its own query; both survive, the visitor's
+ * appended last. Re-encoding through `URL` also means a hostile query can never
+ * smuggle a CR/LF into the `Location` header.
+ */
+function withQuery(target, search) {
+  if (search.size === 0) return target;
+  const resolved = new URL(target);
+  for (const [key, value] of search) resolved.searchParams.append(key, value);
+  return resolved.href;
+}
 
 /** Validate one admin-supplied field; returns an error string or null. */
 function fieldError(field, value) {
@@ -191,7 +207,12 @@ export function createRouterServer({
     switch (route.kind) {
       case "live":
         registry.recordHit(id); // best-effort; never blocks the redirect
-        return respond(response, 302, { Location: route.url, "Cache-Control": "no-store" }, undefined);
+        return respond(
+          response,
+          302,
+          { Location: withQuery(route.url, url.searchParams), "Cache-Control": "no-store" },
+          undefined,
+        );
       case "expired":
       case "killed":
         return respondPage(response, 410);

--- a/tools/demo-router/server.test.mjs
+++ b/tools/demo-router/server.test.mjs
@@ -63,6 +63,31 @@ describe("public routes", () => {
     assert.equal(registry.get("acme").hits, 1);
   });
 
+  it("GET /:id forwards the visitor's query to the demo", async () => {
+    const { request } = await boot({ seed: [liveRow] });
+    const response = await request("/acme?view=rent-roll&unit=12B");
+    assert.equal(response.status, 302);
+    assert.equal(response.headers.get("location"), "https://demo-acme.up.railway.app/?view=rent-roll&unit=12B");
+  });
+
+  it("GET /:id keeps the registry url's own query and appends the visitor's", async () => {
+    const { request } = await boot({ seed: [{ ...liveRow, url: "https://demo-acme.up.railway.app/app?tenant=acme" }] });
+    const response = await request("/acme?view=rent-roll");
+    assert.equal(response.status, 302);
+    assert.equal(
+      response.headers.get("location"),
+      "https://demo-acme.up.railway.app/app?tenant=acme&view=rent-roll",
+    );
+  });
+
+  it("GET /:id re-encodes the query, so it cannot smuggle a header", async () => {
+    const { request } = await boot({ seed: [liveRow] });
+    const response = await request("/acme?view=a%0d%0aX-Injected:%201");
+    assert.equal(response.status, 302);
+    assert.equal(response.headers.get("location"), "https://demo-acme.up.railway.app/?view=a%0D%0AX-Injected%3A+1");
+    assert.equal(response.headers.get("x-injected"), null);
+  });
+
   it("GET /:id for an expired demo returns the branded 410 page", async () => {
     const { request } = await boot({ seed: [{ ...liveRow, id: "old", expiresAt: "2020-01-01T00:00:00Z" }] });
     const response = await request("/old");


### PR DESCRIPTION
## What

`demos.vendo.run/<slug>` 302s to the demo's own origin and **dropped the query
string**, so deep links only worked for same-origin navigation inside the demo:

```
$ curl -sI "https://demos.vendo.run/keystone?view=rent-roll" | grep -i location
location: https://host-production-b9a5.up.railway.app/keystone      # query gone
```

The Keystone runbook documents this as a stage caveat ("Navigate with the
sidebar, not with URLs"). This forwards the visitor's query on the redirect.

A registry url may carry a query of its own; both survive, with the visitor's
params appended last. Re-encoding through `URL` also means a hostile query can
never smuggle a CR/LF into the `Location` header.

Note the router lives in this monorepo at `tools/demo-router` (the spec says
"vendo-demos repo" — it isn't; that repo only holds the demo host it points at).

Spec: `docs/superpowers/specs/2026-07-31-keystone-graduates-design.md` — item A6.

## Proof

Three new tests in `tools/demo-router/server.test.mjs`, failing before the
change and passing after (`node --test`, from `tools/demo-router`):

- before (tests only, `server.mjs` stashed): `location` is
  `https://demo-acme.up.railway.app/` — the query is gone; 3 failures
- after: **54/54 pass**

Real run, not just the suite — router booted locally with a keystone-shaped row:

```
$ curl -sI "http://127.0.0.1:8479/keystone?view=rent-roll&unit=12B"
HTTP/1.1 302 Found
Location: https://host-production-b9a5.up.railway.app/keystone?view=rent-roll&unit=12B

$ curl -sI "http://127.0.0.1:8479/keystone"     # no query, byte-identical to today
Location: https://host-production-b9a5.up.railway.app/keystone
```

`tools/demo-router` is deliberately outside the pnpm workspace (zero deps,
standalone deploy), so `node --test` is its whole gate; no workspace file is
touched, and CI runs on this PR regardless.

## Deploy

**Merge ok, deploy after the show.** The `demo-router` Railway service is *not*
GitHub-linked (`source.repo: null`, Dockerfile build via `railway up`), so
merging this cannot redeploy it — verified against the live service before
merging. The redeploy is a deliberate post-YC-show step.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirects from `demos.vendo.run/:id` now forward the visitor’s query to the demo origin so deep links work. Params are re-encoded to prevent header injection via the `Location` header.

- **Bug Fixes**
  - Forward the visitor’s query on 302; appended after any query in the registry URL.
  - Re-encode query via `URL` to block CR/LF smuggling in `Location`.
  - Updated router README and added tests for forwarding, query merge, and header injection.

<sup>Written for commit 7d6f376900ed5a96a5a80dd40a12fcadf8566f6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

