### PR TITLE
feat(cli): knowledge sync targets the engine the server would use

### DIFF
--- a/.changeset/knowledge-sync-targets-server-engine.md
+++ b/.changeset/knowledge-sync-targets-server-engine.md
@@ -1,0 +1,24 @@
+---
+"@vendoai/vendo": minor
+---
+
+`vendo knowledge sync` now pushes to the engine the composed server would
+read, and says which one it chose.
+
+Engine selection mirrors `selectKnowledge` (server.ts), restricted to what a
+CLI can know: an injected adapter wins; otherwise `VENDO_API_KEY` means Vendo
+Cloud (honouring `VENDO_CLOUD_URL`), so sync pushes over the existing
+`vendo/knowledge-wire@1` /upsert + /remove; with no key it stays on today's
+local lexical engine over `.vendo/data`.
+
+Before, a Cloud-keyed project synced its docs into a *local* store while its
+agent searched Cloud — the docs went somewhere the server never read, and
+nothing said so. Both the plan line and the result line now name the target:
+
+```
+Synced: 3 upserted, 1 removed, 128 unchanged → Vendo Cloud (console.vendo.run)
+Synced: 3 upserted, 1 removed, 128 unchanged → local store (.vendo/data)
+```
+
+No new flags or config: the key you already have decides, the same way it
+decides for the server.

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -42,11 +42,20 @@ vendo knowledge sync             # ingest → diff → push changed docs
 `sync` is the only verb that moves content. It parses and chunks your files,
 diffs against the sha256 hash manifest (`.vendo/knowledge-manifest.json` —
 regenerable, add it to `.gitignore`), upserts exactly the documents that
-changed, removes the ones that vanished, and rewrites the manifest last. With
-no engine configured it targets the local lexical engine over the project's
-default store (`.vendo/data` — the dev server's ENG-351 single-writer lock
-applies, so stop the dev server first or point the engines at your own
-Postgres). Re-running with no changes pushes nothing.
+changed, removes the ones that vanished, and rewrites the manifest last.
+Re-running with no changes pushes nothing.
+
+`sync` pushes to the engine your **server** would read, so the docs land where
+the agent will look for them: with `VENDO_API_KEY` set that is Vendo Cloud,
+and without it the local lexical engine over the project's default store
+(`.vendo/data` — the dev server's ENG-351 single-writer lock applies, so stop
+the dev server first or point the engines at your own Postgres). Every run
+says which one it chose, and `--dry-run` names the target it would push to:
+
+```
+Synced: 3 upserted, 1 removed, 128 unchanged → Vendo Cloud (console.vendo.run)
+Synced: 3 upserted, 1 removed, 128 unchanged → local store (.vendo/data)
+```
 
 The agent side needs no wiring beyond the knowledge slot on `createVendo`:
 `knowledge: vendoKnowledge()` — the composed store is injected for you, and

