### PR TITLE
feat(harnesses,vendo): the screen agent IS vendo(), and the checks floor rides the vendo_make route

### DIFF
--- a/.changeset/screen-agent-is-vendo.md
+++ b/.changeset/screen-agent-is-vendo.md
@@ -1,0 +1,48 @@
+---
+"@vendoai/harnesses": minor
+"@vendoai/vendo": patch
+---
+
+The screen agent IS `vendo()`, and the checks floor rides the `vendo_make` route.
+
+## `vendo()` takes a closed loadout
+
+`VendoHarnessDeps.tools` is new. Set, the equipped set is EXACTLY that list: a
+string equips that registry tool (guarded, through `turn.tools.call`, as today);
+a `HarnessHand` — `{ name, description, inputSchema, execute(input, turn) }` — is
+the harness's own hand, invisible to every other consumer. No discovery rail
+(`find_tools` is not mounted: a fixed loadout has nothing to discover), no
+`vendo_*` always-active exemption, no `hire_subagent` unless the list names it. A
+name the deployment's listing does not carry is simply not offered, because that
+list is written once at boot against a listing that legitimately varies per
+deployment.
+
+Unset — every existing caller — behaves exactly as before.
+
+`execute` receives the TURN, which is what lets a hand be declared where a
+`Harness` value is built (no run in sight) while its effects are per-run:
+`turn.workspace` is this run's files.
+
+## The screen agent is configuration, not a second loop
+
+`screenAgent()` / `screenAssembler()` keep their doors, their brief, their
+`SCREEN_STEPS = 10` budget and their outcome semantics, but the bespoke
+`startTurn` drive underneath them is gone: they are now `vendo()` with a closed
+loadout and two hands (`save_app`, `escalate`). The step cap, the seat
+resolution, `wireErrorMessage`, the context knobs and the system precedence are
+the default harness's, so a rail cannot be fixed in one loop and stay broken in
+the other.
+
+## Fixed: a screen assembled through `vendo_make` was never checked
+
+Composition wired the screen slot's render seam without the checks floor, while
+the harness-turn route passed `{ authoredApp, commitSource, floor }`. One seam,
+two answers: the same `app.vendo` — a binding naming a tool the host has not got,
+a prop the renderer drops — was refused on the harness route and painted on the
+`vendo_make` route, where it also compiled in the wrong dialect (no inline tool
+expansion, `bindingErrors: []` by construction) and never persisted its source.
+
+The screen slot now carries the same `floor` and `commitSource`. A blocking
+finding means nothing paints and the last good view stays, exactly as everywhere
+else; the write still lands, so `validate` can read it back and repair it. Hosts
+need no code change.

--- a/packages/harnesses/src/index.ts
+++ b/packages/harnesses/src/index.ts
@@ -29,7 +29,7 @@ export {
   type TranscriptStore,
   type TurnRunInput,
 } from "./runtime.js";
