### PR TITLE
ci: drop the cadence-supabase-auth job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ permissions:
 #                     single shard — see the comment on that job)
 #   hermetic-extras   the suites that were never in CI at all
 #   ci                aggregate; KEEPS the required-check name `ci`
-# Required checks on main are: ci, integration, perf, conformance,
-# cadence-supabase-auth, audit. Renaming any of those job names breaks merges.
+# Required checks on main are: ci, integration, perf, conformance, audit.
+# Renaming any of those job names breaks merges.
 jobs:
   typecheck-lint:
     runs-on: ubuntu-latest
@@ -472,38 +472,6 @@ jobs:
           name: ui-browser-playwright-trace
           path: packages/ui/e2e/test-results
           retention-days: 7
-
-  # Cadence's Supabase Auth suite (ENG-260): boots `supabase start` (Docker)
-  # and runs demo-accounting's full test suite — the /login password grant
-  # end to end against the seeded users, the away drill (which needs no
-  # Supabase), and the auth/session unit tests. This is the only job that
-  # runs demo-accounting's tests per PR (demo apps define no test:coverage
-  # script, so the test-rest job's turbo run skips them). The login e2e probes
-  # GoTrue and skips itself cleanly when the stack is absent, so Supabase
-  # local never becomes a hard dependency for unrelated tests.
-  cadence-supabase-auth:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 22
-          cache: pnpm
-      - name: Turbo remote cache (GitHub-cache backed)
-        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
-      - uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520 # v3.0.0
-        with:
-          # Matches the version the config/seed were verified against.
-          version: 2.90.0
-      - run: pnpm install --frozen-lockfile
-      # Build only the workspace deps the app boot needs; the suite runs the
-      # app itself through `next dev`.
-      - run: pnpm turbo run build --filter=demo-accounting^...
-      - run: supabase start
-        working-directory: examples/demo-accounting
-      - run: pnpm --filter demo-accounting test
 
   # Supply-chain gate: fails on high/critical advisories in the PRODUCTION
   # dependency graph (what ships in the published tarballs). Scoped to --prod so


### PR DESCRIPTION
Yousef's call: the Cadence demo (demo-accounting) does not need a per-PR test gate.

- Deletes the `cadence-supabase-auth` job, which booted Docker Supabase on every PR (~2m 14s) to run demo-accounting's login/auth suite.
- Already removed from `main`'s required status checks (done via API before this PR so the PR itself can merge).
- demo-accounting's tests still exist and run locally; they just no longer gate PRs.

No code touched — workflow-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `cadence-supabase-auth` CI job to drop the per-PR auth gate for `demo-accounting`, saving ~2 minutes per PR. The check was removed from `main`’s required checks; tests still run locally but no longer block merges.

<sup>Written for commit 64ddd9323d48156e8124dbb8d10536cec437bcd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

