### PR TITLE
self-serve R+P: try unlisted, runnable JS scaffolds, doctor version-skew, CLI honesty fixes

### DIFF
--- a/.changeset/self-serve-cli-honesty.md
+++ b/.changeset/self-serve-cli-honesty.md
@@ -1,0 +1,42 @@
+---
+"@vendoai/vendo": minor
+---
+
+Seven self-serve fixes across the CLI: the install path stops lying, and the JS
+scaffolds run.
+
+**Plain-JavaScript hosts boot again.** The generated `vendo/server.mjs` carried
+two pieces of TypeScript — `kind: "user" as const` in the principal line and a
+`as Headers & { … }` cast around `getSetCookie` — so every Express, bare-Node
+and `--framework custom` host on a JS codebase died with `SyntaxError:
+Unexpected identifier 'as'` on its first `node server.js`. Both expressions now
+follow the host's language, and Node's own parser gates them in CI.
+
+**`vendo doctor` names a stale install.** npm release-cooldown configs
+(`min-release-age`) silently resolve an old `@vendoai/vendo`, and nothing ever
+said so. Doctor now checks npm's `latest` and prints `warning: installed
+@vendoai/vendo X is behind latest Y` with the upgrade command. Fail-soft: an
+offline, blocked or slow registry says nothing at all and never changes the
+exit code.
+
+**Two silent CI failures are loud.** `vendo mcp server-json` with missing flags
+used to fall into a readline prompt even on a piped stdin — a script or agent
+hung forever; it now exits 1 naming `--domain` and `--url`. `vendo sync
+--report` without a Cloud key used to complain and exit 0, so a reporting lane
+stayed green while never reporting; it now exits 1.
+
+**`vendo try` is unlisted.** The command still runs for anyone invoking it, but
+help no longer advertises it (nor do the retired `playground`/`refine`
+notices): the pre-install `npx vendo try` pitch it fronted resolves no npm
+package.
+
+**Init's ending puts the paste last.** The run's final line is the outstanding
+paste, on interactive and non-interactive runs alike, instead of the star ask
+or the agent tail; the "start your dev server — the agent is live in your app"
+line is withheld while a paste is still pending (it contradicted the frame
+right above it); and the keyless Cloud pitch is three lines, since `vendo
+login` narrates its own ceremony.
+
+**Quieter dev-server logs.** The hosted-store automations notice is latched per
+process — a Next dev server recomposes on nearly every request, and the
+paragraph was landing in the host's log dozens of times per session.

--- a/packages/vendo/src/cli.playground.test.ts
+++ b/packages/vendo/src/cli.playground.test.ts
@@ -2,27 +2,30 @@ import { describe, expect, it, vi } from "vitest";
 import { main } from "./cli.js";
 
 describe("vendo playground retirement", () => {
-  it("fails with a one-liner pointing at vendo try", async () => {
+  it("fails with a one-liner pointing at the install path", async () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
     expect(await main(["playground"])).toBe(1);
     const printed = error.mock.calls.flat().join("\n");
-    expect(printed).toContain("vendo try");
+    expect(printed).toContain("vendo init");
     expect(printed).toContain("retired");
+    // `try` is unlisted (self-serve audit B1) — a retirement notice must not
+    // send the next stranger at a command help does not name.
+    expect(printed).not.toContain("vendo try");
     error.mockRestore();
   });
 
-  it("points at vendo try even when the old flags ride along", async () => {
+  it("says the same thing when the old flags ride along", async () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
     expect(await main(["playground", "--port", "4123", "--no-open"])).toBe(1);
-    expect(error.mock.calls.flat().join("\n")).toContain("vendo try");
+    expect(error.mock.calls.flat().join("\n")).toContain("vendo init");
     error.mockRestore();
   });
 
-  it("--help lists try, not playground", async () => {
+  it("--help lists neither playground nor the unlisted try", async () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
     expect(await main(["--help"])).toBe(0);
     const help = log.mock.calls.flat().join("\n");
-    expect(help).toContain("try");
+    expect(help).not.toMatch(/\btry\b/);
     expect(help).not.toContain("playground");
     log.mockRestore();
   });

--- a/packages/vendo/src/cli.test.ts
+++ b/packages/vendo/src/cli.test.ts
@@ -43,13 +43,12 @@ describe("vendo CLI commands", () => {
     log.mockRestore();
   });
 
-  it("vendo refine is no longer a command: retirement notice pointing at sync + try", async () => {
+  it("vendo refine is no longer a command: retirement notice pointing at sync", async () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
     expect(await main(["refine"])).toBe(1);
     const output = error.mock.calls.flat().join("\n");
     expect(output).toContain("vendo refine was retired");
     expect(output).toContain("vendo sync");
-    expect(output).toContain("vendo try");
     error.mockRestore();
   });
 

--- a/packages/vendo/src/cli.try.test.ts
+++ b/packages/vendo/src/cli.try.test.ts
@@ -7,10 +7,13 @@ vi.mock("./cli/try.js", () => ({ runTry: vi.fn(async () => 0) }));
 const runTryMock = vi.mocked(runTry);
 
 describe("vendo try CLI wiring", () => {
-  it("lists try in --help", async () => {
+  // Unlisted, not retired (self-serve audit B1): help never names try — the
+  // pre-install `npx vendo try` pitch resolves no package — but every invocation
+  // below must keep working for the scripts and docs already using it.
+  it("is unlisted in --help", async () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
     expect(await main(["--help"])).toBe(0);
-    expect(log.mock.calls.flat().join("\n")).toContain("try");
+    expect(log.mock.calls.flat().join("\n")).not.toMatch(/\btry\b/);
     log.mockRestore();
   });
 

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -18,7 +18,6 @@ const HELP = `vendo — install your product's agent
 Usage: vendo <command> [dir] [options]
 
 Commands:
-  try             See your product's agent before installing: profile this repo read-only, serve a live local demo
   init [dir]      Set up Vendo: wire the handler, extract tools + theme, resolve a model key
   login           Claim a Vendo Cloud key: approve in the browser; the key lands in .env.local
   doctor [dir]    Verify the install: wiring, live probes, and one real model turn (--json for agents)
@@ -41,7 +40,7 @@ Options:
   --wait <seconds>           Login only: bound this call's polling to N seconds (agents loop re-runs; each resumes the same request), then exit resumably
   --byo                      Init only: decline the Vendo Cloud offer (bring your own model key)
   --ai                       Init/sync: run the AI judgment pass without asking (works non-interactively)
-  --engine <name>            Init/try/sync: pin the AI engine (claude, codex, npx) instead of first-available
+  --engine <name>            Init/sync: pin the AI engine (claude, codex, npx) instead of first-available
   --theme <slot=value>       Init only: override a theme slot value directly (repeatable)
   --list                     Eject only: show the ejectable surfaces
   --url <url>                Doctor/server-json: mounted wire base or public MCP URL
@@ -49,9 +48,7 @@ Options:
   --review                   Sync only: show the queued + new loosenings and confirm before writing
   --full                     Sync only: judge the whole catalog instead of only what moved
   --theme-refresh            Sync only: take the theme scan's values even for slots you hand-edited
-  --port <port>              Try only: listen on a fixed port (default: any free port)
-  --no-open                  Try only: print the URL without opening the browser
-  --no-ai                    Init/sync: force the AI judgment pass off; try: skip the background AI deepening
+  --no-ai                    Init/sync: force the AI judgment pass off
   --json                     Sync/doctor: print one machine-readable report object
   --report                   Sync only: push the report to Vendo Cloud
   --key <key>                Sync/cloud: override VENDO_API_KEY
@@ -279,9 +276,13 @@ export async function main(argv: string[]): Promise<number> {
     // .vendo (compounds/briefs live in .vendo/overrides.json), and the try
     // surface's refine panel carries the conversational-correction loop —
     // the refine ENGINE lives on there (src/refine.ts).
-    console.error("vendo refine was retired — `vendo sync` AI-enriches .vendo now (compounds and briefs live in .vendo/overrides.json), and `vendo try` offers conversational corrections in its refine panel. Run: vendo sync");
+    console.error("vendo refine was retired — `vendo sync` AI-enriches .vendo now (compounds and briefs live in .vendo/overrides.json). Run: vendo sync");
     return 1;
   }
