### PR TITLE
feat(store,core,vendo): workspace rides StoreOps with per-owner drawers (S2)

### DIFF
--- a/packages/core/src/conformance/memory-store-ops.ts
+++ b/packages/core/src/conformance/memory-store-ops.ts
@@ -68,10 +68,19 @@ export function memoryStoreOps(): StoreOps {
   // harness: Map<"appId:subject", state>
   const harnessState = new Map<string, unknown>();
 
-  // workspace
-  type WsEntry = { path: string; data: unknown };
-  type WsCommit = { id: string; entries: WsEntry[]; before: Map<string, unknown> };
-  const wsFiles = new Map<string, unknown>();
+  // workspace — one drawer per owner (the end user or org the files belong to);
+  // a call with no owner rides the bound single-player default, exactly as the
+  // local backend does.
+  type WsEntry = { path: string; data?: unknown; delete?: true; expectedRevision?: number };
+  type WsFile = { data: unknown; revision: number; updatedAt: IsoDateTime };
+  type WsCommit = { id: string; owner: string; entries: WsEntry[]; before: Map<string, unknown> };
+  const BOUND_OWNER = "user_local";
+  const drawers = new Map<string, Map<string, WsFile>>();
+  const drawer = (owner: string): Map<string, WsFile> => {
+    let files = drawers.get(owner);
+    if (!files) { files = new Map(); drawers.set(owner, files); }
+    return files;
+  };
   const wsCommits: WsCommit[] = [];
   let wsCommitSeq = 0;
   // idempotency key -> the body it first carried, so a replay can be told from
@@ -244,10 +253,19 @@ export function memoryStoreOps(): StoreOps {
         if (k.startsWith(`${harnessSlot(id)}:`)) harnessState.delete(k);
       }
     },
