### PR TITLE
fix(ui): the pin invites, lands somewhere real, and picks the app it claims to

### DIFF
--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -1562,6 +1562,29 @@ function SlotFallbackScenario() {
   );
 }
 
+/** §10.1 — the pin round trip, end to end, on a host with NO slot: the page's
+ *  Apps shelf is behind the assistant, a build settles in the conversation, its
+ *  pin invites (the nudge), and taking it dismisses the panel and lands the
+ *  ceremony in the shelf. The `onPin` write is the HOST's, so the recorder below
+ *  is the only honest proof that it fired. */
+function PinShelfScenario() {
+  const [pinned, setPinned] = useState<string[]>([]);
+  return (
+    <VendoProvider
+      client={baseClient}
+      components={components}
+      theme={mapleTheme}
+      onPin={app => setPinned(current => [...current, app.appId])}
+    >
+      <VendoPage />
+      <VendoOverlay />
+      <p data-testid="pin-recorder" style={{ position: "fixed", left: 10, bottom: 10, margin: 0, fontSize: 11, color: "#8a8b92" }}>
+        pinned: {pinned.length === 0 ? "none" : pinned.join(",")}
+      </p>
+    </VendoProvider>
+  );
+}
+
 /** A stored tree rendered beside the freshly compiled wire (v1 is gone;
  *  stored documents all carry the current format). */
 const storedTree: UIPayload = {
@@ -2245,6 +2268,7 @@ function scenario(pathname: string): { title: string; theme?: Partial<VendoTheme
     case "/slot-empty-dark": return { title: "Inline slot — empty CTA (dark)", theme: darkTheme, content: <><VendoSlot id="hero" /><VendoPalette /><VendoOverlay launcher="none" /></> };
     case "/slot-pinned": return { title: "Inline slot — pinned component", theme: mapleTheme, content: <VendoSlot id="hero" pin={{ payload: pinnedViewTree }}><section aria-label="Original host component"><h2>Original host hero</h2></section></VendoSlot> };
     case "/slot-fallback": return { title: "Slot pin fallback", content: <SlotFallbackScenario />, ownProvider: true };
+    case "/pin-shelf": return { title: "Pin — nudge, ceremony, Apps shelf", content: <PinShelfScenario />, ownProvider: true };
     case "/appframe": return { title: "App execution planes", content: <AppFrameScenario /> };
     case "/appframe-resize": return { title: "App frame resize — the host's bounds win", content: <AppFrameResizeScenario /> };
     case "/appframe-devserver": return { title: "Live dev-server preview (HMR)", content: <DevServerPreviewScenario /> };

--- a/packages/ui/e2e/pin-nudge.spec.ts
+++ b/packages/ui/e2e/pin-nudge.spec.ts
@@ -9,7 +9,7 @@
  * the ask queue, and for the same reason: every spec in the run shares one wire
  * server, so a mutation left behind would leak into its neighbours.
  */
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 import { openScenario, screenshotPath } from "./helpers.js";
 
 /** The scripted multi-tool + build turn (`[smoke-build]` in the wire fixture). */
@@ -50,6 +50,30 @@ async function hostPinWrite(page: Page): Promise<() => void> {
   };
 }
 
+/** Park the nudge on the keyframe at `ms`, or `null` to let it run again.
+ *  Photography only — it changes no declared timing, and it seeks the animation
+ *  itself: pausing and then rewriting `animation-delay` does NOT re-seek in
+ *  Chromium, which silently photographed the same resting frame twice. */
+async function freezeAt(target: Locator, ms: number | null): Promise<void> {
+  await target.evaluate((node, at) => {
+    const nudge = node.getAnimations().find(item => (item as CSSAnimation).animationName === "fl-pin-nudge");
+    if (nudge === undefined) throw new Error("the pin nudge is not animating");
+    if (at === null) return nudge.play();
+    nudge.pause();
+    nudge.currentTime = at;
+  }, ms);
+}
+
+/** The affordance itself, with room around it: the nudge is a ring OUTSIDE the
+ *  button's box, so a tight crop would cut off the thing being photographed. */
+async function closeUp(page: Page, target: Locator, name: string): Promise<void> {
+  const box = (await target.boundingBox())!;
+  await page.screenshot({
+    path: screenshotPath(name),
+    clip: { x: box.x - 24, y: box.y - 24, width: box.width + 48, height: box.height + 48 },
+  });
+}
+
 /** Chromium's animation clock, slowed so a 300ms flight and a 180ms ring can be
  *  photographed. The ceremony's own timings are untouched. */
 async function slowMotion(page: Page): Promise<void> {
@@ -85,6 +109,26 @@ test("a settled build invites the pin, and the pin lands in the Apps shelf", asy
   await expect(pin).toHaveAttribute("data-vendo-pin", "invite");
   await expect(pin).toHaveCSS("animation-iteration-count", /infinite/);
   await page.screenshot({ path: screenshotPath("pin-nudge-invite") });
+  // A still cannot show a pulse, so photograph both ENDS of the cycle — rest,
+  // then the 45% peak. This proves the ring's shape; the assertion above proves
+  // it is actually running.
+  await freezeAt(pin, 0);
+  await closeUp(page, pin, "pin-nudge-invite-rest");
+  const rest = await pin.evaluate(node => getComputedStyle(node).boxShadow);
+  await freezeAt(pin, 1_080);
+  await closeUp(page, pin, "pin-nudge-invite-peak");
+  const peak = await pin.evaluate(node => getComputedStyle(node).boxShadow);
+  // …and one frame per 200ms of the cycle, which assembles into the loop a
+  // person actually sees (a still can only ever show one instant of it).
+  for (let at = 0; at < 2_400; at += 200) {
+    await freezeAt(pin, at);
+    await closeUp(page, pin, `frames/pin-nudge-frame-${String(at).padStart(4, "0")}`);
+  }
+  // The ring really does open and close — a flat keyframe would photograph the
+  // same at both ends, and the two stills above could not tell you.
+  expect(peak, `rest ${rest} → peak ${peak}`).not.toBe(rest);
+  expect(peak).toMatch(/5px/);
+  await freezeAt(pin, null);
 
   // Taking it: the panel goes first, then the ghost flies to the shelf and the
   // shelf takes the settle ring. No slot is mounted anywhere on this page — that
@@ -128,5 +172,8 @@ test("the invitation resolves once the pin is taken, on whichever surface shows 
     .getByRole("button", { name: "Pin to dashboard" });
   await expect(settled).toHaveAttribute("data-vendo-pin", "pinned");
   await expect(settled).toHaveCSS("animation-iteration-count", /^(?!.*infinite).*$/);
-  await page.screenshot({ path: screenshotPath("pin-settled") });
+  // `animations: "disabled"` finishes the panel's entrance first — without it the
+  // shot lands mid-open and photographs a half-transparent dialog.
+  await page.screenshot({ path: screenshotPath("pin-settled"), animations: "disabled" });
+  await closeUp(page, settled, "pin-settled-bar");
 });

--- a/packages/ui/e2e/pin-nudge.spec.ts
+++ b/packages/ui/e2e/pin-nudge.spec.ts
@@ -16,6 +16,24 @@ import { openScenario, screenshotPath } from "./helpers.js";
 const BUILD_TURN = "[smoke-build] a board showing where my money goes";
 const BUILT_APP = "app_smoke";
 
+/** The view the pinned app renders — in the thread's card and, once pinned, in
+ *  its shelf tile. */
+const BUILT_VIEW = {
+  formatVersion: "vendo-genui/v2",
+  root: "root",
+  nodes: [{ id: "root", component: "Text", props: { text: "$1,240 this month across 4 categories." } }],
+};
+
+/** The record the real runtime would have persisted for the build, placed. */
+const BUILT_APP_DOC = {
+  format: "vendo/app@1",
+  id: BUILT_APP,
+  name: "Where my money goes",
+  ui: "tree",
+  tree: BUILT_VIEW,
+  placements: ["hero"],
+};
+
 /**
  * The HOST's half of a pin: its own API writes the placement, and the shelf then
  * reads the app back over the wire. `vendo_make`'s fixture turn streams the view
@@ -28,22 +46,16 @@ async function hostPinWrite(page: Page): Promise<() => void> {
     if (route.request().method() !== "GET") return await route.fallback();
     const response = await route.fetch();
     const apps = (await response.json()) as unknown[];
-    await route.fulfill({
-      json: placed
-        ? [{
-          format: "vendo/app@1",
-          id: BUILT_APP,
-          name: "Where my money goes",
-          ui: "tree",
-          tree: {
-            formatVersion: "vendo-genui/v2",
-            root: "root",
-            nodes: [{ id: "root", component: "Text", props: { text: "$1,240 this month across 4 categories." } }],
-          },
-          placements: ["hero"],
-        }, ...apps]
-        : apps,
-    });
+    await route.fulfill({ json: placed ? [BUILT_APP_DOC, ...apps] : apps });
+  });
+  // A shelf tile renders the app's OWN view, and `useApp` fetches the document
+  // and the surface TOGETHER — stubbing only the list left a real tile reading
+  // "This didn't load.", which is a fixture gap, not a product state.
+  await page.route(`**/api/vendo/apps/${BUILT_APP}`, async (route) => {
+    await route.fulfill({ json: BUILT_APP_DOC });
+  });
+  await page.route(`**/api/vendo/apps/${BUILT_APP}/open*`, async (route) => {
+    await route.fulfill({ json: { kind: "tree", payload: BUILT_VIEW } });
   });
   return () => {
     placed = true;
@@ -142,6 +154,15 @@ test("a settled build invites the pin, and the pin lands in the Apps shelf", asy
   for (const side of ["x", "y", "width", "height"] as const) {
     expect(Math.abs(ring[side] - target[side]), `the ring's ${side} follows the shelf, not the page`).toBeLessThan(2);
   }
+  // The ring lands in the ACCENT, not in body text. Borrowing the shelf's own
+  // `color` drew a near-black rectangle around it — a debug outline where the
+  // payoff of the whole ceremony should be.
+  const ink = await page.locator("[data-vendo-pin-ring]").evaluate(node => ({
+    ring: getComputedStyle(node).boxShadow,
+    accent: getComputedStyle(node.parentElement!).getPropertyValue("--vendo-accent"),
+    body: getComputedStyle(document.querySelector(".fl-shelf")!).color,
+  }));
+  expect(ink.ring, `ring ${ink.ring} · accent ${ink.accent} · body ${ink.body}`).not.toContain(ink.body);
   await page.screenshot({ path: screenshotPath("pin-ring-on-shelf") });
 
   // The host's write fired…

--- a/packages/ui/e2e/pin-nudge.spec.ts
+++ b/packages/ui/e2e/pin-nudge.spec.ts
@@ -146,11 +146,10 @@ test("a settled build invites the pin, and the pin lands in the Apps shelf", asy
 
   // The host's write fired…
   await expect(page.getByTestId("pin-recorder")).toHaveText(`pinned: ${BUILT_APP}`);
-  // …and the shelf reads the pinned app back over the wire.
-  await page.reload();
-  await page.getByRole("button", { name: "New chat" }).click();
-  await expect(page.getByRole("region", { name: "Your apps" })
-    .getByRole("button", { name: "Open Where my money goes" })).toBeVisible();
+  // …and the shelf holds the app WITHOUT a refresh. This used to need a reload,
+  // which meant the flight above landed in a shelf that did not have the app in
+  // it — the ceremony asserting something untrue.
+  await expect(shelf.getByRole("button", { name: "Open Where my money goes" })).toBeVisible();
   await page.screenshot({ path: screenshotPath("pin-shelf-holds-app") });
 });
 

