### PR TITLE
test: the suite tells the truth under load, and at the seams that broke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,12 @@ jobs:
       # --concurrency=4 bounds turbo's cross-package parallelism: unbounded
       # parallelism oversubscribes the runner's CPUs and flakes the
       # live-Next-server suites (see PR #340).
+      # --continue so ONE red package cannot hide every other package's result.
+      # Without it turbo cancels the rest of the graph on the first failure, and
+      # a run that reports "1 failing package" may be sitting on several — which
+      # is how a deterministic fixture breakage read as a shifting flake.
       - name: Test with coverage (PGlite + PostgreSQL)
-        run: pnpm exec turbo run test:coverage --concurrency=4
+        run: pnpm exec turbo run test:coverage --concurrency=4 --continue
         env:
           POSTGRES_URL: postgres://vendo:vendo@localhost:5432/vendo_test
       - run: pnpm typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,12 @@ dist
 .next/
 *.log
 
+# Next rewrites this on every dev/build boot to point at whichever distDir ran
+# last, so a tracked copy is dirty after every test run — over a hundred stashes
+# in this repo's history are named for exactly that churn. Every other Next app
+# here already leaves it untracked; fixtures/host-app was the lone exception.
+next-env.d.ts
+
 # misc
 corpus/.repos/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,3 +49,31 @@ generated UI in a sandboxed, brand-native surface.
   PR. Tests and typecheck alone don't count.
 - `pnpm build && pnpm test && pnpm typecheck && pnpm lint` must be green
   before any PR.
+
+## Tests
+
+- A harness that mocks the counterparty proves nothing. When a feature spans
+  a producer and a consumer, test the SEAM: write through the real write path
+  and read back through the real read path, with no stub on either side. The
+  host-component previews shipped four times with a green suite and a dead
+  feature because the producer and the consumer each mocked the other, so
+  they could never disagree. Anything this repo emits for `vendo-web` to read
+  (`.vendo/components/`, `vendo_*` collections, blob namespaces) is one of
+  those seams, and the console's copy of the schema is a mirror — see the
+  testing section of `vendo-web/AGENTS.md` for the full lesson.
+- Two suites must not share a directory that either of them deletes.
+  `next build` wipes its whole `distDir`, so a fixture dev server's dist dir
+  is a SIBLING of the build's, never a child. Nesting them took out all 36
+  `automations-e2e` tests on every full-suite run while each suite passed
+  alone, and which suite lost varied by scheduling — which read as flake.
+- A poll inside a test must not have a wall-clock budget tighter than the
+  test's own timeout. The test timeout is the hang-detector; a tighter inner
+  budget is a second, invisible speed limit that reports a product bug when
+  the machine is merely busy.
+- `pnpm test` runs turbo with `--continue` and `--concurrency=4`, the same
+  bound CI has used since #340. `--continue` so one red package never hides
+  every other package's result; the bound because unbounded parallelism runs
+  ~27 vitest workers at once on a 12-core laptop (load average ~150) and the
+  full-stack suites in `packages/vendo` then miss their 30s budget on work
+  that takes 5s alone. A timeout is a hang-detector; do not raise one to buy
+  headroom the machine never had.

