### PR TITLE
fix(mcp): a tool nobody graded is not a tool the door can call safe

### DIFF
--- a/.changeset/mcp-ungraded-asserts-nothing.md
+++ b/.changeset/mcp-ungraded-asserts-nothing.md
@@ -1,0 +1,27 @@
+---
+"@vendoai/mcp": patch
+---
+
+The MCP door no longer tells a client a tool is non-destructive when nobody has
+graded it.
+
+Every listing carried `readOnlyHint` and `destructiveHint` derived from the
+tool's risk label, and `ungraded` fell through to the same pair a `write` gets:
+`readOnlyHint: false`, `destructiveHint: false`. MCP's own default for
+`destructiveHint` is **`true`** — absent means "assume destructive" — so
+emitting `false` was not a neutral value, it was an active claim of safety about
+a tool no human, no judge, and no protocol fact had ever judged. That is exactly
+the guess the risk-grading redesign deleted everywhere else, still being made on
+the wire.
+
+An `ungraded` tool now asserts neither hint. They are omitted, and the client
+falls back to the spec's own conservative defaults. `destructiveHint: true`
+would have been the opposite guess and just as unfounded; `readOnlyHint: false`
+claims "this modifies its environment", which is equally unknown. The door says
+nothing it cannot support, and `title` still rides along. Grade the tool
+(`vendo sync`, the judge, or `.vendo/overrides.json`) and the hints come back.
+
+`read`, `write`, and `destructive` listings are byte-for-byte unchanged. Both
+surfaces that build MCP tools — the OAuth listing an outside agent sees and the
+live-turn listing a `claudeCode()` box reads — share the one helper, so they
+cannot drift.

--- a/docs-site/capabilities/mcp.mdx
+++ b/docs-site/capabilities/mcp.mdx
@@ -168,6 +168,13 @@ so a client can warn a person before a write without re-reading prose:
 | `read` | `true` | `false` |
 | `write` | `false` | `false` |
 | `destructive` | `false` | `true` |
+| `ungraded` | *omitted* | *omitted* |
+
+An `ungraded` tool asserts neither hint. MCP's own default for
+`destructiveHint` is `true`, so emitting `false` would be an active claim of
+safety about a tool nobody has graded — and `true` would be the opposite guess.
+Omitting them leaves the client on the spec's conservative defaults. Grade the
+tool (`vendo sync`, or `.vendo/overrides.json`) and the hints appear.
 
 Annotations are hints for presentation. The guard is what decides.
 

--- a/examples/demo-bank/scripts/assert-curated-mcp-menu.mjs
+++ b/examples/demo-bank/scripts/assert-curated-mcp-menu.mjs
@@ -44,7 +44,12 @@ const expectedTitles = Object.fromEntries(
   expected.map((name) => [name, overrides.tools?.[name]?.title]),
 );
 const extracted = JSON.parse(await readFile(`${appDir}/.vendo/tools.json`, "utf8"));
