### PR TITLE
feat(demo-bank): deep seed — 6 months of data, 7 accounts, 4 users, richer console history

### DIFF
--- a/examples/demo-bank/scripts/seed-console.ts
+++ b/examples/demo-bank/scripts/seed-console.ts
@@ -6,11 +6,13 @@
  * boot), and the scripted-demo rows are seedDemoScript's; this script adds,
  * per seeded Maple user:
  *
- * - three ENABLED automations (`vendo_apps`) — payday savings sweep,
- *   balance-below-$500 alert, monthly bill review;
- * - ~3 weeks of run history (`vendo_runs`) so the automations page shows fires;
- * - ~3 weeks of audit events (`vendo_audit`) — chat/automation/mcp tool calls,
- *   an approval, and one org-blocked MCP transfer;
+ * - six automations (`vendo_apps`) — four enabled (payday savings sweep,
+ *   balance-below-$500 alert, monthly bill review, weekly spending digest)
+ *   and two disabled (subscription price watch, quarterly tax set-aside);
+ * - ~6 weeks of run history (`vendo_runs`) — mostly ok, a few failures — so
+ *   the automations page shows a lived-in fire record;
+ * - ~100 audit events per user (`vendo_audit`) — chat/automation/mcp tool
+ *   calls, approvals granted and denied, and one org-blocked MCP transfer;
  * - the org guard policy at /orgs/maple/policy.json (LOCAL store only — the
  *   workspace door needs a SQL handle; on the hosted store the console owns
  *   that file).
@@ -50,6 +52,17 @@ function daysAgo(anchor: Date, n: number, h = 9, m = 0): Date {
 function seedId(key: string, subject: string): string {
   return `app_seed_${key}_${subject}`;
 }
+
+/** The seeded automations — the doc plus whether the row is enabled, so the
+ *  list shows a couple of paused ones the way a real tenant's would. */
+function automationSeeds(subject: string): { doc: AppDocument; enabled: boolean }[] {
+  return automationDocs(subject).map((doc) => ({
+    doc,
+    enabled: !DISABLED_KEYS.some((key) => doc.id === seedId(key, subject)),
+  }));
+}
+
+const DISABLED_KEYS = ["pricewatch", "taxsetaside"];
 
 function automationDocs(subject: string): AppDocument[] {
   return [
@@ -96,6 +109,49 @@ function automationDocs(subject: string): AppDocument[] {
         },
       },
     },
+    {
+      format: "vendo/app@1",
+      id: seedId("weeklydigest", subject) as AppId,
+      name: "Weekly spending digest",
+      description: "Every Monday at 8:00 AM, summarize last week's spending by category and how cashflow is trending.",
+      trigger: {
+        on: { kind: "schedule", cron: "0 8 * * 1" },
+        run: {
+          kind: "steps",
+          steps: [
+            { id: "spending", tool: "host_getSpendingInsights" },
+            { id: "cashflow", tool: "host_getCashflowInsights" },
+          ],
+        },
+      },
+    },
+    {
+      format: "vendo/app@1",
+      id: seedId("pricewatch", subject) as AppId,
+      name: "Subscription price watch",
+      description: "On the 5th at 10:00 AM, flag any subscription that got more expensive month-over-month. (Paused.)",
+      trigger: {
+        on: { kind: "schedule", cron: "0 10 5 * *" },
+        run: {
+          kind: "steps",
+          steps: [{ id: "recurring", tool: "host_getRecurringInsights" }],
+        },
+      },
+    },
+    {
+      format: "vendo/app@1",
+      id: seedId("taxsetaside", subject) as AppId,
+      name: "Quarterly tax set-aside",
+      description: "Quarterly on the 1st at 9:00 AM, move 25% of the quarter's business income into Maple Money Market. (Paused.)",
+      trigger: {
+        on: { kind: "schedule", cron: "0 9 1 */3 *" },
+        run: {
+          kind: "agentic",
+          prompt: "Total this quarter's Maple Business Checking income, move 25% of it to Maple Money Market, and confirm the transfer posted.",
+          budget: { maxToolCalls: 8 },
+        },
+      },
+    },
   ];
 }
 
