### PR TITLE
proof: worst-case CI timing (do not merge)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  // Worst-case CI proof — this comment is the only change.
   "tasks": {
     "build": { "dependsOn": ["^build"], "outputs": ["dist/**", ".next/**", "!.next/cache/**"] },
     "test": { "dependsOn": ["^build", "build"], "env": ["CI", "POSTGRES_URL", "VITEST_MIN_FORKS", "VITEST_MAX_FORKS", "VITEST_MIN_THREADS", "VITEST_MAX_THREADS"] },


### PR DESCRIPTION
Worker C worst-case proof. Comment-only change in `turbo.json` — defeats the --affected skip so all 8 shards run live. Will be closed after measurement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force worst-case CI timing by adding a no-op comment in `turbo.json`, which bypasses `--affected` and makes all 8 shards run. No functional changes; CI-only for measurement.

<sup>Written for commit 8cfacd0b20562c9e5fbbb5add64ae448c9364be1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

