### PR TITLE
Envelope-miss retry hints and plan-vocabulary leak hardening in genui

### DIFF
--- a/.changeset/plan-vocabulary-and-envelope-hints.md
+++ b/.changeset/plan-vocabulary-and-envelope-hints.md
@@ -1,0 +1,24 @@
+---
+"@vendoai/core": patch
+"@vendoai/apps": patch
+---
+
+Two generation-hardening fixes, both aimed at a model correcting itself instead
+of an app failing outright:
+
+- **The `.data` envelope binding miss now names the fix.** When a binding reads
+  a field that is actually one level down, under the tool's own `data` field
+  (`sum(accounts, "balance")` where `accounts` is `{ data: [...] }`), the fact
+  check's "the real fields are: data" message now also says which path to use
+  instead (`accounts.data.balance`) — the fix-it retry gets the exact
+  correction rather than just the shape.
+- **The plan's own vocabulary no longer leaks into a shipped app as an unknown
+  component.** A worker filling a group, or the brain writing a whole app in
+  one shot, occasionally copies the PLAN's own wrapper syntax
+  (`<Leaf component="Stat" query="..." purpose="...">`, `<Group>`) verbatim
+  into the markup it writes. `skeleton.ts`'s `withoutPlanVocabulary` already
+  stripped `query`/`purpose` off a fill fragment's props; it now also resolves
+  a stray `<Leaf component="X">` to the `X` it names and a stray `<Group>` to
+  the `Stack` it always meant, and the same pass now also runs on the DIRECT
+  create path (`validateCompiledCreate`), which has no fill fragment and
+  previously had no defence against this at all.

--- a/packages/apps/src/generation/skeleton.test.ts
+++ b/packages/apps/src/generation/skeleton.test.ts
@@ -8,9 +8,9 @@
  * PREFIX of the plan must mint the same ids as the skeleton of the whole plan,
  * so a plan arriving group by group makes the UI GROW instead of re-mounting.
  */
-import { validateTree, type AppPlan } from "@vendoai/core";
+import { VENDO_TREE_FORMAT, validateTree, type AppPlan, type Tree } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
-import { growSkeleton, skeletonFromPlan } from "./skeleton.js";
+import { growSkeleton, skeletonFromPlan, spliceFragment } from "./skeleton.js";
 
 const plan = (groups: AppPlan["groups"], extra: Partial<AppPlan> = {}): AppPlan => ({
   name: "Invoices",
@@ -210,5 +210,82 @@ describe("growSkeleton", () => {
       { name: "invoices", tool: "host_listInvoices", input: {} },
       { name: "payments", tool: "host_listPayments", input: {} },
     ]);
+  });
+});
+
+describe("spliceFragment", () => {
+  const base: Tree = {
+    formatVersion: VENDO_TREE_FORMAT,
+    root: "app",
+    nodes: [
+      { id: "app", component: "Stack", source: "prewired", children: ["slot"] },
+      { id: "slot", component: "Stack", source: "prewired", children: [] },
+    ],
+  };
+
+  it("strips the plan's query/purpose vocabulary off a worker-written node's props", () => {
+    const fragment: Tree = {
+      formatVersion: VENDO_TREE_FORMAT,
+      root: "root",
+      nodes: [
+        { id: "root", component: "Stack", source: "generated", children: ["stat-1"] },
+        {
+          id: "stat-1",
+          component: "Stat",
+          source: "generated",
+          props: { label: "Total", value: 5, query: "invoices", purpose: "the total" },
+        },
+      ],
+    };
+    const spliced = spliceFragment(base, "slot", fragment);
+    expect(spliced.nodes.find((node) => node.id === "slot-stat-1")?.props).toEqual({ label: "Total", value: 5 });
+  });
+
+  it("resolves a worker's <Leaf component=...> copy-paste to the real component it names", () => {
+    const fragment: Tree = {
+      formatVersion: VENDO_TREE_FORMAT,
+      root: "root",
+      nodes: [
+        { id: "root", component: "Stack", source: "generated", children: ["leaf-1"] },
+        {
+          id: "leaf-1",
+          component: "Leaf",
+          source: "generated",
+          props: { component: "Stat", query: "invoices", purpose: "the total", label: "Total" },
+        },
+      ],
+    };
+    const spliced = spliceFragment(base, "slot", fragment);
+    const leaf = spliced.nodes.find((node) => node.id === "slot-leaf-1");
+    expect(leaf?.component).toBe("Stat");
+    expect(leaf?.props).toEqual({ label: "Total" });
+  });
+
+  it("resolves a worker's <Group> copy-paste to the Stack it always meant", () => {
+    const fragment: Tree = {
+      formatVersion: VENDO_TREE_FORMAT,
+      root: "root",
+      nodes: [
+        { id: "root", component: "Stack", source: "generated", children: ["group-1"] },
+        { id: "group-1", component: "Group", source: "generated", children: [] },
+      ],
+    };
+    const spliced = spliceFragment(base, "slot", fragment);
+    expect(spliced.nodes.find((node) => node.id === "slot-group-1")?.component).toBe("Stack");
+  });
+
+  it("never touches a host node's props or component name — a host may call either whatever it likes", () => {
+    const fragment: Tree = {
+      formatVersion: VENDO_TREE_FORMAT,
+      root: "root",
+      nodes: [
+        { id: "root", component: "Stack", source: "generated", children: ["host-1"] },
+        { id: "host-1", component: "Leaf", source: "host", props: { query: "kept", purpose: "kept", component: "kept" } },
+      ],
+    };
+    const spliced = spliceFragment(base, "slot", fragment);
+    const hostNode = spliced.nodes.find((node) => node.id === "slot-host-1");
+    expect(hostNode?.component).toBe("Leaf");
+    expect(hostNode?.props).toEqual({ query: "kept", purpose: "kept", component: "kept" });
   });
 });

