### PR TITLE
fix(deps): security floor for @auth/core — getToken() DoS patched in 0.41.3

### DIFF
--- a/.changeset/auth-core-security-floor.md
+++ b/.changeset/auth-core-security-floor.md
@@ -1,0 +1,10 @@
+---
+"@vendoai/vendo": patch
+"@vendoai/actions": patch
+---
+
+Security floor for `@auth/core`: the optional peer range moves from `^0.34.3`
+to `>=0.41.3`. The `authJs()` presets pass the raw incoming request to the
+host's `getToken()`, and `@auth/core` versions before 0.41.3 have a
+request-triggered CPU-exhaustion DoS in that call. 0.41.3 is the patched
+release; hosts on older Auth.js should upgrade `@auth/core` alongside this.

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -62,7 +62,7 @@
     "zod": "^3.25.0"
   },
   "peerDependencies": {
-    "@auth/core": "^0.34.3",
+    "@auth/core": ">=0.41.3",
     "next": ">=14"
   },
   "peerDependenciesMeta": {
@@ -74,7 +74,7 @@
     }
   },
   "devDependencies": {
-    "@auth/core": "^0.34.3",
+    "@auth/core": "^0.41.3",
     "@types/node": "^22.0.0",
     "graphql": "^16.9.0",
     "jose": "^6.2.3",

--- a/packages/vendo/package.json
+++ b/packages/vendo/package.json
@@ -121,7 +121,7 @@
     "zod": "^3.25.0"
   },
   "peerDependencies": {
-    "@auth/core": "^0.34.3",
+    "@auth/core": ">=0.41.3",
     "@clerk/backend": ">=1.0.0",
     "@mastra/core": ">=1.0.0 <2",
     "ai": ">=6.0.0 <7",
@@ -145,7 +145,7 @@
     }
   },
   "devDependencies": {
-    "@auth/core": "^0.34.3",
+    "@auth/core": "^0.41.3",
     "@clerk/backend": "^3.11.7",
     "@mastra/core": "1.51.0",
     "@types/json-schema": "^7.0.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -995,8 +995,8 @@ importers:
         version: 3.25.76
     devDependencies:
       '@auth/core':
-        specifier: ^0.34.3
-        version: 0.34.3
+        specifier: ^0.41.3
+        version: 0.41.3
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.0
@@ -1574,8 +1574,8 @@ importers:
         version: 3.25.76
     devDependencies:
       '@auth/core':
-        specifier: ^0.34.3
-        version: 0.34.3
+        specifier: ^0.41.3
+        version: 0.41.3
       '@clerk/backend':
         specifier: ^3.11.7
         version: 3.11.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2123,20 +2123,6 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
-
-  '@auth/core@0.34.3':
-    resolution: {integrity: sha512-jMjY/S0doZnWYNV90x0jmU3B+UcrsfGYnukxYrRbj0CVvGI/MX3JbHsxSrx2d4mbnXaUsqJmAcDfoQWA6r0lOw==}
-    peerDependencies:
-      '@simplewebauthn/browser': ^9.0.1
-      '@simplewebauthn/server': ^9.0.2
-      nodemailer: ^7
-    peerDependenciesMeta:
-      '@simplewebauthn/browser':
-        optional: true
-      '@simplewebauthn/server':
-        optional: true
-      nodemailer:
-        optional: true
 
   '@auth/core@0.41.3':
     resolution: {integrity: sha512-sJ3JMHHkXMD3aOjopv7mOBTO1Ocw4b0fAEXJBz6k7YHLpYQI6C40jCUPc5fNvUKxXRXNE1/sRISA15UrwWJBTw==}
@@ -5734,9 +5720,6 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
-  '@types/cookie@0.6.0':
-    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
-
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -6903,10 +6886,6 @@ packages:
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
-
-  cookie@0.6.0:
-    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
-    engines: {node: '>= 0.6'}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -9529,9 +9508,6 @@ packages:
   nwsapi@2.2.24:
     resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
 
-  oauth4webapi@2.17.0:
-    resolution: {integrity: sha512-lbC0Z7uzAFNFyzEYRIC+pkSVvDHJTbEW+dYlSBAlCYDe6RxUkJ26bClhk8ocBZip1wfI9uKTe0fm4Ib4RHn6uQ==}
-
   oauth4webapi@3.8.6:
     resolution: {integrity: sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==}
 
@@ -9975,18 +9951,10 @@ packages:
       rxjs:
         optional: true
 
-  preact-render-to-string@5.2.3:
-    resolution: {integrity: sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==}
-    peerDependencies:
-      preact: '>=10'
-
   preact-render-to-string@6.5.11:
     resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
     peerDependencies:
       preact: '>=10'
-
-  preact@10.11.3:
-    resolution: {integrity: sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==}
 
   preact@10.24.3:
     resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
@@ -10014,9 +9982,6 @@ packages:
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-
-  pretty-format@3.8.0:
-    resolution: {integrity: sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==}
 
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
@@ -12290,16 +12255,6 @@ snapshots:
   '@asamuzakjp/generational-cache@1.0.1': {}
 
   '@asamuzakjp/nwsapi@2.3.9': {}
-
-  '@auth/core@0.34.3':
-    dependencies:
-      '@panva/hkdf': 1.2.1
-      '@types/cookie': 0.6.0
-      cookie: 0.6.0
-      jose: 5.10.0
-      oauth4webapi: 2.17.0
-      preact: 10.11.3
-      preact-render-to-string: 5.2.3(preact@10.11.3)
 
   '@auth/core@0.41.3':
     dependencies:
@@ -16133,8 +16088,6 @@ snapshots:
     dependencies:
       '@types/node': 22.20.0
 
-  '@types/cookie@0.6.0': {}
-
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-axis@3.0.6':
@@ -17413,8 +17366,6 @@ snapshots:
   cookie-signature@1.0.7: {}
 
   cookie-signature@1.2.2: {}
-
-  cookie@0.6.0: {}
 
   cookie@0.7.2: {}
 
@@ -20896,8 +20847,6 @@ snapshots:
 
   nwsapi@2.2.24: {}
 
-  oauth4webapi@2.17.0: {}
-
   oauth4webapi@3.8.6: {}
 
   object-assign@4.1.1: {}
@@ -21351,16 +21300,9 @@ snapshots:
     optionalDependencies:
       rxjs: 7.8.1
 
-  preact-render-to-string@5.2.3(preact@10.11.3):
-    dependencies:
-      preact: 10.11.3
-      pretty-format: 3.8.0
-
   preact-render-to-string@6.5.11(preact@10.24.3):
     dependencies:
       preact: 10.24.3
-
-  preact@10.11.3: {}
 
   preact@10.24.3: {}
 
@@ -21391,8 +21333,6 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
-
-  pretty-format@3.8.0: {}
 
   pretty-ms@9.3.0:
     dependencies:


### PR DESCRIPTION
## What

Raises the optional peer dependency floor for `@auth/core` from `^0.34.3` to `>=0.41.3` in `@vendoai/vendo` and `@vendoai/actions`, and bumps the repo's own devDependency to `^0.41.3`. Patch changeset included.

## Why

`@auth/core` versions before 0.41.3 have a request-triggered CPU-exhaustion DoS in `getToken()` (GHSA). Our `authJs()` presets pass the raw incoming request straight to the host's `getToken()` — `packages/vendo/src/auth-presets/auth-js.ts:84` and the mirror in `packages/actions/src/presets/auth-js.ts` — so any host on a vulnerable `@auth/core` is exposed through the shipped call site. The floor makes installs surface the requirement instead of silently pairing with a vulnerable release.

## Verification

- `pnpm install` resolves cleanly (only pre-existing peer warnings, none for `@auth/core`)
- `pnpm build` green (27/27)
- `pnpm typecheck` green in `packages/vendo` and `packages/actions`
- `pnpm lint` (incl. dependency-guard) green
- auth-js preset tests in both packages pass against `@auth/core` 0.41.3 (24 + 7 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set a security floor for `@auth/core` to 0.41.3+ to fix a request-triggered CPU DoS in `getToken()` when used by our `authJs()` presets. Updates peer ranges and dev deps so installs and builds use the patched release.

- **Dependencies**
  - Raise optional peer `@auth/core` to `>=0.41.3` in `@vendoai/vendo` and `@vendoai/actions`.
  - Bump repo devDependency to `^0.41.3`.

- **Migration**
  - Hosts must upgrade to `@auth/core` 0.41.3+ to satisfy the peer and avoid the `getToken()` DoS.

<sup>Written for commit 9374f2d3a63a580c0a1efee016d961cd489f417c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

