### PR TITLE
cloud audit: small fixes (tick sweep, sessions-404 bookkeeping, fn: warn+docs, doctor copy, e2b misconfig)

### DIFF
--- a/.changeset/cloud-audit-small-fixes.md
+++ b/.changeset/cloud-audit-small-fixes.md
@@ -1,0 +1,36 @@
+---
+"@vendoai/vendo": patch
+"@vendoai/automations": patch
+---
+
+Cloud-audit small fixes: five places where the runtime and what it claims had
+drifted apart.
+
+**The hosted session sweep now rides the authenticated tick.** Both existing
+cadences are unreachable on a serverless host — the unref'd interval timer
+never fires, and the amortized on-request sweep is gated by a per-process
+`lastSweepAt` that a per-request process re-seeds every invocation. A
+deployment on the hosted store leaked idle anonymous sessions forever.
+`POST /api/vendo/tick` now runs the same sweep the other two cadences call
+(hosted stores only; a local composition already has both). Two cadences
+firing at once is safe — the claim leg is a single-winner election
+server-side.
+
+**`E2B_API_KEY` without the `e2b` package is now a loud misconfig.**
+`createVendo` used to silently demote a half-configured BYO sandbox to Cloud,
+or to the dark venue with no key at all, so the operator found out at the
+first server-app build. It now throws with the exact fix. An explicitly
+passed `sandbox:` adapter still wins before any env check.
+
+**`fn:` steps deferred to Cloud now warn.** Enabling an automation whose
+schedule or external trigger fires on Cloud, with `fn:` steps in it, warns
+once naming the app: `fn:` runs in the app's own sandbox machine, which the
+Cloud runner may not be able to wake or reach in v1. The docs claimed this
+warning existed and described `fn:` as a callback into the host process —
+both wrong, both fixed.
+
+**Two honesty fixes to operator copy.** `vendo doctor` no longer offers a
+"managed MCP broker" no code path wires from a key; it names the adapter slots
+a key actually defaults. And the hosted-session-doors warning no longer blames
+a vendo-web commit for a surface the console restored on 2026-07-20 — it
+reports what the client observed (a bare 404) instead.

--- a/docs-site/deploy/vendo-cloud.mdx
+++ b/docs-site/deploy/vendo-cloud.mdx
@@ -163,15 +163,27 @@ API keys use the format `vnd_` followed by 40 hex characters. `vendo init
 --cloud-key` rejects a malformed key before writing it; `vendo doctor` warns
 on one already in the environment. Neither makes a network call to do so.
 
-### The `fn:` limitation for synced automations
+### The `fn:` limitation for Cloud-fired automations
 
-Automations whose steps use `fn:` tools (calls back into the host
-application's process) warn on sync. Hosted sandboxes cannot reach your
-machine in v1, so those steps will fail or park when the automation fires
-in the cloud. Either replace them with tools the hosted runtime can
-execute, or pass an explicit local `store:` (see the warning above) to keep
-that composition's schedule- and external-trigger automations firing on
-your own machine instead of Cloud's.
+A `fn:` step is not a call back into your host process — it is an HTTP call
+into the generated app's **own sandbox machine** (`POST /fn/<name>`). When
+your composition fires the automation itself, that machine is one it just
+woke. When Cloud fires it (schedule and external triggers under the hosted
+store), the Cloud runner is the one that has to wake and reach the machine,
+and in v1 it may not be able to; a step that cannot reach a machine settles
+as an error outcome for that step, not a crashed run.
+
+Enabling such an automation warns once, naming the app:
+
+```
+[vendo] automation "Weekly digest" has fn: steps but its schedule trigger
+fires on Vendo Cloud, not in this process: ...
+```
+
+Either replace the `fn:` steps with host tools the Cloud runner can execute,
+or pass an explicit local `store:` (see the warning above) to keep that
+composition's schedule- and external-trigger automations firing on your own
+machine instead of Cloud's.
 
 ### Hosted sandboxes
 

--- a/docs/persistence-and-deploy.md
+++ b/docs/persistence-and-deploy.md
@@ -82,9 +82,9 @@ JOIN vendo_records r
 
 `subject` is the only partition axis. Ephemeral (anonymous) principals write ordinary rows under their subject; a TTL sweep erases sessions idle past `sessions.ttlMs`.
 
-On the Cloud hosted store the session doors are currently unavailable (the
-console removed `/api/v1/store/sessions/*`); the composition detects this,
-warns once, and disables anonymous-session registration, the
+If a Cloud console deployment does not serve the session doors
+(`/api/v1/store/sessions/*` answering a bare 404), the composition detects
+this, warns once, and disables anonymous-session registration, the
 anonymous→signed-in merge, and the hosted TTL sweep for the process.
 Anonymous traffic keeps serving. Local stores are unaffected.
 

--- a/docs/verification/existing-agents/polish/hosted-sessions-404.md
+++ b/docs/verification/existing-agents/polish/hosted-sessions-404.md
@@ -1,5 +1,12 @@
 # Hosted-store session sweep 404 — findings + flowlet fix (Polish Lane B)
 
+**STATUS: HEALED** — the console restored the doors over the `end_user` model
+(vendo-web #88, `b37dceea`, 2026-07-20); live-verified against prod 2026-08-02
+(all four doors 200, `adopt` returned a merge report). The latch described
+below is dormant and self-re-arming: it is per-process, trips only on a bare
+404, and needs no client change if the doors ever go away again. Everything
+from here down is the historical record of the outage.
+
 **PROD-IMPACT.** Until this branch lands, any keyed host (Cloud hosted store)
 serving anonymous traffic hard-fails those requests in prod: the first
 session registration fails closed against a route the console no longer

--- a/packages/automations/src/engine.test.ts
+++ b/packages/automations/src/engine.test.ts
@@ -1115,6 +1115,68 @@ describe("localTriggerKinds: deferring schedule/external firing to another autho
     expect(ids).toHaveLength(1);
     expect((await store.records("vendo_runs").list()).records).toHaveLength(1);
   });
+
+  // Cloud-audit fix 3. A fn: step is an HTTP call into the APP's own sandbox
+  // machine (packages/apps/src/fn.ts POSTs /fn/<name>), so the authority that
+  // fires the trigger is the one that has to wake and reach that machine. When
+  // this engine defers firing to Cloud, whether Cloud can do that is not
+  // knowable here — so the operator hears about it at the arming point, which
+  // is the only place that sees both the trigger kind and the steps.
+  describe("fn: steps deferred to another firing authority warn at enable()", () => {
+    const enableWithWarn = async (
+      doc: AppDocument,
+      localTriggerKinds?: ReadonlySet<"schedule" | "external">,
+    ): Promise<string[]> => {
+      const store = memoryStoreAdapter();
+      await seedApp(store, doc);
+      const engine = createAutomations({
+        apps: appsDouble(), tools: registry([readTool]), guard: new GuardDouble(), store, now: () => NOW,
+        ...(localTriggerKinds === undefined ? {} : { localTriggerKinds }),
+      });
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      try {
+        await engine.enable(doc.id, ctx());
+        return warn.mock.calls
+          .map(([message]) => (typeof message === "string" ? message : ""))
+          .filter((message) => message.includes("fn: steps"));
+      } finally {
+        warn.mockRestore();
+      }
+    };
+
+    it("warns, naming the app and the deferred trigger kind", async () => {
+      const warns = await enableWithWarn(app("app_fn_cloud", {
+        on: { kind: "schedule", every: "15m" },
+        run: { kind: "steps", steps: [{ id: "run", tool: "fn:main" }] },
+      }, "Weekly digest"), new Set());
+
+      expect(warns).toHaveLength(1);
+      expect(warns[0]).toContain("Weekly digest");
+      expect(warns[0]).toContain("schedule");
+      expect(warns[0]).toContain("sandbox machine");
+    });
+
+    it("stays silent for a deferred automation whose steps are all host tools", async () => {
+      expect(await enableWithWarn(app("app_tools_cloud", {
+        on: { kind: "external", connector: "github", event: "push" },
+        run: { kind: "steps", steps: [{ id: "handle", tool: readTool.name }] },
+      }), new Set())).toEqual([]);
+    });
+
+    it("stays silent when this engine fires the trigger itself — the machine is one it wakes", async () => {
+      expect(await enableWithWarn(app("app_fn_local", {
+        on: { kind: "schedule", every: "15m" },
+        run: { kind: "steps", steps: [{ id: "run", tool: "fn:main" }] },
+      }))).toEqual([]);
+    });
+
+    it("stays silent for host-event automations, which are never deferred", async () => {
+      expect(await enableWithWarn(app("app_fn_host", {
+        on: { kind: "host-event", event: "invoice.paid" },
+        run: { kind: "steps", steps: [{ id: "run", tool: "fn:main" }] },
+      }), new Set())).toEqual([]);
+    });
+  });
 });
 
 describe("dry runs, run visibility, agentic execution, and stopping", () => {

--- a/packages/automations/src/engine.ts
+++ b/packages/automations/src/engine.ts
@@ -1065,6 +1065,21 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
     const found = await ownedApp(appId, ctx.principal.subject);
     if (found.row.doc.trigger === undefined) throw new VendoError("validation", "app has no trigger");
     const trigger = validateTrigger(found.row.doc.trigger);
+    // fn: steps run in the APP's own sandbox machine (packages/apps/src/fn.ts
+    // POSTs /fn/<name> to it), not in this process — so when some other
+    // authority fires this trigger, that authority is the one that has to wake
+    // and reach the machine, and in v1 it may not be able to. Arming is the
+    // only point that sees both the trigger kind and the steps.
+    if (trigger.on.kind !== "host-event" && !firesLocally(trigger.on.kind)
+      && trigger.run.kind === "steps"
+      && trigger.run.steps.some((step) => step.tool.startsWith("fn:"))) {
+      console.warn(
+        `[vendo] automation "${found.row.doc.name}" has fn: steps but its ${trigger.on.kind} trigger fires on Vendo Cloud, `
+        + "not in this process: fn: steps run in the app's own sandbox machine, which the Cloud runner may not be able to "
+        + "wake or reach in v1 (those steps then settle as an error outcome). Replace them with host tools, or pass an "
+        + "explicit local `store:` to createVendo to keep this composition firing its own schedule and external triggers.",
+      );
+    }
     const byName = await descriptors();
     const surface = trigger.run.kind === "steps"
       ? [...new Set(trigger.run.steps.map((step) => step.tool).filter((tool) => !tool.startsWith("fn:")))]

--- a/packages/vendo/src/cli/doctor-live.ts
+++ b/packages/vendo/src/cli/doctor-live.ts
@@ -162,7 +162,7 @@ export const CLOUD_UNLOCKS: readonly string[] = [
   "a free dev-mode starter model allowance (keyless first turns)",
   "team sharing and org governance (roles, SSO)",
   "hosted deploys of your enabled automations",
-  "registry publishing and hosted infrastructure defaults like the managed MCP broker",
+  "registry publishing, and hosted defaults for the adapter slots you leave unset (managed inference, the sandbox pool, the hosted store, the connections broker)",
 ];
 
 export interface CloudDoctorResult {

--- a/packages/vendo/src/cli/doctor.ts
+++ b/packages/vendo/src/cli/doctor.ts
@@ -453,11 +453,8 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
             ...(keyPresent ? [] : ["E2B_API_KEY is not set"]),
             ...(installed ? [] : ["the e2b package does not resolve from this project"]),
           ].join(" and ");
-          // Still reachable after the cloud-audit fix that made selectSandbox
-          // THROW on a key without the package: this check reads doctor's own
-          // env and project root, not the server's. A live e2b venue failing
-          // here now means the two disagree (different shell, different root),
-          // which is exactly the case doctor must not silently bless.
+          // This reads doctor's OWN env and project root, not the server's, so
+          // a live e2b venue failing here means the two disagree.
           fail("live/venue", "E-LIVE-007", `the running wire selected the e2b execution venue but ${missing}; server-app builds will fail in an unusable sandbox. Fix: install the e2b package and set E2B_API_KEY, or remove E2B_API_KEY from the server env (with VENDO_API_KEY set, the managed Cloud sandbox takes over), then restart the dev server and re-run doctor`);
         }
       } else if (sandboxVenue === "cloud" || sandboxVenue === "custom") {

--- a/packages/vendo/src/cli/doctor.ts
+++ b/packages/vendo/src/cli/doctor.ts
@@ -453,6 +453,11 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
             ...(keyPresent ? [] : ["E2B_API_KEY is not set"]),
             ...(installed ? [] : ["the e2b package does not resolve from this project"]),
           ].join(" and ");
