### PR TITLE
feat(vendo,examples): an outside agent asks for a screen and gets words back

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/claude-marketplace.json",
+  "name": "vendo",
+  "description": "The Vendo plugin: Claude Code acts through a Vendo-equipped product's own API, as the signed-in user.",
+  "owner": { "name": "Vendo", "url": "https://vendo.run" },
+  "plugins": [
+    {
+      "name": "vendo",
+      "source": "./examples/claude-code-plugin",
+      "description": "Connect Claude Code to a product running Vendo: guarded host tools, and `vendo_make` for putting a screen in front of the user."
+    }
+  ]
+}

--- a/examples/claude-code-plugin/.claude-plugin/plugin.json
+++ b/examples/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "vendo",
+  "displayName": "Vendo",
+  "description": "Connect Claude Code to a product running Vendo: act through its API as the signed-in user, and make that user a screen instead of typing the answer out.",
+  "version": "0.1.0",
+  "author": { "name": "Vendo", "url": "https://vendo.run" },
+  "homepage": "https://docs.vendo.run/capabilities/mcp",
+  "repository": "https://github.com/runvendo/vendo",
+  "license": "Apache-2.0",
+  "keywords": ["vendo", "mcp", "generated-ui"]
+}

--- a/examples/claude-code-plugin/.mcp.json
+++ b/examples/claude-code-plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "vendo": {
+      "type": "http",
+      "url": "${VENDO_MCP_URL:-http://localhost:3000/api/vendo/mcp}"
+    }
+  }
+}

--- a/examples/claude-code-plugin/README.md
+++ b/examples/claude-code-plugin/README.md
@@ -1,0 +1,66 @@
+# The Vendo plugin for Claude Code
+
+Two files and one skill. That is the whole plugin, and it is deliberate: the
+MCP door already projects the product's tools verbatim, so a plugin has nothing
+to implement. What it adds is **judgment** — teaching an outside agent *when* an
+answer wants to be looked at rather than read, and how to ask.
+
+| File | What it is |
+| --- | --- |
+| [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json) | the manifest |
+| [`.mcp.json`](.mcp.json) | the connection — one remote HTTP MCP server, the product's door |
+| [`skills/make-a-screen/SKILL.md`](skills/make-a-screen/SKILL.md) | when and how to call `vendo_make` |
+
+No door code, no second tool surface, no client. `vendo_make` and every host
+tool arrive through the door's own `tools/list`.
+
+## Install
+
+```bash
+# in Claude Code, from anywhere
+/plugin marketplace add runvendo/vendo
+/plugin install vendo@vendo
+```
+
+Point it at your deployment (the default is a local `pnpm --filter demo-bank dev`):
+
+```bash
+export VENDO_MCP_URL=https://app.example.com/api/vendo/mcp
+```
+
+## Signing in
+
+Nothing to configure. The door answers an unauthenticated request with the
+RFC 9728 protected-resource challenge, so Claude Code runs the standard OAuth
+flow itself — dynamic client registration, PKCE, your product's own login and
+consent page. You are the user you signed in as, and every tool call is judged
+by your product's policy, parked for your own approval, and audited under your
+subject.
+
+Revoke it the way you revoke anything else: the door's client list is per
+subject, and a revoked client's bearer stops working on its next request.
+
+## What Claude Code can then do
+
+```
+> what did I spend on travel last quarter?
+```
+
+It calls the product's read tools and answers in text.
+
+```
+> make me something I can watch my travel spend on
+```
+
+It calls `vendo_make` with a plain-language request, gets back a one-line
+receipt, and says it. The screen itself never touches the conversation — it
+arrives on your own page in the product, on a channel the agent is not on. That
+separation is the point: pixels go server → slot, words go to the agent.
+
+## The skill's job
+
+An agent that has `vendo_make` in its tool list will still use it wrongly: for
+answers that were one sentence, with numbers it computed pasted into the
+request, or by inventing a description of a screen it never saw. The skill is
+the fix for all three, and it is one screen of text because it gets read
+mid-conversation.

--- a/examples/claude-code-plugin/skills/make-a-screen/SKILL.md
+++ b/examples/claude-code-plugin/skills/make-a-screen/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: make-a-screen
+description: Use when an answer about the connected product would land better as something the person can look at and use than as text you type out — a comparison, a trend, many rows, a thing they will come back to, or a thing they need to act on. Also use when they ask to change a screen they already have.
+---
+
+# Making the person a screen
+
+The connected product exposes one tool for this: `vendo_make`. It is the only
+way to put a screen in front of the person, and you never build UI yourself.
+
+## When an answer wants to be looked at
+
+Reach for `vendo_make` when the honest answer is a shape rather than a sentence:
+
+- **more than a handful of rows** — you would be reading a table out loud
+- **a comparison, a trend, or a breakdown** — anything with an "over time" or
+  "versus" in it
+- **something they will come back to** — "keep an eye on", "every week", "track"
+- **something they need to act on** — a screen can carry the buttons; your
+  message cannot
+
+Answer in words instead when the answer *is* words: one number, one status, one
+fact, a yes or no, or an explanation. A screen for "what's my balance" is worse
+than saying the balance.
+
+## How to phrase `request`
+
+`request` is prose — what you would say to a designer sitting next to you. Say
+what the person wants, in your own words.
+
+- **Do** describe the want: "the last three months of spending, broken down by
+  category, with a way to jump into any month"
+- **Don't** describe an implementation: no component names, no layout grids, no
+  JSON, no field names you guessed at
+- **Don't** ask for fonts, colors, or branding — it inherits the product's own
+- **Don't** bake in data. Never paste numbers you looked up or computed
+  ("Total: $4,210"). The screen binds live data itself, and hardcoded figures
+  are rejected as invented
+
+Pass `context` for background the product cannot see from its side: what they
+told you earlier in this conversation, a constraint they mentioned, which of
+several things they meant. Free text, a couple of sentences.
+
+Pass `app` **only** to change one specific existing app you already have the id
+for. Leaving it out lets the product decide whether to continue the last thing
+or start something new — which is usually the right call.
+
+## What comes back, and what does not
+
+You get a receipt: an id, a title, a status, and `say` — one line written in the
+person's voice. **Say `say`, close to verbatim.** That is the whole report.
+
+You never get the screen. Pixels travel from the server straight to the
+person's own page, on a channel you are not on.
+
+So:
+
+- **Never wait for it.** There is nothing to poll and nothing to check. The
+  receipt is the end of your turn's work on it.
+- **Never describe it.** You have not seen it. Do not narrate sections, charts,
+  colors, or buttons, and do not tell them what to click.
+- **Never paste a link or an id** unless they asked for one.
+- If `status` is `"failed"`, try once more on the same `app` with a narrower
+  request. If it fails again, say so plainly and stop.
+- If `status` is `"building"`, that is the honest answer: it is on its way.
+  Say the line and move on.

