### PR TITLE
fix(telemetry): the capture socket can never hold the CLI open after Done

### DIFF
--- a/.changeset/telemetry-never-holds-the-process.md
+++ b/.changeset/telemetry-never-holds-the-process.md
@@ -1,0 +1,21 @@
+---
+"@vendoai/telemetry": patch
+---
+
+Telemetry can no longer keep a process alive after its work is done. On a
+captive-portal network — one that accepts the TCP connection to the capture
+endpoint and then never answers — `vendo init` printed its summary and sat
+there for another ten seconds doing nothing; `DO_NOT_TRACK=1` removed the pause
+entirely, naming telemetry as the handle. The cause is Node's global fetch
+(undici): aborting the request does not destroy a socket that is still
+connecting, so it stayed alive until undici's own 10s connect timeout.
+
+The default transport is now a raw request whose socket is unref'd the moment
+it exists, so a stranded telemetry POST can never be the last handle holding
+the CLI open, under any network condition. The timeout — unchanged at 1.5s — is
+now the only thing a caller ever waits on. An injected `fetchImpl` still takes
+the fetch path, so hosts and tests that supply their own are unaffected.
+
+Also adds `VENDO_POSTHOG_HOST`, which points capture events at a self-hosted
+PostHog instead of the shipped US cloud (`VENDO_POSTHOG_KEY` already set the
+project key).

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -91,6 +91,8 @@ Set `"optedOut": false` in `~/.vendo/telemetry.json` to clear the local opt-out 
 
 ## Where Data Goes
 
-Product events are sent to PostHog US Cloud using a write-only project key. Network calls are fire-and-forget, use a short timeout, and failures are swallowed so telemetry cannot break builds or dev servers.
+Product events are sent to PostHog US Cloud using a write-only project key. Set `VENDO_POSTHOG_HOST` to send them to your own PostHog instead (`VENDO_POSTHOG_KEY` sets the project key); the path is always `/capture/`.
+
+Network calls are fire-and-forget, use a short timeout, and failures are swallowed so telemetry cannot break builds or dev servers. The capture socket is unref'd the moment it exists, so a telemetry POST can never keep the CLI running after a command finishes — on a captive-portal network that accepts the connection and never answers, `vendo init` still exits as soon as it prints its summary.
 
 Published package download attribution is wired through Scarf for npm installs. Scarf registration is an owner-operated package setup step.

--- a/fixtures/integration/src/telemetry-wire.e2e.test.ts
+++ b/fixtures/integration/src/telemetry-wire.e2e.test.ts
@@ -3,7 +3,7 @@
  * The umbrella composed with `telemetry: true` fires anonymous product telemetry
  * from the wire (server.ts: `deps.telemetry?.track("agent_run", …)` on POST
  * /threads). This journey proves the end-to-end contract of TELEMETRY.md against
- * the REAL composed client by intercepting the PostHog capture endpoint:
+ * the REAL composed client, pointed at a capture endpoint of our own:
  *
  *   - OPT-IN  (consent granted): a wire chat turn produces exactly one capture,
  *     whose event name is in the closed EVENT_ALLOWLIST and whose properties are
@@ -16,13 +16,12 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 import { createHash } from "node:crypto";
+import { createServer } from "node:http";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { EVENT_ALLOWLIST, initTelemetry, type EventName, type Telemetry } from "@vendoai/telemetry";
 import { createStack, readSse, resetFixture, textTurn, ADA, type Stack } from "./harness.js";
