### PR TITLE
fix(agent): vendo_create_app ref is machine-marked "building", never success-shaped (#822 defect 2)

### DIFF
--- a/docs-site/existing-agents/embeds.mdx
+++ b/docs-site/existing-agents/embeds.mdx
@@ -18,7 +18,7 @@ envelope discriminated by `kind`:
 | Output | Meaning | Render with |
 | --- | --- | --- |
 | plain data | the guarded call executed cleanly; your model consumes it like any tool output | nothing |
-| `vendo/app-ref@1` `{ appId, title }` | an app is building; the build streams over the wire | `<VendoAppEmbed>` |
+| `vendo/app-ref@1` `{ appId, title, status: "building" }` | an app is building; the build streams over the wire | `<VendoAppEmbed>` |
 | `vendo/approval-ref@1` `{ approvalId, summary }` | the call parked for approval | `<VendoApprovalEmbed>` |
 
 You rarely dispatch on `kind` yourself: `<VendoToolResult output={...}>`

--- a/docs/superpowers/specs/2026-07-20-existing-agents-contracts.md
+++ b/docs/superpowers/specs/2026-07-20-existing-agents-contracts.md
@@ -23,7 +23,7 @@ the agent consumes it like any tool output, no embed).
 export const VENDO_APP_REF_KIND = "vendo/app-ref@1";
 export const VENDO_APPROVAL_REF_KIND = "vendo/approval-ref@1";
 
