### PR TITLE
ci: demote perf, knowledge-eval, hermetic-extras to nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,8 @@ concurrency:
 #   coverage-merge    merges the shards' blob reports and enforces the
 #                     per-package coverage floors (they cannot be enforced on a
 #                     single shard — see the comment on that job)
-#   hermetic-extras   the suites that were never in CI at all
 #   ci                aggregate; KEEPS the required-check name `ci`
-# Required checks on main are: ci, integration, perf, conformance, audit.
+# Required checks on main are: ci, integration, conformance, audit.
 # Renaming any of those job names breaks merges.
 jobs:
   typecheck-lint:
@@ -246,40 +245,10 @@ jobs:
             fi
           done
 
-  # Three suites that existed, passed locally, and ran NOWHERE in CI: both
-  # framework integration examples and the corpus express host. All hermetic — scripted models, temp PGlite,
-  # no keys. They define `test` and not `test:coverage`, which is exactly why
-  # the old ci job's `turbo run test:coverage` never touched them.
-  # ai-sdk-agent's cloud-posture.e2e.test.ts self-skips without
-  # VENDO_LIVE_CLOUD=1; it stays skipped here (it is a nightly-class live test).
-  hermetic-extras:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    env:
-      VITEST_MIN_FORKS: "1"
-      VITEST_MAX_FORKS: "2"
-      VITEST_MIN_THREADS: "1"
-      VITEST_MAX_THREADS: "2"
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 22
-          cache: pnpm
-      - name: Turbo remote cache (GitHub-cache backed)
-        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
-      - run: pnpm install --frozen-lockfile
-      # No separate build step: turbo.json gives `test` dependsOn
-      # ["^build", "build"], so this one command builds the three packages and
-      # their workspace deps before running them.
-      - name: Test formerly-local-only suites
-        run: pnpm turbo run test --continue --concurrency=2 --filter=@vendoai-examples/ai-sdk-agent --filter=@vendoai-examples/mastra-agent --filter=@vendoai-corpus/express-host
-
   # The required check. Its name must stay `ci` (branch protection on main).
   ci:
     runs-on: ubuntu-latest
-    needs: [typecheck-lint, test-shards, test-rest, coverage-merge, hermetic-extras]
+    needs: [typecheck-lint, test-shards, test-rest, coverage-merge]
     if: always()
     steps:
       - name: All lanes green

--- a/.github/workflows/knowledge-eval.yml
+++ b/.github/workflows/knowledge-eval.yml
@@ -1,15 +1,16 @@
 name: Knowledge Eval
 
-# The per-PR knowledge eval gate (docs/eval/KNOWLEDGE.md): deterministic
-# offline legs only — golden-set retrieval vs expected doc ids, refusal
-# mechanics, ratcheted bars — against the in-memory engine. Exits nonzero on
-# any hard failure or bars breach. Model-costed judging and live engines run
-# nightly/on-demand, never here (the front door's per-PR carve-out).
+# The knowledge eval gate (docs/eval/KNOWLEDGE.md): deterministic offline
+# legs only — golden-set retrieval vs expected doc ids, refusal mechanics,
+# ratcheted bars — against the in-memory engine. Exits nonzero on any hard
+# failure or bars breach. Model-costed judging and live engines stay
+# on-demand. Demoted from a per-PR gate to nightly (2026-08-06, Yousef's
+# call): an eval regression caught overnight is soon enough.
 
 on:
-  push:
-    branches: [main]
-  pull_request:
+  schedule:
+    - cron: "17 7 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,6 +9,37 @@ permissions:
   contents: read
 
 jobs:
+  # The example/corpus suites (both framework integration examples and the
+  # corpus express host): all hermetic — scripted models, temp PGlite, no
+  # keys. They define `test` and not `test:coverage`, which is why the ci
+  # workflow's coverage runs never touch them. Demoted from a per-PR gate to
+  # nightly (2026-08-06, Yousef's call): a broken example caught overnight is
+  # soon enough. ai-sdk-agent's cloud-posture.e2e.test.ts self-skips without
+  # VENDO_LIVE_CLOUD=1; it stays skipped here too.
+  hermetic-extras:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      VITEST_MIN_FORKS: "1"
+      VITEST_MAX_FORKS: "2"
+      VITEST_MIN_THREADS: "1"
+      VITEST_MAX_THREADS: "2"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Turbo remote cache (GitHub-cache backed)
+        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
+      - run: pnpm install --frozen-lockfile
+      # No separate build step: turbo.json gives `test` dependsOn
+      # ["^build", "build"], so this one command builds the three packages and
+      # their workspace deps before running them.
+      - name: Test example/corpus suites
+        run: pnpm turbo run test --continue --concurrency=2 --filter=@vendoai-examples/ai-sdk-agent --filter=@vendoai-examples/mastra-agent --filter=@vendoai-corpus/express-host
+
   live-conformance:
     runs-on: ubuntu-latest
     timeout-minutes: 90

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,18 +1,15 @@
 name: Perf
 
