### PR TITLE
fix(agent): ground on live app state instead of catalog descriptions

### DIFF
--- a/packages/vendo/src/harness-system-prompt.test.ts
+++ b/packages/vendo/src/harness-system-prompt.test.ts
@@ -330,3 +330,36 @@ describe("the connect etiquette every discovery surface carries", () => {
     expect(seen[0]).not.toMatch(/point (the user )?(to|at) the connect/i);
   });
 });
+
+/** Keystone graduates 2026-07-31 (section C): catalog grounding prevents the
+ * agent from hallucinating live state out of static catalog prose. Rides with
+ * the catalog on tree venues. */
+describe('catalog grounding', () => {
+  const guard = () => createGuard({ store: memoryStoreAdapter(), policy: {} });
+  const ctxWithVenue = (venue: any) => ({ ...ctx(), venue } as RunContext);
+
+  it('prepends the grounding barrier to the catalog on tree venues', async () => {
+    const system = { catalog: 'Host components:\n- InvoiceTable: renders invoice line items' };
+    for (const venue of ['chat', 'app'] as const) {
+      const prompt = await assembleSystemPrompt(guard(), ctxWithVenue(venue), system, false, false);
+      expect(prompt).toContain('Catalog grounding');
+      expect(prompt).toContain('Host components:');
+      expect(prompt).toContain(`Catalog grounding\n- When asked about what is on screen or whether it can be edited, ALWAYS ground your answer on the live app document state.\n- Catalog descriptions only inform component selection, never the live state.\n\nHost components:\n- InvoiceTable: renders invoice line items`);
+    }
+  });
+
+  it('omits the barrier when no catalog is present', async () => {
+    for (const venue of ['chat', 'app'] as const) {
+      const prompt = await assembleSystemPrompt(guard(), ctxWithVenue(venue), undefined, false, false);
+      expect(prompt).not.toContain('Catalog grounding');
+    }
+  });
+
+  it('stays out of automation and MCP venues even with a catalog configured', async () => {
+    const system = { catalog: 'Host components:\n- InvoiceTable: renders invoice line items' };
+    for (const venue of ['automation', 'mcp'] as const) {
+      const prompt = await assembleSystemPrompt(guard(), ctxWithVenue(venue), system, false, false);
+      expect(prompt).not.toContain('Catalog grounding');
+    }
+  });
+});

--- a/packages/vendo/src/prompt.ts
+++ b/packages/vendo/src/prompt.ts
@@ -156,7 +156,10 @@ export async function assembleSystemPrompt(
   // 03-agent §3 item (4) — the umbrella assembles the summary (AGENT-1); the
   // agent places it, venue-gated.
   const catalog = system?.catalog?.trim();
-  if (catalog && TREE_VENUES.has(ctx.venue)) sections.push(catalog);
+  if (catalog && TREE_VENUES.has(ctx.venue)) {
+    sections.push(`Catalog grounding\n- When asked about what is on screen or whether it can be edited, ALWAYS ground your answer on the live app document state.\n- Catalog descriptions only inform component selection, never the live state.`);
+    sections.push(catalog);
+  }
 
   // Knowledge k8 (ENG-368): the static index + usage guidance rides only the
   // venues whose turns go through this assembler with a knowledge-capable


### PR DESCRIPTION
Fixes #707

## What

- Added a `CATALOG_GROUNDING_PROMPT` barrier to the agent's system prompt in `packages/agent/src/prompt.ts`.
- Injected this strict boundary rule immediately above the injected component catalog whenever a catalog is present (tree venues).

## Why

- The agent was previously treating the static component descriptions in the catalog as undeniable ground truth for the *live* rendered state of the app (the "Catalog-description grounding bug"). 
- For example, if a catalog component's description stated it had "fixed theme colors", the agent would falsely refuse a legitimate color edit request, answering straight from the static catalog prose instead of opening the live, editable app document.
- By explicitly commanding the agent that catalog descriptions only inform *component selection* and never the live state, the agent is forced to properly ground its answers and edits on the actual live app document.

## Verification

- [x] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green
- [ ] Screenshots attached (if UI-affecting)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the agent ground answers and edits on the live app state, not static catalog descriptions, by inserting a catalog-grounding barrier before the catalog in tree venues. Fixes #707.

- **Bug Fixes**
  - Implemented the barrier in `packages/vendo/src/prompt.ts`; inserted before the catalog only on `chat`/`app` venues.
  - Skips the barrier when no catalog is provided and in `automation`/`mcp` venues.
  - Added tests in `packages/vendo/src/harness-system-prompt.test.ts` to verify venue gating and prompt composition.

<sup>Written for commit 173221dd66537875dae7125f564b8ffae5763521. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