-interface VendoAppRef      { kind: "vendo/app-ref@1";      appId: AppId;           title: string }
+interface VendoAppRef      { kind: "vendo/app-ref@1";      appId: AppId;           title: string; status: "building" }
 interface VendoApprovalRef { kind: "vendo/approval-ref@1"; approvalId: ApprovalId; summary: string }
 type VendoToolEnvelope = VendoAppRef | VendoApprovalRef;
 ```
@@ -39,6 +39,12 @@ type VendoToolEnvelope = VendoAppRef | VendoApprovalRef;
   (the embed's chrome while the build streams). `summary` is one human-readable
   line describing what is waiting (Lane A derives it from the tool descriptor +
   input preview, same vocabulary as `ApprovalRequest.inputPreview`).
+- `status` on `VendoAppRef` is always the literal `"building"` — additive
+  field (runvendo/flowlet#822 defect 2), machine-readable so a calling model
+  cannot mistake the fast-return ref for a finished, describable app even if
+  it skims past the tool description. A terminally failed build is never
+  wrapped in this envelope at all — the tool's plain output (a `MakeReceipt`,
+  or an error outcome) carries the failure instead.
 
 ## 2. Public tool-pack API (`@vendoai/agent` types, umbrella subpaths)
 

--- a/packages/agent/src/pack.test.ts
+++ b/packages/agent/src/pack.test.ts
@@ -316,6 +316,53 @@ describe("vendo_create_app", () => {
     const { byName } = await pack({ implementations: hostTools() });
     expect(byName.has(VENDO_CREATE_APP_TOOL)).toBe(false);
   });
+
+  // runvendo/flowlet#822 defect 2: the fast ref wins the race against the
+  // build's real outcome on essentially every generation that streams any
+  // content before failing (the common case for a wire-validation failure).
+  // A calling model narrated three fabricated successes off an envelope that
+  // carried only an appId and a title — nothing distinguishing "accepted,
+  // outcome unknown" from "done". The envelope must say so itself, in a field
+  // a model cannot skim past, on BOTH the fast path and the (rarer) case
+  // where the build's own success outruns the stream.
+  it("the fast-path ref is machine-readable as still-building, not a finished resource", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const implementations = {
+      ...hostTools(),
+      [VENDO_MAKE_TOOL]: makeTool({ appId: "app_fast", name: "Weather dashboard", gate }),
+    };
+    const { byName } = await pack({ implementations });
+    const output = await byName.get(VENDO_CREATE_APP_TOOL)!.execute(
+      { prompt: "Compare weather in 3 cities" },
+      { ctx: ctx() },
+    );
+    const envelope = vendoAppRefSchema.parse(output);
+    expect(envelope.status).toBe("building");
+    release();
+  });
+
+  it("without a streamed view part, the ref built from the finished receipt is STILL marked building — this tool never tells the model a build is done", async () => {
+    const implementations = {
+      ...hostTools(),
+      [VENDO_MAKE_TOOL]: makeTool({ appId: "app_done", name: "Trip planner", stream: false }),
+    };
+    const { byName } = await pack({ implementations });
+    const output = await byName.get(VENDO_CREATE_APP_TOOL)!.execute(
+      { prompt: "plan my trip" },
+      { ctx: ctx() },
+    );
+    expect(vendoAppRefSchema.parse(output).status).toBe("building");
+  });
+
+  it("the tool description forbids narrating a build as done or inventing its contents", async () => {
+    const { byName } = await pack({
+      implementations: { ...hostTools(), [VENDO_MAKE_TOOL]: makeTool({ appId: "app_x", name: "x" }) },
+    });
+    const description = byName.get(VENDO_CREATE_APP_TOOL)!.description;
+    expect(description).toContain("building");
+    expect(description).toMatch(/never describe|never say it is created/i);
+  });
 });
 
 describe("vendo_delegate", () => {
@@ -358,6 +405,45 @@ describe("vendo_delegate", () => {
       { ctx: ctx() },
     ) as { status: string; refs: unknown[] };
     expect(output.status).toBe("error");
+    expect(output.refs).toEqual([]);
+  });
+
+  // runvendo/flowlet#822 defect 2, generalized: `vendo_make` answers a failed
+  // EDIT with an ok outcome whose MakeReceipt carries status:"failed" and a
+  // speakable `say` (agent-tools.ts's vendo_make handler) — a soft failure,
+  // never a throw, by design. Ref capture must not launder that failure into
+  // a bare {kind, appId, title} ref: an appId and a title are indistinguishable
+  // from a completed edit, so the delegate's caller would read this as one
+  // more successful change.
+  it("never turns a failed EDIT's receipt into a success-shaped ref", async () => {
+    const implementations = {
+      ...hostTools(),
+      [VENDO_MAKE_TOOL]: {
+        descriptor: makeTool({ appId: "app_edit", name: "Report app" }).descriptor,
+        execute: () => ({
+          id: "app_edit",
+          title: "Report app",
+          status: "failed",
+          say: "I couldn't make that change to Report app.",
+        } as unknown as Json),
+      },
+    };
+    const runner: AgentRunner = async (task, runCtx) => {
+      const outcome = await task.tools.execute(
+        { id: "call_edit", tool: VENDO_MAKE_TOOL, args: { request: "add a column", app: "app_edit" } },
+        runCtx,
+      );
+      expect(outcome.status).toBe("ok");
+      return { status: "ok", summary: "Couldn't make that change to Report app.", toolCalls: [] };
+    };
+    const { byName } = await pack({ implementations, runner });
+    const output = await byName.get(VENDO_DELEGATE_TOOL)!.execute(
+      { task: "add a column to the report" },
+      { ctx: ctx() },
+    ) as { status: string; refs: unknown[] };
+    expect(output.status).toBe("ok");
+    // No ref at all beats a false one: refs are read as "this exists and is
+    // fine", and a failed edit is neither.
     expect(output.refs).toEqual([]);
   });
 });

--- a/packages/agent/src/pack.ts
+++ b/packages/agent/src/pack.ts
@@ -103,10 +103,24 @@ function titleFromPrompt(prompt: unknown): string {
   return collapsed.length > TITLE_CAP ? `${collapsed.slice(0, TITLE_CAP - 1)}…` : collapsed;
 }
 
+/**
+ * A `MakeReceipt` carries its own honest status (`"ready" | "building" |
+ * "failed"`, `packages/core/src/make-receipt.ts`) and a speakable `say` line
+ * — exactly the two fields a failed edit needs to be reported as failed. A
+ * failed receipt must NEVER become a ref: the ref schema has no room for
+ * failure (runvendo/flowlet#822 defect 2, generalized) — an id and a title
+ * are the whole shape of "this exists and is fine". Returning null here lets
+ * the caller fall back to the receipt itself, `status` and `say` intact.
+ */
 function appRefFromReceipt(output: unknown, fallbackTitle: string): VendoAppRef | null {
   const receipt = makeReceiptSchema.safeParse(output);
-  if (!receipt.success) return null;
-  return { kind: VENDO_APP_REF_KIND, appId: receipt.data.id, title: receipt.data.title || fallbackTitle };
+  if (!receipt.success || receipt.data.status === "failed") return null;
+  return {
+    kind: VENDO_APP_REF_KIND,
+    appId: receipt.data.id,
+    title: receipt.data.title || fallbackTitle,
+    status: "building",
+  };
 }
 
 async function guardedExecute(
@@ -159,7 +173,7 @@ function wrapHostTool(registry: ToolRegistry, descriptor: ToolDescriptor): Vendo
 function createAppTool(registry: ToolRegistry, descriptor: ToolDescriptor): VendoPackTool {
   return {
     name: VENDO_CREATE_APP_TOOL,
-    description: "Create a Vendo app (generated UI) from a natural-language prompt. Returns fast with a vendo/app-ref@1 envelope meaning the build was ACCEPTED and is still streaming — the app is NOT built yet. Do not tell the user the app is created/ready/done; the embed shows live build progress and the final result (including any build failure) itself, so never wait for or report on build completion.",
+    description: "Create a Vendo app (generated UI) from a natural-language prompt. Returns fast with a vendo/app-ref@1 envelope carrying status \"building\" — the build was only ACCEPTED and is still streaming; you have not seen its contents and do not know yet whether it will succeed. Say only that you're building it (present tense, no specifics) and stop there. Never say it is created/ready/done, and never describe, list, or invent anything it will contain (no tables, no numbers, no chart data) — the embed shows real build progress and the true final result, including a build failure, and it will contradict anything you claim. If the build later fails, you will not be told in this reply; do not assume or claim success in a later turn either — check with the user or a read tool before describing this app again.",
     inputSchema: {
       $schema: DRAFT_2020_12,
       type: "object",
@@ -186,7 +200,7 @@ function createAppTool(registry: ToolRegistry, descriptor: ToolDescriptor): Vend
         value: (update: { id: string; part: { appId?: unknown } }) => {
           const appId = update?.part?.appId;
           if (typeof appId === "string" && appId.startsWith("app_")) {
-            resolveFast({ kind: VENDO_APP_REF_KIND, appId, title: fallbackTitle });
+            resolveFast({ kind: VENDO_APP_REF_KIND, appId, title: fallbackTitle, status: "building" });
           }
         },
       });

--- a/packages/agent/src/prompt.ts
+++ b/packages/agent/src/prompt.ts
@@ -8,6 +8,7 @@ If a call is blocked, explain the constraint and adapt your approach.
 If a call is queued for approval, say what is pending and continue where useful.
 Never claim a tool ran unless its result confirms that it did.
 Never invent tool outputs, records, or side effects.
+A tool result whose status is "building" (or otherwise not yet final) is not done — never say it succeeded, never describe or invent what it contains, and never report a build as anything but failed once its result says it failed.
 For away runs, clearly state what completed and what was left pending.
 When someone asks for something to look at, track, or use — a dashboard, a list, a recurring report — build them an app instead of describing the data in text; the building-apps skill is the manual.
 

--- a/packages/agent/src/tool-pack.test.ts
+++ b/packages/agent/src/tool-pack.test.ts
@@ -39,7 +39,7 @@ describe("tool-pack contract", () => {
   });
 
   it("pins vendo_delegate's plain-data result: report summary plus produced refs", () => {
-    const appRef: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_x", title: "Dashboard" };
+    const appRef: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_x", title: "Dashboard", status: "building" };
     const approvalRef: VendoApprovalRef = {
       kind: "vendo/approval-ref@1",
       approvalId: "apr_x",

--- a/packages/core/src/tool-envelopes.test.ts
+++ b/packages/core/src/tool-envelopes.test.ts
@@ -15,6 +15,7 @@ const appRef: VendoAppRef = {
   kind: "vendo/app-ref@1",
   appId: "app_dash",
   title: "Weather dashboard",
+  status: "building",
 };
 
 const approvalRef: VendoApprovalRef = {

--- a/packages/core/src/tool-envelopes.ts
+++ b/packages/core/src/tool-envelopes.ts
@@ -16,12 +16,21 @@ export const VENDO_APPROVAL_REF_KIND = "vendo/approval-ref@1" as const;
 /** `vendo_create_app` returned fast: the build was ACCEPTED and is still
  *  streaming over the wire — the app is NOT built yet. `<VendoAppEmbed>` mounts
  *  it by this ref and shows live build progress, the finished app, or the build
- *  failure itself, so the model must not claim the app is created/ready/done. */
+ *  failure itself, so the model must not claim the app is created/ready/done.
+ *  `status` is always `"building"` — a MACHINE-readable field, not prose, so a
+ *  model that skims past the tool description still cannot mistake this for a
+ *  finished, describable resource (runvendo/flowlet#822 defect 2: three
+ *  observed conversations narrated a fabricated, finished dashboard off an
+ *  envelope that carried an appId and a title and nothing telling the model
+ *  otherwise). A build that terminally fails is never wrapped in this ref —
+ *  see `appRefFromReceipt` in `@vendoai/agent`. */
 export interface VendoAppRef {
   kind: typeof VENDO_APP_REF_KIND;
   appId: AppId;
   /** Display title for the embed's chrome while the build streams. */
   title: string;
+  /** Always "building": this envelope never means done, win or lose. */
+  status: "building";
 }
 
 /** A guarded call parked on approval: the model sees "pending — the user must
@@ -41,6 +50,7 @@ export const vendoAppRefSchema = z.object({
   kind: z.literal(VENDO_APP_REF_KIND),
   appId: appIdSchema,
   title: z.string(),
+  status: z.literal("building"),
 }).passthrough() satisfies z.ZodType<VendoAppRef>;
 
 export const vendoApprovalRefSchema = z.object({

--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -2196,7 +2196,7 @@ function ByoEmbedScenario({ appId, title }: { appId: string; title: string }) {
       <div style={{ maxWidth: 640, margin: "0 auto", fontFamily: "Georgia, serif", display: "grid", gap: 12 }}>
         <p style={{ margin: 0 }}>User: make me a dashboard comparing the weather in three cities</p>
         <p style={{ margin: 0 }}>AI: building it now — it will appear below.</p>
-        <VendoToolResult output={{ kind: "vendo/app-ref@1", appId, title }} />
+        <VendoToolResult output={{ kind: "vendo/app-ref@1", appId, title, status: "building" }} />
         <p style={{ margin: 0 }} data-testid="after-embed">AI: let me know if you want more cities.</p>
       </div>
     </VendoProvider>

--- a/packages/ui/test/embed-contract.test.ts
+++ b/packages/ui/test/embed-contract.test.ts
@@ -13,7 +13,7 @@ import type {
 
 describe("embed prop contracts", () => {
   it("VendoAppEmbed takes the app-ref envelope verbatim", () => {
-    const refValue: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_x", title: "Dashboard" };
+    const refValue: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_x", title: "Dashboard", status: "building" };
     const props: VendoAppEmbedProps = { refValue };
     expect(props.refValue.appId).toBe("app_x");
   });
@@ -34,7 +34,7 @@ describe("embed prop contracts", () => {
     const props: VendoToolResultProps = { output: { delivered: true } };
     expect(parseVendoToolEnvelope(props.output)).toBeNull();
     const appProps: VendoToolResultProps = {
-      output: { kind: "vendo/app-ref@1", appId: "app_x", title: "Dashboard" },
+      output: { kind: "vendo/app-ref@1", appId: "app_x", title: "Dashboard", status: "building" },
     };
     expect(parseVendoToolEnvelope(appProps.output)?.kind).toBe("vendo/app-ref@1");
   });

--- a/packages/ui/test/embeds.test.tsx
+++ b/packages/ui/test/embeds.test.tsx
@@ -19,7 +19,7 @@ import { createWireServer } from "./wire-server.js";
 // use. The wire owns approval state; the embed renders it in place with the
 // existing failed/expired vocabulary — never a silent blank.
 
-const appRef: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_1", title: "Invoices" };
+const appRef: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_1", title: "Invoices", status: "building" };
 const approvalRef: VendoApprovalRef = {
   kind: "vendo/approval-ref@1",
   approvalId: "apr_1",
@@ -176,14 +176,14 @@ describe("existing-agents embeds", () => {
     });
 
     it("shows the build beat while the app is not yet servable", async () => {
-      const building: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_building", title: "Weather board" };
+      const building: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_building", title: "Weather board", status: "building" };
       mount(<VendoAppEmbed refValue={building} />);
       await waitFor(() => expect(screen.getByText(/Building/)).toBeDefined());
       expect(screen.getByText("Weather board")).toBeDefined();
     });
 
     it("polls the build window under the pending flag, so a miss is a 200 envelope and never a console 404", async () => {
-      const building: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_building", title: "Weather board" };
+      const building: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_building", title: "Weather board", status: "building" };
       mount(<VendoAppEmbed refValue={building} />);
       await waitFor(() => {
         const polls = wire.requests.filter(item => item.path.startsWith("/apps/app_building/open"));
@@ -195,7 +195,7 @@ describe("existing-agents embeds", () => {
     });
 
     it("resolves the failed vocabulary WITH the reason promptly when the build terminally fails (#492)", async () => {
-      const doomed: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_doomed", title: "Budget tracker" };
+      const doomed: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_doomed", title: "Budget tracker", status: "building" };
       // The build turn threw server-side: open() now answers {kind:"failed"}
       // instead of an eternal pending, so the embed resolves on the FIRST poll
       // rather than waiting for APP_BUILD_DEADLINE_MS.
@@ -246,7 +246,7 @@ describe("existing-agents embeds", () => {
       "says the CONSUMER sentence, never the developer's, for: %s",
       async (reason) => {
         const appId = `app_voice_${developerReasons.indexOf(reason)}`;
-        const doomed: VendoAppRef = { kind: "vendo/app-ref@1", appId, title: "Spending board" };
+        const doomed: VendoAppRef = { kind: "vendo/app-ref@1", appId, title: "Spending board", status: "building" };
         wire.state.failedApps.set(appId, { reason, retryable: true, prompt: "A spending board" });
         mount(<VendoAppEmbed refValue={doomed} />);
         await waitFor(() => expect(screen.getByText(BUILD_FAILURE_COPY)).toBeDefined());
@@ -268,7 +268,7 @@ describe("existing-agents embeds", () => {
     );
 
     it("shows a retry BUTTON when the terminal failure is retryable — never a dead embed (speed-core, criterion 8)", async () => {
-      const doomed: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_retry", title: "Retry tracker" };
+      const doomed: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_retry", title: "Retry tracker", status: "building" };
       // The shape the build watchdog persists: terminal, retryable, with the
       // original prompt riding the record so the retry re-issues it exactly.
       wire.state.failedApps.set("app_retry", {
@@ -285,7 +285,7 @@ describe("existing-agents embeds", () => {
     });
 
     it("retry re-issues the create with the persisted prompt and resolves into the fresh build", async () => {
-      const doomed: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_retry2", title: "Net worth…" };
+      const doomed: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_retry2", title: "Net worth…", status: "building" };
       wire.state.failedApps.set("app_retry2", {
         reason: "the build never finished",
         retryable: true,
@@ -307,7 +307,7 @@ describe("existing-agents embeds", () => {
     });
 
     it("actions on the retried app target the REPLACEMENT app id, never the dead record (checker F5)", async () => {
-      const doomed: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_dead", title: "Refresh board" };
+      const doomed: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_dead", title: "Refresh board", status: "building" };
       wire.state.failedApps.set("app_dead", {
         reason: "the build never finished",
         retryable: true,
@@ -327,7 +327,7 @@ describe("existing-agents embeds", () => {
     });
 
     it("retry falls back to the embed title when the failed record predates the prompt field", async () => {
-      const doomed: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_retry3", title: "Budget board" };
+      const doomed: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_retry3", title: "Budget board", status: "building" };
       wire.state.failedApps.set("app_retry3", { reason: "generation failed", retryable: true });
       mount(<VendoAppEmbed refValue={doomed} />);
       fireEvent.click(await screen.findByRole("button", { name: "Try again" }));
@@ -337,7 +337,7 @@ describe("existing-agents embeds", () => {
     });
 
     it("a failed retry resolves back to the failed vocabulary with the retry button, never a blank", async () => {
-      const doomed: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_retry4", title: "Alerts inbox" };
+      const doomed: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_retry4", title: "Alerts inbox", status: "building" };
       wire.state.failedApps.set("app_retry4", { reason: "generation failed", retryable: true, prompt: "An alerts inbox" });
       wire.state.failures.push({
         method: "POST",
@@ -354,7 +354,7 @@ describe("existing-agents embeds", () => {
     });
 
     it("resolves the build beat into the app when the build lands mid-poll", async () => {
-      const late: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_late", title: "Late app" };
+      const late: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_late", title: "Late app", status: "building" };
       mount(<VendoAppEmbed refValue={late} />);
       await waitFor(() => expect(screen.getByText(/Building/)).toBeDefined());
       // The build lands: the app becomes servable on a later poll.
@@ -378,7 +378,7 @@ describe("existing-agents embeds", () => {
       // eternal pending into the failed beat at its bound.
       vi.useFakeTimers();
       try {
-        const masked: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_masked", title: "Masked app" };
+        const masked: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_masked", title: "Masked app", status: "building" };
         const pendingClient: VendoClient = {
           ...client,
           apps: {
@@ -408,7 +408,7 @@ describe("existing-agents embeds", () => {
       // absolute deadline timer depends on nothing but the clock.
       vi.useFakeTimers();
       try {
-        const hung: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_hung", title: "Hung app" };
+        const hung: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_hung", title: "Hung app", status: "building" };
         const hangingClient: VendoClient = {
           ...client,
           apps: {


### PR DESCRIPTION
## Root cause

`vendo_create_app` (`packages/agent/src/pack.ts`) returns fast: it races a
`fast` promise (resolves the instant the FIRST streamed view part carries an
appId — i.e. as soon as the model emits any content) against `settled` (the
real build outcome). Because streaming starts well before wire/gate
validation can fail a build, `fast` wins essentially every time a build later
fails — the model is handed `{ kind: "vendo/app-ref@1", appId, title }`, an
object indistinguishable in shape from a genuinely finished, describable
resource. `settled`'s honest failure is silently discarded
(`settled.catch(() => undefined)`) and never reaches the model. The only
defense was prose in the tool description ("do not tell the user the app is
created/ready/done") — which a model narrating three fabricated dashboards
(#822) demonstrably ignored.

A second, directly reproducible instance of the same "success-shaped result
on failure" defect: `appRefFromReceipt` unconditionally converted ANY
`MakeReceipt` into a bare `{ appId, title }` ref, discarding the receipt's own
`status`/`say` fields. A `vendo_make` **edit** that fails returns an *ok*
outcome with `status: "failed"` and a speakable `say` (by design, non-
throwing) — and `vendo_delegate`'s ref capture turned that into a plain
`vendo/app-ref@1` envelope with no failure indication at all. Proven with a
red test (`packages/agent/src/pack.test.ts`, "never turns a failed EDIT's
receipt into a success-shaped ref") that fails against the pre-fix code with
a real `vendo/app-ref@1` ref for a failed edit.

## Fix (general — applies to every `vendo_create_app`/`vendo_delegate` caller)

- `VendoAppRef` (`packages/core/src/tool-envelopes.ts`) now carries a
  mandatory `status: "building"` literal — a machine-readable field, not
  prose, so a model that skims past the description still can't mistake the
  fast ref for a finished resource. Additive within the frozen `@1` envelope
  contract (`.passthrough()` schema; doc + spec updated).
- `appRefFromReceipt` (`packages/agent/src/pack.ts`) now returns `null` for a
  failed `MakeReceipt`, so the caller falls back to the honest receipt itself
  (`status`/`say` intact) instead of a bare success-shaped ref.
- The `vendo_create_app` tool description now explicitly forbids describing,
  listing, or inventing anything the app "will contain" and states the model
  will not be told later if the build fails.
- Added the same explicit rule to Vendo's own internal system prompt
  (`packages/agent/src/prompt.ts`) as defense in depth for the first-party
  loop.

## Proof

`packages/agent/src/pack.test.ts` — 4 new tests:
- the fast-path ref carries `status: "building"`
- the settled-success ref (no stream) is still `status: "building"` (this
  tool never claims done)
- the tool description contains the honesty rule
- `vendo_delegate` never turns a failed edit's receipt into a success-shaped
  ref (`refs` stays empty rather than lying)

Red-proofed: stashed the fix, reran — all 4 new assertions failed (the
delegate test failed with a real `{ kind: "vendo/app-ref@1", appId: "app_edit", title: "Report app" }`
in `refs` for a failed edit); restored the fix — green.

```
VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2 \
  pnpm --filter @vendoai/agent test -- pack.test.ts   # 221 passed
