### PR TITLE
self-serve P: the panel shows the turn error instead of swallowing the message

### DIFF
--- a/.changeset/turn-error-rides-the-turn.md
+++ b/.changeset/turn-error-rides-the-turn.md
@@ -1,0 +1,28 @@
+---
+"@vendoai/core": minor
+"@vendoai/agent": minor
+"@vendoai/ui": minor
+---
+
+A failed turn now carries its own error, so the thread never shows a blank
+reply.
+
+When a turn's stream errored, the only trace on the wire was the ai-SDK `error`
+chunk. That chunk belongs to no message: it sets `useChat`'s transient `error`
+and nothing else. The turn itself persisted as an assistant message with **zero
+parts**, so the moment the thread was re-read — a reload, a thread switch,
+`VendoPage` refetching after the mint — the explanation was gone and the user's
+question sat there answered by a blank bubble. On a keyless install that
+blank bubble was the whole first experience: the server logged `Vendo found no
+model key…`, the panel showed nothing durable.
+
+The agent now writes the same gated string (`wireErrorMessage` — Vendo's own
+crafted text or the fixed generic line, never provider internals) into the turn
+as a `data-vendo-turn-error` part beside the error chunk. It persists with the
+turn, and the thread renders it inline where the reply would have been, in the
+failed-beat vocabulary a failed app build already uses. The live banner keeps
+its Retry but drops its detail line while the turn is already saying it, so the
+same sentence is never printed twice.
+
+Additive to the wire (§15 forward-compat): consumers that don't recognize the
+part ignore it.

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -615,7 +615,16 @@ export function createAgent(config: AgentConfig): VendoAgent {
             originalMessages: thread.messages,
             // Raw provider/model error strings never reach the wire (they can
             // carry request internals); the error part is a fixed generic message.
-            onError: (error) => wireErrorMessage(error),
+            onError: (error) => {
+              const message = wireErrorMessage(error);
+              // self-serve P: the ai-SDK error chunk is TRANSIENT — it sets the
+              // client's `error` and belongs to no message, so the failed turn
+              // persisted (and reloaded) as a blank assistant reply. Write the
+              // same gated string into the turn as well, so the thread keeps a
+              // record of why the answer never came.
+              writer.write(toVendoWirePart({ type: "data-vendo-turn-error", message }) as never);
+              return message;
+            },
           }));
           // AGENT-7: exhausting the step cap is VISIBLE. A run that still wants
           // tool calls after its final permitted step ended because of the cap,

--- a/packages/agent/src/stream-error.test.ts
+++ b/packages/agent/src/stream-error.test.ts
@@ -86,6 +86,26 @@ describe("mid-stream turn errors", () => {
     expect(errorPart?.errorText).toBe("An error occurred while generating the response.");
   });
 
