### PR TITLE
self-serve P fix: the turn-error notice only when the turn actually failed

### DIFF
--- a/.changeset/turn-error-only-when-the-turn-failed.md
+++ b/.changeset/turn-error-only-when-the-turn-failed.md
@@ -1,0 +1,32 @@
+---
+"@vendoai/agent": patch
+---
+
+Turn-error notices now appear only when the turn actually failed, and never
+outlive the failure.
+
+Three fixes to the `data-vendo-turn-error` part shipped alongside it:
+
+**Recoverable tool errors are not turn failures.** The notice was written from
+`toUIMessageStream`'s `onError`, which is the ai-SDK's general error-TEXT
+formatter — it also runs for the `tool-input-error` and `tool-output-error`
+chunks a hallucinated tool name or a throwing tool produces. The SDK feeds those
+back and the model routinely answers on the next step, so a turn that finished
+fine persisted permanent failed-beat alerts above its own answer. The notice is
+now tapped off the merged stream's fatal `error` chunk instead, and is
+once-guarded — the SDK runs the gate a second time over its own error text while
+assembling the message to persist.
+
+**A retry no longer inherits the failed turn's notice.** When a thread's last
+message is an assistant turn the SDK CONTINUES it, reusing its id and its parts,
+so the flagship keyless → `vendo login` → Retry flow appended the real answer
+underneath the stale "no model key" line and persisted both — wrong on every
+reload, forever. A new turn now clears the trailing turn's notice; anything that
+turn really produced (partial text, tool beats) stays, and a turn left with
+nothing else is dropped so the reply starts clean.
+
+**Failures thrown before the model stream exists are recorded too.** Tool
+building, `descriptors()`, and history conversion fail before any model chunk
+exists, so those turns still persisted blank — the exact defect the part was
+added to end. They now carry the same gated string, making good the previous
+changeset's claim that the thread never shows a blank reply.

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -390,6 +390,27 @@ function providerHistory(messages: UIMessage[]): UIMessage[] {
   }));
 }
 
