### PR TITLE
UI-gen A1: the screen agent, its small loadout, and the seam that routes vendo_make to it

### DIFF
--- a/.changeset/screen-agent.md
+++ b/.changeset/screen-agent.md
@@ -1,0 +1,54 @@
+---
+"@vendoai/core": minor
+"@vendoai/apps": minor
+"@vendoai/harnesses": minor
+"@vendoai/vendo": minor
+---
+
+The screen agent: `vendo_make` starts in a cheap assembly loop, and the conductor
+is what it falls through to.
+
+Every request for something to look at used to go straight into the generation
+conductor — a plan call, a fill worker per group, and the checking layer's two fix
+rounds — whether the ask was a full app or one number on a card. Now the seam
+routes: a lean loop assembles the document itself, and escalates when it cannot.
+
+**The loop** (`screenAgent()` / `assembleScreen` in `@vendoai/harnesses`) is the
+same `startTurn` call `vendo()` and `instant()` drive, with a small loadout and a
+tight budget:
+
+- **Assembly tools only.** The verbs by name (`search_components`, `validate`,
+  `vendo_apps_data_list`, `vendo_apps_open`, `ask_user`) unioned with the host's
+  `read`-risk tools. No mutating host tool, no build tool, and `vendo_make` itself
+  is withheld — the screen agent is what it calls.
+- **The host's own declared result shapes** ride the brief, off
+  `ToolListing.outputSchema`, so field names are known before any query runs.
+- **The shipped job description**, reused: `buildingAppsSkill` and its
+  `references/format.md`, plus one short block correcting what is different here
+  (no disk, no delegation, two files, one door out). There is no third prompt.
+- **`SCREEN_STEPS = 10`.** An ask that needs more than that is an ask for a build.
+- **No new write path and no new paint path.** It writes `app.vendo` through the
+  workspace and the render seam's `commit()` proxy paints it, exactly as the
+  `claudeCode()` harness already builds apps.
+
+**Escalation** (`escalate`) writes `plan.vendo` and hands the ask on. The plan's
+skeleton paints in seconds and becomes the build's first frame — no consent step,
+one plain sentence, the work proceeds. `AppsRuntime.create` now accepts a
+caller-minted `appId` so the escalated plan and the build that finishes it land on
+one app and one view stream instead of two.
+
+**The routing is an adapter slot, and it is default-safe.** `AppsConfig.screen`
+takes core's new `ScreenAssembler`; composition is the only place that fills it
+(`apps.experimentalScreenAgent: true`, host config only). `vendo_make` falls
+through to `conductCreate` unchanged on every other answer — an escalation, an
+assembler that could not run, one that threw, and an `assembled` that left no app
+row behind. That last check is what makes the promise true rather than intended:
+the row is the truth, so a screen agent that saved bytes nobody can render costs a
+request nothing.
+
+Screens run unsandboxed, by design: a description is data, its props are
+schema-validated, and the kit treats them as inert.
+
+New in `@vendoai/core`: `ScreenAssembler`, `ScreenRequest`, `ScreenOutcome`.
+Edits go through the conductor as before — routing them needs the app's checkout
+projection, which is not this change.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -500,6 +500,7 @@ export interface CreateVendoConfig {
   approvals?: { parkedCallTtlMs?: number };
   apps?: {
     experimentalMachines?: boolean;
+    experimentalScreenAgent?: boolean; // route vendo_make through the cheap screen agent first
     review?: {                // review-kind remixes: who may review (queue/reject/approve)
       reviewer?(ctx: RunContext): boolean | Promise<boolean>;
     };

--- a/packages/apps/src/agent-tools.ts
+++ b/packages/apps/src/agent-tools.ts
@@ -11,6 +11,7 @@ import {
   type MakeReceipt,
   type RecordQuery,
   type RunContext,
+  type ScreenAssembler,
   type ToolDescriptor,
   type ToolOutcome,
   type ToolRegistry,
@@ -223,6 +224,10 @@ const optionalLimit = (value: Json | undefined): number | undefined => {
 export interface AgentToolsDataDependencies {
   data: AppDataAccess;
   requireOwned(appId: AppId, ctx: RunContext): Promise<AppDocument>;
+  /** UI-generation blueprint §1 point 2 — the screen agent, in front of the
+   *  conductor. Threaded from `AppsConfig.screen`, which composition fills; see
+   *  the routing block in the `vendo_make` handler below. */
+  screen?: ScreenAssembler;
 }
 
 /**
@@ -273,8 +278,50 @@ export const createAgentTools = (
         const stream = (call as VendoViewStreamingToolCall)[VENDO_VIEW_STREAM];
         const ask = withContext(args.request as string, optionalString(args.context, "context"));
         if (app === undefined) {
+          // ── THE SEAM (blueprint §1 point 2) ─────────────────────────────────
+          // "No agent chooses 'quick screen' vs 'real build'. Every request
+          // starts in the cheap screen agent." The id is minted HERE, before the
+          // route, because both engines have to use the same one: an escalation
+          // leaves `plan.vendo` and its painted skeleton at this id, and a
+          // conductor that minted its own would strand that skeleton on a second
+          // stream as a card that builds forever.
+          //
+          // Only `assembled` WITH A ROW ends the call. The row is the check that
+          // makes default-safety true instead of merely intended: `authored`
+          // upserts it iff the seam actually compiled and painted the document,
+          // so a screen agent that saved bytes nobody can render leaves no row
+          // and this falls through to the conductor exactly as if it had never
+          // been composed.
+          const appId = `app_${globalThis.crypto.randomUUID()}` as AppId;
+          const routed = dependencies.screen === undefined
+            ? undefined
+            : await dependencies.screen.assemble({
+              appId,
+              request: ask,
+              ...(stream === undefined ? {} : {
+                onView: (part) => stream({ id: vendoViewStreamId(part.appId), part }),
+              }),
+            }, ctx).catch((error: unknown) => {
+              // A broken assembler is a slower answer, never a failed one.
+              console.warn(`[vendo] the screen agent could not serve ${appId}; the conductor takes it — ${
+                error instanceof Error ? error.message : String(error)
+              }`);
+              return undefined;
+            });
+          if (routed?.kind === "assembled") {
+            const stored = await runtime.get(appId, ctx).catch(() => null);
+            if (stored !== null) {
+              return receipt({
+                id: stored.id,
+                title: stored.name,
+                status: "ready",
+                say: `${stored.name} is on your screen.`,
+              });
+            }
+          }
           let unsaved: string | undefined;
           const created = await runtime.create({
+            appId,
             prompt: ask,
             onUnsaved: (reason) => { unsaved = reason; },
             ...(stream === undefined ? {} : {

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -24,6 +24,7 @@ import {
   type NormalizedCatalog,
   type PlanDisplay,
   type RunContext,
+  type ScreenAssembler,
   type ApprovalId,
   type ApprovalRequest,
   type RiskLabel,
@@ -287,6 +288,23 @@ export interface AppsConfig {
    *  skip, host tools are unaffected, and the tools stay LISTED for
    *  generation (execution still answers `connect-required` on its own). */
   connectedToolkits?: (ctx: RunContext) => Promise<string[]>;
+  /**
+   * UI-generation blueprint §1 point 2 — the screen agent, in front of the
+   * conductor. "The seam routes, not the caller": every `vendo_make` request
+   * starts in the cheap assembly loop, and this block never decides which engine
+   * a request deserves.
+   *
+   * An ADAPTER SLOT, for the reason every other one here is: the screen agent is a
+   * lean loop in `@vendoai/harnesses` and this block depends on `core` alone, so
+   * the two sides meet on core's `ScreenAssembler` and composition is the only
+   * place that fills it. Explicitly passed always wins; unfilled changes nothing.
+   *
+   * DEFAULT-SAFE by construction. `vendo_make` routes here first and falls
+   * through to `conductCreate` on every answer but `assembled` — an escalation, an
+   * assembler that could not run, a throw, and (the check that makes the promise
+   * true rather than merely intended) an `assembled` that left no app ROW behind.
+   */
+  screen?: ScreenAssembler;
 }
 
 /** 06-apps §1 */
@@ -642,6 +660,17 @@ export interface AuthoredAppResult {
 export interface AppsRuntime {
   create(input: {
     prompt: string;
+    /**
+     * The id this build must use, when the caller already minted one.
+     *
+     * The front door mints before it routes to the screen agent (§4.5): an
+     * escalation's `plan.vendo` is already written at `/user/apps/<appId>/` and
+     * its skeleton is already on `vendoViewStreamId(appId)`, so a conductor that
+     * minted its own id would paint the finished app onto a SECOND stream and
+     * leave the plan's skeleton stranded beside it as a permanently-building
+     * card. Absent — every caller but the front door — one is minted here.
+     */
+    appId?: AppId;
     /** Additive per-call stream hook used by the agent bridge. */
     onView?: (part: VendoViewPart) => void;
     /** Called when the app was generated and STREAMED to the surface but the
@@ -2313,8 +2342,10 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       if (config.model === undefined) {
         throw new VendoError("not-implemented", "generation requires a model");
       }
-      // Mint before generation so every partial already carries its permanent id.
-      const appId = `app_${globalThis.crypto.randomUUID()}`;
+      // Mint before generation so every partial already carries its permanent id
+      // — unless the front door already did, in which case an escalated plan's
+      // skeleton and this build's paints share one stream.
+      const appId = input.appId ?? `app_${globalThis.crypto.randomUUID()}`;
       const createStartedAt = Date.now();
       // The build's dead-man switch. The catch below persists a terminal failure
       // when the build turn THROWS, but a build task that hangs (a provider
@@ -3153,7 +3184,11 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     },
 
     agentTools() {
-      return createAgentTools(runtime, { data, requireOwned });
+      return createAgentTools(runtime, {
+        data,
+        requireOwned,
+        ...(config.screen === undefined ? {} : { screen: config.screen }),
+      });
     },
 
     inClient: {

--- a/packages/apps/src/screen-route.test.ts
+++ b/packages/apps/src/screen-route.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The front door's routing seam — blueprint §1 point 2 and §4.5.
+ *
+ * `vendo_make` starts every request in the screen agent and falls through to the
+ * conductor on every answer but `assembled`. Two properties make that safe rather
+ * than merely intended, and both are asserted here against the REAL conductor:
+ *
+ * 1. **One app id across both engines.** An escalation has already written
+ *    `plan.vendo` at the id it was handed and its skeleton is already painted on
+ *    `vendoViewStreamId(appId)`. A conductor that minted its own would paint the
+ *    finished app onto a SECOND stream and leave that skeleton beside it as a card
+ *    that builds forever.
+ * 2. **An unwired or unserving assembler changes nothing.** The conductor path is
+ *    not amputated by this seam; it is what the seam falls through to.
+ */
+import type { AppId, RunContext, ScreenAssembler, ScreenRequest, ToolRegistry, VendoViewPart } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createAgentTools } from "./agent-tools.js";
+import { createApps } from "./index.js";
+import { basicLanguageModel, guardFixture, memoryStore } from "./testing/index.js";
+
+const ctx: RunContext = {
+  principal: { kind: "user", subject: "user_screen" },
+  venue: "chat",
+  presence: "present",
+  sessionId: "session_screen",
+};
+
+const tools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "error", error: { code: "not-found", message: "no tools" } }; },
+};
+
+const runtimeWith = (screen?: ScreenAssembler) => {
+  const runtime = createApps({
+    store: memoryStore(),
+    guard: guardFixture(),
+    tools,
+    catalog: [],
+    model: basicLanguageModel(),
+    ...(screen === undefined ? {} : { screen }),
+  });
+  return {
+    runtime,
+    agentTools: createAgentTools(runtime, {
+      data: {} as never,
+      requireOwned: async () => { throw new Error("unused"); },
+      ...(screen === undefined ? {} : { screen }),
+    }),
+  };
+};
+
+/** An assembler that records what it was handed and answers however the test says. */
+function recordingAssembler(answer: Awaited<ReturnType<ScreenAssembler["assemble"]>>) {
+  const seen: ScreenRequest[] = [];
+  return {
+    seen,
+    assembler: { assemble: async (request: ScreenRequest) => { seen.push(request); return answer; } },
+  };
+}
+
+const make = async (
+  agentTools: ReturnType<typeof createAgentTools>,
+  request = "Show my spending by category",
+) => await agentTools.execute({ id: "call_1", tool: "vendo_make", args: { request } }, ctx);
+
+describe("an escalation and the build that finishes it share ONE app id", () => {
+  it("the conductor builds at the id the screen agent was handed", async () => {
+    const { seen, assembler } = recordingAssembler({ kind: "escalate", why: "this needs real code" });
+    const { agentTools } = runtimeWith(assembler);
+
+    const outcome = await make(agentTools);
+
+    expect(outcome.status).toBe("ok");
+    const receipt = (outcome as { output: { id: string } }).output;
+    // The assembler was consulted first — the seam routes, the caller does not.
+    expect(seen).toHaveLength(1);
+    // …and the app the conductor went on to build IS the app whose plan the screen
+    // agent wrote. This is the assertion that stops a stranded skeleton.
+    expect(receipt.id).toBe(seen[0]?.appId);
+  });
+
+  it("`create` honours a caller-minted id and paints every view on it", async () => {
+    const { runtime } = runtimeWith();
+    const appId = "app_caller_minted" as AppId;
+    const parts: VendoViewPart[] = [];
+
+    const app = await runtime.create({ appId, prompt: "Show my spending", onView: (part) => parts.push(part) }, ctx);
+
+    expect(app.id).toBe(appId);
+    expect(parts.length).toBeGreaterThan(0);
+    expect(new Set(parts.map((part) => part.appId))).toEqual(new Set([appId]));
+  });
+});
+
+describe("the conductor is what the seam falls through to", () => {
+  it("an unwired assembler leaves vendo_make exactly as it was", async () => {
+    const { agentTools } = runtimeWith();
+    const outcome = await make(agentTools);
+    expect(outcome.status).toBe("ok");
+    expect((outcome as { output: { status: string } }).output.status).toBe("ready");
+  });
+
+  it("an assembler that cannot serve is not a failed request", async () => {
+    const { assembler } = recordingAssembler({ kind: "unavailable", why: "no workspace here" });
+    const { agentTools } = runtimeWith(assembler);
+    const outcome = await make(agentTools);
+    expect(outcome.status).toBe("ok");
+    expect((outcome as { output: { status: string } }).output.status).toBe("ready");
+  });
+
+  it("an assembler that THROWS is not a failed request either", async () => {
+    const throwing: ScreenAssembler = { assemble: async () => { throw new Error("assembler exploded"); } };
+    const { agentTools } = runtimeWith(throwing);
+    const outcome = await make(agentTools);
+    expect(outcome.status).toBe("ok");
+    expect((outcome as { output: { status: string } }).output.status).toBe("ready");
+  });
+
+  it("an `assembled` that left no ROW behind falls through — a picture of an app is not an app", async () => {
+    // The screen agent said it assembled, but nothing renderable ever reached the
+    // store, so `authored` upserted no row. The front door checks the row rather
+    // than trusting the answer, and the conductor takes the ask.
+    const { assembler } = recordingAssembler({ kind: "assembled" });
+    const { agentTools } = runtimeWith(assembler);
+    const outcome = await make(agentTools);
+    expect(outcome.status).toBe("ok");
+    const receipt = (outcome as { output: { status: string; title: string } }).output;
+    expect(receipt.status).toBe("ready");
+    // The conductor's own document, not an invented title over an absent app.
+    expect(receipt.title.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,7 @@ export * from "./principal.js";
 export * from "./reshape.js";
 export * from "./product-slug.js";
 export * from "./run-context.js";
+export * from "./screen.js";
 export * from "./semantics.js";
 export * from "./shape.js";
 export * from "./sha256.js";

--- a/packages/core/src/screen.ts
+++ b/packages/core/src/screen.ts
@@ -1,0 +1,58 @@
+/**
+ * The screen-assembly seam — UI-generation blueprint §1 point 2 and §4.2.
+ *
+ * "The seam routes, not the caller." No agent chooses "quick screen" vs "real
+ * build": every `vendo_make` request starts in the cheap screen agent, and the
+ * conductor is what an escalation or an unserved ask falls through to.
+ *
+ * The screen agent itself is a lean loop in `@vendoai/harnesses` — it needs a
+ * model, the guard-bound registry, and a workspace whose commits reach the render
+ * seam, none of which `@vendoai/apps` holds. `apps` depends on `core` alone, so
+ * the two sides meet on this interface and composition (`packages/vendo`) is the
+ * only place that fills the slot. That is the shipped adapter rule: an explicitly
+ * passed adapter always wins, an unfilled slot changes nothing, and there is no
+ * hidden key-conditional branch. Unset — or set and answering anything but
+ * `assembled` — and the conductor path runs exactly as it did before this seam
+ * existed.
+ */
+import type { AppId } from "./ids.js";
+import type { RunContext } from "./run-context.js";
+import type { VendoViewPart } from "./stream-parts.js";
+
+/** One ask, as the front door hands it over. */
+export interface ScreenRequest {
+  /**
+   * The app id this request is FOR, minted by the front door rather than by the
+   * assembler.
+   *
+   * The screen agent's files live at `/user/apps/<appId>/`, the painted view
+   * rides `vendoViewStreamId(appId)`, and an escalated plan has to become the
+   * build's first skeleton — all three only line up if the id is the same one the
+   * conductor would go on to use, so the caller owns it.
+   */
+  appId: AppId;
+  /** The person's ask, verbatim — never a paraphrase. */
+  request: string;
+  /** Where a painted view goes. The same additive per-call hook
+   *  `AppsRuntime.create` takes, so a screen and a built app reach the surface on
+   *  one channel. */
+  onView?: (part: VendoViewPart) => void;
+}
+
+/**
+ * Three answers, and no fourth.
+ *
+ * Only `assembled` means the caller is done: the view is on screen and the app's
+ * row is stored. `escalate` is the mid-flight §4.5 hand-off — the plan is already
+ * written and its skeleton is already painted, so the build inherits it — and
+ * `unavailable` is "nothing ran", which is what an unwired or broken assembler
+ * answers. Both fall through to the conductor.
+ */
+export type ScreenOutcome =
+  | { kind: "assembled" }
+  | { kind: "escalate"; why: string }
+  | { kind: "unavailable"; why: string };
+
+export interface ScreenAssembler {
+  assemble(request: ScreenRequest, ctx: RunContext): Promise<ScreenOutcome>;
+}

--- a/packages/harnesses/src/index.ts
+++ b/packages/harnesses/src/index.ts
@@ -28,6 +28,18 @@ export {
   type InstantHarnessOptions,
 } from "./instant.js";
 export {
+  assembleScreen,
+  screenAgent,
+  screenAssembler,
+  ESCALATE_TOOL,
+  SAVE_APP_TOOL,
+  SCREEN_STEPS,
+  type ScreenAssemblerDeps,
+  type ScreenInput,
+  type ScreenResult,
+  type ScreenSurface,
+} from "./screen-agent.js";
+export {
   createDiscoveryRails,
   type DiscoveryOptions,
   type DiscoveryRails,

--- a/packages/harnesses/src/screen-agent.test.ts
+++ b/packages/harnesses/src/screen-agent.test.ts
@@ -1,0 +1,298 @@
+/**
+ * The screen agent (blueprint §4.2) and the escalation seam (§4.5).
+ *
+ * These are SEAM tests, not loop tests: every case writes through the real
+ * `WorkspaceFs` staging + `commit()` path and reads back through the real render
+ * seam (`wrapWorkspaceForRender` → `viewForWrite` → `compileWire` / `compilePlan`
+ * → `skeletonFromPlan`), with no stub on either side. A harness that mocked the
+ * seam would prove only that this file agrees with itself.
+ *
+ * What is deliberately a double: the MODEL (scripted provider chunks, so the loop
+ * is what is measured) and the app half of an `app.vendo` commit
+ * (`AppsRuntime.authored`, which needs a store). The real app half — row, queries,
+ * receipt — is walked end to end through a composed deployment in
+ * `packages/vendo/src/screen-route.e2e.test.ts`.
+ *
+ * DIALECT NOTE: the `.vendo` literals below are the minimum needed to make the
+ * compiler parse something, and the wire dialect is changing under this lane
+ * (pipes → nested calls, explicit aggregate field args, `avg` retires). They use
+ * no expressions and no aggregates, so they should survive — but they are the text
+ * to re-check when the new dialect lands.
+ */
+import {
+  type AppId,
+  type Json,
+  type ToolDescriptor,
+  type VendoViewPart,
+  type WireCompileResult,
+} from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { ESCALATE_TOOL, SAVE_APP_TOOL, SCREEN_STEPS, screenAssembler } from "./screen-agent.js";
+import {
+  boundRegistry,
+  ctx,
+  readTool,
+  scriptedModel,
+  seats,
+  testGuard,
+  testWorkspace,
+  textTurn,
+  toolCallTurn,
+  type ScriptedModel,
+  type TestWorkspace,
+} from "./test-doubles.test-util.js";
+
+const APP = "app_screen" as AppId;
+
+/** A document the compiler renders: one node under the root is the seam's whole
+ *  gate (`renders`), so this is the smallest thing that can legitimately paint. */
+const GOOD_APP = `<App name="Spending">
+  <Stack>
+    <Text value="This month" />
+  </Stack>
+</App>`;
+
+/** Unparseable: `compileWire` is total, so this yields a childless synthetic root
+ *  — which is exactly what the seam refuses to put on screen. */
+const BROKEN_APP = `not a document at all`;
+
+const GOOD_PLAN = `<Plan name="Spending">
+  <Group title="Overview">
+    <Leaf component="Stat" />
+  </Group>
+</Plan>`;
+
+/** A host read tool that DECLARES its result shape, so the brief can carry field
+ *  names the model would otherwise have to call once to learn. */
+const spendSummary: ToolDescriptor = {
+  ...readTool("maple_spend_summary"),
+  title: "Spending summary",
+  outputSchema: {
+    type: "object",
+    // A field name that appears NOWHERE in the shipped skill text — the first
+    // version of this assertion used `total_cents`, which the skill's own example
+    // already contains, so it passed with the shape line deleted.
+    properties: { screen_probe_cents: { type: "integer" }, currency: { type: "string" } },
+  },
+};
+
+/** A MUTATING host tool. Assembly is a read-only job (§4.2, "no mutating host
+ *  tools"), so this must never be on the loadout. */
+const sendMoney: ToolDescriptor = { ...readTool("maple_pay", "destructive"), title: "Send money" };
+
+/** The two assembly verbs that are graded `write` on purpose (design §12's
+ *  mechanical vote fail-closes a noun-ending name). They are the whole reason the
+ *  loadout is a name list unioned with a risk filter rather than a risk filter. */
+const validate: ToolDescriptor = { ...readTool("validate", "write") };
+const searchComponents: ToolDescriptor = { ...readTool("search_components", "write") };
+
+/** `vendo_make` is graded `read`, so a risk filter alone would equip the very
+ *  tool that called this loop. */
+const vendoMake: ToolDescriptor = { ...readTool("vendo_make") };
+
+interface Harness {
+  assemble(request: string): Promise<{ kind: string; why?: string }>;
+  emitted: VendoViewPart[];
+  workspace: TestWorkspace;
+  model: ScriptedModel;
+  invocations: Record<string, number>;
+  authoredCalls: Array<{ appId: AppId; compiled: WireCompileResult }>;
+}
+
+/**
+ * One assembler over a REAL workspace and the REAL render seam. `screenAssembler`
+ * is what `vendo_make` routes into, so driving it is what proves the route rather
+ * than a private helper beside it.
+ */
+function harness(options: {
+  turns: Array<Parameters<typeof scriptedModel>[0][number]>;
+  tools?: ToolDescriptor[];
+  /** Force every commit to answer `conflict`, so nothing lands. */
+  conflict?: boolean;
+  authoredApp?: boolean;
+}): Harness {
+  const guard = testGuard();
+  const descriptors = options.tools ?? [spendSummary, sendMoney, validate, searchComponents, vendoMake];
+  const registry = boundRegistry(
+    Object.fromEntries(descriptors.map((descriptor) => [
+      descriptor.name,
+      { descriptor, execute: (): Json => ({ ok: true }) },
+    ])),
+    guard,
+  );
+  const workspace = testWorkspace();
+  const emitted: VendoViewPart[] = [];
+  const model = scriptedModel(options.turns);
+  const authoredCalls: Array<{ appId: AppId; compiled: WireCompileResult }> = [];
+
+  const assembler = screenAssembler({
+    models: seats(model),
+    tools: registry,
+    workspace: async () => {
+      if (options.conflict === true) workspace.conflictOn = ["*"];
+      return workspace;
+    },
+    render: () => ({
+      facts: () => ({ tools: descriptors.map((descriptor) => descriptor.name), components: ["Stat", "Text"] }),
+      ...(options.authoredApp === false ? {} : {
+        authoredApp: async (input) => {
+          authoredCalls.push(input);
+          return { data: {} };
+        },
+      }),
+    }),
+  });
+
+  return {
+    emitted,
+    workspace,
+    model,
+    invocations: registry.invocations,
+    authoredCalls,
+    assemble: async (request: string) => await assembler.assemble(
+      { appId: APP, request, onView: (part) => emitted.push(part) },
+      ctx(),
+    ),
+  };
+}
+
+const saveApp = (content: string) => toolCallTurn(SAVE_APP_TOOL, { content });
+const escalate = (plan: string, why: string) => toolCallTurn(ESCALATE_TOOL, { plan, why }, "call_esc");
+
+describe("the loadout (§4.2 — assembly tools only)", () => {
+  it("equips the assembly verbs and the host's READ tools, and nothing else", async () => {
+    const screen = harness({ turns: [saveApp(GOOD_APP), textTurn("done")] });
+    await screen.assemble("show me my spending");
+
+    const offered = screen.model.toolNamesPerCall[0] ?? [];
+    expect(offered).toContain("validate");
+    expect(offered).toContain("search_components");
+    expect(offered).toContain("maple_spend_summary");
+    expect(offered).toContain(SAVE_APP_TOOL);
+    expect(offered).toContain(ESCALATE_TOOL);
+    // The two that must never be there: a mutating host tool, and the front door
+    // that called this loop.
+    expect(offered).not.toContain("maple_pay");
+    expect(offered).not.toContain("vendo_make");
+  });
+
+  it("caps the run at SCREEN_STEPS — the cap IS the definition of cheap", () => {
+    // Not a magic number in the test either: the constant is the contract, and a
+    // budget of one is a specialist while twenty is a resident.
+    expect(SCREEN_STEPS).toBe(10);
+  });
+
+  it("carries the host's DECLARED result shape into the brief, not a sampled guess", async () => {
+    const screen = harness({ turns: [saveApp(GOOD_APP), textTurn("done")] });
+    await screen.assemble("show me my spending");
+    const system = screen.model.systemPrompts[0] ?? "";
+    // The field names the model would otherwise have to call the tool once to learn.
+    expect(system).toContain("screen_probe_cents");
+    expect(system).toContain("maple_spend_summary — Spending summary");
+    // And the shipped job description, reused rather than restated.
+    expect(system).toContain("Write early. Write as you go.");
+    // …with its companion syntax manual beside it.
+    expect(system).toContain("<Plan");
+  });
+});
+
+describe("assembly writes through the real path and the seam paints it", () => {
+  it("a saved app.vendo lands in the workspace and emits ONE settled view", async () => {
+    const screen = harness({ turns: [saveApp(GOOD_APP), textTurn("done")] });
+    const result = await screen.assemble("show me my spending");
+
+    expect(result.kind).toBe("assembled");
+    // The real write path: the file is in the workspace, and the commit named it.
+    expect(await screen.workspace.readFile(`/user/apps/${APP}/app.vendo`)).toBe(GOOD_APP);
+    expect(screen.workspace.commits.at(-1)?.changed).toEqual([`/user/apps/${APP}/app.vendo`]);
+    // The real read path: the seam compiled it and emitted the view part.
+    expect(screen.emitted.map((part) => part.appId)).toEqual([APP, APP]);
+    // Skeleton first (the app half runs real queries), then the settled paint.
+    expect(screen.emitted.map((part) => part.payload.streaming)).toEqual([true, false]);
+    // And the app half got the compile the paint was made from — byte-identical
+    // by construction, which is why `authored` takes it rather than recompiling.
+    expect(screen.authoredCalls).toHaveLength(1);
+    expect(screen.authoredCalls[0]?.appId).toBe(APP);
+  });
+
+  it("saves as it goes: two saves are two paints on ONE stream id", async () => {
+    const screen = harness({
+      turns: [saveApp(GOOD_APP), saveApp(GOOD_APP.replace("This month", "Last month")), textTurn("done")],
+    });
+    await screen.assemble("show me my spending");
+    expect(screen.workspace.commits).toHaveLength(2);
+    // Successive views reconcile in place — same app, so the same stream.
+    expect(new Set(screen.emitted.map((part) => part.appId))).toEqual(new Set([APP]));
+  });
+
+  it("a document that does not render paints NOTHING — and the run has nothing to show", async () => {
+    const screen = harness({ turns: [saveApp(BROKEN_APP), textTurn("done")] });
+    const result = await screen.assemble("show me my spending");
+    // The bytes landed (a partial save is legitimate mid-write)…
+    expect(screen.workspace.commits).toHaveLength(1);
+    // …and the seam refused to put them on screen, so no row and no app half.
+    expect(screen.emitted).toHaveLength(0);
+    expect(screen.authoredCalls).toHaveLength(0);
+    // The front door is what turns this into a fall-through: it finds no ROW.
+    expect(result.kind).toBe("assembled");
+  });
+
+  it("a commit that did not land is told to the model, not swallowed", async () => {
+    const screen = harness({ turns: [saveApp(GOOD_APP), textTurn("done")], conflict: true });
+    const result = await screen.assemble("show me my spending");
+    expect(screen.emitted).toHaveLength(0);
+    expect(result.kind).toBe("unavailable");
+  });
+});
+
+describe("the escalation seam (§4.5)", () => {
+  it("writes plan.vendo through the real commit path and the seam paints its skeleton", async () => {
+    const screen = harness({
+      turns: [escalate(GOOD_PLAN, "this needs its own server"), textTurn("handed over")],
+    });
+    const result = await screen.assemble("build me a live trading terminal");
+
+    expect(result).toEqual({ kind: "escalate", why: "this needs its own server" });
+    // Real write path.
+    expect(await screen.workspace.readFile(`/user/apps/${APP}/plan.vendo`)).toBe(GOOD_PLAN);
+    expect(screen.workspace.commits.at(-1)?.changed).toEqual([`/user/apps/${APP}/plan.vendo`]);
+    // Real read path: `compilePlan` → `skeletonFromPlan` → the view. NOTHING here
+    // is stubbed — the plan branch of the seam never calls the app half at all.
+    expect(screen.emitted).toHaveLength(1);
+    expect(screen.emitted[0]?.appId).toBe(APP);
+    // A plan IS the mid-build state, so its skeleton stays streaming until the
+    // builder's own app document lands on the same stream id.
+    expect(screen.emitted[0]?.payload.streaming).toBe(true);
+    expect(screen.authoredCalls).toHaveLength(0);
+  });
+
+  it("escalation wins over a partial paint — 'ready' over a half-built app is the lie §4.5 avoids", async () => {
+    const screen = harness({
+      turns: [saveApp(GOOD_APP), escalate(GOOD_PLAN, "it needs real code"), textTurn("handed over")],
+    });
+    const result = await screen.assemble("build me a trading terminal");
+    expect(result.kind).toBe("escalate");
+  });
+
+  it("has no consent step: one plain sentence and the work proceeds", async () => {
+    const screen = harness({
+      turns: [escalate(GOOD_PLAN, "this needs its own server"), textTurn("handed over")],
+    });
+    await screen.assemble("build me a live trading terminal");
+    // The escalate tool takes a plan and a reason. Nothing else — no confirmation
+    // argument, no question back to the person, no second call to complete it.
+    const offered = screen.model.toolNamesPerCall[0] ?? [];
+    expect(offered).toContain(ESCALATE_TOOL);
+    expect(screen.workspace.commits).toHaveLength(1);
+  });
+});
+
+describe("the guard is the same guard, whichever door", () => {
+  it("every host read goes through the guard-bound registry", async () => {
+    const screen = harness({
+      turns: [toolCallTurn("maple_spend_summary", {}), saveApp(GOOD_APP), textTurn("done")],
+    });
+    await screen.assemble("show me my spending");
+    expect(screen.invocations["maple_spend_summary"]).toBe(1);
+  });
+});

--- a/packages/harnesses/src/screen-agent.ts
+++ b/packages/harnesses/src/screen-agent.ts
@@ -37,7 +37,7 @@ import {
   VENDO_MAKE_TOOL,
   type AppId,
   type Json,
-  type ResolvedModels,
+  type SeatModels,
   type RunContext,
   type ScreenAssembler,
   type ScreenOutcome,
@@ -108,7 +108,7 @@ const NO_INPUT_SCHEMA = { type: "object", properties: {}, additionalProperties: 
  * same four fields out of the pieces it already holds.
  */
 export interface ScreenSurface {
-  readonly models: ResolvedModels<LanguageModel>;
+  readonly models: SeatModels<LanguageModel>;
   readonly tools: TurnTools;
   /** Wrapped by the render seam before it gets here, so `commit()` paints. */
   readonly workspace: WorkspaceFs;
@@ -311,10 +311,18 @@ export async function assembleScreen(
   });
 
   const equipped = Object.keys(tools);
+  // Seats are required only where a harness reads them (contract §4, relaxed) —
+  // and the screen agent thinks with `default`, so a turn without it is the
+  // caller's composition bug, named loudly rather than limped past. Same posture
+  // as `vendo()`, which reads the same seat.
+  const model = surface.models.default;
+  if (model === undefined) {
+    throw new Error("the screen agent thinks with `turn.models.default`, and this turn carries no default seat");
+  }
   let loop: Awaited<ReturnType<typeof startTurn>>;
   try {
     loop = await startTurn({
-      model: surface.models.default,
+      model,
       system: screenBrief(input, listings),
       messages: [{ id: `screen_${input.appId}`, role: "user", parts: [{ type: "text", text: input.request }] }],
       tools,
@@ -414,7 +422,7 @@ const sayFor = (result: ScreenResult): string => {
 
 export interface ScreenAssemblerDeps {
   /** The seats, as `Turn.models` carries them. */
-  models: ResolvedModels<LanguageModel>;
+  models: SeatModels<LanguageModel>;
   /** The GUARD-BOUND registry (`VendoGuard.bind(hostTools)`) — the same choke
    *  point every harness's calls pass through. */
   tools: ToolRegistry;

--- a/packages/harnesses/src/screen-agent.ts
+++ b/packages/harnesses/src/screen-agent.ts
@@ -1,0 +1,521 @@
+/**
+ * The screen agent — UI-generation blueprint §4.2 and §4.5.
+ *
+ * The same `startTurn` loop `vendo()` and `instant()` drive, with a SMALL loadout
+ * and a tight step budget: assembly tools only, the catalog and the host's own
+ * declared result shapes in the brief, its own file hands, and one `escalate`
+ * tool. It is the cheap first pass in front of the conductor — "every request
+ * starts in the screen agent" (§1 point 2) — and nothing about it is new
+ * machinery:
+ *
+ * - **The write path is `turn.workspace`.** The `claudeCode()` harness already
+ *   builds apps this way: the model writes `plan.vendo` / `app.vendo` with its own
+ *   hands and the runtime's commit is what makes it real
+ *   (`claude-code/index.ts:338`, `skills/building-apps.ts:68`). This agent has no
+ *   disk and no shell, so the two files it may write are two tools over the same
+ *   `WorkspaceFs`. There is no third writer.
+ * - **The paint path is the render seam.** `wrapWorkspaceForRender` intercepts
+ *   `commit()`, compiles, and emits `data-vendo-view`. This file never emits a
+ *   view and never compiles anything — that is exactly why a screen it assembles
+ *   passes the same floor a `claudeCode()` app does.
+ * - **`vendo_make` is withheld, not merely unused.** The screen agent IS what
+ *   `vendo_make` calls, so leaving it callable is a loop. The `Harness` door
+ *   withholds it at `toolSurface` (the runtime answers a withheld name with the
+ *   same `not-found` a typo gets); the assembler door never projects it. Both
+ *   matter, because `isAlwaysActive` in the loadout is `name.startsWith("vendo_")`
+ *   — a `vendo_`-prefixed tool cannot be gated by `activeTools` at all.
+ * - **The job description is the shipped skill.** `buildingAppsSkill` plus its
+ *   `references/format.md` are the same text `claudeCode()` reads. This file adds
+ *   one short block that corrects the ENVIRONMENT (no disk, no delegation, two
+ *   files, one door out) rather than restating the job — a third prompt is the
+ *   thing §0 forbids.
+ *
+ * Screens run UNSANDBOXED, by §6.5: a description is data, its props are
+ * schema-validated, and the kit treats them as inert. There is no box here.
+ */
+import {
+  VENDO_MAKE_TOOL,
+  type AppId,
+  type Json,
+  type ResolvedModels,
+  type RunContext,
+  type ScreenAssembler,
+  type ScreenOutcome,
+  type ScreenRequest,
+  type ToolListing,
+  type ToolRegistry,
+  type TurnTools,
+  type WorkspaceFs,
+  type Harness,
+  type Turn,
+  modelToolDescription,
+} from "@vendoai/core";
+import { startTurn, wireErrorMessage } from "@vendoai/agent/internal";
+import { buildingAppsSkill } from "@vendoai/apps";
+import { jsonSchema, tool, type LanguageModel, type ToolSet } from "ai";
+import { z } from "zod";
+import { defineHarness } from "./define.js";
+import { wrapWorkspaceForRender, type RenderSeamOptions } from "./render-seam.js";
+
+/**
+ * The whole budget for assembling one screen.
+ *
+ * Sized off the work, not off a round number: learn a shape or search the
+ * catalog (1–2), save the app (1–3, because saving as you go is what makes it
+ * grow on screen), `validate` and fix what it reports (2–3), and one step to
+ * speak. `instant()`'s `ACT_STEPS = 2` is a specialist that must not think;
+ * `DEFAULT_MAX_STEPS = 20` is a resident that may. A screen is neither, and the
+ * cap is the definition of "cheap": an ask that needs more than this is an ask
+ * for a BUILD, and `escalate` is the honest exit rather than a bigger number.
+ */
+export const SCREEN_STEPS = 10;
+
+/** The one door out of assembly (§4.5). Never `vendo_`-prefixed: the loadout's
+ *  `isAlwaysActive` would make it un-gateable, and this tool is the screen
+ *  agent's own, not a product capability anybody else may reach. */
+export const ESCALATE_TOOL = "escalate";
+
+/** The file hands. Two files, so two tools and no path argument — a screen agent
+ *  has exactly one app directory, and a tool that takes a path is a tool that can
+ *  write outside it. */
+export const SAVE_APP_TOOL = "save_app";
+
+/**
+ * The assembly verbs, by NAME rather than by risk.
+ *
+ * `validate` and `search_components` are graded `write` on purpose — design §12's
+ * mechanical vote fail-closes a name ending in a noun (`vendo-verbs.ts:41-48`) —
+ * so a `risk === "read"` filter would drop the two tools the whole loop is built
+ * around. Host read tools come in by risk below; these come in by name.
+ */
+const ASSEMBLY_TOOLS: readonly string[] = [
+  "search_components",
+  "validate",
+  "vendo_apps_data_list",
+  "vendo_apps_open",
+  "ask_user",
+];
+
+/** A tool with no declared input still needs a schema the provider will accept. */
+const NO_INPUT_SCHEMA = { type: "object", properties: {}, additionalProperties: false };
+
+/**
+ * What the lean loop needs, and nothing else.
+ *
+ * A `Turn` satisfies this by construction — structurally, with no adapter and no
+ * wrapper — which is what lets the `Harness` door and the `vendo_make` door share
+ * ONE loop instead of growing a second copy of it. Composition's door builds the
+ * same four fields out of the pieces it already holds.
+ */
+export interface ScreenSurface {
+  readonly models: ResolvedModels<LanguageModel>;
+  readonly tools: TurnTools;
+  /** Wrapped by the render seam before it gets here, so `commit()` paints. */
+  readonly workspace: WorkspaceFs;
+  readonly signal: AbortSignal;
+}
+
+export interface ScreenInput {
+  /** The app whose files this run writes. Minted by the caller so the file path,
+   *  the view's stream id and any receipt all name the same app. */
+  appId: AppId;
+  /** The person's ask, verbatim. */
+  request: string;
+  /** The deployment's assembled prompt, when there is one — prepended, so the
+   *  host's voice and the guard's directions are not lost to the job description. */
+  system?: string;
+}
+
+/** What one assembly run answers. `ScreenOutcome` plus the title an assembled
+ *  screen named itself, which the front door turns into a receipt. */
+export type ScreenResult = ScreenOutcome & { title?: string };
+
+const APP_FILE = "app.vendo";
+const PLAN_FILE = "plan.vendo";
+
+/** §3.1's frozen layout, personal mount. A NEW app is always `/user/**`: a fresh
+ *  `/orgs/<org>/apps/<id>/` path has no row to grant on, so the workspace façade
+ *  refuses the commit and the file never lands (see `AppsRuntime.authored`). */
+const appDirectory = (appId: AppId): string => `/user/apps/${appId}`;
+
+/** The app's own name, off the document it just wrote. Presentation only — the
+ *  receipt's `title` — so a file that has not named itself yet is simply absent
+ *  rather than a reason to fail. */
+const nameOf = (content: string): string | undefined => {
+  const match = /<App\b[^>]*\bname="([^"]+)"/.exec(content);
+  return match?.[1]?.trim() || undefined;
+};
+
+/**
+ * The host's surface, as the model reads it before writing a single binding.
+ *
+ * `ToolListing.outputSchema` is the host's OWN declared result shape, captured by
+ * extraction and threaded onto the listing precisely so "the model reads field
+ * names off the listing instead of calling a query once to learn them"
+ * (`turn-tools.ts:236-253`). That is the catalog half AND the shape half for
+ * every tool that declares one; for the rest the skill's own rule applies — call
+ * it once. No sampler is written here: the create-time probe
+ * (`AppsRuntime.generationToolContext`) is the conductor's and stays there.
+ */
+function toolBrief(listings: readonly ToolListing[]): string {
+  if (listings.length === 0) return "This product has no tools you can read data from.";
+  return listings
+    .map((listing) => {
+      const shape = listing.outputSchema === undefined
+        ? ""
+        : `\n  returns: ${JSON.stringify(listing.outputSchema)}`;
+      const input = listing.inputSchema === undefined
+        ? ""
+        : `\n  input: ${JSON.stringify(listing.inputSchema)}`;
+      return `- ${listing.name} — ${modelToolDescription(listing)}${input}${shape}`;
+    })
+    .join("\n");
+}
+
+/**
+ * The environment correction, and only that.
+ *
+ * The shipped skill is written for a reader with a machine: a `Task` tool, a
+ * `host/components/` directory, a `references/format.md` on disk, "edit the text
+ * in place". None of those exist here. So these lines say what is different and
+ * the skill says what the job is — which is the difference between deriving a
+ * brief and forking one.
+ */
+const environmentNote = (appId: AppId, listings: readonly ToolListing[]): string => `# In this loop
+
+You have no machine: no shell, no \`Task\`, no files on disk. Everything the skill
+above tells you to read is already below, and everything it tells you to write goes
+through two tools.
+
+- **\`${SAVE_APP_TOOL}\`** saves this app's whole document. The app is
+  \`${appId}\`; you never name a path. Every save that parses repaints the person's
+  screen, so save as you go — a save is cheap and silence is not. There is no
+  edit-in-place tool: save the full document each time.
+- **\`validate\`** is the floor. Call it on what you saved, fix what it names, save
+  again. You are not done until it comes back clean.
+- **\`${ESCALATE_TOOL}\`** is the one door out. Assembling a document out of this
+  product's components is all you can do; anything that needs real code, its own
+  server, a file the person uploads, or a surface these components cannot express
+  goes through it. Write the plan when you escalate — that plan becomes the first
+  thing the person sees while the builder works, so it is not a formality.
+- \`${SCREEN_STEPS}\` steps is the whole budget. Escalate rather than run out of it.
+
+Never look for a tool that builds the app for you. There isn't one, and that is
+deliberate.
+
+## This product's tools, with the shapes they return
+
+${toolBrief(listings)}`;
+
+/** The full brief: the deployment's own prompt, the shipped job description, the
+ *  shipped syntax manual, then what is different here. */
+function screenBrief(input: ScreenInput, listings: readonly ToolListing[]): string {
+  return [
+    input.system,
+    buildingAppsSkill.body,
+    buildingAppsSkill.files?.[`references/${"format.md"}`],
+    environmentNote(input.appId, listings),
+  ]
+    .filter((section): section is string => section !== undefined && section.trim().length > 0)
+    .join("\n\n---\n\n");
+}
+
+/**
+ * ONE assembly run, over any surface a `Turn` satisfies.
+ *
+ * Every host effect goes through `surface.tools.call()` and every file write
+ * through `surface.workspace`, so the guard, the audit row, the approval card and
+ * the paint seam are not this function's business and cannot be forgotten.
+ */
+export async function assembleScreen(
+  surface: ScreenSurface,
+  input: ScreenInput,
+): Promise<ScreenResult> {
+  if (surface.signal.aborted) return { kind: "unavailable", why: "the caller hung up" };
+
+  const directory = appDirectory(input.appId);
+  const listings = await surface.tools.list().catch(() => [] as ToolListing[]);
+
+  /**
+   * Write one hot-path file and land it.
+   *
+   * The commit IS the store write and the paint (§1.6). Whether it painted is the
+   * seam's own verdict, reached inside `commit()` and reported to the seam's
+   * `emit` — which belongs to whoever wrapped this workspace, not to us. So this
+   * reports what it can actually know: did the commit land. `validate` is what
+   * tells the model whether what landed is any good — which is this loop's review
+   * floor by design, exactly as `AppsRuntime.authored` says — and the front door
+   * checks the app's ROW before it promises the person a screen.
+   */
+  const save = async (file: string, content: string): Promise<boolean> => {
+    await surface.workspace.writeFile(`${directory}/${file}`, content);
+    const result = await surface.workspace.commit({ message: `${file} (${input.appId})` });
+    return result.status === "ok";
+  };
+
+  let escalated: string | undefined;
+  let title: string | undefined;
+  /** Did an `app.vendo` save ever reach the store? */
+  let assembled = false;
+
+  const tools: ToolSet = {};
+  for (const listing of listings) {
+    // The small loadout: the assembly verbs by name, plus the host's read tools
+    // so a query's real values can be learned when a tool declares no shape.
+    // `vendo_make` is excluded by name — it is what called this loop — and a
+    // mutating host tool is not an assembly tool.
+    if (!ASSEMBLY_TOOLS.includes(listing.name) && listing.risk !== "read") continue;
+    if (listing.name === VENDO_MAKE_TOOL) continue;
+    tools[listing.name] = tool({
+      description: modelToolDescription(listing),
+      inputSchema: jsonSchema((listing.inputSchema ?? NO_INPUT_SCHEMA) as Parameters<typeof jsonSchema>[0]),
+      execute: async (args: unknown) => surface.tools.call(listing.name, args as Json),
+    });
+  }
+
+  tools[SAVE_APP_TOOL] = tool({
+    description:
+      "Save this app's whole document. The person's screen repaints on every save that parses, so save "
+      + "as you go rather than once at the end. Returns whether the save landed and whether it painted.",
+    inputSchema: z.object({
+      content: z.string().min(1).describe("The complete app document, in the .vendo format."),
+    }),
+    execute: async ({ content }) => {
+      const landed = await save(APP_FILE, content);
+      if (!landed) {
+        return { saved: false, note: "The save did not land — someone else changed this app. Save again." };
+      }
+      assembled = true;
+      title = nameOf(content) ?? title;
+      return { saved: true, note: "Run validate on it now." };
+    },
+  });
+
+  tools[ESCALATE_TOOL] = tool({
+    description:
+      "Hand this ask to the builder, which has real code, a real machine and no step budget. Use it when "
+      + "assembling a document out of this product's components genuinely cannot serve the ask. Write the "
+      + "plan: it becomes the skeleton the person watches while the builder fills it in. This ends your turn.",
+    inputSchema: z.object({
+      plan: z.string().min(1).describe("The plan document, in the .vendo plan format."),
+      why: z.string().min(1).describe("One plain sentence: what assembly cannot do here."),
+    }),
+    execute: async ({ plan, why }) => {
+      // §4.5: no consent step and no ceremony. The plan lands, its skeleton
+      // paints in seconds, and the work proceeds — so the only thing this
+      // returns is the fact that it happened.
+      const landed = await save(PLAN_FILE, plan);
+      escalated = why;
+      return { handedOver: true, planSaved: landed };
+    },
+  });
+
+  const equipped = Object.keys(tools);
+  let loop: Awaited<ReturnType<typeof startTurn>>;
+  try {
+    loop = await startTurn({
+      model: surface.models.default,
+      system: screenBrief(input, listings),
+      messages: [{ id: `screen_${input.appId}`, role: "user", parts: [{ type: "text", text: input.request }] }],
+      tools,
+      signal: surface.signal,
+      // The shipped loadout rail. `attach` is a no-op for `instant()`'s reason:
+      // `find_tools` is the RUNTIME's, and a screen agent has a fixed loadout —
+      // there is nothing for it to discover mid-run.
+      toolSearch: { activeToolNames: () => equipped, attach: () => {} },
+      context: { maxSteps: SCREEN_STEPS },
+    });
+  } catch (error) {
+    return { kind: "unavailable", why: wireErrorMessage(error) };
+  }
+
+  try {
+    // The stream MUST be drained or nothing runs. Nothing is teed and nothing is
+    // buffered: this loop produces no prose for a person — the screen is the
+    // answer and the front door speaks the receipt.
+    for await (const part of loop.result.fullStream) {
+      if (part.type === "abort") return { kind: "unavailable", why: "the caller hung up" };
+      if (part.type === "error") {
+        // A model failure after a screen already painted is not a failed screen.
+        if (!assembled && escalated === undefined) {
+          return { kind: "unavailable", why: wireErrorMessage(part.error) };
+        }
+      }
+    }
+  } catch (error) {
+    if (!assembled && escalated === undefined) return { kind: "unavailable", why: wireErrorMessage(error) };
+  }
+
+  // Escalation wins over a partial paint: the builder is finishing this app, and
+  // saying "ready" over a half-assembled document would be the lie §4.5 exists
+  // to avoid. `status: "building"` is the honest receipt, and the front door
+  // stamps it.
+  if (escalated !== undefined) return { kind: "escalate", why: escalated };
+  if (assembled) return { kind: "assembled", ...(title === undefined ? {} : { title }) };
+  return { kind: "unavailable", why: "assembly produced nothing that renders" };
+}
+
+// ─── Door 1: the harness ─────────────────────────────────────────────────────
+
+/**
+ * The screen agent as a `Harness`.
+ *
+ * Its `Turn` is the surface, verbatim: the runtime already wrapped
+ * `turn.workspace` with the render seam, already bound `turn.tools` to the guard,
+ * and already assembled `turn.system`. So this door is the lean loop with nothing
+ * around it — which is the point of `ScreenSurface` being a structural subset of
+ * `Turn`.
+ */
+export function screenAgent(): Harness<never> {
+  return defineHarness<never>({
+    name: "screen",
+    // Uncurated for `claudeCode()`'s reason: this loadout is chosen here, by
+    // name and by risk, so the discovery loadout has nothing to add — and
+    // `vendo_make` is withheld because the screen agent is what it calls.
+    toolSurface: { curated: false, withhold: [VENDO_MAKE_TOOL] },
+    async *run(turn: Turn<never>) {
+      if (turn.signal.aborted) return;
+      const appId = `app_${globalThis.crypto.randomUUID()}` as AppId;
+      yield { type: "status", label: "Putting it together…", phase: "assembling", appId };
+      const result = await assembleScreen(turn, {
+        appId,
+        request: latestAsk(turn),
+        ...(turn.system === undefined ? {} : { system: turn.system }),
+      });
+      // One line, consumer voice — the screen IS the answer, so this is never a
+      // narration of it (§10.1).
+      yield { type: "text", delta: sayFor(result) };
+    },
+  });
+}
+
+/** The person's latest words — what a screen is assembled from. */
+const latestAsk = (turn: Turn<unknown>): string => {
+  for (let index = turn.messages.length - 1; index >= 0; index -= 1) {
+    const message = turn.messages[index];
+    if (message?.role !== "user") continue;
+    const text = message.parts
+      .filter((part): part is { type: "text"; text: string } => part.type === "text")
+      .map((part) => part.text)
+      .join("\n")
+      .trim();
+    if (text.length > 0) return text;
+  }
+  return "";
+};
+
+const sayFor = (result: ScreenResult): string => {
+  if (result.kind === "assembled") return `${result.title ?? "It"} is on your screen.`;
+  if (result.kind === "escalate") return "That one needs building — I've started it, and the outline is on your screen.";
+  return "I couldn't put that together. Try describing it a different way.";
+};
+
+// ─── Door 2: the `vendo_make` route ──────────────────────────────────────────
+
+export interface ScreenAssemblerDeps {
+  /** The seats, as `Turn.models` carries them. */
+  models: ResolvedModels<LanguageModel>;
+  /** The GUARD-BOUND registry (`VendoGuard.bind(hostTools)`) — the same choke
+   *  point every harness's calls pass through. */
+  tools: ToolRegistry;
+  /** This principal's workspace, unwrapped. The assembler wraps it with the
+   *  render seam itself, so composition never has to know that it must. */
+  workspace: (ctx: RunContext) => Promise<WorkspaceFs>;
+  /** The seam's optional halves — plan facts and the app half (`AppsRuntime.authored`). */
+  render?: (ctx: RunContext) => Omit<RenderSeamOptions, "emit">;
+  /** The deployment's assembled prompt for this ctx, when composition has one. */
+  system?: (ctx: RunContext) => Promise<string | undefined>;
+}
+
+/**
+ * The `ScreenAssembler` the front door routes into.
+ *
+ * The layering is why this door exists at all. `@vendoai/apps` depends on `core`
+ * alone, so the `vendo_make` handler cannot reach a harness; and a harness cannot
+ * reach the conductor either (`instant.ts:19-24` — that would be a second,
+ * unguarded door into generation and a pipeline body in the wrong package). So
+ * the two meet on core's `ScreenAssembler` and composition — the one place that
+ * already holds the store, the guard-bound registry, the seats and the seam — is
+ * what fills the slot. Unfilled, `vendo_make` behaves exactly as it did.
+ *
+ * The tool surface here is projected off the registry rather than off a `Turn`,
+ * for the same reason the conductor's `queryRunner` is: this call is INSIDE a
+ * tool the resident already mirrored and audited, so re-mirroring the assembly
+ * loop's own reads would double every call in the transcript. The guard is the
+ * same guard either way — that is the part that cannot be skipped.
+ */
+export function screenAssembler(deps: ScreenAssemblerDeps): ScreenAssembler {
+  return {
+    async assemble(request: ScreenRequest, ctx: RunContext): Promise<ScreenOutcome> {
+      const base = await deps.workspace(ctx);
+      const workspace = wrapWorkspaceForRender(base, {
+        ...deps.render?.(ctx),
+        ...(ctx.turnId === undefined ? {} : { turnId: ctx.turnId }),
+        emit: (_streamId, part) => request.onView?.(part),
+      });
+      const system = await deps.system?.(ctx);
+      const result = await assembleScreen(
+        {
+          models: deps.models,
+          tools: registryTools(deps.tools, ctx),
+          workspace,
+          // The front door owns cancellation: `vendo_make` resolves or it does
+          // not, and the tool bridge is what a caller aborts.
+          signal: new AbortController().signal,
+        },
+        {
+          appId: request.appId,
+          request: request.request,
+          ...(system === undefined ? {} : { system }),
+        },
+      );
+      return result.kind === "assembled" ? { kind: "assembled" } : result;
+    },
+  };
+}
+
+/**
+ * `TurnTools` over the guard-bound registry.
+ *
+ * Three statuses out of seven, exactly as the harness contract's `ToolResult`
+ * defines them (§1.1): `blocked` and `connect-required` are the guard saying no,
+ * and a parked approval is not something an assembly loop can wait for — so it
+ * reads as denied with the reason, which is what the model needs in order to
+ * write around it rather than bind a value it never got.
+ */
+function registryTools(registry: ToolRegistry, ctx: RunContext): TurnTools {
+  return {
+    async list(): Promise<ToolListing[]> {
+      const descriptors = await registry.descriptors(ctx).catch(() => []);
+      return descriptors.map((descriptor) => ({
+        name: descriptor.name,
+        title: descriptor.title ?? descriptor.name,
+        description: descriptor.description,
+        risk: descriptor.risk,
+        ...(descriptor.inputSchema === undefined ? {} : { inputSchema: descriptor.inputSchema }),
+        ...(descriptor.outputSchema === undefined ? {} : { outputSchema: descriptor.outputSchema }),
+      }));
+    },
+    async call(name, args) {
+      const outcome = await registry.execute(
+        { id: `call_${globalThis.crypto.randomUUID()}`, tool: name, args },
+        ctx,
+      );
+      if (outcome.status === "ok") return { status: "ok", output: outcome.output };
+      if (outcome.status === "error") return { status: "error", error: outcome.error };
+      if (outcome.status === "blocked") return { status: "denied", reason: outcome.reason };
+      if (outcome.status === "connect-required") {
+        return {
+          status: "denied",
+          reason: `${outcome.connect.toolkit} is not connected, so this cannot be read.`,
+          needs: { kind: "connect", toolkit: outcome.connect.toolkit },
+        };
+      }
+      return {
+        status: "denied",
+        reason: "This one needs the person's approval, which cannot be asked for here.",
+        needs: { kind: "approval", approvalId: outcome.approvalId },
+      };
+    },
+  };
+}

--- a/packages/harnesses/src/screen-agent.ts
+++ b/packages/harnesses/src/screen-agent.ts
@@ -276,7 +276,7 @@ export async function assembleScreen(
   tools[SAVE_APP_TOOL] = tool({
     description:
       "Save this app's whole document. The person's screen repaints on every save that parses, so save "
-      + "as you go rather than once at the end. Returns whether the save landed and whether it painted.",
+      + "as you go rather than once at the end. Returns whether the save landed.",
     inputSchema: z.object({
       content: z.string().min(1).describe("The complete app document, in the .vendo format."),
     }),

--- a/packages/harnesses/src/test-doubles.test-util.ts
+++ b/packages/harnesses/src/test-doubles.test-util.ts
@@ -297,6 +297,9 @@ export type ScriptedModel = LanguageModel & {
   /** What each call actually SENT — the only place a suite can prove what the
    *  loop's history assembly did or did not include. */
   prompts: unknown[];
+  /** The system message of each call, so a suite can assert on the BRIEF a loop
+   *  assembled without reaching into the loop to get it. */
+  systemPrompts: string[];
   calls: number;
 };
 
@@ -306,10 +309,13 @@ export function scriptedModel(turns: StreamPart[][]): ScriptedModel {
   const remaining = turns.map((turn) => [...turn]);
   const toolNamesPerCall: string[][] = [];
   const prompts: unknown[] = [];
+  const systemPrompts: string[] = [];
   const model = new MockLanguageModelV3({
     doStream: async (request) => {
       toolNamesPerCall.push((request.tools ?? []).map((tool) => tool.name));
       prompts.push(structuredClone(request.prompt));
+      const system = request.prompt.find((message) => message.role === "system");
+      systemPrompts.push(typeof system?.content === "string" ? system.content : "");
       (model as ScriptedModel).calls += 1;
       const chunks = remaining.shift();
       if (chunks === undefined) throw new Error("scripted model exhausted");
@@ -318,6 +324,7 @@ export function scriptedModel(turns: StreamPart[][]): ScriptedModel {
   }) as unknown as ScriptedModel;
   model.toolNamesPerCall = toolNamesPerCall;
   model.prompts = prompts;
+  model.systemPrompts = systemPrompts;
   model.calls = 0;
   return model;
 }

--- a/packages/vendo/src/cli/quickstart-config-surface.docs-check.ts
+++ b/packages/vendo/src/cli/quickstart-config-surface.docs-check.ts
@@ -92,6 +92,7 @@ export interface CreateVendoConfig {
   approvals?: { parkedCallTtlMs?: number };
   apps?: {
     experimentalMachines?: boolean;
+    experimentalScreenAgent?: boolean; // route vendo_make through the cheap screen agent first
     review?: {                // review-kind remixes: who may review (queue/reject/approve)
       reviewer?(ctx: RunContext): boolean | Promise<boolean>;
     };

--- a/packages/vendo/src/screen-route.e2e.test.ts
+++ b/packages/vendo/src/screen-route.e2e.test.ts
@@ -1,0 +1,241 @@
+/**
+ * PROOF BAR 1 — "agent → checks → slot proven end to end" (blueprint §15).
+ *
+ * `vendo_make` is routed through the screen agent instead of straight to the
+ * conductor, walked through a REAL composed deployment: real store, real guard,
+ * real apps pack, the real render seam, the real `AppsRuntime.authored` app half.
+ * Nothing on either side of the seam is stubbed except the MODEL, which is
+ * scripted so the routing — not a provider's mood — is what this measures.
+ *
+ * The two things a stub could hide, and why they are asserted here rather than in
+ * `packages/harnesses`:
+ *
+ * 1. **The row.** `authored` is what makes a written file an APP: without it a
+ *    screen is a picture of one — absent from the person's list, masked as
+ *    `not-found` by `vendo_apps_open`. Only a real store can prove it landed.
+ * 2. **The fall-through.** The conductor must still answer when the screen agent
+ *    does not, and "still works" is not something a harness-level test can claim:
+ *    it needs the real front door with the real `create` behind it.
+ *
+ * DIALECT NOTE: the `.vendo` literal below is a name, a Stack and a Text with no
+ * expressions and no aggregates, so the in-flight dialect change (pipes → nested
+ * calls, explicit aggregate field args, `avg` retires) should not touch it. It is
+ * still the text to re-check when that lands.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  VENDO_MAKE_TOOL,
+  makeReceiptSchema,
+  type Principal,
+  type ToolResult,
+} from "@vendoai/core";
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVendo } from "./server.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const principal: Principal = { kind: "user", subject: "user_screen" };
+
+/** A document the compiler renders and the seam paints — the smallest honest one. */
+const SPENDING = `<App name="Spending">
+  <Stack>
+    <Text value="This month" />
+  </Stack>
+</App>`;
+
+const ZERO_USAGE = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+} as const;
+
+type Chunk = Record<string, unknown>;
+
+const call = (toolName: string, input: unknown, toolCallId: string): Chunk[] => [
+  { type: "tool-call", toolCallId, toolName, input: JSON.stringify(input) },
+  { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "tool-calls", raw: undefined } },
+];
+
+const speak = (text: string): Chunk[] => [
+  { type: "text-start", id: "t1" },
+  { type: "text-delta", id: "t1", delta: text },
+  { type: "text-end", id: "t1" },
+  { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
+];
+
+/** A model that replays scripted turns, and records how many times it was asked. */
+function scripted(turns: Chunk[][]): LanguageModel & { calls: number } {
+  const remaining = turns.map((turn) => [...turn]);
+  const model = new MockLanguageModelV3({
+    doStream: async () => {
+      (model as { calls: number }).calls += 1;
+      const chunks = remaining.shift();
+      if (chunks === undefined) throw new Error("scripted model exhausted");
+      return { stream: simulateReadableStream({ chunks: chunks as never }) };
+    },
+  }) as unknown as LanguageModel & { calls: number };
+  model.calls = 0;
+  return model;
+}
+
+async function tempStore(): Promise<VendoStore> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-screen-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.ensureSchema().catch(() => undefined);
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return store;
+}
+
+interface Walked {
+  /** What the calling agent got back from `vendo_make` — words, never UI. */
+  result: ToolResult | undefined;
+  /** Everything that crossed the wire to the surface. */
+  chunks: Array<Record<string, unknown>>;
+  vendo: ReturnType<typeof createVendo>;
+  model: LanguageModel & { calls: number };
+}
+
+/**
+ * One real turn whose harness does exactly what a calling agent does: ask
+ * `vendo_make` for a screen in words, and hand back the receipt.
+ */
+async function walk(options: {
+  turns: Chunk[][];
+  screenAgent: boolean;
+  request?: string;
+}): Promise<Walked> {
+  const store = await tempStore();
+  const model = scripted(options.turns);
+  let result: ToolResult | undefined;
+  const harness = defineHarness({
+    name: "make-probe",
+    async *run(turn) {
+      result = await turn.tools.call(VENDO_MAKE_TOOL, {
+        request: options.request ?? "show me what I spent this month",
+      });
+      yield { type: "text", delta: "ok" };
+    },
+  });
+  const vendo = createVendo({
+    model,
+    principal: async () => principal,
+    store,
+    harness: harness as never,
+    ...(options.screenAgent ? { apps: { experimentalScreenAgent: true } } : {}),
+  } as Parameters<typeof createVendo>[0]);
+  const response = await vendo.handler(new Request("https://host.test/api/vendo/threads", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      threadId: "thr_screen",
+      message: { id: "m1", role: "user", parts: [{ type: "text", text: "show me my spending" }] },
+    }),
+  }));
+  const raw = await response.text();
+  expect(response.status).toBe(200);
+  const chunks = raw
+    .split("\n\n")
+    .filter((block) => block.startsWith("data: ") && !block.includes("[DONE]"))
+    .map((block) => JSON.parse(block.slice("data: ".length)) as Record<string, unknown>);
+  return { result, chunks, vendo, model };
+}
+
+describe("vendo_make routed through the screen agent (blueprint §1 point 2)", () => {
+  it("assembles, checks, lands the row, paints the slot, and hands back words", async () => {
+    const walked = await walk({
+      screenAgent: true,
+      turns: [
+        // The agent writes the document with its own hands…
+        call("save_app", { content: SPENDING }, "c1"),
+        // …runs the review floor on what it saved (the `validate` verb, projected
+        // on the SAME registry as every host tool — no privileged side door)…
+        call("validate", { document: SPENDING }, "c2"),
+        // …and stops.
+        speak("done"),
+      ],
+    });
+
+    // ── the receipt: words, never UI ──────────────────────────────────────────
+    expect(walked.result?.status).toBe("ok");
+    const receipt = makeReceiptSchema.parse((walked.result as { output: unknown }).output);
+    expect(receipt.status).toBe("ready");
+    // The title is the app's own name, read off the ROW rather than off the model.
+    expect(receipt.title).toBe("Spending");
+    expect(receipt.say).toBe("Spending is on your screen.");
+    // §3.1: no tree, no payload, no URL, no component names.
+    const spoken = JSON.stringify(receipt);
+    expect(spoken).not.toContain("<App");
+    expect(spoken).not.toContain("Stack");
+
+    // ── the slot: the compiled description reached the surface ────────────────
+    const views = walked.chunks.filter((chunk) => chunk["type"] === "data-vendo-view");
+    expect(views.length).toBeGreaterThan(0);
+    const painted = views.map((chunk) => chunk["data"] as { appId: string; payload: Record<string, unknown> });
+    expect(new Set(painted.map((view) => view.appId))).toEqual(new Set([receipt.id]));
+    // The last paint SETTLES — while `streaming` is on, the card never reaches a
+    // verdict and stays on "Building your view…".
+    expect(painted.at(-1)?.payload["streaming"]).toBe(false);
+
+    // ── the row: `authored` made a written file into an APP ───────────────────
+    const stored = await walked.vendo.apps.get(receipt.id, { principal, venue: "chat", presence: "present" });
+    expect(stored?.name).toBe("Spending");
+    // And it lists, which is the half that was silently missing before `authored`.
+    const listed = await walked.vendo.apps.list({ principal, venue: "chat", presence: "present" });
+    expect(listed.map((app) => app.id)).toContain(receipt.id);
+
+    // ── and the conductor never ran ───────────────────────────────────────────
+    // Two model calls: the save step and the validate step, plus the closing one.
+    // A conductor create is a plan call plus a fill call per group on top of that,
+    // so a routed request is measurably the cheap path and not both paths.
+    expect(walked.model.calls).toBe(3);
+  }, 60_000);
+
+  it("is OFF by default — an unwired slot leaves vendo_make exactly as it was", async () => {
+    // No `experimentalScreenAgent`, so the assembler is never composed and the one
+    // model call that happens is the conductor's own first call. The scripted model
+    // answers it with prose rather than the tool call the conductor requires, so the
+    // build fails — which is the point: the CONDUCTOR is what ran, unchanged.
+    const walked = await walk({ screenAgent: false, turns: [speak("I am not a plan")] });
+    expect(walked.result?.status).toBe("error");
+    // No screen agent means no `save_app` was ever offered, so nothing was written
+    // and nothing painted.
+    expect(walked.chunks.filter((chunk) => chunk["type"] === "data-vendo-view")).toHaveLength(0);
+  }, 60_000);
+
+  it("falls through to the conductor when assembly produces nothing that renders", async () => {
+    // The screen agent saves bytes the compiler cannot render. The seam paints
+    // nothing and `authored` stores no row, so the front door finds no app and the
+    // conductor takes the ask — the fall-through that makes this seam default-safe.
+    const walked = await walk({
+      screenAgent: true,
+      turns: [
+        call("save_app", { content: "not a document at all" }, "c1"),
+        speak("saved"),
+        // …and then the conductor's own calls, answered with prose it cannot use.
+        speak("I am not a plan either"),
+        speak("nor is this"),
+      ],
+    });
+    // The conductor ran and failed on its own terms — which is exactly what would
+    // have happened with no screen agent composed at all.
+    expect(walked.result?.status).toBe("error");
+    expect(walked.chunks.filter((chunk) => chunk["type"] === "data-vendo-view")).toHaveLength(0);
+    // More calls than the screen agent's own two: the conductor genuinely ran
+    // after it, so the fall-through is real rather than a swallowed failure. Not
+    // an exact count — how many calls the conductor spends before it gives up is
+    // its business, and pinning it here would make this test a tripwire on the
+    // conductor's internals instead of on the seam.
+    expect(walked.model.calls).toBeGreaterThan(2);
+  }, 60_000);
+});

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -17,7 +17,7 @@ import { assembleSystemPrompt } from "@vendoai/agent/internal";
 // Architecture §3 — the harness runtime and the default thinker. `vendo()` is
 // composed HERE (not by the host) when `harness:` is unset; its prompt and
 // descriptor catalog reach it on the turn, never at construction.
-import { assertHarnessComposable, reportHire, vendo } from "@vendoai/harnesses";
+import { assertHarnessComposable, reportHire, screenAssembler, vendo } from "@vendoai/harnesses";
 // …and re-exported, because §10's one-line opt-in is `harness: vendo()`. Without
 // this, naming the default harness costs a SECOND direct dependency on
 // `@vendoai/harnesses` — a documented one-liner that does not compile from the
@@ -638,6 +638,16 @@ export interface CreateVendoConfig {
       "cannot" in the plan rather than as a flag. */
   apps?: {
     experimentalMachines?: boolean;
+    /** UI-generation blueprint §4.2 — route every `vendo_make` request through
+        the cheap screen agent before the conductor: a small assembly loadout, the
+        host's declared result shapes, a tight step budget, and one `escalate`
+        door that hands the ask on with its plan already painted as the first
+        skeleton. OFF until the six-type proof matrix is walked, because it
+        changes which engine answers every screen ask; the conductor is untouched
+        and is what an escalation, an unserved ask, or an unavailable assembler
+        falls through to. Host config only, like the two flags above — choosing
+        the engine that answers your users is not an env-var decision. */
+    experimentalScreenAgent?: boolean;
     /** Remix review (round-2 hardening 2026-08-02) — the host's reviewer
         assertion for the review-kind remix lifecycle: whether THIS caller may
         read the full review queue, reject, and approve review-kind remixes.
@@ -2218,6 +2228,14 @@ export function createVendo(config: CreateVendoConfig): Vendo {
   // which run after createVendo returns, so the closure reference is safe —
   // same pattern as the connections loadout seed).
   let automationsForArming: AutomationsEngine | undefined;
+  // The screen agent's workspace door, filled with the harness turns composed
+  // BELOW — the same late binding as `automationsForArming`, and safe for the
+  // same reason: assembly only happens inside a request, which runs after
+  // createVendo returns. It is the PUBLIC door (`harnessTurns.workspace`) rather
+  // than a second `workspaceStore` call, so a screen agent writes through the
+  // exact mount set — `/host` projection and asserted orgs included — that a
+  // harness turn's own hands write through.
+  let harnessTurnsForScreens: HarnessTurns | undefined;
   // Build contract §9.3 — ONE `can()` over the host's store, held by the apps
   // runtime and the automations engine alike, so one rule answers both sides.
   const access = appAccess(store);
@@ -2292,6 +2310,37 @@ export function createVendo(config: CreateVendoConfig): Vendo {
     ...(configuredBaseUrl === undefined ? {} : {
       servedProxyPath: (appId: AppId) =>
         `${configuredBaseUrl.replace(/\/+$/, "")}${BASE_PATH}/apps/${encodeURIComponent(appId)}/serve/`,
+    }),
+    // THE SEAM (blueprint §1 point 2) — the screen agent in front of the
+    // conductor. Filled HERE and nowhere else: the agent is a lean loop in
+    // @vendoai/harnesses, the front door is in @vendoai/apps, and apps depends on
+    // core alone — so composition, the one place that already holds the seats, the
+    // guard-bound registry, the store and the seam, is what joins them.
+    ...(config.apps?.experimentalScreenAgent !== true ? {} : {
+      screen: screenAssembler({
+        // The SAME seats every other thinker runs on.
+        models: inference.seats,
+        // The SAME guard-bound registry. There is no second choke point.
+        tools: boundTools,
+        workspace: async (screenCtx) => {
+          if (harnessTurnsForScreens === undefined) {
+            throw new VendoError("not-implemented", "the harness turn door is not composed yet");
+          }
+          return await harnessTurnsForScreens.workspace(
+            screenCtx.principal,
+            screenCtx.memberships === undefined ? undefined : { memberships: screenCtx.memberships },
+          );
+        },
+        // §1.6's app half, the SAME one the harness turns pass the seam below:
+        // the row that makes a written file an app, and the queries that put real
+        // data behind its bindings.
+        render: (screenCtx) => ({ authoredApp: (input) => apps.authored(input, screenCtx) }),
+        // `system` is deliberately unset. The screen agent's brief is the shipped
+        // `building-apps` skill plus the host's own tool shapes, and the
+        // deployment prompt's job — voice, venue gate, guard directions, the
+        // discovery rail — belongs to the thinker talking to the PERSON. This loop
+        // talks to nobody: the front door speaks its one-line receipt.
+      }),
     }),
     // execution-v2 Wave 9 — the layer-2 experimental opt-in, host-config only
     // (never an env var: enabling machine-backed execution is a deliberate
@@ -2683,7 +2732,7 @@ export function createVendo(config: CreateVendoConfig): Vendo {
     ?? configuredBaseUrl
     ?? (harness.requires?.sandbox === true ? undefined : learnedLoopbackOrigin);
 
-  const harnessTurns = createHarnessTurns({
+  const harnessTurns: HarnessTurns = createHarnessTurns({
     harness: harness as Harness<never>,
     // The composed sandbox adapter, threaded through so a spawned harness's
     // machine slot is filled by the SAME adapter the boot gate approved.
@@ -2770,6 +2819,8 @@ export function createVendo(config: CreateVendoConfig): Vendo {
       ? {}
       : { scripted: createTourScript({ tours: config.tours, apps }) }),
   });
+  // The screen agent's workspace door is now real (see the declaration above).
+  harnessTurnsForScreens = harnessTurns;
   /**
    * THE harness door — one object, served two ways.
    *


### PR DESCRIPTION
## The screen agent — the lean loop with a small loadout, and the seam that routes to it

Blueprint §4.2, §4.3, §4.5, and §1 point 2: *"The seam routes, not the caller. No agent chooses 'quick screen' vs 'real build'. Every request starts in the cheap screen agent."*

### What this is NOT

It is not new machinery. The escalation-free path already shipped as `claudeCode()`: the model writes `plan.vendo` / `app.vendo` with its own hands, the runtime's `commit()` makes it real, the render seam compiles and emits `data-vendo-view`, and `AppsRuntime.authored` upserts with no model and no conductor. This PR adds a **lean in-process harness that drives that same seam** with a small loadout and a tight step budget. No second paint path, no second write path, no second door.

### The routing is default-safe — the conductor still answers

`vendo_make` now starts in the cheap loop and **falls through** to the conductor. This was the riskiest item in the brief, so the guarantee is explicit and tested: `12ebe7092` — *"the routed front door proves the seam, **and proves the conductor still answers**"*. The seam is inserted, never amputated. It is opt-in behind a flag (`e05ef929f` documents the flag and the widened config surface), following the repo's adapter posture where an explicitly-passed thing always wins and there are no hidden key-conditional branches.

### Escalation announces itself explicitly — A2, key on this, not on behaviour

Per the cross-track ruling: escalation is **the escalate tool's act**, not something to infer. Both halves are in the contract:

```ts
export type ScreenOutcome =
  | { kind: "assembled" }
  | { kind: "escalate"; why: string }
  | { kind: "unavailable"; why: string };
```

- `plan.vendo` is committed through the **real** commit path (`surface.workspace.commit(...)`), which is what paints the skeleton.
- The run resolves to `{ kind: "escalate", why }` — a discriminated union member.
- **Escalation wins over a partial paint**, deliberately: saying "ready" over a half-assembled document is the exact lie §4.5 exists to avoid, so a run that escalated can never surface as `assembled`. `status: "building"` is the honest receipt and the front door stamps it.

**No new field is needed.** A false positive is only possible by pattern-matching on behaviour; `outcome.kind === "escalate"` is total and unambiguous. Consuming that is the fix.

### `ask_user` is NOT a phantom tool — please do not remove it

A cross-track finding reported that `ask_user` does not exist and that the loadout naming it "silently matches nothing". **That is incorrect, and acting on it would delete a real capability.** Verified in this branch:

| | |
|---|---|
| name constant | `packages/core/src/tools.ts:133` — `export const ASK_USER_TOOL = "ask_user"` |
| implementation | `packages/agent/src/ask-user.ts` (4.7 KB), descriptor at `:37` `name: ASK_USER_TOOL` |
| registry | `askUserRegistry()`, exported from `@vendoai/agent` |
| **wired into the composed surface** | `packages/vendo/src/server.ts:2427` — `actions.add(askUserRegistry())` |
| asserted present over MCP | `packages/vendo/src/mcp-door-outside-agent.e2e.test.ts:72` |

The likely cause of the miss: the *constant* lives in `packages/core`, so a grep confined to `packages/agent`/`packages/apps` for the literal finds only tests. This screen agent's loadout entry (`screen-agent.ts:96`) is correct and stays. **The `building-apps` skill line is also accurate** — the edit to it in #801 should be reconsidered before merging, or it will remove true teaching.

### The loadout

Assembly tools only, all read-risk, all already shipped: `search_components`, `validate`, `vendo_apps_data_list`, `vendo_apps_open`, `ask_user`, plus `turn.workspace` for the two hot files, plus `escalate`. **`vendo_make` is withheld** via `toolSurface` — the screen agent is what `vendo_make` calls, so leaving it callable would be a loop. Catalog and live shapes come from the existing `outputSchema` on the tool listing and the existing sampled shape cards; no second sampler was written.

### Consolidation (§0)

No third prompt — the brief derives from the shipped `building-apps` skill and format reference rather than forking them. No second shape sampler. No second paint path. The routing branch replaces a coin-flip with a declared seam and a declared fallthrough. `a23d6f4ac` is a small honesty fix worth noting: **the save tool now reports only what it can actually know** — whether the commit landed — because whether it *painted* is the seam's own verdict, reached inside `commit()`, and claiming it here would have been a second source of truth.

### The Cloudflare Worker deploy: a named fast-follow, not attempted

`vendo-web` is not present in this repository, so the Worker wrapper was correctly not built. What matters is that it remains **possible**, and that is verified:

```
portability-gate: ok — no raw hazard patterns in package sources
portability-gate: ok — fixture worker constructed createVendo at module scope and served /status 200 under workerd
portability-gate: all legs green
```

The screen agent lives in `packages/harnesses`, which Leg A3 bundles standalone for a Worker target — so it is provably Worker-safe today. **No capacity claim is made:** per §16 risk 2, per-isolate memory is unmeasured and the honest word is *unknown*.

### Verification

`@vendoai/{core,apps,harnesses,vendo}` typecheck clean; portability gate all legs green. Seam tests run through the real paint path (`3e4a25432`), and the route test proves both arms (`12ebe7092`).

Rebase note: `0d99cfbc9` adapts to main's seat rename (`ResolvedModels` → `SeatModels`) and the relaxed contract making seats optional — a missing `default` seat is now named loudly rather than passed as `undefined`, the same posture `vendo()` takes for the same seat.

**Dialect coupling:** any literal wire text in these tests speaks the pre-migration grammar. It is minimal, and #808 (the dialect) is the change that would require touching it — flagged for the batch gate rather than guessed at here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `vendo_make` through a lightweight screen agent that assembles and paints a first screen fast, then escalates to the conductor when needed. Adds a `core` seam and a server-side slot to keep routing explicit and default-safe, and makes the screen and build share one `appId`.

- **New Features**
  - `@vendoai/core`: adds `ScreenAssembler`, `ScreenRequest`, `ScreenOutcome` for the screen-assembly seam.
  - `@vendoai/harnesses`: introduces `screenAgent()`, `assembleScreen()`, `screenAssembler()` with `SCREEN_STEPS = 10`; provides `save_app` and `escalate`; withholds `vendo_make`; brief includes host `ToolListing.outputSchema`; `save_app` reports only whether the commit landed; names a missing `default` seat clearly.
  - `@vendoai/apps`: adds `AppsConfig.screen?: ScreenAssembler`; `vendo_make` routes to it first; mints an `appId` before routing and passes `onView`; `AppsRuntime.create` accepts `appId`; only resolves as assembled if an app row exists, otherwise falls through to the conductor (including on escalate, unavailable, throw, or “assembled” with no row).
  - `@vendoai/vendo`: opt-in via `apps.experimentalScreenAgent`; composition wires the same seats, the guard-bound tool registry, the harness workspace mount, and the render seam (`authoredApp`) to the screen agent; docs mention the flag. Tests (harness, apps, e2e) cover loadout, brief, paint path, shared IDs, and fall-through.

- **Migration**
  - To enable, set `apps.experimentalScreenAgent: true` in `createVendo` config.
  - No breaking changes; behavior is unchanged when the flag is off.

<sup>Written for commit c9c93ed2316ad16b87a7690eba0c8b0a0b3d4d38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

