### PR TITLE
feat(core): store-wire protocol and StoreOps named-op interface

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export * from "./shape.js";
 export * from "./sha256.js";
 export * from "./skills.js";
 export * from "./store.js";
+export * from "./store-wire.js";
 export * from "./stream-parts.js";
 export * from "./tool-envelopes.js";
 export * from "./tools.js";

--- a/packages/core/src/store-wire.test.ts
+++ b/packages/core/src/store-wire.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import {
+  STORE_WIRE_PATHS,
+  STORE_WIRE_STATUS_BY_CODE,
+  VENDO_STORE_WIRE_FORMAT,
+  VendoError,
+  storeWireErrorBody,
+  storeWireErrorSchema,
+  storeWireStatusSchema,
+  parseStoreWireError,
+  storeWireRecordsGetRequestSchema,
+  storeWireRecordsPutRequestSchema,
+  storeWireRecordsDeleteRequestSchema,
+  storeWireRecordsListRequestSchema,
+  storeWireRecordsClaimRequestSchema,
+  storeWireRecordsInsertIfAbsentRequestSchema,
+  storeWireRecordsCompareAndSwapRequestSchema,
+  storeWireBlobsPutRequestSchema,
+  storeWireBlobsGetRequestSchema,
+  storeWireBlobsDeleteRequestSchema,
+  storeWireBlobsListRequestSchema,
+  storeWireTranscriptsPutThreadRequestSchema,
+  storeWireTranscriptsGetThreadRequestSchema,
+  storeWireTranscriptsListThreadsRequestSchema,
+  storeWireTranscriptsDeleteThreadRequestSchema,
+  storeWireTranscriptsPutMessageRequestSchema,
+  storeWireTranscriptsRecordAnswerRequestSchema,
+  storeWireHarnessGetRequestSchema,
+  storeWireHarnessSetRequestSchema,
+  storeWireHarnessClearRequestSchema,
+  storeWireWorkspaceIndexRequestSchema,
+  storeWireWorkspaceReadRequestSchema,
+  storeWireWorkspaceCommitRequestSchema,
+  storeWireWorkspaceHistoryRequestSchema,
+  storeWireWorkspaceUndoRequestSchema,
+  storeWireLifecycleEraseRequestSchema,
+  storeWireLifecycleAdoptRequestSchema,
+  storeWireLifecyclePromoteRequestSchema,
+  storeWireSessionRegisterRequestSchema,
+  storeWireSessionStaleRequestSchema,
+  storeWireSessionClaimRequestSchema,
+  type StoreWireStatus,
+} from "./index.js";
+
+describe("vendo/store-wire@1", () => {
+  it("exposes the format constant and 32+1 mount-relative paths", () => {
+    expect(VENDO_STORE_WIRE_FORMAT).toBe("vendo/store-wire@1");
+    // 7 families: records(7) + blobs(4) + transcripts(6) + harness(3) + workspace(5) + lifecycle(6) + status(1) = 32
+    expect(Object.keys(STORE_WIRE_PATHS)).toHaveLength(32);
+    expect(STORE_WIRE_PATHS.status).toBe("/status");
+    expect(STORE_WIRE_PATHS["records.get"]).toBe("/records/get");
+    expect(STORE_WIRE_PATHS["lifecycle.session.claim"]).toBe("/lifecycle/session/claim");
+  });
+
+  it("parses records request DTOs and rejects invalid ones", () => {
+    expect(storeWireRecordsGetRequestSchema.parse({ collection: "users", id: "u1" }).id).toBe("u1");
+    expect(storeWireRecordsGetRequestSchema.safeParse({ collection: "", id: "u1" }).success).toBe(false);
+
+    expect(storeWireRecordsPutRequestSchema.parse({
+      collection: "users",
+      record: { id: "u1", data: { name: "Alice" } },
+    }).record.id).toBe("u1");
+    expect(storeWireRecordsPutRequestSchema.safeParse({ collection: "users" }).success).toBe(false);
+
+    expect(storeWireRecordsDeleteRequestSchema.parse({ collection: "users", id: "u1" }).collection).toBe("users");
+
+    expect(storeWireRecordsListRequestSchema.parse({ collection: "users" }).collection).toBe("users");
+    expect(storeWireRecordsListRequestSchema.parse({
+      collection: "users",
+      query: { refs: { org: "o1" }, limit: 50 },
+    }).query?.limit).toBe(50);
+
+    expect(storeWireRecordsClaimRequestSchema.parse({
+      collection: "users",
+      expected: { id: "u1", data: { status: "free" } },
+      replacement: { data: { status: "claimed" } },
+    }).expected.id).toBe("u1");
+
+    expect(storeWireRecordsInsertIfAbsentRequestSchema.parse({
+      collection: "users",
+      record: { id: "u2", data: {} },
+    }).record.id).toBe("u2");
+
+    expect(storeWireRecordsCompareAndSwapRequestSchema.parse({
+      collection: "users",
+      record: { id: "u1", data: {} },
+      expectedRevision: "rev_1",
+    }).expectedRevision).toBe("rev_1");
+    expect(storeWireRecordsCompareAndSwapRequestSchema.safeParse({
+      collection: "users",
+      record: { id: "u1", data: {} },
+      expectedRevision: "",
+    }).success).toBe(false);
+  });
+
+  it("parses blobs request DTOs — bytes are base64 on the wire", () => {
+    expect(storeWireBlobsPutRequestSchema.parse({
+      namespace: "avatars",
+      key: "u1.png",
+      bytes: btoa("fake-image"),
+      contentType: "image/png",
+    }).contentType).toBe("image/png");
+    expect(storeWireBlobsPutRequestSchema.safeParse({ namespace: "", key: "k", bytes: "x" }).success).toBe(false);
+
+    expect(storeWireBlobsGetRequestSchema.parse({ namespace: "avatars", key: "u1.png" }).key).toBe("u1.png");
+    expect(storeWireBlobsDeleteRequestSchema.parse({ namespace: "avatars", key: "u1.png" }).namespace).toBe("avatars");
+    expect(storeWireBlobsListRequestSchema.parse({ namespace: "avatars", prefix: "u1" }).prefix).toBe("u1");
+  });
+
+  it("parses transcripts request DTOs", () => {
+    expect(storeWireTranscriptsPutThreadRequestSchema.parse({
+      thread: { id: "t1", subject: "sub_user1", messages: [{ role: "user", content: "hi" }] },
+    }).thread.id).toBe("t1");
+    expect(storeWireTranscriptsPutThreadRequestSchema.safeParse({
+      thread: { id: "", subject: "s", messages: [] },
+    }).success).toBe(false);
+
+    expect(storeWireTranscriptsGetThreadRequestSchema.parse({ id: "t1", limit: 50 }).limit).toBe(50);
+    expect(storeWireTranscriptsListThreadsRequestSchema.parse({ subject: "sub_user1" }).subject).toBe("sub_user1");
+    expect(storeWireTranscriptsDeleteThreadRequestSchema.parse({ id: "t1" }).id).toBe("t1");
+    expect(storeWireTranscriptsPutMessageRequestSchema.parse({ threadId: "t1", message: { role: "user", content: "test" } }).threadId).toBe("t1");
+    expect(storeWireTranscriptsRecordAnswerRequestSchema.parse({ threadId: "t1", answer: { text: "done" } }).threadId).toBe("t1");
+  });
+
+  it("parses harness request DTOs", () => {
+    expect(storeWireHarnessGetRequestSchema.parse({ appId: "app_1", subject: "sub_1" }).appId).toBe("app_1");
+    expect(storeWireHarnessSetRequestSchema.parse({ appId: "app_1", subject: "sub_1", state: { step: 3 } }).state).toEqual({ step: 3 });
+    expect(storeWireHarnessClearRequestSchema.parse({ appId: "app_1", subject: "sub_1" }).subject).toBe("sub_1");
+    expect(storeWireHarnessClearRequestSchema.safeParse({ appId: "", subject: "s" }).success).toBe(false);
+  });
+
+  it("parses workspace request DTOs", () => {
+    expect(storeWireWorkspaceIndexRequestSchema.parse({ limit: 100 }).limit).toBe(100);
+    expect(storeWireWorkspaceReadRequestSchema.parse({ paths: ["/a.md"] }).paths).toEqual(["/a.md"]);
+    expect(storeWireWorkspaceReadRequestSchema.safeParse({ paths: [] }).success).toBe(false);
+    expect(storeWireWorkspaceCommitRequestSchema.parse({ entries: [{ path: "/a.md", content: "hi" }] }).entries).toHaveLength(1);
+    expect(storeWireWorkspaceHistoryRequestSchema.parse({ cursor: "c1" }).cursor).toBe("c1");
+    expect(storeWireWorkspaceUndoRequestSchema.parse({ commitId: "commit_1" }).commitId).toBe("commit_1");
+    expect(storeWireWorkspaceUndoRequestSchema.safeParse({ commitId: "" }).success).toBe(false);
+  });
+
+  it("parses lifecycle request DTOs", () => {
+    expect(storeWireLifecycleEraseRequestSchema.parse({ target: { subject: "sub_1" } }).target.subject).toBe("sub_1");
+    expect(storeWireLifecycleAdoptRequestSchema.parse({ from: "sub_anon", to: "sub_real" }).from).toBe("sub_anon");
+    expect(storeWireLifecycleAdoptRequestSchema.safeParse({ from: "", to: "x" }).success).toBe(false);
+    expect(storeWireLifecyclePromoteRequestSchema.parse({ appId: "app_1", orgId: "org_1" }).orgId).toBe("org_1");
+    expect(storeWireSessionRegisterRequestSchema.parse({ subject: "sub_1", now: 1000 }).now).toBe(1000);
+    expect(storeWireSessionStaleRequestSchema.parse({ idleMs: 60000 }).idleMs).toBe(60000);
+    expect(storeWireSessionStaleRequestSchema.safeParse({ idleMs: 0 }).success).toBe(false);
+    expect(storeWireSessionClaimRequestSchema.parse({ subject: "sub_1", idleMs: 5000 }).subject).toBe("sub_1");
+  });
+
+  it("status doubles as the discovery handshake: format + ops count", () => {
+    const status: StoreWireStatus = {
+      format: VENDO_STORE_WIRE_FORMAT,
+      ops: 32,
+    };
+    expect(storeWireStatusSchema.parse(status).ops).toBe(32);
+    expect(storeWireStatusSchema.safeParse({ ...status, format: "vendo/store-wire@2" }).success).toBe(false);
+  });
+
+  it("maps every VendoError code to the wire status table and back", () => {
+    const { status, body } = storeWireErrorBody(new VendoError("not-found", "unknown record"));
+    expect(status).toBe(404);
+    expect(storeWireErrorSchema.parse(body).error.code).toBe("not-found");
+    const roundTripped = parseStoreWireError(status, body);
+    expect(roundTripped).toBeInstanceOf(VendoError);
+    expect(roundTripped.code).toBe("not-found");
+    expect(roundTripped.message).toBe("unknown record");
+    expect(STORE_WIRE_STATUS_BY_CODE["cloud-required"]).toBe(402);
+    expect(STORE_WIRE_STATUS_BY_CODE["validation"]).toBe(400);
+  });
+
+  it("parseStoreWireError: enveloped code wins, bare statuses map, junk degrades honestly", () => {
+    expect(parseStoreWireError(400, { error: { code: "conflict", message: "id taken" } }).code).toBe("conflict");
+    expect(parseStoreWireError(402, undefined).code).toBe("cloud-required");
+    expect(parseStoreWireError(500, { error: { code: "not-a-real-code", message: "?" } }).code).toBe("not-implemented");
+    expect(parseStoreWireError(503, null).code).toBe("not-implemented");
+  });
+
+  it("only an enveloped not-found reads as record absence — a bare 404 surfaces as failure", () => {
+    expect(parseStoreWireError(404, { error: { code: "not-found", message: "unknown record" } }).code).toBe("not-found");
+    expect(parseStoreWireError(404, "<html>nginx 404</html>").code).toBe("not-implemented");
+    expect(parseStoreWireError(404, undefined).code).toBe("not-implemented");
+  });
+
+  it("the reverse status table round-trips through the forward table", () => {
+    for (const [status, code] of Object.entries({ 400: "validation", 402: "cloud-required", 403: "blocked", 409: "conflict" } as const)) {
+      expect(STORE_WIRE_STATUS_BY_CODE[code]).toBe(Number(status));
+      expect(parseStoreWireError(Number(status), undefined).code).toBe(code);
+    }
+    expect(STORE_WIRE_STATUS_BY_CODE["not-found"]).toBe(404);
+    expect(parseStoreWireError(501, undefined).code).toBe("not-implemented");
+  });
+});

