### PR TITLE
remix W0: pins/placements split + idempotent fork

### DIFF
--- a/examples/demo-bank/.vendo/remixable/home-hero.json
+++ b/examples/demo-bank/.vendo/remixable/home-hero.json
@@ -1,7 +1,0 @@
-{
-  "slot": "home-hero",
-  "source": "\"use client\";\n\nimport { VendoSlot } from \"@vendoai/ui/chrome\";\nimport { VendoRoot } from \"@/components/vendo/VendoRoot\";\n\n/**\n * The Home hero slot — a REAL VendoSlot with the stable id \"home-hero\".\n * It self-discovers whatever app the user pinned (the thread embed's\n * \"Pin to dashboard\" affordance records the pin server-side; the slot's\n * own polling picks it up). Empty, it renders the ghost invitation with\n * Maple-flavored prompts that prefill the Ask Maple composer.\n */\nexport function VendoCard() {\n  return (\n    <section aria-label=\"Custom view\" className=\"h-full\">\n      <VendoRoot>\n        <VendoSlot\n          id=\"home-hero\"\n          emptyState={{\n            title: \"This space builds itself\",\n            subtitle: \"ask Maple for a view — it renders here, live on your data\",\n            suggestions: [\n              \"Build my money HQ\",\n              \"Show my spending by category\",\n              \"Track my savings goals\",\n            ],\n          }}\n        />\n      </VendoRoot>\n    </section>\n  );\n}\n",
-  "hash": "sha256:7ad7026ac3e6585378d1cdac2b38f0b475148a669e308348026399c2b6cf8150",
-  "exportable": true,
-  "capturedAt": "2026-07-23T09:49:03.059Z"
-}

--- a/examples/demo-bank/.vendo/tools.json
+++ b/examples/demo-bank/.vendo/tools.json
@@ -134,7 +134,7 @@
         "argsIn": "body"
       },
       "note": "input schema partially interpreted; permissive where unknown (appId: unsupported type (unknown); slot: unsupported type (unknown))",
