### PR TITLE
ci: turbo remote cache + sharded test gate; orphan suites join CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       # affected — verified locally: 74 tasks vs the correct 0.
       - name: Skip if package unaffected (PRs only)
         id: affected
-        if: github.event_name == 'TEMP-proof-force-shards-to-run'
+        if: github.event_name == 'pull_request'
         env:
           TURBO_SCM_BASE: origin/${{ github.base_ref }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,48 @@ on:
 permissions:
   contents: read
 
+# The old `ci` job did install → build → test:coverage (24 min) → typecheck →
+# lint on ONE runner, ~30 min wall. It is now, all fanned out over the shared
+# turbo remote cache so the fan-out does not multiply the build:
+#   typecheck-lint    the non-test half
+#   test-shards       8 intra-package vitest shards for the big three
+#                     (vendo x3, store x3, ui x2 — 40 of the 55 serial minutes)
+#   test-rest         the other 15 packages in 2 turbo groups
+#   coverage-merge    merges the shards' blob reports and enforces the
+#                     per-package coverage floors (they cannot be enforced on a
+#                     single shard — see the comment on that job)
+#   ci                aggregate; KEEPS the required-check name `ci`
+# Required checks on main are: ci, integration, perf, conformance,
+# cadence-supabase-auth, audit. Renaming any of those job names breaks merges.
 jobs:
-  ci:
+  typecheck-lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Turbo remote cache (GitHub-cache backed)
+        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm typecheck
+      - run: pnpm lint
+
+  # The big three, split file-wise inside each package. Coverage is collected
+  # per shard as a BLOB report and merged in coverage-merge; the per-shard runs
+  # pass --coverage.thresholds.lines=0 because vitest enforces the package's
+  # floor against whatever that shard happened to cover (measured: kit's
+  # shard 1/2 reports 48% of the 94% the whole suite reaches, and a floor of 90
+  # fails the shard). Zeroing it here moves the floor to the merge, where the
+  # number is the real one — the gate is not weakened, it is moved to the only
+  # place it can be correct.
+  test-shards:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
     services:
       postgres:
         image: postgres:16
@@ -24,6 +63,109 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: vendo-1, pkg: "@vendoai/vendo", dir: packages/vendo, shard: "1/3", pre: "build:playground" }
+          - { name: vendo-2, pkg: "@vendoai/vendo", dir: packages/vendo, shard: "2/3", pre: "build:playground" }
+          - { name: vendo-3, pkg: "@vendoai/vendo", dir: packages/vendo, shard: "3/3", pre: "build:playground" }
+          - { name: store-1, pkg: "@vendoai/store", dir: packages/store, shard: "1/3", tsc: "true" }
+          - { name: store-2, pkg: "@vendoai/store", dir: packages/store, shard: "2/3", tsc: "true" }
+          - { name: store-3, pkg: "@vendoai/store", dir: packages/store, shard: "3/3", tsc: "true" }
+          - { name: ui-1, pkg: "@vendoai/ui", dir: packages/ui, shard: "1/2", pre: "build:jail" }
+          - { name: ui-2, pkg: "@vendoai/ui", dir: packages/ui, shard: "2/2", pre: "build:jail" }
+    env:
+      POSTGRES_URL: postgres://vendo:vendo@localhost:5432/vendo_test
+      VITEST_MIN_FORKS: "1"
+      VITEST_MAX_FORKS: "2"
+      VITEST_MIN_THREADS: "1"
+      VITEST_MAX_THREADS: "2"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0 # turbo --affected diffs against the base branch
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Turbo remote cache (GitHub-cache backed)
+        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
+      - run: pnpm install --frozen-lockfile
+      # TURBO_SCM_BASE is explicit: turbo's default base is the local branch
+      # `main`, which does not exist on a PR checkout (and is stale in a
+      # worktree), so without it --affected silently reports EVERYTHING
+      # affected — verified locally: 74 tasks vs the correct 0.
+      - name: Skip if package unaffected (PRs only)
+        id: affected
+        if: github.event_name == 'pull_request'
+        env:
+          TURBO_SCM_BASE: origin/${{ github.base_ref }}
+        run: |
+          if pnpm turbo run test:coverage --filter=${{ matrix.pkg }} --affected --dry=json > /tmp/dry.json \
+             && jq -e '.tasks | length == 0' /tmp/dry.json > /dev/null; then
+            echo "${{ matrix.pkg }} is unaffected by this PR; skipping shard ${{ matrix.shard }}"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Build deps
+        if: steps.affected.outputs.skip != 'true'
+        run: pnpm turbo run build --filter=${{ matrix.pkg }}
+      # The package's own pretest hook does not run here (we invoke vitest
+      # directly, to pass --shard), and a turbo cache HIT on `build` skips the
+      # prebuild hook that would otherwise produce these. So do it explicitly.
+      - name: Pre-step
+        if: steps.affected.outputs.skip != 'true' && matrix.pre
+        run: pnpm --filter ${{ matrix.pkg }} run ${{ matrix.pre }}
+      - name: tsc (store keeps its tsc-before-test contract)
+        if: steps.affected.outputs.skip != 'true' && matrix.tsc == 'true'
+        run: pnpm --filter ${{ matrix.pkg }} exec tsc -p tsconfig.json
+      - name: Test shard
+        if: steps.affected.outputs.skip != 'true'
+        run: pnpm --filter ${{ matrix.pkg }} exec vitest run --coverage --coverage.thresholds.lines=0 --reporter=blob --shard=${{ matrix.shard }}
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        if: steps.affected.outputs.skip != 'true'
+        with:
+          name: blob-${{ matrix.name }}
+          path: ${{ matrix.dir }}/.vitest-reports/
+          # .vitest-reports is a dotted directory; upload-artifact drops hidden
+          # files by default since v4.4 and the artifact would be empty.
+          include-hidden-files: true
+          retention-days: 1
+
+  # Everything that is not one of the big three. No --affected skip step here:
+  # turbo's remote cache IS the skip — an unchanged package's test:coverage
+  # replays from cache in seconds. group-b is expressed as negations so a new
+  # package joins CI the day it is created, without editing this file.
+  test-rest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: vendo
+          POSTGRES_PASSWORD: vendo
+          POSTGRES_DB: vendo_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U vendo"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: group-a, filters: "--filter=@vendoai/guard --filter=@vendoai/actions" }
+          - { name: group-b, filters: "--filter=!@vendoai/vendo --filter=!@vendoai/store --filter=!@vendoai/ui --filter=!@vendoai/guard --filter=!@vendoai/actions" }
+    env:
+      POSTGRES_URL: postgres://vendo:vendo@localhost:5432/vendo_test
+      VITEST_MIN_FORKS: "1"
+      VITEST_MAX_FORKS: "2"
+      VITEST_MIN_THREADS: "1"
+      VITEST_MAX_THREADS: "2"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -34,26 +176,81 @@ jobs:
       - name: Turbo remote cache (GitHub-cache backed)
         uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
       - run: pnpm install --frozen-lockfile
