### PR TITLE
UI-gen A1: engine hardening — turn id, compaction, failover, budget stop, supervisor slot

### DIFF
--- a/.changeset/lean-loop-hardened.md
+++ b/.changeset/lean-loop-hardened.md
@@ -1,0 +1,43 @@
+---
+"@vendoai/agent": minor
+"@vendoai/harnesses": minor
+"@vendoai/guard": patch
+"@vendoai/vendo": patch
+---
+
+Harden the turn loop: one turn id everywhere, a token budget instead of a message
+count, a stated retry budget with ordered failover, an extensible stop array, and
+the supervisor slot.
+
+Every part of this is the shipped loop doing more, not a second loop beside it.
+
+- **Turn id on both routes.** `mintTurnId` had exactly one call site — the harness
+  runtime — so a deployment whose store cannot serve harness turns (a host's own
+  non-SQL adapter, the Cloud hosted store) wrote audit rows that named no turn.
+  `createAgent` now mints on the same terms, onto the `RunContext` every guarded
+  call and audit mint already holds. An id the caller already minted wins.
+- **Token-budgeted compaction.** `context.contextTokenBudget` bounds the PROMPT
+  rather than the message count, shedding reasoning, then old tool payloads, then
+  the oldest messages — via `pruneMessages`, which drops a tool call together with
+  its result so the prompt stays well-formed however much it sheds. The size is a
+  documented chars/4 estimate; `historyWindow` is unchanged.
+- **The knobs reach both thinkers.** `vendo()` built its context only when a
+  `maxSteps` existed and put only `maxSteps` in it, so a host's `agent:` history
+  window was silently ignored on the DEFAULT route. `VendoHarnessOptions` and
+  `VendoHarnessDeps` now carry `historyWindow`, `contextTokenBudget` and
+  `maxOutputTokens`, the whole context is passed, and `createVendo` forwards the
+  host's `agent:` block to the harness it composes.
+- **Retries and failover.** `context.maxRetries` is explicit against
+  `DEFAULT_MAX_RETRIES` (the SDK's own value, so nothing changed but ownership).
+  `fallbacks` takes the rungs below the primary model and is tried in order when a
+  provider fails BEFORE producing output; once output streams there is no
+  failover, because a mid-stream switch would emit a second answer on top of half
+  a first one. Cancellation is the only thing classified, and the last rung's error
+  is rethrown untouched, so the wire error gate is unchanged.
+- **`stopWhen` is extensible.** `createAgent`'s `stopWhen` composes with the loop's
+  own three conditions; `tokenBudgetStop(n)` is the shipped per-tenant ceiling and
+  is exported publicly. Opt-in — unset, a turn runs exactly as it did.
+- **Supervisor slot, shipped as a no-op.** `createAgent`'s `supervise` gets the
+  turn id, the final answer and the `RunContext`, and a refusal travels the failure
+  path a turn already has (`wireErrorMessage`, the same `error` chunk, the same
+  recorded notice). Unset costs a turn nothing.

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -23,7 +23,7 @@ import {
   type UIMessage,
   type UIMessageStreamWriter,
 } from "ai";
-import { startTurn, type TurnContext } from "./loop.js";
+import { startTurn, type Supervise, type TurnContext } from "./loop.js";
 import { wireErrorMessage } from "./wire-error.js";
 import { assembleSystemPrompt } from "./prompt.js";
 import { createRunner } from "./runner.js";
@@ -113,6 +113,10 @@ interface AgentConfig {
    *  ceiling it is, because neither this door nor the loop has any business
    *  knowing. Unset changes nothing. */
   stopWhen?: readonly StopCondition<ToolSet>[];
+  /** §4.1 item 6 — a verdict on every final answer, shipped as a no-op (unset =
+   *  approved). Lives here rather than on the harness because the frozen signature
+   *  takes a `RunContext` and a `Turn` deliberately carries none. */
+  supervise?: Supervise;
   capabilityMiss?: CapabilityMissConfig;
   /** ENG-252: enable the `find_tools` meta-tool and runtime loadout.
    *  When set, the model starts with a bounded initial loadout and discovers the
@@ -551,6 +555,7 @@ export function createAgent(config: AgentConfig): VendoAgent {
             ...(input.signal === undefined ? {} : { signal: input.signal }),
             ...(config.context === undefined ? {} : { context: config.context }),
             ...(config.stopWhen === undefined ? {} : { stopWhen: config.stopWhen }),
+            ...(config.supervise === undefined ? {} : { supervision: { ctx, supervise: config.supervise } }),
             ...(toolSearch === undefined ? {} : { toolSearch }),
           });
           // self-serve P: the ai-SDK `error` chunk is TRANSIENT — it sets the
@@ -583,6 +588,20 @@ export function createAgent(config: AgentConfig): VendoAgent {
           // not because the model finished — stream a renderable notice.
           const stepLimit = await loop.stepLimitPart();
           if (stepLimit !== undefined) writer.write(toVendoWirePart(stepLimit) as never);
+          // §4.1 item 6 — a withheld answer is a turn failure, so it travels the
+          // failure path this turn already has: the same `error` chunk the client
+          // renders and the same recorded notice a reload reads. Nothing new.
+          const refusal = await loop.supervisorRefusal();
+          if (refusal !== undefined) {
+            const message = wireErrorMessage(refusal);
+            // Recorded BEFORE the chunk, and in that order for the same reason
+            // the tap above records before it enqueues: writing an `error` chunk
+            // re-enters the stream's own onError with its own `new Error(text)`,
+            // which this gate can only render generically. The once-guard keeps
+            // whichever message got there first, so the crafted one has to.
+            recordTurnError(message, (part) => writer.write(part as never));
+            writer.write({ type: "error", errorText: message } as never);
+          }
         },
         onFinish: async ({ messages }) => {
           await persistFinishedTurn(threads, thread, messages, ctx);

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1,5 +1,6 @@
 import {
   VendoError,
+  mintTurnId,
   toVendoWirePart,
   type AgentRunner,
   type ApprovalId,
@@ -392,7 +393,18 @@ export function createAgent(config: AgentConfig): VendoAgent {
   return {
     async stream(input) {
       validateMessage(input?.message);
-      const thread = await threads.resolve(input.threadId, input.ctx);
+      // §3.5 — the turn's identity, minted HERE because here is where a turn
+      // begins on this route. The harness runtime mints for its own route; this
+      // one had no mint at all, so every deployment whose store cannot serve
+      // harness turns (a host's non-SQL adapter, the Cloud hosted store — see
+      // `storeServesHarnessTurns`) produced audit rows that named no turn. It
+      // rides the CTX rather than a second parameter, so every guarded call and
+      // every audit row below joins for free. An id the caller already minted
+      // WINS: the id belongs to the turn, and a second one would split its rows.
+      const ctx: RunContext = input.ctx.turnId === undefined
+        ? { ...input.ctx, turnId: mintTurnId() }
+        : input.ctx;
+      const thread = await threads.resolve(input.threadId, ctx);
       validateUpsert(thread.messages, input.message);
       if (input.message.role === "user"
         && !thread.messages.some((message) => message.id === input.message.id)) {
@@ -403,7 +415,7 @@ export function createAgent(config: AgentConfig): VendoAgent {
         const approvalIds = guardApprovalIds(thread.messages, abandonedCalls);
         if (approvalIds.length > 0 && config.guard.abandonApprovals !== undefined) {
           try {
-            await config.guard.abandonApprovals(approvalIds, input.ctx);
+            await config.guard.abandonApprovals(approvalIds, ctx);
           } catch {
             // The thread already reflects abandonment; queue cleanup retries
             // implicitly on the next abandoned turn.
@@ -414,7 +426,7 @@ export function createAgent(config: AgentConfig): VendoAgent {
       clearFailedTurnRecord(thread.messages);
       const system = await assembleSystemPrompt(
         config.guard,
-        input.ctx,
+        ctx,
         config.system,
         config.capabilityMiss !== undefined,
         // This thinker is `vendo()`'s loadout path: its meta-tool is find_tools.
@@ -450,7 +462,7 @@ export function createAgent(config: AgentConfig): VendoAgent {
           const play = await config.scripted?.({
             message: input.message,
             messages: thread.messages,
-            ctx: input.ctx,
+            ctx: ctx,
           });
           if (play !== undefined) {
             await play({ writer, ...(input.signal === undefined ? {} : { signal: input.signal }) });
@@ -460,7 +472,7 @@ export function createAgent(config: AgentConfig): VendoAgent {
             ? undefined
             : createCapabilityMissDetector({
                 config: config.capabilityMiss,
-                ctx: input.ctx,
+                ctx: ctx,
                 threadId: thread.id,
                 intent: latestUserIntent(thread.messages),
               });
@@ -471,7 +483,7 @@ export function createAgent(config: AgentConfig): VendoAgent {
           let seedNames: string[] | undefined;
           if (config.toolSearch?.seed !== undefined) {
             try {
-              seedNames = await config.toolSearch.seed(input.ctx);
+              seedNames = await config.toolSearch.seed(ctx);
             } catch {
               seedNames = undefined;
             }
@@ -482,7 +494,7 @@ export function createAgent(config: AgentConfig): VendoAgent {
           let menuNames: readonly string[] | undefined;
           if (config.toolSearch?.menu !== undefined) {
             try {
-              menuNames = await config.toolSearch.menu(input.ctx);
+              menuNames = await config.toolSearch.menu(ctx);
             } catch {
               menuNames = undefined;
             }
@@ -490,7 +502,7 @@ export function createAgent(config: AgentConfig): VendoAgent {
           const bridgeOptions = {
             registry: config.tools,
             guard: config.guard,
-            ctx: input.ctx,
+            ctx: ctx,
             writer,
             toolOutputCap: config.context?.toolOutputCap,
             ...(missDetector === undefined ? {} : { onCall: missDetector.onCall }),
@@ -505,10 +517,10 @@ export function createAgent(config: AgentConfig): VendoAgent {
             : createToolSearchSession({
                 config: config.toolSearch,
                 // Per-subject connection state annotates search results.
-                ctx: input.ctx,
+                ctx: ctx,
                 // THE LAW's projection (design §12): an unattended turn is
                 // never even offered a destructive or external tool.
-                descriptors: await config.tools.descriptors(input.ctx),
+                descriptors: await config.tools.descriptors(ctx),
                 loaded: loadedFor(thread.id),
                 ...(seedNames === undefined ? {} : { seedNames }),
                 ...(menuNames === undefined ? {} : { menuNames }),
@@ -517,7 +529,7 @@ export function createAgent(config: AgentConfig): VendoAgent {
                 // active names each step, so they are callable next step.
                 // Search must not be a way back to a withheld tool, so the
                 // same projection applies to what it can resolve.
-                resolve: async (names) => (await config.tools.descriptors(input.ctx)).filter((d) => names.includes(d.name)),
+                resolve: async (names) => (await config.tools.descriptors(ctx)).filter((d) => names.includes(d.name)),
                 materialize: (descriptor) => addAgentTool(tools, descriptor, bridgeOptions),
               });
           toolSearch?.attach(tools);
@@ -530,6 +542,7 @@ export function createAgent(config: AgentConfig): VendoAgent {
             system,
             messages: thread.messages,
             tools,
+            ...(ctx.turnId === undefined ? {} : { turnId: ctx.turnId }),
             ...(input.signal === undefined ? {} : { signal: input.signal }),
             ...(config.context === undefined ? {} : { context: config.context }),
             ...(toolSearch === undefined ? {} : { toolSearch }),
@@ -566,7 +579,7 @@ export function createAgent(config: AgentConfig): VendoAgent {
           if (stepLimit !== undefined) writer.write(toVendoWirePart(stepLimit) as never);
         },
         onFinish: async ({ messages }) => {
-          await persistFinishedTurn(threads, thread, messages, input.ctx);
+          await persistFinishedTurn(threads, thread, messages, ctx);
         },
         onError: (error) => {
           const message = wireErrorMessage(error);

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -21,7 +21,7 @@ import {
   type UIMessage,
   type UIMessageStreamWriter,
 } from "ai";
-import { startTurn } from "./loop.js";
+import { startTurn, type TurnContext } from "./loop.js";
 import { wireErrorMessage } from "./wire-error.js";
 import { assembleSystemPrompt } from "./prompt.js";
 import { createRunner } from "./runner.js";
@@ -101,17 +101,11 @@ interface AgentConfig {
     knowledge?: string | (() => string | undefined | Promise<string | undefined>);
     instructions?: string;
   };
-  context?: {
-    maxOutputTokens?: number;
-    toolOutputCap?: number;
-    /** Bound the messages re-sent to the model per turn to the last N (whole messages,
-     *  so tool-call/result pairing inside a message is never split). Undefined → send the
-     *  full thread (current behavior). Persistence and the streamed thread are unaffected. */
-    historyWindow?: number;
-    /** AGENT-7: the agent-loop step cap (default 20). Exhausting it is VISIBLE:
-     *  the stream carries a `data-vendo-step-limit` part the client can render. */
-    maxSteps?: number;
-  };
+  /** The turn loop's own knobs (ONE shape, shared with the harness caller — see
+   *  {@link TurnContext}) plus the one this door owns: `toolOutputCap` truncates a
+   *  host tool's result before it reaches the model, which happens in the tool
+   *  bridge here rather than in the loop. */
+  context?: TurnContext & { toolOutputCap?: number };
   capabilityMiss?: CapabilityMissConfig;
   /** ENG-252: enable the `find_tools` meta-tool and runtime loadout.
    *  When set, the model starts with a bounded initial loadout and discovers the
@@ -187,6 +181,10 @@ function validateConfig(config: AgentConfig): void {
   }
   if (historyWindow !== undefined && (!Number.isInteger(historyWindow) || historyWindow < 1)) {
     throw new VendoError("validation", "historyWindow must be a positive integer");
+  }
+  const { contextTokenBudget } = config.context ?? {};
+  if (contextTokenBudget !== undefined && (!Number.isInteger(contextTokenBudget) || contextTokenBudget < 1)) {
+    throw new VendoError("validation", "contextTokenBudget must be a positive integer");
   }
   const { maxSteps } = config.context ?? {};
   if (maxSteps !== undefined && (!Number.isInteger(maxSteps) || maxSteps < 1)) {

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -18,6 +18,8 @@ import {
   createUIMessageStreamResponse,
   isToolUIPart,
   type LanguageModel,
+  type StopCondition,
+  type ToolSet,
   type UIMessage,
   type UIMessageStreamWriter,
 } from "ai";
@@ -106,6 +108,11 @@ interface AgentConfig {
    *  host tool's result before it reaches the model, which happens in the tool
    *  bridge here rather than in the loop. */
   context?: TurnContext & { toolOutputCap?: number };
+  /** §4.1 item 4 — extra stop conditions for every turn, composed with the loop's
+   *  own three. `tokenBudgetStop(n)` is the shipped one; a host closes over whose
+   *  ceiling it is, because neither this door nor the loop has any business
+   *  knowing. Unset changes nothing. */
+  stopWhen?: readonly StopCondition<ToolSet>[];
   capabilityMiss?: CapabilityMissConfig;
   /** ENG-252: enable the `find_tools` meta-tool and runtime loadout.
    *  When set, the model starts with a bounded initial loadout and discovers the
@@ -543,6 +550,7 @@ export function createAgent(config: AgentConfig): VendoAgent {
             ...(ctx.turnId === undefined ? {} : { turnId: ctx.turnId }),
             ...(input.signal === undefined ? {} : { signal: input.signal }),
             ...(config.context === undefined ? {} : { context: config.context }),
+            ...(config.stopWhen === undefined ? {} : { stopWhen: config.stopWhen }),
             ...(toolSearch === undefined ? {} : { toolSearch }),
           });
           // self-serve P: the ai-SDK `error` chunk is TRANSIENT — it sets the

--- a/packages/agent/src/compaction.test.ts
+++ b/packages/agent/src/compaction.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Token-budgeted compaction (§4.1 item 2).
+ *
+ * The ORDER of shedding is the contract, not an implementation detail. Reasoning
+ * is never re-read by the model after the step that produced it; an old tool
+ * payload has already been summarised into the words around it; a dropped
+ * message loses something later turns refer to. So each band is asserted on its
+ * own — an implementation that jumped straight to dropping the oldest messages
+ * would satisfy "fits the budget" and fail every test below it.
+ *
+ * The window this replaces was a message-COUNT tail slice, which is the wrong
+ * unit: twelve one-line messages and twelve 40KB tool results are the same
+ * number and nothing like the same prompt.
+ */
+import { describe, expect, it } from "vitest";
+import type { ModelMessage, UIMessage } from "ai";
+import { turnModelMessages } from "./loop.js";
+
+const REASONING = `R${"e".repeat(4000)}`;
+const TOOL_OUTPUT = `T${"o".repeat(4000)}`;
+const OLDEST = "the oldest question";
+const NEWEST = "the newest question";
+
+/** A thread with all three sheddable kinds in it, newest last. */
+const thread = (): UIMessage[] => [
+  { id: "m1", role: "user", parts: [{ type: "text", text: OLDEST }] },
+  {
+    id: "m2",
+    role: "assistant",
+    parts: [
+      { type: "reasoning", text: REASONING },
+      { type: "text", text: "Let me look." },
+    ],
+  } as unknown as UIMessage,
+  {
+    id: "m3",
+    role: "assistant",
+    parts: [{
+      type: "dynamic-tool",
+      toolName: "dump",
+      toolCallId: "c1",
+      state: "output-available",
+      input: {},
+      output: { rows: TOOL_OUTPUT },
+    }],
+  } as unknown as UIMessage,
+  { id: "m4", role: "assistant", parts: [{ type: "text", text: "Found some." }] },
+  { id: "m5", role: "user", parts: [{ type: "text", text: NEWEST }] },
+];
+
+const wire = (messages: ModelMessage[]): string => JSON.stringify(messages);
+
+/** Every prompt must still be sendable: a system prompt, then at least the ask. */
+function expectSendable(messages: ModelMessage[]): void {
+  expect(messages[0]?.role).toBe("system");
+  expect(messages.at(-1)?.role).toBe("user");
+  expect(wire(messages)).toContain(NEWEST);
+}
+
+describe("token-budgeted compaction", () => {
+  it("sheds nothing at all when the thread already fits", async () => {
+    const generous = await turnModelMessages(thread(), "system", undefined, 100_000);
+    const unbudgeted = await turnModelMessages(thread(), "system", undefined);
+    expect(wire(generous)).toBe(wire(unbudgeted));
+  });
+
+  it("sheds REASONING first, and nothing else", async () => {
+    const shed = await turnModelMessages(thread(), "system", undefined, 1_500);
+    const raw = wire(shed);
+    expect(raw).not.toContain(REASONING);
+    // Everything cheaper to keep is still here — this is the whole point of an
+    // ordered shed rather than a tail slice.
+    expect(raw).toContain(TOOL_OUTPUT);
+    expect(raw).toContain(OLDEST);
+    expect(raw).toContain("Let me look.");
+    expectSendable(shed);
+  });
+
+  it("sheds OLD TOOL PAYLOADS second, keeping the words around them", async () => {
+    const shed = await turnModelMessages(thread(), "system", undefined, 400);
+    const raw = wire(shed);
+    expect(raw).not.toContain(REASONING);
+    expect(raw).not.toContain(TOOL_OUTPUT);
+    // The conversation itself survives a shed of its tool payloads.
+    expect(raw).toContain(OLDEST);
+    expect(raw).toContain("Found some.");
+    expectSendable(shed);
+  });
+
+  it("drops the OLDEST messages only as a last resort", async () => {
+    const shed = await turnModelMessages(thread(), "system", undefined, 10);
+    const raw = wire(shed);
+    expect(raw).not.toContain(OLDEST);
+    // Under any budget the ask survives: a turn with no user message is not a
+    // cheaper turn, it is a broken one.
+    expectSendable(shed);
+  });
+
+  it("leaves a tool call and its result PAIRED whatever it sheds", async () => {
+    // An assistant tool-call whose result was pruned is a malformed prompt every
+    // provider rejects, so the pair is shed together or not at all.
+    for (const budget of [100_000, 1_500, 400, 10]) {
+      const shed = await turnModelMessages(thread(), "system", undefined, budget);
+      const calls = shed.flatMap((message) =>
+        typeof message.content === "string"
+          ? []
+          : message.content.filter((part) => part.type === "tool-call" || part.type === "tool-result"));
+      expect(calls.length % 2, `budget ${budget}`).toBe(0);
+    }
+  });
+
+  it("keeps the message-count window working untouched", async () => {
+    // Back-compat: `historyWindow` is a shipped host knob and its meaning does
+    // not change because a budget joined it.
+    const windowed = await turnModelMessages(thread(), "system", 1);
+    expect(wire(windowed)).toContain(NEWEST);
+    expect(wire(windowed)).not.toContain(OLDEST);
+  });
+});

--- a/packages/agent/src/failover.test.ts
+++ b/packages/agent/src/failover.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Explicit retries and ordered provider failover (§4.1 item 3).
+ *
+ * `maxRetries` was unset, so the loop inherited whatever the SDK's default
+ * happened to be — a posture nobody chose and nobody could read off the code.
+ * And there was no failover at all: `startTurn` took one resolved model and had
+ * no way to be told about a second.
+ *
+ * The boundary under test is FIRST BYTE. A provider that fails before producing
+ * output has produced nothing anyone saw, so the next model can serve the whole
+ * answer; once output is streaming, switching would duplicate it, so the failure
+ * travels instead. Both halves are asserted — a "failover" that also fired
+ * mid-stream would be a correctness bug, not a more generous version of this one.
+ */
+import { APICallError } from "ai";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_MAX_RETRIES, startTurn, type TurnLoopOptions } from "./loop.js";
+import { ZERO_USAGE } from "./test-helpers.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+type Chunks = Parameters<typeof simulateReadableStream>[0]["chunks"];
+
+/** A provider failure the SDK is willing to retry — the shape that makes the
+ *  retry budget observable at all. */
+const overloaded = (): APICallError => new APICallError({
+  message: "Overloaded",
+  url: "https://api.example.test/v1/messages",
+  requestBodyValues: {},
+  statusCode: 503,
+});
+
+const answer = (text: string): Chunks => [
+  { type: "text-start", id: "t" },
+  { type: "text-delta", id: "t", delta: text },
+  { type: "text-end", id: "t" },
+  { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
+];
+
+/** Named models that record the ORDER the ladder tried them in. */
+function ladder(...rungs: Array<{ id: string; behave: () => Promise<Chunks> }>) {
+  const attempts: string[] = [];
+  const models = rungs.map((rung) => new MockLanguageModelV3({
+    modelId: rung.id,
+    doStream: async () => {
+      attempts.push(rung.id);
+      return { stream: simulateReadableStream({ chunks: await rung.behave() }) };
+    },
+  }));
+  return { attempts, models };
+}
+
+async function drain(options: Omit<TurnLoopOptions, "system" | "messages" | "tools">) {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  const loop = await startTurn({
+    system: "system",
+    messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "hi" }] }],
+    tools: {},
+    ...options,
+  });
+  let text = "";
+  const errors: unknown[] = [];
+  for await (const part of loop.result.fullStream) {
+    if (part.type === "text-delta") text += part.text;
+    if (part.type === "error") errors.push(part.error);
+  }
+  return { text, errors };
+}
+
+describe("the retry budget", () => {
+  it("is EXPLICIT — a caller can spend nothing", async () => {
+    const model = new MockLanguageModelV3({
+      doStream: async () => {
+        throw overloaded();
+      },
+    });
+    await drain({ model, context: { maxRetries: 0 } });
+    expect(model.doStreamCalls).toHaveLength(1);
+  });
+
+  it("defaults to the named constant rather than whatever the SDK ships", async () => {
+    const model = new MockLanguageModelV3({
+      doStream: async () => {
+        throw overloaded();
+      },
+    });
+    await drain({ model });
+    expect(model.doStreamCalls).toHaveLength(DEFAULT_MAX_RETRIES + 1);
+    // The SDK's backoff between retries is a real sleep (~2s then ~4s), so this
+    // test's own wall clock has to be looser than the work it waits on — a
+    // tighter budget would report a product bug for a spec-conformant delay.
+  }, 30_000);
+});
+
+describe("ordered provider failover", () => {
+  it("falls over when the primary fails BEFORE a byte, in order", async () => {
+    const { attempts, models } = ladder(
+      { id: "primary", behave: () => Promise.reject(overloaded()) },
+      { id: "second", behave: async () => answer("the second rung served") },
+    );
+    const [primary, second] = models;
+    const { text, errors } = await drain({
+      model: primary!,
+      fallbacks: [second!],
+      context: { maxRetries: 0 },
+    });
+
+    expect(text).toBe("the second rung served");
+    expect(errors).toEqual([]);
+    // The ORDER is the contract: a ladder that tried the fallback first would
+    // silently demote the seat the host chose.
+    expect(attempts).toEqual(["primary", "second"]);
+  });
+
+  it("falls over on a stream that errors at its first output part", async () => {
+    // A provider that accepted the call and then failed has still produced
+    // nothing a user saw. `stream-start` carries warnings, not output, so it
+    // must not count as a committed byte.
+    const { attempts, models } = ladder(
+      {
+        id: "primary",
+        behave: async () => [
+          { type: "stream-start", warnings: [] },
+          { type: "error", error: overloaded() },
+        ],
+      },
+      { id: "second", behave: async () => answer("recovered") },
+    );
+    const { text, errors } = await drain({
+      model: models[0]!,
+      fallbacks: [models[1]!],
+      context: { maxRetries: 0 },
+    });
+
+    expect(text).toBe("recovered");
+    expect(errors).toEqual([]);
+    expect(attempts).toEqual(["primary", "second"]);
+  });
+
+  it("does NOT fall over once output is streaming — that would duplicate it", async () => {
+    const { attempts, models } = ladder(
+      {
+        id: "primary",
+        behave: async () => [
+          { type: "text-start", id: "t" },
+          { type: "text-delta", id: "t", delta: "half an answ" },
+          { type: "error", error: overloaded() },
+        ],
+      },
+      { id: "second", behave: async () => answer("a whole second answer") },
+    );
+    const { text, errors } = await drain({
+      model: models[0]!,
+      fallbacks: [models[1]!],
+      context: { maxRetries: 0 },
+    });
+
+    expect(text).toBe("half an answ");
+    expect(errors).toHaveLength(1);
+    expect(attempts).toEqual(["primary"]);
+  });
+
+  it("surfaces the LAST rung's failure when every rung fails", async () => {
+    const { attempts, models } = ladder(
+      { id: "primary", behave: () => Promise.reject(overloaded()) },
+      { id: "second", behave: () => Promise.reject(overloaded()) },
+    );
+    const { errors } = await drain({
+      model: models[0]!,
+      fallbacks: [models[1]!],
+      context: { maxRetries: 0 },
+    });
+    expect(errors).toHaveLength(1);
+    expect(attempts).toEqual(["primary", "second"]);
+  });
+
+  it("does not walk the ladder for a turn the caller cancelled", async () => {
+    // Otherwise one hang-up calls every provider the host configured.
+    const abort = new AbortController();
+    const { attempts, models } = ladder(
+      {
+        id: "primary",
+        behave: () => {
+          abort.abort();
+          return Promise.reject(new Error("aborted"));
+        },
+      },
+      { id: "second", behave: async () => answer("never") },
+    );
+    await drain({
+      model: models[0]!,
+      fallbacks: [models[1]!],
+      signal: abort.signal,
+      context: { maxRetries: 0 },
+    });
+    expect(attempts).toEqual(["primary"]);
+  });
+});