--- a/examples/mcp-agent/README.md
+++ b/examples/mcp-agent/README.md
@@ -1,0 +1,86 @@
+# A stock AI SDK agent through the MCP door
+
+[`agent.mjs`](agent.mjs) is the doors proof: **an agent with no Vendo code in its
+process** asking a Vendo-equipped product to make its user a screen.
+
+Three third-party packages and nothing else — `ai` for the loop,
+`@ai-sdk/anthropic` for the model, `@modelcontextprotocol/sdk` for the
+connection. `grep @vendoai agent.mjs` returns nothing, and that is the claim: an
+outside agent needs no SDK, no adapter, and no integration to reach the product's
+tools. It connects to the door, takes its `tools/list` verbatim, and hands the
+whole thing to `streamText`.
+
+Contrast with [`../ai-sdk-agent`](../ai-sdk-agent), which is the *other* door: an
+agent running **inside** the host's own backend, spreading the guarded tool pack
+into its loop with `@vendoai/vendo/ai-sdk`. Same `vendo_make`, same guard, same
+audit — one door for your own agent, one for everyone else's.
+
+## Run it
+
+```bash
+# 1. a live deployment (any Vendo host with `mcp: true`)
+pnpm --filter demo-bank dev
+
+# 2. the agent
+export ANTHROPIC_API_KEY=sk-ant-…
+export VENDO_MCP_URL=http://localhost:3000/api/vendo/mcp
+node examples/mcp-agent/agent.mjs "make me something I can watch this month's spending on"
+```
+
+## What it prints
+
+```
+door     http://localhost:3123/api/vendo/mcp
+bearer   vmat_EAqWt7p…  (the product's own OAuth: DCR, PKCE, login, consent)
+listed   21 tools, including vendo_make
+
+user     make me something I can watch this month's spending on
+
+agent    → vendo_make({"request":"A spending dashboard for the current month showing total
+           spend, a breakdown by category with amounts and progress bars, and a list of
+           recent transactions. Keep it live so it updates as new transactions come in."})
+         ← {"id":"app_790892b0…","title":"August Spending","status":"ready",
+            "say":"August Spending is on your screen."}
+
+         August Spending is on your screen! …
+
+receipt  {"id":"app_790892b0…","title":"August Spending","status":"ready","say":"…"}
+
+PASS — words to the agent, pixels to the product.
+       the screen is at http://localhost:3123/vendo/apps  (app app_790892b0…)
+```
+
+Read that bottom line literally. The agent got four fields of words and narrated
+them; it never received a tree, a component, a payload or a URL. The screen went
+server → the product's own page, and this process never saw it. Open the app in
+the product to look at it — the screen the agent cannot describe.
+
+The script asserts the receipt law itself: if `tree`, `components`,
+`componentTools`, `machine` or `snapshotRef` ever appeared in a receipt, it exits
+non-zero and says which one.
+
+## Two things it will do that are not bugs
+
+**A read may park for approval.** Under a `cautious` policy an outside agent's
+tool call is judged like any other, so the first `host_*` read comes back as
+"approval `apr_…` is waiting in the product's queue". Approve it in the product
+(the Vendo tab's approvals inbox) and run again — that is the perimeter working,
+and the reason the door is not a bypass.
+
+**`vendo_make` may answer `failed` and explain why.** The checks floor rejects a
+screen whose bindings claim data the host does not return ("the binding sums
+`spending.amount`, but the query returns `amount_cents`"). The agent gets that
+sentence and can retry with a narrower request. A broken binding is a lie, and it
+never reaches the person.
+
+## Signing in
+
+The `bearer()` function is the part a real MCP client does in a browser: Claude
+Code, Cursor and ChatGPT open the door's authorize URL and the person signs in
+and consents on the product's own pages. This script is headless, so it walks the
+same redirects itself — discovery, dynamic client registration, PKCE S256, the
+product's login, the door's consent page, code exchange.
+
+If you are wiring a real client instead of a script, none of that is your code to
+write. See [`../claude-code-plugin`](../claude-code-plugin) — it is a manifest, a
+connection and a skill.

--- a/examples/mcp-agent/agent.mjs
+++ b/examples/mcp-agent/agent.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/**
+ * THE DOORS PROOF — a stock AI SDK agent, no Vendo imports, reaching a live
+ * Vendo deployment through the MCP door.
+ *
+ * Three third-party packages and nothing else: `ai` for the loop,
+ * `@ai-sdk/anthropic` for the model, `@modelcontextprotocol/sdk` for the
+ * connection. Grep this file for `@vendoai` — there is nothing to find. That is
+ * the claim being proved: an outside agent gets the product's tools and
+ * `vendo_make` with no SDK, no adapter, and no code of ours in its process.
+ *
+ * What you should see:
+ *   1. the door lists `vendo_make` alongside the product's own tools
+ *   2. the model calls it with a plain-language request
+ *   3. it gets back a RECEIPT — four fields of words, never a screen
+ *   4. it narrates the receipt in its own voice
+ *   5. the screen is on the product's page, which this process never touched
+ *
+ * Usage:
+ *   ANTHROPIC_API_KEY=sk-ant-… \
+ *   VENDO_MCP_URL=http://localhost:3000/api/vendo/mcp \
+ *   node agent.mjs ["what to ask for"]
+ */
+import { createHash, randomBytes } from "node:crypto";
+import { anthropic } from "@ai-sdk/anthropic";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { jsonSchema, stepCountIs, streamText, tool } from "ai";
+
+const DOOR = process.env.VENDO_MCP_URL ?? "http://localhost:3000/api/vendo/mcp";
+const ASK = process.argv[2] ?? "make me something I can watch this month's spending on";
+const EMAIL = process.env.DEMO_EMAIL ?? "yousef@maple.com";
+const PASSWORD = process.env.DEMO_PASSWORD ?? "maple-demo";
+const REDIRECT = "http://127.0.0.1:43117/callback";
+
+/** Where the product lives, and where its door is mounted inside it — a Vendo
+ *  deployment can sit under a path prefix, so the two are derived separately. */
+const MOUNT = "/api/vendo/mcp";
+const HOST = DOOR.replace(new RegExp(`${MOUNT}/?$`), "");
+const b64url = (bytes) => Buffer.from(bytes).toString("base64url");
+const cookiesOf = (response) => response.headers.getSetCookie().map((raw) => raw.split(";")[0]).join("; ");
+const field = (html, name) => html.match(new RegExp(`name="${name}"[^>]+value="([^"]+)"`, "i"))?.[1]
+  ?.replaceAll("&amp;", "&");
+
+const die = async (stage, response) => {
+  console.error(`\n${stage} failed (${response.status}): ${(await response.text()).slice(0, 300)}`);
+  process.exit(1);
+};
+
+/**
+ * SIGN IN — the part a real MCP client does in a browser.
+ *
+ * Claude Code, Cursor and ChatGPT open the door's authorize URL and the person
+ * signs in and consents on the product's own pages. This script is headless, so
+ * it walks the same three redirects itself: the door bounces to the product's
+ * login, the product sets its session and sends us back, and the door's consent
+ * page asks the person to allow this client. Nothing here is Vendo-specific
+ * except which fields the demo host's login form wants.
+ *
+ * Everything else is stock RFC 8414 discovery, dynamic client registration and
+ * PKCE — the flow every MCP client already implements.
+ */
+async function bearer() {
+  const discovered = await fetch(`${HOST}/.well-known/oauth-authorization-server${MOUNT}`);
+  if (!discovered.ok) await die("discovery", discovered);
+  const meta = await discovered.json();
+
+  const registered = await fetch(meta.registration_endpoint, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ client_name: "stock-ai-sdk-agent", redirect_uris: [REDIRECT] }),
+  });
+  if (!registered.ok) await die("register", registered);
+  const { client_id: clientId } = await registered.json();
+
+  const verifier = b64url(randomBytes(32));
+  const state = b64url(randomBytes(16));
+  const authorize = new URL(meta.authorization_endpoint);
+  authorize.search = new URLSearchParams({
+    response_type: "code",
+    client_id: clientId,
+    redirect_uri: REDIRECT,
+    code_challenge: b64url(createHash("sha256").update(verifier).digest()),
+    code_challenge_method: "S256",
+    resource: DOOR,
+    state,
+  }).toString();
+
+  // 1. the door bounces an unauthenticated authorize to the product's login
+  const bounce = await fetch(authorize, { redirect: "manual" });
+  const login = new URL(bounce.headers.get("location") ?? "", HOST);
+  const returnTo = login.searchParams.get("returnTo");
+  if (returnTo === null) await die("authorize bounce", bounce);
+
+  // 2. the product signs the person in and sends them back to the exact request
+  const signedIn = await fetch(new URL(login.pathname, HOST), {
+    method: "POST",
+    redirect: "manual",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ email: EMAIL, password: PASSWORD, returnTo }),
+  });
+  const session = cookiesOf(signedIn);
+  if (!session.includes("session-token")) await die("sign-in", signedIn);
+
+  // 3. the door's own consent page — "allow this client to act as you"
+  const consentUrl = signedIn.headers.get("location");
+  const consent = await fetch(consentUrl, { redirect: "manual", headers: { cookie: session } });
+  const html = await consent.text();
+  const form = html.match(/<form[^>]+action="([^"]+)"/i)?.[1]?.replaceAll("&amp;", "&");
+  if (form === undefined) {
+    console.error(`\nconsent page did not render a form (${consent.status})`);
+    process.exit(1);
+  }
+  const approved = await fetch(new URL(form, HOST), {
+    method: "POST",
+    redirect: "manual",
+    headers: { cookie: session, "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      transaction: field(html, "transaction") ?? "",
+      csrf_token: field(html, "csrf_token") ?? "",
+      decision: "approve",
+    }),
+  });
+  const callback = new URL(approved.headers.get("location") ?? "", HOST);
+  if (callback.searchParams.get("state") !== state) await die("consent", approved);
+  const code = callback.searchParams.get("code");
+
+  const issued = await fetch(meta.token_endpoint, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      code_verifier: verifier,
+      client_id: clientId,
+      redirect_uri: REDIRECT,
+      resource: DOOR,
+    }),
+  });
+  if (!issued.ok) await die("token", issued);
+  return (await issued.json()).access_token;
+}
+
+console.log(`door     ${DOOR}`);
+const token = await bearer();
+console.log(`bearer   ${token.slice(0, 12)}…  (the product's own OAuth: DCR, PKCE, login, consent)`);
+
+const client = new Client({ name: "stock-ai-sdk-agent", version: "1.0.0" });
+await client.connect(new StreamableHTTPClientTransport(new URL(DOOR), {
+  requestInit: { headers: { authorization: `Bearer ${token}` } },
+}));
+
+/** Every tool the door offers, handed to the loop verbatim. The door's listing
+ *  IS the tool set — this script curates nothing and knows no tool by name. */
+const { tools: listed } = await client.listTools();
+console.log(`listed   ${listed.length} tools, including ${
+  listed.some((entry) => entry.name === "vendo_make") ? "vendo_make" : "NO vendo_make"
+}\n`);
+
+const receipts = [];
+const tools = Object.fromEntries(listed.map((entry) => [entry.name, tool({
+  description: entry.description,
+  inputSchema: jsonSchema(entry.inputSchema),
+  async execute(args) {
+    console.log(`→ ${entry.name}(${JSON.stringify(args).slice(0, 300)})`);
+    const result = await client.callTool({ name: entry.name, arguments: args });
+    const text = (result.content ?? []).map((part) => part.text ?? "").join("");
+    console.log(`← ${text.slice(0, 300)}\n`);
+    if (entry.name === "vendo_make" && result.isError !== true) receipts.push(text);
+    return text;
+  },
+})]));
+
+console.log(`user     ${ASK}\n`);
+const run = streamText({
+  model: anthropic("claude-sonnet-4-6"),
+  system: "You are an assistant inside a banking product. When an answer would be better looked"
+    + " at than read, call vendo_make with a plain-language request, then say the receipt's `say`"
+    + " line. You never see the screen and must not describe one.",
+  prompt: ASK,
+  stopWhen: stepCountIs(4),
+  tools,
+});
+
+process.stdout.write("agent    ");
+for await (const delta of run.textStream) process.stdout.write(delta);
+console.log("\n");
+
+await client.close();
+
+// The proof, stated. `receipts` holds exactly what crossed the wire: four
+// fields of words. A tree, an island source or a machine ref in there would
+// break the receipt law (build contract §3.1), and this says so out loud.
+if (receipts.length === 0) {
+  console.error("FAIL — the agent never got a receipt from vendo_make");
+  process.exit(1);
+}
+const receipt = JSON.parse(receipts.at(-1));
+console.log(`receipt  ${JSON.stringify(receipt)}`);
+const leaked = ["tree", "components", "componentTools", "machine", "snapshotRef"]
+  .filter((name) => name in receipt);
+if (leaked.length > 0) {
+  console.error(`FAIL — the receipt carried UI: ${leaked.join(", ")}`);
+  process.exit(1);
+}
+console.log("\nPASS — words to the agent, pixels to the product.");
+console.log(`       the screen is at ${HOST}/vendo/apps  (app ${receipt.id})`);

