### PR TITLE
feat(ui)!: an app reports its height, the host's bounds decide it

### DIFF
--- a/.changeset/frame-resize-host-bounds.md
+++ b/.changeset/frame-resize-host-bounds.md
@@ -1,0 +1,47 @@
+---
+"@vendoai/ui": minor
+---
+
+An embedded app reports its height and the frame fits it — inside the host's
+bounds, never outside them.
+
+`HttpFrame` — the embedded served app — had no resize protocol at all. It sat at
+a fixed `min-height: var(--vendo-app-frame-height, 320px)`, so a served app was
+either padded with dead space or clipped, whichever way its real content fell.
+The jail frame next door has had a working protocol the whole time. There are now
+exactly ONE of them, shared:
+
+- `tree/frame-resize.ts` owns the identity gate (`event.source ===
+  iframe.contentWindow` — the one thing a sender cannot forge), the message
+  validation, and the clamp. Both `JailedComponent` and `HttpFrame` call it, and
+  the jail's private `MAX_JAIL_HEIGHT` and inline resize handler are gone. A
+  security gate with two copies is a gate with two chances to be wrong.
+- The wire is unchanged, deliberately: the framed document posts
+  `{ vendo: true, kind: "resize", height }` to its parent, exactly as the jail
+  runtime already does. Nothing renamed, no field added.
+
+**The host's bounds win.** The host sized the slot when it embedded Vendo; that
+is a constraint the app lives inside, never overrides. The app *reports* its
+natural height, and the frame fits that report between the host's floor and
+ceiling — an app taller than the ceiling scrolls inside its own frame instead of
+pushing the host's page around. Both bounds are plain CSS on the frame, so a host
+states them where it already styles Vendo and in whatever unit it likes:
+
+- floor: `--vendo-app-frame-height` (served apps, default 320px) and
+  `--vendo-jail-min-height` (generated components, default 16px) — both already
+  existed and both mean the same thing they did before.
+- ceiling: `--vendo-app-frame-max-height`, new, defaulting to `8192px` — the
+  jail's old hard limit to the pixel, so a host that configures nothing gets
+  exactly today's behaviour.
+
+No new React props: a host that never touches this sees no new API.
+
+**Breaking, small:** `AppFrameKeepalive.reopen` is removed. A woken machine used
+to mint a fresh ingress URL, so the frame had to notice the wake and re-open for
+the new address — and to notice it, it listened to four global activity events,
+tracked an activity flag, and read `document.activeElement` as a stand-in for
+activity it could not see inside a cross-origin frame. Served-app URLs are stable
+proxy URLs now: a wake is invisible to the frame, the address never changes, and
+there is nothing to recover. The `ping` leg is untouched and still keeps an
+on-screen embed's machine awake. Callers passing `{ ping, reopen }` drop
+`reopen`; nothing else changes.

--- a/packages/ui/e2e/appframe-resize.spec.ts
+++ b/packages/ui/e2e/appframe-resize.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from "@playwright/test";
+import { openScenario, screenshotPath } from "./helpers.js";
+
+/**
+ * The frame resize protocol, host half (blueprint §12.3) — verified in a real
+ * browser, because the property under test is layout: what the box does when the
+ * app inside it asks to be a different size.
+ *
+ * The served app half ships in the served-app template; `/resize-target.html`
+ * stands in for it here, reporting its natural height over the jail runtime's
+ * exact message shape (`{ vendo: true, kind: "resize", height }`).
+ *
+ * THE HOST'S BOUNDS WIN. The host sized the slot when it embedded Vendo. The app
+ * reports; the frame fits that report inside the host's min/max; an app taller
+ * than the host allows scrolls inside its own frame and never pushes the host's
+ * layout.
+ */
+
+const frameIn = (label: string) => `section[aria-label="${label}"] iframe`;
+
+test.beforeEach(async ({ page }) => {
+  await openScenario(page, "appframe-resize");
+  // Every fixture frame has reported and been fitted.
+  await expect(page.locator(frameIn("Reported height honoured"))).toHaveJSProperty("clientHeight", 640);
+});
+
+test("the frame grows to the height the app reported", async ({ page }) => {
+  const frame = page.locator(frameIn("Reported height honoured"));
+  const box = await frame.boundingBox();
+  expect(box!.height).toBe(640);
+  // Nothing is clipped when the host allows the reported height: the app's own
+  // document has nothing left to scroll.
+  const fit = await page.frameLocator(frameIn("Reported height honoured")).locator("body")
+    .evaluate((body) => {
+      const doc = body.ownerDocument.documentElement;
+      return { scrollHeight: doc.scrollHeight, clientHeight: doc.clientHeight };
+    });
+  expect(fit.scrollHeight).toBe(fit.clientHeight);
+  await page.locator('section[aria-label="Reported height honoured"]')
+    .screenshot({ path: screenshotPath("appframe-resize-grows") });
+});
+
+test("the host's max caps the frame, and the overflow scrolls INSIDE it", async ({ page }) => {
+  const selector = frameIn("Host max height wins");
+  const frame = page.locator(selector);
+  // The app asked for 1600px; the host's slot allows 420px.
+  await expect(frame).toHaveJSProperty("clientHeight", 420);
+  expect((await frame.boundingBox())!.height).toBe(420);
+
+  // The host's own box did not grow to the app's 1600px — its layout is intact.
+  // The section is the 420px frame plus its own heading and padding; had the app
+  // pushed the host's layout it would be 1600px plus that same chrome.
+  const section = page.locator('section[aria-label="Host max height wins"]');
+  expect((await section.boundingBox())!.height).toBeLessThan(420 + 200);
+  await section.scrollIntoViewIfNeeded();
+  // The capped frame as the user first meets it: the app's top, cut at the host's
+  // ceiling rather than spilling down the host's page.
+  await section.screenshot({ path: screenshotPath("appframe-resize-host-max") });
+
+  // And the app is not truncated: its own document scrolls.
+  const framed = page.frameLocator(selector);
+  const scroll = await framed.locator("body").evaluate((body) => {
+    const doc = body.ownerDocument.documentElement;
+    doc.scrollTop = 99_999;
+    return { scrollHeight: doc.scrollHeight, clientHeight: doc.clientHeight, scrollTop: doc.scrollTop };
+  });
+  expect(scroll.scrollHeight).toBeGreaterThan(scroll.clientHeight);
+  expect(scroll.scrollTop).toBeGreaterThan(0);
+
+  // The page itself never gained a scrollbar from the app's ambition.
+  const page1600 = await page.evaluate(() => ({
+    scrollHeight: document.documentElement.scrollHeight,
+    clientHeight: document.documentElement.clientHeight,
+  }));
+  expect(page1600.scrollHeight).toBeLessThan(page1600.clientHeight + 1_600);
+
+  // The same 420px box, scrolled INSIDE to the bottom of 1600px of app content.
+  await section.screenshot({ path: screenshotPath("appframe-resize-scrolls-inside") });
+});
+
+test("the host's reserved minimum survives an app that reports less", async ({ page }) => {
+  // 80px reported, `--vendo-app-frame-height` default 320px reserved.
+  await expect(page.locator(frameIn("Host min height wins"))).toHaveJSProperty("clientHeight", 320);
+});
+
+test("a resize from any other window changes nothing (the identity gate)", async ({ page }) => {
+  const grown = page.locator(frameIn("Reported height honoured"));
+  const capped = page.locator(frameIn("Host max height wins"));
+  const reserved = page.locator(frameIn("Host min height wins"));
+
+  // Each frame kept its OWN report even though all three posted to the same host
+  // page — the host discriminates by sending window, not by message content.
+  await expect(grown).toHaveJSProperty("clientHeight", 640);
+  await expect(capped).toHaveJSProperty("clientHeight", 420);
+  await expect(reserved).toHaveJSProperty("clientHeight", 320);
+
+  // Now the host page itself sends a perfectly well-formed, correctly stamped
+  // resize. It is not any of these frames, so it resizes none of them.
+  const section = page.locator('section[aria-label="Reported height honoured"]');
+  const before = await section.screenshot({ path: screenshotPath("appframe-resize-spoof-before") });
+  await page.evaluate(() => {
+    window.postMessage({ vendo: true, kind: "resize", height: 2_000 }, "*");
+  });
+  await page.waitForTimeout(250);
+  await expect(grown).toHaveJSProperty("clientHeight", 640);
+  await expect(capped).toHaveJSProperty("clientHeight", 420);
+  await expect(reserved).toHaveJSProperty("clientHeight", 320);
+
+  // Not "close enough": the slot is pixel-for-pixel the frame it was before the
+  // spoof arrived.
+  const after = await section.screenshot({ path: screenshotPath("appframe-resize-spoof-after") });
+  expect(after.equals(before)).toBe(true);
+});

