### PR TITLE
self-serve D3: capabilities and deploy docs describe shipped APIs only

### DIFF
--- a/docs-site/capabilities/compound-tools.mdx
+++ b/docs-site/capabilities/compound-tools.mdx
@@ -53,19 +53,17 @@ rejected at load with a pointer here.
           {
             "id": "load",
             "tool": "host_invoices_get",
-            "args": { "id": "{{ args.invoiceId }}" }
+            "args": { "id": "args.invoiceId" }
           },
           {
             "id": "notify",
-            "if": "{{ load.status = 'overdue' }}",
+            "if": "steps.load.status = 'overdue'",
             "tool": "host_email_send",
             "args": {
-              "to": "{{ load.customerEmail }}",
-              "template": "invoice-reminder",
-              "vars": {
-                "invoiceId": "{{ load.id }}",
-                "amount": "{{ load.amount }}"
-              }
+              "to": "steps.load.customerEmail",
+              "template": "'invoice-reminder'",
+              "invoiceId": "steps.load.id",
+              "amount": "steps.load.amount"
             }
           }
         ]
@@ -76,20 +74,56 @@ rejected at load with a pointer here.
 ```
 
 A binding accepts 1–50 steps with unique `id` values. Each step targets one
-existing tool by name. `args`, `if`, and `forEach` are JSONata expressions
-evaluated against the root `args` and prior step results by id.
+existing tool by name.
+
+### Expressions
+
+`if`, `forEach`, and every value in `args` are **raw JSONata**, compiled
+verbatim. There is no template syntax: `{{ args.invoiceId }}` is a parse
+error, and a literal string has to be quoted inside the expression
+(`"'invoice-reminder'"`, as above).
+
+Every expression sees the same three bindings and nothing else:
+
+| Binding | What it holds |
+| --- | --- |
+| `args` | the compound's own call arguments |
+| `steps` | completed step outputs, keyed by step `id` — `steps.load.amount` |
+| `item` | the current `forEach` element; undefined outside a loop |
+
+`args` values are strings, one expression each — nest structure inside the
+target tool's schema, not inside the expression map.
 
 ### Steps
 
 Every step runs `if → forEach → args → invoke` in that order.
 
-- `if`: skip the step when the expression is falsy.
-- `forEach`: invoke the step once per item, up to 1000 items. The item is
-  available to `args` as the step's context. Non-array values fail loudly.
-- `args`: the JSON object passed to the target tool after evaluation.
+- `if`: skip the step when the expression is falsy. A skipped step writes no
+  `steps.<id>` key at all, so later steps must not assume one.
+- `forEach`: evaluated once, before iteration, with `item` undefined. It must
+  produce an array of at most 1000 items; anything else halts the walk. The
+  step then runs once per element with that element bound to `item`, and its
+  outputs collect as an array under `steps.<id>`.
+- `args`: evaluated per invocation and passed to the target tool.
 
-Prior step results are available by step `id`. Root inputs are available as
-`args`.
+The compound returns `{ steps: { … } }` — every completed step's output under
+its own id.
+
+```json
+"steps": [
+  { "id": "load", "tool": "host_customers_list" },
+  {
+    "id": "each",
+    "tool": "host_email_send",
+    "forEach": "steps.load.items",
+    "args": { "to": "item.email" }
+  }
+]
+```
+
+With `host_customers_list` returning
+`{ "items": [{ "email": "a@x" }, { "email": "b@x" }] }`, the walk sends twice
+and `steps.each` is the two-element array of send results.
 
 ### Risk
 

--- a/docs-site/capabilities/compound-tools.mdx
+++ b/docs-site/capabilities/compound-tools.mdx
@@ -133,8 +133,15 @@ overrides apply. Under- or over-declaring risk quarantines the entry.
 ## Overrides
 
 The `tools` map of the same file applies to compounds by name, field by
-field, the same way it applies to extracted tools. Use it to tighten risk,
-mark a compound `critical`, or disable it without editing the compound entry.
+field, the same way it applies to extracted tools. Use it to mark a compound
+`critical`, or to disable it, without editing the compound entry.
+
+`risk` is the exception. Overrides merge *before* validation, and the rule
+above is equality, not a floor — so an override that changes a compound's
+risk in either direction quarantines it. Overriding a *step's* risk can
+quarantine the compound the same way, by moving the step maximum out from
+under the compound's declaration. To change a compound's risk, change the
+declaration and the steps together.
 
 ```json
 {

--- a/docs-site/capabilities/mcp.mdx
+++ b/docs-site/capabilities/mcp.mdx
@@ -10,10 +10,10 @@ connect to over OAuth. Every door tool call runs through the same guard-bound
 registry, policy, approvals, and audit path as chat, so outside agents get no
 weaker perimeter than your own conversation surface.
 
-Opening the door is a host decision. It is off by default, and `vendo init`
-asks whether you want it. On yes, init generates the Next.js discovery route
-and points you at the host-owned OAuth wiring; it never invents an auth adapter
-or turns the flag on by itself.
+Opening the door is a host decision, and entirely a manual one. It is off by
+default; `vendo init` never asks about it, never turns it on, and scaffolds
+none of its wiring. You set `mcp: true`, pass your own OAuth adapter, and add
+the discovery route yourself — all three steps are below.
 
 **Status: experimental.** `mcp: true` is real, guard-bound, and covered by
 protocol-level e2e (`fixtures/mcp-e2e`), but it stays out of the main
@@ -273,11 +273,11 @@ JavaScript and it themes itself from `.vendo/theme.json`.
 
 The door's transport and OAuth endpoints mount under the wire at
 `/api/vendo/mcp`, so your existing catch-all handler already serves them. The
-OAuth discovery documents live at the origin root, outside `/api/vendo`. When
-you opt into MCP during `vendo init`, a Next.js host gets
-`app/.well-known/[...vendo]/route.ts` (under `src/app` when present), forwarding
-to the same handler. If you wire Vendo without init, add the equivalent route
-as a two-line re-export of the shipped handler:
+OAuth discovery documents live at the origin root, outside `/api/vendo`, so
+the catch-all never sees them. Init does not scaffold that route: add it by
+hand as a two-line re-export of the shipped handler. On Next.js it goes at
+`app/.well-known/[...vendo]/route.ts` (under `src/app` when present) —
+`examples/demo-bank` has the reference wiring.
 
 ```ts
 // app/.well-known/[...vendo]/route.ts

--- a/docs-site/capabilities/mcp.mdx
+++ b/docs-site/capabilities/mcp.mdx
@@ -12,8 +12,9 @@ weaker perimeter than your own conversation surface.
 
 Opening the door is a host decision, and entirely a manual one. It is off by
 default; `vendo init` never asks about it, never turns it on, and scaffolds
-none of its wiring. You set `mcp: true`, pass your own OAuth adapter, and add
-the discovery route yourself — all three steps are below.
+none of its wiring. You set `mcp: true`, make sure a `HostOAuthAdapter` is in
+the composition — any `auth` preset already carries one, so most hosts need
+nothing extra — and add the discovery route yourself. All three are below.
 
 **Status: experimental.** `mcp: true` is real, guard-bound, and covered by
 protocol-level e2e (`fixtures/mcp-e2e`), but it stays out of the main

--- a/docs-site/changelog/overview.mdx
+++ b/docs-site/changelog/overview.mdx
@@ -33,7 +33,7 @@ inside its own fields.
 friendly labels and readable argument previews instead of raw tool slugs,
 ai-SDK lifecycle strings, or raw JSON. `VendoProvider` accepts an optional
 `tools` prop (`ToolMetaMap`) with per-tool `label`, `description`, and
-`summarize(args)`; the new `useVendoTools()` hook exposes the same map to
+`formatField(key, value)`; the new `useVendoTools()` hook exposes the same map to
 custom surfaces. Chrome falls back to prettified ids and `Key: value`
 previews when no metadata is supplied, collapses consecutive identical
 chips into a single entry with an `×N` count, and no longer prints a
@@ -164,12 +164,12 @@ failing audit sink never blocks the host call. See the
 [CLI reference](/reference/cli#vendo-doctor-dir) and
 [Troubleshooting](/deploy/troubleshooting).
 
-**Atomic claims on the store contract.** `store.claim({ key, owner, ttlMs })`
-and `store.release(claim)` let concurrent workers coordinate on a shared
-key without external locks, with TTL-based expiry so a crashed owner never
-holds a key forever. The same compare-and-set machinery backs
-run-lifecycle transitions, so cancellations and scheduler ticks cannot
-race a run into a resurrected state. See [Persistence](/deploy/persistence).
+**Compare-and-set on the store contract.** Record stores can expose
+`records(name).claim(expected, replacement?)` — `true` for the single caller
+whose read of `expected` still matched — plus `atomic.insertIfAbsent` and
+`atomic.compareAndSwap`, so concurrent workers coordinate without external
+locks. Both are optional capabilities: check for the method before use. See
+[Persistence](/deploy/persistence).
 
 **Invisible graduation to rung 4.** Tree apps can now graduate to a
 machine-served HTTP app without a visible UI change. On graduation, the

--- a/docs-site/concepts/architecture.mdx
+++ b/docs-site/concepts/architecture.mdx
@@ -1,10 +1,10 @@
 ---
 title: "How Vendo works"
 sidebarTitle: "How Vendo works"
-description: "What Vendo is made of: the nine blocks, the two files you own, and how a request flows from the browser through the guard to your API."
+description: "What Vendo is made of: the twelve blocks, the two files you own, and how a request flows from the browser through the guard to your API."
 ---
 
-Vendo is nine packages behind one umbrella, wired into your app through two
+Vendo is twelve packages behind one umbrella, wired into your app through two
 files you own. When you finish this page you have the map: what each block
 does, which parts are yours, and how a request travels through them.
 
@@ -17,10 +17,16 @@ does, which parts are yours, and how a request travels through them.
 | `@vendoai/guard` | policy, approvals, grants, and audit |
 | `@vendoai/apps` | user-owned app generation and runtime |
 | `@vendoai/automations` | triggers and away runs |
+| `@vendoai/mcp` | the MCP door for third-party agents |
+| `@vendoai/knowledge` | product knowledge ingestion and retrieval |
 | `@vendoai/ui` | headless hooks and optional chrome |
 | `@vendoai/telemetry` | build and development telemetry |
+| `@vendoai/engine` | the npx-fetched extraction engine `vendo init` can reach for |
 
-`@vendoai/vendo` composes the blocks and owns the public wire and CLI.
+`@vendoai/vendo` composes the blocks and owns the public wire and CLI, and
+`vendoai` is an unscoped alias of it. `@vendoai/engine` is deliberately not a
+dependency of anything — init fetches it at a pinned version at run time so
+its Agent SDK never lands in your install.
 
 ## The two files you own
 
@@ -60,10 +66,16 @@ through the guarded tool proxy.
 ## Dependency rule
 
 ```text
-core -> apps -> automations
-store, agent, actions, guard, ui -> core only
-vendo -> every block
+core                                              -> nothing
+store, agent, actions, guard, ui, apps, mcp, knowledge -> core only
+automations                                       -> core, apps
+telemetry, engine                                 -> nothing
+vendo                                             -> every block
+vendoai                                           -> vendo only
 ```
+
+`pnpm lint` enforces this map in `scripts/dependency-guard.mjs`; a package
+missing from it fails the build rather than picking up a default.
 
 Cross-block communication uses the seams in core: `Guard`, `StoreAdapter`,
 `ActAs`, `SecretsProvider`, `AgentRunner`, and `ToolRegistry`. The umbrella is

--- a/docs-site/concepts/architecture.mdx
+++ b/docs-site/concepts/architecture.mdx
@@ -21,12 +21,14 @@ does, which parts are yours, and how a request travels through them.
 | `@vendoai/knowledge` | product knowledge ingestion and retrieval |
 | `@vendoai/ui` | headless hooks and optional chrome |
 | `@vendoai/telemetry` | build and development telemetry |
-| `@vendoai/engine` | the npx-fetched extraction engine `vendo init` can reach for |
+| `@vendoai/engine` | a command-agnostic Agent SDK runner: a job in on stdin, the final message out on stdout |
 
 `@vendoai/vendo` composes the blocks and owns the public wire and CLI, and
-`vendoai` is an unscoped alias of it. `@vendoai/engine` is deliberately not a
-dependency of anything — init fetches it at a pinned version at run time so
-its Agent SDK never lands in your install.
+`vendoai` is an unscoped alias of it. Eleven of the twelve are ordinary
+dependencies of the umbrella. `@vendoai/engine` is the exception and is
+deliberately a dependency of nothing: `vendo init`'s last-resort rung fetches
+it at a pinned version with `npm exec`, so the Agent SDK's bundled binary
+never lands in your `node_modules`.
 
 ## The two files you own
 

--- a/docs-site/concepts/generated-ui.mdx
+++ b/docs-site/concepts/generated-ui.mdx
@@ -123,10 +123,11 @@ surface flip, and opening a served app all refuse with a typed
 
 Layer 3 works on both venues: BYO e2b (`E2B_API_KEY` or an explicit
 `e2bSandbox`) and the Vendo Cloud hosted sandbox. Cloud ingress is a
-single-label hostname, `https://<id>-m.vendo.run`, on the existing
-`*.vendo.run` certificate; non-default ports insert before the suffix as
-`<id>-<port>-m.vendo.run`. The console mints the URL, so the shape is
-console-side and the SDK echoes it.
+single-label hostname on the existing `*.vendo.run` certificate:
+`https://<id-suffix>-m.vendo.run`, where `<id-suffix>` is the machine id
+minus its two-character prefix. The console mints that canonical-port URL;
+for any other port the SDK rewrites the host client-side, inserting the port
+before the suffix as `<id-suffix>-<port>-m.vendo.run`.
 
 ### Graduation rollback
 

--- a/docs-site/concepts/generated-ui.mdx
+++ b/docs-site/concepts/generated-ui.mdx
@@ -121,11 +121,12 @@ served apps require machines. With the flags off, layer-3 generation, the
 surface flip, and opening a served app all refuse with a typed
 `not-implemented` error naming the flag.
 
-Layer 3 currently has one working venue: BYO e2b (`E2B_API_KEY` or an
-explicit `e2bSandbox`). On the Vendo Cloud hosted sandbox, the
-`*.m.vendo.run` ingress TLS certificate is not yet live, so served-app URLs
-fail the TLS handshake until it lands; layers 1 and 2 are unaffected on both
-venues.
+Layer 3 works on both venues: BYO e2b (`E2B_API_KEY` or an explicit
+`e2bSandbox`) and the Vendo Cloud hosted sandbox. Cloud ingress is a
+single-label hostname, `https://<id>-m.vendo.run`, on the existing
+`*.vendo.run` certificate; non-default ports insert before the suffix as
+`<id>-<port>-m.vendo.run`. The console mints the URL, so the shape is
+console-side and the SDK echoes it.
 
 ### Graduation rollback
 

--- a/docs-site/concepts/in-client-venue.mdx
+++ b/docs-site/concepts/in-client-venue.mdx
@@ -32,25 +32,23 @@ one app. The hash covers all app content, so any edit (a pin change, a
 generated-component change, a tree edit) produces a new hash and invalidates
 every existing approval for that app.
 
-The three verdict states behave differently in the surface:
-
-- An approved, unchanged version mounts in the host page.
-- A version that changed after approval renders jailed with a loud in-surface
-  notice ("…running in the sandbox again until the new version is
-  re-approved"), so users know an approval was invalidated.
-- An app that was never approved renders jailed and silent. That is the
-  universal state and does not announce itself.
+One exception to the jail fallback: a *review-kind* app — one whose pins were
+captured with `review: true` — never drops to the jail while it waits.
+Anything short of a grant becomes `pending-review`, the surface ships no
+executable source at all, and the user sees the review standing.
 
 If an approved component fails to compile or render, the surface drops back
-to the jail with an error notice. The exact record and verdict shapes are in
-the [Approval reference](#approval-reference).
+to the jail with an error notice. Every verdict and how it renders is in the
+[Approval reference](#approval-reference).
 
 ## Reviewing what changed: ship-diff
 
-Before minting an approval, a reviewer reads the *ship-diff*: the diff of
-approvable code against the last approved baseline, hash-pinned to the current
-version. Pinned host slots are diffed against the baseline captured when the
-pin was created; drift or a missing baseline is flagged and fails closed.
+Before minting an approval, a reviewer reads the *ship-diff*: approvable code
+diffed against the host baselines `vendo sync` captured, hash-pinned to the
+current version. Approvals are not an input — the diff answers "how far has
+this drifted from the shipped product", not "what changed since last
+approval". A pin whose captured baseline has since moved is flagged
+`drifted`; the diff still returns, and approving is still possible.
 Net-new generated components appear as pure additions. The tree structure
 itself is not in the diff; the reviewable *code* is.
 
@@ -63,13 +61,15 @@ const diff = await client.apps.shipDiff(appId);
 Or on the server:
 
 ```ts
-const diff = await vendo.apps.inClient.shipDiff(appId, {
-  principal
-});
+// ctx is the RunContext for the request: { principal, venue, presence, sessionId }
+const diff = await vendo.apps.inClient.shipDiff(appId, ctx);
 ```
 
-Both routes are owner-scoped. Only the app's owner can read the diff. The
-response shape is in [Ship-diff shape](#ship-diff-shape).
+Both are owner-scoped: only the app's owner can read the diff. The one
+exception is the review queue — `vendo.apps.review.queue(ctx)` hands the
+ship-diffs of *other* users' review-kind apps to a caller your composition's
+`apps.review.reviewer(ctx)` hook asserts. The response shape is in
+[Ship-diff shape](#ship-diff-shape).
 
 ## Minting approvals
 
@@ -81,8 +81,13 @@ is running, never a hand-crafted hash.
 ### Server-side
 
 ```ts
-await vendo.apps.inClient.approve(appId, { principal });
+await vendo.apps.inClient.approve({ appId, approvedBy: reviewerId }, ctx);
 ```
+
+`approvedBy` is required — the record names who reviewed. A review-kind app
+refuses to be approved by its own owner unless your composition asserts a
+reviewer through `apps.review.reviewer(ctx)`; without that hook the call is
+`blocked` with a pointer to it.
 
 ### Development wire route
 
@@ -93,19 +98,20 @@ curl -X POST \
   -d '{ "appId": "app_…" }'
 ```
 
-This route follows the rules in [Dev route rules](#dev-route-rules); it never
-mounts in production.
+`approvedBy` is optional here and defaults to `"local-dev"`. The route
+returns the approval record, and follows the rules in
+[Dev route rules](#dev-route-rules); it never mounts in production.
 
 Approvals are audited through `guard.report`. Read the record store with
-`vendo.apps.inClient.approvals(appId, { principal })`.
+`vendo.apps.inClient.approvals(appId, ctx)`.
 
 ## What runs in the host page
 
 Approved content runs in a closed module space: sucrase-compiled code with a
 controlled `require` that resolves React and captured sub-sources only, the
 same evaluation model the jail uses, in the venue the approved verdict
-unlocks. `sampleProps` are not used in the host mount; the shipped surface
-never renders stub data.
+unlocks. Venue parity extends to props: a node with no live props falls back
+to its captured `sampleProps` rehearsal stub, exactly as it would in the jail.
 
 The `$action` dispatch continues to route through the tree chokepoint, so
 host tools remain gated by the same policy, grants, and audit path as the
@@ -119,9 +125,13 @@ jailed venue.
 
 | State | Field on `payload.inClient` | Rendering |
 | --- | --- | --- |
-| Approved | `{ granted: true, versionHash }` | Host-page mount |
+| Approved | `{ granted: true, versionHash, approvedBy, at, review? }` | Host-page mount |
 | Approval exists but version changed | `{ granted: false, reason: "version-changed" }` | Jailed, with a loud in-surface notice |
+| Review-kind app not yet granted | `{ granted: false, reason: "pending-review", review }` | No source shipped; the review standing is rendered instead |
 | No approval ever recorded | field omitted | Jailed, silent (the default) |
+
+`review` is the standing: `{ status: "pending", versionHash }` or
+`{ status: "rejected", versionHash, note, by, at }`.
 
 ### The approval record
 
@@ -145,6 +155,7 @@ approvals.
 
 ```json
 {
+  "appId": "app_…",
   "versionHash": "…",
   "pins": [{ "slot": "…", "component": "…",
              "baseHash": "…", "baselineHash": "…",
@@ -155,9 +166,10 @@ approvals.
 
 ### Dev route rules
 
-`POST /api/vendo/dev/inclient-approval` is only mounted in development
-compositions (production returns `404`, matching `/dev/remixable-source`).
-The request must resolve a host principal; anonymous callers get `401`.
+`POST /api/vendo/dev/inclient-approval` is the only `/dev/*` route Vendo
+serves, and it is mounted in development compositions only (production
+returns `404`). The request must resolve a host principal; anonymous callers
+get `401`.
 
 ## Related reading
 

--- a/docs-site/concepts/in-client-venue.mdx
+++ b/docs-site/concepts/in-client-venue.mdx
@@ -126,8 +126,8 @@ jailed venue.
 | State | Field on `payload.inClient` | Rendering |
 | --- | --- | --- |
 | Approved | `{ granted: true, versionHash, approvedBy, at, review? }` | Host-page mount |
-| Approval exists but version changed | `{ granted: false, reason: "version-changed" }` | Jailed, with a loud in-surface notice |
-| Review-kind app not yet granted | `{ granted: false, reason: "pending-review", review }` | No source shipped; the review standing is rendered instead |
+| Approval exists but version changed | `{ granted: false, versionHash, reason: "version-changed" }` | Jailed, with a loud in-surface notice |
+| Review-kind app not yet granted | `{ granted: false, versionHash, reason: "pending-review", review }` | No source shipped; the review standing is rendered instead |
 | No approval ever recorded | field omitted | Jailed, silent (the default) |
 
 `review` is the standing: `{ status: "pending", versionHash }` or

--- a/docs-site/concepts/tools-and-safety.mdx
+++ b/docs-site/concepts/tools-and-safety.mdx
@@ -94,12 +94,16 @@ Breakers can turn a run decision into an ask at any point.
 
 Loadout selection is deterministic:
 
-- If you pass an explicit `agent.loadout` list, the agent loads exactly those
-  tool names (missing names are dropped).
-- Else, if the enabled host surface fits `agent.maxInitialTools` (default
-  `128`), every enabled host tool is loaded.
-- Else, the agent picks a read-first bounded default: safest risk first, then
-  name. The remainder stay searchable.
+- An explicit `agent.loadout` list wins: exactly those tool names, uncapped
+  (missing names are dropped).
+- Otherwise the default is a connection-scoped seed — your host tools plus
+  the toolkits this principal has actually connected — capped at
+  `agent.maxInitialTools` (default `128`), never an alphabetical slice.
+- If the seed cannot be resolved, the agent degrades to the whole enabled
+  host surface when it fits the cap, else to a read-first bounded default:
+  safest risk first, then name. The remainder stay searchable.
+
+Vendo's own `vendo_*` tools are always active and never count against the cap.
 
 `vendo_tools_search` ranks candidates from the enabled, post-override
 descriptor set: name-token matches beat name substrings, name matches beat

--- a/docs-site/connect/act-as-presets.mdx
+++ b/docs-site/connect/act-as-presets.mdx
@@ -36,8 +36,9 @@ name/email session-token claims:
 | `jwt({ secret })` | none (a host-owned scheme has no vendor env, so `secret` is required) | `Authorization: Bearer` |
 
 `jwt` shares the presets' options type, so `jwt()` type-checks — and then
-throws at construction telling you to pass `{ secret }`. A function-form
-`secret` that resolves empty throws on first use instead.
+throws at construction telling you to pass `{ secret }`. A `secret` that is
+present but resolves empty passes construction and throws later, on the first
+Bearer request it has to verify.
 
 Both options are shared across every preset: `secret` overrides the
 provider's env-read secret, and `user(subject, claims)` swaps in custom

--- a/docs-site/connect/act-as-presets.mdx
+++ b/docs-site/connect/act-as-presets.mdx
@@ -35,6 +35,10 @@ name/email session-token claims:
 | `auth0()` | `AUTH0_DOMAIN` / `AUTH0_ISSUER_BASE_URL` (tenant JWKS) | `Authorization: Bearer` |
 | `jwt({ secret })` | none (a host-owned scheme has no vendor env, so `secret` is required) | `Authorization: Bearer` |
 
+`jwt` shares the presets' options type, so `jwt()` type-checks — and then
+throws at construction telling you to pass `{ secret }`. A function-form
+`secret` that resolves empty throws on first use instead.
+
 Both options are shared across every preset: `secret` overrides the
 provider's env-read secret, and `user(subject, claims)` swaps in custom
 subject→user resolution instead of the provider's claims defaults (returning

--- a/docs-site/connect/api-tools.mdx
+++ b/docs-site/connect/api-tools.mdx
@@ -123,8 +123,8 @@ up whichever your app uses:
 
 ```json
 {
-  "name": "host_polls_delete",
-  "description": "polls.delete",
+  "name": "host_delete_poll",
+  "description": "GraphQL mutation deletePoll",
   "inputSchema": {
     "type": "object",
     "properties": { "id": { "type": "string" } },
@@ -133,16 +133,19 @@ up whichever your app uses:
   "risk": "destructive",
   "binding": {
     "kind": "graphql",
-    "operation": "delete",
+    "operation": "deletePoll",
     "type": "mutation",
     "endpoint": "/graphql",
-    "document": "mutation delete($id: ID!) { delete(id: $id) { __typename } }"
+    "document": "mutation deletePoll($id: ID!) { deletePoll(id: $id) { __typename } }"
   }
 }
 ```
 
-Each binding records the operation name, its `query` or `mutation` type, the
-endpoint, and a full executable `document`. The document declares variables
+GraphQL has no namespace dot path, so the tool name is `host_` plus the
+word-split schema field name alone — colliding names fall back to
+`host_<name>_<type>`. The description is always
+`GraphQL <type> <operation>`. Each binding records the operation name, its
+`query` or `mutation` type, the endpoint, and a full executable `document`. The document declares variables
 for every argument, marks optional or defaulted arguments as nullable so the
 agent can omit them, and uses a depth-limited default selection set with a
 `{ __typename }` floor. At runtime Vendo POSTs

--- a/docs-site/connect/api-tools.mdx
+++ b/docs-site/connect/api-tools.mdx
@@ -60,7 +60,7 @@ each mount is detected independently.
 ```json
 {
   "name": "host_polls_delete",
-  "description": "polls.delete",
+  "description": "tRPC mutation polls.delete",
   "inputSchema": {
     "type": "object",
     "properties": { "id": { "type": "string" } },
@@ -143,8 +143,10 @@ up whichever your app uses:
 
 GraphQL has no namespace dot path, so the tool name is `host_` plus the
 word-split schema field name alone — colliding names fall back to
-`host_<name>_<type>`. The description is always
-`GraphQL <type> <operation>`. Each binding records the operation name, its
+`host_<name>_<type>`. Queries and mutations get the description
+`GraphQL <type> <operation>`; a subscription is emitted disabled, with a
+description saying it is not invokable over a single HTTP request. Each
+binding records the operation name, its
 `query` or `mutation` type, the endpoint, and a full executable `document`. The document declares variables
 for every argument, marks optional or defaulted arguments as nullable so the
 agent can omit them, and uses a depth-limited default selection set with a
@@ -186,8 +188,8 @@ tool.
 
 ```json
 {
-  "name": "host_actions_boards_delete_board",
-  "description": "actions/boards#deleteBoard",
+  "name": "host_delete_board",
+  "description": "server action app/actions/boards.ts#deleteBoard",
   "inputSchema": {
     "type": "object",
     "properties": { "id": { "type": "string" } },

--- a/docs-site/connect/host-components.mdx
+++ b/docs-site/connect/host-components.mdx
@@ -41,7 +41,7 @@ object keys, so there is no second client-side map to keep in sync:
 
 ```ts
 import { createVendo } from "@vendoai/vendo/server";
-import type { ComponentRegistry } from "@vendoai/core";
+import type { ComponentRegistry } from "@vendoai/vendo";
 import { z } from "zod";
 import {
   SpendingDonut

--- a/docs-site/connect/instructions.mdx
+++ b/docs-site/connect/instructions.mdx
@@ -13,7 +13,7 @@ each to that place and to its position in the assembled prompt.
 | --- | --- |
 | `.vendo/brief.md` | product brief placed near the start of the agent prompt |
 | `.vendo/policy.json` `directions` | company steering returned by guard |
-| `createAgent({ system: { instructions } })` | final host additions to the agent prompt |
+| `createVendo({ agent: { instructions } })` | final host additions to the agent prompt |
 | `.vendo/design-rules.md` | optional rules for app generation, re-read per generation (edits apply without a restart) |
 | `createVendo({ apps: { designRules } })` | the same rules in config; a non-blank value wins over the file |
 
@@ -22,14 +22,20 @@ Directions are policy data. Put them in the policy file or inline
 
 ## Prompt assembly order
 
-The agent assembles its system prompt fresh for each turn:
+The agent assembles its system prompt fresh for each turn. Conditional
+sections drop out entirely; the rest keep this order:
 
 1. Vendo's operating prompt.
-2. Capability-miss reporting guidance, when enabled.
-3. The host product brief from `.vendo/brief.md`.
-4. Company directions returned by `guard.directions(ctx)`.
-5. Catalog and theme summary when the venue can render trees.
-6. Host instructions.
+2. Presentation guidance, when the venue can render trees (chat and app).
+3. Capability-miss reporting guidance, when enabled.
+4. Discovery-budget guidance, when tool search is on.
+5. The host product brief from `.vendo/brief.md`.
+6. Company directions returned by `guard.directions(ctx)`.
+7. Catalog and theme summary, when the venue can render trees.
+8. The knowledge index, when knowledge is configured and the venue can
+   render trees.
+9. Host instructions — last, so they are the final word on tone and emphasis.
+   Policy belongs in guard directions, not here.
 
 The apps generation engine has its own specialized prompts for tree emission
 and code edits. It receives the component catalog, theme, optional design

--- a/docs-site/deploy/deploying.mdx
+++ b/docs-site/deploy/deploying.mdx
@@ -40,8 +40,9 @@ backup and retention. If something is broken, start with
 ## Block unlocks
 
 Past the checklist, turn on the rest of the platform deliberately, one block
-at a time. `vendo doctor` ends with a ladder line naming exactly what each
-remaining block unlocks for your install.
+at a time. `vendo doctor` prints a short ladder pointer covering three of
+them — execution venue, `actAs`, and connectors. The rest of the table is
+yours to work through.
 
 | Unlock | What it adds | Where |
 | --- | --- | --- |

--- a/docs-site/deploy/persistence.mdx
+++ b/docs-site/deploy/persistence.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Persistence: Postgres schema and PGlite for local dev"
 sidebarTitle: "Persistence"
-description: "How Vendo's Postgres schema, default-on secret encryption, append-only audit, and eraseStore API work across PGlite dev and hosted production."
+description: "How Vendo's Postgres schema, secret encryption, append-only audit, and eraseStore API work across PGlite dev and hosted production."
 ---
 
 Vendo persists threads, apps, records, blobs, state, grants, approvals,
@@ -54,10 +54,12 @@ Anonymous traffic keeps serving, and local stores are unaffected.
 
 ### Stable tables
 
-The stable public tables are `vendo_meta`, `vendo_apps`, `vendo_records`,
-`vendo_blobs`, `vendo_state`, `vendo_threads`, `vendo_grants`,
-`vendo_approvals`, `vendo_audit`, `vendo_runs`, `vendo_secrets`, and
-`vendo_sessions` (the anonymous-session registry the TTL sweep reads).
+The sixteen stable public tables are `vendo_meta`, `vendo_apps`,
+`vendo_records`, `vendo_blobs`, `vendo_state`, `vendo_threads`,
+`vendo_grants`, `vendo_approvals`, `vendo_audit`, `vendo_runs`,
+`vendo_secrets`, `vendo_mcp_clients`, `vendo_mcp_grants`, `vendo_sessions`
+(the anonymous-session registry the TTL sweep reads), `vendo_knowledge_docs`,
+and `vendo_knowledge_chunks`. `eraseStore` covers all sixteen.
 
 ### PGlite is single-writer
 
@@ -69,20 +71,28 @@ safe. A lock left behind by a killed process is reclaimed automatically. If
 boot logs show the store waiting on a pid, another server owns that dir:
 stop it, give each server its own `dataDir`, or move to a Postgres `url`.
 
-### Encryption is on by default
+### Encryption is opt-in, and production fails closed without it
 
-Set a 32-byte base64 key at `VENDO_STORE_ENCRYPTION_KEY` in your host
-`.env`. The default composition reads it when no store is passed to
-`createVendo`, so secret values in `vendo_secrets` are encrypted at rest
-without extra wiring. Do not rotate the key by hand: losing it makes
-existing secrets unreadable.
+Encryption covers exactly one column, `vendo_secrets.ciphertext`. Everything
+else stays host-queryable plaintext by design.
+
+Set a 32-byte base64 key at `VENDO_STORE_ENCRYPTION_KEY` in your host `.env`.
+The default composition reads it when no store is passed to `createVendo`.
+Without that key:
+
+- In dev (`NODE_ENV` is not `production`), secrets are written **unencrypted**
+  under the gitignored data dir, and the first plaintext write logs a warning.
+- In production, secret reads and writes **throw** rather than fall back to
+  plaintext. Set the key before you deploy anything that stores a secret.
 
 An explicitly configured store always wins. If you pass
 `store: createStore({ encryption: { key } })` to `createVendo`, the
 environment variable is ignored.
 
-Ciphertext is bound to the secret name with AES-GCM authenticated data, so a
-tampered or swapped row fails to decrypt.
+Ciphertext is AES-256-GCM and bound to the secret name as authenticated data,
+so a tampered or swapped row fails to decrypt. Do not rotate the key by hand:
+losing it makes existing secrets unreadable. Encryption needs the Node
+runtime — see [edge runtimes](/deploy/edge-runtimes).
 
 ### Audit is append-only
 
@@ -115,35 +125,13 @@ const byApp = await eraseStore(vendo.store).byApp(appId);
 Each call returns per-table deleted counts so you can log or verify the
 cascade.
 
-### Atomic claims
+### Compare-and-set on your own collections
 
-The store contract exposes a compare-and-set (CAS) claim primitive so
-concurrent workers can safely coordinate on a shared key without external
-locks. Use it whenever two ticks, retries, or agent runs might race on the
-same record: for example, deduplicating a webhook delivery, claiming a
-queued token exchange, or ensuring only one worker processes an invoice.
-
-```ts
-const claim = await vendo.store.claim({
-  key: `invoice:${invoiceId}`,
-  owner: runId,
-  ttlMs: 60_000,
-});
-
-if (!claim.acquired) {
-  // Another run already holds this key. Skip.
-  return;
-}
-
-try {
-  await processInvoice(invoiceId);
-} finally {
-  await vendo.store.release(claim);
-}
-```
-
-Claims are keyed per principal and expire after `ttlMs`, so a crashed worker
-never holds a key forever. `acquired` is false when another owner holds the
-key and its TTL has not elapsed. The same CAS machinery backs run-lifecycle
-transitions (start, stop, complete), so cancellation and scheduler ticks
-cannot resurrect a terminal run.
+When two ticks, retries, or agent runs might race on the same record, a
+record store exposes optional compare-and-set primitives on the collection
+handle: `records(name).claim(expected, replacement?)` returns `true` for the
+single caller whose read of `expected` still matched, and
+`records(name).atomic?.insertIfAbsent(record)` /
+`.compareAndSwap(record, expectedRevision)` return `null` when another caller
+won. Both are optional capabilities — check for them before use, and note
+that Vendo's own reserved collections do not expose them.

--- a/docs-site/deploy/persistence.mdx
+++ b/docs-site/deploy/persistence.mdx
@@ -76,18 +76,25 @@ stop it, give each server its own `dataDir`, or move to a Postgres `url`.
 Encryption covers exactly one column, `vendo_secrets.ciphertext`. Everything
 else stays host-queryable plaintext by design.
 
-Set a 32-byte base64 key at `VENDO_STORE_ENCRYPTION_KEY` in your host `.env`.
-The default composition reads it when no store is passed to `createVendo`.
-Without that key:
+What actually gates it is the store's own `allowUnencryptedSecrets` option:
+with no encryption key and no explicit opt-in to plaintext, every secret read
+*and* write throws. `createStore({})` by hand therefore refuses secrets even
+in development.
 
-- In dev (`NODE_ENV` is not `production`), secrets are written **unencrypted**
-  under the gitignored data dir, and the first plaintext write logs a warning.
-- In production, secret reads and writes **throw** rather than fall back to
-  plaintext. Set the key before you deploy anything that stores a secret.
+The default composition — no `store` passed to `createVendo` — supplies that
+opt-in for you from the environment. Set a 32-byte base64 key at
+`VENDO_STORE_ENCRYPTION_KEY` in your host `.env` and secrets encrypt. Without
+it, the composition passes `allowUnencryptedSecrets` when `NODE_ENV` is not
+`production`, so:
+
+- In dev, secrets are written **unencrypted** under the gitignored data dir,
+  and the first plaintext write logs a warning.
+- In production, secret reads and writes **throw**. Set the key before you
+  deploy anything that stores a secret.
 
 An explicitly configured store always wins. If you pass
 `store: createStore({ encryption: { key } })` to `createVendo`, the
-environment variable is ignored.
+environment variable is ignored — and so is the `NODE_ENV` convenience above.
 
 Ciphertext is AES-256-GCM and bound to the secret name as authenticated data,
 so a tampered or swapped row fails to decrypt. Do not rotate the key by hand:
@@ -133,5 +140,6 @@ handle: `records(name).claim(expected, replacement?)` returns `true` for the
 single caller whose read of `expected` still matched, and
 `records(name).atomic?.insertIfAbsent(record)` /
 `.compareAndSwap(record, expectedRevision)` return `null` when another caller
-won. Both are optional capabilities — check for them before use, and note
-that Vendo's own reserved collections do not expose them.
+won. Your own collections expose both. Vendo's internal tables vary — the
+routed reserved tables expose no `claim` at all — so feature-detect the
+method on the handle rather than assuming it is there.

--- a/docs-site/deploy/principals-and-orgs.mdx
+++ b/docs-site/deploy/principals-and-orgs.mdx
@@ -58,8 +58,11 @@ update them to match `vendo:webhook:<source>` instead of the bare
 ### Anonymous sessions
 
 When `principal(req)` returns `null`, Vendo mints an ephemeral session
-principal and carries it in an opaque `httpOnly` cookie: a random session id
-scoped to the wire base path. The cookie is just a pointer; the session row
+principal and carries it in an opaque cookie holding a random session id:
+`Path=/`, `HttpOnly`, `SameSite=Lax`, and over HTTPS the `Secure`,
+`__Host-`-prefixed form. `Path=/` is deliberate — the pointer has to be
+visible on document responses so a host can mint it on a cold load, and the
+`__Host-` prefix requires it. The cookie is just a pointer; the session row
 in the database is the authority, so a forged id merely names its own empty
 session. Ephemeral principals write ordinary rows under their anonymous
 subject; a TTL sweep erases sessions idle past `sessions.ttlMs` (default 30

--- a/docs-site/deploy/telemetry.mdx
+++ b/docs-site/deploy/telemetry.mdx
@@ -88,9 +88,9 @@ Vendo Cloud uploads capability misses when, and only when, both of these hold:
 - the environment does not trip a kill switch (see below)
 
 The non-empty API key is the host's explicit opt-in, so production runs upload
-misses by default once a key is present. The build-and-development-only
-`NODE_ENV=production` fail-close and the persisted `optedOut` flag in
-`~/.vendo/telemetry.json` do not gate this stream.
+misses by default once a key is present. Neither the `NODE_ENV` fail-close
+(which applies only to the dev-server runtime collector) nor the persisted
+`optedOut` flag in `~/.vendo/telemetry.json` gates this stream.
 
 Any of these environment values blocks upload for the current process:
 

--- a/docs-site/deploy/telemetry.mdx
+++ b/docs-site/deploy/telemetry.mdx
@@ -31,14 +31,20 @@ ever sent, and it is scrubbed first: file paths, email addresses, and
 secret-shaped strings are replaced with fixed tokens, then the result is
 capped at 200 characters.
 
-Disable telemetry with any of these controls — each applies to both lanes, so
-an opted-out user with a cloud key sends nothing:
+Disable this stream with any of these controls — each applies to both lanes,
+so an opted-out user with a cloud key sends nothing:
 
-- `VENDO_TELEMETRY_DISABLED=1`
+- `VENDO_TELEMETRY_DISABLED=1` (or `true`)
+- `DO_NOT_TRACK=1` (or `true`)
+- `CI` set to anything other than `""`, `"0"`, or `"false"`
 - `"optedOut": true` in `~/.vendo/telemetry.json`
-- `DO_NOT_TRACK=1`
-- `CI`
-- `NODE_ENV=production`
+
+`NODE_ENV` is a separate, narrower gate. It applies only to the dev-server
+runtime collector, which fires solely when `NODE_ENV` is `development` or
+`test` — an unset or unrecognized value is treated as production and
+collects nothing. It does **not** gate the CLI and build collector, which is
+what `vendo init`, `sync`, and `doctor` report through; use the four controls
+above for that.
 
 The stored id is a random UUID and is not derived from a machine, account,
 project, or host app. Deleting the file rotates it.

--- a/docs-site/deploy/troubleshooting.mdx
+++ b/docs-site/deploy/troubleshooting.mdx
@@ -74,7 +74,7 @@ Every non-2xx response uses `{ "error": { "code", "message" } }`.
 
 ## Doctor probes
 
-`vendo doctor` calls four `/doctor/*` routes on the running dev server:
+`vendo doctor` calls three `/doctor/*` routes on the running dev server:
 
 - `POST /doctor/present` verifies that `authorization` and `cookie` headers
   reach the host API on same-origin calls. Failure means `VENDO_BASE_URL` is
@@ -84,10 +84,13 @@ Every non-2xx response uses `{ "error": { "code", "message" } }`.
   material the host principal resolver accepts. Doctor warns (does not
   fail) when `actAs` is not configured.
 - `GET /doctor/machines` reports the sandbox and scheduler wiring.
-- `GET /doctor/base-url` reports whether `VENDO_BASE_URL` is set.
 
 The probes report booleans only — no credential values are printed or
-persisted. The synthetic routes return 404 in production; `/doctor/base-url`
-is the deliberate exception, because production is exactly the environment
-whose missing `VENDO_BASE_URL` it exists to report.
+persisted, and the synthetic `/doctor/*` routes return 404 in production.
+
+`GET /doctor/base-url` is the one exception to that 404, and doctor does not
+call it: it exists for a deployed production server to answer. It reports the
+missing case **only** in production — outside production it returns
+`{ "ok": true }` unconditionally, whether or not `VENDO_BASE_URL` is set, so a
+green answer in dev says nothing about your production wiring.
 See the [CLI reference](/reference/cli#vendo-doctor-dir).

--- a/docs-site/deploy/troubleshooting.mdx
+++ b/docs-site/deploy/troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting Vendo: doctor, /status, and error codes"
 sidebarTitle: "Troubleshooting"
-description: "Diagnose broken Vendo wiring with npx vendo doctor, the /status round trip, and the stable error taxonomy shared by CLI, handler, and client."
+description: "Diagnose broken Vendo wiring with npx vendo doctor, its live probes against your dev server, and the stable error taxonomy shared by CLI, handler, and client."
 ---
 
 Start with:
@@ -10,8 +10,10 @@ Start with:
 npx vendo doctor
 ```
 
-Doctor checks local wiring and makes one live `/status` round trip. Exit code 0
-is green; exit code 1 means broken wiring. See
+Doctor checks local wiring, then probes your running dev server live — a
+`/status` round trip, your root page, the credential-forwarding probes, and
+finally one real streaming model turn through the wire, which spends tokens.
+Exit code 0 is green; exit code 1 means broken wiring. See
 [Verify](/agents/verify) for the symptom, cause, and fix behind every doctor
 error code.
 
@@ -72,7 +74,7 @@ Every non-2xx response uses `{ "error": { "code", "message" } }`.
 
 ## Doctor probes
 
-`vendo doctor` runs two live probes against the running dev server:
+`vendo doctor` calls four `/doctor/*` routes on the running dev server:
 
 - `POST /doctor/present` verifies that `authorization` and `cookie` headers
   reach the host API on same-origin calls. Failure means `VENDO_BASE_URL` is
@@ -81,7 +83,11 @@ Every non-2xx response uses `{ "error": { "code", "message" } }`.
 - `POST /doctor/act-as` verifies that `createVendo({ actAs })` mints auth
   material the host principal resolver accepts. Doctor warns (does not
   fail) when `actAs` is not configured.
+- `GET /doctor/machines` reports the sandbox and scheduler wiring.
+- `GET /doctor/base-url` reports whether `VENDO_BASE_URL` is set.
 
-Both probes report booleans only (no credential values are printed or
-persisted), and the synthetic `/doctor/*` routes return 404 in production.
+The probes report booleans only — no credential values are printed or
+persisted. The synthetic routes return 404 in production; `/doctor/base-url`
+is the deliberate exception, because production is exactly the environment
+whose missing `VENDO_BASE_URL` it exists to report.
 See the [CLI reference](/reference/cli#vendo-doctor-dir).

--- a/docs-site/existing-agents/configuration.mdx
+++ b/docs-site/existing-agents/configuration.mdx
@@ -49,7 +49,7 @@ explicit provider key (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
 - No `VENDO_API_KEY` yet? `npx vendo login` mints a free metered dev key
   straight into `.env.local`.
 - If your loop's model has no key on this machine, either set one or point
-  your `model` at `devModel()` from `@vendoai/vendo/server` to ride the
+  your `model` at `vendoModel()` from `@vendoai/vendo/server` to ride the
   same ladder.
 
 The done-criterion for an install is a REAL chat turn that renders a Vendo
@@ -58,9 +58,7 @@ tool output — `vendo doctor` cannot check your loop's model.
 ## Next.js notes
 
 - The wire route needs no `runtime` or `dynamic` exports: Node is the
-  default runtime and route handlers are dynamic by default. On a Next 16
-  app with `cacheComponents: true`, an `export const dynamic` line is a
-  build error.
+  default runtime and route handlers are dynamic by default.
 - `serverExternalPackages: ["esbuild", "@electric-sql/pglite"]` keeps
   Vendo's native and wasm dependencies out of the bundler.
 

--- a/docs-site/existing-agents/embeds.mdx
+++ b/docs-site/existing-agents/embeds.mdx
@@ -6,8 +6,8 @@ description: "The versioned JSON envelope vendo_* tools return, and the three @v
 When your own agent calls a guarded tool, the result has to reach your chat
 without your loop ever needing to know what an "app" or an "approval" is.
 Vendo answers that with one small envelope format: a `vendo_*` tool returns
-either plain data or a versioned ref, and one of three `@vendoai/ui`
-components turns that ref into the right rendered surface. This page is the
+either plain data or a versioned ref, and one of three embed components
+turns that ref into the right rendered surface. This page is the
 canonical reference for both.
 
 ## The envelope contract
@@ -24,12 +24,15 @@ envelope discriminated by `kind`:
 You rarely dispatch on `kind` yourself: `<VendoToolResult output={...}>`
 takes any `vendo_*` tool output and renders the right embed, or nothing for
 plain data. If you need the dispatcher server-side,
-`parseVendoToolEnvelope(output)` from `@vendoai/core` returns the envelope
-or `null`.
+`parseVendoToolEnvelope(output)` returns the envelope or `null`. It is a
+runtime value, so it ships from `@vendoai/core` rather than the type-only
+umbrella root — add `@vendoai/core` to your dependencies to import it.
 
 ## The three embeds
 
-Import all three from `@vendoai/ui`. Each reads the wire through the
+Import all three from `@vendoai/vendo/react`, which re-exports them so you
+need no second package. (Their prop types are named in the table below; those
+live on `@vendoai/ui`.) Each reads the wire through the
 surrounding `VendoProvider` and polls on its own until it reaches a terminal
 state; none takes config props beyond the one shown, since theming and
 behavior come entirely from `VendoProvider`.
@@ -58,7 +61,7 @@ render on-brand. Failure states use the existing failed/expired vocabulary,
 never a silent blank.
 
 ```tsx
-import { VendoProvider, VendoToolResult } from "@vendoai/ui";
+import { VendoProvider, VendoToolResult } from "@vendoai/vendo/react";
 
 <VendoProvider>
   {/* your chat; for each finished tool part: */}

--- a/docs-site/existing-agents/embeds.mdx
+++ b/docs-site/existing-agents/embeds.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Embeds and envelopes"
-description: "The versioned JSON envelope vendo_* tools return, and the three @vendoai/ui components (VendoToolResult, VendoAppEmbed, VendoApprovalEmbed) that render it inside your own chat."
+description: "The versioned JSON envelope vendo_* tools return, and the three embed components (VendoToolResult, VendoAppEmbed, VendoApprovalEmbed) that render it inside your own chat."
 ---
 
 When your own agent calls a guarded tool, the result has to reach your chat

--- a/docs-site/existing-agents/index.mdx
+++ b/docs-site/existing-agents/index.mdx
@@ -47,7 +47,9 @@ the embeds: Vendo minus the conversation.
 ```ts
 // lib/vendo.ts: the same composition as any Vendo host
 import { createVendo } from "@vendoai/vendo/server";
-import { getWeather, sendTripReport } from "./actions";
+
+export async function getWeather(city: string) { /* … */ }
+export async function sendTripReport(to: string, body: string) { /* … */ }
 
 export const vendo = createVendo({
   policy: "cautious",
@@ -58,6 +60,12 @@ export const vendo = createVendo({
   },
 });
 ```
+
+Each key is `<declaring module>#<export name>` — the path of the file the
+action is *declared* in, relative to the project root, not the file that
+imports it. Move `getWeather` into `lib/actions.ts` and the key becomes
+`lib/actions.ts#getWeather`; get it wrong and dispatch fails closed with
+`not-implemented`.
 
 On a Next.js host that ran `vendo init`, this map is generated for you as
 `vendo-actions.ts` next to the route file and imported from there — the route

--- a/docs-site/existing-agents/index.mdx
+++ b/docs-site/existing-agents/index.mdx
@@ -47,13 +47,22 @@ the embeds: Vendo minus the conversation.
 ```ts
 // lib/vendo.ts: the same composition as any Vendo host
 import { createVendo } from "@vendoai/vendo/server";
-import { serverActions } from "./vendo-actions";
+import { getWeather, sendTripReport } from "./actions";
 
 export const vendo = createVendo({
   policy: "cautious",
-  serverActions, // the map vendo init generates from your host actions
+  // in-process dispatch for the actions declared in .vendo/tools.json
+  serverActions: {
+    "lib/vendo.ts#getWeather": getWeather,
+    "lib/vendo.ts#sendTripReport": sendTripReport,
+  },
 });
 ```
+
+On a Next.js host that ran `vendo init`, this map is generated for you as
+`vendo-actions.ts` next to the route file and imported from there — the route
+module is the composition. Compose in `lib/` only if you are wiring by hand,
+as the BYO examples do.
 
 Then build the tool pack per framework and spread it into your agent:
 
@@ -102,7 +111,7 @@ same eventual consistency Vendo's own thread uses for abandoned approvals,
 in a new venue.
 
 See [Embeds and envelopes](/existing-agents/embeds) for the envelope
-contract and the three `@vendoai/ui` embed components that render it inside
+contract and the three embed components that render it inside
 your own chat.
 
 ## Two models, deliberately

--- a/docs-site/existing-agents/mastra.mdx
+++ b/docs-site/existing-agents/mastra.mdx
@@ -91,7 +91,10 @@ Wrap the chat once in `VendoProvider` and hand finished tool outputs to
 parts, so match both:
 
 ```tsx
-// src/app/page.tsx — inside your existing message-parts loop
+// src/app/page.tsx
+type ToolLikePart = { type: string; toolName?: string; state?: string; output?: unknown };
+
+// inside your existing message-parts loop
 if (part.type === "dynamic-tool" || part.type.startsWith("tool-")) {
   const tool = part as ToolLikePart;
   return tool.state === "output-available"

--- a/docs-site/existing-agents/mastra.mdx
+++ b/docs-site/existing-agents/mastra.mdx
@@ -92,6 +92,8 @@ parts, so match both:
 
 ```tsx
 // src/app/page.tsx
+import { VendoToolResult } from "@vendoai/vendo/react";
+
 type ToolLikePart = { type: string; toolName?: string; state?: string; output?: unknown };
 
 // inside your existing message-parts loop

--- a/docs-site/ui/components.mdx
+++ b/docs-site/ui/components.mdx
@@ -299,30 +299,30 @@ the three components, and their props.
 ## Theming
 
 Every component above re-themes from one token file. Extract it with
-`vendo init`, or hand-edit `.vendo/theme.json`; the try surface's theme
+`vendo init`, or hand-edit `.vendo/theme.json`; the playground's theme
 editor emits a valid file from whatever look you land on. See
 [Theming](/connect/theming) for the full token reference.
 
-<Frame caption="The try surface's theme editor: presets, per-token colors, any Google Font, radius, density, motion.">
-  <img src="/images/ui/hero-theme-editor.png" alt="The Vendo try surface theme editor open over the activities surface" />
+<Frame caption="The playground's theme editor: presets, per-token colors, any Google Font, radius, density, motion.">
+  <img src="/images/ui/hero-theme-editor.png" alt="The Vendo playground theme editor open over the activities surface" />
 </Frame>
 
-## Try every surface live
+## See every surface live
 
-The hosted try surface below runs the same components. Paste your product's
+The hosted playground below runs the same components. Paste your product's
 domain to see them re-themed to your brand on generated data, or explore as
 is. Use the **Theme** button inside it to edit every theme token live, copy a
 ready `.vendo/theme.json`, and share a themed link.
 
 <iframe
   src="https://vendo.run/playground"
-  title="The hosted Vendo try surface: paste a domain, see every surface in your brand"
+  title="The Vendo playground: paste a domain, see every surface in your brand"
   width="100%"
   height="720"
   style={{ border: "1px solid #e5e5e5", borderRadius: "12px" }}
 />
 
 If the embeds on this page do not load, open
-[vendo.run/playground](https://vendo.run/playground) directly, or run
-`npx vendo try` from your app's repo for the real thing: your tools, your
-theme, nothing written. See [Try Vendo](/try).
+[vendo.run/playground](https://vendo.run/playground) directly. To see these
+surfaces on your own tools and your own theme, run `vendo init` in your app —
+the [quickstart](/quickstart) walks the whole path.

--- a/docs-site/ui/components.mdx
+++ b/docs-site/ui/components.mdx
@@ -138,18 +138,12 @@ field is optional; missing fields fall through to the default fallback.
 ```tsx
 "use client";
 
-import { VendoProvider, type ToolMetaMap } from "@vendoai/ui";
+import { VendoProvider, type ToolMetaMap } from "@vendoai/vendo/react";
 
 const tools: ToolMetaMap = {
   host_email_send: {
     label: "Send email",
     description: "Send a message from your connected inbox.",
-    summarize: (args) => {
-      if (args && typeof args === "object" && "to" in args) {
-        return `To ${(args as { to: string }).to}`;
-      }
-      return undefined;
-    },
   },
   host_invoice_create: {
     label: "Create invoice",
@@ -166,7 +160,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
 | --- | --- |
 | `label` | Short display name shown on the tool chip and as the approval card title. |
 | `description` | One-line description shown under the approval card title. |
-| `summarize(args)` | Custom one-line summary shown on the tool chip. Return `undefined` to fall back to the default `Key value` summary. |
+| `formatField(key, value)` | Display formatting for one approval-card field, e.g. integer cents as `$500.00`. Return `undefined` to keep the raw value. Display-only: the raw args still drive the decision hash and the exact-input grant. |
 
 `tools` is additive and UI-side. It does not change the wire, the tool
 descriptor, or guard behavior: a call still routes through the same policy,
@@ -183,7 +177,7 @@ components degrade to the formatting fallback.
 ```tsx
 "use client";
 
-import { useVendoTools } from "@vendoai/ui";
+import { useVendoTools } from "@vendoai/vendo/react";
 
 export function ToolLabel({ name }: { name: string }) {
   const tools = useVendoTools();
@@ -297,7 +291,7 @@ variables. Configure the voice driver and its model provider in host code.
 ## Embeds for your own agent's chat
 
 If your product keeps its own agent loop and spreads in the
-[guarded tool pack](/existing-agents), three `@vendoai/ui` components render
+[guarded tool pack](/existing-agents), three embed components render
 Vendo inline in that chat instead of the chrome above. See
 [Embeds and envelopes](/existing-agents/embeds) for the envelope contract,
 the three components, and their props.


### PR DESCRIPTION
Wave D lane 3 of the self-serve audit (`2026-08-02-self-serve-audit.md`, Appendix A rows #52–73 and #77–78). Every row was re-verified against `packages/` source before any edit; where the audit was wrong, the doc was left alone and the row is called out below.

Doctrine was delete-before-rewrite: the single largest change is the removal of an entire fabricated API section.

## Dispositions

| # | Page | Finding | Disposition |
| --- | --- | --- | --- |
| 52 | deploy/persistence | `vendo.store.claim({key,owner,ttlMs})` / `release` | **Deleted.** No such API exists anywhere in `packages/`. Replaced by one verified paragraph on the real optional primitives: `records(name).claim(expected, replacement?)` and `records(name).atomic?.insertIfAbsent / compareAndSwap` (`packages/core/src/store.ts:46-88`). |
| 53 | deploy/persistence | "Encryption is on by default" | **Fixed.** On only with `VENDO_STORE_ENCRYPTION_KEY`; dev writes plaintext with a warning, production **throws** on secret reads *and* writes. Scope narrowed to the one encrypted column, `vendo_secrets.ciphertext`. |
| 54 | deploy/persistence | 12 stable tables | **Fixed** → 16 (`ERASE_TABLES`, `packages/store/src/erase.ts:12-27`). |
| 55 | capabilities/compound-tools | `{{ … }}` template expressions | **Fixed.** Raw JSONata, compiled verbatim. Every example rewritten; a new "Expressions" section states that `{{ }}` is a parse error and that a literal string needs inner quotes (`"'invoice-reminder'"`). |
| 56 | capabilities/compound-tools | bare `load.status` step addressing | **Fixed** → `steps.<id>`, cribbed from `packages/actions/src/runtime/steps.test.ts` so the examples actually run. |
| 57 | capabilities/compound-tools | forEach item "available to args" | **Fixed.** Bound to the name `item`; documented with the array collection under `steps.<id>`, the 1000-item ceiling, and the skipped-`if` no-key rule. Also corrected a latent error the audit missed: step `args` is `Record<string,string>`, so the old nested `vars` object would have failed schema validation. |
| 58 | capabilities/mcp | "init asks about MCP / scaffolds `.well-known`" | **Deleted** in both places. Init has zero MCP prompts and writes no such route. The page now says the door is entirely manual and documents the hand-mount of `wellKnownVendoHandler`, pointing at `examples/demo-bank` for reference wiring. |
| 59 | concepts/in-client-venue | `approve(appId, {principal})` | **Fixed** → `approve({ appId, approvedBy }, ctx)` (`packages/apps/src/runtime.ts:563`), plus the undocumented review-kind refusal that requires `apps.review.reviewer(ctx)`. |
| 60 | concepts/in-client-venue | shipDiff signature; two verdicts | **Fixed.** Second arg is the full `RunContext`. `pending-review` documented as a first-class verdict with its `ReviewStanding` rider; the granted row gained `approvedBy`/`at`. Also fixed the ship-diff baseline: it diffs against sync-captured host baselines, not the last approved version, and drift is flagged rather than fail-closed. |
| 61 | concepts/in-client-venue | `/dev/remixable-source` | **Deleted.** Route does not exist; `/dev/inclient-approval` is the only `/dev/*` route Vendo serves. |
| 62 | connect/host-components | `ComponentRegistry` from `@vendoai/core` | **Fixed** → `@vendoai/vendo` (TS2307 under pnpm strict linking; the init scaffold and its docs-check assert this exact specifier). |
| 63 | existing-agents/embeds | `parseVendoToolEnvelope` from `@vendoai/core` | **Documented the true path.** It is a runtime value and the umbrella root is type-only, so `@vendoai/core` *is* correct — the page now says it must be a direct dependency, as both BYO examples declare. |
| 64 | existing-agents/index | `lib/vendo.ts` imports `./vendo-actions` | **Fixed.** Snippet now matches the shipped BYO example (inline map), with a note that init's Next scaffold generates `vendo-actions.ts` next to the route module and composes there. |
| 65 | existing-agents/configuration | `devModel()`; "`export const dynamic` is a build error" | **Fixed** → `vendoModel()`. Build-error claim **deleted** — the shipped `demo-accounting` wire route declares both `runtime` and `dynamic`. |
| 66 | existing-agents/mastra | `part as ToolLikePart` | **Fixed.** Snippet is now self-contained with the same inline type `examples/mastra-agent` uses. No package exports that name. |
| 67 | embeds + ui/components | direct `@vendoai/ui` imports, no install step | **Fixed** → `@vendoai/vendo/react`, which re-exports the embeds, `VendoProvider`, `ToolMetaMap`, and `useVendoTools`; no extra install. Prop-type home noted where it differs. |
| 68 | connect/instructions | `createAgent({system})`; 6 prompt sections | **Fixed** → `createVendo({ agent: { instructions } })` (`createAgent` is an internal seam, not host-facing). Prompt list corrected to the real 9 sections in real order — Presentation, Discovery budget, and Knowledge were missing and capability-miss was mis-ordered. |
| 69 | ui/components | `summarize(args)` on the tool chip | **Deleted.** Zero call sites; the page contradicted itself 50 lines earlier. Replaced with `formatField`, which is real and consumed. |
| 70 | act-as-presets + api-tools | `jwt({secret})`; GraphQL naming | **Fixed.** Added the type-vs-runtime honesty for `jwt()` (it type-checks with no args, then throws). GraphQL example de-tRPC'd: the name is `host_` + the schema field alone (no dot path exists in GraphQL) and the description is always `GraphQL <type> <operation>`. |
| 71 | concepts/architecture | "nine packages"; incomplete dep map | **Fixed** → twelve blocks (adds `mcp`, `knowledge`, `engine`), plus the `vendoai` alias and the note that `engine` is deliberately not a dependency of anything. The dependency block now mirrors `scripts/dependency-guard.mjs` exactly. |
| 72 | concepts/generated-ui | Cloud sandbox "TLS not yet live" | **Fixed.** Shipped 2026-07-20 on single-label `<id>-m.vendo.run` over the existing `*.vendo.run` certificate. The doc was telling Cloud users a working feature was broken. |
| 73 | concepts/tools-and-safety | 3 loadout branches | **Fixed** → 4. The connection-scoped seed is the shipped default path, not an edge case; branches 3 and 4 are the degrade path. Added that `vendo_*` tools never count against the cap. |
| 77 | deploy/telemetry | `NODE_ENV=production` disables telemetry | **Fixed.** It gates only the dev-server runtime collector (which requires `development` or `test`, failing closed on unset). The CLI/build collector — what `init`, `sync`, and `doctor` report through — is unaffected. Moved out of the flat opt-out list. |
| 78 | deploy/deploying, troubleshooting | ladder line; "one live round trip"; doctor probes | **Fixed.** The ladder line is a static three-item pointer, not per-install. Doctor makes 6–10 live requests including a real billable streaming model turn. Four `/doctor/*` routes, not two — with the deliberate `/doctor/base-url` production carve-out. |
| 44 (sibling) | deploy/principals-and-orgs | anon cookie "scoped to the wire base" | **Fixed** → `Path=/` on both forms, with the reason (document-response minting; `__Host-` requires it). Base-path scoping was bug #693. |

## Audit-was-wrong cases

- **#78, `vendo sync --org`.** The audit implied the `--org` scoping was documented wrong. `--org` does not exist on `sync` at all — it is a `vendo cloud` org selector, and `reference/cli.mdx` (another lane's file) already describes it correctly. No edit made.
- **#63.** The audit called the `@vendoai/core` specifier for `parseVendoToolEnvelope` the defect. It is the *only* correct specifier — the umbrella root is `export type *`. The real defect was the unstated direct dependency, which is what I fixed.
- **#70, GraphQL.** Correction to my own earlier framing: the binding was *not* already correct — I changed `operation` in the same hunk. The audit's characterization ("copy-pasted from tRPC") was right about the whole entry, name, description, and binding alike.
- **#60.** "Two verdict states" undercounts differently than the audit framed it: `InClientVerdict` (server) and `InClientVenueState` (wire) are two distinct unions. The page documents the wire one, which is the right choice — it was simply missing a member.

## Addendum (second commit)

Coordinator-approved addition, outside the audit rows: `vendo try` is being unlisted from public docs. `ui/components.mdx` was the last page in this lane still pitching it — the `npx vendo try` invocation and the `[Try Vendo](/try)` link are gone, the hosted surface is called the playground throughout (heading, prose, iframe title, image caption and alt), and the closing line points at `vendo init` and the quickstart instead. No inbound links pointed at the renamed `#try-every-surface-live` anchor.

## Scope and gates

Twenty files, all under `docs-site/`. No code changes. Net **+87 lines** (265 added, 178 removed): the four blocker rewrites replace short lies with correct explanations that are necessarily longer, offset by the deleted claim section, deduplicated verdict prose, and the dropped dead metadata field.

`pnpm build`, `pnpm typecheck`, and `pnpm lint` are green.

Correction on the test note in an earlier revision of this description: I saw two `src/dev-creds/model.test.ts` failures locally and called them pre-existing on main after reproducing them at the pre-change commit. The checker showed they do **not** reproduce on a clean frozen-lockfile install — they are a local pnpm-link artifact in my worktree, not a property of main. Retracted.

## Checker round 1

Four blockers and thirteen minors, all fixed in `5ad5f2b48`:

| Item | Fix |
| --- | --- |
| troubleshooting: "four `/doctor/*` routes" | **Three.** The CLI calls `present`, `act-as`, `machines`; it never fetches `/doctor/base-url`. Registered ≠ called. |
| troubleshooting: `/doctor/base-url` "reports whether `VENDO_BASE_URL` is set" | False outside production, where it returns `{ok:true}` unconditionally. Removed from the called list and rewritten so a dev curl can't read a false all-clear. |
| existing-agents/index: import/key mismatch | Registry keys are `<declaring module>#<export>`; importing from `./actions` under a `lib/vendo.ts#` key fails closed. Snippet now declares inline, matching the shipped `ai-sdk-agent` example, with the keying rule stated. |
| changelog collateral | My deletion left `changelog/overview.mdx` as the sole surviving doc of the fabricated `store.claim({key,owner,ttlMs})`, linking to a persistence page that now says the opposite. Rewritten to the real primitives; the dead `summarize(args)` mention in the same file replaced with `formatField`. |
| persistence: capability matrix | `claim`/`atomic` exposure varies by collection class; "reserved collections do not expose them" was too broad. Now says feature-detect. |
| persistence: encryption gate | The gate is the store's `allowUnencryptedSecrets` option — a hand-built `createStore({})` throws even in dev. `NODE_ENV` only feeds the default composition. |
| generated-ui: hostname | `<id-suffix>` is the machine id minus its two-char prefix; the non-default-port rewrite is client-side. |
| mcp: "pass your own OAuth adapter" | Any composed `auth` preset already carries one — `demo-bank` passes no `oauth` key. |
| in-client-venue: verdict table | `versionHash` is required on all three union members. |
| architecture: engine | It is a command-agnostic Agent SDK runner (job on stdin, final message on stdout), not an extraction engine. Count reconciled with the no-dependents note. |
| act-as-presets: empty secret | Not function-form-specific; throws on the first Bearer request. |
| api-tools: descriptions | Real values are `tRPC mutation polls.delete` and `server action app/actions/boards.ts#deleteBoard` (name `host_delete_board`). GraphQL "always" dropped — subscriptions get the not-invokable description. |
| telemetry: contradiction | The untouched capability-miss paragraph called the `NODE_ENV` fail-close "build-and-development-only"; aligned with the corrected runtime-collector scope. |
| embeds frontmatter, mastra import | Frontmatter de-`@vendoai/ui`'d; the missing `VendoToolResult` import added, consistent with the embeds guidance. |
| compound-tools: risk override | Overrides merge *before* validation and the rule is equality, so a risk override **quarantines** rather than tightens. Reconciled with the Risk section. |