+          // Still reachable after the cloud-audit fix that made selectSandbox
+          // THROW on a key without the package: this check reads doctor's own
+          // env and project root, not the server's. A live e2b venue failing
+          // here now means the two disagree (different shell, different root),
+          // which is exactly the case doctor must not silently bless.
           fail("live/venue", "E-LIVE-007", `the running wire selected the e2b execution venue but ${missing}; server-app builds will fail in an unusable sandbox. Fix: install the e2b package and set E2B_API_KEY, or remove E2B_API_KEY from the server env (with VENDO_API_KEY set, the managed Cloud sandbox takes over), then restart the dev server and re-run doctor`);
         }
       } else if (sandboxVenue === "cloud" || sandboxVenue === "custom") {

--- a/packages/vendo/src/hosted-sessions.test.ts
+++ b/packages/vendo/src/hosted-sessions.test.ts
@@ -585,4 +585,52 @@ describe("hosted store: a failed erase after a claim does not strand the subject
     expect(h.console_.eraseCalls).toContainEqual({ subject });
     expect(h.console_.sessions.has(subject)).toBe(false);
   });
+
+  // Checker round 2. The compensation writes a BACKDATED stamp, so it is only
+  // safe because the console's register/touch never moves a subject's stamp
+  // backward (vendo-web session-registry.ts bumps under `last_seen < seenAt`;
+  // the fake console mirrors that clamp). This pins the client's half of that
+  // contract: the sweep may write the backdated stamp unconditionally, and a
+  // visitor who returned mid-sweep must still come out alive.
+  it("keeps a returning visitor's fresh touch when the compensation lands after it", async () => {
+    let subject = "";
+    const h = harness({ ttlMs: 1_000, sweepIntervalMs: 100 }, (inner) =>
+      async (input, init) => {
+        const request = new Request(input, init);
+        if (!new URL(request.url).pathname.endsWith("/erase")) return inner(input, init);
+        // The race: the claim already deleted the row, the visitor comes back
+        // and re-registers at the current clock, and only THEN does the erase
+        // fail and the compensation write its backdated stamp.
+        await inner(new Request("https://cloud-sessions.test/api/v1/store/sessions/register", {
+          method: "POST",
+          headers: { "content-type": "application/json", authorization: "Bearer vnd_hosted_key" },
+          body: JSON.stringify({ subject, now: 5_000 }),
+        }));
+        return Response.json(
+          { error: { code: "unavailable", message: "erase cascade blip" } },
+          { status: 503 },
+        );
+      });
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    h.setNow(0);
+    expect((await h.vendo.handler(listThreads())).status).toBe(200);
+    subject = (h.wireCalls("/sessions/register")[0]!.json as { subject: string }).subject;
+
+    h.setNow(5_000);
+    expect((await h.vendo.handler(listThreads())).status).toBe(200);
+    expect(h.wireCalls("/sessions/claim")).toHaveLength(1);
+
+    // The visitor's fresh stamp won: the backdated compensation did not
+    // regress it, so the session is live, not one cutoff away from erasure.
+    expect(h.console_.sessions.get(subject)).toBe(5_000);
+
+    // Proof it matters: a sweep inside the TTL of that fresh touch leaves the
+    // subject alone. Without the clamp the compensation would have stamped it
+    // at 3_999 and this pass would erase a session in use.
+    h.setNow(5_500);
+    expect((await h.vendo.handler(listThreads())).status).toBe(200);
+    expect(h.console_.eraseCalls).toEqual([]);
+    expect(h.console_.sessions.has(subject)).toBe(true);
+  });
 });

