### PR TITLE
feat(demo-accounting): Cadence serves in place at demos.vendo.run/cadence

### DIFF
--- a/apps/demo-accounting/.vendo/tools.json
+++ b/apps/demo-accounting/.vendo/tools.json
@@ -13,7 +13,7 @@
         "kind": "openapi",
         "operationId": "createVoiceSession",
         "method": "POST",
-        "path": "/api/voice"
+        "path": "/cadence/api/voice"
       },
       "outputSchema": {
         "type": "object",
@@ -26,7 +26,7 @@
           }
         }
       },
-      "srcHash": "sha256:16b1366a315696207861f0805d15f24bdc265568f62ffdcaf6b740fa2a48edc1"
+      "srcHash": "sha256:41d8566da3857a4ce17ad6fc404d7510b7b1409af0f1740beb041d32aa7de98c"
     },
     {
       "name": "host_getClient",
@@ -48,7 +48,7 @@
         "kind": "openapi",
         "operationId": "getClient",
         "method": "GET",
-        "path": "/api/clients/{id}"
+        "path": "/cadence/api/clients/{id}"
       },
       "outputSchema": {
         "type": "object",
@@ -129,7 +129,7 @@
           }
         }
       },
-      "srcHash": "sha256:16b1366a315696207861f0805d15f24bdc265568f62ffdcaf6b740fa2a48edc1"
+      "srcHash": "sha256:41d8566da3857a4ce17ad6fc404d7510b7b1409af0f1740beb041d32aa7de98c"
     },
     {
       "name": "host_getDashboard",
@@ -143,7 +143,7 @@
         "kind": "openapi",
         "operationId": "getDashboard",
         "method": "GET",
-        "path": "/api/dashboard"
+        "path": "/cadence/api/dashboard"
       },
       "outputSchema": {
         "type": "object",
@@ -191,20 +191,7 @@
           }
         }
       },
-      "semantics": {
-        "data.nearestDeadline": {
-          "kind": "date",
-          "format": "iso"
-        },
-        "data.nearestDeadlineClient.id": {
-          "kind": "id"
-        },
-        "data.nearestDeadlineClient.filingDeadline": {
-          "kind": "date",
-          "format": "iso"
-        }
-      },
-      "srcHash": "sha256:16b1366a315696207861f0805d15f24bdc265568f62ffdcaf6b740fa2a48edc1"
+      "srcHash": "sha256:41d8566da3857a4ce17ad6fc404d7510b7b1409af0f1740beb041d32aa7de98c"
     },
     {
       "name": "host_listActivity",
@@ -223,7 +210,7 @@
         "kind": "openapi",
         "operationId": "listActivity",
         "method": "GET",
-        "path": "/api/activity"
+        "path": "/cadence/api/activity"
       },
       "outputSchema": {
         "type": "object",
@@ -261,30 +248,7 @@
           }
         }
       },
-      "semantics": {
-        "data.id": {
-          "kind": "id"
-        },
-        "data.type": {
-          "kind": "enum",
-          "labels": {
-            "deadline_approaching": "Deadline approaching",
-            "document_rejected": "Document rejected",
-            "document_verified": "Document verified",
-            "message_sent": "Message sent",
-            "upload_received": "Upload received"
-          }
-        },
-        "data.clientId": {
-          "kind": "id",
-          "entity": "client"
-        },
-        "data.at": {
-          "kind": "date",
-          "format": "iso"
-        }
-      },
-      "srcHash": "sha256:16b1366a315696207861f0805d15f24bdc265568f62ffdcaf6b740fa2a48edc1"
+      "srcHash": "sha256:41d8566da3857a4ce17ad6fc404d7510b7b1409af0f1740beb041d32aa7de98c"
     },
     {
       "name": "host_listClientDocuments",
@@ -306,7 +270,7 @@
         "kind": "openapi",
         "operationId": "listClientDocuments",
         "method": "GET",
-        "path": "/api/clients/{id}/documents"
+        "path": "/cadence/api/clients/{id}/documents"
       },
       "outputSchema": {
         "type": "object",
@@ -359,7 +323,7 @@
           }
         }
       },
-      "srcHash": "sha256:16b1366a315696207861f0805d15f24bdc265568f62ffdcaf6b740fa2a48edc1"
+      "srcHash": "sha256:41d8566da3857a4ce17ad6fc404d7510b7b1409af0f1740beb041d32aa7de98c"
     },
     {
       "name": "host_listClientMessages",
@@ -381,7 +345,7 @@
         "kind": "openapi",
         "operationId": "listClientMessages",
         "method": "GET",
-        "path": "/api/clients/{id}/messages"
+        "path": "/cadence/api/clients/{id}/messages"
       },
       "outputSchema": {
         "type": "object",
@@ -420,7 +384,7 @@
           }
         }
       },
-      "srcHash": "sha256:16b1366a315696207861f0805d15f24bdc265568f62ffdcaf6b740fa2a48edc1"
+      "srcHash": "sha256:41d8566da3857a4ce17ad6fc404d7510b7b1409af0f1740beb041d32aa7de98c"
     },
     {
       "name": "host_listClients",
@@ -446,7 +410,7 @@
         "kind": "openapi",
         "operationId": "listClients",
         "method": "GET",
-        "path": "/api/clients"
+        "path": "/cadence/api/clients"
       },
       "outputSchema": {
         "type": "object",
@@ -530,40 +494,7 @@
           }
         }
       },
-      "semantics": {
-        "data.id": {
-          "kind": "id"
-        },
-        "data.entityType": {
-          "kind": "enum",
-          "labels": {
-            "c_corp": "C corp",
-            "individual": "Individual",
-            "partnership": "Partnership",
-            "s_corp": "S corp",
-            "sole_prop": "Sole prop"
-          }
-        },
-        "data.assigneeId": {
-          "kind": "id",
-          "entity": "assignee"
-        },
-        "data.filingDeadline": {
-          "kind": "date",
-          "format": "iso"
-        },
-        "data.status": {
-          "kind": "enum",
-          "labels": {
-            "complete": "Complete",
-            "missing_docs": "Missing docs"
-          }
-        },
-        "data.assignee.id": {
-          "kind": "id"
-        }
-      },
-      "srcHash": "sha256:16b1366a315696207861f0805d15f24bdc265568f62ffdcaf6b740fa2a48edc1"
+      "srcHash": "sha256:41d8566da3857a4ce17ad6fc404d7510b7b1409af0f1740beb041d32aa7de98c"
     },
     {
       "name": "host_listDeadlines",
@@ -577,7 +508,7 @@
         "kind": "openapi",
         "operationId": "listDeadlines",
         "method": "GET",
-        "path": "/api/deadlines"
+        "path": "/cadence/api/deadlines"
       },
       "outputSchema": {
         "type": "object",
@@ -677,40 +608,7 @@
           }
         }
       },