-export { vendo, type VendoHarnessDeps, type VendoHarnessOptions } from "./vendo.js";
+export { vendo, type HarnessHand, type VendoHarnessDeps, type VendoHarnessOptions } from "./vendo.js";
 export {
   assembleScreen,
   screenAgent,

--- a/packages/harnesses/src/screen-agent.test.ts
+++ b/packages/harnesses/src/screen-agent.test.ts
@@ -182,6 +182,28 @@ describe("the loadout (§4.2 — assembly tools only)", () => {
     expect(SCREEN_STEPS).toBe(10);
   });
 
+  it("spends the budget and no more — the cap is the shipped loop's, not a comment", async () => {
+    // The screen agent IS `vendo()` with a closed loadout, so the cap it declares
+    // has to reach the loop that enforces it. A model that never stops is what
+    // measures that: the default resident budget is 20, so an unpassed cap runs
+    // every one of these turns.
+    const screen = harness({
+      turns: Array.from({ length: SCREEN_STEPS + 1 }, () => saveApp(GOOD_APP)),
+    });
+    await screen.assemble("show me my spending");
+    expect(screen.model.calls).toBe(SCREEN_STEPS);
+  });
+
+  it("offers no hiring and no discovery — a closed list is total", async () => {
+    const screen = harness({ turns: [saveApp(GOOD_APP), textTurn("done")] });
+    await screen.assemble("show me my spending");
+    const offered = screen.model.toolNamesPerCall[0] ?? [];
+    // `vendo()`'s own two additions to any loadout. A fixed menu has nothing to
+    // discover, and a cheap first pass does not staff a build.
+    expect(offered).not.toContain("hire_subagent");
+    expect(offered).not.toContain("find_tools");
+  });
+
   it("carries the host's DECLARED result shape into the brief, not a sampled guess", async () => {
     const screen = harness({ turns: [saveApp(GOOD_APP), textTurn("done")] });
     await screen.assemble("show me my spending");

--- a/packages/harnesses/src/screen-agent.ts
+++ b/packages/harnesses/src/screen-agent.ts
@@ -1,29 +1,28 @@
 /**
  * The screen agent — UI-generation blueprint §4.2 and §4.5.
  *
- * The same `startTurn` loop `vendo()` and `instant()` drive, with a SMALL loadout
- * and a tight step budget: assembly tools only, the catalog and the host's own
- * declared result shapes in the brief, its own file hands, and one `escalate`
- * tool. It is the cheap first pass in front of the conductor — "every request
- * starts in the screen agent" (§1 point 2) — and nothing about it is new
- * machinery:
+ * It is `vendo()` with a CLOSED loadout and a tight step budget, not a harness of
+ * its own: the assembly verbs and the host's read tools by name, two hands of its
+ * own, and one door out. There is no second drive of `startTurn` here — the step
+ * cap, the seat resolution, `wireErrorMessage`, the history knobs and the system
+ * precedence are the default harness's, so a rail cannot be fixed in one loop and
+ * stay broken in the other. What this file holds is the CONFIGURATION: the brief,
+ * the loadout, the two hands, and the outcome the front door reads.
  *
  * - **The write path is `turn.workspace`.** The `claudeCode()` harness already
  *   builds apps this way: the model writes `plan.vendo` / `app.vendo` with its own
  *   hands and the runtime's commit is what makes it real
  *   (`claude-code/index.ts:338`, `skills/building-apps.ts:68`). This agent has no
- *   disk and no shell, so the two files it may write are two tools over the same
+ *   disk and no shell, so the two files it may write are two hands over the same
  *   `WorkspaceFs`. There is no third writer.
  * - **The paint path is the render seam.** `wrapWorkspaceForRender` intercepts
  *   `commit()`, compiles, and emits `data-vendo-view`. This file never emits a
  *   view and never compiles anything — that is exactly why a screen it assembles
  *   passes the same floor a `claudeCode()` app does.
  * - **`vendo_make` is withheld, not merely unused.** The screen agent IS what
- *   `vendo_make` calls, so leaving it callable is a loop. The `Harness` door
- *   withholds it at `toolSurface` (the runtime answers a withheld name with the
- *   same `not-found` a typo gets); the assembler door never projects it. Both
- *   matter, because `isAlwaysActive` in the loadout is `name.startsWith("vendo_")`
- *   — a `vendo_`-prefixed tool cannot be gated by `activeTools` at all.
+ *   `vendo_make` calls, so leaving it callable is a loop. A closed loadout excludes
+ *   it by omission; the `Harness` door withholds it at `toolSurface` as well, so
+ *   the runtime answers the name with the same `not-found` a typo gets.
  * - **The job description is the shipped skill.** `buildingAppsSkill` plus its
  *   `references/format.md` are the same text `claudeCode()` reads. This file adds
  *   one short block that corrects the ENVIRONMENT (no disk, no delegation, two
@@ -35,8 +34,8 @@
  */
 import {
   VENDO_MAKE_TOOL,
+  mintTurnId,
   type AppId,
-  type Json,
   type SeatModels,
   type RunContext,
   type ScreenAssembler,
@@ -44,17 +43,19 @@ import {
   type ScreenRequest,
   type ToolListing,
   type ToolRegistry,
+  type TurnId,
+  type TurnSkills,
+  type TurnState,
   type TurnTools,
   type WorkspaceFs,
   type Harness,
   type Turn,
   modelToolDescription,
 } from "@vendoai/core";
-import { startTurn, wireErrorMessage } from "@vendoai/agent/internal";
 import { buildingAppsSkill } from "@vendoai/apps";
-import { jsonSchema, tool, type LanguageModel, type ToolSet } from "ai";
-import { z } from "zod";
+import type { LanguageModel } from "ai";
 import { defineHarness } from "./define.js";
+import { vendo, type HarnessHand, type VendoHarnessOptions } from "./vendo.js";
 import { wrapWorkspaceForRender, type RenderSeamOptions } from "./render-seam.js";
 
 /**
@@ -96,16 +97,14 @@ const ASSEMBLY_TOOLS: readonly string[] = [
   "ask_user",
 ];
 
-/** A tool with no declared input still needs a schema the provider will accept. */
-const NO_INPUT_SCHEMA = { type: "object", properties: {}, additionalProperties: false };
-
 /**
  * What the lean loop needs, and nothing else.
  *
  * A `Turn` satisfies this by construction — structurally, with no adapter and no
  * wrapper — which is what lets the `Harness` door and the `vendo_make` door share
  * ONE loop instead of growing a second copy of it. Composition's door builds the
- * same four fields out of the pieces it already holds.
+ * same fields out of the pieces it already holds; the two identities are optional
+ * because only the harness door is inside a turn that already has them.
  */
 export interface ScreenSurface {
   readonly models: SeatModels<LanguageModel>;
@@ -113,6 +112,8 @@ export interface ScreenSurface {
   /** Wrapped by the render seam before it gets here, so `commit()` paints. */
   readonly workspace: WorkspaceFs;
   readonly signal: AbortSignal;
+  readonly threadId?: string;
+  readonly turnId?: TurnId;
 }
 
 export interface ScreenInput {
@@ -220,6 +221,40 @@ function screenBrief(input: ScreenInput, listings: readonly ToolListing[]): stri
     .join("\n\n---\n\n");
 }
 
+/** What the two hands recorded, for THIS run. A collector on the run rather than
+ *  module state: the hands are built per run and closed over it, so two concurrent
+ *  assemblies cannot read each other's verdict. */
+interface RunRecord {
+  /** Did an `app.vendo` save ever reach the store? */
+  assembled: boolean;
+  title?: string;
+  escalated?: string;
+}
+
+/** Nothing to hire and nothing to load: the job description is already the whole
+ *  brief, and `hire_subagent` is not on this loadout. */
+const NO_SKILLS: TurnSkills = {
+  async list() {
+    return [];
+  },
+  async load(name: string) {
+    throw new Error(`the screen agent carries no skills, so it cannot load ${name}`);
+  },
+};
+
+const runState = (): TurnState => {
+  let value: string | undefined;
+  return {
+    get: () => value,
+    set: (next: string) => {
+      value = next;
+    },
+    clear: () => {
+      value = undefined;
+    },
+  };
+};
+
 /**
  * ONE assembly run, over any surface a `Turn` satisfies.
  *
@@ -233,8 +268,17 @@ export async function assembleScreen(
 ): Promise<ScreenResult> {
   if (surface.signal.aborted) return { kind: "unavailable", why: "the caller hung up" };
 
+  // Seats are required only where a harness reads them (contract §4, relaxed) —
+  // and the screen agent thinks with `default`, so a turn without it is the
+  // caller's composition bug, named loudly rather than limped past. Same posture
+  // as `vendo()`, which reads the same seat.
+  if (surface.models.default === undefined) {
+    throw new Error("the screen agent thinks with `turn.models.default`, and this turn carries no default seat");
+  }
+
   const directory = appDirectory(input.appId);
   const listings = await surface.tools.list().catch(() => [] as ToolListing[]);
+  const record: RunRecord = { assembled: false };
 
   /**
    * Write one hot-path file and land it.
@@ -247,120 +291,119 @@ export async function assembleScreen(
    * floor by design, exactly as `AppsRuntime.authored` says — and the front door
    * checks the app's ROW before it promises the person a screen.
    */
-  const save = async (file: string, content: string): Promise<boolean> => {
-    await surface.workspace.writeFile(`${directory}/${file}`, content);
-    const result = await surface.workspace.commit({ message: `${file} (${input.appId})` });
+  const save = async (turn: Turn<unknown>, file: string, content: string): Promise<boolean> => {
+    await turn.workspace.writeFile(`${directory}/${file}`, content);
+    const result = await turn.workspace.commit({ message: `${file} (${input.appId})` });
     return result.status === "ok";
   };
 
-  let escalated: string | undefined;
-  let title: string | undefined;
-  /** Did an `app.vendo` save ever reach the store? */
-  let assembled = false;
-
-  const tools: ToolSet = {};
-  for (const listing of listings) {
-    // The small loadout: the assembly verbs by name, plus the host's read tools
-    // so a query's real values can be learned when a tool declares no shape.
-    // `vendo_make` is excluded by name — it is what called this loop — and a
-    // mutating host tool is not an assembly tool.
-    if (!ASSEMBLY_TOOLS.includes(listing.name) && listing.risk !== "read") continue;
-    if (listing.name === VENDO_MAKE_TOOL) continue;
-    tools[listing.name] = tool({
-      description: modelToolDescription(listing),
-      inputSchema: jsonSchema((listing.inputSchema ?? NO_INPUT_SCHEMA) as Parameters<typeof jsonSchema>[0]),
-      execute: async (args: unknown) => surface.tools.call(listing.name, args as Json),
-    });
-  }
-
-  tools[SAVE_APP_TOOL] = tool({
+  const saveApp: HarnessHand = {
+    name: SAVE_APP_TOOL,
     description:
       "Save this app's whole document. The person's screen repaints on every save that parses, so save "
       + "as you go rather than once at the end. Returns whether the save landed.",
-    inputSchema: z.object({
-      content: z.string().min(1).describe("The complete app document, in the .vendo format."),
-    }),
-    execute: async ({ content }) => {
-      const landed = await save(APP_FILE, content);
+    inputSchema: {
+      type: "object",
+      properties: { content: { type: "string", description: "The complete app document, in the .vendo format." } },
+      required: ["content"],
+      additionalProperties: false,
+    },
+    execute: async (args, turn) => {
+      const content = (args as { content: string }).content;
+      const landed = await save(turn, APP_FILE, content);
       if (!landed) {
         return { saved: false, note: "The save did not land — someone else changed this app. Save again." };
       }
-      assembled = true;
-      title = nameOf(content) ?? title;
+      record.assembled = true;
+      record.title = nameOf(content) ?? record.title;
       return { saved: true, note: "Run validate on it now." };
     },
-  });
+  };
 
-  tools[ESCALATE_TOOL] = tool({
+  const escalate: HarnessHand = {
+    name: ESCALATE_TOOL,
     description:
       "Hand this ask to the builder, which has real code, a real machine and no step budget. Use it when "
       + "assembling a document out of this product's components genuinely cannot serve the ask. Write the "
       + "plan: it becomes the skeleton the person watches while the builder fills it in. This ends your turn.",
-    inputSchema: z.object({
-      plan: z.string().min(1).describe("The plan document, in the .vendo plan format."),
-      why: z.string().min(1).describe("One plain sentence: what assembly cannot do here."),
-    }),
-    execute: async ({ plan, why }) => {
+    inputSchema: {
+      type: "object",
+      properties: {
+        plan: { type: "string", description: "The plan document, in the .vendo plan format." },
+        why: { type: "string", description: "One plain sentence: what assembly cannot do here." },
+      },
+      required: ["plan", "why"],
+      additionalProperties: false,
+    },
+    execute: async (args, turn) => {
+      const { plan, why } = args as { plan: string; why: string };
       // §4.5: no consent step and no ceremony. The plan lands, its skeleton
       // paints in seconds, and the work proceeds — so the only thing this
       // returns is the fact that it happened.
-      const landed = await save(PLAN_FILE, plan);
-      escalated = why;
+      const landed = await save(turn, PLAN_FILE, plan);
+      record.escalated = why;
       return { handedOver: true, planSaved: landed };
     },
+  };
+
+  // The small loadout, resolved where the listings are: the assembly verbs by
+  // name, plus the host's read tools so a query's real values can be learned when
+  // a tool declares no shape. `vendo_make` is excluded by name — it is what called
+  // this loop — and a mutating host tool is not an assembly tool. Names, not a
+  // risk filter passed downward: the closed list stays a list, and the one place
+  // that can decide "is this an assembly tool" is the one holding the listing.
+  const loadout: Array<string | HarnessHand> = listings
+    .filter((listing) => listing.name !== VENDO_MAKE_TOOL)
+    .filter((listing) => ASSEMBLY_TOOLS.includes(listing.name) || listing.risk === "read")
+    .map((listing) => listing.name);
+  loadout.push(saveApp, escalate);
+
+  const turn: Turn<VendoHarnessOptions> = {
+    messages: [{ id: `screen_${input.appId}`, role: "user", parts: [{ type: "text", text: input.request }] }],
+    // The listings are read ONCE and handed back verbatim: a closed loadout has
+    // nothing to discover, so re-reading them mid-run would be a second projection
+    // of the same static menu.
+    tools: { call: (name, args) => surface.tools.call(name, args), list: async () => listings },
+    skills: NO_SKILLS,
+    workspace: surface.workspace,
+    models: surface.models,
+    state: runState(),
+    options: {},
+    signal: surface.signal,
+    // This loop talks to nobody: the front door speaks the receipt, and an
+    // approval it cannot show is a denial with a reason (see `registryTools`).
+    interactive: false,
+    threadId: surface.threadId ?? `screen_${input.appId}`,
+    turnId: surface.turnId ?? mintTurnId(),
+  };
+
+  /** The first thing that went wrong, in the shipped loop's own words
+   *  (`wireErrorMessage`, applied inside `vendo()`). */
+  let failure: string | undefined;
+  const harness = vendo({
+    tools: loadout,
+    maxSteps: SCREEN_STEPS,
+    // The brief WINS over `turn.system`: it already folds the deployment's prompt
+    // in as its first section, so letting the turn's copy through would say it
+    // twice.
+    system: () => screenBrief(input, listings),
   });
-
-  const equipped = Object.keys(tools);
-  // Seats are required only where a harness reads them (contract §4, relaxed) —
-  // and the screen agent thinks with `default`, so a turn without it is the
-  // caller's composition bug, named loudly rather than limped past. Same posture
-  // as `vendo()`, which reads the same seat.
-  const model = surface.models.default;
-  if (model === undefined) {
-    throw new Error("the screen agent thinks with `turn.models.default`, and this turn carries no default seat");
-  }
-  let loop: Awaited<ReturnType<typeof startTurn>>;
-  try {
-    loop = await startTurn({
-      model,
-      system: screenBrief(input, listings),
-      messages: [{ id: `screen_${input.appId}`, role: "user", parts: [{ type: "text", text: input.request }] }],
-      tools,
-      signal: surface.signal,
-      // The shipped loadout rail. `attach` is a no-op for `instant()`'s reason:
-      // `find_tools` is the RUNTIME's, and a screen agent has a fixed loadout —
-      // there is nothing for it to discover mid-run.
-      toolSearch: { activeToolNames: () => equipped, attach: () => {} },
-      context: { maxSteps: SCREEN_STEPS },
-    });
-  } catch (error) {
-    return { kind: "unavailable", why: wireErrorMessage(error) };
+  // The events MUST be drained or nothing runs. Nothing is teed and nothing is
+  // buffered: this loop produces no prose for a person — the screen is the answer
+  // and the front door speaks the receipt.
+  for await (const event of harness.run(turn)) {
+    if (event.type === "error") failure ??= event.message;
   }
 
-  try {
-    // The stream MUST be drained or nothing runs. Nothing is teed and nothing is
-    // buffered: this loop produces no prose for a person — the screen is the
-    // answer and the front door speaks the receipt.
-    for await (const part of loop.result.fullStream) {
-      if (part.type === "abort") return { kind: "unavailable", why: "the caller hung up" };
-      if (part.type === "error") {
-        // A model failure after a screen already painted is not a failed screen.
-        if (!assembled && escalated === undefined) {
-          return { kind: "unavailable", why: wireErrorMessage(part.error) };
-        }
-      }
-    }
-  } catch (error) {
-    if (!assembled && escalated === undefined) return { kind: "unavailable", why: wireErrorMessage(error) };
-  }
-
+  if (surface.signal.aborted) return { kind: "unavailable", why: "the caller hung up" };
   // Escalation wins over a partial paint: the builder is finishing this app, and
   // saying "ready" over a half-assembled document would be the lie §4.5 exists
   // to avoid. `status: "building"` is the honest receipt, and the front door
   // stamps it.
-  if (escalated !== undefined) return { kind: "escalate", why: escalated };
-  if (assembled) return { kind: "assembled", ...(title === undefined ? {} : { title }) };
-  return { kind: "unavailable", why: "assembly produced nothing that renders" };
+  if (record.escalated !== undefined) return { kind: "escalate", why: record.escalated };
+  // A model failure AFTER a screen already painted is not a failed screen.
+  if (record.assembled) return { kind: "assembled", ...(record.title === undefined ? {} : { title: record.title }) };
+  return { kind: "unavailable", why: failure ?? "assembly produced nothing that renders" };
 }
 
 // ─── Door 1: the harness ─────────────────────────────────────────────────────
@@ -429,7 +472,10 @@ export interface ScreenAssemblerDeps {
   /** This principal's workspace, unwrapped. The assembler wraps it with the
    *  render seam itself, so composition never has to know that it must. */
   workspace: (ctx: RunContext) => Promise<WorkspaceFs>;
-  /** The seam's optional halves — plan facts and the app half (`AppsRuntime.authored`). */
+  /** The seam's optional halves — the checks floor, plan facts, the app half
+   *  (`AppsRuntime.authored`) and source persistence. The SAME options the
+   *  harness-turn route passes: a screen assembled here compiles in the production
+   *  dialect and passes the same floor, or it does not paint. */
   render?: (ctx: RunContext) => Omit<RenderSeamOptions, "emit">;
   /** The deployment's assembled prompt for this ctx, when composition has one. */
   system?: (ctx: RunContext) => Promise<string | undefined>;
@@ -456,6 +502,9 @@ export function screenAssembler(deps: ScreenAssemblerDeps): ScreenAssembler {
   return {
     async assemble(request: ScreenRequest, ctx: RunContext): Promise<ScreenOutcome> {
       const base = await deps.workspace(ctx);
+      // ONE wrap for the whole screen path, here: composition hands the seam's
+      // options and never has to know that a workspace must be wrapped before an
+      // assembly writes to it.
       const workspace = wrapWorkspaceForRender(base, {
         ...deps.render?.(ctx),
         ...(ctx.turnId === undefined ? {} : { turnId: ctx.turnId }),
@@ -470,6 +519,7 @@ export function screenAssembler(deps: ScreenAssemblerDeps): ScreenAssembler {
           // The front door owns cancellation: `vendo_make` resolves or it does
           // not, and the tool bridge is what a caller aborts.
           signal: new AbortController().signal,
+          ...(ctx.turnId === undefined ? {} : { turnId: ctx.turnId }),
         },
         {
           appId: request.appId,

--- a/packages/harnesses/src/vendo.test.ts
+++ b/packages/harnesses/src/vendo.test.ts
@@ -7,9 +7,9 @@
  * These suites assert the LOOP, not a model: the thinker is scripted so what is
  * measured is the lift.
  */
-import type { HarnessEvent, ToolDescriptor, Turn } from "@vendoai/core";
+import type { HarnessEvent, Json, ToolDescriptor, Turn } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
-import { vendo } from "./vendo.js";
+import { vendo, type HarnessHand } from "./vendo.js";
 import { createTurnTools } from "./turn-tools.js";
 import {
   boundRegistry,
@@ -54,11 +54,21 @@ async function drive(options: {
     interactive: options.interactive ?? true,
     mirror: (event) => mirrored.push(event.kind),
   });
+  /** How many times the loop re-read the equipped listing — the discovery rail's
+   *  only observable, and what a closed loadout must not do more than once. */
+  const listCalls = { count: 0 };
+  const workspace = testWorkspace();
   const turn: Turn = {
     messages: options.messages ?? [userMessage("m1", "hello")],
-    tools: turnTools,
+    tools: {
+      call: (name, args) => turnTools.call(name, args),
+      list: async () => {
+        listCalls.count += 1;
+        return await turnTools.list();
+      },
+    },
     skills: options.skills ?? testSkills(),
-    workspace: testWorkspace(),
+    workspace,
     models: options.models,
     state: { get: () => undefined, set: () => undefined, clear: () => undefined },
     options: options.options ?? {},
@@ -68,7 +78,7 @@ async function drive(options: {
   const events: HarnessEvent[] = [];
   for await (const event of options.harness.run(turn)) events.push(event);
   turnTools.dispose();
-  return { events, registry, guard, mirrored };
+  return { events, registry, guard, mirrored, workspace, listCalls };
 }
 
 const texts = (events: HarnessEvent[]): string =>
@@ -365,6 +375,120 @@ describe("vendo() — subagent hiring (build-list item 4)", () => {
     // Turn 1 = resident (has the hiring tool), turn 2 = subagent (must not).
     expect(model.toolNamesPerCall[0]).toContain("hire_subagent");
     expect(model.toolNamesPerCall[1]).not.toContain("hire_subagent");
+  });
+});
+
+describe("vendo() — the closed loadout (`tools`)", () => {
+  const hostTools = {
+    maple_invoices_list: { descriptor: readTool("maple_invoices_list"), execute: () => ({ count: 2 }) },
+    maple_pay: { descriptor: readTool("maple_pay", "destructive"), execute: () => ({ ok: true }) },
+  };
+
+  /** A hand the harness itself provides. It reaches THIS run's workspace through
+   *  the turn, which is the whole reason `execute` takes one. */
+  const saveApp: HarnessHand = {
+    name: "save_app",
+    description: "Save the document.",
+    inputSchema: {
+      type: "object",
+      properties: { content: { type: "string" } },
+      required: ["content"],
+      additionalProperties: false,
+    },
+    execute: async (input, turn) => {
+      await turn.workspace.writeFile("/user/apps/app_1/app.vendo", (input as { content: string }).content);
+      const result = await turn.workspace.commit({ message: "app.vendo" });
+      return { saved: result.status === "ok" } as Json;
+    },
+  };
+
+  it("equips EXACTLY the list: no unnamed host tool, no hire_subagent", async () => {
+    const model = scriptedModel([textTurn("nothing to do")]);
+    await drive({
+      harness: vendo({ tools: ["maple_invoices_list", saveApp] }),
+      tools: hostTools,
+      models: seats(model),
+    });
+    expect(model.toolNamesPerCall[0]).toEqual(["maple_invoices_list", "save_app"]);
+  });
+
+  it("a named registry tool still runs through the guard-bound call path", async () => {
+    const model = scriptedModel([toolCallTurn("maple_invoices_list", {}), textTurn("You have 2.")]);
+    const { registry, mirrored } = await drive({
+      harness: vendo({ tools: ["maple_invoices_list"] }),
+      tools: hostTools,
+      models: seats(model),
+    });
+    expect(registry.invocations.maple_invoices_list).toBe(1);
+    // The guard, the audit row and the transcript mirror are not this file's
+    // business — which is only true while the call goes through `turn.tools`.
+    expect(mirrored).toEqual(["call", "result"]);
+  });
+
+  it("an inline hand acts on THIS run's turn, and is invisible to the registry", async () => {
+    const model = scriptedModel([toolCallTurn("save_app", { content: "<App name=\"x\" />" }), textTurn("saved")]);
+    const { workspace, registry } = await drive({
+      harness: vendo({ tools: [saveApp] }),
+      tools: hostTools,
+      models: seats(model),
+    });
+    expect(await workspace.readFile("/user/apps/app_1/app.vendo")).toBe("<App name=\"x\" />");
+    expect(workspace.commits).toHaveLength(1);
+    // A hand is the harness's own: no listing, no registry execution, nothing for
+    // another consumer to discover.
+    expect(registry.invocations["save_app"]).toBeUndefined();
+  });
+
+  it("names a listing that a legit deployment lacks: the tool is simply not offered", async () => {
+    // The list is written once, at boot, against a listing that varies per
+    // deployment — so a name the host has not got is an ABSENCE, not a fault. It
+    // costs nothing at turn time and the model is never told about a tool it
+    // cannot call. (Failing loudly here would take down every host that does not
+    // ship the optional tool.)
+    const model = scriptedModel([textTurn("ok")]);
+    await drive({
+      harness: vendo({ tools: ["maple_invoices_list", "no_such_tool"] }),
+      tools: hostTools,
+      models: seats(model),
+    });
+    expect(model.toolNamesPerCall[0]).toEqual(["maple_invoices_list"]);
+  });
+
+  it("hires only when hiring is on the list", async () => {
+    const closed = scriptedModel([textTurn("ok")]);
+    await drive({ harness: vendo({ tools: ["maple_invoices_list"] }), tools: hostTools, models: seats(closed) });
+    expect(closed.toolNamesPerCall[0]).not.toContain("hire_subagent");
+
+    const named = scriptedModel([textTurn("ok")]);
+    await drive({
+      harness: vendo({ tools: ["maple_invoices_list", "hire_subagent"] }),
+      tools: hostTools,
+      models: seats(named),
+    });
+    expect(named.toolNamesPerCall[0]).toContain("hire_subagent");
+  });
+
+  it("has no discovery rail: the listing is read ONCE, never re-read after a call", async () => {
+    const model = scriptedModel([
+      toolCallTurn("maple_invoices_list", {}, "c1"),
+      toolCallTurn("maple_invoices_list", {}, "c2"),
+      textTurn("done"),
+    ]);
+    const { listCalls } = await drive({
+      harness: vendo({ tools: ["maple_invoices_list"] }),
+      tools: hostTools,
+      models: seats(model),
+    });
+    expect(listCalls.count).toBe(1);
+  });
+
+  it("leaves the open loadout exactly as it was when `tools` is unset", async () => {
+    const model = scriptedModel([textTurn("ok")]);
+    await drive({ harness: vendo(), tools: hostTools, models: seats(model) });
+    const offered = model.toolNamesPerCall[0] ?? [];
+    expect(offered).toContain("maple_invoices_list");
+    expect(offered).toContain("maple_pay");
+    expect(offered).toContain("hire_subagent");
   });
 });
 

--- a/packages/harnesses/src/vendo.ts
+++ b/packages/harnesses/src/vendo.ts
@@ -90,6 +90,39 @@ export interface VendoHarnessDeps {
     summary: string;
     usage: { inputTokens: number; outputTokens: number };
   }) => void;
+  /**
+   * The CLOSED toolbox. Set, the equipped set is EXACTLY this list: a string
+   * equips that registry tool (guarded, via `turn.tools.call`, same as today); a
+   * {@link HarnessHand} is the harness's own hand, invisible to every other
+   * consumer. No discovery rail (`find_tools` is not mounted — a fixed loadout has
+   * nothing to discover), no `vendo_*` always-active exemption (the list is
+   * total), no `hire_subagent` unless named. Unset = today's behaviour, unchanged.
+   *
+   * This is what lets a specialist BE `vendo()` plus configuration rather than a
+   * second copy of the loop: the step cap, the seat resolution, `wireErrorMessage`
+   * and the system precedence are the ones above, not a fork of them.
+   */
+  tools?: readonly (string | HarnessHand)[];
+}
+
+/**
+ * A tool the harness itself provides — the other half of a closed loadout.
+ *
+ * `execute` receives the TURN, which is what lets a hand be declared once at boot
+ * (where a `Harness` value is built, with no run in sight) while its effects are
+ * per-run: `turn.workspace` is this run's files and `turn.state` is this run's
+ * scratch. A hand never reaches the registry, so nothing else can discover it and
+ * the guard has nothing to decide about it — a hand that touches host data does it
+ * by calling `turn.tools.call` like anyone else.
+ */
+export interface HarnessHand {
+  /** What the model calls it. Never `vendo_`-prefixed: those names are the
+   *  product's, and the loadout rail treats them as always-active. */
+  name: string;
+  description: string;
+  /** JSON Schema, the same dialect a `ToolListing.inputSchema` carries. */
+  inputSchema: Record<string, unknown>;
+  execute(input: Json, turn: Turn<unknown>): Promise<Json>;
 }
 
 /** A tool with no declared input still needs a schema the provider will accept. */
@@ -133,6 +166,51 @@ async function refreshEquipped(
     });
   }
   return listings.map((listing) => listing.name);
+}
+
+/**
+ * Mount a CLOSED loadout: this list, resolved once, and nothing else.
+ *
+ * The listing is read one time and never re-read — a fixed loadout has nothing to
+ * discover, so `find_tools` is not mounted and there is no `afterCall` refresh. A
+ * name the listing does not carry is simply NOT OFFERED: the list is written at
+ * boot against a listing that legitimately varies per deployment (an optional
+ * host tool, a pack that is not installed), so an absence is a fact about the
+ * deployment rather than a fault in the harness — and the model is never told
+ * about a tool it could not have called anyway.
+ */
+async function equipClosedLoadout(
+  turn: Turn<unknown>,
+  tools: ToolSet,
+  loadout: readonly (string | HarnessHand)[],
+  hireSubagent: ToolSet[string],
+): Promise<string[]> {
+  const listings = new Map((await turn.tools.list()).map((listing) => [listing.name, listing]));
+  for (const entry of loadout) {
+    if (typeof entry !== "string") {
+      tools[entry.name] = tool({
+        description: entry.description,
+        inputSchema: jsonSchema(entry.inputSchema as Parameters<typeof jsonSchema>[0]),
+        execute: async (input: unknown) => await entry.execute(input as Json, turn),
+      });
+      continue;
+    }
+    if (entry === HIRE_SUBAGENT) {
+      tools[entry] = hireSubagent;
+      continue;
+    }
+    const listing = listings.get(entry);
+    if (listing === undefined) continue;
+    tools[entry] = tool({
+      description: modelToolDescription(listing),
+      inputSchema: jsonSchema((listing.inputSchema ?? NO_INPUT_SCHEMA) as Parameters<typeof jsonSchema>[0]),
+      // The same one line as the open loadout: the guard, the audit row, the view
+      // channel, the transcript mirror and §1.4's approval block live behind
+      // `call()`, closed list or not.
+      execute: async (input: unknown) => await turn.tools.call(listing.name, input as Json),
+    });
+  }
+  return Object.keys(tools);
 }
 
 interface SubagentReport {
@@ -211,50 +289,61 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
       // the curated, equipped set, and re-reading it is how a tool searched in
       // through `find_tools` becomes callable in the SAME turn. One object, never
       // a copy — `streamText` re-reads it per step, so a copy would freeze the
-      // toolset at step one and strand every discovery.
+      // toolset at step one and strand every discovery. (A closed loadout has
+      // nothing to discover, so it fills the same object once and stops.)
       const residentTools: ToolSet = {};
       let equipped: string[] = [];
-      const refresh = async (): Promise<void> => {
-        equipped = await refreshEquipped(turn, residentTools, refresh);
-      };
-      await refresh();
       /** Subagent tokens, drained onto the turn's usage after the stream ends. */
       const hiredUsage: Array<{ inputTokens: number; outputTokens: number }> = [];
-      Object.assign(residentTools, {
-        [HIRE_SUBAGENT]: tool({
-          description:
-            "Hire a specialist for one big job (building or editing an app, a long research pass). "
-            + "Name a skill to give it the full instructions. It reports back a short summary.",
-          inputSchema: z.object({
-            instructions: z.string().describe("What the specialist should accomplish."),
-            skill: z.string().optional().describe("A skill name from your skill list."),
-          }),
-          execute: async (input) => {
-            try {
-              // The specialist gets the same hands as the resident has RIGHT NOW —
-              // searched-in tools included — minus the hiring tool, so depth is
-              // bounded at one and a helper cannot spawn a tree.
-              const { [HIRE_SUBAGENT]: _hiring, ...hands } = residentTools;
-              const report = await runSubagent(turn, model, input, hands);
-              hiredUsage.push(report.usage);
-              (deps.onHire ?? reportHire)({
-                purpose: input.instructions,
-                ...(input.skill === undefined ? {} : { skill: input.skill }),
-                summary: report.summary,
-                usage: report.usage,
-              });
-              return { summary: report.summary };
-            } catch (error) {
-              // A failed hire is one tool result the resident can react to — never
-              // the turn's death.
-              console.error("[vendo] harness: subagent failed", {
-                error: error instanceof Error ? error.message : String(error),
-              });
-              return { error: "The specialist could not be reached for that job." };
-            }
-          },
+      const hireSubagent = tool({
+        description:
+          "Hire a specialist for one big job (building or editing an app, a long research pass). "
+          + "Name a skill to give it the full instructions. It reports back a short summary.",
+        inputSchema: z.object({
+          instructions: z.string().describe("What the specialist should accomplish."),
+          skill: z.string().optional().describe("A skill name from your skill list."),
         }),
+        execute: async (input) => {
+          try {
+            // The specialist gets the same hands as the resident has RIGHT NOW —
+            // searched-in tools included — minus the hiring tool, so depth is
+            // bounded at one and a helper cannot spawn a tree.
+            const { [HIRE_SUBAGENT]: _hiring, ...hands } = residentTools;
+            const report = await runSubagent(turn, model, input, hands);
+            hiredUsage.push(report.usage);
+            (deps.onHire ?? reportHire)({
+              purpose: input.instructions,
+              ...(input.skill === undefined ? {} : { skill: input.skill }),
+              summary: report.summary,
+              usage: report.usage,
+            });
+            return { summary: report.summary };
+          } catch (error) {
+            // A failed hire is one tool result the resident can react to — never
+            // the turn's death.
+            console.error("[vendo] harness: subagent failed", {
+              error: error instanceof Error ? error.message : String(error),
+            });
+            return { error: "The specialist could not be reached for that job." };
+          }
+        },
       });
+
+      // The closed list is TOTAL: what it names is what the model gets, hiring
+      // included only if it is named. The open path keeps the discovery rail — the
+      // listing re-read after every call — and hires by default.
+      let activeToolNames: () => string[];
+      if (deps.tools === undefined) {
+        const refresh = async (): Promise<void> => {
+          equipped = await refreshEquipped(turn, residentTools, refresh);
+        };
+        await refresh();
+        residentTools[HIRE_SUBAGENT] = hireSubagent;
+        activeToolNames = () => [...equipped, HIRE_SUBAGENT];
+      } else {
+        equipped = await equipClosedLoadout(turn, residentTools, deps.tools, hireSubagent);
+        activeToolNames = () => equipped;
+      }
 
       let loop: Awaited<ReturnType<typeof startTurn>>;
       try {
@@ -275,10 +364,7 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
           // curated-off tool never is. `attach` is a no-op because the runtime —
           // not the harness — owns `find_tools`: that is the dividing line, and it
           // is what gives a third-party harness the same rail for free.
-          toolSearch: {
-            activeToolNames: () => [...equipped, HIRE_SUBAGENT],
-            attach: () => {},
-          },
+          toolSearch: { activeToolNames, attach: () => {} },
           // The WHOLE context, not just `maxSteps`. Passing one knob is what made
           // every other knob unreachable from `vendo()` — the loop declared them,
           // `createAgent` passed them, and this caller silently dropped them, so

--- a/packages/vendo/src/screen-route.e2e.test.ts
+++ b/packages/vendo/src/screen-route.e2e.test.ts
@@ -45,10 +45,30 @@ afterEach(async () => {
 
 const principal: Principal = { kind: "user", subject: "user_screen" };
 
-/** A document the compiler renders and the seam paints — the smallest honest one. */
+/** A document the compiler renders and the seam paints — the smallest honest one.
+ *
+ *  `text`, not `value`: with the checks floor on this route (it was missing, which
+ *  is the bug the case below pins) `components-exist` refuses a prop the renderer
+ *  would silently drop, so a fixture that spoke the wrong prop name only ever
+ *  painted because nothing was checking it. */
 const SPENDING = `<App name="Spending">
   <Stack>
-    <Text value="This month" />
+    <Text text="This month" />
+  </Stack>
+</App>`;
+
+/**
+ * The same document with a `<Query>` naming a tool this deployment has not got.
+ *
+ * It COMPILES and it RENDERS — the tree has children, so the seam's own gate waves
+ * it through — and only the checks floor's `tools-exist` fact refuses it. That is
+ * what makes it the right probe for §7.1 at a route: if it paints, the floor is
+ * not on that route.
+ */
+const LYING = `<App name="Spending">
+  <Query id="spend" tool="nope_notATool" />
+  <Stack>
+    <Text text="Last month" />
   </Stack>
 </App>`;
 
@@ -114,6 +134,9 @@ async function walk(options: {
   turns: Chunk[][];
   screenAgent: boolean;
   request?: string;
+  /** Skip `vendo_make` entirely and write the documents with the harness's own
+   *  hands — the OTHER route into the same seam. */
+  writes?: string[];
 }): Promise<Walked> {
   const store = await tempStore();
   const model = scripted(options.turns);
@@ -121,6 +144,14 @@ async function walk(options: {
   const harness = defineHarness({
     name: "make-probe",
     async *run(turn) {
+      if (options.writes !== undefined) {
+        for (const [index, content] of options.writes.entries()) {
+          await turn.workspace.writeFile(`/user/apps/app_written/app.vendo`, content);
+          await turn.workspace.commit({ message: `save ${index}` });
+        }
+        yield { type: "text", delta: "ok" };
+        return;
+      }
       result = await turn.tools.call(VENDO_MAKE_TOOL, {
         request: options.request ?? "show me what I spent this month",
       });
@@ -199,6 +230,46 @@ describe("vendo_make routed through the screen agent (blueprint §1 point 2)", (
     // A conductor create is a plan call plus a fill call per group on top of that,
     // so a routed request is measurably the cheap path and not both paths.
     expect(walked.model.calls).toBe(3);
+  }, 60_000);
+
+  it("refuses to paint a document the checks floor blocks, and the last good view stays", async () => {
+    // THE BUG THIS PINS. The screen slot wired the render seam WITHOUT the floor,
+    // so a screen assembled through `vendo_make` compiled with a bare
+    // `compileWire`: no fact checks, no binding gate, no tsc. A query naming a
+    // tool the host has not got painted anyway — an app promising data it can
+    // never load — while the very same document written on the harness-turn route
+    // was refused. One seam, two answers.
+    const walked = await walk({
+      screenAgent: true,
+      turns: [
+        call("save_app", { content: SPENDING }, "c1"),
+        call("save_app", { content: LYING }, "c2"),
+        speak("done"),
+      ],
+    });
+
+    const views = walked.chunks.filter((chunk) => chunk["type"] === "data-vendo-view");
+    expect(views.length).toBeGreaterThan(0);
+    const painted = JSON.stringify(views);
+    // The honest save is on screen…
+    expect(painted).toContain("This month");
+    // …and the blocked one never reached it: no view carries the lie, so the last
+    // good view is what the person still sees. The bytes DID land — the floor
+    // refuses the paint, never the commit — and `validate` is how the model hears
+    // about it.
+    expect(painted).not.toContain("Last month");
+    expect(painted).not.toContain("nope_notATool");
+  }, 60_000);
+
+  it("the harness-turn route answers the same, which is the point of one seam", async () => {
+    // The control. This route already carried the floor, so it is the definition
+    // of correct behaviour — and the two routes must not disagree about the same
+    // bytes.
+    const walked = await walk({ screenAgent: true, turns: [], writes: [SPENDING, LYING] });
+    const painted = JSON.stringify(walked.chunks.filter((chunk) => chunk["type"] === "data-vendo-view"));
+    expect(painted).toContain("This month");
+    expect(painted).not.toContain("Last month");
+    expect(painted).not.toContain("nope_notATool");
   }, 60_000);
 
   it("is OFF by default — an unwired slot leaves vendo_make exactly as it was", async () => {

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -2332,10 +2332,22 @@ export function createVendo(config: CreateVendoConfig): Vendo {
             screenCtx.memberships === undefined ? undefined : { memberships: screenCtx.memberships },
           );
         },
-        // §1.6's app half, the SAME one the harness turns pass the seam below:
-        // the row that makes a written file an app, and the queries that put real
-        // data behind its bindings.
-        render: (screenCtx) => ({ authoredApp: (input) => apps.authored(input, screenCtx) }),
+        // The SAME seam options the harness turns pass below — every one of them,
+        // because a screen assembled here lands on the same store through the same
+        // `commit()`. §1.6's app half (the row that makes a written file an app,
+        // and the queries that put real data behind its bindings), §3.2's source
+        // half, and §7.1's floor.
+        //
+        // The floor was the one that was missing, and its absence was invisible: a
+        // screen assembled through `vendo_make` compiled with a bare `compileWire`
+        // — no fact checks, no binding gate, no tsc — so a lying binding painted
+        // here and was refused one route over. One seam cannot have two answers
+        // about the same bytes.
+        render: (screenCtx) => ({
+          authoredApp: (input) => apps.authored(input, screenCtx),
+          commitSource: (input) => apps.commitSource(input, screenCtx),
+          floor: apps.floor(screenCtx),
+        }),
         // `system` is deliberately unset. The screen agent's brief is the shipped
         // `building-apps` skill plus the host's own tool shapes, and the
         // deployment prompt's job — voice, venue gate, guard directions, the


### PR DESCRIPTION
## What changed

**1. `vendo()` takes a closed loadout.** New `VendoHarnessDeps.tools`. Set, the
equipped set is EXACTLY that list: a string equips that registry tool (guarded,
through `turn.tools.call`, exactly as today); a `HarnessHand` —
`{ name, description, inputSchema, execute(input, turn) }` — is the harness's own
hand, invisible to every other consumer. The list is total: no `find_tools` (a
fixed loadout has nothing to discover), no `vendo_*` always-active exemption, no
`hire_subagent` unless the list names it. Unset — every existing caller — is
byte-for-byte today's behaviour.

`execute` receives the TURN. That is what lets a hand be declared where a
`Harness` value is built (at boot, with no run in sight) while its effects are
per-run: `turn.workspace` is this run's files.

A name the deployment's listing does not carry is **simply not offered**, with a
comment and a test saying so. The list is written once against a listing that
legitimately varies per deployment (an optional host tool, a pack that is not
installed); failing loudly there would take down every host that ships one fewer
tool, and the model is never told about something it could not have called.

**2. The screen agent is that configuration, not a second loop.**
`packages/harnesses/src/screen-agent.ts` hand-rolled its own `startTurn` drive:
its own ToolSet filtering, two ad-hoc `ai` tools, its own stream drain, its own
outcome. All of that is deleted. What remains is the brief (`screenBrief` /
`environmentNote`, unchanged), `SCREEN_STEPS = 10`, the loadout, two
`HarnessHand`s (`save_app`, `escalate`) and the outcome the front door reads —
driven through `vendo()`'s normal `run(turn)` door. Both public doors
(`screenAgent()`, `screenAssembler()`), the `ScreenOutcome` semantics and
`packages/core/src/screen.ts` are untouched.

One loop means the step cap, the seat resolution, `wireErrorMessage`, the context
knobs and the system precedence are the default harness's — a rail cannot be
fixed in one thinker and stay broken in the other. The step cap is now proven to
reach the loop that enforces it rather than asserted as a constant.

**3. The bug: a screen assembled through `vendo_make` was never checked.**
Composition wired the screen slot's render seam **without** `floor` or
`commitSource`, while the harness-turn route passed
`{ authoredApp, commitSource, floor }`. One seam, two answers about the same
bytes:

- an `app.vendo` whose `<Query>` names a tool the host has not got — or whose
  prop the renderer silently drops — was refused on the harness route and
  **painted** on the `vendo_make` route;
- that route compiled with a bare `compileWire`: no inline tool expansion (the
  binding is dropped and the query never minted, and it paints anyway) and
  `bindingErrors: []` by construction;
- and the app's own source never reached the store, so its only home was the
  sandbox snapshot.

The screen slot now carries the same `floor` and `commitSource`. A blocking
finding means nothing paints and the last good view stays — the seam's existing
mechanism, not a new failure channel — while the write still lands so `validate`
can read it back and repair it. Exactly one place in the screen path wraps the
workspace, as before (`screenAssembler`); the floor rides in through its deps.

## The seam proof (no mock on either side)

`packages/vendo/src/screen-route.e2e.test.ts`, in a real composed deployment
(real store, real guard, real apps pack, real render seam, real floor — only the
model is scripted):

- **`vendo_make` route:** save an honest `app.vendo` (paints), then save one the
  floor blocks. The blocked document paints nothing and the honest view is still
  what the person has.
- **harness-turn route:** the same two documents written straight through
  `turn.workspace` + `commit()`. Identical answer — that is the point of one
  seam.

Proven able to fail: with `floor:` removed from the screen slot and everything
else identical, the `vendo_make` case goes red (`expected … not to contain 'Last
month'`) while the harness-turn control stays green — the two routes disagreeing,
which is the bug.

**Fixture correction (flagged):** the pre-existing e2e fixture wrote
`<Text value="…" />`. `value` is not a `Text` prop (`text` is), so
`components-exist` refuses it — it only ever painted because nothing on that
route was checking. The fixture now says `text`. The test's assertions are
unchanged.

## Behaviour deliberately unchanged

`experimentalScreenAgent` semantics (default off), the conductor path,
`packages/apps/src/screen-route.test.ts`'s contract, the wire formats,
`packages/core`, `claudeCode()`, and `vendo()` with no `tools` set.

## Gate

`pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint`, green
(dependency-guard and portability-gate included). Two pre-existing failures in
`packages/vendo/src/dev-creds/model.test.ts` (`Cannot find module
'@ai-sdk/anthropic'` from a temp dir) reproduce on a clean `origin/main` in this
worktree and are unrelated to this change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converted the screen agent to run as `vendo()` with a closed tool loadout, and made the `vendo_make` route use the same checks floor and source persistence as harness turns to keep both paths consistent.

- **New Features**
  - Added `VendoHarnessDeps.tools` to `vendo()` for a closed loadout. Accepts registry tool names and inline `HarnessHand` entries (`{ name, description, inputSchema, execute(input, turn) }`).
  - Closed loadouts have no discovery rail, no implicit `vendo_*` tools, and include `hire_subagent` only if named. Unset `tools` keeps the current open loadout.
  - Exported `HarnessHand` from `@vendoai/harnesses`. The screen agent now uses `vendo()` with this loadout; doors and outcome semantics remain the same.

- **Bug Fixes**
  - Fixed `vendo_make` to compile with the same options as harness turns: `floor`, `commitSource`, and `authoredApp`. Blocked screens no longer paint; the last good view stays, and source persists for `validate`.
  - Removed the bespoke screen-agent loop and its ad-hoc tool filtering. The shared harness loop now enforces the step cap and default rails consistently.
  - Hosts require no code changes.

<sup>Written for commit 612c3b029ee5030125ef23e6b79eb6273bad1e86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