--- a/fixtures/automations-e2e/src/schedule-extra.e2e.test.ts
+++ b/fixtures/automations-e2e/src/schedule-extra.e2e.test.ts
@@ -85,7 +85,13 @@ describe("schedule trigger extras", () => {
       clock = new Date("2026-07-12T00:00:02.000Z");
       const stop = stack.automations.start(20);
       try {
-        const deadline = Date.now() + 5_000;
+        // A poll inside a test must never have a budget TIGHTER than the test's
+        // own: this suite's testTimeout is 120s, and a 5s wall clock here was a
+        // second, invisible speed limit that would report "expected 0 to be 1"
+        // — a scheduler bug — for nothing worse than a busy machine. 60s keeps
+        // vitest's timeout the single hang-detector and costs a green run
+        // nothing (the timer fires in ~20ms when the box is idle).
+        const deadline = Date.now() + 60_000;
         while (Date.now() < deadline && (await runCount(stack, appId)) < 1) {
           await new Promise((resolve) => setTimeout(resolve, 25));
         }

--- a/fixtures/host-app/next-env.d.ts
+++ b/fixtures/host-app/next-env.d.ts
@@ -1,7 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/redteam-e2e/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/fixtures/host-app/next.config.mjs
+++ b/fixtures/host-app/next.config.mjs
@@ -2,7 +2,16 @@ const nextConfig = {
   // Next allows one dev server per dist dir. Concurrent consumers (the actions
   // fixture e2e and the automations e2e harness run in parallel under turbo)
   // each point FIXTURE_DIST_DIR at their own directory to get their own lock.
-  distDir: process.env.FIXTURE_DIST_DIR || ".next",
+  //
+  // The default is a SIBLING of those, never their parent. `next build` wipes
+  // its own distDir before writing, so a default of ".next" deleted
+  // ".next/automations-e2e" and friends out from under four running dev
+  // servers — every request after that returned 500, and because
+  // `@vendoai-fixtures/host-app#build` is not a dependency of the e2e packages
+  // turbo runs it right alongside them. That took out all 36
+  // automations-e2e tests on every full-suite run while each suite passed
+  // alone.
+  distDir: process.env.FIXTURE_DIST_DIR || ".next/app",
 };
 
 export default nextConfig;

--- a/fixtures/host-app/tsconfig.json
+++ b/fixtures/host-app/tsconfig.json
@@ -29,16 +29,27 @@
       ]
     }
   },
-  // One entry per generated type dir, not the twenty Next accreted here as each
-  // e2e suite invented its own FIXTURE_DIST_DIR. `.next/app` is the BUILD's dist
-  // dir (next.config.mjs); every `.next/<suite>` beside it belongs to an e2e
-  // suite's dev server.
+  // `.next/app` is the BUILD's dist dir (next.config.mjs); every `.next/<suite>`
+  // beside it belongs to one e2e suite's dev server. Next APPENDS the entry for
+  // whichever dist dir it just booted, so the full set is committed on purpose —
+  // trimming it only means the next test run dirties this file again. `exclude`
+  // below is what actually keeps them harmless.
   "include": [
     "next-env.d.ts",
     "src/**/*.ts",
     "src/**/*.tsx",
     ".next/app/types/**/*.ts",
-    ".next/app/dev/types/**/*.ts"
+    ".next/app/dev/types/**/*.ts",
+    ".next/actions-e2e/dev/types/**/*.ts",
+    ".next/actions-e2e/dev/dev/types/**/*.ts",
+    ".next/automations-e2e/dev/types/**/*.ts",
+    ".next/automations-e2e/dev/dev/types/**/*.ts",
+    ".next/integration-e2e/dev/types/**/*.ts",
+    ".next/integration-e2e/dev/dev/types/**/*.ts",
+    ".next/redteam-e2e/dev/types/**/*.ts",
+    ".next/redteam-e2e/dev/dev/types/**/*.ts",
+    ".next/mcp-e2e/dev/types/**/*.ts",
+    ".next/mcp-e2e/dev/dev/types/**/*.ts"
   ],
   // Dev-server type output is excluded on purpose. Next emits a `validator.ts`
   // there that references helpers it only defines in the dev type context, so

--- a/fixtures/host-app/tsconfig.json
+++ b/fixtures/host-app/tsconfig.json
@@ -50,7 +50,9 @@
     ".next/integration-browser/dev/dev/types/**/*.ts",
     ".next/integration-browser/types/**/*.ts",
     ".next/actions-e2e/dev/types/**/*.ts",
-    ".next/actions-e2e/dev/dev/types/**/*.ts"
+    ".next/actions-e2e/dev/dev/types/**/*.ts",
+    ".next/app/types/**/*.ts",
+    ".next/app/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/fixtures/host-app/tsconfig.json
+++ b/fixtures/host-app/tsconfig.json
@@ -29,32 +29,27 @@
       ]
     }
   },