-const riskByName = Object.fromEntries(extracted.tools.map((tool) => [tool.name, tool.risk]));
+// The MERGED risk, the way the registry's mergeOverride resolves it — an
+// override's `risk` is what the door annotates from, so reading tools.json
+// alone measures a grade the wire never carried.
+const riskByName = Object.fromEntries(
+  extracted.tools.map((tool) => [tool.name, overrides.tools?.[tool.name]?.risk ?? tool.risk]),
+);
 
 // ---- earn a bearer over the door's real OAuth wire ---------------------------
 const cookie = `${COOKIE_NAME}=${await encode({
@@ -178,8 +183,11 @@ for (const tool of hostTools) {
   if (title && tool.title !== title) problems.push(`${tool.name}: title "${tool.title}" != "${title}"`);
   if (title && tool.annotations?.title !== title) problems.push(`${tool.name}: annotations.title missing`);
   const risk = riskByName[tool.name];
-  const readOnly = risk === "read";
-  const destructive = risk === "destructive";
+  // An `ungraded` tool asserts NEITHER hint: MCP's default for
+  // `destructiveHint` is `true`, so `false` would claim safety about a tool
+  // nobody graded. Absent is the answer, and this measures that it is absent.
+  const readOnly = risk === "ungraded" ? undefined : risk === "read";
+  const destructive = risk === "ungraded" ? undefined : risk === "destructive";
   if (tool.annotations?.readOnlyHint !== readOnly) problems.push(`${tool.name}: readOnlyHint != ${readOnly} (risk ${risk})`);
   if (tool.annotations?.destructiveHint !== destructive) problems.push(`${tool.name}: destructiveHint != ${destructive} (risk ${risk})`);
 }

--- a/packages/mcp/src/door.test.ts
+++ b/packages/mcp/src/door.test.ts
@@ -1849,6 +1849,25 @@ describe("createMcpDoor tool menu, titles, and annotations", () => {
     await connected.client.close();
   });
 
+  it("says nothing about a tool NOBODY graded — an ungraded listing carries neither hint", async () => {
+    const { connected } = await open({
+      extraDescriptors: [
+        { name: "host_maybe", description: "Nobody graded this", inputSchema: { type: "object" }, risk: "ungraded" as const, title: "Maybe" },
+        { name: "host_unknown", description: "Nobody graded this either", inputSchema: { type: "object" }, risk: "ungraded" as const },
+      ],
+    });
+    const listed = await connected.client.listTools();
+    const byName = new Map(listed.tools.map((tool) => [tool.name, tool]));
+
+    // MCP's default for `destructiveHint` is TRUE, so emitting `false` was an
+    // active claim of safety about a tool nobody judged — and `true` would be
+    // the opposite guess. Omitted, the client keeps its own conservative
+    // default. `readOnlyHint: false` is the same unfounded claim, so it goes too.
+    expect(byName.get("host_maybe")?.annotations).toEqual({ title: "Maybe" });
+    expect(byName.get("host_unknown")?.annotations).toEqual({});
+    await connected.client.close();
+  });
+
   it("treats an empty title as no title (generated files can carry one; the wire must not)", async () => {
     const { connected } = await open({
       extraDescriptors: [
@@ -2886,6 +2905,39 @@ describe("createMcpDoor turn-credential results", () => {
     // The listing is not consulted by the call path at all — which is the fix:
     // it ran AFTER the write, unguarded.
     expect(lists.length).toBe(1);
+    await connected.client.close();
+  });
+
+  it("grades the LIVE-TURN listing by the same rule — ungraded says nothing there either", async () => {
+    // The turn surface is a second place that builds MCP `Tool` objects, so a
+    // claim deleted from the OAuth listing has to be deleted here too or the two
+    // drift and a claudeCode() box reads the guess the outside agent no longer does.
+    const harness = makeHarness({
+      turnCredentials: {
+        async resolve(token) {
+          if (token !== TOKEN) return null;
+          const turn = liveTurn("x", () => {});
+          return {
+            ...turn,
+            tools: {
+              ...turn.tools,
+              list: async () => [
+                { name: "host_lookup", description: "Look something up", risk: "read" as const, inputSchema: { type: "object", properties: {} } },
+                { name: "host_wipe", description: "Delete everything", risk: "destructive" as const, inputSchema: { type: "object", properties: {} } },
+                { name: "host_maybe", description: "Nobody graded this", risk: "ungraded" as const, inputSchema: { type: "object", properties: {} } },
+              ],
+            },
+          };
+        },
+      },
+    });
+    const connected = await connect(harness.door, TOKEN);
+    const listed = await connected.client.listTools();
+    const byName = new Map(listed.tools.map((tool) => [tool.name, tool]));
+
+    expect(byName.get("host_lookup")?.annotations).toEqual({ readOnlyHint: true, destructiveHint: false });
+    expect(byName.get("host_wipe")?.annotations).toEqual({ readOnlyHint: false, destructiveHint: true });
+    expect(byName.get("host_maybe")?.annotations).toEqual({});
     await connected.client.close();
   });
 

--- a/packages/mcp/src/door.ts
+++ b/packages/mcp/src/door.ts
@@ -1336,12 +1336,19 @@ function offeredAtDoor(menu: Set<string> | undefined, name: string): boolean {
  * rides along here too — the spec moved it to a top-level field, but clients
  * that predate that move still read `annotations.title`, so the door emits
  * both and neither can drift from the other.
+ *
+ * `ungraded` asserts NEITHER hint. MCP's own default for `destructiveHint` is
+ * `true`, so emitting `false` was an active claim of safety about a tool nobody
+ * judged — the exact guess the risk-grading redesign deleted everywhere else.
+ * `true` would be the opposite guess and just as unfounded, and `readOnlyHint:
+ * false` claims "modifies its environment", also unknown. Omitted, the client
+ * falls back to the spec's own conservative defaults and the door says nothing
+ * it cannot support.
  */
 function toolAnnotations(risk: RiskLabel, title?: string): NonNullable<Tool["annotations"]> {
   return {
     ...(title === undefined ? {} : { title }),
-    readOnlyHint: risk === "read",
-    destructiveHint: risk === "destructive",
+    ...(risk === "ungraded" ? {} : { readOnlyHint: risk === "read", destructiveHint: risk === "destructive" }),
   };
 }
 


### PR DESCRIPTION
The MCP door told clients a tool was non-destructive when nobody had graded it.

## The annotation table

`packages/mcp/src/door.ts`'s `toolAnnotations` is the single helper every MCP
`Tool` object goes through. It derived two hints from the one risk label:

| `risk` | before `readOnlyHint` | before `destructiveHint` | after `readOnlyHint` | after `destructiveHint` |
| --- | --- | --- | --- | --- |
| `read` | `true` | `false` | `true` | `false` |
| `write` | `false` | `false` | `false` | `false` |
| `destructive` | `false` | `true` | `false` | `true` |
| `ungraded` | `false` | `false` | *omitted* | *omitted* |

`title` still rides along in `annotations` unchanged (older clients read it
there), so an untitled `ungraded` tool now carries `annotations: {}` and a
titled one carries `{ title }` alone. `read`, `write` and `destructive` are
byte-for-byte what they were.

## Why omitting beats guessing in either direction

MCP's spec default for `destructiveHint` is **`true`** — an absent hint means
"assume this destroys something". So `destructiveHint: false` was never a
neutral value. It was an active claim of safety, made about a tool that no
human (`overrides.json`), no AI judge, and no protocol fact had ever judged.
That is precisely the guess #747 (`feat(guard)!: risk grading stops guessing
from names; ungraded asks; critical → confirmEach`) deleted everywhere else:
`ungraded` became a first-class ask-by-default state and THE LAW withholds it
from unattended runs. The wire kept making it.

`destructiveHint: true` would be the opposite guess and just as unfounded — the
door does not know the tool is destructive either, it knows nothing. Omitted,
the client falls back to the spec's own conservative default and the door
asserts only what it can support.

`readOnlyHint` gets the same treatment for the same reason: `false` claims
"this tool modifies its environment", which is equally unknown. It happens to
coincide with the spec default, but leaving it in while dropping the other
would say the door knows half a thing about a tool it knows nothing about.

## One place, two surfaces

There are two call sites that build MCP `Tool` objects, and the second is new:

- `#listedTools` — the outside-agent / OAuth surface.
- `turnTools` — the live-turn surface a `claudeCode()` box reads over native
  remote MCP, **added by #770**. So this claim now shipped on both.