-      "srcHash": "sha256:4f322ddb9ec89d6b19c83d22f3783e7748120e3fdfc589030f9c63a8ea2ee967"
+      "srcHash": "sha256:3396acc44548ff2d621f3101ad7a9e601e96a3b1b1e5ee2cd6c097a6193a4eea"
     },
     {
       "name": "host_demo_reset_create",

--- a/examples/demo-bank/src/app/api/demo/pin/route.ts
+++ b/examples/demo-bank/src/app/api/demo/pin/route.ts
@@ -1,20 +1,21 @@
 /**
- * POST /api/demo/pin — record a pin on an app the caller owns, landing it in a
- * host slot. This is Maple's implementation of the thread embed's onPin seam:
- * the pin is written onto the REAL app row (`doc.pins`), which is exactly
- * what VendoSlot's self-discovery (useSlotApp) reads — so the pinned app
- * appears in the "home-hero" slot and persists across navigation and reloads.
+ * POST /api/demo/pin — record a placement on an app the caller owns, landing
+ * it in a host slot. This is Maple's implementation of the thread embed's
+ * onPin seam: the placement is written onto the REAL app row
+ * (`doc.placements`), which is exactly what VendoSlot's self-discovery
+ * (useSlotApp) reads — so the app appears in the "home-hero" slot and
+ * persists across navigation and reloads. A placement is a slot NAME only
+ * (2026-08-02 pins/placements split); `doc.pins` records fork provenance and
+ * is never written here.
  */
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
-import { canonicalJson, sha256Hex, type AppDocument } from "@vendoai/core";
+import type { AppDocument } from "@vendoai/core";
 import { badRequest, notFound, ok } from "@/server/http";
 import { resolveMapleSession } from "@/vendo/auth";
 import { vendo } from "@/vendo/server";
 
 /** The reserved vendo_apps record payload (02-store §2). Access rides the
- *  PUBLIC records door so the pin write behaves identically on the local
- *  PGlite store and the Cloud hosted store. */
+ *  PUBLIC records door so the placement write behaves identically on the
+ *  local PGlite store and the Cloud hosted store. */
 interface AppData {
   subject: string;
   enabled: boolean;
@@ -45,25 +46,6 @@ async function listSubjectApps(subject: string): Promise<AppRecord[]> {
   return rows;
 }
 
-/** Pin.base must be a "sha256:" hash (01-core §9), and detectPinDrift keeps a
- *  pin quiet only while it matches the slot's captured baseline hash — so the
- *  pin records the CURRENT `.vendo/remixable/<slot>.json` hash, exactly like
- *  the runtime's own fork-pin path. Fallback (baseline missing): the app's
- *  content hash — still a valid pin, but the slot shows a drift notice. */
-async function pinBase(slot: string, doc: AppDocument): Promise<string> {
-  try {
-    const raw = await readFile(join(process.cwd(), ".vendo", "remixable", `${slot}.json`), "utf8");
-    const baseline = JSON.parse(raw) as { hash?: unknown };
-    if (typeof baseline.hash === "string" && baseline.hash.startsWith("sha256:")) return baseline.hash;
-  } catch {
-    // fall through to the content hash
-  }
-  const content: Partial<AppDocument> = structuredClone(doc);
-  delete content.id;
-  delete content.forkedFrom;
-  return `sha256:${sha256Hex(canonicalJson(content))}`;
-}
-
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
@@ -86,23 +68,21 @@ export async function POST(request: Request) {
   const row = appRecord(await apps.get(appId));
   if (row === null || row.data.subject !== user.subject) return notFound("App not found.");
 
-  // Latest pin wins per slot (useSlotApp takes the newest pinned app); clear
-  // the slot from any OTHER app this user pinned earlier so the swap is clean.
+  // Latest placement wins per slot (useSlotApp takes the newest placed app);
+  // clear the slot from any OTHER app this user placed earlier so the swap is
+  // clean.
   for (const other of await listSubjectApps(user.subject)) {
-    if (other.id === appId || !other.data.doc.pins?.some((pin) => pin.slot === slot)) continue;
+    if (other.id === appId || !other.data.doc.placements?.includes(slot)) continue;
     await apps.put({
       id: other.id,
       data: {
         ...other.data,
-        doc: { ...other.data.doc, pins: other.data.doc.pins.filter((pin) => pin.slot !== slot) },
+        doc: { ...other.data.doc, placements: other.data.doc.placements.filter((name) => name !== slot) },
       },
     });
   }
 
-  const pins = [
-    ...(row.data.doc.pins ?? []).filter((pin) => pin.slot !== slot),
-    { slot, base: await pinBase(slot, row.data.doc) },
-  ];
-  await apps.put({ id: appId, data: { ...row.data, doc: { ...row.data.doc, pins } } });
+  const placements = [...(row.data.doc.placements ?? []).filter((name) => name !== slot), slot];
+  await apps.put({ id: appId, data: { ...row.data, doc: { ...row.data.doc, placements } } });
   return ok({ pinned: true, appId, slot });
 }

--- a/examples/demo-bank/src/vendo/demo-pin-route.test.ts
+++ b/examples/demo-bank/src/vendo/demo-pin-route.test.ts
@@ -1,0 +1,62 @@
+// POST /api/demo/pin after the 2026-08-02 pins/placements split: the route
+// writes the slot NAME into doc.placements — no fabricated base hash, no
+// doc.pins write. The fake-hash synthesis (and the orphan home-hero.json
+// baseline it read) is deleted.
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { rows, subject } = vi.hoisted(() => ({
+  rows: new Map<string, { id: string; data: { subject: string; enabled: boolean; doc: Record<string, unknown> } }>(),
+  subject: "maple_user",
+}))
+
+vi.mock("@/vendo/auth", () => ({ resolveMapleSession: vi.fn(async () => ({ subject })) }))
+vi.mock("@/vendo/server", () => ({
+  vendo: {
+    store: {
+      records: () => ({
+        get: async (id: string) => rows.get(id) ?? null,
+        list: async () => ({ records: [...rows.values()] }),
+        put: async (row: { id: string; data: { subject: string; enabled: boolean; doc: Record<string, unknown> } }) => {
+          rows.set(row.id, structuredClone(row))
+        },
+      }),
+    },
+  },
+}))
+
+import { POST } from "@/app/api/demo/pin/route"
+
+const seed = (id: string, doc: Record<string, unknown> = {}) =>
+  rows.set(id, { id, data: { subject, enabled: false, doc: { id, ...doc } } })
+
+const post = (appId: string, slot = "home-hero") =>
+  POST(new Request("http://maple/api/demo/pin", { method: "POST", body: JSON.stringify({ appId, slot }) }))
+
+beforeEach(() => rows.clear())
+
+describe("POST /api/demo/pin", () => {
+  it("writes the slot into doc.placements with no base hash anywhere", async () => {
+    seed("app_1")
+    const res = await post("app_1")
+    expect(res.status).toBe(200)
+    const stored = rows.get("app_1")!.data.doc
+    expect(stored.placements).toEqual(["home-hero"])
+    expect(stored.pins).toBeUndefined()
+    expect(JSON.stringify(stored)).not.toContain("sha256:")
+    expect(JSON.stringify(stored)).not.toContain("base")
+  })
+
+  it("moves the slot between apps — latest placement wins, the old app is cleared", async () => {
+    seed("app_1", { placements: ["home-hero"] })
+    seed("app_2")
+    await post("app_2")
+    expect(rows.get("app_1")!.data.doc.placements).toEqual([])
+    expect(rows.get("app_2")!.data.doc.placements).toEqual(["home-hero"])
+  })
+
+  it("re-placing the same app keeps a single entry", async () => {
+    seed("app_1", { placements: ["home-hero"] })
+    await post("app_1")
+    expect(rows.get("app_1")!.data.doc.placements).toEqual(["home-hero"])
+  })
+})

--- a/packages/apps/src/fork-pin.test.ts
+++ b/packages/apps/src/fork-pin.test.ts
@@ -245,3 +245,41 @@ describe("06-apps §8 — gesture-owned deterministic fork (pins.fork)", () => {
     expect(rebase.app.components?.[COMPONENT]).toContain("/* v2 */");
   });
 });
+
+// Remix final shape (2026-08-02) — the appId-less gesture is idempotent per
+// (subject, slot): the server dedupes, so a double-tap can never mint a
+// duplicate app and the UI latch is cosmetic.
+describe("06-apps §8 — fork idempotency (appId-less dedupe)", () => {
+  it("returns the existing app on a second gesture instead of minting a duplicate", async () => {
+    const store = memoryStore();
+    const runtime = runtimeWith(store);
+
+    const first = await runtime.pins.fork({ slot: SLOT }, ctx);
+    // The empty-slot mint records the placement slot discovery mounts by.
+    expect(first.app.placements).toEqual([SLOT]);
+    const second = await runtime.pins.fork({ slot: SLOT }, ctx);
+    expect(second.app.id).toBe(first.app.id);
+    expect(second.app).toEqual(first.app);
+    expect(second.slot).toBe(SLOT);
+    expect(second.componentName).toBe(COMPONENT);
+    // The result still describes the recorded deterministic fork.
+    expect(second.version.intent).toBe(`Remix the host component "${SLOT}"`);
+
+    // One app row, not two.
+    const listed = await runtime.list(ctx);
+    expect(listed.filter(({ pins }) => pins?.some((pin) => pin.slot === SLOT))).toHaveLength(1);
+  });
+
+  it("drops a riding instruction on the dedupe hit — no edit, no model call", async () => {
+    const store = memoryStore();
+    // No model configured: an edit attempt on the dedupe path would surface
+    // as a failure-shaped edit, so an undefined `edit` proves none ran.
+    const runtime = runtimeWith(store);
+
+    const first = await runtime.pins.fork({ slot: SLOT }, ctx);
+    const second = await runtime.pins.fork({ slot: SLOT, instruction: "Make it green" }, ctx);
+    expect(second.app.id).toBe(first.app.id);
+    expect(second.edit).toBeUndefined();
+    expect(second.app).toEqual(first.app);
+  });
+});

