### PR TITLE
remix WFIX2: checker round-2 findings — review gating and pending-state rendering

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -470,7 +470,8 @@ import type {
   ActAs, ActionsRegistry, AppsRuntime, AutomationsEngine, CatalogFile,
   ComponentCatalog, ComponentRegistry, Connector, ExtractedTool,
   HostOAuthAdapter, Json, Judge, KnowledgeAdapter, OverridesFile, PolicyConfig,
-  PolicyFile, Principal, RunId, SandboxAdapter, SecretsProvider, ToolRegistry,
+  PolicyFile, Principal, RunContext, RunId, SandboxAdapter, SecretsProvider,
+  ToolRegistry,
   VendoAgent, VendoGuard, VendoStore, VendoTheme,
 } from "@vendoai/vendo";
 import type {
@@ -543,6 +544,9 @@ export interface CreateVendoConfig {
       rebind?: boolean;
     };
     designRules?: string;
+    review?: {                // review-kind remixes: who may review (queue/reject/approve)
+      reviewer?(ctx: RunContext): boolean | Promise<boolean>;
+    };
   };
   tours?: readonly TourEntry[];
 }

--- a/packages/apps/src/review.test.ts
+++ b/packages/apps/src/review.test.ts
@@ -61,7 +61,10 @@ const doc = (slot: string, overrides: Partial<AppDocument> = {}): AppDocument =>
   ...overrides,
 });
 
