### PR TITLE
MCP broker selection seam: cloudMcpTenant client, selectMcpBroker, /status posture, doctor (Worker B)

### DIFF
--- a/.changeset/mcp-broker-selection-seam.md
+++ b/.changeset/mcp-broker-selection-seam.md
@@ -1,0 +1,26 @@
+---
+"@vendoai/vendo": minor
+---
+
+A keyed host's MCP door now fronts itself with the hosted broker — zero config.
+
+**The broker default (adapter rule).** With `mcp` enabled, `VENDO_API_KEY` set,
+and a public `VENDO_BASE_URL`, composition ensures a broker tenant at
+`{slug}.mcp.vendo.run` through your Vendo Cloud console and wires the door's
+`remoteAs` + `federation` from the response — the same way the key already
+fills the store, sandbox, inference and connections slots. An explicit
+`mcp.remoteAs` in config still wins verbatim, and a host with no key (or no
+public URL — localhost, `*.local`, and private addresses can't be fronted by
+the broker) keeps today's local door byte-for-byte. The ensure call is
+idempotent and rides the boot-once ready latch, so composition stays I/O-free
+at module init (Workers-safe); if the console blips at boot, the door falls
+back to its own local OAuth surface with one loud warning instead of dying.
+
+**`/status` says which door composed.** `blocks.mcp` is now a posture —
+`"local"`, `"broker"`, or `false` — following the `blocks.connections`
+pattern. Older clients that only checked truthiness keep working.
+
+**Doctor explains the silent cases.** A key + an open door + no public base
+URL prints the new `I-CLOUD-002` informational ("the hosted MCP broker
+activates when the deployment has a public base URL"); with a public URL,
+doctor resolves and prints the tenant your door composes against.

--- a/docs-site/reference/http-routes.mdx
+++ b/docs-site/reference/http-routes.mdx
@@ -59,7 +59,7 @@ unauthenticated in every environment by design: it reveals only whether
 | `/connections/initiate` | POST | `{ toolkit, connector?, callbackUrl? }` → `{ id, connector, redirectUrl }`; refused for ephemeral and synthetic (`webhook:` / `vendo:`) subjects |
 | `/connections/:id?connector=` | GET · DELETE | status (poll while connecting) · disconnect through the broker |
 | `/orgs` · `/orgs/:id` and every other `/orgs/*` path | any | always `cloud-required` (`402`); organizations are a [Vendo Cloud](/deploy/vendo-cloud) capability, not an OSS wire route |
-| `/status` | GET | `{ posture, version, blocks: {...} }`, includes `blocks.mcp: true` when the door is open, `blocks.sandbox` reporting the execution venue (`"e2b"`, `"cloud"`, `"custom"`, or `false` when none is wired), and `blocks.connections` reporting the connected-accounts broker posture (`"byo"`, `"cloud"`, or `false`) |
+| `/status` | GET | `{ posture, version, blocks: {...} }`, includes `blocks.mcp` reporting the door posture (`"local"` when it serves its own OAuth surface, `"broker"` when an external authorization server fronts it, or `false` when the door is closed), `blocks.sandbox` reporting the execution venue (`"e2b"`, `"cloud"`, `"custom"`, or `false` when none is wired), and `blocks.connections` reporting the connected-accounts broker posture (`"byo"`, `"cloud"`, or `false`) |
 | `/sync/impact` | POST | dev-only. `{ tools: string[] }` → `{ impact }`, per-tool reference counts across enabled apps, enabled automations, and active standing grants. Accepts up to 200 tool names per call. In production it answers `blocked` (`403`), not `404` — the route is mounted everywhere and refuses on `NODE_ENV` |
 
 ## Development routes

--- a/packages/vendo/src/cli/doctor-codes.ts
+++ b/packages/vendo/src/cli/doctor-codes.ts
@@ -62,6 +62,18 @@ export const DOCTOR_ERROR_CODES = {
 
 export type DoctorErrorCode = keyof typeof DOCTOR_ERROR_CODES;
 
+/** Informational notes (I-<AREA>-<NNN>): nothing is broken, doctor is
+ *  explaining a decision a seam made silently. They are NOT failures, carry
+ *  no verify-page anchor, and stay OUT of doctorErrorCodes (the registry-rot
+ *  CI gate enumerates error codes only). Append-only all the same; NNN stays
+ *  unique within an area across both registries (E-CLOUD-001 exists, so the
+ *  first CLOUD informational is 002). */
+export const DOCTOR_INFO_CODES = {
+  "I-CLOUD-002": "the hosted MCP broker activates when the deployment has a public base URL",
+} as const;
+
+export type DoctorInfoCode = keyof typeof DOCTOR_INFO_CODES;
+
 /** Complete list of every code doctor can emit, for CI enumeration. */
 export const doctorErrorCodes = Object.keys(DOCTOR_ERROR_CODES) as readonly DoctorErrorCode[];
 

--- a/packages/vendo/src/cli/doctor-live.ts
+++ b/packages/vendo/src/cli/doctor-live.ts
@@ -163,6 +163,10 @@ export const CLOUD_UNLOCKS: readonly string[] = [
   "team sharing and org governance (roles, SSO)",
   "hosted deploys of your enabled automations",
   "registry publishing, and hosted defaults for the adapter slots you leave unset (managed inference, the sandbox pool, the hosted store, the connections broker)",
+  // Truthful again since the selectMcpBroker seam (provisioning plan
+  // 2026-08-03): a key really does wire the hosted broker now — the condition
+  // rides along so the promise stays exactly as big as the code path.
+  "the hosted MCP broker for your app's MCP door, once it is deployed to a public URL",
 ];
 
 export interface CloudDoctorResult {

--- a/packages/vendo/src/cli/doctor-mcp-broker.test.ts
+++ b/packages/vendo/src/cli/doctor-mcp-broker.test.ts
@@ -49,13 +49,28 @@ async function healthy(): Promise<string> {
   return root;
 }
 
+/** What the broker PRM advertises and how the advertised issuer answers. */
+interface ExternalAs {
+  servers?: string[];
+  respond?: () => Response;
+}
+
 /** A live wire whose /status reports the given mcp posture, with the door's
  *  discovery documents and the doctor probes all answering. `selection` is
  *  what /doctor/mcp reports (defaults to the posture); `null` models an older
  *  wire without the route (404). */
-function probeFetch(mcp: unknown, selection: unknown = mcp): typeof fetch {
+function probeFetch(mcp: unknown, selection: unknown = mcp, external?: ExternalAs): typeof fetch {
   return vi.fn(async (input: string | URL | Request) => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    // The external authorization server the broker PRM advertises: doctor in
+    // broker posture must resolve ITS RFC 8414 metadata (10-mcp §5 — both
+    // documents), so the healthy fixture answers it; `external.respond`
+    // models a dead, 404ing, or non-AS issuer.
+    if (url === "https://maple.mcp.vendo.run/.well-known/oauth-authorization-server") {
+      return external?.respond === undefined
+        ? Response.json({ issuer: "https://maple.mcp.vendo.run", jwks_uri: "https://maple.mcp.vendo.run/jwks" })
+        : external.respond();
+    }
     if (url.endsWith("/api/vendo/status")) {
       return Response.json({ posture: "unconfigured", version: CLI_VERSION, blocks: { store: true, sandbox: "cloud", mcp } });
     }
@@ -69,7 +84,7 @@ function probeFetch(mcp: unknown, selection: unknown = mcp): typeof fetch {
     if (url.endsWith("/doctor/machines")) return Response.json({ scheduleCallerConfigured: false, machines: [] });
     if (url.includes("/.well-known/oauth-protected-resource/")) {
       return Response.json(mcp === "broker"
-        ? { resource: "mcp", authorization_servers: ["https://maple.mcp.vendo.run"] }
+        ? { resource: "mcp", authorization_servers: external?.servers ?? ["https://maple.mcp.vendo.run"] }
         : { resource: "mcp", authorization_servers: ["mcp"] });
     }
     if (url.includes("/.well-known/oauth-authorization-server/")) {
@@ -104,6 +119,7 @@ async function brokerDoctor(options: {
   mcp?: unknown;
   selection?: unknown;
   cloudOk?: boolean;
+  external?: ExternalAs;
   ensureTenant?: Parameters<typeof runDoctor>[0]["ensureTenant"];
 }): Promise<{ exit: number; logs: string[]; errors: string[] }> {
   const root = await healthy();
@@ -112,7 +128,7 @@ async function brokerDoctor(options: {
     targetDir: root,
     env: options.env,
     interactive: false,
-    fetchImpl: probeFetch(options.mcp ?? "local", options.selection === undefined ? options.mcp ?? "local" : options.selection),
+    fetchImpl: probeFetch(options.mcp ?? "local", options.selection === undefined ? options.mcp ?? "local" : options.selection, options.external),
     output: messages.sink,
     telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
     liveTurn: async () => ({
@@ -240,5 +256,52 @@ describe("doctor: the hosted MCP broker seam", () => {
     const unlock = CLOUD_UNLOCKS.find((entry) => entry.includes("MCP broker"));
     expect(unlock).toBeDefined();
     expect(unlock).toMatch(/public/i);
+  });
+});
+
+// Checker round 2 (F2): in broker posture doctor used to validate the
+// protected-resource document TWICE and never fetch the authorization server
+// it advertises — so a dead or garbage issuer passed doctor while the runtime
+// later failed resolving its metadata (remote-as.ts). The frozen contract
+// (10-mcp §5) requires BOTH metadata documents to resolve.
+describe("doctor: broker posture resolves the ADVERTISED external authorization server", () => {
+  const env = { VENDO_API_KEY: "vnd_" + "a".repeat(40), VENDO_BASE_URL: "https://app.maplebank.com" };
+  const broker = (external?: ExternalAs): Parameters<typeof brokerDoctor>[0] =>
+    ({ env, mcp: "broker", ensureTenant: vi.fn(async () => ensured), ...(external === undefined ? {} : { external }) });
+
+  it("healthy broker: the advertised issuer's own metadata is fetched and passes", async () => {
+    const { exit, logs } = await brokerDoctor(broker());
+    expect(exit).toBe(0);
+    expect(logs.some((entry) => entry.includes("MCP authorization-server metadata at https://maple.mcp.vendo.run resolves"))).toBe(true);
+  });
+
+  it("authorization_servers: [\"garbage\"] fails E-MCP-002 — the runtime could never resolve it", async () => {
+    const { exit, errors } = await brokerDoctor(broker({ servers: ["garbage"] }));
+    expect(exit).not.toBe(0);
+    expect(errors.some((entry) => entry.includes("garbage"))).toBe(true);
+  });
+
+  it("an advertised issuer that 404s its metadata fails, naming the issuer", async () => {
+    const { exit, errors } = await brokerDoctor(broker({ respond: () => new Response("not found", { status: 404 }) }));
+    expect(exit).not.toBe(0);
+    expect(errors.some((entry) => entry.includes("https://maple.mcp.vendo.run") && entry.includes("404"))).toBe(true);
+  });
+
+  it("an advertised issuer that answers a non-AS body fails", async () => {
+    const { exit, errors } = await brokerDoctor(broker({ respond: () => Response.json({ hello: "world" }) }));
+    expect(exit).not.toBe(0);
+    expect(errors.some((entry) => entry.includes("https://maple.mcp.vendo.run"))).toBe(true);
+  });
+
+  it("a dead/unreachable issuer fails with a message naming the issuer", async () => {
+    const { exit, errors } = await brokerDoctor(broker({ respond: () => { throw new Error("connect ECONNREFUSED"); } }));
+    expect(exit).not.toBe(0);
+    expect(errors.some((entry) => entry.includes("https://maple.mcp.vendo.run") && entry.includes("unreachable"))).toBe(true);
+  });
+
+  it("the local-door posture still requires the door's OWN authorization-server document", async () => {
+    const { exit, logs } = await brokerDoctor({ env, mcp: "local", ensureTenant: vi.fn(async () => ensured) });
+    expect(exit).toBe(0);
+    expect(logs.some((entry) => entry.includes("MCP authorization-server metadata resolves"))).toBe(true);
   });
 });

--- a/packages/vendo/src/cli/doctor-mcp-broker.test.ts
+++ b/packages/vendo/src/cli/doctor-mcp-broker.test.ts
@@ -1,0 +1,191 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runDoctor } from "./doctor.js";
+import { CLOUD_UNLOCKS } from "./doctor-live.js";
+import { CLI_VERSION } from "./shared.js";
+
+// Task B3 of the MCP broker provisioning plan: doctor explains the broker
+// seam's silent decisions. The seam skips the hosted broker without a word
+// when the base URL is private (the broker cannot forward visitors to a
+// laptop) — doctor is where that gets said (I-CLOUD-002, informational). With
+// a public URL it resolves and prints the tenant the composition WOULD/did
+// front the door with (the ensure is idempotent — the same call the boot
+// makes). Patterns follow doctor.test.ts; this is a NEW file so the
+// pre-existing suite stays untouched.
+
+const cleanup: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  for (const dispose of cleanup.splice(0).reverse()) await dispose();
+});
+
+function output(): { logs: string[]; errors: string[]; sink: { log(message: string): void; error(message: string): void } } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return {
+    logs,
+    errors,
+    sink: { log: (message) => logs.push(message), error: (message) => errors.push(message) },
+  };
+}
+
+/** The healthy Next.js fixture from doctor.test.ts, trimmed to what the
+ *  static checks need to stay green. */
+async function healthy(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-doctor-broker-"));
+  cleanup.push(() => rm(root, { recursive: true, force: true }));
+  const write = async (relative: string, body: string): Promise<void> => {
+    const path = join(root, relative);
+    await mkdir(join(path, ".."), { recursive: true });
+    await writeFile(path, body);
+  };
+  await write("package.json", JSON.stringify({ dependencies: { "@vendoai/vendo": "0.3.0", next: "16" } }));
+  await write("app/layout.tsx", "export default ({children}) => <VendoRoot>{children}<VendoOverlay /></VendoRoot>;");
+  await write("app/api/vendo/[...vendo]/route.ts", "export const GET = () => {};\n");
+  for (const file of ["tools.json", "overrides.json", "policy.json", "brief.md", "theme.json"]) await write(`.vendo/${file}`, "{}\n");
+  await write(".vendo/data/.gitignore", "*\n");
+  return root;
+}
+
+/** A live wire whose /status reports the given mcp posture, with the door's
+ *  discovery documents and the doctor probes all answering. */
+function probeFetch(mcp: unknown): typeof fetch {
+  return vi.fn(async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (url.endsWith("/api/vendo/status")) {
+      return Response.json({ posture: "unconfigured", version: CLI_VERSION, blocks: { store: true, sandbox: "cloud", mcp } });
+    }
+    if (url.endsWith("/doctor/present")) return Response.json({ ok: true });
+    if (url.endsWith("/doctor/act-as")) return Response.json({ ok: true });
+    if (url.endsWith("/doctor/machines")) return Response.json({ scheduleCallerConfigured: false, machines: [] });
+    if (url.includes("/.well-known/oauth-protected-resource/")) return Response.json({ resource: "mcp" });
+    if (url.includes("/.well-known/oauth-authorization-server/")) return Response.json({ issuer: "auth" });
+    if (url.endsWith("/.well-known/mcp/server-card.json")) {
+      return Response.json({ name: "maple", transports: [{ type: "streamable-http", url: "http://localhost:3000/api/vendo/mcp" }] });
+    }
+    if (url.endsWith("/.well-known/mcp-registry-auth")) return new Response("not found", { status: 404 });
+    if (new URL(url).pathname === "/") return new Response("<html />", { status: 200 });
+    return Response.json({ error: { message: "unexpected probe" } }, { status: 404 });
+  }) as typeof fetch;
+}
+
+const ensured = {
+  tenant: {
+    slug: "maple",
+    issuer: "https://maple.mcp.vendo.run",
+    audience: "https://maple.mcp.vendo.run/mcp",
+    status: "active" as const,
+    upstreamOrigin: "https://app.maplebank.com",
+    upstreamMount: "/api/vendo/mcp",
+  },
+  federationSecret: "c2VjcmV0",
+};
+
+async function brokerDoctor(options: {
+  env: Record<string, string | undefined>;
+  mcp?: unknown;
+  cloudOk?: boolean;
+  ensureTenant?: Parameters<typeof runDoctor>[0]["ensureTenant"];
+}): Promise<{ exit: number; logs: string[]; errors: string[] }> {
+  const root = await healthy();
+  const messages = output();
+  const exit = await runDoctor({
+    targetDir: root,
+    env: options.env,
+    interactive: false,
+    fetchImpl: probeFetch(options.mcp ?? "local"),
+    output: messages.sink,
+    telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    liveTurn: async () => ({
+      attempted: true,
+      ok: true,
+      rung: "env-key",
+      credential: "explicit ANTHROPIC_API_KEY (anthropic)",
+      reply: "ok",
+      elapsedMs: 1,
+    }),
+    cloudProbe: async () => (options.cloudOk === false
+      ? { present: false, ok: false, unlocks: CLOUD_UNLOCKS }
+      : { present: true, ok: true, unlocks: CLOUD_UNLOCKS }),
+    npmLatest: async () => null,
+    ...(options.ensureTenant === undefined ? {} : { ensureTenant: options.ensureTenant }),
+  });
+  return { exit, logs: messages.logs, errors: messages.errors };
+}
+
+describe("doctor: the hosted MCP broker seam", () => {
+  it("key + mcp + no public base URL → the I-CLOUD-002 informational, and no ensure call", async () => {
+    const ensureTenant = vi.fn(async () => ensured);
+    const { logs } = await brokerDoctor({ env: { VENDO_API_KEY: "vnd_" + "a".repeat(40) }, ensureTenant });
+    const line = logs.find((entry) => entry.includes("I-CLOUD-002"));
+    expect(line).toBeDefined();
+    expect(line).toMatch(/public (base )?URL/i);
+    expect(ensureTenant).not.toHaveBeenCalled();
+  });
+
+  it("a localhost VENDO_BASE_URL gets the same informational — the frozen localhost rule, explained", async () => {
+    const ensureTenant = vi.fn(async () => ensured);
+    const { logs } = await brokerDoctor({
+      env: { VENDO_API_KEY: "vnd_" + "a".repeat(40), VENDO_BASE_URL: "http://localhost:3000" },
+      ensureTenant,
+    });
+    expect(logs.some((entry) => entry.includes("I-CLOUD-002"))).toBe(true);
+    expect(ensureTenant).not.toHaveBeenCalled();
+  });
+
+  it("key + mcp + public base URL → resolves and prints the tenant the door composes against", async () => {
+    const ensureTenant = vi.fn(async () => ensured);
+    const { logs } = await brokerDoctor({
+      env: { VENDO_API_KEY: "vnd_" + "a".repeat(40), VENDO_BASE_URL: "https://app.maplebank.com" },
+      mcp: "broker",
+      ensureTenant,
+    });
+    expect(ensureTenant).toHaveBeenCalledTimes(1);
+    expect(ensureTenant).toHaveBeenCalledWith({
+      baseUrl: "https://app.maplebank.com",
+      mount: "/api/vendo/mcp",
+    });
+    expect(logs.some((entry) => entry.includes("https://maple.mcp.vendo.run"))).toBe(true);
+  });
+
+  it("an ensure failure stays informational — named, never a doctor failure of its own", async () => {
+    const ensureTenant = vi.fn(async () => { throw new Error("console unreachable"); });
+    const { logs, errors } = await brokerDoctor({
+      env: { VENDO_API_KEY: "vnd_" + "a".repeat(40), VENDO_BASE_URL: "https://app.maplebank.com" },
+      mcp: "broker",
+      ensureTenant,
+    });
+    expect(logs.some((entry) => entry.includes("console unreachable"))).toBe(true);
+    expect(errors.join("\n")).not.toContain("console unreachable");
+  });
+
+  it("no usable key → no broker line at all", async () => {
+    const ensureTenant = vi.fn(async () => ensured);
+    const { logs } = await brokerDoctor({
+      env: { VENDO_BASE_URL: "https://app.maplebank.com" },
+      cloudOk: false,
+      ensureTenant,
+    });
+    expect(logs.some((entry) => entry.includes("I-CLOUD-002"))).toBe(false);
+    expect(ensureTenant).not.toHaveBeenCalled();
+  });
+
+  it("the new /status postures still count as an open door — the E-MCP discovery checks run", async () => {
+    for (const mcp of ["local", "broker"]) {
+      const { logs } = await brokerDoctor({
+        env: { VENDO_API_KEY: "vnd_" + "a".repeat(40), VENDO_BASE_URL: "https://app.maplebank.com" },
+        mcp,
+        ensureTenant: vi.fn(async () => ensured),
+      });
+      expect(logs.some((entry) => entry.includes("MCP protected-resource metadata resolves")), mcp).toBe(true);
+    }
+  });
+
+  it("CLOUD_UNLOCKS truthfully names the hosted MCP broker again, with its deploy condition", async () => {
+    const unlock = CLOUD_UNLOCKS.find((entry) => entry.includes("MCP broker"));
+    expect(unlock).toBeDefined();
+    expect(unlock).toMatch(/public/i);
+  });
+});

--- a/packages/vendo/src/cli/doctor-mcp-broker.test.ts
+++ b/packages/vendo/src/cli/doctor-mcp-broker.test.ts
@@ -50,18 +50,34 @@ async function healthy(): Promise<string> {
 }
 
 /** A live wire whose /status reports the given mcp posture, with the door's
- *  discovery documents and the doctor probes all answering. */
-function probeFetch(mcp: unknown): typeof fetch {
+ *  discovery documents and the doctor probes all answering. `selection` is
+ *  what /doctor/mcp reports (defaults to the posture); `null` models an older
+ *  wire without the route (404). */
+function probeFetch(mcp: unknown, selection: unknown = mcp): typeof fetch {
   return vi.fn(async (input: string | URL | Request) => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
     if (url.endsWith("/api/vendo/status")) {
       return Response.json({ posture: "unconfigured", version: CLI_VERSION, blocks: { store: true, sandbox: "cloud", mcp } });
     }
+    if (url.endsWith("/doctor/mcp")) {
+      return selection === null
+        ? Response.json({ error: { message: "unknown Vendo route" } }, { status: 404 })
+        : Response.json({ selection });
+    }
     if (url.endsWith("/doctor/present")) return Response.json({ ok: true });
     if (url.endsWith("/doctor/act-as")) return Response.json({ ok: true });
     if (url.endsWith("/doctor/machines")) return Response.json({ scheduleCallerConfigured: false, machines: [] });
-    if (url.includes("/.well-known/oauth-protected-resource/")) return Response.json({ resource: "mcp" });
-    if (url.includes("/.well-known/oauth-authorization-server/")) return Response.json({ issuer: "auth" });
+    if (url.includes("/.well-known/oauth-protected-resource/")) {
+      return Response.json(mcp === "broker"
+        ? { resource: "mcp", authorization_servers: ["https://maple.mcp.vendo.run"] }
+        : { resource: "mcp", authorization_servers: ["mcp"] });
+    }
+    if (url.includes("/.well-known/oauth-authorization-server/")) {
+      // Remote-AS posture: the real door deliberately 404s its own
+      // authorization-server metadata (door.ts remoteAs guard) — a 200 here
+      // would be an impossible response for a broker-fronted door.
+      return mcp === "broker" ? new Response("not found", { status: 404 }) : Response.json({ issuer: "auth" });
+    }
     if (url.endsWith("/.well-known/mcp/server-card.json")) {
       return Response.json({ name: "maple", transports: [{ type: "streamable-http", url: "http://localhost:3000/api/vendo/mcp" }] });
     }
@@ -86,6 +102,7 @@ const ensured = {
 async function brokerDoctor(options: {
   env: Record<string, string | undefined>;
   mcp?: unknown;
+  selection?: unknown;
   cloudOk?: boolean;
   ensureTenant?: Parameters<typeof runDoctor>[0]["ensureTenant"];
 }): Promise<{ exit: number; logs: string[]; errors: string[] }> {
@@ -95,7 +112,7 @@ async function brokerDoctor(options: {
     targetDir: root,
     env: options.env,
     interactive: false,
-    fetchImpl: probeFetch(options.mcp ?? "local"),
+    fetchImpl: probeFetch(options.mcp ?? "local", options.selection === undefined ? options.mcp ?? "local" : options.selection),
     output: messages.sink,
     telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
     liveTurn: async () => ({
@@ -137,11 +154,14 @@ describe("doctor: the hosted MCP broker seam", () => {
 
   it("key + mcp + public base URL → resolves and prints the tenant the door composes against", async () => {
     const ensureTenant = vi.fn(async () => ensured);
-    const { logs } = await brokerDoctor({
+    const { exit, logs } = await brokerDoctor({
       env: { VENDO_API_KEY: "vnd_" + "a".repeat(40), VENDO_BASE_URL: "https://app.maplebank.com" },
       mcp: "broker",
       ensureTenant,
     });
+    // A healthy broker-fronted door is WIRED: its deliberate 404 on the local
+    // authorization-server metadata must not read as broken (E-MCP-002).
+    expect(exit).toBe(0);
     expect(ensureTenant).toHaveBeenCalledTimes(1);
     expect(ensureTenant).toHaveBeenCalledWith({
       baseUrl: "https://app.maplebank.com",
@@ -161,6 +181,35 @@ describe("doctor: the hosted MCP broker seam", () => {
     expect(errors.join("\n")).not.toContain("console unreachable");
   });
 
+  it("an explicit mcp.remoteAs composition → doctor never POSTs ensure (explicit-adapter precedence)", async () => {
+    // /status reports explicit remoteAs as the same "broker" posture as the
+    // Cloud-managed default; only /doctor/mcp carries the distinction. An
+    // ensure here could provision or repoint an unrelated Cloud tenant.
+    const ensureTenant = vi.fn(async () => ensured);
+    const { exit, logs } = await brokerDoctor({
+      env: { VENDO_API_KEY: "vnd_" + "a".repeat(40), VENDO_BASE_URL: "https://app.maplebank.com" },
+      mcp: "broker",
+      selection: "explicit",
+      ensureTenant,
+    });
+    expect(ensureTenant).not.toHaveBeenCalled();
+    expect(logs.some((entry) => entry.includes("explicit"))).toBe(true);
+    expect(exit).toBe(0);
+  });
+
+  it("a wire without /doctor/mcp (older wire) → conservative: no ensure, an explanatory note", async () => {
+    const ensureTenant = vi.fn(async () => ensured);
+    const { exit, logs } = await brokerDoctor({
+      env: { VENDO_API_KEY: "vnd_" + "a".repeat(40), VENDO_BASE_URL: "https://app.maplebank.com" },
+      mcp: "broker",
+      selection: null,
+      ensureTenant,
+    });
+    expect(ensureTenant).not.toHaveBeenCalled();
+    expect(logs.some((entry) => entry.includes("hosted MCP broker"))).toBe(true);
+    expect(exit).toBe(0);
+  });
+
   it("no usable key → no broker line at all", async () => {
     const ensureTenant = vi.fn(async () => ensured);
     const { logs } = await brokerDoctor({
@@ -172,14 +221,18 @@ describe("doctor: the hosted MCP broker seam", () => {
     expect(ensureTenant).not.toHaveBeenCalled();
   });
 
-  it("the new /status postures still count as an open door — the E-MCP discovery checks run", async () => {
+  it("the new /status postures still count as an open door — the E-MCP discovery checks run and pass", async () => {
     for (const mcp of ["local", "broker"]) {
-      const { logs } = await brokerDoctor({
+      const { exit, logs } = await brokerDoctor({
         env: { VENDO_API_KEY: "vnd_" + "a".repeat(40), VENDO_BASE_URL: "https://app.maplebank.com" },
         mcp,
         ensureTenant: vi.fn(async () => ensured),
       });
       expect(logs.some((entry) => entry.includes("MCP protected-resource metadata resolves")), mcp).toBe(true);
+      // Each posture is probed for what its door actually exposes: the local
+      // door serves its own AS metadata; the broker-fronted door 404s it and
+      // instead names the external AS in the protected-resource document.
+      expect(exit, mcp).toBe(0);
     }
   });
 

--- a/packages/vendo/src/cli/doctor.ts
+++ b/packages/vendo/src/cli/doctor.ts
@@ -16,7 +16,9 @@ import { describeDevCredential, resolveDevCredential } from "../dev-creds/resolv
 // Relative (not the #dev-creds condition): the CLI is Node-only and the edge
 // build deliberately does not export the pin map.
 import { SLOT_PIN_ENV } from "../dev-creds/model.js";
-import { doctorFixRef, type DoctorErrorCode } from "./doctor-codes.js";
+import { DOCTOR_INFO_CODES, doctorFixRef, type DoctorErrorCode } from "./doctor-codes.js";
+import { cloudMcpTenant, type EnsureTenantResult } from "../cloud-mcp.js";
+import { publicBaseUrl } from "../mcp-broker-select.js";
 import { EJECT_MANIFEST_FILE, type EjectedManifest } from "./eject.js";
 import { applyJudgment, judgmentsFileSchema, overridesFileSchema, toolsFileSchema, type ToolJudgment } from "@vendoai/actions";
 import { detectFramework, detectVendoWiring } from "./framework.js";
@@ -54,6 +56,10 @@ export interface DoctorOptions {
   /** The npm `latest` lookup behind the version-skew line — its own seam, not
       fetchImpl, so a scripted wire probe never doubles as a registry answer. */
   npmLatest?: () => Promise<string | null>;
+  /** The broker ensure-tenant call behind the hosted-MCP line — its own seam
+      for the same reason as npmLatest: it rides the Cloud console, not the
+      probed wire. */
+  ensureTenant?: (input: { baseUrl: string; mount: string }) => Promise<EnsureTenantResult>;
 }
 
 type CheckStatus = "ok" | "broken" | "warning";
@@ -513,8 +519,10 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
       } else {
         fail("deps/version-skew", "E-DEP-002", `the running wire serves @vendoai/vendo ${body.version} but this CLI is ${CLI_VERSION} — likely a split-brain install (a direct @vendoai/vendo dependency pinned to an older range wins over the vendoai umbrella's). Fix: npm install @vendoai/vendo@${CLI_VERSION} (or remove the direct @vendoai/vendo dependency and reinstall), then restart the dev server and re-run doctor.`);
       }
-      // 10-mcp §1 — the door flag lives under blocks.mcp.
-      mcpEnabled = body.blocks.mcp === true;
+      // 10-mcp §1 — the door flag lives under blocks.mcp. Since the broker
+      // seam it is a posture ("local" | "broker" | false); older wires still
+      // send a boolean (version skew), and both mean the door is open.
+      mcpEnabled = body.blocks.mcp === true || body.blocks.mcp === "local" || body.blocks.mcp === "broker";
       sandboxVenue = body.blocks.sandbox;
       if (sandboxVenue === "e2b") {
         // 0.4.4 defect C — "ok: execution venue: e2b" on a host that cannot
@@ -766,6 +774,38 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
     warn("cloud/key", "E-CLOUD-001", `VENDO_API_KEY is set but not usable: ${cloud.error ?? "malformed"}`);
   } else {
     note(`Vendo Cloud (optional): no VENDO_API_KEY. A key unlocks ${cloud.unlocks.join("; ")}. Run \`vendo login\` to start.`);
+  }
+
+  // MCP broker seam (provisioning plan 2026-08-03): with a usable key and an
+  // open door, doctor explains what the broker default does — the seam skips
+  // the broker SILENTLY on a private base URL (the broker cannot forward
+  // visitors to a laptop), so doctor is where that decision gets said. With a
+  // public URL it resolves and prints the tenant the composition WOULD/did
+  // front the door with; the ensure is idempotent — the very call boot makes.
+  if (cloud.present && cloud.ok && mcpEnabled) {
+    const brokerBase = publicBaseUrl(env["VENDO_BASE_URL"]);
+    if (brokerBase === undefined) {
+      // Informational, not a failure: nothing is broken — deploying to a
+      // public URL is simply what arms the broker.
+      note(`I-CLOUD-002: ${DOCTOR_INFO_CODES["I-CLOUD-002"]} — VENDO_BASE_URL is unset or private, so the door serves its own local OAuth surface for now`);
+    } else {
+      const ensure = options.ensureTenant ?? ((input: { baseUrl: string; mount: string }) =>
+        cloudMcpTenant({
+          apiKey: env["VENDO_API_KEY"] ?? "",
+          ...(env["VENDO_CLOUD_URL"] === undefined ? {} : { baseUrl: env["VENDO_CLOUD_URL"] }),
+        }).ensure(input));
+      try {
+        const { tenant } = await ensure({
+          baseUrl: brokerBase,
+          mount: `${new URL(statusUrl).pathname.replace(/\/$/, "")}/mcp`,
+        });
+        pass("cloud/mcp-broker", `hosted MCP broker tenant: ${tenant.issuer}${tenant.status === "disabled" ? " (disabled in the console — the broker refuses traffic)" : ""} — the door composes against it when deployed at ${brokerBase}`);
+      } catch (error) {
+        // Informational like the arm above: the composition itself degrades
+        // to the local door on the same failure, loudly, at boot.
+        note(`hosted MCP broker: the tenant could not be resolved (${error instanceof Error ? error.message : String(error)}) — the door falls back to its own local OAuth surface until the console answers`);
+      }
+    }
   }
 
   if (devServerStop !== null) devServerStop();

--- a/packages/vendo/src/cli/doctor.ts
+++ b/packages/vendo/src/cli/doctor.ts
@@ -627,17 +627,23 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
   if (mcpPosture !== false) {
     const origin = new URL(statusUrl).origin;
     const mountPath = `${new URL(statusUrl).pathname.replace(/\/$/, "")}/mcp`;
-    const resolves = async (id: string, code: DoctorErrorCode, url: string, valid: (body: Record<string, unknown>) => boolean, label: string): Promise<void> => {
+    const resolves = async (id: string, code: DoctorErrorCode, url: string, valid: (body: Record<string, unknown>) => boolean, label: string): Promise<Record<string, unknown> | null> => {
+      let status: number | undefined;
       try {
         const response = await fetchImpl(url, { headers: { accept: "application/json" } });
+        status = response.status;
         const body = await response.json() as Record<string, unknown>;
-        if (response.ok && valid(body)) pass(id, label);
-        else fail(id, code, `${label} (${response.status})`);
+        if (response.ok && valid(body)) { pass(id, label); return body; }
+        fail(id, code, `${label} (${status})`);
       } catch {
-        fail(id, code, `${label} is unreachable`);
+        // A non-JSON error page still names its status; only a fetch that
+        // never answered is "unreachable".
+        if (status === undefined) fail(id, code, `${label} is unreachable`);
+        else fail(id, code, `${label} (${status})`);
       }
+      return null;
     };
-    await resolves(
+    const resource = await resolves(
       "mcp/protected-resource",
       "E-MCP-001",
       `${origin}/.well-known/oauth-protected-resource${mountPath}`,
@@ -646,19 +652,28 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
     );
     if (mcpPosture === "broker") {
       // Remote-AS posture: the door deliberately 404s its own authorization-
-      // server metadata (an external AS fronts it) — requiring it here read
-      // every healthy broker-fronted door as broken. What that door MUST
-      // expose instead is a protected-resource document naming the external
-      // authorization server (RFC 9728 §2).
-      await resolves(
-        "mcp/authorization-server",
-        "E-MCP-002",
-        `${origin}/.well-known/oauth-protected-resource${mountPath}`,
-        (body) => Array.isArray(body.authorization_servers)
-          && body.authorization_servers.length > 0
-          && body.authorization_servers.every((entry) => typeof entry === "string"),
-        "MCP protected-resource metadata names the external authorization server",
-      );
+      // server metadata — an external AS fronts it, named in the protected-
+      // resource document (RFC 9728 §2). The contract still requires BOTH
+      // documents to resolve (10-mcp §5), and the runtime fetches the
+      // EXTERNAL issuer's metadata before it can verify a single token
+      // (remote-as.ts) — so doctor must resolve that document, not re-read
+      // the one it already validated.
+      const servers = resource?.authorization_servers;
+      const advertised = Array.isArray(servers) && typeof servers[0] === "string" ? servers[0] as string : undefined;
+      const parses = (value: string): boolean => { try { new URL(value); return true; } catch { return false; } };
+      if (advertised === undefined) {
+        fail("mcp/authorization-server", "E-MCP-002", "MCP protected-resource metadata does not name the external authorization server fronting the door");
+      } else if (!parses(advertised)) {
+        fail("mcp/authorization-server", "E-MCP-002", `the advertised authorization server "${advertised}" is not a valid URL — the runtime cannot resolve its metadata`);
+      } else {
+        await resolves(
+          "mcp/authorization-server",
+          "E-MCP-002",
+          `${advertised.replace(/\/+$/, "")}/.well-known/oauth-authorization-server`,
+          (body) => body.issuer === advertised,
+          `MCP authorization-server metadata at ${advertised} resolves`,
+        );
+      }
     } else {
       await resolves(
         "mcp/authorization-server",

--- a/packages/vendo/src/cli/doctor.ts
+++ b/packages/vendo/src/cli/doctor.ts
@@ -490,7 +490,7 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
     }
   }
 
-  let mcpEnabled = false;
+  let mcpPosture: "local" | "broker" | false = false;
   let sandboxVenue: unknown;
   let liveComposition = false;
   try {
@@ -521,8 +521,10 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
       }
       // 10-mcp §1 — the door flag lives under blocks.mcp. Since the broker
       // seam it is a posture ("local" | "broker" | false); older wires still
-      // send a boolean (version skew), and both mean the door is open.
-      mcpEnabled = body.blocks.mcp === true || body.blocks.mcp === "local" || body.blocks.mcp === "broker";
+      // send a boolean (version skew), which predates the broker — "local".
+      mcpPosture = body.blocks.mcp === "broker" ? "broker"
+        : body.blocks.mcp === true || body.blocks.mcp === "local" ? "local"
+        : false;
       sandboxVenue = body.blocks.sandbox;
       if (sandboxVenue === "e2b") {
         // 0.4.4 defect C — "ok: execution venue: e2b" on a host that cannot
@@ -622,7 +624,7 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
   // 10-mcp §5 — when the door is open, verify both discovery documents resolve
   // and the server card parses. The metadata is path-inserted (RFC 9728 §3): a
   // door mounted at /api/vendo/mcp serves /.well-known/...-resource/api/vendo/mcp.
-  if (mcpEnabled) {
+  if (mcpPosture !== false) {
     const origin = new URL(statusUrl).origin;
     const mountPath = `${new URL(statusUrl).pathname.replace(/\/$/, "")}/mcp`;
     const resolves = async (id: string, code: DoctorErrorCode, url: string, valid: (body: Record<string, unknown>) => boolean, label: string): Promise<void> => {
@@ -642,13 +644,30 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
       (body) => typeof body.resource === "string",
       "MCP protected-resource metadata resolves",
     );
-    await resolves(
-      "mcp/authorization-server",
-      "E-MCP-002",
-      `${origin}/.well-known/oauth-authorization-server${mountPath}`,
-      (body) => typeof body.issuer === "string",
-      "MCP authorization-server metadata resolves",
-    );
+    if (mcpPosture === "broker") {
+      // Remote-AS posture: the door deliberately 404s its own authorization-
+      // server metadata (an external AS fronts it) — requiring it here read
+      // every healthy broker-fronted door as broken. What that door MUST
+      // expose instead is a protected-resource document naming the external
+      // authorization server (RFC 9728 §2).
+      await resolves(
+        "mcp/authorization-server",
+        "E-MCP-002",
+        `${origin}/.well-known/oauth-protected-resource${mountPath}`,
+        (body) => Array.isArray(body.authorization_servers)
+          && body.authorization_servers.length > 0
+          && body.authorization_servers.every((entry) => typeof entry === "string"),
+        "MCP protected-resource metadata names the external authorization server",
+      );
+    } else {
+      await resolves(
+        "mcp/authorization-server",
+        "E-MCP-002",
+        `${origin}/.well-known/oauth-authorization-server${mountPath}`,
+        (body) => typeof body.issuer === "string",
+        "MCP authorization-server metadata resolves",
+      );
+    }
     await resolves(
       "mcp/server-card",
       "E-MCP-003",
@@ -782,28 +801,47 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
   // visitors to a laptop), so doctor is where that decision gets said. With a
   // public URL it resolves and prints the tenant the composition WOULD/did
   // front the door with; the ensure is idempotent — the very call boot makes.
-  if (cloud.present && cloud.ok && mcpEnabled) {
+  if (cloud.present && cloud.ok && mcpPosture !== false) {
     const brokerBase = publicBaseUrl(env["VENDO_BASE_URL"]);
     if (brokerBase === undefined) {
       // Informational, not a failure: nothing is broken — deploying to a
       // public URL is simply what arms the broker.
       note(`I-CLOUD-002: ${DOCTOR_INFO_CODES["I-CLOUD-002"]} — VENDO_BASE_URL is unset or private, so the door serves its own local OAuth surface for now`);
     } else {
-      const ensure = options.ensureTenant ?? ((input: { baseUrl: string; mount: string }) =>
-        cloudMcpTenant({
-          apiKey: env["VENDO_API_KEY"] ?? "",
-          ...(env["VENDO_CLOUD_URL"] === undefined ? {} : { baseUrl: env["VENDO_CLOUD_URL"] }),
-        }).ensure(input));
+      // Explicit-adapter precedence (the seam's rule): /status reports both
+      // an explicit `mcp.remoteAs` and the Cloud-managed broker as "broker",
+      // but only the Cloud-managed arm ever calls ensure — against an
+      // explicitly configured AS the same POST could provision or repoint an
+      // unrelated Cloud tenant. Read the composition's own selection off the
+      // dev-only probe; anything but a confirmed "broker" skips the ensure.
+      let selection: unknown;
       try {
-        const { tenant } = await ensure({
-          baseUrl: brokerBase,
-          mount: `${new URL(statusUrl).pathname.replace(/\/$/, "")}/mcp`,
-        });
-        pass("cloud/mcp-broker", `hosted MCP broker tenant: ${tenant.issuer}${tenant.status === "disabled" ? " (disabled in the console — the broker refuses traffic)" : ""} — the door composes against it when deployed at ${brokerBase}`);
-      } catch (error) {
-        // Informational like the arm above: the composition itself degrades
-        // to the local door on the same failure, loudly, at boot.
-        note(`hosted MCP broker: the tenant could not be resolved (${error instanceof Error ? error.message : String(error)}) — the door falls back to its own local OAuth surface until the console answers`);
+        const probed = await fetchImpl(`${statusUrl}/doctor/mcp`, { headers: { accept: "application/json" } });
+        if (probed.ok) selection = (await probed.json() as { selection?: unknown }).selection;
+      } catch {
+        // Unreachable probe — same conservative skip as an older wire below.
+      }
+      if (selection === "explicit") {
+        note("hosted MCP broker: an explicit mcp.remoteAs fronts the door — the broker default does not apply, so doctor ensures no tenant");
+      } else if (selection !== "broker") {
+        note("hosted MCP broker: the composition did not report selecting the broker (older wire, or a probe the dev-only route cannot answer) — skipping the tenant ensure");
+      } else {
+        const ensure = options.ensureTenant ?? ((input: { baseUrl: string; mount: string }) =>
+          cloudMcpTenant({
+            apiKey: env["VENDO_API_KEY"] ?? "",
+            ...(env["VENDO_CLOUD_URL"] === undefined ? {} : { baseUrl: env["VENDO_CLOUD_URL"] }),
+          }).ensure(input));
+        try {
+          const { tenant } = await ensure({
+            baseUrl: brokerBase,
+            mount: `${new URL(statusUrl).pathname.replace(/\/$/, "")}/mcp`,
+          });
+          pass("cloud/mcp-broker", `hosted MCP broker tenant: ${tenant.issuer}${tenant.status === "disabled" ? " (disabled in the console — the broker refuses traffic)" : ""} — the door composes against it when deployed at ${brokerBase}`);
+        } catch (error) {
+          // Informational like the arm above: the composition itself degrades
+          // to the local door on the same failure, loudly, at boot.
+          note(`hosted MCP broker: the tenant could not be resolved (${error instanceof Error ? error.message : String(error)}) — the door falls back to its own local OAuth surface until the console answers`);
+        }
       }
     }
   }

--- a/packages/vendo/src/cloud-mcp.test.ts
+++ b/packages/vendo/src/cloud-mcp.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from "vitest";
+import { cloudMcpTenant } from "./cloud-mcp.js";
+
+// The umbrella-side broker ensure-tenant console client (MCP broker
+// provisioning plan 2026-08-03, task B1): the implementation selectMcpBroker
+// injects when VENDO_API_KEY + a public VENDO_BASE_URL fill the mcp seam.
+// Behavior comes ONLY from constructor arguments (adapter rule); it rides the
+// shared console-client plumbing — deployment-identity headers, per-request
+// abort timeout, and the honest 401/402 → cloud-required error table
+// (cloud-console.ts). The mocked responses below are byte-precise to the
+// FROZEN WIRE CONTRACT in the plan; Worker A builds the server side against
+// the same bytes.
+
+const ensureResponse = {
+  tenant: {
+    slug: "maple",
+    issuer: "https://maple.mcp.vendo.run",
+    audience: "https://maple.mcp.vendo.run/mcp",
+    status: "active",
+    upstreamOrigin: "https://app.maplebank.com",
+    upstreamMount: "/api/vendo/mcp",
+  },
+  federationSecret: "c2VjcmV0LWJhc2U2NHVybA",
+};
+
+describe("cloudMcpTenant", () => {
+  it("posts { baseUrl, mount } bearer-keyed with deployment identity and returns the parsed ensure response", async () => {
+    const requests: Array<{
+      url: string;
+      method: string;
+      authorization: string | null;
+      contentType: string | null;
+      deploymentHost: string | null;
+      signal: boolean;
+      body: unknown;
+    }> = [];
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      requests.push({
+        url: request.url,
+        method: request.method,
+        authorization: request.headers.get("authorization"),
+        contentType: request.headers.get("content-type"),
+        deploymentHost: request.headers.get("x-vendo-deployment-host"),
+        signal: init?.signal instanceof AbortSignal,
+        body: await request.json(),
+      });
+      return Response.json(ensureResponse);
+    });
+    const client = cloudMcpTenant({
+      apiKey: "vnd_secret",
+      baseUrl: "https://cloud.test",
+      fetch: fetchImpl as unknown as typeof fetch,
+    });
+
+    await expect(client.ensure({
+      baseUrl: "https://app.maplebank.com",
+      mount: "/api/vendo/mcp",
+    })).resolves.toEqual(ensureResponse);
+
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/mcp/tenant",
+      method: "POST",
+      authorization: "Bearer vnd_secret",
+      contentType: "application/json",
+      signal: true,
+      body: { baseUrl: "https://app.maplebank.com", mount: "/api/vendo/mcp" },
+    });
+    expect(requests[0]!.deploymentHost).toEqual(expect.any(String));
+    expect(requests[0]!.deploymentHost).not.toBe("");
+  });
+
+  it("defaults the base URL to the Vendo console", async () => {
+    const fetchImpl = vi.fn(async () => Response.json(ensureResponse));
+    const client = cloudMcpTenant({ apiKey: "vnd_secret", fetch: fetchImpl as unknown as typeof fetch });
+    await client.ensure({ baseUrl: "https://app.maplebank.com", mount: "/api/vendo/mcp" });
+    expect(String(fetchImpl.mock.calls[0]![0])).toBe("https://console.vendo.run/api/v1/mcp/tenant");
+  });
+
+  it("still returns the secret for a disabled tenant (broker refuses traffic; the host keeps composing)", async () => {
+    const disabled = {
+      ...ensureResponse,
+      tenant: { ...ensureResponse.tenant, status: "disabled" },
+    };
+    const fetchImpl = vi.fn(async () => Response.json(disabled));
+    const client = cloudMcpTenant({
+      apiKey: "vnd_key",
+      baseUrl: "https://cloud.test",
+      fetch: fetchImpl as unknown as typeof fetch,
+    });
+    await expect(client.ensure({ baseUrl: "https://app.maplebank.com", mount: "/api/vendo/mcp" }))
+      .resolves.toEqual(disabled);
+  });
+
+  it("maps the meter (402) and a bad key (401) to cloud-required with the server's message", async () => {
+    for (const [status, message] of [[402, "Upgrade your Vendo Cloud plan"], [401, "invalid API key"]] as const) {
+      const fetchImpl = vi.fn(async () =>
+        Response.json({ error: { code: "unauthorized", message } }, { status }));
+      const client = cloudMcpTenant({
+        apiKey: "vnd_key",
+        baseUrl: "https://cloud.test",
+        fetch: fetchImpl as unknown as typeof fetch,
+      });
+      await expect(client.ensure({ baseUrl: "https://app.maplebank.com", mount: "/api/vendo/mcp" }))
+        .rejects.toMatchObject({ code: "cloud-required", message });
+    }
+  });
+
+  it("forwards wire-legal console error codes as VendoErrors (the 400 validation envelope)", async () => {
+    const fetchImpl = vi.fn(async () =>
+      Response.json({ error: { code: "validation", message: "baseUrl must be https://" } }, { status: 400 }));
+    const client = cloudMcpTenant({
+      apiKey: "vnd_key",
+      baseUrl: "https://cloud.test",
+      fetch: fetchImpl as unknown as typeof fetch,
+    });
+    await expect(client.ensure({ baseUrl: "https://app.maplebank.com", mount: "/api/vendo/mcp" }))
+      .rejects.toMatchObject({ code: "validation", message: "baseUrl must be https://" });
+  });
+
+  it("a console 5xx does not read as a caller validation error", async () => {
+    const fetchImpl = vi.fn(async () => new Response("bad gateway", { status: 502 }));
+    const client = cloudMcpTenant({
+      apiKey: "vnd_key",
+      baseUrl: "https://cloud.test",
+      fetch: fetchImpl as unknown as typeof fetch,
+    });
+    const failure = await client.ensure({ baseUrl: "https://app.maplebank.com", mount: "/api/vendo/mcp" }).then(
+      () => { throw new Error("expected ensure to reject"); },
+      (error: unknown) => error as { code?: string; message: string },
+    );
+    expect(failure.code).not.toBe("validation");
+    expect(failure.message).toMatch(/502/);
+  });
+
+  it("maps a malformed 2xx body to not-implemented (the knowledge-client posture: a server-shaped failure)", async () => {
+    for (const body of [
+      () => new Response("<!doctype html>", { status: 200, headers: { "content-type": "text/html" } }),
+      () => Response.json({ tenant: { slug: "maple" } }),
+    ]) {
+      const fetchImpl = vi.fn(async () => body());
+      const client = cloudMcpTenant({
+        apiKey: "vnd_key",
+        baseUrl: "https://cloud.test",
+        fetch: fetchImpl as unknown as typeof fetch,
+      });
+      await expect(client.ensure({ baseUrl: "https://app.maplebank.com", mount: "/api/vendo/mcp" }))
+        .rejects.toMatchObject({ code: "not-implemented" });
+    }
+  });
+
+  it("aborts a hung console request after timeoutMs", async () => {
+    const fetchImpl = vi.fn((_input: RequestInfo | URL, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal!.reason));
+      }));
+    const client = cloudMcpTenant({
+      apiKey: "vnd_key",
+      baseUrl: "https://cloud.test",
+      fetch: fetchImpl as unknown as typeof fetch,
+      timeoutMs: 25,
+    });
+    await expect(client.ensure({ baseUrl: "https://app.maplebank.com", mount: "/api/vendo/mcp" }))
+      .rejects.toMatchObject({ name: "TimeoutError" });
+  });
+});

--- a/packages/vendo/src/cloud-mcp.ts
+++ b/packages/vendo/src/cloud-mcp.ts
@@ -1,0 +1,105 @@
+import { VendoError, defaultFetch } from "@vendoai/core";
+import { z } from "zod";
+import { consoleSender, raiseCloudError } from "./cloud-console.js";
+
+/** The Cloud broker ensure-tenant client — the implementation the composition
+ * seam (createVendo) calls when VENDO_API_KEY + a public VENDO_BASE_URL fill
+ * the mcp seam's broker default (adapter rule — see selectMcpBroker in
+ * server.ts; the door itself never reads the environment). Idempotent: the
+ * console creates the tenant on the first call and returns the existing one
+ * (with the federation secret, every call) after that. Rides the shared
+ * console-client plumbing (cloud-console.ts): Bearer auth + deployment
+ * identity + per-request abort timeout + the honest 401/402 → cloud-required
+ * error table. */
+
+export interface CloudMcpOptions {
+  apiKey: string;
+  /** Defaults to the Vendo console; the composition seam passes VENDO_CLOUD_URL. */
+  baseUrl?: string;
+  fetch?: typeof fetch;
+  /** Per-request abort budget (default 30s, hosted-store's). */
+  timeoutMs?: number;
+}
+
+/** The frozen ensure-tenant wire (plan 2026-08-03-mcp-broker-provisioning):
+ * `status: "disabled"` still carries the secret — the host keeps composing
+ * remoteAs and the BROKER refuses traffic, so a status flip needs no host
+ * redeploy in either direction. */
+export interface McpTenant {
+  slug: string;
+  issuer: string;
+  audience: string;
+  status: "active" | "disabled";
+  upstreamOrigin: string;
+  upstreamMount: string;
+}
+
+export interface EnsureTenantResult {
+  tenant: McpTenant;
+  federationSecret: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** The console mounts the broker tenant surface here. */
+const CONSOLE_MCP_PATH = "/api/v1/mcp";
+
+const ensureTenantSchema = z.object({
+  tenant: z.object({
+    slug: z.string(),
+    issuer: z.string(),
+    audience: z.string(),
+    status: z.enum(["active", "disabled"]),
+    upstreamOrigin: z.string(),
+    upstreamMount: z.string(),
+  }),
+  federationSecret: z.string(),
+});
+
+/** Shared console error table: 401/402 → cloud-required, wire-legal envelope
+ * codes forward as VendoErrors, anything else (unknown codes, 5xx, non-JSON
+ * bodies) rides a plain Error with the server's code attached — never a
+ * "validation" error blaming the caller for the console misbehaving. */
+const raiseMcpError = (response: Response): Promise<never> =>
+  raiseCloudError(response, "mcp", (code, message) => {
+    throw Object.assign(new Error(message), { code: code ?? "unavailable" });
+  });
+
+export interface CloudMcpTenantClient {
+  ensure(input: { baseUrl: string; mount: string }): Promise<EnsureTenantResult>;
+}
+
+export function cloudMcpTenant(options: CloudMcpOptions): CloudMcpTenantClient {
+  const base = (options.baseUrl ?? "https://console.vendo.run").replace(/\/$/, "");
+  const send = consoleSender({
+    base,
+    mountPath: CONSOLE_MCP_PATH,
+    apiKey: options.apiKey,
+    timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    fetchImpl: options.fetch ?? defaultFetch,
+    raise: raiseMcpError,
+  });
+
+  return {
+    async ensure(input) {
+      const response = await send("/tenant", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      const payload: unknown = await response.json().catch(() => undefined);
+      const parsed = ensureTenantSchema.safeParse(payload);
+      if (!parsed.success) {
+        // A server-shaped failure, never the caller's: the mount answered 2xx
+        // with a body that is not the ensure-tenant wire (the knowledge
+        // client's posture — a missing/misdeployed mount must not read as a
+        // caller mistake).
+        throw new VendoError(
+          "not-implemented",
+          "Vendo Cloud /api/v1/mcp/tenant answered with a body that is not the ensure-tenant wire — check VENDO_CLOUD_URL and the console deployment",
+        );
+      }
+      return parsed.data;
+    },
+  };
+}

--- a/packages/vendo/src/mcp-broker-select.test.ts
+++ b/packages/vendo/src/mcp-broker-select.test.ts
@@ -83,6 +83,39 @@ describe("selectMcpBroker (pure)", () => {
     expect(publicBaseUrl("https://[::ffff:8.8.8.8]")).toBe("https://[::ffff:8.8.8.8]");
     expect(publicBaseUrl("https://[2606:4700::1111]")).toBe("https://[2606:4700::1111]");
   });
+
+  // Checker round 2 (F1): the trailing-dot strip must be exhaustive, not
+  // dot-count-specific — `localhost..` names the same unreachable machine as
+  // `localhost.`, and URL percent-decodes `%2e` into those dots for http(s).
+  it("strips ALL trailing root-label dots — multi-dot and percent-encoded spellings stay private", () => {
+    for (const baseUrl of [
+      "https://localhost..",
+      "https://localhost...",
+      "https://foo.local..",
+      "https://127.0.0.1..",
+      "https://10.0.0.1..",
+      "https://192.168.1.5..",
+      "https://localhost%2e%2e",
+      "https://127.0.0.1%2e%2e",
+      "https://foo%2elocal%2e%2e",
+    ]) {
+      expect(selectMcpBroker({}, cloud, baseUrl, MOUNT), baseUrl).toEqual({ mode: "local" });
+    }
+  });
+
+  it("a hostname that normalizes to empty is never public", () => {
+    expect(publicBaseUrl("https://.")).toBeUndefined();
+    expect(publicBaseUrl("https://..")).toBeUndefined();
+    expect(publicBaseUrl("https://%2e%2e")).toBeUndefined();
+  });
+
+  it("the exhaustive strip keeps genuinely public hosts public, bytes preserved", () => {
+    expect(publicBaseUrl("https://app.maplebank.com..")).toBe("https://app.maplebank.com..");
+    expect(publicBaseUrl("https://localhost.example.com")).toBe("https://localhost.example.com");
+    expect(publicBaseUrl("https://my-local.com")).toBe("https://my-local.com");
+    expect(publicBaseUrl("https://10.example.com")).toBe("https://10.example.com");
+    expect(publicBaseUrl("https://172.32.0.1..")).toBe("https://172.32.0.1..");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/vendo/src/mcp-broker-select.test.ts
+++ b/packages/vendo/src/mcp-broker-select.test.ts
@@ -1,0 +1,268 @@
+import { createHmac } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { createVendo, type CreateVendoConfig, type Vendo } from "./server.js";
+import { publicBaseUrl, selectMcpBroker } from "./mcp-broker-select.js";
+
+// Task B2 of the MCP broker provisioning plan: the mcp seam's selection —
+// cloned from selectConnections' adapter rule. Explicit `mcp.remoteAs` wins
+// verbatim (no ensure call); else a Cloud key + a PUBLIC base URL default the
+// hosted broker (ensure-tenant at the composition boundary, remoteAs +
+// federation wired from the response); else today's local door, byte-identical.
+// The localhost rule and the ensure request bytes are the plan's FROZEN WIRE
+// CONTRACT.
+
+const MOUNT = "/api/vendo/mcp";
+const cloud = { apiKey: "vnd_broker_key" };
+
+describe("selectMcpBroker (pure)", () => {
+  it("answers off when the door is closed", () => {
+    expect(selectMcpBroker(undefined, cloud, "https://app.example.com", MOUNT)).toEqual({ mode: "off" });
+  });
+
+  it("explicit mcp.remoteAs wins verbatim — no ensure even with a key and a public URL", () => {
+    const selection = selectMcpBroker(
+      { remoteAs: { issuer: "https://own-as.example.com", audience: "https://app.example.com/api/vendo/mcp" } },
+      cloud,
+      "https://app.example.com",
+      MOUNT,
+    );
+    expect(selection).toEqual({ mode: "explicit" });
+  });
+
+  it("a key plus a public base URL defaults the hosted broker with the ensure input", () => {
+    expect(selectMcpBroker({}, cloud, "https://app.maplebank.com", MOUNT)).toEqual({
+      mode: "broker",
+      ensure: { baseUrl: "https://app.maplebank.com", mount: MOUNT },
+    });
+  });
+
+  it("no key keeps today's local door even on a public URL", () => {
+    expect(selectMcpBroker({}, undefined, "https://app.maplebank.com", MOUNT)).toEqual({ mode: "local" });
+  });
+
+  it("skips the broker default for every localhost/private base URL shape (the frozen localhost rule)", () => {
+    for (const baseUrl of [
+      undefined,
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://[::1]:3000",
+      "https://demo.local",
+      "https://10.1.2.3",
+      "https://192.168.1.5:8443",
+      "https://172.16.0.1",
+      "https://172.31.255.255",
+      "not a url",
+    ]) {
+      expect(selectMcpBroker({}, cloud, baseUrl, MOUNT), String(baseUrl)).toEqual({ mode: "local" });
+    }
+  });
+
+  it("publicBaseUrl keeps genuinely public hosts — 172.32.x is outside RFC1918", () => {
+    expect(publicBaseUrl("https://172.32.0.1")).toBe("https://172.32.0.1");
+    expect(publicBaseUrl("https://app.maplebank.com")).toBe("https://app.maplebank.com");
+    expect(publicBaseUrl("https://mylocal.example.com")).toBe("https://mylocal.example.com");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Composition: the seam consumed where the door is composed.
+// ---------------------------------------------------------------------------
+
+const ensureResponse = {
+  tenant: {
+    slug: "maple",
+    issuer: "https://maple.mcp.vendo.run",
+    audience: "https://maple.mcp.vendo.run/mcp",
+    status: "active",
+    upstreamOrigin: "https://app.maplebank.com",
+    upstreamMount: MOUNT,
+  },
+  federationSecret: "umbrella-federation-secret-with-entropy",
+};
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  while (cleanups.length > 0) await cleanups.pop()!();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/** Temp-dir PGlite store with registered teardown (server.test.ts pattern):
+ * teardown awaits schema readiness first — closing PGlite mid-query hangs. */
+async function tempStore(): Promise<VendoStore> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-broker-seam-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.ensureSchema().catch(() => undefined);
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return store;
+}
+
+function fakeConsole(respond: () => Response): {
+  requests: Array<{ authorization: string | null; body: unknown }>;
+  handler: typeof fetch;
+} {
+  const requests: Array<{ authorization: string | null; body: unknown }> = [];
+  const handler = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = new Request(input, init);
+    const url = new URL(request.url);
+    if (url.host !== "cloud-mcp.test" || url.pathname !== "/api/v1/mcp/tenant") {
+      throw new Error(`unexpected fetch during composition: ${request.url}`);
+    }
+    requests.push({
+      authorization: request.headers.get("authorization"),
+      body: await request.json(),
+    });
+    return respond();
+  }) as typeof fetch;
+  return { requests, handler };
+}
+
+async function composeVendo(options: {
+  respond?: () => Response;
+  baseUrl?: string | null;
+  mcp?: CreateVendoConfig["mcp"];
+}): Promise<{ vendo: Vendo; requests: Array<{ authorization: string | null; body: unknown }> }> {
+  vi.stubEnv("VENDO_API_KEY", "vnd_broker_key");
+  vi.stubEnv("VENDO_CLOUD_URL", "https://cloud-mcp.test");
+  if (options.baseUrl !== null) vi.stubEnv("VENDO_BASE_URL", options.baseUrl ?? "https://app.maplebank.com");
+  const console_ = fakeConsole(options.respond ?? (() => Response.json(ensureResponse)));
+  vi.stubGlobal("fetch", console_.handler);
+  const vendo = createVendo({
+    model: {} as LanguageModel,
+    principal: async () => null,
+    store: await tempStore(),
+    mcp: options.mcp ?? true,
+    oauth: {
+      async authorize() { return { subject: "user_door" }; },
+      async principal(subject) { return { kind: "user", subject }; },
+    },
+  });
+  return { vendo, requests: console_.requests };
+}
+
+const root = (path: string): Request => new Request(`https://host.test${path}`);
+const PRM_PATH = "/.well-known/oauth-protected-resource/api/vendo/mcp";
+
+const statusMcp = async (vendo: Vendo): Promise<unknown> => {
+  const response = await vendo.handler(root("/api/vendo/status"));
+  expect(response.status).toBe(200);
+  return (await response.json() as { blocks: { mcp: unknown } }).blocks.mcp;
+};
+
+/** Compact HS256 JWS, enough to speak the 10-mcp §3.2 handshake in-test. */
+function signHs256(secret: string, payload: Record<string, unknown>): string {
+  const part = (value: unknown): string => Buffer.from(JSON.stringify(value)).toString("base64url");
+  const signingInput = `${part({ alg: "HS256", typ: "JWT" })}.${part(payload)}`;
+  const signature = createHmac("sha256", secret).update(signingInput).digest("base64url");
+  return `${signingInput}.${signature}`;
+}
+
+describe("the broker arm: key + public VENDO_BASE_URL ensures a tenant and wires remoteAs + federation", () => {
+  it("ensures once with the frozen request bytes and fronts the door with the tenant", async () => {
+    const { vendo, requests } = await composeVendo({});
+
+    const prm = await vendo.handler(root(PRM_PATH));
+    expect(prm.status).toBe(200);
+    expect((await prm.json() as { authorization_servers?: string[] }).authorization_servers)
+      .toEqual(["https://maple.mcp.vendo.run"]);
+    // Remote-AS mode: the door stops serving its own authorization-server surface.
+    expect((await vendo.handler(root("/.well-known/oauth-authorization-server/api/vendo/mcp"))).status).toBe(404);
+
+    expect(await statusMcp(vendo)).toBe("broker");
+
+    // One ensure for the whole composition — the frozen request, key-authed.
+    expect(requests).toEqual([{
+      authorization: "Bearer vnd_broker_key",
+      body: { baseUrl: "https://app.maplebank.com", mount: MOUNT },
+    }]);
+  });
+
+  it("wires federation from the ensured secret — the broker's signed login handshake lands", async () => {
+    const { vendo } = await composeVendo({});
+    const now = Math.floor(Date.now() / 1_000);
+    const request = signHs256(ensureResponse.federationSecret, {
+      iss: ensureResponse.tenant.issuer,
+      aud: "https://app.maplebank.com/api/vendo/mcp",
+      exp: now + 300,
+      jti: "broker-seam-nonce",
+      redirect_uri: `${ensureResponse.tenant.issuer}/federation/callback`,
+      scopes: ["tools"],
+      client_name: "Vendo broker",
+    });
+    const federated = await vendo.handler(root(`/api/vendo/mcp/federate?request=${request}`));
+    expect(federated.status).toBe(302);
+    const assertion = new URL(federated.headers.get("location")!).searchParams.get("assertion")!;
+    const payload = JSON.parse(Buffer.from(assertion.split(".")[1]!, "base64url").toString()) as Record<string, unknown>;
+    expect(payload).toMatchObject({ sub: "user_door", jti: "broker-seam-nonce" });
+  });
+
+  it("a disabled tenant still composes remoteAs — the broker refuses traffic, the host stays consistent", async () => {
+    const { vendo } = await composeVendo({
+      respond: () => Response.json({
+        ...ensureResponse,
+        tenant: { ...ensureResponse.tenant, status: "disabled" },
+      }),
+    });
+    const prm = await vendo.handler(root(PRM_PATH));
+    expect((await prm.json() as { authorization_servers?: string[] }).authorization_servers)
+      .toEqual(["https://maple.mcp.vendo.run"]);
+    expect(await statusMcp(vendo)).toBe("broker");
+  });
+
+  it("an ensure failure at composition degrades to the local door with one loud warn — boot survives", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { vendo, requests } = await composeVendo({
+      respond: () => new Response("bad gateway", { status: 502 }),
+    });
+
+    // The local door serves its own OAuth surface; nothing died.
+    const as = await vendo.handler(root("/.well-known/oauth-authorization-server/api/vendo/mcp"));
+    expect(as.status).toBe(200);
+    expect((await as.json() as { issuer?: string }).issuer).toBe("https://app.maplebank.com/api/vendo/mcp");
+    expect(await statusMcp(vendo)).toBe("local");
+
+    // Loud, once — the degrade is latched with the composed door.
+    const brokerWarns = warn.mock.calls.filter((call) => String(call[0]).includes("MCP broker"));
+    expect(brokerWarns).toHaveLength(1);
+    expect(String(brokerWarns[0]![0])).toContain("local");
+    expect(requests).toHaveLength(1);
+  });
+});
+
+describe("the other arms stay byte-identical", () => {
+  it("explicit mcp.remoteAs wins verbatim — no ensure call rides the wire", async () => {
+    const issuer = "https://own-as.example.com";
+    const { vendo, requests } = await composeVendo({
+      mcp: { remoteAs: { issuer, audience: "https://app.maplebank.com/api/vendo/mcp" } },
+    });
+    const prm = await vendo.handler(root(PRM_PATH));
+    expect((await prm.json() as { authorization_servers?: string[] }).authorization_servers).toEqual([issuer]);
+    expect(await statusMcp(vendo)).toBe("broker");
+    expect(requests).toHaveLength(0);
+  });
+
+  it("a localhost base URL skips the broker silently — the local door, no wire call", async () => {
+    const { vendo, requests } = await composeVendo({ baseUrl: "http://localhost:3000" });
+    const as = await vendo.handler(root("/.well-known/oauth-authorization-server/api/vendo/mcp"));
+    expect(as.status).toBe(200);
+    expect(await statusMcp(vendo)).toBe("local");
+    expect(requests).toHaveLength(0);
+  });
+
+  it("no base URL at all skips the broker — the local door", async () => {
+    const { vendo, requests } = await composeVendo({ baseUrl: null });
+    const as = await vendo.handler(root("/.well-known/oauth-authorization-server/api/vendo/mcp"));
+    expect(as.status).toBe(200);
+    expect(await statusMcp(vendo)).toBe("local");
+    expect(requests).toHaveLength(0);
+  });
+});

--- a/packages/vendo/src/mcp-broker-select.test.ts
+++ b/packages/vendo/src/mcp-broker-select.test.ts
@@ -57,6 +57,17 @@ describe("selectMcpBroker (pure)", () => {
       "https://172.16.0.1",
       "https://172.31.255.255",
       "not a url",
+      // Canonical alternate spellings of the same private/loopback hosts: a
+      // trailing-dot FQDN and IPv4-mapped IPv6 (URL serializes the mapped
+      // form as hex groups, e.g. [::ffff:7f00:1]) still name the same
+      // unreachable machine — the frozen rule covers the HOST, not the bytes.
+      "https://localhost.",
+      "https://foo.local.",
+      "https://[::ffff:127.0.0.1]",
+      "https://[::ffff:10.0.0.1]",
+      "https://[::ffff:192.168.1.2]",
+      "https://[::ffff:172.16.1.2]",
+      "https://[::ffff:a00:1]",
     ]) {
       expect(selectMcpBroker({}, cloud, baseUrl, MOUNT), String(baseUrl)).toEqual({ mode: "local" });
     }
@@ -66,6 +77,11 @@ describe("selectMcpBroker (pure)", () => {
     expect(publicBaseUrl("https://172.32.0.1")).toBe("https://172.32.0.1");
     expect(publicBaseUrl("https://app.maplebank.com")).toBe("https://app.maplebank.com");
     expect(publicBaseUrl("https://mylocal.example.com")).toBe("https://mylocal.example.com");
+    // The normalizations must not over-reach: a trailing-dot PUBLIC FQDN, an
+    // IPv4-mapped PUBLIC address, and a plain public IPv6 all stay public.
+    expect(publicBaseUrl("https://app.maplebank.com.")).toBe("https://app.maplebank.com.");
+    expect(publicBaseUrl("https://[::ffff:8.8.8.8]")).toBe("https://[::ffff:8.8.8.8]");
+    expect(publicBaseUrl("https://[2606:4700::1111]")).toBe("https://[2606:4700::1111]");
   });
 });
 
@@ -235,6 +251,36 @@ describe("the broker arm: key + public VENDO_BASE_URL ensures a tenant and wires
     expect(brokerWarns).toHaveLength(1);
     expect(String(brokerWarns[0]![0])).toContain("local");
     expect(requests).toHaveLength(1);
+  });
+});
+
+describe("the dev-only /doctor/mcp probe reports the seam's selection", () => {
+  // /status collapses explicit-remoteAs and the Cloud-managed broker into one
+  // "broker" posture (the frozen shape); doctor needs the distinction to keep
+  // the explicit-wins precedence — it must never ensure a tenant for an
+  // explicitly configured AS. The probe carries the seam's own selection.
+  const selectionOf = async (vendo: Vendo): Promise<unknown> => {
+    const response = await vendo.handler(root("/api/vendo/doctor/mcp"));
+    expect(response.status).toBe(200);
+    return (await response.json() as { selection: unknown }).selection;
+  };
+
+  it("broker arm → \"broker\"", async () => {
+    const { vendo } = await composeVendo({});
+    expect(await selectionOf(vendo)).toBe("broker");
+  });
+
+  it("explicit mcp.remoteAs → \"explicit\", though /status says \"broker\" for both", async () => {
+    const { vendo } = await composeVendo({
+      mcp: { remoteAs: { issuer: "https://own-as.example.com", audience: "https://app.maplebank.com/api/vendo/mcp" } },
+    });
+    expect(await statusMcp(vendo)).toBe("broker");
+    expect(await selectionOf(vendo)).toBe("explicit");
+  });
+
+  it("localhost skip → \"local\"", async () => {
+    const { vendo } = await composeVendo({ baseUrl: "http://localhost:3000" });
+    expect(await selectionOf(vendo)).toBe("local");
   });
 });
 

--- a/packages/vendo/src/mcp-broker-select.ts
+++ b/packages/vendo/src/mcp-broker-select.ts
@@ -36,12 +36,24 @@ export function publicBaseUrl(baseUrl: string | undefined): string | undefined {
   } catch {
     return undefined;
   }
-  // URL keeps IPv6 hostnames bracketed ("[::1]").
-  const host = hostname.replace(/^\[|\]$/g, "").toLowerCase();
-  if (host === "localhost" || host === "::1" || host.endsWith(".local")) return undefined;
-  if (isPrivateIpv4(host)) return undefined;
+  if (isPrivateHost(normalizeHost(hostname))) return undefined;
   return baseUrl;
 }
+
+/** Canonicalize the spellings URL leaves alone so the checks below see one
+    form per host: brackets off IPv6 ("[::1]"), one trailing root-label dot
+    off an FQDN ("localhost."), and an IPv4-mapped IPv6 address — which URL
+    serializes as hex groups ("::ffff:7f00:1") — back to its dotted quad. */
+const normalizeHost = (hostname: string): string => {
+  const host = hostname.replace(/^\[|\]$/g, "").toLowerCase().replace(/\.$/, "");
+  const mapped = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(host);
+  if (mapped === null) return host;
+  const [high, low] = [parseInt(mapped[1]!, 16), parseInt(mapped[2]!, 16)];
+  return `${high >> 8}.${high & 255}.${low >> 8}.${low & 255}`;
+};
+
+const isPrivateHost = (host: string): boolean =>
+  host === "localhost" || host === "::1" || host.endsWith(".local") || isPrivateIpv4(host);
 
 const isPrivateIpv4 = (host: string): boolean => {
   const octets = host.split(".");

--- a/packages/vendo/src/mcp-broker-select.ts
+++ b/packages/vendo/src/mcp-broker-select.ts
@@ -36,16 +36,28 @@ export function publicBaseUrl(baseUrl: string | undefined): string | undefined {
   } catch {
     return undefined;
   }
-  if (isPrivateHost(normalizeHost(hostname))) return undefined;
+  const host = normalizeHost(hostname);
+  if (host === "" || isPrivateHost(host)) return undefined;
   return baseUrl;
 }
 
 /** Canonicalize the spellings URL leaves alone so the checks below see one
-    form per host: brackets off IPv6 ("[::1]"), one trailing root-label dot
-    off an FQDN ("localhost."), and an IPv4-mapped IPv6 address — which URL
-    serializes as hex groups ("::ffff:7f00:1") — back to its dotted quad. */
+    form per host: percent-escapes decoded (URL decodes them for http(s), but
+    the rule must not depend on that), EVERY trailing root-label dot off an
+    FQDN ("localhost..", however many — one strip per dot is how "localhost.."
+    slipped past a single-dot rule), brackets off IPv6 ("[::1]"), and an
+    IPv4-mapped IPv6 address — which URL serializes as hex groups
+    ("::ffff:7f00:1") — back to its dotted quad. A hostname that cannot be
+    decoded, or that normalizes to empty (".."), returns "" — the caller
+    treats that as never public. */
 const normalizeHost = (hostname: string): string => {
-  const host = hostname.replace(/^\[|\]$/g, "").toLowerCase().replace(/\.$/, "");
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(hostname);
+  } catch {
+    return "";
+  }
+  const host = decoded.replace(/\.+$/, "").replace(/^\[|\]$/g, "").toLowerCase();
   const mapped = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(host);
   if (mapped === null) return host;
   const [high, low] = [parseInt(mapped[1]!, 16), parseInt(mapped[2]!, 16)];

--- a/packages/vendo/src/mcp-broker-select.ts
+++ b/packages/vendo/src/mcp-broker-select.ts
@@ -1,0 +1,66 @@
+/** ADAPTER RULE, mcp seam (cloned from selectConnections in server.ts): which
+    authorization surface fronts the MCP door is decided at the composition
+    seam — never by a hidden key-conditional inside the door. Precedence, top
+    to bottom:
+      1. an explicit `mcp.remoteAs` always wins, verbatim — no ensure call;
+      2. VENDO_API_KEY plus a PUBLIC base URL make the hosted broker the
+         default: an idempotent ensure-tenant call at the composition boundary
+         wires `remoteAs` + `federation` from the response;
+      3. otherwise today's local door, byte-identical.
+    The door itself never reads the environment; this module is PURE (the
+    ensure call happens at the seam in server.ts, behind the ready latch). */
+
+export interface McpSeamConfig {
+  baseUrl?: string;
+  remoteAs?: { issuer: string; jwksUri?: string; audience: string };
+  federation?: { secret: string };
+}
+
+export type McpBrokerSelection =
+  | { mode: "off" }
+  | { mode: "explicit" }
+  | { mode: "broker"; ensure: { baseUrl: string; mount: string } }
+  | { mode: "local" };
+
+/** The frozen localhost rule (plan 2026-08-03-mcp-broker-provisioning): the
+    broker cannot forward visitors to a machine the internet cannot reach, so
+    the broker default is SKIPPED — silently; doctor explains — when the base
+    URL is unset, unparsable, or points at `localhost`, `127.0.0.1` (any
+    loopback), `::1`, `*.local`, or an RFC1918 address. Returns the base URL
+    when the broker can front it, undefined otherwise. */
+export function publicBaseUrl(baseUrl: string | undefined): string | undefined {
+  if (baseUrl === undefined) return undefined;
+  let hostname: string;
+  try {
+    hostname = new URL(baseUrl).hostname;
+  } catch {
+    return undefined;
+  }
+  // URL keeps IPv6 hostnames bracketed ("[::1]").
+  const host = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  if (host === "localhost" || host === "::1" || host.endsWith(".local")) return undefined;
+  if (isPrivateIpv4(host)) return undefined;
+  return baseUrl;
+}
+
+const isPrivateIpv4 = (host: string): boolean => {
+  const octets = host.split(".");
+  if (octets.length !== 4) return false;
+  const numbers = octets.map(Number);
+  if (numbers.some((value) => !Number.isInteger(value) || value < 0 || value > 255)) return false;
+  const [a, b] = numbers as [number, number, number, number];
+  return a === 127 || a === 10 || (a === 192 && b === 168) || (a === 172 && b >= 16 && b <= 31);
+};
+
+export function selectMcpBroker(
+  mcp: McpSeamConfig | undefined,
+  cloud: { apiKey: string } | undefined,
+  baseUrl: string | undefined,
+  mount: string,
+): McpBrokerSelection {
+  if (mcp === undefined) return { mode: "off" };
+  if (mcp.remoteAs !== undefined) return { mode: "explicit" };
+  const ensureBaseUrl = cloud === undefined ? undefined : publicBaseUrl(baseUrl);
+  if (ensureBaseUrl === undefined) return { mode: "local" };
+  return { mode: "broker", ensure: { baseUrl: ensureBaseUrl, mount } };
+}

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -2878,6 +2878,11 @@ export function createVendo(config: CreateVendoConfig): Vendo {
   // through a deps getter, so the ensure-failure degrade below reports what
   // actually composed.
   let mcpPosture: "local" | "broker" | false = false;
+  // The seam's selection, kept beside the posture for the dev-only
+  // /doctor/mcp probe (wire/doctor.ts): the posture collapses explicit
+  // `mcp.remoteAs` and the Cloud-managed broker into "broker", and doctor
+  // needs the distinction to never ensure a tenant for an explicit AS.
+  let mcpSelection: "off" | "explicit" | "broker" | "local" = "off";
   if (mcpOptions !== undefined) {
     if (oauthSeam === undefined) {
       throw new VendoError(
@@ -2953,6 +2958,7 @@ export function createVendo(config: CreateVendoConfig): Vendo {
     // are frozen in the provisioning plan.
     const mcpCloud = cloudKeyOptions();
     const selection = selectMcpBroker(mcpOptions, mcpCloud, doorBaseUrl, MCP_MOUNT);
+    mcpSelection = selection.mode;
     if (selection.mode === "broker" && mcpCloud !== undefined) {
       mcpPosture = "broker";
       // Boot-once, awaited: the first door construction rides the ready latch
@@ -3067,6 +3073,7 @@ export function createVendo(config: CreateVendoConfig): Vendo {
     model: inference.agent.venue,
     doctor,
     get mcp() { return mcpPosture; },
+    mcpSelection,
     development,
     sessions: {
       ttlMs: sessionsConfig.ttlMs,

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -182,6 +182,8 @@ import { cloudSandbox } from "./sandbox.js";
 // its own options instead of relying on the VENDO_API_KEY default.
 export { cloudSandbox, type CloudSandboxOptions } from "./sandbox.js";
 import { cloudApps } from "./cloud-apps.js";
+import { cloudMcpTenant } from "./cloud-mcp.js";
+import { selectMcpBroker } from "./mcp-broker-select.js";
 import { chainSecrets, cloudSecrets } from "./cloud-secrets.js";
 // The Cloud secrets provider and its chaining helper ride the server surface
 // like the other Cloud adapters: a host can compose them explicitly via
@@ -1646,10 +1648,18 @@ export function createVendo(config: CreateVendoConfig): Vendo {
   // background sweep together through this once-latch; on Node the first
   // request pays the same cost the old eager kick merely front-loaded.
   let startBackgroundSweep: () => void = () => undefined;
+  // Assigned at the door composition below when the broker arm of the mcp
+  // seam is selected: the ensure-tenant call rides this SAME boot-once latch
+  // as ensureSchema — an awaited compose step, resolved before the first
+  // request is served — never construction-time I/O (createVendo runs at
+  // module init in the edge wiring, where Workers forbids fetch).
+  let warmMcpBroker: (() => Promise<void>) | undefined;
   let readyState: Promise<void> | undefined;
   const ready = (): Promise<void> => {
     if (readyState === undefined) {
-      readyState = store.ensureSchema();
+      readyState = warmMcpBroker === undefined
+        ? store.ensureSchema()
+        : Promise.all([store.ensureSchema(), warmMcpBroker()]).then(() => undefined);
       // No unhandled rejection before a handler/emit awaits the latch.
       void readyState.catch(() => undefined);
       startBackgroundSweep();
@@ -2861,6 +2871,13 @@ export function createVendo(config: CreateVendoConfig): Vendo {
    */
   const turnCredentials: TurnCredentials = createTurnCredentials();
   let door: McpDoor | undefined;
+  // The /status posture for the mcp block (connections-posture pattern):
+  // false when the door is closed, "local" when it serves its own OAuth
+  // surface, "broker" when an external authorization server fronts it —
+  // ensured from the Cloud broker or explicitly configured. A `let` read
+  // through a deps getter, so the ensure-failure degrade below reports what
+  // actually composed.
+  let mcpPosture: "local" | "broker" | false = false;
   if (mcpOptions !== undefined) {
     if (oauthSeam === undefined) {
       throw new VendoError(
@@ -2894,7 +2911,10 @@ export function createVendo(config: CreateVendoConfig): Vendo {
     // (ENG-333). An explicit `mcp.baseUrl` overrides the env default for
     // compositions whose door origin differs from the route-binding origin.
     const doorBaseUrl = mcpOptions.baseUrl ?? configuredBaseUrl;
-    door = createMcpDoor({
+    const composeDoor = (
+      remoteAs = mcpOptions.remoteAs,
+      federation = mcpOptions.federation,
+    ): McpDoor => createMcpDoor({
       tools: boundTools,
       guard,
       store,
@@ -2921,16 +2941,63 @@ export function createVendo(config: CreateVendoConfig): Vendo {
       ...(doorBaseUrl === undefined ? {} : { baseUrl: doorBaseUrl }),
       // 10-mcp §3.1/§3.2 — broker-fronted compositions: trust the external
       // authorization server's tokens and answer its login federation.
-      ...(mcpOptions.remoteAs === undefined ? {} : { remoteAs: mcpOptions.remoteAs }),
-      ...(mcpOptions.federation === undefined ? {} : { federation: mcpOptions.federation }),
+      ...(remoteAs === undefined ? {} : { remoteAs }),
+      ...(federation === undefined ? {} : { federation }),
       ...(theme === undefined ? {} : { theme }),
     });
+    // ADAPTER RULE, mcp seam (selectMcpBroker — cloned from selectConnections
+    // above): explicit `mcp.remoteAs` wins verbatim; else VENDO_API_KEY plus a
+    // PUBLIC base URL default the hosted broker (an idempotent ensure-tenant
+    // call wires remoteAs + federation from the response); else the local
+    // door, byte-identical to today. The localhost rule and the ensure wire
+    // are frozen in the provisioning plan.
+    const mcpCloud = cloudKeyOptions();
+    const selection = selectMcpBroker(mcpOptions, mcpCloud, doorBaseUrl, MCP_MOUNT);
+    if (selection.mode === "broker" && mcpCloud !== undefined) {
+      mcpPosture = "broker";
+      // Boot-once, awaited: the first door construction rides the ready latch
+      // (warmMcpBroker above) so the trust anchor is resolved before the first
+      // request is served — and the wrapper below awaits the same latch, so a
+      // door request can never race a half-composed door.
+      let brokerDoor: Promise<McpDoor> | undefined;
+      const composeBrokerDoor = async (): Promise<McpDoor> => {
+        try {
+          const { tenant, federationSecret } = await cloudMcpTenant(mcpCloud).ensure(selection.ensure);
+          return composeDoor(
+            { issuer: tenant.issuer, audience: tenant.audience },
+            { secret: federationSecret },
+          );
+        } catch (error) {
+          // Same degrade posture as the hosted overrides fetch above: a
+          // console blip must not kill boot. Loud, once, then the local door
+          // for this composition's lifetime; the next boot re-ensures.
+          mcpPosture = "local";
+          console.warn(
+            "[vendo] hosted MCP broker ensure-tenant failed; the door serves its own local OAuth "
+            + `surface this boot: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          return composeDoor();
+        }
+      };
+      const doorReady = (): Promise<McpDoor> => (brokerDoor ??= composeBrokerDoor());
+      warmMcpBroker = async () => { await doorReady(); };
+      door = {
+        handler: async (request) => (await doorReady()).handler(request),
+        revokeClient: async (subject, clientId) => (await doorReady()).revokeClient(subject, clientId),
+      };
+    } else {
+      mcpPosture = selection.mode === "explicit" ? "broker" : "local";
+      door = composeDoor();
+    }
   } else if (internalDoorOnly) {
     // The INTERNAL half alone. It answers one live turn's credential and
     // nothing else, so it is handed only what that leg reads: the credential
     // registry and where it lives. No oauth (there is no space to sign into),
     // no apps ride-alongs, no `surfaces.mcp` menu, no theme — a turn's tools,
-    // curation and rendering are all decided by the turn.
+    // curation and rendering are all decided by the turn. The broker seam
+    // (selectMcpBroker above) never applies here: there is no outside OAuth
+    // surface for an external authorization server to front, so this half
+    // keeps `mcp: false` posture like any closed door.
     door = createMcpDoor({
       internal: true,
       tools: boundTools,
@@ -2999,7 +3066,7 @@ export function createVendo(config: CreateVendoConfig): Vendo {
     sandbox: sandbox.venue,
     model: inference.agent.venue,
     doctor,
-    mcp: mcpOptions !== undefined,
+    get mcp() { return mcpPosture; },
     development,
     sessions: {
       ttlMs: sessionsConfig.ttlMs,

--- a/packages/vendo/src/wire/doctor.ts
+++ b/packages/vendo/src/wire/doctor.ts
@@ -64,6 +64,14 @@ export const doctorRoutes: RouteEntry[] = [
     }
     return undefined;
   }),
+  // The broker seam's selection (selectMcpBroker) — a composition fact, no
+  // secret material; dev-only like every probe route below the gate. /status
+  // collapses an explicit `mcp.remoteAs` and the Cloud-managed broker into
+  // one "broker" posture; doctor reads this to keep the seam's explicit-wins
+  // precedence: only a confirmed "broker" selection may POST the tenant
+  // ensure (against an explicit AS the same call could provision or repoint
+  // an unrelated Cloud tenant).
+  route("GET", "/doctor/mcp", async ({ deps }) => json({ selection: deps.mcpSelection })),
   // execution-v2 Lane D — dev-only machine/schedule reporting (sits AFTER the
   // production gate above, like every probe route). Reporting only: which apps
   // carry a machine, whether a schedule caller (VENDO_TICK_SECRET) is

--- a/packages/vendo/src/wire/misc.ts
+++ b/packages/vendo/src/wire/misc.ts
@@ -192,8 +192,10 @@ export const statusRoutes: RouteEntry[] = [
         // Inference seam (cloud definition 2026-07-17): "custom" (host-passed
         // model) or "ladder" (the composed vendoModel env default).
         model: deps.model,
-        // 10-mcp §1 — the door is off by default; true only when
-        // createVendo({ mcp: true }) opened it.
+        // 10-mcp §1 + the broker seam (selectMcpBroker): false while the door
+        // is closed (it is off by default); "local" when the open door serves
+        // its own OAuth surface; "broker" when an external authorization
+        // server fronts it.
         mcp: deps.mcp,
         // 04-actions §3 — how per-user connected accounts are brokered:
         // "byo" (host's own Composio key), "cloud" (VENDO_API_KEY), or off.

--- a/packages/vendo/src/wire/shared.ts
+++ b/packages/vendo/src/wire/shared.ts
@@ -98,7 +98,10 @@ export interface WireDeps {
     present(ctx: RunContext): Promise<ToolOutcome>;
     actAs(): Promise<ToolOutcome>;
   };
-  mcp: boolean;
+  /** The mcp block's /status posture (connections-posture pattern): false
+      when the door is closed, "local" when it serves its own OAuth surface,
+      "broker" when an external authorization server fronts it. */
+  mcp: "local" | "broker" | false;
   door?: McpDoor;
   /** True only in a development composition — gates the local injection seams. */
   development: boolean;

--- a/packages/vendo/src/wire/shared.ts
+++ b/packages/vendo/src/wire/shared.ts
@@ -102,6 +102,13 @@ export interface WireDeps {
       when the door is closed, "local" when it serves its own OAuth surface,
       "broker" when an external authorization server fronts it. */
   mcp: "local" | "broker" | false;
+  /** The broker seam's selection as CHOSEN at composition (dev-only
+      /doctor/mcp probe): the /status posture above collapses an explicit
+      `mcp.remoteAs` and the Cloud-managed broker into one "broker", but
+      doctor must keep the seam's explicit-wins precedence — it never ensures
+      a tenant for an explicitly configured authorization server. Unlike the
+      posture this never degrades: it records what the seam chose. */
+  mcpSelection: "off" | "explicit" | "broker" | "local";
   door?: McpDoor;
   /** True only in a development composition — gates the local injection seams. */
   development: boolean;


### PR DESCRIPTION
Worker B of the MCP broker provisioning plan
(`docs/superpowers/plans/2026-08-03-mcp-broker-provisioning.md`, tasks B1–B4).
Consumes the plan's FROZEN WIRE CONTRACT exactly; Worker A implements the
server side (console route + broker endpoints) in vendo-web in parallel.

> **⚠️ Merge-order guard: this PR must NOT release to npm before the vendo-web
> console route (`POST /api/v1/mcp/tenant`) deploys.** The broker arm's ensure
> call degrades gracefully (loud warn, local door) against an old console, but
> releasing first would ship a default that cannot activate.

## What this does

A keyed host with `mcp` enabled, deployed to a public URL, automatically
fronts its MCP door with the hosted broker at `{slug}.mcp.vendo.run` — no
hand-run curl, no copied secret.

- **B1 — `cloudMcpTenant`** (`packages/vendo/src/cloud-mcp.ts`): the console
  ensure-tenant client, modeled line-for-line on `cloud-apps.ts` (shared
  `consoleSender` plumbing, 401/402 → `cloud-required`, wire-legal codes
  forwarded). Malformed-2xx → `not-implemented` (the knowledge client's
  server-shaped-failure posture). Test mocks are byte-precise to the frozen
  contract, including the `federationSecret`-on-every-200 amendment and the
  `disabled` tenant shape.
- **B2 — `selectMcpBroker`** (`mcp-broker-select.ts` + `server.ts`): the
  selection seam, ADAPTER RULE cloned from `selectConnections`. Precedence:
  explicit `mcp.remoteAs` verbatim (no ensure) → key + public base URL →
  ensured broker (`remoteAs` + `federation` wired from the response) → today's
  local door, byte-identical. The frozen localhost rule (unset / `localhost` /
  loopback / `::1` / `*.local` / RFC1918) skips the broker silently. The
  ensure rides the `ready()` boot-once latch — an awaited compose step,
  resolved before the first request, never construction-time I/O
  (Workers-safe) — and the door wrapper awaits the same latch so no request
  races a half-composed door. Ensure failure → one loud warn + local door
  (the hosted-config fetch degrade posture). A `disabled` tenant still
  composes `remoteAs` (the broker refuses traffic; the host stays
  consistent). `/status` `blocks.mcp` is now `"local" | "broker" | false`
  (connections-posture pattern).
- **B3 — doctor**: new `I-CLOUD-002` informational (key + open door + no
  public base URL → "the hosted MCP broker activates when the deployment has
  a public base URL"); with a public URL doctor resolves and prints the
  tenant the door composes against (new injectable `ensureTenant` seam,
  `npmLatest` pattern). `blocks.mcp` parsing accepts the new postures and
  legacy booleans. `CLOUD_UNLOCKS` truthfully names the hosted MCP broker
  again (it was removed in #739 because no code path delivered it — this
  seam does), with the deploy condition in the sentence.

## Testing

Every new test was verified to FAIL against pre-fix code. No pre-existing
test was modified; doctor tests live in a new file
(`cli/doctor-mcp-broker.test.ts`).

- `cloud-mcp.test.ts` (8): frozen-contract bytes, error table, malformed-2xx,
  disabled tenant, timeout.
- `mcp-broker-select.test.ts` (13): all selector arms; every frozen
  localhost-rule host shape; compose-level — ensure-once with exact request
  bytes, tenant-fronted discovery metadata, federation handshake landing with
  the ensured secret, degrade-on-ensure-failure (warn once, boot survives),
  disabled-tenant composition, explicit-wins with zero wire calls, silent
  localhost skip.
- `cli/doctor-mcp-broker.test.ts` (7): both informational arms, ensure seam
  call shape, failure stays informational, posture parsing, unlock copy.

Gates (foreground, full monorepo): `pnpm build` 23/23 ✓ · `pnpm test` 53/53 ✓
· `pnpm typecheck` 41/41 ✓ · `pnpm lint` 6/6 ✓. Changeset: `@vendoai/vendo`
minor. (One environmental note: this builder box had no swap and the kernel
OOM-killed a vitest worker on `server.test.ts` — reproduced identically on
clean main; adding swap fixed it and the full suite passes, 116/116 in that
file.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hosted MCP broker default. With `mcp` enabled, a `VENDO_API_KEY`, and a public `VENDO_BASE_URL`, the door fronts with `{slug}.mcp.vendo.run`. `/status` now reports `"local" | "broker" | false`. Doctor explains when the broker is skipped and resolves the advertised external AS in broker posture.

- **New Features**
  - `cloudMcpTenant`: client for `POST /api/v1/mcp/tenant` → `{ tenant, federationSecret }`. Maps 401/402 → `cloud-required`; malformed 2xx → `not-implemented`. Disabled tenants still return a secret.
  - `selectMcpBroker`: precedence is explicit `mcp.remoteAs` → ensured broker (key + public base URL) → local door. Private/localhost URLs skip the broker silently. Ensure runs once on the boot latch; failures warn once and fall back to local. `/status.blocks.mcp` is `"local" | "broker" | false`.
  - Doctor: adds `I-CLOUD-002` when the door is open but the base URL isn’t public; with a public URL, resolves and prints the broker tenant via an `ensureTenant` seam. Adds dev-only `/doctor/mcp` to report the seam’s selection; doctor only ensures when selection is `"broker"`.

- **Bug Fixes**
  - Exhaustive localhost rule: normalizes hostnames (IPv6 brackets, ALL trailing dots including percent-encoded, and IPv4-mapped IPv6) before private-host checks; public hosts remain public.
  - Broker posture checks: doctor now resolves the advertised external authorization server’s RFC 8414 metadata and fails clearly on garbage/404/unreachable; local posture still requires the door’s own AS document.
  - Explicit-wins ensure gate: avoids calling ensure against explicit `mcp.remoteAs` or older wires; skips conservatively with an explanatory note.

<sup>Written for commit 08cd1a06fa6c17d8ed72cb90b6587d209ddc96b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