--- a/packages/apps/src/pins.ts
+++ b/packages/apps/src/pins.ts
@@ -277,6 +277,43 @@ export const detectPinDrift = (
 });
 
 /**
+ * Remix final shape (2026-08-02) — pins/placements split. Before the split one
+ * array stored two unrelated facts, so slot-landing paths fabricated `Pin.base`
+ * hashes and raised false drift warnings. There is no migration script: the
+ * runtime classifies stored rows on read (and the classified document
+ * normalizes the row on its next write). A `pins` entry whose `base` matches
+ * no captured baseline hash is a placement — with two fail-closed carve-outs
+ * that stay pins, surfaced by drift and the export gate instead of guessed
+ * away: an entry whose SLOT still names a captured baseline (a real, possibly
+ * drifted fork drift detection and rebase must keep seeing), and an entry
+ * whose forked component source is still on the document (provenance whose
+ * baseline disappeared — reclassifying it would launder captured host source
+ * past assertPinsExportable). With no baselines captured at all there is no
+ * signal to classify against, so the document passes through untouched.
+ */
+export const classifyLegacyPlacements = (
+  doc: AppDocument,
+  baselines: readonly PinBaseline[] | undefined,
+): AppDocument => {
+  if (baselines === undefined || baselines.length === 0 || doc.pins === undefined || doc.pins.length === 0) return doc;
+  const slots = new Set(baselines.map(({ slot }) => slot));
+  const hashes = new Set(baselines.map(({ hash }) => hash));
+  const isPlacement = (pin: Pin): boolean => !slots.has(pin.slot)
+    && !hashes.has(pin.base)
+    && doc.components?.[pinComponentName(pin.slot)] === undefined;
+  const legacy = doc.pins.filter(isPlacement);
+  if (legacy.length === 0) return doc;
+  const pins = doc.pins.filter((pin) => !isPlacement(pin));
+  const classified: AppDocument = {
+    ...doc,
+    placements: [...new Set([...(doc.placements ?? []), ...legacy.map(({ slot }) => slot)])],
+  };
+  if (pins.length === 0) delete classified.pins;
+  else classified.pins = pins;
+  return classified;
+};
+
+/**
  * 06-apps §7–§8 — require explicit host permission for every exported pin.
  * Missing baselines fail closed because an artifact export must never strip pins.
  */