(Plus `appTools` for the `vendo_apps_*` ride-alongs.) All three already shared
`toolAnnotations`, so the fix is one expression and the surfaces cannot drift.

## Tests

Both go through the real `@modelcontextprotocol/sdk` client, the way the
existing door tests do, and both **fail against current `main`**:

1. `createMcpDoor tool menu, titles, and annotations > says nothing about a tool
   NOBODY graded` — pre-fix: `expected { title: 'Maybe', destructiveHint: false,
   readOnlyHint: false } to deeply equal { title: 'Maybe' }`.
2. `createMcpDoor turn-credential results > grades the LIVE-TURN listing by the
   same rule` — pre-fix: `expected { readOnlyHint: false, destructiveHint: false
   } to deeply equal {}`. Its `read` and `destructive` assertions passed pre-fix
   and still pass, which is the "nothing else moved" half. The turn surface had
   **no** annotation coverage at all before this.

## An existing assertion of the defect

`examples/demo-bank/scripts/assert-curated-mcp-menu.mjs` is the attended proof
that Maple's curated door matches its authored files. It asserted
`destructiveHint === false` and `readOnlyHint === false` for every tool it
graded as neither `read` nor `destructive` — and 11 of Maple's 12 curated tools
are `"risk": "ungraded"` in `.vendo/tools.json`. It was asserting the defect;
corrected to expect both hints absent.

While there: the script built its risk map from `.vendo/tools.json` alone,
ignoring `overrides.json`'s `tools[*].risk`, while the door annotates from the
**merged** risk. `host_transferMoney` is `ungraded` in `tools.json` and
`"destructive"` in `overrides.json`, so the script was already demanding
`destructiveHint: false` for a tool the door correctly marks `true`. It now
merges the override, the way `mergeOverride` does.

