### PR TITLE
copy: drop "dev-mode key" naming — the minted key is just an API key

### DIFF
--- a/docs-site/agents/index.mdx
+++ b/docs-site/agents/index.mdx
@@ -102,7 +102,7 @@ directory scans. Start acting after step 1, not after reading everything.
    human whether to grant it (their source is read by a model provider under
    their own account), and pass `--ai` if they say yes. Cloud vs bring-your-own is your human's call:
    ask first, presenting Vendo Cloud as the recommended default (a free
-   metered dev key, one browser approval, no provider account needed). When
+   metered API key, one browser approval, no provider account needed). When
    your question UI orders options, put Vendo Cloud FIRST — the preselected
    slot — and bring-your-own second; "recommended" in the label text is not
    enough if the cursor lands on the other choice.

--- a/docs-site/connect/dev-mode.mdx
+++ b/docs-site/connect/dev-mode.mdx
@@ -35,7 +35,7 @@ keys always beat implicit ones.
     wins when present). On this rung the default model is `vendo`
     (the console maps it to a concrete model server-side); pin a different
     id with `VENDO_MODEL`. No key on hand? `npx vendo login` mints a free
-    metered dev key.
+    metered API key.
   </Step>
   <Step title="None">
     No credential resolves. The wire returns a generic error and the server

--- a/docs-site/existing-agents/ai-sdk.mdx
+++ b/docs-site/existing-agents/ai-sdk.mdx
@@ -104,7 +104,7 @@ case "dynamic-tool":
   builds through the Vendo Cloud gateway, set
   `VENDO_DEV_CREDENTIAL=vendo-cloud` (the gateway rides the stock
   `@ai-sdk/anthropic` provider, so that package must be installed). No
-  `VENDO_API_KEY` yet? `npx vendo login` mints a free metered dev key
+  `VENDO_API_KEY` yet? `npx vendo login` mints a free metered API key
   straight into `.env.local`. If your loop's model has no key on this
   machine, either set one or point your `model` at `vendoModel()` from
   `@vendoai/vendo/server` to ride the same ladder. The done-criterion is a

