### PR TITLE
test(mcp): door kill-session test no longer races its own SSE stream

### DIFF
--- a/packages/mcp/src/door.test.ts
+++ b/packages/mcp/src/door.test.ts
@@ -1301,9 +1301,12 @@ describe("createMcpDoor MCP protocol", () => {
     const harness = makeHarness({ principal: () => principal });
     const registration = await register(harness.door);
     const tokens = await issue(harness.door, registration.body.client_id);
-    const connected = await connect(harness.door, tokens.access_token);
-    await connected.client.listTools();
-    const sessionId = connected.transport.sessionId!;
+    // Raw HTTP, not the SDK client: the client's unawaited background SSE GET
+    // could observe the null principal first, kill the subject, and hand THIS
+    // request the 404 — exactly one request may be in flight across the flip.
+    const initialized = await harness.door.handler(mcpRequest(tokens.access_token));
+    expect(initialized.status).toBe(200);
+    const sessionId = initialized.headers.get("mcp-session-id")!;
 
     principal = null;
     const revoked = await harness.door.handler(mcpRequest(tokens.access_token, sessionId));


### PR DESCRIPTION
## What

TEST-ONLY change to `packages/mcp/src/door.test.ts` — pins a race assumption in the "kills a subject's live session when principal resolution returns null" test. `door.ts` is untouched.

## Mechanism

The test's `connect()` uses the SDK's `StreamableHTTPClientTransport`, which opens a background GET SSE stream the test never awaits. In `door.ts` the session lookup (404) runs before the null-principal check (401), and `#killSubject` removes every session for the subject — so whichever request first observes `principal = null` kills the subject and takes the 401; the OTHER request then finds no session and gets 404. The test assumed its foreground POST always wins; under load the unawaited background GET can win, and the test sees `expected 404 to be 401`.

This is a test-assumption bug, not a product bug — the 404-before-401 ordering in `door.ts` is deliberate and unchanged.

## Fix

Drive the test over raw HTTP (`mcpRequest`), the same pattern the standalone-SSE-slot test already uses: no background stream exists, so exactly one request can observe the flip. One-line comment in the test states the constraint.

## Verification

- Reproduced the original flake with the old test body under 6-way concurrent contention: 1/6 runs failed with exactly `expected 404 to be 401`.
- Fixed body: 10/10 green running the file solo (capped `VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2`, `--minWorkers=1 --maxWorkers=2`), and 6/6 green under the same 6-way contention that broke the old body.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the kill-on-null-principal test by using raw HTTP instead of the SDK SSE client, removing a race that sometimes returned 404 instead of the expected 401. Product code in `door.ts` is unchanged.

- **Bug Fixes**
  - Use raw HTTP (`mcpRequest`) to init/revoke so no background SSE GET can preempt the 401.
  - Added a brief comment; confirmed the test is stable under contention.

<sup>Written for commit f58ee7dc86a20cc07f421399be0d26573f9bf27f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