--- a/packages/apps/src/generation/skeleton.ts
+++ b/packages/apps/src/generation/skeleton.ts
@@ -246,20 +246,39 @@ const subtree = (byId: ReadonlyMap<string, TreeNode>, roots: readonly string[]):
 };
 
 /**
- * `query` and `purpose` are the PLAN's vocabulary for describing a leaf, not
- * props any component takes — and a worker reading its own group's leaf list
- * routinely copies them onto the element it writes. The renderer drops them and
- * the checks report them, which is just noise about something no one can act on,
- * so they come off here.
+ * `<Leaf component="...">` and `<Group>` are the PLAN's own wrapper tags, and
+ * `query`/`purpose` are the PLAN's vocabulary for describing a leaf — none of
+ * it is real component markup, but a worker reading its own group's leaf list
+ * (or the brain writing a whole app in one shot) routinely copies the plan's
+ * syntax onto the element it writes instead of the real thing the plan asked
+ * for. The renderer drops what it does not recognise and the checks report
+ * the rest as an unknown component, which is just noise about something no
+ * one can act on, so both come off here: a `<Leaf component="Stat">` becomes
+ * the `Stat` it names, a `<Group>` becomes the `Stack` it always meant, and
+ * `query`/`purpose`/the now-consumed `component` come off every node's props.
  *
- * Only on nodes the worker itself invented: a `source: "host"` node names a real
- * host component, and a host is entitled to declare a prop called whatever it
- * likes — silently deleting one would be the worse bug.
+ * Only on nodes the worker itself invented: a `source: "host"` node names a
+ * real host component, and a host is entitled to declare a prop — or a
+ * component — called whatever it likes; silently rewriting one would be the
+ * worse bug.
  */
