### PR TITLE
ci: drop two dead steps from the sharded gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,8 @@ jobs:
     timeout-minutes: 15
     needs: test-shards
     if: always() && needs.test-shards.result != 'cancelled'
+    # No turbo cache step: this job never invokes turbo — it replays blob
+    # reports through vitest directly.
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -201,8 +203,6 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-      - name: Turbo remote cache (GitHub-cache backed)
-        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
       - run: pnpm install --frozen-lockfile
       # continue-on-error: a package whose shards all skipped (unaffected) has
       # no artifacts, and download-artifact treats a pattern that matches
@@ -264,8 +264,9 @@ jobs:
       - name: Turbo remote cache (GitHub-cache backed)
         uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
       - run: pnpm install --frozen-lockfile
-      - name: Build deps
-        run: pnpm turbo run build --filter=@vendoai-examples/ai-sdk-agent --filter=@vendoai-examples/mastra-agent --filter=@vendoai-corpus/express-host
+      # No separate build step: turbo.json gives `test` dependsOn
+      # ["^build", "build"], so this one command builds the three packages and
+      # their workspace deps before running them.
       - name: Test formerly-local-only suites
         run: pnpm turbo run test --continue --concurrency=2 --filter=@vendoai-examples/ai-sdk-agent --filter=@vendoai-examples/mastra-agent --filter=@vendoai-corpus/express-host
 


### PR DESCRIPTION
Two steps in the gate landed in #834 that do nothing. Both verified before cutting.

**`coverage-merge`: the turbo remote-cache step.** That job never invokes turbo — it downloads the shards' blob artifacts and replays them with `pnpm --filter … exec vitest run --merge-reports --coverage`. The cache action was starting a cache server nothing talked to.

**`hermetic-extras`: the explicit `Build deps` step.** `turbo.json` declares `test` with `dependsOn: ["^build", "build"]`, so `turbo run test` already builds the three packages and their workspace deps. Verified with `--dry=json`: the test run's task graph contains `build` for ai-sdk-agent, mastra-agent and express-host plus every `@vendoai/*` dependency. The separate step was building the same graph a second time.

**Left alone on purpose:** the `test-shards` jobs keep their `Build deps` step. Those invoke vitest directly (to pass `--shard`), so no turbo `test` task exists to pull the build in — their builds are load-bearing.

No behaviour change; `hermetic-extras` and `coverage-merge` should be a bit faster.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove two no-op steps from the sharded CI gate to cut setup time and duplicate work. No behavior change; tests run the same, a bit faster.

- **Refactors**
  - coverage-merge: removed the turbo remote-cache step. This job never calls `turbo`; it replays shard blobs via `pnpm`/`vitest` with `--merge-reports`.
  - hermetic-extras: removed the explicit "Build deps" step. `turbo.json` sets `test` to depend on `build`, so `pnpm turbo run test` builds before testing. `test-shards` keep their build step since they run `vitest` directly.

<sup>Written for commit f7da6cb4329cbe6eff224a737d0db6e0219a561d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