--- a/packages/vendo/src/hosted-sessions.test.ts
+++ b/packages/vendo/src/hosted-sessions.test.ts
@@ -438,14 +438,19 @@ describe("hosted store: the authenticated tick drives the session sweep", () => 
     const first = await h.vendo.handler(listThreads());
     expect(first.status).toBe(200);
     const staleSubject = (h.wireCalls("/sessions/register")[0]!.json as { subject: string }).subject;
-
-    // Past the TTL, but nowhere near a sweep interval: no request-driven sweep.
-    h.setNow(5_000);
     expect(h.wireCalls("/sessions/stale")).toHaveLength(0);
 
-    const ticked = await tick(h.vendo);
-    expect(ticked.status).toBe(200);
-    expect(h.wireCalls("/sessions/stale")[0]!.json).toEqual({ idleMs: 1_000, now: 5_000 });
+    // Inside the TTL: the tick lists candidates and finds nothing to claim.
+    h.setNow(500);
+    expect((await tick(h.vendo)).status).toBe(200);
+    expect(h.wireCalls("/sessions/stale")).toHaveLength(1);
+    expect(h.wireCalls("/sessions/claim")).toHaveLength(0);
+    expect(h.console_.eraseCalls).toEqual([]);
+
+    // Past it, still nowhere near a sweep interval: only the forced pass runs.
+    h.setNow(5_000);
+    expect((await tick(h.vendo)).status).toBe(200);
+    expect(h.wireCalls("/sessions/stale").at(-1)!.json).toEqual({ idleMs: 1_000, now: 5_000 });
     expect(h.wireCalls("/sessions/claim")[0]!.json).toEqual({
       subject: staleSubject,
       idleMs: 1_000,
@@ -453,6 +458,17 @@ describe("hosted store: the authenticated tick drives the session sweep", () => 
     });
     expect(h.console_.eraseCalls).toEqual([{ subject: staleSubject }]);
     expect(h.console_.sessions.has(staleSubject)).toBe(false);
+
+    // A second tick at the same clock adds nothing — the claim leg is a
+    // single-winner election on the console.
+    expect((await tick(h.vendo)).status).toBe(200);
+    expect(h.console_.eraseCalls).toHaveLength(1);
+
+    // …and an unauthenticated one drives no sweep at all.
+    const scans = h.wireCalls("/sessions/stale").length;
+    expect((await tick(h.vendo, "Bearer wrong")).status).toBe(401);
+    expect(h.wireCalls("/sessions/stale")).toHaveLength(scans);
+    expect(h.console_.eraseCalls).toHaveLength(1);
   });
 
   it("runs the registry scan ONCE per tick when the amortized leg also fires", async () => {
@@ -505,37 +521,6 @@ describe("hosted store: the authenticated tick drives the session sweep", () => 
       .toEqual([expect.stringContaining("sessions:")]);
   });
 
-  it("is idempotent across a second tick and never sweeps a live session", async () => {
-    vi.stubEnv("VENDO_TICK_SECRET", TICK_SECRET);
-    const h = harness({ ttlMs: 1_000, sweepIntervalMs: 10 ** 9 });
-    h.setNow(0);
-    expect((await h.vendo.handler(listThreads())).status).toBe(200);
-
-    // Inside the TTL: the tick lists candidates and finds nothing to claim.
-    h.setNow(500);
-    expect((await tick(h.vendo)).status).toBe(200);
-    expect(h.wireCalls("/sessions/stale")).toHaveLength(1);
-    expect(h.wireCalls("/sessions/claim")).toHaveLength(0);
-    expect(h.console_.eraseCalls).toEqual([]);
-
-    // Past it: one erase, and a second tick at the same clock adds nothing —
-    // the claim leg is a single-winner election on the console.
-    h.setNow(5_000);
-    expect((await tick(h.vendo)).status).toBe(200);
-    expect((await tick(h.vendo)).status).toBe(200);
-    expect(h.console_.eraseCalls).toHaveLength(1);
-  });
-
-  it("still refuses an unauthenticated tick", async () => {
-    vi.stubEnv("VENDO_TICK_SECRET", TICK_SECRET);
-    const h = harness({ ttlMs: 1_000, sweepIntervalMs: 10 ** 9 });
-    h.setNow(0);
-    expect((await h.vendo.handler(listThreads())).status).toBe(200);
-    h.setNow(5_000);
-    expect((await tick(h.vendo, "Bearer wrong")).status).toBe(401);
-    expect(h.wireCalls("/sessions/stale")).toHaveLength(0);
-    expect(h.console_.eraseCalls).toEqual([]);
-  });
 });
 
 // Checker round 1, finding 2. A hosted claim COMMITS by deleting the registry

--- a/packages/vendo/src/hosted-sessions.test.ts
+++ b/packages/vendo/src/hosted-sessions.test.ts
@@ -327,7 +327,7 @@ describe("hosted store: console without session doors (vendo-web@7cd0a02)", () =
     return { hits, wrap };
   };
 
-  it("keeps serving anonymous traffic: registration disables once, with ONE warn naming the removal", async () => {
+  it("keeps serving anonymous traffic: registration disables once, with ONE warn naming the bare 404", async () => {
     const doors = withoutDoors();
     const h = harness({ ttlMs: 3_600_000, sweepIntervalMs: 1_000 }, doors.wrap);
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
@@ -344,7 +344,7 @@ describe("hosted store: console without session doors (vendo-web@7cd0a02)", () =
     const doorWarns = warn.mock.calls.filter(([message]) =>
       typeof message === "string" && message.includes("session doors"));
     expect(doorWarns).toHaveLength(1);
-    expect(doorWarns[0]![0]).toContain("vendo-web@7cd0a02");
+    expect(doorWarns[0]![0]).toContain("bare 404");
     // The warn names every capability the process is giving up.
     expect(doorWarns[0]![0]).toContain("registration");
     expect(doorWarns[0]![0]).toContain("merge");
@@ -411,5 +411,78 @@ describe("hosted store: console without session doors (vendo-web@7cd0a02)", () =
     expect(doors.hits).not.toContain("adopt");
     expect(h.wireCalls("/records/vendo_audit/put").filter((request) =>
       JSON.stringify(request.json).includes("anon-merge"))).toHaveLength(0);
+  });
+});
+
+// Cloud-audit fix 1. Both existing sweep cadences are unreachable on a
+// serverless host: the interval timer is illegal/never fires, and the
+// amortized on-request sweep is gated by a per-PROCESS `lastSweepAt` that a
+// per-request process re-seeds every invocation. The authenticated tick is the
+// one cadence a serverless deployment does have.
+describe("hosted store: the authenticated tick drives the session sweep", () => {
+  const TICK_SECRET = "tick-secret-for-hosted-sessions";
+
+  const tick = (vendo: Vendo, authorization = `Bearer ${TICK_SECRET}`): Promise<Response> =>
+    vendo.handler(new Request("https://host.test/api/vendo/tick", {
+      method: "POST",
+      headers: { authorization },
+    }));
+
+  it("runs stale → claim → erase on tick, with the amortized on-request sweep throttled out", async () => {
+    vi.stubEnv("VENDO_TICK_SECRET", TICK_SECRET);
+    // A sweep interval far longer than the whole test pins maybeSweep shut, so
+    // every wire call below is attributable to the TICK leg alone.
+    const h = harness({ ttlMs: 1_000, sweepIntervalMs: 10 ** 9 });
+    h.setNow(0);
+    const first = await h.vendo.handler(listThreads());
+    expect(first.status).toBe(200);
+    const staleSubject = (h.wireCalls("/sessions/register")[0]!.json as { subject: string }).subject;
+
+    // Past the TTL, but nowhere near a sweep interval: no request-driven sweep.
+    h.setNow(5_000);
+    expect(h.wireCalls("/sessions/stale")).toHaveLength(0);
+
+    const ticked = await tick(h.vendo);
+    expect(ticked.status).toBe(200);
+    expect(h.wireCalls("/sessions/stale")[0]!.json).toEqual({ idleMs: 1_000, now: 5_000 });
+    expect(h.wireCalls("/sessions/claim")[0]!.json).toEqual({
+      subject: staleSubject,
+      idleMs: 1_000,
+      now: 5_000,
+    });
+    expect(h.console_.eraseCalls).toEqual([{ subject: staleSubject }]);
+    expect(h.console_.sessions.has(staleSubject)).toBe(false);
+  });
+
+  it("is idempotent across a second tick and never sweeps a live session", async () => {
+    vi.stubEnv("VENDO_TICK_SECRET", TICK_SECRET);
+    const h = harness({ ttlMs: 1_000, sweepIntervalMs: 10 ** 9 });
+    h.setNow(0);
+    expect((await h.vendo.handler(listThreads())).status).toBe(200);
+
+    // Inside the TTL: the tick lists candidates and finds nothing to claim.
+    h.setNow(500);
+    expect((await tick(h.vendo)).status).toBe(200);
+    expect(h.wireCalls("/sessions/stale")).toHaveLength(1);
+    expect(h.wireCalls("/sessions/claim")).toHaveLength(0);
+    expect(h.console_.eraseCalls).toEqual([]);
+
+    // Past it: one erase, and a second tick at the same clock adds nothing —
+    // the claim leg is a single-winner election on the console.
+    h.setNow(5_000);
+    expect((await tick(h.vendo)).status).toBe(200);
+    expect((await tick(h.vendo)).status).toBe(200);
+    expect(h.console_.eraseCalls).toHaveLength(1);
+  });
+
+  it("still refuses an unauthenticated tick", async () => {
+    vi.stubEnv("VENDO_TICK_SECRET", TICK_SECRET);
+    const h = harness({ ttlMs: 1_000, sweepIntervalMs: 10 ** 9 });
+    h.setNow(0);
+    expect((await h.vendo.handler(listThreads())).status).toBe(200);
+    h.setNow(5_000);
+    expect((await tick(h.vendo, "Bearer wrong")).status).toBe(401);
+    expect(h.wireCalls("/sessions/stale")).toHaveLength(0);
+    expect(h.console_.eraseCalls).toEqual([]);
   });
 });

--- a/packages/vendo/src/hosted-sessions.test.ts
+++ b/packages/vendo/src/hosted-sessions.test.ts
@@ -428,10 +428,11 @@ describe("hosted store: the authenticated tick drives the session sweep", () => 
       headers: { authorization },
     }));
 