--- a/examples/mcp-agent/package.json
+++ b/examples/mcp-agent/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@vendoai-examples/mcp-agent",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "A stock AI SDK agent that reaches a Vendo-equipped product through the MCP door — zero Vendo imports. The doors proof: `vendo_make` called from outside, the receipt narrated by the calling agent, the screen landing on the product's own page.",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "agent": "node agent.mjs"
+  },
+  "dependencies": {
+    "@ai-sdk/anthropic": "3.0.12",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "ai": "6.0.28"
+  }
+}

--- a/packages/vendo/src/mcp-door-parity.e2e.test.ts
+++ b/packages/vendo/src/mcp-door-parity.e2e.test.ts
@@ -36,10 +36,12 @@
  * `mcp-door-outside-agent.e2e.test.ts`.
  */
 import type { ExtractedTool } from "@vendoai/actions";
-import { afterEach, describe, expect, it } from "vitest";
+import { VENDO_MAKE_TOOL, VENDO_TOOL_TITLES, makeReceiptSchema } from "@vendoai/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   MOUNT,
   READ_TOOL,
+  SCREEN_TITLE,
   SUBJECT,
   WRITE_TOOL,
   type DoorSession,
@@ -50,12 +52,16 @@ import {
   runCleanups,
   runHarnessTurn,
   runUnattendedTurn,
+  screenModel,
   shapeOf,
   tapWhenItAppears,
   toolRows,
 } from "./mcp-door.test-util.js";
 
