### PR TITLE
docs: remix final shape — approved spec, executor plan, review-console mockup

### DIFF
--- a/docs/superpowers/specs/2026-08-02-remix-final-shape-design.md
+++ b/docs/superpowers/specs/2026-08-02-remix-final-shape-design.md
@@ -94,17 +94,39 @@ placements: ["home-hero"]                                          // "show this
 - The demo-bank fake-hash workaround and the orphan `home-hero.json` baseline
   are deleted with the split.
 
-## Review: instant when personal, gated when shared
+## Review: a host policy knob (Yousef 2026-08-02)
+
+Personal-remix review is **configurable by the host**:
+
+```ts
+remix: { review: "none" | "required" }   // default: "none"
+```
+
+- `"none"` (default): a personal remix renders instantly, jailed, that user
+  only.
+- `"required"`: the remix is created but held; the user sees "sent for
+  review" and the fork renders only after a host reviewer approves its
+  ship-diff. Execution stays jailed either way — approval controls *when* the
+  user sees it, never whether it runs in-process.
+
+Independent of the knob, the blast-radius gates are fixed:
 
 | Scope of a remix | Execution | Review |
 |---|---|---|
-| Personal (default) | Jail, that user only | None — instant |
-| Shared with other users | Jail, wider audience | Ship-diff reviewed before others see it |
-| Promoted by the host | Real host code, in-process | Host engineers review the ship-diff like any code change |
+| Personal | Jail, that user only | Per the host's `review` knob |
+| Shared with other users | Jail, wider audience | Ship-diff reviewed before others see it, always |
+| Promoted by the host | Real host code, in-process | Host engineers review the ship-diff like any code change, always |
 
 The ship-diff (`packages/apps/src/ship-diff.ts` — the fork's unified diff
 against the captured baseline, keyed to a version hash) is the review artifact
-at both gates. The sandbox is the nursery; promotion is the graduation.
+at every gate. The sandbox is the nursery; promotion is the graduation.
+
+**Fork-quality warning at sync time:** capture analyzes the wrapped component
+for reach into host plumbing (router, context, callback props) and warns the
+host developer that such a component will fork with degraded behavior — bad
+remix candidates get caught before they ever ship a sparkle. This is the
+mitigation for missing-functionality disappointment; the frozen eval measures
+whether it suffices or the `review` default must flip.
 
 ## Also folded into this shape
 

