### PR TITLE
remix W1c: review-kind lifecycle + review seam

### DIFF
--- a/packages/apps/src/inclient.ts
+++ b/packages/apps/src/inclient.ts
@@ -1,4 +1,4 @@
-import type { AppDocument, AppId, RecordStore, StoreAdapter } from "@vendoai/core";
+import type { AppDocument, AppId, IsoDateTime, RecordStore, StoreAdapter } from "@vendoai/core";
 import { listAllRecords } from "./persistence.js";
 import { inClientApprovalSchema, type InClientApproval } from "./pins.js";
 import { appVersionHash } from "./version-hash.js";
@@ -14,14 +14,30 @@ export type InClientVerdict =
   | { granted: false; versionHash: string; reason: "no-approval" | "version-changed" };
 
 /**
+ * Remix final shape (2026-08-02) — where the CURRENT version of a review-kind
+ * app stands with the host reviewer, riding the venue state so the user's
+ * panel can say "sent for review" or surface the rejection note. Server-
+ * authoritative like the rest of the venue field.
+ */
+export type ReviewStanding =
+  | { status: "pending"; versionHash: string }
+  | { status: "rejected"; versionHash: string; note: string; by: string; at: IsoDateTime };
+
+/**
  * The additive in-client venue state the opener rides inside the tree payload
  * (like `furnishings` — UIPayload is forward-compatible; the frozen
  * OpenSurface shape stays intact). The client's renderer treats a missing
  * field as the default: jailed.
+ *
+ * Review-kind additions (2026-08-02): `reason: "pending-review"` means the
+ * client shows the ORIGINAL host component — never a jailed fork; the granted
+ * state's optional `review` rider means an OLDER approved version is being
+ * served while the current one awaits review.
  */
 export type InClientVenueState =