-  it("runs stale → claim → erase on tick, with the amortized on-request sweep throttled out", async () => {
+  it("runs stale → claim → erase on tick when the interval gate would have skipped it", async () => {
     vi.stubEnv("VENDO_TICK_SECRET", TICK_SECRET);
-    // A sweep interval far longer than the whole test pins maybeSweep shut, so
-    // every wire call below is attributable to the TICK leg alone.
+    // The serverless shape: a process whose lastSweepAt was seeded THIS request,
+    // so the amortized pre-routing leg is throttled out and only the tick's
+    // forced pass can reclaim anything.
     const h = harness({ ttlMs: 1_000, sweepIntervalMs: 10 ** 9 });
     h.setNow(0);
     const first = await h.vendo.handler(listThreads());
@@ -452,6 +453,56 @@ describe("hosted store: the authenticated tick drives the session sweep", () => 
     });
     expect(h.console_.eraseCalls).toEqual([{ subject: staleSubject }]);
     expect(h.console_.sessions.has(staleSubject)).toBe(false);
+  });
+
+  it("runs the registry scan ONCE per tick when the amortized leg also fires", async () => {
+    vi.stubEnv("VENDO_TICK_SECRET", TICK_SECRET);
+    // The long-lived shape, with a realistic interval the tick's clock is well
+    // past: the pre-routing amortized sweep DOES fire on the tick request. The
+    // route must await that same pass, not open a second scan of the registry.
+    const h = harness({ ttlMs: 1_000, sweepIntervalMs: 100 });
+    h.setNow(0);
+    expect((await h.vendo.handler(listThreads())).status).toBe(200);
+
+    h.setNow(5_000);
+    expect((await tick(h.vendo)).status).toBe(200);
+    expect(h.wireCalls("/sessions/stale")).toHaveLength(1);
+    expect(h.wireCalls("/sessions/claim")).toHaveLength(1);
+    expect(h.console_.eraseCalls).toHaveLength(1);
+  });
+
+  it("answers 500 when the amortized pass failed, instead of quietly re-running it", async () => {
+    vi.stubEnv("VENDO_TICK_SECRET", TICK_SECRET);
+    // The amortized leg is allowed to swallow a sweep failure — an innocent
+    // request must not 500 for it. A TICK is not innocent: a cron that gets 200
+    // after a failed sweep never comes back, so the failure has to ride out.
+    // The failure is ONE-SHOT on purpose: with two passes per tick the first
+    // would fail into the warn and the second would succeed, handing the cron
+    // a clean 200 for the sweep that did not happen.
+    let failStale = true;
+    const h = harness({ ttlMs: 1_000, sweepIntervalMs: 100 }, (inner) =>
+      async (input, init) => {
+        const url = new URL(new Request(input, init).url);
+        if (failStale && url.pathname.endsWith("/sessions/stale")) {
+          failStale = false;
+          return Response.json(
+            { error: { code: "unavailable", message: "console blip" } },
+            { status: 503 },
+          );
+        }
+        return inner(input, init);
+      });
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    h.setNow(0);
+    expect((await h.vendo.handler(listThreads())).status).toBe(200);
+
+    // Interval elapsed: the pre-routing pass runs, fails, and warns — and the
+    // tick inherits that same rejection instead of reporting a clean run.
+    h.setNow(5_000);
+    const ticked = await tick(h.vendo);
+    expect(ticked.status).toBe(500);
+    expect((await ticked.json() as { errors: string[] }).errors)
+      .toEqual([expect.stringContaining("sessions:")]);
   });
 
   it("is idempotent across a second tick and never sweeps a live session", async () => {
@@ -484,5 +535,54 @@ describe("hosted store: the authenticated tick drives the session sweep", () => 
     expect((await tick(h.vendo, "Bearer wrong")).status).toBe(401);
     expect(h.wireCalls("/sessions/stale")).toHaveLength(0);
     expect(h.console_.eraseCalls).toEqual([]);
+  });
+});
+
+// Checker round 1, finding 2. A hosted claim COMMITS by deleting the registry
+// row, so an erase that fails after it would leave the subject's rows
+// unreachable by every later stale scan — silently stranded on the console.
+describe("hosted store: a failed erase after a claim does not strand the subject", () => {
+  it("re-registers the claimed subject so the next sweep retries it", async () => {
+    let failErase = true;
+    const h = harness({ ttlMs: 1_000, sweepIntervalMs: 100 }, (inner) =>
+      async (input, init) => {
+        const url = new URL(new Request(input, init).url);
+        if (failErase && url.pathname.endsWith("/erase")) {
+          return Response.json(
+            { error: { code: "unavailable", message: "erase cascade blip" } },
+            { status: 503 },
+          );
+        }
+        return inner(input, init);
+      });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    h.setNow(0);
+    const first = await h.vendo.handler(listThreads());
+    expect(first.status).toBe(200);
+    const subject = (h.wireCalls("/sessions/register")[0]!.json as { subject: string }).subject;
+
+    // Past the TTL: stale → claim → erase, and the erase fails.
+    h.setNow(5_000);
+    expect((await h.vendo.handler(listThreads())).status).toBe(200);
+    expect(h.wireCalls("/sessions/claim")).toHaveLength(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("session sweep failed"));
+
+    // The compensation: the registry row is BACK, stamped past the cutoff so
+    // the subject is stale again immediately rather than after another TTL.
+    expect(h.console_.sessions.has(subject)).toBe(true);
+    const registers = h.wireCalls("/sessions/register")
+      .map((request) => request.json as { subject: string; now: number })
+      .filter((body) => body.subject === subject);
+    expect(registers).toHaveLength(2);
+    expect(registers[1]!.now).toBeLessThan(5_000 - 1_000);
+
+    // Next sweep, console healthy: the subject is still reachable and erases.
+    failErase = false;
+    h.setNow(10_000);
+    expect((await h.vendo.handler(listThreads())).status).toBe(200);
+    expect(h.wireCalls("/sessions/stale").at(-1)!.json).toEqual({ idleMs: 1_000, now: 10_000 });
+    expect(h.console_.eraseCalls).toContainEqual({ subject });
+    expect(h.console_.sessions.has(subject)).toBe(false);
   });
 });

