### PR TITLE
fix(deps): floor brace-expansion, undici, fast-uri and ip-address for the 2026-08-03 advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,12 +6,17 @@ settings:
 
 overrides:
   '@types/react': ^19.2.0
-  fast-uri: '>=3.1.4'
+  fast-uri: '>=4.1.2'
   sharp: '>=0.35.0'
   next-auth: '>=5.0.0-beta.32'
   next: '>=16.2.11'
   '@types/react-dom': ^19.2.0
   postcss@<8.5.18: '>=8.5.18'
+  brace-expansion@<1.1.18: '>=1.1.18 <2'
+  brace-expansion@>=2 <2.1.3: '>=2.1.3 <3'
+  brace-expansion@>=4 <5.0.9: '>=5.0.9 <6'
+  undici@>=7 <7.29.0: '>=7.29.0 <8'
+  ip-address@>=10 <10.3.1: '>=10.3.1 <11'
 
 importers:
 
@@ -6478,15 +6483,15 @@ packages:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -7618,8 +7623,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -8165,8 +8170,8 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -11111,8 +11116,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicode-emoji-modifier-base@1.0.0:
@@ -16696,14 +16701,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -16968,16 +16973,16 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -17690,7 +17695,7 @@ snapshots:
       openapi-fetch: 0.14.1
       platform: 1.3.6
       tar: 7.5.20
-      undici: 7.28.0
+      undici: 7.29.0
 
   eastasianwidth@0.2.0: {}
 
@@ -18308,7 +18313,7 @@ snapshots:
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.4.0
 
   express@4.22.2:
     dependencies:
@@ -18431,7 +18436,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -19087,7 +19092,7 @@ snapshots:
 
   internmap@2.0.3: {}
 
-  ip-address@10.2.0: {}
+  ip-address@10.4.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -19401,7 +19406,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -19478,7 +19483,7 @@ snapshots:
       sprintf-js: 1.1.3
       sql.js: 1.14.1
       turndown: 7.2.4
-      undici: 7.28.0
+      undici: 7.29.0
       yaml: 2.9.0
     optionalDependencies:
       '@mongodb-js/zstd': 7.0.0
@@ -20442,7 +20447,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.3(@types/node@22.20.0)
-      undici: 7.28.0
+      undici: 7.29.0
       workerd: 1.20260714.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -20453,15 +20458,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.6: {}
 
@@ -22874,7 +22879,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,22 +54,21 @@ minimumReleaseAgeExclude:
   - '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.214'
   - '@anthropic-ai/claude-agent-sdk@0.3.214'
 
-# TEMPORARY (2026-07-24): brace-expansion unbounded-expansion DoS
-# GHSA-mh99-v99m-4gvg is ignored because its only patched version (5.0.8)
-# breaks CJS consumers at runtime (minimatch@3's `expand is not a function`
-# — verified empirically) and the 1.x/2.x lines have no backports yet. The
-# package only ever sees developer-authored glob patterns in this tree, never
-# untrusted input. REMOVE this ignore as soon as upstream backports land.
-auditConfig:
-  ignoreGhsas:
-    - GHSA-mh99-v99m-4gvg
+# The 2026-07-24 GHSA-mh99-v99m-4gvg ignore is GONE (2026-08-03): the 1.x/2.x
+# backports it was waiting on landed (1.1.17, 2.1.3), so the advisory is fixed
+# by the per-line brace-expansion floors below instead of masked.
 
 # pnpm 11 no longer reads the `pnpm` field in package.json; overrides live here.
 overrides:
   "@types/react": "^19.2.0"
   # Security floors (2026-07-21 advisories): fast-uri GHSA-v2hh-gcrm-f6hx,
   # sharp/libvips GHSA-f88m-g3jw-g9cj — both reach us only via examples/demos.