-  | { granted: true; versionHash: string; approvedBy: string; at: string }
-  | { granted: false; versionHash: string; reason: "version-changed" };
+  | { granted: true; versionHash: string; approvedBy: string; at: string; review?: ReviewStanding }
+  | { granted: false; versionHash: string; reason: "version-changed" }
+  | { granted: false; versionHash: string; reason: "pending-review"; review: ReviewStanding };
 
 export interface InClientApprovalAccess {
   /** All stored approvals for one app — an audit trail, one per approved version. */

--- a/packages/apps/src/index.ts
+++ b/packages/apps/src/index.ts
@@ -70,7 +70,16 @@ export { appVersionHash } from "./version-hash.js";
 export {
   type InClientVenueState,
   type InClientVerdict,
+  type ReviewStanding,
 } from "./inclient.js";
+// Remix final shape (2026-08-02) — the review-kind lifecycle vocabulary:
+// the queue entry the console seam lists and the rejection record the note
+// surfaces from (AppsRuntime.review is the behavior surface).
+export {
+  remixRejectionSchema,
+  type RemixRejection,
+  type ReviewQueueEntry,
+} from "./review.js";
 export {
   type ShipDiff,
   type ShipDiffGenerated,

--- a/packages/apps/src/open.ts
+++ b/packages/apps/src/open.ts
@@ -316,6 +316,14 @@ export const createAppOpener = (
     if (pinDrift.length > 0) {
       (tree as Tree & { pinDrift: PinDrift[] }).pinDrift = pinDrift;
     }
+    // Review-kind gate (2026-08-02): an unapproved review-kind version ships
+    // NO executable source — no components, no componentTools, no furnishings,
+    // no resolved query data — so a jailed fork render cannot occur even on a
+    // client that ignores the venue state. The client keeps the ORIGINAL host
+    // component in place and surfaces the standing riding `inClient`.
+    if (inClient?.granted === false && inClient.reason === "pending-review") {
+      return { kind: "tree", payload: tree as unknown as UIPayload };
+    }
     attachPinFurnishings(tree, app, pinBaselines);
     const queries = createProgressiveQueryResolver(caller, app, ctx);
     queries.update(tree);

--- a/packages/apps/src/pins.ts
+++ b/packages/apps/src/pins.ts
@@ -18,6 +18,11 @@ export interface PinBaseline {
   hash: string;
   exportable: boolean;
   capturedAt: IsoDateTime;
+  /** Remix final shape (2026-08-02) — the component kind, captured by sync
+   *  from the `<Remixable review>` wrapper prop: a fork of a review-kind
+   *  baseline is invisible to its own user until a host reviewer approves,
+   *  then mounts natively. Absent = instant (jailed, no review process). */
+  review?: boolean;
   sourceImports?: Record<string, string>;
   subSources?: Record<string, PinSubSource>;
   sampleProps?: Record<string, Json>;
@@ -53,6 +58,7 @@ export const pinBaselineSchema = z.object({
   hash: z.string().startsWith("sha256:"),
   exportable: z.boolean(),
   capturedAt: isoDateTimeSchema,
+  review: z.boolean().optional(),
   sourceImports: z.record(z.string()).optional(),
   subSources: z.record(pinSubSourceSchema).optional(),
   sampleProps: z.record(z.unknown()).optional(),

--- a/packages/apps/src/review.test.ts
+++ b/packages/apps/src/review.test.ts
@@ -1,0 +1,333 @@
+import { VENDO_APP_FORMAT, type AppDocument, type RunContext, type ToolRegistry } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createInClientApprovals } from "./inclient.js";
+import { createApps } from "./index.js";
+import { pinComponentName, type PinBaseline } from "./pins.js";
+import { createReviewLifecycle } from "./review.js";
+import { guardFixture, memoryStore, scriptedLanguageModel, seedAppRow } from "./testing/index.js";
+import { appVersionHash } from "./version-hash.js";
+
+const tools: ToolRegistry = {
+  async descriptors() {
+    return [];
+  },
+  async execute() {
+    return { status: "error", error: { code: "not-found", message: "No fixture tools" } };
+  },
+};
+
+const context = (subject: string): RunContext => ({
+  principal: { kind: "user", subject },
+  venue: "app",
+  presence: "present",
+  sessionId: `session_${subject}`,
+});
+
+/** A review-kind capture beside an instant one: kind is baseline metadata. */
+const reviewedBaseline: PinBaseline = {
+  slot: "transfer-panel",
+  source: "export default function TransferPanel() { return <b>host</b>; }",
+  hash: "sha256:transfer-base",
+  exportable: true,
+  capturedAt: "2026-08-01T12:00:00.000Z",
+  review: true,
+};
+
+const instantBaseline: PinBaseline = {
+  slot: "hero-card",
+  source: "export default function Hero() { return <b>host</b>; }",
+  hash: "sha256:hero-base",
+  exportable: true,
+  capturedAt: "2026-08-01T12:00:00.000Z",
+};
+
+const doc = (slot: string, overrides: Partial<AppDocument> = {}): AppDocument => ({
+  format: VENDO_APP_FORMAT,
+  id: `app_review_${slot.replaceAll("-", "_")}`,
+  name: `${slot} remix`,
+  ui: "tree",
+  tree: {
+    formatVersion: "vendo-genui/v2",
+    root: "root",
+    nodes: [
+      { id: "root", component: "Stack", source: "prewired", children: ["fork"] },
+      { id: "fork", component: pinComponentName(slot), source: "generated" },
+    ],
+  },
+  pins: [{ slot, base: `sha256:${slot === "transfer-panel" ? "transfer" : "hero"}-base` }],
+  components: {
+    [pinComponentName(slot)]: "export default function Fork() { return <b>fork</b>; }",
+  },
+  ...overrides,
+});
+
+const setup = () => {
+  const store = memoryStore();
+  const guard = guardFixture();
+  const runtime = createApps({
+    store,
+    guard,
+    tools,
+    catalog: [],
+    pinBaselines: [reviewedBaseline, instantBaseline],
+    model: scriptedLanguageModel('<Edit><SetName name="Edited name"/></Edit>'),
+  });
+  return { store, guard, runtime };
+};
+
+const owner = context("user_ada");
+const reviewer = context("host_reviewer");
+
+describe("review-kind gating in open()", () => {
+  it("an unapproved review-kind remix answers pending-review and ships NO executable source", async () => {
+    const { store, runtime } = setup();
+    const app = doc("transfer-panel");
+    await seedAppRow(store, app, owner.principal.subject);
+
+    const surface = await runtime.open(app.id, owner);
+    if (surface.kind !== "tree") throw new Error("expected tree surface");
+    expect((surface.payload as { inClient?: unknown }).inClient).toEqual({
+      granted: false,
+      versionHash: appVersionHash(app),
+      reason: "pending-review",
+      review: { status: "pending", versionHash: appVersionHash(app) },
+    });
+    // A jailed render can NEVER occur: no fork source travels — not on the
+    // surface, not in the payload, not as jail furnishings or island tools.
+    expect(surface.components).toBeUndefined();
+    const payload = surface.payload as {
+      components?: unknown;
+      componentTools?: unknown;
+      furnishings?: unknown;
+    };
+    expect(payload.components).toBeUndefined();
+    expect(payload.componentTools).toBeUndefined();
+    expect(payload.furnishings).toBeUndefined();
+  });
+
+  it("an instant-kind remix is completely unaffected (regression)", async () => {
+    const { store, runtime } = setup();
+    const app = doc("hero-card");
+    await seedAppRow(store, app, owner.principal.subject);
+
+    const surface = await runtime.open(app.id, owner);
+    if (surface.kind !== "tree") throw new Error("expected tree surface");
+    // Jailed by default, source present: exactly the pre-review behavior.
+    expect((surface.payload as { inClient?: unknown }).inClient).toBeUndefined();
+    expect(surface.components).toEqual(app.components);
+  });
+});
+
+describe("approval swaps the served version", () => {
+  it("approve grants native for that hash; an edit leaves the approved version rendering; approving the new version swaps", async () => {
+    const { store, runtime } = setup();
+    const v1 = doc("transfer-panel");
+    await seedAppRow(store, v1, owner.principal.subject);
+    const v1Hash = appVersionHash(v1);
+
+    await runtime.inClient.approve({ appId: v1.id, approvedBy: "host-console" }, owner);
+    const approved = await runtime.open(v1.id, owner);
+    if (approved.kind !== "tree") throw new Error("expected tree surface");
+    expect((approved.payload as { inClient?: unknown }).inClient).toMatchObject({
+      granted: true,
+      versionHash: v1Hash,
+      approvedBy: "host-console",
+    });
+    expect(approved.components).toEqual(v1.components);
+
+    // Edit → a NEW version is pending; the LAST approved version keeps
+    // rendering natively, with the new version's standing riding along.
+    const edited = await runtime.edit(v1.id, "Rename it", owner);
+    expect(edited.failure).toBeUndefined();
+    const v2Hash = appVersionHash(edited.app);
+    expect(v2Hash).not.toBe(v1Hash);
+
+    const during = await runtime.open(v1.id, owner);
+    if (during.kind !== "tree") throw new Error("expected tree surface");
+    expect((during.payload as { inClient?: unknown }).inClient).toEqual({
+      granted: true,
+      versionHash: v1Hash,
+      approvedBy: "host-console",
+      at: expect.any(String) as unknown as string,
+      review: { status: "pending", versionHash: v2Hash },
+    });
+    expect(during.components).toEqual(v1.components);
+
+    // Approving the new version swaps it in, rider gone.
+    await runtime.inClient.approve({ appId: v1.id, approvedBy: "host-console" }, owner);
+    const swapped = await runtime.open(v1.id, owner);
+    if (swapped.kind !== "tree") throw new Error("expected tree surface");
+    expect((swapped.payload as { inClient?: { versionHash?: string; review?: unknown } }).inClient).toMatchObject({
+      granted: true,
+      versionHash: v2Hash,
+    });
+    expect((swapped.payload as { inClient?: { review?: unknown } }).inClient?.review).toBeUndefined();
+  });
+
+  it("an approval whose version left the capped history fails closed to pending-review, never the jail", async () => {
+    const store = memoryStore();
+    const approvals = createInClientApprovals(store);
+    const lifecycle = createReviewLifecycle({
+      store,
+      baselines: [reviewedBaseline],
+      approvals,
+      history: { documents: async () => [] },
+    });
+    const app = doc("transfer-panel");
+    await seedAppRow(store, app, owner.principal.subject);
+    // An approval exists, but for a version no history snapshot can vouch for.
+    await approvals.record({
+      appId: app.id,
+      versionHash: "sha256:gone-from-history",
+      approvedBy: "host-console",
+      at: "2026-08-01T13:00:00.000Z",
+    });
+    expect(await lifecycle.serveDocFor(app)).toEqual(app);
+    expect(await lifecycle.venueStateFor(app)).toMatchObject({
+      granted: false,
+      reason: "pending-review",
+    });
+  });
+});
+
+describe("rejection", () => {
+  it("requires a note", async () => {
+    const { store, runtime } = setup();
+    const app = doc("transfer-panel");
+    await seedAppRow(store, app, owner.principal.subject);
+    await expect(runtime.review.reject({ appId: app.id, note: "   " }, reviewer))
+      .rejects.toMatchObject({ code: "validation" });
+  });
+
+  it("refuses on a non-review-kind app, an approved version, and an unknown app", async () => {
+    const { store, runtime } = setup();
+    const instant = doc("hero-card");
+    await seedAppRow(store, instant, owner.principal.subject);
+    await expect(runtime.review.reject({ appId: instant.id, note: "no" }, reviewer))
+      .rejects.toMatchObject({ code: "conflict" });
+
+    const reviewed = doc("transfer-panel");
+    await seedAppRow(store, reviewed, owner.principal.subject);
+    await runtime.inClient.approve({ appId: reviewed.id, approvedBy: "host-console" }, owner);
+    await expect(runtime.review.reject({ appId: reviewed.id, note: "too late" }, reviewer))
+      .rejects.toMatchObject({ code: "conflict" });
+
+    await expect(runtime.review.reject({ appId: "app_missing", note: "no" }, reviewer))
+      .rejects.toMatchObject({ code: "not-found" });
+  });
+
+  it("records the note, surfaces it to the user, drops the version from the queue, and audits under the owner", async () => {
+    const { store, guard, runtime } = setup();
+    const app = doc("transfer-panel");
+    await seedAppRow(store, app, owner.principal.subject);
+
+    expect(await runtime.review.queue()).toHaveLength(1);
+
+    const rejection = await runtime.review.reject(
+      { appId: app.id, note: "Keep the original balance label." },
+      reviewer,
+    );
+    expect(rejection).toMatchObject({
+      appId: app.id,
+      versionHash: appVersionHash(app),
+      note: "Keep the original balance label.",
+      by: reviewer.principal.subject,
+    });
+
+    // The queue drops it; the work is NOT deleted.
+    expect(await runtime.review.queue()).toEqual([]);
+    expect(await runtime.get(app.id, owner)).not.toBeNull();
+
+    // The note rides the venue state the user's panel reads.
+    const surface = await runtime.open(app.id, owner);
+    if (surface.kind !== "tree") throw new Error("expected tree surface");
+    expect((surface.payload as { inClient?: unknown }).inClient).toMatchObject({
+      granted: false,
+      reason: "pending-review",
+      review: {
+        status: "rejected",
+        versionHash: appVersionHash(app),
+        note: "Keep the original balance label.",
+        by: reviewer.principal.subject,
+      },
+    });
+
+    // The audit event lands under the OWNER's subject — the rejection is loud
+    // in the remixing user's activity, not the reviewer's.
+    expect(guard.audit.some((event) =>
+      event.kind === "app-lifecycle"
+      && event.principal.subject === owner.principal.subject
+      && event.detail?.operation === "review-reject"
+      && event.detail?.note === "Keep the original balance label.")).toBe(true);
+  });
+
+  it("a new version supersedes the rejection and increments the resubmission count", async () => {
+    const { store, runtime } = setup();
+    const app = doc("transfer-panel");
+    await seedAppRow(store, app, owner.principal.subject);
+    await runtime.review.reject({ appId: app.id, note: "Not like this." }, reviewer);
+    expect(await runtime.review.queue()).toEqual([]);
+
+    const edited = await runtime.edit(app.id, "Rename it", owner);
+    expect(edited.failure).toBeUndefined();
+
+    const queue = await runtime.review.queue();
+    expect(queue).toHaveLength(1);
+    expect(queue[0]).toMatchObject({
+      appId: app.id,
+      versionHash: appVersionHash(edited.app),
+      resubmissions: 1,
+    });
+    // Pending again — the old note no longer speaks for the new version.
+    const surface = await runtime.open(app.id, owner);
+    if (surface.kind !== "tree") throw new Error("expected tree surface");
+    expect((surface.payload as { inClient?: { review?: { status?: string } } }).inClient?.review?.status).toBe("pending");
+  });
+
+  it("delete clears the app's rejection records", async () => {
+    const { store, runtime } = setup();
+    const app = doc("transfer-panel");
+    await seedAppRow(store, app, owner.principal.subject);
+    await runtime.review.reject({ appId: app.id, note: "Nope." }, reviewer);
+    await runtime.delete(app.id, owner);
+    expect((await store.records("vendo_remix_rejections").list({ refs: { appId: app.id } })).records).toEqual([]);
+  });
+});
+
+describe("review queue", () => {
+  it("lists pending review-kind versions with requester, slot, hash, submission time, resubmissions and the ship-diff", async () => {
+    const { store, runtime } = setup();
+    const app = doc("transfer-panel");
+    await seedAppRow(store, app, owner.principal.subject);
+
+    const queue = await runtime.review.queue();
+    expect(queue).toHaveLength(1);
+    expect(queue[0]).toMatchObject({
+      appId: app.id,
+      requester: owner.principal.subject,
+      slot: "transfer-panel",
+      versionHash: appVersionHash(app),
+      resubmissions: 0,
+    });
+    expect(queue[0]?.submittedAt).toEqual(expect.any(String));
+    expect(queue[0]?.shipDiff).toMatchObject({
+      appId: app.id,
+      versionHash: appVersionHash(app),
+      pins: [{ slot: "transfer-panel" }],
+    });
+    expect(queue[0]?.shipDiff.pins[0]?.diff).toContain("+export default function Fork() { return <b>fork</b>; }");
+  });
+
+  it("never lists instant-kind apps or approved review-kind versions", async () => {
+    const { store, runtime } = setup();
+    const instant = doc("hero-card");
+    await seedAppRow(store, instant, owner.principal.subject);
+    expect(await runtime.review.queue()).toEqual([]);
+
+    const reviewed = doc("transfer-panel");
+    await seedAppRow(store, reviewed, owner.principal.subject);
+    expect(await runtime.review.queue()).toHaveLength(1);
+    await runtime.inClient.approve({ appId: reviewed.id, approvedBy: "host-console" }, owner);
+    expect(await runtime.review.queue()).toEqual([]);
+  });
+});

--- a/packages/apps/src/review.ts
+++ b/packages/apps/src/review.ts
@@ -1,0 +1,254 @@
+import {
+  VendoError,
+  appIdSchema,
+  isoDateTimeSchema,
+  type AppDocument,
+  type AppId,
+  type IsoDateTime,
+  type RecordStore,
+  type StoreAdapter,
+} from "@vendoai/core";
+import { z } from "zod";
+import type { AppHistoryAccess } from "./history.js";
+import type { InClientApprovalAccess, InClientVenueState, ReviewStanding } from "./inclient.js";
+import { classifyLegacyPlacements, type PinBaseline } from "./pins.js";
+import { documentFromRecord, listAllRecords, rowFromRecord } from "./persistence.js";
+import { computeShipDiff, type ShipDiff } from "./ship-diff.js";
+import { appVersionHash } from "./version-hash.js";
+
+/**
+ * Remix final shape (2026-08-02) — one reviewer rejection of one exact app
+ * version. The work is NOT deleted: the note goes back to the user's panel,
+ * and a new version supersedes the rejection (the resubmission count on the
+ * review queue increments).
+ */
+export interface RemixRejection {
+  appId: AppId;
+  versionHash: string;
+  note: string;
+  by: string;
+  at: IsoDateTime;
+}
+
+/** Validated persisted representation of a remix rejection. */
+export const remixRejectionSchema = z.object({
+  appId: appIdSchema,
+  versionHash: z.string(),
+  note: z.string().min(1),
+  by: z.string(),
+  at: isoDateTimeSchema,
+}).passthrough() satisfies z.ZodType<RemixRejection>;
+
+/**
+ * One pending review-kind version awaiting the host reviewer, as
+ * `GET /apps/review-queue` lists it. `shipDiff` is the review artifact —
+ * the fork's unified diff against the captured baseline, hash-pinned to
+ * the version an approval would cover.
+ */
+export interface ReviewQueueEntry {
+  appId: AppId;
+  /** The remixing user (the app's owner subject). */
+  requester: string;
+  /** The review-kind host slot this fork pins (first of several, if ever). */
+  slot: string;
+  versionHash: string;
+  /** When this version landed (the app row's last write). */
+  submittedAt: IsoDateTime;
+  /** Prior rejections superseded by newer versions of this app. */
+  resubmissions: number;
+  shipDiff: ShipDiff;
+}
+
+const COLLECTION = "vendo_remix_rejections";
+
+/**
+ * Remix final shape (2026-08-02) — review-kind gating over the hash-pinned
+ * in-client approval machinery (inclient.ts). An app forked from a baseline
+ * captured with `review: true` is invisible to its own user until a host
+ * reviewer approves: open() serves the newest APPROVED version (or, before
+ * any approval, a pending state the client resolves to the ORIGINAL host
+ * component — a jailed fork render never occurs for review-kind).
+ */
+export interface ReviewLifecycle {
+  /** Kind is capture metadata: any fork pin whose baseline carries `review: true`. */
+  isReviewKind(doc: AppDocument): boolean;
+  /**
+   * The document open() serves. Review-kind and the current version
+   * unapproved → the newest approved version from the existing history
+   * (content is never re-minted); none approved → the current document,
+   * whose venue state below withholds every executable source.
+   */
+  serveDocFor(current: AppDocument): Promise<AppDocument>;
+  /**
+   * The opener's venue callback. Instant-kind delegates to the plain
+   * hash-pin venue; review-kind never answers with a jail state — an
+   * unapproved version rides `pending-review` (with the rejection note when
+   * the reviewer left one), and a served older version carries the current
+   * version's standing as the `review` rider.
+   */
+  venueStateFor(doc: AppDocument): Promise<InClientVenueState | undefined>;
+  /** Every review-kind version awaiting review, oldest submission first. */
+  queue(): Promise<ReviewQueueEntry[]>;
+  /** Persist one rejection of the app's CURRENT version. */
+  reject(input: { doc: AppDocument; note: string; by: string }): Promise<RemixRejection>;
+  /** All rejections recorded for one app, oldest first. */
+  rejections(appId: AppId): Promise<RemixRejection[]>;
+  /** Remove every rejection for one app (delete path). */
+  clear(appId: AppId): Promise<void>;
+}
+
+export interface ReviewLifecycleDeps {
+  store: StoreAdapter;
+  baselines: readonly PinBaseline[] | undefined;
+  approvals: InClientApprovalAccess;
+  history: Pick<AppHistoryAccess, "documents">;
+}
+
+export const createReviewLifecycle = (deps: ReviewLifecycleDeps): ReviewLifecycle => {
+  const rejections: RecordStore = deps.store.records(COLLECTION);
+  const baselines = (): readonly PinBaseline[] => deps.baselines ?? [];
+
+  const isReviewKind = (doc: AppDocument): boolean =>
+    (doc.pins ?? []).some((pin) =>
+      baselines().some((baseline) => baseline.slot === pin.slot && baseline.review === true));
+
+  const rejectionsFor = async (appId: AppId): Promise<RemixRejection[]> => {
+    const records = await listAllRecords(rejections, { refs: { appId } });
+    return records
+      .flatMap((record) => {
+        const parsed = remixRejectionSchema.safeParse(record.data);
+        // A corrupt row is simply not a rejection — same rule as approvals.
+        return parsed.success && parsed.data.appId === appId ? [parsed.data] : [];
+      })
+      .sort((left, right) => left.at.localeCompare(right.at));
+  };
+
+  const standingFor = async (appId: AppId, versionHash: string): Promise<ReviewStanding> => {
+    const rejection = (await rejectionsFor(appId))
+      .filter((candidate) => candidate.versionHash === versionHash)
+      .at(-1);
+    if (rejection === undefined) return { status: "pending", versionHash };
+    return {
+      status: "rejected",
+      versionHash,
+      note: rejection.note,
+      by: rejection.by,
+      at: rejection.at,
+    };
+  };
+
+  const serveDocFor = async (current: AppDocument): Promise<AppDocument> => {
+    if (!isReviewKind(current)) return current;
+    if ((await deps.approvals.verdictFor(current)).granted) return current;
+    const approved = new Set((await deps.approvals.list(current.id)).map(({ versionHash }) => versionHash));
+    if (approved.size === 0) return current;
+    // Newest approved version wins: history is oldest-first, snapshots are
+    // classified like every runtime read so their hashes line up with the
+    // approvals minted over classified documents. An approved version that
+    // fell off the capped history fails closed to the pending state below.
+    const snapshots = await deps.history.documents(current.id);
+    for (const snapshot of snapshots.reverse()) {
+      const classified = classifyLegacyPlacements(snapshot, deps.baselines);
+      if (approved.has(appVersionHash(classified))) return classified;
+    }
+    return current;
+  };
+
+  const venueStateFor = async (doc: AppDocument): Promise<InClientVenueState | undefined> => {
+    const base = await deps.approvals.venueStateFor(doc);
+    if (!isReviewKind(doc)) return base;
+    // The opener may be serving an older approved snapshot (serveDocFor), so
+    // the review standing speaks about the CURRENT stored version.
+    const record = await deps.store.records("vendo_apps").get(doc.id);
+    const current = record === null ? doc : classifyLegacyPlacements(documentFromRecord(record), deps.baselines);
+    const currentHash = appVersionHash(current);
+    if (base?.granted === true) {
+      if (base.versionHash === currentHash) return base;
+      return { ...base, review: await standingFor(doc.id, currentHash) };
+    }
+    // Review-kind never jails: any unapproved state (including the instant
+    // vocabulary's version-changed drop-back) becomes pending-review, and the
+    // opener withholds every executable source for it.
+    return {
+      granted: false,
+      versionHash: currentHash,
+      reason: "pending-review",
+      review: await standingFor(doc.id, currentHash),
+    };
+  };
+
+  return {
+    isReviewKind,
+    serveDocFor,
+    venueStateFor,
+
+    async queue() {
+      const entries: ReviewQueueEntry[] = [];
+      for (const record of await listAllRecords(deps.store.records("vendo_apps"))) {
+        let row;
+        try {
+          row = rowFromRecord(record);
+        } catch {
+          continue; // an invalid row cannot be reviewed
+        }
+        const doc = classifyLegacyPlacements(row.doc, deps.baselines);
+        // The review-kind slot doubles as the kind test: none → instant-kind.
+        const slot = (doc.pins ?? []).find((pin) =>
+          baselines().some((baseline) => baseline.slot === pin.slot && baseline.review === true))?.slot;
+        if (slot === undefined) continue;
+        if ((await deps.approvals.verdictFor(doc)).granted) continue;
+        const versionHash = appVersionHash(doc);
+        const standing = await standingFor(doc.id, versionHash);
+        // A rejected version left the queue; it re-enters when a new version
+        // supersedes the rejection.
+        if (standing.status === "rejected") continue;
+        entries.push({
+          appId: doc.id,
+          requester: row.subject,
+          slot,
+          versionHash,
+          submittedAt: record.updatedAt,
+          resubmissions: (await rejectionsFor(doc.id)).length,
+          shipDiff: computeShipDiff(doc, baselines()),
+        });
+      }
+      return entries.sort((left, right) => left.submittedAt.localeCompare(right.submittedAt));
+    },
+
+    async reject({ doc, note, by }) {
+      // The note is the whole point of a rejection — it is what the user's
+      // panel surfaces — so an empty one refuses loudly (the wire's 4xx).
+      if (note.trim().length === 0) {
+        throw new VendoError("validation", "a rejection requires a note for the user");
+      }
+      if (!isReviewKind(doc)) {
+        throw new VendoError("conflict", `app ${doc.id} is not a review-kind remix`);
+      }
+      const versionHash = appVersionHash(doc);
+      if ((await deps.approvals.verdictFor(doc)).granted) {
+        throw new VendoError("conflict", `version ${versionHash} is already approved`);
+      }
+      const rejection = remixRejectionSchema.parse({
+        appId: doc.id,
+        versionHash,
+        note,
+        by,
+        at: new Date().toISOString(),
+      });
+      await rejections.put({
+        id: `remrej_${globalThis.crypto.randomUUID()}`,
+        data: rejection,
+        refs: { appId: rejection.appId },
+      });
+      return rejection;
+    },
+
+    rejections: rejectionsFor,
+
+    async clear(appId) {
+      for (const record of await listAllRecords(rejections, { refs: { appId } })) {
+        await rejections.delete(record.id);
+      }
+    },
+  };
+};

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -78,6 +78,7 @@ import { isDisclaimerOnlyTree } from "./pipeline.js";
 import { createAppOpener, createProgressiveQueryResolver, machinesDisabledError, servedAppsDisabledError, stripServerAuthoritativeFields } from "./open.js";
 import { appRecordInput, documentFromRecord, enabledAfterDocumentEdit, listAllRecords, nextEnvStaleAt, rowFromRecord, updateAppRow } from "./persistence.js";
 import { classifyLegacyPlacements, detectPinDrift, hasDefaultExport, pinComponentName, pinForkSource, type InClientApproval, type PinBaseline, type PinDrift } from "./pins.js";
+import { createReviewLifecycle, type RemixRejection, type ReviewQueueEntry } from "./review.js";
 import { collectSecretValues, redactSecretJson, redactSecretText } from "./redaction.js";
 import {
   boxAllowlist,
@@ -546,6 +547,24 @@ export interface AppsRuntime {
     approvals(appId: AppId, ctx: RunContext): Promise<InClientApproval[]>;
     verdict(appId: AppId, ctx: RunContext): Promise<InClientVerdict>;
     approve(input: { appId: AppId; approvedBy: string }, ctx: RunContext): Promise<InClientApproval>;
+  };
+  /**
+   * Remix final shape (2026-08-02) — additive review-kind lifecycle surface
+   * (same additive precedent as `inClient`/`pins`). A review-kind remix (an
+   * app forked from a baseline captured with `review: true`) is invisible to
+   * its own user until a host reviewer approves; the approved version then
+   * mounts natively in place, riding the §9 hash-pin machinery. These two
+   * methods are the reviewer's side and cross owner boundaries BY DESIGN
+   * (the reviewer is not the remixing user): like `history()`, they carry no
+   * owner scoping of their own — the wire layer enforces its host-admin
+   * principal scoping before exposing them.
+   */
+  review: {
+    /** Every review-kind version awaiting review, oldest submission first. */
+    queue(): Promise<ReviewQueueEntry[]>;
+    /** Reject the app's CURRENT version with a note the user's panel surfaces.
+     *  The work is not deleted; a new version supersedes the rejection. */
+    reject(input: { appId: AppId; note: string }, ctx: RunContext): Promise<RemixRejection>;
   };
   /**
    * 06-apps §8 — additive drift→rebase surface (same additive precedent as
@@ -1087,6 +1106,16 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
   config.guard.onApprovalDecision((id, approved) => onApprovalDecision(id, approved));
 
   const inClientApprovals = createInClientApprovals(config.store);
+  // Remix final shape (2026-08-02) — review-kind gating over the §9 hash-pin
+  // machinery: which document open() serves and the venue vocabulary the
+  // client resolves ("pending-review" = show the ORIGINAL, never a jailed
+  // fork; a served older approved version carries the current standing).
+  const review = createReviewLifecycle({
+    store: config.store,
+    baselines: config.pinBaselines,
+    approvals: inClientApprovals,
+    history,
+  });
   // execution-v2 Lane D — fn: refs on a machine-bearing app resolve over the
   // v2 box door (the same wake Lane C's wire proxy rides); the wrap leaves
   // every other ref on the existing caller. Queries hit this at open(),
@@ -1107,7 +1136,9 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
   const opener = createAppOpener(
     caller,
     config.pinBaselines,
-    (doc) => inClientApprovals.venueStateFor(doc),
+    // Review-aware venue: instant-kind answers exactly the plain hash-pin
+    // venue; review-kind never answers a jail state (review.ts).
+    (doc) => review.venueStateFor(doc),
     // Wave 4 (layer 3) — the served surface: wake-on-open over the machine
     // lifecycle, the provider's public ingress URL for $PORT, and the theming
     // handoff (host theme tokens as a query param the served app MAY consume).
@@ -2050,6 +2081,7 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       await data.clear(app, ctx.principal.subject, await history.documents(appId));
       await history.clear(appId);
       await inClientApprovals.clear(appId);
+      await review.clear(appId);
       await exposure.clearForApp(appId);
       await egressApprovals.clearForApp(appId);
       await parkedActions.clearForApp(appId);
@@ -2191,7 +2223,12 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     },
 
     async open(appId, ctx) {
-      return opener(await requireOwned(appId, ctx.principal.subject), ctx);
+      const app = await requireOwned(appId, ctx.principal.subject);
+      // Review-kind (2026-08-02): an unapproved current version is invisible —
+      // open() serves the newest APPROVED version from the existing history
+      // instead (or the pending state when none was ever approved). Instant
+      // kind passes through untouched.
+      return opener(await review.serveDocFor(app), ctx);
     },
 
     async call(appId, ref, args, ctx) {
@@ -2261,6 +2298,30 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
           approvedBy: approval.approvedBy,
         });
         return approval;
+      },
+    },
+
+    review: {
+      async queue() {
+        return review.queue();
+      },
+      async reject(input, ctx) {
+        // Reviewer-side, cross-subject by design: the app is looked up
+        // WITHOUT owner scoping (the wire's host-admin gate stands in front).
+        const record = await apps.get(input.appId);
+        if (record === null) throw new VendoError("not-found", `app not found: ${input.appId}`);
+        const row = rowFromRecord(record);
+        const doc = classifyLegacyPlacements(row.doc, config.pinBaselines);
+        const rejection = await review.reject({ doc, note: input.note, by: ctx.principal.subject });
+        // The audit event lands under the OWNER's subject so the rejection is
+        // loud in the remixing user's activity, not the reviewer's.
+        await reportGuard(row.subject, doc.id, ctx, {
+          operation: "review-reject",
+          versionHash: rejection.versionHash,
+          by: rejection.by,
+          note: rejection.note,
+        });
+        return rejection;
       },
     },
 

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -596,6 +596,29 @@ function StatefulTreeView({
     [validation.ok ? validation.tree.nodes : validation.error.message],
   );
 
+  // Remix final shape (2026-08-02) — a review-kind version awaiting the host
+  // reviewer renders NOTHING but its standing, checked BEFORE tree validation:
+  // the server ships no executable fork source with `pending-review` (its
+  // generated nodes have no components to validate against), so instead of an
+  // invalid-tree verdict, a jailed fork, or skeletons of stripped components
+  // the surface says "sent for review" — or carries the reviewer's rejection
+  // note back to the user.
+  if (inClient !== undefined && inClient.granted === false && inClient.reason === "pending-review") {
+    const standing = inClient.review;
+    if (standing?.status === "rejected") {
+      return (
+        <ContainedNotice label="Remix rejected" outcome="blocked">
+          {`The host reviewer rejected this remix — "${standing.note}". Edit the remix to resubmit it for review.`}
+        </ContainedNotice>
+      );
+    }
+    return (
+      <ContainedNotice label="Sent for review">
+        This remix was sent to the host for review. The original component stays in place until a reviewer approves it.
+      </ContainedNotice>
+    );
+  }
+
   if (!validation.ok) {
     return (
       <ContainedNotice label="Invalid UI tree" code={validation.error.code}>
@@ -620,7 +643,7 @@ function StatefulTreeView({
 
   // 06-apps §9 — a version change under an existing approval must be LOUD: the
   // surface drops back to the sandbox and says so, in-surface, above the tree.
-  const dropBackNotice = inClient !== undefined && inClient.granted === false
+  const dropBackNotice = inClient !== undefined && inClient.granted === false && inClient.reason === "version-changed"
     ? (
       <ContainedNotice label="In-client approval invalidated" outcome="blocked">
         This app changed since it was approved for the host page. It is running in the sandbox again until the new version is re-approved.

--- a/packages/ui/src/wire-types.ts
+++ b/packages/ui/src/wire-types.ts
@@ -44,15 +44,31 @@ export interface PendingSurface {
 }
 
 /**
+ * Remix final shape (2026-08-02) — where the CURRENT version of a review-kind
+ * remix stands with the host reviewer, riding the venue verdict: "pending"
+ * renders as "sent for review"; "rejected" carries the reviewer's note for
+ * the user's panel.
+ */
+export type ReviewStanding =
+  | { status: "pending"; versionHash: string }
+  | { status: "rejected"; versionHash: string; note: string; by: string; at: IsoDateTime };
+
+/**
  * 06-apps §9 — the additive in-client venue verdict riding a tree payload
  * (`payload.inClient`). SERVER-AUTHORITATIVE: only the runtime's hash-pin
  * verification writes it. `granted: true` is the ONLY state that lets the
  * renderer mount generated code in the host page; a missing field and every
- * other state stay in the sandboxed iframe jail.
+ * other state stay in the sandboxed iframe jail — except review-kind's
+ * `reason: "pending-review"` (2026-08-02), which must render the ORIGINAL
+ * host component: the server ships no executable fork source with it, so a
+ * jailed fork render cannot occur. A granted verdict's `review` rider means
+ * an OLDER approved version is being served while the current one awaits
+ * review.
  */
 export type InClientVenue =
-  | { granted: true; versionHash: string; approvedBy: string; at: IsoDateTime }
-  | { granted: false; versionHash: string; reason: "version-changed" };
+  | { granted: true; versionHash: string; approvedBy: string; at: IsoDateTime; review?: ReviewStanding }
+  | { granted: false; versionHash: string; reason: "version-changed" }
+  | { granted: false; versionHash: string; reason: "pending-review"; review: ReviewStanding };
 
 /**
  * 06-apps §8 — one drifted pin riding a tree payload (`payload.pinDrift`):

--- a/packages/ui/test/tree/review-standing.test.tsx
+++ b/packages/ui/test/tree/review-standing.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { VENDO_TREE_FORMAT, type ToolOutcome, type UIPayload } from "@vendoai/core";
+import { TreeView } from "../../src/tree/index.js";
+import type { InClientVenue } from "../../src/tree/renderer.js";
+
+afterEach(() => cleanup());
+
+const ok = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
+
+/** A review-kind payload as the server ships it while unapproved: the venue
+ *  says pending-review and NO fork source travels (open() strips it). */
+function pendingTree(inClient: InClientVenue): UIPayload {
+  const tree: UIPayload & { inClient?: InClientVenue } = {
+    formatVersion: VENDO_TREE_FORMAT,
+    root: "root",
+    nodes: [
+      { id: "root", component: "Stack", children: ["fork"] },
+      { id: "fork", component: "Widget", source: "generated" },
+    ],
+  };
+  tree.inClient = inClient;
+  return tree;
+}
+
+describe("review-kind standing (remix final shape 2026-08-02)", () => {
+  it("a pending-review payload renders ONLY the sent-for-review standing — no jail, no skeletons", () => {
+    render(
+      <TreeView
+        tree={pendingTree({
+          granted: false,
+          versionHash: "sha256:pending",
+          reason: "pending-review",
+          review: { status: "pending", versionHash: "sha256:pending" },
+        })}
+        components={{}}
+        onAction={ok}
+      />,
+    );
+    const notice = screen.getByRole("note", { name: "Sent for review" });
+    expect(notice.textContent).toContain("sent to the host for review");
+    // Never a jailed fork render, never the drop-back vocabulary.
+    expect(document.querySelector("iframe")).toBeNull();
+    expect(screen.queryByRole("note", { name: "In-client approval invalidated" })).toBeNull();
+  });
+
+  it("a rejected standing carries the reviewer's note back to the user", () => {
+    render(
+      <TreeView
+        tree={pendingTree({
+          granted: false,
+          versionHash: "sha256:rejected",
+          reason: "pending-review",
+          review: {
+            status: "rejected",
+            versionHash: "sha256:rejected",
+            note: "Keep the original balance label.",
+            by: "host_reviewer",
+            at: "2026-08-02T10:00:00.000Z",
+          },
+        })}
+        components={{}}
+        onAction={ok}
+      />,
+    );
+    const notice = screen.getByRole("note", { name: "Remix rejected" });
+    expect(notice.textContent).toContain("Keep the original balance label.");
+    expect(notice.textContent).toContain("resubmit");
+    expect(document.querySelector("iframe")).toBeNull();
+  });
+});

--- a/packages/vendo/src/review.fixture.test.ts
+++ b/packages/vendo/src/review.fixture.test.ts
@@ -1,0 +1,241 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { vendoSync } from "@vendoai/actions/sync";
+import { appVersionHash, pinComponentName } from "@vendoai/apps";
+import type { AppDocument, Principal } from "@vendoai/core";
+import { createStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVendo } from "./server.js";
+
+interface ModelCall {
+  prompt: Array<{
+    role: string;
+    content: string | Array<{ type?: string; text?: string }>;
+  }>;
+}
+
+const scriptedModel = (responses: string[]): LanguageModel => {
+  let call = 0;
+  const next = (): string => {
+    const response = responses[Math.min(call, responses.length - 1)];
+    call += 1;
+    if (response === undefined) throw new Error("scripted model exhausted");
+    return response;
+  };
+  return {
+    specificationVersion: "v2",
+    provider: "vendo-review-fixture",
+    modelId: "vendo-review-fixture-v1",
+    supportedUrls: {},
+    async doGenerate(_call: ModelCall) {
+      return {
+        content: [{ type: "text" as const, text: next() }],
+        finishReason: "stop" as const,
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      };
+    },
+    async doStream(_call: ModelCall) {
+      const text = next();
+      return {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: "stream-start", warnings: [] });
+            controller.enqueue({ type: "text-start", id: "text_1" });
+            controller.enqueue({ type: "text-delta", id: "text_1", delta: text });
+            controller.enqueue({ type: "text-end", id: "text_1" });
+            controller.enqueue({
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            });
+            controller.close();
+          },
+        }),
+      };
+    },
+  } as unknown as LanguageModel;
+};
+
+const USER_HEADER = "x-fixture-user";
+
+const originalCwd = process.cwd();
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+/** `as` = a host-resolved principal subject; omit it for an anonymous caller. */
+const request = (method: string, path: string, options: { as?: string; body?: unknown } = {}): Request =>
+  new Request(`https://host.test/api/vendo${path}`, {
+    method,
+    headers: {
+      ...(options.body === undefined ? {} : { "content-type": "application/json" }),
+      ...(options.as === undefined ? {} : { [USER_HEADER]: options.as }),
+    },
+    ...(options.body === undefined ? {} : { body: JSON.stringify(options.body) }),
+  });
+
+describe.sequential("remix W1c — the review-kind lifecycle through the real umbrella", () => {
+  it("fork is invisible until approved; reject sends the note back; approval swaps versions natively", async () => {
+    // A review-kind host slot, captured by the REAL sync from <Remixable review>.
+    const root = await mkdtemp(join(tmpdir(), "vendo-review-journey-"));
+    cleanups.push(async () => rm(root, { recursive: true, force: true }));
+    await mkdir(join(root, "src"), { recursive: true });
+    const hostSource = `export default function TransferPanel() {
+  return <form><span>Transfer</span><button>Send</button></form>;
+}\n`;
+    await writeFile(join(root, "src", "TransferPanel.tsx"), hostSource);
+    await writeFile(join(root, "src", "page.tsx"), `
+import { Remixable } from "@vendoai/ui/chrome";
+import TransferPanel from "./TransferPanel";
+export default function Page() {
+  return <Remixable review><TransferPanel /></Remixable>;
+}
+`);
+    const synced = await vendoSync({ root, out: join(root, ".vendo") });
+    expect(synced.pins.captured).toEqual(["TransferPanel"]);
+    // W1a handoff: sync wrote the kind into the baseline file.
+    const baseline = JSON.parse(await readFile(join(root, ".vendo", "remixable", "TransferPanel.json"), "utf8")) as { review?: boolean };
+    expect(baseline.review).toBe(true);
+
+    const store = createStore({ dataDir: join(root, ".data") });
+    cleanups.push(async () => store.close());
+    await store.ensureSchema();
+    process.chdir(root);
+    const vendo = createVendo({
+      model: scriptedModel([
+        '<Edit><SetName name="Transfer remix v2"/></Edit>',
+        '<Edit><SetName name="Transfer remix v3"/></Edit>',
+      ]),
+      // Host-resolved principal from the fixture header; absent = anonymous
+      // (the wire mints an ephemeral session — the "non-admin" caller).
+      principal: async (req): Promise<Principal | null> => {
+        const subject = req.headers.get(USER_HEADER);
+        return subject === null ? null : { kind: "user", subject };
+      },
+      store,
+      development: true,
+    });
+    const user = "user_ada";
+    const reviewer = "host_reviewer";
+
+    // 1. The user's Remix gesture forks the review-kind slot.
+    const forkResponse = await vendo.handler(request("POST", "/apps/fork-pin", { as: user, body: { slot: "TransferPanel" } }));
+    expect(forkResponse.status).toBe(200);
+    const fork = await forkResponse.json() as { app: AppDocument };
+    const appId = fork.app.id;
+    const v1Hash = appVersionHash(fork.app);
+
+    // 2. Unapproved: the user gets the pending state and the ORIGINAL — the
+    // payload ships no fork source, so a jailed render can never occur.
+    const pending = await (await vendo.handler(request("GET", `/apps/${appId}/open`, { as: user }))).json();
+    expect(pending.kind).toBe("tree");
+    expect(pending.payload.inClient).toEqual({
+      granted: false,
+      versionHash: v1Hash,
+      reason: "pending-review",
+      review: { status: "pending", versionHash: v1Hash },
+    });
+    expect(pending.components).toBeUndefined();
+    expect(pending.payload.components).toBeUndefined();
+    expect(pending.payload.furnishings).toBeUndefined();
+
+    // 3. The review queue: the host reviewer sees the submission with the
+    // ship-diff; an anonymous caller gets nothing (masked).
+    const queueResponse = await vendo.handler(request("GET", "/apps/review-queue", { as: reviewer }));
+    expect(queueResponse.status).toBe(200);
+    const queue = await queueResponse.json();
+    expect(queue).toHaveLength(1);
+    expect(queue[0]).toMatchObject({
+      appId,
+      requester: user,
+      slot: "TransferPanel",
+      versionHash: v1Hash,
+      resubmissions: 0,
+      shipDiff: { appId, versionHash: v1Hash },
+    });
+    expect(queue[0].submittedAt).toEqual(expect.any(String));
+    const masked = await vendo.handler(request("GET", "/apps/review-queue"));
+    expect(masked.status).toBe(200);
+    expect(await masked.json()).toEqual([]);
+
+    // 4. Rejection: the note is required; an anonymous caller is masked out.
+    const noteless = await vendo.handler(request("POST", `/apps/${appId}/reject-review`, { as: reviewer, body: {} }));
+    expect(noteless.status).toBe(400);
+    const anonymous = await vendo.handler(request("POST", `/apps/${appId}/reject-review`, { body: { note: "nope" } }));
+    expect(anonymous.status).toBe(404);
+    const rejected = await vendo.handler(request("POST", `/apps/${appId}/reject-review`, {
+      as: reviewer,
+      body: { note: "Keep the send button label exactly as shipped." },
+    }));
+    expect(rejected.status).toBe(200);
+    expect(await rejected.json()).toMatchObject({
+      appId,
+      versionHash: v1Hash,
+      note: "Keep the send button label exactly as shipped.",
+      by: reviewer,
+    });
+
+    // The queue drops it; the note reaches the user's panel; work survives.
+    expect(await (await vendo.handler(request("GET", "/apps/review-queue", { as: reviewer }))).json()).toEqual([]);
+    const noted = await (await vendo.handler(request("GET", `/apps/${appId}/open`, { as: user }))).json();
+    expect(noted.payload.inClient.review).toMatchObject({
+      status: "rejected",
+      note: "Keep the send button label exactly as shipped.",
+      by: reviewer,
+    });
+
+    // 5. The user edits → the new version supersedes the rejection and the
+    // resubmission count increments.
+    const editResponse = await vendo.handler(request("POST", `/apps/${appId}/edit`, { as: user, body: { instruction: "Rename it" } }));
+    expect(editResponse.status).toBe(200);
+    const edited = await editResponse.json() as { app: AppDocument; failure?: unknown };
+    expect(edited.failure).toBeUndefined();
+    const v2Hash = appVersionHash(edited.app);
+    const resubmitted = await (await vendo.handler(request("GET", "/apps/review-queue", { as: reviewer }))).json();
+    expect(resubmitted).toHaveLength(1);
+    expect(resubmitted[0]).toMatchObject({ appId, versionHash: v2Hash, resubmissions: 1 });
+
+    // 6. Approval grants the native venue for exactly that hash — the fork
+    // now ships, in place, as real code.
+    const approved = await vendo.handler(request("POST", "/dev/inclient-approval", {
+      as: user,
+      body: { appId, approvedBy: "host-security-review" },
+    }));
+    expect(approved.status).toBe(200);
+    const granted = await (await vendo.handler(request("GET", `/apps/${appId}/open`, { as: user }))).json();
+    expect(granted.payload.inClient).toMatchObject({
+      granted: true,
+      versionHash: v2Hash,
+      approvedBy: "host-security-review",
+    });
+    expect(granted.payload.inClient.review).toBeUndefined();
+    const componentName = pinComponentName("TransferPanel");
+    expect(granted.components?.[componentName]).toContain("TransferPanel");
+
+    // 7. Another edit: the LAST approved version keeps rendering natively
+    // while the new one is pending — never a gap, never unreviewed code.
+    const reEdited = await (await vendo.handler(request("POST", `/apps/${appId}/edit`, { as: user, body: { instruction: "Rename again" } }))).json() as { app: AppDocument };
+    const v3Hash = appVersionHash(reEdited.app);
+    const during = await (await vendo.handler(request("GET", `/apps/${appId}/open`, { as: user }))).json();
+    expect(during.payload.inClient).toMatchObject({
+      granted: true,
+      versionHash: v2Hash,
+      review: { status: "pending", versionHash: v3Hash },
+    });
+    expect(during.components?.[componentName]).toContain("TransferPanel");
+    // ...and the pending version is back in the reviewer's queue.
+    const pendingAgain = await (await vendo.handler(request("GET", "/apps/review-queue", { as: reviewer }))).json();
+    expect(pendingAgain[0]).toMatchObject({ appId, versionHash: v3Hash, resubmissions: 1 });
+
+    // 8. Approving the new version swaps it in.
+    await vendo.handler(request("POST", "/dev/inclient-approval", { as: user, body: { appId, approvedBy: "host-security-review" } }));
+    const swapped = await (await vendo.handler(request("GET", `/apps/${appId}/open`, { as: user }))).json();
+    expect(swapped.payload.inClient).toMatchObject({ granted: true, versionHash: v3Hash });
+    expect(swapped.payload.inClient.review).toBeUndefined();
+  }, 120_000);
+});

--- a/packages/vendo/src/wire/apps.ts
+++ b/packages/vendo/src/wire/apps.ts
@@ -81,6 +81,20 @@ export const appRoutes: RouteEntry[] = [
       ...(body["instruction"] === undefined ? {} : { instruction: string(body["instruction"], "instruction") }),
     }, ctx));
   }),
