### PR TITLE
chore: scoped local gate (test:affected); CI owns the full suite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ generated UI in a sandboxed, brand-native surface.
 
 ## Commands
 
-- `pnpm install` · `pnpm build` · `pnpm test` · `pnpm typecheck` · `pnpm lint` (turbo-cached)
+- `pnpm install` · `pnpm build` · `pnpm test` · `pnpm test:affected` (scoped to changed packages — the local default) · `pnpm typecheck` · `pnpm lint` (turbo-cached)
 - Demos: `pnpm --filter demo-bank dev` (Maple) · `pnpm --filter demo-accounting dev` (Cadence)
 
 ## Vendo Cloud
@@ -50,8 +50,9 @@ generated UI in a sandboxed, brand-native surface.
 - Never commit to `main`; branch and open a PR.
 - UI-affecting changes are verified in a real browser with screenshots in the
   PR. Tests and typecheck alone don't count.
-- `pnpm build && pnpm test && pnpm typecheck && pnpm lint` must be green
-  before any PR.
+- Local gate = `pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint`
+  on the touched scope. The FULL suite runs only in CI — the PR's green `ci`
+  check is the gate of record; never run the full suite locally.
 
 ## Tests
 
@@ -73,13 +74,17 @@ generated UI in a sandboxed, brand-native surface.
   test's own timeout. The test timeout is the hang-detector; a tighter inner
   budget is a second, invisible speed limit that reports a product bug when
   the machine is merely busy.
-- `pnpm test` runs turbo with `--continue` and `--concurrency=4`, the same
-  bound CI has used since #340. `--continue` so one red package never hides
-  every other package's result; the bound because unbounded parallelism runs
-  ~27 vitest workers at once on a 12-core laptop (load average ~150) and the
-  full-stack suites in `packages/vendo` then miss their 30s budget on work
-  that takes 5s alone. A timeout is a hang-detector; do not raise one to buy
-  headroom the machine never had.
+- The full suite (`pnpm test`) is CI's job now — sharded into 8 vitest shards
+  for the big three (vendo×3, store×3, ui×2), 2 turbo groups for the remaining
+  packages, and a `hermetic-extras` job for the orphan suites. It still runs
+  with `--continue` and `--concurrency=4`, the same bound CI has used since
+  #340: `--continue` so one red package never hides every other package's
+  result; the bound because unbounded parallelism runs ~27 vitest workers at
+  once on a 12-core laptop (load average ~150) and the full-stack suites in
+  `packages/vendo` then miss their 30s budget on work that takes 5s alone. A
+  timeout is a hang-detector; do not raise one to buy headroom the machine
+  never had. Locally, run `pnpm test:affected` instead — same caps, scoped to
+  changed packages; never run the full suite on a laptop.
 - Turbo's bound is only the OUTER layer. Each package's vitest sizes its own
   worker pool to the CPU count, so 4 packages at a time meant ~60 processes and
   ~13GB on a 12-core laptop, and an OOM kill on a 15GB runner — the PGlite

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "turbo run build",
     "test": "VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2 turbo run test test:ui --continue --concurrency=4",
+    "test:affected": "TURBO_SCM_BASE=main VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2 turbo run test --affected --continue --concurrency=4",
     "conformance": "turbo run conformance --filter=@vendoai/core --filter=@vendoai/store --filter=@vendoai/agent",
     "typecheck": "turbo run typecheck",
     "lint": "node scripts/dependency-guard.mjs && node scripts/portability-gate.mjs && turbo run lint",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "turbo run build",
     "test": "VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2 turbo run test test:ui --continue --concurrency=4",
-    "test:affected": "TURBO_SCM_BASE=origin/main VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2 turbo run test --affected --continue --concurrency=4",
+    "test:affected": "TURBO_SCM_BASE=origin/main VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2 turbo run test test:ui --affected --continue --concurrency=4",
     "conformance": "turbo run conformance --filter=@vendoai/core --filter=@vendoai/store --filter=@vendoai/agent",
     "typecheck": "turbo run typecheck",
     "lint": "node scripts/dependency-guard.mjs && node scripts/portability-gate.mjs && turbo run lint",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "turbo run build",
     "test": "VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2 turbo run test test:ui --continue --concurrency=4",
-    "test:affected": "TURBO_SCM_BASE=main VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2 turbo run test --affected --continue --concurrency=4",
+    "test:affected": "TURBO_SCM_BASE=origin/main VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2 turbo run test --affected --continue --concurrency=4",
     "conformance": "turbo run conformance --filter=@vendoai/core --filter=@vendoai/store --filter=@vendoai/agent",
     "typecheck": "turbo run typecheck",
     "lint": "node scripts/dependency-guard.mjs && node scripts/portability-gate.mjs && turbo run lint",

--- a/packages/ui/e2e/README.md
+++ b/packages/ui/e2e/README.md
@@ -5,7 +5,7 @@ Three tiers, and the difference between them matters:
 | Tier | Command | Runs in CI | What it is |
 |---|---|---|---|
 | **smoke** | `pnpm --filter @vendoai/ui test:ui` | yes, and in `pnpm test` | `smoke.spec.ts` only. 15 tests, ~35s. The things that must never silently stop working. |
