### PR TITLE
UI-gen A1: SSE first-byte heartbeat + the server half of stream resume

### DIFF
--- a/.changeset/sse-keepalive-and-stream-resume.md
+++ b/.changeset/sse-keepalive-and-stream-resume.md
@@ -1,0 +1,36 @@
+---
+"@vendoai/core": minor
+"@vendoai/agent": minor
+"@vendoai/harnesses": minor
+"@vendoai/vendo": minor
+"@vendoai/ui": minor
+---
+
+A streaming turn never goes silent, and a turn whose client vanished can be
+rejoined.
+
+**SSE keepalive.** A turn's first byte waits on a provider call and a slow tool
+streams nothing for its whole duration, so the wire could sit quiet long enough
+for a proxy or a browser to drop the connection. Every turn response now leads
+with an SSE comment frame and gets one per 15s of silence. `@vendoai/core` gains
+`withSseKeepalive`, `startSseKeepalive`, `SSE_KEEPALIVE_FRAME` and
+`DEFAULT_SSE_KEEPALIVE_INTERVAL_MS`; both engines' responses use it, and the
+`vendo try` dev server's own copy is gone.
+
+Hosts may notice: **the SSE body now contains comment frames.** They are ignored
+by the SSE grammar, so `useChat`, `DefaultChatTransport` and any spec-compliant
+parser see an unchanged message sequence — but a hand-rolled reader that assumes
+every frame starts with `data: ` needs to skip lines beginning with `:`. This is
+not a new event: there is no new `HarnessEvent` member and no new
+`data-vendo-*` part.
+
+**Stream resume.** The client half already shipped in `ai@6`
+(`ChatTransport.reconnectToStream`, which `useChat().resumeStream()` calls) and
+had no server to talk to, so a reload mid-turn painted the user's question and
+nothing else. The wire gains `GET /threads/:id/stream` — the SDK's own URL,
+method and 204 contract — serving the turn from the start of the stream and then
+following it live. Recording is per-turn, in memory, byte-capped, and dropped 30s
+after the turn settles; the persisted transcript remains the durable record.
+
+`useVendoThread` now resumes automatically after it loads a thread's transcript,
+and returns `resumeStream()` for surfaces that reconnect on their own.

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -2,6 +2,7 @@ import {
   VendoError,
   mintTurnId,
   toVendoWirePart,
+  withSseKeepalive,
   type AgentRunner,
   type ApprovalId,
   type Guard,
@@ -618,7 +619,10 @@ export function createAgent(config: AgentConfig): VendoAgent {
           return message;
         },
       });
-      const response = createUIMessageStreamResponse({ stream });
+      // Same keepalive the harness path gets: a first frame before the provider
+      // has said anything, then one per interval of silence. SSE comment frames,
+      // so the client's message sequence is untouched (core/sse-keepalive.ts).
+      const response = withSseKeepalive(createUIMessageStreamResponse({ stream }));
       // ENG-211: a caller may begin without an id, in which case resolve()
       // mints one. Return the effective id on every turn so fetch clients can
       // adopt it without changing the ai-SDK SSE part contract.

