### PR TITLE
remix graduates: experimental label dropped

### DIFF
--- a/docs-site/connect/host-components.mdx
+++ b/docs-site/connect/host-components.mdx
@@ -12,11 +12,6 @@ component drifts and rebases as your host code changes; the exact
 registration shapes and capture rules live in the reference section at the
 end.
 
-<Note>Remix — forking a captured component — is **experimental**. Baseline
-formats may evolve between versions. A `<Remixable>` wrapper `vendo sync`
-cannot capture fails the run loudly (exit 2) with the file, line, and
-fix.</Note>
-
 ## Register your components
 
 The shared registry is the current form: one object, keyed by component

--- a/packages/vendo/src/cli/remix-graduation.docs.test.ts
+++ b/packages/vendo/src/cli/remix-graduation.docs.test.ts
@@ -1,0 +1,47 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Graduation gate (2026-08-03): remix shipped — the frozen eval scored the
+ * redesigned journey and the label came off. No shipping doc may call remix
+ * experimental again without deliberately deleting this test. The docs live
+ * in this repo, so this is a plain test against the doc sources — it runs in
+ * the normal `pnpm test` suite (same pattern as doctor-codes.docs.test.ts).
+ */
+
+const REPO_ROOT = new URL("../../../../", import.meta.url);
+
+/** The remix-dedicated pages: nothing on them is experimental anymore. */
+const REMIX_PAGES = [
+  "docs-site/connect/host-components.mdx",
+  "docs/host-components.md",
+];
+
+/** Pages that mention remix among other features: the word "experimental"
+ *  may appear (machines, served apps), but never on a line about remix. */
+const MIXED_PAGES = [
+  "docs-site/reference/cli.mdx",
+  "docs-site/reference/dot-vendo.mdx",
+  "docs/quickstart.md",
+  "README.md",
+];
+
+describe("remix is a shipped capability, not an experiment", () => {
+  it("keeps the remix-dedicated pages free of 'experimental'", async () => {
+    for (const page of REMIX_PAGES) {
+      const text = await readFile(new URL(page, REPO_ROOT), "utf8");
+      expect(text, `${page} may not call remix experimental`).not.toMatch(/experimental/i);
+    }
+  });
+
+  it("never pairs remix with 'experimental' on mixed pages", async () => {
+    for (const page of MIXED_PAGES) {
+      const lines = (await readFile(new URL(page, REPO_ROOT), "utf8")).split("\n");
+      for (const [index, line] of lines.entries()) {
+        if (/remix/i.test(line)) {
+          expect(line, `${page}:${index + 1} may not call remix experimental`).not.toMatch(/experimental/i);
+        }
+      }
+    }
+  });
+});

--- a/packages/vendo/src/cli/sync.test.ts
+++ b/packages/vendo/src/cli/sync.test.ts
@@ -222,6 +222,19 @@ describe("vendo sync", () => {
     expect(errors.join("\n")).toContain("extract it into a component and wrap that");
   });
 
+  it("keeps wrapper errors at exit two under --strict as well", async () => {
+    const failed = {
+      ...report(),
+      remixableErrors: [
+        "src/app/page.tsx:4 — <Remixable> must wrap exactly one component element; extract it into a component and wrap that",
+      ],
+    };
+    // Exit 2 in ANY mode: --strict adds nothing here because the failure is
+    // already hard — a wrapper the host marked remixable that cannot capture
+    // means the remix silently would not exist.
+    expect(await runSync({ targetDir: ".", strict: true, output: captureOutput().output, sync: async () => failed })).toBe(2);
+  });
+
   it("prints one line per pruned stale baseline", async () => {
     const messages = captureOutput();
     const pruned = {


### PR DESCRIPTION
## What

Remix graduates out of experimental (Yousef, 2026-08-03): the final shape shipped across 11 PRs, the journey is browser-proven, and the frozen eval scored 9/12 vs the 2/12 baseline with every remix-machinery invariant holding.

- **Experimental label dropped**: the `<Note>` in `docs-site/connect/host-components.mdx` calling remix experimental ("baseline formats may evolve") is removed. That was the only shipping surface still carrying the label — a full sweep (code, docs-site, docs/, README, CLI strings; history under `docs/archive`, `docs/superpowers`, `docs/verification`, `docs/eval`, `corpus/reports` excluded as written) found no other remix + experimental pairing. Remaining "experimental" mentions in the repo are machines/served-apps/MCP, which keep their own labels.
- **Graduation gate test** (`packages/vendo/src/cli/remix-graduation.docs.test.ts`, the repo's docs-check pattern): the remix-dedicated pages must never contain "experimental", and mixed pages (cli.mdx, dot-vendo.mdx, quickstart, README) must never pair it with remix on a line.
- **Sync behaviour unchanged from main**: an uncapturable `<Remixable>` wrapper stays a hard `error:` + exit 2 in ANY mode — a wrapper the host marked remixable that sync cannot capture means the remix silently would not exist, so the build must fail (W1a, #729). A new behaviour-neutral test pins that `--strict` does not change this. `cli.mdx` already documents this truth exactly; it is untouched.

## Proof

- `pnpm build` green; full `pnpm test` green (one demo-bank worker crash under full-parallel load, clean on isolated rerun); `pnpm typecheck` and `pnpm lint` green.
- Existing sync tests already prove exit 2 with wrapper errors in normal mode and exit 3 precedence under `--strict --report`; the new test adds the explicit `--strict` → exit 2 case.
- Grep gate: `remix-graduation.docs.test.ts` runs in `pnpm test` and fails if any shipping remix doc calls it experimental again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Graduates Remix from experimental and locks the status with tests. Removes the “experimental” note from docs, adds a docs gate to block “experimental” on Remix pages/lines, and pins that an uncapturable `<Remixable>` exits 2 in any mode, including `--strict`.

<sup>Written for commit 873eda9e0b507abe9dbf812da8098ea20aa1a5ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