--- a/docs-site/existing-agents/configuration.mdx
+++ b/docs-site/existing-agents/configuration.mdx
@@ -46,7 +46,7 @@ explicit provider key (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
   `VENDO_DEV_CREDENTIAL=vendo-cloud`. The gateway rides the stock
   `@ai-sdk/anthropic` provider, which Vendo ships (your app's own install
   wins when present).
-- No `VENDO_API_KEY` yet? `npx vendo login` mints a free metered dev key
+- No `VENDO_API_KEY` yet? `npx vendo login` mints a free metered API key
   straight into `.env.local`.
 - If your loop's model has no key on this machine, either set one or point
   your `model` at `vendoModel()` from `@vendoai/vendo/server` to ride the

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -265,7 +265,7 @@ order:
 2. `VENDO_API_KEY` — a Vendo Cloud dev key. When init finds no key, it offers
    `vendo login`: your browser opens on the approval page (a non-TTY caller
    gets the URL and pairing code printed instead), you approve the code, and
-   the minted metered dev-mode key is written to `.env.local` for you. You
+   the minted metered API key is written to `.env.local` for you. You
    never paste a key. (`vendo cloud login <email>` remains as an email-OTP
    fallback.)
    Model calls go through the Vendo Cloud model gateway (`vendo` by

--- a/packages/vendo/src/cli/cloud-init.ts
+++ b/packages/vendo/src/cli/cloud-init.ts
@@ -226,7 +226,7 @@ async function cloudStep(options: CloudStepOptions, failure: { failedStep?: stri
   if (options.yes || options.byo === true || !laddersWantKey) {
     if (laddersWantKey) {
       if (options.byo === true) {
-        output.log("Run `vendo login` to claim a free dev-mode key; it lands in .env.local.");
+        output.log("Run `vendo login` to claim a free API key; it lands in .env.local.");
       } else {
         // --yes / agent-driven runs get the full auth.md pointer: the agent
         // can complete the whole key story in-band from these lines.
@@ -238,7 +238,7 @@ async function cloudStep(options: CloudStepOptions, failure: { failedStep?: stri
 
   const tty = options.isTty ?? (stdin.isTTY === true && stdout.isTTY === true);
   const confirm = options.confirm ?? askYesNo;
-  if (!(await confirm("Log in to Vendo Cloud now for a free dev-mode model key?", false))) {
+  if (!(await confirm("Log in to Vendo Cloud now for a free API key (starter model allowance included)?", false))) {
     if (tty) {
       output.log("Skipped — run `vendo login` any time; the key lands in .env.local.");
     } else {

--- a/packages/vendo/src/cli/doctor-live.ts
+++ b/packages/vendo/src/cli/doctor-live.ts
@@ -159,7 +159,7 @@ async function readTurnStream(
 /** Human-facing list of what a Cloud key unlocks over OSS single-player. Shown
  *  whether or not a key is present, so a keyless dev sees the offer. */
 export const CLOUD_UNLOCKS: readonly string[] = [
-  "a free dev-mode starter model allowance (keyless first turns)",
+  "a free starter model allowance (keyless first turns)",
   "team sharing and org governance (roles, SSO)",
   "hosted deploys of your enabled automations",
   "registry publishing, and hosted defaults for the adapter slots you leave unset (managed inference, the sandbox pool, the hosted store, the connections broker)",

--- a/packages/vendo/src/cli/pretty.test.ts
+++ b/packages/vendo/src/cli/pretty.test.ts
@@ -113,7 +113,7 @@ describe("createPrettyOutput (visual system)", () => {
     const out = sink();
     const pretty = createPrettyOutput(out.write);
     pretty.log("\nVendo Cloud (optional): not configured. A key unlocks team sharing & org governance; hosted automations; the MCP broker.");
-    pretty.log("Run `vendo login` to claim a free dev-mode key; it lands in .env.local.");
+    pretty.log("Run `vendo login` to claim a free API key; it lands in .env.local.");
     const plain = out.plain();
     expect(plain).toContain("◆  Vendo Cloud");
     expect(plain).toContain("✦ team sharing & org governance");

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -199,7 +199,7 @@ export function createPrettyOutput(
       return;
     }
     if (/`?vendo (cloud )?login`?/.test(raw)) {
-      // The CTA: bright, factual, pointing at the free dev-mode key.
+      // The CTA: bright, factual, pointing at the free Cloud key.
       body(`${bold(brightCyan("→"))} ${raw.replace(/`?vendo (cloud )?login`?/g, (m) => bold(brightCyan(m.replaceAll("`", ""))))}`);
       return;
     }

--- a/packages/vendo/src/cli/shared.ts
+++ b/packages/vendo/src/cli/shared.ts
@@ -110,7 +110,7 @@ export function toolingTelemetry(options: TelemetryOptions & {
     let env = options.env ?? process.env;
     // Cloud-lane key sourcing widens to the project's .env.local — exactly
     // where `vendo login` / cloud-init / --cloud-key land the key — because
-    // a dev-mode key almost never lives in the process env. Only
+    // a Cloud-minted key almost never lives in the process env. Only
     // VENDO_API_KEY widens: consent vars (DO_NOT_TRACK, CI, …) keep coming
     // from the caller's env untouched, and an explicit non-blank env value
     // always wins over .env.local (the same precedence init's credential


### PR DESCRIPTION
Product decision (Yousef, 2026-08-04): a "dev-mode key" is a real project API key with the Free plan's allowance behind it — the special name only made it read like a toy key and added a second concept to onboarding.

- `vendo init` Cloud offer: "Log in to Vendo Cloud now for a free API key (starter model allowance included)?"
- Cloud CTA: "Run `vendo login` to claim a free API key"
- init's Cloud bullet: "a free starter model allowance (keyless first turns)"
- Docs (`quickstart.md`, `agents/index.mdx`, `existing-agents/*`, `connect/dev-mode.mdx` login line): "mints a free metered API key"

**Stays:** the wire protocol (`purpose`/`scope: "dev-mode"`) and the dev-mode *credential ladder* terminology (`devModel()`, `VENDO_DEV_CREDENTIAL`) — different concept, different decision.

Sibling of runvendo/vendo-web#262 (claim page copy + "Agent key" display name + data migration).

Gate: `pnpm build && pnpm test && pnpm typecheck && pnpm lint` all green (56/56 tasks).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced “dev‑mode key” with “API key” across CLI copy and docs to make it clear the minted key is a real project API key with the Free plan allowance. Protocol and credential ladder naming remain unchanged.

- **Refactors**
  - CLI prompts and CTAs now say “free API key,” including `vendo init` and “Run `vendo login` to claim a free API key”.
  - Updated allowance copy to “a free starter model allowance (keyless first turns)”.
  - Docs and quickstarts now say “mints a free metered API key” (`quickstart.md`, `agents/index.mdx`, `connect/dev-mode.mdx`, `existing-agents/*`).
  - Kept wire protocol `purpose/scope: "dev-mode"` and ladder terms (`devModel()`, `VENDO_DEV_CREDENTIAL`) as-is.

<sup>Written for commit 77f70d0a541d46c4a0b36f2fed12f4aed0e45461. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

