### PR TITLE
cloud: meter refusals and usage speak dollars

### DIFF
--- a/docs-site/deploy/vendo-cloud.mdx
+++ b/docs-site/deploy/vendo-cloud.mdx
@@ -142,13 +142,44 @@ console and the hosted trigger registers itself. Host-event automations
 (`on: { kind: "host-event", ... }`) still fire in your own process, since
 they react to events your process emits.
 
+## Pricing
+
+A plan's price is the amount of usage it includes, and your bill for a period is
+whichever is larger — the plan price or your usage.
+
+| Plan | Price | Includes |
+| --- | --- | --- |
+| Free | $0 | $5 of usage / month |
+| Pro | $49 / month | $49 of usage / month |
+| Teams | $499 / month | $499 of usage / month |
+| Enterprise | Custom | Committed usage |
+
+Usage is metered org-wide across every project, at four published rates that are
+identical on every plan, including Free.
+
+| Rate | Price |
+| --- | --- |
+| `vendo-fast` | $1.15 / M input tokens · $5.75 / M output tokens |
+| `vendo` | $2.30 / M input tokens · $11.50 / M output tokens |
+| `vendo-strong` | $5.75 / M input tokens · $28.75 / M output tokens |
+| Sandbox | $0.01 per minute of wall-clock run time |
+| Storage | $0.25 per GB-month |
+| Automation runs | $3 per 1,000 runs |
+
+Free hard-stops at $5 — a clear error naming the reset date, never a charge. Paid
+plans continue past their included dollars at the same rates under an
+organization spend cap that defaults to twice the plan price; owners are emailed
+at 50%, 90%, and 100% of it. Every rate has a bring-your-own path: your own model
+key, sandbox account, Postgres, or infrastructure means that rate never fires and
+reads $0.
+
 ## Error handling
 
 Cloud calls surface the shared error taxonomy (see
 [Troubleshooting](/deploy/troubleshooting)):
 
 - `cloud-required` (HTTP 402): no `VENDO_API_KEY`, the key is invalid, or the
-  operation's meter is exhausted.
+  organization has used up the dollars its plan includes.
 - `validation`, `not-found`, `conflict`, `blocked`: propagated from the hosted
   API with the same codes the wire uses.
 
@@ -193,7 +224,7 @@ Reach for it when you want app machines without an E2B account. You normally
 never construct it: with `VENDO_API_KEY` set, `createVendo` fills the unset
 sandbox slot with it automatically. An explicitly passed `sandbox:` adapter,
 or `E2B_API_KEY` with the `e2b` package installed, always wins over that
-default. Usage meters as `sandbox_minutes`.
+default. Sandbox time bills at $0.01 per minute of wall-clock run time.
 
 To construct it explicitly (the adapter itself never reads the environment):
 
@@ -220,7 +251,7 @@ Machines boot from Cloud's own pooled base image (Node plus the in-box agent);
 enforced HTTP(S)-only: raw TCP is severed even to allowlisted hosts, so a
 direct database connection from the box never works while the HTTPS store
 callback does. Errors map to the shared taxonomy: invalid or revoked keys
-(HTTP 401) and exhausted meters (HTTP 402) surface as `cloud-required`,
+(HTTP 401) and used-up included usage (HTTP 402) surface as `cloud-required`,
 console outages as `sandbox-unavailable`; with no key and no adapter at all
 the sandbox slot is simply unconfigured, so machine paths fail with
 `sandbox-unavailable`. See [Server API](/reference/server-api) for the

--- a/docs-site/deploy/vendo-cloud.mdx
+++ b/docs-site/deploy/vendo-cloud.mdx
@@ -144,8 +144,9 @@ they react to events your process emits.
 
 ## Pricing
 
-A plan's price is the amount of usage it includes, and your bill for a period is
-whichever is larger — the plan price or your usage.
+A plan's price is the amount of usage it includes. On a paid plan, your bill for
+a period is whichever is larger — the plan price or your usage. Free never
+bills: it stops when the $5 it includes is spent.
 
 | Plan | Price | Includes |
 | --- | --- | --- |
@@ -154,14 +155,15 @@ whichever is larger — the plan price or your usage.
 | Teams | $499 / month | $499 of usage / month |
 | Enterprise | Custom | Committed usage |
 
-Usage is metered org-wide across every project, at four published rates that are
-identical on every plan, including Free.
+Usage is metered org-wide across every project, at four published rates — AI,
+sandbox, storage, and automation runs — that are identical on every plan,
+including Free. The AI rate prints in three model tiers.
 
 | Rate | Price |
 | --- | --- |
