### PR TITLE
fix(apps): the box template bake re-stages the runner after cleanup (bake was broken on main)

### DIFF
--- a/packages/apps/box/build-template.mjs
+++ b/packages/apps/box/build-template.mjs
@@ -45,7 +45,6 @@ const PKG_DIR = "/opt/vendo-box/pkg";
 // removed again below — it is a build artifact, and .gitignore says so.
 process.chdir(here);
 const STAGED_RUNNER = "claude-turn.mjs";
-copyFileSync(path.join(here, "../dist/claude-turn.js"), path.join(here, STAGED_RUNNER));
 
 // ─── the app template, staged in for the same e2b reason ─────────────────────
 //
@@ -66,6 +65,10 @@ const cleanStaged = () => {
 };
 
 cleanStaged();
+// Stage the compiled turn runner AFTER cleanStaged() — it removes STAGED_RUNNER,
+// so staging it before the clean (as this script originally did) left the build
+// with no claude-turn.mjs to copy.
+copyFileSync(path.join(here, "../dist/claude-turn.js"), path.join(here, STAGED_RUNNER));
 const skipped = new Set(["node_modules", "dist", "package-lock.json"]);
 cpSync(SOURCE_TEMPLATE, stagedTemplate, {
   recursive: true,


### PR DESCRIPTION
## What

`packages/apps/box/build-template.mjs` staged the compiled turn runner (`claude-turn.mjs`) at the top of the script, then `cleanStaged()` deleted it again, and nothing re-staged it before `Template.build`. Every bake therefore failed at the copy step with:

```
[vendo-box] build failed: Error: No files found in .../packages/apps/box/claude-turn.mjs
```

The bake has been broken on main since #809. Fix: stage the runner **after** `cleanStaged()` runs.

## Why it wasn't caught

`build-template.mjs` drives a live e2b template build, so there is no CI test for it — the regression shipped green.

## Verification

Ran the full bake end-to-end after the fix; it built successfully:

```
[vendo-box] built template: h5pf20fap7ows6io81kr
```

Diff is a one-line reorder plus an explanatory comment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the box template bake by re-staging the compiled turn runner after cleanup so `claude-turn.mjs` is present for the copy step and builds succeed.

- **Bug Fixes**
  - Move runner staging to after `cleanStaged()` in `packages/apps/box/build-template.mjs`.
  - Add a brief comment on ordering; verified with a full end-to-end bake.

<sup>Written for commit f40709e8249e91799565f29c206e6146fc6498fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