`docs-site/capabilities/mcp.mdx` publishes this exact table; it gains the
`ungraded` row and the reason.

## Other risk-derived claims, swept

Grepped the repo for `destructiveHint` / `readOnlyHint` / `annotations` and for
every branch over `RiskLabel`. `toolAnnotations` is the only place that *emits*
MCP annotations. Found but **not** fixed here (different defects, each worth its
own change):

- `packages/actions/src/connectors/mcp.ts:250` grades an **upstream** MCP tool
  with no hints as `"write"`, where `composio-risk.ts` (updated by #747) returns
  `"ungraded"` for the same situation. Inbound grading, not an outbound claim.
- `packages/ui/src/chrome/approval-card.tsx:97`, `waiting-queue.tsx:23`,
  `voice/voice-consent.tsx:30`, `voice/stage.tsx:103` — the ceremony picker tests
  `risk === "destructive"`, so `ungraded` gets the low-ceremony presentation even
  though the guard treats it like `destructive`. The chip copy is honest ("Not
  reviewed"); only the visual ceremony lumps it with `write`.
- `packages/ui/src/chrome/thread/parts.tsx:165,574`, `thread/index.tsx:381`,
  `build-beat.tsx:121` — an absent/unparseable wire risk defaults to `"read"`,
  rendering a positive "Read-only" claim.
- `packages/apps/src/generation/validation/smoke-render.ts:73` — `isMutating`
  omits `ungraded`, so smoke validation feeds it a success payload where the
  runtime will park it.
- `packages/vendo/src/cli/try/extract.ts:125` — deliberately writes
  `risk: "read"` into `overrides.json` for `ungraded` GETs under `npx vendo try`.
  Reasoned in-place, but a `try` scaffold carried into a real host reintroduces
  the claim this PR removes.

## Verify

Real exit codes, on this branch:

```
pnpm build                          BUILD_EXIT=0     (24/24 tasks)
pnpm typecheck                      TYPECHECK_EXIT=0 (43/43 tasks)
pnpm lint                           LINT_EXIT=0      (6/6 tasks)
npx turbo run test --concurrency=2  1 pre-existing failure, below
@vendoai/mcp test                   Test Files 2 passed (2)
```

`@vendoai/mcp` was rebuilt before every `vendo` run (vendo resolves it from
`dist`).

Two runs of the full suite produced **different** failing sets, all of them in
the real-server fixture e2e suites, exactly the documented flake:

- Run 1: `vendo/src/cli/telemetry-exit.test.ts` and
  `vendo/src/config-consolidation.test.ts` — both pass standalone.
- Run 2: `fixtures/integration/src/away-park-revoke.e2e.test.ts` — re-run
  standalone `INTEGRATION_EXIT=0`, `Test Files 19 passed | 1 skipped (20)`.

One stable failure remains, and it is **pre-existing on `main`**:
`packages/vendo/src/dev-creds/model.test.ts`, 2 tests in "provider module
resolution", failing on `@ai-sdk/anthropic` self-resolution from a temp fixture
root. Checked out pristine `origin/main` (`4515c7f74`) in this same worktree and
ran that file: `MAIN_DEVCREDS_EXIT=1`, the identical 2 tests. Nothing in this
diff touches `packages/vendo/`, and that test file imports no Vendo package this
PR changes.

Changeset: `.changeset/mcp-ungraded-asserts-nothing.md` (`@vendoai/mcp` patch).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop claiming safety for ungraded MCP tools. For `risk: "ungraded"`, we now omit `readOnlyHint` and `destructiveHint` so clients fall back to spec defaults; graded tools are unchanged.

- **Bug Fixes**
  - Updated `toolAnnotations` to omit both hints when risk is `ungraded` (previously emitted `readOnlyHint: false`, `destructiveHint: false`, which claimed non-destructive).
  - Applies to all MCP tool listings via the shared helper: OAuth/outside-agent, live-turn, and app ride-alongs.
  - Kept `title` in `annotations` for older clients; `read`/`write`/`destructive` cases remain identical.
  - Updated docs and the demo-bank assertion script to reflect the new behavior; added tests covering both surfaces using `@modelcontextprotocol/sdk`.

<sup>Written for commit dcc08ab342f7a38c7b5dbdbcc13f4d91189da217. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

