### PR TITLE
fix(sync): a keyless build says the pin baselines stayed local

### DIFF
--- a/packages/vendo/src/cli/sync.coherence.test.ts
+++ b/packages/vendo/src/cli/sync.coherence.test.ts
@@ -468,6 +468,14 @@ describe("pin baselines reach Vendo Cloud (decision 4)", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it("keyless with captures SAYS the baselines stayed local", async () => {
+    vi.stubEnv("VENDO_API_KEY", "");
+    const dir = await hostWithBaselines([{ slot: "NetWorthCard", hash: "aa" }]);
+    const messages = captureOutput();
+    expect(await runSync({ targetDir: dir, output: messages.output, sync: scan, ai: false })).toBe(0);
+    expect(messages.logs.join("\n")).toContain("baselines stay local");
+  });
+
   it("a Cloud hiccup is a warning, never a failed build", async () => {
     const dir = await hostWithBaselines([{ slot: "NetWorthCard", hash: "aa" }]);
     const messages = captureOutput();

--- a/packages/vendo/src/cli/sync.ts
+++ b/packages/vendo/src/cli/sync.ts
@@ -333,6 +333,12 @@ async function sync(options: SyncOptions): Promise<number> {
       if (result.error !== undefined) {
         noteError(`warning: pin baselines did not fully reach Vendo Cloud: ${result.error} — the rest stay in .vendo/remixable/ and the next sync retries`);
       }
+    } else if (await exists(join(vendoDir, "remixable"))) {
+      // Captures exist but this environment has no key. Keyless is a supported
+      // path (BYO), so this is a statement of fact rather than a warning — but
+      // it must be SAID: a build env that lacks the key the runtime has pushes
+      // nothing, and the console then shows a fork it cannot diff.
+      note("baselines stay local — no Vendo Cloud key in this environment; Cloud's Remix reviews screen needs a keyed sync to diff forks");
     }
 
     let reportUnkeyed = false;


### PR DESCRIPTION
Found while verifying whether Cloud review can reach captured baselines (it can — `cloud/pin-baselines.ts` pushes them on a keyed sync).

The edge: `sync.ts` gated the push on `.vendo/remixable/` existing **and** a resolved key, with no `else`. A host whose key lives in the deploy/runtime env but not the *build* env therefore pushed nothing and printed nothing; `--json` reported `baselines: null`. Cloud's Remix reviews screen then has a fork and no baseline to diff it against, and nothing anywhere says why.

Keyless/BYO is a supported path, so this is a `note`, not a warning — it must be said, not nagged about.

## Proof
- New test: keyless + captures present → output contains "baselines stay local".
- The existing keyless test (zero network calls) still passes unchanged.
- `sync.coherence` 28/28 · build 23/23 · typecheck 41/41 · lint 6/6.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a silent no-op during sync when captures exist but the build environment has no Cloud key. We now print a note that baselines stay local; Cloud reviews need a keyed sync to diff forks.

- **Bug Fixes**
  - When `.vendo/remixable/` exists but `VENDO_API_KEY` is missing, `sync` prints: “baselines stay local” (note, not a warning).
  - Added a test to assert the message for keyless + captures; existing keyless test remains unchanged.

<sup>Written for commit 99b627960862c88e92573c5d590e7e07bc474964. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