-      - run: pnpm build
-      # Runs every package's suite WITH v8 coverage and enforces each package's
-      # ratcheted line-coverage floor (coverage.thresholds.lines in its vitest
-      # config); a drop below the floor fails the build. This is the required
-      # coverage gate — it supersedes a bare `pnpm test`.
-      # The root script owns the bounds so CI and a laptop run the same shape:
-      # --concurrency=4 bounds turbo's cross-package parallelism (unbounded
-      # parallelism oversubscribes the runner's CPUs and flakes the
-      # live-Next-server suites, PR #340); --continue so ONE red package cannot
-      # hide every other package's result — without it turbo cancels the rest of
-      # the graph on the first failure, and a run that reports "1 failing
-      # package" may be sitting on several, which is how a deterministic fixture
-      # breakage read as a shifting flake; and the VITEST_MIN/MAX_FORKS pair
-      # bounds the SECOND layer, the worker pool inside each package's vitest.
+      # --continue so ONE red package cannot hide every other package's result;
+      # --concurrency=2 bounds turbo's cross-package parallelism, and the
+      # VITEST_MIN/MAX pair above bounds the SECOND layer (the worker pool
+      # inside each package's vitest). Unbounded, the two layers multiply and
+      # the live-Next-server suites flake (PR #340).
       - name: Test with coverage (PGlite + PostgreSQL)