+  it("the failed turn CARRIES the error: a data-vendo-turn-error part beside the transient error chunk", async () => {
+    // self-serve P — the ai-SDK error chunk belongs to no message, so a
+    // reloaded thread showed the question answered by a blank assistant turn.
+    // The same gated string rides the turn as a part, which persists.
+    const { parts } = await streamWithThrowingModel(
+      new VendoError("validation", "Vendo found no model key. Run `vendo login` for a free dev key."),
+    );
+    const notice = parts.find((part) => part.type === "data-vendo-turn-error");
+    expect(notice).toBeDefined();
+    expect((notice?.data as { message?: string }).message)
+      .toBe("Vendo: Vendo found no model key. Run `vendo login` for a free dev key. (validation)");
+  });
+
+  it("an unknown error's turn part stays the fixed generic string too (no internals in the persisted turn)", async () => {
+    const { parts } = await streamWithThrowingModel(new Error("ECONNRESET at https://provider.internal/key=sk-123"));
+    const notice = parts.find((part) => part.type === "data-vendo-turn-error");
+    expect((notice?.data as { message?: string }).message).toBe("An error occurred while generating the response.");
+    expect(JSON.stringify(notice)).not.toContain("sk-123");
+  });
+
   it("an unknown error stays the fixed generic string (raw internals never reach the wire) but still logs", async () => {
     const { parts, logged } = await streamWithThrowingModel(new Error("ECONNRESET at https://provider.internal/key=sk-123"));
     const errorPart = parts.find((part) => part.type === "error");

--- a/packages/core/src/stream-parts.ts
+++ b/packages/core/src/stream-parts.ts
@@ -142,6 +142,27 @@ export const vendoStepLimitPartSchema = z.object({
   message: z.string(),
 }).passthrough() satisfies z.ZodType<VendoStepLimitPart>;
 
+/** self-serve P (additive — 01 §16 amendment parked, same footing as the
+ *  step-limit part): streamed when a turn's stream errors, so the failure is
+ *  part of the ASSISTANT MESSAGE rather than only ephemeral client state. The
+ *  ai-SDK `error` chunk sets `useChat`'s transient `error` and is gone on the
+ *  next mount, so a reloaded (or refetched) thread showed the user's question
+ *  answered by a blank reply — the keyless install's whole first experience.
+ *  `message` is the gated wire string (agent wireErrorMessage): Vendo's own
+ *  crafted text or the fixed generic line, never provider internals.
+ *  Consumers that don't recognize it ignore it (§15 forward-compat). */
+export interface VendoTurnErrorPart {
+  type: "data-vendo-turn-error";
+  /** A renderable, provider-safe explanation of why the turn ended. */
+  message: string;
+}
+
+/** self-serve P */
+export const vendoTurnErrorPartSchema = z.object({
+  type: z.literal("data-vendo-turn-error"),
+  message: z.string().min(1),
+}).passthrough() satisfies z.ZodType<VendoTurnErrorPart>;
+
 /** 0.4.4 cert defect B (additive — 01 §16 amendment parked, same footing as
  *  the step-limit part): streamed beside the native tool part when an app
  *  BUILD terminally fails in a chat turn, so the thread shows the classified

--- a/packages/ui/src/chrome/thread/index.tsx
+++ b/packages/ui/src/chrome/thread/index.tsx
@@ -10,7 +10,7 @@ import { MorphToast, type MorphToastProps } from "../morph-toast.js";
 import { Composer, dragHasFiles, useComposer } from "./composer.js";
 import { MessageList } from "./message-list.js";
 import { useMessageWindow, useStickToBottom } from "./scrolling.js";
-import { approvalByCall, grantSetByCall, riskByCall, userText } from "./message-data.js";
+import { approvalByCall, grantSetByCall, riskByCall, userText, VENDO_ERROR_PREFIX } from "./message-data.js";
 
 /** Lane pick 4B — a rich landing suggestion: two-line starter card. */
 export interface VendoSuggestionCard {
@@ -273,8 +273,13 @@ export function VendoThread({
   // code + operator-crafted text, wireErrorMessage in @vendoai/agent) — the
   // ONE error shape end users may see in detail. Raw transport/provider
   // strings never match the prefix and stay hidden (ENG-214 policy).
-  const errorDetail = thread.error?.message?.startsWith("Vendo: ") === true
-    ? thread.error.message.slice("Vendo: ".length)
+  // self-serve P — a live turn error now ALSO lands in the turn itself (the
+  // data-vendo-turn-error part, which survives reload); when that part is
+  // already saying it, the banner keeps only its headline + Retry so the same
+  // sentence isn't printed twice.
+  const turnErrorInThread = activeAssistant?.parts.some(part => part.type === "data-vendo-turn-error") ?? false;
+  const errorDetail = !turnErrorInThread && thread.error?.message?.startsWith(VENDO_ERROR_PREFIX) === true
+    ? thread.error.message.slice(VENDO_ERROR_PREFIX.length)
     : null;
   const errorBanner = thread.error ? (
     <div className="fl-error">

--- a/packages/ui/src/chrome/thread/message-data.ts
+++ b/packages/ui/src/chrome/thread/message-data.ts
@@ -7,6 +7,13 @@ export function partData(part: UIMessage["parts"][number]): unknown {
   return "data" in part ? part.data : part;
 }
 
+/** ENG-214 — the marker the agent's `wireErrorMessage` puts on its OWN safe
+ * error text (VendoError code + operator-crafted message). Only prefixed
+ * strings may be shown in detail to an end user; raw transport/provider
+ * strings never carry it. Read by both error surfaces (the banner and the
+ * in-thread turn-error part). */
+export const VENDO_ERROR_PREFIX = "Vendo: ";
+
 // ENG-216 — a stable placeholder for the in-thread synthesized ApprovalRequest's
 // required `createdAt`. The wire approval part carries no timestamp; this value
 // is never displayed (the card hides the context byline in-thread) and a fixed

--- a/packages/ui/src/chrome/thread/parts.tsx
+++ b/packages/ui/src/chrome/thread/parts.tsx
@@ -1,4 +1,4 @@
-import type { ApprovalRequest, Json, RiskLabel, UIPayload, VendoAutomationPart, VendoBuildFailedPart, VendoGrantSetPart, VendoViewPart } from "@vendoai/core";
+import type { ApprovalRequest, Json, RiskLabel, UIPayload, VendoAutomationPart, VendoBuildFailedPart, VendoGrantSetPart, VendoTurnErrorPart, VendoViewPart } from "@vendoai/core";
 import { isToolUIPart, type UIMessage } from "ai";
 import { useEffect, useRef, useState } from "react";
 import { useVendoContext } from "../../context.js";
@@ -23,6 +23,7 @@ import {
   preview,
   SYNTHESIZED_CREATED_AT,
   toolName,
+  VENDO_ERROR_PREFIX,
 } from "./message-data.js";
 
 /** ENG-218 — a plain user turn (rendered verbatim, not markdown) collapses when
@@ -155,6 +156,31 @@ export function ThreadPart({ part, partKey, role, restored, count = 1, risks, co
           <span className="fl-beat-label">Couldn&apos;t build the app</span>
         </div>
         <div className="fl-approval-more" role="alert">{data.reason}</div>
+      </div>
+    );
+  }
+  if (part.type === "data-vendo-turn-error") {
+    // self-serve P — a turn whose stream errored is content, not progress: the
+    // reply never arrives, so without this the transcript held an empty
+    // assistant turn. Same beat vocabulary as a failed build, carrying the
+    // agent's gated wire string (its "Vendo: " prefix is the wire's marker for
+    // our OWN safe text — the reader gets the sentence, not the plumbing).
+    const data = partData(part) as Partial<VendoTurnErrorPart>;
+    if (typeof data.message !== "string" || data.message.length === 0) return null;
+    const message = data.message.startsWith(VENDO_ERROR_PREFIX)
+      ? data.message.slice(VENDO_ERROR_PREFIX.length)
+      : data.message;
+    return (
+      <div className="fl-buildfail" data-vendo-turn-error="">
+        <div className="fl-beat fl-beat-error">
+          <span className="fl-beat-ic fl-beat-x" aria-hidden="true">
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round">
+              <path d="M18 6 6 18M6 6l12 12" />
+            </svg>
+          </span>
+          <span className="fl-beat-label">The response didn&rsquo;t finish</span>
+        </div>
+        <div className="fl-approval-more" role="alert">{message}</div>
       </div>
     );
   }

--- a/packages/ui/test/chrome/error-surface.test.tsx
+++ b/packages/ui/test/chrome/error-surface.test.tsx
@@ -99,6 +99,40 @@ describe("visible error surface + retry (ENG-214)", () => {
     expect(banner?.textContent).not.toContain("connection reset");
   });
 
+  it("renders a failed turn's error INLINE where the reply would be, and survives a reload", async () => {
+    // self-serve P — the transient error chunk is gone on the next mount, so a
+    // reloaded thread used to show the question answered by a blank assistant
+    // turn. The agent now writes the same gated string into the turn, and the
+    // transcript renders it in the failed-beat vocabulary.
+    wire.state.threads.set("thr_failed", {
+      id: "thr_failed",
+      subject: "user_1",
+      messages: [
+        { id: "msg_ask", role: "user", parts: [{ type: "text", text: "Show me a dashboard" }] },
+        {
+          id: "msg_failed",
+          role: "assistant",
+          parts: [{
+            type: "data-vendo-turn-error",
+            data: { message: "Vendo: Vendo found no model key. Run `vendo login` for a free dev key. (validation)" },
+          }],
+        },
+      ],
+      createdAt: "2026-07-11T12:00:00.000Z",
+      updatedAt: "2026-07-11T12:00:00.000Z",
+    } as never);
+    render(<VendoProvider client={client}><VendoThread threadId="thr_failed" /></VendoProvider>);
+
+    // The user's message stays, and the failure reads where the answer would be
+    // — with no live thread.error, so nothing but the turn itself is saying it.
+    expect(await screen.findByText("Show me a dashboard")).toBeTruthy();
+    const notice = await screen.findByText(/Vendo found no model key/);
+    expect(notice.closest("[data-vendo-turn-error]")).toBeTruthy();
+    // The wire's "Vendo: " marker is plumbing, never shown to the reader.
+    expect(notice.textContent).not.toContain("Vendo: ");
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
   it("retries a mid-stream failure without duplicating messages", async () => {
     wire.state.streamFailures = 1;
     render(<VendoProvider client={client}><VendoThread threadId="thr_1" /></VendoProvider>);


### PR DESCRIPTION
## What a keyless install saw

Open `<VendoOverlay />` with no model key, ask anything: `POST /api/vendo/threads`
returns 200, the server logs `[vendo] turn stream error: … Vendo found no model
key…`, and the turn is stored as the question answered by a **blank assistant
bubble**. Reload — or switch threads, or let `VendoPage` refetch after the mint —
and there is no explanation anywhere in the thread. That blank bubble is the
first thing every keyless install ends up with.

## Root cause: the error belonged to no message

The error text *does* leave the server. `wireErrorMessage` (@vendoai/agent) gates
it — Vendo's own crafted sentence for a `VendoError`, the fixed generic line for
anything else — and it reaches the client.

But it travels only as the ai-SDK **`error` chunk**, which is transient by
design: it sets `useChat`'s `error` field and is attached to no message. The turn
itself persisted with `parts: []` (read straight off the live wire):

```json
{"id":"1sgY…","role":"assistant","parts":[]}
```

Live, the panel's `.fl-error` banner reads `chat.error` and renders — that half
worked, and the screenshot below shows it. The moment that ephemeral state is
gone (remount, reload, thread switch, any surface that loads history from the
store) the failure is unrecoverable from the thread, and the answer slot is
blank with nothing saying why.

## The fix: the failed turn carries its own error

- **@vendoai/core** — new `data-vendo-turn-error` part (`{ message }`), additive,
  same footing as `data-vendo-step-limit` / `data-vendo-build-failed`. Unknown
  consumers ignore it (§15 forward-compat).
- **@vendoai/agent** — `toUIMessageStream`'s `onError` writes that part with the
  **same gated string** it already returns for the error chunk. No new text, no
  stack traces, no provider internals on the wire; the real error still lands in
  the server log only.
- **@vendoai/ui** — the thread renders it inline where the reply would have been,
  in the exact failed-beat vocabulary a failed app build already uses
  (`.fl-buildfail` › `.fl-beat.fl-beat-error` + `.fl-approval-more[role=alert]`).
  No new design. The `"Vendo: "` wire marker is stripped before display, exactly
  as the banner already does.
- The live banner keeps its headline and **Retry**, but drops its detail line
  while the turn is already saying it — one sentence, one place.

## Proof — real browser, fresh app, no model key

Fresh `create-next-app` in `/tmp`, `npm install` of tarballs packed from this
branch, `vendo init` from the built CLI, no `.env.local` and no
`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_GENERATIVE_AI_API_KEY` /
`VENDO_API_KEY` in the environment, `next dev` on :3311, headless Chromium.

**After — the failure reads where the answer would be, and the banner keeps only
its headline + Retry:**

![keyless turn error rendered inline in the panel](https://raw.githubusercontent.com/runvendo/vendo/55f2787ef83478d7d879e055c1c6d6141fd45aa8/docs/verification/self-serve-p-after.png)

**Before (same app, same ask, this branch reverted) — the banner carried the
sentence below the transcript and the answer slot was an empty assistant turn:**

![keyless turn error before the change](https://raw.githubusercontent.com/runvendo/vendo/55f2787ef83478d7d879e055c1c6d6141fd45aa8/docs/verification/self-serve-p-before.png)

(Screenshots live on the throwaway `self-serve/panel-error-proof` branch, pinned
by SHA — `docs/verification/**/*.png` is gitignored and media never lands on
main.)

And the wire, read live off the running app after the failed turn — the
explanation is now part of the stored turn:

```json
{"id":"bFoRyDssQ4ODYWyp","role":"assistant","parts":[
  {"type":"data-vendo-turn-error","data":{"message":"Vendo: Vendo found no model key. Set ANTHROPIC_API_KEY / … (validation)"}}]}
```

## Tests

- `packages/agent/src/stream-error.test.ts` — a stream error puts a
  `data-vendo-turn-error` part on the wire carrying the gated message; an unknown
  error's part is the fixed generic string with no internals.
- `packages/ui/test/chrome/error-surface.test.tsx` — a thread loaded from the
  store with a failed turn renders the error inline where the reply would be,
  with the user's message still visible and the wire prefix not shown.

Gate: `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist turn-stream errors as a part so the panel shows the failure inline instead of a blank assistant reply. Errors now survive reloads, and the banner avoids duplicating details.

- **Bug Fixes**
  - `@vendoai/core`: Added `data-vendo-turn-error` part (additive, forward-compatible).
  - `@vendoai/agent`: `onError` writes the part with the gated `wireErrorMessage` (no provider internals).
  - `@vendoai/ui`: Renders the error inline using the existing failed-beat UI, strips the `"Vendo: "` prefix, and shows only the banner headline + Retry when the turn already carries the error.
  - Tests cover persisted error parts, safe generic messages for unknown errors, and rendering after reload.

<sup>Written for commit e20a8bb32510234d35a48248d782e510bd7ee74a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