--- a/packages/agent/src/failover.ts
+++ b/packages/agent/src/failover.ts
@@ -1,0 +1,108 @@
+/**
+ * Ordered provider failover, at the FIRST BYTE and no later.
+ *
+ * Why it lives at the model seam rather than around `streamText`: `streamText`
+ * does not throw a provider failure — the default `onError` logs it and the text
+ * stream simply ends, so callers tap the `error` chunk instead. A try/catch
+ * around the call would therefore never see the failure it is meant to recover
+ * from, and peeking the result's stream to check is not available either
+ * (`toUIMessageStream()` and `fullStream` read the same source once, so a peek
+ * upstream of the caller would eat the answer). One rung DOWN, at `doStream`, the
+ * failure is a rejection or a first `error` part and the stream is still ours to
+ * hand on.
+ *
+ * The boundary is first byte, deliberately. A provider that fails before
+ * producing output produced nothing anyone saw, so the next rung can serve the
+ * whole answer. Once output is streaming, switching would emit a second answer
+ * on top of half of a first one, so the failure travels to the caller's existing
+ * error path instead. There is no partial-replay mode and there should not be.
+ *
+ * Nothing here classifies a failure by ORIGIN or reshapes its message: the last
+ * rung's own error is rethrown untouched, so `wireErrorMessage` sees exactly what
+ * it sees today and keeps knowing the shape and never the origin.
+ */
+import type { LanguageModel } from "ai";
+
+/** A model this can wrap. `LanguageModel` also admits a provider-id string, and a
+ *  string has no `doStream` to fall over. */
+export type ResolvedModel = Extract<LanguageModel, { specificationVersion: "v3" }>;
+
+type StreamResult = Awaited<ReturnType<ResolvedModel["doStream"]>>;
+type StreamPart = StreamResult["stream"] extends ReadableStream<infer Part> ? Part : never;
+
+/** Parts that carry no model OUTPUT: warnings and response metadata arrive before
+ *  the model has said anything, so a failure after them is still a failure at the
+ *  first byte. */
+const PREAMBLE = new Set(["stream-start", "response-metadata"]);
+
+/** Re-serve the parts already read, then the rest of the same stream. */
+function replay(buffered: StreamPart[], reader: ReadableStreamDefaultReader<StreamPart>): ReadableStream<StreamPart> {
+  return new ReadableStream<StreamPart>({
+    start(controller) {
+      for (const part of buffered) controller.enqueue(part);
+    },
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (done) controller.close();
+      else controller.enqueue(value);
+    },
+    cancel: (reason) => reader.cancel(reason),
+  });
+}
+
+/** One rung: call it, and read up to (and including) its first OUTPUT part so a
+ *  failure that early can still be someone else's turn to serve. */
+async function attempt(model: ResolvedModel, options: Parameters<ResolvedModel["doStream"]>[0]): Promise<StreamResult> {
+  const result = await model.doStream(options);
+  const reader = result.stream.getReader();
+  const buffered: StreamPart[] = [];
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffered.push(value);
+      if (value.type === "error") throw value.error;
+      if (!PREAMBLE.has(value.type)) break;
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => undefined);
+    throw error;
+  }
+  return { ...result, stream: replay(buffered, reader) };
+}
+
+/**
+ * The ordered ladder as ONE model, so every caller downstream — `streamText`, its
+ * retry budget, its step loop — is unchanged and unaware.
+ */
+export function failoverModel(ladder: readonly [ResolvedModel, ...ResolvedModel[]]): ResolvedModel {
+  const [primary] = ladder;
+  const walk = async <T>(
+    options: { abortSignal?: AbortSignal },
+    call: (model: ResolvedModel) => PromiseLike<T>,
+  ): Promise<T> => {
+    let last: unknown;
+    for (const model of ladder) {
+      try {
+        return await call(model);
+      } catch (error) {
+        // The ONE classification, and it is not about the error's origin: a
+        // cancelled turn is not a failed provider. Without this, one hang-up
+        // calls every provider the host configured.
+        if (options.abortSignal?.aborted === true) throw error;
+        last = error;
+      }
+    }
+    throw last;
+  };
+  return {
+    specificationVersion: "v3",
+    provider: primary.provider,
+    modelId: primary.modelId,
+    get supportedUrls() {
+      return primary.supportedUrls;
+    },
+    doGenerate: (options) => walk(options, (model) => model.doGenerate(options)),
+    doStream: (options) => walk(options, (model) => attempt(model, options)),
+  };
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,4 +1,7 @@
 export { createAgent } from "./agent.js";
+// §4.1 item 4 — the shipped per-tenant token ceiling, for `createAgent`'s
+// `stopWhen`. Public because the ceiling belongs to whoever is being metered.
+export { tokenBudgetStop } from "./loop.js";
 export type { ScriptedTurn, VendoAgent } from "./agent.js";
 export type { CapabilityMissConfig } from "./capability-miss.js";
 export {

--- a/packages/agent/src/internal.ts
+++ b/packages/agent/src/internal.ts
@@ -9,7 +9,7 @@
  * bump — the only supported consumer is another `@vendoai/*` block.
  */
 export { startTurn, providerHistory, turnModelMessages, DEFAULT_MAX_STEPS } from "./loop.js";
-export type { TurnLoop, TurnLoopOptions } from "./loop.js";
+export type { TurnContext, TurnLoop, TurnLoopOptions } from "./loop.js";
 export { wireErrorMessage } from "./wire-error.js";
 export { addAgentTool, buildAgentTools, guardedCall, previewApproval } from "./tools.js";
 export type { ToolBridgeOptions } from "./tools.js";

--- a/packages/agent/src/internal.ts
+++ b/packages/agent/src/internal.ts
@@ -8,7 +8,16 @@
  * as before it. Anything re-exported here is free to change shape without a major
  * bump — the only supported consumer is another `@vendoai/*` block.
  */
-export { startTurn, providerHistory, turnModelMessages, DEFAULT_MAX_STEPS } from "./loop.js";
+export {
+  startTurn,
+  providerHistory,
+  tokenBudgetStop,
+  turnModelMessages,
+  DEFAULT_MAX_RETRIES,
+  DEFAULT_MAX_STEPS,
+} from "./loop.js";
+export { failoverModel } from "./failover.js";
+export type { ResolvedModel } from "./failover.js";
 export type { TurnContext, TurnLoop, TurnLoopOptions } from "./loop.js";
 export { wireErrorMessage } from "./wire-error.js";
 export { addAgentTool, buildAgentTools, guardedCall, previewApproval } from "./tools.js";

--- a/packages/agent/src/loop.ts
+++ b/packages/agent/src/loop.ts
@@ -19,6 +19,7 @@ import {
   VendoError,
   VENDO_MAKE_TOOL,
   VENDO_APP_BUILD_FAILED_PREFIX,
+  type RunContext,
   type TurnId,
   type VendoStepLimitPart,
 } from "@vendoai/core";
@@ -234,6 +235,17 @@ export interface TurnLoopOptions {
    *  composed turn; every composed caller mints one. */
   turnId?: TurnId;
   context?: TurnContext;
+  /**
+   * §4.1 item 6 — the supervisor slot, shipped as a NO-OP. Unset means
+   * `{ok: true}` and costs the turn nothing: the final answer is not even
+   * awaited for it.
+   *
+   * `ctx` travels beside the hook because the signature is a frozen inter-project
+   * seam that asks for one, and the loop holds no `RunContext` of its own. That is
+   * also why only `createAgent` can fill this: a `Turn` deliberately carries no
+   * ctx, so a harness has none to hand over.
+   */
+  supervision?: { ctx: RunContext; supervise: Supervise };
   /** Extra stop conditions, COMPOSED with the loop's own three rather than
    *  replacing them. The array used to be a literal, so a caller who needed a
    *  fourth condition had nowhere to put it and would have had to grow a second
@@ -259,6 +271,17 @@ export interface TurnContext {
   maxRetries?: number;
 }
 
+/**
+ * §4.1 item 6 — FROZEN signature (inter-project seam; the verification project
+ * is the consumer). A verdict on the turn's final answer: `{ok: true}` lets it
+ * stand, `{ok: false}` withholds it with a reason the user is shown.
+ */
+export type Supervise = (input: {
+  turnId: TurnId;
+  answer: string;
+  ctx: RunContext;
+}) => Promise<{ ok: true } | { ok: false; reason: string }>;
+
 export interface TurnLoop {
   result: ReturnType<typeof streamText>;
   maxSteps: number;
@@ -268,6 +291,17 @@ export interface TurnLoop {
    * because of the cap, not because the model finished.
    */
   stepLimitPart(): Promise<VendoStepLimitPart | undefined>;
+  /**
+   * §4.1 item 6 — the supervisor's verdict on the final answer, as an ERROR the
+   * caller sends through the failure path it already has. A `VendoError` because
+   * that is the one shape `wireErrorMessage` passes through recognizably: the
+   * reason is ours and crafted, so the user reads it instead of the generic line,
+   * and no new wire part or `HarnessEvent` member had to exist for this.
+   *
+   * Resolves `undefined` when no supervisor is configured — including without
+   * awaiting the answer, so an unset slot is not even a scheduling difference.
+   */
+  supervisorRefusal(): Promise<VendoError | undefined>;
 }
 
 /** The model `streamText` is handed: the one the caller named, or the ordered
@@ -285,6 +319,11 @@ function turnModel(options: TurnLoopOptions): LanguageModel {
 
 export async function startTurn(options: TurnLoopOptions): Promise<TurnLoop> {
   const maxSteps = options.context?.maxSteps ?? DEFAULT_MAX_STEPS;
+  if (options.supervision !== undefined && options.turnId === undefined) {
+    // A verdict nobody can attribute is not a verdict. Every composed caller
+    // mints a turn id, so this is a wiring mistake, not a runtime condition.
+    throw new VendoError("validation", "supervision needs the turn it is judging (turnId)");
+  }
   const modelMessages = await turnModelMessages(
     options.messages,
     options.system,
@@ -319,6 +358,17 @@ export async function startTurn(options: TurnLoopOptions): Promise<TurnLoop> {
   return {
     result,
     maxSteps,
+    async supervisorRefusal() {
+      const { supervision, turnId } = options;
+      if (supervision === undefined || turnId === undefined) return undefined;
+      const verdict = await supervision.supervise({
+        turnId,
+        answer: await result.text,
+        ctx: supervision.ctx,
+      });
+      if (verdict.ok) return undefined;
+      return new VendoError("blocked", verdict.reason);
+    },
     async stepLimitPart() {
       try {
         const [finishReason, steps] = await Promise.all([result.finishReason, result.steps]);

--- a/packages/agent/src/loop.ts
+++ b/packages/agent/src/loop.ts
@@ -16,6 +16,7 @@
  */
 import {
   ASK_USER_TOOL,
+  VendoError,
   VENDO_MAKE_TOOL,
   VENDO_APP_BUILD_FAILED_PREFIX,
   type TurnId,
@@ -33,11 +34,19 @@ import {
   type ToolSet,
   type UIMessage,
 } from "ai";
+import { failoverModel, type ResolvedModel } from "./failover.js";
 import type { ToolSearchSession } from "./tool-search.js";
 
 // AGENT-7: the default agent-loop step cap (unchanged from the previously
 // hardcoded value); hosts raise or lower it via context.maxSteps.
 export const DEFAULT_MAX_STEPS = 20;
+
+/** §4.1 item 3 — the per-turn provider retry budget, STATED. It used to be unset,
+ *  so the loop inherited whatever the SDK's default happened to be: a posture
+ *  nobody chose, that no reader of this file could see, and that a minor version
+ *  bump could change under us. The value matches the SDK's own default, so making
+ *  it explicit changed no behaviour — only who owns it. */
+export const DEFAULT_MAX_RETRIES = 2;
 
 // Anthropic prompt-caching breakpoint. providerOptions.anthropic is ignored by every
 // other provider (and by the test mocks), so marking breakpoints degrades to a no-op.
@@ -192,6 +201,11 @@ export async function turnModelMessages(
 
 export interface TurnLoopOptions {
   model: LanguageModel;
+  /** §4.1 item 3 — the rungs BELOW `model`, tried in order when a provider fails
+   *  before producing any output. Unset (the normal case) means no ladder is built
+   *  and the model reaches `streamText` exactly as it does today. See
+   *  {@link failoverModel} for why the boundary is the first byte. */
+  fallbacks?: readonly ResolvedModel[];
   system: string;
   messages: UIMessage[];
   /** Already built and guard-bound by the caller (buildAgentTools, or the
@@ -218,6 +232,9 @@ export interface TurnContext {
    *  tokenized (see {@link CHARS_PER_TOKEN}). */
   contextTokenBudget?: number;
   maxSteps?: number;
+  /** How many times the SDK re-issues a failed provider call. Defaults to
+   *  {@link DEFAULT_MAX_RETRIES}; 0 spends nothing. */
+  maxRetries?: number;
 }
 
 export interface TurnLoop {
@@ -231,6 +248,19 @@ export interface TurnLoop {
   stepLimitPart(): Promise<VendoStepLimitPart | undefined>;
 }
 
+/** The model `streamText` is handed: the one the caller named, or the ordered
+ *  ladder when it named more. Unset fallbacks build nothing at all, so a
+ *  single-model turn is byte-for-byte the call it was before failover existed. */
+function turnModel(options: TurnLoopOptions): LanguageModel {
+  const fallbacks = options.fallbacks ?? [];
+  if (fallbacks.length === 0) return options.model;
+  const primary = options.model;
+  if (typeof primary === "string" || primary.specificationVersion !== "v3") {
+    throw new VendoError("validation", "provider failover needs a resolved v3 model as the primary");
+  }
+  return failoverModel([primary, ...fallbacks]);
+}
+
 export async function startTurn(options: TurnLoopOptions): Promise<TurnLoop> {
   const maxSteps = options.context?.maxSteps ?? DEFAULT_MAX_STEPS;
   const modelMessages = await turnModelMessages(
@@ -241,11 +271,13 @@ export async function startTurn(options: TurnLoopOptions): Promise<TurnLoop> {
   );
   const { toolSearch } = options;
   const result = streamText({
-    model: options.model,
+    model: turnModel(options),
     messages: modelMessages,
     tools: options.tools,
     stopWhen: [stepCountIs(maxSteps), buildFailedStop, askedUserStop],
     maxOutputTokens: options.context?.maxOutputTokens,
+    // Stated rather than inherited — see DEFAULT_MAX_RETRIES.
+    maxRetries: options.context?.maxRetries ?? DEFAULT_MAX_RETRIES,
     // ENG-252 loadout: restrict what the model may pick to the current loadout.
     // `prepareStep` re-reads it each step so a tool loaded via
     // `vendo_tools_search` becomes callable on the very next step. This gates the

--- a/packages/agent/src/loop.ts
+++ b/packages/agent/src/loop.ts
@@ -90,6 +90,23 @@ const askedUserStop: StopCondition<ToolSet> = ({ steps }) => {
   });
 };
 
+/**
+ * §4.1 item 4 — a token ceiling for one turn, as one more StopCondition. The
+ * caller closes over whose ceiling it is (a tenant, a seat, a plan), because the
+ * loop has no business knowing.
+ *
+ * A StopCondition is consulted AFTER a step, so crossing the ceiling always costs
+ * the step that crossed it. That is what makes this a budget rather than a hard
+ * cap, and it is the only honest shape available: token spend is not knowable
+ * until the provider reports it.
+ */
+export function tokenBudgetStop(maxTotalTokens: number): StopCondition<ToolSet> {
+  return ({ steps }) => steps.reduce((spent, step) => {
+    const { totalTokens, inputTokens, outputTokens } = step.usage;
+    return spent + (totalTokens ?? (inputTokens ?? 0) + (outputTokens ?? 0));
+  }, 0) >= maxTotalTokens;
+}
+
 /** An approval the conversation abandoned reaches the PROVIDER as a denied tool
  *  call, not as our internal `approval-responded` state. */
 export function providerHistory(messages: UIMessage[]): UIMessage[] {
@@ -217,6 +234,11 @@ export interface TurnLoopOptions {
    *  composed turn; every composed caller mints one. */
   turnId?: TurnId;
   context?: TurnContext;
+  /** Extra stop conditions, COMPOSED with the loop's own three rather than
+   *  replacing them. The array used to be a literal, so a caller who needed a
+   *  fourth condition had nowhere to put it and would have had to grow a second
+   *  stop mechanism beside this one. */
+  stopWhen?: readonly StopCondition<ToolSet>[];
   toolSearch?: ToolSearchSession;
 }
 
@@ -274,7 +296,7 @@ export async function startTurn(options: TurnLoopOptions): Promise<TurnLoop> {
     model: turnModel(options),
     messages: modelMessages,
     tools: options.tools,
-    stopWhen: [stepCountIs(maxSteps), buildFailedStop, askedUserStop],
+    stopWhen: [stepCountIs(maxSteps), buildFailedStop, askedUserStop, ...(options.stopWhen ?? [])],
     maxOutputTokens: options.context?.maxOutputTokens,
     // Stated rather than inherited — see DEFAULT_MAX_RETRIES.
     maxRetries: options.context?.maxRetries ?? DEFAULT_MAX_RETRIES,

--- a/packages/agent/src/loop.ts
+++ b/packages/agent/src/loop.ts
@@ -1,5 +1,5 @@
 /**
- * The turn loop — ONE implementation, two callers.
+ * The turn loop — ONE implementation, every caller.
  *
  * This is the `streamText` call that used to live inside `createAgent`'s
  * `createUIMessageStream` closure, lifted out verbatim so it can also be driven
@@ -14,7 +14,13 @@
  * merges `result.toUIMessageStream()`; the harness reads `result.fullStream` and
  * yields events. Everything before that fork is identical.
  */
-import { ASK_USER_TOOL, VENDO_MAKE_TOOL, VENDO_APP_BUILD_FAILED_PREFIX, type VendoStepLimitPart } from "@vendoai/core";
+import {
+  ASK_USER_TOOL,
+  VENDO_MAKE_TOOL,
+  VENDO_APP_BUILD_FAILED_PREFIX,
+  type TurnId,
+  type VendoStepLimitPart,
+} from "@vendoai/core";
 import {
   convertToModelMessages,
   isToolUIPart,
@@ -132,6 +138,10 @@ export interface TurnLoopOptions {
    *  harness runtime's delegating set). */
   tools: ToolSet;
   signal?: AbortSignal;
+  /** §3.5 — the turn this loop is running, for anything downstream that has to
+   *  name it. Optional only because a caller may drive the loop outside a
+   *  composed turn; every composed caller mints one. */
+  turnId?: TurnId;
   context?: {
     maxOutputTokens?: number;
     historyWindow?: number;

--- a/packages/agent/src/loop.ts
+++ b/packages/agent/src/loop.ts
@@ -24,6 +24,7 @@ import {
 import {
   convertToModelMessages,
   isToolUIPart,
+  pruneMessages,
   stepCountIs,
   streamText,
   type LanguageModel,
@@ -102,21 +103,80 @@ export function providerHistory(messages: UIMessage[]): UIMessage[] {
 }
 
 /**
+ * Prompt tokens per character. An ESTIMATE, deliberately: there is no tokenizer
+ * in this repo and adding one buys accuracy the budget does not need — a
+ * per-provider vocabulary is megabytes, is wrong for every model it was not
+ * built for, and would have to load before the first turn. Four characters per
+ * token is within a few percent of every BPE tokenizer on English prose and
+ * JSON, and both directions of error are cheap: under-shedding is caught by the
+ * provider's own context limit, over-shedding costs one extra old message.
+ */
+const CHARS_PER_TOKEN = 4;
+
+/** The estimate, over the wire form the provider is actually billed for. */
+function estimateTokens(messages: readonly ModelMessage[]): number {
+  return Math.ceil(JSON.stringify(messages).length / CHARS_PER_TOKEN);
+}
+
+/**
+ * Shed a turn's history to a token budget, CHEAPEST LOSS FIRST:
+ *
+ *   1. reasoning — never re-read by the model after the step that produced it;
+ *   2. old tool payloads — a result the conversation has already summarised, and
+ *      the newest exchange keeps its own;
+ *   3. the oldest messages — the only band that loses something a later turn may
+ *      refer to, so it is the last resort.
+ *
+ * `pruneMessages` (shipped in `ai`) does bands 1 and 2, and it drops a tool call
+ * together with its result, so the prompt stays well-formed however much it
+ * sheds. The ask always survives: a turn with no user message is not a cheaper
+ * turn, it is a broken one.
+ */
+function shedToBudget(
+  messages: readonly ModelMessage[],
+  system: string,
+  budget: number,
+): ModelMessage[] {
+  // The system prompt is part of the same window and is not sheddable, so it is
+  // charged against the budget rather than ignored by it.
+  const overhead = estimateTokens([{ role: "system", content: system }]);
+  const fits = (candidate: readonly ModelMessage[]): boolean =>
+    estimateTokens(candidate) + overhead <= budget;
+  if (fits(messages)) return [...messages];
+  let shed = pruneMessages({
+    messages: [...messages],
+    reasoning: "before-last-message",
+    emptyMessages: "remove",
+  });
+  if (fits(shed)) return shed;
+  shed = pruneMessages({ messages: shed, toolCalls: "before-last-message", emptyMessages: "remove" });
+  if (fits(shed)) return shed;
+  while (shed.length > 1 && !fits(shed)) shed = shed.slice(1);
+  return shed;
+}
+
+/**
  * The provider messages for one turn: the system prompt, the optionally windowed
- * history, and the cache breakpoints that keep a growing thread from re-billing.
+ * and budgeted history, and the cache breakpoints that keep a growing thread from
+ * re-billing.
  */
 export async function turnModelMessages(
   messages: UIMessage[],
   system: string,
   historyWindow: number | undefined,
+  tokenBudget?: number,
 ): Promise<ModelMessage[]> {
   // History windowing: bound what is re-sent per turn to the last N whole messages.
   // Slicing whole UIMessages keeps each turn's tool-call/result pairing intact.
   const history = historyWindow !== undefined && messages.length > historyWindow
     ? messages.slice(-historyWindow)
     : messages;
-  const converted = (await convertToModelMessages(providerHistory(history)))
+  let converted = (await convertToModelMessages(providerHistory(history)))
     .filter((message) => message.content.length > 0);
+  // Budgeting runs on the CONVERTED form because that is the form the provider
+  // bills, and it runs before the breakpoints below because shedding changes
+  // which message is the stable prefix's last one.
+  if (tokenBudget !== undefined) converted = shedToBudget(converted, system, tokenBudget);
   // Cache the stable history prefix (everything but the final message) alongside the
   // static system prompt below, so Anthropic re-reads the cached prefix instead of
   // re-billing the whole growing thread each turn.
@@ -142,12 +202,22 @@ export interface TurnLoopOptions {
    *  name it. Optional only because a caller may drive the loop outside a
    *  composed turn; every composed caller mints one. */
   turnId?: TurnId;
-  context?: {
-    maxOutputTokens?: number;
-    historyWindow?: number;
-    maxSteps?: number;
-  };
+  context?: TurnContext;
   toolSearch?: ToolSearchSession;
+}
+
+/** The per-turn knobs, one shape both callers pass so neither can carry half of
+ *  them (`vendo()` used to pass `maxSteps` alone, which made every other knob
+ *  structurally unreachable from the default harness). */
+export interface TurnContext {
+  maxOutputTokens?: number;
+  /** Bound the messages re-sent per turn to the last N whole messages. */
+  historyWindow?: number;
+  /** §4.1 item 2 — bound the PROMPT instead of the message count: reasoning and
+   *  old tool payloads are shed before any message is dropped. Estimated, not
+   *  tokenized (see {@link CHARS_PER_TOKEN}). */
+  contextTokenBudget?: number;
+  maxSteps?: number;
 }
 
 export interface TurnLoop {
@@ -167,6 +237,7 @@ export async function startTurn(options: TurnLoopOptions): Promise<TurnLoop> {
     options.messages,
     options.system,
     options.context?.historyWindow,
+    options.context?.contextTokenBudget,
   );
   const { toolSearch } = options;
   const result = streamText({

--- a/packages/agent/src/supervisor.test.ts
+++ b/packages/agent/src/supervisor.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The supervisor slot (§4.1 item 6) — ONE slot, ONE call site, shipped as a
+ * no-op.
+ *
+ * It exists before anyone needs it because the verification project fills it, and
+ * its signature is a frozen inter-project seam. So the two things worth testing
+ * are the two things that could go wrong on our side: an unset supervisor must
+ * cost a turn nothing at all, and a refusal must reach the user through the error
+ * path that already exists rather than a new part nobody renders.
+ */
+import type { RunContext } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createAgent } from "./index.js";
+import {
+  boundRegistry,
+  ctx,
+  readSse,
+  scriptedModel,
+  testGuard,
+  textTurn,
+  userMessage,
+} from "./test-helpers.js";
+
+type Supervised = { turnId: string; answer: string; ctx: RunContext };
+
+async function turn(supervise?: (input: Supervised) => Promise<{ ok: true } | { ok: false; reason: string }>) {
+  const guard = testGuard({});
+  const agent = createAgent({
+    model: scriptedModel([textTurn("Two invoices.", "t1")]),
+    tools: boundRegistry({}, guard),
+    guard,
+    ...(supervise === undefined ? {} : { supervise }),
+  });
+  const response = await agent.stream({
+    threadId: "thr_supervise",
+    message: userMessage("u1", "how many invoices"),
+    ctx: ctx(),
+  });
+  return readSse(response);
+}
+
+/** The `start` frame's messageId is minted per stream by the SDK, so it is the
+ *  one field two runs of the same turn cannot agree on. Everything else is
+ *  compared byte for byte. */
+const stable = (frames: string[]): string[] =>
+  frames.map((frame) => frame.replace(/"messageId":"[^"]+"/u, '"messageId":"<minted>"'));
+
+describe("the supervisor slot", () => {
+  it("costs an unset turn nothing — byte-identical to no supervisor at all", async () => {
+    const baseline = await turn();
+    const approved = await turn(async () => ({ ok: true }));
+    expect(stable(approved.rawFrames)).toEqual(stable(baseline.rawFrames));
+  });
+
+  it("sends a refusal through the EXISTING error path, with no new part", async () => {
+    const { parts } = await turn(async () => ({ ok: false, reason: "The answer names an account the user cannot see." }));
+
+    // `wireErrorMessage`'s Vendo-shaped branch: the reason is ours, crafted, and
+    // safe to show, so it travels recognizably prefixed — the same affordance
+    // (banner, Retry, detail line) every other turn failure already renders.
+    const error = parts.find((part) => part.type === "error");
+    expect(error?.errorText).toBe(
+      "Vendo: The answer names an account the user cannot see. (blocked)",
+    );
+    // And it is RECORDED in the turn, like any other failure, so a reload still
+    // says why the answer was withheld.
+    const recorded = parts.find((part) => part.type === "data-vendo-turn-error");
+    expect((recorded as { data: { message: string } } | undefined)?.data.message)
+      .toBe("Vendo: The answer names an account the user cannot see. (blocked)");
+    // No second vocabulary: nothing shaped like a supervision part is on the wire.
+    expect(parts.some((part) => String(part.type).includes("supervis"))).toBe(false);
+  });
+
+  it("is told the turn it judged, the answer it judged, and whose run it was", async () => {
+    const seen: Supervised[] = [];
+    await turn(async (input) => {
+      seen.push(input);
+      return { ok: true };
+    });
+
+    expect(seen).toHaveLength(1);
+    const [only] = seen;
+    // The turn id is §3.5's, minted once per turn — the same id the audit rows
+    // carry, which is the whole point of handing it over.
+    expect(only!.turnId).toMatch(/^trn_[0-9a-f]{32}$/);
+    expect(only!.answer).toBe("Two invoices.");
+    expect(only!.ctx.principal.subject).toBe("u1");
+    expect(only!.ctx.turnId).toBe(only!.turnId);
+  });
+});

--- a/packages/agent/src/token-budget.test.ts
+++ b/packages/agent/src/token-budget.test.ts
@@ -1,0 +1,85 @@
+/**
+ * A per-tenant token ceiling (§4.1 item 4).
+ *
+ * The loop's `stopWhen` was a hardcoded array literal — three conditions and no
+ * seam — so a caller who needed a fourth had no way to add one and would have
+ * had to build a second stop mechanism beside it. It takes extra conditions now,
+ * and the ceiling is one member of that array rather than a new rail.
+ *
+ * Modelled on step-cap.test.ts: the scripted model carries exactly as many turns
+ * as the run is allowed, so `doStreamCalls.length` — not a claim about intent —
+ * is what proves the loop stopped.
+ */
+import { tool } from "ai";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { startTurn, tokenBudgetStop } from "./loop.js";
+
+/** 100 tokens a step, so a ceiling lands between steps unambiguously. */
+const STEP_USAGE = {
+  inputTokens: { total: 60, noCache: 60, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 40, text: 40, reasoning: 0 },
+} as const;
+const TOKENS_PER_STEP = 100;
+
+const echo = tool({
+  description: "Echo a value back.",
+  inputSchema: z.object({ value: z.string() }),
+  execute: async (input: { value: string }) => input,
+});
+
+/** A model that asks for one more tool call every step, forever. */
+function insatiableModel() {
+  let step = 0;
+  return new MockLanguageModelV3({
+    doStream: async () => {
+      step += 1;
+      return {
+        stream: simulateReadableStream({ chunks: [
+          { type: "tool-call", toolCallId: `call_${step}`, toolName: "echo", input: JSON.stringify({ value: `v${step}` }) },
+          { type: "finish", usage: STEP_USAGE, finishReason: { unified: "tool-calls", raw: undefined } },
+        ] }),
+      };
+    },
+  });
+}
+
+async function run(options: { budget?: number; maxSteps: number }) {
+  const model = insatiableModel();
+  const loop = await startTurn({
+    model,
+    system: "system",
+    messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "keep going" }] }],
+    tools: { echo },
+    context: { maxSteps: options.maxSteps },
+    ...(options.budget === undefined ? {} : { stopWhen: [tokenBudgetStop(options.budget)] }),
+  });
+  for await (const _part of loop.result.fullStream) { /* drain */ }
+  return model.doStreamCalls.length;
+}
+
+describe("a per-tenant token budget", () => {
+  it("stops after the step that crosses the ceiling", async () => {
+    // Step 1 spends 100 (under 150, so the loop continues); step 2 puts the run
+    // at 200 (over, so it stops). A condition is consulted after a step, so
+    // "crossing" always costs the step that crossed — which is why the ceiling is
+    // a budget and not a hard cap.
+    expect(await run({ budget: TOKENS_PER_STEP + 50, maxSteps: 10 })).toBe(2);
+  });
+
+  it("changes nothing when it is unset", async () => {
+    // OPT-IN: the same insatiable model, no ceiling, runs to the step cap.
+    expect(await run({ maxSteps: 4 })).toBe(4);
+  });
+
+  it("stops on the FIRST step when the ceiling is below one step's spend", async () => {
+    expect(await run({ budget: 1, maxSteps: 10 })).toBe(1);
+  });
+
+  it("leaves the loop's own three conditions in force", async () => {
+    // The extras are composed with the shipped array, never a replacement for it:
+    // a generous ceiling must still hit the step cap.
+    expect(await run({ budget: 1_000_000, maxSteps: 3 })).toBe(3);
+  });
+});

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -163,8 +163,11 @@ function exactInputHash(args: unknown): string {
 /** Build contract §7's key: sha256 over the run, the tool, and the exact input.
  *  `undefined` means this call is not ledger-eligible at all.
  *
- *  The contract writes the preimage as `runId|turnId`. There is no turn id
- *  anywhere in this codebase, so the run component is `ctx.trigger.runId`.
+ *  The contract writes the preimage as `runId|turnId`. `ctx.turnId` now exists
+ *  (§3.5) but the run component stays `ctx.trigger.runId` — deliberately, and
+ *  the reasoning below is why: a turn is even narrower than a session, so keying
+ *  on it would make "pay this invoice" asked twice in one conversation charge
+ *  twice, which is precisely what the ledger exists to prevent.
  *
  *  It deliberately does NOT fall back to `ctx.sessionId`, even though the write
  *  breaker and `task`-duration grants do. The ledger exists to make

--- a/packages/harnesses/src/test-doubles.test-util.ts
+++ b/packages/harnesses/src/test-doubles.test-util.ts
@@ -292,16 +292,24 @@ export function toolCallTurn(toolName: string, input: unknown, toolCallId = "cal
   ];
 }
 
-export type ScriptedModel = LanguageModel & { toolNamesPerCall: string[][]; calls: number };
+export type ScriptedModel = LanguageModel & {
+  toolNamesPerCall: string[][];
+  /** What each call actually SENT — the only place a suite can prove what the
+   *  loop's history assembly did or did not include. */
+  prompts: unknown[];
+  calls: number;
+};
 
 /** A model that replays scripted provider chunks — so the harness's loop, not a
  *  real model, is what the suite measures. */
 export function scriptedModel(turns: StreamPart[][]): ScriptedModel {
   const remaining = turns.map((turn) => [...turn]);
   const toolNamesPerCall: string[][] = [];
+  const prompts: unknown[] = [];
   const model = new MockLanguageModelV3({
     doStream: async (request) => {
       toolNamesPerCall.push((request.tools ?? []).map((tool) => tool.name));
+      prompts.push(structuredClone(request.prompt));
       (model as ScriptedModel).calls += 1;
       const chunks = remaining.shift();
       if (chunks === undefined) throw new Error("scripted model exhausted");
@@ -309,6 +317,7 @@ export function scriptedModel(turns: StreamPart[][]): ScriptedModel {
     },
   }) as unknown as ScriptedModel;
   model.toolNamesPerCall = toolNamesPerCall;
+  model.prompts = prompts;
   model.calls = 0;
   return model;
 }

--- a/packages/harnesses/src/vendo.test.ts
+++ b/packages/harnesses/src/vendo.test.ts
@@ -38,6 +38,8 @@ async function drive(options: {
   signal?: AbortSignal;
   skills?: ReturnType<typeof testSkills>;
   messages?: Turn["messages"];
+  /** The per-turn options a caller sent — `optionsSchema`'s parsed shape. */
+  options?: Record<string, unknown>;
 }) {
   const guard = options.guard ?? testGuard();
   const registry = boundRegistry(
@@ -59,7 +61,7 @@ async function drive(options: {
     workspace: testWorkspace(),
     models: options.models,
     state: { get: () => undefined, set: () => undefined, clear: () => undefined },
-    options: {},
+    options: options.options ?? {},
     signal: options.signal ?? new AbortController().signal,
     interactive: options.interactive ?? true,
   };
@@ -363,6 +365,46 @@ describe("vendo() — subagent hiring (build-list item 4)", () => {
     // Turn 1 = resident (has the hiring tool), turn 2 = subagent (must not).
     expect(model.toolNamesPerCall[0]).toContain("hire_subagent");
     expect(model.toolNamesPerCall[1]).not.toContain("hire_subagent");
+  });
+});
+
+describe("vendo() passes the WHOLE context to the shipped loop", () => {
+  // The bug this pins: this caller used to build `context` only when a `maxSteps`
+  // existed and to put only `maxSteps` in it. The loop declared a history window
+  // and `createAgent` passed one, so a host who set one got it on one route and
+  // silently not on the other — and the default route is this one.
+  const OLDEST = "the oldest question";
+  const NEWEST = "the newest question";
+  const twoTurns = (): Turn["messages"] => [
+    userMessage("m1", OLDEST),
+    userMessage("m2", NEWEST),
+  ];
+
+  it("honours a history window set as a deployment default", async () => {
+    const model = scriptedModel([textTurn("ok")]);
+    await drive({ harness: vendo({ historyWindow: 1 }), models: seats(model), messages: twoTurns() });
+    const sent = JSON.stringify(model.prompts[0]);
+    expect(sent).toContain(NEWEST);
+    expect(sent).not.toContain(OLDEST);
+  });
+
+  it("honours a token budget, and a per-turn option beats the default", async () => {
+    const model = scriptedModel([textTurn("ok")]);
+    await drive({
+      harness: vendo({ contextTokenBudget: 100_000 }),
+      models: seats(model),
+      messages: twoTurns(),
+      options: { contextTokenBudget: 10 },
+    });
+    const sent = JSON.stringify(model.prompts[0]);
+    expect(sent).toContain(NEWEST);
+    expect(sent).not.toContain(OLDEST);
+  });
+
+  it("sends the whole thread when nothing is configured", async () => {
+    const model = scriptedModel([textTurn("ok")]);
+    await drive({ harness: vendo(), models: seats(model), messages: twoTurns() });
+    expect(JSON.stringify(model.prompts[0])).toContain(OLDEST);
   });
 });
 

--- a/packages/harnesses/src/vendo.ts
+++ b/packages/harnesses/src/vendo.ts
@@ -18,7 +18,7 @@
  */
 import { z } from "zod";
 import { modelToolDescription, type Harness, type HarnessEvent, type Json, type ToolDescriptor, type Turn } from "@vendoai/core";
-import { startTurn, wireErrorMessage } from "@vendoai/agent/internal";
+import { startTurn, wireErrorMessage, type TurnContext } from "@vendoai/agent/internal";
 import { reportHire } from "./runtime.js";
 import { jsonSchema, stepCountIs, streamText, tool, type LanguageModel, type ToolSet } from "ai";
 import { defineHarness } from "./define.js";
@@ -38,12 +38,27 @@ const optionsSchema = z.object({
   /** Overrides the `default` seat for this turn only. */
   model: z.unknown().optional(),
   maxSteps: z.number().int().positive().optional(),
+  historyWindow: z.number().int().positive().optional(),
+  contextTokenBudget: z.number().int().positive().optional(),
+  maxOutputTokens: z.number().int().positive().optional(),
 });
 
 export interface VendoHarnessOptions {
   model?: LanguageModel;
   maxSteps?: number;
+  /** The shipped loop's context knobs, per turn. They were declared on the loop
+   *  and on `createAgent` but not here, and this file passed `maxSteps` alone —
+   *  so a deployment on the default harness (which is every deployment whose
+   *  store can serve harness turns) could not reach the history window or the
+   *  token budget at all. */
+  historyWindow?: number;
+  contextTokenBudget?: number;
+  maxOutputTokens?: number;
 }
+
+/** The knobs a per-turn option may override, and the deployment defaults they
+ *  override. One list, so a new knob cannot reach one half and not the other. */
+const CONTEXT_KNOBS = ["maxSteps", "historyWindow", "contextTokenBudget", "maxOutputTokens"] as const;
 
 export interface VendoHarnessDeps {
   /**
@@ -56,6 +71,12 @@ export interface VendoHarnessDeps {
    */
   system?: string | (() => string | undefined | Promise<string | undefined>);
   maxSteps?: number;
+  /** The deployment's defaults for the loop's context knobs; a per-turn option of
+   *  the same name wins. `maxSteps` stays above for back-compat and reads the
+   *  same either way. */
+  historyWindow?: number;
+  contextTokenBudget?: number;
+  maxOutputTokens?: number;
   /**
    * Called once per hired specialist. Defaults to the runtime's own
    * {@link reportHire}, which writes the audit row and the transcript receipt — a
@@ -175,6 +196,11 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
       if (model === undefined) {
         throw new Error("vendo() thinks with `turn.models.default`, and this turn carries no default seat");
       }
+      const context: TurnContext = {};
+      for (const knob of CONTEXT_KNOBS) {
+        const value = turn.options?.[knob] ?? deps[knob];
+        if (value !== undefined) context[knob] = value;
+      }
       const system =
         (typeof deps.system === "function" ? await deps.system() : deps.system)
         ?? turn.system
@@ -253,9 +279,11 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
             activeToolNames: () => [...equipped, HIRE_SUBAGENT],
             attach: () => {},
           },
-          ...(turn.options?.maxSteps ?? deps.maxSteps) === undefined
-            ? {}
-            : { context: { maxSteps: turn.options?.maxSteps ?? deps.maxSteps } },
+          // The WHOLE context, not just `maxSteps`. Passing one knob is what made
+          // every other knob unreachable from `vendo()` — the loop declared them,
+          // `createAgent` passed them, and this caller silently dropped them, so
+          // the two thinkers disagreed about a host's own configuration.
+          ...(Object.keys(context).length === 0 ? {} : { context }),
         });
       } catch (error) {
         yield { type: "error", message: wireErrorMessage(error), code: "model" };

--- a/packages/harnesses/src/vendo.ts
+++ b/packages/harnesses/src/vendo.ts
@@ -240,6 +240,9 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
           messages: [...turn.messages],
           tools: residentTools,
           signal: turn.signal,
+          // §3.5 — the runtime already minted it and put it on the Turn, so
+          // passing it is simply true.
+          turnId: turn.turnId,
           // The loadout, in the shipped loop's own vocabulary: `prepareStep`
           // re-reads this each step and restricts what the model may PICK, so a
           // tool the runtime equipped mid-turn is choosable on the next step and a

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -2617,9 +2617,12 @@ export function createVendo(config: CreateVendoConfig): Vendo {
   // carries its own bound knobs, so only the default construction takes them.
   const harness = (composed?.harness ?? config.harness ?? vendo({
     onHire: reportHire,
-    ...(config.agent?.maxSteps === undefined ? {} : { maxSteps: config.agent.maxSteps }),
-    ...(config.agent?.historyWindow === undefined ? {} : { historyWindow: config.agent.historyWindow }),
-    ...(config.agent?.maxOutputTokens === undefined ? {} : { maxOutputTokens: config.agent.maxOutputTokens }),
+    // `agentOptions` is the ONE place the chat knobs are read from (see its
+    // definition): it already normalizes both arms of `agent:`, so a composed
+    // agent contributes nothing here and cannot double-bind its own knobs.
+    ...(agentOptions.maxSteps === undefined ? {} : { maxSteps: agentOptions.maxSteps }),
+    ...(agentOptions.historyWindow === undefined ? {} : { historyWindow: agentOptions.historyWindow }),
+    ...(agentOptions.maxOutputTokens === undefined ? {} : { maxOutputTokens: agentOptions.maxOutputTokens }),
   })) as Harness;
   assertHarnessComposable(harness, sandbox.adapter === undefined ? {} : { sandbox: sandbox.adapter });
   // The harness runtime, wired to everything a turn needs: the store handle (its

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -2609,7 +2609,18 @@ export function createVendo(config: CreateVendoConfig): Vendo {
   // default is still a choice that has to hold.
   // A composed agent IS a harness choice (its brain, with its knobs already
   // bound and its sandbox already injected), so it takes the same slot.
-  const harness = (composed?.harness ?? config.harness ?? vendo({ onHire: reportHire })) as Harness;
+  //
+  // The host's `agent:` context knobs reach BOTH thinkers. They used to reach
+  // `createAgent` only, so on the default (harness) route a configured history
+  // window or step cap was silently ignored — the same deployment, two answers,
+  // depending on which door happened to serve. A composed harness already
+  // carries its own bound knobs, so only the default construction takes them.
+  const harness = (composed?.harness ?? config.harness ?? vendo({
+    onHire: reportHire,
+    ...(config.agent?.maxSteps === undefined ? {} : { maxSteps: config.agent.maxSteps }),
+    ...(config.agent?.historyWindow === undefined ? {} : { historyWindow: config.agent.historyWindow }),
+    ...(config.agent?.maxOutputTokens === undefined ? {} : { maxOutputTokens: config.agent.maxOutputTokens }),
+  })) as Harness;
   assertHarnessComposable(harness, sandbox.adapter === undefined ? {} : { sandbox: sandbox.adapter });
   // The harness runtime, wired to everything a turn needs: the store handle (its
   // transcript and its workspace), the ONE guard-bound registry, the merged pack

--- a/packages/vendo/src/turn-id.e2e.test.ts
+++ b/packages/vendo/src/turn-id.e2e.test.ts
@@ -19,6 +19,7 @@ import type { AuditEvent, Principal, ToolDescriptor, ToolRegistry } from "@vendo
 import { defineHarness } from "@vendoai/harnesses";
 import { createStore, type VendoStore } from "@vendoai/store";
 import type { LanguageModel } from "ai";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
 import { afterEach, describe, expect, it } from "vitest";
 import { createVendo } from "./server.js";
 
@@ -58,6 +59,54 @@ function hostTools(): ToolRegistry {
       return { status: "ok", output: { ok: true } };
     },
   };
+}
+
+/**
+ * A store the way a HOST supplies one: the whole public `VendoStore` surface,
+ * delegating to a real store so records genuinely work — but not the handle
+ * `@vendoai/store` minted, so it has no SQL handle and `storeServesHarnessTurns`
+ * refuses it. That deployment keeps `agent.stream`, which is the route this file
+ * had no coverage for. (Same shape as `nonSqlStore` in harness-wire.test.ts.)
+ */
+function nonSqlStore(backing: VendoStore): VendoStore {
+  return {
+    records: (collection) => backing.records(collection),
+    blobs: (namespace) => backing.blobs(namespace),
+    ensureSchema: () => backing.ensureSchema(),
+    close: () => backing.close(),
+    raw: () => backing.raw(),
+  };
+}
+
+const USAGE = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+} as const;
+
+/** Two guarded reads, then an answer: two audit rows that must name the same turn. */
+function twoReadsThenAnswer(): LanguageModel {
+  let step = 0;
+  return new MockLanguageModelV3({
+    doStream: async () => {
+      step += 1;
+      if (step <= 2) {
+        return {
+          stream: simulateReadableStream({ chunks: [
+            { type: "tool-call" as const, toolCallId: `call_${step}`, toolName: READ_TOOL, input: "{}" },
+            { type: "finish" as const, usage: USAGE, finishReason: { unified: "tool-calls" as const, raw: undefined } },
+          ] }),
+        };
+      }
+      return {
+        stream: simulateReadableStream({ chunks: [
+          { type: "text-start" as const, id: "answer" },
+          { type: "text-delta" as const, id: "answer", delta: "Two invoices." },
+          { type: "text-end" as const, id: "answer" },
+          { type: "finish" as const, usage: USAGE, finishReason: { unified: "stop" as const, raw: undefined } },
+        ] }),
+      };
+    },
+  });
 }
 
 const auditRows = async (store: VendoStore): Promise<AuditEvent[]> => {
@@ -185,6 +234,53 @@ describe("the turn id (contract §3.5)", () => {
     // And the turn's OTHER rows agree with it, which is the whole point of a
     // join key: one turn, one id, every plane.
     expect(rows.filter((row) => row.turnId !== turnId)).toEqual([]);
+  }, 60_000);
+
+  it("stamps the turn on the AGENT route too — the BYO/no-SQL path was turn-less", async () => {
+    // The other tests here prove the HARNESS route, which mints in the harness
+    // runtime. `mintTurnId` had exactly one call site, so every deployment whose
+    // store cannot serve harness turns — a host's own non-SQL adapter, the Cloud
+    // hosted store — produced audit rows with no turn on them at all. Same
+    // question, same plane, other door.
+    const backing = await tempStore();
+    const store = nonSqlStore(backing);
+    let harnessRan = false;
+
+    const vendo = createVendo({
+      model: twoReadsThenAnswer(),
+      principal: async () => principal,
+      store,
+      // The route pin: a store with no SQL handle must NOT be served by a
+      // harness, so this must never run. Without it, a regression that routed
+      // here would pass on the runtime's own mint and prove nothing.
+      harness: defineHarness({
+        name: "must-not-run",
+        async *run() {
+          harnessRan = true;
+          yield { type: "text", delta: "" };
+        },
+      }) as never,
+    } as Parameters<typeof createVendo>[0]);
+    vendo.actions.add(hostTools());
+
+    const response = await vendo.handler(new Request("https://host.test/api/vendo/threads", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        threadId: "thr_agent_route",
+        message: { id: "m1", role: "user", parts: [{ type: "text", text: "list my invoices twice" }] },
+      }),
+    }));
+    await response.text();
+    expect(response.status).toBe(200);
+    expect(harnessRan, "a no-SQL store must stay on the agent route").toBe(false);
+
+    const rows = (await auditRows(backing)).filter((row) => row.kind === "tool-call");
+    // Two scripted reads, so the join is proven across rows rather than on one.
+    expect(rows.map((row) => row.tool)).toEqual([READ_TOOL, READ_TOOL]);
+    const turnIds = [...new Set(rows.map((row) => row.turnId))];
+    expect(turnIds, "every row this turn produced names ONE turn").toHaveLength(1);
+    expect(turnIds[0]).toMatch(/^trn_[0-9a-f]{32}$/);
   }, 60_000);
 
   it("mints a fresh id for the next turn on the same thread", async () => {


### PR DESCRIPTION
## ⚠️ MERGING THIS PR TRIGGERS THE FOUNDER'S ENGINE-SESSION GREEN LIGHT

This is the engine-hardening merge unit of UI-gen Track A1. Another session is gated on it.

---

Blueprint §4.1 — the lean engine (`packages/agent/src/loop.ts` + `startTurn`), hardened. Six items were specified; five landed here, one is a deferred fast-follow (below).

### What landed

| # | Item | Commit |
|---|---|---|
| 1 | **Turn id on the BYO route.** `mintTurnId` had exactly ONE call site in the repo (the harness runtime), so `createAgent` never minted one — every deployment whose store cannot serve harness turns (a host's non-SQL adapter, the Cloud hosted store) produced audit rows naming no turn. Minted once, on the ctx, so every guarded call and audit row below joins for free. A caller-supplied id wins. | `177613336` |
| 2 | **Token-budgeted compaction.** `pruneMessages` sheds reasoning and stale tool payloads BEFORE any message is dropped. Wired for **both** callers — `vendo()` previously passed only `maxSteps`, so a configured `historyWindow` was structurally unreachable on the harness route: the same deployment gave two answers depending on which door served. | `7f2152498` |
| 3 | **Explicit retry budget + ordered provider failover.** `maxRetries` was unset and silently inherited the SDK default. Failover is **first-byte only** — once bytes stream, no switch, because a mid-stream provider change would duplicate output. | `4b1fa5578` |
| 4 | **Per-tenant budget StopCondition.** The `stopWhen` array became extensible and takes a fourth condition rather than growing a rival mechanism. Opt-in; no behaviour change when unset. | `c263d1390` |
| 5 | **Supervisor hook, shipped as a NO-OP.** One slot, one call site, frozen signature. Unset = `{ok:true}`. A refusal reaches the user through the existing `wireErrorMessage` path — no new part, no new `HarnessEvent` member. | `fd7a0d338` |
| — | Rebase fix: `agent:`'s widened type on main means the chat knobs read from `agentOptions`, the one place they are already normalized. | `37b642712` |

Also corrected: the stale comment in `guard.ts` claiming "there is no turn id anywhere in this codebase", and `loop.ts`'s "two callers" docstring (there are three).

### Deferral 1 — `ai` dedupe/upgrade → fast-follow (ACCEPTED)

Item 7 of §4.1 does not ship here. It is **hygiene, not function**, and `pruneMessages` was verified byte-identical across all three installed copies, so the compaction work above is unaffected by the version we sit on.

The investigation was completed and is **parked on `uigen/a1-aidedupe`** (not merged, no PR) because it surfaced **two real product breaks that exist only on the newer SDK, both in safety-critical boundary files**:

1. **An approved tool never executes.** `ai@6.0.202` re-calls `needsApproval` on approval replay. Vendo's is `previewApproval` → `guard.previewCheck`, which correctly answers `run` once granted — so the SDK discards the approval as "did not require approval". `GuardDecision.run` cannot distinguish *never needed approval* from *already approved*, and the replay is a fresh toolset so no local memo helps. Fix belongs in `packages/guard/src/guard.ts`.
2. **An aborted turn poisons the next turn.** The abort persists an unpaired tool call; the old version tolerated it, the new one throws `AI_MissingToolResultsError`. This contradicts AGENT-3's "leaves the thread resumable". Fix belongs in `agent.ts`'s `onFinish`.

Both were proven bump-caused by aliasing `ai` back to the old copy and watching them go green. Touching the guard's approval path hours before a live demo is the wrong moment. The fast-follow ships the dedupe + both fixes as **one reviewed unit**, since the coupling is what makes them one change.

A third finding travels with that branch: `scripts/portability-gate.mjs` bundles with `conditions: ["workerd","worker"]`, but Wrangler's own `getBuildConditions()` defaults to `["workerd","worker","browser"]` — **the gate was stricter than the runtime it claims to mirror.** Not corrected here; it goes with the parked branch.

### Deferral 2 — the supervisor slot is unreachable from the harness route (KNOWN SEAM NOTE)

Stated plainly so the parallel verification project inherits it as written: **the supervisor slot ships wired on the agent route, but is not reachable from the harness route, because the harness runtime owns the ctx.** The signature is frozen and is the inter-project seam:

```ts
supervise?(input: { turnId: TurnId; answer: string; ctx: RunContext }): Promise<{ ok: true } | { ok: false; reason: string }>;
```

The verification project fills the slot. Closing the harness-route gap is its own change against the harness runtime's ctx ownership, not a hidden second slot here.

### Deferral 3 — the fallbacks-config surface stays unwired (PRODUCT DECISION PENDING)

Ordered provider failover works at the loop, but the host-facing configuration surface for declaring the provider order is deliberately **not** wired to a public config key. That is a product decision about how a host expresses provider preference, and inventing the surface now would be a guess we would have to break later.

### Consolidation (§0)

The `stopWhen` array gained a member instead of a rival mechanism; the history window went from two divergent behaviours (agent route honoured it, harness route silently ignored it) to one; the chat knobs read from one place; two stale comments that asserted false things about the codebase are gone. No new concepts.

### Verification

`@vendoai/agent`, `@vendoai/harnesses`, `@vendoai/vendo` typecheck clean (including `tsconfig.docs-check.json`). Every guard added was proven able to fail — the implementation reverted, the test watched go red, then restored. Test runs were file-scoped and worker-capped throughout.

**Test edits** are declared in the commit bodies; the one existing test touched is `packages/vendo/src/turn-id.e2e.test.ts`, extended (not weakened) to assert the BYO route also names its turn.

---

### Ledger — inherited items visible at the merge boundary

**1. `role:"system"` inside `messages` — a design question this PR inherits.** The parked `ai` investigation found that `ai@7` **rejects** `role:"system"` inside `messages`. Two production sites do it, and one of them is this track's file: **`packages/agent/src/loop.ts:122`** (the other is `packages/apps/src/generation/engine.ts:132`, a different owner). Both already emit a warning on every turn today.

This is not a codemod. The system message is where the **Anthropic cache breakpoint** is attached, and moving to `instructions` may cost that breakpoint — so it is a design decision about prompt caching, not a rename. It rides with this engine work's future rather than with a dependency bump. Naming it here so it does not evaporate.

**2. The v7 sizing is provisional.** The fast-follow's cost estimate ("only one census symbol removed, no mock rename, the 202 imports are a non-event") was measured against **`ai@7.0.41`** — `7.0.52` was unfetchable inside this repo's npm minimum-release-age window. Whoever runs the fast-follow **must re-measure** against the version actually fetchable at that time before trusting the sizing.

**3. Real v7 costs, for whoever picks it up** — decisions, not tasks: `ai@7` requires **Node ≥22** while every package declares ≥20 (a support-matrix call); v7 is **ESM-only**; ~20 manifests need paired majors. Mastra does not block it.

**4. `vendo_create_app` stays.** Track ledger item, decided: it is **not** a second door. It is only ever constructed when `vendo_make` is already on the registry, and it calls through the same guard-bound path — same door, different doorknob, for a different consumer. A BYO agent renders an embed from `vendo/app-ref@1` and has no use for a spoken `say`. Collapsing it would break a frozen public contract, two shims, two examples and four e2e journeys for zero capability gain. §0 forbids a second *door*, not a second *return shape*.
