### PR TITLE
fix(ui): the ⌘K opener races its own re-register (stale closure); + one racy test disambiguated

### DIFF
--- a/packages/ui/src/chrome/vendo-overlay.tsx
+++ b/packages/ui/src/chrome/vendo-overlay.tsx
@@ -433,6 +433,12 @@ export function VendoOverlay({
   const portalRoot = useRef<HTMLDivElement>(null);
   const opener = useRef<HTMLElement | null>(null);
   const wasOpen = useRef(false);
+  // The registry opener effect only re-registers on a later passive flush, so a
+  // ⌘K landing between the hide-commit and that flush reached a closure with a
+  // stale `open` and toggled a closed overlay shut (the dialog never mounted).
+  // The ref always reads the committed value, independent of re-registration.
+  const openRef = useRef(open);
+  openRef.current = open;
 
   const setOpen = useCallback((next: boolean) => {
     if (next && !open && document.activeElement instanceof HTMLElement && document.activeElement !== document.body) {
@@ -506,12 +512,12 @@ export function VendoOverlay({
   useEffect(() => registerOverlayOpener(options => {
     // The one-surface ⌘K path: a toggle request closes an open overlay instead
     // of no-opping; every other affordance strictly opens.
-    if (options?.toggle === true && open) {
+    if (options?.toggle === true && openRef.current) {
       setOpen(false);
       return;
     }
     if (options?.close === true) {
-      if (open) setOpen(false);
+      if (openRef.current) setOpen(false);
       return;
     }
     setOpen(true);
@@ -530,7 +536,7 @@ export function VendoOverlay({
         { scope: prefillScope.current, defer: fresh },
       );
     }
-  }), [setOpen, open]);
+  }), [setOpen]);
 
   // LANE D (spec §2, §3, §4) — what the pill says while the user is elsewhere:
   // the live beat of a run that kept going after they left, the result toast

--- a/packages/ui/test/chrome/transcript-beats.test.tsx
+++ b/packages/ui/test/chrome/transcript-beats.test.tsx
@@ -210,9 +210,14 @@ describe("the transcript's beats", () => {
     ] as unknown as Thread["messages"][number]["parts"]);
     // The card is present and IS the step.
     expect(document.querySelector("[data-vendo-app-embed='app_renewals']")).toBeTruthy();
-    expect(document.querySelector(".fl-beatsummary")?.textContent).toBe("Did 1 thing");
+    const summary = document.querySelector(".fl-beatsummary");
+    expect(summary?.textContent).toBe("Did 1 thing");
     // Reopening the row still shows no beat for the build — not even folded away.
-    fireEvent.click(screen.getByRole("button", { expanded: false }));
+    // Click the summary row we just located: `getByRole("button", { expanded:
+    // false })` is ambiguous the moment the composer's "Connect tools" dock
+    // button (also aria-expanded=false, gated behind the connector-catalog
+    // fetch) has rendered — a genuine before/after-fetch race.
+    fireEvent.click(summary as HTMLElement);
     expect(document.querySelector("[data-vendo-tool='vendo_make']")).toBeNull();
     expect(screen.queryByText(/Make you a screen/)).toBeNull();
   });

--- a/packages/ui/test/chrome/workspace-palette-slot.test.tsx
+++ b/packages/ui/test/chrome/workspace-palette-slot.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useLayoutEffect, useRef, useState } from "react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VendoProvider, createVendoClient, type OpenSurface, type VendoClient } from "../../src/index.js";
 import { VendoOverlay, VendoPage, VendoPalette, VendoSlot } from "../../src/chrome/index.js";
-import { getConversationCommands } from "../../src/chrome/overlay-registry.js";
+import { getConversationCommands, openVendoConversation } from "../../src/chrome/overlay-registry.js";
 import { createWireServer } from "../wire-server.js";
 
 describe("VendoPage, VendoPalette, and VendoSlot exports", () => {
@@ -99,6 +100,58 @@ describe("VendoPage, VendoPalette, and VendoSlot exports", () => {
     fireEvent.keyDown(reopenedComposer, { key: "k", metaKey: true });
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "Vendo assistant" })).toBeNull());
     await waitFor(() => expect(document.activeElement).toBe(opener));
+  });
+
+  // A ⌘K that lands in the window between the overlay's hide-commit and the
+  // registry opener's re-register used to reach a closure holding a STALE `open`
+  // (still true), so the toggle "closed" an already-closed overlay and the
+  // dialog never came back — hit ⌘K right after the surface hides and the
+  // assistant stays dark.
+  //
+  // The window is real in production: the browser can dispatch a keydown after
+  // React commits the hide but before it flushes the (passive) re-register,
+  // which the scheduler defers to a later macrotask. A layout effect is that
+  // window made deterministic — it runs during the SAME commit, after render
+  // (so the opener's `openRef` already reads false) but before any passive
+  // effect (so the opener has not re-registered). `Racer` fires the racing ⌘K
+  // there on the hide transition. With the ref-read guard the toggle reopens;
+  // revert it to the stale `open` read and this goes red every run.
+  function Racer({ open }: { open: boolean }) {
+    const previous = useRef(open);
+    useLayoutEffect(() => {
+      if (previous.current && !open) fireEvent.keyDown(globalThis, { key: "k", metaKey: true });
+      previous.current = open;
+    }, [open]);
+    return null;
+  }
+
+  it("reopens on a ⌘K racing its own hide — no stale-closure toggle swallows it", async () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <VendoProvider client={client}>
+          <button type="button">Palette opener</button>
+          <VendoPalette />
+          <VendoOverlay launcher="none" onOpenChange={setOpen} />
+          <Racer open={open} />
+        </VendoProvider>
+      );
+    }
+    render(<Harness />);
+    await waitFor(() => expect(wire.requests.some(request => request.path === "/apps")).toBe(true));
+    const opener = screen.getByRole("button", { name: "Palette opener" });
+    opener.focus();
+    fireEvent.keyDown(globalThis, { key: "k", metaKey: true });
+    await screen.findByRole("dialog", { name: "Vendo assistant" });
+
+    // Close from a host affordance; the Racer's layout effect fires the racing
+    // ⌘K in the hide's own commit, before the opener re-registers.
+    await act(async () => {
+      openVendoConversation({ close: true });
+    });
+
+    // The racing toggle must have re-opened the surface, not swallowed itself.
+    await screen.findByRole("dialog", { name: "Vendo assistant" });
   });
 
   it("contains app mutation wire errors in an alert without an unhandled rejection", async () => {


### PR DESCRIPTION
Two flaky chrome tests were reddening CI across many in-flight PRs. Diagnosing the second one showed it was **not** a test-only race — it was a real product defect. So this PR is one product fix plus one test disambiguation.

## Fix 2 — PRODUCT BUG: the ⌘K opener races its own re-register (`packages/ui/src/chrome/vendo-overlay.tsx`)

**User-facing symptom:** hit ⌘K right after the assistant surface hides and the assistant never opens.

**Mechanism (stale closure):** the one-surface ⌘K path registers an opener closure via `registerOverlayOpener`. That closure captured `open`, and the effect only re-registered a fresh closure on a *later passive-effect flush*. A ⌘K that lands in the window between the hide-commit and that passive flush reaches the **stale** closure — `open` is still `true` — so a `{ toggle: true }` request reads "already open" and calls `setOpen(false)`, closing an already-closed overlay. The dialog never mounts.

**Fix (3 edits):**
- `const openRef = useRef(open); openRef.current = open;` — updated on every render (commit), independent of re-registration.
- Both `open` reads inside the opener (the toggle guard and the close guard) now read `openRef.current`.
- Drop `open` from the effect's dependency array — the ref carries the live value now.

**Prove-it-can-fail (deterministic, no CPU load needed):** the added test `reopens on a ⌘K racing its own hide` uses a **layout-effect racer**. A layout effect runs inside the hide's own commit — after render (so `openRef` already reads `false`) but before any passive effect (so the opener has **not** re-registered) — which is exactly the production window. It fires the racing ⌘K there.
- With the `openRef` guard: **GREEN** (the toggle reads the committed `false` and reopens).
- Revert to the stale `open` read: **RED every run** — `Unable to find role="dialog" name "Vendo assistant"` (verified locally).

(Note: a MutationObserver on the portal's `style` fires as a microtask, which under `act()` runs *after* React's synchronous passive-effect flush — i.e. after re-register — so it does not land in the window. The layout effect is the reliable injection point.)

## Fix 1 — TEST-ONLY: disambiguate an ambiguous role query (`packages/ui/test/chrome/transcript-beats.test.tsx`)

Test: *"renders NO beat for the apps call whose result became the app card, but still counts it"*.

**Race:** it re-found the reopen row with an unscoped `screen.getByRole("button", { expanded: false })`. That matches **two** elements whenever the composer's "Connect tools" dock button (also `aria-expanded=false`, gated behind the `useConnectorCatalog` fetch) has rendered — a genuine before/after-fetch race. When the fetch resolved first: `Found multiple elements with the role "button"`.

**Fix:** click the `.fl-beatsummary` element the test already located on the prior line. Same behavior, unambiguous. Assertion unchanged.

**Prove-it-can-fail:** the ambiguous version reproduced **2/32 red** locally (comparable to the known 3/32), failing with `Found multiple elements` in exactly this test.

## Stability evidence

All runs file-scoped, capped (`VITEST_MIN_FORKS=1 MAX_FORKS=2 MIN_THREADS=1 MAX_THREADS=2 --minWorkers=1 --maxWorkers=2`), one at a time, on a heavily loaded machine.

| File | Fixed | Reverted |
| --- | --- | --- |
| `transcript-beats.test.tsx` | **20/20 green** | 2/32 red (`Found multiple elements`) |
| `workspace-palette-slot.test.tsx` | **20/20 green** | RED every run (dialog never reopens) |

`pnpm --filter @vendoai/ui typecheck` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stale-closure race in the ⌘K overlay opener that could prevent the assistant from reopening. Also stabilizes a flaky transcript-beats test and adds a deterministic repro test for the race.

- **Bug Fixes**
  - VendoOverlay: the `registerOverlayOpener` now reads `openRef.current` (live state) instead of a captured `open`; both toggle/close guards use the ref, and `open` was removed from the effect deps. Pressing ⌘K right after hide now reliably reopens.
  - Tests: added a layout-effect racer test that fires ⌘K during the hide commit to cover the window; disambiguated the transcript-beats query by clicking `.fl-beatsummary` instead of `getByRole("button", { expanded: false })` to remove flakiness.

<sup>Written for commit b6695ee7128ae3c64404dd6fee4da54204bd13b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