```

## Test plan

- [x] `pnpm build` — 27/27 green
- [x] `pnpm typecheck` — 48/48 green
- [x] `pnpm lint` — green (1 pre-existing unrelated warning in demo-bank)
- [x] Scoped, capped tests green: `@vendoai/core`, `@vendoai/agent`,
      `@vendoai/apps`, `@vendoai/vendo`, `@vendoai/ui` — all pass in
      isolation. The only test failures anywhere in a full-suite run are
      pre-existing and unrelated to this change (confirmed identical on a
      clean `origin/main` checkout): `packages/core/src/packaging.e2e.test.ts`
      (missing packed artifact), `packages/vendo/src/dev-creds/model.test.ts`
      (host `@ai-sdk/anthropic` module resolution), `packages/store` drill
      fixtures, and two `next build` scheduling collisions
      (`mastra-agent`/`genui-bench`, "another next build process is already
      running" under concurrent load).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes success-shaped results: `vendo_create_app` now returns an app ref that is explicitly marked as still building, and failed edits no longer produce success-looking refs. This prevents models from narrating “done” dashboards when the build later fails.

- **Bug Fixes**
  - Added required `status: "building"` to `vendo/app-ref@1` in `@vendoai/core`.
  - `vendo_create_app` always returns a ref with `status: "building"` (both fast and settled paths) in `@vendoai/agent`.
  - `appRefFromReceipt` returns null for failed `MakeReceipt` values; `vendo_delegate` now surfaces the honest receipt instead of a ref.
  - Tightened tool copy and the system prompt to forbid describing or inventing unbuilt app contents.
  - Updated docs and tests across `@vendoai/agent`, `@vendoai/ui`, and site content.

- **Migration**
  - If you construct `vendo/app-ref@1` envelopes, include `status: "building"`.
  - If you expected a ref from a failed `vendo_make` edit, expect none; handle the receipt’s `status`/`say` instead.

<sup>Written for commit cd0de2484935d595941f1f78c2841c5ed833cdc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