+/** self-serve P — a new turn never inherits the LAST turn's failure notice.
+ *  When the thread's final message is an assistant turn, the ai-SDK CONTINUES
+ *  it (handleUIMessageStreamFinish reuses its id and seeds the new turn's state
+ *  from its parts), so a retry after a failed turn would append the real answer
+ *  UNDER the stale "no model key" line and persist both — the flagship keyless
+ *  → `vendo login` → Retry flow, permanently wrong on every reload. Anything
+ *  the failed turn actually produced (partial text, tool beats) stays.
+ *
+ *  The emptied message is KEPT rather than dropped: persistence merges a turn
+ *  into the stored row by message id (mergeMessages in threads.ts) and can only
+ *  add or replace, never remove. A message dropped here would simply stay in
+ *  the store — the retry would look clean live and still reload with the stale
+ *  notice above the answer. Left in place, the continuation reuses its id and
+ *  the merge overwrites the stored copy with the real reply. */
+function clearFailedTurnRecord(messages: UIMessage[]): void {
+  const last = messages.at(-1);
+  if (last?.role !== "assistant") return;
+  const kept = last.parts.filter((part) => part.type !== "data-vendo-turn-error");
+  if (kept.length !== last.parts.length) last.parts = kept;
+}
+
 /** 03-agent §1 */
 
 /** The one gate raw errors pass on their way to the wire. Vendo's OWN errors
@@ -484,6 +505,7 @@ export function createAgent(config: AgentConfig): VendoAgent {
         }
       }
       upsertMessage(thread.messages, input.message);
+      clearFailedTurnRecord(thread.messages);
       const system = await assembleSystemPrompt(
         config.guard,
         input.ctx,
@@ -492,9 +514,25 @@ export function createAgent(config: AgentConfig): VendoAgent {
         config.toolSearch !== undefined,
       );
 
+      // self-serve P: the writer, reachable from the stream's own onError below
+      // so a failure thrown BEFORE the model stream exists (tool building,
+      // descriptors, history conversion) is recorded in the turn too, instead
+      // of persisting the blank assistant reply this whole lane is about.
+      let turnWriter: UIMessageStreamWriter<UIMessage> | undefined;
+      // ONE notice per turn, from whichever path sees the failure first — a
+      // turn can only fail once. Needed because the stream's onError runs
+      // TWICE per error chunk: the SDK's finish pass re-feeds the gate its own
+      // `new Error(errorText)` while assembling the message to persist.
+      let turnErrorRecorded = false;
+      const recordTurnError = (message: string, write: (part: unknown) => void): void => {
+        if (turnErrorRecorded) return;
+        turnErrorRecorded = true;
+        write(toVendoWirePart({ type: "data-vendo-turn-error", message }));
+      };
       const stream = createUIMessageStream<UIMessage>({
         originalMessages: thread.messages,
         execute: async ({ writer }) => {
+          turnWriter = writer;
           // AGENT-3: a client that disconnected before the turn started gets no
           // provider call at all — the stream closes empty but well-formed.
           if (input.signal?.aborted) return;
@@ -611,21 +649,31 @@ export function createAgent(config: AgentConfig): VendoAgent {
             // never starts another step once the signal fires.
             abortSignal: input.signal,
           });
+          // self-serve P: the ai-SDK `error` chunk is TRANSIENT — it sets the
+          // client's `error` and belongs to no message, so a failed turn
+          // persisted (and reloaded) as a blank assistant reply. The gated
+          // string is written into the turn as well, so the thread keeps a
+          // record of why the answer never came.
+          //
+          // Tapped off the CHUNKS, never off `onError`: onError is the SDK's
+          // general error-TEXT formatter and also runs for the recoverable
+          // `tool-input-error` / `tool-output-error` chunks (a hallucinated
+          // tool name, args that miss the schema — the SDK feeds those back and
+          // the model retries and finishes). Hooking it stamped permanent
+          // failure notices onto turns that went on to answer fine.
           writer.merge(result.toUIMessageStream({
             originalMessages: thread.messages,
             // Raw provider/model error strings never reach the wire (they can
             // carry request internals); the error part is a fixed generic message.
-            onError: (error) => {
-              const message = wireErrorMessage(error);
-              // self-serve P: the ai-SDK error chunk is TRANSIENT — it sets the
-              // client's `error` and belongs to no message, so the failed turn
-              // persisted (and reloaded) as a blank assistant reply. Write the
-              // same gated string into the turn as well, so the thread keeps a
-              // record of why the answer never came.
-              writer.write(toVendoWirePart({ type: "data-vendo-turn-error", message }) as never);
-              return message;
+            onError: (error) => wireErrorMessage(error),
+          }).pipeThrough(new TransformStream({
+            transform(chunk, controller) {
+              if (chunk.type === "error") {
+                recordTurnError(chunk.errorText, (part) => controller.enqueue(part as never));
+              }
+              controller.enqueue(chunk);
             },
-          }));
+          })));
           // AGENT-7: exhausting the step cap is VISIBLE. A run that still wants
           // tool calls after its final permitted step ended because of the cap,
           // not because the model finished — stream a renderable notice.
@@ -646,7 +694,17 @@ export function createAgent(config: AgentConfig): VendoAgent {
         onFinish: async ({ messages }) => {
           await persistFinishedTurn(threads, thread, messages, input.ctx);
         },
-        onError: (error) => wireErrorMessage(error),
+        onError: (error) => {
+          const message = wireErrorMessage(error);
+          // The record for failures the tap above can never see: `execute`
+          // itself rejecting (tool building, descriptors, history conversion)
+          // — those never become a model-stream chunk. Tapped failures reach
+          // here too, one beat later; the once-guard keeps the first write.
+          // The SDK's writer swallows a write past close, so this is safe at
+          // any point in the turn's life.
+          recordTurnError(message, (part) => turnWriter?.write(part as never));
+          return message;
+        },
       });
       const response = createUIMessageStreamResponse({ stream });
       // ENG-211: a caller may begin without an id, in which case resolve()

--- a/packages/agent/src/stream-error.test.ts
+++ b/packages/agent/src/stream-error.test.ts
@@ -1,8 +1,17 @@
 import { VendoError } from "@vendoai/core";
-import { MockLanguageModelV3 } from "ai/test";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAgent } from "./index.js";
-import { boundRegistry, ctx, readSse, testGuard } from "./test-helpers.js";
+import {
+  boundRegistry,
+  ctx,
+  readSse,
+  scriptedModel,
+  testGuard,
+  textTurn,
+  toolCallTurn,
+  userMessage,
+} from "./test-helpers.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -93,9 +102,9 @@ describe("mid-stream turn errors", () => {
     const { parts } = await streamWithThrowingModel(
       new VendoError("validation", "Vendo found no model key. Run `vendo login` for a free dev key."),
     );
-    const notice = parts.find((part) => part.type === "data-vendo-turn-error");
-    expect(notice).toBeDefined();
-    expect((notice?.data as { message?: string }).message)
+    const notices = parts.filter((part) => part.type === "data-vendo-turn-error");
+    expect(notices).toHaveLength(1);
+    expect((notices[0]?.data as { message?: string }).message)
       .toBe("Vendo: Vendo found no model key. Run `vendo login` for a free dev key. (validation)");
   });
 
@@ -112,6 +121,140 @@ describe("mid-stream turn errors", () => {
     expect(errorPart).toBeDefined();
     expect(errorPart?.errorText).toBe("An error occurred while generating the response.");
     expect(String(errorPart?.errorText)).not.toContain("sk-123");
+    expect(logged.some((args) => String(args[0]).includes("[vendo] turn stream error"))).toBe(true);
+  });
+});
+
+describe("recoverable tool errors are NOT turn failures (checker round, blocker 1)", () => {
+  const descriptor = {
+    name: "echo",
+    description: "Echo the input back",
+    inputSchema: { type: "object", properties: { value: { type: "string" } } },
+    risk: "read" as const,
+  };
+
+  it("a hallucinated tool name the model recovers from leaves no turn-error part", async () => {
+    // The ai-SDK's `onError` is a general error-TEXT formatter: it also runs
+    // for the recoverable `tool-input-error` chunk a bad tool name produces.
+    // The SDK feeds that back and the model answers on the next step, so the
+    // finished turn must carry the answer and nothing else — a notice here
+    // would render a permanent failed-beat alert above a successful reply.
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const guard = testGuard({});
+    const tools = boundRegistry({ echo: { descriptor, execute: async (args) => args } }, guard);
+    const model = scriptedModel([
+      toolCallTurn("no_such_tool", { value: "x" }, "call_bogus"),
+      textTurn("Here is your dashboard.", "text_ok"),
+    ]);
+    const agent = createAgent({ model, tools, guard });
+
+    const response = await agent.stream({
+      threadId: "thr_recoverable",
+      message: userMessage("u_recoverable", "Show me a dashboard"),
+      ctx: ctx(),
+    });
+    const { parts } = await readSse(response);
+
+    expect(parts.some((part) => part.type === "tool-input-error")).toBe(true);
+    expect(parts.filter((part) => part.type === "data-vendo-turn-error")).toHaveLength(0);
+    const stored = await agent.threads.get("thr_recoverable", ctx());
+    const assistant = stored?.messages.at(-1);
+    expect(assistant?.role).toBe("assistant");
+    expect(assistant?.parts.some((part) => part.type === "data-vendo-turn-error")).toBe(false);
+  });
+
+  it("a tool that throws mid-turn leaves no turn-error part either", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const guard = testGuard({});
+    const tools = boundRegistry({
+      echo: { descriptor, execute: async () => { throw new Error("upstream 500"); } },
+    }, guard);
+    const model = scriptedModel([
+      toolCallTurn("echo", { value: "x" }, "call_throws"),
+      textTurn("Recovered without it.", "text_recovered"),
+    ]);
+    const agent = createAgent({ model, tools, guard });
+
+    const response = await agent.stream({
+      threadId: "thr_tool_throw",
+      message: userMessage("u_tool_throw", "Echo something"),
+      ctx: ctx(),
+    });
+    const { parts } = await readSse(response);
+
+    expect(parts.filter((part) => part.type === "data-vendo-turn-error")).toHaveLength(0);
+  });
+});
+
+describe("a retry never inherits the failed turn's notice (checker round, blocker 2)", () => {
+  it("the flagship keyless → key → Retry flow persists a clean assistant message", async () => {
+    // The stored thread still ends with the errored assistant turn when the
+    // retry arrives, and the ai-SDK CONTINUES a trailing assistant message —
+    // so the successful answer used to land under the stale "no model key"
+    // line and persist that way forever.
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const guard = testGuard({});
+    const tools = boundRegistry({}, guard);
+    let keyed = false;
+    const model = new MockLanguageModelV3({
+      doStream: async () => {
+        if (!keyed) throw new VendoError("validation", "Vendo found no model key.");
+        return { stream: simulateReadableStream({ chunks: textTurn("Here is your dashboard.", "text_after_key") }) };
+      },
+    });
+    const agent = createAgent({ model, tools, guard });
+    const threadId = "thr_retry_clean";
+    const ask = userMessage("u_retry", "Show me a dashboard");
+
+    await readSse(await agent.stream({ threadId, message: ask, ctx: ctx() }));
+    const failed = (await agent.threads.get(threadId, ctx()))?.messages.at(-1);
+    expect(failed?.parts.some((part) => part.type === "data-vendo-turn-error")).toBe(true);
+
+    // `vendo login` lands the key; the banner's Retry re-issues the same user turn.
+    keyed = true;
+    await readSse(await agent.stream({ threadId, message: ask, ctx: ctx() }));
+
+    // What a reload reads back. Asserted over the WHOLE thread, not just the
+    // last message: persistence merges by message id and can only add or
+    // replace, so a failed turn left behind in the store would sit ABOVE the
+    // answer and never show up in a tail-only check (it didn't — the browser
+    // caught it). One user turn, one assistant turn, no notice anywhere.
+    const stored = await agent.threads.get(threadId, ctx());
+    expect(stored?.messages.flatMap((message) => message.parts)
+      .filter((part) => part.type === "data-vendo-turn-error")).toHaveLength(0);
+    expect(stored?.messages.filter((message) => message.role === "user")).toHaveLength(1);
+    expect(stored?.messages.filter((message) => message.role === "assistant")).toHaveLength(1);
+    const assistant = stored?.messages.at(-1);
+    expect(assistant?.parts.some((part) => part.type === "text" && part.text === "Here is your dashboard.")).toBe(true);
+  });
+});
+
+describe("failures thrown before the model stream exists (checker round, finding 3)", () => {
+  it("a turn that dies building its toolset still records why, instead of persisting blank", async () => {
+    const logged: unknown[][] = [];
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => { logged.push(args); });
+    const guard = testGuard({});
+    const tools = boundRegistry({}, guard);
+    // descriptors() is read while the toolset is assembled — well before
+    // streamText exists, so this never reaches the model stream's error chunk.
+    tools.descriptors = async () => { throw new VendoError("validation", "the tool catalog is unreadable"); };
+    const agent = createAgent({ model: new MockLanguageModelV3({}), tools, guard });
+
+    const response = await agent.stream({
+      threadId: "thr_prestream",
+      message: userMessage("u_prestream", "hi"),
+      ctx: ctx(),
+    });
+    const { parts } = await readSse(response);
+
+    const notice = parts.find((part) => part.type === "data-vendo-turn-error");
+    expect((notice?.data as { message?: string }).message)
+      .toBe("Vendo: the tool catalog is unreadable (validation)");
+    expect(parts.find((part) => part.type === "error")?.errorText)
+      .toBe("Vendo: the tool catalog is unreadable (validation)");
+    // Exactly one notice: the SDK runs the gate again over its own error text
+    // while assembling the message to persist, so the record is once-guarded.
+    expect(parts.filter((part) => part.type === "data-vendo-turn-error")).toHaveLength(1);
     expect(logged.some((args) => String(args[0]).includes("[vendo] turn stream error"))).toBe(true);
   });
 });


### PR DESCRIPTION
Fix-forward on #758. An independent checker found two high-severity defects in
the `data-vendo-turn-error` part; both reproduce, both are fixed here, plus the
low-severity gap the same review flagged. Gates the 0.7.0 release.

## 1. BLOCKER — the notice fired for recoverable tool errors

Verified at source. `toUIMessageStream`'s `onError` is not a fatal-error hook —
it is the SDK's general error-**text** formatter, called from three places
(`ai/dist/index.mjs`):

| call site | chunk | fatal? |
|---|---|---|
| `case "tool-call"` + `part.invalid` | `tool-input-error` | no — fed back, model retries |
| `case "tool-error"` | `tool-output-error` | no — fed back, model retries |
| `case "error"` | `error` | **yes** |

So a model that hallucinated a tool name, or a tool that threw, stamped a
permanent failed-beat alert onto a turn that went on to answer perfectly — and
persisted it. Hallucinated names are ordinary in production under ENG-252
loadout gating.

The notice is now tapped off the merged stream's **fatal `error` chunk** and
never off `onError`. It is also **once-guarded**: while assembling the message
to persist, the SDK runs the gate a *second* time over its own
`new Error(errorText)`, which would otherwise write a duplicate notice
(previously masked only by controller-close timing).

## 2. HIGH — a successful retry inherited the failed turn's notice

`handleUIMessageStreamFinish` CONTINUES a trailing assistant message: it reuses
its id and seeds the new turn's state from a clone of its parts. After a failed
turn the stored thread still ends with that assistant message, so the retry's
real answer landed *underneath* the stale "no model key" line and persisted that
way — the flagship keyless → `vendo login` → Retry flow, wrong on every reload,
forever.

A new turn now clears the trailing turn's notices. **The emptied message is kept
rather than dropped**, and that detail is the whole fix: persistence merges a
turn into the stored row by message id (`mergeMessages`, threads.ts) and can only
add or replace — never remove. My first attempt popped the message; it looked
clean live and still reloaded dirty. The browser caught it, then the tightened
unit test did. Left in place, the continuation reuses the id and the merge
overwrites the stored copy with the real reply. Anything the failed turn really
produced (partial text, tool beats) is preserved.

## 3. LOW — failures before the model stream existed still persisted blank

Tool building, `descriptors()`, and history conversion fail before any model
chunk exists, so those turns never reached the tap and still persisted the blank
assistant reply this lane exists to end. The stream's own `onError` now records
the same gated string through the turn writer, making good #758's changeset
claim. Exactly one of the two paths records any given failure (once-guard).

No wire-shape change: the part is unchanged, so this is a **patch**.

## Proof — real browser, fresh Next app, no model key

Same harness as #758 (fresh `create-next-app`, tarballs packed from this branch,
`vendo init`, no key in `.env.local` or the environment, `next dev` on :3311,
headless Chromium). The flagship flow, including the **reload** leg that the
first fix attempt failed:

| step | `[data-vendo-turn-error]` | banner |
|---|---|---|
| 1. keyless ask | 1 | 1 |
| 2. key lands → **Retry** | 0 | 0 |
| 3. **reload** thread from store | **0** | 0 |

![step 1 — keyless, the error reads where the reply would be](https://raw.githubusercontent.com/runvendo/vendo/ea7c72002de7c97ab1047757b2cedd122b7018e1/docs/verification/self-serve-p2-1-keyless-error.png)

![step 3 — after retry and a full reload, the thread is clean](https://raw.githubusercontent.com/runvendo/vendo/ea7c72002de7c97ab1047757b2cedd122b7018e1/docs/verification/self-serve-p2-3-reloaded-clean.png)

And blocker 1 live — the model calls a tool that does not exist, the SDK feeds
the error back, the model answers. Zero notices live, zero after reload, and the
persisted parts carry no notice at all:

```
STORED parts: [["user",["text"]],["assistant",["step-start","dynamic-tool","step-start","text"]]]
```

![recoverable tool error — the turn finishes with no failure notice](https://raw.githubusercontent.com/runvendo/vendo/ea7c72002de7c97ab1047757b2cedd122b7018e1/docs/verification/self-serve-p2-4-recoverable-tool.png)

(Screenshots ride the throwaway `self-serve/panel-error-proof` branch, pinned by
SHA — `docs/verification/**/*.png` is gitignored and media never lands on main.)

## Tests

`packages/agent/src/stream-error.test.ts`, 4 new cases:

- a hallucinated tool name the model recovers from → **zero** turn-error parts,
  on the wire and in the store
- a tool that throws mid-turn → zero turn-error parts
- keyless → key → Retry → the stored thread has one user turn, one assistant
  turn, and **no notice anywhere** (asserted across the whole thread, not the
  tail — a tail-only check passed against the broken version)
- a turn that dies building its toolset → exactly one notice with the gated text

The existing fatal-path case now asserts exactly one notice. Each new test was
confirmed to fail against the defective code before being kept.

Gate: `pnpm build` 23/23 · `typecheck` 41/41 · `lint` green · agent 145 passed,
ui 696 passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turn-error notices now show only when a turn actually fails and never persist across retries. This fixes stale error banners and cleans up stored threads; ships as a patch to `@vendoai/agent`.

- **Bug Fixes**
  - Notice is emitted only from fatal `error` chunks, not `onError` for recoverable tool issues; protected with a once-guard to prevent duplicates.
  - On a new turn, clear the previous assistant message’s `data-vendo-turn-error` part while keeping other parts, so retries persist a clean answer.
  - Failures before the model stream exists are recorded in the turn, preventing blank assistant replies.

<sup>Written for commit 3e6882c3321c505e513f7f1e444ca9d91497130e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