+  // Remix final shape (2026-08-02) — the review seam for the host's console:
+  // every review-kind version awaiting a reviewer, with requester, slot,
+  // version hash, submission time, resubmission count and the ship-diff
+  // payload. Host-admin scoped on the SAME principal bar as the in-client
+  // approval seam (wire/misc.ts): reviewing is a HOST trust decision, so a
+  // caller without a host-resolved principal gets an EMPTY queue — masked,
+  // never a probe into other subjects' pending work. Like fork-pin above,
+  // this entry must stay ahead of the "/apps/:appId/*" catch-all, whose rest
+  // pattern would otherwise capture appId="review-queue".
+  route("GET", "/apps/review-queue", async ({ deps, context }) => {
+    const ctx = await context("app");
+    if (ctx.principal.ephemeral === true) return json([]);
+    return json(await deps.apps.review.queue());
+  }),
   route("POST", "/apps/import", async ({ request, deps, context }) => {
     // The CSRF floor exempts import (binary body), so it must instead require
     // a non-CORS-safelisted media type — forcing a cross-origin preflight so
@@ -198,6 +212,20 @@ export const appRoutes: RouteEntry[] = [
         slot: string(body["slot"], "slot"),
         ...(body["instruction"] === undefined ? {} : { instruction: string(body["instruction"], "instruction") }),
       }, ctx));