--- a/packages/agent/src/test-helpers.ts
+++ b/packages/agent/src/test-helpers.ts
@@ -266,7 +266,11 @@ export async function readSse(response: Response): Promise<{
 }> {
   const raw = await response.text();
   expect(raw.endsWith("\n\n")).toBe(true);
-  const blocks = raw.slice(0, -2).split("\n\n");
+  // The wire carries SSE keepalive COMMENT frames now (core/sse-keepalive.ts) —
+  // transport framing the SSE grammar ignores, so a real client never sees them.
+  // Dropped here for the same reason: they are not part of the message sequence
+  // these suites assert on. Every remaining block must still be a lone data frame.
+  const blocks = raw.slice(0, -2).split("\n\n").filter((block) => !block.startsWith(":"));
   expect(blocks.length).toBeGreaterThan(0);
   expect(blocks.every((block) => block.startsWith("data: ") && !block.includes("\n"))).toBe(true);
   const rawFrames = blocks.map((block) => `${block}\n\n`);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export * from "./semantics.js";
 export * from "./shape.js";
 export * from "./sha256.js";
 export * from "./skills.js";
+export * from "./sse-keepalive.js";
 export * from "./store.js";
 export * from "./store-wire.js";
 export * from "./stream-parts.js";

--- a/packages/core/src/sse-keepalive.test.ts
+++ b/packages/core/src/sse-keepalive.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SSE_KEEPALIVE_FRAME, startSseKeepalive, withSseKeepalive } from "./sse-keepalive.js";
+
+// Blueprint §4.1 item 5 / §4.2 — the SERVER→CLIENT half of the wire's
+// keepalive. Distinct from `heartbeat.ts`, which is the CLIENT→SERVER abort
+// beat: this one is transport framing, never an event.
+
+const decoder = new TextDecoder();
+const encoder = new TextEncoder();
+
+function sourceResponse(headers: Record<string, string> = {}): {
+  response: Response;
+  push: (text: string) => void;
+  end: () => void;
+  fail: (error: Error) => void;
+} {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  return {
+    response: new Response(stream, { status: 200, headers }),
+    push: (text) => controller.enqueue(encoder.encode(text)),
+    end: () => controller.close(),
+    fail: (error) => controller.error(error),
+  };
+}
+
+async function readFrame(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<string> {
+  const { done, value } = await reader.read();
+  if (done) return "<done>";
+  return decoder.decode(value);
+}
+
+describe("withSseKeepalive", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("gets a first frame out before the source has produced anything", async () => {
+    // The whole point: time-to-first-byte. The source below never writes, so a
+    // proxy or browser watching an unwrapped response would see nothing at all.
+    const { response } = sourceResponse();
+    const reader = withSseKeepalive(response, { intervalMs: 15_000 }).body!.getReader();
+    expect(await readFrame(reader)).toBe(SSE_KEEPALIVE_FRAME);
+  });
+
+  it("keeps punctuating a long silence, one frame per interval", async () => {
+    const { response, push } = sourceResponse();
+    const reader = withSseKeepalive(response, { intervalMs: 1_000 }).body!.getReader();
+    expect(await readFrame(reader)).toBe(SSE_KEEPALIVE_FRAME);
+
+    // A deliberately slow tool call: nothing on the wire for three intervals.
+    for (let beat = 0; beat < 3; beat += 1) {
+      const next = readFrame(reader);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(await next).toBe(SSE_KEEPALIVE_FRAME);
+    }
+
+    // And the real chunk still arrives when the model finally speaks.
+    push("data: {\"type\":\"text-delta\"}\n\n");
+    expect(await readFrame(reader)).toBe("data: {\"type\":\"text-delta\"}\n\n");
+  });
+
+  it("never buffers or delays a real chunk", async () => {
+    const { response, push, end } = sourceResponse();
+    const reader = withSseKeepalive(response, { intervalMs: 60_000 }).body!.getReader();
+    expect(await readFrame(reader)).toBe(SSE_KEEPALIVE_FRAME);
+
+    // No timer advance anywhere below: every frame must land on its own,
+    // meaning the wrapper is not sitting on chunks waiting for a tick.
+    push("data: a\n\n");
+    expect(await readFrame(reader)).toBe("data: a\n\n");
+    push("data: b\n\n");
+    push("data: [DONE]\n\n");
+    expect(await readFrame(reader)).toBe("data: b\n\n");
+    expect(await readFrame(reader)).toBe("data: [DONE]\n\n");
+    end();
+    expect(await readFrame(reader)).toBe("<done>");
+  });
+
+  it("stops the moment the stream ends — no timer outlives the turn", async () => {
+    const { response, end } = sourceResponse();
+    const reader = withSseKeepalive(response, { intervalMs: 1_000 }).body!.getReader();
+    await readFrame(reader);
+    end();
+    expect(await readFrame(reader)).toBe("<done>");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("stops when the consumer cancels", async () => {
+    const { response } = sourceResponse();
+    const wrapped = withSseKeepalive(response, { intervalMs: 1_000 });
+    const reader = wrapped.body!.getReader();
+    await readFrame(reader);
+    await reader.cancel("gone");
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("surfaces a source error instead of hiding it behind keepalives", async () => {
+    const { response, fail } = sourceResponse();
+    const reader = withSseKeepalive(response, { intervalMs: 1_000 }).body!.getReader();
+    await readFrame(reader);
+    fail(new Error("provider exploded"));
+    await expect(reader.read()).rejects.toThrow("provider exploded");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("preserves the response status and headers", () => {
+    const { response } = sourceResponse({ "content-type": "text/event-stream", "x-vendo-thread-id": "thr_1" });
+    const wrapped = withSseKeepalive(response);
+    expect(wrapped.status).toBe(200);
+    expect(wrapped.headers.get("content-type")).toBe("text/event-stream");
+    expect(wrapped.headers.get("x-vendo-thread-id")).toBe("thr_1");
+  });
+
+  it("passes a bodyless response through untouched", () => {
+    const empty = new Response(null, { status: 204 });
+    expect(withSseKeepalive(empty)).toBe(empty);
+  });
+});
+
+describe("startSseKeepalive", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("writes a frame immediately, then one per interval, until stopped", async () => {
+    const written: string[] = [];
+    const stop = startSseKeepalive({ write: (frame) => written.push(frame), intervalMs: 20 });
+    expect(written).toEqual([SSE_KEEPALIVE_FRAME]);
+    await vi.advanceTimersByTimeAsync(60);
+    expect(written).toHaveLength(4);
+    stop();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(written).toHaveLength(4);
+  });
+});

--- a/packages/core/src/sse-keepalive.ts
+++ b/packages/core/src/sse-keepalive.ts
@@ -1,0 +1,112 @@
+/** The SERVER→CLIENT half of the wire's keepalive (blueprint §4.1 item 5, §4.2).
+ *
+ * Not to be confused with `heartbeat.ts`, which points the other way:
+ * `withTurnHeartbeat` is the CLIENT beating `POST /threads/:id/heartbeat` so the
+ * server can idle-abort an abandoned turn. This file is transport framing —
+ * bytes the server puts on an SSE response so the connection stays visibly
+ * alive while nothing interesting is happening.
+ *
+ * Two problems, one policy:
+ *
+ * 1. **Time to first byte.** A turn's first real chunk waits on a provider call.
+ *    Until then the response head may be sitting in a proxy buffer and the
+ *    client has nothing at all.
+ * 2. **Long silent gaps.** A slow tool call streams nothing for its whole
+ *    duration; proxies and browsers drop connections that go quiet.
+ *
+ * The policy: emit a comment frame NOW, then one per `intervalMs` of silence.
+ * SSE comments are ignored by every spec-compliant parser (the `eventsource-parser`
+ * the ai-SDK's `DefaultChatTransport` uses treats a leading `:` as a comment and
+ * emits nothing), so a keepalive is invisible to the client's message sequence.
+ * It is deliberately NOT a `HarnessEvent` and NOT a `data-vendo-*` part: a
+ * keepalive is not something that happened, it is the wire saying it is still there.
+ *
+ * Two sinks, because the two SSE surfaces in this repo genuinely differ: the
+ * production wire returns a web `Response` (`withSseKeepalive`), and the `vendo
+ * try` dev server writes to a Node `ServerResponse` (`startSseKeepalive`).
+ */
+
+/** The frame itself. An SSE comment — no event, no data, ~14 bytes. */
+export const SSE_KEEPALIVE_FRAME = ": heartbeat\n\n";
+
+/** Well inside the 30–60s idle windows proxies and load balancers default to. */
+export const DEFAULT_SSE_KEEPALIVE_INTERVAL_MS = 15_000;
+
+export interface SseKeepaliveOptions {
+  /** Cadence of silence-filling frames. Defaults to 15s. */
+  intervalMs?: number;
+}
+
+/** Callback-sink form: writes a frame immediately, then one per interval, until
+ *  the returned `stop` is called. For sinks that are not a web stream (Node's
+ *  `ServerResponse`). */
+export function startSseKeepalive(
+  options: SseKeepaliveOptions & { write: (frame: string) => void },
+): () => void {
+  options.write(SSE_KEEPALIVE_FRAME);
+  const timer = setInterval(
+    () => options.write(SSE_KEEPALIVE_FRAME),
+    options.intervalMs ?? DEFAULT_SSE_KEEPALIVE_INTERVAL_MS,
+  );
+  // A keepalive must never hold a Node process open.
+  (timer as { unref?: () => void }).unref?.();
+  return () => clearInterval(timer);
+}
+
+/** Stream-sink form: wrap an SSE `Response` so its first frame leaves at once
+ *  and silence is punctuated.
+ *
+ *  Backpressure and ordering are preserved by construction: each pull races the
+ *  in-flight source read against the keepalive deadline, and the read that loses
+ *  is KEPT for the next pull — so a real chunk is never buffered, never delayed,
+ *  and never dropped. No timer outlives the stream either: the deadline is a
+ *  per-pull timeout, cleared on every path, and a closed or cancelled stream is
+ *  never pulled again. */
+export function withSseKeepalive(response: Response, options: SseKeepaliveOptions = {}): Response {
+  if (response.body === null) return response;
+  const intervalMs = options.intervalMs ?? DEFAULT_SSE_KEEPALIVE_INTERVAL_MS;
+  const frame = new TextEncoder().encode(SSE_KEEPALIVE_FRAME);
+  const reader = response.body.getReader();
+  const KEEPALIVE = Symbol("sse-keepalive");
+  /** The source read that lost a race, held for the next pull. */
+  let inflight: ReturnType<ReadableStreamDefaultReader<Uint8Array>["read"]> | undefined;
+  let opened = false;
+
+  const framed = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (!opened) {
+        opened = true;
+        controller.enqueue(frame);
+        return;
+      }
+      const read = (inflight ??= reader.read());
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const deadline = new Promise<typeof KEEPALIVE>((resolve) => {
+        timer = setTimeout(() => resolve(KEEPALIVE), intervalMs);
+        (timer as { unref?: () => void }).unref?.();
+      });
+      try {
+        const won = await Promise.race([read, deadline]);
+        if (won === KEEPALIVE) {
+          controller.enqueue(frame);
+          return;
+        }
+        inflight = undefined;
+        if (won.done) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(won.value);
+      } catch (error) {
+        inflight = undefined;
+        controller.error(error);
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+  return new Response(framed, response);
+}

--- a/packages/harnesses/src/runtime.test.ts
+++ b/packages/harnesses/src/runtime.test.ts
@@ -5,7 +5,7 @@
  * frozen routing table. Harness adapters contain no persistence and no wire code.
  */
 import { defineHarness } from "./define.js";
-import type { Harness, HarnessEvent, ThreadId, Turn } from "@vendoai/core";
+import { SSE_KEEPALIVE_FRAME, type Harness, type HarnessEvent, type ThreadId, type Turn } from "@vendoai/core";
 import type { UIMessage } from "ai";
 import { describe, expect, it, vi } from "vitest";
 import { createHarnessRuntime, type TurnRunInput } from "./runtime.js";
@@ -183,8 +183,10 @@ describe("turn assembly", () => {
     const f = fixture();
     // Empty but well-formed is the established behaviour (today's agent closes
     // the same way on a pre-turn abort): the terminator is what a client needs.
+    // The keepalive rides in front of it (core/sse-keepalive.ts) — an SSE comment
+    // frame, so "empty" now means "one frame of nothing, then the terminator".
     const raw = await (await f.runRaw(scripted([]))).text();
-    expect(raw).toBe("data: [DONE]\n\n");
+    expect(raw).toBe(`${SSE_KEEPALIVE_FRAME}data: [DONE]\n\n`);
   });
 });
 

--- a/packages/harnesses/src/runtime.ts
+++ b/packages/harnesses/src/runtime.ts
@@ -12,6 +12,7 @@ import {
   auditContext,
   mintTurnId,
   VendoError,
+  withSseKeepalive,
   type ApprovalId,
   type AuditEvent,
   type Json,
@@ -517,7 +518,11 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
         }
       })();
 
-      return createUIMessageStreamResponse({ stream: toClient });
+      // A harness turn can be quiet for a long time — a provider call before
+      // the first token, a slow tool. The keepalive puts a first frame on the
+      // wire at once and punctuates the silence, without touching the message
+      // sequence (SSE comment frames; see core/sse-keepalive.ts).
+      return withSseKeepalive(createUIMessageStreamResponse({ stream: toClient }));
     },
   };
 }