--- a/packages/vendo/src/hosted-store.test-util.ts
+++ b/packages/vendo/src/hosted-store.test-util.ts
@@ -130,9 +130,15 @@ export function fakeConsole() {
         const idleMs = typeof body.idleMs === "number" ? body.idleMs : 0;
         const cutoff = now - idleMs;
         switch (rest[1]) {
-          case "register":
-            sessions.set(body.subject as string, now);
+          case "register": {
+            // Mirrors the console's clamp: touch never moves a subject's
+            // stamp BACKWARD (vendo-web session-registry.ts bumps under
+            // `last_seen < seenAt`). The sweep's erase-failure compensation
+            // writes a backdated stamp and leans on exactly this.
+            const subject = body.subject as string;
+            sessions.set(subject, Math.max(sessions.get(subject) ?? now, now));
             return json({ ok: true });
+          }
           case "adopt": {
             const from = body.from as string;
             if (!sessions.has(from)) return json({ report: null });

--- a/packages/vendo/src/hosted-store.test-util.ts
+++ b/packages/vendo/src/hosted-store.test-util.ts
@@ -131,10 +131,8 @@ export function fakeConsole() {
         const cutoff = now - idleMs;
         switch (rest[1]) {
           case "register": {
-            // Mirrors the console's clamp: touch never moves a subject's
-            // stamp BACKWARD (vendo-web session-registry.ts bumps under
-            // `last_seen < seenAt`). The sweep's erase-failure compensation
-            // writes a backdated stamp and leans on exactly this.
+            // Mirrors the console's clamp (vendo-web session-registry.ts):
+            // touch never moves a subject's stamp BACKWARD.
             const subject = body.subject as string;
             sessions.set(subject, Math.max(sessions.get(subject) ?? now, now));
             return json({ ok: true });

--- a/packages/vendo/src/hosted-store.ts
+++ b/packages/vendo/src/hosted-store.ts
@@ -75,17 +75,18 @@ const raiseStoreError = (response: Response): Promise<never> =>
     throw Object.assign(new Error(message), { code: code ?? "unavailable" });
   });
 
-/** vendo-web@7cd0a02 (2026-07-19) deleted the console's ephemeral-session op
- * family (/api/v1/store/sessions/*) per spec — the removed routes answer
- * Next.js's BARE 404 page, no error envelope. Typed so the composition layer
- * (hostedSessionOps in server.ts) can disable the session doors gracefully
- * instead of failing anonymous traffic; an ENVELOPED 404 is a live console
- * answering "not-found" and keeps the loud path, same for every other
- * failure. */
+/** A console that is not serving the ephemeral-session op family
+ * (/api/v1/store/sessions/*) answers Next.js's BARE 404 page, no error
+ * envelope. Typed so the composition layer (hostedSessionOps in server.ts)
+ * can disable the session doors gracefully instead of failing anonymous
+ * traffic; an ENVELOPED 404 is a live console answering "not-found" and keeps
+ * the loud path, same for every other failure. Prod has served the doors
+ * again since 2026-07-20 (vendo-web #88), so this is a guard, not a
+ * description of today. */
 export class HostedSessionDoorsMissingError extends Error {
   constructor() {
     super(
-      "Vendo Cloud console does not serve /api/v1/store/sessions/* (removed in vendo-web@7cd0a02)",
+      "Vendo Cloud console did not serve /api/v1/store/sessions/* (bare 404)",
     );
     this.name = "HostedSessionDoorsMissingError";
   }

--- a/packages/vendo/src/server-venue.test.ts
+++ b/packages/vendo/src/server-venue.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { LanguageModel } from "ai";
-import type { Principal } from "@vendoai/core";
+import type { Principal, SandboxAdapter } from "@vendoai/core";
 import { createStore, type VendoStore } from "@vendoai/store";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -11,7 +11,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 // had e2bInstalled() blanket-passing, so a stray E2B_API_KEY outranked the
 // Cloud sandbox and the first build died in an unusable venue. This file pins
 // the ADAPTER RULE's ladder against exactly that: an e2b the runtime cannot
-// load must never be selected, whatever keys are in the env.
+// load is never selected. Cloud-audit fix 5 sharpened the answer — half a BYO
+// sandbox is now a LOUD compose-time misconfig instead of a silent demotion to
+// Cloud (or to the dark venue), so the operator learns at startup rather than
+// at the first server-app build.
 vi.mock("@vendoai/apps/e2b", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@vendoai/apps/e2b")>()),
   e2bInstalled: () => false,
@@ -39,7 +42,7 @@ async function tempStore(): Promise<VendoStore> {
   return store;
 }
 
-async function venueFor(env: Record<string, string>): Promise<unknown> {
+async function venueFor(env: Record<string, string>, sandbox?: SandboxAdapter): Promise<unknown> {
   vi.stubEnv("E2B_API_KEY", "");
   vi.stubEnv("VENDO_API_KEY", "");
   for (const [key, value] of Object.entries(env)) vi.stubEnv(key, value);
@@ -47,6 +50,7 @@ async function venueFor(env: Record<string, string>): Promise<unknown> {
     model: {} as LanguageModel,
     principal: async () => principal,
     store: await tempStore(),
+    ...(sandbox === undefined ? {} : { sandbox }),
   });
   const status = await vendo.handler(new Request("https://host.test/api/vendo/status"));
   return (await status.json() as { blocks: { sandbox: unknown } }).blocks.sandbox;
@@ -60,15 +64,23 @@ describe("venue ladder with an unloadable e2b SDK (0.4.4 defect C)", () => {
     })).toBe("cloud");
   });
 
-  it("skips an unusable e2b: a stray E2B_API_KEY without a loadable SDK never outranks the Cloud sandbox", async () => {
-    expect(await venueFor({
+  it("refuses to compose: an E2B_API_KEY without a loadable SDK is a misconfig, not a demotion to Cloud", async () => {
+    await expect(venueFor({
       E2B_API_KEY: "e2b_leaked_from_shell",
       VENDO_API_KEY: "vnd_cloud_key",
       ANTHROPIC_API_KEY: "sk-ant-byo",
-    })).toBe("cloud");
+    })).rejects.toThrow("E2B_API_KEY is set but the e2b package is not installed");
   });
 
-  it("goes dark rather than claiming e2b when the SDK is unloadable and no Vendo key is set", async () => {
-    expect(await venueFor({ E2B_API_KEY: "e2b_leaked_from_shell" })).toBe(false);
+  it("names the exact fix rather than going dark when the SDK is unloadable and no Vendo key is set", async () => {
+    await expect(venueFor({ E2B_API_KEY: "e2b_leaked_from_shell" }))
+      .rejects.toThrow("install e2b, or unset E2B_API_KEY to use another sandbox");
+  });
+
+  it("still lets an explicit sandbox: adapter win before any env check", async () => {
+    expect(await venueFor(
+      { E2B_API_KEY: "e2b_leaked_from_shell" },
+      { create: async () => { throw new Error("never called"); } } as unknown as SandboxAdapter,
+    )).toBe("custom");
   });
 });

--- a/packages/vendo/src/server-venue.test.ts
+++ b/packages/vendo/src/server-venue.test.ts
@@ -77,6 +77,16 @@ describe("venue ladder with an unloadable e2b SDK (0.4.4 defect C)", () => {
       .rejects.toThrow("install e2b, or unset E2B_API_KEY to use another sandbox");
   });
 
+  it("treats a whitespace-only E2B_API_KEY as unset, the way doctor's check reads it", async () => {
+    // environment() only strips "", so a stray-space value used to reach the
+    // throw above while `vendo doctor` (which trims) reported no key set.
+    expect(await venueFor({
+      E2B_API_KEY: "   ",
+      VENDO_API_KEY: "vnd_cloud_key",
+      ANTHROPIC_API_KEY: "sk-ant-byo",
+    })).toBe("cloud");
+  });
+
   it("still lets an explicit sandbox: adapter win before any env check", async () => {
     expect(await venueFor(
       { E2B_API_KEY: "e2b_leaked_from_shell" },

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -2254,6 +2254,9 @@ export function createVendo(config: CreateVendoConfig): Vendo {
     sessionStore: sessionOps,
     sweep: runSweep,
     sweepEnabled,
+    // Serverless hosts (the hosted store's typical deployment) fire no
+    // interval timer, so the authenticated tick carries the sweep for them.
+    sweepOnTick: sweepEnabled && hostedStoreComposed,
     ...(door === undefined ? {} : { door }),
     onRequestOrigin: (origin) => {
       // Same-origin default for route-binding execution (04): no VENDO_BASE_URL

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -864,14 +864,9 @@ function hostedSessionOps(store: HostedStore, touchDebounceMs: number): SessionO
     // The HOST-driven sweep (hosted-store one-pager): list stale candidates,
     // claim each (the wire claim repeats the idleness predicate — a re-touch
     // defeats it, same serialization as sweepEphemeralSubjects), and finish
-    // every claimed subject through the erase cascade.
-    //
-    // Claim stays BEFORE erase: it is the single-winner election AND the
-    // re-check that a subject touched since the stale scan is spared. Erasing
-    // first would race a visitor who came back mid-sweep and delete a live
-    // session's data. The cost is that a claim commits by deleting the
-    // registry row, so a failed erase would leave the subject's rows
-    // unreachable by every later stale scan — compensated below.
+    // every claimed subject through the erase cascade. A claim COMMITS by
+    // deleting the registry row, so a failed erase would leave the subject's
+    // rows unreachable by every later stale scan — compensated below.
     async sweep(idleMs, now) {
       if (doorsMissing) return [];
       const evicted: string[] = [];

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -865,13 +865,29 @@ function hostedSessionOps(store: HostedStore, touchDebounceMs: number): SessionO
     // claim each (the wire claim repeats the idleness predicate — a re-touch
     // defeats it, same serialization as sweepEphemeralSubjects), and finish
     // every claimed subject through the erase cascade.
+    //
+    // Claim stays BEFORE erase: it is the single-winner election AND the
+    // re-check that a subject touched since the stale scan is spared. Erasing
+    // first would race a visitor who came back mid-sweep and delete a live
+    // session's data. The cost is that a claim commits by deleting the
+    // registry row, so a failed erase would leave the subject's rows
+    // unreachable by every later stale scan — compensated below.
     async sweep(idleMs, now) {
       if (doorsMissing) return [];
       const evicted: string[] = [];
       try {
         for (const subject of await store.sessions.stale(idleMs, now)) {
           if (!(await store.sessions.claim(subject, idleMs, now))) continue;
-          await store.erase.bySubject(subject);
+          try {
+            await store.erase.bySubject(subject);
+          } catch (error) {
+            // Put the claimed row back, stamped one tick past the idleness
+            // cutoff so the very next sweep re-claims it instead of waiting
+            // out another TTL. Best-effort: if the console is down for this
+            // too, the erase failure is the one worth reporting.
+            await store.sessions.register(subject, now - idleMs - 1).catch(() => undefined);
+            throw error;
+          }
           wireTouched.delete(subject);
           evicted.push(subject);
         }
@@ -1127,16 +1143,16 @@ function createWireHandler(deps: WireDeps): (request: Request) => Promise<Respon
   // request that triggered it (same posture as the background timer leg) — a
   // failed sweep just means idle sessions live until the next interval.
   let lastSweepAt = deps.sessions.now();
-  const maybeSweep = async (): Promise<void> => {
-    if (!deps.sweepEnabled) return;
+  /** Starts a sweep pass and books the cadence, or answers undefined when the
+      interval has not elapsed. `force` is for a route that ASKED for the sweep
+      (POST /tick): a serverless process re-seeds lastSweepAt on every
+      invocation, so the interval gate would never let one of those through. */
+  const startSweep = (force: boolean): Promise<void> | undefined => {
+    if (!deps.sweepEnabled) return undefined;
     const now = deps.sessions.now();
-    if (now - lastSweepAt < deps.sessions.sweepIntervalMs) return;
+    if (!force && now - lastSweepAt < deps.sessions.sweepIntervalMs) return undefined;
     lastSweepAt = now;
-    try {
-      await deps.sweep();
-    } catch (error) {
-      console.warn(`[vendo] session sweep failed; will retry next interval: ${error instanceof Error ? error.message : String(error)}`);
-    }
+    return deps.sweep();
   };
   // LOAD-BEARING per-request ordering relative to routing (kill-list B4 kept
   // it byte-identical to the old chain):
@@ -1155,7 +1171,15 @@ function createWireHandler(deps: WireDeps): (request: Request) => Promise<Respon
   //   9. withAnonCookie at the single exit — the minted Set-Cookie rides
   //      every response shape (JSON, error, SSE/stream).
   return async (request) => {
-    await maybeSweep();
+    // ONE sweep pass per request, shared with any route that drives the sweep
+    // itself (POST /tick) so a tick can never run two scans of the same
+    // registry. The amortized leg only WARNS — an innocent request must not
+    // 500 for a sweep it merely happened to trigger — but the pass keeps its
+    // rejection, so a route that asked for the sweep still answers with it.
+    let sweepPass = startSweep(false);
+    await sweepPass?.catch((error: unknown) => {
+      console.warn(`[vendo] session sweep failed; will retry next interval: ${error instanceof Error ? error.message : String(error)}`);
+    });
     // Per-request anonymous-session state + the one shared context-resolution
     // pass (see wire/shared.ts). Both MUST be minted per-invocation — the
     // handler closure is shared across requests.
@@ -1201,6 +1225,7 @@ function createWireHandler(deps: WireDeps): (request: Request) => Promise<Respon
         },
         params: {},
         context: (venue) => context(request, venue),
+        sweep: () => (sweepPass ??= startSweep(true) ?? Promise.resolve()),
         deps,
       };
 

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -566,9 +566,17 @@ function selectSandbox(configured: SandboxAdapter | undefined): {
 
   // An env key only lights a venue when its optional SDK is actually
   // installed; otherwise /status would report a venue whose first
-  // create() dies on a missing module.
+  // create() dies on a missing module. Half a BYO sandbox is a MISCONFIG,
+  // not a fallback: silently riding Cloud (or going dark) hides the missing
+  // install until the first server-app build fails somewhere else entirely.
   const e2bApiKey = environment("E2B_API_KEY");
-  if (e2bApiKey !== undefined && e2bInstalled()) {
+  if (e2bApiKey !== undefined) {
+    if (!e2bInstalled()) {
+      throw new VendoError(
+        "validation",
+        "E2B_API_KEY is set but the e2b package is not installed — install e2b, or unset E2B_API_KEY to use another sandbox",
+      );
+    }
     // Wave 4 — operator knob for the provider machine lifetime. The default
     // 5-minute TTL kills a box mid-way through a long in-box agent build
     // (the box agent loop runs for minutes). Explicit VENDO_E2B_TIMEOUT_MS

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -569,7 +569,12 @@ function selectSandbox(configured: SandboxAdapter | undefined): {
   // create() dies on a missing module. Half a BYO sandbox is a MISCONFIG,
   // not a fallback: silently riding Cloud (or going dark) hides the missing
   // install until the first server-app build fails somewhere else entirely.
-  const e2bApiKey = environment("E2B_API_KEY");
+  // Trimmed, because a whitespace-only value is not a key: environment() only
+  // treats "" as unset, but doctor's E-LIVE-007 check trims before deciding one
+  // is present — and after the throw above, disagreeing with doctor about
+  // whether the operator set a key means one of them is lying to the operator.
+  const e2bKey = environment("E2B_API_KEY")?.trim();
+  const e2bApiKey = e2bKey === "" ? undefined : e2bKey;
   if (e2bApiKey !== undefined) {
     if (!e2bInstalled()) {
       throw new VendoError(

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -885,6 +885,16 @@ function hostedSessionOps(store: HostedStore, touchDebounceMs: number): SessionO
             // cutoff so the very next sweep re-claims it instead of waiting
             // out another TTL. Best-effort: if the console is down for this
             // too, the erase failure is the one worth reporting.
+            //
+            // RELIES ON a console guarantee: register/touch never moves a
+            // subject's touched_at BACKWARD (vendo-web
+            // apps/console/lib/core/session-registry.ts, `touch` bumps under
+            // `last_seen < seenAt`). Without that clamp this backdated write
+            // would overwrite the fresh stamp of a visitor who returned
+            // between the claim and here, and the next sweep would erase a
+            // LIVE session. The client cannot enforce it — only the registry
+            // can compare-and-set atomically. Pinned by "a fresh touch from a
+            // returning visitor survives the compensation" below.
             await store.sessions.register(subject, now - idleMs - 1).catch(() => undefined);
             throw error;
           }

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -790,22 +790,21 @@ function hostedSessionOps(store: HostedStore, touchDebounceMs: number): SessionO
   // registered on the console; entries retire with the session (adopt/sweep),
   // so the map tracks at most the live anonymous sessions of this process.
   const wireTouched = new Map<string, number>();
-  // vendo-web@7cd0a02 (2026-07-19) removed the console's session doors per a
-  // newer spec (anonymous visitor = end_user row; adoption = PUT
-  // /users/{externalId}); against that console every door op meets a bare
-  // 404. The doors then go quiet for the process — one warn, no per-request
-  // failures, no per-interval sweep retries — because anonymous traffic must
-  // keep serving and there is nothing to retry INTO. The full contract catch-
-  // up (merge + TTL lifecycle on the new surface) is the vendo-web follow-up
-  // tracked in docs/verification/existing-agents/polish/hosted-sessions-404.md.
+  // A console that answers a BARE 404 (no error envelope) on a session door is
+  // not serving that surface at all. The doors then go quiet for the process —
+  // one warn, no per-request failures, no per-interval sweep retries — because
+  // anonymous traffic must keep serving and there is nothing to retry INTO.
+  // The latch is per-process and re-arms on the next composition, so a console
+  // that grows the doors back needs no client change (history:
+  // docs/verification/existing-agents/polish/hosted-sessions-404.md).
   let doorsMissing = false;
   const disableDoors = (): void => {
     if (doorsMissing) return;
     doorsMissing = true;
     console.warn(
-      "[vendo] Vendo Cloud console does not serve the hosted session doors (/api/v1/store/sessions/* was removed in vendo-web@7cd0a02): "
+      "[vendo] Vendo Cloud console did not serve the hosted session doors (/api/v1/store/sessions/* answered a bare 404): "
       + "anonymous-session registration, the anonymous→signed-in merge, and the hosted TTL sweep are disabled for this process. "
-      + "Hosted anonymous sessions will not be swept until the console grows a replacement surface.",
+      + "Hosted anonymous sessions will not be swept until the console serves those doors again.",
     );
   };
   return {

--- a/packages/vendo/src/session-lifecycle.test.ts
+++ b/packages/vendo/src/session-lifecycle.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import type { Principal } from "@vendoai/core";
 import { createStore, type VendoStore } from "@vendoai/store";
 import type { LanguageModel } from "ai";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createVendo, type CreateVendoConfig, type Vendo } from "./server.js";
 
 // Minimal streaming model: one text turn per call, never exhausts. Enough to
@@ -31,7 +31,10 @@ const chatModel = (): LanguageModel => ({
 } as unknown as LanguageModel);
 
 const cleanups: Array<() => Promise<void>> = [];
-afterEach(async () => { for (const cleanup of cleanups.splice(0).reverse()) await cleanup(); });
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
 
 const hostPrincipal: Principal = { kind: "user", subject: "user_host" };
 
@@ -168,4 +171,27 @@ describe("ephemeral session lifecycle through the umbrella (02-store §4, kill-l
     expect(await count("vendo_records")).toBe(0);
     expect(await count("vendo_apps")).toBe(0);
   }, 60_000);
+
+  // Cloud-audit fix 1's other half: the tick leg is HOSTED-only. A local
+  // composition already has both working cadences (the unref'd interval timer
+  // and the amortized on-request sweep in its long-lived process), so the tick
+  // must not quietly grow a third one behind its back.
+  it("does not drive the sweep from /tick on a non-hosted composition", async () => {
+    vi.stubEnv("VENDO_TICK_SECRET", "tick-secret-for-local-sessions");
+    // A sweep interval longer than the test pins the amortized sweep shut, so
+    // the surviving row can only mean the tick left the sweep alone.
+    const { vendo, setNow, count } = await harness({ ttlMs: 1_000, sweepIntervalMs: 10 ** 9 });
+    setNow(0);
+    await drain(await vendo.handler(chat()));
+    expect(await count("vendo_sessions")).toBe(1);
+
+    setNow(5_000);
+    const ticked = await vendo.handler(new Request("https://host.test/api/vendo/tick", {
+      method: "POST",
+      headers: { authorization: "Bearer tick-secret-for-local-sessions" },
+    }));
+    expect(ticked.status).toBe(200);
+    expect(await count("vendo_sessions")).toBe(1);
+    expect(await count("vendo_threads")).toBe(1);
+  });
 });

--- a/packages/vendo/src/wire/misc.ts
+++ b/packages/vendo/src/wire/misc.ts
@@ -95,7 +95,7 @@ export const systemRoutes: RouteEntry[] = [
   prefixRoute("POST", "/webhooks/", async ({ request, deps }) => {
     return await deps.automations.webhook(request);
   }),
-  route("POST", "/tick", async ({ request, deps }) => {
+  route("POST", "/tick", async ({ request, deps, sweep }) => {
     if (!await tickAuthorized(request)) {
       return json({ error: { code: "blocked", message: "invalid tick credential" } }, 401);
     }
@@ -105,11 +105,14 @@ export const systemRoutes: RouteEntry[] = [
     // external cron here (Vercel cron, GitHub Actions, crontab); the Cloud
     // broker calls this same surface. The legs settle independently so one
     // failing can never suppress the others; any failure still answers 500 so
-    // a retrying cron comes back (all three are idempotent within their windows).
+    // a retrying cron comes back (all three are idempotent within their
+    // windows). `sweep()` is the REQUEST's one pass — if the amortized
+    // pre-routing leg already ran it, this awaits that same pass rather than
+    // scanning the registry twice, and inherits its failure.
     const [runs, schedules, sessions] = await Promise.allSettled([
       deps.automations.tick(),
       deps.apps.schedules.tick(),
-      deps.sweepOnTick ? deps.sweep() : Promise.resolve(),
+      deps.sweepOnTick ? sweep() : Promise.resolve(),
     ]);
     const errors = [
       ...(runs.status === "rejected" ? [`automations: ${runs.reason instanceof Error ? runs.reason.message : "tick failed"}`] : []),

--- a/packages/vendo/src/wire/misc.ts
+++ b/packages/vendo/src/wire/misc.ts
@@ -101,18 +101,20 @@ export const systemRoutes: RouteEntry[] = [
     }
     // execution-v2 Lane D — one authenticated tick drives BOTH schedulers: the
     // automations engine and the machine-app vendo.json schedules (additive
-    // `schedules` field). Point any external cron here (Vercel cron, GitHub
-    // Actions, crontab); the Cloud broker calls this same surface. The engines
-    // settle independently so one failing can never suppress the other; any
-    // failure still answers 500 so a retrying cron comes back (both engines
-    // are idempotent within their windows).
-    const [runs, schedules] = await Promise.allSettled([
+    // `schedules` field), plus the hosted TTL sweep (sweepOnTick). Point any
+    // external cron here (Vercel cron, GitHub Actions, crontab); the Cloud
+    // broker calls this same surface. The legs settle independently so one
+    // failing can never suppress the others; any failure still answers 500 so
+    // a retrying cron comes back (all three are idempotent within their windows).
+    const [runs, schedules, sessions] = await Promise.allSettled([
       deps.automations.tick(),
       deps.apps.schedules.tick(),
+      deps.sweepOnTick ? deps.sweep() : Promise.resolve(),
     ]);
     const errors = [
       ...(runs.status === "rejected" ? [`automations: ${runs.reason instanceof Error ? runs.reason.message : "tick failed"}`] : []),
       ...(schedules.status === "rejected" ? [`schedules: ${schedules.reason instanceof Error ? schedules.reason.message : "tick failed"}`] : []),
+      ...(sessions.status === "rejected" ? [`sessions: ${sessions.reason instanceof Error ? sessions.reason.message : "sweep failed"}`] : []),
     ];
     return json({
       ...(runs.status === "fulfilled" ? { runIds: runs.value } : {}),

--- a/packages/vendo/src/wire/misc.ts
+++ b/packages/vendo/src/wire/misc.ts
@@ -106,9 +106,7 @@ export const systemRoutes: RouteEntry[] = [
     // broker calls this same surface. The legs settle independently so one
     // failing can never suppress the others; any failure still answers 500 so
     // a retrying cron comes back (all three are idempotent within their
-    // windows). `sweep()` is the REQUEST's one pass — if the amortized
-    // pre-routing leg already ran it, this awaits that same pass rather than
-    // scanning the registry twice, and inherits its failure.
+    // windows).
     const [runs, schedules, sessions] = await Promise.allSettled([
       deps.automations.tick(),
       deps.apps.schedules.tick(),

--- a/packages/vendo/src/wire/shared.ts
+++ b/packages/vendo/src/wire/shared.ts
@@ -119,6 +119,10 @@ export interface WireContext {
   params: Record<string, string>;
   /** Resolve this request's RunContext for a venue. */
   context(venue: RunContext["venue"]): Promise<RunContext>;
+  /** Run this request's TTL sweep pass, awaiting the one the handler may
+      already have started before routing — at most one pass per request. The
+      rejection is the caller's to answer with; the pre-routing leg only warns. */
+  sweep(): Promise<void>;
   deps: WireDeps;
 }
 

--- a/packages/vendo/src/wire/shared.ts
+++ b/packages/vendo/src/wire/shared.ts
@@ -94,6 +94,12 @@ export interface WireDeps {
     adopt(from: string, to: string): Promise<SubjectMergeReport | null>;
   };
   sweep: () => Promise<void>;
+  /** True when the composed store carries the HOSTED session doors — the
+      authenticated /tick then drives `sweep` too. A serverless deployment
+      never fires the composition's interval timer, so the tick is the only
+      cadence its idle hosted sessions have. Safe against a timer that DOES
+      fire: the hosted claim leg is a single-winner election server-side. */
+  sweepOnTick: boolean;
 }
 
 /** The per-request view a route handler receives: the raw request, its parsed


### PR DESCRIPTION
Five small fixes from the Cloud audit, one commit each. Every fix is a place
where the runtime and what it claimed had drifted apart.

Gates green in the worktree, uncached where it mattered:
`pnpm build` 0 · `pnpm test` 0 (53/53 tasks) · `pnpm typecheck` 0 · `pnpm lint` 0.

---

### 1. Tick-driven session sweep — `50b841ed3`

The hosted-store anonymous-session sweep had two cadences and **a serverless
host can reach neither**: the unref'd interval timer never fires, and the
amortized on-request sweep is gated by a per-PROCESS `lastSweepAt` that a
per-request process re-seeds every invocation. A Vercel-shaped deployment on
the hosted store leaks idle anonymous sessions forever.

`POST /api/vendo/tick` (already authenticated, already driving
`automations.tick` + `apps.schedules.tick`) now runs the composition's existing
`runSweep` as a third settled leg. No logic is duplicated — it is the same
`deps.sweep` the timer and the on-request leg call. Gated on a new
`sweepOnTick` dep = `sweepEnabled && hostedStoreComposed`, so a long-lived
local composition (which already has both working cadences) is untouched. Two
cadences firing at once is safe: the claim leg is a single-winner election
server-side.

**Tests** (new): `hosted-sessions.test.ts` → "the authenticated tick drives the
session sweep" — stale → claim → erase over the wire with the amortized sweep
pinned shut by a huge `sweepIntervalMs`, idempotence across a second tick, no
sweep of a live session, and 401 still 401.
`session-lifecycle.test.ts` → a non-hosted composition's tick leaves its
session rows alone.

### 2. Retire the stale sessions-404 bookkeeping — `c91a2ed46`

The console restored the session doors over the `end_user` model on 2026-07-20
(vendo-web #88, `b37dceea`), live-verified against prod 2026-08-02: all four
doors 200, `adopt` returned a merge report. Two places still asserted the
surface was gone.

- `docs/verification/existing-agents/polish/hosted-sessions-404.md` gets a
  **HEALED** status header; the rest stays as the historical record.
- The one-time warn in `server.ts` no longer blames `vendo-web@7cd0a02`. It
  reports what the client actually observed — a bare 404 from the session
  doors — and names the same three lost capabilities.

Latch mechanics and `HostedSessionDoorsMissingError` detection in
`hosted-store.ts` are untouched, as briefed.

⚠️ **One existing assertion changed**: `hosted-sessions.test.ts` asserted the
warn `toContain("vendo-web@7cd0a02")` — the exact string this fix removes.
Swapped to `toContain("bare 404")` (display copy only; same category as the
exception the brief granted for fix 4). Nothing else in that test moved.

### 3. `fn:` warning + doc correction — `37134e440`

`docs-site/deploy/vendo-cloud.mdx` promised automations with `fn:` steps "warn
on sync" and described `fn:` as "calls back into the host application's
process". Neither was true: no such warning existed anywhere, and there is no
sync flow for automations at all. A `fn:` step is an HTTP call into the **app's
own sandbox machine** (`packages/apps/src/fn.ts` POSTs `/fn/<name>`); with no
machine it settles as a contained validation error, not a host callback.

**Surface chosen: automation ARMING — `engine.enable()` in
`packages/automations`.** Reasoning: composition time can't enumerate
automations (they are store rows read per-tick, not a compose-time input), and
`enable()` is the only point that sees both the trigger kind and the steps —
and the moment the operator is making the decision. It already walks
`trigger.run.steps` to compute the grant surface.

The warn fires when `firesLocally(trigger.on.kind)` is false (deferred to Cloud
under the hosted store) and the steps contain `fn:`. Silent for host-event
triggers (never deferred), for tool-only steps, and when this engine fires the
trigger itself.

The mdx paragraph is rewritten to describe `fn:` correctly and to match the
warning that now exists.

**Tests** (new): `engine.test.ts` → "fn: steps deferred to another firing
authority warn at enable()" — 4 cases (warns naming app + kind; silent for
tool-only, for locally-fired, for host-event).

### 4. Doctor honesty — `626ce13df`

`CLOUD_UNLOCKS` told every keyless dev that a key unlocks "hosted
infrastructure defaults like the managed MCP broker". **No code path wires the
MCP broker from a key** — the door is composed from `createVendo({ mcp })` and
the host's own OAuth seam, key or no key. Replaced with the slots a key
actually defaults: managed inference, the sandbox pool, the hosted store, the
connections broker (registry publishing stays).

No test change needed: `doctor-live.test.ts` asserts against the
`CLOUD_UNLOCKS` symbol, not the literal string. The brief's permitted
display-copy exception went unused here.

### 5. E2B misconfig errors loudly — `00852730d`

`selectSandbox` silently demoted a half-configured BYO sandbox to Cloud, or to
the dark venue with no key at all. The operator learned about the missing
install at the first server-app build, somewhere else entirely. It now throws
`VendoError("validation", ...)` naming the exact fix. An explicitly passed
`sandbox:` adapter still wins before any env check.

`doctor.ts` **E-LIVE-007 copy is unchanged** — it does not describe an
impossible state after this fix. That check reads doctor's OWN `env` and
project root, not the server's, so a live e2b venue that fails it now means
doctor and the dev server disagree (different shell, different root), which is
exactly what doctor must not silently bless. Added a comment saying so.

⚠️ **Two existing tests rewritten**: `server-venue.test.ts` pinned the old
fall-through behaviour verbatim ("a stray `E2B_API_KEY` … never outranks the
Cloud sandbox" → `cloud`; "goes dark …" → `false`). Those two assertions ARE
the behaviour this fix deliberately changes, so they now assert the throw, and
a third case was added proving an explicit `sandbox:` adapter still wins with
the module missing. The first test in the file (no E2B key → cloud) is
untouched. "Key set + module present → e2b" stays covered by the existing
`server.test.ts` precedence test, unmodified.

**Product tradeoff worth a human look:** the original test's history (0.4.4
defect C) was a field host with `E2B_API_KEY` *leaking from the shell* in a
Turbopack bundle with no e2b install. Under this change that host now
hard-fails at `createVendo` instead of quietly running on Cloud. That is the
intended "error loudly", but it does mean an env leak takes the app down at
composition rather than degrading. Flagging it rather than deciding it.

---

### Baseline

Run before any change: build 0, typecheck 0, lint 0, test **1** — a single
flake in `@vendoai/mcp` `src/door.test.ts` ("kills a subject's live session
when principal resolution returns null", expected 401 got 404). It passes 3/3
in isolation and passed on an immediate full re-run. Pre-existing, untouched by
this branch, and worth its own look.

Do not auto-merge — an independent check round runs first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes five Cloud audit gaps to align runtime with reality and improve operator feedback. Adds tick‑driven hosted session sweep with a single pass per request and clear 500s on failure, compensates erase failures safely, updates docs/warns, and tightens E2B venue selection (whitespace‑only keys are treated as unset).

- **Bug Fixes**
  - Hosted session sweep runs on the authenticated `/api/vendo/tick` for hosted stores. One sweep pass per request is shared with `/tick`; if the sweep fails, `/tick` returns 500 so cron retries. Failed erase after a claim re‑registers the subject (backdated) and never overwrites a returning visitor’s fresh touch.
  - Retired stale sessions‑404 bookkeeping. The warn now reports a bare 404, and the doc is marked healed.
  - `fn:` steps warn at `engine.enable()` when the trigger fires on Vendo Cloud. Docs now describe `fn:` correctly (runs in the app’s sandbox machine).
  - `CLOUD_UNLOCKS` copy corrected: no “managed MCP broker.” Lists actual hosted defaults (inference, sandbox pool, hosted store, connections broker).
  - `E2B_API_KEY` without `e2b` now throws a validation error in `createVendo`. Whitespace‑only values are treated as unset to match `vendo doctor`. An explicit `sandbox:` adapter still wins before env checks.

- **Migration**
  - Ensure your cron hits `/api/vendo/tick` in hosted deployments (it now also drives the session sweep and will return 500 on sweep failure; configure retries).
  - If `E2B_API_KEY` is set, install `e2b` or unset the key to use another sandbox (whitespace‑only values count as unset).

<sup>Written for commit 8bdcbc9cbc57d3a987a288c5650b76cb718a029b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