+  // One entry per generated type dir, not the twenty Next accreted here as each
+  // e2e suite invented its own FIXTURE_DIST_DIR. `.next/app` is the BUILD's dist
+  // dir (next.config.mjs); every `.next/<suite>` beside it belongs to an e2e
+  // suite's dev server.
   "include": [
     "next-env.d.ts",
-    ".next/types/**/*.ts",
     "src/**/*.ts",
     "src/**/*.tsx",
-    ".next/dev/types/**/*.ts",
-    ".next/dev/dev/types/**/*.ts",
-    ".next-automations-e2e/dev/types/**/*.ts",
-    ".next-automations-e2e/dev/dev/types/**/*.ts",
-    ".next/automations-e2e/dev/types/**/*.ts",
-    ".next/automations-e2e/dev/dev/types/**/*.ts",
-    ".next/mcp-e2e/dev/types/**/*.ts",
-    ".next/mcp-e2e/dev/dev/types/**/*.ts",
-    ".next/redteam-e2e/dev/types/**/*.ts",
-    ".next/redteam-e2e/dev/dev/types/**/*.ts",
-    ".next/integration-e2e/dev/types/**/*.ts",
-    ".next/integration-e2e/dev/dev/types/**/*.ts",
-    ".next/integration-browser/dev/types/**/*.ts",
-    ".next/integration-browser/dev/dev/types/**/*.ts",
-    ".next/integration-browser/types/**/*.ts",
-    ".next/actions-e2e/dev/types/**/*.ts",
-    ".next/actions-e2e/dev/dev/types/**/*.ts",
     ".next/app/types/**/*.ts",
     ".next/app/dev/types/**/*.ts"
   ],
