### PR TITLE
feat(apps,harnesses): the builder narrates itself instead of going quiet for 52 seconds

### DIFF
--- a/packages/apps/src/claude-beats.test.ts
+++ b/packages/apps/src/claude-beats.test.ts
@@ -226,6 +226,41 @@ describe("a beat is our copy, never the model's", () => {
     }
   });
 
+  /**
+   * THE OTHER HALF OF THE COPY LAW: a beat says what the builder is DOING, never
+   * what the result LOOKS like.
+   *
+   * The builder cannot see what it is building — it is writing files inside a box,
+   * and nothing has been rendered when any of these fire. So an appearance claim
+   * is not merely off-tone, it is a claim about something that does not exist yet.
+   * Only the receipt's `say` line speaks for the result.
+   *
+   * This is the same failure Track C hit live: an agent given a short prompt
+   * narrated UI it had never seen. A model writing its own todos will cheerfully
+   * author "Build beautiful spending dashboard", which is exactly why that text is
+   * not the beat source.
+   */
+  test("no beat claims what the result looks like", async () => {
+    const events = await run([[
+      { say: "I'll build a beautiful, clean spending dashboard with charts.", stream: true,
+        use: { name: "TodoWrite", input: { todos: [{
+          content: "Build beautiful spending dashboard with a clean summary table",
+          status: "in_progress",
+          activeForm: "Building a beautiful dashboard that looks great with charts",
+        }] } } },
+      { use: { name: "Write" } },
+    ]]);
+    const said = beats(events).map(([, label]) => label);
+    // Appearance vocabulary, and the shapes of a rendered thing. A TEST oracle,
+    // never a runtime gate (ruling 14) — the emitter's copy is fixed, so this
+    // guards the next person who edits it.
+    const APPEARANCE = /beautiful|clean|great|nice|polished|looks?\b|chart|graph|table|dashboard|screen|layout|colou?r|styl|design|pretty|slick|modern/i;
+    for (const label of said) expect(label, `beat claims an appearance: "${label}"`).not.toMatch(APPEARANCE);
+    // And nothing asserts the visual is DONE — `finishing` is a stage, not a verdict.
+    for (const label of said) expect(label).not.toMatch(/ready|done\b|finished\b|complete/i);
+    expect(said).toEqual(["Getting started", "Working out the steps", "Putting it together", "Finishing up"]);
+  });
+
   test("a beat stays OFF the transcript vocabulary — it is a status, never text", async () => {
     const events = await run([[{ use: { name: "Write" } }]]);
     const spoken = events.filter((event) => event.type === "text");

--- a/packages/apps/src/claude-beats.test.ts
+++ b/packages/apps/src/claude-beats.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Beats from inside the SDK loop — contract §3.4, producer half.
+ *
+ * The user waits 52 seconds while a heavy build runs inside a box. §3.4 gave
+ * beats a contract and the wire already carries them; nothing in the loop that
+ * does the work ever said anything. These tests are the loop learning to narrate
+ * itself, on the channel that already exists.
+ *
+ * The SDK is the ONE thing doubled here — a unit test cannot run a model. Every
+ * message shape below is the shape the real stream yields (verified against
+ * @anthropic-ai/claude-agent-sdk 0.3.214's own `sdk-tools.d.ts`).
+ */
+import { describe, expect, test } from "vitest";
+import type { BeatPhase as ContractBeatPhase } from "@vendoai/core";
+import {
+  createClaudeSession,
+  type BeatPhase,
+  type ClaudeTurnEvent,
+} from "./claude-turn.js";
+
+/** One step of a scripted turn: prose, a tool the model used, or both. */
+interface ScriptStep {
+  say?: string;
+  /** An `assistant` tool_use block, exactly as the SDK delivers one. */
+  use?: { name: string; input?: Record<string, unknown> };
+  /** Deliver `say` as token deltas FIRST, then the completed block — which is
+   *  what `includePartialMessages: true` actually produces. */
+  stream?: boolean;
+}
+
+/** The SDK's stream, one scripted turn per user message pushed in. */
+function fakeSdk(turns: ScriptStep[][], subtype = "success", sessionId = "sess_beat") {
+  return {
+    query: ({ prompt }: { prompt: unknown }) => ({
+      async *[Symbol.asyncIterator]() {
+        yield { type: "system", subtype: "init", session_id: sessionId, model: "claude-test" };
+        let index = 0;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        for await (const _message of prompt as AsyncIterable<unknown>) {
+          for (const step of turns[index] ?? []) {
+            if (step.say !== undefined && step.stream === true) {
+              yield {
+                type: "stream_event",
+                event: { type: "content_block_delta", delta: { type: "text_delta", text: step.say } },
+              };
+            }
+            const content: Array<Record<string, unknown>> = [];
+            if (step.say !== undefined) content.push({ type: "text", text: step.say });
+            if (step.use !== undefined) {
+              content.push({ type: "tool_use", name: step.use.name, input: step.use.input ?? {} });
+            }
+            if (content.length > 0) yield { type: "assistant", message: { content } };
+          }
+          index += 1;
+          yield { type: "result", subtype, session_id: sessionId, usage: { input_tokens: 1, output_tokens: 1 } };
+        }
+      },
+    }),
+  };
+}
+
+/** Run `turns.length` messages through ONE live session and return every event. */
+async function run(turns: ScriptStep[][], subtype = "success"): Promise<ClaudeTurnEvent[]> {
+  const events: ClaudeTurnEvent[] = [];
+  const session = createClaudeSession({
+    cwd: "/box/user",
+    env: {},
+    emit: (event) => events.push(event),
+    sdk: fakeSdk(turns, subtype) as never,
+  });
+  for (let index = 0; index < turns.length; index += 1) await session.send(`message ${index}`);
+  await session.end();
+  return events;
+}
+
+/** Just the beats, as `[phase, label]` — the thing every test below reads. */
+const beats = (events: ClaudeTurnEvent[]): Array<[BeatPhase | undefined, string]> =>
+  events
+    .filter((event): event is Extract<ClaudeTurnEvent, { type: "status" }> => event.type === "status")
+    .map((beat) => [beat.phase, beat.label]);
+
+describe("the loop narrates itself — one beat per real step (§3.4)", () => {
+  test("the session opening IS the first real step", async () => {
+    expect(beats(await run([[]]))).toContainEqual(["understanding", "Getting started"]);
+  });
+
+  test("the model publishing a task list IS planning", async () => {
+    const events = await run([[{ use: { name: "TodoWrite" } }]]);
+    expect(beats(events)).toContainEqual(["planning", "Working out the steps"]);
+  });
+
+  test("the first write IS building", async () => {
+    const events = await run([[{ use: { name: "Write" } }]]);
+    expect(beats(events)).toContainEqual(["building", "Putting it together"]);
+  });
+
+  test("the turn boundary IS finishing", async () => {
+    expect(beats(await run([[]]))).toContainEqual(["finishing", "Finishing up"]);
+  });
+
+  test("a whole build reads as the arc of making something, in order", async () => {
+    const events = await run([[
+      { say: "I'll put together a spending screen." },
+      { use: { name: "TodoWrite" } },
+      { use: { name: "Write" } },
+      { use: { name: "Edit" } },
+      { say: "Done." },
+    ]]);
+    expect(beats(events)).toEqual([
+      ["understanding", "Getting started"],
+      ["planning", "Working out the steps"],
+      ["building", "Putting it together"],
+      ["finishing", "Finishing up"],
+    ]);
+  });
+
+  test("a phase is a STAGE, not a tick: the tenth write is not news", async () => {
+    const events = await run([[
+      { use: { name: "Write" } },
+      { use: { name: "Edit" } },
+      { use: { name: "MultiEdit" } },
+      { use: { name: "Bash", input: { command: "npm run build" } } },
+      { use: { name: "NotebookEdit" } },
+      { use: { name: "TodoWrite" } },
+      { use: { name: "TodoWrite" } },
+    ]]);
+    expect(beats(events).filter(([phase]) => phase === "building")).toHaveLength(1);
+    expect(beats(events).filter(([phase]) => phase === "planning")).toHaveLength(1);
+  });
+
+  test("turn 2 plans and builds again — but nothing 'gets started' twice", async () => {
+    const events = await run([
+      [{ use: { name: "TodoWrite" } }, { use: { name: "Write" } }],
+      [{ use: { name: "TodoWrite" } }, { use: { name: "Write" } }],
+    ]);
+    const spelled = beats(events).map(([phase]) => phase);
+    expect(spelled.filter((phase) => phase === "understanding")).toHaveLength(1);
+    expect(spelled.filter((phase) => phase === "planning")).toHaveLength(2);
+    expect(spelled.filter((phase) => phase === "building")).toHaveLength(2);
+    expect(spelled.filter((phase) => phase === "finishing")).toHaveLength(2);
+  });
+
+  test("a turn that FAILED never says it is finishing — the error is the news", async () => {
+    const events = await run([[{ use: { name: "Write" } }]], "error_during_execution");
+    expect(beats(events).map(([phase]) => phase)).not.toContain("finishing");
+    expect(events).toContainEqual({ type: "error", message: "I couldn't finish that one." });
+  });
+
+  /**
+   * THE DEFECT this closes. `includePartialMessages: true` means prose arrives as
+   * deltas and the completed `assistant` message is then a duplicate — so the loop
+   * skipped that whole message. A tool_use block rides in the SAME message as the
+   * text that introduced it, so every beat in a turn where the model said anything
+   * at all was silently thrown away with the duplicate prose.
+   */
+  test("a tool the model used is still seen when its sentence already streamed", async () => {
+    const events = await run([[
+      { say: "Let me lay this out.", stream: true, use: { name: "TodoWrite" } },
+      { say: "Now the table.", stream: true, use: { name: "Write" } },
+    ]]);
+    expect(beats(events).map(([phase]) => phase)).toEqual([
+      "understanding", "planning", "building", "finishing",
+    ]);
+    // And the prose is still said exactly once.
+    expect(events.filter((event) => event.type === "text")).toEqual([
+      { type: "text", delta: "Let me lay this out." },
+      { type: "text", delta: "Now the table." },
+    ]);
+  });
+});
+
+/**
+ * THE COPY LAW, and why it is enforced by CONSTRUCTION here.
+ *
+ * §3.4: a beat never names a filename, tool slug, model name, token count or id.
+ * The tempting source is the model's own text — `TodoWrite`'s `activeForm` is
+ * literally documented by the CLI as "the present continuous form shown during
+ * execution", which is a beat in all but name. It is also untrusted: it can say
+ * "Creating app/src/InvoiceTable.tsx", and admitting it would need a regex gate
+ * over model-authored prose. Ruling 14 (`ui/src/consumer-voice.ts`) already tried
+ * that and reversed it — "a regex set cannot be the authority for what a person
+ * may read", because it admitted raw JSON and exceptions while deleting good
+ * copy. Its replacement is a precedence ladder of trusted sources ending in OUR
+ * OWN fixed sentence (`consentWords`), and beats have no rung above that one: no
+ * host authors beat copy and there is nothing structured to synthesize from.
+ *
+ * So the loop reads a tool's NAME and nothing else. It never touches `activeForm`,
+ * never touches `file_path`, and therefore holds no filename it could leak.
+ */
+describe("a beat is our copy, never the model's", () => {
+  test("nothing a tool's inputs contain reaches the user", async () => {
+    const events = await run([[
+      {
+        say: "Creating app/src/InvoiceTable.tsx now.",
+        stream: true,
+        use: {
+          name: "TodoWrite",
+          input: {
+            todos: [{
+              content: "Create app/src/InvoiceTable.tsx",
+              status: "in_progress",
+              activeForm: "Creating app/src/InvoiceTable.tsx",
+            }],
+          },
+        },
+      },
+      { use: { name: "Write", input: { file_path: "/workspace/user/apps/app_9f2/app.vendo" } } },
+      { use: { name: "Bash", input: { command: "pnpm vite build --outDir dist" } } },
+    ]]);
+    const said = beats(events).map(([, label]) => label).join(" | ");
+    expect(said).not.toMatch(/InvoiceTable|\.tsx|app\.vendo|app_9f2|vite|TodoWrite|Bash|Write/);
+    expect(beats(events)).toEqual([
+      ["understanding", "Getting started"],
+      ["planning", "Working out the steps"],
+      ["building", "Putting it together"],
+      ["finishing", "Finishing up"],
+    ]);
+  });
+
+  test("no beat claims to be about an app — this loop is never told which one", async () => {
+    const events = await run([[{ use: { name: "Write", input: { file_path: "/workspace/user/apps/app_1/app.vendo" } } }]]);
+    // `appId` is optional in the contract precisely so a producer that does not
+    // have one leaves it off instead of parsing one out of a path.
+    for (const event of events) {
+      if (event.type === "status") expect(event).not.toHaveProperty("appId");
+    }
+  });
+
+  test("a beat stays OFF the transcript vocabulary — it is a status, never text", async () => {
+    const events = await run([[{ use: { name: "Write" } }]]);
+    const spoken = events.filter((event) => event.type === "text");
+    expect(spoken).toEqual([]);
+  });
+});
+
+/**
+ * THE MIRROR SEAM.
+ *
+ * `claude-turn.ts` imports NOTHING (its module header explains why: the emitted
+ * `dist/claude-turn.js` is copied verbatim into a machine image, and a module that
+ * named its dependencies was reachable from every composed host's build graph). So
+ * `BeatPhase` is restated there structurally rather than imported from core.
+ *
+ * `claude-code/index.ts` yields these events straight into `HarnessEvent`, so
+ * TypeScript already compares the two unions on every build — but it does it 200
+ * lines away, as an inference failure nobody can read. These two records make the
+ * drift fail HERE, by name, in both directions.
+ */
+describe("the phase union cannot drift from core's", () => {
+  /** Keyed by every member of CORE's union: a seventh phase in core leaves a
+   *  missing key here. Valued as the MIRROR's: a member core has and the mirror
+   *  lacks fails on the value. */
+  const MIRRORS_CORE: Record<ContractBeatPhase, BeatPhase> = {
+    understanding: "understanding",
+    planning: "planning",
+    assembling: "assembling",
+    building: "building",
+    checking: "checking",
+    finishing: "finishing",
+  };
+
+  /** The other direction: a member the MIRROR has and core does not. */
+  const CORE_MIRRORS: Record<BeatPhase, ContractBeatPhase> = MIRRORS_CORE;
+
+  test("the six member strings are the same six, spelled the same way", () => {
+    expect(Object.keys(MIRRORS_CORE).sort()).toEqual([
+      "assembling", "building", "checking", "finishing", "planning", "understanding",
+    ]);
+    expect(Object.keys(CORE_MIRRORS).sort()).toEqual(Object.keys(MIRRORS_CORE).sort());
+  });
+
+  test("every phase this loop emits is a member of the contract's six", async () => {
+    const events = await run([[{ use: { name: "TodoWrite" } }, { use: { name: "Write" } }]]);
+    for (const [phase] of beats(events)) {
+      expect(Object.keys(MIRRORS_CORE)).toContain(phase);
+    }
+  });
+});
+
+describe("the widening is ADDITIVE (§3.4)", () => {
+  test("a status with only a label is still exactly what it always was", () => {
+    // The dead `{ type: "status"; label: string }` member this PR took its seat in
+    // had no `phase` and no `appId`; a producer that says nothing but `label` must
+    // put the identical chunk on the wire. `harnesses/src/beats.test.ts` asserts
+    // the wire half; this asserts the TYPE still admits the narrow form.
+    const bare: ClaudeTurnEvent = { type: "status", label: "Reading your invoices" };
+    expect(bare).toEqual({ type: "status", label: "Reading your invoices" });
+  });
+});

--- a/packages/apps/src/claude-beats.test.ts
+++ b/packages/apps/src/claude-beats.test.ts
@@ -234,46 +234,42 @@ describe("a beat is our copy, never the model's", () => {
 });
 
 /**
- * THE MIRROR SEAM.
+ * THE MIRROR SEAM — and where its teeth actually are.
  *
- * `claude-turn.ts` imports NOTHING (its module header explains why: the emitted
- * `dist/claude-turn.js` is copied verbatim into a machine image, and a module that
- * named its dependencies was reachable from every composed host's build graph). So
- * `BeatPhase` is restated there structurally rather than imported from core.
+ * `claude-turn.ts` restates core's `BeatPhase` instead of importing it, because
+ * that file imports NOTHING (module header: the emitted `dist/claude-turn.js` is
+ * copied verbatim into a machine image).
  *
- * `claude-code/index.ts` yields these events straight into `HarnessEvent`, so
- * TypeScript already compares the two unions on every build — but it does it 200
- * lines away, as an inference failure nobody can read. These two records make the
- * drift fail HERE, by name, in both directions.
+ * The COMPILE-TIME half of that seam deliberately does not live here. Nothing in
+ * this repo typechecks a test file — `packages/apps/tsconfig.json` excludes
+ * `src/**` + `*.test.ts`, no package defines a `lint` script, and vitest is not
+ * run with `--typecheck` — so a type-level assertion in this file would be pure
+ * decoration. It lives in gated production code instead: `BEAT_PHASES` in
+ * `harnesses/src/claude-code/index.ts` fails when CORE gains a phase the mirror
+ * lacks, and the `yield` beside it fails in the other direction. Both were
+ * verified red by adding a seventh phase to each side in turn.
+ *
+ * What IS worth asserting here is the runtime fact: the phases this loop actually
+ * puts on the wire are members of the contract's six, spelled the contract's way.
  */
-describe("the phase union cannot drift from core's", () => {
-  /** Keyed by every member of CORE's union: a seventh phase in core leaves a
-   *  missing key here. Valued as the MIRROR's: a member core has and the mirror
-   *  lacks fails on the value. */
-  const MIRRORS_CORE: Record<ContractBeatPhase, BeatPhase> = {
-    understanding: "understanding",
-    planning: "planning",
-    assembling: "assembling",
-    building: "building",
-    checking: "checking",
-    finishing: "finishing",
-  };
+describe("every phase this loop emits is one of the contract's six", () => {
+  /** Spelled out as a value, following `harnesses/src/beats.test.ts`'s own
+   *  precedent, so a seventh cannot arrive without this line changing on purpose. */
+  const ARC: ContractBeatPhase[] = [
+    "understanding", "planning", "assembling", "building", "checking", "finishing",
+  ];
 
-  /** The other direction: a member the MIRROR has and core does not. */
-  const CORE_MIRRORS: Record<BeatPhase, ContractBeatPhase> = MIRRORS_CORE;
-
-  test("the six member strings are the same six, spelled the same way", () => {
-    expect(Object.keys(MIRRORS_CORE).sort()).toEqual([
-      "assembling", "building", "checking", "finishing", "planning", "understanding",
-    ]);
-    expect(Object.keys(CORE_MIRRORS).sort()).toEqual(Object.keys(MIRRORS_CORE).sort());
+  test("nothing outside the arc reaches the wire", async () => {
+    const events = await run([[{ use: { name: "TodoWrite" } }, { use: { name: "Write" } }]]);
+    const emitted = beats(events).map(([phase]) => phase);
+    expect(emitted.length).toBeGreaterThan(0);
+    for (const phase of emitted) expect(ARC).toContain(phase);
   });
 
-  test("every phase this loop emits is a member of the contract's six", async () => {
+  test("the beats arrive in the order the arc runs", async () => {
     const events = await run([[{ use: { name: "TodoWrite" } }, { use: { name: "Write" } }]]);
-    for (const [phase] of beats(events)) {
-      expect(Object.keys(MIRRORS_CORE)).toContain(phase);
-    }
+    const positions = beats(events).map(([phase]) => ARC.indexOf(phase as ContractBeatPhase));
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
   });
 });
 

--- a/packages/apps/src/claude-turn.ts
+++ b/packages/apps/src/claude-turn.ts
@@ -105,9 +105,11 @@ const DISALLOWED_TOOLS = [
  *
  * Restated rather than imported because this file imports nothing (module
  * header). `claude-code/index.ts` yields these events straight into
- * `HarnessEvent`, so the compiler already compares the two unions on every
- * build — but 200 lines away, as an inference failure nobody can read.
- * `claude-beats.test.ts` makes the drift fail by name, in both directions.
+ * `HarnessEvent`, so the compiler already compares the two unions — but in ONE
+ * direction only, and 200 lines away as an inference failure nobody can read.
+ * `BEAT_PHASES` there closes the other direction and names the drift; it is in
+ * production code rather than a test because nothing in this repo typechecks a
+ * test file.
  */
 export type BeatPhase =
   | "understanding"

--- a/packages/apps/src/claude-turn.ts
+++ b/packages/apps/src/claude-turn.ts
@@ -99,9 +99,36 @@ const DISALLOWED_TOOLS = [
   "ScheduleWakeup",
 ];
 
+/**
+ * Where a beat sits in the arc of making something — a STRUCTURAL MIRROR of
+ * core's `BeatPhase` (contract §3.4), CLOSED at six.
+ *
+ * Restated rather than imported because this file imports nothing (module
+ * header). `claude-code/index.ts` yields these events straight into
+ * `HarnessEvent`, so the compiler already compares the two unions on every
+ * build — but 200 lines away, as an inference failure nobody can read.
+ * `claude-beats.test.ts` makes the drift fail by name, in both directions.
+ */
+export type BeatPhase =
+  | "understanding"
+  | "planning"
+  | "assembling"
+  | "building"
+  | "checking"
+  | "finishing";
+
 export type ClaudeTurnEvent =
   | { type: "text"; delta: string }
-  | { type: "status"; label: string }
+  /**
+   * A BEAT — consumer voice, ephemeral, screen only.
+   *
+   * `phase` and `appId` are ADDITIVE (§3.4): a status carrying nothing but a
+   * `label` puts the identical chunk on the wire it always did. `appId` stays
+   * unset here — this loop is never told which app it is building, and the
+   * contract makes the field optional precisely so a producer without one leaves
+   * it off instead of parsing an id out of a file path.
+   */
+  | { type: "status"; label: string; phase?: BeatPhase; appId?: string }
   | { type: "error"; message: string }
   | { type: "usage"; inputTokens: number; outputTokens: number; cacheReadTokens?: number; cacheWriteTokens?: number; model?: string }
   /** Not a `HarnessEvent`: the native session ref the caller puts in `turn.state`. */
@@ -265,6 +292,30 @@ function messageInbox() {
  */
 const WRITING_TOOLS = "Write|Edit|MultiEdit|NotebookEdit|Bash";
 
+/** The same names, as a set — one list decides both the hook matcher above and
+ *  the building beat, so the two can never disagree about what a write is. */
+const WRITING_TOOL_NAMES = new Set(WRITING_TOOLS.split("|"));
+
+/**
+ * The task-list tool: the model writes its plan as todos and flips them as it
+ * goes, which is the one place this loop can watch PLANNING happen.
+ *
+ * Only THAT it was used is read. Its `activeForm` field is documented by the CLI
+ * as "the present continuous form shown during execution" and is a beat in all
+ * but name — and it is also the model's own untrusted text, free to say
+ * "Creating app/src/InvoiceTable.tsx". Admitting it would need a regex gate over
+ * model prose, which ruling 14 (`ui/src/consumer-voice.ts`) already tried and
+ * reversed: a regex set cannot be the authority for what a person may read. So
+ * the beats below are OUR fixed copy, and this loop holds no filename it could
+ * leak.
+ *
+ * A future SDK that RENAMES this tool makes the planning beat fall silent, which
+ * is the right failure — silence, never a lie about progress. The rename itself
+ * is already loud: `claude-turn.test.ts` fails on any tool name its ledger has
+ * not classified.
+ */
+const PLANNING_TOOL = "TodoWrite";
+
 /**
  * Open ONE live session for a whole conversation.
  *
@@ -294,6 +345,22 @@ export function createClaudeSession(input: ClaudeSessionInput): ClaudeSession {
 
   /** The open `Query`, once it exists — the only thing that can interrupt a turn. */
   let live: { interrupt?: () => Promise<unknown> } | undefined;
+
+  /**
+   * Which stages this turn has already narrated (§3.4: "one beat per real step").
+   *
+   * A phase is a STAGE, not a tick — the tenth file write is not news — so each
+   * fires once and the set clears at the turn boundary, letting turn 2 plan and
+   * build again. `understanding` rides the session's own `init`, which happens
+   * once per SESSION: turn 2 does not claim to be getting started, because it
+   * isn't.
+   */
+  const narrated = new Set<BeatPhase>();
+  const beat = (phase: BeatPhase, label: string): void => {
+    if (narrated.has(phase)) return;
+    narrated.add(phase);
+    input.emit({ type: "status", label, phase });
+  };
 
   const drain = (async () => {
     const options: Record<string, unknown> = {
@@ -375,6 +442,7 @@ export function createClaudeSession(input: ClaudeSessionInput): ClaudeSession {
         }
         const named = message["model"];
         if (typeof named === "string") model = named;
+        beat("understanding", "Getting started");
         continue;
       }
       if (type === "assistant") {
@@ -383,16 +451,25 @@ export function createClaudeSession(input: ClaudeSessionInput): ClaudeSession {
         // twice (measured live 2026-08-02, once `includePartialMessages` went on).
         // Whichever arrived first wins; the block is still the only source when
         // an SDK build streams nothing, so the fallback stays real.
-        if (streamed) {
-          streamed = false;
-          continue;
-        }
+        //
+        // The message is SCANNED either way, never skipped whole: a `tool_use`
+        // block rides in the SAME message as the sentence that introduced it, so
+        // skipping the duplicate prose also threw away every beat in any turn
+        // where the model spoke — which is every real turn.
         const content = (message["message"] as { content?: Array<Record<string, unknown>> } | undefined)?.content;
         for (const block of content ?? []) {
-          if (block["type"] === "text" && typeof block["text"] === "string" && block["text"] !== "") {
-            input.emit({ type: "text", delta: block["text"] });
+          if (block["type"] === "text") {
+            if (!streamed && typeof block["text"] === "string" && block["text"] !== "") {
+              input.emit({ type: "text", delta: block["text"] });
+            }
+          } else if (block["type"] === "tool_use" && typeof block["name"] === "string") {
+            // The tool's NAME and nothing else. Its inputs are the model's own
+            // text and can name a file (see {@link PLANNING_TOOL}).
+            if (block["name"] === PLANNING_TOOL) beat("planning", "Working out the steps");
+            else if (WRITING_TOOL_NAMES.has(block["name"])) beat("building", "Putting it together");
           }
         }
+        streamed = false;
         continue;
       }
       if (type === "stream_event") {
@@ -409,9 +486,14 @@ export function createClaudeSession(input: ClaudeSessionInput): ClaudeSession {
         const usage = usageEvent(message["usage"], model);
         if (usage !== undefined) input.emit(usage);
         if (message["subtype"] !== "success") {
-          // Consumer voice: no subtypes, no internals.
+          // Consumer voice: no subtypes, no internals. And no `finishing` beat —
+          // a beat that claimed progress in front of an error would be a lie.
           input.emit({ type: "error", message: "I couldn't finish that one." });
+        } else {
+          beat("finishing", "Finishing up");
         }
+        // The next turn narrates afresh, whichever way this one ended.
+        narrated.clear();
         // THE turn boundary. The input stream stays open; only this message's
         // caller is released.
         const settle = settleTurn;

--- a/packages/harnesses/src/claude-code/beats-wire.test.ts
+++ b/packages/harnesses/src/claude-code/beats-wire.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Beats, SDK loop to WIRE — contract §3.4, the whole chain with no stub in it.
+ *
+ * `harnesses/src/beats.test.ts` proves the second half (a harness that yields a
+ * status reaches `data-vendo-status` with `phase` and `appId` intact, through the
+ * real runtime and the real writer). This proves the FIRST half joined to it, so
+ * the two together cover the seam end to end:
+ *
+ *   scripted SDK stream
+ *     → the REAL `createClaudeSession` loop, imported from `dist` — the very file
+ *       `build-template.mjs` copies into the machine image
+ *     → the REAL box door (`packages/apps/box/turn-routes.mjs`), over a transport
+ *       adapter instead of a socket
+ *     → the REAL `box.ts` poll loop and its `message.emit` forward
+ *     → the REAL `claude-code/index.ts` queue passthrough
+ *     → the REAL harness runtime and the REAL wire writer
+ *     → `readSse`
+ *
+ * The SDK is the one thing doubled: a unit test cannot run a model. Nothing here
+ * mocks any code of ours, which is the point — `claude-code.test.ts`'s fake box
+ * SCRIPTS the session and so can never disagree with the loop about what the loop
+ * emits. This one runs the loop.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import type { ThreadId } from "@vendoai/core";
+import { createSessionRoutes } from "@vendoai/apps/box-door";
+import { createClaudeSession } from "@vendoai/apps/claude-turn";
+import { createHarnessRuntime } from "../runtime.js";
+import { VENDO_STATUS_PART } from "../wire.js";
+import {
+  boundRegistry,
+  ctx,
+  readSse,
+  testGuard,
+  testSkills,
+  testTranscript,
+  testWorkspace,
+  unusedModels,
+  userMessage,
+} from "../test-doubles.test-util.js";
+import { claudeCode } from "./index.js";
+import { disposeSessionMachines, type SandboxAdapterLike } from "./box.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/** One tool the model used, as an `assistant` tool_use block. */
+interface Used {
+  say?: string;
+  use?: { name: string; input?: Record<string, unknown> };
+}
+
+/** The SDK's own stream shapes (verified against @anthropic-ai/claude-agent-sdk
+ *  0.3.214's `sdk-tools.d.ts`): prose streams as deltas, then the completed
+ *  message carrying the same text AND the tool_use block arrives. */
+function fakeSdk(script: Used[]) {
+  return {
+    query: ({ prompt }: { prompt: unknown }) => ({
+      async *[Symbol.asyncIterator]() {
+        yield { type: "system", subtype: "init", session_id: "sess_wire", model: "claude-test" };
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        for await (const _message of prompt as AsyncIterable<unknown>) {
+          for (const step of script) {
+            if (step.say !== undefined) {
+              yield {
+                type: "stream_event",
+                event: { type: "content_block_delta", delta: { type: "text_delta", text: step.say } },
+              };
+            }
+            const content: Array<Record<string, unknown>> = [];
+            if (step.say !== undefined) content.push({ type: "text", text: step.say });
+            if (step.use !== undefined) {
+              content.push({ type: "tool_use", name: step.use.name, input: step.use.input ?? {} });
+            }
+            if (content.length > 0) yield { type: "assistant", message: { content } };
+          }
+          yield {
+            type: "result",
+            subtype: "success",
+            session_id: "sess_wire",
+            usage: { input_tokens: 9, output_tokens: 4 },
+          };
+        }
+      },
+    }),
+  };
+}
+
+const roots: string[] = [];
+afterEach(async () => {
+  await disposeSessionMachines();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+/**
+ * A box that speaks the REAL control-port protocol, running the REAL SDK loop.
+ *
+ * Deliberately not `claude-code.test.ts`'s fake sandbox: that one injects a
+ * SCRIPTED session in place of `createClaudeSession`, which is exactly the
+ * counterparty-mocking this test exists to avoid. Here `openSession` builds the
+ * real session and hands it the doubled SDK — the pattern `turn-routes.mjs`
+ * itself documents ("an injected factory is a test double and brings its own SDK
+ * double").
+ */
+function boxRunningTheRealLoop(script: Used[]): SandboxAdapterLike {
+  return {
+    async create() {
+      const root = mkdtempSync(path.join(tmpdir(), "vendo-beatbox-"));
+      roots.push(root);
+      const routes = createSessionRoutes({
+        root,
+        // A created machine boots with no token; the first hello claims it.
+        token: "",
+        env: {},
+        openSession: (input: Record<string, unknown>) =>
+          createClaudeSession({ ...input, sdk: fakeSdk(script) } as never),
+      }) as {
+        handle: (method: string, pathname: string, headers: Record<string, string>, payload: unknown)
+          => Promise<{ status: number; body: unknown }>;
+      };
+      return {
+        id: "box_beats",
+        async destroy() { /* the root is reaped in afterEach */ },
+        async request(req) {
+          const payload = req.body === undefined
+            ? {}
+            : JSON.parse(typeof req.body === "string" ? req.body : decoder.decode(req.body)) as unknown;
+          const answer = await routes.handle(
+            req.method,
+            req.path,
+            (req.headers ?? {}) as Record<string, string>,
+            payload,
+          );
+          return { status: answer.status, headers: {}, body: encoder.encode(JSON.stringify(answer.body)) };
+        },
+      };
+    },
+    async destroy() { /* teardown by ref */ },
+  };
+}
+
+/** Run one real turn all the way to SSE and return every transient status chunk. */
+async function beatsOnTheWire(script: Used[]): Promise<Array<Record<string, unknown>>> {
+  const guard = testGuard();
+  const runtime = createHarnessRuntime({
+    tools: boundRegistry({}, guard),
+    guard,
+    skills: testSkills([]),
+    transcript: testTranscript(),
+  });
+  const parts = await readSse(await runtime.run({
+    harness: claudeCode({ sandbox: boxRunningTheRealLoop(script) }) as never,
+    threadId: "thr_beats_wire" as ThreadId,
+    messages: [userMessage("m1", "make me a spending screen")],
+    ctx: ctx(),
+    workspace: testWorkspace(),
+    models: unusedModels(),
+    interactive: true,
+  }));
+  return parts
+    .filter((part) => part["type"] === VENDO_STATUS_PART)
+    .map((part) => part["data"] as Record<string, unknown>);
+}
+
+describe("beats reach the wire from inside the box (§3.4)", () => {
+  test("a real build narrates itself, in order, with its phases intact", async () => {
+    const beats = await beatsOnTheWire([
+      { say: "I'll lay out a spending screen." },
+      { use: { name: "TodoWrite", input: { todos: [{ content: "Build the table", status: "in_progress", activeForm: "Building the table" }] } } },
+      { use: { name: "Write", input: { file_path: "/workspace/user/apps/app_1/app.vendo" } } },
+      { say: "All set." },
+    ]);
+    expect(beats).toEqual([
+      { label: "Getting started", phase: "understanding" },
+      { label: "Working out the steps", phase: "planning" },
+      { label: "Putting it together", phase: "building" },
+      { label: "Finishing up", phase: "finishing" },
+    ]);
+  });
+
+  test("nothing the model or its tools named reaches the user's screen", async () => {
+    const beats = await beatsOnTheWire([
+      {
+        say: "Creating app/src/InvoiceTable.tsx.",
+        use: {
+          name: "TodoWrite",
+          input: { todos: [{ content: "Create app/src/InvoiceTable.tsx", status: "in_progress", activeForm: "Creating app/src/InvoiceTable.tsx" }] },
+        },
+      },
+      { use: { name: "Bash", input: { command: "pnpm vite build --outDir dist" } } },
+    ]);
+    const said = beats.map((beat) => String(beat["label"])).join(" | ");
+    expect(said).not.toMatch(/InvoiceTable|\.tsx|app\.vendo|vite|TodoWrite|Bash|claude-test|sess_wire/);
+    // And no beat invents an app it was never told about.
+    for (const beat of beats) expect(beat).not.toHaveProperty("appId");
+  });
+
+  test("a beat is EPHEMERAL — the transcript never keeps one", async () => {
+    const guard = testGuard();
+    const transcript = testTranscript();
+    const runtime = createHarnessRuntime({
+      tools: boundRegistry({}, guard),
+      guard,
+      skills: testSkills([]),
+      transcript,
+    });
+    const thread = "thr_beats_wire_ephemeral" as ThreadId;
+    await readSse(await runtime.run({
+      harness: claudeCode({ sandbox: boxRunningTheRealLoop([{ use: { name: "Write" } }]) }) as never,
+      threadId: thread,
+      messages: [userMessage("m1", "make me a spending screen")],
+      ctx: ctx(),
+      workspace: testWorkspace(),
+      models: unusedModels(),
+      interactive: true,
+    }));
+    const stored = JSON.stringify(await transcript.list({ kind: "user", subject: "u1" }, thread));
+    for (const label of ["Getting started", "Working out the steps", "Putting it together", "Finishing up"]) {
+      expect(stored).not.toContain(label);
+    }
+  });
+});

--- a/packages/harnesses/src/claude-code/beats-wire.test.ts
+++ b/packages/harnesses/src/claude-code/beats-wire.test.ts
@@ -41,7 +41,7 @@ import {
   unusedModels,
   userMessage,
 } from "../test-doubles.test-util.js";
-import { claudeCode } from "./index.js";
+import { BEAT_PHASES, claudeCode } from "./index.js";
 import { disposeSessionMachines, type SandboxAdapterLike } from "./box.js";
 
 const encoder = new TextEncoder();
@@ -196,6 +196,25 @@ describe("beats reach the wire from inside the box (§3.4)", () => {
     expect(said).not.toMatch(/InvoiceTable|\.tsx|app\.vendo|vite|TodoWrite|Bash|claude-test|sess_wire/);
     // And no beat invents an app it was never told about.
     for (const beat of beats) expect(beat).not.toHaveProperty("appId");
+  });
+
+  /**
+   * The runtime half of the mirror seam. `BEAT_PHASES` is the COMPILE-TIME pin —
+   * keyed by core's union, valued as the loop's — and it is the only reason the
+   * duplicated union is safe. Its compile-time teeth were verified red in both
+   * directions; this holds its spelling at runtime, and holds the wire to it.
+   */
+  test("the phases on the wire are the pinned six, spelled the pinned way", async () => {
+    expect(Object.keys(BEAT_PHASES).sort()).toEqual([
+      "assembling", "building", "checking", "finishing", "planning", "understanding",
+    ]);
+    // The map is an identity: a typo on either side of a pair would mean the box
+    // emitted a phase string no receiver dispatches on.
+    for (const [core, loop] of Object.entries(BEAT_PHASES)) expect(loop).toBe(core);
+
+    const beats = await beatsOnTheWire([{ use: { name: "TodoWrite" } }, { use: { name: "Write" } }]);
+    expect(beats.length).toBeGreaterThan(0);
+    for (const beat of beats) expect(Object.keys(BEAT_PHASES)).toContain(beat["phase"]);
   });
 
   test("a beat is EPHEMERAL — the transcript never keeps one", async () => {

--- a/packages/harnesses/src/claude-code/index.ts
+++ b/packages/harnesses/src/claude-code/index.ts
@@ -16,11 +16,12 @@
  */
 import {
   VENDO_MAKE_TOOL,
+  type BeatPhase,
   type Harness,
   type HarnessEvent,
   type Turn,
 } from "@vendoai/core";
-import type { ClaudeTurnEvent } from "@vendoai/apps/claude-turn";
+import type { BeatPhase as LoopBeatPhase, ClaudeTurnEvent } from "@vendoai/apps/claude-turn";
 import type { UIMessage } from "ai";
 import { z } from "zod";
 import { defineHarness } from "../define.js";
@@ -35,6 +36,32 @@ import { boxMachine, type SandboxAdapterLike } from "./box.js";
 export interface ClaudeCodeTurnOptions {
   maxTurns?: number;
 }
+
+/**
+ * The beat phase union is declared TWICE, and this is what makes that safe.
+ *
+ * Core owns `BeatPhase` (contract §3.4). `claude-turn.ts` restates it
+ * structurally because that file imports NOTHING — its module header explains
+ * why: the emitted `dist/claude-turn.js` is copied verbatim into a machine image,
+ * and a module that named its dependencies was reachable from every composed
+ * host's build graph.
+ *
+ * The `yield event` below already compares the two unions, but only in ONE
+ * direction: a mirror that is a SUBSET of core stays assignable, so a seventh
+ * phase added to core would leave the box silently unable to ever emit it, with
+ * nothing failing anywhere (verified: adding one to core left every typecheck
+ * green). This map closes that direction — its keys are required by CORE's union
+ * and its values are typed as the LOOP's, so drift either way fails here, by
+ * name, instead of as an inference error 200 lines down.
+ */
+export const BEAT_PHASES: Record<BeatPhase, LoopBeatPhase> = {
+  understanding: "understanding",
+  planning: "planning",
+  assembling: "assembling",
+  building: "building",
+  checking: "checking",
+  finishing: "finishing",
+};
 
 /** v1 options, exactly (design §3): nothing else until asked. */
 export interface ClaudeCodeOptions extends ClaudeCodeTurnOptions {


### PR DESCRIPTION
## The problem

A heavy build runs the Claude Agent SDK inside a box and the user watches ~52s of nothing. Contract §3.4 gave beats a contract and Phase 0 landed the channel end to end — `HarnessEvent`'s `status` member is widened, `writeStatus` writes the transient `data-vendo-status` part. Nothing inside the box ever emitted one.

`ClaudeTurnEvent` even carried a `status` member that **no code path had ever reached**. This PR takes that seat.

**No new event, no new channel, no new stream, no new `HarnessEvent` member, no new surface.**

## The beat source, and why

Four steps the loop **genuinely observes**:

| Signal in the SDK loop | Phase | What the user reads |
|---|---|---|
| `system`/`init` | `understanding` | Getting started |
| an `assistant` `tool_use` block naming `TodoWrite` | `planning` | Working out the steps |
| the first `tool_use` in `WRITING_TOOLS` | `building` | Putting it together |
| `result` with `subtype: "success"` | `finishing` | Finishing up |

A phase is a **stage, not a tick** — the tenth write is not news — so each fires once and resets at the turn boundary. `understanding` rides the session's own `init`, which happens once per session, so turn 2 does not claim to be getting started, because it isn't. A failed turn emits **no** `finishing` beat; the error is the news.

### The beats are OUR copy, never the model's

The tempting source was `TodoWrite`'s `activeForm`, documented by the shipped CLI as *"The present continuous form shown during execution (e.g. 'Running tests', 'Building the project')"* — a beat in all but name. It is also **untrusted model text**, free to say `Creating app/src/InvoiceTable.tsx` or `Build beautiful spending dashboard`.

Admitting it needs a regex gate over model prose, and **ruling 14 already tried that and reversed it** (`ui/src/consumer-voice.ts`): *"a regex set cannot be the authority for what a person may read"* — it admitted raw JSON and exceptions while deleting good host copy. Its replacement is a precedence ladder of trusted sources ending in **our own fixed sentence** (`consentWords`), and beats have no rung above that one: no host authors beat copy, and there is nothing structured to synthesize from.

So the loop reads a tool's **NAME and nothing else**. It never touches `activeForm`, never touches `file_path` — it therefore **holds no filename it could leak**. `appId` stays unset because this loop is never told which app it is building, and the contract makes the field optional precisely so a producer without one leaves it off instead of parsing an id out of a path.

That also satisfies the "never describe UI you didn't see" law: the builder cannot see what it is building, so a beat says what it is **doing**, never what the result looks like.

## Two defects found on the way

**1. Every beat in a talking turn was being thrown away.** `includePartialMessages: true` means prose arrives as deltas, so the completed `assistant` message is a duplicate — and the loop skipped it **whole**. A `tool_use` block rides in the *same* message as the sentence introducing it, so any turn where the model spoke (i.e. every real turn) lost its tool signals. The message is now scanned either way; prose is still said exactly once.

**2. The phase mirror only compared in one direction.** `claude-turn.ts` restates core's `BeatPhase` because that file imports nothing by design (the emitted `dist/claude-turn.js` is copied verbatim into a machine image). The `yield` into `HarnessEvent` only catches a mirror that is a *superset* — a phase added to **core** left every typecheck green and the box silently unable to emit it. Verified by adding a seventh phase to core: clean. `BEAT_PHASES` in the claude-code driver closes it with a named error.

That pin is in **production code, not a test**, because nothing in this repo typechecks a test file — both tsconfigs exclude `*.test.ts`, no package defines a `lint` script, and vitest is not run with `--typecheck`.

## Evidence

The real emitted `dist/claude-turn.js` — the exact file `build-template.mjs` bakes to `/opt/vendo-box/claude-turn.mjs` — driven with a scripted SDK stream carrying a filename-bearing `activeForm`, real file paths, a model name and token counts:

```
WHAT THE USER READS, in order:

  [understanding] Getting started
  [planning     ] Working out the steps
  [building     ] Putting it together
  [finishing    ] Finishing up
```

None of `SpendTable.tsx`, `app_7c1`, `app.vendo`, `claude-sonnet-4-6`, `4210` reaches a label.

### Tests — the seam, both halves

`beats-wire.test.ts` runs the whole chain with **no stub but the SDK**: scripted stream → real `createClaudeSession` (from `dist`) → real box door (`box/turn-routes.mjs`) → real `box.ts` poll/forward → real `index.ts` passthrough → real runtime → real wire writer → `readSse`. Deliberately *not* `claude-code.test.ts`'s fake box, which scripts the session and so can never disagree with the loop about what the loop emits.

Every test was proven able to fail:

- reverted the emit → 9 producer tests and the wire arc test go red
- reinstated the original `streamed` short-circuit (emit intact) → the streaming-defect test goes red, alone and by name
- added a 7th phase to core → `BEAT_PHASES` fails: `Property 'polishing' is missing … but required in type 'Record<BeatPhase, BeatPhase>'`
- added a 7th phase to the mirror → the `yield` fails
- injected `"Building your dashboard — it looks great"` → the appearance-claim test fails: `beat claims an appearance`

**Zero edits to existing test files** — both test files are new.

## Rebake dependency

`machine: "local"` picks this up immediately (it imports `@vendoai/apps/claude-turn` from `dist`). **A real box does not emit beats until the template is rebaked**, because `build-template.mjs:40` stages `../dist/claude-turn.js` and copies it to `/opt/vendo-box/claude-turn.mjs`, which `turn-routes.mjs:40` imports from that absolute path. Recompiling that one file is the *only* thing the rebake needs from this PR — no protocol change, no new route, no new payload field. Per blueprint §11, one bake carries this and the frame-resize change together.

## §0 — what went down, not up

- The dead `{ type: "status"; label: string }` member is no longer dead.
- `WRITING_TOOL_NAMES` derives from the existing `WRITING_TOOLS` matcher, so one list decides both the hook and the building beat.
- Deleted a type-level mirror record from the test file that asserted nothing (no gate typechecks tests) rather than leaving two pins standing.
- No second card, pill, toast, preview surface, stream, channel, event vocabulary, or query path.

`instant.ts` untouched (A1 deletes it; the channel stays).

## Gate

Package-scoped per fleet law (the root build fans out to 7 package builds and spiked machine load to 260):

- `pnpm --filter @vendoai/apps build` / `typecheck` — clean
- `pnpm --filter @vendoai/harnesses build` / `typecheck` — clean
- `dependency-guard` OK (15 packages) · `portability-gate` all legs green
- test slices, doubly capped, **green twice**: apps 69/69, harnesses 69/69

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The builder now narrates long builds by emitting on-screen `status` beats from inside the SDK loop, so users see progress instead of ~52s of silence. Uses the existing channel; local runs pick this up immediately, and real boxes start emitting after a template rebake.

- New Features
  - Emit four progress beats with phases: understanding (session init), planning (`TodoWrite`), building (first write tool), finishing (success). One per stage, per turn.
  - `ClaudeTurnEvent.status` now includes optional `phase` and `appId`; beats are ephemeral and never stored. Copy is fixed and safe: no model/tool text, filenames, or appearance claims.
  - `@vendoai/harnesses` provides `BEAT_PHASES` to map core `BeatPhase` to loop phases and pin the spelling at compile time.

- Bug Fixes
  - Scan `assistant` messages even when text already streamed, so `tool_use` signals aren’t dropped; prose is still de-duplicated.
  - Close the phase mirror in both directions: additions in core or the loop now fail loudly via `BEAT_PHASES` instead of going silent.

<sup>Written for commit 76c4a22128c397ecd8ce42a58794357da72e866f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

