### PR TITLE
fix(vendo): the theme extractor resolves next/font CSS variables without a TypeScript compiler

### DIFF
--- a/.changeset/theme-next-font-vars-without-typescript.md
+++ b/.changeset/theme-next-font-vars-without-typescript.md
@@ -1,0 +1,21 @@
+---
+"@vendoai/vendo": patch
+---
+
+The theme extractor now resolves `next/font` CSS variables on hosts without a
+resolvable `typescript`. The standard Next.js pattern — `--font-sans:
+var(--font-inter)` in CSS, `Inter({ variable: "--font-inter" })` in the root
+layout — is read through a real TypeScript program, and `typescript` is an
+optional resolution: a JS-only Next app, a strict pnpm tree, or an npx-run CLI
+simply doesn't have one. When it was missing, every next/font derivation went
+dark at once and `vendo init` fell all the way through to "No host evidence for
+fontFamily — neutral defaults used" on an app whose font was sitting right
+there in its layout.
+
+Without a compiler the extractor now text-scans the layout's next/font and
+geist loader calls for the family each CSS variable names. The scan reports
+those fonts as un-applied, because text cannot prove a font reaches the markup:
+every derivation that needs that proof still fails closed to the model pass,
+and only var() resolution — where the host's own CSS is the authority on what
+the body font is — gains an answer. `next/font/local` stays unresolvable by
+design; its loader declares a variable but no family name.

--- a/packages/vendo/src/cli/theme/font-stack.no-compiler.test.ts
+++ b/packages/vendo/src/cli/theme/font-stack.no-compiler.test.ts
@@ -84,6 +84,16 @@ describe("layoutFontBindings without a TypeScript compiler", () => {
     ]);
   });
 