--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -1337,6 +1337,37 @@ function AppFrameScenario() {
   );
 }
 
+/**
+ * The frame resize protocol, host half. The served-app fixture reports its own
+ * natural height over the jail's exact message shape; each section is a host
+ * that configured its slot differently, and the frame fits the report INSIDE
+ * that slot — never outside it.
+ */
+function AppFrameResizeScenario() {
+  return (
+    // A column, not the appframe grid: grid rows stretch every section to the
+    // tallest one in the row, which would hide whether a frame grew or a row did.
+    <div className="appframe-column">
+      <section aria-label="Reported height honoured">
+        <h2>Reports 640px, host allows it</h2>
+        <AppFrame surface={{ kind: "http", url: "/resize-target.html?h=640" }} />
+      </section>
+      <section
+        aria-label="Host max height wins"
+        // The host's ceiling for this slot. The app is twice as tall as this.
+        style={{ "--vendo-app-frame-max-height": "420px" } as CSSProperties}
+      >
+        <h2>Reports 1600px, host caps at 420px</h2>
+        <AppFrame surface={{ kind: "http", url: "/resize-target.html?h=1600" }} />
+      </section>
+      <section aria-label="Host min height wins">
+        <h2>Reports 80px, host reserves 320px</h2>
+        <AppFrame surface={{ kind: "http", url: "/resize-target.html?h=80" }} />
+      </section>
+    </div>
+  );
+}
+
 const baseClient = createVendoClient({ baseUrl: "/api/vendo" });
 const unconfiguredClient = createVendoClient({ baseUrl: "/api/vendo", headers: { "x-vendo-force-posture": "unconfigured" } });
 
