### PR TITLE
docs: Vendo-specific rules move into repo CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,9 @@ generated UI in a sandboxed, brand-native surface.
 
 ## Rules
 
+- Use Yousef's Vendo Cloud account for any and all testing.
+- Vendo-facing API/SDK/CLI design additionally routes through the
+  **vendo-dx** skill (on top of api-design-dx).
 - Never commit to `main`; branch and open a PR.
 - UI-affecting changes are verified in a real browser with screenshots in the
   PR. Tests and typecheck alone don't count.


### PR DESCRIPTION
Moves two Vendo-specific rules out of Yousef's global CLAUDE.md into the repo where they belong: test against Yousef's Vendo Cloud account, and Vendo-facing API/SDK/CLI design routes through vendo-dx. Docs-only diff (two lines in CLAUDE.md); no code touched, so the local build/test gate was deliberately skipped — CI validates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs-only: moves two Vendo-specific rules into this repo’s `CLAUDE.md` so guidance is local. Tests must use Yousef’s Vendo Cloud account, and Vendo-facing API/SDK/CLI design also routes through `vendo-dx` in addition to `api-design-dx`.

<sup>Written for commit 850ade793ea214b9e385a608e7a10c23abf73299. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

