### PR TITLE
feat(harnesses,apps,vendo): the code a box writes lands in the row, so the box is disposable

### DIFF
--- a/.changeset/app-source-reaches-the-store.md
+++ b/.changeset/app-source-reaches-the-store.md
@@ -36,3 +36,22 @@ file-read method at all), and the new seam test deletes an app's snapshot, prove
 never held its files — byte for byte, including a file past the inline cap so the
 blob-spill leg is proven too. `trigger`, `placements`, grants and the app's id all
 ride through untouched: a commit is not a generation.
+
+Two things that ride along, because this PR is `commitApp`'s first real caller and
+both only become reachable with one:
+
+- **`commitSource` is a new authorization surface, so it is tested hostilely.** The
+  appId it writes to is derived from the COMMITTED PATHS, and a caller may write
+  anything under their own `/user` mount — including another person's app
+  directory. Three cases are now pinned: a foreign caller is refused and the
+  refusal is AUDIBLE rather than a silent skip; an org-owned app resolves to its
+  ORG address even when the caller's personal mount is writable too; and a commit
+  naming a stranger's app alongside the caller's own lands nothing on the
+  stranger's while still landing the caller's. All three pass against the gates
+  Phase 0 already put in — these document them, they do not add them.
+- **"Would not read" is no longer treated as "was deleted."** `commitApp` decided
+  deletions by whether the read-back threw, and for a spilled file that read is a
+  live fetch from the files adapter — so a blob store having a bad minute looked
+  exactly like a deletion and the entry was dropped. Now a path that still EXISTS
+  but will not read keeps its stored entry and says so loudly; only a confirmed
+  absence is a deletion. Per path, so the rest of the commit still lands.

--- a/.changeset/app-source-reaches-the-store.md
+++ b/.changeset/app-source-reaches-the-store.md
@@ -1,0 +1,38 @@
+---
+"@vendoai/apps": minor
+"@vendoai/harnesses": minor
+"@vendoai/vendo": minor
+---
+
+An app's code reaches the store, so the box is disposable.
+
+`AppDocument.source` and the `checkoutApp`/`commitApp` seam landed with the
+contract but with ZERO production callers: every build still persisted code only
+into the sandbox snapshot behind `machine.snapshotRef`, so losing a snapshot lost
+the customer's app. This wires the commit half in.
+
+- `RenderSeamOptions.commitSource` is the sibling of `authoredApp` on the SAME
+  interception point. `commit()` is the store-write moment, and the reason is the
+  one already stated in `render-seam.ts`: the sandbox sync-back path commits
+  without ever calling `writeFile` on this façade, so a builder working inside a
+  box reaches the store here and nowhere else. It runs once per APP a commit
+  touched, with `CommitResult.changed` verbatim; a `conflict` result persists
+  nothing, because nothing landed.
+- `AppsRuntime.commitSource` is the store half, binding `commitApp` to the app
+  row's ownership (§9.7 — the address comes from the owner, never from which
+  mount happens to be writable), its compare-and-swap update, and — new —
+  `AppsConfig.files`, the SAME `FilesAdapter` the workspace rows spill to.
+- The `HOT_PATH` regex became one `APP_PATH` regex with the filename as a tail,
+  so "which app is this path in?" has one answer for the hot paths and the source
+  tree alike. No second path reader.
+- Source persistence can never fail the commit it rides on, exactly as a view
+  cannot — but a silently dropped source file is a lost app, so a failure is
+  logged loudly rather than swallowed.
+
+`machine.snapshotRef` is now a cache in fact and not only in the doc comment: the
+audit found no reader of it anywhere that recovers source (`SandboxMachine` has no
+file-read method at all), and the new seam test deletes an app's snapshot, proves
+`resume` fails, and rebuilds the app from its row alone into a store that has
+never held its files — byte for byte, including a file past the inline cap so the
+blob-spill leg is proven too. `trigger`, `placements`, grants and the app's id all
+ride through untouched: a commit is not a generation.