-      "semantics": {
-        "data.id": {
-          "kind": "id"
-        },
-        "data.entityType": {
-          "kind": "enum",
-          "labels": {
-            "c_corp": "C corp",
-            "individual": "Individual",
-            "partnership": "Partnership",
-            "s_corp": "S corp",
-            "sole_prop": "Sole prop"
-          }
-        },
-        "data.assigneeId": {
-          "kind": "id",
-          "entity": "assignee"
-        },
-        "data.filingDeadline": {
-          "kind": "date",
-          "format": "iso"
-        },
-        "data.status": {
-          "kind": "enum",
-          "labels": {
-            "complete": "Complete",
-            "missing_docs": "Missing docs"
-          }
-        },
-        "data.assignee.id": {
-          "kind": "id"
-        }
-      },
-      "srcHash": "sha256:16b1366a315696207861f0805d15f24bdc265568f62ffdcaf6b740fa2a48edc1"
+      "srcHash": "sha256:41d8566da3857a4ce17ad6fc404d7510b7b1409af0f1740beb041d32aa7de98c"
     },
     {
       "name": "host_listDemoChips",
@@ -724,7 +622,7 @@
         "kind": "openapi",
         "operationId": "listDemoChips",
         "method": "GET",
-        "path": "/api/demo/chips"
+        "path": "/cadence/api/demo/chips"
       },
       "outputSchema": {
         "type": "object",
@@ -757,7 +655,7 @@
           }
         }
       },
-      "srcHash": "sha256:16b1366a315696207861f0805d15f24bdc265568f62ffdcaf6b740fa2a48edc1"
+      "srcHash": "sha256:41d8566da3857a4ce17ad6fc404d7510b7b1409af0f1740beb041d32aa7de98c"
     },
     {
       "name": "host_resetDemo",
@@ -771,7 +669,7 @@
         "kind": "openapi",
         "operationId": "resetDemo",
         "method": "POST",
-        "path": "/api/demo/reset"
+        "path": "/cadence/api/demo/reset"
       },
       "outputSchema": {
         "type": "object",
@@ -819,7 +717,7 @@
           }
         }
       },
-      "srcHash": "sha256:16b1366a315696207861f0805d15f24bdc265568f62ffdcaf6b740fa2a48edc1"
+      "srcHash": "sha256:41d8566da3857a4ce17ad6fc404d7510b7b1409af0f1740beb041d32aa7de98c"
     },
     {
       "name": "host_sendClientMessage",
@@ -858,7 +756,7 @@
         "kind": "openapi",
         "operationId": "sendClientMessage",
         "method": "POST",
-        "path": "/api/clients/{id}/messages"
+        "path": "/cadence/api/clients/{id}/messages"
       },
       "outputSchema": {
         "type": "object",
@@ -894,7 +792,7 @@
           }
         }
       },
-      "srcHash": "sha256:16b1366a315696207861f0805d15f24bdc265568f62ffdcaf6b740fa2a48edc1"
+      "srcHash": "sha256:41d8566da3857a4ce17ad6fc404d7510b7b1409af0f1740beb041d32aa7de98c"
     },
     {
       "name": "host_setDocumentStatus",
@@ -947,7 +845,7 @@
         "kind": "openapi",
         "operationId": "setDocumentStatus",
         "method": "POST",
-        "path": "/api/clients/{id}/documents/{docId}/status"
+        "path": "/cadence/api/clients/{id}/documents/{docId}/status"
       },
       "outputSchema": {
         "type": "object",
@@ -997,7 +895,7 @@
           }
         }
       },
-      "srcHash": "sha256:16b1366a315696207861f0805d15f24bdc265568f62ffdcaf6b740fa2a48edc1"
+      "srcHash": "sha256:41d8566da3857a4ce17ad6fc404d7510b7b1409af0f1740beb041d32aa7de98c"
     },
     {
       "name": "host_simulateClientUpload",
@@ -1045,7 +943,7 @@
         "kind": "openapi",
         "operationId": "simulateClientUpload",
         "method": "POST",
-        "path": "/api/demo/simulate/upload"
+        "path": "/cadence/api/demo/simulate/upload"
       },
       "outputSchema": {
         "type": "object",
@@ -1129,7 +1027,7 @@
           }
         }
       },
-      "srcHash": "sha256:16b1366a315696207861f0805d15f24bdc265568f62ffdcaf6b740fa2a48edc1"
+      "srcHash": "sha256:41d8566da3857a4ce17ad6fc404d7510b7b1409af0f1740beb041d32aa7de98c"
     }
   ]
 }

--- a/apps/demo-accounting/next.config.ts
+++ b/apps/demo-accounting/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
+import { BASE_PATH } from "./src/lib/base-path";
 
 const nextConfig: NextConfig = {
   devIndicators: false,
+  // Served in place at demos.vendo.run/cadence — see ./src/lib/base-path.
+  basePath: BASE_PATH,
   // The apps engine syntax-checks generated islands with esbuild (native
   // binary) — keep it out of the Turbopack server bundle. PGlite's Emscripten
   // module breaks under Turbopack's production chunking ("f.instantiateWasm

--- a/apps/demo-accounting/openapi.json
+++ b/apps/demo-accounting/openapi.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "/"
+      "url": "/cadence"
     }
   ],
   "paths": {

--- a/apps/demo-accounting/src/app/demo/page.tsx
+++ b/apps/demo-accounting/src/app/demo/page.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardHeader } from "@/components/ui/card"
 import { PageHeader } from "@/components/ui/page-header"
 import { Reveal } from "@/components/ui/reveal"
+import { withBasePath } from "@/lib/base-path"
 import { fetcher, type ClientSummary, type DocumentRequest } from "@/lib/api"
 import { cn } from "@/lib/cn"
 