--- a/packages/ui/e2e/pin-nudge.spec.ts
+++ b/packages/ui/e2e/pin-nudge.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * §10.1 — the pin, proven as a person meets it. There was no browser proof of
+ * this path at all: not the nudge, not the ceremony's flight, and not what a pin
+ * does on a host with no slot mounted (which used to be nothing at all — the
+ * panel dismissed and the pin vanished).
+ *
+ * Real Chromium, the production-built harness, the scripted wire fixture. The
+ * host's own pin write is stubbed at the wire boundary the way smoke.spec stubs
+ * the ask queue, and for the same reason: every spec in the run shares one wire
+ * server, so a mutation left behind would leak into its neighbours.
+ */
+import { expect, test, type Page } from "@playwright/test";
+import { openScenario, screenshotPath } from "./helpers.js";
+
+/** The scripted multi-tool + build turn (`[smoke-build]` in the wire fixture). */
+const BUILD_TURN = "[smoke-build] a board showing where my money goes";
+const BUILT_APP = "app_smoke";
+
+/**
+ * The HOST's half of a pin: its own API writes the placement, and the shelf then
+ * reads the app back over the wire. `vendo_make`'s fixture turn streams the view
+ * without persisting a record, so this stands in for the record the real runtime
+ * would have — spec-scoped, so no other spec sees it.
+ */
+async function hostPinWrite(page: Page): Promise<() => void> {
+  let placed = false;
+  await page.route("**/api/vendo/apps", async (route) => {
+    if (route.request().method() !== "GET") return await route.fallback();
+    const response = await route.fetch();
+    const apps = (await response.json()) as unknown[];
+    await route.fulfill({
+      json: placed
+        ? [{
+          format: "vendo/app@1",
+          id: BUILT_APP,
+          name: "Where my money goes",
+          ui: "tree",
+          tree: {
+            formatVersion: "vendo-genui/v2",
+            root: "root",
+            nodes: [{ id: "root", component: "Text", props: { text: "$1,240 this month across 4 categories." } }],
+          },
+          placements: ["hero"],
+        }, ...apps]
+        : apps,
+    });
+  });
+  return () => {
+    placed = true;
+  };
+}
+
+/** Chromium's animation clock, slowed so a 300ms flight and a 180ms ring can be
+ *  photographed. The ceremony's own timings are untouched. */
+async function slowMotion(page: Page): Promise<void> {
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send("Animation.enable");
+  await cdp.send("Animation.setPlaybackRate", { playbackRate: 0.1 });
+}
+
+test("a settled build invites the pin, and the pin lands in the Apps shelf", async ({ page }) => {
+  const write = await hostPinWrite(page);
+  await openScenario(page, "pin-shelf");
+
+  // The page behind the assistant: the Apps shelf, live, holding real apps. The
+  // shelf rides the HOME composer, and the fixture's stored conversation is
+  // selected on mount — so start a fresh one, as a person landing here would.
+  await page.getByRole("button", { name: "New chat" }).click();
+  const shelf = page.getByRole("region", { name: "Your apps" });
+  await expect(shelf).toBeVisible();
+
+  // The build happens in the conversation, over the page.
+  await page.getByRole("button", { name: "AI agent" }).click();
+  const dialog = page.getByRole("dialog", { name: "Vendo assistant" });
+  await dialog.getByRole("textbox", { name: "Message" }).fill(BUILD_TURN);
+  await dialog.getByRole("button", { name: "Send" }).click();
+
+  // While it BUILDS there is no pin at all — §8 gives a build one moving thing.
+  await expect(dialog.getByText("Building your view…")).toBeVisible({ timeout: 20_000 });
+  await expect(dialog.getByRole("button", { name: "Pin to dashboard" })).toHaveCount(0);
+
+  // Settled: the pin invites. Quiet, and at the edge of vision.
+  await expect(dialog.getByText("Spending board").first()).toBeVisible({ timeout: 25_000 });
+  const pin = dialog.getByRole("button", { name: "Pin to dashboard" });
+  await expect(pin).toHaveAttribute("data-vendo-pin", "invite");
+  await expect(pin).toHaveCSS("animation-iteration-count", /infinite/);
+  await page.screenshot({ path: screenshotPath("pin-nudge-invite") });
+
+  // Taking it: the panel goes first, then the ghost flies to the shelf and the
+  // shelf takes the settle ring. No slot is mounted anywhere on this page — that
+  // used to mean the pin did nothing visible at all.
+  await slowMotion(page);
+  write();
+  await pin.click();
+  await expect(page.locator("[data-vendo-pin-ring]")).toBeAttached({ timeout: 10_000 });
+  const ring = (await page.locator("[data-vendo-pin-ring]").boundingBox())!;
+  const target = (await shelf.boundingBox())!;
+  for (const side of ["x", "y", "width", "height"] as const) {
+    expect(Math.abs(ring[side] - target[side]), `the ring's ${side} follows the shelf, not the page`).toBeLessThan(2);
+  }
+  await page.screenshot({ path: screenshotPath("pin-ring-on-shelf") });
+
+  // The host's write fired…
+  await expect(page.getByTestId("pin-recorder")).toHaveText(`pinned: ${BUILT_APP}`);
+  // …and the shelf reads the pinned app back over the wire.
+  await page.reload();
+  await page.getByRole("button", { name: "New chat" }).click();
+  await expect(page.getByRole("region", { name: "Your apps" })
+    .getByRole("button", { name: "Open Where my money goes" })).toBeVisible();
+  await page.screenshot({ path: screenshotPath("pin-shelf-holds-app") });
+});
+
+test("the invitation resolves once the pin is taken, on whichever surface shows it next", async ({ page }) => {
+  await hostPinWrite(page);
+  await openScenario(page, "pin-shelf");
+
+  await page.getByRole("button", { name: "AI agent" }).click();
+  const dialog = page.getByRole("dialog", { name: "Vendo assistant" });
+  await dialog.getByRole("textbox", { name: "Message" }).fill(BUILD_TURN);
+  await dialog.getByRole("button", { name: "Send" }).click();
+  await expect(dialog.getByText("Spending board").first()).toBeVisible({ timeout: 25_000 });
+  await dialog.getByRole("button", { name: "Pin to dashboard" }).click();
+
+  // The pin closed the panel. Reopening restores the same conversation (closing
+  // never discards it), and the card's pin is settled rather than still asking.
+  await page.getByRole("button", { name: "AI agent" }).click();
+  const settled = page.getByRole("dialog", { name: "Vendo assistant" })
+    .getByRole("button", { name: "Pin to dashboard" });
+  await expect(settled).toHaveAttribute("data-vendo-pin", "pinned");
+  await expect(settled).toHaveCSS("animation-iteration-count", /^(?!.*infinite).*$/);
+  await page.screenshot({ path: screenshotPath("pin-settled") });
+});

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -1856,6 +1856,23 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
 @media (prefers-reduced-motion: no-preference) {
   .fl-appcard-bar[data-state="ready"] .fl-barpin { animation: fl-fade-in .3s ease both; }
 }
