### PR TITLE
feat(ui): a beat the harness narrates is a beat somebody sees

### DIFF
--- a/packages/ui/e2e/beats.spec.ts
+++ b/packages/ui/e2e/beats.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test";
+import { openScenario, screenshotPath } from "./helpers.js";
+
+/**
+ * §3.4 + §10.2 — the beat channel, in a real browser.
+ *
+ * No new scenario: `/overlay` already mounts the surface a heavy build is
+ * watched in, and the beats ride the prompt the user types. The two frames a
+ * person actually sees are the ones photographed here — the build in flight
+ * with its accumulated dot-to-tick rail, and the settled turn that leaves
+ * nothing behind.
+ */
+test("the workspace narrates a build as accumulating beats, then leaves nothing behind", async ({ page }) => {
+  await openScenario(page, "overlay");
+  await page.getByRole("button", { name: "Expand workspace" }).click();
+  // The workspace flip is a real transition; photograph the settled layout, not
+  // a half-faded frame.
+  await expect(page.locator(".fl-split-stage")).toHaveCSS("opacity", "1");
+
+  const composer = page.getByRole("textbox", { name: "Message" });
+  await composer.fill("[beats] build me a reconciliation workbench");
+  await composer.press("Enter");
+
+  const rail = page.locator(".fl-beatrail");
+  await expect(rail.locator(".fl-beat")).toHaveCount(4);
+  // Exactly one live beat, and every earlier line settled with a tick.
+  await expect(rail.locator(".fl-beat.fl-beat-working")).toHaveCount(1);
+  await expect(rail.locator(".fl-beat.fl-beat-done .fl-beat-tick")).toHaveCount(3);
+  await expect(rail.locator(".fl-beat").last()).toContainText("Adding drag and drop");
+  await expect(rail).toContainText("You can close this and keep working");
+  // The between-steps ribbon speaks the same latest step, not "Working".
+  const ribbon = page.locator(".fl-ribbon--working");
+  await expect(ribbon).toContainText("Adding drag and drop");
+  await page.screenshot({ path: screenshotPath("beats-midflight") });
+
+  await expect(page.getByText("All done.")).toBeVisible({ timeout: 15_000 });
+  // Ephemeral by construction: the settled turn narrates nothing, on either
+  // surface. The transcript's own per-tool beat is the record that remains.
+  await expect(rail).toHaveCount(0);
+  await expect(ribbon).toHaveCount(0);
+  await page.screenshot({ path: screenshotPath("beats-settled") });
+});
+
+/** Below the breakpoint the panel is a full-bleed takeover and the stage pane is
+ *  display:none, so the composer ribbon is the ONLY beat narration a phone gets.
+ *  It has to carry the real step there too — that is where most of the reach is. */
+test("a phone narrates the latest beat on the ribbon, with no stage to fall back on", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await openScenario(page, "overlay");
+
+  const composer = page.getByRole("textbox", { name: "Message" });
+  await composer.fill("[beats] build me a reconciliation workbench");
+  await composer.press("Enter");
+
+  await expect(page.locator(".fl-ribbon--working")).toContainText("Adding drag and drop");
+  await expect(page.locator(".fl-beatrail")).toBeHidden();
+  await page.screenshot({ path: screenshotPath("beats-mobile") });
+});

--- a/packages/ui/src/chrome/build-beat.tsx
+++ b/packages/ui/src/chrome/build-beat.tsx
@@ -6,6 +6,7 @@ import { useVendoContext } from "../context.js";
 import { developmentMode } from "./dev-mode.js";
 import { memberSchema } from "./field-rows.js";
 import { argValue, humanizeToolName, toolTitle, type ToolMeta } from "./humanize.js";