+  // UNLISTED (self-serve audit B1): `try` still runs for anyone who already
+  // invokes it, but HELP no longer advertises it — the pre-install pitch it
+  // fronted (`npx vendo try`) resolves no npm package, so naming it here sends
+  // strangers to a 404 or, worse, a same-named binary already on their PATH.
   if (command === "try") {
     const { errors, port, engine } = tryOptionErrors(args);
     if (errors.length > 0) {
@@ -296,10 +297,10 @@ export async function main(argv: string[]): Promise<number> {
     });
   }
   if (command === "playground") {
-    // Retired: `vendo try` absorbed the playground's job (the scripted
-    // surfaces still serve when try runs keyless or outside a repo). The
-    // bundle machinery lives on in cli/playground.ts and cli/playground/.
-    console.error("vendo playground was retired — `vendo try` does the same job (and more): scripted surfaces with no model key, plus a live profile of your repo when run inside one. Run: vendo try");
+    // Retired: the playground's job moved into the try surface (unlisted —
+    // see the `try` branch below). The bundle machinery lives on in
+    // cli/playground.ts and cli/playground/.
+    console.error("vendo playground was retired — set Vendo up in your own repo instead: `vendo init`, then `vendo doctor`. Docs: https://vendo.run/quickstart");
     return 1;
   }
   if (command === "sync") {

--- a/packages/vendo/src/cli/cloud-init.ts
+++ b/packages/vendo/src/cli/cloud-init.ts
@@ -122,16 +122,17 @@ function gitCheckIgnore(cwd: string, path: string): Promise<IgnoreVerdict> {
 export const AUTH_MD_URL = "https://vendo.run/auth.md";
 
 /** The agent-path key pointer: when an agent-driven init needs a Cloud key
-    and none exists, this block is the whole story — discovery URL, the CLI
-    command that runs the user-claimed ceremony, and both fallbacks (paste a
-    key with --cloud-key; stay keyless with --byo). Deterministic lines an
-    agent parses; exported so init's tail and the tests share one source. */
+    and none exists, this block is the whole story — the CLI command that runs
+    the user-claimed ceremony, its discovery URL, and both fallbacks (paste a
+    key with --cloud-key; stay keyless with --byo). Three lines, not the full
+    device-flow walkthrough: `vendo login` narrates its own ceremony step by
+    step, and the upsell used to open a keyless init before the user learned
+    what init did (self-serve audit F8). Deterministic lines an agent parses;
+    exported so init's tail and the tests share one source. */
 export function agentKeyPointerLines(): string[] {
   return [
-    `Vendo Cloud key (agent path): fetch ${AUTH_MD_URL} and follow the user-claimed flow —`,
-    "  1. run `vendo login` — it prints a code your human approves in the browser",
-    "  2. the minted VENDO_API_KEY lands in .env.local automatically (never printed)",
-    "  3. re-run `vendo init` (it picks the key up from .env.local) or pass --cloud-key <key>",
+    "Vendo Cloud key (agent path): run `vendo login` — it prints a code your human approves in the browser, and the minted VENDO_API_KEY lands in .env.local (never printed).",
+    `Then re-run \`vendo init\` (it picks the key up) or pass --cloud-key <key>. Protocol: ${AUTH_MD_URL}`,
     "No Cloud account wanted? Re-run with --byo and set a provider key (ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_GENERATIVE_AI_API_KEY).",
   ];
 }

--- a/packages/vendo/src/cli/dep-versions.ts
+++ b/packages/vendo/src/cli/dep-versions.ts
@@ -92,6 +92,51 @@ function versionOf(manifestSource: string): string | null {
 }
 
 /**
+ * npm's dist-tag document for one package — the smallest request that answers
+ * "what is latest". Fail-soft to null on ANY problem (offline, proxy, 404,
+ * slow registry, non-JSON): a version hint must never slow doctor down, break
+ * an air-gapped run, or invent a skew it could not verify.
+ */
+export async function npmLatestVersion(
+  name: string,
+  fetchImpl: typeof fetch = fetch,
+  timeoutMs = 2_000,
+): Promise<string | null> {
+  try {
+    const response = await fetchImpl(`https://registry.npmjs.org/-/package/${name}/dist-tags`, {
+      headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) return null;
+    const tags = await response.json() as { latest?: unknown };
+    return typeof tags.latest === "string" ? tags.latest : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Plain numeric "is `version` older than `other`". Prereleases are compared on
+    their numeric head only — Vendo publishes none to `latest`, and a guess is
+    worse than silence here, so anything unparseable answers false. */
+export function isOlderVersion(version: string, other: string): boolean {
+  const parts = (value: string): number[] | null => {
+    const bare = bareVersion(value);
+    if (bare === undefined) return null;
+    return bare.split(/[.\-+]/).slice(0, 3).map((part) => Number.parseInt(part, 10));
+  };
+  const left = parts(version);
+  const right = parts(other);
+  if (left === null || right === null) return false;
+  for (let index = 0; index < 3; index += 1) {
+    const a = left[index] ?? 0;
+    const b = right[index] ?? 0;
+    if (Number.isNaN(a) || Number.isNaN(b)) return false;
+    if (a !== b) return a < b;
+  }
+  return false;
+}
+
+/**
  * Read the host project's dependency versions (deps + devDeps) for telemetry.
  * Non-throwing: a missing or malformed package.json returns {}.
  */

--- a/packages/vendo/src/cli/doctor-version-skew.test.ts
+++ b/packages/vendo/src/cli/doctor-version-skew.test.ts
@@ -1,0 +1,88 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { npmLatestVersion } from "./dep-versions.js";
+import { runDoctor } from "./doctor.js";
+import { CLI_VERSION, type Output } from "./shared.js";
+
+/**
+ * Self-serve audit F1: npm release-cooldown configs (`min-release-age`)
+ * resolve an old @vendoai/vendo silently — one gauntlet install sat four
+ * versions and seven days behind with nothing ever saying so. Doctor now says
+ * it, and says nothing at all when the registry cannot be reached.
+ */
+
+const cleanup: string[] = [];
+afterEach(async () => {
+  await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+function sink(): { errors: string[]; output: Output } {
+  const errors: string[] = [];
+  return { errors, output: { log: () => {}, error: (message) => errors.push(message) } };
+}
+
+/** The smallest host doctor will run against: nothing here reaches a network
+    except the npm lookup under test (which every case scripts). */
+async function host(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-doctor-skew-"));
+  cleanup.push(root);
+  await mkdir(join(root, ".vendo"), { recursive: true });
+  await writeFile(join(root, "package.json"), JSON.stringify({ dependencies: { "@vendoai/vendo": CLI_VERSION } }));
+  return root;
+}
+
+async function doctorErrors(npmLatest: () => Promise<string | null>): Promise<string> {
+  const messages = sink();
+  await runDoctor({
+    targetDir: await host(),
+    env: {},
+    interactive: false,
+    fetchImpl: vi.fn(async () => { throw new Error("connection refused"); }),
+    liveTurn: async () => ({ attempted: false, ok: false, rung: "none", credential: "none", elapsedMs: 0 }),
+    cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
+    telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    output: messages.output,
+    npmLatest,
+  });
+  return messages.errors.join("\n");
+}
+
+describe("doctor names an install that is behind npm latest", () => {
+  it("stale: names both versions, the upgrade command, and why it happened", async () => {
+    const errors = await doctorErrors(async () => "99.0.0");
+    expect(errors).toContain(`warning: installed @vendoai/vendo ${CLI_VERSION} is behind latest 99.0.0`);
+    expect(errors).toContain("npm install @vendoai/vendo@latest");
+    expect(errors).toContain("min-release-age");
+  });
+
+  it("current: silent when the installed version IS latest", async () => {
+    expect(await doctorErrors(async () => CLI_VERSION)).not.toContain("is behind latest");
+  });
+
+  it("offline: silent when the registry cannot answer", async () => {
+    expect(await doctorErrors(async () => null)).not.toContain("is behind latest");
+  });
+
+  it("never warns backwards — a prerelease CLI ahead of latest stays quiet", async () => {
+    expect(await doctorErrors(async () => "0.0.1")).not.toContain("is behind latest");
+  });
+});
+
+describe("the npm latest lookup fails soft", () => {
+  it("reads the dist-tag document", async () => {
+    const fetchImpl = vi.fn(async () => Response.json({ latest: "1.2.3", next: "2.0.0-rc.1" }));
+    expect(await npmLatestVersion("@vendoai/vendo", fetchImpl as unknown as typeof fetch)).toBe("1.2.3");
+    expect(String(fetchImpl.mock.calls[0]?.[0])).toBe("https://registry.npmjs.org/-/package/@vendoai/vendo/dist-tags");
+  });
+
+  it("answers null for a throwing fetch, a non-2xx, and a shapeless body", async () => {
+    const throws = vi.fn(async () => { throw new Error("ENOTFOUND"); });
+    const notFound = vi.fn(async () => new Response("nope", { status: 404 }));
+    const shapeless = vi.fn(async () => Response.json({ tags: {} }));
+    for (const impl of [throws, notFound, shapeless]) {
+      expect(await npmLatestVersion("@vendoai/vendo", impl as unknown as typeof fetch)).toBeNull();
+    }
+  });
+});

--- a/packages/vendo/src/cli/doctor.test.ts
+++ b/packages/vendo/src/cli/doctor.test.ts
@@ -37,6 +37,9 @@ async function doctor(options: Parameters<typeof runDoctor>[0]): Promise<number>
       elapsedMs: 1,
     }),
     cloudProbe: async () => ({ present: false, ok: false, unlocks: ["a starter allowance"] }),
+    // No registry round-trip from the suite: the npm-latest hint is its own
+    // test (doctor-version-skew.test.ts).
+    npmLatest: async () => null,
     ...options,
   });
 }
@@ -758,6 +761,7 @@ describe("vendo doctor v2 (live turn + --json + cloud + dev-server probe)", () =
       },
       interactive: false,
       cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
+      npmLatest: async () => null,
       output: messages.sink,
       telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
     })).toBe(0);
