### PR TITLE
UI-gen A2: the builder's references reach the box disk (§4.4 loadout 2&3)

### DIFF
--- a/packages/harnesses/src/claude-code/claude-code.test.ts
+++ b/packages/harnesses/src/claude-code/claude-code.test.ts
@@ -1466,3 +1466,60 @@ describe("stop is still the only thing that cancels — steering never does", ()
     expect(sandbox.boxes[0]!.interrupted).toBe(false);
   });
 });
+
+/**
+ * §4.4's loadout, items 2 and 3: the builder's two REFERENCES, on disk, where the
+ * `building-apps` skill tells it to look.
+ *
+ * Both already exist and are already generated — `hostComponentFiles(catalog)`
+ * writes `/host/components/<Name>.md` and `buildingAppsSkill.files` carries
+ * `references/format.md`, which is `kitPrompt()`'s output, not a hand-written
+ * second copy. What nothing proved is the HOP: that the projection composition
+ * assembles actually reaches the machine's disk, at a path the skill's own
+ * workspace-relative instructions resolve against.
+ *
+ * That is precisely the producer/consumer seam this repo shipped four times green
+ * and dead, so it is tested through the REAL box door with nothing stubbed on
+ * either side: a real checkout, a real materialize, a real in-box walk.
+ */
+describe("the builder's references reach the box's disk (§4.4 loadout)", () => {
+  /** Exactly what `hostSkillFiles` + `hostComponentFiles` project, in shape. */
+  const HOST_FILES = {
+    "/host/components/DataTable.md": "# DataTable\n\nRows of things.\n\n## Props\n\n```json\n{}\n```\n",
+    "/host/skills/building-apps/SKILL.md": "---\nname: building-apps\ndescription: Build an app.\n---\n\nbody\n",
+    "/host/skills/building-apps/references/format.md": "# The .vendo format\n\n<App>…</App>\n",
+  };
+
+  test("the component reference and the format reference are both readable in the box", async () => {
+    const seen: Record<string, string | undefined> = {};
+    const sandbox = fakeSandbox(async (box) => {
+      // The skill body sends the builder to `host/components/` and
+      // `host/skills/building-apps/references/format.md`, RELATIVE to its cwd.
+      // The box's cwd is the workspace root, so these are the resolved paths.
+      for (const path of Object.keys(HOST_FILES)) seen[path] = box.read(path);
+    });
+    const { turn } = makeTurn({ files: { ...HOST_FILES, "/user/apps/app_1/app.vendo": "<App/>" } });
+    await drain(claudeCode({ sandbox }), turn);
+
+    expect(seen).toEqual(HOST_FILES);
+  });
+
+  // "the references are never carried home" is NOT tested here on purpose:
+  // `/user/scratch never leaves the box, and /host is never written back` above
+  // already pins it through the same real door, and a second copy of it would be
+  // a test that has to be kept in step with nothing.
+
+  test("the /host mount IS the SDK plugin root — one skills mechanism, not two", async () => {
+    let pluginRoot: string | undefined;
+    const sandbox = fakeSandbox(async (box) => { pluginRoot = box.read("/host/skills/building-apps/SKILL.md"); });
+    const { turn } = makeTurn({
+      files: HOST_FILES,
+      skills: [{ name: "building-apps", description: "Build an app." }],
+    });
+    await drain(claudeCode({ sandbox }), turn);
+
+    // The plugin path the driver hands the SDK and the mount the skill file lands
+    // on are the same directory, which is why no projection or copy exists.
+    expect(pluginRoot).toBe(HOST_FILES["/host/skills/building-apps/SKILL.md"]);
+  });
+});


### PR DESCRIPTION
The A2 builder work reduced to what is genuinely unique after #815.

## Why this shrank to one test

#815 (the checks-floor relocation) shipped the canonical validate-must-pass gate — `packages/harnesses/src/validate-gate.ts` (`validateWrittenApps` / `repairInstruction`), wired into the claude-code loop. It calls `validate` with `{ document }`, which is the correct form: a file that failed has no store row (the seam won't author it), so an `{ appId }` gate would 404 on exactly the case the gate exists for.

This PR originally carried a second validate gate (`done.ts`, the `{ appId }` form), its loop wiring, and a composed-test fix. All three duplicate what #815 already landed — main already reads `expect(host.calls).toHaveLength(2)` with the same tool-shape-probe explanation. Landing them would have put **two** validate gates in the tree, the §0 violation this project exists to prevent. They are dropped.

## What remains, and why it is worth landing

The §4.4 loadout has four items. #815 covers item 4 (validate). Items 2 and 3 — the **host component reference** and the **format reference** reaching the box's disk — were never proven. Both already exist and are already generated (`hostComponentFiles(catalog)` → `/host/components/<Name>.md`; `buildingAppsSkill.files` → `references/format.md`, which is `kitPrompt()`'s output, not a second hand-written copy). What nothing proved is the HOP: that the projection composition assembles actually reaches the machine's disk, at the workspace-relative paths the skill body sends the builder to.

That is exactly the producer/consumer seam this repo shipped four times green and dead, so it is tested through the **real box door** — a real checkout, a real materialize, a real in-box read, nothing stubbed on either side. Proven able to fail: stubbing the in-box read turns it red.

- 1 file, +57/−0. No production change. No second gate. `dependency-guard` green (18 packages).

## Named fast-follow (not this PR)

The §4.5 escalation receiving end — continuing a build from a `plan.vendo` that landed with no `app.vendo` — is a real gap main lacks. It belongs as a **plan-only sibling to #815's `validateWrittenApps`**, built on the canonical gate and coordinated with A1 — never a parallel second gate. Logged for the fast-follow list.

Consequence, accepted and on the record: with the escalation receiving end deferred, app-building ships tonight via **direct** request (`vendo_make` "build me X" → the builder builds it), not via auto-escalation from a screen. The capability ships; the screen→build auto-routing is the follow-up.