+  it("reads no font out of commented-out imports (review: text is not evidence)", async () => {
+    const { layoutFontBindings } = await import("./font-stack.js");
+    expect(layoutFontBindings(`
+      // Old migration note: import { GeistSans } from "geist/font/sans";
+      /* was: import { Inter } from "next/font/google";
+         const inter = Inter({ variable: "--font-inter" }); */
+      export default function L({ children }) { return <body>{children}</body>; }
+    `)).toEqual([]);
+  });
+
   it("never claims a font is applied — proof-requiring derivations stay closed", async () => {
     const { deriveBodyFontStack, layoutFontBindings } = await import("./font-stack.js");
     // One next/font family, applied in the markup, no --font-sans to lean on:

--- a/packages/vendo/src/cli/theme/font-stack.no-compiler.test.ts
+++ b/packages/vendo/src/cli/theme/font-stack.no-compiler.test.ts
@@ -1,0 +1,150 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The extractor with no `typescript` to resolve — the shape a JS-only Next
+ * host, a strict pnpm tree, or an npx-run CLI presents. Before this, every
+ * next/font derivation went dark there and the standard
+ * `--font-sans: var(--font-inter)` root layout fell through to neutral
+ * defaults ("No host evidence for fontFamily"), which is what the Keystone
+ * stub hit. The var must resolve to the family the loader declares, and
+ * everything that needs PROOF a font reaches the markup must still fail
+ * closed.
+ */
+
+/** The Keystone stub verbatim (~/Desktop/keystone-init-cast/keystone-stub). */
+const KEYSTONE_LAYOUT = `import type { Metadata } from "next";
+import { Inter, Fraunces } from "next/font/google";
+import "./globals.css";
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
+const fraunces = Fraunces({ subsets: ["latin"], variable: "--font-fraunces" });
+
+export const metadata: Metadata = { title: "Keystone" };
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className={\`\${inter.variable} \${fraunces.variable}\`}>
+        {children}
+      </body>
+    </html>
+  );
+}
+`;
+
+const KEYSTONE_CSS = `:root {
+  --background: #fbfaf7;
+  --foreground: #14201c;
+  --primary: #1f6f5c;
+  --radius: 8px;
+  --font-sans: var(--font-inter), system-ui, sans-serif;
+  --font-display: Fraunces, Georgia, serif;
+}
+
+body {
+  background: var(--background);
+  color: var(--foreground);
+  font-family: var(--font-sans);
+}
+`;
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.doMock("node:module", () => ({
+    createRequire: () => () => { throw new Error("Cannot find module 'typescript'"); },
+  }));
+});
+
+afterEach(() => {
+  vi.doUnmock("node:module");
+  vi.resetModules();
+});
+
+describe("layoutFontBindings without a TypeScript compiler", () => {
+  it("still names each next/font variable's family", async () => {
+    const { layoutFontBindings } = await import("./font-stack.js");
+    expect(layoutFontBindings(KEYSTONE_LAYOUT)).toEqual([
+      { variable: "--font-inter", family: "Inter", applied: false },
+      { variable: "--font-fraunces", family: "Fraunces", applied: false },
+    ]);
+  });
+
+  it("reads aliased imports, multi-word families, and geist's fixed names", async () => {
+    const { layoutFontBindings } = await import("./font-stack.js");
+    expect(layoutFontBindings(`
+      import { GeistSans } from "geist/font/sans";
+      import { Plus_Jakarta_Sans as Body } from "next/font/google";
+      const body = Body({ subsets: ["latin"], variable: "--font-body" });
+    `)).toEqual([
+      { variable: "--font-geist-sans", family: "Geist Sans", applied: false },
+      { variable: "--font-body", family: "Plus Jakarta Sans", applied: false },
+    ]);
+  });
+
+  it("never claims a font is applied — proof-requiring derivations stay closed", async () => {
+    const { deriveBodyFontStack, layoutFontBindings } = await import("./font-stack.js");
+    // One next/font family, applied in the markup, no --font-sans to lean on:
+    // WITH a compiler this derives; without one it must not.
+    const layout = `
+      import { Inter } from "next/font/google";
+      const inter = Inter({ subsets: ["latin"] });
+      export default function L({ children }) { return <body className={inter.className}>{children}</body>; }
+    `;
+    expect(layoutFontBindings(layout).every((binding) => !binding.applied)).toBe(true);
+    expect(deriveBodyFontStack({
+      layout,
+      tailwindConfig: null,
+      cssText: "",
+      resolveCssVar: () => null,
+    })).toBeNull();
+  });
+
+  it("fails closed on a next/font/local variable — the loader declares no family", async () => {
+    const { deriveBodyFontStack } = await import("./font-stack.js");
+    expect(deriveBodyFontStack({
+      layout: `
+        import localFont from "next/font/local";
+        const brand = localFont({ src: "./brand.woff2", variable: "--font-brand" });
+      `,
+      tailwindConfig: null,
+      cssText: "",
+      resolveCssVar: () => null,
+      cssFontSans: "var(--font-brand), sans-serif",
+    })).toBeNull();
+  });
+});
+
+describe("extractTheme on the Keystone stub without a TypeScript compiler", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "vendo-keystone-stub-"));
+    await mkdir(join(root, "app"), { recursive: true });
+    await writeFile(join(root, "app", "layout.tsx"), KEYSTONE_LAYOUT);
+    await writeFile(join(root, "app", "globals.css"), KEYSTONE_CSS);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("reports the real font instead of neutral defaults", async () => {
+    const { extractTheme } = await import("./extract-theme.js");
+    const summary = await extractTheme(root);
+    expect(summary.slots.fontFamily).toBe("Inter, system-ui, sans-serif");
+    expect(summary.matched.fontFamily).toBe("--font-sans (next/font vars)");
+    expect(summary.defaulted).not.toContain("fontFamily");
+  });
+
+  it("still falls back to neutral defaults when the variable is genuinely unresolvable", async () => {
+    await writeFile(join(root, "app", "globals.css"),
+      KEYSTONE_CSS.replace("var(--font-inter)", "var(--font-nowhere)"));
+    const { extractTheme } = await import("./extract-theme.js");
+    const summary = await extractTheme(root);
+    expect(summary.slots.fontFamily).toBe("system-ui, sans-serif");
+    expect(summary.defaulted).toContain("fontFamily");
+  });
+});