-  "fast-uri": ">=3.1.4"
+  # fast-uri floor raised 3.1.4 -> 4.1.2 for the 2026-08-03 host-confusion
+  # advisory GHSA-7p8r-x3mc-p8w7 (>=4.0.0 <4.1.2). This entry was already an
+  # unbounded global floor, so every consumer (ajv, ajv-formats) was resolving
+  # to the same 4.1.1 anyway — raising the floor moves that single version to
+  # the patched one rather than widening the override's reach.
+  "fast-uri": ">=4.1.2"
   "sharp": ">=0.35.0"
   # 2026-07-23 advisories: Auth.js fail-open + email-normalizer criticals
   # (via demo-bank), Next.js App Router middleware-bypass + DoS highs
@@ -80,3 +79,35 @@ overrides:
   # 2026-07-24 advisory: PostCSS path traversal in previous source map,
   # GHSA-r28c-9q8g-f849 (<=8.5.17) — floor raised from the earlier 8.5.10 line.
   "postcss@<8.5.18": ">=8.5.18"
+  # 2026-08-03 advisory: brace-expansion DoS via unbounded intermediate arrays
+  # bypassing the CVE-2026-14257 mitigation, GHSA-rgw5-rvv9-x895 (<1.1.18 and
+  # >=4.0.0 <5.0.9). Reaches the prod graph only transitively, through every
+  # minimatch line at once: e2b>glob>minimatch@10 (demo-bank's sandbox),
+  # mastra>archiver>readdir-glob>minimatch@9, mastra>serve-handler>minimatch@3.
+  #
+  # Floored PER MAJOR LINE, not globally, because brace-expansion 5.x is
+  # ESM-first and swapping it under minimatch@3 breaks that CJS consumer at
+  # runtime (`expand is not a function`). The 1.x/2.x floors are the upstream
+  # backports, which stay plain-CJS. These also close the older
+  # GHSA-mh99-v99m-4gvg (>=1.1.17 / >=2.1.3 / >=5.0.8), whose ignore entry is
+  # deleted above — 2.x is pinned solely to satisfy that older advisory, since
+  # the tree's 2.1.2 predates its backport.
+  # Both sides of each pair are bounded on purpose: an unbounded ">=1.1.18"
+  # right-hand side resolves to the newest brace-expansion overall (5.x), which
+  # is precisely the cross-major swap that breaks minimatch@3 — verified.
+  "brace-expansion@<1.1.18": ">=1.1.18 <2"
+  "brace-expansion@>=2 <2.1.3": ">=2.1.3 <3"
+  "brace-expansion@>=4 <5.0.9": ">=5.0.9 <6"
+  # 2026-08-03 advisory: undici cross-user information disclosure + parse-time
+  # crash via degenerate private cache directives, GHSA-4cwx-7wf7-3272
+  # (>=7.0.0 <7.29.0). Scoped to the 7.x line (the only one in the tree, via
+  # demo-bank>e2b and genui-bench>@copilotkit/runtime>vitest>jsdom) so a 6.x
+  # consumer would not be dragged across a major.
+  "undici@>=7 <7.29.0": ">=7.29.0 <8"
+  # 2026-08-03 advisory: ip-address parses leading-zero octets as decimal while
+  # resolvers read them as octal, giving an SSRF / trust-boundary bypass,
+  # GHSA-mwp4-54f8-5fhr (<=10.3.0). Reaches prod only through
+  # mastra>@modelcontextprotocol/sdk>express-rate-limit. Left side scoped to the
+  # 10.x line that is actually installed rather than the advisory's open-ended
+  # "<=10.3.0", so a hypothetical 9.x consumer is not dragged across a major.
+  "ip-address@>=10 <10.3.1": ">=10.3.1 <11"


### PR DESCRIPTION
## What

Unblocks the repo-wide `audit` CI job. `main`'s own CI at d0c3cc936 fails this job, so this is not caused by any open PR — it unblocks **every** open PR rather than one.

## Why it appeared

No new dependency was added. A wave of advisories published on 2026-08-03 landed against packages that were *already* in the production graph transitively, so a previously-green tree went red without a single line of source changing.