--- a/packages/vendo/src/cli/knowledge/index.ts
+++ b/packages/vendo/src/cli/knowledge/index.ts
@@ -10,6 +10,7 @@ import {
 } from "@vendoai/core";
 import {
   VENDO_KNOWLEDGE_CONFIG_FORMAT,
+  cloudKnowledge,
   ingestSources,
   knowledgeConfigSchema,
   knowledgeSourceConfigSchema,
@@ -17,6 +18,8 @@ import {
   type KnowledgeConfig,
 } from "@vendoai/knowledge";
 import { createStore } from "@vendoai/store";
+import { resolveCloudBaseUrl } from "../../cloud-key-fetch.js";
+import { environment } from "../../wire/shared.js";
 import { formatTable } from "../cloud/output.js";
 import { consoleOutput, withCommandRun, type Output, type TelemetryOptions } from "../shared.js";
 
@@ -61,8 +64,9 @@ export interface KnowledgeCliOptions {
   output?: Output;
   /** Injectable telemetry deps (matches init/doctor). */
   telemetry?: TelemetryOptions;
-  /** The engine sync targets. Default: the local lexical engine over the
-      project store (deferred to ENG-363); tests inject a double. */
+  /** The engine sync targets. Default: whichever engine the composed server
+      would use for this project (see chooseSyncEngine); tests inject a
+      double, and an injected adapter always wins. */
   adapter?: KnowledgeAdapter;
 }
 
@@ -267,7 +271,10 @@ async function runSyncVerb(
   const removes = Object.keys(manifest?.docs ?? {}).filter((id) => !hashes.has(id));
   const unchanged = docs.length - upserts.length;
 
-  output.log(`Plan: ${upserts.length} to upsert, ${removes.length} to remove, ${unchanged} unchanged (${docs.length} docs total).`);
+  // Named before the plan prints: a developer must be able to see WHERE the
+  // docs are going without running the sync to find out.
+  const engine = chooseSyncEngine(dir, options.adapter);
+  output.log(`Plan: ${upserts.length} to upsert, ${removes.length} to remove, ${unchanged} unchanged (${docs.length} docs total) → ${engine.target}.`);
   if (dryRun) {
     for (const doc of upserts) output.log(`  upsert ${doc.id}`);
     for (const id of removes) output.log(`  remove ${id}`);
@@ -275,7 +282,7 @@ async function runSyncVerb(
     return 0;
   }
 
-  const resolved = options.adapter === undefined ? await defaultSyncAdapter(dir) : { adapter: options.adapter };
+  const resolved = await engine.open();
   const adapter = resolved.adapter;
   try {
     if (!adapter.posture.write || adapter.upsert === undefined || adapter.remove === undefined) {
@@ -294,22 +301,70 @@ async function runSyncVerb(
       updatedAt: new Date().toISOString(),
     };
     await writeFile(manifestPath(dir), `${JSON.stringify(next, null, 2)}\n`, "utf8");
-    output.log(`Synced: ${upserts.length} upserted, ${removes.length} removed, ${unchanged} unchanged.`);
+    output.log(`Synced: ${upserts.length} upserted, ${removes.length} removed, ${unchanged} unchanged → ${engine.target}.`);
     return 0;
   } finally {
     await resolved.close?.();
   }
 }
 
-/** The zero-config engine when none is injected: the local lexical engine
-    over the project's local store (`.vendo/data`, the same createStore
-    default the composed server uses when no store is configured — ENG-351
-    single-writer discipline applies, so a running dev server on the same
-    data dir makes this fail loudly rather than corrupt). */
-async function defaultSyncAdapter(dir: string): Promise<{ adapter: KnowledgeAdapter; close?: () => Promise<void> }> {
-  const store = createStore({ dataDir: join(dir, ".vendo", "data") });
-  await store.ensureSchema();
-  return { adapter: vendoKnowledge({ store }), close: () => store.close() };
+/** What sync is about to push to, chosen and NAMED before anything moves.
+    `open()` is deferred so `--dry-run` can print the target without building
+    an engine (opening the local store would take its single-writer lock). */
+interface SyncEngine {
+  /** Human phrase for the output line — the whole point is that a developer
+      can see WHERE their docs went without reading this file. */
+  target: string;
+  open: () => Promise<{ adapter: KnowledgeAdapter; close?: () => Promise<void> }>;
+}
+
+/** Which engine sync targets, mirroring the composed server's
+    `selectKnowledge` seam (server.ts) restricted to what a CLI can know:
+
+      1. an injected adapter always wins (the adapter rule — tests and hosts
+         driving the CLI directly);
+      2. a Cloud key means Vendo Cloud, so `sync` pushes over the same
+         `vendo/knowledge-wire@1` /upsert + /remove the server would read
+         from — the key is read exactly the way the server reads it
+         (cloudKeyOptions: VENDO_API_KEY, repointed by VENDO_CLOUD_URL);
+      3. no key: the local lexical engine over the project store
+         (`.vendo/data`, the same createStore default the server falls back
+         to — ENG-351 single-writer discipline applies, so a running dev
+         server on the same data dir makes this fail loudly, never corrupt).
+
+    Syncing into a store the server never reads is the failure this closes:
+    before, a Cloud-keyed project pushed its docs into a local store while its
+    agent searched Cloud, and nothing said so. */
+function chooseSyncEngine(dir: string, injected: KnowledgeAdapter | undefined): SyncEngine {
+  if (injected !== undefined) {
+    return { target: "the configured engine", open: async () => ({ adapter: injected }) };
+  }
+  const apiKey = environment("VENDO_API_KEY");
+  if (apiKey !== undefined) {
+    const baseUrl = resolveCloudBaseUrl();
+    return {
+      target: `Vendo Cloud (${hostLabel(baseUrl)})`,
+      open: async () => ({ adapter: cloudKnowledge({ apiKey, baseUrl }) }),
+    };
+  }
+  return {
+    target: "local store (.vendo/data)",
+    open: async () => {
+      const store = createStore({ dataDir: join(dir, ".vendo", "data") });
+      await store.ensureSchema();
+      return { adapter: vendoKnowledge({ store }), close: () => store.close() };
+    },
+  };
+}
+
+/** The console's host, so the line reads "Vendo Cloud (console.vendo.run)"
+    rather than repeating a full URL nobody needs to read. */
+function hostLabel(baseUrl: string): string {
+  try {
+    return new URL(baseUrl).host;
+  } catch {
+    return baseUrl;
+  }
 }
 
 export async function runKnowledge(args: string[], options: KnowledgeCliOptions = {}): Promise<number> {

--- a/packages/vendo/src/cli/knowledge/sync-engine.test.ts
+++ b/packages/vendo/src/cli/knowledge/sync-engine.test.ts
@@ -1,0 +1,234 @@
+import { createServer, type Server } from "node:http";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AddressInfo } from "node:net";
+import {
+  KNOWLEDGE_WIRE_PATHS,
+  VENDO_KNOWLEDGE_WIRE_FORMAT,
+  knowledgeWireRemoveRequestSchema,
+  knowledgeWireSearchRequestSchema,
+  knowledgeWireUpsertRequestSchema,
+  type KnowledgeAdapter,
+} from "@vendoai/core";
+import { memoryKnowledgeAdapter } from "@vendoai/core/conformance";
+import { cloudKnowledge } from "@vendoai/knowledge";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runKnowledge } from "./index.js";
+import type { Output } from "../shared.js";
+
+/**
+ * ENG-363 — `vendo knowledge sync` pushes to the engine the SERVER would use.
+ *
+ * The seam rule (repo CLAUDE.md): a harness that mocks the counterparty proves
+ * nothing. So nothing here is stubbed on either side. The producer is the real
+ * CLI resolving the key from the environment and building the real
+ * `cloudKnowledge` client; the transport is real HTTP over a real listening
+ * socket; the consumer is core's own `vendo/knowledge-wire@1` request schemas
+ * over the real `memoryKnowledgeAdapter`. Read-back goes out through the same
+ * wire, so the producer and the consumer CAN disagree — which is the point.
+ */
+
+const dirs: string[] = [];
+const servers: Server[] = [];
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  for (const dir of dirs.splice(0)) await rm(dir, { recursive: true, force: true });
+  for (const server of servers.splice(0)) await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+async function tempProject(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "vendo-knowledge-sync-"));
+  dirs.push(dir);
+  await mkdir(join(dir, "docs"), { recursive: true });
+  await writeFile(join(dir, "docs", "guide.md"), "# Guide\nRefunds take five days.\n");
+  await writeFile(join(dir, "docs", "faq.md"), "# FAQ\nAnswers live here.\n");
+  return dir;
+}
+
+interface WireServer {
+  url: string;
+  /** Every wire path the CLI actually hit, in order. */
+  paths: string[];
+  authorizations: Array<string | null>;
+  engine: KnowledgeAdapter;
+}
+
+/** A real `vendo/knowledge-wire@1` server on a real port, speaking core's
+    shipped request schemas over a real adapter. The console mounts the five
+    routes under `/api/v1/knowledge`, which is where cloudKnowledge sends. */
+async function wireServer(): Promise<WireServer> {
+  const engine = memoryKnowledgeAdapter();
+  const paths: string[] = [];
+  const authorizations: Array<string | null> = [];
+  const ctx = { principal: { kind: "user" as const, subject: "user_wire" } };
+
+  const server = createServer((req, res) => {
+    void (async () => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) chunks.push(chunk as Buffer);
+      const raw = Buffer.concat(chunks).toString("utf8");
+      const body: unknown = raw === "" ? undefined : JSON.parse(raw);
+      const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+      const route = Object.values(KNOWLEDGE_WIRE_PATHS).find((wire) => pathname.endsWith(wire));
+      paths.push(route ?? pathname);
+      authorizations.push(req.headers.authorization ?? null);
+
+      const send = (status: number, payload: unknown): void => {
+        res.writeHead(status, { "content-type": "application/json" });
+        res.end(JSON.stringify(payload));
+      };
+
+      if (route === KNOWLEDGE_WIRE_PATHS.status) {
+        send(200, {
+          format: VENDO_KNOWLEDGE_WIRE_FORMAT,
+          posture: engine.posture,
+          status: await engine.status(),
+        });
+        return;
+      }
+      if (route === KNOWLEDGE_WIRE_PATHS.upsert) {
+        const parsed = knowledgeWireUpsertRequestSchema.safeParse(body);
+        if (!parsed.success) return send(400, { error: { code: "validation", message: "not wire@1" } });
+        await engine.upsert!(parsed.data.docs);
+        return send(200, {});
+      }
+      if (route === KNOWLEDGE_WIRE_PATHS.remove) {
+        const parsed = knowledgeWireRemoveRequestSchema.safeParse(body);
+        if (!parsed.success) return send(400, { error: { code: "validation", message: "not wire@1" } });
+        await engine.remove!(parsed.data.docIds);
+        return send(200, {});
+      }
+      if (route === KNOWLEDGE_WIRE_PATHS.search) {
+        const parsed = knowledgeWireSearchRequestSchema.safeParse(body);
+        if (!parsed.success) return send(400, { error: { code: "validation", message: "not wire@1" } });
+        return send(200, await engine.search(parsed.data.query, ctx));
+      }
+      send(404, { error: { code: "not-found", message: pathname } });
+    })();
+  });
+
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return { url: `http://127.0.0.1:${port}`, paths, authorizations, engine };
+}
+
+function capture(): { output: Output; lines: string[]; errors: string[] } {
+  const lines: string[] = [];
+  const errors: string[] = [];
+  return { output: { log: (m) => lines.push(m), error: (m) => errors.push(m) }, lines, errors };
+}
+
+const manifestOf = (dir: string): Promise<string> =>
+  readFile(join(dir, ".vendo", "knowledge-manifest.json"), "utf8");
+
+describe("vendo knowledge sync — engine selection mirrors the server's seam", () => {
+  it("with a Cloud key: docs arrive over the real wire and read back through it", async () => {
+    const wire = await wireServer();
+    const dir = await tempProject();
+    const cap = capture();
+    await runKnowledge(["add", "docs/**/*.md", dir], { output: cap.output });
+
+    vi.stubEnv("VENDO_API_KEY", "vnd_live_key");
+    vi.stubEnv("VENDO_CLOUD_URL", wire.url);
+
+    expect(await runKnowledge(["sync", dir], { output: cap.output })).toBe(0);
+
+    // The docs went out over /upsert, carrying the key as a Bearer token.
+    expect(wire.paths).toContain(KNOWLEDGE_WIRE_PATHS.upsert);
+    expect(wire.authorizations).toContain("Bearer vnd_live_key");
+
+    // READ BACK through the same wire — the producer and consumer are
+    // independent, so this is the assertion that a mocked pair could not make.
+    const reader = cloudKnowledge({ apiKey: "vnd_live_key", baseUrl: wire.url });
+    const found = await reader.search(
+      { text: "Refunds take five days", intent: "chat" },
+      { principal: { kind: "user", subject: "u1" } },
+    );
+    expect(found.hits.map((hit) => hit.ref.docId)).toContain("docs#docs/guide.md");
+
+    // The manifest is written only after the engine confirmed.
+    expect(JSON.parse(await manifestOf(dir)).docs).toHaveProperty("docs#docs/guide.md");
+  });
+
+  it("says Vendo Cloud is the target, in the plan line and the synced line", async () => {
+    const wire = await wireServer();
+    const dir = await tempProject();
+    const cap = capture();
+    await runKnowledge(["add", "docs/**/*.md", dir], { output: cap.output });
+    vi.stubEnv("VENDO_API_KEY", "vnd_live_key");
+    vi.stubEnv("VENDO_CLOUD_URL", wire.url);
+
+    expect(await runKnowledge(["sync", dir], { output: cap.output })).toBe(0);
+    const printed = cap.lines.join("\n");
+    expect(printed).toMatch(/Plan: .* → Vendo Cloud \(127\.0\.0\.1:\d+\)\./);
+    expect(printed).toMatch(/Synced: 2 upserted, 0 removed, 0 unchanged → Vendo Cloud \(127\.0\.0\.1:\d+\)\./);
+  });
+
+  it("a dry run names the target it WOULD push to, and pushes nothing", async () => {
+    const wire = await wireServer();
+    const dir = await tempProject();
+    const cap = capture();
+    await runKnowledge(["add", "docs/**/*.md", dir], { output: cap.output });
+    vi.stubEnv("VENDO_API_KEY", "vnd_live_key");
+    vi.stubEnv("VENDO_CLOUD_URL", wire.url);
+
+    expect(await runKnowledge(["sync", dir, "--dry-run"], { output: cap.output })).toBe(0);
+    expect(cap.lines.join("\n")).toContain("→ Vendo Cloud (");
+    expect(wire.paths).toEqual([]);
+    await expect(manifestOf(dir)).rejects.toThrow();
+  });
+
+  it("no key: the local store serves, and the output says so", async () => {
+    const dir = await tempProject();
+    const cap = capture();
+    await runKnowledge(["add", "docs/**/*.md", dir], { output: cap.output });
+    vi.stubEnv("VENDO_API_KEY", "");
+    vi.stubEnv("VENDO_CLOUD_URL", "");
+
+    expect(await runKnowledge(["sync", dir], { output: cap.output })).toBe(0);
+    expect(cap.lines.join("\n")).toContain("→ local store (.vendo/data).");
+    expect(JSON.parse(await manifestOf(dir)).docs).toHaveProperty("docs#docs/guide.md");
+  });
+
+  it("an injected adapter still wins over a Cloud key", async () => {
+    const wire = await wireServer();
+    const dir = await tempProject();
+    const cap = capture();
+    await runKnowledge(["add", "docs/**/*.md", dir], { output: cap.output });
+    vi.stubEnv("VENDO_API_KEY", "vnd_live_key");
+    vi.stubEnv("VENDO_CLOUD_URL", wire.url);
+
+    const injected = memoryKnowledgeAdapter();
+    expect(await runKnowledge(["sync", dir], { output: cap.output, adapter: injected })).toBe(0);
+    // Nothing crossed the wire: the explicit adapter is the engine.
+    expect(wire.paths).toEqual([]);
+    const seen = await injected.search(
+      { text: "Refunds take five days", intent: "chat" },
+      { principal: { kind: "user", subject: "u1" } },
+    );
+    expect(seen.hits).toHaveLength(1);
+  });
+
+  it("key set but the console is down: fails loudly and leaves the manifest unwritten", async () => {
+    // Bind a real port, then close it: the connection refusal is a real one,
+    // and the port is guaranteed to be free rather than guessed.
+    const dead = await wireServer();
+    const port = new URL(dead.url).port;
+    const index = servers.findIndex((server) => (server.address() as AddressInfo | null)?.port === Number(port));
+    const [closing] = servers.splice(index, 1);
+    await new Promise<void>((resolve) => closing!.close(() => resolve()));
+
+    const dir = await tempProject();
+    const cap = capture();
+    await runKnowledge(["add", "docs/**/*.md", dir], { output: cap.output });
+    vi.stubEnv("VENDO_API_KEY", "vnd_live_key");
+    vi.stubEnv("VENDO_CLOUD_URL", `http://127.0.0.1:${port}`);
+
+    expect(await runKnowledge(["sync", dir], { output: cap.output })).toBe(1);
+    expect(cap.errors.join("\n")).toContain("unreachable");
+    await expect(manifestOf(dir)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## What

`vendo knowledge sync` now pushes to the engine the composed **server** would
read, and says which one it chose. This closes the `defaultSyncAdapter` gap
that was deferred to ENG-363.

Engine selection mirrors `selectKnowledge` (`server.ts`), restricted to what a
CLI can know:

1. an injected `options.adapter` always wins (unchanged);
2. `VENDO_API_KEY` set → `cloudKnowledge`, honouring `VENDO_CLOUD_URL`, so sync
   pushes over the existing `vendo/knowledge-wire@1` `/upsert` + `/remove`. The
   key is read exactly the way the server reads it (`environment()` +
   `resolveCloudBaseUrl`) — no new lookup was invented;
3. no key → the local lexical engine over `.vendo/data` (today's behaviour,
   unchanged).

Both the plan line and the result line name the target, and `--dry-run` names
the target it *would* push to:

```
Plan: 3 to upsert, 1 to remove, 128 unchanged (132 docs total) → Vendo Cloud (console.vendo.run).
Synced: 3 upserted, 1 removed, 128 unchanged → Vendo Cloud (console.vendo.run).
Synced: 3 upserted, 1 removed, 128 unchanged → local store (.vendo/data).
```

Resolving the engine is deferred behind `open()` so a dry run never takes the
local store's single-writer lock just to print a plan.

## Why

Before this, a Cloud-keyed project synced its documents into a **local** store
while its agent searched **Cloud**. The docs went somewhere the server never
looked, the sync reported success, and nothing said so.

## Tests — the seam, with no stub on either side

Per the repo's testing rule (a harness that mocks the counterparty proves
nothing), `sync-engine.test.ts` wires the real thing end to end:

- **producer** — the real CLI resolving `VENDO_API_KEY` from the environment
  and building the real `cloudKnowledge` client;
- **transport** — real HTTP over a real listening socket;
- **consumer** — core's own shipped `vendo/knowledge-wire@1` request schemas
  over the real `memoryKnowledgeAdapter`;
- **read-back** — out through that same wire, so producer and consumer can
  genuinely disagree.

Covered: docs arrive via `/upsert` carrying the Bearer key and read back
through search; the manifest is written only after a 200; the target is named
in both lines; a dry run names the target and pushes nothing; no key → local;
an injected adapter wins over a key; key + console down → loud failure with
the manifest left unwritten.

**These tests were verified to fail.** Disabling the cloud branch turns 4 of
the 6 red — they detect the feature rather than passing either way.

## Not in scope (declined)

No `--engine`/`--local` flag, no BYO endpoint config in the CLI, no new config
surface. The read-only posture refusal already handles read-only endpoints.

## Verification

- [x] `pnpm build` — 25/25
- [x] `pnpm typecheck` — 45/45
- [x] `pnpm lint` — clean (one pre-existing unrelated warning in demo-bank)
- [x] `@vendoai/vendo` — 2071 passed, 24 skipped (the only package touched).
      The full suite is CI's job per `CLAUDE.md`; this PR's `ci` check is the
      gate of record.
- No UI surface touched, so no screenshots.

## Note for review

`docs/knowledge.md` said sync "targets the local lexical engine over the
project's default store" — this change makes that sentence false, so it is
corrected here rather than left to mislead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `vendo knowledge sync` push to the same engine your server uses, and show the chosen target in the output. This prevents Cloud-keyed projects from syncing to local while agents read from Cloud.

- **New Features**
  - Engine selection mirrors the server: injected `adapter` wins; `VENDO_API_KEY` → Vendo Cloud (honors `VENDO_CLOUD_URL` over `vendo/knowledge-wire@1`), else local `.vendo/data`.
  - Plan and result lines include the target; `--dry-run` prints the target without pushing.
  - Defers engine open so dry runs don’t take the local store’s single-writer lock.
  - Updated `docs/knowledge.md`; no new flags or config.

<sup>Written for commit 2b809e8c2d0a969b947edcd1df90a7bfdd422e70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