--- a/packages/apps/src/placements.test.ts
+++ b/packages/apps/src/placements.test.ts
@@ -1,0 +1,154 @@
+// Remix final shape (2026-08-02) — pins/placements split. `pins` records fork
+// provenance ONLY (drift, ship-diff, rebase); `placements` records "show this
+// app in that slot" and feeds slot discovery ONLY. Stored legacy rows (the
+// demo hosts' fake-hash pin workaround) classify on read and normalize on the
+// next write; drift and ship-diff never see them.
+import type { AppDocument, RunContext, StoreAdapter, ToolRegistry } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createApps, type PinBaseline } from "./index.js";
+import { classifyLegacyPlacements, pinComponentName } from "./pins.js";
+import { guardFixture, memoryStore, seedAppRow } from "./testing/index.js";
+
+const ctx: RunContext = {
+  principal: { kind: "user", subject: "user_placements" },
+  venue: "app",
+  presence: "present",
+  sessionId: "session_placements",
+};
+
+const tools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "error", error: { code: "not-found", message: "missing" } }; },
+};
+
+const SLOT = "net-worth-card";
+const SOURCE = `export default function NetWorthCard() {
+  return <strong>$1.2M</strong>;
+}`;
+
+const baseline: PinBaseline = {
+  slot: SLOT,
+  source: SOURCE,
+  hash: "sha256:maple-base",
+  exportable: false,
+  capturedAt: "2026-07-14T12:00:00.000Z",
+};
+
+/** The pre-split demo workaround: a slot landing stored as a pin whose `base`
+ *  is a fabricated content hash matching no captured baseline. */
+const LEGACY_ROW = { slot: "home-hero", base: "sha256:fake-content-hash" };
+
+const seedDoc = (id: string, overrides: Partial<AppDocument> = {}): AppDocument => ({
+  format: "vendo/app@1",
+  id,
+  name: "Legacy remix",
+  ui: "tree",
+  tree: {
+    formatVersion: "vendo-genui/v2",
+    root: "root",
+    nodes: [{ id: "root", component: "Stack", source: "prewired" }],
+  },
+  ...overrides,
+});
+
+const runtimeWith = (store: StoreAdapter) => createApps({
+  store,
+  guard: guardFixture(),
+  tools,
+  catalog: [],
+  pinBaselines: [baseline],
+});
+
+describe("pins/placements split — legacy-row classification", () => {
+  it("classifies a fake-hash entry as a placement and keeps real and drifted pins", () => {
+    const classified = classifyLegacyPlacements(
+      seedDoc("app_classify", { pins: [LEGACY_ROW, { slot: SLOT, base: "sha256:maple-base" }] }),
+      [baseline],
+    );
+    expect(classified.pins).toEqual([{ slot: SLOT, base: "sha256:maple-base" }]);
+    expect(classified.placements).toEqual(["home-hero"]);
+
+    // A drifted fork (captured slot, superseded hash) is provenance the drift
+    // and rebase surfaces must keep seeing — never a placement.
+    const drifted = classifyLegacyPlacements(
+      seedDoc("app_drifted", { pins: [{ slot: SLOT, base: "sha256:maple-old" }] }),
+      [baseline],
+    );
+    expect(drifted.pins).toEqual([{ slot: SLOT, base: "sha256:maple-old" }]);
+    expect(drifted.placements).toBeUndefined();
+
+    // No baselines captured (unset or empty) — no signal to classify against;
+    // fail closed and pass the document through untouched.
+    const untouched = seedDoc("app_untouched", { pins: [LEGACY_ROW] });
+    expect(classifyLegacyPlacements(untouched, undefined)).toBe(untouched);
+    expect(classifyLegacyPlacements(untouched, [])).toBe(untouched);
+
+    // An entry still carrying its forked component is provenance whose
+    // baseline disappeared — never a placement, or captured host source would
+    // launder past the export gate (assertPinsExportable fail-closed rule).
+    const orphanedFork = seedDoc("app_orphaned", {
+      pins: [{ slot: "gone-slot", base: "sha256:gone-base" }],
+      components: { [pinComponentName("gone-slot")]: SOURCE },
+    });
+    expect(classifyLegacyPlacements(orphanedFork, [baseline])).toBe(orphanedFork);
+  });
+
+  it("reads a stored legacy row as a placement: slot discovery mounts it, drift stays quiet", async () => {
+    const store = memoryStore();
+    await seedAppRow(store, seedDoc("app_legacy", { pins: [LEGACY_ROW] }), ctx.principal.subject);
+    const runtime = runtimeWith(store);
+
+    // list() is what useSlotApp reads: the slot arrives in `placements`, and
+    // `pins` no longer carries the fake-hash row (pins never place an app).
+    const listed = await runtime.list(ctx);
+    expect(listed.map(({ id }) => id)).toEqual(["app_legacy"]);
+    expect(listed[0]?.placements).toEqual(["home-hero"]);
+    expect(listed[0]?.pins).toBeUndefined();
+
+    // The false drift warning the fake hash used to raise is gone.
+    await expect(runtime.pins.drift("app_legacy", ctx)).resolves.toEqual([]);
+  });
+
+  it("normalizes the row on its next write: placements persist, the fake-hash pin does not", async () => {
+    const store = memoryStore();
+    await seedAppRow(store, seedDoc("app_norm", { pins: [LEGACY_ROW] }), ctx.principal.subject);
+    const runtime = runtimeWith(store);
+
+    // Any ordinary recorded write (here the deterministic gesture fork, which
+    // also proves the edit path's concurrency check reads legacy rows
+    // classified) persists the classified document.
+    await runtime.pins.fork({ appId: "app_norm", slot: SLOT }, ctx);
+    const stored = (await store.records("vendo_apps").get("app_norm"))?.data as { doc: AppDocument };
+    expect(stored.doc.placements).toEqual(["home-hero"]);
+    expect(stored.doc.pins).toEqual([{ slot: SLOT, base: "sha256:maple-base" }]);
+  });
+
+  it("keeps reporting real drift beside a classified placement", async () => {
+    const store = memoryStore();
+    await seedAppRow(
+      store,
+      seedDoc("app_drift", { pins: [LEGACY_ROW, { slot: SLOT, base: "sha256:maple-old" }] }),
+      ctx.principal.subject,
+    );
+    const runtime = runtimeWith(store);
+    await expect(runtime.pins.drift("app_drift", ctx)).resolves.toEqual([{
+      slot: SLOT,
+      component: pinComponentName(SLOT),
+      baseHash: "sha256:maple-old",
+      baselineHash: "sha256:maple-base",
+      reason: "baseline-changed",
+    }]);
+  });
+
+  it("ship-diff reviews fork provenance only — placements never enter the diff", async () => {
+    const store = memoryStore();
+    await seedAppRow(
+      store,
+      seedDoc("app_ship", { pins: [LEGACY_ROW, { slot: SLOT, base: "sha256:maple-base" }] }),
+      ctx.principal.subject,
+    );
+    const runtime = runtimeWith(store);
+    const diff = await runtime.inClient.shipDiff("app_ship", ctx);
+    expect(diff.pins.map(({ slot }) => slot)).toEqual([SLOT]);
+  });
+});

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -77,7 +77,7 @@ import { parseVendoManifest } from "./manifest.js";
 import { isDisclaimerOnlyTree } from "./pipeline.js";
 import { createAppOpener, createProgressiveQueryResolver, machinesDisabledError, servedAppsDisabledError, stripServerAuthoritativeFields } from "./open.js";
 import { appRecordInput, documentFromRecord, enabledAfterDocumentEdit, listAllRecords, nextEnvStaleAt, rowFromRecord, updateAppRow } from "./persistence.js";
