### PR TITLE
feat(store): transcripts + harness state ride StoreOps — hosted stores serve harness turns (S1)

### DIFF
--- a/.changeset/transcripts-and-harness-state-over-storeops.md
+++ b/.changeset/transcripts-and-harness-state-over-storeops.md
@@ -1,0 +1,46 @@
+---
+"@vendoai/store": minor
+"@vendoai/vendo": minor
+---
+
+Transcripts and harness state ride StoreOps, so a hosted store can serve a
+harness turn.
+
+`threadMessageStore` and `harnessStateStore` opened with `dbFor(store)` and threw
+"Unknown VendoStore handle" for anything `@vendoai/store` did not mint — which is
+every key-only deployment. So `storeServesHarnessTurns` answered false for them
+and the host silently fell back to the legacy chat path: hosted deployments could
+not use `harness:` at all.
+
+- `VendoStore` gains an optional `ops?: StoreOps`. The Cloud `hostedStore` already
+  exposed one, so it satisfies the member with no change.
+- One internal selector, `backendOf`, decides for every store-shaped helper: the
+  SQL handle when there is one (same database, one hop shorter), the store's own
+  32-op surface when there is not, and a named `not-implemented` refusal only when
+  the store offers neither. Nothing above the store package can tell the two
+  apart — no caller changed.
+- Transcripts ride the wire as-is: `transcripts.putMessage` for the write,
+  `transcripts.getThread` for the read, ownership enforced against the thread
+  record's subject exactly as the SQL join enforces it against `vendo_threads`.
+  A foreign or absent thread reads as empty and refuses writes, as it does
+  locally. A guarded (`expectedRevision`) edit has no wire expression and is
+  refused loudly rather than downgraded to last-write-wins; no runtime caller
+  asks for one.
+- Harness state rides the wire's `harness` family under the SAME slot the SQL
+  half uses (`harness_state:<threadId>`, keyed by the thread's owner), so §1.3's
+  rules — one slot per thread, a foreign harness destroying rather than shadowing
+  it, the slot dying with its thread — hold on both backends.
+
+The harness-turn refusal now names both options instead of only SQL, and the
+route probe accepts an ops-capable store.
+
+Proven where it counts: one behavioral suite for each helper runs against three
+backends (real Postgres/PGlite, core's `memoryStoreOps`, and the local 32-op
+backend), and a live seam test writes through the real helper over a real
+`hostedStore` against the real console and reads it back on a second,
+freshly-constructed client — no stub on either side.
+
+Known gap, recorded as a live `it.fails` rather than a comment: the console's
+`transcripts.putMessage` appends instead of editing by id, so re-writing an
+already persisted message (the approval flip) is refused there. The fix is
+console-side; the local backends already do the right thing.

--- a/packages/store/src/harness-state.ops.test.ts
+++ b/packages/store/src/harness-state.ops.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Durable harness state (build contract §1.3), proven against every backend it
+ * can sit on — the transcript suite's sibling, same shape and same reason.
+ *
+ * `harnessStateStore` demanded a SQL handle, which is why a key-only deployment
+ * re-seeded a session-owning harness on every turn. It picks a backend now
+ * (`backendOf`); this file is the proof that §1.3's rules — one slot per thread,
+ * keyed by its OWNER, a foreign harness DESTROYING rather than shadowing it, and
+ * the slot dying with its thread — read identically whichever backend answers.
+ */
+import { VendoError, type Principal, type StoreOps } from "@vendoai/core";
+import { memoryStoreOps } from "@vendoai/core/conformance";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { backends, type MadeBackend } from "./backends.test-util.js";
+import { createStoreOps, harnessStateStore, threadStore, type VendoStore } from "./index.js";
+
+const alice: Principal = { kind: "user", subject: "user_alice" };
+
+/** Not a handle `@vendoai/store` minted — the shape a hosted store presents. */
+function opsOnlyStore(ops: StoreOps): VendoStore {
+  const unused = (what: string): never => {
+    throw new Error(`the harness-state helper must not reach ${what}`);
+  };
+  return {
+    ops,
+    records: () => unused("records()"),
+    blobs: () => unused("blobs()"),
+    async ensureSchema() {},
+    async close() {},
+    raw: () => unused("raw()"),
+  };
+}
+
+interface Mode {
+  name: string;
+  store: VendoStore;
+  own(id: string, subject: string): Promise<void>;
+  removeThread(id: string, subject: string): Promise<void>;
+}
+
+/** Ids are namespaced per mode because `local-ops` and `sql` share one database. */
+const modesFor = (made: MadeBackend): Mode[] => {
+  const viaOps = (name: string, ops: StoreOps): Mode => ({
+    name,
+    store: opsOnlyStore(ops),
+    own: async (id, subject) => { await ops.transcripts.putThread({ id, subject, messages: [] }); },
+    removeThread: async (id) => { await ops.transcripts.deleteThread(id); },
+  });
+  return [
+    {
+      name: "sql",
+      store: made.store,
+      own: async (id, subject) => { await threadStore(made.store).put({ kind: "user", subject }, { id, messages: [] }); },
+      removeThread: async (id, subject) => { await threadStore(made.store).delete({ kind: "user", subject }, id); },
+    },
+    viaOps("memory-ops", memoryStoreOps()),
+    viaOps("local-ops", createStoreOps(made.store)),
+  ];
+};
+
+for (const backend of backends()) {
+  describe(`${backend.name} durable harness state across backends (§1.3, design D1)`, () => {
+    let made: MadeBackend;
+    let modes: Mode[];
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+      modes = modesFor(made);
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    describe.each([{ mode: "sql" }, { mode: "memory-ops" }, { mode: "local-ops" }])("$mode", ({ mode }) => {
+      const pick = (): Mode => modes.find((candidate) => candidate.name === mode)!;
+      const id = (suffix: string): string => `thr_hs_${mode.replace("-", "_")}_${suffix}`;
+
+      it("survives the handle: a value set on one reads back on another", async () => {
+        const { store, own } = pick();
+        const thread = id("durable");
+        await own(thread, alice.subject);
+        await harnessStateStore(store).set(thread, "claude-code", "sess_1");
+
+        expect(await harnessStateStore(store).get(thread, "claude-code")).toBe("sess_1");
+      });
+
+      it("a foreign harness CLEARS the slot rather than shadowing it", async () => {
+        const { store, own } = pick();
+        const thread = id("swap");
+        await own(thread, alice.subject);
+        const states = harnessStateStore(store);
+        await states.set(thread, "claude-code", "sess_swap");
+
+        expect(await states.get(thread, "vendo")).toBeUndefined();
+        // Destroyed, not hidden: swapping back must not resurrect a session the
+        // conversation has outgrown.
+        expect(await states.get(thread, "claude-code")).toBeUndefined();
+      });
+
+      it("set(undefined) deletes", async () => {
+        const { store, own } = pick();
+        const thread = id("delete");
+        await own(thread, alice.subject);
+        const states = harnessStateStore(store);
+        await states.set(thread, "claude-code", "sess_delete");
+        await states.set(thread, "claude-code", undefined);
+
+        expect(await states.get(thread, "claude-code")).toBeUndefined();
+      });
+
+      it("clear drops the thread's state whoever owns it", async () => {
+        const { store, own } = pick();
+        const thread = id("clear");
+        await own(thread, alice.subject);
+        const states = harnessStateStore(store);
+        await states.set(thread, "claude-code", "sess_clear");
+        await states.clear(thread);
+
+        expect(await states.get(thread, "claude-code")).toBeUndefined();
+      });
+
+      it("one thread's state is never another's", async () => {
+        const { store, own } = pick();
+        await own(id("a"), alice.subject);
+        await own(id("b"), alice.subject);
+        const states = harnessStateStore(store);
+        await states.set(id("a"), "claude-code", "sess_a");
+        await states.set(id("b"), "claude-code", "sess_b");
+
+        expect(await states.get(id("a"), "claude-code")).toBe("sess_a");
+        expect(await states.get(id("b"), "claude-code")).toBe("sess_b");
+      });
+
+      it("a thread nobody owns cannot hold state — the row would outlive the erase cascade", async () => {
+        await expect(harnessStateStore(pick().store).set(id("orphan"), "claude-code", "x"))
+          .rejects.toBeInstanceOf(VendoError);
+      });
+
+      it("reads a thread that never existed as no state, not an error", async () => {
+        await expect(harnessStateStore(pick().store).get(id("absent"), "claude-code"))
+          .resolves.toBeUndefined();
+      });
+
+      it("deleting the thread deletes its harness state — no ref outlives its thread", async () => {
+        const { store, own, removeThread } = pick();
+        const thread = id("gone");
+        await own(thread, alice.subject);
+        const states = harnessStateStore(store);
+        await states.set(thread, "claude-code", "sess_gone");
+        await removeThread(thread, alice.subject);
+
+        expect(await states.get(thread, "claude-code")).toBeUndefined();
+      });
+    });
+  });
+}
+
+describe("a store with neither a SQL handle nor a StoreOps surface", () => {
+  it("is refused by name, at construction", () => {
+    const bare = { ...opsOnlyStore(memoryStoreOps()), ops: undefined };
+    expect(() => harnessStateStore(bare)).toThrow(/SQL handle or a StoreOps-capable store/);
+  });
+});

--- a/packages/store/src/harness-state.ts
+++ b/packages/store/src/harness-state.ts
@@ -1,5 +1,7 @@
-import { VendoError } from "@vendoai/core";
-import { dbFor, type VendoStore } from "./store.js";
+import { VendoError, type StoreOps } from "@vendoai/core";
+import type { Db } from "./db-postgres.js";
+import { backendOf } from "./helpers/backend.js";
+import type { VendoStore } from "./store.js";
 
 /**
  * Build contract §1.3 — `turn.state`, made durable.
@@ -28,15 +30,89 @@ import { dbFor, type VendoStore } from "./store.js";
  */
 /** The synthetic `app_id` a thread's harness state rides under. Shared with the
  *  thread delete path (`helpers/threads.ts`), which sweeps the row so no
- *  native-session ref outlives its thread. */
+ *  native-session ref outlives its thread — and with the wire's own harness
+ *  family, whose slot is keyed identically so `deleteThread` cascades there too. */
 export const harnessStateKey = (threadId: string): string => `harness_state:${threadId}`;
 
-export function harnessStateStore(store: VendoStore): {
+export interface HarnessStateStore {
   get(threadId: string, harnessName: string): Promise<string | undefined>;
   set(threadId: string, harnessName: string, value: string | undefined): Promise<void>;
   clear(threadId: string): Promise<void>;
-} {
-  const db = dbFor(store);
+}
+
+/** The one row's payload, whichever backend holds it. */
+interface StoredState {
+  harness?: unknown;
+  value?: unknown;
+}
+
+/** Rows come back as jsonb (an object) or as text, depending on the driver. */
+function decode(row: unknown): StoredState | undefined {
+  const stored = typeof row === "string" ? (JSON.parse(row) as unknown) : row;
+  if (typeof stored !== "object" || stored === null) return undefined;
+  return stored as StoredState;
+}
+
+export function harnessStateStore(store: VendoStore): HarnessStateStore {
+  const backend = backendOf(store, "durable harness state (build contract §1.3)");
+  return backend.kind === "ops" ? overOps(backend.ops) : overSql(backend.db);
+}
+
+/**
+ * The hosted half: the SAME slot — `harness_state:<threadId>` as the appId, the
+ * thread's owner as the subject — served by the wire's `harness` family, so a
+ * deployment can move between backends without its sessions changing shape.
+ *
+ * The owner comes from `transcripts.getThread` where SQL reads `vendo_threads`
+ * directly. That read is not decoration: the wire's harness verbs are keyed by
+ * (appId, subject), and a row stored under the wrong subject is a row no erase
+ * and no adoption can reach — the same reason the SQL half refuses to store one.
+ */
+function overOps(ops: StoreOps): HarnessStateStore {
+  const ownerOf = async (threadId: string): Promise<string | undefined> => {
+    const record = await ops.transcripts.getThread(threadId);
+    const subject = (record?.data as { subject?: unknown } | undefined)?.subject;
+    return typeof subject === "string" ? subject : undefined;
+  };
+
+  return {
+    async get(threadId, harnessName) {
+      const subject = await ownerOf(threadId);
+      // No thread, no slot — the SQL half's missing row, reached differently.
+      if (subject === undefined) return undefined;
+      const stored = decode(await ops.harness.get(harnessStateKey(threadId), subject));
+      if (stored === undefined) return undefined;
+      if (stored.harness === harnessName) return typeof stored.value === "string" ? stored.value : undefined;
+      // §1.3's clearing rule: a different thinker holds this conversation now.
+      await ops.harness.clear(harnessStateKey(threadId), subject);
+      return undefined;
+    },
+
+    async set(threadId, harnessName, value) {
+      const subject = await ownerOf(threadId);
+      if (value === undefined) {
+        if (subject !== undefined) await ops.harness.clear(harnessStateKey(threadId), subject);
+        return;
+      }
+      if (subject === undefined) {
+        throw new VendoError("not-found", `No thread ${threadId} to hold harness state for.`);
+      }
+      // One row per (appId, subject), so a harness swap overwrites in place —
+      // the SQL half's delete-then-insert, expressed as the wire's own upsert.
+      await ops.harness.set(harnessStateKey(threadId), subject, { harness: harnessName, value });
+    },
+
+    async clear(threadId) {
+      const subject = await ownerOf(threadId);
+      // A thread that is already gone took its slot with it (deleteThread
+      // cascades the `harness_state:<id>` appId), so there is nothing to drop.
+      if (subject === undefined) return;
+      await ops.harness.clear(harnessStateKey(threadId), subject);
+    },
+  };
+}
+
+function overSql(db: Db): HarnessStateStore {
   const key = harnessStateKey;
 
   const ownerOf = async (threadId: string): Promise<string> => {
@@ -57,11 +133,9 @@ export function harnessStateStore(store: VendoStore): {
   return {
     async get(threadId, harnessName) {
       const result = await db.query("SELECT data FROM vendo_state WHERE app_id = $1", [key(threadId)]);
-      const row = result.rows[0]?.["data"];
-      const stored = typeof row === "string" ? (JSON.parse(row) as unknown) : row;
-      if (typeof stored !== "object" || stored === null) return undefined;
-      const { harness, value } = stored as { harness?: unknown; value?: unknown };
-      if (harness === harnessName) return typeof value === "string" ? value : undefined;
+      const stored = decode(result.rows[0]?.["data"]);
+      if (stored === undefined) return undefined;
+      if (stored.harness === harnessName) return typeof stored.value === "string" ? stored.value : undefined;
       // §1.3's clearing rule: a different thinker holds this conversation now.
       await drop(threadId);
       return undefined;

--- a/packages/store/src/helpers/backend.ts
+++ b/packages/store/src/helpers/backend.ts
@@ -1,0 +1,35 @@
+import { VendoError, type StoreOps } from "@vendoai/core";
+// Type-only — erased at compile time, so the engine stays out of this module's
+// bundle graph (the same rule store.ts states).
+import type { Db } from "../db-postgres.js";
+import { maybeDbFor, type VendoStore } from "../store.js";
+
+/** Where a helper's rows actually live for THIS store handle. */
+export type StoreBackend =
+  | { kind: "sql"; db: Db }
+  | { kind: "ops"; ops: StoreOps };
+
+/**
+ * The one selector every store-shaped helper resolves itself through.
+ *
+ * A helper like `threadMessageStore` used to open with `dbFor(store)` and throw
+ * "Unknown VendoStore handle" for anything this package did not mint — which is
+ * every hosted deployment, and is why a key-only host could not serve a harness
+ * turn. The rows exist either way; only the road to them differs. So: the SQL
+ * handle when there is one, the store's own 32-op surface when there is not, and
+ * a named refusal only when the store offers neither.
+ *
+ * SQL wins when both are present. It is the same database, one hop shorter.
+ *
+ * `what` names the thing being served, so the refusal reads as a fact about the
+ * deployment rather than an internals leak.
+ */
+export function backendOf(store: VendoStore, what: string): StoreBackend {
+  const db = maybeDbFor(store);
+  if (db !== undefined) return { kind: "sql", db };
+  if (store.ops !== undefined) return { kind: "ops", ops: store.ops };
+  throw new VendoError(
+    "not-implemented",
+    `${what} needs a SQL handle or a StoreOps-capable store; the configured store has neither.`,
+  );
+}

--- a/packages/store/src/helpers/thread-messages.ts
+++ b/packages/store/src/helpers/thread-messages.ts
@@ -1,5 +1,7 @@
-import { VendoError, type Principal, type ThreadId } from "@vendoai/core";
-import { dbFor, type VendoStore } from "../store.js";
+import { VendoError, type Principal, type StoreOps, type ThreadId } from "@vendoai/core";
+import type { Db } from "../db-postgres.js";
+import type { VendoStore } from "../store.js";
+import { backendOf } from "./backend.js";
 
 /** The least a transcript row must have for this store to key it: an id.
  *
@@ -15,23 +17,8 @@ export interface ThreadMessageLike {
   id: string;
 }
 
-/** Build contract §6 — one row per transcript message.
- *
- *  Why this exists: rewriting a whole `messages` array on every turn is
- *  O(messages²) over a conversation. One row per message makes a turn's write
- *  O(new messages), which is the property E6 measures.
- *
- *  Two invariants the SQL below enforces rather than trusts:
- *  - **`seq` is the only ordering authority.** Approval flips rewrite older
- *    messages, so `updated_at` does not order a transcript and is never read
- *    for ordering.
- *  - **Threads never cross subjects** (03 §5). The thread row is the ownership
- *    record; every read and write here joins it under `principal.subject`, so a
- *    foreign thread id reads as empty and writes to it are refused.
- */
-export function threadMessageStore<M extends ThreadMessageLike = ThreadMessageLike>(
-  store: VendoStore,
-): {
+/** Build contract §6 — the surface, whichever backend serves it. */
+export interface ThreadMessageStore<M extends ThreadMessageLike = ThreadMessageLike> {
   /** One row per message. Pass `expectedRevision` for a per-row CAS edit
    *  (contract §6): the write lands only if the row is still at that revision,
    *  so an edit built on a stale read is refused instead of clobbering a
@@ -45,8 +32,95 @@ export function threadMessageStore<M extends ThreadMessageLike = ThreadMessageLi
   ): Promise<void>;
   /** Reassembled by seq, oldest → newest. */
   list(principal: Principal, threadId: ThreadId): Promise<M[]>;
-} {
-  const db = dbFor(store);
+}
+
+function requireMessageId(message: ThreadMessageLike): string {
+  const messageId = message.id;
+  if (typeof messageId !== "string" || messageId === "") {
+    throw new VendoError("validation", "a thread message needs a non-empty id");
+  }
+  return messageId;
+}
+
+/** Build contract §6 — one row per transcript message.
+ *
+ *  Why this exists: rewriting a whole `messages` array on every turn is
+ *  O(messages²) over a conversation. One row per message makes a turn's write
+ *  O(new messages), which is the property E6 measures.
+ *
+ *  Two invariants both backends enforce rather than trust:
+ *  - **`seq` is the only ordering authority.** Approval flips rewrite older
+ *    messages, so `updated_at` does not order a transcript and is never read
+ *    for ordering.
+ *  - **Threads never cross subjects** (03 §5). The thread row is the ownership
+ *    record; every read and write here joins it under `principal.subject`, so a
+ *    foreign thread id reads as empty and writes to it are refused.
+ */
+export function threadMessageStore<M extends ThreadMessageLike = ThreadMessageLike>(
+  store: VendoStore,
+): ThreadMessageStore<M> {
+  const backend = backendOf(store, "the per-message transcript (build contract §6)");
+  return backend.kind === "ops" ? overOps<M>(backend.ops) : overSql<M>(backend.db);
+}
+
+/**
+ * The hosted half (design D2): transcripts ride `vendo/store-wire@1` as-is —
+ * `putMessage` for both the insert and the edit (an approval flip re-sends the
+ * message under its own id, which is the wire's edit), `getThread` for the read.
+ *
+ * Two honest differences from the SQL half, neither of which the runtime's
+ * caller can see:
+ * - **`seq` is not sent.** The wire's `putMessage` carries no seq; the service
+ *   appends at `max(seq) + 1`. `persistTurn` walks the canonical array in index
+ *   order and writes only what changed, so appended order IS seq order.
+ * - **Ownership is read-then-write**, not one statement. The TOCTOU window that
+ *   opens is between two writes by the same subject to a thread whose owner
+ *   would have to change mid-call, which the store has no verb for.
+ */
+function overOps<M extends ThreadMessageLike>(ops: StoreOps): ThreadMessageStore<M> {
+  /** The thread record is the ownership record on the wire exactly as the
+   *  `vendo_threads` row is in SQL: `data.subject` is the same field the join
+   *  reads. A foreign or absent thread yields nothing, so reads answer empty
+   *  and writes refuse — mirroring the local empty-read. */
+  const ownedThread = async (
+    principal: Principal,
+    threadId: ThreadId,
+  ): Promise<{ messages?: unknown } | undefined> => {
+    const record = await ops.transcripts.getThread(threadId);
+    if (record === null) return undefined;
+    const data = record.data as { subject?: unknown; messages?: unknown };
+    return data.subject === principal.subject ? data : undefined;
+  };
+
+  return {
+    async upsert(principal, threadId, message, _seq, opts) {
+      requireMessageId(message);
+      if (opts?.expectedRevision !== undefined) {
+        // Deliberately loud rather than silently downgraded to last-write-wins:
+        // a caller asking for CAS is asking not to clobber a concurrent edit.
+        // `transcripts.putMessage` carries no revision, so the guarantee cannot
+        // be honored over the wire — and no runtime caller asks for it.
+        throw new VendoError(
+          "not-implemented",
+          "a per-row CAS transcript edit (expectedRevision) is not expressible over the store wire: "
+          + "transcripts.putMessage carries no revision. Use a SQL-backed store for guarded edits.",
+        );
+      }
+      if (await ownedThread(principal, threadId) === undefined) {
+        throw new VendoError("conflict", `thread ${threadId} does not belong to this subject`);
+      }
+      await ops.transcripts.putMessage(threadId, message);
+    },
+    async list(principal, threadId) {
+      const data = await ownedThread(principal, threadId);
+      if (data === undefined) return [];
+      return Array.isArray(data.messages) ? data.messages as M[] : [];
+    },
+  };
+}
+
+/** The SQL half: the statements are the enforcement. */
+function overSql<M extends ThreadMessageLike>(db: Db): ThreadMessageStore<M> {
   return {
     async upsert(principal, threadId, message, seq, opts) {
       // The ownership gate is the INSERT's own source of rows: the SELECT
@@ -55,10 +129,7 @@ export function threadMessageStore<M extends ThreadMessageLike = ThreadMessageLi
       // Doing it in ONE statement closes the TOCTOU window a read-then-write
       // pre-check leaves open (the same reasoning as putThreadRow's guarded
       // upsert), and it is why the answer cannot be "insert anyway".
-      const messageId = message.id;
-      if (typeof messageId !== "string" || messageId === "") {
-        throw new VendoError("validation", "a thread message needs a non-empty id");
-      }
+      const messageId = requireMessageId(message);
       const expected = opts?.expectedRevision;
       const at = new Date().toISOString();
       // A CAS write is an EDIT, so it is a plain UPDATE rather than an upsert: it

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -1,4 +1,4 @@
-import type { BlobStore, RecordStore, StoreAdapter } from "@vendoai/core";
+import type { BlobStore, RecordStore, StoreAdapter, StoreOps } from "@vendoai/core";
 import { createBlobStore } from "./blobs.js";
 import { validateEncryptionKey } from "#store/crypto";
 // Type-only — erased at compile time. This module is the engine-agnostic
@@ -15,6 +15,11 @@ export interface VendoStore extends StoreAdapter {
   ensureSchema(): Promise<void>;
   close(): Promise<void>;
   raw(): unknown;
+  /** The 32-op named-operation surface, when this store carries one (the Cloud
+   *  hosted store does; a local store's lives behind `createStoreOps`). It is
+   *  what lets the helpers that need a transcript, a workspace or harness state
+   *  serve a store with no SQL handle — see `backendOf`. */
+  ops?: StoreOps;
 }
 
 /** Per-handle internals kept OFF the public store object (02-store §4 keeps
@@ -31,6 +36,14 @@ export function dbFor(store: VendoStore): Db {
   const found = internals.get(store);
   if (!found) throw new Error("Unknown VendoStore handle");
   return found.db;
+}
+
+/** The SQL handle behind a store, or `undefined` when this handle is not one
+ *  this package minted — a hosted store, or a host's own adapter. The asking
+ *  form of `dbFor`, for the callers that have a second way to serve the read
+ *  (`backendOf`) instead of nothing to say but "unknown handle". */
+export function maybeDbFor(store: VendoStore): Db | undefined {
+  return internals.get(store)?.db;
 }
 
 /** Package-internal (secrets.ts): the secrets configuration bound to a store

--- a/packages/store/src/thread-messages.ops.test.ts
+++ b/packages/store/src/thread-messages.ops.test.ts
@@ -1,0 +1,201 @@
+/**
+ * The transcript helper, proven against EVERY backend it can sit on.
+ *
+ * `threadMessageStore` used to open with `dbFor(store)`, so a store with no SQL
+ * handle — every hosted deployment — got "Unknown VendoStore handle" and the
+ * host silently fell back to the legacy chat path. It picks a backend now
+ * (`backendOf`), and the point of this file is that the CHOICE is invisible: one
+ * suite, three backends, same answers.
+ *
+ * The three:
+ *  - `sql`         — the store's own Postgres, the shipped path;
+ *  - `memory-ops`  — `memoryStoreOps()`, core's reference StoreOps;
+ *  - `local-ops`   — `createStoreOps(store)`, the 32-op contract served off the
+ *                    same real database, which is the closest offline stand-in
+ *                    for the console's own implementation.
+ *
+ * The console itself is proven with no stand-in at all, against Yousef's Vendo
+ * Cloud account, in `packages/vendo/src/hosted-transcript.live.test.ts`.
+ */
+import { VendoError, type Principal, type StoreOps } from "@vendoai/core";
+import { memoryStoreOps } from "@vendoai/core/conformance";
+import type { UIMessage } from "ai";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { backends, type MadeBackend } from "./backends.test-util.js";
+import { createStoreOps, threadMessageStore, threadStore, type VendoStore } from "./index.js";
+
+const alice: Principal = { kind: "user", subject: "user_alice" };
+const bob: Principal = { kind: "user", subject: "user_bob" };
+
+function message(id: string, text: string, role: "user" | "assistant" = "user"): UIMessage {
+  return { id, role, parts: [{ type: "text", text }] } as UIMessage;
+}
+
+/**
+ * A store the way a HOST supplies one: the public `VendoStore` surface plus a
+ * StoreOps, but NOT a handle `@vendoai/store` minted — so it is absent from the
+ * package's internals WeakMap and `dbFor` misses it. That is exactly the shape
+ * the Cloud hosted store presents.
+ */
+function opsOnlyStore(ops: StoreOps): VendoStore {
+  const unused = (what: string): never => {
+    throw new Error(`the transcript helper must not reach ${what}`);
+  };
+  return {
+    ops,
+    records: () => unused("records()"),
+    blobs: () => unused("blobs()"),
+    async ensureSchema() {},
+    async close() {},
+    raw: () => unused("raw()"),
+  };
+}
+
+interface Mode {
+  name: string;
+  store: VendoStore;
+  own(id: string, subject: string): Promise<void>;
+}
+
+/** Ids are namespaced per mode because `local-ops` and `sql` share one database. */
+const modesFor = (made: MadeBackend): Mode[] => {
+  const viaOps = (name: string, ops: StoreOps): Mode => ({
+    name,
+    store: opsOnlyStore(ops),
+    own: async (id, subject) => { await ops.transcripts.putThread({ id, subject, messages: [] }); },
+  });
+  return [
+    {
+      name: "sql",
+      store: made.store,
+      own: async (id, subject) => { await threadStore(made.store).put({ kind: "user", subject }, { id, messages: [] }); },
+    },
+    viaOps("memory-ops", memoryStoreOps()),
+    viaOps("local-ops", createStoreOps(made.store)),
+  ];
+};
+
+for (const backend of backends()) {
+  describe(`${backend.name} transcript helper across backends (build contract §6, design D1/D2)`, () => {
+    let made: MadeBackend;
+    let modes: Mode[];
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+      modes = modesFor(made);
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    describe.each([{ mode: "sql" }, { mode: "memory-ops" }, { mode: "local-ops" }])("$mode", ({ mode }) => {
+      const pick = (): Mode => modes.find((candidate) => candidate.name === mode)!;
+      const id = (suffix: string): string => `thr_${mode.replace("-", "_")}_${suffix}`;
+
+      it("reads back every message it wrote, oldest → newest", async () => {
+        const { store, own } = pick();
+        const thread = id("order");
+        await own(thread, alice.subject);
+        const messages = threadMessageStore<UIMessage>(store);
+        await messages.upsert(alice, thread, message("m_a", "first"), 0);
+        await messages.upsert(alice, thread, message("m_b", "second"), 1);
+        await messages.upsert(alice, thread, message("m_c", "third"), 2);
+
+        // A FRESH helper: nothing is cached in the handle, the rows are the truth.
+        const listed = await threadMessageStore<UIMessage>(store).list(alice, thread);
+        expect(listed.map((m) => m.id)).toEqual(["m_a", "m_b", "m_c"]);
+      });
+
+      it("scopes to the principal: one subject never reads another's thread messages", async () => {
+        const { store, own } = pick();
+        const thread = id("scoped");
+        await own(thread, alice.subject);
+        const messages = threadMessageStore<UIMessage>(store);
+        await messages.upsert(alice, thread, message("m_secret", "alice only"), 0);
+
+        await expect(messages.list(bob, thread)).resolves.toEqual([]);
+      });
+
+      it("a thread nobody created reads as empty rather than throwing", async () => {
+        const messages = threadMessageStore<UIMessage>(pick().store);
+        await expect(messages.list(alice, id("absent"))).resolves.toEqual([]);
+      });
+
+      it("refuses a cross-subject write to an existing thread", async () => {
+        const { store, own } = pick();
+        const thread = id("takeover");
+        await own(thread, alice.subject);
+        const messages = threadMessageStore<UIMessage>(store);
+        await messages.upsert(alice, thread, message("m_1", "mine"), 0);
+
+        await expect(messages.upsert(bob, thread, message("m_2", "yours"), 1)).rejects.toBeInstanceOf(VendoError);
+        await expect(messages.list(alice, thread)).resolves.toHaveLength(1);
+      });
+
+      it("refuses a write to a thread that does not exist", async () => {
+        const messages = threadMessageStore<UIMessage>(pick().store);
+        await expect(messages.upsert(alice, id("orphan"), message("m_1", "nowhere"), 0))
+          .rejects.toBeInstanceOf(VendoError);
+      });
+
+      it("refuses a message with no id — it is the row's key", async () => {
+        const { store, own } = pick();
+        const thread = id("noid");
+        await own(thread, alice.subject);
+        const messages = threadMessageStore<UIMessage>(store);
+        await expect(messages.upsert(alice, thread, { id: "" } as UIMessage, 0))
+          .rejects.toBeInstanceOf(VendoError);
+      });
+    });
+
+    /**
+     * The approval flip: the runtime re-writes an ALREADY PERSISTED message
+     * under its own id, and the transcript must hold one copy of it, not two.
+     * Over the wire that is `transcripts.putMessage` doing an edit-by-id.
+     *
+     * `memory-ops` is excluded because core's reference `putMessage` appends
+     * unconditionally — the wire's conformance suite only asserts append, so the
+     * reference has no id semantics to edit by. The LIVE console shares that gap
+     * (measured: `packages/vendo/src/hosted-transcript.live.test.ts` records it
+     * with an `it.fails`), which is why the two backends that DO carry id
+     * semantics are the ones checked here: they are what the wire contract has
+     * to grow into, not a lower bar this helper settled for.
+     */
+    describe.each([{ mode: "sql" }, { mode: "local-ops" }])("$mode approval flip", ({ mode }) => {
+      it("edits a message in place instead of appending a second copy", async () => {
+        const target = modes.find((candidate) => candidate.name === mode)!;
+        const thread = `thr_${mode.replace("-", "_")}_flip`;
+        await target.own(thread, alice.subject);
+        const messages = threadMessageStore<UIMessage>(target.store);
+        await messages.upsert(alice, thread, message("m_1", "before", "assistant"), 0);
+        await messages.upsert(alice, thread, message("m_2", "after it", "user"), 1);
+        await messages.upsert(alice, thread, message("m_1", "approved", "assistant"), 0);
+
+        const listed = await messages.list(alice, thread);
+        expect(listed.map((m) => m.id)).toEqual(["m_1", "m_2"]);
+        expect(JSON.stringify(listed[0])).toContain("approved");
+      });
+    });
+
+    /** SQL's per-row CAS has no wire expression: `transcripts.putMessage`
+     *  carries no revision. Loud beats a silent downgrade to last-write-wins. */
+    describe.each([{ mode: "memory-ops" }, { mode: "local-ops" }])("$mode", ({ mode }) => {
+      it("refuses a guarded (expectedRevision) edit rather than quietly clobbering", async () => {
+        const target = modes.find((candidate) => candidate.name === mode)!;
+        const thread = `thr_${mode.replace("-", "_")}_cas`;
+        await target.own(thread, alice.subject);
+        const messages = threadMessageStore<UIMessage>(target.store);
+        await messages.upsert(alice, thread, message("m_1", "one"), 0);
+
+        await expect(
+          messages.upsert(alice, thread, message("m_1", "two"), 0, { expectedRevision: 1 }),
+        ).rejects.toMatchObject({ code: "not-implemented" });
+      });
+    });
+  });
+}
+
+describe("a store with neither a SQL handle nor a StoreOps surface", () => {
+  it("is refused by name, at construction", () => {
+    const bare = { ...opsOnlyStore(memoryStoreOps()), ops: undefined };
+    expect(() => threadMessageStore(bare)).toThrow(/SQL handle or a StoreOps-capable store/);
+  });
+});

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -169,13 +169,12 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
   const threads = new ThreadRepository(config.store);
   // LAZY, and the laziness is load-bearing twice over.
   //
-  // `threadMessageStore` and `workspaceStore` both resolve a SQL handle
-  // (`dbFor`) as their first act. Building them at compose would (a) do work
-  // inside `createVendo`, which the common edge wiring calls at module init where
-  // Workers forbids it, and (b) throw "Unknown VendoStore handle" outright for a
-  // hosted store — which has no local SQL and, in wave 1, no workspace or
-  // transcript door of its own. Deferred, a hosted deployment composes exactly as
-  // before and only a host that actually drives a harness turn meets the gap.
+  // These three helpers pick their backend (`backendOf`) as their first act.
+  // Building them at compose would (a) do work inside `createVendo`, which the
+  // common edge wiring calls at module init where Workers forbids it, and (b)
+  // throw outright for a store that offers neither a SQL handle nor a StoreOps
+  // surface. Deferred, such a deployment composes exactly as before and only a
+  // host that actually drives a harness turn meets the gap.
   let sql: {
     transcript: ReturnType<typeof threadMessageStore<UIMessage>>;
     workspaces: ReturnType<typeof workspaceStore>;
@@ -195,10 +194,10 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       } catch (cause) {
         throw new VendoError(
           "not-implemented",
-          "Serving a turn through a harness needs a SQL-backed store: the transcript and the workspace "
-          + "(build contract §3.3 / §6) are tables. The configured store has no SQL handle — the Cloud "
-          + "hosted store does not serve the workspace or per-message transcript doors yet. Pass "
-          + "`store: postgres(url)` (or the local default) to use `harness:`.",
+          "Serving a turn through a harness needs somewhere to keep the transcript and the workspace "
+          + "(build contract §3.3 / §6): it needs a SQL-backed store (`store: postgres(url)`, or the "
+          + "local default) or a StoreOps-capable store (the Cloud hosted store). The configured store "
+          + "is neither.",
           { cause },
         );
       }

--- a/packages/vendo/src/hosted-transcript.live.test.ts
+++ b/packages/vendo/src/hosted-transcript.live.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The T1 seam, with no stand-in on either side: the REAL transcript and
+ * harness-state helpers, over a REAL `hostedStore`, against the REAL Vendo Cloud
+ * console — written through one client and read back through a second, freshly
+ * constructed one.
+ *
+ * Why a second client: a harness that mocks the counterparty proves nothing, and
+ * so does one that reads its own process's memory back. The read here goes over
+ * the wire a second time, from a client that has never seen the write, so the
+ * only thing that can make it pass is the console genuinely holding the rows.
+ *
+ * Gated on `VENDO_API_KEY` having content, like every other `.live.test.ts`:
+ * skipped without it, so CI and a keyless clone stay green. `VENDO_CLOUD_URL`
+ * overrides the mount for a staging console. Everything written is deleted at
+ * the end, and every id is per-run unique so two runs never collide.
+ */
+import { VendoError, type Principal } from "@vendoai/core";
+import { harnessStateStore, threadMessageStore } from "@vendoai/store";
+import type { UIMessage } from "ai";
+import { afterAll, describe, expect, it } from "vitest";
+import { hostedStore, type HostedStore } from "./hosted-store.js";
+
+// A named secret can EXIST and be empty (`infisical secrets get` exits 0 either
+// way), so the gate checks for content rather than for presence.
+const apiKey = process.env["VENDO_API_KEY"] ?? "";
+const live = apiKey === "" ? describe.skip : describe;
+
+const LIVE_TIMEOUT_MS = 60_000;
+
+/** Every run gets its own thread and its own subjects — the console account is
+ *  Yousef's real one, shared with every other live test. */
+const run = globalThis.crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+const threadId = `thr_live_${run}`;
+const owner: Principal = { kind: "user", subject: `user_live_${run}` };
+const stranger: Principal = { kind: "user", subject: `user_other_${run}` };
+
+const client = (): HostedStore => hostedStore({
+  apiKey,
+  ...(process.env["VENDO_CLOUD_URL"] === undefined ? {} : { baseUrl: process.env["VENDO_CLOUD_URL"] }),
+});
+
+const message = (id: string, text: string, role: "user" | "assistant" = "user"): UIMessage =>
+  ({ id, role, parts: [{ type: "text", text }] }) as UIMessage;
+
+const textOf = (m: UIMessage | undefined): string =>
+  (m?.parts ?? []).map((part) => (part.type === "text" ? part.text : "")).join("");
+
+live("hosted transcript + harness state over the real console", () => {
+  // ONE writer for the whole file; every read builds its own reader.
+  const writer = client();
+
+  afterAll(async () => {
+    await writer.ops.transcripts.deleteThread(threadId).catch(() => undefined);
+  }, LIVE_TIMEOUT_MS);
+
+  it("writes a transcript through the helper and reads it back on a fresh client", async () => {
+    await writer.ops.transcripts.putThread({ id: threadId, subject: owner.subject, messages: [] });
+
+    // The producer: the SHIPPED helper, picking the ops backend off the hosted
+    // store because there is no SQL handle to pick.
+    const producer = threadMessageStore<UIMessage>(writer);
+    await producer.upsert(owner, threadId, message("m_1", "what do I owe?"), 0);
+    await producer.upsert(owner, threadId, message("m_2", "checking now", "assistant"), 1);
+
+    // The consumer: the same shipped helper, over a client constructed after the
+    // write and sharing nothing with the writer but the account.
+    const consumer = threadMessageStore<UIMessage>(client());
+    const listed = await consumer.list(owner, threadId);
+
+    expect(listed.map((m) => m.id)).toEqual(["m_1", "m_2"]);
+    expect(textOf(listed[0])).toBe("what do I owe?");
+    expect(textOf(listed[1])).toBe("checking now");
+  }, LIVE_TIMEOUT_MS);
+
+  /**
+   * KNOWN CONSOLE GAP, recorded as an executable fact rather than a comment:
+   * `it.fails` passes while the console is wrong and turns RED the moment it is
+   * fixed, so nobody has to remember to come back.
+   *
+   * Design D2 reads `transcripts.putMessage` as "insert OR edit-by-id", which is
+   * what the local backend does (`packages/store/src/ops.ts`: append, and on an
+   * id collision UPDATE that row). The live console instead appends into the
+   * thread's message array and re-puts the whole thread, so re-writing a message
+   * under its own id is refused with
+   *   `thread … carries two messages with the id "m_2"; message ids must be
+   *    unique within a thread`.
+   *
+   * That is the approval flip: when an approval resolves, the runtime re-writes
+   * the already persisted assistant message under its own id. Until the console
+   * makes `putMessage` replace-by-id, a hosted deployment fails that write —
+   * loudly, at least, not silently duplicating history. The fix is console-side;
+   * there is no wire op that expresses an edit any other way.
+   */
+  it.fails("an approval flip edits the message in place — one copy, not two", async () => {
+    await threadMessageStore<UIMessage>(writer)
+      .upsert(owner, threadId, message("m_2", "approved: you owe $40", "assistant"), 1);
+
+    const listed = await threadMessageStore<UIMessage>(client()).list(owner, threadId);
+
+    expect(listed.map((m) => m.id)).toEqual(["m_1", "m_2"]);
+    expect(textOf(listed[1])).toBe("approved: you owe $40");
+  }, LIVE_TIMEOUT_MS);
+
+  it("another subject reads the thread as empty and cannot write to it", async () => {
+    const foreign = threadMessageStore<UIMessage>(client());
+
+    await expect(foreign.list(stranger, threadId)).resolves.toEqual([]);
+    await expect(foreign.upsert(stranger, threadId, message("m_x", "mine now"), 2))
+      .rejects.toBeInstanceOf(VendoError);
+    // And the owner's transcript is untouched by the attempt.
+    await expect(threadMessageStore<UIMessage>(client()).list(owner, threadId)).resolves.toHaveLength(2);
+  }, LIVE_TIMEOUT_MS);
+
+  it("keeps a harness's native session across clients, and destroys it on a swap", async () => {
+    await harnessStateStore(writer).set(threadId, "claude-code", `sess_${run}`);
+
+    expect(await harnessStateStore(client()).get(threadId, "claude-code")).toBe(`sess_${run}`);
+    // §1.3: a different thinker holds this conversation now, so the slot is
+    // destroyed rather than shadowed — swapping back must not resurrect it.
+    expect(await harnessStateStore(client()).get(threadId, "vendo")).toBeUndefined();
+    expect(await harnessStateStore(client()).get(threadId, "claude-code")).toBeUndefined();
+  }, LIVE_TIMEOUT_MS);
+});

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -1133,15 +1133,17 @@ function selectFiles(configured: FilesAdapter | undefined, store: VendoStore): F
 }
 
 /**
- * Can this store serve a harness turn? The transcript (build contract §6) and the
- * workspace (§3.3) are SQL tables; `threadMessageStore` resolves the handle as its
- * first act and throws for a store that has none — the Cloud hosted store, or a
- * host's own non-SQL adapter. Probing is a WeakMap lookup, never I/O, so it is
- * safe where `createVendo` runs at module init (Workers).
+ * Can this store serve a harness turn? The transcript (build contract §6) and
+ * the workspace (§3.3) need a home: a SQL handle, or the store's own 32-op
+ * StoreOps surface, which is what the Cloud hosted store carries.
+ * `threadMessageStore` picks between them (`backendOf`) as its first act and
+ * throws only for a store with neither. Probing stays a WeakMap lookup plus a
+ * property read, never I/O, so it is safe where `createVendo` runs at module
+ * init (Workers).
  *
  * This is the ONE thing that keeps the wave-2 default-route flip honest: a
  * deployment that cannot serve harness turns keeps the shipped `agent.stream`
- * path, which needs neither table, instead of failing every chat turn.
+ * path, which needs neither, instead of failing every chat turn.
  */
 function storeServesHarnessTurns(store: VendoStore): boolean {
   try {
@@ -3311,12 +3313,13 @@ export function createVendo(config: CreateVendoConfig): Vendo {
     // harness improvement shipped to nobody.
     //
     // ONE exception, and it is a capability fact rather than a preference: serving
-    // a turn through a harness needs the transcript and workspace TABLES (build
-    // contract §3.3/§6). A store with no SQL handle — the Cloud hosted store in
-    // wave 1, or a host's own non-SQL adapter — cannot serve them, and flipping
-    // such a deployment would turn every chat turn into a boot-shaped error. Those
-    // stay on `agent.stream`, which needs neither table. The probe is a WeakMap
-    // lookup inside @vendoai/store, not I/O, so it is safe at module init.
+    // a turn through a harness needs somewhere to keep the transcript and the
+    // workspace (build contract §3.3/§6) — a SQL handle, or the store's own
+    // StoreOps surface, which the Cloud hosted store carries. A store with
+    // NEITHER (a host's own bare adapter) cannot serve them, and flipping such a
+    // deployment would turn every chat turn into a boot-shaped error. Those stay
+    // on `agent.stream`, which needs neither. The probe is a WeakMap lookup
+    // inside @vendoai/store, not I/O, so it is safe at module init.
     ...(storeServesHarnessTurns(store) ? { harness: harnessDoor } : {}),
     guard,
     apps,


### PR DESCRIPTION
## What this changes

The three store helpers a harness turn needs demanded a raw SQL handle, so a
key-only (hosted-store) deployment could not serve harness turns and silently
fell back to the legacy chat path. This is **S1** of the one-path project: the
transcript and harness-state helpers gain hosted support. Workspace is S2.

- **`VendoStore` gains `ops?: StoreOps`.** `hostedStore` already exposed `.ops`,
  so it satisfies the member structurally — no change there.
- **One internal selector, `backendOf(store, what)`** (`packages/store/src/helpers/backend.ts`):
  the SQL handle when there is one (same database, one hop shorter), the store's
  own 32-op surface when there is not, and a named `VendoError("not-implemented")`
  naming *"a SQL handle or a StoreOps-capable store"* only when the store offers
  neither. Nothing above the store package can tell the two apart — **no caller
  changed**.
- **Transcripts over the wire as-is (D2):** `transcripts.putMessage` for the
  write, `transcripts.getThread` for the read. Ownership is enforced against the
  thread record's `subject` exactly as the SQL join enforces it against
  `vendo_threads`: a foreign or absent thread reads as `[]` and refuses writes.
  A guarded (`expectedRevision`) edit has no wire expression, so it is refused
  loudly rather than downgraded to last-write-wins — no runtime caller asks for
  one.
- **Harness state** rides the wire's `harness` family under the SAME slot the SQL
  half uses (`harness_state:<threadId>`, keyed by the thread's owner), so §1.3 —
  one slot per thread, a foreign harness *destroying* rather than shadowing it,
  the slot dying with its thread — holds identically on both backends.
- **`harness-turn.ts`** refusal reworded: thrown only when the store has neither
  a SQL handle nor ops, and it names both options.
- **`server.ts`** `storeServesHarnessTurns` now answers true for an ops-carrying
  store (still a no-I/O probe: a WeakMap lookup plus a property read).

## Proof

New tests only; no existing test was touched.

- `packages/store/src/thread-messages.ops.test.ts` and
  `packages/store/src/harness-state.ops.test.ts` — **one behavioral suite per
  helper, run against three backends**: `sql` (real PGlite/Postgres),
  `memory-ops` (core's `memoryStoreOps` reference), and `local-ops`
  (`createStoreOps` — the 32-op contract served off the same real database).
  48 tests.
- `packages/vendo/src/hosted-transcript.live.test.ts` — **the seam with no stub
  on either side**: writes through the real `threadMessageStore` over a real
  `hostedStore` against the **real console** on Yousef's Vendo Cloud account,
  then reads back through a *second, freshly constructed* client that has never
  seen the write. Same for harness state. Gated on `VENDO_API_KEY` having
  content, so CI and a keyless clone stay green.

**Prove-red done:** disabling the ops leg in `backendOf` turns **31 of the 48**
new store tests red (the 17 survivors are the `sql` cases and the two
neither-backend refusals). Restored, all 48 pass.

## Gate

| check | result |
| --- | --- |
| `pnpm --filter @vendoai/store test` | 481 passed, **2 pre-existing environment failures** — `durability.drill` / `split-brain.drill`, which resolve a fixture via `new URL(...).pathname` and break on a worktree path containing a space (`Cool%20Code`). Unrelated to this diff; the store vitest config already calls this drill out as space-path-sensitive. |
| `pnpm --filter @vendoai/store typecheck` | green |
| `pnpm --filter @vendoai/vendo typecheck` | green |
| affected vendo suites (`harness-wire`, `turn-id.e2e`, `org-policy`, `hosted-store`) | 87 passed |
| `hosted-transcript.live.test.ts` (real console) | 4 passed |
| `scripts/dependency-guard.mjs` | green |

Full suite runs centrally at the merge boundary, not here.

## Two things the reviewer must decide on

**1. The console's `putMessage` appends — it does not edit by id.** Measured
live: re-writing an already persisted message under its own id is refused with
`thread … carries two messages with the id "m_2"; message ids must be unique
within a thread`. The console implements `putMessage` as read-thread → push →
put-whole-thread, so it trips the duplicate-id guard.

That is the **approval flip**: when an approval resolves, the runtime re-writes
the already persisted assistant message under its own id (`persistTurn` diffs
against the pristine copy and re-upserts what changed). Until the console makes
`putMessage` replace-by-id, a hosted deployment fails that write. It fails
loudly rather than duplicating history, and there is no wire op that expresses
an edit any other way — **the fix is console-side.** Structure §2's D2 line
("putMessage for insert AND edit-by-id") does not hold against today's console.

Recorded as an executable fact: an `it.fails` in the live test, which passes
while the console is wrong and turns **red the moment it is fixed**. Core's
`memoryStoreOps` shares the gap (its `putMessage` appends unconditionally, and
the wire conformance suite only asserts append), which is why the flip case in
the store suite runs against `sql` + `local-ops` — the two backends that do
carry id semantics. Conformance files belong to S2/S3, so I did not touch them;
they should gain an edit-by-id case with the console fix.

**2. Interim window with S2.** With the probe now accepting ops-capable stores,
a hosted deployment is routed to the harness path — but `workspaceStore` (S2's
file) still resolves `dbFor` and throws, so `sqlDoors()` still fails for hosted
until S2 lands. S1 and S2 must land together; S1 alone on `main` would move
hosted chat from "legacy path, works" to "harness path, errors".

Also noted: `seq` is not sent over the wire (`transcripts.putMessage` carries
none — the service appends at `max(seq)+1`). `persistTurn` walks the canonical
array in index order and writes only what changed, so appended order *is* seq
order. Documented at the branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hosted stores can now serve harness turns by moving transcripts and harness state to the `StoreOps` surface. This removes the SQL-only requirement and keeps behavior consistent across backends.

- **New Features**
  - `VendoStore` adds `ops?: StoreOps`; `backendOf` selects SQL or `ops`, and throws only if neither is available.
  - Transcripts use wire ops (`transcripts.putMessage` / `transcripts.getThread`) with ownership checks; guarded edits (`expectedRevision`) are rejected over the wire.
  - Harness state rides the same slot (`harness_state:<threadId>`, keyed by thread owner) with identical clearing and cascade rules on both backends.
  - `server.ts` probe now accepts ops-capable stores; `harness-turn.ts` error mentions both SQL and `StoreOps` options.

- **Migration**
  - Hosted deployments will route to the harness path; `workspaceStore` (S2) must land with S1 to avoid hosted errors.

<sup>Written for commit 384527c76a925b740ef40268fa463795fa50ea10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