@@ -24,7 +25,7 @@ interface ResetMetrics {
 }
 
 async function post(url: string, body?: unknown): Promise<{ ok: boolean; json: unknown }> {
-  const res = await fetch(url, {
+  const res = await fetch(withBasePath(url), {
     method: "POST",
     ...(body !== undefined
       ? { headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) }

--- a/apps/demo-accounting/src/app/login/route.ts
+++ b/apps/demo-accounting/src/app/login/route.ts
@@ -1,5 +1,6 @@
 import { resolveCadenceSession, sessionCookie } from "@/server/session"
 import { cadenceDemoEmail, cadenceDemoUsers, supabaseAnonKey, supabaseUrl } from "@/server/users"
+import { withBasePath } from "@/lib/base-path"
 import { cadencePublicUrl, publicOrigin, safeReturnTo } from "@/vendo/auth"
 
 export const runtime = "nodejs"
@@ -50,7 +51,7 @@ function loginPage(request: Request, message?: string, status = 401): Response {
     <h1>Welcome back</h1>
     <p>Sign in to Cadence to keep your clients on schedule.</p>
     ${message ? `<div class="error" role="alert">${escapeHtml(message)}</div>` : ""}
-    <form method="post" action="/login">
+    <form method="post" action="${withBasePath("/login")}">
       <input type="hidden" name="returnTo" value="${escapeHtml(returnTo)}">
       <label>Email<input name="email" type="email" autocomplete="username" value="${escapeHtml(cadenceDemoEmail())}" required></label>
       <label>Password<input name="password" type="password" autocomplete="current-password" required autofocus></label>
@@ -83,8 +84,10 @@ export async function GET(request: Request): Promise<Response> {
       // Relative, same-origin redirect: returnTo is a safeReturnTo path, so the
       // browser resolves it against its own origin. Deriving an absolute origin
       // here can drift from the client's origin (e.g. 127.0.0.1 vs localhost in
-      // dev), which would drop the just-set host-only session cookie.
-      headers: { location: returnTo, "cache-control": "no-store" },
+      // dev) — and behind the edge that serves this demo in place it would name
+      // the Railway container, which would drop the just-set host-only session
+      // cookie or strand the visitor on a hostname they never typed.
+      headers: { location: withBasePath(returnTo), "cache-control": "no-store" },
     })
   }
   return loginPage(request)
@@ -98,7 +101,7 @@ export async function POST(request: Request): Promise<Response> {
   const returnTo = safeReturnTo(form.get("returnTo"), publicOrigin(request))
   const errorPage = (message: string, status?: number) =>
     loginPage(
-      new Request(cadencePublicUrl(request, `/login?returnTo=${encodeURIComponent(returnTo)}`)),
+      new Request(cadencePublicUrl(request, withBasePath(`/login?returnTo=${encodeURIComponent(returnTo)}`))),
       message,
       status,
     )
@@ -139,7 +142,7 @@ export async function POST(request: Request): Promise<Response> {
     headers: {
       // Relative, same-origin redirect so the browser keeps the origin it
       // signed in on and sends the host-only session cookie set just below.
-      location: returnTo,
+      location: withBasePath(returnTo),
       "set-cookie": sessionCookie(session.access_token, session.expires_in ?? 3600),
       "cache-control": "no-store",
     },

--- a/apps/demo-accounting/src/app/logout/route.ts
+++ b/apps/demo-accounting/src/app/logout/route.ts
@@ -1,3 +1,4 @@
+import { withBasePath } from "@/lib/base-path"
 import { SESSION_COOKIE } from "@/server/session"
 
 /** Sign out: drop the session cookie and land back on the login form. */
@@ -6,7 +7,7 @@ export function GET(request: Request): Response {
   return new Response(null, {
     status: 303,
     headers: {
-      location: "/login",
+      location: withBasePath("/login"),
       "set-cookie": `${SESSION_COOKIE}=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax${secure}`,
       "cache-control": "no-store",
     },

--- a/apps/demo-accounting/src/components/clients/client-marks.tsx
+++ b/apps/demo-accounting/src/components/clients/client-marks.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+import { withBasePath } from "@/lib/base-path"
 import { cn } from "@/lib/cn"
 import { logoUrl } from "@/lib/logos"
 
@@ -86,7 +87,7 @@ export function ClientMark({
     >
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
-        src={domain.startsWith("/") ? domain : logoUrl(domain, 128)}
+        src={domain.startsWith("/") ? withBasePath(domain) : logoUrl(domain, 128)}
         alt=""
         onError={() => setErrored(true)}
         loading="lazy"

--- a/apps/demo-accounting/src/components/clients/document-checklist.tsx
+++ b/apps/demo-accounting/src/components/clients/document-checklist.tsx
@@ -9,6 +9,7 @@ import { Card, CardHeader } from "@/components/ui/card"
 import { EmptyState } from "@/components/ui/empty-state"
 import { ErrorState } from "@/components/ui/error-state"
 import { Skeleton } from "@/components/ui/skeleton"
+import { withBasePath } from "@/lib/base-path"
 import { fetcher, type DocumentRequest } from "@/lib/api"
 import { cn } from "@/lib/cn"
 import { relativeTime } from "@/lib/format"
@@ -167,7 +168,7 @@ export function DocumentChecklist({ clientId }: { clientId: string }) {
     setPendingIds(prev => new Set(prev).add(docId))
     setActionError(null)
     try {
-      const res = await fetch(`/api/clients/${clientId}/documents/${docId}/status`, {
+      const res = await fetch(withBasePath(`/api/clients/${clientId}/documents/${docId}/status`), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(reason ? { action, reason } : { action }),

--- a/apps/demo-accounting/src/components/clients/message-thread.tsx
+++ b/apps/demo-accounting/src/components/clients/message-thread.tsx
@@ -8,6 +8,7 @@ import { Card, CardHeader } from "@/components/ui/card"
 import { EmptyState } from "@/components/ui/empty-state"
 import { ErrorState } from "@/components/ui/error-state"
 import { Skeleton } from "@/components/ui/skeleton"
+import { withBasePath } from "@/lib/base-path"
 import { fetcher, type Message } from "@/lib/api"
 import { cn } from "@/lib/cn"
 import { relativeTime } from "@/lib/format"
@@ -62,7 +63,7 @@ export function MessageThread({ clientId, contactName }: { clientId: string; con
     setSending(true)
     setSendError(null)
     try {
-      const res = await fetch(`/api/clients/${clientId}/messages`, {
+      const res = await fetch(withBasePath(`/api/clients/${clientId}/messages`), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ body }),

--- a/apps/demo-accounting/src/components/vendo/VendoLayer.tsx
+++ b/apps/demo-accounting/src/components/vendo/VendoLayer.tsx
@@ -4,6 +4,7 @@ import { useEffect, type ReactNode } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { useVendoOverlay } from "@vendoai/ui";
 import { VendoOverlay, VendoPalette, VendoThread, type VendoCommand, type VendoThreadProps } from "@vendoai/ui/chrome";
+import { withBasePath } from "@/lib/base-path";
 import { CadenceMark } from "@/components/brand";
 import { cadenceScenarios } from "@/vendo/scenarios";
 import { useTryThisChips } from "./use-try-this-chips";
@@ -24,9 +25,9 @@ function CadenceThread(props: VendoThreadProps) {
 
 async function resetDemo(): Promise<void> {
   try {
-    await fetch("/api/demo/reset", { method: "POST" });
+    await fetch(withBasePath("/api/demo/reset"), { method: "POST" });
   } finally {
-    window.location.href = "/";
+    window.location.href = withBasePath("/");
   }
 }
 

--- a/apps/demo-accounting/src/components/vendo/VendoRoot.tsx
+++ b/apps/demo-accounting/src/components/vendo/VendoRoot.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useSyncExternalStore, type ReactNode } from "react";
 import { VendoRoot as UmbrellaVendoRoot } from "@vendoai/vendo/react";
 import { ScriptedTransport, type DirectorScript, type ToolMetaMap } from "@vendoai/ui";
+import { withBasePath } from "@/lib/base-path";
 import { cadenceRegistry } from "@/vendo/registry";
 import { cadenceTheme } from "@/vendo/theme";
 import { cadenceRealtimeVoiceDriver } from "./voice-realtime";
@@ -37,6 +38,10 @@ const cadenceToolMeta: ToolMetaMap = {
  * live take by setting `globalThis.__vendoDirectorRecord = true` before a
  * run, then save `__vendoDirectorRecording` as the script's cues.
  */
+/** The Vendo door under the mount point. The provider's default is the bare
+ *  `/api/vendo`, which 404s once the app is served at a subpath. */
+const VENDO_DOOR = withBasePath("/api/vendo");
+
 const noopSubscribe = () => () => {};
 /** Client-only flag, hydration-safe: false on the server, real value on the client. */
 function useDirectorRequested(): boolean {
@@ -56,7 +61,7 @@ function useDirectorTransport(): { enabled: boolean; transport?: ScriptedTranspo
     if (!enabled) return;
     let alive = true;
     // Cache-busted: a stale cached script replays old component sources.
-    void fetch(`/vendo-director/script.json?v=${Date.now()}`, { cache: "no-store" })
+    void fetch(withBasePath(`/vendo-director/script.json?v=${Date.now()}`), { cache: "no-store" })
       .then(response => (response.ok ? (response.json() as Promise<DirectorScript>) : undefined))
       .then(script => {
         if (alive && (script?.cues?.length || script?.turns?.length)) setTransport(new ScriptedTransport(script));
@@ -92,7 +97,7 @@ export function VendoRoot({
   if (directorEligible && director.enabled && !director.transport) return null;
   if (!directorEligible) {
     return (
-      <UmbrellaVendoRoot components={cadenceRegistry} theme={cadenceTheme} tools={cadenceToolMeta} voice={{ driver: cadenceRealtimeVoiceDriver }} greeting={cadenceGreeting} onPin={onPin}>
+      <UmbrellaVendoRoot baseUrl={VENDO_DOOR} components={cadenceRegistry} theme={cadenceTheme} tools={cadenceToolMeta} voice={{ driver: cadenceRealtimeVoiceDriver }} greeting={cadenceGreeting} onPin={onPin}>
         {children}
       </UmbrellaVendoRoot>
     );
@@ -100,6 +105,7 @@ export function VendoRoot({
   return (
     <UmbrellaVendoRoot
       key={director.transport ? "vendo-director" : "vendo-live"}
+      baseUrl={VENDO_DOOR}
       components={cadenceRegistry}
       theme={cadenceTheme}
       tools={cadenceToolMeta}

--- a/apps/demo-accounting/src/components/vendo/use-try-this-chips.ts
+++ b/apps/demo-accounting/src/components/vendo/use-try-this-chips.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
+import { withBasePath } from "@/lib/base-path"
 
 /** The signed-in user's "try this" chip prompts (demo-hygiene). Rides the
  * thread's string-suggestion tier — pill chips below the scenario cards.
@@ -9,7 +10,7 @@ export function useTryThisChips(): string[] {
   const [chips, setChips] = useState<string[]>([])
   useEffect(() => {
     let cancelled = false
-    void fetch("/api/demo/chips")
+    void fetch(withBasePath("/api/demo/chips"))
       .then(response => (response.ok ? response.json() : null))
       .then((body: { data?: { chips?: { prompt: string }[] } } | null) => {
         const prompts = (body?.data?.chips ?? []).map(chip => chip.prompt)

--- a/apps/demo-accounting/src/components/vendo/vendo-card.tsx
+++ b/apps/demo-accounting/src/components/vendo/vendo-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { VendoSlot } from "@vendoai/ui/chrome";
+import { withBasePath } from "@/lib/base-path";
 import { VendoRoot } from "./VendoRoot";
 import { cadencePinnedDashboard } from "./pinned-dashboard";
 
@@ -12,7 +13,7 @@ export function VendoCard() {
             (a pinned vendo-genui/v2 dashboard). The host <a> stays the pin
             error fallback (06-apps §8). */}
         <VendoSlot id="home-dashboard" pin={{ payload: cadencePinnedDashboard }}>
-          <a className="block rounded-xl border border-dashed border-line p-6 text-sm text-ink-soft" href="/assistant">
+          <a className="block rounded-xl border border-dashed border-line p-6 text-sm text-ink-soft" href={withBasePath("/assistant")}>
             Design a view with Vendo
           </a>
         </VendoSlot>

--- a/apps/demo-accounting/src/components/vendo/voice-realtime.ts
+++ b/apps/demo-accounting/src/components/vendo/voice-realtime.ts
@@ -1,5 +1,6 @@
 import { createVendoClient } from "@vendoai/ui";
 import { createVoiceActBridge, realtimeVoiceDriver } from "@vendoai/ui/voice";
+import { withBasePath } from "@/lib/base-path";
 
 /** Cadence's WebRTC voice surface (08-ui §1), with the ENG-319 live pipeline:
  * the realtime model acts through Vendo mid-call via the `vendo_act` bridge —
@@ -7,7 +8,7 @@ import { createVoiceActBridge, realtimeVoiceDriver } from "@vendoai/ui/voice";
  * stage's consent bar. */
 export const cadenceRealtimeVoiceDriver = realtimeVoiceDriver({
   getSession: async () => {
-    const response = await fetch("/api/voice", { method: "POST" });
+    const response = await fetch(withBasePath("/api/voice"), { method: "POST" });
     const body = (await response.json().catch(() => ({}))) as {
       clientSecret?: string;
       model?: string;
@@ -23,5 +24,5 @@ export const cadenceRealtimeVoiceDriver = realtimeVoiceDriver({
     + "that touches clients, deadlines, documents, views or messages — describe the action in plain "
     + "language and speak from its result. Anything needing permission is asked on screen; tell the "
     + "user to look at the consent card when the result says so.",
-  act: createVoiceActBridge({ client: createVendoClient({ baseUrl: "/api/vendo" }) }),
+  act: createVoiceActBridge({ client: createVendoClient({ baseUrl: withBasePath("/api/vendo") }) }),
 });

--- a/apps/demo-accounting/src/lib/api.ts
+++ b/apps/demo-accounting/src/lib/api.ts
@@ -2,6 +2,7 @@
 // `{ data }` envelope (see src/server/http.ts); the fetcher unwraps it so SWR
 // hooks work directly with domain shapes.
 
+import { withBasePath } from "@/lib/base-path"
 import type { ClientSummary, DeadlineEntry } from "@/server/clients"
 import type { DashboardMetrics } from "@/server/documents"
 import type { ActivityEvent, DocumentRequest, Message } from "@/server/types"
@@ -16,8 +17,11 @@ export class ApiError extends Error {
   }
 }
 
+/** `url` is the bare API path (`/api/dashboard`), which is also its SWR key —
+ * so keys and `mutate()` calls stay written in the API's own vocabulary. The
+ * mount point is added here, at the one place the request is actually made. */
 export async function fetcher<T>(url: string): Promise<T> {
-  const res = await fetch(url)
+  const res = await fetch(withBasePath(url))
   const json = (await res.json().catch(() => null)) as
     | { data?: T; error?: { message?: string } }
     | null

--- a/apps/demo-accounting/src/lib/base-path.ts
+++ b/apps/demo-accounting/src/lib/base-path.ts
@@ -1,0 +1,20 @@
+/**
+ * WHERE CADENCE IS MOUNTED.
+ *
+ * The demo is served in place at demos.vendo.run/cadence, so `basePath` in
+ * next.config.ts is this constant — that is what moves the pages, the `/_next`
+ * assets, `next/link` hrefs and `useRouter().push` under the prefix, and what
+ * strips it back off `request.nextUrl.pathname` on the way in.
+ *
+ * What Next does NOT touch is any URL the app builds itself: `fetch("/api/…")`,
+ * a raw `<a href>`, a `<form action>`, a `window.location` assignment, a
+ * redirect's Location header, a file in `public/`. Those go through
+ * `withBasePath` — and so does the OpenAPI spec's server url, which is how the
+ * prefix reaches the agent's host tool calls.
+ */
+export const BASE_PATH = "/cadence"
+
+/** An app-absolute path (`/api/dashboard`) as the browser must request it. */
+export function withBasePath(path: string): string {
+  return `${BASE_PATH}${path}`
+}

--- a/apps/demo-accounting/src/proxy.ts
+++ b/apps/demo-accounting/src/proxy.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server"
+import { withBasePath } from "@/lib/base-path"
 import { autologinReturnTo, demoAutologinActive, mintAutologinToken } from "@/server/autologin"
 import { resolveCadenceSession, SESSION_COOKIE } from "@/server/session"
 import { isSecureDeployment } from "@/server/users"
@@ -40,6 +41,34 @@ function replaceCookie(header: string | null, name: string, value: string): stri
   return kept.join("; ")
 }
 
+/**
+ * A REDIRECT TO A PATH UNDER THE MOUNT POINT.
+ *
+ * `pathname` arrives with the mount point already stripped by Next, and Next
+ * does not put it back on a URL the app builds — so it goes back on here, or
+ * the visitor is bounced to a path nothing serves.
+ *
+ * THE ORIGIN IS THE REQUEST'S OWN, AND IT IS NOT ALWAYS THE VISITOR'S. Behind
+ * the edge that serves this demo in place, the worker proxies to the container
+ * with Host dropped (it has to be: `demoAutologinActive` only auto-signs-in a
+ * request whose Host is the origin `VENDO_BASE_URL` names, and that is the
+ * container's own origin, the one the app's tool calls go to). So every
+ * absolute URL reachable in here names Railway. A path-only Location would be
+ * the header-trust-free answer and is NOT available: Next's proxy runtime
+ * re-parses the header as an absolute URL and throws ERR_INVALID_URL, answering
+ * 500 — proven on the real production server, not assumed. Next emits absolute
+ * Locations of its own anyway (the trailing-slash 308), so no amount of care in
+ * here can make the app the place this is solved.
+ *
+ * It is solved one hop out instead: the edge worker rewrites a Location that
+ * names the origin it proxied to, which is what a reverse proxy is for and
+ * covers Next's own redirects as well as these. On a local run and on the bare
+ * Railway origin the request's own origin is already the right answer.
+ */
+function mountedRedirect(request: NextRequest, path: string): NextResponse {
+  return NextResponse.redirect(new URL(withBasePath(path), request.nextUrl))
+}
+
 async function setMintedCookie(response: NextResponse): Promise<void> {
   const minted = await mintAutologinToken()
   // Same attributes sessionCookie() (server/session.ts) sets on login.
@@ -61,7 +90,7 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
     // Z1: with auto-login active the login form must never render — the
     // /logout continuation lands here, so mint (if needed) and continue
     // straight into the product at the sanitized returnTo.
-    const response = NextResponse.redirect(new URL(autologinReturnTo(request), request.nextUrl))
+    const response = mountedRedirect(request, autologinReturnTo(request))
     if (!(await resolveCadenceSession(request))) await setMintedCookie(response)
     return response
   }
@@ -97,12 +126,20 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
       { status: 401 },
     )
   }
-  const login = new URL("/login", request.nextUrl)
-  login.searchParams.set("returnTo", `${pathname}${search}`)
-  return NextResponse.redirect(login)
+  // `pathname` already has the mount point stripped by Next, so returnTo stays
+  // in the app's own vocabulary; the prefix goes back on when a URL is emitted.
+  const returnTo = encodeURIComponent(`${pathname}${search}`)
+  return mountedRedirect(request, `/login?returnTo=${returnTo}`)
 }
 
 export const config = {
   // Skip Next internals and static files (anything with an extension).
-  matcher: ["/((?!_next/|.*\\..*).*)"],
+  //
+  // "/" is listed SEPARATELY and is load-bearing under a basePath. Next prefixes
+  // every matcher with the mount point, so the catch-all below becomes
+  // `/cadence/((?!…).*)` — which needs the slash after `/cadence` and therefore
+  // does not match the bare mount root a visitor actually types. Without this
+  // entry the dashboard is the ONE page the auth gate never sees, and it renders
+  // signed-out visitors a signed-in page. Proven on the real server.
+  matcher: ["/", "/((?!_next/|.*\\..*).*)"],
 }

--- a/apps/demo-accounting/src/server/__tests__/autologin.test.ts
+++ b/apps/demo-accounting/src/server/__tests__/autologin.test.ts
@@ -1,7 +1,7 @@
 import { SignJWT } from "jose"
 import { NextRequest } from "next/server"
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { proxy } from "../../proxy"
+import { config, proxy } from "../../proxy"
 import { isAutologinToken, mintAutologinToken } from "../autologin"
 import { resolveCadenceSession, SESSION_COOKIE } from "../session"
 import { cadenceDemoUsers, supabaseAnonKey, supabaseJwtSecret, supabaseUrl } from "../users"
@@ -22,6 +22,33 @@ function stubDemoDeployment(): void {
   vi.stubEnv("DEMO_AUTOLOGIN", "1")
   vi.stubEnv("VENDO_BASE_URL", "http://localhost:3100")
 }
+
+/**
+ * The redirect target as path+query, asserted to stay on the request's OWN
+ * origin and under the mount point.
+ *
+ * Cadence is served in place at demos.vendo.run/cadence, so a bounce to a path
+ * missing the `/cadence` prefix lands on nothing. The origin cannot be fixed
+ * here — Next's proxy runtime rejects a relative Location and emits absolute
+ * ones itself — so it is rewritten at the edge; what this pins is that the
+ * proxy never *introduces* a foreign origin of its own.
+ */
+function locationOf(response: Response, request: NextRequest): string {
+  const location = new URL(response.headers.get("location")!)
+  expect(location.origin).toBe(request.nextUrl.origin)
+  expect(location.pathname, "every redirect stays under the mount point").toMatch(/^\/cadence(?:\/|$)/u)
+  return `${location.pathname}${location.search}`
+}
+
+describe("proxy matcher", () => {
+  /** Next prefixes every matcher with the mount point, so the catch-all becomes
+   *  `/cadence/((?!…).*)` and does not match the bare `/cadence` a visitor
+   *  types. Dropping the explicit "/" leaves the dashboard as the one page the
+   *  gate never sees — and it renders a signed-out visitor a signed-in page. */
+  it("covers the bare mount root, not just paths under it", () => {
+    expect(config.matcher).toContain("/")
+  })
+})
 
 describe("auto-login token minting", () => {
   it("round-trips the UNCHANGED session verifier as the primary seeded user", async () => {
@@ -113,18 +140,21 @@ describe("proxy auto-login behavior", () => {
     stubDemoDeployment()
     // /logout clears the cookie and 303s to /login — with the flag that
     // continuation must never show a login form.
-    const response = await proxy(requestFor("/login"))
+    const request = requestFor("/login")
+    const response = await proxy(request)
     expect(response.status).toBe(307)
-    expect(new URL(response.headers.get("location")!).pathname).toBe("/")
+    expect(locationOf(response, request)).toBe("/cadence/")
     expect(response.headers.get("set-cookie")).toContain(`${SESSION_COOKIE}=`)
   })
 
   it("/login honors a same-origin returnTo and collapses foreign ones", async () => {
     stubDemoDeployment()
-    const same = await proxy(requestFor("/login?returnTo=%2Fclients%3Fq%3Dblue"))
-    expect(new URL(same.headers.get("location")!).pathname).toBe("/clients")
-    const foreign = await proxy(requestFor(`/login?returnTo=${encodeURIComponent("https://evil.example/phish")}`))
-    expect(new URL(foreign.headers.get("location")!).pathname).toBe("/")
+    const sameRequest = requestFor("/login?returnTo=%2Fclients%3Fq%3Dblue")
+    const same = await proxy(sameRequest)
+    expect(locationOf(same, sameRequest)).toBe("/cadence/clients?q=blue")
+    const foreignRequest = requestFor(`/login?returnTo=${encodeURIComponent("https://evil.example/phish")}`)
+    const foreign = await proxy(foreignRequest)
+    expect(locationOf(foreign, foreignRequest)).toBe("/cadence/")
   })
 
   it("without the flag, /login still renders the form (passes through untouched)", async () => {
@@ -143,7 +173,7 @@ describe("proxy auto-login behavior", () => {
     const response = await proxy(spoofed)
     // Normal unauthenticated flow: bounce to /login, nothing minted.
     expect(response.status).toBe(307)
-    expect(new URL(response.headers.get("location")!).pathname).toBe("/login")
+    expect(locationOf(response, spoofed)).toBe("/cadence/login?returnTo=%2Fclients")
     expect(response.headers.get("set-cookie")).toBeNull()
   })
 
@@ -162,7 +192,7 @@ describe("proxy auto-login behavior", () => {
     })
     const response = await proxy(loopback)
     expect(response.status).toBe(307)
-    expect(new URL(response.headers.get("location")!).pathname).toBe("/login")
+    expect(locationOf(response, loopback)).toBe("/cadence/login?returnTo=%2Fclients")
     expect(response.headers.get("set-cookie")).toBeNull()
   })
 

--- a/apps/demo-accounting/src/server/__tests__/openapi.test.ts
+++ b/apps/demo-accounting/src/server/__tests__/openapi.test.ts
@@ -7,6 +7,8 @@ import { describe, expect, it } from "vitest"
 import { existsSync, readFileSync, readdirSync } from "node:fs"
 import { join, relative, sep } from "node:path"
 import spec from "../../../openapi.json"
+import tools from "../../../.vendo/tools.json"
+import { BASE_PATH } from "@/lib/base-path"
 
 const APP_DIR = join(__dirname, "..", "..", "app")
 
@@ -52,6 +54,38 @@ describe("openapi.json <-> route handlers", () => {
     for (const method of Object.keys(item)) {
       expect(source).toMatch(new RegExp(`export async function ${method.toUpperCase()}\\b`))
     }
+  })
+
+  /**
+   * THE MOUNT POINT HAS TO REACH THE AGENT'S TOOL CALLS.
+   *
+   * Cadence is served in place at demos.vendo.run/cadence, so the endpoints
+   * really live at `<origin>/cadence/api/…`. Next rewrites the app's own
+   * requests; it does not know the agent exists. The prefix travels
+   * `openapi.json` servers → `vendo sync` → `.vendo/tools.json` `binding.path`,
+   * and NOTHING a human can see depends on it: get it wrong and every page
+   * renders perfectly while every number the agent quotes is a 404. That is why
+   * this is asserted rather than eyeballed.
+   */
+  it("declares the mount point as its server", () => {
+    expect(spec.servers).toEqual([{ url: BASE_PATH }])
+  })
+
+  it("carries the mount point into every synced tool binding", () => {
+    const bindings = tools.tools.map(tool => tool.binding)
+    expect(bindings.length).toBeGreaterThan(0)
+    for (const binding of bindings) {
+      expect(binding.path.startsWith(`${BASE_PATH}/`), `${binding.method} ${binding.path}`).toBe(true)
+    }
+  })
+
+  /** Also catches a STALE tools.json — a spec edit that never got synced. */
+  it("synced one tool binding per documented operation", () => {
+    const documented = paths.flatMap(([path, item]) =>
+      Object.keys(item).map(method => `${method.toUpperCase()} ${BASE_PATH}${path}`),
+    )
+    const synced = tools.tools.map(tool => `${tool.binding.method} ${tool.binding.path}`)
+    expect(synced.sort()).toEqual(documented.sort())
   })
 
   it("gives every operation a unique operationId", () => {

--- a/apps/demo-accounting/src/vendo/away-drill.test.ts
+++ b/apps/demo-accounting/src/vendo/away-drill.test.ts
@@ -55,7 +55,7 @@ async function createStack(): Promise<Stack> {
   const guard = createGuard({ store })
   const actions = createActions({
     tools: await cadenceTools(),
-    baseUrl: app!.baseUrl,
+    baseUrl: app!.origin,
     // The drill's point: away identity is a REAL Supabase user JWT minted
     // with the project's own secret. Unknown subjects are declined via
     // claims → null.
@@ -152,9 +152,12 @@ describe("Cadence away drill (ENG-260)", () => {
     })
     expect(anonymous.status).toBe(401)
 
-    const page = await appFetch(`${app!.baseUrl}/`, { redirect: "manual" })
+    // `baseUrl` IS the app root (origin + mount point) — a trailing slash on
+    // top of it is a different URL, and Next answers it with its own 308 to the
+    // canonical path instead of the login bounce this asserts.
+    const page = await appFetch(app!.baseUrl, { redirect: "manual" })
     expect([302, 303, 307, 308]).toContain(page.status)
-    expect(page.headers.get("location")).toContain("/login")
+    expect(page.headers.get("location")).toContain("/cadence/login")
   })
 
   it("executes an automation as the granting user with no live session", { timeout: 120_000 }, async () => {

--- a/apps/demo-accounting/src/vendo/e2e-harness.ts
+++ b/apps/demo-accounting/src/vendo/e2e-harness.ts
@@ -5,12 +5,18 @@ import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
 import { createServer } from "node:net"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
+import { BASE_PATH } from "../lib/base-path"
 
 export const appDir = fileURLToPath(new URL("../..", import.meta.url))
 export const BOOT_MS = 240_000
 
 export interface CadenceApp {
+  /** The app's own root — the origin plus the mount point Cadence is served
+   *  under. What a visitor types, and what every page/API fetch hangs off. */
   baseUrl: string
+  /** The bare origin. The WIRE base: `binding.path` in tools.json already
+   *  carries the mount point, so joining it onto `baseUrl` would double it. */
+  origin: string
   stop(): Promise<void>
 }
 
@@ -52,11 +58,12 @@ export async function bootCadence(
   env: Record<string, string> = {},
 ): Promise<CadenceApp> {
   const port = await freePort()
-  const baseUrl = `http://127.0.0.1:${port}`
+  const origin = `http://127.0.0.1:${port}`
+  const baseUrl = `${origin}${BASE_PATH}`
   let serverOutput = ""
   const childEnv = {
     ...process.env,
-    VENDO_BASE_URL: baseUrl,
+    VENDO_BASE_URL: origin,
     NEXT_TELEMETRY_DISABLED: "1",
     CADENCE_DIST_DIR: distDir,
     ...env,
@@ -89,6 +96,7 @@ export async function bootCadence(
 
   return {
     baseUrl,
+    origin,
     async stop() {
       if (child.exitCode !== null) return
       child.kill("SIGTERM")

--- a/packages/actions/src/sync/extractors.ts
+++ b/packages/actions/src/sync/extractors.ts
@@ -2,7 +2,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import type { SourcedExtractedTool } from "./common.js";
 import { detectGraphql, extractGraphql, graphqlEndpoints } from "./graphql.js";
-import { extractOpenApi } from "./openapi.js";
+import { extractOpenApi, openApiMountPath } from "./openapi.js";
 import { scanRoutes } from "./route-scan.js";
 import { detectServerActions, extractServerActions } from "./server-actions.js";
 import { detectTrpc, extractTrpc, trpcMounts } from "./trpc.js";
@@ -101,6 +101,38 @@ function withoutShadowedRoutes(tools: SourcedExtractedTool[]): SourcedExtractedT
   });
 }
 
+/**
+ * THE MOUNT POINT THE WHOLE HOST ANSWERS UNDER, ON EVERY HTTP BINDING.
+ *
+ * A host is not always at the root of its origin: a Next `basePath`, a reverse
+ * proxy, an app mounted inside a bigger one. The runtime does not know that —
+ * it joins `binding.path` straight onto the wire origin — so every tool call
+ * lands one prefix short of the real endpoint and 404s, while the host's own
+ * pages render perfectly because the framework rewrites THOSE for you. The
+ * result is a product that looks entirely correct and whose agent quietly has
+ * no data.
+ *
+ * Declared in ONE place — a relative `servers[0].url` in the OpenAPI document —
+ * and applied to EVERY http-shaped binding, including the ones route-scan
+ * found, because a mount point is a property of the host, not of one extractor.
+ * Uniform is also the only consistent choice: `dedupKey` is method+path, so
+ * prefixing one extractor's paths and not another's stops an OpenAPI operation
+ * and the route handler behind it from collapsing into a single tool and ships
+ * both, one of them broken.
+ *
+ * tRPC and GraphQL bindings address their mount/endpoint separately and are
+ * left alone; a subpath-mounted host that also speaks either would need the
+ * same treatment there.
+ */
+function mounted(tools: SourcedExtractedTool[], mount: string): SourcedExtractedTool[] {
+  if (mount === "") return tools;
+  return tools.map((tool) =>
+    tool.binding.kind === "openapi" || tool.binding.kind === "route"
+      ? { ...tool, binding: { ...tool.binding, path: `${mount}${tool.binding.path}` } }
+      : tool,
+  );
+}
+
 export async function runExtractors(
   root: string,
   registrations: readonly Extractor[] = extractorRegistrations,
@@ -113,5 +145,7 @@ export async function runExtractors(
     tools.push(...result.tools);
     warnings.push(...result.warnings);
   }
-  return { tools: withoutShadowedRoutes(tools), warnings };
+  const spec = await firstOpenApiSpec(root);
+  const mount = spec === null ? "" : await openApiMountPath(spec);
+  return { tools: mounted(withoutShadowedRoutes(tools), mount), warnings };
 }

--- a/packages/actions/src/sync/openapi.test.ts
+++ b/packages/actions/src/sync/openapi.test.ts
@@ -1,0 +1,88 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { OpenApiBinding, RouteBinding } from "../formats.js";
+import { runExtractors } from "./extractors.js";
+import { openApiMountPath } from "./openapi.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })));
+});
+
+async function writeFile(root: string, relative: string, source: string): Promise<void> {
+  const file = path.join(root, relative);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, source, "utf8");
+}
+
+const spec = (servers: unknown) => ({
+  openapi: "3.1.0",
+  info: { title: "Host", version: "1.0.0" },
+  ...(servers === undefined ? {} : { servers }),
+  paths: {
+    "/api/dashboard": { get: { operationId: "getDashboard", responses: {} } },
+    "/api/clients/{id}": { get: { operationId: "getClient", responses: {} } },
+  },
+});
+
+/** A host whose OpenAPI spec and Next route handlers describe the SAME two
+ *  endpoints — the shape both extractors see, and the one that has to keep
+ *  collapsing to one tool per endpoint. */
+async function host(servers: unknown): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "vendo-actions-openapi-"));
+  temporaryDirectories.push(root);
+  await writeFile(root, "package.json", JSON.stringify({ name: "mounted-host", dependencies: { next: "16.0.0" } }));
+  await writeFile(root, "openapi.json", JSON.stringify(spec(servers)));
+  await writeFile(root, "app/api/dashboard/route.ts", "export async function GET() { return Response.json({}) }\n");
+  await writeFile(root, "app/api/clients/[id]/route.ts", "export async function GET() { return Response.json({}) }\n");
+  return root;
+}
+
+/** Every distinct binding path the extractors produce. Both the OpenAPI
+ *  operation and the route handler behind it appear here — `unionExtracted`
+ *  collapses them downstream, and it collapses them BY PATH, which is why the
+ *  set below has to come out the same size prefixed or not. */
+async function paths(servers: unknown): Promise<string[]> {
+  const { tools } = await runExtractors(await host(servers));
+  const bound = tools.map((tool) => (tool.binding as OpenApiBinding | RouteBinding).path);
+  return [...new Set(bound)].sort();
+}
+
+async function mountOf(servers: unknown): Promise<string> {
+  const root = await host(servers);
+  return openApiMountPath(path.join(root, "openapi.json"));
+}
+
+describe("openApiMountPath", () => {
+  it.each([
+    ["a root server", [{ url: "/" }], ""],
+    ["no servers at all", undefined, ""],
+    ["an absolute server url", [{ url: "https://host.example/cadence" }], ""],
+    ["a relative server url", [{ url: "/cadence" }], "/cadence"],
+    ["a trailing slash on the mount point", [{ url: "/cadence/" }], "/cadence"],
+  ])("reads %s as %j", async (_label, servers, expected) => {
+    expect(await mountOf(servers)).toBe(expected);
+  });
+});
+
+describe("a host mounted under a subpath", () => {
+  it("leaves an origin-root host's paths alone", async () => {
+    expect(await paths([{ url: "/" }])).toEqual(["/api/clients/{id}", "/api/dashboard"]);
+  });
+
+  /** The one that matters: without the prefix every tool call lands on the
+   *  unmounted origin path and 404s while the pages themselves render fine. */
+  it("carries the mount point into every binding path", async () => {
+    expect(await paths([{ url: "/cadence" }])).toEqual(["/cadence/api/clients/{id}", "/cadence/api/dashboard"]);
+  });
+
+  /** dedupKey is method+path: prefix the OpenAPI operation and not the route
+   *  handler behind it and the two stop collapsing, shipping two tools per
+   *  endpoint with one of them pointing at nothing. */
+  it("moves every extractor's paths together, so they still collapse", async () => {
+    expect(await paths([{ url: "/cadence" }])).toHaveLength((await paths([{ url: "/" }])).length);
+  });
+});

--- a/packages/actions/src/sync/openapi.ts
+++ b/packages/actions/src/sync/openapi.ts
@@ -111,10 +111,31 @@ function descriptionFor(operation: JsonObject, method: HttpMethod, route: string
   return parts.length > 0 ? parts.join(". ") : `${method} ${route}`;
 }
 
-export async function extractOpenApi(specPath: string): Promise<ExtractedTool[]> {
+async function readDocument(specPath: string): Promise<JsonObject> {
   const raw = await fs.readFile(specPath, "utf8");
   const parsed = specPath.endsWith(".yaml") || specPath.endsWith(".yml") ? YAML.parse(raw) : JSON.parse(raw);
-  const document = jsonObject(parsed);
+  return jsonObject(parsed);
+}
+
+/**
+ * The mount point a RELATIVE `servers[0].url` declares — `"/cadence"` for a host
+ * served in place at `demos.vendo.run/cadence` — or "" for a host at the origin
+ * root. `"/"`, an absent `servers`, and an absolute url all mean "" (an absolute
+ * url carries its own path on `binding.baseUrl` instead), so every spec that
+ * does not opt in is untouched.
+ *
+ * Read here and applied by the caller across ALL extractors, not folded into the
+ * bindings below: see `runExtractors`.
+ */
+export async function openApiMountPath(specPath: string): Promise<string> {
+  const servers = (await readDocument(specPath)).servers;
+  const url = jsonObject((Array.isArray(servers) ? servers : [])[0]).url;
+  if (typeof url !== "string" || !url.startsWith("/")) return "";
+  return url.replace(/\/+$/u, "");
+}
+
+export async function extractOpenApi(specPath: string): Promise<ExtractedTool[]> {
+  const document = await readDocument(specPath);
   const paths = jsonObject(document.paths);
   const baseUrl = absoluteBaseUrl(document);
   const tools: ExtractedTool[] = [];


### PR DESCRIPTION
## Why

`demos.vendo.run/cadence` and `/maple` are the last two prospect-facing links whose 302 puts a `railway.app` hostname in the visitor's address bar. This is the Cadence half — it has no working clean URL today, so it is the lowest-risk one to move first. Maple follows in its own PR.

## What

`basePath: "/cadence"` in `next.config.ts`, plus a new `src/lib/base-path.ts` (`BASE_PATH` + `withBasePath`) for everything Next does *not* rewrite for you: client fetches, the Vendo door `baseUrl`, the voice session, `public/` assets, raw `<a href>`/`<form action>`, `window.location`, and every redirect's Location.

### Two failure modes worth naming — both invisible in a browser

**1. The tools.** `binding.path` in `tools.json` is joined straight onto the wire origin; the runtime has no idea a mount point exists. Left alone, every page renders perfectly and every number the agent quotes is a 404 — the "pages render, numbers silently wrong" class.

The mount point is now declared **once** (a relative `servers[0].url` in `openapi.json`) and `@vendoai/actions` applies it to **every** http-shaped binding at sync time, not just the OpenAPI ones. That uniformity is load-bearing: `dedupKey` is `method+path`, so prefixing one extractor and not another stops an OpenAPI operation from shadowing the route handler behind it — I hit exactly this mid-build and it turned 13 tools into 26, half of them pointing at nothing.

**2. The mount root.** Next prefixes proxy matchers with the basePath, so the catch-all becomes `/cadence/((?!…).*)` — which requires the slash and therefore **never matches the bare `/cadence` a visitor types**. The dashboard was the one page the auth gate did not see, and it rendered a signed-out visitor a fully signed-in page. Found on the real server, not by reading. `matcher` now lists `"/"` explicitly.

### Redirects

Route handlers emit path-only Locations. The proxy can't: Next's proxy runtime re-parses a relative Location as an absolute URL and answers **500** (`ERR_INVALID_URL`, reproduced on a real production build), and Next emits absolute Locations of its own anyway (the trailing-slash 308). So the proxy builds from the request's own origin, and the edge worker rewrites a Location that names the origin it proxied to — which is what a reverse proxy is for, and covers Next's own redirects too.

`VENDO_BASE_URL` is deliberately **unchanged**: the auto-login gate binds it to the origin the container answers on, and it is the base the app's own tool calls go to.

## Test changes, stated out loud

- proxy redirect assertions now pin the mount point and the request's *own* origin, instead of parsing the origin away
- the e2e harness splits `baseUrl` (app root, origin + mount) from `origin` (the wire base — `tools.json` paths already carry the mount point, so joining would double it)
- the away drill asserts the bare mount root bounces to `/cadence/login`; that is the regression test for the matcher bug, on a real server
- new: `packages/actions/src/sync/openapi.test.ts`, and mount-point assertions against this app's real spec + synced `tools.json`

## Verification

`pnpm build && pnpm test && pnpm typecheck && pnpm lint` green.

Proven on a **production build** booted locally with the deployed service's own configuration:

| check | result |
| --- | --- |
| renders at `/cadence` | ✅ full dashboard, real logos |
| auto-login before first paint | ✅ Maya Alvarez, on `/cadence`, `/cadence/work`, `/cadence/clients` |
| every link/asset under the mount | ✅ `/cadence/clients`, `/cadence/logos/…`, `/cadence/api/…` |
| unauthenticated bounce | ✅ `/cadence` → `/cadence/login?returnTo=%2F` (was a 200 signed-in page) |
| live agent turn, on-screen data | ✅ "**8 clients** are missing documents, and **21 documents** are still outstanding" — matches the seed |
| live agent turn, OFF-screen data | ✅ "Compass (Susan Kim) has **2 documents received out of 5**, assignee **Priya Natarajan**" — only reachable through the prefixed `host_getClient` binding |

> **Screenshots:** `*.png` is gitignored repo-wide, so these were silently skipped by `git add -A` here. They are force-added in the Maple half, #725 — [Cadence local](https://github.com/runvendo/vendo/blob/yousefh409/maple-in-place-basepath/apps/demo-accounting/docs/verification/one-surface-cadence-home.png?raw=true) · [live agent turn](https://github.com/runvendo/vendo/blob/yousefh409/maple-in-place-basepath/apps/demo-accounting/docs/verification/one-surface-cadence-agent.png?raw=true) · [live at demos.vendo.run/cadence](https://github.com/runvendo/vendo/blob/yousefh409/maple-in-place-basepath/apps/demo-accounting/docs/verification/one-surface-cadence-live.png?raw=true)

The off-screen prompt is the one that matters: it can't be answered from page context, so it proves the prefix reached the wire.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve Cadence in place at demos.vendo.run/cadence. Sets Next `basePath` and adds a `withBasePath` helper so all client-built URLs, assets, redirects, and API calls work under the mount, and syncs tool paths so agent calls hit real endpoints.

- **New Features**
  - Set `basePath: "/cadence"` and add `src/lib/base-path.ts` (`BASE_PATH`, `withBasePath`).
  - Update client fetches, Vendo door (`baseUrl`), voice session, public assets, `<a>`, `<form>`, and `window.location` to use `withBasePath`.
  - Declare server url as `/cadence` in `openapi.json`; tests assert server and synced tool paths.

- **Bug Fixes**
  - Proxy `matcher` now includes `/` so the bare `/cadence` hits the auth gate.
  - Redirects built from the request origin and `withBasePath` to avoid invalid relative `Location` and wrong hostnames.
  - `@vendoai/actions` applies the OpenAPI server mount to every HTTP binding (OpenAPI + route-scan) to prevent agent 404s and keep dedup by method+path consistent.

<sup>Written for commit 0bbb4c47fada42cc12a6b6683cec04f8fd31c0db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


