### PR TITLE
fix(apps,core): teach direct-mode dialect rules, retry a failed direct answer (#822 defect 1)

### DIFF
--- a/.changeset/direct-mode-idiom-gap.md
+++ b/.changeset/direct-mode-idiom-gap.md
@@ -1,0 +1,27 @@
+---
+"@vendoai/core": patch
+"@vendoai/apps": patch
+---
+
+Closes the two gaps behind #822's defect 1 (the canonical "compare weather in
+three cities" dashboard failing persistently on the BYO default model):
+
+- **The brain's direct-mode prompt now teaches the wire's real constraints.**
+  `brainPrompt` had almost no dialect-syntax teaching for a direct (single-shot)
+  answer — the fill-worker prompt had it, but a "tiny ask" never reaches a
+  worker. The model reached for JS idioms the wire rejects: a method-call tool
+  name (`cities.map`, `Math.round`), braces as text interpolation, and a loop
+  variable with no declared query behind it. `brainPrompt`'s rules now say so
+  explicitly, and that a fixed small set of named rows reads by array
+  position off its query, never a loop.
+- **A direct answer that fails to compile now gets a retry.** `conductCreate`
+  had a fix-it loop for every other outcome (`checkAndFix`, bounded at
+  `FIX_ROUNDS`) except this one: a direct answer with ANY compile mistake
+  (unknown tool, braces-in-text, an undeclared reference) returned
+  `kind: "failure"` on the very first try, with no chance to self-heal from
+  the compiler's own message. It now retries up to `FIX_ROUNDS` times, feeding
+  the brain its own wire and exactly what was wrong with it — the same
+  teaching-sentence discipline `fixInstruction` already uses.
+- **The wire's "unknown-reference" issue now names the declared queries**, the
+  same way "unknown tool" already lists the real tools — a retry (from either
+  fix above) gets something to pick from instead of guessing again.

--- a/packages/apps/src/generation/brain.test.ts
+++ b/packages/apps/src/generation/brain.test.ts
@@ -80,6 +80,18 @@ describe("the brain", () => {
     expect(validateTree(compiled.tree).ok).toBe(true);
   });
 
+  it("warns off the JS idioms a direct write reaches for: method-call tool names, text interpolation, and loop variables", async () => {
+    let prompt = "";
+    await runBrainTurn({ instruction: "show my outstanding total" }, depsWith((call) => {
+      prompt = promptText(call);
+      return TINY_APP;
+    }));
+
+    expect(prompt).toContain('never a method call like "cities.map" or "Math.round"');
+    expect(prompt).toContain("<Text>{x}</Text> is refused outright");
+    expect(prompt).toContain("there is no loop variable");
+  });
+
   it("plans a normal ask, read through compilePlan", async () => {
     const result = await runBrainTurn({ instruction: "an invoices workspace" }, depsWith(PLAN));
 

--- a/packages/apps/src/generation/conductor.test.ts
+++ b/packages/apps/src/generation/conductor.test.ts
@@ -1,0 +1,63 @@
+/**
+ * The direct outcome's own fix-it loop (issue #822, defect 1): a direct
+ * answer that reaches for a JS idiom the wire rejects (a method-call tool
+ * name, an undeclared reference) used to be a single dead end — the one
+ * outcome in conductCreate with no retry at all.
+ */
+import type { NormalizedCatalog } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { conductCreate } from "./conductor.js";
+import { scriptedLanguageModel, type ScriptedModelCall } from "../testing/scripted-model.js";
+import type { GenerationDependencies, HostToolInfo } from "./engine.js";
+
+const catalog: NormalizedCatalog = [];
+
+const tools: HostToolInfo[] = [
+  { name: "host_listCities", description: "Weather for a set of named cities.", risk: "read" },
+];
+
+const depsWith = (...responses: Parameters<typeof scriptedLanguageModel>): GenerationDependencies => ({
+  model: scriptedLanguageModel(...responses),
+  catalog,
+  tools,
+});
+
+const promptText = (call: ScriptedModelCall): string => call.prompt.map((message) => {
+  if (typeof message.content === "string") return message.content;
+  return message.content.map((part) => part.text ?? "").join("");
+}).join("\n");
+
+// A JS-idiom mistake the wire rejects: "cities.map" is not a real tool.
+const BROKEN = '<App name="Weather"><Query id="citiesMap" tool="cities.map"/><Text text="Paris"/></App>';
+const FIXED = '<App name="Weather"><Query id="cities" tool="host_listCities"/><Text text={cities.0.name}/></App>';
+
+describe("conductCreate — the direct outcome's fix-it loop", () => {
+  it("retries a direct answer that fails to compile, feeding back exactly what was wrong, and ships the fixed one", async () => {
+    const prompts: string[] = [];
+    const result = await conductCreate({ prompt: "weather dashboard" }, depsWith((call) => {
+      prompts.push(promptText(call));
+      return prompts.length === 1 ? BROKEN : FIXED;
+    }));
+
+    // Calls beyond the second (the retry) are checkAndFix's own AI reviewer
+    // pass over the now-valid app — a separate concern from this loop.
+    expect(prompts.length).toBeGreaterThanOrEqual(2);
+    expect(prompts[1]).toContain("does not compile");
+    expect(prompts[1]).toContain(BROKEN);
+    expect(prompts[1]).toContain('unknown tool "cities.map"');
+    expect(result.kind).toBe("app");
+  });
+
+  it("gives up after FIX_ROUNDS retries instead of looping forever on a model that never fixes it", async () => {
+    let calls = 0;
+    const result = await conductCreate({ prompt: "weather dashboard" }, depsWith(() => {
+      calls += 1;
+      return BROKEN;
+    }));
+
+    // One first attempt plus FIX_ROUNDS retries — bounded, never unbounded.
+    expect(calls).toBe(3);
+    expect(result.kind).toBe("failure");
+    expect(result.kind === "failure" && result.issues.some((issue) => issue.includes('unknown tool "cities.map"'))).toBe(true);
+  });
+});

--- a/packages/apps/src/generation/conductor.ts
+++ b/packages/apps/src/generation/conductor.ts
@@ -194,6 +194,17 @@ const fixInstruction = (findings: readonly Finding[]): string => [
   ...findings.map(({ where, message }) => (where === undefined ? `- ${message}` : `- ${where}: ${message}`)),
 ].join("\n");
 
+/** What the brain is told when a DIRECT answer failed to compile. There is no
+ *  valid tree yet, so there is nothing to hand back as an <Edit> target
+ *  (fixInstruction's job) — the brain gets the ask again, its own wire, and
+ *  exactly what was wrong with it, the same teaching-sentence discipline. */
+const directRewriteInstruction = (request: string, wire: string, issues: readonly string[]): string => [
+  `${request}`,
+  "Your last answer does not compile. Answer again from scratch — directly, or as a plan if that now fits better — fixing every problem below; do not repeat them.",
+  `WHAT YOU WROTE:\n${wire}`,
+  `WHAT WAS WRONG WITH IT:\n${issues.map((issue) => `- ${issue}`).join("\n")}`,
+].join("\n\n");
+
 /**
  * Run the checking layer and hand every BLOCKING finding back to the brain as
  * an instruction, up to {@link FIX_ROUNDS} times. Whatever survives is returned
@@ -383,14 +394,42 @@ export const conductCreate = async (
     return { kind: "cannot", reasons: outcome.reasons, session: turn.session };
   }
   if (outcome.kind === "direct") {
-    const built = await documentFromWire(outcome.wire, deps, input.prompt);
+    let wire = outcome.wire;
+    let built = await documentFromWire(wire, deps, input.prompt);
+    let session = turn.session;
+    // A direct answer that fails to compile used to be a single dead end —
+    // the one outcome in this module with no retry at all, so a model that
+    // reaches for a JS idiom the wire rejects (a method-call tool name,
+    // braces in text, an undeclared reference) failed the WHOLE build on the
+    // first try. This mirrors checkAndFix's bounded loop, for the case
+    // checkAndFix cannot help with: there is no valid tree yet to hand back
+    // as an <Edit> target.
+    for (let round = 0; built.document === undefined && round < FIX_ROUNDS; round += 1) {
+      const retry = await runBrainTurn({
+        instruction: directRewriteInstruction(input.prompt, wire, built.issues),
+        session,
+      }, deps);
+      session = retry.session;
+      if (retry.outcome?.kind === "cannot") return { kind: "cannot", reasons: retry.outcome.reasons, session };
+      if (retry.outcome?.kind === "plan") {
+        return buildPlan({
+          plan: retry.outcome.plan,
+          skeleton: skeletonFromPlan(retry.outcome.plan),
+          request: input.prompt,
+          session,
+        }, deps, options);
+      }
+      if (retry.outcome?.kind !== "direct") break;
+      wire = retry.outcome.wire;
+      built = await documentFromWire(wire, deps, input.prompt);
+    }
     if (built.document === undefined) {
-      return { kind: "failure", issues: [...turn.issues, ...built.issues], session: turn.session };
+      return { kind: "failure", issues: [...turn.issues, ...built.issues], session };
     }
     const checked = await checkAndFix({
       document: withId(built.document),
       request: input.prompt,
-      session: turn.session,
+      session,
     }, deps, checkingFor(deps, {}, options.checks), options);
     return {
       kind: "app",

--- a/packages/apps/src/generation/prompts/brain.ts
+++ b/packages/apps/src/generation/prompts/brain.ts
@@ -49,6 +49,8 @@ One <Edit> per replacement, as many as the change needs. <Old> is copied EXACTLY
 
 THE RULES
 - Never invent data. Every number and row a part shows comes from a query you declared against a real tool below.
+- The app text is not JavaScript: no .map, no Math.*, no string interpolation, no loop variable. A <Query tool="..."> names one of the TOOLS below VERBATIM — never a method call like "cities.map" or "Math.round". A value inside {} is a live binding the runtime computes on every render — a field path off a declared query, an aggregate (sum(rows, "field")), or arithmetic — never a number or string you worked out yourself and pasted in, and never {...} written inside a tag's BODY (<Text>{x}</Text> is refused outright) — give it its own attribute instead (<Text text={x}/>).
+- A fixed, small, named set of rows (three cities, not "however many the host returns") reads by POSITION off its query — cities.0.temp, cities.1.temp — there is no loop variable. An unbounded or longer list belongs in a component that reads the whole array itself (DataTable, CardList, a chart's data/rows prop bound to every row at once), never one hand-written element per row.
 - When something is out of reach, say so in a <Cannot> line, in the person's own words. An honest refusal always beats a plausible fake.
 - Don't reach for <Island> or <Server> when a component and a query do the job — both are escapes, and the "why" has to be earned.
 - Last resort of all: <Server kind="box" served why="..."/> hands the WHOLE app surface to the sandbox, which deletes the app's own layout. Earn it only with an interaction no component and no island can express — dragging between columns, a rich-text editor. Never for a look, and never just to be safe.

--- a/packages/core/src/genui/wire/expression.test.ts
+++ b/packages/core/src/genui/wire/expression.test.ts
@@ -187,6 +187,11 @@ describe("parseExpression bindings", () => {
     expect(result.issues[0]?.message).toContain("mystery.total");
   });
 
+  it("lists the declared queries in an unknown-reference issue, so a retry can pick one instead of guessing again", () => {
+    const result = parse("mystery");
+    expect(result.issues[0]?.message).toContain("revenue, payments");
+  });
+
   it("compiles bindings nested inside arrays and objects", () => {
     expectValue("[revenue, state.tab]", [{ $path: "/revenue" }, { $state: "tab" }]);
     expectValue("{ points: revenue.total, active: state.tab }", {

--- a/packages/core/src/genui/wire/expression.ts
+++ b/packages/core/src/genui/wire/expression.ts
@@ -281,7 +281,7 @@ const lowerPath = (state: ParserState, node: ExprNode & { kind: "path" }): Json 
   return fail(
     state,
     "unknown-reference",
-    `"${node.text}" does not name a declared <Query> or state`,
+    `"${node.text}" does not name a declared <Query> or state; the queries are: ${[...state.queryNames].join(", ") || "(none declared)"} — there is no loop variable, so a fixed row reads by position off one of them (cities.0.temp)`,
   );
 };
 
@@ -344,7 +344,7 @@ const parseComputed = (state: ParserState): Json | Failed => {
   const unknown = exprPathHeads(node).filter((head) => !state.queryNames.has(head));
   if (unknown.length > 0) {
     for (const head of unknown) {
-      fail(state, "unknown-reference", `"${head}" does not name a declared <Query>`);
+      fail(state, "unknown-reference", `"${head}" does not name a declared <Query>; the queries are: ${[...state.queryNames].join(", ") || "(none declared)"}`);
     }
     return FAILED;
   }


### PR DESCRIPTION
## Summary

Fixes defect 1 of #822: the canonical "compare weather in Paris, London, Tokyo" dashboard failed 4/4 builder runs on the BYO default model with three general failure classes — JS-idiom tool names (`cities.map`, `Math.round`), braces-in-text treated as interpolation, and undeclared-reference loop variables. Fixed at the general level, no weather/city-specific patching:

1. **`brainPrompt` (`packages/apps/src/generation/prompts/brain.ts`) had almost no wire-syntax teaching for a direct (single-shot) answer.** The fill-worker prompt (`worker.ts`) already teaches the aggregate grammar and data-binding rules — but a "tiny ask" never reaches a worker, it's answered directly by the brain, which had none of that. Added three explicit rules: no JS idioms (`.map`, `Math.*`, string interpolation, loop variables), a `<Query tool="...">` must name a real tool verbatim, and a fixed small set of named rows reads by array position off its query (`cities.0.temp`) rather than looping.
2. **`conductCreate`'s direct outcome had zero retry.** Every other outcome in the module (`checkAndFix`) gets up to `FIX_ROUNDS` (2) fix-it rounds; a direct answer that failed to compile returned `kind: "failure"` on the very first try — the one dead end in the whole module. It now retries up to `FIX_ROUNDS` times, feeding the brain its own wire text and the exact compile issues, mirroring `checkAndFix`'s "a finding is already a teaching sentence" discipline. A retry that decides a plan fits better now falls through to the well-supported plan path instead of failing.
3. **The wire's `unknown-reference` issue now lists the declared queries**, the same way `unknown tool` already lists the real tool names — general teaching-quality improvement that also makes the new retry (and the plan-path's existing retry) converge faster instead of guessing again.

Note: `packages/apps/src/generation/conductor.ts` carries a `QUARANTINED` docstring (blueprint §14.2) marking it superseded by a new "lean loop + checks floor at paint seam" architecture, with callers "frozen, not extended." This PR fixes a correctness gap in currently-live functionality (confirmed still called from `runtime.ts:2488`, exercised by the reported issue on the SAME commit that introduced the quarantine) rather than adding a feature, but flagging this tension for review since the note is explicit about new work here.

## Test plan
- [x] `packages/apps/src/generation/brain.test.ts` — new case asserts the direct-mode system prompt carries the anti-idiom teaching; reverted, watched it go red, restored, green.
- [x] `packages/apps/src/generation/conductor.test.ts` (new file) — proves a broken direct answer retries and ships once fixed, and that the retry is bounded (gives up after `FIX_ROUNDS`, never loops forever); reverted the retry loop, watched both go red, restored, green.
- [x] `packages/core/src/genui/wire/expression.test.ts` — new case asserts `unknown-reference` lists the declared queries; reverted, red, restored, green.
- [x] `pnpm typecheck` clean on `@vendoai/core` and `@vendoai/apps`.
- [x] `node scripts/dependency-guard.mjs` clean.
- All test runs capped at `VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2`, scoped to the affected + directly neighboring test files (138 tests total, all green).

Defect 2 of #822 (the chat agent narrating a fabricated success after the build actually failed) is out of scope here — assigned to another agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teach the brain the wire rules for direct answers and add a bounded retry when a direct answer doesn’t compile, fixing #822 defect 1 where the “compare weather in three cities” dashboard failed on the BYO default model. Also improve unknown-reference errors to list declared queries for faster recovery.

- **Bug Fixes**
  - In `@vendoai/apps`, the direct-mode prompt now enforces wire constraints: no `.map`/`Math.*`/string interpolation/loop vars; `<Query tool="...">` must match a real tool; fixed small lists read by position (e.g., `cities.0.temp`).
  - In `@vendoai/apps`, `conductCreate` retries failed direct answers up to `FIX_ROUNDS`, feeding back the wire and exact compile issues; if a plan fits better, it falls through to the plan path.
  - In `@vendoai/core`, “unknown-reference” errors now list declared queries (mirrors “unknown tool”), reducing guesswork during retries.

<sup>Written for commit 0b184cb1f72070aceb849b90726ba9c9cd7fcd61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