--- a/packages/vendo/src/cli/theme/font-stack.no-compiler.test.ts
+++ b/packages/vendo/src/cli/theme/font-stack.no-compiler.test.ts
@@ -94,6 +94,15 @@ describe("layoutFontBindings without a TypeScript compiler", () => {
     `)).toEqual([]);
   });
 
+  it("reads no variable out of a loader call quoted in a string (review)", async () => {
+    const { layoutFontBindings } = await import("./font-stack.js");
+    expect(layoutFontBindings(`
+      import { Inter } from "next/font/google";
+      const usage = "example: Inter({ variable: '--font-example' })";
+      export default function L({ children }) { return <body>{children}</body>; }
+    `)).toEqual([{ variable: null, family: "Inter", applied: false }]);
+  });
+
   it("never claims a font is applied — proof-requiring derivations stay closed", async () => {
     const { deriveBodyFontStack, layoutFontBindings } = await import("./font-stack.js");
     // One next/font family, applied in the markup, no --font-sans to lean on:

--- a/packages/vendo/src/cli/theme/font-stack.ts
+++ b/packages/vendo/src/cli/theme/font-stack.ts
@@ -164,12 +164,17 @@ function importedNames(source: string, module: string): Array<{ imported: string
   return names;
 }
 
-/** The `variable: "--font-x"` option of a loader call, read from the options
- *  up to the call's first `)`. Every documented next/font option list is
- *  paren-free; anything fancier resolves to null and fails closed. */
+/** The `variable: "--font-x"` option of a loader call. The call must be a
+ *  declaration's initializer — `const inter = Inter({ … })`, the shape the
+ *  compiler path requires too — so an example inside a string or doc text is
+ *  never read as configuration. Options are taken up to the call's first `)`:
+ *  every documented next/font option list is paren-free, and anything fancier
+ *  resolves to null and fails closed. */
 function scannedLoaderVariable(source: string, callee: string): string | null {
-  const call = new RegExp(`\\b${callee}\\s*\\(([^)]*)\\)`).exec(source);
-  return call?.[1]?.match(/\bvariable\s*:\s*["']([^"']+)["']/)?.[1] ?? null;
+  const declaration = new RegExp(
+    `\\b(?:const|let|var)\\s+[A-Za-z_$][\\w$]*\\s*=\\s*${callee}\\s*\\(([^)]*)\\)`,
+  ).exec(source);
+  return declaration?.[1]?.match(/\bvariable\s*:\s*["']([^"']+)["']/)?.[1] ?? null;
 }
 
 /**

--- a/packages/vendo/src/cli/theme/font-stack.ts
+++ b/packages/vendo/src/cli/theme/font-stack.ts
@@ -19,8 +19,11 @@ import type TS from "typescript";
  * from "tailwindcss/defaultTheme"; a font is "applied" only when the JSX
  * reference's symbol IS the font's declaration; the config's sans array is
  * located through the exported config object, never by scanning for a
- * `fontFamily` key anywhere in the file. Anything unprovable — including an
- * unavailable compiler — fails CLOSED to the staged model pass.
+ * `fontFamily` key anywhere in the file. Anything unprovable fails CLOSED to
+ * the staged model pass. The one exception is an unavailable compiler, where
+ * a text scan (`scanFontBindings`) still names each next/font variable's
+ * family but can never mark a font applied — see its comment for why that
+ * keeps every proof-requiring rule fail-closed.
  *
  * Precision boundary (Yousef ruling 2026-07-26): symbol-correct import +
  * direct JSX usage is the required depth. Documented limitations, out of
@@ -134,6 +137,58 @@ const GEIST_FONTS = [
   { importName: "GeistMono", specifier: "geist/font/mono", family: "Geist Mono", variable: "--font-geist-mono" },
 ] as const;
 
+/** `import { A, B as C } from "next/font/google"` — the specifier list. */
+const GOOGLE_IMPORT_LIST = /import\s*\{([^}]*)\}\s*from\s*["']next\/font\/google["']/g;
+const IDENTIFIER = /^[A-Za-z_$][\w$]*$/;
+
+/** The `variable: "--font-x"` option of a loader call, read from the options
+ *  up to the call's first `)`. Every documented next/font option list is
+ *  paren-free; anything fancier resolves to null and fails closed. */
+function scannedLoaderVariable(source: string, callee: string): string | null {
+  const call = new RegExp(`\\b${callee}\\s*\\(([^)]*)\\)`).exec(source);
+  return call?.[1]?.match(/\bvariable\s*:\s*["']([^"']+)["']/)?.[1] ?? null;
+}
+
+/**
+ * Compiler-free fallback for `layoutFontBindings`. `typescript` is an OPTIONAL
+ * resolution here (loadCompiler): a JS-only Next host, a strict pnpm tree, or
+ * an npx-run CLI simply doesn't have one, and without it every next/font
+ * derivation went dark — the standard `--font-sans: var(--font-inter)` layout
+ * pattern fell all the way through to neutral defaults ("No host evidence for
+ * fontFamily"), which is exactly what the Keystone stub hit.
+ *
+ * This scan answers one narrow question — which family does a given next/font
+ * CSS variable NAME denote — for a variable the host's own CSS has already
+ * named as its body font. It reports `applied: false` because text cannot
+ * prove a font reaches the markup: every derivation that requires proof of
+ * application (the single-applied-font rules) still fails closed, and only
+ * var() resolution, where the CSS is the authority, gains an answer.
+ *
+ * `next/font/local` is deliberately absent: its loader declares a variable but
+ * no family name, so there is nothing to resolve a var() to.
+ */
+function scanFontBindings(source: string): FontBinding[] {
+  const bindings: FontBinding[] = [];
+  for (const font of GEIST_FONTS) {
+    if (source.includes(font.specifier) && new RegExp(`\\b${font.importName}\\b`).test(source)) {
+      bindings.push({ variable: font.variable, family: font.family, applied: false });
+    }
+  }
+  for (const match of source.matchAll(GOOGLE_IMPORT_LIST)) {
+    for (const specifier of match[1]!.split(",")) {
+      const [imported, alias] = specifier.split(/\bas\b/).map((part) => part.trim());
+      const callee = alias ?? imported;
+      if (imported === undefined || !IDENTIFIER.test(imported) || callee === undefined || !IDENTIFIER.test(callee)) continue;
+      bindings.push({
+        variable: scannedLoaderVariable(source, callee),
+        family: imported.replace(/_/g, " "),
+        applied: false,
+      });
+    }
+  }
+  return bindings;
+}
+
 interface NamedImportLocal {
   local: string;
   /** The ImportSpecifier node — the symbol-comparison anchor. */
@@ -190,7 +245,7 @@ function appliedToJsx(mod: BoundModule, local: string, declaration: TS.Declarati
  *  derivation simply doesn't fire, leaving the slot to the model pass). */
 export function layoutFontBindings(source: string): FontBinding[] {
   const mod = boundModule(source, "layout.tsx");
-  if (mod === null) return [];
+  if (mod === null) return scanFontBindings(source);
   const { ts, sf } = mod;
   const bindings: FontBinding[] = [];
 

--- a/packages/vendo/src/cli/theme/font-stack.ts
+++ b/packages/vendo/src/cli/theme/font-stack.ts
@@ -137,9 +137,32 @@ const GEIST_FONTS = [
   { importName: "GeistMono", specifier: "geist/font/mono", family: "Geist Mono", variable: "--font-geist-mono" },
 ] as const;
 
-/** `import { A, B as C } from "next/font/google"` — the specifier list. */
-const GOOGLE_IMPORT_LIST = /import\s*\{([^}]*)\}\s*from\s*["']next\/font\/google["']/g;
 const IDENTIFIER = /^[A-Za-z_$][\w$]*$/;
+
+/** Comments are not code: a commented-out `import { GeistSans } …` or a
+ *  migration note quoting a loader call must never register as a font. Block
+ *  comments go entirely; a line comment goes from `//` to end of line unless
+ *  the slashes are a URL's `://`. */
+function withoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
+/** Every `import { A, B as C } from "<module>"` binding in the source, as
+ *  imported/local pairs. */
+function importedNames(source: string, module: string): Array<{ imported: string; local: string }> {
+  const imports = new RegExp(`import\\s*\\{([^}]*)\\}\\s*from\\s*["']${module}["']`, "g");
+  const names: Array<{ imported: string; local: string }> = [];
+  for (const match of source.matchAll(imports)) {
+    for (const specifier of match[1]!.split(",")) {
+      const [imported, alias] = specifier.split(/\bas\b/).map((part) => part.trim());
+      const local = alias ?? imported;
+      if (imported === undefined || local === undefined) continue;
+      if (!IDENTIFIER.test(imported) || !IDENTIFIER.test(local)) continue;
+      names.push({ imported, local });
+    }
+  }
+  return names;
+}
 
 /** The `variable: "--font-x"` option of a loader call, read from the options
  *  up to the call's first `)`. Every documented next/font option list is
@@ -167,24 +190,22 @@ function scannedLoaderVariable(source: string, callee: string): string | null {
  * `next/font/local` is deliberately absent: its loader declares a variable but
  * no family name, so there is nothing to resolve a var() to.
  */