-        run: pnpm test:coverage
+        run: pnpm turbo run test:coverage --continue --concurrency=2 ${{ matrix.filters }}
+
+  # The per-package coverage floors (vendo 78 / store 84 / ui 74, each in the
+  # package's vitest config) live HERE, because a floor is only meaningful
+  # against the whole suite's coverage. vitest replays the shards' blob reports
+  # without re-running a single test, then reports and enforces.
+  coverage-merge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: test-shards
+    if: always() && needs.test-shards.result != 'cancelled'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Turbo remote cache (GitHub-cache backed)
+        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
+      - run: pnpm install --frozen-lockfile
+      # continue-on-error: a package whose shards all skipped (unaffected) has
+      # no artifacts, and download-artifact treats a pattern that matches
+      # nothing as an error. The merge step below skips that package instead.
+      - name: Download vendo shard blobs
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: blob-vendo-*
+          merge-multiple: true
+          path: packages/vendo/.vitest-reports
+      - name: Download store shard blobs
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: blob-store-*
+          merge-multiple: true
+          path: packages/store/.vitest-reports
+      - name: Download ui shard blobs
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: blob-ui-*
+          merge-multiple: true
+          path: packages/ui/.vitest-reports
+      - name: Merge shard reports and enforce coverage floors
+        run: |
+          for pkg in vendo store ui; do
+            if [ -d "packages/$pkg/.vitest-reports" ]; then
+              echo "::group::coverage merge — @vendoai/$pkg"
+              pnpm --filter "@vendoai/$pkg" exec vitest run --merge-reports --coverage
+              echo "::endgroup::"
+            else
+              echo "no shard blobs for @vendoai/$pkg (unaffected by this PR); nothing to merge"
+            fi
+          done
+
+  # The required check. Its name must stay `ci` (branch protection on main).
+  ci:
+    runs-on: ubuntu-latest
+    needs: [typecheck-lint, test-shards, test-rest, coverage-merge]
+    if: always()
+    steps:
+      - name: All lanes green
         env:
-          POSTGRES_URL: postgres://vendo:vendo@localhost:5432/vendo_test
-      - run: pnpm typecheck
-      - run: pnpm lint
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          echo "$RESULTS"
+          [[ "$RESULTS" != *failure* && "$RESULTS" != *cancelled* ]]
 
   integration:
     runs-on: ubuntu-latest
@@ -114,7 +311,7 @@ jobs:
       # shared server.
       - run: pnpm --filter @vendoai-fixtures/chat-e2e test
       # Maple's suite (auth, away drill, transfers, money, mcp-config, server
-      # routes). demo apps define no test:coverage script, so the main ci job's
+      # routes). demo apps define no test:coverage script, so the test-rest job's
       # turbo run skips them — this is demo-bank's only CI execution (Cadence
       # gets the cadence-supabase-auth job).
       - run: pnpm --filter demo-bank test
@@ -250,7 +447,7 @@ jobs:
   # end to end against the seeded users, the away drill (which needs no
   # Supabase), and the auth/session unit tests. This is the only job that
   # runs demo-accounting's tests per PR (demo apps define no test:coverage
-  # script, so the main ci job's turbo run skips them). The login e2e probes
+  # script, so the test-rest job's turbo run skips them). The login e2e probes
   # GoTrue and skips itself cleanly when the stack is absent, so Supabase
   # local never becomes a hard dependency for unrelated tests.
   cadence-supabase-auth:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ permissions:
 #   coverage-merge    merges the shards' blob reports and enforces the
 #                     per-package coverage floors (they cannot be enforced on a
 #                     single shard — see the comment on that job)
