### PR TITLE
eval: replace the burned alongside-composition scenario (blind-authored)

### DIFF
--- a/docs/eval/REMIX.md
+++ b/docs/eval/REMIX.md
@@ -177,7 +177,7 @@ Measured steps are (A), (B), (C) in order on the scenario's fresh base app.
 carrying that instruction; with no instruction it is the plain add-as-is
 gesture.
 
-### demo-bank (Maple) — R-M1–R-M6
+### demo-bank (Maple) — R-M1–R-M7
 
 - **R-M1** [gesture-fork][fork-modify] — (A) Remix gesture on
   `MapleNetWorthCard` with «also show the change in dollars for the selected
@@ -216,8 +216,18 @@ gesture.
   `drifted`. (C) invoke the explicit rebase for the slot — expect
   `status:"rebased"` with the (A) intent replayed, the reopened fork showing
   BOTH the host's new label and the 1Y default, and the drift notice gone.
+- **R-M7** [gesture-fork][pin-preserve] — (A) Remix gesture on
+  `MapleNetWorthCard` with «show the total in whole dollars — drop the
+  cents». (B) text edit `add my savings goals with progress bars next to the
+  card`. Expect: (A) fork faithful with the headline rounded to whole dollars
+  (the cents digits gone, nothing else changed — badge, switcher, and chart
+  intact); (B) leaves the fork byte-identical (pin diff unchanged between
+  shots), pin still listed, goals section added outside the fork showing the
+  goals `listGoals` returns — each with its name and progress toward target —
+  no invented goals or amounts. (Blind replacement for burned R-C6, authored
+  2026-08-03 under rule 4.)
 
-### demo-accounting (Cadence) — R-C1–R-C6
+### demo-accounting (Cadence) — R-C1–R-C5
 
 - **R-C1** [gesture-fork][fork-modify] — (A) Remix gesture on
   `CadenceMissingDocsHero` with «also show what percent of clients are fully
@@ -247,16 +257,22 @@ gesture.
   per the F4 ruling (no invented literals, no lookalike), and the table
   composed from real data. A silently minted pin or fabricated hero numbers
   are FAILs.
-- **R-C6** [gesture-fork][pin-preserve] — (A) Remix gesture with «make the
-  label read 'Clients still owing documents'». (B) text edit `add a donut of
-  documents by status next to it`. Expect: (B) leaves the fork byte-identical,
-  pin intact, donut added outside the fork from real document data.
 
 ## DEV list — burned scenarios
 
 (empty at freeze — rule 4 populates this. The 2026-07-21 gesture-first
 restatement is eval maintenance under the design rulings above, not a fix-PR
 discussion; the asks and bar substance are unchanged, so the set stays live.)
+
+Entries below are kept verbatim for development use only. They are NEVER
+scored and do not count toward the 12.
+
+- **R-C6** [gesture-fork][pin-preserve] — BURNED 2026-08-03 under rule 4
+  (analyzed in a fix PR; replaced blind by R-M7) — (A) Remix gesture with
+  «make the label read 'Clients still owing documents'». (B) text edit `add a
+  donut of documents by status next to it`. Expect: (B) leaves the fork
+  byte-identical, pin intact, donut added outside the fork from real document
+  data.
 
 ## Run ledger
 


### PR DESCRIPTION
## What burned and why

**R-C6** (Cadence: fork `CadenceMissingDocsHero` with a label change, then add a donut of documents by status next to it) was named and analyzed in a fix PR. Under REMIX rule 4, a discussed scenario is burned: it moves to the DEV list and is replaced blind before the next run.

## What this PR does (docs only — `docs/eval/REMIX.md`)

- Moves R-C6 verbatim into a clearly-marked **DEV list** entry (kept for development use, explicitly never scored).
- Adds **R-M7**, the blind replacement, exercising the same capability — composing NEW content ALONGSIDE a forked host component that must stay byte-identical (`[gesture-fork][pin-preserve]`) — with every specific changed: host Maple instead of Cadence, component `MapleNetWorthCard` instead of the Cadence hero, a whole-dollars headline instruction on the fork, and a savings-goals-with-progress-bars addition bound to `listGoals` (real seeded data) instead of a document-status donut.
- The set stays at **12 scored scenarios**. No other scenario is renumbered or reworded; no PASS bar is softened.

## Blindness confirmation

This replacement was authored blind: I did not read the fix PR, the 2026-08-03 run README or results, or any recent commits touching `packages/apps/src/generation/**`. Inputs were limited to `docs/eval/REMIX.md` itself, the 2026-08-02 remix final-shape spec, and the demo hosts' user-visible surfaces/API inventories (to confirm the ask is expressible and the data really exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Burned Cadence scenario R-C6 per REMIX rule 4 and replaced it blind with Maple scenario R-M7. Updated `docs/eval/REMIX.md` to move `R-C6` to the DEV list (never scored) and add `R-M7`; the scored set remains 12.

- **New Features**
  - Added `R-M7`: fork `MapleNetWorthCard` and round the headline to whole dollars; add savings goals with progress bars next to the card using `listGoals` data; fork must remain byte-identical (pin preserved).

<sup>Written for commit d1679dc9236df23b100308fe7957467decbcf574. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