--- a/packages/ui/src/hooks/use-vendo-thread.ts
+++ b/packages/ui/src/hooks/use-vendo-thread.ts
@@ -222,7 +222,15 @@ export function useVendoThread(threadId?: string) {
             return;
           }
           return client.threads.get(threadId).then(thread => {
-            if (active) chat.setMessages(thread.messages);
+            if (!active) return;
+            chat.setMessages(thread.messages);
+            // Stream resume (blueprint §4.1 item 5). The transcript has no row
+            // for a turn that is still streaming, so a reload mid-turn would
+            // otherwise paint the user's question and nothing else, forever.
+            // AFTER setMessages, never before: the SDK builds the resumed
+            // message on top of whatever the last message is, so the transcript
+            // has to have landed first. Nothing in flight → 204 → no-op.
+            chat.resumeStream();
           });
         })
         .catch(() => undefined);
@@ -230,7 +238,7 @@ export function useVendoThread(threadId?: string) {
     return () => {
       active = false;
     };
-  }, [client, threadId, chat.setMessages]);
+  }, [client, threadId, chat.setMessages, chat.resumeStream]);
 
   // LANE D (spec §2) — surfaces OUTSIDE the conversation (the launcher pill,
   // the badge) must be able to narrate a run whose state lives in here: the
@@ -270,6 +278,10 @@ export function useVendoThread(threadId?: string) {
     approvals,
     addToolApprovalResponse: chat.addToolApprovalResponse,
     stop: chat.stop,
+    // Rejoin a turn still streaming on the server (`GET /threads/:id/stream`).
+    // Called for you on mount; exposed for a surface that reconnects on its own
+    // (a tab waking from background, a socket the browser dropped).
+    resumeStream: chat.resumeStream,
     // ENG-215 — edit last message: the composer truncates the transcript to
     // before the edited user turn, then re-sends the amended text as a fresh
     // turn (never duplicating what the user originally sent).

--- a/packages/ui/src/hooks/use-vendo-thread.ts
+++ b/packages/ui/src/hooks/use-vendo-thread.ts
@@ -232,13 +232,17 @@ export function useVendoThread(threadId?: string) {
           return client.threads.get(threadId).then(thread => {
             if (!active) return;
             chat.setMessages(thread.messages);
-            // Stream resume (blueprint §4.1 item 5). The transcript has no row
-            // for a turn that is still streaming, so a reload mid-turn would
-            // otherwise paint the user's question and nothing else, forever.
-            // AFTER setMessages, never before: the SDK builds the resumed
-            // message on top of whatever the last message is, so the transcript
-            // has to have landed first. Nothing in flight → 204 → no-op.
-            chat.resumeStream();
+            // Stream resume (blueprint §4.1 item 5). A turn still streaming has
+            // no persisted assistant row yet, so its transcript ends on the
+            // user's message — and a reload mid-turn would otherwise paint that
+            // question and nothing else, forever. Resume ONLY then: a transcript
+            // that already ends in an assistant reply is a completed turn, and
+            // asking the SDK to resume onto it makes it treat that finished
+            // message as the in-flight one and repaint it empty. AFTER
+            // setMessages, never before: the SDK resumes onto the last message,
+            // so the transcript has to have landed first. Nothing in flight on
+            // the server → 204 → no-op.
+            if (thread.messages.at(-1)?.role === "user") chat.resumeStream();
           });
         })
         .catch(() => undefined);

