### PR TITLE
feat(apps,vendo,harnesses): reading a file off a box is the seam's business, not each adapter's

### DIFF
--- a/.changeset/sandbox-file-seam.md
+++ b/.changeset/sandbox-file-seam.md
@@ -1,0 +1,47 @@
+---
+"@vendoai/apps": minor
+"@vendoai/vendo": minor
+"@vendoai/harnesses": minor
+---
+
+Reading a file off a sandbox is part of the seam, not each adapter's private
+business.
+
+`SandboxMachine.files` — `read`, `write`, `list` — is now declared on the public
+interface in `@vendoai/apps`. It already existed three times with an identical
+shape, hidden behind `satisfies SandboxMachine & Record<string, unknown> as
+SandboxMachine` casts in the e2b and Vendo Cloud adapters and on the fake, and
+was missing entirely from two other test doubles: five private spellings (or
+absences) of one contract, on the seam a built app's SOURCE has to cross.
+
+The interface now states the answers all of them have to agree on:
+
+- `read` REJECTS for a path the box does not hold — never empty bytes, because a
+  silently empty source file is a lost app.
+- `write` creates or replaces the whole file and creates the directories on the
+  way to it. It never appends.
+- `list` is ONE level and names only: entries directly in `dir`, a subdirectory
+  as its own name, never a path and never recursive. It rejects for a directory
+  the box does not hold, exactly as `read` does.
+- `read` hands bytes back UNCHANGED — no text decode, no BOM strip, no
+  line-ending normalization — because box content is untrusted and the layer
+  above verifies it against the hash in the app's row.
+
+The shared conformance suite (`@vendoai/apps/adapter-conformance`) pins all of
+it in one leg that every adapter runs, so no provider can drift. Verified live
+against a real e2b sandbox, including a payload of NULs, bare CRs and invalid
+UTF-8.
+
+Two disagreements the promotion exposed, both invisible while `files` was
+private: the Vendo Cloud list route answers deeper than one level, so the Cloud
+adapter folds the depth away at the seam; and a missing directory rejected on
+real e2b (`[not_found] lstat …`) while both in-memory fakes answered `[]`,
+which is how a mistyped source directory reads as an app with no files. The
+seam now rejects everywhere.
+
+What went away: two redundant `files` casts on the real adapters, the
+`files`-shaped half of the Cloud wire test's private-surface cast, the
+`files` cast in three live bootstraps, and three copies of the fakes'
+in-memory file semantics (now one `inMemoryBoxFiles`). `SandboxMachineLike` in
+`@vendoai/harnesses/claude-code` carries `files`, still structurally and
+without widening the subpath's imports. `exec` stays adapter-private.

--- a/.changeset/sandbox-file-seam.md
+++ b/.changeset/sandbox-file-seam.md
@@ -32,7 +32,15 @@ it in one leg that every adapter runs, so no provider can drift. Verified live
 against a real e2b sandbox, including a payload of NULs, bare CRs and invalid
 UTF-8.
 
-Two disagreements the promotion exposed, both invisible while `files` was
+The consolidation paid for itself immediately: a review found that the
+in-memory `list` treated the root's prefix as `""` rather than `"/"`, so it
+sliced nothing off an absolute path and dropped every name as blank — `list("/")`
+answered `[]` on a box full of files. Before `inMemoryBoxFiles` that line existed
+in every fake that had a `list` and would have been a separate fix in each. It
+was one fix in one file, and the conformance suite now pins the root case for
+every implementation.
+
+Two further disagreements the promotion exposed, both invisible while `files` was
 private: the Vendo Cloud list route answers deeper than one level, so the Cloud
 adapter folds the depth away at the seam; and a missing directory rejected on
 real e2b (`[not_found] lstat …`) while both in-memory fakes answered `[]`,