-| `vendo-fast` | $1.15 / M input tokens · $5.75 / M output tokens |
-| `vendo` | $2.30 / M input tokens · $11.50 / M output tokens |
-| `vendo-strong` | $5.75 / M input tokens · $28.75 / M output tokens |
+| AI tier `vendo-fast` | $1.15 / M input tokens · $5.75 / M output tokens |
+| AI tier `vendo` | $2.30 / M input tokens · $11.50 / M output tokens |
+| AI tier `vendo-strong` | $5.75 / M input tokens · $28.75 / M output tokens |
 | Sandbox | $0.01 per minute of wall-clock run time |
 | Storage | $0.25 per GB-month |
 | Automation runs | $3 per 1,000 runs |

--- a/docs-site/reference/cli.mdx
+++ b/docs-site/reference/cli.mdx
@@ -691,6 +691,19 @@ one organization on the account, one project in the organization. Run
 `vendo cloud help` for the full list. See
 [Vendo Cloud](/deploy/vendo-cloud) for setup, keys, and sharing.
 
+`vendo cloud usage [--project <id>] [--days <n>]` — per-day usage for a project:
+request count and dollars at the published rates, plus the period total.
+
+```json
+{
+  "days": [{ "day": "2026-08-04", "requests": 128, "usd": 4.02 }],
+  "totalUsd": 23.41
+}
+```
+
+The rates behind those dollars are in
+[Vendo Cloud › Pricing](/deploy/vendo-cloud#pricing).
+
 ## Telemetry opt-out
 
 Set `VENDO_TELEMETRY_DISABLED=1` or set `"optedOut": true` in

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -270,7 +270,7 @@ order:
    fallback.)
    Model calls go through the Vendo Cloud model gateway (`vendo` by
    default — pin another id with `VENDO_MODEL` or `models.default`, served via
-   `@ai-sdk/anthropic`) and meter your dev-mode runs allowance.
+   `@ai-sdk/anthropic`) and draw down the usage your plan includes.
 3. Nothing available: chat fails honestly, with exact instructions in the
    server log.
 