--- a/packages/ui/src/hooks/use-vendo-thread.ts
+++ b/packages/ui/src/hooks/use-vendo-thread.ts
@@ -157,6 +157,14 @@ export function useVendoThread(threadId?: string) {
         headers: client.headers,
         fetch: async (input, init) => {
           const response = await globalThis.fetch(input, init);
+          // The transport's only GET is `reconnectToStream`'s, and the SDK THROWS
+          // on any answer that is neither ok nor 204 — which would turn "this
+          // wire has no resume route" (an older deployment) into a failed
+          // thread. From the client's side that is the same fact as "nothing to
+          // resume", so it is answered the same way.
+          if ((init?.method ?? "GET").toUpperCase() === "GET" && !response.ok) {
+            return new Response(null, { status: 204 });
+          }
           const returnedThreadId = response.headers.get(THREAD_ID_HEADER);
           if (returnedThreadId !== null && THREAD_ID_PATTERN.test(returnedThreadId)) {
             activeThreadIdRef.current = returnedThreadId;

--- a/packages/ui/test/hooks.test.tsx
+++ b/packages/ui/test/hooks.test.tsx
@@ -295,6 +295,10 @@ describe("headless hooks", () => {
       .toEqual([
         expect.objectContaining({ path: "/threads" }),
         expect.objectContaining({ path: "/threads/thr_1" }),
+        // Stream resume: once the transcript has landed, the hook asks whether a
+        // turn is still streaming on the server. Third, never first — the SDK
+        // builds the resumed message on top of the last one it has.
+        expect.objectContaining({ path: "/threads/thr_1/stream" }),
       ]);
 
     await act(() => result.current.sendMessage({ text: "Send the email" }));

--- a/packages/ui/test/hooks.test.tsx
+++ b/packages/ui/test/hooks.test.tsx
@@ -295,10 +295,9 @@ describe("headless hooks", () => {
       .toEqual([
         expect.objectContaining({ path: "/threads" }),
         expect.objectContaining({ path: "/threads/thr_1" }),
-        // Stream resume: once the transcript has landed, the hook asks whether a
-        // turn is still streaming on the server. Third, never first — the SDK
-        // builds the resumed message on top of the last one it has.
-        expect.objectContaining({ path: "/threads/thr_1/stream" }),
+        // No resume probe: thr_1 ends on a COMPLETED assistant reply, so there
+        // is nothing in flight to rejoin. Resume fires only for a transcript
+        // that ends on the user's turn (see the resume-probe test below).
       ]);
 
     await act(() => result.current.sendMessage({ text: "Send the email" }));

--- a/packages/ui/test/thread-resume-tolerance.test.tsx
+++ b/packages/ui/test/thread-resume-tolerance.test.tsx
@@ -38,8 +38,17 @@ describe("a wire without the resume route", () => {
   }
 
   it("opens the thread ready, with its transcript, instead of erroring on a resume it cannot do", async () => {
+    // A transcript that ends on the user's turn — the mid-turn-reload shape,
+    // the one case the hook actually probes the server to resume. The fixture
+    // wire has no resume route, so the probe is refused.
+    const existing = wire.state.threads.get("thr_1")!;
+    wire.state.threads.set("thr_1", {
+      ...existing,
+      messages: [...existing.messages, { id: "msg_asking", role: "user", parts: [{ type: "text", text: "Mid-turn question" }] }],
+    });
+
     const { result } = renderHook(() => useVendoThread("thr_1"), { wrapper });
-    await waitFor(() => expect(result.current.messages[0]?.id).toBe("msg_existing"));
+    await waitFor(() => expect(result.current.messages.at(-1)?.id).toBe("msg_asking"));
 
     // The ask really happened — otherwise this test proves nothing about how a
     // refused ask is handled.
@@ -52,5 +61,6 @@ describe("a wire without the resume route", () => {
     await waitFor(() => expect(result.current.status).toBe("ready"));
     expect(result.current.error).toBeUndefined();
     expect(result.current.messages[0]?.id).toBe("msg_existing");
+    expect(result.current.messages.at(-1)?.id).toBe("msg_asking");
   });
 });

--- a/packages/ui/test/thread-resume-tolerance.test.tsx
+++ b/packages/ui/test/thread-resume-tolerance.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { VendoProvider, createVendoClient, useVendoThread, type VendoClient } from "../src/index.js";
+import { createWireServer } from "./wire-server.js";
+
+/**
+ * Stream resume against a wire that does not have it.
+ *
+ * `useVendoThread` asks `GET /threads/:id/stream` after it loads a transcript,
+ * so a reload mid-turn rejoins instead of painting the question and nothing else.
+ * But `ChatTransport.reconnectToStream` THROWS on any answer that is neither ok
+ * nor 204 (`ai@6`, `HttpChatTransport.reconnectToStream`), and `AbstractChat`
+ * turns that throw into the chat's error state.
+ *
+ * So a host still on a server version without the route — or any wire that 404s
+ * it — would see a healthy thread open in an ERROR state, caused by a feature
+ * that merely was not available. The fixture wire here has no such route (its
+ * thread matcher is `/^\/threads\/([^/]+)$/`), which makes it exactly the older
+ * deployment this has to tolerate.
+ */
+describe("a wire without the resume route", () => {
+  let wire: Awaited<ReturnType<typeof createWireServer>>;
+  let client: VendoClient;
+
+  beforeEach(async () => {
+    wire = await createWireServer();
+    client = createVendoClient({ baseUrl: wire.url, headers: { "X-Hook-Test": "true" } });
+  });
+
+  afterEach(async () => {
+    await wire.close();
+  });
+
+  function wrapper({ children }: PropsWithChildren) {
+    return <VendoProvider client={client}>{children}</VendoProvider>;
+  }
+
+  it("opens the thread ready, with its transcript, instead of erroring on a resume it cannot do", async () => {
+    const { result } = renderHook(() => useVendoThread("thr_1"), { wrapper });
+    await waitFor(() => expect(result.current.messages[0]?.id).toBe("msg_existing"));
+
+    // The ask really happened — otherwise this test proves nothing about how a
+    // refused ask is handled.
+    await waitFor(() =>
+      expect(wire.requests).toContainEqual(
+        expect.objectContaining({ method: "GET", path: "/threads/thr_1/stream" }),
+      ));
+
+    // And the refusal cost the thread nothing.
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.messages[0]?.id).toBe("msg_existing");
+  });
+});

--- a/packages/vendo/src/cli/try/server.ts
+++ b/packages/vendo/src/cli/try/server.ts
@@ -5,6 +5,7 @@ import { dirname, join, resolve, sep } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { toolsFileSchema, type ExtractedTool } from "@vendoai/actions";
+import { DEFAULT_SSE_KEEPALIVE_INTERVAL_MS, startSseKeepalive } from "@vendoai/core";
 import { createStore } from "@vendoai/store";
 import type { LanguageModel } from "ai";
 import { DevModelController } from "../../dev-creds/model.js";
@@ -93,7 +94,6 @@ export function createTryEventBus(): TryEventBus {
 /** The wire mount and the boot object the surface app reads off `window`. */
 const API_BASE = "/api/vendo";
 const TRY_BOOT = JSON.stringify({ profileUrl: "/profile.json", eventsUrl: "/events", apiBase: API_BASE });
-const DEFAULT_HEARTBEAT_INTERVAL_MS = 15_000;
 
 export interface StartTryServerOptions {
   /** The Task-2 profile root (`assembleTryProfile` boots from it) — also the
@@ -326,7 +326,7 @@ type MountState = { vendo: Vendo } | { error: string };
 
 export async function startTryServer(options: StartTryServerOptions): Promise<TryServer> {
   const bus = options.events ?? createTryEventBus();
-  const heartbeatIntervalMs = options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+  const heartbeatIntervalMs = options.heartbeatIntervalMs ?? DEFAULT_SSE_KEEPALIVE_INTERVAL_MS;
   const model = await resolveTryModel(options);
   const liveChat = options.capabilities?.liveChat ?? model !== null;
   // refine (Task 11) = (model resolved) AND (tools.json present), decided once
@@ -556,10 +556,11 @@ export async function startTryServer(options: StartTryServerOptions): Promise<Tr
     // heartbeat (an idle stream would otherwise sit head-less for 15s).
     response.flushHeaders();
     let unsubscribe: () => void = () => undefined;
+    let stopKeepalive: () => void = () => undefined;
     let closed = false;
     const teardown = (): void => {
       closed = true;
-      clearInterval(heartbeat);
+      stopKeepalive();
       unsubscribe();
       sseClients.delete(response);
     };
@@ -573,14 +574,18 @@ export async function startTryServer(options: StartTryServerOptions): Promise<Tr
         teardown();
       }
     };
-    const heartbeat = setInterval(() => {
-      try {
-        response.write(": heartbeat\n\n");
-      } catch {
-        teardown();
-      }
-    }, heartbeatIntervalMs);
-    heartbeat.unref();
+    // The SAME keepalive policy the production wire uses (core/sse-keepalive.ts):
+    // one comment frame now, then one per interval of silence.
+    stopKeepalive = startSseKeepalive({
+      intervalMs: heartbeatIntervalMs,
+      write: (frame) => {
+        try {
+          response.write(frame);
+        } catch {
+          teardown();
+        }
+      },
+    });
     // Latest-known state first: a late subscriber paints current progress
     // immediately instead of waiting for the next emission.
     for (const event of bus.replay()) send(event);

--- a/packages/vendo/src/sse-keepalive.e2e.test.ts
+++ b/packages/vendo/src/sse-keepalive.e2e.test.ts
@@ -1,0 +1,178 @@
+/**
+ * The SSE keepalive, on the production wire — blueprint §4.1 item 5, §4.2.
+ *
+ * The seam: `vendo.handler` (real store, real guard, real registry, real turn)
+ * → a real `Response` → the RAW SSE BYTES a proxy and a browser would see, and
+ * the same bytes read back through the ai-SDK's own reducer. No double stands
+ * between the response the wire produced and the frames asserted here.
+ *
+ * Two facts have to hold at once, and they pull against each other:
+ *   1. the connection is never silent (first byte before the model speaks, then
+ *      frames through a long tool call), and
+ *   2. a normal client sees EXACTLY the message sequence it saw before — a
+ *      keepalive is transport framing, not an event.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SSE_KEEPALIVE_FRAME, type Principal } from "@vendoai/core";
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { readUIMessageStream, type LanguageModel, type UIMessage, type UIMessageChunk } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVendo } from "./server.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const principal: Principal = { kind: "user", subject: "user_keepalive" };
+
+async function tempStore(): Promise<VendoStore> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-keepalive-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.ensureSchema().catch(() => undefined);
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return store;
+}
+
+/** A turn that stalls where a real one stalls: before its first token (the
+ *  provider call) and again mid-flight (a slow tool). The test drives both
+ *  gates, so "silence" here is the product's silence, not a sleep. */
+function gatedHarness(gates: { firstToken: Promise<void>; afterTool: Promise<void> }) {
+  return defineHarness({
+    name: "keepalive-probe",
+    async *run() {
+      await gates.firstToken;
+      yield { type: "text", delta: "Working on it." };
+      await gates.afterTool;
+      yield { type: "text", delta: " Done." };
+    },
+  });
+}
+
+function gate(): { promise: Promise<void>; open: () => void } {
+  let open!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return { promise, open };
+}
+
+function vendoWith(harness: unknown, store: VendoStore) {
+  return createVendo({
+    model: {} as LanguageModel,
+    principal: async () => principal,
+    store,
+    harness: harness as never,
+  } as Parameters<typeof createVendo>[0]);
+}
+
+function turnRequest(threadId: string): Request {
+  return new Request("https://host.test/api/vendo/threads", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      threadId,
+      message: { id: "m1", role: "user", parts: [{ type: "text", text: "do the slow thing" }] },
+    }),
+  });
+}
+
+/** Read raw SSE frames off a live response until `stop()` says so. */
+function readFrames(response: Response): { frames: string[]; next: () => Promise<string> } {
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  const frames: string[] = [];
+  let buffered = "";
+  const next = async (): Promise<string> => {
+    for (;;) {
+      const boundary = buffered.indexOf("\n\n");
+      if (boundary !== -1) {
+        const frame = `${buffered.slice(0, boundary)}\n\n`;
+        buffered = buffered.slice(boundary + 2);
+        frames.push(frame);
+        return frame;
+      }
+      const { done, value } = await reader.read();
+      if (done) return "<done>";
+      buffered += decoder.decode(value, { stream: true });
+    }
+  };
+  return { frames, next };
+}
+
+describe("the SSE keepalive on the production wire", () => {
+  it("puts a frame on the wire before the model has produced anything, and again through a slow tool call", async () => {
+    const store = await tempStore();
+    const firstToken = gate();
+    const afterTool = gate();
+    const vendo = vendoWith(gatedHarness({ firstToken: firstToken.promise, afterTool: afterTool.promise }), store);
+
+    const response = await vendo.handler(turnRequest("thr_keepalive"));
+    expect(response.status).toBe(200);
+
+    const { next } = readFrames(response);
+    // The turn is parked on `firstToken` — the model has said NOTHING. Without
+    // the keepalive this read would block until the gate opens.
+    expect(await next()).toBe(SSE_KEEPALIVE_FRAME);
+
+    firstToken.open();
+    // Drain until the first real text delta arrives; more keepalives may ride
+    // ahead of it, which is the point.
+    let frame = await next();
+    while (frame === SSE_KEEPALIVE_FRAME) frame = await next();
+    expect(frame.startsWith("data: ")).toBe(true);
+
+    afterTool.open();
+    // And the stream still completes, ending on the SDK's terminator.
+    let last = frame;
+    for (;;) {
+      const seen = await next();
+      if (seen === "<done>") break;
+      last = seen;
+    }
+    expect(last).toBe("data: [DONE]\n\n");
+  }, 60_000);
+
+  it("leaves a normal client's message sequence byte-for-byte unchanged", async () => {
+    const store = await tempStore();
+    const open = gate();
+    open.open();
+    const vendo = vendoWith(gatedHarness({ firstToken: open.promise, afterTool: open.promise }), store);
+
+    const response = await vendo.handler(turnRequest("thr_keepalive_parse"));
+    const body = await response.text();
+
+    // The keepalive IS on the wire...
+    expect(body).toContain(SSE_KEEPALIVE_FRAME);
+
+    // ...and the ai-SDK's own SSE reducer never sees it. Parsed exactly the way
+    // `DefaultChatTransport` parses it: comment frames are ignored by the SSE
+    // grammar, so they can never become a UIMessage part.
+    const chunks = body
+      .split("\n\n")
+      .filter((frame) => frame.startsWith("data: ") && frame !== "data: [DONE]")
+      .map((frame) => JSON.parse(frame.slice("data: ".length)) as UIMessageChunk);
+    const messages: UIMessage[] = [];
+    for await (const message of readUIMessageStream<UIMessage>({
+      stream: new ReadableStream<UIMessageChunk>({
+        start(controller) {
+          for (const chunk of chunks) controller.enqueue(chunk);
+          controller.close();
+        },
+      }),
+    })) {
+      messages[0] = message;
+    }
+    const text = messages[0]?.parts.filter((part) => part.type === "text")
+      .map((part) => (part as { text: string }).text).join("");
+    expect(text).toBe("Working on it. Done.");
+    // Not one part came from a keepalive.
+    expect(messages[0]?.parts.some((part) => JSON.stringify(part).includes("heartbeat"))).toBe(false);
+  }, 60_000);
+});

--- a/packages/vendo/src/stream-resume.e2e.test.ts
+++ b/packages/vendo/src/stream-resume.e2e.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Stream resume, both halves, no stub on either side — blueprint §4.1 item 5.
+ *
+ * The seam: the REAL client transport (`DefaultChatTransport` from `ai` — the
+ * same class `useVendoThread` constructs, calling the same `reconnectToStream`
+ * `useChat().resumeStream()` calls) against the REAL wire (`vendo.handler`, real
+ * store, real guard, real turn). The transport's `fetch` hands requests to the
+ * handler; that is the only plumbing, and it stubs neither the producer nor the
+ * consumer.
+ *
+ * The claim under test: a client that loses its connection mid-turn and rejoins
+ * ends with the SAME complete message as a client that never dropped. Anything
+ * less than "same" is the feature not existing — a green suite around a resume
+ * that returns half a reply is exactly the failure mode this repo keeps naming.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Principal } from "@vendoai/core";
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore, type VendoStore } from "@vendoai/store";
+import {
+  DefaultChatTransport,
+  readUIMessageStream,
+  type LanguageModel,
+  type UIMessage,
+  type UIMessageChunk,
+} from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVendo } from "./server.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const principal: Principal = { kind: "user", subject: "user_resume" };
+const OTHER: Principal = { kind: "user", subject: "user_stranger" };
+
+async function tempStore(): Promise<VendoStore> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-resume-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.ensureSchema().catch(() => undefined);
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return store;
+}
+
+function gate(): { promise: Promise<void>; open: () => void } {
+  let open!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return { promise, open };
+}
+
+/** Four text beats with a gate in the middle, so the test decides exactly when
+ *  the turn crosses the point the client disappears at. No sleeps: the timing is
+ *  the product's, driven by the test, not by the clock. */
+function beatingHarness(midTurn: Promise<void>) {
+  return defineHarness({
+    name: "resume-probe",
+    async *run() {
+      yield { type: "text", delta: "One." };
+      yield { type: "text", delta: " Two." };
+      await midTurn;
+      yield { type: "text", delta: " Three." };
+      yield { type: "text", delta: " Four." };
+    },
+  });
+}
+
+function vendoWith(harness: unknown, store: VendoStore, who: Principal = principal) {
+  return createVendo({
+    model: {} as LanguageModel,
+    principal: async () => who,
+    store,
+    harness: harness as never,
+  } as Parameters<typeof createVendo>[0]);
+}
+
+/** The transport the panel builds, pointed at the handler instead of a socket. */
+function transportFor(vendo: { handler: (request: Request) => Promise<Response> }): DefaultChatTransport<UIMessage> {
+  return new DefaultChatTransport<UIMessage>({
+    api: "https://host.test/api/vendo/threads",
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) =>
+      vendo.handler(new Request(input as string, init))) as unknown as typeof fetch,
+    prepareSendMessagesRequest: ({ messages, id }) => ({
+      body: { threadId: id, message: messages.at(-1) },
+    }),
+  });
+}
+
+const userTurn = (): UIMessage => ({
+  id: "m1",
+  role: "user",
+  parts: [{ type: "text", text: "count to four" }],
+});
+
+/** Assemble a chunk stream the way the SDK's own client does. */
+async function assemble(stream: ReadableStream<UIMessageChunk>): Promise<UIMessage | undefined> {
+  let last: UIMessage | undefined;
+  for await (const message of readUIMessageStream<UIMessage>({ stream })) last = message;
+  return last;
+}
+
+const textOf = (message: UIMessage | undefined): string =>
+  (message?.parts ?? []).filter((part) => part.type === "text")
+    .map((part) => (part as { text: string }).text).join("");
+
+describe("stream resume (blueprint §4.1 item 5)", () => {
+  it("a client that drops mid-turn and reconnects ends with the same message as one that never dropped", async () => {
+    // 1. The reference: an uninterrupted run.
+    const clean = await tempStore();
+    const cleanGate = gate();
+    cleanGate.open();
+    const cleanVendo = vendoWith(beatingHarness(cleanGate.promise), clean);
+    const uninterrupted = await assemble(await transportFor(cleanVendo).sendMessages({
+      chatId: "thr_clean",
+      messages: [userTurn()],
+      trigger: "submit-message",
+      messageId: "m1",
+    }));
+    expect(textOf(uninterrupted)).toBe("One. Two. Three. Four.");
+
+    // 2. The same turn, interrupted.
+    const store = await tempStore();
+    const midTurn = gate();
+    const vendo = vendoWith(beatingHarness(midTurn.promise), store);
+    const transport = transportFor(vendo);
+
+    const live = await transport.sendMessages({
+      chatId: "thr_resume",
+      messages: [userTurn()],
+      trigger: "submit-message",
+      messageId: "m1",
+    });
+    // Read a bit of it, then vanish — the socket dies, the fetch is NEVER
+    // aborted (a recycled isolate, a dropped connection, a closed tab on a
+    // runtime that does not surface the disconnect). The turn keeps running.
+    const reader = live.getReader();
+    await reader.read();
+    await reader.read();
+    await reader.cancel("connection lost");
+
+    // The rest of the turn happens with nobody listening.
+    midTurn.open();
+
+    // 3. Rejoin through the REAL client path. Poll because the reconnect can
+    //    legitimately land before the wire has registered anything; the budget
+    //    is the test's own timeout, never a tighter inner clock.
+    let resumed: ReadableStream<UIMessageChunk> | null = null;
+    while (resumed === null) {
+      resumed = await transport.reconnectToStream({ chatId: "thr_resume" });
+      if (resumed === null) await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    const replayed = await assemble(resumed);
+
+    // The whole point: same words, same shape, as if nothing had happened.
+    expect(textOf(replayed)).toBe(textOf(uninterrupted));
+    expect(replayed?.parts.map((part) => part.type)).toEqual(uninterrupted?.parts.map((part) => part.type));
+  }, 60_000);
+
+  it("answers 204 — not an error, not another principal's turn — when there is nothing to resume", async () => {
+    const store = await tempStore();
+    const open = gate();
+    open.open();
+    const vendo = vendoWith(beatingHarness(open.promise), store);
+
+    // A thread that never ran.
+    const cold = await vendo.handler(new Request("https://host.test/api/vendo/threads/thr_never/stream"));
+    expect(cold.status).toBe(204);
+
+    // A thread whose turn belongs to somebody else: the SAME 204, so the route
+    // is not an oracle for another principal's activity.
+    const midTurn = gate();
+    const mine = vendoWith(beatingHarness(midTurn.promise), store);
+    const live = await mine.handler(new Request("https://host.test/api/vendo/threads", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ threadId: "thr_mine", message: userTurn() }),
+    }));
+    const reader = live.body!.getReader();
+    await reader.read();
+
+    const stranger = vendoWith(beatingHarness(open.promise), store, OTHER);
+    const foreign = await stranger.handler(new Request("https://host.test/api/vendo/threads/thr_mine/stream"));
+    expect(foreign.status).toBe(204);
+
+    // And the owner can still resume it, so the 204 above was about the
+    // principal and not about an empty registry.
+    const owned = await mine.handler(new Request("https://host.test/api/vendo/threads/thr_mine/stream"));
+    expect(owned.status).toBe(200);
+    expect(owned.headers.get("content-type")).toContain("text/event-stream");
+    // The resumed consumer inherits the turn's liveness beat.
+    expect(owned.headers.get("x-vendo-thread-id")).toBe("thr_mine");
+
+    midTurn.open();
+    await reader.cancel("done");
+    await owned.body?.cancel();
+  }, 60_000);
+});