--- a/fixtures/integration/src/machine-skin.e2e.test.ts
+++ b/fixtures/integration/src/machine-skin.e2e.test.ts
@@ -110,6 +110,14 @@ function fakeBox(): { sandbox: SandboxAdapter; setEnv(env: Record<string, string
       const result = await handler();
       return { status: 200, headers, body: encoder.encode(JSON.stringify(result)) };
     },
+    // The skin journey is the fn/callback boundary, never the box's disk — the
+    // seam member is here so this double stays a whole SandboxMachine, and it
+    // fails loudly rather than answering a file it does not hold.
+    files: {
+      async read(path) { throw new Error(`the machine-skin box holds no files (${path})`); },
+      async write(path) { throw new Error(`the machine-skin box holds no files (${path})`); },
+      async list(dir) { throw new Error(`the machine-skin box holds no files (${dir})`); },
+    },
     async url(port?: number) { return `https://${port ?? 8080}-fake_box_machine.skin.test`; },
     async snapshot() { return "fake:machine-skin"; },
     async stop() { /* sleep */ },

--- a/packages/apps/src/adapter-conformance.ts
+++ b/packages/apps/src/adapter-conformance.ts
@@ -244,6 +244,47 @@ export const sandboxAdapterConformance = (
       TEST_TIMEOUT_MS,
     );
 
+    it("writes, reads back byte-for-byte, lists one level, and rejects what it does not hold", async () => {
+      const adapter = await harness.makeAdapter();
+      const machine = track(await adapter.create({ env: { PORT: "8080" } }));
+      // /tmp, not the app root: every provider's box has it and it is writable
+      // without bootstrap, so the file seam is provable on a bare machine.
+      const dir = "/tmp/vendo-conformance-files";
+      // Deliberately hostile bytes: a NUL, a CRLF, a lone CR, and three
+      // sequences that are not valid UTF-8. Box content is UNTRUSTED — the
+      // layer above verifies a built app's source against the hash in its row,
+      // which it can only do if this seam hands back the bytes UNCHANGED. No
+      // text decode, no BOM strip, no line-ending normalization.
+      const hostile = new Uint8Array([0, 13, 10, 13, 0xff, 0xfe, 0x80, 65, 13, 0]);
+
+      await machine.files.write(`${dir}/one.txt`, "first");
+      await machine.files.write(`${dir}/nested/two.bin`, hostile);
+
+      const read = await machine.files.read(`${dir}/one.txt`);
+      expect(read).toBeInstanceOf(Uint8Array);
+      expect(decoder.decode(read)).toBe("first");
+      expect(await machine.files.read(`${dir}/nested/two.bin`)).toEqual(hostile);
+
+      // A second write REPLACES the file whole; it never appends.
+      await machine.files.write(`${dir}/one.txt`, "second");
+      expect(decoder.decode(await machine.files.read(`${dir}/one.txt`))).toBe("second");
+
+      // list is ONE level and names only: the subdirectory's own name, never
+      // the file inside it and never a path.
+      expect([...await machine.files.list(dir)].sort()).toEqual(["nested", "one.txt"]);
+
+      // The seam's one answer for a path the box does not hold: it rejects.
+      // Answering empty bytes would turn a lost source file into a silently
+      // empty one.
+      await expect(machine.files.read(`${dir}/absent.txt`)).rejects.toThrow();
+
+      // …and the same answer for a DIRECTORY it does not hold. Probed against
+      // real e2b, which reports `[not_found] lstat …: no such file or
+      // directory`; both in-memory fakes used to answer `[]` instead, which is
+      // how a mistyped source directory reads as "this app has no files".
+      await expect(machine.files.list(`${dir}/nope`)).rejects.toThrow();
+    }, TEST_TIMEOUT_MS);
+
     it("exposes a public ingress URL, defaulting to the app's $PORT", async () => {
       const adapter = await harness.makeAdapter();
       const machine = track(await adapter.create({

--- a/packages/apps/src/adapter-conformance.ts
+++ b/packages/apps/src/adapter-conformance.ts
@@ -283,6 +283,16 @@ export const sandboxAdapterConformance = (
       // directory`; both in-memory fakes used to answer `[]` instead, which is
       // how a mistyped source directory reads as "this app has no files".
       await expect(machine.files.list(`${dir}/nope`)).rejects.toThrow();
+
+      // The ROOT is a directory like any other, and it EXISTS on every box —
+      // it must never answer empty on a box that demonstrably holds files.
+      // An in-memory impl that treats the root prefix as "" instead of "/"
+      // slices nothing off an absolute path and drops every name as blank.
+      // Asserted by containment, not equality: a real box's root also holds
+      // bin, etc, home…
+      const rootNames = await machine.files.list("/");
+      expect(rootNames).toContain("tmp");
+      expect(rootNames.filter((name) => name === "" || name.includes("/"))).toEqual([]);
     }, TEST_TIMEOUT_MS);
 
     it("exposes a public ingress URL, defaulting to the app's $PORT", async () => {

--- a/packages/apps/src/e2b/e2b.live.test.ts
+++ b/packages/apps/src/e2b/e2b.live.test.ts
@@ -61,14 +61,13 @@ http.createServer((request, response) => {
 }).listen(Number(process.env.PORT || 8080));
 `;
 
-/** Install and start the conformance app through the ADAPTER-PRIVATE surface
-    (in production the in-box agent owns the inside of the box). */
+/** Install the conformance app through the seam's `files`, and start it through
+    the ADAPTER-PRIVATE exec (in production the in-box agent starts the app). */
 const bootstrap = async (machine: SandboxMachine): Promise<void> => {
   const box = machine as unknown as {
     exec(cmd: string, opts?: { cwd?: string; timeoutMs?: number }): Promise<{ code: number; stdout: string; stderr: string }>;
-    files: { write(path: string, bytes: Uint8Array | string): Promise<void> };
   };
-  await box.files.write("/app/server.js", CONFORMANCE_SERVER_SOURCE);
+  await machine.files.write("/app/server.js", CONFORMANCE_SERVER_SOURCE);
   const started = await box.exec(
     [
       "i=0",

--- a/packages/apps/src/e2b/index.ts
+++ b/packages/apps/src/e2b/index.ts
@@ -204,10 +204,10 @@ const loadE2b = async (): Promise<E2BModule> => {
  * allowedDomains rides E2B's provider-native network allowlist plus an
  * all-traffic deny rule; undefined means unrestricted egress.
  *
- * The machine object also carries adapter-private exec/files used for
- * bootstrap, diagnostics, and the dying v1 compat paths — they are NOT part
- * of the public seam (the in-box agent owns the inside of the box).
- * The optional SDK is imported only when create/resume is called.
+ * `files` is part of the public seam (sandbox.ts). The machine object also
+ * carries adapter-private exec used for bootstrap, diagnostics, and the dying
+ * v1 compat paths — NOT part of the seam (the in-box agent owns the inside of
+ * the box). The optional SDK is imported only when create/resume is called.
  */
 export const e2bSandbox = (options: E2BSandboxOptions = {}): SandboxAdapter => {
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
@@ -289,6 +289,19 @@ export const e2bSandbox = (options: E2BSandboxOptions = {}): SandboxAdapter => {
           .then(() => undefined);
         await destroying;
       },
+      files: {
+        async read(path: string) {
+          return sandbox.files.read(path, { format: "bytes" });
+        },
+        async write(path: string, bytes: Uint8Array | string) {
+          await sandbox.files.write(path, typeof bytes === "string" ? bytes : toArrayBuffer(bytes));
+        },
+        async list(dir: string) {
+          // E2B lists one level by default and reports entry names, which is
+          // the seam's rule exactly.
+          return (await sandbox.files.list(dir)).map((entry) => entry.name);
+        },
+      },
       // ——— adapter-private below this line (bootstrap/diagnostics + v1 compat) ———
       async exec(cmd: string, execOptions?: { cwd?: string; timeoutMs?: number }) {
         // Box bootstrap and diagnostics are activity too — a minutes-long
@@ -310,17 +323,6 @@ export const e2bSandbox = (options: E2BSandboxOptions = {}): SandboxAdapter => {
           }
           throw error;
         }
-      },
-      files: {
-        async read(path: string) {
-          return sandbox.files.read(path, { format: "bytes" });
-        },
-        async write(path: string, bytes: Uint8Array | string) {
-          await sandbox.files.write(path, typeof bytes === "string" ? bytes : toArrayBuffer(bytes));
-        },
-        async list(dir: string) {
-          return (await sandbox.files.list(dir)).map((entry) => entry.name);
-        },
       },
     } satisfies SandboxMachine & Record<string, unknown> as SandboxMachine;
   };

--- a/packages/apps/src/e2b/secrets-egress.live.test.ts
+++ b/packages/apps/src/e2b/secrets-egress.live.test.ts
@@ -73,13 +73,12 @@ http.createServer((request, response) => {
 `;
 
 const bootstrap = async (machine: SandboxMachine): Promise<void> => {
-  // The ADAPTER-PRIVATE bootstrap surface (in production the in-box agent
-  // owns the inside of the box) — same shape the Lane A live test uses.
+  // Files ride the public seam; starting the app rides the ADAPTER-PRIVATE exec
+  // (in production the in-box agent does it) — same shape the Lane A test uses.
   const box = machine as unknown as {
     exec(cmd: string, opts?: { cwd?: string; timeoutMs?: number }): Promise<{ code: number; stdout: string; stderr: string }>;
-    files: { write(path: string, bytes: Uint8Array | string): Promise<void> };
   };
-  await box.files.write("/app/server.js", CONFORMANCE_SERVER_SOURCE);
+  await machine.files.write("/app/server.js", CONFORMANCE_SERVER_SOURCE);
   const started = await box.exec(
     "nohup node /app/server.js >/tmp/vendo-conformance.log 2>&1 &\necho $! >/tmp/vendo-conformance.pid",
     { cwd: "/app", timeoutMs: 15_000 },

--- a/packages/apps/src/machine-lifecycle.ts
+++ b/packages/apps/src/machine-lifecycle.ts
@@ -298,6 +298,11 @@ export const createMachineLifecycle = (config: MachineLifecycleConfig): MachineL
       }
     },
     url: (port) => raw.url(port),
+    files: {
+      read: (path) => raw.files.read(path),
+      write: (path, bytes) => raw.files.write(path, bytes),
+      list: (dir) => raw.files.list(dir),
+    },
     snapshot: () => raw.snapshot(),
     stop: () => raw.stop(),
     destroy: () => raw.destroy(),

--- a/packages/apps/src/sandbox.ts
+++ b/packages/apps/src/sandbox.ts
@@ -3,9 +3,11 @@
  * (docs/superpowers/specs/2026-07-19-execution-v2-design.md).
  *
  * The whole public contract between Vendo and a sandbox provider. The coding
- * agent lives INSIDE the box (Wave 3), so outside-the-box exec/files dropped
- * out of this seam; a provider adapter may keep them adapter-private for
- * bootstrap and diagnostics. The v1 seam this replaces is archived in
+ * agent lives INSIDE the box (Wave 3), so outside-the-box `exec` dropped out of
+ * this seam; a provider adapter may keep it adapter-private for bootstrap and
+ * diagnostics. `files` came BACK: a built app's source has to leave the box,
+ * and every adapter had grown its own private copy of the same three
+ * operations. The v1 seam this replaces is archived in
  * docs/archive/contracts/06-apps.md §3-4.
  */
 export interface SandboxAdapter {
@@ -89,6 +91,38 @@ export interface SandboxMachine {
    * provider's business (e.g. e2b's per-port public hostname).
    */
   url(port?: number): Promise<string>;
+
+  /**
+   * The box's filesystem — the seam a built app's SOURCE crosses. The in-box
+   * agent owns the inside of the box, but the bytes it produces have to come
+   * back out: this is what §3.2's commit reads a built app's source through,
+   * and what puts scaffolding in before the agent starts. Three operations,
+   * identical for every provider — it used to be adapter-private, which meant
+   * five private spellings (or absences) of the same thing.
+   *
+   * - `read` REJECTS for a path the box does not hold. It never answers empty
+   *   bytes: a silently empty source file is a lost app.
+   * - `write` creates or REPLACES the whole file, and creates the directories
+   *   on the way to it. It never appends.
+   * - `list` is ONE level and names only — the entry names directly in `dir`,
+   *   a subdirectory as its own name, never a path and never recursive. It
+   *   REJECTS for a directory the box does not hold, exactly as `read` does:
+   *   answering `[]` there lets a mistyped source directory read as an app
+   *   with no files.
+   *
+   * Box content is UNTRUSTED. A compromised or merely buggy in-box agent
+   * controls every path and every byte crossing this seam, so `read` hands
+   * bytes back UNCHANGED — no text decode, no BOM strip, no line-ending
+   * normalization — and the layer above verifies them against the hash in the
+   * app's row. Confining which paths may become an app's source is that layer's
+   * job too (`app-source.ts`), not this one's: a box's own filesystem is not
+   * partitioned, and the bootstrap legitimately writes outside the app root.
+   */
+  files: {
+    read(path: string): Promise<Uint8Array>;
+    write(path: string, bytes: Uint8Array | string): Promise<void>;
+    list(dir: string): Promise<string[]>;
+  };
 
   /** Persist the machine's current state; the ref restores it via SandboxAdapter.resume. */
   snapshot(): Promise<string>;

--- a/packages/apps/src/sandbox.ts
+++ b/packages/apps/src/sandbox.ts
@@ -108,7 +108,8 @@ export interface SandboxMachine {
    *   a subdirectory as its own name, never a path and never recursive. It
    *   REJECTS for a directory the box does not hold, exactly as `read` does:
    *   answering `[]` there lets a mistyped source directory read as an app
-   *   with no files.
+   *   with no files. `"/"` is the one directory that always exists, so it
+   *   answers the box's top-level names and never rejects.
    *
    * Box content is UNTRUSTED. A compromised or merely buggy in-box agent
    * controls every path and every byte crossing this seam, so `read` hands

--- a/packages/apps/src/testing/box-files.ts
+++ b/packages/apps/src/testing/box-files.ts
@@ -1,0 +1,46 @@
+import type { SandboxMachine } from "../sandbox.js";
+
+const textEncoder = new TextEncoder();
+
+/**
+ * The in-memory box filesystem every fake sandbox serves `files` from — one
+ * implementation of the seam's three operations (sandbox.ts), so no two fakes
+ * can drift into disagreeing about what reading a file means.
+ *
+ * `guard` is the fake's own lifecycle check. It runs for write and list and
+ * NOT for read: a read stays available after stop/destroy on purpose, so the
+ * fakes double as a post-mortem probe for tests asserting what a torn-down
+ * machine held. Every other operation is lifecycle-guarded like a real
+ * provider.
+ */
+export const inMemoryBoxFiles = (
+  contents: Map<string, Uint8Array>,
+  guard: (operation: string) => void = () => undefined,
+): SandboxMachine["files"] => ({
+  read: async (path: string): Promise<Uint8Array> => {
+    const bytes = contents.get(path);
+    if (bytes === undefined) throw new Error(`Unknown fake sandbox file: ${path}`);
+    return bytes.slice();
+  },
+  write: async (path: string, bytes: Uint8Array | string): Promise<void> => {
+    guard("write a file");
+    contents.set(path, typeof bytes === "string" ? textEncoder.encode(bytes) : bytes.slice());
+  },
+  list: async (dir: string): Promise<string[]> => {
+    guard("list files");
+    const prefix = dir === "" || dir === "/" ? "" : `${dir.replace(/\/$/, "")}/`;
+    const names = [...new Set(
+      [...contents.keys()]
+        .filter((path) => path.startsWith(prefix))
+        .map((path) => path.slice(prefix.length).split("/")[0])
+        .filter((name): name is string => name !== undefined && name !== ""),
+    )].sort();
+    // A flat map cannot hold an EMPTY directory, so "nothing under this
+    // prefix" is exactly "no such directory" — and the seam says that
+    // rejects, like a real provider's lstat does.
+    if (names.length === 0 && prefix !== "") {
+      throw new Error(`Unknown fake sandbox directory: ${dir}`);
+    }
+    return names;
+  },
+});

--- a/packages/apps/src/testing/box-files.ts
+++ b/packages/apps/src/testing/box-files.ts
@@ -28,7 +28,13 @@ export const inMemoryBoxFiles = (
   },
   list: async (dir: string): Promise<string[]> => {
     guard("list files");
-    const prefix = dir === "" || dir === "/" ? "" : `${dir.replace(/\/$/, "")}/`;
+    // Box paths are ABSOLUTE, so the root's prefix is "/" — not "". An empty
+    // prefix slices nothing off, leaving `/app/a.txt`.split("/")[0] === "",
+    // which the empty-name filter below then drops: the root of a box full of
+    // files listed as empty. Both spellings of root collapse onto this one
+    // branch, so they cannot answer differently.
+    const root = dir === "" || dir === "/";
+    const prefix = root ? "/" : `${dir.replace(/\/$/, "")}/`;
     const names = [...new Set(
       [...contents.keys()]
         .filter((path) => path.startsWith(prefix))
@@ -37,8 +43,9 @@ export const inMemoryBoxFiles = (
     )].sort();
     // A flat map cannot hold an EMPTY directory, so "nothing under this
     // prefix" is exactly "no such directory" — and the seam says that
-    // rejects, like a real provider's lstat does.
-    if (names.length === 0 && prefix !== "") {
+    // rejects, like a real provider's lstat does. The ROOT is the exception:
+    // it exists on every box, with files or without.
+    if (names.length === 0 && !root) {
       throw new Error(`Unknown fake sandbox directory: ${dir}`);
     }
     return names;

--- a/packages/apps/src/testing/fake-box.ts
+++ b/packages/apps/src/testing/fake-box.ts
@@ -1,6 +1,7 @@
 import type { SandboxAdapter, SandboxMachine } from "../sandbox.js";
 import type { BoxEditResult } from "../box-agent.js";
 import { BOX_CONTROL_PORT } from "../box-agent.js";
+import { inMemoryBoxFiles } from "./box-files.js";
 
 /**
  * execution-v2 Wave 3 test substrate — a fake sandbox that models a REAL v2
@@ -27,6 +28,9 @@ export interface FakeBoxState {
    * (path → HTML body). When present, the box "serves a real web app".
    */
   pages: Map<string, string>;
+  /** The box's disk, as the seam's `files` reads and writes it — the app's
+   *  SOURCE, distinct from the pages the box serves. */
+  files: Map<string, Uint8Array>;
 }
 
 /** The injectable in-box coding agent: mutates box state, returns a result. */
@@ -42,6 +46,7 @@ interface BoxSnapshot {
   manifest: FakeBoxState["manifest"];
   fns: Map<string, (args: unknown, env: Record<string, string>) => unknown>;
   pages: Map<string, string>;
+  files: Map<string, Uint8Array>;
   allowedDomains?: readonly string[];
 }
 
@@ -65,11 +70,16 @@ class FakeBoxMachine implements SandboxMachine {
   /** Task results by id (control-port task store). */
   private readonly tasks = new Map<string, { status: "running" | "done"; result?: BoxEditResult }>();
 
+  /** The seam's file operations (sandbox.ts), over the box's own disk. */
+  readonly files: SandboxMachine["files"];
+
   constructor(
     readonly state: FakeBoxState,
     readonly allowedDomains: readonly string[] | undefined,
     private readonly agent: FakeBoxAgent,
-  ) {}
+  ) {
+    this.files = inMemoryBoxFiles(state.files);
+  }
 
   private appPort(): number {
     const port = Number(this.state.env.PORT ?? 8080);
@@ -184,6 +194,7 @@ class FakeBoxMachine implements SandboxMachine {
       manifest: structuredClone(this.state.manifest),
       fns: new Map(this.state.fns),
       pages: new Map(this.state.pages),
+      files: new Map([...this.state.files].map(([path, bytes]) => [path, bytes.slice()])),
       ...(this.allowedDomains === undefined ? {} : { allowedDomains: [...this.allowedDomains] }),
     });
     return ref;
@@ -208,7 +219,7 @@ export const fakeBoxSandbox = (options: FakeBoxOptions = {}): FakeBoxAdapter => 
     machines,
     async create(spec) {
       return make(
-        { env: { ...spec.env }, manifest: {}, fns: new Map(), pages: new Map() },
+        { env: { ...spec.env }, manifest: {}, fns: new Map(), pages: new Map(), files: new Map() },
         spec.allowedDomains,
       );
     },
@@ -216,7 +227,13 @@ export const fakeBoxSandbox = (options: FakeBoxOptions = {}): FakeBoxAdapter => 
       const snap = snapshots.get(snapshotRef);
       if (snap === undefined) throw new Error(`unknown fake-box snapshot: ${snapshotRef}`);
       return make(
-        { env: { ...snap.env }, manifest: structuredClone(snap.manifest), fns: new Map(snap.fns), pages: new Map(snap.pages) },
+        {
+          env: { ...snap.env },
+          manifest: structuredClone(snap.manifest),
+          fns: new Map(snap.fns),
+          pages: new Map(snap.pages),
+          files: new Map([...snap.files].map(([path, bytes]) => [path, bytes.slice()])),
+        },
         policy === undefined ? snap.allowedDomains : policy.allowedDomains,
       );
     },

--- a/packages/apps/src/testing/fake-sandbox-stateful.ts
+++ b/packages/apps/src/testing/fake-sandbox-stateful.ts
@@ -1,5 +1,6 @@
 import { VendoError } from "@vendoai/core";
 import type { SandboxAdapter, SandboxMachine } from "../sandbox.js";
+import { inMemoryBoxFiles } from "./box-files.js";
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
@@ -19,6 +20,7 @@ interface FakeStatefulSnapshot {
   allowedDomains?: readonly string[];
   template?: string;
   state: ReadonlyMap<string, string>;
+  files: ReadonlyMap<string, Uint8Array>;
 }
 
 /**
@@ -35,6 +37,10 @@ export class FakeStatefulMachine implements SandboxMachine {
   reaped = false;
   readonly env: Readonly<Record<string, string>>;
   readonly state: Map<string, string>;
+  /** The box's disk, beside its key-value state: a snapshot/resume cycle
+   *  carries both, so a lifecycle test can prove the app's SOURCE survived. */
+  readonly fileContents: Map<string, Uint8Array>;
+  readonly files: SandboxMachine["files"];
 
   constructor(
     readonly id: string,
@@ -42,10 +48,13 @@ export class FakeStatefulMachine implements SandboxMachine {
     readonly allowedDomains: readonly string[] | undefined,
     readonly template: string | undefined,
     state: ReadonlyMap<string, string>,
+    files: ReadonlyMap<string, Uint8Array>,
     private readonly saveSnapshot: (machine: FakeStatefulMachine) => string,
   ) {
     this.env = Object.freeze({ ...env });
     this.state = new Map(state);
+    this.fileContents = new Map([...files].map(([path, bytes]) => [path, bytes.slice()]));
+    this.files = inMemoryBoxFiles(this.fileContents);
   }
 
   async request(req: {
@@ -124,6 +133,7 @@ export const fakeStatefulSandbox = (): FakeStatefulSandbox => {
       ...(machine.allowedDomains === undefined ? {} : { allowedDomains: Object.freeze([...machine.allowedDomains]) }),
       ...(machine.template === undefined ? {} : { template: machine.template }),
       state: new Map(machine.state),
+      files: new Map([...machine.fileContents].map(([path, bytes]) => [path, bytes.slice()])),
     }));
     return ref;
   };
@@ -133,6 +143,7 @@ export const fakeStatefulSandbox = (): FakeStatefulSandbox => {
     allowedDomains: readonly string[] | undefined,
     template: string | undefined,
     state: ReadonlyMap<string, string>,
+    files: ReadonlyMap<string, Uint8Array>,
   ): FakeStatefulMachine => {
     const machine = new FakeStatefulMachine(
       `fake-machine-${nextMachine++}`,
@@ -140,6 +151,7 @@ export const fakeStatefulSandbox = (): FakeStatefulSandbox => {
       allowedDomains === undefined ? undefined : Object.freeze([...allowedDomains]),
       template,
       state,
+      files,
       saveSnapshot,
     );
     machines.push(machine);
@@ -154,7 +166,7 @@ export const fakeStatefulSandbox = (): FakeStatefulSandbox => {
     resumes: 0,
     async create(spec) {
       adapter.creates += 1;
-      return boot(spec.env, spec.allowedDomains, spec.template, new Map());
+      return boot(spec.env, spec.allowedDomains, spec.template, new Map(), new Map());
     },
     async resume(snapshotRef, policy) {
       adapter.resumes += 1;
@@ -162,7 +174,7 @@ export const fakeStatefulSandbox = (): FakeStatefulSandbox => {
       if (snapshot === undefined) throw new Error(`unknown fake stateful snapshot: ${snapshotRef}`);
       // Lane E — a passed policy replaces the snapshot-time allowlist (seam rule).
       const allowedDomains = policy === undefined ? snapshot.allowedDomains : policy.allowedDomains;
-      return boot({ ...snapshot.env }, allowedDomains, snapshot.template, snapshot.state);
+      return boot({ ...snapshot.env }, allowedDomains, snapshot.template, snapshot.state, snapshot.files);
     },
     async destroy(snapshotRef) {
       destroyed.push(snapshotRef);

--- a/packages/apps/src/testing/fake-sandbox.ts
+++ b/packages/apps/src/testing/fake-sandbox.ts
@@ -1,4 +1,5 @@
 import type { SandboxAdapter, SandboxMachine } from "../sandbox.js";
+import { inMemoryBoxFiles } from "./box-files.js";
 
 export interface MachineRequest {
   method: string;
@@ -132,6 +133,9 @@ export class FakeSandboxMachine implements SandboxMachine {
   readonly commands: FakeExecCall[] = [];
   readonly execResults: FakeExecResult[] = [];
   readonly fileContents: Map<string, Uint8Array>;
+  /** The seam's file operations (sandbox.ts), over this machine's contents.
+   *  Exec/screenshot/url/request/snapshot are lifecycle-guarded separately. */
+  readonly files: SandboxMachine["files"];
   readonly env: Record<string, string>;
   readonly port: number;
   /** v2 sleep flag; also true once destroyed. Writable for test scripting. */
@@ -152,6 +156,7 @@ export class FakeSandboxMachine implements SandboxMachine {
     this.env = Object.freeze({ ...env });
     this.port = parsePort(this.env);
     this.fileContents = new Map([...files].map(([path, bytes]) => [path, bytes.slice()]));
+    this.files = inMemoryBoxFiles(this.fileContents, (operation) => this.ensureRunning(operation));
     this.app = app;
   }
 
@@ -163,32 +168,6 @@ export class FakeSandboxMachine implements SandboxMachine {
     if (this.destroyed) throw new Error(`Fake sandbox machine ${this.id} is destroyed; cannot ${operation}`);
     if (this.stopped) throw new Error(`Fake sandbox machine ${this.id} is stopped (asleep); cannot ${operation}`);
   }
-
-  readonly files = {
-    // Reads stay available after stop/destroy on purpose: the fake doubles as
-    // a post-mortem probe for tests asserting what a torn-down machine held.
-    // Every OPERATION (write/list/exec/screenshot/url/request/snapshot) is
-    // lifecycle-guarded like a real provider.
-    read: async (path: string): Promise<Uint8Array> => {
-      const bytes = this.fileContents.get(path);
-      if (bytes === undefined) throw new Error(`Unknown fake sandbox file: ${path}`);
-      return bytes.slice();
-    },
-    write: async (path: string, bytes: Uint8Array | string): Promise<void> => {
-      this.ensureRunning("write a file");
-      this.fileContents.set(path, toBytes(bytes));
-    },
-    list: async (dir: string): Promise<string[]> => {
-      this.ensureRunning("list files");
-      const prefix = dir === "" || dir === "/" ? "" : `${dir.replace(/\/$/, "")}/`;
-      return [...new Set(
-        [...this.fileContents.keys()]
-          .filter((path) => path.startsWith(prefix))
-          .map((path) => path.slice(prefix.length).split("/")[0])
-          .filter((name): name is string => name !== undefined && name !== ""),
-      )].sort();
-    },
-  };
 
   async request(request: MachineRequest): Promise<{ status: number; headers: Record<string, string>; body: Uint8Array }> {
     this.ensureRunning("serve a request");

--- a/packages/apps/src/testing/index.ts
+++ b/packages/apps/src/testing/index.ts
@@ -1,3 +1,4 @@
+export * from "./box-files.js";
 export * from "./fake-sandbox.js";
 export * from "./fake-sandbox-stateful.js";
 export * from "./fake-box.js";

--- a/packages/harnesses/src/claude-code/box.ts
+++ b/packages/harnesses/src/claude-code/box.ts
@@ -52,6 +52,14 @@ export interface SandboxMachineLike {
   id: string;
   request(req: { method: string; path: string; port?: number; headers?: Record<string, string>; body?: Uint8Array | string }):
     Promise<{ status: number; headers: Record<string, string>; body: Uint8Array }>;
+  /** The box's filesystem, as `SandboxMachine.files` defines it: read rejects
+   *  for a path the box does not hold, write replaces whole, list is one level
+   *  and names only. */
+  files: {
+    read(path: string): Promise<Uint8Array>;
+    write(path: string, bytes: Uint8Array | string): Promise<void>;
+    list(dir: string): Promise<string[]>;
+  };
   destroy(): Promise<void>;
 }
 

--- a/packages/vendo/src/sandbox.live.test.ts
+++ b/packages/vendo/src/sandbox.live.test.ts
@@ -63,14 +63,13 @@ http.createServer((request, response) => {
 }).listen(Number(process.env.PORT || 8080));
 `;
 
-/** Install and start the conformance app through the ADAPTER-PRIVATE surface
-    (in production the in-box agent owns the inside of the box). */
+/** Install the conformance app through the seam's `files`, and start it through
+    the ADAPTER-PRIVATE exec (in production the in-box agent starts the app). */
 const bootstrap = async (machine: SandboxMachine): Promise<void> => {
   const box = machine as unknown as {
     exec(cmd: string, opts?: { cwd?: string; timeoutMs?: number }): Promise<{ code: number; stdout: string; stderr: string }>;
-    files: { write(path: string, bytes: Uint8Array | string): Promise<void> };
   };
-  await box.files.write("/app/server.js", CONFORMANCE_SERVER_SOURCE);
+  await machine.files.write("/app/server.js", CONFORMANCE_SERVER_SOURCE);
   const started = await box.exec(
     [
       "i=0",

--- a/packages/vendo/src/sandbox.test.ts
+++ b/packages/vendo/src/sandbox.test.ts
@@ -660,17 +660,13 @@ describe("cloudSandbox", () => {
       .rejects.toMatchObject({ code: "sandbox-unavailable", message: expect.stringContaining("502") });
   });
 
-  it("keeps the adapter-private exec/files bootstrap surface on the console wire", async () => {
-    // NOT part of the public seam — the in-box agent owns the inside of the
-    // box; the live conformance lane uses these to install its test app.
+  it("puts the seam's files and the adapter-private exec on the console wire", async () => {
+    // `files` is the public seam (apps/sandbox.ts); `exec` is NOT — the in-box
+    // agent owns the inside of the box, and the live conformance lane uses
+    // exec only to start its test app.
     const console_ = fakeConsole();
     const machine = await adapterFor(console_).create({ env: {} }) as SandboxMachine & {
       exec(cmd: string, opts?: { cwd?: string; timeoutMs?: number }): Promise<{ code: number; stdout: string; stderr: string }>;
-      files: {
-        read(path: string): Promise<Uint8Array>;
-        write(path: string, bytes: Uint8Array | string): Promise<void>;
-        list(dir: string): Promise<string[]>;
-      };
     };
     expect(await machine.exec("pwd", { cwd: "/app", timeoutMs: 9_000 })).toMatchObject({ code: 0 });
     expect(console_.requests.at(-1)).toMatchObject({

--- a/packages/vendo/src/sandbox.test.ts
+++ b/packages/vendo/src/sandbox.test.ts
@@ -198,10 +198,14 @@ function fakeConsole(options: { mintUrl?: (id: string) => string } = {}) {
         machine.files.set(url.searchParams.get("path") ?? "", recorded.bytes ?? new Uint8Array());
         return json({ ok: true });
       case "GET /files/list": {
+        // `${dir}/` assumed dir never ends in one, so the root asked for "//"
+        // and matched nothing — a mock arithmetic bug, not console semantics:
+        // no filesystem or route treats "//" as the root.
         const dir = url.searchParams.get("dir") ?? "";
+        const inside = dir.endsWith("/") ? dir : `${dir}/`;
         const entries = [...machine.files.keys()]
-          .filter((filePath) => filePath.startsWith(`${dir}/`))
-          .map((filePath) => filePath.slice(dir.length + 1));
+          .filter((filePath) => filePath.startsWith(inside))
+          .map((filePath) => filePath.slice(inside.length));
         return json({ entries });
       }
       default:

--- a/packages/vendo/src/sandbox.ts
+++ b/packages/vendo/src/sandbox.ts
@@ -157,9 +157,11 @@ const isGone = (error: unknown): boolean =>
  * - `spec.template` is dropped from the wire: the create route takes none —
  *   the pooled base image (Node + the in-box agent) is Cloud's own.
  *
- * The machine object also carries adapter-private exec/files/url used for
- * live-lane bootstrap and diagnostics — NOT part of the public seam (the
- * in-box agent owns the inside of the box). */
+ * `files` is part of the public seam (apps/sandbox.ts), and the console's
+ * list route may answer any depth — the adapter folds it to the seam's one
+ * level. The machine object also carries adapter-private exec used for
+ * live-lane bootstrap and diagnostics — NOT part of the seam (the in-box agent
+ * owns the inside of the box). */
 export function cloudSandbox(options: CloudSandboxOptions): SandboxAdapter {
   const base = (options.baseUrl ?? "https://console.vendo.run").replace(/\/$/, "");
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
@@ -306,22 +308,6 @@ export function cloudSandbox(options: CloudSandboxOptions): SandboxAdapter {
           .then(remove);
         await destroying;
       },
-      // ——— adapter-private below this line (live-lane bootstrap + diagnostics) ———
-      async exec(cmd: string, execOptions?: { cwd?: string; timeoutMs?: number }) {
-        const payload = await sendJson(`${prefix}/exec`, "POST", {
-          cmd,
-          ...(execOptions?.cwd === undefined ? {} : { cwd: execOptions.cwd }),
-          ...(execOptions?.timeoutMs === undefined ? {} : { timeout_ms: execOptions.timeoutMs }),
-        }) as { code?: unknown; stdout?: unknown; stderr?: unknown };
-        if (typeof payload.code !== "number") {
-          throw new VendoError("sandbox-unavailable", "Vendo Cloud sandbox returned an invalid exec response");
-        }
-        return {
-          code: payload.code,
-          stdout: typeof payload.stdout === "string" ? payload.stdout : "",
-          stderr: typeof payload.stderr === "string" ? payload.stderr : "",
-        };
-      },
       files: {
         async read(path: string) {
           const response = await send(`${prefix}/files?path=${encodeURIComponent(path)}`);
@@ -336,9 +322,28 @@ export function cloudSandbox(options: CloudSandboxOptions): SandboxAdapter {
         },
         async list(dir: string) {
           const payload = await sendJson(`${prefix}/files/list?dir=${encodeURIComponent(dir)}`, "GET") as { entries?: unknown };
-          return Array.isArray(payload.entries)
+          const entries = Array.isArray(payload.entries)
             ? payload.entries.filter((entry): entry is string => typeof entry === "string")
             : [];
+          // The seam's list is ONE level and names only; the console answers
+          // whatever depth it answers, so fold the depth away here — strip the
+          // listed directory back off an absolute answer, keep the first
+          // segment, and a deep answer collapses onto its top-level names.
+          const inside = dir.endsWith("/") ? dir : `${dir}/`;
+          const names = [...new Set(entries.map((entry) => {
+            const relative = entry.startsWith(inside) ? entry.slice(inside.length) : entry;
+            return relative.split("/")[0] ?? "";
+          }).filter((name) => name !== ""))];
+          // The seam rejects for a directory the box does not hold. The console
+          // route answers an empty list for BOTH an absent directory and an
+          // empty one, so this reports the absent case — loud in the safe
+          // direction, where answering `[]` would let a mistyped source
+          // directory read as an app with no files. Narrows to the real
+          // not-found when the console's list route grows one.
+          if (names.length === 0) {
+            throw new VendoError("not-found", `Vendo Cloud sandbox holds no directory ${dir}`);
+          }
+          return names;
         },
       },
       async url(port?: number) {
@@ -358,6 +363,22 @@ export function cloudSandbox(options: CloudSandboxOptions): SandboxAdapter {
           ? `${target}-${ingress.host}`
           : `${suffixed[1]}-${target}-m${suffixed[2]}`;
         return ingress.origin;
+      },
+      // ——— adapter-private below this line (live-lane bootstrap + diagnostics) ———
+      async exec(cmd: string, execOptions?: { cwd?: string; timeoutMs?: number }) {
+        const payload = await sendJson(`${prefix}/exec`, "POST", {
+          cmd,
+          ...(execOptions?.cwd === undefined ? {} : { cwd: execOptions.cwd }),
+          ...(execOptions?.timeoutMs === undefined ? {} : { timeout_ms: execOptions.timeoutMs }),
+        }) as { code?: unknown; stdout?: unknown; stderr?: unknown };
+        if (typeof payload.code !== "number") {
+          throw new VendoError("sandbox-unavailable", "Vendo Cloud sandbox returned an invalid exec response");
+        }
+        return {
+          code: payload.code,
+          stdout: typeof payload.stdout === "string" ? payload.stdout : "",
+          stderr: typeof payload.stderr === "string" ? payload.stderr : "",
+        };
       },
     } satisfies SandboxMachine & Record<string, unknown> as SandboxMachine;
   };

--- a/packages/vendo/src/sandbox.ts
+++ b/packages/vendo/src/sandbox.ts
@@ -339,8 +339,9 @@ export function cloudSandbox(options: CloudSandboxOptions): SandboxAdapter {
           // empty one, so this reports the absent case — loud in the safe
           // direction, where answering `[]` would let a mistyped source
           // directory read as an app with no files. Narrows to the real
-          // not-found when the console's list route grows one.
-          if (names.length === 0) {
+          // not-found when the console's list route grows one. The ROOT is the
+          // exception: it exists on every box, with files or without.
+          if (names.length === 0 && dir !== "" && dir !== "/") {
             throw new VendoError("not-found", `Vendo Cloud sandbox holds no directory ${dir}`);
           }
           return names;


### PR DESCRIPTION
## Why

Reading a file off a sandbox was **adapter-private**. Three implementations
existed with an identical shape, hidden behind
`satisfies SandboxMachine & Record<string, unknown> as SandboxMachine` casts,
and two test doubles had no `files` at all — five private spellings (or
absences) of one contract, sitting on the seam a built app's SOURCE has to
cross on its way out of the box.

Blueprint §3.2 + §12.2, risk §16.4. §16.4's rule is that partial promotion is
two ways to read a file, so all of it lands here in one change with the
conformance suite extended in the same commit.

## What the interface now says

`SandboxMachine.files` — `read`, `write`, `list` — is declared in
`packages/apps/src/sandbox.ts`. The signature is the one all three real
adapters already had; nothing was invented. The documented answers:

- `read` REJECTS for a path the box does not hold — never empty bytes, because
  a silently empty source file is a lost app.
- `read` hands bytes back UNCHANGED: no text decode, no BOM strip, no
  line-ending normalization. Box content is untrusted, and the layer above can
  only verify it against the hash in the app's row if these bytes are those
  bytes.
- `write` creates or replaces the whole file and creates the directories on the
  way to it. It never appends.
- `list` is ONE level and names only, and rejects for a directory the box does
  not hold — same rule as `read`.

## Two real disagreements the promotion exposed

Both were invisible while `files` was private, and both are now pinned by the
shared conformance suite:

1. **The Vendo Cloud list route answers deeper than one level.** With the
   adapter's depth fold reverted, the mock-console conformance leg fails with
   `expected [ 'nested/two.bin', 'one.txt' ] to deeply equal [ 'nested', 'one.txt' ]`.
   The fold is load-bearing, not decoration.
2. **A missing directory rejected on real e2b** (`[not_found] path not found:
   lstat /tmp/vendo-conformance-files/nope`) **while both in-memory fakes
   answered `[]`.** `[]` is how a mistyped source directory reads as "this app
   has no files". The seam now rejects everywhere: the fakes reject (a flat map
   cannot hold an empty directory, so "nothing under this prefix" IS "no such
   directory"), and the Cloud adapter rejects when the console answers no
   entries — loud in the safe direction, with the console's inability to
   distinguish absent from empty recorded at the call site.

## Hostile cases: what is pinned here and what belongs a layer up

Box content is untrusted data — a compromised or merely buggy in-box agent
controls every path and every byte crossing this seam. Pinned in the
conformance leg:

- **Byte fidelity.** The round-trip payload is deliberately hostile: a NUL, a
  CRLF, a bare CR, and three sequences that are not valid UTF-8. Verified
  byte-for-byte through a real e2b box.
- **Entries that look like paths.** `list` returns names only — proven by the
  reverted-fold red above, which is exactly a provider answering a path where a
  name belongs. (A POSIX filename cannot itself contain `/`.)
- **Absent paths and absent directories.** Both reject.

Deliberately NOT pinned here, with reasoning:

- **Paths escaping the app directory (`../`, absolute paths outside it).** This
  seam is the box's whole filesystem, not a partition of it: the bootstrap
  legitimately writes `/app/server.js` and `/tmp/vendo-conformance.pid`.
  Confinement already lives one layer up, at the layer that decides which paths
  may become an app's source — `app-source.ts:97-106` refuses an absolute key
  or any `.`/`..`/empty segment, with the comment "Refused here rather than at
  write time because a `../` key is a checkout escape". Adding a second copy
  down here would be §0's second door for one rule, and would break the
  bootstrap.
- **Bytes that disagree with a caller's metadata.** This seam carries no
  metadata — no hash, no length. The comparison is P0's fail-closed gate at
  `app-source.ts:175,182` ("refusing to check out content that is not the
  content stored"). What this layer owes that gate is bytes it did not touch,
  which is now the pinned byte-fidelity case above.

## §0: what was consolidated or removed

Total concept count goes down.

- Two redundant `files` casts on the real adapters (`files` moved above the
  adapter-private line in both).
- The `files`-shaped half of the Cloud wire test's private-surface cast.
- The `files` cast in three live bootstraps (`e2b.live`, `secrets-egress.live`,
  `sandbox.live`) — they now call `machine.files.write` directly.
- **Three copies of the fakes' in-memory file semantics collapsed into one**
  `inMemoryBoxFiles` (`packages/apps/src/testing/box-files.ts`), shared by
  `fake-sandbox`, `fake-sandbox-stateful` and `fake-box`. The two fakes that had
  no `files` at all now get the same one, so they cannot drift.
- `packages/vendo/src/sandbox.ts`: the public `url()` moved ABOVE the
  adapter-private line, where it always belonged.

**The `satisfies … Record<string, unknown> as SandboxMachine` cast still stands
at `e2b/index.ts` and `vendo/sandbox.ts` — deliberately.** It now carries only
`exec`, which stays adapter-private and out of scope. Removing it would force
`exec` onto the public seam, the opposite of the brief.

`SandboxMachineLike` in `@vendoai/harnesses/claude-code` carries `files` and is
still a structural subset, so the subpath's type surface did not widen.

## §0 receipt: the consolidation caught its own bug, once instead of five times

A review found a real defect in `inMemoryBoxFiles.list`: it treated the root's
prefix as `""` instead of `"/"`, so it sliced nothing off an absolute stored path,
`"/app/a.txt".split("/")[0]` came back `""`, and the empty-name filter dropped it.
**`list("/")` answered `[]` on a box that demonstrably held files** — a root
listing claiming an empty box, which on this seam means "this app's source has no
files". Exactly the silent-wrong-answer class this project keeps closing, and it
was pre-existing: `fake-sandbox.ts` shipped that identical line before this PR.

**It was one fix in one file.** Before the `inMemoryBoxFiles` consolidation in
this same PR, that line lived in every fake that had a `list`, and this finding
would have been five separate fixes in five separate files — with five chances to
fix four of them. The conformance suite now pins the root case for every
implementation at once. That is the measurable payoff of "reuse, never duplicate":
the consolidation is not overhead attached to the feature, it is what made the
next bug cheap.

Checked rather than assumed: `e2b`'s `list` is pure delegation to
`sandbox.files.list(dir).map(entry => entry.name)` with no prefix arithmetic, so
it was structurally immune. The Cloud adapter's depth fold handles the root
correctly but its not-found throw lacked a root exemption — fixed. The mock
console's route built `"//"` for `dir=/` and matched nothing; that is the mock's
own path arithmetic, not console semantics (no filesystem or route treats `"//"`
as root), so fixing it removes an artifact rather than shaping the counterparty
to fit an assertion.

## Verification

**The root-listing fix in commit 2 is WRITTEN BUT NOT YET RUN.** Fleet load
policy has test execution queued behind a shared verification slot, so the
red/green evidence for the new root leg does not exist yet and is not claimed
here. Everything below describes the first commit, which was fully verified.

TDD: the conformance expectations went in first and could not compile against
the un-promoted interface (`error TS2339: Property 'files' does not exist on
type 'SandboxMachine'`, five sites). Three deliberate breaks, each seen red and
restored:

| Break | Red |
|---|---|
| Cloud `list` returns the console's entries unfolded | `expected [ 'nested/two.bin', 'one.txt' ] to deeply equal [ 'nested', 'one.txt' ]` |
| `inMemoryBoxFiles.read` answers empty bytes for a missing path | `promise resolved "Uint8Array[]" instead of rejecting` |
| `inMemoryBoxFiles.list` answers `[]` for a missing directory | `promise resolved "[]" instead of rejecting` |

**Live e2b: green.** The file-seam conformance leg ran against a real E2B
sandbox (`E2B_API_KEY` from Infisical, piped straight in) — 1 passed. That is
what settled the missing-directory question.

**Live Vendo Cloud: could not run, and this is not green.** The console refuses
the prod `VENDO_API_KEY` with `VendoError: Invalid API key.` at `create()`
(`adapter-conformance.ts:249`), before any `files` call, so it says nothing
about the file seam. External credential state, not this change; not chased
further, because hunting a working production credential through the secret
store is the 2026-07-28 exposure pattern. Cloud file-seam coverage therefore
rests on the mock-console lane over the real adapter wire, which the reverted
fold proves is a genuine test.

Tests were run FILE-SCOPED and capped both ways
(`VITEST_MIN_FORKS/MAX_FORKS=1/2`, `VITEST_MIN_THREADS/MAX_THREADS=1/2`,
`--minWorkers=1 --maxWorkers=2`), never `pnpm test`:

- `@vendoai/apps` — 17 files, 249 passed (conformance, fixtures,
  machine-lifecycle, machine-runtime, box-agent, box-turn-routes, e2b,
  egress-failopen, egress-flow, grant-env-reinjection, redaction, schedules,
  secrets-injection, served-apps, served-orgs, access, building-apps)
- `@vendoai/vendo` — `sandbox.test.ts` + `app-source.e2e.test.ts`, 33 passed
- `@vendoai/harnesses` — `materialize.test.ts` + `claude-code.test.ts`, 85 passed
- `@vendoai-fixtures/integration` — `machine-skin.e2e.test.ts`, 1 passed

Package-scoped `build` and `typecheck` green for `@vendoai/apps`,
`@vendoai/vendo`, `@vendoai/harnesses` (exit 0 each). `dependency-guard` OK (15
packages) and `portability-gate` all legs green. **The full suite and full build
are the coordinator's gate at the merge boundary, not run here** — per fleet
policy, four parallel builders running root builds is what spiked this box.

## TEST EDITS

Stated separately, as they are their own change:

- `packages/apps/src/adapter-conformance.ts` — the new conformance leg (this is
  the point of the PR, not incidental).
- `packages/apps/src/e2b/e2b.live.test.ts`,
  `packages/apps/src/e2b/secrets-egress.live.test.ts`,
  `packages/vendo/src/sandbox.live.test.ts` — bootstrap now calls
  `machine.files.write` through the public seam; the private cast shrank to
  `exec` only.
- `packages/vendo/src/sandbox.test.ts` — the private-surface wire test keeps all
  its wire assertions; its title and cast now say `files` is public and only
  `exec` is private.
- `fixtures/integration/src/machine-skin.e2e.test.ts` — its inline
  `SandboxMachine` double gained a `files` member that throws, because that
  journey is the fn/callback boundary and never the box's disk. This is the one
  test file the promotion actually broke at typecheck.

Not touched, deliberately: ~10 other test files hold inline
`const machine: SandboxMachine = {…}` literals with no `files`. Every package's
`tsconfig.json` excludes `src/**/*.test.ts`, so they are never typechecked and
nothing under test calls `.files` on them. Editing ten files for no verification
gain is churn.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promoted sandbox file I/O to the public seam via `SandboxMachine.files` (read/write/list) and added a shared conformance test to keep all providers in sync. This removes duplicate adapter logic, enforces byte-fidelity, and standardizes list semantics.

- **New Features**
  - Declared `files` on `SandboxMachine` in `@vendoai/apps` with clear rules: read rejects missing paths, write replaces whole files, list is one-level names only.
  - Added a conformance leg that verifies byte-for-byte reads (including invalid UTF-8) and list behavior; verified against real e2b.
  - Introduced `inMemoryBoxFiles` for all fakes to share identical semantics; `machine-lifecycle` now exposes `files`; adapters implement `files` and bootstraps write via `machine.files`.

- **Bug Fixes**
  - Cloud adapter now folds deep list responses to one-level names to match the seam.
  - Listing a missing directory now rejects across providers and fakes (no empty array on absent dirs).
  - Listing the root (`"/"`) now returns top-level names instead of empty: fixed in in-memory fakes and the Vendo console mock.

<sup>Written for commit 233aeb0dd018efb3e123f3b2d0cff59b788bb86f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

