### PR TITLE
fix(ui): surface stale app refresh failures

### DIFF
--- a/packages/ui/src/chrome/app-stale-notice.tsx
+++ b/packages/ui/src/chrome/app-stale-notice.tsx
@@ -1,0 +1,10 @@
+/** A failed refresh must not hide a usable app, but users need an honest way
+ * to see that it may be out of date and ask for another refresh. */
+export function AppStaleNotice({ error, onRetry }: { error: Error; onRetry(): void }) {
+  return (
+    <div role="alert" className="fl-error">
+      This view may be out of date — {error.message}
+      <button type="button" className="fl-error-retry" onClick={onRetry}>Try again</button>
+    </div>
+  );
+}

--- a/packages/ui/src/chrome/vendo-page.tsx
+++ b/packages/ui/src/chrome/vendo-page.tsx
@@ -7,6 +7,7 @@ import { useThreads } from "../hooks/use-threads.js";
 import { AppFrame } from "../tree/frames.js";
 import { ActivityPanel } from "./activity-panel.js";
 import { AutomationsPanel } from "./automations-panel.js";
+import { AppStaleNotice } from "./app-stale-notice.js";
 import { ChromeRoot } from "./chrome-root.js";
 import { ACTIVITY_ANCHOR_ATTRIBUTE, ACTIVITY_BUMP_EVENT } from "./morph-toast.js";
 import { ConnectedAccountsPanel } from "./connected-accounts-panel.js";
@@ -153,7 +154,12 @@ function OpenApp({ appId }: { appId: string }) {
     }
     return <div role="status">Opening app…</div>;
   }