--- a/packages/vendo/src/turn-resume.ts
+++ b/packages/vendo/src/turn-resume.ts
@@ -1,0 +1,155 @@
+/** The SERVER half of ai-SDK stream resume — blueprint §4.1 item 5, §4.2.
+ *
+ * The client half already ships in `ai@6`: `ChatTransport.reconnectToStream`
+ * (what `useChat`'s `resumeStream()` calls) issues
+ *
+ *     GET {api}/{chatId}/stream
+ *
+ * and expects either `204` — nothing to resume, go back to ready — or an SSE
+ * body it parses with the SAME reducer as the original turn. That request
+ * carries NO cursor, so the only protocol the contract allows is
+ * REPLAY-FROM-THE-START-OF-THE-TURN: the server cannot know what the client
+ * missed, so it hands back everything the turn has emitted and then keeps
+ * following it live. (This is also how the SDK's own resumable-stream design
+ * works. We are matching it, not inventing.)
+ *
+ * Why a turn survives its reader vanishing: `recordResumableTurn` tees the turn
+ * response — the same tee-plus-detached-drain seam the harness runtime already
+ * uses to checkpoint parked turns (`harnesses/src/runtime.ts`). The recording
+ * branch is drained by us, not by the client, so a client that stops reading
+ * (recycled isolate, dropped socket, closed tab on `next dev`) does not stall
+ * the turn. A client that genuinely ABORTS the fetch still kills the turn
+ * through `request.signal` — the AGENT-3 fast path is untouched, and a resume
+ * then replays as far as the turn actually got.
+ *
+ * State lifetime: per-turn, in memory, gone `RESUME_GRACE_MS` after the turn
+ * settles. That is deliberately not a store table — there is nothing here worth
+ * surviving a restart (a restart ends the turn), and the persisted transcript is
+ * already the durable record. Frames are also capped: an in-memory buffer with
+ * no ceiling is a memory footgun, and a turn past the cap simply becomes
+ * unresumable (204) rather than unbounded.
+ *
+ * The registry lives on globalThis (Symbol.for) for the same reason
+ * `turn-liveness.ts`'s does: HMR copies of this module under a dev server must
+ * share one view of the in-flight turns.
+ */
+
+const RESUME_GRACE_MS = 30_000;
+const MAX_RESUME_BYTES = 4 * 1024 * 1024;
+
+interface ResumableTurn {
+  threadId: string;
+  subject: string;
+  /** Raw SSE bytes, in wire order. Replayed verbatim — no re-serialization. */
+  frames: Uint8Array[];
+  bytes: number;
+  settled: boolean;
+  /** Past the byte cap: the buffer is dropped and the turn stops being resumable. */
+  overflowed: boolean;
+  /** Resolves whenever a frame lands or the turn settles. */
+  changed: Promise<void>;
+  wake: () => void;
+}
+
+const RESUMABLE_TURNS_KEY = Symbol.for("vendoai.vendo.resumable-turns@1");
+
+function resumableTurns(): Set<ResumableTurn> {
+  const holder = globalThis as { [RESUMABLE_TURNS_KEY]?: Set<ResumableTurn> };
+  return (holder[RESUMABLE_TURNS_KEY] ??= new Set());
+}
+
+function armChanged(entry: ResumableTurn): void {
+  entry.changed = new Promise<void>((resolve) => {
+    entry.wake = resolve;
+  });
+}
+
+function notify(entry: ResumableTurn): void {
+  const wake = entry.wake;
+  armChanged(entry);
+  wake();
+}
+
+/** Wrap a streaming turn response so a dropped client can replay it. Returns the
+ *  response to hand the client; the recording branch drains itself. */
+export function recordResumableTurn(
+  response: Response,
+  key: { threadId: string; subject: string },
+): Response {
+  if (response.body === null) return response;
+  // One resumable stream per thread: a new turn supersedes the last one's buffer.
+  for (const existing of resumableTurns()) {
+    if (existing.threadId === key.threadId && existing.subject === key.subject) {
+      resumableTurns().delete(existing);
+    }
+  }
+  const entry: ResumableTurn = {
+    ...key,
+    frames: [],
+    bytes: 0,
+    settled: false,
+    overflowed: false,
+    changed: Promise.resolve(),
+    wake: () => undefined,
+  };
+  armChanged(entry);
+  resumableTurns().add(entry);
+
+  const [toClient, toRecord] = response.body.tee();
+  void (async () => {
+    const reader = toRecord.getReader();
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (entry.overflowed) continue;
+        entry.bytes += value.byteLength;
+        if (entry.bytes > MAX_RESUME_BYTES) {
+          entry.overflowed = true;
+          entry.frames = [];
+        } else {
+          entry.frames.push(value);
+        }
+        notify(entry);
+      }
+    } catch {
+      // A failed turn is still worth replaying up to the failure; the client's
+      // own error part is already in the frames.
+    } finally {
+      entry.settled = true;
+      notify(entry);
+      // Followers already attached keep reading from `entry`; a reconnect after
+      // the grace window gets 204 and falls back to the persisted transcript.
+      const expiry = setTimeout(() => resumableTurns().delete(entry), RESUME_GRACE_MS);
+      (expiry as { unref?: () => void }).unref?.();
+    }
+  })();
+
+  return new Response(toClient, response);
+}
+
+/** The turn's stream from the beginning, or null when there is nothing to resume.
+ *  Principal-scoped: a foreign or unknown thread id is indistinguishable from an
+ *  idle one — no oracle, exactly like `touchActiveTurn`. */
+export function resumableTurnStream(key: { threadId: string; subject: string }): ReadableStream<Uint8Array> | null {
+  let entry: ResumableTurn | undefined;
+  for (const candidate of resumableTurns()) {
+    if (candidate.threadId === key.threadId && candidate.subject === key.subject) entry = candidate;
+  }
+  if (entry === undefined || entry.overflowed) return null;
+  const turn = entry;
+  let index = 0;
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      while (index >= turn.frames.length) {
+        if (turn.settled) {
+          controller.close();
+          return;
+        }
+        await turn.changed;
+      }
+      controller.enqueue(turn.frames[index]!);
+      index += 1;
+    },
+  });
+}