@@ -773,6 +777,7 @@ describe("vendo doctor v2 (live turn + --json + cloud + dev-server probe)", () =
       env: { ANTHROPIC_API_KEY: "sk-test" },
       interactive: false,
       cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
+      npmLatest: async () => null,
       output: bare.sink,
       telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
     })).toBe(0);
@@ -789,6 +794,7 @@ describe("vendo doctor v2 (live turn + --json + cloud + dev-server probe)", () =
       env: { ANTHROPIC_API_KEY: "sk-test" },
       interactive: false,
       cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
+      npmLatest: async () => null,
       output: messages.sink,
       telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
     })).toBe(0);
@@ -806,6 +812,7 @@ describe("vendo doctor v2 (live turn + --json + cloud + dev-server probe)", () =
       env: { ANTHROPIC_API_KEY: "sk-test" },
       interactive: false,
       cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
+      npmLatest: async () => null,
       output: messages.sink,
       telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
     })).toBe(1);
@@ -920,6 +927,7 @@ describe("vendo doctor v2 (live turn + --json + cloud + dev-server probe)", () =
       confirm,
       startDevServer,
       cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
+      npmLatest: async () => null,
       output: messages.sink,
       telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
     })).toBe(0);
@@ -960,6 +968,7 @@ describe("vendo doctor v2 (live turn + --json + cloud + dev-server probe)", () =
       confirm,
       startDevServer,
       cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
+      npmLatest: async () => null,
       output: messages.sink,
       telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
     })).toBe(0);

--- a/packages/vendo/src/cli/doctor.ts
+++ b/packages/vendo/src/cli/doctor.ts
@@ -332,10 +332,13 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
   // resolve an old @vendoai/vendo silently, and Vendo ships often enough that
   // those users stay permanently behind with nothing ever saying so. A hint,
   // not a check: it has no fix_ref registry code and never changes the exit
