### PR TITLE
self-serve D3 follow-up: five checker round-2 residuals

### DIFF
--- a/docs-site/concepts/generated-ui.mdx
+++ b/docs-site/concepts/generated-ui.mdx
@@ -126,8 +126,9 @@ Layer 3 works on both venues: BYO e2b (`E2B_API_KEY` or an explicit
 single-label hostname on the existing `*.vendo.run` certificate:
 `https://<id-suffix>-m.vendo.run`, where `<id-suffix>` is the machine id
 minus its two-character prefix. The console mints that canonical-port URL;
-for any other port the SDK rewrites the host client-side, inserting the port
-before the suffix as `<id-suffix>-<port>-m.vendo.run`.
+for any other port the SDK rewrites the host string SDK-side, in your Node
+process, inserting the port before the suffix as
+`<id-suffix>-<port>-m.vendo.run`.
 
 ### Graduation rollback
 

--- a/docs-site/connect/api-tools.mdx
+++ b/docs-site/connect/api-tools.mdx
@@ -66,7 +66,7 @@ each mount is detected independently.
     "properties": { "id": { "type": "string" } },
     "required": ["id"]
   },
-  "risk": "write",
+  "risk": "destructive",
   "binding": {
     "kind": "trpc",
     "procedure": "polls.delete",

--- a/docs-site/deploy/persistence.mdx
+++ b/docs-site/deploy/persistence.mdx
@@ -77,9 +77,10 @@ Encryption covers exactly one column, `vendo_secrets.ciphertext`. Everything
 else stays host-queryable plaintext by design.
 
 What actually gates it is the store's own `allowUnencryptedSecrets` option:
-with no encryption key and no explicit opt-in to plaintext, every secret read
-*and* write throws. `createStore({})` by hand therefore refuses secrets even
-in development.
+with no encryption key and no explicit opt-in to plaintext, reading or writing
+a secret value throws. `createStore({})` by hand therefore refuses secrets
+even in development. Deleting and listing secrets keep working without a key —
+neither touches ciphertext.
 
 The default composition — no `store` passed to `createVendo` — supplies that
 opt-in for you from the environment. Set a 32-byte base64 key at
@@ -89,8 +90,8 @@ it, the composition passes `allowUnencryptedSecrets` when `NODE_ENV` is not
 
 - In dev, secrets are written **unencrypted** under the gitignored data dir,
   and the first plaintext write logs a warning.
-- In production, secret reads and writes **throw**. Set the key before you
-  deploy anything that stores a secret.
+- In production, reading or writing a secret value **throws**. Set the key
+  before you deploy anything that stores a secret.
 
 An explicitly configured store always wins. If you pass
 `store: createStore({ encryption: { key } })` to `createVendo`, the

--- a/docs-site/deploy/troubleshooting.mdx
+++ b/docs-site/deploy/troubleshooting.mdx
@@ -83,10 +83,12 @@ Every non-2xx response uses `{ "error": { "code", "message" } }`.
 - `POST /doctor/act-as` verifies that `createVendo({ actAs })` mints auth
   material the host principal resolver accepts. Doctor warns (does not
   fail) when `actAs` is not configured.
-- `GET /doctor/machines` reports the sandbox and scheduler wiring.
+- `GET /doctor/machines` reports the scheduler wiring and machine state: which
+  apps carry a machine, whether a `/tick` caller secret is configured, and
+  each schedule's last-fired state.
 
-The probes report booleans only — no credential values are printed or
-persisted, and the synthetic `/doctor/*` routes return 404 in production.
+No credential values are printed or persisted by any probe, and the synthetic
+`/doctor/*` routes return 404 in production.
 
 `GET /doctor/base-url` is the one exception to that 404, and doctor does not
 call it: it exists for a deployed production server to answer. It reports the


### PR DESCRIPTION
Checker round-2 residuals on the D3 truth pass (#756). Five one-liners, each re-verified against source before editing — all five were real.

| Page | Was | Is |
| --- | --- | --- |
| `connect/api-tools.mdx` | tRPC `polls.delete` example carried `"risk": "write"` | `"destructive"`. `delete` is in `DESTRUCTIVE_WORDS`, so `trpcRisk` returns `destructive` (`actions/src/sync/common.ts:459,487-489`). #756 fixed the description in that block and left the risk field behind; the GraphQL example below already had it right. |
| `deploy/troubleshooting.mdx` | "`GET /doctor/machines` reports the sandbox and scheduler wiring" | Scheduler wiring and machine state only — which apps carry a machine, whether a `/tick` caller secret is set, each schedule's last-fired state (`wire/doctor.ts:71-76`). The sandbox venue comes from `/status` `blocks.sandbox`, not this route. |
| `deploy/troubleshooting.mdx` | "The probes report booleans only" | False for `machines`, which prints app ids, names, cron expressions, and last-fired timestamps (`cli/doctor.ts:699-704`). Kept the load-bearing half: no credential values are printed or persisted. |
| `concepts/generated-ui.mdx` | "the SDK rewrites the host client-side" | "SDK-side, in your Node process" (`sandbox.ts:353-360`). "Client-side" invited the browser reading. |
| `deploy/persistence.mdx` | "every secret read *and* write throws" | Only `get` and `set` throw without a key. `delete` and `list` succeed keyless — neither touches ciphertext (`store/src/secrets.ts:88-96`). Corrected in both places the page says it. |

Four files, +15/−11, docs only. `pnpm build`, `pnpm typecheck`, `pnpm lint` green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes five small D3 doc errors to match actual behavior across the SDK and doctor tools. Clarifies risk labels, doctor output, host rewrite location, and secret store behavior.

- **Bug Fixes**
  - `connect/api-tools.mdx`: `polls.delete` example now uses `"risk": "destructive"` (was `"write"`).
  - `deploy/troubleshooting.mdx`: `/doctor/machines` documents scheduler wiring and machine state only; removed sandbox claim. Clarifies that probes don’t print credentials and `/doctor/*` returns 404 in production.
  - `concepts/generated-ui.mdx`: Host string rewrite happens in the SDK (Node process), not client-side.
  - `deploy/persistence.mdx`: Without an encryption key, `get`/`set` throw; `delete`/`list` still work. Updated dev/prod notes for `createVendo` and `createStore`.

<sup>Written for commit 0a18b0ff0ec179bd04558f13557eab7319e2701f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