--- a/packages/vendo/src/wire/threads.ts
+++ b/packages/vendo/src/wire/threads.ts
@@ -52,10 +52,16 @@ export const threadRoutes: RouteEntry[] = [
     // client whose connection died can rejoin through `GET /threads/:id/stream`.
     // Recorded HERE because this is the one place both engines' turns converge
     // and the turn's identity (thread + subject) already exists.
-    return recordResumableTurn(trackTurnResponse(turn, unregister), {
-      threadId,
-      subject: ctx.principal.subject,
-    });
+    //
+    // Recorder INSIDE, liveness OUTSIDE, and the order is load-bearing: ENG-353's
+    // registration must end when THIS CLIENT stops reading, not when the turn's
+    // bytes run out. The recorder drains its own branch, so the turn still
+    // completes for a reader who left — but the watchdog keeps watching a turn
+    // whose client is merely slow.
+    return trackTurnResponse(
+      recordResumableTurn(turn, { threadId, subject: ctx.principal.subject }),
+      unregister,
+    );
   }),
   // The SERVER half of `ChatTransport.reconnectToStream` (ai@6): the URL, the
   // method and the 204 are the SDK's, not ours. 204 = nothing in flight, so the

--- a/packages/vendo/src/wire/threads.ts
+++ b/packages/vendo/src/wire/threads.ts
@@ -1,5 +1,7 @@
-import { VendoError } from "@vendoai/core";
+import { VendoError, withSseKeepalive } from "@vendoai/core";
+import { UI_MESSAGE_STREAM_HEADERS } from "ai";
 import { registerActiveTurn, touchActiveTurn, trackTurnResponse } from "../turn-liveness.js";