+    }
+    // Remix final shape (2026-08-02) — the reviewer's rejection of the app's
+    // CURRENT review-kind version: the note is REQUIRED (it is what the
+    // user's panel surfaces) and the work is not deleted — a new version
+    // supersedes the rejection. Reviewer-side and cross-subject by design,
+    // so it carries the review seam's host-admin principal bar instead of
+    // owner scoping: a caller without a host-resolved principal gets the
+    // same not-found an unowned app answers (masked).
+    if (request.method === "POST" && operation === "reject-review" && segments.length === 3) {
+      if (ctx.principal.ephemeral === true) {
+        throw new VendoError("not-found", `app not found: ${appId}`);
+      }
+      const body = await requestJson(request);
+      return json(await deps.apps.review.reject({ appId, note: string(body["note"], "note") }, ctx));
     }
     // Wave 7 H2 — the embed surface's keepalive: user activity on an embedded
     // served app rides one host-proxied HEAD through the machine (re-arming


### PR DESCRIPTION
Lane W1c of the remix final shape (spec + plan: `docs/superpowers/specs/2026-08-02-remix-final-shape-*.md`). Review buys the venue: an app forked from a baseline captured with `review: true` is invisible to its own user until a host reviewer approves; the approved version then mounts natively in place, riding the existing hash-pinned in-client approval machinery.

