### PR TITLE
fix(apps): teach direct-mode single-<App>-wrapper rule, reinforce on retry

### DIFF
--- a/.changeset/direct-mode-single-app-wrapper.md
+++ b/.changeset/direct-mode-single-app-wrapper.md
@@ -1,0 +1,12 @@
+---
+"@vendoai/apps": patch
+---
+
+Follow-up to #823: with the JS-idiom mistakes gone, "expected a single <App
+...>...</App> element" became the dominant direct-mode failure — the model's
+answer wasn't wrapped in exactly one root `<App>` element. `brainPrompt` now
+states that rule explicitly, quoting the wire compiler's own error text, and
+the direct-mode retry loop's own instruction repeats it for the retry
+specifically. This failure was already reaching `conductCreate`'s #823 retry
+loop like any other compile issue (confirmed by test) — the gap was purely
+that nothing taught the model the rule in the first place.

--- a/packages/apps/src/generation/brain.test.ts
+++ b/packages/apps/src/generation/brain.test.ts
@@ -92,6 +92,17 @@ describe("the brain", () => {
     expect(prompt).toContain("there is no loop variable");
   });
 
+  it("teaches that a direct answer is exactly one root <App> element, naming the wire's own rule and error text", async () => {
+    let prompt = "";
+    await runBrainTurn({ instruction: "show my outstanding total" }, depsWith((call) => {
+      prompt = promptText(call);
+      return TINY_APP;
+    }));
+
+    expect(prompt).toContain("exactly ONE <App");
+    expect(prompt).toContain('"expected a single <App ...>...</App> element."');
+  });
+
   it("plans a normal ask, read through compilePlan", async () => {
     const result = await runBrainTurn({ instruction: "an invoices workspace" }, depsWith(PLAN));
 

--- a/packages/apps/src/generation/conductor.test.ts
+++ b/packages/apps/src/generation/conductor.test.ts
@@ -31,6 +31,13 @@ const promptText = (call: ScriptedModelCall): string => call.prompt.map((message
 const BROKEN = '<App name="Weather"><Query id="citiesMap" tool="cities.map"/><Text text="Paris"/></App>';
 const FIXED = '<App name="Weather"><Query id="cities" tool="host_listCities"/><Text text={cities.0.name}/></App>';
 
+// Not wrapped in a single root <App>: the tag opening the answer reads as
+// "<App" by naive substring search (so the brain's own extraction still
+// treats it as a direct answer) but is really a different, longer tag name —
+// the same mismatch a model produces when it answers with a root element
+// that merely STARTS WITH "App" instead of writing the literal wrapper.
+const UNWRAPPED = '<Applet name="Weather"><Text text="Paris"/></Applet>\n</App>';
+
 describe("conductCreate — the direct outcome's fix-it loop", () => {
   it("retries a direct answer that fails to compile, feeding back exactly what was wrong, and ships the fixed one", async () => {
     const prompts: string[] = [];
@@ -45,6 +52,19 @@ describe("conductCreate — the direct outcome's fix-it loop", () => {
     expect(prompts[1]).toContain("does not compile");
     expect(prompts[1]).toContain(BROKEN);
     expect(prompts[1]).toContain('unknown tool "cities.map"');
+    expect(result.kind).toBe("app");
+  });
+
+  it("retries a direct answer that is not wrapped in a single root <App>, naming the rule in the fed-back instruction", async () => {
+    const prompts: string[] = [];
+    const result = await conductCreate({ prompt: "weather dashboard" }, depsWith((call) => {
+      prompts.push(promptText(call));
+      return prompts.length === 1 ? UNWRAPPED : FIXED;
+    }));
+
+    expect(prompts.length).toBeGreaterThanOrEqual(2);
+    expect(prompts[1]).toContain("does not compile");
+    expect(prompts[1]).toContain('expected a single <App ...>...</App> element');
     expect(result.kind).toBe("app");
   });
 

--- a/packages/apps/src/generation/conductor.ts
+++ b/packages/apps/src/generation/conductor.ts
@@ -200,7 +200,7 @@ const fixInstruction = (findings: readonly Finding[]): string => [
  *  exactly what was wrong with it, the same teaching-sentence discipline. */
 const directRewriteInstruction = (request: string, wire: string, issues: readonly string[]): string => [
   `${request}`,
-  "Your last answer does not compile. Answer again from scratch — directly, or as a plan if that now fits better — fixing every problem below; do not repeat them.",
+  "Your last answer does not compile. Answer again from scratch — directly, or as a plan if that now fits better — fixing every problem below; do not repeat them. If you answer directly, your ENTIRE answer is exactly ONE <App name=\"...\">…</App> element wrapping everything — nothing before it, nothing after it, and never a second <App>.",
   `WHAT YOU WROTE:\n${wire}`,
   `WHAT WAS WRONG WITH IT:\n${issues.map((issue) => `- ${issue}`).join("\n")}`,
 ].join("\n\n");

--- a/packages/apps/src/generation/prompts/brain.ts
+++ b/packages/apps/src/generation/prompts/brain.ts
@@ -16,7 +16,7 @@ import type { GenerationDependencies, HostToolInfo } from "../engine.js";
 // Yousef iterates on this text — keep it one screen.
 const ROLE = `You are the brain behind one app. Somebody asks for something; you answer in exactly one of these ways, and write nothing else — no preamble, no explanation of what you are about to do.
 
-1. THE ASK IS TINY (one number, one list, a label) — just write the app and stop: <App name="...">…</App> markup, using the components below. Never write a plan for something you can finish in a sentence.
+1. THE ASK IS TINY (one number, one list, a label) — just write the app and stop. Your ENTIRE answer is exactly ONE <App name="...">…</App> element wrapping everything you write — nothing before it, nothing after it, and never a second <App> — using the components below. Never write a plan for something you can finish in a sentence.
 2. THE ASK IS NORMAL — write a plan: which host data to read, and the groups of parts that show it. Fast workers fill each group in afterwards, and each one sees ONLY its own group and the one sentence you wrote for each part, so write purposes a stranger could build from.
 3. THE APP ALREADY EXISTS and the change is small — edit its text: quote the exact lines that should go, and write what replaces them. If the change is structural (a new tab, a new section, a different shape), write a plan for the NEW parts only.
 4. THE HOST CANNOT DO IT — say so: one <Cannot> line per thing that is out of reach, and nothing else.
@@ -48,6 +48,7 @@ EDITING THE APP TEXT
 One <Edit> per replacement, as many as the change needs. <Old> is copied EXACTLY from the app printed below and has to appear there exactly once — include a surrounding line when it would otherwise match twice. To remove something, leave <New> empty.
 
 THE RULES
+- A direct answer is ONE <App name="...">…</App> element and nothing else — no sibling elements beside it, no second <App>, no text before or after it. Anything else fails outright: "expected a single <App ...>...</App> element."
 - Never invent data. Every number and row a part shows comes from a query you declared against a real tool below.
 - The app text is not JavaScript: no .map, no Math.*, no string interpolation, no loop variable. A <Query tool="..."> names one of the TOOLS below VERBATIM — never a method call like "cities.map" or "Math.round". A value inside {} is a live binding the runtime computes on every render — a field path off a declared query, an aggregate (sum(rows, "field")), or arithmetic — never a number or string you worked out yourself and pasted in, and never {...} written inside a tag's BODY (<Text>{x}</Text> is refused outright) — give it its own attribute instead (<Text text={x}/>).
 - A fixed, small, named set of rows (three cities, not "however many the host returns") reads by POSITION off its query — cities.0.temp, cities.1.temp — there is no loop variable. An unbounded or longer list belongs in a component that reads the whole array itself (DataTable, CardList, a chart's data/rows prop bound to every row at once), never one hand-written element per row.


### PR DESCRIPTION
## Summary

Follow-up to #823 (merged). Post-merge battle-test: the JS-idiom failure modes are gone, but a new dominant failure appeared — `expected a single <App ...>...</App> element` (the model's direct-mode answer isn't wrapped in exactly one root `<App>`).

1. **`brainPrompt` now states the rule explicitly**, quoting the wire compiler's own error text verbatim (`packages/core/src/genui/wire/compile.ts:552`, the `missing-app` issue): a direct answer is exactly one `<App name="...">…</App>` element, nothing before or after it, never a second one.
2. **The #823 retry instruction (`directRewriteInstruction`) repeats the rule** specifically on the retry turn, since that's the turn most likely to need it restated.
3. **Confirmed (not just assumed) this failure class already reaches the #823 retry loop**: a `missing-app` compile issue is just another entry in `compiled.issues` — the exact same code path as the `unknown-tool`/`trailing-content` cases #823 already covers. No additional wiring was needed there; the gap was purely that nothing taught the model the rule up front.

## Test plan
- [x] `packages/apps/src/generation/brain.test.ts` — new case asserts the direct-mode system prompt states the single-`<App>` rule, quoting the compiler's exact error text; reverted, watched it go red, restored, green.
- [x] `packages/apps/src/generation/conductor.test.ts` — new case constructs a direct answer that trips the wire's `missing-app` check (a root tag that reads as `<App` under naive extraction but fails the compiler's stricter tag-boundary check — the same shape mismatch a hallucinated near-miss tag name produces), and proves it retries through the #823 loop and ships once fixed.
- [x] `pnpm typecheck` clean on `@vendoai/apps`.
- [x] `node scripts/dependency-guard.mjs` clean.
- All test runs capped at `VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2`, scoped to the affected + directly neighboring test files (26 tests in `packages/apps`, all green; core's 81 pre-existing tests unaffected — no core changes in this PR).

Minimal diff: 2 teaching-line additions (one in `brainPrompt`'s numbered list, one in `THE RULES`, one in the retry instruction) plus 2 new test cases. No changes to compile/validation logic — that rule and its retry path already existed and needed no code change, only the prompt teaching it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teaches and reinforces the single-root `<App>` rule in direct mode to prevent the dominant compile error. This reduces “expected a single <App ...>...</App> element” failures in direct answers.

- **Bug Fixes**
  - `brainPrompt` now explicitly states the single `<App>` wrapper rule, quoting the compiler’s error text.
  - Retry turn (`directRewriteInstruction`) repeats the rule when a direct answer fails to compile.
  - Added tests to confirm the prompt includes the rule and that `missing-app` issues hit the retry loop and succeed once fixed (`@vendoai/apps`).

<sup>Written for commit 1c3424cedf1a0d1f9924c1c0661234184b9095fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