+#   hermetic-extras   the suites that were never in CI at all
 #   ci                aggregate; KEEPS the required-check name `ci`
 # Required checks on main are: ci, integration, perf, conformance,
 # cadence-supabase-auth, audit. Renaming any of those job names breaks merges.
@@ -239,10 +240,39 @@ jobs:
             fi
           done
 
+  # Three suites that existed, passed locally, and ran NOWHERE in CI: both
+  # framework integration examples and the corpus express host. All hermetic — scripted models, temp PGlite,
+  # no keys. They define `test` and not `test:coverage`, which is exactly why
+  # the old ci job's `turbo run test:coverage` never touched them.
+  # ai-sdk-agent's cloud-posture.e2e.test.ts self-skips without
+  # VENDO_LIVE_CLOUD=1; it stays skipped here (it is a nightly-class live test).
+  hermetic-extras:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      VITEST_MIN_FORKS: "1"
+      VITEST_MAX_FORKS: "2"
+      VITEST_MIN_THREADS: "1"
+      VITEST_MAX_THREADS: "2"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Turbo remote cache (GitHub-cache backed)
+        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
+      - run: pnpm install --frozen-lockfile
+      - name: Build deps
+        run: pnpm turbo run build --filter=@vendoai-examples/ai-sdk-agent --filter=@vendoai-examples/mastra-agent --filter=@vendoai-corpus/express-host
+      - name: Test formerly-local-only suites
+        run: pnpm turbo run test --continue --concurrency=2 --filter=@vendoai-examples/ai-sdk-agent --filter=@vendoai-examples/mastra-agent --filter=@vendoai-corpus/express-host
+
   # The required check. Its name must stay `ci` (branch protection on main).
   ci:
     runs-on: ubuntu-latest
-    needs: [typecheck-lint, test-shards, test-rest, coverage-merge]
+    needs: [typecheck-lint, test-shards, test-rest, coverage-merge, hermetic-extras]
     if: always()
     steps:
       - name: All lanes green

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+      - name: Turbo remote cache (GitHub-cache backed)
+        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       # Runs every package's suite WITH v8 coverage and enforces each package's
@@ -82,6 +84,8 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+      - name: Turbo remote cache (GitHub-cache backed)
+        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
       - run: pnpm install --frozen-lockfile
       # Build only the workspace deps the integration suites need (the `...`
       # suffix pulls each fixture package's transitive workspace deps;
@@ -150,6 +154,8 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+      - name: Turbo remote cache (GitHub-cache backed)
+        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
       - run: pnpm install --frozen-lockfile
       - run: pnpm conformance
       # Vite's generated bundle differs byte-for-byte between macOS and Linux,
@@ -257,6 +263,8 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+      - name: Turbo remote cache (GitHub-cache backed)
+        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
       - uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520 # v3.0.0
         with:
           # Matches the version the config/seed were verified against.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       # affected — verified locally: 74 tasks vs the correct 0.
       - name: Skip if package unaffected (PRs only)
         id: affected
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'TEMP-proof-force-shards-to-run'
         env:
           TURBO_SCM_BASE: origin/${{ github.base_ref }}
         run: |

--- a/.github/workflows/knowledge-eval.yml
+++ b/.github/workflows/knowledge-eval.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+      - name: Turbo remote cache (GitHub-cache backed)
+        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - name: Knowledge eval (memory engine, strict)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -118,6 +118,22 @@ jobs:
         continue-on-error: true
         run: pnpm --filter @vendoai/guard exec vitest run test/live/judge.live.test.ts 2>&1 | tee nightly-logs/judge-live.log
 
