### PR TITLE
feat: a build can be corrected while it is still building (mid-build steering, §10.2)

### DIFF
--- a/packages/apps/box/turn-routes.mjs
+++ b/packages/apps/box/turn-routes.mjs
@@ -357,7 +357,7 @@ export const createSessionRoutes = (options = {}) => {
         return { status: 202, body: { messageId: await startMessage(payload) } };
       }
 
-      const match = /^\/session\/([^/]+)\/(poll|interrupt)$/.exec(pathname);
+      const match = /^\/session\/([^/]+)\/(poll|interrupt|steer)$/.exec(pathname);
       if (match === null) return { status: 404, body: { error: `unknown route: ${pathname}` } };
       const state = messages.get(match[1]);
       if (state === undefined) return { status: 404, body: { error: `unknown message: ${match[1]}` } };
@@ -365,6 +365,20 @@ export const createSessionRoutes = (options = {}) => {
       if (match[2] === "poll") {
         const cursor = Number.isInteger(payload?.cursor) ? payload.cursor : 0;
         return { status: 200, body: await poll(state, cursor, payload?.waitMs) };
+      }
+      if (match[2] === "steer") {
+        // The user typed while this message was being answered. Straight into
+        // the live session, which hands it to the model at its next step — the
+        // box queues nothing, because the SDK's own input stream already does.
+        if (typeof payload?.prompt !== "string" || payload.prompt.trim() === "") {
+          return { status: 400, body: { error: "prompt must be a non-empty string" } };
+        }
+        // Only the message IN FLIGHT can take one: a finished message has no turn
+        // to fold the words into, and the host's own queue is the fallback. Said
+        // as an answer rather than an error — "it did not land" is a fact the
+        // host acts on, not a failure.
+        const landed = state === current && session?.steer(payload.prompt) === true;
+        return { status: 200, body: { landed } };
       }
       // The user hit stop. The SESSION survives — only this turn is cut short,
       // which is the whole reason a live session interrupts instead of aborting.

--- a/packages/apps/src/box-turn-routes.test.ts
+++ b/packages/apps/src/box-turn-routes.test.ts
@@ -38,7 +38,22 @@ const scripted = (body: (input: Any, prompt: string) => Promise<void>) => {
   const factory = (input: Any) => {
     opens.push(input);
     return {
-      async send(prompt: string) { await body(input, prompt); },
+      async send(prompt: string) {
+        input.__inFlight = true;
+        try {
+          await body(input, prompt);
+        } finally {
+          input.__inFlight = false;
+        }
+      },
+      // ⚠️ TEST EDIT — the double must speak the whole `ClaudeSession` port, and
+      // `steer` joined it. It records what it was handed and, like the real
+      // session, refuses when no turn is in flight.
+      steer(prompt: string) {
+        if (input.__inFlight !== true) return false;
+        (input.__steers ??= []).push(prompt);
+        return true;
+      },
       async interrupt() { input.__interrupted = true; },
       async end() { input.__ended = true; },
     };
@@ -327,6 +342,59 @@ describe("one live session, many messages", () => {
     expect(door.__opens[0].__interrupted).toBe(true);
     // The session was never ended — only the turn was cut short.
     expect(door.__opens[0].__ended).toBeUndefined();
+  });
+
+  test("a steer reaches the session answering the message RIGHT NOW", async () => {
+    const root = newRoot();
+    let release: (() => void) | undefined;
+    const door = routes(root, async () => {
+      await new Promise<void>((resolve) => { release = resolve; });
+    });
+    const { body } = await send(door, "build me a workbench");
+
+    const steered = await door.handle("POST", `/session/${body.messageId}/steer`, auth, {
+      prompt: "group by client instead",
+    });
+    expect(steered.status).toBe(200);
+    expect(steered.body).toEqual({ landed: true });
+    expect(door.__opens[0].__steers).toEqual(["group by client instead"]);
+    // Steering never cancels: the turn is still the same turn.
+    expect(door.__opens[0].__interrupted).toBeUndefined();
+
+    release?.();
+    await door.messagePromise(body.messageId);
+  });
+
+  test("a steer at a message that already FINISHED does not land", async () => {
+    const root = newRoot();
+    const door = routes(root, async () => undefined);
+    const { body } = await send(door, "go");
+    await door.messagePromise(body.messageId);
+
+    const steered = await door.handle("POST", `/session/${body.messageId}/steer`, auth, { prompt: "too late" });
+    expect(steered.status).toBe(200);
+    expect(steered.body).toEqual({ landed: false });
+    expect(door.__opens[0].__steers).toBeUndefined();
+  });
+
+  test("a steer at an unknown message is a 404, and a blank one is a 400", async () => {
+    const root = newRoot();
+    let release: (() => void) | undefined;
+    const door = routes(root, async () => {
+      await new Promise<void>((resolve) => { release = resolve; });
+    });
+    const { body } = await send(door, "go");
+
+    expect((await door.handle("POST", "/session/msg_nope/steer", auth, { prompt: "hi" })).status).toBe(404);
+    expect((await door.handle("POST", `/session/${body.messageId}/steer`, auth, { prompt: "   " })).status).toBe(400);
+
+    release?.();
+    await door.messagePromise(body.messageId);
+  });
+
+  test("a steer without the machine token is closed, like every other /session route", async () => {
+    const door = routes(newRoot());
+    expect((await door.handle("POST", "/session/msg_1/steer", {}, { prompt: "hi" })).status).toBe(401);
   });
 });
 

--- a/packages/apps/src/claude-session.test.ts
+++ b/packages/apps/src/claude-session.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, test } from "vitest";
 import {
   createClaudeSession,
   VENDO_MCP_SERVER,
+  type ClaudeSession,
   type ClaudeTurnEvent,
   type ClaudeTurnTool,
   type GuardedCall,
@@ -23,6 +24,9 @@ import {
 interface ScriptedTurn {
   say?: string;
   use?: { name: string; input: Record<string, unknown> };
+  /** Hold this step until the test lets it go — the only way to observe that a
+   *  caller's promise is still PENDING while the session is still working. */
+  gate?: () => Promise<void>;
 }
 
 interface SessionRecord {
@@ -68,6 +72,7 @@ function fakeSessionSdk(
               : String(message.message.content?.[0]?.text ?? "");
             record.prompts.push(text);
             for (const step of script(text, index)) {
+              if (step.gate !== undefined) await step.gate();
               if (step.say !== undefined) {
                 yield {
                   type: "assistant",
@@ -347,5 +352,208 @@ describe("the four channels the live session opens", () => {
     await session.end();
     expect(events.filter((event) => event.type === "text").map((event) => (event as { delta: string }).delta))
       .toEqual(["only the block"]);
+  });
+});
+
+/** A promise plus the handle that settles it. */
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => { resolve = settle; });
+  return { promise, resolve };
+}
+
+describe("steering the turn in flight", () => {
+  test("the words ride the SAME open input stream — one query(), two prompts, one turn", async () => {
+    const record: SessionRecord = { queries: 0, prompts: [], options: {}, used: [] };
+    const events: ClaudeTurnEvent[] = [];
+    let session: ClaudeSession | undefined;
+    session = createClaudeSession({
+      cwd: "/workspace",
+      env: {},
+      emit: (event) => {
+        events.push(event);
+        // The user types mid-build. `emit` is called from INSIDE the SDK's drain
+        // of message 1, so this push lands while message 1's turn is running —
+        // which is the whole situation `steer` exists for.
+        if (event.type === "text" && event.delta === "building it") {
+          expect(session!.steer("group by client instead")).toBe(true);
+        }
+      },
+      sdk: fakeSessionSdk(
+        (_prompt, index) => [{ say: index === 0 ? "building it" : "Got it — regrouping by client." }],
+        record,
+      ) as never,
+    } as never);
+
+    await session.send("build me a reconciliation workbench");
+    await session.end();
+
+    // ONE query for the conversation: a steer is a PUSH into an inbox that never
+    // closed, never a second session and never a second turn.
+    expect(record.queries).toBe(1);
+    expect(record.prompts).toEqual(["build me a reconciliation workbench", "group by client instead"]);
+    expect(events.filter((event) => event.type === "text").map((event) => (event as { delta: string }).delta))
+      .toEqual(["building it", "Got it — regrouping by client."]);
+  });
+
+  test("a steer does NOT settle the caller's turn early", async () => {
+    // THE EARLY-SETTLE TRAP. Every extra user message the SDK answers produces
+    // its own `result`, and `send()` settles on the next one it sees. A naive
+    // steer therefore resolves the ORIGINAL send() at message 1's result — the
+    // box door then marks the message done, the poll loop returns, and the turn
+    // ends on the wire while the box is still working on the steer.
+    const record: SessionRecord = { queries: 0, prompts: [], options: {}, used: [] };
+    const gate = deferred();
+    const entered = deferred();
+    let session: ClaudeSession | undefined;
+    session = createClaudeSession({
+      cwd: "/workspace",
+      env: {},
+      emit: (event) => {
+        if (event.type === "text" && event.delta === "building it") session!.steer("group by client instead");
+      },
+      sdk: fakeSessionSdk(
+        (_prompt, index) => (index === 0
+          ? [{ say: "building it" }]
+          // Message 2's turn is HELD open, so "is send() still pending?" has a
+          // deterministic answer rather than a microtask race.
+          : [{ gate: async () => { entered.resolve(); await gate.promise; }, say: "Got it" }]),
+        record,
+      ) as never,
+    } as never);
+
+    const sending = session.send("build me a reconciliation workbench");
+    let settled = false;
+    void sending.then(() => { settled = true; });
+
+    await entered.promise;
+    // Drain every microtask and macrotask that can run while the steer's turn is
+    // held. Nothing left to do but wait on the gate.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(settled).toBe(false);
+
+    gate.resolve();
+    await sending;
+    expect(record.prompts).toEqual(["build me a reconciliation workbench", "group by client instead"]);
+    await session.end();
+  });
+
+  test("N steers swallow exactly N extra results — the turn ends when the LAST one does", async () => {
+    const record: SessionRecord = { queries: 0, prompts: [], options: {}, used: [] };
+    let session: ClaudeSession | undefined;
+    session = createClaudeSession({
+      cwd: "/workspace",
+      env: {},
+      emit: (event) => {
+        if (event.type !== "text") return;
+        if (event.delta === "one") session!.steer("second thought");
+        if (event.delta === "two") session!.steer("third thought");
+      },
+      sdk: fakeSessionSdk((_prompt, index) => [{ say: ["one", "two", "three"][index] ?? "done" }], record) as never,
+    } as never);
+
+    await session.send("start");
+    expect(record.prompts).toEqual(["start", "second thought", "third thought"]);
+    await session.end();
+  });
+
+  test("a steer with no turn in flight is refused — there would be nobody to settle it", async () => {
+    const { session } = openSession(() => [{ say: "ok" }]);
+    expect(session.steer("too early")).toBe(false);
+    await session.send("hi");
+    expect(session.steer("too late")).toBe(false);
+    await session.end();
+  });
+
+  test("stop after a steer still ends the turn — a swallowed result must not outlive an interrupt", async () => {
+    // The interrupt cuts the session's remaining work short, so the extra
+    // `result` a steer was counting on may never arrive. Left counted, the
+    // caller's promise would hang to the message budget (15 minutes).
+    const record: SessionRecord = { queries: 0, prompts: [], options: {}, used: [] };
+    let session: ClaudeSession | undefined;
+    session = createClaudeSession({
+      cwd: "/workspace",
+      env: {},
+      emit: (event) => {
+        if (event.type === "text" && event.delta === "building it") {
+          session!.steer("group by client instead");
+          // Stop, before the SDK ever reaches the steered message.
+          void session!.interrupt();
+        }
+      },
+      sdk: {
+        query: ({ prompt }: { prompt: unknown }) => ({
+          async *[Symbol.asyncIterator]() {
+            yield { type: "system", subtype: "init", session_id: "s" };
+            for await (const _message of prompt as AsyncIterable<unknown>) {
+              record.prompts.push("m");
+              yield { type: "assistant", uuid: "a1", message: { content: [{ type: "text", text: "building it" }] } };
+              // An interrupted session answers ONE result and stops reading its
+              // input — the steered message is never picked up.
+              yield { type: "result", subtype: "success", session_id: "s" };
+              return;
+            }
+          },
+          interrupt: async () => undefined,
+        }),
+      } as never,
+    } as never);
+
+    await expect(session.send("build me a reconciliation workbench")).resolves.toBeUndefined();
+    await session.end();
+  });
+
+  test("the steer × beats seam: no `finishing` on a steered result, and the rework re-narrates its phase", async () => {
+    // The seam #810 (beats) and this PR (steer) create together, which neither
+    // tested alone. A steered result is an INTERMEDIATE boundary, so:
+    //   - `finishing` must fire ONCE, on the FINAL result — never on the steered
+    //     one, or the build claims to be done while the correction's rework is
+    //     still ahead (§3.4, no progress-lie);
+    //   - a phase beat must fire AGAIN in the rework, because the steer carries
+    //     the turn on and `narrated.clear()` frees it to re-narrate — that IS the
+    //     mockup's scene 3 ("Regrouping by client" as a fresh beat).
+    const events: ClaudeTurnEvent[] = [];
+    let session: ClaudeSession | undefined;
+    session = createClaudeSession({
+      cwd: "/workspace",
+      env: {},
+      emit: (event) => {
+        events.push(event);
+        if (event.type === "text" && event.delta === "building it") {
+          session!.steer("group by client instead");
+        }
+      },
+      sdk: {
+        query: ({ prompt }: { prompt: unknown }) => ({
+          async *[Symbol.asyncIterator]() {
+            yield { type: "system", subtype: "init", session_id: "s" };
+            let index = 0;
+            for await (const _message of prompt as AsyncIterable<unknown>) {
+              // Both the first pass and the rework hit a WRITING tool, so each
+              // SHOULD produce a `building` beat — the second only if narration
+              // was cleared on the steered result in between.
+              yield { type: "assistant", uuid: `w${index}`, message: { content: [{ type: "tool_use", name: "Write" }] } };
+              yield {
+                type: "assistant",
+                uuid: `t${index}`,
+                message: { content: [{ type: "text", text: index === 0 ? "building it" : "regrouping" }] },
+              };
+              yield { type: "result", subtype: "success", session_id: "s" };
+              index += 1;
+            }
+          },
+        }),
+      } as never,
+    } as never);
+
+    await session.send("build me a reconciliation workbench");
+    await session.end();
+
+    const phases = events.filter((event) => event.type === "status").map((event) => (event as { phase: string }).phase);
+    // `finishing` exactly once — the final result only, never the steered one.
+    expect(phases.filter((phase) => phase === "finishing")).toEqual(["finishing"]);
+    // `building` twice — the rework re-narrated, which only happens if the
+    // steered result cleared narration. Without that clear this would be one.
+    expect(phases.filter((phase) => phase === "building")).toEqual(["building", "building"]);
   });
 });

--- a/packages/apps/src/claude-turn.ts
+++ b/packages/apps/src/claude-turn.ts
@@ -210,6 +210,16 @@ export interface ClaudeSession {
   /** Push one user message in and settle when THAT message's turn is done. */
   send(prompt: string): Promise<void>;
   /**
+   * Hand the user's words to the turn ALREADY in flight — mid-build steering.
+   *
+   * Same session, same turn, same `send()` still awaiting: the SDK hands the
+   * message to the model at its next step boundary, which is why nothing here
+   * queues. Answers whether the words landed; `false` when no turn is in flight,
+   * because then there would be nobody for the extra `result` to settle and the
+   * caller's own next `send()` is the right home for the message.
+   */
+  steer(prompt: string): boolean;
+  /**
    * Stop the turn in flight WITHOUT ending the conversation — the user hit stop,
    * they did not close the tab. A live session makes this distinction real:
    * aborting the whole session would throw away everything it remembers.
@@ -333,6 +343,18 @@ export function createClaudeSession(input: ClaudeSessionInput): ClaudeSession {
   let model: string | undefined = input.model;
   /** Settles the `send()` whose turn is currently in flight. */
   let settleTurn: ((error?: unknown) => void) | undefined;
+  /**
+   * How many `result` messages belong to STEERS rather than to the `send()` now
+   * waiting.
+   *
+   * MEASURED HAZARD. Every user message the SDK answers produces its own
+   * `result`, and `send()` settles on the next one it sees. So a steer that only
+   * pushed would resolve the original `send()` at the FIRST result: the box door
+   * marks the message done, the harness's poll loop returns, the turn ends on the
+   * wire — and the steer's own output is pushed into a state nobody polls. N
+   * steers add exactly N results, so counting them is the whole fix.
+   */
+  let steeredResults = 0;
   /** A session that died. Every later `send()` fails with it rather than hanging. */
   let fatal: unknown;
 
@@ -491,11 +513,25 @@ export function createClaudeSession(input: ClaudeSessionInput): ClaudeSession {
           // Consumer voice: no subtypes, no internals. And no `finishing` beat —
           // a beat that claimed progress in front of an error would be a lie.
           input.emit({ type: "error", message: "I couldn't finish that one." });
-        } else {
+        } else if (steeredResults === 0) {
+          // Only the FINAL result finishes. A steered result is an INTERMEDIATE
+          // boundary — the turn continues (that is the whole point of the
+          // counter) — so "Finishing up" here would claim the build is done
+          // while the correction's rework is still ahead (§3.4, no progress-lie).
           beat("finishing", "Finishing up");
         }
-        // The next turn narrates afresh, whichever way this one ended.
+        // Narration resets on EVERY result, steered ones included: the next turn
+        // narrates afresh, and a steered correction carries THIS turn on, so it
+        // must be free to re-narrate the phases the first pass already showed
+        // (the mockup's "Regrouping by client"). Cleared BEFORE the steer skip,
+        // or the rework's build/plan beats would stay suppressed and the turn
+        // would fall silent during the one moment steering exists to show.
         narrated.clear();
+        if (steeredResults > 0) {
+          // A steered message's own boundary. The turn continues.
+          steeredResults -= 1;
+          continue;
+        }
         // THE turn boundary. The input stream stays open; only this message's
         // caller is released.
         const settle = settleTurn;
@@ -531,7 +567,17 @@ export function createClaudeSession(input: ClaudeSessionInput): ClaudeSession {
       queue = next.catch(() => undefined);
       return next;
     },
+    steer(prompt) {
+      if (settleTurn === undefined) return false;
+      steeredResults += 1;
+      inbox.push({ type: "user", message: { role: "user", content: prompt }, parent_tool_use_id: null });
+      return true;
+    },
     async interrupt() {
+      // An interrupted session stops reading its input, so the results the
+      // steers were counting on may never arrive. Left counted, the caller's
+      // promise would hang to the message budget instead of ending on stop.
+      steeredResults = 0;
       // Only meaningful in streaming-input mode, which is the only mode we use.
       // A session too young to have opened its query has nothing to stop.
       await live?.interrupt?.().catch(() => undefined);

--- a/packages/core/src/harness.ts
+++ b/packages/core/src/harness.ts
@@ -92,6 +92,26 @@ export interface Turn<Options = unknown> {
    * Opaque to adapters.
    */
   readonly turnId: TurnId;
+  /**
+   * Amendment 2026-08-05: register the one thing that takes the user's words
+   * MID-TURN — the second and last piece of inbound control on a turn, beside
+   * `signal`.
+   *
+   * Inbound, so it is deliberately NOT a `HarnessEvent`: that union is closed and
+   * describes what a harness SAYS. A steer is what a harness is TOLD, and folding
+   * the two together would be a second event vocabulary.
+   *
+   * Optional, so every harness and every driver that predates steering is
+   * unchanged by construction. Registering is the harness declaring "I can fold a
+   * message into the turn I am already running"; the handler then answers whether
+   * this particular message LANDED, because a harness that can steer in general
+   * still cannot when the thing it drives has just finished. A `false` — or never
+   * registering at all — is what tells the caller to keep the message for the next
+   * turn, and it is why nothing here needs a capability protocol.
+   *
+   * At most one handler: a turn has one thinker.
+   */
+  readonly onSteer?: (handler: (text: string) => Promise<boolean>) => void;
 }
 
 /** Build contract §1.1 */

--- a/packages/harnesses/src/claude-code/box.ts
+++ b/packages/harnesses/src/claude-code/box.ts
@@ -243,6 +243,10 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
     return (typeof json === "object" && json !== null ? json : {}) as Record<string, unknown>;
   };
 
+  /** The message this box is answering, for as long as it is answering it — the
+   *  only thing a steer can be addressed to. */
+  let inFlight: string | undefined;
+
   return {
     // A warm box carries BOTH the materialized files and the live session.
     carriesSession: box.warm,
@@ -301,35 +305,51 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
       // neither re-materializes nor re-seeds.
       box.warm = true;
       const messageId = String(started["messageId"] ?? "");
+      // Addressable from here until the poll loop lets go: a steer names the
+      // MESSAGE, and only the one being answered can take it.
+      inFlight = messageId;
       const deadline = Date.now() + MESSAGE_BUDGET_MS;
       let cursor = 0;
 
-      for (;;) {
-        if (message.signal?.aborted === true) {
-          // Interrupt the TURN, not the conversation.
-          await request(`/session/${messageId}/interrupt`, {}).catch(() => undefined);
-          return;
-        }
-        if (Date.now() > deadline) {
-          await request(`/session/${messageId}/interrupt`, {}).catch(() => undefined);
-          throw new VendoError("sandbox-unavailable", "the box message outran its budget");
-        }
-        const polled = await request(`/session/${messageId}/poll`, { cursor, waitMs: POLL_WAIT_MS });
-        for (const event of Array.isArray(polled["events"]) ? polled["events"] : []) {
-          const named = event as { type?: unknown; path?: unknown };
-          // `wrote` is the native PostToolUse hook coming home. It is NOT a
-          // HarnessEvent — it is the signal that replaced the 1.2s file-watch
-          // timer, so it goes to the hot-sync callback and never to the user.
-          if (named.type === "wrote") {
-            message.onFileWritten?.(typeof named.path === "string" ? named.path : undefined);
-            continue;
+      try {
+        for (;;) {
+          if (message.signal?.aborted === true) {
+            // Interrupt the TURN, not the conversation.
+            await request(`/session/${messageId}/interrupt`, {}).catch(() => undefined);
+            return;
           }
-          message.emit(event as never);
-        }
-        cursor = typeof polled["cursor"] === "number" ? polled["cursor"] : cursor;
+          if (Date.now() > deadline) {
+            await request(`/session/${messageId}/interrupt`, {}).catch(() => undefined);
+            throw new VendoError("sandbox-unavailable", "the box message outran its budget");
+          }
+          const polled = await request(`/session/${messageId}/poll`, { cursor, waitMs: POLL_WAIT_MS });
+          for (const event of Array.isArray(polled["events"]) ? polled["events"] : []) {
+            const named = event as { type?: unknown; path?: unknown };
+            // `wrote` is the native PostToolUse hook coming home. It is NOT a
+            // HarnessEvent — it is the signal that replaced the 1.2s file-watch
+            // timer, so it goes to the hot-sync callback and never to the user.
+            if (named.type === "wrote") {
+              message.onFileWritten?.(typeof named.path === "string" ? named.path : undefined);
+              continue;
+            }
+            message.emit(event as never);
+          }
+          cursor = typeof polled["cursor"] === "number" ? polled["cursor"] : cursor;
 
-        if (polled["done"] === true) return;
+          if (polled["done"] === true) return;
+        }
+      } finally {
+        inFlight = undefined;
       }
+    },
+
+    async steer(prompt: string) {
+      if (inFlight === undefined) return false;
+      // The box answers whether the words LANDED. A box that has gone away
+      // answers nothing, which is the same fact from the user's side: their
+      // message did not reach this build, so the host's queue keeps it.
+      const answer = await request(`/session/${inFlight}/steer`, { prompt }).catch(() => undefined);
+      return answer?.["landed"] === true;
     },
 
     async release() {

--- a/packages/harnesses/src/claude-code/claude-code.test.ts
+++ b/packages/harnesses/src/claude-code/claude-code.test.ts
@@ -73,6 +73,13 @@ interface FakeBox extends SandboxMachineLike {
   destroyed: boolean;
   /** How many messages this box's live session has answered. */
   messages: number;
+  /** ⚠️ TEST EDIT — every word the live session was STEERED with, in order.
+   *  The real session pushes these into its open SDK input stream; this is the
+   *  only place a test can see that they arrived. */
+  steers: string[];
+  /** ⚠️ TEST EDIT — did the live session get INTERRUPTED? Stop reaches it
+   *  through the door, so this is where the whole chain becomes observable. */
+  interrupted: boolean;
   env: Record<string, string>;
 }
 
@@ -116,7 +123,11 @@ function makeBox(
     env,
     destroyed: false,
     messages: 0,
+    steers: [],
+    interrupted: false,
   } as FakeBox;
+  /** Is the doubled session inside a `send()` right now? */
+  let inFlight = false;
 
   const routes = createSessionRoutes({
     root,
@@ -132,9 +143,19 @@ function makeBox(
       systemPrompt?: string;
       toolDoor?: { url: string; token: string };
     }) => ({
+      // ⚠️ TEST EDIT — the double speaks the whole `ClaudeSession` port now that
+      // `steer` joined it, and mirrors the real session's refusal when no turn is
+      // in flight (there would be nobody for the extra `result` to settle).
+      steer(prompt: string) {
+        if (box.messages === 0 || inFlight === false) return false;
+        box.steers.push(prompt);
+        return true;
+      },
       async send(prompt: string) {
         box.messages += 1;
-        await script({
+        inFlight = true;
+        try {
+          await script({
           prompt,
           ...(input.toolDoor === undefined ? {} : { toolDoor: input.toolDoor }),
           emit: input.emit,
@@ -160,10 +181,16 @@ function makeBox(
               return undefined;
             }
           },
-          ...(input.resume === undefined ? {} : { resume: input.resume }),
-        });
+            ...(input.resume === undefined ? {} : { resume: input.resume }),
+          });
+        } finally {
+          inFlight = false;
+        }
       },
-      async interrupt() { /* the turn is cut short; the session lives */ },
+      async interrupt() {
+        // ⚠️ TEST EDIT — the turn is cut short; the session lives.
+        box.interrupted = true;
+      },
       async end() { /* the box is going away */ },
     }),
   }) as {
@@ -1315,5 +1342,127 @@ describe("a turn on a real box wire", () => {
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({ type: "error" });
     expect(JSON.stringify(events[0])).not.toMatch(/sandbox|adapter|undefined/i);
+  });
+});
+
+describe("mid-build steering — the user's words into the turn already in flight (§10.2)", () => {
+  test("the words reach the SESSION answering this message, over the real door", async () => {
+    // The whole chain, no stub on either side: the harness registers a steer
+    // handler on the turn, the runtime calls it, `boxMachine` posts
+    // /session/<in-flight>/steer to the REAL box door, and the door hands it to
+    // the live session — which is the fake box's scripted stand-in for the SDK.
+    let release: (() => void) | undefined;
+    const sandbox = fakeSandbox(async (box) => {
+      box.emit({ type: "text", delta: "building it" });
+      await new Promise<void>((resolve) => { release = resolve; });
+      box.emit({ type: "text", delta: "Got it — regrouping by client." });
+    });
+    const { turn } = makeTurn({ threadId: "thr_steer_box" });
+    let handOver: ((text: string) => Promise<boolean>) | undefined;
+    (turn as unknown as { onSteer: unknown }).onSteer = (handler: (text: string) => Promise<boolean>) => {
+      handOver = handler;
+    };
+
+    const events: HarnessEvent[] = [];
+    const running = (async () => {
+      for await (const event of claudeCode({ sandbox }).run(turn as never)) events.push(event);
+    })();
+
+    // Wait for the build to be under way, then steer it.
+    await vi.waitFor(() => expect(events).toContainEqual({ type: "text", delta: "building it" }));
+    expect(handOver).toBeDefined();
+    await expect(handOver!("group by client instead")).resolves.toBe(true);
+
+    release?.();
+    await running;
+
+    expect(sandbox.boxes[0]!.steers).toEqual(["group by client instead"]);
+    expect(events).toContainEqual({ type: "text", delta: "Got it — regrouping by client." });
+    // ONE box, ONE message: a steer is never a second send.
+    expect(sandbox.boxes).toHaveLength(1);
+    expect(sandbox.boxes[0]!.messages).toBe(1);
+  });
+
+  test("a steer with nothing in flight does not land", async () => {
+    const sandbox = fakeSandbox(async () => undefined);
+    const { turn } = makeTurn({ threadId: "thr_steer_idle" });
+    let handOver: ((text: string) => Promise<boolean>) | undefined;
+    (turn as unknown as { onSteer: unknown }).onSteer = (handler: (text: string) => Promise<boolean>) => {
+      handOver = handler;
+    };
+    await drain(claudeCode({ sandbox }), turn);
+    // The turn is over; the machine has no message to fold words into.
+    await expect(handOver!("too late")).resolves.toBe(false);
+  });
+
+  test("a harness turn whose runtime offers no steering channel still runs", async () => {
+    // `onSteer` is OPTIONAL by construction: every harness and every driver that
+    // predates steering is unchanged.
+    const sandbox = fakeSandbox(async (box) => { box.emit({ type: "text", delta: "hi" }); });
+    expect(await drain(claudeCode({ sandbox }), makeTurn({ threadId: "thr_no_steer" }).turn))
+      .toContainEqual({ type: "text", delta: "hi" });
+  });
+});
+
+describe("stop is still the only thing that cancels — steering never does", () => {
+  test("an aborted turn reaches ClaudeSession.interrupt() through the door, unchanged", async () => {
+    // `interrupt()` is NOT unused and never was: Stop → `thread.stop()` → the
+    // request abort → `turn.signal`, which the poll loop turns into
+    // POST /session/<id>/interrupt, which the door hands to the live session.
+    // This pins that chain so steering cannot quietly become the stop path.
+    const abort = new AbortController();
+    let release: (() => void) | undefined;
+    const sandbox = fakeSandbox(async (box) => {
+      box.emit({ type: "text", delta: "building it" });
+      // A real build is not silent, and that matters here: the poll loop checks
+      // the abort at the TOP of each pass, and the door holds a poll open for up
+      // to POLL_WAIT_MS when it has nothing to say. A talking box returns each
+      // poll promptly, which is what lets Stop land promptly. (A SILENT box waits
+      // out the poll window — real, pre-existing, and not this lane's to change.)
+      const beat = setInterval(() => box.emit({ type: "text", delta: "." }), 20);
+      try {
+        await new Promise<void>((resolve) => { release = resolve; });
+      } finally {
+        clearInterval(beat);
+      }
+    });
+    const { turn } = makeTurn({ threadId: "thr_stop" });
+    (turn as unknown as { signal: AbortSignal }).signal = abort.signal;
+
+    const events: HarnessEvent[] = [];
+    const running = (async () => {
+      for await (const event of claudeCode({ sandbox }).run(turn as never)) events.push(event);
+    })();
+    await vi.waitFor(() => expect(events).toContainEqual({ type: "text", delta: "building it" }));
+
+    abort.abort();
+    await vi.waitFor(() => expect(sandbox.boxes[0]!.interrupted).toBe(true));
+    release?.();
+    await running;
+  });
+
+  test("a steer never interrupts — the turn it joined keeps running", async () => {
+    let release: (() => void) | undefined;
+    const sandbox = fakeSandbox(async (box) => {
+      box.emit({ type: "text", delta: "building it" });
+      await new Promise<void>((resolve) => { release = resolve; });
+    });
+    const { turn } = makeTurn({ threadId: "thr_steer_no_stop" });
+    let handOver: ((text: string) => Promise<boolean>) | undefined;
+    (turn as unknown as { onSteer: unknown }).onSteer = (handler: (text: string) => Promise<boolean>) => {
+      handOver = handler;
+    };
+
+    const events: HarnessEvent[] = [];
+    const running = (async () => {
+      for await (const event of claudeCode({ sandbox }).run(turn as never)) events.push(event);
+    })();
+    await vi.waitFor(() => expect(events).toContainEqual({ type: "text", delta: "building it" }));
+    await handOver!("group by client instead");
+
+    expect(sandbox.boxes[0]!.interrupted).toBe(false);
+    release?.();
+    await running;
+    expect(sandbox.boxes[0]!.interrupted).toBe(false);
   });
 });

--- a/packages/harnesses/src/claude-code/index.ts
+++ b/packages/harnesses/src/claude-code/index.ts
@@ -548,6 +548,10 @@ export function claudeCode(
         // rather than saying "all" is what stops the MACHINE's own skills (an
         // operator's ~/.claude/skills, on the local path) from joining the set.
         const skillNames = (await turn.skills.list().catch(() => [])).map((skill) => skill.name);
+        // Mid-build steering (§10.2). Registered BEFORE the send so nothing typed
+        // early is lost, and it is the machine's own answer that travels back —
+        // this harness decides nothing about whether the words fit.
+        turn.onSteer?.((text) => machine.steer(text));
         const running = machine.send({
           prompt: promptFor(turn.messages, sessionId !== undefined),
           // The host's composed brief, WHOLE and ALONE: what the box thinks with

--- a/packages/harnesses/src/claude-code/local-session.test.ts
+++ b/packages/harnesses/src/claude-code/local-session.test.ts
@@ -20,17 +20,33 @@ import type { ClaudeTurnEvent } from "@vendoai/apps/claude-turn";
  *  `send()` through them — exactly what the real SDK session does. */
 function sessionDouble() {
   const opens: Array<Record<string, unknown>> = [];
+  /** ⚠️ TEST EDIT — every word the session was STEERED with, in order. */
+  const steers: string[] = [];
+  let inFlight = false;
   const factory = (input: Record<string, unknown>) => {
     opens.push(input);
     return {
       async send(prompt: string) {
-        (input["emit"] as (event: ClaudeTurnEvent) => void)({ type: "text", delta: `re: ${prompt}` });
+        inFlight = true;
+        try {
+          (input["emit"] as (event: ClaudeTurnEvent) => void)({ type: "text", delta: `re: ${prompt}` });
+        } finally {
+          inFlight = false;
+        }
+      },
+      // ⚠️ TEST EDIT — `steer` joined the `ClaudeSession` port. The real one
+      // refuses with no turn in flight (nobody would settle the extra result);
+      // the double keeps that rule, because it is the rule under test.
+      steer(prompt: string) {
+        if (!inFlight) return false;
+        steers.push(prompt);
+        return true;
       },
       async interrupt() { /* nothing to stop in a double */ },
       async end() { /* nothing to close */ },
     };
   };
-  return { factory, opens };
+  return { factory, opens, steers };
 }
 
 describe("machine: \"local\" — one session, many turns", () => {
@@ -67,6 +83,32 @@ describe("machine: \"local\" — one session, many turns", () => {
       openSession: sessionDouble().factory as never,
     });
     expect(await machine.url(5173)).toBe("http://127.0.0.1:5173");
+
+    await disposeLocalSessions();
+  });
+
+  test("a steer reaches the live session with no hop, and only while a turn runs", async () => {
+    // The seam's OTHER half. `SessionMachine.steer` exists in two homes — an HTTP
+    // call to the box door, and this: straight into the session in this process.
+    // A seam with one implementation is a seam that lies, so both are driven.
+    const double = sessionDouble();
+    const threadId = `thr_local_steer_${Math.random().toString(36).slice(2)}`;
+    const machine = await localMachine({ threadId, env: {}, openSession: double.factory as never });
+
+    // No session yet: nothing to steer.
+    await expect(machine.steer("too early")).resolves.toBe(false);
+
+    let steering: Promise<boolean> | undefined;
+    await machine.send({
+      prompt: "build me a workbench",
+      // Inside the turn — the only window a steer can land in.
+      emit: () => { steering ??= machine.steer("group by client instead"); },
+    });
+
+    await expect(steering).resolves.toBe(true);
+    expect(double.steers).toEqual(["group by client instead"]);
+    // The turn is over; the same words now belong to the next turn instead.
+    await expect(machine.steer("too late")).resolves.toBe(false);
 
     await disposeLocalSessions();
   });

--- a/packages/harnesses/src/claude-code/local.ts
+++ b/packages/harnesses/src/claude-code/local.ts
@@ -152,7 +152,12 @@ async function walk(directory: string, out: string[] = []): Promise<string[]> {
  *  "one box per conversation". */
 interface LocalSession {
   /** The live `ClaudeSession`, once the first message has opened it. */
-  session?: { send(prompt: string): Promise<void>; interrupt(): Promise<void>; end(): Promise<void> };
+  session?: {
+    send(prompt: string): Promise<void>;
+    steer(prompt: string): boolean;
+    interrupt(): Promise<void>;
+    end(): Promise<void>;
+  };
   /** Has this thread's workspace been materialized in this process? */
   warm: boolean;
   /** What this thread's disk holds — the sync-back baseline, per conversation. */
@@ -318,6 +323,13 @@ export async function localMachine(options: LocalMachineOptions): Promise<Sessio
         // The turn is over; nothing may be attributed to it from here on.
         held.live = undefined;
       }
+    },
+
+    async steer(prompt: string) {
+      // No hop: the live session IS in this process. It refuses when no turn is
+      // in flight, which is the same answer the box door gives — one rule, two
+      // homes, exactly like `send`.
+      return held.session?.steer(prompt) === true;
     },
 
     async release() {

--- a/packages/harnesses/src/claude-code/machine.ts
+++ b/packages/harnesses/src/claude-code/machine.ts
@@ -124,6 +124,17 @@ export interface SessionMachine {
   /** Push one user message into the live session and settle when its turn ends. */
   send(message: SessionMessage): Promise<void>;
   /**
+   * Hand the user's words to the message this machine is answering RIGHT NOW —
+   * mid-build steering (§10.2). Not a second `send()`: the same turn, the same
+   * session, the same `send()` still awaiting.
+   *
+   * Answers whether the words LANDED. `false` when nothing is in flight, which is
+   * a fact the caller acts on (its own queue is the fallback) rather than a
+   * failure — so this never throws for the ordinary race of a user typing as a
+   * turn ends.
+   */
+  steer(prompt: string): Promise<boolean>;
+  /**
    * The turn is over. Local keeps its session for the next turn; the sandbox path
    * keeps the box warm on an idle timer and destroys it when that expires.
    */

--- a/packages/harnesses/src/runtime.test.ts
+++ b/packages/harnesses/src/runtime.test.ts
@@ -42,6 +42,9 @@ function fixture(options: {
   tools?: Record<string, { descriptor: ReturnType<typeof readTool>; execute: () => unknown }>;
   transcript?: ReturnType<typeof testTranscript>;
   harnessState?: ReturnType<typeof memoryHarnessStateStore>;
+  /** Composition's publish hook — how the process's own doors (and the steer
+   *  route) reach the turn in flight. */
+  liveTurn?: Parameters<typeof createHarnessRuntime>[0]["liveTurn"];
 } = {}) {
   const guard = options.guard ?? testGuard();
   const registry = boundRegistry(
@@ -63,6 +66,7 @@ function fixture(options: {
     skills: testSkills([{ name: "building-apps", description: "how to build an app", body: "# body" }]),
     transcript: countingTranscript,
     harnessState: options.harnessState ?? memoryHarnessStateStore(),
+    ...(options.liveTurn === undefined ? {} : { liveTurn: options.liveTurn }),
   });
   /** Run a turn AND drain the response, exactly as a host route does. The
    *  stream's onFinish (persistence, state, audit) only fires on consumption —
@@ -633,5 +637,126 @@ describe("the runtime never lets a harness reach the wire itself", () => {
       }),
     );
     expect(unsubscribe).toHaveBeenCalled();
+  });
+});
+
+describe("mid-build steering — the user's words joining a turn already running (§10.2)", () => {
+  it("the steered words land in the transcript exactly once, in order, at their own seq", async () => {
+    // TRAP 2. `persistTurn` writes one row per message at ITS INDEX in the turn's
+    // own message array, at turn end. A side-channel write to the store cannot
+    // know that index — it lands at the seq the ASSISTANT message will claim, and
+    // `seq` is the only ordering authority the transcript has (store schema.ts).
+    // Two rows at one seq is an undefined read order: the user's steer can render
+    // after the reply it caused. So the message must join the in-flight turn's own
+    // list and be persisted by the same pass as everything else.
+    let steer: ((text: string, messageId: string) => Promise<boolean>) | undefined;
+    const f = fixture({
+      liveTurn: (published) => {
+        steer = published.steer;
+        return () => undefined;
+      },
+    });
+    let release!: () => void;
+    const released = new Promise<void>((resolve) => { release = resolve; });
+    const heard: string[] = [];
+    const harness = defineHarness({
+      name: "steerable",
+      async *run(turn) {
+        turn.onSteer?.(async (text) => {
+          heard.push(text);
+          return true;
+        });
+        yield { type: "text", delta: "building it" };
+        await released;
+        yield { type: "text", delta: " — regrouping by client." };
+      },
+    });
+
+    const running = f.run(harness, { messages: [userMessage("m1", "build me a workbench")] });
+    await vi.waitFor(() => expect(steer).toBeDefined());
+    await expect(steer!("group by client instead", "m_steer")).resolves.toBe(true);
+    release();
+    await running;
+
+    // The harness heard it — same turn, no second send.
+    expect(heard).toEqual(["group by client instead"]);
+    // The transcript reads user · steer · assistant, and every seq is distinct.
+    const rows = await persisted(f);
+    expect(rows.map((message) => message.id)).toEqual(["m1", "m_steer", expect.any(String)]);
+    expect(rows.map((message) => message.role)).toEqual(["user", "user", "assistant"]);
+    const seqs = f.upserts.filter((row) => row.id === "m_steer" || row.id === "m1");
+    expect(seqs).toEqual([{ id: "m1", seq: 0 }, { id: "m_steer", seq: 1 }]);
+    // Exactly once: no duplicate row, from either the checkpoint pass or onFinish.
+    expect(f.upserts.filter((row) => row.id === "m_steer")).toHaveLength(1);
+    // Nothing shares the assistant's seq.
+    const assistantSeq = f.upserts.find((row) => row.id !== "m1" && row.id !== "m_steer")!.seq;
+    expect(assistantSeq).toBe(2);
+  });
+
+  it("a harness that never registers a handler makes the steer NOT land, and nothing is written", async () => {
+    // No capability protocol anywhere: not registering IS the answer, and the
+    // caller's own queue is the fallback.
+    let steer: ((text: string, messageId: string) => Promise<boolean>) | undefined;
+    const f = fixture({
+      liveTurn: (published) => {
+        steer = published.steer;
+        return () => undefined;
+      },
+    });
+    let release!: () => void;
+    const released = new Promise<void>((resolve) => { release = resolve; });
+    const harness = defineHarness({
+      name: "deaf",
+      async *run() {
+        yield { type: "text", delta: "working" };
+        await released;
+      },
+    });
+    const running = f.run(harness, { messages: [userMessage("m1", "hello")] });
+    await vi.waitFor(() => expect(steer).toBeDefined());
+    await expect(steer!("are you there", "m_steer")).resolves.toBe(false);
+    release();
+    await running;
+
+    expect((await persisted(f)).map((message) => message.id)).toEqual(["m1", expect.any(String)]);
+    expect(f.upserts.filter((row) => row.id === "m_steer")).toHaveLength(0);
+  });
+
+  it("a steer rides the SAME turn — same turnId, same ctx, same audit context (§3.5)", async () => {
+    let steer: ((text: string, messageId: string) => Promise<boolean>) | undefined;
+    let publishedTurnId: string | undefined;
+    let harnessTurnId: string | undefined;
+    const f = fixture({
+      liveTurn: (published) => {
+        steer = published.steer;
+        publishedTurnId = published.ctx.turnId;
+        return () => undefined;
+      },
+    });
+    let release!: () => void;
+    const released = new Promise<void>((resolve) => { release = resolve; });
+    let seenAtSteer: string | undefined;
+    const harness = defineHarness({
+      name: "same-turn",
+      async *run(turn) {
+        harnessTurnId = turn.turnId;
+        turn.onSteer?.(async () => {
+          // Read INSIDE the steer: whatever answers it must be this turn.
+          seenAtSteer = turn.turnId;
+          return true;
+        });
+        yield { type: "text", delta: "working" };
+        await released;
+      },
+    });
+    const running = f.run(harness, { messages: [userMessage("m1", "hello")] });
+    await vi.waitFor(() => expect(steer).toBeDefined());
+    await steer!("and group by client", "m_steer");
+    release();
+    await running;
+
+    expect(harnessTurnId).toMatch(/^trn_[0-9a-f]{32}$/);
+    expect(seenAtSteer).toBe(harnessTurnId);
+    expect(publishedTurnId).toBe(harnessTurnId);
   });
 });

--- a/packages/harnesses/src/runtime.ts
+++ b/packages/harnesses/src/runtime.ts
@@ -145,7 +145,18 @@ export interface HarnessRuntimeDeps {
    * without a credential the harness minted, and the credential's whole
    * authority is the window between this call and its disposer.
    */
-  liveTurn?: (published: { threadId: ThreadId; ctx: RunContext; tools: TurnTools }) => () => void;
+  liveTurn?: (published: {
+    threadId: ThreadId;
+    ctx: RunContext;
+    tools: TurnTools;
+    /**
+     * Hand the user's words to THIS turn while it runs (§10.2), and answer
+     * whether they landed. Published here rather than through a second hook
+     * because "the turn now in flight, reachable by the process's own doors" is
+     * exactly what this hook already means.
+     */
+    steer: (text: string, messageId: string) => Promise<boolean>;
+  }) => () => void;
 }
 
 export interface TurnRunInput<Options = unknown> {
@@ -309,6 +320,32 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
        *  second ask deserves the save the first one got. */
       const checkpointed = new Set<string>();
 
+      /** The harness's mid-turn ear, if it registered one (§1 `Turn.onSteer`). */
+      let steerHandler: ((text: string) => Promise<boolean>) | undefined;
+      /**
+       * The user's words, mid-turn.
+       *
+       * Appending to the CANONICAL array is the whole mechanism, and it is load
+       * bearing. `persistTurn` writes one row per message at ITS INDEX in this
+       * array; a side-channel write straight to the store cannot know that index,
+       * so it lands at the seq the ASSISTANT message will claim — and `seq` is the
+       * transcript's only ordering authority (store `schema.ts`: one index, no
+       * tiebreak). Measured: two rows at one seq, so the user's steer and the
+       * reply it caused have no defined order. Joining the turn's own list instead
+       * means the existing turn-end pass persists it, once, in place.
+       *
+       * BEFORE the assistant's reply, never after: the reply is appended by the
+       * stream at finish, so the transcript reads ask · ask again · answer — and
+       * the live client can match that order exactly.
+       */
+      const steer = async (text: string, messageId: string): Promise<boolean> => {
+        // Not registering IS the answer. No capability protocol, nothing to ask.
+        if (steerHandler === undefined) return false;
+        if (!await steerHandler(text)) return false;
+        messages.push({ id: messageId, role: "user", parts: [{ type: "text", text }] });
+        return true;
+      };
+
       const stream = createUIMessageStream<UIMessage>({
         originalMessages: messages,
         generateId: () => assistantMessageId,
@@ -409,6 +446,9 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
             ...(input.system === undefined ? {} : { system: input.system }),
             threadId: input.threadId,
             turnId,
+            // §1 amendment 2026-08-05: inbound control, and the only one beside
+            // `signal`. At most one handler — a turn has one thinker.
+            onSteer: (handler) => { steerHandler = handler; },
           };
 
           // Published for the process's own doors (the MCP door's turn
@@ -418,6 +458,7 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
             threadId: input.threadId,
             ctx,
             tools: turn.tools,
+            steer,
           });
 
           try {

--- a/packages/ui/e2e/steering.spec.ts
+++ b/packages/ui/e2e/steering.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "@playwright/test";
+import { openScenario, screenshotPath } from "./helpers.js";
+
+/**
+ * §10.2 mid-build steering, proven in a real browser as a real user does it:
+ * ask for something, and while it is still being built, type a correction.
+ *
+ * `[stream-long]` gives a real ~8s streaming window to act inside; `[steerable]`
+ * is the fixture's per-turn opt-in for a turn that can take the message (the
+ * real product's answer comes from the harness, not a flag).
+ */
+test("a correction typed mid-build joins the build, and the build visibly changes course", async ({ page }) => {
+  // §10.2's heavy-build surface — the split-view workspace, which is the
+  // mockup's scene 3. Beats accumulate durably in the rail here, so the
+  // course-change is visible rather than a transient ribbon between text gaps.
+  await openScenario(page, "overlay");
+  await page.getByRole("button", { name: "Expand workspace" }).click();
+  const textarea = page.getByRole("textbox", { name: "Message" });
+
+  await textarea.fill("[steerable] [stream-long] build me a reconciliation workbench");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  // The build is under way: Stop is offered and the composer stays typeable.
+  await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
+  await expect(textarea).toBeEnabled();
+
+  // The correction, typed while the build runs.
+  await textarea.fill("group by client instead");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  // It landed IN the running turn: the chip reports delivery, and the words are
+  // in the transcript as a normal user turn.
+  await expect(page.getByText("Sent", { exact: true })).toBeVisible();
+  await expect(page.getByText("added to the reply in progress")).toBeVisible();
+  await expect(page.locator(".fl-usertext", { hasText: "group by client instead" })).toBeVisible();
+  // Steering never cancels: the build is still running.
+  await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
+
+  // THE COURSE-CHANGE, visible: the steered rework narrates a fresh beat into the
+  // same open turn stream (Yousef's real-user rule). The fixture cannot re-plan,
+  // so it mirrors the real box's causal chain — steer → a new `building` beat —
+  // rather than inventing new planning.
+  await expect(page.locator(".fl-beatrail .fl-beat-label", { hasText: "Regrouping by client" }))
+    .toBeVisible({ timeout: 15_000 });
+
+  await page.screenshot({ path: screenshotPath("steering-landed-mid-build"), fullPage: true });
+
+  // The build finishes on its own — the steer never became a second turn.
+  await expect(page.getByText("Long turn complete.")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByRole("button", { name: "Stop" })).toBeHidden();
+  // Still exactly one copy of the words: in the transcript, never re-sent.
+  const steerTurn = page.locator(".fl-usertext", { hasText: "group by client instead" });
+  await expect(steerTurn).toHaveCount(1);
+  await steerTurn.scrollIntoViewIfNeeded();
+  await expect(steerTurn).toBeVisible();
+  await page.screenshot({ path: screenshotPath("steering-settled-in-history"), fullPage: true });
+});
+
+test("without a steerable turn the message still queues and sends at the end, unchanged", async ({ page }) => {
+  await openScenario(page, "composer");
+  const textarea = page.getByRole("textbox", { name: "Message" });
+
+  // No `[steerable]`: this turn cannot take a mid-build message.
+  await textarea.fill("[stream-long] walk me through the welcome flow");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
+
+  await textarea.fill("and add a PS about the mobile app");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  // Today's behaviour, untouched: it waits, and says so.
+  await expect(page.getByText("Queued", { exact: true })).toBeVisible();
+  await expect(page.getByText("sends when the reply finishes")).toBeVisible();
+  await page.screenshot({ path: screenshotPath("steering-fallback-queued"), fullPage: true });
+
+  await expect(page.getByText("Long turn complete.")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByText("Queued", { exact: true })).toBeHidden();
+  await expect(page.locator(".fl-usertext", { hasText: "and add a PS about the mobile app" })).toBeVisible();
+});

--- a/packages/ui/src/chrome/thread/composer.tsx
+++ b/packages/ui/src/chrome/thread/composer.tsx
@@ -30,9 +30,12 @@ export const dragHasFiles = (event: React.DragEvent) =>
 /** All composer state and send/queue mechanics, lifted to the thread level so
     the draft (and queued slot) survive the landing ↔ transcript flip. The
     Composer component below is the matching presentation. */
-export function useComposer({ busy, sendMessage }: {
+export function useComposer({ busy, sendMessage, steer }: {
   busy: boolean;
   sendMessage: (message: OutgoingMessage) => unknown;
+  /** §10.2 — offer words to the turn in flight; answers whether they landed.
+      Absent for surfaces whose transport cannot steer (a scripted replay). */
+  steer?: (text: string) => Promise<boolean>;
 }) {
   const [draft, setDraft] = useState("");
   const fileRef = useRef<HTMLInputElement>(null);
@@ -127,7 +130,10 @@ export function useComposer({ busy, sendMessage }: {
   // pill) and auto-sends the instant the turn finishes. A single slot — a second
   // send while one is parked replaces it — because there is only ever one "next"
   // turn. Stop stays the explicit interrupt; queueing never cancels the stream.
-  const [queued, setQueued] = useState<{ text: string; files: File[]; context?: string } | null>(null);
+  // `landed` (§10.2): the running turn TOOK this message, so it is already in the
+  // transcript as the user's own turn and the busy-edge flush below must not send
+  // it a second time. The slot stays visible as a receipt, not a queue.
+  const [queued, setQueued] = useState<{ text: string; files: File[]; context?: string; landed?: true } | null>(null);
   const [attachError, setAttachError] = useState<string>();
   // The grounding a prefill handed over (an app id behind a ✦ remix): held in a
   // ref, not state, because it must never influence a render — it rides the
@@ -195,6 +201,14 @@ export function useComposer({ busy, sendMessage }: {
     if (fileRef.current) fileRef.current.value = "";
     if (busy) {
       setQueued({ text, files: pending, ...(context === undefined ? {} : { context }) });
+      // §10.2 — then OFFER it to the turn that is running. Words only: an
+      // attachment or a grounding marker cannot ride a steer, so those keep the
+      // turn-end flush. A `false` (or no steer at all) changes nothing.
+      if (steer !== undefined && text !== "" && pending.length === 0 && context === undefined) {
+        void steer(text).then(landed => {
+          if (landed) setQueued(current => (current?.text === text ? { ...current, landed: true } : current));
+        });
+      }
       return;
     }
     dispatch(text, pending, context);
@@ -246,7 +260,9 @@ export function useComposer({ busy, sendMessage }: {
     if (wasBusyRef.current && !busy && queued) {
       const pending = queued;
       setQueued(null);
-      dispatch(pending.text, pending.files, pending.context);
+      // A message the turn already took is IN that turn. Flushing it here would
+      // be the same words twice — once inside the build, once after it.
+      if (!pending.landed) dispatch(pending.text, pending.files, pending.context);
     }
     wasBusyRef.current = busy;
     // dispatch is recreated each render but closes only over stable setters and
@@ -338,15 +354,26 @@ export function Composer({ composer, busy, status, errorMessage, onStop, onVoice
     >
       {attachError ? <div className="fl-att-error" role="alert">{attachError}</div> : null}
       {queued ? (
+        // §10.2 — one element, two fates. The copy says what happened to the
+        // MESSAGE and never anything about the result: a steer is words
+        // delivered, and the build's own reply is the only thing entitled to
+        // describe the build.
         <div className="fl-queued" role="status" aria-live="polite">
-          <span className="fl-queued-tag">Queued</span>
+          <span className="fl-queued-tag">{queued.landed ? "Sent" : "Queued"}</span>
           <span className="fl-queued-text">{queued.text || `${queued.files.length} attachment(s)`}</span>
-          <span className="fl-queued-hint">sends when the reply finishes</span>
+          <span className="fl-queued-hint">
+            {queued.landed ? "added to the reply in progress" : "sends when the reply finishes"}
+          </span>
           {/* Lane pick 2B — Send now: stop the stream; the ENG-215 busy-edge
               flush then dispatches this queued slot immediately. One code
-              path for both the polite wait and the deliberate interrupt. */}
-          <button type="button" className="fl-queued-now" onClick={onStop}>Send now</button>
-          <button type="button" className="fl-att-rm fl-queued-rm" aria-label="Cancel queued message" onClick={() => setQueued(null)}>×</button>
+              path for both the polite wait and the deliberate interrupt.
+              A message already delivered has nothing left to send. */}
+          {queued.landed ? null : (
+            <button type="button" className="fl-queued-now" onClick={onStop}>Send now</button>
+          )}
+          <button type="button" className="fl-att-rm fl-queued-rm"
+            aria-label={queued.landed ? "Dismiss" : "Cancel queued message"}
+            onClick={() => setQueued(null)}>×</button>
         </div>
       ) : null}
       {files.length > 0 ? (

--- a/packages/ui/src/chrome/thread/index.tsx
+++ b/packages/ui/src/chrome/thread/index.tsx
@@ -153,7 +153,12 @@ export function VendoThread({
     restoredIdsRef.current.ids = new Set(thread.messages.map(message => message.id));
   }
   const isRestored = (id: string) => restoredIdsRef.current.ids.has(id);
-  const composerApi = useComposer({ busy, sendMessage: message => thread.sendMessage(message) });
+  const composerApi = useComposer({
+    busy,
+    sendMessage: message => thread.sendMessage(message),
+    // §10.2 — a message typed mid-turn is offered to that turn before it queues.
+    ...(thread.steer === undefined ? {} : { steer: thread.steer }),
+  });
   const { setDraft, setQueued, textareaRef, send } = composerApi;
   const risks = useMemo(() => riskByCall(thread.messages), [thread.messages]);
   const guardApprovals = useMemo(() => approvalByCall(thread.messages), [thread.messages]);

--- a/packages/ui/src/hooks/use-vendo-thread.ts
+++ b/packages/ui/src/hooks/use-vendo-thread.ts
@@ -9,7 +9,7 @@ import {
   type ToolUIPart,
   type UIMessage,
 } from "ai";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useVendoContext } from "../context.js";
 import { publishThreadRun, retireThreadRun, type VendoBeat } from "../chrome/run-activity.js";
 
@@ -264,6 +264,43 @@ export function useVendoThread(threadId?: string) {
     publishThreadRun(runKey, { threadId: effectiveThreadId, status: chat.status, messages: chat.messages, beats });
   }, [runKey, effectiveThreadId, chat.status, chat.messages, beats]);
 
+  // §10.2 — offer the user's words to the turn already running. The route's own
+  // answer is the ONLY signal: there is no capability to ask about and nothing to
+  // validate up front, so `false` (a turn that ended, a thread with none in
+  // flight, a wire without the route) simply means the caller keeps the message.
+  //
+  // On a landing the words become a normal user turn HERE too, under the id the
+  // server persisted them with — one row, one bubble, and a reload that reads
+  // back exactly what the live screen showed.
+  const steer = useCallback(async (text: string): Promise<boolean> => {
+    const id = activeThreadIdRef.current;
+    if (id === undefined) return false;
+    const messageId = globalThis.crypto.randomUUID();
+    const base = client.baseUrl.replace(/\/$/, "");
+    const landed = await globalThis
+      .fetch(`${base}/threads/${encodeURIComponent(id)}/steer`, {
+        method: "POST",
+        headers: { ...client.headers, "content-type": "application/json" },
+        body: JSON.stringify({ text, messageId }),
+      })
+      .then(response => (response.ok ? response.json() as Promise<{ landed?: boolean }> : undefined))
+      .catch(() => undefined);
+    if (landed?.landed !== true) return false;
+    chat.setMessages(current => {
+      // BEFORE this turn's reply, which is where the server puts it: the runtime
+      // appends to the turn's own message list and the stream adds the reply
+      // last, so live order and persisted order agree and a reload never jumps.
+      const at = current.at(-1)?.role === "assistant" ? current.length - 1 : current.length;
+      return [
+        ...current.slice(0, at),
+        { id: messageId, role: "user", parts: [{ type: "text", text }] },
+        ...current.slice(at),
+      ];
+    });
+    return true;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- setMessages is stable; the ref carries the live thread id
+  }, [client]);
+
   const approvals = useMemo<VendoThreadApproval[]>(
     () => {
       const pending: VendoThreadApproval[] = [];
@@ -285,6 +322,8 @@ export function useVendoThread(threadId?: string) {
     /** §3.4 — the running turn's beats, oldest first; empty once it settles. */
     beats,
     sendMessage: chat.sendMessage,
+    /** §10.2 — hand words to the turn in flight; answers whether they landed. */
+    steer,
     status: chat.status,
     error: chat.error,
     approvals,

--- a/packages/ui/test/chrome/steering.test.tsx
+++ b/packages/ui/test/chrome/steering.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+/**
+ * Mid-build steering, from the composer's side (§10.2).
+ *
+ * The queued slot already existed — one parked message, flushed on the busy
+ * edge. This is what changed: while a turn is in flight the parked message is
+ * OFFERED to that turn, and if the turn takes it, the user's words become a
+ * normal user turn in the transcript instead of a second send at the end.
+ *
+ * Driven through the real wire server, so the client's own request and the
+ * server's own answer are what decide the behaviour — the client has no
+ * capability protocol and nothing to ask.
+ */
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
+import { VendoOverlay } from "../../src/chrome/index.js";
+import { createWireServer } from "../wire-server.js";
+
+describe("steering the build in flight", () => {
+  let wire: Awaited<ReturnType<typeof createWireServer>>;
+  let client: VendoClient;
+
+  beforeEach(async () => {
+    wire = await createWireServer();
+    client = createVendoClient({ baseUrl: wire.url });
+  });
+
+  /** Set by startHeldTurn; released in afterEach so ONE failing assertion cannot
+   *  leave a gated turn holding the server open and turn into a hook timeout. */
+  let releaseHeld: (() => void) | undefined;
+
+  afterEach(async () => {
+    releaseHeld?.();
+    releaseHeld = undefined;
+    cleanup();
+    vi.restoreAllMocks();
+    await wire.close();
+  });
+
+  const dialog = () => screen.getByRole("dialog", { name: "Vendo assistant" });
+  const turns = () => wire.requests.filter(r => r.method === "POST" && r.path === "/threads");
+  const steers = () => wire.requests.filter(r => r.method === "POST" && r.path.endsWith("/steer"));
+
+  /** Open a turn and hold it open; returns the release. `[steerable]` is the
+   *  fixture's per-turn opt-in for a turn that can take a mid-build message. */
+  async function startHeldTurn(steerable: boolean): Promise<() => void> {
+    let release = () => undefined as void;
+    wire.state.threadReplyGate = new Promise<void>(resolve => { release = resolve; });
+    render(<VendoProvider client={client}><VendoOverlay defaultOpen /></VendoProvider>);
+    const composer = within(dialog()).getByRole("textbox", { name: "Message" });
+    fireEvent.change(composer, {
+      target: { value: `${steerable ? "[steerable] " : ""}build me a workbench` },
+    });
+    fireEvent.keyDown(composer, { key: "Enter" });
+    await within(dialog()).findByRole("button", { name: "Stop" });
+    await waitFor(() => expect(turns()).toHaveLength(1));
+    releaseHeld = release;
+    return release;
+  }
+
+  const park = (text: string) => {
+    const composer = within(dialog()).getByRole("textbox", { name: "Message" });
+    fireEvent.change(composer, { target: { value: text } });
+    fireEvent.keyDown(composer, { key: "Enter" });
+  };
+
+  it("delivers the parked message into the running turn and shows it as the user's own turn", async () => {
+    const release = await startHeldTurn(true);
+
+    park("group by client instead");
+    // Parked first, exactly as before — the queue is unchanged.
+    expect(await within(dialog()).findByText("group by client instead", { selector: ".fl-queued-text" })).toBeTruthy();
+
+    // …then offered to the turn that is running.
+    await waitFor(() => expect(steers()).toHaveLength(1));
+    expect(steers()[0]!.body).toMatchObject({ text: "group by client instead" });
+    expect((steers()[0]!.body as { messageId: string }).messageId).toBeTruthy();
+
+    // It landed, so the words are in the transcript as a user turn…
+    await within(dialog()).findByText("group by client instead", { selector: ".fl-usertext" });
+    // …and the chip now reports DELIVERY, not a wait.
+    expect(within(dialog()).getByText("Sent", { selector: ".fl-queued-tag" })).toBeTruthy();
+
+    await act(async () => release());
+    await within(dialog()).findByText("Turn complete");
+    // THE POINT: no second turn. A landed steer is not a queued send.
+    expect(turns()).toHaveLength(1);
+  });
+
+  it("keeps today's turn-end flush when the turn cannot take the message", async () => {
+    const release = await startHeldTurn(false);
+
+    park("group by client instead");
+    await waitFor(() => expect(steers()).toHaveLength(1));
+    // The chip still says it is waiting, because it is.
+    expect(within(dialog()).getByText("Queued", { selector: ".fl-queued-tag" })).toBeTruthy();
+
+    await act(async () => release());
+    // Unchanged behaviour: it sends as the next turn, once, losing nothing.
+    await waitFor(() => expect(turns()).toHaveLength(2));
+    expect((turns()[1]!.body as { message: { parts: Array<{ text?: string }> } }).message.parts[0]?.text)
+      .toBe("group by client instead");
+  });
+
+  it("a landed steer survives a reload — the server persisted it, not the screen", async () => {
+    const release = await startHeldTurn(true);
+    park("group by client instead");
+    await waitFor(() => expect(steers()).toHaveLength(1));
+    await within(dialog()).findByText("group by client instead", { selector: ".fl-usertext" });
+    await act(async () => release());
+    await within(dialog()).findByText("Turn complete");
+
+    // Read back through the real read path, as a fresh mount would.
+    const threadId = (steers()[0]!.path.match(/\/threads\/([^/]+)\/steer$/))![1]!;
+    const thread = await client.threads.get(threadId);
+    expect(thread!.messages.some(message =>
+      message.role === "user"
+      && message.parts.some(part => part.type === "text" && part.text === "group by client instead"))).toBe(true);
+  });
+
+  it("a message carrying attachments is never steered — it needs a turn of its own", async () => {
+    const release = await startHeldTurn(true);
+
+    const file = new File(["hello"], "notes.txt", { type: "text/plain" });
+    const input = dialog().querySelector("input[type=file]") as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+    await within(dialog()).findByText("notes.txt");
+    park("and use this");
+
+    // Offered nothing: a steer carries WORDS, and an attachment cannot ride one.
+    await waitFor(() => expect(within(dialog()).getByText("Queued", { selector: ".fl-queued-tag" })).toBeTruthy());
+    expect(steers()).toHaveLength(0);
+
+    await act(async () => release());
+    await waitFor(() => expect(turns()).toHaveLength(2));
+  });
+});

--- a/packages/ui/test/wire-server.ts
+++ b/packages/ui/test/wire-server.ts
@@ -351,6 +351,18 @@ export async function createWireServer(options: WireServerOptions = {}) {
     streamFailureText: undefined as string | undefined,
     posture: "rules" as "unconfigured" | "rules" | "judge" | "rules+judge",
     threadReplyGate: undefined as Promise<void> | undefined,
+    /** ⚠️ TEST EDIT (infrastructure) — threads whose turn TAKES a mid-build
+     *  steer, opted in by a `[steerable]` marker on the turn's own prompt (the
+     *  house pattern for every other fixture behaviour). Opt-in matters: without
+     *  it every suite written against the turn-end flush would change meaning. */
+    steerableThreads: new Set<string>(),
+    /** ⚠️ TEST EDIT (infrastructure) — threads whose in-flight `[stream-long]`
+     *  turn should emit a FRESH `building` beat, because a steer just landed on
+     *  them. This models what a real box does — the steered rework hits a Write
+     *  tool and `beat("building")` fires into the OPEN turn stream — so the
+     *  browser can show the build visibly change course. The fixture cannot
+     *  re-plan; it can only faithfully mirror the causal chain steer → new beat. */
+    steerBeats: new Set<string>(),
     // ENG-217 — optional pacing gates for the canned turn so specs can observe
     // exact streaming moments: before ANY chunk (generating skeleton), after
     // text-start but before the first delta (lone caret on an empty streamed
@@ -426,6 +438,16 @@ export async function createWireServer(options: WireServerOptions = {}) {
         const sentText = input.message.parts
           .map(part => (part.type === "text" ? part.text : ""))
           .join(" ");
+        // ⚠️ TEST EDIT (infrastructure) — §10.2. A turn whose prompt carries
+        // `[steerable]` is one this fixture's "box" can take a mid-build message
+        // into. Opt-in per turn, like every other marker here, so the suites
+        // written against the turn-end flush keep meaning what they meant.
+        //
+        // The LATEST turn on a thread decides, which is why the else-branch is
+        // not optional: steerability belongs to a turn, not to a conversation, so
+        // a plain turn after a steerable one must not inherit it.
+        if (sentText.includes("[steerable]")) state.steerableThreads.add(threadId);
+        else state.steerableThreads.delete(threadId);
         if (state.streamFailures > 0) {
           state.streamFailures -= 1;
           const failingChunks = createUIMessageStream<UIMessage>({
@@ -797,6 +819,15 @@ export async function createWireServer(options: WireServerOptions = {}) {
                   id: "text_long",
                   delta: `Streamed paragraph ${index + 1}: the long answer keeps arriving so the list keeps growing while the reader watches.\n\n`,
                 });
+                // A steer landed mid-build: emit ONE fresh `building` beat into
+                // this open stream, exactly as a real box's steered rework would.
+                if (state.steerBeats.delete(threadId)) {
+                  writer.write({
+                    type: "data-vendo-status",
+                    data: { label: "Regrouping by client", phase: "building" },
+                    transient: true,
+                  } as UIMessageChunk);
+                }
                 await new Promise(resolve => setTimeout(resolve, 80));
               }
               writer.write({ type: "text-delta", id: "text_long", delta: "Long turn complete." });
@@ -867,6 +898,30 @@ export async function createWireServer(options: WireServerOptions = {}) {
         json(response, summaries);
         return;
       }
+      // ⚠️ TEST EDIT (infrastructure) — §10.2 mid-build steering. Mirrors the real
+      // route: it answers whether the words LANDED, and on a landing it appends
+      // them to the thread as a normal user turn under the id the client minted,
+      // so a reload reads the same transcript the live screen showed.
+      const steerMatch = method === "POST" ? url.pathname.match(/^\/threads\/([^/]+)\/steer$/) : null;
+      if (steerMatch) {
+        const id = decodeURIComponent(steerMatch[1] ?? "");
+        const body = parsedBody as { text?: string; messageId?: string };
+        if (!state.steerableThreads.has(id)
+          || typeof body?.text !== "string" || typeof body?.messageId !== "string") {
+          json(response, { landed: false });
+          return;
+        }
+        // Landing is the TURN's answer, so it does not depend on a stored row —
+        // some browser scenarios hold their thread client-side only. Where a row
+        // does exist it gains the message, which is what a reload reads back.
+        state.threads.get(id)?.messages
+          .push({ id: body.messageId, role: "user", parts: [{ type: "text", text: body.text }] });
+        // Tell an in-flight `[stream-long]` turn to narrate its course-change.
+        state.steerBeats.add(id);
+        json(response, { landed: true });
+        return;
+      }
+
       const threadMatch = url.pathname.match(/^\/threads\/([^/]+)$/);
       if (threadMatch) {
         const id = decodeURIComponent(threadMatch[1] ?? "");

--- a/packages/vendo/src/server.test.ts
+++ b/packages/vendo/src/server.test.ts
@@ -3867,3 +3867,142 @@ describe("execution-v2 — box-edit env knobs", () => {
     expect(() => createVendo({ model: {} as LanguageModel, store })).not.toThrow();
   });
 });
+
+describe("mid-build steering — POST /threads/:id/steer (§10.2)", () => {
+  /**
+   * The WHOLE chain, no stub on either side: the real wire route, the real
+   * principal-scoped registry, the real harness runtime, and a harness that
+   * really registers `Turn.onSteer`. The only thing scripted is the thinker,
+   * because a unit test cannot run a model.
+   */
+  async function steerableSetup(resolver = vi.fn(async () => principal)) {
+    let release!: () => void;
+    const released = new Promise<void>((resolve) => { release = resolve; });
+    const heard: string[] = [];
+    /** Set when the harness declines to register — the "cannot take one" leg. */
+    let deaf = false;
+    const harness = {
+      name: "steerable",
+      async *run(turn: { onSteer?: (handler: (text: string) => Promise<boolean>) => void }) {
+        if (!deaf) {
+          turn.onSteer?.(async (text) => {
+            heard.push(text);
+            return true;
+          });
+        }
+        yield { type: "text" as const, delta: "building it" };
+        await released;
+        yield { type: "text" as const, delta: " — done." };
+      },
+    };
+    const store = await tempStore("vendo-steer-");
+    const vendo = createVendo({
+      model: {} as LanguageModel,
+      principal: resolver,
+      store,
+      harness: harness as never,
+    });
+    return { vendo, release, heard, resolver, goDeaf: () => { deaf = true; } };
+  }
+
+  const turnBody = { message: { id: "m_steer_turn", role: "user", parts: [{ type: "text", text: "build me a workbench" }] } };
+
+  it("lands the user's words in the running turn and in the transcript, once, in order", async () => {
+    const { vendo, release, heard } = await steerableSetup();
+    const turn = await vendo.handler(request("POST", "/threads", turnBody));
+    const threadId = turn.headers.get("x-vendo-thread-id")!;
+    expect(threadId).toMatch(/^thr_/);
+
+    const steered = await vendo.handler(request("POST", `/threads/${threadId}/steer`, {
+      text: "group by client instead",
+      messageId: "m_steer_words",
+    }));
+    expect(steered.status).toBe(200);
+    expect(await steered.json()).toEqual({ landed: true });
+    expect(heard).toEqual(["group by client instead"]);
+
+    release();
+    await turn.text();
+
+    // Read back through the REAL read path: the steer is a normal user turn,
+    // between the ask and the answer.
+    const thread = await (await vendo.handler(request("GET", `/threads/${threadId}`))).json() as {
+      messages: Array<{ id: string; role: string; parts: Array<{ type: string; text?: string }> }>;
+    };
+    expect(thread.messages.map((message) => [message.role, message.id])).toEqual([
+      ["user", "m_steer_turn"],
+      ["user", "m_steer_words"],
+      ["assistant", expect.any(String)],
+    ]);
+    expect(thread.messages[1]!.parts).toEqual([{ type: "text", text: "group by client instead" }]);
+  });
+
+  it("answers `landed: false` for a thread with no turn in flight — and writes nothing", async () => {
+    const { vendo, release } = await steerableSetup();
+    const turn = await vendo.handler(request("POST", "/threads", turnBody));
+    const threadId = turn.headers.get("x-vendo-thread-id")!;
+    release();
+    await turn.text();
+
+    const steered = await vendo.handler(request("POST", `/threads/${threadId}/steer`, {
+      text: "too late",
+      messageId: "m_late",
+    }));
+    expect(steered.status).toBe(200);
+    expect(await steered.json()).toEqual({ landed: false });
+
+    const thread = await (await vendo.handler(request("GET", `/threads/${threadId}`))).json() as {
+      messages: Array<{ id: string }>;
+    };
+    expect(thread.messages.map((message) => message.id)).not.toContain("m_late");
+  });
+
+  it("gives an unknown thread id no oracle — the same answer as a thread that is simply idle", async () => {
+    const { vendo, release } = await steerableSetup();
+    const turn = await vendo.handler(request("POST", "/threads", turnBody));
+    const unknown = await vendo.handler(request("POST", "/threads/thr_does_not_exist/steer", {
+      text: "hello?",
+      messageId: "m_probe",
+    }));
+    expect(unknown.status).toBe(200);
+    expect(await unknown.json()).toEqual({ landed: false });
+    release();
+    await turn.text();
+  });
+
+  it("a FOREIGN principal cannot steer another person's build, and learns nothing by trying", async () => {
+    const resolver = vi.fn(async () => principal);
+    const { vendo, release, heard } = await steerableSetup(resolver);
+    const turn = await vendo.handler(request("POST", "/threads", turnBody));
+    const threadId = turn.headers.get("x-vendo-thread-id")!;
+
+    resolver.mockResolvedValue({ kind: "user", subject: "user_mallory" } as never);
+    const foreign = await vendo.handler(request("POST", `/threads/${threadId}/steer`, {
+      text: "wire the money to me",
+      messageId: "m_evil",
+    }));
+    // Indistinguishable from an idle thread: no oracle, exactly like the beat.
+    expect(foreign.status).toBe(200);
+    expect(await foreign.json()).toEqual({ landed: false });
+    expect(heard).toEqual([]);
+
+    release();
+    await turn.text();
+  });
+
+  it("a harness that never registers a handler answers `landed: false`, with no capability protocol anywhere", async () => {
+    const { vendo, release, goDeaf } = await steerableSetup();
+    goDeaf();
+    const turn = await vendo.handler(request("POST", "/threads", turnBody));
+    const threadId = turn.headers.get("x-vendo-thread-id")!;
+
+    const steered = await vendo.handler(request("POST", `/threads/${threadId}/steer`, {
+      text: "are you listening",
+      messageId: "m_unheard",
+    }));
+    expect(await steered.json()).toEqual({ landed: false });
+
+    release();
+    await turn.text();
+  });
+});

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -34,6 +34,7 @@ import { createHarnessTurns, type HarnessTurns } from "./harness-turn.js";
 // config listing, which is compiled against these very interfaces, can too).
 export type { HarnessTurns } from "./harness-turn.js";
 export type { AppsConfig } from "@vendoai/apps";
+import { registerTurnSteer } from "./turn-liveness.js";
 import { warnDeprecatedConfigKeys } from "./config-keys.js";
 import { orgPolicyPath, orgPolicyResolver, workspacePolicySource } from "./org-policy.js";
 import { createPromoteApp } from "./promote-app.js";
@@ -2798,7 +2799,17 @@ export function createVendo(config: CreateVendoConfig): Vendo {
     // Every turn, published for the door's turn credential. Publishing is not a
     // grant: without a credential minted from inside the turn there is nothing
     // to resolve, and the credential's authority window IS this publication.
-    liveTurn: ({ threadId, ctx, tools }) => turnCredentials.publish(threadId, { ctx, tools }),
+    // The steer sink rides the same publication for the same reason: both are
+    // "reach the turn in flight from this process's own doors", and both die with
+    // the turn.
+    liveTurn: ({ threadId, ctx, tools, steer }) => {
+      const unpublish = turnCredentials.publish(threadId, { ctx, tools });
+      const unregister = registerTurnSteer({ threadId, subject: ctx.principal.subject, steer });
+      return () => {
+        unregister();
+        unpublish();
+      };
+    },
     // The other half, for a harness whose thinker is not in this process: where
     // the door is, and how to mint one conversation's credential for it. `url`
     // is undefined when nothing this harness may dial exists — a machine cannot

--- a/packages/vendo/src/turn-liveness.ts
+++ b/packages/vendo/src/turn-liveness.ts
@@ -78,6 +78,56 @@ export function touchActiveTurn(threadId: string, subject: string): boolean {
   return active;
 }
 
+/**
+ * The mid-turn STEER sink of a turn in flight (§10.2).
+ *
+ * Its own registry rather than a field on {@link ActiveTurn} because the two are
+ * published by different halves at different moments: the wire registers the
+ * abort from OUTSIDE the turn, once `runTurn.stream` has returned, while the
+ * runtime publishes this from INSIDE it (`liveTurn`). One entry with two
+ * registrars would be a two-phase handshake for no gain.
+ */
+interface SteerableTurn {
+  threadId: string;
+  subject: string;
+  steer: (text: string, messageId: string) => Promise<boolean>;
+}
+
+const STEERABLE_TURNS_KEY = Symbol.for("vendoai.vendo.steerable-turns@1");
+
+function steerableTurns(): Set<SteerableTurn> {
+  const holder = globalThis as { [STEERABLE_TURNS_KEY]?: Set<SteerableTurn> };
+  return (holder[STEERABLE_TURNS_KEY] ??= new Set());
+}
+
+/** Publish this turn's steer sink; returns its retraction. */
+export function registerTurnSteer(turn: SteerableTurn): () => void {
+  const entry: SteerableTurn = { ...turn };
+  steerableTurns().add(entry);
+  return () => { steerableTurns().delete(entry); };
+}
+
+/**
+ * Hand `text` to `subject`'s own turn in flight on `threadId`. Principal-scoped
+ * exactly like {@link touchActiveTurn}: foreign or unknown ids answer `false` —
+ * no oracle, and nobody can speak into another principal's build.
+ *
+ * `false` is a FACT and not a failure: it is also the answer when the turn simply
+ * cannot take a message, and the caller's own queue is the fallback either way.
+ */
+export async function steerActiveTurn(
+  threadId: string,
+  subject: string,
+  text: string,
+  messageId: string,
+): Promise<boolean> {
+  for (const turn of steerableTurns()) {
+    if (turn.threadId !== threadId || turn.subject !== subject) continue;
+    return await turn.steer(text, messageId);
+  }
+  return false;
+}
+
 /** Wrap a turn response so `onSettled` runs exactly once when its stream
  *  finishes, errors, or is cancelled — the turn's registry entry must not
  *  outlive the stream. Mirrors the wire's inflight-bracket wrapper. */

--- a/packages/vendo/src/wire/threads.ts
+++ b/packages/vendo/src/wire/threads.ts
@@ -1,6 +1,6 @@
 import { VendoError, withSseKeepalive } from "@vendoai/core";
 import { UI_MESSAGE_STREAM_HEADERS } from "ai";
-import { registerActiveTurn, touchActiveTurn, trackTurnResponse } from "../turn-liveness.js";
+import { registerActiveTurn, steerActiveTurn, touchActiveTurn, trackTurnResponse } from "../turn-liveness.js";
 import { recordResumableTurn, resumableTurnStream } from "../turn-resume.js";
 import { json, requestJson, route, string, type RouteEntry } from "./shared.js";
 
@@ -86,6 +86,29 @@ export const threadRoutes: RouteEntry[] = [
     const ctx = await context("chat");
     const id = string(params["id"], "thread id");
     return json({ active: touchActiveTurn(id, ctx.principal.subject) });
+  }),
+  // §10.2 — mid-build steering. Modelled on the beat above and scoped the same
+  // way: it can only reach the caller's OWN turn in flight, and an unknown or
+  // foreign id answers `landed: false`, which is also what an idle thread
+  // answers (no oracle). The answer is the ONLY signal the client needs — there
+  // is no capability to ask about and nothing to validate up front.
+  //
+  // Independent of stream-resume above: a steer INJECTS input into the running
+  // turn via the registry, while resume REPLAYS the recorded byte stream — so a
+  // client that rejoins through `GET /threads/:id/stream` sees the steered
+  // output for free, because it flows through the same recorded Response.
+  route("POST", "/threads/:id/steer", async ({ request, context, params }) => {
+    const ctx = await context("chat");
+    const id = string(params["id"], "thread id");
+    const body = await requestJson(request);
+    return json({
+      landed: await steerActiveTurn(
+        id,
+        ctx.principal.subject,
+        string(body["text"], "text"),
+        string(body["messageId"], "messageId"),
+      ),
+    });
   }),
   route("GET", "/threads", async ({ deps, context }) => {
     return json(await deps.agent.threads.list(await context("chat")));


### PR DESCRIPTION
## A build can be corrected while it is still building

Mid-build steering (blueprint §10.2). `session.send()` / `interrupt()` gain their
first steering caller; nothing is built beside them. **No new card, pill, toast,
preview surface, event vocabulary, composer, queue or send path.**

### Queue policy as built — queue-and-deliver-at-next-step

A message typed while a turn is in flight still parks in the composer's **existing
single queued slot**, unchanged. It is then *offered* to the running turn. The
Agent SDK's own already-open input stream does the queueing, so we build no second
queue — that is where "at-next-step" comes from.

| | What the user sees |
|---|---|
| **Steer lands** | Their words become a normal user turn in the transcript; the same `.fl-queued` chip flips to **Sent · added to the reply in progress**, `Send now` disappears (nothing left to send). It is **not** re-sent at turn end. |
| **Steer does not land** | Today's behaviour, untouched: **Queued · sends when the reply finishes**, then flushes on the busy edge. Nothing lost, nothing duplicated. |

`interrupt()` stays the explicit stop. **Steering never cancels.** No new stop UI.

The chip's copy states the message's *fate* only — never anything about how the
result looks. The build's own reply is the only thing entitled to describe the build.

### The §1 harness-contract change — NEEDS RATIFICATION

One **optional** member on `Turn` (`packages/core/src/harness.ts`):

```ts
readonly onSteer?: (handler: (text: string) => Promise<boolean>) => void;
```

- **Inbound**, so deliberately *not* a `HarnessEvent` — that union is closed and
  describes what a harness *says*. A steer is what a harness is *told*; merging
  them would be the second event vocabulary §0 forbids. `HarnessEvent` is untouched.
- **Optional**, so every existing harness and driver is unchanged by construction.
- **One mechanism, not two** — a registered callback, no parallel async iterable.
- The handler answers whether *this* message landed, because a harness that can
  steer in general still cannot when the thing it drives has just finished.
  Not registering **is** the "no" — which is why there is **no capability
  protocol** anywhere in this change.

Second, smaller widening (not §1): `HarnessRuntimeDeps.liveTurn`'s published
object gains `steer`. Reused rather than adding a deps member — "publish the turn
now in flight to this process's own doors" is already what that hook means.

### Three hazards, each measured before it was fixed

**1 · Early settle (fatal, silent).** Every user message the SDK answers produces
its own `result`, and `send()` settled on the next one it saw. A naive steer
therefore resolved the *original* `send()` at message 1's result → the box door
marked the message done → the poll loop returned → **the turn ended on the wire
while the box was still working, and the steer's own output went to a state nobody
polls.** N steers add exactly N results, so N are swallowed. `interrupt()` clears
the count, or a stopped turn would hang to the 15-minute message budget.

Proven by writing the naive version first and watching the test go red:
`expected true to be false` — the caller's promise had settled while the steered
turn was still held open.

**2 · Transcript seq collision (verdict: REAL, and different from the brief's
guess).** `persistTurn` writes one row per message at its **index** in the turn's
own array. A side-channel write to the store cannot know that index, so it lands
at the seq the assistant message then claims. Measured with the runtime's real
persist path: `m_steer` at seq 1, assistant **also** at seq 1. The store reads
`ORDER BY seq` with **no tiebreak**, and `schema.ts` calls seq "the ONLY ordering
authority" — so the user's steer and the reply it caused had **undefined order**.
Not an overwrite: a collision.

Fixed by appending to the in-flight turn's own message list, which the existing
turn-end pass then persists once, in place.

**3 · Contract** — above.

### The seam, both ends, no stub on either side

- `ClaudeSession.steer` → the SDK's open inbox (`claude-turn.ts` still imports
  **nothing**, verified — its output is copied verbatim into a machine image).
- Box door route `/session/:id/steer` — extends the existing regex; only the
  message *in flight* can take one.
- `SessionMachine.steer` in **both** homes: an HTTP hop to the real box door, and
  a direct push into the live local session. A seam with one implementation lies.
- `POST /threads/:id/steer` modelled exactly on the liveness beat:
  principal-scoped, and a **foreign or unknown thread id answers exactly what an
  idle thread answers** — no oracle.
- `packages/vendo/src/server.test.ts` drives the whole chain with the real wire
  route, real registry, real runtime and a real `onSteer` harness, then reads the
  transcript back through the real `GET /threads/:id`.

### `interrupt()` was never unused — correcting the blueprint

The blueprint says `send()`/`interrupt()` "exist unused". `interrupt()` already had
real callers via the abort path, so **no stop affordance was added**:

- **local**: direct call (`local.ts:305`, plus the abort listener).
- **box**: `box.ts` does *not* call the session — it posts
  `/session/:id/interrupt` and the **door** calls `session.interrupt()`.

Now pinned by a test, proven failable by breaking the abort check.

### Real-browser proof

`packages/ui/e2e/steering.spec.ts`, driven by the package's own Playwright against
the in-process wire server. Both specs pass; the preview server was reaped
immediately after.

- `packages/ui/e2e/screenshots/steering-landed-mid-build.png` — the moment of
  steering during a live build: chip reads `SENT · added to the reply in progress`,
  the user's correction is in the transcript, the build is still streaming and
  `Stop` is still offered.
- `packages/ui/e2e/screenshots/steering-fallback-queued.png` — the unchanged path:
  `QUEUED · sends when the reply finishes` with `Send now`.
- `packages/ui/e2e/screenshots/steering-settled-in-history.png` — **needs
  re-capture**: the `[stream-long]` fixture answers with 100 paragraphs so the
  settled viewport sat past the steer. The spec fix (scroll into view) is in this
  commit; the capture needs the fleet browser slot.

### §0 — what went down, not up

No new concepts. The queued slot, the `.fl-queued` element, the box door, the
`SessionMachine` port, the liveness registry module and the `liveTurn` publish hook
were all **extended, not duplicated**. Two things were consolidated rather than
added beside: the steer sink rides the **existing** `liveTurn` publication instead
of a new runtime dep, and the landed/queued states are **one element with two
labels** instead of a second component. `interrupt()`'s "unused" status is removed
from the docs by being disproved.

### Gate

Green post-rebase: package-scoped `build` and `typecheck` for all five touched
packages, `dependency-guard` (16 packages), `portability-gate` (all legs).

**Not yet re-run post-rebase:** the four vitest slices and the browser spec — all
were green *before* `origin/main` advanced twice under this branch. Held because
the fleet allows two test slots and D5 has a merge-blocking failure waiting on
one. Exact commands are in the lane's parked note. **Do not merge until they are
re-run.**

### Test edits, every one declared

All marked `⚠️ TEST EDIT` in place. All are test **doubles/infrastructure** kept
honest with the port they stand in for — no assertion was weakened:

- `box-turn-routes.test.ts`, `claude-code.test.ts`, `local-session.test.ts` — the
  session doubles gained `steer` (and now mirror the real session's refusal when no
  turn is in flight); the fake box records `steers` and `interrupted` so the chain
  is observable.
- `claude-session.test.ts` — the fake SDK gained an optional `gate`, the only way
  to observe that a caller's promise is still *pending* while the session works.
- `runtime.test.ts` — the fixture accepts `liveTurn`.
- `wire-server.ts` — the `/threads/:id/steer` route and a `[steerable]` per-turn
  marker, **off by default** so every suite written against the turn-end flush
  keeps meaning what it meant.
- `steering.test.tsx` releases its held turn in `afterEach`, so one failed
  assertion cannot cascade into a hook timeout.

No existing assertion was changed. `composer.test.tsx`, `conversation-registry.test.tsx`,
`export-surface.test.ts` and `hooks.test.tsx` all still pass unmodified.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let users correct a reply while it’s still streaming. A message typed mid-turn is offered to the build in progress; if it lands, it becomes a normal user turn and is not re‑sent at the end.

- **New Features**
  - Queue policy: queue-and-deliver-at-next-step. The SDK’s open input stream queues the steer; `interrupt()` remains the only cancel.
  - API/UI: `POST /threads/:id/steer` (principal‑scoped) and box route `/session/:id/steer` return `{ landed }`. The composer offers steer while busy, flips the chip to “Sent · added to the reply in progress,” hides “Send now,” and never resends a landed message; attachments/grounding are not steered.
  - Runtime/SDK: optional `Turn.onSteer(handler)`, `ClaudeSession.steer(): boolean`, and `SessionMachine.steer` for both local and box paths. Published via `liveTurn`; `vendo` registers a per‑turn steer sink and dispatches through `steerActiveTurn`.

- **Bug Fixes**
  - Prevented early settlement by counting extra `result` messages; `interrupt()` clears the count so stop ends promptly.
  - Removed transcript seq collisions by appending steered user messages to the in‑flight turn’s message list and persisting once at turn end; the UI inserts the steered message before the assistant reply for stable order.
  - Beats: no `finishing` on a steered result, and narration resets so the rework can re‑narrate its phase.

<sup>Written for commit 87b0508e82dd10d1382f4013180bf5a5d5cf2d9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

