### PR TITLE
remix W1c triage: review seam is dev-composition scoped + venue rider fixes

### DIFF
--- a/packages/apps/src/review.test.ts
+++ b/packages/apps/src/review.test.ts
@@ -164,6 +164,37 @@ describe("approval swaps the served version", () => {
     expect((swapped.payload as { inClient?: { review?: unknown } }).inClient?.review).toBeUndefined();
   });
 
+  it("keeps the pending rider when the served approved version predates the review-kind fork", async () => {
+    // v1 has NO pins at all — approved as a plain app. The review-kind fork
+    // arrives in v2. The venue must still say "sent for review" even though
+    // the SERVED document carries no review-kind pin of its own.
+    const { store, runtime } = setup();
+    const v1 = doc("transfer-panel", {
+      pins: undefined,
+      tree: {
+        formatVersion: "vendo-genui/v2",
+        root: "root",
+        nodes: [{ id: "root", component: "Stack", source: "prewired" }],
+      },
+      components: undefined,
+    });
+    await seedAppRow(store, v1, owner.principal.subject);
+    await runtime.inClient.approve({ appId: v1.id, approvedBy: "host-console" }, owner);
+    const v1Hash = appVersionHash(await runtime.get(v1.id, owner) as AppDocument);
+
+    const forked = await runtime.pins.fork({ appId: v1.id, slot: "transfer-panel" }, owner);
+    const v2Hash = appVersionHash(forked.app);
+    expect(v2Hash).not.toBe(v1Hash);
+
+    const surface = await runtime.open(v1.id, owner);
+    if (surface.kind !== "tree") throw new Error("expected tree surface");
+    expect((surface.payload as { inClient?: unknown }).inClient).toMatchObject({
+      granted: true,
+      versionHash: v1Hash,
+      review: { status: "pending", versionHash: v2Hash },
+    });
+  });
+
   it("an approval whose version left the capped history fails closed to pending-review, never the jail", async () => {
     const store = memoryStore();
     const approvals = createInClientApprovals(store);
@@ -214,6 +245,15 @@ describe("rejection", () => {
 
     await expect(runtime.review.reject({ appId: "app_missing", note: "no" }, reviewer))
       .rejects.toMatchObject({ code: "not-found" });
+  });
+
+  it("refuses a second rejection of the same version — the count stays honest", async () => {
+    const { store, runtime } = setup();
+    const app = doc("transfer-panel");
+    await seedAppRow(store, app, owner.principal.subject);
+    await runtime.review.reject({ appId: app.id, note: "First note." }, reviewer);
+    await expect(runtime.review.reject({ appId: app.id, note: "Second note." }, reviewer))
+      .rejects.toMatchObject({ code: "conflict" });
   });
 
   it("records the note, surfaces it to the user, drops the version from the queue, and audits under the owner", async () => {

--- a/packages/apps/src/review.ts
+++ b/packages/apps/src/review.ts
@@ -156,11 +156,15 @@ export const createReviewLifecycle = (deps: ReviewLifecycleDeps): ReviewLifecycl
 
   const venueStateFor = async (doc: AppDocument): Promise<InClientVenueState | undefined> => {
     const base = await deps.approvals.venueStateFor(doc);
-    if (!isReviewKind(doc)) return base;
-    // The opener may be serving an older approved snapshot (serveDocFor), so
-    // the review standing speaks about the CURRENT stored version.
+    // The kind — and the standing — belong to the CURRENT stored version: the
+    // opener may be serving an older approved snapshot whose own pins predate
+    // the review-kind fork, and deciding from the served document would
+    // silently drop the "sent for review" indicator. A granted serve is the
+    // one case where the snapshot's kind can differ, so it re-reads too.
+    if (!isReviewKind(doc) && base?.granted !== true) return base;
     const record = await deps.store.records("vendo_apps").get(doc.id);
     const current = record === null ? doc : classifyLegacyPlacements(documentFromRecord(record), deps.baselines);
+    if (!isReviewKind(current)) return base;
     const currentHash = appVersionHash(current);
     if (base?.granted === true) {
       if (base.versionHash === currentHash) return base;
@@ -208,7 +212,9 @@ export const createReviewLifecycle = (deps: ReviewLifecycleDeps): ReviewLifecycl
           slot,
           versionHash,
           submittedAt: record.updatedAt,
-          resubmissions: (await rejectionsFor(doc.id)).length,
+          // Distinct rejected VERSIONS, not rejection rows: one resubmission
+          // per superseded rejection even if legacy rows doubled up.
+          resubmissions: new Set((await rejectionsFor(doc.id)).map((rejection) => rejection.versionHash)).size,
           shipDiff: computeShipDiff(doc, baselines()),
         });
       }
@@ -227,6 +233,11 @@ export const createReviewLifecycle = (deps: ReviewLifecycleDeps): ReviewLifecycl
       const versionHash = appVersionHash(doc);
       if ((await deps.approvals.verdictFor(doc)).granted) {
         throw new VendoError("conflict", `version ${versionHash} is already approved`);
+      }
+      // A rejected version already left the queue — a second note for the
+      // same version would only inflate the resubmission count.
+      if ((await standingFor(doc.id, versionHash)).status === "rejected") {
+        throw new VendoError("conflict", `version ${versionHash} is already rejected`);
       }
       const rejection = remixRejectionSchema.parse({
         appId: doc.id,

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -643,7 +643,13 @@ function StatefulTreeView({
 
   // 06-apps §9 — a version change under an existing approval must be LOUD: the
   // surface drops back to the sandbox and says so, in-surface, above the tree.
-  const dropBackNotice = inClient !== undefined && inClient.granted === false && inClient.reason === "version-changed"
+  // Every ungranted reason except review-kind's pending-review (returned
+  // above) keeps this notice, so an unknown future reason still says
+  // SOMETHING rather than silently jailing.
+  const dropBackNotice = inClient !== undefined && inClient.granted === false
+    // Widened: the payload is a wire value, so a FUTURE ungranted reason this
+    // union does not know yet must still drop back loudly, not silently jail.
+    && (inClient.reason as string) !== "pending-review"
     ? (
       <ContainedNotice label="In-client approval invalidated" outcome="blocked">
         This app changed since it was approved for the host page. It is running in the sandbox again until the new version is re-approved.

--- a/packages/vendo/src/review.fixture.test.ts
+++ b/packages/vendo/src/review.fixture.test.ts
@@ -162,6 +162,19 @@ export default function Page() {
     const masked = await vendo.handler(request("GET", "/apps/review-queue"));
     expect(masked.status).toBe(200);
     expect(await masked.json()).toEqual([]);
+    // The seam carries the in-client approval seam's FULL scoping: outside a
+    // development composition it is masked for EVERY caller — production
+    // reviews ride Cloud's console or the self-hoster's own admin route over
+    // the runtime surface, never this door.
+    const production = createVendo({
+      principal: async (req): Promise<Principal | null> => {
+        const subject = req.headers.get(USER_HEADER);
+        return subject === null ? null : { kind: "user", subject };
+      },
+      store,
+    });
+    expect(await (await production.handler(request("GET", "/apps/review-queue", { as: reviewer }))).json()).toEqual([]);
+    expect((await production.handler(request("POST", `/apps/${appId}/reject-review`, { as: reviewer, body: { note: "nope" } }))).status).toBe(404);
 
     // 4. Rejection: the note is required; an anonymous caller is masked out.
     const noteless = await vendo.handler(request("POST", `/apps/${appId}/reject-review`, { as: reviewer, body: {} }));

--- a/packages/vendo/src/wire/apps.ts
+++ b/packages/vendo/src/wire/apps.ts
@@ -84,15 +84,19 @@ export const appRoutes: RouteEntry[] = [
   // Remix final shape (2026-08-02) — the review seam for the host's console:
   // every review-kind version awaiting a reviewer, with requester, slot,
   // version hash, submission time, resubmission count and the ship-diff
-  // payload. Host-admin scoped on the SAME principal bar as the in-client
-  // approval seam (wire/misc.ts): reviewing is a HOST trust decision, so a
-  // caller without a host-resolved principal gets an EMPTY queue — masked,
-  // never a probe into other subjects' pending work. Like fork-pin above,
-  // this entry must stay ahead of the "/apps/:appId/*" catch-all, whose rest
-  // pattern would otherwise capture appId="review-queue".
+  // payload. It crosses owner boundaries, so it carries the FULL scoping of
+  // the in-client approval seam (wire/misc.ts): a development composition AND
+  // a host-resolved principal — reviewing is a HOST trust decision, and in
+  // production no OSS wire surface may expose one subject's pending fork
+  // source to another. Any other caller gets an EMPTY queue — masked, never
+  // a probe. Production reviews ride Cloud's console, or the self-hoster's
+  // own admin-authenticated route over the runtime surface (apps.review).
+  // Like fork-pin above, this entry must stay ahead of the "/apps/:appId/*"
+  // catch-all, whose rest pattern would otherwise capture
+  // appId="review-queue".
   route("GET", "/apps/review-queue", async ({ deps, context }) => {
     const ctx = await context("app");
-    if (ctx.principal.ephemeral === true) return json([]);
+    if (!deps.development || ctx.principal.ephemeral === true) return json([]);
     return json(await deps.apps.review.queue());
   }),
   route("POST", "/apps/import", async ({ request, deps, context }) => {
@@ -217,11 +221,12 @@ export const appRoutes: RouteEntry[] = [
     // CURRENT review-kind version: the note is REQUIRED (it is what the
     // user's panel surfaces) and the work is not deleted — a new version
     // supersedes the rejection. Reviewer-side and cross-subject by design,
-    // so it carries the review seam's host-admin principal bar instead of
-    // owner scoping: a caller without a host-resolved principal gets the
-    // same not-found an unowned app answers (masked).
+    // so it carries the review queue's full scoping (development composition
+    // + host-resolved principal, the in-client approval seam's bar) instead
+    // of owner scoping; any other caller gets the same not-found an unowned
+    // app answers (masked).
     if (request.method === "POST" && operation === "reject-review" && segments.length === 3) {
-      if (ctx.principal.ephemeral === true) {
+      if (!deps.development || ctx.principal.ephemeral === true) {
         throw new VendoError("not-found", `app not found: ${appId}`);
       }
       const body = await requestJson(request);


### PR DESCRIPTION
Batched triage of the AI reviews on #731 — auto-merge fired on green CI before the batch could ride the same PR, so it lands here immediately.

## Fixes

- **Security (Devin 🟥 + Greptile P1, live-probed):** `GET /apps/review-queue` and `POST /apps/:id/reject-review` were gated only on a host-resolved principal, so any durable signed-in user could list every other subject's pending fork source (ship-diff payloads) and reject their work. They now carry the in-client approval seam's FULL scoping (`wire/misc.ts`): **development composition AND host-resolved principal** — outside development the wire masks (empty queue / the same not-found an unowned app answers). Production reviews ride Cloud's console, or the self-hoster's own admin-authenticated route over the runtime surface (`apps.review`) — exactly the posture the approve door already has ("no production surface can self-approve"). E2E extended with a production-composition probe.
- **Venue rider drop (Devin 🟡):** the review standing is now decided from the CURRENT stored version, not the served document — a served approved version that predates the review-kind fork no longer loses the "sent for review" indicator. New test covers the approve-then-fork sequence.
- **Resubmission inflation (Devin):** rejecting an already-rejected version refuses with a conflict, and the queue counts distinct rejected versions.
- **Renderer forward-compat (Devin):** the drop-back notice fires for every ungranted reason except `pending-review`, so an unknown future reason still says something instead of silently jailing.

## Answered without code change (on #731)

- Queue scan cost / no pagination: now dev-composition-only; OSS dev scale. Cloud's console reads its own store.
- Pending payload retains stored tree `data`/query declarations: model-authored document content owned by the same user; no resolved host data and no executable source travels.
- `call()` resolves against the current document while an older version renders: pre-existing `call()` semantics; host-tool refs stay guard-bound. Flagged to the driving session as a known edge.
- Missing `.vendo/remixable` baselines un-gate review→instant: kind is capture metadata by frozen contract (`Pin {slot, base}` is frozen); the sandboxed iframe remains the security boundary in that misconfiguration.

Gates: apps 795 passed, ui 695 passed, vendo review E2E green; typecheck 41/41, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/runvendo/vendo/pull/733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened security on review endpoints to prevent cross-tenant access and fixed review state so pending indicators persist correctly. Renderer now shows a clear drop-back notice for all ungranted reasons except `pending-review`.

- **Bug Fixes**
  - Secured `GET /apps/review-queue` and `POST /apps/:id/reject-review` behind development composition and a host-resolved principal. In production, the queue is masked (empty) and reject returns not-found; reviews go via Cloud console or an admin route over `apps.review`.
  - Review standing now derives from the current stored version, not the served snapshot, so a served pre-fork approval still shows “sent for review.”
  - Rejecting an already-rejected version returns conflict; resubmission count now tracks distinct rejected versions.
  - UI: show the drop-back notice for all ungranted reasons except `pending-review` to avoid silent jailing.

<sup>Written for commit 1dbaeb2852665e8f692ea8995cf74ca31c81c48e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