@@ -103,9 +159,9 @@ async function seedAutomations(store: VendoStore, subjects: string[]): Promise<n
   const apps = store.records("vendo_apps");
   let written = 0;
   for (const subject of subjects) {
-    for (const doc of automationDocs(subject)) {
+    for (const { doc, enabled } of automationSeeds(subject)) {
       if (await apps.get(doc.id) !== null) continue;
-      await apps.put({ id: doc.id, data: { subject, enabled: true, doc } });
+      await apps.put({ id: doc.id, data: { subject, enabled, doc } });
       written++;
     }
   }
@@ -121,13 +177,16 @@ interface SeedRun {
   durationS: number;
   steps: { id: string; tool: string }[];
   summary: string;
+  /** Absent means "ok"; present means the run errored with this message. */
+  failure?: string;
 }
 
-/** ~3 weeks of believable fires per user, matching each automation's cadence. */
+/** ~6 weeks of believable fires per user, matching each automation's cadence —
+ *  mostly clean, with the occasional failure a real fire record has. */
 function runHistory(subject: string, anchor: Date): SeedRun[] {
   const runs: SeedRun[] = [];
   const sweep = seedId("paydaysweep", subject);
-  for (const [n, day] of [[1, 6], [2, 20]] as const) {
+  for (const [n, day] of [[1, 3], [2, 17], [3, 31]] as const) {
     runs.push({
       id: `run_seed_sweep_${n}_${subject}`, appId: sweep,
       startedAt: daysAgo(anchor, day, 9, 0), durationS: 8,
@@ -136,23 +195,40 @@ function runHistory(subject: string, anchor: Date): SeedRun[] {
     });
   }
   const alert = seedId("lowbalance500", subject);
-  for (let day = 1; day <= 21; day += 2) {
+  const alertFailures = new Set([13, 27]);
+  for (let day = 1; day <= 41; day += 2) {
     runs.push({
       id: `run_seed_alert_${day}_${subject}`, appId: alert,
       startedAt: daysAgo(anchor, day, 7, 0), durationS: 3,
       steps: [{ id: "balance", tool: "host_listAccounts" }],
       summary: "Maple Checking is at $9,412.20 — above the $500 threshold, no alert needed.",
+      ...(alertFailures.has(day) ? { failure: "Maple API timed out fetching accounts." } : {}),
     });
   }
-  runs.push({
-    id: `run_seed_bills_1_${subject}`, appId: seedId("billreview", subject),
-    startedAt: daysAgo(anchor, 8, 9, 0), durationS: 6,
-    steps: [
-      { id: "scheduled", tool: "host_listScheduledPayments" },
-      { id: "recurring", tool: "host_getRecurringInsights" },
-    ],
-    summary: "2 bills upcoming ($2,936.40) and 6 active subscriptions ($345.47/mo); nothing overdue.",
-  });
+  for (const [n, day] of [[1, 8], [2, 38]] as const) {
+    runs.push({
+      id: `run_seed_bills_${n}_${subject}`, appId: seedId("billreview", subject),
+      startedAt: daysAgo(anchor, day, 9, 0), durationS: 6,
+      steps: [
+        { id: "scheduled", tool: "host_listScheduledPayments" },
+        { id: "recurring", tool: "host_getRecurringInsights" },
+      ],
+      summary: "6 bills upcoming ($5,790.59) and 10 active subscriptions ($485.41/mo); nothing overdue.",
+    });
+  }
+  const digest = seedId("weeklydigest", subject);
+  for (const day of [2, 9, 16, 23, 30, 37]) {
+    runs.push({
+      id: `run_seed_digest_${day}_${subject}`, appId: digest,
+      startedAt: daysAgo(anchor, day, 8, 0), durationS: 5,
+      steps: [
+        { id: "spending", tool: "host_getSpendingInsights" },
+        { id: "cashflow", tool: "host_getCashflowInsights" },
+      ],
+      summary: "Spent $2,184.63 last week — dining up 18%, groceries flat; cashflow positive.",
+      ...(day === 23 ? { failure: "Insights endpoint returned 503; digest skipped." } : {}),
+    });
+  }
   return runs;
 }
 
@@ -164,19 +240,23 @@ async function seedRuns(store: VendoStore, subjects: string[], anchor: Date): Pr
       if (await table.get(run.id) !== null) continue;
       const startedAt = iso(run.startedAt);
       const finishedAt = iso(new Date(run.startedAt.getTime() + run.durationS * 1000));
+      const status = run.failure === undefined ? ("ok" as const) : ("error" as const);
+      const outcome = run.failure === undefined ? ("ok" as const) : ("error" as const);
       const record = {
         id: run.id, appId: run.appId,
         trigger: { kind: "schedule" as const },
-        status: "ok" as const, startedAt, finishedAt,
+        status, startedAt, finishedAt,
         steps: run.steps.map((step, index) => ({
-          ...step, outcome: "ok" as const,
+          ...step, outcome,
           at: iso(new Date(run.startedAt.getTime() + (index + 1) * 1000)),
         })),
-        summary: run.summary,
+        ...(run.failure === undefined
+          ? { summary: run.summary }
+          : { error: { code: "host-error", message: run.failure } }),
       };
       await table.put({
         id: run.id,
-        data: { appId: run.appId, trigger: { kind: "schedule" }, status: "ok", record, startedAt, finishedAt },
+        data: { appId: run.appId, trigger: { kind: "schedule" }, status, record, startedAt, finishedAt },
       });
       written++;
     }
@@ -187,7 +267,8 @@ async function seedRuns(store: VendoStore, subjects: string[], anchor: Date): Pr
 // ------------------------------------------------------------- agent activity
 
 /** Audit trail matching the run history plus everyday chat activity, so the
- *  console's activity surfaces have ~3 weeks of varied rows. */
+ *  console's activity surfaces have ~6 weeks (~100 rows per user) of varied
+ *  history. decidedBy stays within the hosted-store mirror's accepted set. */
 function auditEvents(subject: string, anchor: Date): AuditEvent[] {
   const events: AuditEvent[] = [];
   let n = 0;
@@ -201,34 +282,42 @@ function auditEvents(subject: string, anchor: Date): AuditEvent[] {
   // Every automation fire leaves a run event + its tool calls, away.
   for (const run of runHistory(subject, anchor)) {
     const trigger = { runId: run.id as RunId, kind: "schedule" as const };
+    const outcome = run.failure === undefined ? ("ok" as const) : ("error" as const);
     add(run.startedAt, {
       kind: "run", venue: "automation", presence: "away",
-      appId: run.appId as AppId, trigger, outcome: "ok",
+      appId: run.appId as AppId, trigger, outcome,
     });
     for (const step of run.steps) {
       add(new Date(run.startedAt.getTime() + 1000), {
         kind: "tool-call", venue: "automation", presence: "away",
         appId: run.appId as AppId, trigger,
-        tool: step.tool, outcome: "ok", decidedBy: "grant",
+        tool: step.tool, outcome, decidedBy: "grant",
       });
     }
   }
 
-  // Everyday chat reads, present, allowed by the host policy's read rule.
-  const chat: [number, number, string][] = [
-    [2, 19, "host_listTransactions"], [2, 19, "host_getSpendingInsights"],
-    [5, 12, "host_listAccounts"], [9, 20, "host_getCashflowInsights"],
-    [12, 8, "host_listTransactions"], [16, 13, "host_getBudgets"],
-    [19, 18, "host_listGoals"],
+  // Everyday chat reads, present, auto-run by the host policy's read rule —
+  // with the occasional grant-, judge- and default-decided call mixed in.
+  const chat: [number, number, string, AuditEvent["decidedBy"]][] = [
+    [1, 21, "host_listTransactions", "rule"], [2, 19, "host_listTransactions", "rule"],
+    [2, 19, "host_getSpendingInsights", "rule"], [4, 9, "host_listCards", "grant"],
+    [5, 12, "host_listAccounts", "rule"], [6, 15, "host_getBudgets", "rule"],
+    [8, 10, "host_listScheduledPayments", "judge"], [9, 20, "host_getCashflowInsights", "rule"],
+    [11, 14, "host_listTransactions", "rule"], [12, 8, "host_listTransactions", "rule"],
+    [14, 17, "host_getRecurringInsights", "grant"], [16, 13, "host_getBudgets", "rule"],
+    [19, 18, "host_listGoals", "rule"], [22, 11, "host_listAccounts", "default"],
+    [25, 16, "host_getSpendingInsights", "rule"], [28, 9, "host_listTransactions", "rule"],
+    [31, 19, "host_getCashflowInsights", "rule"], [34, 12, "host_listPayees", "rule"],
+    [37, 15, "host_listTransactions", "rule"], [40, 10, "host_getRecurringInsights", "rule"],
   ];
-  for (const [day, hour, tool] of chat) {
+  for (const [day, hour, tool, decidedBy] of chat) {
     add(daysAgo(anchor, day, hour, 24), {
       kind: "tool-call", venue: "chat", presence: "present",
-      tool, outcome: "ok", decidedBy: "rule",
+      tool, outcome: "ok", decidedBy,
     });
   }
 
-  // A transfer asked about in chat and approved by the user...
+  // Two transfers asked about in chat and approved by the user...
   add(daysAgo(anchor, 4, 11, 3), {
     kind: "tool-call", venue: "chat", presence: "present",
     tool: "host_transferMoney", inputPreview: "$150.00 Checking → Savings",
@@ -237,6 +326,26 @@ function auditEvents(subject: string, anchor: Date): AuditEvent[] {
   add(daysAgo(anchor, 4, 11, 4), {
     kind: "approval", venue: "chat", presence: "present",
     tool: "host_transferMoney", outcome: "ok",
+  });
+  add(daysAgo(anchor, 20, 13, 12), {
+    kind: "tool-call", venue: "chat", presence: "present",
+    tool: "host_payBill", inputPreview: "$86.40 PG&E from Checking",
+    outcome: "pending-approval", decidedBy: "rule",
+  });
+  add(daysAgo(anchor, 20, 13, 13), {
+    kind: "approval", venue: "chat", presence: "present",
+    tool: "host_payBill", outcome: "ok",
+  });
+  // ...one the user looked at and declined...
+  add(daysAgo(anchor, 13, 18, 47), {
+    kind: "tool-call", venue: "chat", presence: "present",
+    tool: "host_transferMoney", inputPreview: "$2,000.00 Savings → Checking",
+    outcome: "pending-approval", decidedBy: "rule",
+  });
+  add(daysAgo(anchor, 13, 18, 49), {
+    kind: "approval", venue: "chat", presence: "present",
+    tool: "host_transferMoney", inputPreview: "$2,000.00 Savings → Checking",
+    outcome: "blocked",
   });
   // ...and one MCP transfer the org policy blocks (see /orgs/maple/policy.json).
   add(daysAgo(anchor, 3, 15, 41), {

--- a/examples/demo-bank/src/server/__tests__/api.test.ts
+++ b/examples/demo-bank/src/server/__tests__/api.test.ts
@@ -22,9 +22,9 @@ describe("api", () => {
     const res = await getTxn(new Request("http://x"), { params: Promise.resolve({ id: "nope" }) })
     expect(res.status).toBe(404)
   })
-  it("GET /api/accounts returns four accounts", async () => {
+  it("GET /api/accounts returns seven accounts", async () => {
     const res = await getAccounts()
     const body = await res.json()
-    expect(body.data.length).toBe(4)
+    expect(body.data.length).toBe(7)
   })
 })

--- a/examples/demo-bank/src/server/__tests__/seed.test.ts
+++ b/examples/demo-bank/src/server/__tests__/seed.test.ts
@@ -6,16 +6,16 @@ const anchor = new Date("2026-06-29T12:00:00-07:00")
 describe("buildSeed", () => {
   const data = buildSeed(anchor)
 
-  it("creates four accounts including checking and savings", () => {
+  it("creates seven accounts including checking and savings", () => {
     const kinds = data.accounts.map(a => a.kind)
     expect(kinds).toContain("checking")
     expect(kinds).toContain("savings")
-    expect(data.accounts.length).toBe(4)
+    expect(data.accounts.length).toBe(7)
   })
 
   it("generates a substantial, deterministic transaction history", () => {
     const a = buildSeed(anchor); const b = buildSeed(anchor)
-    expect(a.transactions.length).toBeGreaterThanOrEqual(120)
+    expect(a.transactions.length).toBeGreaterThanOrEqual(900)
     expect(a.transactions.map(t => t.id)).toEqual(b.transactions.map(t => t.id))
   })
 

--- a/examples/demo-bank/src/server/__tests__/users.test.ts
+++ b/examples/demo-bank/src/server/__tests__/users.test.ts
@@ -11,10 +11,10 @@ import {
 afterEach(() => vi.unstubAllEnvs())
 
 describe("Maple seeded demo users", () => {
-  it("seeds two users so per-user isolation is demonstrable", () => {
+  it("seeds four users so per-user isolation is demonstrable", () => {
     const users = mapleDemoUsers()
-    expect(users.map(({ subject }) => subject)).toEqual(["vendo-demo", "maple-mia"])
-    expect(new Set(users.map(({ email }) => email)).size).toBe(2)
+    expect(users.map(({ subject }) => subject)).toEqual(["vendo-demo", "maple-mia", "maple-sam", "maple-dana"])
+    expect(new Set(users.map(({ email }) => email)).size).toBe(4)
   })
 
   it("has no switchable roster when password login is unconfigured", () => {
@@ -24,7 +24,7 @@ describe("Maple seeded demo users", () => {
     vi.stubEnv("NODE_ENV", "production")
     expect(mapleDemoUsers()).toEqual([])
     vi.stubEnv("MAPLE_DEMO_PASSWORD", "set-in-production")
-    expect(mapleDemoUsers().map(({ subject }) => subject)).toEqual(["vendo-demo", "maple-mia"])
+    expect(mapleDemoUsers().map(({ subject }) => subject)).toEqual(["vendo-demo", "maple-mia", "maple-sam", "maple-dana"])
   })
 
   it("authenticates both seeded users case-insensitively and rejects bad passwords", async () => {

--- a/examples/demo-bank/src/server/seed.ts
+++ b/examples/demo-bank/src/server/seed.ts
@@ -15,8 +15,14 @@ export interface SeedData {
 
 const CHECKING = "acc_checking"
 const SAVINGS = "acc_savings"
+const JOINT = "acc_savings_joint"
 const CREDIT = "acc_credit"
 const INVEST = "acc_investing"
+const BUSINESS = "acc_business"
+const MONEYMARKET = "acc_moneymarket"
+
+/** Six months of history, in days. */
+const HISTORY_DAYS = 180
 
 function iso(d: Date) { return d.toISOString() }
 function daysAgo(anchor: Date, n: number, h = 12, m = 0) {
@@ -26,17 +32,26 @@ function initials(name: string) {
   return name.replace(/[^a-zA-Z ]/g, "").split(" ").filter(Boolean).slice(0, 2).map(w => w[0]).join("").toUpperCase()
 }
 
-// Recurring merchant templates
+// Recurring merchant templates — rent, utilities and ten subscriptions,
+// each on its own day of month so the recurring detector has real signal.
 const RECURRING: { merchant: string; category: Category; dom: number; cents: number; descriptor: string }[] = [
-  { merchant: "Equinox", category: "subscriptions", dom: 1, cents: -28500, descriptor: "EQUINOX SF" },
   { merchant: "Rent — Mission St", category: "housing", dom: 1, cents: -285000, descriptor: "ACH RENT MISSION" },
+  { merchant: "Equinox", category: "subscriptions", dom: 1, cents: -28500, descriptor: "EQUINOX SF" },
   { merchant: "Spotify", category: "subscriptions", dom: 4, cents: -1199, descriptor: "SPOTIFY USA" },
   { merchant: "Netflix", category: "subscriptions", dom: 7, cents: -1549, descriptor: "NETFLIX.COM" },
   { merchant: "iCloud+", category: "subscriptions", dom: 9, cents: -299, descriptor: "APPLE.COM/BILL" },
   { merchant: "ChatGPT", category: "subscriptions", dom: 12, cents: -2000, descriptor: "OPENAI CHATGPT" },
+  { merchant: "PG&E", category: "housing", dom: 15, cents: -8640, descriptor: "PGANDE WEB ONLINE" },
+  { merchant: "YouTube Premium", category: "subscriptions", dom: 16, cents: -1399, descriptor: "GOOGLE *YOUTUBE" },
+  { merchant: "Comcast Xfinity", category: "housing", dom: 17, cents: -8999, descriptor: "COMCAST CALIFORNIA" },
+  { merchant: "Notion", category: "subscriptions", dom: 18, cents: -1200, descriptor: "NOTION LABS INC" },
+  { merchant: "SF Water Power Sewer", category: "housing", dom: 20, cents: -6420, descriptor: "SFPUC WATER" },
+  { merchant: "NYTimes", category: "subscriptions", dom: 21, cents: -1700, descriptor: "NYTIMES*SUBSCRIPTION" },
+  { merchant: "Verizon Wireless", category: "subscriptions", dom: 24, cents: -9200, descriptor: "VZWRLSS*APOCC" },
+  { merchant: "Audible", category: "subscriptions", dom: 26, cents: -1495, descriptor: "AUDIBLE*PMT" },
 ]
 
-// One-off merchant pool
+// One-off merchant pool — everyday personal noise.
 const POOL: { merchant: string; category: Category; min: number; max: number; descriptor: string }[] = [
   { merchant: "Whole Foods Market", category: "groceries", min: 2200, max: 9400, descriptor: "WHOLEFDS SFO" },
   { merchant: "Trader Joe's", category: "groceries", min: 1800, max: 6200, descriptor: "TRADER JOE'S #182" },
@@ -49,7 +64,38 @@ const POOL: { merchant: string; category: Category; min: number; max: number; de
   { merchant: "Tartine Bakery", category: "dining", min: 1400, max: 4800, descriptor: "TARTINE" },
   { merchant: "Philz Coffee", category: "coffee", min: 500, max: 1500, descriptor: "PHILZ COFFEE" },
   { merchant: "Chipotle", category: "dining", min: 1100, max: 2600, descriptor: "CHIPOTLE 2244" },
+  { merchant: "Souvla", category: "dining", min: 1600, max: 4200, descriptor: "SOUVLA HAYES" },
+  { merchant: "State Bird Provisions", category: "dining", min: 6800, max: 18500, descriptor: "STATE BIRD PROV" },
+  { merchant: "Walgreens", category: "shopping", min: 600, max: 4400, descriptor: "WALGREENS #3721" },
   { merchant: "Shell", category: "transport", min: 3500, max: 7200, descriptor: "SHELL OIL" },
+  { merchant: "Clipper", category: "transport", min: 2000, max: 4000, descriptor: "CLIPPER AUTOLOAD" },
+]
+
+// Business-account expense pool — SaaS, shipping, supplies, client meals.
+const BUSINESS_POOL: { merchant: string; category: Category; min: number; max: number; descriptor: string }[] = [
+  { merchant: "AWS", category: "subscriptions", min: 8200, max: 31400, descriptor: "AMAZON WEB SERVICES" },
+  { merchant: "Google Workspace", category: "subscriptions", min: 1440, max: 7200, descriptor: "GOOGLE *WORKSPACE" },
+  { merchant: "Adobe", category: "subscriptions", min: 5999, max: 8499, descriptor: "ADOBE *CREATIVE CLD" },
+  { merchant: "Office Depot", category: "shopping", min: 2400, max: 18900, descriptor: "OFFICE DEPOT #1123" },
+  { merchant: "FedEx", category: "shopping", min: 1250, max: 9600, descriptor: "FEDEX 78202" },
+  { merchant: "Costco Business", category: "shopping", min: 8900, max: 34200, descriptor: "COSTCO WHSE #0148" },
+  { merchant: "Zeitgeist", category: "dining", min: 3200, max: 11800, descriptor: "ZEITGEIST SF" },
+  { merchant: "Uber", category: "transport", min: 1400, max: 5200, descriptor: "UBER *TRIP" },
+]
+
+// Occasional large one-offs — the memorable purchases a quarter actually has.
+const ONE_OFFS: {
+  d: number; merchant: string; descriptor: string; cents: number
+  category: Category; account: string; card?: string
+}[] = [
+  { d: 23, merchant: "West Elm", descriptor: "WEST ELM #109 SF", cents: -232500, category: "shopping", account: CREDIT, card: "card_virtual" },
+  { d: 37, merchant: "Delta Air Lines", descriptor: "DELTA AIR 0062341", cents: -48920, category: "transport", account: CREDIT, card: "card_virtual" },
+  { d: 52, merchant: "Golden Gate Dental", descriptor: "GG DENTAL SF", cents: -41000, category: "other", account: CHECKING },
+  { d: 66, merchant: "Hotel Nia", descriptor: "HOTEL NIA MENLO PK", cents: -63780, category: "other", account: CREDIT, card: "card_virtual" },
+  { d: 81, merchant: "REI", descriptor: "REI #83 SOMA", cents: -28935, category: "shopping", account: CHECKING, card: "card_physical" },
+  { d: 108, merchant: "Apple Store", descriptor: "APPLE STORE R052", cents: -219900, category: "shopping", account: CREDIT, card: "card_virtual" },
+  { d: 131, merchant: "Ticketmaster", descriptor: "TICKETMASTER EVENT", cents: -18450, category: "other", account: CREDIT, card: "card_virtual" },
+  { d: 156, merchant: "SF Auto Works", descriptor: "SF AUTO WORKS", cents: -87600, category: "transport", account: CHECKING },
 ]
 
 function timeline(status: Transaction["status"], ts: string) {
@@ -75,8 +121,12 @@ export function buildSeed(anchor: Date = new Date()): SeedData {
     } as Transaction)
   }
 
-  // 90 days of history
-  for (let day = 90; day >= 1; day--) {
+  // Six months of daily history
+  for (let day = HISTORY_DAYS; day >= 1; day--) {
+    const date = daysAgo(anchor, day)
+    const weekday = date.getDay() >= 1 && date.getDay() <= 5
+
+    // Biweekly payroll + the savings sweep it funds
     if (day % 14 === 0) {
       add({ accountId: CHECKING, merchant: "Acme Corp Payroll", descriptor: "ACME CORP DIR DEP",
         amount: 642000, timestamp: iso(daysAgo(anchor, day, 9, 2)), category: "income", status: "posted",
@@ -88,26 +138,145 @@ export function buildSeed(anchor: Date = new Date()): SeedData {
         amount: 100000, timestamp: iso(daysAgo(anchor, day, 9, 5)), category: "transfer", status: "posted",
         method: "Internal transfer" })
     }
-    const count = rand() < 0.25 ? 0 : rand() < 0.6 ? 1 : rand() < 0.9 ? 2 : 3
+
+    // The weekly grocery run, bigger than the incidental top-ups in the pool
+    if (day % 7 === 2) {
+      add({ accountId: CHECKING, merchant: "Whole Foods Market", descriptor: "WHOLEFDS SFO",
+        amount: between(8000, 16000), timestamp: iso(daysAgo(anchor, day, 17, Math.floor(rand() * 60))),
+        category: "groceries", status: "posted", location: "San Francisco, CA", cardId: "card_physical" })
+    }
+
+    // Everyday personal noise across checking + credit
+    const count = 2 + Math.floor(rand() * 3)
     for (let i = 0; i < count; i++) {
       const m = pick(POOL)
       const hour = 8 + Math.floor(rand() * 13)
-      add({ accountId: rand() < 0.2 ? CREDIT : CHECKING, merchant: m.merchant, descriptor: m.descriptor,
+      add({ accountId: rand() < 0.25 ? CREDIT : CHECKING, merchant: m.merchant, descriptor: m.descriptor,
         amount: between(m.min, m.max), timestamp: iso(daysAgo(anchor, day, hour, Math.floor(rand() * 60))),
         category: m.category, status: "posted", location: "San Francisco, CA",
-        cardId: rand() < 0.2 ? "card_virtual" : "card_physical" })
+        cardId: rand() < 0.25 ? "card_virtual" : "card_physical" })
+    }
+
+    // Business checking runs on weekdays
+    if (weekday) {
+      const bCount = rand() < 0.35 ? 0 : rand() < 0.8 ? 1 : 2
+      for (let i = 0; i < bCount; i++) {
+        const m = pick(BUSINESS_POOL)
+        const hour = 9 + Math.floor(rand() * 9)
+        add({ accountId: BUSINESS, merchant: m.merchant, descriptor: m.descriptor,
+          amount: between(m.min, m.max), timestamp: iso(daysAgo(anchor, day, hour, Math.floor(rand() * 60))),
+          category: m.category, status: "posted", location: "San Francisco, CA",
+          cardId: "card_business", method: "Maple Business ·· 3308" })
+      }
+    }
+
+    // Client revenue lands twice a month on the business account
+    if (day % 15 === 5) {
+      add({ accountId: BUSINESS, merchant: "Stripe Payout", descriptor: "STRIPE TRANSFER",
+        amount: 420000 + Math.floor(rand() * 260000), timestamp: iso(daysAgo(anchor, day, 8, 30)),
+        category: "income", status: "posted", method: "ACH deposit" })
+    }
+    if (day % 15 === 12) {
+      add({ accountId: BUSINESS, merchant: "Brightline LLC", descriptor: "ACH BRIGHTLINE LLC INV",
+        amount: 610000 + Math.floor(rand() * 340000), timestamp: iso(daysAgo(anchor, day, 10, 15)),
+        category: "income", status: "posted", method: "ACH deposit" })
     }
   }
 
-  for (let monthsBack = 2; monthsBack >= 0; monthsBack--) {
+  // Monthly cycles across the half year
+  for (let monthsBack = 6; monthsBack >= 0; monthsBack--) {
+    const onDom = (dom: number, h = 6, m = 0) => {
+      const d = new Date(anchor); d.setMonth(d.getMonth() - monthsBack); d.setDate(dom); d.setHours(h, m, 0, 0)
+      return d <= anchor && d >= daysAgo(anchor, HISTORY_DAYS + 3) ? d : null
+    }
+
+    // Rent, utilities, subscriptions
     for (const r of RECURRING) {
-      const d = new Date(anchor); d.setMonth(d.getMonth() - monthsBack); d.setDate(r.dom); d.setHours(6, 0, 0, 0)
-      if (d <= anchor && d >= daysAgo(anchor, 92)) {
+      const d = onDom(r.dom)
+      if (d) {
         add({ accountId: CHECKING, merchant: r.merchant, descriptor: r.descriptor, amount: r.cents,
           timestamp: iso(d), category: r.category, status: "posted",
           recurringId: `rec_${r.merchant.toLowerCase().replace(/[^a-z]/g, "")}` })
       }
     }
+
+    // Monthly auto-invest sweep into Maple Invest
+    const invest = onDom(2, 9, 10)
+    if (invest) {
+      add({ accountId: CHECKING, merchant: "Transfer to Maple Invest", descriptor: "INTERNAL XFER",
+        amount: -100000, timestamp: iso(invest), category: "transfer", status: "posted", method: "Internal transfer" })
+      add({ accountId: INVEST, merchant: "Transfer from Checking", descriptor: "INTERNAL XFER",
+        amount: 100000, timestamp: iso(invest), category: "transfer", status: "posted", method: "Internal transfer" })
+    }
+
+    // Joint savings contribution on the 3rd
+    const joint = onDom(3, 9, 20)
+    if (joint) {
+      add({ accountId: CHECKING, merchant: "Transfer to Joint Savings", descriptor: "INTERNAL XFER",
+        amount: -75000, timestamp: iso(joint), category: "transfer", status: "posted", method: "Internal transfer" })
+      add({ accountId: JOINT, merchant: "Transfer from Checking", descriptor: "INTERNAL XFER",
+        amount: 75000, timestamp: iso(joint), category: "transfer", status: "posted", method: "Internal transfer" })
+    }
+
+    // Business rent on the 1st
+    const wework = onDom(1, 7, 0)
+    if (wework) {
+      add({ accountId: BUSINESS, merchant: "WeWork SOMA", descriptor: "WEWORK ACH SOMA", amount: -185000,
+        timestamp: iso(wework), category: "housing", status: "posted", method: "ACH payment",
+        recurringId: "rec_weworksoma" })
+    }
+
+    // Credit-card autopay on the 25th — out of checking, onto the card
+    const autopay = onDom(25, 8, 0)
+    if (autopay) {
+      add({ accountId: CHECKING, merchant: "Maple Credit Payment", descriptor: "MAPLE CARD AUTOPAY",
+        amount: -85000, timestamp: iso(autopay), category: "transfer", status: "posted", method: "ACH payment" })
+      add({ accountId: CREDIT, merchant: "Payment Received", descriptor: "MAPLE CARD AUTOPAY",
+        amount: 85000, timestamp: iso(autopay), category: "transfer", status: "posted", method: "ACH payment" })
+    }
+
+    // Interest credits on every savings-kind account on the 28th
+    const interest = onDom(28, 5, 0)
+    if (interest) {
+      const post = (accountId: string, base: number) =>
+        add({ accountId, merchant: "Interest Earned", descriptor: "INTEREST PAYMENT",
+          amount: base + Math.floor(rand() * 400), timestamp: iso(interest), category: "income",
+          status: "posted", method: "Interest credit" })
+      post(SAVINGS, 9900); post(JOINT, 5200); post(MONEYMARKET, 19100)
+    }
+
+    // Quarterly dividend into Maple Invest
+    const dividend = onDom(27, 6, 30)
+    if (dividend && monthsBack % 3 === 0) {
+      add({ accountId: INVEST, merchant: "Vanguard Dividend", descriptor: "VANGUARD DIV VTI",
+        amount: 18400 + Math.floor(rand() * 9000), timestamp: iso(dividend), category: "income",
+        status: "posted", method: "Dividend" })
+    }
+  }
+
+  // The memorable one-offs
+  for (const x of ONE_OFFS) {
+    add({ accountId: x.account, merchant: x.merchant, descriptor: x.descriptor, amount: x.cents,
+      timestamp: iso(daysAgo(anchor, x.d, 11 + (x.d % 7), 7 + (x.d % 50))), category: x.category,
+      status: "posted", location: "San Francisco, CA", ...(x.card ? { cardId: x.card } : {}) })
+  }
+
+  // Annual bonus, then most of it parked in the money market the next morning
+  add({ accountId: CHECKING, merchant: "Acme Corp Bonus", descriptor: "ACME CORP BONUS",
+    amount: 1500000, timestamp: iso(daysAgo(anchor, 95, 9, 1)), category: "income", status: "posted",
+    method: "ACH deposit" })
+  add({ accountId: CHECKING, merchant: "Transfer to Money Market", descriptor: "INTERNAL XFER",
+    amount: -1000000, timestamp: iso(daysAgo(anchor, 94, 9, 30)), category: "transfer", status: "posted",
+    method: "Internal transfer" })
+  add({ accountId: MONEYMARKET, merchant: "Transfer from Checking", descriptor: "INTERNAL XFER",
+    amount: 1000000, timestamp: iso(daysAgo(anchor, 94, 9, 30)), category: "transfer", status: "posted",
+    method: "Internal transfer" })
+
+  // Quarterly estimated taxes out of the business account
+  for (const day of [30, 120]) {
+    add({ accountId: BUSINESS, merchant: "IRS Estimated Tax", descriptor: "IRS USATAXPYMT",
+      amount: -680000, timestamp: iso(daysAgo(anchor, day, 7, 45)), category: "other", status: "posted",
+      method: "ACH payment" })
   }
 
   add({ accountId: CHECKING, merchant: "Amazon", descriptor: "AMZN Refund", amount: 3499,
@@ -137,6 +306,10 @@ export function buildSeed(anchor: Date = new Date()): SeedData {
     { d: 41, h: 2,  m: 9,  merchant: "7-Eleven",   descriptor: "7-ELEVEN 33418",      cents: -1240, category: "groceries", account: CHECKING, card: "card_physical" },
     { d: 48, h: 0,  m: 15, merchant: "McDonald's", descriptor: "MCDONALDS F2241",     cents: -1485, category: "dining",    account: CHECKING, card: "card_physical" },
     { d: 57, h: 1,  m: 22, merchant: "Amazon",     descriptor: "AMZN MKTP US",        cents: -3850, category: "shopping",  account: CREDIT,   card: "card_virtual" },
+    { d: 74, h: 0,  m: 51, merchant: "DoorDash",   descriptor: "DOORDASH*ORDER 3310", cents: -3690, category: "dining",    account: CHECKING, card: "card_physical" },
+    { d: 92, h: 1,  m: 12, merchant: "Uber",       descriptor: "UBER *TRIP",          cents: -3150, category: "transport", account: CHECKING, card: "card_physical" },
+    { d: 118, h: 2, m: 4,  merchant: "Uber Eats",  descriptor: "UBER EATS SF",        cents: -4210, category: "dining",    account: CHECKING, card: "card_physical" },
+    { d: 149, h: 0, m: 36, merchant: "Taco Bell",  descriptor: "TACO BELL 7042",      cents: -1610, category: "dining",    account: CHECKING, card: "card_physical" },
   ]
   for (const x of LATE_NIGHT) {
     add({ accountId: x.account, cardId: x.card, merchant: x.merchant, descriptor: x.descriptor,
@@ -158,10 +331,16 @@ export function buildSeed(anchor: Date = new Date()): SeedData {
       accountNumber: "•••• •••• 4471", routingNumber: "•••••• 021", sparkline: spark(rand, 941220) },
     { id: SAVINGS, name: "Maple Savings", kind: "savings", mask: "8820", balance: 2814135, apy: 4.25,
       accountNumber: "•••• •••• 8820", routingNumber: "•••••• 021", sparkline: spark(rand, 2814135) },
+    { id: JOINT, name: "Maple Joint Savings", kind: "savings", mask: "6114", balance: 1523060, apy: 4.1,
+      accountNumber: "•••• •••• 6114", routingNumber: "•••••• 021", sparkline: spark(rand, 1523060) },
     { id: CREDIT, name: "Maple Credit", kind: "credit", mask: "0934", balance: -128840, apy: 0,
       accountNumber: "•••• •••• 0934", sparkline: spark(rand, 128840) },
     { id: INVEST, name: "Maple Invest", kind: "investing", mask: "5567", balance: 1864200,
       accountNumber: "•••• •••• 5567", sparkline: spark(rand, 1864200) },
+    { id: BUSINESS, name: "Maple Business Checking", kind: "checking", mask: "3308", balance: 2247915,
+      accountNumber: "•••• •••• 3308", routingNumber: "•••••• 021", sparkline: spark(rand, 2247915) },
+    { id: MONEYMARKET, name: "Maple Money Market", kind: "savings", mask: "7702", balance: 5031240, apy: 4.6,
+      accountNumber: "•••• •••• 7702", routingNumber: "•••••• 021", sparkline: spark(rand, 5031240) },
   ]
 
   const cards: Card[] = [
@@ -169,6 +348,8 @@ export function buildSeed(anchor: Date = new Date()): SeedData {
       expMonth: 8, expYear: 28, frozen: false, spendLimit: 500000, design: "graphite" },
     { id: "card_virtual", accountId: CREDIT, type: "virtual", network: "visa", mask: "0934",
       expMonth: 3, expYear: 27, frozen: false, spendLimit: 250000, design: "amber" },
+    { id: "card_business", accountId: BUSINESS, type: "physical", network: "mastercard", mask: "3308",
+      expMonth: 11, expYear: 28, frozen: false, spendLimit: 1000000, design: "forest" },
   ]
 
   const payees: Payee[] = [
@@ -176,19 +357,35 @@ export function buildSeed(anchor: Date = new Date()): SeedData {
     { id: "pay_landlord", name: "Mission St Property", kind: "biller", mask: "ACH" },
     { id: "pay_pge", name: "PG&E", kind: "biller", mask: "utility" },
     { id: "pay_mom", name: "Mom", kind: "person" },
+    { id: "pay_comcast", name: "Comcast Xfinity", kind: "biller", mask: "utility" },
+    { id: "pay_sfwater", name: "SF Water Power Sewer", kind: "biller", mask: "utility" },
+    { id: "pay_alex", name: "Alex Rivera", kind: "person", mask: "zelle" },
+    { id: "pay_dana", name: "Dana Whitfield", kind: "person", mask: "venmo" },
+    { id: "pay_maplecard", name: "Maple Credit Autopay", kind: "biller", mask: "autopay" },
+    { id: "pay_wework", name: "WeWork SOMA", kind: "biller", mask: "ACH" },
   ]
 
   const scheduled: ScheduledPayment[] = [
     { id: "sch_rent", payeeId: "pay_landlord", payeeName: "Mission St Property", amount: -285000,
       nextDate: iso(nextDom(anchor, 1)), cadence: "monthly" },
+    { id: "sch_wework", payeeId: "pay_wework", payeeName: "WeWork SOMA", amount: -185000,
+      nextDate: iso(nextDom(anchor, 1)), cadence: "monthly" },
     { id: "sch_pge", payeeId: "pay_pge", payeeName: "PG&E", amount: -8640,
       nextDate: iso(nextDom(anchor, 15)), cadence: "monthly" },
+    { id: "sch_comcast", payeeId: "pay_comcast", payeeName: "Comcast Xfinity", amount: -8999,
+      nextDate: iso(nextDom(anchor, 17)), cadence: "monthly" },
+    { id: "sch_water", payeeId: "pay_sfwater", payeeName: "SF Water Power Sewer", amount: -6420,
+      nextDate: iso(nextDom(anchor, 20)), cadence: "monthly" },
+    { id: "sch_cc_autopay", payeeId: "pay_maplecard", payeeName: "Maple Credit Autopay", amount: -85000,
+      nextDate: iso(nextDom(anchor, 25)), cadence: "monthly" },
   ]
 
   const goals: Goal[] = [
     { id: "goal_japan", name: "Japan trip", target: 500000, saved: 312000, icon: "plane" },
     { id: "goal_emergency", name: "Emergency fund", target: 1000000, saved: 740000, icon: "shield" },
     { id: "goal_mac", name: "New MacBook", target: 250000, saved: 90000, icon: "laptop" },
+    { id: "goal_house", name: "House down payment", target: 15000000, saved: 6480000, icon: "home" },
+    { id: "goal_wedding", name: "Wedding fund", target: 3000000, saved: 1150000, icon: "heart" },
   ]
 
   const notifications: Notification[] = [
@@ -200,6 +397,22 @@ export function buildSeed(anchor: Date = new Date()): SeedData {
       at: iso(dd), read: false },
     { id: "ntf_4", kind: "security", title: "New device signed in", body: "MacBook Pro · San Francisco",
       at: iso(daysAgo(anchor, 2, 22, 10)), read: true },
+    { id: "ntf_5", kind: "deposit", title: "Interest earned", body: "Interest posted to 3 savings accounts",
+      at: iso(daysAgo(anchor, 2, 5, 0)), read: false },
+    { id: "ntf_6", kind: "alert", title: "Credit autopay scheduled", body: "$850.00 · Maple Credit on the 25th",
+      at: iso(daysAgo(anchor, 3, 8, 0)), read: false },
+    { id: "ntf_7", kind: "card", title: "Large purchase at West Elm", body: "$2,325.00 · Maple Credit ·· 0934",
+      at: iso(daysAgo(anchor, 23, 12, 30)), read: true },
+    { id: "ntf_8", kind: "deposit", title: "Stripe payout received", body: "Deposit to Maple Business Checking",
+      at: iso(daysAgo(anchor, 5, 8, 30)), read: true },
+    { id: "ntf_9", kind: "alert", title: "Japan trip goal at 62%", body: "$3,120.00 of $5,000.00 saved",
+      at: iso(daysAgo(anchor, 6, 9, 0)), read: true },
+    { id: "ntf_10", kind: "alert", title: "Statement ready", body: "Your Maple Credit statement is available",
+      at: iso(daysAgo(anchor, 8, 7, 0)), read: true },
+    { id: "ntf_11", kind: "transfer", title: "Transfer completed", body: "$750.00 to Maple Joint Savings",
+      at: iso(daysAgo(anchor, 9, 9, 20)), read: true },
+    { id: "ntf_12", kind: "security", title: "Password changed", body: "Your Maple password was updated",
+      at: iso(daysAgo(anchor, 31, 16, 45)), read: true },
   ]
 
   return { accounts, transactions: txns, cards, payees, scheduled, goals, notifications }

--- a/examples/demo-bank/src/server/users.ts
+++ b/examples/demo-bank/src/server/users.ts
@@ -1,7 +1,7 @@
 /**
  * Maple's seeded demo identities — real Auth.js authentication with zero
- * external services. Two users are seeded so per-user isolation (threads,
- * grants, approvals) is demonstrable; both share the single demo password so
+ * external services. Four users are seeded so per-user isolation (threads,
+ * grants, approvals) is demonstrable; all share the single demo password so
  * one env knob (`MAPLE_DEMO_PASSWORD`) covers deployment.
  *
  * Everything here must stay edge-safe (Web Crypto + env only): the Next proxy
@@ -40,6 +40,16 @@ function seededIdentities(): MapleDemoUser[] {
       subject: "maple-mia",
       display: "Mia Nakamura",
       email: "mia@maple.com",
+    },
+    {
+      subject: "maple-sam",
+      display: "Sam Okafor",
+      email: "sam@maple.com",
+    },
+    {
+      subject: "maple-dana",
+      display: "Dana Whitfield",
+      email: "dana@maple.com",
     },
   ];
 }


### PR DESCRIPTION
Deepens the Maple demo-bank seed so a stress-test of ~15 fintech use cases finds rich, realistic data everywhere. All data stays deterministic (mulberry32(20260629), anchored dates, no Date.now()).

## Totals

| Surface | Before | After |
| --- | --- | --- |
| Accounts | 4 | **7** (checking, savings, joint savings, credit, investing, business checking, money market) |
| Transactions | ~250 (90 days) | **932** at the fixed test anchor / **908 served live** (180 days) |
| Cards | 2 | **3** (adds business Mastercard) |
| Payees | 4 | **10** |
| Scheduled payments | 2 | **6** |
| Goals | 3 | **5** |
| Notifications | 4 | **12** |
| Seeded users | 2 | **4** (adds sam@maple.com, dana@maple.com) |
| Automations per user | 3 | **6** (4 enabled, 2 disabled; varied crons) |
| Runs per user | ~13 (3 weeks) | **32** over 6 weeks (29 ok, 3 error) |
| Audit events per user | ~40 | **99** (chat reads by rule/grant/judge/default, 2 asks approved, 1 deny, 1 org-blocked MCP transfer) |

Console totals across the 4 users: 24 automations, 128 runs, 396 audit events — verified idempotent (second run writes 0).

## Patterns in the bank data

Biweekly payroll + savings sweep, rent on the 1st, three mid-month utilities, 10 monthly subscriptions, weekly grocery runs, daily dining/coffee/transport noise, business revenue twice a month with weekday SaaS/supplies expenses, quarterly IRS estimated tax, monthly interest on all three savings-kind accounts, monthly credit-card autopay + auto-invest transfers, an annual bonus parked into the money market, 8 large one-offs (flight, furniture, MacBook…), and an expanded late-night spending pattern. The planted **$87.00 DoorDash at 1:14 AM** remains, and remains the most recent transaction.

## Tests touched (expectations only)

- `seed.test.ts` — account count 4 → 7; volume floor 120 → 900
- `api.test.ts` — /api/accounts count 4 → 7
- `users.test.ts` — roster `[vendo-demo, maple-mia]` → `[vendo-demo, maple-mia, maple-sam, maple-dana]` (two assertions)

The $87 DoorDash plant assertions are untouched and pass.

## Verification

- `pnpm exec turbo run build --filter=demo-bank` ✅
- `VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2 pnpm --filter demo-bank test` — 26 files, 111 tests, all green ✅
- `pnpm --filter demo-bank lint` — 0 errors (1 pre-existing unrelated warning) ✅
- Booted `PORT=3400 pnpm dev` and hit the live APIs: `/maple/api/accounts` → 7 accounts; paged `/maple/api/transactions` → 908 transactions, newest = DoorDash −$87.00 ✅
- `pnpm seed:console -- --data-dir /tmp/...` run twice: 24/128/396 written, then 0/0/0 (idempotent) ✅ — local only, no `--cloud`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the Maple `demo-bank` seed to six months of deterministic, realistic activity and a richer console history to better cover personal and business use cases. Adds new accounts, users, and deeper automation history while keeping seeds idempotent.

- **New Features**
  - 6 months of deterministic history (~930 txns; ~908 via API).
  - Accounts/cards: adds joint savings, business checking, money market (7 total) and a business Mastercard (3 cards).
  - Users: adds `sam@maple.com` and `dana@maple.com` (4 total).
  - Realistic cycles: biweekly payroll + savings sweep; rent/utilities/subscriptions; weekly groceries; business revenue/expenses; monthly interest, credit autopay, auto‑invest; quarterly taxes; large one‑offs; expanded late‑night pattern (the $87 DoorDash remains most recent).
  - Console data: 6 automations per user (2 paused), ~6 weeks of runs (32/user; with a few errors), ~100 audit events/user including approvals and a policy‑blocked MCP transfer; remains idempotent.

- **Migration**
  - No breaking changes. Optionally re-seed console data locally with `pnpm seed:console`.

<sup>Written for commit c4a27ce2a228b608134a4537bab387aa4a636b2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