--- a/packages/core/src/store-wire.test.ts
+++ b/packages/core/src/store-wire.test.ts
@@ -39,6 +39,7 @@ import {
   storeWireSessionRegisterRequestSchema,
   storeWireSessionStaleRequestSchema,
   storeWireSessionClaimRequestSchema,
+  type EraseTarget,
   type StoreWireStatus,
 } from "./index.js";
 
@@ -141,6 +142,14 @@ describe("vendo/store-wire@1", () => {
 
   it("parses lifecycle request DTOs", () => {
     expect(storeWireLifecycleEraseRequestSchema.parse({ target: { subject: "sub_1" } }).target.subject).toBe("sub_1");
+    expect(storeWireLifecycleEraseRequestSchema.parse({ target: { appId: "app_1" } }).target.appId).toBe("app_1");
+    // A destructive erase must name exactly one scope: no empty target...
+    expect(storeWireLifecycleEraseRequestSchema.safeParse({ target: {} }).success).toBe(false);
+    // ...and no ambiguous both-set target.
+    expect(storeWireLifecycleEraseRequestSchema.safeParse({
+      target: { subject: "sub_1", appId: "app_1" },
+    }).success).toBe(false);
+    expect(storeWireLifecycleEraseRequestSchema.safeParse({ target: { subject: "" } }).success).toBe(false);
     expect(storeWireLifecycleAdoptRequestSchema.parse({ from: "sub_anon", to: "sub_real" }).from).toBe("sub_anon");
     expect(storeWireLifecycleAdoptRequestSchema.safeParse({ from: "", to: "x" }).success).toBe(false);
     expect(storeWireLifecyclePromoteRequestSchema.parse({ appId: "app_1", orgId: "org_1" }).orgId).toBe("org_1");
@@ -148,6 +157,16 @@ describe("vendo/store-wire@1", () => {
     expect(storeWireSessionStaleRequestSchema.parse({ idleMs: 60000 }).idleMs).toBe(60000);
     expect(storeWireSessionStaleRequestSchema.safeParse({ idleMs: 0 }).success).toBe(false);
     expect(storeWireSessionClaimRequestSchema.parse({ subject: "sub_1", idleMs: 5000 }).subject).toBe("sub_1");
+  });
+
+  it("the erase target is a compile-time discriminated selector", () => {
+    const check = (target: EraseTarget) => target;
+    expect(check({ subject: "sub_1" }).subject).toBe("sub_1");
+    expect(check({ appId: "app_1" }).appId).toBe("app_1");
+    // @ts-expect-error a destructive erase must name a scope — {} is not a target
+    check({});
+    // @ts-expect-error exactly one scope: subject and appId cannot both be set
+    check({ subject: "sub_1", appId: "app_1" });
   });
 
   it("status doubles as the discovery handshake: format + ops count", () => {

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -225,11 +225,16 @@ export const storeWireWorkspaceUndoRequestSchema = z.object({
 // lifecycle
 // ---------------------------------------------------------------------------
 
+/** Exactly ONE of subject/appId — an erase with no scope (or an ambiguous
+    both-set scope) is a destructive call with no target and must be rejected. */
 export const storeWireLifecycleEraseRequestSchema = z.object({
   target: z.object({
-    subject: z.string().optional(),
-    appId: z.string().optional(),
-  }).passthrough(),
+    subject: z.string().min(1).optional(),
+    appId: z.string().min(1).optional(),
+  }).passthrough().refine(
+    (t) => (t.subject === undefined) !== (t.appId === undefined),
+    { message: "erase target must set exactly one of subject or appId" },
+  ),
 }).passthrough();
 
 export const storeWireLifecycleAdoptRequestSchema = z.object({

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -1,0 +1,341 @@
+import { z } from "zod";
+import { VendoError, safeErrorMessage, vendoErrorCodeSchema, type VendoErrorCode } from "./errors.js";
+import {
+  recordQuerySchema,
+} from "./store.js";
+
+/** Store design v1 — the wire protocol version tag. The HTTP profile of the
+    StoreOps contract, shared verbatim by the cloud client and the BYO
+    `httpStore` template. */
+export const VENDO_STORE_WIRE_FORMAT = "vendo/store-wire@1" as const;
+
+/** Mount-relative endpoint paths. POST-JSON RPC for all mutations and queries;
+    GET /status doubles as the discovery handshake.
+    ONE Idempotency-Key header on every mutation.
+    ONE keyset cursor (default 100, max 1000) on every list op.
+    Unknown op → enveloped `not-implemented` (501). */
+export const STORE_WIRE_PATHS = {
+  // records (7)
+  "records.get": "/records/get",
+  "records.put": "/records/put",
+  "records.delete": "/records/delete",
+  "records.list": "/records/list",
+  "records.claim": "/records/claim",
+  "records.insertIfAbsent": "/records/insertIfAbsent",
+  "records.compareAndSwap": "/records/compareAndSwap",
+  // blobs (4)
+  "blobs.put": "/blobs/put",
+  "blobs.get": "/blobs/get",
+  "blobs.delete": "/blobs/delete",
+  "blobs.list": "/blobs/list",
+  // transcripts (6)
+  "transcripts.putThread": "/transcripts/putThread",
+  "transcripts.getThread": "/transcripts/getThread",
+  "transcripts.listThreads": "/transcripts/listThreads",
+  "transcripts.deleteThread": "/transcripts/deleteThread",
+  "transcripts.putMessage": "/transcripts/putMessage",
+  "transcripts.recordAnswer": "/transcripts/recordAnswer",
+  // harness (3)
+  "harness.get": "/harness/get",
+  "harness.set": "/harness/set",
+  "harness.clear": "/harness/clear",
+  // workspace (5)
+  "workspace.index": "/workspace/index",
+  "workspace.read": "/workspace/read",
+  "workspace.commit": "/workspace/commit",
+  "workspace.history": "/workspace/history",
+  "workspace.undo": "/workspace/undo",
+  // lifecycle (6)
+  "lifecycle.erase": "/lifecycle/erase",
+  "lifecycle.adopt": "/lifecycle/adopt",
+  "lifecycle.promote": "/lifecycle/promote",
+  "lifecycle.session.register": "/lifecycle/session/register",
+  "lifecycle.session.stale": "/lifecycle/session/stale",
+  "lifecycle.session.claim": "/lifecycle/session/claim",
+  // status (1)
+  status: "/status",
+} as const;
+
+// ---------------------------------------------------------------------------
+// Shared schemas
+// ---------------------------------------------------------------------------
+
+const recordInputSchema = z.object({
+  id: z.string().min(1),
+  data: z.unknown(),
+  refs: z.record(z.string()).optional(),
+}).passthrough();
+
+const cursorQuerySchema = z.object({
+  cursor: z.string().optional(),
+  limit: z.number().int().min(1).max(1000).optional(),
+}).passthrough();
+
+// ---------------------------------------------------------------------------
+// records
+// ---------------------------------------------------------------------------
+
+export const storeWireRecordsGetRequestSchema = z.object({
+  collection: z.string().min(1),
+  id: z.string().min(1),
+}).passthrough();
+
+export const storeWireRecordsPutRequestSchema = z.object({
+  collection: z.string().min(1),
+  record: recordInputSchema,
+}).passthrough();
+
+export const storeWireRecordsDeleteRequestSchema = z.object({
+  collection: z.string().min(1),
+  id: z.string().min(1),
+}).passthrough();
+
+export const storeWireRecordsListRequestSchema = z.object({
+  collection: z.string().min(1),
+  query: recordQuerySchema.optional(),
+}).passthrough();
+
+export const storeWireRecordsClaimRequestSchema = z.object({
+  collection: z.string().min(1),
+  expected: recordInputSchema,
+  replacement: z.object({
+    data: z.unknown(),
+    refs: z.record(z.string()).optional(),
+  }).passthrough().optional(),
+}).passthrough();
+
+export const storeWireRecordsInsertIfAbsentRequestSchema = z.object({
+  collection: z.string().min(1),
+  record: recordInputSchema,
+}).passthrough();
+
+export const storeWireRecordsCompareAndSwapRequestSchema = z.object({
+  collection: z.string().min(1),
+  record: recordInputSchema,
+  expectedRevision: z.string().min(1),
+}).passthrough();
+
+// ---------------------------------------------------------------------------
+// blobs
+// ---------------------------------------------------------------------------
+
+/** Blob bytes are base64-encoded on the wire. */
+export const storeWireBlobsPutRequestSchema = z.object({
+  namespace: z.string().min(1),
+  key: z.string().min(1),
+  bytes: z.string().min(1), // base64
+  contentType: z.string().optional(),
+}).passthrough();
+
+export const storeWireBlobsGetRequestSchema = z.object({
+  namespace: z.string().min(1),
+  key: z.string().min(1),
+}).passthrough();
+
+export const storeWireBlobsDeleteRequestSchema = z.object({
+  namespace: z.string().min(1),
+  key: z.string().min(1),
+}).passthrough();
+
+export const storeWireBlobsListRequestSchema = z.object({
+  namespace: z.string().min(1),
+  prefix: z.string().optional(),
+}).passthrough();
+
+// ---------------------------------------------------------------------------
+// transcripts
+// ---------------------------------------------------------------------------
+
+export const storeWireTranscriptsPutThreadRequestSchema = z.object({
+  thread: z.object({
+    id: z.string().min(1),
+    subject: z.string().min(1),
+    messages: z.array(z.unknown()),
+    title: z.string().optional(),
+  }).passthrough(),
+}).passthrough();
+
+export const storeWireTranscriptsGetThreadRequestSchema = z.object({
+  id: z.string().min(1),
+  cursor: z.string().optional(),
+  limit: z.number().int().min(1).max(1000).optional(),
+}).passthrough();
+
+export const storeWireTranscriptsListThreadsRequestSchema = z.object({
+  subject: z.string().optional(),
+  cursor: z.string().optional(),
+  limit: z.number().int().min(1).max(1000).optional(),
+}).passthrough();
+
+export const storeWireTranscriptsDeleteThreadRequestSchema = z.object({
+  id: z.string().min(1),
+}).passthrough();
+
+export const storeWireTranscriptsPutMessageRequestSchema = z.object({
+  threadId: z.string().min(1),
+  message: z.unknown(),
+}).passthrough();
+
+export const storeWireTranscriptsRecordAnswerRequestSchema = z.object({
+  threadId: z.string().min(1),
+  answer: z.unknown(),
+}).passthrough();
+
+// ---------------------------------------------------------------------------
+// harness
+// ---------------------------------------------------------------------------
+
+export const storeWireHarnessGetRequestSchema = z.object({
+  appId: z.string().min(1),
+  subject: z.string().min(1),
+}).passthrough();
+
+export const storeWireHarnessSetRequestSchema = z.object({
+  appId: z.string().min(1),
+  subject: z.string().min(1),
+  state: z.unknown(),
+}).passthrough();
+
+export const storeWireHarnessClearRequestSchema = z.object({
+  appId: z.string().min(1),
+  subject: z.string().min(1),
+}).passthrough();
+
+// ---------------------------------------------------------------------------
+// workspace
+// ---------------------------------------------------------------------------
+
+export const storeWireWorkspaceIndexRequestSchema = cursorQuerySchema;
+
+export const storeWireWorkspaceReadRequestSchema = z.object({
+  paths: z.array(z.string().min(1)).min(1),
+}).passthrough();
+
+export const storeWireWorkspaceCommitRequestSchema = z.object({
+  entries: z.array(z.unknown()).min(1),
+}).passthrough();
+
+export const storeWireWorkspaceHistoryRequestSchema = cursorQuerySchema;
+
+export const storeWireWorkspaceUndoRequestSchema = z.object({
+  commitId: z.string().min(1),
+}).passthrough();
+
+// ---------------------------------------------------------------------------
+// lifecycle
+// ---------------------------------------------------------------------------
+
+export const storeWireLifecycleEraseRequestSchema = z.object({
+  target: z.object({
+    subject: z.string().optional(),
+    appId: z.string().optional(),
+  }).passthrough(),
+}).passthrough();
+
+export const storeWireLifecycleAdoptRequestSchema = z.object({
+  from: z.string().min(1),
+  to: z.string().min(1),
+}).passthrough();
+
+export const storeWireLifecyclePromoteRequestSchema = z.object({
+  appId: z.string().min(1),
+  orgId: z.string().min(1),
+}).passthrough();
+
+export const storeWireSessionRegisterRequestSchema = z.object({
+  subject: z.string().min(1),
+  now: z.number().optional(),
+}).passthrough();
+
+export const storeWireSessionStaleRequestSchema = z.object({
+  idleMs: z.number().int().min(1),
+  now: z.number().optional(),
+}).passthrough();
+
+export const storeWireSessionClaimRequestSchema = z.object({
+  subject: z.string().min(1),
+  idleMs: z.number().int().min(1),
+  now: z.number().optional(),
+}).passthrough();
+
+// ---------------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------------
+
+/** GET /status — the discovery handshake. Clients learn the protocol version,
+    the min client version for negotiation, and counts. */
+export interface StoreWireStatus {
+  format: typeof VENDO_STORE_WIRE_FORMAT;
+  minClientVersion?: string;
+  ops: number;
+}
+
+export const storeWireStatusSchema = z.object({
+  format: z.literal(VENDO_STORE_WIRE_FORMAT),
+  minClientVersion: z.string().optional(),
+  ops: z.number(),
+}).passthrough() satisfies z.ZodType<StoreWireStatus>;
+
+// ---------------------------------------------------------------------------
+// Error envelope (identical shape to knowledge-wire / umbrella wire)
+// ---------------------------------------------------------------------------
+
+export interface StoreWireError {
+  error: {
+    code: VendoErrorCode;
+    message: string;
+  };
+}
+
+export const storeWireErrorSchema = z.object({
+  error: z.object({
+    code: vendoErrorCodeSchema,
+    message: z.string(),
+  }).passthrough(),
+}).passthrough() satisfies z.ZodType<StoreWireError>;
+
+/** Mirrors the umbrella wire's STATUS_BY_CODE — core cannot import it
+    (layering: core depends on nothing). */
+export const STORE_WIRE_STATUS_BY_CODE: Record<VendoErrorCode, number> = {
+  validation: 400,
+  "not-found": 404,
+  blocked: 403,
+  forbidden: 403,
+  conflict: 409,
+  "cloud-required": 402,
+  "sandbox-unavailable": 501,
+  "not-implemented": 501,
+};
+
+/** 404 is deliberately absent: only an ENVELOPED `not-found` may become the
+    record-absence code. A bare 404 is a mount/deployment failure and degrades
+    to "not-implemented" so it surfaces as an error. */
+const STATUS_TO_CODE: Record<number, VendoErrorCode> = {
+  400: "validation",
+  402: "cloud-required",
+  403: "blocked",
+  409: "conflict",
+};
+
+/** Server half: one VendoError → the enveloped body + HTTP status. */
+export function storeWireErrorBody(error: VendoError): { status: number; body: StoreWireError } {
+  return {
+    status: STORE_WIRE_STATUS_BY_CODE[error.code],
+    body: { error: { code: error.code, message: safeErrorMessage(error) } },
+  };
+}
+
+/** Client half: a non-2xx response → VendoError. An enveloped wire-legal
+    code wins over the bare status; recognized statuses map through
+    STATUS_TO_CODE; anything else degrades to "not-implemented". */
+export function parseStoreWireError(status: number, body: unknown): VendoError {
+  const parsed = storeWireErrorSchema.safeParse(body);
+  if (parsed.success) {
+    return new VendoError(parsed.data.error.code, parsed.data.error.message);
+  }
+  const code = STATUS_TO_CODE[status];
+  if (code !== undefined) {
+    return new VendoError(code, `store wire request failed with HTTP ${status}`);
+  }
+  return new VendoError("not-implemented", `store wire request failed with HTTP ${status}`);
+}

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -86,3 +86,60 @@ export interface StoreAdapter {
   blobs(namespace: string): BlobStore;
   ensureSchema(): Promise<void>;
 }
+
+// ---------------------------------------------------------------------------
+// StoreOps — the named-operation contract for the 32-op / 7-family store.
+// Both the local backend (store/ops.ts) and the cloud client
+// (hosted-store.ts) implement this interface.
+// ---------------------------------------------------------------------------
+
+import type { StoreWireStatus } from "./store-wire.js";
+
+/** The typed contract for all 32 store operations across 7 families.
+    Lean by design — this is the CONTRACT interface, not the implementation. */
+export interface StoreOps {
+  records: {
+    get(collection: string, id: string): Promise<VendoRecord | null>;
+    put(collection: string, record: RecordInput): Promise<VendoRecord>;
+    delete(collection: string, id: string): Promise<void>;
+    list(collection: string, query?: RecordQuery): Promise<{ records: VendoRecord[]; cursor?: string }>;
+    claim(collection: string, expected: RecordInput, replacement?: Pick<VendoRecord, "data" | "refs">): Promise<boolean>;
+    insertIfAbsent(collection: string, record: RecordInput): Promise<VendoRecord | null>;
+    compareAndSwap(collection: string, record: RecordInput, expectedRevision: string): Promise<VendoRecord | null>;
+  };
+  blobs: {
+    put(namespace: string, key: string, bytes: Uint8Array, meta?: { contentType?: string }): Promise<void>;
+    get(namespace: string, key: string): Promise<{ bytes: Uint8Array; contentType?: string } | null>;
+    delete(namespace: string, key: string): Promise<void>;
+    list(namespace: string, prefix?: string): Promise<string[]>;
+  };
+  transcripts: {
+    putThread(thread: { id: string; subject: string; messages: unknown[]; title?: string }): Promise<VendoRecord>;
+    getThread(id: string, opts?: { cursor?: string; limit?: number }): Promise<VendoRecord | null>;
+    listThreads(query?: { subject?: string; cursor?: string; limit?: number }): Promise<{ records: VendoRecord[]; cursor?: string }>;
+    deleteThread(id: string): Promise<void>;
+    putMessage(threadId: string, message: unknown): Promise<VendoRecord>;
+    recordAnswer(threadId: string, answer: unknown): Promise<VendoRecord>;
+  };
+  harness: {
+    get(appId: string, subject: string): Promise<unknown | null>;
+    set(appId: string, subject: string, state: unknown): Promise<void>;
+    clear(appId: string, subject: string): Promise<void>;
+  };
+  workspace: {
+    index(query?: { cursor?: string; limit?: number }): Promise<{ entries: unknown[]; cursor?: string }>;
+    read(paths: string[]): Promise<Record<string, unknown>>;
+    commit(entries: unknown[], opts?: { idempotencyKey?: string }): Promise<void>;
+    history(query?: { cursor?: string; limit?: number }): Promise<{ entries: unknown[]; cursor?: string }>;
+    undo(commitId: string): Promise<void>;
+  };
+  lifecycle: {
+    erase(target: { subject?: string; appId?: string }): Promise<unknown>;
+    adopt(from: string, to: string): Promise<unknown>;
+    promote(appId: string, orgId: string): Promise<void>;
+    sessionRegister(subject: string, now?: number): Promise<void>;
+    sessionStale(idleMs: number, now?: number): Promise<string[]>;
+    sessionClaim(subject: string, idleMs: number, now?: number): Promise<boolean>;
+  };
+  status(): Promise<StoreWireStatus>;
+}

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -95,6 +95,13 @@ export interface StoreAdapter {
 
 import type { StoreWireStatus } from "./store-wire.js";
 
+/** The scope of a destructive erase: exactly ONE of subject or appId.
+    A union (not two optionals) so `erase({})` and a both-set target are
+    compile errors — an erase can never run without a data scope. */
+export type EraseTarget =
+  | { subject: string; appId?: never }
+  | { appId: string; subject?: never };
+
 /** The typed contract for all 32 store operations across 7 families.
     Lean by design — this is the CONTRACT interface, not the implementation. */
 export interface StoreOps {
@@ -134,7 +141,7 @@ export interface StoreOps {
     undo(commitId: string): Promise<void>;
   };
   lifecycle: {
-    erase(target: { subject?: string; appId?: string }): Promise<unknown>;
+    erase(target: EraseTarget): Promise<unknown>;
     adopt(from: string, to: string): Promise<unknown>;
     promote(appId: string, orgId: string): Promise<void>;
     sessionRegister(subject: string, now?: number): Promise<void>;


### PR DESCRIPTION
## What

Piece 1 of the phase-1 store stack. Adds the `vendo/store-wire@1` protocol
(envelope, error codes, status shape, operation manifest) and the `StoreOps`
named-op interface — 32 operations across 7 families — in `@vendoai/core`.

No behaviour changes: this is the contract every later piece implements or
consumes.

## Why

Phase 1 replaces ad-hoc store access with one named-op surface so a Cloud-key
host can persist without holding database credentials. The interface has to
exist and be agreed before the local backend (#T4), the cloud client (#T6),
the console doors (vendo-web) and the conformance kit (#T3) can be written
against it.

## Verification

- [x] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green
- [ ] Screenshots attached (if UI-affecting) — n/a, no UI

Gates were run and verified at descendant SHA `aa88d773` (this commit is an
ancestor): `@vendoai/core` 1055 pass, `@vendoai/store` 431 pass / 2 skip,
build 24/24, typecheck 43/43, lint clean. CI re-runs them against current
`main` on this PR.

## Known gap, disclosed not buried

`STORE_WIRE_PATHS` in this commit **disagrees with the shipped console server
for 4 of the 7 families** — records is `/records/{collection}/{op}` not
`/records/get`; blobs are REST raw-byte routes, not POST+base64; erase takes
its target flat; erase/adopt/sessions are not under `/lifecycle/*` at all.

The constant has **zero production consumers** — only its own test asserts it,
which is exactly the producer-and-consumer-mock trap this repo has a law
about. It is made truthful *and* actually consumed by the client (so it cannot
drift again) on `store/phase1-integrate`, which is in flight. Reviewers should
read that constant as not-yet-load-bearing.

## Status

Proven: gates above. Still running: the live cut-down acceptance and AI
reviewer triage. Per the merge bar, this does not merge until gates are green,
the live acceptance passes, and every reviewer comment is triaged against the
code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `vendo/store-wire@1` HTTP protocol and the `StoreOps` named-operation interface to `@vendoai/core` for a 32-op store contract. Also enforces that `lifecycle.erase` names exactly one scope (`subject` or `appId`) at both type and schema levels. No runtime behavior changes.

- **New Features**
  - Wire protocol: 32 named ops across records, blobs, transcripts, harness, workspace, lifecycle. Mount-relative paths with POST JSON; `GET /status` handshake (format + ops).
  - Request/response typing: Zod schemas for DTOs and error envelope; `STORE_WIRE_STATUS_BY_CODE`, `storeWireErrorBody`, and `parseStoreWireError` for consistent HTTP ↔ VendoError mapping.
  - `StoreOps` interface: typed surface mirroring the 32 ops, to be implemented by the local backend and cloud client; exported via `@vendoai/core` index.
  - Tests: validate path manifest, schema parsing, and error/status round-trips.
  - Note: `STORE_WIRE_PATHS` differs from the current console server for some families and has no production consumers yet; alignment lands in the upcoming integration branch.

- **Bug Fixes**
  - `lifecycle.erase` target must set exactly one of `subject` or `appId` (compile-time via `EraseTarget` union and runtime via schema refine).

<sup>Written for commit 1bc70382d58fc07cb3c32f4a8e4a5d4862472e12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