-  // code, and an unreachable registry says nothing at all.
-  const latestPublished = await (options.npmLatest ?? (() => npmLatestVersion("@vendoai/vendo")))();
-  if (latestPublished !== null && isOlderVersion(CLI_VERSION, latestPublished) && !json) {
-    output.error(`warning: installed @vendoai/vendo ${CLI_VERSION} is behind latest ${latestPublished} — npm install @vendoai/vendo@latest (release-cooldown npm configs like min-release-age resolve old versions silently)`);
+  // code, and an unreachable registry says nothing at all. Skipped outright
+  // under --json, so an agent run never pays for a lookup it cannot see.
+  if (!json) {
+    const latestPublished = await (options.npmLatest ?? (() => npmLatestVersion("@vendoai/vendo")))();
+    if (latestPublished !== null && isOlderVersion(CLI_VERSION, latestPublished)) {
+      output.error(`warning: installed @vendoai/vendo ${CLI_VERSION} is behind latest ${latestPublished} — npm install @vendoai/vendo@latest (release-cooldown npm configs like min-release-age resolve old versions silently)`);
+    }
   }
 
   for (const file of ["tools.json", "overrides.json", "policy.json", "brief.md", "theme.json"]) {

--- a/packages/vendo/src/cli/doctor.ts
+++ b/packages/vendo/src/cli/doctor.ts
@@ -10,7 +10,7 @@ import {
   type CloudDoctorResult,
   type LiveTurnResult,
 } from "./doctor-live.js";
-import { installedAiVersion, installedZodVersion } from "./dep-versions.js";
+import { installedAiVersion, installedZodVersion, isOlderVersion, npmLatestVersion } from "./dep-versions.js";
 import { zodBelowAiSdkFloor, zodBumpInvocation } from "./provider-deps.js";
 import { describeDevCredential, resolveDevCredential } from "../dev-creds/resolve.js";
 // Relative (not the #dev-creds condition): the CLI is Node-only and the edge
@@ -51,6 +51,9 @@ export interface DoctorOptions {
   cloudProbe?: (options: { env?: Record<string, string | undefined> }) => Promise<CloudDoctorResult>;
   startDevServer?: (options: { root: string; statusUrl: string; env?: Record<string, string | undefined>; fetchImpl?: typeof fetch }) => Promise<{ ok: boolean; stop: () => void }>;
   e2bResolvable?: (root: string) => boolean;
+  /** The npm `latest` lookup behind the version-skew line — its own seam, not
+      fetchImpl, so a scripted wire probe never doubles as a registry answer. */
+  npmLatest?: () => Promise<string | null>;
 }
 
 type CheckStatus = "ok" | "broken" | "warning";
@@ -323,6 +326,16 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
     fail("deps/zod-floor", "E-DEP-003", `installed zod@${zodVersion} predates the zod/v3 + zod/v4 subpaths the AI SDK imports (needs >=3.25) — the app build fails inside ai@6; bump within zod 3: ${await zodBumpInvocation(root)}`);
   } else if (zodVersion !== null) {
     pass("deps/zod-floor", `installed zod@${zodVersion} exposes the AI SDK's zod/v3 + zod/v4 subpaths (>=3.25)`);
+  }
+
+  // Self-serve audit F1 — npm release-cooldown configs (`min-release-age`)
+  // resolve an old @vendoai/vendo silently, and Vendo ships often enough that
+  // those users stay permanently behind with nothing ever saying so. A hint,
+  // not a check: it has no fix_ref registry code and never changes the exit
+  // code, and an unreachable registry says nothing at all.
+  const latestPublished = await (options.npmLatest ?? (() => npmLatestVersion("@vendoai/vendo")))();
+  if (latestPublished !== null && isOlderVersion(CLI_VERSION, latestPublished) && !json) {
+    output.error(`warning: installed @vendoai/vendo ${CLI_VERSION} is behind latest ${latestPublished} — npm install @vendoai/vendo@latest (release-cooldown npm configs like min-release-age resolve old versions silently)`);
   }
 
   for (const file of ["tools.json", "overrides.json", "policy.json", "brief.md", "theme.json"]) {

--- a/packages/vendo/src/cli/init-scaffolds.test.ts
+++ b/packages/vendo/src/cli/init-scaffolds.test.ts
@@ -1,0 +1,54 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { execPath } from "node:process";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import { customServerSource, expressServerSource } from "./init-scaffolds.js";
+
+const run = promisify(execFile);
+
+const cleanup: string[] = [];
+afterEach(async () => {
+  await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+/** Node's own parser is the only honest judge of "is this valid JavaScript" —
+    a substring assertion misses the next type annotation that sneaks in. */
+async function parses(source: string): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-scaffold-check-"));
+  cleanup.push(root);
+  const file = join(root, "server.mjs");
+  await writeFile(file, source);
+  await run(execPath, ["--check", file]);
+}
+
+/**
+ * Self-serve audit B2: the JS-emitted scaffolds carried TypeScript syntax —
+ * `kind: "user" as const` in the principal line and a `as Headers & {…}` cast
+ * around getSetCookie — so every plain-JS host threw `SyntaxError: Unexpected
+ * identifier 'as'` on its first `node server.js`.
+ */
+describe("JS-emitted scaffolds are valid JavaScript", () => {
+  it("the Express composition parses as .mjs", async () => {
+    await parses(expressServerSource(false));
+  });
+
+  it("the runtime-neutral composition parses as .mjs", async () => {
+    await parses(customServerSource(false));
+  });
+
+  it("neither JS scaffold carries a type annotation", () => {
+    for (const source of [expressServerSource(false), customServerSource(false)]) {
+      expect(source).not.toContain(" as const");
+      expect(source).not.toContain(" as Headers");
+    }
+  });
+
+  it("the TypeScript scaffolds keep the annotations they need", () => {
+    expect(expressServerSource(true)).toContain(`kind: "user" as const`);
+    expect(expressServerSource(true)).toContain("as Headers & { getSetCookie?: () => string[] }");
+    expect(customServerSource(true)).toContain(`kind: "user" as const`);
+  });
+});

--- a/packages/vendo/src/cli/init-scaffolds.ts
+++ b/packages/vendo/src/cli/init-scaffolds.ts
@@ -64,12 +64,16 @@ export function registrySource(variant: "tsx" | "mjs"): string {
     the embeds, which call this route directly (0.4.1 E2E cert blocker B4:
     a `() => null` wire against a demo-user chat route rendered an infinite
     skeleton). Replaced wholesale when an auth preset is wired. */
-export function anonymousPrincipalLines(): string {
+export function anonymousPrincipalLines(typescript: boolean): string {
+  // `as const` narrows kind to the Principal literal in TypeScript and is a
+  // SyntaxError in a .mjs file (self-serve audit B2: every plain-JS host died on
+  // its first `node server.js`), so the annotation rides the host's language.
+  const kind = typescript ? `"user" as const` : `"user"`;
   return `  // Who the wire's callers act as. This must resolve the SAME subject your\n` +
     `  // agent loop uses (the docs' chat routes set this demo principal), or apps\n` +
     `  // and approvals created in chat are invisible to the embeds, which call\n` +
     `  // this route directly. Replace both sides with your real session lookup.\n` +
-    `  principal: async () => ({ kind: "user" as const, subject: "demo-user" }),\n`;
+    `  principal: async () => ({ kind: ${kind}, subject: "demo-user" }),\n`;
 }
 
 /**
@@ -127,7 +131,8 @@ export function routeSource(options: { serverActions: boolean; auth: AuthMatch |
     (options.serverActions ? `import { serverActions } from "./vendo-actions";\n` : "") +
     `import { registry } from ${JSON.stringify(options.registrySpecifier)};\n` +
     `\nconst vendo = createVendo({\n` +
-    (options.auth === null ? anonymousPrincipalLines() : authConfigLines(options.auth)) +
+    // The Next route is always TypeScript (app/api/vendo/[...vendo]/route.ts).
+    (options.auth === null ? anonymousPrincipalLines(true) : authConfigLines(options.auth)) +
     `  catalog: registry,\n` +
     (options.serverActions ? `  serverActions,\n` : "") +
     `  policy: {}, // .vendo/policy.json: destructive asks, reads run\n` +
@@ -345,7 +350,7 @@ export function customServerSource(typescript: boolean, auth: AuthMatch | null =
     `    const baseUrl = (env.VENDO_CLOUD_URL ?? processEnv.VENDO_CLOUD_URL ?? "https://console.vendo.run").replace(/\\/+$/, "");\n` +
     `    const cloud = apiKey === undefined || apiKey === "" ? undefined : { apiKey, baseUrl };\n` +
     `    vendo = createVendo({\n` +
-    (auth === null ? anonymousPrincipalLines() : authConfigLines(auth))
+    (auth === null ? anonymousPrincipalLines(typescript) : authConfigLines(auth))
       .split("\n").map((line) => (line === "" ? line : `    ${line}`)).join("\n") +
     `      catalog: registry,\n` +
     `      policy: {}, // .vendo/policy.json: destructive asks, reads run\n` +
@@ -389,6 +394,13 @@ export function expressServerSource(typescript: boolean, auth: AuthMatch | null 
         mountReturn: `: (request: ExpressRequest, response: ServerResponse, next: ExpressNext) => void`,
       }
     : { requestHeaders: "(headers)", absoluteUrl: "(request)", sendResponse: "(source, target)", handle: "(request, response)", mountReturn: "" };
+  // getSetCookie is the only correct way to read multiple Set-Cookie headers,
+  // but it is missing from older lib.dom Headers types — the TS variant casts,
+  // and the JS variant must not (a cast is a SyntaxError in .mjs; self-serve
+  // audit B2).
+  const getSetCookieExpression = typescript
+    ? `(source.headers as Headers & { getSetCookie?: () => string[] }).getSetCookie`
+    : `source.headers.getSetCookie`;
   const requestInit = typescript
     ? `  const init: RequestInit & { duplex?: "half" } = { method, headers: requestHeaders(request.headers) };\n`
     : `  const init = { method, headers: requestHeaders(request.headers) };\n`;
@@ -426,7 +438,7 @@ export function expressServerSource(typescript: boolean, auth: AuthMatch | null 
     `import { registry } from ${JSON.stringify(registrySpecifier)};\n` +
     types +
     `\nconst vendo = createVendo({\n` +
-    (auth === null ? anonymousPrincipalLines() : authConfigLines(auth)) +
+    (auth === null ? anonymousPrincipalLines(typescript) : authConfigLines(auth)) +
     `  catalog: registry,\n` +
     `  policy: {}, // .vendo/policy.json: destructive asks, reads run\n` +
     `});\n\n` +
@@ -450,7 +462,7 @@ export function expressServerSource(typescript: boolean, auth: AuthMatch | null 
     `  source.headers.forEach((value, name) => {\n` +
     `    if (name.toLowerCase() !== "set-cookie") target.setHeader(name, value);\n` +
     `  });\n` +
-    `  const getSetCookie = (source.headers as Headers & { getSetCookie?: () => string[] }).getSetCookie;\n` +
+    `  const getSetCookie = ${getSetCookieExpression};\n` +
     `  const fallbackCookie = source.headers.get("set-cookie");\n` +
     `  const cookies = typeof getSetCookie === "function"\n` +
     `    ? getSetCookie.call(source.headers)\n` +

--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -572,10 +572,13 @@ describe("vendo init (zero-question)", () => {
     expect(tail).toContain(`edit ${join("vendo", "registry.tsx")} — `);
     expect(tail).toContain(`edit ${join("app", "layout.tsx")} — wrap the app in the <VendoRoot> lines above`);
     expect(tail).toContain(`edit ${join(".vendo", "brief.md")} — `);
-    // …and the machine gate, as the run's FINAL line.
+    // …and the machine gate, closing the tail block.
     expect(tail).toContain("vendo doctor --json");
-    expect(sink.logs[sink.logs.length - 1]).toContain("vendo doctor --json");
-    expect(sink.logs[sink.logs.length - 1]).toContain("green");
+    expect(sink.logs[sink.logs.length - 2]).toContain("vendo doctor --json");
+    expect(sink.logs[sink.logs.length - 2]).toContain("green");
+    // The one line after it is the outstanding-paste echo: with a mount still
+    // pending, the run's LAST word is the step the human owns (audit F5).
+    expect(sink.logs[sink.logs.length - 1]).toBe(`\n→ Don't forget the paste in ${join("app", "layout.tsx")} (frame above)`);
   });
 
   // Agent-install-dx Layer 2 (key-mint integration): a keyless run's tail

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -1446,14 +1446,20 @@ export async function runInit(options: InitOptions): Promise<number> {
     // key" is the whole story, while one init did not write may pass its own
     // `model` to createVendo — nothing here can see that, so state the
     // condition rather than guess either way.
+    // …and it only gets to speak at all once nothing is outstanding: a paste
+    // still pending means the frame above just said Vendo is invisible until
+    // it lands, so "the agent is live in your app" would contradict it in the
+    // same breath (self-serve audit F5).
     const modelReady = credential.rung === "env-key"
       || (credential.rung === "vendo-cloud" && cloud.keyValid);
-    output.log(`\nThen start your dev server — ${modelReady
-      ? "the agent is live in your app."
-      : compositionPath !== null
-        ? "the agent is live once you add a model key."
-        : "no model key resolved here, so the agent is live only if your composition passes its own model."}`);
-    output.log("Verify everything: `npx vendo doctor` (it can start the server and run a live turn).");
+    if (handSteps.length === 0) {
+      output.log(`\nThen start your dev server — ${modelReady
+        ? "the agent is live in your app."
+        : compositionPath !== null
+          ? "the agent is live once you add a model key."
+          : "no model key resolved here, so the agent is live only if your composition passes its own model."}`);
+    }
+    output.log(`${handSteps.length === 0 ? "" : "\n"}Verify everything: \`npx vendo doctor\` (it can start the server and run a live turn).`);
 
     // Agent tail (agent-install-dx): the --yes-or-non-TTY path is agent-driven
     // — the run's FINAL block is the repo-specific pointers an agent parses.
@@ -1495,6 +1501,16 @@ export async function runInit(options: InitOptions): Promise<number> {
       } catch {
         // The ask is best-effort by design; init already succeeded.
       }
+    }
+    // The run's LAST word is the outstanding paste, on both paths (self-serve
+    // audit F5: interactive installs used to end on the star ask with the one
+    // step that matters scrolled off-screen). The frame itself stays up-screen
+    // — the agent tail's "the lines above" pointers depend on that order — so
+    // the closer is a one-line echo of it, not a second copy.
+    if (handSteps.length > 0) {
+      output.log(handSteps.length === 1
+        ? `\n→ Don't forget the paste in ${handSteps[0]!.file} (frame above)`
+        : `\n→ Don't forget the ${handSteps.length} pastes above (frame above)`);
     }
     pretty?.done(Date.now() - started, true);
     return 0;

--- a/packages/vendo/src/cli/mcp/server-json.test.ts
+++ b/packages/vendo/src/cli/mcp/server-json.test.ts
@@ -56,17 +56,55 @@ describe("vendo mcp server-json", () => {
     expect(messages.errors).toEqual([]);
   });
 
-  it("prompts for domain and public URL when flags are missing", async () => {
+  it("prompts for domain and public URL when flags are missing on a TTY", async () => {
     const root = await fixture();
     const prompt = vi.fn()
       .mockResolvedValueOnce("example.com")
       .mockResolvedValueOnce("https://example.com/api/vendo/mcp");
 
-    expect(await runServerJson({ targetDir: root, prompt, output: output().sink })).toBe(0);
+    expect(await runServerJson({ targetDir: root, prompt, isTty: true, output: output().sink })).toBe(0);
     expect(prompt.mock.calls.map(([question]) => question)).toEqual([
       "Registry domain (for example example.com): ",
       "Public MCP URL: ",
     ]);
+  });
+
+  // Self-serve audit B6: the prompts used to fire on a piped stdin too, so a
+  // CI job or an agent hung forever on a question nobody could answer.
+  it("fails loudly instead of prompting when stdin is not a TTY", async () => {
+    const root = await fixture();
+    const prompt = vi.fn();
+    const messages = output();
+
+    expect(await runServerJson({ targetDir: root, prompt, isTty: false, output: messages.sink })).toBe(1);
+    expect(prompt).not.toHaveBeenCalled();
+    expect(messages.errors).toEqual([
+      "vendo mcp server-json: --domain and --url are required non-interactively (example: vendo mcp server-json --domain example.com --url https://example.com/api/vendo/mcp)",
+    ]);
+    await expect(readFile(join(root, "server.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("half the flags is still not enough non-interactively", async () => {
+    const messages = output();
+    expect(await runServerJson({
+      targetDir: await fixture(),
+      domain: "example.com",
+      isTty: false,
+      output: messages.sink,
+    })).toBe(1);
+    expect(messages.errors.join("\n")).toContain("--domain and --url are required non-interactively");
+  });
+
+  it("both flags need no TTY at all", async () => {
+    const messages = output();
+    expect(await runServerJson({
+      targetDir: await fixture(),
+      domain: "example.com",
+      url: "https://example.com/api/vendo/mcp",
+      isTty: false,
+      output: messages.sink,
+    })).toBe(0);
+    expect(messages.errors).toEqual([]);
   });
 
   it("validates namespace and remote URL binding before writing", async () => {

--- a/packages/vendo/src/cli/mcp/server-json.test.ts
+++ b/packages/vendo/src/cli/mcp/server-json.test.ts
@@ -84,6 +84,33 @@ describe("vendo mcp server-json", () => {
     await expect(readFile(join(root, "server.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  // A flag present but blank is an answer nobody gave: `option()` returns ""
+  // for both `--domain=` and `--domain ""`, which used to satisfy the presence
+  // check and reach the generator as `Invalid registry domain: `.
+  it("treats blank flag values as missing rather than as answers", async () => {
+    const messages = output();
+    expect(await runServerJson({
+      targetDir: await fixture(),
+      domain: "",
+      url: "",
+      isTty: false,
+      output: messages.sink,
+    })).toBe(1);
+    expect(messages.errors.join("\n")).toContain("--domain and --url are required non-interactively");
+    expect(messages.errors.join("\n")).not.toContain("Invalid registry domain");
+  });
+
+  it("a blank flag on a TTY asks the question instead of accepting the blank", async () => {
+    const root = await fixture();
+    const prompt = vi.fn()
+      .mockResolvedValueOnce("example.com")
+      .mockResolvedValueOnce("https://example.com/api/vendo/mcp");
+
+    expect(await runServerJson({ targetDir: root, domain: "", url: "  ", prompt, isTty: true, output: output().sink })).toBe(0);
+    expect(prompt).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(await readFile(join(root, "server.json"), "utf8"))).toMatchObject({ name: "com.example/maple" });
+  });
+
   it("half the flags is still not enough non-interactively", async () => {
     const messages = output();
     expect(await runServerJson({

--- a/packages/vendo/src/cli/mcp/server-json.ts
+++ b/packages/vendo/src/cli/mcp/server-json.ts
@@ -66,16 +66,25 @@ export async function runServerJson(options: ServerJsonOptions): Promise<number>
   // Self-serve audit B6: the two questions below used to fire on a piped stdin
   // too, so a CI job or an agent wedged on a prompt nobody could ever answer.
   // Ask only where an answer can arrive; everywhere else, name both flags.
+  // A flag present but blank (`--domain=`, `--domain ""`) is an ANSWER NOBODY
+  // GAVE, not an answer: the option parser hands back "" for both spellings,
+  // so treating it as supplied skipped the prompt on a TTY and slipped past
+  // this guard everywhere else, surfacing as `Invalid registry domain:` from
+  // the generator instead of the two flag names.
+  const supplied = (value: string | undefined): string | undefined =>
+    value === undefined || value.trim() === "" ? undefined : value;
+  const suppliedDomain = supplied(options.domain);
+  const suppliedUrl = supplied(options.url);
   const tty = options.isTty ?? stdin.isTTY === true;
-  if (!tty && (options.domain === undefined || options.url === undefined)) {
+  if (!tty && (suppliedDomain === undefined || suppliedUrl === undefined)) {
     output.error("vendo mcp server-json: --domain and --url are required non-interactively (example: vendo mcp server-json --domain example.com --url https://example.com/api/vendo/mcp)");
     return 1;
   }
 
   try {
     const prompt = options.prompt ?? promptOnce;
-    const domain = options.domain ?? await prompt("Registry domain (for example example.com): ");
-    const publicUrl = options.url ?? await prompt("Public MCP URL: ");
+    const domain = suppliedDomain ?? await prompt("Registry domain (for example example.com): ");
+    const publicUrl = suppliedUrl ?? await prompt("Public MCP URL: ");
     const identity = await hostIdentity(root);
     const server = {
       $schema: SERVER_SCHEMA_URL,

--- a/packages/vendo/src/cli/mcp/server-json.ts
+++ b/packages/vendo/src/cli/mcp/server-json.ts
@@ -17,6 +17,8 @@ export interface ServerJsonOptions {
   force?: boolean;
   prompt?: (question: string) => Promise<string>;
   output?: Output;
+  /** TTY seam (tests pin both sides). */
+  isTty?: boolean;
 }
 
 interface HostIdentity {
@@ -58,6 +60,15 @@ export async function runServerJson(options: ServerJsonOptions): Promise<number>
 
   if (!options.force && await exists(path)) {
     output.error("server.json already exists; pass --force to overwrite it");
+    return 1;
+  }
+
+  // Self-serve audit B6: the two questions below used to fire on a piped stdin
+  // too, so a CI job or an agent wedged on a prompt nobody could ever answer.
+  // Ask only where an answer can arrive; everywhere else, name both flags.
+  const tty = options.isTty ?? stdin.isTTY === true;
+  if (!tty && (options.domain === undefined || options.url === undefined)) {
+    output.error("vendo mcp server-json: --domain and --url are required non-interactively (example: vendo mcp server-json --domain example.com --url https://example.com/api/vendo/mcp)");
     return 1;
   }
 

--- a/packages/vendo/src/cli/onboarding-safety.test.ts
+++ b/packages/vendo/src/cli/onboarding-safety.test.ts
@@ -45,6 +45,17 @@ async function pagesHost(): Promise<string> {
   return root;
 }
 
+/** The same host with the surface ALREADY mounted — nothing left to paste, so
+    the closing line about the model key is the run's own last word. */
+async function mountedPagesHost(): Promise<string> {
+  const root = await pagesHost();
+  await writeFile(join(root, "pages", "_app.tsx"),
+    'import { VendoRoot } from "@vendoai/vendo/react";\n' +
+    "export default function App({ Component, pageProps }) {\n" +
+    "  return <VendoRoot><Component {...pageProps} /><VendoOverlay /></VendoRoot>;\n}\n");
+  return root;
+}
+
 function run(root: string, sink: { output: Output }, extra: Partial<Parameters<typeof runInit>[0]> = {}): Promise<number> {
   return runInit({
     targetDir: root,
@@ -192,7 +203,7 @@ describe("the closing line tells the truth about the model key", () => {
     ];
     for (const extra of keyless) {
       const sink = output();
-      expect(await run(await pagesHost(), sink, extra)).toBe(0);
+      expect(await run(await mountedPagesHost(), sink, extra)).toBe(0);
       expect(sink.logs.join("\n")).toContain(PENDING);
       expect(sink.logs.join("\n")).not.toContain(LIVE);
     }
@@ -200,14 +211,14 @@ describe("the closing line tells the truth about the model key", () => {
 
   it("keyed: live in your app", async () => {
     const sink = output();
-    expect(await run(await pagesHost(), sink, { env: { ANTHROPIC_API_KEY: "sk-a" } })).toBe(0);
+    expect(await run(await mountedPagesHost(), sink, { env: { ANTHROPIC_API_KEY: "sk-a" } })).toBe(0);
     expect(sink.logs.join("\n")).toContain(LIVE);
   });
 
   it("a re-run over an existing composition states the condition — it may pass its own model", async () => {
     // createVendo({ model }) needs no env key, so a keyless re-run over a
     // composition init did not write must claim neither "live" nor "not live".
-    const root = await pagesHost();
+    const root = await mountedPagesHost();
     expect(await run(root, output())).toBe(0);
     const sink = output();
     expect(await run(root, sink)).toBe(0);
@@ -218,7 +229,7 @@ describe("the closing line tells the truth about the model key", () => {
   });
 
   it("a key minted mid-run IS live", async () => {
-    const root = await pagesHost();
+    const root = await mountedPagesHost();
     const sink = output();
     expect(await run(root, sink, {
       cloud: {
@@ -231,6 +242,19 @@ describe("the closing line tells the truth about the model key", () => {
       },
     })).toBe(0);
     expect(sink.logs.join("\n")).toContain(LIVE);
+  });
+
+  // Self-serve audit F5: with a paste still outstanding, "the agent is live in
+  // your app" contradicted the frame two lines above it, which had just said
+  // Vendo stays invisible until that paste lands.
+  it("says nothing about being live while a paste is still pending", async () => {
+    const sink = output();
+    expect(await run(await pagesHost(), sink, { env: { ANTHROPIC_API_KEY: "sk-a" } })).toBe(0);
+    const logs = sink.logs.join("\n");
+    expect(logs).toContain("ONE STEP LEFT");
+    expect(logs).not.toContain("Then start your dev server");
+    // …and the outstanding paste is the run's very last word.
+    expect(sink.logs[sink.logs.length - 1]).toBe(`\n→ Don't forget the paste in ${join("pages", "_app.tsx")} (frame above)`);
   });
 });
 

--- a/packages/vendo/src/cli/sync.test.ts
+++ b/packages/vendo/src/cli/sync.test.ts
@@ -178,7 +178,27 @@ describe("vendo sync", () => {
     });
 
     expect(exit).toBe(2);
-    expect(messages.errors).toContain("--report requires VENDO_API_KEY or --key");
+    expect(messages.errors).toContain("vendo sync: --report needs a Vendo Cloud key — run `vendo login`, set VENDO_API_KEY, or pass --key.");
+  });
+
+  // Self-serve audit B6: a keyless --report used to complain and exit 0, so a
+  // CI reporting lane stayed green for as long as it never reported anything.
+  it("a keyless --report is a failed run, not a note (exit 1)", async () => {
+    vi.stubEnv("VENDO_API_KEY", "");
+    const messages = captureOutput();
+    const fetchImpl = vi.fn() as typeof fetch;
+
+    const exit = await runSync({
+      targetDir: ".",
+      report: true,
+      output: messages.output,
+      fetchImpl,
+      sync: async () => report(),
+    });
+
+    expect(exit).toBe(1);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(messages.errors).toContain("vendo sync: --report needs a Vendo Cloud key — run `vendo login`, set VENDO_API_KEY, or pass --key.");
   });
 
   it("warns when report push rejects and preserves blast-radius exit three", async () => {
@@ -374,14 +394,14 @@ describe("vendo sync", () => {
       sync: async () => report(),
     });
 
-    expect(exit).toBe(0);
+    expect(exit).toBe(1);
     expect(fetchImpl).not.toHaveBeenCalled();
     expect(messages.errors).toHaveLength(0);
     expect(JSON.parse(messages.logs[0]!)).toMatchObject({
-      ok: true,
-      exitCode: 0,
+      ok: false,
+      exitCode: 1,
       impact: [],
-      notes: ["judgment: skipped — this run cannot ask (pass `--ai` to judge non-interactively, `--no-ai` to say so explicitly)", "--report requires VENDO_API_KEY or --key"],
+      notes: ["judgment: skipped — this run cannot ask (pass `--ai` to judge non-interactively, `--no-ai` to say so explicitly)", "vendo sync: --report needs a Vendo Cloud key — run `vendo login`, set VENDO_API_KEY, or pass --key."],
     });
   });
 

--- a/packages/vendo/src/cli/sync.ts
+++ b/packages/vendo/src/cli/sync.ts
@@ -59,9 +59,10 @@ export interface SyncOptions {
 /** `sync --json` — the one machine-readable object printed on stdout. */
 export interface SyncJsonResult {
   ok: boolean;                       // exitCode === 0
-  /** 2 = uncapturable `<Remixable>` wrapper, or breaking changes under
+  /** 1 = the run could not do what was asked (`--report` with no Cloud key);
+   *  2 = uncapturable `<Remixable>` wrapper, or breaking changes under
    *  --strict; 3 = breaking changes with saved references. */
-  exitCode: 0 | 2 | 3;
+  exitCode: 0 | 1 | 2 | 3;
   report: SyncReportWithWarnings;
   /** [] = nothing referenced the changed tools; null = impact unknown (dev server unreachable). */
   impact: ToolImpact[] | null;
@@ -334,13 +335,17 @@ async function sync(options: SyncOptions): Promise<number> {
       }
     }
 
+    let reportUnkeyed = false;
     if (options.report === true) {
       // The same resolved key the baseline push uses — a `--report` that saw a
       // different env from the reconcile beside it was a trap (#567's fix
       // applies to every keyed leg of a sync, not just the judgment pass).
       const apiKey = cloudKey;
       if (!apiKey) {
-        noteError("--report requires VENDO_API_KEY or --key");
+        // Self-serve audit B6: this used to complain and exit 0, so a CI
+        // reporting lane stayed green for as long as it never reported.
+        reportUnkeyed = true;
+        noteError("vendo sync: --report needs a Vendo Cloud key — run `vendo login`, set VENDO_API_KEY, or pass --key.");
       } else {
         const payload: SyncReportPayload = {
           report,
@@ -366,6 +371,9 @@ async function sync(options: SyncOptions): Promise<number> {
       const breakingTools = new Set(report.breaking.map((breaking) => breaking.tool));
       exitCode = impact?.some((entry) => breakingTools.has(entry.tool) && nonzero(entry)) === true ? 3 : 2;
     }
+    // A --report that never reported is a failed run, whatever the catalog
+    // said; the --strict codes are more specific, so they keep their meaning.
+    if (reportUnkeyed && exitCode === 0) exitCode = 1;
     if (json) {
       const result: SyncJsonResult = {
         ok: exitCode === 0,

--- a/packages/vendo/src/hosted-store-notice.test.ts
+++ b/packages/vendo/src/hosted-store-notice.test.ts
@@ -1,0 +1,39 @@
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createVendo } from "./server.js";
+import { fakeConsole } from "./hosted-store.test-util.js";
+
+/**
+ * Self-serve audit F7: the hosted-store automations notice is a boot fact, but
+ * a Next dev server recomposes on nearly every request — the paragraph landed
+ * in the host's log 29 times in one short session. It is latched per PROCESS.
+ */
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function compose(): void {
+  const vendo = createVendo({ model: {} as LanguageModel, principal: async () => null });
+  cleanups.push(async () => { await vendo.store.close(); });
+}
+
+describe("the hosted-store automations notice", () => {
+  it("prints once per process, however many compositions there are", async () => {
+    vi.stubEnv("VENDO_API_KEY", "vnd_hosted_key");
+    vi.stubEnv("VENDO_CLOUD_URL", "https://cloud-notice.test");
+    vi.stubGlobal("fetch", fakeConsole().handler as unknown as typeof fetch);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    for (let index = 0; index < 3; index += 1) compose();
+
+    const printed = warn.mock.calls
+      .flat()
+      .filter((message) => String(message).includes("Vendo Cloud is the hosted store for this deployment"));
+    expect(printed).toHaveLength(1);
+  });
+});

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -318,8 +318,8 @@ export interface CreateVendoConfig {
       default. */
   development?: boolean;
   /** Unified try surface — the project root the `.vendo/` profile is read
-      under: the actions files (tools.json/overrides.json via the actions
-      block's `dir`), theme.json, brief.md, catalog.json, the
+      under: the actions files (tools.json/overrides.json, read by the actions
+      registry this composition builds with `dir`), theme.json, brief.md, catalog.json, the
       per-generation design-rules.md read, and the remixable pin baselines
       all resolve against it. Unset keeps today's
       behavior (the process cwd), so `npx vendo try` can mount a real
@@ -471,9 +471,10 @@ export interface CreateVendoConfig {
     review?: {
       reviewer?(ctx: RunContext): boolean | Promise<boolean>;
     };
-    /** Generation-pipeline flags (exemplarContract, structuredRepair,
-        regionParallel, endPass) — opt-in while the A/B is measured; threaded
-        verbatim to the apps engine. */
+    /** Generation-pipeline flags, threaded verbatim to the apps engine.
+        `structuredRepair` and `smokeRender` are ON by default and take `false`
+        to disable; `exemplarContract`, `regionParallel`, `endPass`, and
+        `rebind` are opt-in while their A/Bs are measured. */
     pipeline?: AppsConfig["pipeline"];
     /** Host design rules for app generation (spec 2026-07-20): the same prose
         `.vendo/design-rules.md` carries, for hosts that prefer programmatic
@@ -922,6 +923,11 @@ function hostedSessionOps(store: HostedStore, touchDebounceMs: number): SessionO
     },
   };
 }
+
+/** Per-process latch for the hosted-store automations notice below — a dev
+    server recomposes on nearly every request, and the paragraph is a boot
+    fact, not a per-request one (self-serve audit F7). */
+let hostedStoreNoticePrinted = false;
 
 /** A host may also pass hostedStore({...}) explicitly via createVendo({ store });
     the session doors it carries are then used as-is instead of the local SQL
@@ -2153,9 +2159,12 @@ export function createVendo(config: CreateVendoConfig): Vendo {
   // store, Cloud is the firing authority for those two kinds; host-event automations
   // (vendo.emit) are untouched — they're invoked directly by this host process, not
   // scheduled or delivered, so there's nothing for Cloud to duplicate. One warn per
-  // composition (not per tick), same posture as hostedSessionOps' door warn above.
+  // PROCESS (self-serve audit F7: a dev server recomposes on nearly every request,
+  // so "once per composition" printed this paragraph 29 times in one short
+  // session), same latch posture as hostedSessionOps' door warn above.
   const hostedStoreComposed = isHostedStore(store);
-  if (hostedStoreComposed) {
+  if (hostedStoreComposed && !hostedStoreNoticePrinted) {
+    hostedStoreNoticePrinted = true;
     console.warn(
       "[vendo] Vendo Cloud is the hosted store for this deployment: schedule and external-trigger "
       + "automations are Cloud's job (its scheduler and Composio delivery already fire them for this "

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -319,9 +319,9 @@ export interface CreateVendoConfig {
   development?: boolean;
   /** Unified try surface — the project root the `.vendo/` profile is read
       under: the actions files (tools.json/overrides.json, read by the actions
-      registry this composition builds with `dir`), theme.json, brief.md, catalog.json, the
-      per-generation design-rules.md read, and the remixable pin baselines
-      all resolve against it. Unset keeps today's
+      registry this composition builds with `dir`), theme.json, brief.md,
+      catalog.json, the per-generation design-rules.md read, and the remixable
+      pin baselines all resolve against it. Unset keeps today's
       behavior (the process cwd), so `npx vendo try` can mount a real
       composition over a profile living in a temp directory without chdir. */
   profileDir?: string;


### PR DESCRIPTION
Seven fixes from the 2026-08-02 self-serve audit (Appendices B/C), Waves R+P. One changeset, `@vendoai/vendo` **minor** (drives 0.7.0).

## Items

**1 — `vendo try` is unlisted.** Removed from the HELP command list and scrubbed from the `--engine` and `--no-ai` flag descriptions; the try-only `--port` and `--no-open` lines are dropped from HELP (the flags still work). The command, its dispatch branch, and every option keep working when invoked. The two retired-command stubs that pointed users AT try — `vendo playground` and `vendo refine` — no longer advertise it (playground now points at `vendo init` + the quickstart). Docs-site untouched (another lane owns it).

**2 — JS-emitted scaffolds are valid JavaScript (audit B2, blocker).** `anonymousPrincipalLines()` emitted `kind: "user" as const` and `expressServerSource()` emitted `(source.headers as Headers & { getSetCookie?: () => string[] })` unconditionally, so every plain-JS host (Express, bare Node, `--framework custom`) died with `SyntaxError: Unexpected identifier 'as'` on its first `node server.js`. Both now branch on the `typescript` flag, mirroring the `signatures` map beside them.

**3 — `vendo doctor` names a stale install (audit F1).** New `npmLatestVersion()` reads npm's dist-tag document with a 2s timeout and fails soft to `null` on any problem. When the installed CLI is behind, doctor prints:

```
warning: installed @vendoai/vendo 0.6.1 is behind latest 0.7.0 — npm install @vendoai/vendo@latest (release-cooldown npm configs like min-release-age resolve old versions silently)
```

A hint, not a registry check: no `error_code`/`fix_ref`, no exit-code change, nothing in `--json`. That keeps `agents/verify.mdx`'s code table (which IS test-enforced) correct without touching docs-site.

**4 — `vendo mcp server-json` no longer hangs a script (audit B6, blocker).** Missing `--domain`/`--url` on a non-TTY stdin used to fall into `readline.question` forever. Now exit 1:

```
vendo mcp server-json: --domain and --url are required non-interactively (example: vendo mcp server-json --domain example.com --url https://example.com/api/vendo/mcp)
```

TTY behavior is unchanged.

**5 — `vendo sync --report` without a key exits 1 (audit B6, blocker).** It used to print a complaint and exit 0, so a CI reporting lane stayed green while never reporting. New message: ``vendo sync: --report needs a Vendo Cloud key — run `vendo login`, set VENDO_API_KEY, or pass --key.`` The `--strict` codes (2 breaking, 3 impacted) are more specific and keep their meaning; 1 applies when the run would otherwise be green.

**6 — Hosted-store notice is once per process (audit F7).** A Next dev server recomposes on nearly every request, so "once per composition" printed the paragraph 29 times in one short session. Module-level latch, same posture as `hostedSessionOps`' door warn.

**7 — Init's ending and the Cloud pitch (audit F5, F8).**
- The run's **last** line is now the outstanding paste, on interactive and non-interactive runs alike. The frame itself stays up-screen and the closer is a one-line echo: `→ Don't forget the paste in app/layout.tsx (frame above)`. This is the brief's stated escape hatch — the agent tail's own pointers say "the `<VendoRoot>` lines **above**", so moving the frame below the tail would make those lines false.
- "Then start your dev server — the agent is live in your app" is **withheld while a paste is pending** — it contradicted the frame two lines above it, which had just said Vendo stays invisible until the paste lands.
- The keyless Cloud pitch is 3 lines (what a key unlocks / `vendo login` / `--byo`) instead of 5; the device-flow walkthrough lives in `vendo login`.

**Bonus (comment-only, no behavior change):** two stale `server.ts` JSDoc comments corrected — the pipeline-flags comment now states real defaults (`structuredRepair` and `smokeRender` ON by default; `exemplarContract`/`regionParallel`/`endPass`/`rebind` opt-in), and `profileDir`'s cross-reference no longer names a nonexistent top-level "actions block".

## Proof

### Item 2 — real Express host, built CLI, `node --check`

`npm init -y` + `npm install express@5` in a temp dir, then this branch's built CLI:

```
$ node <worktree>/packages/vendo/dist/cli.js init . --yes --byo --no-ai --framework express
Wired (3 files):
  + vendo/registry.mjs
  + vendo/server.mjs
  ~ package.json

$ node --check vendo/server.mjs
PARSE OK: vendo/server.mjs
$ node --check vendo/registry.mjs
PARSE OK: vendo/registry.mjs

$ grep -n 'kind:\|getSetCookie =' vendo/server.mjs
21:  principal: async () => ({ kind: "user", subject: "demo-user" }),
48:  const getSetCookie = source.headers.getSetCookie;
```

Same file with the two pre-fix expressions restored (lines 21 and 48 — exactly the lines the audit reported):

```
$ node --check before.mjs
before.mjs:21
  principal: async () => ({ kind: "user" as const, subject: "demo-user" }),
                                         ^^
SyntaxError: Unexpected identifier 'as'
```

Unit test `init-scaffolds.test.ts` runs `node --check` over both JS scaffolds, so Node's own parser is the gate — a substring assertion would miss the next annotation that sneaks in.

### Item 7 — init transcript tail, Next host, built CLI

**Before** (order on main): frame → `Then start your dev server — the agent is live once you add a model key.` → `Verify everything: …` → `Agent tail:` … ending on `gate: run vendo doctor --json`. Interactive runs ended on the star ask.

**After** (real run, this branch):

```
────────────────────────────────────────────────────────────────
ONE STEP LEFT — paste this yourself (init never edits your files)

  File: app/layout.tsx
    import { VendoRoot } from "../vendo/vendo-root";
    … then wrap: <VendoRoot>{children}</VendoRoot>

  vendo/vendo-root.tsx mounts <VendoOverlay />, the visible launcher + panel — until this lands, Vendo is wired but invisible.
  Then confirm it landed: npx vendo doctor
────────────────────────────────────────────────────────────────

Verify everything: `npx vendo doctor` (it can start the server and run a live turn).

Agent tail:
  auth: none wired — sessions stay anonymous until a preset is added
  edit vendo/registry.tsx — register the components the agent may render (generated empty)
  edit app/api/vendo/[...vendo]/route.ts — add the auth preset named in the advisory above when the host has auth
  edit app/layout.tsx — wrap the app in the <VendoRoot> lines above (it mounts <VendoOverlay />, the visible surface; without it users see nothing)
  edit .vendo/brief.md — replace the placeholder with what this product does and for whom
  cloud key: none — for Vendo Cloud, fetch https://vendo.run/auth.md and run `vendo login` …
  gate: run `vendo doctor --json` — done when every check reports green

→ Don't forget the paste in app/layout.tsx (frame above)
```

Note the "start your dev server" line is gone (paste pending) and the paste echo is the last word.

Keyless Cloud pitch, same CLI, 5 lines → 3:

```
Vendo Cloud (optional): not configured. A key unlocks …
Vendo Cloud key (agent path): run `vendo login` — it prints a code your human approves in the browser, and the minted VENDO_API_KEY lands in .env.local (never printed).
Then re-run `vendo init` (it picks the key up) or pass --cloud-key <key>. Protocol: https://vendo.run/auth.md
No Cloud account wanted? Re-run with --byo and set a provider key (ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_GENERATIVE_AI_API_KEY).
```

### Item 6 — the once-only test is real

With the latch removed the new test fails `expected [ …(3) ] to have a length of 1 but got 3`; with it, 1. Three compositions in one process, one notice.

## Tests

New: `init-scaffolds.test.ts` (node --check both JS scaffolds + the TS variants keep their annotations), `doctor-version-skew.test.ts` (stale / current / offline / never-backwards, plus the lookup's fail-soft paths), `hosted-store-notice.test.ts` (once per process). Extended: `server-json.test.ts` (non-TTY exit, half-flags, both-flags-no-TTY), `sync.test.ts` (keyless `--report` exits 1).

Updated because the change IS the change: the help/stub assertions in `cli.test.ts` / `cli.try.test.ts` / `cli.playground.test.ts`; the two `sync.test.ts` cases that encoded exit 0 and the old wording; the init-ending order in `init.test.ts` and the closing-line cases in `onboarding-safety.test.ts` (those now run against a host with the surface already mounted, so the model-key truth-telling invariant is tested exactly as before, and a new case asserts the line stays silent while a paste is pending). `doctor.test.ts` gains an `npmLatest: async () => null` stub so the suite makes no registry round-trip.

## Gate

`pnpm build`, `pnpm typecheck`, `pnpm lint` green. `pnpm test` green.

Pre-existing, unrelated, reproduced on a clean tree at this branch point: `packages/vendo/src/dev-creds/model.test.ts` fails 2/29 locally (`Cannot find module '@ai-sdk/anthropic'` under `withoutGlobalPaths` — a local resolution issue, not a code change). `examples/demo-bank/src/vendo/away-drill.test.ts` flaked once ("Maple exited early") and passed on re-run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves CLI reliability and UX: JS scaffolds run in plain JS hosts, non-interactive flows fail fast with clear errors (blank flags included), and `vendo doctor` warns when the installed `@vendoai/vendo` lags npm (skips under `--json`). `vendo try` is hidden from `--help`, logs are quieter, and init ends with a clear paste reminder.

- **Bug Fixes**
  - JS scaffolds no longer emit TypeScript in JS output; Node parses cleanly (branches on the `typescript` flag).
  - Non-TTY flows fail fast: `mcp server-json` requires `--domain` and `--url` (blank values count as missing; TTY prompts again, non-TTY exits 1); `sync --report` without a key exits 1.
  - Hosted-store notice prints once per process to avoid dev-server spam.

- **New Features**
  - Doctor version hint: warns when installed `@vendoai/vendo` is behind npm `latest` (2s timeout, fail-soft, no exit-code change, skipped under `--json`).
  - Init UX: the final line is the paste reminder; “agent is live” is withheld until the paste lands; Cloud pitch trimmed to three lines via `vendo login`.
  - CLI help: `vendo try` is unlisted and no longer promoted by retired stubs; the command still works when invoked.

<sup>Written for commit 67b348f76a58b1777afd32099b057ccbffaa3ed6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

