### PR TITLE
fix(ui): the three Keystone-graduate bugs — StrictMode connect hang, composer multiline alignment, app-load retry

### DIFF
--- a/.changeset/keystone-graduates-ui-fixes.md
+++ b/.changeset/keystone-graduates-ui-fixes.md
@@ -1,0 +1,28 @@
+---
+"@vendoai/ui": patch
+---
+
+Three fixes the Keystone demo build turned up.
+
+**ConnectCard hangs on "Connecting…" under React StrictMode.** The card's
+cancel ref was only ever SET (by the effect's cleanup) and never reset on
+setup, so dev-mode's mount → cleanup → re-mount latched it before the user
+ever clicked: `completeConnection`'s poll loop saw "cancelled" on its first
+check, returned without throwing, and the card sat on the spinner forever.
+It now resets on setup, exactly like its sibling `ConnectedAccountsPanel`
+already did. Hosts no longer need `reactStrictMode: false` to demo a connect.
+
+**The composer centred its own text past one line.** `.fl-composer-row` was
+`align-items: flex-end`, which is right for a one-line field and wrong for
+every other: a textarea's text sits at ITS top, so as the field grew the row
+pushed the icons and Send DOWN while the text stayed put — the input read as
+mis-centred and Send moved under the cursor mid-sentence. The row is now
+top-anchored, so the field grows downward and the controls hold still. At one
+line the icon's 34px box and the text's 33px line box agree, so the collapsed
+composer is unchanged.
+
+**A single failed `apps.open` skeletoned a pinned app forever.** `useApp`
+recorded the error and every mounted surface kept rendering "Loading app…"
+until a full page reload. The load now retries three times with backoff
+(300ms, 600ms), and a load that really is dead renders a terminal state with
+a "Try again" button — in `VendoSlot` and in `VendoPage`'s app pane.

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -741,8 +741,14 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the wave-2
     0 10px 28px color-mix(in srgb, var(--vendo-fg) 7%, transparent),
     0 0 0 3px var(--vendo-accent-soft); }
 .fl-composer-drag { border-color: var(--vendo-accent); }
-/* align-items:flex-end so the buttons sit at the bottom as the field grows. */
-.fl-composer-row { display: flex; align-items: flex-end; gap: 10px; }
+/* align-items:flex-start so the text grows DOWNWARD from a fixed top edge and
+   the controls stay where the user last saw them. flex-end (the old rule) was
+   right for a one-line field and wrong for every other: the textarea's own text
+   sits at ITS top, so past one line the row pushed the icons and Send down while
+   the text stayed put — the field read as mis-centred and Send moved under the
+   cursor mid-sentence. At one line the icon's 34px box and the text's 33px line
+   box agree within half a pixel, so the collapsed composer is unchanged. */
+.fl-composer-row { display: flex; align-items: flex-start; gap: 10px; }
 .fl-composer textarea { flex: 1; border: 0; outline: 0; background: transparent; color: var(--vendo-fg);
   font-family: var(--vendo-font); font-size: var(--vendo-base-size); line-height: 1.5; resize: none; max-height: 200px;
   padding: 6px 0; overflow-y: auto; scrollbar-width: none; }