--- a/packages/agent/src/provider-401.test.ts
+++ b/packages/agent/src/provider-401.test.ts
@@ -65,9 +65,11 @@ describe("a provider 401 at the wire gate", () => {
   it("still renders the pricing sentence for a 401 that carries the meter refusal", async () => {
     // The refusal BODY is self-identifying (pricing v3 §5), so this one needs
     // no guess about origin: the structured fields are the source of truth.
-    const errorText = await errorFrameFor(unauthorized({ code: "meter-exhausted", meter: "ai_tokens" }));
+    const errorText = await errorFrameFor(
+      unauthorized({ code: "meter-exhausted", meter: "usage", unit: "usd" }),
+    );
     expect(errorText).toBe(
-      "Vendo: Vendo Cloud paused AI tokens — the allowance for this billing period is used up. "
+      "Vendo: Vendo Cloud paused usage — the allowance for this billing period is used up. "
       + "Upgrade your plan or bring your own infrastructure. (cloud-required)",
     );
   });

--- a/packages/agent/src/stream-error.test.ts
+++ b/packages/agent/src/stream-error.test.ts
@@ -56,9 +56,10 @@ describe("mid-stream turn errors", () => {
       statusCode: 402,
       responseBody: JSON.stringify({
         code: "meter-exhausted",
-        meter: "ai_tokens",
-        used: 1_204_000,
-        limit: 1_000_000,
+        meter: "usage",
+        unit: "usd",
+        used: 5.2,
+        limit: 5,
         resets_at: "2026-08-01T00:00:00.000Z",
         reason: "allowance",
         exits: { upgrade_url: "https://console.vendo.run/billing", byo_docs_url: "https://docs.vendo.run/byo" },
@@ -66,8 +67,8 @@ describe("mid-stream turn errors", () => {
     }));
     const errorPart = parts.find((part) => part.type === "error");
     expect(errorPart?.errorText).toBe(
-      "Vendo: Vendo Cloud paused AI tokens — the allowance for this billing period is used up "
-      + "(1,204,000 of 1,000,000 used; resets 2026-08-01). "
+      "Vendo: Vendo Cloud paused usage — the $5.00 included this billing period is used up "
+      + "($5.20 of $5.00 used; resets 2026-08-01). "
       + "Upgrade your plan (https://console.vendo.run/billing) "
       + "or bring your own infrastructure (https://docs.vendo.run/byo). (cloud-required)",
     );

--- a/packages/core/src/knowledge-wire.test.ts
+++ b/packages/core/src/knowledge-wire.test.ts
@@ -109,6 +109,41 @@ describe("parseKnowledgeWireError and the meter refusal", () => {
     expect(error.message).toContain("$5.20 of $5.00 used");
   });
 
+  // THE cross-repo seam. This object is the byte-for-byte 402 body the console
+  // emitter produces, copied from the recorded wire fixture
+  // `apps/console/fixtures/knowledge-wire/upsert.quota-exhausted.json` (which
+  // is itself recorded from `poolRefusalResponse`, never hand-written). Neither
+  // side stubs the other: the console's real emitter wrote it, and the real
+  // parser below reads it. If the console changes the envelope, this goes red.
+  const RECORDED_CONSOLE_402 = {
+    error: {
+      code: "meter-exhausted",
+      message:
+        "Meter exhausted: the $5.00 of usage included this billing period is used up ($5.20 used). The included usage resets 2026-08-01T00:00:00.000Z. Two exits: upgrade your plan (https://console.vendo.run/billing) or bring your own infrastructure (https://vendo.run/docs/byo).",
+    },
+    meter: "usage",
+    unit: "usd",
+    used: 5.2,
+    limit: 5,
+    resets_at: "2026-08-01T00:00:00.000Z",
+    reason: "allowance",
+    exits: {
+      upgrade_url: "https://console.vendo.run/billing",
+      byo_docs_url: "https://vendo.run/docs/byo",
+    },
+  };
+
+  it("renders the console's RECORDED 402 body as the crafted currency sentence", () => {
+    const error = parseKnowledgeWireError(402, RECORDED_CONSOLE_402);
+    expect(error.code).toBe("cloud-required");
+    expect(error.message).toBe(
+      "Vendo Cloud paused usage — the $5.00 included this billing period is used up " +
+        "($5.20 of $5.00 used; resets 2026-08-01). " +
+        "Upgrade your plan (https://console.vendo.run/billing) or bring your own " +
+        "infrastructure (https://vendo.run/docs/byo).",
+    );
+  });
+
   it("still maps a bare 402 to cloud-required", () => {
     expect(parseKnowledgeWireError(402, undefined).code).toBe("cloud-required");
     expect(parseKnowledgeWireError(402, undefined).message).toContain("HTTP 402");

--- a/packages/core/src/knowledge-wire.test.ts
+++ b/packages/core/src/knowledge-wire.test.ts
@@ -85,3 +85,38 @@ describe("vendo/knowledge-wire@1", () => {
     expect(parseKnowledgeWireError(501, undefined).code).toBe("not-implemented");
   });
 });
+
+describe("parseKnowledgeWireError and the meter refusal", () => {
+  it("carries the crafted dollar sentence out of a pool 402", () => {
+    const error = parseKnowledgeWireError(402, {
+      error: {
+        code: "meter-exhausted",
+        message: "ignored — the formatter re-renders it",
+      },
+      meter: "usage",
+      unit: "usd",
+      used: 5.2,
+      limit: 5,
+      resets_at: "2026-09-04T00:00:00.000Z",
+      reason: "allowance",
+      exits: {
+        upgrade_url: "https://console.vendo.run/billing",
+        byo_docs_url: "https://docs.vendo.run/deploy/vendo-cloud",
+      },
+    });
+    expect(error.code).toBe("cloud-required");
+    expect(error.message).toContain("Vendo Cloud paused usage");
+    expect(error.message).toContain("$5.20 of $5.00 used");
+  });
+
+  it("still maps a bare 402 to cloud-required", () => {
+    expect(parseKnowledgeWireError(402, undefined).code).toBe("cloud-required");
+    expect(parseKnowledgeWireError(402, undefined).message).toContain("HTTP 402");
+  });
+
+  it("still prefers an enveloped wire-legal code over the status", () => {
+    expect(
+      parseKnowledgeWireError(402, { error: { code: "validation", message: "nope" } }).code,
+    ).toBe("validation");
+  });
+});

--- a/packages/core/src/knowledge-wire.ts
+++ b/packages/core/src/knowledge-wire.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { VendoError, safeErrorMessage, vendoErrorCodeSchema, type VendoErrorCode } from "./errors.js";
+import { formatMeterExhausted, parseMeterExhausted } from "./meter-exhausted.js";
 import {
   knowledgeDocSchema,
   knowledgePostureSchema,
@@ -170,6 +171,12 @@ export function knowledgeWireErrorBody(error: VendoError): { status: number; bod
     tails — e.g. the cloud client folding bare 401 into "cloud-required" —
     belong to the client (ENG-364), not the protocol. */
 export function parseKnowledgeWireError(status: number, body: unknown): VendoError {
+  // The pool refusal wins: it is the ONE crafted sentence every Vendo surface
+  // prints, and this door used to swallow it into a generic 402.
+  const refusal = parseMeterExhausted(body);
+  if (refusal !== undefined) {
+    return new VendoError("cloud-required", formatMeterExhausted(refusal));
+  }
   const parsed = knowledgeWireErrorSchema.safeParse(body);
   if (parsed.success) {
     return new VendoError(parsed.data.error.code, parsed.data.error.message);

--- a/packages/core/src/meter-exhausted.test.ts
+++ b/packages/core/src/meter-exhausted.test.ts
@@ -82,7 +82,9 @@ describe("formatMeterExhausted", () => {
   it("renders the full refusal: meter, figures, reset date, both exits", () => {
     const parsed = parseMeterExhausted({ code: "meter-exhausted", ...REFUSAL_BODY });
     expect(formatMeterExhausted(parsed!)).toBe(
-      "Vendo Cloud paused AI tokens — the allowance for this billing period is used up "
+      // `ai_tokens` is a retired Cloud meter, so it renders through the raw-id
+      // fallback now — the label table carries only the pool meter `usage`.
+      "Vendo Cloud paused ai_tokens — the allowance for this billing period is used up "
       + "(1,204,000 of 1,000,000 used; resets 2026-08-01). "
       + "Upgrade your plan (https://console.vendo.run/billing) "
       + "or bring your own infrastructure (https://docs.vendo.run/byo).",
@@ -91,7 +93,7 @@ describe("formatMeterExhausted", () => {
 
   it("names the spend cap when the reason says so", () => {
     expect(formatMeterExhausted({ meter: "automation_runs", reason: "spend-cap" })).toBe(
-      "Vendo Cloud paused automation runs — your spend cap is reached. "
+      "Vendo Cloud paused automation_runs — your spend cap is reached. "
       + "Upgrade your plan or bring your own infrastructure.",
     );
   });
@@ -105,6 +107,72 @@ describe("formatMeterExhausted", () => {
       "Vendo Cloud paused usage — the allowance for this billing period is used up. "
       + "Upgrade your plan or bring your own infrastructure.",
     );
+  });
+});
+
+describe("formatMeterExhausted in dollars", () => {
+  const usd = {
+    meter: "usage",
+    unit: "usd" as const,
+    used: 49,
+    limit: 49,
+    resetsAt: "2026-09-04T00:00:00.000Z",
+    reason: "allowance",
+    upgradeUrl: "https://console.vendo.run/billing",
+    byoDocsUrl: "https://docs.vendo.run/deploy/vendo-cloud",
+  };
+
+  it("renders currency and names the included dollars", () => {
+    expect(formatMeterExhausted(usd)).toBe(
+      "Vendo Cloud paused usage — the $49.00 included this billing period is used up " +
+        "($49.00 of $49.00 used; resets 2026-09-04). " +
+        "Upgrade your plan (https://console.vendo.run/billing) or bring your own " +
+        "infrastructure (https://docs.vendo.run/deploy/vendo-cloud).",
+    );
+  });
+
+  it("still starts with the head the thread banner matches on", () => {
+    expect(formatMeterExhausted(usd)).toMatch(/^Vendo Cloud paused /);
+  });
+
+  it("names the spend cap when that is the reason", () => {
+    expect(formatMeterExhausted({ ...usd, reason: "spend_cap", limit: 147 })).toContain(
+      "your spend cap is reached",
+    );
+  });
+
+  it("also accepts the hyphenated reason token", () => {
+    expect(formatMeterExhausted({ ...usd, reason: "spend-cap" })).toContain(
+      "your spend cap is reached",
+    );
+  });
+
+  it("falls back to counts when the body carries no unit", () => {
+    expect(
+      formatMeterExhausted({ meter: "usage", used: 300, limit: 300 }),
+    ).toBe(
+      "Vendo Cloud paused usage — the allowance for this billing period is used up " +
+        "(300 of 300 used). Upgrade your plan or bring your own infrastructure.",
+    );
+  });
+
+  it("reads the unit off the wire body", () => {
+    expect(
+      parseMeterExhausted({
+        code: "meter-exhausted",
+        meter: "usage",
+        unit: "usd",
+        used: 5.2,
+        limit: 5,
+      }),
+    ).toEqual({ meter: "usage", unit: "usd", used: 5.2, limit: 5 });
+  });
+
+  it("ignores a unit it does not understand", () => {
+    expect(
+      parseMeterExhausted({ code: "meter-exhausted", meter: "usage", unit: "quatloos" })
+        .unit,
+    ).toBeUndefined();
   });
 });
 

--- a/packages/core/src/meter-exhausted.ts
+++ b/packages/core/src/meter-exhausted.ts
@@ -15,6 +15,10 @@ export interface MeterExhausted {
   /** The refused meter's canonical id (e.g. `ai_tokens`) — or undefined when
    *  the body carried none / an unprintable value (the format falls back). */
   meter?: string;
+  /** `"usd"` means every figure in this refusal is dollars — render currency.
+   *  Absent means counts, so a host pinned to an older @vendoai/core still
+   *  renders a correct (if unit-less) sentence against a new server. */
+  unit?: "usd";
   used?: number;
   limit?: number;
   /** ISO timestamp; kept verbatim (format renders just the date part). */
@@ -28,17 +32,10 @@ export interface MeterExhausted {
 /** The console's stable refusal code (one shape, all services). */
 export const METER_EXHAUSTED_CODE = "meter-exhausted";
 
-/** The six canonical meters' human labels. An unknown meter falls back to its
- *  raw id (new Cloud meters stay nameable without an OSS release) — and to
- *  plain "usage" when the body carried nothing printable. */
-const METER_LABELS: Record<string, string> = {
-  ai_tokens: "AI tokens",
-  sandbox_minutes: "sandbox minutes",
-  storage_gb: "storage",
-  knowledge_gb: "knowledge storage",
-  automation_runs: "automation runs",
-  active_connections: "active connections",
-};
+/** Cloud sends one meter now — `usage`, the org's dollar pool. An unknown meter
+ *  still falls back to its raw id so a future Cloud meter stays nameable
+ *  without an OSS release. */
+const METER_LABELS: Record<string, string> = { usage: "usage" };
 
 /** Only short machine-token strings from the body are ever rendered — the
  *  message stays operator-grade even against a garbled body. */
@@ -91,6 +88,7 @@ export function parseMeterExhausted(payload: unknown): MeterExhausted | undefine
   const result: MeterExhausted = {};
   const meter = asToken(read("meter"));
   if (meter !== undefined) result.meter = meter;
+  if (read("unit") === "usd") result.unit = "usd";
   const used = asCount(read("used"));
   if (used !== undefined) result.used = used;
   const limit = asCount(read("limit"));
@@ -146,11 +144,21 @@ const resetDate = (resetsAt: string | undefined): string | undefined => {
  */
 export function formatMeterExhausted(refusal: MeterExhausted): string {
   const label = refusal.meter === undefined ? "usage" : METER_LABELS[refusal.meter] ?? refusal.meter;
-  const head = refusal.reason === "spend-cap"
+  const money = (value: number): string =>
+    new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
+  const dollars = refusal.unit === "usd";
+  const amount = (value: number): string => (dollars ? money(value) : count.format(value));
+  // The console sends `spend_cap`; this formatter historically only tested
+  // `spend-cap`, so the spend-cap head never rendered in production. Both
+  // tokens are accepted on purpose — do not collapse to one.
+  const capped = refusal.reason === "spend-cap" || refusal.reason === "spend_cap";
+  const head = capped
     ? `Vendo Cloud paused ${label} — your spend cap is reached`
-    : `Vendo Cloud paused ${label} — the allowance for this billing period is used up`;
+    : dollars && refusal.limit !== undefined
+      ? `Vendo Cloud paused ${label} — the ${money(refusal.limit)} included this billing period is used up`
+      : `Vendo Cloud paused ${label} — the allowance for this billing period is used up`;
   const figures = refusal.used !== undefined && refusal.limit !== undefined
-    ? `${count.format(refusal.used)} of ${count.format(refusal.limit)} used`
+    ? `${amount(refusal.used)} of ${amount(refusal.limit)} used`
     : undefined;
   const resets = resetDate(refusal.resetsAt);
   const clauses = [figures, resets === undefined ? undefined : `resets ${resets}`]

--- a/packages/core/src/meter-exhausted.ts
+++ b/packages/core/src/meter-exhausted.ts
@@ -32,11 +32,6 @@ export interface MeterExhausted {
 /** The console's stable refusal code (one shape, all services). */
 export const METER_EXHAUSTED_CODE = "meter-exhausted";
 
-/** Cloud sends one meter now — `usage`, the org's dollar pool. An unknown meter
- *  still falls back to its raw id so a future Cloud meter stays nameable
- *  without an OSS release. */
-const METER_LABELS: Record<string, string> = { usage: "usage" };
-
 /** Only short machine-token strings from the body are ever rendered — the
  *  message stays operator-grade even against a garbled body. */
 const TOKEN = /^[a-z0-9_.:-]{1,64}$/i;
@@ -127,6 +122,7 @@ export function meterExhaustedFromError(error: unknown): MeterExhausted | undefi
 }
 
 const count = new Intl.NumberFormat("en-US");
+const money = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" });
 
 const resetDate = (resetsAt: string | undefined): string | undefined => {
   if (resetsAt === undefined) return undefined;
@@ -143,20 +139,21 @@ const resetDate = (resetsAt: string | undefined): string | undefined => {
  * CLI, and doctor all print exactly this.
  */
 export function formatMeterExhausted(refusal: MeterExhausted): string {
-  const label = refusal.meter === undefined ? "usage" : METER_LABELS[refusal.meter] ?? refusal.meter;
-  const money = (value: number): string =>
-    new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
+  // Cloud sends one meter now — `usage`, the org's dollar pool. Any other meter
+  // renders its raw id, so a future Cloud meter stays nameable without an OSS release.
+  const label = refusal.meter ?? "usage";
   const dollars = refusal.unit === "usd";
-  const amount = (value: number): string => (dollars ? money(value) : count.format(value));
+  const amount = (value: number): string => (dollars ? money.format(value) : count.format(value));
   // The console sends `spend_cap`; this formatter historically only tested
   // `spend-cap`, so the spend-cap head never rendered in production. Both
   // tokens are accepted on purpose — do not collapse to one.
-  const capped = refusal.reason === "spend-cap" || refusal.reason === "spend_cap";
-  const head = capped
-    ? `Vendo Cloud paused ${label} — your spend cap is reached`
-    : dollars && refusal.limit !== undefined
-      ? `Vendo Cloud paused ${label} — the ${money(refusal.limit)} included this billing period is used up`
-      : `Vendo Cloud paused ${label} — the allowance for this billing period is used up`;
+  let cause = "the allowance for this billing period is used up";
+  if (refusal.reason === "spend-cap" || refusal.reason === "spend_cap") {
+    cause = "your spend cap is reached";
+  } else if (dollars && refusal.limit !== undefined) {
+    cause = `the ${money.format(refusal.limit)} included this billing period is used up`;
+  }
+  const head = `Vendo Cloud paused ${label} — ${cause}`;
   const figures = refusal.used !== undefined && refusal.limit !== undefined
     ? `${amount(refusal.used)} of ${amount(refusal.limit)} used`
     : undefined;

--- a/packages/ui/e2e/pass3-consumer-voice.spec.ts
+++ b/packages/ui/e2e/pass3-consumer-voice.spec.ts
@@ -32,8 +32,8 @@ const MODEL_INSTRUCTION =
 const ROUTE_FALLBACK = "POST /api/demo/pin";
 
 /** The scheduler's own refusal, as the run-history row used to print it. */
-const RUN_FAILURE_WIRE = "meter-exhausted: blocked by allowance: Vendo Cloud paused automation"
-  + " runs — the allowance for this billing period is used up (resets 2026-08-01)."
+const RUN_FAILURE_WIRE = "meter-exhausted: blocked by allowance: Vendo Cloud paused usage"
+  + " — the $49.00 included this billing period is used up (resets 2026-08-01)."
   + " Upgrade your plan (https://console.vendo.run/billing).";
 
 /** The card's ask, applied to the WIRE's own pending approval so the queue row
@@ -61,7 +61,7 @@ const FAILED_RUN = {
   steps: [],
   error: {
     code: "meter-exhausted",
-    message: "blocked by allowance: Vendo Cloud paused automation runs — the allowance for this"
+    message: "blocked by allowance: Vendo Cloud paused usage — the $49.00 included this"
       + " billing period is used up (resets 2026-08-01). Upgrade your plan"
       + " (https://console.vendo.run/billing) or bring your own infrastructure"
       + " (https://docs.vendo.run/byo).",

--- a/packages/ui/test/chrome/error-surface.test.tsx
+++ b/packages/ui/test/chrome/error-surface.test.tsx
@@ -53,13 +53,13 @@ describe("the turn-error gate (C4)", () => {
   });
 
   it("keeps the ONE crafted sentence that is consumer copy — the meter refusal", () => {
-    const meter = "Vendo: Vendo Cloud paused AI tokens — the allowance for this billing period is used up "
-      + "(1,204,000 of 1,000,000 used; resets 2026-08-01). "
+    const meter = "Vendo: Vendo Cloud paused usage — the $5.00 included this billing period is used up "
+      + "($5.00 of $5.00 used; resets 2026-08-01). "
       + "Upgrade your plan (https://console.vendo.run/billing) "
       + "or bring your own infrastructure (https://docs.vendo.run/byo). (cloud-required)";
     expect(turnErrorSentence(meter)).toBe(
-      "Vendo Cloud paused AI tokens — the allowance for this billing period is used up "
-      + "(1,204,000 of 1,000,000 used; resets 2026-08-01). "
+      "Vendo Cloud paused usage — the $5.00 included this billing period is used up "
+      + "($5.00 of $5.00 used; resets 2026-08-01). "
       + "Upgrade your plan (https://console.vendo.run/billing) "
       + "or bring your own infrastructure (https://docs.vendo.run/byo).",
     );
@@ -131,8 +131,8 @@ describe("visible error surface + retry (ENG-214)", () => {
     // Vendo-detail rail as any safe stream error, and the turn ends (Retry).
     wire.state.streamFailures = 1;
     wire.state.streamFailureText =
-      "Vendo: Vendo Cloud paused AI tokens — the allowance for this billing period is used up "
-      + "(1,204,000 of 1,000,000 used; resets 2026-08-01). "
+      "Vendo: Vendo Cloud paused usage — the $5.00 included this billing period is used up "
+      + "($5.00 of $5.00 used; resets 2026-08-01). "
       + "Upgrade your plan (https://console.vendo.run/billing) "
       + "or bring your own infrastructure (https://docs.vendo.run/byo). (cloud-required)";
     render(<VendoProvider client={client}><VendoThread threadId="thr_1" /></VendoProvider>);
@@ -141,7 +141,7 @@ describe("visible error surface + retry (ENG-214)", () => {
     sendFromComposer("Hello");
     const banner = (await screen.findByText(/Something went wrong/)).closest(".fl-error");
     expect(banner?.textContent).toContain("Something went wrong");
-    expect(banner?.textContent).toContain("Vendo Cloud paused AI tokens");
+    expect(banner?.textContent).toContain("Vendo Cloud paused usage");
     expect(banner?.textContent).toContain("resets 2026-08-01");
     expect(banner?.textContent).toContain("Upgrade your plan (https://console.vendo.run/billing)");
     expect(banner?.textContent).toContain("bring your own infrastructure (https://docs.vendo.run/byo)");

--- a/packages/ui/test/chrome/panels.test.tsx
+++ b/packages/ui/test/chrome/panels.test.tsx
@@ -299,7 +299,7 @@ describe("ActivityPanel and AutomationsPanel exports", () => {
   /** The scheduler's own refusal, written for whoever runs the deployment: it
    *  names a billing allowance and links a console. */
   const BLOCKED_REASON =
-    "blocked by allowance: Vendo Cloud paused automation runs — the allowance for this billing "
+    "blocked by allowance: Vendo Cloud paused usage — the $49.00 included this billing "
     + "period is used up (resets 2026-08-01). Upgrade your plan (https://console.vendo.run/billing) "
     + "or bring your own infrastructure (https://docs.vendo.run/byo).";
 

--- a/packages/vendo/src/cli/cloud/client.test.ts
+++ b/packages/vendo/src/cli/cloud/client.test.ts
@@ -55,12 +55,14 @@ describe("cloud client", () => {
     }));
   });
 
-  it("prints a meter-exhausted 402 as the one crafted refusal sentence (pricing v3 §5)", async () => {
+  it("prints a meter-exhausted 402 as the one crafted refusal sentence", async () => {
+    // The console's real 402 body: one meter (`usage`), dollars, one limit.
     const fetchImpl = vi.fn().mockResolvedValue(Response.json({
       error: { code: "meter-exhausted", message: "meter exhausted" },
-      meter: "automation_runs",
-      used: 1_050,
-      limit: 1_000,
+      meter: "usage",
+      unit: "usd",
+      used: 105,
+      limit: 100,
       resets_at: "2026-08-01T00:00:00.000Z",
       reason: "allowance",
       exits: { upgrade_url: "https://console.vendo.run/billing", byo_docs_url: "https://docs.vendo.run/byo" },
@@ -73,8 +75,8 @@ describe("cloud client", () => {
     })).rejects.toMatchObject<Partial<CloudError>>({
       name: "CloudError",
       code: "meter-exhausted",
-      message: "Vendo Cloud paused automation runs — the allowance for this billing period is used up "
-        + "(1,050 of 1,000 used; resets 2026-08-01). "
+      message: "Vendo Cloud paused usage — the $100.00 included this billing period is used up "
+        + "($105.00 of $100.00 used; resets 2026-08-01). "
         + "Upgrade your plan (https://console.vendo.run/billing) "
         + "or bring your own infrastructure (https://docs.vendo.run/byo).",
       status: 402,

--- a/packages/vendo/src/cli/cloud/read.test.ts
+++ b/packages/vendo/src/cli/cloud/read.test.ts
@@ -39,6 +39,20 @@ describe("cloud organization reads", () => {
     expect(fetcher.mock.calls[2]?.[0]).toBe("/api/v1/projects/proj_only/usage?days=30");
   });
 
+  // Pins the dollar fields the usage route now returns. runUsage hands the
+  // response straight to printJson, so nothing here transforms them — this
+  // test exists so a future refactor cannot silently drop them.
+  it("prints the dollar figures the usage route returns", async () => {
+    const messages = output();
+    const fetcher = vi.fn().mockResolvedValue({
+      days: [{ day: "2026-08-04", requests: 2, usd: 4 }],
+      totalUsd: 4,
+    });
+    expect(await runUsage(["--project", "p1"], { output: messages.sink, fetcher })).toBe(0);
+    expect(messages.logs.join("\n")).toContain('"usd": 4');
+    expect(messages.logs.join("\n")).toContain('"totalUsd": 4');
+  });
+
   it("returns a clear error when a project cannot be inferred", async () => {
     const messages = output();
     const fetcher = vi.fn()

--- a/packages/vendo/src/hosted-store.test.ts
+++ b/packages/vendo/src/hosted-store.test.ts
@@ -223,22 +223,24 @@ describe("hostedStore error mapping", () => {
     });
   });
 
-  it("renders the pricing-v3 meter-exhausted refusal as the crafted spec-§5 sentence", async () => {
+  it("renders the pool meter-exhausted refusal as the crafted dollar sentence", async () => {
+    // The console's real 402 body: one meter (`usage`), dollars, one limit.
     const store = adapterFor(respond("meter-exhausted", "meter exhausted", 402, {
-      meter: "storage_gb",
-      used: 12,
-      limit: 10,
+      meter: "usage",
+      unit: "usd",
+      used: 6.2,
+      limit: 5,
       resets_at: "2026-08-01T00:00:00.000Z",
       reason: "allowance",
       exits: { upgrade_url: "https://console.vendo.run/billing", byo_docs_url: "https://docs.vendo.run/byo" },
     }));
     await expect(store.records("invoices").put({ id: "r", data: {} })).rejects.toMatchObject({
       code: "cloud-required",
-      message: "Vendo Cloud paused storage — the allowance for this billing period is used up "
-        + "(12 of 10 used; resets 2026-08-01). "
+      message: "Vendo Cloud paused usage — the $5.00 included this billing period is used up "
+        + "($6.20 of $5.00 used; resets 2026-08-01). "
         + "Upgrade your plan (https://console.vendo.run/billing) "
         + "or bring your own infrastructure (https://docs.vendo.run/byo).",
-      detail: { meter: "storage_gb" },
+      detail: { meter: "usage", unit: "usd" },
     });
   });
 

--- a/packages/vendo/src/sandbox.test.ts
+++ b/packages/vendo/src/sandbox.test.ts
@@ -555,13 +555,15 @@ describe("cloudSandbox", () => {
       .rejects.toMatchObject({ code: "cloud-required" });
   });
 
-  it("renders the pricing-v3 meter-exhausted refusal as the crafted spec-§5 sentence", async () => {
+  it("renders the pool meter-exhausted refusal as the crafted dollar sentence", async () => {
+    // The console's real 402 body: one meter (`usage`), dollars, one limit.
     const refused = vi.fn(async () => Response.json(
       {
         error: { code: "meter-exhausted", message: "meter exhausted" },
-        meter: "sandbox_minutes",
-        used: 5_400,
-        limit: 5_000,
+        meter: "usage",
+        unit: "usd",
+        used: 54,
+        limit: 49,
         resets_at: "2026-08-01T00:00:00.000Z",
         reason: "allowance",
         exits: { upgrade_url: "https://console.vendo.run/billing", byo_docs_url: "https://docs.vendo.run/byo" },
@@ -571,11 +573,11 @@ describe("cloudSandbox", () => {
     const adapter = cloudSandbox({ apiKey: "vnd_secret", baseUrl: "https://cloud.test", fetch: refused as unknown as typeof fetch });
     await expect(adapter.create({ env: {} })).rejects.toMatchObject({
       code: "cloud-required",
-      message: "Vendo Cloud paused sandbox minutes — the allowance for this billing period is used up "
-        + "(5,400 of 5,000 used; resets 2026-08-01). "
+      message: "Vendo Cloud paused usage — the $49.00 included this billing period is used up "
+        + "($54.00 of $49.00 used; resets 2026-08-01). "
         + "Upgrade your plan (https://console.vendo.run/billing) "
         + "or bring your own infrastructure (https://docs.vendo.run/byo).",
-      detail: { meter: "sandbox_minutes", used: 5_400, limit: 5_000 },
+      detail: { meter: "usage", unit: "usd", used: 54, limit: 49 },
     });
   });
 


### PR DESCRIPTION
## What

The 402 refusal now renders in currency ("Vendo Cloud paused usage — …"). Knowledge's
402 path now joins the standard parser instead of being handled separately. `vendo
cloud usage` returns dollar amounts. Docs gain the pricing table.

## Why

Ties the OSS-side surfaces (CLI, refusal messages, docs) to the pricing model
shipping in the companion vendo-web PR (tandem — must merge in the same window):
https://github.com/runvendo/vendo-web/pull/268

## Verification

- [x] Full turbo suite green (56 tasks)
- [x] typecheck 43/43
- [x] lint clean
- [ ] Screenshots attached (if UI-affecting) — N/A, no UI in this repo; UI screenshots
      are in the companion vendo-web PR above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render 402 “meter-exhausted” refusals in dollars and switch messaging to the single `usage` pool across CLI, core, and UI. `vendo cloud usage` now reports per‑day dollar totals, and docs add a pricing table, rates, and a clear paid‑vs‑Free billing model.

- New Features
  - Dollar-aware refusal messages when the wire includes `unit: "usd"` (e.g., “Vendo Cloud paused usage — the $49.00 included this billing period is used up …”); accepts both `spend-cap` and `spend_cap`; non-`usage` meters fall back to raw ids.
  - Knowledge-wire 402s now flow through the shared meter‑refusal parser, returning `cloud-required` with the crafted sentence.
  - `vendo cloud usage` prints `usd` per day and `totalUsd`; docs cover plan pricing, published rates, Free’s $5 hard‑stop, and that paid plans bill max(plan price, usage).

<sup>Written for commit 1b0e46803cc0ffd4982f78fb40c7a78ad4c63d73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