## What this adds

**Review-kind gating in open/venue logic** (`packages/apps`)
- `PinBaseline.review` — the kind is capture metadata; W1a's sync already writes it from `<Remixable review>`, this types it through the runtime.
- New `review.ts`: the review lifecycle over `inclient.ts`. Kind detection, serve-doc selection, venue vocabulary, rejections, queue.
- `open()` on an unapproved review-kind version answers `inClient: { granted: false, reason: "pending-review", review: <standing> }` and ships **no executable source** — no `components`, no `componentTools`, no jail furnishings, no resolved query data — so a jailed fork render cannot occur even on a client that ignores the venue state. The client keeps the ORIGINAL host component in place.
- **Newest-approved-version rendering**: when the current version is unapproved, `open()` serves the newest approved version from the existing history (`history.documents` — content is never re-minted) with `granted: true` for *that* hash, plus a `review` rider carrying the pending version's standing. After an edit, the last approved version keeps rendering until the new one is approved; approving the new version swaps it in. An approval whose version left the capped history fails closed to pending — never the jail.

**Rejection** (`POST /apps/:id/reject-review { note }`)
- Note required (4xx without). Records `{appId, versionHash, note, by, at}` in the routed collection `vendo_remix_rejections`; the note rides the venue state (`review: { status: "rejected", note, … }`) that the user's panel reads, and the audit event lands under the **owner's** subject so it is loud in the remixing user's activity. The work is not deleted; a new version supersedes the rejection and the resubmission count increments. `delete` clears an app's rejection records alongside its approvals.