-const withoutPlanVocabulary = (node: TreeNode): TreeNode["props"] => {
-  if (node.source === "host" || node.props === undefined) return node.props;
-  const { query: _query, purpose: _purpose, ...props } = node.props as Record<string, unknown>;
-  return props as TreeNode["props"];
+export const withoutPlanVocabulary = (node: TreeNode): TreeNode => {
+  if (node.source === "host") return node;
+  const props = node.props as Record<string, unknown> | undefined;
+  const renamed = node.component === "Leaf" && typeof props?.component === "string"
+    ? props.component
+    : node.component === "Group"
+      ? "Stack"
+      : undefined;
+  if (props === undefined) {
+    return renamed === undefined ? node : { ...node, component: renamed };
+  }
+  const { query: _query, purpose: _purpose, component: _component, ...rest } = props;
+  return {
+    ...node,
+    ...(renamed === undefined ? {} : { component: renamed }),
+    props: rest as TreeNode["props"],
+  };
 };
 
 /**
@@ -279,7 +298,7 @@ export const spliceFragment = (tree: Tree, slotNodeId: string, fragment: Tree): 
   if (slot === undefined) return tree;
   const stale = subtree(byId, slot.children ?? []);
   const namespaced = (id: string): string => `${slotNodeId}-${id}`;
-  const landing = fragment.nodes.filter((node) => node.id !== fragment.root);
+  const landing = fragment.nodes.filter((node) => node.id !== fragment.root).map(withoutPlanVocabulary);
   const nodes = tree.nodes.flatMap((node) => {
     if (stale.has(node.id)) return [];
     if (node.id !== slotNodeId) return [node];
@@ -291,7 +310,6 @@ export const spliceFragment = (tree: Tree, slotNodeId: string, fragment: Tree): 
         ...child,
         id: namespaced(child.id),
         ...(child.children === undefined ? {} : { children: child.children.map(namespaced) }),
-        ...(child.props === undefined ? {} : { props: withoutPlanVocabulary(child) }),
       })),
     ];
   });

--- a/packages/apps/src/generation/validation/validate.test.ts
+++ b/packages/apps/src/generation/validation/validate.test.ts
@@ -1,0 +1,33 @@
+/**
+ * validateCompiledCreate (generation pipeline, create path). The direct path
+ * (the brain writing a whole app in one shot, conductor.ts's documentFromWire)
+ * has no fill worker and no spliceFragment to catch it copying its OWN plan
+ * vocabulary — skeleton.ts's withoutPlanVocabulary — so the same defence has
+ * to run here too, before any check reads the compiled tree.
+ */
+import { compileWire, type NormalizedCatalog } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { scriptedLanguageModel } from "../../testing/scripted-model.js";
+import { asTree, type GenerationDependencies, type HostToolInfo } from "../engine.js";
+import { validateCompiledCreate } from "./validate.js";
+
+const catalog: NormalizedCatalog = [];
+const tools: HostToolInfo[] = [];
+
+const deps = (): GenerationDependencies => ({
+  model: scriptedLanguageModel(() => '<App name="unused"/>'),
+  catalog,
+  tools,
+});
+
+describe("validateCompiledCreate", () => {
+  it("resolves a direct-mode <Leaf component=...>/<Group> copy-paste instead of failing it as an unknown component", async () => {
+    const wire = '<App name="Balance"><Group><Leaf component="Text" query="accounts" purpose="the balance" text="All good"/></Group></App>';
+    const compiled = compileWire(wire, {});
+    const { document, issues } = await validateCompiledCreate(compiled, deps());
+    expect(issues).toEqual([]);
+    const nodes = asTree(document?.tree as NonNullable<typeof document>["tree"]).nodes;
+    expect(nodes.map((node) => node.component).sort()).toEqual(["Stack", "Stack", "Text"]);
+    expect(nodes.find((node) => node.component === "Text")?.props).toEqual({ text: "All good" });
+  });
+});

--- a/packages/apps/src/generation/validation/validate.ts
+++ b/packages/apps/src/generation/validation/validate.ts
@@ -36,6 +36,7 @@ import {
   type GeneratedAppDocument,
   type GenerationDependencies,
 } from "../engine.js";
+import { withoutPlanVocabulary } from "../skeleton.js";
 import { prepareIslands } from "./islands.js";
 import { smokeRenderIslands } from "./smoke-render.js";
 
@@ -60,19 +61,24 @@ export const validateCompiledCreate = async (
   } else if (name.length > APP_NAME_MAX_CHARS) {
     issues.push(`App name="${name}" is ${name.length} characters — name is the app's display title (at most ${APP_NAME_MAX_CHARS} characters); write a short human title, never the request echoed back`);
   }
+  // The direct path (the brain writing a whole app in one shot) has no fill
+  // worker and no spliceFragment to catch it copying its OWN plan syntax
+  // (skeleton.ts's withoutPlanVocabulary) — so the same defence runs here,
+  // on every node the compile produced, before any check reads them.
+  const tree = { ...compiled.tree, nodes: compiled.tree.nodes.map(withoutPlanVocabulary) };
   const prepared = await prepareIslands(compiled.components, deps.tools, deps.catalog.map(({ name: componentName }) => componentName), requestText);
   const components = Object.keys(prepared.components).length === 0 ? undefined : prepared.components;
   issues.push(...prepared.issues);
-  issues.push(...unknownToolIssues(compiled.tree, deps.tools).map(factIssueLine));
+  issues.push(...unknownToolIssues(tree, deps.tools).map(factIssueLine));
   issues.push(...compiled.bindingErrors.map((error) =>
     `binding ${error.path} on node "${error.nodeId}" prop "${error.prop}": ${error.message}${error.available === undefined ? "" : ` (available: ${error.available.join(", ")})`}`));
-  issues.push(...bindingKindIssues(compiled.tree, deps).map(factIssueLine));
-  issues.push(...kitSlotIssues(compiled.tree, deps).map(factIssueLine));
-  issues.push(...hostReshapeIssues(compiled.tree, deps).map(factIssueLine));
-  issues.push(...exprIssues(compiled.tree, deps).map(factIssueLine));
-  issues.push(...queryInputIssues(compiled.tree).map(factIssueLine));
-  issues.push(...interpolationIssues(compiled.tree).map(factIssueLine));
-  issues.push(...(await catalogIssues(compiled.tree, components, deps.catalog)).map(factIssueLine));
+  issues.push(...bindingKindIssues(tree, deps).map(factIssueLine));
+  issues.push(...kitSlotIssues(tree, deps).map(factIssueLine));
+  issues.push(...hostReshapeIssues(tree, deps).map(factIssueLine));
+  issues.push(...exprIssues(tree, deps).map(factIssueLine));
+  issues.push(...queryInputIssues(tree).map(factIssueLine));
+  issues.push(...interpolationIssues(tree).map(factIssueLine));
+  issues.push(...(await catalogIssues(tree, components, deps.catalog)).map(factIssueLine));
   if (issues.length > 0) return { issues };
   // The smoke-render gate (crash classes the 2026-07-21 gate shipped: React
   // #310 hooks-in-map, undefined names, unguarded-data throws). Runs LAST,
@@ -92,7 +98,7 @@ export const validateCompiledCreate = async (
     format: VENDO_APP_FORMAT,
     name,
     ui: "tree",
-    tree: asPayload(structuredClone(compiled.tree)),
+    tree: asPayload(structuredClone(tree)),
     ...(components === undefined ? {} : {
       components: structuredClone(components),
       // The compiler-stamped per-island tool manifest (least privilege: an

--- a/packages/core/src/genui/expr.test.ts
+++ b/packages/core/src/genui/expr.test.ts
@@ -57,15 +57,26 @@ const clientsShape: ShapeType = {
   items: { kind: "object", fields: { id: { kind: "string" }, name: { kind: "string" } } },
 };
 
+/** A REST-envelope tool: rows sit under "data", the top-level object's only
+ *  other field is "total" — the shape TOOL RESPONSE SHAPES already teaches. */
+const accountsShape: ShapeType = {
+  kind: "object",
+  fields: {
+    data: { kind: "array", items: { kind: "object", fields: { id: { kind: "string" }, balance: { kind: "number" } } } },
+    total: { kind: "number" },
+  },
+};
+
 const shapes: Record<string, ShapeType> = {
   invoices: invoicesShape,
   clients: clientsShape,
   metrics: { kind: "object", fields: { total_cents: { kind: "number" }, label: { kind: "string" } } },
   logs: { kind: "array", items: { kind: "json" } },
+  accounts: accountsShape,
 };
 
 const context: ExprCheckContext = {
-  queryNames: ["invoices", "clients", "metrics", "unsampled", "logs"],
+  queryNames: ["invoices", "clients", "metrics", "unsampled", "logs", "accounts"],
   shapeOf: (name) => shapes[name],
 };
 
@@ -266,6 +277,13 @@ describe("checkExpr", () => {
     expect(issue).toContain("client_name");
     expect(issue).toContain("string");
     expect(issue).toContain("amount_cents");
+  });
+
+  it("hints the .data envelope when the field really lives one level down", () => {
+    const [issue] = checkExpr('sum(accounts, "balance")', context);
+    expect(issue).toContain("balance");
+    expect(issue).toContain("accounts.data.balance");
+    expect(issue).toContain('"data" field');
   });
 
   it("reports every other slot whose type cannot compute", () => {

--- a/packages/core/src/genui/expr.ts
+++ b/packages/core/src/genui/expr.ts
@@ -847,6 +847,18 @@ type ShapeWalk =
 const numericFields = (fields: Record<string, ShapeType>): string[] =>
   Object.entries(fields).filter(([, field]) => field.kind === "number").map(([name]) => name);
 
+/** A field missing at the top level is often sitting one envelope down: many
+ *  host tools wrap their rows as `{ data: [...] }` (the REST convention
+ *  TOOL RESPONSE SHAPES already teaches). When the object's own "data" field
+ *  — or its array items — really carries the field the model reached for,
+ *  say so by name instead of leaving it to guess from the sibling list. */
+const envelopeField = (fields: Record<string, ShapeType>, head: string): string | undefined => {
+  const envelope = fields["data"];
+  if (envelope === undefined) return undefined;
+  const inner = envelope.kind === "array" ? envelope.items : envelope;
+  return inner.kind === "object" && inner.fields[head] !== undefined ? "data" : undefined;
+};
+
 const walkShape = (
   shape: ShapeType,
   segments: readonly string[],
@@ -862,7 +874,11 @@ const walkShape = (
   if (shape.kind === "object") {
     const field = shape.fields[head];
     if (field === undefined) {
-      return { ok: false, issue: `"${head}" is absent from ${at} — the real fields are: ${Object.keys(shape.fields).join(", ")}` };
+      const envelope = envelopeField(shape.fields, head);
+      const hint = envelope === undefined
+        ? ""
+        : ` — this tool wraps its rows in a "${envelope}" field, so read ${[...consumed, envelope, head].join(".")} instead`;
+      return { ok: false, issue: `"${head}" is absent from ${at} — the real fields are: ${Object.keys(shape.fields).join(", ")}${hint}` };
     }
     return walkShape(field, rest, [...consumed, head], shape.fields);
   }


### PR DESCRIPTION
## Summary
- `sum(accounts, "balance")` against a tool that returns `{ data: [...] }` now gets told the real path (`accounts.data.balance`), not just the top-level field list — the fix-it retry can self-heal instead of guessing (`packages/core/src/genui/expr.ts`).
- A worker (or the brain, writing a whole app in one shot) that copies the PLAN's own wrapper syntax (`<Leaf component="X" query="..." purpose="...">`, `<Group>`) into real markup no longer ships as an "unknown component" — it resolves to the `X`/`Stack` it always meant. This already partly existed for the multi-group fill path (`spliceFragment`); it's now extended to also strip the newly-consumed `component` prop, and applied to the direct create path (`validateCompiledCreate`), which had no equivalent defense before.

## Why
Root-caused from a production/dev-server failure log: real user threads and background chip-pregeneration both hit "app build failed" on these two exact signatures — a REST envelope binding miss, and the plan's own `<Leaf>`/`<Group>`/`query=`/`purpose=` tokens leaking into generated output as unknown components. Neither mechanism was a regression from any recent merge (traced through git history), but both are real, recurring generation-quality gaps worth hardening.

## Test plan
- [x] `packages/core/src/genui/expr.test.ts` — new case proves the envelope hint; reverted the fix and watched it go red, restored, green.
- [x] `packages/apps/src/generation/skeleton.test.ts` — new `spliceFragment` cases for query/purpose stripping, Leaf→component rename, Group→Stack rename, and the host-node bypass; reverted and watched the two rename cases go red, restored, green.
- [x] `packages/apps/src/generation/validation/validate.test.ts` (new file) — proves the direct-create path resolves the same leak (reproduces the exact "references unknown component" error from the original log when reverted).
- [x] `pnpm typecheck` clean on `@vendoai/core` and `@vendoai/apps`.
- [x] `node scripts/dependency-guard.mjs` clean.
- All test runs capped at `VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2`, scoped to the affected test files only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened generation in `@vendoai/core` and `@vendoai/apps` to self-correct common binding mistakes and stop PLAN syntax from leaking into shipped UI. Adds precise envelope hints and resolves `<Leaf>`/`<Group>` copies to real components.

- **Bug Fixes**
  - Envelope miss hinting: when a field really lives under a tool’s `.data` envelope, the check now suggests the full path (e.g., `accounts.data.balance`) so fix-it retries can auto-correct.
  - Plan vocabulary stripping: normalize copied PLAN wrappers — `<Leaf component="X">` becomes `X`, `<Group>` becomes `Stack`, and `query`/`purpose`/`component` props are removed. Applied during fragment splicing and in the direct create path to avoid “unknown component” errors.

<sup>Written for commit 26ec5d5f71dbee298fc68e16a87ab4eb4aa1af38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