+  // Dev-server type output is excluded on purpose. Next emits a `validator.ts`
+  // there that references helpers it only defines in the dev type context, so
+  // `next build`'s TypeScript pass fails on a LEFTOVER one
+  // (`.next/integration-e2e/dev/types/validator.ts:181 Cannot find name
+  // 'IsExpected'`). That used to be invisible because the build wiped all of
+  // `.next` first — which is exactly the deletion that took out four running dev
+  // servers. Neither the build nor `pnpm typecheck` should depend on which dev
+  // server happened to run last.
   "exclude": [
-    "node_modules"
+    "node_modules",
+    ".next/*/dev/**"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "packageManager": "pnpm@11.10.0",
   "scripts": {
     "build": "turbo run build",
-    "test": "turbo run test",
+    "test": "turbo run test --continue --concurrency=4",
     "conformance": "turbo run conformance --filter=@vendoai/core --filter=@vendoai/store --filter=@vendoai/agent",
     "typecheck": "turbo run typecheck",
     "lint": "node scripts/dependency-guard.mjs && node scripts/portability-gate.mjs && turbo run lint",

--- a/packages/vendo/src/audit-superset.e2e.test.ts
+++ b/packages/vendo/src/audit-superset.e2e.test.ts
@@ -122,10 +122,22 @@ const transcript = async (vendo: Vendo): Promise<UIMessage[]> => {
  * mid-turn. Polled because the interactive `call()` blocks INSIDE the turn: the
  * approval only exists once the guard has parked it, which happens while this
  * request is still in flight.
+ *
+ * `turnFinished` is the stop condition, NOT a wall clock. This poll used to give
+ * up after 10s — a second, invisible speed limit inside a test whose own budget
+ * is 30s. Under full-suite contention the file takes ~62s and the turn is still
+ * legitimately in flight at 10s, so the poll rejected, the approval was never
+ * decided, the turn never returned, and the run reported an unhandled rejection
+ * plus a generic 30s timeout — none of which named the real cause. The turn
+ * cannot complete until the approval is decided, so "the turn finished and
+ * nothing was parked" is the only honest failure here; vitest's testTimeout stays
+ * the single hang-detector.
  */
-async function tapApprovalWhenItAppears(vendo: Vendo): Promise<string> {
-  const deadline = Date.now() + 10_000;
-  while (Date.now() < deadline) {
+async function tapApprovalWhenItAppears(
+  vendo: Vendo,
+  turnFinished: () => boolean,
+): Promise<string> {
+  while (!turnFinished()) {
     const listed = await vendo.handler(
       new Request("https://host.test/api/vendo/approvals", {
         headers: { "content-type": "application/json" },
@@ -148,7 +160,7 @@ async function tapApprovalWhenItAppears(vendo: Vendo): Promise<string> {
     }
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
-  throw new Error("no approval was ever parked for the write tool");
+  throw new Error("the turn finished and no approval was ever parked for the write tool");
 }
 
 interface TurnResult {
@@ -214,19 +226,31 @@ async function runTheTurn(): Promise<TurnResult> {
   vendo.actions.add(hostTools());
 
   // The turn and the tap race on purpose — that IS the interactive approval.
-  const tap = tapApprovalWhenItAppears(vendo);
-  const turn = await vendo.handler(
-    new Request("https://host.test/api/vendo/threads", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        threadId: THREAD,
-        message: { id: "m1", role: "user", parts: [{ type: "text", text: "pay Acme and check my reports" }] },
-      }),
+  // Awaited together so neither side's rejection can float: the tap used to be
+  // started bare, and when it gave up first its throw became an unhandled
+  // rejection that vitest reported instead of the actual failure.
+  let turnFinished = false;
+  const tap = tapApprovalWhenItAppears(vendo, () => turnFinished);
+  const [turn] = await Promise.all([
+    (async () => {
+      const response = await vendo.handler(
+        new Request("https://host.test/api/vendo/threads", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            threadId: THREAD,
+            message: { id: "m1", role: "user", parts: [{ type: "text", text: "pay Acme and check my reports" }] },
+          }),
+        }),
+      );
+      await response.text();
+      return response;
+    })().finally(() => {
+      turnFinished = true;
     }),
-  );
+    tap,
+  ]);
   expect(turn.status).toBe(200);
-  await turn.text();
   const approvalId = await tap;
 
   return { vendo, store, results, approvalId };


### PR DESCRIPTION
`pnpm test` could not pass on `main`. Not "flakily" — **never**. Three consecutive
runs failed identically, and because turbo cancels the graph on the first failure,
17 of 45 tasks never ran at all, so the report said "1 failing package" while
nobody knew about the rest.

## The empirical flake data

**`pnpm test` exactly as it shipped** (`turbo run test`), `origin/main` d0c3cc936,
12-core laptop, `--force` so nothing was cached:

| run | exit | wall | failing tests | tasks that ran |
| --- | --- | --- | --- | --- |
| 1 | 1 | 67s | 36 | 28 / 45 |
| 2 | 1 | 74s | 36 | 28 / 45 |
| 3 | 1 | 63s | 36 | 28 / 45 |

Failure rate **3/3**. Every failure was in `@vendoai-fixtures/automations-e2e`,
every one of them `Fixture reset failed (500)`, and the same suite passes **36/36
in 52s when run alone**. The short wall times are not good news — that is turbo
aborting.

**Same tree with `--continue`**, so nothing was hidden:

| run | wall | failing tests | failing tasks |
| --- | --- | --- | --- |
| 1 | 407s | 37 | `automations-e2e` (36) · `packages/vendo audit-superset.e2e` (1) · `host-app#build` |
| 2 | 350s | 36 | `automations-e2e` (36) · `host-app#build` |
| 3 | 375s | 38 | `automations-e2e` (36) · `demo-bank away-drill` (2) · `host-app#build` |

That is the shape that was reported as "1–3 tests fail, and the set changes":
**36 deterministic failures nobody could see past, plus 1–2 genuine
timing-sensitive ones behind them.**

## Root cause of the 36 — and of the shifting set

`fixtures/host-app` defaulted its `distDir` to `.next`. The four e2e suites that
boot it (`automations-e2e`, `integration`, `mcp-e2e`, `redteam`) each point
`FIXTURE_DIST_DIR` at `.next/<suite>` — **children of that default**, on purpose,
so gitignore rules that skip `.next` cover them.

`next build` wipes its whole `distDir` before writing. And
`@vendoai-fixtures/host-app#build` is not a dependency of those e2e packages, so
turbo schedules it **right alongside them**: the build deletes four live dev
servers' dist directories out from under them, and every request after that
returns 500.

The build says it out loud in the log nobody had read past:

```
@vendoai-fixtures/host-app:build: Error: ENOTEMPTY: directory not empty,
  rmdir '.../fixtures/host-app/.next/automations-e2e/dev/cache/turbopack'
```

Reproduced by hand: `POST /fixture/reset` → 200, run `next build`, `POST
/fixture/reset` → **500**. With the default moved to a *sibling* (`.next/app`),
reset stays **200**.

**Which suite loses the race depends on scheduling** — that is why the failing set
moved between runs. CI never saw any of it: CI runs `test:coverage`, a task
`host-app` does not have, so its build never enters that graph. The gate this
repo's CLAUDE.md tells you to run and the gate CI runs were different commands
with different results.

## What was fixed vs quarantined

**Nothing was skipped. Nothing was quarantined. No assertion was weakened. No
timeout was raised to buy headroom the machine never had.**

1. **`fixtures/host-app/next.config.mjs`** — the default `distDir` is
   `.next/app`, a sibling of the e2e dist dirs rather than their parent. Fixes
   all 36 plus the `host-app#build` failure.

2. **`packages/vendo/src/audit-superset.e2e.test.ts`** — a real defect, not just
   slowness. `tapApprovalWhenItAppears` polled against its own **10s** wall clock
   inside a test whose budget is **30s**. Under contention that file takes ~62s
   and the turn is still legitimately in flight at 10s, so the poll rejected, the
   approval was never decided, the turn never returned, and the run reported an
   *unhandled rejection* plus a *generic 30s timeout* — neither of which named the
   cause. The turn cannot complete until the approval is decided, so the turn's
   own completion is now the stop condition and vitest's `testTimeout` is the
   single hang-detector. Both promises are awaited together so neither side's
   rejection can float. Verified: 0 unhandled rejections in every run since.

3. **`fixtures/automations-e2e/src/schedule-extra.e2e.test.ts`** — same shape (a
   5s poll inside a 120s test, a 24× mismatch). Never observed failing; fixed
   because it is the same latent lie.

4. **`pnpm test` → `turbo run test --continue --concurrency=4`.** `--continue`
   so one red package can never hide every other package's result again.
   `--concurrency=4` is the bound CI has used since #340 for the documented
   reason; locally there was none, and unbounded the suite runs **~27 vitest
   workers at once on 12 cores — load average ~150**. `packages/vendo` alone is
   179 files that each compose a full stack over PGlite, and under that load its
   suites miss a 30s budget doing work that takes 5s alone. Measured, on the same
   tree at unbounded concurrency with other worktrees' suites co-resident: 799s /
   4 red files and 930s / 9 red files, **every single failure a 30s timeout, no
   deterministic failures at all**. CI's `test:coverage` gets `--continue` too.

5. **`fixtures/host-app/next-env.d.ts` untracked.** Next rewrites it on every dev
   or build boot to point at whichever `distDir` ran last, so a tracked copy is
   dirty after every test run. It was the only tracked copy in the repo — every
   other Next app here already ignores it — and **over a hundred stashes in this
   repository's history are literally named for that churn.**

### Timing-sensitive, understood, not touched

- `examples/demo-bank/src/vendo/away-drill.test.ts` and its `demo-accounting`
  twin (1 run in 3 each). They boot a real `next dev` and drive a full stack
  through it; under load the file takes 80s and a route answers 404 or the run
  reports `error`. Not a product bug and not a bad test — starvation. The
  concurrency bound is the fix; if they recur, that is the signal that something
  else is running.
- Under co-tenant load only (three other worktrees running full suites on the
  same box): `packages/vendo/{mcp-door-internal, mcp-door-parity,
  risk-provenance-wire, harness-wire, hosted-store, knowledge-resolution,
  law-read-verb-anywhere, wave3-integration}`, `packages/mcp/src/door.test.ts`,
  `packages/bench/src/demo-creator/quarantine.test.ts`. All 30s timeouts, none of
  them reproducible on a box that is not hosting other suites. **This machine
  cannot host four concurrent full suites; that is an ops rule, not a test fix.**

## Live-model tests

All 17 key-gated files already skip rather than fail, and **zero of them failed in
any of the runs above**. Gates, for the record:

`ANTHROPIC_API_KEY` — `packages/agent/src/live.test.ts`,
`packages/apps/src/engine.live.test.ts`, `packages/engine/src/engine.live.test.ts`,
`packages/guard/test/live/judge.live.test.ts`,
`packages/harnesses/src/claude-code/claude-code.live.test.ts`,
`packages/vendo/src/claude-code-composed.live.test.ts`,
`corpus/harness/src/knowledge-eval/judge.live.test.ts`,
`fixtures/automations-e2e/src/live-agentic.e2e.test.ts`.
`E2B_API_KEY` + `VENDO_LIVE_SANDBOX` — `packages/apps/src/e2b/e2b.live.test.ts`,
`packages/apps/src/e2b/secrets-egress.live.test.ts`.
`COMPOSIO_API_KEY` — `packages/actions/src/connectors/composio.live.test.ts`,
`packages/vendo/src/discovery-budget.live.test.ts`.
`VENDO_API_KEY` — `packages/vendo/src/sandbox.live.test.ts`,
`packages/vendo/src/orgs-materialize.live.test.ts`.
`VENDO_LIVE_MCP` — `fixtures/mcp-e2e/src/live-claude.e2e.test.ts`.
Others — `packages/harnesses/src/claude-code/claude-code-box.live.test.ts`,
`packages/vendo/src/cli/theme/extract-theme.live.test.ts`.

Six more files carry "live" in their name but need no key — `live` there names the
code under test (`liveTurn`, `turn-liveness`, the `doctor-live` module, the
`verifier-live` artifacts), not a live model.

## The seam tests

They are in the console: **runvendo/vendo-web#PENDING**. The producer half lives
here (`vendo sync` → `.vendo/components/`, the knowledge upsert door), so the
fixtures that PR reads are this repo's real capture output, copied verbatim out of
`examples/demo-accounting/.vendo/components/`. `CLAUDE.md` gains the short version
of the lesson and points at the long one.

## Before / after

| | runs | wall (mean) | red runs | failing tests |
| --- | --- | --- | --- | --- |
| before (`turbo run test`) | 3 | 68s (aborted) | **3 / 3** | 36, 36, 36 |
| before (`--continue`, nothing hidden) | 3 | 377s | **3 / 3** | 37, 36, 38 |
| after (`pnpm test`, uncached) | 3 | 409s | **0 / 3** | 0, 0, 0 |

Per-run, and the peak load column is the point: **all three went green while three
other worktrees were running full suites on the same 12-core box.**

| after run | exit | wall | tasks | failing tests | peak load avg |
| --- | --- | --- | --- | --- | --- |
| 1 | 0 | 458s | 55 / 55 | 0 | 133 |
| 2 | 0 | 363s | 55 / 55 | 0 | 121 |
| 3 | 0 | 406s | 55 / 55 | 0 | 98 |

## Gates

All green, on this branch:

| gate | result |
| --- | --- |
| `pnpm build` | ✅ (runs as `test`'s dependency — 55/55 tasks) |
| `pnpm test` | ✅ **3 / 3 uncached runs**, 55/55 tasks, 0 failing tests |
| `pnpm typecheck` | ✅ 43/43 tasks, uncached |
| `pnpm lint` | ✅ 6/6 tasks (dependency-guard + portability-gate + eslint) |
| working tree after a full build | ✅ clean |

Companion (the consumer half — the seam tests and the console's own two
findings): runvendo/vendo-web#260.

**Do not merge yet** — this wants your read on the two judgement calls: the
`--concurrency=4` bound on `pnpm test`, and untracking
`fixtures/host-app/next-env.d.ts`.