+/* The pin nudge (founder mockup, 2026-08-04). A settled build INVITES the pin
+   with a slow ring at the edge of vision — never a toast, never an action, and
+   never while the build is still running (§8 gives a build one moving thing).
+   Taken, it resolves to the settled accent state. Reduced motion keeps the
+   accent and drops the ring: the colour alone is the invitation. */
+.fl-barpin[data-vendo-pin] { color: var(--vendo-accent); }
+.fl-barpin[data-vendo-pin="pinned"] { background: var(--vendo-accent-soft); }
+@media (prefers-reduced-motion: no-preference) {
+  .fl-barpin[data-vendo-pin="invite"] { animation: fl-pin-nudge 2.4s var(--vendo-ease) infinite; }
+  /* The card's pin also fades in with its bar (rule above); naming both keeps
+     the entrance, which a bare nudge would silently replace. */
+  .fl-appcard-bar[data-state="ready"] .fl-barpin[data-vendo-pin="invite"] {
+    animation: fl-fade-in .3s ease both, fl-pin-nudge 2.4s var(--vendo-ease) infinite; }
+}
+@keyframes fl-pin-nudge {
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--vendo-accent) 26%, transparent); }
+  45% { box-shadow: 0 0 0 5px color-mix(in srgb, var(--vendo-accent) 10%, transparent); } }
 
 /* 2B — Send now on the queued pill. */
 .fl-queued-now { flex-shrink: 0; border: 0; background: none; cursor: pointer; padding: 3px 6px;

--- a/packages/ui/src/chrome/index.ts
+++ b/packages/ui/src/chrome/index.ts
@@ -24,7 +24,7 @@ export { VendoOverlay, type VendoOverlayProps } from "./vendo-overlay.js";
 export { defaultVendoGreeting, hasSeen, markSeen, type VendoDiscoverability, type VendoGreeting } from "./discoverability.js";
 export { openVendoConversation, type OpenConversationOptions } from "./overlay-registry.js";
 export { Remixable, type RemixableProps } from "./remixable.js";
-export { playPinCeremony, usePinAction, type PinCeremonyOptions } from "./pin-ceremony.js";
+export { playPinCeremony, usePinAction, usePinNudge, type PinCeremonyOptions } from "./pin-ceremony.js";
 export { VendoTrigger, type VendoTriggerProps } from "./vendo-trigger.js";
 export { VendoPage, type VendoPageProps } from "./vendo-page.js";
 export { VendoPalette, type VendoCommand } from "./vendo-palette.js";

--- a/packages/ui/src/chrome/pin-ceremony.ts
+++ b/packages/ui/src/chrome/pin-ceremony.ts
@@ -88,18 +88,27 @@ function destinationOf(slot: string | undefined): Element | null {
     ?? document.querySelector(OUR_CHROME);
 }
 
-/** The ring's ink.
+/**
+ * The settle ring's shadow.
  *
- *  A HOST slot lends its own `color`, and that is the point: a pin lands in the
- *  host's page and should look like it belongs to it.
+ * A HOST SLOT gets a crisp hairline in the slot's OWN `color`: it is a small,
+ * defined region in someone else's page, the line reads as "here", and
+ * borrowing the ink is what makes a pin look like it belongs to the host.
  *
- *  OUR OWN chrome must not, and this is where borrowing it went wrong: the
- *  shelf's `color` is body text, so the payoff of the whole ceremony drew a
- *  near-black rectangle around the shelf — a debug outline. Our surfaces are
- *  themed, so they have an accent to land in. */
-function inkOf(destination: Element, style: CSSStyleDeclaration): string {
-  if (!destination.matches(OUR_CHROME)) return style.color;
-  return style.getPropertyValue("--vendo-accent").trim() || style.color;
+ * OUR OWN Apps shelf gets a soft bloom instead, because the same treatment drew
+ * a debug border around it. Two things had to change, and the first alone was
+ * not enough: the shelf's `color` is body text (so the ring was inked in body
+ * text), AND a full-strength hairline around a WIDE band reads as a border
+ * whatever its hue — this theme's accent is itself near-black, so switching
+ * token changed almost nothing on screen. A wide destination takes a glow.
+ */
+function ringShadow(destination: Element, style: CSSStyleDeclaration): string {
+  if (!destination.matches(OUR_CHROME)) {
+    return `0 0 0 1.5px ${style.color}, 0 12px 40px -14px ${style.color}`;
+  }
+  const accent = style.getPropertyValue("--vendo-accent").trim() || style.color;
+  return `0 0 0 3px color-mix(in srgb, ${accent} 16%, transparent),`
+    + ` 0 10px 34px -12px color-mix(in srgb, ${accent} 40%, transparent)`;
 }
 
 /** The settle pulse: a ring drawn OVER the destination, never a style written
@@ -108,7 +117,6 @@ function pulse(destination: Element): void {
   const box = boxOf(destination);
   if (box === null) return;
   const style = getComputedStyle(destination);
-  const ink = inkOf(destination, style);
   const ring = document.createElement("div");
   ring.setAttribute("data-vendo-pin-ring", "");
   ring.setAttribute("aria-hidden", "true");
@@ -119,7 +127,7 @@ function pulse(destination: Element): void {
     width: `${box.width}px`,
     height: `${box.height}px`,
     borderRadius: style.borderRadius,
-    boxShadow: `0 0 0 1.5px ${ink}, 0 12px 40px -14px ${ink}`,
+    boxShadow: ringShadow(destination, style),
     pointerEvents: "none",
     zIndex: ABOVE_OVERLAY,
   });

--- a/packages/ui/src/chrome/pin-ceremony.ts
+++ b/packages/ui/src/chrome/pin-ceremony.ts
@@ -22,9 +22,9 @@
  * Lifted from the Keystone demo's `pin-flight.ts`, which is where the sequence
  * was designed and proven on stage.
  */
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useVendoContext } from "../context.js";
-import { announcePin } from "../pin-events.js";
+import { announcePin, onPinAnnounced, pinTaken } from "../pin-events.js";
 import { openVendoConversation } from "./overlay-registry.js";
 
 /** 300 + 180 = 480ms end to end (the design budget is "under half a second"). */