**Review seam for the console** (`GET /apps/review-queue`)
- Lists pending review-kind versions with requester, slot, versionHash, submittedAt, resubmission count, and the ship-diff payload (the review artifact), oldest submission first.
- Host-admin scoped on the same principal bar as the existing in-client approval seam (`wire/misc.ts`): reviewing is a HOST trust decision, so a caller without a host-resolved principal gets an empty queue (masked) and `reject-review` answers the same not-found an unowned app answers. No new auth concept; the runtime `review` surface documents (like `history()`) that the wire layer owns this scoping.
- Approve stays the existing approval record door — untouched.

**Client floor** (`packages/ui`)
- `wire-types.ts` mirrors the venue vocabulary (`ReviewStanding`, the `pending-review` variant, the granted `review` rider) for W1b/W1d to consume.
- `tree/renderer.tsx`: a `pending-review` payload renders its standing — "Sent for review", or the reviewer's rejection note — using the existing `ContainedNotice` idiom, instead of mis-firing the "approval invalidated" drop-back notice and painting skeletons of the stripped components. The drop-back notice is now scoped to its own reason (`version-changed`). The in-place ✦ affordance and panel chrome land with W1b, which reads these states.

## Proof (tests with the code)

- `packages/apps/src/review.test.ts` (11 tests): pending state + no executable source; instant-kind regression untouched; approve → native for that hash; edit → last approved keeps rendering with pending rider; approve new → swaps; history-fell-off fails closed; reject requires note / refuses non-review-kind + approved + unknown; note surfaces + queue drops + owner-subject audit; resubmission increments; delete clears rejections; queue shape incl. ship-diff.
- `packages/vendo/src/review.fixture.test.ts` (E2E through the real umbrella): real `vendo sync` captures `<Remixable review>` → wire fork → pending + original → reviewer queue (with ship-diff) → anonymous caller masked (`[]` / 404) → noteless reject 400 → reject → note in user's venue state → edit resubmits (count 1) → dev-seam approval → native mount → edit keeps last-approved rendering → approve swaps.