+# Demoted from a per-PR required check to nightly (2026-08-06, Yousef's call):
+# a budget breach caught overnight is soon enough, and it keeps the per-PR
+# surface small. Same cron as the nightly live conformance run.
 on:
-  push:
-    branches: [main]
-  pull_request:
+  schedule:
+    - cron: "17 7 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read
-
-# A new push to a PR supersedes the previous run; cancel it. Pushes to main
-# never cancel each other (every main commit keeps its full record).
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   perf:
@@ -20,8 +17,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          fetch-depth: 0 # turbo ls --affected diffs against the base branch
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -30,25 +25,8 @@ jobs:
       - name: Turbo remote cache (GitHub-cache backed)
         uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
       - run: pnpm install --frozen-lockfile
-      # @vendoai/bench depends on every package it measures, so `--affected`
-      # (which includes dependents) marks it whenever anything the budgets
-      # cover changes — see the ci.yml integration job's skip step for the
-      # TURBO_SCM_BASE and fall-open rationale.
-      - name: Skip if bench scope unaffected (PRs only)
-        id: affected
-        if: github.event_name == 'pull_request'
-        env:
-          TURBO_SCM_BASE: origin/${{ github.base_ref }}
-        run: |
-          if pnpm turbo ls --affected --output=json > /tmp/affected.json \
-             && jq -e '[.packages.items[].name | select(. == "@vendoai/bench")] | length == 0' /tmp/affected.json > /dev/null; then
-            echo "bench scope unaffected by this PR; skipping"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          fi
-      - if: steps.affected.outputs.skip != 'true'
-        run: pnpm build
+      - run: pnpm build
       # Deterministic suites only, compared against bench/budgets.json; exits 1
       # on any breach and writes the results table to the job summary. Live
       # suites (gen-live, e2b) never run in CI — they need paid API keys.
-      - if: steps.affected.outputs.skip != 'true'
-        run: pnpm --filter @vendoai/bench bench -- --check
+      - run: pnpm --filter @vendoai/bench bench -- --check


### PR DESCRIPTION
Third approved CI cut. None of these change PR wait time (they were off the critical path); this shrinks the per-PR surface.

- **perf** → nightly cron (`17 7 * * *`) + manual dispatch. Removed from `main`'s required checks via API (now: ci, integration, conformance, audit). The PR-skip probe added in #846 comes back out — a scheduled run has no PR to diff against.
- **knowledge-eval** → same cron + dispatch.
- **hermetic-extras** → moves out of `ci.yml` into `nightly.yml` as its own job (keyless, unlike the live-conformance job beside it), and out of the `ci` aggregate's `needs`.

A regression in any of these now surfaces next morning instead of at merge — accepted tradeoff, decided by Yousef.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved perf, knowledge-eval, and hermetic-extras off per-PR CI to a nightly cron (17 7 * * *) with manual triggers. Required checks on `main` are now `ci`, `integration`, `conformance`, and `audit`.

- **Refactors**
  - Perf: switched to nightly + `workflow_dispatch`; removed PR-diff skip logic; always builds and runs `@vendoai/bench` deterministic checks; no longer a required check.
  - Knowledge eval: switched to nightly + `workflow_dispatch`; remains offline-only; live/model-costed judges stay on-demand.
  - Hermetic-extras: moved from `ci.yml` to `nightly.yml` as a standalone keyless job; dropped from the `ci` aggregate’s `needs`.
  - CI: kept the `ci` job name stable; updated comments to reflect the new required checks.

<sup>Written for commit f541f58b81f0b0d9d313b0f3f19c2ada72f0cd59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