-| **CI browser gate** | the `UI solidity + stress suite` step in `.github/workflows/ci.yml` | yes | smoke + 15 more spec files. |
+| **CI browser gate** | the `UI solidity + stress suite` step in `.github/workflows/ci.yml` | yes | smoke + 29 more spec files (15 pre-existing + 14 hermetic specs added in PR ci-cache-shards). |
 | **local pre-PR** | `pnpm --filter @vendoai/ui test:browser` | no | everything in `e2e/`. |
 
 The harness is served **production-built** (`vite build` + `vite preview`, ~3.4s).
@@ -56,9 +56,12 @@ assertion in a real Chromium:
 |---|---|
 | `keyboard.spec.ts` | `workspace tabs rove with arrows and open an app by keyboard` is RED on this branch: the Automations tab's `aria-selected` stays `"false"` after Enter. A product defect, owned by the defects worker — not a CI-environment issue. The focus-order coverage CI needed is in `center-a11y.spec.ts`, which is green. |
 | `screenshots.spec.ts` | writes PNGs; a capture job, not a gate. |
-| `live-voice.spec.ts` | needs `OPENAI_API_KEY` and a real model. |
+| `live-voice.spec.ts` | needs `OPENAI_API_KEY` and a real model; runs as its own leg in `nightly.yml` instead. |
 | `mcp-shim.spec.ts` | runs in CI under its own config (`test:mcp-shim`). |