--- a/packages/apps/src/app-source.ts
+++ b/packages/apps/src/app-source.ts
@@ -33,6 +33,7 @@ import {
   WORKSPACE_INLINE_MAX_BYTES,
   appRootPath,
   appSourceFileSchema,
+  safeErrorMessage,
   sha256Hex,
   type AppDocument,
   type AppId,
@@ -235,8 +236,10 @@ export async function checkoutApp(
  * instead of it. Paths outside this app, and the two hot files, are ignored: they
  * belong to someone else.
  *
- * A path in `changed` that no longer reads is a deletion, and drops out of
- * `source`. Nothing else about the document is touched.
+ * A path in `changed` that no longer EXISTS is a deletion, and drops out of
+ * `source`. A path that is still there and merely would not READ is a fault, and
+ * keeps its stored entry — stale beats gone. Nothing else about the document is
+ * touched.
  */
 export async function commitApp(
   appId: AppId,
@@ -259,7 +262,27 @@ export async function commitApp(
     let text: string;
     try {
       text = await workspace.readFile(`${prefix}${path}`);
-    } catch {
+    } catch (error) {
+      // "Would not read" is not "was deleted" (coordinator ruling 2026-08-05, once
+      // this seam had a real caller). For a spilled file the read-back is a LIVE
+      // FETCH from the files adapter, so a blob store having a bad minute used to
+      // look exactly like a deletion and the entry was dropped — a lost source file,
+      // which is the one outcome "the row is the truth" cannot survive.
+      //
+      // `exists()` is the discriminator, and the thrown error deliberately is not:
+      // the façade raises the same POSIX-shaped `ENOENT` for a deleted row as for a
+      // row whose bytes have gone missing, and carries no code to switch on.
+      // `exists()` answers from the row index and never touches the blob.
+      //
+      // Per PATH, not per commit: the other files in this commit still land, because
+      // getting source into the store is the whole point.
+      if (await workspace.exists(`${prefix}${path}`)) {
+        console.error(
+          `[vendo] source file "${path}" of ${appId} is still there but would not read back;`
+          + ` its stored entry is KEPT rather than dropped — ${safeErrorMessage(error)}`,
+        );
+        continue;
+      }
       removed.push(path);
       continue;
     }

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -16,6 +16,7 @@ import {
   type AppGrantRecord,
   type AppId,
   type AppPlan,
+  type FilesAdapter,
   type Guard,
   type Membership,
   type Principal,
@@ -42,10 +43,12 @@ import {
   type VendoTheme,
   type VendoRecord,
   type WireCompileResult,
+  type WorkspaceFs,
 } from "@vendoai/core";
 import type { LanguageModel } from "ai";
 import { createAgentTools } from "./agent-tools.js";
 import { createAppData } from "./app-data.js";
+import { commitApp } from "./app-source.js";
 import { appLifecycleEvent } from "./audit.js";
 import { createAppCaller } from "./call.js";
 import { createParkedActions } from "./parked-action.js";
@@ -242,6 +245,16 @@ export interface AppsConfig {
    * first away run's ungranted step parks the normal approval card.
    */
   armAutomation?: (appId: AppId, ctx: RunContext) => Promise<{ enabled: boolean; missing: ApprovalRequest[] }>;
+  /**
+   * Contract §3.2 — the workspace's OWN blob seam, for source past
+   * {@link WORKSPACE_INLINE_MAX_BYTES}. The SAME `FilesAdapter` the workspace rows
+   * spill to (the umbrella's `selectFiles`), never a second spill mechanism: a
+   * source file and a workspace file are the same bytes in two projections.
+   *
+   * Unset, `commitSource` is inline-only and an oversized file is refused LOUDLY
+   * rather than dropped — a silently missing source file is a lost app.
+   */
+  files?: FilesAdapter;
   model?: LanguageModel;
   /** The fast fill tier: `model` is the no-think switch (a thinking-disabled
    *  model instance) the group workers run on while the brain keeps `model`. */
@@ -689,6 +702,29 @@ export interface AppsRuntime {
     input: { appId: AppId; compiled: WireCompileResult },
     ctx: RunContext,
   ): Promise<AuthoredAppResult>;
+  /**
+   * Contract §3.2/§2.2 — the app's own SOURCE, landed in its row.
+   *
+   * The sibling of {@link AppsRuntime.authored}, on the same interception point and
+   * with the same one caller: the render seam's `commit()` proxy. `changed` is
+   * `CommitResult.changed` verbatim, and this is the store half of it —
+   * `commitApp` diffs the paths inside THIS app's directory back into
+   * `doc.source`, leaving everything else in the document (`trigger` above all)
+   * untouched. A commit is not a generation.
+   *
+   * This exists because `machine.snapshotRef` was an app's only home: the box's
+   * writes reach the store through the workspace façade and nowhere else, so this
+   * is where the row becomes the truth. Without it, losing a snapshot loses the
+   * customer's app.
+   *
+   * `workspace` is passed in rather than held: this block never owns a workspace
+   * (§3.5 — a sandboxed harness holds a workspace and never a store), and the
+   * caller is the one with the façade whose commit just landed.
+   */
+  commitSource(
+    input: { appId: AppId; changed: readonly string[]; workspace: WorkspaceFs },
+    ctx: RunContext,
+  ): Promise<void>;
   /** Speed lane — best-effort page-open warm-up of the generation model(s)
    *  (full + paint), so the first create reuses a live connection. Safe to
    *  call on surface mount; never throws. */
@@ -2698,6 +2734,26 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       queries.update(asTree(document.tree));
       const data = await queries.complete();
       return { data, ...(queries.dataUnavailable() ? { dataUnavailable: true as const } : {}) };
+    },
+
+    async commitSource(input, ctx) {
+      await commitApp(input.appId, input.changed, input.workspace, ctx, {
+        requireOwned,
+        update: (appId, mutate) => updateAppDocument(appId, mutate),
+        // §9.7 — the app's ADDRESS comes from its OWNER, and the row's subject is
+        // the authoritative answer (§9.5: a promoted app's row subject IS the org
+        // id, verbatim). Read here, never remembered: permission cannot choose an
+        // address, because an org app's editor can usually write their own `/user`
+        // mount too.
+        ownerOf: async (appId) => {
+          const subject = (await apps.get(appId))?.refs?.subject;
+          if (subject === undefined) {
+            throw new VendoError("not-found", `${appId} has no row to hold its source`);
+          }
+          return subject;
+        },
+        ...(config.files === undefined ? {} : { blobs: config.files }),
+      });
     },
 
     async get(appId, ctx) {

--- a/packages/harnesses/src/render-seam.test.ts
+++ b/packages/harnesses/src/render-seam.test.ts
@@ -504,6 +504,157 @@ describe("saves that are not hot paths", () => {
   });
 });
 
+/**
+ * Contract §2.2/§3.2 — the SAME interception point, for the app's own source.
+ *
+ * `commit()` is the store-write moment for source exactly as it is for a view, and
+ * for the extra reason stated in this file's header: the sandbox sync-back path
+ * commits without ever calling `writeFile` on this façade, so a builder working in
+ * a box reaches the store here and nowhere else. Until this seam existed
+ * `checkoutApp`/`commitApp` had zero production callers and every built app's code
+ * lived only inside its sandbox snapshot.
+ */
+describe("source persistence", () => {
+  const OTHER = "app_2";
+
+  function sourceSeam() {
+    const inner = testWorkspace();
+    const calls: Array<{ appId: string; changed: readonly string[]; sameWorkspace: boolean }> = [];
+    let fail: string | undefined;
+    const workspace = wrapWorkspaceForRender(inner, {
+      emit: () => undefined,
+      commitSource: async (input) => {
+        calls.push({
+          appId: input.appId,
+          changed: input.changed,
+          sameWorkspace: input.workspace === inner,
+        });
+        if (fail !== undefined) throw new Error(fail);
+      },
+    });
+    return { workspace, inner, calls, failWith: (message: string) => { fail = message; } };
+  }
+
+  it("runs for a commit that lands an app's source file", async () => {
+    const { workspace, calls } = sourceSeam();
+    await workspace.writeFile(`/user/apps/${APP}/src/App.tsx`, "export const App = () => null;\n");
+    await workspace.commit();
+    expect(calls).toEqual([{
+      appId: APP,
+      changed: [`/user/apps/${APP}/src/App.tsx`],
+      sameWorkspace: true,
+    }]);
+  });
+
+  it("hands over CommitResult.changed verbatim — the paths that actually landed", async () => {
+    const { workspace, calls } = sourceSeam();
+    await workspace.writeFile(`/user/apps/${APP}/src/App.tsx`, "a\n");
+    await workspace.writeFile(`/user/apps/${APP}/vendo.json`, "{}\n");
+    await workspace.writeFile("/user/memory/notes.md", "mine\n");
+    const result = await workspace.commit();
+    expect(result.status).toBe("ok");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.changed).toEqual(result.status === "ok" ? result.changed : []);
+  });
+
+  it("runs once per APP when one commit touches several", async () => {
+    const { workspace, calls } = sourceSeam();
+    await workspace.writeFile(`/user/apps/${APP}/src/App.tsx`, "one\n");
+    await workspace.writeFile(`/orgs/maple/apps/${OTHER}/src/App.tsx`, "two\n");
+    await workspace.writeFile(`/user/apps/${APP}/vendo.json`, "{}\n");
+    await workspace.commit();
+    expect(calls.map((call) => call.appId).sort()).toEqual([APP, OTHER]);
+  });
+
+  it("reads the app out of BOTH mounts — a team app's source is source too", async () => {
+    const { workspace, calls } = sourceSeam();
+    await workspace.writeFile(`/orgs/maple/apps/${OTHER}/src/App.tsx`, "team\n");
+    await workspace.commit();
+    expect(calls.map((call) => call.appId)).toEqual([OTHER]);
+  });
+
+  it("does not run for a commit that landed nothing — a conflict is not a write", async () => {
+    const { workspace, inner, calls } = sourceSeam();
+    await workspace.writeFile(`/user/apps/${APP}/src/App.tsx`, "a\n");
+    inner.conflictOn = [`/user/apps/${APP}/src/App.tsx`];
+    expect(await workspace.commit()).toEqual({
+      status: "conflict",
+      paths: [`/user/apps/${APP}/src/App.tsx`],
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("does not run for paths that are not inside an app's directory", async () => {
+    const { workspace, calls } = sourceSeam();
+    await workspace.writeFile("/user/memory/notes.md", "mine\n");
+    await workspace.writeFile("/user/files/report.pdf", "pdf\n");
+    await workspace.writeFile("/user/apps/nope/src/App.tsx", "not an appId\n");
+    await workspace.commit();
+    expect(calls).toHaveLength(0);
+  });
+
+  /**
+   * The seam's standing rule, inherited: "a view is a courtesy on top of a landed
+   * commit; it can never fail one." Source persistence gets the same treatment —
+   * but unlike a view, a silently dropped source file is a LOST APP, so the
+   * failure is loud.
+   */
+  it("never fails the commit it rides on, and says so loudly", async () => {
+    const { workspace, inner, calls, failWith } = sourceSeam();
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    failWith("the store said no");
+    await workspace.writeFile(`/user/apps/${APP}/src/App.tsx`, "a\n");
+    await expect(workspace.commit()).resolves.toEqual({
+      status: "ok",
+      changed: [`/user/apps/${APP}/src/App.tsx`],
+    });
+    expect(calls).toHaveLength(1);
+    // The commit itself landed, exactly once.
+    expect(inner.commits).toHaveLength(1);
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining("source did not reach the store"),
+      expect.objectContaining({ appId: APP, error: "the store said no" }),
+    );
+    spy.mockRestore();
+  });
+
+  it("unwired, a commit behaves exactly as it did — the snapshot stays the only home", async () => {
+    const inner = testWorkspace();
+    const workspace = wrapWorkspaceForRender(inner, { emit: () => undefined });
+    await workspace.writeFile(`/user/apps/${APP}/src/App.tsx`, "a\n");
+    await expect(workspace.commit()).resolves.toEqual({
+      status: "ok",
+      changed: [`/user/apps/${APP}/src/App.tsx`],
+    });
+  });
+
+  /**
+   * Views go FIRST for two reasons. §1.6 is a promise about seconds, and — the
+   * load-bearing one — an `app.vendo` commit is the moment a files-first app
+   * BECOMES an app: the `authoredApp` seam is what upserts its row. Persisting
+   * source before that would look for a row that does not exist yet.
+   */
+  it("runs AFTER the view — the app half is what makes the row it writes to", async () => {
+    const inner = testWorkspace();
+    const order: string[] = [];
+    const workspace = wrapWorkspaceForRender(inner, {
+      emit: () => order.push("view"),
+      authoredApp: async () => {
+        order.push("authored");
+        return { data: {} };
+      },
+      commitSource: async () => {
+        order.push("source");
+      },
+    });
+    await workspace.writeFile(APP_VENDO, GOOD_APP);
+    await workspace.writeFile(`/user/apps/${APP}/src/App.tsx`, "a\n");
+    await workspace.commit();
+    expect(order.at(-1)).toBe("source");
+    expect(order).toContain("authored");
+  });
+});
+
 describe("the wrapper", () => {
   it("leaves every other filesystem operation untouched", async () => {
     const { workspace } = seam({ "/user/memory/a.md": "alpha" });

--- a/packages/harnesses/src/render-seam.ts
+++ b/packages/harnesses/src/render-seam.ts
@@ -22,6 +22,12 @@
  * names exactly the paths that reached the store. Hooking the write instead would
  * emit views for content that never landed, and would miss the sandbox sync-back
  * path, which commits without ever calling `writeFile` on this façade.
+ *
+ * That last clause is why the app's own SOURCE is persisted from here too
+ * (contract §2.2/§3.2, the `commitSource` seam): a builder working inside a box
+ * reaches the store through this same `commit()`, so this is the one place that
+ * sees its files at all. Before it, an app's code lived only in the sandbox
+ * snapshot behind `machine.snapshotRef` — lose the snapshot, lose the app.
  */
 import {
   compilePlan,
@@ -48,12 +54,23 @@ import { assembleTree, stripServerAuthoritativeFields } from "@vendoai/apps/inte
 /** §1.6 — the two files that sync mid-turn. Everything else waits for turn end. */
 export const HOT_PATH_FILES = ["app.vendo", "plan.vendo"] as const;
 
-/** §3.1, frozen: `/user/apps/<appId>/app.vendo` and — since wave 3 (§9.7) —
- *  `/orgs/<orgId>/apps/<appId>/app.vendo`. `appId` is the store's app id
- *  verbatim in BOTH, which is exactly why one regex can read either: a path's
- *  meaning never depends on who wrote it, so a promoted app's hot paths must
- *  keep painting the skeleton mid-turn like a personal one's. */
-const HOT_PATH = /^\/(?:user|orgs\/[^/]+)\/apps\/(app_[^/]+)\/(app\.vendo|plan\.vendo)$/;
+/** §3.1, frozen: `/user/apps/<appId>/**` and — since wave 3 (§9.7) —
+ *  `/orgs/<orgId>/apps/<appId>/**`. `appId` is the store's app id verbatim in
+ *  BOTH, which is exactly why one regex can read either: a path's meaning never
+ *  depends on who wrote it, so a promoted app's hot paths must keep painting the
+ *  skeleton mid-turn like a personal one's.
+ *
+ *  ONE regex for the whole layout, with the file left as a tail: the hot paths and
+ *  the source tree are the same two addresses with different names hanging off
+ *  them, and two regexes would be two answers to "which app is this?". */
+const APP_PATH = /^\/(?:user|orgs\/[^/]+)\/apps\/(app_[^/]+)\/(.+)$/;
+
+/** The appId a write ANYWHERE inside an app's directory belongs to, hot path or
+ *  not — what source persistence asks of a commit's changed list. */
+const appPathAppId = (path: string): AppId | undefined => {
+  const match = APP_PATH.exec(path);
+  return match === null ? undefined : (match[1] as AppId);
+};
 
 /**
  * §3.5's hot paths as WATCH SHAPES — what a machine's mid-turn collect asks for,
@@ -71,16 +88,15 @@ const HOT_PATH = /^\/(?:user|orgs\/[^/]+)\/apps\/(app_[^/]+)\/(app\.vendo|plan\.
 export const HOT_PATH_WATCH: readonly string[] = ["/user/apps/*", "/orgs/*/apps/*"]
   .flatMap((prefix) => HOT_PATH_FILES.map((name) => `${prefix}/${name}`));
 
+const hotPathFile = (path: string): (typeof HOT_PATH_FILES)[number] | undefined => {
+  const tail = APP_PATH.exec(path)?.[2];
+  return HOT_PATH_FILES.find((name) => name === tail);
+};
+
 /** The appId a hot-path write belongs to, or undefined if this is not one. */
 export function hotPathAppId(path: string): AppId | undefined {
-  const match = HOT_PATH.exec(path);
-  return match === null ? undefined : (match[1] as AppId);
+  return hotPathFile(path) === undefined ? undefined : appPathAppId(path);
 }
-
-const hotPathFile = (path: string): (typeof HOT_PATH_FILES)[number] | undefined => {
-  const match = HOT_PATH.exec(path);
-  return match === null ? undefined : (match[2] as (typeof HOT_PATH_FILES)[number]);
-};
 
 /**
  * Did this content parse into something worth putting on screen?
@@ -124,6 +140,34 @@ export interface RenderSeamOptions {
     data: Record<string, Json>;
     dataUnavailable?: boolean;
   } | undefined>;
+  /**
+   * Contract §2.2/§3.2 — persist the app's own SOURCE for a commit that landed.
+   *
+   * The same interception point as a view, for the same reason plus one: the
+   * sandbox sync-back path (`materialize.ts`) commits without ever calling
+   * `writeFile` on this façade, so a builder working inside a box reaches the
+   * store HERE and nowhere else. Hooking the write instead would persist content
+   * that never landed and miss the box entirely.
+   *
+   * `changed` is `CommitResult.changed` verbatim — the paths that actually reached
+   * the store. Called once per APP the commit touched, because `commitApp` is
+   * per-app and one commit can carry several; it does its own prefix filtering, so
+   * the whole list rides every call. `workspace` is the real façade underneath this
+   * wrapper, which is what the diff reads the landed bytes back through.
+   *
+   * Composition injects `AppsRuntime.commitSource` (see `packages/vendo/server.ts`),
+   * which binds `commitApp` to the app row's ownership, its compare-and-swap
+   * update, and the deployment's files adapter for blob spill.
+   *
+   * UNWIRED, source is not persisted: `machine.snapshotRef` stays the only home an
+   * app's code has, which is exactly today's behaviour — so no host regresses, and
+   * no host is protected either.
+   */
+  commitSource?: (input: {
+    appId: AppId;
+    changed: readonly string[];
+    workspace: WorkspaceFs;
+  }) => Promise<void>;
   /** The turn this seam is painting inside, stamped on every view it emits so a
    *  screen joins back to the exchange that made it. Absent outside a turn. */
   turnId?: TurnId;
@@ -291,6 +335,37 @@ export function wrapWorkspaceForRender(workspace: WorkspaceFs, options: RenderSe
     }
   };
 
+  /**
+   * Land the source of every app this commit touched — AFTER the views, for two
+   * reasons. §1.6 is a promise about seconds, and — the load-bearing one — an
+   * `app.vendo` commit is the moment a files-first app BECOMES an app: the
+   * `authoredApp` seam above is what upserts its row. Running source persistence
+   * first would look for a row that does not exist yet.
+   *
+   * It can never fail the commit either, for the same reason a view cannot. But
+   * unlike a view, a silently dropped source file is a LOST APP — the snapshot
+   * being the only other home is the whole problem this closes — so the failure is
+   * LOUD, in the same voice as the runtime's own commit failure.
+   */
+  const persistSource = async (changed: readonly string[]): Promise<void> => {
+    if (options.commitSource === undefined) return;
+    const apps = new Set<AppId>();
+    for (const path of changed) {
+      const appId = appPathAppId(path);
+      if (appId !== undefined) apps.add(appId);
+    }
+    for (const appId of apps) {
+      try {
+        await options.commitSource({ appId, changed, workspace });
+      } catch (error) {
+        console.error("[vendo] render seam: source did not reach the store", {
+          appId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  };
+
   return new Proxy(workspace, {
     // `receiver` is deliberately NOT forwarded to Reflect.get: a method read off
     // the proxy and then called would run with `this` === proxy, and any real
@@ -330,6 +405,7 @@ export function wrapWorkspaceForRender(workspace: WorkspaceFs, options: RenderSe
         for (const { path, appId } of plans) {
           if (!painted.has(appId)) await emitFor(path);
         }
+        await persistSource(result.changed);
         return result;
       };
     },

--- a/packages/vendo/src/app-rebuild.e2e.test.ts
+++ b/packages/vendo/src/app-rebuild.e2e.test.ts
@@ -47,7 +47,7 @@ import {
 import { createGuard } from "@vendoai/guard";
 import { wrapWorkspaceForRender } from "@vendoai/harnesses";
 import { appAccess, createStore, workspaceStore } from "@vendoai/store";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const cleanups: Array<() => Promise<void>> = [];
 afterEach(async () => {
@@ -57,6 +57,9 @@ afterEach(async () => {
 const principal: Principal = { kind: "user", subject: "user_rebuild" };
 const READER: Principal = { kind: "user", subject: "user_reader" };
 const APP = "app_rebuild_1" as AppId;
+/** Someone else's app, and the person who owns it. */
+const THEIRS = "app_rebuild_theirs" as AppId;
+const STRANGER = "user_stranger";
 const ORG = "maple";
 const MEMBERSHIP = { org: ORG, display: "Maple Bank", teams: ["support"], admin: true };
 const ctx: RunContext = { principal, venue: "chat", presence: "present", sessionId: "s_rebuild" };
@@ -80,22 +83,32 @@ const TRIGGER = {
 } as const;
 
 /** An in-memory `FilesAdapter` — the SAME seam the workspace rows spill to, which
- *  is the point: one adapter, two callers, no second spill mechanism. */
-function memoryBlobs(): FilesAdapter & { keys(): string[] } {
+ *  is the point: one adapter, two callers, no second spill mechanism.
+ *
+ *  `failRowReads` simulates the fault that makes deletion-by-failed-read
+ *  dangerous: a live blob store having a bad minute. It fails only `get`, and only
+ *  for the WORKSPACE row keys (`wsb_*`), because that is the fetch a read-back of a
+ *  spilled file actually makes. */
+function memoryBlobs(): FilesAdapter & { keys(): string[]; failRowReads: boolean } {
   const blobs = new Map<string, Uint8Array>();
-  return {
-    async put(key, bytes) {
+  const adapter = {
+    failRowReads: false,
+    async put(key: string, bytes: Uint8Array) {
       blobs.set(key, bytes);
     },
-    async get(key) {
+    async get(key: string) {
+      if (adapter.failRowReads && key.startsWith("wsb_")) {
+        throw new Error(`the blob store refused ${key}`);
+      }
       const bytes = blobs.get(key);
       return bytes === undefined ? undefined : { bytes };
     },
-    async delete(key) {
+    async delete(key: string) {
       blobs.delete(key);
     },
     keys: () => [...blobs.keys()],
   };
+  return adapter;
 }
 
 /**
@@ -365,5 +378,234 @@ describe.sequential("an app rebuilds from its row onto a fresh box, with its sna
     expect(result.status === "ok" && result.changed).toContain("/user/apps/app_no_such_row/src/App.tsx");
     // And the workspace still holds the file: the commit really did land.
     expect(await workspace.readFile(`/user/apps/app_no_such_row/src/App.tsx`)).toBe("orphan\n");
+  }, 120_000);
+});
+
+/**
+ * `commitSource` is a NEW AUTHORIZATION SURFACE, so it is tested hostilely rather
+ * than reasoned about — the lesson Phase 0 paid for three times over.
+ *
+ * The shape of the power: the render seam now writes to app ROWS on behalf of
+ * whoever committed, and the appId it writes to is derived FROM THE COMMITTED
+ * PATHS. A caller can write anything they like under their own `/user` mount,
+ * including `/user/apps/<somebody-else's-id>/`, and the façade will land it —
+ * `/user/**` is its subject's at every level. So the committed path is an
+ * ATTACKER-CONTROLLED input to an authorization decision, and the only thing
+ * standing between it and a cross-tenant write is `appDirectory`: the address comes
+ * from `ownerOf` (the row's subject) and `canCommit` is the gate over it.
+ *
+ * Every assertion below is about that gate holding, and about the refusal being
+ * AUDIBLE — because this path is deliberately non-fatal, a refusal that looked
+ * identical to "nothing to persist" would be the worst possible outcome.
+ */
+describe.sequential("committing source is an authorization surface", () => {
+  /** A stored app owned by someone else, with source already on it — so "untouched"
+   *  is a thing that can be asserted rather than an absence. */
+  const THEIR_SOURCE = "export const Theirs = () => null;\n";
+  async function seedTheirs(store: VendoStore): Promise<void> {
+    await store.records("vendo_apps").put({
+      id: THEIRS,
+      data: {
+        subject: STRANGER,
+        enabled: false,
+        doc: {
+          format: VENDO_APP_FORMAT,
+          id: THEIRS,
+          name: "Their private app",
+          source: {
+            "src/Theirs.tsx": {
+              hash: `sha256:${"0".repeat(64)}`,
+              bytes: THEIR_SOURCE.length,
+              text: THEIR_SOURCE,
+            },
+          },
+        },
+      },
+      refs: { subject: STRANGER },
+    });
+  }
+
+  const theirDoc = async (store: VendoStore): Promise<AppDocument> => {
+    const record = await store.records("vendo_apps").get(THEIRS);
+    if (record === null) throw new Error("their row vanished");
+    return appDocumentSchema.parse((record.data as { doc: unknown }).doc);
+  };
+
+  /**
+   * HOSTILE 1 — the foreign caller. Staging a file under another person's app in
+   * your OWN mount is a write the façade allows, and P0's third gate is what stops
+   * it becoming their app's source. The commit still lands (it is the caller's own
+   * mount, and persistence may never fail a commit), so the ONLY signal that
+   * anything was refused is the loud log — which is exactly why it is asserted.
+   */
+  it("refuses a commit against another person's app, out loud rather than silently", async () => {
+    const { store, open } = await harness();
+    await seedTheirs(store);
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const workspace = await open();
+    // The caller really can write here — this is why permission cannot be the thing
+    // that refuses, and why the refusal has to come from OWNERSHIP.
+    expect(await workspace.canCommit(`/user/apps/${THEIRS}/src/Mine.tsx`)).toBe(true);
+    await workspace.writeFile(`/user/apps/${THEIRS}/src/Mine.tsx`, "mine\n");
+    const result = await workspace.commit();
+    expect(result.status).toBe("ok");
+
+    // Their app is exactly as it was: one file, theirs, unchanged.
+    const doc = await theirDoc(store);
+    expect(Object.keys(doc.source ?? {})).toEqual(["src/Theirs.tsx"]);
+    expect(doc.source!["src/Theirs.tsx"]!.text).toBe(THEIR_SOURCE);
+
+    // And the refusal was AUDIBLE. A silent skip here would be indistinguishable
+    // from "there was nothing to persist", which is the failure mode being ruled out.
+    expect(spy).toHaveBeenCalledWith(
+      "[vendo] render seam: source did not reach the store",
+      expect.objectContaining({
+        appId: THEIRS,
+        error: expect.stringContaining("another person's workspace"),
+      }),
+    );
+    spy.mockRestore();
+  }, 120_000);
+
+  /**
+   * HOSTILE 2 — ambiguous ownership, the exact case P0's ownership-addressing gate
+   * was written for. An org-owned app whose editor can ALSO write their own `/user`
+   * mount: both addresses answer `canCommit` yes, so permission cannot choose
+   * between them. If the address came from permission, the projection would land in
+   * the personal mount and every org edit would be filtered out and SILENTLY
+   * DROPPED. So both are written in the SAME commit, and the row must take the org
+   * one.
+   */
+  it("resolves the ORG address when the personal mount is writable too", async () => {
+    const { store, apps, open } = await harness();
+    await seedApp(store, ORG);
+
+    const workspace = await open(orgCtx);
+    expect(await workspace.canCommit(`/user/apps/${APP}/src/App.tsx`)).toBe(true);
+    expect(await workspace.canCommit(`/orgs/${ORG}/apps/${APP}/src/App.tsx`)).toBe(true);
+
+    await workspace.writeFile(`/orgs/${ORG}/apps/${APP}/src/App.tsx`, "team\n");
+    // The decoy, at the same relative path in the caller's own mount. Both land in
+    // the workspace; only one of them is the app.
+    await workspace.writeFile(`/user/apps/${APP}/src/App.tsx`, "personal\n");
+    expect((await workspace.commit()).status).toBe("ok");
+
+    const doc = await apps.get(APP, orgCtx);
+    expect(Object.keys(doc!.source ?? {})).toEqual(["src/App.tsx"]);
+    expect(doc!.source!["src/App.tsx"]!.text).toBe("team\n");
+  }, 120_000);
+
+  /**
+   * HOSTILE 3 — the sharp one, and the reason this block exists. The appId is
+   * derived from the commit's changed paths, so ONE commit can name the caller's own
+   * app and a stranger's at the same time. The seam then calls `commitSource` for
+   * both. Nothing may land on the stranger's app — and, just as important, their
+   * refusal must not take the caller's own landed work down with it.
+   */
+  it("lands nothing on a foreign app named in the same commit, and still lands the caller's own", async () => {
+    const { store, apps, open } = await harness();
+    await seedApp(store);
+    await seedTheirs(store);
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const workspace = await open();
+    await workspace.writeFile(`/user/apps/${APP}/src/Mine.tsx`, "mine\n");
+    await workspace.writeFile(`/user/apps/${THEIRS}/src/Stolen.tsx`, "not yours\n");
+    const result = await workspace.commit();
+    expect(result.status).toBe("ok");
+    // Both paths really did reach the store — the attack is live, not hypothetical.
+    expect(result.status === "ok" && result.changed).toEqual(expect.arrayContaining([
+      `/user/apps/${APP}/src/Mine.tsx`,
+      `/user/apps/${THEIRS}/src/Stolen.tsx`,
+    ]));
+
+    // The caller's own app took its file.
+    const mine = await apps.get(APP, ctx);
+    expect(Object.keys(mine!.source ?? {})).toEqual(["src/Mine.tsx"]);
+
+    // The stranger's app took NOTHING. This is the cross-tenant write, refused.
+    const theirs = await theirDoc(store);
+    expect(Object.keys(theirs.source ?? {})).toEqual(["src/Theirs.tsx"]);
+    expect(theirs.source!["src/Theirs.tsx"]!.text).toBe(THEIR_SOURCE);
+
+    expect(spy).toHaveBeenCalledWith(
+      "[vendo] render seam: source did not reach the store",
+      expect.objectContaining({ appId: THEIRS }),
+    );
+    spy.mockRestore();
+  }, 120_000);
+});
+
+/**
+ * "Unreadable" and "deleted" are not the same fact — coordinator ruling,
+ * 2026-08-05, on freshly-merged `app-source.ts`.
+ *
+ * `commitApp` decided deletions by whether the read-back threw. For a spilled file
+ * that read is a LIVE FETCH from the files adapter, so a blob store having a bad
+ * minute looked exactly like "the user deleted this" and the entry was dropped from
+ * `doc.source`. With this PR making the row the app's only home, that is the lost
+ * app the whole change exists to prevent.
+ *
+ * The discriminator is `exists()`, not the error: it answers from the row index and
+ * never touches the blob. The thrown error CANNOT be the discriminator — the façade
+ * raises the same POSIX-shaped `ENOENT` for a deleted row as for a row whose bytes
+ * have gone missing (`workspace-rows.ts` `load()` returning undefined →
+ * `workspace-fs.ts` `bytesOf` → `enoent`), and it carries no code to switch on.
+ *
+ * Both directions are asserted. Survival alone would pass on code that simply never
+ * deletes anything.
+ */
+describe.sequential("a source file is never dropped because it merely would not read", () => {
+  const SMALL = "export const App = () => null;\n";
+
+  it("KEEPS the stored entry when the read-back FAILS, and says so", async () => {
+    const { store, apps, blobs, open } = await harness();
+    await seedApp(store);
+    const workspace = await open();
+
+    // v1 lands and spills, so its read-back is a real blob fetch.
+    const v1 = `// ${"a".repeat(WORKSPACE_INLINE_MAX_BYTES)}\n`;
+    await workspace.writeFile(`/user/apps/${APP}/src/big.ts`, v1);
+    expect((await workspace.commit()).status).toBe("ok");
+    const landed = (await apps.get(APP, ctx))!.source!["src/big.ts"]!;
+    expect(landed.blobRef).toBeDefined();
+
+    // Now the blob store starts refusing reads. v2 is a DIFFERENT length so the
+    // commit itself never needs the prior content — only the read-back does.
+    blobs.failRowReads = true;
+    const v2 = `// ${"b".repeat(WORKSPACE_INLINE_MAX_BYTES + 10)}\n`;
+    await workspace.writeFile(`/user/apps/${APP}/src/big.ts`, v2);
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const result = await workspace.commit();
+    expect(result.status).toBe("ok");
+
+    // The file is STILL in the row, still describing v1 — stale, and stale is the
+    // correct answer. What must never happen is the entry disappearing.
+    const after = (await apps.get(APP, ctx))!.source!;
+    expect(Object.keys(after)).toEqual(["src/big.ts"]);
+    expect(after["src/big.ts"]!.bytes).toBe(landed.bytes);
+    expect(after["src/big.ts"]!.hash).toBe(landed.hash);
+    // And it was audible, naming the path that did not make it.
+    expect(spy.mock.calls.flat().join(" ")).toContain("src/big.ts");
+    spy.mockRestore();
+  }, 120_000);
+
+  it("still drops an entry the user really DELETED", async () => {
+    const { store, apps, open } = await harness();
+    await seedApp(store);
+    const workspace = await open();
+
+    await workspace.writeFile(`/user/apps/${APP}/src/App.tsx`, SMALL);
+    await workspace.writeFile(`/user/apps/${APP}/vendo.json`, "{}\n");
+    expect((await workspace.commit()).status).toBe("ok");
+    expect(Object.keys((await apps.get(APP, ctx))!.source ?? {}).sort())
+      .toEqual(["src/App.tsx", "vendo.json"]);
+
+    // A real deletion: the row goes, so `exists()` answers false and the entry
+    // must go with it.
+    await workspace.rm(`/user/apps/${APP}/src/App.tsx`);
+    expect((await workspace.commit()).status).toBe("ok");
+    expect(Object.keys((await apps.get(APP, ctx))!.source ?? {})).toEqual(["vendo.json"]);
   }, 120_000);
 });

--- a/packages/vendo/src/app-rebuild.e2e.test.ts
+++ b/packages/vendo/src/app-rebuild.e2e.test.ts
@@ -1,0 +1,369 @@
+/**
+ * The rebuildability proof — contract §2.2/§2.3, Track B's done bar.
+ *
+ * "The code lives in your database like everything else, and the box is
+ * disposable." Before this, an app built in a box existed only inside the E2B
+ * snapshot behind `machine.snapshotRef`: lose the snapshot and the customer's app
+ * is gone, because the store never had it. `doc.source` demotes that ref to a
+ * CACHE — and the only way to know it really is one is to DELETE the snapshot and
+ * rebuild the app without it.
+ *
+ * So this is a seam test with no stub on either side (repo CLAUDE.md's testing
+ * law). Every piece is the shipped one:
+ *
+ *   - the real PGlite store, and the real `workspaceStore(store, { files })` façade
+ *   - the real `wrapWorkspaceForRender` commit interception, wired the way
+ *     `server.ts` wires it: `commitSource: (input) => apps.commitSource(input, ctx)`
+ *   - the real `createApps` runtime behind that verb, so ownership, the
+ *     compare-and-swap update and the blob spill are the production ones
+ *   - a fake `SandboxAdapter` whose snapshot is genuinely destroyed, so `resume`
+ *     genuinely fails and the test cannot pass on a snapshot that is still there
+ *
+ * The live-box half of the bar (a real E2B box, really re-served) belongs to the
+ * builder track; this half proves the STORAGE: what a rebuild has to read.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  checkoutApp,
+  createApps,
+  type AppSourceSeam,
+  type SandboxAdapter,
+  type SandboxMachine,
+} from "@vendoai/apps";
+import {
+  VENDO_APP_FORMAT,
+  WORKSPACE_INLINE_MAX_BYTES,
+  appDocumentSchema,
+  type AppDocument,
+  type AppId,
+  type FilesAdapter,
+  type Principal,
+  type RunContext,
+  type VendoStore,
+  type WorkspaceFs,
+} from "@vendoai/core";
+import { createGuard } from "@vendoai/guard";
+import { wrapWorkspaceForRender } from "@vendoai/harnesses";
+import { appAccess, createStore, workspaceStore } from "@vendoai/store";
+import { afterEach, describe, expect, it } from "vitest";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const principal: Principal = { kind: "user", subject: "user_rebuild" };
+const READER: Principal = { kind: "user", subject: "user_reader" };
+const APP = "app_rebuild_1" as AppId;
+const ORG = "maple";
+const MEMBERSHIP = { org: ORG, display: "Maple Bank", teams: ["support"], admin: true };
+const ctx: RunContext = { principal, venue: "chat", presence: "present", sessionId: "s_rebuild" };
+/** The same person, with the team they belong to asserted — §9.1's host org query,
+ *  which is what makes the org mount reachable and the app's address an org one. */
+const orgCtx: RunContext = { ...ctx, memberships: [MEMBERSHIP] };
+
+/** The app's files. `src/big.ts` is deliberately past the inline cap, so the
+ *  blob-spill leg is proven and not just the inline one — a rebuild that only ever
+ *  read `text` would come back with a hole exactly where the bundle is. */
+const SOURCE: Record<string, string> = {
+  "src/App.tsx": "export const App = () => <div>Spending</div>;\n",
+  "vendo.json": '{"name":"Spending","egress":[]}\n',
+  "src/server.ts": "export default { fetch: () => new Response('ok') };\n",
+  "src/big.ts": `// ${"x".repeat(WORKSPACE_INLINE_MAX_BYTES)}\n`,
+};
+
+const TRIGGER = {
+  on: { kind: "schedule", cron: "0 9 * * *" },
+  run: { kind: "agentic", prompt: "send the digest" },
+} as const;
+
+/** An in-memory `FilesAdapter` — the SAME seam the workspace rows spill to, which
+ *  is the point: one adapter, two callers, no second spill mechanism. */
+function memoryBlobs(): FilesAdapter & { keys(): string[] } {
+  const blobs = new Map<string, Uint8Array>();
+  return {
+    async put(key, bytes) {
+      blobs.set(key, bytes);
+    },
+    async get(key) {
+      const bytes = blobs.get(key);
+      return bytes === undefined ? undefined : { bytes };
+    },
+    async delete(key) {
+      blobs.delete(key);
+    },
+    keys: () => [...blobs.keys()],
+  };
+}
+
+/**
+ * A provider that really HOLDS its snapshots, so destroying one is observable —
+ * the only property this test needs from a box, and the one a returns-the-same-
+ * machine-forever double cannot give. Local to this file, like every other
+ * `SandboxAdapter` double in this package.
+ */
+function snapshotHoldingSandbox(): SandboxAdapter & { snapshots: Set<string> } {
+  const snapshots = new Set<string>();
+  let next = 1;
+  const boot = (): SandboxMachine => {
+    const id = `rebuild_box_${next++}`;
+    return {
+      id,
+      async request() { return { status: 200, headers: {}, body: new Uint8Array() }; },
+      async url(port?: number) { return `https://${port ?? 8080}-${id}.rebuild.test`; },
+      async snapshot() {
+        const ref = `fake:${id}_snap`;
+        snapshots.add(ref);
+        return ref;
+      },
+      async stop() { /* sleep */ },
+      async destroy() { /* gone; taken refs stay valid */ },
+    };
+  };
+  return {
+    snapshots,
+    async create() { return boot(); },
+    async resume(snapshotRef) {
+      // The seam's own word: after `destroy`, "the provider holds no state for it".
+      if (!snapshots.has(snapshotRef)) throw new Error(`unknown snapshot: ${snapshotRef}`);
+      return boot();
+    },
+    async destroy(snapshotRef) {
+      snapshots.delete(snapshotRef);
+    },
+  };
+}
+
+/** The checkout half's seam, bound over the REAL row exactly as composition does.
+ *  Read (`checkoutApp`) is the assertion side of this test; the WRITE side goes
+ *  through `apps.commitSource`, which is the production verb under test. */
+function readSeam(store: VendoStore, blobs: FilesAdapter): AppSourceSeam {
+  const apps = store.records("vendo_apps");
+  const row = async (): Promise<{ subject: string; doc: AppDocument }> => {
+    const record = await apps.get(APP);
+    if (record === null) throw new Error(`no row for ${APP}`);
+    const data = record.data as { subject: string; doc: unknown };
+    return { subject: data.subject, doc: appDocumentSchema.parse(data.doc) };
+  };
+  return {
+    requireOwned: async () => (await row()).doc,
+    ownerOf: async () => (await row()).subject,
+    update: async () => {
+      throw new Error("the read seam never writes");
+    },
+    blobs,
+  };
+}
+
+async function freshStore(): Promise<VendoStore> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-app-rebuild-"));
+  cleanups.push(async () => rm(root, { recursive: true, force: true }));
+  const store = createStore({ dataDir: join(root, ".data") });
+  cleanups.push(async () => store.close());
+  await store.ensureSchema();
+  return store;
+}
+
+/**
+ * Carry the app's ROW — and only its row — into another store. This is the whole
+ * premise stated as an operation: an app IS its row, so a deployment holding
+ * nothing but the row must be able to put the app back. Its grant rows travel too,
+ * because on an org app `canCommit` asks them who may write there.
+ */
+async function carryRowAcross(from: VendoStore, to: VendoStore): Promise<void> {
+  const record = await from.records("vendo_apps").get(APP);
+  if (record === null) throw new Error(`no row for ${APP}`);
+  await to.records("vendo_apps").put(record);
+  for (const grant of (await from.records("vendo_app_grants").list({})).records) {
+    await to.records("vendo_app_grants").put(grant);
+  }
+}
+
+async function harness() {
+  const store = await freshStore();
+  const guard = createGuard({ store, policy: "autopilot" });
+  const blobs = memoryBlobs();
+  const sandbox = snapshotHoldingSandbox();
+  const apps = createApps({
+    store,
+    guard,
+    tools: guard.bind({ async descriptors() { return []; }, async execute() {
+      return { status: "error", error: { code: "not-found", message: "no host tools here" } };
+    } }),
+    catalog: [],
+    files: blobs,
+    appAccess: appAccess(store),
+    // Sharing's WRITES are Cloud-gated; the grant this test asserts survives a
+    // rebuild has to be creatable, and `can()` behind it is never key-conditional.
+    multiParty: true,
+    machine: { sandbox },
+  });
+
+  /** The composition line from `packages/vendo/src/server.ts`, verbatim in shape:
+   *  the render seam's two app-runtime halves, bound to THIS turn's ctx. */
+  const open = async (turnCtx: RunContext = ctx): Promise<WorkspaceFs> => wrapWorkspaceForRender(
+    await workspaceStore(store, { files: blobs }).open(
+      turnCtx.principal,
+      turnCtx.memberships === undefined ? undefined : { memberships: turnCtx.memberships },
+    ),
+    {
+      emit: () => undefined,
+      commitSource: (input) => apps.commitSource(input, turnCtx),
+    },
+  );
+
+  return { store, apps, blobs, sandbox, open };
+}
+
+/** A stored app carrying everything §2.4 promises survives an escalation: a
+ *  trigger, a placement, and — once the box exists — a machine ref.
+ *
+ *  `owner` is the row's subject, which IS the app's address (§9.7 — owner and path
+ *  prefix always travel together): a person's subject, or an org id verbatim. */
+async function seedApp(store: VendoStore, owner: string = principal.subject): Promise<void> {
+  const doc = {
+    format: VENDO_APP_FORMAT,
+    id: APP,
+    name: "Spending",
+    trigger: TRIGGER,
+    placements: ["dashboard.main"],
+  } as unknown as AppDocument;
+  await store.records("vendo_apps").put({
+    id: APP,
+    data: { subject: owner, enabled: false, doc },
+    refs: { subject: owner },
+  });
+}
+
+describe.sequential("an app rebuilds from its row onto a fresh box, with its snapshot deleted", () => {
+  /**
+   * The app is ORG-OWNED, which is the harder address and the only one that can be
+   * SHARED: a personal app refuses a grant outright ("move it into a team first"),
+   * so a grant is only a thing to survive on a team app. It also puts the whole
+   * round trip through `/orgs/<org>/apps/<appId>/**`, where getting the address from
+   * permission instead of ownership used to drop every edit silently.
+   */
+  it("comes back byte for byte — inline files and the blob-spilled one alike", async () => {
+    const { store, apps, sandbox, blobs, open } = await harness();
+    await seedApp(store, ORG);
+    const root = `/orgs/${ORG}/apps/${APP}`;
+
+    // ── 1. BUILD. The builder's writes reach the store through the ONE
+    // interception point: this façade's `commit()`. That is the same door the
+    // sandbox sync-back path uses (`materialize.ts` writes then commits here), so
+    // this is the real write path whether the hands were in-process or in a box.
+    const building = await open(orgCtx);
+    for (const [path, text] of Object.entries(SOURCE)) {
+      await building.writeFile(`${root}/${path}`, text);
+    }
+    const landed = await building.commit();
+    expect(landed.status).toBe("ok");
+
+    // The row is now the truth: every file, hashed, with the big one spilled.
+    const stored = await apps.get(APP, orgCtx);
+    expect(Object.keys(stored!.source ?? {}).sort()).toEqual(Object.keys(SOURCE).sort());
+    expect(stored!.source!["src/big.ts"]!.text).toBeUndefined();
+    expect(blobs.keys()).toContain(stored!.source!["src/big.ts"]!.blobRef);
+    expect(stored!.source!["src/App.tsx"]!.text).toBe(SOURCE["src/App.tsx"]);
+
+    // A grant, so the rebuild can be asked whether sharing survived it.
+    await apps.access.grant(APP, `user:${READER.subject}`, "viewer", orgCtx);
+
+    // ── 2. THE BOX. A machine is minted and its ref stored, which is the state
+    // that used to be the app's ONLY home. Written onto the row directly rather
+    // than through `provision`: what is under test is whether the ref is a cache,
+    // not how it is taken.
+    const machine = await sandbox.create({ env: { PORT: "8080" } });
+    const snapshotRef = await machine.snapshot();
+    await store.records("vendo_apps").put({
+      id: APP,
+      data: {
+        subject: ORG,
+        enabled: false,
+        doc: { ...(await apps.get(APP, orgCtx))!, machine: { snapshotRef, provisionedAt: new Date().toISOString() } },
+      },
+      refs: { subject: ORG },
+    });
+    await expect(sandbox.resume(snapshotRef)).resolves.toBeDefined();
+
+    // ── 3. DELETE THE SNAPSHOT. `destroy` is documented as exactly this:
+    // "afterwards resume(snapshotRef) fails and the provider holds no state for
+    // it." Asserting the failure is what stops this test passing by accident on a
+    // snapshot that is quietly still there.
+    await sandbox.destroy(snapshotRef);
+    await expect(sandbox.resume(snapshotRef)).rejects.toThrow(/unknown snapshot/);
+    expect(sandbox.snapshots.has(snapshotRef)).toBe(false);
+
+    // ── 4. REBUILD. A FRESH box, and a workspace over an EMPTY store that has
+    // never held these files — the app's ROW is the only thing carried across, plus
+    // the blobs its row points at. Reopening a workspace over the SAME store would
+    // prove nothing: those file rows are the working copy the build left behind, so
+    // the checkout would be a no-op and the read-backs would pass with `doc.source`
+    // completely empty (measured — see the falsification note in the PR). The whole
+    // claim is that the ROW is enough, so the row is all it gets.
+    const fresh = await sandbox.create({ env: { PORT: "8080" } });
+    expect(fresh.id).not.toBe(machine.id);
+    const elsewhere = await freshStore();
+    await carryRowAcross(store, elsewhere);
+    const rebuilt = await workspaceStore(elsewhere, { files: blobs })
+      .open(principal, { memberships: [MEMBERSHIP] });
+    // Nothing of this app is in that workspace yet — the disk really is blank.
+    await expect(rebuilt.readFile(`${root}/src/App.tsx`)).rejects.toThrow();
+
+    await checkoutApp(APP, rebuilt, orgCtx, readSeam(elsewhere, blobs));
+    for (const [path, text] of Object.entries(SOURCE)) {
+      expect(await rebuilt.readFile(`${root}/${path}`)).toBe(text);
+    }
+
+    // ── 5. AND THE APP IS STILL THE SAME APP. §2.4: escalation is no longer a
+    // migration, so nothing but `source` may have moved.
+    const after = await apps.get(APP, orgCtx);
+    expect(after!.id).toBe(APP);
+    expect(after!.trigger).toEqual(TRIGGER);
+    expect(after!.placements).toEqual(["dashboard.main"]);
+    expect((await apps.access.list(APP, orgCtx)).map((grant) => grant.principal))
+      .toEqual([`user:${READER.subject}`]);
+  }, 120_000);
+
+  /**
+   * `trigger` is the one obligation this contract carries toward automations:
+   * don't gratuitously break it. A source commit is not a generation, so every
+   * field but `source` rides through untouched — asserted over SEVERAL commits,
+   * because a mutate that rebuilds the document instead of spreading it would only
+   * lose the trigger on the second one.
+   */
+  it("carries trigger, placements and every other field through commit after commit", async () => {
+    const { store, apps, open } = await harness();
+    await seedApp(store);
+
+    const workspace = await open();
+    for (const round of ["one", "two", "three"]) {
+      await workspace.writeFile(`/user/apps/${APP}/src/App.tsx`, `// ${round}\n`);
+      expect((await workspace.commit()).status).toBe("ok");
+      const doc = await apps.get(APP, ctx);
+      expect(doc!.trigger).toEqual(TRIGGER);
+      expect(doc!.placements).toEqual(["dashboard.main"]);
+      expect(doc!.name).toBe("Spending");
+      expect(doc!.source!["src/App.tsx"]!.text).toBe(`// ${round}\n`);
+    }
+  }, 120_000);
+
+  /**
+   * The persistence is a courtesy on top of a landed commit and can never fail
+   * one — but a silently dropped source file is a lost app, so a failure is loud.
+   * A commit under an app directory with no row is the honest case for that: the
+   * files landed in the workspace, and there is no app to persist them onto.
+   */
+  it("never fails the commit that carried it, even with no app row to write to", async () => {
+    const { open } = await harness();
+    const workspace = await open();
+    await workspace.writeFile(`/user/apps/app_no_such_row/src/App.tsx`, "orphan\n");
+    const result = await workspace.commit();
+    expect(result.status).toBe("ok");
+    expect(result.status === "ok" && result.changed).toContain("/user/apps/app_no_such_row/src/App.tsx");
+    // And the workspace still holds the file: the commit really did land.
+    expect(await workspace.readFile(`/user/apps/app_no_such_row/src/App.tsx`)).toBe("orphan\n");
+  }, 120_000);
+});

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -2194,6 +2194,10 @@ export function createVendo(config: CreateVendoConfig): Vendo {
     model: inference.agent.model,
     catalog,
     pinBaselines,
+    // Contract §3.2 — the SAME `FilesAdapter` the workspace rows spill to (one
+    // `selectFiles` answer, above), so an app's source past the inline cap uses the
+    // spill that already exists instead of inventing a second one.
+    files,
     // Build contract §9 — the multi-party half. `can()` over whatever store the
     // host wired (OSS, unconditional); `multiParty` is the Cloud gate on the
     // three writes that create sharing; `promoteApp` is the store's sanctioned
@@ -2680,10 +2684,17 @@ export function createVendo(config: CreateVendoConfig): Vendo {
     // not on its listing.
     connectorDiscovery: serviceCatalog,
     bridge: () => ({ toolOutputCap, preflight: (call, ctx) => connectGate.check(call, ctx) }),
-    // §1.6's app half. Without it a files-first app (D4) is a PICTURE of an app: no
-    // store row, so it never lists and `vendo_apps_open` masks it as not-found, and
-    // no query data, so every value renders "—" with the real host data one call away.
-    render: (ctx) => ({ authoredApp: (input) => apps.authored(input, ctx) }),
+    // §1.6's app half, and — contract §3.2 — the app's SOURCE half beside it, on
+    // the SAME interception point. Without `authoredApp` a files-first app (D4) is a
+    // PICTURE of an app: no store row, so it never lists and `vendo_apps_open` masks
+    // it as not-found, and no query data, so every value renders "—" with the real
+    // host data one call away. Without `commitSource` the app's CODE has no home but
+    // the sandbox snapshot behind `machine.snapshotRef` — lose the snapshot and the
+    // customer's app is gone, because the store never had it.
+    render: (ctx) => ({
+      authoredApp: (input) => apps.authored(input, ctx),
+      commitSource: (input) => apps.commitSource(input, ctx),
+    }),
     // Build contract §9.1/§9.7 — the same host org query the wire resolves per
     // request, so a harness turn's façade mounts the team's files too.
     ...(membershipsSeam === undefined ? {} : { memberships: membershipsSeam }),


### PR DESCRIPTION
Track B of the UI-gen overhaul, storage half. Blueprint §2.2, §2.3, §12.2, and Track B's "done" bar in §15.

## The hole this closes

Phase 0 landed `AppDocument.source` and the `checkoutApp`/`commitApp` seam — and then nothing called them. Grep the merged tree: the only caller was `app-source.e2e.test.ts`. So every built app's code still lived in exactly one place, the sandbox snapshot behind `machine.snapshotRef`, and losing that snapshot lost the customer's app because the store never had it. The contract was landed and dead.

Founder-level statement of what changes: **the code lives in the database like everything else, and the box is disposable.**

## The seam, and why it hangs where it does

`render-seam.ts` already argued the interception point, and the clause that decides it for source is the one about the box:

> "…and would **miss the sandbox sync-back path, which commits without ever calling `writeFile` on this façade.**"

A builder working inside a box reaches the store through that same `commit()`. Confirmed with Track A2 rather than assumed: `materialize.ts:249`'s `workspace.commit()` is the single store-write moment for builder files — `syncHot` (mid-turn, hot-only) and `syncAll` (turn-end) are the same `apply()` with different flags, so non-hot source lands at turn end through that one call. There is no bypass and no second harvest path to build.

- **`RenderSeamOptions.commitSource`** (`packages/harnesses/src/render-seam.ts:137`) — `authoredApp`'s sibling: optional, composition-injected, unwired-still-works. Called once per APP a commit touched, with `CommitResult.changed` verbatim.
- **Composition** (`packages/vendo/src/server.ts:2696`) — `render: (ctx) => ({ authoredApp: …, commitSource: (input) => apps.commitSource(input, ctx) })`.
- **`AppsRuntime.commitSource`** (`packages/apps/src/runtime.ts:2739`) — the store half, closing over the runtime's own `requireOwned`, its compare-and-swap update, the row's subject as the app's OWNER (§9.7 — the address comes from ownership, never from which mount happens to be writable), and `AppsConfig.files` for spill.

Three §0 obligations, met rather than worked around:

- **No second hook.** It hangs off the `commit()` proxy that already exists, beside `authoredApp`.
- **No second spill.** `AppsConfig.files` is filled from the umbrella's one `selectFiles` answer — the SAME `FilesAdapter` the workspace rows already spill to. A source file and a workspace file are the same bytes in two projections.
- **No second path reader.** `HOT_PATH` became one `APP_PATH` regex with the filename as a tail, so "which app is this path in?" has a single answer for the hot paths and the source tree alike. `hotPathAppId` is derived from it and keeps its exact meaning.

**Ordering, and it is load-bearing:** source persistence runs AFTER the views. Not only because §1.6 is a promise about seconds — an `app.vendo` commit is the moment a files-first app BECOMES an app, and `authoredApp` is what upserts the row `commitSource` then writes to.

**A `{status:"conflict"}` commit persists nothing**, because nothing landed. Per A2: an empty `changed` means "nothing landed", never "no files exist" — it is a no-op here, never a reason to clear `source`.

## The tradeoff, stated plainly

Persistence can never fail the commit it rides on — the seam's own standing rule about views, unchanged. But a lost view costs a repaint and a lost source file costs the app, so **a failure is logged loudly instead of swallowed**:

```
console.error("[vendo] render seam: source did not reach the store", { appId, error })
```

The cost is a log line on a commit under an app directory that has no row (a path that looks like an app but is not one yet). That noise is the deliberate price of never dropping source in silence.

**For reviewers scanning the test output:** `app-rebuild.e2e.test.ts` writes this to stderr *on a passing test*, and it is the feature working, not a smell —

```
[vendo] render seam: source did not reach the store {
  appId: 'app_no_such_row',
  error: 'app_no_such_row has no row to hold its source'
}
```

The `never fails the commit that carried it, even with no app row to write to` case deliberately drives that path, because "a dropped source file must never be silent" is the property the whole change rests on. A green run with silent stderr there would mean the loud path had stopped working.

## The rebuildability proof

`packages/vendo/src/app-rebuild.e2e.test.ts` — a seam test with no stub on either side. Real PGlite store, real `workspaceStore` façade, real `wrapWorkspaceForRender`, real `createApps` runtime behind the verb, and a `SandboxAdapter` that really holds its snapshots.

1. An ORG-owned app is built through the real write path (the harder address, and the only one that can be shared).
2. A machine is provisioned and its ref stored — the state that used to be the app's only home.
3. **The snapshot is destroyed**, and `resume` is asserted to genuinely fail, so the test cannot pass on a snapshot quietly still there.
4. The app is rebuilt from its row alone onto a fresh box — into **a workspace over an EMPTY store that has never held these files**. Byte for byte, including one file past the 65_536-byte inline cap so the blob-spill leg is proven and not only the inline one.
5. `trigger`, `placements`, the grant, and the app's `id` all survive — §2.4's promise that escalation is no longer a migration.

Step 4's shape is not incidental, and it is the most useful thing in this PR. **My first version reopened the workspace over the same store and passed with `doc.source` completely empty** — the read-backs were being served by the workspace file rows the build left behind, so the checkout was a no-op. The falsification caught it; the assertion is now against a store that holds only the row.

## Prove-it-can-fail

| Test | Break | Observed red |
|---|---|---|
| rebuildability, snapshot deleted | removed `await persistSource(result.changed)` | `ENOENT: no such file or directory, open '/orgs/maple/apps/app_rebuild_1/src/App.tsx'` — the app genuinely unrecoverable |
| trigger survival | `commitApp`'s mutate returns `{format,id,name,source}` instead of `{...doc, source}` | `expected TRIGGER, received undefined`, on the first of three commits |
| read-failure durability | refused blob GET on the spilled file's read-back | `Cannot convert undefined or null to object` — `doc.source` gone entirely |
| real deletion still deletes | n/a — guards the row above from passing on code that never deletes | asserted in the same block |

## `snapshotRef` audit — no reader is a source-recovery path

Audited every non-test read. `machine-lifecycle.ts` uses it for provision (:367), wake-to-serve (:470), sleep/re-snapshot (:321-335), and destroy/orphan-reap (:525, :551); the e2b and Cloud adapters only decode-and-boot or decode-and-delete. **None reads files back**, and structurally none can: `SandboxMachine` exposes `request`, `url`, `snapshot`, `stop`, `destroy` and **has no file-read method at all**. So nothing had to be removed. The gap was never an unsafe read-from-snapshot path — it was the absence of any sync-back of source bytes, which is what this PR adds. `machine.snapshotRef` is now a cache in fact, not only in its doc comment.

## Two things riding along, both reachable only once the seam has a real caller

**1. `commitSource` is a new authorization surface, so it is tested hostilely.** The appId it writes to is derived from the COMMITTED PATHS, and `/user/**` is its subject's at every level — so a caller can stage `/user/apps/<somebody-else's-id>/…` and the façade will land it. The committed path is therefore an attacker-controlled input to an authorization decision. Three cases pinned:

- a foreign caller is refused, and the refusal is **AUDIBLE** — critical, because this path is deliberately non-fatal and a silent skip would be indistinguishable from "nothing to persist";
- an org-owned app resolves to its ORG address even with the caller's personal mount writable and a decoy file staged there;
- a commit naming a stranger's app **alongside** the caller's own lands nothing on the stranger's and still lands the caller's.

All three pass against the gates Phase 0 already added. They document those gates; they do not add any.

**2. "Would not read" is no longer "was deleted"** — `packages/apps/src/app-source.ts`, on the coordinator's explicit ruling of 2026-08-05 after this branch surfaced the path. **This is freshly-merged, freshly-reviewed code and I am flagging that deliberately; it is not an unprompted edit.**

`commitApp` inferred deletions from a thrown read-back. For a spilled file that read is a live fetch from the files adapter, so a blob store having a bad minute looked exactly like a deletion and the entry was dropped — the larger the file, the likelier it is the one that vanishes.

The precondition the ruling asked me to establish first, recorded because it changes the fix: **the thrown error cannot be the discriminator.** The façade throws POSIX-shaped BARE `Error`s on purpose (bash prints them verbatim), so there is no code to switch on — and a row whose blob has gone missing raises the *same* `ENOENT` as a row that was deleted (`workspace-rows.ts` `load()` → undefined → `workspace-fs.ts` `bytesOf` → `enoent`). Message-sniffing would still have deleted the data-loss case while looking safe.

`exists()` is used instead: it answers from the row index and never touches the blob, so it separates "gone" from "will not come" exactly. Confirmed absence still deletes; anything else keeps the stale entry and logs loudly. Per path, so the rest of the commit still lands.

## Verification

Merge base verified against: **`1261c825f`** (`feat(store): Db.transaction() primitive`). Everything below was run and observed on that tree, and the working tree has been clean since, so the tested state and the committed state are the same. `main` has advanced by one commit (#791, `@vendoai/agents`) since; the PR reads MERGEABLE and needs no rebase, but the results below correspond to `1261c825f`, not to today's `main` tip.

**The full build and the full suite are the coordinator's at the merge boundary, by fleet policy**: workers run package-scoped builds and file-scoped capped test slices only, because turbo is the outer parallelism layer and running it from a worker defeats the inner worker cap. An unrun full suite here is the expected state, not a gap.

### Independent re-run in the granted verification slot

The three load-bearing files were re-run by the coordinator, capped and file-scoped, at machine load ~98 falling — a second observation on the committed tree, independent of mine:

```
packages/harnesses/src/render-seam.test.ts        52 passed
packages/vendo/src/app-source.e2e.test.ts          7 passed
packages/vendo/src/app-rebuild.e2e.test.ts         8 passed
                                             ─────────────
                                             67 passed, 0 failed
```

Every hostile case and both durability directions passed by name: `refuses a commit against another person's app, out loud rather than silently` · `resolves the ORG address when the personal mount is writable too` · `lands nothing on a foreign app named in the same commit, and still lands the caller's own` (the cross-tenant case) · `KEEPS the stored entry when the read-back FAILS, and says so` · `still drops an entry the user really DELETED`.

Green:

- Package-scoped builds and typechecks for `@vendoai/apps`, `@vendoai/harnesses`, `@vendoai/vendo`.
- `scripts/dependency-guard.mjs` (15 packages) and `scripts/portability-gate.mjs` (all legs). These two are what `pnpm lint` actually covers for `packages/*` — none of the three defines a `lint` script.

Test slices, all capped both ways (`VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2 … --minWorkers=1 --maxWorkers=2`):

- `harnesses`: `render-seam` · `materialize` · `runtime` · `screen-description` · `parity` — **143 passed**
- `apps`: `machine-lifecycle` · `machine-runtime` · `served-apps` — **61 passed**
- `vendo`: `app-rebuild.e2e` · `app-source.e2e` — **15 passed** (8 + 7)

`app-source.e2e.test.ts` is on that list deliberately, because this PR changes `app-source.ts`: it is that file's own suite, including the adversarial cases added during Phase 0's review, and it is unchanged here and still green. Its deletion test in particular is what proves the durability fix did not simply stop deleting.

## TEST EDITS

- `packages/harnesses/src/render-seam.test.ts` — added a `source persistence` block (9 cases): fires on a source commit, `changed` verbatim, once per app across both mounts, no-op on conflict, no-op off-app paths, never fails the commit and logs loudly, unwired unchanged, and runs after the view.
- `packages/vendo/src/app-rebuild.e2e.test.ts` — NEW. The rebuildability proof, the three hostile authorization cases, and the read-failure durability pair.

No existing test assertion was weakened or removed.