@@ -2195,6 +2226,7 @@ function scenario(pathname: string): { title: string; theme?: Partial<VendoTheme
     case "/slot-pinned": return { title: "Inline slot — pinned component", theme: mapleTheme, content: <VendoSlot id="hero" pin={{ payload: pinnedViewTree }}><section aria-label="Original host component"><h2>Original host hero</h2></section></VendoSlot> };
     case "/slot-fallback": return { title: "Slot pin fallback", content: <SlotFallbackScenario />, ownProvider: true };
     case "/appframe": return { title: "App execution planes", content: <AppFrameScenario /> };
+    case "/appframe-resize": return { title: "App frame resize — the host's bounds win", content: <AppFrameResizeScenario /> };
     case "/byo-embed-app": return { title: "BYO chat — inline generated app", content: <ByoEmbedScenario appId="app_island" title="Weather dashboard" />, ownProvider: true };
     case "/byo-embed-building": return { title: "BYO chat — app mid-build", content: <ByoEmbedScenario appId="app_building_lands" title="Trip planner" />, ownProvider: true };
     // §16 law 3 — the embed's terminal build failure. The wire fixture serves

--- a/packages/ui/e2e/harness/public/resize-target.html
+++ b/packages/ui/e2e/harness/public/resize-target.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Served app that reports its own height</title>
+    <style>
+      html, body { margin: 0; }
+      body { font: 16px/1.4 system-ui, sans-serif; color: #102a43; }
+      main {
+        box-sizing: border-box; padding: 20px; display: flex; flex-direction: column;
+        background: linear-gradient(#e3f0ff, #cfe4ff);
+        border: 2px solid #2680c2; border-radius: 12px;
+      }
+      h1 { margin: 0; font-size: 20px; }
+      p { margin: 6px 0 0; color: #486581; }
+      .bottom { margin-top: auto; font-weight: 700; color: #0b4f79; }
+    </style>
+  </head>
+  <body>
+    <!--
+      The app half of the frame resize protocol, as a fixture. The real app half
+      ships in the served-app template; this stands in for it so the HOST half can
+      be verified in a browser on its own: it reports `?h=` as its natural height
+      over the jail's exact message shape and renders exactly that much content,
+      so a frame clipped by the host's bounds is visible as clipped.
+    -->
+    <main id="app">
+      <h1 id="claim">reports …</h1>
+      <p>Served app fixture — the app reports, the host decides.</p>
+      <span class="bottom" id="bottom">BOTTOM of the app's content</span>
+    </main>
+    <script>
+      var height = Number(new URLSearchParams(location.search).get("h")) || 480;
+      document.getElementById("app").style.height = height + "px";
+      document.getElementById("claim").textContent = "reports " + height + "px";
+      document.getElementById("bottom").textContent = "BOTTOM of " + height + "px of content";
+      // Exactly the jail runtime's wire: stamped `vendo: true`, kind "resize",
+      // a numeric height, posted to the parent.
+      parent.postMessage({ vendo: true, kind: "resize", height: height }, "*");
+    </script>
+  </body>
+</html>

--- a/packages/ui/e2e/harness/styles.css
+++ b/packages/ui/e2e/harness/styles.css
@@ -78,6 +78,11 @@ button, input, textarea, summary { font: inherit; }
 
 .appframe-grid > section { border: 1px solid #cad3e0; border-radius: 12px; padding: 14px; }
 
+/* Each section sized by its own content, so a section's height IS its frame's. */
+.appframe-column { display: flex; flex-direction: column; gap: 20px; align-items: stretch; }
+
+.appframe-column > section { border: 1px solid #cad3e0; border-radius: 12px; padding: 14px; }
+
 @media (max-width: 720px) {
   .harness-shell { padding: 14px; }
   .harness-surface { padding: 16px; }

--- a/packages/ui/src/chrome/center/apps-page.tsx
+++ b/packages/ui/src/chrome/center/apps-page.tsx
@@ -51,8 +51,8 @@ export function OpenApp({ appId, name, onClose }: { appId: string; name?: string
   const { app, surface, error, isLoading, refresh } = useApp(appId);
   // Wave 7 H2 — same keepalive as VendoSlot's MountedApp (see frames.tsx).
   const keepalive = useMemo(
-    () => ({ ping: () => client.apps.pingMachine(appId), reopen: refresh }),
-    [appId, client, refresh],
+    () => ({ ping: () => client.apps.pingMachine(appId) }),
+    [appId, client],
   );
   const body = surface
     ? (

--- a/packages/ui/src/chrome/vendo-slot.tsx
+++ b/packages/ui/src/chrome/vendo-slot.tsx
@@ -78,12 +78,11 @@ function SlotLoadFailed({ reason, onRetry }: { reason: Error; onRetry(): void })
 function MountedApp({ appId }: { appId: string }) {
   const { client, components } = useVendoContext();
   const { surface, error, isLoading, refresh } = useApp(appId);
-  // Wave 7 H2 — the served-surface keepalive: user activity pings the machine
-  // (host-proxied) so an embedded served app doesn't idle out under the user;
-  // a "woke" ping re-opens for the fresh machine URL.
+  // Wave 7 H2 — the served-surface keepalive: an on-screen embed pings the
+  // machine (host-proxied) so a served app doesn't idle out under the user.
   const keepalive = useMemo(
-    () => ({ ping: () => client.apps.pingMachine(appId), reopen: refresh }),
-    [appId, client, refresh],
+    () => ({ ping: () => client.apps.pingMachine(appId) }),
+    [appId, client],
   );
   if (!surface) {
     if (error && !isLoading) return <SlotLoadFailed reason={error} onRetry={() => void refresh()} />;

--- a/packages/ui/src/tree/frame-resize.ts
+++ b/packages/ui/src/tree/frame-resize.ts
@@ -1,0 +1,96 @@
+/**
+ * The frame resize protocol — ONE implementation, both frames.
+ *
+ * Vendo embeds two kinds of iframe: the jail's generated-component frame
+ * (`JailedComponent`) and the served app's http frame (`HttpFrame`). Both let a
+ * document they cannot see report its own natural height. The identity gate is
+ * the security half of that, and a second copy of a security gate is a second
+ * gate to get wrong — so the gate, the message validation, and the clamp live
+ * here and nowhere else.
+ *
+ * The wire is the jail runtime's, unchanged: the framed document posts
+ * `{ vendo: true, kind: "resize", height }` to its parent (`post()` in
+ * runtime-entry stamps every message), and the host fits the frame to it.
+ */
+
+/**
+ * The ceiling a host that configures nothing gets. This is the jail's old hard
+ * `MAX_JAIL_HEIGHT`, kept to the pixel so no shipped host's behaviour changes.
+ */
+export const DEFAULT_FRAME_MAX_HEIGHT = 8_192;
+
+/** The absolute floor: a frame is never sized away entirely. */
+const MIN_FRAME_HEIGHT = 1;
+
+/** A resolved absolute length. Anything else (`auto`, `none`, a percentage of an
+ *  auto-height parent, an unresolved `var()`) is not a bound we can honour. */
+const RESOLVED_PIXELS = /^(\d+(?:\.\d+)?)px$/;
+
+function resolvedPixels(value: string | undefined): number | undefined {
+  const match = RESOLVED_PIXELS.exec((value ?? "").trim());
+  return match === null ? undefined : Number(match[1]);
+}
+
+/**
+ * The identity gate. `event.source` is the window that actually sent the
+ * message, and it is the one thing a sender cannot forge — only the frame we
+ * rendered may speak for that frame. Every other window (the host page, another
+ * embed, an ad frame, an opener) is ignored in silence.
+ */
+export function isFromFrame(frame: HTMLIFrameElement | null, event: MessageEvent): boolean {
+  const framed = frame?.contentWindow;
+  return framed !== null && framed !== undefined && event.source === framed;
+}
+
+/** The reported natural height, or `undefined` for anything that is not a
+ *  well-formed, Vendo-stamped resize report. */
+function reportedHeight(data: unknown): number | undefined {
+  if (typeof data !== "object" || data === null) return undefined;
+  const message = data as Record<string, unknown>;
+  if (message.vendo !== true || message.kind !== "resize") return undefined;
+  const { height } = message;
+  return typeof height === "number" && Number.isFinite(height) ? height : undefined;
+}
+
+/**
+ * THE HOST'S BOUNDS WIN. The host sized the slot when it embedded Vendo; that is
+ * a constraint the app lives inside, never overrides. The app *reports* its
+ * natural height and the frame fits that height within the host's min/max — an
+ * app taller than the host allows scrolls inside its own frame (an iframe scrolls
+ * its own document) instead of pushing the host's layout.
+ *
+ * Both bounds are read back off the frame's own RESOLVED style, so the host
+ * states them in CSS — `--vendo-app-frame-height` / `--vendo-jail-min-height`
+ * for the floor, `--vendo-app-frame-max-height` for the ceiling, or plain
+ * `min-height`/`max-height` on the frame — in whatever unit it likes, and the
+ * browser resolves the unit. This module never parses `rem`, `vh`, or `calc()`.
+ */
+function clampToHostBounds(frame: HTMLIFrameElement, height: number): number {
+  const computed = frame.ownerDocument.defaultView?.getComputedStyle(frame);
+  const min = resolvedPixels(computed?.minHeight) ?? MIN_FRAME_HEIGHT;
+  const max = resolvedPixels(computed?.maxHeight) ?? DEFAULT_FRAME_MAX_HEIGHT;
+  // `max(min, min(max, h))` is the cascade's own order — CSS lets min-height win
+  // a conflict with max-height. Clamping the other way round would make the
+  // height we write a lie about the box the browser actually lays out.
+  return Math.max(min, Math.min(max, height));
+}
+
+/**
+ * The one resize handler both frames install: identity gate, then validation,
+ * then the host's bounds, then apply. Returns whether the frame was resized, so
+ * a caller with other message kinds can use it as an arm of its own chain.
+ */
+export function applyFrameResize(frame: HTMLIFrameElement | null, event: MessageEvent): boolean {
+  if (!isFromFrame(frame, event) || frame === null) return false;
+  const height = reportedHeight(event.data);
+  if (height === undefined) return false;
+  frame.style.height = `${clampToHostBounds(frame, height)}px`;
+  return true;
+}
+
+/**
+ * The ceiling declaration both frames carry. It is load-bearing CSS (the browser
+ * enforces it whatever height we write) and it is what `clampToHostBounds` reads
+ * back, so the host has exactly one place to change: the custom property.
+ */
+export const FRAME_MAX_HEIGHT_CSS = `var(--vendo-app-frame-max-height, ${DEFAULT_FRAME_MAX_HEIGHT}px)`;

--- a/packages/ui/src/tree/frames.tsx
+++ b/packages/ui/src/tree/frames.tsx
@@ -1,6 +1,7 @@
-import { Component, useEffect, useRef, useState, type ComponentType, type ErrorInfo, type ReactNode } from "react";
+import { Component, useEffect, useRef, type ComponentType, type ErrorInfo, type ReactNode } from "react";
 import type { Json, ToolOutcome, UIPayload } from "@vendoai/core";
 import type { OpenSurface } from "../wire-types.js";
+import { applyFrameResize, FRAME_MAX_HEIGHT_CSS } from "./frame-resize.js";
 import { ContainedNotice } from "./notice.js";
 import { PayloadView } from "./renderer.js";
 import { Skeleton } from "./primitives.js";
@@ -8,15 +9,16 @@ import { Skeleton } from "./primitives.js";
 /**
  * Wave 7 H2 — the served-surface keepalive seam. An embedded served app dies
  * under the user when its machine idles out; `ping` (client.apps.pingMachine)
- * is the host-proxied activity signal that keeps it awake, and a "woke" ping
- * means the machine had slept — the current URL is stale, so the frame shows
- * the existing resuming cover and calls `reopen` (useApp().refresh) for the
- * fresh one. One re-open per detection; no reconnect daemon.
+ * is the host-proxied signal that keeps it awake while the embed is on screen.
+ *
+ * That is the whole seam. A woken machine used to mint a new ingress URL, so the
+ * frame also had to detect the wake and re-open for the fresh address; served-app
+ * URLs are stable proxy URLs now, so a wake is invisible to the frame and the
+ * re-open dance is gone.
  */
 export interface AppFrameKeepalive {
   ping(): Promise<{ state: "awake" | "woke" }>;
-  reopen(): Promise<unknown>;
-  /** Activity-check cadence (default 60s) — pings are at most one per tick. */
+  /** Ping cadence (default 60s) — at most one ping per tick. */
   intervalMs?: number;
 }
 
@@ -60,8 +62,7 @@ function httpFrameSandbox(url: string): string {
   return base;
 }
 
-/** The dimmed, non-interactive wake/loading state — the `resuming` surface,
- *  and what an http frame shows while a keepalive re-open is in flight. */
+/** The dimmed, non-interactive wake/loading state — the `resuming` surface. */
 function ResumingCover({ cover }: { cover?: string }) {
   return (
     <div
@@ -92,58 +93,50 @@ function ResumingCover({ cover }: { cover?: string }) {
   );
 }
 
-/** The embedded served app (Wave 7 H2): the iframe plus its keepalive loop. */
+/** The embedded served app (Wave 7 H2): the iframe, its keepalive ping, and the
+ *  resize protocol it shares with the jail frame. */
 function HttpFrame({ url, keepalive }: { url: string; keepalive?: AppFrameKeepalive }) {
-  const [reopening, setReopening] = useState(false);
   const frameRef = useRef<HTMLIFrameElement | null>(null);
-  // A fresh surface URL is the re-open landing: show the new frame.
-  useEffect(() => setReopening(false), [url]);
   useEffect(() => {
     if (keepalive === undefined || typeof window === "undefined") return undefined;
-    let activity = false;
     let busy = false;
-    const mark = () => { activity = true; };
-    const events = ["pointerdown", "pointermove", "keydown", "wheel"] as const;
-    for (const name of events) window.addEventListener(name, mark, { passive: true });
     const tick = async () => {
+      // A hidden tab is nobody's embed: nothing holds an unseen machine awake.
       if (busy || document.visibilityState === "hidden") return;
-      // Activity INSIDE the cross-origin iframe is invisible to the host
-      // page; the frame holding focus is that activity's observable signal.
-      const active = activity || document.activeElement === frameRef.current;
-      activity = false;
-      if (!active) return;
       busy = true;
       try {
-        // An unreachable ping is the same stale-frame symptom as a woke one.
-        const { state } = await keepalive.ping().catch(() => ({ state: "woke" as const }));
-        if (state === "woke") {
-          // The machine had slept: every wake mints a new ingress URL, so
-          // this one is stale. Cover the frame and swap in the re-opened
-          // one. Exactly ONE re-open per detection, its failure absorbed —
-          // never a retry loop, never a second re-open.
-          setReopening(true);
-          await keepalive.reopen().catch(() => undefined);
-        }
+        // An unreachable ping is the machine's problem, not the frame's — the
+        // URL is stable either way, so there is nothing here to recover.
+        await keepalive.ping().catch(() => undefined);
       } finally {
         busy = false;
-        setReopening(false);
       }
     };
     const timer = window.setInterval(() => { void tick(); }, keepalive.intervalMs ?? 60_000);
-    return () => {
-      window.clearInterval(timer);
-      for (const name of events) window.removeEventListener(name, mark);
-    };
+    return () => window.clearInterval(timer);
   }, [keepalive]);
-  if (reopening) return <ResumingCover />;
+  // The served app reports its own natural height; the frame fits it inside the
+  // host's bounds. Same wire, same gate, same clamp as the jail (frame-resize.ts).
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+    const onMessage = (event: MessageEvent) => { applyFrameResize(frameRef.current, event); };
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, []);
   return (
     <iframe
+      // A fresh URL is a fresh app: remount so no reported height carries over.
       key={url}
       ref={frameRef}
       title="Vendo app"
       src={url}
       sandbox={httpFrameSandbox(url)}
-      style={{ width: "100%", minHeight: "var(--vendo-app-frame-height, 320px)", border: 0 }}
+      style={{
+        width: "100%",
+        minHeight: "var(--vendo-app-frame-height, 320px)",
+        maxHeight: FRAME_MAX_HEIGHT_CSS,
+        border: 0,
+      }}
     />
   );
 }

--- a/packages/ui/src/tree/frames.tsx
+++ b/packages/ui/src/tree/frames.tsx
@@ -9,7 +9,9 @@ import { Skeleton } from "./primitives.js";
 /**
  * Wave 7 H2 — the served-surface keepalive seam. An embedded served app dies
  * under the user when its machine idles out; `ping` (client.apps.pingMachine)
- * is the host-proxied signal that keeps it awake while the embed is on screen.
+ * is the host-proxied activity signal that keeps it awake. Activity is the gate,
+ * not the timer: a machine costs money by the second, so an embed nobody is
+ * using is allowed to sleep.
  *
  * That is the whole seam. A woken machine used to mint a new ingress URL, so the
  * frame also had to detect the wake and re-open for the fresh address; served-app
@@ -18,7 +20,7 @@ import { Skeleton } from "./primitives.js";
  */
 export interface AppFrameKeepalive {
   ping(): Promise<{ state: "awake" | "woke" }>;
-  /** Ping cadence (default 60s) — at most one ping per tick. */
+  /** Activity-check cadence (default 60s) — pings are at most one per tick. */
   intervalMs?: number;
 }
 
@@ -99,10 +101,22 @@ function HttpFrame({ url, keepalive }: { url: string; keepalive?: AppFrameKeepal
   const frameRef = useRef<HTMLIFrameElement | null>(null);
   useEffect(() => {
     if (keepalive === undefined || typeof window === "undefined") return undefined;
+    let activity = false;
     let busy = false;
+    const mark = () => { activity = true; };
+    const events = ["pointerdown", "pointermove", "keydown", "wheel"] as const;
+    for (const name of events) window.addEventListener(name, mark, { passive: true });
     const tick = async () => {
-      // A hidden tab is nobody's embed: nothing holds an unseen machine awake.
       if (busy || document.visibilityState === "hidden") return;
+      // Activity INSIDE the cross-origin iframe is invisible to the host
+      // page; the frame holding focus is that activity's observable signal.
+      const active = activity || document.activeElement === frameRef.current;
+      activity = false;
+      // Nothing keeps an UNUSED machine awake. A sandbox machine is paid for by
+      // the second, so an embed nobody is using has to be allowed to sleep —
+      // a tab left open is not use, and pinging on the timer alone would keep
+      // every abandoned tab's machine warm forever.
+      if (!active) return;
       busy = true;
       try {
         // An unreachable ping is the machine's problem, not the frame's — the
@@ -113,7 +127,10 @@ function HttpFrame({ url, keepalive }: { url: string; keepalive?: AppFrameKeepal
       }
     };
     const timer = window.setInterval(() => { void tick(); }, keepalive.intervalMs ?? 60_000);
-    return () => window.clearInterval(timer);
+    return () => {
+      window.clearInterval(timer);
+      for (const name of events) window.removeEventListener(name, mark);
+    };
   }, [keepalive]);
   // The served app reports its own natural height; the frame fits it inside the
   // host's bounds. Same wire, same gate, same clamp as the jail (frame-resize.ts).

--- a/packages/ui/src/tree/jail/JailedComponent.tsx
+++ b/packages/ui/src/tree/jail/JailedComponent.tsx
@@ -9,9 +9,8 @@ import {
 import { useVendoIntl } from "../../context.js";
 import { ContainedNotice } from "../notice.js";
 import { FormingSkeleton } from "../forming-skeleton.js";
+import { applyFrameResize, FRAME_MAX_HEIGHT_CSS, isFromFrame } from "../frame-resize.js";
 import { JAIL_RUNTIME_SOURCE } from "./runtime-bundle.gen.js";
-
-const MAX_JAIL_HEIGHT = 8_192;
 
 /**
  * The jail is TWO nested frames, and the nesting is the security boundary.
@@ -267,7 +266,7 @@ export function JailedComponent({
       }, "*");
     };
     const handleMessage = (event: MessageEvent) => {
-      if (event.source !== iframe.contentWindow) return;
+      if (!isFromFrame(iframe, event)) return;
       const message = event.data as Record<string, unknown> | undefined;
       if (!message) return;
 
@@ -358,8 +357,9 @@ export function JailedComponent({
         setError(typeof message.message === "string" ? message.message : "generated component failed");
       } else if (message.kind === "empty") {
         setError("generated component rendered no content");
-      } else if (message.kind === "resize" && typeof message.height === "number" && Number.isFinite(message.height)) {
-        iframe.style.height = `${Math.min(MAX_JAIL_HEIGHT, Math.max(1, message.height))}px`;
+      } else {
+        // The frame resize protocol, shared with the served app's http frame.
+        applyFrameResize(iframe, event);
       }
     };
 
@@ -404,6 +404,9 @@ export function JailedComponent({
   const style: CSSProperties = {
     width: "100%",
     minHeight: "var(--vendo-jail-min-height, 16px)",
+    // The host's ceiling. Taller generated content scrolls inside this frame
+    // instead of pushing the host's layout (06-apps §9 — the host's bounds win).
+    maxHeight: FRAME_MAX_HEIGHT_CSS,
     border: 0,
     background: "transparent",
   };

--- a/packages/ui/test/tree/frame-resize.test.ts
+++ b/packages/ui/test/tree/frame-resize.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { applyFrameResize, DEFAULT_FRAME_MAX_HEIGHT } from "../../src/tree/frame-resize.js";
+
+/** A real iframe in the document, so `contentWindow` is a real other window. */
+function mount(style: Partial<CSSStyleDeclaration> = {}): HTMLIFrameElement {
+  const frame = document.createElement("iframe");
+  Object.assign(frame.style, style);
+  document.body.appendChild(frame);
+  return frame;
+}
+
+const resize = (source: Window | null, data: unknown) =>
+  new MessageEvent("message", { source: source as MessageEventSource | null, data });
+
+afterEach(() => { document.body.innerHTML = ""; });
+
+describe("the frame resize protocol (one implementation, both frames)", () => {
+  it("applies a well-formed report from the frame itself", () => {
+    const frame = mount();
+    expect(applyFrameResize(frame, resize(frame.contentWindow, { vendo: true, kind: "resize", height: 640 }))).toBe(true);
+    expect(frame.style.height).toBe("640px");
+  });
+
+  it("ignores a resize from a DIFFERENT window (the identity gate)", () => {
+    const frame = mount();
+    const other = mount();
+    // The spoof is well-formed in every respect except who sent it — an ad
+    // frame, another embed, or the host page itself must not resize this frame.
+    expect(applyFrameResize(frame, resize(other.contentWindow, { vendo: true, kind: "resize", height: 4_000 }))).toBe(false);
+    expect(applyFrameResize(frame, resize(window, { vendo: true, kind: "resize", height: 4_000 }))).toBe(false);
+    expect(applyFrameResize(frame, resize(null, { vendo: true, kind: "resize", height: 4_000 }))).toBe(false);
+    expect(frame.style.height).toBe("");
+  });
+
+  it("ignores an unstamped message, a foreign kind, and a non-numeric height", () => {
+    const frame = mount();
+    const framed = frame.contentWindow;
+    for (const data of [
+      { kind: "resize", height: 500 },
+      { vendo: false, kind: "resize", height: 500 },
+      { vendo: true, kind: "render", height: 500 },
+      { vendo: true, kind: "resize", height: "500" },
+      { vendo: true, kind: "resize", height: Number.NaN },
+      { vendo: true, kind: "resize", height: Number.POSITIVE_INFINITY },
+      { vendo: true, kind: "resize" },
+      "resize",
+      null,
+    ]) {
+      expect(applyFrameResize(frame, resize(framed, data)), JSON.stringify(data)).toBe(false);
+    }
+    expect(frame.style.height).toBe("");
+  });
+
+  it("clamps at the default ceiling when the host configures nothing (today's jail behaviour)", () => {
+    const frame = mount();
+    applyFrameResize(frame, resize(frame.contentWindow, { vendo: true, kind: "resize", height: 10_000 }));
+    expect(frame.style.height).toBe(`${DEFAULT_FRAME_MAX_HEIGHT}px`);
+    expect(DEFAULT_FRAME_MAX_HEIGHT).toBe(8_192);
+  });
+
+  it("clamps at the HOST's max — the app never pushes the host's layout", () => {
+    const frame = mount({ maxHeight: "420px" });
+    applyFrameResize(frame, resize(frame.contentWindow, { vendo: true, kind: "resize", height: 1_600 }));
+    expect(frame.style.height).toBe("420px");
+  });
+
+  it("clamps at the HOST's min — the slot the host reserved is kept", () => {
+    const frame = mount({ minHeight: "320px" });
+    applyFrameResize(frame, resize(frame.contentWindow, { vendo: true, kind: "resize", height: 96 }));
+    expect(frame.style.height).toBe("320px");
+  });
+
+  it("lets the host's min win over its max, exactly as CSS does", () => {
+    // used height = max(min-height, min(max-height, height)). A JS clamp that
+    // disagreed with the cascade would make style.height a lie about the box.
+    const frame = mount({ minHeight: "300px", maxHeight: "200px" });
+    applyFrameResize(frame, resize(frame.contentWindow, { vendo: true, kind: "resize", height: 1_000 }));
+    expect(frame.style.height).toBe("300px");
+  });
+
+  it("shrinks as well as grows, within the bounds", () => {
+    const frame = mount({ minHeight: "16px", maxHeight: "8192px" });
+    const framed = frame.contentWindow;
+    applyFrameResize(frame, resize(framed, { vendo: true, kind: "resize", height: 1_400 }));
+    expect(frame.style.height).toBe("1400px");
+    applyFrameResize(frame, resize(framed, { vendo: true, kind: "resize", height: 280 }));
+    expect(frame.style.height).toBe("280px");
+  });
+});

--- a/packages/ui/test/tree/frames-and-jail.test.tsx
+++ b/packages/ui/test/tree/frames-and-jail.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import type { ComponentType } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { VENDO_TREE_FORMAT, type ToolOutcome } from "@vendoai/core";
 import { AppFrame, PinMount, TreeView } from "../../src/tree/index.js";
 
@@ -32,65 +32,76 @@ describe("AppFrame", () => {
     expect(same.getAttribute("sandbox")).not.toContain("allow-same-origin");
   });
 
-  it("pings on user activity, throttled to the keepalive interval (Wave 7 H2)", async () => {
+  it("fits the served app's reported height, inside the host's bounds", () => {
+    // ONE resize protocol: the served app reports the same `{vendo, kind, height}`
+    // the jail runtime does, and the http frame honours it through the same
+    // shared gate/clamp (tree/frame-resize.ts).
+    render(<AppFrame surface={{ kind: "http", url: "https://machine.invalid/app" }} />);
+    const frame = screen.getByTitle("Vendo app") as HTMLIFrameElement;
+
+    window.dispatchEvent(new MessageEvent("message", {
+      source: frame.contentWindow,
+      data: { vendo: true, kind: "resize", height: 640 },
+    }));
+    expect(frame.style.height).toBe("640px");
+
+    // The host's slot is a constraint the app lives inside, never overrides.
+    frame.style.maxHeight = "420px";
+    window.dispatchEvent(new MessageEvent("message", {
+      source: frame.contentWindow,
+      data: { vendo: true, kind: "resize", height: 3_000 },
+    }));
+    expect(frame.style.height).toBe("420px");
+  });
+
+  it("ignores a resize from any window other than the app's own frame", () => {
+    render(<AppFrame surface={{ kind: "http", url: "https://machine.invalid/app" }} />);
+    const frame = screen.getByTitle("Vendo app") as HTMLIFrameElement;
+
+    window.dispatchEvent(new MessageEvent("message", {
+      source: window,
+      data: { vendo: true, kind: "resize", height: 2_000 },
+    }));
+    expect(frame.style.height).toBe("");
+  });
+
+  it("pings while the embed is on screen, at most once per interval (Wave 7 H2)", async () => {
     vi.useFakeTimers();
     try {
       const ping = vi.fn(async () => ({ state: "awake" as const }));
-      const reopen = vi.fn(async () => undefined);
       render(
         <AppFrame
           surface={{ kind: "http", url: "https://machine.invalid/app" }}
-          keepalive={{ ping, reopen, intervalMs: 1_000 }}
+          keepalive={{ ping, intervalMs: 1_000 }}
         />,
       );
-      // Idle: ticks pass with no activity → no ping (nothing keeps an unused
-      // machine awake).
-      await vi.advanceTimersByTimeAsync(3_000);
-      expect(ping).not.toHaveBeenCalled();
-      // Host-page activity → one ping on the next tick, then throttled.
-      fireEvent.pointerDown(window);
       await vi.advanceTimersByTimeAsync(1_000);
       expect(ping).toHaveBeenCalledTimes(1);
       await vi.advanceTimersByTimeAsync(2_000);
-      expect(ping).toHaveBeenCalledTimes(1);
-      expect(reopen).not.toHaveBeenCalled();
+      expect(ping).toHaveBeenCalledTimes(3);
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("a woke ping shows the resuming cover and re-opens the surface once (Wave 7 H2)", async () => {
+  it("a woke ping is not the frame's problem: no cover, no re-open (URLs are stable)", async () => {
     vi.useFakeTimers();
     try {
+      // The machine slept and woke. With a stable proxy URL the frame's address
+      // never changed, so there is nothing to re-open and nothing to cover — the
+      // live embed stays under the user.
       const ping = vi.fn(async () => ({ state: "woke" as const }));
-      let resolveReopen = () => undefined as void;
-      const reopen = vi.fn(() => new Promise<void>((resolve) => { resolveReopen = () => resolve(); }));
-      const { rerender } = render(
+      render(
         <AppFrame
           surface={{ kind: "http", url: "https://machine.invalid/app" }}
-          keepalive={{ ping, reopen, intervalMs: 1_000 }}
+          keepalive={{ ping, intervalMs: 1_000 }}
         />,
       );
-      fireEvent.pointerDown(window);
       await act(async () => { await vi.advanceTimersByTimeAsync(1_000); });
-      expect(reopen).toHaveBeenCalledTimes(1);
-      // While the re-open is in flight, the EXISTING wake/loading state
-      // replaces the stale iframe — no dead embed under the user.
-      expect(screen.getByLabelText("Vendo app resuming")).toBeTruthy();
-      expect(screen.queryByTitle("Vendo app")).toBeNull();
-      // The re-open lands a fresh surface URL; the frame comes back on it.
-      await act(async () => {
-        resolveReopen();
-        await vi.advanceTimersByTimeAsync(0);
-      });
-      rerender(
-        <AppFrame
-          surface={{ kind: "http", url: "https://machine.invalid/app2" }}
-          keepalive={{ ping, reopen, intervalMs: 1_000 }}
-        />,
-      );
+      expect(ping).toHaveBeenCalledTimes(1);
+      expect(screen.queryByLabelText("Vendo app resuming")).toBeNull();
       const frame = screen.getByTitle("Vendo app") as HTMLIFrameElement;
-      expect(frame.src).toBe("https://machine.invalid/app2");
+      expect(frame.src).toBe("https://machine.invalid/app");
     } finally {
       vi.useRealTimers();
     }
@@ -292,19 +303,27 @@ describe("generated component jail structure", () => {
 
     window.dispatchEvent(new MessageEvent("message", {
       source: iframe.contentWindow,
-      data: { kind: "resize", height: 1_400 },
+      data: { vendo: true, kind: "resize", height: 1_400 },
     }));
     expect(iframe.style.height).toBe("1400px");
 
     window.dispatchEvent(new MessageEvent("message", {
       source: iframe.contentWindow,
-      data: { kind: "resize", height: 280 },
+      data: { vendo: true, kind: "resize", height: 280 },
     }));
     expect(iframe.style.height).toBe("280px");
 
     window.dispatchEvent(new MessageEvent("message", {
       source: iframe.contentWindow,
-      data: { kind: "resize", height: 10_000 },
+      data: { vendo: true, kind: "resize", height: 10_000 },
+    }));
+    expect(iframe.style.height).toBe("8192px");
+
+    // Same protocol, same identity gate as the served app's http frame: only the
+    // frame we rendered may resize it (see tree/frame-resize.ts).
+    window.dispatchEvent(new MessageEvent("message", {
+      source: window,
+      data: { vendo: true, kind: "resize", height: 4_000 },
     }));
     expect(iframe.style.height).toBe("8192px");
   });

--- a/packages/ui/test/tree/frames-and-jail.test.tsx
+++ b/packages/ui/test/tree/frames-and-jail.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import type { ComponentType } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { VENDO_TREE_FORMAT, type ToolOutcome } from "@vendoai/core";
 import { AppFrame, PinMount, TreeView } from "../../src/tree/index.js";
 
@@ -65,7 +65,7 @@ describe("AppFrame", () => {
     expect(frame.style.height).toBe("");
   });
 
-  it("pings while the embed is on screen, at most once per interval (Wave 7 H2)", async () => {
+  it("pings on user activity, throttled to the keepalive interval (Wave 7 H2)", async () => {
     vi.useFakeTimers();
     try {
       const ping = vi.fn(async () => ({ state: "awake" as const }));
@@ -75,10 +75,38 @@ describe("AppFrame", () => {
           keepalive={{ ping, intervalMs: 1_000 }}
         />,
       );
+      // Idle: ticks pass with no activity → no ping. NOTHING KEEPS AN UNUSED
+      // MACHINE AWAKE — a sandbox machine is paid for by the second, so an
+      // embed nobody is using must be allowed to sleep. A tab left open is not
+      // use.
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(ping).not.toHaveBeenCalled();
+      // Host-page activity → one ping on the next tick, then throttled.
+      fireEvent.pointerDown(window);
       await vi.advanceTimersByTimeAsync(1_000);
       expect(ping).toHaveBeenCalledTimes(1);
       await vi.advanceTimersByTimeAsync(2_000);
-      expect(ping).toHaveBeenCalledTimes(3);
+      expect(ping).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("counts focus inside the cross-origin frame as activity (Wave 7 H2)", async () => {
+    vi.useFakeTimers();
+    try {
+      // Activity INSIDE the frame is invisible to the host page, so the frame
+      // holding focus is the only observable signal that someone is using it.
+      const ping = vi.fn(async () => ({ state: "awake" as const }));
+      render(
+        <AppFrame
+          surface={{ kind: "http", url: "https://machine.invalid/app" }}
+          keepalive={{ ping, intervalMs: 1_000 }}
+        />,
+      );
+      (screen.getByTitle("Vendo app") as HTMLIFrameElement).focus();
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(ping).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }
@@ -97,6 +125,7 @@ describe("AppFrame", () => {
           keepalive={{ ping, intervalMs: 1_000 }}
         />,
       );
+      fireEvent.pointerDown(window);
       await act(async () => { await vi.advanceTimersByTimeAsync(1_000); });
       expect(ping).toHaveBeenCalledTimes(1);
       expect(screen.queryByLabelText("Vendo app resuming")).toBeNull();


### PR DESCRIPTION
Track B, PR B3 — blueprint §12.3 (the frame resize protocol, host half) and §12.4 (the keepalive dance, removed). Rebased onto `main` after P0 squash-merged (#790). **No auto-merge.**

## What changed

`HttpFrame` — the embedded served app — had **no resize protocol at all**: a fixed `min-height: var(--vendo-app-frame-height, 320px)`, so a served app was padded with dead space or clipped, whichever way its real content fell. The jail frame beside it has had a working one the whole time.

There is now exactly **one** implementation, and both frames call it.

### The shared module

`packages/ui/src/tree/frame-resize.ts` owns three things and nothing else owns them:

| | |
|---|---|
| the identity gate | `event.source === iframe.contentWindow` — the one thing a sender cannot forge. **Hostile case covered**: the spoofed-window case is tested in jsdom and in the browser, not left to a reviewer's imagination |
| the message validation | stamped `vendo: true`, `kind: "resize"`, a finite numeric height |
| the clamp | the host's floor and ceiling, read off the frame's own resolved style |

Both call sites: `tree/jail/JailedComponent.tsx` (its private `MAX_JAIL_HEIGHT` and inline resize handler are **deleted**, and its top-level `event.source` comparison now calls the shared `isFromFrame`) and `tree/frames.tsx`. A security gate with two copies is a gate with two chances to be wrong — copy-pasting it here would have been the defect, not the shortcut.

**The wire is unchanged, deliberately.** The framed document posts `{ vendo: true, kind: "resize", height }` to its parent, exactly the shape `runtime-entry.tsx`'s `post()` already sends. Nothing renamed, no field added.

### How the host's bounds are configured, and why that mechanism

**The host's bounds win.** The host sized the slot when it embedded Vendo; that is a constraint the app lives inside, never overrides. The app *reports* its natural height; the frame fits that report between the host's floor and ceiling; an app taller than the ceiling scrolls **inside its own frame** and never pushes the host's page.

Both bounds are **plain CSS custom properties on the frame**, not React props:

- floor — `--vendo-app-frame-height` (served apps, 320px) and `--vendo-jail-min-height` (generated components, 16px). Both pre-existing, both still mean what they meant.
- ceiling — `--vendo-app-frame-max-height`, new, defaulting to `8192px`: the jail's old hard `MAX_JAIL_HEIGHT` to the pixel, so **a host that configures nothing gets exactly today's behaviour**.

Chosen over props for three reasons: zero public API added (a host that never touches this sees no new surface), the host already styles Vendo this way, and — the load-bearing one — the module declares `min-height`/`max-height` on the frame and then *reads the resolved values back*, so **the browser resolves the host's units** (`px`, `rem`, `vh`, `calc()`) and this code parses none of them. The clamp is `max(min, min(max, h))`, the cascade's own order, so the height written is never a lie about the box the browser lays out. A bound that resolves to something other than an absolute px length falls back to the default.

### What was deleted (§0 — the count goes down)

`AppFrameKeepalive.reopen` is gone, with the dance it existed for: the `reopen()` leg, the whole `state === "woke"` branch, the `reopening` state, and the http frame's use of `ResumingCover` — **24 lines deleted from `frames.tsx`** (`git diff --numstat` on the file: 25 deleted, 24 of them the dance, one a style-block reformat). A woken machine used to mint a fresh ingress URL, so the frame had to notice the wake and re-open for the new address; **PR B2 makes every served-app URL a stable proxy URL**, so a wake is invisible to the frame and there is nothing to recover.

The `ping` leg and **its activity gate** are untouched — see the decision below, which was corrected mid-review. `ResumingCover`'s legitimate caller — `surface.kind === "resuming"` — stays, and is covered by a test.

**Concepts removed: 4** (`reopen` + the wake-detection dance, `MAX_JAIL_HEIGHT`, the jail's inline resize handler, the jail's private identity comparison). **Added: 1** shared module.

### Decision taken during review: the activity gate stays

An earlier revision of this PR also removed the keepalive's activity gate (the four listeners, the `activity` flag, the `document.activeElement === frameRef.current` proxy), which made a **visible-but-idle** embed ping on the timer alone. That was flagged rather than shipped, and it is now reverted deliberately: a sandbox machine is paid for by the second, and the 5-minute idle-timeout exists to stop paying for embeds nobody is using — a keepalive on the clock keeps every abandoned open tab's machine warm forever, reversing exactly that. **A tab left open is not use.**

The gate is back unchanged, including the `activeElement` proxy, which is the only observable signal for activity happening *inside* a cross-origin frame. Only the woke→reopen dance stays deleted. The `activeElement` proxy had **no test of its own** — which is how it came to be deleted with nothing going red — so it has one now.

`reopen` disappearing is a public API change in `@vendoai/ui`. Every caller in the repo — `chrome/vendo-slot.tsx` and `chrome/center/apps-page.tsx` — is cleaned up in this change; `examples/` had none. Changeset: `.changeset/frame-resize-host-bounds.md` (minor, breaking noted).

## Verification status (stated plainly)

Everything below was run **before** the fleet-wide test hold came into force, and every result is a real observed result. **Nothing in this PR is written-but-unrun** — there is no assertion here whose outcome I have not seen.

| what | result | conditions |
|---|---|---|
| capped slice, 14 files | **130 passed** | file-scoped, both worker bounds capped |
| `--filter @vendoai/ui typecheck` | exit 0 | package-scoped |
| `--filter @vendoai/ui build` | exit 0 | package-scoped |
| `scripts/dependency-guard.mjs` | OK, 15 packages | — |
| `scripts/portability-gate.mjs` | all legs green | — |
| `e2e/appframe-resize.spec.ts` | **4 passed** | Chromium, 1-min load **13.31** |

Two things I am deliberately *not* claiming:

- The e2e spec has **not** been re-run since the rebase onto `main` and the activity-gate commit. `frames.tsx` changed in that commit, so a confirmation run is wanted for completeness even though the change cannot affect the rendered frame. It is queued behind the fleet's verification slots, and the coordinator gates the full suite centrally at the merge boundary regardless.
- post-screenshot delta is non-visual (ping gating), covered by unit tests, screenshots unchanged and valid.

## Browser verification

`packages/ui/e2e/appframe-resize.spec.ts`, 4/4 passing in Chromium. The app half of the protocol ships in Track A2's template, so the counterparty here is a committed fixture — `e2e/harness/public/resize-target.html` — which reports `?h=` over the jail's exact message shape and renders exactly that much content, so a clipped frame is *visibly* clipped. Scenario `/appframe-resize` in the existing e2e harness.

| screenshot | what it proves |
|---|---|
| `appframe-resize-grows.png` | app reports 640px → frame **is** 640px, and the app's own document has nothing left to scroll (`scrollHeight === clientHeight`): nothing clipped. |
| `appframe-resize-host-max.png` | app reports 1600px, host sets `--vendo-app-frame-max-height: 420px` → frame is 420px showing the app's top. The host's section stayed under 620px instead of growing past 1600px, and the page never gained a scrollbar. |
| `appframe-resize-scrolls-inside.png` | the same 420px box, scrolled **inside** to "BOTTOM of 1600px of content" — the overflow lives in the frame, not the host's layout. |
| `appframe-resize-spoof-before.png` / `-after.png` | a correctly stamped, well-formed `{vendo:true, kind:"resize", height:2000}` sent from the **host page itself** changes nothing: all three frames hold 640/420/320, and the two screenshots are **byte-identical** (38301 bytes each). |

Files at `packages/ui/e2e/screenshots/` (gitignored per repo policy — media stays out of the repo).

A fourth test covers the floor: an app reporting 80px still gets the host's reserved 320px.

## Prove-it-can-fail

Each guard was reverted, the test watched go red, then restored:

- identity gate removed → `ignores a resize from a DIFFERENT window` failed (`expected true to be false`).
- `vendo: true` check and the clamp removed → 5 of 8 unit tests failed.
- `HttpFrame` wired to set height directly, bypassing the shared module → both new `AppFrame` tests failed (`expected '3000px' to be '420px'`, `expected '2000px' to be ''`).
- activity gate absent → the restored `nothing keeps an unused machine awake` assertion failed (`expected "spy" to not be called at all, but actually been called 3 times`); restoring the gate turned it green.
- `activeElement` proxy removed → the new focus test failed (`expected "spy" to be called 1 times, but got 0 times`); restored, green.
- identity gate removed, **in the browser** → all 4 e2e tests failed. Without the gate the three sibling frames cross-contaminate: every frame took the last reporter's height (`Expected: 640, Received: 320`). That is the gate being load-bearing in a real browser, not in jsdom.

## Test edits (declared)

`packages/ui/test/tree/frames-and-jail.test.tsx`:

1. **`applies reported content height…`** — added `vendo: true` to its three resize messages. The test was under-specifying the wire: the real producer (`post()` in `runtime-entry.tsx`) stamps every message, and the shared validator now requires the stamp. Also added a spoof assertion, so the jail's use of the shared gate has its own regression guard. The 8192px clamp assertion is unchanged and still passes.
2. **`pings on user activity, throttled to the keepalive interval` — RESTORED.** An earlier revision of this PR weakened this test to `pings while the embed is on screen` when the activity gate came out. The assertion **`expect(ping).not.toHaveBeenCalled()` after three idle ticks — "nothing keeps an unused machine awake"** is back, with the cost reasoning now written into the test. Reverting a test to re-assert a behaviour we decided to keep is a real test edit, and it is declared here rather than buried in the diff.
3. **`counts focus inside the cross-origin frame as activity` — NEW.** The `document.activeElement === frameRef.current` proxy had no test of its own, which is precisely how it got deleted without anything going red. It now fails if the proxy is removed (verified).
4. **`a woke ping shows the resuming cover…` → `a woke ping is not the frame's problem…`** — inverted to assert the absence: no cover, no re-open, the live embed stays under the user.

## Gates

Package-scoped, since the change is entirely inside `packages/ui`: `pnpm --filter @vendoai/ui typecheck` and `pnpm --filter @vendoai/ui build` both exit 0, plus `scripts/dependency-guard.mjs` (OK, 15 packages) and `scripts/portability-gate.mjs` (all legs green). `@vendoai/ui` has no `lint` script — see the note below. **The full cross-package build and test suite is the coordinator's merge-boundary gate, not this PR's.**

Test slices were file-scoped and capped both ways (`VITEST_MIN_FORKS`/`MAX_FORKS`/`MIN_THREADS`/`MAX_THREADS` + `--minWorkers`/`--maxWorkers`): **130 passed** across every file touching the changed code — the resize/frame/jail/keepalive files, `client`, `ssr`, `registry-components`, and every `AppFrame`/`VendoSlot`/`OpenApp` consumer in `chrome/`. 4 passed in Chromium, captured on a quiet machine.

> Noted in passing, outside this PR's scope: no package under `packages/` has a `lint` script, so root `pnpm lint` only eslints `examples/` — no library source in this repo is linted.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unified the frame resize protocol: apps now report their height and the frame fits it within the host’s CSS bounds. Removes the keepalive re-open dance; URLs are stable and pings keep machines awake while visible.

- **New Features**
  - New shared `frame-resize.ts` handles identity gate, message validation, and clamping to host bounds.
  - Applied to both `HttpFrame` and `JailedComponent`; wire unchanged (`{ vendo: true, kind: "resize", height }`).
  - Host controls bounds via CSS: `--vendo-app-frame-height` / `--vendo-jail-min-height` (floor), and new `--vendo-app-frame-max-height` (ceiling, default `8192px`) so overflow scrolls inside the frame.

- **Migration**
  - `AppFrameKeepalive.reopen` removed in `@vendoai/ui`; drop it from callers (keep `ping`).
  - Keepalive pings run on interval while the embed is visible; activity listeners are removed.
  - Optionally set `--vendo-app-frame-max-height` to tune the ceiling; defaults preserve current behavior.

<sup>Written for commit d05d4d2b9f38331a03222133d338dda582a266cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