+import { recordResumableTurn, resumableTurnStream } from "../turn-resume.js";
 import { json, requestJson, route, string, type RouteEntry } from "./shared.js";
 
 /** The effective thread id the agent stamps on every turn response (03 §1). */
@@ -46,7 +48,30 @@ export const threadRoutes: RouteEntry[] = [
       subject: ctx.principal.subject,
       abort: () => turnAbort.abort(),
     });
-    return trackTurnResponse(turn, unregister);
+    // Stream resume (blueprint §4.1 item 5): the turn's bytes are recorded so a
+    // client whose connection died can rejoin through `GET /threads/:id/stream`.
+    // Recorded HERE because this is the one place both engines' turns converge
+    // and the turn's identity (thread + subject) already exists.
+    return recordResumableTurn(trackTurnResponse(turn, unregister), {
+      threadId,
+      subject: ctx.principal.subject,
+    });
+  }),
+  // The SERVER half of `ChatTransport.reconnectToStream` (ai@6): the URL, the
+  // method and the 204 are the SDK's, not ours. 204 = nothing in flight, so the
+  // client goes back to ready on its persisted transcript.
+  route("GET", "/threads/:id/stream", async ({ context, params }) => {
+    const ctx = await context("chat");
+    const id = string(params["id"], "thread id");
+    const replay = resumableTurnStream({ threadId: id, subject: ctx.principal.subject });
+    if (replay === null) return new Response(null, { status: 204 });
+    const response = withSseKeepalive(new Response(replay, { headers: UI_MESSAGE_STREAM_HEADERS }));
+    // The resumed consumer takes over the turn's liveness beat: the panel's
+    // `withTurnHeartbeat` arms itself off this header, so a turn whose first
+    // client vanished is kept alive by the one that rejoined instead of being
+    // idle-aborted out from under it.
+    response.headers.set(THREAD_ID_HEADER, id);
+    return response;
   }),
   // ENG-353 — turn-liveness beat. Principal-scoped: it refreshes only the
   // caller's own in-flight turns, and unknown/foreign ids answer


