### PR TITLE
fix(core): box-served plan with zero groups is not empty

### DIFF
--- a/packages/core/src/genui/plan/compile.test.ts
+++ b/packages/core/src/genui/plan/compile.test.ts
@@ -592,6 +592,21 @@ describe("compilePlan", () => {
       expect(result.plan?.server?.served).toBeUndefined();
       expect(result.issues.join(" ")).toContain("bare flag");
     });
+
+    it("accepts a box-served plan with zero groups — the whole surface is the box", () => {
+      const result = compilePlan(
+        `<Plan name="Board">
+           <Server kind="box" served why="Drag-and-drop between columns is an interaction no component can express."/>
+         </Plan>`,
+        FACTS,
+      );
+      expect(result.issues).toEqual([]);
+      expect(result.plan?.server).toEqual({
+        kind: "box",
+        served: true,
+        why: "Drag-and-drop between columns is an interaction no component can express.",
+      });
+    });
   });
 
   describe("the display hint (redesign spec §5)", () => {

--- a/packages/core/src/genui/plan/compile.ts
+++ b/packages/core/src/genui/plan/compile.ts
@@ -534,7 +534,8 @@ const compilePlanUnsafe = (text: string, facts: PlanFacts): PlanCompileResult =>
     );
   }
   if (!head.selfClosing) compilePlanChildren(plan, appPlan);
-  if (appPlan.groups.length === 0 && appPlan.cannot.length === 0) {
+  const servedByBox = appPlan.server?.kind === "box" && appPlan.server.served === true;
+  if (appPlan.groups.length === 0 && appPlan.cannot.length === 0 && !servedByBox) {
     plan.issues.push(
       "this plan says nothing: it needs at least one <Group> of leaves, or a <Cannot> line explaining honestly why the ask cannot be built here.",
     );


### PR DESCRIPTION
## The bug

Root-caused from live Railway logs: the entire full-app box-served build tier was dead.

The generation brain is instructed that a full-app, box-served plan hands the WHOLE surface to the sandbox, so it emits `<Server kind="box" served>` with **zero** `<Group>` elements (`packages/apps/src/generation/prompts/brain.ts`).

But the plan compiler's minimum-content gate (`packages/core/src/genui/plan/compile.ts:537`) rejected any plan with zero groups and no `<Cannot>` line as "this plan says nothing" — it never checked `appPlan.server`. So every legitimate server-only box-served plan was rejected, the build failed with "Couldn't build the app", and the E2B box arm was never reached.

## The fix

One line: treat a box-served plan (`server.kind === "box" && server.served === true`) as legitimately saying something.

```diff
   if (!head.selfClosing) compilePlanChildren(plan, appPlan);
-  if (appPlan.groups.length === 0 && appPlan.cannot.length === 0) {
+  const servedByBox = appPlan.server?.kind === "box" && appPlan.server.served === true;
+  if (appPlan.groups.length === 0 && appPlan.cannot.length === 0 && !servedByBox) {
```

Genuinely-empty plans (no groups, no cannot, no served box) are still rejected.

## The test

Every existing `<Server served>` test also included a `<Group><Leaf>` — the server-only shape the brain actually produces was never covered. Added a test for a `<Server kind="box" served>` plan with zero groups and no `<Cannot>`, asserting it compiles with no issues. Confirmed red-before / green-after.

## Impact

Unblocks the app-build tier: box provisioning (the E2B arm) was never reached before this.

Only `compile.ts` + `compile.test.ts` changed. Typecheck green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the plan compiler to accept a full-app box-served plan with zero groups. This unblocks app builds and allows the E2B box provisioning path to run.

- **Bug Fixes**
  - Treat `<Server kind="box" served>` with no groups and no `<Cannot>` as valid; still reject truly empty plans.
  - Added a unit test for the server-only box plan shape (zero groups).

<sup>Written for commit 0d15975b7d53b64bffb1238adc5e847fd094dcc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