-function scanFontBindings(source: string): FontBinding[] {
+function scanFontBindings(rawSource: string): FontBinding[] {
+  const source = withoutComments(rawSource);
   const bindings: FontBinding[] = [];
   for (const font of GEIST_FONTS) {
-    if (source.includes(font.specifier) && new RegExp(`\\b${font.importName}\\b`).test(source)) {
-      bindings.push({ variable: font.variable, family: font.family, applied: false });
+    for (const { imported } of importedNames(source, font.specifier)) {
+      if (imported === font.importName) {
+        bindings.push({ variable: font.variable, family: font.family, applied: false });
+      }
     }
   }
-  for (const match of source.matchAll(GOOGLE_IMPORT_LIST)) {
-    for (const specifier of match[1]!.split(",")) {
-      const [imported, alias] = specifier.split(/\bas\b/).map((part) => part.trim());
-      const callee = alias ?? imported;
-      if (imported === undefined || !IDENTIFIER.test(imported) || callee === undefined || !IDENTIFIER.test(callee)) continue;
-      bindings.push({
-        variable: scannedLoaderVariable(source, callee),
-        family: imported.replace(/_/g, " "),
-        applied: false,
-      });
-    }
+  for (const { imported, local } of importedNames(source, "next/font/google")) {
+    bindings.push({
+      variable: scannedLoaderVariable(source, local),
+      family: imported.replace(/_/g, " "),
+      applied: false,
+    });
   }
   return bindings;
 }


### PR DESCRIPTION
Spec: `docs/superpowers/specs/2026-07-31-keystone-graduates-design.md` — **A4**
(lane 2, cli/extraction). Found because the Keystone stub needed a hand-edit to
demo the theme capture.

## The bug

The standard Next.js font pattern —

```css
/* app/globals.css */
--font-sans: var(--font-inter), system-ui, sans-serif;
body { font-family: var(--font-sans); }
```
```tsx
// app/layout.tsx
const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
```

made the deterministic extractor fail closed:

```
Type: system-ui, sans-serif · headings Fraunces, Georgia, serif · radius 8px
No host evidence for fontFamily — neutral defaults used.
```

`--font-inter` is not declared in any stylesheet — next/font injects it at
runtime — so the CSS read can't resolve it and the extractor asks the layout
instead. That read goes through a real `ts.Program`, and `typescript` is an
**optional** resolution (`loadCompiler`, same posture as `@vendoai/actions`).
A JS-only Next app, a strict pnpm tree, or an npx-run CLI simply doesn't have
one — and when it's missing, `layoutFontBindings` returned `[]`, every
next/font derivation went dark at once, and the font sitting right there in the
layout was reported as no evidence at all.

Reproduced verbatim against the staged Keystone stub with the shipped
`@vendoai/vendo@0.6.1` and no resolvable `typescript`:

```
BEFORE  fontFamily: "system-ui, sans-serif"
        matched.fontFamily: undefined
        defaulted: ["fontFamily","baseSize","density","motion"]

AFTER   fontFamily: "Inter, system-ui, sans-serif"
        matched.fontFamily: "--font-sans (next/font vars)"
        defaulted: ["baseSize","density","motion"]
```

## The fix

With no compiler, `layoutFontBindings` now text-scans the source for next/font
and geist loader declarations and reports which family each CSS variable names.

The scan is deliberately weaker than the compiler path, and the weakness is the
point: it reports every font as **un-applied**, because text cannot prove a
font reaches the markup. Every derivation that requires that proof (the
single-applied-font rules) still fails closed to the staged model pass. Only
var() resolution gains an answer — and there the host's own CSS is already the
authority on what the body font is; the layout is only being asked what
`--font-inter` means.

`next/font/local` stays unresolvable by design: its loader declares a variable
but no family name, so there is nothing to resolve a var() to.

## Tests

`packages/vendo/src/cli/theme/font-stack.no-compiler.test.ts` runs the whole
module with `createRequire("typescript")` throwing. Three of its six cases
**fail on `main`**; the other three are the fail-closed guards, which must keep
passing:

- names each next/font variable's family (the Keystone stub layout verbatim)
- reads aliased imports, multi-word families, geist's fixed names
- never claims a font is applied — a proof-requiring derivation stays `null`
- `next/font/local` still fails closed
- `extractTheme` on a Keystone-shaped fixture reports `Inter, system-ui,
  sans-serif` with provenance `--font-sans (next/font vars)`
- a genuinely unresolvable `var(--font-nowhere)` still lands on neutral
  defaults

## Gate

`pnpm build && pnpm test && pnpm typecheck && pnpm lint` green.
No npm release — per the spec, releases queue until after the YC show.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes font detection in `@vendoai/vendo` when `typescript` isn’t available by resolving `next/font` CSS variables with an import-aware scan that strips comments and requires real declaration initializers. JS-only Next apps now resolve `--font-sans: var(--font-*)` to the layout’s declared family without marking fonts as applied.

- **Bug Fixes**
  - Switched to an import-based scan in `layoutFontBindings` that reads named imports for `next/font` and `geist/font/*`, strips comments, and only extracts `variable` from loader calls used as declaration initializers; all bindings are `applied: false`.
  - `next/font/local` stays unresolved by design; the compiler path is unchanged and the scan runs only when `typescript` can’t be resolved.

- **Tests**
  - Added no-compiler tests for alias imports, multi-word families, geist names, commented-out imports, and that quoted examples don’t create variables.
  - End-to-end Keystone stub verifies body font resolves; genuinely unresolvable vars still default neutrally.

<sup>Written for commit 84779577b9459bbc919b4b7b6cb1b9c1ea405628. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

