### PR TITLE
chore(core): drop dead knowledge surface — KnowledgeEmbedder, chunk/context schemas

### DIFF
--- a/packages/core/src/knowledge.ts
+++ b/packages/core/src/knowledge.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { isoDateTimeSchema, type IsoDateTime } from "./ids.js";
-import { principalSchema, type Principal } from "./principal.js";
+import { type Principal } from "./principal.js";
 
 /** Knowledge design v2 (2026-07-22) R1 — the doc-hash manifest version tag. */
 export const VENDO_KNOWLEDGE_HASH_FORMAT = "vendo/knowledge-hash@1" as const;
@@ -106,11 +106,6 @@ export interface KnowledgeContext {
   principal: Principal;
   includeInternal?: boolean;
 }
-
-export const knowledgeContextSchema = z.object({
-  principal: principalSchema,
-  includeInternal: z.boolean().optional(),
-}).passthrough() satisfies z.ZodType<KnowledgeContext>;
 
 /** Knowledge design v2 (2026-07-22) R3/R4. */
 export interface KnowledgeHit {
@@ -218,29 +213,12 @@ export interface KnowledgeChunk {
   heading?: string;
 }
 
-export const knowledgeChunkSchema = z.object({
-  docId: z.string().min(1),
-  chunkId: z.string().min(1),
-  text: z.string(),
-  index: z.number().int().nonnegative(),
-  heading: z.string().optional(),
-}).passthrough() satisfies z.ZodType<KnowledgeChunk>;
-
 /** Knowledge design v2 (2026-07-22) R1 — structural chunking only in v1
     (semantic chunking cut 2026-07-22). Bumping `version` obliges the local
     engine to re-chunk stored docs (the engine owns re-index versioning). */
 export interface KnowledgeChunker {
   version: number;
   chunk(doc: KnowledgeDoc): KnowledgeChunk[];
-}
-
-/** Knowledge design v2 (2026-07-22) R3 — the minimal embedding client: exists
-    solely because hybrid RRF needs a vector list to fuse. Local-engine
-    internal; Anthropic-only hosts never invoke it. A changed `model` obliges
-    re-embedding from stored docs. */
-export interface KnowledgeEmbedder {
-  model: string;
-  embed(texts: string[]): Promise<number[][]>;
 }
 
 /** Knowledge design v2 (2026-07-22) R1 — sync's doc-level content-hash


### PR DESCRIPTION
## What

Removes three exports from `packages/core/src/knowledge.ts` with zero consumers anywhere in the repo (verified by grep across packages/docs/corpus/examples):

- **`KnowledgeEmbedder`** — existed solely for hybrid RRF, part of the semantic-search plan cut 2026-07-22; never implemented, never imported.
- **`knowledgeChunkSchema`** — the chunker uses the plain `KnowledgeChunk` type; no chunk crosses a runtime-validation boundary.
- **`knowledgeContextSchema`** — the context deliberately never crosses the wire (the principal stays host-side per R5), so nothing validates it.

The types `KnowledgeChunk`, `KnowledgeChunker`, and `KnowledgeContext` stay — they have real consumers. The now-unused `principalSchema` import is trimmed.

## Why

Dead surface in the frozen contract file reads as promised API. `-23` lines, no behavior change.

## Verification

Full gate green locally: `pnpm build && pnpm test && pnpm typecheck && pnpm lint`. No UI impact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused exports from `packages/core/src/knowledge.ts` to shrink the public surface with no behavior change. Dropped `KnowledgeEmbedder`, `knowledgeChunkSchema`, and `knowledgeContextSchema`, and trimmed the unused `principalSchema` import; kept the `KnowledgeChunk`, `KnowledgeChunker`, and `KnowledgeContext` types.

<sup>Written for commit c71c6171bd1461f98ee8ef81e749f16307aa97bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