@@ -64,17 +64,25 @@ function boxOf(element: Element | null): DOMRect | null {
 /** The destination the pin lands in — a mounted VendoSlot, or a `<Remixable>`
  *  wrapper (the fork's in-place mount boundary, 2026-08-02 final shape). A
  *  named destination is exact; unnamed, the only mounted one is unambiguous
- *  and every host with one dashboard slot gets the ceremony for free. Two or
- *  more and this returns null — better no animation than one that flies to
- *  the wrong place. */
+ *  and every host with one dashboard slot gets the ceremony for free. Host
+ *  slots keep priority; with none resolvable the Apps shelf is the floor. */
 function destinationOf(slot: string | undefined): Element | null {
   // Matched by attribute VALUE rather than an interpolated selector: slot and
   // app ids come from the host, and a quote in one would break the selector.
   const mounted = [...document.querySelectorAll("[data-vendo-slot], [data-vendo-remixable]")];
-  if (slot === undefined) return mounted.length === 1 ? mounted[0]! : null;
-  return mounted.find(element =>
-    element.getAttribute("data-vendo-slot") === slot || element.getAttribute("data-vendo-remixable") === slot,
-  ) ?? null;
+  const named = slot === undefined
+    ? (mounted.length === 1 ? mounted[0]! : null)
+    : mounted.find(element =>
+      element.getAttribute("data-vendo-slot") === slot || element.getAttribute("data-vendo-remixable") === slot,
+    ) ?? null;
+  // No slot resolved — none mounted, or several with no name to choose by. This
+  // used to return null, and since the dismiss had already fired the user's pin
+  // appeared to VANISH: no flight, no ring, nothing. The Apps shelf is where a
+  // pinned app shows up, so it is where the pin lands. The day-zero ghost shelf
+  // is the last resort: it advertises what to build and holds no apps.
+  return named
+    ?? document.querySelector(".fl-shelf:not(.fl-shelf--ghost)")
+    ?? document.querySelector(".fl-shelf");
 }
 
 /** The settle pulse: a ring drawn OVER the destination, never a style written
@@ -243,6 +251,32 @@ export function playPinCeremony({ appId, slot, dismiss = () => {} }: PinCeremony
  *  announcement that lets the slot show the result without waiting for a poll.
  *  Returns undefined when the host wired no `onPin` — which is what hides the
  *  affordances in the first place. */
+/**
+ * The pin affordance's nudge state (mockup 2026-08-04): a settled build whose
+ * pin has not been taken INVITES it with a quiet infinite pulse, and the moment
+ * it is taken the affordance resolves to a settled accent state. `undefined` is
+ * the quiet default.
+ *
+ * "Not taken yet" is the pin bus, NOT a placements read: placements live on the
+ * app document, which no pin affordance holds, so knowing it for certain costs a
+ * list fetch per card — a request to render one boolean. The honest cost of that
+ * choice is that a pin made in an earlier session invites once more.
+ *
+ * `invited` is the CALLER's — whether this surface's build just landed (the
+ * in-thread card is `restored === false`) — because only the caller knows.
+ */
+export function usePinNudge(appId: string, invited: boolean): "invite" | "pinned" | undefined {
+  const [taken, setTaken] = useState(() => pinTaken(appId));
+  useEffect(() => {
+    setTaken(pinTaken(appId));
+    return onPinAnnounced(pinned => {
+      if (pinned === appId) setTaken(true);
+    });
+  }, [appId]);
+  if (taken) return "pinned";
+  return invited ? "invite" : undefined;
+}
+
 export function usePinAction(): ((app: { appId: string; payload: unknown }) => void) | undefined {
   const { onPin, pinSlot } = useVendoContext();
   const pin = useCallback(

--- a/packages/ui/src/chrome/pin-ceremony.ts
+++ b/packages/ui/src/chrome/pin-ceremony.ts
@@ -39,6 +39,9 @@ const ABOVE_OVERLAY = "2147483002";
 /** A slot is often a short banner while the source card is a tall panel; fitting
  *  both axes would shrink the ghost to an unreadable speck. */
 const MIN_GHOST_SCALE = 0.34;
+/** The destinations that are OURS rather than the host's page — the Apps shelf,
+ *  live or day-zero. They are themed, so the ring lands in the accent. */
+const OUR_CHROME = ".fl-shelf";
 
 export interface PinCeremonyOptions {
   /** The app being pinned — its in-thread card is the ghost's source. */
@@ -81,17 +84,31 @@ function destinationOf(slot: string | undefined): Element | null {
   // pinned app shows up, so it is where the pin lands. The day-zero ghost shelf
   // is the last resort: it advertises what to build and holds no apps.
   return named
-    ?? document.querySelector(".fl-shelf:not(.fl-shelf--ghost)")
-    ?? document.querySelector(".fl-shelf");
+    ?? document.querySelector(`${OUR_CHROME}:not(.fl-shelf--ghost)`)
+    ?? document.querySelector(OUR_CHROME);
+}
+
+/** The ring's ink.
+ *
+ *  A HOST slot lends its own `color`, and that is the point: a pin lands in the
+ *  host's page and should look like it belongs to it.
+ *
+ *  OUR OWN chrome must not, and this is where borrowing it went wrong: the
+ *  shelf's `color` is body text, so the payoff of the whole ceremony drew a
+ *  near-black rectangle around the shelf — a debug outline. Our surfaces are
+ *  themed, so they have an accent to land in. */
+function inkOf(destination: Element, style: CSSStyleDeclaration): string {
+  if (!destination.matches(OUR_CHROME)) return style.color;
+  return style.getPropertyValue("--vendo-accent").trim() || style.color;
 }
 
 /** The settle pulse: a ring drawn OVER the destination, never a style written
- *  onto it — this module animates surfaces it does not own. Its ink is the
- *  destination's own colour, because a pin lands in the host's page. */
+ *  onto it — this module animates surfaces it does not own. */
 function pulse(destination: Element): void {
   const box = boxOf(destination);
   if (box === null) return;
   const style = getComputedStyle(destination);
+  const ink = inkOf(destination, style);
   const ring = document.createElement("div");
   ring.setAttribute("data-vendo-pin-ring", "");
   ring.setAttribute("aria-hidden", "true");
@@ -102,7 +119,7 @@ function pulse(destination: Element): void {
     width: `${box.width}px`,
     height: `${box.height}px`,
     borderRadius: style.borderRadius,
-    boxShadow: `0 0 0 1.5px ${style.color}, 0 12px 40px -14px ${style.color}`,
+    boxShadow: `0 0 0 1.5px ${ink}, 0 12px 40px -14px ${ink}`,
     pointerEvents: "none",
     zIndex: ABOVE_OVERLAY,
   });

--- a/packages/ui/src/chrome/remixable.tsx
+++ b/packages/ui/src/chrome/remixable.tsx
@@ -109,7 +109,15 @@ const NO_APPS: AppDocument[] = [];
 /** Fork discovery: the user's fork for this slot is the app whose `pins` name
  *  it (provenance — the 2026-08-02 pins/placements split). An in-place fork
  *  needs no placement: its location IS the wrapper it replaced, so this reads
- *  pins, never placements. Latest wins, like slot discovery. */
+ *  pins, never placements.
+ *
+ *  The OLDEST matching row wins, and deliberately: `.at(-1)` over a newest-first
+ *  list is the same winner the SERVER's fork-pin dedupe converges on (runtime.ts
+ *  — "the OLDEST matching row, so every dedupe path converges"). Newest-wins
+ *  here would put the wrapper and the server on different apps whenever a slot
+ *  somehow carries two. (This comment used to say "latest wins, like slot
+ *  discovery"; slot discovery genuinely meant latest and was reading the oldest
+ *  — see use-slot-app.ts. Here the code was right and the comment was wrong.) */
 function useRemixFork(slot: string | null) {
   const { client } = useVendoContext();
   const list = useCallback(

--- a/packages/ui/src/chrome/thread/parts.tsx
+++ b/packages/ui/src/chrome/thread/parts.tsx
@@ -14,7 +14,7 @@ import { GrantSetCard, type GrantSetPermission } from "../grant-set-card.js";
 import { toolkitDisplayName, toolTitle } from "../humanize.js";
 import { Markdown } from "../markdown.js";
 import type { MorphToastProps } from "../morph-toast.js";
-import { usePinAction } from "../pin-ceremony.js";
+import { usePinAction, usePinNudge } from "../pin-ceremony.js";
 import { LONG_TEXT_CAP, truncateHead } from "../truncate.js";
 import { SentAttachment } from "./attachments.js";
 import { buildApprovalRequest } from "./approval-wire.js";
@@ -421,6 +421,11 @@ function ThreadAppCard({ appId, payload, restored, buildKey }: { appId: string; 
   const pin = usePinAction();
   const split = useSplitView();
   const streaming = (payload as { streaming?: boolean }).streaming === true;
+  // The nudge belongs to the build that just LANDED (§10.1: the user pins, the
+  // agent never does). Restored history and a card still building are both
+  // quiet — the second one matters twice over, because §8 gives a build exactly
+  // one moving element and an invitation is not it.
+  const nudge = usePinNudge(appId, !restored && !streaming);
   // When a LIVE build settles (streaming flips off), the full-size card
   // scrolls its own top into view once: stick-to-bottom otherwise leaves the
   // reader parked at the bottom of a tall app, mid-document with the title
@@ -583,6 +588,7 @@ function ThreadAppCard({ appId, payload, restored, buildKey }: { appId: string; 
           <button
             type="button"
             className="fl-barpin"
+            {...(nudge === undefined ? {} : { "data-vendo-pin": nudge })}
             onClick={() => pin({ appId, payload })}
           >
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>

--- a/packages/ui/src/chrome/vendo-overlay.tsx
+++ b/packages/ui/src/chrome/vendo-overlay.tsx
@@ -11,7 +11,7 @@ import { hasSeen, markSeen, type VendoDiscoverability, type VendoGreeting } from
 import { inertBehind } from "./inert-behind.js";
 import { LauncherFace, LauncherToast, useLauncherStatus } from "./launcher-status.js";
 import { deliverPrefill, PrefillScopeContext, registerOverlayOpener } from "./overlay-registry.js";
-import { usePinAction } from "./pin-ceremony.js";
+import { usePinAction, usePinNudge } from "./pin-ceremony.js";
 import { IDLE_RUN_ACTIVITY, runActivity, subscribeRunActivity } from "./run-activity.js";
 import {
   escapeIntent,
@@ -233,6 +233,9 @@ export function VendoOverlay({
   const [splitState, dispatchSplit] = useReducer(splitViewReducer, initialSplitViewState);
   const expanded = splitState.expanded && !takeover.active;
   const featured = featuredEmbed(splitState);
+  // The workspace IS the mockup's pin: one app on the stage at a time, so its
+  // pin invites until the user takes it (§10.1 — the user pins, never the agent).
+  const stageNudge = usePinNudge(featured?.appId ?? "", featured !== undefined);
   // The collapse ANIMATES: like the connect tray's exit walk, the stage stays
   // mounted through expanded → collapsing → collapsed so the featured app
   // doesn't blink out before the panes finish sliding. Render-phase state
@@ -695,6 +698,7 @@ export function VendoOverlay({
                         <button
                           type="button"
                           className="fl-barpin fl-stage-pin"
+                          {...(stageNudge === undefined ? {} : { "data-vendo-pin": stageNudge })}
                           onClick={() => {
                             pin({ appId: featured.appId, payload: featured.payload });
                             dispatchSplit({ type: "collapse" });

--- a/packages/ui/src/chrome/vendo-page.tsx
+++ b/packages/ui/src/chrome/vendo-page.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { useApps } from "../hooks/use-apps.js";
 import { useMobileTakeover } from "../hooks/use-mobile-takeover.js";
+import { useRefreshOnPin } from "../hooks/use-pin-refresh.js";
 import { useThreads } from "../hooks/use-threads.js";
 import { ActivityPanel } from "./activity-panel.js";
 import { AutomationsPanel } from "./automations-panel.js";
@@ -143,6 +144,10 @@ export function VendoPage({ thread }: VendoPageProps = {}) {
   const station = view === "apps" ? "apps" : view === "chat" && home ? "home" : "elsewhere";
   const arrivedAt = useRef(station);
   const refreshApps = appsApi.refresh;
+  // The pin ceremony flies its ghost INTO the shelf below, so the shelf cannot
+  // wait for the next arrival at this door: the flight would land in a shelf
+  // that does not have the app in it yet. Same bus slot discovery rides.
+  useRefreshOnPin(refreshApps);
   useEffect(() => {
     // useResource already fetched on mount; only transitions refresh.
     if (station !== arrivedAt.current && station !== "elsewhere") void refreshApps();

--- a/packages/ui/src/hooks/use-pin-refresh.ts
+++ b/packages/ui/src/hooks/use-pin-refresh.ts
@@ -1,0 +1,38 @@
+/** "Re-read because a pin just landed", in one place.
+ *
+ *  A pin is a HOST write (`onPin`), so nothing in this package can see it
+ *  happen — a surface showing pinned apps would sit stale until its next poll
+ *  tick, or forever if it does not poll. The pin bus announces instead.
+ *
+ *  The second read is the load-bearing half: `onPin` is fire-and-forget by
+ *  contract (it returns void), so the read on the announcement itself can beat
+ *  the host's write to the server. The settle read lands as the ceremony's ghost
+ *  does (~480ms), which is also the moment the user is looking at the
+ *  destination. Any poll the caller has stays the floor under both.
+ *
+ *  Both callers — slot discovery and the Apps shelf — are destinations the pin
+ *  ceremony flies into, which is why they cannot be left to a poll: the flight
+ *  would land in a surface that does not have the app yet. */
+import { useEffect } from "react";
+import { onPinAnnounced } from "../pin-events.js";
+
+const PIN_SETTLE_MS = 500;
+
+export function useRefreshOnPin(refresh: () => Promise<void>, enabled = true): void {
+  useEffect(() => {
+    if (!enabled) return;
+    const settles = new Set<ReturnType<typeof setTimeout>>();
+    const stop = onPinAnnounced(() => {
+      void refresh();
+      const settle = setTimeout(() => {
+        settles.delete(settle);
+        void refresh();
+      }, PIN_SETTLE_MS);
+      settles.add(settle);
+    });
+    return () => {
+      stop();
+      for (const settle of settles) clearTimeout(settle);
+    };
+  }, [enabled, refresh]);
+}

--- a/packages/ui/src/hooks/use-slot-app.ts
+++ b/packages/ui/src/hooks/use-slot-app.ts
@@ -61,8 +61,14 @@ export function useSlotApp(slotId: string, options: PollOptions & {
       for (const settle of settles) clearTimeout(settle);
     };
   }, [enabled, refresh]);
-  // Latest placement wins — matching the "the newest remix takes the slot"
-  // semantics the demos established (hero-slot took `.at(-1)`).
-  const appId = data.filter(app => app.placements?.includes(slotId)).at(-1)?.id;
+  // Latest placement wins ("the newest remix takes the slot"), and the wire
+  // lists apps NEWEST FIRST — `runtime.list()` sorts createdAt descending, and
+  // an AppDocument carries no timestamp, so list order is the only newness
+  // signal here. This read was `.at(-1)`, which is the OLDEST placed app: the
+  // exact opposite of its own comment. Two things hid it — the reference host
+  // strips the slot off every other app the subject owns, so only one ever
+  // carries a placement, and the test mocked `apps.list` with a hand-ordered
+  // array instead of the wire's real order.
+  const appId = data.find(app => app.placements?.includes(slotId))?.id;
   return { appId, error, isLoading, refresh };
 }

--- a/packages/ui/src/hooks/use-slot-app.ts
+++ b/packages/ui/src/hooks/use-slot-app.ts
@@ -8,17 +8,12 @@
  *  classified into `placements` by the server's read path, so they arrive
  *  here already split. */
 import type { AppDocument, AppId } from "@vendoai/core";
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import { useVendoContext } from "../context.js";
-import { onPinAnnounced } from "../pin-events.js";
+import { useRefreshOnPin } from "./use-pin-refresh.js";
 import { type PollOptions, useResource } from "./use-resource.js";
 
 const DEFAULT_POLL_MS = 5000;
-
-/** A second read as the pin ceremony's ghost lands (~480ms). The host's write
- *  is fire-and-forget when `onPin` returns void, so the read on the pin itself
- *  can beat it to the server; this covers that without waiting for the poll. */
-const PIN_SETTLE_MS = 500;
 
 const NO_APPS: AppDocument[] = [];
 
@@ -45,22 +40,7 @@ export function useSlotApp(slotId: string, options: PollOptions & {
   // A pin is a HOST write, so nothing here can see it — the slot used to sit
   // empty for up to a poll tick after the user asked for the app. The pin
   // announces itself instead; the poll stays as the floor.
-  useEffect(() => {
-    if (!enabled) return;
-    const settles = new Set<ReturnType<typeof setTimeout>>();
-    const stop = onPinAnnounced(() => {
-      void refresh();
-      const settle = setTimeout(() => {
-        settles.delete(settle);
-        void refresh();
-      }, PIN_SETTLE_MS);
-      settles.add(settle);
-    });
-    return () => {
-      stop();
-      for (const settle of settles) clearTimeout(settle);
-    };
-  }, [enabled, refresh]);
+  useRefreshOnPin(refresh, enabled);
   // Latest placement wins ("the newest remix takes the slot"), and the wire
   // lists apps NEWEST FIRST — `runtime.list()` sorts createdAt descending, and
   // an AppDocument carries no timestamp, so list order is the only newness

--- a/packages/ui/src/pin-events.ts
+++ b/packages/ui/src/pin-events.ts
@@ -12,6 +12,7 @@
 type PinListener = (appId: string) => void;
 
 const listeners = new Set<PinListener>();
+const taken = new Set<string>();
 
 /** Subscribe to pins; returns an unsubscribe. */
 export function onPinAnnounced(listener: PinListener): () => void {
@@ -21,5 +22,15 @@ export function onPinAnnounced(listener: PinListener): () => void {
 
 /** Announce that `appId` was just pinned. */
 export function announcePin(appId: string): void {
+  taken.add(appId);
   for (const listener of [...listeners]) listener(appId);
+}
+
+/** Whether this app's pin has already been taken — the same fact the bus
+ *  announces, retained so an affordance that mounts LATER (a card re-rendered
+ *  from the thread, the stage featuring the app again) is not left inviting a
+ *  pin the user already gave. Session-scoped by design: a placement made in an
+ *  earlier session lives on the app document, which no pin affordance holds. */
+export function pinTaken(appId: string): boolean {
+  return taken.has(appId);
 }

--- a/packages/ui/test/chrome/center.test.tsx
+++ b/packages/ui/test/chrome/center.test.tsx
@@ -24,6 +24,7 @@ import { VendoProvider, type VendoClient } from "../../src/index.js";
 import { VendoPage } from "../../src/chrome/index.js";
 import { markSeen } from "../../src/chrome/discoverability.js";
 import { publishThreadRun, resetRunActivity } from "../../src/chrome/run-activity.js";
+import { announcePin } from "../../src/pin-events.js";
 import type { ThreadSummary } from "../../src/wire-types.js";
 
 const DAY_MS = 86_400_000;
@@ -83,7 +84,12 @@ function stubClient(over: {
       async delete() { return undefined; },
     },
     apps: {
-      async list() { return apps; },
+      // ⚠️ FIXTURE EDIT — a COPY, which is the only thing a real client can
+      // return: every read parses fresh JSON. Handing back the same array twice
+      // made a re-read invisible to React (`setData` bails on Object.is), so a
+      // test could not tell "the surface never re-read" from "the surface
+      // re-read and nothing changed".
+      async list() { return [...apps]; },
       async get(id: string) {
         log.push(`get:${id}`);
         return apps.find(app => app.id === id) ?? apps[0]!;
@@ -424,6 +430,21 @@ describe("the home shelf", () => {
     const reachable = [...shelf.querySelectorAll<HTMLElement>("button,input,select,textarea,a[href],[tabindex]")]
       .filter(node => node.closest("[inert]") === null);
     expect(reachable.map(node => node.getAttribute("aria-label"))).toEqual(["Open Invoices"]);
+  });
+
+  it("a pin appears in the shelf on its own — the ceremony flies the ghost INTO it", async () => {
+    // The pin ceremony's fallback destination is this shelf, so a shelf that
+    // only catches up on the next refresh makes the animation assert something
+    // untrue: the ghost lands in a shelf without the app in it.
+    const apps = [appDoc("app_1", "Invoices")];
+    mount(stubClient({ apps }));
+    await screen.findByRole("region", { name: "Your apps" });
+    expect(screen.queryByRole("button", { name: "Open Spending board" })).toBeNull();
+    // `onPin` is the HOST's write, so no read here can see it happen — the pin
+    // bus is the only signal, exactly as slot discovery already rides it.
+    apps.push(appDoc("app_smoke", "Spending board"));
+    act(() => announcePin("app_smoke"));
+    expect(await screen.findByRole("button", { name: "Open Spending board" })).toBeTruthy();
   });
 
   it("once an app exists the ghosts are gone and the shelf is live", async () => {

--- a/packages/ui/test/chrome/export-surface.test.ts
+++ b/packages/ui/test/chrome/export-surface.test.ts
@@ -54,6 +54,12 @@ const VALUE_EXPORTS = [
   // a pin from its own control.
   "playPinCeremony",
   "usePinAction",
+  // ⚠️ TEST EDIT — `usePinNudge` joins them DELIBERATELY. The thread is an eject
+  // surface, so every import in `thread/parts.tsx` is public API by
+  // construction, and the pin button there needs its invite state. The action
+  // and the invitation are two halves of one affordance: a host that ejects the
+  // template and keeps the pin needs both or its pin goes quiet.
+  "usePinNudge",
   // Shelf Lane B — the two placeable pieces (ui-usage-dx §2).
   "VendoActivities",
   "VendoTrigger",

--- a/packages/ui/test/chrome/pin-ceremony.test.tsx
+++ b/packages/ui/test/chrome/pin-ceremony.test.tsx
@@ -255,14 +255,38 @@ describe("the pin ceremony (Keystone graduates B8)", () => {
     expect(ring()!.getAttribute("style")).not.toContain("rgb(20, 21, 26)");
   });
 
-  it("a HOST slot still lends the ring its own ink — a pin lands in the host's page", async () => {
+  it("blooms instead of outlining when it lands in our own chrome", async () => {
+    const { panel } = stage();
+    document.querySelector("[data-vendo-slot]")!.remove();
+    stubRects([
+      { selector: "[data-vendo-app-embed]", rect: { left: 400, top: 120, width: 600, height: 400 } },
+      { selector: ".fl-shelf", rect: { left: 40, top: 600, width: 300, height: 200 } },
+    ]);
+    shelf().style.setProperty("--vendo-accent", "rgb(10, 125, 85)");
+    playPinCeremony({ appId: "app_1", slot: "hero", dismiss: () => panel.remove() });
+
+    await flushFrames();
+    flight()!.animation.onfinish!();
+    // The accent alone was not enough: this theme's accent IS near-black, so a
+    // full-strength 1.5px line still drew a box around the whole shelf. The
+    // shelf is a WIDE band of our own chrome — it takes a soft bloom, and the
+    // crisp hairline stays where it reads as a highlight (a host's slot).
+    const style = ring()!.getAttribute("style")!;
+    expect(style).not.toContain("1.5px");
+    expect(style).toContain("color-mix");
+  });
+
+  it("a HOST slot still lends the ring its own ink, and keeps its crisp hairline", async () => {
     stage();
     (document.querySelector("[data-vendo-slot]") as HTMLElement).style.color = "rgb(180, 40, 40)";
     playPinCeremony({ appId: "app_1", slot: "hero" });
 
     await flushFrames();
     flight()!.animation.onfinish!();
-    expect(ring()!.getAttribute("style")).toContain("rgb(180, 40, 40)");
+    const style = ring()!.getAttribute("style")!;
+    expect(style).toContain("rgb(180, 40, 40)");
+    expect(style).toContain("1.5px");
+    expect(style).not.toContain("color-mix");
   });
 
   it("dismisses and strands nothing when the destination is not mounted", async () => {

--- a/packages/ui/test/chrome/pin-ceremony.test.tsx
+++ b/packages/ui/test/chrome/pin-ceremony.test.tsx
@@ -175,6 +175,66 @@ describe("the pin ceremony (Keystone graduates B8)", () => {
     expect(ring()).toBeTruthy();
   });
 
+  /** The Apps shelf, as `AppShelf` renders it live (center/home.tsx). */
+  function shelf(ghost = false): HTMLElement {
+    const section = document.createElement("section");
+    section.className = ghost ? "fl-shelf fl-shelf--ghost" : "fl-shelf";
+    section.setAttribute("aria-label", ghost ? "What you could build" : "Your apps");
+    document.body.append(section);
+    return section;
+  }
+
+  it("lands in the Apps shelf when no host slot resolves — the pin used to vanish", async () => {
+    // The silent no-op this closes: zero slots mounted (or several and none
+    // named) dismissed the panel and then played NOTHING, so the user's pin
+    // disappeared. The shelf is where a pinned app shows up, so it is the floor.
+    const { panel } = stage();
+    document.querySelector("[data-vendo-slot]")!.remove();
+    stubRects([
+      { selector: "[data-vendo-app-embed]", rect: { left: 400, top: 120, width: 600, height: 400 } },
+      { selector: ".fl-shelf", rect: { left: 40, top: 600, width: 300, height: 200 } },
+    ]);
+    shelf();
+    playPinCeremony({ appId: "app_1", slot: "hero", dismiss: () => panel.remove() });
+
+    await flushFrames();
+    expect(flight()!.keyframes[1]!.transform).toBe("translate(-360px, 480px) scale(0.5)");
+    flight()!.animation.onfinish!();
+    expect(ring()).toBeTruthy();
+  });
+
+  it("a mounted host slot still wins over the shelf", async () => {
+    stage();
+    stubRects([
+      { selector: "[data-vendo-app-embed]", rect: { left: 400, top: 120, width: 600, height: 400 } },
+      { selector: "[data-vendo-slot]", rect: { left: 40, top: 600, width: 300, height: 200 } },
+      { selector: ".fl-shelf", rect: { left: 900, top: 20, width: 120, height: 120 } },
+    ]);
+    shelf();
+    playPinCeremony({ appId: "app_1", slot: "hero" });
+
+    await flushFrames();
+    // The slot's geometry, not the shelf's — host slots keep priority.
+    expect(flight()!.keyframes[1]!.transform).toBe("translate(-360px, 480px) scale(0.5)");
+  });
+
+  it("prefers the live shelf over the day-zero ghost one, which holds no apps", async () => {
+    const { panel } = stage();
+    document.querySelector("[data-vendo-slot]")!.remove();
+    stubRects([
+      { selector: "[data-vendo-app-embed]", rect: { left: 400, top: 120, width: 600, height: 400 } },
+      // Matched in order: the ghost carries both classes.
+      { selector: ".fl-shelf--ghost", rect: { left: 900, top: 20, width: 120, height: 120 } },
+      { selector: ".fl-shelf", rect: { left: 40, top: 600, width: 300, height: 200 } },
+    ]);
+    shelf(true);
+    shelf();
+    playPinCeremony({ appId: "app_1", dismiss: () => panel.remove() });
+
+    await flushFrames();
+    expect(flight()!.keyframes[1]!.transform).toBe("translate(-360px, 480px) scale(0.5)");
+  });
+
   it("dismisses and strands nothing when the destination is not mounted", async () => {
     const { panel } = stage();
     document.querySelector("[data-vendo-slot]")!.remove();

--- a/packages/ui/test/chrome/pin-ceremony.test.tsx
+++ b/packages/ui/test/chrome/pin-ceremony.test.tsx
@@ -235,6 +235,36 @@ describe("the pin ceremony (Keystone graduates B8)", () => {
     expect(flight()!.keyframes[1]!.transform).toBe("translate(-360px, 480px) scale(0.5)");
   });
 
+  it("inks the ring with the ACCENT when it lands in our own chrome", async () => {
+    const { panel } = stage();
+    document.querySelector("[data-vendo-slot]")!.remove();
+    stubRects([
+      { selector: "[data-vendo-app-embed]", rect: { left: 400, top: 120, width: 600, height: 400 } },
+      { selector: ".fl-shelf", rect: { left: 40, top: 600, width: 300, height: 200 } },
+    ]);
+    const section = shelf();
+    section.style.color = "rgb(20, 21, 26)";
+    section.style.setProperty("--vendo-accent", "rgb(10, 125, 85)");
+    playPinCeremony({ appId: "app_1", slot: "hero", dismiss: () => panel.remove() });
+
+    await flushFrames();
+    flight()!.animation.onfinish!();
+    // The shelf's `color` is body text, so borrowing it drew a near-black box
+    // around the whole shelf — a debug outline where the payoff should be.
+    expect(ring()!.getAttribute("style")).toContain("rgb(10, 125, 85)");
+    expect(ring()!.getAttribute("style")).not.toContain("rgb(20, 21, 26)");
+  });
+
+  it("a HOST slot still lends the ring its own ink — a pin lands in the host's page", async () => {
+    stage();
+    (document.querySelector("[data-vendo-slot]") as HTMLElement).style.color = "rgb(180, 40, 40)";
+    playPinCeremony({ appId: "app_1", slot: "hero" });
+
+    await flushFrames();
+    flight()!.animation.onfinish!();
+    expect(ring()!.getAttribute("style")).toContain("rgb(180, 40, 40)");
+  });
+
   it("dismisses and strands nothing when the destination is not mounted", async () => {
     const { panel } = stage();
     document.querySelector("[data-vendo-slot]")!.remove();

--- a/packages/ui/test/chrome/pin-nudge.test.tsx
+++ b/packages/ui/test/chrome/pin-nudge.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+// §10.1 — the pin NUDGE, the mockup's one new visual beat (founder-approved,
+// 2026-08-04). When a build SETTLES and its app has not been pinned yet, the
+// pin affordance that already exists (`.fl-barpin`, both sites) draws a quiet
+// invitation; taking the pin resolves it to a settled accent state. An
+// invitation, never an action — the agent never pins.
+//
+// The state rides ONE attribute on the EXISTING button (`data-vendo-pin`), the
+// same shape `data-vendo-suggest` uses on the expand affordance: no new button,
+// no new component, no toast.
+import type { Thread } from "@vendoai/core";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
+import { VendoOverlay, VendoThread, type VendoThreadProps } from "../../src/chrome/index.js";
+import { ThreadPart } from "../../src/chrome/thread/parts.js";
+import { createWireServer } from "../wire-server.js";
+
+/** A `data-vendo-view` part, the shape the stream emits. */
+function view(appId: string, name: string, streaming = false) {
+  return {
+    type: "data-vendo-view",
+    data: {
+      appId,
+      payload: {
+        formatVersion: "vendo-genui/v2",
+        name,
+        root: "root",
+        nodes: [{ id: "root", component: "Text", props: { text: `${name} body` } }],
+        ...(streaming ? { streaming: true } : {}),
+      },
+    },
+  } as unknown as Parameters<typeof ThreadPart>[0]["part"];
+}
+
+const pinButton = () => screen.getByRole("button", { name: "Pin to dashboard" });
+const pinState = () => pinButton().getAttribute("data-vendo-pin");
+
+describe("the pin nudge on the in-thread card", () => {
+  let wire: Awaited<ReturnType<typeof createWireServer>>;
+  let client: VendoClient;
+
+  beforeEach(async () => {
+    wire = await createWireServer();
+    client = createVendoClient({ baseUrl: wire.url });
+  });
+
+  afterEach(async () => {
+    cleanup();
+    vi.restoreAllMocks();
+    await wire.close();
+  });
+
+  /** Every case uses its OWN app id: "pinned" is a module-scope fact (the pin
+   *  bus), so a shared id would carry one case's pin into the next. */
+  function card(appId: string, restored: boolean, streaming = false) {
+    render(
+      <VendoProvider client={client} onPin={() => {}}>
+        <ThreadPart part={view(appId, "Spending board", streaming)} partKey="p0" role="assistant" restored={restored} />
+      </VendoProvider>,
+    );
+  }
+
+  it("a build that just settled invites the pin", () => {
+    card("app_nudge_live", false);
+    expect(pinState()).toBe("invite");
+  });
+
+  it("a card still BUILDING has no pin at all, so the nudge can never join the build's one moving thing", () => {
+    card("app_nudge_building", false, true);
+    expect(screen.queryByRole("button", { name: "Pin to dashboard" })).toBeNull();
+  });
+
+  it("restored history does not nudge — the invitation belongs to the build that just landed", () => {
+    card("app_nudge_restored", true);
+    expect(pinState()).toBeNull();
+  });
+
+  it("taking the pin resolves the invitation to a settled state", () => {
+    card("app_nudge_taken", false);
+    fireEvent.click(pinButton());
+    expect(pinState()).toBe("pinned");
+  });
+
+  it("a pin taken once stays settled on the next mount of the same app (the pin bus)", () => {
+    card("app_nudge_remount", false);
+    fireEvent.click(pinButton());
+    cleanup();
+    card("app_nudge_remount", false);
+    expect(pinState()).toBe("pinned");
+  });
+});
+
+describe("the pin nudge on the split-view stage", () => {
+  let wire: Awaited<ReturnType<typeof createWireServer>>;
+  let client: VendoClient;
+
+  beforeEach(async () => {
+    wire = await createWireServer();
+    client = createVendoClient({ baseUrl: wire.url });
+  });
+
+  afterEach(async () => {
+    cleanup();
+    vi.restoreAllMocks();
+    await wire.close();
+  });
+
+  const NOW = "2026-08-04T12:00:00.000Z";
+
+  function threadClient(thread: Thread): VendoClient {
+    return {
+      ...client,
+      threads: {
+        ...client.threads,
+        get: async id => (id === thread.id ? thread : client.threads.get(id)),
+        list: async () => [{ id: thread.id, title: thread.subject, updatedAt: thread.updatedAt }],
+      },
+    };
+  }
+
+  it("the stage bar's pin carries the same invitation — the workspace is the mockup's own pin", async () => {
+    const thread = {
+      id: "thr_stage_nudge",
+      subject: "browser-user",
+      createdAt: NOW,
+      updatedAt: NOW,
+      messages: [{ id: "msg_view", role: "assistant", parts: [view("app_stage_nudge", "Goals board")] }],
+    } as unknown as Thread;
+    const ThreadWithEmbed = (props: VendoThreadProps) => <VendoThread {...props} threadId={thread.id} />;
+    render(
+      <VendoProvider client={threadClient(thread)} onPin={() => {}}>
+        <VendoOverlay defaultOpen thread={ThreadWithEmbed} />
+      </VendoProvider>,
+    );
+    await screen.findAllByText("Goals board body");
+    fireEvent.click(screen.getByRole("button", { name: "Expand workspace" }));
+    const stagePin = document.querySelector(".fl-stage-pin")!;
+    expect(stagePin.getAttribute("data-vendo-pin")).toBe("invite");
+  });
+});

--- a/packages/ui/test/chrome/slot-discovery.test.tsx
+++ b/packages/ui/test/chrome/slot-discovery.test.tsx
@@ -49,14 +49,18 @@ describe("Slot pin self-discovery (useSlotApp + VendoSlot)", () => {
     return <output>{isLoading ? "loading" : appId ?? "none"}</output>;
   }
 
-  it("resolves the latest app pinned to the slot", async () => {
-    vi.spyOn(client.apps, "list").mockResolvedValue([
-      pinnedApp(),
-      pinnedApp({ id: "app_2", name: "Newer remix" }),
+  // ⚠️ TEST EDIT (D5) — this case used a HAND-ORDERED `client.apps.list` mock, so
+  // it could not express the order the wire actually returns and `.at(-1)` (the
+  // OLDEST match) passed as "latest wins" for two months. It now goes over the
+  // real wire, whose /apps mirrors `runtime.list()`: newest first.
+  it("resolves the LATEST app placed in the slot, over the wire's real newest-first order", async () => {
+    wire.state.apps.push(
+      pinnedApp({ id: "app_older", name: "First remix" }),
+      pinnedApp({ id: "app_newer", name: "Newer remix" }),
       pinnedApp({ id: "app_other", placements: ["sidebar"] }),
-    ]);
+    );
     render(<VendoProvider client={client}><Probe slot="hero" /></VendoProvider>);
-    await waitFor(() => expect(screen.getByRole("status").textContent).toBe("app_2"));
+    await waitFor(() => expect(screen.getByRole("status").textContent).toBe("app_newer"));
   });
 
   it("reports no app when nothing is placed in the slot", async () => {

--- a/packages/ui/test/chrome/workspace-palette-slot.test.tsx
+++ b/packages/ui/test/chrome/workspace-palette-slot.test.tsx
@@ -79,8 +79,15 @@ describe("VendoPage, VendoPalette, and VendoSlot exports", () => {
       expect(set?.commands.some(command => command.kind === "open-app")).toBe(true);
     });
     const set = getConversationCommands()!;
-    set.select(set.commands.find(command => command.kind === "open-app")!);
-    expect(onCommand).toHaveBeenCalledWith(expect.objectContaining({ kind: "open-app", appId: "app_1" }));
+    // ⚠️ TEST EDIT — assert the command SELECTED is the command routed, rather
+    // than a hardcoded `app_1`. That id was only ever the first open-app command
+    // because the wire fixture served apps in insertion order; the real wire
+    // (and now the fixture) serves them newest-first, so the first is `app_auto`.
+    // The test's point is that selecting an open-app command routes it with its
+    // appId — not which app happens to sort first.
+    const openApp = set.commands.find(command => command.kind === "open-app")!;
+    set.select(openApp);
+    expect(onCommand).toHaveBeenCalledWith(expect.objectContaining({ kind: "open-app", appId: openApp.appId }));
     // Host-routed select closes the surface (close-on-select) — reopen for
     // the Escape/focus assertions below.
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "Vendo assistant" })).toBeNull());

--- a/packages/ui/test/wire-server.ts
+++ b/packages/ui/test/wire-server.ts
@@ -1083,7 +1083,14 @@ export async function createWireServer(options: WireServerOptions = {}) {
           componentName,
         });
       }
-      if (url.pathname === "/apps" && method === "GET") return json(response, state.apps);
+      // ⚠️ FIXTURE EDIT (D5) — NEWEST FIRST, which is what the real wire returns.
+      // `runtime.list()` sorts createdAt DESCENDING (packages/apps/src/runtime.ts,
+      // pinned by its "newest-first list" case in lifecycle.test.ts) and
+      // AppDocument carries no timestamp at all — so list ORDER is the only
+      // newness signal a client has. This fixture served insertion order, the
+      // exact opposite, which is how `.at(-1)` shipped in use-slot-app.ts under a
+      // "latest placement wins" comment while it resolved the OLDEST placed app.
+      if (url.pathname === "/apps" && method === "GET") return json(response, [...state.apps].reverse());
       if (url.pathname === "/apps" && method === "POST") {
         const prompt = (parsedBody as { prompt: string }).prompt;
         const created = app(`app_${state.apps.length + 1}`, prompt);


### PR DESCRIPTION
Track D5 — pin / placement polish. Three items, all inside machinery that already existed: no new button, no new component, no toast, no second surface.

## 1. The nudge — the mockup's one new visual beat

When a build **settles** and its pin has not been taken, the **existing** `.fl-barpin` (card bar and stage bar, both sites) draws a slow ring inviting the pin; taking it resolves to a settled accent state. One attribute on one button — `data-vendo-pin="invite" | "pinned"` — the same shape `data-vendo-suggest` already uses on the expand affordance.

- **How it knows "settled":** the card's existing `restored` prop (live turn vs rehydrated history) plus `!streaming`. A card still building has **no pin at all**, so the invitation can never join the build's one moving element (§8). Restored history stays quiet — the invitation belongs to the build that just landed.
- **How it knows "not yet placed":** the pin bus (`announcePin`), now retaining what it announced. **Not** a placements read: placements live on the app document, which no pin affordance holds, so knowing it for certain costs a list fetch per card to render one boolean. Honest cost of that choice: a pin made in an *earlier session* invites once more. Cheaper and more reversible than adding a fetch.
- Reduced motion keeps the accent colour and drops the ring.
- Copy untouched — the label is still "Pin to dashboard". It names the action and its destination; it says nothing about how the app looks.

## 2. The ceremony's floor — a pin that used to vanish

With no host slot resolvable (none mounted, or several and no name), `destinationOf` returned `null` **after** `dismiss()` had already fired: no flight, no ring, nothing. The user's pin visibly disappeared. It now lands in the **Apps shelf**, preferring the live `Your apps` section over the day-zero ghost one. A named slot that is mounted still wins — host slots keep priority. With no shelf either, the existing graceful no-op stands.

## 3. The `.at(-1)` bug — REAL, and fixed

`useSlotApp` read `data.filter(…).at(-1)` under a comment saying *"Latest placement wins"*. The wire lists apps **newest first** (`runtime.list` sorts `createdAt` descending; `AppDocument` carries no timestamp at all, so list order is the only newness signal a client has) — so `.at(-1)` resolved the **OLDEST** placed app. Now `.find(…)`.

Two things hid it, and both are fixed here:
- the reference host strips the slot off every other app the subject owns, so in practice only one app ever carries a placement;
- `slot-discovery.test.tsx` mocked `apps.list` with a **hand-ordered array**, and the wire fixture served **insertion order** — the exact opposite of the real wire. The test could not express the bug.

`remixable.tsx` is the mirror image: its `.at(-1)` is **deliberate** — it converges on the same winner the server's fork-pin dedupe picks ("the OLDEST matching row, so every dedupe path converges", `runtime.ts`). Behaviour unchanged; only its comment was wrong, and it now says so.

## Evidence

Browser proof, real Chromium, production-built harness — `pnpm exec playwright test e2e/pin-nudge.spec.ts` (2 passed), and the smoke pack re-run alongside it (17 passed) to prove §8's "a build animates exactly one thing" still holds with an infinite animation now living on that bar.

Screenshots + GIF (local artifacts, `e2e/screenshots/` is gitignored; regenerate with the command above):

| what | file |
|---|---|
| the settled build, nudge on the pin | `packages/ui/e2e/screenshots/pin-nudge-invite.png` |
| the pulse, 6 frames of the 2.4s cycle | `packages/ui/e2e/screenshots/pin-nudge-pulse-strip.png` · `pin-nudge-pulse.gif` |
| the ring landing on the Apps shelf, panel already gone | `packages/ui/e2e/screenshots/pin-ring-on-shelf.png` |
| the shelf holding the pinned app | `packages/ui/e2e/screenshots/pin-shelf-holds-app.png` |
| the settled state on reopen | `packages/ui/e2e/screenshots/pin-settled.png` · `pin-settled-bar.png` |

A still cannot show a pulse, so the spec seeks the animation itself and reads the computed ring at both ends of the cycle (`0px` → `5px`). Two things worth knowing for anyone photographing motion here: pausing a CSS animation and then rewriting `animation-delay` does **not** re-seek in Chromium — it silently photographs the resting frame twice — and the ceremony's 300ms flight + 180ms ring needs CDP `Animation.setPlaybackRate` to be caught at all.

## Test edits, declared

- `test/chrome/slot-discovery.test.tsx` — replaced the hand-ordered `apps.list` mock with a real wire round trip and renamed the case. The mock was the reason `.at(-1)` passed as "latest wins" for two months.
- `test/wire-server.ts` — `GET /apps` now serves **newest first**, mirroring `runtime.list()`. It served insertion order, the exact opposite of the real wire. This is the fixture-is-a-mirror lesson in `CLAUDE.md`, applied.

No acceptance criterion was weakened. Every new assertion was watched failing first, including the motion one (flattening the keyframe reddened it: `rest … 0px → peak … 0px`).

## What this consolidates

- Two `.at(-1)` reads that disagreed about their own intent → one is fixed, one is documented as deliberate. No more "latest wins" that means oldest.
- One silent no-op path deleted: the ceremony now always has a destination when a shelf is on screen.
- One mock deleted from `slot-discovery.test.tsx` (replaced by the real wire) and one fixture lie removed from `wire-server.ts`.
- No new concepts: one attribute, one keyframe, one 8-line hook on the existing pin bus.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a quiet pin invite when a build settles, makes the pin land visibly (host slot first, Apps shelf fallback), and correctly picks the newest placed app. The settle ring now blooms in the accent on our chrome, and the Apps shelf updates on pin so the app appears without a reload.

- **New Features**
  - Quiet pin nudge on the card and stage bars via `data-vendo-pin="invite" | "pinned"`; respects reduced motion.
  - Exported `usePinNudge` from `@vendoai/ui/chrome` for eject surfaces.

- **Bug Fixes**
  - Slot discovery now selects the latest placement from the newest-first app list; tests and the wire fixture mirror backend order.
  - Pin ceremony no longer disappears without a resolvable slot; it lands on the Apps shelf (prefers live “Your apps”). Host slots still win.
  - Settle ring fixed: it blooms in the accent on our chrome; host slots continue to lend their own color and keep a crisp hairline.
  - The Apps shelf refreshes on pin via a shared `useRefreshOnPin` hook, so the flight lands in a shelf that already has the app.
  - Remember a taken pin in-session so remounts don’t re-invite.
  - Palette open-app routing test no longer depends on app order.

<sup>Written for commit ec96e2a052df82aa1fa781d0a4314cb726842d07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