-import { detectPinDrift, hasDefaultExport, pinComponentName, pinForkSource, type InClientApproval, type PinBaseline, type PinDrift } from "./pins.js";
+import { classifyLegacyPlacements, detectPinDrift, hasDefaultExport, pinComponentName, pinForkSource, type InClientApproval, type PinBaseline, type PinDrift } from "./pins.js";
 import { collectSecretValues, redactSecretJson, redactSecretText } from "./redaction.js";
 import {
   boxAllowlist,
@@ -828,10 +828,14 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     allowedDomains: (doc) => boxAllowlist(doc, implicitEgress),
   });
 
+  // Pins/placements split (2026-08-02) — every runtime read classifies legacy
+  // rows (classifyLegacyPlacements), so drift, ship-diff, export, and the wire
+  // all see fork provenance in `pins` and slot placement in `placements`; the
+  // next persistEdit writes the classified document, normalizing the row.
   const owned = async (appId: AppId, subject: string): Promise<AppDocument | null> => {
     const record = await apps.get(appId);
     if (record === null || record.refs?.subject !== subject) return null;
-    return documentFromRecord(record);
+    return classifyLegacyPlacements(documentFromRecord(record), config.pinBaselines);
   };
 
   const requireOwned = async (appId: AppId, subject: string): Promise<AppDocument> => {
@@ -1176,9 +1180,12 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     const assertCurrent = async (): Promise<boolean> => {
       const current = await apps.get(previous.id);
       const row = current === null ? null : rowFromRecord(current);
+      // `previous` came through a classifying read (owned), so the stored row
+      // classifies the same way before comparing — otherwise every edit of a
+      // not-yet-normalized legacy row would read as a concurrent change.
       if (row === null
         || row.subject !== subject
-        || JSON.stringify(row.doc) !== JSON.stringify(previous)) {
+        || JSON.stringify(classifyLegacyPlacements(row.doc, config.pinBaselines)) !== JSON.stringify(previous)) {
         throw new VendoError("conflict", `app changed during edit: ${previous.id}`);
       }
       return row.enabled;
@@ -2020,7 +2027,7 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       for (const record of records
         .sort((left, right) => right.createdAt.localeCompare(left.createdAt) || right.id.localeCompare(left.id))) {
         try {
-          const document = documentFromRecord(record);
+          const document = classifyLegacyPlacements(documentFromRecord(record), config.pinBaselines);
           // A terminally failed build is a tombstone open() reads to resolve
           // the embed — not a real app; it never joins the listable surface.
           if (document.buildFailed !== undefined) continue;
@@ -2291,6 +2298,30 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
             throw new VendoError("conflict", "a pin fork requires a vendo-genui/v2 tree app");
           }
         } else {
+          // Idempotent per (subject, slot) — the appId-less gesture dedupes
+          // server-side: when this subject already has an app whose pins name
+          // the slot, that app IS the fork, and it is returned instead of
+          // minting a duplicate (a double-tap can never mint two; the UI
+          // latch is cosmetic). A riding instruction is dropped — the tap
+          // that created the fork already carries it, and replaying it here
+          // would apply the same edit twice.
+          const existing = (await runtime.list(ctx))
+            .find((app) => app.pins?.some((pin) => pin.slot === input.slot));
+          if (existing !== undefined) {
+            // The deterministic fork this result describes was recorded when
+            // the app was minted — intents[0] of the pin's replay trail.
+            const recorded = (await history.pinIntents(existing.id, input.slot))[0];
+            return {
+              app: existing,
+              version: {
+                at: recorded?.at ?? new Date().toISOString(),
+                intent: recorded?.intent ?? `Remix the host component "${input.slot}"`,
+                rung: rungFor(existing),
+              },
+              slot: input.slot,
+              componentName: pinComponentName(input.slot),
+            };
+          }
           // The empty-slot Remix gesture: mint the minimal base document the
           // fork lands in, so the fork itself is an ordinary recorded edit
           // (undo returns to the empty base; rebase finds a full trail).
@@ -2304,6 +2335,10 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
               root: "root",
               nodes: [{ id: "root", component: "Stack", source: "prewired" }],
             },
+            // The empty-slot gesture means "show the remix in THIS slot": the
+            // mint records the placement (location) beside the pin the fork
+            // records (provenance) — slot discovery reads placements only.
+            placements: [input.slot],
           };
           // Dry-run the fork BEFORE persisting the base, so a bad baseline
           // never strands an empty app.

--- a/packages/core/src/app-document.test.ts
+++ b/packages/core/src/app-document.test.ts
@@ -399,3 +399,23 @@ describe("validateAppDocument with vendo-genui/v2 trees", () => {
     expect(validateAppDocument(document)).toEqual({ ok: true, app: document });
   });
 });
+
+// Remix final shape (2026-08-02) — pins/placements split: `placements` is
+// "show this app in that slot" (slot discovery), `pins` stays fork provenance.
+describe("placements", () => {
+  it("round-trips placements beside pins", () => {
+    const placed = {
+      ...minimal(),
+      pins: [{ slot: "NetWorthCard", base: "sha256:abc123" }],
+      placements: ["home-hero"],
+    };
+    expect(appDocumentSchema.parse(placed)).toEqual(placed);
+    expect(validateAppDocument(placed)).toEqual({ ok: true, app: placed });
+  });
+
+  it("rejects empty placement slots", () => {
+    const result = validateAppDocument({ ...minimal(), placements: [""] });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("validation");
+  });
+});