+      # packages/ui/e2e/live-voice.spec.ts — the only UI browser spec that needs
+      # a real model: it drives the OpenAI Realtime session over WebRTC. That is
+      # why it is not in the per-PR conformance gate, and until now it ran
+      # nowhere at all. `build:jail` first (the gitignored jail runtime is what
+      # `test:browser`'s pretest hook would normally build; `exec playwright
+      # test` skips that hook).
+      - name: UI live voice (OpenAI Realtime, WebRTC)
+        id: live_voice
+        continue-on-error: true
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          pnpm --filter @vendoai/ui run build:jail
+          pnpm --filter @vendoai/ui exec playwright install chromium
+          pnpm --filter @vendoai/ui exec playwright test e2e/live-voice.spec.ts 2>&1 | tee nightly-logs/live-voice.log
+
       - name: Install Claude Code for live MCP door
         run: npm install --global @anthropic-ai/claude-code@2.1.209
 
@@ -179,10 +195,11 @@ jobs:
           LIVE_EGRESS: ${{ steps.live_egress.outcome }}
           CLOUD_SANDBOX: ${{ steps.cloud_sandbox.outcome }}
           JUDGE_LIVE: ${{ steps.judge_live.outcome }}
+          LIVE_VOICE: ${{ steps.live_voice.outcome }}
           LIVE_CLAUDE: ${{ steps.live_claude.outcome }}
         run: |
           failed=0
-          for leg in AGENT_PROVIDERS PROVIDER_MATRIX_GUARD LIVE_AGENTIC LIVE_E2B LIVE_EGRESS CLOUD_SANDBOX JUDGE_LIVE LIVE_CLAUDE; do
+          for leg in AGENT_PROVIDERS PROVIDER_MATRIX_GUARD LIVE_AGENTIC LIVE_E2B LIVE_EGRESS CLOUD_SANDBOX JUDGE_LIVE LIVE_VOICE LIVE_CLAUDE; do
             eval "outcome=\$$leg"
             if [ "$outcome" != "success" ]; then
               echo "::error title=Nightly live leg failed::$leg finished with outcome '$outcome'; inspect the uploaded logs."

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+      - name: Turbo remote cache (GitHub-cache backed)
+        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: mkdir -p nightly-logs

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+      - name: Turbo remote cache (GitHub-cache backed)
+        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       # Deterministic suites only, compared against bench/budgets.json; exits 1


### PR DESCRIPTION
## What this does

CI is the gate of record, so it has to be fast enough to be one. Today the `ci`
job is a single runner doing install → build → 24 min of tests → typecheck →
lint, ~30 min push-to-green. This splits it and gives every job a shared build
cache.

**Turbo remote cache.** `rharkor/caching-for-turbo` (pinned by SHA, v2.5.1)
runs a localhost cache server backed by the GitHub Actions cache — no external
service, no secrets, no `turbo.json` change. Added to every job that invokes
turbo, in `ci.yml`, `nightly.yml`, `knowledge-eval.yml` and `perf.yml`. This is
what makes the fan-out below cheap: the build happens once and replays.

**Shard architecture.** Three packages are 40 of the suite's 55 serial minutes
(vendo 17.25, store 14.15, ui 9.24), so cross-package parallelism alone could
never fix it — they are split *inside* the package:

| job | what runs |
|---|---|
| `typecheck-lint` | build + typecheck + lint |
| `test-shards` (8) | vendo ×3, store ×3, ui ×2 via `vitest --shard`, blob reports uploaded |
| `test-rest` (2) | group-a = guard + actions; group-b = everything else, by negation filters |
| `coverage-merge` | replays the blobs, enforces the coverage floors (vendo 78 / store 84 / ui 74) |
| `hermetic-extras` | the suites that were never in CI |
| `ci` | aggregate — **keeps the required-check name**, no branch-protection change |

Required checks were verified before any renaming: `ci`, `integration`, `perf`,
`conformance`, `cadence-supabase-auth`, `audit`. All still exist by name.

**Two things worth a reviewer's attention.**