--- a/packages/ui/src/chrome/connect-card.tsx
+++ b/packages/ui/src/chrome/connect-card.tsx
@@ -77,8 +77,12 @@ export function ConnectCard({ connector, toolkit, message, onConnected, live = t
   // branding after the prop changes.
   const [logoFailedFor, setLogoFailedFor] = useState<string>();
   const cancelled = useRef(false);
-  useEffect(() => () => {
-    cancelled.current = true;
+  useEffect(() => {
+    // cancelled persists across effects; reset for StrictMode remounts.
+    cancelled.current = false;
+    return () => {
+      cancelled.current = true;
+    };
   }, []);
 
   // The host's catalog label wins when it named this toolkit (same rule as

--- a/packages/ui/src/chrome/vendo-page.tsx
+++ b/packages/ui/src/chrome/vendo-page.tsx
@@ -134,13 +134,25 @@ function ChatWorkspace({ thread }: { thread?: VendoPageProps["thread"] }) {
 
 function OpenApp({ appId }: { appId: string }) {
   const { client, components } = useVendoContext();
-  const { surface, refresh } = useApp(appId);
+  const { surface, error, isLoading, refresh } = useApp(appId);
   // Wave 7 H2 — same keepalive as VendoSlot's MountedApp (see frames.tsx).
   const keepalive = useMemo(
     () => ({ ping: () => client.apps.pingMachine(appId), reopen: refresh }),
     [appId, client, refresh],
   );
-  if (!surface) return <div role="status">Opening app…</div>;
+  if (!surface) {
+    // useApp has already spent its retries; without a way to ask again the
+    // pane sat on "Opening app…" until a page reload (Keystone graduates A5).
+    if (error && !isLoading) {
+      return (
+        <div role="alert" className="fl-error">
+          This app didn’t open — {error.message}
+          <button type="button" className="fl-error-retry" onClick={() => void refresh()}>Try again</button>
+        </div>
+      );
+    }
+    return <div role="status">Opening app…</div>;
+  }
   return <AppFrame key={appId} surface={surface} components={components} keepalive={keepalive} onAction={({ action, payload }) => client.apps.call(appId, action, payload ?? {})} />;
 }
 

--- a/packages/ui/src/chrome/vendo-slot.tsx
+++ b/packages/ui/src/chrome/vendo-slot.tsx
@@ -41,9 +41,25 @@ function SlotGhost({ label, detail, loading = false }: { label: string; detail?:
   );
 }
 
+/** The terminal load failure. useApp already spent its retries, so this is a
+ *  dead end until the user asks again — and without a way to ask, the slot sat
+ *  on its skeleton until a page reload (Keystone graduates A5). */
+function SlotLoadFailed({ reason, onRetry }: { reason: Error; onRetry(): void }) {
+  return (
+    <div className="fl-slot-ghost">
+      <GhostSkeleton />
+      <span className="fl-slot-cta" role="alert">
+        <span className="fl-slot-cta-label">This view didn’t load</span>
+        <small>{reason.message}</small>
+        <button type="button" className="fl-invite-btn" onClick={onRetry}>Try again</button>
+      </span>
+    </div>
+  );
+}
+
 function MountedApp({ appId }: { appId: string }) {
   const { client, components } = useVendoContext();
-  const { surface, refresh } = useApp(appId);
+  const { surface, error, isLoading, refresh } = useApp(appId);
   // Wave 7 H2 — the served-surface keepalive: user activity pings the machine
   // (host-proxied) so an embedded served app doesn't idle out under the user;
   // a "woke" ping re-opens for the fresh machine URL.
@@ -51,7 +67,10 @@ function MountedApp({ appId }: { appId: string }) {
     () => ({ ping: () => client.apps.pingMachine(appId), reopen: refresh }),
     [appId, client, refresh],
   );
-  if (!surface) return <SlotGhost label="Loading app…" loading />;
+  if (!surface) {
+    if (error && !isLoading) return <SlotLoadFailed reason={error} onRetry={() => void refresh()} />;
+    return <SlotGhost label="Loading app…" loading />;
+  }
   return <AppFrame key={appId} surface={surface} components={components} keepalive={keepalive} onAction={({ action, payload }) => client.apps.call(appId, action, payload ?? {})} />;
 }
 

--- a/packages/ui/src/hooks/use-app.ts
+++ b/packages/ui/src/hooks/use-app.ts
@@ -4,6 +4,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useVendoContext } from "../context.js";
 import type { EditResult, OpenSurface, VersionEntry } from "../wire-types.js";
 
+/** How many times a load may try before the error becomes the user's problem.
+ *  A pinned app is mounted, unattended chrome — one dropped `apps.open` used to
+ *  leave every surface on its skeleton until a full page reload. */
+const LOAD_ATTEMPTS = 3;
+/** Doubling from here: 300ms, 600ms. Short enough that a transient blip heals
+ *  inside the skeleton the user is already looking at. */
+const RETRY_BASE_MS = 300;
+
 export function useApp(appId: AppId): {
   app: AppDocument | undefined;
   /** Alias for `app` — the consistent `data` field across data hooks (§3). */
@@ -30,19 +38,27 @@ export function useApp(appId: AppId): {
     // Mirror useResource: bump per call, so overlapping refreshes (manual +
     // edit + undo) can never let a stale response clobber newer app state.
     const generation = (generationRef.current += 1);
+    const current = () => generation === generationRef.current;
     if (!loadedRef.current) setIsLoading(true);
-    try {
-      const [nextApp, nextSurface] = await Promise.all([client.apps.get(appId), client.apps.open(appId)]);
-      if (generation !== generationRef.current) return;
-      setApp(nextApp);
-      setSurface(nextSurface);
-      setError(undefined);
-      loadedRef.current = true;
-    } catch (reason) {
-      if (generation !== generationRef.current) return;
-      setError(reason instanceof Error ? reason : new Error(String(reason)));
-    } finally {
-      if (generation === generationRef.current) setIsLoading(false);
+    setError(undefined);
+    for (let attempt = 1; current(); attempt += 1) {
+      try {
+        const [nextApp, nextSurface] = await Promise.all([client.apps.get(appId), client.apps.open(appId)]);
+        if (!current()) return;
+        setApp(nextApp);
+        setSurface(nextSurface);
+        loadedRef.current = true;
+        setIsLoading(false);
+        return;
+      } catch (reason) {
+        if (!current()) return;
+        if (attempt >= LOAD_ATTEMPTS) {
+          setError(reason instanceof Error ? reason : new Error(String(reason)));
+          setIsLoading(false);
+          return;
+        }
+        await new Promise(resolve => setTimeout(resolve, RETRY_BASE_MS * 2 ** (attempt - 1)));
+      }
     }
   }, [appId, client]);
 

--- a/packages/ui/test/chrome/app-load-retry.test.tsx
+++ b/packages/ui/test/chrome/app-load-retry.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+// Keystone graduates A5 — a transient `apps.open` failure used to skeleton a
+// pinned app forever: useApp recorded the error, every surface kept rendering
+// "Loading app…", and only a full page reload got the user out. The load now
+// retries with backoff, and a load that really is dead offers a way back in.
+import type { AppDocument } from "@vendoai/core";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
+import { VendoSlot } from "../../src/chrome/index.js";
+import { createWireServer } from "../wire-server.js";
+
+const pinned: AppDocument = {
+  format: "vendo/app@1",
+  id: "app_1",
+  name: "Invoices",
+  ui: "tree",
+  tree: {
+    formatVersion: "vendo-genui/v2",
+    root: "root",
+    nodes: [{ id: "root", component: "Text", props: { text: "Invoices app surface" } }],
+  },
+  pins: [{ slot: "hero", base: "sha256:abc123" }],
+};
+
+describe("useApp load retry (Keystone graduates A5)", () => {
+  let wire: Awaited<ReturnType<typeof createWireServer>>;
+  let client: VendoClient;
+
+  beforeEach(async () => {
+    wire = await createWireServer();
+    client = createVendoClient({ baseUrl: wire.url });
+    vi.spyOn(client.apps, "list").mockResolvedValue([pinned]);
+  });
+
+  afterEach(async () => {
+    cleanup();
+    vi.restoreAllMocks();
+    await wire.close();
+  });
+
+  it("rides out a transient open failure instead of skeletoning forever", async () => {
+    const open = client.apps.open.bind(client.apps);
+    const spy = vi.spyOn(client.apps, "open")
+      .mockRejectedValueOnce(new Error("network hiccup"))
+      .mockImplementation(open);
+
+    render(<VendoProvider client={client}><VendoSlot id="hero" /></VendoProvider>);
+
+    expect(await screen.findByText("Invoices app surface")).toBeTruthy();
+    expect(spy.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("gives up after a bounded number of attempts and offers a retry", async () => {
+    const open = client.apps.open.bind(client.apps);
+    const spy = vi.spyOn(client.apps, "open").mockRejectedValue(new Error("app machine is down"));
+
+    render(<VendoProvider client={client}><VendoSlot id="hero" /></VendoProvider>);
+
+    const retry = await screen.findByRole("button", { name: /try again/i });
+    expect(spy.mock.calls).toHaveLength(3);
+    expect(screen.getByRole("alert").textContent).toContain("app machine is down");
+
+    // The affordance is real: with the wire healed, the same button loads the app.
+    spy.mockImplementation(open);
+    fireEvent.click(retry);
+    expect(await screen.findByText("Invoices app surface")).toBeTruthy();
+  });
+
+  it("keeps showing the skeleton while the retries are still in flight", async () => {
+    vi.spyOn(client.apps, "open").mockRejectedValue(new Error("app machine is down"));
+
+    render(<VendoProvider client={client}><VendoSlot id="hero" /></VendoProvider>);
+
+    await waitFor(() => expect(screen.getByRole("status").textContent).toContain("Loading app…"));
+    expect(screen.queryByRole("button", { name: /try again/i })).toBeNull();
+  });
+});

--- a/packages/ui/test/chrome/composer.test.tsx
+++ b/packages/ui/test/chrome/composer.test.tsx
@@ -143,6 +143,23 @@ describe("composer: type-while-streaming, queued send, edit, regenerate (ENG-215
     await waitFor(() => expect(screen.queryByText("Original question", { selector: ".fl-usertext" })).toBeNull());
   });
 
+  it("top-aligns the composer row so multiline text does not centre itself", async () => {
+    // With `align-items: flex-end` the row's controls ride DOWN as the textarea
+    // grows while the text stays at the top of it: past one line the field
+    // reads as mis-centred and Send moves under the cursor mid-sentence
+    // (Yousef's screenshot, Keystone). Anchoring the row to the top keeps the
+    // icons and Send where the user last saw them; at one line the icon's 34px
+    // box and the text's line box still agree, so the collapsed composer is
+    // unchanged. jsdom has no layout, but it does resolve the cascade — and the
+    // cascade is exactly what this fix is.
+    render(<VendoProvider client={client}><VendoThread threadId="thr_1" /></VendoProvider>);
+    await screen.findByText("Existing thread");
+
+    type("first line\nsecond line\nthird line");
+    const row = composer().closest(".fl-composer-row") as HTMLElement;
+    expect(getComputedStyle(row).alignItems).toBe("flex-start");
+  });
+
   it("regenerates the last assistant response", async () => {
     render(<VendoProvider client={client}><VendoThread threadId="thr_1" /></VendoProvider>);
     await screen.findByText("Existing thread");

--- a/packages/ui/test/chrome/connect.test.tsx
+++ b/packages/ui/test/chrome/connect.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { StrictMode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
 import { ConnectCard, ConnectedAccountsPanel } from "../../src/chrome/index.js";
@@ -101,6 +102,26 @@ describe("ConnectCard and ConnectedAccountsPanel", () => {
     // Give the one-shot /connections read time to settle: still nothing.
     await waitFor(() => expect(wire.requests.some(r => r.method === "GET" && r.path === "/connections")).toBe(true));
     expect(container.querySelector(".fl-approval")).toBeNull();
+  });
+
+  it("still completes after a StrictMode remount (the cancel latch resets)", async () => {
+    // React's dev StrictMode mounts, tears down, and re-mounts every effect.
+    // A cancel ref that is only ever SET by the cleanup stays latched through
+    // the second mount, so the poll loop in completeConnection exits on its
+    // first check and the card sits on "Connecting…" forever (the demo host
+    // had to ship reactStrictMode:false because of this).
+    vi.stubGlobal("open", vi.fn());
+    const onConnected = vi.fn();
+    render(
+      <StrictMode>
+        <VendoProvider client={client}>
+          <ConnectCard connector="composio" toolkit="gmail" message="Connect gmail." onConnected={onConnected} />
+        </VendoProvider>
+      </StrictMode>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Connect Gmail" }));
+    await waitFor(() => expect(onConnected).toHaveBeenCalledTimes(1));
+    expect((await screen.findByRole("status")).textContent).toContain("Connected");
   });
 
   it("surfaces an initiation failure inline and stays retryable", async () => {


### PR DESCRIPTION
Lane 1 of the **Keystone graduates** wave — the three `packages/ui` bugs the YC
demo build turned up. Spec:
`docs/superpowers/specs/2026-07-31-keystone-graduates-design.md` (items A1, A2, A5).

Each fix has a test that fails on `main` and passes here.

## A1 — ConnectCard hangs on "Connecting…" under StrictMode

`connect-card.tsx` set `cancelled.current = true` in the effect's cleanup and
never reset it on setup. React's dev StrictMode mounts → tears down → re-mounts,
so the latch was already `true` before the user clicked anything:
`completeConnection`'s poll loop failed its very first `!isCancelled()` check,
fell out of the loop, skipped the timeout throw (also cancel-guarded) and
returned normally — and `connect()`'s own `if (cancelled.current) return` left
the phase on `"connecting"` forever. No error, no spinner end.

The sibling `connected-accounts-panel.tsx` already had the right pattern with a
comment saying why; this is the identical two lines.

Downstream: hosts no longer need `reactStrictMode: false` to demo a connect
(the demo host's workaround is reverted post-show, per the spec).

**Test:** `test/chrome/connect.test.tsx` — the card renders inside
`<StrictMode>`, the user clicks Connect, and `onConnected` has to fire.

## A2 — the composer centres its own text past one line

`.fl-composer-row` was `align-items: flex-end`. That is right for a one-line
field and wrong for every other one: a textarea's text sits at *its* top, so as
the field grew the row pushed the icons and Send **down** while the text stayed
put — the input read as mis-centred, and Send moved under the cursor
mid-sentence. (Yousef's screenshot during the Keystone build.)

Top-anchoring the row lets the field grow downward and pins the controls where
the user last saw them. At one line the icon's 34px box and the text's 33px line
box agree within half a pixel, so the collapsed composer is pixel-unchanged.
This ports the demo host's scoped `.vendo-root .fl-composer-row` override —
marked UPSTREAM-WORTHY in its own comment — into the package properly.

**Test:** `test/chrome/composer.test.tsx` — jsdom has no layout but it does
resolve the cascade, and the cascade is exactly what this fix is.

## A5 — one failed `apps.open` skeletons a pinned app forever

`useApp` recorded the error and stopped. Every mounted surface then rendered
"Loading app…" (VendoSlot) / "Opening app…" (VendoPage) until a full page
reload — no retry, no way out, on chrome that is typically unattended.

- The load retries up to 3 attempts with backoff (300ms, 600ms), so a transient
  blip heals inside the skeleton the user is already looking at.
- A load that really is dead now renders a terminal state carrying the reason
  and a **Try again** button, in both surfaces.

**Tests:** `test/chrome/app-load-retry.test.tsx` — a transient failure recovers
on its own; a permanent one stops at exactly 3 attempts, shows the retry, and
the retry actually reloads the app once the wire heals; the skeleton (not the
error) is what shows while retries are in flight.

## Gate

`pnpm build && pnpm test && pnpm typecheck && pnpm lint` all green
(670 tests in `@vendoai/ui`, 53 tasks across the monorepo).

Changeset included (`patch`). Per the spec's hard constraint the npm release and
every demo-fleet redeploy queue until after the YC show — this PR is code only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three Keystone graduates bugs in `@vendoai/ui`: prevents StrictMode connect hangs, keeps composer controls aligned on multiline input, and adds retry + “Try again” for app loads so pinned apps don’t skeleton forever. Covers spec items A1, A2, and A5.

- **Bug Fixes**
  - A1: `ConnectCard` resets its cancel ref on effect setup; connection now completes under React StrictMode. Hosts no longer need `reactStrictMode: false`.
  - A2: `.fl-composer-row` is top-aligned (`align-items: flex-start`) so text grows downward and icons/Send stay fixed; single-line layout unchanged.
  - A5: `useApp` retries loads up to 3 times with backoff (300ms, 600ms). When exhausted, shows a terminal error with a “Try again” button in `VendoSlot` and `VendoPage`; skeleton remains during in-flight retries.

<sup>Written for commit 49897968af674f0a2a8f77ba81bd669eabee93ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