--- a/packages/core/src/app-document.ts
+++ b/packages/core/src/app-document.ts
@@ -121,6 +121,14 @@ export interface AppDocument {
   egressApproved?: string[];
   secrets?: string[];
   pins?: Pin[];
+  /**
+   * Remix final shape (2026-08-02) — "show this app in that slot". A placement
+   * is a host-authored slot name (a `VendoSlot` id) and feeds slot discovery
+   * ONLY; `pins` records fork provenance ONLY (drift, ship-diff, rebase). The
+   * pre-split rows that fabricated `Pin.base` hashes to land an app in a slot
+   * are classified into this field on read and normalized on the next write.
+   */
+  placements?: string[];
   forkedFrom?: AppId;
   /**
    * A terminal build failure. Present only on a record the runtime persisted
@@ -156,6 +164,7 @@ export const appDocumentSchema = z.object({
   egressApproved: z.array(z.string()).optional(),
   secrets: z.array(z.string()).optional(),
   pins: z.array(pinSchema).optional(),
+  placements: z.array(z.string()).optional(),
   forkedFrom: appIdSchema.optional(),
   buildFailed: appBuildFailureSchema.optional(),
 }).passthrough() satisfies z.ZodType<AppDocument>;
@@ -300,6 +309,11 @@ const validateAppDocumentUnsafe = (input: unknown): AppDocumentValidation => {
     }
     if (!pin.base.startsWith("sha256:")) {
       return fail("validation", `pin base "${pin.base}" must start with "sha256:"`);
+    }
+  }
+  for (const placement of app.placements ?? []) {
+    if (placement.length === 0) {
+      return fail("validation", "placement slot must be non-empty");
     }
   }
 

--- a/packages/ui/src/hooks/use-slot-app.ts
+++ b/packages/ui/src/hooks/use-slot-app.ts
@@ -1,8 +1,12 @@
-/** Slot pin self-discovery (08-ui §4) — resolve "the app currently pinned to
+/** Slot self-discovery (08-ui §4) — resolve "the app currently placed in
  *  slot X" so hosts never hand-roll the poll-apps-and-filter dance. Rides the
  *  standard useResource lifecycle (SSR-safe: fetching starts in an effect),
- *  polling by default so a pin made in the conversation surface appears in the
- *  slot on its own. */
+ *  polling by default so a placement made in the conversation surface appears
+ *  in the slot on its own. Placement is `doc.placements` ONLY (2026-08-02
+ *  pins/placements split): `pins` records fork provenance and never mounts an
+ *  app in a slot. Legacy rows that stored a placement as a fake-hash pin are
+ *  classified into `placements` by the server's read path, so they arrive
+ *  here already split. */
 import type { AppDocument, AppId } from "@vendoai/core";
 import { useCallback, useEffect } from "react";
 import { useVendoContext } from "../context.js";
@@ -23,7 +27,7 @@ export function useSlotApp(slotId: string, options: PollOptions & {
    *  used by VendoSlot when the host supplies an explicit `appId`/`pin`. */
   enabled?: boolean;
 } = {}): {
-  /** The most recently pinned app for this slot, or undefined when none. */
+  /** The most recently placed app for this slot, or undefined when none. */
   appId: AppId | undefined;
   error: Error | undefined;
   isLoading: boolean;
@@ -57,8 +61,8 @@ export function useSlotApp(slotId: string, options: PollOptions & {
       for (const settle of settles) clearTimeout(settle);
     };
   }, [enabled, refresh]);
-  // Latest pin wins — matching the "the newest remix takes the slot" semantics
-  // the demos established (hero-slot took `.at(-1)`).
-  const appId = data.filter(app => app.pins?.some(pin => pin.slot === slotId)).at(-1)?.id;
+  // Latest placement wins — matching the "the newest remix takes the slot"
+  // semantics the demos established (hero-slot took `.at(-1)`).
+  const appId = data.filter(app => app.placements?.includes(slotId)).at(-1)?.id;
   return { appId, error, isLoading, refresh };
 }

--- a/packages/ui/test/chrome/app-load-retry.test.tsx
+++ b/packages/ui/test/chrome/app-load-retry.test.tsx
@@ -20,7 +20,7 @@ const pinned: AppDocument = {
     root: "root",
     nodes: [{ id: "root", component: "Text", props: { text: "Invoices app surface" } }],
   },