1. *Coverage floors moved, not removed.* A shard's `--coverage` run enforces the
   package floor against only what that shard covered. Measured on `kit`: shard
   1/2 reports 48% of the suite's real 94%, and a floor of 90 fails the shard
   (exit 1). So shards pass `--coverage.thresholds.lines=0` and the floor is
   enforced in `coverage-merge`, where the number is the true one. Also verified
   that `--merge-reports --coverage` reproduces the full coverage table and does
   fail when the merged number is under the floor.
2. *`--affected` needs an explicit base.* turbo's default base is the **local**
   branch `main`, which does not exist on a PR checkout. Without
   `TURBO_SCM_BASE`, `--affected` reported 74 tasks on a tree with zero changes.
   With it: 0 tasks when untouched, 4 when the package is edited, 0 for an
   unrelated package. `fetch-depth: 0` is set so the base ref resolves.

**Orphan suites join CI.** `@vendoai-examples/ai-sdk-agent`,
`@vendoai-examples/mastra-agent`, `@vendoai-corpus/express-host` — all hermetic,
all green locally, all previously running nowhere because they define `test` and
not `test:coverage`.

**Nightly.** `live-voice.spec.ts` joins the live matrix, wired into the same
fail-when-any-leg-failed aggregate as every other leg. `OPENAI_API_KEY` is
already a nightly secret.

## Proof

**Cache, two runs.**

| | run | `typecheck-lint` |
|---|---|---|
| cold | [31063196259](https://github.com/runvendo/vendo/actions/runs/31063196259) | 3m42s |
| warm | [31063727249](https://github.com/runvendo/vendo/actions/runs/31063727249) | 40s — `cache hit, replaying logs` on every build task |

**Shards actually ran.** The first run was green while skipping all 8 shards
(this PR touches only workflows, so `--affected` correctly found nothing
affected — `coverage-merge` logged `no shard blobs … nothing to merge`). A green
run that never executed the new mechanism proves nothing, so I pushed a throwaway
commit forcing the skip off, then reverted it. Run
[31063727249](https://github.com/runvendo/vendo/actions/runs/31063727249) has all
8 shards live and `coverage-merge` reporting real merged coverage — **vendo
86.88** (floor 78), **store 94.05** (floor 84), **ui 90.49** (floor 74).

**Wall time.** Final run [31064206387](https://github.com/runvendo/vendo/actions/runs/31064206387):
every new job ≤ 1m10s, longest job overall is `integration` at 8m53s, so
push-to-green is ~9 min against a 29–31 min baseline. Worst case (everything
affected) was 7m31s for the slowest shard.

## Deviations from the plan — main moved under this branch

`#831` (repo-wide deletion sweep) merged mid-flight and removed a lot of what
the plan told me to wire up. Nothing was improvised around it; each item is
reported instead:

- **UI browser lane extension is NOT in this PR.** The plan named 15 hermetic
  specs to add to the `conformance` gate. I ran all of them locally first — 122
  passed, 3 skipped, 3.4 min — and then `#831` deleted **14 of the 15** plus
  `verification-eng218/223/225/229` and `appframe-devserver`. There is nothing
  left to add, so the `conformance` job is untouched here apart from the cache
  step.
- **`demo-template` dropped from `hermetic-extras`** — `#831` deleted the
  package. Three suites instead of four.
- **Probationary two, decided before the sweep:** `cdn-packages.spec.ts` was
  GREEN (4 tests, 9.4s) and its fixture was tracked → would have been included.
  `appframe-devserver.spec.ts` was RED locally → excluded. Both specs are now
  deleted anyway.
- **Action pin:** plan guessed `v2.3.13`; latest v2.x is `v2.5.1`, which is what
  is pinned.

## Gate

`pnpm build`, `pnpm lint`, `pnpm typecheck` green locally on the rebased base.
`actionlint` clean on all four workflows (its one `SC2034` warning in
`nightly.yml` is pre-existing on `main`, verified against the base file).