-
-const POSTHOG = "https://us.i.posthog.com";
 
 interface Capture {
   event: string;
@@ -31,25 +30,34 @@ interface Capture {
   distinct_id?: string;
 }
 
-/** Install a global-fetch shim that captures PostHog capture POSTs and passes
- * every other request (the wire, the host app, host tools) through untouched. */
-function captureTelemetry(): { captures: Capture[]; restore: () => void } {
+/** Stand a real capture endpoint up on loopback and point the client at it
+ * through VENDO_POSTHOG_HOST. A local server, not a fetch stub: the shipped
+ * client posts over a raw socket it can unref (so a stranded telemetry POST
+ * can never hold a process open), which a `globalThis.fetch` shim would never
+ * see. Every other request — the wire, the host app, host tools — is untouched. */
+async function captureTelemetry(): Promise<{ captures: Capture[]; restore: () => Promise<void> }> {
   const captures: Capture[] = [];
-  const realFetch = globalThis.fetch;
-  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-    if (url.startsWith(POSTHOG)) {
-      const body = typeof init?.body === "string" ? init.body : "";
+  const server = createServer((request, response) => {
+    const chunks: Buffer[] = [];
+    request.on("data", (chunk: Buffer) => chunks.push(chunk));
+    request.on("end", () => {
       try {
-        captures.push(JSON.parse(body) as Capture);
+        captures.push(JSON.parse(Buffer.concat(chunks).toString("utf8")) as Capture);
       } catch {
         // A malformed body would itself be a telemetry regression; record nothing.
       }
-      return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
-    }
-    return realFetch(input as never, init);
-  }) as typeof fetch;
-  return { captures, restore: () => { globalThis.fetch = realFetch; } };
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end("{}");
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") throw new Error("no capture port");
+  process.env.VENDO_POSTHOG_HOST = `http://127.0.0.1:${address.port}`;
+  return {
+    captures,
+    restore: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
 }
 
 async function driveTurn(stack: Stack, threadId: string): Promise<void> {
@@ -72,7 +80,7 @@ async function waitForCaptures(captures: Capture[], atLeast: number, timeoutMs =
 }
 
 let stack: Stack | undefined;
-let restoreFetch: (() => void) | undefined;
+let restoreCapture: (() => Promise<void>) | undefined;
 let tempHome: string | undefined;
 const savedEnv: Record<string, string | undefined> = {};
 
@@ -89,8 +97,8 @@ function restoreEnv(): void {
 afterEach(async () => {
   await stack?.close();
   stack = undefined;
-  restoreFetch?.();
-  restoreFetch = undefined;
+  await restoreCapture?.();
+  restoreCapture = undefined;
   restoreEnv();
   if (tempHome !== undefined) await rm(tempHome, { recursive: true, force: true });
   tempHome = undefined;
@@ -99,7 +107,7 @@ afterEach(async () => {
 describe("J11: telemetry emits only allowlisted events, and nothing when opted out", () => {
   it("(opt-in) a wire turn emits exactly one allowlisted, allowlist-scoped event", async () => {
     await resetFixture();
-    saveEnv("CI", "NODE_ENV", "HOME", "VENDO_TELEMETRY_DISABLED", "DO_NOT_TRACK");
+    saveEnv("CI", "NODE_ENV", "HOME", "VENDO_TELEMETRY_DISABLED", "DO_NOT_TRACK", "VENDO_POSTHOG_HOST");
     tempHome = await mkdtemp(join(tmpdir(), "vendo-j11-home-"));
     delete process.env.CI; // CI fails consent closed
     delete process.env.VENDO_TELEMETRY_DISABLED;
@@ -107,8 +115,8 @@ describe("J11: telemetry emits only allowlisted events, and nothing when opted o
     process.env.NODE_ENV = "test"; // runtime consent needs an explicit dev/test env
     process.env.HOME = tempHome;
 
-    const telemetry = captureTelemetry();
-    restoreFetch = telemetry.restore;
+    const telemetry = await captureTelemetry();
+    restoreCapture = telemetry.restore;
 
     stack = await createStack({ telemetry: true, turns: [textTurn("Hi.", "t1")] });
     await driveTurn(stack, "thr_j11_in");
@@ -131,15 +139,15 @@ describe("J11: telemetry emits only allowlisted events, and nothing when opted o
 
   it("(opt-out) the identical turn under VENDO_TELEMETRY_DISABLED emits nothing", async () => {
     await resetFixture();
-    saveEnv("CI", "NODE_ENV", "HOME", "VENDO_TELEMETRY_DISABLED");
+    saveEnv("CI", "NODE_ENV", "HOME", "VENDO_TELEMETRY_DISABLED", "VENDO_POSTHOG_HOST");
     tempHome = await mkdtemp(join(tmpdir(), "vendo-j11-home-"));
     delete process.env.CI;
     process.env.NODE_ENV = "test";
     process.env.HOME = tempHome;
     process.env.VENDO_TELEMETRY_DISABLED = "1"; // explicit env opt-out
 
-    const telemetry = captureTelemetry();
-    restoreFetch = telemetry.restore;
+    const telemetry = await captureTelemetry();
+    restoreCapture = telemetry.restore;
 
     stack = await createStack({ telemetry: true, turns: [textTurn("Hi.", "t1")] });
     await driveTurn(stack, "thr_j11_out");

--- a/packages/vendo-telemetry/src/client.test.ts
+++ b/packages/vendo-telemetry/src/client.test.ts
@@ -180,6 +180,40 @@ describe("default transport (no fetchImpl)", () => {
     }
   });
 
+  it("follows a capture redirect, the way fetch did (review: proxied self-hosts move)", async () => {
+    const bodies: string[] = [];
+    const destination = createHttpServer((request, response) => {
+      const chunks: Buffer[] = [];
+      request.on("data", (chunk: Buffer) => chunks.push(chunk));
+      request.on("end", () => {
+        bodies.push(Buffer.concat(chunks).toString("utf8"));
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end("{}");
+      });
+    });
+    await new Promise<void>((resolve) => destination.listen(0, "127.0.0.1", resolve));
+    const destinationPort = (destination.address() as { port: number }).port;
+    const proxy = createHttpServer((request, response) => {
+      request.resume();
+      response.writeHead(308, { location: `http://127.0.0.1:${destinationPort}/capture/` });
+      response.end();
+    });
+    await new Promise<void>((resolve) => proxy.listen(0, "127.0.0.1", resolve));
+    const proxyPort = (proxy.address() as { port: number }).port;
+    try {
+      const deps = makeDeps({
+        fetchImpl: undefined,
+        env: { VENDO_POSTHOG_HOST: `http://127.0.0.1:${proxyPort}` },
+      });
+      await createTelemetry(deps).track("init_started", { framework: "next" });
+      expect(bodies).toHaveLength(1);
+      expect(JSON.parse(bodies[0]!).event).toBe("init_started");
+    } finally {
+      await new Promise<void>((resolve) => proxy.close(() => resolve()));
+      await new Promise<void>((resolve) => destination.close(() => resolve()));
+    }
+  });
+
   it("returns on the timeout when the endpoint accepts the connection and never answers", async () => {
     const held: Socket[] = [];
     const blackHole = createSocketServer((socket) => {

--- a/packages/vendo-telemetry/src/client.test.ts
+++ b/packages/vendo-telemetry/src/client.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { createServer as createHttpServer } from "node:http";
+import { createServer as createSocketServer, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
@@ -112,6 +114,20 @@ describe("createTelemetry.track", () => {
     await expect(t.track("agent_run", {})).resolves.toBeUndefined();
   });
 
+  it("sends to a VENDO_POSTHOG_HOST override instead of the shipped cloud", async () => {
+    const deps = makeDeps({ env: { VENDO_POSTHOG_HOST: "https://posthog.internal:8000" } });
+    const t = createTelemetry(deps);
+    await t.track("init_started", { framework: "next" });
+    expect(String(deps.fetchImpl.mock.calls[0][0])).toBe("https://posthog.internal:8000/capture/");
+  });
+
+  it("falls back to the shipped cloud when the override is unusable", async () => {
+    const deps = makeDeps({ env: { VENDO_POSTHOG_HOST: "not a url" } });
+    const t = createTelemetry(deps);
+    await t.track("init_started", { framework: "next" });
+    expect(String(deps.fetchImpl.mock.calls[0][0])).toContain("us.i.posthog.com");
+  });
+
   it("returns after the telemetry timeout when fetch never settles", async () => {
     vi.useFakeTimers();
     try {
@@ -127,6 +143,67 @@ describe("createTelemetry.track", () => {
       vi.useRealTimers();
     }
   });
+});
+
+/**
+ * The default transport — no injected fetchImpl, a real socket. It exists
+ * because Node's global fetch keeps a connecting socket alive after an abort,
+ * which held `vendo init` open for ten seconds past its summary on a
+ * captive-portal network. The socket is unref'd, so the timeout is the only
+ * bound; `packages/vendo/src/cli/telemetry-exit.test.ts` proves the exit
+ * guarantee on the real CLI process.
+ */
+describe("default transport (no fetchImpl)", () => {
+  it("posts the capture body over a real socket", async () => {
+    const bodies: string[] = [];
+    const server = createHttpServer((request, response) => {
+      const chunks: Buffer[] = [];
+      request.on("data", (chunk: Buffer) => chunks.push(chunk));
+      request.on("end", () => {
+        bodies.push(Buffer.concat(chunks).toString("utf8"));
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end("{}");
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as { port: number }).port;
+    try {
+      const deps = makeDeps({
+        fetchImpl: undefined,
+        env: { VENDO_POSTHOG_HOST: `http://127.0.0.1:${port}` },
+      });
+      await createTelemetry(deps).track("init_started", { framework: "next" });
+      expect(bodies).toHaveLength(1);
+      expect(JSON.parse(bodies[0]!).event).toBe("init_started");
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("returns on the timeout when the endpoint accepts the connection and never answers", async () => {
+    const held: Socket[] = [];
+    const blackHole = createSocketServer((socket) => {
+      socket.on("error", () => {});
+      held.push(socket);
+    });
+    await new Promise<void>((resolve) => blackHole.listen(0, "127.0.0.1", resolve));
+    const port = (blackHole.address() as { port: number }).port;
+    try {
+      const deps = makeDeps({
+        fetchImpl: undefined,
+        // https against a server that never speaks TLS: the handshake hangs,
+        // which is the exact captive-portal shape.
+        env: { VENDO_POSTHOG_HOST: `https://127.0.0.1:${port}` },
+      });
+      const started = Date.now();
+      await expect(createTelemetry(deps).track("init_started", { framework: "next" }))
+        .resolves.toBeUndefined();
+      expect(Date.now() - started).toBeLessThan(4000);
+    } finally {
+      for (const socket of held) socket.destroy();
+      await new Promise<void>((resolve) => blackHole.close(() => resolve()));
+    }
+  }, 15_000);
 });
 
 const CLOUD_KEY = `vnd_${"0123456789abcdef".repeat(2)}01234567`; // 40 hex chars

--- a/packages/vendo-telemetry/src/client.ts
+++ b/packages/vendo-telemetry/src/client.ts
@@ -1,4 +1,6 @@
 import { createHash } from "node:crypto";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
 import { resolveConsent } from "./consent.js";
 import { baseProps, projectProps, type ProjectProps } from "./base-props.js";
 import { CLOUD_PROP_KEYS, EVENT_ALLOWLIST, type EventName } from "./events.js";
@@ -69,9 +71,88 @@ function filterToAllowlist(
   return out;
 }
 
-function unrefTimer(timer: ReturnType<typeof setTimeout>): void {
-  if (typeof timer === "object" && timer !== null && "unref" in timer) {
-    (timer as { unref?: () => void }).unref?.();
+/** Posts one capture body. Resolves on success, failure, or timeout — never
+ *  rejects, and never outlives TIMEOUT_MS. */
+type Post = (endpoint: string, body: string) => Promise<void>;
+
+/**
+ * The default transport, and the reason it is not `fetch`. Node's global fetch
+ * (undici) leaves a connecting socket alive after the request is aborted: on a
+ * captive-portal network — one that accepts TCP and then never answers —
+ * `vendo init` printed its summary and then sat there doing nothing until
+ * undici's 10s connect timeout expired. A raw request hands us the socket, so
+ * we unref it the moment it exists: a stranded telemetry POST can never be the
+ * last handle keeping the CLI alive, under any network condition.
+ *
+ * The timeout is therefore the ONLY thing holding the caller — ref'd on
+ * purpose, so an exiting process still reports its command's exit code instead
+ * of racing an unref'd event loop to zero handles.
+ */
+function socketPost(endpoint: string, body: string): Promise<void> {
+  return new Promise((resolve) => {
+    const url = new URL(endpoint);
+    const send = url.protocol === "http:" ? httpRequest : httpsRequest;
+    const request = send(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", "content-length": Buffer.byteLength(body) },
+    });
+    let settled = false;
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      request.destroy();
+      resolve();
+    };
+    const timer = setTimeout(finish, TIMEOUT_MS);
+    request.on("socket", (socket) => socket.unref());
+    request.on("response", (response) => {
+      response.resume();
+      response.on("end", finish);
+      response.on("error", finish);
+    });
+    request.on("error", finish);
+    request.end(body);
+  });
+}
+
+/** Transport for an injected `fetchImpl` (tests, and hosts that supply their
+ *  own). A fetch response body is not a handle we can unref, so here the
+ *  abort + timeout pair is the whole bound. */
+function fetchPost(fetchImpl: typeof fetch): Post {
+  return (endpoint, body) => new Promise<void>((resolve) => {
+    const controller = new AbortController();
+    let settled = false;
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      controller.abort();
+      finish();
+    }, TIMEOUT_MS);
+
+    void fetchImpl(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+      signal: controller.signal,
+    }).then(finish, finish);
+  });
+}
+
+/** Where capture events go. `VENDO_POSTHOG_HOST` redirects them at a
+ *  self-hosted PostHog (and lets the CLI's exit tests aim at a black hole);
+ *  unset means the shipped US cloud. */
+function captureEndpoint(env: Record<string, string | undefined>): string {
+  const host = env.VENDO_POSTHOG_HOST?.trim();
+  if (!host) return POSTHOG_ENDPOINT;
+  try {
+    return new URL("/capture/", host).toString();
+  } catch {
+    return POSTHOG_ENDPOINT;
   }
 }
 
@@ -79,7 +160,8 @@ function unrefTimer(timer: ReturnType<typeof setTimeout>): void {
 const CLOUD_KEY_RE = /^vnd_[0-9a-f]{40}$/;
 
 export function createTelemetry(deps: TelemetryDeps): Telemetry {
-  const doFetch = deps.fetchImpl ?? fetch;
+  const post: Post = deps.fetchImpl === undefined ? socketPost : fetchPost(deps.fetchImpl);
+  const endpoint = captureEndpoint(deps.env);
   // Cloud lane: a well-formed VENDO_API_KEY marks events as coming from a
   // Cloud-configured install. Producer-set like the base props — callers can
   // never pass `cloud` or `cloudKeyHash` themselves. cloudKeyHash is the
@@ -139,28 +221,7 @@ export function createTelemetry(deps: TelemetryDeps): Telemetry {
           properties,
         });
 
-        const controller = new AbortController();
-        await new Promise<void>((resolve) => {
-          let settled = false;
-          const finish = () => {
-            if (settled) return;
-            settled = true;
-            clearTimeout(timer);
-            resolve();
-          };
-          const timer = setTimeout(() => {
-            controller.abort();
-            finish();
-          }, TIMEOUT_MS);
-          unrefTimer(timer);
-
-          void doFetch(POSTHOG_ENDPOINT, {
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body,
-            signal: controller.signal,
-          }).then(finish, finish);
-        });
+        await post(endpoint, body);
       } catch {
         // Telemetry must never break a build or dev server. Intentional silent failure.
       }

--- a/packages/vendo-telemetry/src/client.ts
+++ b/packages/vendo-telemetry/src/client.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { request as httpRequest } from "node:http";
+import { request as httpRequest, type ClientRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
 import { resolveConsent } from "./consent.js";
 import { baseProps, projectProps, type ProjectProps } from "./base-props.js";
@@ -75,6 +75,13 @@ function filterToAllowlist(
  *  rejects, and never outlives TIMEOUT_MS. */
 type Post = (endpoint: string, body: string) => Promise<void>;
 
+/** A capture endpoint behind a proxy can move (an http→https or bare-host
+ *  redirect); fetch followed those for us, so the raw transport must too. The
+ *  body is replayed as a POST on every hop: this is an API endpoint, where a
+ *  redirect is always a relocation, never a "see other". */
+const REDIRECT_STATUSES = new Set([301, 302, 307, 308]);
+const MAX_REDIRECTS = 3;
+
 /**
  * The default transport, and the reason it is not `fetch`. Node's global fetch
  * (undici) leaves a connecting socket alive after the request is aborted: on a
@@ -90,29 +97,40 @@ type Post = (endpoint: string, body: string) => Promise<void>;
  */
 function socketPost(endpoint: string, body: string): Promise<void> {
   return new Promise((resolve) => {
-    const url = new URL(endpoint);
-    const send = url.protocol === "http:" ? httpRequest : httpsRequest;
-    const request = send(url, {
-      method: "POST",
-      headers: { "content-type": "application/json", "content-length": Buffer.byteLength(body) },
-    });
+    let current: ClientRequest | undefined;
     let settled = false;
     const finish = (): void => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      request.destroy();
+      current?.destroy();
       resolve();
     };
     const timer = setTimeout(finish, TIMEOUT_MS);
-    request.on("socket", (socket) => socket.unref());
-    request.on("response", (response) => {
-      response.resume();
-      response.on("end", finish);
-      response.on("error", finish);
-    });
-    request.on("error", finish);
-    request.end(body);
+
+    const send = (url: URL, hopsLeft: number): void => {
+      const request = (url.protocol === "http:" ? httpRequest : httpsRequest)(url, {
+        method: "POST",
+        headers: { "content-type": "application/json", "content-length": Buffer.byteLength(body) },
+      });
+      current = request;
+      // The socket exists only once the agent hands one over; unref it there so
+      // a connect that never completes cannot keep the event loop alive.
+      request.on("socket", (socket) => socket.unref());
+      request.on("error", finish);
+      request.on("response", (response) => {
+        response.resume();
+        const location = response.headers.location;
+        if (hopsLeft > 0 && location !== undefined && REDIRECT_STATUSES.has(response.statusCode ?? 0)) {
+          response.on("end", () => { if (!settled) send(new URL(location, url), hopsLeft - 1); });
+          return;
+        }
+        response.on("end", finish);
+        response.on("error", finish);
+      });
+      request.end(body);
+    };
+    send(new URL(endpoint), MAX_REDIRECTS);
   });
 }
 

--- a/packages/vendo/src/cli/telemetry-exit.test.ts
+++ b/packages/vendo/src/cli/telemetry-exit.test.ts
@@ -1,0 +1,85 @@
+import { spawn } from "node:child_process";
+import { createServer, type Server } from "node:net";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { afterAll, beforeAll, expect, it } from "vitest";
+
+/**
+ * The CLI must exit the moment its command is done — no network condition may
+ * hold the process open after the summary prints.
+ *
+ * The condition that broke it live: a captive-portal network accepts the TCP
+ * connection to the telemetry endpoint and then never answers. `vendo init`
+ * printed Done and sat there; `DO_NOT_TRACK=1` made it exit instantly, naming
+ * telemetry as the handle. This spawns the real `bin/vendo.mjs` against
+ * exactly that shape (a socket server that accepts and stays silent, spoken to
+ * over https so the TLS handshake never completes) and asserts the process
+ * still exits promptly.
+ */
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const BIN = join(packageRoot, "bin", "vendo.mjs");
+
+/** Generous enough that startup jitter can't flake it, tight enough to fail
+ *  on the real bug — the stranded fetch socket held the process for ~10s
+ *  (undici's connect timeout) past the summary. */
+const EXIT_BUDGET_MS = 6_000;
+
+let blackHole: Server;
+let blackHoleUrl: string;
+const sockets: Array<{ destroy: () => void }> = [];
+
+beforeAll(async () => {
+  blackHole = createServer((socket) => {
+    // Accept, hold, never answer, never close.
+    socket.on("error", () => {});
+    sockets.push(socket);
+  });
+  await new Promise<void>((resolve) => blackHole.listen(0, "127.0.0.1", resolve));
+  const address = blackHole.address();
+  if (address === null || typeof address === "string") throw new Error("no black-hole port");
+  blackHoleUrl = `https://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  for (const socket of sockets) socket.destroy();
+  await new Promise<void>((resolve) => blackHole.close(() => resolve()));
+});
+
+it("exits promptly when the telemetry endpoint accepts the connection and never answers", async () => {
+  const home = await mkdtemp(join(tmpdir(), "vendo-telemetry-exit-"));
+  try {
+    const started = Date.now();
+    const child = spawn(process.execPath, [BIN, "eject", "--list", home], {
+      // A bare env on purpose: CI / DO_NOT_TRACK / VENDO_TELEMETRY_DISABLED
+      // would opt out and the run would prove nothing. HOME points the
+      // anonymous-id file at a throwaway dir.
+      env: { PATH: process.env.PATH ?? "", HOME: home, VENDO_POSTHOG_HOST: blackHoleUrl },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    child.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString(); });
+    child.stderr.resume();
+
+    const exited = await new Promise<{ code: number | null; ms: number }>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        child.kill("SIGKILL");
+        reject(new Error(`vendo did not exit within ${EXIT_BUDGET_MS}ms`));
+      }, EXIT_BUDGET_MS);
+      child.on("error", reject);
+      child.on("exit", (code) => {
+        clearTimeout(timer);
+        resolve({ code, ms: Date.now() - started });
+      });
+    });
+
+    expect(exited.code).toBe(0);
+    expect(exited.ms).toBeLessThan(EXIT_BUDGET_MS);
+    // The command really ran (an exit that skipped the work would prove nothing).
+    expect(stdout).toContain("Ejectable surfaces");
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+}, 30_000);


### PR DESCRIPTION
Spec: `docs/superpowers/specs/2026-07-31-keystone-graduates-design.md` — **A3**
(lane 2, cli/extraction). Found while proving the Keystone stage run offline.

## The bug

On a captive-portal network — one that accepts the TCP connection to the
telemetry endpoint and then never answers — `vendo init` printed its summary
and then sat there for another ten seconds doing nothing. `DO_NOT_TRACK=1`
removed the pause entirely, which named telemetry as the handle holding the
process.

The cause is Node's global `fetch` (undici): the client already aborts the
capture POST after 1.5s, but aborting does **not** destroy a socket that is
still connecting. The socket stayed alive until undici's own 10s connect
timeout, and `bin/vendo.mjs` sets `process.exitCode` and waits for the loop to
drain — so the CLI waited with it.

Measured against a local black hole (a socket server that accepts and never
answers, spoken to over https so the TLS handshake never completes):

```
before:  10.82s total   (command output done in <0.5s, then a 10s tail)
after:    1.79s total   (the 1.5s telemetry timeout, then nothing)
```

## The fix

The default transport is a raw `node:http`/`node:https` request whose socket is
unref'd the moment it exists. A stranded telemetry POST can never be the last
handle keeping the CLI alive, under any network condition. The timeout —
unchanged at 1.5s — is now the only thing a caller ever waits on, and it is
ref'd on purpose so an exiting process still reports its command's exit code
instead of racing an unref'd event loop to zero handles.

Redirects are followed (bounded to three hops, POST replayed) because `fetch`
did that for us and a proxied self-hosted endpoint relies on it. An injected
`fetchImpl` still takes the fetch path unchanged, so hosts and tests that
supply their own are unaffected.

Also adds `VENDO_POSTHOG_HOST` (documented in `TELEMETRY.md`), which points
capture events at a self-hosted PostHog instead of the shipped US cloud —
`VENDO_POSTHOG_KEY` already set the project key. The exit test needs a
redirectable endpoint; self-hosting is the honest general form of that seam.

## Tests

- `packages/vendo/src/cli/telemetry-exit.test.ts` — spawns the real
  `bin/vendo.mjs` against exactly that black hole and asserts it exits within
  6s having actually run the command. Verified failing first: with only the
  `VENDO_POSTHOG_HOST` seam applied on top of `main`'s fetch transport (the
  test needs a redirectable endpoint to aim at a black hole at all), it fails
  with "vendo did not exit within 6000ms". With the transport fix, 1.8s.
- `packages/vendo-telemetry/src/client.test.ts` — the default transport posts
  over a real socket, follows a 308 to a second local server, returns on the
  timeout against the black hole, and honors / safely ignores the
  `VENDO_POSTHOG_HOST` override.

## Test change, stated out loud

`fixtures/integration/src/telemetry-wire.e2e.test.ts` (J11) intercepted
telemetry by monkey-patching `globalThis.fetch`, which the new transport
bypasses. It now stands a real capture server up on loopback and points the
client at it with `VENDO_POSTHOG_HOST` — a strictly stronger end-to-end test:
it exercises the shipped transport over real HTTP instead of stubbing it out.
No assertion changed.

## Gate

`pnpm build && pnpm test && pnpm typecheck && pnpm lint` green.
No npm release — per the spec, releases queue until after the YC show.
