### PR TITLE
fix(ui): the overlay's beat rail was reading the global run singleton, not its own thread

### DIFF
--- a/packages/ui/src/chrome/run-activity.ts
+++ b/packages/ui/src/chrome/run-activity.ts
@@ -31,6 +31,11 @@ export interface VendoBeat {
 /** The live step of a running turn, for the pill's label + ring. */
 export interface RunActivity {
   running: boolean;
+  /** WHICH conversation is running. A host may mount several thread surfaces at
+      once (the `/concurrent` scenario mounts an embedded thread beside an
+      overlay) and this store answers for whichever one is running — so any
+      surface that narrates a run has to check the run is one it is showing. */
+  threadId?: string;
   /** §3.4 — the RUNNING turn's beats, oldest first. Ephemeral by the same rule
       as everything else here: nothing is running, so there is nothing to
       narrate, so the list is empty. */
@@ -178,11 +183,13 @@ function recompute(): void {
     : {
       running: true,
       ...(live.tool === undefined ? {} : { tool: live.tool }),
+      ...(live.threadId === undefined ? {} : { threadId: live.threadId }),
       done: live.done,
       total: live.total,
       beats: live.beats,
     };
   const changed = next.running !== activity.running
+    || next.threadId !== activity.threadId
     || next.tool !== activity.tool
     || next.done !== activity.done
     || next.total !== activity.total

--- a/packages/ui/src/chrome/vendo-overlay.tsx
+++ b/packages/ui/src/chrome/vendo-overlay.tsx
@@ -233,11 +233,6 @@ export function VendoOverlay({
   const [splitState, dispatchSplit] = useReducer(splitViewReducer, initialSplitViewState);
   const expanded = splitState.expanded && !takeover.active;
   const featured = featuredEmbed(splitState);
-  // §3.4 + §10.2 — the running turn's beats, for the stage's rail. The thread
-  // lives in the OTHER pane's React tree, so this rides the run-activity store
-  // the launcher pill already reads — the one channel for what a surface
-  // outside the conversation may know about a turn inside it.
-  const beats = useSyncExternalStore(subscribeRunActivity, runActivity, () => IDLE_RUN_ACTIVITY).beats;
   // The collapse ANIMATES: like the connect tray's exit walk, the stage stays
   // mounted through expanded → collapsing → collapsed so the featured app
   // doesn't blink out before the panes finish sliding. Render-phase state
@@ -544,6 +539,24 @@ export function VendoOverlay({
   // results. The panel's own thread id scopes the toast to runs this panel can
   // actually show.
   const [panelThreadId, setPanelThreadId] = useState<string>();
+  // §3.4 + §10.2 — the running turn's beats, for the stage's rail. The thread
+  // lives in the OTHER pane's React tree, so this rides the run-activity store
+  // the launcher pill already reads — the one channel for what a surface
+  // outside the conversation may know about a turn inside it.
+  //
+  // SCOPED, because that store answers for whichever surface is running and a
+  // host may mount several (`/concurrent` mounts an embedded thread beside this
+  // overlay): unscoped, an idle workspace narrated somebody else's build.
+  //
+  // Stricter than the toast's rule two lines below, deliberately. A toast is news
+  // the user might otherwise miss, so it fails toward SHOWING and lets an
+  // unidentified run through; a rail claims "this is what YOUR workspace is
+  // doing", so it fails toward SILENCE — an unidentifiable turn narrates nowhere
+  // rather than in the wrong panel.
+  const activity = useSyncExternalStore(subscribeRunActivity, runActivity, () => IDLE_RUN_ACTIVITY);
+  const beats = activity.threadId !== undefined && activity.threadId === panelThreadId
+    ? activity.beats
+    : IDLE_RUN_ACTIVITY.beats;
   const status = useLauncherStatus({
     open,
     ...(panelThreadId === undefined ? {} : { threadId: panelThreadId }),

--- a/packages/ui/test/chrome/status-beats.test.tsx
+++ b/packages/ui/test/chrome/status-beats.test.tsx
@@ -163,4 +163,58 @@ describe("the status channel reaches the screen", () => {
     // Ephemeral on screen too: the settled turn leaves the stage clean.
     await waitFor(() => expect(rail()).toBeNull());
   });
+
+  /**
+   * P1 (bot review on #796) — SCOPE. The run store narrates whichever surface is
+   * RUNNING, globally (`recompute`: `find(surface => surface.running)`), so a
+   * stage that reads it unscoped narrates a conversation it is not showing.
+   *
+   * This is not hypothetical: the shipped `/concurrent` harness scenario mounts
+   * an embedded `VendoThread` beside this very overlay, so ONE running turn plus
+   * one expanded workspace is enough. It is also the third instance of this
+   * codebase's singleton-vs-scoped mistake — `PrefillScopeContext` exists because
+   * prompts went "to whichever composer registered last", and `publishThreadRun`
+   * carries a comment about one settle being announced twice.
+   */
+  it("a stage narrates its OWN conversation, never whichever surface happens to be running", { timeout: 30_000 }, async () => {
+    render(
+      <VendoProvider client={client}>
+        <VendoThread threadId="thr_1" />
+        <VendoOverlay defaultOpen />
+      </VendoProvider>,
+    );
+    expect(await screen.findByText("Existing thread")).toBeTruthy();
+    fireEvent.click(await screen.findByRole("button", { name: "Expand workspace" }));
+    const panel = screen.getByRole("dialog", { name: "Vendo assistant" });
+    const composerIn = (inside: boolean) => screen.getAllByRole("textbox", { name: "Message" })
+      .find(box => panel.contains(box) === inside)!;
+
+    // The EMBEDDED thread runs the build. The overlay's workspace is open on a
+    // different, brand-new, never-run conversation.
+    const outside = composerIn(false);
+    fireEvent.change(outside, { target: { value: "[beats] build it" } });
+    fireEvent.keyDown(outside, { key: "Enter" });
+
+    // Positive anchor FIRST: the beats really are live on the running surface,
+    // so the absence asserted next cannot pass vacuously.
+    await waitFor(() => expect(document.querySelector(".fl-ribbon--working")?.textContent)
+      .toContain("Adding drag and drop"));
+    // …and they do not leak onto a stage that is showing someone else.
+    expect(panel.querySelector(".fl-beatrail")).toBeNull();
+
+    await act(async () => release());
+    await waitFor(() => expect(document.querySelector(".fl-ribbon--working")).toBeNull());
+
+    // The same stage DOES narrate its own conversation — the scope is a filter,
+    // not a mute.
+    wire.state.threadReplyGate = new Promise<void>(resolve => { release = resolve; });
+    const inside = composerIn(true);
+    fireEvent.change(inside, { target: { value: "[beats] build mine" } });
+    fireEvent.keyDown(inside, { key: "Enter" });
+
+    await waitFor(() => expect(panel.querySelectorAll(".fl-beatrail .fl-beat")).toHaveLength(4));
+    expect(panel.querySelector(".fl-beatrail")?.textContent).toContain("Adding drag and drop");
+    await act(async () => release());
+    await waitFor(() => expect(panel.querySelector(".fl-beatrail")).toBeNull());
+  });
 });


### PR DESCRIPTION
## A live P1 in main: the overlay's beat rail reads the global run singleton

Merged in #796 (`085215601`) **without** the scoping this PR adds. On current
`main` the expanded workspace stage narrates **whichever thread is running,
globally** — not the conversation the panel is actually showing.

### The chain (verified against `origin/main`)

- `run-activity.ts` `recompute()`: `const live = [...surfaces.values()].find(s => s.running)` — the **first running surface wins, globally**, and `threadId` is dropped when narrowing `Derived → RunActivity`.
- `vendo-overlay.tsx:240`: `const beats = useSyncExternalStore(subscribeRunActivity, runActivity, …).beats;` — reads that singleton, unscoped.
- `vendo-overlay.tsx:718`: `<BeatRail beats={beats} />`.

**Not hypothetical — one running turn is enough.** The shipped `/concurrent`
harness scenario mounts `<VendoThread threadId="thr_1" />` beside `<VendoOverlay />`
in one provider. Run a turn in the embedded thread, expand the overlay, and the
overlay's stage narrates `thr_1` — a conversation it isn't showing and never ran.
It's the third instance of this codebase's singleton-vs-scoped mistake
(`PrefillScopeContext` exists because prompts went "to whichever composer
registered last"; `publishThreadRun` carries a comment about one settle being
announced twice).

### The fix

`panelThreadId` already existed for exactly this job — its own comment says it
"scopes the toast to runs this panel can actually show." The rail simply skipped
it. This carries `threadId` through the store's public snapshot and scopes the
stage's beats to `panelThreadId`.

**Scoped by thread, not app.** `appId` says which app a beat is *about*, not which
surface owns it, and §3.4 makes it optional — an appId filter would silently drop
every bare beat.

**Strict, not permissive.** The check is `activity.threadId !== undefined &&
activity.threadId === panelThreadId`. The reported case has `panelThreadId`
undefined (that overlay never ran anything), so the toast's permissive rule at
`launcher-status.tsx:82` — which only suppresses when *both* ids are known and
differ — would let the foreign beats straight through and the bug would survive.
The two rules legitimately differ: a toast is news the user might otherwise miss,
so it fails toward **showing**; a rail claims "this is what YOUR workspace is
doing", so it fails toward **silence** — an unidentifiable turn narrates nowhere
rather than in the wrong panel.

### Red → green (deterministic, on this branch)

New test in `status-beats.test.tsx` mounts an embedded thread beside an expanded
overlay, runs a build in the embedded thread, and asserts the overlay stage stays
empty; then runs a build in the overlay's own thread and asserts its rail fills.

- **RED** against main's unscoped code (`const beats = activity.beats;`): the scope test fails with `expected <div class="fl-beatrail"> to be null` — the foreign rail leaked. The other 4 beat tests stayed green (Home-B only).
- **GREEN** with the fix: `status-beats.test.tsx` 5/5. Guard slice — `run-activity-honesty`, `split-view`, `thread-and-overlay`, `pill-states` — 45/45.

`pnpm --filter @vendoai/ui build` + `typecheck` green. Diff: 3 files, +79/−5.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a P1 where the overlay’s beat rail narrated whichever thread was running globally. The rail is now scoped to the overlay’s own thread so an idle workspace stays silent and only shows its own builds.

- **Bug Fixes**
  - Added `threadId` to `RunActivity` and propagated it in the run-activity store.
  - In `VendoOverlay`, show beats only when `activity.threadId === panelThreadId`; otherwise, show none.
  - Added a deterministic test to ensure an adjacent embedded thread doesn’t leak beats and that the overlay narrates only its own runs.

<sup>Written for commit 2afc2368c5e6ec204f80cdb18da5763bf15afae4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