-  pins: [{ slot: "hero", base: "sha256:abc123" }],
+  placements: ["hero"],
 };
 
 describe("useApp load retry (Keystone graduates A5)", () => {

--- a/packages/ui/test/chrome/pin-ceremony.test.tsx
+++ b/packages/ui/test/chrome/pin-ceremony.test.tsx
@@ -181,7 +181,7 @@ const pinnedApp: AppDocument = {
     root: "root",
     nodes: [{ id: "root", component: "Text", props: { text: "Invoices app surface" } }],
   },
-  pins: [{ slot: "hero", base: "sha256:abc123" }],
+  placements: ["hero"],
 };
 
 describe("the slot refreshes on the pin, not on the next poll tick", () => {

--- a/packages/ui/test/chrome/slot-discovery.test.tsx
+++ b/packages/ui/test/chrome/slot-discovery.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
-// Shelf Task 3 — Slot pin self-discovery: the slot resolves "the app pinned to
+// Shelf Task 3 — Slot self-discovery: the slot resolves "the app placed in
 // slot X" on its own (the polling dance demo-accounting's hero-slot used to
 // hand-roll), via the useSlotApp hook over the standard useResource lifecycle.
+// Since the 2026-08-02 pins/placements split, discovery reads `placements`
+// ONLY; `pins` is fork provenance and never places an app.
 import type { AppDocument } from "@vendoai/core";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -9,7 +11,7 @@ import { VendoProvider, createVendoClient, useSlotApp, type VendoClient } from "
 import { VendoSlot } from "../../src/chrome/index.js";
 import { createWireServer } from "../wire-server.js";
 
-/** The wire server's app_1 ("Invoices"), pinned to the hero slot. Keeping the
+/** The wire server's app_1 ("Invoices"), placed in the hero slot. Keeping the
  *  id real lets the slot's mount path open it over the same wire. */
 function pinnedApp(overrides: Partial<AppDocument> = {}): AppDocument {
   return {
@@ -22,7 +24,7 @@ function pinnedApp(overrides: Partial<AppDocument> = {}): AppDocument {
       root: "root",
       nodes: [{ id: "root", component: "Text", props: { text: "Invoices app surface" } }],
     },
-    pins: [{ slot: "hero", base: "sha256:abc123" }],
+    placements: ["hero"],
     ...overrides,
   };
 }
@@ -51,19 +53,27 @@ describe("Slot pin self-discovery (useSlotApp + VendoSlot)", () => {
     vi.spyOn(client.apps, "list").mockResolvedValue([
       pinnedApp(),
       pinnedApp({ id: "app_2", name: "Newer remix" }),
-      pinnedApp({ id: "app_other", pins: [{ slot: "sidebar", base: "sha256:def456" }] }),
+      pinnedApp({ id: "app_other", placements: ["sidebar"] }),
     ]);
     render(<VendoProvider client={client}><Probe slot="hero" /></VendoProvider>);
     await waitFor(() => expect(screen.getByRole("status").textContent).toBe("app_2"));
   });
 
-  it("reports no app when nothing is pinned to the slot", async () => {
-    vi.spyOn(client.apps, "list").mockResolvedValue([pinnedApp({ pins: [] })]);
+  it("reports no app when nothing is placed in the slot", async () => {
+    vi.spyOn(client.apps, "list").mockResolvedValue([pinnedApp({ placements: [] })]);
     render(<VendoProvider client={client}><Probe slot="hero" /></VendoProvider>);
     await waitFor(() => expect(screen.getByRole("status").textContent).toBe("none"));
   });
 
-  it("keeps polling on the configured interval so a new pin appears on its own", async () => {
+  it("ignores pins — fork provenance never places an app in a slot", async () => {
+    vi.spyOn(client.apps, "list").mockResolvedValue([
+      pinnedApp({ placements: [], pins: [{ slot: "hero", base: "sha256:abc123" }] }),
+    ]);
+    render(<VendoProvider client={client}><Probe slot="hero" /></VendoProvider>);
+    await waitFor(() => expect(screen.getByRole("status").textContent).toBe("none"));
+  });
+
+  it("keeps polling on the configured interval so a new placement appears on its own", async () => {
     const list = vi.spyOn(client.apps, "list").mockResolvedValue([]);
     render(<VendoProvider client={client}><Probe slot="hero" pollMs={20} /></VendoProvider>);
     await waitFor(() => expect(screen.getByRole("status").textContent).toBe("none"));
@@ -72,7 +82,7 @@ describe("Slot pin self-discovery (useSlotApp + VendoSlot)", () => {
     expect(list.mock.calls.length).toBeGreaterThan(1);
   });
 
-  it("VendoSlot discovers its own pin when no appId/pin prop is passed", async () => {
+  it("VendoSlot discovers its own placement when no appId/pin prop is passed", async () => {
     vi.spyOn(client.apps, "list").mockResolvedValue([pinnedApp()]);
     render(
       <VendoProvider client={client}>
@@ -84,8 +94,8 @@ describe("Slot pin self-discovery (useSlotApp + VendoSlot)", () => {
     expect(await screen.findByText("Invoices app surface")).toBeTruthy();
   });
 
-  it("VendoSlot leaves children untouched when nothing is pinned", async () => {
-    vi.spyOn(client.apps, "list").mockResolvedValue([pinnedApp({ pins: [] })]);
+  it("VendoSlot leaves children untouched when nothing is placed", async () => {
+    vi.spyOn(client.apps, "list").mockResolvedValue([pinnedApp({ placements: [] })]);
     render(
       <VendoProvider client={client}>
         <VendoSlot id="hero"><span>Original hero</span></VendoSlot>

--- a/packages/ui/test/chrome/slot-remix.test.tsx
+++ b/packages/ui/test/chrome/slot-remix.test.tsx
@@ -63,7 +63,8 @@ describe("VendoSlot remix flag + overlay registry", () => {
       expect(forks.length).toBe(1);
       expect(forks[0]?.body).toEqual({ slot: "hero" });
     });
-    // The forked app mounts through slot discovery (pins carry the slot id).
+    // The forked app mounts through slot discovery (the mint records the
+    // slot as a placement; pins are fork provenance only).
     await waitFor(() => expect(screen.getByText("hero remix app surface")).toBeTruthy());
     expect(wire.requests.filter(r => r.method === "POST" && r.path === "/threads").length).toBe(0);
   });

--- a/packages/ui/test/wire-server.ts
+++ b/packages/ui/test/wire-server.ts
@@ -717,6 +717,10 @@ export async function createWireServer(options: WireServerOptions = {}) {
         const target = existingId === undefined
           ? (() => {
             const minted = app(`app_pin_${state.apps.length + 1}`, `${slot} remix`);
+            // Mirrors the runtime's empty-slot mint: the gesture records the
+            // placement (location) beside the pin (provenance) — slot
+            // discovery reads placements only (2026-08-02 split).
+            minted.placements = [slot];
             state.apps.push(minted);
             return minted;
           })()


### PR DESCRIPTION
Lane W0 of the remix final shape plan (`docs/superpowers/specs/2026-08-02-remix-final-shape-plan.md`). Splits the two facts one array used to store: `pins` is fork provenance ONLY (drift, ship-diff, rebase), the new `AppDocument.placements` is "show this app in that slot" ONLY (slot discovery). No migration script — readers classify legacy rows on read, rows normalize on the next write.

## What changed

- **`@vendoai/core`** — `AppDocument.placements?: string[]` (+ schema + non-empty validation). `Pin {slot, base}` untouched.
- **`@vendoai/apps` classification** — `classifyLegacyPlacements` (pins.ts): a stored `pins` entry whose `base` matches no captured baseline hash is a placement, with three fail-closed carve-outs that stay pins (surfaced, not guessed — see Contract friction): the slot still names a captured baseline (a real, possibly drifted fork drift/rebase must keep seeing), the document still carries the forked component source (reclassifying would launder captured host source past `assertPinsExportable`), or no baselines are captured at all (zero signal). Every runtime read (`owned`, `list`) classifies; the edit path's concurrency check compares classified-to-classified so a legacy row's first edit doesn't read as a concurrent change; the next persisted write normalizes the row. Drift, ship-diff, rebase, and export all ride the classified document.
- **`@vendoai/apps` fork dedupe** — appId-less `pins.fork` (the `POST /apps/fork-pin` gesture) dedupes server-side per (subject, slot): an existing app whose pins name the slot is returned instead of minting a duplicate; a riding instruction is dropped on the dedupe hit (replaying it would double-apply). The UI latch stays, now cosmetic. The empty-slot mint also records `placements: [slot]` — the gesture means "show the remix in THIS slot", and slot discovery no longer reads pins.
- **`@vendoai/ui`** — `useSlotApp` reads `placements` only; pins never place an app. Legacy rows arrive already classified by the server's read path.
- **demo-bank** — `POST /api/demo/pin` writes `doc.placements`; the fake-hash `pinBase` synthesis is deleted, along with the orphan `.vendo/remixable/home-hero.json` baseline it read (`.vendo/tools.json` srcHash follows the route edit).

## Proof tests (written with the code)

- `packages/ui/test/chrome/slot-discovery.test.tsx` — placements read by slot discovery; **pins ignored for placement** (new test).
- `packages/apps/src/placements.test.ts` (9 tests) — a stored legacy fake-hash row classifies to a placement on read: it lands in `list()`/slot discovery (still mounts in its slot) and `pins.drift` stays quiet; it **normalizes to `placements` on the next write** (also proves the edit concurrency check handles unnormalized rows); classification unit coverage (real pin kept, drifted pin kept, forked-component fail-closed, empty/unset baselines pass-through).
- `examples/demo-bank/src/vendo/demo-pin-route.test.ts` — demo pin route writes placements; stored doc contains **no base hash anywhere**; slot swap + re-place idempotence.
- `packages/apps/src/fork-pin.test.ts` (new describe) — double appId-less fork (same subject+slot) → same app id, one app row; riding instruction dropped on the dedupe hit; the mint carries the slot placement.
- Drift/ship-diff regressions — `placements.test.ts`: real drift still reported beside a classified placement; ship-diff reviews provenance pins only. The untouched `rebase.test.ts`, `pins.test.ts`, and `interchange.test.ts` suites (drift surfacing, rebase gating, export fail-closed) stay green.

## Existing-test changes (stated per the lane rules)

Legitimately obsolete under the approved spec — slot discovery's source of truth moved from pins to placements, which is exactly what these fixtures encode:
- `packages/ui/test/chrome/slot-discovery.test.tsx` — fixtures `pins: [{slot, base}]` → `placements: ["hero"]`.
- `packages/ui/test/chrome/app-load-retry.test.tsx`, `pin-ceremony.test.tsx` — same one-line fixture move.
- `packages/ui/test/wire-server.ts` — the fixture's fork-pin mint mirrors the runtime's new `placements: [slot]`.
- `packages/apps/src/fork-pin.test.ts` — additions only (new describe + one placement assertion); no existing assertion changed.

No other existing test was modified.

## Contract friction (for the driving session)

The frozen contract's classification rule ("a `pins` entry whose `base` matches no captured baseline hash is treated as a placement") taken literally also matches every REAL drifted fork (drift is by definition base ≠ any current baseline hash), which would empty drift/rebase and break their suites; it likewise matches export-blocked orphaned forks, laundering captured host source past the export gate. Implemented with the fail-closed carve-outs above (the design doc's "surfaced, not guessed" rule). Also: the frozen contract doesn't mention the empty-slot mint writing a placement, but without it the shipped VendoSlot remix gesture would mount nothing between W0 and W1b. Both are flagged here for logging as amendments if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split `pins` (fork provenance) from new `placements` (slot location) and made appId-less forks idempotent per user+slot. Slot discovery now reads placements only; legacy fake-hash pins are classified on read and normalized on next write.

- **New Features**
  - `@vendoai/core`: Added `AppDocument.placements?: string[]` with validation.
  - `@vendoai/apps`: Added `classifyLegacyPlacements` to auto-split legacy rows on read; edit concurrency compares classified docs; `POST /apps/fork-pin` dedupes per (subject, slot) and records `placements: [slot]`.
  - `@vendoai/ui`: `useSlotApp` reads `placements` only; latest placement wins.
  - `examples/demo-bank`: `POST /api/demo/pin` writes `doc.placements`; deleted fake-hash synthesis and the orphan `.vendo/remixable/home-hero.json`.

- **Migration**
  - No script. Legacy rows classify on read and normalize on the next write.
  - Hosts should write `placements` for slot mounting; `pins` remains provenance (drift, ship-diff, rebase).
  - Drifted pins and orphaned forks stay in `pins` by design (fail-closed carve-outs).

<sup>Written for commit 627224928211d07a5ae0ad040e1aaadae9c7233c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

