### PR TITLE
ci: vendo tests go 3 → 4 shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ concurrency:
 # lint on ONE runner, ~30 min wall. It is now, all fanned out over the shared
 # turbo remote cache so the fan-out does not multiply the build:
 #   typecheck-lint    the non-test half
-#   test-shards       8 intra-package vitest shards for the big three
-#                     (vendo x3, store x3, ui x2 — 40 of the 55 serial minutes)
+#   test-shards       9 intra-package vitest shards for the big three
+#                     (vendo x4, store x3, ui x2 — 40 of the 55 serial minutes)
 #   test-rest         the other 15 packages in 2 turbo groups
 #   coverage-merge    merges the shards' blob reports and enforces the
 #                     per-package coverage floors (they cannot be enforced on a
@@ -73,9 +73,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: vendo-1, pkg: "@vendoai/vendo", dir: packages/vendo, shard: "1/3", pre: "build:playground" }
-          - { name: vendo-2, pkg: "@vendoai/vendo", dir: packages/vendo, shard: "2/3", pre: "build:playground" }
-          - { name: vendo-3, pkg: "@vendoai/vendo", dir: packages/vendo, shard: "3/3", pre: "build:playground" }
+          # 4 shards, not 3: vitest deals files by count, not duration, and at
+          # 3 the full-stack suites clustered on shard 2 (7m25s vs its
+          # siblings' ~4m45s — measured on the #849 proof run), making it tie
+          # integration as the whole run's critical path.
+          - { name: vendo-1, pkg: "@vendoai/vendo", dir: packages/vendo, shard: "1/4", pre: "build:playground" }
+          - { name: vendo-2, pkg: "@vendoai/vendo", dir: packages/vendo, shard: "2/4", pre: "build:playground" }
+          - { name: vendo-3, pkg: "@vendoai/vendo", dir: packages/vendo, shard: "3/4", pre: "build:playground" }
+          - { name: vendo-4, pkg: "@vendoai/vendo", dir: packages/vendo, shard: "4/4", pre: "build:playground" }
           - { name: store-1, pkg: "@vendoai/store", dir: packages/store, shard: "1/3", tsc: "true" }
           - { name: store-2, pkg: "@vendoai/store", dir: packages/store, shard: "2/3", tsc: "true" }
           - { name: store-3, pkg: "@vendoai/store", dir: packages/store, shard: "3/3", tsc: "true" }


### PR DESCRIPTION
The vendo suite's 3-way split was lopsided: shard 2 carried 7m25s of work while its siblings carried ~4m45s (measured on proof PR #849), making it tie the integration job as the whole run's critical path. Four shards spread the heavy full-stack files thinner; expected worst shard ~5m.

No coverage change: same files, one more machine. coverage-merge already downloads `blob-vendo-*`, so the fourth shard's report joins the merge automatically.

Note: this PR is workflow-only, so its own run *skips* the vendo shards (unaffected). The real 4-shard timing shows on the main push after merge — I'll record it there.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split `@vendoai/vendo` tests into 4 shards (was 3) to balance load and shorten the CI critical path; worst shard expected ~5 minutes. Coverage is unchanged; `coverage-merge` already includes the new shard via `blob-vendo-*`.

- **Refactors**
  - Updated `.github/workflows/ci.yml` matrix to use shards "1/4"…"4/4" and add `vendo-4`.
  - No coverage config changes; the fourth report is merged automatically.

<sup>Written for commit f244ce380c7a633502d805ec7423b3664ee03156. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