-  return <AppFrame key={appId} surface={surface} components={components} keepalive={keepalive} onAction={({ action, payload }) => client.apps.call(appId, action, payload ?? {})} />;
+  return (
+    <>
+      <AppFrame key={appId} surface={surface} components={components} keepalive={keepalive} onAction={({ action, payload }) => client.apps.call(appId, action, payload ?? {})} />
+      {error && !isLoading ? <AppStaleNotice error={error} onRetry={() => void refresh()} /> : null}
+    </>
+  );
 }
 
 function AppsWorkspace() {

--- a/packages/ui/src/chrome/vendo-slot.tsx
+++ b/packages/ui/src/chrome/vendo-slot.tsx
@@ -5,6 +5,7 @@ import { useApp } from "../hooks/use-app.js";
 import { useSlotApp } from "../hooks/use-slot-app.js";
 import { FluidReveal } from "../tree/fluid-reveal.js";
 import { AppFrame, PinMount } from "../tree/frames.js";
+import { AppStaleNotice } from "./app-stale-notice.js";
 import { ChromeRoot } from "./chrome-root.js";
 import { developmentMode } from "./dev-mode.js";
 import { defaultSlotSuggestions } from "./discoverability.js";
@@ -71,7 +72,12 @@ function MountedApp({ appId }: { appId: string }) {
     if (error && !isLoading) return <SlotLoadFailed reason={error} onRetry={() => void refresh()} />;
     return <SlotGhost label="Loading app…" loading />;
   }
-  return <AppFrame key={appId} surface={surface} components={components} keepalive={keepalive} onAction={({ action, payload }) => client.apps.call(appId, action, payload ?? {})} />;
+  return (
+    <>
+      <AppFrame key={appId} surface={surface} components={components} keepalive={keepalive} onAction={({ action, payload }) => client.apps.call(appId, action, payload ?? {})} />
+      {error && !isLoading ? <AppStaleNotice error={error} onRetry={() => void refresh()} /> : null}
+    </>
+  );
 }
 
 /** A generated view pinned into a slot (08-ui §4 — "or a pinned component").

--- a/packages/ui/test/chrome/app-load-retry.test.tsx
+++ b/packages/ui/test/chrome/app-load-retry.test.tsx
@@ -7,7 +7,6 @@ import type { AppDocument } from "@vendoai/core";
 import { act, cleanup, fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VendoProvider, createVendoClient, type VendoClient, useApp } from "../../src/index.js";
-import { AppStaleNotice } from "../../src/chrome/app-stale-notice.js";
 import { VendoSlot } from "../../src/chrome/index.js";
 import { createWireServer } from "../wire-server.js";
 
@@ -92,12 +91,4 @@ describe("useApp load retry (Keystone graduates A5)", () => {
     expect(result.current.error?.message).toBe("reopen failed");
   });
 
-  it("marks a retained app as stale and retries without unmounting it", () => {
-    const retry = vi.fn();
-    render(<AppStaleNotice error={new Error("reopen failed")} onRetry={retry} />);
-
-    expect(screen.getByRole("alert").textContent).toContain("This view may be out of date");
-    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
-    expect(retry).toHaveBeenCalledOnce();
-  });
 });

--- a/packages/ui/test/chrome/app-load-retry.test.tsx
+++ b/packages/ui/test/chrome/app-load-retry.test.tsx
@@ -4,9 +4,10 @@
 // "Loading app…", and only a full page reload got the user out. The load now
 // retries with backoff, and a load that really is dead offers a way back in.
 import type { AppDocument } from "@vendoai/core";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
+import { VendoProvider, createVendoClient, type VendoClient, useApp } from "../../src/index.js";
+import { AppStaleNotice } from "../../src/chrome/app-stale-notice.js";
 import { VendoSlot } from "../../src/chrome/index.js";
 import { createWireServer } from "../wire-server.js";
 
@@ -75,5 +76,28 @@ describe("useApp load retry (Keystone graduates A5)", () => {
 
     await waitFor(() => expect(screen.getByRole("status").textContent).toContain("Loading app…"));
     expect(screen.queryByRole("button", { name: /try again/i })).toBeNull();
+  });
+
+  it("keeps the last app surface while a later refresh fails", async () => {
+    const { result } = renderHook(() => useApp("app_1"), {
+      wrapper: ({ children }) => <VendoProvider client={client}>{children}</VendoProvider>,
+    });
+    await waitFor(() => expect(result.current.surface).toBeDefined());
+    const previous = result.current.surface;
+    vi.spyOn(client.apps, "open").mockRejectedValue(new Error("reopen failed"));
+
+    await act(() => result.current.refresh());
+
+    expect(result.current.surface).toBe(previous);
+    expect(result.current.error?.message).toBe("reopen failed");
+  });
+
+  it("marks a retained app as stale and retries without unmounting it", () => {
+    const retry = vi.fn();
+    render(<AppStaleNotice error={new Error("reopen failed")} onRetry={retry} />);
+
+    expect(screen.getByRole("alert").textContent).toContain("This view may be out of date");
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(retry).toHaveBeenCalledOnce();
   });
 });

--- a/packages/ui/test/chrome/app-stale-slot.test.tsx
+++ b/packages/ui/test/chrome/app-stale-slot.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
+import { VendoSlot } from "../../src/chrome/index.js";
+import { createWireServer } from "../wire-server.js";
+
+vi.mock("../../src/tree/frames.js", () => ({
+  AppFrame: ({ keepalive }: { keepalive?: { reopen(): Promise<unknown> } }) => (
+    <>
+      <div>Rendered app</div>
+      <button type="button" onClick={() => void keepalive?.reopen()}>Refresh rendered app</button>
+    </>
+  ),
+  PinMount: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+describe("stale app refresh recovery", () => {
+  let wire: Awaited<ReturnType<typeof createWireServer>>;
+  let client: VendoClient;
+
+  beforeEach(async () => {
+    wire = await createWireServer();
+    client = createVendoClient({ baseUrl: wire.url });
+  });
+
+  afterEach(async () => {
+    cleanup();
+    vi.restoreAllMocks();
+    await wire.close();
+  });
+
+  it("keeps a mounted slot visible and offers recovery after its reopen fails", async () => {
+    render(<VendoProvider client={client}><VendoSlot id="hero" appId="app_1" /></VendoProvider>);
+    expect(await screen.findByText("Rendered app")).toBeTruthy();
+
+    vi.spyOn(client.apps, "open").mockRejectedValue(new Error("reopen failed"));
+    fireEvent.click(screen.getByRole("button", { name: "Refresh rendered app" }));
+
+    expect((await screen.findByRole("alert")).textContent).toContain("This view may be out of date");
+    expect(screen.getByText("Rendered app")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #717.

Keeps an already-rendered app visible when a later `useApp.refresh()` exhausts its retries. Both slot and workspace mounts now show an explicit stale-state notice with a retry action instead of silently presenting stale content as current.

Tests:
- `pnpm build`
- `pnpm --filter @vendoai/ui test`
- `pnpm typecheck`
- `pnpm lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the app mounted when a `useApp.refresh()` fails after retries and shows a clear “stale” notice with a retry button. Closes #717 by preventing stale content from appearing current without warning.

- **Bug Fixes**
  - Added `AppStaleNotice` and render it in `vendo-page` and `vendo-slot` when `error && !isLoading`, showing the error and a “Try again” action.
  - Preserve the previous `surface` on refresh failure; tests cover surface retention and slot recovery with the stale notice.

<sup>Written for commit dba06942ee93d1db854b166baa03c5029e544063. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