--- a/docs/superpowers/specs/2026-08-02-remix-final-shape-design.md
+++ b/docs/superpowers/specs/2026-08-02-remix-final-shape-design.md
@@ -1,0 +1,139 @@
+# Remix — the final shape (2026-08-02)
+
+Decided with Yousef 2026-08-02. This spec settles the end-state of the remix
+use case: one concept, one API, one honest data model, and a review boundary
+placed where blast radius begins. It supersedes the split personality that
+shipped across the July waves (`remixable: true` registry captures + the
+`<Remixable>` grounding chip from #714).
+
+## The product promise
+
+**Remix always means fork.** A remix starts from the host's real component,
+copied byte-for-byte by the engine — never regenerated, never retyped by the
+model. There is no graded-fidelity mode: a surface either forks or it has no
+remix affordance at all.
+
+Consequences:
+
+- The context-chip behavior `<Remixable>` has today (open the composer with a
+  "REMIXING · <surface>" chip, no fork) **dies entirely**. No rename, no
+  fallback. `openVendoConversation({ remix })` and the chip plumbing are
+  removed.
+- The gesture-owned-forking law from 2026-07-21 is unchanged and remains the
+  trust foundation: the engine copies, the model only edits afterwards.
+
+## The API: `<Remixable>` is the whole surface
+
+The wrapper becomes the registration. One line, one sync run:
+
+```tsx
+<Remixable>
+  <NetWorthCard accounts={accounts} />
+</Remixable>
+```
+
+- `vendo sync` scans host source for `<Remixable>` usages, resolves the child
+  through its import (same static source analysis capture already performs),
+  and snapshots it into `.vendo/remixable/` — source, local imports
+  (`subSources`), stylesheets (`styles`), hash.
+- **Constraint (defended, not hidden):** the wrapped child must be a single,
+  statically importable component. Arbitrary inline JSX is a **loud sync-time
+  error** whose message says: extract a component and wrap that. No silent
+  degradation of any kind.
+- **Removed:** the catalog `remixable: true` flag, `VendoSlot`'s `remix` flag,
+  and the runtime-capture browser helper (`packages/vendo/src/remixable.ts`,
+  `runtime-capture.ts`) — its baselines were strictly weaker (no subSources /
+  styles / sampleProps) and the wrapper replaces its reason to exist. Remix is
+  experimental, so these are deleted without a deprecation cycle.
+- `VendoSlot` returns to its one job: mounting brand-new generated apps.
+
+## Rendering: in place, in the jail, with real data
+
+- The fork **replaces the wrapped element in place**, for that user only. The
+  wrapper (`data-vendo-remixable`) is the mount boundary; the host page morphs
+  per user. No slot required.
+- The fork always renders inside the jail (sandboxed iframe, locked CSP).
+  **In-process execution of user remixes is ruled out** — the frame is the
+  only real security boundary a browser offers, and in-process model-edited
+  code would force review before first render, killing instant remix.
+- **Data is real, two routes:**
+  1. In place, the live (JSON-serializable) props the host passes at the call
+     site flow across the frame boundary into the fork. Nothing captured,
+     nothing stale.
+  2. Anything beyond that — edits wanting data the original never received, or
+     a fork placed on a dashboard away from the host page — the agent binds
+     through the host's API as that user, exactly like any generated app.
+- Host **functions do not cross** (callbacks, router, context plumbing).
+  Behavior is rewired through the API; that is the accepted trade for the
+  boundary. Declared `sampleProps` die with the registry flag; the fork's seed
+  for the dashboard-placement edge case is a snapshot of the serializable live
+  props at the wrapper, taken at fork time.
+- Known jail costs accepted with the ruling: frame weight per fork, clipped
+  overlays at the boundary, client-only first paint. The reviewed **promote**
+  path (below) is the escape hatch to zero-seam native code.
+
+## Data model: pins vs placements
+
+Today one array (`doc.pins`, `Pin { slot, base }`) stores two unrelated facts,
+forcing the dashboard-pin path to fabricate `base` hashes and triggering false
+drift warnings. Split:
+
+```ts
+pins:       [{ slot: "MapleNetWorthCard", base: "sha256:abc…" }]  // fork provenance ONLY
+placements: ["home-hero"]                                          // "show this app in that slot"
+```
+
+- `pins` feeds drift detection, ship-diff, and rebase — provenance, nothing
+  else. `placements` feeds slot discovery (`useSlotApp`) — location, nothing
+  else. A "place" is a host-authored name (`VendoSlot` id), never a DOM path.
+- An in-place fork needs **no placement** — its location is the wrapper it
+  replaced.
+- **One-time migration** of stored apps: a pin whose `base` matches a known
+  captured baseline hash stays a pin; every other entry becomes a placement.
+  Fail closed: an entry that matches neither pattern is surfaced, not guessed.
+- The demo-bank fake-hash workaround and the orphan `home-hero.json` baseline
+  are deleted with the split.
+
+## Review: instant when personal, gated when shared
+
+| Scope of a remix | Execution | Review |
+|---|---|---|
+| Personal (default) | Jail, that user only | None — instant |
+| Shared with other users | Jail, wider audience | Ship-diff reviewed before others see it |
+| Promoted by the host | Real host code, in-process | Host engineers review the ship-diff like any code change |
+
+The ship-diff (`packages/apps/src/ship-diff.ts` — the fork's unified diff
+against the captured baseline, keyed to a version hash) is the review artifact
+at both gates. The sandbox is the nursery; promotion is the graduation.
+
+## Also folded into this shape
+
+- **Fork idempotency:** the appId-less `POST /apps/fork-pin` currently mints a
+  new app on every call (UI latch is the only guard). The route gains a
+  server-side dedupe per (user, wrapper) so a double-tap can never mint a
+  duplicate; the latch becomes cosmetic.
+- **Graduation gate:** "experimental" stays a label until the frozen REMIX
+  eval is re-run and scores the redesigned journey (ledger is still 2/12,
+  pre-redesign). The eval re-run happens **after** the pins/placements split
+  (score the honest model, not the workarounds) and per its own frozen
+  protocol — nothing in this spec tunes against it.
+- **Housekeeping riding along:** the three stale doc sections (duplicated
+  remix section in `docs-site/connect/host-components.mdx`, the dead exit-2
+  claim in `cli.mdx`, the deleted-init-picker section in
+  `docs/host-components.md`), the never-emitted `remixOffered/Wrapped/Skipped`
+  telemetry events, and the CSP-blocked `@import` console noise (eval F5).
+
+## Out of scope
+
+- The eval re-run itself (own protocol, own run doc).
+- Vendor-authored distribution / ship-app endgame beyond the promote gate
+  (see the embedded-agent architecture spec).
+- Any change to generation or the edit dialect.
+
+## Sequencing
+
+1. Pins/placements split + migration (small, unblocks an honest eval).
+2. The `<Remixable>`-as-registration build (sync scan, in-place fork mount,
+   chip removal, old-API deletion, idempotent fork route).
+3. Frozen REMIX eval re-run → graduation decision.
+4. Housekeeping PR.

--- a/docs/superpowers/specs/2026-08-02-remix-final-shape-design.md
+++ b/docs/superpowers/specs/2026-08-02-remix-final-shape-design.md
@@ -52,10 +52,11 @@ The wrapper becomes the registration. One line, one sync run:
 - The fork **replaces the wrapped element in place**, for that user only. The
   wrapper (`data-vendo-remixable`) is the mount boundary; the host page morphs
   per user. No slot required.
-- The fork always renders inside the jail (sandboxed iframe, locked CSP).
-  **In-process execution of user remixes is ruled out** — the frame is the
-  only real security boundary a browser offers, and in-process model-edited
-  code would force review before first render, killing instant remix.
+- An **unapproved** fork always renders inside the jail (sandboxed iframe,
+  locked CSP) — the frame is the only real security boundary a browser offers,
+  and unreviewed model-edited code never runs in-process. A **host-approved**
+  version mounts natively in the page (see Review below); the jail is the
+  draft venue, not a permanent ceiling.
 - **Data is real, two routes:**
   1. In place, the live (JSON-serializable) props the host passes at the call
      site flow across the frame boundary into the fork. Nothing captured,
@@ -68,9 +69,9 @@ The wrapper becomes the registration. One line, one sync run:
   boundary. Declared `sampleProps` die with the registry flag; the fork's seed
   for the dashboard-placement edge case is a snapshot of the serializable live
   props at the wrapper, taken at fork time.
-- Known jail costs accepted with the ruling: frame weight per fork, clipped
-  overlays at the boundary, client-only first paint. The reviewed **promote**
-  path (below) is the escape hatch to zero-seam native code.
+- Known jail costs accepted for drafts: frame weight per fork, clipped
+  overlays at the boundary, client-only first paint. Approval (below) is the
+  path to zero-seam native execution.
 
 ## Data model: pins vs placements
 
@@ -94,39 +95,69 @@ placements: ["home-hero"]                                          // "show this
 - The demo-bank fake-hash workaround and the orphan `home-hero.json` baseline
   are deleted with the split.
 
-## Review: a host policy knob (Yousef 2026-08-02)
+## Review: draft → approved, and review buys the venue (Yousef 2026-08-02)
 
-Personal-remix review is **configurable by the host**:
+A remix has two states, and host review moves it between them:
 
-```ts
-remix: { review: "none" | "required" }   // default: "none"
+```
+user remixes ──► DRAFT: instantly visible, jailed (self-contained behavior
+    │                   works; reach into host plumbing is degraded)
+    │  host reviews the ship-diff, approves
+    ▼
+APPROVED: that exact version mounts IN THE HOST PAGE — native, in place,
+    │     full functionality, hash-pinned to the reviewed version
+    │  user edits again
+    ▼
+back to DRAFT (jailed) until re-approved — fail-closed by construction
 ```
 
-- `"none"` (default): a personal remix renders instantly, jailed, that user
-  only.
-- `"required"`: the remix is created but held; the user sees "sent for
-  review" and the fork renders only after a host reviewer approves its
-  ship-diff. Execution stays jailed either way — approval controls *when* the
-  user sees it, never whether it runs in-process.
+This rides the existing in-client approval machinery
+(`packages/apps/src/inclient.ts`): jailed is the default venue; only a stored
+approval matching the CURRENT version's content hash mounts the UI in the host
+page; any hash mismatch drops back to the iframe. Review is not bureaucracy —
+it is what makes a remix fully real. The sandbox is the draft state, not a
+permanent ceiling.
 
-Independent of the knob, the blast-radius gates are fixed:
+**The policy is per-component, on the wrapper** — because remixability varies
+by component (Yousef: a self-contained chart forks cleanly; a plumbing-heavy
+panel does not):
+
+```tsx
+<Remixable>                      {/* default: drafts="instant" */}
+  <NetWorthCard accounts={accounts} />
+</Remixable>
+
+<Remixable drafts="held">        {/* remixes wait for host approval */}
+  <TransferPanel />
+</Remixable>
+```
+
+- `drafts="instant"` (default): the jailed draft renders immediately;
+  approval upgrades that exact version to native in place.
+- `drafts="held"`: the user sees "sent for review"; nothing renders until a
+  reviewer approves, and it then mounts native directly.
+
+The blast-radius gates are fixed regardless of the knob:
 
 | Scope of a remix | Execution | Review |
 |---|---|---|
-| Personal | Jail, that user only | Per the host's `review` knob |
-| Shared with other users | Jail, wider audience | Ship-diff reviewed before others see it, always |
-| Promoted by the host | Real host code, in-process | Host engineers review the ship-diff like any code change, always |
+| Personal draft | Jail, that user only | None (visible per the wrapper's `drafts`) |
+| Personal approved | Host page, that user only | Ship-diff approved, hash-pinned |
+| Shared with other users | Per approval state | Ship-diff reviewed before others see it, always |
+| Promoted by the host | Host codebase | Host engineers review like any code change, always |
 
 The ship-diff (`packages/apps/src/ship-diff.ts` — the fork's unified diff
 against the captured baseline, keyed to a version hash) is the review artifact
-at every gate. The sandbox is the nursery; promotion is the graduation.
+at every gate. Approving is one screen: the diff, approve/reject. Self-hosters
+wire the approval seam themselves; Cloud's console is the ready-made review
+screen (the usual OSS/Cloud split).
 
 **Fork-quality warning at sync time:** capture analyzes the wrapped component
 for reach into host plumbing (router, context, callback props) and warns the
-host developer that such a component will fork with degraded behavior — bad
-remix candidates get caught before they ever ship a sparkle. This is the
-mitigation for missing-functionality disappointment; the frozen eval measures
-whether it suffices or the `review` default must flip.
+host developer — including suggesting `drafts="held"` for plumbing-heavy
+components, so the policy is learned exactly where it would be gotten wrong.
+The frozen eval measures whether draft-quality forks satisfy or the default
+must flip.
 
 ## Also folded into this shape
 

--- a/docs/superpowers/specs/2026-08-02-remix-final-shape-design.md
+++ b/docs/superpowers/specs/2026-08-02-remix-final-shape-design.md
@@ -55,8 +55,7 @@ The wrapper becomes the registration. One line, one sync run:
 - An **unapproved** fork always renders inside the jail (sandboxed iframe,
   locked CSP) — the frame is the only real security boundary a browser offers,
   and unreviewed model-edited code never runs in-process. A **host-approved**
-  version mounts natively in the page (see Review below); the jail is the
-  draft venue, not a permanent ceiling.
+  version mounts natively in the page (see Review below).
 - **Data is real, two routes:**
   1. In place, the live (JSON-serializable) props the host passes at the call
      site flow across the frame boundary into the fork. Nothing captured,
@@ -69,9 +68,9 @@ The wrapper becomes the registration. One line, one sync run:
   boundary. Declared `sampleProps` die with the registry flag; the fork's seed
   for the dashboard-placement edge case is a snapshot of the serializable live
   props at the wrapper, taken at fork time.
-- Known jail costs accepted for drafts: frame weight per fork, clipped
-  overlays at the boundary, client-only first paint. Approval (below) is the
-  path to zero-seam native execution.
+- Known jail costs accepted for instant-kind remixes: frame weight per fork,
+  clipped overlays at the boundary, client-only first paint. Review-kind
+  components get zero-seam native execution through approval (below).
 
 ## Data model: pins vs placements
 
@@ -95,69 +94,65 @@ placements: ["home-hero"]                                          // "show this
 - The demo-bank fake-hash workaround and the orphan `home-hero.json` baseline
   are deleted with the split.
 
-## Review: draft → approved, and review buys the venue (Yousef 2026-08-02)
+## Review: two component kinds, review buys the venue (Yousef 2026-08-02)
 
-A remix has two states, and host review moves it between them:
-
-```
-user remixes ──► DRAFT: instantly visible, jailed (self-contained behavior
-    │                   works; reach into host plumbing is degraded)
-    │  host reviews the ship-diff, approves
-    ▼
-APPROVED: that exact version mounts IN THE HOST PAGE — native, in place,
-    │     full functionality, hash-pinned to the reviewed version
-    │  user edits again
-    ▼
-back to DRAFT (jailed) until re-approved — fail-closed by construction
-```
-
-This rides the existing in-client approval machinery
-(`packages/apps/src/inclient.ts`): jailed is the default venue; only a stored
-approval matching the CURRENT version's content hash mounts the UI in the host
-page; any hash mismatch drops back to the iframe. Review is not bureaucracy —
-it is what makes a remix fully real. The sandbox is the draft state, not a
-permanent ceiling.
-
-**The policy is per-component, on the wrapper** — because remixability varies
-by component (Yousef: a self-contained chart forks cleanly; a plumbing-heavy
-panel does not):
+Review NEVER affects who can see a remix — remixes are personal, always. It
+decides only sandboxed-vs-in-place. Each wrapped component is one of exactly
+two kinds:
 
 ```tsx
-<Remixable>                      {/* default: drafts="instant" */}
-  <NetWorthCard accounts={accounts} />
+<Remixable>            {/* instant: remix appears immediately, runs SANDBOXED,
+  <NetWorthCard />        forever. No review process exists for it. */}
 </Remixable>
 
-<Remixable drafts="held">        {/* remixes wait for host approval */}
-  <TransferPanel />
-</Remixable>
+<Remixable review>     {/* reviewed: the user sees NOTHING until a host
+  <TransferPanel />       reviewer approves; the approved version then renders
+</Remixable>              IN PLACE as real code. */}
 ```
 
-- `drafts="instant"` (default): the jailed draft renders immediately;
-  approval upgrades that exact version to native in place.
-- `drafts="held"`: the user sees "sent for review"; nothing renders until a
-  reviewer approves, and it then mounts native directly.
+- **Instant** (default): remix → it renders, jailed, done. No queue, no
+  pending state, no approval ceremony — there is nothing to signal. The ✦
+  mark on the remixed component is the management handle (revert, edit).
+- **Reviewed**: after remixing, the original stays and the only user-visible
+  state is "sent for review" (surfaced in the panel). On approval the remix
+  appears in place, native. On rejection the reviewer's note lands in the
+  panel; the work is not deleted — the user can edit and resubmit.
+- **Edits to an approved remix go back through review.** Until the new
+  version is approved, the LAST approved version keeps rendering — never a
+  gap, never unreviewed code in place. This rides the existing hash-pinned
+  in-client approval machinery (`packages/apps/src/inclient.ts`): only a
+  stored approval matching a version's content hash mounts in the host page.
 
-The blast-radius gates are fixed regardless of the knob:
+Fixed gates regardless of kind:
 
-| Scope of a remix | Execution | Review |
+| Scope | Execution | Review |
 |---|---|---|
-| Personal draft | Jail, that user only | None (visible per the wrapper's `drafts`) |
-| Personal approved | Host page, that user only | Ship-diff approved, hash-pinned |
-| Shared with other users | Per approval state | Ship-diff reviewed before others see it, always |
+| Personal, instant component | Jail, that user only | None, ever |
+| Personal, reviewed component | Host page, that user only | Ship-diff approved before the user sees it |
+| Shared with other users | Per component kind | Ship-diff approved before sharing, always (see Sharing) |
 | Promoted by the host | Host codebase | Host engineers review like any code change, always |
 
 The ship-diff (`packages/apps/src/ship-diff.ts` — the fork's unified diff
 against the captured baseline, keyed to a version hash) is the review artifact
-at every gate. Approving is one screen: the diff, approve/reject. Self-hosters
-wire the approval seam themselves; Cloud's console is the ready-made review
-screen (the usual OSS/Cloud split).
+at every gate. Approving is one screen: the user's version rendered live next
+to the host's original, the exact code diff one tap away, approve/reject with
+a note (Yousef's pick). Self-hosters get the approval seam; Cloud's console is
+the ready-made review screen (the usual OSS/Cloud split).
 
 **Fork-quality warning at sync time:** capture analyzes the wrapped component
 for reach into host plumbing (router, context, callback props) and warns the
-host developer — including suggesting `drafts="held"` for plumbing-heavy
-components, so the policy is learned exactly where it would be gotten wrong.
-The frozen eval measures whether draft-quality forks satisfy or the default
-must flip.
+host developer — suggesting `review` for plumbing-heavy components, so the
+policy is learned exactly where it would be gotten wrong.
+
+## Sharing (Yousef 2026-08-02: in scope, rides wave 3)
+
+Sharing a remix = sharing an app that contains a fork, on the wave-3 rebuild
+primitives (grants to user/team/org, `can()`, the share dialog) — nothing new
+is built. Remix adds ONE rule: an app containing a fork can be shared only
+when its current version has an approval; otherwise the share dialog shows
+"needs review first" and can request it. Built as the FINAL wave, after the
+rebuild cutover lands on main, coordinated with the wave-3 orchestrator
+session.
 
 ## Also folded into this shape
 
@@ -182,11 +177,14 @@ must flip.
 - Vendor-authored distribution / ship-app endgame beyond the promote gate
   (see the embedded-agent architecture spec).
 - Any change to generation or the edit dialect.
+- New sharing machinery of any kind — sharing reuses wave-3 primitives only.
 
 ## Sequencing
 
 1. Pins/placements split + migration (small, unblocks an honest eval).
 2. The `<Remixable>`-as-registration build (sync scan, in-place fork mount,
-   chip removal, old-API deletion, idempotent fork route).
+   chip removal, old-API deletion, idempotent fork route, the two component
+   kinds + review flow, console review screen seam).
 3. Frozen REMIX eval re-run → graduation decision.
 4. Housekeeping PR.
+5. Sharing wave — after the rebuild cutover lands on main, on wave-3 grants.

--- a/docs/superpowers/specs/2026-08-02-remix-final-shape-plan.md
+++ b/docs/superpowers/specs/2026-08-02-remix-final-shape-plan.md
@@ -1,0 +1,99 @@
+# Remix final shape — executor plan (2026-08-02)
+
+Executes `2026-08-02-remix-final-shape-design.md` (approved by Yousef
+2026-08-02, with the console mockup `...remix-review-console-mockup.html`).
+Nothing outside this plan gets built. Frozen checklist = session task list
+W0–W4; only the driving session flips items, only with proof.
+
+## Frozen contract (all lanes build against this; amendments only via the
+## driving session, logged here)
+
+- **Wrapper API** (`@vendoai/ui`):
+  `<Remixable review?: boolean>{child}</Remixable>` — no other props beyond
+  today's `name`/`context` REMOVED (the grounding chip dies; `name` is no
+  longer needed: the captured component's exported name is the slot name).
+  `data-vendo-remixable=<slot>` stays the DOM boundary.
+- **Slot naming**: the captured component's exported identifier (e.g.
+  `NetWorthCard`), exactly as the registry name works today. Collisions
+  (two wrappers, same component) are ONE capture, many mount points — legal.
+- **Capture format**: `PinBaseline` unchanged (`pins.ts`), except
+  `sampleProps` is no longer written by sync; schema keeps it optional
+  (legacy files stay valid).
+- **Fork call**: `POST /apps/fork-pin { slot, props? }` — `props` = the
+  wrapper's serializable live props at fork time, stored on the app as the
+  dashboard seed. Server dedupes per (subject, slot): an existing app whose
+  pins name the slot is returned instead of minting (W0).
+- **Data model** (`@vendoai/core`): `AppDocument.placements?: string[]`
+  added; `Pin {slot, base}` untouched. Readers classify legacy rows on read:
+  a `pins` entry whose `base` matches no captured baseline hash is treated
+  as a placement; rows normalize on next write. No migration script.
+- **Review state** (rides `inclient.ts`, additive): review-kind remixes are
+  apps whose venue requires an approval. New records: rejection note
+  `{appId, versionHash, note, by, at}` in a routed collection
+  `vendo_remix_rejections`. Wire seam (OSS):
+  `GET /apps/review-queue` (host-admin scoped) · existing approval record
+  door for approve · `POST /apps/:id/reject-review { note }`.
+  Kind (`review` flag) is capture metadata: sync writes `review: true` into
+  the baseline file from the wrapper prop.
+- **Layering law**: dependency-guard order stays; no new packages.
+
+## Lanes
+
+**W0 (first, alone — everything else rebases on it):** core schema +
+placements readers + demo-host pin routes + fork dedupe + orphan deletion.
+Packages: core, apps, ui (useSlotApp), examples/*. One PR.
+
+**W1a sync (after W0):** wrapper scan in the sync pipeline
+(`packages/actions/src/sync/`), child-import resolution reusing the existing
+static capture; loud non-component error; plumbing heuristic (imports of
+next/navigation, react context hooks, function-typed props at the call
+site) → `review` suggestion; delete registry `remixable:true` handling +
+`packages/vendo/src/remixable.ts` + `runtime-capture.ts` and their routes.
+
+**W1b ui (after W0, parallel with W1a):** move the ✦ affordance from
+VendoSlot to Remixable; gesture → fork-pin with props snapshot; in-place
+jailed mount at the wrapper (reuse JailedComponent + AppFrame); delete chip
+plumbing; VendoSlot keeps only app-mounting; ✦ management popover (status /
+revert / open panel scoped to the remix).
+
+**W1c lifecycle (after W0, parallel):** review-kind gating in open/venue
+logic; last-approved-version rendering (venue verdict picks newest approved
+version, not current, for review-kind); rejection notes + panel surfacing;
+review-queue wire seam. Forbidden from W1b's files except `use-slot-app.ts`
+read (coordinate via driving session if a shared file is unavoidable).
+
+**W1d console (vendo-web repo, after W1c's seam is merged):** the approved
+mockup as a real console screen against the seam. Deploy after merge.
+
+**W1e integration (after W1a–W1d):** convert demo-bank + demo-accounting;
+ONE continuous browser E2E per checklist. This lane owns redeploying any
+demo host it touches.
+
+**W2 eval (after W1e):** frozen protocol runner. Read
+`docs/eval/REMIX.md` rules 1–5 verbatim; scenarios run against the wrapper
+surface; fails are data; never feed findings back into code this wave.
+
+**W3 housekeeping (parallel with W2):** per checklist. Docs rewrite covers
+docs/host-components.md, docs-site connect/cli/reference pages.
+
+**W4 sharing (gated):** starts only after rebuild/cutover lands on main.
+Rebase everything first. One rule: `can()`-granting on an app with pins
+requires an approval for the CURRENT version; share dialog "needs review
+first" state + request-review action. Coordinate with the wave-3
+orchestrator before touching their surface.
+
+## Rules for every lane
+
+- Own worktree, own branch off the current base; NEVER two agents in one
+  worktree (dist artifacts are shared — proven 2026-08-01).
+- Tests written with the code; never edit existing tests to make code pass
+  (a legitimately-obsolete test change is stated out loud in the PR).
+- Local `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green
+  before push; umbrella suite judged un-contended (--concurrency=1 rule).
+- PR per lane, auto-merge armed when green; AI-reviewer findings triaged
+  and batched into one push.
+- UI-touching PRs carry real-browser screenshots.
+- Known env gotchas: engine #631 (generation vs Maple catalog) — seed apps
+  through the records door where generation blocks a test; `pkill -f "next
+  start"` does not kill the next-server child (PGlite lock corruption);
+  `next dev` can wedge in worktrees — prefer `next build && next start`.

--- a/docs/superpowers/specs/2026-08-02-remix-review-console-mockup.html
+++ b/docs/superpowers/specs/2026-08-02-remix-review-console-mockup.html
@@ -1,0 +1,1317 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Vendo Console — Remix review</title>
+<style>
+  /* ------------------------------------------------------------------ */
+  /* Console tokens — neutral grays, one violet accent, light mode.     */
+  /* Radii echo Vendo chrome: 7 / 12 / 16.                              */
+  /* ------------------------------------------------------------------ */
+  :root {
+    --bg: #f6f6f8;
+    --surface: #ffffff;
+    --text: #17181c;
+    --text-secondary: #4b4d55;
+    --muted: #7c7e88;
+    --faint: #a4a6b0;
+    --border: #e6e6ea;
+    --border-strong: #d8d8de;
+    --accent: #6d4de6;
+    --accent-hover: #5f3fd6;
+    --accent-soft: rgba(109, 77, 230, 0.08);
+    --accent-softer: rgba(109, 77, 230, 0.05);
+    --ok: #1f8a5f;
+    --ok-soft: #e7f5ee;
+    --danger: #c03d2e;
+    --danger-soft: #fbeeec;
+    --warn: #8a6a2e;
+    --warn-soft: #faf3e3;
+    --radius-sm: 7px;
+    --radius: 12px;
+    --radius-lg: 16px;
+    --shadow-card: 0 1px 2px rgba(23, 24, 28, 0.04), 0 2px 8px rgba(23, 24, 28, 0.04);
+    --shadow-pop: 0 4px 12px rgba(23, 24, 28, 0.08), 0 12px 32px rgba(23, 24, 28, 0.10);
+    --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+    --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  html, body { height: 100%; }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-size: 14px;
+    color: var(--text);
+    background: var(--bg);
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .app {
+    display: grid;
+    grid-template-columns: 292px 1fr;
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Sidebar                                                             */
+  /* ------------------------------------------------------------------ */
+  .sidebar {
+    background: var(--surface);
+    border-right: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 18px 20px 16px;
+  }
+  .brand-mark {
+    width: 28px; height: 28px;
+    border-radius: 8px;
+    background: linear-gradient(135deg, #7a5bf0, #5b3fd4);
+    color: #fff;
+    display: flex; align-items: center; justify-content: center;
+    font-weight: 700; font-size: 14px;
+    letter-spacing: -0.02em;
+    flex: none;
+  }
+  .brand-text { line-height: 1.25; }
+  .brand-name { font-weight: 600; font-size: 13.5px; }
+  .brand-project { font-size: 12px; color: var(--muted); }
+
+  .queue-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 20px 8px;
+  }
+  .queue-title {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--faint);
+  }
+  .queue-count {
+    font-size: 11.5px;
+    font-weight: 600;
+    color: var(--accent);
+    background: var(--accent-soft);
+    border-radius: 999px;
+    padding: 2px 8px;
+    min-width: 22px;
+    text-align: center;
+  }
+
+  .queue {
+    flex: 1;
+    overflow-y: auto;
+    padding: 4px 10px 16px;
+  }
+
+  .queue-item {
+    width: 100%;
+    display: block;
+    text-align: left;
+    background: none;
+    border: 0;
+    border-radius: var(--radius);
+    padding: 11px 12px;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+    position: relative;
+    transition: background 120ms ease;
+  }
+  .queue-item:hover { background: #f3f3f6; }
+  .queue-item.selected { background: var(--accent-soft); }
+  .queue-item.selected::before {
+    content: "";
+    position: absolute;
+    left: 0; top: 12px; bottom: 12px;
+    width: 3px;
+    border-radius: 2px;
+    background: var(--accent);
+  }
+  .queue-item-top {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .queue-item-name {
+    font-weight: 600;
+    font-size: 13.5px;
+    color: var(--text);
+    font-family: var(--mono);
+    font-size: 12.5px;
+  }
+  .queue-item.selected .queue-item-name { color: var(--accent-hover); }
+  .queue-item-sub {
+    margin-top: 3px;
+    font-size: 12.5px;
+    color: var(--muted);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .queue-item-sub .dot { color: var(--faint); }
+
+  .badge-resub {
+    font-size: 10.5px;
+    font-weight: 600;
+    color: var(--warn);
+    background: var(--warn-soft);
+    border-radius: 999px;
+    padding: 1px 7px;
+    white-space: nowrap;
+  }
+
+  .queue-empty {
+    padding: 28px 16px;
+    text-align: center;
+    color: var(--faint);
+    font-size: 13px;
+  }
+
+  .sidebar-footer {
+    border-top: 1px solid var(--border);
+    padding: 12px 20px;
+    display: flex;
+    align-items: center;
+    gap: 9px;
+  }
+  .reviewer-avatar {
+    width: 26px; height: 26px;
+    border-radius: 999px;
+    background: #e3e0f5;
+    color: #5b3fd4;
+    font-size: 11px; font-weight: 600;
+    display: flex; align-items: center; justify-content: center;
+    flex: none;
+  }
+  .reviewer-meta { line-height: 1.25; }
+  .reviewer-name { font-size: 12.5px; font-weight: 500; }
+  .reviewer-role { font-size: 11px; color: var(--muted); }
+
+  /* ------------------------------------------------------------------ */
+  /* Main                                                                */
+  /* ------------------------------------------------------------------ */
+  .main {
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 32px;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface);
+    position: sticky;
+    top: 0;
+    z-index: 5;
+  }
+  .crumbs { font-size: 13px; color: var(--muted); display: flex; align-items: center; gap: 7px; }
+  .crumbs .sep { color: var(--faint); }
+  .crumbs .here { color: var(--text); font-weight: 600; }
+
+  .content {
+    flex: 1;
+    padding: 28px 32px 48px;
+    max-width: 1120px;
+    width: 100%;
+    margin: 0 auto;
+  }
+
+  /* --- review header ------------------------------------------------ */
+  .review-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 6px;
+  }
+  .review-title {
+    font-size: 20px;
+    font-weight: 650;
+    letter-spacing: -0.015em;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .review-title code {
+    font-family: var(--mono);
+    font-size: 19px;
+  }
+  .review-sub {
+    margin-top: 5px;
+    font-size: 13.5px;
+    color: var(--muted);
+  }
+
+  .meta-strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px 36px;
+    margin: 20px 0 0;
+    padding: 16px 20px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+  }
+  .meta-item { min-width: 120px; }
+  .meta-label {
+    font-size: 10.5px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--faint);
+    margin-bottom: 4px;
+  }
+  .meta-value { font-size: 13px; color: var(--text-secondary); font-weight: 500; }
+  .meta-value .sub { color: var(--muted); font-weight: 400; }
+  .meta-value code {
+    font-family: var(--mono);
+    font-size: 12px;
+    background: var(--accent-softer);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 1px 6px;
+    color: var(--accent-hover);
+  }
+
+  .changes-hint {
+    margin-top: 12px;
+    padding: 11px 14px;
+    background: var(--warn-soft);
+    border: 1px solid #efe2c2;
+    border-radius: var(--radius);
+    font-size: 13px;
+    color: var(--warn);
+    display: flex;
+    gap: 9px;
+    align-items: baseline;
+  }
+  .changes-hint b { font-weight: 600; }
+
+  /* --- comparison card ----------------------------------------------- */
+  .compare-card {
+    margin-top: 20px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-card);
+    overflow: hidden;
+  }
+  .compare-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+  }
+  .compare-toolbar-label {
+    font-size: 12.5px;
+    color: var(--muted);
+  }
+  .compare-toolbar-label code { font-family: var(--mono); font-size: 11.5px; color: var(--text-secondary); }
+
+  .seg {
+    display: inline-flex;
+    background: #efeff2;
+    border-radius: var(--radius-sm);
+    padding: 2px;
+    gap: 2px;
+  }
+  .seg button {
+    font: inherit;
+    font-size: 12.5px;
+    font-weight: 500;
+    color: var(--muted);
+    background: none;
+    border: 0;
+    border-radius: 5px;
+    padding: 5px 12px;
+    cursor: pointer;
+    transition: color 120ms ease, background 120ms ease;
+  }
+  .seg button.active {
+    background: var(--surface);
+    color: var(--text);
+    box-shadow: 0 1px 2px rgba(23,24,28,0.08);
+  }
+
+  .compare-body { padding: 24px; }
+
+  .panes {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 24px;
+  }
+  .pane { min-width: 0; }
+  .pane-label {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--faint);
+    margin-bottom: 10px;
+  }
+  .pane-label .pip { width: 7px; height: 7px; border-radius: 999px; flex: none; }
+  .pane-label .pip.orig { background: var(--faint); }
+  .pane-label .pip.remix { background: var(--accent); }
+  .pane-label.remix-label { color: var(--accent-hover); }
+
+  .pane-stage {
+    background: #f0efe9;
+    border-radius: var(--radius);
+    padding: 26px 22px;
+    display: flex;
+    justify-content: center;
+    min-height: 300px;
+    align-items: flex-start;
+  }
+  .pane-stage.remix-stage {
+    outline: 1px solid rgba(109, 77, 230, 0.25);
+    outline-offset: -1px;
+  }
+
+  /* --- diff view ------------------------------------------------------ */
+  .diff {
+    background: #fbfbfc;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow-x: auto;
+    font-family: var(--mono);
+    font-size: 12.5px;
+    line-height: 1.75;
+  }
+  .diff-file {
+    padding: 8px 16px;
+    font-size: 11.5px;
+    color: var(--muted);
+    border-bottom: 1px solid var(--border);
+    background: #f5f5f7;
+  }
+  .diff pre { padding: 10px 0 12px; }
+  .diff .ln {
+    display: block;
+    padding: 0 16px 0 34px;
+    white-space: pre;
+    position: relative;
+    color: var(--text-secondary);
+  }
+  .diff .ln::before {
+    position: absolute;
+    left: 14px;
+    color: var(--faint);
+  }
+  .diff .ln.add { background: #e9f6ef; color: #1a5c40; }
+  .diff .ln.add::before { content: "+"; color: #1f8a5f; }
+  .diff .ln.del { background: #fbeeec; color: #8c3227; }
+  .diff .ln.del::before { content: "−"; color: var(--danger); }
+  .diff .ln.hunk { color: var(--accent-hover); background: var(--accent-softer); font-size: 11.5px; }
+  .diff .tok-str { color: #9a4a00; }
+  .diff .ln.add .tok-str { color: #135c3d; font-weight: 600; }
+  .diff .ln.del .tok-str { color: #a02c1f; font-weight: 600; }
+  .diff .tok-tag { color: #5b3fd4; }
+
+  /* --- actions --------------------------------------------------------- */
+  .actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 14px 24px;
+    border-top: 1px solid var(--border);
+    background: #fcfcfd;
+  }
+  .actions-note {
+    font-size: 12.5px;
+    color: var(--muted);
+  }
+  .actions-buttons { display: flex; gap: 10px; }
+
+  .btn {
+    font: inherit;
+    font-size: 13.5px;
+    font-weight: 550;
+    border-radius: var(--radius-sm);
+    padding: 8px 18px;
+    cursor: pointer;
+    border: 1px solid transparent;
+    transition: transform 140ms var(--ease-out), background 120ms ease, border-color 120ms ease;
+  }
+  .btn:active { transform: scale(0.97); }
+  .btn-primary {
+    background: var(--accent);
+    color: #fff;
+  }
+  .btn-primary:hover { background: var(--accent-hover); }
+  .btn-secondary {
+    background: var(--surface);
+    color: var(--text-secondary);
+    border-color: var(--border-strong);
+  }
+  .btn-secondary:hover { border-color: var(--faint); color: var(--text); }
+  .btn-danger {
+    background: var(--danger);
+    color: #fff;
+  }
+  .btn-danger:hover { background: #a83526; }
+  .btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    transform: none;
+  }
+  .btn-ghost {
+    background: none;
+    border: 0;
+    color: var(--muted);
+    font: inherit;
+    font-size: 13px;
+    cursor: pointer;
+    padding: 8px 10px;
+  }
+  .btn-ghost:hover { color: var(--text); }
+
+  /* --- reject panel ---------------------------------------------------- */
+  .reject-panel {
+    border-top: 1px solid var(--border);
+    padding: 16px 24px 18px;
+    background: #fdf7f6;
+    display: none;
+  }
+  .reject-panel.open { display: block; }
+  .reject-panel-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--danger);
+    margin-bottom: 4px;
+  }
+  .reject-panel-sub {
+    font-size: 12.5px;
+    color: var(--muted);
+    margin-bottom: 10px;
+  }
+  .reject-panel textarea {
+    width: 100%;
+    min-height: 74px;
+    resize: vertical;
+    font: inherit;
+    font-size: 13.5px;
+    color: var(--text);
+    padding: 10px 12px;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+  }
+  .reject-panel textarea:focus {
+    outline: 2px solid rgba(192, 61, 46, 0.35);
+    outline-offset: 1px;
+    border-color: transparent;
+  }
+  .reject-panel-actions {
+    margin-top: 10px;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+  /* --- empty state ------------------------------------------------------ */
+  .empty-state {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 64px 32px;
+    color: var(--muted);
+  }
+  .empty-state .glyph {
+    width: 52px; height: 52px;
+    border-radius: 999px;
+    background: var(--ok-soft);
+    color: var(--ok);
+    font-size: 24px;
+    display: flex; align-items: center; justify-content: center;
+    margin-bottom: 16px;
+  }
+  .empty-state h2 { font-size: 17px; font-weight: 600; color: var(--text); margin-bottom: 6px; }
+  .empty-state p { font-size: 13.5px; max-width: 340px; line-height: 1.55; }
+
+  /* --- toast ------------------------------------------------------------ */
+  .toast {
+    position: fixed;
+    left: 50%;
+    bottom: 26px;
+    transform: translate(-50%, 12px);
+    opacity: 0;
+    pointer-events: none;
+    background: #1e1f24;
+    color: #f2f2f4;
+    font-size: 13px;
+    padding: 10px 16px;
+    border-radius: 10px;
+    box-shadow: var(--shadow-pop);
+    transition: transform 220ms var(--ease-out), opacity 220ms var(--ease-out);
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    max-width: 480px;
+    z-index: 50;
+  }
+  .toast.show { transform: translate(-50%, 0); opacity: 1; }
+  .toast .tick { color: #4ade80; font-weight: 700; }
+  .toast .cross { color: #f87171; font-weight: 700; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .toast { transition: opacity 180ms ease; transform: translate(-50%, 0); }
+    .btn:active { transform: none; }
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Maple bank component styling (the host product's design language). */
+  /* Clean, rounded, green accent — deliberately distinct from console.  */
+  /* ------------------------------------------------------------------ */
+  .mp-card {
+    width: 100%;
+    max-width: 330px;
+    background: #ffffff;
+    border: 1px solid #e7e5df;
+    border-radius: 18px;
+    padding: 20px;
+    box-shadow: 0 1px 2px rgba(26, 46, 37, 0.05), 0 6px 18px rgba(26, 46, 37, 0.05);
+    color: #1a2e25;
+    font-size: 13.5px;
+  }
+  .mp-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 6px;
+  }
+  .mp-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: #74807a;
+    letter-spacing: 0.01em;
+  }
+  .mp-logo {
+    font-size: 11px;
+    font-weight: 700;
+    color: #0e7a52;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+  .mp-logo::before { content: "🍁"; font-size: 11px; }
+  .mp-value {
+    font-size: 27px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    line-height: 1.1;
+  }
+  .mp-delta { font-size: 12.5px; margin-top: 5px; font-weight: 550; }
+  .mp-delta.up { color: #0e7a52; }
+  .mp-chart {
+    display: flex;
+    align-items: flex-end;
+    gap: 5px;
+    height: 76px;
+    margin-top: 18px;
+  }
+  .mp-chart span {
+    flex: 1;
+    border-radius: 4px 4px 2px 2px;
+    background: #bcd9cb;
+  }
+  .mp-chart span.hi { background: #0e7a52; }
+  .mp-chart.teal span { background: #b6d8d5; }
+  .mp-chart.teal span.hi { background: #0f766e; }
+  .mp-axis {
+    display: flex;
+    justify-content: space-between;
+    font-size: 10.5px;
+    color: #9aa5a0;
+    margin-top: 8px;
+  }
+  .mp-goal {
+    margin-top: 18px;
+    padding-top: 14px;
+    border-top: 1px solid #eeece6;
+  }
+  .mp-goal-top {
+    display: flex;
+    justify-content: space-between;
+    font-size: 12.5px;
+    margin-bottom: 8px;
+  }
+  .mp-goal-top .name { font-weight: 600; }
+  .mp-goal-top .nums { color: #74807a; }
+  .mp-bar {
+    height: 8px;
+    border-radius: 999px;
+    background: #e8efe9;
+    overflow: hidden;
+  }
+  .mp-bar > div { height: 100%; border-radius: 999px; background: #0e7a52; }
+  .mp-goal-hint { font-size: 11.5px; color: #74807a; margin-top: 7px; }
+
+  .mp-field { margin-top: 14px; }
+  .mp-field-label { display: block; font-size: 11.5px; color: #74807a; font-weight: 550; margin-bottom: 5px; }
+  .mp-select {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 12px;
+    border: 1px solid #dfe3df;
+    border-radius: 11px;
+    font-size: 13px;
+    font-weight: 500;
+    background: #fbfbf9;
+  }
+  .mp-select .chev { color: #9aa5a0; font-size: 11px; }
+  .mp-avail { font-size: 12px; color: #74807a; margin-top: 7px; }
+  .mp-avail b { color: #1a2e25; font-weight: 600; }
+  .mp-avail.loud { color: #0e7a52; font-weight: 600; font-size: 12.5px; }
+  .mp-avail.loud b { color: #0e7a52; font-size: 14px; }
+  .mp-amount {
+    margin-top: 14px;
+    display: flex;
+    align-items: baseline;
+    gap: 5px;
+    padding: 12px 14px;
+    border: 1px solid #dfe3df;
+    border-radius: 11px;
+    background: #fbfbf9;
+  }
+  .mp-amount .cur { font-size: 15px; color: #9aa5a0; font-weight: 600; }
+  .mp-amount .amt { font-size: 21px; font-weight: 700; color: #b9c2bd; }
+  .mp-btn {
+    display: block;
+    width: 100%;
+    margin-top: 16px;
+    padding: 11px 0;
+    border: 0;
+    border-radius: 11px;
+    background: #0e7a52;
+    color: #fff;
+    font: inherit;
+    font-size: 13.5px;
+    font-weight: 600;
+    cursor: default;
+  }
+  .mp-recents { margin-top: 6px; display: flex; gap: 8px; }
+  .mp-recent {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    font-size: 10.5px;
+    color: #74807a;
+  }
+  .mp-recent .face {
+    width: 34px; height: 34px;
+    border-radius: 999px;
+    background: #e2efe8;
+    color: #0e7a52;
+    font-size: 12px; font-weight: 650;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .mp-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-top: 13px;
+  }
+  .mp-row .cat { font-size: 13px; font-weight: 550; flex: none; width: 96px; }
+  .mp-row .amt { font-size: 12.5px; color: #74807a; flex: none; text-align: right; width: 88px; }
+  .mp-row .amt b { color: #1a2e25; font-weight: 600; }
+  .mp-row .track { flex: 1; height: 7px; border-radius: 999px; background: #e8efe9; overflow: hidden; }
+  .mp-row .track > div { height: 100%; border-radius: 999px; background: #0e7a52; }
+  .mp-row.over .track > div { background: #c98a1b; }
+  .mp-row.over .amt b { color: #a06c0d; }
+  .mp-accounts { margin-top: 16px; padding-top: 6px; }
+  .mp-acct {
+    display: flex;
+    justify-content: space-between;
+    padding: 9px 0;
+    border-top: 1px solid #eeece6;
+    font-size: 13px;
+  }
+  .mp-acct .n { color: #74807a; }
+  .mp-acct .v { font-weight: 600; }
+</style>
+</head>
+<body>
+
+<div class="app">
+  <!-- ============================== SIDEBAR ============================== -->
+  <aside class="sidebar">
+    <div class="brand">
+      <div class="brand-mark">V</div>
+      <div class="brand-text">
+        <div class="brand-name">Vendo Console</div>
+        <div class="brand-project">Maple · production</div>
+      </div>
+    </div>
+
+    <div class="queue-header">
+      <div class="queue-title">Remix review</div>
+      <div class="queue-count" id="queueCount">5</div>
+    </div>
+
+    <nav class="queue" id="queueList" aria-label="Pending remixes"></nav>
+
+    <div class="sidebar-footer">
+      <div class="reviewer-avatar">ST</div>
+      <div class="reviewer-meta">
+        <div class="reviewer-name">Sam Torres</div>
+        <div class="reviewer-role">Reviewer · Maple design systems</div>
+      </div>
+    </div>
+  </aside>
+
+  <!-- ================================ MAIN =============================== -->
+  <main class="main">
+    <div class="topbar">
+      <div class="crumbs">
+        <span>Maple</span><span class="sep">/</span>
+        <span>Remixes</span><span class="sep">/</span>
+        <span class="here">Review queue</span>
+      </div>
+      <div class="crumbs"><span>Components marked <code style="font-family:var(--mono);font-size:12px;">review</code> require approval before users see their remix</span></div>
+    </div>
+
+    <div class="content" id="reviewArea"></div>
+  </main>
+</div>
+
+<div class="toast" id="toast"></div>
+
+<script>
+/* ==================================================================== */
+/* Data — five pending remixes on the Maple bank host product.          */
+/* ==================================================================== */
+
+const REVIEWS = [
+  {
+    id: "rmx_priya_nw",
+    component: "NetWorthCard",
+    page: "/dashboard",
+    requester: "Priya Raman",
+    email: "priya.raman@gmail.com",
+    age: "12m ago",
+    submitted: "Today, 9:41 AM",
+    hash: "8f3c21a",
+    resub: null,
+    changesSince: null,
+    summary: "Adds a savings-goal progress bar and switches the trend chart to teal.",
+    original: `
+      <div class="mp-card">
+        <div class="mp-head"><span class="mp-label">Net worth</span><span class="mp-logo">Maple</span></div>
+        <div class="mp-value">$128,540</div>
+        <div class="mp-delta up">▲ $2,340 this month</div>
+        <div class="mp-chart">
+          <span style="height:34%"></span><span style="height:41%"></span><span style="height:38%"></span>
+          <span style="height:52%"></span><span style="height:47%"></span><span style="height:58%"></span>
+          <span style="height:55%"></span><span style="height:66%"></span><span style="height:61%"></span>
+          <span style="height:74%"></span><span style="height:81%"></span><span class="hi" style="height:92%"></span>
+        </div>
+        <div class="mp-axis"><span>Feb</span><span>Mar</span><span>Apr</span><span>May</span><span>Jun</span><span>Jul</span></div>
+      </div>`,
+    remix: `
+      <div class="mp-card">
+        <div class="mp-head"><span class="mp-label">Net worth</span><span class="mp-logo">Maple</span></div>
+        <div class="mp-value">$128,540</div>
+        <div class="mp-delta up">▲ $2,340 this month</div>
+        <div class="mp-chart teal">
+          <span style="height:34%"></span><span style="height:41%"></span><span style="height:38%"></span>
+          <span style="height:52%"></span><span style="height:47%"></span><span style="height:58%"></span>
+          <span style="height:55%"></span><span style="height:66%"></span><span style="height:61%"></span>
+          <span style="height:74%"></span><span style="height:81%"></span><span class="hi" style="height:92%"></span>
+        </div>
+        <div class="mp-axis"><span>Feb</span><span>Mar</span><span>Apr</span><span>May</span><span>Jun</span><span>Jul</span></div>
+        <div class="mp-goal">
+          <div class="mp-goal-top"><span class="name">House fund</span><span class="nums">$34,000 / $60,000</span></div>
+          <div class="mp-bar"><div style="width:57%"></div></div>
+          <div class="mp-goal-hint">57% saved · on track for Mar 2027</div>
+        </div>
+      </div>`,
+    diff: {
+      file: "NetWorthCard.tsx",
+      lines: [
+        ["hunk", "@@ -12,9 +12,15 @@ export function NetWorthCard({ netWorth, history }) {"],
+        ["ctx", "  <Card>"],
+        ["ctx", "    <CardLabel>Net worth</CardLabel>"],
+        ["ctx", "    <Amount value={netWorth} />"],
+        ["ctx", "    <MonthDelta value={monthDelta} />"],
+        ["del", '    <TrendChart data={history} color="#0E7A52" />'],
+        ["add", '    <TrendChart data={history} color="#0F766E" />'],
+        ["add", "    <GoalProgress"],
+        ["add", '      label="House fund"'],
+        ["add", "      current={savingsGoal.saved}"],
+        ["add", "      target={savingsGoal.target}"],
+        ["add", "    />"],
+        ["ctx", '    <AxisLabels range="6m" />'],
+        ["ctx", "  </Card>"],
+      ],
+    },
+  },
+  {
+    id: "rmx_marcus_tp",
+    component: "TransferPanel",
+    page: "/transfers",
+    requester: "Marcus Webb",
+    email: "mwebb.trades@outlook.com",
+    age: "1h ago",
+    submitted: "Today, 8:52 AM",
+    hash: "c47d90e",
+    resub: null,
+    changesSince: null,
+    summary: "Renames the balance line and folds the overdraft limit into the number shown.",
+    original: `
+      <div class="mp-card">
+        <div class="mp-head"><span class="mp-label">Transfer money</span><span class="mp-logo">Maple</span></div>
+        <div class="mp-field">
+          <span class="mp-field-label">From</span>
+          <div class="mp-select"><span>Everyday Checking ··4821</span><span class="chev">▾</span></div>
+          <div class="mp-avail">Available balance <b>$4,210.55</b></div>
+        </div>
+        <div class="mp-field">
+          <span class="mp-field-label">To</span>
+          <div class="mp-select"><span>Choose a recipient</span><span class="chev">▾</span></div>
+        </div>
+        <div class="mp-amount"><span class="cur">$</span><span class="amt">0.00</span></div>
+        <button class="mp-btn" tabindex="-1">Review transfer</button>
+      </div>`,
+    remix: `
+      <div class="mp-card">
+        <div class="mp-head"><span class="mp-label">Transfer money</span><span class="mp-logo">Maple</span></div>
+        <div class="mp-field">
+          <span class="mp-field-label">From</span>
+          <div class="mp-select"><span>Everyday Checking ··4821</span><span class="chev">▾</span></div>
+          <div class="mp-avail loud">You can spend <b>$5,710.55</b></div>
+        </div>
+        <div class="mp-field">
+          <span class="mp-field-label">To</span>
+          <div class="mp-select"><span>Choose a recipient</span><span class="chev">▾</span></div>
+        </div>
+        <div class="mp-amount"><span class="cur">$</span><span class="amt">0.00</span></div>
+        <button class="mp-btn" tabindex="-1">Review transfer</button>
+      </div>`,
+    diff: {
+      file: "TransferPanel.tsx",
+      lines: [
+        ["hunk", "@@ -21,7 +21,7 @@ export function TransferPanel({ account }) {"],
+        ["ctx", "  <Field label=\"From\">"],
+        ["ctx", "    <AccountPicker value={account} />"],
+        ["del", "    <Hint>"],
+        ["del", "      Available balance <b>{usd(account.available)}</b>"],
+        ["del", "    </Hint>"],
+        ["add", "    <Hint tone=\"positive\">"],
+        ["add", "      You can spend <b>{usd(account.available + account.overdraftLimit)}</b>"],
+        ["add", "    </Hint>"],
+        ["ctx", "  </Field>"],
+        ["ctx", "  <Field label=\"To\">"],
+        ["ctx", "    <RecipientPicker />"],
+        ["ctx", "  </Field>"],
+      ],
+    },
+  },
+  {
+    id: "rmx_dana_sb",
+    component: "SpendingBreakdown",
+    page: "/insights",
+    requester: "Dana Okafor",
+    email: "dana@okafor.studio",
+    age: "3h ago",
+    submitted: "Today, 6:15 AM",
+    hash: "2b91f7c",
+    resub: 2,
+    changesSince: "Removed the full-width red “OVER BUDGET” banner from v1. Caps are now quiet per-category text; the over-cap state is an amber bar, not an alert.",
+    summary: "Adds a monthly budget cap next to each spending category.",
+    original: `
+      <div class="mp-card">
+        <div class="mp-head"><span class="mp-label">Spending this month</span><span class="mp-logo">Maple</span></div>
+        <div class="mp-value" style="font-size:23px;">$2,148</div>
+        <div class="mp-row"><span class="cat">Groceries</span><div class="track"><div style="width:64%"></div></div><span class="amt"><b>$642</b></span></div>
+        <div class="mp-row"><span class="cat">Dining</span><div class="track"><div style="width:41%"></div></div><span class="amt"><b>$415</b></span></div>
+        <div class="mp-row"><span class="cat">Transport</span><div class="track"><div style="width:24%"></div></div><span class="amt"><b>$238</b></span></div>
+        <div class="mp-row"><span class="cat">Subscriptions</span><div class="track"><div style="width:19%"></div></div><span class="amt"><b>$189</b></span></div>
+      </div>`,
+    remix: `
+      <div class="mp-card">
+        <div class="mp-head"><span class="mp-label">Spending this month</span><span class="mp-logo">Maple</span></div>
+        <div class="mp-value" style="font-size:23px;">$2,148</div>
+        <div class="mp-row"><span class="cat">Groceries</span><div class="track"><div style="width:80%"></div></div><span class="amt"><b>$642</b> of $800</span></div>
+        <div class="mp-row over"><span class="cat">Dining</span><div class="track"><div style="width:100%"></div></div><span class="amt"><b>$415</b> of $350</span></div>
+        <div class="mp-row"><span class="cat">Transport</span><div class="track"><div style="width:60%"></div></div><span class="amt"><b>$238</b> of $400</span></div>
+        <div class="mp-row"><span class="cat">Subscriptions</span><div class="track"><div style="width:95%"></div></div><span class="amt"><b>$189</b> of $200</span></div>
+      </div>`,
+    diff: {
+      file: "SpendingBreakdown.tsx",
+      lines: [
+        ["hunk", "@@ -18,8 +18,10 @@ export function SpendingBreakdown({ categories }) {"],
+        ["ctx", "  {categories.map((cat) => ("],
+        ["del", "    <CategoryRow key={cat.id} name={cat.name}"],
+        ["del", "      spent={cat.spent} share={cat.spent / total} />"],
+        ["add", "    <CategoryRow key={cat.id} name={cat.name}"],
+        ["add", "      spent={cat.spent} cap={budgets[cat.id]}"],
+        ["add", "      share={cat.spent / budgets[cat.id]}"],
+        ["add", "      tone={cat.spent > budgets[cat.id] ? \"over\" : \"ok\"} />"],
+        ["ctx", "  ))}"],
+        ["ctx", "</Card>"],
+      ],
+    },
+  },
+  {
+    id: "rmx_lena_tp",
+    component: "TransferPanel",
+    page: "/transfers",
+    requester: "Lena Fischer",
+    email: "lena.fischer@posteo.de",
+    age: "5h ago",
+    submitted: "Today, 4:03 AM",
+    hash: "d05e3ba",
+    resub: null,
+    changesSince: null,
+    summary: "Adds a “recent recipients” quick-pick row above the recipient field.",
+    original: `
+      <div class="mp-card">
+        <div class="mp-head"><span class="mp-label">Transfer money</span><span class="mp-logo">Maple</span></div>
+        <div class="mp-field">
+          <span class="mp-field-label">From</span>
+          <div class="mp-select"><span>Everyday Checking ··4821</span><span class="chev">▾</span></div>
+          <div class="mp-avail">Available balance <b>$4,210.55</b></div>
+        </div>
+        <div class="mp-field">
+          <span class="mp-field-label">To</span>
+          <div class="mp-select"><span>Choose a recipient</span><span class="chev">▾</span></div>
+        </div>
+        <div class="mp-amount"><span class="cur">$</span><span class="amt">0.00</span></div>
+        <button class="mp-btn" tabindex="-1">Review transfer</button>
+      </div>`,
+    remix: `
+      <div class="mp-card">
+        <div class="mp-head"><span class="mp-label">Transfer money</span><span class="mp-logo">Maple</span></div>
+        <div class="mp-field">
+          <span class="mp-field-label">From</span>
+          <div class="mp-select"><span>Everyday Checking ··4821</span><span class="chev">▾</span></div>
+          <div class="mp-avail">Available balance <b>$4,210.55</b></div>
+        </div>
+        <div class="mp-field">
+          <span class="mp-field-label">Recent</span>
+          <div class="mp-recents">
+            <div class="mp-recent"><span class="face">JM</span>Jonas</div>
+            <div class="mp-recent"><span class="face">AK</span>Anna</div>
+            <div class="mp-recent"><span class="face">RB</span>Rent</div>
+            <div class="mp-recent"><span class="face">SF</span>Sofia</div>
+          </div>
+        </div>
+        <div class="mp-field">
+          <span class="mp-field-label">To</span>
+          <div class="mp-select"><span>Choose a recipient</span><span class="chev">▾</span></div>
+        </div>
+        <div class="mp-amount"><span class="cur">$</span><span class="amt">0.00</span></div>
+        <button class="mp-btn" tabindex="-1">Review transfer</button>
+      </div>`,
+    diff: {
+      file: "TransferPanel.tsx",
+      lines: [
+        ["hunk", "@@ -27,6 +27,11 @@ export function TransferPanel({ account }) {"],
+        ["ctx", "  </Field>"],
+        ["add", "  <Field label=\"Recent\">"],
+        ["add", "    <RecipientChips"],
+        ["add", "      items={recentRecipients.slice(0, 4)}"],
+        ["add", "      onPick={setRecipient}"],
+        ["add", "    />"],
+        ["add", "  </Field>"],
+        ["ctx", "  <Field label=\"To\">"],
+        ["ctx", "    <RecipientPicker />"],
+        ["ctx", "  </Field>"],
+      ],
+    },
+  },
+  {
+    id: "rmx_tom_nw",
+    component: "NetWorthCard",
+    page: "/dashboard",
+    requester: "Tom Alvarez",
+    email: "t.alvarez88@icloud.com",
+    age: "1d ago",
+    submitted: "Yesterday, 3:27 PM",
+    hash: "5a6b8d1",
+    resub: null,
+    changesSince: null,
+    summary: "Compact variant: drops the chart in favor of a per-account breakdown.",
+    original: `
+      <div class="mp-card">
+        <div class="mp-head"><span class="mp-label">Net worth</span><span class="mp-logo">Maple</span></div>
+        <div class="mp-value">$128,540</div>
+        <div class="mp-delta up">▲ $2,340 this month</div>
+        <div class="mp-chart">
+          <span style="height:34%"></span><span style="height:41%"></span><span style="height:38%"></span>
+          <span style="height:52%"></span><span style="height:47%"></span><span style="height:58%"></span>
+          <span style="height:55%"></span><span style="height:66%"></span><span style="height:61%"></span>
+          <span style="height:74%"></span><span style="height:81%"></span><span class="hi" style="height:92%"></span>
+        </div>
+        <div class="mp-axis"><span>Feb</span><span>Mar</span><span>Apr</span><span>May</span><span>Jun</span><span>Jul</span></div>
+      </div>`,
+    remix: `
+      <div class="mp-card">
+        <div class="mp-head"><span class="mp-label">Net worth</span><span class="mp-logo">Maple</span></div>
+        <div class="mp-value">$128,540</div>
+        <div class="mp-delta up">▲ $2,340 this month</div>
+        <div class="mp-accounts">
+          <div class="mp-acct"><span class="n">Everyday Checking</span><span class="v">$12,480</span></div>
+          <div class="mp-acct"><span class="n">High-Yield Savings</span><span class="v">$58,900</span></div>
+          <div class="mp-acct"><span class="n">Investments</span><span class="v">$57,160</span></div>
+        </div>
+      </div>`,
+    diff: {
+      file: "NetWorthCard.tsx",
+      lines: [
+        ["hunk", "@@ -12,9 +12,8 @@ export function NetWorthCard({ netWorth, history }) {"],
+        ["ctx", "    <Amount value={netWorth} />"],
+        ["ctx", "    <MonthDelta value={monthDelta} />"],
+        ["del", '    <TrendChart data={history} color="#0E7A52" />'],
+        ["del", '    <AxisLabels range="6m" />'],
+        ["add", "    <AccountList"],
+        ["add", "      accounts={accounts}"],
+        ["add", "      sortBy=\"balance\""],
+        ["add", "    />"],
+        ["ctx", "  </Card>"],
+      ],
+    },
+  },
+];
+
+/* ==================================================================== */
+/* State + rendering                                                     */
+/* ==================================================================== */
+
+let queue = REVIEWS.slice();
+let selectedId = queue[0].id;
+let view = "preview";       // "preview" | "diff"
+let rejecting = false;
+
+const $queueList = document.getElementById("queueList");
+const $queueCount = document.getElementById("queueCount");
+const $reviewArea = document.getElementById("reviewArea");
+const $toast = document.getElementById("toast");
+
+function esc(s) {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/* Light-touch highlighting for the diff: strings + JSX tag names. */
+function highlight(code) {
+  let out = esc(code);
+  out = out.replace(/(&quot;|")((?:[^"\\]|\\.)*?)(\1)/g, '<span class="tok-str">"$2"</span>');
+  out = out.replace(/(&lt;\/?)([A-Z][A-Za-z0-9]*)/g, '$1<span class="tok-tag">$2</span>');
+  return out;
+}
+
+function renderQueue() {
+  $queueCount.textContent = queue.length;
+  if (queue.length === 0) {
+    $queueList.innerHTML = '<div class="queue-empty">No remixes waiting on you.</div>';
+    return;
+  }
+  $queueList.innerHTML = queue.map((r) => `
+    <button class="queue-item ${r.id === selectedId ? "selected" : ""}" data-id="${r.id}">
+      <div class="queue-item-top">
+        <span class="queue-item-name">${r.component}</span>
+        ${r.resub ? `<span class="badge-resub">resubmission #${r.resub}</span>` : ""}
+      </div>
+      <div class="queue-item-sub">
+        <span>${r.requester}</span><span class="dot">·</span><span>${r.age}</span>
+      </div>
+    </button>
+  `).join("");
+
+  $queueList.querySelectorAll(".queue-item").forEach((el) => {
+    el.addEventListener("click", () => selectReview(el.dataset.id));
+  });
+}
+
+function renderReview() {
+  const r = queue.find((x) => x.id === selectedId);
+
+  if (!r) {
+    $reviewArea.innerHTML = `
+      <div class="empty-state">
+        <div class="glyph">✓</div>
+        <h2>Queue clear</h2>
+        <p>No remixes are waiting for review. New submissions from Maple users will appear here.</p>
+      </div>`;
+    return;
+  }
+
+  const comparison = view === "preview"
+    ? `
+      <div class="panes">
+        <div class="pane">
+          <div class="pane-label"><span class="pip orig"></span>Original</div>
+          <div class="pane-stage">${r.original}</div>
+        </div>
+        <div class="pane">
+          <div class="pane-label remix-label"><span class="pip remix"></span>Their remix</div>
+          <div class="pane-stage remix-stage">${r.remix}</div>
+        </div>
+      </div>`
+    : `
+      <div class="diff">
+        <div class="diff-file">${r.component} — remix ${r.hash} vs. original — <code>${r.diff.file}</code></div>
+        <pre>${r.diff.lines.map(([t, s]) =>
+          `<span class="ln ${t}">${t === "hunk" ? esc(s) : highlight(s)}</span>`
+        ).join("")}</pre>
+      </div>`;
+
+  $reviewArea.innerHTML = `
+    <div class="review-head">
+      <div>
+        <div class="review-title">
+          <code>${r.component}</code>
+          ${r.resub ? `<span class="badge-resub">resubmission #${r.resub}</span>` : ""}
+        </div>
+        <div class="review-sub">${r.summary}</div>
+      </div>
+    </div>
+
+    <div class="meta-strip">
+      <div class="meta-item">
+        <div class="meta-label">Requested by</div>
+        <div class="meta-value">${r.requester} <span class="sub">· ${r.email}</span></div>
+      </div>
+      <div class="meta-item">
+        <div class="meta-label">Component</div>
+        <div class="meta-value"><code>${r.component}</code></div>
+      </div>
+      <div class="meta-item">
+        <div class="meta-label">Lives on</div>
+        <div class="meta-value"><code>${r.page}</code></div>
+      </div>
+      <div class="meta-item">
+        <div class="meta-label">Submitted</div>
+        <div class="meta-value">${r.submitted} <span class="sub">· ${r.age}</span></div>
+      </div>
+      <div class="meta-item">
+        <div class="meta-label">Version</div>
+        <div class="meta-value"><code>${r.hash}</code></div>
+      </div>
+    </div>
+
+    ${r.changesSince ? `
+      <div class="changes-hint">
+        <span>↺</span>
+        <span><b>Changes since last review:</b> ${r.changesSince}</span>
+      </div>` : ""}
+
+    <div class="compare-card">
+      <div class="compare-toolbar">
+        <div class="compare-toolbar-label">Rendered against live Maple data (sandboxed)</div>
+        <div class="seg" role="tablist" aria-label="Comparison view">
+          <button id="viewPreview" class="${view === "preview" ? "active" : ""}" role="tab" aria-selected="${view === "preview"}">Preview</button>
+          <button id="viewDiff" class="${view === "diff" ? "active" : ""}" role="tab" aria-selected="${view === "diff"}">View diff</button>
+        </div>
+      </div>
+
+      <div class="compare-body">${comparison}</div>
+
+      <div class="actions">
+        <div class="actions-note">Approving publishes version <b>${r.hash}</b> to ${r.requester.split(" ")[0]} only — no one else sees it.</div>
+        <div class="actions-buttons">
+          <button class="btn btn-secondary" id="rejectBtn">Reject…</button>
+          <button class="btn btn-primary" id="approveBtn">Approve remix</button>
+        </div>
+      </div>
+
+      <div class="reject-panel ${rejecting ? "open" : ""}" id="rejectPanel">
+        <div class="reject-panel-title">Reject this remix</div>
+        <div class="reject-panel-sub">Your note goes back to ${r.requester.split(" ")[0]} with the rejection. Required.</div>
+        <textarea id="rejectNote" placeholder="e.g. This relabels the available balance in a way that could mislead — please keep the original label and number."></textarea>
+        <div class="reject-panel-actions">
+          <button class="btn btn-danger" id="rejectSend" disabled>Reject &amp; send note</button>
+          <button class="btn-ghost" id="rejectCancel">Cancel</button>
+        </div>
+      </div>
+    </div>
+  `;
+
+  document.getElementById("viewPreview").addEventListener("click", () => setView("preview"));
+  document.getElementById("viewDiff").addEventListener("click", () => setView("diff"));
+  document.getElementById("approveBtn").addEventListener("click", () => approve(r));
+  document.getElementById("rejectBtn").addEventListener("click", () => { rejecting = true; renderReview(); document.getElementById("rejectNote").focus(); });
+  document.getElementById("rejectCancel").addEventListener("click", () => { rejecting = false; renderReview(); });
+
+  const $note = document.getElementById("rejectNote");
+  const $send = document.getElementById("rejectSend");
+  $note.addEventListener("input", () => { $send.disabled = $note.value.trim().length === 0; });
+  $send.addEventListener("click", () => reject(r, $note.value.trim()));
+}
+
+function selectReview(id) {
+  selectedId = id;
+  view = "preview";
+  rejecting = false;
+  renderQueue();
+  renderReview();
+}
+
+function setView(v) {
+  view = v;
+  renderReview();
+}
+
+function advanceFrom(id) {
+  const idx = queue.findIndex((x) => x.id === id);
+  queue = queue.filter((x) => x.id !== id);
+  const next = queue[Math.min(idx, queue.length - 1)];
+  selectedId = next ? next.id : null;
+  view = "preview";
+  rejecting = false;
+  renderQueue();
+  renderReview();
+}
+
+function approve(r) {
+  advanceFrom(r.id);
+  showToast(`<span class="tick">✓</span> ${r.component} <b style="font-family:var(--mono);font-weight:500;">${r.hash}</b>&nbsp;approved — now live for ${r.requester.split(" ")[0]}`);
+}
+
+function reject(r, note) {
+  advanceFrom(r.id);
+  showToast(`<span class="cross">✕</span> ${r.component} rejected — your note was sent to ${r.requester.split(" ")[0]}`);
+}
+
+let toastTimer = null;
+function showToast(html) {
+  $toast.innerHTML = html;
+  $toast.classList.add("show");
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => $toast.classList.remove("show"), 3400);
+}
+
+renderQueue();
+renderReview();
+</script>
+</body>
+</html>


### PR DESCRIPTION
The remix end-state design decided with Yousef 2026-08-02, its executor plan, and the approved clickable mockup of the console review screen.

Docs only — the build waves (W0–W4) execute against these on their own PRs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs that lock in the final Remix design, the executor plan, and the approved review-console mockup. Defines `Remixable` as the registration surface, splits pins vs placements, and sets a simple host review policy.

- **New Features**
  - One concept: remix always means a fork of the real component; no graded fidelity.
  - API: `<Remixable review?>{child}</Remixable>` — wrapper drives sync and in-place fork mount (jailed until approved).
  - Data: live serializable props flow into the fork; anything extra binds via the host API; callbacks/context don’t cross the jail.
  - Model: split `pins` (provenance) from `placements` (where it shows); drift, rebase, and slot discovery each read the right field.
  - Review: instant vs reviewed components; reviewed remixes render native only after ship-diff approval; edits re-review; hash-pinned approvals enforce venue.
  - Console: adds the approved review screen mockup (preview side-by-side + code diff + approve/reject with note).
  - Sharing: apps with forks can be shared only when the current version is approved (rides wave‑3 grants).
  - Dedupe: `POST /apps/fork-pin { slot, props? }` returns an existing app per (user, slot) instead of minting duplicates.

- **Migration**
  - Replace the catalog `remixable: true`, `VendoSlot.remix`, and runtime capture with the `Remixable` wrapper; `VendoSlot` goes back to app mounting only.
  - Wrapped child must be one statically importable component; inline JSX is a loud sync-time error.
  - Readers classify legacy `pins`: unknown `base` → placement; rows normalize on next write; no script needed.
  - Execution happens in waves W0–W4 per the plan; this PR is docs only.

<sup>Written for commit 0efe85b5707830aeba4cdcbb684e8bef84a6c963. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

