### PR TITLE
proof: e2e skip runs-in-full on a core change (do not merge)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -116,3 +116,4 @@ export type { AppMount } from "./workspace.js";
 // missing `verifier` and `Turn.models` could not describe the verifier seat.
 // Lane A's own file said "if lane D's version differs, lane D's wins"; it does,
 // so the copy is gone and there is one definition.
+// proof: e2e skip must mark this package's dependents affected (PR is closed unmerged)


### PR DESCRIPTION
Companion proof for #846: a one-line change in packages/core must make integration/conformance/perf run their FULL suites (no skip). #846's own run proved the skip path; this proves the run path. Closed unmerged once the timing is recorded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a no-op comment change in `packages/core` to confirm CI marks dependents as affected and runs the full integration, conformance, and perf suites (no skip).
This is a timing probe and will be closed without merging.

<sup>Written for commit 5564405e0bf84ed01be7ac8b9609d2e0b9acea73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