+import type { VendoBeat } from "./run-activity.js";
 
 /**
  * The thread's in-progress presentation speaks in the product's voice: each
@@ -403,6 +404,74 @@ export function WorkingRibbon({ label = "Working" }: { label?: string }) {
   );
 }
 
+/** How a beat's mark reads: in flight, settled, failed, or refused. */
+type BeatMark = "working" | "done" | "error" | "declined";
+
+/**
+ * The ONE beat line — its mark and its words, nothing else.
+ *
+ * Extracted so the accumulating workspace rail and the transcript's per-tool
+ * beat are literally the same line. A second beat visual would be a second
+ * vocabulary for the same idea, and the two would drift on the first change.
+ */
+function BeatLine({ mark, label }: { mark: BeatMark; label: string }) {
+  return (
+    <>
+      {mark === "error" || mark === "declined" ? (
+        // Same glyph, different register: the error beat is danger-colored
+        // (.fl-beat-error), a decline quiets to muted like any settled line.
+        <span className={`fl-beat-ic${mark === "error" ? " fl-beat-x" : ""}`} aria-hidden="true">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round">
+            <path d="M18 6 6 18M6 6l12 12" />
+          </svg>
+        </span>
+      ) : mark === "done" ? (
+        <BeatTick />
+      ) : (
+        <span className="fl-beat-orb" aria-hidden="true" />
+      )}
+      <span className="fl-beat-label">{label}</span>
+    </>
+  );
+}
+
+/**
+ * §3.4 + §10.2 — the accumulating rail a heavy build is watched through, on the
+ * EXISTING split-view stage. Quiet dot→tick lines in a vertical list, never a
+ * spinner: the newest beat is the live one, everything above it has settled.
+ *
+ * It is NOT a live region. The between-steps ribbon beside the composer already
+ * announces the latest beat, and the transcript's own beats have never
+ * announced — two live regions saying the same words is the duplication the
+ * ribbon/card ruling (D1) exists to prevent.
+ *
+ * `phase` and `appId` ride as machine affordances only. A phase is a slug, and
+ * a slug is not something a person reads (the same answer `data-vendo-tool`
+ * gives for a raw tool name); the label already carries the words.
+ */
+export function BeatRail({ beats }: { beats: readonly VendoBeat[] }) {
+  if (beats.length === 0) return null;
+  const active = beats.length - 1;
+  return (
+    <div className="fl-beatrail">
+      <p className="fl-beatrail-head">Building</p>
+      <ol className="fl-beats">
+        {beats.map((beat, index) => (
+          <li
+            key={`${index}:${beat.label}`}
+            className={`fl-beat ${index === active ? "fl-beat-working" : "fl-beat-done"}`}
+            {...(beat.phase === undefined ? {} : { "data-vendo-phase": beat.phase })}
+            {...(beat.appId === undefined ? {} : { "data-vendo-app": beat.appId })}
+          >
+            <BeatLine mark={index === active ? "working" : "done"} label={beat.label} />
+          </li>
+        ))}
+      </ol>
+      <p className="fl-beatrail-cap">You can close this and keep working. It carries on in the background.</p>
+    </div>
+  );
+}
+
 /** The settled tick — shared by a done beat and the turn's summary row. */
 function BeatTick() {
   return (
@@ -484,7 +553,10 @@ export function BuildBeat({
   const declined = part.state === "output-denied";
   const label = toolTitle(name, tools[name]);
   const result = done ? toolResultSummary(part.output) : undefined;
-  const state = error ? "fl-beat-error" : done || declined ? "fl-beat-done" : "fl-beat-working";
+  const mark: BeatMark = error ? "error" : declined ? "declined" : done ? "done" : "working";
+  const state = mark === "error" ? "fl-beat-error"
+    : mark === "done" || mark === "declined" ? "fl-beat-done"
+    : "fl-beat-working";
   return (
     <div
       className={`fl-beat ${state}`}
@@ -492,26 +564,14 @@ export function BuildBeat({
       data-vendo-tool={name}
       {...(developmentMode() ? { title: name } : {})}
     >
-      {error || declined ? (
-        // Same glyph, different register: the error beat is danger-colored
-        // (.fl-beat-error), a decline quiets to muted like any settled line.
-        <span className={`fl-beat-ic${error ? " fl-beat-x" : ""}`} aria-hidden="true">
-          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round">
-            <path d="M18 6 6 18M6 6l12 12" />
-          </svg>
-        </span>
-      ) : done ? (
-        <BeatTick />
-      ) : (
-        <span className="fl-beat-orb" aria-hidden="true" />
-      )}
-      <span className="fl-beat-label">
-        {waiting ? `${label} — waiting for your approval`
+      <BeatLine
+        mark={mark}
+        label={waiting ? `${label} — waiting for your approval`
           : error ? `${label} — couldn't finish`
           : declined ? `${label} — you declined it`
           : done ? label
           : `${label}…`}
-      </span>
+      />
       {result ? <span className="fl-beat-result">· {result}</span> : null}
       {/* M30 — `aria-label` on a plain <span> is ignored by screen readers, so a
           collapsed run announced only "×3". A role makes the label the element's

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -2218,6 +2218,27 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
    once is the opposite of calm. */
 .fl-no-entrance .fl-beat { animation: none; }
 
+/* ---------- the workspace beat rail (§3.4 + §10.2) ----------
+   A heavy build is watched as an accumulating vertical list of the SAME beat
+   line the transcript uses, on the existing split-view stage. Sits under
+   whatever the stage is showing, above the pane's bottom edge. */
+.fl-beatrail { flex: none; padding: 14px 18px 16px; border-top: 1px solid var(--vendo-border); }
+.fl-beatrail-head { margin: 0 0 10px; font: 600 11px/1 var(--vendo-font); letter-spacing: .055em;
+  text-transform: uppercase; color: var(--vendo-fg-muted); }
+.fl-beats { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }
+/* The caption is the point of the rail: watching is optional. */
+.fl-beatrail-cap { margin: 12px 0 0; max-width: 42ch;
+  font: 400 11.5px/1.45 var(--vendo-font); color: var(--vendo-fg-muted); }
+/* The rail's own register — the mockup's 6px pip. In the TRANSCRIPT the orb is
+   a static position marker (§8 build calm, where the card is the step and the
+   boot hairline is the one moving thing); a rail with no card and no hairline
+   has nothing else to say "still going", so here the pip carries the pulse. */
+.fl-beatrail .fl-beat-orb { width: 6px; height: 6px; background: var(--vendo-accent); }
+@media (prefers-reduced-motion: no-preference) {
+  .fl-beatrail .fl-beat-working .fl-beat-orb { animation: fl-beat-pip 1.5s var(--vendo-ease) infinite; }
+}
+@keyframes fl-beat-pip { 50% { opacity: .35; transform: scale(.82); } }
+
 /* ================== LANE B — card-shell surfaces (spec §16, §4) ==================
    Nothing here dresses or undresses a card: it sizes the shell inside each
    ancestor (law 1) and styles the two containers the shell lives in. */

--- a/packages/ui/src/chrome/run-activity.ts
+++ b/packages/ui/src/chrome/run-activity.ts
@@ -12,12 +12,29 @@
  * one rule — a settle is unseen until somebody says it was seen — and the
  * overlay marks results seen the moment the panel is open.
  */
+import type { BeatPhase } from "@vendoai/core";
 import { isToolUIPart, type UIMessage } from "ai";
 import { appTitle } from "./thread/message-data.js";
+
+/**
+ * §3.4 — one BEAT: the transient `data-vendo-status` channel's payload, after
+ * the receiver has decided it is words a person may read. `phase` and `appId`
+ * are present exactly when the harness sent usable ones (the receiver never
+ * invents either).
+ */
+export interface VendoBeat {
+  label: string;
+  phase?: BeatPhase;
+  appId?: string;
+}
 
 /** The live step of a running turn, for the pill's label + ring. */
 export interface RunActivity {
   running: boolean;
+  /** §3.4 — the RUNNING turn's beats, oldest first. Ephemeral by the same rule
+      as everything else here: nothing is running, so there is nothing to
+      narrate, so the list is empty. */
+  beats: readonly VendoBeat[];
   /** RAW tool name of the live step — the reader humanizes it (`toolTitle`). */
   tool?: string;
   /** Tool steps of the live turn that have settled, and how many it started.
@@ -45,6 +62,9 @@ export interface ThreadRunSnapshot {
   threadId?: string;
   status: "submitted" | "streaming" | "ready" | "error";
   messages: UIMessage[];
+  /** Omitted by a surface that narrates no beats — the same shape `threadId`
+      has, and the same meaning as an empty list. */
+  beats?: readonly VendoBeat[];
 }
 
 interface Derived extends RunActivity {
@@ -54,7 +74,8 @@ interface Derived extends RunActivity {
   status: ThreadRunSnapshot["status"];
 }
 
-const IDLE: RunActivity = { running: false, done: 0, total: 0 };
+const NO_BEATS: readonly VendoBeat[] = [];
+const IDLE: RunActivity = { running: false, done: 0, total: 0, beats: NO_BEATS };
 
 const surfaces = new Map<symbol, Derived>();
 const listeners = new Set<() => void>();
@@ -119,6 +140,7 @@ function derive(snapshot: ThreadRunSnapshot): Derived {
     ...(tool === undefined ? {} : { tool }),
     done,
     total: parts.length,
+    beats: snapshot.beats ?? NO_BEATS,
     ...(snapshot.threadId === undefined ? {} : { threadId: snapshot.threadId }),
     waiting,
     status: snapshot.status,
@@ -153,11 +175,19 @@ function recompute(): void {
   const live = [...surfaces.values()].find(surface => surface.running);
   const next: RunActivity = live === undefined
     ? IDLE
-    : { running: true, ...(live.tool === undefined ? {} : { tool: live.tool }), done: live.done, total: live.total };
+    : {
+      running: true,
+      ...(live.tool === undefined ? {} : { tool: live.tool }),
+      done: live.done,
+      total: live.total,
+      beats: live.beats,
+    };
   const changed = next.running !== activity.running
     || next.tool !== activity.tool
     || next.done !== activity.done
-    || next.total !== activity.total;
+    || next.total !== activity.total
+    // The publisher hands over a stable array until a beat actually arrives.
+    || next.beats !== activity.beats;
   if (changed) activity = next;
 }
 

--- a/packages/ui/src/chrome/thread/index.tsx
+++ b/packages/ui/src/chrome/thread/index.tsx
@@ -357,7 +357,14 @@ export function VendoThread({
     && lastPart.text.trim().length > 0;
   const quietBusy = busy && liveToolPart === undefined
     && !textActivelyStreaming && !caretShowing && !working;
-  const ribbon = quietBusy ? <WorkingRibbon /> : null;
+  // §3.4 — the ribbon has always taken a `label` and nobody ever passed one, so
+  // every busy gap said "Working" while the harness was already narrating the
+  // real step on the status channel. The latest beat is that step; "Working" is
+  // the floor for a harness that says nothing.
+  const latestBeat = thread.beats.at(-1);
+  const ribbon = quietBusy
+    ? <WorkingRibbon {...(latestBeat === undefined ? {} : { label: latestBeat.label })} />
+    : null;
 
   // Lane pick 2E — the WHOLE thread surface is the drop target (the composer
   // bar no longer owns drag): a huge, overshoot-proof zone with a centered

--- a/packages/ui/src/chrome/vendo-overlay.tsx
+++ b/packages/ui/src/chrome/vendo-overlay.tsx
@@ -1,16 +1,18 @@
 import type { UIPayload } from "@vendoai/core";
-import { useCallback, useEffect, useMemo, useReducer, useRef, useState, type ComponentType, type CSSProperties, type KeyboardEvent, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState, useSyncExternalStore, type ComponentType, type CSSProperties, type KeyboardEvent, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useVendoContext, useVendoDiscoverability, useVendoTheme } from "../context.js";
 import { useMobileTakeover } from "../hooks/use-mobile-takeover.js";
 import { themeCssVariables } from "../theme.js";
 import { PayloadView } from "../tree/renderer.js";
+import { BeatRail } from "./build-beat.js";
 import { ChromeRoot } from "./chrome-root.js";
 import { hasSeen, markSeen, type VendoDiscoverability, type VendoGreeting } from "./discoverability.js";
 import { inertBehind } from "./inert-behind.js";
 import { LauncherFace, LauncherToast, useLauncherStatus } from "./launcher-status.js";
 import { deliverPrefill, PrefillScopeContext, registerOverlayOpener } from "./overlay-registry.js";
 import { usePinAction } from "./pin-ceremony.js";
+import { IDLE_RUN_ACTIVITY, runActivity, subscribeRunActivity } from "./run-activity.js";
 import {
   escapeIntent,
   expandedStageRect,
@@ -231,6 +233,11 @@ export function VendoOverlay({
   const [splitState, dispatchSplit] = useReducer(splitViewReducer, initialSplitViewState);
   const expanded = splitState.expanded && !takeover.active;
   const featured = featuredEmbed(splitState);
+  // §3.4 + §10.2 — the running turn's beats, for the stage's rail. The thread
+  // lives in the OTHER pane's React tree, so this rides the run-activity store
+  // the launcher pill already reads — the one channel for what a surface
+  // outside the conversation may know about a turn inside it.
+  const beats = useSyncExternalStore(subscribeRunActivity, runActivity, () => IDLE_RUN_ACTIVITY).beats;
   // The collapse ANIMATES: like the connect tray's exit walk, the stage stays
   // mounted through expanded → collapsing → collapsed so the featured app
   // doesn't blink out before the panes finish sliding. Render-phase state
@@ -655,7 +662,8 @@ export function VendoOverlay({
           <div className="fl-split">
             <div className="fl-split-stage" key="stage" {...(expanded ? {} : { "aria-hidden": true })}>
               {stagePhase !== "collapsed" ? (
-                featured ? (
+                <>
+                {featured ? (
                   <div className="fl-stage" key={featured.appId}>
                     <div className="fl-stage-bar">
                       <span className="fl-appcard-dot" aria-hidden="true" />
@@ -697,7 +705,12 @@ export function VendoOverlay({
                     <p>Views you build land here.</p>
                     <p>Ask for a view in the conversation and it renders large on this stage.</p>
                   </div>
-                )
+                )}
+                {/* The build's own progress, under whatever the stage is
+                    showing: the empty stage while the first view is still
+                    being made, the view itself once it lands. */}
+                <BeatRail beats={beats} />
+                </>
               ) : null}
             </div>
             <div className="fl-split-rail" key="rail">

--- a/packages/ui/src/hooks/use-vendo-thread.ts
+++ b/packages/ui/src/hooks/use-vendo-thread.ts
@@ -1,5 +1,5 @@
 /** ai-SDK v6-compatible conversation transport (08-ui §3, 03-agent §4). */
-import { riskLabelSchema, withTurnHeartbeat, type VendoApprovalPart } from "@vendoai/core";
+import { riskLabelSchema, withTurnHeartbeat, type BeatPhase, type VendoApprovalPart } from "@vendoai/core";
 import { useChat } from "@ai-sdk/react";
 import {
   DefaultChatTransport,
@@ -11,7 +11,7 @@ import {
 } from "ai";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useVendoContext } from "../context.js";
-import { publishThreadRun, retireThreadRun } from "../chrome/run-activity.js";
+import { publishThreadRun, retireThreadRun, type VendoBeat } from "../chrome/run-activity.js";
 
 export type VendoThreadApproval = ToolUIPart | DynamicToolUIPart | VendoApprovalPart;
 
@@ -57,6 +57,62 @@ function recordStream(response: Response): void {
     });
   void pump().catch(() => undefined);
 }
+
+/**
+ * §3.4's status channel, RECEIVED.
+ *
+ * The part name is written out rather than imported: `VENDO_STATUS_PART` lives
+ * in @vendoai/harnesses, and @vendoai/ui may depend on core alone
+ * (scripts/dependency-guard.mjs). The producer pins the same literal on the
+ * wire in packages/harnesses/src/runtime.test.ts.
+ *
+ * THE CHANNEL IS `onData`, NOT A `parts.tsx` BRANCH. A transient data chunk is
+ * handed to `onData` and `break`s before the SDK pushes anything into
+ * `state.message.parts` (ai@6.0.28, dist/index.mjs ~5140) — which is exactly
+ * what §3.4 asks for: a beat in `parts` would be persisted history, and beats
+ * are ephemeral by construction.
+ */
+const VENDO_STATUS_PART = "data-vendo-status";
+
+/** The six, as a runtime set. A `Record<BeatPhase, …>` so the build breaks if
+    §3.4's closed union ever gains or loses a member. */
+const BEAT_PHASES: Record<BeatPhase, true> = {
+  understanding: true,
+  planning: true,
+  assembling: true,
+  building: true,
+  checking: true,
+  finishing: true,
+};
+
+/**
+ * A beat is words on a screen, so the LABEL is the whole requirement — a chunk
+ * without one is simply not a beat. `phase` and `appId` are dropped when
+ * unusable rather than repaired: a seventh phase, or a phase for a beat that
+ * carried none, would make the receiver the author of a fact the harness never
+ * sent.
+ *
+ * The label itself is NOT rewritten. Ruling 14 (consumer-voice.ts) settled that
+ * a regex set may not be the runtime authority for what a person may read — as
+ * a gate it deleted good host copy while admitting raw JSON. The beat text rules
+ * bind the PRODUCER; here the label is passed through as sent.
+ */
+function vendoBeat(chunk: { type: string; data?: unknown }): VendoBeat | undefined {
+  if (chunk.type !== VENDO_STATUS_PART) return undefined;
+  if (typeof chunk.data !== "object" || chunk.data === null) return undefined;
+  const candidate = chunk.data as { label?: unknown; phase?: unknown; appId?: unknown };
+  if (typeof candidate.label !== "string" || candidate.label.trim().length === 0) return undefined;
+  return {
+    label: candidate.label,
+    ...(typeof candidate.phase === "string" && Object.hasOwn(BEAT_PHASES, candidate.phase)
+      ? { phase: candidate.phase as BeatPhase }
+      : {}),
+    ...(typeof candidate.appId === "string" ? { appId: candidate.appId } : {}),
+  };
+}
+
+/** Stable identity so an idle turn never re-renders a beat reader. */
+const NO_BEATS: readonly VendoBeat[] = [];
 
 function vendoApproval(part: UIMessage["parts"][number]): VendoApprovalPart | undefined {
   if (part.type !== "data-vendo-approval") return undefined;
@@ -130,6 +186,7 @@ export function useVendoThread(threadId?: string) {
       }),
     [client, transportOverride],
   );
+  const [beats, setBeats] = useState<readonly VendoBeat[]>(NO_BEATS);
   const chat = useChat<UIMessage>({
     ...(threadId === undefined ? {} : { id: threadId }),
     messages: [],
@@ -137,7 +194,19 @@ export function useVendoThread(threadId?: string) {
     // Approval decisions resume the parked turn server-side (03 §4): once every
     // requested approval has a response, send the updated messages back.
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
+    onData: chunk => {
+      const beat = vendoBeat(chunk);
+      if (beat !== undefined) setBeats(current => [...current, beat]);
+    },
   });
+  const running = chat.status === "submitted" || chat.status === "streaming";
+  // Beats belong to the RUNNING turn: clearing on the settle (rather than on the
+  // next turn's start) is one rule that answers both halves of §3.4's ephemeral
+  // law — a finished turn narrates nothing, and the next turn therefore starts
+  // empty without a reset that could race the first beat off the wire.
+  useEffect(() => {
+    if (!running) setBeats(NO_BEATS);
+  }, [running]);
 
   useEffect(() => {
     let active = true;
@@ -172,8 +241,8 @@ export function useVendoThread(threadId?: string) {
   const runKey = useRef(Symbol("vendo-run")).current;
   useEffect(() => () => retireThreadRun(runKey), [runKey]);
   useEffect(() => {
-    publishThreadRun(runKey, { threadId: effectiveThreadId, status: chat.status, messages: chat.messages });
-  }, [runKey, effectiveThreadId, chat.status, chat.messages]);
+    publishThreadRun(runKey, { threadId: effectiveThreadId, status: chat.status, messages: chat.messages, beats });
+  }, [runKey, effectiveThreadId, chat.status, chat.messages, beats]);
 
   const approvals = useMemo<VendoThreadApproval[]>(
     () => {
@@ -193,6 +262,8 @@ export function useVendoThread(threadId?: string) {
   return {
     threadId: effectiveThreadId,
     messages: chat.messages,
+    /** §3.4 — the running turn's beats, oldest first; empty once it settles. */
+    beats,
     sendMessage: chat.sendMessage,
     status: chat.status,
     error: chat.error,

--- a/packages/ui/test/chrome/status-beats.test.tsx
+++ b/packages/ui/test/chrome/status-beats.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+/**
+ * §3.4 — the beat / status channel, CLIENT half.
+ *
+ * The producer has shipped for a while (`writeStatus` →
+ * `data-vendo-status`, transient) and had NO receiver, so the whole channel
+ * was dead on arrival. These tests read it back through the real client: a
+ * real HTTP wire server writes the exact chunks the harness writes, and the
+ * real ai-SDK transport + the real `useVendoThread` deliver them. Nothing on
+ * either side is stubbed — a beat test that mocked the stream would have
+ * passed against the dead channel too.
+ *
+ * The law being pinned, in order: a beat with `phase`/`appId` lands, a bare
+ * label lands, beats accumulate newest-active, the composer ribbon speaks the
+ * latest one, a settled turn leaves NOTHING behind (ephemeral by
+ * construction — no `data-vendo-status` ever reaches `messages`), and a
+ * malformed chunk is simply not a beat.
+ */
+import { act, cleanup, fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
+import { VendoOverlay, VendoThread } from "../../src/chrome/index.js";
+import { useVendoThread } from "../../src/hooks/use-vendo-thread.js";
+import { resetRunActivity } from "../../src/chrome/run-activity.js";
+import { createWireServer } from "../wire-server.js";
+
+describe("the status channel reaches the screen", () => {
+  let wire: Awaited<ReturnType<typeof createWireServer>>;
+  let client: VendoClient;
+  let release = () => undefined;
+
+  beforeEach(async () => {
+    wire = await createWireServer();
+    client = createVendoClient({ baseUrl: wire.url });
+    wire.state.threadReplyGate = new Promise<void>(resolve => { release = resolve; });
+  });
+
+  afterEach(async () => {
+    cleanup();
+    resetRunActivity();
+    await wire.close();
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <VendoProvider client={client}>{children}</VendoProvider>
+  );
+
+  // The hook is where the chunks arrive, so it is where the shape law is read
+  // back: the SDK hands a transient data chunk to `onData` and never pushes it
+  // into `message.parts`, which is exactly what "ephemeral by construction"
+  // means here.
+  it("accumulates phase-carrying and bare beats in arrival order, and drops junk", { timeout: 20_000 }, async () => {
+    const { result } = renderHook(() => useVendoThread("thr_1"), { wrapper });
+    await waitFor(() => expect(result.current.messages[0]?.id).toBe("msg_existing"));
+    expect(result.current.beats).toEqual([]);
+
+    void act(() => { void result.current.sendMessage({ text: "[beats] build it" }); });
+    // Mid-turn: the gate is still held, so this is the LIVE frame.
+    await waitFor(() => expect(result.current.beats).toHaveLength(4));
+    expect(result.current.beats).toEqual([
+      { label: "Reading what you asked for", phase: "understanding", appId: "app_1" },
+      { label: "Laying out the matching table", phase: "assembling" },
+      { label: "Wiring up your transactions" },
+      // "polishing" is not one of the six phases and 42 is not an app id: the
+      // label is real, so the beat is real, and the two unusable fields are
+      // absent rather than guessed at.
+      { label: "Adding drag and drop" },
+    ]);
+    // Four valid labels out of eight chunks — an empty label, a whitespace
+    // label, a numeric label and a null payload are not beats.
+    await act(async () => release());
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+  });
+
+  it("leaves no beat behind when the turn settles, and never persists one as a message part", { timeout: 20_000 }, async () => {
+    const { result } = renderHook(() => useVendoThread("thr_1"), { wrapper });
+    await waitFor(() => expect(result.current.messages[0]?.id).toBe("msg_existing"));
+
+    const seenPartTypes = new Set<string>();
+    void act(() => { void result.current.sendMessage({ text: "[beats] build it" }); });
+    await waitFor(() => expect(result.current.beats.length).toBeGreaterThan(0));
+    for (const message of result.current.messages) {
+      for (const part of message.parts) seenPartTypes.add(part.type);
+    }
+
+    await act(async () => release());
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    // §3.4 — ephemeral by construction. A beat that landed in `parts` would be
+    // persisted history, which is the one thing the channel forbids.
+    expect(result.current.beats).toEqual([]);
+    for (const message of result.current.messages) {
+      for (const part of message.parts) seenPartTypes.add(part.type);
+    }
+    expect([...seenPartTypes]).not.toContain("data-vendo-status");
+    expect(result.current.messages.at(-1)?.parts).toContainEqual(
+      expect.objectContaining({ type: "text", text: "All done." }),
+    );
+  });
+
+  // HOME A — the between-steps ribbon above the composer. It has always taken
+  // a `label` and nobody ever passed one, so every busy gap said "Working".
+  it("the composer ribbon speaks the latest beat instead of the generic label", { timeout: 20_000 }, async () => {
+    render(<VendoProvider client={client}><VendoThread threadId="thr_1" /></VendoProvider>);
+    expect(await screen.findByText("Existing thread")).toBeTruthy();
+
+    const composer = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(composer, { target: { value: "[beats] build it" } });
+    fireEvent.keyDown(composer, { key: "Enter" });
+
+    expect(await screen.findByText(/Here is the plan/)).toBeTruthy();
+    await waitFor(() => {
+      const working = document.querySelector(".fl-ribbon--working");
+      expect(working).toBeTruthy();
+      // The LAST valid beat, not the last chunk (the stream's final chunk is
+      // deliberately malformed) and not "Working".
+      expect(working?.textContent).toContain("Adding drag and drop");
+    });
+    expect(document.querySelector(".fl-ribbon--working")?.textContent).not.toContain("Working");
+
+    await act(async () => release());
+    expect(await screen.findByText("All done.")).toBeTruthy();
+    await waitFor(() => expect(document.querySelector(".fl-ribbon--working")).toBeNull());
+  });
+
+  // HOME B — the accumulating rail on the EXISTING split-view stage (no new
+  // panel, no second preview surface).
+  it("the workspace stage accumulates the beats: newest active, earlier ones ticked", { timeout: 20_000 }, async () => {
+    render(<VendoProvider client={client}><VendoOverlay defaultOpen /></VendoProvider>);
+    fireEvent.click(await screen.findByRole("button", { name: "Expand workspace" }));
+
+    const composer = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(composer, { target: { value: "[beats] build it" } });
+    fireEvent.keyDown(composer, { key: "Enter" });
+
+    const rail = () => document.querySelector(".fl-beatrail");
+    await waitFor(() => expect(rail()?.querySelectorAll(".fl-beat")).toHaveLength(4));
+    const lines = [...rail()!.querySelectorAll<HTMLElement>(".fl-beat")];
+    expect(lines.map(line => line.querySelector(".fl-beat-label")?.textContent)).toEqual([
+      "Reading what you asked for",
+      "Laying out the matching table",
+      "Wiring up your transactions",
+      "Adding drag and drop",
+    ]);
+    // The newest is the working one; every earlier line is settled with a tick.
+    expect(lines.at(-1)!.classList.contains("fl-beat-working")).toBe(true);
+    expect(lines.at(-1)!.querySelector(".fl-beat-tick")).toBeNull();
+    for (const settled of lines.slice(0, -1)) {
+      expect(settled.classList.contains("fl-beat-done")).toBe(true);
+      expect(settled.querySelector(".fl-beat-tick")).toBeTruthy();
+    }
+    // The optional fields ride as machine affordances only — a phase slug is
+    // never words on a screen (the `data-vendo-*` convention the beat and
+    // ribbon already use for the raw tool name).
+    expect(lines[0]!.getAttribute("data-vendo-phase")).toBe("understanding");
+    expect(lines[0]!.getAttribute("data-vendo-app")).toBe("app_1");
+    expect(lines[2]!.hasAttribute("data-vendo-phase")).toBe(false);
+    expect(lines[3]!.hasAttribute("data-vendo-phase")).toBe(false);
+    expect(rail()?.textContent).toContain("You can close this and keep working");
+
+    await act(async () => release());
+    expect(await screen.findByText("All done.")).toBeTruthy();
+    // Ephemeral on screen too: the settled turn leaves the stage clean.
+    await waitFor(() => expect(rail()).toBeNull());
+  });
+});

--- a/packages/ui/test/wire-server.ts
+++ b/packages/ui/test/wire-server.ts
@@ -647,7 +647,10 @@ export async function createWireServer(options: WireServerOptions = {}) {
               // Last chunk before the gap is junk, so the ribbon's "latest
               // beat" can never be a malformed one.
               writer.write(beat({ label: "" }) as UIMessageChunk);
-              await state.threadReplyGate;
+              // The gate is the unit suite's deterministic release. A browser has
+              // no way to resolve one, so the harness gets a real-timer hold
+              // instead — long enough to read the live frame and photograph it.
+              await (state.threadReplyGate ?? new Promise(resolve => setTimeout(resolve, 6_000)));
               writer.write({ type: "text-start", id: "text_done" });
               writer.write({ type: "text-delta", id: "text_done", delta: "All done." });
               writer.write({ type: "text-end", id: "text_done" });

--- a/packages/ui/test/wire-server.ts
+++ b/packages/ui/test/wire-server.ts
@@ -599,6 +599,65 @@ export async function createWireServer(options: WireServerOptions = {}) {
           await sendFetchResponse(settledGapResponse, response);
           return;
         }
+        if (sentText.includes("[beats]")) {
+          // §3.4 — the STATUS channel: transient `data-vendo-status` chunks, the
+          // exact shape `writeStatus` (packages/harnesses/src/wire.ts) puts on
+          // the wire. Written here as the literal part name because @vendoai/ui
+          // may depend on core only (scripts/dependency-guard.mjs), so the
+          // producer's constant cannot be imported; the producer side pins the
+          // same literal in packages/harnesses/src/runtime.test.ts.
+          //
+          // The script is the settled-gap shape (prose, then a call that
+          // settles, then the busy gap) with beats riding through it: two
+          // carrying phase/appId, two bare, and malformed chunks interleaved —
+          // a beat channel that has to survive junk without a receiver-side
+          // schema is the whole point of validating on arrival.
+          const beat = (data: unknown) => ({ type: "data-vendo-status", data, transient: true });
+          const beatChunks = createUIMessageStream<UIMessage>({
+            originalMessages: [input.message],
+            generateId: () => "msg_assistant_beats",
+            execute: async ({ writer }) => {
+              writer.write({ type: "text-start", id: "text_plan" });
+              writer.write({ type: "text-delta", id: "text_plan", delta: "Here is the plan — building your workbench now." });
+              writer.write({ type: "text-end", id: "text_plan" });
+              writer.write(beat({ label: "Reading what you asked for", phase: "understanding", appId: "app_1" }) as UIMessageChunk);
+              writer.write({
+                type: "tool-input-available",
+                toolCallId: "call_beats",
+                toolName: "host_list_transactions",
+                input: {},
+                dynamic: true,
+              });
+              writer.write({
+                type: "tool-output-available",
+                toolCallId: "call_beats",
+                output: { rows: [] },
+                dynamic: true,
+              } as UIMessageChunk);
+              writer.write(beat({ label: "Laying out the matching table", phase: "assembling" }) as UIMessageChunk);
+              // Bare label — the shape a harness that says nothing else emits.
+              writer.write(beat({ label: "Wiring up your transactions" }) as UIMessageChunk);
+              // Malformed: an empty label, a non-string label, no data at all.
+              writer.write(beat({ label: "   " }) as UIMessageChunk);
+              writer.write(beat({ label: 7 }) as UIMessageChunk);
+              writer.write(beat(null) as UIMessageChunk);
+              // A real label carrying junk in the optional fields: the beat
+              // still renders, the two unusable fields simply do not.
+              writer.write(beat({ label: "Adding drag and drop", phase: "polishing", appId: 42 }) as UIMessageChunk);
+              // Last chunk before the gap is junk, so the ribbon's "latest
+              // beat" can never be a malformed one.
+              writer.write(beat({ label: "" }) as UIMessageChunk);
+              await state.threadReplyGate;
+              writer.write({ type: "text-start", id: "text_done" });
+              writer.write({ type: "text-delta", id: "text_done", delta: "All done." });
+              writer.write({ type: "text-end", id: "text_done" });
+            },
+          });
+          const beatsResponse = createUIMessageStreamResponse({ stream: beatChunks });
+          beatsResponse.headers.set("x-vendo-thread-id", threadId);
+          await sendFetchResponse(beatsResponse, response);
+          return;
+        }
         if (sentText.includes("[smoke-build]")) {
           // The smoke pack's one scripted turn (checklist 11): two tool steps
           // that settle into beats, then an app BUILD that holds the floor —


### PR DESCRIPTION
## The dead status channel gets its receiver

`writeStatus()` has been putting transient `data-vendo-status` chunks on the wire
for a while, and `packages/harnesses` proves it. **Nothing was listening.** Every
beat the harness narrated died at the browser, and every busy gap above the
composer said "Working" while the harness was already saying something better.

This PR builds the receiver, and gives it two homes that already existed.

### The blueprint asked for something that cannot be built

§10.2 says the client half is "a `data-vendo-status` branch in `parts.tsx`". It is
not implementable. `parts.tsx` renders `message.parts`, and a **transient** data
chunk never gets there — `ai@6.0.28` (`dist/index.mjs` ~5140):

```js
const dataChunk = chunk;
if (dataChunk.transient) {
  onData?.(dataChunk);
  break;          // <-- returns before the parts.push below
}
```

So the receiver is **`onData`**. That is also exactly what §3.4 demands: a beat
that landed in `message.parts` would be persisted history, which is the one thing
"ephemeral by construction" forbids. The test suite pins this from both sides —
flipping the producer to `transient: false` reddens the ephemerality test with
`expected [ 'text', 'data-vendo-status', … ] to not include 'data-vendo-status'`.

### What changed

| File | What |
|---|---|
| `packages/ui/src/hooks/use-vendo-thread.ts` | the `onData` receiver: validates the chunk, accumulates beats, clears them on the settle, exposes `beats` |
| `packages/ui/src/chrome/run-activity.ts` | `VendoBeat`; beats ride the **existing** cross-tree run store the launcher pill already reads |
| `packages/ui/src/chrome/build-beat.tsx` | `BeatLine` extracted (one beat line, two callers) + `BeatRail` |
| `packages/ui/src/chrome/thread/index.tsx` | the ribbon finally gets the `label` prop nobody ever passed |
| `packages/ui/src/chrome/vendo-overlay.tsx` | the rail on the **existing** split-view stage |
| `packages/ui/src/chrome/chrome-css.ts` | `.fl-beatrail*` beside its `.fl-beat*` siblings, bridged tokens only, reduced-motion honoured |

### §0 — the concept count went DOWN

- The dead status channel became live. **No new card, pill, toast, preview
  surface, event vocabulary or store was added.**
- `BuildBeat`'s mark-and-label pair was **extracted, not duplicated**: the rail
  and the transcript beat are literally the same line. `BuildBeat`'s DOM is
  unchanged and its 22 tests pass untouched.
- The cross-tree hop reuses `run-activity.ts` — the module singleton whose own
  doc comment describes this exact job. No second channel.
- **No new harness scenario**: `/overlay` already mounts the surface, and the
  beats ride the prompt the user types.
- `BuildBeat` lost a duplicated four-branch ternary (mark and class now derive
  from one value).

### Decisions

- **`phase` and `appId` render as `data-vendo-phase` / `data-vendo-app` only.** A
  phase is a slug, and a slug is not something a person reads — the same answer
  `data-vendo-tool` already gives for a raw tool name. Arrival order is the truth;
  beats are never re-sorted by phase, because the receiver may not author order
  the harness did not send.
- **No runtime scrub of a server-sent label.** Ruling 14 settled that a regex set
  may not be the runtime authority for what a person may read. The beat text rules
  bind the producer; a malformed chunk is simply not a beat.
- **The rail is not a live region.** The ribbon already announces the latest beat,
  and the transcript's beats have never announced. Two live regions saying the
  same words is the duplication the ribbon/card ruling exists to prevent.
- **The rail's pip pulses; the transcript's orb still does not.** §8 build calm
  makes the boot hairline the one moving thing while a *card* builds. The rail has
  no card and no hairline, so the founder-approved mockup's 6px pulsing pip
  carries "still going" there. Scoped to `.fl-beatrail`; `s1-recipe.test.ts` green.

### Proof

Every test was watched fail before it passed — four separate reverts:

| Revert | Result |
|---|---|
| receiver disabled | all 4 red |
| producer `transient: false` | ephemerality red: `…to not include 'data-vendo-status'` |
| ribbon `label` removed | `expected 'Working…10.0s' to contain 'Adding drag and drop'` |
| rail render removed | rail test red, other 3 green |

Slices, run twice, both green — **145 passed (145)**, 12 files including
`transcript-beats`, `export-surface`, `consumer-voice-law`, `s1-recipe`,
`run-activity-honesty`, `split-view`, `thread-and-overlay`, `pill-states`,
`theme-tokens`, `viewport-css`, `hooks`.

`pnpm --filter @vendoai/ui build` and `typecheck` green. `dependency-guard` and
`portability-gate` green.

### Real browser (2 specs, 2 passed)

`packages/ui/e2e/beats.spec.ts` — screenshots preserved durably at
`~/Desktop/uigen-proof-evidence/d1-beats/` (also regenerated by the spec into
`packages/ui/e2e/screenshots/`):

- **`beats-midflight.png`** — the expanded workspace: `BUILDING`, four beats
  (three ticked and quieted, the newest full-strength with its pip), the caption
  "You can close this and keep working. It carries on in the background.", and
  the composer ribbon saying the same latest step, `Adding drag and drop… 0.1s`.
- **`beats-settled.png`** — the turn settled: rail gone, ribbon gone, the
  transcript folded to `✓ Did 1 thing · 6.0s`. Nothing left behind.
- **`beats-mobile.png`** (390×844) — under the takeover the stage pane is
  `display: none`, so the ribbon is the only narration a phone gets. It carries
  the real step there too.

### Copy law

Every string authored here is about the PROCESS, never the result's appearance:
the `BUILDING` eyebrow and the mockup's caption. No settled-state summary replaces
the beats — they simply vanish. No `aria-label` or `title` was authored.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implemented the client receiver for transient `data-vendo-status` beats and surfaced them in the UI. The composer ribbon now shows the latest beat, and the workspace stage displays an accumulating beat rail; beats remain ephemeral and clear when the turn settles.

- New Features
  - Added an `onData` receiver in `use-vendo-thread` to validate, accumulate, and expose `beats`; clears them when the turn settles.
  - Extended the run-activity store to include `beats` and keep a stable array; overlay reads it via `useSyncExternalStore`.
  - Added `BeatRail` on the existing stage; shares a single `BeatLine` with the transcript’s `BuildBeat` to avoid duplicate visuals.
  - Updated `WorkingRibbon` to use the latest beat `label` instead of a generic "Working".
  - Added CSS for the rail and a scoped pulsing pip (reduced-motion respected).
  - Tests: new unit tests for the beat flow, Playwright e2e screenshots, and a wire server that streams transient `data-vendo-status` chunks.

<sup>Written for commit 0bdbef9b4a95c3a525c8c619d391346a65c5d268. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