-| `containment.spec.ts`, `exfil-probe.spec.ts`, `appframe-isolation.spec.ts`, `byo-embeds.spec.ts`, `pin-drift.spec.ts`, `review-standing.spec.ts`, `inclient.spec.ts`, `voice-approval-overlap.spec.ts`, `eng-222.spec.ts`, `composer.spec.ts`, `chrome-behavior.spec.ts`, `verification-eng218.spec.ts`, `verification-eng223.spec.ts` | not triaged in this round. They are the local pre-PR gate. Two of them (`eng-222`) are currently red on a product defect — see below. |
+| `verification-eng218.spec.ts`, `verification-eng223.spec.ts` | capture jobs, not gates. |
+| `eng-222.spec.ts` | RED on a real product defect (`New conversation` never appears in the page thread's sidebar) — tracked, not fixed here; see "Currently RED" below. |
+| `cdn-packages.spec.ts` | depends on `examples/demo-bank/.vendo/components/` existing as tracked files in the checkout (probation — see PR ci-cache-shards). |
+| `appframe-devserver.spec.ts` | boots a real Vite dev server; inclusion depends on it running green in under 2 minutes locally (probation — see PR ci-cache-shards). |
 
 ### Currently RED on this branch (product defects, not spec bugs)
 

--- a/packages/ui/e2e/README.md
+++ b/packages/ui/e2e/README.md
@@ -5,7 +5,7 @@ Three tiers, and the difference between them matters:
 | Tier | Command | Runs in CI | What it is |
 |---|---|---|---|
 | **smoke** | `pnpm --filter @vendoai/ui test:ui` | yes, and in `pnpm test` | `smoke.spec.ts` only. 15 tests, ~35s. The things that must never silently stop working. |
-| **CI browser gate** | the `UI solidity + stress suite` step in `.github/workflows/ci.yml` | yes | smoke + 29 more spec files (15 pre-existing + 14 hermetic specs added in PR ci-cache-shards). |
+| **CI browser gate** | the `UI solidity + stress suite` step in `.github/workflows/ci.yml` | yes | smoke + 13 more spec files (14 total). |
 | **local pre-PR** | `pnpm --filter @vendoai/ui test:browser` | no | everything in `e2e/`. |
 
 The harness is served **production-built** (`vite build` + `vite preview`, ~3.4s).
@@ -54,14 +54,11 @@ assertion in a real Chromium:
 
 | Spec | Why |
 |---|---|
-| `keyboard.spec.ts` | `workspace tabs rove with arrows and open an app by keyboard` is RED on this branch: the Automations tab's `aria-selected` stays `"false"` after Enter. A product defect, owned by the defects worker — not a CI-environment issue. The focus-order coverage CI needed is in `center-a11y.spec.ts`, which is green. |
+| `keyboard.spec.ts` | the whole file asserts `:focus-visible` outlines, which headless CI mis-resolves. Green locally; not a CI-environment fix that belongs here. |
 | `screenshots.spec.ts` | writes PNGs; a capture job, not a gate. |
-| `live-voice.spec.ts` | needs `OPENAI_API_KEY` and a real model; runs as its own leg in `nightly.yml` instead. |
 | `mcp-shim.spec.ts` | runs in CI under its own config (`test:mcp-shim`). |
-| `verification-eng218.spec.ts`, `verification-eng223.spec.ts` | capture jobs, not gates. |
-| `eng-222.spec.ts` | RED on a real product defect (`New conversation` never appears in the page thread's sidebar) — tracked, not fixed here; see "Currently RED" below. |
-| `cdn-packages.spec.ts` | depends on `examples/demo-bank/.vendo/components/` existing as tracked files in the checkout (probation — see PR ci-cache-shards). |
-| `appframe-devserver.spec.ts` | boots a real Vite dev server; inclusion depends on it running green in under 2 minutes locally (probation — see PR ci-cache-shards). |
+| `eng-222.spec.ts` | currently-RED product defect (`New conversation` never appears in the page thread's sidebar) — tracked, not fixed here; see "Currently RED" below. |
+| `live-voice.spec.ts` | needs `OPENAI_API_KEY` and a real model; moves to the `nightly.yml` live-voice leg instead (landing in PR #834). |
 
 ### Currently RED on this branch (product defects, not spec bugs)
 


### PR DESCRIPTION
## Summary

Task 5 of the lighter-testing plan (Worker B slice): local dev no longer runs
the full test suite. CI is the gate of record.

- Root `package.json`: new `test:affected` script —
  `turbo run test test:ui --affected` (matches `pnpm test`'s task selection,
  including UI browser smoke) with the same VITEST_MIN/MAX_FORKS/THREADS caps
  as `test`, plus `TURBO_SCM_BASE=origin/main` so the comparison is always
  "differs from main as landed" and can't drift with a stale local `main`
  branch ref (see Resolved decisions below).
- `CLAUDE.md`: Commands section gains `pnpm test:affected`; Rules section's
  pre-PR gate now reads `pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint`
  with "never run the full suite locally"; Tests section's `pnpm test`
  paragraph now describes CI's sharded ownership and points local runs at
  `test:affected`. Seam-testing, sibling-distDir, poll-budget, and
  VITEST_MIN/MAX lessons are untouched (verbatim). Checked for stale
  `demo-template`/four-suite-extras references (both were plan artifacts that
  never survived PR #831) — none present, no fix needed.
- `packages/ui/e2e/README.md`: tier table and "NOT in CI" table now match
  what actually exists on this branch after PR #831 (the deletion sweep)
  removed 14 of the 15 specs the plan named for the CI browser gate, plus
  both probationary specs entirely. The gate is unchanged at smoke + 13 files
  (14 total, per PR #834's report — nothing was left to add); "NOT in CI" is
  now exactly keyboard/screenshots/eng-222/live-voice (+ mcp-shim, which runs
  in CI under its own job).

**Note on scope drift:** the plan also had me delete `scripts/serial-gate.sh`
and remove its `.gitignore` entries. PR #831 had already done both before I
rebased onto it — same end state, arrived at by a different PR, zero
`serial-gate`/`gate-failures` references remain either way (grep-confirmed).

## Resolved decisions

**`TURBO_SCM_BASE`.** `turbo run test --affected` doesn't scope correctly by
default, and the originally-pre-approved fallback (`TURBO_SCM_BASE=main`)
didn't fix it — it resolves to whatever the *local* `main` branch ref points
to, which can be stale/diverged from `origin/main` (shared across worktrees,
never fast-forwarded), silently marking nearly every package affected instead
of erroring. Approved fix: `TURBO_SCM_BASE=origin/main` — matches the spec's
intent ("differs from main as landed") and can't go stale the way a local
branch ref can. Re-verified on a clean scratch branch off `origin/main` with
a single-line comment edit in `packages/kit/src/index.ts`: scope resolved to
exactly `@vendoai/box-template`, `@vendoai/kit` for the `test` task (core/ui
only rebuilt as upstream deps, correctly not re-tested).

**`test:ui` coverage (greptile P1, real).** `test:affected` only ran the
`test` task, omitting the browser-smoke `test:ui` task that full `pnpm test`
runs — a regression that only broke browser smoke in the affected package
could pass the local gate. Fixed: now runs `turbo run test test:ui --affected`.
Verified `test:ui` is defined only in `packages/ui/package.json`; turbo
silently skips it everywhere else (confirmed via a live run, not just
`--dry`), so this doesn't inflate scope for unrelated changes. Verified
against an actual `@vendoai/ui` edit: correctly fans out to ui's real
dependents (`demo-bank`, `kit`, `vendo` all declare the dependency) — wide,
but genuine, not a scoping bug.

**greptile P1 on single-branch clones (dismissed, not fixed).** See PR
comment — `TURBO_SCM_BASE=origin/main` is the deliberate choice already
covered above; a `--single-branch` clone lacking `origin/main` isn't this
repo's supported setup, and the alternative (a stale local `main`) is a more
common real failure mode here.

## Test plan

- [x] `pnpm install && pnpm build` clean
- [x] `pnpm lint` green
- [x] `pnpm typecheck` green
- [x] Zero remaining `serial-gate`/`gate-failures` references (grep)
- [x] `test:affected` sanity-checked twice: base scoping (kit → 4 packages)
  and task selection (`test:ui` correctly included/skipped per package)
- [x] greptile-apps findings triaged: 2 real and fixed, 1 dismissed with reason