Four distinct HIGH findings, all confirmed by running the exact gate command (`pnpm audit --prod --audit-level high`) — plus a fifth (`ip-address`) that was published mid-session, between two audit runs minutes apart:

| Package | Advisory | Vulnerable | Patched | Reaches prod via |
|---|---|---|---|---|
| `brace-expansion` | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) | `>=4.0.0 <5.0.9` | `>=5.0.9` | `demo-bank>e2b>glob>minimatch`, `mastra-agent>mastra>archiver>readdir-glob>minimatch` |
| `brace-expansion` | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) | `<1.1.18` | `>=1.1.18` | `mastra-agent>mastra>serve>serve-handler>minimatch`, `mastra-agent>mastra>serve-handler>minimatch` |
| `undici` | [GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272) | `>=7.0.0 <7.29.0` | `>=7.29.0` | `demo-bank>e2b`, `genui-bench>@copilotkit/runtime>…>vitest>jsdom` |
| `fast-uri` | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) | `>=4.0.0 <4.1.2` | `>=4.1.2` | `mastra-agent>…>ajv` (100 paths) |
| `ip-address` | [GHSA-mwp4-54f8-5fhr](https://github.com/advisories/GHSA-mwp4-54f8-5fhr) | `<=10.3.0` | `>=10.3.1` | `mastra-agent>…>@modelcontextprotocol/sdk>express-rate-limit` (25 paths) |

`ip-address@10.2.0` is byte-identical on `main` and on this branch and is untouched by this diff — it is the same class of problem (new advisory, pre-existing dep) and fails the same gate, so it is fixed here rather than left to red the next run.

Note: overrides live in `pnpm-workspace.yaml`, not the `pnpm` field in `package.json` — pnpm 11 no longer reads the latter.

## The overrides, and why each is scoped that way

**Both sides of every pair are bounded.** This is the load-bearing detail. An unbounded right-hand side like `">=1.1.18"` resolves to the newest `brace-expansion` *overall* (5.x), not the newest 1.x — verified empirically here: a first attempt with unbounded right sides silently pulled `minimatch@3` onto `brace-expansion@5` and dragged `undici` from 7.28.0 to **8.9.0**, a major bump. That cross-major swap is exactly what the deleted `GHSA-mh99-v99m-4gvg` ignore existed to avoid (`brace-expansion@5` is ESM-first; `minimatch@3` does `require('brace-expansion')` and calls the result, getting `expand is not a function`).

```yaml
"brace-expansion@<1.1.18":      ">=1.1.18 <2"
"brace-expansion@>=2 <2.1.3":   ">=2.1.3 <3"
"brace-expansion@>=4 <5.0.9":   ">=5.0.9 <6"
"undici@>=7 <7.29.0":           ">=7.29.0 <8"
"ip-address@>=10 <10.3.1":      ">=10.3.1 <11"
"fast-uri":                     ">=4.1.2"   # was ">=3.1.4"
```

- **`brace-expansion` — floored per major line, not globally.** A single global pin is what breaks `minimatch@3`. The 1.x/2.x floors are upstream backports that stay plain-CJS. Verified after install: `minimatch@3.1.5` links to `brace-expansion@1.1.18`, and `require()` of both the 1.1.18 and 2.1.4 artifacts returns a callable function (`expand('a{b,c}')` → `["ab","ac"]`).
- **`brace-expansion@>=2 <2.1.3`** is pinned solely to satisfy the *older* advisory, since the tree's 2.1.2 predates its backport. It is not required by GHSA-rgw5-rvv9-x895.
- **`undici` / `ip-address`** — left side scoped to the single major actually installed, so a hypothetical 6.x / 9.x consumer is not dragged across a major.
- **`fast-uri`** — this entry was *already* an unbounded global floor, so every consumer was resolving to the same 4.1.1 anyway. Raising the floor moves that one version to the patched one rather than widening the override's reach; adding a second scoped entry beside it would be redundant.

### The `GHSA-mh99-v99m-4gvg` ignore is deleted

That ignore was added 2026-07-24 with an explicit instruction in its own comment: *"REMOVE this ignore as soon as upstream backports land."* They have landed (1.1.17, 2.1.3, 3.0.3, 5.0.8). The advisory is now **fixed** by the floors above instead of masked, so the mask comes out. The gate's `(2 ignored)` suffix is gone and nothing needs suppressing.

## Gate output

**Before** (at `main`, d0c3cc936):
```
13 vulnerabilities found
Severity: 1 low | 6 moderate | 6 high (2 ignored)
exit 1
```

**After:**
```
6 vulnerabilities found
Severity: 1 low | 5 moderate
exit 0
```

## Proof nothing broke

Real exit codes, no `tail` swallowing them:

| Gate | Exit |
|---|---|
| `pnpm build` | **0** — 24/24 |
| `pnpm typecheck` | **0** — 43/43 |
| `pnpm lint` | **0** — dependency-guard + portability-gate + 6/6 |
| `pnpm audit --prod --audit-level high` | **0** |

Tests were run at `--concurrency=2`. The packages that actually consume the overridden deps were **force-executed with 0 cached**, and all pass:

- `demo-bank` (e2b → glob/minimatch/brace-expansion, undici) — 110/110
- `@vendoai-examples/mastra-agent` (mastra → archiver + serve-handler → minimatch/brace-expansion; fast-uri; ip-address) — 5/5
- `genui-bench` (undici via jsdom) — 122/122
- `demo-accounting` — 156 passed, `ai-sdk-agent` — 3 passed
- Total: 23/23 tasks successful

Seven tests do fail locally (`@vendoai/core` packaging ×3, `@vendoai/store` drills ×2, `@vendoai/vendo` dev-creds ×2). **All seven fail identically on a pristine `origin/main` checkout at d0c3cc936** — verified by switching this same worktree to detached `main`, reinstalling `--frozen-lockfile`, and re-running them. The cause is environmental and unrelated: this worktree sits under a path containing a space (`Cool Code`), and the errors literally carry the encoded form, e.g. `Cannot find module '/…/Cool%20Code/…/drill-writer.mjs'`. CI's checkout path has no space. Nothing was skipped or modified to make them pass; no test file is touched by this PR.

## Changeset

**None needed.** No published package's dependencies changed — the diff is confined to `pnpm-workspace.yaml` and `pnpm-lock.yaml`, no `package.json` is touched, and no `packages/*` package declares any of the four overridden deps (they are transitive, reaching only `examples/` and `tools/`). Nothing in the published surface changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Floors vulnerable transitive dependencies to patched versions to resolve the 2026-08-03 advisories and make the audit CI pass. Removes the temporary `GHSA-mh99-v99m-4gvg` ignore now that backports are available.

- **Dependencies**
  - `brace-expansion`: per-major floors to avoid CJS/ESM breakage and fix `GHSA-rgw5-rvv9-x895` (also closes the older advisory without ignores):
    - `<1.1.18` → `>=1.1.18 <2`, `>=2 <2.1.3` → `>=2.1.3 <3`, `>=4 <5.0.9` → `>=5.0.9 <6`
  - `undici`: `>=7 <7.29.0` → `>=7.29.0 <8` for `GHSA-4cwx-7wf7-3272`
  - `fast-uri`: global floor `>=4.1.2` for `GHSA-7p8r-x3mc-p8w7`
  - `ip-address`: `>=10 <10.3.1` → `>=10.3.1 <11` for `GHSA-mwp4-54f8-5fhr`
  - Overrides live in `pnpm-workspace.yaml`; only that and `pnpm-lock.yaml` changed. Audit gate now passes.

<sup>Written for commit 3c02e4a0f9d16586fa99a1b4c8a7a14e74937cdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