### PR DESCRIPTION
## SSE first-byte heartbeat + the server half of stream resume

Blueprint §4.1 item 5. Two halves of the same problem: a turn that is thinking looks identical to a turn that died, and a client that loses its connection loses the turn.

### 1. A streaming turn says it is still there before the model does

**The hole:** there was **no server→client SSE keepalive on the production wire at all.** A long tool call streamed nothing for its entire duration, so any proxy or browser was free to drop the connection. The only keepalive in the repo was dev-only, inside the `vendo try` server.

**The fix, and it is a consolidation not an addition:** that dev-only implementation was **promoted into one shared place** and is now used by both production response paths. The dev server no longer keeps its own copy — it uses the shared one. One implementation, three callers.

The keepalive is transport-level by construction: it is **not** a `UIMessage` part, **not** a new `data-vendo-*` part, and **not** a new `HarnessEvent` member. A normal client reading through `readUIMessageStream` sees an unchanged message sequence.

`90e0ef467` is worth a reviewer's attention: **two existing readers assumed the SSE wire would never carry comment frames.** Adding a legal SSE construct surfaced two latent parsers that only worked because nothing had ever exercised that path. Both fixed in the same change.

### 2. A turn whose client vanished can be rejoined instead of lost

The client half already existed in the installed SDK (`ChatTransport.reconnectToStream`). The **server** route and the resumable store are what was missing. Built to match the SDK's own contract — no invented protocol — and wired to the real client transport so the feature is not dead on arrival.

This matters because of a standing lesson in this repo: *the host-component previews shipped four times with a green suite and a dead feature, because the producer and the consumer each mocked the other.* The resume test therefore runs a real turn, reads part of the SSE, drops the connection, reconnects **through the real client path**, and asserts the client ends with the **same complete message sequence** as an uninterrupted run. No stub on either side.

Two follow-on fixes from real behaviour:
- `f5ce784ee` — **a resume the wire cannot serve is not an error the user caused.** An unresumable turn degrades quietly rather than surfacing as a failure the viewer did nothing to deserve.
- `11811aa2a` — **the recorder goes inside the liveness bracket, not around it.** Ordering bug: recording outside the bracket meant the resumable copy could outlive the liveness registration that governs it.

### Consolidation (§0)

The dev server's private heartbeat copy is gone, folded into the one shared implementation. The resume path reuses the existing tee-and-checkpoint machinery rather than adding a second "keep a copy of the stream" mechanism. No new event vocabulary, no new stream mechanism.

### Verification

`@vendoai/{core,agent,harnesses,vendo,ui}` all typecheck clean. Seam tests read **raw SSE bytes** — the assertion is on the wire, not on a mock of it.

**A caveat I would rather state than bury:** several of this branch's test runs happened while the machine was at load 244+, and these are *timing* tests (first-byte latency, keepalive intervals during silence, mid-stream disconnect). Timing assertions were **not** retuned to chase reds — the rule held that a poll must never have a wall-clock budget tighter than the test's own timeout. If any assertion here proves flaky under the batch gate, treat it as a machine-sensitivity finding to fix properly rather than a threshold to loosen.

Changeset included (`6c1b48f47`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an SSE first-byte heartbeat and server-side stream resume. Long silent turns stay connected, and clients that drop mid-turn can rejoin and finish with the same message.

- **New Features**
  - `@vendoai/core`: `withSseKeepalive`, `startSseKeepalive`, `SSE_KEEPALIVE_FRAME`, `DEFAULT_SSE_KEEPALIVE_INTERVAL_MS`. Sends a comment frame immediately, then every 15s of silence. Invisible to spec SSE parsers.
  - Production wire: `@vendoai/agent` and `@vendoai/harnesses` stream responses now wrapped with `withSseKeepalive`. `@vendoai/vendo` dev server uses `startSseKeepalive`.
  - Stream resume: server records per-turn SSE bytes in memory (capped at 4 MiB, GC 30s after settle) and serves them via `GET /threads/:id/stream` (200 with SSE or 204 when nothing to resume). Recorder runs inside the liveness bracket to keep watchdog semantics correct. Resumed consumers inherit the `x-vendo-thread-id` heartbeat header.
  - UI: `@vendoai/ui` `useVendoThread` resumes only when a loaded transcript ends with a user message, then auto-calls `resumeStream()` and exposes it. Treats a missing resume route as 204 to avoid user-facing errors.

- **Migration**
  - SSE bodies now include comment frames beginning with `:`. Spec-compliant parsers ignore them; custom readers must skip `:` lines.

<sup>Written for commit 1b38942c3f92f016cdd0f27c5608817cfdd27098. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

