### PR TITLE
feat(harnesses,ui): a build's own dev server is reachable from the browser

### DIFF
--- a/packages/harnesses/src/claude-code/box.ts
+++ b/packages/harnesses/src/claude-code/box.ts
@@ -60,6 +60,10 @@ export interface SandboxMachineLike {
     write(path: string, bytes: Uint8Array | string): Promise<void>;
     list(dir: string): Promise<string[]>;
   };
+  /** The machine's PUBLIC ingress URL for a port — the browser→box path, which
+   *  `request()` (host→box) cannot stand in for. Declared exactly as
+   *  `SandboxMachine.url` so a real adapter still satisfies this narrowing. */
+  url(port?: number): Promise<string>;
   destroy(): Promise<void>;
 }
 
@@ -247,6 +251,10 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
     pluginPath: "/workspace/host",
 
     tree: box.tree,
+
+    async url(port: number) {
+      return await box.machine.url(port);
+    },
 
     async materialize(files: readonly CheckoutFile[]) {
       // Chunked by COUNT, which bounds the typical upload body — not a hard

--- a/packages/harnesses/src/claude-code/claude-code-local.test.ts
+++ b/packages/harnesses/src/claude-code/claude-code-local.test.ts
@@ -32,6 +32,9 @@ vi.mock("./local.js", () => ({
     carriesSession: false,
     pluginPath: "/tmp/vendo-local-double/host",
     tree: emptyTree(),
+    // ⚠️ TEST EDIT — the widened `SessionMachine` requires it. Same loopback
+    // answer the real local machine gives.
+    async url(port: number) { return `http://127.0.0.1:${port}`; },
     async materialize() {},
     async collect() { return []; },
     async send(message: SessionMessage) { sent.push(message); },

--- a/packages/harnesses/src/claude-code/claude-code.test.ts
+++ b/packages/harnesses/src/claude-code/claude-code.test.ts
@@ -172,6 +172,10 @@ function makeBox(
   };
 
   box.destroy = async () => { box.destroyed = true; };
+  // ⚠️ TEST EDIT — the widened `SandboxMachineLike` requires it. Shaped like
+  // e2b's per-port public hostname (`https://<host-for-port>`), which is the
+  // provider behaviour the shared adapter conformance suite certifies.
+  box.url = async (port?: number) => `https://${box.id}-${port ?? 8080}.fake-provider.test`;
   box.request = async (req) => {
     if (box.destroyed) throw new VendoError("not-found", "machine is gone");
     const payload = req.body === undefined
@@ -706,6 +710,17 @@ describe("one box per conversation, destroyed when it goes idle (design §9)", (
     await machine.send({ prompt: "p", emit: () => undefined });
     // Three times the idle budget later, the box is still there.
     expect(sandbox.boxes[0]!.destroyed).toBe(false);
+  });
+});
+
+describe("the build's own dev server is reachable from the browser (blueprint §10.2)", () => {
+  test("the box hands out its provider ingress URL for a port its own traffic never uses", async () => {
+    // A coded build's preview is the TEMPLATE's dev server, on a second listener
+    // in the same box. `request()` already reaches any port from the HOST side;
+    // this is the browser→box side, which the session seam could not express.
+    const sandbox = fakeSandbox(async () => undefined);
+    const machine = await boxMachine({ sandbox, threadId: "thr_preview", env: {}, allowedDomains: [] });
+    expect(await machine.url(5173)).toBe("https://box_0-5173.fake-provider.test");
   });
 });
 

--- a/packages/harnesses/src/claude-code/local-session.test.ts
+++ b/packages/harnesses/src/claude-code/local-session.test.ts
@@ -56,4 +56,18 @@ describe("machine: \"local\" — one session, many turns", () => {
 
     await disposeLocalSessions();
   });
+
+  test("a dev server on this machine is reachable at loopback (blueprint §10.2)", async () => {
+    // The seam has to answer on BOTH legs or it is not a seam: a box points at
+    // the provider's per-port ingress, a local machine at the loopback address
+    // the browser and the dev server already share.
+    const machine = await localMachine({
+      threadId: `thr_local_${Math.random().toString(36).slice(2)}`,
+      env: {},
+      openSession: sessionDouble().factory as never,
+    });
+    expect(await machine.url(5173)).toBe("http://127.0.0.1:5173");
+
+    await disposeLocalSessions();
+  });
 });

--- a/packages/harnesses/src/claude-code/local.ts
+++ b/packages/harnesses/src/claude-code/local.ts
@@ -208,6 +208,13 @@ export async function localMachine(options: LocalMachineOptions): Promise<Sessio
 
     tree: held.tree,
 
+    // Loopback, because on this path the machine IS the host: a dev server the
+    // session starts binds here, and the browser asking for the preview is on
+    // the same box by definition (that is what `machine: "local"` means).
+    async url(port: number) {
+      return `http://127.0.0.1:${port}`;
+    },
+
     async materialize(files) {
       for (const file of files) {
         const target = toDisk(root, file.path);

--- a/packages/harnesses/src/claude-code/machine.ts
+++ b/packages/harnesses/src/claude-code/machine.ts
@@ -102,6 +102,25 @@ export interface SessionMachine {
    * only.
    */
   collect(paths?: readonly string[]): Promise<SyncFile[]>;
+  /**
+   * The BROWSER-reachable URL for a listener on this machine — the build's own
+   * dev server, so a coded build previews through HMR instead of a
+   * save→rebuild→reload protocol of ours (blueprint §10.2).
+   *
+   * `port` is required, unlike the adapter's `url(port?)` underneath: this seam
+   * has no notion of a default listener (the session's own traffic names the
+   * control port explicitly on every request), and the only reason the member
+   * exists is a SECOND listener the machine did not boot with.
+   *
+   * The URL is browser→machine DIRECT, and has to be: HMR is a WebSocket, while
+   * the wire's `/apps/:id/serve/**` proxy relays ONE request and one response
+   * carrying method, path, content-type and body — it has no upgrade path. So a
+   * preview URL is a capability on the provider's public ingress with no
+   * per-request check, unlike a shared served app's proxied URL. What keeps that
+   * acceptable is the scope: the owner's own build, alive only as long as its box
+   * (`BOX_IDLE_TTL_MS`), never persisted on a document.
+   */
+  url(port: number): Promise<string>;
   /** Push one user message into the live session and settle when its turn ends. */
   send(message: SessionMessage): Promise<void>;
   /**

--- a/packages/ui/e2e/appframe-devserver.spec.ts
+++ b/packages/ui/e2e/appframe-devserver.spec.ts
@@ -1,0 +1,133 @@
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { createServer as createProbe } from "node:net";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { expect, test, type Frame, type Page } from "@playwright/test";
+import { createServer, type ViteDevServer } from "vite";
+import { screenshotPath } from "./helpers.js";
+
+/**
+ * Blueprint §10.2 point 2 — "live preview for coded builds via the TEMPLATE'S OWN
+ * DEV SERVER (HMR). No bespoke save→rebuild→reload protocol."
+ *
+ * This is the proof that the second sentence needs no code: the frame the product
+ * already ships (`AppFrame` → `HttpFrame`, an `{ kind: "http", url }` surface)
+ * renders a REAL Vite dev server, and an edit on disk repaints the frame through
+ * Vite's own HMR channel with no reload — so there is nothing for us to build
+ * between "the agent wrote a file" and "the person sees it".
+ *
+ * The dev server is genuine, not a static fixture: Vite's Node API, its HMR
+ * WebSocket, its module graph. It is created and closed inside this file, so the
+ * suite never leaves a listener behind.
+ */
+
+// Motion evidence: a screenshot pair cannot show that the repaint happened in
+// place. The recording can.
+test.use({ video: "on" });
+
+/** A minimal Vite app whose headline lives in an HMR-accepted dependency. */
+const indexHtml = `<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Preview app</title></head>
+  <body style="font: 16px/1.5 system-ui; margin: 24px">
+    <!-- Stamped ONCE per document load. If HMR were secretly a reload, this
+         changes — which is exactly what the test asserts it does not. -->
+    <script>window.__bootId = Math.random().toString(36).slice(2);</script>
+    <h1 id="headline">booting…</h1>
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>
+`;
+
+const mainJs = `import { headline } from "./headline.js";
+
+const paint = (text) => { document.querySelector("#headline").textContent = text; };
+paint(headline);
+
+if (import.meta.hot) {
+  import.meta.hot.accept("./headline.js", (next) => { if (next) paint(next.headline); });
+}
+`;
+
+const headlineJs = (text: string) => `export const headline = ${JSON.stringify(text)};\n`;
+
+/**
+ * A free port, reserved the same way `playwright.config.ts` reserves the
+ * harness's — vite normalizes `port: 0` to its default 5173 and then tells the
+ * HMR client that number, so "let the OS pick" is not expressible here and a
+ * fixed port would race every parallel worktree.
+ */
+async function freePort(): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const probe = createProbe();
+    probe.unref();
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const { port } = probe.address() as AddressInfo;
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+/** The dev server's frame, by the src it was given. */
+function previewFrame(page: Page, url: string): Frame {
+  const frame = page.frames().find((candidate) => candidate.url().startsWith(url));
+  if (frame === undefined) throw new Error(`no frame is serving ${url}`);
+  return frame;
+}
+
+test("the existing http frame renders a live dev server, and HMR repaints it without a reload", async ({ page }) => {
+  // realpath, not `tmpdir()` raw: on macOS /var/folders is a symlink to
+  // /private/var/folders, so the watcher reports the REAL path while vite's root
+  // stays the symlinked one — the changed file then looks like it lives outside
+  // the project and no module matches it. Measured: no hmr update at all.
+  const root = mkdtempSync(path.join(realpathSync(tmpdir()), "vendo-preview-app-"));
+  writeFileSync(path.join(root, "index.html"), indexHtml);
+  writeFileSync(path.join(root, "main.js"), mainJs);
+  writeFileSync(path.join(root, "headline.js"), headlineJs("BEFORE THE EDIT"));
+
+  let server: ViteDevServer | undefined;
+  try {
+    server = await createServer({
+      configFile: false,
+      root,
+      server: { host: "127.0.0.1", port: await freePort(), strictPort: true },
+      logLevel: "warn",
+    });
+    await server.listen();
+    const devUrl = server.resolvedUrls?.local[0];
+    expect(devUrl, "the vite dev server must report a local url").toBeTruthy();
+    const url = devUrl!.replace(/\/$/, "");
+
+    await page.goto(`/appframe-devserver#${encodeURIComponent(url)}`);
+    const frameElement = page.locator('section[aria-label="Live dev server preview"] iframe');
+    await expect(frameElement).toHaveAttribute("src", url);
+
+    // The dev server is a different ORIGIN from the harness page (a different
+    // port is a different origin), so `httpFrameSandbox` grants the frame its
+    // OWN origin — which is what lets Vite's HMR client open its WebSocket.
+    // A same-origin preview url would run opaque and could not.
+    expect(await frameElement.getAttribute("sandbox")).toContain("allow-same-origin");
+
+    const framed = page.frameLocator('section[aria-label="Live dev server preview"] iframe');
+    await expect(framed.locator("#headline")).toHaveText("BEFORE THE EDIT");
+    const bootId = await previewFrame(page, url).evaluate(() => (window as unknown as { __bootId: string }).__bootId);
+    expect(bootId).toBeTruthy();
+    await page.screenshot({ path: screenshotPath("appframe-devserver-before"), fullPage: false });
+
+    // THE EDIT — the only thing a coded build does: write a file.
+    writeFileSync(path.join(root, "headline.js"), headlineJs("AFTER THE EDIT — HMR, NO RELOAD"));
+
+    await expect(framed.locator("#headline")).toHaveText("AFTER THE EDIT — HMR, NO RELOAD");
+    await page.screenshot({ path: screenshotPath("appframe-devserver-after-hmr"), fullPage: false });
+
+    // The document never reloaded: same boot id, new content. That is HMR, and it
+    // is why no save→rebuild→reload protocol of ours is needed.
+    const afterBootId = await previewFrame(page, url).evaluate(() => (window as unknown as { __bootId: string }).__bootId);
+    expect(afterBootId).toBe(bootId);
+  } finally {
+    await server?.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -1368,6 +1368,26 @@ function AppFrameResizeScenario() {
   );
 }
 
+/**
+ * Blueprint §10.2 point 2 — a coded build's live preview IS the template's own
+ * dev server, rendered by the EXISTING http surface. No new frame, no new panel:
+ * the only thing that changes is which URL the surface carries.
+ *
+ * The spec boots a real Vite dev server on a port it reserves at run time and
+ * passes the URL in the location hash (the same handoff `/live-stage` uses for
+ * its ephemeral secret), because a port baked in here would collide with every
+ * parallel lane.
+ */
+function DevServerPreviewScenario() {
+  const url = decodeURIComponent(globalThis.location.hash.slice(1));
+  return (
+    <section aria-label="Live dev server preview">
+      <h2>Dev server preview</h2>
+      <AppFrame surface={{ kind: "http", url }} />
+    </section>
+  );
+}
+
 const baseClient = createVendoClient({ baseUrl: "/api/vendo" });
 const unconfiguredClient = createVendoClient({ baseUrl: "/api/vendo", headers: { "x-vendo-force-posture": "unconfigured" } });
 
@@ -2227,6 +2247,7 @@ function scenario(pathname: string): { title: string; theme?: Partial<VendoTheme
     case "/slot-fallback": return { title: "Slot pin fallback", content: <SlotFallbackScenario />, ownProvider: true };
     case "/appframe": return { title: "App execution planes", content: <AppFrameScenario /> };
     case "/appframe-resize": return { title: "App frame resize — the host's bounds win", content: <AppFrameResizeScenario /> };
+    case "/appframe-devserver": return { title: "Live dev-server preview (HMR)", content: <DevServerPreviewScenario /> };
     case "/byo-embed-app": return { title: "BYO chat — inline generated app", content: <ByoEmbedScenario appId="app_island" title="Weather dashboard" />, ownProvider: true };
     case "/byo-embed-building": return { title: "BYO chat — app mid-build", content: <ByoEmbedScenario appId="app_building_lands" title="Trip planner" />, ownProvider: true };
     // §16 law 3 — the embed's terminal build failure. The wire fixture serves


### PR DESCRIPTION
## What

A coded build's live preview is the **template's own dev server**, rendered by the surface the product already ships. Blueprint §10.2 point 2 — "no bespoke save→rebuild→reload protocol" — and this PR is mostly the proof that the second half needs no code at all.

Base note: rebased onto `main` (Phase 0 landed as `fbf265ba5`).

## The preview surface needed nothing — that is the point (§0)

`AppFrame` already dispatches an http surface straight to an iframe (`packages/ui/src/tree/frames.tsx:153`). `SandboxMachine.url(port?)` has existed and been conformance-certified since wave 4 (`packages/apps/src/adapter-conformance.ts:247-259`). **No new frame, no new panel, no new preview concept, no new event.** `packages/ui/src/` is untouched.

What was actually missing was one member on one seam.

## The change

| File | Change |
|---|---|
| `packages/harnesses/src/claude-code/box.ts` | `SandboxMachineLike` gains `url(port?)`, declared verbatim as `SandboxMachine.url` so a real adapter still satisfies the narrowing; the session machine delegates to it |
| `packages/harnesses/src/claude-code/machine.ts` | `SessionMachine` gains `url(port)` |
| `packages/harnesses/src/claude-code/local.ts` | the local leg answers loopback |

The build's box could already reach any port from the **host** side (`request({ port })`); it could expose none to a **browser**. Both legs implement it, because a seam with one implementation is a seam that lies.

`port` is required here although the adapter's is optional: this seam has no default listener (the session names the control port on every request), and the only reason the member exists is a port the machine did not boot with.

## Browser evidence

Real Vite 6 dev server (Node API, real HMR WebSocket, real module graph), rendered by the shipped frame, edited on disk mid-test.

- `packages/ui/e2e/screenshots/appframe-devserver-before.png`
- `packages/ui/e2e/screenshots/appframe-devserver-after-hmr.png`

The frame's console showed `[vite] hot updated: /headline.js via /main.js`, and the document's boot id is **unchanged** across the update — so the repaint was HMR, not a reload. That assertion is the test's whole point: removing `import.meta.hot.accept` makes the text still update (a weaker test passes) while the boot id changes and the test fails.

Known gap, **not fixed here**: the frame does not size to its content (static `min-height: 320px`). That is the resize protocol, blueprint §12.3 / Track B, paired with the template rebake.

## Security: provider ingress vs the `/apps/:id/serve/**` proxy

**Recommendation: the provider's per-port ingress, because the proxy physically cannot carry HMR — and say so out loud rather than let it look like a convenience choice.**

`servedProxyRoutes` (`packages/vendo/src/wire/box.ts:83`) relays **one request and one response**, carrying method, path, content-type and body only. There is no upgrade path, and `grep -i websocket` over the whole sandbox seam, both adapters and the serve proxy returns nothing. HMR is a WebSocket. Routing the preview through the proxy would mean building WebSocket proxying — a second mechanism, which §0 forbids.

So the shipped posture is explicit: **a preview URL is a bearer-by-obscurity capability on the provider's public ingress**, exactly the posture the code's own comment criticises at `packages/apps/src/runtime.ts:1242`, and exactly what §12.1 is flipping away from for stored served apps.

Three things make that acceptable *for a preview* rather than for a served app, and they should be stated in §12.1's flip so the two do not silently diverge:
1. it is the **owner's own build**, mid-turn — the one case §12.1 leaves on provider ingress today;
2. it lives as long as the build box does (`BOX_IDLE_TTL_MS`, 5 minutes) rather than for the life of a stored app;
3. it is never persisted on a document, so there is no long-lived capability to leak.

If §12.1 later decides owners must also be proxied, **the preview cannot follow without WebSocket support in the proxy**, and the honest fallback is losing HMR (back to a reload protocol) — which is the thing §10.2 exists to avoid. That is a real coupling between Track B and Track A2 and it should be decided deliberately.

Also worth flagging: the browser gets `allow-same-origin` for a preview only because the provider ingress is cross-origin (`httpFrameSandbox`, `frames.tsx:50-63`). A **same-origin** proxy URL would run the frame opaque — which breaks Vite's HMR client for a second, independent reason.

## The Cloud `multiPort: false` risk — narrower than it looks, but a different risk is real

`multiPort` gates exactly one conformance case (`adapter-conformance.ts:175`): whether a **portless** `request()` reaches the box's `$PORT`. The `url(port)` ingress case at line 247 is **not** gated and **does** run for Cloud (`packages/vendo/src/sandbox.test.ts:279`). The wire contract states explicitly that "any explicit 1-65535 routes… so the in-box agent control port (8811) works", and the alternate-port hostname shape (`<id-suffix>-<port>-m.vendo.run`) is documented as matching the console's own machine-proxy parse, TLS live-verified 2026-07-20.

So alternate-port ingress is **not** the uncertified part. The uncertified part is sharper and nobody has flagged it yet:

> **Nothing in this repo certifies a WebSocket upgrade through either provider's per-port ingress.** No `Upgrade`/WebSocket handling exists anywhere in the sandbox seam, either adapter, or the Cloud wire contract, and no conformance case covers it.

HMR-in-a-box therefore rests on an unverified assumption for **both** e2b and Cloud. Certifying it is one conformance case — a box listener that accepts a WebSocket on a non-default port, asserted through `machine.url(port)` — but it can only run on the live lanes (real provider money), so it needs an owner and a budget decision, not a unit test.

## What I need from A2 (the template's dev server) — the exact seam

The claude-code session box's env is inference-only (`inferenceEnv()`, plus `VENDO_BOX_TOKEN` / `VENDO_WORKSPACE_ROOT` at `box.ts:189`). There is no `PORT` on this path. So:

1. **The port must be host-declared at box create time**, as one env var on `boxMachine`'s `env`, with the default in one constant both the host and the template derive from. It cannot be discovered after the fact: reporting it out of the box would need a new channel, and the event vocabulary is closed.
2. **`port: 0` is not expressible.** Measured: Vite normalises `server.port: 0` to its default 5173 and then tells the HMR client that number. A host-declared fixed port is the only workable shape. Inside the box that is safe — the supervisor owns 8080 and 8811, and the box is per-thread.
3. **`server.host` must bind `0.0.0.0`.** A dev server on `127.0.0.1` is unreachable from the provider's ingress.
4. **The HMR client must be told the PUBLIC origin.** Through the ingress the page is served from `https://<id>-<port>-m.vendo.run:443` while Vite believes it is on port N without TLS, so the template almost certainly needs `server.hmr.clientPort: 443` + `protocol: "wss"`. My local proof is same-host, same-port, no TLS, so it explicitly does **not** cover this. It is the single most likely thing to break first in a real box.

## Not shipped, and why

Plumbing the URL into a live `{ kind: "http", url }` answer needs a map from an appId to the live build box, and **that join key does not exist**: the box map keys on `threadId` (`box.ts:88`) and nothing reaching `apps.open()` carries a thread — `RunContext` is principal, venue, presence, sessionId, appId, turnId (`packages/core/src/run-context.ts:66-90`). Inventing that registry is the split-view workspace's call, and there would be nothing to point it at until the template lands. The good news is the consumer end needs no work either: `?pending=1` already answers a build-window poll (`packages/vendo/src/wire/apps.ts:167`) and `embeds.tsx` already renders whatever surface comes back, so when the registry exists the preview is a returned value, not a new path.

## Tests

- `packages/harnesses/src/claude-code/claude-code.test.ts` — the box leg, driven through the **real** box door.
- `packages/harnesses/src/claude-code/local-session.test.ts` — the local leg.
- `packages/ui/e2e/appframe-devserver.spec.ts` — the browser proof.

Every one was watched failing first (`machine.url is not a function` ×2; boot-id mismatch for the browser proof).

**Test edits, declared:** two test doubles gained the member the widened seam requires, both marked `⚠️ TEST EDIT` — the box double in `claude-code.test.ts` (shaped like e2b's per-port hostname) and the `SessionMachine` double in `claude-code-local.test.ts`. `adapter-conformance.ts` is **not** touched: `url(port)` is already certified there, and adding a case would have duplicated it.

## Two findings for someone else's backlog

1. **`packages/harnesses` type-checks none of its tests.** `tsconfig.json` excludes `src/**/*.test.ts` and there is no `tsconfig.test.json` (`engine` and `guard` both have one). Consequence: the widened seam left a stale `SessionMachine` double compiling-by-absence — I only found it by building the missing config by hand. Wiring it up properly surfaces ~8 pre-existing unrelated errors, so it is its own change. I removed a type-level assertion I had written for this PR once I proved no typecheck program runs it: a test that cannot fail is worse than none.
2. `claude-code/index.ts:405` casts the composed adapter to `SandboxAdapterLike` because `HarnessAdapters.sandbox` is typed `unknown` (deliberately, to keep provider SDKs out of the root entry). That cast means widening this seam is unchecked against real adapters — and it is why finding 1 has teeth.

## §0 concept count

Unchanged, deliberately: one member added to an existing seam, one implementation per leg, zero new surfaces, zero new vocabulary, zero lines in `packages/ui/src/`. Nothing was replaced, so nothing needed quarantining — the whole change is 216 added lines and no deletions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coded builds now preview through the template’s own dev server (real HMR) in the existing `AppFrame` iframe. Added `url(port)` to the session sandbox seam so the browser can reach the dev server locally and in the provider.

- **New Features**
  - Added `url(port)` to `SandboxMachineLike` and `SessionMachine`; box delegates to the adapter’s per‑port public ingress, local returns `http://127.0.0.1:<port>`.
  - The existing `AppFrame` renders `{ kind: "http", url }`; no UI changes needed.
  - Playwright E2E boots a real Vite server via a new e2e harness page (`/appframe-devserver`) and proves HMR (content updates without reload; boot id unchanged).
  - Preview uses direct ingress to support WebSocket HMR; the `/apps/:id/serve/**` proxy is not used.

- **Migration**
  - Set a fixed dev-server port in the box env (no port 0); bind `0.0.0.0`.
  - Configure the HMR client for the public origin (e.g., `wss` and `clientPort: 443` when behind TLS).
  - Use `SessionMachine.url(port)` to get the preview URL; UI already accepts `{ kind: "http", url }`.

<sup>Written for commit 14dec4e5d254e8daedb765aeb09d212d102d7fdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