-afterEach(runCleanups);
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await runCleanups();
+});
 
 describe("parity gate — the MCP door vs the in-process projection", () => {
   it("a READ the policy runs: the two paths produce the IDENTICAL audit row and the IDENTICAL mirror", async () => {
@@ -300,6 +306,152 @@ describe("parity gate — the MCP door vs the in-process projection", () => {
     // is where §12 withholds, and the curated loadout decides the rest.
     expect(listed).toContain(READ_TOOL);
   }, 30_000);
+
+  /**
+   * §9.1 + §3.1 — `vendo_make` through the door, on ZERO door code.
+   *
+   * The door's whole claim for the front door is that there is nothing to build:
+   * `turnTools` projects `turn.tools.list()` verbatim, fresh per `tools/list`, so
+   * the tool appears the moment it exists in the turn. That claim is only worth
+   * anything if it is measured on the tool the product now leads with — the
+   * schema, the title and the risk annotation the wire actually carries, not the
+   * descriptor the registry holds.
+   *
+   * The annotation is the part a projection is most likely to lose: `risk: "read"`
+   * becomes `readOnlyHint: true`, which is what a foreign client reads to decide
+   * whether to ask its own user first. A door that dropped it would silently turn
+   * "make me a screen" into a confirm-first tool in every outside agent.
+   */
+  it("§9.1 — `vendo_make` reaches the wire listing with its schema, title and read annotation intact", async () => {
+    let listed: Awaited<ReturnType<DoorSession["listTools"]>> = [];
+    const host = await composedHostOverDoor(async (door) => {
+      listed = await door.listTools();
+    });
+    await runHarnessTurn(host.vendo, "thr_make_list", "what can you do");
+
+    const make = listed.find((tool) => tool.name === VENDO_MAKE_TOOL);
+    expect(make, "the front door must cross the MCP wire").toBeDefined();
+    // The three-param surface, verbatim — `additionalProperties: false` included,
+    // which is what makes it a promise rather than a suggestion.
+    expect(make!.inputSchema).toMatchObject({
+      type: "object",
+      properties: {
+        request: { type: "string", minLength: 1 },
+        app: { type: "string", minLength: 1 },
+        context: { type: "string", minLength: 1 },
+      },
+      required: ["request"],
+      additionalProperties: false,
+    });
+    expect(make).toMatchObject({
+      title: VENDO_TOOL_TITLES[VENDO_MAKE_TOOL],
+      annotations: { title: VENDO_TOOL_TITLES[VENDO_MAKE_TOOL], readOnlyHint: true, destructiveHint: false },
+    });
+    // The rename is only real if the old two names are unreachable HERE too — a
+    // door still offering them is a second front door for every outside agent.
+    const names = listed.map((tool) => tool.name);
+    expect(names).not.toContain("vendo_apps_create");
+    expect(names).not.toContain("vendo_apps_edit");
+  }, 30_000);
+
+  it("§3.1 — a `vendo_make` call through the door answers a RECEIPT, leaves the identical audit row, and carries the turn id", async () => {
+    // LEG A — in process. A real model, so this is the receipt path rather than
+    // the no-model failure path, and a leak would have something to leak.
+    let inResult: unknown;
+    const inHost = await composedHost(async (call) => {
+      inResult = await call(VENDO_MAKE_TOOL, { request: "my spending this month" });
+    }, screenModel());
+    const fromTurn = await rowsAddedBy(inHost.store, VENDO_MAKE_TOOL, async () => {
+      await runHarnessTurn(inHost.vendo, "thr_make", "show me my spending");
+    });
+    expect(inHost.observed).toEqual([`${VENDO_MAKE_TOOL}:ok`]);
+    const inReceipt = makeReceiptSchema.parse((inResult as { output: unknown }).output);
+    expect(inReceipt.title).toBe(SCREEN_TITLE);
+
+    // LEG B — the same ask, through the door, on a minted turn credential.
+    let doorSaid = "";
+    const doorHost = await composedHostOverDoor(async (door) => {
+      const answered = await door.callTool(VENDO_MAKE_TOOL, { request: "my spending this month" });
+      expect(answered.isError, answered.text).toBeFalsy();
+      doorSaid = answered.text;
+    }, undefined, screenModel());
+    const fromDoor = await rowsAddedBy(doorHost.store, VENDO_MAKE_TOOL, async () => {
+      await runHarnessTurn(doorHost.vendo, "thr_make", "show me my spending");
+    });
+
+    // The RECEIPT crossed the wire, and only the receipt. The door serializes a
+    // tool's output as text, so the four fields are read back out of it — and the
+    // app DOCUMENT's fields are the ones asserted absent, because a projection
+    // that handed the model a tree is the §3.1 law being broken.
+    const doorReceipt = makeReceiptSchema.parse(JSON.parse(doorSaid));
+    expect(Object.keys(doorReceipt).sort()).toEqual(["id", "say", "status", "title"]);
+    expect(doorReceipt.title).toBe(inReceipt.title);
+    expect(doorReceipt.status).toBe(inReceipt.status);
+    expect(doorReceipt.say).toBe(inReceipt.say);
+    for (const leaked of ["\"tree\"", "\"components\"", "\"componentTools\"", "\"machine\"", "\"snapshotRef\""]) {
+      expect(doorSaid, `${leaked} reached the outside agent`).not.toContain(leaked);
+    }
+
+    // The LEDGER read the two legs identically — same five contract fields.
+    const expected = {
+      outcome: "ok",
+      decidedBy: "rule",
+      presence: "present",
+      venue: "chat",
+      subject: SUBJECT,
+    };
+    expect(shapeOf(fromTurn[0])).toEqual(expected);
+    expect(shapeOf(fromDoor[0])).toEqual(expected);
+
+    // §3.5 — and the row joins to the turn it came out of, through the door as in
+    // process. Without this a `vendo_make` billed to a tenant cannot be traced to
+    // the exchange that asked for it.
+    expect(doorHost.turnIds[0]).toMatch(/^trn_[0-9a-f]{32}$/);
+    expect(fromDoor[0]!.turnId).toBe(doorHost.turnIds[0]);
+    expect(fromTurn[0]!.turnId).toBe(inHost.turnIds[0]);
+  }, 40_000);
+
+  /**
+   * §9.1 — `mode: "local"` IS the self-hosted path, and it is byte-identical.
+   *
+   * `selectMcpBroker`'s hostname rules are pinned exhaustively and purely in
+   * `mcp-broker-select.test.ts`. What that cannot say is whether the door a
+   * self-hoster actually gets differs from the one they got before the broker
+   * existed — the failure this guards is a key silently changing the front door's
+   * shape for a deployment the broker cannot even reach.
+   *
+   * So the same composition is booted twice — once with no key at all, once with
+   * a key AND a private base URL — and the `vendo_make` entry the wire carries is
+   * compared as SERIALIZED BYTES. Same door, same listing, key or no key.
+   */
+  it("§9.1 — no key and key-plus-private-host both keep the LOCAL door, and its `vendo_make` listing byte-for-byte", async () => {
+    const localArm = async (): Promise<{ selection: unknown; make: string }> => {
+      let listed: Awaited<ReturnType<DoorSession["listTools"]>> = [];
+      const host = await composedHostOverDoor(async (door) => {
+        listed = await door.listTools();
+      });
+      await runHarnessTurn(host.vendo, "thr_local_arm", "what can you do");
+      const doctor = await host.vendo.handler(new Request("https://host.test/api/vendo/doctor/mcp"));
+      return {
+        selection: ((await doctor.json()) as { selection: unknown }).selection,
+        make: JSON.stringify(listed.find((tool) => tool.name === VENDO_MAKE_TOOL)),
+      };
+    };
+
+    const noKey = await localArm();
+    expect(noKey.selection).toBe("local");
+
+    // A Cloud key present, but the deployment is a private host the broker cannot
+    // forward a visitor to — the frozen localhost rule. The broker default is
+    // SKIPPED, silently, and today's door stands.
+    vi.stubEnv("VENDO_API_KEY", "vnd_parity_local_arm");
+    vi.stubEnv("VENDO_BASE_URL", "https://app.internal.local");
+    const privateHost = await localArm();
+    expect(privateHost.selection).toBe("local");
+
+    expect(noKey.make).toContain(VENDO_MAKE_TOOL);
+    expect(privateHost.make).toBe(noKey.make);
+  }, 40_000);
 
   it("a credential is dead the moment its turn ends — a door call between turns is a 401", async () => {
     let stolen: string | undefined;

--- a/packages/vendo/src/mcp-door.test-util.ts
+++ b/packages/vendo/src/mcp-door.test-util.ts
@@ -13,7 +13,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExtractedTool } from "@vendoai/actions";
-import type { AuditEvent, Principal, ToolDescriptor, ToolRegistry } from "@vendoai/core";
+import type { AuditEvent, Principal, ToolDescriptor, ToolRegistry, ToolResult } from "@vendoai/core";
 import { defineHarness, harnessAdapters } from "@vendoai/harnesses";
 import { createStore, type VendoStore } from "@vendoai/store";
 import type { LanguageModel } from "ai";
@@ -82,6 +82,7 @@ export interface Row {
   decidedBy?: string;
   venue?: string;
   presence?: string;
+  turnId?: string;
   principal?: { subject?: string };
 }
 
@@ -131,30 +132,82 @@ export interface ComposedHost {
   vendo: Vendo;
   store: VendoStore;
   observed: string[];
+  /** The `turn.turnId` of every turn the probe harness ran, in order — the join
+   *  key contract §3.5 puts on audit rows, read from the harness that owned it. */
+  turnIds: string[];
 }
+
+/**
+ * A model that answers every generation prompt with one valid screen, so a
+ * `vendo_make` call reaches a REAL receipt instead of the no-model failure path.
+ *
+ * Local rather than `@vendoai/apps`' `scriptedLanguageModel` because `testing/`
+ * is not on that package's exports map; same shape as the other fixture doubles
+ * in this package (`inclient.fixture.test.ts`, `pins.fixture.test.ts`).
+ */
+export const SCREEN_TITLE = "Spending this month";
+const SCREEN = `<App name="${SCREEN_TITLE}"><Text text="Ready"/><Disclaimer reason="Fixture app."/></App>`;
+
+export const screenModel = (): LanguageModel => {
+  const answer = {
+    content: [{ type: "text" as const, text: SCREEN }],
+    finishReason: "stop" as const,
+    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+  };
+  return {
+    specificationVersion: "v2",
+    provider: "vendo-parity-screen",
+    modelId: "vendo-parity-screen-v1",
+    supportedUrls: {},
+    async doGenerate() {
+      return answer;
+    },
+    async doStream() {
+      return {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: "stream-start", warnings: [] });
+            controller.enqueue({ type: "text-start", id: "text_1" });
+            controller.enqueue({ type: "text-delta", id: "text_1", delta: SCREEN });
+            controller.enqueue({ type: "text-end", id: "text_1" });
+            controller.enqueue({
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            });
+            controller.close();
+          },
+        }),
+      };
+    },
+  } as unknown as LanguageModel;
+};
 
 /**
  * ONE composed host serving BOTH doors: a `claudeCode()`-shaped harness turn on
  * the chat wire, and the MCP door at its canonical mount.
  */
 export async function composedHost(
-  script: (call: (tool: string, args: unknown) => Promise<string>) => Promise<void>,
+  script: (call: (tool: string, args: unknown) => Promise<ToolResult>) => Promise<void>,
+  model?: LanguageModel,
 ): Promise<ComposedHost> {
   const store = await tempStore();
   const observed: string[] = [];
+  const turnIds: string[] = [];
   const harness = defineHarness({
     name: "parity-probe",
     async *run(turn) {
+      turnIds.push(turn.turnId);
       await script(async (tool, args) => {
         const result = await turn.tools.call(tool, args as never);
         observed.push(`${tool}:${result.status}`);
-        return result.status;
+        return result;
       });
       yield { type: "text", delta: "done" };
     },
   });
   const vendo = createVendo({
-    model: {} as LanguageModel,
+    model: model ?? ({} as LanguageModel),
     principal: async () => principal,
     store,
     policy: "cautious",
@@ -171,7 +224,7 @@ export async function composedHost(
   } as Parameters<typeof createVendo>[0]);
   vendo.actions.add(hostTools());
   await store.ensureSchema();
-  return { vendo, store, observed };
+  return { vendo, store, observed, turnIds };
 }
 
 /**
@@ -189,13 +242,16 @@ export async function composedHostOverDoor(
    *  the two registry tools — the only way to drive the extraction → registry →
    *  door plumbing from here. Left out, the host is exactly what it always was. */
   extracted?: ExtractedTool[],
+  model?: LanguageModel,
 ): Promise<ComposedHost> {
   const store = await tempStore();
   const observed: string[] = [];
+  const turnIds: string[] = [];
   let composed: Vendo;
   const harness = defineHarness({
     name: "door-probe",
     async *run(turn) {
+      turnIds.push(turn.turnId);
       const port = harnessAdapters(harness).toolDoor;
       if (port === undefined) throw new Error("composition did not provide a tool door");
       const mint = (): string | undefined => port.mint(turn.threadId as string);
@@ -208,7 +264,7 @@ export async function composedHostOverDoor(
     },
   });
   composed = createVendo({
-    model: {} as LanguageModel,
+    model: model ?? ({} as LanguageModel),
     principal: async () => principal,
     store,
     policy: "cautious",
@@ -226,7 +282,7 @@ export async function composedHostOverDoor(
   } as Parameters<typeof createVendo>[0]);
   composed.actions.add(hostTools());
   await store.ensureSchema();
-  return { vendo: composed, store, observed };
+  return { vendo: composed, store, observed, turnIds };
 }
 
 /** The chat wire's own turn — the in-process path. Returns the raw UI-message

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -676,6 +676,18 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)
 
+  examples/mcp-agent:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: 3.0.12
+        version: 3.0.12(zod@4.4.3)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      ai:
+        specifier: 6.0.28
+        version: 6.0.28(zod@4.4.3)
+
   fixtures/automations-e2e:
     dependencies:
       '@vendoai/actions':
@@ -11824,12 +11836,25 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.5(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/anthropic@3.0.12(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.5(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/gateway@3.0.11(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.2
       '@ai-sdk/provider-utils': 4.0.4(zod@3.25.76)
       '@vercel/oidc': 3.1.0
       zod: 3.25.76
+
+  '@ai-sdk/gateway@3.0.11(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.4(zod@4.4.3)
+      '@vercel/oidc': 3.1.0
+      zod: 4.4.3
 
   '@ai-sdk/gateway@3.0.151(zod@3.25.76)':
     dependencies:
@@ -11942,6 +11967,13 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 3.25.76
 
+  '@ai-sdk/provider-utils@4.0.4(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.2
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
   '@ai-sdk/provider-utils@4.0.40(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
@@ -11955,6 +11987,13 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.1.0
       zod: 3.25.76
+
+  '@ai-sdk/provider-utils@4.0.5(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.2
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
 
   '@ai-sdk/provider-utils@5.0.7(zod@3.25.76)':
     dependencies:
@@ -16677,6 +16716,14 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.4(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
+
+  ai@6.0.28(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.11(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.4(zod@4.4.3)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.4.3
 
   ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:


### PR DESCRIPTION
**Track C of the UI-gen overhaul.** Blueprint §9 (doors + the plugin), §15 Track C.

The law of this track was *if you write door code, you have gone wrong.* No door code was written. `turnTools` (`packages/mcp/src/door.ts`) already projects `turn.tools.list()` verbatim, fresh per `tools/list`, so `vendo_make` crossed the MCP wire the moment §3.1 landed in P0. The work was **proving** that and giving outside agents the judgment to use it.

**Consolidates/removes: nothing added to the product.** The door, the broker (`local` included), the OAuth server, the turn credential and the parity gate all already existed. Three new files are examples; two are tests.

---

## 1. The exposure, verified — three cases in the existing parity e2e

`packages/vendo/src/mcp-door-parity.e2e.test.ts`

| Case | What it measures |
| --- | --- |
| `vendo_make` reaches the wire listing | the three-param schema (`additionalProperties: false` included), the title, and `readOnlyHint: true` — plus `vendo_apps_create`/`_edit` unreachable through the door too |
| a call through the door answers a RECEIPT | four fields of words; none of `tree`/`components`/`componentTools`/`machine`/`snapshotRef`; the **identical** audit row to in-process (outcome · decidedBy · presence · venue · subject); and the **turn id** carried, so the row joins to the exchange that asked |
| `mode: "local"` is byte-identical | no key, and a key plus a private base URL the broker cannot reach, both keep today's door and the same **serialized** `vendo_make` entry |

The annotation assertion is the load-bearing one: `readOnlyHint` is what a foreign client reads to decide whether to confirm first, so a projection that dropped it would silently turn "make me a screen" into a confirm-first tool in every outside agent. **Falsified**: stubbing the door's `annotations` to `{}` turns that case red on exactly that field, and only that case.

`mcp-door.test-util.ts` grows a model slot and a `turnIds` list; `call` hands back the whole `ToolResult` so a receipt can be read (no existing caller used the return value). Its `screenModel` is local rather than `@vendoai/apps`' `scriptedLanguageModel` because `testing/` is not on that package's exports map — same shape as this package's other fixture doubles.

## 2. The plugin — `examples/claude-code-plugin/`

A manifest, a `.mcp.json` naming one remote HTTP door, and one skill. That is all a plugin is here, and it is the point: there is nothing to implement.

The skill (`skills/make-a-screen/SKILL.md`) teaches **judgment, not schema** — one screen of text, because it gets read mid-conversation:

- **when** an answer wants to be looked at (many rows, a comparison, something they'll return to, something they need to act on) and when it does not (one number, one fact)
- **how** to phrase `request` — prose, the user's want, no component names, no fonts, and **no data you computed**
- `context` for background our side cannot see; `app` only to change one specific app
- **the receipt is words to speak; the screen arrives on its own channel** — never wait for pixels, never describe UI you did not see, never paste an id

`.claude-plugin/marketplace.json` at the repo root makes it installable (`/plugin marketplace add runvendo/vendo`). Both manifests pass `claude plugin validate --strict`.

**Where it lives, and why:** `examples/`. That is where this repo ships integration artifacts for other people's stacks — the demo hosts plus `ai-sdk-agent`/`mastra-agent`. The plugin is the same kind of thing. It is not a `packages/` block: nothing imports it and it ships no code.

## 3. The doors proof — `examples/mcp-agent/`

A stock AI SDK script. `grep @vendoai agent.mjs` returns nothing: `ai` for the loop, `@ai-sdk/anthropic` for the model, `@modelcontextprotocol/sdk` for the connection. It OAuths in (discovery, DCR, PKCE, the product's login, the door's consent page), takes the door's `tools/list` **verbatim**, and asserts the receipt law itself — a `tree` or `machine` in a receipt exits non-zero and names it.

Sibling to `ai-sdk-agent`, which is the *other* door: an agent inside the host's backend spreading the guarded pack into its own loop. Same `vendo_make`, same guard, same audit.

### The live run — Maple, real model, real door

```
door     http://localhost:3123/api/vendo/mcp
bearer   vmat_EAqWt7p…  (the product's own OAuth: DCR, PKCE, login, consent)
listed   21 tools, including vendo_make

user     make me something I can watch this month's spending on

agent    → vendo_make({"request":"A spending dashboard for the current month showing total
           spend, a breakdown by category with amounts and progress bars, and a list of
           recent transactions. Keep it live so it updates as new transactions come in."})
         ← {"id":"app_790892b0…","title":"August Spending","status":"ready",
            "say":"August Spending is on your screen."}

         August Spending is on your screen! …

PASS — words to the agent, pixels to the product.
```

The screen landed in Maple's own apps shelf with **live data** — donut chart, $4,017.81 total, real categories — brand-native, in a process the agent never touched.

**Evidence:** `~/Desktop/uigen-proof-evidence/` — `2-screen-in-slot.png` (the screen an outside agent asked for, rendered in Maple's own slot) and `1-apps-shelf.png` (it landed in the shelf). Track PROOF owns the consolidated walk.

Two incidental confirmations from the run, both other tracks' wins:

- **the guard is not bypassed.** The first `host_*` read parked for approval (`venue: mcp`, cautious policy). Approving it in-product, as the user, is what let the run proceed.
- **the checks floor blocks a lying screen, live.** An earlier attempt was rejected with *"the binding sums `spending.amount`, but the query returns `amount_cents` — summing the wrong field produces 0"*. The model got that sentence and retried narrower. A broken binding never reached the person.

---

## Findings for other tracks

1. **Maple's MCP door drops its base path.** Maple is mounted at `/maple` (`next.config.ts` `basePath`), the door answers at `/maple/api/vendo/mcp`, but its RFC 8414 metadata advertises `http://host/api/vendo/mcp/authorize` — which 404s. `VENDO_BASE_URL=http://host/maple` does not help; the door takes only the origin. **Pre-existing, not touched here** (door code is out of this track's scope), and it means Maple's door is unreachable by a spec-compliant client under its prefix. The live run above was done with the prefix neutralized locally and reverted — the deployment shape was "Maple served at the origin root", which is every other host in the docs.
2. **"never describe UI you did not see" does not hold on prompt alone.** With a one-line system instruction the model narrated its own `request` back as if it had seen the screen ("a donut chart breaking down spend by category…"). The skill in this PR spells the law out; a short prompt does not. Worth knowing for §10's beats copy and for anyone writing the harness system prompt.
3. **`examples/ai-sdk-agent`'s README still documents `vendo_create_app`.** Part of §3.1's 19-file rename blast radius, flagged for Track A rather than touched here.

---

## Verification

- `pnpm build` · `pnpm typecheck` · `pnpm lint` — green
- Slices, capped both ways (`VITEST_MIN_FORKS=1 MAX_FORKS=2 MIN_THREADS=1 MAX_THREADS=2 --minWorkers=1 --maxWorkers=2`):
  `mcp-door-parity` (11) · `mcp-door-outside-agent` (7) · `mcp-door-internal` (18) · `vendo-make` (4) — **40 passed**
- The falsification described above, run and reverted
- The live doors proof, run end to end against a real deployment with a real model

**TEST EDITS declared:** `mcp-door-parity.e2e.test.ts` (three cases added, none changed) and `mcp-door.test-util.ts` (model slot, `turnIds`, `call` returns `ToolResult`). No product code in this PR.

Rebased onto `main` after #790 merged — `git log origin/main..HEAD` is exactly one commit, and the four slices were re-run capped on the new base: **40 passed (40)**. No auto-merge; the coordinator gates and merges centrally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proves the MCP door already exposes `vendo_make` with no door changes and that outside agents only receive a words-only receipt while the screen lands in-product. Adds an installable Claude Code plugin and a stock MCP agent to demonstrate this end to end; no product code changed.

- **New Features**
  - Example Claude Code plugin (`examples/claude-code-plugin`): manifest, `.mcp.json` for the door, marketplace entry (`.claude-plugin/marketplace.json`), and a one-page skill on when/how to call `vendo_make`.
  - Example MCP agent (`examples/mcp-agent`): OAuths (DCR + PKCE), lists `tools` verbatim, calls `vendo_make`, and asserts the receipt-only contract using `ai`, `@ai-sdk/anthropic`, and `@modelcontextprotocol/sdk`.
  - Parity e2e tests: verify the `vendo_make` listing (full schema, title, `readOnlyHint`), a door call returns only a receipt (no UI), audit rows match in-process, turn ids join, and `mode: "local"` is identical with no key and with a key + private base URL.

- **Dependencies**
  - Added example-only deps: `ai`, `@ai-sdk/anthropic`, `@modelcontextprotocol/sdk`.

<sup>Written for commit bc5253a8e7735440980f1064e5a8986004e1cdff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

