### PR TITLE
fix(examples): deterministic weather fixture in ai-sdk-agent

### DIFF
--- a/examples/ai-sdk-agent/e2e/weather-fixture.test.ts
+++ b/examples/ai-sdk-agent/e2e/weather-fixture.test.ts
@@ -1,0 +1,15 @@
+import { expect, it } from "vitest";
+
+import { getWeather } from "../lib/vendo";
+
+// The generated app re-runs `getWeather` at build time, and the gen checks
+// block any app whose live query data contradicts what the model already told
+// the user in chat. A random fixture made the README's dashboard step fail on
+// nearly every run — the demo data must be stable per city.
+it("getWeather returns the same weather for the same city every call", async () => {
+  for (const city of ["Paris", "London", "Tokyo"]) {
+    const first = await getWeather(city);
+    const second = await getWeather(city);
+    expect(second).toEqual(first);
+  }
+});

--- a/examples/ai-sdk-agent/lib/vendo.ts
+++ b/examples/ai-sdk-agent/lib/vendo.ts
@@ -7,12 +7,16 @@ import { createVendo } from "@vendoai/vendo/server";
 
 /** The quickstart's weather lookup, registered as a Vendo action
  *  (`host_get_weather`, risk `read` — the cautious policy runs it and audits
- *  it). Same fake data as the AI SDK quickstart's inline tool. */
+ *  it). Fake data like the AI SDK quickstart's inline tool, but deterministic
+ *  per city: the generated app re-runs this query at build time, and the gen
+ *  checks block any app whose live data contradicts what the model already
+ *  told the user — random data failed the README's dashboard step on nearly
+ *  every run. */
 export async function getWeather(city: string) {
-  const temperature = Math.round(Math.random() * (90 - 32) + 32);
-  const conditions = ["sunny", "cloudy", "rainy", "snowy"][
-    Math.floor(Math.random() * 4)
-  ];
+  let hash = 0;
+  for (const ch of city.toLowerCase()) hash = (hash * 31 + ch.charCodeAt(0)) % 1009;
+  const temperature = 32 + (hash % 59);
+  const conditions = ["sunny", "cloudy", "rainy", "snowy"][hash % 4];
   return { city, temperature, conditions };
 }
 


### PR DESCRIPTION
## What

`getWeather` in the ai-sdk-agent example returned random data on every call. The generated app re-runs it at build time, and the gen checks (correctly) block any app whose live query data contradicts what the model already told the user in chat — so the README's demo step 2 ("Make me a dashboard…") failed on nearly every run. This hashes the city name instead, so every call returns the same reading.

## Proof

- Red-proof test `e2e/weather-fixture.test.ts`: two calls per city must return the same reading — fails on the random implementation (verified red before the fix, green after).
- Live BYO run (real browser, direct Anthropic key, no Vendo Cloud): before the fix, two consecutive dashboard builds blocked with `the query data does not match the user's specification` (e.g. "user was told Paris is 62°F/Cloudy, query returned 83°F/cloudy"). After the fix, re-queried data matches the narration and the honesty blocks are gone.

## What this does NOT fix

With consistent data, dashboard builds on current main still fail in the generation stage itself (invalid wire code: `cities.map`/`Math.round` invented as tools, brace-interpolation in text, hard-coded superlative badges). Filed separately with full logs — this PR removes only the fixture-induced failure.

Scoped gate: example e2e suite (capped forks/threads), typecheck, lint — all green. Full suite rides CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `getWeather` deterministic per city in the `ai-sdk-agent` example to prevent dashboard builds from failing when live query data conflicts with the chat narration. City names are hashed to produce stable temperature and conditions; adds an e2e test to lock this in.

- **Bug Fixes**
  - Replace random weather with city-hash-based values in `examples/ai-sdk-agent/lib/vendo.ts` (`host_get_weather` via `@vendoai/vendo/server`).
  - Add `e2e/weather-fixture.test.ts` to assert two calls per city return the same result.

<sup>Written for commit 683ce88eaf7fe902843a939fbb845967ca5ffd51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