## Notes for reviewers

- Kind follows the CURRENT capture by slot (like drift detection): flipping a component to `review` in the wrapper immediately gates unapproved forks; removing the wrapper returns them to instant/jail semantics with the drift report loud.
- The reviewer race (user edits between queue fetch and approve/reject) resolves to the CURRENT version by design — the frozen contract keeps approve as the record door keyed to a hash, and a mismatched hash simply never mounts.
- Thread-stream previews of an in-progress edit are unchanged (out of scope per the plan: no change to generation or the edit dialect); the review gate binds `open()`, the venue verdict, and every surface that rides them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a review lifecycle for remixable components: forks from `review`-kind baselines are invisible to their authors until approved; approved versions mount natively in place. Unapproved versions ship no executable source, and the server serves the newest approved version instead.

- New Features
  - Review-kind detection via `PinBaseline.review`, with lifecycle in `review.ts` over in-client approvals.
  - `open()` returns `pending-review` for unapproved review-kind versions and ships no executable source. When a newer version is pending, the newest approved version keeps rendering; approval swaps it in. If an approval’s hash fell out of history, it fails closed to pending.
  - Review seam: `GET /apps/review-queue` (host-admin scoped) lists pending review-kind versions with requester, slot, `versionHash`, `submittedAt`, resubmissions, and `shipDiff`.
  - Rejections: `POST /apps/:id/reject-review { note }` records the note in `vendo_remix_rejections`, surfaces it via `inClient.review` (status `rejected`), drops the item from the queue, audits under the owner, and keeps the work. Edits supersede the rejection and increment resubmissions. `delete` clears rejections.
  - UI: `pending-review` renders a standing notice (“Sent for review” or the reviewer’s note) and never jails or shows skeletons; the drop-back notice now only appears for `version-changed`. `wire-types` mirrors the new `ReviewStanding` and `inClient.review` rider.

<sup>Written for commit b91a60201980eb35bf6a3ba24e2cbd84afb9632a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