-const setup = () => {
+/** Round-2 hardening: reviewing takes the composition's explicit assertion —
+ *  these tests assert it for exactly the host_reviewer subject. `setup({})`
+ *  (no hook) is the unconfigured composition. */
+const setup = (review: { reviewer?(ctx: RunContext): boolean } = { reviewer: (ctx) => ctx.principal.subject === "host_reviewer" }) => {
   const store = memoryStore();
   const guard = guardFixture();
   const runtime = createApps({
@@ -71,6 +74,7 @@ const setup = () => {
     catalog: [],
     pinBaselines: [reviewedBaseline, instantBaseline],
     model: scriptedLanguageModel('<Edit><SetName name="Edited name"/></Edit>'),
+    review,
   });
   return { store, guard, runtime };
 };
@@ -125,7 +129,7 @@ describe("approval swaps the served version", () => {
     await seedAppRow(store, v1, owner.principal.subject);
     const v1Hash = appVersionHash(v1);
 
-    await runtime.inClient.approve({ appId: v1.id, approvedBy: "host-console" }, owner);
+    await runtime.inClient.approve({ appId: v1.id, approvedBy: "host-console" }, reviewer);
     const approved = await runtime.open(v1.id, owner);
     if (approved.kind !== "tree") throw new Error("expected tree surface");
     expect((approved.payload as { inClient?: unknown }).inClient).toMatchObject({
@@ -154,7 +158,7 @@ describe("approval swaps the served version", () => {
     expect(during.components).toEqual(v1.components);
 
     // Approving the new version swaps it in, rider gone.
-    await runtime.inClient.approve({ appId: v1.id, approvedBy: "host-console" }, owner);
+    await runtime.inClient.approve({ appId: v1.id, approvedBy: "host-console" }, reviewer);
     const swapped = await runtime.open(v1.id, owner);
     if (swapped.kind !== "tree") throw new Error("expected tree surface");
     expect((swapped.payload as { inClient?: { versionHash?: string; review?: unknown } }).inClient).toMatchObject({
@@ -239,7 +243,7 @@ describe("rejection", () => {
 
     const reviewed = doc("transfer-panel");
     await seedAppRow(store, reviewed, owner.principal.subject);
-    await runtime.inClient.approve({ appId: reviewed.id, approvedBy: "host-console" }, owner);
+    await runtime.inClient.approve({ appId: reviewed.id, approvedBy: "host-console" }, reviewer);
     await expect(runtime.review.reject({ appId: reviewed.id, note: "too late" }, reviewer))
       .rejects.toMatchObject({ code: "conflict" });
 
@@ -256,12 +260,28 @@ describe("rejection", () => {
       .rejects.toMatchObject({ code: "conflict" });
   });
 
+  it("two concurrent rejections of the same version converge on ONE note", async () => {
+    const { store, runtime } = setup();
+    const app = doc("transfer-panel");
+    await seedAppRow(store, app, owner.principal.subject);
+    // Both racers can pass the duplicate check before either writes; the
+    // version-keyed idempotent id makes them land on the SAME row.
+    const results = await Promise.allSettled([
+      runtime.review.reject({ appId: app.id, note: "First racer." }, reviewer),
+      runtime.review.reject({ appId: app.id, note: "Second racer." }, reviewer),
+    ]);
+    expect(results.some((result) => result.status === "fulfilled")).toBe(true);
+    const rows = (await store.records("vendo_remix_rejections").list({ refs: { appId: app.id } })).records;
+    expect(rows).toHaveLength(1);
+    expect(await runtime.review.queue(reviewer)).toEqual([]);
+  });
+
   it("records the note, surfaces it to the user, drops the version from the queue, and audits under the owner", async () => {
     const { store, guard, runtime } = setup();
     const app = doc("transfer-panel");
     await seedAppRow(store, app, owner.principal.subject);
 
-    expect(await runtime.review.queue()).toHaveLength(1);
+    expect(await runtime.review.queue(reviewer)).toHaveLength(1);
 
     const rejection = await runtime.review.reject(
       { appId: app.id, note: "Keep the original balance label." },
@@ -275,7 +295,7 @@ describe("rejection", () => {
     });
 
     // The queue drops it; the work is NOT deleted.
-    expect(await runtime.review.queue()).toEqual([]);
+    expect(await runtime.review.queue(reviewer)).toEqual([]);
     expect(await runtime.get(app.id, owner)).not.toBeNull();
 
     // The note rides the venue state the user's panel reads.
@@ -306,12 +326,12 @@ describe("rejection", () => {
     const app = doc("transfer-panel");
     await seedAppRow(store, app, owner.principal.subject);
     await runtime.review.reject({ appId: app.id, note: "Not like this." }, reviewer);
-    expect(await runtime.review.queue()).toEqual([]);
+    expect(await runtime.review.queue(reviewer)).toEqual([]);
 
     const edited = await runtime.edit(app.id, "Rename it", owner);
     expect(edited.failure).toBeUndefined();
 
-    const queue = await runtime.review.queue();
+    const queue = await runtime.review.queue(reviewer);
     expect(queue).toHaveLength(1);
     expect(queue[0]).toMatchObject({
       appId: app.id,
@@ -340,7 +360,7 @@ describe("review queue", () => {
     const app = doc("transfer-panel");
     await seedAppRow(store, app, owner.principal.subject);
 
-    const queue = await runtime.review.queue();
+    const queue = await runtime.review.queue(reviewer);
     expect(queue).toHaveLength(1);
     expect(queue[0]).toMatchObject({
       appId: app.id,
@@ -362,12 +382,64 @@ describe("review queue", () => {
     const { store, runtime } = setup();
     const instant = doc("hero-card");
     await seedAppRow(store, instant, owner.principal.subject);
-    expect(await runtime.review.queue()).toEqual([]);
+    expect(await runtime.review.queue(reviewer)).toEqual([]);
 
     const reviewed = doc("transfer-panel");
     await seedAppRow(store, reviewed, owner.principal.subject);
-    expect(await runtime.review.queue()).toHaveLength(1);
-    await runtime.inClient.approve({ appId: reviewed.id, approvedBy: "host-console" }, owner);
-    expect(await runtime.review.queue()).toEqual([]);
+    expect(await runtime.review.queue(reviewer)).toHaveLength(1);
+    await runtime.inClient.approve({ appId: reviewed.id, approvedBy: "host-console" }, reviewer);
+    expect(await runtime.review.queue(reviewer)).toEqual([]);
+  });
+});
+
+describe("the reviewer assertion (round-2 hardening)", () => {
+  it("scopes the queue: the asserted reviewer reads everything, anyone else only their own submissions", async () => {
+    const { store, runtime } = setup();
+    const app = doc("transfer-panel");
+    await seedAppRow(store, app, owner.principal.subject);
+    expect(await runtime.review.queue(reviewer)).toHaveLength(1);
+    expect(await runtime.review.queue(owner)).toHaveLength(1);
+    expect(await runtime.review.queue(context("user_bob"))).toEqual([]);
+  });
+
+  it("without the hook the queue serves only the caller's own items and reject refuses, naming the hook", async () => {
+    const { store, runtime } = setup({});
+    const app = doc("transfer-panel");
+    await seedAppRow(store, app, owner.principal.subject);
+    expect(await runtime.review.queue(owner)).toHaveLength(1);
+    expect(await runtime.review.queue(reviewer)).toEqual([]);
+    await expect(runtime.review.reject({ appId: app.id, note: "no" }, reviewer))
+      .rejects.toMatchObject({ code: "blocked", message: expect.stringContaining("apps.review.reviewer") });
+  });
+
+  it("masks a non-reviewer's reject as not-found even with the hook set", async () => {
+    const { store, runtime } = setup();
+    const app = doc("transfer-panel");
+    await seedAppRow(store, app, owner.principal.subject);
+    await expect(runtime.review.reject({ appId: app.id, note: "no" }, owner))
+      .rejects.toMatchObject({ code: "not-found" });
+  });
+
+  it("a review-kind remix is never approved by its own user; an asserted reviewer approves across the owner boundary", async () => {
+    const { store, runtime } = setup();
+    const app = doc("transfer-panel");
+    await seedAppRow(store, app, owner.principal.subject);
+    await expect(runtime.inClient.approve({ appId: app.id, approvedBy: "self" }, owner))
+      .rejects.toMatchObject({ code: "blocked", message: expect.stringContaining("apps.review.reviewer") });
+    // A non-reviewer, non-owner caller learns nothing.
+    await expect(runtime.inClient.approve({ appId: app.id, approvedBy: "bob" }, context("user_bob")))
+      .rejects.toMatchObject({ code: "not-found" });
+    const approval = await runtime.inClient.approve({ appId: app.id, approvedBy: "host-console" }, reviewer);
+    expect(approval.versionHash).toBe(appVersionHash(app));
+  });
+
+  it("keeps owner self-approval for instant-kind apps, owner-scoped as before (regression)", async () => {
+    const { store, runtime } = setup({});
+    const app = doc("hero-card");
+    await seedAppRow(store, app, owner.principal.subject);
+    const approval = await runtime.inClient.approve({ appId: app.id, approvedBy: "local-dev" }, owner);
+    expect(approval.versionHash).toBe(appVersionHash(app));
+    await expect(runtime.inClient.approve({ appId: app.id, approvedBy: "bob" }, context("user_bob")))
+      .rejects.toMatchObject({ code: "not-found" });
   });
 });

--- a/packages/apps/src/review.ts
+++ b/packages/apps/src/review.ts
@@ -2,6 +2,7 @@ import {
   VendoError,
   appIdSchema,
   isoDateTimeSchema,
+  sha256Hex,
   type AppDocument,
   type AppId,
   type IsoDateTime,
@@ -246,8 +247,12 @@ export const createReviewLifecycle = (deps: ReviewLifecycleDeps): ReviewLifecycl
         by,
         at: new Date().toISOString(),
       });
+      // The id is deterministic per (app, version), so the duplicate check
+      // above being check-then-write racy cannot double-record: concurrent
+      // rejections of the same version upsert the SAME row and converge on
+      // one note.
       await rejections.put({
-        id: `remrej_${globalThis.crypto.randomUUID()}`,
+        id: `remrej_${sha256Hex(`${rejection.appId}:${versionHash}`)}`,
         data: rejection,
         refs: { appId: rejection.appId },
       });

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -187,6 +187,15 @@ export interface AppsConfig {
    *  per create/edit (engine.ts GenerationDependencies). */
   designRules?: string | (() => string | undefined);
   pinBaselines?: PinBaseline[];
+  /** Remix review (round-2 hardening 2026-08-02) — the host's reviewer
+   *  assertion for the review-kind lifecycle. Reviewing crosses owner
+   *  boundaries, so it is never inferred from a principal alone: `reviewer`
+   *  answers whether THIS caller may read the full queue, reject, and approve
+   *  review-kind remixes. Unset, the queue serves only the caller's own
+   *  submissions and reject/approve-as-reviewer refuse, naming this hook. */
+  review?: {
+    reviewer?(ctx: RunContext): boolean | Promise<boolean>;
+  };
   /** ADAPTER RULE — the share/publish seam (see cloud.ts): the umbrella wires
    * the Cloud console client when VENDO_API_KEY fills the unset slot; this
    * block never reads the environment. Unset → share/publish fail with
@@ -560,13 +569,18 @@ export interface AppsRuntime {
    * its own user until a host reviewer approves; the approved version then
    * mounts natively in place, riding the §9 hash-pin machinery. These two
    * methods are the reviewer's side and cross owner boundaries BY DESIGN
-   * (the reviewer is not the remixing user): like `history()`, they carry no
-   * owner scoping of their own — the wire layer enforces its host-admin
-   * principal scoping before exposing them.
+   * (the reviewer is not the remixing user), so both are gated on the host's
+   * reviewer assertion ({@link AppsConfig.review} `reviewer`): this is the
+   * production path — a self-hoster mounts their own admin-authenticated
+   * route over it (Cloud's console is the hosted equivalent). Without the
+   * hook, `queue` serves only the caller's own submissions and `reject`
+   * refuses, naming the hook.
    */
   review: {
-    /** Every review-kind version awaiting review, oldest submission first. */
-    queue(): Promise<ReviewQueueEntry[]>;
+    /** Every review-kind version awaiting review, oldest submission first —
+     *  the full queue for an asserted reviewer, the caller's own items
+     *  otherwise. */
+    queue(ctx: RunContext): Promise<ReviewQueueEntry[]>;
     /** Reject the app's CURRENT version with a note the user's panel surfaces.
      *  The work is not deleted; a new version supersedes the rejection. */
     reject(input: { appId: AppId; note: string }, ctx: RunContext): Promise<RemixRejection>;
@@ -1121,6 +1135,11 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     approvals: inClientApprovals,
     history,
   });
+  // Round-2 hardening (2026-08-02) — reviewing is a HOST trust decision, so
+  // it only ever comes from the composition's explicit assertion; no hook
+  // means no caller is a reviewer, ever.
+  const reviewerAsserted = async (ctx: RunContext): Promise<boolean> =>
+    config.review?.reviewer !== undefined && await config.review.reviewer(ctx) === true;
   // execution-v2 Lane D — fn: refs on a machine-bearing app resolve over the
   // v2 box door (the same wake Lane C's wire proxy rides); the wrap leaves
   // every other ref on the existing caller. Queries hit this at open(),
@@ -2291,7 +2310,28 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
         return inClientApprovals.verdictFor(app);
       },
       async approve(input, ctx) {
-        const app = await requireOwned(input.appId, ctx.principal.subject);
+        // Round-2 hardening (2026-08-02) — a review-kind approval IS the
+        // review, so it never comes from the remixing user themselves: the
+        // owner is refused unless the host's reviewer assertion
+        // (apps.review.reviewer) covers them, and an asserted reviewer may
+        // approve across the owner boundary (that is the reviewer's job).
+        // Instant-kind keeps the plain owner scoping unchanged.
+        const record = await apps.get(input.appId);
+        if (record === null) throw new VendoError("not-found", `app not found: ${input.appId}`);
+        const row = rowFromRecord(record);
+        const app = classifyLegacyPlacements(row.doc, config.pinBaselines);
+        const isOwner = row.subject === ctx.principal.subject;
+        if (review.isReviewKind(app)) {
+          if (!await reviewerAsserted(ctx)) {
+            if (isOwner) {
+              throw new VendoError("blocked", "a review-kind remix cannot be approved by its own user — set apps.review.reviewer(ctx) in your composition to assert who reviews");
+            }
+            // Masked like every unowned app read.
+            throw new VendoError("not-found", `app not found: ${input.appId}`);
+          }
+        } else if (!isOwner) {
+          throw new VendoError("not-found", `app not found: ${input.appId}`);
+        }
         const approval = await inClientApprovals.record({
           appId: app.id,
           versionHash: appVersionHash(app),
@@ -2307,12 +2347,25 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     },
 
     review: {
-      async queue() {
-        return review.queue();
+      async queue(ctx) {
+        const entries = await review.queue();
+        if (await reviewerAsserted(ctx)) return entries;
+        // No reviewer assertion → a caller sees only their own submissions;
+        // nobody reads another user's pending fork source through this door.
+        return entries.filter((entry) => entry.requester === ctx.principal.subject);
       },
       async reject(input, ctx) {
+        // Rejecting is reviewer-only, and reviewing is a HOST trust decision:
+        // it requires the composition's explicit assertion, in every venue.
+        if (config.review?.reviewer === undefined) {
+          throw new VendoError("blocked", "rejecting a remix review requires the host's reviewer assertion — set apps.review.reviewer(ctx) in your composition");
+        }
+        if (!await reviewerAsserted(ctx)) {
+          // Masked like every unowned app read: a non-reviewer learns nothing.
+          throw new VendoError("not-found", `app not found: ${input.appId}`);
+        }
         // Reviewer-side, cross-subject by design: the app is looked up
-        // WITHOUT owner scoping (the wire's host-admin gate stands in front).
+        // WITHOUT owner scoping (the reviewer assertion above stands in front).
         const record = await apps.get(input.appId);
         if (record === null) throw new VendoError("not-found", `app not found: ${input.appId}`);
         const row = rowFromRecord(record);

--- a/packages/ui/src/chrome/remixable.tsx
+++ b/packages/ui/src/chrome/remixable.tsx
@@ -129,8 +129,21 @@ function remixStatus(review: boolean, surface: OpenSurface | undefined): string 
   if (surface?.kind === "failed") return surface.reason;
   if (surface?.kind !== "tree") return "Waiting for review";
   const venue = (surface.payload as { inClient?: InClientVenue }).inClient;
-  if (venue?.granted === true) return `Approved by ${venue.approvedBy} — runs in the page`;
-  if (venue?.granted === false) return "Changed since approval — sandboxed until re-approved";
+  if (venue?.granted === true) {
+    // An older approved version can be serving while the CURRENT one awaits
+    // review (the `review` rider) — the status reports BOTH, or it would hide
+    // the pending state and the reviewer's note behind "Approved".
+    const serving = `Approved by ${venue.approvedBy} — runs in the page`;
+    if (venue.review?.status === "pending") return `${serving}; your latest edit is waiting for review`;
+    if (venue.review?.status === "rejected") return `${serving}; your latest edit was rejected — "${venue.review.note}"`;
+    return serving;
+  }
+  if (venue?.granted === false && venue.reason === "pending-review" && venue.review.status === "rejected") {
+    return `Rejected — "${venue.review.note}". Edit the remix to resubmit it for review.`;
+  }
+  if (venue?.granted === false && venue.reason === "version-changed") {
+    return "Changed since approval — sandboxed until re-approved";
+  }
   return "Waiting for review";
 }
 
@@ -203,13 +216,23 @@ function RemixedFork({ appId, slot, review, liveProps, menuOpen, onMenuToggle, o
       .finally(() => setReverting(false));
   };
 
+  // The founder's binding rule (2026-08-02): until a reviewer approves, the
+  // ORIGINAL host component stays rendered, untouched. A pending or rejected
+  // review-kind remix mounts NOTHING here — no AppFrame, no notice in the
+  // page; its status lives in the panel and the ✦ popover. The venue verdict
+  // is server-authoritative ("pending-review" ships no executable source);
+  // the wrapper's own `review` flag covers a payload that carries no venue.
+  const venue = surface?.kind === "tree" ? (surface.payload as { inClient?: InClientVenue }).inClient : undefined;
+  const underReview = venue?.granted !== true
+    && (review || (venue !== undefined && !venue.granted && venue.reason === "pending-review"));
+
   // Until the fork's surface arrives (or if it never does), the original child
   // is the honest content — the wrapper never trades working host markup for
   // a skeleton, and a crashing fork drops back to it (PinMount).
   const Original = () => <>{original}</>;
   return (
     <>
-      {staged?.kind === "tree" ? (
+      {staged?.kind === "tree" && !underReview ? (
         <ChromeRoot automaticPolicyNotice={false}>
           <FluidReveal stateKey={`fork:${appId}`} initialExit={original}>
             <PinMount slot={slot} fallback={Original}>

--- a/packages/ui/test/chrome/remixable.test.tsx
+++ b/packages/ui/test/chrome/remixable.test.tsx
@@ -201,13 +201,77 @@ describe("Remixable — the wrapper fork gesture + in-place jailed mount", () =>
     expect(within(menu).getByRole("status").textContent).toBe("Sandboxed — only you see this");
   });
 
-  it("the ✦ popover renders whatever venue state the open payload reports for a review-kind remix", async () => {
+  // Round-2 finding 1 (the founder's binding rule): until a reviewer
+  // approves, the ORIGINAL host component stays rendered, untouched — this
+  // test previously asserted the jailed fork mount for a pending review-kind
+  // remix, which was the WRONG behavior.
+  it("keeps the ORIGINAL rendered for a review-kind remix awaiting review — no fork mount, status in the ✦ popover only", async () => {
     mount(<Remixable review><TopMerchants title="Top merchants" /></Remixable>);
     fireEvent.click(forkPill());
-    await waitFor(() => expect(forkIframe()).toBeTruthy());
-    // No venue on the payload → the pending state, exactly as reported.
+    await waitFor(() => expect(managePill()).toBeTruthy());
+    // Wait past the fork surface actually arriving: STILL the original.
+    await waitFor(() => expect(wire.requests.some(r => r.method === "GET" && /\/apps\/.+\/open/.test(r.path))).toBe(true));
+    await new Promise(resolve => setTimeout(resolve, 60));
+    expect(screen.getByText("Blue Bottle")).toBeTruthy();
+    expect(forkIframe()).toBeNull();
+    // The pending state lives in the panel/popover ONLY — never as an
+    // in-page notice replacing the host component.
+    expect(screen.queryByText(/sent for review/i)).toBeNull();
     fireEvent.click(managePill());
     expect(screen.getByRole("status").textContent).toBe("Waiting for review");
+  });
+
+  it("keeps the ORIGINAL rendered for a REJECTED review-kind remix, with the note in the ✦ popover", async () => {
+    const forked = await client.apps.forkPin({ slot: SLOT, props: {} });
+    const stored = wire.state.apps.find(app => app.id === forked.app.id)!;
+    (stored.tree as unknown as { inClient: unknown }).inClient = {
+      granted: false,
+      versionHash: "sha256:v1",
+      reason: "pending-review",
+      review: { status: "rejected", versionHash: "sha256:v1", note: "Keep the table layout.", by: "host-admin", at: "2026-08-02T00:00:00.000Z" },
+    };
+    mount(<Remixable review><TopMerchants title="Top merchants" /></Remixable>);
+    await waitFor(() => expect(managePill()).toBeTruthy());
+    fireEvent.click(managePill());
+    await waitFor(() => expect(screen.getByRole("status").textContent)
+      .toBe('Rejected — "Keep the table layout.". Edit the remix to resubmit it for review.'));
+    expect(screen.getByText("Blue Bottle")).toBeTruthy();
+    expect(forkIframe()).toBeNull();
+    expect(screen.queryByText(/remix rejected/i)).toBeNull();
+  });
+
+  it("reports BOTH states when an older approved version serves while the current one is pending review", async () => {
+    const forked = await client.apps.forkPin({ slot: SLOT, props: {} });
+    const stored = wire.state.apps.find(app => app.id === forked.app.id)!;
+    (stored.tree as unknown as { inClient: unknown }).inClient = {
+      granted: true,
+      versionHash: "sha256:v1",
+      approvedBy: "host-admin",
+      at: "2026-08-02T00:00:00.000Z",
+      review: { status: "pending", versionHash: "sha256:v2" },
+    };
+    mount(<Remixable review><TopMerchants title="Top merchants" /></Remixable>);
+    await waitFor(() => expect(managePill()).toBeTruthy());
+    fireEvent.click(managePill());
+    await waitFor(() => expect(screen.getByRole("status").textContent)
+      .toBe("Approved by host-admin — runs in the page; your latest edit is waiting for review"));
+  });
+
+  it("reports BOTH states when an older approved version serves and the current one was rejected", async () => {
+    const forked = await client.apps.forkPin({ slot: SLOT, props: {} });
+    const stored = wire.state.apps.find(app => app.id === forked.app.id)!;
+    (stored.tree as unknown as { inClient: unknown }).inClient = {
+      granted: true,
+      versionHash: "sha256:v1",
+      approvedBy: "host-admin",
+      at: "2026-08-02T00:00:00.000Z",
+      review: { status: "rejected", versionHash: "sha256:v2", note: "Too wide.", by: "host-admin", at: "2026-08-02T01:00:00.000Z" },
+    };
+    mount(<Remixable review><TopMerchants title="Top merchants" /></Remixable>);
+    await waitFor(() => expect(managePill()).toBeTruthy());
+    fireEvent.click(managePill());
+    await waitFor(() => expect(screen.getByRole("status").textContent)
+      .toBe('Approved by host-admin — runs in the page; your latest edit was rejected — "Too wide."'));
   });
 
   it("the ✦ popover surfaces a server-granted venue verdict verbatim", async () => {

--- a/packages/vendo/src/cli/quickstart-config-surface.docs-check.ts
+++ b/packages/vendo/src/cli/quickstart-config-surface.docs-check.ts
@@ -33,7 +33,8 @@ import type {
   ActAs, ActionsRegistry, AppsRuntime, AutomationsEngine, CatalogFile,
   ComponentCatalog, ComponentRegistry, Connector, ExtractedTool,
   HostOAuthAdapter, Json, Judge, KnowledgeAdapter, OverridesFile, PolicyConfig,
-  PolicyFile, Principal, RunId, SandboxAdapter, SecretsProvider, ToolRegistry,
+  PolicyFile, Principal, RunContext, RunId, SandboxAdapter, SecretsProvider,
+  ToolRegistry,
   VendoAgent, VendoGuard, VendoStore, VendoTheme,
 } from "../index.js";
 import type {
@@ -106,6 +107,9 @@ export interface CreateVendoConfig {
       rebind?: boolean;
     };
     designRules?: string;
+    review?: {                // review-kind remixes: who may review (queue/reject/approve)
+      reviewer?(ctx: RunContext): boolean | Promise<boolean>;
+    };
   };
   tours?: readonly TourEntry[];
 }

--- a/packages/vendo/src/review.fixture.test.ts
+++ b/packages/vendo/src/review.fixture.test.ts
@@ -106,6 +106,8 @@ export default function Page() {
     cleanups.push(async () => store.close());
     await store.ensureSchema();
     process.chdir(root);
+    const user = "user_ada";
+    const reviewer = "host_reviewer";
     const vendo = createVendo({
       model: scriptedModel([
         '<Edit><SetName name="Transfer remix v2"/></Edit>',
@@ -119,9 +121,10 @@ export default function Page() {
       },
       store,
       development: true,
+      // Round-2 hardening: reviewing takes the composition's explicit
+      // assertion — even a dev composition never infers it from a principal.
+      apps: { review: { reviewer: (ctx) => ctx.principal.subject === reviewer } },
     });
-    const user = "user_ada";
-    const reviewer = "host_reviewer";
 
     // 1. The user's Remix gesture forks the review-kind slot.
     const forkResponse = await vendo.handler(request("POST", "/apps/fork-pin", { as: user, body: { slot: "TransferPanel" } }));
@@ -144,7 +147,7 @@ export default function Page() {
     expect(pending.payload.components).toBeUndefined();
     expect(pending.payload.furnishings).toBeUndefined();
 
-    // 3. The review queue: the host reviewer sees the submission with the
+    // 3. The review queue: the ASSERTED reviewer sees the submission with the
     // ship-diff; an anonymous caller gets nothing (masked).
     const queueResponse = await vendo.handler(request("GET", "/apps/review-queue", { as: reviewer }));
     expect(queueResponse.status).toBe(200);
@@ -162,6 +165,29 @@ export default function Page() {
     const masked = await vendo.handler(request("GET", "/apps/review-queue"));
     expect(masked.status).toBe(200);
     expect(await masked.json()).toEqual([]);
+    // A host-resolved NON-reviewer sees only their own submissions — the
+    // owner their own item, anyone else nothing (never another user's fork
+    // source) — and their reject is masked like any unowned app.
+    const ownItems = await (await vendo.handler(request("GET", "/apps/review-queue", { as: user }))).json();
+    expect(ownItems).toHaveLength(1);
+    expect(ownItems[0]).toMatchObject({ appId, requester: user });
+    expect(await (await vendo.handler(request("GET", "/apps/review-queue", { as: "user_bob" }))).json()).toEqual([]);
+    expect((await vendo.handler(request("POST", `/apps/${appId}/reject-review`, { as: "user_bob", body: { note: "nope" } }))).status).toBe(404);
+    // WITHOUT the reviewer assertion a dev composition serves no cross-owner
+    // review capability at all: own items only, and reject refuses loudly,
+    // naming the hook to set.
+    const unasserted = createVendo({
+      principal: async (req): Promise<Principal | null> => {
+        const subject = req.headers.get(USER_HEADER);
+        return subject === null ? null : { kind: "user", subject };
+      },
+      store,
+      development: true,
+    });
+    expect(await (await unasserted.handler(request("GET", "/apps/review-queue", { as: reviewer }))).json()).toEqual([]);
+    const unassertedReject = await unasserted.handler(request("POST", `/apps/${appId}/reject-review`, { as: reviewer, body: { note: "nope" } }));
+    expect(unassertedReject.status).toBe(403);
+    expect(((await unassertedReject.json()) as { error: { message: string } }).error.message).toContain("apps.review.reviewer");
     // The seam carries the in-client approval seam's FULL scoping: outside a
     // development composition it is masked for EVERY caller — production
     // reviews ride Cloud's console or the self-hoster's own admin route over
@@ -214,9 +240,16 @@ export default function Page() {
     expect(resubmitted[0]).toMatchObject({ appId, versionHash: v2Hash, resubmissions: 1 });
 
     // 6. Approval grants the native venue for exactly that hash — the fork
-    // now ships, in place, as real code.
-    const approved = await vendo.handler(request("POST", "/dev/inclient-approval", {
+    // now ships, in place, as real code. Never from the remixing user
+    // themselves though, even on this dev seam: approval IS the review.
+    const selfApproved = await vendo.handler(request("POST", "/dev/inclient-approval", {
       as: user,
+      body: { appId, approvedBy: "host-security-review" },
+    }));
+    expect(selfApproved.status).toBe(403);
+    expect(((await selfApproved.json()) as { error: { message: string } }).error.message).toContain("apps.review.reviewer");
+    const approved = await vendo.handler(request("POST", "/dev/inclient-approval", {
+      as: reviewer,
       body: { appId, approvedBy: "host-security-review" },
     }));
     expect(approved.status).toBe(200);
@@ -246,7 +279,7 @@ export default function Page() {
     expect(pendingAgain[0]).toMatchObject({ appId, versionHash: v3Hash, resubmissions: 1 });
 
     // 8. Approving the new version swaps it in.
-    await vendo.handler(request("POST", "/dev/inclient-approval", { as: user, body: { appId, approvedBy: "host-security-review" } }));
+    await vendo.handler(request("POST", "/dev/inclient-approval", { as: reviewer, body: { appId, approvedBy: "host-security-review" } }));
     const swapped = await (await vendo.handler(request("GET", `/apps/${appId}/open`, { as: user }))).json();
     expect(swapped.payload.inClient).toMatchObject({ granted: true, versionHash: v3Hash });
     expect(swapped.payload.inClient.review).toBeUndefined();

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -458,6 +458,19 @@ export interface CreateVendoConfig {
   apps?: {
     experimentalServedApps?: boolean;
     experimentalMachines?: boolean;
+    /** Remix review (round-2 hardening 2026-08-02) — the host's reviewer
+        assertion for the review-kind remix lifecycle: whether THIS caller may
+        read the full review queue, reject, and approve review-kind remixes.
+        Reviewing crosses owner boundaries, so it is never inferred from a
+        principal alone. Unset, the dev review-queue route serves only the
+        caller's own submissions, reject refuses naming this hook, and a user
+        can never approve their own review-kind remix. The same gate rides the
+        runtime surface (`vendo.apps.review` / `vendo.apps.inClient.approve`)
+        — the production path a self-hoster mounts an admin-authenticated
+        route over; Cloud's console is the hosted equivalent. */
+    review?: {
+      reviewer?(ctx: RunContext): boolean | Promise<boolean>;
+    };
     /** Generation-pipeline flags (exemplarContract, structuredRepair,
         regionParallel, endPass) — opt-in while the A/B is measured; threaded
         verbatim to the apps engine. */
@@ -1777,6 +1790,9 @@ export function createVendo(config: CreateVendoConfig): Vendo {
     // that runs generated web apps is a deliberate per-project decision).
     ...(config.apps?.experimentalServedApps === undefined ? {} : { experimentalServedApps: config.apps.experimentalServedApps }),
     ...(config.apps?.experimentalMachines === undefined ? {} : { experimentalMachines: config.apps.experimentalMachines }),
+    // Round-2 hardening — the host's reviewer assertion for the review-kind
+    // remix lifecycle, threaded verbatim (see the CreateVendoConfig comment).
+    ...(config.apps?.review === undefined ? {} : { review: config.apps.review }),
     // Wave 9 — a ladder-authored automation is armed through the automations
     // engine's own enable(), so the 07 §3 grant-capture flow runs at creation
     // and the missing standing-grant approvals surface on the edit result.

--- a/packages/vendo/src/wire/apps.ts
+++ b/packages/vendo/src/wire/apps.ts
@@ -93,18 +93,24 @@ export const appRoutes: RouteEntry[] = [
   // version hash, submission time, resubmission count and the ship-diff
   // payload. It crosses owner boundaries, so it carries the FULL scoping of
   // the in-client approval seam (wire/misc.ts): a development composition AND
-  // a host-resolved principal — reviewing is a HOST trust decision, and in
-  // production no OSS wire surface may expose one subject's pending fork
-  // source to another. Any other caller gets an EMPTY queue — masked, never
-  // a probe. Production reviews ride Cloud's console, or the self-hoster's
-  // own admin-authenticated route over the runtime surface (apps.review).
+  // a host-resolved principal — reviewing is a HOST trust decision, and no
+  // wire surface may expose one subject's pending fork source to another.
+  // Even in dev the cross-owner read requires the composition's reviewer
+  // assertion (apps.review.reviewer, enforced by the runtime); without it a
+  // caller sees only their own submissions, and any other caller gets an
+  // EMPTY queue — masked, never a probe. Production reviews ride Cloud's
+  // console, or the self-hoster's own admin-authenticated route over the
+  // runtime surface (apps.review).
   // Like fork-pin above, this entry must stay ahead of the "/apps/:appId/*"
   // catch-all, whose rest pattern would otherwise capture
   // appId="review-queue".
   route("GET", "/apps/review-queue", async ({ deps, context }) => {
     const ctx = await context("app");
     if (!deps.development || ctx.principal.ephemeral === true) return json([]);
-    return json(await deps.apps.review.queue());
+    // Round-2 hardening: the runtime scopes the answer — the FULL queue only
+    // under the host's reviewer assertion (apps.review.reviewer); any other
+    // host-resolved caller sees just their own submissions.
+    return json(await deps.apps.review.queue(ctx));
   }),
   route("POST", "/apps/import", async ({ request, deps, context }) => {
     // The CSRF floor exempts import (binary body), so it must instead require
@@ -229,9 +235,10 @@ export const appRoutes: RouteEntry[] = [
     // user's panel surfaces) and the work is not deleted — a new version
     // supersedes the rejection. Reviewer-side and cross-subject by design,
     // so it carries the review queue's full scoping (development composition
-    // + host-resolved principal, the in-client approval seam's bar) instead
-    // of owner scoping; any other caller gets the same not-found an unowned
-    // app answers (masked).
+    // + host-resolved principal + the composition's reviewer assertion,
+    // enforced by the runtime: without apps.review.reviewer the reject
+    // refuses, naming the hook) instead of owner scoping; any other caller
+    // gets the same not-found an unowned app answers (masked).
     if (request.method === "POST" && operation === "reject-review" && segments.length === 3) {
       if (!deps.development || ctx.principal.ephemeral === true) {
         throw new VendoError("not-found", `app not found: ${appId}`);

--- a/packages/vendo/src/wire/misc.ts
+++ b/packages/vendo/src/wire/misc.ts
@@ -66,7 +66,11 @@ export const devRoutes: RouteEntry[] = [
   // records (demos and dev; Cloud's review console mints these in
   // production). Development compositions only: production handlers fall
   // through to the ordinary 404, so no production surface can self-approve
-  // an app into the host page.
+  // an app into the host page. For a REVIEW-KIND remix the runtime refuses
+  // the app's own user even here (round-2 hardening): approval IS the
+  // review, so it takes the composition's reviewer assertion
+  // (apps.review.reviewer) — which also lets an asserted reviewer approve
+  // across the owner boundary.
   route("POST", "/dev/inclient-approval", async ({ request, deps, context }) => {
     if (!deps.development) return undefined;
     const body = await requestJson(request);


### PR DESCRIPTION
Round-2 adversarial-check fixes for the remix review lifecycle (spec: `docs/superpowers/specs/2026-08-02-remix-final-shape-design.md`, Review section).

## Findings

**F1 (HIGH, spec violation) — pending/rejected review-kind rendered a notice in place of the host component.**
`packages/ui/src/chrome/remixable.tsx` no longer mounts anything for a pending or rejected review-kind remix: the ORIGINAL host child stays rendered, untouched (no AppFrame, no in-page "Sent for review"/rejection notice). The status lives in the panel and the ✦ popover only. The venue verdict is server-authoritative; the wrapper's `review` flag covers a payload with no venue. Tests: pending → original in DOM, no AppFrame; same for rejected.

**F2 (MEDIUM) — status hid the current version's review state behind "Approved".**
`remixStatus()` now reports BOTH the serving-version state and the current-version standing: "Approved by X — runs in the page; your latest edit is waiting for review" / "…was rejected — \"note\"", plus the rejected-with-note state for an unserved current version. Both rider combinations tested.

**F3 — review queue/reject were gated on `deps.development` alone.**
(a) New optional `reviewer(ctx): boolean | Promise<boolean>` hook on the apps review config (`createVendo({ apps: { review: { reviewer } } })`, threaded to `AppsConfig.review`). Unset: the dev queue route serves ONLY the caller's own items, and reject refuses with a message naming the hook. Set: only asserted reviewers read the full queue (with diffs) or reject; non-reviewers are masked as not-found.
(b) The same reviewer-gated capability rides the runtime surface (`vendo.apps.review.queue(ctx)` / `.reject(input, ctx)`) — the production path a self-hoster mounts an admin-authenticated route over. Cloud's console (hosted, out of repo) keeps its own minting path; nothing it relies on was removed or renamed.

**F4 — dev-seam self-approval of review-kind remixes.**
`inClient.approve` now refuses a review-kind app's own user unless the reviewer hook covers them (message names the hook), and lets an asserted reviewer approve across the owner boundary. Instant-kind keeps plain owner scoping, unchanged. The seam stays dev-only. Tests: owner self-approve refused; reviewer approve allowed.

**F5 (LOW) — duplicate-rejection check-then-write race.**
Rejection rows now use a deterministic id keyed by (appId, versionHash), so racing duplicate rejections upsert the SAME row and converge on one note. Test: two concurrent rejections → one stored row.

## Existing-test changes (called out per the lane rules)

- `packages/ui/test/chrome/remixable.test.tsx` — "the ✦ popover renders whatever venue state the open payload reports for a review-kind remix" asserted the jailed fork MOUNT for a pending review-kind remix — the exact wrong behavior finding 1 bans. Rewritten to assert the original child stays with no AppFrame; three new tests cover rejected-with-note and both approved+rider statuses.
- `packages/vendo/src/review.fixture.test.ts` — asserted that ANY host-resolved principal reads the full queue and rejects (wrong per F3) and that the OWNER self-approves via `/dev/inclient-approval` (wrong per F4). The composition now asserts the reviewer; approvals move to the reviewer; added: own-items-only scoping, non-reviewer reject masked, hookless composition refusals naming the hook, owner self-approve refused (403).
- `packages/apps/src/review.test.ts` — same category at the unit level: setup composes the reviewer hook, `queue()` calls pass the reviewer ctx, review-kind approvals move from owner to reviewer ctx. New describe covers queue scoping, hookless refusal naming the hook, masked non-reviewer reject, owner-refused/reviewer-allowed approval, instant-kind owner self-approval regression, and the F5 concurrent-rejection convergence.

## Lane-boundary note (W3)

`docs/quickstart.md` (W3's directory) carries ONE mechanical addition: the quickstart drift gate (`quickstart-config-surface.docs-check.ts` + `quickstart.docs.test.ts`) pins the doc's config listing byte-identical to the real `CreateVendoConfig`, so adding `apps.review` is impossible without it — typecheck and the docs test fail otherwise. W3's declared doc work touches different files (`docs-site/connect/host-components.mdx`, `docs-site` cli.mdx, `docs/host-components.md`), so no collision is expected.

## Gates

`pnpm build` / `pnpm typecheck` / `pnpm lint` green; full `pnpm test` green (umbrella suite run un-contended: 131 files passed, 1594 tests passed, 0 errors; earlier contended runs had a vitest worker OOM-killed by a sibling lane's 7GB test worker — infra, all executed tests passed every run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the remix review lifecycle: added host reviewer gating and fixed pending-state rendering to keep originals visible until approval. Prevents self-approval, improves status messaging, and makes rejections idempotent.

- **New Features**
  - Added `apps.review.reviewer(ctx)` to assert reviewers; gates queue, reject, and approval across owner boundaries.
  - `apps.review.queue(ctx)` now requires `ctx`; non-reviewers see only their own items, and non-reviewer rejects are masked as not-found. Review-kind approvals require a reviewer; instant-kind unchanged.

- **Bug Fixes**
  - Pending/rejected remixes no longer replace the host component; original stays rendered with status shown in the panel/✦ popover. `remixStatus` now reports serving and current version states (pending/rejected with note).
  - Removed duplicate-rejection race by keying rows by `(appId, versionHash)` so concurrent rejects converge to one note.

<sup>Written for commit aba136ffe02deb64325f537788e291117fafdafb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