+    /** Insert, or EDIT BY ID: a message whose id is already in the thread
+        replaces it in place — that is how an approval flips from pending to
+        answered. Appending it would leave two messages under one id, which
+        every real backend refuses. */
     async putMessage(threadId, message) {
       const entry = threads.get(threadId);
       if (!entry) throw new VendoError("not-found", `thread ${threadId} not found`);
-      entry.thread.messages.push(jsonCopy(message));
+      const id = (message as { id?: unknown } | null)?.id;
+      const at = typeof id === "string" && id !== ""
+        ? entry.thread.messages.findIndex((m) => (m as { id?: unknown } | null)?.id === id)
+        : -1;
+      if (at !== -1) entry.thread.messages[at] = jsonCopy(message);
+      else entry.thread.messages.push(jsonCopy(message));
       const rec = threadRecord(threadId, entry.thread, entry.record);
       threads.set(threadId, { record: rec, thread: entry.thread });
       return copyRecord(rec);
@@ -292,9 +310,18 @@ export function memoryStoreOps(): StoreOps {
   // workspace family
   // ---------------------------------------------------------------------------
 
+  const byteLength = (data: unknown): number =>
+    new TextEncoder().encode(JSON.stringify(data ?? null)).length;
+
   const workspace: StoreOps["workspace"] = {
     async index(query) {
-      const entries = [...wsFiles.entries()].map(([path, data]) => ({ path, data }));
+      const files = drawer(query?.owner ?? BOUND_OWNER);
+      const entries = [...files.entries()].map(([path, file]) => ({
+        path,
+        bytes: byteLength(file.data),
+        revision: file.revision,
+        updatedAt: file.updatedAt,
+      }));
       const offset = query?.cursor ? Math.max(0, Number.parseInt(query.cursor, 10)) : 0;
       const end = Math.min(offset + pageLimit(query?.limit), entries.length);
       return {
@@ -302,15 +329,17 @@ export function memoryStoreOps(): StoreOps {
         ...(end < entries.length ? { cursor: String(end) } : {}),
       };
     },
-    async read(paths) {
+    async read(paths, opts) {
+      const files = drawer(opts?.owner ?? BOUND_OWNER);
       const result: Record<string, unknown> = {};
       for (const p of paths) {
-        const v = wsFiles.get(p);
-        if (v !== undefined) result[p] = jsonCopy(v);
+        const file = files.get(p);
+        if (file !== undefined) result[p] = jsonCopy(file.data);
       }
       return result;
     },
     async commit(entries, opts) {
+      const owner = opts?.owner ?? BOUND_OWNER;
       const key = opts?.idempotencyKey;
       if (key !== undefined) {
         const body = JSON.stringify(entries);
@@ -321,16 +350,40 @@ export function memoryStoreOps(): StoreOps {
         }
         wsIdempotencyKeys.set(key, body);
       }
+      const files = drawer(owner);
+      // Strict compare-and-swap is checked for the WHOLE set first: a commit
+      // that conflicts on one path applies none of itself.
+      const conflicts = (entries as WsEntry[])
+        .filter((e) => e.expectedRevision !== undefined
+          && files.get(e.path)?.revision !== e.expectedRevision)
+        .map((e) => e.path);
+      if (conflicts.length > 0) {
+        throw new VendoError(
+          "conflict",
+          `the workspace moved on under ${conflicts.sort().join(", ")}; nothing was committed`,
+        );
+      }
       wsCommitSeq += 1;
       const before = new Map<string, unknown>();
       for (const e of entries as WsEntry[]) {
-        before.set(e.path, wsFiles.get(e.path));
-        wsFiles.set(e.path, jsonCopy(e.data));
+        before.set(e.path, files.get(e.path)?.data);
+        if (e.delete === true) {
+          files.delete(e.path);
+          continue;
+        }
+        files.set(e.path, {
+          data: jsonCopy(e.data),
+          revision: (files.get(e.path)?.revision ?? 0) + 1,
+          updatedAt: isoNow(),
+        });
       }
-      wsCommits.push({ id: String(wsCommitSeq), entries: entries as WsEntry[], before });
+      wsCommits.push({ id: String(wsCommitSeq), owner, entries: entries as WsEntry[], before });
     },
     async history(query) {
-      const all = wsCommits.map((c) => ({ commitId: c.id, entries: c.entries }));
+      const owner = query?.owner ?? BOUND_OWNER;
+      const all = wsCommits
+        .filter((c) => c.owner === owner)
+        .map((c) => ({ commitId: c.id, entries: c.entries }));
       all.reverse(); // newest first
       const offset = query?.cursor ? Math.max(0, Number.parseInt(query.cursor, 10)) : 0;
       const end = Math.min(offset + pageLimit(query?.limit), all.length);
@@ -339,13 +392,17 @@ export function memoryStoreOps(): StoreOps {
         ...(end < all.length ? { cursor: String(end) } : {}),
       };
     },
-    async undo(commitId) {
-      const idx = wsCommits.findIndex((c) => c.id === commitId);
+    async undo(commitId, opts) {
+      const owner = opts?.owner ?? BOUND_OWNER;
+      // Another owner's commit is not this owner's to undo — and saying so
+      // would make the door an existence oracle.
+      const idx = wsCommits.findIndex((c) => c.id === commitId && c.owner === owner);
       if (idx === -1) throw new VendoError("not-found", `commit ${commitId} not found`);
       const commit = wsCommits[idx]!;
+      const files = drawer(owner);
       for (const [path, prev] of commit.before) {
-        if (prev === undefined) wsFiles.delete(path);
-        else wsFiles.set(path, prev);
+        if (prev === undefined) files.delete(path);
+        else files.set(path, { data: prev, revision: (files.get(path)?.revision ?? 0) + 1, updatedAt: isoNow() });
       }
       wsCommits.splice(idx, 1);
     },

--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -86,6 +86,15 @@ const stringField = (entry: unknown, field: string, message: string): string => 
   return value;
 };
 
+/** The numeric twin of {@link stringField} — `workspace.index` entries carry
+    the revision a strict commit compare-and-swaps against, so the field is
+    contract the same way `commitId` is. */
+const numberField = (entry: unknown, field: string, message: string): number => {
+  const value = (entry as Record<string, unknown> | null)?.[field];
+  assert(typeof value === "number", `${message}: entry ${JSON.stringify(entry)} has no number "${field}"`);
+  return value;
+};
+
 /** A thread's harness state rides the harness slot under this synthetic appId
     (the store's `harnessStateKey`), which is what makes deleteThread's cascade
     onto harness state observable through the 32 ops. */
@@ -344,6 +353,27 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         assert(msgs.length === 2, `putMessage did not append: got ${msgs.length} messages`);
       }),
 
+      /** putMessage is an UPSERT, not an append-only log: a message re-sent
+          under an id the thread already holds REPLACES it, in place. That is
+          how an edit lands and how an approval flips from pending to answered;
+          appending instead leaves two messages under one id, which the thread
+          engines refuse outright, so the flip could never persist. */
+      opsCase(opts, "transcripts.putMessage edits by id, in place", async (ops) => {
+        await ops.transcripts.putThread({ id: "thr_pm2", subject: "u", messages: [] });
+        await ops.transcripts.putMessage("thr_pm2", { id: "msg_a", role: "user", text: "ask" });
+        await ops.transcripts.putMessage("thr_pm2", { id: "msg_b", role: "assistant", text: "answer" });
+        await ops.transcripts.putMessage("thr_pm2", { id: "msg_a", role: "user", text: "ask (edited)" });
+
+        const got = await ops.transcripts.getThread("thr_pm2");
+        const msgs = (got!.data as Record<string, unknown>)["messages"] as Array<Record<string, unknown>>;
+        assert(msgs.length === 2, `the edit should not have added a message: got ${msgs.length}`);
+        assertDeepEqual(
+          msgs.map((message) => [message["id"], message["text"]]),
+          [["msg_a", "ask (edited)"], ["msg_b", "answer"]],
+          "the edit did not replace its message in place",
+        );
+      }),
+
       opsCase(opts, "transcripts.recordAnswer records answer; duplicate same-id refused as conflict", async (ops) => {
         await ops.transcripts.putThread({ id: "thr_ra1", subject: "u", messages: [] });
         await ops.transcripts.recordAnswer("thr_ra1", { id: "ans_1", value: 42 });
@@ -461,6 +491,134 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
           "undo did not restore the value its commit replaced",
         );
         await assertThrowsCode(() => ops.workspace.undo("commit_absent"), "not-found", "undoing an unknown commit");
+      }),
+
+      /** The workspace is the last op family to name its owner, and until it
+          did, every end user of one deployment shared ONE drawer. Two owners,
+          one path: no read, index, history or undo may cross. */
+      opsCase(opts, "workspace ops keep two owners' drawers apart", async (ops) => {
+        const path = "shared.json";
+        await ops.workspace.commit([{ path, data: { who: "a" } }], { owner: "own_a" });
+        await ops.workspace.commit([{ path, data: { who: "b" } }], { owner: "own_b" });
+
+        assertDeepEqual(
+          (await ops.workspace.read([path], { owner: "own_a" }))[path],
+          { who: "a" },
+          "one owner's read returned another owner's file",
+        );
+        assertDeepEqual(
+          (await ops.workspace.read([path], { owner: "own_b" }))[path],
+          { who: "b" },
+          "one owner's read returned another owner's file",
+        );
+        assertDeepEqual(
+          await ops.workspace.read([path], { owner: "own_c" }),
+          {},
+          "an owner with no files read someone else's drawer",
+        );
+        assertDeepEqual(
+          (await ops.workspace.index({ owner: "own_a" })).entries
+            .map((entry) => stringField(entry, "path", "workspace.index")),
+          [path],
+          "one owner's index listed another owner's files",
+        );
+        assertDeepEqual(
+          (await ops.workspace.index({ owner: "own_c" })).entries,
+          [],
+          "an owner with no files indexed someone else's drawer",
+        );
+
+        const commitsOf = async (owner: string): Promise<string[]> =>
+          (await ops.workspace.history({ owner })).entries
+            .map((entry) => stringField(entry, "commitId", "workspace.history"));
+        const [ofA, ofB] = [await commitsOf("own_a"), await commitsOf("own_b")];
+        assert(ofA.length === 1 && ofB.length === 1, "history did not filter by owner");
+        assert(ofA[0] !== ofB[0], "two owners' histories returned the same commit");
+        await assertThrowsCode(
+          () => ops.workspace.undo(ofB[0]!, { owner: "own_a" }),
+          "not-found",
+          "undoing another owner's commit",
+        );
+        assertDeepEqual(
+          (await ops.workspace.read([path], { owner: "own_b" }))[path],
+          { who: "b" },
+          "a cross-owner undo changed the other owner's file",
+        );
+      }),
+
+      /** Deletion was inexpressible over the wire: a hosted workspace could
+          add and overwrite files forever but never drop one. */
+      opsCase(opts, "workspace.commit removes a path with a delete tombstone, and undo restores it", async (ops) => {
+        await ops.workspace.commit([{ path: "tomb.json", data: { v: 1 } }]);
+        await ops.workspace.commit([{ path: "tomb.json", delete: true }]);
+        assertDeepEqual(
+          await ops.workspace.read(["tomb.json"]),
+          {},
+          "the tombstone left the file behind",
+        );
+        assertDeepEqual(
+          (await ops.workspace.index()).entries
+            .map((entry) => stringField(entry, "path", "workspace.index")),
+          [],
+          "the tombstoned path is still in the index",
+        );
+        const newest = stringField(
+          (await ops.workspace.history()).entries[0],
+          "commitId",
+          "workspace.history",
+        );
+        await ops.workspace.undo(newest);
+        assertDeepEqual(
+          (await ops.workspace.read(["tomb.json"]))["tomb.json"],
+          { v: 1 },
+          "undoing a tombstone did not bring the file back",
+        );
+      }),
+
+      /** The `/orgs` mounts commit under strict compare-and-swap: a write built
+          on a revision that has moved must be refused, not silently applied
+          over a colleague's edit. */
+      opsCase(opts, "workspace.commit refuses a stale expectedRevision and applies nothing", async (ops) => {
+        await ops.workspace.commit([{ path: "cas.json", data: { v: 1 } }]);
+        const revision = numberField(
+          (await ops.workspace.index()).entries[0],
+          "revision",
+          "workspace.index",
+        );
+        // The head moves under the caller.
+        await ops.workspace.commit([{ path: "cas.json", data: { v: 2 } }]);
+
+        await assertThrowsCode(
+          () => ops.workspace.commit([
+            { path: "cas.json", data: { v: 3 }, expectedRevision: revision },
+            { path: "cas-other.json", data: { v: 3 } },
+          ]),
+          "conflict",
+          "committing against a revision that has moved",
+        );
+        assertDeepEqual(
+          (await ops.workspace.read(["cas.json"]))["cas.json"],
+          { v: 2 },
+          "the refused commit overwrote the newer content",
+        );
+        assert(
+          !("cas-other.json" in await ops.workspace.read(["cas-other.json"])),
+          "the refused commit applied its non-conflicting entry anyway",
+        );
+
+        // Re-aimed at the live head, the same commit lands.
+        const head = numberField(
+          (await ops.workspace.index()).entries
+            .find((entry) => (entry as { path?: unknown }).path === "cas.json"),
+          "revision",
+          "workspace.index",
+        );
+        await ops.workspace.commit([{ path: "cas.json", data: { v: 3 }, expectedRevision: head }]);
+        assertDeepEqual(
+          (await ops.workspace.read(["cas.json"]))["cas.json"],
+          { v: 3 },
+          "a commit aimed at the live revision did not land",
+        );
       }),
 
       // =====================================================================

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -205,19 +205,42 @@ export const storeWireHarnessClearRequestSchema = z.object({
 // workspace
 // ---------------------------------------------------------------------------
 
-export const storeWireWorkspaceIndexRequestSchema = cursorQuerySchema;
+/** The owner whose drawer a workspace op addresses: the end user (or org) the
+    files belong to, the way every other op family already names its subject.
+    Optional here because a single-player mount binds its one owner at
+    construction; a mount serving more than one user always sends it, or its
+    whole user base shares one drawer. */
+const ownerField = { owner: z.string().min(1).optional() };
+
+/** One committed change to one path: new content, or a tombstone that removes
+    it (deletion was otherwise inexpressible over the wire). `expectedRevision`
+    makes the write a strict compare-and-swap against the revision the caller
+    read — the `/orgs` mounts' policy — and a stale one refuses the commit.
+    `data` stays unknown: content is the caller's JSON, with binary riding the
+    `{"$vendoWorkspaceBytes": base64}` envelope. */
+export const storeWireWorkspaceEntrySchema = z.object({
+  path: z.string().min(1),
+  data: z.unknown(),
+  delete: z.literal(true).optional(),
+  expectedRevision: z.number().int().min(0).optional(),
+}).passthrough();
+
+export const storeWireWorkspaceIndexRequestSchema = cursorQuerySchema.extend(ownerField);
 
 export const storeWireWorkspaceReadRequestSchema = z.object({
+  ...ownerField,
   paths: z.array(z.string().min(1)).min(1),
 }).passthrough();
 
 export const storeWireWorkspaceCommitRequestSchema = z.object({
-  entries: z.array(z.unknown()).min(1),
+  ...ownerField,
+  entries: z.array(storeWireWorkspaceEntrySchema).min(1),
 }).passthrough();
 
-export const storeWireWorkspaceHistoryRequestSchema = cursorQuerySchema;
+export const storeWireWorkspaceHistoryRequestSchema = cursorQuerySchema.extend(ownerField);
 
 export const storeWireWorkspaceUndoRequestSchema = z.object({
+  ...ownerField,
   commitId: z.string().min(1),
 }).passthrough();
 

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -133,12 +133,23 @@ export interface StoreOps {
     set(appId: string, subject: string, state: unknown): Promise<void>;
     clear(appId: string, subject: string): Promise<void>;
   };
+  /** Every workspace verb names its OWNER — the end user (or org) whose drawer
+      the files live in, exactly as conversations, records and blobs already do.
+      Omitted, the backend falls back to the owner it was constructed with, which
+      is the single-player local default; a multi-user hosted mount always passes
+      one, or its whole user base shares one drawer.
+
+      Entries are `{ path, data?, delete?, expectedRevision? }`: `delete: true` is
+      a tombstone (deletion is otherwise inexpressible), and `expectedRevision` is
+      the strict compare-and-swap the `/orgs` mounts commit under — a stale one
+      refuses the WHOLE commit with `conflict`, so the caller re-reads once.
+      Binary content rides `{"$vendoWorkspaceBytes": base64, contentType?}`. */
   workspace: {
-    index(query?: { cursor?: string; limit?: number }): Promise<{ entries: unknown[]; cursor?: string }>;
-    read(paths: string[]): Promise<Record<string, unknown>>;
-    commit(entries: unknown[], opts?: { idempotencyKey?: string }): Promise<void>;
-    history(query?: { cursor?: string; limit?: number }): Promise<{ entries: unknown[]; cursor?: string }>;
-    undo(commitId: string): Promise<void>;
+    index(query?: { cursor?: string; limit?: number; owner?: string }): Promise<{ entries: unknown[]; cursor?: string }>;
+    read(paths: string[], opts?: { owner?: string }): Promise<Record<string, unknown>>;
+    commit(entries: unknown[], opts?: { idempotencyKey?: string; owner?: string }): Promise<void>;
+    history(query?: { cursor?: string; limit?: number; owner?: string }): Promise<{ entries: unknown[]; cursor?: string }>;
+    undo(commitId: string, opts?: { owner?: string }): Promise<void>;
   };
   lifecycle: {
     erase(target: EraseTarget): Promise<unknown>;

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -33,17 +33,32 @@ const WORKSPACE_COMMITS = "vendo_workspace_commits";
 
 interface WorkspaceEntry {
   path: string;
-  data: unknown;
+  data?: unknown;
+  /** A tombstone: the commit removes this path (history keeps the content, so
+   *  undo brings it back). */
+  delete?: true;
+  /** Strict compare-and-swap against the revision the caller read — the
+   *  `/orgs` mounts' commit policy. A stale one refuses the WHOLE commit. */
+  expectedRevision?: number;
 }
 
 function parseWorkspaceEntries(entries: unknown[]): WorkspaceEntry[] {
   return entries.map((entry) => {
     const path = (entry as { path?: unknown } | null)?.path;
     if (typeof path !== "string" || path === "") invalid("workspace entry needs a non-empty path");
-    if ((entry as { data?: unknown }).data === undefined) {
+    const tombstone = (entry as { delete?: unknown }).delete === true;
+    if (!tombstone && (entry as { data?: unknown }).data === undefined) {
       invalid(`workspace entry ${path} needs data`);
     }
-    return { path, data: (entry as { data: unknown }).data };
+    const expectedRevision = (entry as { expectedRevision?: unknown }).expectedRevision;
+    if (expectedRevision !== undefined && typeof expectedRevision !== "number") {
+      invalid(`workspace entry ${path} has a non-numeric expectedRevision`);
+    }
+    return {
+      path,
+      ...(tombstone ? { delete: true as const } : { data: (entry as { data: unknown }).data }),
+      ...(expectedRevision === undefined ? {} : { expectedRevision }),
+    };
   });
 }
 
@@ -64,9 +79,12 @@ export function createStoreOps(
   options: { files?: FilesAdapter; workspaceOwner?: string } = {},
 ): StoreOps {
   const db = dbFor(store);
-  /** Workspace verbs carry no subject on the contract — the backend is bound
-   *  to its caller's mount at construction (the cloud door binds per tenant). */
-  const owner = options.workspaceOwner ?? "user_local";
+  /** Whose drawer a workspace verb addresses. The call names it when the mount
+   *  serves more than one user (`/user/**` is the subject's, `/orgs/<org>/**`
+   *  the org's); with no owner on the call the backend falls back to the one it
+   *  was bound to at construction — today's single-player default. */
+  const boundOwner = options.workspaceOwner ?? "user_local";
+  const ownerFor = (opts?: { owner?: string }): string => opts?.owner ?? boundOwner;
 
   /** The helpers all speak Db but only ever call `query`, so a verb's
    *  transaction hands them the same handle with the tx-scoped query in it. */
@@ -316,6 +334,7 @@ export function createStoreOps(
     // -----------------------------------------------------------------------
     workspace: {
       async index(query) {
+        const owner = ownerFor(query);
         const limit = pageLimit(query?.limit);
         const params: unknown[] = [owner];
         let where = "owner = $1";
@@ -342,7 +361,8 @@ export function createStoreOps(
             : {}),
         };
       },
-      async read(paths) {
+      async read(paths, opts) {
+        const owner = ownerFor(opts);
         const rows = workspaceRows(db, files);
         const result: Record<string, unknown> = {};
         for (const path of paths) {
@@ -353,6 +373,7 @@ export function createStoreOps(
         return result;
       },
       async commit(entries, opts) {
+        const owner = ownerFor(opts);
         const parsed = parseWorkspaceEntries(entries);
         const body = JSON.stringify(parsed);
         const key = opts?.idempotencyKey;
@@ -372,6 +393,9 @@ export function createStoreOps(
         let replayed: boolean | undefined;
         try {
           for (const entry of parsed) {
+            // A tombstone stages nothing: the removal is a row delete, and the
+            // content it removes is already stored (history keeps it).
+            if (entry.delete === true) continue;
             prepared.push({
               path: entry.path,
               write: await rows.prepare(owner, entry.path, encoder.encode(JSON.stringify(entry.data))),
@@ -397,9 +421,37 @@ export function createStoreOps(
               return (existing?.data as { body?: unknown } | undefined)?.body === body;
             }
             const txRows = workspaceRows(tdb, filesFor(tdb));
+            const expected = new Map(
+              parsed
+                .filter((entry) => entry.expectedRevision !== undefined)
+                .map((entry) => [entry.path, entry.expectedRevision!]),
+            );
+            // Strict entries compare-and-swap against the revision the caller
+            // read. A lost swap throws, so the transaction takes the whole
+            // commit back with it: a conflicting set applies none of itself and
+            // the caller re-reads once.
+            const conflicts: string[] = [];
             for (const staged of prepared) {
               if (staged.write === "unchanged") continue;
-              await txRows.land(owner, staged.write, commitId);
+              const at = expected.get(staged.path);
+              const written = await txRows.land(
+                owner,
+                staged.write,
+                commitId,
+                at === undefined ? undefined : { strict: true, expectedRevision: at },
+              );
+              if (written.conflict === true) conflicts.push(staged.path);
+            }
+            for (const entry of parsed) {
+              if (entry.delete !== true) continue;
+              await txRows.remove(owner, entry.path, commitId);
+            }
+            if (conflicts.length > 0) {
+              throw new VendoError(
+                "conflict",
+                `the workspace moved on under ${conflicts.sort().join(", ")}; nothing was committed`,
+                { conflicts },
+              );
             }
             return undefined;
           });
@@ -419,6 +471,7 @@ export function createStoreOps(
         }
       },
       async history(query) {
+        const owner = ownerFor(query);
         const page = await createRecordStore(db, WORKSPACE_COMMITS).list({
           refs: { subject: owner },
           ...(query?.limit === undefined ? {} : { limit: query.limit }),
@@ -433,12 +486,15 @@ export function createStoreOps(
         };
       },
       /** Land the restore and consume the history it walked in ONE transaction. */
-      async undo(commitId) {
+      async undo(commitId, opts) {
+        const owner = ownerFor(opts);
         await db.transaction(async (q) => {
           const tdb = txDb(q);
           const ledger = createRecordStore(tdb, WORKSPACE_COMMITS);
           const commit = await ledger.get(commitId);
-          if (commit === null) {
+          // Another owner's commit is not this owner's to undo, and saying so
+          // would make the door an existence oracle: it is simply not found.
+          if (commit === null || commit.refs?.["subject"] !== owner) {
             throw new VendoError("not-found", `commit ${commitId} not found`);
           }
           const data = commit.data as { entries?: WorkspaceEntry[]; created?: string[] };

--- a/packages/store/src/workspace-ops-rows.ts
+++ b/packages/store/src/workspace-ops-rows.ts
@@ -1,0 +1,192 @@
+import { VendoError, type StoreOps } from "@vendoai/core";
+import { iso } from "./helpers/utils.js";
+import type {
+  UndoOutcome,
+  WorkspaceFileMeta,
+  WorkspaceHistoryEntry,
+  WorkspaceRows,
+} from "./workspace-rows.js";
+
+/**
+ * The workspace pair over the 32-op contract instead of this store's own
+ * Postgres — what makes a hosted store (a key, no database) serve the same
+ * `WorkspaceStoreFs` a local one does, byte for byte. The façade above
+ * (workspace.ts) is unchanged, and so are its permission checks: `can()` reads
+ * through the records door, which the hosted store already serves.
+ *
+ * Two shapes differ from the SQL backend and both are deliberate:
+ *   - **Content is JSON on the wire**, so text files ride as a JSON string and
+ *     anything that is not valid UTF-8 rides the {@link WORKSPACE_BYTES_KEY}
+ *     base64 envelope. Encoding a PNG as a lossy string was the alternative.
+ *   - **Revisions come from the caller.** The wire's commit answers `ok`, not a
+ *     new revision, so `land` reports the checked-out revision plus one — which
+ *     is exactly what the server assigns, and where it is not (a racing writer
+ *     on a `/user` mount) the next turn's index reads the truth. Strict mounts
+ *     never guess: their commit carries `expectedRevision`, and a lost swap
+ *     comes back `conflict`.
+ */
+
+/** The binary envelope: a workspace file whose bytes are not text travels as
+    `{"$vendoWorkspaceBytes": "<base64>"}`. A plain JSON string is text. */
+export const WORKSPACE_BYTES_KEY = "$vendoWorkspaceBytes";
+
+const utf8 = new TextDecoder("utf-8", { fatal: true });
+const encoder = new TextEncoder();
+
+const bytesToBase64 = (bytes: Uint8Array): string => {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+};
+
+const base64ToBytes = (value: string): Uint8Array =>
+  Uint8Array.from(atob(value), (char) => char.charCodeAt(0));
+
+const sameBytes = (left: Uint8Array, right: Uint8Array): boolean =>
+  left.byteLength === right.byteLength && left.every((byte, index) => byte === right[index]);
+
+/** Bytes → the JSON the wire carries: the string itself when the content is
+    text, the base64 envelope when it is not. */
+export function workspaceBytesToJson(bytes: Uint8Array): unknown {
+  try {
+    const text = utf8.decode(bytes);
+    if (!text.includes("\u0000")) return text;
+  } catch {
+    // not UTF-8 — fall through to the envelope
+  }
+  return { [WORKSPACE_BYTES_KEY]: bytesToBase64(bytes) };
+}
+
+/** The wire's JSON → bytes. A value that is neither a string nor an envelope
+    was written by something other than a workspace filesystem (a direct
+    `ops.workspace.commit` of a JSON document), and reads as its JSON text —
+    exactly the bytes the SQL backend stores for the same commit. */
+export function workspaceJsonToBytes(data: unknown): Uint8Array {
+  if (typeof data === "string") return encoder.encode(data);
+  const envelope = (data as Record<string, unknown> | null)?.[WORKSPACE_BYTES_KEY];
+  if (typeof envelope === "string") return base64ToBytes(envelope);
+  return encoder.encode(JSON.stringify(data));
+}
+
+/** S3 wires per-path history and undo over the wire's `path` legs. Until it
+    lands, a hosted workspace says so instead of pretending there is nothing to
+    restore — a silent `{status:"empty"}` would read as "no history" forever. */
+const notWiredYet = (verb: string): never => {
+  throw new VendoError(
+    "not-implemented",
+    `a hosted workspace cannot ${verb} yet: per-path history rides the store wire's path legs`,
+  );
+};
+
+export function workspaceOpsRows(ops: StoreOps): WorkspaceRows {
+  const readOne = async (owner: string, path: string): Promise<unknown | undefined> => {
+    const files = await ops.workspace.read([path], { owner });
+    return path in files ? files[path] : undefined;
+  };
+
+  return {
+    async index(owners) {
+      const metas: WorkspaceFileMeta[] = [];
+      for (const owner of owners) {
+        let cursor: string | undefined;
+        do {
+          const page = await ops.workspace.index({
+            owner,
+            ...(cursor === undefined ? {} : { cursor }),
+          });
+          for (const entry of page.entries) {
+            const row = entry as Record<string, unknown>;
+            if (typeof row["path"] !== "string") continue;
+            metas.push({
+              path: row["path"],
+              owner,
+              bytes: Number(row["bytes"] ?? 0),
+              revision: Number(row["revision"] ?? 0),
+              updatedAt: iso(row["updatedAt"] ?? new Date(0).toISOString()),
+            });
+          }
+          cursor = page.cursor;
+        } while (cursor !== undefined);
+      }
+      return metas.sort((left, right) => (left.path < right.path ? -1 : 1));
+    },
+
+    async read(owner, path) {
+      const data = await readOne(owner, path);
+      return data === undefined ? undefined : workspaceJsonToBytes(data);
+    },
+
+    async prepare(owner, path, bytes) {
+      const current = await readOne(owner, path);
+      if (current !== undefined && sameBytes(workspaceJsonToBytes(current), bytes)) {
+        return "unchanged";
+      }
+      // Nothing is placed remotely until `land` commits: the wire has no
+      // staging area, so there is no blob to orphan and `discard` is free.
+      return {
+        path,
+        content: bytes,
+        bytes: bytes.byteLength,
+        // The server assigns the real revision; `land` reports it from the
+        // revision the caller checked out.
+        revision: 0,
+        stored: { content: undefined, blobRef: undefined },
+        prior: undefined,
+      };
+    },
+
+    async land(owner, prepared, _intent, options) {
+      // The commit message has no field on the wire; it is a history label, and
+      // history is S3's leg.
+      const strict = options?.strict === true && typeof options.expectedRevision === "number";
+      const checkedOut = typeof options?.expectedRevision === "number" ? options.expectedRevision : 0;
+      try {
+        await ops.workspace.commit(
+          [{
+            path: prepared.path,
+            data: workspaceBytesToJson(prepared.content),
+            ...(strict ? { expectedRevision: options!.expectedRevision } : {}),
+          }],
+          { owner },
+        );
+      } catch (error) {
+        // §9.7 — a strict mount's lost swap is the frozen conflict branch, not
+        // a failure: the façade re-reads the new head and re-applies.
+        if (strict && error instanceof VendoError && error.code === "conflict") {
+          return {
+            landed: false,
+            revision: checkedOut,
+            updatedAt: new Date().toISOString(),
+            conflict: true,
+          };
+        }
+        throw error;
+      }
+      return { landed: true, revision: checkedOut + 1, updatedAt: new Date().toISOString() };
+    },
+
+    async discard() {
+      // Nothing was staged remotely, so there is nothing to release.
+    },
+
+    async remove(owner, path, _intent) {
+      if ((await readOne(owner, path)) === undefined) return false;
+      await ops.workspace.commit([{ path, delete: true }], { owner });
+      return true;
+    },
+
+    async moveApp() {
+      // Promote's workspace half is one transaction with the app-row flip, so a
+      // hosted store runs the whole move server-side (`lifecycle.promote`).
+      return notWiredYet("move an app between mounts");
+    },
+
+    async history(): Promise<WorkspaceHistoryEntry[]> {
+      return notWiredYet("list a path's history");
+    },
+
+    async undo(): Promise<UndoOutcome> {
+      return notWiredYet("undo a path");
+    },
+  };
+}

--- a/packages/store/src/workspace-ops.test.ts
+++ b/packages/store/src/workspace-ops.test.ts
@@ -1,0 +1,142 @@
+import type { Membership, Principal } from "@vendoai/core";
+import { VendoError } from "@vendoai/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { backends, type MadeBackend } from "./backends.test-util.js";
+import { createStoreOps } from "./ops.js";
+import type { VendoStore as StoreHandle } from "./store.js";
+import { workspaceStore } from "./workspace.js";
+
+/**
+ * T1/D3 — the workspace façade over the 32-op contract instead of a SQL handle.
+ *
+ * The seam is real on both sides: the PRODUCER is `WorkspaceStoreFs` driving
+ * `workspaceOpsRows`, and the CONSUMER is `createStoreOps` writing this store's
+ * own Postgres. Neither half is stubbed, so a disagreement between them shows
+ * up here — and the SQL-backed façade reads the same rows back, which is the
+ * parity claim ("hosted is indistinguishable from local") stated as a test.
+ */
+
+const dana: Principal = { kind: "user", subject: "dana" };
+const kim: Principal = { kind: "user", subject: "kim" };
+const acme: Membership[] = [{ org: "acme" }];
+
+/** A store handle with NO local database and the 32 ops instead — exactly the
+    shape a hosted store presents. The record/blob doors still delegate to the
+    real store, because that is what the hosted store's own doors do. */
+const opsBacked = (store: StoreHandle): StoreHandle => ({
+  records: (collection) => store.records(collection),
+  blobs: (namespace) => store.blobs(namespace),
+  ensureSchema: () => store.ensureSchema(),
+  async close() { /* the ops handle owns no local resource */ },
+  raw() { throw new Error("a hosted store has no local database handle"); },
+  ops: createStoreOps(store),
+});
+
+for (const backend of backends()) {
+  describe(`${backend.name} the workspace over StoreOps`, () => {
+    let made: MadeBackend;
+
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    /** The façade a hosted deployment gets. */
+    const hosted = () => workspaceStore(opsBacked(made.store));
+
+    it("commits through the ops backend into the ordinary workspace rows", async () => {
+      const path = "/user/notes/plan.md";
+      const first = await hosted().open(dana);
+      await first.writeFile(path, "the plan");
+      expect(await first.commit({ message: "planned" })).toEqual({ status: "ok", changed: [path] });
+
+      // Next turn — a different façade instance — reads it back byte for byte.
+      expect(await (await hosted().open(dana)).readFile(path)).toBe("the plan");
+      // The row is the ordinary workspace row, under the writer as its owner.
+      // Its content is the file's JSON, because the contract carries JSON
+      // documents (a text file is a JSON string, binary is the base64
+      // envelope) — the round trip that matters is façade → ops → row →
+      // façade, and it is exact.
+      expect(await made.sql(
+        "SELECT owner, content FROM vendo_workspace_files WHERE path = $1",
+        [path],
+      )).toEqual([{ owner: "dana", content: '"the plan"' }]);
+    });
+
+    it("keeps two owners' drawers apart at the same path", async () => {
+      const path = "/user/shared.md";
+      const mine = await hosted().open(dana);
+      await mine.writeFile(path, "dana's");
+      await mine.commit();
+      const theirs = await hosted().open(kim);
+      await theirs.writeFile(path, "kim's");
+      await theirs.commit();
+
+      expect(await (await hosted().open(dana)).readFile(path)).toBe("dana's");
+      expect(await (await hosted().open(kim)).readFile(path)).toBe("kim's");
+      const sam = await hosted().open({ kind: "user", subject: "sam" });
+      expect(await sam.exists(path)).toBe(false);
+    });
+
+    it("carries bytes that are not text through the base64 envelope", async () => {
+      const path = "/user/uploads/pixel.png";
+      // A PNG header: valid bytes, invalid UTF-8, with a NUL in it.
+      const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0xff]);
+      const fs = await hosted().open(dana);
+      await fs.writeFile(path, bytes);
+      await fs.commit();
+
+      const next = await hosted().open(dana);
+      expect([...(await next.readFileBuffer(path))]).toEqual([...bytes]);
+      expect((await next.stat(path)).size).toBeGreaterThan(0);
+    });
+
+    it("removes a file with a tombstone, and the next turn does not see it", async () => {
+      const path = "/user/temp.md";
+      const seed = await hosted().open(dana);
+      await seed.writeFile(path, "temporary");
+      await seed.commit();
+
+      const cleaner = await hosted().open(dana);
+      await cleaner.rm(path);
+      expect(await cleaner.commit()).toEqual({ status: "ok", changed: [path] });
+
+      const next = await hosted().open(dana);
+      expect(await next.exists(path)).toBe(false);
+      expect(await made.sql("SELECT path FROM vendo_workspace_files WHERE path = $1", [path])).toEqual([]);
+    });
+
+    it("answers an /orgs commit that lost its base with the conflict branch", async () => {
+      const path = "/orgs/acme/files/roadmap.md";
+      const seed = await hosted().open(dana, { memberships: acme });
+      await seed.writeFile(path, "v1");
+      await seed.commit();
+
+      // Two turns open on the same revision; the second commits against a base
+      // that has moved.
+      const stale = await hosted().open(dana, { memberships: acme });
+      const fresh = await hosted().open(kim, { memberships: acme });
+      await fresh.writeFile(path, "v2 from kim");
+      expect(await fresh.commit()).toEqual({ status: "ok", changed: [path] });
+
+      await stale.writeFile(path, "v2 from dana");
+      expect(await stale.commit()).toEqual({ status: "conflict", paths: [path] });
+      // The colleague's edit stands.
+      expect(await (await hosted().open(dana, { memberships: acme })).readFile(path)).toBe("v2 from kim");
+    });
+
+    it("says per-path history and undo are not wired yet instead of answering empty", async () => {
+      const path = "/user/history.md";
+      const fs = await hosted().open(dana);
+      await fs.writeFile(path, "v1");
+      await fs.commit();
+
+      const workspace = hosted();
+      const caller = { principal: dana };
+      await expect(workspace.history(caller, path)).rejects.toThrow(VendoError);
+      await expect(workspace.history(caller, path)).rejects.toThrow(/not wired|per-path history/);
+      await expect(workspace.undo(caller, path)).rejects.toThrow(/per-path history/);
+    });
+  });
+}

--- a/packages/store/src/workspace.ts
+++ b/packages/store/src/workspace.ts
@@ -1,7 +1,9 @@
 import { VendoError, type FilesAdapter, type Membership, type Principal, type RunContext, type WorkspaceFs } from "@vendoai/core";
 import { storeFiles } from "./files-store.js";
 import { appAccess, orgOfPath } from "./helpers/app-access.js";
-import { dbFor, type VendoStore } from "./store.js";
+import { backendOf } from "./helpers/backend.js";
+import type { VendoStore } from "./store.js";
+import { workspaceOpsRows } from "./workspace-ops-rows.js";
 import { HOST_MOUNT, normalizePath, pathForbidden, pathNotFound, WorkspaceStoreFs } from "./workspace-fs.js";
 import { workspaceRows, type AppMount, type UndoOutcome, type WorkspaceHistoryEntry } from "./workspace-rows.js";
 
@@ -75,7 +77,17 @@ export function workspaceStore(store: VendoStore, options: { files?: FilesAdapte
       here even though the reads it already served stand. */
   canCommit(caller: WorkspaceCaller, path: string): Promise<boolean>;
 } {
-  const rows = workspaceRows(dbFor(store), options.files ?? storeFiles(store));
+  // T1/D1 — the branch is INSIDE the helper: a store with its own Postgres
+  // keeps today's row helpers, a store with only the 32-op contract (the hosted
+  // one: a key, no database) rides the same façade over the wire. Nothing above
+  // this line can tell the two apart, which is what lets a hosted deployment
+  // serve harness turns with zero caller changes. The permission checks below
+  // are untouched — `can()` reads through the records door, which the hosted
+  // store already serves.
+  const backend = backendOf(store, "the workspace");
+  const rows = backend.kind === "sql"
+    ? workspaceRows(backend.db, options.files ?? storeFiles(store))
+    : workspaceOpsRows(backend.ops);
   const access = appAccess(store);
 
   /** The ctx `can()` reads: it only ever looks at the subject and the asserted

--- a/packages/vendo/src/hosted-store.ts
+++ b/packages/vendo/src/hosted-store.ts
@@ -537,6 +537,11 @@ export function hostedStoreOps(options: HostedStoreOptions): StoreOps {
 
   const cursorQuery = (query?: { cursor?: string; limit?: number }): Record<string, unknown> => ({ ...query });
 
+  /** The workspace family's owner, passed through only when the caller named
+      one — a mount that binds its own owner must not be handed `undefined`. */
+  const owned = (opts?: { owner?: string }): Record<string, unknown> =>
+    opts?.owner === undefined ? {} : { owner: opts.owner };
+
   const P = STORE_WIRE_PATHS;
 
   return {
@@ -659,13 +664,18 @@ export function hostedStoreOps(options: HostedStoreOptions): StoreOps {
         await mutate("harness.clear", P["harness.clear"], { appId, subject });
       },
     },
+    // Every workspace call names its OWNER: the mount serves a whole project,
+    // so without one its users would share a single drawer. Entries carry the
+    // wire's tombstones (`delete: true`) and strict-CAS `expectedRevision`
+    // through verbatim — the service reports a lost swap as an enveloped
+    // `conflict`, which the façade reads as the frozen conflict branch.
     workspace: {
       async index(query) {
-        return entriesOf(await post("workspace.index", P["workspace.index"], cursorQuery(query)));
+        return entriesOf(await post("workspace.index", P["workspace.index"], { ...query }));
       },
-      async read(paths) {
+      async read(paths, opts) {
         return field<Record<string, unknown>>(
-          await post("workspace.read", P["workspace.read"], { paths }),
+          await post("workspace.read", P["workspace.read"], { paths, ...owned(opts) }),
           "files",
           "invalid workspace read",
           (value) => typeof value === "object" && value !== null && !Array.isArray(value),
@@ -674,13 +684,18 @@ export function hostedStoreOps(options: HostedStoreOptions): StoreOps {
       async commit(entries, opts) {
         // The caller may own the key (a resumed job replaying its own commit);
         // otherwise `mutate` mints the one key for this operation.
-        await mutate("workspace.commit", P["workspace.commit"], { entries }, opts?.idempotencyKey);
+        await mutate(
+          "workspace.commit",
+          P["workspace.commit"],
+          { entries, ...owned(opts) },
+          opts?.idempotencyKey,
+        );
       },
       async history(query) {
-        return entriesOf(await post("workspace.history", P["workspace.history"], cursorQuery(query)));
+        return entriesOf(await post("workspace.history", P["workspace.history"], { ...query }));
       },
-      async undo(commitId) {
-        await mutate("workspace.undo", P["workspace.undo"], { commitId });
+      async undo(commitId, opts) {
+        await mutate("workspace.undo", P["workspace.undo"], { commitId, ...owned(opts) });
       },
     },
     lifecycle: {

--- a/packages/vendo/src/hosted-workspace.live.test.ts
+++ b/packages/vendo/src/hosted-workspace.live.test.ts
@@ -1,0 +1,98 @@
+/**
+ * The T1/D3 workspace seam, with no stand-in on either side: the REAL
+ * `workspaceStore` façade over a REAL `hostedStore`, against the REAL Vendo
+ * Cloud console — written through one client and read back through a second,
+ * freshly constructed one, so the only thing that can make it pass is the
+ * console genuinely holding the files.
+ *
+ * What it proves, in order: the façade works at all over the wire; two owners
+ * of the SAME deployment do not see each other's files (the hole the console's
+ * per-request `owner` closes); a delete actually deletes; and erasing one
+ * subject takes their whole drawer with it and leaves the other's.
+ *
+ * Gated on `VENDO_API_KEY` having content, like every other `.live.test.ts`:
+ * skipped without it, so CI and a keyless clone stay green. `VENDO_CLOUD_URL`
+ * overrides the mount for a staging console. Every id is per-run unique so two
+ * runs never collide, and everything written is erased at the end.
+ */
+import type { Principal } from "@vendoai/core";
+import { workspaceStore } from "@vendoai/store";
+import { afterAll, describe, expect, it } from "vitest";
+import { hostedStore, type HostedStore } from "./hosted-store.js";
+
+// A named secret can EXIST and be empty (`infisical secrets get` exits 0 either
+// way), so the gate checks for content rather than for presence.
+const apiKey = process.env["VENDO_API_KEY"] ?? "";
+const live = apiKey === "" ? describe.skip : describe;
+
+const LIVE_TIMEOUT_MS = 60_000;
+
+const run = globalThis.crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+const mine: Principal = { kind: "user", subject: `user_ws_${run}` };
+const theirs: Principal = { kind: "user", subject: `user_ws_other_${run}` };
+const PATH = "/user/notes/plan.md";
+
+const client = (): HostedStore => hostedStore({
+  apiKey,
+  ...(process.env["VENDO_CLOUD_URL"] === undefined ? {} : { baseUrl: process.env["VENDO_CLOUD_URL"] }),
+});
+
+/** The shipped façade, picking the ops backend off the hosted store because
+    there is no SQL handle to pick. */
+const workspace = (store: HostedStore = client()) => workspaceStore(store);
+
+live("hosted workspace over the real console", () => {
+  const writer = client();
+
+  afterAll(async () => {
+    for (const subject of [mine.subject, theirs.subject]) {
+      await writer.ops.lifecycle.erase({ subject }).catch(() => undefined);
+    }
+  }, LIVE_TIMEOUT_MS);
+
+  it("commits a file through the façade and reads it back on a fresh client", async () => {
+    const turn = await workspace(writer).open(mine);
+    await turn.writeFile(PATH, "the plan");
+    expect(await turn.commit({ message: "planned" })).toEqual({ status: "ok", changed: [PATH] });
+
+    // A client constructed after the write, sharing nothing with the writer but
+    // the account.
+    const next = await workspace().open(mine);
+    expect(await next.readFile(PATH)).toBe("the plan");
+    expect(next.getAllPaths()).toContain(PATH);
+  }, LIVE_TIMEOUT_MS);
+
+  it("keeps another user of the same deployment out of that file", async () => {
+    const stranger = await workspace().open(theirs);
+    // Not "forbidden" — absent. The path is not in their drawer at all.
+    expect(await stranger.exists(PATH)).toBe(false);
+
+    // And their own file at the SAME path is their own.
+    await stranger.writeFile(PATH, "someone else's plan");
+    expect(await stranger.commit()).toEqual({ status: "ok", changed: [PATH] });
+    expect(await (await workspace().open(theirs)).readFile(PATH)).toBe("someone else's plan");
+    expect(await (await workspace().open(mine)).readFile(PATH)).toBe("the plan");
+  }, LIVE_TIMEOUT_MS);
+
+  it("removes a file, and a fresh client agrees it is gone", async () => {
+    const doomed = "/user/notes/scratchpad.md";
+    const first = await workspace().open(mine);
+    await first.writeFile(doomed, "temporary");
+    await first.commit();
+    expect(await (await workspace().open(mine)).readFile(doomed)).toBe("temporary");
+
+    const cleaner = await workspace().open(mine);
+    await cleaner.rm(doomed);
+    expect(await cleaner.commit()).toEqual({ status: "ok", changed: [doomed] });
+    expect(await (await workspace().open(mine)).exists(doomed)).toBe(false);
+    // The file that was not deleted is still there.
+    expect(await (await workspace().open(mine)).readFile(PATH)).toBe("the plan");
+  }, LIVE_TIMEOUT_MS);
+
+  it("erases one subject's whole drawer and leaves the other's", async () => {
+    await writer.ops.lifecycle.erase({ subject: mine.subject });
+
+    expect((await workspace().open(mine)).getAllPaths()).toEqual([]);
+    expect(await (await workspace().open(theirs)).readFile(PATH)).toBe("someone else's plan");
+  }, LIVE_TIMEOUT_MS);
+});


### PR DESCRIPTION
**Stacked on `one-path/s1-transcripts-ops` (S1)** — review/merge that first; this
branch is rebased on it. Paired with the console half,
runvendo/vendo-web#276, which must deploy before the live seam test can pass.

## Why

The workspace was the last of the three store helpers a harness turn needs that
demanded a raw SQL handle. `workspaceStore(store)` opened with `dbFor(store)`,
which throws for anything this package did not mint — i.e. every hosted
deployment. So a key-only host had no filesystem, and fell back to the legacy
chat path.

## What changed

**The branch is inside the helper (D1).** `workspaceStore` now resolves through
S1's `backendOf`: SQL handle when there is one, the store's own 32-op surface
when there is not. `WorkspaceStoreFs` is reused verbatim and the permission
checks (`appAccess`/`can()`) are untouched — they read through the records door,
which the hosted store already serves. Nothing above the store package can tell
the two apart.

**`packages/store/src/workspace-ops-rows.ts` (new)** maps the row helpers onto
`StoreOps.workspace`. Three things are worth knowing:

- *Content is JSON on the wire.* A text file rides as a JSON string; anything
  that is not valid UTF-8 (or holds a NUL) rides a
  `{"$vendoWorkspaceBytes": "<base64>"}` envelope. Encoding a PNG as a lossy
  string was the alternative.
- *Revisions come from the caller.* The wire's commit answers `ok`, not a new
  revision, so `land` reports the checked-out revision plus one — what the server
  assigns. Strict mounts never guess: they send `expectedRevision`, and a lost
  swap comes back as the façade's frozen `conflict`.
- *Per-path history and undo throw a named not-implemented*, rather than
  answering "empty" — S3 wires them over the wire's `path` legs. `moveApp` does
  the same: a hosted promote runs server-side through `lifecycle.promote`.

**The contract (core).** `StoreOps.workspace` index/read/commit/history/undo take
an optional `owner` (a mount that binds one owner at construction keeps working);
commit entries take `delete: true` tombstones — deletion was inexpressible, so a
hosted workspace could never drop a file — and `expectedRevision`. The five wire
schemas carry all of it.

**The local backend (`store/ops.ts`)** honors the per-call owner on all five
verbs, applies tombstones through the existing `remove` (so undo restores them),
and refuses a commit whose `expectedRevision` has moved — inside the verb's own
transaction, so a conflicting set applies none of itself. `undo` refuses another
owner's commit as `not-found`.

**The hosted client** sends owner, tombstones and expectedRevision.

## Tests

- `packages/core/src/conformance/store-ops.ts` — three additive workspace cases
  (two-owner isolation across read/index/history/undo, tombstone + undo, stale
  `expectedRevision` refused with nothing applied) and one transcript case
  (`putMessage` edits by id, in place — the approval flip). All green against
  the memory reference AND the local backend on real Postgres.
- `packages/store/src/workspace-ops.test.ts` (new) — the seam with no stand-in
  on either side: the producer is `WorkspaceStoreFs` over `workspaceOpsRows`, the
  consumer is `createStoreOps` writing real Postgres. Commit/read across turns,
  two owners at one path, the base64 envelope for binary, tombstone removal, the
  `/orgs` conflict branch, and the named not-implemented for history/undo.
- `packages/vendo/src/hosted-workspace.live.test.ts` (new) — the real console,
  env-gated on `VENDO_API_KEY` like every other `.live.test.ts` (skipped in CI).

**Live status, honestly: 1 of 4 red against the console as deployed today**, and
each failure names exactly what runvendo/vendo-web#276 fixes — the stranger sees
another user's file (one shared drawer), `{ delete: true }` is rejected as
`entries must be a non-empty array of { path, data }`, and an erased subject's
files survive (no `refs`). The first case (write here, read back on a fresh
client) already passes. Re-run after the console deploys.

## Prove-red

Every new case was watched fail with the behavior reverted, then restored:
per-call owner, tombstone application and the CAS check each turned exactly its
own conformance case red on BOTH the memory reference and the local Postgres
backend; the base64 envelope, the conflict mapping and the tombstone commit each
turned their own `workspace-ops.test.ts` case red; the memory `putMessage`
replace-by-id turned the new transcript case red.

## Gate (own scope, worker-capped)

- `pnpm --filter @vendoai/core --filter @vendoai/store --filter @vendoai/vendo typecheck` — green.
- `@vendoai/store` suite: 491 passed, **2 pre-existing environment failures** —
  `durability.drill` and `split-brain.drill`, both failing to spawn a fixture at
  a path this agent's worktree spells with a space (`Cool%20Code`); the store's
  own vitest config already calls these "space-path-sensitive".
- `@vendoai/core` suite: 1062 passed, **3 pre-existing environment failures** —
  `packaging.e2e`, same `Cool%20Code` cause (its own first case proves the packed
  file exists; Node imports the same dist fine).
- `@vendoai/vendo`: hosted-store, app-access-door and automations-defer suites green.

Neither failing group touches this diff. The full suite runs centrally at the
merge boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the workspace helper work on hosted deployments by routing through `StoreOps` with per-owner drawers, adding delete tombstones and strict compare-and-swap to keep multi-user workspaces consistent.

- **New Features**
  - `StoreOps.workspace` now takes `owner` on index/read/commit/history/undo; commit entries support `delete: true` and `expectedRevision`. Index entries return `bytes`, `revision`, and `updatedAt`.
  - Hosted workspace uses `workspaceOpsRows` to map the façade to `StoreOps`: content is JSON; binary rides `{"$vendoWorkspaceBytes": "<base64>"}`. Strict CAS returns a `conflict`; per-path history/undo throw not-implemented for now.
  - Local ops backend enforces owner isolation, applies tombstones, and refuses the whole commit when any `expectedRevision` is stale; `undo` is owner-scoped.
  - `@vendoai/vendo` client sends `owner`, tombstones, and `expectedRevision`. Transcript `putMessage` edits by id in place (no duplicate messages).

- **Migration**
  - For multi-user mounts, pass `owner` on all workspace ops; single-user mounts can omit it.
  - On strict mounts, include `expectedRevision`; handle `conflict` from `workspace.commit` by re-reading and retrying.
  - Use `delete: true` to remove files; per-path history/undo is not yet wired for hosted.

<sup>Written for commit 664bc6af71c517a4c0752c35f9c543a3cfdd7970. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

